### PR TITLE
fix: hide sidebar toggle in split view secondary panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-04-06 — Split View Polish
+
+### Fixed
+- Hide sidebar collapse icon in split view panes (only show in primary/leftmost pane)
+
+---
+
 ## 2026-04-05 — Inbox Detail Panel Polish
 
 ### Added

--- a/apps/desktop/src/renderer/src/components/split-view/split-layout-renderer.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/split-layout-renderer.tsx
@@ -6,6 +6,7 @@ import { TabPane } from './tab-pane'
 interface SplitLayoutRendererProps {
   layout: SplitLayout
   path: number[]
+  showSidebarToggle?: boolean
 }
 
 /**
@@ -21,7 +22,8 @@ const getLayoutDirection = (layout: SplitLayout): SplitDirection => {
 
 export const SplitLayoutRenderer = ({
   layout,
-  path
+  path,
+  showSidebarToggle = true
 }: SplitLayoutRendererProps): React.JSX.Element | null => {
   const { state, dispatch } = useTabs()
 
@@ -30,7 +32,11 @@ export const SplitLayoutRenderer = ({
     if (!group) return null
 
     return (
-      <TabPane groupId={layout.tabGroupId} isActive={state.activeGroupId === layout.tabGroupId} />
+      <TabPane
+        groupId={layout.tabGroupId}
+        isActive={state.activeGroupId === layout.tabGroupId}
+        showSidebarToggle={showSidebarToggle}
+      />
     )
   }
 
@@ -47,8 +53,12 @@ export const SplitLayoutRenderer = ({
       onResize={handleResize}
       minSize={100}
     >
-      <SplitLayoutRenderer layout={layout.first} path={[...path, 0]} />
-      <SplitLayoutRenderer layout={layout.second} path={[...path, 1]} />
+      <SplitLayoutRenderer
+        layout={layout.first}
+        path={[...path, 0]}
+        showSidebarToggle={showSidebarToggle}
+      />
+      <SplitLayoutRenderer layout={layout.second} path={[...path, 1]} showSidebarToggle={false} />
     </SplitPane>
   )
 }

--- a/apps/desktop/src/renderer/src/components/split-view/tab-pane.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-pane.tsx
@@ -8,12 +8,14 @@ import { cn } from '@/lib/utils'
 interface TabPaneProps {
   groupId: string
   isActive: boolean
+  showSidebarToggle?: boolean
   className?: string
 }
 
 export const TabPane = ({
   groupId,
   isActive,
+  showSidebarToggle = true,
   className
 }: TabPaneProps): React.JSX.Element | null => {
   const { dispatch } = useTabs()
@@ -42,7 +44,7 @@ export const TabPane = ({
       data-pane-id={groupId}
       data-pane-active={isActive}
     >
-      <TabBarWithDrag groupId={groupId} />
+      <TabBarWithDrag groupId={groupId} showSidebarToggle={showSidebarToggle} />
 
       <div
         className={cn(

--- a/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
@@ -22,6 +22,8 @@ import { cn } from '@/lib/utils'
 interface TabBarWithDragProps {
   /** ID of the tab group to display */
   groupId: string
+  /** Whether to show the sidebar collapse toggle (hidden in split panes) */
+  showSidebarToggle?: boolean
   /** Additional CSS classes */
   className?: string
 }
@@ -32,6 +34,7 @@ interface TabBarWithDragProps {
  */
 export const TabBarWithDrag = ({
   groupId,
+  showSidebarToggle = true,
   className
 }: TabBarWithDragProps): React.JSX.Element | null => {
   const group = useTabGroup(groupId)
@@ -119,10 +122,11 @@ export const TabBarWithDrag = ({
         aria-orientation="horizontal"
         data-group-id={groupId}
       >
-        {/* Sidebar toggle */}
-        <div className="no-drag flex items-center px-2 self-center">
-          <SidebarTrigger className="text-text-tertiary hover:text-foreground transition-colors duration-150" />
-        </div>
+        {showSidebarToggle && (
+          <div className="no-drag flex items-center px-2 self-center">
+            <SidebarTrigger className="text-text-tertiary hover:text-foreground transition-colors duration-150" />
+          </div>
+        )}
 
         {/* Pinned tabs section (not in sortable context) */}
         {pinnedTabs.length > 0 && (


### PR DESCRIPTION
## What

Hide the sidebar collapse icon in split view secondary panes — only the primary (leftmost) pane shows it.

## Why

When splitting the view, every pane rendered its own `SidebarTrigger`. The toggle only makes sense next to the actual sidebar (leftmost pane). Secondary panes should show only tabs.

## How

Thread a `showSidebarToggle` prop through the recursive `SplitLayoutRenderer → TabPane → TabBarWithDrag` chain. The root starts with `true`; at each split node, only the first child inherits the flag while the second child gets `false`. Handles nested splits automatically.

## Type

- [x] `fix` — bug fix

## Test plan

- [x] Manual testing (describe below)

**Manual verification:**
1. Single pane → sidebar toggle visible (unchanged behavior)
2. Split view → only left/top pane shows sidebar toggle; right/bottom pane shows only tabs
3. Nested split (split the first pane again) → still only the leftmost pane has the toggle

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns