### PR TITLE
refactor: remove unused home tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-04-07 — Remove Home Tab
+
+### Removed
+- Remove unused Home tab from sidebar navigation, tab types, content routing, and icon mappings
+- Remove SidebarHome SVG icon component
+- Renumber sidebar keyboard shortcuts (Journal → ⌘⌥2, Tasks → ⌘⌥3)
+
+---
+
 ## 2026-04-07 — Inline Task Blocks
 
 ### Added
@@ -33,7 +42,7 @@ Format: weekly entries grouped by feature area.
 
 ### Changed
 - Replace horizontal nav with vertical sidebar nav using shadcn SidebarMenu primitives
-- Move navigation (Inbox, Home, Journal, Tasks) from sidebar header to sidebar content area
+- Move navigation (Inbox, Journal, Tasks) from sidebar header to sidebar content area
 - Simplify SidebarHeaderContent to only render traffic lights and vault switcher
 
 ---

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -56,7 +56,7 @@ const log = createLogger('App')
 const startupTheme = getStartupTheme()
 
 // Base pages (non-task)
-export type BasePage = 'inbox' | 'home' | 'journal' | 'graph'
+export type BasePage = 'inbox' | 'journal' | 'graph'
 
 // Task view type for navigation within tasks
 export type TaskViewId = 'all' | 'today' | 'completed'

--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -12,12 +12,7 @@ import {
   Search,
   Upload
 } from '@/lib/icons'
-import {
-  SidebarInbox,
-  SidebarHome,
-  SidebarJournal,
-  SidebarTasks
-} from '@/lib/icons/sidebar-nav-icons'
+import { SidebarInbox, SidebarJournal, SidebarTasks } from '@/lib/icons/sidebar-nav-icons'
 import { toast } from 'sonner'
 
 import { cn } from '@/lib/utils'
@@ -70,9 +65,8 @@ const mainNav: {
   shortcut?: string
 }[] = [
   { title: 'Inbox', page: 'inbox', icon: SidebarInbox, shortcut: '⌘⌥1' },
-  { title: 'Home', page: 'home', icon: SidebarHome, shortcut: '⌘⌥2' },
-  { title: 'Journal', page: 'journal', icon: SidebarJournal, shortcut: '⌘⌥3' },
-  { title: 'Tasks', page: 'tasks', icon: SidebarTasks, shortcut: '⌘⌥4' }
+  { title: 'Journal', page: 'journal', icon: SidebarJournal, shortcut: '⌘⌥2' },
+  { title: 'Tasks', page: 'tasks', icon: SidebarTasks, shortcut: '⌘⌥3' }
 ]
 
 function SidebarHeaderContent() {
@@ -210,14 +204,12 @@ function AppSidebarInner({ currentPage, viewCounts, ...props }: AppSidebarProps)
     // Map page to tab type and title
     const pageToTabType: Record<AppPage, TabType> = {
       inbox: 'inbox',
-      home: 'home',
       journal: 'journal',
       tasks: 'tasks',
       graph: 'graph'
     }
     const pageToTitle: Record<AppPage, string> = {
       inbox: 'Inbox',
-      home: 'Home',
       journal: 'Journal',
       tasks: 'Tasks',
       graph: 'Graph'
@@ -236,7 +228,6 @@ function AppSidebarInner({ currentPage, viewCounts, ...props }: AppSidebarProps)
     (page: AppPage) => {
       const titles: Record<AppPage, string> = {
         inbox: 'Inbox',
-        home: 'Home',
         journal: 'Journal',
         tasks: 'Tasks',
         graph: 'Graph'

--- a/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
@@ -91,9 +91,6 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
       case 'inbox':
         return <MemoizedInboxPage />
 
-      case 'home':
-        return <PlaceholderView title="Home" icon="home" />
-
       case 'tasks':
       case 'all-tasks':
       case 'today':

--- a/apps/desktop/src/renderer/src/components/tabs/tab-hover-preview.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-hover-preview.test.tsx
@@ -106,7 +106,7 @@ describe('TabHoverPreview', () => {
 
   describe('previewable tab types', () => {
     const previewableTypes = ['note', 'journal', 'file'] as const
-    const nonPreviewableTypes = ['inbox', 'home', 'tasks', 'graph', 'search', 'templates'] as const
+    const nonPreviewableTypes = ['inbox', 'tasks', 'graph', 'search', 'templates'] as const
 
     it.each(previewableTypes)('should wrap %s tab with hover card trigger', (tabType) => {
       // #given

--- a/apps/desktop/src/renderer/src/components/tabs/tab-icon.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-icon.tsx
@@ -73,7 +73,6 @@ const ICON_COMPONENTS: Record<string, React.ComponentType<{ className?: string }
  */
 const TYPE_TO_ICON: Record<TabType, string> = {
   inbox: 'inbox',
-  home: 'home',
   tasks: 'list-checks', // New unified tasks tab
   'all-tasks': 'list-checks',
   today: 'star',

--- a/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
@@ -85,7 +85,6 @@ export const findPreviewTab = (group: TabGroup): Tab | null => {
  */
 const TAB_ICONS: Record<TabType, string> = {
   inbox: 'inbox',
-  home: 'home',
   tasks: 'list-checks',
   'all-tasks': 'list-checks',
   today: 'star',
@@ -118,7 +117,6 @@ export const getTabIcon = (type: TabType): string => {
  */
 const TAB_PATHS: Partial<Record<TabType, string>> = {
   inbox: '/inbox',
-  home: '/home',
   'all-tasks': '/tasks/all',
   today: '/tasks/today',
   completed: '/tasks/completed'

--- a/apps/desktop/src/renderer/src/contexts/tabs/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/types.ts
@@ -12,7 +12,6 @@
  */
 export type TabType =
   | 'inbox'
-  | 'home'
   | 'tasks' // New unified tasks tab
   | 'all-tasks' // Legacy - kept for backwards compatibility
   | 'today' // Legacy - kept for backwards compatibility
@@ -34,7 +33,6 @@ export type TabType =
  */
 export const SINGLETON_TAB_TYPES: TabType[] = [
   'inbox',
-  'home',
   'journal',
   'tasks', // New unified tasks tab
   'all-tasks', // Legacy

--- a/apps/desktop/src/renderer/src/lib/icons/sidebar-nav-icons.tsx
+++ b/apps/desktop/src/renderer/src/lib/icons/sidebar-nav-icons.tsx
@@ -36,14 +36,6 @@ export const SidebarInbox = createSvgIcon(
   'SidebarInbox'
 )
 
-export const SidebarHome = createSvgIcon(
-  <>
-    <path d="M2 7.5l5.5-5 5.5 5" />
-    <path d="M3.5 6.5v5.5h3v-3h2v3h3v-5.5" />
-  </>,
-  'SidebarHome'
-)
-
 export const SidebarJournal = createSvgIcon(
   <>
     <rect x="3" y="1.5" width="9.5" height="12" rx="1" />

--- a/apps/desktop/tests/e2e/tabs.e2e.ts
+++ b/apps/desktop/tests/e2e/tabs.e2e.ts
@@ -445,9 +445,9 @@ test.describe('Session Persistence', () => {
     const tabCount = await getTabCount(page)
     expect(tabCount).toBeGreaterThanOrEqual(1)
 
-    // Default tab should be Inbox or Home
+    // Default tab should be Inbox
     const activeTitle = await getActiveTabTitle(page)
-    // On fresh launch, the default tab is either Inbox or Home
+    // On fresh launch, the default tab is Inbox
     expect(activeTitle).toBeTruthy()
   })
 })


### PR DESCRIPTION
## What

Remove the unused Home tab from the entire tab system — it only rendered a placeholder view.

## Why

The Home tab was never implemented beyond a placeholder. Removing dead code keeps the codebase lean and avoids confusion about which navigation items are functional.

## How

Surgical removal across 9 source files:
- Removed `'home'` from `TabType` union, `SINGLETON_TAB_TYPES`, icon/path mappings
- Removed `SidebarHome` SVG icon and sidebar nav entry
- Removed `case 'home':` from tab content routing
- Removed `'home'` from `BasePage` type and all `Record<AppPage, ...>` maps
- Renumbered sidebar keyboard shortcuts (Journal → ⌘⌥2, Tasks → ⌘⌥3)
- Updated test fixtures and e2e comments

Kept unrelated `Home` references: Lucide icon (icon-picker), keyboard Home key (list navigation), English prose in seed data.

## Type

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `style` — visual/UI only
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `chore` — tooling, deps, config
- [ ] `docs` — documentation only
- [ ] `ci` — CI/CD changes

## Test plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing (describe below)

TypeScript compiles clean (5/5 packages). ESLint passes (0 errors). Removed `'home'` from tab-hover-preview test fixture.

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns