### PR TITLE
refactor: consolidate service API delegation with createWindowApiForwarder

### DIFF
--- a/apps/desktop/src/main/preload-types.test.ts
+++ b/apps/desktop/src/main/preload-types.test.ts
@@ -1,4 +1,15 @@
+import type { InboxClientAPI, InboxItem } from '@memry/rpc/inbox'
+import type { Note, NotesClientAPI } from '@memry/rpc/notes'
+import type { Task, TasksClientAPI } from '@memry/rpc/tasks'
 import { describe, expectTypeOf, it } from 'vitest'
+import type {
+  InboxClientAPI as PreloadInboxClientAPI,
+  InboxItem as PreloadInboxItem,
+  Note as PreloadNote,
+  NotesClientAPI as PreloadNotesClientAPI,
+  Task as PreloadTask,
+  TasksClientAPI as PreloadTasksClientAPI
+} from '../preload/index.d'
 
 describe('preload type declarations', () => {
   it('exposes sync and crypto APIs on window.api', () => {
@@ -10,5 +21,19 @@ describe('preload type declarations', () => {
     expectTypeOf<Window['api']['crypto']['encryptItem']>().toBeFunction()
     expectTypeOf<Window['api']['syncAttachments']['upload']>().toBeFunction()
     expectTypeOf<Window['api']['onSyncStatusChanged']>().toBeFunction()
+  })
+
+  it('reuses canonical rpc note, task, and inbox types', () => {
+    expectTypeOf<PreloadNote>().toEqualTypeOf<Note>()
+    expectTypeOf<PreloadTask>().toEqualTypeOf<Task>()
+    expectTypeOf<PreloadInboxItem>().toEqualTypeOf<InboxItem>()
+
+    expectTypeOf<PreloadNotesClientAPI>().toEqualTypeOf<NotesClientAPI>()
+    expectTypeOf<PreloadTasksClientAPI>().toEqualTypeOf<TasksClientAPI>()
+    expectTypeOf<PreloadInboxClientAPI>().toEqualTypeOf<InboxClientAPI>()
+
+    expectTypeOf<Window['api']['notes']>().toEqualTypeOf<NotesClientAPI>()
+    expectTypeOf<Window['api']['tasks']>().toEqualTypeOf<TasksClientAPI>()
+    expectTypeOf<Window['api']['inbox']>().toEqualTypeOf<InboxClientAPI>()
   })
 })

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1,5 +1,8 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
 import type { GeneratedRpcApi } from '@memry/rpc'
+import type * as InboxRpc from '@memry/rpc/inbox'
+import type * as NotesRpc from '@memry/rpc/notes'
+import type * as TasksRpc from '@memry/rpc/tasks'
 import type {
   SyncStatusChangedEvent,
   ItemSyncedEvent,
@@ -34,31 +37,9 @@ export interface VaultInfo {
   isDefault: boolean
 }
 
-// Note types (mirrored from contracts for preload compatibility)
-export interface NoteFrontmatter {
-  id: string
-  title?: string
-  created: string
-  modified: string
-  tags?: string[]
-  aliases?: string[]
-  [key: string]: unknown
-}
-
-export interface Note {
-  id: string
-  path: string
-  title: string
-  content: string
-  frontmatter: NoteFrontmatter
-  created: Date
-  modified: Date
-  tags: string[]
-  aliases: string[]
-  wordCount: number
-  properties: Record<string, unknown> // T020: Properties support
-  emoji?: string | null // T028: Emoji icon for visual identification
-}
+// Note types
+export type NoteFrontmatter = NotesRpc.Note['frontmatter']
+export type Note = NotesRpc.Note
 
 // T020: Property types — canonical set from @memry/contracts/property-types
 export type PropertyType =
@@ -78,71 +59,21 @@ export interface PropertyValue {
   type: PropertyType
 }
 
-export interface PropertyDefinition {
-  name: string
-  type: PropertyType
-  options: string | null // JSON array
-  defaultValue: string | null
-  color: string | null
-  createdAt: string
-}
-
-export interface CreatePropertyDefinitionInput {
-  name: string
-  type: PropertyType
-  options?: string[]
-  defaultValue?: unknown
-  color?: string
-}
-
-export interface UpdatePropertyDefinitionInput {
-  name: string
-  type?: PropertyType
-  options?: string[]
-  defaultValue?: unknown
-  color?: string
-}
+export type PropertyDefinition = NotesRpc.PropertyDefinition
+export type CreatePropertyDefinitionInput = NotesRpc.CreatePropertyDefinitionInput
+export type UpdatePropertyDefinitionInput = NotesRpc.UpdatePropertyDefinitionInput
 
 export interface SetPropertiesResponse {
   success: boolean
   error?: string
 }
 
-export interface CreatePropertyDefinitionResponse {
-  success: boolean
-  definition: PropertyDefinition | null
-  error?: string
-}
+export type CreatePropertyDefinitionResponse = NotesRpc.CreatePropertyDefinitionResponse
 
 // T070: Attachment types
-export interface AttachmentResult {
-  success: boolean
-  /** Relative path from note to attachment */
-  path?: string
-  /** Original filename */
-  name?: string
-  /** File size in bytes */
-  size?: number
-  /** MIME type */
-  mimeType?: string
-  /** Category: image or file */
-  type?: 'image' | 'file'
-  /** Error message if failed */
-  error?: string
-}
-
-export interface AttachmentInfo {
-  filename: string
-  path: string
-  size: number
-  mimeType: string
-  type: 'image' | 'file'
-}
-
-export interface DeleteAttachmentResponse {
-  success: boolean
-  error?: string
-}
+export type AttachmentResult = NotesRpc.AttachmentResult
+export type AttachmentInfo = NotesRpc.AttachmentInfo
+export type DeleteAttachmentResponse = NotesRpc.DeleteAttachmentResponse
 
 // Template types (Phase 15)
 export type TemplatePropertyType =
@@ -212,51 +143,18 @@ export interface TemplateListResponse {
   templates: TemplateListItem[]
 }
 
-export interface FolderConfig {
-  icon?: string | null
-  template?: string
-  inherit?: boolean
-}
-
-export interface FolderInfo {
-  path: string
-  icon?: string | null
-}
+export type FolderConfig = NotesRpc.FolderConfig
+export type FolderInfo = NotesRpc.FolderInfo
 
 // Export types (T106, T108)
-export interface ExportNoteInput {
-  noteId: string
-  includeMetadata?: boolean
-  pageSize?: 'A4' | 'Letter' | 'Legal'
-}
-
-export interface ExportNoteResponse {
-  success: boolean
-  path?: string
-  error?: string
-}
+export type ExportNoteInput = NotesRpc.ExportNoteInput
+export type ExportNoteResponse = NotesRpc.ExportNoteResponse
 
 // Version History types (T110-T114)
-export type SnapshotReason = 'manual' | 'auto' | 'timer' | 'significant'
-
-export interface SnapshotListItem {
-  id: string
-  noteId: string
-  title: string
-  wordCount: number
-  reason: SnapshotReason
-  createdAt: string
-}
-
-export interface SnapshotDetail extends SnapshotListItem {
-  fileContent: string // Full file content (frontmatter + markdown body)
-}
-
-export interface RestoreVersionResponse {
-  success: boolean
-  note: Note | null
-  error?: string
-}
+export type SnapshotReason = NotesRpc.SnapshotListItem['reason']
+export type SnapshotListItem = NotesRpc.SnapshotListItem
+export type SnapshotDetail = NotesRpc.SnapshotDetail
+export type RestoreVersionResponse = NotesRpc.RestoreVersionResponse
 
 export interface TemplateCreatedEvent {
   template: Template
@@ -271,161 +169,26 @@ export interface TemplateDeletedEvent {
   id: string
 }
 
-export interface NoteListItem {
-  id: string
-  path: string
-  title: string
-  created: Date
-  modified: Date
-  tags: string[]
-  wordCount: number
-  snippet?: string
-  emoji?: string | null // T028: Emoji icon for visual identification
-  localOnly?: boolean
-  fileType?: 'markdown' | 'pdf' | 'image' | 'audio' | 'video' // File type discriminator
-  mimeType?: string | null // MIME type (e.g., 'application/pdf')
-  fileSize?: number | null // File size in bytes
-}
-
-/**
- * File metadata for non-markdown files (PDF, image, audio, video)
- */
-export interface FileMetadata {
-  id: string
-  path: string // Relative path within vault
-  absolutePath: string // Full filesystem path for viewers
-  title: string
-  fileType: 'pdf' | 'image' | 'audio' | 'video'
-  mimeType: string | null
-  fileSize: number | null
-  created: Date
-  modified: Date
-}
-
-/**
- * WikiLink resolution result for format-aware link handling.
- * Used to determine whether to open a note or file viewer.
- */
-export interface WikiLinkResolution {
-  id: string
-  path: string
-  title: string
-  fileType: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
-}
-
-export interface WikiLinkPreview {
-  id: string
-  title: string
-  emoji: string | null
-  snippet: string | null
-  tags: Array<{ name: string; color: string }>
-  createdAt: string
-}
-
-export interface NoteCreateInput {
-  title: string
-  content?: string
-  folder?: string
-  tags?: string[]
-  template?: string
-}
-
-export interface NoteUpdateInput {
-  id: string
-  title?: string
-  content?: string
-  tags?: string[]
-  frontmatter?: Record<string, unknown>
-  emoji?: string | null // T028: Emoji icon for visual identification
-}
-
-export interface NoteListOptions {
-  folder?: string
-  tags?: string[]
-  sortBy?: 'modified' | 'created' | 'title'
-  sortOrder?: 'asc' | 'desc'
-  limit?: number
-  offset?: number
-}
-
-export interface NoteCreateResponse {
-  success: boolean
-  note: Note | null
-  error?: string
-}
-
-export interface NoteUpdateResponse {
-  success: boolean
-  note: Note | null
-  error?: string
-}
-
-export interface NoteListResponse {
-  notes: NoteListItem[]
-  total: number
-  hasMore: boolean
-}
-
-export interface NoteLink {
-  sourceId: string
-  targetId: string | null
-  targetTitle: string
-}
-
-export interface BacklinkContext {
-  snippet: string
-  linkStart: number
-  linkEnd: number
-}
-
-export interface Backlink {
-  sourceId: string
-  sourcePath: string
-  sourceTitle: string
-  contexts: BacklinkContext[]
-}
-
-export interface NoteLinksResponse {
-  outgoing: NoteLink[]
-  incoming: Backlink[]
-}
-
-export interface NoteCreatedEvent {
-  note: NoteListItem
-  source: 'internal' | 'external'
-}
-
-export interface NoteUpdatedEvent {
-  id: string
-  changes: Partial<Note>
-  source: 'internal' | 'external'
-}
-
-export interface NoteDeletedEvent {
-  id: string
-  path: string
-  source: 'internal' | 'external'
-}
-
-export interface NoteRenamedEvent {
-  id: string
-  oldPath: string
-  newPath: string
-  oldTitle: string
-  newTitle: string
-}
-
-export interface NoteMovedEvent {
-  id: string
-  oldPath: string
-  newPath: string
-}
-
-export interface NoteExternalChangeEvent {
-  id: string
-  path: string
-  type: 'modified' | 'deleted'
-}
+export type NoteListItem = NotesRpc.NoteListItem
+export type FileMetadata = NotesRpc.FileMetadata
+export type WikiLinkResolution = NotesRpc.WikiLinkResolution
+export type WikiLinkPreview = NotesRpc.WikiLinkPreview
+export type NoteCreateInput = NotesRpc.NoteCreateInput
+export type NoteUpdateInput = NotesRpc.NoteUpdateInput
+export type NoteListOptions = NotesRpc.NoteListOptions
+export type NoteCreateResponse = NotesRpc.NoteCreateResponse
+export type NoteUpdateResponse = NotesRpc.NoteUpdateResponse
+export type NoteListResponse = NotesRpc.NoteListResponse
+export type NoteLink = NotesRpc.NoteLink
+export type BacklinkContext = NotesRpc.BacklinkContext
+export type Backlink = NotesRpc.Backlink
+export type NoteLinksResponse = NotesRpc.NoteLinksResponse
+export type NoteCreatedEvent = NotesRpc.NoteCreatedEvent
+export type NoteUpdatedEvent = NotesRpc.NoteUpdatedEvent
+export type NoteDeletedEvent = NotesRpc.NoteDeletedEvent
+export type NoteRenamedEvent = NotesRpc.NoteRenamedEvent
+export type NoteMovedEvent = NotesRpc.NoteMovedEvent
+export type NoteExternalChangeEvent = NotesRpc.NoteExternalChangeEvent
 
 export interface IndexRecoveredEvent {
   reason: 'corrupt' | 'missing' | 'healthy'
@@ -433,233 +196,34 @@ export interface IndexRecoveredEvent {
   duration: number
 }
 
-// RepeatConfig type (matches frontend format for full feature support)
-export interface RepeatConfig {
-  frequency: 'daily' | 'weekly' | 'monthly' | 'yearly'
-  interval: number
-  daysOfWeek?: number[]
-  monthlyType?: 'dayOfMonth' | 'weekPattern'
-  dayOfMonth?: number
-  weekOfMonth?: number
-  dayOfWeekForMonth?: number
-  endType: 'never' | 'date' | 'count'
-  endDate?: string | null
-  endCount?: number
-  completedCount: number
-  createdAt: string
-}
+export type RepeatConfig = TasksRpc.RepeatConfig
 
-// Task types (mirrored from contracts for preload compatibility)
-export interface Task {
-  id: string
-  projectId: string
-  statusId: string | null
-  parentId: string | null
-  title: string
-  description: string | null
-  priority: 0 | 1 | 2 | 3 | 4
-  position: number
-  dueDate: string | null
-  dueTime: string | null
-  startDate: string | null
-  repeatConfig: RepeatConfig | null
-  repeatFrom: 'due' | 'completion' | null
-  sourceNoteId: string | null
-  completedAt: string | null
-  archivedAt: string | null
-  createdAt: string
-  modifiedAt: string
-  // Enriched properties
-  tags?: string[]
-  linkedNoteIds?: string[]
-  hasSubtasks?: boolean
-  subtaskCount?: number
-  completedSubtaskCount?: number
-}
-
-export interface TaskListItem extends Task {
-  tags: string[]
-  hasSubtasks: boolean
-  subtaskCount: number
-  completedSubtaskCount: number
-}
-
-export interface Project {
-  id: string
-  name: string
-  description: string | null
-  color: string
-  icon: string | null
-  position: number
-  isInbox: boolean
-  createdAt: string
-  modifiedAt: string
-  archivedAt: string | null
-}
-
-export interface ProjectWithStats extends Project {
-  taskCount: number
-  completedCount: number
-  overdueCount: number
-}
-
-export interface ProjectWithStatuses extends Project {
-  statuses: Status[]
-}
-
-export interface Status {
-  id: string
-  projectId: string
-  name: string
-  color: string
-  position: number
-  isDefault: boolean
-  isDone: boolean
-  createdAt: string
-}
-
-export interface TaskCreateInput {
-  projectId: string
-  title: string
-  description?: string | null
-  priority?: number
-  statusId?: string | null
-  parentId?: string | null
-  dueDate?: string | null
-  dueTime?: string | null
-  startDate?: string | null
-  isRepeating?: boolean
-  repeatConfig?: RepeatConfig | null
-  repeatFrom?: 'due' | 'completion' | null
-  tags?: string[]
-  linkedNoteIds?: string[]
-  position?: number
-}
-
-export interface TaskUpdateInput {
-  id: string
-  title?: string
-  description?: string | null
-  priority?: number
-  projectId?: string
-  statusId?: string | null
-  parentId?: string | null
-  dueDate?: string | null
-  dueTime?: string | null
-  startDate?: string | null
-  isRepeating?: boolean
-  repeatConfig?: RepeatConfig | null
-  repeatFrom?: 'due' | 'completion' | null
-  tags?: string[]
-  linkedNoteIds?: string[]
-}
-
-export interface TaskListOptions {
-  projectId?: string
-  statusId?: string | null
-  parentId?: string | null
-  includeCompleted?: boolean
-  includeArchived?: boolean
-  dueBefore?: string
-  dueAfter?: string
-  tags?: string[]
-  search?: string
-  sortBy?: 'position' | 'dueDate' | 'priority' | 'created' | 'modified'
-  sortOrder?: 'asc' | 'desc'
-  limit?: number
-  offset?: number
-}
-
-export interface TaskCreateResponse {
-  success: boolean
-  task: Task | null
-  error?: string
-}
-
-export interface TaskListResponse {
-  tasks: TaskListItem[]
-  total: number
-  hasMore: boolean
-}
-
-export interface ProjectCreateInput {
-  name: string
-  description?: string | null
-  color?: string
-  icon?: string | null
-}
-
-export interface ProjectUpdateInput {
-  id: string
-  name?: string
-  description?: string | null
-  color?: string
-  icon?: string | null
-}
-
-export interface ProjectListResponse {
-  projects: ProjectWithStats[]
-}
-
-export interface StatusCreateInput {
-  projectId: string
-  name: string
-  color?: string
-  isDone?: boolean
-}
-
-export interface TaskStats {
-  total: number
-  completed: number
-  overdue: number
-  dueToday: number
-  dueThisWeek: number
-}
-
-export interface TaskMoveInput {
-  taskId: string
-  targetProjectId?: string
-  targetStatusId?: string | null
-  targetParentId?: string | null
-  position: number
-}
-
-export interface TaskCreatedEvent {
-  task: Task
-}
-
-export interface TaskUpdatedEvent {
-  id: string
-  task: Task
-  changes: Partial<Task>
-}
-
-export interface TaskDeletedEvent {
-  id: string
-}
-
-export interface TaskCompletedEvent {
-  id: string
-  task: Task
-}
-
-export interface TaskMovedEvent {
-  id: string
-  task: Task
-}
-
-export interface ProjectCreatedEvent {
-  project: Project
-}
-
-export interface ProjectUpdatedEvent {
-  id: string
-  project: Project
-}
-
-export interface ProjectDeletedEvent {
-  id: string
-}
+// Task types
+export type Task = TasksRpc.Task
+export type TaskListItem = TasksRpc.TaskListItem
+export type Project = TasksRpc.Project
+export type ProjectWithStats = TasksRpc.ProjectWithStats
+export type ProjectWithStatuses = TasksRpc.ProjectWithStatuses
+export type Status = TasksRpc.Status
+export type TaskCreateInput = TasksRpc.TaskCreateInput
+export type TaskUpdateInput = TasksRpc.TaskUpdateInput
+export type TaskListOptions = TasksRpc.TaskListOptions
+export type TaskCreateResponse = TasksRpc.TaskCreateResponse
+export type TaskListResponse = TasksRpc.TaskListResponse
+export type ProjectCreateInput = TasksRpc.ProjectCreateInput
+export type ProjectUpdateInput = TasksRpc.ProjectUpdateInput
+export type ProjectListResponse = TasksRpc.ProjectListResponse
+export type StatusCreateInput = TasksRpc.StatusCreateInput
+export type TaskStats = TasksRpc.TaskStats
+export type TaskMoveInput = TasksRpc.TaskMoveInput
+export type TaskCreatedEvent = TasksRpc.TaskCreatedEvent
+export type TaskUpdatedEvent = TasksRpc.TaskUpdatedEvent
+export type TaskDeletedEvent = TasksRpc.TaskDeletedEvent
+export type TaskCompletedEvent = TasksRpc.TaskCompletedEvent
+export type TaskMovedEvent = TasksRpc.TaskMovedEvent
+export type ProjectCreatedEvent = TasksRpc.ProjectCreatedEvent
+export type ProjectUpdatedEvent = TasksRpc.ProjectUpdatedEvent
+export type ProjectDeletedEvent = TasksRpc.ProjectDeletedEvent
 
 // Saved Filter types
 export interface DueDateFilter {
@@ -875,108 +439,7 @@ export interface VaultClientAPI {
 }
 
 // Notes client API interface
-export interface NotesClientAPI {
-  create(input: NoteCreateInput): Promise<NoteCreateResponse>
-  get(id: string): Promise<Note | null>
-  getByPath(path: string): Promise<Note | null>
-  getFile(id: string): Promise<FileMetadata | null>
-  resolveByTitle(title: string): Promise<WikiLinkResolution | null>
-  previewByTitle(title: string): Promise<WikiLinkPreview | null>
-  update(input: NoteUpdateInput): Promise<NoteUpdateResponse>
-  rename(id: string, newTitle: string): Promise<NoteUpdateResponse>
-  move(id: string, newFolder: string): Promise<NoteUpdateResponse>
-  delete(id: string): Promise<{ success: boolean; error?: string }>
-  list(options?: NoteListOptions): Promise<NoteListResponse>
-  getTags(): Promise<{ tag: string; color: string; count: number }[]>
-  getLinks(id: string): Promise<NoteLinksResponse>
-  getFolders(): Promise<FolderInfo[]>
-  createFolder(path: string): Promise<{ success: boolean; error?: string }>
-  renameFolder(oldPath: string, newPath: string): Promise<{ success: boolean; error?: string }>
-  deleteFolder(path: string): Promise<{ success: boolean; error?: string }>
-  exists(titleOrPath: string): Promise<boolean>
-  openExternal(id: string): Promise<void>
-  revealInFinder(id: string): Promise<void>
-  // Property Definitions API (T017-T018)
-  // Note: get/set properties moved to unified PropertiesClientAPI
-  getPropertyDefinitions(): Promise<PropertyDefinition[]>
-  createPropertyDefinition(
-    input: CreatePropertyDefinitionInput
-  ): Promise<CreatePropertyDefinitionResponse>
-  updatePropertyDefinition(
-    input: UpdatePropertyDefinitionInput
-  ): Promise<CreatePropertyDefinitionResponse>
-  ensurePropertyDefinition(name: string, type: string): Promise<{ success: boolean }>
-  addPropertyOption(
-    propertyName: string,
-    option: { value: string; color: string }
-  ): Promise<{ success: boolean }>
-  addStatusOption(
-    propertyName: string,
-    categoryKey: string,
-    option: { value: string; color: string }
-  ): Promise<{ success: boolean }>
-  removePropertyOption(propertyName: string, optionValue: string): Promise<{ success: boolean }>
-  renamePropertyOption(
-    propertyName: string,
-    oldValue: string,
-    newValue: string
-  ): Promise<{ success: boolean }>
-  updateOptionColor(
-    propertyName: string,
-    optionValue: string,
-    newColor: string
-  ): Promise<{ success: boolean }>
-  deletePropertyDefinition(name: string): Promise<{ success: boolean }>
-  // T070: Attachments API
-  uploadAttachment(noteId: string, file: File): Promise<AttachmentResult>
-  listAttachments(noteId: string): Promise<AttachmentInfo[]>
-  deleteAttachment(noteId: string, filename: string): Promise<DeleteAttachmentResponse>
-  // Folder config API (T096.5)
-  getFolderConfig(folderPath: string): Promise<FolderConfig | null>
-  setFolderConfig(
-    folderPath: string,
-    config: FolderConfig
-  ): Promise<{ success: boolean; error?: string }>
-  getFolderTemplate(folderPath: string): Promise<string | null>
-  // Export API (T106, T108)
-  exportPdf(input: ExportNoteInput): Promise<ExportNoteResponse>
-  exportHtml(input: ExportNoteInput): Promise<ExportNoteResponse>
-  // Version History API (T114)
-  getVersions(noteId: string): Promise<SnapshotListItem[]>
-  getVersion(snapshotId: string): Promise<SnapshotDetail | null>
-  restoreVersion(snapshotId: string): Promise<RestoreVersionResponse>
-  deleteVersion(snapshotId: string): Promise<{ success: boolean; error?: string }>
-  // Position/Reorder API
-  getPositions(folderPath: string): Promise<{
-    success: boolean
-    positions: Record<string, number>
-    error?: string
-  }>
-  getAllPositions(): Promise<{
-    success: boolean
-    positions: Record<string, number>
-    error?: string
-  }>
-  reorder(folderPath: string, notePaths: string[]): Promise<{ success: boolean; error?: string }>
-
-  // File import API
-  importFiles(
-    sourcePaths: string[],
-    targetFolder?: string
-  ): Promise<{
-    success: boolean
-    imported: number
-    failed: number
-    errors: string[]
-    importedFiles: Array<{ destPath: string; filename: string; fileType: string }>
-  }>
-  showImportDialog(): Promise<{ canceled: boolean; filePaths: string[] }>
-  setLocalOnly(
-    id: string,
-    localOnly: boolean
-  ): Promise<{ success: boolean; note: Note | null; error?: string }>
-  getLocalOnlyCount(): Promise<{ count: number }>
-}
+export type NotesClientAPI = NotesRpc.NotesClientAPI
 
 // Unified Properties API (works with notes and journal entries)
 export interface PropertiesClientAPI {
@@ -1000,81 +463,7 @@ export interface PropertiesClientAPI {
 }
 
 // Tasks client API interface
-export interface TasksClientAPI {
-  // Task CRUD
-  create(input: TaskCreateInput): Promise<TaskCreateResponse>
-  get(id: string): Promise<Task | null>
-  update(input: TaskUpdateInput): Promise<TaskCreateResponse>
-  delete(id: string): Promise<{ success: boolean; error?: string }>
-  list(options?: TaskListOptions): Promise<TaskListResponse>
-
-  // Task actions
-  complete(input: { id: string; completedAt?: string }): Promise<TaskCreateResponse>
-  uncomplete(id: string): Promise<TaskCreateResponse>
-  archive(id: string): Promise<{ success: boolean; error?: string }>
-  unarchive(id: string): Promise<{ success: boolean; error?: string }>
-  move(input: TaskMoveInput): Promise<TaskCreateResponse>
-  reorder(taskIds: string[], positions: number[]): Promise<{ success: boolean; error?: string }>
-  duplicate(id: string): Promise<TaskCreateResponse>
-
-  // Subtask operations
-  getSubtasks(parentId: string): Promise<Task[]>
-  convertToSubtask(taskId: string, parentId: string): Promise<TaskCreateResponse>
-  convertToTask(taskId: string): Promise<TaskCreateResponse>
-
-  // Project operations
-  createProject(
-    input: ProjectCreateInput
-  ): Promise<{ success: boolean; project: Project | null; error?: string }>
-  getProject(id: string): Promise<ProjectWithStatuses | null>
-  updateProject(
-    input: ProjectUpdateInput
-  ): Promise<{ success: boolean; project: Project | null; error?: string }>
-  deleteProject(id: string): Promise<{ success: boolean; error?: string }>
-  listProjects(): Promise<ProjectListResponse>
-  archiveProject(id: string): Promise<{ success: boolean; error?: string }>
-  reorderProjects(
-    projectIds: string[],
-    positions: number[]
-  ): Promise<{ success: boolean; error?: string }>
-
-  // Status operations
-  createStatus(
-    input: StatusCreateInput
-  ): Promise<{ success: boolean; status: Status | null; error?: string }>
-  updateStatus(id: string, updates: Partial<Status>): Promise<{ success: boolean; error?: string }>
-  deleteStatus(id: string): Promise<{ success: boolean; error?: string }>
-  reorderStatuses(
-    statusIds: string[],
-    positions: number[]
-  ): Promise<{ success: boolean; error?: string }>
-  listStatuses(projectId: string): Promise<Status[]>
-
-  // Tag operations
-  getTags(): Promise<{ tag: string; count: number }[]>
-
-  // Bulk operations
-  bulkComplete(ids: string[]): Promise<{ success: boolean; count: number; error?: string }>
-  bulkDelete(ids: string[]): Promise<{ success: boolean; count: number; error?: string }>
-  bulkMove(
-    ids: string[],
-    projectId: string
-  ): Promise<{ success: boolean; count: number; error?: string }>
-  bulkArchive(ids: string[]): Promise<{ success: boolean; count: number; error?: string }>
-
-  // Stats and views
-  getStats(): Promise<TaskStats>
-  getToday(): Promise<TaskListResponse>
-  getUpcoming(days?: number): Promise<TaskListResponse>
-  getOverdue(): Promise<TaskListResponse>
-
-  // Note linking
-  getLinkedTasks(noteId: string): Promise<Task[]>
-
-  // Development/Testing
-  seedPerformanceTest(): Promise<{ success: boolean; message: string }>
-  seedDemo(): Promise<{ success: boolean; message: string }>
-}
+export type TasksClientAPI = TasksRpc.TasksClientAPI
 
 // Saved Filters client API interface
 export interface SavedFiltersClientAPI {
@@ -1304,406 +693,40 @@ export interface TagsClientAPI {
 }
 
 // Inbox types
-export type InboxItemType =
-  | 'link'
-  | 'note'
-  | 'image'
-  | 'voice'
-  | 'video'
-  | 'clip'
-  | 'pdf'
-  | 'social'
-  | 'reminder'
-export type InboxProcessingStatus = 'pending' | 'processing' | 'complete' | 'failed'
-export type InboxFilingAction = 'folder' | 'note' | 'linked'
-export type InboxJobType =
-  | 'transcription'
-  | 'metadata-scrape'
-  | 'duplicate-detection'
-  | 'suggestion-generation'
-  | 'thumbnail-generation'
-export type InboxJobStatus = 'pending' | 'running' | 'failed' | 'complete'
-
-export interface InboxItem {
-  id: string
-  type: InboxItemType
-  title: string
-  content: string | null
-  createdAt: Date
-  modifiedAt: Date
-  filedAt: Date | null
-  filedTo: string | null
-  filedAction: InboxFilingAction | null
-  snoozedUntil: Date | null
-  snoozeReason: string | null
-  viewedAt: Date | null
-  processingStatus: InboxProcessingStatus
-  processingError: string | null
-  metadata: unknown
-  attachmentPath: string | null
-  attachmentUrl: string | null
-  thumbnailPath: string | null
-  thumbnailUrl: string | null
-  transcription: string | null
-  transcriptionStatus: InboxProcessingStatus | null
-  sourceUrl: string | null
-  sourceTitle: string | null
-  tags: string[]
-  isStale: boolean
-}
-
-export interface InboxItemListItem {
-  id: string
-  type: InboxItemType
-  title: string
-  content: string | null
-  createdAt: Date
-  thumbnailUrl: string | null
-  sourceUrl: string | null
-  tags: string[]
-  isStale: boolean
-  processingStatus: InboxProcessingStatus
-  duration?: number
-  excerpt?: string
-  pageCount?: number
-  // Voice transcription fields
-  transcription?: string | null
-  transcriptionStatus?: InboxProcessingStatus | null
-  // Snooze fields (optional - only present for snoozed items)
-  snoozedUntil?: Date
-  snoozeReason?: string
-  // Viewed field (for reminder items)
-  viewedAt?: Date
-  // Metadata (for reminder items - includes target info)
-  metadata?: unknown
-}
-
-export interface InboxListResponse {
-  items: InboxItemListItem[]
-  total: number
-  hasMore: boolean
-}
-
-export interface InboxDuplicateMatch {
-  id: string
-  title: string
-  createdAt: string
-}
-
-export interface InboxCaptureResponse {
-  success: boolean
-  item: InboxItem | null
-  error?: string
-  duplicate?: boolean
-  existingItem?: InboxDuplicateMatch
-}
-
-export interface InboxFileResponse {
-  success: boolean
-  filedTo: string | null
-  noteId?: string
-  error?: string
-}
-
-export interface InboxBulkResponse {
-  success: boolean
-  processedCount: number
-  errors: Array<{ itemId: string; error: string }>
-}
-
-export interface InboxFilingHistoryEntry {
-  id: string
-  itemId: string
-  itemType: InboxItemType
-  itemTitle: string
-  filedTo: string
-  filedAction: InboxFilingAction
-  filedAt: Date
-  tags: string[]
-}
-
-export interface InboxFilingHistoryResponse {
-  entries: InboxFilingHistoryEntry[]
-}
-
-export interface InboxFilingSuggestion {
-  destination: {
-    type: 'folder' | 'note' | 'new-note'
-    path?: string
-    noteId?: string
-    noteTitle?: string
-  }
-  confidence: number
-  reason: string
-  suggestedTags: string[]
-  suggestedNote?: {
-    id: string
-    title: string
-    snippet: string
-    emoji?: string | null
-  }
-}
-
-export interface InboxSuggestionsResponse {
-  suggestions: InboxFilingSuggestion[]
-}
-
-export interface InboxAgeDistribution {
-  fresh: number
-  aging: number
-  stale: number
-}
-
-export interface InboxStats {
-  totalItems: number
-  itemsByType: Record<InboxItemType, number>
-  staleCount: number
-  snoozedCount: number
-  processedToday: number
-  capturedToday: number
-  avgTimeToProcess: number
-  capturedThisWeek: number
-  processedThisWeek: number
-  captureProcessRatio: number
-  ageDistribution: InboxAgeDistribution
-  oldestItemDays: number
-  currentStreak: number
-}
-
-export interface InboxCapturePattern {
-  timeHeatmap: number[][]
-  typeDistribution: Array<{
-    type: InboxItemType
-    count: number
-    percentage: number
-    trend: 'up' | 'down' | 'stable'
-  }>
-  topDomains: Array<{ domain: string; count: number }>
-  topTags: Array<{ tag: string; count: number }>
-}
-
-export interface InboxJob {
-  id: string
-  itemId: string
-  type: InboxJobType
-  status: InboxJobStatus
-  runAt: Date
-  attempts: number
-  maxAttempts: number
-  payload: Record<string, unknown> | null
-  result: Record<string, unknown> | null
-  lastError: string | null
-  startedAt: Date | null
-  completedAt: Date | null
-  createdAt: Date
-  updatedAt: Date
-}
-
-export interface InboxJobsResponse {
-  jobs: InboxJob[]
-}
-
-export interface InboxCapturedEvent {
-  item: InboxItemListItem
-}
-
-export interface InboxUpdatedEvent {
-  id: string
-  changes: Partial<InboxItem>
-}
-
-export interface InboxArchivedEvent {
-  id: string
-}
-
-export interface InboxFiledEvent {
-  id: string
-  filedTo: string
-  filedAction: string
-}
-
-export interface InboxSnoozedEvent {
-  id: string
-  snoozeUntil: string
-}
-
-export interface InboxSnoozeDueEvent {
-  items: InboxItemListItem[]
-}
-
-export interface InboxTranscriptionCompleteEvent {
-  id: string
-  transcription: string
-}
-
-export interface InboxMetadataCompleteEvent {
-  id: string
-  metadata: unknown
-}
-
-export interface InboxProcessingErrorEvent {
-  id: string
-  operation: string
-  error: string
-}
-
-export interface LinkPreviewData {
-  title: string
-  domain: string
-  favicon?: string
-  image?: string
-  description?: string
-}
+export type InboxItemType = InboxRpc.InboxItemType
+export type InboxProcessingStatus = InboxRpc.InboxProcessingStatus
+export type InboxFilingAction = InboxRpc.InboxFilingAction
+export type InboxJobType = InboxRpc.InboxJobType
+export type InboxJobStatus = InboxRpc.InboxJobStatus
+export type InboxItem = InboxRpc.InboxItem
+export type InboxItemListItem = InboxRpc.InboxItemListItem
+export type InboxListResponse = InboxRpc.InboxListResponse
+export type InboxDuplicateMatch = NonNullable<InboxRpc.InboxCaptureResponse['existingItem']>
+export type InboxCaptureResponse = InboxRpc.InboxCaptureResponse
+export type InboxFileResponse = InboxRpc.InboxFileResponse
+export type InboxBulkResponse = InboxRpc.InboxBulkResponse
+export type InboxFilingHistoryEntry = InboxRpc.InboxFilingHistoryEntry
+export type InboxFilingHistoryResponse = InboxRpc.InboxFilingHistoryResponse
+export type InboxFilingSuggestion = InboxRpc.InboxFilingSuggestion
+export type InboxSuggestionsResponse = InboxRpc.InboxSuggestionsResponse
+export type InboxAgeDistribution = InboxRpc.InboxStats['ageDistribution']
+export type InboxStats = InboxRpc.InboxStats
+export type InboxCapturePattern = InboxRpc.InboxCapturePattern
+export type InboxJob = InboxRpc.InboxJob
+export type InboxJobsResponse = InboxRpc.InboxJobsResponse
+export type InboxCapturedEvent = InboxRpc.InboxCapturedEvent
+export type InboxUpdatedEvent = InboxRpc.InboxUpdatedEvent
+export type InboxArchivedEvent = InboxRpc.InboxArchivedEvent
+export type InboxFiledEvent = InboxRpc.InboxFiledEvent
+export type InboxSnoozedEvent = InboxRpc.InboxSnoozedEvent
+export type InboxSnoozeDueEvent = InboxRpc.InboxSnoozeDueEvent
+export type InboxTranscriptionCompleteEvent = InboxRpc.InboxTranscriptionCompleteEvent
+export type InboxMetadataCompleteEvent = InboxRpc.InboxMetadataCompleteEvent
+export type InboxProcessingErrorEvent = InboxRpc.InboxProcessingErrorEvent
+export type LinkPreviewData = InboxRpc.LinkPreviewData
 
 // Inbox client API interface
-export interface InboxClientAPI {
-  // Capture
-  captureText(input: {
-    content: string
-    title?: string
-    tags?: string[]
-    force?: boolean
-  }): Promise<InboxCaptureResponse>
-  captureLink(input: {
-    url: string
-    tags?: string[]
-    force?: boolean
-  }): Promise<InboxCaptureResponse>
-  captureImage(input: {
-    data: ArrayBuffer
-    filename: string
-    mimeType: string
-    tags?: string[]
-  }): Promise<InboxCaptureResponse>
-  captureVoice(input: {
-    data: ArrayBuffer
-    duration: number
-    format: string
-    transcribe?: boolean
-    tags?: string[]
-  }): Promise<InboxCaptureResponse>
-  captureClip(input: {
-    html: string
-    text: string
-    sourceUrl: string
-    sourceTitle: string
-    tags?: string[]
-  }): Promise<InboxCaptureResponse>
-  capturePdf(input: {
-    data: ArrayBuffer
-    filename: string
-    extractText?: boolean
-    tags?: string[]
-  }): Promise<InboxCaptureResponse>
-
-  // CRUD
-  get(id: string): Promise<InboxItem | null>
-  list(options?: {
-    type?: string
-    includeSnoozed?: boolean
-    sortBy?: 'created' | 'modified' | 'title'
-    sortOrder?: 'asc' | 'desc'
-    limit?: number
-    offset?: number
-  }): Promise<InboxListResponse>
-  update(input: { id: string; title?: string; content?: string }): Promise<InboxCaptureResponse>
-  archive(id: string): Promise<{ success: boolean; error?: string }>
-
-  // Filing
-  file(input: {
-    itemId: string
-    destination: { type: string; path?: string; noteId?: string; noteTitle?: string }
-    tags?: string[]
-  }): Promise<InboxFileResponse>
-  getSuggestions(itemId: string): Promise<InboxSuggestionsResponse>
-  convertToNote(itemId: string): Promise<InboxFileResponse>
-  convertToTask(
-    itemId: string
-  ): Promise<{ success: boolean; taskId: string | null; error?: string }>
-  linkToNote(
-    itemId: string,
-    noteId: string,
-    tags?: string[]
-  ): Promise<{ success: boolean; error?: string }>
-  trackSuggestion(input: {
-    itemId: string
-    itemType: string
-    suggestedTo: string
-    actualTo: string
-    confidence: number
-    suggestedTags?: string[]
-    actualTags?: string[]
-  }): Promise<{ success: boolean; error?: string }>
-
-  // Tags
-  addTag(itemId: string, tag: string): Promise<{ success: boolean; error?: string }>
-  removeTag(itemId: string, tag: string): Promise<{ success: boolean; error?: string }>
-  getTags(): Promise<Array<{ tag: string; count: number }>>
-
-  // Snooze
-  snooze(input: {
-    itemId: string
-    snoozeUntil: string
-    reason?: string
-  }): Promise<{ success: boolean; error?: string }>
-  unsnooze(itemId: string): Promise<{ success: boolean; error?: string }>
-  getSnoozed(): Promise<InboxItem[]>
-
-  // Viewed (for reminder items)
-  markViewed(itemId: string): Promise<{ success: boolean; error?: string }>
-
-  // Bulk operations
-  bulkFile(input: {
-    itemIds: string[]
-    destination: { type: string; path?: string; noteId?: string }
-    tags?: string[]
-  }): Promise<InboxBulkResponse>
-  bulkArchive(input: { itemIds: string[] }): Promise<InboxBulkResponse>
-  bulkTag(input: { itemIds: string[]; tags: string[] }): Promise<InboxBulkResponse>
-  bulkSnooze(input: {
-    itemIds: string[]
-    snoozeUntil: string
-    reason?: string
-  }): Promise<InboxBulkResponse>
-  fileAllStale(): Promise<InboxBulkResponse>
-
-  // Transcription
-  retryTranscription(itemId: string): Promise<{ success: boolean; error?: string }>
-
-  // Preview
-  previewLink(url: string): Promise<LinkPreviewData>
-
-  // Metadata
-  retryMetadata(itemId: string): Promise<{ success: boolean; error?: string }>
-
-  // Stats
-  getStats(): Promise<InboxStats>
-  getJobs(options?: {
-    itemIds?: string[]
-    statuses?: Array<'pending' | 'running' | 'failed' | 'complete'>
-  }): Promise<InboxJobsResponse>
-  getPatterns(): Promise<InboxCapturePattern>
-
-  // Settings
-  getStaleThreshold(): Promise<number>
-  setStaleThreshold(days: number): Promise<{ success: boolean }>
-
-  // Archived items
-  listArchived(options?: {
-    search?: string
-    limit?: number
-    offset?: number
-  }): Promise<InboxListResponse>
-  unarchive(id: string): Promise<{ success: boolean; error?: string }>
-  deletePermanent(id: string): Promise<{ success: boolean; error?: string }>
-
-  // Filing history
-  getFilingHistory(options?: { limit?: number }): Promise<InboxFilingHistoryResponse>
-
-  // Undo operations
-  undoFile(id: string): Promise<{ success: boolean; error?: string }>
-  undoArchive(id: string): Promise<{ success: boolean; error?: string }>
-}
+export type InboxClientAPI = InboxRpc.InboxClientAPI
 
 // Search types
 import type {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -37,11 +37,9 @@ export interface VaultInfo {
   isDefault: boolean
 }
 
-// Note types
 export type NoteFrontmatter = NotesRpc.Note['frontmatter']
 export type Note = NotesRpc.Note
 
-// T020: Property types — canonical set from @memry/contracts/property-types
 export type PropertyType =
   | 'text'
   | 'number'
@@ -70,7 +68,6 @@ export interface SetPropertiesResponse {
 
 export type CreatePropertyDefinitionResponse = NotesRpc.CreatePropertyDefinitionResponse
 
-// T070: Attachment types
 export type AttachmentResult = NotesRpc.AttachmentResult
 export type AttachmentInfo = NotesRpc.AttachmentInfo
 export type DeleteAttachmentResponse = NotesRpc.DeleteAttachmentResponse
@@ -146,11 +143,9 @@ export interface TemplateListResponse {
 export type FolderConfig = NotesRpc.FolderConfig
 export type FolderInfo = NotesRpc.FolderInfo
 
-// Export types (T106, T108)
 export type ExportNoteInput = NotesRpc.ExportNoteInput
 export type ExportNoteResponse = NotesRpc.ExportNoteResponse
 
-// Version History types (T110-T114)
 export type SnapshotReason = NotesRpc.SnapshotListItem['reason']
 export type SnapshotListItem = NotesRpc.SnapshotListItem
 export type SnapshotDetail = NotesRpc.SnapshotDetail
@@ -198,7 +193,6 @@ export interface IndexRecoveredEvent {
 
 export type RepeatConfig = TasksRpc.RepeatConfig
 
-// Task types
 export type Task = TasksRpc.Task
 export type TaskListItem = TasksRpc.TaskListItem
 export type Project = TasksRpc.Project
@@ -692,7 +686,6 @@ export interface TagsClientAPI {
   mergeTag(input: { source: string; target: string }): Promise<MergeTagResponse>
 }
 
-// Inbox types
 export type InboxItemType = InboxRpc.InboxItemType
 export type InboxProcessingStatus = InboxRpc.InboxProcessingStatus
 export type InboxFilingAction = InboxRpc.InboxFilingAction
@@ -701,7 +694,7 @@ export type InboxJobStatus = InboxRpc.InboxJobStatus
 export type InboxItem = InboxRpc.InboxItem
 export type InboxItemListItem = InboxRpc.InboxItemListItem
 export type InboxListResponse = InboxRpc.InboxListResponse
-export type InboxDuplicateMatch = NonNullable<InboxRpc.InboxCaptureResponse['existingItem']>
+export type InboxDuplicateMatch = InboxRpc.InboxDuplicateMatch
 export type InboxCaptureResponse = InboxRpc.InboxCaptureResponse
 export type InboxFileResponse = InboxRpc.InboxFileResponse
 export type InboxBulkResponse = InboxRpc.InboxBulkResponse
@@ -709,7 +702,7 @@ export type InboxFilingHistoryEntry = InboxRpc.InboxFilingHistoryEntry
 export type InboxFilingHistoryResponse = InboxRpc.InboxFilingHistoryResponse
 export type InboxFilingSuggestion = InboxRpc.InboxFilingSuggestion
 export type InboxSuggestionsResponse = InboxRpc.InboxSuggestionsResponse
-export type InboxAgeDistribution = InboxRpc.InboxStats['ageDistribution']
+export type InboxAgeDistribution = InboxRpc.InboxAgeDistribution
 export type InboxStats = InboxRpc.InboxStats
 export type InboxCapturePattern = InboxRpc.InboxCapturePattern
 export type InboxJob = InboxRpc.InboxJob
@@ -725,7 +718,6 @@ export type InboxMetadataCompleteEvent = InboxRpc.InboxMetadataCompleteEvent
 export type InboxProcessingErrorEvent = InboxRpc.InboxProcessingErrorEvent
 export type LinkPreviewData = InboxRpc.LinkPreviewData
 
-// Inbox client API interface
 export type InboxClientAPI = InboxRpc.InboxClientAPI
 
 // Search types

--- a/apps/desktop/src/renderer/src/components/inbox/inbox-capture-heatmap.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox/inbox-capture-heatmap.tsx
@@ -1,4 +1,4 @@
-import type { InboxCapturePattern } from '../../../../preload/index.d'
+import type { InboxCapturePattern } from '@memry/rpc/inbox'
 
 export interface InboxCaptureHeatmapProps {
   patterns: InboxCapturePattern | undefined

--- a/apps/desktop/src/renderer/src/components/inbox/inbox-filing-history.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox/inbox-filing-history.tsx
@@ -13,8 +13,8 @@ import {
   Bell,
   HelpCircle
 } from '@/lib/icons'
+import type { InboxFilingHistoryEntry } from '@memry/rpc/inbox'
 import { formatCompactDate } from '@/services/inbox-service'
-import type { InboxFilingHistoryEntry } from '../../../../preload/index.d'
 
 export interface InboxFilingHistoryListProps {
   items: InboxFilingHistoryEntry[]

--- a/apps/desktop/src/renderer/src/components/inbox/inbox-stats-cards.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox/inbox-stats-cards.tsx
@@ -7,7 +7,7 @@ import {
   TrendingDown,
   Minus
 } from '@/lib/icons'
-import type { InboxStats } from '../../../../preload/index.d'
+import type { InboxStats } from '@memry/rpc/inbox'
 import { cn } from '@/lib/utils'
 
 export interface InboxStatsCardsProps {

--- a/apps/desktop/src/renderer/src/components/inbox/inbox-type-distribution.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox/inbox-type-distribution.tsx
@@ -11,7 +11,7 @@ import {
   HelpCircle,
   File
 } from '@/lib/icons'
-import type { InboxStats } from '../../../../preload/index.d'
+import type { InboxStats } from '@memry/rpc/inbox'
 
 export interface InboxTypeDistributionProps {
   stats: InboxStats | null

--- a/apps/desktop/src/renderer/src/features/inbox/use-inbox-jobs.ts
+++ b/apps/desktop/src/renderer/src/features/inbox/use-inbox-jobs.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import type { InboxJob } from '../../../../preload/index.d'
+import type { InboxJob } from '@memry/rpc/inbox'
 
 import {
   inboxService,

--- a/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
+++ b/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import type { Project, ProjectWithStats, Status, Task } from '@memry/rpc/tasks'
 import { formatDateKey } from '@/lib/task-utils'
 import type { Task as UiTask, RepeatConfig as UiRepeatConfig } from '@/data/sample-tasks'
 import type { Project as UiProject, Status as UiStatus, StatusType } from '@/data/tasks-data'
@@ -11,11 +12,7 @@ import {
   onTaskCompleted,
   onProjectCreated,
   onProjectUpdated,
-  onProjectDeleted,
-  type Task,
-  type Project,
-  type ProjectWithStats,
-  type Status
+  onProjectDeleted
 } from '@/services/tasks-service'
 import { createLogger } from '@/lib/logger'
 

--- a/apps/desktop/src/renderer/src/hooks/inbox-query-keys.ts
+++ b/apps/desktop/src/renderer/src/hooks/inbox-query-keys.ts
@@ -1,4 +1,4 @@
-import type { InboxListInput } from '@/services/inbox-service'
+import type { InboxListInput } from '@memry/rpc/inbox'
 
 export const DEFAULT_PAGE_SIZE = 50
 export const ITEM_STALE_TIME = 30 * 1000

--- a/apps/desktop/src/renderer/src/hooks/use-inbox-keyboard.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-inbox-keyboard.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
+import type { InboxItemListItem } from '@memry/rpc/inbox'
 import { toast } from 'sonner'
 import { isInputFocused } from '@/hooks/use-keyboard-shortcuts'
-import type { InboxItemListItem } from '../../../preload/index.d'
 
 export interface UseInboxKeyboardOptions {
   enabled: boolean

--- a/apps/desktop/src/renderer/src/hooks/use-inbox-mutations.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-inbox-mutations.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
 import type {
+  InboxBulkResponse,
   InboxCaptureResponse,
-  InboxFileResponse,
-  InboxBulkResponse
-} from '../../../preload/index.d'
+  InboxFileResponse
+} from '@memry/rpc/inbox'
 import {
   inboxService,
   type CaptureTextInput,

--- a/apps/desktop/src/renderer/src/hooks/use-inbox-queries.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-inbox-queries.ts
@@ -7,12 +7,12 @@ import {
   type UseQueryResult
 } from '@tanstack/react-query'
 import type {
+  InboxFilingHistoryResponse,
   InboxItem,
   InboxItemListItem,
   InboxStats,
-  InboxSuggestionsResponse,
-  InboxFilingHistoryResponse
-} from '../../../preload/index.d'
+  InboxSuggestionsResponse
+} from '@memry/rpc/inbox'
 import {
   inboxService,
   onInboxCaptured,

--- a/apps/desktop/src/renderer/src/hooks/use-note-editor.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-editor.ts
@@ -11,10 +11,10 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react'
+import type { Note } from '@memry/rpc/notes'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { notesService, onNoteDeleted, onNoteExternalChange } from '@/services/notes-service'
 import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
-import type { Note } from '../../../preload/index.d'
 import { toast } from 'sonner'
 
 // ============================================================================

--- a/apps/desktop/src/renderer/src/hooks/use-notes-query.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-notes-query.ts
@@ -8,12 +8,12 @@
 import { useEffect, useCallback, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type {
+  FolderInfo,
   Note,
-  NoteListItem,
-  NoteListResponse,
   NoteLinksResponse,
-  FolderInfo
-} from '../../../preload/index.d'
+  NoteListItem,
+  NoteListResponse
+} from '@memry/rpc/notes'
 
 // Types are re-exported at the end of this file
 import {

--- a/apps/desktop/src/renderer/src/pages/file.tsx
+++ b/apps/desktop/src/renderer/src/pages/file.tsx
@@ -12,7 +12,7 @@ import { notesService } from '@/services/notes-service'
 import { PdfViewer, ImageViewer, AudioPlayer, VideoPlayer } from '@/components/viewers'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import type { FileMetadata } from '../../../preload/index.d'
+import type { FileMetadata } from '@memry/rpc/notes'
 
 // ============================================================================
 // Types

--- a/apps/desktop/src/renderer/src/pages/inbox/inbox-health-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox/inbox-health-view.tsx
@@ -13,9 +13,9 @@ import {
   CheckCircle
 } from '@/lib/icons'
 import type { AppIcon } from '@/lib/icons'
+import type { InboxCapturePattern, InboxFilingHistoryEntry } from '@memry/rpc/inbox'
 import { useInboxStats, useInboxFilingHistory, useInboxPatterns } from '@/hooks/use-inbox'
 import { cn } from '@/lib/utils'
-import type { InboxCapturePattern, InboxFilingHistoryEntry } from '../../../../preload/index.d'
 
 export interface InboxHealthViewProps {
   className?: string

--- a/apps/desktop/src/renderer/src/services/inbox-service.test.ts
+++ b/apps/desktop/src/renderer/src/services/inbox-service.test.ts
@@ -52,6 +52,14 @@ describe('inbox-service', () => {
     vi.useRealTimers()
   })
 
+  it('exposes inbox RPC methods directly from window.api.inbox', () => {
+    expect(inboxService.captureText).toBe(api.inbox.captureText)
+    expect(inboxService.file).toBe(api.inbox.file)
+    expect(inboxService.bulkArchive).toBe(api.inbox.bulkArchive)
+    expect(inboxService.getStats).toBe(api.inbox.getStats)
+    expect(inboxService.setStaleThreshold).toBe(api.inbox.setStaleThreshold)
+  })
+
   it('forwards capture, file, and snooze operations', async () => {
     await inboxService.captureText({ content: 'Hello' })
     expect(api.inbox.captureText).toHaveBeenCalledWith({ content: 'Hello' })

--- a/apps/desktop/src/renderer/src/services/inbox-service.ts
+++ b/apps/desktop/src/renderer/src/services/inbox-service.ts
@@ -43,8 +43,6 @@ import type {
 } from '@memry/rpc/inbox'
 import { createWindowApiForwarder } from './window-api-forwarder'
 
-type FilingHistoryResponse = InboxFilingHistoryResponse
-
 export type {
   BulkArchiveInput,
   BulkFileInput,
@@ -61,7 +59,6 @@ export type {
   CaptureVoiceInput,
   FileItemInput,
   FileResponse,
-  FilingHistoryResponse,
   GetFilingHistoryInput,
   GetJobsInput,
   InboxArchivedEvent,

--- a/apps/desktop/src/renderer/src/services/inbox-service.ts
+++ b/apps/desktop/src/renderer/src/services/inbox-service.ts
@@ -41,6 +41,7 @@ import type {
   ListArchivedInput,
   SnoozeInput
 } from '@memry/rpc/inbox'
+import { createWindowApiForwarder } from './window-api-forwarder'
 
 type FilingHistoryResponse = InboxFilingHistoryResponse
 
@@ -89,50 +90,7 @@ export type {
   SuggestionsResponse
 }
 
-export const inboxService: InboxClientAPI = {
-  captureText: (input) => window.api.inbox.captureText(input),
-  captureLink: (input) => window.api.inbox.captureLink(input),
-  previewLink: (url) => window.api.inbox.previewLink(url),
-  captureImage: (input) => window.api.inbox.captureImage(input),
-  captureVoice: (input) => window.api.inbox.captureVoice(input),
-  captureClip: (input) => window.api.inbox.captureClip(input),
-  capturePdf: (input) => window.api.inbox.capturePdf(input),
-  get: (id) => window.api.inbox.get(id),
-  list: (options) => window.api.inbox.list(options),
-  update: (input) => window.api.inbox.update(input),
-  archive: (id) => window.api.inbox.archive(id),
-  file: (input) => window.api.inbox.file(input),
-  getSuggestions: (itemId) => window.api.inbox.getSuggestions(itemId),
-  trackSuggestion: (input) => window.api.inbox.trackSuggestion(input),
-  convertToNote: (itemId) => window.api.inbox.convertToNote(itemId),
-  convertToTask: (itemId) => window.api.inbox.convertToTask(itemId),
-  linkToNote: (itemId, noteId, tags) => window.api.inbox.linkToNote(itemId, noteId, tags),
-  addTag: (itemId, tag) => window.api.inbox.addTag(itemId, tag),
-  removeTag: (itemId, tag) => window.api.inbox.removeTag(itemId, tag),
-  getTags: () => window.api.inbox.getTags(),
-  snooze: (input) => window.api.inbox.snooze(input),
-  unsnooze: (itemId) => window.api.inbox.unsnooze(itemId),
-  getSnoozed: () => window.api.inbox.getSnoozed(),
-  markViewed: (itemId) => window.api.inbox.markViewed(itemId),
-  bulkFile: (input) => window.api.inbox.bulkFile(input),
-  bulkArchive: (input) => window.api.inbox.bulkArchive(input),
-  bulkTag: (input) => window.api.inbox.bulkTag(input),
-  bulkSnooze: (input) => window.api.inbox.bulkSnooze(input),
-  fileAllStale: () => window.api.inbox.fileAllStale(),
-  retryTranscription: (itemId) => window.api.inbox.retryTranscription(itemId),
-  retryMetadata: (itemId) => window.api.inbox.retryMetadata(itemId),
-  getStats: () => window.api.inbox.getStats(),
-  getJobs: (options) => window.api.inbox.getJobs(options),
-  getPatterns: () => window.api.inbox.getPatterns(),
-  getStaleThreshold: () => window.api.inbox.getStaleThreshold(),
-  setStaleThreshold: (days) => window.api.inbox.setStaleThreshold(days),
-  listArchived: (options) => window.api.inbox.listArchived(options),
-  unarchive: (id) => window.api.inbox.unarchive(id),
-  deletePermanent: (id) => window.api.inbox.deletePermanent(id),
-  getFilingHistory: (options) => window.api.inbox.getFilingHistory(options),
-  undoFile: (id) => window.api.inbox.undoFile(id),
-  undoArchive: (id) => window.api.inbox.undoArchive(id)
-}
+export const inboxService: InboxClientAPI = createWindowApiForwarder(() => window.api.inbox)
 
 export function onInboxCaptured(callback: (event: InboxCapturedEvent) => void): () => void {
   return window.api.onInboxCaptured(callback)

--- a/apps/desktop/src/renderer/src/services/notes-service.test.ts
+++ b/apps/desktop/src/renderer/src/services/notes-service.test.ts
@@ -18,6 +18,14 @@ describe('notes-service', () => {
     ;(window as Window & { api: unknown }).api = api
   })
 
+  it('exposes note RPC methods directly from window.api.notes', () => {
+    expect(notesService.create).toBe(api.notes.create)
+    expect(notesService.get).toBe(api.notes.get)
+    expect(notesService.list).toBe(api.notes.list)
+    expect(notesService.uploadAttachment).toBe(api.notes.uploadAttachment)
+    expect(notesService.reorder).toBe(api.notes.reorder)
+  })
+
   it('forwards core note operations to window.api.notes', async () => {
     const createResponse = { success: true, note: { id: 'note-1' } }
     api.notes.create = vi.fn().mockResolvedValue(createResponse)

--- a/apps/desktop/src/renderer/src/services/notes-service.ts
+++ b/apps/desktop/src/renderer/src/services/notes-service.ts
@@ -36,6 +36,7 @@ import type {
   WikiLinkPreview,
   WikiLinkResolution
 } from '@memry/rpc/notes'
+import { createWindowApiForwarder } from './window-api-forwarder'
 
 export type {
   AttachmentInfo,
@@ -76,63 +77,7 @@ export type {
   WikiLinkResolution
 }
 
-export const notesService: NotesClientAPI = {
-  create: (input) => window.api.notes.create(input),
-  get: (id) => window.api.notes.get(id),
-  getByPath: (path) => window.api.notes.getByPath(path),
-  getFile: (id) => window.api.notes.getFile(id),
-  resolveByTitle: (title) => window.api.notes.resolveByTitle(title),
-  previewByTitle: (title) => window.api.notes.previewByTitle(title),
-  update: (input) => window.api.notes.update(input),
-  rename: (id, newTitle) => window.api.notes.rename(id, newTitle),
-  move: (id, newFolder) => window.api.notes.move(id, newFolder),
-  delete: (id) => window.api.notes.delete(id),
-  list: (options) => window.api.notes.list(options),
-  getTags: () => window.api.notes.getTags(),
-  getLinks: (id) => window.api.notes.getLinks(id),
-  getFolders: () => window.api.notes.getFolders(),
-  createFolder: (path) => window.api.notes.createFolder(path),
-  renameFolder: (oldPath, newPath) => window.api.notes.renameFolder(oldPath, newPath),
-  deleteFolder: (path) => window.api.notes.deleteFolder(path),
-  exists: (titleOrPath) => window.api.notes.exists(titleOrPath),
-  openExternal: (id) => window.api.notes.openExternal(id),
-  revealInFinder: (id) => window.api.notes.revealInFinder(id),
-  getPropertyDefinitions: () => window.api.notes.getPropertyDefinitions(),
-  createPropertyDefinition: (input) => window.api.notes.createPropertyDefinition(input),
-  updatePropertyDefinition: (input) => window.api.notes.updatePropertyDefinition(input),
-  ensurePropertyDefinition: (name, type) => window.api.notes.ensurePropertyDefinition(name, type),
-  addPropertyOption: (propertyName, option) =>
-    window.api.notes.addPropertyOption(propertyName, option),
-  addStatusOption: (propertyName, categoryKey, option) =>
-    window.api.notes.addStatusOption(propertyName, categoryKey, option),
-  removePropertyOption: (propertyName, optionValue) =>
-    window.api.notes.removePropertyOption(propertyName, optionValue),
-  renamePropertyOption: (propertyName, oldValue, newValue) =>
-    window.api.notes.renamePropertyOption(propertyName, oldValue, newValue),
-  updateOptionColor: (propertyName, optionValue, newColor) =>
-    window.api.notes.updateOptionColor(propertyName, optionValue, newColor),
-  deletePropertyDefinition: (name) => window.api.notes.deletePropertyDefinition(name),
-  uploadAttachment: (noteId, file) => window.api.notes.uploadAttachment(noteId, file),
-  listAttachments: (noteId) => window.api.notes.listAttachments(noteId),
-  deleteAttachment: (noteId, filename) => window.api.notes.deleteAttachment(noteId, filename),
-  getFolderConfig: (folderPath) => window.api.notes.getFolderConfig(folderPath),
-  setFolderConfig: (folderPath, config) => window.api.notes.setFolderConfig(folderPath, config),
-  getFolderTemplate: (folderPath) => window.api.notes.getFolderTemplate(folderPath),
-  exportPdf: (input) => window.api.notes.exportPdf(input),
-  exportHtml: (input) => window.api.notes.exportHtml(input),
-  getVersions: (noteId) => window.api.notes.getVersions(noteId),
-  getVersion: (snapshotId) => window.api.notes.getVersion(snapshotId),
-  restoreVersion: (snapshotId) => window.api.notes.restoreVersion(snapshotId),
-  deleteVersion: (snapshotId) => window.api.notes.deleteVersion(snapshotId),
-  getPositions: (folderPath) => window.api.notes.getPositions(folderPath),
-  getAllPositions: () => window.api.notes.getAllPositions(),
-  reorder: (folderPath, notePaths) => window.api.notes.reorder(folderPath, notePaths),
-  importFiles: (sourcePaths, targetFolder) =>
-    window.api.notes.importFiles(sourcePaths, targetFolder),
-  showImportDialog: () => window.api.notes.showImportDialog(),
-  setLocalOnly: (id, localOnly) => window.api.notes.setLocalOnly(id, localOnly),
-  getLocalOnlyCount: () => window.api.notes.getLocalOnlyCount()
-}
+export const notesService: NotesClientAPI = createWindowApiForwarder(() => window.api.notes)
 
 export function onNoteCreated(callback: (event: NoteCreatedEvent) => void): () => void {
   return window.api.onNoteCreated(callback)

--- a/apps/desktop/src/renderer/src/services/tasks-service.test.ts
+++ b/apps/desktop/src/renderer/src/services/tasks-service.test.ts
@@ -20,6 +20,14 @@ describe('tasks-service', () => {
     ;(window as Window & { api: unknown }).api = api
   })
 
+  it('exposes task RPC methods directly from window.api.tasks', () => {
+    expect(tasksService.create).toBe(api.tasks.create)
+    expect(tasksService.update).toBe(api.tasks.update)
+    expect(tasksService.list).toBe(api.tasks.list)
+    expect(tasksService.bulkComplete).toBe(api.tasks.bulkComplete)
+    expect(tasksService.getUpcoming).toBe(api.tasks.getUpcoming)
+  })
+
   it('forwards CRUD and list calls', async () => {
     api.tasks.create = vi.fn().mockResolvedValue({ success: true, task: { id: 'task-1' } })
     api.tasks.update = vi.fn().mockResolvedValue({ success: true, task: { id: 'task-1' } })

--- a/apps/desktop/src/renderer/src/services/tasks-service.ts
+++ b/apps/desktop/src/renderer/src/services/tasks-service.ts
@@ -27,6 +27,7 @@ import type {
   TaskUpdatedEvent,
   TaskUpdateInput
 } from '@memry/rpc/tasks'
+import { createWindowApiForwarder } from './window-api-forwarder'
 
 export type {
   Project,
@@ -54,48 +55,7 @@ export type {
   TaskUpdatedEvent,
   TaskUpdateInput
 }
-export const tasksService: TasksClientAPI = {
-  create: (input) => window.api.tasks.create(input),
-  get: (id) => window.api.tasks.get(id),
-  update: (input) => window.api.tasks.update(input),
-  delete: (id) => window.api.tasks.delete(id),
-  list: (options) => window.api.tasks.list(options),
-  complete: (input) => window.api.tasks.complete(input),
-  uncomplete: (id) => window.api.tasks.uncomplete(id),
-  archive: (id) => window.api.tasks.archive(id),
-  unarchive: (id) => window.api.tasks.unarchive(id),
-  move: (input) => window.api.tasks.move(input),
-  reorder: (taskIds, positions) => window.api.tasks.reorder(taskIds, positions),
-  duplicate: (id) => window.api.tasks.duplicate(id),
-  getSubtasks: (parentId) => window.api.tasks.getSubtasks(parentId),
-  convertToSubtask: (taskId, parentId) => window.api.tasks.convertToSubtask(taskId, parentId),
-  convertToTask: (taskId) => window.api.tasks.convertToTask(taskId),
-  createProject: (input) => window.api.tasks.createProject(input),
-  getProject: (id) => window.api.tasks.getProject(id),
-  updateProject: (input) => window.api.tasks.updateProject(input),
-  deleteProject: (id) => window.api.tasks.deleteProject(id),
-  listProjects: () => window.api.tasks.listProjects(),
-  archiveProject: (id) => window.api.tasks.archiveProject(id),
-  reorderProjects: (projectIds, positions) =>
-    window.api.tasks.reorderProjects(projectIds, positions),
-  createStatus: (input) => window.api.tasks.createStatus(input),
-  updateStatus: (id, updates) => window.api.tasks.updateStatus(id, updates),
-  deleteStatus: (id) => window.api.tasks.deleteStatus(id),
-  reorderStatuses: (statusIds, positions) => window.api.tasks.reorderStatuses(statusIds, positions),
-  listStatuses: (projectId) => window.api.tasks.listStatuses(projectId),
-  getTags: () => window.api.tasks.getTags(),
-  bulkComplete: (ids) => window.api.tasks.bulkComplete(ids),
-  bulkDelete: (ids) => window.api.tasks.bulkDelete(ids),
-  bulkMove: (ids, projectId) => window.api.tasks.bulkMove(ids, projectId),
-  bulkArchive: (ids) => window.api.tasks.bulkArchive(ids),
-  getStats: () => window.api.tasks.getStats(),
-  getToday: () => window.api.tasks.getToday(),
-  getUpcoming: (days) => window.api.tasks.getUpcoming(days),
-  getOverdue: () => window.api.tasks.getOverdue(),
-  getLinkedTasks: (noteId) => window.api.tasks.getLinkedTasks(noteId),
-  seedPerformanceTest: () => window.api.tasks.seedPerformanceTest(),
-  seedDemo: () => window.api.tasks.seedDemo()
-}
+export const tasksService: TasksClientAPI = createWindowApiForwarder(() => window.api.tasks)
 
 export function onTaskCreated(callback: (event: TaskCreatedEvent) => void): () => void {
   return window.api.onTaskCreated(callback)

--- a/apps/desktop/src/renderer/src/services/window-api-forwarder.test.ts
+++ b/apps/desktop/src/renderer/src/services/window-api-forwarder.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createWindowApiForwarder } from './window-api-forwarder'
+
+interface TestApi {
+  greet(name: string): string
+  count(): number
+}
+
+function createTestApi(): TestApi {
+  return {
+    greet: vi.fn((name: string) => `hi ${name}`),
+    count: vi.fn(() => 42)
+  }
+}
+
+describe('createWindowApiForwarder', () => {
+  it('forwards method calls to the underlying API', () => {
+    const api = createTestApi()
+    const proxy = createWindowApiForwarder<TestApi>(() => api)
+
+    expect(proxy.greet('Kaan')).toBe('hi Kaan')
+    expect(api.greet).toHaveBeenCalledWith('Kaan')
+    expect(proxy.count()).toBe(42)
+  })
+
+  it('returns the same function reference as the underlying API', () => {
+    const api = createTestApi()
+    const proxy = createWindowApiForwarder<TestApi>(() => api)
+
+    expect(proxy.greet).toBe(api.greet)
+    expect(proxy.count).toBe(api.count)
+  })
+
+  it('supports the "in" operator via has trap', () => {
+    const api = createTestApi()
+    const proxy = createWindowApiForwarder<TestApi>(() => api)
+
+    expect('greet' in proxy).toBe(true)
+    expect('nonExistent' in proxy).toBe(false)
+  })
+
+  it('returns undefined for non-existent properties', () => {
+    const api = createTestApi()
+    const proxy = createWindowApiForwarder<TestApi>(() => api)
+
+    expect((proxy as Record<string, unknown>)['missing']).toBeUndefined()
+  })
+
+  it('enumerates keys via Object.keys', () => {
+    const api = createTestApi()
+    const proxy = createWindowApiForwarder<TestApi>(() => api)
+
+    expect(Object.keys(proxy).sort()).toEqual(['count', 'greet'])
+  })
+
+  it('resolves lazily — follows selectApi changes', () => {
+    let current = createTestApi()
+    const proxy = createWindowApiForwarder<TestApi>(() => current)
+
+    expect(proxy.count()).toBe(42)
+
+    const replacement = { greet: vi.fn(() => 'replaced'), count: vi.fn(() => 99) }
+    current = replacement
+
+    expect(proxy.count()).toBe(99)
+    expect(replacement.count).toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/services/window-api-forwarder.ts
+++ b/apps/desktop/src/renderer/src/services/window-api-forwarder.ts
@@ -1,10 +1,16 @@
 export function createWindowApiForwarder<T extends object>(selectApi: () => T): T {
   return new Proxy({} as T, {
-    get(_target, property, receiver) {
-      return Reflect.get(selectApi(), property, receiver)
+    get(_target, property) {
+      return Reflect.get(selectApi(), property)
     },
     has(_target, property) {
       return property in selectApi()
+    },
+    ownKeys() {
+      return Reflect.ownKeys(selectApi())
+    },
+    getOwnPropertyDescriptor(_target, property) {
+      return Reflect.getOwnPropertyDescriptor(selectApi(), property)
     }
   })
 }

--- a/apps/desktop/src/renderer/src/services/window-api-forwarder.ts
+++ b/apps/desktop/src/renderer/src/services/window-api-forwarder.ts
@@ -1,0 +1,7 @@
+export function createWindowApiForwarder<T extends object>(selectApi: () => T): T {
+  return new Proxy({} as T, {
+    get(_target, property, receiver) {
+      return Reflect.get(selectApi(), property, receiver)
+    }
+  })
+}

--- a/apps/desktop/src/renderer/src/services/window-api-forwarder.ts
+++ b/apps/desktop/src/renderer/src/services/window-api-forwarder.ts
@@ -2,6 +2,9 @@ export function createWindowApiForwarder<T extends object>(selectApi: () => T): 
   return new Proxy({} as T, {
     get(_target, property, receiver) {
       return Reflect.get(selectApi(), property, receiver)
+    },
+    has(_target, property) {
+      return property in selectApi()
     }
   })
 }

--- a/apps/desktop/src/renderer/src/types/index.ts
+++ b/apps/desktop/src/renderer/src/types/index.ts
@@ -12,19 +12,19 @@ export interface TreeDataItem {
   inheritedIcon?: string // Parent'tan gelen ikon adı
 }
 
-// Re-export inbox types from preload (backend types)
+// Re-export canonical inbox RPC types for renderer consumers.
 export type {
-  InboxItemType,
+  InboxBulkResponse,
+  InboxCaptureResponse,
+  InboxFilingAction,
+  InboxFileResponse,
   InboxItem,
   InboxItemListItem,
+  InboxItemType,
   InboxListResponse,
-  InboxCaptureResponse,
-  InboxFileResponse,
-  InboxBulkResponse,
-  InboxStats,
   InboxProcessingStatus,
-  InboxFilingAction
-} from '../../../preload/index.d'
+  InboxStats
+} from '@memry/rpc/inbox'
 
 // Metadata types for type-specific content
 export interface LinkMetadata {

--- a/packages/rpc/src/inbox.ts
+++ b/packages/rpc/src/inbox.ts
@@ -7,7 +7,7 @@ import {
   type RpcSubscriptions
 } from './schema.ts'
 
-type InboxItemType =
+export type InboxItemType =
   | 'link'
   | 'note'
   | 'image'
@@ -18,9 +18,9 @@ type InboxItemType =
   | 'social'
   | 'reminder'
 
-type ProcessingStatus = 'pending' | 'processing' | 'complete' | 'failed'
-type FilingAction = 'folder' | 'note' | 'linked'
-type CaptureSource = 'quick-capture' | 'inline' | 'browser-extension' | 'api' | 'reminder'
+export type InboxProcessingStatus = 'pending' | 'processing' | 'complete' | 'failed'
+export type InboxFilingAction = 'folder' | 'note' | 'linked'
+export type CaptureSource = 'quick-capture' | 'inline' | 'browser-extension' | 'api' | 'reminder'
 export type InboxJobType =
   | 'transcription'
   | 'metadata-scrape'
@@ -52,11 +52,11 @@ export interface InboxItem {
   modifiedAt: Date
   filedAt: Date | null
   filedTo: string | null
-  filedAction: FilingAction | null
+  filedAction: InboxFilingAction | null
   snoozedUntil: Date | null
   snoozeReason: string | null
   viewedAt: Date | null
-  processingStatus: ProcessingStatus
+  processingStatus: InboxProcessingStatus
   processingError: string | null
   metadata: InboxMetadata | null
   attachmentPath: string | null
@@ -64,7 +64,7 @@ export interface InboxItem {
   thumbnailPath: string | null
   thumbnailUrl: string | null
   transcription: string | null
-  transcriptionStatus: ProcessingStatus | null
+  transcriptionStatus: InboxProcessingStatus | null
   sourceUrl: string | null
   sourceTitle: string | null
   captureSource?: CaptureSource | null
@@ -82,12 +82,12 @@ export interface InboxItemListItem {
   sourceUrl: string | null
   tags: string[]
   isStale: boolean
-  processingStatus: ProcessingStatus
+  processingStatus: InboxProcessingStatus
   duration?: number
   excerpt?: string
   pageCount?: number
   transcription?: string | null
-  transcriptionStatus?: ProcessingStatus | null
+  transcriptionStatus?: InboxProcessingStatus | null
   snoozedUntil?: Date
   snoozeReason?: string
   viewedAt?: Date
@@ -209,7 +209,7 @@ export interface InboxFilingHistoryEntry {
   itemType: InboxItemType
   itemTitle: string
   filedTo: string
-  filedAction: FilingAction
+  filedAction: InboxFilingAction
   filedAt: Date
   tags: string[]
 }

--- a/packages/rpc/src/inbox.ts
+++ b/packages/rpc/src/inbox.ts
@@ -101,7 +101,7 @@ export interface InboxListResponse {
   hasMore: boolean
 }
 
-interface InboxDuplicateMatch {
+export interface InboxDuplicateMatch {
   id: string
   title: string
   createdAt: string
@@ -150,6 +150,12 @@ export interface InboxSuggestionsResponse {
   suggestions: InboxFilingSuggestion[]
 }
 
+export interface InboxAgeDistribution {
+  fresh: number
+  aging: number
+  stale: number
+}
+
 export interface InboxStats {
   totalItems: number
   itemsByType: Record<InboxItemType, number>
@@ -161,11 +167,7 @@ export interface InboxStats {
   capturedThisWeek: number
   processedThisWeek: number
   captureProcessRatio: number
-  ageDistribution: {
-    fresh: number
-    aging: number
-    stale: number
-  }
+  ageDistribution: InboxAgeDistribution
   oldestItemDays: number
   currentStreak: number
 }


### PR DESCRIPTION
## Summary
Introduces `createWindowApiForwarder` utility to eliminate boilerplate in service API delegation, consolidating 100+ lines of repetitive proxy code across inbox, notes, and tasks services into a single reusable pattern. Simultaneously restructures type exports to use @memry/rpc packages as the canonical source, simplifying import paths across components.

## Why
- **Boilerplate reduction**: Services had 40-60 line manual delegation objects for each API. Consolidation ~40% code reduction.
- **Type canonicalization**: Removes duplicated type definitions in preload; @memry/rpc is now the single source of truth.
- **Maintainability**: New APIs or method changes only require updates in one place, not across multiple services.

## How
1. Created `createWindowApiForwarder<T>(selectApi: () => T): T` — a generic Proxy that delegates all property access to a lazily-selected API object
2. Refactored inbox, notes, and tasks services to use the forwarder instead of manual delegation
3. Moved type definitions from preload to RPC packages; preload re-exports for compatibility
4. Updated all consumer imports (components, hooks, pages) to source types from @memry/rpc instead of preload

## Type
refactor

## Test plan
- [x] All 5511 unit tests pass
- [x] TypeScript strict mode passes
- [x] ESLint reports no new errors
- [x] IPC contract validation passes
- [x] Manual test: service methods still callable (via Proxy delegation)
- [x] Import verification: components resolve types from @memry/rpc