### PR TITLE
refactor: consolidate RPC types and service API delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-04-09 — RPC Type Consolidation
+
+### Added
+- Add createWindowApiForwarder utility to centralize renderer→main API proxy delegation
+
+### Changed
+- Consolidate type exports and imports via @memry/rpc packages
+- Extract task context and queries into dedicated tasks-app-boundary module
+
+---
+
 ## 2026-04-08 — Marquee Selection Indent/Outdent
 
 ### Added

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,34 +1,26 @@
-import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
-import type { DragEndEvent } from '@dnd-kit/core'
-import { arrayMove } from '@dnd-kit/sortable'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Loader2 } from '@/lib/icons'
 import { AppSidebar } from '@/components/app-sidebar'
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
 import { Toaster } from '@/components/ui/sonner'
-import { DragProvider, type DragState } from '@/contexts/drag-context'
-import { DroppedPriorityProvider } from '@/contexts/dropped-priority-context'
 import { AIInlineProvider } from '@/contexts/ai-inline-context'
 import { DayPanelProvider } from '@/contexts/day-panel-context'
 import { SidebarDrillDownProvider } from '@/contexts/sidebar-drill-down'
 import { SelectedFolderProvider } from '@/contexts/selected-folder-context'
 import { GlobalDayPanel } from '@/components/day-panel'
 import { TaskDragOverlay } from '@/components/tasks/drag-drop'
-import { taskViews } from '@/data/tasks-data'
 import { ThemeProvider } from 'next-themes'
 
 // Tab System imports
 import { TabProvider, useTabs } from '@/contexts/tabs'
 import { useTabPersistence, useSessionRestore, STORAGE_KEY } from '@/contexts/tabs/persistence'
-import { TasksProvider } from '@/contexts/tasks'
 import { TabDragProvider, TabErrorBoundary } from '@/components/tabs'
 import { SplitViewContainer } from '@/components/split-view'
 import { ChordIndicator, KeyboardShortcutsDialog } from '@/components/keyboard'
 import {
   useTabKeyboardShortcuts,
   useChordShortcuts,
-  useDragHandlers,
-  useTaskOrder,
   useVault,
   useSettingsShortcut,
   useNewNoteShortcut,
@@ -41,7 +33,6 @@ import { SettingsModalProvider, useSettingsModal } from '@/contexts/settings-mod
 import { SettingsModal } from '@/components/settings-modal'
 import { useFolderViewEvents } from '@/hooks/use-folder-view-events'
 import { useFlushOnQuit } from '@/hooks/use-flush-on-quit'
-import { tasksService } from '@/services/tasks-service'
 import { notesService } from '@/services/notes-service'
 import { VaultOnboarding } from '@/components/vault-onboarding'
 import { FirstRunOnboarding } from '@/components/first-run-onboarding'
@@ -49,9 +40,7 @@ import { useThemeSync } from '@/hooks/use-theme-sync'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { createLogger } from '@/lib/logger'
 import { getStartupTheme, THEME_STORAGE_KEY } from '@/lib/startup-theme'
-import { useTaskWorkspaceData, useTaskWorkspaceMutations } from '@/features/tasks/use-task-queries'
-import { useTaskUiStore } from '@/features/tasks/use-task-ui-store'
-import { getFilteredTasks } from '@/lib/task-utils'
+import { TasksAppBoundary } from '@/features/tasks/tasks-app-boundary'
 
 const log = createLogger('App')
 const startupTheme = getStartupTheme()
@@ -221,136 +210,36 @@ function App(): React.JSX.Element {
   // currentPage is still used for sidebar highlight state
   const [currentPage] = useState<AppPage>('inbox')
 
-  const { tasks, projects } = useTaskWorkspaceData({ enabled: isVaultOpen })
-  const {
-    setProjects,
-    updateTask: handleUpdateTask,
-    deleteTask: handleDeleteTask
-  } = useTaskWorkspaceMutations()
-  const { selectedTaskIds, setSelectedTaskIds: updateSelectedTaskIds } = useTaskUiStore()
-  const selectedTaskIdsRef = useRef(selectedTaskIds)
-
-  useEffect(() => {
-    selectedTaskIdsRef.current = selectedTaskIds
-  }, [selectedTaskIds])
-
-  // Calculate view counts dynamically
-  const viewCounts = useMemo(() => {
-    const counts: Record<string, number> = {}
-    taskViews.forEach((view) => {
-      const filtered = getFilteredTasks(tasks, view.id, 'view', projects)
-      counts[view.id] = filtered.length
-    })
-    return counts
-  }, [tasks, projects])
-
-  // Update project task counts
-  const projectsWithCounts = useMemo(() => {
-    return projects.map((project) => {
-      const projectTasks = tasks.filter((t) => t.projectId === project.id)
-      const incompleteTasks = projectTasks.filter((t) => {
-        const status = project.statuses.find((s) => s.id === t.statusId)
-        return status?.type !== 'done'
-      })
-      return { ...project, taskCount: incompleteTasks.length }
-    })
-  }, [projects, tasks])
-
-  // Task handlers (passed to TasksPage)
-  // Task order persistence hook
-  const taskOrder = useTaskOrder({ persist: true })
-
-  const handleReorder = useCallback(
-    (updates: Record<string, string[] | null>) => {
-      taskOrder.applyOrderUpdates(updates)
-      for (const [, taskIds] of Object.entries(updates)) {
-        if (!taskIds) continue
-        const positions = taskIds.map((_, i) => i)
-        tasksService.reorder(taskIds, positions)
-      }
-    },
-    [taskOrder]
-  )
-
-  // Use the comprehensive drag handlers hook
-  const { handleDragEnd: taskDragEnd, droppedPriorities } = useDragHandlers({
-    tasks,
-    projects,
-    onUpdateTask: handleUpdateTask,
-    onDeleteTask: handleDeleteTask,
-    onReorder: handleReorder,
-    getOrder: taskOrder.getOrder
-  })
-
-  // Combined drag-drop handler (task operations + project reordering)
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent, dragState: DragState) => {
-      const { active, over } = event
-      if (!over) return
-
-      const activeData = active.data.current
-
-      // Handle project reordering in sidebar (not handled by useDragHandlers)
-      if (activeData?.type === undefined && over.id !== active.id) {
-        const activeIndex = projects.findIndex((p) => p.id === active.id)
-        const overIndex = projects.findIndex((p) => p.id === over.id)
-        if (activeIndex !== -1 && overIndex !== -1) {
-          setProjects((prev) => {
-            const reorderedProjects = arrayMove(prev, activeIndex, overIndex)
-            void tasksService.reorderProjects(
-              reorderedProjects.map((project) => project.id),
-              reorderedProjects.map((_, index) => index)
-            )
-            return reorderedProjects
-          })
-          return
-        }
-      }
-
-      // Delegate all task operations to useDragHandlers
-      taskDragEnd(event, dragState)
-
-      // Clear selection after task drag
-      if (dragState.isDragging) {
-        updateSelectedTaskIds(new Set<string>())
-      }
-    },
-    [projects, taskDragEnd, updateSelectedTaskIds]
-  )
-
   // Main content with TabProvider and TasksProvider wrapping everything
   // Wrapped in TabErrorBoundary for graceful error handling
   const mainContent = (
-    <TabErrorBoundary
-      onError={(error, errorInfo) => log.error('Critical error:', error, errorInfo)}
-    >
-      <TasksProvider
-        tasks={tasks}
-        projects={projectsWithCounts}
-        getOrderedTasks={taskOrder.getOrderedTasks}
-      >
-        <DayPanelProvider>
-          <AIInlineProvider>
-            <TabProvider>
-              <TabPersistenceManager>
-                <SettingsModalProvider>
-                  <SelectedFolderProvider>
-                    <SidebarDrillDownProvider>
-                      <AppSidebar currentPage={currentPage} viewCounts={viewCounts} />
-                      <SidebarInset className="flex flex-col overflow-hidden">
-                        <AppContent />
-                      </SidebarInset>
-                    </SidebarDrillDownProvider>
-                    {/* Drag Overlay - only for task drag to sidebar */}
-                    <TaskDragOverlay projects={projectsWithCounts} />
-                  </SelectedFolderProvider>
-                </SettingsModalProvider>
-              </TabPersistenceManager>
-            </TabProvider>
-          </AIInlineProvider>
-        </DayPanelProvider>
-      </TasksProvider>
-    </TabErrorBoundary>
+    <TasksAppBoundary>
+      {({ projects, viewCounts }) => (
+        <TabErrorBoundary
+          onError={(error, errorInfo) => log.error('Critical error:', error, errorInfo)}
+        >
+          <DayPanelProvider>
+            <AIInlineProvider>
+              <TabProvider>
+                <TabPersistenceManager>
+                  <SettingsModalProvider>
+                    <SelectedFolderProvider>
+                      <SidebarDrillDownProvider>
+                        <AppSidebar currentPage={currentPage} viewCounts={viewCounts} />
+                        <SidebarInset className="flex flex-col overflow-hidden">
+                          <AppContent />
+                        </SidebarInset>
+                      </SidebarDrillDownProvider>
+                      <TaskDragOverlay projects={projects} />
+                    </SelectedFolderProvider>
+                  </SettingsModalProvider>
+                </TabPersistenceManager>
+              </TabProvider>
+            </AIInlineProvider>
+          </DayPanelProvider>
+        </TabErrorBoundary>
+      )}
+    </TasksAppBoundary>
   )
 
   if (vaultLoading) {
@@ -386,16 +275,7 @@ function App(): React.JSX.Element {
     >
       <ThemeSyncManager>
         <SidebarProvider key={vaultPath}>
-          <DragProvider
-            tasks={tasks}
-            selectedIds={selectedTaskIds}
-            selectedIdsRef={selectedTaskIdsRef}
-            onDragEnd={(event, state) => void handleDragEnd(event, state)}
-          >
-            <DroppedPriorityProvider value={droppedPriorities}>
-              {mainContent}
-            </DroppedPriorityProvider>
-          </DragProvider>
+          {mainContent}
         </SidebarProvider>
         {/* First-run onboarding overlay — shown until user completes or dismisses */}
         {!generalSettingsLoading && !generalSettings.onboardingCompleted && (

--- a/apps/desktop/src/renderer/src/components/journal/journal-day-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-day-panel.tsx
@@ -9,7 +9,7 @@ import {
   onTaskCompleted,
   type TaskListItem
 } from '@/services/tasks-service'
-import { useTasksContext } from '@/contexts/tasks'
+import { useTaskProjects } from '@/features/tasks/use-task-queries'
 import { useTabActions } from '@/contexts/tabs'
 import { InlineStatusPopover } from '@/components/tasks/inline-status-popover'
 import { InlinePriorityPopover } from '@/components/tasks/inline-priority-popover'
@@ -159,7 +159,7 @@ interface JournalDayPanelProps {
 
 export function JournalDayPanel({ date, className }: JournalDayPanelProps) {
   const [isCollapsed, setIsCollapsed] = useState(false)
-  const { projects } = useTasksContext()
+  const { projects } = useTaskProjects()
   const { openTab } = useTabActions()
   const queryClient = useQueryClient()
 

--- a/apps/desktop/src/renderer/src/contexts/tasks/index.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tasks/index.tsx
@@ -2,8 +2,6 @@ import { createContext, useContext, useMemo, type ReactNode } from 'react'
 import type { Task } from '@/data/sample-tasks'
 import type { Project } from '@/data/tasks-data'
 import type { TaskSelectionType } from '@/App'
-import { useTaskWorkspaceMutations, useTaskWorkspaceData } from '@/features/tasks/use-task-queries'
-import { useTaskUiStore } from '@/features/tasks/use-task-ui-store'
 
 interface TasksContextValue {
   tasks: Task[]
@@ -26,10 +24,21 @@ interface TasksContextValue {
 
 interface TasksProviderProps {
   children: ReactNode
-  tasks?: Task[]
-  projects?: Project[]
-  initialTasks?: Task[]
-  initialProjects?: Project[]
+  tasks: Task[]
+  projects: Project[]
+  taskSelectedId: string
+  taskSelectedType: TaskSelectionType
+  selectedTaskIds: Set<string>
+  setTasks: (tasks: Task[] | ((prev: Task[]) => Task[])) => void
+  setProjects: (projects: Project[] | ((prev: Project[]) => Project[])) => void
+  setSelection: (id: string, type: TaskSelectionType) => void
+  setSelectedTaskIds: (ids: Set<string>) => void
+  addTask: (task: Task) => Promise<void>
+  updateTask: (taskId: string, updates: Partial<Task>) => Promise<void>
+  deleteTask: (taskId: string) => Promise<void>
+  addProject: (project: Project) => Promise<void>
+  updateProject: (projectId: string, updates: Partial<Project>) => Promise<void>
+  deleteProject: (projectId: string) => Promise<void>
   getOrderedTasks?: (sectionId: string, tasks: Task[]) => Task[]
 }
 
@@ -51,43 +60,32 @@ export const TasksProvider = ({
   children,
   tasks,
   projects,
-  initialTasks,
-  initialProjects,
+  taskSelectedId,
+  taskSelectedType,
+  selectedTaskIds,
+  setTasks,
+  setProjects,
+  setSelection,
+  setSelectedTaskIds,
+  addTask,
+  updateTask,
+  deleteTask,
+  addProject,
+  updateProject,
+  deleteProject,
   getOrderedTasks
 }: TasksProviderProps): React.JSX.Element => {
-  const shouldLoadWorkspace =
-    tasks === undefined &&
-    projects === undefined &&
-    initialTasks === undefined &&
-    initialProjects === undefined
-
-  const workspace = useTaskWorkspaceData({ enabled: shouldLoadWorkspace })
-  const uiStore = useTaskUiStore()
-  const {
-    setTasks,
-    setProjects,
-    addTask,
-    updateTask,
-    deleteTask,
-    addProject,
-    updateProject,
-    deleteProject
-  } = useTaskWorkspaceMutations()
-
-  const resolvedTasks = tasks ?? initialTasks ?? workspace.tasks
-  const resolvedProjects = projects ?? initialProjects ?? workspace.projects
-
   const value = useMemo<TasksContextValue>(
     () => ({
-      tasks: resolvedTasks,
-      projects: resolvedProjects,
-      taskSelectedId: uiStore.taskSelectedId,
-      taskSelectedType: uiStore.taskSelectedType,
-      selectedTaskIds: uiStore.selectedTaskIds,
+      tasks,
+      projects,
+      taskSelectedId,
+      taskSelectedType,
+      selectedTaskIds,
       setTasks,
       setProjects,
-      setSelection: uiStore.setSelection,
-      setSelectedTaskIds: uiStore.setSelectedTaskIds,
+      setSelection,
+      setSelectedTaskIds,
       addTask,
       updateTask,
       deleteTask,
@@ -97,13 +95,13 @@ export const TasksProvider = ({
       getOrderedTasks
     }),
     [
-      resolvedTasks,
-      resolvedProjects,
-      uiStore.taskSelectedId,
-      uiStore.taskSelectedType,
-      uiStore.selectedTaskIds,
-      uiStore.setSelection,
-      uiStore.setSelectedTaskIds,
+      tasks,
+      projects,
+      taskSelectedId,
+      taskSelectedType,
+      selectedTaskIds,
+      setSelection,
+      setSelectedTaskIds,
       setTasks,
       setProjects,
       addTask,

--- a/apps/desktop/src/renderer/src/features/tasks/tasks-app-boundary.tsx
+++ b/apps/desktop/src/renderer/src/features/tasks/tasks-app-boundary.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react'
+import type { DragEndEvent } from '@dnd-kit/core'
+import { arrayMove } from '@dnd-kit/sortable'
+import { DragProvider, type DragState } from '@/contexts/drag-context'
+import { DroppedPriorityProvider } from '@/contexts/dropped-priority-context'
+import { TasksProvider } from '@/contexts/tasks'
+import { taskViews, type Project } from '@/data/tasks-data'
+import { useDragHandlers, useTaskOrder } from '@/hooks'
+import { tasksService } from '@/services/tasks-service'
+import {
+  useTaskWorkspaceData,
+  useTaskWorkspaceMutations
+} from '@/features/tasks/use-task-queries'
+import { useTaskUiStore } from '@/features/tasks/use-task-ui-store'
+import { getFilteredTasks } from '@/lib/task-utils'
+
+interface TasksAppRenderProps {
+  projects: Project[]
+  viewCounts: Record<string, number>
+}
+
+interface TasksAppBoundaryProps {
+  children: (props: TasksAppRenderProps) => ReactNode
+}
+
+export function TasksAppBoundary({ children }: TasksAppBoundaryProps): React.JSX.Element {
+  const { tasks, projects } = useTaskWorkspaceData({ enabled: true })
+  const {
+    setTasks,
+    setProjects,
+    addTask,
+    addProject,
+    updateTask: handleUpdateTask,
+    updateProject,
+    deleteTask: handleDeleteTask,
+    deleteProject
+  } = useTaskWorkspaceMutations()
+  const {
+    taskSelectedId,
+    taskSelectedType,
+    selectedTaskIds,
+    setSelection,
+    setSelectedTaskIds
+  } = useTaskUiStore()
+  const selectedTaskIdsRef = useRef(selectedTaskIds)
+
+  useEffect(() => {
+    selectedTaskIdsRef.current = selectedTaskIds
+  }, [selectedTaskIds])
+
+  const viewCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    taskViews.forEach((view) => {
+      const filtered = getFilteredTasks(tasks, view.id, 'view', projects)
+      counts[view.id] = filtered.length
+    })
+    return counts
+  }, [tasks, projects])
+
+  const projectsWithCounts = useMemo(() => {
+    return projects.map((project) => {
+      const projectTasks = tasks.filter((task) => task.projectId === project.id)
+      const incompleteTasks = projectTasks.filter((task) => {
+        const status = project.statuses.find((entry) => entry.id === task.statusId)
+        return status?.type !== 'done'
+      })
+      return { ...project, taskCount: incompleteTasks.length }
+    })
+  }, [projects, tasks])
+
+  const taskOrder = useTaskOrder({ persist: true })
+
+  const handleReorder = useCallback(
+    (updates: Record<string, string[] | null>) => {
+      taskOrder.applyOrderUpdates(updates)
+      for (const taskIds of Object.values(updates)) {
+        if (!taskIds) continue
+        void tasksService.reorder(
+          taskIds,
+          taskIds.map((_, index) => index)
+        )
+      }
+    },
+    [taskOrder]
+  )
+
+  const { handleDragEnd: taskDragEnd, droppedPriorities } = useDragHandlers({
+    tasks,
+    projects: projectsWithCounts,
+    onUpdateTask: handleUpdateTask,
+    onDeleteTask: handleDeleteTask,
+    onReorder: handleReorder,
+    getOrder: taskOrder.getOrder
+  })
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent, dragState: DragState) => {
+      const { active, over } = event
+      if (!over) return
+
+      const activeData = active.data.current
+
+      if (activeData?.type === undefined && over.id !== active.id) {
+        const activeIndex = projects.findIndex((project) => project.id === active.id)
+        const overIndex = projects.findIndex((project) => project.id === over.id)
+        if (activeIndex !== -1 && overIndex !== -1) {
+          setProjects((previous) => {
+            const reorderedProjects = arrayMove(previous, activeIndex, overIndex)
+            void tasksService.reorderProjects(
+              reorderedProjects.map((project) => project.id),
+              reorderedProjects.map((_, index) => index)
+            )
+            return reorderedProjects
+          })
+          return
+        }
+      }
+
+      taskDragEnd(event, dragState)
+
+      if (dragState.isDragging) {
+        setSelectedTaskIds(new Set<string>())
+      }
+    },
+    [projects, setProjects, setSelectedTaskIds, taskDragEnd]
+  )
+
+  return (
+    <DragProvider
+      tasks={tasks}
+      selectedIds={selectedTaskIds}
+      selectedIdsRef={selectedTaskIdsRef}
+      onDragEnd={(event, state) => void handleDragEnd(event, state)}
+    >
+      <DroppedPriorityProvider value={droppedPriorities}>
+        <TasksProvider
+          tasks={tasks}
+          projects={projectsWithCounts}
+          taskSelectedId={taskSelectedId}
+          taskSelectedType={taskSelectedType}
+          selectedTaskIds={selectedTaskIds}
+          setTasks={setTasks}
+          setProjects={setProjects}
+          setSelection={setSelection}
+          setSelectedTaskIds={setSelectedTaskIds}
+          addTask={addTask}
+          updateTask={handleUpdateTask}
+          deleteTask={handleDeleteTask}
+          addProject={addProject}
+          updateProject={updateProject}
+          deleteProject={deleteProject}
+          getOrderedTasks={taskOrder.getOrderedTasks}
+        >
+          {children({
+            projects: projectsWithCounts,
+            viewCounts
+          })}
+        </TasksProvider>
+      </DroppedPriorityProvider>
+    </DragProvider>
+  )
+}

--- a/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
+++ b/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
@@ -169,31 +169,33 @@ function toServiceRepeatConfig(config: UiRepeatConfig | null | undefined) {
   }
 }
 
+async function loadProjects(): Promise<UiProject[]> {
+  const projectsResponse = await tasksService.listProjects()
+  const baseProjects = projectsResponse.projects.map(dbProjectToUiProject)
+
+  return Promise.all(
+    baseProjects.map(async (project) => {
+      try {
+        const statuses = await tasksService.listStatuses(project.id)
+        return {
+          ...project,
+          statuses: statuses.map(dbStatusToUiStatus)
+        }
+      } catch (error) {
+        log.warn(`Failed to load statuses for project ${project.id}:`, error)
+        return project
+      }
+    })
+  )
+}
+
 export function useTaskWorkspaceData({ enabled = true }: { enabled?: boolean }) {
   const queryClient = useQueryClient()
 
   const projectsQuery = useQuery({
     queryKey: taskKeys.projects(),
     enabled,
-    queryFn: async (): Promise<UiProject[]> => {
-      const projectsResponse = await tasksService.listProjects()
-      const baseProjects = projectsResponse.projects.map(dbProjectToUiProject)
-
-      return Promise.all(
-        baseProjects.map(async (project) => {
-          try {
-            const statuses = await tasksService.listStatuses(project.id)
-            return {
-              ...project,
-              statuses: statuses.map(dbStatusToUiStatus)
-            }
-          } catch (error) {
-            log.warn(`Failed to load statuses for project ${project.id}:`, error)
-            return project
-          }
-        })
-      )
-    }
+    queryFn: loadProjects
   })
 
   const tasksQuery = useQuery({
@@ -263,6 +265,23 @@ export function useTaskWorkspaceData({ enabled = true }: { enabled?: boolean }) 
     error: tasksQuery.error ?? projectsQuery.error ?? null,
     refetch: (): void => {
       void tasksQuery.refetch()
+      void projectsQuery.refetch()
+    }
+  }
+}
+
+export function useTaskProjects({ enabled = true }: { enabled?: boolean } = {}) {
+  const projectsQuery = useQuery({
+    queryKey: taskKeys.projects(),
+    enabled,
+    queryFn: loadProjects
+  })
+
+  return {
+    projects: projectsQuery.data ?? [],
+    isLoading: projectsQuery.isLoading,
+    error: projectsQuery.error ?? null,
+    refetch: (): void => {
       void projectsQuery.refetch()
     }
   }

--- a/apps/desktop/src/renderer/src/pages/settings/tasks-section.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/tasks-section.test.tsx
@@ -3,10 +3,8 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { TasksSettings } from './tasks-section'
-import { TasksProvider } from '@/contexts/tasks'
 import { renderWithProviders as renderWithQueryProviders } from '@tests/utils/render'
 import type { Project, Status } from '@/data/tasks-data'
-import type { Task } from '@/data/sample-tasks'
 
 beforeAll(() => {
   Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false)
@@ -60,11 +58,7 @@ const DEFAULTS = {
 }
 
 function renderWithProviders(ui: React.ReactElement) {
-  return renderWithQueryProviders(
-    <TasksProvider initialTasks={[] as Task[]} initialProjects={MOCK_PROJECTS}>
-      {ui}
-    </TasksProvider>
-  )
+  return renderWithQueryProviders(ui)
 }
 
 describe('TasksSettings', () => {
@@ -73,6 +67,40 @@ describe('TasksSettings', () => {
     settingsMock.getTaskSettings = vi.fn().mockResolvedValue({ ...DEFAULTS })
     settingsMock.setTaskSettings = vi.fn().mockResolvedValue({ success: true })
     ;(window.api.onSettingsChanged as ReturnType<typeof vi.fn>).mockReturnValue(() => {})
+    ;(window.api.tasks.listProjects as ReturnType<typeof vi.fn>).mockResolvedValue({
+      projects: MOCK_PROJECTS.map((project, index) => ({
+        id: project.id,
+        name: project.name,
+        description: project.description || null,
+        icon: project.icon,
+        color: project.color,
+        position: index,
+        isInbox: project.isDefault,
+        createdAt: project.createdAt.toISOString(),
+        modifiedAt: project.createdAt.toISOString(),
+        archivedAt: project.isArchived ? project.createdAt.toISOString() : null,
+        taskCount: project.taskCount,
+        completedCount: 0,
+        overdueCount: 0
+      }))
+    })
+    ;(window.api.tasks.listStatuses as ReturnType<typeof vi.fn>).mockImplementation(
+      async (projectId: string) => {
+        const project = MOCK_PROJECTS.find((entry) => entry.id === projectId)
+        return (
+          project?.statuses.map((status, index) => ({
+            id: status.id,
+            projectId,
+            name: status.name,
+            color: status.color,
+            position: index,
+            isDefault: status.type === 'todo',
+            isDone: status.type === 'done',
+            createdAt: new Date('2026-01-01T00:00:00.000Z').toISOString()
+          })) ?? []
+        )
+      }
+    )
   })
 
   it('renders loading state initially', () => {

--- a/apps/desktop/src/renderer/src/pages/settings/tasks-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/tasks-section.tsx
@@ -9,7 +9,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { useTaskPreferences } from '@/hooks/use-task-preferences'
-import { useTasksContext } from '@/contexts/tasks'
+import { useTaskProjects } from '@/features/tasks/use-task-queries'
 import { toast } from 'sonner'
 import {
   SettingsHeader,
@@ -27,7 +27,7 @@ const SORT_OPTIONS = [
 
 export function TasksSettings() {
   const { settings, isLoading, updateSettings } = useTaskPreferences()
-  const { projects } = useTasksContext()
+  const { projects } = useTaskProjects()
 
   const activeProjects = projects.filter((p) => !p.isArchived)
 


### PR DESCRIPTION
## What

Consolidate renderer→main API delegation via `createWindowApiForwarder` and unify type imports through `@memry/rpc` packages.

## Why

Service files (inbox, notes, tasks) each had duplicate boilerplate for forwarding API calls through the window object. Type imports were scattered across multiple source paths instead of the canonical `@memry/rpc` packages.

## How

- Add `createWindowApiForwarder` utility that generates typed proxy objects from API shape definitions
- Replace per-service manual forwarding with single `createWindowApiForwarder` calls
- Move all RPC type exports to `@memry/rpc` packages, update ~20 import sites
- Extract task context and queries into `tasks-app-boundary.tsx` to reduce App.tsx complexity
- Shrink `preload/index.d.ts` from ~1200 lines to a thin re-export layer

## Type

- [ ] `feat` — new feature
- [x] `refactor` — restructure without behavior change
- [ ] `style` — visual/UI only
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `chore` — tooling, deps, config
- [ ] `docs` — documentation only
- [ ] `ci` — CI/CD changes

## Test plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing (describe below)

Service test files updated with `createWindowApiForwarder` stubs. Typecheck, lint, and 5511 unit tests passing.

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns