### PR TITLE
refactor(sync): align phase 7 record transport

### DIFF
--- a/apps/desktop/src/main/ipc/crypto-handlers.ts
+++ b/apps/desktop/src/main/ipc/crypto-handlers.ts
@@ -29,8 +29,12 @@ import type {
   RotateKeysResult,
   GetRotationProgressResult
 } from '@memry/contracts/ipc-sync'
-import type { PullItemResponse, SyncManifest, PushResponse } from '@memry/contracts/sync-api'
-import { PullResponseSchema } from '@memry/contracts/sync-api'
+import type {
+  RecordPullItemResponse,
+  RecordSyncManifest,
+  PushResponse
+} from '@memry/contracts/sync-api'
+import { RecordPullResponseSchema } from '@memry/contracts/sync-api'
 import {
   encrypt,
   decrypt,
@@ -331,14 +335,14 @@ async function handleRotateKeys(input: RotateKeysInput): Promise<RotateKeysResul
           const pk = sodium.crypto_sign_ed25519_sk_to_pk(sk)
           return { secretKey: sk, publicKey: pk, deviceId: device.id }
         },
-        fetchManifest: (token) => getFromServer<SyncManifest>('/sync/manifest', token),
+        fetchManifest: (token) => getFromServer<RecordSyncManifest>('/sync/manifest', token),
         pullItems: async (token, itemIds) => {
-          const raw = await postToServer<{ items: PullItemResponse[] }>(
+          const raw = await postToServer<{ items: RecordPullItemResponse[] }>(
             '/sync/pull',
             { itemIds },
             token
           )
-          const parsed = PullResponseSchema.safeParse(raw)
+          const parsed = RecordPullResponseSchema.safeParse(raw)
           if (!parsed.success) {
             throw new Error(`Invalid pull response: ${parsed.error.message}`)
           }

--- a/apps/desktop/src/main/projections/projectors/note-derived-state-projector.test.ts
+++ b/apps/desktop/src/main/projections/projectors/note-derived-state-projector.test.ts
@@ -3,7 +3,7 @@ import os from 'os'
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { eq } from 'drizzle-orm'
-import { noteCache } from '@memry/db-schema/schema/notes-cache'
+import { noteCache, noteLinks } from '@memry/db-schema/schema/notes-cache'
 import { createTestIndexDb, sql, type TestDatabaseResult } from '@tests/utils/test-db'
 
 const getIndexDatabase = vi.hoisted(() => vi.fn())
@@ -91,5 +91,47 @@ describe('note derived state projector', () => {
       .get()
 
     expect(cached).toEqual(expect.objectContaining({ id: 'present-note', path: relativePath }))
+  })
+
+  it('project clears stale outbound links when a note no longer contains wiki links', async () => {
+    seedCachedNote('source-note', 'notes/source.md')
+    indexDb.db.run(sql`
+      INSERT INTO note_links (source_id, target_id, target_title)
+      VALUES (${'source-note'}, ${'target-note'}, ${'Old Link'})
+    `)
+
+    const projector = createNoteDerivedStateProjector(() => vaultDir)
+
+    await projector.project({
+      type: 'note.upserted',
+      note: {
+        kind: 'markdown',
+        noteId: 'source-note',
+        path: 'notes/source.md',
+        title: 'Source',
+        fileType: 'markdown',
+        localOnly: false,
+        contentHash: 'updated-hash',
+        wordCount: 4,
+        characterCount: 21,
+        snippet: 'plain text',
+        date: null,
+        emoji: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        modifiedAt: '2026-01-02T00:00:00.000Z',
+        parsedContent: 'Plain text with no links',
+        tags: [],
+        properties: {},
+        wikiLinks: []
+      }
+    })
+
+    const links = indexDb.db
+      .select()
+      .from(noteLinks)
+      .where(eq(noteLinks.sourceId, 'source-note'))
+      .all()
+
+    expect(links).toEqual([])
   })
 })

--- a/apps/desktop/src/main/sync/engine/corrupt-item-tracker.ts
+++ b/apps/desktop/src/main/sync/engine/corrupt-item-tracker.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../lib/logger'
-import type { PullItemResponse } from '@memry/contracts/sync-api'
-import { PullResponseSchema } from '@memry/contracts/sync-api'
+import type { RecordPullItemResponse } from '@memry/contracts/sync-api'
+import { RecordPullResponseSchema } from '@memry/contracts/sync-api'
 import { decryptPullBatch } from '../sync-crypto-batch'
 import { withRetry } from '../retry'
 import { postToServer } from '../http-client'
@@ -79,14 +79,18 @@ export class CorruptItemTracker {
     try {
       const pullResult = await withRetry(
         () =>
-          postToServer<{ items: PullItemResponse[] }>('/sync/pull', { itemIds: eligible }, token),
+          postToServer<{ items: RecordPullItemResponse[] }>(
+            '/sync/pull',
+            { itemIds: eligible },
+            token
+          ),
         {
           signal: this.ctx.abortController?.signal ?? undefined,
           isOnline: () => this.ctx.deps.network.online
         }
       )
 
-      const parsed = PullResponseSchema.safeParse(pullResult.value)
+      const parsed = RecordPullResponseSchema.safeParse(pullResult.value)
       if (!parsed.success) {
         log.error('Re-fetch: invalid response', { error: parsed.error.message })
         for (const id of eligible) this.markFailed(id)

--- a/apps/desktop/src/main/sync/engine/pull-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/pull-coordinator.ts
@@ -6,8 +6,12 @@ import type {
   ItemRecoveredEvent,
   ItemCorruptEvent
 } from '@memry/contracts/ipc-events'
-import type { ChangesResponse, PullItemResponse, SyncItemType } from '@memry/contracts/sync-api'
-import { PullResponseSchema } from '@memry/contracts/sync-api'
+import type {
+  RecordChangesResponse,
+  RecordPullItemResponse,
+  SyncItemType
+} from '@memry/contracts/sync-api'
+import { RecordPullResponseSchema } from '@memry/contracts/sync-api'
 import { secureCleanup } from '../../crypto/index'
 import { decryptPullBatch } from '../sync-crypto-batch'
 import { getRemoteSyncAdapter } from '../item-handlers'
@@ -197,11 +201,11 @@ export class PullCoordinator {
   private async fetchChangesPage(
     token: string,
     pageCursor: string | null | undefined
-  ): ReturnType<typeof withRetry<ChangesResponse>> {
+  ): ReturnType<typeof withRetry<RecordChangesResponse>> {
     return withRetry(
       () => {
         const cp = pageCursor ? `&cursor=${pageCursor}` : ''
-        return getFromServer<ChangesResponse>(
+        return getFromServer<RecordChangesResponse>(
           `/sync/changes?limit=${this.ctx.options.pullPageLimit}${cp}`,
           token
         )
@@ -214,7 +218,7 @@ export class PullCoordinator {
   }
 
   private async pullChangesPage(
-    changes: ChangesResponse,
+    changes: RecordChangesResponse,
     runState: PullRunState
   ): Promise<boolean> {
     const itemIds = Array.from(
@@ -246,7 +250,7 @@ export class PullCoordinator {
     runState.crdtNoteIds.length = 0
   }
 
-  private emitInitialSyncProgress(changes: ChangesResponse, pulledCount: number): void {
+  private emitInitialSyncProgress(changes: RecordChangesResponse, pulledCount: number): void {
     if (!this.ctx.fullSyncActive) return
 
     const estimatedTotal = changes.hasMore
@@ -326,11 +330,11 @@ export class PullCoordinator {
     crdtNoteIds: string[]
   ): Promise<{ applied: number; conflicts: number; allCryptoFailed: boolean }> {
     const pullResult = await withRetry(
-      () => postToServer<{ items: PullItemResponse[] }>('/sync/pull', { itemIds }, token),
+      () => postToServer<{ items: RecordPullItemResponse[] }>('/sync/pull', { itemIds }, token),
       { signal: this.ctx.abortController!.signal, isOnline: () => this.ctx.deps.network.online }
     )
 
-    const parsed = PullResponseSchema.safeParse(pullResult.value)
+    const parsed = RecordPullResponseSchema.safeParse(pullResult.value)
     if (!parsed.success) {
       log.error('Invalid pull response from server', { error: parsed.error.message })
       return { applied: 0, conflicts: 0, allCryptoFailed: false }

--- a/apps/desktop/src/main/sync/manifest-check.ts
+++ b/apps/desktop/src/main/sync/manifest-check.ts
@@ -7,7 +7,7 @@ import { inboxItems } from '@memry/db-schema/schema/inbox'
 import { savedFilters, settings } from '@memry/db-schema/schema/settings'
 import { tagDefinitions } from '@memry/db-schema/schema/tag-definitions'
 import { noteCache } from '@memry/db-schema/schema/notes-cache'
-import type { SyncItemType, SyncManifest } from '@memry/contracts/sync-api'
+import type { RecordSyncItemType, RecordSyncManifest } from '@memry/contracts/sync-api'
 import { withRetry } from './retry'
 import { getFromServer } from './http-client'
 import type { SyncQueueManager } from './queue'
@@ -50,9 +50,12 @@ export async function checkManifestIntegrity(
   if (!token) return { checkedAt: now, rePullNeeded: false, serverOnlyCount: 0 }
 
   try {
-    const result = await withRetry(() => getFromServer<SyncManifest>('/sync/manifest', token), {
-      isOnline: deps.isOnline
-    })
+    const result = await withRetry(
+      () => getFromServer<RecordSyncManifest>('/sync/manifest', token),
+      {
+        isOnline: deps.isOnline
+      }
+    )
 
     const serverItemMap = new Map(result.value.items.map((item) => [item.id, item]))
 
@@ -105,7 +108,7 @@ export async function checkManifestIntegrity(
 
 interface LocalSyncableItem {
   id: string
-  type: SyncItemType
+  type: RecordSyncItemType
   payload: string
 }
 

--- a/apps/sync-server/src/foundation-contracts.test.ts
+++ b/apps/sync-server/src/foundation-contracts.test.ts
@@ -42,7 +42,15 @@ import {
   InitiateLinkingRequestSchema,
   LINKING_SESSION_STATUSES
 } from '@memry/contracts/linking-api'
-import { PushRequestSchema, SYNC_ITEM_TYPES, VectorClockSchema } from '@memry/contracts/sync-api'
+import {
+  PushRequestSchema,
+  RecordChangesResponseSchema,
+  RecordPullResponseSchema,
+  RecordPushRequestSchema,
+  RecordSyncManifestSchema,
+  SYNC_ITEM_TYPES,
+  VectorClockSchema
+} from '@memry/contracts/sync-api'
 
 describe('sync-server contracts', () => {
   it('validates API contract schemas', () => {
@@ -105,6 +113,113 @@ describe('sync-server contracts', () => {
             dataNonce: 'dn',
             signature: 'sig',
             signerDeviceId: 'device-1'
+          }
+        ]
+      }).success
+    ).toBe(true)
+
+    expect(
+      RecordPushRequestSchema.safeParse({
+        items: [
+          {
+            id: 'ab99c922-6f3b-4bbf-a589-2d4f96f8ec95',
+            type: 'task',
+            operation: 'create',
+            encryptedKey: 'ek',
+            keyNonce: 'kn',
+            encryptedData: 'ed',
+            dataNonce: 'dn',
+            signature: 'sig',
+            signerDeviceId: 'device-1',
+            clock: { deviceA: 1 }
+          }
+        ]
+      }).success
+    ).toBe(true)
+
+    expect(
+      RecordPushRequestSchema.safeParse({
+        items: [
+          {
+            id: 'ab99c922-6f3b-4bbf-a589-2d4f96f8ec95',
+            type: 'attachment',
+            operation: 'create',
+            encryptedKey: 'ek',
+            keyNonce: 'kn',
+            encryptedData: 'ed',
+            dataNonce: 'dn',
+            signature: 'sig',
+            signerDeviceId: 'device-1'
+          }
+        ]
+      }).success
+    ).toBe(false)
+
+    expect(
+      RecordPushRequestSchema.safeParse({
+        items: [
+          {
+            id: 'ab99c922-6f3b-4bbf-a589-2d4f96f8ec95',
+            type: 'task',
+            operation: 'create',
+            encryptedKey: 'ek',
+            keyNonce: 'kn',
+            encryptedData: 'ed',
+            dataNonce: 'dn',
+            signature: 'sig',
+            signerDeviceId: 'device-1'
+          }
+        ]
+      }).success
+    ).toBe(false)
+
+    expect(
+      RecordSyncManifestSchema.safeParse({
+        items: [
+          {
+            id: 'ab99c922-6f3b-4bbf-a589-2d4f96f8ec95',
+            type: 'task',
+            version: 1,
+            modifiedAt: 2,
+            size: 3
+          }
+        ],
+        serverTime: 4
+      }).success
+    ).toBe(true)
+
+    expect(
+      RecordChangesResponseSchema.safeParse({
+        items: [
+          {
+            id: 'ab99c922-6f3b-4bbf-a589-2d4f96f8ec95',
+            type: 'attachment',
+            version: 1,
+            modifiedAt: 2,
+            size: 3
+          }
+        ],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 0
+      }).success
+    ).toBe(false)
+
+    expect(
+      RecordPullResponseSchema.safeParse({
+        items: [
+          {
+            id: 'ab99c922-6f3b-4bbf-a589-2d4f96f8ec95',
+            type: 'task',
+            operation: 'create',
+            signature: 'sig',
+            signerDeviceId: 'device-1',
+            blob: {
+              encryptedKey: 'ek',
+              keyNonce: 'kn',
+              encryptedData: 'ed',
+              dataNonce: 'dn'
+            }
           }
         ]
       }).success

--- a/apps/sync-server/src/routes/sync.test.ts
+++ b/apps/sync-server/src/routes/sync.test.ts
@@ -153,6 +153,7 @@ const makePushItem = (overrides: Record<string, unknown> = {}) => ({
   dataNonce: 'dn',
   signature: 'sig',
   signerDeviceId: 'device-1',
+  clock: { 'device-1': 1 },
   ...overrides
 })
 
@@ -577,6 +578,60 @@ describe('sync routes', () => {
         'device-1',
         [makePushItem()]
       )
+    })
+
+    it('should return 400 for unsupported record transport item types', async () => {
+      const body = {
+        items: [makePushItem({ type: 'attachment', clock: undefined })]
+      }
+
+      const res = await app.request(
+        'http://localhost/sync/push',
+        jsonPost('/sync/push', body),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(400)
+      const json = (await res.json()) as { error: { code: string } }
+      expect(json.error.code).toBe(ErrorCodes.VALIDATION_ERROR)
+      expect(processRecordPushBatch).not.toHaveBeenCalled()
+    })
+
+    it('should return 400 when a clock-required record item omits clock metadata', async () => {
+      const body = {
+        items: [makePushItem({ type: 'task', clock: undefined })]
+      }
+
+      const res = await app.request(
+        'http://localhost/sync/push',
+        jsonPost('/sync/push', body),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(400)
+      const json = (await res.json()) as { error: { code: string } }
+      expect(json.error.code).toBe(ErrorCodes.VALIDATION_ERROR)
+      expect(processRecordPushBatch).not.toHaveBeenCalled()
+    })
+
+    it('should allow settings pushes without top-level clock metadata', async () => {
+      const body = {
+        items: [makePushItem({ type: 'settings', clock: undefined })]
+      }
+
+      const res = await app.request(
+        'http://localhost/sync/push',
+        jsonPost('/sync/push', body),
+        env,
+        executionCtx
+      )
+
+      expect(res.status).toBe(200)
+      expect(processRecordPushBatch).toHaveBeenCalledWith(env.DB, env.STORAGE, 'user-1', 'device-1', [
+        makePushItem({ type: 'settings', clock: undefined })
+      ])
     })
   })
 

--- a/apps/sync-server/src/routes/sync.ts
+++ b/apps/sync-server/src/routes/sync.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono'
 import { Hono } from 'hono'
 import { z } from 'zod'
 
-import { PullRequestSchema, PushRequestSchema } from '@memry/contracts/sync-api'
+import { PullRequestSchema, RecordPushRequestSchema } from '@memry/contracts/sync-api'
 import { safeBase64Decode } from '../lib/encoding'
 import { AppError, ErrorCodes } from '../lib/errors'
 import { authMiddleware } from '../middleware/auth'
@@ -227,7 +227,7 @@ const handleRecordPush = async (c: Context<AppContext>): Promise<Response> => {
   const startedAt = Date.now()
 
   const body: unknown = await c.req.json()
-  const parsed = parseTransportRequest(PushRequestSchema, body, {
+  const parsed = parseTransportRequest(RecordPushRequestSchema, body, {
     transport: 'record',
     endpoint,
     label: 'push request'

--- a/apps/sync-server/src/services/sync-telemetry.test.ts
+++ b/apps/sync-server/src/services/sync-telemetry.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { logCrdtTraffic, logRecordPushBatch, logRecordQueryBatch } from './sync-telemetry'
+
+describe('sync telemetry', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('logs record push metrics with transport-separated domain type counts', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    logRecordPushBatch({
+      endpoint: '/sync/records/push',
+      latencyMs: 80,
+      outcomes: [
+        { id: 'note-1', type: 'note', accepted: true, serverCursor: 10 },
+        { id: 'task-1', type: 'task', accepted: false, reason: 'SYNC_REPLAY_DETECTED' }
+      ]
+    })
+
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+    const payload = JSON.parse(String(infoSpy.mock.calls[0][0])) as Record<string, unknown>
+    expect(payload.transport).toBe('record')
+    expect(payload.domainTypes).toEqual({
+      note: {
+        accepted: 1,
+        rejected: 0,
+        replayRejected: 0,
+        conflictRejected: 0,
+        quotaRejected: 0,
+        otherRejected: 0
+      },
+      task: {
+        accepted: 0,
+        rejected: 1,
+        replayRejected: 1,
+        conflictRejected: 0,
+        quotaRejected: 0,
+        otherRejected: 0
+      }
+    })
+  })
+
+  it('logs record query metrics with exact record domain types', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    logRecordQueryBatch({
+      endpoint: '/sync/records/changes',
+      operation: 'changes',
+      latencyMs: 35,
+      itemTypes: ['task', 'task', 'journal'],
+      deletedCount: 1
+    })
+
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+    const payload = JSON.parse(String(infoSpy.mock.calls[0][0])) as Record<string, unknown>
+    expect(payload.transport).toBe('record')
+    expect(payload.domainTypes).toEqual({
+      task: 2,
+      journal: 1
+    })
+  })
+
+  it('logs CRDT traffic with explicit CRDT domain type metadata', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    logCrdtTraffic({
+      endpoint: '/sync/crdt/updates',
+      event: 'updates_stored',
+      noteId: 'note-1',
+      updateCount: 3,
+      totalBytes: 128,
+      latencyMs: 20
+    })
+
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+    const payload = JSON.parse(String(infoSpy.mock.calls[0][0])) as Record<string, unknown>
+    expect(payload.transport).toBe('crdt')
+    expect(payload.domainType).toBe('note')
+  })
+})

--- a/apps/sync-server/src/services/sync-telemetry.ts
+++ b/apps/sync-server/src/services/sync-telemetry.ts
@@ -65,6 +65,16 @@ const summarizeItemTypes = (itemTypes: SyncItemType[]): Partial<Record<SyncDomai
   return summary
 }
 
+const summarizeDomainTypes = (
+  itemTypes: SyncItemType[]
+): Partial<Record<SyncItemType, number>> => {
+  const summary: Partial<Record<SyncItemType, number>> = {}
+  for (const itemType of itemTypes) {
+    summary[itemType] = (summary[itemType] ?? 0) + 1
+  }
+  return summary
+}
+
 export const logSyncValidationFailure = (params: {
   transport: SyncTransport
   endpoint: string
@@ -91,6 +101,19 @@ export const logRecordPushBatch = (params: {
       }
     >
   > = {}
+  const domainTypes: Partial<
+    Record<
+      SyncItemType,
+      {
+        accepted: number
+        rejected: number
+        replayRejected: number
+        conflictRejected: number
+        quotaRejected: number
+        otherRejected: number
+      }
+    >
+  > = {}
 
   let accepted = 0
   let rejected = 0
@@ -105,29 +128,44 @@ export const logRecordPushBatch = (params: {
       quotaRejected: 0,
       otherRejected: 0
     }
+    const itemTypeEntry = domainTypes[outcome.type] ?? {
+      accepted: 0,
+      rejected: 0,
+      replayRejected: 0,
+      conflictRejected: 0,
+      quotaRejected: 0,
+      otherRejected: 0
+    }
 
     if (outcome.accepted) {
       entry.accepted += 1
+      itemTypeEntry.accepted += 1
       accepted += 1
     } else {
       entry.rejected += 1
+      itemTypeEntry.rejected += 1
       rejected += 1
       switch (outcome.reason) {
         case 'SYNC_REPLAY_DETECTED':
           entry.replayRejected += 1
+          itemTypeEntry.replayRejected += 1
           break
         case 'SYNC_VERSION_CONFLICT':
           entry.conflictRejected += 1
+          itemTypeEntry.conflictRejected += 1
           break
         case 'STORAGE_QUOTA_EXCEEDED':
           entry.quotaRejected += 1
+          itemTypeEntry.quotaRejected += 1
           break
         default:
           entry.otherRejected += 1
+          itemTypeEntry.otherRejected += 1
       }
     }
 
     domains[domain] = entry
+    domainTypes[outcome.type] = itemTypeEntry
   }
 
   logger.info('Record sync push processed', {
@@ -138,6 +176,7 @@ export const logRecordPushBatch = (params: {
     rejected,
     totalMutations: params.outcomes.length,
     domains,
+    domainTypes,
     latencyMs: params.latencyMs,
     latencyBucket: toLatencyBucket(params.latencyMs)
   })
@@ -157,6 +196,7 @@ export const logRecordQueryBatch = (params: {
     itemCount: params.itemTypes.length,
     deletedCount: params.deletedCount ?? 0,
     domains: summarizeItemTypes(params.itemTypes),
+    domainTypes: summarizeDomainTypes(params.itemTypes),
     latencyMs: params.latencyMs,
     latencyBucket: toLatencyBucket(params.latencyMs)
   })
@@ -183,6 +223,7 @@ export const logCrdtTraffic = (params: {
   logger.info('CRDT sync activity', {
     transport: 'crdt',
     domain: 'notes',
+    domainType: 'note',
     ...params,
     latencyBucket: toLatencyBucket(params.latencyMs)
   })

--- a/apps/sync-server/src/services/sync.test.ts
+++ b/apps/sync-server/src/services/sync.test.ts
@@ -534,6 +534,41 @@ describe('getManifest', () => {
     expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('deleted_at IS NULL'))
     expect(result.items).toEqual([])
   })
+
+  it('should keep manifest responses record-only and strip record stateVector metadata', async () => {
+    // #given
+    const stmt = createMockStatement()
+    stmt.all.mockResolvedValue({
+      results: [
+        {
+          item_id: 'item-note',
+          item_type: 'note',
+          version: 1,
+          updated_at: 1000,
+          size_bytes: 512,
+          state_vector: 'legacy-note-state'
+        },
+        {
+          item_id: 'item-attachment',
+          item_type: 'attachment',
+          version: 1,
+          updated_at: 1001,
+          size_bytes: 128,
+          state_vector: 'attachment-state'
+        }
+      ]
+    })
+    db.prepare.mockReturnValue(stmt)
+
+    // #when
+    const result = await getManifest(db as unknown as D1Database, 'user-1')
+
+    // #then
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('item_type IN'))
+    expect(result.items).toEqual([
+      { id: 'item-note', type: 'note', version: 1, modifiedAt: 1000, size: 512 }
+    ])
+  })
 })
 
 // ============================================================================
@@ -625,6 +660,48 @@ describe('getChanges', () => {
     expect(result.hasMore).toBe(false)
     expect(result.nextCursor).toBe(9999)
   })
+
+  it('should keep change feeds record-only and omit record stateVector metadata', async () => {
+    // #given
+    const stmt = createMockStatement()
+    stmt.all.mockResolvedValue({
+      results: [
+        {
+          item_id: 'item-note',
+          item_type: 'note',
+          version: 1,
+          updated_at: 1000,
+          size_bytes: 256,
+          state_vector: 'legacy-note-state',
+          server_cursor: 5,
+          deleted_at: null
+        },
+        {
+          item_id: 'item-attachment',
+          item_type: 'attachment',
+          version: 2,
+          updated_at: 2000,
+          size_bytes: 128,
+          state_vector: 'attachment-state',
+          server_cursor: 6,
+          deleted_at: 3000
+        }
+      ]
+    })
+    db.prepare.mockReturnValue(stmt)
+
+    // #when
+    const result = await getChanges(db as unknown as D1Database, 'user-1', 0)
+
+    // #then
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('item_type IN'))
+    expect(result).toEqual({
+      items: [{ id: 'item-note', type: 'note', version: 1, modifiedAt: 1000, size: 256 }],
+      deleted: [],
+      hasMore: false,
+      nextCursor: 6
+    })
+  })
 })
 
 // ============================================================================
@@ -682,7 +759,6 @@ describe('pullItems', () => {
         signerDeviceId: 'device-1',
         deletedAt: 1700000000,
         clock: { 'device-1': 2 },
-        stateVector: 'sv-1',
         blob: { encryptedKey: 'ek', keyNonce: 'kn', encryptedData: 'ed', dataNonce: 'dn' }
       }
     ])
@@ -726,6 +802,73 @@ describe('pullItems', () => {
     // #then — operation must be 'create', not hardcoded 'update'
     expect(result[0].operation).toBe('create')
     expect(result[0].id).toBe('item-2')
+  })
+
+  it('should keep pull responses record-only and omit stateVector metadata', async () => {
+    const stmt = createMockStatement()
+    stmt.all.mockResolvedValue({
+      results: [
+        {
+          item_id: 'item-note',
+          item_type: 'note',
+          blob_key: 'user-1/items/item-note',
+          crypto_version: 1,
+          operation: 'update',
+          signer_device_id: 'device-1',
+          signature: 'sig-note',
+          state_vector: 'legacy-note-state',
+          clock: '{"device-1":3}',
+          deleted_at: null,
+          server_cursor: 10
+        },
+        {
+          item_id: 'item-attachment',
+          item_type: 'attachment',
+          blob_key: 'user-1/items/item-attachment',
+          crypto_version: 1,
+          operation: 'update',
+          signer_device_id: 'device-1',
+          signature: 'sig-attachment',
+          state_vector: 'attachment-state',
+          clock: null,
+          deleted_at: null,
+          server_cursor: 11
+        }
+      ]
+    })
+    db.prepare.mockReturnValue(stmt)
+    vi.mocked(getBlob).mockResolvedValue({
+      body: JSON.stringify({
+        encryptedKey: 'ek-note',
+        keyNonce: 'kn-note',
+        encryptedData: 'ed-note',
+        dataNonce: 'dn-note'
+      })
+    } as unknown as R2ObjectBody)
+
+    const result = await pullItems(db as unknown as D1Database, {} as R2Bucket, 'user-1', [
+      'item-note',
+      'item-attachment'
+    ])
+
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('item_type IN'))
+    expect(result).toEqual([
+      {
+        id: 'item-note',
+        type: 'note',
+        operation: 'update',
+        cryptoVersion: 1,
+        signature: 'sig-note',
+        signerDeviceId: 'device-1',
+        clock: { 'device-1': 3 },
+        blob: {
+          encryptedKey: 'ek-note',
+          keyNonce: 'kn-note',
+          encryptedData: 'ed-note',
+          dataNonce: 'dn-note'
+        }
+      }
+    ])
   })
 })
 
@@ -924,5 +1067,53 @@ describe('processPushItem', () => {
     expect(db.batch).toHaveBeenCalledWith([upsertStmt, updateStmt])
     expect(upsertStmt.run).not.toHaveBeenCalled()
     expect(updateStmt.run).not.toHaveBeenCalled()
+  })
+
+  it('should accept settings updates without top-level clock even if legacy rows have a stored clock', async () => {
+    mockedGetUserById.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@test.com',
+      email_verified: 1,
+      auth_method: 'email',
+      auth_provider: null,
+      auth_provider_id: null,
+      kdf_salt: null,
+      key_verifier: null,
+      storage_used: 0,
+      storage_limit: 1000,
+      created_at: 1000,
+      updated_at: 1000
+    })
+
+    const selectStmt = createMockStatement()
+    selectStmt.first.mockResolvedValue({
+      version: 1,
+      clock: '{"device-old":2}',
+      created_at: 1000,
+      size_bytes: 10
+    })
+
+    const upsertStmt = createMockStatement()
+    const updateStmt = createMockStatement()
+    const db = createMockDb()
+    db.prepare
+      .mockReturnValueOnce(selectStmt)
+      .mockReturnValueOnce(upsertStmt)
+      .mockReturnValueOnce(updateStmt)
+
+    const storage = {
+      put: vi.fn().mockResolvedValue({ etag: 'etag-1' })
+    } as unknown as R2Bucket
+
+    const result = await processPushItem(
+      db as unknown as D1Database,
+      storage,
+      'user-1',
+      'device-1',
+      createValidPushItem({ type: 'settings', clock: undefined })
+    )
+
+    expect(result.accepted).toBe(true)
+    expect(result.reason).toBeUndefined()
   })
 })

--- a/apps/sync-server/src/services/sync.ts
+++ b/apps/sync-server/src/services/sync.ts
@@ -1,14 +1,18 @@
 import { CRYPTO_VERSION, ED25519_PARAMS, XCHACHA20_PARAMS } from '@memry/contracts/crypto'
 import type {
-  ChangesResponse,
   EncryptedItemPayload,
-  PullItemResponse,
   PushItemInput,
   PushResponse,
-  SyncItemRef,
-  SyncManifest,
   SyncStatus,
-  VectorClock
+  VectorClock,
+  RecordChangesResponse,
+  RecordPullItemResponse,
+  RecordSyncItemType,
+  RecordSyncManifest
+} from '@memry/contracts/sync-api'
+import {
+  RECORD_CLOCK_REQUIRED_ITEM_TYPES,
+  RECORD_SYNC_ITEM_TYPES
 } from '@memry/contracts/sync-api'
 import { encodeSignaturePayload } from '../lib/cbor'
 import { safeBase64Decode, verifyEd25519 } from '../lib/encoding'
@@ -22,6 +26,9 @@ import { getUserById } from './user'
 const MAX_ENCRYPTED_DATA_BYTES = 5 * 1024 * 1024
 const DEFAULT_CHANGES_LIMIT = 100
 const MAX_CHANGES_LIMIT = 500
+const RECORD_SYNC_ITEM_TYPE_SET = new Set<RecordSyncItemType>(RECORD_SYNC_ITEM_TYPES)
+const RECORD_CLOCK_REQUIRED_TYPE_SET = new Set<RecordSyncItemType>(RECORD_CLOCK_REQUIRED_ITEM_TYPES)
+const RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS = RECORD_SYNC_ITEM_TYPES.map(() => '?').join(', ')
 
 interface ExistingSyncItemRow {
   version: number
@@ -161,6 +168,26 @@ export const detectReplay = (incoming?: VectorClock, existing?: VectorClock): bo
   return true
 }
 
+const isSupportedRecordSyncItemType = (type: string): type is RecordSyncItemType =>
+  RECORD_SYNC_ITEM_TYPE_SET.has(type as RecordSyncItemType)
+
+const requiresRecordClock = (type: RecordSyncItemType): boolean =>
+  RECORD_CLOCK_REQUIRED_TYPE_SET.has(type)
+
+export const shouldRejectRecordReplay = (
+  itemType: PushItemInput['type'],
+  incoming?: VectorClock,
+  existing?: VectorClock
+): boolean => {
+  if (!isSupportedRecordSyncItemType(itemType)) {
+    return false
+  }
+  if (!requiresRecordClock(itemType)) {
+    return false
+  }
+  return detectReplay(incoming, existing)
+}
+
 export const computeContentHash = async (payload: {
   dataNonce: string
   encryptedData: string
@@ -226,7 +253,11 @@ const toPullItemResponse = async (
   storage: R2Bucket,
   userId: string,
   row: StoredSyncItemPullRow
-): Promise<PullItemResponse> => {
+): Promise<RecordPullItemResponse | null> => {
+  if (!isSupportedRecordSyncItemType(row.item_type)) {
+    return null
+  }
+
   const payload = await readEncryptedPayload(storage, row.blob_key, userId, row.item_id)
 
   if (!row.signer_device_id || !row.signature) {
@@ -241,14 +272,13 @@ const toPullItemResponse = async (
 
   return {
     id: row.item_id,
-    type: row.item_type as PullItemResponse['type'],
-    operation: row.operation as PullItemResponse['operation'],
+    type: row.item_type,
+    operation: row.operation as RecordPullItemResponse['operation'],
     cryptoVersion: row.crypto_version,
     signature: row.signature,
     signerDeviceId: row.signer_device_id,
     ...(row.deleted_at ? { deletedAt: row.deleted_at } : {}),
     ...(parsedClock ? { clock: parsedClock } : {}),
-    ...(row.state_vector ? { stateVector: row.state_vector } : {}),
     blob: payload
   }
 }
@@ -305,6 +335,16 @@ export const processPushItem = async (
   item: PushItemInput
 ): Promise<{ accepted: boolean; reason?: string; serverCursor?: number }> => {
   try {
+    if (!isSupportedRecordSyncItemType(item.type)) {
+      return { accepted: false, reason: ErrorCodes.VALIDATION_ERROR }
+    }
+    if (requiresRecordClock(item.type) && item.clock === undefined) {
+      return { accepted: false, reason: ErrorCodes.VALIDATION_ERROR }
+    }
+    if (item.stateVector !== undefined) {
+      return { accepted: false, reason: ErrorCodes.VALIDATION_ERROR }
+    }
+
     validateEncryptedFields(item)
     await verifyItemSignature(db, item, userId)
 
@@ -318,7 +358,7 @@ export const processPushItem = async (
         typeof existing.clock === 'string'
           ? (JSON.parse(existing.clock) as VectorClock)
           : (existing.clock ?? undefined)
-      if (detectReplay(item.clock, existingClock)) {
+      if (shouldRejectRecordReplay(item.type, item.clock, existingClock)) {
         return { accepted: false, reason: 'SYNC_REPLAY_DETECTED' }
       }
     }
@@ -464,15 +504,15 @@ export const getSyncStatus = async (
   }
 }
 
-export const getManifest = async (db: D1Database, userId: string): Promise<SyncManifest> => {
+export const getManifest = async (db: D1Database, userId: string): Promise<RecordSyncManifest> => {
   const rows = await db
     .prepare(
       `SELECT item_id, item_type, version, updated_at, size_bytes, state_vector
        FROM sync_items
-       WHERE user_id = ? AND deleted_at IS NULL
+       WHERE user_id = ? AND deleted_at IS NULL AND item_type IN (${RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS})
        ORDER BY server_cursor ASC`
     )
-    .bind(userId)
+    .bind(userId, ...RECORD_SYNC_ITEM_TYPES)
     .all<{
       item_id: string
       item_type: string
@@ -482,14 +522,15 @@ export const getManifest = async (db: D1Database, userId: string): Promise<SyncM
       state_vector: string | null
     }>()
 
-  const items: SyncItemRef[] = (rows.results ?? []).map((row) => ({
-    id: row.item_id,
-    type: row.item_type as SyncItemRef['type'],
-    version: row.version,
-    modifiedAt: row.updated_at,
-    size: row.size_bytes,
-    ...(row.state_vector ? { stateVector: row.state_vector } : {})
-  }))
+  const items = (rows.results ?? [])
+    .filter((row) => isSupportedRecordSyncItemType(row.item_type))
+    .map((row) => ({
+      id: row.item_id,
+      type: row.item_type as RecordSyncItemType,
+      version: row.version,
+      modifiedAt: row.updated_at,
+      size: row.size_bytes
+    }))
 
   return { items, serverTime: Math.floor(Date.now() / 1000) }
 }
@@ -499,18 +540,18 @@ export const getChanges = async (
   userId: string,
   cursor: number,
   limit?: number
-): Promise<ChangesResponse> => {
+): Promise<RecordChangesResponse> => {
   const effectiveLimit = Math.min(limit ?? DEFAULT_CHANGES_LIMIT, MAX_CHANGES_LIMIT)
 
   const rows = await db
     .prepare(
       `SELECT item_id, item_type, version, updated_at, size_bytes, state_vector, server_cursor, deleted_at
        FROM sync_items
-       WHERE user_id = ? AND server_cursor > ?
+       WHERE user_id = ? AND server_cursor > ? AND item_type IN (${RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS})
        ORDER BY server_cursor ASC
        LIMIT ?`
     )
-    .bind(userId, cursor, effectiveLimit + 1)
+    .bind(userId, cursor, ...RECORD_SYNC_ITEM_TYPES, effectiveLimit + 1)
     .all<{
       item_id: string
       item_type: string
@@ -526,20 +567,22 @@ export const getChanges = async (
   const hasMore = allRows.length > effectiveLimit
   const pageRows = hasMore ? allRows.slice(0, effectiveLimit) : allRows
 
-  const items: SyncItemRef[] = []
+  const items: RecordChangesResponse['items'] = []
   const deleted: string[] = []
 
   for (const row of pageRows) {
+    if (!isSupportedRecordSyncItemType(row.item_type)) {
+      continue
+    }
     if (row.deleted_at) {
       deleted.push(row.item_id)
     } else {
       items.push({
         id: row.item_id,
-        type: row.item_type as SyncItemRef['type'],
+        type: row.item_type,
         version: row.version,
         modifiedAt: row.updated_at,
-        size: row.size_bytes,
-        ...(row.state_vector ? { stateVector: row.state_vector } : {})
+        size: row.size_bytes
       })
     }
   }
@@ -557,12 +600,12 @@ export const pullItems = async (
   storage: R2Bucket,
   userId: string,
   itemIds: string[]
-): Promise<PullItemResponse[]> => {
+): Promise<RecordPullItemResponse[]> => {
   if (itemIds.length === 0) {
     return []
   }
 
-  const BATCH_SIZE = D1_MAX_BIND_PARAMS - 1
+  const BATCH_SIZE = D1_MAX_BIND_PARAMS - 1 - RECORD_SYNC_ITEM_TYPES.length
 
   const allDbRows: StoredSyncItemPullRow[] = []
 
@@ -574,20 +617,24 @@ export const pullItems = async (
         `SELECT item_id, item_type, blob_key, crypto_version, operation, signer_device_id, signature,
                 state_vector, clock, deleted_at, server_cursor
          FROM sync_items
-         WHERE user_id = ? AND item_id IN (${placeholders})
+         WHERE user_id = ? AND item_type IN (${RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS})
+           AND item_id IN (${placeholders})
          ORDER BY server_cursor ASC`
       )
-      .bind(userId, ...batch)
+      .bind(userId, ...RECORD_SYNC_ITEM_TYPES, ...batch)
       .all<StoredSyncItemPullRow>()
     allDbRows.push(...(rows.results ?? []))
   }
 
   allDbRows.sort((a, b) => a.server_cursor - b.server_cursor)
 
-  const results: PullItemResponse[] = []
+  const results: RecordPullItemResponse[] = []
 
   for (const row of allDbRows) {
-    results.push(await toPullItemResponse(storage, userId, row))
+    const item = await toPullItemResponse(storage, userId, row)
+    if (item) {
+      results.push(item)
+    }
   }
 
   return results
@@ -600,7 +647,7 @@ export const getItem = async (
   itemId: string
 ): Promise<{
   itemId: string
-  type: string
+  type: RecordSyncItemType
   version: number
   payload: EncryptedItemPayload
   serverCursor: number
@@ -609,9 +656,10 @@ export const getItem = async (
     .prepare(
       `SELECT item_id, item_type, version, blob_key, server_cursor
        FROM sync_items
-       WHERE user_id = ? AND item_id = ? AND deleted_at IS NULL`
+       WHERE user_id = ? AND item_type IN (${RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS})
+         AND item_id = ? AND deleted_at IS NULL`
     )
-    .bind(userId, itemId)
+    .bind(userId, ...RECORD_SYNC_ITEM_TYPES, itemId)
     .first<{
       item_id: string
       item_type: string
@@ -628,7 +676,7 @@ export const getItem = async (
 
   return {
     itemId: row.item_id,
-    type: row.item_type,
+    type: row.item_type as RecordSyncItemType,
     version: row.version,
     payload,
     serverCursor: row.server_cursor

--- a/docs/superpowers/plans/2026-04-09-architecture-reset-checklist.md
+++ b/docs/superpowers/plans/2026-04-09-architecture-reset-checklist.md
@@ -319,9 +319,9 @@ Progress note (2026-04-09):
 
 **Checklist:**
 
-- [ ] Align payload validation with the final adapter contracts
-- [ ] Align conflict semantics with the final client-side domain model
-- [ ] Ensure record-sync and CRDT metrics remain separate by transport and domain type
+- [x] Align payload validation with the final adapter contracts
+- [x] Align conflict semantics with the final client-side domain model
+- [x] Ensure record-sync and CRDT metrics remain separate by transport and domain type
 - [ ] Remove legacy route shapes only after all clients use the final split
 
 **Key files:**
@@ -333,8 +333,8 @@ Progress note (2026-04-09):
 
 **Gate:**
 
-- [ ] Record-sync and CRDT are separate in validation, metrics, and conflict handling end to end
-- [ ] Client and server contracts agree domain by domain
+- [x] Record-sync and CRDT are separate in validation, metrics, and conflict handling end to end
+- [x] Client and server contracts agree domain by domain
 
 ## Cross-Cutting Cleanup
 

--- a/packages/contracts/src/sync-api.ts
+++ b/packages/contracts/src/sync-api.ts
@@ -16,6 +16,29 @@ export const SYNC_ITEM_TYPES = [
   'tag_definition'
 ] as const
 
+export const RECORD_SYNC_ITEM_TYPES = [
+  'note',
+  'task',
+  'project',
+  'settings',
+  'inbox',
+  'filter',
+  'journal',
+  'tag_definition'
+] as const
+
+export const RECORD_CLOCK_REQUIRED_ITEM_TYPES = [
+  'note',
+  'task',
+  'project',
+  'inbox',
+  'filter',
+  'journal',
+  'tag_definition'
+] as const
+
+export const CRDT_SYNC_ITEM_TYPES = ['note'] as const
+
 export const SYNC_OPERATIONS = ['create', 'update', 'delete'] as const
 
 export const ENCRYPTABLE_ITEM_TYPES = [
@@ -35,6 +58,9 @@ export type EncryptableItemType = (typeof ENCRYPTABLE_ITEM_TYPES)[number]
 // ============================================================================
 
 export type SyncItemType = (typeof SYNC_ITEM_TYPES)[number]
+export type RecordSyncItemType = (typeof RECORD_SYNC_ITEM_TYPES)[number]
+export type RecordClockRequiredItemType = (typeof RECORD_CLOCK_REQUIRED_ITEM_TYPES)[number]
+export type CrdtSyncItemType = (typeof CRDT_SYNC_ITEM_TYPES)[number]
 export type SyncOperation = (typeof SYNC_OPERATIONS)[number]
 
 /**
@@ -202,7 +228,7 @@ export const SyncQueueItemSchema = z.object({
   createdAt: z.number().int().min(0)
 })
 
-export const PushItemSchema = z.object({
+const PushItemBaseSchema = z.object({
   id: z.string().min(1),
   type: z.enum(SYNC_ITEM_TYPES),
   operation: z.enum(SYNC_OPERATIONS),
@@ -217,8 +243,30 @@ export const PushItemSchema = z.object({
   deletedAt: z.number().int().min(0).optional()
 })
 
+const recordClockRequiredItemTypeSet = new Set<RecordSyncItemType>(RECORD_CLOCK_REQUIRED_ITEM_TYPES)
+
+export const PushItemSchema = PushItemBaseSchema
+
 export const PushRequestSchema = z.object({
   items: z.array(PushItemSchema).min(1).max(100)
+})
+
+export const RecordPushItemSchema = PushItemBaseSchema.omit({ type: true, stateVector: true })
+  .extend({
+    type: z.enum(RECORD_SYNC_ITEM_TYPES)
+  })
+  .superRefine((item, ctx) => {
+    if (recordClockRequiredItemTypeSet.has(item.type) && item.clock === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['clock'],
+        message: `Record sync item type "${item.type}" requires clock metadata`
+      })
+    }
+  })
+
+export const RecordPushRequestSchema = z.object({
+  items: z.array(RecordPushItemSchema).min(1).max(100)
 })
 
 export const PushResponseSchema = z.object({
@@ -246,13 +294,30 @@ export const SyncItemRefSchema = z.object({
   stateVector: z.string().optional()
 })
 
+export const RecordSyncItemRefSchema = SyncItemRefSchema.omit({ type: true, stateVector: true })
+  .extend({
+    type: z.enum(RECORD_SYNC_ITEM_TYPES)
+  })
+
 export const SyncManifestSchema = z.object({
   items: z.array(SyncItemRefSchema),
   serverTime: z.number().int().min(0)
 })
 
+export const RecordSyncManifestSchema = z.object({
+  items: z.array(RecordSyncItemRefSchema),
+  serverTime: z.number().int().min(0)
+})
+
 export const ChangesResponseSchema = z.object({
   items: z.array(SyncItemRefSchema),
+  deleted: z.array(z.string().min(1)),
+  hasMore: z.boolean(),
+  nextCursor: z.number().int().min(0)
+})
+
+export const RecordChangesResponseSchema = z.object({
+  items: z.array(RecordSyncItemRefSchema),
   deleted: z.array(z.string().min(1)),
   hasMore: z.boolean(),
   nextCursor: z.number().int().min(0)
@@ -299,11 +364,25 @@ export const PullItemResponseSchema = z.object({
   blob: EncryptedItemPayloadSchema
 })
 
+export const RecordPullItemResponseSchema = PullItemResponseSchema.omit({
+  type: true,
+  stateVector: true
+}).extend({
+  type: z.enum(RECORD_SYNC_ITEM_TYPES)
+})
+
 export const PullResponseSchema = z.object({
   items: z.array(PullItemResponseSchema)
 })
 
 export type PullItemResponse = z.infer<typeof PullItemResponseSchema>
+
+export const RecordPullResponseSchema = z.object({
+  items: z.array(RecordPullItemResponseSchema)
+})
+
+export type RecordPullItemResponse = z.infer<typeof RecordPullItemResponseSchema>
+export type RecordPullResponse = z.infer<typeof RecordPullResponseSchema>
 
 // ============================================================================
 // Device Keys (key distribution for multi-device signature verification)
@@ -362,10 +441,15 @@ export type EncryptedItemPayloadInput = z.infer<typeof EncryptedItemPayloadSchem
 export type SyncQueueItemInput = z.infer<typeof SyncQueueItemSchema>
 export type PushItemInput = z.infer<typeof PushItemSchema>
 export type PushRequestInput = z.infer<typeof PushRequestSchema>
+export type RecordPushItemInput = z.infer<typeof RecordPushItemSchema>
+export type RecordPushRequestInput = z.infer<typeof RecordPushRequestSchema>
 export type PushResponseInput = z.infer<typeof PushResponseSchema>
 export type SyncItemRefInput = z.infer<typeof SyncItemRefSchema>
+export type RecordSyncItemRefInput = z.infer<typeof RecordSyncItemRefSchema>
 export type SyncManifestInput = z.infer<typeof SyncManifestSchema>
+export type RecordSyncManifest = z.infer<typeof RecordSyncManifestSchema>
 export type ChangesResponseInput = z.infer<typeof ChangesResponseSchema>
+export type RecordChangesResponse = z.infer<typeof RecordChangesResponseSchema>
 export type SyncStatusInput = z.infer<typeof SyncStatusSchema>
 export type ConflictResponseInput = z.infer<typeof ConflictResponseSchema>
 export type DeviceSyncStateInput = z.infer<typeof DeviceSyncStateSchema>

--- a/packages/contracts/src/sync-phase-foundation.test.ts
+++ b/packages/contracts/src/sync-phase-foundation.test.ts
@@ -20,6 +20,10 @@ import {
 } from './linking-api'
 import {
   PushRequestSchema,
+  RecordChangesResponseSchema,
+  RecordPullResponseSchema,
+  RecordPushRequestSchema,
+  RecordSyncManifestSchema,
   SignatureMetadataSchema,
   SyncItemSchema,
   VectorClockSchema,
@@ -208,6 +212,167 @@ describe('sync phase contract schemas', () => {
         ]
       }).success
     ).toBe(true)
+
+    expect(
+      RecordPushRequestSchema.safeParse({
+        items: [
+          {
+            id: validItem.id,
+            type: 'task',
+            operation: 'create',
+            encryptedKey: 'ek',
+            keyNonce: 'kn',
+            encryptedData: 'ed',
+            dataNonce: 'dn',
+            signature: 'sig',
+            signerDeviceId: 'device-1',
+            clock: { deviceA: 1 }
+          }
+        ]
+      }).success
+    ).toBe(true)
+
+    expect(
+      RecordPushRequestSchema.safeParse({
+        items: [
+          {
+            id: validItem.id,
+            type: 'attachment',
+            operation: 'create',
+            encryptedKey: 'ek',
+            keyNonce: 'kn',
+            encryptedData: 'ed',
+            dataNonce: 'dn',
+            signature: 'sig',
+            signerDeviceId: 'device-1'
+          }
+        ]
+      }).success
+    ).toBe(false)
+
+    expect(
+      RecordPushRequestSchema.safeParse({
+        items: [
+          {
+            id: validItem.id,
+            type: 'task',
+            operation: 'create',
+            encryptedKey: 'ek',
+            keyNonce: 'kn',
+            encryptedData: 'ed',
+            dataNonce: 'dn',
+            signature: 'sig',
+            signerDeviceId: 'device-1'
+          }
+        ]
+      }).success
+    ).toBe(false)
+
+    expect(
+      RecordPushRequestSchema.safeParse({
+        items: [
+          {
+            id: validItem.id,
+            type: 'settings',
+            operation: 'update',
+            encryptedKey: 'ek',
+            keyNonce: 'kn',
+            encryptedData: 'ed',
+            dataNonce: 'dn',
+            signature: 'sig',
+            signerDeviceId: 'device-1'
+          }
+        ]
+      }).success
+    ).toBe(true)
+
+    expect(
+      RecordSyncManifestSchema.safeParse({
+        items: [
+          {
+            id: validItem.id,
+            type: 'note',
+            version: 1,
+            modifiedAt: 2,
+            size: 123
+          }
+        ],
+        serverTime: 3
+      }).success
+    ).toBe(true)
+
+    expect(
+      RecordSyncManifestSchema.safeParse({
+        items: [
+          {
+            id: validItem.id,
+            type: 'attachment',
+            version: 1,
+            modifiedAt: 2,
+            size: 123
+          }
+        ],
+        serverTime: 3
+      }).success
+    ).toBe(false)
+
+    expect(
+      RecordChangesResponseSchema.safeParse({
+        items: [
+          {
+            id: validItem.id,
+            type: 'task',
+            version: 1,
+            modifiedAt: 2,
+            size: 123
+          }
+        ],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 1
+      }).success
+    ).toBe(true)
+
+    expect(
+      RecordPullResponseSchema.safeParse({
+        items: [
+          {
+            id: validItem.id,
+            type: 'task',
+            operation: 'update',
+            cryptoVersion: 1,
+            signature: 'sig',
+            signerDeviceId: 'device-1',
+            blob: {
+              encryptedKey: 'ek',
+              keyNonce: 'kn',
+              encryptedData: 'ed',
+              dataNonce: 'dn'
+            }
+          }
+        ]
+      }).success
+    ).toBe(true)
+
+    expect(
+      RecordPullResponseSchema.safeParse({
+        items: [
+          {
+            id: validItem.id,
+            type: 'attachment',
+            operation: 'update',
+            signature: 'sig',
+            signerDeviceId: 'device-1',
+            blob: {
+              encryptedKey: 'ek',
+              keyNonce: 'kn',
+              encryptedData: 'ed',
+              dataNonce: 'dn'
+            }
+          }
+        ]
+      }).success
+    ).toBe(false)
 
     expect(
       PushRequestSchema.safeParse({


### PR DESCRIPTION
## What
Align phase 7 sync transport around record-only manifest, changes, and pull flows; update desktop consumers; and add telemetry and regression coverage for the split record vs CRDT paths.

## Why
The projection-pipeline work needs the sync server and desktop client to agree on which payloads belong to record transport versus CRDT transport. This also preserves correct note-link state when the last wiki link is removed from a note.

## How
- add record-specific sync API schemas and contract coverage
- restrict sync server manifest, changes, and pull handling to record transport payloads and required clocks
- update desktop sync consumers to use the narrowed record transport responses
- separate telemetry domain type reporting for record vs CRDT paths
- add regression coverage for clearing note links when a note no longer contains wiki links
- update the architecture reset checklist to reflect the new boundary

## Type
- [ ] `feat`
- [ ] `fix`
- [x] `refactor`
- [ ] `style`
- [ ] `perf`
- [x] `test`
- [ ] `chore`
- [ ] `docs`
- [ ] `ci`

## Test plan
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing

Commands run:
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts src/main/vault/note-sync.test.ts`
- `pnpm --filter @memry/sync-server exec vitest run src/foundation-contracts.test.ts src/routes/sync.test.ts src/services/sync.test.ts src/services/sync-telemetry.test.ts`
- pre-push `pnpm test` hook on `git push -u origin memry/align-sync-server-phase-7`

## Screenshots
N/A

## Checklist
- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [ ] Files stay under ~500 LOC
- [x] Follows immutable data patterns