### PR TITLE
fix(desktop): normalize Windows inbox filing paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-04-12 — Windows Inbox Folder Filing Fix
+
+### Fixed
+- Fix Windows inbox filing so creating a folder inline no longer leaves the item in Inbox after restart
+- Normalize vault-relative paths and folder picker matching so newly created folders resolve consistently across macOS and Windows
+
+---
+
 ## 2026-04-11 — Settings Modal Scroll Fix and Sidebar Action Reorder
 
 ### Changed

--- a/apps/desktop/src/main/inbox/attachments.test.ts
+++ b/apps/desktop/src/main/inbox/attachments.test.ts
@@ -32,9 +32,13 @@ vi.mock('../vault', () => ({
 }))
 
 // Mock paths module
-vi.mock('../lib/paths', () => ({
-  toMemryFileUrl: vi.fn((path: string) => `memry-file://${encodeURIComponent(path)}`)
-}))
+vi.mock('../lib/paths', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/paths')>()
+  return {
+    ...actual,
+    toMemryFileUrl: vi.fn((path: string) => `memry-file://${encodeURIComponent(path)}`)
+  }
+})
 
 import { getStatus } from '../vault'
 import { toMemryFileUrl } from '../lib/paths'

--- a/apps/desktop/src/main/inbox/attachments.ts
+++ b/apps/desktop/src/main/inbox/attachments.ts
@@ -12,7 +12,7 @@ import { existsSync } from 'fs'
 import path from 'path'
 import { customAlphabet } from 'nanoid'
 import { getStatus } from '../vault'
-import { toMemryFileUrl } from '../lib/paths'
+import { normalizeRelativePath, toMemryFileUrl } from '../lib/paths'
 
 // ============================================================================
 // Constants
@@ -279,7 +279,7 @@ export async function storeInboxAttachment(
 
     // Return relative path from vault root
     const vaultPath = requireVaultPath()
-    const relativePath = path.relative(vaultPath, filePath)
+    const relativePath = normalizeRelativePath(path.relative(vaultPath, filePath))
 
     return {
       success: true,
@@ -316,7 +316,7 @@ export async function storeThumbnail(
     await writeFile(filePath, data)
 
     const vaultPath = requireVaultPath()
-    const relativePath = path.relative(vaultPath, filePath)
+    const relativePath = normalizeRelativePath(path.relative(vaultPath, filePath))
 
     return {
       success: true,
@@ -369,7 +369,7 @@ export async function listInboxAttachments(itemId: string): Promise<InboxAttachm
     if (file.name.startsWith('thumbnail.')) continue
 
     const filePath = path.join(itemDir, file.name)
-    const relativePath = path.relative(vaultPath, filePath)
+    const relativePath = normalizeRelativePath(path.relative(vaultPath, filePath))
 
     // Determine type from extension
     const ext = path.extname(file.name).toLowerCase().slice(1)
@@ -452,7 +452,7 @@ export async function moveAttachmentsToNote(itemId: string, noteId: string): Pro
     // Copy instead of rename to avoid cross-device issues
     await copyFile(sourcePath, targetPath)
 
-    const relativePath = path.relative(vaultPath, targetPath)
+    const relativePath = normalizeRelativePath(path.relative(vaultPath, targetPath))
     movedPaths.push(relativePath)
   }
 

--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -17,6 +17,7 @@ import { createNote, getNoteById, updateNote, createFolder, getFolders } from '.
 import { getStatus, getConfig } from '../vault/index'
 import { inboxItems, inboxItemTags, filingHistory } from '@memry/db-schema/schema/inbox'
 import { generateId } from '../lib/id'
+import { normalizeRelativePath } from '../lib/paths'
 import { eq } from 'drizzle-orm'
 import { InboxChannels, TasksChannels } from '@memry/contracts/ipc-channels'
 import { resolveAttachmentUrl, deleteInboxAttachments } from './attachments'
@@ -464,7 +465,7 @@ async function fileBinaryToFolder(itemId: string, folderPath: string): Promise<F
     await deleteInboxAttachments(itemId)
 
     // Calculate relative path from vault root for storage
-    const relativePath = path.relative(vaultPath, finalPath)
+    const relativePath = normalizeRelativePath(path.relative(vaultPath, finalPath))
 
     // Mark inbox item as filed
     markItemAsFiled(itemId, relativePath, 'folder')
@@ -824,7 +825,7 @@ async function linkBinaryToNotes(
     }
 
     // Calculate relative path for storage
-    const relativePath = path.relative(vaultPath, finalPath)
+    const relativePath = normalizeRelativePath(path.relative(vaultPath, finalPath))
 
     // Mark inbox item as filed
     markItemAsFiled(itemId, relativePath, 'linked')

--- a/apps/desktop/src/main/lib/paths.test.ts
+++ b/apps/desktop/src/main/lib/paths.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import path from 'path'
 import {
   sanitizePath,
+  normalizeRelativePath,
   getRelativePath,
   isPathInVault,
   safeFileName,
@@ -21,10 +22,18 @@ describe('paths utils', () => {
     expect(sanitized).toBe(path.join('note.md'))
   })
 
+  it('normalizeRelativePath converts backslashes to forward slashes', () => {
+    expect(normalizeRelativePath('notes\\windows\\note.md')).toBe('notes/windows/note.md')
+  })
+
+  it('normalizeRelativePath leaves forward-slash paths unchanged', () => {
+    expect(normalizeRelativePath('notes/projects/note.md')).toBe('notes/projects/note.md')
+  })
+
   it('getRelativePath returns relative path for files inside the vault', () => {
     const vaultRoot = path.join(process.cwd(), 'vault-root')
     const inside = path.join(vaultRoot, 'notes', 'note.md')
-    expect(getRelativePath(vaultRoot, inside)).toBe(path.join('notes', 'note.md'))
+    expect(getRelativePath(vaultRoot, inside)).toBe('notes/note.md')
   })
 
   it('getRelativePath returns null for files outside the vault', () => {

--- a/apps/desktop/src/main/lib/paths.ts
+++ b/apps/desktop/src/main/lib/paths.ts
@@ -15,6 +15,13 @@ export function sanitizePath(inputPath: string): string {
 }
 
 /**
+ * Normalizes vault-relative paths to forward slashes for cross-platform storage.
+ */
+export function normalizeRelativePath(relativePath: string): string {
+  return relativePath.replace(/\\/g, '/')
+}
+
+/**
  * Calculates relative path from vault root.
  * Returns null if the path is outside the vault.
  */
@@ -27,7 +34,7 @@ export function getRelativePath(vaultPath: string, filePath: string): string | n
     return null
   }
 
-  return path.relative(resolvedVault, resolvedFile)
+  return normalizeRelativePath(path.relative(resolvedVault, resolvedFile))
 }
 
 /**

--- a/apps/desktop/src/main/vault/file-ops.test.ts
+++ b/apps/desktop/src/main/vault/file-ops.test.ts
@@ -263,7 +263,7 @@ describe('listMarkdownFiles', () => {
 
     const files = await listMarkdownFiles(tempDir.path, tempDir.path)
 
-    expect(files).toContain(path.join('notes', 'test.md'))
+    expect(files).toContain('notes/test.md')
   })
 
   it('returns empty array for non-existent directory', async () => {

--- a/apps/desktop/src/main/vault/file-ops.ts
+++ b/apps/desktop/src/main/vault/file-ops.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'fs'
 import { randomBytes } from 'crypto'
 import path from 'path'
 import { NoteError, NoteErrorCode } from '../lib/errors'
+import { normalizeRelativePath } from '../lib/paths'
 
 // ============================================================================
 // Atomic Write
@@ -136,7 +137,9 @@ export async function listMarkdownFiles(dirPath: string, relativeTo?: string): P
         if (entry.isDirectory()) {
           await scanDir(fullPath)
         } else if (entry.isFile() && entry.name.endsWith('.md')) {
-          const filePath = relativeTo ? path.relative(relativeTo, fullPath) : fullPath
+          const filePath = relativeTo
+            ? normalizeRelativePath(path.relative(relativeTo, fullPath))
+            : fullPath
           files.push(filePath)
         }
       }
@@ -178,7 +181,9 @@ export async function listDirectories(dirPath: string, relativeTo?: string): Pro
 
         if (entry.isDirectory()) {
           const fullPath = path.join(currentPath, entry.name)
-          const dirPath = relativeTo ? path.relative(relativeTo, fullPath) : fullPath
+          const dirPath = relativeTo
+            ? normalizeRelativePath(path.relative(relativeTo, fullPath))
+            : fullPath
           dirs.push(dirPath)
           await scanDir(fullPath)
         }

--- a/apps/desktop/src/main/vault/indexer.ts
+++ b/apps/desktop/src/main/vault/indexer.ts
@@ -24,6 +24,7 @@ import {
 import { parseNote, serializeNote } from './frontmatter'
 import { safeRead, atomicWrite } from './file-ops'
 import { generateNoteId } from '../lib/id'
+import { normalizeRelativePath } from '../lib/paths'
 import { syncNoteToCache, syncFileToCache } from './note-sync'
 import { flushProjectionEvents } from '../projections'
 import {
@@ -86,7 +87,7 @@ async function findVaultFiles(
         const supported = isSupportedPath(fullPath)
         if (supported) {
           // Add supported file (relative path from vault root)
-          files.push(path.relative(basePath, fullPath))
+          files.push(normalizeRelativePath(path.relative(basePath, fullPath)))
         } else {
           logger.debug(`Skipping unsupported file: ${entry.name}`)
         }

--- a/apps/desktop/src/main/vault/notes.ts
+++ b/apps/desktop/src/main/vault/notes.ts
@@ -10,6 +10,7 @@ import fs from 'fs/promises'
 import { shell } from 'electron'
 import { BrowserWindow } from 'electron'
 import { getStatus, getConfig } from './index'
+import { normalizeRelativePath } from '../lib/paths'
 import {
   parseNote,
   serializeNote,
@@ -246,7 +247,7 @@ export function toAbsolutePath(relativePath: string): string {
  */
 export function toRelativePath(absolutePath: string): string {
   const vaultPath = getVaultPath()
-  return path.relative(vaultPath, absolutePath)
+  return normalizeRelativePath(path.relative(vaultPath, absolutePath))
 }
 
 /**

--- a/apps/desktop/src/main/vault/watcher.ts
+++ b/apps/desktop/src/main/vault/watcher.ts
@@ -43,6 +43,7 @@ import {
   initializeJournalCrdt
 } from '../journal/runtime-effects'
 import { syncNoteCreate, syncNoteDelete, syncNoteUpdate } from '../notes/runtime-effects'
+import { normalizeRelativePath } from '../lib/paths'
 
 const logger = createLogger('Watcher')
 
@@ -315,7 +316,7 @@ export class VaultWatcher {
     if (isWritebackIgnored(absolutePath)) return
 
     try {
-      const relativePath = path.relative(this.vaultPath, absolutePath)
+      const relativePath = normalizeRelativePath(path.relative(this.vaultPath, absolutePath))
       const fileType = getFileType(getExtension(absolutePath))
 
       if (!fileType) {
@@ -560,7 +561,7 @@ export class VaultWatcher {
     if (isWritebackIgnored(absolutePath)) return
 
     try {
-      const relativePath = path.relative(this.vaultPath, absolutePath)
+      const relativePath = normalizeRelativePath(path.relative(this.vaultPath, absolutePath))
       const fileType = getFileType(getExtension(absolutePath))
 
       if (!fileType) {
@@ -717,7 +718,7 @@ export class VaultWatcher {
     if (!this.vaultPath) return
 
     try {
-      const relativePath = path.relative(this.vaultPath, absolutePath)
+      const relativePath = normalizeRelativePath(path.relative(this.vaultPath, absolutePath))
 
       const db = getIndexDatabase()
 

--- a/apps/desktop/src/renderer/src/components/inbox-detail/filing-section.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/filing-section.tsx
@@ -19,6 +19,10 @@ import { createLogger } from '@/lib/logger'
 
 const log = createLogger('Component:FilingSection')
 
+function normalizeFolderPath(folderPath: string): string {
+  return folderPath.replace(/\\/g, '/').replace(/[\\/]+$/, '')
+}
+
 // Filing section can work with either full or list item types
 type FilingItem = InboxItem | InboxItemListItem
 
@@ -66,12 +70,15 @@ export const FilingSection = ({
       const folderInfos = await window.api.notes.getFolders()
       const folders: FolderType[] = [{ id: '', name: 'Notes (root)', path: '' }]
       for (const fi of folderInfos) {
-        if (fi.path) {
+        const normalizedPath = normalizeFolderPath(fi.path)
+        if (normalizedPath) {
           folders.push({
-            id: fi.path,
-            name: fi.path.split('/').pop() || fi.path,
-            path: fi.path,
-            parent: fi.path.includes('/') ? fi.path.split('/').slice(0, -1).join('/') : undefined,
+            id: normalizedPath,
+            name: normalizedPath.split('/').pop() || normalizedPath,
+            path: normalizedPath,
+            parent: normalizedPath.includes('/')
+              ? normalizedPath.split('/').slice(0, -1).join('/')
+              : undefined,
             icon: fi.icon ?? null
           })
         }
@@ -105,7 +112,7 @@ export const FilingSection = ({
         .filter((s) => s.destination.type === 'folder' && s.destination.path)
         .slice(0, 3)
         .map((s) => {
-          const path = s.destination.path || ''
+          const path = normalizeFolderPath(s.destination.path || '')
           const vaultMatch = vaultFolders.find((f) => f.path === path)
           return {
             id: path,
@@ -187,24 +194,45 @@ export const FilingSection = ({
     )
   }, [vaultFolders, folderSearch])
 
-  const trimmedSearch = folderSearch.trim().replace(/\/+$/, '')
+  const trimmedSearch = normalizeFolderPath(folderSearch.trim())
   const canCreateFolder = trimmedSearch.length > 0 && filteredFolders.length === 0
 
   const handleCreateFolder = useCallback(async () => {
     if (!trimmedSearch || isCreatingFolder) return
     setIsCreatingFolder(true)
     try {
-      await window.api.notes.createFolder(trimmedSearch)
-      await queryClient.invalidateQueries({ queryKey: ['vault', 'folders'] })
-      const name = trimmedSearch.split('/').pop() || trimmedSearch
-      onFolderSelect({
+      const result = await window.api.notes.createFolder(trimmedSearch)
+      if (!result.success) {
+        log.error('Failed to create folder', { path: trimmedSearch })
+        return
+      }
+
+      const createdFolder: FolderType = {
         id: trimmedSearch,
-        name,
+        name: trimmedSearch.split('/').pop() || trimmedSearch,
         path: trimmedSearch,
         parent: trimmedSearch.includes('/')
           ? trimmedSearch.split('/').slice(0, -1).join('/')
           : undefined
+      }
+
+      queryClient.setQueryData<FolderType[]>(['vault', 'folders'], (current = []) => {
+        const baseFolders =
+          current.length > 0 ? current : [{ id: '', name: 'Notes (root)', path: '' }]
+        if (baseFolders.some((folder) => folder.path === createdFolder.path)) {
+          return baseFolders
+        }
+
+        const rootFolder = baseFolders.find((folder) => folder.path === '')
+        const nextFolders = baseFolders
+          .filter((folder) => folder.path !== '')
+          .concat(createdFolder)
+          .sort((left, right) => left.path.localeCompare(right.path))
+
+        return rootFolder ? [rootFolder, ...nextFolders] : nextFolders
       })
+
+      onFolderSelect(createdFolder)
       setShowAllFolders(false)
       setFolderSearch('')
     } catch (error) {


### PR DESCRIPTION
## What

Fix Windows inbox folder filing by normalizing vault-relative paths and the inline folder-create flow.

## Why

A Windows user reported in #136 that creating a folder while filing a note/link could leave the app unresponsive, and after restart the folder existed but the item still remained in Inbox. The filing flow was mixing Windows `\\`-delimited relative paths with `/`-delimited folder ids.

## How

- add `normalizeRelativePath` and use it anywhere the desktop app emits vault-relative note, folder, watcher, inbox, or attachment paths
- normalize folder search and AI suggestion paths in the inbox filing UI
- update inline folder creation to insert the new folder into the React Query cache immediately instead of waiting for a refetch
- add and update cross-platform tests so normalized relative paths are asserted explicitly

## Type

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `refactor` — restructure without behavior change
- [ ] `style` — visual/UI only
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `chore` — tooling, deps, config
- [ ] `docs` — documentation only
- [ ] `ci` — CI/CD changes

## Test plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing (describe below)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm ipc:check`

## Screenshots

- N/A (behavioral fix, no visible UI change)

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns
