### PR TITLE
[0.3] fix(types): unblock websocket.test.ts type errors

### DIFF
--- a/apps/desktop/src/main/sync/websocket.test.ts
+++ b/apps/desktop/src/main/sync/websocket.test.ts
@@ -7,7 +7,7 @@ import {
 import { CertificatePinningError } from './certificate-pinning'
 
 const { MockWebSocket, getInstances, resetInstances } = vi.hoisted(() => {
-  const { EventEmitter: EE } = require('events')
+  const { EventEmitter: EE } = require('events') as typeof import('events')
   const instances: Array<InstanceType<typeof MockWS>> = []
 
   class MockWS extends EE {


### PR DESCRIPTION
## Summary

Adds a TypeScript type assertion to the `require('events')` call inside `vi.hoisted()` in `apps/desktop/src/main/sync/websocket.test.ts` so the returned module namespace is typed correctly without enabling `esModuleInterop` project-wide.

The CJS `require('events')` returned `any`, which flowed through the destructured `EventEmitter` and into `class MockWS extends EE`, cascading into ~45 downstream type errors in that file when checked against `tests/tsconfig.json`.

## Fix applied

```ts
// before
const { EventEmitter: EE } = require('events')

// after
const { EventEmitter: EE } = require('events') as typeof import('events')
```

This was option (b) from the task spec — cast the `require` result to the proper ES module namespace type. No tsconfig changes needed; avoids the broader blast radius of turning on `esModuleInterop` / `allowSyntheticDefaultImports`.

## Before / after

- **Before** (baseline on main): ~45 type errors in `apps/desktop/src/main/sync/websocket.test.ts` when typechecked via `tests/tsconfig.json`.
- **After** (this branch): **0** type errors in `websocket.test.ts`. Confirmed via `pnpm exec tsc --noEmit -p tests/tsconfig.json` — remaining errors are in unrelated test files (calendar, inbox, ipc handlers) and outside this unit's scope.
- `pnpm --filter @memry/desktop typecheck:node` — passes cleanly (test files already excluded by production tsconfig; no regressions).
- `pnpm --filter @memry/desktop exec vitest run src/main/sync/websocket.test.ts` — **28/28 tests pass**.

## Test plan

- [x] `websocket.test.ts` typechecks clean via `tests/tsconfig.json`
- [x] `websocket.test.ts` runtime — all 28 tests pass
- [x] `typecheck:node` still green (test files excluded there)
- [ ] CI lint / typecheck / test pipeline green