### PR TITLE
[1.8] refactor(embeddings): type extractor with FeatureExtractionPipeline

### DIFF
--- a/apps/desktop/src/main/lib/embeddings.ts
+++ b/apps/desktop/src/main/lib/embeddings.ts
@@ -11,6 +11,7 @@
 
 import { app, BrowserWindow } from 'electron'
 import path from 'path'
+import type { FeatureExtractionPipeline } from '@huggingface/transformers'
 import { SettingsChannels } from '@memry/contracts/ipc-channels'
 import { EMBEDDING_DIMENSION } from './embeddings-constants'
 import { createLogger } from './logger'
@@ -57,9 +58,7 @@ const MAX_CONTENT_LENGTH = 2000
 // State
 // ============================================================================
 
-// Pipeline instance (lazy loaded)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let extractor: any = null
+let extractor: FeatureExtractionPipeline | null = null
 let isLoading = false
 let loadError: string | null = null
 
@@ -132,9 +131,10 @@ export async function initEmbeddingModel(): Promise<boolean> {
 
     emitProgress('downloading', 5, 'Loading model (downloading if first time)...')
 
-    // Create feature extraction pipeline with progress callback
-    // Explicitly set dtype to fp32 for CPU (silences "dtype not specified" warning)
-    extractor = await pipeline('feature-extraction', MODEL_NAME, {
+    // Explicitly set dtype to fp32 for CPU (silences "dtype not specified" warning).
+    // `pipeline('feature-extraction', ...)` returns a union over all task pipelines that TS
+    // reports as "too complex to represent"; route through `unknown` to narrow to the concrete type.
+    const loaded: unknown = await pipeline('feature-extraction', MODEL_NAME, {
       dtype: 'fp32',
       progress_callback: (progress: ModelProgress) => {
         if (progress.status === 'progress' && progress.progress !== undefined) {
@@ -145,6 +145,7 @@ export async function initEmbeddingModel(): Promise<boolean> {
         }
       }
     })
+    extractor = loaded as FeatureExtractionPipeline
 
     emitProgress('ready', 100, 'Model ready')
     logger.info('Model loaded successfully')
@@ -172,21 +173,20 @@ export async function generateEmbedding(text: string): Promise<Float32Array | nu
     return null
   }
 
-  // Ensure model is loaded
   if (!extractor) {
-    const loaded = await initEmbeddingModel()
-    if (!loaded) {
-      logger.warn('Model not available, skipping embedding')
-      return null
-    }
+    await initEmbeddingModel()
+  }
+
+  const extractorInstance = extractor
+  if (!extractorInstance) {
+    logger.warn('Model not available, skipping embedding')
+    return null
   }
 
   try {
-    // Truncate very long texts (model max ~512 tokens)
     const truncated = text.substring(0, MAX_CONTENT_LENGTH)
 
-    // Generate embedding with mean pooling and normalization
-    const output = (await extractor(truncated, {
+    const output = (await extractorInstance(truncated, {
       pooling: 'mean',
       normalize: true
     })) as { data: ArrayLike<number> }


### PR DESCRIPTION
## Summary

Replaces the `let extractor: any = null` escape hatch in `apps/desktop/src/main/lib/embeddings.ts` with the real `FeatureExtractionPipeline` type imported from `@huggingface/transformers`, removing the file's only `eslint-disable @typescript-eslint/no-explicit-any` directive.

`pipeline('feature-extraction', ...)` returns a large discriminated union that TypeScript reports as "too complex to represent". The return is routed through `unknown` (not `any`) and cast once to the concrete pipeline type — keeping the module-level `extractor` strongly typed at every call site.

## Before / After

```diff
-// Pipeline instance (lazy loaded)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let extractor: any = null
+let extractor: FeatureExtractionPipeline | null = null
```

And inside `initEmbeddingModel()`:

```diff
-extractor = await pipeline('feature-extraction', MODEL_NAME, { ... })
+const loaded: unknown = await pipeline('feature-extraction', MODEL_NAME, { ... })
+extractor = loaded as FeatureExtractionPipeline
```

`generateEmbedding()` now calls a locally-typed `extractorInstance` (same narrowed reference) rather than re-reading the module variable after the `initEmbeddingModel()` call.

## Verification

- `pnpm --filter @memry/desktop typecheck:node 2>&1 | grep "embeddings.ts" | wc -l` = **0**
- `rg ": any|as any" apps/desktop/src/main/lib/embeddings.ts` = **no matches**
- `pnpm --filter @memry/desktop typecheck:web` = **pass**
- `pnpm typecheck:packages` = **pass (10/10 cached)**
- `pnpm exec eslint --cache src/main/lib/embeddings.ts` = **0 errors, 0 warnings**
- `pnpm test` = 2 failures, both pre-existing and unrelated:
  - `calendar-page.test.tsx:258` "Due draft" (known flake, ignored per unit instructions)
  - `notes-tree.test.tsx` T523 — reproduces on clean `main` without this change (`@/components/kibo-ui/tree` alias resolution issue in local env)

## Test plan

- [x] `typecheck:node` clean for touched file
- [x] `typecheck:web` clean
- [x] `typecheck:packages` clean
- [x] No `any` remaining in `embeddings.ts`
- [x] No new lint errors in touched file
- [ ] Smoke embedding generation in dev app (manual follow-up)