### PR TITLE
[0.2] fix(preload): swap raw console.error for createLogger

### DIFF
--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
+import { createLogger } from '../main/lib/logger'
 
 // Import channel constants from shared (single source of truth)
 import {
@@ -47,6 +48,8 @@ import type {
   MainIpcInvokeArgs,
   MainIpcInvokeResult
 } from '../main/ipc/generated-ipc-invoke-map'
+
+const logger = createLogger('Preload')
 
 function invoke<C extends MainIpcInvokeChannel>(
   channel: C,
@@ -1097,7 +1100,7 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld('electron', electronAPI)
     contextBridge.exposeInMainWorld('api', api)
   } catch (error) {
-    console.error(error)
+    logger.error('contextBridge exposure failed', error)
   }
 } else {
   ;(window as unknown as Record<string, unknown>).electron = electronAPI


### PR DESCRIPTION
## Summary

Replaces the raw `console.error(error)` inside the `contextBridge` try/catch in `apps/desktop/src/preload/index.ts` with `createLogger('Preload').error(...)`, aligning with the project-wide logging convention (`createLogger` from `electron-log`, never raw `console.*`).

This is Unit 0.2 of the tech-debt remediation batch.

## Change

```diff
-    console.error(error)
+    logger.error('contextBridge exposure failed', error)
```

Plus the supporting import:

```ts
import { createLogger } from '../main/lib/logger'
...
const logger = createLogger('Preload')
```

## Files touched

- `apps/desktop/src/preload/index.ts` (+4 / -1)

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm lint` — `0 errors, 1435 warnings` (all pre-existing)
- `pnpm --filter @memry/desktop typecheck:node` — clean
- `pnpm --filter @memry/desktop typecheck:web` — clean
- `pnpm typecheck:packages` — `10 successful, 10 total` (FULL TURBO cached)
- `pnpm test` — `1 failed | 5686 passed` — the single failure is `calendar-page.test.tsx:258` ("Due draft"), a known pre-existing flake on `main` (see task instructions), unrelated to this change

## Caveats

None. Scope is a single log-site swap; no behavior change beyond logging output format.