### PR TITLE
[P.1] chore(hooks): add 800-line file size pre-commit gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Reject commits that introduce or modify any source file exceeding MAX_LINES.
+# Keeps module boundaries honest — split files before they become unreviewable.
+
+set -eu
+
+MAX_LINES=800
+
+excluded() {
+  case "$1" in
+    node_modules/*|*/node_modules/*) return 0 ;;
+    .worktrees/*|*/.worktrees/*)     return 0 ;;
+    .claude/*)                        return 0 ;;
+    dist/*|*/dist/*)                  return 0 ;;
+    out/*|*/out/*)                    return 0 ;;
+    coverage/*|*/coverage/*)          return 0 ;;
+    tests/*|*/tests/*)                return 0 ;;
+    *.test.ts|*.test.tsx)             return 0 ;;
+    *.spec.ts|*.spec.tsx)             return 0 ;;
+    *.d.ts)                           return 0 ;;
+    *generated-ipc-invoke-map.ts)     return 0 ;;
+  esac
+  case "$1" in
+    apps/*|packages/*) return 1 ;;
+    */*)               return 0 ;;
+    *)                 return 1 ;;
+  esac
+}
+
+offender_files=()
+offender_lines=()
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  [ -f "$file" ] || continue
+  if excluded "$file"; then
+    continue
+  fi
+  lines=$(wc -l < "$file" | tr -d ' ')
+  if [ "$lines" -gt "$MAX_LINES" ]; then
+    offender_files+=("$file")
+    offender_lines+=("$lines")
+  fi
+done < <(git diff --cached --name-only --diff-filter=ACMR)
+
+count=${#offender_files[@]}
+
+if [ "$count" -gt 0 ]; then
+  printf '\n\033[31mpre-commit: %d file(s) exceed %d-line limit:\033[0m\n\n' "$count" "$MAX_LINES" >&2
+  printf '  %-70s %s\n' "FILE" "LINES" >&2
+  printf '  %-70s %s\n' "----" "-----" >&2
+  for i in "${!offender_files[@]}"; do
+    printf '  %-70s %s\n' "${offender_files[$i]}" "${offender_lines[$i]}" >&2
+  done
+  printf '\nSplit these files into smaller modules before committing.\n' >&2
+  printf 'Limit lives in .githooks/pre-commit (MAX_LINES).\n\n' >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Adds `.githooks/pre-commit` that blocks commits introducing source files over 800 lines. Keeps module boundaries honest: split files before they grow unreviewable.

- Scope: `apps/**` and `packages/**` source only
- Excluded: tests (`*.test.*`, `*.spec.*`, `tests/**`), `*.d.ts`, generated IPC map, build output, `node_modules`, `.worktrees`, `.claude`
- Limit: `MAX_LINES=800` (lives in the hook itself)
- Activation: `core.hooksPath=.githooks` is set by the existing root `prepare` script, so `pnpm install` picks it up automatically

## Hook source

` ``sh
#!/usr/bin/env bash
# Reject commits that introduce or modify any source file exceeding MAX_LINES.
# Keeps module boundaries honest — split files before they become unreviewable.

set -eu

MAX_LINES=800

excluded() {
  case "\$1" in
    node_modules/*|*/node_modules/*) return 0 ;;
    .worktrees/*|*/.worktrees/*)     return 0 ;;
    .claude/*)                        return 0 ;;
    dist/*|*/dist/*)                  return 0 ;;
    out/*|*/out/*)                    return 0 ;;
    coverage/*|*/coverage/*)          return 0 ;;
    tests/*|*/tests/*)                return 0 ;;
    *.test.ts|*.test.tsx)             return 0 ;;
    *.spec.ts|*.spec.tsx)             return 0 ;;
    *.d.ts)                           return 0 ;;
    *generated-ipc-invoke-map.ts)     return 0 ;;
  esac
  case "\$1" in
    apps/*|packages/*) return 1 ;;
    */*)               return 0 ;;
    *)                 return 1 ;;
  esac
}

offender_files=()
offender_lines=()

while IFS= read -r file; do
  [ -z "\$file" ] && continue
  [ -f "\$file" ] || continue
  if excluded "\$file"; then
    continue
  fi
  lines=\$(wc -l < "\$file" | tr -d ' ')
  if [ "\$lines" -gt "\$MAX_LINES" ]; then
    offender_files+=("\$file")
    offender_lines+=("\$lines")
  fi
done < <(git diff --cached --name-only --diff-filter=ACMR)

count=\${#offender_files[@]}

if [ "\$count" -gt 0 ]; then
  printf '\n\033[31mpre-commit: %d file(s) exceed %d-line limit:\033[0m\n\n' "\$count" "\$MAX_LINES" >&2
  printf '  %-70s %s\n' "FILE" "LINES" >&2
  printf '  %-70s %s\n' "----" "-----" >&2
  for i in "\${!offender_files[@]}"; do
    printf '  %-70s %s\n' "\${offender_files[\$i]}" "\${offender_lines[\$i]}" >&2
  done
  printf '\nSplit these files into smaller modules before committing.\n' >&2
  printf 'Limit lives in .githooks/pre-commit (MAX_LINES).\n\n' >&2
  exit 1
fi

exit 0
` ``

## Fail-case transcript (801-line file rejected)

` ``
\$ awk 'BEGIN{for(i=0;i<801;i++)print "// line " i}' > apps/desktop/src/_throwaway.ts
\$ wc -l apps/desktop/src/_throwaway.ts
     801 apps/desktop/src/_throwaway.ts
\$ git add apps/desktop/src/_throwaway.ts
\$ git commit -m "test-oversized"

pre-commit: 1 file(s) exceed 800-line limit:

  FILE                                                                   LINES
  ----                                                                   -----
  apps/desktop/src/_throwaway.ts                                         801

Split these files into smaller modules before committing.
Limit lives in .githooks/pre-commit (MAX_LINES).
` ``

Hook exits non-zero, commit aborted.

## Pass-case transcript (799-line file accepted)

` ``
\$ awk 'BEGIN{for(i=0;i<799;i++)print "// line " i}' > apps/desktop/src/_okay.ts
\$ wc -l apps/desktop/src/_okay.ts
     799 apps/desktop/src/_okay.ts
\$ git add apps/desktop/src/_okay.ts
\$ git commit -m "test-ok"
[debt/P.1-file-size-precommit 7d4f5726] test-ok
 1 file changed, 799 insertions(+)
 create mode 100644 apps/desktop/src/_okay.ts
\$ git reset --hard HEAD~1
HEAD is now at 77ec9ea3 chore(hooks): add 800-line file size pre-commit gate
` ``

## Test plan

- [x] Hook file executable (`-rwxr-xr-x`)
- [x] `core.hooksPath` resolves to `.githooks` (set by root `prepare` script)
- [x] 801-line source file commit rejected with clear error
- [x] 799-line source file commit accepted
- [x] `pnpm lint` passes
- [x] `pnpm --filter @memry/desktop typecheck:node` passes
- [x] `pnpm --filter @memry/desktop typecheck:web` passes
- [x] `pnpm typecheck:packages` passes
- [x] `pnpm test` passes (ignored known `calendar-page.test.tsx:258` "Due draft" flake)