### PR TITLE
[P.2] chore(lint): enforce 800-line max-lines rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,7 +105,92 @@ export default defineConfig(
       'no-case-declarations': 'warn',
       'no-empty-pattern': 'warn',
       'no-control-regex': 'warn',
-      'prefer-const': 'warn'
+      'prefer-const': 'warn',
+      'max-lines': ['error', { max: 800, skipBlankLines: true, skipComments: true }]
+    }
+  },
+  {
+    files: ['apps/desktop/src/main/ipc/sync-handlers.ts'],
+    rules: {
+      // TODO(phase-2): drop this override once sync-handlers.ts is split
+      'max-lines': 'off'
+    }
+  },
+  {
+    files: ['apps/desktop/src/main/vault/notes.ts'],
+    rules: {
+      // TODO(phase-3): drop this override once vault/notes.ts is split
+      'max-lines': 'off'
+    }
+  },
+  {
+    files: [
+      'apps/desktop/src/main/ipc/notes-handlers.ts',
+      'apps/desktop/src/main/ipc/settings-handlers.ts'
+    ],
+    rules: {
+      // TODO(phase-2): drop these overrides once IPC handler files are split (Phase 2 registerCommand rollout)
+      'max-lines': 'off'
+    }
+  },
+  {
+    files: [
+      'apps/desktop/src/main/index.ts',
+      'apps/desktop/src/main/database/seed.ts',
+      'apps/desktop/src/main/database/queries/tasks.ts',
+      'apps/desktop/src/main/inbox/filing.ts',
+      'apps/desktop/src/main/inbox/suggestions.ts',
+      'apps/desktop/src/main/sync/attachments.ts',
+      'apps/desktop/src/main/vault/watcher.ts'
+    ],
+    rules: {
+      // TODO(phase-tbd): drop these overrides once large main-process modules are split
+      'max-lines': 'off'
+    }
+  },
+  {
+    files: [
+      'apps/desktop/src/preload/index.ts',
+      'apps/desktop/src/preload/index.d.ts'
+    ],
+    rules: {
+      // TODO(phase-tbd): preload is generated from contracts; drop overrides once chunked output lands
+      'max-lines': 'off'
+    }
+  },
+  {
+    files: [
+      'packages/contracts/src/ipc-channels.ts',
+      'packages/contracts/src/inbox-api.ts'
+    ],
+    rules: {
+      // TODO(phase-4): drop these overrides once contract modules are split by domain
+      'max-lines': 'off'
+    }
+  },
+  {
+    files: [
+      'apps/desktop/src/renderer/src/pages/tasks.tsx',
+      'apps/desktop/src/renderer/src/pages/note.tsx',
+      'apps/desktop/src/renderer/src/pages/journal.tsx',
+      'apps/desktop/src/renderer/src/pages/folder-view.tsx',
+      'apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx',
+      'apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx',
+      'apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx',
+      'apps/desktop/src/renderer/src/components/folder-view/property-cell.tsx',
+      'apps/desktop/src/renderer/src/components/kibo-ui/tree/index.tsx',
+      'apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx',
+      'apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx',
+      'apps/desktop/src/renderer/src/contexts/tabs/context.tsx',
+      'apps/desktop/src/renderer/src/hooks/use-drag-handlers.ts',
+      'apps/desktop/src/renderer/src/hooks/use-folder-view.ts',
+      'apps/desktop/src/renderer/src/hooks/use-note-tree-actions.ts',
+      'apps/desktop/src/renderer/src/hooks/use-subtask-management.ts',
+      'apps/desktop/src/renderer/src/lib/expression-evaluator.ts'
+    ],
+    rules: {
+      // TODO(phase-5): drop these overrides once renderer files are split during UI polish
+      'max-lines': 'off'
     }
   }
 )


### PR DESCRIPTION
## Summary

Enforce an 800-line ESLint `max-lines` rule (blank lines and comments excluded) on the workspace so new files stay focused and large modules get split up over time.

- Adds `'max-lines': ['error', { max: 800, skipBlankLines: true, skipComments: true }]` to the root rules block in `eslint.config.mjs`.
- Adds per-file `max-lines: 'off'` overrides for existing files that already exceed 800 LOC so this PR remains a scope-limited enablement. Each override carries a `TODO(phase-N): drop this override once <file> is split` comment.
- Tests are already globally ignored via `ignores` — no test overrides needed.

## Per-file overrides (with phase tag)

### phase-2 (IPC handler splits)
- `apps/desktop/src/main/ipc/sync-handlers.ts`
- `apps/desktop/src/main/ipc/notes-handlers.ts`
- `apps/desktop/src/main/ipc/settings-handlers.ts`

### phase-3 (vault split)
- `apps/desktop/src/main/vault/notes.ts`

### phase-4 (contracts split by domain)
- `packages/contracts/src/ipc-channels.ts`
- `packages/contracts/src/inbox-api.ts`

### phase-5 (renderer polish)
- `apps/desktop/src/renderer/src/pages/tasks.tsx`
- `apps/desktop/src/renderer/src/pages/note.tsx`
- `apps/desktop/src/renderer/src/pages/journal.tsx`
- `apps/desktop/src/renderer/src/pages/folder-view.tsx`
- `apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx`
- `apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx`
- `apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx`
- `apps/desktop/src/renderer/src/components/folder-view/property-cell.tsx`
- `apps/desktop/src/renderer/src/components/kibo-ui/tree/index.tsx`
- `apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx`
- `apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx`
- `apps/desktop/src/renderer/src/contexts/tabs/context.tsx`
- `apps/desktop/src/renderer/src/hooks/use-drag-handlers.ts`
- `apps/desktop/src/renderer/src/hooks/use-folder-view.ts`
- `apps/desktop/src/renderer/src/hooks/use-note-tree-actions.ts`
- `apps/desktop/src/renderer/src/hooks/use-subtask-management.ts`
- `apps/desktop/src/renderer/src/lib/expression-evaluator.ts`

### phase-tbd (large main-process modules + generated preload)
- `apps/desktop/src/main/index.ts`
- `apps/desktop/src/main/database/seed.ts`
- `apps/desktop/src/main/database/queries/tasks.ts`
- `apps/desktop/src/main/inbox/filing.ts`
- `apps/desktop/src/main/inbox/suggestions.ts`
- `apps/desktop/src/main/sync/attachments.ts`
- `apps/desktop/src/main/vault/watcher.ts`
- `apps/desktop/src/preload/index.ts`
- `apps/desktop/src/preload/index.d.ts`

## Verification

### Rule fires on new files
```
$ awk 'BEGIN{for(i=0;i<801;i++)print "export const x_" i " = " i}' > apps/desktop/src/main/_throwaway.ts
$ pnpm exec eslint --cache apps/desktop/src/main/_throwaway.ts

/Users/h4yfans/sideproject/memry/.claude/worktrees/agent-ab43b94f/apps/desktop/src/main/_throwaway.ts
  801:1  error  File has too many lines (801). Maximum allowed is 800  max-lines

✖ 1 problem (1 error, 0 warnings)
EXIT=1

$ rm apps/desktop/src/main/_throwaway.ts
$ pnpm lint
✖ 1435 problems (0 errors, 1435 warnings)
EXIT=0
```

Throwaway file triggers a single `max-lines` error (exit 1); after removal, the full workspace lint is clean (exit 0, warnings only).

### Verification steps run
- `pnpm install --frozen-lockfile` — exit 0
- `pnpm lint` — exit 0 (0 errors; 1435 pre-existing warnings unchanged)
- `pnpm --filter @memry/desktop typecheck:node` — exit 0
- `pnpm --filter @memry/desktop typecheck:web` — exit 0
- `pnpm typecheck:packages` — exit 0
- `pnpm test` — 279/280 files pass, 5686/5687 tests pass. Only failure is the pre-existing `calendar-page.test.tsx:258` "Due draft" flake, which is in the ignore list for this PR.

## Test plan
- [ ] CI `pnpm lint` passes
- [ ] CI typecheck passes
- [ ] CI tests pass (ignoring `calendar-page.test.tsx:258` flake)
- [ ] New files > 800 LOC surface as lint errors (not bypassed by the existing overrides)