### PR TITLE
refactor(sync): remove or justify remaining `any` usages in sync tests (Phase 1.9)

### DIFF
--- a/apps/desktop/src/main/sync/apply-item.test.ts
+++ b/apps/desktop/src/main/sync/apply-item.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { eq } from 'drizzle-orm'
-import { createTestDataDb, asSyncDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import {
+  createTestDataDb,
+  asClientDb,
+  asSyncDb,
+  type TestDatabaseResult
+} from '@tests/utils/test-db'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
 import { inboxItems } from '@memry/db-schema/schema/inbox'
 import { savedFilters } from '@memry/db-schema/schema/settings'
 import type { VectorClock } from '@memry/contracts/sync-api'
 import { ItemApplier, type EmitToWindows } from './apply-item'
+import { SyncQueueManager } from './queue'
 
 const TEST_PROJECT = {
   id: 'proj-1',
@@ -550,8 +556,7 @@ describe('ItemApplier', () => {
       initSettingsSyncManager({
         db: asSyncDb(testDb.db),
         getDeviceId: () => 'device-1',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        queue: null as any
+        queue: new SyncQueueManager(asClientDb(testDb.db))
       })
 
       const settingsPayload = {

--- a/apps/desktop/src/main/sync/dirty-recovery.test.ts
+++ b/apps/desktop/src/main/sync/dirty-recovery.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { eq } from 'drizzle-orm'
-import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { createTestDataDb, asClientDb, type TestDatabaseResult } from '@tests/utils/test-db'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
+import type { DataDb } from '../database/client'
 import { SyncQueueManager } from './queue'
 import { initTaskSyncService, resetTaskSyncService } from './task-sync'
 import { initProjectSyncService, resetProjectSyncService } from './project-sync'
@@ -21,12 +22,11 @@ const TEST_PROJECT = {
 describe('dirty-recovery', () => {
   let testDb: TestDatabaseResult
   let queue: SyncQueueManager
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let db: any
+  let db: DataDb
 
   beforeEach(() => {
     testDb = createTestDataDb()
-    db = testDb.db
+    db = asClientDb(testDb.db)
     queue = new SyncQueueManager(db)
     initTaskSyncService({ queue, db, getDeviceId: () => 'device-A' })
     initProjectSyncService({ queue, db, getDeviceId: () => 'device-A' })

--- a/apps/desktop/src/main/sync/item-handlers/folder-config-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/folder-config-handler.test.ts
@@ -4,7 +4,15 @@ import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
 import { folderConfigs } from '@memry/db-schema/schema/folder-configs'
 import type { FolderConfigSyncPayload } from '@memry/contracts/sync-payloads'
 import type { VectorClock } from '@memry/contracts/sync-api'
+import type { SyncQueueManager } from '../queue'
 import type { ApplyContext, DrizzleDb } from './types'
+
+type MockQueue = Pick<SyncQueueManager, 'enqueue'> & { enqueue: ReturnType<typeof vi.fn> }
+
+function makeMockQueue(): { mock: MockQueue; queue: SyncQueueManager } {
+  const mock: MockQueue = { enqueue: vi.fn() }
+  return { mock, queue: mock as unknown as SyncQueueManager }
+}
 
 vi.mock('../../vault/folders', () => ({
   writeFolderConfig: vi.fn(),
@@ -298,12 +306,12 @@ describe('folderConfigHandler', () => {
         ])
         .run()
 
-      const mockQueue = { enqueue: vi.fn() }
+      const { mock: mockQueue, queue } = makeMockQueue()
 
       const count = folderConfigHandler.seedUnclocked(
         testDb.db as unknown as DrizzleDb,
         'device-A',
-        mockQueue as any
+        queue
       )
 
       expect(count).toBe(2)
@@ -337,12 +345,12 @@ describe('folderConfigHandler', () => {
         })
         .run()
 
-      const mockQueue = { enqueue: vi.fn() }
+      const { mock: mockQueue, queue } = makeMockQueue()
 
       const count = folderConfigHandler.seedUnclocked(
         testDb.db as unknown as DrizzleDb,
         'device-A',
-        mockQueue as any
+        queue
       )
 
       expect(count).toBe(0)

--- a/apps/desktop/src/main/sync/item-handlers/settings-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/settings-handler.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { SettingsSyncPayload } from '@memry/contracts/settings-sync'
 import type { VectorClock } from '@memry/contracts/sync-api'
-import type { ApplyContext } from './types'
+import type { ApplyContext, DrizzleDb } from './types'
 
 const mockMergeRemote = vi.fn()
 const mockGetSettings = vi.fn(() => ({}))
@@ -61,9 +61,8 @@ import { settingsHandler } from './settings-handler'
 
 describe('settingsHandler.applyUpsert', () => {
   const ctx: ApplyContext = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    db: {} as any,
-    deviceId: 'device-A'
+    db: {} as unknown as DrizzleDb,
+    emit: vi.fn()
   }
   const clock: VectorClock = { 'device-B': 3 }
 

--- a/apps/desktop/src/main/sync/task-sync-gaps-e2e.test.ts
+++ b/apps/desktop/src/main/sync/task-sync-gaps-e2e.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { eq } from 'drizzle-orm'
-import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import {
+  createTestDataDb,
+  asClientDb,
+  asSyncDb,
+  type TestDatabaseResult
+} from '@tests/utils/test-db'
 import { projects } from '@memry/db-schema/schema/projects'
 import { statuses } from '@memry/db-schema/schema/statuses'
 import { tasks } from '@memry/db-schema/schema/tasks'
@@ -141,8 +146,8 @@ describe('task sync gap fixes — E2E', () => {
     deviceA = createTestDataDb()
     deviceB = createTestDataDb()
 
-    queueA = new SyncQueueManager(deviceA.db as any)
-    queueB = new SyncQueueManager(deviceB.db as any)
+    queueA = new SyncQueueManager(asClientDb(deviceA.db))
+    queueB = new SyncQueueManager(asClientDb(deviceB.db))
   })
 
   afterEach(() => {
@@ -168,7 +173,7 @@ describe('task sync gap fixes — E2E', () => {
 
       const serviceA = new TaskSyncService({
         queue: queueA,
-        db: deviceA.db as any,
+        db: asClientDb(deviceA.db),
         getDeviceId: () => 'device-A'
       })
       serviceA.enqueueUpdate('task-1', ['position'])
@@ -185,7 +190,7 @@ describe('task sync gap fixes — E2E', () => {
       expect(task3Item).toBeDefined()
       const task3Payload = JSON.parse(task3Item!.payload) as Record<string, unknown>
 
-      const applierB = new ItemApplier(deviceB.db as any, vi.fn())
+      const applierB = new ItemApplier(asSyncDb(deviceB.db), vi.fn())
       const result = applyRemotePayload(applierB, 'task-3', task3Payload)
       expect(result).toBe('applied')
 
@@ -229,7 +234,7 @@ describe('task sync gap fixes — E2E', () => {
       expect((parsed.tags as string[]).sort()).toEqual(['bug', 'urgent'])
 
       // #when Device B applies the payload
-      const applierB = new ItemApplier(deviceB.db as any, vi.fn())
+      const applierB = new ItemApplier(asSyncDb(deviceB.db), vi.fn())
       const result = applyRemotePayload(applierB, 'task-1', parsed)
       expect(result).toBe('applied')
 
@@ -261,7 +266,7 @@ describe('task sync gap fixes — E2E', () => {
       expect((parsed.linkedNoteIds as string[]).sort()).toEqual(['note-alpha', 'note-beta'])
 
       // #when Device B applies
-      const applierB = new ItemApplier(deviceB.db as any, vi.fn())
+      const applierB = new ItemApplier(asSyncDb(deviceB.db), vi.fn())
       applyRemotePayload(applierB, 'task-1', parsed)
 
       // #then Device B has linked notes
@@ -279,7 +284,7 @@ describe('task sync gap fixes — E2E', () => {
       deviceA.db.insert(taskTags).values({ taskId: 'task-1', tag: 'frontend' }).run()
       const serviceA = new TaskSyncService({
         queue: queueA,
-        db: deviceA.db as any,
+        db: asClientDb(deviceA.db),
         getDeviceId: () => 'device-A'
       })
       serviceA.enqueueUpdate('task-1', ['tags'])
@@ -288,20 +293,20 @@ describe('task sync gap fixes — E2E', () => {
       deviceB.db.insert(taskTags).values({ taskId: 'task-1', tag: 'backend' }).run()
       const serviceB = new TaskSyncService({
         queue: queueB,
-        db: deviceB.db as any,
+        db: asClientDb(deviceB.db),
         getDeviceId: () => 'device-B'
       })
       serviceB.enqueueUpdate('task-1', ['tags'])
 
       // Cross-apply: A pulls B's payload
       const payloadFromB = JSON.parse(queueB.peek(1)[0].payload) as Record<string, unknown>
-      const applierA = new ItemApplier(deviceA.db as any, vi.fn())
+      const applierA = new ItemApplier(asSyncDb(deviceA.db), vi.fn())
       const resultA = applyRemotePayload(applierA, 'task-1', payloadFromB)
       expect(['applied', 'conflict']).toContain(resultA)
 
       // Cross-apply: B pulls A's payload
       const payloadFromA = JSON.parse(queueA.peek(1)[0].payload) as Record<string, unknown>
-      const applierB = new ItemApplier(deviceB.db as any, vi.fn())
+      const applierB = new ItemApplier(asSyncDb(deviceB.db), vi.fn())
       const resultB = applyRemotePayload(applierB, 'task-1', payloadFromA)
       expect(['applied', 'conflict']).toContain(resultB)
 
@@ -323,7 +328,7 @@ describe('task sync gap fixes — E2E', () => {
       // #when Device B changes title (no tags in payload)
       const serviceB = new TaskSyncService({
         queue: queueB,
-        db: deviceB.db as any,
+        db: asClientDb(deviceB.db),
         getDeviceId: () => 'device-B'
       })
       deviceB.db.update(tasks).set({ title: 'Renamed Task' }).where(eq(tasks.id, 'task-1')).run()
@@ -331,7 +336,7 @@ describe('task sync gap fixes — E2E', () => {
 
       // Apply B's change to A
       const payloadFromB = JSON.parse(queueB.peek(1)[0].payload) as Record<string, unknown>
-      const applierA = new ItemApplier(deviceA.db as any, vi.fn())
+      const applierA = new ItemApplier(asSyncDb(deviceA.db), vi.fn())
       applyRemotePayload(applierA, 'task-1', payloadFromB)
 
       // #then Device A's tags are NOT wiped
@@ -362,7 +367,7 @@ describe('task sync gap fixes — E2E', () => {
       // #when enqueue via TaskSyncService (the real enqueue path)
       const serviceA = new TaskSyncService({
         queue: queueA,
-        db: deviceA.db as any,
+        db: asClientDb(deviceA.db),
         getDeviceId: () => 'device-A'
       })
       serviceA.enqueueUpdate('task-1', ['title'])
@@ -375,7 +380,7 @@ describe('task sync gap fixes — E2E', () => {
       expect(payload.linkedNoteIds).toEqual([])
 
       // And remote device can consume it
-      const applierB = new ItemApplier(deviceB.db as any, vi.fn())
+      const applierB = new ItemApplier(asSyncDb(deviceB.db), vi.fn())
       const result = applyRemotePayload(applierB, 'task-1', payload)
       expect(result).toBe('applied')
       expect(getTagsFor(deviceB, 'task-1')).toEqual(['p0', 'release'])


### PR DESCRIPTION
Closes Phase 1 §1.9 of `.claude/plans/tech-debt-remediation.md`.

## Summary
Audit of `: any` / `as any` across `apps/desktop/src/main/crypto/**` and `apps/desktop/src/main/sync/**`. Crypto production code was already clean (0 hits). This PR removes 17+ `as any` uses in sync test files by introducing typed test helpers.

## Changes
- `dirty-recovery.test.ts` — `let db: any` → `let db: DataDb`, use `asClientDb()` helper.
- `apply-item.test.ts` — `queue: null as any` → real `SyncQueueManager` (cleaner than a null stub).
- `task-sync-gaps-e2e.test.ts` — 14 hits of `deviceX.db as any` → typed `asClientDb()` + `asSyncDb()` helpers.
- `item-handlers/folder-config-handler.test.ts` — `mockQueue as any` (×2) → `Pick<SyncQueueManager, 'enqueue'>` + `makeMockQueue()` helper.
- `item-handlers/settings-handler.test.ts` — `db: {} as any` → `db: {} as unknown as DrizzleDb`; removed invalid `deviceId` field, replaced with proper `emit: vi.fn()`.

## Verification (run locally by agent)
- `grep -rn ": any\|as any" apps/desktop/src/main/crypto apps/desktop/src/main/sync` → **0 hits**
- `npx tsc -p apps/desktop/tsconfig.node.json --noEmit` — no errors
- `npx tsc -p apps/desktop/tsconfig.web.json --noEmit` — no errors
- `vitest run` on affected files → **59/59 passing**
- `vitest run` on full `src/main/sync` → **627/627 passing** across 52 files

## Test plan
- [x] typecheck:node clean
- [x] typecheck:web clean
- [x] all sync tests passing
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)