### PR TITLE
chore(crypto): add Phase 1 golden-vector fixture scaffolding

### DIFF
--- a/apps/desktop/src/main/crypto/__fixtures__/README.md
+++ b/apps/desktop/src/main/crypto/__fixtures__/README.md
@@ -1,0 +1,104 @@
+# Crypto Golden-Vector Fixtures
+
+RFC-derived test vectors used by `apps/desktop/src/main/crypto` to prove
+that our libsodium wrappers and any future cross-implementation code agree
+with the canonical specifications.
+
+These fixtures are inputs to tests, not runtime code. They are intentionally
+imported eagerly so that the typed loader (`load-vectors.ts`) catches shape
+drift the moment a vector file is edited.
+
+## Files
+
+| File | Algorithm | Source |
+| --- | --- | --- |
+| `xchacha20-rfc8439.ts` | XChaCha20-Poly1305 (IETF) | [draft-irtf-cfrg-xchacha-03 §A.3.1](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha-03#appendix-A.3.1) |
+| `ed25519-rfc8032.ts` | Ed25519 (pure) | [RFC 8032 §7.1](https://datatracker.ietf.org/doc/html/rfc8032#section-7.1) |
+| `argon2id-rfc9106.ts` | Argon2id | [RFC 9106 §5.3](https://datatracker.ietf.org/doc/html/rfc9106#section-5.3) |
+| `load-vectors.ts` | typed loader + shape assertions | — |
+
+All vector files were captured on **2026-04-16**. The retrieval date is also
+recorded in each file header and on each exported vector constant.
+
+## Vector shape
+
+Every vector exports a typed constant with the following invariants enforced
+at import time by `assert*Vector` helpers in `load-vectors.ts`:
+
+- All cryptographic material is a `Uint8Array` (never a hex string at the
+  consumer boundary — the file uses `hexToBytes` only as an internal helper).
+- Length-bound fields (keys, nonces, signatures, tags) carry their expected
+  length on the type and are validated.
+- Each vector carries `name`, `source` (RFC reference), and `retrievedAt`.
+
+## Tamper sentinels
+
+Each vector file reserves a `// SHA-256:` line next to its expected-output
+literal. The line is intentionally left empty in this scaffolding commit so
+no stale value can mask a later silent edit; the first consuming test run
+should compute and pin the value via the recipe below.
+
+```bash
+# from apps/desktop, run inside a vitest test or one-off `tsx` script —
+# direct `node --input-type=module -e` cannot resolve the .ts import.
+
+pnpm exec tsx -e '
+  import { createHash } from "node:crypto"
+  import { XCHACHA20_RFC8439_DRAFT_VECTOR } from "./src/main/crypto/__fixtures__/xchacha20-rfc8439"
+  const v = XCHACHA20_RFC8439_DRAFT_VECTOR
+  const buf = Buffer.concat([Buffer.from(v.ciphertext), Buffer.from(v.tag)])
+  console.log(createHash("sha256").update(buf).digest("hex"))
+'
+```
+
+Substitute the vector import + concatenated bytes as appropriate:
+
+| Vector file | Bytes to hash |
+| --- | --- |
+| `xchacha20-rfc8439.ts` | `ciphertext ‖ tag` |
+| `ed25519-rfc8032.ts` | `signature` |
+| `argon2id-rfc9106.ts` | `tag` |
+
+Once a sentinel is pinned, edits that change the literal will produce a hash
+mismatch the first time a consuming test re-runs the recipe, surfacing the
+tamper.
+
+## Re-fetching from the RFCs
+
+If the upstream vector ever needs to be re-verified:
+
+1. Open the source URL listed in the file header.
+2. Copy each hex blob *exactly* — keep groupings reproducible (we use
+   32-hex-char chunks so diffs stay local).
+3. Update the `retrievedAt` field on the vector constant **and** the
+   per-file header comment to match the day of re-fetch (ISO `YYYY-MM-DD`).
+4. Re-run the SHA-256 regeneration recipe above and update the comment
+   sentinel near the literal.
+5. Run `pnpm --filter desktop test --project main src/main/crypto/` to
+   confirm any consuming tests still pass.
+
+## Adding a new vector
+
+1. Create a new `<algorithm>-<source>.ts` file in this directory.
+2. Define a typed interface in `load-vectors.ts` and an `assert*Vector`
+   helper that enforces every length / structural invariant.
+3. Export the vector constant wrapped in the assert helper so corrupted
+   data fails at import time, not at first use.
+4. Document source URL, retrieval date, and any deviations from Memry's
+   runtime parameters (e.g., Argon2id parallelism mismatch).
+5. Update this README's table.
+
+## Memry runtime parameter deviations
+
+These vectors exercise the canonical RFC primitive. Memry's production
+parameters do not always match the RFC reference vector parameters:
+
+- **Argon2id**: RFC 9106 §5.3 uses parallelism = 4. libsodium's
+  `crypto_pwhash` hardcodes parallelism = 1, which is why
+  `packages/contracts/src/crypto.ts` documents p = 1 as our canonical
+  value. The RFC vector therefore validates the primitive
+  (cross-implementation tests via `@noble/hashes` or similar), not
+  Memry's `crypto_pwhash` instantiation.
+- **XChaCha20-Poly1305 / Ed25519**: no deviation — libsodium's
+  `crypto_aead_xchacha20poly1305_ietf_*` and `crypto_sign_*` directly match
+  the cited RFC / draft constructions.

--- a/apps/desktop/src/main/crypto/__fixtures__/argon2id-rfc9106.ts
+++ b/apps/desktop/src/main/crypto/__fixtures__/argon2id-rfc9106.ts
@@ -1,0 +1,62 @@
+// Argon2id golden vectors.
+//
+// Source: RFC 9106 §5.3 — Argon2id Test Vectors
+// URL:    https://datatracker.ietf.org/doc/html/rfc9106#section-5.3
+// Retrieved: 2026-04-16
+//
+// Parameter glossary (per RFC 9106 §3.1):
+//   - parallelism (p): degree of parallelism (number of lanes)
+//   - tagLength   (T): output length in bytes
+//   - memoryKiB   (m): memory size in kibibytes
+//   - iterations  (t): number of passes
+//   - version     (v): Argon2 version number — 0x13 (= 19) for current spec
+//
+// Memry's runtime instantiation differs (memory = 64 MiB, ops = 3,
+// parallelism = 1 because libsodium's crypto_pwhash hardcodes p=1). These
+// vectors validate the underlying primitive against the RFC reference; tests
+// that exercise libsodium's crypto_pwhash directly cannot reuse them without
+// matching p. Cross-implementation verification (e.g., via @noble/hashes
+// argon2id) is the recommended consumer.
+
+import { assertArgon2idVector, hexToBytes, type Argon2idVector } from './load-vectors'
+
+// Inputs per RFC 9106 §5.3:
+//   Password:        0x01 repeated 32 times
+//   Salt:            0x02 repeated 16 times
+//   Secret value:    0x03 repeated 8 times
+//   Associated data: 0x04 repeated 12 times
+//   parallelism = 4, tagLength = 32, memory = 32 KiB, iterations = 3,
+//   version = 0x13
+
+const PASSWORD_HEX = '01'.repeat(32)
+const SALT_HEX = '02'.repeat(16)
+const SECRET_HEX = '03'.repeat(8)
+const ASSOCIATED_DATA_HEX = '04'.repeat(12)
+
+// Expected output tag (32 bytes) per RFC 9106 §5.3 final hash.
+const TAG_HEX =
+  '0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659'
+
+// Tamper sentinel: SHA-256 of `hexToBytes(TAG_HEX)`. Pin via ./README.md →
+// "Tamper sentinels" recipe on first consumer test run.
+// SHA-256:
+
+export const ARGON2ID_RFC9106_VECTOR: Argon2idVector = assertArgon2idVector({
+  name: 'argon2id-rfc9106-section-5.3',
+  source: 'RFC 9106 §5.3',
+  retrievedAt: '2026-04-16',
+  password: hexToBytes(PASSWORD_HEX),
+  salt: hexToBytes(SALT_HEX),
+  secret: hexToBytes(SECRET_HEX),
+  associatedData: hexToBytes(ASSOCIATED_DATA_HEX),
+  parallelism: 4,
+  tagLength: 32,
+  memoryKiB: 32,
+  iterations: 3,
+  version: 0x13,
+  tag: hexToBytes(TAG_HEX)
+})
+
+export const ARGON2ID_RFC9106_VECTORS: readonly Argon2idVector[] = [
+  ARGON2ID_RFC9106_VECTOR
+]

--- a/apps/desktop/src/main/crypto/__fixtures__/ed25519-rfc8032.ts
+++ b/apps/desktop/src/main/crypto/__fixtures__/ed25519-rfc8032.ts
@@ -1,0 +1,77 @@
+// Ed25519 (Ed25519ph context = none) golden vectors.
+//
+// Source: RFC 8032 §7.1 — Test Vectors for Ed25519
+// URL:    https://datatracker.ietf.org/doc/html/rfc8032#section-7.1
+// Retrieved: 2026-04-16
+//
+// libsodium's crypto_sign_seed_keypair / crypto_sign_detached implement the
+// pure Ed25519 variant covered by these vectors. The 64-byte secret-key form
+// libsodium emits is `seed || publicKey`; we store the seed alone here so
+// signing tests can reconstruct the keypair via crypto_sign_seed_keypair.
+
+import { assertEd25519Vector, hexToBytes, type Ed25519Vector } from './load-vectors'
+
+// ---------------------------------------------------------------------------
+// TEST 1 — empty message
+// ---------------------------------------------------------------------------
+
+const TEST1_SEED_HEX =
+  '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60'
+
+const TEST1_PUBLIC_KEY_HEX =
+  'd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a'
+
+const TEST1_MESSAGE_HEX = ''
+
+const TEST1_SIGNATURE_HEX =
+  'e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e06522490155' +
+  '5fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b'
+
+// Tamper sentinel: SHA-256 of `hexToBytes(TEST1_SIGNATURE_HEX)`. Pin via
+// ./README.md → "Tamper sentinels" recipe on first consumer test run.
+// SHA-256:
+
+export const ED25519_RFC8032_TEST_1: Ed25519Vector = assertEd25519Vector({
+  name: 'ed25519-rfc8032-test-1-empty',
+  source: 'RFC 8032 §7.1 TEST 1',
+  retrievedAt: '2026-04-16',
+  secretKeySeed: hexToBytes(TEST1_SEED_HEX),
+  publicKey: hexToBytes(TEST1_PUBLIC_KEY_HEX),
+  message: hexToBytes(TEST1_MESSAGE_HEX),
+  signature: hexToBytes(TEST1_SIGNATURE_HEX)
+})
+
+// ---------------------------------------------------------------------------
+// TEST 2 — single-byte message 0x72
+// ---------------------------------------------------------------------------
+
+const TEST2_SEED_HEX =
+  '4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb'
+
+const TEST2_PUBLIC_KEY_HEX =
+  '3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c'
+
+const TEST2_MESSAGE_HEX = '72'
+
+const TEST2_SIGNATURE_HEX =
+  '92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da' +
+  '085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00'
+
+// Tamper sentinel: SHA-256 of `hexToBytes(TEST2_SIGNATURE_HEX)`. Pin via
+// ./README.md → "Tamper sentinels" recipe on first consumer test run.
+// SHA-256:
+
+export const ED25519_RFC8032_TEST_2: Ed25519Vector = assertEd25519Vector({
+  name: 'ed25519-rfc8032-test-2-single-byte',
+  source: 'RFC 8032 §7.1 TEST 2',
+  retrievedAt: '2026-04-16',
+  secretKeySeed: hexToBytes(TEST2_SEED_HEX),
+  publicKey: hexToBytes(TEST2_PUBLIC_KEY_HEX),
+  message: hexToBytes(TEST2_MESSAGE_HEX),
+  signature: hexToBytes(TEST2_SIGNATURE_HEX)
+})
+
+export const ED25519_RFC8032_VECTORS: readonly Ed25519Vector[] = [
+  ED25519_RFC8032_TEST_1,
+  ED25519_RFC8032_TEST_2
+]

--- a/apps/desktop/src/main/crypto/__fixtures__/load-vectors.ts
+++ b/apps/desktop/src/main/crypto/__fixtures__/load-vectors.ts
@@ -1,0 +1,124 @@
+// Golden-vector loader helpers for crypto fixtures.
+//
+// Each `assert*Vector` runs at module-import time so that corrupted or
+// accidentally-edited vectors fail fast at fixture load, not deep inside
+// crypto code. Provenance metadata (`name`, `source`, `retrievedAt`) lives
+// on every vector; SHA-256 sentinels for expected outputs are stored as
+// comments next to the literals (see ./README.md regen recipe).
+
+export interface XChaCha20Vector {
+  readonly name: string
+  readonly source: string
+  readonly retrievedAt: string
+  readonly key: Uint8Array
+  readonly nonce: Uint8Array
+  readonly aad: Uint8Array
+  readonly plaintext: Uint8Array
+  readonly ciphertext: Uint8Array
+  readonly tag: Uint8Array
+}
+
+export interface Ed25519Vector {
+  readonly name: string
+  readonly source: string
+  readonly retrievedAt: string
+  readonly secretKeySeed: Uint8Array
+  readonly publicKey: Uint8Array
+  readonly message: Uint8Array
+  readonly signature: Uint8Array
+}
+
+export interface Argon2idVector {
+  readonly name: string
+  readonly source: string
+  readonly retrievedAt: string
+  readonly password: Uint8Array
+  readonly salt: Uint8Array
+  readonly secret: Uint8Array
+  readonly associatedData: Uint8Array
+  readonly parallelism: number
+  readonly tagLength: number
+  readonly memoryKiB: number
+  readonly iterations: number
+  readonly version: number
+  readonly tag: Uint8Array
+}
+
+const failShape = (vectorName: string, fieldName: string, detail: string): never => {
+  throw new Error(
+    `Invalid vector "${vectorName}" — field "${fieldName}" failed shape check: ${detail}`
+  )
+}
+
+const requireBytes = (vectorName: string, fieldName: string, value: unknown): void => {
+  if (!(value instanceof Uint8Array)) {
+    failShape(vectorName, fieldName, 'expected Uint8Array')
+  }
+}
+
+const requireFixedBytes = (
+  vectorName: string,
+  fieldName: string,
+  value: unknown,
+  expectedLength: number
+): void => {
+  if (!(value instanceof Uint8Array) || value.length !== expectedLength) {
+    failShape(vectorName, fieldName, `expected ${expectedLength}-byte Uint8Array`)
+  }
+}
+
+const requirePositiveInt = (vectorName: string, fieldName: string, value: number): void => {
+  if (!Number.isInteger(value) || value <= 0) {
+    failShape(vectorName, fieldName, 'expected positive integer')
+  }
+}
+
+export const assertXChaCha20Vector = (vector: XChaCha20Vector): XChaCha20Vector => {
+  requireFixedBytes(vector.name, 'key', vector.key, 32)
+  requireFixedBytes(vector.name, 'nonce', vector.nonce, 24)
+  requireBytes(vector.name, 'aad', vector.aad)
+  requireBytes(vector.name, 'plaintext', vector.plaintext)
+  requireFixedBytes(vector.name, 'ciphertext', vector.ciphertext, vector.plaintext.length)
+  requireFixedBytes(vector.name, 'tag', vector.tag, 16)
+  return vector
+}
+
+export const assertEd25519Vector = (vector: Ed25519Vector): Ed25519Vector => {
+  requireFixedBytes(vector.name, 'secretKeySeed', vector.secretKeySeed, 32)
+  requireFixedBytes(vector.name, 'publicKey', vector.publicKey, 32)
+  requireBytes(vector.name, 'message', vector.message)
+  requireFixedBytes(vector.name, 'signature', vector.signature, 64)
+  return vector
+}
+
+export const assertArgon2idVector = (vector: Argon2idVector): Argon2idVector => {
+  requireBytes(vector.name, 'password', vector.password)
+  requireBytes(vector.name, 'salt', vector.salt)
+  requireBytes(vector.name, 'secret', vector.secret)
+  requireBytes(vector.name, 'associatedData', vector.associatedData)
+  requirePositiveInt(vector.name, 'parallelism', vector.parallelism)
+  requirePositiveInt(vector.name, 'tagLength', vector.tagLength)
+  requirePositiveInt(vector.name, 'memoryKiB', vector.memoryKiB)
+  requirePositiveInt(vector.name, 'iterations', vector.iterations)
+  requirePositiveInt(vector.name, 'version', vector.version)
+  requireFixedBytes(vector.name, 'tag', vector.tag, vector.tagLength)
+  return vector
+}
+
+// Vector files invoke `hexToBytes` at module-evaluation time, before any
+// `await sodium.ready` has had a chance to run. We therefore avoid
+// libsodium's `from_hex` here so fixtures stay synchronously importable.
+export const hexToBytes = (hex: string): Uint8Array => {
+  const stripped = hex.replace(/\s+/g, '')
+  if (stripped.length % 2 !== 0) {
+    throw new Error(`hexToBytes: odd-length input (${stripped.length} chars)`)
+  }
+  if (!/^[0-9a-f]*$/i.test(stripped)) {
+    throw new Error('hexToBytes: input contains non-hex characters')
+  }
+  const out = new Uint8Array(stripped.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(stripped.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}

--- a/apps/desktop/src/main/crypto/__fixtures__/xchacha20-rfc8439.ts
+++ b/apps/desktop/src/main/crypto/__fixtures__/xchacha20-rfc8439.ts
@@ -1,0 +1,64 @@
+// XChaCha20-Poly1305 golden vectors.
+//
+// Source: draft-irtf-cfrg-xchacha-03 §A.3.1 (XChaCha20-Poly1305 AEAD)
+// URL:    https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha-03#appendix-A.3.1
+// Retrieved: 2026-04-16
+//
+// The IETF Poly1305 construction used here is the same one referenced by
+// RFC 8439 §2.8 — XChaCha20 extends the nonce to 24 bytes via HChaCha20.
+// libsodium exposes this exact construction as
+// crypto_aead_xchacha20poly1305_ietf_encrypt / _decrypt.
+//
+// Tag identity: the AEAD output concatenates ciphertext || tag(16). The split
+// below stores them separately so tests can assert each half independently.
+
+import { assertXChaCha20Vector, hexToBytes, type XChaCha20Vector } from './load-vectors'
+
+// Plaintext: ASCII "Ladies and Gentlemen of the class of '99: If I could offer
+// you only one tip for the future, sunscreen would be it." (114 bytes)
+const PLAINTEXT_HEX =
+  '4c616469657320616e642047656e746c656d656e206f662074686520636c6173' +
+  '73206f66202739393a204966204920636f756c64206f6666657220796f75206f' +
+  '6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73' +
+  '637265656e20776f756c642062652069742e'
+
+// AAD: 50 51 52 53 c0 c1 c2 c3 c4 c5 c6 c7
+const AAD_HEX = '50515253c0c1c2c3c4c5c6c7'
+
+// Key: 80 81 82 ... 9f (32 bytes, monotonically increasing)
+const KEY_HEX = '808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f'
+
+// Nonce: 40 41 42 ... 57 (24 bytes, monotonically increasing)
+const NONCE_HEX = '404142434445464748494a4b4c4d4e4f5051525354555657'
+
+// Ciphertext (114 bytes) and Poly1305 tag (16 bytes) per the draft's
+// "Resulting ciphertext" section.
+const CIPHERTEXT_HEX =
+  'bd6d179d3e83d43b9576579493c0e939572a1700252bfaccbed2902c21396cbb' +
+  '731c7f1b0b4aa6440bf3a82f4eda7e39ae64c6708c54c216cb96b72e1213b452' +
+  '2f8c9ba40db5d945b11b69b982c1bb9e3f3fac2bc369488f76b2383565d3fff9' +
+  '21f9664c97637da9768812f615c68b13b52e'
+
+const TAG_HEX = 'c0875924c1c7987947deafd8780acf49'
+
+// Tamper sentinel: SHA-256 of `hexToBytes(CIPHERTEXT_HEX + TAG_HEX)`.
+// Pin the value on first consumer test run via ./README.md → "Tamper
+// sentinels" recipe; until then this comment intentionally stays empty so a
+// stale hash never silently masks a real edit.
+// SHA-256:
+
+export const XCHACHA20_RFC8439_DRAFT_VECTOR: XChaCha20Vector = assertXChaCha20Vector({
+  name: 'xchacha20-poly1305-ietf-draft-A.3.1',
+  source: 'draft-irtf-cfrg-xchacha-03 §A.3.1',
+  retrievedAt: '2026-04-16',
+  key: hexToBytes(KEY_HEX),
+  nonce: hexToBytes(NONCE_HEX),
+  aad: hexToBytes(AAD_HEX),
+  plaintext: hexToBytes(PLAINTEXT_HEX),
+  ciphertext: hexToBytes(CIPHERTEXT_HEX),
+  tag: hexToBytes(TAG_HEX)
+})
+
+export const XCHACHA20_RFC8439_VECTORS: readonly XChaCha20Vector[] = [
+  XCHACHA20_RFC8439_DRAFT_VECTOR
+]


### PR DESCRIPTION
Closes Phase 1 §1.1 of `.claude/plans/tech-debt-remediation.md`.

## Summary
Seeds `apps/desktop/src/main/crypto/__fixtures__/` with RFC-derived test vectors + a typed loader for Phase 1 crypto tests.

## Files
- `load-vectors.ts` — `XChaCha20Vector` / `Ed25519Vector` / `Argon2idVector` interfaces + `assert*Vector` shape-check helpers + sync `hexToBytes` (no `sodium.ready` dep).
- `xchacha20-rfc8439.ts` — `draft-irtf-cfrg-xchacha-03 §A.3.1` canonical AEAD vector (114-byte plaintext, ciphertext + Poly1305 tag separate).
- `ed25519-rfc8032.ts` — RFC 8032 §7.1 TEST 1 (empty message) + TEST 2 (single byte 0x72). 32-byte seeds; libsodium reconstructs 64-byte SK via `crypto_sign_seed_keypair`.
- `argon2id-rfc9106.ts` — RFC 9106 §5.3 reference (p=4, T=32, m=32 KiB, t=3, v=0x13). README documents Memry-vs-RFC parallelism deviation.
- `README.md` — file table, source URLs, vector-shape contract, regen recipe.

## Test plan
- [ ] `pnpm typecheck:node` passes
- [ ] `pnpm lint` passes
- [ ] Subsequent Phase 1 test PRs consume these fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)