### PR TITLE
test(crypto): expand encryption coverage with golden vectors + boundary cases

### DIFF
--- a/apps/desktop/src/main/crypto/__fixtures__/encryption-extras.ts
+++ b/apps/desktop/src/main/crypto/__fixtures__/encryption-extras.ts
@@ -1,0 +1,53 @@
+/**
+ * Self-contained fixtures for encryption.test.ts boundary + golden cases.
+ *
+ * IETF golden vector source: draft-irtf-cfrg-xchacha-03, Appendix A.3.1
+ *   https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha-03#appendix-A.3.1
+ *
+ * The vector pins XChaCha20-Poly1305-IETF AEAD output for a known
+ * (key, nonce, AAD, plaintext) tuple. Any drift in libsodium's primitive
+ * or our parameter wiring (nonce length, key length, AEAD variant) will
+ * cause the deterministic ciphertext assertion to fail.
+ */
+
+const fromHex = (hex: string): Uint8Array => {
+  const stripped = hex.replace(/\s+/g, '')
+  if (stripped.length % 2 !== 0) {
+    throw new Error(`Hex string must have even length, got ${stripped.length}`)
+  }
+  const bytes = new Uint8Array(stripped.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(stripped.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+export const IETF_XCHACHA20_POLY1305_VECTOR = {
+  key: fromHex(
+    '808182838485868788898a8b8c8d8e8f' + '909192939495969798999a9b9c9d9e9f'
+  ),
+  nonce: fromHex('404142434445464748494a4b4c4d4e4f5051525354555657'),
+  aad: fromHex('50515253c0c1c2c3c4c5c6c7'),
+  plaintext: fromHex(
+    '4c616469657320616e642047656e746c656d656e206f662074686520636c6173' +
+      '73206f66202739393a204966204920636f756c64206f6666657220796f75206f' +
+      '6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73' +
+      '637265656e20776f756c642062652069742e'
+  ),
+  ciphertext: fromHex(
+    'bd6d179d3e83d43b9576579493c0e939572a1700252bfaccbed2902c21396cbb' +
+      '731c7f1b0b4aa6440bf3a82f4eda7e39ae64c6708c54c216cb96b72e1213b452' +
+      '2f8c9ba40db5d945b11b69b982c1bb9e3f3fac2bc369488f76b2383565d3fff9' +
+      '21f9664c97637da9768812f615c68b13b52e' + 'c0875924c1c7987947deafd8780acf49'
+  )
+} as const
+
+export const ONE_MIB_PLUS_ONE = 1024 * 1024 + 1
+
+export const buildPatternedPayload = (length: number): Uint8Array => {
+  const buffer = new Uint8Array(length)
+  for (let i = 0; i < length; i++) {
+    buffer[i] = (i * 31 + 7) & 0xff
+  }
+  return buffer
+}

--- a/apps/desktop/src/main/crypto/encryption.test.ts
+++ b/apps/desktop/src/main/crypto/encryption.test.ts
@@ -13,6 +13,11 @@ import {
   unwrapFileKey,
   wrapFileKey
 } from './encryption'
+import {
+  IETF_XCHACHA20_POLY1305_VECTOR,
+  ONE_MIB_PLUS_ONE,
+  buildPatternedPayload
+} from './__fixtures__/encryption-extras'
 
 beforeAll(async () => {
   await sodium.ready
@@ -263,6 +268,162 @@ describe('encryption', () => {
     expectCryptoError(
       () => decrypt(ciphertext, shortNonce, validKey),
       'INVALID_NONCE_LENGTH'
+    )
+  })
+
+  it('matches the IETF XChaCha20-Poly1305 golden vector for decrypt', () => {
+    // #given the canonical draft-irtf-cfrg-xchacha-03 §A.3.1 vector
+    const { key, nonce, aad, plaintext, ciphertext } = IETF_XCHACHA20_POLY1305_VECTOR
+
+    // #when the pinned ciphertext is decrypted with the canonical inputs
+    const recovered = decrypt(ciphertext, nonce, key, aad)
+
+    // #then the recovered plaintext matches the canonical plaintext byte-for-byte
+    expect(recovered).toEqual(plaintext)
+  })
+
+  it('produces deterministic ciphertext bytes when re-encrypted under the IETF golden vector', () => {
+    // #given the canonical key/nonce/AAD/plaintext from the IETF vector
+    const { key, nonce, aad, plaintext, ciphertext } = IETF_XCHACHA20_POLY1305_VECTOR
+
+    // #when sodium re-runs the AEAD with the pinned nonce (bypassing generateNonce)
+    const produced = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(
+      plaintext,
+      aad,
+      null,
+      nonce,
+      key
+    )
+
+    // #then the bytes match the published vector exactly (catches AEAD param drift)
+    expect(produced).toEqual(ciphertext)
+  })
+
+  it('fails when AAD is omitted on decrypt but supplied on encrypt', () => {
+    // #given a payload encrypted with associated data
+    const key = makeKey()
+    const plaintext = encoder.encode('aad-required')
+    const associatedData = encoder.encode('mandatory-aad')
+    const { ciphertext, nonce } = encrypt(plaintext, key, associatedData)
+
+    // #when decrypt is called without AAD
+    // #then authentication fails with DECRYPTION_FAILED
+    expectCryptoError(
+      () => decrypt(ciphertext, nonce, key),
+      'DECRYPTION_FAILED',
+      /Ciphertext authentication failed:/
+    )
+  })
+
+  it('fails when AAD is supplied on decrypt but omitted on encrypt', () => {
+    // #given a payload encrypted without associated data
+    const key = makeKey()
+    const plaintext = encoder.encode('aad-not-bound')
+    const { ciphertext, nonce } = encrypt(plaintext, key)
+
+    // #when decrypt is called with non-empty AAD
+    // #then authentication fails with DECRYPTION_FAILED
+    expectCryptoError(
+      () => decrypt(ciphertext, nonce, key, encoder.encode('unexpected-aad')),
+      'DECRYPTION_FAILED',
+      /Ciphertext authentication failed:/
+    )
+  })
+
+  it('round-trips an empty Uint8Array via encrypt/decrypt', () => {
+    // #given a zero-length plaintext
+    const key = makeKey()
+    const plaintext = new Uint8Array(0)
+
+    // #when the empty payload round-trips
+    const { ciphertext, nonce } = encrypt(plaintext, key)
+    const recovered = decrypt(ciphertext, nonce, key)
+
+    // #then the result is empty and the ciphertext carries only the auth tag
+    expect(recovered).toHaveLength(0)
+    expect(recovered).toEqual(plaintext)
+    expect(ciphertext).toHaveLength(XCHACHA20_PARAMS.TAG_LENGTH)
+  })
+
+  it('round-trips a 1 MiB + 1 byte payload across the R2 chunk boundary', () => {
+    // #given a payload one byte over the canonical 1 MiB threshold
+    const key = makeKey()
+    const plaintext = buildPatternedPayload(ONE_MIB_PLUS_ONE)
+    const associatedData = encoder.encode('r2-chunk-boundary-plus-one')
+
+    // #when the boundary-sized payload round-trips with AAD bound
+    const { ciphertext, nonce } = encrypt(plaintext, key, associatedData)
+    const recovered = decrypt(ciphertext, nonce, key, associatedData)
+
+    // #then every byte survives and the ciphertext carries plaintext + auth tag
+    expect(recovered).toHaveLength(ONE_MIB_PLUS_ONE)
+    expect(recovered).toEqual(plaintext)
+    expect(ciphertext.length).toBe(plaintext.length + XCHACHA20_PARAMS.TAG_LENGTH)
+  })
+
+  it('rejects unwrapping a file key with the wrong vault key', () => {
+    // #given a file key wrapped under vault key A
+    const vaultKeyA = makeKey()
+    const vaultKeyB = makeKey()
+    const fileKey = sodium.randombytes_buf(XCHACHA20_PARAMS.KEY_LENGTH)
+    const { wrappedKey, nonce } = wrapFileKey(fileKey, vaultKeyA)
+
+    // #when unwrap is attempted with vault key B
+    // #then authentication fails (no silent recovery, no plaintext leak)
+    expectCryptoError(
+      () => unwrapFileKey(wrappedKey, nonce, vaultKeyB),
+      'DECRYPTION_FAILED',
+      /Ciphertext authentication failed:/
+    )
+  })
+
+  it('rejects unwrapping a tampered wrapped file key', () => {
+    // #given a file key wrapped under a vault key, then bit-flipped
+    const vaultKey = makeKey()
+    const fileKey = sodium.randombytes_buf(XCHACHA20_PARAMS.KEY_LENGTH)
+    const { wrappedKey, nonce } = wrapFileKey(fileKey, vaultKey)
+    const tampered = new Uint8Array(wrappedKey)
+    tampered[tampered.length - 1] ^= 0x01
+
+    // #when unwrap is attempted on the tampered wrapped key
+    // #then the auth tag check fails
+    expectCryptoError(
+      () => unwrapFileKey(tampered, nonce, vaultKey),
+      'DECRYPTION_FAILED',
+      /Ciphertext authentication failed:/
+    )
+  })
+
+  it('detects tampering on the master-key linking ciphertext', () => {
+    // #given a master key encrypted for device linking
+    const encKey = makeKey()
+    const masterKey = sodium.randombytes_buf(XCHACHA20_PARAMS.KEY_LENGTH)
+    const { ciphertext, nonce } = encryptMasterKeyForLinking(masterKey, encKey)
+    const tampered = new Uint8Array(ciphertext)
+    tampered[0] ^= 0xff
+
+    // #when decryption is attempted on the tampered ciphertext
+    // #then DECRYPTION_FAILED is raised — server-injected master keys cannot pass
+    expectCryptoError(
+      () => decryptMasterKeyFromLinking(tampered, nonce, encKey),
+      'DECRYPTION_FAILED',
+      /Ciphertext authentication failed:/
+    )
+  })
+
+  it('rejects master-key linking decryption with the wrong ephemeral key', () => {
+    // #given a master key encrypted under ephemeral key A
+    const encKeyA = makeKey()
+    const encKeyB = makeKey()
+    const masterKey = sodium.randombytes_buf(XCHACHA20_PARAMS.KEY_LENGTH)
+    const { ciphertext, nonce } = encryptMasterKeyForLinking(masterKey, encKeyA)
+
+    // #when decryption is attempted with ephemeral key B
+    // #then the channel rejects the wrong recipient
+    expectCryptoError(
+      () => decryptMasterKeyFromLinking(ciphertext, nonce, encKeyB),
+      'DECRYPTION_FAILED',
+      /Ciphertext authentication failed:/
     )
   })
 })


### PR DESCRIPTION
Closes Phase 1 §1.2 of `.claude/plans/tech-debt-remediation.md`.

## Summary
Adds 10 tests to `encryption.test.ts` targeting 95% per-file coverage on `encryption.ts`, including the IETF XChaCha20-Poly1305 golden vector (both decrypt + bit-exact re-encrypt) so any AEAD parameter drift trips the suite.

## New tests
1. IETF XChaCha20-Poly1305 golden-vector **decrypt** (draft-irtf-cfrg-xchacha-03 §A.3.1)
2. IETF golden-vector **deterministic re-encrypt** — byte-for-byte ciphertext match via direct `crypto_aead_xchacha20poly1305_ietf_encrypt`
3. AAD omitted on decrypt but supplied on encrypt → fails
4. AAD supplied on decrypt but omitted on encrypt → fails
5. Zero-length payload roundtrip; ciphertext exactly `TAG_LENGTH` bytes
6. 1 MiB + 1-byte payload (R2 chunk boundary)
7. `wrapFileKey(A)` + `unwrapFileKey(B)` → `DECRYPTION_FAILED`
8. Tampered wrapped file key → `DECRYPTION_FAILED`
9. Master-key linking ciphertext tamper → `DECRYPTION_FAILED`
10. Wrong ephemeral key on linking decrypt → fails

## Files
- `encryption.test.ts` — +161 lines, 10 new `it()` cases
- `__fixtures__/encryption-extras.ts` — new self-contained vector file (IETF §A.3.1)

## Test plan
- [ ] `pnpm --filter desktop test --project main src/main/crypto/encryption.test.ts` — 0 failures
- [ ] per-file coverage on `encryption.ts` ≥ 95% stmts/branches/lines/functions
- [ ] `pnpm typecheck:node && pnpm typecheck:web` clean
- [ ] `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)