### PR TITLE
test(contracts): add domain APIs schema coverage

### DIFF
--- a/packages/contracts/src/ai-inline-channels.test.ts
+++ b/packages/contracts/src/ai-inline-channels.test.ts
@@ -1,0 +1,87 @@
+/**
+ * AI Inline Channels Contract Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  AIInlineChannels,
+  AI_INLINE_SETTINGS_DEFAULTS,
+  type AIInlineInvokeChannel,
+  type AIInlineEventChannel,
+  type AIInlineSettings
+} from './ai-inline-channels'
+
+describe('AIInlineChannels.invoke', () => {
+  it('exposes the expected invoke channels', () => {
+    expect(AIInlineChannels.invoke).toEqual({
+      GET_SETTINGS: 'ai-inline:get-settings',
+      SET_SETTINGS: 'ai-inline:set-settings',
+      GET_SERVER_PORT: 'ai-inline:get-server-port',
+      START_SERVER: 'ai-inline:start-server',
+      STOP_SERVER: 'ai-inline:stop-server'
+    })
+  })
+
+  it('all invoke channel ids share the ai-inline: prefix', () => {
+    for (const channel of Object.values(AIInlineChannels.invoke)) {
+      expect(channel.startsWith('ai-inline:')).toBe(true)
+    }
+  })
+
+  it('type-checks every invoke channel', () => {
+    const channels: AIInlineInvokeChannel[] = [
+      AIInlineChannels.invoke.GET_SETTINGS,
+      AIInlineChannels.invoke.SET_SETTINGS,
+      AIInlineChannels.invoke.GET_SERVER_PORT,
+      AIInlineChannels.invoke.START_SERVER,
+      AIInlineChannels.invoke.STOP_SERVER
+    ]
+    expect(channels).toHaveLength(5)
+  })
+})
+
+describe('AIInlineChannels.events', () => {
+  it('exposes the expected event channels', () => {
+    expect(AIInlineChannels.events).toEqual({
+      SERVER_READY: 'ai-inline:server-ready',
+      SERVER_ERROR: 'ai-inline:server-error'
+    })
+  })
+
+  it('type-checks every event channel', () => {
+    const events: AIInlineEventChannel[] = [
+      AIInlineChannels.events.SERVER_READY,
+      AIInlineChannels.events.SERVER_ERROR
+    ]
+    expect(events).toHaveLength(2)
+  })
+})
+
+describe('AI_INLINE_SETTINGS_DEFAULTS', () => {
+  it('matches the expected defaults', () => {
+    expect(AI_INLINE_SETTINGS_DEFAULTS).toEqual({
+      enabled: true,
+      provider: 'ollama',
+      model: 'llama3.2',
+      apiKey: '',
+      baseUrl: 'http://localhost:11434/v1'
+    })
+  })
+
+  it('conforms to AIInlineSettings type', () => {
+    const settings: AIInlineSettings = AI_INLINE_SETTINGS_DEFAULTS
+    expect(settings.provider).toBe('ollama')
+    expect(typeof settings.enabled).toBe('boolean')
+    expect(typeof settings.model).toBe('string')
+    expect(typeof settings.apiKey).toBe('string')
+    expect(typeof settings.baseUrl).toBe('string')
+  })
+
+  it('allows all supported providers', () => {
+    const providers: AIInlineSettings['provider'][] = ['ollama', 'openai', 'anthropic']
+    for (const provider of providers) {
+      const settings: AIInlineSettings = { ...AI_INLINE_SETTINGS_DEFAULTS, provider }
+      expect(settings.provider).toBe(provider)
+    }
+  })
+})

--- a/packages/contracts/src/bookmark-types.test.ts
+++ b/packages/contracts/src/bookmark-types.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Bookmark Types Contract Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import { BookmarkItemTypes, type BookmarkItemType } from './bookmark-types'
+
+describe('BookmarkItemTypes', () => {
+  it('exposes the expected key/value map', () => {
+    expect(BookmarkItemTypes).toEqual({
+      NOTE: 'note',
+      JOURNAL: 'journal',
+      TASK: 'task',
+      IMAGE: 'image',
+      PDF: 'pdf',
+      AUDIO: 'audio',
+      VIDEO: 'video',
+      CANVAS: 'canvas',
+      FILE: 'file'
+    })
+  })
+
+  it('type-checks all values', () => {
+    const values: BookmarkItemType[] = [
+      BookmarkItemTypes.NOTE,
+      BookmarkItemTypes.JOURNAL,
+      BookmarkItemTypes.TASK,
+      BookmarkItemTypes.IMAGE,
+      BookmarkItemTypes.PDF,
+      BookmarkItemTypes.AUDIO,
+      BookmarkItemTypes.VIDEO,
+      BookmarkItemTypes.CANVAS,
+      BookmarkItemTypes.FILE
+    ]
+    expect(values).toHaveLength(9)
+  })
+
+  it('values are unique lowercase strings', () => {
+    const values = Object.values(BookmarkItemTypes)
+    const uniqueValues = new Set(values)
+    expect(uniqueValues.size).toBe(values.length)
+    for (const v of values) {
+      expect(v).toBe(v.toLowerCase())
+    }
+  })
+})

--- a/packages/contracts/src/calendar-api.test.ts
+++ b/packages/contracts/src/calendar-api.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Calendar API Contract Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  CalendarSourceKindSchema,
+  CalendarSourceSyncStatusSchema,
+  CalendarProjectionSourceTypeSchema,
+  CalendarProjectionVisualTypeSchema,
+  CalendarChangeEntityTypeSchema,
+  CreateCalendarEventSchema,
+  UpdateCalendarEventSchema,
+  ListCalendarEventsSchema,
+  GetCalendarRangeSchema,
+  ListCalendarSourcesSchema,
+  UpdateCalendarSourceSelectionSchema,
+  CalendarProviderRequestSchema
+} from './calendar-api'
+
+describe('CalendarSourceKindSchema', () => {
+  it('accepts valid kinds', () => {
+    expect(CalendarSourceKindSchema.safeParse('account').success).toBe(true)
+    expect(CalendarSourceKindSchema.safeParse('calendar').success).toBe(true)
+  })
+
+  it('rejects invalid kind', () => {
+    const result = CalendarSourceKindSchema.safeParse('other')
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('CalendarSourceSyncStatusSchema', () => {
+  it('accepts valid statuses', () => {
+    for (const v of ['idle', 'ok', 'error', 'pending']) {
+      expect(CalendarSourceSyncStatusSchema.safeParse(v).success).toBe(true)
+    }
+  })
+
+  it('rejects invalid status', () => {
+    expect(CalendarSourceSyncStatusSchema.safeParse('running').success).toBe(false)
+  })
+})
+
+describe('CalendarProjectionSourceTypeSchema', () => {
+  it('accepts valid source types', () => {
+    for (const v of ['event', 'task', 'reminder', 'inbox_snooze', 'external_event']) {
+      expect(CalendarProjectionSourceTypeSchema.safeParse(v).success).toBe(true)
+    }
+  })
+
+  it('rejects invalid source type', () => {
+    expect(CalendarProjectionSourceTypeSchema.safeParse('note').success).toBe(false)
+  })
+})
+
+describe('CalendarProjectionVisualTypeSchema', () => {
+  it('accepts valid visual types', () => {
+    for (const v of ['event', 'task', 'reminder', 'snooze', 'external_event']) {
+      expect(CalendarProjectionVisualTypeSchema.safeParse(v).success).toBe(true)
+    }
+  })
+
+  it('rejects invalid visual type', () => {
+    expect(CalendarProjectionVisualTypeSchema.safeParse('inbox_snooze').success).toBe(false)
+  })
+})
+
+describe('CalendarChangeEntityTypeSchema', () => {
+  it('accepts valid entity types', () => {
+    for (const v of [
+      'calendar_event',
+      'calendar_source',
+      'calendar_binding',
+      'calendar_external_event',
+      'projection'
+    ]) {
+      expect(CalendarChangeEntityTypeSchema.safeParse(v).success).toBe(true)
+    }
+  })
+
+  it('rejects invalid entity type', () => {
+    expect(CalendarChangeEntityTypeSchema.safeParse('note').success).toBe(false)
+  })
+})
+
+describe('CreateCalendarEventSchema', () => {
+  it('accepts minimal valid input with defaults', () => {
+    const result = CreateCalendarEventSchema.safeParse({
+      title: 'Team Sync',
+      startAt: '2026-04-16T10:00:00Z'
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.timezone).toBe('UTC')
+      expect(result.data.isAllDay).toBe(false)
+    }
+  })
+
+  it('accepts full valid input', () => {
+    const result = CreateCalendarEventSchema.safeParse({
+      title: 'Team Sync',
+      description: 'Weekly sync',
+      location: 'Zoom',
+      startAt: '2026-04-16T10:00:00Z',
+      endAt: '2026-04-16T11:00:00Z',
+      timezone: 'America/New_York',
+      isAllDay: false,
+      recurrenceRule: { freq: 'WEEKLY' },
+      recurrenceExceptions: [{ date: '2026-04-23' }]
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts null description/location/endAt', () => {
+    const result = CreateCalendarEventSchema.safeParse({
+      title: 'Solo',
+      startAt: '2026-04-16T10:00:00Z',
+      description: null,
+      location: null,
+      endAt: null,
+      recurrenceRule: null,
+      recurrenceExceptions: null
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty title', () => {
+    const result = CreateCalendarEventSchema.safeParse({
+      title: '',
+      startAt: '2026-04-16T10:00:00Z'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('title')
+    }
+  })
+
+  it('rejects title over 200 chars', () => {
+    const result = CreateCalendarEventSchema.safeParse({
+      title: 'x'.repeat(201),
+      startAt: '2026-04-16T10:00:00Z'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects description over 5000 chars', () => {
+    const result = CreateCalendarEventSchema.safeParse({
+      title: 'Test',
+      startAt: '2026-04-16T10:00:00Z',
+      description: 'x'.repeat(5001)
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects location over 500 chars', () => {
+    const result = CreateCalendarEventSchema.safeParse({
+      title: 'Test',
+      startAt: '2026-04-16T10:00:00Z',
+      location: 'x'.repeat(501)
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid startAt (not ISO datetime)', () => {
+    const result = CreateCalendarEventSchema.safeParse({
+      title: 'Test',
+      startAt: '2026-04-16'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('startAt')
+    }
+  })
+
+  it('rejects empty timezone', () => {
+    const result = CreateCalendarEventSchema.safeParse({
+      title: 'Test',
+      startAt: '2026-04-16T10:00:00Z',
+      timezone: ''
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing title', () => {
+    const result = CreateCalendarEventSchema.safeParse({
+      startAt: '2026-04-16T10:00:00Z'
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('UpdateCalendarEventSchema', () => {
+  it('accepts minimal input with only id', () => {
+    const result = UpdateCalendarEventSchema.safeParse({ id: 'evt-1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts full update', () => {
+    const result = UpdateCalendarEventSchema.safeParse({
+      id: 'evt-1',
+      title: 'Updated',
+      description: 'new',
+      location: 'new place',
+      startAt: '2026-04-16T12:00:00Z',
+      endAt: '2026-04-16T13:00:00Z',
+      timezone: 'UTC',
+      isAllDay: true,
+      recurrenceRule: { freq: 'DAILY' },
+      recurrenceExceptions: []
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty id', () => {
+    const result = UpdateCalendarEventSchema.safeParse({ id: '' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('id')
+    }
+  })
+
+  it('rejects missing id', () => {
+    const result = UpdateCalendarEventSchema.safeParse({ title: 'x' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid datetime on endAt', () => {
+    const result = UpdateCalendarEventSchema.safeParse({
+      id: 'evt-1',
+      endAt: 'not-a-date'
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('ListCalendarEventsSchema', () => {
+  it('accepts empty object with defaults', () => {
+    const result = ListCalendarEventsSchema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.includeArchived).toBe(false)
+    }
+  })
+
+  it('accepts includeArchived: true', () => {
+    const result = ListCalendarEventsSchema.safeParse({ includeArchived: true })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects non-boolean includeArchived', () => {
+    const result = ListCalendarEventsSchema.safeParse({ includeArchived: 'yes' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('GetCalendarRangeSchema', () => {
+  it('accepts minimal valid input', () => {
+    const result = GetCalendarRangeSchema.safeParse({
+      startAt: '2026-04-01T00:00:00Z',
+      endAt: '2026-04-30T23:59:59Z'
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.includeUnselectedSources).toBe(false)
+    }
+  })
+
+  it('accepts includeUnselectedSources', () => {
+    const result = GetCalendarRangeSchema.safeParse({
+      startAt: '2026-04-01T00:00:00Z',
+      endAt: '2026-04-30T23:59:59Z',
+      includeUnselectedSources: true
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing startAt', () => {
+    const result = GetCalendarRangeSchema.safeParse({ endAt: '2026-04-30T23:59:59Z' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid endAt', () => {
+    const result = GetCalendarRangeSchema.safeParse({
+      startAt: '2026-04-01T00:00:00Z',
+      endAt: '2026-04-30'
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('ListCalendarSourcesSchema', () => {
+  it('accepts empty object', () => {
+    const result = ListCalendarSourcesSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts full filter', () => {
+    const result = ListCalendarSourcesSchema.safeParse({
+      provider: 'google',
+      kind: 'calendar',
+      selectedOnly: true
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty provider', () => {
+    const result = ListCalendarSourcesSchema.safeParse({ provider: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid kind', () => {
+    const result = ListCalendarSourcesSchema.safeParse({ kind: 'group' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('UpdateCalendarSourceSelectionSchema', () => {
+  it('accepts valid input', () => {
+    const result = UpdateCalendarSourceSelectionSchema.safeParse({
+      id: 'src-1',
+      isSelected: true
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty id', () => {
+    const result = UpdateCalendarSourceSelectionSchema.safeParse({
+      id: '',
+      isSelected: true
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('id')
+    }
+  })
+
+  it('rejects missing isSelected', () => {
+    const result = UpdateCalendarSourceSelectionSchema.safeParse({ id: 'src-1' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('CalendarProviderRequestSchema', () => {
+  it('accepts valid provider', () => {
+    const result = CalendarProviderRequestSchema.safeParse({ provider: 'google' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty provider', () => {
+    const result = CalendarProviderRequestSchema.safeParse({ provider: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing provider', () => {
+    const result = CalendarProviderRequestSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/contracts/src/graph-api.test.ts
+++ b/packages/contracts/src/graph-api.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Graph API Contract Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  GraphNodeSchema,
+  GraphEdgeSchema,
+  GraphDataResponseSchema,
+  LocalGraphRequestSchema,
+  GraphSettingsSchema,
+  GRAPH_SETTINGS_DEFAULTS
+} from './graph-api'
+
+describe('GraphNodeSchema', () => {
+  it('accepts minimal valid input', () => {
+    const result = GraphNodeSchema.safeParse({
+      id: 'n1',
+      type: 'note',
+      label: 'My Note',
+      tags: [],
+      wordCount: 0,
+      connectionCount: 0,
+      emoji: null,
+      color: '#fff',
+      isOrphan: false,
+      isUnresolved: false
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts all valid node types', () => {
+    for (const type of ['note', 'task', 'journal', 'project']) {
+      const result = GraphNodeSchema.safeParse({
+        id: 'n1',
+        type,
+        label: 'L',
+        tags: [],
+        wordCount: 0,
+        connectionCount: 0,
+        emoji: null,
+        color: '#fff',
+        isOrphan: false,
+        isUnresolved: false
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('accepts emoji string or null', () => {
+    const withEmoji = GraphNodeSchema.safeParse({
+      id: 'n1',
+      type: 'note',
+      label: 'L',
+      tags: ['t'],
+      wordCount: 10,
+      connectionCount: 2,
+      emoji: '📝',
+      color: '#ff0',
+      isOrphan: true,
+      isUnresolved: false
+    })
+    expect(withEmoji.success).toBe(true)
+  })
+
+  it('rejects invalid type', () => {
+    const result = GraphNodeSchema.safeParse({
+      id: 'n1',
+      type: 'folder',
+      label: 'L',
+      tags: [],
+      wordCount: 0,
+      connectionCount: 0,
+      emoji: null,
+      color: '#fff',
+      isOrphan: false,
+      isUnresolved: false
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('type')
+    }
+  })
+
+  it('rejects empty id', () => {
+    const result = GraphNodeSchema.safeParse({
+      id: '',
+      type: 'note',
+      label: 'L',
+      tags: [],
+      wordCount: 0,
+      connectionCount: 0,
+      emoji: null,
+      color: '#fff',
+      isOrphan: false,
+      isUnresolved: false
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects negative wordCount', () => {
+    const result = GraphNodeSchema.safeParse({
+      id: 'n1',
+      type: 'note',
+      label: 'L',
+      tags: [],
+      wordCount: -1,
+      connectionCount: 0,
+      emoji: null,
+      color: '#fff',
+      isOrphan: false,
+      isUnresolved: false
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-integer connectionCount', () => {
+    const result = GraphNodeSchema.safeParse({
+      id: 'n1',
+      type: 'note',
+      label: 'L',
+      tags: [],
+      wordCount: 0,
+      connectionCount: 1.5,
+      emoji: null,
+      color: '#fff',
+      isOrphan: false,
+      isUnresolved: false
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('GraphEdgeSchema', () => {
+  it('accepts minimal valid input with default weight', () => {
+    const result = GraphEdgeSchema.safeParse({
+      id: 'e1',
+      source: 'a',
+      target: 'b',
+      type: 'wikilink'
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.weight).toBe(1)
+    }
+  })
+
+  it('accepts all valid edge types', () => {
+    for (const type of ['wikilink', 'task-note', 'project-task', 'tag-cooccurrence']) {
+      const result = GraphEdgeSchema.safeParse({
+        id: 'e1',
+        source: 'a',
+        target: 'b',
+        type,
+        weight: 2
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects invalid edge type', () => {
+    const result = GraphEdgeSchema.safeParse({
+      id: 'e1',
+      source: 'a',
+      target: 'b',
+      type: 'bogus'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('type')
+    }
+  })
+
+  it('rejects empty source', () => {
+    const result = GraphEdgeSchema.safeParse({
+      id: 'e1',
+      source: '',
+      target: 'b',
+      type: 'wikilink'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty target', () => {
+    const result = GraphEdgeSchema.safeParse({
+      id: 'e1',
+      source: 'a',
+      target: '',
+      type: 'wikilink'
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('GraphDataResponseSchema', () => {
+  it('accepts empty graph', () => {
+    const result = GraphDataResponseSchema.safeParse({ nodes: [], edges: [] })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts populated graph', () => {
+    const result = GraphDataResponseSchema.safeParse({
+      nodes: [
+        {
+          id: 'n1',
+          type: 'note',
+          label: 'L',
+          tags: [],
+          wordCount: 0,
+          connectionCount: 0,
+          emoji: null,
+          color: '#fff',
+          isOrphan: false,
+          isUnresolved: false
+        }
+      ],
+      edges: [{ id: 'e1', source: 'n1', target: 'n2', type: 'wikilink', weight: 1 }]
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing edges', () => {
+    const result = GraphDataResponseSchema.safeParse({ nodes: [] })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('LocalGraphRequestSchema', () => {
+  it('accepts minimal input with default depth', () => {
+    const result = LocalGraphRequestSchema.safeParse({ noteId: 'n1' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.depth).toBe(2)
+    }
+  })
+
+  it('accepts depth at boundaries (1 and 3)', () => {
+    expect(LocalGraphRequestSchema.safeParse({ noteId: 'n1', depth: 1 }).success).toBe(true)
+    expect(LocalGraphRequestSchema.safeParse({ noteId: 'n1', depth: 3 }).success).toBe(true)
+  })
+
+  it('rejects depth below 1', () => {
+    const result = LocalGraphRequestSchema.safeParse({ noteId: 'n1', depth: 0 })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('depth')
+    }
+  })
+
+  it('rejects depth above 3', () => {
+    const result = LocalGraphRequestSchema.safeParse({ noteId: 'n1', depth: 4 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-integer depth', () => {
+    const result = LocalGraphRequestSchema.safeParse({ noteId: 'n1', depth: 2.5 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty noteId', () => {
+    const result = LocalGraphRequestSchema.safeParse({ noteId: '' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('GraphSettingsSchema', () => {
+  it('accepts all valid layouts', () => {
+    for (const layout of ['forceatlas2', 'circular', 'random']) {
+      const result = GraphSettingsSchema.safeParse({
+        layout,
+        showLabels: true,
+        showEdgeLabels: false,
+        animateLayout: false,
+        showTagEdges: true
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects invalid layout', () => {
+    const result = GraphSettingsSchema.safeParse({
+      layout: 'grid',
+      showLabels: false,
+      showEdgeLabels: false,
+      animateLayout: false,
+      showTagEdges: false
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('layout')
+    }
+  })
+
+  it('rejects missing boolean field', () => {
+    const result = GraphSettingsSchema.safeParse({
+      layout: 'forceatlas2',
+      showLabels: true,
+      showEdgeLabels: false,
+      animateLayout: false
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('GRAPH_SETTINGS_DEFAULTS matches schema', () => {
+    const result = GraphSettingsSchema.safeParse(GRAPH_SETTINGS_DEFAULTS)
+    expect(result.success).toBe(true)
+  })
+})

--- a/packages/contracts/src/linking-api.test.ts
+++ b/packages/contracts/src/linking-api.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Linking API Contract Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  InitiateLinkingRequestSchema,
+  ScanLinkingRequestSchema,
+  ApproveLinkingRequestSchema,
+  CompleteLinkingRequestSchema,
+  InitiateLinkingResponseSchema,
+  ScanLinkingResponseSchema,
+  ApproveLinkingResponseSchema,
+  CompleteLinkingResponseSchema,
+  LINKING_SESSION_STATUSES
+} from './linking-api'
+
+describe('LINKING_SESSION_STATUSES', () => {
+  it('exposes the expected statuses', () => {
+    expect(LINKING_SESSION_STATUSES).toEqual([
+      'pending',
+      'scanned',
+      'approved',
+      'completed',
+      'expired'
+    ])
+  })
+})
+
+describe('InitiateLinkingRequestSchema', () => {
+  it('accepts valid input', () => {
+    const result = InitiateLinkingRequestSchema.safeParse({
+      ephemeralPublicKey: 'pub-abc'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty ephemeralPublicKey', () => {
+    const result = InitiateLinkingRequestSchema.safeParse({ ephemeralPublicKey: '' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('ephemeralPublicKey')
+    }
+  })
+
+  it('rejects missing ephemeralPublicKey', () => {
+    const result = InitiateLinkingRequestSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('ScanLinkingRequestSchema', () => {
+  const validInput = {
+    sessionId: 's1',
+    newDevicePublicKey: 'np',
+    newDeviceConfirm: 'nc',
+    linkingSecret: 'ls',
+    scanConfirm: 'sc',
+    scanProof: 'sp'
+  }
+
+  it('accepts valid input', () => {
+    const result = ScanLinkingRequestSchema.safeParse(validInput)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty sessionId', () => {
+    const result = ScanLinkingRequestSchema.safeParse({ ...validInput, sessionId: '' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('sessionId')
+    }
+  })
+
+  it('rejects missing newDevicePublicKey', () => {
+    const { newDevicePublicKey, ...rest } = validInput
+    void newDevicePublicKey
+    const result = ScanLinkingRequestSchema.safeParse(rest)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty linkingSecret', () => {
+    const result = ScanLinkingRequestSchema.safeParse({ ...validInput, linkingSecret: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty scanProof', () => {
+    const result = ScanLinkingRequestSchema.safeParse({ ...validInput, scanProof: '' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('ApproveLinkingRequestSchema', () => {
+  it('accepts valid input', () => {
+    const result = ApproveLinkingRequestSchema.safeParse({
+      sessionId: 's1',
+      encryptedMasterKey: 'emk',
+      encryptedKeyNonce: 'ekn',
+      keyConfirm: 'kc'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty encryptedMasterKey', () => {
+    const result = ApproveLinkingRequestSchema.safeParse({
+      sessionId: 's1',
+      encryptedMasterKey: '',
+      encryptedKeyNonce: 'ekn',
+      keyConfirm: 'kc'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('encryptedMasterKey')
+    }
+  })
+
+  it('rejects missing keyConfirm', () => {
+    const result = ApproveLinkingRequestSchema.safeParse({
+      sessionId: 's1',
+      encryptedMasterKey: 'emk',
+      encryptedKeyNonce: 'ekn'
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('CompleteLinkingRequestSchema', () => {
+  it('accepts valid input', () => {
+    const result = CompleteLinkingRequestSchema.safeParse({ sessionId: 's1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty sessionId', () => {
+    const result = CompleteLinkingRequestSchema.safeParse({ sessionId: '' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('InitiateLinkingResponseSchema', () => {
+  it('accepts valid response', () => {
+    const result = InitiateLinkingResponseSchema.safeParse({
+      sessionId: 's1',
+      expiresAt: 1744800000,
+      linkingSecret: 'ls'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects non-number expiresAt', () => {
+    const result = InitiateLinkingResponseSchema.safeParse({
+      sessionId: 's1',
+      expiresAt: '2026-04-16',
+      linkingSecret: 'ls'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('expiresAt')
+    }
+  })
+})
+
+describe('ScanLinkingResponseSchema', () => {
+  it('accepts success only', () => {
+    expect(ScanLinkingResponseSchema.safeParse({ success: true }).success).toBe(true)
+  })
+
+  it('accepts success + valid status', () => {
+    const result = ScanLinkingResponseSchema.safeParse({ success: true, status: 'scanned' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid status', () => {
+    const result = ScanLinkingResponseSchema.safeParse({ success: true, status: 'busy' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('ApproveLinkingResponseSchema', () => {
+  it('accepts success only', () => {
+    expect(ApproveLinkingResponseSchema.safeParse({ success: false }).success).toBe(true)
+  })
+
+  it('accepts success + status', () => {
+    const result = ApproveLinkingResponseSchema.safeParse({ success: true, status: 'approved' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing success', () => {
+    const result = ApproveLinkingResponseSchema.safeParse({ status: 'approved' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('CompleteLinkingResponseSchema', () => {
+  it('accepts minimal response', () => {
+    expect(CompleteLinkingResponseSchema.safeParse({ success: true }).success).toBe(true)
+  })
+
+  it('accepts full response', () => {
+    const result = CompleteLinkingResponseSchema.safeParse({
+      success: true,
+      encryptedMasterKey: 'emk',
+      encryptedKeyNonce: 'ekn',
+      keyConfirm: 'kc'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects non-boolean success', () => {
+    const result = CompleteLinkingResponseSchema.safeParse({ success: 'yes' })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/contracts/src/properties-api.test.ts
+++ b/packages/contracts/src/properties-api.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Properties API Contract Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  GetPropertiesSchema,
+  SetPropertiesSchema,
+  RenamePropertySchema,
+  PropertyTypes
+} from './properties-api'
+
+describe('GetPropertiesSchema', () => {
+  it('accepts valid input', () => {
+    const result = GetPropertiesSchema.safeParse({ entityId: 'note-1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty entityId', () => {
+    const result = GetPropertiesSchema.safeParse({ entityId: '' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('entityId')
+    }
+  })
+
+  it('rejects missing entityId', () => {
+    const result = GetPropertiesSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('SetPropertiesSchema', () => {
+  it('accepts valid input with empty properties', () => {
+    const result = SetPropertiesSchema.safeParse({
+      entityId: 'note-1',
+      properties: {}
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts mixed unknown property values', () => {
+    const result = SetPropertiesSchema.safeParse({
+      entityId: 'note-1',
+      properties: {
+        status: 'Done',
+        count: 3,
+        tags: ['a', 'b'],
+        flag: true,
+        note: null
+      }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty entityId', () => {
+    const result = SetPropertiesSchema.safeParse({
+      entityId: '',
+      properties: {}
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing properties', () => {
+    const result = SetPropertiesSchema.safeParse({ entityId: 'note-1' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-object properties', () => {
+    const result = SetPropertiesSchema.safeParse({
+      entityId: 'note-1',
+      properties: 'invalid'
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('RenamePropertySchema', () => {
+  it('accepts valid input', () => {
+    const result = RenamePropertySchema.safeParse({
+      entityId: 'note-1',
+      oldName: 'status',
+      newName: 'state'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty oldName', () => {
+    const result = RenamePropertySchema.safeParse({
+      entityId: 'note-1',
+      oldName: '',
+      newName: 'state'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('oldName')
+    }
+  })
+
+  it('rejects empty newName', () => {
+    const result = RenamePropertySchema.safeParse({
+      entityId: 'note-1',
+      oldName: 'status',
+      newName: ''
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing entityId', () => {
+    const result = RenamePropertySchema.safeParse({
+      oldName: 'status',
+      newName: 'state'
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('PropertyTypes re-export', () => {
+  it('exposes all expected property types', () => {
+    expect(PropertyTypes.TEXT).toBe('text')
+    expect(PropertyTypes.NUMBER).toBe('number')
+    expect(PropertyTypes.CHECKBOX).toBe('checkbox')
+    expect(PropertyTypes.DATE).toBe('date')
+    expect(PropertyTypes.URL).toBe('url')
+    expect(PropertyTypes.STATUS).toBe('status')
+    expect(PropertyTypes.SELECT).toBe('select')
+    expect(PropertyTypes.MULTISELECT).toBe('multiselect')
+  })
+})

--- a/packages/contracts/src/property-types.test.ts
+++ b/packages/contracts/src/property-types.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Property Types Contract Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  PropertyTypes,
+  STATUS_CATEGORY_KEYS,
+  DEFAULT_STATUS_DEFINITION,
+  PropertyDefinitionSchema,
+  PropertyDefinitionsFileSchema
+} from './property-types'
+
+describe('PropertyTypes', () => {
+  it('exposes all property type constants', () => {
+    expect(PropertyTypes).toEqual({
+      TEXT: 'text',
+      NUMBER: 'number',
+      CHECKBOX: 'checkbox',
+      DATE: 'date',
+      URL: 'url',
+      STATUS: 'status',
+      SELECT: 'select',
+      MULTISELECT: 'multiselect'
+    })
+  })
+})
+
+describe('STATUS_CATEGORY_KEYS', () => {
+  it('exposes the expected category keys', () => {
+    expect(STATUS_CATEGORY_KEYS).toEqual(['todo', 'in_progress', 'done'])
+  })
+})
+
+describe('DEFAULT_STATUS_DEFINITION', () => {
+  it('is a valid status property definition', () => {
+    const result = PropertyDefinitionSchema.safeParse({
+      type: DEFAULT_STATUS_DEFINITION.type,
+      categories: DEFAULT_STATUS_DEFINITION.categories
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('has canonical default option marked in todo category', () => {
+    const todoOption = DEFAULT_STATUS_DEFINITION.categories?.todo.options[0]
+    expect(todoOption?.default).toBe(true)
+    expect(todoOption?.value).toBe('Not started')
+  })
+})
+
+describe('PropertyDefinitionSchema (discriminated union)', () => {
+  it('accepts status variant', () => {
+    const result = PropertyDefinitionSchema.safeParse({
+      type: 'status',
+      categories: {
+        todo: { label: 'To-do', options: [{ value: 'Not started', color: 'stone' }] },
+        in_progress: { label: 'In progress', options: [{ value: 'Active', color: 'amber' }] },
+        done: { label: 'Done', options: [{ value: 'Complete', color: 'emerald' }] }
+      }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts select variant', () => {
+    const result = PropertyDefinitionSchema.safeParse({
+      type: 'select',
+      options: [
+        { value: 'Low', color: 'slate' },
+        { value: 'High', color: 'red', default: true }
+      ]
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts multiselect variant with empty options', () => {
+    const result = PropertyDefinitionSchema.safeParse({
+      type: 'multiselect',
+      options: []
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects status variant missing a category', () => {
+    const result = PropertyDefinitionSchema.safeParse({
+      type: 'status',
+      categories: {
+        todo: { label: 'To-do', options: [] },
+        done: { label: 'Done', options: [] }
+      }
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects select variant missing options', () => {
+    const result = PropertyDefinitionSchema.safeParse({ type: 'select' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unknown variant type', () => {
+    const result = PropertyDefinitionSchema.safeParse({ type: 'text', options: [] })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('type')
+    }
+  })
+
+  it('rejects select option with empty value', () => {
+    const result = PropertyDefinitionSchema.safeParse({
+      type: 'select',
+      options: [{ value: '', color: 'red' }]
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects select option with empty color', () => {
+    const result = PropertyDefinitionSchema.safeParse({
+      type: 'select',
+      options: [{ value: 'Low', color: '' }]
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects status category with empty label', () => {
+    const result = PropertyDefinitionSchema.safeParse({
+      type: 'status',
+      categories: {
+        todo: { label: '', options: [] },
+        in_progress: { label: 'In progress', options: [] },
+        done: { label: 'Done', options: [] }
+      }
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('PropertyDefinitionsFileSchema', () => {
+  it('accepts empty file with default properties', () => {
+    const result = PropertyDefinitionsFileSchema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.properties).toEqual({})
+    }
+  })
+
+  it('accepts file with named select property', () => {
+    const result = PropertyDefinitionsFileSchema.safeParse({
+      properties: {
+        priority: {
+          type: 'select',
+          options: [{ value: 'High', color: 'red' }]
+        }
+      }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects file with invalid property definition', () => {
+    const result = PropertyDefinitionsFileSchema.safeParse({
+      properties: {
+        priority: { type: 'bogus' }
+      }
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/contracts/src/reminder-types.test.ts
+++ b/packages/contracts/src/reminder-types.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Reminder Types Contract Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  reminderTargetType,
+  reminderStatus,
+  type ReminderTargetType,
+  type ReminderStatus
+} from './reminder-types'
+
+describe('reminderTargetType', () => {
+  it('exposes the expected target types', () => {
+    expect(reminderTargetType).toEqual({
+      NOTE: 'note',
+      JOURNAL: 'journal',
+      HIGHLIGHT: 'highlight'
+    })
+  })
+
+  it('type-checks all target values', () => {
+    const values: ReminderTargetType[] = [
+      reminderTargetType.NOTE,
+      reminderTargetType.JOURNAL,
+      reminderTargetType.HIGHLIGHT
+    ]
+    expect(values).toHaveLength(3)
+  })
+})
+
+describe('reminderStatus', () => {
+  it('exposes the expected statuses', () => {
+    expect(reminderStatus).toEqual({
+      PENDING: 'pending',
+      TRIGGERED: 'triggered',
+      DISMISSED: 'dismissed',
+      SNOOZED: 'snoozed'
+    })
+  })
+
+  it('type-checks all status values', () => {
+    const values: ReminderStatus[] = [
+      reminderStatus.PENDING,
+      reminderStatus.TRIGGERED,
+      reminderStatus.DISMISSED,
+      reminderStatus.SNOOZED
+    ]
+    expect(values).toHaveLength(4)
+  })
+
+  it('values are unique lowercase strings', () => {
+    const values = Object.values(reminderStatus)
+    expect(new Set(values).size).toBe(values.length)
+    for (const v of values) {
+      expect(v).toBe(v.toLowerCase())
+    }
+  })
+})

--- a/packages/contracts/src/search-api.test.ts
+++ b/packages/contracts/src/search-api.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Search API Contract Tests
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  ContentTypeEnum,
+  DateRangeSchema,
+  SearchQuerySchema,
+  AddReasonSchema
+} from './search-api'
+
+describe('ContentTypeEnum', () => {
+  it('accepts all valid content types', () => {
+    for (const t of ['note', 'journal', 'task', 'inbox']) {
+      expect(ContentTypeEnum.safeParse(t).success).toBe(true)
+    }
+  })
+
+  it('rejects invalid content type', () => {
+    expect(ContentTypeEnum.safeParse('file').success).toBe(false)
+  })
+})
+
+describe('DateRangeSchema', () => {
+  it('accepts valid range', () => {
+    const result = DateRangeSchema.safeParse({ from: '2026-04-01', to: '2026-04-30' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing to', () => {
+    const result = DateRangeSchema.safeParse({ from: '2026-04-01' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('to')
+    }
+  })
+
+  it('rejects non-string from', () => {
+    const result = DateRangeSchema.safeParse({ from: 20260401, to: '2026-04-30' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('SearchQuerySchema', () => {
+  it('accepts minimal input with defaults', () => {
+    const result = SearchQuerySchema.safeParse({ text: 'meeting' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.types).toEqual([])
+      expect(result.data.tags).toEqual([])
+      expect(result.data.dateRange).toBeNull()
+      expect(result.data.projectId).toBeNull()
+      expect(result.data.folderPath).toBeNull()
+      expect(result.data.limit).toBe(10)
+      expect(result.data.offset).toBe(0)
+    }
+  })
+
+  it('accepts full query', () => {
+    const result = SearchQuerySchema.safeParse({
+      text: 'meeting',
+      types: ['note', 'task'],
+      tags: ['work'],
+      dateRange: { from: '2026-04-01', to: '2026-04-30' },
+      projectId: 'proj-1',
+      folderPath: '/notes',
+      limit: 50,
+      offset: 20
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts empty text (no min)', () => {
+    const result = SearchQuerySchema.safeParse({ text: '' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects text over 500 chars', () => {
+    const result = SearchQuerySchema.safeParse({ text: 'x'.repeat(501) })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('text')
+    }
+  })
+
+  it('accepts text at 500 char boundary', () => {
+    const result = SearchQuerySchema.safeParse({ text: 'x'.repeat(500) })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid content type in types array', () => {
+    const result = SearchQuerySchema.safeParse({ text: 'q', types: ['bogus'] })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects limit below 1', () => {
+    const result = SearchQuerySchema.safeParse({ text: 'q', limit: 0 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects limit above 100', () => {
+    const result = SearchQuerySchema.safeParse({ text: 'q', limit: 101 })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts limit at boundaries', () => {
+    expect(SearchQuerySchema.safeParse({ text: 'q', limit: 1 }).success).toBe(true)
+    expect(SearchQuerySchema.safeParse({ text: 'q', limit: 100 }).success).toBe(true)
+  })
+
+  it('rejects negative offset', () => {
+    const result = SearchQuerySchema.safeParse({ text: 'q', offset: -1 })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts explicit null dateRange', () => {
+    const result = SearchQuerySchema.safeParse({ text: 'q', dateRange: null })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid dateRange shape', () => {
+    const result = SearchQuerySchema.safeParse({
+      text: 'q',
+      dateRange: { from: '2026-04-01' }
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('AddReasonSchema', () => {
+  it('accepts minimal valid input with default icon null', () => {
+    const result = AddReasonSchema.safeParse({
+      itemId: 'i1',
+      itemType: 'note',
+      itemTitle: 'Note',
+      searchQuery: 'q'
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.itemIcon).toBeNull()
+    }
+  })
+
+  it('accepts itemIcon string', () => {
+    const result = AddReasonSchema.safeParse({
+      itemId: 'i1',
+      itemType: 'task',
+      itemTitle: 'T',
+      itemIcon: '📝',
+      searchQuery: 'q'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty itemId', () => {
+    const result = AddReasonSchema.safeParse({
+      itemId: '',
+      itemType: 'note',
+      itemTitle: 'Note',
+      searchQuery: 'q'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('itemId')
+    }
+  })
+
+  it('rejects invalid itemType', () => {
+    const result = AddReasonSchema.safeParse({
+      itemId: 'i1',
+      itemType: 'file',
+      itemTitle: 'Note',
+      searchQuery: 'q'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty searchQuery', () => {
+    const result = AddReasonSchema.safeParse({
+      itemId: 'i1',
+      itemType: 'note',
+      itemTitle: 'Note',
+      searchQuery: ''
+    })
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
Phase 4 U6 — adds Zod schema validation tests for 9 previously-untested contracts files:
- calendar-api, graph-api, linking-api, search-api, properties-api
- bookmark-types, reminder-types, property-types, ai-inline-channels

Tests use safeParse to exercise valid + invalid inputs per schema.

## Test plan
- [x] 9 test files created, all under 800-line pre-commit limit
- [ ] CI: `pnpm --dir apps/desktop test:coverage` green

Ref: [.claude/plans/tech-debt-remediation.md](.claude/plans/tech-debt-remediation.md) Phase 4.4