### PR TITLE
test(contracts): add settings + plumbing schema coverage

### DIFF
--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Contracts Barrel Smoke Test
+ *
+ * The contracts package exposes its surface through subpath imports, so the
+ * root index.ts is intentionally near-empty to avoid duplicate symbol exports
+ * across independently named modules. This test pins that design by:
+ *  - loading the barrel module without side-effects
+ *  - asserting it remains importable and does not add unexpected exports
+ */
+
+import { describe, it, expect } from 'vitest'
+import * as contracts from './index'
+
+describe('contracts barrel', () => {
+  it('loads without error', () => {
+    expect(contracts).toBeDefined()
+    expect(typeof contracts).toBe('object')
+  })
+
+  it('exposes no named exports (subpath imports are the public API)', () => {
+    const keys = Object.keys(contracts).filter((key) => key !== 'default')
+    expect(keys).toEqual([])
+  })
+})

--- a/packages/contracts/src/ipc-channels.test.ts
+++ b/packages/contracts/src/ipc-channels.test.ts
@@ -1,0 +1,225 @@
+/**
+ * IPC Channels Contract Tests
+ *
+ * Validates channel name constants and structural invariants:
+ *  - each channel value is a non-empty string
+ *  - every channel uses its namespace prefix (e.g. "vault:*")
+ *  - no duplicate channel strings across all channel groups
+ *  - well-known entries are present on the exported objects
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  VaultChannels,
+  NotesChannels,
+  TagsChannels,
+  TasksChannels,
+  SavedFiltersChannels,
+  TemplatesChannels,
+  PropertiesChannels,
+  JournalChannels,
+  SettingsChannels,
+  AccountChannels,
+  DataChannels,
+  BookmarksChannels,
+  InboxChannels,
+  CalendarChannels,
+  ReminderChannels,
+  SearchChannels,
+  FolderViewChannels,
+  GraphChannels
+} from './ipc-channels'
+
+type ChannelGroup = {
+  readonly invoke?: Readonly<Record<string, string>>
+  readonly events?: Readonly<Record<string, string>>
+  readonly sync?: Readonly<Record<string, string>>
+}
+
+const ALL_GROUPS: Array<readonly [string, ChannelGroup]> = [
+  ['VaultChannels', VaultChannels],
+  ['NotesChannels', NotesChannels],
+  ['TagsChannels', TagsChannels],
+  ['TasksChannels', TasksChannels],
+  ['SavedFiltersChannels', SavedFiltersChannels],
+  ['TemplatesChannels', TemplatesChannels],
+  ['PropertiesChannels', PropertiesChannels],
+  ['JournalChannels', JournalChannels],
+  ['SettingsChannels', SettingsChannels],
+  ['AccountChannels', AccountChannels],
+  ['DataChannels', DataChannels],
+  ['BookmarksChannels', BookmarksChannels],
+  ['InboxChannels', InboxChannels],
+  ['CalendarChannels', CalendarChannels],
+  ['ReminderChannels', ReminderChannels],
+  ['SearchChannels', SearchChannels],
+  ['FolderViewChannels', FolderViewChannels],
+  ['GraphChannels', GraphChannels]
+]
+
+const GROUP_PREFIXES: Record<string, string> = {
+  VaultChannels: 'vault:',
+  NotesChannels: 'notes:',
+  TagsChannels: 'tags:',
+  TasksChannels: 'tasks:',
+  SavedFiltersChannels: 'saved-filters:',
+  TemplatesChannels: 'templates:',
+  PropertiesChannels: 'properties:',
+  JournalChannels: 'journal:',
+  SettingsChannels: 'settings:',
+  AccountChannels: 'account:',
+  DataChannels: 'data:',
+  BookmarksChannels: 'bookmarks:',
+  InboxChannels: 'inbox:',
+  CalendarChannels: 'calendar:',
+  ReminderChannels: 'reminder:',
+  SearchChannels: 'search:',
+  FolderViewChannels: 'folder-view:',
+  GraphChannels: 'graph:'
+}
+
+function collectChannels(group: ChannelGroup): string[] {
+  const values: string[] = []
+  for (const bucket of [group.invoke, group.events, group.sync]) {
+    if (!bucket) continue
+    for (const value of Object.values(bucket)) {
+      values.push(value)
+    }
+  }
+  return values
+}
+
+describe('IPC channel constants', () => {
+  it.each(ALL_GROUPS)('%s has at least one channel', (_name, group) => {
+    const channels = collectChannels(group)
+    expect(channels.length).toBeGreaterThan(0)
+  })
+
+  it.each(ALL_GROUPS)('%s entries are non-empty strings', (_name, group) => {
+    for (const channel of collectChannels(group)) {
+      expect(typeof channel).toBe('string')
+      expect(channel.length).toBeGreaterThan(0)
+    }
+  })
+
+  it.each(ALL_GROUPS)('%s entries use their namespace prefix', (name, group) => {
+    const prefix = GROUP_PREFIXES[name]
+    for (const channel of collectChannels(group)) {
+      expect(channel.startsWith(prefix)).toBe(true)
+    }
+  })
+
+  it('has no duplicate channel strings across groups', () => {
+    const seen = new Map<string, string>()
+    const duplicates: Array<{ channel: string; firstGroup: string; secondGroup: string }> = []
+    for (const [name, group] of ALL_GROUPS) {
+      for (const channel of collectChannels(group)) {
+        const existing = seen.get(channel)
+        if (existing && existing !== name) {
+          duplicates.push({ channel, firstGroup: existing, secondGroup: name })
+        } else {
+          seen.set(channel, name)
+        }
+      }
+    }
+    expect(duplicates).toEqual([])
+  })
+})
+
+describe('VaultChannels', () => {
+  it('exposes expected invoke channels', () => {
+    expect(VaultChannels.invoke.SELECT).toBe('vault:select')
+    expect(VaultChannels.invoke.CREATE).toBe('vault:create')
+    expect(VaultChannels.invoke.REVEAL).toBe('vault:reveal')
+  })
+
+  it('exposes expected event channels', () => {
+    expect(VaultChannels.events.STATUS_CHANGED).toBe('vault:status-changed')
+    expect(VaultChannels.events.ERROR).toBe('vault:error')
+  })
+})
+
+describe('NotesChannels', () => {
+  it('exposes CRUD invoke channels', () => {
+    expect(NotesChannels.invoke.CREATE).toBe('notes:create')
+    expect(NotesChannels.invoke.UPDATE).toBe('notes:update')
+    expect(NotesChannels.invoke.DELETE).toBe('notes:delete')
+    expect(NotesChannels.invoke.LIST).toBe('notes:list')
+  })
+
+  it('exposes expected event channels', () => {
+    expect(NotesChannels.events.CREATED).toBe('notes:created')
+    expect(NotesChannels.events.UPDATED).toBe('notes:updated')
+    expect(NotesChannels.events.DELETED).toBe('notes:deleted')
+  })
+})
+
+describe('TasksChannels', () => {
+  it('exposes task + project + status channels', () => {
+    expect(TasksChannels.invoke.CREATE).toBe('tasks:create')
+    expect(TasksChannels.invoke.PROJECT_CREATE).toBe('tasks:project-create')
+    expect(TasksChannels.invoke.STATUS_CREATE).toBe('tasks:status-create')
+  })
+
+  it('exposes bulk operation channels', () => {
+    expect(TasksChannels.invoke.BULK_COMPLETE).toBe('tasks:bulk-complete')
+    expect(TasksChannels.invoke.BULK_DELETE).toBe('tasks:bulk-delete')
+    expect(TasksChannels.invoke.BULK_MOVE).toBe('tasks:bulk-move')
+  })
+})
+
+describe('SettingsChannels', () => {
+  it('exposes invoke, sync, and events buckets', () => {
+    expect(SettingsChannels.invoke.GET).toBe('settings:get')
+    expect(SettingsChannels.sync.GET_STARTUP_THEME).toBe('settings:getStartupThemeSync')
+    expect(SettingsChannels.events.CHANGED).toBe('settings:changed')
+  })
+
+  it('exposes per-group getters + setters', () => {
+    expect(SettingsChannels.invoke.GET_GENERAL_SETTINGS).toBe('settings:getGeneralSettings')
+    expect(SettingsChannels.invoke.SET_GENERAL_SETTINGS).toBe('settings:setGeneralSettings')
+    expect(SettingsChannels.invoke.GET_EDITOR_SETTINGS).toBe('settings:getEditorSettings')
+    expect(SettingsChannels.invoke.SET_EDITOR_SETTINGS).toBe('settings:setEditorSettings')
+    expect(SettingsChannels.invoke.GET_SYNC_SETTINGS).toBe('settings:getSyncSettings')
+    expect(SettingsChannels.invoke.SET_SYNC_SETTINGS).toBe('settings:setSyncSettings')
+  })
+})
+
+describe('AccountChannels', () => {
+  it('exposes auth-related channels', () => {
+    expect(AccountChannels.invoke.GET_INFO).toBe('account:getInfo')
+    expect(AccountChannels.invoke.SIGN_OUT).toBe('account:signOut')
+    expect(AccountChannels.invoke.GET_RECOVERY_KEY).toBe('account:getRecoveryKey')
+  })
+})
+
+describe('PropertiesChannels', () => {
+  it('exposes get/set/rename invoke channels', () => {
+    expect(PropertiesChannels.invoke.GET).toBe('properties:get')
+    expect(PropertiesChannels.invoke.SET).toBe('properties:set')
+    expect(PropertiesChannels.invoke.RENAME).toBe('properties:rename')
+  })
+})
+
+describe('GraphChannels', () => {
+  it('exposes graph data invoke channels', () => {
+    expect(GraphChannels.invoke.GET_GRAPH_DATA).toBe('graph:get-graph-data')
+    expect(GraphChannels.invoke.GET_LOCAL_GRAPH).toBe('graph:get-local-graph')
+  })
+})
+
+describe('channel key casing', () => {
+  it.each(ALL_GROUPS)('%s invoke keys are SCREAMING_SNAKE_CASE', (_name, group) => {
+    if (!group.invoke) return
+    for (const key of Object.keys(group.invoke)) {
+      expect(key).toMatch(/^[A-Z][A-Z0-9_]*$/)
+    }
+  })
+
+  it.each(ALL_GROUPS)('%s event keys are SCREAMING_SNAKE_CASE', (_name, group) => {
+    if (!group.events) return
+    for (const key of Object.keys(group.events)) {
+      expect(key).toMatch(/^[A-Z][A-Z0-9_]*$/)
+    }
+  })
+})

--- a/packages/contracts/src/settings-schemas.test.ts
+++ b/packages/contracts/src/settings-schemas.test.ts
@@ -1,0 +1,613 @@
+/**
+ * Settings Schemas Contract Tests
+ *
+ * Zod schema validation coverage for settings-schemas.ts.
+ * Tests cover default values, valid inputs, and invalid input rejection paths.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  GeneralSettingsSchema,
+  GENERAL_SETTINGS_DEFAULTS,
+  EditorSettingsSchema,
+  EDITOR_SETTINGS_DEFAULTS,
+  TaskSettingsSchema,
+  TASK_SETTINGS_DEFAULTS,
+  ShortcutBindingSchema,
+  KeyboardShortcutsSchema,
+  KEYBOARD_SHORTCUTS_DEFAULTS,
+  SyncSettingsSchema,
+  SYNC_SETTINGS_DEFAULTS,
+  AISettingsSchema,
+  AI_SETTINGS_DEFAULTS,
+  VoiceTranscriptionSettingsSchema,
+  VOICE_TRANSCRIPTION_SETTINGS_DEFAULTS,
+  BackupSettingsSchema,
+  BACKUP_SETTINGS_DEFAULTS,
+  AccountInfoSchema,
+  TagInfoSchema,
+  ExportRequestSchema,
+  ImportRequestSchema,
+  ImportResultSchema,
+  GetRecoveryKeyRequestSchema,
+  SetApiKeyRequestSchema,
+  TestConnectionRequestSchema,
+  TestConnectionResultSchema
+} from './settings-schemas'
+
+describe('GeneralSettingsSchema', () => {
+  it('accepts the shipped default payload', () => {
+    const result = GeneralSettingsSchema.safeParse(GENERAL_SETTINGS_DEFAULTS)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a custom accent color with 6-digit hex', () => {
+    const result = GeneralSettingsSchema.safeParse({
+      ...GENERAL_SETTINGS_DEFAULTS,
+      accentColor: '#aAbBcC'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid theme enum', () => {
+    const result = GeneralSettingsSchema.safeParse({
+      ...GENERAL_SETTINGS_DEFAULTS,
+      theme: 'midnight'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('theme')
+    }
+  })
+
+  it('rejects invalid fontFamily enum', () => {
+    const result = GeneralSettingsSchema.safeParse({
+      ...GENERAL_SETTINGS_DEFAULTS,
+      fontFamily: 'comic-sans'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('fontFamily')
+    }
+  })
+
+  it('rejects malformed accent color', () => {
+    const result = GeneralSettingsSchema.safeParse({
+      ...GENERAL_SETTINGS_DEFAULTS,
+      accentColor: 'blue'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('accentColor')
+    }
+  })
+
+  it('rejects language shorter than 2 chars', () => {
+    const result = GeneralSettingsSchema.safeParse({
+      ...GENERAL_SETTINGS_DEFAULTS,
+      language: 'e'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects language longer than 5 chars', () => {
+    const result = GeneralSettingsSchema.safeParse({
+      ...GENERAL_SETTINGS_DEFAULTS,
+      language: 'en-US-x'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid clockFormat enum', () => {
+    const result = GeneralSettingsSchema.safeParse({
+      ...GENERAL_SETTINGS_DEFAULTS,
+      clockFormat: '48h'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing required boolean field', () => {
+    const { startOnBoot: _omit, ...rest } = GENERAL_SETTINGS_DEFAULTS
+    const result = GeneralSettingsSchema.safeParse(rest)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('startOnBoot')
+    }
+  })
+})
+
+describe('EditorSettingsSchema', () => {
+  it('accepts the shipped default payload', () => {
+    const result = EditorSettingsSchema.safeParse(EDITOR_SETTINGS_DEFAULTS)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects width outside enum', () => {
+    const result = EditorSettingsSchema.safeParse({
+      ...EDITOR_SETTINGS_DEFAULTS,
+      width: 'full'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('width')
+    }
+  })
+
+  it('rejects negative autoSaveDelay', () => {
+    const result = EditorSettingsSchema.safeParse({
+      ...EDITOR_SETTINGS_DEFAULTS,
+      autoSaveDelay: -1
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects autoSaveDelay above 30000', () => {
+    const result = EditorSettingsSchema.safeParse({
+      ...EDITOR_SETTINGS_DEFAULTS,
+      autoSaveDelay: 30001
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts autoSaveDelay at boundaries', () => {
+    const low = EditorSettingsSchema.safeParse({ ...EDITOR_SETTINGS_DEFAULTS, autoSaveDelay: 0 })
+    expect(low.success).toBe(true)
+    const high = EditorSettingsSchema.safeParse({
+      ...EDITOR_SETTINGS_DEFAULTS,
+      autoSaveDelay: 30000
+    })
+    expect(high.success).toBe(true)
+  })
+
+  it('rejects non-integer autoSaveDelay', () => {
+    const result = EditorSettingsSchema.safeParse({
+      ...EDITOR_SETTINGS_DEFAULTS,
+      autoSaveDelay: 1500.5
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid toolbarMode enum', () => {
+    const result = EditorSettingsSchema.safeParse({
+      ...EDITOR_SETTINGS_DEFAULTS,
+      toolbarMode: 'pinned'
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('TaskSettingsSchema', () => {
+  it('accepts the shipped default payload', () => {
+    const result = TaskSettingsSchema.safeParse(TASK_SETTINGS_DEFAULTS)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a string defaultProjectId', () => {
+    const result = TaskSettingsSchema.safeParse({
+      ...TASK_SETTINGS_DEFAULTS,
+      defaultProjectId: 'proj-1'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid defaultSortOrder', () => {
+    const result = TaskSettingsSchema.safeParse({
+      ...TASK_SETTINGS_DEFAULTS,
+      defaultSortOrder: 'alphabetical'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('defaultSortOrder')
+    }
+  })
+
+  it('rejects invalid weekStartDay', () => {
+    const result = TaskSettingsSchema.safeParse({
+      ...TASK_SETTINGS_DEFAULTS,
+      weekStartDay: 'wednesday'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects staleInboxDays below 1', () => {
+    const result = TaskSettingsSchema.safeParse({
+      ...TASK_SETTINGS_DEFAULTS,
+      staleInboxDays: 0
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects staleInboxDays above 90', () => {
+    const result = TaskSettingsSchema.safeParse({
+      ...TASK_SETTINGS_DEFAULTS,
+      staleInboxDays: 91
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-integer staleInboxDays', () => {
+    const result = TaskSettingsSchema.safeParse({
+      ...TASK_SETTINGS_DEFAULTS,
+      staleInboxDays: 5.5
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('ShortcutBindingSchema', () => {
+  it('accepts a single key with no modifiers', () => {
+    const result = ShortcutBindingSchema.safeParse({
+      key: 'k',
+      modifiers: {}
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a binding with full modifier set', () => {
+    const result = ShortcutBindingSchema.safeParse({
+      key: 'Enter',
+      modifiers: { meta: true, ctrl: false, shift: true, alt: false }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty key', () => {
+    const result = ShortcutBindingSchema.safeParse({
+      key: '',
+      modifiers: {}
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('key')
+    }
+  })
+
+  it('rejects missing modifiers object', () => {
+    const result = ShortcutBindingSchema.safeParse({ key: 'k' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('KeyboardShortcutsSchema', () => {
+  it('accepts the shipped default payload', () => {
+    const result = KeyboardShortcutsSchema.safeParse(KEYBOARD_SHORTCUTS_DEFAULTS)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts overrides map keyed by command name', () => {
+    const result = KeyboardShortcutsSchema.safeParse({
+      overrides: {
+        'note.save': { key: 's', modifiers: { meta: true } }
+      },
+      globalCapture: { key: 'n', modifiers: { meta: true, shift: true } }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects override with invalid binding', () => {
+    const result = KeyboardShortcutsSchema.safeParse({
+      overrides: { 'note.save': { key: '', modifiers: {} } },
+      globalCapture: null
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing globalCapture field', () => {
+    const result = KeyboardShortcutsSchema.safeParse({ overrides: {} })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('globalCapture')
+    }
+  })
+})
+
+describe('SyncSettingsSchema', () => {
+  it('accepts the shipped default payload', () => {
+    const result = SyncSettingsSchema.safeParse(SYNC_SETTINGS_DEFAULTS)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects non-boolean enabled', () => {
+    const result = SyncSettingsSchema.safeParse({ enabled: 'yes', autoSync: true })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('enabled')
+    }
+  })
+
+  it('rejects missing autoSync field', () => {
+    const result = SyncSettingsSchema.safeParse({ enabled: true })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('autoSync')
+    }
+  })
+})
+
+describe('AISettingsSchema', () => {
+  it('accepts the shipped default payload', () => {
+    const result = AISettingsSchema.safeParse(AI_SETTINGS_DEFAULTS)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a named model', () => {
+    const result = AISettingsSchema.safeParse({
+      enabled: true,
+      provider: 'openai',
+      model: 'gpt-4o-mini'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid provider', () => {
+    const result = AISettingsSchema.safeParse({
+      enabled: true,
+      provider: 'mistral',
+      model: null
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('provider')
+    }
+  })
+})
+
+describe('VoiceTranscriptionSettingsSchema', () => {
+  it('accepts the shipped default payload', () => {
+    const result = VoiceTranscriptionSettingsSchema.safeParse(VOICE_TRANSCRIPTION_SETTINGS_DEFAULTS)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects unsupported provider', () => {
+    const result = VoiceTranscriptionSettingsSchema.safeParse({ provider: 'whisper-cloud' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('provider')
+    }
+  })
+})
+
+describe('BackupSettingsSchema', () => {
+  it('accepts the shipped default payload', () => {
+    const result = BackupSettingsSchema.safeParse(BACKUP_SETTINGS_DEFAULTS)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts each allowed frequencyHours literal', () => {
+    for (const frequencyHours of [1, 6, 12, 24] as const) {
+      const result = BackupSettingsSchema.safeParse({
+        ...BACKUP_SETTINGS_DEFAULTS,
+        frequencyHours
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects frequencyHours outside the literal set', () => {
+    const result = BackupSettingsSchema.safeParse({
+      ...BACKUP_SETTINGS_DEFAULTS,
+      frequencyHours: 3
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('frequencyHours')
+    }
+  })
+
+  it('rejects maxBackups below 1', () => {
+    const result = BackupSettingsSchema.safeParse({
+      ...BACKUP_SETTINGS_DEFAULTS,
+      maxBackups: 0
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects maxBackups above 50', () => {
+    const result = BackupSettingsSchema.safeParse({
+      ...BACKUP_SETTINGS_DEFAULTS,
+      maxBackups: 51
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a stored lastBackupAt string', () => {
+    const result = BackupSettingsSchema.safeParse({
+      ...BACKUP_SETTINGS_DEFAULTS,
+      lastBackupAt: '2026-04-16T10:00:00Z'
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('AccountInfoSchema', () => {
+  const baseAccount = {
+    email: 'test@example.com',
+    authProvider: 'email' as const,
+    createdAt: '2026-01-01T00:00:00Z',
+    storageUsedBytes: 1024,
+    storageLimitBytes: 1048576,
+    avatarUrl: null
+  }
+
+  it('accepts a well-formed account payload', () => {
+    const result = AccountInfoSchema.safeParse(baseAccount)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an invalid email', () => {
+    const result = AccountInfoSchema.safeParse({ ...baseAccount, email: 'not-an-email' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('email')
+    }
+  })
+
+  it('rejects an unsupported authProvider', () => {
+    const result = AccountInfoSchema.safeParse({ ...baseAccount, authProvider: 'apple' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('TagInfoSchema', () => {
+  it('accepts tag with name and count', () => {
+    const result = TagInfoSchema.safeParse({ name: 'work', count: 12 })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts tag with optional color', () => {
+    const result = TagInfoSchema.safeParse({ name: 'work', count: 12, color: '#ff0000' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects non-integer count', () => {
+    const result = TagInfoSchema.safeParse({ name: 'work', count: 1.5 })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('count')
+    }
+  })
+})
+
+describe('ExportRequestSchema', () => {
+  it('accepts valid export request', () => {
+    const result = ExportRequestSchema.safeParse({
+      format: 'json',
+      destPath: '/tmp/export.json'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid format', () => {
+    const result = ExportRequestSchema.safeParse({
+      format: 'xml',
+      destPath: '/tmp/export.xml'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty destPath', () => {
+    const result = ExportRequestSchema.safeParse({ format: 'json', destPath: '' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('destPath')
+    }
+  })
+})
+
+describe('ImportRequestSchema', () => {
+  it('accepts a valid import request', () => {
+    const result = ImportRequestSchema.safeParse({
+      sourcePath: '/tmp/export.json',
+      format: 'notion'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty sourcePath', () => {
+    const result = ImportRequestSchema.safeParse({ sourcePath: '', format: 'json' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unsupported format', () => {
+    const result = ImportRequestSchema.safeParse({
+      sourcePath: '/tmp/data',
+      format: 'evernote'
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('ImportResultSchema', () => {
+  it('accepts integer counts', () => {
+    const result = ImportResultSchema.safeParse({ imported: 5, skipped: 2 })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects non-integer counts', () => {
+    const result = ImportResultSchema.safeParse({ imported: 5.5, skipped: 2 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing skipped field', () => {
+    const result = ImportResultSchema.safeParse({ imported: 5 })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('GetRecoveryKeyRequestSchema', () => {
+  it('accepts a non-empty reAuthToken', () => {
+    const result = GetRecoveryKeyRequestSchema.safeParse({ reAuthToken: 'token-123' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an empty reAuthToken', () => {
+    const result = GetRecoveryKeyRequestSchema.safeParse({ reAuthToken: '' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('reAuthToken')
+    }
+  })
+})
+
+describe('SetApiKeyRequestSchema', () => {
+  it('accepts a valid provider + key', () => {
+    const result = SetApiKeyRequestSchema.safeParse({
+      provider: 'openai',
+      key: 'sk-test-123'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects unsupported provider (local is read-only)', () => {
+    const result = SetApiKeyRequestSchema.safeParse({
+      provider: 'local',
+      key: 'sk-test-123'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('provider')
+    }
+  })
+
+  it('rejects empty key', () => {
+    const result = SetApiKeyRequestSchema.safeParse({ provider: 'openai', key: '' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('TestConnectionRequestSchema', () => {
+  it('accepts each supported provider', () => {
+    for (const provider of ['local', 'openai', 'anthropic'] as const) {
+      const result = TestConnectionRequestSchema.safeParse({ provider })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects unsupported provider', () => {
+    const result = TestConnectionRequestSchema.safeParse({ provider: 'mistral' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('TestConnectionResultSchema', () => {
+  it('accepts a successful result without an error field', () => {
+    const result = TestConnectionResultSchema.safeParse({ valid: true })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a failed result with an error message', () => {
+    const result = TestConnectionResultSchema.safeParse({
+      valid: false,
+      error: 'invalid api key'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects non-boolean valid', () => {
+    const result = TestConnectionResultSchema.safeParse({ valid: 'yes' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('valid')
+    }
+  })
+})

--- a/packages/contracts/src/settings-sync.test.ts
+++ b/packages/contracts/src/settings-sync.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Settings Sync Contract Tests
+ *
+ * Zod schema validation coverage for settings-sync.ts.
+ * Covers nested synced settings groups + field-level vector clocks.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  SyncedSettingsSchema,
+  FieldClockMapSchema,
+  SettingsSyncPayloadSchema
+} from './settings-sync'
+
+describe('SyncedSettingsSchema', () => {
+  it('accepts an empty object (all groups optional)', () => {
+    const result = SyncedSettingsSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a general group with partial fields', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      general: { theme: 'dark', fontSize: 'large' }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid general.theme', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      general: { theme: 'midnight' }
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('theme')
+    }
+  })
+
+  it('rejects invalid general.fontFamily', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      general: { fontFamily: 'comic-sans' }
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('fontFamily')
+    }
+  })
+
+  it('accepts an editor group', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      editor: {
+        width: 'wide',
+        spellCheck: false,
+        autoSaveDelay: 2000,
+        showWordCount: true,
+        toolbarMode: 'sticky'
+      }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid editor.width', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      editor: { width: 'huge' }
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('width')
+    }
+  })
+
+  it('rejects invalid editor.toolbarMode', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      editor: { toolbarMode: 'hidden' }
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a tasks group with null defaultProjectId', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      tasks: { defaultProjectId: null, weekStartDay: 'sunday' }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid tasks.defaultSortOrder', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      tasks: { defaultSortOrder: 'alphabetical' }
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid tasks.weekStartDay', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      tasks: { weekStartDay: 'friday' }
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a keyboard group with arbitrary override records', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      keyboard: {
+        overrides: {
+          'note.save': { key: 's', modifiers: { meta: true } }
+        }
+      }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a notes group', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      notes: {
+        defaultFolder: '/work',
+        editorFontSize: 16,
+        spellCheck: true
+      }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects notes.editorFontSize when non-numeric', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      notes: { editorFontSize: 'large' }
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('editorFontSize')
+    }
+  })
+
+  it('accepts a sync group with autoSync + interval', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      sync: { autoSync: false, syncIntervalMinutes: 15 }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects sync.autoSync when not boolean', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      sync: { autoSync: 'yes' }
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('autoSync')
+    }
+  })
+
+  it('accepts all groups populated together', () => {
+    const result = SyncedSettingsSchema.safeParse({
+      general: { theme: 'light', accentColor: '#123456' },
+      editor: { width: 'narrow' },
+      tasks: { weekStartDay: 'monday' },
+      keyboard: { overrides: {} },
+      notes: { spellCheck: true },
+      sync: { autoSync: true }
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('FieldClockMapSchema', () => {
+  it('accepts an empty map', () => {
+    const result = FieldClockMapSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a map of field → vector clock', () => {
+    const result = FieldClockMapSchema.safeParse({
+      'general.theme': { 'device-a': 3, 'device-b': 1 },
+      'editor.width': { 'device-a': 0 }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a negative tick value in a vector clock', () => {
+    const result = FieldClockMapSchema.safeParse({
+      'general.theme': { 'device-a': -1 }
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a non-integer tick value', () => {
+    const result = FieldClockMapSchema.safeParse({
+      'general.theme': { 'device-a': 1.5 }
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a non-object clock entry', () => {
+    const result = FieldClockMapSchema.safeParse({
+      'general.theme': 42
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('SettingsSyncPayloadSchema', () => {
+  it('accepts a minimal payload with empty settings + clocks', () => {
+    const result = SettingsSyncPayloadSchema.safeParse({
+      settings: {},
+      fieldClocks: {}
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a populated payload', () => {
+    const result = SettingsSyncPayloadSchema.safeParse({
+      settings: {
+        general: { theme: 'dark' },
+        editor: { autoSaveDelay: 1000 }
+      },
+      fieldClocks: {
+        'general.theme': { 'device-a': 2 },
+        'editor.autoSaveDelay': { 'device-a': 1 }
+      }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing settings field', () => {
+    const result = SettingsSyncPayloadSchema.safeParse({ fieldClocks: {} })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('settings')
+    }
+  })
+
+  it('rejects missing fieldClocks field', () => {
+    const result = SettingsSyncPayloadSchema.safeParse({ settings: {} })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('fieldClocks')
+    }
+  })
+
+  it('rejects invalid nested settings group', () => {
+    const result = SettingsSyncPayloadSchema.safeParse({
+      settings: { general: { theme: 'not-a-theme' } },
+      fieldClocks: {}
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid nested clock value', () => {
+    const result = SettingsSyncPayloadSchema.safeParse({
+      settings: {},
+      fieldClocks: { 'general.theme': { 'device-a': -5 } }
+    })
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
Phase 4 U7 — adds Zod schema validation tests for 4 previously-untested contracts files:
- settings-schemas
- settings-sync
- ipc-channels
- index (barrel smoke)

## Test plan
- [x] 4 test files created, all under 800-line pre-commit limit
- [ ] CI: `pnpm --dir apps/desktop test:coverage` green

Ref: [.claude/plans/tech-debt-remediation.md](.claude/plans/tech-debt-remediation.md) Phase 4.4