### PR TITLE
test(storage): add coverage for storage-data + storage-vault (U3)

### DIFF
--- a/packages/storage-data/src/note-metadata-repository.test.ts
+++ b/packages/storage-data/src/note-metadata-repository.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import type { NewNoteMetadata } from '@memry/db-schema/data-schema'
+import {
+  upsertNoteMetadata,
+  updateNoteMetadata,
+  deleteNoteMetadata,
+  getNoteMetadataById,
+  getNoteMetadataByPath,
+  getJournalNoteMetadataByDate,
+  listNoteMetadata,
+  countLocalOnlyNoteMetadata,
+  getPropertyDefinition,
+  upsertPropertyDefinition,
+  listPropertyDefinitions,
+  deletePropertyDefinition,
+  type NoteMetadataDb
+} from './note-metadata-repository'
+
+function makeNote(overrides: Partial<NewNoteMetadata> = {}): NewNoteMetadata {
+  return {
+    id: 'note-1',
+    path: 'notes/note-1.md',
+    title: 'Note 1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    modifiedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+describe('note-metadata-repository', () => {
+  let testDb: TestDatabaseResult
+  let db: NoteMetadataDb
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    db = testDb.db as unknown as NoteMetadataDb
+  })
+
+  afterEach(() => {
+    testDb.close()
+  })
+
+  describe('upsertNoteMetadata', () => {
+    it('inserts a new note on first call', () => {
+      // #when
+      const created = upsertNoteMetadata(db, makeNote())
+
+      // #then
+      expect(created.id).toBe('note-1')
+      expect(created.title).toBe('Note 1')
+      expect(created.path).toBe('notes/note-1.md')
+    })
+
+    it('updates existing row on id conflict', () => {
+      // #given
+      upsertNoteMetadata(db, makeNote({ title: 'Original' }))
+
+      // #when
+      const updated = upsertNoteMetadata(
+        db,
+        makeNote({ title: 'Updated', modifiedAt: '2026-02-01T00:00:00.000Z' })
+      )
+
+      // #then
+      expect(updated.title).toBe('Updated')
+      expect(updated.modifiedAt).toBe('2026-02-01T00:00:00.000Z')
+      // Only one row stored
+      const all = listNoteMetadata(db)
+      expect(all).toHaveLength(1)
+    })
+
+    it('persists optional fields (emoji, fileType, localOnly, journalDate)', () => {
+      // #when
+      const created = upsertNoteMetadata(
+        db,
+        makeNote({
+          emoji: 'note',
+          fileType: 'markdown',
+          localOnly: true,
+          journalDate: '2026-04-16'
+        })
+      )
+
+      // #then
+      expect(created.emoji).toBe('note')
+      expect(created.localOnly).toBe(true)
+      expect(created.journalDate).toBe('2026-04-16')
+    })
+  })
+
+  describe('updateNoteMetadata', () => {
+    it('updates fields on existing note', () => {
+      // #given
+      upsertNoteMetadata(db, makeNote())
+
+      // #when
+      const updated = updateNoteMetadata(db, 'note-1', { title: 'Renamed' })
+
+      // #then
+      expect(updated?.title).toBe('Renamed')
+    })
+
+    it('returns undefined when id does not exist', () => {
+      // #when
+      const updated = updateNoteMetadata(db, 'missing', { title: 'No' })
+
+      // #then
+      expect(updated).toBeUndefined()
+    })
+  })
+
+  describe('getNoteMetadataById', () => {
+    it('returns the note when found', () => {
+      // #given
+      upsertNoteMetadata(db, makeNote())
+
+      // #when
+      const found = getNoteMetadataById(db, 'note-1')
+
+      // #then
+      expect(found?.id).toBe('note-1')
+    })
+
+    it('returns undefined when not found', () => {
+      expect(getNoteMetadataById(db, 'missing')).toBeUndefined()
+    })
+  })
+
+  describe('getNoteMetadataByPath', () => {
+    it('resolves canonical path', () => {
+      // #given
+      upsertNoteMetadata(db, makeNote())
+
+      // #when
+      const found = getNoteMetadataByPath(db, 'notes/note-1.md')
+
+      // #then
+      expect(found?.id).toBe('note-1')
+    })
+  })
+
+  describe('getJournalNoteMetadataByDate', () => {
+    it('finds journal entry by date', () => {
+      // #given
+      upsertNoteMetadata(
+        db,
+        makeNote({
+          id: 'journal-1',
+          path: 'journal/2026-04-16.md',
+          title: '2026-04-16',
+          journalDate: '2026-04-16'
+        })
+      )
+
+      // #when
+      const found = getJournalNoteMetadataByDate(db, '2026-04-16')
+
+      // #then
+      expect(found?.id).toBe('journal-1')
+    })
+
+    it('returns undefined when no journal for date', () => {
+      expect(getJournalNoteMetadataByDate(db, '1999-01-01')).toBeUndefined()
+    })
+  })
+
+  describe('listNoteMetadata', () => {
+    beforeEach(() => {
+      upsertNoteMetadata(
+        db,
+        makeNote({
+          id: 'n-a',
+          path: 'notes/a.md',
+          title: 'Alpha',
+          modifiedAt: '2026-01-01T00:00:00.000Z'
+        })
+      )
+      upsertNoteMetadata(
+        db,
+        makeNote({
+          id: 'n-b',
+          path: 'notes/sub/b.md',
+          title: 'Bravo',
+          modifiedAt: '2026-03-01T00:00:00.000Z'
+        })
+      )
+      upsertNoteMetadata(
+        db,
+        makeNote({
+          id: 'j-1',
+          path: 'journal/2026-04-16.md',
+          title: '2026-04-16',
+          journalDate: '2026-04-16',
+          modifiedAt: '2026-04-16T00:00:00.000Z'
+        })
+      )
+    })
+
+    it('returns only notes by default (excludes journal)', () => {
+      // #when
+      const rows = listNoteMetadata(db)
+
+      // #then
+      expect(rows.map((r) => r.id).sort()).toEqual(['n-a', 'n-b'])
+    })
+
+    it('filters to journal when journalOnly=true', () => {
+      // #when
+      const rows = listNoteMetadata(db, { journalOnly: true })
+
+      // #then
+      expect(rows.map((r) => r.id)).toEqual(['j-1'])
+    })
+
+    it('filters by folder prefix', () => {
+      // #when
+      const rows = listNoteMetadata(db, { folder: 'sub' })
+
+      // #then
+      expect(rows.map((r) => r.id)).toEqual(['n-b'])
+    })
+
+    it('sorts by title asc', () => {
+      // #when
+      const rows = listNoteMetadata(db, { sortBy: 'title', sortOrder: 'asc' })
+
+      // #then
+      expect(rows.map((r) => r.title)).toEqual(['Alpha', 'Bravo'])
+    })
+
+    it('sorts by modified desc by default', () => {
+      // #when
+      const rows = listNoteMetadata(db)
+
+      // #then
+      expect(rows.map((r) => r.id)).toEqual(['n-b', 'n-a'])
+    })
+
+    it('respects limit + offset', () => {
+      // #when
+      const first = listNoteMetadata(db, { limit: 1, offset: 0 })
+      const second = listNoteMetadata(db, { limit: 1, offset: 1 })
+
+      // #then
+      expect(first).toHaveLength(1)
+      expect(second).toHaveLength(1)
+      expect(first[0].id).not.toBe(second[0].id)
+    })
+  })
+
+  describe('deleteNoteMetadata', () => {
+    it('removes row by id', () => {
+      // #given
+      upsertNoteMetadata(db, makeNote())
+
+      // #when
+      deleteNoteMetadata(db, 'note-1')
+
+      // #then
+      expect(getNoteMetadataById(db, 'note-1')).toBeUndefined()
+    })
+
+    it('is a no-op for missing id', () => {
+      expect(() => deleteNoteMetadata(db, 'missing')).not.toThrow()
+    })
+  })
+
+  describe('countLocalOnlyNoteMetadata', () => {
+    it('counts only rows flagged localOnly=true', () => {
+      // #given
+      upsertNoteMetadata(db, makeNote({ id: 'a', path: 'notes/a.md', localOnly: true }))
+      upsertNoteMetadata(db, makeNote({ id: 'b', path: 'notes/b.md', localOnly: true }))
+      upsertNoteMetadata(db, makeNote({ id: 'c', path: 'notes/c.md', localOnly: false }))
+
+      // #when / #then
+      expect(countLocalOnlyNoteMetadata(db)).toBe(2)
+    })
+
+    it('returns 0 on empty table', () => {
+      expect(countLocalOnlyNoteMetadata(db)).toBe(0)
+    })
+  })
+
+  describe('property definitions', () => {
+    it('upserts then retrieves by name', () => {
+      // #when
+      const created = upsertPropertyDefinition(db, {
+        name: 'priority',
+        type: 'select',
+        options: JSON.stringify(['low', 'high']),
+        defaultValue: 'low',
+        color: '#f00'
+      })
+
+      // #then
+      expect(created.name).toBe('priority')
+      const found = getPropertyDefinition(db, 'priority')
+      expect(found?.defaultValue).toBe('low')
+    })
+
+    it('updates existing definition on conflict', () => {
+      // #given
+      upsertPropertyDefinition(db, { name: 'priority', type: 'select', defaultValue: 'low' })
+
+      // #when
+      const updated = upsertPropertyDefinition(db, {
+        name: 'priority',
+        type: 'select',
+        defaultValue: 'high'
+      })
+
+      // #then
+      expect(updated.defaultValue).toBe('high')
+    })
+
+    it('lists all definitions ordered by name', () => {
+      // #given
+      upsertPropertyDefinition(db, { name: 'zeta', type: 'text' })
+      upsertPropertyDefinition(db, { name: 'alpha', type: 'text' })
+
+      // #when
+      const all = listPropertyDefinitions(db)
+
+      // #then
+      expect(all.map((d) => d.name)).toEqual(['alpha', 'zeta'])
+    })
+
+    it('returns undefined when definition missing', () => {
+      expect(getPropertyDefinition(db, 'missing')).toBeUndefined()
+    })
+
+    it('deletes definition by name', () => {
+      // #given
+      upsertPropertyDefinition(db, { name: 'priority', type: 'select' })
+
+      // #when
+      deletePropertyDefinition(db, 'priority')
+
+      // #then
+      expect(getPropertyDefinition(db, 'priority')).toBeUndefined()
+    })
+  })
+})

--- a/packages/storage-data/src/tasks-repository.test.ts
+++ b/packages/storage-data/src/tasks-repository.test.ts
@@ -1,0 +1,474 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type {
+  Project,
+  ProjectWithStats,
+  ProjectWithStatuses,
+  Status,
+  Task,
+  TaskStats
+} from '@memry/domain-tasks'
+import {
+  createTasksRepository,
+  type ProjectQueryModule,
+  type TaskQueryModule
+} from './tasks-repository'
+
+type TestDb = { __test: true }
+
+type TaskRow = Omit<Task, 'isRepeating' | 'priority' | 'repeatConfig' | 'repeatFrom'> & {
+  priority: number
+  repeatConfig: unknown
+  repeatFrom: string | null
+}
+
+function makeTaskRow(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    id: 'task-1',
+    projectId: 'proj-1',
+    statusId: 'status-todo',
+    parentId: null,
+    title: 'Task',
+    description: null,
+    priority: 0,
+    position: 0,
+    dueDate: null,
+    dueTime: null,
+    startDate: null,
+    repeatConfig: null,
+    repeatFrom: null,
+    sourceNoteId: null,
+    completedAt: null,
+    archivedAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    modifiedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+function makeStatus(overrides: Partial<Status> = {}): Status {
+  return {
+    id: 'status-todo',
+    projectId: 'proj-1',
+    name: 'Todo',
+    color: '#000',
+    position: 0,
+    isDefault: true,
+    isDone: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'proj-1',
+    name: 'Project',
+    description: null,
+    color: '#000',
+    icon: null,
+    position: 0,
+    isInbox: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    modifiedAt: '2026-01-01T00:00:00.000Z',
+    archivedAt: null,
+    ...overrides
+  }
+}
+
+function createTaskQueries(): TaskQueryModule<TestDb> {
+  return {
+    insertTask: vi.fn((_db, task) => makeTaskRow(task as Partial<TaskRow>)),
+    updateTask: vi.fn((_db, id, updates) => makeTaskRow({ id, ...(updates as Partial<TaskRow>) })),
+    deleteTask: vi.fn(),
+    getTaskById: vi.fn(),
+    listTasks: vi.fn(() => []),
+    countTasks: vi.fn(() => 0),
+    getSubtasks: vi.fn(() => []),
+    countSubtasks: vi.fn(() => ({ total: 0, completed: 0 })),
+    completeTask: vi.fn((_db, id) =>
+      makeTaskRow({ id, completedAt: '2026-04-16T00:00:00.000Z' })
+    ),
+    uncompleteTask: vi.fn((_db, id) => makeTaskRow({ id, completedAt: null })),
+    archiveTask: vi.fn((_db, id) =>
+      makeTaskRow({ id, archivedAt: '2026-04-16T00:00:00.000Z' })
+    ),
+    unarchiveTask: vi.fn((_db, id) => makeTaskRow({ id, archivedAt: null })),
+    moveTask: vi.fn((_db, id, updates) =>
+      makeTaskRow({ id, ...(updates as Partial<TaskRow>) })
+    ),
+    reorderTasks: vi.fn(),
+    duplicateTask: vi.fn((_db, _id, newId) => makeTaskRow({ id: newId })),
+    duplicateSubtask: vi.fn((_db, _id, newId, newParentId) =>
+      makeTaskRow({ id: newId, parentId: newParentId })
+    ),
+    setTaskTags: vi.fn(),
+    getTaskTags: vi.fn(() => []),
+    setTaskNotes: vi.fn(),
+    getTaskNoteIds: vi.fn(() => []),
+    getAllTaskTags: vi.fn(() => []),
+    getTaskStats: vi.fn<TaskQueryModule<TestDb>['getTaskStats']>(
+      () =>
+        ({
+          total: 0,
+          completed: 0,
+          overdue: 0,
+          dueToday: 0,
+          dueThisWeek: 0
+        }) satisfies TaskStats
+    ),
+    getTodayTasks: vi.fn(() => []),
+    getUpcomingTasks: vi.fn(() => []),
+    getOverdueTasks: vi.fn(() => []),
+    getTasksLinkedToNote: vi.fn(() => []),
+    getNextTaskPosition: vi.fn(() => 0),
+    bulkCompleteTasks: vi.fn(() => 0),
+    bulkDeleteTasks: vi.fn(() => 0),
+    bulkMoveTasks: vi.fn(() => 0),
+    bulkArchiveTasks: vi.fn(() => 0)
+  }
+}
+
+function createProjectQueries(): ProjectQueryModule<TestDb> {
+  return {
+    insertProject: vi.fn((_db, project) => makeProject(project as Partial<Project>)),
+    updateProject: vi.fn((_db, id) => makeProject({ id })),
+    deleteProject: vi.fn(),
+    getProjectWithStatuses: vi.fn<ProjectQueryModule<TestDb>['getProjectWithStatuses']>(
+      (_db, id) => ({
+        ...makeProject({ id }),
+        statuses: [makeStatus()]
+      }) satisfies ProjectWithStatuses
+    ),
+    getProjectsWithStats: vi.fn<ProjectQueryModule<TestDb>['getProjectsWithStats']>(
+      () => [
+        {
+          ...makeProject(),
+          taskCount: 2,
+          completedCount: 1,
+          overdueCount: 0
+        } satisfies ProjectWithStats
+      ]
+    ),
+    archiveProject: vi.fn((_db, id) =>
+      makeProject({ id, archivedAt: '2026-04-16T00:00:00.000Z' })
+    ),
+    reorderProjects: vi.fn(),
+    getNextProjectPosition: vi.fn(() => 3),
+    insertStatus: vi.fn((_db, status) => makeStatus(status as Partial<Status>)),
+    updateStatus: vi.fn((_db, id) => makeStatus({ id })),
+    deleteStatus: vi.fn(),
+    getStatusesByProject: vi.fn(() => [makeStatus()]),
+    reorderStatuses: vi.fn(),
+    getNextStatusPosition: vi.fn(() => 2),
+    getStatusById: vi.fn((_db, id) => makeStatus({ id })),
+    getEquivalentStatus: vi.fn((_db, _pid, src) => (src ? makeStatus({ id: src.id }) : undefined)),
+    createDefaultStatuses: vi.fn(() => [makeStatus()]),
+    createCustomStatuses: vi.fn(() => [makeStatus()]),
+    reconcileProjectStatuses: vi.fn()
+  }
+}
+
+describe('createTasksRepository', () => {
+  let db: TestDb
+  let taskQueries: TaskQueryModule<TestDb>
+  let projectQueries: ProjectQueryModule<TestDb>
+  let repo: ReturnType<typeof createTasksRepository<TestDb>>
+
+  beforeEach(() => {
+    db = { __test: true }
+    taskQueries = createTaskQueries()
+    projectQueries = createProjectQueries()
+    repo = createTasksRepository({ db, taskQueries, projectQueries })
+  })
+
+  describe('task lifecycle', () => {
+    it('createTask delegates to insertTask and enriches result', () => {
+      // #given
+      vi.mocked(taskQueries.getTaskTags).mockReturnValue(['urgent'])
+      vi.mocked(taskQueries.getTaskNoteIds).mockReturnValue(['note-1'])
+      vi.mocked(taskQueries.countSubtasks).mockReturnValue({ total: 2, completed: 1 })
+
+      // #when
+      const created = repo.createTask({
+        id: 'task-2',
+        projectId: 'proj-1',
+        statusId: null,
+        parentId: null,
+        title: 'New task',
+        description: null,
+        priority: 1,
+        position: 0,
+        dueDate: null,
+        dueTime: null,
+        startDate: null,
+        repeatConfig: null,
+        repeatFrom: null,
+        sourceNoteId: null,
+        completedAt: null,
+        archivedAt: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        modifiedAt: '2026-01-01T00:00:00.000Z'
+      })
+
+      // #then
+      expect(taskQueries.insertTask).toHaveBeenCalledOnce()
+      expect(created.id).toBe('task-2')
+      expect(created.tags).toEqual(['urgent'])
+      expect(created.linkedNoteIds).toEqual(['note-1'])
+      expect(created.hasSubtasks).toBe(true)
+      expect(created.subtaskCount).toBe(2)
+      expect(created.completedSubtaskCount).toBe(1)
+      expect(created.isRepeating).toBe(false)
+    })
+
+    it('updateTask returns undefined when query returns nothing', () => {
+      // #given
+      vi.mocked(taskQueries.updateTask).mockReturnValue(undefined)
+
+      // #when
+      const result = repo.updateTask('missing', { title: 'x' })
+
+      // #then
+      expect(result).toBeUndefined()
+    })
+
+    it('updateTask enriches returned task', () => {
+      // #when
+      const result = repo.updateTask('task-1', { title: 'renamed' })
+
+      // #then
+      expect(taskQueries.updateTask).toHaveBeenCalledWith(db, 'task-1', { title: 'renamed' })
+      expect(result?.id).toBe('task-1')
+    })
+
+    it('deleteTask forwards to taskQueries.deleteTask', () => {
+      // #when
+      repo.deleteTask('task-1')
+
+      // #then
+      expect(taskQueries.deleteTask).toHaveBeenCalledWith(db, 'task-1')
+    })
+
+    it('getTask returns undefined when missing', () => {
+      vi.mocked(taskQueries.getTaskById).mockReturnValue(undefined)
+      expect(repo.getTask('missing')).toBeUndefined()
+    })
+
+    it('getTask enriches when found', () => {
+      vi.mocked(taskQueries.getTaskById).mockReturnValue(makeTaskRow())
+      const task = repo.getTask('task-1')
+      expect(task?.id).toBe('task-1')
+    })
+
+    it('completeTask sets completedAt via query', () => {
+      // #when
+      const result = repo.completeTask('task-1')
+
+      // #then
+      expect(taskQueries.completeTask).toHaveBeenCalledWith(db, 'task-1', undefined)
+      expect(result?.completedAt).not.toBeNull()
+    })
+
+    it('completeTask returns undefined when query returns undefined', () => {
+      vi.mocked(taskQueries.completeTask).mockReturnValue(undefined)
+      expect(repo.completeTask('missing')).toBeUndefined()
+    })
+
+    it('uncompleteTask clears completedAt', () => {
+      const result = repo.uncompleteTask('task-1')
+      expect(result?.completedAt).toBeNull()
+    })
+
+    it('archive / unarchive delegate + enrich', () => {
+      expect(repo.archiveTask('task-1')?.archivedAt).not.toBeNull()
+      expect(repo.unarchiveTask('task-1')?.archivedAt).toBeNull()
+    })
+
+    it('moveTask passes updates through', () => {
+      repo.moveTask('task-1', { projectId: 'proj-2', position: 5 })
+      expect(taskQueries.moveTask).toHaveBeenCalledWith(db, 'task-1', {
+        projectId: 'proj-2',
+        position: 5
+      })
+    })
+
+    it('reorderTasks forwards ids + positions', () => {
+      repo.reorderTasks(['a', 'b'], [1, 0])
+      expect(taskQueries.reorderTasks).toHaveBeenCalledWith(db, ['a', 'b'], [1, 0])
+    })
+
+    it('duplicateTask / duplicateSubtask delegate', () => {
+      expect(repo.duplicateTask('task-1', 'task-1-copy')?.id).toBe('task-1-copy')
+      const sub = repo.duplicateSubtask('task-1', 'sub-copy', 'parent-2')
+      expect(sub?.parentId).toBe('parent-2')
+    })
+  })
+
+  describe('list + count', () => {
+    it('listTasks enriches each row', () => {
+      // #given
+      vi.mocked(taskQueries.listTasks).mockReturnValue([makeTaskRow({ id: 'a' }), makeTaskRow({ id: 'b' })])
+
+      // #when
+      const list = repo.listTasks({ projectId: 'proj-1' })
+
+      // #then
+      expect(list).toHaveLength(2)
+      expect(list.map((t) => t.id)).toEqual(['a', 'b'])
+      expect(taskQueries.listTasks).toHaveBeenCalledWith(db, { projectId: 'proj-1' })
+    })
+
+    it('countTasks delegates to query', () => {
+      vi.mocked(taskQueries.countTasks).mockReturnValue(42)
+      expect(repo.countTasks({ includeCompleted: true })).toBe(42)
+    })
+
+    it('getSubtasks / countSubtasks delegate', () => {
+      vi.mocked(taskQueries.getSubtasks).mockReturnValue([makeTaskRow({ id: 'sub-1' })])
+      expect(repo.getSubtasks('task-1')).toHaveLength(1)
+      expect(repo.countSubtasks('task-1')).toEqual({ total: 0, completed: 0 })
+    })
+
+    it('getTodayTasks / getUpcomingTasks / getOverdueTasks / getTasksLinkedToNote enrich', () => {
+      vi.mocked(taskQueries.getTodayTasks).mockReturnValue([makeTaskRow({ id: 't' })])
+      vi.mocked(taskQueries.getUpcomingTasks).mockReturnValue([makeTaskRow({ id: 'u' })])
+      vi.mocked(taskQueries.getOverdueTasks).mockReturnValue([makeTaskRow({ id: 'o' })])
+      vi.mocked(taskQueries.getTasksLinkedToNote).mockReturnValue([makeTaskRow({ id: 'l' })])
+
+      expect(repo.getTodayTasks()).toHaveLength(1)
+      expect(repo.getUpcomingTasks(7)).toHaveLength(1)
+      expect(repo.getOverdueTasks()).toHaveLength(1)
+      expect(repo.getTasksLinkedToNote('note-1')).toHaveLength(1)
+      expect(taskQueries.getUpcomingTasks).toHaveBeenCalledWith(db, 7)
+    })
+
+    it('getNextTaskPosition passes parentId through', () => {
+      repo.getNextTaskPosition('proj-1', 'parent-1')
+      expect(taskQueries.getNextTaskPosition).toHaveBeenCalledWith(db, 'proj-1', 'parent-1')
+    })
+  })
+
+  describe('tags and notes', () => {
+    it('get/setTaskTags delegate', () => {
+      vi.mocked(taskQueries.getTaskTags).mockReturnValue(['urgent'])
+      expect(repo.getTaskTags('task-1')).toEqual(['urgent'])
+      repo.setTaskTags('task-1', ['new'])
+      expect(taskQueries.setTaskTags).toHaveBeenCalledWith(db, 'task-1', ['new'])
+    })
+
+    it('get/setTaskNoteIds delegate', () => {
+      vi.mocked(taskQueries.getTaskNoteIds).mockReturnValue(['n'])
+      expect(repo.getTaskNoteIds('task-1')).toEqual(['n'])
+      repo.setTaskNotes('task-1', ['n2'])
+      expect(taskQueries.setTaskNotes).toHaveBeenCalledWith(db, 'task-1', ['n2'])
+    })
+
+    it('getAllTaskTags + getTaskStats delegate', () => {
+      vi.mocked(taskQueries.getAllTaskTags).mockReturnValue([{ tag: 'urgent', count: 3 }])
+      expect(repo.getAllTaskTags()).toEqual([{ tag: 'urgent', count: 3 }])
+      const stats = repo.getTaskStats()
+      expect(stats.total).toBe(0)
+    })
+  })
+
+  describe('bulk operations', () => {
+    it('bulkComplete/Delete/Move/Archive return counts', () => {
+      vi.mocked(taskQueries.bulkCompleteTasks).mockReturnValue(3)
+      vi.mocked(taskQueries.bulkDeleteTasks).mockReturnValue(2)
+      vi.mocked(taskQueries.bulkMoveTasks).mockReturnValue(4)
+      vi.mocked(taskQueries.bulkArchiveTasks).mockReturnValue(1)
+
+      expect(repo.bulkCompleteTasks(['a', 'b', 'c'])).toBe(3)
+      expect(repo.bulkDeleteTasks(['a', 'b'])).toBe(2)
+      expect(repo.bulkMoveTasks(['a', 'b'], 'proj-2')).toBe(4)
+      expect(repo.bulkArchiveTasks(['a'])).toBe(1)
+      expect(taskQueries.bulkMoveTasks).toHaveBeenCalledWith(db, ['a', 'b'], 'proj-2')
+    })
+  })
+
+  describe('projects', () => {
+    it('createProject delegates', () => {
+      repo.createProject({
+        id: 'p',
+        name: 'P',
+        description: null,
+        color: '#000',
+        icon: null,
+        position: 0,
+        isInbox: false
+      })
+      expect(projectQueries.insertProject).toHaveBeenCalledOnce()
+    })
+
+    it('updateProject / deleteProject / archiveProject delegate', () => {
+      repo.updateProject('p', { name: 'X' })
+      repo.deleteProject('p')
+      repo.archiveProject('p')
+      expect(projectQueries.updateProject).toHaveBeenCalledWith(db, 'p', { name: 'X' })
+      expect(projectQueries.deleteProject).toHaveBeenCalledWith(db, 'p')
+      expect(projectQueries.archiveProject).toHaveBeenCalledWith(db, 'p')
+    })
+
+    it('getProject returns project with statuses', () => {
+      const p = repo.getProject('p-1')
+      expect(p?.id).toBe('p-1')
+      expect(p?.statuses).toHaveLength(1)
+    })
+
+    it('listProjects returns projects with stats', () => {
+      const list = repo.listProjects()
+      expect(list).toHaveLength(1)
+      expect(list[0].taskCount).toBe(2)
+    })
+
+    it('reorderProjects / getNextProjectPosition delegate', () => {
+      repo.reorderProjects(['a', 'b'], [0, 1])
+      expect(projectQueries.reorderProjects).toHaveBeenCalledWith(db, ['a', 'b'], [0, 1])
+      expect(repo.getNextProjectPosition()).toBe(3)
+    })
+  })
+
+  describe('statuses', () => {
+    it('create/list/get/update/delete delegate', () => {
+      repo.createStatus({
+        id: 's',
+        projectId: 'p',
+        name: 'Todo',
+        color: '#000',
+        position: 0,
+        isDefault: true,
+        isDone: false
+      })
+      expect(projectQueries.insertStatus).toHaveBeenCalled()
+
+      expect(repo.listStatuses('p-1')).toHaveLength(1)
+      expect(repo.getStatus('s-1')?.id).toBe('s-1')
+
+      repo.updateStatus('s-1', { name: 'New' })
+      expect(projectQueries.updateStatus).toHaveBeenCalledWith(db, 's-1', { name: 'New' })
+
+      repo.deleteStatus('s-1')
+      expect(projectQueries.deleteStatus).toHaveBeenCalledWith(db, 's-1')
+    })
+
+    it('reorderStatuses + getNextStatusPosition delegate', () => {
+      repo.reorderStatuses(['a', 'b'], [0, 1])
+      expect(projectQueries.reorderStatuses).toHaveBeenCalledWith(db, ['a', 'b'], [0, 1])
+      expect(repo.getNextStatusPosition('p-1')).toBe(2)
+    })
+
+    it('createDefaultStatuses + createCustomStatuses + reconcile + equivalent delegate', () => {
+      expect(repo.createDefaultStatuses('p-1')).toHaveLength(1)
+      expect(
+        repo.createCustomStatuses('p-1', [{ name: 'A', color: '#000', type: 'todo', order: 0 }])
+      ).toHaveLength(1)
+      repo.reconcileProjectStatuses('p-1', [
+        { name: 'A', color: '#000', type: 'todo', order: 0 }
+      ])
+      expect(projectQueries.reconcileProjectStatuses).toHaveBeenCalled()
+
+      const eq = repo.getEquivalentStatus('p-2', makeStatus({ id: 'src' }))
+      expect(eq?.id).toBe('src')
+    })
+  })
+})

--- a/packages/storage-vault/src/note-content-store.test.ts
+++ b/packages/storage-vault/src/note-content-store.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { createNoteContentStore, type NoteContentStore, type VaultStoreLayout } from './note-content-store'
+
+describe('createNoteContentStore', () => {
+  let rootPath: string
+  let layout: VaultStoreLayout
+  let store: NoteContentStore
+
+  beforeEach(async () => {
+    rootPath = path.join(
+      os.tmpdir(),
+      `memry-test-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+    )
+    await fs.mkdir(rootPath, { recursive: true })
+    layout = {
+      rootPath,
+      notesFolder: 'notes',
+      journalFolder: 'journal'
+    }
+    store = createNoteContentStore(layout)
+  })
+
+  afterEach(async () => {
+    await fs.rm(rootPath, { recursive: true, force: true })
+  })
+
+  describe('resolve', () => {
+    it('joins root + relative path', () => {
+      // #when
+      const resolved = store.resolve('notes/hello.md')
+
+      // #then
+      expect(resolved).toBe(path.join(rootPath, 'notes/hello.md'))
+    })
+  })
+
+  describe('write + read', () => {
+    it('writes file and creates parent directories', async () => {
+      // #when
+      await store.write('notes/sub/deep/hello.md', 'hello world')
+
+      // #then
+      const contents = await fs.readFile(
+        path.join(rootPath, 'notes/sub/deep/hello.md'),
+        'utf-8'
+      )
+      expect(contents).toBe('hello world')
+    })
+
+    it('read returns written content', async () => {
+      // #given
+      await store.write('notes/hello.md', 'body')
+
+      // #when
+      const read = await store.read('notes/hello.md')
+
+      // #then
+      expect(read).toBe('body')
+    })
+
+    it('overwrites existing file on write', async () => {
+      // #given
+      await store.write('notes/hello.md', 'v1')
+
+      // #when
+      await store.write('notes/hello.md', 'v2')
+
+      // #then
+      expect(await store.read('notes/hello.md')).toBe('v2')
+    })
+
+    it('write uses tmp+rename (no .tmp residue on success)', async () => {
+      // #when
+      await store.write('notes/atomic.md', 'done')
+
+      // #then
+      const dir = await fs.readdir(path.join(rootPath, 'notes'))
+      expect(dir).toContain('atomic.md')
+      expect(dir.filter((f) => f.endsWith('.tmp'))).toHaveLength(0)
+    })
+
+    it('read returns null when file does not exist', async () => {
+      // #when
+      const value = await store.read('notes/missing.md')
+
+      // #then
+      expect(value).toBeNull()
+    })
+  })
+
+  describe('exists', () => {
+    it('returns true when file exists', async () => {
+      // #given
+      await store.write('notes/here.md', 'x')
+
+      // #when / #then
+      expect(await store.exists('notes/here.md')).toBe(true)
+    })
+
+    it('returns false when file missing', async () => {
+      expect(await store.exists('notes/missing.md')).toBe(false)
+    })
+  })
+
+  describe('remove', () => {
+    it('deletes existing file and returns true', async () => {
+      // #given
+      await store.write('notes/gone.md', 'x')
+
+      // #when
+      const removed = await store.remove('notes/gone.md')
+
+      // #then
+      expect(removed).toBe(true)
+      expect(await store.exists('notes/gone.md')).toBe(false)
+    })
+
+    it('returns false when file missing', async () => {
+      // #when
+      const removed = await store.remove('notes/nothing.md')
+
+      // #then
+      expect(removed).toBe(false)
+    })
+  })
+
+  describe('getJournalRelativePath', () => {
+    it('returns YYYY-MM-DD.md under journal folder', () => {
+      // #when
+      const p = store.getJournalRelativePath('2026-04-16')
+
+      // #then
+      expect(p).toBe('journal/2026-04-16.md')
+    })
+
+    it('uses forward slashes regardless of platform', () => {
+      // #when
+      const p = store.getJournalRelativePath('2026-04-16')
+
+      // #then
+      expect(p).not.toContain('\\')
+    })
+
+    it('respects custom journalFolder', () => {
+      // #given
+      const custom = createNoteContentStore({ ...layout, journalFolder: 'daily' })
+
+      // #when
+      const p = custom.getJournalRelativePath('2026-04-16')
+
+      // #then
+      expect(p).toBe('daily/2026-04-16.md')
+    })
+  })
+})


### PR DESCRIPTION
Phase 4 U3 of tech-debt-remediation. Adds 68 tests across 3 files for packages that had zero coverage.

- packages/storage-data/src/note-metadata-repository.test.ts (25 tests, real in-memory SQLite via @tests/utils/test-db)
- packages/storage-data/src/tasks-repository.test.ts (31 tests, mocked query modules)
- packages/storage-vault/src/note-content-store.test.ts (12 tests, real fs via os.tmpdir)

All 68 new tests pass. Full suite: 5940 passing, 1 skipped. Typecheck clean.

Plan: .claude/plans/tech-debt-remediation.md