### PR TITLE
chore(turbo): declare typecheck outputs + scope cache inputs

### DIFF
--- a/docs/turbo-cache.md
+++ b/docs/turbo-cache.md
@@ -1,0 +1,38 @@
+# Turbo Cache
+
+Memry uses [Turborepo](https://turborepo.com/docs/crafting-your-repository/caching) to cache task outputs across the monorepo. This note covers what is cached, how to inspect it, and how to debug misses.
+
+## Cached vs Not Cached
+
+| Task        | Cached? | Outputs                             |
+| ----------- | ------- | ----------------------------------- |
+| `dev`       | No      | (long-running, persistent)          |
+| `build`     | Yes     | `out/**`, `dist/**`, `.wrangler/**` |
+| `typecheck` | Yes     | `**/*.tsbuildinfo`                  |
+| `test`      | Yes     | none (exit code only)               |
+| `lint`      | Yes     | none (exit code only)               |
+
+Cache storage is local-only via `.turbo/` in the repo root. Remote caching is not configured.
+
+## Scoped Invalidation via `inputs`
+
+Each cacheable task in `turbo.json` declares an `inputs` allowlist so unrelated file changes (e.g. Markdown, images, migrations) don't bust the cache. If you add a new file extension the task needs to watch, extend the `inputs` array there.
+
+- `typecheck`: `.ts`, `.tsx`, `tsconfig*.json`, `package.json`
+- `test`: `.ts`, `.tsx`, `**/*.test.*`, `package.json`, `vitest.config.*`
+- `lint`: `.ts`, `.tsx`, `.js`, `.jsx`, `eslint.config.*`, `.eslintrc*`, `package.json`
+- `build`: default (all tracked source), since builds can pull in JSON, assets, etc.
+
+## Inspecting Cache Behavior
+
+```bash
+turbo run build --summarize         # writes .turbo/runs/<hash>.json with hit/miss per task
+turbo run build --dry=json          # preview what would run without executing
+turbo run build --force             # bypass cache (useful when debugging a suspected bad hit)
+```
+
+The human-readable summary at the tail of a run shows `cache hit, replaying logs` or `cache miss, executing …` per task. A full no-op re-run reports `>>> FULL TURBO`.
+
+## Typecheck Incremental Note
+
+No package currently sets `incremental: true` in `tsconfig.json`, so `**/*.tsbuildinfo` is a forward-looking output — if a package opts in later the cache picks it up with no `turbo.json` edit.

--- a/turbo.json
+++ b/turbo.json
@@ -6,19 +6,34 @@
       "persistent": true
     },
     "build": {
+      "cache": true,
       "dependsOn": ["^build"],
       "outputs": ["out/**", "dist/**", ".wrangler/**"]
     },
     "typecheck": {
+      "cache": true,
       "dependsOn": ["^typecheck"],
-      "outputs": []
+      "inputs": ["**/*.ts", "**/*.tsx", "tsconfig*.json", "package.json"],
+      "outputs": ["**/*.tsbuildinfo"]
     },
     "test": {
+      "cache": true,
       "dependsOn": ["^test"],
+      "inputs": ["**/*.ts", "**/*.tsx", "**/*.test.*", "package.json", "vitest.config.*"],
       "outputs": []
     },
     "lint": {
+      "cache": true,
       "dependsOn": ["^lint"],
+      "inputs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "eslint.config.*",
+        ".eslintrc*",
+        "package.json"
+      ],
       "outputs": []
     }
   }


### PR DESCRIPTION
## Summary

Part of Phase 5 (UI stubs + polish) in the tech-debt-remediation plan — see `.claude/plans/tech-debt-remediation.md § 5.5`.

Three tightening changes to `turbo.json`:

- **Explicit `cache: true`** on every cacheable task (documents intent; default behaviour but makes it visible).
- **`outputs: ["**/*.tsbuildinfo"]`** on the `typecheck` task so incremental TypeScript state is cached across runs.
- **Per-task `inputs`** scoping cache invalidation to relevant source / config:
  - `typecheck` → `*.ts`, `*.tsx`, `tsconfig*.json`, `package.json`
  - `test` → `*.ts`, `*.tsx`, `*.test.*`, `package.json`, `vitest.config.*`
  - `lint` → `*.ts`, `*.tsx`, `*.js`, `*.jsx`, `eslint.config.*`, `.eslintrc*`, `package.json`
  - `build` left at default (all source) intentionally.

New `docs/turbo-cache.md` documents the cache model, how to inspect hits/misses, and how to force re-runs while debugging.

## Test plan

- [x] `turbo run typecheck --dry=json` accepts the new config
- [ ] After merge: run `turbo run build --filter=@memry/desktop` twice locally; second run should show cache hits for unchanged packages
- [ ] Touch one `.ts` in `apps/desktop/src/renderer/`, re-run `turbo run typecheck`; confirm only `@memry/desktop` invalidates, library packages stay warm
- [x] `pnpm ipc:check` unaffected (config changes don't touch it)

## Notes

- Root `package.json` scripts (via `scripts/run-turbo.js` wrapper) and `.github/workflows/*` are intentionally unchanged — they orchestrate filters independently.
- No behavioural change to existing build output; this is purely a cache-correctness and cache-scoping win.