### PR TITLE
feat(sidebar): wire tag rename + delete actions

### DIFF
--- a/apps/desktop/src/renderer/src/components/sidebar/tag-delete-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/tag-delete-dialog.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react'
+import { useState } from 'react'
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+
+export interface TagDeleteDialogProps {
+  tag: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => Promise<void>
+}
+
+export function TagDeleteDialog({
+  tag,
+  open,
+  onOpenChange,
+  onConfirm
+}: TagDeleteDialogProps): React.JSX.Element {
+  const [submitting, setSubmitting] = useState(false)
+
+  const close = (): void => {
+    if (submitting) return
+    onOpenChange(false)
+  }
+
+  const handleConfirm = async (): Promise<void> => {
+    setSubmitting(true)
+    try {
+      await onConfirm()
+      onOpenChange(false)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={(next) => (!next ? close() : onOpenChange(next))}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete tag #{tag}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Notes with this tag won&apos;t be deleted, just untagged.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <Button variant="outline" onClick={close} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => void handleConfirm()}
+            disabled={submitting}
+          >
+            {submitting ? 'Deleting...' : 'Delete tag'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export default TagDeleteDialog

--- a/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.test.tsx
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { TagDetailView } from './tag-detail-view'
+
+const {
+  mockRenameTag,
+  mockDeleteTag,
+  mockUpdateTagColor,
+  mockGetNotesByTag,
+  mockPinNoteToTag,
+  mockUnpinNoteFromTag,
+  mockRemoveTagFromNote,
+  mockGetAllWithCounts,
+  mockMergeTag,
+  mockOnTagRenamed,
+  mockOnTagDeleted,
+  mockOnTagNotesChanged,
+  mockOnTagColorUpdated,
+  mockToastSuccess,
+  mockToastError,
+  mockGoBack,
+  mockOpenSidebarItem
+} = vi.hoisted(() => ({
+  mockRenameTag: vi.fn(),
+  mockDeleteTag: vi.fn(),
+  mockUpdateTagColor: vi.fn(),
+  mockGetNotesByTag: vi.fn(),
+  mockPinNoteToTag: vi.fn(),
+  mockUnpinNoteFromTag: vi.fn(),
+  mockRemoveTagFromNote: vi.fn(),
+  mockGetAllWithCounts: vi.fn(),
+  mockMergeTag: vi.fn(),
+  mockOnTagRenamed: vi.fn(() => () => {}),
+  mockOnTagDeleted: vi.fn(() => () => {}),
+  mockOnTagNotesChanged: vi.fn(() => () => {}),
+  mockOnTagColorUpdated: vi.fn(() => () => {}),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockGoBack: vi.fn(),
+  mockOpenSidebarItem: vi.fn()
+}))
+
+vi.mock('@/services/tags-service', () => ({
+  tagsService: {
+    getNotesByTag: mockGetNotesByTag,
+    pinNoteToTag: mockPinNoteToTag,
+    unpinNoteFromTag: mockUnpinNoteFromTag,
+    renameTag: mockRenameTag,
+    updateTagColor: mockUpdateTagColor,
+    deleteTag: mockDeleteTag,
+    removeTagFromNote: mockRemoveTagFromNote,
+    getAllWithCounts: mockGetAllWithCounts,
+    mergeTag: mockMergeTag
+  },
+  onTagRenamed: mockOnTagRenamed,
+  onTagDeleted: mockOnTagDeleted,
+  onTagNotesChanged: mockOnTagNotesChanged,
+  onTagColorUpdated: mockOnTagColorUpdated
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: mockToastSuccess,
+    error: mockToastError
+  }
+}))
+
+vi.mock('@/contexts/sidebar-drill-down', () => ({
+  useSidebarDrillDown: () => ({
+    viewStack: [],
+    currentView: { type: 'tag', tag: 'react', color: 'blue' },
+    isAtMain: false,
+    animationDirection: null,
+    openTag: vi.fn(),
+    goBack: mockGoBack,
+    resetToMain: vi.fn()
+  })
+}))
+
+vi.mock('@/hooks/use-sidebar-navigation', () => ({
+  useSidebarNavigation: () => ({
+    openSidebarItem: mockOpenSidebarItem
+  })
+}))
+
+const defaultNotesResponse = {
+  tag: 'react',
+  color: 'blue',
+  count: 0,
+  pinnedNotes: [],
+  unpinnedNotes: []
+}
+
+const success = { success: true as const }
+
+describe('TagDetailView rename + delete actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetNotesByTag.mockResolvedValue(defaultNotesResponse)
+    mockRenameTag.mockResolvedValue(success)
+    mockDeleteTag.mockResolvedValue(success)
+    ;(mockOnTagRenamed as Mock).mockReturnValue(() => {})
+    ;(mockOnTagDeleted as Mock).mockReturnValue(() => {})
+    ;(mockOnTagNotesChanged as Mock).mockReturnValue(() => {})
+    ;(mockOnTagColorUpdated as Mock).mockReturnValue(() => {})
+  })
+
+  const renderView = async () => {
+    const view = render(<TagDetailView tag="react" color="blue" />)
+    // Wait for the initial load to finish
+    await waitFor(() => expect(mockGetNotesByTag).toHaveBeenCalled())
+    return view
+  }
+
+  const openOverflow = async (user: ReturnType<typeof userEvent.setup>) => {
+    const trigger = screen.getByRole('button', { name: 'Tag actions' })
+    await user.click(trigger)
+  }
+
+  describe('rename', () => {
+    it('opens dialog prefilled with current tag name', async () => {
+      const user = userEvent.setup()
+      await renderView()
+      await openOverflow(user)
+
+      await user.click(await screen.findByText('Edit tag name'))
+
+      const input = await screen.findByLabelText('New name')
+      expect(input).toHaveValue('react')
+    })
+
+    it('calls renameTag with trimmed new name and closes on success', async () => {
+      const user = userEvent.setup()
+      await renderView()
+      await openOverflow(user)
+      await user.click(await screen.findByText('Edit tag name'))
+
+      const input = await screen.findByLabelText('New name')
+      await user.clear(input)
+      await user.type(input, '  typescript  ')
+      await user.click(screen.getByRole('button', { name: 'Save' }))
+
+      await waitFor(() =>
+        expect(mockRenameTag).toHaveBeenCalledWith({ oldName: 'react', newName: 'typescript' })
+      )
+      expect(mockToastSuccess).toHaveBeenCalledWith('Renamed #react to #typescript')
+      expect(mockGoBack).toHaveBeenCalled()
+    })
+
+    it('refuses empty input', async () => {
+      const user = userEvent.setup()
+      await renderView()
+      await openOverflow(user)
+      await user.click(await screen.findByText('Edit tag name'))
+
+      const input = await screen.findByLabelText('New name')
+      await user.clear(input)
+      await user.click(screen.getByRole('button', { name: 'Save' }))
+
+      expect(await screen.findByText('Tag name cannot be empty')).toBeInTheDocument()
+      expect(mockRenameTag).not.toHaveBeenCalled()
+    })
+
+    it('toasts error and keeps dialog open on failure', async () => {
+      mockRenameTag.mockResolvedValueOnce({ success: false, error: 'Tag already exists' })
+      const user = userEvent.setup()
+      await renderView()
+      await openOverflow(user)
+      await user.click(await screen.findByText('Edit tag name'))
+
+      const input = await screen.findByLabelText('New name')
+      await user.clear(input)
+      await user.type(input, 'typescript')
+      await user.click(screen.getByRole('button', { name: 'Save' }))
+
+      await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('Tag already exists'))
+      expect(mockGoBack).not.toHaveBeenCalled()
+      expect(await screen.findByLabelText('New name')).toBeInTheDocument()
+    })
+  })
+
+  describe('delete', () => {
+    it('calls deleteTag and navigates back on confirm', async () => {
+      const user = userEvent.setup()
+      await renderView()
+      await openOverflow(user)
+
+      await user.click(await screen.findByText('Delete tag'))
+      expect(await screen.findByText(/Delete tag #react\?/i)).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: 'Delete tag' }))
+
+      await waitFor(() => expect(mockDeleteTag).toHaveBeenCalledWith('react'))
+      expect(mockToastSuccess).toHaveBeenCalledWith('Deleted #react')
+      expect(mockGoBack).toHaveBeenCalled()
+    })
+
+    it('toasts error when delete fails', async () => {
+      mockDeleteTag.mockResolvedValueOnce({ success: false, error: 'Permission denied' })
+      const user = userEvent.setup()
+      await renderView()
+      await openOverflow(user)
+      await user.click(await screen.findByText('Delete tag'))
+      await user.click(screen.getByRole('button', { name: 'Delete tag' }))
+
+      await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('Permission denied'))
+      expect(mockGoBack).not.toHaveBeenCalled()
+    })
+
+    it('cancel closes dialog without calling deleteTag', async () => {
+      const user = userEvent.setup()
+      await renderView()
+      await openOverflow(user)
+      await user.click(await screen.findByText('Delete tag'))
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect(mockDeleteTag).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('event subscriptions', () => {
+    it('subscribes to onTagRenamed and onTagDeleted on mount', async () => {
+      await renderView()
+      expect(mockOnTagRenamed).toHaveBeenCalled()
+      expect(mockOnTagDeleted).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.tsx
@@ -10,7 +10,7 @@
  */
 
 import * as React from 'react'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import {
   ArrowLeft,
   MoreHorizontal,
@@ -46,12 +46,19 @@ import { useSidebarDrillDown } from '@/contexts/sidebar-drill-down'
 import { useTagDetail, type TagSortBy } from '@/hooks/use-tag-detail'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
 import { COLOR_NAMES, getTagColors } from '@/components/note/tags-row/tag-colors'
-import { tagsService, type TagNoteItem } from '@/services/tags-service'
+import {
+  tagsService,
+  onTagRenamed,
+  onTagDeleted,
+  type TagNoteItem
+} from '@/services/tags-service'
 import type { SidebarItem } from '@/contexts/tabs/types'
 import { createLogger } from '@/lib/logger'
 import { toast } from 'sonner'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { NoteIconDisplay } from '@/lib/render-note-icon'
+import { TagRenameDialog } from './tag-rename-dialog'
+import { TagDeleteDialog } from './tag-delete-dialog'
 
 const log = createLogger('Component:TagDetailView')
 
@@ -74,8 +81,12 @@ export function TagDetailView({ tag, color, className }: TagDetailViewProps): Re
     sortBy,
     setSortBy,
     pinNote,
-    unpinNote
+    unpinNote,
+    refresh
   } = useTagDetail({ tag, fallbackColor: color })
+
+  const [renameOpen, setRenameOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
 
   const tagColors = getTagColors(resolvedColor)
 
@@ -93,6 +104,58 @@ export function TagDetailView({ tag, color, className }: TagDetailViewProps): Re
     },
     [openSidebarItem]
   )
+
+  const handleRenameSubmit = useCallback(
+    async (newName: string) => {
+      try {
+        const result = await tagsService.renameTag({ oldName: tag, newName })
+        if (!result.success) {
+          throw new Error(result.error ?? 'Failed to rename tag')
+        }
+        toast.success(`Renamed #${tag} to #${newName}`)
+        goBack()
+      } catch (err) {
+        log.error('Failed to rename tag', err)
+        const message = extractErrorMessage(err, 'Failed to rename tag')
+        toast.error(message)
+        throw err instanceof Error ? err : new Error(message)
+      }
+    },
+    [goBack, tag]
+  )
+
+  const handleDeleteConfirm = useCallback(async () => {
+    try {
+      const result = await tagsService.deleteTag(tag)
+      if (!result.success) {
+        throw new Error(result.error ?? 'Failed to delete tag')
+      }
+      toast.success(`Deleted #${tag}`)
+      goBack()
+    } catch (err) {
+      log.error('Failed to delete tag', err)
+      toast.error(extractErrorMessage(err, 'Failed to delete tag'))
+    }
+  }, [goBack, tag])
+
+  useEffect(() => {
+    const unsubscribeRenamed = onTagRenamed((event) => {
+      if (event.oldName.toLowerCase() === tag.toLowerCase()) {
+        goBack()
+        return
+      }
+      void refresh()
+    })
+    const unsubscribeDeleted = onTagDeleted((event) => {
+      if (event.tag.toLowerCase() === tag.toLowerCase()) {
+        goBack()
+      }
+    })
+    return () => {
+      unsubscribeRenamed()
+      unsubscribeDeleted()
+    }
+  }, [goBack, refresh, tag])
 
   return (
     <div className={cn('flex flex-col h-full', className)}>
@@ -138,8 +201,26 @@ export function TagDetailView({ tag, color, className }: TagDetailViewProps): Re
         </div>
 
         {/* Overflow menu */}
-        <TagOverflowMenu tag={tag} color={resolvedColor} />
+        <TagOverflowMenu
+          tag={tag}
+          color={resolvedColor}
+          onRequestRename={() => setRenameOpen(true)}
+          onRequestDelete={() => setDeleteOpen(true)}
+        />
       </div>
+
+      <TagRenameDialog
+        tag={tag}
+        open={renameOpen}
+        onOpenChange={setRenameOpen}
+        onSubmit={handleRenameSubmit}
+      />
+      <TagDeleteDialog
+        tag={tag}
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        onConfirm={handleDeleteConfirm}
+      />
 
       {/* Content */}
       <ScrollArea className="flex-1">
@@ -313,16 +394,17 @@ function NoteItem({ note, isPinned, onClick, onPin, onUnpin }: NoteItemProps): R
 interface TagOverflowMenuProps {
   tag: string
   color: string
+  onRequestRename: () => void
+  onRequestDelete: () => void
 }
 
-function TagOverflowMenu({ tag, color }: TagOverflowMenuProps): React.JSX.Element {
-  // TODO: Implement rename and delete handlers
+function TagOverflowMenu({
+  tag,
+  color,
+  onRequestRename,
+  onRequestDelete
+}: TagOverflowMenuProps): React.JSX.Element {
   const [isUpdatingColor, setIsUpdatingColor] = React.useState(false)
-
-  const handleRename = () => {
-    log.info('Rename tag:', tag)
-    // TODO: Open rename dialog
-  }
 
   const handleColorChange = async (newColor: string) => {
     if (newColor === color || isUpdatingColor) {
@@ -343,22 +425,22 @@ function TagOverflowMenu({ tag, color }: TagOverflowMenuProps): React.JSX.Elemen
     }
   }
 
-  const handleDelete = () => {
-    log.info('Delete tag:', tag)
-    // TODO: Show confirmation and call tagsService.deleteTag
-  }
-
   const colorOptions = COLOR_NAMES
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          aria-label="Tag actions"
+        >
           <MoreHorizontal className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48">
-        <DropdownMenuItem onClick={handleRename}>
+        <DropdownMenuItem onClick={onRequestRename}>
           <Pencil className="h-4 w-4 mr-2" />
           Edit tag name
         </DropdownMenuItem>
@@ -390,7 +472,7 @@ function TagOverflowMenu({ tag, color }: TagOverflowMenuProps): React.JSX.Elemen
         </DropdownMenuSub>
         <DropdownMenuSeparator />
         <DropdownMenuItem
-          onClick={handleDelete}
+          onClick={onRequestDelete}
           className="text-destructive focus:text-destructive"
         >
           <Trash2 className="h-4 w-4 mr-2" />

--- a/apps/desktop/src/renderer/src/components/sidebar/tag-rename-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/tag-rename-dialog.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react'
+import { useEffect, useState } from 'react'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+export interface TagRenameDialogProps {
+  tag: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (newName: string) => Promise<void>
+}
+
+export function TagRenameDialog({
+  tag,
+  open,
+  onOpenChange,
+  onSubmit
+}: TagRenameDialogProps): React.JSX.Element {
+  const [value, setValue] = useState(tag)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setValue(tag)
+      setError(null)
+      setSubmitting(false)
+    }
+  }, [open, tag])
+
+  const close = (): void => {
+    if (submitting) return
+    onOpenChange(false)
+  }
+
+  const handleSave = async (): Promise<void> => {
+    const next = value.trim()
+    if (!next) {
+      setError('Tag name cannot be empty')
+      return
+    }
+    if (next === tag) {
+      onOpenChange(false)
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      await onSubmit(next)
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Rename failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      void handleSave()
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (!next ? close() : onOpenChange(next))}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Rename tag</DialogTitle>
+          <DialogDescription>
+            Rename <span className="font-mono">#{tag}</span> across every note that uses it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2 py-2">
+          <Label htmlFor="tag-rename-input">New name</Label>
+          <Input
+            id="tag-rename-input"
+            value={value}
+            onChange={(event) => {
+              setValue(event.target.value)
+              if (error) setError(null)
+            }}
+            onKeyDown={handleKeyDown}
+            disabled={submitting}
+            autoFocus
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? 'tag-rename-error' : undefined}
+          />
+          {error && (
+            <p id="tag-rename-error" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={close} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={submitting}>
+            {submitting ? 'Saving...' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default TagRenameDialog

--- a/apps/desktop/tests/e2e/tags-rename-delete.e2e.ts
+++ b/apps/desktop/tests/e2e/tags-rename-delete.e2e.ts
@@ -1,0 +1,91 @@
+// @ts-nocheck
+/**
+ * Tags Rename + Delete E2E
+ *
+ * Covers the sidebar tag detail view's overflow menu flows:
+ *  - Rename dialog: input prefilled, save calls rename, sidebar refreshes.
+ *  - Delete dialog: confirmation, tag removed from sidebar after confirm.
+ *
+ * Plan ref: .claude/plans/tech-debt-remediation.md § 5.2
+ */
+
+import { test, expect } from './fixtures'
+import { waitForAppReady, waitForVaultReady, SELECTORS } from './utils/electron-helpers'
+
+const UNIQUE = Date.now().toString(36)
+const TAG = `renamecandidate${UNIQUE}`
+const RENAMED = `renamed${UNIQUE}`
+
+async function seedNoteWithTag(page, tag: string): Promise<void> {
+  const created = await page.evaluate(async (tagName) => {
+    const api = (window as unknown as { api: Record<string, any> }).api
+    if (!api?.notes?.create) return false
+    const res = await api.notes.create({
+      title: `Tag Test ${tagName}`,
+      content: `Note body with #${tagName}`,
+      tags: [tagName]
+    })
+    return !!res?.success
+  }, tag)
+  expect(created).toBeTruthy()
+}
+
+async function openTagDrilldown(page, tag: string): Promise<void> {
+  // Tags appear as buttons rendered by TagTreeItem; they have the tag text.
+  const tagTrigger = page.locator(`aside button:has-text("${tag}")`).first()
+  await tagTrigger.waitFor({ state: 'visible', timeout: 15000 })
+  await tagTrigger.click()
+  // Wait for drill-down header to settle
+  await page.locator('button[aria-label="Go back"]').waitFor({ state: 'visible', timeout: 10000 })
+}
+
+test.describe('Tag rename + delete (§5.2)', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+  })
+
+  test('renames a tag via overflow menu', async ({ page }) => {
+    await seedNoteWithTag(page, TAG)
+    await openTagDrilldown(page, TAG)
+
+    await page.locator('button[aria-label="Tag actions"]').click()
+    await page.locator('text=Edit tag name').click()
+
+    const input = page.locator('#tag-rename-input')
+    await expect(input).toBeVisible()
+    await expect(input).toHaveValue(TAG)
+
+    await input.fill(RENAMED)
+    await page.locator('button', { hasText: 'Save' }).click()
+
+    // After success we auto-navigate back; sidebar should show renamed tag
+    await expect(page.locator(`aside button:has-text("${RENAMED}")`).first()).toBeVisible({
+      timeout: 10000
+    })
+    await expect(page.locator(`aside button:has-text("${TAG}")`)).toHaveCount(0)
+  })
+
+  test('deletes a tag via overflow menu', async ({ page }) => {
+    const deleteTag = `deletecandidate${UNIQUE}`
+    await seedNoteWithTag(page, deleteTag)
+    await openTagDrilldown(page, deleteTag)
+
+    await page.locator('button[aria-label="Tag actions"]').click()
+    await page.locator('text=Delete tag').first().click()
+
+    // Confirmation dialog
+    await expect(page.locator(`text=Delete tag #${deleteTag}?`)).toBeVisible()
+    // Click the destructive confirm — matches the "Delete tag" button in the dialog
+    await page
+      .locator('[role="alertdialog"] button', { hasText: 'Delete tag' })
+      .click()
+
+    await expect(page.locator(`aside button:has-text("${deleteTag}")`)).toHaveCount(0, {
+      timeout: 10000
+    })
+  })
+})
+
+// Keep referenced so unused-imports linters stay quiet if SELECTORS evolves.
+void SELECTORS


### PR DESCRIPTION
## Summary

Part of Phase 5 (UI stubs + polish) in the tech-debt-remediation plan — see `.claude/plans/tech-debt-remediation.md § 5.2`.

Closes three TODOs in `apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.tsx` (lines 319, 324, 348).

### New components
- **`tag-rename-dialog.tsx`** — controlled shadcn `Dialog` with prefilled input, submit-locked while in-flight, calls `tagsService.renameTag({ oldName, newName })`.
- **`tag-delete-dialog.tsx`** — shadcn `AlertDialog` with confirmation copy clarifying that notes are _untagged_, not deleted. Calls `tagsService.deleteTag(tag)`.

### Wiring changes
- `TagOverflowMenu` now opens each dialog on its respective menu item.
- On success/failure: `toast.success` / `toast.error` using the existing `extractErrorMessage` helper.
- Subscribes to `onTagRenamed` and `onTagDeleted` events so the detail view re-fetches after a mutation.

### Tests
- `tag-detail-view.test.tsx` (vitest + RTL): mocks `tagsService`, asserts menu entries open the correct dialog, dialogs call the right service method with correct args, and toasts fire on both paths.
- `tests/e2e/tags-rename-delete.e2e.ts` (Playwright): seeds a note with a tag, drives the rename + delete flow through the real Electron UI, asserts sidebar state after each mutation.

## Test plan

- [x] `pnpm exec tsc -p tsconfig.web.json --noEmit` clean in the worktree
- [ ] CI: `pnpm test --filter @memry/desktop` green on tag-detail-view tests
- [ ] CI: `pnpm test:e2e --grep tags-rename-delete` green against a built bundle
- [ ] Manual smoke: create note with tag, open sidebar tag detail, Rename + Delete flows