### PR TITLE
feat(journal): wire image upload + focus mode in editor toolbar

### DIFF
--- a/apps/desktop/src/renderer/src/components/journal/collapsible-section.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/collapsible-section.tsx
@@ -127,13 +127,22 @@ export interface JournalSectionProps {
   content?: string
   /** Content change callback */
   onContentChange?: (content: string) => void
+  /** Journal entry id (date) used to scope image uploads */
+  journalId?: string
+  /** Whether focus mode is currently active */
+  isFocusMode?: boolean
+  /** Callback fired when the toolbar focus-mode button is pressed */
+  onFocusToggle?: () => void
 }
 
 export const JournalSection = memo(function JournalSection({
   isActive = false,
   placeholder = 'Start writing...',
   content = '',
-  onContentChange
+  onContentChange,
+  journalId,
+  isFocusMode = false,
+  onFocusToggle
 }: JournalSectionProps): React.JSX.Element {
   return (
     <div className="rounded-md border border-border/40 bg-muted/20">
@@ -152,6 +161,9 @@ export const JournalSection = memo(function JournalSection({
           placeholder={placeholder}
           isActive={isActive}
           onContentChange={onContentChange}
+          journalId={journalId}
+          isFocusMode={isFocusMode}
+          onFocusToggle={onFocusToggle}
         />
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/journal/day-card.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/day-card.tsx
@@ -192,6 +192,9 @@ export const DayCard = memo(
             <JournalSection
               isActive={isActive}
               placeholder={isFuture ? 'Plan your day...' : 'Start writing...'}
+              journalId={date}
+              isFocusMode={isFocusMode}
+              onFocusToggle={onToggleFocusMode}
             />
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/components/journal/editor-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/editor-toolbar.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Editor Toolbar tests (Phase 5.3 — journal editor polish).
+ *
+ * Covers the previously-stubbed image upload and focus-mode toggle,
+ * plus the guards that keep them disabled when callers forget to
+ * thread `journalId` / `onFocusToggle` through.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { Editor } from '@tiptap/react'
+
+import { EditorToolbar } from './editor-toolbar'
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn()
+  }
+}))
+
+vi.mock('@/services/notes-service', () => ({
+  notesService: {
+    uploadAttachment: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('@/lib/ipc-error', () => ({
+  extractErrorMessage: (err: unknown, fallback: string) =>
+    err instanceof Error ? err.message : fallback
+}))
+
+type ChainMock = {
+  focus: () => ChainMock
+  setImage: ReturnType<typeof vi.fn>
+  setLink: ReturnType<typeof vi.fn>
+  toggleBold: ReturnType<typeof vi.fn>
+  toggleItalic: ReturnType<typeof vi.fn>
+  toggleUnderline: ReturnType<typeof vi.fn>
+  toggleStrike: ReturnType<typeof vi.fn>
+  toggleHeading: ReturnType<typeof vi.fn>
+  toggleBulletList: ReturnType<typeof vi.fn>
+  toggleOrderedList: ReturnType<typeof vi.fn>
+  toggleTaskList: ReturnType<typeof vi.fn>
+  toggleBlockquote: ReturnType<typeof vi.fn>
+  setHorizontalRule: ReturnType<typeof vi.fn>
+  toggleCodeBlock: ReturnType<typeof vi.fn>
+  run: ReturnType<typeof vi.fn>
+}
+
+function makeEditor(): { editor: Editor; chain: ChainMock } {
+  const chain: ChainMock = {
+    focus: () => chain,
+    setImage: vi.fn().mockReturnThis(),
+    setLink: vi.fn().mockReturnThis(),
+    toggleBold: vi.fn().mockReturnThis(),
+    toggleItalic: vi.fn().mockReturnThis(),
+    toggleUnderline: vi.fn().mockReturnThis(),
+    toggleStrike: vi.fn().mockReturnThis(),
+    toggleHeading: vi.fn().mockReturnThis(),
+    toggleBulletList: vi.fn().mockReturnThis(),
+    toggleOrderedList: vi.fn().mockReturnThis(),
+    toggleTaskList: vi.fn().mockReturnThis(),
+    toggleBlockquote: vi.fn().mockReturnThis(),
+    setHorizontalRule: vi.fn().mockReturnThis(),
+    toggleCodeBlock: vi.fn().mockReturnThis(),
+    run: vi.fn()
+  }
+
+  const editor = {
+    chain: () => chain,
+    isActive: vi.fn(() => false)
+  } as unknown as Editor
+
+  return { editor, chain }
+}
+
+describe('EditorToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  describe('image upload', () => {
+    it('disables the Image button when no journalId is provided', () => {
+      // #given
+      const { editor } = makeEditor()
+
+      // #when
+      render(<EditorToolbar editor={editor} />)
+
+      // #then
+      expect(screen.getByRole('button', { name: 'Image' })).toBeDisabled()
+    })
+
+    it('uploads and inserts the image when journalId is provided', async () => {
+      // #given
+      const { editor, chain } = makeEditor()
+      const { notesService } = await import('@/services/notes-service')
+      vi.mocked(notesService.uploadAttachment).mockResolvedValue({
+        success: true,
+        path: '/vault/attachments/foo.png',
+        name: 'foo.png'
+      })
+
+      render(<EditorToolbar editor={editor} journalId="2026-04-16" />)
+
+      const fileInput = screen.getByTestId('journal-image-input') as HTMLInputElement
+      const file = new File(['hello'], 'foo.png', { type: 'image/png' })
+
+      // #when
+      fireEvent.change(fileInput, { target: { files: [file] } })
+      await vi.waitFor(() => expect(chain.setImage).toHaveBeenCalled())
+
+      // #then
+      expect(notesService.uploadAttachment).toHaveBeenCalledWith('2026-04-16', file)
+      expect(chain.setImage).toHaveBeenCalledWith({
+        src: '/vault/attachments/foo.png',
+        alt: 'foo.png'
+      })
+      expect(chain.run).toHaveBeenCalled()
+    })
+
+    it('shows an error toast when upload fails', async () => {
+      // #given
+      const { editor, chain } = makeEditor()
+      const { notesService } = await import('@/services/notes-service')
+      const { toast } = await import('sonner')
+      vi.mocked(notesService.uploadAttachment).mockResolvedValue({
+        success: false,
+        error: 'Quota exceeded'
+      })
+
+      render(<EditorToolbar editor={editor} journalId="2026-04-16" />)
+
+      const fileInput = screen.getByTestId('journal-image-input') as HTMLInputElement
+      const file = new File(['data'], 'bar.png', { type: 'image/png' })
+
+      // #when
+      fireEvent.change(fileInput, { target: { files: [file] } })
+      await vi.waitFor(() => expect(toast.error).toHaveBeenCalled())
+
+      // #then
+      expect(chain.setImage).not.toHaveBeenCalled()
+      expect(toast.error).toHaveBeenCalledWith('Quota exceeded')
+    })
+  })
+
+  describe('focus mode', () => {
+    it('disables the focus button when onFocusToggle is not provided', () => {
+      // #given
+      const { editor } = makeEditor()
+
+      // #when
+      render(<EditorToolbar editor={editor} />)
+
+      // #then
+      expect(screen.getByRole('button', { name: 'Focus Mode' })).toBeDisabled()
+    })
+
+    it('fires onFocusToggle when the focus button is clicked', () => {
+      // #given
+      const { editor } = makeEditor()
+      const onFocusToggle = vi.fn()
+
+      render(<EditorToolbar editor={editor} onFocusToggle={onFocusToggle} />)
+
+      // #when
+      fireEvent.click(screen.getByRole('button', { name: 'Focus Mode' }))
+
+      // #then
+      expect(onFocusToggle).toHaveBeenCalledTimes(1)
+    })
+
+    it('flips the icon label and aria-pressed state when isFocusMode is true', () => {
+      // #given
+      const { editor } = makeEditor()
+
+      // #when
+      render(
+        <EditorToolbar editor={editor} isFocusMode onFocusToggle={() => {}} />
+      )
+
+      // #then
+      const button = screen.getByRole('button', { name: 'Exit Focus Mode' })
+      expect(button).toHaveAttribute('aria-pressed', 'true')
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/components/journal/editor-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/editor-toolbar.tsx
@@ -3,8 +3,9 @@
  * Toolbar with formatting buttons for the journal editor
  */
 
-import { memo } from 'react'
+import { memo, useCallback, useRef } from 'react'
 import type { Editor } from '@tiptap/react'
+import { toast } from 'sonner'
 import {
   Bold,
   Italic,
@@ -22,10 +23,13 @@ import {
   Quote,
   Minus,
   Code,
-  Maximize2
+  Maximize2,
+  Minimize2
 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { createLogger } from '@/lib/logger'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { notesService } from '@/services/notes-service'
 import { Button } from '@/components/ui/button'
 
 const log = createLogger('Component:EditorToolbar')
@@ -43,6 +47,12 @@ import {
 
 export interface EditorToolbarProps {
   editor: Editor | null
+  /** Journal entry id used to scope uploaded attachments */
+  journalId?: string
+  /** Whether focus mode is currently active */
+  isFocusMode?: boolean
+  /** Callback fired when the focus-mode button is pressed */
+  onFocusToggle?: () => void
   className?: string
 }
 
@@ -55,8 +65,60 @@ export interface EditorToolbarProps {
  */
 export const EditorToolbar = memo(function EditorToolbar({
   editor,
+  journalId,
+  isFocusMode = false,
+  onFocusToggle,
   className
 }: EditorToolbarProps): React.JSX.Element | null {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleImageFile = useCallback(
+    async (file: File) => {
+      if (!editor) return
+
+      if (!journalId) {
+        toast.error('Cannot upload image: no journal entry selected')
+        log.warn('Image upload skipped - missing journalId')
+        return
+      }
+
+      try {
+        const result = await notesService.uploadAttachment(journalId, file)
+        if (!result.success || !result.path) {
+          const message = result.error || 'Upload failed'
+          toast.error(message)
+          log.error('Image upload failed', message)
+          return
+        }
+
+        editor
+          .chain()
+          .focus()
+          .setImage({ src: result.path, alt: result.name ?? file.name })
+          .run()
+      } catch (err) {
+        const message = extractErrorMessage(err, 'Failed to upload image')
+        toast.error(message)
+        log.error('Image upload threw', err)
+      }
+    },
+    [editor, journalId]
+  )
+
+  const handleImageClick = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [])
+
+  const handleFileChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0]
+      event.target.value = ''
+      if (!file) return
+      void handleImageFile(file)
+    },
+    [handleImageFile]
+  )
+
   if (!editor) return null
 
   return (
@@ -69,6 +131,17 @@ export const EditorToolbar = memo(function EditorToolbar({
         className
       )}
     >
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="sr-only"
+        onChange={handleFileChange}
+        aria-hidden="true"
+        tabIndex={-1}
+        data-testid="journal-image-input"
+      />
+
       {/* Text Formatting Group */}
       <ToolbarGroup>
         <ToolbarButton
@@ -120,10 +193,8 @@ export const EditorToolbar = memo(function EditorToolbar({
         <ToolbarButton
           icon={Image}
           label="Image"
-          onClick={() => {
-            // TODO: Image upload - requires @tiptap/extension-image
-            log.info('Image insert - coming soon')
-          }}
+          onClick={handleImageClick}
+          disabled={!journalId}
         />
       </ToolbarGroup>
 
@@ -134,14 +205,14 @@ export const EditorToolbar = memo(function EditorToolbar({
 
       <div className="flex-1" />
 
-      {/* View Mode Toggle (placeholder) */}
+      {/* Focus Mode Toggle */}
       <ToolbarButton
-        icon={Maximize2}
-        label="Focus Mode"
-        onClick={() => {
-          // TODO: Toggle focus mode
-          log.info('Focus mode toggle')
-        }}
+        icon={isFocusMode ? Minimize2 : Maximize2}
+        label={isFocusMode ? 'Exit Focus Mode' : 'Focus Mode'}
+        shortcut="⌘\\"
+        isActive={isFocusMode}
+        disabled={!onFocusToggle}
+        onClick={() => onFocusToggle?.()}
       />
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/journal/journal-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-editor.tsx
@@ -8,6 +8,7 @@ import { useEditor, EditorContent, ReactRenderer } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
+import Image from '@tiptap/extension-image'
 import Placeholder from '@tiptap/extension-placeholder'
 import tippy from 'tippy.js'
 import type { Instance } from 'tippy.js'
@@ -36,6 +37,12 @@ export interface JournalEditorProps {
   className?: string
   /** Read-only mode */
   readOnly?: boolean
+  /** Journal entry id (date) used to scope image uploads */
+  journalId?: string
+  /** Whether focus mode is currently active */
+  isFocusMode?: boolean
+  /** Callback fired when the toolbar focus-mode button is pressed */
+  onFocusToggle?: () => void
 }
 
 // =============================================================================
@@ -51,7 +58,10 @@ export const JournalEditor = memo(function JournalEditor({
   isActive = false,
   onContentChange,
   className,
-  readOnly = false
+  readOnly = false,
+  journalId,
+  isFocusMode = false,
+  onFocusToggle
 }: JournalEditorProps): React.JSX.Element {
   // Hooks for pages and tags
   const { searchPages } = usePages()
@@ -79,6 +89,13 @@ export const JournalEditor = memo(function JournalEditor({
           openOnClick: false,
           HTMLAttributes: {
             class: 'text-primary underline underline-offset-2 hover:text-primary/80'
+          }
+        }),
+        Image.configure({
+          inline: false,
+          allowBase64: false,
+          HTMLAttributes: {
+            class: 'rounded-md max-w-full h-auto my-2'
           }
         }),
         Placeholder.configure({
@@ -260,7 +277,12 @@ export const JournalEditor = memo(function JournalEditor({
         />
 
         {/* Toolbar */}
-        <EditorToolbar editor={editor} />
+        <EditorToolbar
+          editor={editor}
+          journalId={journalId}
+          isFocusMode={isFocusMode}
+          onFocusToggle={onFocusToggle}
+        />
       </div>
     </>
   )


### PR DESCRIPTION
## Summary

Phase 5.3 (ref `.claude/plans/tech-debt-remediation.md § 5.3`).

Closes two TODOs in `apps/desktop/src/renderer/src/components/journal/editor-toolbar.tsx` (originally lines 124 and 142).

### Image upload
- Registers `@tiptap/extension-image` in `journal-editor.tsx` (`inline: false`, `allowBase64: false`, rounded preview styling).
- Toolbar Image button opens a hidden `<input type=file accept="image/*">` via ref.
- Upload routes through `notesService.uploadAttachment(journalId, file)` (same IPC used by notes).
- On success, inserts the returned path via `editor.chain().focus().setImage({ src, alt }).run()`.
- On failure: `toast.error(...)` with the service error message or `extractErrorMessage(err, fallback)`.
- Button is disabled when `journalId` is missing (instead of failing silently).

### Focus mode
- Adds `isFocusMode` + `onFocusToggle` props to `EditorToolbarProps`.
- Button icon flips `Maximize2 ↔ Minimize2`; `aria-pressed` mirrors the state; disabled when `onFocusToggle` is absent.
- Threads `isFocusMode` and `onFocusToggle` through `JournalEditor → JournalSection → DayCard`, so the toolbar's focus button shares one callback with the existing `DayCardHeader` focus button (no state duplication).

### Prop plumbing
- `JournalEditorProps` gains `journalId`, `isFocusMode`, `onFocusToggle`.
- `JournalSectionProps` gains the same three.
- `day-card.tsx` now passes `journalId={date}` (journals are keyed by date), `isFocusMode={isFocusMode}`, `onFocusToggle={onToggleFocusMode}`.

### Tests
`editor-toolbar.test.tsx` (vitest + RTL, mocks `notesService`/`sonner`/`@/lib/logger`):
- Image button disabled without `journalId`.
- Happy-path upload → `notesService.uploadAttachment` called with correct args; `setImage` inserted with `{ src, alt }`.
- Failure-path upload → error toast fires and `setImage` is not called.
- Focus button disabled without `onFocusToggle`; fires once on click; `aria-pressed` + label flip when `isFocusMode` is true.

## Test plan

- [x] `pnpm exec tsc -p tsconfig.web.json --noEmit` clean (exit 0)
- [ ] CI: `pnpm test --filter @memry/desktop` green on `editor-toolbar.test.tsx`
- [ ] Manual smoke in `pnpm dev`: open today's journal, click Image, pick a PNG, confirm it renders in the editor + hits disk under the vault's attachments path; click focus toggle, confirm chrome collapses via `DayCardHeader`'s existing handler.