### PR TITLE
chore(typescript): align typescript to ^5.9.3 across workspace

### DIFF
--- a/apps/sync-server/package.json
+++ b/apps/sync-server/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-types": "^4.20250204.0",
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.5.0",
-    "typescript": "^5.7.0",
+    "typescript": "^5.9.3",
     "vitest": "^4.0.0",
     "wrangler": "^4.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "turbo": "^2",
-    "typescript": "^5.7.0"
+    "typescript": "^5.9.3"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^2
         version: 2.8.13
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.9.3
         version: 5.9.3
 
   apps/desktop:
@@ -644,7 +644,7 @@ importers:
         specifier: ^12.5.0
         version: 12.6.2
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.0


### PR DESCRIPTION
Part of Phase 6 Tech Debt Remediation — see `.claude/plans/tech-debt-remediation.md § 6.7`.

## Summary
- Align `typescript` devDependency to `^5.9.3` across the workspace
  - Root `package.json`: `^5.7.0` → `^5.9.3`
  - `apps/sync-server/package.json`: `^5.7.0` → `^5.9.3`
  - `apps/desktop/package.json` already at `^5.9.3` (unchanged)
- Lockfile updated (`pnpm install` dedups to single TS version)

## Why
Version drift between workspace packages can cause subtle compile differences (new inference rules, strict flags, module resolution). Aligning to desktop's existing pin means every package compiles against the same TS; `pnpm typecheck` output becomes the single source of truth.

5.7 → 5.9 is backward compatible for well-typed code; no source edits were required.

## Test plan
- [ ] CI: full `pnpm typecheck` green (acid test for this PR)
- [ ] CI: full `pnpm test` green
- [ ] CI: `pnpm ipc:check` green
- [ ] CI: `pnpm lint` green