### PR TITLE
chore(deps): add renovate config with grouped rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits"],
+  "extends": ["config:recommended", ":semanticCommits"],
   "schedule": ["before 6am on monday"],
   "timezone": "UTC",
   "labels": ["dependencies"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits"],
+  "schedule": ["before 6am on monday"],
+  "timezone": "UTC",
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "postUpdateOptions": ["pnpmDedupe"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "matchPackageNames": ["/^@radix-ui//"],
+      "groupName": "radix-ui"
+    },
+    {
+      "matchPackageNames": ["/^@fontsource-variable//", "/^@fontsource//"],
+      "groupName": "fontsource"
+    },
+    {
+      "matchPackageNames": ["/^@dnd-kit//"],
+      "groupName": "dnd-kit"
+    },
+    {
+      "matchPackageNames": ["electron", "electron-builder", "electron-updater", "@electron/rebuild"],
+      "groupName": "electron-core",
+      "automerge": false
+    },
+    {
+      "matchPackageNames": ["better-sqlite3", "keytar", "sodium-native", "sqlite-vec", "classic-level"],
+      "groupName": "native-modules",
+      "automerge": false,
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchPackageNames": [
+        "libsodium-wrappers",
+        "libsodium-wrappers-sumo",
+        "drizzle-orm",
+        "drizzle-kit"
+      ],
+      "automerge": false,
+      "minimumReleaseAge": "7 days"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  }
+}


### PR DESCRIPTION
Part of Phase 6 Tech Debt Remediation — see `.claude/plans/tech-debt-remediation.md § 6.9`.

## Summary
- New `renovate.json` at repo root establishing automated dep-bump PRs.
- Group rules for `@radix-ui/*`, `@fontsource-variable/*` + `@fontsource/*`, `@dnd-kit/*`, Electron-core, native modules, and crypto/DB primitives.
- Patch updates auto-merge; minor/major require manual review.
- Weekly schedule (Monday before 6am UTC); `pnpmDedupe` on post-update.
- Security vulnerability alerts enabled with `security` label.

## Why
No dep-automation exists today. Dep drift accumulates fast (the Phase 6 audit surfaced exactly this pattern for @radix-ui v1/v2 split and dnd-kit version spread). Renovate turns heroic manual bumps into routine review.

## Next step after merge
Enable the Renovate GitHub App on the repo settings — the config is inert until the app is authorized. Renovate will auto-create a "Dependency Dashboard" issue on first scan.

## Test plan
- [ ] `npx --yes --package=renovate renovate-config-validator renovate.json` validates (can be run locally or via the Renovate app).
- [ ] No `.github/dependabot.yml` exists to conflict.