### PR TITLE
ci(lockfile): add drift detection workflow + outdated:check script

### DIFF
--- a/.github/workflows/lockfile-drift.yml
+++ b/.github/workflows/lockfile-drift.yml
@@ -1,0 +1,57 @@
+name: Lockfile Drift
+
+on:
+  pull_request:
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lockfile-drift-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+jobs:
+  lockfile-drift:
+    name: Verify Lockfile Integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Verify lockfile is in sync with package manifests
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Report drift if regen would change lockfile
+        run: |
+          cp pnpm-lock.yaml /tmp/before.yaml
+          pnpm install --lockfile-only --ignore-scripts
+          if ! diff -q /tmp/before.yaml pnpm-lock.yaml > /dev/null; then
+            echo "::error::pnpm-lock.yaml would change after 'pnpm install'. Lockfile is drifted — commit the regenerated lockfile."
+            diff /tmp/before.yaml pnpm-lock.yaml | head -80 || true
+            exit 1
+          fi
+          echo "Lockfile is clean."

--- a/docs/ci-guardrails.md
+++ b/docs/ci-guardrails.md
@@ -1,0 +1,44 @@
+# CI Guardrails
+
+This doc covers CI safety nets that run on every PR and push to `main`. These are separate from the main `quality` pipeline (lint/typecheck/test) and guard against classes of failure that slip through normal review.
+
+## Lockfile Drift (`.github/workflows/lockfile-drift.yml`)
+
+### What it does
+
+Runs on any PR or push to `main` that touches `**/package.json`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml`. Two checks:
+
+1. **Frozen install** — `pnpm install --frozen-lockfile --ignore-scripts` fails if `package.json` and `pnpm-lock.yaml` disagree.
+2. **Regen diff** — snapshots the committed lockfile, runs `pnpm install --lockfile-only --ignore-scripts`, then diffs. A non-empty diff fails the job.
+
+The second check is the load-bearing one. `--frozen-lockfile` only catches mismatches that pnpm treats as hard errors; regen-diff catches the subtler case where pnpm would silently rewrite the lockfile on the next local install.
+
+### Fixing a drift failure
+
+```bash
+pnpm install         # regenerate the lockfile locally
+git add pnpm-lock.yaml
+git commit -m "chore: refresh pnpm-lock.yaml"
+git push
+```
+
+If the diff in CI points at a package you didn't touch, it usually means an upstream `package.json` was bumped and the lockfile was committed without a matching install. Regenerating locally brings them back in sync.
+
+### Why it matters
+
+Pinning the lockfile is the cheapest way to get reproducible builds:
+
+- Every dev machine, CI runner, and release build resolves the exact same dependency graph.
+- Transitive version drift (the common source of "works on my machine" bugs) gets caught at PR time instead of leaking into a release.
+- Supply-chain attacks via surprise transitive upgrades are blocked — a lockfile bump is always a reviewable diff.
+
+## Local Helpers
+
+Two root-level scripts mirror the CI checks for fast pre-push feedback:
+
+| Script                | What it runs                                                         |
+| --------------------- | -------------------------------------------------------------------- |
+| `pnpm check:lockfile` | Mirrors the drift workflow locally via `scripts/check-lockfile.js`.  |
+| `pnpm outdated:check` | `pnpm outdated -r --format list`, truncated to 100 lines.            |
+
+Run `pnpm check:lockfile` before pushing a dep change to catch drift without waiting on CI. Run `pnpm outdated:check` when triaging "why is this dep so old" — it surfaces every workspace package with an available minor or major bump.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "sync:clean": "rm -rf apps/sync-server/.wrangler",
     "sync:seed": "pnpm --filter @memry/sync-server exec wrangler d1 execute memry-sync --local --file=schema/d1.sql",
     "sync:reset": "pnpm sync:clean && pnpm sync:seed",
+    "outdated:check": "pnpm outdated -r --format list | head -100",
+    "check:lockfile": "node scripts/check-lockfile.js",
     "prepare": "git config core.hooksPath .githooks"
   },
   "devDependencies": {

--- a/scripts/check-lockfile.js
+++ b/scripts/check-lockfile.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+const { execSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const repoRoot = path.resolve(__dirname, '..')
+const lockfilePath = path.join(repoRoot, 'pnpm-lock.yaml')
+const snapshotPath = path.join(os.tmpdir(), `memry-lockfile-${process.pid}.yaml`)
+
+function cleanup() {
+  if (fs.existsSync(snapshotPath)) {
+    fs.unlinkSync(snapshotPath)
+  }
+}
+
+function finish(code, message) {
+  cleanup()
+  if (message) {
+    const stream = code === 0 ? process.stdout : process.stderr
+    stream.write(`${message}\n`)
+  }
+  process.exit(code)
+}
+
+function run(command) {
+  execSync(command, { cwd: repoRoot, stdio: ['ignore', 'inherit', 'inherit'] })
+}
+
+process.on('SIGINT', () => finish(130))
+process.on('SIGTERM', () => finish(143))
+
+if (!fs.existsSync(lockfilePath)) {
+  finish(1, '\n  pnpm-lock.yaml not found. Are you at the repo root?\n')
+}
+
+console.log('Snapshotting current lockfile...')
+fs.copyFileSync(lockfilePath, snapshotPath)
+
+console.log('Regenerating lockfile (pnpm install --lockfile-only --ignore-scripts)...')
+run('pnpm install --lockfile-only --ignore-scripts')
+
+const before = fs.readFileSync(snapshotPath)
+const after = fs.readFileSync(lockfilePath)
+
+if (before.equals(after)) {
+  finish(0, '\nLockfile is clean.')
+}
+
+fs.copyFileSync(snapshotPath, lockfilePath)
+finish(
+  1,
+  '\n  pnpm-lock.yaml would change after "pnpm install". Lockfile is drifted.\n' +
+    '  Fix: run "pnpm install" and commit the regenerated pnpm-lock.yaml.\n',
+)


### PR DESCRIPTION
Refs § 6.10 of `.claude/plans/tech-debt-remediation.md` (Phase 6 Unit U10).

## Summary

- New `.github/workflows/lockfile-drift.yml` runs on PRs + pushes to `main` when `**/package.json`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml` change. Two-stage check: `pnpm install --frozen-lockfile` catches hard mismatches, then a regen diff catches the subtler case where pnpm would silently rewrite the lockfile on the next local install.
- `scripts/check-lockfile.js` mirrors the CI workflow for pre-push feedback. Wired as `pnpm check:lockfile` at the repo root.
- `pnpm outdated:check` surfaces stale workspace deps across the monorepo, truncated to 100 lines so the output is scan-able instead of a wall of text.
- `docs/ci-guardrails.md` documents what the workflow does, how to fix a drift failure, and why reproducible builds matter.

## Why

Lockfile drift = non-reproducible builds + "works on my machine" bugs. Today `--frozen-lockfile` in every CI job already catches drift as an install error, but the signal is noisy and only fires when pnpm treats the mismatch as a hard error. The new workflow is dedicated, narrowly scoped to dep-file changes, and also catches the silent-rewrite case.

## Test plan

- [x] `pnpm install --frozen-lockfile` passes locally.
- [x] `pnpm check:lockfile` reports `Lockfile is clean.` on clean tree.
- [x] Simulated drift (appended a line to `pnpm-lock.yaml`) → script exits 1 with actionable error; lockfile auto-restored.
- [x] Tmp snapshot file cleaned up on both clean + drift exit paths.
- [x] `pnpm outdated:check` produces truncated workspace-wide dep report.
- [x] Workflow YAML parses cleanly (js-yaml); matches existing `ci.yml` conventions (action versions, pnpm-setup-before-setup-node ordering so cache works).
- [ ] CI confirms workflow runs green on this PR.