### PR TITLE
chore(native): add pnpm check:native mismatch detection script

### DIFF
--- a/apps/desktop/scripts/check-native.js
+++ b/apps/desktop/scripts/check-native.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Detects NODE_MODULE_VERSION mismatch between built native modules
+// (better-sqlite3, keytar) and the current runtime (Node or Electron).
+//
+// Exit 0: native modules load cleanly under the current runtime.
+// Exit 1: at least one module's ABI does not match — prints the fix command.
+//
+// Relies on the stamp file written by apps/desktop/scripts/ensure-native.sh
+// to report which target the modules were last built for.
+
+const { spawnSync } = require('node:child_process')
+const { existsSync, readFileSync } = require('node:fs')
+const { join } = require('node:path')
+
+const APP_ROOT = join(__dirname, '..')
+const STAMP_FILE = join(APP_ROOT, 'node_modules', '.native-build-target')
+const MODULES = ['better-sqlite3', 'keytar']
+
+const stamp = existsSync(STAMP_FILE) ? readFileSync(STAMP_FILE, 'utf8').trim() : 'unknown'
+const inElectron = Boolean(process.versions.electron)
+const currentRuntime = inElectron ? 'electron' : 'node'
+
+function tryRequire(mod) {
+  const res = spawnSync(process.execPath, ['-e', `require('${mod}')`], {
+    cwd: APP_ROOT,
+    encoding: 'utf8'
+  })
+  if (res.status === 0) return { ok: true }
+  const err = (res.stderr || '').trim()
+  const match = err.match(/NODE_MODULE_VERSION\s+(\d+).+?this version of Node\.js requires\s+NODE_MODULE_VERSION\s+(\d+)/s)
+  return { ok: false, compiledAbi: match?.[1], expectedAbi: match?.[2], err }
+}
+
+const failures = []
+for (const mod of MODULES) {
+  const result = tryRequire(mod)
+  if (!result.ok) failures.push({ mod, ...result })
+}
+
+if (failures.length === 0) {
+  console.log(`[check:native] OK — modules load under ${currentRuntime} (stamp: ${stamp})`)
+  process.exit(0)
+}
+
+console.error(`[check:native] NODE_MODULE_VERSION mismatch — ${failures.length} module(s) failed to load under ${currentRuntime}:`)
+for (const f of failures) {
+  if (f.compiledAbi && f.expectedAbi) {
+    console.error(`  - ${f.mod}: compiled for ABI ${f.compiledAbi}, runtime needs ABI ${f.expectedAbi}`)
+  } else {
+    console.error(`  - ${f.mod}: ${f.err.split('\n')[0]}`)
+  }
+}
+
+const fix = stamp === 'electron' ? 'pnpm rebuild:node' : 'pnpm rebuild:electron'
+const altFix = stamp === 'electron' ? 'pnpm rebuild:electron' : 'pnpm rebuild:node'
+console.error('')
+console.error(`[check:native] stamp says last build target was "${stamp}"; current runtime is "${currentRuntime}".`)
+console.error(`[check:native] fix:`)
+console.error(`    ${fix}           # to run tests/scripts under Node`)
+console.error(`    ${altFix}        # to run the Electron app (pnpm dev)`)
+process.exit(1)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "check:contracts": "node scripts/check-contract-boundaries.js",
     "check:contract-boundaries": "node scripts/check-contract-boundaries.js",
     "check:architecture": "node scripts/check-architecture-boundaries.js",
+    "check:native": "node apps/desktop/scripts/check-native.js",
     "ipc:generate": "pnpm --filter @memry/desktop ipc:generate",
     "ipc:check": "pnpm --filter @memry/desktop ipc:check",
     "sync:clean": "rm -rf apps/sync-server/.wrangler",


### PR DESCRIPTION
Part of Phase 6 Tech Debt Remediation — see `.claude/plans/tech-debt-remediation.md § 6.1`.

## Summary
- `apps/desktop/scripts/check-native.js` — cross-platform Node script that detects NODE_MODULE_VERSION mismatch by attempting to `require()` each native module in a child process and parsing any ERR_DLOPEN_FAILED output.
- Root `pnpm check:native` wired next to other `check:*` scripts.
- Reads the stamp file written by `ensure-native.sh` to report last build target + suggest the right `pnpm rebuild:{node,electron}` fix.

## Why
`ERR_DLOPEN_FAILED` has repeatedly burned cycles — per project memory, caused `autoOpenLastVault` to silently fail and E2E tests to time out on `.bn-container`. Turning an opaque dlopen error into a one-command fix removes the landmine.

## Smoke test (run locally)
```bash
pnpm check:native
# [check:native] OK — modules load under node (stamp: node)

# Force mismatch:
bash apps/desktop/scripts/ensure-native.sh electron
pnpm check:native
# exits 1 with "pnpm rebuild:node" suggestion

# Restore:
bash apps/desktop/scripts/ensure-native.sh node
```

## Test plan
- [x] Script exits 0 when modules match runtime (verified locally before push)
- [ ] CI: `pnpm typecheck && pnpm test` green (no source touched)