### PR TITLE
chore(deps): remove unused libsodium-wrappers dep, keep -sumo variant

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -174,7 +174,6 @@
     "jose": "^6.1.3",
     "keytar": "^7.9.0",
     "level": "^10.0.0",
-    "libsodium-wrappers": "^0.8.0",
     "libsodium-wrappers-sumo": "^0.8.2",
     "marked": "^17.0.1",
     "metascraper": "^5.49.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,9 +335,6 @@ importers:
       level:
         specifier: ^10.0.0
         version: 10.0.0
-      libsodium-wrappers:
-        specifier: ^0.8.0
-        version: 0.8.2
       libsodium-wrappers-sumo:
         specifier: ^0.8.2
         version: 0.8.2
@@ -6210,12 +6207,6 @@ packages:
 
   libsodium-wrappers-sumo@0.8.2:
     resolution: {integrity: sha512-wd1xAY++Kr6VMikSaa4EPRAHJmFvNlGWiiwU3Jh3GR1zRYF3/I3vy/wYsr4k3LVsNzwb9sqfEQ4LdVQ6zEebyQ==}
-
-  libsodium-wrappers@0.8.2:
-    resolution: {integrity: sha512-VFLmfxkxo+U9q60tjcnSomQBRx2UzlRjKWJqvB4K1pUqsMQg4cu3QXA2nrcsj9A1qRsnJBbi2Ozx1hsiDoCkhw==}
-
-  libsodium@0.8.2:
-    resolution: {integrity: sha512-TsnGYMoZtpweT+kR+lOv5TVsnJ/9U0FZOsLFzFOMWmxqOAYXjX3fsrPAW+i1LthgDKXJnI9A8dWEanT1tnJKIw==}
 
   lie@3.1.1:
     resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
@@ -14761,12 +14752,6 @@ snapshots:
   libsodium-wrappers-sumo@0.8.2:
     dependencies:
       libsodium-sumo: 0.8.2
-
-  libsodium-wrappers@0.8.2:
-    dependencies:
-      libsodium: 0.8.2
-
-  libsodium@0.8.2: {}
 
   lie@3.1.1:
     dependencies:


### PR DESCRIPTION
Part of Phase 6 Tech Debt Remediation — see `.claude/plans/tech-debt-remediation.md § 6.2`.

## Summary
Removes the unused `libsodium-wrappers: ^0.8.0` dep from `apps/desktop/package.json`. All 43 crypto + sync source sites use `libsodium-wrappers-sumo: ^0.8.2` (a strict superset); the plain wrapper was dead code.

## Verification before removal
- `grep "from 'libsodium-wrappers'" apps/desktop/src/` → **0 matches**
- `grep "from 'libsodium-wrappers'" .` (whole repo) → **0 matches**
- No `@types/libsodium-wrappers` (plain) declared — only `@types/libsodium-wrappers-sumo`, which stays.

## Why
Two copies of the same crypto library in a desktop app:
- doubles the surface area external security audit has to trace
- doubles bundle cost for zero benefit (`-sumo` is a strict superset)
- invites future drift (one version floats ahead of the other)

## Delta
- `apps/desktop/package.json`: **1 line removed**
- `pnpm-lock.yaml`: **15 lines removed** (the full `libsodium-wrappers@0.8.0` package entry)

## Test plan
- [ ] CI: `pnpm install --frozen-lockfile` green
- [ ] CI: `pnpm typecheck` green (crypto path untouched — only -sumo used)
- [ ] CI: `pnpm test` green (crypto tests in particular)