### PR TITLE
fix(e2e): unblock tags-rename-delete (emit tags-changed + fix selectors)

### DIFF
--- a/apps/desktop/src/main/vault/notes-crud.ts
+++ b/apps/desktop/src/main/vault/notes-crud.ts
@@ -262,6 +262,10 @@ export async function createNote(input: NoteCreateInput): Promise<Note> {
     source: 'internal'
   })
 
+  if (mergedTags.length > 0) {
+    emitNoteEvent('notes:tags-changed', undefined)
+  }
+
   return note
 }
 

--- a/apps/desktop/tests/e2e/tags-rename-delete.e2e.ts
+++ b/apps/desktop/tests/e2e/tags-rename-delete.e2e.ts
@@ -30,12 +30,24 @@ async function seedNoteWithTag(page, tag: string): Promise<void> {
   expect(created).toBeTruthy()
 }
 
+async function expandTagsSection(page): Promise<void> {
+  const trigger = page.locator('button[aria-label^="Tags section, "]')
+  await trigger.waitFor({ state: 'visible', timeout: 10000 })
+  const label = (await trigger.getAttribute('aria-label')) ?? ''
+  if (label.includes('collapsed')) {
+    await trigger.click()
+    await page.locator('button[aria-label^="Tags section, expanded"]').waitFor({
+      state: 'visible',
+      timeout: 5000
+    })
+  }
+}
+
 async function openTagDrilldown(page, tag: string): Promise<void> {
-  // Tags appear as buttons rendered by TagTreeItem; they have the tag text.
-  const tagTrigger = page.locator(`aside button:has-text("${tag}")`).first()
+  await expandTagsSection(page)
+  const tagTrigger = page.getByRole('button', { name: tag, exact: true }).first()
   await tagTrigger.waitFor({ state: 'visible', timeout: 15000 })
   await tagTrigger.click()
-  // Wait for drill-down header to settle
   await page.locator('button[aria-label="Go back"]').waitFor({ state: 'visible', timeout: 10000 })
 }
 
@@ -60,10 +72,11 @@ test.describe('Tag rename + delete (§5.2)', () => {
     await page.locator('button', { hasText: 'Save' }).click()
 
     // After success we auto-navigate back; sidebar should show renamed tag
-    await expect(page.locator(`aside button:has-text("${RENAMED}")`).first()).toBeVisible({
+    await expandTagsSection(page)
+    await expect(page.getByRole('button', { name: RENAMED, exact: true }).first()).toBeVisible({
       timeout: 10000
     })
-    await expect(page.locator(`aside button:has-text("${TAG}")`)).toHaveCount(0)
+    await expect(page.getByRole('button', { name: TAG, exact: true })).toHaveCount(0)
   })
 
   test('deletes a tag via overflow menu', async ({ page }) => {
@@ -79,7 +92,8 @@ test.describe('Tag rename + delete (§5.2)', () => {
     // Click the destructive confirm — matches the "Delete tag" button in the dialog
     await page.locator('[role="alertdialog"] button', { hasText: 'Delete tag' }).click()
 
-    await expect(page.locator(`aside button:has-text("${deleteTag}")`)).toHaveCount(0, {
+    await expandTagsSection(page)
+    await expect(page.getByRole('button', { name: deleteTag, exact: true })).toHaveCount(0, {
       timeout: 10000
     })
   })


### PR DESCRIPTION
## Summary

Three compounding bugs kept the `tags-rename-delete.e2e.ts` suite red from the moment it was added in #238.

- **Product:** `createNote()` only emitted `NotesChannels.events.CREATED`, never `notes:tags-changed`. The sidebar's `useNoteTagsQuery` only invalidates on the latter, so the tag tree never refetched after API-created notes. `updateNote()` already does this correctly — `createNote()` was missed when `notes.ts` was split (#232).
- **Test selector:** `aside button:has-text(...)` targets an `<aside>` element that doesn't exist (the main sidebar is a `<div>`; only `calendar-sidebar.tsx` uses `<aside>`).
- **Test setup:** the Tags `SidebarSection` uses `defaultExpanded={false}`, so even after the tag was indexed and rendered, it wasn't visible to Playwright. The test never expanded the section.

## Changes

- `apps/desktop/src/main/vault/notes-crud.ts` — emit `notes:tags-changed` from `createNote()` when `mergedTags.length > 0`, mirroring `updateNote()`.
- `apps/desktop/tests/e2e/tags-rename-delete.e2e.ts` — extract `expandTagsSection()` helper that toggles via `aria-label="Tags section, collapsed"`; replace `aside button:has-text(...)` with `getByRole('button', { name: tag, exact: true })`.

## Test plan

- [x] `pnpm exec playwright test tests/e2e/tags-rename-delete.e2e.ts` — both tests green in 18.8 s locally
- [ ] CI shard 3/3 confirms the fix in the larger context
- [ ] No regressions in adjacent tag-related tests