### PR TITLE
fix(e2e): make T541 row-position drop test independent of task sort order

### DIFF
--- a/apps/desktop/tests/e2e/tasks.e2e.ts
+++ b/apps/desktop/tests/e2e/tasks.e2e.ts
@@ -377,7 +377,11 @@ test.describe('Tasks Management', () => {
       await expect(firstHighRow).toBeVisible()
       await expect(secondHighRow).toBeVisible()
 
-      await moveDraggedTaskToTarget(page, sourceRow, firstHighRow, { yRatio: 0.2 })
+      // Hover over the SECOND row's top edge so the row-position assertion is
+      // distinguishable from a section-start drop. Hovering over the first row's
+      // top edge would put insertIndex at 0 — visually identical to a header drop
+      // and would only verify section membership, not row-position semantics.
+      await moveDraggedTaskToTarget(page, sourceRow, secondHighRow, { yRatio: 0.2 })
 
       await expect(firstHighRow).toHaveAttribute('data-section-drag-state', 'target-highlighted')
       await expect(secondHighRow).toHaveAttribute('data-section-drag-state', 'target-highlighted')
@@ -398,8 +402,8 @@ test.describe('Tasks Management', () => {
       expect(firstHighIndex).toBeGreaterThanOrEqual(0)
       expect(sourceIndex).toBeGreaterThanOrEqual(0)
       expect(secondHighIndex).toBeGreaterThanOrEqual(0)
-      expect(secondHighIndex).toBeLessThan(sourceIndex)
-      expect(sourceIndex).toBeLessThan(firstHighIndex)
+      expect(firstHighIndex).toBeLessThan(sourceIndex)
+      expect(sourceIndex).toBeLessThan(secondHighIndex)
     })
 
     test('T541: should keep intermediate sections visually stable during cross-section drags', async ({


### PR DESCRIPTION
## Summary

The failing T541 assertion `secondHighIndex < sourceIndex < firstHighIndex` required the High section to render in `[secondHigh, firstHigh]` order (newest-created on top), but the actual product order is `[firstHigh, secondHigh]` (creation order, oldest first).

Hovering over `firstHighRow` at `yRatio: 0.2` therefore landed source at section index 0 — **visually identical** to a section-header drop. That defeated the entire purpose of the test, which is to verify that hovering on a specific row inserts at *that row's position*, not at the section start.

## Root cause verification

Added a temporary `console.log` in [`buildCrossSectionOrderUpdates`](apps/desktop/src/renderer/src/hooks/use-drag-handlers.ts) and observed:

```json
{ "targetOrder": ["firstHigh", "secondHigh"], "overId": "firstHigh", "overTaskEdge": "before", "sectionDropPosition": null, "insertIndex": 0 }
```

The drag handler is correct. The bug was entirely in the test's coupled assumption about pre-drop ordering.

## Change

- `apps/desktop/tests/e2e/tasks.e2e.ts` — switch hover target from `firstHighRow` to `secondHighRow` and invert assertions to `firstHigh < source < secondHigh`. Insertion now lands between the two existing rows, properly exercising row-position semantics regardless of sort order.

No production code changes.

## Test plan

- [x] `pnpm exec playwright test tasks.e2e.ts --grep "T541: should highlight the full target"` — green in 11.3 s
- [x] All 6 T541 sibling tests still pass (49.6 s)
- [ ] CI shard 3/3 confirms no regressions