### PR TITLE
fix(e2e): give note-list sync poll 30s headroom for CI runners

### DIFF
--- a/apps/desktop/tests/e2e/utils/note-sync-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/note-sync-helpers.ts
@@ -93,20 +93,29 @@ export async function openNoteByTitle(page: Page, title: string): Promise<void> 
   await openNoteInUi(page, note)
 }
 
+// Sync-dependent polls need more headroom than the default 10 s expect timeout
+// because they depend on cross-device replication landing in B's index.
+// Locally the post-sync poll resolves in ~100 ms, but CI runners have been
+// observed to take >10 s under load (manual-sync-smoke.e2e.ts shard 2/3).
+const NOTE_LIST_POLL_TIMEOUT_MS = 30_000
+
 export async function getNoteHandleByTitle(
   page: Page,
   title: string
 ): Promise<{ id: string; title: string; emoji?: string | null }> {
   let note: { id: string; title: string; emoji?: string | null } | null = null
   await expect
-    .poll(async () => {
-      note = await page.evaluate(async (expectedTitle) => {
-        const result = await window.api.notes.list({})
-        const match = result.notes.find((item) => item.title === expectedTitle)
-        return match ? { id: match.id, title: match.title, emoji: match.emoji ?? null } : null
-      }, title)
-      return note !== null
-    })
+    .poll(
+      async () => {
+        note = await page.evaluate(async (expectedTitle) => {
+          const result = await window.api.notes.list({})
+          const match = result.notes.find((item) => item.title === expectedTitle)
+          return match ? { id: match.id, title: match.title, emoji: match.emoji ?? null } : null
+        }, title)
+        return note !== null
+      },
+      { timeout: NOTE_LIST_POLL_TIMEOUT_MS }
+    )
     .toBe(true)
 
   return note!


### PR DESCRIPTION
## Summary

Manual-sync-smoke (and the body-CRDT same-note merge tests, which use the same helper) timed out in CI shard 2/3 at [\`note-sync-helpers.ts:101\`](apps/desktop/tests/e2e/utils/note-sync-helpers.ts) after the default 10 s \`expect.poll\` budget. The poll waits for device B's \`notes.list({})\` to surface the note that device A pushed.

## Diagnostic findings

- Test passes **5/5 locally** in 10.8 – 12.3 s end-to-end.
- The post-sync poll typically resolves in ~100 ms — the note is already in B's index right after \`syncBothAndWait\` returns with \`pendingCount === 0\`.
- The original plan hypothesized a missing \`flushProjectionEvents()\` or \`CREATED\` emit in the [note-handler markdown insert branch](apps/desktop/src/main/sync/item-handlers/note-handler.ts) — both already exist (lines 441, 463). No product bug found.
- CI runners under shard load take materially longer between sync settling and the renderer's IPC reflecting the new row. The 10 s default is too tight for a sync-dependent helper.

## Change

- [\`apps/desktop/tests/e2e/utils/note-sync-helpers.ts\`](apps/desktop/tests/e2e/utils/note-sync-helpers.ts) — bump the \`expect.poll\` timeout in \`getNoteHandleByTitle\` from the default 10 s to a named 30 s constant with explanatory comment.

No product code changes. No other helpers altered.

## Test plan

- [x] \`pnpm exec playwright test manual-sync-smoke.e2e.ts\` × 5 — all green
- [ ] CI shard 2/3 confirms the bump unblocks the test under load
- [ ] Body-CRDT tests (which also use \`getNoteHandleByTitle\`) benefit from the same headroom