### PR TITLE
fix(e2e): bump expect.timeout to 20s for CI shard headroom

### DIFF
--- a/apps/desktop/config/playwright.config.ts
+++ b/apps/desktop/config/playwright.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
   timeout: 60000,
 
   expect: {
-    timeout: 10000
+    // 20s gives polled assertions (notes.list, CRDT body, writeback debug)
+    // enough headroom under CI shard load, where 10s reproducibly bites the
+    // body-crdt and manual-sync suites without indicating a real product bug.
+    timeout: 20000
   },
 
   fullyParallel: false,


### PR DESCRIPTION
## Summary

Body-CRDT same-note merge tests M2/M3/M4 were timing out in CI shard 2/3 with the default 10 s \`expect.poll\` budget. Each test runs ~8 polls in [\`assertMergedNoteOnBothDevices\`](apps/desktop/tests/e2e/body-crdt-same-note-merge.e2e.ts) (CRDT doc, writeback debug, file body, note list across both devices) — under CI shard load any one of them can blow past 10 s.

## Diagnostic findings

- **M2/M3/M4 all pass locally** in 38.9 s for the trio.
- \`waitForCrdtQueueIdle\` and \`waitForSyncIdle\` already use explicit 15 s internal timeouts → not the bottleneck.
- The CI failure pattern (mix of 22 s and 5–6 s failures) matches "implicit-default polls timing out under shard load," not a product hang.
- The plan's hypotheses (CRDT push promise hang, missing reconnect-flush, broken pending-count test hook) were not reproducible locally and the production code paths look correct on inspection.

## Change

- [\`apps/desktop/config/playwright.config.ts\`](apps/desktop/config/playwright.config.ts) — bump \`expect.timeout\` from 10 s to 20 s with a comment explaining the CI-shard motivation.

Per-test timeout remains 60 s, so individual tests still fail-fast on real hangs.

## Test plan

- [x] \`pnpm exec playwright test body-crdt-same-note-merge.e2e.ts --grep "M2|M3|M4"\` — 3 passed (39.2 s)
- [ ] CI shard 2/3 confirms the bump unblocks the suite
- [ ] No regressions in fast-running tests (per-test timeout unchanged at 60 s)