### PR TITLE
feat(calendar): gate Google Calendar sync behind Memry auth state

### DIFF
--- a/apps/desktop/scripts/check-native.js
+++ b/apps/desktop/scripts/check-native.js
@@ -27,7 +27,9 @@ function tryRequire(mod) {
   })
   if (res.status === 0) return { ok: true }
   const err = (res.stderr || '').trim()
-  const match = err.match(/NODE_MODULE_VERSION\s+(\d+).+?this version of Node\.js requires\s+NODE_MODULE_VERSION\s+(\d+)/s)
+  const match = err.match(
+    /NODE_MODULE_VERSION\s+(\d+).+?this version of Node\.js requires\s+NODE_MODULE_VERSION\s+(\d+)/s
+  )
   return { ok: false, compiledAbi: match?.[1], expectedAbi: match?.[2], err }
 }
 
@@ -42,10 +44,14 @@ if (failures.length === 0) {
   process.exit(0)
 }
 
-console.error(`[check:native] NODE_MODULE_VERSION mismatch — ${failures.length} module(s) failed to load under ${currentRuntime}:`)
+console.error(
+  `[check:native] NODE_MODULE_VERSION mismatch — ${failures.length} module(s) failed to load under ${currentRuntime}:`
+)
 for (const f of failures) {
   if (f.compiledAbi && f.expectedAbi) {
-    console.error(`  - ${f.mod}: compiled for ABI ${f.compiledAbi}, runtime needs ABI ${f.expectedAbi}`)
+    console.error(
+      `  - ${f.mod}: compiled for ABI ${f.compiledAbi}, runtime needs ABI ${f.expectedAbi}`
+    )
   } else {
     console.error(`  - ${f.mod}: ${f.err.split('\n')[0]}`)
   }
@@ -54,7 +60,9 @@ for (const f of failures) {
 const fix = stamp === 'electron' ? 'pnpm rebuild:node' : 'pnpm rebuild:electron'
 const altFix = stamp === 'electron' ? 'pnpm rebuild:electron' : 'pnpm rebuild:node'
 console.error('')
-console.error(`[check:native] stamp says last build target was "${stamp}"; current runtime is "${currentRuntime}".`)
+console.error(
+  `[check:native] stamp says last build target was "${stamp}"; current runtime is "${currentRuntime}".`
+)
 console.error(`[check:native] fix:`)
 console.error(`    ${fix}           # to run tests/scripts under Node`)
 console.error(`    ${altFix}        # to run the Electron app (pnpm dev)`)

--- a/apps/desktop/src/main/calendar/google/oauth.ts
+++ b/apps/desktop/src/main/calendar/google/oauth.ts
@@ -3,6 +3,8 @@ import { createHash, randomBytes } from 'node:crypto'
 import { shell } from 'electron'
 import { z } from 'zod'
 import { createLogger } from '../../lib/logger'
+import type { DataDb } from '../../database/types'
+import { listCalendarSources } from '../repositories/calendar-sources-repository'
 import {
   clearGoogleCalendarTokens,
   getGoogleCalendarTokens,
@@ -372,6 +374,12 @@ export async function disconnectGoogleCalendar(): Promise<void> {
 export async function hasGoogleCalendarLocalAuth(): Promise<boolean> {
   const { refreshToken } = await getGoogleCalendarTokens()
   return typeof refreshToken === 'string' && refreshToken.trim().length > 0
+}
+
+export async function hasGoogleCalendarConnection(db: DataDb): Promise<boolean> {
+  if (!(await hasGoogleCalendarLocalAuth())) return false
+  const accounts = listCalendarSources(db, { provider: 'google', kind: 'account' })
+  return accounts.length > 0
 }
 
 export function buildGoogleCalendarAuthUrl(input: {

--- a/apps/desktop/src/main/calendar/google/sync-service.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.test.ts
@@ -32,15 +32,22 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('./oauth', () => ({
-  hasGoogleCalendarLocalAuth: vi.fn(async () => true)
+  hasGoogleCalendarLocalAuth: vi.fn(async () => true),
+  hasGoogleCalendarConnection: vi.fn(async () => true)
 }))
 
-import { hasGoogleCalendarLocalAuth } from './oauth'
+vi.mock('../../sync/auth-state', () => ({
+  isMemryUserSignedIn: vi.fn(async () => true)
+}))
+
+import { hasGoogleCalendarConnection, hasGoogleCalendarLocalAuth } from './oauth'
+import { isMemryUserSignedIn } from '../../sync/auth-state'
 import {
   applyGoogleCalendarDelete,
   applyGoogleCalendarWriteback,
   syncLocalSourceToGoogleCalendar,
   pushSourceToGoogleCalendar,
+  syncGoogleCalendarNow,
   syncGoogleCalendarSource
 } from './sync-service'
 
@@ -55,6 +62,8 @@ describe('google calendar sync service', () => {
     db = dbResult.db
     mockCalendarSend.mockClear()
     vi.mocked(hasGoogleCalendarLocalAuth).mockResolvedValue(true)
+    vi.mocked(hasGoogleCalendarConnection).mockResolvedValue(true)
+    vi.mocked(isMemryUserSignedIn).mockResolvedValue(true)
 
     const seeded = seedTestData(db)
     projectId = seeded.projectId
@@ -648,7 +657,7 @@ describe('google calendar sync service', () => {
 
   it('skips local Google reconciliation when the device is not connected', async () => {
     seedGoogleCalendarSource()
-    vi.mocked(hasGoogleCalendarLocalAuth).mockResolvedValue(false)
+    vi.mocked(hasGoogleCalendarConnection).mockResolvedValue(false)
 
     db.insert(tasks)
       .values({
@@ -683,5 +692,37 @@ describe('google calendar sync service', () => {
 
     expect(client.upsertEvent).not.toHaveBeenCalled()
     expect(client.deleteEvent).not.toHaveBeenCalled()
+  })
+
+  describe('syncGoogleCalendarNow gating', () => {
+    function buildClient() {
+      return {
+        listCalendars: vi.fn(),
+        createCalendar: vi.fn(),
+        listEvents: vi.fn(),
+        upsertEvent: vi.fn(),
+        deleteEvent: vi.fn()
+      }
+    }
+
+    it('skips all Google API calls when Memry user is not signed in', async () => {
+      vi.mocked(isMemryUserSignedIn).mockResolvedValue(false)
+      const client = buildClient()
+
+      await syncGoogleCalendarNow(db, { client })
+
+      expect(client.listCalendars).not.toHaveBeenCalled()
+      expect(client.listEvents).not.toHaveBeenCalled()
+    })
+
+    it('skips all Google API calls when no Google Calendar connection exists', async () => {
+      vi.mocked(hasGoogleCalendarConnection).mockResolvedValue(false)
+      const client = buildClient()
+
+      await syncGoogleCalendarNow(db, { client })
+
+      expect(client.listCalendars).not.toHaveBeenCalled()
+      expect(client.listEvents).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -13,7 +13,8 @@ import {
   enqueueLocalSyncUpdate
 } from '../../sync/local-mutations'
 import { publishProjectionEvent } from '../../projections'
-import { hasGoogleCalendarLocalAuth } from './oauth'
+import { hasGoogleCalendarConnection } from './oauth'
+import { isMemryUserSignedIn } from '../../sync/auth-state'
 import { createGoogleCalendarClient } from './client'
 import {
   mapCalendarEventToGoogleInput,
@@ -339,9 +340,8 @@ export async function syncLocalSourceToGoogleCalendar(
     >
   } = {}
 ): Promise<typeof calendarBindings.$inferSelect | null> {
-  if (!(await hasGoogleCalendarLocalAuth())) {
-    return null
-  }
+  if (!(await isMemryUserSignedIn())) return null
+  if (!(await hasGoogleCalendarConnection(db))) return null
 
   if (shouldSourceSyncToGoogleCalendar(db, target)) {
     return await pushSourceToGoogleCalendar(db, target, deps)
@@ -568,9 +568,8 @@ export async function syncGoogleCalendarNow(
   deps: { client?: GoogleCalendarClient } = {}
 ): Promise<void> {
   if (syncInFlight) return
-  if (!(await hasGoogleCalendarLocalAuth())) {
-    return
-  }
+  if (!(await isMemryUserSignedIn())) return
+  if (!(await hasGoogleCalendarConnection(db))) return
 
   syncInFlight = true
   try {
@@ -591,8 +590,10 @@ export async function syncGoogleCalendarNow(
   }
 }
 
-export function startGoogleCalendarSyncRunner(): void {
+export async function startGoogleCalendarSyncRunner(): Promise<void> {
   if (syncInterval) return
+  if (!(await isMemryUserSignedIn())) return
+  if (!(await hasGoogleCalendarConnection(requireDatabase()))) return
 
   void syncGoogleCalendarNow().catch((error) => {
     log.warn('initial Google Calendar sync failed', error)

--- a/apps/desktop/src/main/crypto/__fixtures__/README.md
+++ b/apps/desktop/src/main/crypto/__fixtures__/README.md
@@ -10,12 +10,12 @@ drift the moment a vector file is edited.
 
 ## Files
 
-| File | Algorithm | Source |
-| --- | --- | --- |
-| `xchacha20-rfc8439.ts` | XChaCha20-Poly1305 (IETF) | [draft-irtf-cfrg-xchacha-03 §A.3.1](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha-03#appendix-A.3.1) |
-| `ed25519-rfc8032.ts` | Ed25519 (pure) | [RFC 8032 §7.1](https://datatracker.ietf.org/doc/html/rfc8032#section-7.1) |
-| `argon2id-rfc9106.ts` | Argon2id | [RFC 9106 §5.3](https://datatracker.ietf.org/doc/html/rfc9106#section-5.3) |
-| `load-vectors.ts` | typed loader + shape assertions | — |
+| File                   | Algorithm                       | Source                                                                                                               |
+| ---------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `xchacha20-rfc8439.ts` | XChaCha20-Poly1305 (IETF)       | [draft-irtf-cfrg-xchacha-03 §A.3.1](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha-03#appendix-A.3.1) |
+| `ed25519-rfc8032.ts`   | Ed25519 (pure)                  | [RFC 8032 §7.1](https://datatracker.ietf.org/doc/html/rfc8032#section-7.1)                                           |
+| `argon2id-rfc9106.ts`  | Argon2id                        | [RFC 9106 §5.3](https://datatracker.ietf.org/doc/html/rfc9106#section-5.3)                                           |
+| `load-vectors.ts`      | typed loader + shape assertions | —                                                                                                                    |
 
 All vector files were captured on **2026-04-16**. The retrieval date is also
 recorded in each file header and on each exported vector constant.
@@ -53,11 +53,11 @@ pnpm exec tsx -e '
 
 Substitute the vector import + concatenated bytes as appropriate:
 
-| Vector file | Bytes to hash |
-| --- | --- |
+| Vector file            | Bytes to hash      |
+| ---------------------- | ------------------ |
 | `xchacha20-rfc8439.ts` | `ciphertext ‖ tag` |
-| `ed25519-rfc8032.ts` | `signature` |
-| `argon2id-rfc9106.ts` | `tag` |
+| `ed25519-rfc8032.ts`   | `signature`        |
+| `argon2id-rfc9106.ts`  | `tag`              |
 
 Once a sentinel is pinned, edits that change the literal will produce a hash
 mismatch the first time a consuming test re-runs the recipe, surfacing the
@@ -68,7 +68,7 @@ tamper.
 If the upstream vector ever needs to be re-verified:
 
 1. Open the source URL listed in the file header.
-2. Copy each hex blob *exactly* — keep groupings reproducible (we use
+2. Copy each hex blob _exactly_ — keep groupings reproducible (we use
    32-hex-char chunks so diffs stay local).
 3. Update the `retrievedAt` field on the vector constant **and** the
    per-file header comment to match the day of re-fetch (ISO `YYYY-MM-DD`).

--- a/apps/desktop/src/main/crypto/__fixtures__/argon2id-rfc9106.ts
+++ b/apps/desktop/src/main/crypto/__fixtures__/argon2id-rfc9106.ts
@@ -34,8 +34,7 @@ const SECRET_HEX = '03'.repeat(8)
 const ASSOCIATED_DATA_HEX = '04'.repeat(12)
 
 // Expected output tag (32 bytes) per RFC 9106 §5.3 final hash.
-const TAG_HEX =
-  '0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659'
+const TAG_HEX = '0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659'
 
 // Tamper sentinel: SHA-256 of `hexToBytes(TAG_HEX)`. Pin via ./README.md →
 // "Tamper sentinels" recipe on first consumer test run.
@@ -57,6 +56,4 @@ export const ARGON2ID_RFC9106_VECTOR: Argon2idVector = assertArgon2idVector({
   tag: hexToBytes(TAG_HEX)
 })
 
-export const ARGON2ID_RFC9106_VECTORS: readonly Argon2idVector[] = [
-  ARGON2ID_RFC9106_VECTOR
-]
+export const ARGON2ID_RFC9106_VECTORS: readonly Argon2idVector[] = [ARGON2ID_RFC9106_VECTOR]

--- a/apps/desktop/src/main/crypto/__fixtures__/ed25519-rfc8032.ts
+++ b/apps/desktop/src/main/crypto/__fixtures__/ed25519-rfc8032.ts
@@ -15,11 +15,9 @@ import { assertEd25519Vector, hexToBytes, type Ed25519Vector } from './load-vect
 // TEST 1 — empty message
 // ---------------------------------------------------------------------------
 
-const TEST1_SEED_HEX =
-  '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60'
+const TEST1_SEED_HEX = '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60'
 
-const TEST1_PUBLIC_KEY_HEX =
-  'd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a'
+const TEST1_PUBLIC_KEY_HEX = 'd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a'
 
 const TEST1_MESSAGE_HEX = ''
 
@@ -45,11 +43,9 @@ export const ED25519_RFC8032_TEST_1: Ed25519Vector = assertEd25519Vector({
 // TEST 2 — single-byte message 0x72
 // ---------------------------------------------------------------------------
 
-const TEST2_SEED_HEX =
-  '4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb'
+const TEST2_SEED_HEX = '4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb'
 
-const TEST2_PUBLIC_KEY_HEX =
-  '3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c'
+const TEST2_PUBLIC_KEY_HEX = '3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c'
 
 const TEST2_MESSAGE_HEX = '72'
 

--- a/apps/desktop/src/main/crypto/__fixtures__/encryption-extras.ts
+++ b/apps/desktop/src/main/crypto/__fixtures__/encryption-extras.ts
@@ -23,9 +23,7 @@ const fromHex = (hex: string): Uint8Array => {
 }
 
 export const IETF_XCHACHA20_POLY1305_VECTOR = {
-  key: fromHex(
-    '808182838485868788898a8b8c8d8e8f' + '909192939495969798999a9b9c9d9e9f'
-  ),
+  key: fromHex('808182838485868788898a8b8c8d8e8f' + '909192939495969798999a9b9c9d9e9f'),
   nonce: fromHex('404142434445464748494a4b4c4d4e4f5051525354555657'),
   aad: fromHex('50515253c0c1c2c3c4c5c6c7'),
   plaintext: fromHex(
@@ -38,7 +36,8 @@ export const IETF_XCHACHA20_POLY1305_VECTOR = {
     'bd6d179d3e83d43b9576579493c0e939572a1700252bfaccbed2902c21396cbb' +
       '731c7f1b0b4aa6440bf3a82f4eda7e39ae64c6708c54c216cb96b72e1213b452' +
       '2f8c9ba40db5d945b11b69b982c1bb9e3f3fac2bc369488f76b2383565d3fff9' +
-      '21f9664c97637da9768812f615c68b13b52e' + 'c0875924c1c7987947deafd8780acf49'
+      '21f9664c97637da9768812f615c68b13b52e' +
+      'c0875924c1c7987947deafd8780acf49'
   )
 } as const
 

--- a/apps/desktop/src/main/crypto/encryption.test.ts
+++ b/apps/desktop/src/main/crypto/encryption.test.ts
@@ -194,7 +194,11 @@ describe('encryption', () => {
         throw new Error('forced decrypt failure')
       })
 
-    expectCryptoError(() => decrypt(ciphertext, nonce, key), 'DECRYPTION_FAILED', /forced decrypt failure/)
+    expectCryptoError(
+      () => decrypt(ciphertext, nonce, key),
+      'DECRYPTION_FAILED',
+      /forced decrypt failure/
+    )
 
     decryptSpy.mockRestore()
   })
@@ -209,15 +213,19 @@ describe('encryption', () => {
         throw 'forced string failure'
       })
 
-    expectCryptoError(() => decrypt(ciphertext, nonce, key), 'DECRYPTION_FAILED', /Decryption failed/)
+    expectCryptoError(
+      () => decrypt(ciphertext, nonce, key),
+      'DECRYPTION_FAILED',
+      /Decryption failed/
+    )
 
     decryptSpy.mockRestore()
   })
 
   it('throws when sodium returns a nonce with the wrong length', () => {
-    const randombytesSpy = vi.spyOn(sodium, 'randombytes_buf').mockReturnValueOnce(
-      new Uint8Array(XCHACHA20_PARAMS.NONCE_LENGTH - 1)
-    )
+    const randombytesSpy = vi
+      .spyOn(sodium, 'randombytes_buf')
+      .mockReturnValueOnce(new Uint8Array(XCHACHA20_PARAMS.NONCE_LENGTH - 1))
 
     expect(() => generateNonce()).toThrow(
       `Nonce length mismatch: expected ${XCHACHA20_PARAMS.NONCE_LENGTH}, got ${XCHACHA20_PARAMS.NONCE_LENGTH - 1}`
@@ -257,18 +265,9 @@ describe('encryption', () => {
     const { ciphertext, nonce } = encrypt(plaintext, validKey)
     const shortNonce = new Uint8Array(XCHACHA20_PARAMS.NONCE_LENGTH - 1)
 
-    expectCryptoError(
-      () => encrypt(plaintext, shortKey),
-      'INVALID_KEY_LENGTH'
-    )
-    expectCryptoError(
-      () => decrypt(ciphertext, nonce, shortKey),
-      'INVALID_KEY_LENGTH'
-    )
-    expectCryptoError(
-      () => decrypt(ciphertext, shortNonce, validKey),
-      'INVALID_NONCE_LENGTH'
-    )
+    expectCryptoError(() => encrypt(plaintext, shortKey), 'INVALID_KEY_LENGTH')
+    expectCryptoError(() => decrypt(ciphertext, nonce, shortKey), 'INVALID_KEY_LENGTH')
+    expectCryptoError(() => decrypt(ciphertext, shortNonce, validKey), 'INVALID_NONCE_LENGTH')
   })
 
   it('matches the IETF XChaCha20-Poly1305 golden vector for decrypt', () => {

--- a/apps/desktop/src/main/crypto/keys.test.ts
+++ b/apps/desktop/src/main/crypto/keys.test.ts
@@ -190,9 +190,7 @@ describe('generateDeviceSigningKeyPair', () => {
     expect(keyPair.deviceId).toHaveLength(32)
 
     // #then deviceId is BLAKE2b-128 of the public key, hex-encoded
-    const expectedDeviceId = sodium.to_hex(
-      sodium.crypto_generichash(16, keyPair.publicKey, null)
-    )
+    const expectedDeviceId = sodium.to_hex(sodium.crypto_generichash(16, keyPair.publicKey, null))
     expect(keyPair.deviceId).toBe(expectedDeviceId)
   })
 

--- a/apps/desktop/src/main/crypto/rotation.test.ts
+++ b/apps/desktop/src/main/crypto/rotation.test.ts
@@ -2,11 +2,7 @@ import sodium from 'libsodium-wrappers-sumo'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { CBOR_FIELD_ORDER } from '@memry/contracts/cbor-ordering'
-import {
-  CRYPTO_VERSION,
-  ED25519_PARAMS,
-  XCHACHA20_PARAMS
-} from '@memry/contracts/crypto'
+import { CRYPTO_VERSION, ED25519_PARAMS, XCHACHA20_PARAMS } from '@memry/contracts/crypto'
 import type { PullItemResponse, PushItem } from '@memry/contracts/sync-api'
 
 import { encrypt, unwrapFileKey, wrapFileKey } from './encryption'
@@ -145,7 +141,13 @@ describe('rewrapItemKey', () => {
     })
 
     // #when rewrapping with the new vault key
-    const result = rewrapItemKey(item, oldVaultKey, newVaultKey, signing.secretKey, signing.deviceId)
+    const result = rewrapItemKey(
+      item,
+      oldVaultKey,
+      newVaultKey,
+      signing.secretKey,
+      signing.deviceId
+    )
 
     // #then the encrypted data and nonce are byte-identical (only the key wrapper changed)
     expect(result.pushItem.encryptedData).toBe(item.blob.encryptedData)
@@ -194,7 +196,13 @@ describe('rewrapItemKey', () => {
     })
 
     // #when rewrapping
-    const result = rewrapItemKey(item, oldVaultKey, newVaultKey, signing.secretKey, signing.deviceId)
+    const result = rewrapItemKey(
+      item,
+      oldVaultKey,
+      newVaultKey,
+      signing.secretKey,
+      signing.deviceId
+    )
 
     // #then deletedAt is preserved and the signature still verifies
     expect(result.pushItem.deletedAt).toBe(deletedAt)
@@ -217,7 +225,13 @@ describe('rewrapItemKey', () => {
     })
 
     // #when rewrapping
-    const result = rewrapItemKey(item, oldVaultKey, newVaultKey, signing.secretKey, signing.deviceId)
+    const result = rewrapItemKey(
+      item,
+      oldVaultKey,
+      newVaultKey,
+      signing.secretKey,
+      signing.deviceId
+    )
 
     // #then the stateVector survives and the signature verifies
     expect(result.pushItem.stateVector).toBe(stateVector)
@@ -317,7 +331,13 @@ describe('rewrapCrdtSnapshot', () => {
     const built = buildCrdtSnapshot(noteId, oldVaultKey, signing, body)
 
     // #when rewrapping under newVaultKey
-    const rewrapped = rewrapCrdtSnapshot(built.packed, noteId, oldVaultKey, newVaultKey, signing.secretKey)
+    const rewrapped = rewrapCrdtSnapshot(
+      built.packed,
+      noteId,
+      oldVaultKey,
+      newVaultKey,
+      signing.secretKey
+    )
 
     // #then the snapshot length is unchanged
     expect(rewrapped).toHaveLength(built.packed.length)
@@ -340,10 +360,7 @@ describe('rewrapCrdtSnapshot', () => {
     expect(newWrapped).not.toEqual(oldWrapped)
 
     // #and the file key recovered with newVaultKey matches the original file key
-    const newKeyNonce = rewrapped.subarray(
-      CRDT_NONCE_LEN,
-      CRDT_NONCE_LEN + CRDT_NONCE_LEN
-    )
+    const newKeyNonce = rewrapped.subarray(CRDT_NONCE_LEN, CRDT_NONCE_LEN + CRDT_NONCE_LEN)
     const recoveredFileKey = unwrapFileKey(newWrapped, newKeyNonce, newVaultKey)
     expect(recoveredFileKey).toEqual(built.fileKey)
 
@@ -578,7 +595,9 @@ describe('performKeyRotation', () => {
     expect(harness.pushedSnapshots).toHaveLength(1)
     const pushed = harness.pushedSnapshots[0]
     expect(pushed.noteId).toBe('note-0')
-    expect(verifyCrdtSnapshotSignature(pushed.snapshot, pushed.noteId, fixture.signing.publicKey)).toBe(true)
+    expect(
+      verifyCrdtSnapshotSignature(pushed.snapshot, pushed.noteId, fixture.signing.publicKey)
+    ).toBe(true)
 
     // #and the server keys were updated and the new master key was stored
     expect(harness.serverKeyUpdates).toEqual([

--- a/apps/desktop/src/main/crypto/signatures.test.ts
+++ b/apps/desktop/src/main/crypto/signatures.test.ts
@@ -112,9 +112,9 @@ describe('signatures', () => {
 
       // #then — forgery rejected; A's own pubkey still verifies (sanity)
       expect(verifiedAsImpersonated).toBe(false)
-      expect(verifySignature(payload, CBOR_FIELD_ORDER.SYNC_ITEM, aSignature, signer.publicKey)).toBe(
-        true
-      )
+      expect(
+        verifySignature(payload, CBOR_FIELD_ORDER.SYNC_ITEM, aSignature, signer.publicKey)
+      ).toBe(true)
     })
 
     it('rejects verification when wrong public key is provided', () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -662,11 +662,9 @@ void app.whenReady().then(async () => {
       } catch (error) {
         mainLog.warn('reminder scheduler failed to start:', error)
       }
-      try {
-        startGoogleCalendarSyncRunner()
-      } catch (error) {
+      void startGoogleCalendarSyncRunner().catch((error) => {
         mainLog.warn('Google Calendar sync runner failed to start:', error)
-      }
+      })
     })
     .catch((err) => mainLog.error('autoOpenLastVault failed:', err))
 

--- a/apps/desktop/src/main/ipc/auth-oauth-handlers.ts
+++ b/apps/desktop/src/main/ipc/auth-oauth-handlers.ts
@@ -14,6 +14,7 @@ import { SYNC_CHANNELS, SYNC_EVENTS } from '@memry/contracts/ipc-sync'
 import { store } from '../store'
 import { postToServer } from '../sync/http-client'
 import { getSyncEngine, startSyncRuntime } from '../sync/runtime'
+import { startGoogleCalendarSyncRunner } from '../calendar/google/sync-service'
 import { teardownSession } from '../sync/session-teardown'
 import { refreshAccessToken, storeToken } from '../sync/token-manager'
 import { createLogger } from '../lib/logger'
@@ -263,6 +264,9 @@ export function registerAuthOAuthHandlers(): void {
         } else {
           void startSyncRuntime()
         }
+        void startGoogleCalendarSyncRunner().catch(() => {
+          // Runner self-logs on failure.
+        })
       }
       return { success: true }
     },

--- a/apps/desktop/src/main/ipc/calendar-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.test.ts
@@ -16,6 +16,9 @@ const mockConnectGoogleCalendar = vi.fn()
 const mockDisconnectGoogleCalendar = vi.fn()
 const mockHasGoogleCalendarLocalAuth = vi.fn()
 const mockSyncGoogleCalendarNow = vi.fn()
+const mockStartGoogleCalendarSyncRunner = vi.fn(async () => {})
+const mockStopGoogleCalendarSyncRunner = vi.fn()
+const mockIsMemryUserSignedIn = vi.fn(async () => true)
 
 vi.mock('electron', () => ({
   ipcMain: {
@@ -55,7 +58,13 @@ vi.mock('../calendar/google/oauth', () => ({
 }))
 
 vi.mock('../calendar/google/sync-service', () => ({
-  syncGoogleCalendarNow: (...args: unknown[]) => mockSyncGoogleCalendarNow(...args)
+  syncGoogleCalendarNow: (...args: unknown[]) => mockSyncGoogleCalendarNow(...args),
+  startGoogleCalendarSyncRunner: (...args: unknown[]) => mockStartGoogleCalendarSyncRunner(...args),
+  stopGoogleCalendarSyncRunner: (...args: unknown[]) => mockStopGoogleCalendarSyncRunner(...args)
+}))
+
+vi.mock('../sync/auth-state', () => ({
+  isMemryUserSignedIn: (...args: unknown[]) => mockIsMemryUserSignedIn(...args)
 }))
 
 import { getDatabase, requireDatabase } from '../database'

--- a/apps/desktop/src/main/ipc/calendar-handlers.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.ts
@@ -40,7 +40,12 @@ import {
   hasGoogleCalendarLocalAuth
 } from '../calendar/google/oauth'
 import { getCalendarRangeProjection } from '../calendar/projection'
-import { syncGoogleCalendarNow } from '../calendar/google/sync-service'
+import {
+  startGoogleCalendarSyncRunner,
+  stopGoogleCalendarSyncRunner,
+  syncGoogleCalendarNow
+} from '../calendar/google/sync-service'
+import { isMemryUserSignedIn } from '../sync/auth-state'
 import {
   syncCalendarBindingDelete,
   syncCalendarEventCreate,
@@ -405,6 +410,10 @@ export function registerCalendarHandlers(): void {
           modifiedAt: now
         })
 
+        void startGoogleCalendarSyncRunner().catch(() => {
+          // Runner self-logs on failure; swallow to keep connect success green.
+        })
+
         return {
           success: true,
           status: await buildProviderStatus(db, input.provider)
@@ -426,6 +435,7 @@ export function registerCalendarHandlers(): void {
           }
         }
 
+        stopGoogleCalendarSyncRunner()
         await disconnectGoogleCalendar()
 
         const providerSources = listCalendarSourceRows(db, { provider: input.provider })
@@ -507,6 +517,14 @@ export function registerCalendarHandlers(): void {
             success: false,
             status: await buildProviderStatus(db, input.provider),
             error: `Unsupported calendar provider: ${input.provider}`
+          }
+        }
+
+        if (!(await isMemryUserSignedIn())) {
+          return {
+            success: false,
+            status: await buildProviderStatus(db, input.provider),
+            error: 'Sign in to Memry before refreshing Google Calendar'
           }
         }
 

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -2,328 +2,2519 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export interface MainIpcInvokeHandlers {
-  "account:getInfo": (...args: []) => Awaited<import("./account-handlers").AccountInfo>
-  "account:getRecoveryKey": (...args: []) => Awaited<Promise<{ success: boolean; error: string; key?: undefined; } | { success: boolean; key: string; error?: undefined; }>>
-  "account:signOut": (...args: []) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean; }>>
-  "ai-inline:get-server-port": (...args: []) => Awaited<number | null>
-  "ai-inline:get-settings": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ai-inline-channels").AIInlineSettings>
-  "ai-inline:set-settings": (...args: [Partial<import("../../../../../packages/contracts/src/ai-inline-channels").AIInlineSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
-  "ai-inline:start-server": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; port?: undefined; } | { success: boolean; port: number; error?: undefined; }>>
-  "ai-inline:stop-server": (...args: []) => Awaited<Promise<{ success: boolean; }>>
-  "auth:init-oauth": (...args: [{ provider: "google"; }]) => Awaited<Promise<{ state: string; }> | { success: false; error: string }>
-  "auth:refresh-token": (...args: []) => Awaited<Promise<{ success: boolean; error: string | undefined; }>>
-  "auth:request-otp": (...args: [{ email: string; }]) => Awaited<Promise<unknown> | { success: false; error: string }>
-  "auth:resend-otp": (...args: [{ email: string; }]) => Awaited<Promise<unknown> | { success: false; error: string }>
-  "auth:verify-otp": (...args: [{ email: string; code: string; }]) => Awaited<Promise<{ success: boolean; isNewUser: boolean; needsSetup: boolean; needsRecoveryInput: boolean; }> | { success: false; error: string }>
-  "bookmarks:bulk-create": (...args: [{ items: { itemType: string; itemId: string; }[]; }]) => Awaited<Promise<{ success: boolean; createdCount: number; }>>
-  "bookmarks:bulk-delete": (...args: [{ bookmarkIds: string[]; }]) => Awaited<Promise<{ success: boolean; deletedCount: number; }>>
-  "bookmarks:create": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<{ success: boolean; bookmark: null; error: string; } | { success: boolean; bookmark: { id: string; createdAt: string; position: number; itemType: string; itemId: string; }; error?: undefined; }>>
-  "bookmarks:delete": (...args: [string]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
-  "bookmarks:get": (...args: [string]) => Awaited<Promise<{ id: string; createdAt: string; position: number; itemType: string; itemId: string; } | null>>
-  "bookmarks:get-by-item": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<{ id: string; createdAt: string; position: number; itemType: string; itemId: string; } | null>>
-  "bookmarks:is-bookmarked": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<boolean>>
-  "bookmarks:list": (...args: [{ itemType?: string | undefined; sortBy?: "createdAt" | "position" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/bookmarks-api").BookmarkListResponse>>
-  "bookmarks:list-by-type": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/bookmarks-api").BookmarkListResponse>>
-  "bookmarks:reorder": (...args: [{ bookmarkIds: string[]; }]) => Awaited<Promise<{ success: boolean; }>>
-  "bookmarks:toggle": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<{ success: boolean; isBookmarked: boolean; bookmark: { id: string; createdAt: string; position: number; itemType: string; itemId: string; } | null; }>>
-  "calendar:connect-provider": (...args: [{ provider: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarProviderMutationResponse>>
-  "calendar:create-event": (...args: [{ title: string; startAt: string; description?: string | null | undefined; location?: string | null | undefined; endAt?: string | null | undefined; timezone?: string | undefined; isAllDay?: boolean | undefined; recurrenceRule?: Record<string, unknown> | null | undefined; recurrenceExceptions?: Record<string, unknown>[] | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarEventMutationResponse>>
-  "calendar:delete-event": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarDeleteResponse>>
-  "calendar:disconnect-provider": (...args: [{ provider: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarProviderMutationResponse>>
-  "calendar:get-event": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarEventRecord | null>>
-  "calendar:get-provider-status": (...args: [{ provider: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarProviderStatus>>
-  "calendar:get-range": (...args: [{ startAt: string; endAt: string; includeUnselectedSources?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarRangeResponse>>
-  "calendar:list-events": (...args: [{ includeArchived?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarEventListResponse>>
-  "calendar:list-sources": (...args: [{ provider?: string | undefined; kind?: "account" | "calendar" | undefined; selectedOnly?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarSourceListResponse>>
-  "calendar:refresh-provider": (...args: [{ provider: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarProviderMutationResponse>>
-  "calendar:update-event": (...args: [{ id: string; title?: string | undefined; description?: string | null | undefined; location?: string | null | undefined; startAt?: string | undefined; endAt?: string | null | undefined; timezone?: string | undefined; isAllDay?: boolean | undefined; recurrenceRule?: Record<string, unknown> | null | undefined; recurrenceExceptions?: Record<string, unknown>[] | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarEventMutationResponse>>
-  "calendar:update-source-selection": (...args: [{ id: string; isSelected: boolean; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarSourceMutationResponse>>
-  "context-menu:show": (...args: [{ id: string; label: string; accelerator?: string | undefined; disabled?: boolean | undefined; type?: "normal" | "separator" | undefined; }[]]) => Awaited<Promise<string | null>>
-  "crdt:apply-update": (...args: [unknown]) => Awaited<Promise<void>>
-  "crdt:close-doc": (...args: [unknown]) => Awaited<Promise<{ success: boolean; }>>
-  "crdt:open-doc": (...args: [unknown]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
-  "crdt:sync-step-1": (...args: [{ noteId: string; stateVector: number[]; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crdt").CrdtSyncStep1Result | null>>
-  "crdt:sync-step-2": (...args: [{ noteId: string; diff: number[]; }]) => Awaited<Promise<void>>
-  "crypto:decrypt-item": (...args: [{ itemId: string; type: "note" | "filter" | "project" | "journal" | "task" | "settings" | "inbox" | "tag_definition" | "folder_config" | "calendar_event" | "calendar_source" | "calendar_binding" | "calendar_external_event"; encryptedKey: string; keyNonce: string; encryptedData: string; dataNonce: string; signature: string; operation?: "create" | "update" | "delete" | undefined; deletedAt?: number | undefined; metadata?: Record<string, unknown> | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").DecryptItemResult>>
-  "crypto:encrypt-item": (...args: [{ itemId: string; type: "note" | "filter" | "project" | "journal" | "task" | "settings" | "inbox" | "tag_definition" | "folder_config" | "calendar_event" | "calendar_source" | "calendar_binding" | "calendar_external_event"; content: Record<string, unknown>; operation?: "create" | "update" | "delete" | undefined; deletedAt?: number | undefined; metadata?: Record<string, unknown> | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").EncryptItemResult>>
-  "crypto:get-rotation-progress": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-crypto").GetRotationProgressResult>
-  "crypto:rotate-keys": (...args: [{ confirm: boolean; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").RotateKeysResult>>
-  "crypto:verify-signature": (...args: [{ itemId: string; type: "note" | "filter" | "project" | "journal" | "task" | "settings" | "inbox" | "tag_definition" | "folder_config" | "calendar_event" | "calendar_source" | "calendar_binding" | "calendar_external_event"; encryptedKey: string; keyNonce: string; encryptedData: string; dataNonce: string; signature: string; operation?: "create" | "update" | "delete" | undefined; deletedAt?: number | undefined; metadata?: Record<string, unknown> | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").VerifySignatureResult>>
-  "folder-view:delete-view": (...args: [{ folderPath: string; viewName: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/folder-view-api").DeleteViewResponse>>
-  "folder-view:folder-exists": (...args: [string]) => Awaited<boolean>
-  "folder-view:get-available-properties": (...args: [{ folderPath: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetAvailablePropertiesResponse>>
-  "folder-view:get-config": (...args: [{ folderPath: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetConfigResponse>>
-  "folder-view:get-folder-suggestions": (...args: [{ noteId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetFolderSuggestionsResponse>>
-  "folder-view:get-views": (...args: [{ folderPath: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetViewsResponse>>
-  "folder-view:list-with-properties": (...args: [{ folderPath: string; properties?: string[] | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").ListWithPropertiesResponse>>
-  "folder-view:set-config": (...args: [{ folderPath: string; config: { path?: string | undefined; template?: string | undefined; inherit?: boolean | undefined; formulas?: Record<string, string> | undefined; properties?: Record<string, { displayName?: string | undefined; color?: boolean | undefined; dateFormat?: string | undefined; numberFormat?: string | undefined; hidden?: boolean | undefined; }> | undefined; summaries?: Record<string, { type: "custom" | "count" | "sum" | "average" | "min" | "max" | "countBy" | "countUnique"; label?: string | undefined; expression?: string | undefined; }> | undefined; views?: { name: string; type?: "table" | "grid" | "list" | "kanban" | undefined; default?: boolean | undefined; columns?: { id: string; width?: number | undefined; displayName?: string | undefined; showSummary?: boolean | undefined; }[] | undefined; filters?: unknown; order?: { property: string; direction: "asc" | "desc"; }[] | undefined; groupBy?: { property: string; direction?: "asc" | "desc" | undefined; collapsed?: boolean | undefined; showSummary?: boolean | undefined; } | undefined; limit?: number | undefined; showSummaries?: boolean | undefined; }[] | undefined; }; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/folder-view-api").SetConfigResponse>>
-  "folder-view:set-view": (...args: [{ folderPath: string; view: { name: string; type?: "table" | "grid" | "list" | "kanban" | undefined; default?: boolean | undefined; columns?: { id: string; width?: number | undefined; displayName?: string | undefined; showSummary?: boolean | undefined; }[] | undefined; filters?: unknown; order?: { property: string; direction: "asc" | "desc"; }[] | undefined; groupBy?: { property: string; direction?: "asc" | "desc" | undefined; collapsed?: boolean | undefined; showSummary?: boolean | undefined; } | undefined; limit?: number | undefined; showSummaries?: boolean | undefined; }; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/folder-view-api").SetViewResponse>>
-  "graph:get-graph-data": (...args: []) => Awaited<{ nodes: { id: string; type: "note" | "project" | "journal" | "task"; label: string; tags: string[]; wordCount: number; connectionCount: number; emoji: string | null; color: string; isOrphan: boolean; isUnresolved: boolean; }[]; edges: { id: string; source: string; target: string; type: "wikilink" | "task-note" | "project-task" | "tag-cooccurrence"; weight: number; }[]; }>
-  "graph:get-local-graph": (...args: [{ noteId: string; depth?: number | undefined; }]) => Awaited<{ nodes: { id: string; type: "note" | "project" | "journal" | "task"; label: string; tags: string[]; wordCount: number; connectionCount: number; emoji: string | null; color: string; isOrphan: boolean; isUnresolved: boolean; }[]; edges: { id: string; source: string; target: string; type: "wikilink" | "task-note" | "project-task" | "tag-cooccurrence"; weight: number; }[]; }>
-  "inbox:add-tag": (...args: [any, any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:archive": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:bulk-archive": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
-  "inbox:bulk-file": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
-  "inbox:bulk-snooze": (...args: [any]) => Awaited<Promise<{ success: boolean; processedCount: number; errors: { itemId: string; error: string; }[]; }>>
-  "inbox:bulk-tag": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
-  "inbox:capture-clip": (...args: [unknown]) => Awaited<Promise<{ success: boolean; item: null; error: string; }>>
-  "inbox:capture-image": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
-  "inbox:capture-link": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
-  "inbox:capture-pdf": (...args: [unknown]) => Awaited<Promise<{ success: boolean; item: null; error: string; }>>
-  "inbox:capture-text": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
-  "inbox:capture-voice": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
-  "inbox:convert-to-note": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxFileResponse>>
-  "inbox:convert-to-task": (...args: [any]) => Awaited<Promise<{ success: boolean; taskId: string | null; error?: string | undefined; }>>
-  "inbox:delete-permanent": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:file": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxFileResponse>>
-  "inbox:file-all-stale": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
-  "inbox:get": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxItem | null>>
-  "inbox:get-filing-history": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").FilingHistoryResponse>>
-  "inbox:get-jobs": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxJobsResponse>>
-  "inbox:get-patterns": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").CapturePattern>>
-  "inbox:get-snoozed": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").SnoozedItem[]>>
-  "inbox:get-stale-threshold": (...args: []) => Awaited<Promise<number>>
-  "inbox:get-stats": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxStats>>
-  "inbox:get-suggestions": (...args: [any]) => Awaited<Promise<{ suggestions: import("../../../../../packages/domain-inbox/src/types").InboxFilingSuggestion[]; }>>
-  "inbox:get-tags": (...args: []) => Awaited<Promise<{ tag: string; count: number; }[]>>
-  "inbox:link-to-note": (...args: [any, any, any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:list": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxListResponse>>
-  "inbox:list-archived": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").ArchivedListResponse>>
-  "inbox:mark-viewed": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:preview-link": (...args: [string]) => Awaited<Promise<{ title: string; domain: string; favicon: string | undefined; image: string | undefined; description: string | undefined; } | { title: string; domain: string; favicon?: undefined; image?: undefined; description?: undefined; }>>
-  "inbox:remove-tag": (...args: [any, any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:retry-metadata": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:retry-transcription": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:set-stale-threshold": (...args: [any]) => Awaited<Promise<{ success: boolean; }>>
-  "inbox:snooze": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:track-suggestion": (...args: [string, string, string, string, number, string[], string[]]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error?: string | undefined; }>>
-  "inbox:unarchive": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:undo-archive": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:undo-file": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:unsnooze": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
-  "inbox:update": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").CaptureResponse>>
-  "journal:createEntry": (...args: [{ date: string; content?: string | undefined; tags?: string[] | undefined; properties?: Record<string, unknown> | undefined; }]) => Awaited<Promise<{ id: string; date: string; content: string; wordCount: number; characterCount: number; tags: string[]; createdAt: string; modifiedAt: string; properties?: Record<string, unknown> | undefined; }>>
-  "journal:deleteEntry": (...args: [{ date: string; }]) => Awaited<Promise<{ success: boolean; }>>
-  "journal:getAllTags": (...args: []) => Awaited<Promise<{ tag: string; count: number; }[]>>
-  "journal:getDayContext": (...args: [{ date: string; }]) => Awaited<Promise<{ date: string; tasks: { id: string; title: string; completed: boolean; priority?: "urgent" | "high" | "medium" | "low" | undefined; isOverdue?: boolean | undefined; }[]; events: { id: string; time: string; title: string; type: "meeting" | "focus" | "event"; attendeeCount?: number | undefined; }[]; overdueCount: number; }>>
-  "journal:getEntry": (...args: [{ date: string; }]) => Awaited<Promise<{ id: string; date: string; content: string; wordCount: number; characterCount: number; tags: string[]; createdAt: string; modifiedAt: string; properties?: Record<string, unknown> | undefined; } | null>>
-  "journal:getHeatmap": (...args: [{ year: number; }]) => Awaited<Promise<{ date: string; characterCount: number; level: 0 | 1 | 2 | 4 | 3; }[]>>
-  "journal:getMonthEntries": (...args: [{ year: number; month: number; }]) => Awaited<Promise<{ date: string; preview: string; wordCount: number; characterCount: number; activityLevel: 0 | 1 | 2 | 4 | 3; tags: string[]; }[]>>
-  "journal:getStreak": (...args: []) => Awaited<Promise<{ currentStreak: number; longestStreak: number; lastEntryDate: string | null; }>>
-  "journal:getYearStats": (...args: [{ year: number; }]) => Awaited<Promise<{ year: number; month: number; entryCount: number; totalWordCount: number; totalCharacterCount: number; averageLevel: number; }[]>>
-  "journal:updateEntry": (...args: [{ date: string; content?: string | undefined; tags?: string[] | undefined; properties?: Record<string, unknown> | undefined; }]) => Awaited<Promise<{ id: string; date: string; content: string; wordCount: number; characterCount: number; tags: string[]; createdAt: string; modifiedAt: string; properties?: Record<string, unknown> | undefined; }>>
-  "notes:add-property-option": (...args: [{ propertyName: string; option: { value: string; color: string; }; }]) => Awaited<Promise<{ success: boolean; }>>
-  "notes:add-status-option": (...args: [{ propertyName: string; categoryKey: "todo" | "in_progress" | "done"; option: { value: string; color: string; }; }]) => Awaited<Promise<{ success: boolean; }>>
-  "notes:create": (...args: [{ title: string; content?: string | undefined; folder?: string | undefined; tags?: string[] | undefined; template?: string | undefined; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
-  "notes:create-folder": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "notes:create-property-definition": (...args: [{ name: string; type: "number" | "date" | "text" | "select" | "checkbox" | "url" | "status" | "multiselect"; options?: { value: string; color: string; default?: boolean | undefined; }[] | undefined; defaultValue?: unknown; color?: string | undefined; }]) => Awaited<Promise<{ success: true; definition: import("../../../../../packages/contracts/src/property-types").PropertyDefinition | undefined; } | { success: true; definition: { type: string; name: string; createdAt: string; options: string | null; defaultValue: string | null; color: string | null; }; }> | { success: false; error: string }>
-  "notes:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "notes:delete-attachment": (...args: [{ noteId: string; filename: string; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>
-  "notes:delete-folder": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "notes:delete-property-definition": (...args: [{ name: string; }]) => Awaited<Promise<{ success: boolean; }>>
-  "notes:delete-version": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "notes:ensure-property-definition": (...args: [{ name: string; type: "select" | "status" | "multiselect"; }]) => Awaited<Promise<{ success: boolean; }>>
-  "notes:exists": (...args: [string]) => Awaited<Promise<boolean>>
-  "notes:export-html": (...args: [{ noteId: string; includeMetadata?: boolean | undefined; pageSize?: "A4" | "Letter" | "Legal" | undefined; }]) => Awaited<Promise<{ success: false; error: string; path?: undefined; } | { success: true; path: string; error?: undefined; }> | { success: false; error: string }>
-  "notes:export-pdf": (...args: [{ noteId: string; includeMetadata?: boolean | undefined; pageSize?: "A4" | "Letter" | "Legal" | undefined; }]) => Awaited<Promise<{ success: false; error: string; path?: undefined; } | { success: true; path: string; error?: undefined; }> | { success: false; error: string }>
-  "notes:get": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").Note | null>>
-  "notes:get-all-positions": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; positions: Record<string, number>; }>>
-  "notes:get-by-path": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").Note | null>>
-  "notes:get-file": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").FileMetadata | null>>
-  "notes:get-folder-config": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/templates-api").FolderConfig | null>>
-  "notes:get-folder-template": (...args: [string]) => Awaited<Promise<string | null>>
-  "notes:get-folders": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/templates-api").FolderInfo[]>>
-  "notes:get-links": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").NoteLinksResponse>>
-  "notes:get-local-only-count": (...args: []) => Awaited<Promise<{ count: number; }>>
-  "notes:get-positions": (...args: [{ folderPath: string; }]) => Awaited<{ success: true; positions: { path: string; position: number; folderPath: string; }[]; } | { success: false; error: string }>
-  "notes:get-property-definitions": (...args: []) => Awaited<Promise<{ type: string; name: string; createdAt: string; options: string | null; defaultValue: string | null; color: string | null; }[]>>
-  "notes:get-tags": (...args: []) => Awaited<Promise<{ tag: string; color: string; count: number; }[]>>
-  "notes:get-version": (...args: [string]) => Awaited<Promise<import("../vault/notes-versions").SnapshotDetail | null>>
-  "notes:get-versions": (...args: [string]) => Awaited<Promise<import("../vault/notes-versions").SnapshotListItem[]>>
-  "notes:import-files": (...args: [{ sourcePaths: string[]; targetFolder?: string | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").ImportFilesResult> | { success: false; error: string }>
-  "notes:list": (...args: [{ folder?: string | undefined; tags?: string[] | undefined; sortBy?: "title" | "modified" | "created" | "position" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").NoteListResponse>>
-  "notes:list-attachments": (...args: [string]) => Awaited<Promise<import("../vault/attachments").AttachmentInfo[]>>
-  "notes:move": (...args: [{ id: string; newFolder: string; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
-  "notes:open-external": (...args: [string]) => Awaited<Promise<void>>
-  "notes:preview-by-title": (...args: [string]) => Awaited<Promise<{ id: string; title: string; emoji: string | null; snippet: string | null; tags: { name: string; color: string; }[]; createdAt: string; } | null>>
-  "notes:remove-property-option": (...args: [{ propertyName: string; optionValue: string; }]) => Awaited<Promise<{ success: boolean; }>>
-  "notes:rename": (...args: [{ id: string; newTitle: string; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
-  "notes:rename-folder": (...args: [{ oldPath: string; newPath: string; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>
-  "notes:rename-property-option": (...args: [{ propertyName: string; oldValue: string; newValue: string; }]) => Awaited<Promise<{ success: boolean; }>>
-  "notes:reorder": (...args: [{ folderPath: string; notePaths: string[]; }]) => Awaited<{ success: true; } | { success: false; error: string }>
-  "notes:resolve-by-title": (...args: [string]) => Awaited<Promise<{ id: string; path: string; title: string; fileType: import("../../../../../packages/shared/src/file-types").FileType; } | null>>
-  "notes:restore-version": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; note: import("../vault/notes-crud").Note; }>>
-  "notes:reveal-in-finder": (...args: [string]) => Awaited<Promise<void>>
-  "notes:set-folder-config": (...args: [{ folderPath: string; config: { icon?: string | null | undefined; template?: string | undefined; inherit?: boolean | undefined; }; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>
-  "notes:set-local-only": (...args: [{ id: string; localOnly: boolean; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
-  "notes:show-import-dialog": (...args: []) => Awaited<Promise<{ canceled: boolean; filePaths: string[]; }>>
-  "notes:update": (...args: [{ id: string; title?: string | undefined; content?: string | undefined; tags?: string[] | undefined; frontmatter?: Record<string, unknown> | undefined; emoji?: string | null | undefined; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
-  "notes:update-option-color": (...args: [{ propertyName: string; optionValue: string; newColor: string; }]) => Awaited<Promise<{ success: boolean; }>>
-  "notes:update-property-definition": (...args: [{ name: string; type?: "number" | "date" | "text" | "select" | "checkbox" | "url" | "status" | "multiselect" | undefined; options?: { value: string; color: string; default?: boolean | undefined; }[] | undefined; defaultValue?: unknown; color?: string | undefined; }]) => Awaited<Promise<{ success: false; definition: null; error: string; } | { success: true; definition: import("../../../../../packages/contracts/src/property-types").PropertyDefinition | undefined; error?: undefined; } | { success: true; definition: { type: string; name: string; createdAt: string; options: string | null; defaultValue: string | null; color: string | null; } | undefined; error?: undefined; }> | { success: false; error: string }>
-  "notes:upload-attachment": (...args: [{ noteId: string; filename: string; data: number[] | ArrayBuffer; }]) => Awaited<Promise<import("../vault/attachments").AttachmentResult>>
-  "properties:get": (...args: [{ entityId: string; }]) => Awaited<Promise<import("../database/queries/notes/property-queries").PropertyValue[]>>
-  "properties:rename": (...args: [{ entityId: string; oldName: string; newName: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/properties-api").RenamePropertyResponse>>
-  "properties:set": (...args: [{ entityId: string; properties: Record<string, unknown>; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/properties-api").SetPropertiesResponse>>
-  "quick-capture:get-clipboard": (...args: []) => Awaited<string>
-  "reminder:bulk-dismiss": (...args: [{ reminderIds: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; dismissedCount: number; }>>
-  "reminder:count-pending": (...args: []) => Awaited<Promise<number>>
-  "reminder:create": (...args: [{ targetType: "note"; targetId: string; remindAt: string; title?: string | undefined; note?: string | undefined; } | { targetType: "journal"; targetId: string; remindAt: string; title?: string | undefined; note?: string | undefined; } | { targetType: "highlight"; targetId: string; highlightText: string; highlightStart: number; highlightEnd: number; remindAt: string; title?: string | undefined; note?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; }>>
-  "reminder:delete": (...args: [string]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
-  "reminder:dismiss": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: null; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; error?: undefined; }>>
-  "reminder:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget | null>>
-  "reminder:get-due": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget[]>>
-  "reminder:get-for-target": (...args: [{ targetType: "note" | "journal" | "highlight"; targetId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/reminders-api").Reminder[]>>
-  "reminder:get-upcoming": (...args: [number | undefined]) => Awaited<Promise<{ reminders: import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget[]; total: number; hasMore: boolean; }>>
-  "reminder:list": (...args: [{ targetType?: "note" | "journal" | "highlight" | undefined; targetId?: string | undefined; status?: "pending" | "triggered" | "dismissed" | "snoozed" | ("pending" | "triggered" | "dismissed" | "snoozed")[] | undefined; fromDate?: string | undefined; toDate?: string | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<{ reminders: import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget[]; total: number; hasMore: boolean; }>>
-  "reminder:snooze": (...args: [{ id: string; snoozeUntil: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: null; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; error?: undefined; }>>
-  "reminder:update": (...args: [{ id: string; remindAt?: string | undefined; title?: string | null | undefined; note?: string | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: null; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; error?: undefined; }>>
-  "saved-filters:create": (...args: [{ name: string; config: { filters: { search?: string | undefined; projectIds?: string[] | undefined; priorities?: ("urgent" | "high" | "medium" | "low" | "none")[] | undefined; dueDate?: { type: "custom" | "any" | "none" | "overdue" | "today" | "tomorrow" | "this-week" | "next-week" | "this-month"; customStart?: string | null | undefined; customEnd?: string | null | undefined; } | undefined; statusIds?: string[] | undefined; completion?: "active" | "completed" | "all" | undefined; repeatType?: "all" | "repeating" | "one-time" | undefined; hasTime?: "all" | "with-time" | "without-time" | undefined; }; sort?: { field: "title" | "createdAt" | "priority" | "dueDate" | "completedAt" | "project"; direction: "asc" | "desc"; } | undefined; starred?: boolean | undefined; }; }]) => Awaited<Promise<{ success: boolean; savedFilter: import("../../../../../packages/contracts/src/saved-filters-api").SavedFilter; }>>
-  "saved-filters:delete": (...args: [{ id: string; }]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
-  "saved-filters:list": (...args: []) => Awaited<Promise<{ savedFilters: import("../../../../../packages/contracts/src/saved-filters-api").SavedFilter[]; }>>
-  "saved-filters:reorder": (...args: [{ ids: string[]; positions: number[]; }]) => Awaited<Promise<{ success: boolean; }>>
-  "saved-filters:update": (...args: [{ id: string; name?: string | undefined; config?: { filters: { search?: string | undefined; projectIds?: string[] | undefined; priorities?: ("urgent" | "high" | "medium" | "low" | "none")[] | undefined; dueDate?: { type: "custom" | "any" | "none" | "overdue" | "today" | "tomorrow" | "this-week" | "next-week" | "this-month"; customStart?: string | null | undefined; customEnd?: string | null | undefined; } | undefined; statusIds?: string[] | undefined; completion?: "active" | "completed" | "all" | undefined; repeatType?: "all" | "repeating" | "one-time" | undefined; hasTime?: "all" | "with-time" | "without-time" | undefined; }; sort?: { field: "title" | "createdAt" | "priority" | "dueDate" | "completedAt" | "project"; direction: "asc" | "desc"; } | undefined; starred?: boolean | undefined; } | undefined; position?: number | undefined; }]) => Awaited<Promise<{ success: boolean; savedFilter: null; error: string; } | { success: boolean; savedFilter: import("../../../../../packages/contracts/src/saved-filters-api").SavedFilter | null; error?: undefined; }>>
-  "search:add-reason": (...args: [{ itemId: string; itemType: "note" | "journal" | "task" | "inbox"; itemTitle: string; searchQuery: string; itemIcon?: string | null | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchReason>>
-  "search:clear-reasons": (...args: []) => Awaited<Promise<{ cleared: true; }>>
-  "search:get-all-tags": (...args: []) => Awaited<Promise<string[]>>
-  "search:get-reasons": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchReason[]>>
-  "search:get-stats": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchStats>>
-  "search:query": (...args: [{ text: string; types?: ("note" | "journal" | "task" | "inbox")[] | undefined; tags?: string[] | undefined; dateRange?: { from: string; to: string; } | null | undefined; projectId?: string | null | undefined; folderPath?: string | null | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchResponse>>
-  "search:quick": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").QuickSearchResponse>>
-  "search:rebuild-index": (...args: []) => Awaited<Promise<{ notes: number; tasks: number; inbox: number; durationMs: number; started: true; error?: undefined; } | { started: false; error: string; }>>
-  "settings:downloadVoiceModel": (...args: []) => Awaited<Promise<{ success: boolean; error?: undefined; } | { success: boolean; error: string; }>>
-  "settings:get": (...args: [string]) => Awaited<string | null>
-  "settings:getAIModelStatus": (...args: []) => Awaited<Promise<import("./settings-handlers").AIModelStatus>>
-  "settings:getAISettings": (...args: []) => Awaited<import("./settings-handlers").AISettings>
-  "settings:getBackupSettings": (...args: []) => Awaited<{ autoBackup: boolean; frequencyHours: 1 | 6 | 12 | 24; maxBackups: number; lastBackupAt: string | null; }>
-  "settings:getEditorSettings": (...args: []) => Awaited<{ width: "medium" | "narrow" | "wide"; spellCheck: boolean; autoSaveDelay: number; showWordCount: boolean; toolbarMode: "floating" | "sticky"; }>
-  "settings:getGeneralSettings": (...args: []) => Awaited<{ theme: "light" | "dark" | "white" | "system"; fontSize: "small" | "medium" | "large"; fontFamily: "system" | "serif" | "sans-serif" | "monospace" | "gelasio" | "geist" | "inter"; accentColor: string; startOnBoot: boolean; language: string; onboardingCompleted: boolean; createInSelectedFolder: boolean; clockFormat: "12h" | "24h"; }>
-  "settings:getGraphSettings": (...args: []) => Awaited<{ layout: "forceatlas2" | "circular" | "random"; showLabels: boolean; showEdgeLabels: boolean; animateLayout: boolean; showTagEdges: boolean; }>
-  "settings:getJournalSettings": (...args: []) => Awaited<{ defaultTemplate: string | null; showSchedule: boolean; showTasks: boolean; showAIConnections: boolean; showStatsFooter: boolean; }>
-  "settings:getKeyboardSettings": (...args: []) => Awaited<{ overrides: Record<string, { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; }>; globalCapture: { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; } | null; }>
-  "settings:getNoteEditorSettings": (...args: []) => Awaited<import("./settings-handlers").NoteEditorSettings>
-  "settings:getSyncSettings": (...args: []) => Awaited<{ enabled: boolean; autoSync: boolean; }>
-  "settings:getTabSettings": (...args: []) => Awaited<import("./settings-handlers").TabSettings>
-  "settings:getTaskSettings": (...args: []) => Awaited<{ defaultProjectId: string | null; defaultSortOrder: "createdAt" | "priority" | "dueDate" | "manual"; weekStartDay: "sunday" | "monday"; staleInboxDays: number; }>
-  "settings:getVoiceModelStatus": (...args: []) => Awaited<import("../inbox/voice-model").VoiceModelStatus>
-  "settings:getVoiceRecordingReadiness": (...args: []) => Awaited<Promise<import("../inbox/voice-transcription-settings").VoiceRecordingReadiness>>
-  "settings:getVoiceTranscriptionOpenAIKeyStatus": (...args: []) => Awaited<Promise<import("./settings-handlers").VoiceTranscriptionOpenAIKeyStatus>>
-  "settings:getVoiceTranscriptionSettings": (...args: []) => Awaited<{ provider: "local" | "openai"; }>
-  "settings:loadAIModel": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; message: string; error?: undefined; } | { success: boolean; error: string; message?: undefined; } | { success: boolean; message?: undefined; error?: undefined; }>>
-  "settings:registerGlobalCapture": (...args: []) => Awaited<Promise<import("./settings-handlers").GlobalCaptureResult>>
-  "settings:reindexEmbeddings": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; computed: number; skipped: number; error?: string | undefined; }>>
-  "settings:resetKeyboardSettings": (...args: []) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
-  "settings:set": (...args: [{ key: string; value: string; }]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
-  "settings:setAISettings": (...args: [Partial<import("./settings-handlers").AISettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
-  "settings:setBackupSettings": (...args: [Partial<{ autoBackup: boolean; frequencyHours: 1 | 6 | 12 | 24; maxBackups: number; lastBackupAt: string | null; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
-  "settings:setEditorSettings": (...args: [Partial<{ width: "medium" | "narrow" | "wide"; spellCheck: boolean; autoSaveDelay: number; showWordCount: boolean; toolbarMode: "floating" | "sticky"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
-  "settings:setGeneralSettings": (...args: [Partial<{ theme: "light" | "dark" | "white" | "system"; fontSize: "small" | "medium" | "large"; fontFamily: "system" | "serif" | "sans-serif" | "monospace" | "gelasio" | "geist" | "inter"; accentColor: string; startOnBoot: boolean; language: string; onboardingCompleted: boolean; createInSelectedFolder: boolean; clockFormat: "12h" | "24h"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
-  "settings:setGraphSettings": (...args: [Partial<{ layout: "forceatlas2" | "circular" | "random"; showLabels: boolean; showEdgeLabels: boolean; animateLayout: boolean; showTagEdges: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
-  "settings:setJournalSettings": (...args: [Partial<import("./settings-handlers").JournalSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
-  "settings:setKeyboardSettings": (...args: [Partial<{ overrides: Record<string, { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; }>; globalCapture: { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; } | null; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
-  "settings:setNoteEditorSettings": (...args: [Partial<import("./settings-handlers").NoteEditorSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
-  "settings:setSyncSettings": (...args: [Partial<{ enabled: boolean; autoSync: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
-  "settings:setTabSettings": (...args: [Partial<import("./settings-handlers").TabSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
-  "settings:setTaskSettings": (...args: [Partial<{ defaultProjectId: string | null; defaultSortOrder: "createdAt" | "priority" | "dueDate" | "manual"; weekStartDay: "sunday" | "monday"; staleInboxDays: number; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
-  "settings:setVoiceTranscriptionOpenAIKey": (...args: [{ apiKey: string; }]) => Awaited<Promise<{ success: boolean; error?: undefined; } | { success: boolean; error: string; }>>
-  "settings:setVoiceTranscriptionSettings": (...args: [Partial<{ provider: "local" | "openai"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
-  "sync:approve-linking": (...args: [{ sessionId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").ApproveLinkingResult> | { success: false; error: string }>
-  "sync:check-device-status": (...args: []) => Awaited<Promise<{ status: string; }>>
-  "sync:complete-linking-qr": (...args: [{ sessionId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").CompleteLinkingQrResult> | { success: false; error: string }>
-  "sync:confirm-recovery-phrase": (...args: [{ confirmed: boolean; }]) => Awaited<Promise<{ success: boolean; }> | { success: false; error: string }>
-  "sync:download-attachment": (...args: [{ attachmentId: string; targetPath?: string | undefined; }]) => Awaited<Promise<{ success: boolean; error: string; filePath?: undefined; } | { success: boolean; filePath: string; error?: undefined; }> | { success: false; error: string }>
-  "sync:emergency-wipe": (...args: []) => Awaited<Promise<{ success: boolean; }>>
-  "sync:generate-linking-qr": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").GenerateLinkingQrResult>>
-  "sync:get-devices": (...args: []) => Awaited<Promise<{ devices: { id: string; name: string; platform: "macos" | "windows" | "linux" | "ios" | "android"; linkedAt: number; lastSyncAt: number | undefined; isCurrentDevice: boolean; }[]; email: string | undefined; }>>
-  "sync:get-download-progress": (...args: [{ attachmentId: string; }]) => Awaited<{ progress: number; downloadedChunks: number; totalChunks: number; status: "downloading"; } | null | { success: false; error: string }>
-  "sync:get-history": (...args: [{ limit?: number | undefined; offset?: number | undefined; }]) => Awaited<{ entries: { id: string; type: "error" | "push" | "pull"; itemCount: number; direction: string | undefined; details: unknown; durationMs: number | undefined; createdAt: number; }[]; total: number; } | { success: false; error: string }>
-  "sync:get-linking-sas": (...args: [{ sessionId: string; }]) => Awaited<Promise<{ verificationCode?: string | undefined; error?: string | undefined; }> | { success: false; error: string }>
-  "sync:get-quarantined-items": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-events").QuarantinedItemInfo[]>
-  "sync:get-queue-size": (...args: []) => Awaited<{ pending: number; failed: number; }>
-  "sync:get-recovery-phrase": (...args: []) => Awaited<string | null>
-  "sync:get-status": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-sync-ops").GetSyncStatusResult | { status: string; pendingCount: number; }>
-  "sync:get-storage-breakdown": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-sync-ops").StorageBreakdownResult | null>>
-  "sync:get-synced-settings": (...args: []) => Awaited<{ general?: { theme?: "light" | "dark" | "white" | "system" | undefined; fontSize?: "small" | "medium" | "large" | undefined; fontFamily?: "system" | "serif" | "sans-serif" | "monospace" | "gelasio" | "geist" | "inter" | undefined; accentColor?: string | undefined; startOnBoot?: boolean | undefined; language?: string | undefined; createInSelectedFolder?: boolean | undefined; } | undefined; editor?: { width?: "medium" | "narrow" | "wide" | undefined; spellCheck?: boolean | undefined; autoSaveDelay?: number | undefined; showWordCount?: boolean | undefined; toolbarMode?: "floating" | "sticky" | undefined; } | undefined; tasks?: { defaultProjectId?: string | null | undefined; defaultSortOrder?: "createdAt" | "priority" | "dueDate" | "manual" | undefined; weekStartDay?: "sunday" | "monday" | undefined; staleInboxDays?: number | undefined; showCompleted?: boolean | undefined; sortBy?: string | undefined; } | undefined; keyboard?: { overrides?: Record<string, unknown> | undefined; } | undefined; notes?: { defaultFolder?: string | undefined; editorFontSize?: number | undefined; spellCheck?: boolean | undefined; } | undefined; sync?: { autoSync?: boolean | undefined; syncIntervalMinutes?: number | undefined; } | undefined; } | null>
-  "sync:get-upload-progress": (...args: [{ sessionId: string; }]) => Awaited<{ progress: number; uploadedChunks: number; totalChunks: number; status: "uploading"; } | null | { success: false; error: string }>
-  "sync:link-via-qr": (...args: [{ qrData: string; oauthToken?: string | undefined; provider?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").LinkViaQrResult> | { success: false; error: string }>
-  "sync:link-via-recovery": (...args: [{ recoveryPhrase: string; }]) => Awaited<Promise<{ success: boolean; error: string; deviceId?: undefined; } | { success: boolean; deviceId: string; error?: undefined; }> | { success: false; error: string }>
-  "sync:logout": (...args: []) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean; }>>
-  "sync:pause": (...args: []) => Awaited<{ success: boolean; wasPaused: boolean; }>
-  "sync:remove-device": (...args: [{ deviceId: string; }]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }> | { success: false; error: string }>
-  "sync:rename-device": (...args: [{ deviceId: string; newName: string; }]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }> | { success: false; error: string }>
-  "sync:resume": (...args: []) => Awaited<{ success: boolean; pendingCount: number; }>
-  "sync:setup-first-device": (...args: [{ oauthToken: string; provider: "google"; state: string; }]) => Awaited<Promise<{ success: boolean; needsRecoverySetup: boolean; deviceId: string; needsRecoveryInput?: undefined; } | { success: boolean; needsRecoverySetup: boolean; needsRecoveryInput: boolean; deviceId?: undefined; }> | { success: false; error: string }>
-  "sync:setup-new-account": (...args: []) => Awaited<Promise<{ success: boolean; error: string; deviceId?: undefined; } | { success: boolean; deviceId: string; error?: undefined; }>>
-  "sync:trigger-sync": (...args: []) => Awaited<Promise<{ success: boolean; } | { success: boolean; error: string; }>>
-  "sync:update-synced-setting": (...args: [{ fieldPath: string; value: unknown; }]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; } | { success: false; error: string }>
-  "sync:upload-attachment": (...args: [{ noteId: string; filePath: string; }]) => Awaited<Promise<{ success: boolean; error: string; attachmentId?: undefined; sessionId?: undefined; } | { success: boolean; attachmentId: string; sessionId: string; error?: undefined; }> | { success: false; error: string }>
-  "tags:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").DeleteTagResponse>>
-  "tags:get-all-with-counts": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/tags-api").GetAllWithCountsResponse>>
-  "tags:get-notes-by-tag": (...args: [{ tag: string; sortBy?: "title" | "modified" | "created" | undefined; sortOrder?: "asc" | "desc" | undefined; includeDescendants?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/tags-api").GetNotesByTagResponse>>
-  "tags:merge": (...args: [{ source: string; target: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").MergeTagResponse>>
-  "tags:pin-note-to-tag": (...args: [{ noteId: string; tag: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
-  "tags:remove-from-note": (...args: [{ noteId: string; tag: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
-  "tags:rename": (...args: [{ oldName: string; newName: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").RenameTagResponse>>
-  "tags:unpin-note-from-tag": (...args: [{ noteId: string; tag: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
-  "tags:update-color": (...args: [{ tag: string; color: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
-  "tasks:archive": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
-  "tasks:bulk-archive": (...args: [{ ids: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
-  "tasks:bulk-complete": (...args: [{ ids: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
-  "tasks:bulk-delete": (...args: [{ ids: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
-  "tasks:bulk-move": (...args: [{ ids: string[]; projectId: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
-  "tasks:complete": (...args: [{ id: string; completedAt?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
-  "tasks:convert-to-subtask": (...args: [{ taskId: string; parentId: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
-  "tasks:convert-to-task": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
-  "tasks:create": (...args: [{ projectId: string; title: string; description?: string | null | undefined; priority?: number | undefined; statusId?: string | null | undefined; parentId?: string | null | undefined; dueDate?: string | null | undefined; dueTime?: string | null | undefined; startDate?: string | null | undefined; isRepeating?: boolean | undefined; repeatConfig?: { frequency: "daily" | "weekly" | "monthly" | "yearly"; endType: "date" | "never" | "count"; createdAt: string; interval?: number | undefined; daysOfWeek?: number[] | undefined; monthlyType?: "dayOfMonth" | "weekPattern" | undefined; dayOfMonth?: number | undefined; weekOfMonth?: number | undefined; dayOfWeekForMonth?: number | undefined; endDate?: string | null | undefined; endCount?: number | undefined; completedCount?: number | undefined; } | null | undefined; repeatFrom?: "due" | "completion" | null | undefined; tags?: string[] | undefined; linkedNoteIds?: string[] | undefined; sourceNoteId?: string | null | undefined; position?: number | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; }>>
-  "tasks:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "tasks:duplicate": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
-  "tasks:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Task | null>>
-  "tasks:get-linked-tasks": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Task[]>>
-  "tasks:get-overdue": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListEnvelope>>
-  "tasks:get-stats": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").TaskStats>>
-  "tasks:get-subtasks": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Task[]>>
-  "tasks:get-tags": (...args: []) => Awaited<Promise<{ tag: string; count: number; }[]>>
-  "tasks:get-today": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListEnvelope>>
-  "tasks:get-upcoming": (...args: [{ days?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListEnvelope>>
-  "tasks:list": (...args: [{ projectId?: string | undefined; statusId?: string | null | undefined; parentId?: string | null | undefined; includeCompleted?: boolean | undefined; includeArchived?: boolean | undefined; dueBefore?: string | undefined; dueAfter?: string | undefined; tags?: string[] | undefined; search?: string | undefined; sortBy?: "modified" | "created" | "position" | "priority" | "dueDate" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListResult>>
-  "tasks:move": (...args: [{ taskId: string; position: number; targetProjectId?: string | undefined; targetStatusId?: string | null | undefined; targetParentId?: string | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
-  "tasks:project-archive": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
-  "tasks:project-create": (...args: [{ name: string; description?: string | null | undefined; color?: string | undefined; icon?: string | null | undefined; statuses?: { name: string; type: "todo" | "in_progress" | "done"; order: number; color?: string | undefined; }[] | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; project: import("../../../../../packages/domain-tasks/src/types").ProjectWithStatuses; }>>
-  "tasks:project-delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "tasks:project-get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").ProjectWithStatuses | undefined>>
-  "tasks:project-list": (...args: []) => Awaited<Promise<{ projects: import("../../../../../packages/domain-tasks/src/types").ProjectWithStats[]; }>>
-  "tasks:project-reorder": (...args: [{ projectIds: string[]; positions: number[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "tasks:project-update": (...args: [{ id: string; name?: string | undefined; description?: string | null | undefined; color?: string | undefined; icon?: string | null | undefined; statuses?: { name: string; type: "todo" | "in_progress" | "done"; order: number; id?: string | undefined; color?: string | undefined; }[] | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; project: null; error: string; } | { success: boolean; project: import("../../../../../packages/domain-tasks/src/types").ProjectWithStatuses; error?: undefined; }>>
-  "tasks:reorder": (...args: [{ taskIds: string[]; positions: number[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "tasks:seed-demo": (...args: []) => Awaited<Promise<{ success: boolean; message: string; }>>
-  "tasks:seed-performance-test": (...args: []) => Awaited<Promise<{ success: boolean; message: string; }>>
-  "tasks:status-create": (...args: [{ projectId: string; name: string; color?: string | undefined; isDone?: boolean | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; status: import("../../../../../packages/domain-tasks/src/types").Status; }>>
-  "tasks:status-delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "tasks:status-list": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Status[]>>
-  "tasks:status-reorder": (...args: [{ statusIds: string[]; positions: number[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "tasks:status-update": (...args: [{ id: string; name?: string | undefined; color?: string | undefined; position?: number | undefined; isDefault?: boolean | undefined; isDone?: boolean | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; status?: undefined; } | { success: boolean; status: import("../../../../../packages/domain-tasks/src/types").Status; error?: undefined; }>>
-  "tasks:unarchive": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
-  "tasks:uncomplete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
-  "tasks:update": (...args: [{ id: string; title?: string | undefined; description?: string | null | undefined; priority?: number | undefined; projectId?: string | undefined; statusId?: string | null | undefined; parentId?: string | null | undefined; dueDate?: string | null | undefined; dueTime?: string | null | undefined; startDate?: string | null | undefined; isRepeating?: boolean | undefined; repeatConfig?: { frequency: "daily" | "weekly" | "monthly" | "yearly"; endType: "date" | "never" | "count"; createdAt: string; interval?: number | undefined; daysOfWeek?: number[] | undefined; monthlyType?: "dayOfMonth" | "weekPattern" | undefined; dayOfMonth?: number | undefined; weekOfMonth?: number | undefined; dayOfWeekForMonth?: number | undefined; endDate?: string | null | undefined; endCount?: number | undefined; completedCount?: number | undefined; } | null | undefined; repeatFrom?: "due" | "completion" | null | undefined; tags?: string[] | undefined; linkedNoteIds?: string[] | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
-  "templates:create": (...args: [{ name: string; description?: string | undefined; icon?: string | null | undefined; tags?: string[] | undefined; properties?: { name: string; type: "number" | "date" | "text" | "select" | "checkbox" | "url" | "multiselect" | "rating"; value: unknown; options?: string[] | undefined; }[] | undefined; content?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; template: import("../../../../../packages/contracts/src/templates-api").Template; }>>
-  "templates:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
-  "templates:duplicate": (...args: [{ id: string; newName: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; template: import("../../../../../packages/contracts/src/templates-api").Template; }>>
-  "templates:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/templates-api").Template | null>>
-  "templates:list": (...args: []) => Awaited<Promise<{ templates: import("../../../../../packages/contracts/src/templates-api").TemplateListItem[]; }>>
-  "templates:update": (...args: [{ id: string; name?: string | undefined; description?: string | undefined; icon?: string | null | undefined; tags?: string[] | undefined; properties?: { name: string; type: "number" | "date" | "text" | "select" | "checkbox" | "url" | "multiselect" | "rating"; value: unknown; options?: string[] | undefined; }[] | undefined; content?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; template: import("../../../../../packages/contracts/src/templates-api").Template; }>>
-  "vault:close": (...args: []) => Awaited<Promise<void>>
-  "vault:get-all": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").GetVaultsResponse>>
-  "vault:get-config": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultConfig>>
-  "vault:get-status": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultStatus>>
-  "vault:reindex": (...args: []) => Awaited<Promise<void>>
-  "vault:remove": (...args: [string]) => Awaited<Promise<void>>
-  "vault:reveal": (...args: []) => Awaited<Promise<void>>
-  "vault:select": (...args: [{ path?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").SelectVaultResponse>>
-  "vault:switch": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").SelectVaultResponse>>
-  "vault:update-config": (...args: [{ excludePatterns?: string[] | undefined; defaultNoteFolder?: string | undefined; journalFolder?: string | undefined; attachmentsFolder?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultConfig>>
+  'account:getInfo': (...args: []) => Awaited<import('./account-handlers').AccountInfo>
+  'account:getRecoveryKey': (
+    ...args: []
+  ) => Awaited<
+    Promise<
+      | { success: boolean; error: string; key?: undefined }
+      | { success: boolean; key: string; error?: undefined }
+    >
+  >
+  'account:signOut': (
+    ...args: []
+  ) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean }>>
+  'ai-inline:get-server-port': (...args: []) => Awaited<number | null>
+  'ai-inline:get-settings': (
+    ...args: []
+  ) => Awaited<import('../../../../../packages/contracts/src/ai-inline-channels').AIInlineSettings>
+  'ai-inline:set-settings': (
+    ...args: [
+      Partial<import('../../../../../packages/contracts/src/ai-inline-channels').AIInlineSettings>
+    ]
+  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  'ai-inline:start-server': (
+    ...args: []
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; error: string; port?: undefined }
+      | { success: boolean; port: number; error?: undefined }
+    >
+  >
+  'ai-inline:stop-server': (...args: []) => Awaited<Promise<{ success: boolean }>>
+  'auth:init-oauth': (
+    ...args: [{ provider: 'google' }]
+  ) => Awaited<Promise<{ state: string }> | { success: false; error: string }>
+  'auth:refresh-token': (
+    ...args: []
+  ) => Awaited<Promise<{ success: boolean; error: string | undefined }>>
+  'auth:request-otp': (
+    ...args: [{ email: string }]
+  ) => Awaited<Promise<unknown> | { success: false; error: string }>
+  'auth:resend-otp': (
+    ...args: [{ email: string }]
+  ) => Awaited<Promise<unknown> | { success: false; error: string }>
+  'auth:verify-otp': (...args: [{ email: string; code: string }]) => Awaited<
+    | Promise<{
+        success: boolean
+        isNewUser: boolean
+        needsSetup: boolean
+        needsRecoveryInput: boolean
+      }>
+    | { success: false; error: string }
+  >
+  'bookmarks:bulk-create': (
+    ...args: [{ items: { itemType: string; itemId: string }[] }]
+  ) => Awaited<Promise<{ success: boolean; createdCount: number }>>
+  'bookmarks:bulk-delete': (
+    ...args: [{ bookmarkIds: string[] }]
+  ) => Awaited<Promise<{ success: boolean; deletedCount: number }>>
+  'bookmarks:create': (...args: [{ itemType: string; itemId: string }]) => Awaited<
+    Promise<
+      | { success: boolean; bookmark: null; error: string }
+      | {
+          success: boolean
+          bookmark: {
+            id: string
+            createdAt: string
+            position: number
+            itemType: string
+            itemId: string
+          }
+          error?: undefined
+        }
+    >
+  >
+  'bookmarks:delete': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  >
+  'bookmarks:get': (...args: [string]) => Awaited<
+    Promise<{
+      id: string
+      createdAt: string
+      position: number
+      itemType: string
+      itemId: string
+    } | null>
+  >
+  'bookmarks:get-by-item': (...args: [{ itemType: string; itemId: string }]) => Awaited<
+    Promise<{
+      id: string
+      createdAt: string
+      position: number
+      itemType: string
+      itemId: string
+    } | null>
+  >
+  'bookmarks:is-bookmarked': (
+    ...args: [{ itemType: string; itemId: string }]
+  ) => Awaited<Promise<boolean>>
+  'bookmarks:list': (
+    ...args: [
+      {
+        itemType?: string | undefined
+        sortBy?: 'createdAt' | 'position' | undefined
+        sortOrder?: 'asc' | 'desc' | undefined
+        limit?: number | undefined
+        offset?: number | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/bookmarks-api').BookmarkListResponse>
+  >
+  'bookmarks:list-by-type': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/bookmarks-api').BookmarkListResponse>
+  >
+  'bookmarks:reorder': (
+    ...args: [{ bookmarkIds: string[] }]
+  ) => Awaited<Promise<{ success: boolean }>>
+  'bookmarks:toggle': (...args: [{ itemType: string; itemId: string }]) => Awaited<
+    Promise<{
+      success: boolean
+      isBookmarked: boolean
+      bookmark: {
+        id: string
+        createdAt: string
+        position: number
+        itemType: string
+        itemId: string
+      } | null
+    }>
+  >
+  'calendar:connect-provider': (
+    ...args: [{ provider: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/calendar-api').CalendarProviderMutationResponse
+    >
+  >
+  'calendar:create-event': (
+    ...args: [
+      {
+        title: string
+        startAt: string
+        description?: string | null | undefined
+        location?: string | null | undefined
+        endAt?: string | null | undefined
+        timezone?: string | undefined
+        isAllDay?: boolean | undefined
+        recurrenceRule?: Record<string, unknown> | null | undefined
+        recurrenceExceptions?: Record<string, unknown>[] | null | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/calendar-api').CalendarEventMutationResponse
+    >
+  >
+  'calendar:delete-event': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/calendar-api').CalendarDeleteResponse
+    >
+  >
+  'calendar:disconnect-provider': (
+    ...args: [{ provider: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/calendar-api').CalendarProviderMutationResponse
+    >
+  >
+  'calendar:get-event': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarEventRecord | null>
+  >
+  'calendar:get-provider-status': (
+    ...args: [{ provider: string }]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarProviderStatus>
+  >
+  'calendar:get-range': (
+    ...args: [{ startAt: string; endAt: string; includeUnselectedSources?: boolean | undefined }]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarRangeResponse>
+  >
+  'calendar:list-events': (
+    ...args: [{ includeArchived?: boolean | undefined }]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarEventListResponse>
+  >
+  'calendar:list-sources': (
+    ...args: [
+      {
+        provider?: string | undefined
+        kind?: 'account' | 'calendar' | undefined
+        selectedOnly?: boolean | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarSourceListResponse>
+  >
+  'calendar:refresh-provider': (
+    ...args: [{ provider: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/calendar-api').CalendarProviderMutationResponse
+    >
+  >
+  'calendar:update-event': (
+    ...args: [
+      {
+        id: string
+        title?: string | undefined
+        description?: string | null | undefined
+        location?: string | null | undefined
+        startAt?: string | undefined
+        endAt?: string | null | undefined
+        timezone?: string | undefined
+        isAllDay?: boolean | undefined
+        recurrenceRule?: Record<string, unknown> | null | undefined
+        recurrenceExceptions?: Record<string, unknown>[] | null | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/calendar-api').CalendarEventMutationResponse
+    >
+  >
+  'calendar:update-source-selection': (
+    ...args: [{ id: string; isSelected: boolean }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/calendar-api').CalendarSourceMutationResponse
+    >
+  >
+  'context-menu:show': (
+    ...args: [
+      {
+        id: string
+        label: string
+        accelerator?: string | undefined
+        disabled?: boolean | undefined
+        type?: 'normal' | 'separator' | undefined
+      }[]
+    ]
+  ) => Awaited<Promise<string | null>>
+  'crdt:apply-update': (...args: [unknown]) => Awaited<Promise<void>>
+  'crdt:close-doc': (...args: [unknown]) => Awaited<Promise<{ success: boolean }>>
+  'crdt:open-doc': (
+    ...args: [unknown]
+  ) => Awaited<
+    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  >
+  'crdt:sync-step-1': (
+    ...args: [{ noteId: string; stateVector: number[] }]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/ipc-crdt').CrdtSyncStep1Result | null>
+  >
+  'crdt:sync-step-2': (...args: [{ noteId: string; diff: number[] }]) => Awaited<Promise<void>>
+  'crypto:decrypt-item': (
+    ...args: [
+      {
+        itemId: string
+        type:
+          | 'note'
+          | 'filter'
+          | 'project'
+          | 'journal'
+          | 'task'
+          | 'settings'
+          | 'inbox'
+          | 'tag_definition'
+          | 'folder_config'
+          | 'calendar_event'
+          | 'calendar_source'
+          | 'calendar_binding'
+          | 'calendar_external_event'
+        encryptedKey: string
+        keyNonce: string
+        encryptedData: string
+        dataNonce: string
+        signature: string
+        operation?: 'create' | 'update' | 'delete' | undefined
+        deletedAt?: number | undefined
+        metadata?: Record<string, unknown> | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/ipc-crypto').DecryptItemResult>
+  >
+  'crypto:encrypt-item': (
+    ...args: [
+      {
+        itemId: string
+        type:
+          | 'note'
+          | 'filter'
+          | 'project'
+          | 'journal'
+          | 'task'
+          | 'settings'
+          | 'inbox'
+          | 'tag_definition'
+          | 'folder_config'
+          | 'calendar_event'
+          | 'calendar_source'
+          | 'calendar_binding'
+          | 'calendar_external_event'
+        content: Record<string, unknown>
+        operation?: 'create' | 'update' | 'delete' | undefined
+        deletedAt?: number | undefined
+        metadata?: Record<string, unknown> | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/ipc-crypto').EncryptItemResult>
+  >
+  'crypto:get-rotation-progress': (
+    ...args: []
+  ) => Awaited<import('../../../../../packages/contracts/src/ipc-crypto').GetRotationProgressResult>
+  'crypto:rotate-keys': (
+    ...args: [{ confirm: boolean }]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/ipc-crypto').RotateKeysResult>>
+  'crypto:verify-signature': (
+    ...args: [
+      {
+        itemId: string
+        type:
+          | 'note'
+          | 'filter'
+          | 'project'
+          | 'journal'
+          | 'task'
+          | 'settings'
+          | 'inbox'
+          | 'tag_definition'
+          | 'folder_config'
+          | 'calendar_event'
+          | 'calendar_source'
+          | 'calendar_binding'
+          | 'calendar_external_event'
+        encryptedKey: string
+        keyNonce: string
+        encryptedData: string
+        dataNonce: string
+        signature: string
+        operation?: 'create' | 'update' | 'delete' | undefined
+        deletedAt?: number | undefined
+        metadata?: Record<string, unknown> | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/ipc-crypto').VerifySignatureResult>
+  >
+  'folder-view:delete-view': (
+    ...args: [{ folderPath: string; viewName: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/folder-view-api').DeleteViewResponse
+    >
+  >
+  'folder-view:folder-exists': (...args: [string]) => Awaited<boolean>
+  'folder-view:get-available-properties': (
+    ...args: [{ folderPath: string }]
+  ) => Awaited<
+    Promise<
+      import('../../../../../packages/contracts/src/folder-view-api').GetAvailablePropertiesResponse
+    >
+  >
+  'folder-view:get-config': (
+    ...args: [{ folderPath: string }]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/folder-view-api').GetConfigResponse>
+  >
+  'folder-view:get-folder-suggestions': (
+    ...args: [{ noteId: string }]
+  ) => Awaited<
+    Promise<
+      import('../../../../../packages/contracts/src/folder-view-api').GetFolderSuggestionsResponse
+    >
+  >
+  'folder-view:get-views': (
+    ...args: [{ folderPath: string }]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/folder-view-api').GetViewsResponse>
+  >
+  'folder-view:list-with-properties': (
+    ...args: [
+      {
+        folderPath: string
+        properties?: string[] | undefined
+        limit?: number | undefined
+        offset?: number | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      import('../../../../../packages/contracts/src/folder-view-api').ListWithPropertiesResponse
+    >
+  >
+  'folder-view:set-config': (
+    ...args: [
+      {
+        folderPath: string
+        config: {
+          path?: string | undefined
+          template?: string | undefined
+          inherit?: boolean | undefined
+          formulas?: Record<string, string> | undefined
+          properties?:
+            | Record<
+                string,
+                {
+                  displayName?: string | undefined
+                  color?: boolean | undefined
+                  dateFormat?: string | undefined
+                  numberFormat?: string | undefined
+                  hidden?: boolean | undefined
+                }
+              >
+            | undefined
+          summaries?:
+            | Record<
+                string,
+                {
+                  type:
+                    | 'custom'
+                    | 'count'
+                    | 'sum'
+                    | 'average'
+                    | 'min'
+                    | 'max'
+                    | 'countBy'
+                    | 'countUnique'
+                  label?: string | undefined
+                  expression?: string | undefined
+                }
+              >
+            | undefined
+          views?:
+            | {
+                name: string
+                type?: 'table' | 'grid' | 'list' | 'kanban' | undefined
+                default?: boolean | undefined
+                columns?:
+                  | {
+                      id: string
+                      width?: number | undefined
+                      displayName?: string | undefined
+                      showSummary?: boolean | undefined
+                    }[]
+                  | undefined
+                filters?: unknown
+                order?: { property: string; direction: 'asc' | 'desc' }[] | undefined
+                groupBy?:
+                  | {
+                      property: string
+                      direction?: 'asc' | 'desc' | undefined
+                      collapsed?: boolean | undefined
+                      showSummary?: boolean | undefined
+                    }
+                  | undefined
+                limit?: number | undefined
+                showSummaries?: boolean | undefined
+              }[]
+            | undefined
+        }
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/folder-view-api').SetConfigResponse
+    >
+  >
+  'folder-view:set-view': (
+    ...args: [
+      {
+        folderPath: string
+        view: {
+          name: string
+          type?: 'table' | 'grid' | 'list' | 'kanban' | undefined
+          default?: boolean | undefined
+          columns?:
+            | {
+                id: string
+                width?: number | undefined
+                displayName?: string | undefined
+                showSummary?: boolean | undefined
+              }[]
+            | undefined
+          filters?: unknown
+          order?: { property: string; direction: 'asc' | 'desc' }[] | undefined
+          groupBy?:
+            | {
+                property: string
+                direction?: 'asc' | 'desc' | undefined
+                collapsed?: boolean | undefined
+                showSummary?: boolean | undefined
+              }
+            | undefined
+          limit?: number | undefined
+          showSummaries?: boolean | undefined
+        }
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/folder-view-api').SetViewResponse
+    >
+  >
+  'graph:get-graph-data': (...args: []) => Awaited<{
+    nodes: {
+      id: string
+      type: 'note' | 'project' | 'journal' | 'task'
+      label: string
+      tags: string[]
+      wordCount: number
+      connectionCount: number
+      emoji: string | null
+      color: string
+      isOrphan: boolean
+      isUnresolved: boolean
+    }[]
+    edges: {
+      id: string
+      source: string
+      target: string
+      type: 'wikilink' | 'task-note' | 'project-task' | 'tag-cooccurrence'
+      weight: number
+    }[]
+  }>
+  'graph:get-local-graph': (...args: [{ noteId: string; depth?: number | undefined }]) => Awaited<{
+    nodes: {
+      id: string
+      type: 'note' | 'project' | 'journal' | 'task'
+      label: string
+      tags: string[]
+      wordCount: number
+      connectionCount: number
+      emoji: string | null
+      color: string
+      isOrphan: boolean
+      isUnresolved: boolean
+    }[]
+    edges: {
+      id: string
+      source: string
+      target: string
+      type: 'wikilink' | 'task-note' | 'project-task' | 'tag-cooccurrence'
+      weight: number
+    }[]
+  }>
+  'inbox:add-tag': (
+    ...args: [any, any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:archive': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:bulk-archive': (
+    ...args: [any]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
+  'inbox:bulk-file': (
+    ...args: [any]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
+  'inbox:bulk-snooze': (...args: [any]) => Awaited<
+    Promise<{
+      success: boolean
+      processedCount: number
+      errors: { itemId: string; error: string }[]
+    }>
+  >
+  'inbox:bulk-tag': (
+    ...args: [any]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
+  'inbox:capture-clip': (
+    ...args: [unknown]
+  ) => Awaited<Promise<{ success: boolean; item: null; error: string }>>
+  'inbox:capture-image': (
+    ...args: [any]
+  ) => Awaited<
+    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
+  >
+  'inbox:capture-link': (
+    ...args: [any]
+  ) => Awaited<
+    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
+  >
+  'inbox:capture-pdf': (
+    ...args: [unknown]
+  ) => Awaited<Promise<{ success: boolean; item: null; error: string }>>
+  'inbox:capture-text': (
+    ...args: [any]
+  ) => Awaited<
+    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
+  >
+  'inbox:capture-voice': (
+    ...args: [any]
+  ) => Awaited<
+    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
+  >
+  'inbox:convert-to-note': (
+    ...args: [any]
+  ) => Awaited<Promise<import('../../../../../packages/domain-inbox/src/types').InboxFileResponse>>
+  'inbox:convert-to-task': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; taskId: string | null; error?: string | undefined }>>
+  'inbox:delete-permanent': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:file': (
+    ...args: [any]
+  ) => Awaited<Promise<import('../../../../../packages/domain-inbox/src/types').InboxFileResponse>>
+  'inbox:file-all-stale': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
+  'inbox:get': (
+    ...args: [any]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxItem | null>>
+  'inbox:get-filing-history': (
+    ...args: [any]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/inbox-api').FilingHistoryResponse>
+  >
+  'inbox:get-jobs': (
+    ...args: [any]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxJobsResponse>>
+  'inbox:get-patterns': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').CapturePattern>>
+  'inbox:get-snoozed': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/domain-inbox/src/types').SnoozedItem[]>>
+  'inbox:get-stale-threshold': (...args: []) => Awaited<Promise<number>>
+  'inbox:get-stats': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxStats>>
+  'inbox:get-suggestions': (...args: [any]) => Awaited<
+    Promise<{
+      suggestions: import('../../../../../packages/domain-inbox/src/types').InboxFilingSuggestion[]
+    }>
+  >
+  'inbox:get-tags': (...args: []) => Awaited<Promise<{ tag: string; count: number }[]>>
+  'inbox:link-to-note': (
+    ...args: [any, any, any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:list': (
+    ...args: [any]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxListResponse>>
+  'inbox:list-archived': (
+    ...args: [any]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/inbox-api').ArchivedListResponse>
+  >
+  'inbox:mark-viewed': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:preview-link': (...args: [string]) => Awaited<
+    Promise<
+      | {
+          title: string
+          domain: string
+          favicon: string | undefined
+          image: string | undefined
+          description: string | undefined
+        }
+      | {
+          title: string
+          domain: string
+          favicon?: undefined
+          image?: undefined
+          description?: undefined
+        }
+    >
+  >
+  'inbox:remove-tag': (
+    ...args: [any, any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:retry-metadata': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:retry-transcription': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:set-stale-threshold': (...args: [any]) => Awaited<Promise<{ success: boolean }>>
+  'inbox:snooze': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:track-suggestion': (
+    ...args: [string, string, string, string, number, string[], string[]]
+  ) => Awaited<
+    Promise<{ success: false; error: string } | { success: boolean; error?: string | undefined }>
+  >
+  'inbox:unarchive': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:undo-archive': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:undo-file': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:unsnooze': (
+    ...args: [any]
+  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
+  'inbox:update': (
+    ...args: [any]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').CaptureResponse>>
+  'journal:createEntry': (
+    ...args: [
+      {
+        date: string
+        content?: string | undefined
+        tags?: string[] | undefined
+        properties?: Record<string, unknown> | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<{
+      id: string
+      date: string
+      content: string
+      wordCount: number
+      characterCount: number
+      tags: string[]
+      createdAt: string
+      modifiedAt: string
+      properties?: Record<string, unknown> | undefined
+    }>
+  >
+  'journal:deleteEntry': (...args: [{ date: string }]) => Awaited<Promise<{ success: boolean }>>
+  'journal:getAllTags': (...args: []) => Awaited<Promise<{ tag: string; count: number }[]>>
+  'journal:getDayContext': (...args: [{ date: string }]) => Awaited<
+    Promise<{
+      date: string
+      tasks: {
+        id: string
+        title: string
+        completed: boolean
+        priority?: 'urgent' | 'high' | 'medium' | 'low' | undefined
+        isOverdue?: boolean | undefined
+      }[]
+      events: {
+        id: string
+        time: string
+        title: string
+        type: 'meeting' | 'focus' | 'event'
+        attendeeCount?: number | undefined
+      }[]
+      overdueCount: number
+    }>
+  >
+  'journal:getEntry': (...args: [{ date: string }]) => Awaited<
+    Promise<{
+      id: string
+      date: string
+      content: string
+      wordCount: number
+      characterCount: number
+      tags: string[]
+      createdAt: string
+      modifiedAt: string
+      properties?: Record<string, unknown> | undefined
+    } | null>
+  >
+  'journal:getHeatmap': (
+    ...args: [{ year: number }]
+  ) => Awaited<Promise<{ date: string; characterCount: number; level: 0 | 1 | 2 | 4 | 3 }[]>>
+  'journal:getMonthEntries': (...args: [{ year: number; month: number }]) => Awaited<
+    Promise<
+      {
+        date: string
+        preview: string
+        wordCount: number
+        characterCount: number
+        activityLevel: 0 | 1 | 2 | 4 | 3
+        tags: string[]
+      }[]
+    >
+  >
+  'journal:getStreak': (
+    ...args: []
+  ) => Awaited<
+    Promise<{ currentStreak: number; longestStreak: number; lastEntryDate: string | null }>
+  >
+  'journal:getYearStats': (...args: [{ year: number }]) => Awaited<
+    Promise<
+      {
+        year: number
+        month: number
+        entryCount: number
+        totalWordCount: number
+        totalCharacterCount: number
+        averageLevel: number
+      }[]
+    >
+  >
+  'journal:updateEntry': (
+    ...args: [
+      {
+        date: string
+        content?: string | undefined
+        tags?: string[] | undefined
+        properties?: Record<string, unknown> | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<{
+      id: string
+      date: string
+      content: string
+      wordCount: number
+      characterCount: number
+      tags: string[]
+      createdAt: string
+      modifiedAt: string
+      properties?: Record<string, unknown> | undefined
+    }>
+  >
+  'notes:add-property-option': (
+    ...args: [{ propertyName: string; option: { value: string; color: string } }]
+  ) => Awaited<Promise<{ success: boolean }>>
+  'notes:add-status-option': (
+    ...args: [
+      {
+        propertyName: string
+        categoryKey: 'todo' | 'in_progress' | 'done'
+        option: { value: string; color: string }
+      }
+    ]
+  ) => Awaited<Promise<{ success: boolean }>>
+  'notes:create': (
+    ...args: [
+      {
+        title: string
+        content?: string | undefined
+        folder?: string | undefined
+        tags?: string[] | undefined
+        template?: string | undefined
+      }
+    ]
+  ) => Awaited<
+    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
+    | { success: false; error: string }
+  >
+  'notes:create-folder': (
+    ...args: [string]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'notes:create-property-definition': (
+    ...args: [
+      {
+        name: string
+        type: 'number' | 'date' | 'text' | 'select' | 'checkbox' | 'url' | 'status' | 'multiselect'
+        options?: { value: string; color: string; default?: boolean | undefined }[] | undefined
+        defaultValue?: unknown
+        color?: string | undefined
+      }
+    ]
+  ) => Awaited<
+    | Promise<
+        | {
+            success: true
+            definition:
+              | import('../../../../../packages/contracts/src/property-types').PropertyDefinition
+              | undefined
+          }
+        | {
+            success: true
+            definition: {
+              type: string
+              name: string
+              createdAt: string
+              options: string | null
+              defaultValue: string | null
+              color: string | null
+            }
+          }
+      >
+    | { success: false; error: string }
+  >
+  'notes:delete': (
+    ...args: [string]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'notes:delete-attachment': (
+    ...args: [{ noteId: string; filename: string }]
+  ) => Awaited<Promise<{ success: true }> | { success: false; error: string }>
+  'notes:delete-folder': (
+    ...args: [string]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'notes:delete-property-definition': (
+    ...args: [{ name: string }]
+  ) => Awaited<Promise<{ success: boolean }>>
+  'notes:delete-version': (
+    ...args: [string]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'notes:ensure-property-definition': (
+    ...args: [{ name: string; type: 'select' | 'status' | 'multiselect' }]
+  ) => Awaited<Promise<{ success: boolean }>>
+  'notes:exists': (...args: [string]) => Awaited<Promise<boolean>>
+  'notes:export-html': (
+    ...args: [
+      {
+        noteId: string
+        includeMetadata?: boolean | undefined
+        pageSize?: 'A4' | 'Letter' | 'Legal' | undefined
+      }
+    ]
+  ) => Awaited<
+    | Promise<
+        | { success: false; error: string; path?: undefined }
+        | { success: true; path: string; error?: undefined }
+      >
+    | { success: false; error: string }
+  >
+  'notes:export-pdf': (
+    ...args: [
+      {
+        noteId: string
+        includeMetadata?: boolean | undefined
+        pageSize?: 'A4' | 'Letter' | 'Legal' | undefined
+      }
+    ]
+  ) => Awaited<
+    | Promise<
+        | { success: false; error: string; path?: undefined }
+        | { success: true; path: string; error?: undefined }
+      >
+    | { success: false; error: string }
+  >
+  'notes:get': (...args: [string]) => Awaited<Promise<import('../vault/notes-crud').Note | null>>
+  'notes:get-all-positions': (
+    ...args: []
+  ) => Awaited<
+    Promise<
+      { success: false; error: string } | { success: boolean; positions: Record<string, number> }
+    >
+  >
+  'notes:get-by-path': (
+    ...args: [string]
+  ) => Awaited<Promise<import('../vault/notes-crud').Note | null>>
+  'notes:get-file': (
+    ...args: [string]
+  ) => Awaited<Promise<import('../vault/notes-crud').FileMetadata | null>>
+  'notes:get-folder-config': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/templates-api').FolderConfig | null>
+  >
+  'notes:get-folder-template': (...args: [string]) => Awaited<Promise<string | null>>
+  'notes:get-folders': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/templates-api').FolderInfo[]>>
+  'notes:get-links': (
+    ...args: [string]
+  ) => Awaited<Promise<import('../vault/notes-crud').NoteLinksResponse>>
+  'notes:get-local-only-count': (...args: []) => Awaited<Promise<{ count: number }>>
+  'notes:get-positions': (
+    ...args: [{ folderPath: string }]
+  ) => Awaited<
+    | { success: true; positions: { path: string; position: number; folderPath: string }[] }
+    | { success: false; error: string }
+  >
+  'notes:get-property-definitions': (...args: []) => Awaited<
+    Promise<
+      {
+        type: string
+        name: string
+        createdAt: string
+        options: string | null
+        defaultValue: string | null
+        color: string | null
+      }[]
+    >
+  >
+  'notes:get-tags': (
+    ...args: []
+  ) => Awaited<Promise<{ tag: string; color: string; count: number }[]>>
+  'notes:get-version': (
+    ...args: [string]
+  ) => Awaited<Promise<import('../vault/notes-versions').SnapshotDetail | null>>
+  'notes:get-versions': (
+    ...args: [string]
+  ) => Awaited<Promise<import('../vault/notes-versions').SnapshotListItem[]>>
+  'notes:import-files': (
+    ...args: [{ sourcePaths: string[]; targetFolder?: string | undefined }]
+  ) => Awaited<
+    Promise<import('../vault/notes-crud').ImportFilesResult> | { success: false; error: string }
+  >
+  'notes:list': (
+    ...args: [
+      {
+        folder?: string | undefined
+        tags?: string[] | undefined
+        sortBy?: 'title' | 'modified' | 'created' | 'position' | undefined
+        sortOrder?: 'asc' | 'desc' | undefined
+        limit?: number | undefined
+        offset?: number | undefined
+      }
+    ]
+  ) => Awaited<Promise<import('../vault/notes-crud').NoteListResponse>>
+  'notes:list-attachments': (
+    ...args: [string]
+  ) => Awaited<Promise<import('../vault/attachments').AttachmentInfo[]>>
+  'notes:move': (
+    ...args: [{ id: string; newFolder: string }]
+  ) => Awaited<
+    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
+    | { success: false; error: string }
+  >
+  'notes:open-external': (...args: [string]) => Awaited<Promise<void>>
+  'notes:preview-by-title': (...args: [string]) => Awaited<
+    Promise<{
+      id: string
+      title: string
+      emoji: string | null
+      snippet: string | null
+      tags: { name: string; color: string }[]
+      createdAt: string
+    } | null>
+  >
+  'notes:remove-property-option': (
+    ...args: [{ propertyName: string; optionValue: string }]
+  ) => Awaited<Promise<{ success: boolean }>>
+  'notes:rename': (
+    ...args: [{ id: string; newTitle: string }]
+  ) => Awaited<
+    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
+    | { success: false; error: string }
+  >
+  'notes:rename-folder': (
+    ...args: [{ oldPath: string; newPath: string }]
+  ) => Awaited<Promise<{ success: true }> | { success: false; error: string }>
+  'notes:rename-property-option': (
+    ...args: [{ propertyName: string; oldValue: string; newValue: string }]
+  ) => Awaited<Promise<{ success: boolean }>>
+  'notes:reorder': (
+    ...args: [{ folderPath: string; notePaths: string[] }]
+  ) => Awaited<{ success: true } | { success: false; error: string }>
+  'notes:resolve-by-title': (...args: [string]) => Awaited<
+    Promise<{
+      id: string
+      path: string
+      title: string
+      fileType: import('../../../../../packages/shared/src/file-types').FileType
+    } | null>
+  >
+  'notes:restore-version': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; note: import('../vault/notes-crud').Note }
+    >
+  >
+  'notes:reveal-in-finder': (...args: [string]) => Awaited<Promise<void>>
+  'notes:set-folder-config': (
+    ...args: [
+      {
+        folderPath: string
+        config: {
+          icon?: string | null | undefined
+          template?: string | undefined
+          inherit?: boolean | undefined
+        }
+      }
+    ]
+  ) => Awaited<Promise<{ success: true }> | { success: false; error: string }>
+  'notes:set-local-only': (
+    ...args: [{ id: string; localOnly: boolean }]
+  ) => Awaited<
+    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
+    | { success: false; error: string }
+  >
+  'notes:show-import-dialog': (
+    ...args: []
+  ) => Awaited<Promise<{ canceled: boolean; filePaths: string[] }>>
+  'notes:update': (
+    ...args: [
+      {
+        id: string
+        title?: string | undefined
+        content?: string | undefined
+        tags?: string[] | undefined
+        frontmatter?: Record<string, unknown> | undefined
+        emoji?: string | null | undefined
+      }
+    ]
+  ) => Awaited<
+    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
+    | { success: false; error: string }
+  >
+  'notes:update-option-color': (
+    ...args: [{ propertyName: string; optionValue: string; newColor: string }]
+  ) => Awaited<Promise<{ success: boolean }>>
+  'notes:update-property-definition': (
+    ...args: [
+      {
+        name: string
+        type?:
+          | 'number'
+          | 'date'
+          | 'text'
+          | 'select'
+          | 'checkbox'
+          | 'url'
+          | 'status'
+          | 'multiselect'
+          | undefined
+        options?: { value: string; color: string; default?: boolean | undefined }[] | undefined
+        defaultValue?: unknown
+        color?: string | undefined
+      }
+    ]
+  ) => Awaited<
+    | Promise<
+        | { success: false; definition: null; error: string }
+        | {
+            success: true
+            definition:
+              | import('../../../../../packages/contracts/src/property-types').PropertyDefinition
+              | undefined
+            error?: undefined
+          }
+        | {
+            success: true
+            definition:
+              | {
+                  type: string
+                  name: string
+                  createdAt: string
+                  options: string | null
+                  defaultValue: string | null
+                  color: string | null
+                }
+              | undefined
+            error?: undefined
+          }
+      >
+    | { success: false; error: string }
+  >
+  'notes:upload-attachment': (
+    ...args: [{ noteId: string; filename: string; data: number[] | ArrayBuffer }]
+  ) => Awaited<Promise<import('../vault/attachments').AttachmentResult>>
+  'properties:get': (
+    ...args: [{ entityId: string }]
+  ) => Awaited<Promise<import('../database/queries/notes/property-queries').PropertyValue[]>>
+  'properties:rename': (
+    ...args: [{ entityId: string; oldName: string; newName: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/properties-api').RenamePropertyResponse
+    >
+  >
+  'properties:set': (
+    ...args: [{ entityId: string; properties: Record<string, unknown> }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/properties-api').SetPropertiesResponse
+    >
+  >
+  'quick-capture:get-clipboard': (...args: []) => Awaited<string>
+  'reminder:bulk-dismiss': (
+    ...args: [{ reminderIds: string[] }]
+  ) => Awaited<
+    Promise<{ success: false; error: string } | { success: boolean; dismissedCount: number }>
+  >
+  'reminder:count-pending': (...args: []) => Awaited<Promise<number>>
+  'reminder:create': (
+    ...args: [
+      | {
+          targetType: 'note'
+          targetId: string
+          remindAt: string
+          title?: string | undefined
+          note?: string | undefined
+        }
+      | {
+          targetType: 'journal'
+          targetId: string
+          remindAt: string
+          title?: string | undefined
+          note?: string | undefined
+        }
+      | {
+          targetType: 'highlight'
+          targetId: string
+          highlightText: string
+          highlightStart: number
+          highlightEnd: number
+          remindAt: string
+          title?: string | undefined
+          note?: string | undefined
+        }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | {
+          success: boolean
+          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
+        }
+    >
+  >
+  'reminder:delete': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  >
+  'reminder:dismiss': (...args: [string]) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; reminder: null; error: string }
+      | {
+          success: boolean
+          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
+          error?: undefined
+        }
+    >
+  >
+  'reminder:get': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget | null>
+  >
+  'reminder:get-due': (
+    ...args: []
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget[]>
+  >
+  'reminder:get-for-target': (
+    ...args: [{ targetType: 'note' | 'journal' | 'highlight'; targetId: string }]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/reminders-api').Reminder[]>>
+  'reminder:get-upcoming': (...args: [number | undefined]) => Awaited<
+    Promise<{
+      reminders: import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget[]
+      total: number
+      hasMore: boolean
+    }>
+  >
+  'reminder:list': (
+    ...args: [
+      {
+        targetType?: 'note' | 'journal' | 'highlight' | undefined
+        targetId?: string | undefined
+        status?:
+          | 'pending'
+          | 'triggered'
+          | 'dismissed'
+          | 'snoozed'
+          | ('pending' | 'triggered' | 'dismissed' | 'snoozed')[]
+          | undefined
+        fromDate?: string | undefined
+        toDate?: string | undefined
+        limit?: number | undefined
+        offset?: number | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<{
+      reminders: import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget[]
+      total: number
+      hasMore: boolean
+    }>
+  >
+  'reminder:snooze': (...args: [{ id: string; snoozeUntil: string }]) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; reminder: null; error: string }
+      | {
+          success: boolean
+          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
+          error?: undefined
+        }
+    >
+  >
+  'reminder:update': (
+    ...args: [
+      {
+        id: string
+        remindAt?: string | undefined
+        title?: string | null | undefined
+        note?: string | null | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; reminder: null; error: string }
+      | {
+          success: boolean
+          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
+          error?: undefined
+        }
+    >
+  >
+  'saved-filters:create': (
+    ...args: [
+      {
+        name: string
+        config: {
+          filters: {
+            search?: string | undefined
+            projectIds?: string[] | undefined
+            priorities?: ('urgent' | 'high' | 'medium' | 'low' | 'none')[] | undefined
+            dueDate?:
+              | {
+                  type:
+                    | 'custom'
+                    | 'any'
+                    | 'none'
+                    | 'overdue'
+                    | 'today'
+                    | 'tomorrow'
+                    | 'this-week'
+                    | 'next-week'
+                    | 'this-month'
+                  customStart?: string | null | undefined
+                  customEnd?: string | null | undefined
+                }
+              | undefined
+            statusIds?: string[] | undefined
+            completion?: 'active' | 'completed' | 'all' | undefined
+            repeatType?: 'all' | 'repeating' | 'one-time' | undefined
+            hasTime?: 'all' | 'with-time' | 'without-time' | undefined
+          }
+          sort?:
+            | {
+                field: 'title' | 'createdAt' | 'priority' | 'dueDate' | 'completedAt' | 'project'
+                direction: 'asc' | 'desc'
+              }
+            | undefined
+          starred?: boolean | undefined
+        }
+      }
+    ]
+  ) => Awaited<
+    Promise<{
+      success: boolean
+      savedFilter: import('../../../../../packages/contracts/src/saved-filters-api').SavedFilter
+    }>
+  >
+  'saved-filters:delete': (
+    ...args: [{ id: string }]
+  ) => Awaited<
+    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  >
+  'saved-filters:list': (...args: []) => Awaited<
+    Promise<{
+      savedFilters: import('../../../../../packages/contracts/src/saved-filters-api').SavedFilter[]
+    }>
+  >
+  'saved-filters:reorder': (
+    ...args: [{ ids: string[]; positions: number[] }]
+  ) => Awaited<Promise<{ success: boolean }>>
+  'saved-filters:update': (
+    ...args: [
+      {
+        id: string
+        name?: string | undefined
+        config?:
+          | {
+              filters: {
+                search?: string | undefined
+                projectIds?: string[] | undefined
+                priorities?: ('urgent' | 'high' | 'medium' | 'low' | 'none')[] | undefined
+                dueDate?:
+                  | {
+                      type:
+                        | 'custom'
+                        | 'any'
+                        | 'none'
+                        | 'overdue'
+                        | 'today'
+                        | 'tomorrow'
+                        | 'this-week'
+                        | 'next-week'
+                        | 'this-month'
+                      customStart?: string | null | undefined
+                      customEnd?: string | null | undefined
+                    }
+                  | undefined
+                statusIds?: string[] | undefined
+                completion?: 'active' | 'completed' | 'all' | undefined
+                repeatType?: 'all' | 'repeating' | 'one-time' | undefined
+                hasTime?: 'all' | 'with-time' | 'without-time' | undefined
+              }
+              sort?:
+                | {
+                    field:
+                      | 'title'
+                      | 'createdAt'
+                      | 'priority'
+                      | 'dueDate'
+                      | 'completedAt'
+                      | 'project'
+                    direction: 'asc' | 'desc'
+                  }
+                | undefined
+              starred?: boolean | undefined
+            }
+          | undefined
+        position?: number | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: boolean; savedFilter: null; error: string }
+      | {
+          success: boolean
+          savedFilter:
+            | import('../../../../../packages/contracts/src/saved-filters-api').SavedFilter
+            | null
+          error?: undefined
+        }
+    >
+  >
+  'search:add-reason': (
+    ...args: [
+      {
+        itemId: string
+        itemType: 'note' | 'journal' | 'task' | 'inbox'
+        itemTitle: string
+        searchQuery: string
+        itemIcon?: string | null | undefined
+      }
+    ]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchReason>>
+  'search:clear-reasons': (...args: []) => Awaited<Promise<{ cleared: true }>>
+  'search:get-all-tags': (...args: []) => Awaited<Promise<string[]>>
+  'search:get-reasons': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchReason[]>>
+  'search:get-stats': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchStats>>
+  'search:query': (
+    ...args: [
+      {
+        text: string
+        types?: ('note' | 'journal' | 'task' | 'inbox')[] | undefined
+        tags?: string[] | undefined
+        dateRange?: { from: string; to: string } | null | undefined
+        projectId?: string | null | undefined
+        folderPath?: string | null | undefined
+        limit?: number | undefined
+        offset?: number | undefined
+      }
+    ]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchResponse>>
+  'search:quick': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/search-api').QuickSearchResponse>
+  >
+  'search:rebuild-index': (...args: []) => Awaited<
+    Promise<
+      | {
+          notes: number
+          tasks: number
+          inbox: number
+          durationMs: number
+          started: true
+          error?: undefined
+        }
+      | { started: false; error: string }
+    >
+  >
+  'settings:downloadVoiceModel': (
+    ...args: []
+  ) => Awaited<
+    Promise<{ success: boolean; error?: undefined } | { success: boolean; error: string }>
+  >
+  'settings:get': (...args: [string]) => Awaited<string | null>
+  'settings:getAIModelStatus': (
+    ...args: []
+  ) => Awaited<Promise<import('./settings-handlers').AIModelStatus>>
+  'settings:getAISettings': (...args: []) => Awaited<import('./settings-handlers').AISettings>
+  'settings:getBackupSettings': (...args: []) => Awaited<{
+    autoBackup: boolean
+    frequencyHours: 1 | 6 | 12 | 24
+    maxBackups: number
+    lastBackupAt: string | null
+  }>
+  'settings:getEditorSettings': (...args: []) => Awaited<{
+    width: 'medium' | 'narrow' | 'wide'
+    spellCheck: boolean
+    autoSaveDelay: number
+    showWordCount: boolean
+    toolbarMode: 'floating' | 'sticky'
+  }>
+  'settings:getGeneralSettings': (...args: []) => Awaited<{
+    theme: 'light' | 'dark' | 'white' | 'system'
+    fontSize: 'small' | 'medium' | 'large'
+    fontFamily: 'system' | 'serif' | 'sans-serif' | 'monospace' | 'gelasio' | 'geist' | 'inter'
+    accentColor: string
+    startOnBoot: boolean
+    language: string
+    onboardingCompleted: boolean
+    createInSelectedFolder: boolean
+    clockFormat: '12h' | '24h'
+  }>
+  'settings:getGraphSettings': (...args: []) => Awaited<{
+    layout: 'forceatlas2' | 'circular' | 'random'
+    showLabels: boolean
+    showEdgeLabels: boolean
+    animateLayout: boolean
+    showTagEdges: boolean
+  }>
+  'settings:getJournalSettings': (...args: []) => Awaited<{
+    defaultTemplate: string | null
+    showSchedule: boolean
+    showTasks: boolean
+    showAIConnections: boolean
+    showStatsFooter: boolean
+  }>
+  'settings:getKeyboardSettings': (...args: []) => Awaited<{
+    overrides: Record<
+      string,
+      {
+        key: string
+        modifiers: {
+          meta?: boolean | undefined
+          ctrl?: boolean | undefined
+          shift?: boolean | undefined
+          alt?: boolean | undefined
+        }
+      }
+    >
+    globalCapture: {
+      key: string
+      modifiers: {
+        meta?: boolean | undefined
+        ctrl?: boolean | undefined
+        shift?: boolean | undefined
+        alt?: boolean | undefined
+      }
+    } | null
+  }>
+  'settings:getNoteEditorSettings': (
+    ...args: []
+  ) => Awaited<import('./settings-handlers').NoteEditorSettings>
+  'settings:getSyncSettings': (...args: []) => Awaited<{ enabled: boolean; autoSync: boolean }>
+  'settings:getTabSettings': (...args: []) => Awaited<import('./settings-handlers').TabSettings>
+  'settings:getTaskSettings': (...args: []) => Awaited<{
+    defaultProjectId: string | null
+    defaultSortOrder: 'createdAt' | 'priority' | 'dueDate' | 'manual'
+    weekStartDay: 'sunday' | 'monday'
+    staleInboxDays: number
+  }>
+  'settings:getVoiceModelStatus': (
+    ...args: []
+  ) => Awaited<import('../inbox/voice-model').VoiceModelStatus>
+  'settings:getVoiceRecordingReadiness': (
+    ...args: []
+  ) => Awaited<Promise<import('../inbox/voice-transcription-settings').VoiceRecordingReadiness>>
+  'settings:getVoiceTranscriptionOpenAIKeyStatus': (
+    ...args: []
+  ) => Awaited<Promise<import('./settings-handlers').VoiceTranscriptionOpenAIKeyStatus>>
+  'settings:getVoiceTranscriptionSettings': (
+    ...args: []
+  ) => Awaited<{ provider: 'local' | 'openai' }>
+  'settings:loadAIModel': (
+    ...args: []
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; message: string; error?: undefined }
+      | { success: boolean; error: string; message?: undefined }
+      | { success: boolean; message?: undefined; error?: undefined }
+    >
+  >
+  'settings:registerGlobalCapture': (
+    ...args: []
+  ) => Awaited<Promise<import('./settings-handlers').GlobalCaptureResult>>
+  'settings:reindexEmbeddings': (
+    ...args: []
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; computed: number; skipped: number; error?: string | undefined }
+    >
+  >
+  'settings:resetKeyboardSettings': (
+    ...args: []
+  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  'settings:set': (
+    ...args: [{ key: string; value: string }]
+  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  'settings:setAISettings': (
+    ...args: [Partial<import('./settings-handlers').AISettings>]
+  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  'settings:setBackupSettings': (
+    ...args: [
+      Partial<{
+        autoBackup: boolean
+        frequencyHours: 1 | 6 | 12 | 24
+        maxBackups: number
+        lastBackupAt: string | null
+      }>
+    ]
+  ) => Awaited<{ success: boolean; error?: string | undefined }>
+  'settings:setEditorSettings': (
+    ...args: [
+      Partial<{
+        width: 'medium' | 'narrow' | 'wide'
+        spellCheck: boolean
+        autoSaveDelay: number
+        showWordCount: boolean
+        toolbarMode: 'floating' | 'sticky'
+      }>
+    ]
+  ) => Awaited<{ success: boolean; error?: string | undefined }>
+  'settings:setGeneralSettings': (
+    ...args: [
+      Partial<{
+        theme: 'light' | 'dark' | 'white' | 'system'
+        fontSize: 'small' | 'medium' | 'large'
+        fontFamily: 'system' | 'serif' | 'sans-serif' | 'monospace' | 'gelasio' | 'geist' | 'inter'
+        accentColor: string
+        startOnBoot: boolean
+        language: string
+        onboardingCompleted: boolean
+        createInSelectedFolder: boolean
+        clockFormat: '12h' | '24h'
+      }>
+    ]
+  ) => Awaited<{ success: boolean; error?: string | undefined }>
+  'settings:setGraphSettings': (
+    ...args: [
+      Partial<{
+        layout: 'forceatlas2' | 'circular' | 'random'
+        showLabels: boolean
+        showEdgeLabels: boolean
+        animateLayout: boolean
+        showTagEdges: boolean
+      }>
+    ]
+  ) => Awaited<{ success: boolean; error?: string | undefined }>
+  'settings:setJournalSettings': (
+    ...args: [Partial<import('./settings-handlers').JournalSettings>]
+  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  'settings:setKeyboardSettings': (
+    ...args: [
+      Partial<{
+        overrides: Record<
+          string,
+          {
+            key: string
+            modifiers: {
+              meta?: boolean | undefined
+              ctrl?: boolean | undefined
+              shift?: boolean | undefined
+              alt?: boolean | undefined
+            }
+          }
+        >
+        globalCapture: {
+          key: string
+          modifiers: {
+            meta?: boolean | undefined
+            ctrl?: boolean | undefined
+            shift?: boolean | undefined
+            alt?: boolean | undefined
+          }
+        } | null
+      }>
+    ]
+  ) => Awaited<{ success: boolean; error?: string | undefined }>
+  'settings:setNoteEditorSettings': (
+    ...args: [Partial<import('./settings-handlers').NoteEditorSettings>]
+  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  'settings:setSyncSettings': (
+    ...args: [Partial<{ enabled: boolean; autoSync: boolean }>]
+  ) => Awaited<{ success: boolean; error?: string | undefined }>
+  'settings:setTabSettings': (
+    ...args: [Partial<import('./settings-handlers').TabSettings>]
+  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+  'settings:setTaskSettings': (
+    ...args: [
+      Partial<{
+        defaultProjectId: string | null
+        defaultSortOrder: 'createdAt' | 'priority' | 'dueDate' | 'manual'
+        weekStartDay: 'sunday' | 'monday'
+        staleInboxDays: number
+      }>
+    ]
+  ) => Awaited<{ success: boolean; error?: string | undefined }>
+  'settings:setVoiceTranscriptionOpenAIKey': (
+    ...args: [{ apiKey: string }]
+  ) => Awaited<
+    Promise<{ success: boolean; error?: undefined } | { success: boolean; error: string }>
+  >
+  'settings:setVoiceTranscriptionSettings': (
+    ...args: [Partial<{ provider: 'local' | 'openai' }>]
+  ) => Awaited<{ success: boolean; error?: string | undefined }>
+  'sync:approve-linking': (
+    ...args: [{ sessionId: string }]
+  ) => Awaited<
+    | Promise<import('../../../../../packages/contracts/src/ipc-devices').ApproveLinkingResult>
+    | { success: false; error: string }
+  >
+  'sync:check-device-status': (...args: []) => Awaited<Promise<{ status: string }>>
+  'sync:complete-linking-qr': (
+    ...args: [{ sessionId: string }]
+  ) => Awaited<
+    | Promise<import('../../../../../packages/contracts/src/ipc-devices').CompleteLinkingQrResult>
+    | { success: false; error: string }
+  >
+  'sync:confirm-recovery-phrase': (
+    ...args: [{ confirmed: boolean }]
+  ) => Awaited<Promise<{ success: boolean }> | { success: false; error: string }>
+  'sync:download-attachment': (
+    ...args: [{ attachmentId: string; targetPath?: string | undefined }]
+  ) => Awaited<
+    | Promise<
+        | { success: boolean; error: string; filePath?: undefined }
+        | { success: boolean; filePath: string; error?: undefined }
+      >
+    | { success: false; error: string }
+  >
+  'sync:emergency-wipe': (...args: []) => Awaited<Promise<{ success: boolean }>>
+  'sync:generate-linking-qr': (
+    ...args: []
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/ipc-devices').GenerateLinkingQrResult>
+  >
+  'sync:get-devices': (...args: []) => Awaited<
+    Promise<{
+      devices: {
+        id: string
+        name: string
+        platform: 'macos' | 'windows' | 'linux' | 'ios' | 'android'
+        linkedAt: number
+        lastSyncAt: number | undefined
+        isCurrentDevice: boolean
+      }[]
+      email: string | undefined
+    }>
+  >
+  'sync:get-download-progress': (
+    ...args: [{ attachmentId: string }]
+  ) => Awaited<
+    | { progress: number; downloadedChunks: number; totalChunks: number; status: 'downloading' }
+    | null
+    | { success: false; error: string }
+  >
+  'sync:get-history': (
+    ...args: [{ limit?: number | undefined; offset?: number | undefined }]
+  ) => Awaited<
+    | {
+        entries: {
+          id: string
+          type: 'error' | 'push' | 'pull'
+          itemCount: number
+          direction: string | undefined
+          details: unknown
+          durationMs: number | undefined
+          createdAt: number
+        }[]
+        total: number
+      }
+    | { success: false; error: string }
+  >
+  'sync:get-linking-sas': (
+    ...args: [{ sessionId: string }]
+  ) => Awaited<
+    | Promise<{ verificationCode?: string | undefined; error?: string | undefined }>
+    | { success: false; error: string }
+  >
+  'sync:get-quarantined-items': (
+    ...args: []
+  ) => Awaited<import('../../../../../packages/contracts/src/ipc-events').QuarantinedItemInfo[]>
+  'sync:get-queue-size': (...args: []) => Awaited<{ pending: number; failed: number }>
+  'sync:get-recovery-phrase': (...args: []) => Awaited<string | null>
+  'sync:get-status': (
+    ...args: []
+  ) => Awaited<
+    | import('../../../../../packages/contracts/src/ipc-sync-ops').GetSyncStatusResult
+    | { status: string; pendingCount: number }
+  >
+  'sync:get-storage-breakdown': (
+    ...args: []
+  ) => Awaited<
+    Promise<
+      import('../../../../../packages/contracts/src/ipc-sync-ops').StorageBreakdownResult | null
+    >
+  >
+  'sync:get-synced-settings': (...args: []) => Awaited<{
+    general?:
+      | {
+          theme?: 'light' | 'dark' | 'white' | 'system' | undefined
+          fontSize?: 'small' | 'medium' | 'large' | undefined
+          fontFamily?:
+            | 'system'
+            | 'serif'
+            | 'sans-serif'
+            | 'monospace'
+            | 'gelasio'
+            | 'geist'
+            | 'inter'
+            | undefined
+          accentColor?: string | undefined
+          startOnBoot?: boolean | undefined
+          language?: string | undefined
+          createInSelectedFolder?: boolean | undefined
+        }
+      | undefined
+    editor?:
+      | {
+          width?: 'medium' | 'narrow' | 'wide' | undefined
+          spellCheck?: boolean | undefined
+          autoSaveDelay?: number | undefined
+          showWordCount?: boolean | undefined
+          toolbarMode?: 'floating' | 'sticky' | undefined
+        }
+      | undefined
+    tasks?:
+      | {
+          defaultProjectId?: string | null | undefined
+          defaultSortOrder?: 'createdAt' | 'priority' | 'dueDate' | 'manual' | undefined
+          weekStartDay?: 'sunday' | 'monday' | undefined
+          staleInboxDays?: number | undefined
+          showCompleted?: boolean | undefined
+          sortBy?: string | undefined
+        }
+      | undefined
+    keyboard?: { overrides?: Record<string, unknown> | undefined } | undefined
+    notes?:
+      | {
+          defaultFolder?: string | undefined
+          editorFontSize?: number | undefined
+          spellCheck?: boolean | undefined
+        }
+      | undefined
+    sync?: { autoSync?: boolean | undefined; syncIntervalMinutes?: number | undefined } | undefined
+  } | null>
+  'sync:get-upload-progress': (
+    ...args: [{ sessionId: string }]
+  ) => Awaited<
+    | { progress: number; uploadedChunks: number; totalChunks: number; status: 'uploading' }
+    | null
+    | { success: false; error: string }
+  >
+  'sync:link-via-qr': (
+    ...args: [{ qrData: string; oauthToken?: string | undefined; provider?: string | undefined }]
+  ) => Awaited<
+    | Promise<import('../../../../../packages/contracts/src/ipc-devices').LinkViaQrResult>
+    | { success: false; error: string }
+  >
+  'sync:link-via-recovery': (
+    ...args: [{ recoveryPhrase: string }]
+  ) => Awaited<
+    | Promise<
+        | { success: boolean; error: string; deviceId?: undefined }
+        | { success: boolean; deviceId: string; error?: undefined }
+      >
+    | { success: false; error: string }
+  >
+  'sync:logout': (
+    ...args: []
+  ) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean }>>
+  'sync:pause': (...args: []) => Awaited<{ success: boolean; wasPaused: boolean }>
+  'sync:remove-device': (
+    ...args: [{ deviceId: string }]
+  ) => Awaited<
+    | Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+    | { success: false; error: string }
+  >
+  'sync:rename-device': (
+    ...args: [{ deviceId: string; newName: string }]
+  ) => Awaited<
+    | Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
+    | { success: false; error: string }
+  >
+  'sync:resume': (...args: []) => Awaited<{ success: boolean; pendingCount: number }>
+  'sync:setup-first-device': (
+    ...args: [{ oauthToken: string; provider: 'google'; state: string }]
+  ) => Awaited<
+    | Promise<
+        | {
+            success: boolean
+            needsRecoverySetup: boolean
+            deviceId: string
+            needsRecoveryInput?: undefined
+          }
+        | {
+            success: boolean
+            needsRecoverySetup: boolean
+            needsRecoveryInput: boolean
+            deviceId?: undefined
+          }
+      >
+    | { success: false; error: string }
+  >
+  'sync:setup-new-account': (
+    ...args: []
+  ) => Awaited<
+    Promise<
+      | { success: boolean; error: string; deviceId?: undefined }
+      | { success: boolean; deviceId: string; error?: undefined }
+    >
+  >
+  'sync:trigger-sync': (
+    ...args: []
+  ) => Awaited<Promise<{ success: boolean } | { success: boolean; error: string }>>
+  'sync:update-synced-setting': (
+    ...args: [{ fieldPath: string; value: unknown }]
+  ) => Awaited<
+    | { success: boolean; error: string }
+    | { success: boolean; error?: undefined }
+    | { success: false; error: string }
+  >
+  'sync:upload-attachment': (
+    ...args: [{ noteId: string; filePath: string }]
+  ) => Awaited<
+    | Promise<
+        | { success: boolean; error: string; attachmentId?: undefined; sessionId?: undefined }
+        | { success: boolean; attachmentId: string; sessionId: string; error?: undefined }
+      >
+    | { success: false; error: string }
+  >
+  'tags:delete': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/tags-api').DeleteTagResponse
+    >
+  >
+  'tags:get-all-with-counts': (
+    ...args: []
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/tags-api').GetAllWithCountsResponse>
+  >
+  'tags:get-notes-by-tag': (
+    ...args: [
+      {
+        tag: string
+        sortBy?: 'title' | 'modified' | 'created' | undefined
+        sortOrder?: 'asc' | 'desc' | undefined
+        includeDescendants?: boolean | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/tags-api').GetNotesByTagResponse>
+  >
+  'tags:merge': (
+    ...args: [{ source: string; target: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/tags-api').MergeTagResponse
+    >
+  >
+  'tags:pin-note-to-tag': (
+    ...args: [{ noteId: string; tag: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
+    >
+  >
+  'tags:remove-from-note': (
+    ...args: [{ noteId: string; tag: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
+    >
+  >
+  'tags:rename': (
+    ...args: [{ oldName: string; newName: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/tags-api').RenameTagResponse
+    >
+  >
+  'tags:unpin-note-from-tag': (
+    ...args: [{ noteId: string; tag: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
+    >
+  >
+  'tags:update-color': (
+    ...args: [{ tag: string; color: string }]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
+    >
+  >
+  'tasks:archive': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; error: string }
+      | { success: boolean; error?: undefined }
+    >
+  >
+  'tasks:bulk-archive': (
+    ...args: [{ ids: string[] }]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
+  'tasks:bulk-complete': (
+    ...args: [{ ids: string[] }]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
+  'tasks:bulk-delete': (
+    ...args: [{ ids: string[] }]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
+  'tasks:bulk-move': (
+    ...args: [{ ids: string[]; projectId: string }]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
+  'tasks:complete': (...args: [{ id: string; completedAt?: string | undefined }]) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; task: null; error: string }
+      | {
+          success: boolean
+          task: import('../../../../../packages/domain-tasks/src/types').Task
+          error?: undefined
+        }
+    >
+  >
+  'tasks:convert-to-subtask': (...args: [{ taskId: string; parentId: string }]) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; task: null; error: string }
+      | {
+          success: boolean
+          task: import('../../../../../packages/domain-tasks/src/types').Task
+          error?: undefined
+        }
+    >
+  >
+  'tasks:convert-to-task': (...args: [string]) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; task: null; error: string }
+      | {
+          success: boolean
+          task: import('../../../../../packages/domain-tasks/src/types').Task
+          error?: undefined
+        }
+    >
+  >
+  'tasks:create': (
+    ...args: [
+      {
+        projectId: string
+        title: string
+        description?: string | null | undefined
+        priority?: number | undefined
+        statusId?: string | null | undefined
+        parentId?: string | null | undefined
+        dueDate?: string | null | undefined
+        dueTime?: string | null | undefined
+        startDate?: string | null | undefined
+        isRepeating?: boolean | undefined
+        repeatConfig?:
+          | {
+              frequency: 'daily' | 'weekly' | 'monthly' | 'yearly'
+              endType: 'date' | 'never' | 'count'
+              createdAt: string
+              interval?: number | undefined
+              daysOfWeek?: number[] | undefined
+              monthlyType?: 'dayOfMonth' | 'weekPattern' | undefined
+              dayOfMonth?: number | undefined
+              weekOfMonth?: number | undefined
+              dayOfWeekForMonth?: number | undefined
+              endDate?: string | null | undefined
+              endCount?: number | undefined
+              completedCount?: number | undefined
+            }
+          | null
+          | undefined
+        repeatFrom?: 'due' | 'completion' | null | undefined
+        tags?: string[] | undefined
+        linkedNoteIds?: string[] | undefined
+        sourceNoteId?: string | null | undefined
+        position?: number | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; task: import('../../../../../packages/domain-tasks/src/types').Task }
+    >
+  >
+  'tasks:delete': (
+    ...args: [string]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'tasks:duplicate': (...args: [string]) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; task: null; error: string }
+      | {
+          success: boolean
+          task: import('../../../../../packages/domain-tasks/src/types').Task
+          error?: undefined
+        }
+    >
+  >
+  'tasks:get': (
+    ...args: [string]
+  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Task | null>>
+  'tasks:get-linked-tasks': (
+    ...args: [string]
+  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Task[]>>
+  'tasks:get-overdue': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListEnvelope>>
+  'tasks:get-stats': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').TaskStats>>
+  'tasks:get-subtasks': (
+    ...args: [string]
+  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Task[]>>
+  'tasks:get-tags': (...args: []) => Awaited<Promise<{ tag: string; count: number }[]>>
+  'tasks:get-today': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListEnvelope>>
+  'tasks:get-upcoming': (
+    ...args: [{ days?: number | undefined }]
+  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListEnvelope>>
+  'tasks:list': (
+    ...args: [
+      {
+        projectId?: string | undefined
+        statusId?: string | null | undefined
+        parentId?: string | null | undefined
+        includeCompleted?: boolean | undefined
+        includeArchived?: boolean | undefined
+        dueBefore?: string | undefined
+        dueAfter?: string | undefined
+        tags?: string[] | undefined
+        search?: string | undefined
+        sortBy?: 'modified' | 'created' | 'position' | 'priority' | 'dueDate' | undefined
+        sortOrder?: 'asc' | 'desc' | undefined
+        limit?: number | undefined
+        offset?: number | undefined
+      }
+    ]
+  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListResult>>
+  'tasks:move': (
+    ...args: [
+      {
+        taskId: string
+        position: number
+        targetProjectId?: string | undefined
+        targetStatusId?: string | null | undefined
+        targetParentId?: string | null | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; task: null; error: string }
+      | {
+          success: boolean
+          task: import('../../../../../packages/domain-tasks/src/types').Task
+          error?: undefined
+        }
+    >
+  >
+  'tasks:project-archive': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; error: string }
+      | { success: boolean; error?: undefined }
+    >
+  >
+  'tasks:project-create': (
+    ...args: [
+      {
+        name: string
+        description?: string | null | undefined
+        color?: string | undefined
+        icon?: string | null | undefined
+        statuses?:
+          | {
+              name: string
+              type: 'todo' | 'in_progress' | 'done'
+              order: number
+              color?: string | undefined
+            }[]
+          | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | {
+          success: boolean
+          project: import('../../../../../packages/domain-tasks/src/types').ProjectWithStatuses
+        }
+    >
+  >
+  'tasks:project-delete': (
+    ...args: [string]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'tasks:project-get': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<
+      import('../../../../../packages/domain-tasks/src/types').ProjectWithStatuses | undefined
+    >
+  >
+  'tasks:project-list': (...args: []) => Awaited<
+    Promise<{
+      projects: import('../../../../../packages/domain-tasks/src/types').ProjectWithStats[]
+    }>
+  >
+  'tasks:project-reorder': (
+    ...args: [{ projectIds: string[]; positions: number[] }]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'tasks:project-update': (
+    ...args: [
+      {
+        id: string
+        name?: string | undefined
+        description?: string | null | undefined
+        color?: string | undefined
+        icon?: string | null | undefined
+        statuses?:
+          | {
+              name: string
+              type: 'todo' | 'in_progress' | 'done'
+              order: number
+              id?: string | undefined
+              color?: string | undefined
+            }[]
+          | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; project: null; error: string }
+      | {
+          success: boolean
+          project: import('../../../../../packages/domain-tasks/src/types').ProjectWithStatuses
+          error?: undefined
+        }
+    >
+  >
+  'tasks:reorder': (
+    ...args: [{ taskIds: string[]; positions: number[] }]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'tasks:seed-demo': (...args: []) => Awaited<Promise<{ success: boolean; message: string }>>
+  'tasks:seed-performance-test': (
+    ...args: []
+  ) => Awaited<Promise<{ success: boolean; message: string }>>
+  'tasks:status-create': (
+    ...args: [
+      { projectId: string; name: string; color?: string | undefined; isDone?: boolean | undefined }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | {
+          success: boolean
+          status: import('../../../../../packages/domain-tasks/src/types').Status
+        }
+    >
+  >
+  'tasks:status-delete': (
+    ...args: [string]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'tasks:status-list': (
+    ...args: [string]
+  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Status[]>>
+  'tasks:status-reorder': (
+    ...args: [{ statusIds: string[]; positions: number[] }]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'tasks:status-update': (
+    ...args: [
+      {
+        id: string
+        name?: string | undefined
+        color?: string | undefined
+        position?: number | undefined
+        isDefault?: boolean | undefined
+        isDone?: boolean | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; error: string; status?: undefined }
+      | {
+          success: boolean
+          status: import('../../../../../packages/domain-tasks/src/types').Status
+          error?: undefined
+        }
+    >
+  >
+  'tasks:unarchive': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; error: string }
+      | { success: boolean; error?: undefined }
+    >
+  >
+  'tasks:uncomplete': (...args: [string]) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; task: null; error: string }
+      | {
+          success: boolean
+          task: import('../../../../../packages/domain-tasks/src/types').Task
+          error?: undefined
+        }
+    >
+  >
+  'tasks:update': (
+    ...args: [
+      {
+        id: string
+        title?: string | undefined
+        description?: string | null | undefined
+        priority?: number | undefined
+        projectId?: string | undefined
+        statusId?: string | null | undefined
+        parentId?: string | null | undefined
+        dueDate?: string | null | undefined
+        dueTime?: string | null | undefined
+        startDate?: string | null | undefined
+        isRepeating?: boolean | undefined
+        repeatConfig?:
+          | {
+              frequency: 'daily' | 'weekly' | 'monthly' | 'yearly'
+              endType: 'date' | 'never' | 'count'
+              createdAt: string
+              interval?: number | undefined
+              daysOfWeek?: number[] | undefined
+              monthlyType?: 'dayOfMonth' | 'weekPattern' | undefined
+              dayOfMonth?: number | undefined
+              weekOfMonth?: number | undefined
+              dayOfWeekForMonth?: number | undefined
+              endDate?: string | null | undefined
+              endCount?: number | undefined
+              completedCount?: number | undefined
+            }
+          | null
+          | undefined
+        repeatFrom?: 'due' | 'completion' | null | undefined
+        tags?: string[] | undefined
+        linkedNoteIds?: string[] | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | { success: boolean; task: null; error: string }
+      | {
+          success: boolean
+          task: import('../../../../../packages/domain-tasks/src/types').Task
+          error?: undefined
+        }
+    >
+  >
+  'templates:create': (
+    ...args: [
+      {
+        name: string
+        description?: string | undefined
+        icon?: string | null | undefined
+        tags?: string[] | undefined
+        properties?:
+          | {
+              name: string
+              type:
+                | 'number'
+                | 'date'
+                | 'text'
+                | 'select'
+                | 'checkbox'
+                | 'url'
+                | 'multiselect'
+                | 'rating'
+              value: unknown
+              options?: string[] | undefined
+            }[]
+          | undefined
+        content?: string | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | {
+          success: boolean
+          template: import('../../../../../packages/contracts/src/templates-api').Template
+        }
+    >
+  >
+  'templates:delete': (
+    ...args: [string]
+  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
+  'templates:duplicate': (...args: [{ id: string; newName: string }]) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | {
+          success: boolean
+          template: import('../../../../../packages/contracts/src/templates-api').Template
+        }
+    >
+  >
+  'templates:get': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/templates-api').Template | null>
+  >
+  'templates:list': (...args: []) => Awaited<
+    Promise<{
+      templates: import('../../../../../packages/contracts/src/templates-api').TemplateListItem[]
+    }>
+  >
+  'templates:update': (
+    ...args: [
+      {
+        id: string
+        name?: string | undefined
+        description?: string | undefined
+        icon?: string | null | undefined
+        tags?: string[] | undefined
+        properties?:
+          | {
+              name: string
+              type:
+                | 'number'
+                | 'date'
+                | 'text'
+                | 'select'
+                | 'checkbox'
+                | 'url'
+                | 'multiselect'
+                | 'rating'
+              value: unknown
+              options?: string[] | undefined
+            }[]
+          | undefined
+        content?: string | undefined
+      }
+    ]
+  ) => Awaited<
+    Promise<
+      | { success: false; error: string }
+      | {
+          success: boolean
+          template: import('../../../../../packages/contracts/src/templates-api').Template
+        }
+    >
+  >
+  'vault:close': (...args: []) => Awaited<Promise<void>>
+  'vault:get-all': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').GetVaultsResponse>>
+  'vault:get-config': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').VaultConfig>>
+  'vault:get-status': (
+    ...args: []
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').VaultStatus>>
+  'vault:reindex': (...args: []) => Awaited<Promise<void>>
+  'vault:remove': (...args: [string]) => Awaited<Promise<void>>
+  'vault:reveal': (...args: []) => Awaited<Promise<void>>
+  'vault:select': (
+    ...args: [{ path?: string | undefined }]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/vault-api').SelectVaultResponse>
+  >
+  'vault:switch': (
+    ...args: [string]
+  ) => Awaited<
+    Promise<import('../../../../../packages/contracts/src/vault-api').SelectVaultResponse>
+  >
+  'vault:update-config': (
+    ...args: [
+      {
+        excludePatterns?: string[] | undefined
+        defaultNoteFolder?: string | undefined
+        journalFolder?: string | undefined
+        attachmentsFolder?: string | undefined
+      }
+    ]
+  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').VaultConfig>>
 }
 
 export type MainIpcInvokeChannel = keyof MainIpcInvokeHandlers
-export type MainIpcInvokeArgs<C extends MainIpcInvokeChannel> =
-  Parameters<MainIpcInvokeHandlers[C]>
-export type MainIpcInvokeResult<C extends MainIpcInvokeChannel> =
-  ReturnType<MainIpcInvokeHandlers[C]>
+export type MainIpcInvokeArgs<C extends MainIpcInvokeChannel> = Parameters<MainIpcInvokeHandlers[C]>
+export type MainIpcInvokeResult<C extends MainIpcInvokeChannel> = ReturnType<
+  MainIpcInvokeHandlers[C]
+>

--- a/apps/desktop/src/main/sync/auth-state.ts
+++ b/apps/desktop/src/main/sync/auth-state.ts
@@ -1,0 +1,7 @@
+import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
+import { retrieveToken } from './token-manager'
+
+export async function isMemryUserSignedIn(): Promise<boolean> {
+  const refresh = await retrieveToken(KEYCHAIN_ENTRIES.REFRESH_TOKEN)
+  return typeof refresh === 'string' && refresh.trim().length > 0
+}

--- a/apps/desktop/src/main/sync/device-registration.ts
+++ b/apps/desktop/src/main/sync/device-registration.ts
@@ -16,6 +16,7 @@ import { getDatabase } from '../database/client'
 import { createLogger } from '../lib/logger'
 import { deleteFromServer, postToServer } from './http-client'
 import { getSyncEngine, startSyncRuntime } from './runtime'
+import { startGoogleCalendarSyncRunner } from '../calendar/google/sync-service'
 import {
   ACCESS_TOKEN_EXPIRY_SECONDS,
   extractJtiFromToken,
@@ -174,6 +175,9 @@ export const persistKeysAndRegisterDevice = async (
     } else {
       void startSyncRuntime()
     }
+    void startGoogleCalendarSyncRunner().catch(() => {
+      // Runner self-logs on failure; sign-in should succeed regardless.
+    })
   }
 
   return deviceResponse.deviceId

--- a/apps/desktop/src/main/sync/item-handlers/base-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/base-handler.ts
@@ -14,12 +14,7 @@ export abstract class BaseItemHandler<T> implements SyncItemHandler<T> {
   abstract readonly type: SyncItemType
   abstract readonly schema: ZodType<T>
 
-  abstract applyUpsert(
-    ctx: ApplyContext,
-    itemId: string,
-    data: T,
-    clock: VectorClock
-  ): ApplyResult
+  abstract applyUpsert(ctx: ApplyContext, itemId: string, data: T, clock: VectorClock): ApplyResult
 
   applyDelete(_ctx: ApplyContext, _itemId: string, _clock?: VectorClock): 'applied' | 'skipped' {
     return 'skipped'

--- a/apps/desktop/src/main/sync/session-teardown.ts
+++ b/apps/desktop/src/main/sync/session-teardown.ts
@@ -14,6 +14,8 @@ import { clearInMemoryAuthState } from '../ipc/sync-core-handlers'
 import { getDatabase, isDatabaseInitialized } from '../database/client'
 import { store } from '../store'
 import { createLogger } from '../lib/logger'
+import { disconnectGoogleCalendar } from '../calendar/google/oauth'
+import { stopGoogleCalendarSyncRunner } from '../calendar/google/sync-service'
 
 const log = createLogger('SessionTeardown')
 
@@ -47,9 +49,15 @@ async function performTeardown(reason: TeardownReason): Promise<TeardownResult> 
   const skipSync = reason === 'logout' || reason === 'integrity'
   await stopSyncRuntime({ skipFinalSync: skipSync })
   resetTokenManagerState()
+  stopGoogleCalendarSyncRunner()
 
   if (reason === 'logout') {
     await revokeServerSession()
+    try {
+      await disconnectGoogleCalendar()
+    } catch (err) {
+      log.warn('Google Calendar disconnect failed during logout', err)
+    }
   }
 
   clearInMemoryAuthState()

--- a/apps/desktop/src/main/vault/notes-versions.ts
+++ b/apps/desktop/src/main/vault/notes-versions.ts
@@ -7,11 +7,7 @@
  */
 
 import fs from 'fs/promises'
-import {
-  parseNote,
-  calculateWordCount,
-  generateContentHash
-} from './frontmatter'
+import { parseNote, calculateWordCount, generateContentHash } from './frontmatter'
 import { syncNoteToCache } from './note-sync'
 import { atomicWrite } from './file-ops'
 import {

--- a/apps/desktop/src/preload/generated-rpc.ts
+++ b/apps/desktop/src/preload/generated-rpc.ts
@@ -2,7 +2,11 @@
 
 export type { GeneratedRpcApi } from '@memry/rpc'
 import type { GeneratedRpcApi } from '@memry/rpc'
-import type { MainIpcInvokeArgs, MainIpcInvokeChannel, MainIpcInvokeResult } from '../main/ipc/generated-ipc-invoke-map'
+import type {
+  MainIpcInvokeArgs,
+  MainIpcInvokeChannel,
+  MainIpcInvokeResult
+} from '../main/ipc/generated-ipc-invoke-map'
 
 export interface GeneratedRpcDeps {
   invoke<C extends MainIpcInvokeChannel>(
@@ -20,119 +24,257 @@ export function createGeneratedRpcApi({
 }: GeneratedRpcDeps): GeneratedRpcApi {
   return {
     notes: {
-      create: ((input) => invoke("notes:create", input)) as GeneratedRpcApi["notes"]["create"],
-      get: ((id) => invoke("notes:get", id)) as GeneratedRpcApi["notes"]["get"],
-      getByPath: ((path) => invoke("notes:get-by-path", path)) as GeneratedRpcApi["notes"]["getByPath"],
-      getFile: ((id) => invoke("notes:get-file", id)) as GeneratedRpcApi["notes"]["getFile"],
-      resolveByTitle: ((title) => invoke("notes:resolve-by-title", title)) as GeneratedRpcApi["notes"]["resolveByTitle"],
-      previewByTitle: ((title) => invoke("notes:preview-by-title", title)) as GeneratedRpcApi["notes"]["previewByTitle"],
-      update: ((input) => invoke("notes:update", input)) as GeneratedRpcApi["notes"]["update"],
-      rename: ((id, newTitle) => invoke("notes:rename", { id, newTitle })) as GeneratedRpcApi["notes"]["rename"],
-      move: ((id, newFolder) => invoke("notes:move", { id, newFolder })) as GeneratedRpcApi["notes"]["move"],
-      delete: ((id) => invoke("notes:delete", id)) as GeneratedRpcApi["notes"]["delete"],
-      list: ((options) => invoke("notes:list", options ?? {})) as GeneratedRpcApi["notes"]["list"],
-      getTags: (() => invoke("notes:get-tags")) as GeneratedRpcApi["notes"]["getTags"],
-      getLinks: ((id) => invoke("notes:get-links", id)) as GeneratedRpcApi["notes"]["getLinks"],
-      getFolders: (() => invoke("notes:get-folders")) as GeneratedRpcApi["notes"]["getFolders"],
-      createFolder: ((path) => invoke("notes:create-folder", path)) as GeneratedRpcApi["notes"]["createFolder"],
-      renameFolder: ((oldPath, newPath) => invoke("notes:rename-folder", { oldPath, newPath })) as GeneratedRpcApi["notes"]["renameFolder"],
-      deleteFolder: ((path) => invoke("notes:delete-folder", path)) as GeneratedRpcApi["notes"]["deleteFolder"],
-      exists: ((titleOrPath) => invoke("notes:exists", titleOrPath)) as GeneratedRpcApi["notes"]["exists"],
-      openExternal: ((id) => invoke("notes:open-external", id)) as GeneratedRpcApi["notes"]["openExternal"],
-      revealInFinder: ((id) => invoke("notes:reveal-in-finder", id)) as GeneratedRpcApi["notes"]["revealInFinder"],
-      getPropertyDefinitions: (() => invoke("notes:get-property-definitions")) as GeneratedRpcApi["notes"]["getPropertyDefinitions"],
-      createPropertyDefinition: ((input) => invoke("notes:create-property-definition", input)) as GeneratedRpcApi["notes"]["createPropertyDefinition"],
-      updatePropertyDefinition: ((input) => invoke("notes:update-property-definition", input)) as GeneratedRpcApi["notes"]["updatePropertyDefinition"],
-      ensurePropertyDefinition: ((name, type) => invoke("notes:ensure-property-definition", { name, type })) as GeneratedRpcApi["notes"]["ensurePropertyDefinition"],
-      addPropertyOption: ((propertyName, option) => invoke("notes:add-property-option", { propertyName, option })) as GeneratedRpcApi["notes"]["addPropertyOption"],
-      addStatusOption: ((propertyName, categoryKey, option) => invoke("notes:add-status-option", { propertyName, categoryKey, option })) as GeneratedRpcApi["notes"]["addStatusOption"],
-      removePropertyOption: ((propertyName, optionValue) => invoke("notes:remove-property-option", { propertyName, optionValue })) as GeneratedRpcApi["notes"]["removePropertyOption"],
-      renamePropertyOption: ((propertyName, oldValue, newValue) => invoke("notes:rename-property-option", { propertyName, oldValue, newValue })) as GeneratedRpcApi["notes"]["renamePropertyOption"],
-      updateOptionColor: ((propertyName, optionValue, newColor) => invoke("notes:update-option-color", { propertyName, optionValue, newColor })) as GeneratedRpcApi["notes"]["updateOptionColor"],
-      deletePropertyDefinition: ((name) => invoke("notes:delete-property-definition", { name })) as GeneratedRpcApi["notes"]["deletePropertyDefinition"],
+      create: ((input) => invoke('notes:create', input)) as GeneratedRpcApi['notes']['create'],
+      get: ((id) => invoke('notes:get', id)) as GeneratedRpcApi['notes']['get'],
+      getByPath: ((path) =>
+        invoke('notes:get-by-path', path)) as GeneratedRpcApi['notes']['getByPath'],
+      getFile: ((id) => invoke('notes:get-file', id)) as GeneratedRpcApi['notes']['getFile'],
+      resolveByTitle: ((title) =>
+        invoke('notes:resolve-by-title', title)) as GeneratedRpcApi['notes']['resolveByTitle'],
+      previewByTitle: ((title) =>
+        invoke('notes:preview-by-title', title)) as GeneratedRpcApi['notes']['previewByTitle'],
+      update: ((input) => invoke('notes:update', input)) as GeneratedRpcApi['notes']['update'],
+      rename: ((id, newTitle) =>
+        invoke('notes:rename', { id, newTitle })) as GeneratedRpcApi['notes']['rename'],
+      move: ((id, newFolder) =>
+        invoke('notes:move', { id, newFolder })) as GeneratedRpcApi['notes']['move'],
+      delete: ((id) => invoke('notes:delete', id)) as GeneratedRpcApi['notes']['delete'],
+      list: ((options) => invoke('notes:list', options ?? {})) as GeneratedRpcApi['notes']['list'],
+      getTags: (() => invoke('notes:get-tags')) as GeneratedRpcApi['notes']['getTags'],
+      getLinks: ((id) => invoke('notes:get-links', id)) as GeneratedRpcApi['notes']['getLinks'],
+      getFolders: (() => invoke('notes:get-folders')) as GeneratedRpcApi['notes']['getFolders'],
+      createFolder: ((path) =>
+        invoke('notes:create-folder', path)) as GeneratedRpcApi['notes']['createFolder'],
+      renameFolder: ((oldPath, newPath) =>
+        invoke('notes:rename-folder', {
+          oldPath,
+          newPath
+        })) as GeneratedRpcApi['notes']['renameFolder'],
+      deleteFolder: ((path) =>
+        invoke('notes:delete-folder', path)) as GeneratedRpcApi['notes']['deleteFolder'],
+      exists: ((titleOrPath) =>
+        invoke('notes:exists', titleOrPath)) as GeneratedRpcApi['notes']['exists'],
+      openExternal: ((id) =>
+        invoke('notes:open-external', id)) as GeneratedRpcApi['notes']['openExternal'],
+      revealInFinder: ((id) =>
+        invoke('notes:reveal-in-finder', id)) as GeneratedRpcApi['notes']['revealInFinder'],
+      getPropertyDefinitions: (() =>
+        invoke(
+          'notes:get-property-definitions'
+        )) as GeneratedRpcApi['notes']['getPropertyDefinitions'],
+      createPropertyDefinition: ((input) =>
+        invoke(
+          'notes:create-property-definition',
+          input
+        )) as GeneratedRpcApi['notes']['createPropertyDefinition'],
+      updatePropertyDefinition: ((input) =>
+        invoke(
+          'notes:update-property-definition',
+          input
+        )) as GeneratedRpcApi['notes']['updatePropertyDefinition'],
+      ensurePropertyDefinition: ((name, type) =>
+        invoke('notes:ensure-property-definition', {
+          name,
+          type
+        })) as GeneratedRpcApi['notes']['ensurePropertyDefinition'],
+      addPropertyOption: ((propertyName, option) =>
+        invoke('notes:add-property-option', {
+          propertyName,
+          option
+        })) as GeneratedRpcApi['notes']['addPropertyOption'],
+      addStatusOption: ((propertyName, categoryKey, option) =>
+        invoke('notes:add-status-option', {
+          propertyName,
+          categoryKey,
+          option
+        })) as GeneratedRpcApi['notes']['addStatusOption'],
+      removePropertyOption: ((propertyName, optionValue) =>
+        invoke('notes:remove-property-option', {
+          propertyName,
+          optionValue
+        })) as GeneratedRpcApi['notes']['removePropertyOption'],
+      renamePropertyOption: ((propertyName, oldValue, newValue) =>
+        invoke('notes:rename-property-option', {
+          propertyName,
+          oldValue,
+          newValue
+        })) as GeneratedRpcApi['notes']['renamePropertyOption'],
+      updateOptionColor: ((propertyName, optionValue, newColor) =>
+        invoke('notes:update-option-color', {
+          propertyName,
+          optionValue,
+          newColor
+        })) as GeneratedRpcApi['notes']['updateOptionColor'],
+      deletePropertyDefinition: ((name) =>
+        invoke('notes:delete-property-definition', {
+          name
+        })) as GeneratedRpcApi['notes']['deletePropertyDefinition'],
       uploadAttachment: (async (noteId, file) =>
-        invoke("notes:upload-attachment", {
+        invoke('notes:upload-attachment', {
           noteId,
           filename: file.name,
           data: Array.from(new Uint8Array(await file.arrayBuffer()))
-        })) as GeneratedRpcApi["notes"]["uploadAttachment"],
-      listAttachments: ((noteId) => invoke("notes:list-attachments", noteId)) as GeneratedRpcApi["notes"]["listAttachments"],
-      deleteAttachment: ((noteId, filename) => invoke("notes:delete-attachment", { noteId, filename })) as GeneratedRpcApi["notes"]["deleteAttachment"],
-      getFolderConfig: ((folderPath) => invoke("notes:get-folder-config", folderPath)) as GeneratedRpcApi["notes"]["getFolderConfig"],
-      setFolderConfig: ((folderPath, config) => invoke("notes:set-folder-config", { folderPath, config })) as GeneratedRpcApi["notes"]["setFolderConfig"],
-      getFolderTemplate: ((folderPath) => invoke("notes:get-folder-template", folderPath)) as GeneratedRpcApi["notes"]["getFolderTemplate"],
-      exportPdf: ((input) => invoke("notes:export-pdf", input)) as GeneratedRpcApi["notes"]["exportPdf"],
-      exportHtml: ((input) => invoke("notes:export-html", input)) as GeneratedRpcApi["notes"]["exportHtml"],
-      getVersions: ((noteId) => invoke("notes:get-versions", noteId)) as GeneratedRpcApi["notes"]["getVersions"],
-      getVersion: ((snapshotId) => invoke("notes:get-version", snapshotId)) as GeneratedRpcApi["notes"]["getVersion"],
-      restoreVersion: ((snapshotId) => invoke("notes:restore-version", snapshotId)) as GeneratedRpcApi["notes"]["restoreVersion"],
-      deleteVersion: ((snapshotId) => invoke("notes:delete-version", snapshotId)) as GeneratedRpcApi["notes"]["deleteVersion"],
-      getPositions: ((folderPath) => invoke("notes:get-positions", { folderPath })) as GeneratedRpcApi["notes"]["getPositions"],
-      getAllPositions: (() => invoke("notes:get-all-positions")) as GeneratedRpcApi["notes"]["getAllPositions"],
-      reorder: ((folderPath, notePaths) => invoke("notes:reorder", { folderPath, notePaths })) as GeneratedRpcApi["notes"]["reorder"],
-      importFiles: ((sourcePaths, targetFolder) => invoke("notes:import-files", { sourcePaths, targetFolder })) as GeneratedRpcApi["notes"]["importFiles"],
-      showImportDialog: (() => invoke("notes:show-import-dialog")) as GeneratedRpcApi["notes"]["showImportDialog"],
-      setLocalOnly: ((id, localOnly) => invoke("notes:set-local-only", { id, localOnly })) as GeneratedRpcApi["notes"]["setLocalOnly"],
-      getLocalOnlyCount: (() => invoke("notes:get-local-only-count")) as GeneratedRpcApi["notes"]["getLocalOnlyCount"],
+        })) as GeneratedRpcApi['notes']['uploadAttachment'],
+      listAttachments: ((noteId) =>
+        invoke('notes:list-attachments', noteId)) as GeneratedRpcApi['notes']['listAttachments'],
+      deleteAttachment: ((noteId, filename) =>
+        invoke('notes:delete-attachment', {
+          noteId,
+          filename
+        })) as GeneratedRpcApi['notes']['deleteAttachment'],
+      getFolderConfig: ((folderPath) =>
+        invoke(
+          'notes:get-folder-config',
+          folderPath
+        )) as GeneratedRpcApi['notes']['getFolderConfig'],
+      setFolderConfig: ((folderPath, config) =>
+        invoke('notes:set-folder-config', {
+          folderPath,
+          config
+        })) as GeneratedRpcApi['notes']['setFolderConfig'],
+      getFolderTemplate: ((folderPath) =>
+        invoke(
+          'notes:get-folder-template',
+          folderPath
+        )) as GeneratedRpcApi['notes']['getFolderTemplate'],
+      exportPdf: ((input) =>
+        invoke('notes:export-pdf', input)) as GeneratedRpcApi['notes']['exportPdf'],
+      exportHtml: ((input) =>
+        invoke('notes:export-html', input)) as GeneratedRpcApi['notes']['exportHtml'],
+      getVersions: ((noteId) =>
+        invoke('notes:get-versions', noteId)) as GeneratedRpcApi['notes']['getVersions'],
+      getVersion: ((snapshotId) =>
+        invoke('notes:get-version', snapshotId)) as GeneratedRpcApi['notes']['getVersion'],
+      restoreVersion: ((snapshotId) =>
+        invoke('notes:restore-version', snapshotId)) as GeneratedRpcApi['notes']['restoreVersion'],
+      deleteVersion: ((snapshotId) =>
+        invoke('notes:delete-version', snapshotId)) as GeneratedRpcApi['notes']['deleteVersion'],
+      getPositions: ((folderPath) =>
+        invoke('notes:get-positions', { folderPath })) as GeneratedRpcApi['notes']['getPositions'],
+      getAllPositions: (() =>
+        invoke('notes:get-all-positions')) as GeneratedRpcApi['notes']['getAllPositions'],
+      reorder: ((folderPath, notePaths) =>
+        invoke('notes:reorder', { folderPath, notePaths })) as GeneratedRpcApi['notes']['reorder'],
+      importFiles: ((sourcePaths, targetFolder) =>
+        invoke('notes:import-files', {
+          sourcePaths,
+          targetFolder
+        })) as GeneratedRpcApi['notes']['importFiles'],
+      showImportDialog: (() =>
+        invoke('notes:show-import-dialog')) as GeneratedRpcApi['notes']['showImportDialog'],
+      setLocalOnly: ((id, localOnly) =>
+        invoke('notes:set-local-only', {
+          id,
+          localOnly
+        })) as GeneratedRpcApi['notes']['setLocalOnly'],
+      getLocalOnlyCount: (() =>
+        invoke('notes:get-local-only-count')) as GeneratedRpcApi['notes']['getLocalOnlyCount']
     },
     tasks: {
-      create: ((input) => invoke("tasks:create", input)) as GeneratedRpcApi["tasks"]["create"],
-      get: ((id) => invoke("tasks:get", id)) as GeneratedRpcApi["tasks"]["get"],
-      update: ((input) => invoke("tasks:update", input)) as GeneratedRpcApi["tasks"]["update"],
-      delete: ((id) => invoke("tasks:delete", id)) as GeneratedRpcApi["tasks"]["delete"],
-      list: ((options) => invoke("tasks:list", options ?? {})) as GeneratedRpcApi["tasks"]["list"],
-      complete: ((input) => invoke("tasks:complete", input)) as GeneratedRpcApi["tasks"]["complete"],
-      uncomplete: ((id) => invoke("tasks:uncomplete", id)) as GeneratedRpcApi["tasks"]["uncomplete"],
-      archive: ((id) => invoke("tasks:archive", id)) as GeneratedRpcApi["tasks"]["archive"],
-      unarchive: ((id) => invoke("tasks:unarchive", id)) as GeneratedRpcApi["tasks"]["unarchive"],
-      move: ((input) => invoke("tasks:move", input)) as GeneratedRpcApi["tasks"]["move"],
-      reorder: ((taskIds, positions) => invoke("tasks:reorder", { taskIds, positions })) as GeneratedRpcApi["tasks"]["reorder"],
-      duplicate: ((id) => invoke("tasks:duplicate", id)) as GeneratedRpcApi["tasks"]["duplicate"],
-      getSubtasks: ((parentId) => invoke("tasks:get-subtasks", parentId)) as GeneratedRpcApi["tasks"]["getSubtasks"],
-      convertToSubtask: ((taskId, parentId) => invoke("tasks:convert-to-subtask", { taskId, parentId })) as GeneratedRpcApi["tasks"]["convertToSubtask"],
-      convertToTask: ((taskId) => invoke("tasks:convert-to-task", taskId)) as GeneratedRpcApi["tasks"]["convertToTask"],
-      createProject: ((input) => invoke("tasks:project-create", input)) as GeneratedRpcApi["tasks"]["createProject"],
-      getProject: ((id) => invoke("tasks:project-get", id)) as GeneratedRpcApi["tasks"]["getProject"],
-      updateProject: ((input) => invoke("tasks:project-update", input)) as GeneratedRpcApi["tasks"]["updateProject"],
-      deleteProject: ((id) => invoke("tasks:project-delete", id)) as GeneratedRpcApi["tasks"]["deleteProject"],
-      listProjects: (() => invoke("tasks:project-list")) as GeneratedRpcApi["tasks"]["listProjects"],
-      archiveProject: ((id) => invoke("tasks:project-archive", id)) as GeneratedRpcApi["tasks"]["archiveProject"],
-      reorderProjects: ((projectIds, positions) => invoke("tasks:project-reorder", { projectIds, positions })) as GeneratedRpcApi["tasks"]["reorderProjects"],
-      createStatus: ((input) => invoke("tasks:status-create", input)) as GeneratedRpcApi["tasks"]["createStatus"],
-      updateStatus: ((id, updates) => invoke("tasks:status-update", { id, ...updates })) as GeneratedRpcApi["tasks"]["updateStatus"],
-      deleteStatus: ((id) => invoke("tasks:status-delete", id)) as GeneratedRpcApi["tasks"]["deleteStatus"],
-      reorderStatuses: ((statusIds, positions) => invoke("tasks:status-reorder", { statusIds, positions })) as GeneratedRpcApi["tasks"]["reorderStatuses"],
-      listStatuses: ((projectId) => invoke("tasks:status-list", projectId)) as GeneratedRpcApi["tasks"]["listStatuses"],
-      getTags: (() => invoke("tasks:get-tags")) as GeneratedRpcApi["tasks"]["getTags"],
-      bulkComplete: ((ids) => invoke("tasks:bulk-complete", { ids })) as GeneratedRpcApi["tasks"]["bulkComplete"],
-      bulkDelete: ((ids) => invoke("tasks:bulk-delete", { ids })) as GeneratedRpcApi["tasks"]["bulkDelete"],
-      bulkMove: ((ids, projectId) => invoke("tasks:bulk-move", { ids, projectId })) as GeneratedRpcApi["tasks"]["bulkMove"],
-      bulkArchive: ((ids) => invoke("tasks:bulk-archive", { ids })) as GeneratedRpcApi["tasks"]["bulkArchive"],
-      getStats: (() => invoke("tasks:get-stats")) as GeneratedRpcApi["tasks"]["getStats"],
-      getToday: (() => invoke("tasks:get-today")) as GeneratedRpcApi["tasks"]["getToday"],
-      getUpcoming: ((days) => invoke("tasks:get-upcoming", { days: days ?? 7 })) as GeneratedRpcApi["tasks"]["getUpcoming"],
-      getOverdue: (() => invoke("tasks:get-overdue")) as GeneratedRpcApi["tasks"]["getOverdue"],
-      getLinkedTasks: ((noteId) => invoke("tasks:get-linked-tasks", noteId)) as GeneratedRpcApi["tasks"]["getLinkedTasks"],
-      seedPerformanceTest: (() => invoke("tasks:seed-performance-test")) as GeneratedRpcApi["tasks"]["seedPerformanceTest"],
-      seedDemo: (() => invoke("tasks:seed-demo")) as GeneratedRpcApi["tasks"]["seedDemo"],
+      create: ((input) => invoke('tasks:create', input)) as GeneratedRpcApi['tasks']['create'],
+      get: ((id) => invoke('tasks:get', id)) as GeneratedRpcApi['tasks']['get'],
+      update: ((input) => invoke('tasks:update', input)) as GeneratedRpcApi['tasks']['update'],
+      delete: ((id) => invoke('tasks:delete', id)) as GeneratedRpcApi['tasks']['delete'],
+      list: ((options) => invoke('tasks:list', options ?? {})) as GeneratedRpcApi['tasks']['list'],
+      complete: ((input) =>
+        invoke('tasks:complete', input)) as GeneratedRpcApi['tasks']['complete'],
+      uncomplete: ((id) =>
+        invoke('tasks:uncomplete', id)) as GeneratedRpcApi['tasks']['uncomplete'],
+      archive: ((id) => invoke('tasks:archive', id)) as GeneratedRpcApi['tasks']['archive'],
+      unarchive: ((id) => invoke('tasks:unarchive', id)) as GeneratedRpcApi['tasks']['unarchive'],
+      move: ((input) => invoke('tasks:move', input)) as GeneratedRpcApi['tasks']['move'],
+      reorder: ((taskIds, positions) =>
+        invoke('tasks:reorder', { taskIds, positions })) as GeneratedRpcApi['tasks']['reorder'],
+      duplicate: ((id) => invoke('tasks:duplicate', id)) as GeneratedRpcApi['tasks']['duplicate'],
+      getSubtasks: ((parentId) =>
+        invoke('tasks:get-subtasks', parentId)) as GeneratedRpcApi['tasks']['getSubtasks'],
+      convertToSubtask: ((taskId, parentId) =>
+        invoke('tasks:convert-to-subtask', {
+          taskId,
+          parentId
+        })) as GeneratedRpcApi['tasks']['convertToSubtask'],
+      convertToTask: ((taskId) =>
+        invoke('tasks:convert-to-task', taskId)) as GeneratedRpcApi['tasks']['convertToTask'],
+      createProject: ((input) =>
+        invoke('tasks:project-create', input)) as GeneratedRpcApi['tasks']['createProject'],
+      getProject: ((id) =>
+        invoke('tasks:project-get', id)) as GeneratedRpcApi['tasks']['getProject'],
+      updateProject: ((input) =>
+        invoke('tasks:project-update', input)) as GeneratedRpcApi['tasks']['updateProject'],
+      deleteProject: ((id) =>
+        invoke('tasks:project-delete', id)) as GeneratedRpcApi['tasks']['deleteProject'],
+      listProjects: (() =>
+        invoke('tasks:project-list')) as GeneratedRpcApi['tasks']['listProjects'],
+      archiveProject: ((id) =>
+        invoke('tasks:project-archive', id)) as GeneratedRpcApi['tasks']['archiveProject'],
+      reorderProjects: ((projectIds, positions) =>
+        invoke('tasks:project-reorder', {
+          projectIds,
+          positions
+        })) as GeneratedRpcApi['tasks']['reorderProjects'],
+      createStatus: ((input) =>
+        invoke('tasks:status-create', input)) as GeneratedRpcApi['tasks']['createStatus'],
+      updateStatus: ((id, updates) =>
+        invoke('tasks:status-update', {
+          id,
+          ...updates
+        })) as GeneratedRpcApi['tasks']['updateStatus'],
+      deleteStatus: ((id) =>
+        invoke('tasks:status-delete', id)) as GeneratedRpcApi['tasks']['deleteStatus'],
+      reorderStatuses: ((statusIds, positions) =>
+        invoke('tasks:status-reorder', {
+          statusIds,
+          positions
+        })) as GeneratedRpcApi['tasks']['reorderStatuses'],
+      listStatuses: ((projectId) =>
+        invoke('tasks:status-list', projectId)) as GeneratedRpcApi['tasks']['listStatuses'],
+      getTags: (() => invoke('tasks:get-tags')) as GeneratedRpcApi['tasks']['getTags'],
+      bulkComplete: ((ids) =>
+        invoke('tasks:bulk-complete', { ids })) as GeneratedRpcApi['tasks']['bulkComplete'],
+      bulkDelete: ((ids) =>
+        invoke('tasks:bulk-delete', { ids })) as GeneratedRpcApi['tasks']['bulkDelete'],
+      bulkMove: ((ids, projectId) =>
+        invoke('tasks:bulk-move', { ids, projectId })) as GeneratedRpcApi['tasks']['bulkMove'],
+      bulkArchive: ((ids) =>
+        invoke('tasks:bulk-archive', { ids })) as GeneratedRpcApi['tasks']['bulkArchive'],
+      getStats: (() => invoke('tasks:get-stats')) as GeneratedRpcApi['tasks']['getStats'],
+      getToday: (() => invoke('tasks:get-today')) as GeneratedRpcApi['tasks']['getToday'],
+      getUpcoming: ((days) =>
+        invoke('tasks:get-upcoming', {
+          days: days ?? 7
+        })) as GeneratedRpcApi['tasks']['getUpcoming'],
+      getOverdue: (() => invoke('tasks:get-overdue')) as GeneratedRpcApi['tasks']['getOverdue'],
+      getLinkedTasks: ((noteId) =>
+        invoke('tasks:get-linked-tasks', noteId)) as GeneratedRpcApi['tasks']['getLinkedTasks'],
+      seedPerformanceTest: (() =>
+        invoke('tasks:seed-performance-test')) as GeneratedRpcApi['tasks']['seedPerformanceTest'],
+      seedDemo: (() => invoke('tasks:seed-demo')) as GeneratedRpcApi['tasks']['seedDemo']
     },
     inbox: {
-      captureText: ((input) => invoke("inbox:capture-text", input)) as GeneratedRpcApi["inbox"]["captureText"],
-      captureLink: ((input) => invoke("inbox:capture-link", input)) as GeneratedRpcApi["inbox"]["captureLink"],
-      previewLink: ((url) => invoke("inbox:preview-link", url)) as GeneratedRpcApi["inbox"]["previewLink"],
-      captureImage: ((input) => invoke("inbox:capture-image", input)) as GeneratedRpcApi["inbox"]["captureImage"],
-      captureVoice: ((input) => invoke("inbox:capture-voice", input)) as GeneratedRpcApi["inbox"]["captureVoice"],
-      captureClip: ((input) => invoke("inbox:capture-clip", input)) as GeneratedRpcApi["inbox"]["captureClip"],
-      capturePdf: ((input) => invoke("inbox:capture-pdf", input)) as GeneratedRpcApi["inbox"]["capturePdf"],
-      get: ((id) => invoke("inbox:get", id)) as GeneratedRpcApi["inbox"]["get"],
-      list: ((options) => invoke("inbox:list", options ?? {})) as GeneratedRpcApi["inbox"]["list"],
-      update: ((input) => invoke("inbox:update", input)) as GeneratedRpcApi["inbox"]["update"],
-      archive: ((id) => invoke("inbox:archive", id)) as GeneratedRpcApi["inbox"]["archive"],
-      file: ((input) => invoke("inbox:file", input)) as GeneratedRpcApi["inbox"]["file"],
-      getSuggestions: ((itemId) => invoke("inbox:get-suggestions", itemId)) as GeneratedRpcApi["inbox"]["getSuggestions"],
+      captureText: ((input) =>
+        invoke('inbox:capture-text', input)) as GeneratedRpcApi['inbox']['captureText'],
+      captureLink: ((input) =>
+        invoke('inbox:capture-link', input)) as GeneratedRpcApi['inbox']['captureLink'],
+      previewLink: ((url) =>
+        invoke('inbox:preview-link', url)) as GeneratedRpcApi['inbox']['previewLink'],
+      captureImage: ((input) =>
+        invoke('inbox:capture-image', input)) as GeneratedRpcApi['inbox']['captureImage'],
+      captureVoice: ((input) =>
+        invoke('inbox:capture-voice', input)) as GeneratedRpcApi['inbox']['captureVoice'],
+      captureClip: ((input) =>
+        invoke('inbox:capture-clip', input)) as GeneratedRpcApi['inbox']['captureClip'],
+      capturePdf: ((input) =>
+        invoke('inbox:capture-pdf', input)) as GeneratedRpcApi['inbox']['capturePdf'],
+      get: ((id) => invoke('inbox:get', id)) as GeneratedRpcApi['inbox']['get'],
+      list: ((options) => invoke('inbox:list', options ?? {})) as GeneratedRpcApi['inbox']['list'],
+      update: ((input) => invoke('inbox:update', input)) as GeneratedRpcApi['inbox']['update'],
+      archive: ((id) => invoke('inbox:archive', id)) as GeneratedRpcApi['inbox']['archive'],
+      file: ((input) => invoke('inbox:file', input)) as GeneratedRpcApi['inbox']['file'],
+      getSuggestions: ((itemId) =>
+        invoke('inbox:get-suggestions', itemId)) as GeneratedRpcApi['inbox']['getSuggestions'],
       trackSuggestion: ((input) =>
         invoke(
-          "inbox:track-suggestion",
+          'inbox:track-suggestion',
           input.itemId,
           input.itemType,
           input.suggestedTo,
@@ -140,59 +282,133 @@ export function createGeneratedRpcApi({
           input.confidence,
           input.suggestedTags ?? [],
           input.actualTags ?? []
-        )) as GeneratedRpcApi["inbox"]["trackSuggestion"],
-      convertToNote: ((itemId) => invoke("inbox:convert-to-note", itemId)) as GeneratedRpcApi["inbox"]["convertToNote"],
-      convertToTask: ((itemId) => invoke("inbox:convert-to-task", itemId)) as GeneratedRpcApi["inbox"]["convertToTask"],
-      linkToNote: ((itemId, noteId, tags) => invoke("inbox:link-to-note", itemId, noteId, tags ?? [])) as GeneratedRpcApi["inbox"]["linkToNote"],
-      addTag: ((itemId, tag) => invoke("inbox:add-tag", itemId, tag)) as GeneratedRpcApi["inbox"]["addTag"],
-      removeTag: ((itemId, tag) => invoke("inbox:remove-tag", itemId, tag)) as GeneratedRpcApi["inbox"]["removeTag"],
-      getTags: (() => invoke("inbox:get-tags")) as GeneratedRpcApi["inbox"]["getTags"],
-      snooze: ((input) => invoke("inbox:snooze", input)) as GeneratedRpcApi["inbox"]["snooze"],
-      unsnooze: ((itemId) => invoke("inbox:unsnooze", itemId)) as GeneratedRpcApi["inbox"]["unsnooze"],
-      getSnoozed: (() => invoke("inbox:get-snoozed")) as GeneratedRpcApi["inbox"]["getSnoozed"],
-      markViewed: ((itemId) => invoke("inbox:mark-viewed", itemId)) as GeneratedRpcApi["inbox"]["markViewed"],
-      bulkFile: ((input) => invoke("inbox:bulk-file", input)) as GeneratedRpcApi["inbox"]["bulkFile"],
-      bulkArchive: ((input) => invoke("inbox:bulk-archive", input)) as GeneratedRpcApi["inbox"]["bulkArchive"],
-      bulkTag: ((input) => invoke("inbox:bulk-tag", input)) as GeneratedRpcApi["inbox"]["bulkTag"],
-      bulkSnooze: ((input) => invoke("inbox:bulk-snooze", input)) as GeneratedRpcApi["inbox"]["bulkSnooze"],
-      fileAllStale: (() => invoke("inbox:file-all-stale")) as GeneratedRpcApi["inbox"]["fileAllStale"],
-      retryTranscription: ((itemId) => invoke("inbox:retry-transcription", itemId)) as GeneratedRpcApi["inbox"]["retryTranscription"],
-      retryMetadata: ((itemId) => invoke("inbox:retry-metadata", itemId)) as GeneratedRpcApi["inbox"]["retryMetadata"],
-      getStats: (() => invoke("inbox:get-stats")) as GeneratedRpcApi["inbox"]["getStats"],
-      getJobs: ((options) => invoke("inbox:get-jobs", options ?? {})) as GeneratedRpcApi["inbox"]["getJobs"],
-      getPatterns: (() => invoke("inbox:get-patterns")) as GeneratedRpcApi["inbox"]["getPatterns"],
-      getStaleThreshold: (() => invoke("inbox:get-stale-threshold")) as GeneratedRpcApi["inbox"]["getStaleThreshold"],
-      setStaleThreshold: ((days) => invoke("inbox:set-stale-threshold", days)) as GeneratedRpcApi["inbox"]["setStaleThreshold"],
-      listArchived: ((options) => invoke("inbox:list-archived", options ?? {})) as GeneratedRpcApi["inbox"]["listArchived"],
-      unarchive: ((id) => invoke("inbox:unarchive", id)) as GeneratedRpcApi["inbox"]["unarchive"],
-      deletePermanent: ((id) => invoke("inbox:delete-permanent", id)) as GeneratedRpcApi["inbox"]["deletePermanent"],
-      getFilingHistory: ((options) => invoke("inbox:get-filing-history", options ?? {})) as GeneratedRpcApi["inbox"]["getFilingHistory"],
-      undoFile: ((id) => invoke("inbox:undo-file", id)) as GeneratedRpcApi["inbox"]["undoFile"],
-      undoArchive: ((id) => invoke("inbox:undo-archive", id)) as GeneratedRpcApi["inbox"]["undoArchive"],
+        )) as GeneratedRpcApi['inbox']['trackSuggestion'],
+      convertToNote: ((itemId) =>
+        invoke('inbox:convert-to-note', itemId)) as GeneratedRpcApi['inbox']['convertToNote'],
+      convertToTask: ((itemId) =>
+        invoke('inbox:convert-to-task', itemId)) as GeneratedRpcApi['inbox']['convertToTask'],
+      linkToNote: ((itemId, noteId, tags) =>
+        invoke(
+          'inbox:link-to-note',
+          itemId,
+          noteId,
+          tags ?? []
+        )) as GeneratedRpcApi['inbox']['linkToNote'],
+      addTag: ((itemId, tag) =>
+        invoke('inbox:add-tag', itemId, tag)) as GeneratedRpcApi['inbox']['addTag'],
+      removeTag: ((itemId, tag) =>
+        invoke('inbox:remove-tag', itemId, tag)) as GeneratedRpcApi['inbox']['removeTag'],
+      getTags: (() => invoke('inbox:get-tags')) as GeneratedRpcApi['inbox']['getTags'],
+      snooze: ((input) => invoke('inbox:snooze', input)) as GeneratedRpcApi['inbox']['snooze'],
+      unsnooze: ((itemId) =>
+        invoke('inbox:unsnooze', itemId)) as GeneratedRpcApi['inbox']['unsnooze'],
+      getSnoozed: (() => invoke('inbox:get-snoozed')) as GeneratedRpcApi['inbox']['getSnoozed'],
+      markViewed: ((itemId) =>
+        invoke('inbox:mark-viewed', itemId)) as GeneratedRpcApi['inbox']['markViewed'],
+      bulkFile: ((input) =>
+        invoke('inbox:bulk-file', input)) as GeneratedRpcApi['inbox']['bulkFile'],
+      bulkArchive: ((input) =>
+        invoke('inbox:bulk-archive', input)) as GeneratedRpcApi['inbox']['bulkArchive'],
+      bulkTag: ((input) => invoke('inbox:bulk-tag', input)) as GeneratedRpcApi['inbox']['bulkTag'],
+      bulkSnooze: ((input) =>
+        invoke('inbox:bulk-snooze', input)) as GeneratedRpcApi['inbox']['bulkSnooze'],
+      fileAllStale: (() =>
+        invoke('inbox:file-all-stale')) as GeneratedRpcApi['inbox']['fileAllStale'],
+      retryTranscription: ((itemId) =>
+        invoke(
+          'inbox:retry-transcription',
+          itemId
+        )) as GeneratedRpcApi['inbox']['retryTranscription'],
+      retryMetadata: ((itemId) =>
+        invoke('inbox:retry-metadata', itemId)) as GeneratedRpcApi['inbox']['retryMetadata'],
+      getStats: (() => invoke('inbox:get-stats')) as GeneratedRpcApi['inbox']['getStats'],
+      getJobs: ((options) =>
+        invoke('inbox:get-jobs', options ?? {})) as GeneratedRpcApi['inbox']['getJobs'],
+      getPatterns: (() => invoke('inbox:get-patterns')) as GeneratedRpcApi['inbox']['getPatterns'],
+      getStaleThreshold: (() =>
+        invoke('inbox:get-stale-threshold')) as GeneratedRpcApi['inbox']['getStaleThreshold'],
+      setStaleThreshold: ((days) =>
+        invoke('inbox:set-stale-threshold', days)) as GeneratedRpcApi['inbox']['setStaleThreshold'],
+      listArchived: ((options) =>
+        invoke('inbox:list-archived', options ?? {})) as GeneratedRpcApi['inbox']['listArchived'],
+      unarchive: ((id) => invoke('inbox:unarchive', id)) as GeneratedRpcApi['inbox']['unarchive'],
+      deletePermanent: ((id) =>
+        invoke('inbox:delete-permanent', id)) as GeneratedRpcApi['inbox']['deletePermanent'],
+      getFilingHistory: ((options) =>
+        invoke(
+          'inbox:get-filing-history',
+          options ?? {}
+        )) as GeneratedRpcApi['inbox']['getFilingHistory'],
+      undoFile: ((id) => invoke('inbox:undo-file', id)) as GeneratedRpcApi['inbox']['undoFile'],
+      undoArchive: ((id) =>
+        invoke('inbox:undo-archive', id)) as GeneratedRpcApi['inbox']['undoArchive']
     },
     settings: {
-      get: ((key) => invoke("settings:get", key)) as GeneratedRpcApi["settings"]["get"],
-      set: ((key, value) => invoke("settings:set", { key, value })) as GeneratedRpcApi["settings"]["set"],
-      getJournalSettings: (() => invoke("settings:getJournalSettings")) as GeneratedRpcApi["settings"]["getJournalSettings"],
-      setJournalSettings: ((settings) => invoke("settings:setJournalSettings", settings)) as GeneratedRpcApi["settings"]["setJournalSettings"],
-      getAISettings: (() => invoke("settings:getAISettings")) as GeneratedRpcApi["settings"]["getAISettings"],
-      setAISettings: ((settings) => invoke("settings:setAISettings", settings)) as GeneratedRpcApi["settings"]["setAISettings"],
-      getVoiceTranscriptionSettings: (() => invoke("settings:getVoiceTranscriptionSettings")) as GeneratedRpcApi["settings"]["getVoiceTranscriptionSettings"],
-      setVoiceTranscriptionSettings: ((settings) => invoke("settings:setVoiceTranscriptionSettings", settings)) as GeneratedRpcApi["settings"]["setVoiceTranscriptionSettings"],
-      getVoiceModelStatus: (() => invoke("settings:getVoiceModelStatus")) as GeneratedRpcApi["settings"]["getVoiceModelStatus"],
-      downloadVoiceModel: (() => invoke("settings:downloadVoiceModel")) as GeneratedRpcApi["settings"]["downloadVoiceModel"],
-      getVoiceRecordingReadiness: (() => invoke("settings:getVoiceRecordingReadiness")) as GeneratedRpcApi["settings"]["getVoiceRecordingReadiness"],
-      getVoiceTranscriptionOpenAIKeyStatus: (() => invoke("settings:getVoiceTranscriptionOpenAIKeyStatus")) as GeneratedRpcApi["settings"]["getVoiceTranscriptionOpenAIKeyStatus"],
-      setVoiceTranscriptionOpenAIKey: ((apiKey) => invoke("settings:setVoiceTranscriptionOpenAIKey", { apiKey })) as GeneratedRpcApi["settings"]["setVoiceTranscriptionOpenAIKey"],
-      getAIModelStatus: (() => invoke("settings:getAIModelStatus")) as GeneratedRpcApi["settings"]["getAIModelStatus"],
-      loadAIModel: (() => invoke("settings:loadAIModel")) as GeneratedRpcApi["settings"]["loadAIModel"],
-      reindexEmbeddings: (() => invoke("settings:reindexEmbeddings")) as GeneratedRpcApi["settings"]["reindexEmbeddings"],
-      getTabSettings: (() => invoke("settings:getTabSettings")) as GeneratedRpcApi["settings"]["getTabSettings"],
-      setTabSettings: ((settings) => invoke("settings:setTabSettings", settings)) as GeneratedRpcApi["settings"]["setTabSettings"],
-      getNoteEditorSettings: (() => invoke("settings:getNoteEditorSettings")) as GeneratedRpcApi["settings"]["getNoteEditorSettings"],
-      setNoteEditorSettings: ((settings) => invoke("settings:setNoteEditorSettings", settings)) as GeneratedRpcApi["settings"]["setNoteEditorSettings"],
+      get: ((key) => invoke('settings:get', key)) as GeneratedRpcApi['settings']['get'],
+      set: ((key, value) =>
+        invoke('settings:set', { key, value })) as GeneratedRpcApi['settings']['set'],
+      getJournalSettings: (() =>
+        invoke('settings:getJournalSettings')) as GeneratedRpcApi['settings']['getJournalSettings'],
+      setJournalSettings: ((settings) =>
+        invoke(
+          'settings:setJournalSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setJournalSettings'],
+      getAISettings: (() =>
+        invoke('settings:getAISettings')) as GeneratedRpcApi['settings']['getAISettings'],
+      setAISettings: ((settings) =>
+        invoke('settings:setAISettings', settings)) as GeneratedRpcApi['settings']['setAISettings'],
+      getVoiceTranscriptionSettings: (() =>
+        invoke(
+          'settings:getVoiceTranscriptionSettings'
+        )) as GeneratedRpcApi['settings']['getVoiceTranscriptionSettings'],
+      setVoiceTranscriptionSettings: ((settings) =>
+        invoke(
+          'settings:setVoiceTranscriptionSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setVoiceTranscriptionSettings'],
+      getVoiceModelStatus: (() =>
+        invoke(
+          'settings:getVoiceModelStatus'
+        )) as GeneratedRpcApi['settings']['getVoiceModelStatus'],
+      downloadVoiceModel: (() =>
+        invoke('settings:downloadVoiceModel')) as GeneratedRpcApi['settings']['downloadVoiceModel'],
+      getVoiceRecordingReadiness: (() =>
+        invoke(
+          'settings:getVoiceRecordingReadiness'
+        )) as GeneratedRpcApi['settings']['getVoiceRecordingReadiness'],
+      getVoiceTranscriptionOpenAIKeyStatus: (() =>
+        invoke(
+          'settings:getVoiceTranscriptionOpenAIKeyStatus'
+        )) as GeneratedRpcApi['settings']['getVoiceTranscriptionOpenAIKeyStatus'],
+      setVoiceTranscriptionOpenAIKey: ((apiKey) =>
+        invoke('settings:setVoiceTranscriptionOpenAIKey', {
+          apiKey
+        })) as GeneratedRpcApi['settings']['setVoiceTranscriptionOpenAIKey'],
+      getAIModelStatus: (() =>
+        invoke('settings:getAIModelStatus')) as GeneratedRpcApi['settings']['getAIModelStatus'],
+      loadAIModel: (() =>
+        invoke('settings:loadAIModel')) as GeneratedRpcApi['settings']['loadAIModel'],
+      reindexEmbeddings: (() =>
+        invoke('settings:reindexEmbeddings')) as GeneratedRpcApi['settings']['reindexEmbeddings'],
+      getTabSettings: (() =>
+        invoke('settings:getTabSettings')) as GeneratedRpcApi['settings']['getTabSettings'],
+      setTabSettings: ((settings) =>
+        invoke(
+          'settings:setTabSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setTabSettings'],
+      getNoteEditorSettings: (() =>
+        invoke(
+          'settings:getNoteEditorSettings'
+        )) as GeneratedRpcApi['settings']['getNoteEditorSettings'],
+      setNoteEditorSettings: ((settings) =>
+        invoke(
+          'settings:setNoteEditorSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setNoteEditorSettings'],
       getStartupThemeSync: (() => {
-        const raw = invokeSync("settings:getStartupThemeSync") as
+        const raw = invokeSync('settings:getStartupThemeSync') as
           | 'light'
           | 'dark'
           | 'white'
@@ -200,68 +416,180 @@ export function createGeneratedRpcApi({
           | { theme?: 'light' | 'dark' | 'white' | 'system' }
           | null
           | undefined
-        return typeof raw === 'string' ? raw : raw?.theme ?? 'system'
-      }) as GeneratedRpcApi["settings"]["getStartupThemeSync"],
-      getGeneralSettings: (() => invoke("settings:getGeneralSettings")) as GeneratedRpcApi["settings"]["getGeneralSettings"],
-      setGeneralSettings: ((settings) => invoke("settings:setGeneralSettings", settings)) as GeneratedRpcApi["settings"]["setGeneralSettings"],
-      getEditorSettings: (() => invoke("settings:getEditorSettings")) as GeneratedRpcApi["settings"]["getEditorSettings"],
-      setEditorSettings: ((settings) => invoke("settings:setEditorSettings", settings)) as GeneratedRpcApi["settings"]["setEditorSettings"],
-      getTaskSettings: (() => invoke("settings:getTaskSettings")) as GeneratedRpcApi["settings"]["getTaskSettings"],
-      setTaskSettings: ((settings) => invoke("settings:setTaskSettings", settings)) as GeneratedRpcApi["settings"]["setTaskSettings"],
-      getKeyboardSettings: (() => invoke("settings:getKeyboardSettings")) as GeneratedRpcApi["settings"]["getKeyboardSettings"],
-      setKeyboardSettings: ((settings) => invoke("settings:setKeyboardSettings", settings)) as GeneratedRpcApi["settings"]["setKeyboardSettings"],
-      resetKeyboardSettings: (() => invoke("settings:resetKeyboardSettings")) as GeneratedRpcApi["settings"]["resetKeyboardSettings"],
-      getSyncSettings: (() => invoke("settings:getSyncSettings")) as GeneratedRpcApi["settings"]["getSyncSettings"],
-      setSyncSettings: ((settings) => invoke("settings:setSyncSettings", settings)) as GeneratedRpcApi["settings"]["setSyncSettings"],
-      getBackupSettings: (() => invoke("settings:getBackupSettings")) as GeneratedRpcApi["settings"]["getBackupSettings"],
-      setBackupSettings: ((settings) => invoke("settings:setBackupSettings", settings)) as GeneratedRpcApi["settings"]["setBackupSettings"],
-      getGraphSettings: (() => invoke("settings:getGraphSettings")) as GeneratedRpcApi["settings"]["getGraphSettings"],
-      setGraphSettings: ((settings) => invoke("settings:setGraphSettings", settings)) as GeneratedRpcApi["settings"]["setGraphSettings"],
-      registerGlobalCapture: (() => invoke("settings:registerGlobalCapture")) as GeneratedRpcApi["settings"]["registerGlobalCapture"],
+        return typeof raw === 'string' ? raw : (raw?.theme ?? 'system')
+      }) as GeneratedRpcApi['settings']['getStartupThemeSync'],
+      getGeneralSettings: (() =>
+        invoke('settings:getGeneralSettings')) as GeneratedRpcApi['settings']['getGeneralSettings'],
+      setGeneralSettings: ((settings) =>
+        invoke(
+          'settings:setGeneralSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setGeneralSettings'],
+      getEditorSettings: (() =>
+        invoke('settings:getEditorSettings')) as GeneratedRpcApi['settings']['getEditorSettings'],
+      setEditorSettings: ((settings) =>
+        invoke(
+          'settings:setEditorSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setEditorSettings'],
+      getTaskSettings: (() =>
+        invoke('settings:getTaskSettings')) as GeneratedRpcApi['settings']['getTaskSettings'],
+      setTaskSettings: ((settings) =>
+        invoke(
+          'settings:setTaskSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setTaskSettings'],
+      getKeyboardSettings: (() =>
+        invoke(
+          'settings:getKeyboardSettings'
+        )) as GeneratedRpcApi['settings']['getKeyboardSettings'],
+      setKeyboardSettings: ((settings) =>
+        invoke(
+          'settings:setKeyboardSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setKeyboardSettings'],
+      resetKeyboardSettings: (() =>
+        invoke(
+          'settings:resetKeyboardSettings'
+        )) as GeneratedRpcApi['settings']['resetKeyboardSettings'],
+      getSyncSettings: (() =>
+        invoke('settings:getSyncSettings')) as GeneratedRpcApi['settings']['getSyncSettings'],
+      setSyncSettings: ((settings) =>
+        invoke(
+          'settings:setSyncSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setSyncSettings'],
+      getBackupSettings: (() =>
+        invoke('settings:getBackupSettings')) as GeneratedRpcApi['settings']['getBackupSettings'],
+      setBackupSettings: ((settings) =>
+        invoke(
+          'settings:setBackupSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setBackupSettings'],
+      getGraphSettings: (() =>
+        invoke('settings:getGraphSettings')) as GeneratedRpcApi['settings']['getGraphSettings'],
+      setGraphSettings: ((settings) =>
+        invoke(
+          'settings:setGraphSettings',
+          settings
+        )) as GeneratedRpcApi['settings']['setGraphSettings'],
+      registerGlobalCapture: (() =>
+        invoke(
+          'settings:registerGlobalCapture'
+        )) as GeneratedRpcApi['settings']['registerGlobalCapture']
     },
     calendar: {
-      createEvent: ((input) => invoke("calendar:create-event", input)) as GeneratedRpcApi["calendar"]["createEvent"],
-      getEvent: ((id) => invoke("calendar:get-event", id)) as GeneratedRpcApi["calendar"]["getEvent"],
-      updateEvent: ((input) => invoke("calendar:update-event", input)) as GeneratedRpcApi["calendar"]["updateEvent"],
-      deleteEvent: ((id) => invoke("calendar:delete-event", id)) as GeneratedRpcApi["calendar"]["deleteEvent"],
-      listEvents: ((options) => invoke("calendar:list-events", options ?? {})) as GeneratedRpcApi["calendar"]["listEvents"],
-      getRange: ((input) => invoke("calendar:get-range", input)) as GeneratedRpcApi["calendar"]["getRange"],
-      listSources: ((options) => invoke("calendar:list-sources", options ?? {})) as GeneratedRpcApi["calendar"]["listSources"],
-      updateSourceSelection: ((input) => invoke("calendar:update-source-selection", input)) as GeneratedRpcApi["calendar"]["updateSourceSelection"],
-      getProviderStatus: ((input) => invoke("calendar:get-provider-status", input)) as GeneratedRpcApi["calendar"]["getProviderStatus"],
-      connectProvider: ((input) => invoke("calendar:connect-provider", input)) as GeneratedRpcApi["calendar"]["connectProvider"],
-      disconnectProvider: ((input) => invoke("calendar:disconnect-provider", input)) as GeneratedRpcApi["calendar"]["disconnectProvider"],
-      refreshProvider: ((input) => invoke("calendar:refresh-provider", input)) as GeneratedRpcApi["calendar"]["refreshProvider"],
+      createEvent: ((input) =>
+        invoke('calendar:create-event', input)) as GeneratedRpcApi['calendar']['createEvent'],
+      getEvent: ((id) =>
+        invoke('calendar:get-event', id)) as GeneratedRpcApi['calendar']['getEvent'],
+      updateEvent: ((input) =>
+        invoke('calendar:update-event', input)) as GeneratedRpcApi['calendar']['updateEvent'],
+      deleteEvent: ((id) =>
+        invoke('calendar:delete-event', id)) as GeneratedRpcApi['calendar']['deleteEvent'],
+      listEvents: ((options) =>
+        invoke('calendar:list-events', options ?? {})) as GeneratedRpcApi['calendar']['listEvents'],
+      getRange: ((input) =>
+        invoke('calendar:get-range', input)) as GeneratedRpcApi['calendar']['getRange'],
+      listSources: ((options) =>
+        invoke(
+          'calendar:list-sources',
+          options ?? {}
+        )) as GeneratedRpcApi['calendar']['listSources'],
+      updateSourceSelection: ((input) =>
+        invoke(
+          'calendar:update-source-selection',
+          input
+        )) as GeneratedRpcApi['calendar']['updateSourceSelection'],
+      getProviderStatus: ((input) =>
+        invoke(
+          'calendar:get-provider-status',
+          input
+        )) as GeneratedRpcApi['calendar']['getProviderStatus'],
+      connectProvider: ((input) =>
+        invoke(
+          'calendar:connect-provider',
+          input
+        )) as GeneratedRpcApi['calendar']['connectProvider'],
+      disconnectProvider: ((input) =>
+        invoke(
+          'calendar:disconnect-provider',
+          input
+        )) as GeneratedRpcApi['calendar']['disconnectProvider'],
+      refreshProvider: ((input) =>
+        invoke(
+          'calendar:refresh-provider',
+          input
+        )) as GeneratedRpcApi['calendar']['refreshProvider']
     },
-    onNoteCreated: ((callback) => subscribe("notes:created", callback)) as GeneratedRpcApi["onNoteCreated"],
-    onNoteUpdated: ((callback) => subscribe("notes:updated", callback)) as GeneratedRpcApi["onNoteUpdated"],
-    onNoteDeleted: ((callback) => subscribe("notes:deleted", callback)) as GeneratedRpcApi["onNoteDeleted"],
-    onNoteRenamed: ((callback) => subscribe("notes:renamed", callback)) as GeneratedRpcApi["onNoteRenamed"],
-    onNoteMoved: ((callback) => subscribe("notes:moved", callback)) as GeneratedRpcApi["onNoteMoved"],
-    onNoteExternalChange: ((callback) => subscribe("notes:external-change", callback)) as GeneratedRpcApi["onNoteExternalChange"],
-    onTagsChanged: ((callback) => subscribe("notes:tags-changed", callback)) as GeneratedRpcApi["onTagsChanged"],
-    onFolderConfigUpdated: ((callback) => subscribe("notes:folder-config-updated", callback)) as GeneratedRpcApi["onFolderConfigUpdated"],
-    onTaskCreated: ((callback) => subscribe("tasks:created", callback)) as GeneratedRpcApi["onTaskCreated"],
-    onTaskUpdated: ((callback) => subscribe("tasks:updated", callback)) as GeneratedRpcApi["onTaskUpdated"],
-    onTaskDeleted: ((callback) => subscribe("tasks:deleted", callback)) as GeneratedRpcApi["onTaskDeleted"],
-    onTaskCompleted: ((callback) => subscribe("tasks:completed", callback)) as GeneratedRpcApi["onTaskCompleted"],
-    onTaskMoved: ((callback) => subscribe("tasks:moved", callback)) as GeneratedRpcApi["onTaskMoved"],
-    onProjectCreated: ((callback) => subscribe("tasks:project-created", callback)) as GeneratedRpcApi["onProjectCreated"],
-    onProjectUpdated: ((callback) => subscribe("tasks:project-updated", callback)) as GeneratedRpcApi["onProjectUpdated"],
-    onProjectDeleted: ((callback) => subscribe("tasks:project-deleted", callback)) as GeneratedRpcApi["onProjectDeleted"],
-    onInboxCaptured: ((callback) => subscribe("inbox:captured", callback)) as GeneratedRpcApi["onInboxCaptured"],
-    onInboxUpdated: ((callback) => subscribe("inbox:updated", callback)) as GeneratedRpcApi["onInboxUpdated"],
-    onInboxArchived: ((callback) => subscribe("inbox:archived", callback)) as GeneratedRpcApi["onInboxArchived"],
-    onInboxFiled: ((callback) => subscribe("inbox:filed", callback)) as GeneratedRpcApi["onInboxFiled"],
-    onInboxSnoozed: ((callback) => subscribe("inbox:snoozed", callback)) as GeneratedRpcApi["onInboxSnoozed"],
-    onInboxSnoozeDue: ((callback) => subscribe("inbox:snooze-due", callback)) as GeneratedRpcApi["onInboxSnoozeDue"],
-    onInboxTranscriptionComplete: ((callback) => subscribe("inbox:transcription-complete", callback)) as GeneratedRpcApi["onInboxTranscriptionComplete"],
-    onInboxMetadataComplete: ((callback) => subscribe("inbox:metadata-complete", callback)) as GeneratedRpcApi["onInboxMetadataComplete"],
-    onInboxProcessingError: ((callback) => subscribe("inbox:processing-error", callback)) as GeneratedRpcApi["onInboxProcessingError"],
-    onSettingsChanged: ((callback) => subscribe("settings:changed", callback)) as GeneratedRpcApi["onSettingsChanged"],
-    onEmbeddingProgress: ((callback) => subscribe("settings:embeddingProgress", callback)) as GeneratedRpcApi["onEmbeddingProgress"],
-    onVoiceModelProgress: ((callback) => subscribe("settings:voiceModelProgress", callback)) as GeneratedRpcApi["onVoiceModelProgress"],
-    onSettingsOpenRequested: ((callback) => subscribe("settings:openSection", callback)) as GeneratedRpcApi["onSettingsOpenRequested"],
-    onCalendarChanged: ((callback) => subscribe("calendar:changed", callback)) as GeneratedRpcApi["onCalendarChanged"],
+    onNoteCreated: ((callback) =>
+      subscribe('notes:created', callback)) as GeneratedRpcApi['onNoteCreated'],
+    onNoteUpdated: ((callback) =>
+      subscribe('notes:updated', callback)) as GeneratedRpcApi['onNoteUpdated'],
+    onNoteDeleted: ((callback) =>
+      subscribe('notes:deleted', callback)) as GeneratedRpcApi['onNoteDeleted'],
+    onNoteRenamed: ((callback) =>
+      subscribe('notes:renamed', callback)) as GeneratedRpcApi['onNoteRenamed'],
+    onNoteMoved: ((callback) =>
+      subscribe('notes:moved', callback)) as GeneratedRpcApi['onNoteMoved'],
+    onNoteExternalChange: ((callback) =>
+      subscribe('notes:external-change', callback)) as GeneratedRpcApi['onNoteExternalChange'],
+    onTagsChanged: ((callback) =>
+      subscribe('notes:tags-changed', callback)) as GeneratedRpcApi['onTagsChanged'],
+    onFolderConfigUpdated: ((callback) =>
+      subscribe(
+        'notes:folder-config-updated',
+        callback
+      )) as GeneratedRpcApi['onFolderConfigUpdated'],
+    onTaskCreated: ((callback) =>
+      subscribe('tasks:created', callback)) as GeneratedRpcApi['onTaskCreated'],
+    onTaskUpdated: ((callback) =>
+      subscribe('tasks:updated', callback)) as GeneratedRpcApi['onTaskUpdated'],
+    onTaskDeleted: ((callback) =>
+      subscribe('tasks:deleted', callback)) as GeneratedRpcApi['onTaskDeleted'],
+    onTaskCompleted: ((callback) =>
+      subscribe('tasks:completed', callback)) as GeneratedRpcApi['onTaskCompleted'],
+    onTaskMoved: ((callback) =>
+      subscribe('tasks:moved', callback)) as GeneratedRpcApi['onTaskMoved'],
+    onProjectCreated: ((callback) =>
+      subscribe('tasks:project-created', callback)) as GeneratedRpcApi['onProjectCreated'],
+    onProjectUpdated: ((callback) =>
+      subscribe('tasks:project-updated', callback)) as GeneratedRpcApi['onProjectUpdated'],
+    onProjectDeleted: ((callback) =>
+      subscribe('tasks:project-deleted', callback)) as GeneratedRpcApi['onProjectDeleted'],
+    onInboxCaptured: ((callback) =>
+      subscribe('inbox:captured', callback)) as GeneratedRpcApi['onInboxCaptured'],
+    onInboxUpdated: ((callback) =>
+      subscribe('inbox:updated', callback)) as GeneratedRpcApi['onInboxUpdated'],
+    onInboxArchived: ((callback) =>
+      subscribe('inbox:archived', callback)) as GeneratedRpcApi['onInboxArchived'],
+    onInboxFiled: ((callback) =>
+      subscribe('inbox:filed', callback)) as GeneratedRpcApi['onInboxFiled'],
+    onInboxSnoozed: ((callback) =>
+      subscribe('inbox:snoozed', callback)) as GeneratedRpcApi['onInboxSnoozed'],
+    onInboxSnoozeDue: ((callback) =>
+      subscribe('inbox:snooze-due', callback)) as GeneratedRpcApi['onInboxSnoozeDue'],
+    onInboxTranscriptionComplete: ((callback) =>
+      subscribe(
+        'inbox:transcription-complete',
+        callback
+      )) as GeneratedRpcApi['onInboxTranscriptionComplete'],
+    onInboxMetadataComplete: ((callback) =>
+      subscribe('inbox:metadata-complete', callback)) as GeneratedRpcApi['onInboxMetadataComplete'],
+    onInboxProcessingError: ((callback) =>
+      subscribe('inbox:processing-error', callback)) as GeneratedRpcApi['onInboxProcessingError'],
+    onSettingsChanged: ((callback) =>
+      subscribe('settings:changed', callback)) as GeneratedRpcApi['onSettingsChanged'],
+    onEmbeddingProgress: ((callback) =>
+      subscribe('settings:embeddingProgress', callback)) as GeneratedRpcApi['onEmbeddingProgress'],
+    onVoiceModelProgress: ((callback) =>
+      subscribe(
+        'settings:voiceModelProgress',
+        callback
+      )) as GeneratedRpcApi['onVoiceModelProgress'],
+    onSettingsOpenRequested: ((callback) =>
+      subscribe('settings:openSection', callback)) as GeneratedRpcApi['onSettingsOpenRequested'],
+    onCalendarChanged: ((callback) =>
+      subscribe('calendar:changed', callback)) as GeneratedRpcApi['onCalendarChanged']
   }
 }

--- a/apps/desktop/src/renderer/src/components/journal/editor-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/editor-toolbar.test.tsx
@@ -189,9 +189,7 @@ describe('EditorToolbar', () => {
       const { editor } = makeEditor()
 
       // #when
-      render(
-        <EditorToolbar editor={editor} isFocusMode onFocusToggle={() => {}} />
-      )
+      render(<EditorToolbar editor={editor} isFocusMode onFocusToggle={() => {}} />)
 
       // #then
       const button = screen.getByRole('button', { name: 'Exit Focus Mode' })

--- a/apps/desktop/src/renderer/src/components/sidebar/tag-delete-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/tag-delete-dialog.tsx
@@ -56,11 +56,7 @@ export function TagDeleteDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <Button
-            variant="outline"
-            onClick={() => handleOpenChange(false)}
-            disabled={isPending}
-          >
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isPending}>
             Cancel
           </Button>
           <Button variant="destructive" onClick={handleConfirm} disabled={isPending}>

--- a/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.tsx
@@ -46,12 +46,7 @@ import { useSidebarDrillDown } from '@/contexts/sidebar-drill-down'
 import { useTagDetail, type TagSortBy } from '@/hooks/use-tag-detail'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
 import { COLOR_NAMES, getTagColors } from '@/components/note/tags-row/tag-colors'
-import {
-  tagsService,
-  onTagRenamed,
-  onTagDeleted,
-  type TagNoteItem
-} from '@/services/tags-service'
+import { tagsService, onTagRenamed, onTagDeleted, type TagNoteItem } from '@/services/tags-service'
 import type { SidebarItem } from '@/contexts/tabs/types'
 import { createLogger } from '@/lib/logger'
 import { toast } from 'sonner'
@@ -430,12 +425,7 @@ function TagOverflowMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 shrink-0"
-          aria-label="Tag actions"
-        >
+        <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" aria-label="Tag actions">
           <MoreHorizontal className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>

--- a/apps/desktop/tests/e2e/tags-rename-delete.e2e.ts
+++ b/apps/desktop/tests/e2e/tags-rename-delete.e2e.ts
@@ -77,9 +77,7 @@ test.describe('Tag rename + delete (§5.2)', () => {
     // Confirmation dialog
     await expect(page.locator(`text=Delete tag #${deleteTag}?`)).toBeVisible()
     // Click the destructive confirm — matches the "Delete tag" button in the dialog
-    await page
-      .locator('[role="alertdialog"] button', { hasText: 'Delete tag' })
-      .click()
+    await page.locator('[role="alertdialog"] button', { hasText: 'Delete tag' }).click()
 
     await expect(page.locator(`aside button:has-text("${deleteTag}")`)).toHaveCount(0, {
       timeout: 10000


### PR DESCRIPTION
Add isMemryUserSignedIn helper and hasGoogleCalendarConnection check; short-circuit sync-service and calendar-handlers when either is false. Start/stop the Google Calendar runner on login, connect, disconnect, and session teardown so the background loop matches current auth state.

## What

<!-- One-liner: what does this PR do? -->

## Why

<!-- Motivation, context, or issue link -->

## How

<!-- Key implementation decisions, trade-offs, anything non-obvious -->

## Type

<!-- Check one -->
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `style` — visual/UI only
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `chore` — tooling, deps, config
- [ ] `docs` — documentation only
- [ ] `ci` — CI/CD changes

## Test plan

<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing (describe below)

## Screenshots

<!-- UI changes? Drop before/after screenshots here. Delete section if N/A -->

## Checklist

- [ ] Self-reviewed the diff
- [ ] No hardcoded secrets or credentials
- [ ] Files stay under ~500 LOC
- [ ] Follows immutable data patterns
