### PR TITLE
fix(calendar): persist events created via marquee quick-create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-04-17 — Calendar Marquee Quick-Create Fix
+
+### Fixed
+- Fix calendar marquee drag to persist the event when the user submits a title via Enter or Save
+- Keep the quick-create popover mounted and show an inline destructive message when event creation fails, instead of closing silently
+
+### Changed
+- Decouple calendar UI refresh from sync queue health so newly created events appear immediately even when background sync is unavailable
+- Extract `localInputToIso` helper for local-input-to-ISO conversion with explicit NaN guarding
+
+---
+
 ## 2026-04-17 — Calendar Auto-scroll to Current Time
 
 ### Added

--- a/apps/desktop/src/main/ipc/calendar-handlers.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.ts
@@ -57,7 +57,7 @@ import {
   syncCalendarSourceUpdate
 } from '../calendar/runtime-effects'
 
-createLogger('IPC:Calendar')
+const log = createLogger('IPC:Calendar')
 
 function emitCalendarChanged(event: CalendarChangedEvent): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -193,7 +193,11 @@ export function registerCalendarHandlers(): void {
           throw new Error('Failed to load created calendar event')
         }
 
-        syncCalendarEventCreate(id)
+        try {
+          syncCalendarEventCreate(id)
+        } catch (error) {
+          log.warn('syncCalendarEventCreate failed; event persisted locally', error)
+        }
         emitCalendarChanged({ entityType: 'calendar_event', id })
         return { success: true, event: mapCalendarEvent(created) }
       }, 'Failed to create calendar event')

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
@@ -29,7 +29,7 @@ interface CalendarDayViewProps {
   items: CalendarProjectionItem[]
   onSelectItem?: (item: CalendarProjectionItem) => void
   onAnchorChange?: (date: string) => void
-  onQuickSave?: (draft: CalendarEventDraft) => void
+  onQuickSave?: (draft: CalendarEventDraft) => void | Promise<void>
   onCreateEventWithRange?: (startAt: string, endAt: string, isAllDay: boolean) => void
 }
 
@@ -85,6 +85,7 @@ export function CalendarDayView({
 
           <div
             ref={gridRef}
+            data-testid="day-time-grid"
             className="relative flex-1"
             style={{ backgroundImage: GRID_LINE_BG }}
             onMouseDown={(e) => handlers.onMouseDown(e, 0)}
@@ -137,8 +138,8 @@ export function CalendarDayView({
                   startAt={selection.startAt}
                   endAt={selection.endAt}
                   isAllDay={false}
-                  onSave={(draft) => {
-                    onQuickSave?.(draft)
+                  onSave={async (draft) => {
+                    await onQuickSave?.(draft)
                     clearSelection()
                   }}
                   onDismiss={clearSelection}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-month-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-month-view.tsx
@@ -14,7 +14,7 @@ interface CalendarMonthViewProps {
   anchorDate: string
   items: CalendarProjectionItem[]
   onSelectItem?: (item: CalendarProjectionItem) => void
-  onQuickSave?: (draft: CalendarEventDraft) => void
+  onQuickSave?: (draft: CalendarEventDraft) => void | Promise<void>
   onCreateEventWithRange?: (startAt: string, endAt: string, isAllDay: boolean) => void
 }
 
@@ -113,8 +113,8 @@ export function CalendarMonthView({
           startAt={selection.startDate}
           endAt={selection.endDate}
           isAllDay={true}
-          onSave={(draft) => {
-            onQuickSave?.(draft)
+          onSave={async (draft) => {
+            await onQuickSave?.(draft)
             clearSelection()
           }}
           onDismiss={clearSelection}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-quick-create-popover.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-quick-create-popover.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverAnchor, PopoverArrow, PopoverContent } from '@/components/ui/popover'
+import { extractErrorMessage } from '@/lib/ipc-error'
 import type { CalendarEventDraft } from './calendar-event-editor-drawer'
 
 interface CalendarQuickCreatePopoverProps {
@@ -9,7 +10,7 @@ interface CalendarQuickCreatePopoverProps {
   startAt: string
   endAt: string
   isAllDay: boolean
-  onSave: (draft: CalendarEventDraft) => void
+  onSave: (draft: CalendarEventDraft) => void | Promise<void>
   onDismiss: () => void
   onOpenFullEditor: (draft: CalendarEventDraft) => void
 }
@@ -69,6 +70,8 @@ export function CalendarQuickCreatePopover({
 }: CalendarQuickCreatePopoverProps): React.JSX.Element {
   const [title, setTitle] = useState('')
   const [location, setLocation] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const titleRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -79,9 +82,21 @@ export function CalendarQuickCreatePopover({
     return { title, description: '', location, isAllDay, startAt, endAt }
   }
 
+  async function submit(): Promise<void> {
+    if (!title.trim() || isSubmitting) return
+    setIsSubmitting(true)
+    setErrorMessage(null)
+    try {
+      await onSave(buildDraft())
+    } catch (error) {
+      setErrorMessage(extractErrorMessage(error, 'Could not create event. Try again.'))
+      setIsSubmitting(false)
+    }
+  }
+
   function handleTitleKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {
     if (e.key === 'Enter' && title.trim()) {
-      onSave(buildDraft())
+      void submit()
     }
   }
 
@@ -123,6 +138,7 @@ export function CalendarQuickCreatePopover({
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           onKeyDown={handleTitleKeyDown}
+          disabled={isSubmitting}
           className="mb-2"
         />
 
@@ -130,8 +146,19 @@ export function CalendarQuickCreatePopover({
           placeholder="Add location"
           value={location}
           onChange={(e) => setLocation(e.target.value)}
+          disabled={isSubmitting}
           className="mb-3"
         />
+
+        {errorMessage && (
+          <p
+            data-testid="quick-create-error"
+            role="alert"
+            className="mb-3 text-xs text-destructive"
+          >
+            {errorMessage}
+          </p>
+        )}
 
         <div className="flex items-center justify-between">
           <button
@@ -142,8 +169,8 @@ export function CalendarQuickCreatePopover({
             Add details
           </button>
 
-          <Button size="sm" disabled={!title.trim()} onClick={() => onSave(buildDraft())}>
-            Save
+          <Button size="sm" disabled={!title.trim() || isSubmitting} onClick={() => void submit()}>
+            {isSubmitting ? 'Saving…' : 'Save'}
           </Button>
         </div>
 

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
@@ -33,7 +33,7 @@ interface CalendarShellProps {
   onEditorDraftChange: (draft: CalendarEventDraft) => void
   onEditorSave: () => void
   onAnchorChange?: (date: string) => void
-  onQuickSave?: (draft: CalendarEventDraft) => void
+  onQuickSave?: (draft: CalendarEventDraft) => void | Promise<void>
   onCreateEventWithRange?: (startAt: string, endAt: string, isAllDay: boolean) => void
 }
 

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
@@ -30,7 +30,7 @@ interface CalendarWeekViewProps {
   anchorDate: string
   items: CalendarProjectionItem[]
   onSelectItem?: (item: CalendarProjectionItem) => void
-  onQuickSave?: (draft: CalendarEventDraft) => void
+  onQuickSave?: (draft: CalendarEventDraft) => void | Promise<void>
   onCreateEventWithRange?: (startAt: string, endAt: string, isAllDay: boolean) => void
 }
 
@@ -176,8 +176,8 @@ export function CalendarWeekView({
                       startAt={selection.startAt}
                       endAt={selection.endAt}
                       isAllDay={false}
-                      onSave={(draft) => {
-                        onQuickSave?.(draft)
+                      onSave={async (draft) => {
+                        await onQuickSave?.(draft)
                         clearSelection()
                       }}
                       onDismiss={clearSelection}

--- a/apps/desktop/src/renderer/src/components/calendar/date-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/date-utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { localInputToIso } from './date-utils'
+
+describe('localInputToIso', () => {
+  it('converts a timed local input into an ISO 8601 UTC string ending in Z', () => {
+    const result = localInputToIso('2026-04-17T09:30', false)
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+  })
+
+  it('prepends midnight for all-day inputs and returns a valid ISO string', () => {
+    const result = localInputToIso('2026-04-17', true)
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+  })
+
+  it('throws when the input cannot be parsed as a date', () => {
+    expect(() => localInputToIso('not-a-date', false)).toThrow(/invalid/i)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/date-utils.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/date-utils.ts
@@ -46,6 +46,15 @@ export function toLocalDateTimeInputValue(value: string): string {
   return `${toLocalDateString(date)}T${pad(date.getHours())}:${pad(date.getMinutes())}`
 }
 
+export function localInputToIso(value: string, isAllDay: boolean): string {
+  const normalized = isAllDay ? `${value}T00:00:00` : value
+  const date = new Date(normalized)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid calendar input datetime: ${value}`)
+  }
+  return date.toISOString()
+}
+
 export function getStartOfWeek(value: string): string {
   const date = parseLocalDate(value)
   date.setDate(date.getDate() - date.getDay())

--- a/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders, userEvent } from '@tests/utils/render'
+import { CalendarPage } from '@/pages/calendar'
+import { CreateCalendarEventSchema } from '@memry/contracts/calendar-api'
+import type { TimeGridSelection } from '@/components/calendar/use-time-grid-marquee'
+import type { CalendarSourceRecord } from '@/services/calendar-service'
+
+const {
+  mockUseCalendarRange,
+  mockListSources,
+  mockCreateEvent,
+  mockUpdateEvent,
+  mockUseTimeGridMarquee,
+  mockClearSelection
+} = vi.hoisted(() => ({
+  mockUseCalendarRange: vi.fn(),
+  mockListSources: vi.fn(),
+  mockCreateEvent: vi.fn(),
+  mockUpdateEvent: vi.fn(),
+  mockUseTimeGridMarquee: vi.fn(),
+  mockClearSelection: vi.fn()
+}))
+
+vi.mock('@/hooks/use-calendar-range', () => ({
+  useCalendarRange: mockUseCalendarRange
+}))
+
+vi.mock('@/services/calendar-service', () => ({
+  calendarService: {
+    listSources: mockListSources,
+    createEvent: mockCreateEvent,
+    updateEvent: mockUpdateEvent
+  },
+  onCalendarChanged: vi.fn(() => () => {})
+}))
+
+vi.mock('@/components/calendar/use-time-grid-marquee', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@/components/calendar/use-time-grid-marquee')>()
+  return {
+    ...original,
+    useTimeGridMarquee: mockUseTimeGridMarquee
+  }
+})
+
+const NO_SOURCES: CalendarSourceRecord[] = []
+
+function stubSelection(): TimeGridSelection {
+  const today = new Date()
+  const y = today.getFullYear()
+  const m = String(today.getMonth() + 1).padStart(2, '0')
+  const d = String(today.getDate()).padStart(2, '0')
+  return {
+    top: 960,
+    height: 96,
+    date: `${y}-${m}-${d}`,
+    startAt: `${y}-${m}-${d}T10:00`,
+    endAt: `${y}-${m}-${d}T11:00`,
+    columnIndex: 0,
+    anchorRect: { x: 100, y: 200, width: 300, height: 96 }
+  }
+}
+
+describe('CalendarPage · marquee → quick-create → save', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockCreateEvent.mockReset()
+    mockUpdateEvent.mockReset()
+    mockListSources.mockReset()
+    mockUseCalendarRange.mockReset()
+    mockUseTimeGridMarquee.mockReset()
+    mockClearSelection.mockReset()
+
+    mockListSources.mockResolvedValue({ sources: NO_SOURCES })
+    mockUseCalendarRange.mockReturnValue({
+      data: { items: [] },
+      items: [],
+      isLoading: false,
+      isFetching: false,
+      error: null
+    })
+    mockUseTimeGridMarquee.mockReturnValue({
+      selection: stubSelection(),
+      isDragging: false,
+      handlers: { onMouseDown: vi.fn(), onDoubleClick: vi.fn() },
+      clearSelection: mockClearSelection
+    })
+
+    localStorage.setItem('calendar-view', 'day')
+  })
+
+  it('calls createEvent with a Zod-valid payload when the user submits via Enter', async () => {
+    mockCreateEvent.mockResolvedValue({
+      success: true,
+      event: { id: 'event-new' }
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<CalendarPage />)
+
+    const popover = await screen.findByTestId('quick-create-popover')
+    expect(popover).toBeInTheDocument()
+
+    const titleInput = screen.getByPlaceholderText('New Event')
+    await user.type(titleInput, 'Team sync{Enter}')
+
+    await waitFor(() => expect(mockCreateEvent).toHaveBeenCalledTimes(1))
+
+    const payload = mockCreateEvent.mock.calls[0][0]
+    expect(payload.title).toBe('Team sync')
+    expect(payload.isAllDay).toBe(false)
+
+    const parsed = CreateCalendarEventSchema.safeParse(payload)
+    expect(parsed.success).toBe(true)
+  })
+
+  it('closes the popover and invalidates calendar range queries on success', async () => {
+    mockCreateEvent.mockResolvedValue({
+      success: true,
+      event: { id: 'event-new' }
+    })
+    const user = userEvent.setup()
+    const { queryClient } = renderWithProviders(<CalendarPage />)
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    await screen.findByTestId('quick-create-popover')
+    await user.type(screen.getByPlaceholderText('New Event'), 'Team sync{Enter}')
+
+    await waitFor(() => expect(mockCreateEvent).toHaveBeenCalledTimes(1))
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['calendar', 'range'] })
+      )
+    })
+    expect(mockClearSelection).toHaveBeenCalled()
+  })
+
+  it('keeps the popover mounted and surfaces an error message when createEvent rejects', async () => {
+    mockCreateEvent.mockRejectedValue(new Error('Database locked'))
+    const user = userEvent.setup()
+    renderWithProviders(<CalendarPage />)
+
+    await screen.findByTestId('quick-create-popover')
+    await user.type(screen.getByPlaceholderText('New Event'), 'Team sync{Enter}')
+
+    await waitFor(() => expect(mockCreateEvent).toHaveBeenCalledTimes(1))
+
+    expect(screen.getByTestId('quick-create-popover')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('New Event')).toHaveValue('Team sync')
+    expect(screen.getByTestId('quick-create-error')).toHaveTextContent(/database locked/i)
+    expect(mockClearSelection).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -11,6 +11,7 @@ import {
   addLocalYears,
   getMonthGridDays,
   getStartOfWeek,
+  localInputToIso,
   parseLocalDate,
   toLocalDateInputValue,
   toLocalDateString,
@@ -112,26 +113,14 @@ function createDraftFromItem(item: CalendarProjectionItem): CalendarEventDraft {
 }
 
 function toCreatePayload(draft: CalendarEventDraft) {
-  if (draft.isAllDay) {
-    return {
-      title: draft.title.trim(),
-      description: draft.description.trim() || null,
-      location: draft.location.trim() || null,
-      startAt: new Date(`${draft.startAt}T00:00:00`).toISOString(),
-      endAt: draft.endAt ? new Date(`${draft.endAt}T00:00:00`).toISOString() : null,
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
-      isAllDay: true
-    }
-  }
-
   return {
     title: draft.title.trim(),
     description: draft.description.trim() || null,
     location: draft.location.trim() || null,
-    startAt: new Date(draft.startAt).toISOString(),
-    endAt: draft.endAt ? new Date(draft.endAt).toISOString() : null,
+    startAt: localInputToIso(draft.startAt, draft.isAllDay),
+    endAt: draft.endAt ? localInputToIso(draft.endAt, draft.isAllDay) : null,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
-    isAllDay: false
+    isAllDay: draft.isAllDay
   }
 }
 
@@ -275,12 +264,8 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
   }
 
   const handleQuickSave = async (draft: CalendarEventDraft) => {
-    try {
-      await calendarService.createEvent(toCreatePayload(draft))
-      await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
-    } catch {
-      // popover stays open on error — user can retry
-    }
+    await calendarService.createEvent(toCreatePayload(draft))
+    await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
   }
 
   const handleCreateEventWithRange = (startAt: string, endAt: string, isAllDay: boolean) => {
@@ -337,7 +322,7 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
       }
       onAnchorChange={(date) => setAnchorDate(date)}
       onEditorSave={() => void handleSaveEditor()}
-      onQuickSave={(draft) => void handleQuickSave(draft)}
+      onQuickSave={handleQuickSave}
       onCreateEventWithRange={handleCreateEventWithRange}
     />
   )

--- a/apps/desktop/tests/e2e/calendar-comprehensive.e2e.ts
+++ b/apps/desktop/tests/e2e/calendar-comprehensive.e2e.ts
@@ -235,10 +235,9 @@ test.describe('Calendar — comprehensive coverage', () => {
   })
 
   test.describe('Event creation — quick-create via marquee', () => {
-    // Skipped: day grid container has no stable selector; needs a
-    // `data-testid="day-time-grid"` on the gridRef div in calendar-day-view.tsx
-    // to anchor the marquee drag reliably.
-    test.skip('drag selection on day view opens quick-create popover', async () => {})
+    // Implemented in calendar-marquee.e2e.ts (separate file so it does not
+    // inherit the comprehensive suite's seed beforeEach, which the marquee
+    // flow does not need).
   })
 
   test.describe('Event editing', () => {

--- a/apps/desktop/tests/e2e/calendar-marquee.e2e.ts
+++ b/apps/desktop/tests/e2e/calendar-marquee.e2e.ts
@@ -1,0 +1,68 @@
+import { test, expect } from './fixtures'
+import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
+
+test.describe('Calendar — marquee quick-create', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+  })
+
+  test('drag selection on day view creates an event after typing a title', async ({ page }) => {
+    const title = `MarqueeE2E-${Date.now()}`
+
+    await page.getByRole('button', { name: 'Calendar' }).click()
+    await expect(page.getByTestId('calendar-page')).toBeVisible()
+
+    await page
+      .getByTestId('calendar-page')
+      .getByRole('button', { name: 'Day', exact: true })
+      .click()
+    await expect(page.getByTestId('calendar-view')).toHaveAttribute('data-view', 'day')
+
+    const grid = page.getByTestId('day-time-grid')
+    await expect(grid).toBeVisible()
+
+    // Scroll the grid's overflow parent to top so absolute grid coords
+    // (HOUR_HEIGHT=96 per hour) align with viewport y.
+    await grid.evaluate((el) => {
+      let parent: HTMLElement | null = el.parentElement
+      while (parent) {
+        const overflow = getComputedStyle(parent).overflowY
+        if (overflow === 'auto' || overflow === 'scroll') {
+          parent.scrollTop = 0
+          break
+        }
+        parent = parent.parentElement
+      }
+    })
+    await page.waitForTimeout(100)
+
+    const box = await grid.boundingBox()
+    if (!box) throw new Error('day-time-grid has no bounding box')
+
+    // Drag from 01:00 (y = 96) to 02:00 (y = 192) — safely within the first
+    // screen of the grid regardless of viewport size.
+    const x = box.x + box.width / 2
+    const yStart = box.y + 96
+    const yEnd = box.y + 192
+
+    await page.mouse.move(x, yStart)
+    await page.mouse.down()
+    await page.mouse.move(x, yEnd, { steps: 8 })
+    await page.mouse.up()
+
+    const popover = page.getByTestId('quick-create-popover')
+    await expect(popover).toBeVisible()
+
+    const titleInput = popover.getByPlaceholder('New Event')
+    await titleInput.fill(title)
+    await titleInput.press('Enter')
+
+    await expect(popover).toBeHidden()
+    const chip = page
+      .getByTestId('calendar-page')
+      .getByRole('button', { name: new RegExp(title) })
+      .first()
+    await expect(chip).toBeVisible()
+  })
+})


### PR DESCRIPTION
## What

Fix the calendar day/week/month marquee drag → quick-create popover → submit flow so the event is actually persisted (and failures are visible instead of silent).

## Why

Dragging a time range in the calendar, typing a title, and pressing Enter / Save appeared to do nothing — the popover closed and no event showed up. Root cause was a three-layer silent failure:

1. `calendar-day-view.tsx` / `calendar-week-view.tsx` / `calendar-month-view.tsx` called `onQuickSave?.(draft)` as fire-and-forget, then ran `clearSelection()` synchronously — unmounting the popover before the IPC resolved.
2. `handleQuickSave` in `calendar.tsx` wrapped the call in `try { … } catch {}`, so any thrown error (Zod rejection, sync failure, preload mismatch) was swallowed. The `void handleQuickSave(draft)` binding further guaranteed no one could await the outcome.
3. `calendar-handlers.ts` ran `syncCalendarEventCreate(id)` **before** `emitCalendarChanged(...)`. If the sync subsystem threw, the emit never fired, and the renderer never refetched — the DB insert was invisible.

## How

- Made `CalendarQuickCreatePopover.onSave` awaitable, added `isSubmitting` + `errorMessage` state, and render inline destructive-styled errors with a `data-testid="quick-create-error"` anchor.
- Widened `onQuickSave` prop types to `void | Promise<void>` across day/week/month views and `CalendarShell`; each `onSave` now `await`s the page callback before clearing the selection.
- Dropped the swallow-all `catch {}` in `handleQuickSave` and removed the `void` prefix at the `CalendarShell` binding so rejections propagate to the popover.
- Reordered the main handler: `syncCalendarEventCreate` now runs inside a `try/catch` (warned via `log.warn`), and `emitCalendarChanged` always runs — UI refresh is no longer coupled to sync health.
- Extracted `localInputToIso(value, isAllDay)` in `date-utils.ts` with an explicit `Number.isNaN` guard and covered it with unit tests.
- Added `data-testid="day-time-grid"` to anchor Playwright coordinates for the marquee drag.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change

## Test plan

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing (describe below)

New coverage:
- `calendar-quick-create.test.tsx` — 3 page-level integration tests (Zod-valid payload on Enter, invalidation on success, popover stays mounted + error text on failure).
- `date-utils.test.ts` — 3 unit tests for `localInputToIso`.
- `calendar-marquee.e2e.ts` — new Playwright e2e file that drags 01:00→02:00 on the day grid, types a title, presses Enter, and asserts the event chip appears.

Verified locally: `pnpm lint` (0 errors), `pnpm typecheck` (clean), `pnpm test` (6900 passed, 1 pre-existing skip), `pnpm exec playwright test … calendar-marquee.e2e.ts` (1 passed in 6.3s).

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns