### PR TITLE
fix(settings): always open on Account section, drop cross-session state

### DIFF
--- a/apps/desktop/src/renderer/src/contexts/settings-modal-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/settings-modal-context.tsx
@@ -1,28 +1,38 @@
 import { createContext, useContext, useState, useCallback, useMemo } from 'react'
 
+export type SettingsSection =
+  | 'general'
+  | 'editor'
+  | 'templates'
+  | 'journal'
+  | 'tasks'
+  | 'vault'
+  | 'appearance'
+  | 'ai'
+  | 'integrations'
+  | 'tags'
+  | 'properties'
+  | 'shortcuts'
+  | 'account'
+
+const DEFAULT_SECTION: SettingsSection = 'account'
+
 interface SettingsModalContextValue {
   isOpen: boolean
+  activeSection: SettingsSection
+  setActiveSection: (section: SettingsSection) => void
   open: (section?: string) => void
   close: () => void
 }
 
 const SettingsModalContext = createContext<SettingsModalContextValue | null>(null)
 
-const SETTINGS_SECTION_KEY = 'memry_settings_section'
-
 export function SettingsModalProvider({ children }: { children: React.ReactNode }) {
   const [isOpen, setIsOpen] = useState(false)
+  const [activeSection, setActiveSection] = useState<SettingsSection>(DEFAULT_SECTION)
 
   const open = useCallback((section?: string) => {
-    if (section) {
-      localStorage.setItem(SETTINGS_SECTION_KEY, section)
-      window.dispatchEvent(
-        new StorageEvent('storage', {
-          key: SETTINGS_SECTION_KEY,
-          newValue: section
-        })
-      )
-    }
+    setActiveSection((section as SettingsSection) ?? DEFAULT_SECTION)
     setIsOpen(true)
   }, [])
 
@@ -31,8 +41,8 @@ export function SettingsModalProvider({ children }: { children: React.ReactNode 
   }, [])
 
   const value = useMemo<SettingsModalContextValue>(
-    () => ({ isOpen, open, close }),
-    [isOpen, open, close]
+    () => ({ isOpen, activeSection, setActiveSection, open, close }),
+    [isOpen, activeSection, open, close]
   )
 
   return <SettingsModalContext.Provider value={value}>{children}</SettingsModalContext.Provider>

--- a/apps/desktop/src/renderer/src/pages/settings.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   FileText,
@@ -29,41 +28,10 @@ import { PropertiesSettings } from './settings/properties-section'
 import { TasksSettings } from './settings/tasks-section'
 import { ShortcutsSettings } from './settings/shortcuts-section'
 import { AccountSettings } from './settings/account-section'
-
-type SettingsSection =
-  | 'general'
-  | 'editor'
-  | 'templates'
-  | 'journal'
-  | 'tasks'
-  | 'vault'
-  | 'appearance'
-  | 'ai'
-  | 'integrations'
-  | 'tags'
-  | 'properties'
-  | 'shortcuts'
-  | 'account'
+import { useSettingsModal } from '@/contexts/settings-modal-context'
 
 export function SettingsPage() {
-  const [activeSection, setActiveSection] = useState<SettingsSection>(() => {
-    const saved = localStorage.getItem('memry_settings_section')
-    return (saved as SettingsSection) || 'general'
-  })
-
-  useEffect(() => {
-    localStorage.setItem('memry_settings_section', activeSection)
-  }, [activeSection])
-
-  useEffect(() => {
-    const onStorage = (e: StorageEvent) => {
-      if (e.key === 'memry_settings_section' && e.newValue) {
-        setActiveSection(e.newValue as SettingsSection)
-      }
-    }
-    window.addEventListener('storage', onStorage)
-    return () => window.removeEventListener('storage', onStorage)
-  }, [])
+  const { activeSection, setActiveSection } = useSettingsModal()
 
   return (
     <div className="flex-1 min-h-0 flex">


### PR DESCRIPTION
## What

Settings modal now always opens on the **Account** section, and the active section no longer survives close/reopen or app restart.

## Why

The active settings section was persisted to `localStorage` under `memry_settings_section`, so if a user left the modal on e.g. _Editor_, that's where the modal reopened next time — even after relaunching the app. The requirement is that Account is the default entry point every time settings opens.

## How

- Lifted `activeSection` state from `<SettingsPage>` into `SettingsModalProvider` so the context owns it.
- `open(section?)` now resets `activeSection` to `section ?? 'account'` on every invocation. Existing deep-link callers (`openSettings('ai')`, `openSettings('journal')`, `openSettings('account')`) keep working because an explicit section still wins.
- Deleted the `localStorage` read/write in `settings.tsx` and the synthetic `StorageEvent` dispatch in the context — both were only needed to sync state between the two components when the child owned it.
- Exported a `SettingsSection` union type from the context so the child no longer needs its own copy.

Radix `<Dialog>` already unmounts `<SettingsPage>` on close, so context state + fresh `open()` call gives us the "reset to Account" behavior cleanly, without needing a `useEffect` to reset on close.

## Type

- [x] `fix` — bug fix

## Test plan

- [x] Manual testing: opened Settings, switched to _Editor_, closed, reopened → lands on **Account**. Relaunched app → still lands on **Account**. Triggered `openSettings('ai')` from the capture input (AI-not-configured flow) → lands on **AI Assistant** as before.
- [x] `pnpm typecheck:web` clean.
- [ ] Unit tests — not added; behavior is a single state source in the context and exercised via manual QA.

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns