### PR TITLE
feat(calendar): use global right sidebar in Day view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Format: weekly entries grouped by feature area.
 
 ---
 
-## 2026-04-17 — Calendar Day View Uses Global Right Sidebar (#TBD)
+## 2026-04-17 — Calendar Day View Uses Global Right Sidebar (#266)
 
 ### Changed
 - Remove the in-page right sidebar from Calendar Day view in favor of the global right sidebar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-04-17 — Calendar Day View Uses Global Right Sidebar (#TBD)
+
+### Changed
+- Remove the in-page right sidebar from Calendar Day view in favor of the global right sidebar
+- Auto-open the global right sidebar on Day view entry and close it on leaving Day view — unless the user had opened it manually, in which case it stays open
+
+---
+
 ## 2026-04-17 — Google Calendar Settings Row Compact Layout
 
 ### Changed

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { CalendarItemChip } from './calendar-item-chip'
-import { CalendarMiniMonth } from './calendar-mini-month'
 import { isToday, toLocalDateKey } from './date-utils'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { formatHour } from '@/lib/time-format'
@@ -28,7 +27,6 @@ interface CalendarDayViewProps {
   anchorDate: string
   items: CalendarProjectionItem[]
   onSelectItem?: (item: CalendarProjectionItem) => void
-  onAnchorChange?: (date: string) => void
   onQuickSave?: (draft: CalendarEventDraft) => void | Promise<void>
   onCreateEventWithRange?: (startAt: string, endAt: string, isAllDay: boolean) => void
 }
@@ -37,14 +35,12 @@ export function CalendarDayView({
   anchorDate,
   items,
   onSelectItem,
-  onAnchorChange,
   onQuickSave,
   onCreateEventWithRange
 }: CalendarDayViewProps): React.JSX.Element {
   const {
     settings: { clockFormat }
   } = useGeneralSettings()
-  const [miniMonthAnchor, setMiniMonthAnchor] = useState(anchorDate)
   const gridRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const dateForColumn = useCallback(() => anchorDate, [anchorDate])
@@ -54,8 +50,9 @@ export function CalendarDayView({
   })
   const today = isToday(anchorDate)
   useScrollToCurrentTime(scrollRef, today)
-  const dayItems = items.filter((item) => toLocalDateKey(item.startAt) === anchorDate)
-  const timedItems = dayItems.filter((item) => !item.isAllDay)
+  const timedItems = items.filter(
+    (item) => toLocalDateKey(item.startAt) === anchorDate && !item.isAllDay
+  )
 
   const currentTimeOffset = useMemo(() => {
     const now = new Date()
@@ -151,33 +148,6 @@ export function CalendarDayView({
               </>
             )}
           </div>
-        </div>
-      </div>
-
-      <div className="hidden w-[328px] shrink-0 flex-col border-l border-border @3xl:flex">
-        <CalendarMiniMonth
-          anchorDate={miniMonthAnchor}
-          items={items}
-          onDateSelect={(date) => onAnchorChange?.(date)}
-          onMonthChange={setMiniMonthAnchor}
-        />
-
-        <div className="flex flex-col gap-3 border-t border-border px-6 py-5">
-          <h3 className="text-sm font-semibold text-foreground">Today&apos;s events</h3>
-          {dayItems.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No events scheduled.</p>
-          ) : (
-            <div className="flex flex-col gap-2">
-              {dayItems.map((item) => (
-                <CalendarItemChip
-                  key={item.projectionId}
-                  item={item}
-                  clockFormat={clockFormat}
-                  onClick={onSelectItem}
-                />
-              ))}
-            </div>
-          )}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/contexts/day-panel-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/day-panel-context.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   type ReactNode
 } from 'react'
 import { getTodayString } from '@/lib/journal-utils'
@@ -23,6 +24,8 @@ export interface DayPanelContextValue {
   toggle: () => void
   open: () => void
   close: () => void
+  openForDayView: (date: string) => void
+  closeForDayView: () => void
   setDate: (date: string) => void
   setWidth: React.Dispatch<React.SetStateAction<number>>
   setIsResizing: React.Dispatch<React.SetStateAction<boolean>>
@@ -68,6 +71,7 @@ export const DayPanelProvider = ({
 
   const [isResizing, setIsResizing] = useState(false)
   const [selectedDate, setSelectedDate] = useState(getTodayString)
+  const autoModeRef = useRef(false)
 
   useEffect(() => {
     try {
@@ -88,15 +92,36 @@ export const DayPanelProvider = ({
   }, [width, isResizing])
 
   const toggle = useCallback(() => {
+    autoModeRef.current = false
     setIsOpen((prev) => !prev)
   }, [])
 
   const open = useCallback(() => {
+    autoModeRef.current = false
     setIsOpen(true)
   }, [])
 
   const close = useCallback(() => {
+    autoModeRef.current = false
     setIsOpen(false)
+  }, [])
+
+  const openForDayView = useCallback((date: string) => {
+    setSelectedDate(date)
+    setIsOpen((prev) => {
+      if (prev) return prev
+      autoModeRef.current = true
+      return true
+    })
+  }, [])
+
+  const closeForDayView = useCallback(() => {
+    setIsOpen((prev) => {
+      if (!prev) return prev
+      if (!autoModeRef.current) return prev
+      autoModeRef.current = false
+      return false
+    })
   }, [])
 
   const setDate = useCallback((date: string) => {
@@ -112,11 +137,24 @@ export const DayPanelProvider = ({
       toggle,
       open,
       close,
+      openForDayView,
+      closeForDayView,
       setDate,
       setWidth,
       setIsResizing
     }),
-    [isOpen, selectedDate, width, isResizing, toggle, open, close, setDate]
+    [
+      isOpen,
+      selectedDate,
+      width,
+      isResizing,
+      toggle,
+      open,
+      close,
+      openForDayView,
+      closeForDayView,
+      setDate
+    ]
   )
 
   return <DayPanelContext.Provider value={value}>{children}</DayPanelContext.Provider>

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -24,6 +24,7 @@ import {
   type CalendarProjectionItem,
   type CalendarSourceRecord
 } from '@/services/calendar-service'
+import { useDayPanel } from '@/contexts/day-panel-context'
 
 interface CalendarPageProps {
   className?: string
@@ -168,6 +169,25 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     draft: CalendarEventDraft
   } | null>(null)
   const [isSaving, setIsSaving] = useState(false)
+
+  const { openForDayView, closeForDayView, setDate: setDayPanelDate } = useDayPanel()
+
+  useEffect(() => {
+    if (view === 'day') {
+      openForDayView(anchorDate)
+    } else {
+      closeForDayView()
+    }
+    // anchorDate intentionally excluded: entering Day view seeds the date once; the
+    // sync effect below keeps it in step while Day view is active.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view, openForDayView, closeForDayView])
+
+  useEffect(() => {
+    if (view === 'day') {
+      setDayPanelDate(anchorDate)
+    }
+  }, [view, anchorDate, setDayPanelDate])
 
   const rangeInput = useMemo(
     () => ({


### PR DESCRIPTION
## What

Delete the in-page right sidebar (mini calendar + "Today's events") from the Calendar Day view and drive the app's global right sidebar instead. The global sidebar auto-opens when the user enters Day view and auto-closes when leaving — unless the user had opened it manually, in which case it stays open (sticky user intent).

## Why

Having two sidebars showing the same information (mini calendar + day events) was redundant and inconsistent. Calendar already relies on the global right sidebar elsewhere; Day view is now aligned with that pattern.

## How

- `DayPanelContext` gains two new actions: `openForDayView(date)` and `closeForDayView()`. An internal `autoModeRef` (non-reactive `useRef`) tracks whether the current open state came from Day-view auto-open vs. a manual user action. Manual `open` / `close` / `toggle` always clear auto-mode so the user's explicit intent wins.
- `openForDayView` is a no-op when the panel is already open (preserves the sticky-user-open case). `closeForDayView` only closes when auto-mode is true.
- `CalendarPage` wires two small effects: one toggles the panel on `view` transitions; the other syncs `selectedDate` to `anchorDate` while in Day view so the global panel follows Prev/Next/Today navigation.
- `CalendarDayView` loses its `<CalendarMiniMonth>` + "Today's events" column, plus the now-dead `miniMonthAnchor` state and `onAnchorChange` prop (confirmed dead — shell never forwarded it to Day view).
- The `timedItems` filter keeps the original `toLocalDateKey(startAt) === anchorDate && !isAllDay` guard so events spilling in from adjacent days are not rendered on the grid.

Trade-off: chose two `useEffect`s over wiring `setDate` into every `anchorDate` mutator (Prev/Next/Today/onAnchorChange). Effects add one lint warning but stay robust if a future change introduces a new anchor-date path.

## Type

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `style` — visual/UI only
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `chore` — tooling, deps, config
- [ ] `docs` — documentation only
- [ ] `ci` — CI/CD changes

## Test plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing (describe below)

Manual scenarios to walk through in `pnpm dev`:

1. **Panel starts closed** → Navigate to Calendar (Month). Click **Day** ⇒ global sidebar opens showing `anchorDate`. Click **Week** ⇒ closes. Click **Day** ⇒ opens again.
2. **Panel starts manually open** (user clicked the global toggle) → Navigate to Calendar. Click **Day** ⇒ stays open. Click **Week** ⇒ **stays open** (sticky). Close manually → click **Day** ⇒ opens in auto-mode → click **Month** ⇒ closes.
3. **Date sync in Day view** → Use Prev/Next/Today; confirm the global sidebar's mini-calendar and day-events follow the calendar's `anchorDate`.
4. **Reload while Day view is auto-open** → Panel persists as open via localStorage and is treated as user-opened after reload (safe default); switching to Week keeps it open.

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns