### PR TITLE
fix(calendar): surface silent IPC failures from quick-create/editor save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-04-17 — Calendar Quick-Create Surfaces Silent IPC Failures
+
+### Fixed
+- Fix calendar quick-create and event editor silently closing without persisting when the create/update IPC resolves with `{ success: false }`. The handlers now throw the returned error message so the popover stays open and shows a destructive inline message instead of discarding the user's input with no feedback
+
+---
+
 ## 2026-04-17 — Calendar Day View Uses Global Right Sidebar (#266)
 
 ### Changed

--- a/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
@@ -151,4 +151,23 @@ describe('CalendarPage · marquee → quick-create → save', () => {
     expect(screen.getByTestId('quick-create-error')).toHaveTextContent(/database locked/i)
     expect(mockClearSelection).not.toHaveBeenCalled()
   })
+
+  it('surfaces the error and keeps the popover mounted when createEvent resolves with { success: false }', async () => {
+    mockCreateEvent.mockResolvedValue({
+      success: false,
+      event: null,
+      error: 'Validation failed: startAt: Invalid datetime'
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<CalendarPage />)
+
+    await screen.findByTestId('quick-create-popover')
+    await user.type(screen.getByPlaceholderText('New Event'), 'Team sync{Enter}')
+
+    await waitFor(() => expect(mockCreateEvent).toHaveBeenCalledTimes(1))
+
+    expect(screen.getByTestId('quick-create-popover')).toBeInTheDocument()
+    expect(screen.getByTestId('quick-create-error')).toHaveTextContent(/validation failed/i)
+    expect(mockClearSelection).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -268,12 +268,18 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     setIsSaving(true)
     try {
       if (editorState.mode === 'create') {
-        await calendarService.createEvent(toCreatePayload(editorState.draft))
+        const result = await calendarService.createEvent(toCreatePayload(editorState.draft))
+        if (!result.success) {
+          throw new Error(result.error ?? 'Could not create event.')
+        }
       } else if (editorState.eventId) {
-        await calendarService.updateEvent({
+        const result = await calendarService.updateEvent({
           id: editorState.eventId,
           ...toCreatePayload(editorState.draft)
         })
+        if (!result.success) {
+          throw new Error(result.error ?? 'Could not update event.')
+        }
       }
 
       await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
@@ -284,7 +290,10 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
   }
 
   const handleQuickSave = async (draft: CalendarEventDraft) => {
-    await calendarService.createEvent(toCreatePayload(draft))
+    const result = await calendarService.createEvent(toCreatePayload(draft))
+    if (!result.success) {
+      throw new Error(result.error ?? 'Could not create event.')
+    }
     await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
   }
 


### PR DESCRIPTION
## Summary

- `handleQuickSave` and `handleSaveEditor` awaited `calendarService.createEvent` / `updateEvent` without checking the returned `success` flag. When the main-process `withDb` wrapper caught a thrown error (Zod validation, DB constraint, or any runtime failure inside the handler) it returned `{ success: false, error }` instead of re-throwing — so the awaited promise resolved cleanly and the popover closed silently with nothing persisted.
- This PR makes both handlers throw on `!result.success`, so the popover's existing `submit()` catch branch renders the error inline and preserves selection state.
- Addresses the user-reported marquee drag-to-create symptom: "type a title, hit Save/Enter, popover closes, no event, no error — even after reload." Google Calendar push already flows through `syncCalendarEventCreate` → `scheduleGoogleCalendarSourceSync`, so once local persistence succeeds the Google upsert runs automatically for users with a connected account.

## Test plan

- [x] `pnpm --filter desktop test` — 6913 passing (1 skipped), including the new `surfaces the error and keeps the popover mounted when createEvent resolves with { success: false }` case
- [x] `pnpm --filter desktop lint` — 0 errors
- [x] `pnpm --filter desktop typecheck:web` — clean
- [x] `pnpm --filter desktop typecheck:node` — clean
- [ ] Manual: rebuild Electron (`bash apps/desktop/scripts/ensure-native.sh electron && npx electron-vite build`), `pnpm dev`, drag marquee on Day view, type title, press Enter → chip appears immediately
- [ ] Manual: with Google Calendar connected in Settings, repeat flow → event appears in the Memry-managed Google calendar within ~10s