### PR TITLE
feat(calendar): infinite horizontal day scroll in week view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-04-18 — Calendar Week View Infinite Horizontal Scroll
+
+### Added
+- Infinite horizontal day scroll in Week view: trackpad swipes (and Shift + mouse wheel) pan the 7 visible day columns continuously across week boundaries, with the toolbar label updating live. Prev/Next/Today buttons now smooth-scroll to their target, and event data prefetches ±1 week around the visible range
+- `dayIndexFromDate` / `dateFromDayIndex` helpers in `date-utils.ts`, anchored at a `2020-01-01` epoch for virtualization math
+- `useWeekInfiniteScroll` hook owning a horizontal `@tanstack/react-virtual` virtualizer, `ResizeObserver`-driven column width, stable ref-backed visible-day callback, and a far-jump fallback inside `scrollToDay`
+- E2E tests in `calendar-week-scroll.e2e.ts` covering scroll right, scroll left, Today button, and Next/Prev buttons (no snap-back assertions)
+
+### Changed
+- Week view rewritten around horizontal virtualization with mirrored header + time-gutter scroll containers and a `data-testid="calendar-week-scroll"` hook point for e2e
+- Calendar page fetch range for Week view expanded to `[weekStart − 7, weekStart + 14)` for ±1 week prefetch via the existing `useCalendarRange` query key cache
+- `useTimeGridMarquee` now accepts an optional `getColumnElement` resolver so drag-select + quick-create popover anchoring work against absolute day indices in the virtualized grid
+- Hidden the Week view body scrollbar via the existing `.scrollbar-none` utility — horizontal scroll stays functional, chrome does not
+
+---
+
 ## 2026-04-17 — Calendar Quick-Create Surfaces Silent IPC Failures
 
 ### Fixed

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
@@ -33,6 +33,7 @@ interface CalendarShellProps {
   onEditorDraftChange: (draft: CalendarEventDraft) => void
   onEditorSave: () => void
   onAnchorChange?: (date: string) => void
+  onWeekVisibleRangeChange?: (startDate: string) => void
   onQuickSave?: (draft: CalendarEventDraft) => void | Promise<void>
   onCreateEventWithRange?: (startAt: string, endAt: string, isAllDay: boolean) => void
 }
@@ -61,6 +62,7 @@ export function CalendarShell({
   onEditorDraftChange,
   onEditorSave,
   onAnchorChange,
+  onWeekVisibleRangeChange,
   onQuickSave,
   onCreateEventWithRange
 }: CalendarShellProps): React.JSX.Element {
@@ -163,6 +165,7 @@ export function CalendarShell({
             {...viewProps}
             onQuickSave={onQuickSave}
             onCreateEventWithRange={onCreateEventWithRange}
+            onVisibleDayStartChange={(_, startDate) => onWeekVisibleRangeChange?.(startDate)}
           />
         ) : view === 'month' ? (
           <CalendarMonthView

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { CalendarItemChip } from './calendar-item-chip'
-import { addLocalDays, getStartOfWeek, isToday, toLocalDateKey } from './date-utils'
+import { dateFromDayIndex, dayIndexFromDate, isToday, toLocalDateKey } from './date-utils'
 import { MarqueeSelectionOverlay } from './marquee-selection-overlay'
 import { CalendarQuickCreatePopover } from './calendar-quick-create-popover'
 import { useTimeGridMarquee } from './use-time-grid-marquee'
 import { useScrollToCurrentTime } from './use-scroll-to-current-time'
+import { useWeekInfiniteScroll } from './use-week-infinite-scroll'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { formatHour } from '@/lib/time-format'
 import { cn } from '@/lib/utils'
@@ -12,6 +13,8 @@ import type { CalendarProjectionItem } from '@/services/calendar-service'
 import type { CalendarEventDraft } from './calendar-event-editor-drawer'
 
 const HOUR_HEIGHT = 96
+const HEADER_HEIGHT = 40
+const GUTTER_WIDTH = 48
 const HOURS = Array.from({ length: 24 }, (_, i) => i)
 const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 const DAY_NAMES_SHORT = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
@@ -32,6 +35,7 @@ interface CalendarWeekViewProps {
   onSelectItem?: (item: CalendarProjectionItem) => void
   onQuickSave?: (draft: CalendarEventDraft) => void | Promise<void>
   onCreateEventWithRange?: (startAt: string, endAt: string, isAllDay: boolean) => void
+  onVisibleDayStartChange?: (dayIndex: number, startDate: string) => void
 }
 
 export function CalendarWeekView({
@@ -39,24 +43,101 @@ export function CalendarWeekView({
   items,
   onSelectItem,
   onQuickSave,
-  onCreateEventWithRange
+  onCreateEventWithRange,
+  onVisibleDayStartChange
 }: CalendarWeekViewProps): React.JSX.Element {
   const {
     settings: { clockFormat }
   } = useGeneralSettings()
-  const weekStart = getStartOfWeek(anchorDate)
-  const days = Array.from({ length: 7 }, (_, i) => addLocalDays(weekStart, i))
 
   const gridRef = useRef<HTMLDivElement>(null)
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const dateForColumn = useCallback((columnIndex: number) => days[columnIndex] ?? days[0], [days])
+  const timeColumnRef = useRef<HTMLDivElement>(null)
+  const headerScrollRef = useRef<HTMLDivElement>(null)
+  const lastEmittedAnchorRef = useRef(anchorDate)
+
+  const notifyVisibleStart = useCallback(
+    (dayIndex: number) => {
+      const startDate = dateFromDayIndex(dayIndex)
+      lastEmittedAnchorRef.current = startDate
+      onVisibleDayStartChange?.(dayIndex, startDate)
+    },
+    [onVisibleDayStartChange]
+  )
+
+  const { scrollContainerRef, virtualizer, visibleDayStart, scrollToDate, dateForDayIndex } =
+    useWeekInfiniteScroll({
+      initialDate: anchorDate,
+      gutterWidth: GUTTER_WIDTH,
+      onVisibleDayStartChange: notifyVisibleStart
+    })
+
+  useEffect(() => {
+    if (anchorDate === lastEmittedAnchorRef.current) return
+    const anchorIndex = dayIndexFromDate(anchorDate)
+    if (anchorIndex >= visibleDayStart && anchorIndex < visibleDayStart + 7) return
+    scrollToDate(anchorDate, { smooth: true })
+  }, [anchorDate, visibleDayStart, scrollToDate])
+
+  useEffect(() => {
+    const body = scrollContainerRef.current
+    if (!body) return
+    const sync = (): void => {
+      if (headerScrollRef.current) {
+        headerScrollRef.current.scrollLeft = body.scrollLeft
+      }
+      if (timeColumnRef.current) {
+        timeColumnRef.current.scrollTop = body.scrollTop
+      }
+    }
+    body.addEventListener('scroll', sync, { passive: true })
+    sync()
+    return () => body.removeEventListener('scroll', sync)
+  }, [scrollContainerRef])
+
+  const virtualItems = virtualizer.getVirtualItems()
+  const totalSize = virtualizer.getTotalSize()
+
+  const getColumnElement = useCallback((dayIndex: number): HTMLElement | null => {
+    const grid = gridRef.current
+    if (!grid) return null
+    return grid.querySelector<HTMLElement>(`[data-day-index="${dayIndex}"]`)
+  }, [])
+
+  const dateForColumn = useCallback(
+    (columnIndex: number) => dateForDayIndex(columnIndex),
+    [dateForDayIndex]
+  )
+
   const { selection, isDragging, handlers, clearSelection } = useTimeGridMarquee({
     gridRef,
     dateForColumn,
-    columnCount: 7
+    columnCount: virtualizer.options.count,
+    getColumnElement
   })
-  const weekContainsToday = days.some((d) => isToday(d))
-  useScrollToCurrentTime(scrollRef, weekContainsToday)
+
+  const weekContainsToday = useMemo(() => {
+    for (let i = 0; i < 7; i++) {
+      if (isToday(dateFromDayIndex(visibleDayStart + i))) return true
+    }
+    return false
+  }, [visibleDayStart])
+
+  useScrollToCurrentTime(scrollContainerRef, weekContainsToday)
+
+  const itemsByDate = useMemo(() => {
+    const map = new Map<string, CalendarProjectionItem[]>()
+    for (const item of items) {
+      if (item.isAllDay) continue
+      const dateKey = toLocalDateKey(item.startAt)
+      const bucket = map.get(dateKey)
+      if (bucket) {
+        bucket.push(item)
+      } else {
+        map.set(dateKey, [item])
+      }
+    }
+    return map
+  }, [items])
 
   const currentTimeOffset = useMemo(() => {
     const now = new Date()
@@ -64,106 +145,134 @@ export function CalendarWeekView({
   }, [])
 
   return (
-    <div className="flex h-full flex-col" data-testid="calendar-view" data-view="week">
-      <div className="grid grid-cols-[48px_repeat(7,1fr)] border-b border-border @xl:grid-cols-[72px_repeat(7,1fr)]">
-        <div />
-        {days.map((day, i) => {
-          const today = isToday(day)
-          const dayNum = parseInt(day.slice(-2), 10)
-          return (
-            <div
-              key={day}
-              className="flex items-center justify-center gap-1 bg-background px-0.5 py-1 @xl:px-2 @xl:py-2"
-            >
-              <span className="text-xs font-medium text-muted-foreground">
-                <span className="hidden @xl:inline">{DAY_NAMES[i]}</span>
-                <span className="@xl:hidden">{DAY_NAMES_SHORT[i]}</span>
-              </span>
-              {today ? (
-                <span className="inline-flex size-6 items-center justify-center rounded-full bg-tint text-xs font-semibold text-tint-foreground">
-                  {dayNum}
-                </span>
-              ) : (
-                <span className="text-xs font-semibold text-foreground">{dayNum}</span>
-              )}
-            </div>
-          )
-        })}
+    <div
+      className="flex h-full min-h-0 flex-col [--grid-line-color:var(--border)]"
+      data-testid="calendar-view"
+      data-view="week"
+    >
+      <div className="flex border-b border-border">
+        <div
+          className="shrink-0 bg-background"
+          style={{ width: GUTTER_WIDTH, height: HEADER_HEIGHT }}
+        />
+        <div
+          ref={headerScrollRef}
+          className="min-w-0 flex-1 overflow-hidden"
+          style={{ height: HEADER_HEIGHT }}
+        >
+          <div className="relative" style={{ width: totalSize, height: HEADER_HEIGHT }}>
+            {virtualItems.map((vi) => {
+              const date = dateForDayIndex(vi.index)
+              const isCurrent = isToday(date)
+              const dayNum = parseInt(date.slice(-2), 10)
+              const dayOfWeek = new Date(date).getDay()
+              return (
+                <div
+                  key={vi.key}
+                  className="absolute top-0 flex items-center justify-center gap-1 bg-background"
+                  style={{
+                    left: vi.start,
+                    width: vi.size,
+                    height: HEADER_HEIGHT
+                  }}
+                >
+                  <span className="text-xs font-medium text-muted-foreground">
+                    <span className="hidden @xl:inline">{DAY_NAMES[dayOfWeek]}</span>
+                    <span className="@xl:hidden">{DAY_NAMES_SHORT[dayOfWeek]}</span>
+                  </span>
+                  {isCurrent ? (
+                    <span className="inline-flex size-6 items-center justify-center rounded-full bg-tint text-xs font-semibold text-tint-foreground">
+                      {dayNum}
+                    </span>
+                  ) : (
+                    <span className="text-xs font-semibold text-foreground">{dayNum}</span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
       </div>
 
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+      <div className="flex min-h-0 flex-1">
         <div
-          ref={gridRef}
-          className="relative grid grid-cols-[48px_repeat(7,1fr)] [--grid-line-color:var(--border)] @xl:grid-cols-[72px_repeat(7,1fr)]"
-          style={{ height: HOUR_HEIGHT * 24 }}
+          ref={timeColumnRef}
+          className="shrink-0 overflow-hidden bg-background"
+          style={{ width: GUTTER_WIDTH }}
         >
-          <div>
+          <div style={{ height: HOUR_HEIGHT * 24 }}>
             {HOURS.map((hour) => (
               <div
                 key={hour}
-                className="flex items-start justify-end pr-1 @xl:pr-3"
+                className="flex items-start justify-end pr-1"
                 style={{ height: HOUR_HEIGHT }}
               >
-                <span className="text-xs font-medium text-muted-foreground -translate-y-1/2">
+                <span className="-translate-y-1/2 text-xs font-medium text-muted-foreground">
                   {formatHour(hour, clockFormat)}
                 </span>
               </div>
             ))}
           </div>
+        </div>
 
-          {days.map((day, i) => {
-            const today = isToday(day)
-            const dayItems = items.filter(
-              (item) => !item.isAllDay && toLocalDateKey(item.startAt) === day
-            )
+        <div
+          ref={scrollContainerRef}
+          className="scrollbar-none relative min-w-0 flex-1 overflow-auto"
+          data-testid="calendar-week-scroll"
+        >
+          <div
+            ref={gridRef}
+            className="relative"
+            style={{ width: totalSize, height: HOUR_HEIGHT * 24 }}
+          >
+            {virtualItems.map((vi) => {
+              const date = dateForDayIndex(vi.index)
+              const dayItems = itemsByDate.get(date) ?? []
+              const today = isToday(date)
 
-            return (
-              <div
-                key={day}
-                className={cn('relative border-r border-border', 'bg-background')}
-                style={{ backgroundImage: GRID_LINE_BG }}
-                onMouseDown={(e) => handlers.onMouseDown(e, i)}
-                onDoubleClick={(e) => handlers.onDoubleClick(e, i)}
-              >
-                {dayItems.map((item) => {
-                  const pos = getEventPosition(item)
-                  return (
+              return (
+                <div
+                  key={vi.key}
+                  data-day-index={vi.index}
+                  data-date={date}
+                  className={cn('absolute top-0 border-r border-border bg-background')}
+                  style={{
+                    left: vi.start,
+                    width: vi.size,
+                    height: HOUR_HEIGHT * 24,
+                    backgroundImage: GRID_LINE_BG
+                  }}
+                  onMouseDown={(e) => handlers.onMouseDown(e, vi.index)}
+                  onDoubleClick={(e) => handlers.onDoubleClick(e, vi.index)}
+                >
+                  {dayItems.map((item) => {
+                    const pos = getEventPosition(item)
+                    return (
+                      <div
+                        key={item.projectionId}
+                        className="absolute left-0.5 right-0.5 z-10"
+                        style={{ top: pos.top, height: pos.height }}
+                      >
+                        <CalendarItemChip
+                          item={item}
+                          clockFormat={clockFormat}
+                          onClick={onSelectItem}
+                        />
+                      </div>
+                    )
+                  })}
+
+                  {today && (
                     <div
-                      key={item.projectionId}
-                      className="absolute left-0.5 right-0.5 z-10"
-                      style={{ top: pos.top, height: pos.height }}
+                      className="absolute left-0 right-0 z-20 flex items-center"
+                      style={{ top: currentTimeOffset }}
                     >
-                      <CalendarItemChip
-                        item={item}
-                        clockFormat={clockFormat}
-                        onClick={onSelectItem}
-                      />
+                      <div className="size-2 rounded-full bg-tint" />
+                      <div className="h-0.5 flex-1 bg-tint" />
                     </div>
-                  )
-                })}
+                  )}
 
-                {today && (
-                  <div
-                    className="absolute left-0 right-0 z-20 flex items-center"
-                    style={{ top: currentTimeOffset }}
-                  >
-                    <div className="size-2 rounded-full bg-tint" />
-                    <div className="h-0.5 flex-1 bg-tint" />
-                  </div>
-                )}
-
-                {isDragging && selection && selection.columnIndex === i && (
-                  <MarqueeSelectionOverlay
-                    top={selection.top}
-                    height={selection.height}
-                    startAt={selection.startAt}
-                    endAt={selection.endAt}
-                    clockFormat={clockFormat}
-                  />
-                )}
-
-                {selection && !isDragging && selection.columnIndex === i && (
-                  <>
+                  {isDragging && selection && selection.columnIndex === vi.index && (
                     <MarqueeSelectionOverlay
                       top={selection.top}
                       height={selection.height}
@@ -171,26 +280,38 @@ export function CalendarWeekView({
                       endAt={selection.endAt}
                       clockFormat={clockFormat}
                     />
-                    <CalendarQuickCreatePopover
-                      anchorRect={selection.anchorRect}
-                      startAt={selection.startAt}
-                      endAt={selection.endAt}
-                      isAllDay={false}
-                      onSave={async (draft) => {
-                        await onQuickSave?.(draft)
-                        clearSelection()
-                      }}
-                      onDismiss={clearSelection}
-                      onOpenFullEditor={(draft) => {
-                        onCreateEventWithRange?.(draft.startAt, draft.endAt, false)
-                        clearSelection()
-                      }}
-                    />
-                  </>
-                )}
-              </div>
-            )
-          })}
+                  )}
+
+                  {selection && !isDragging && selection.columnIndex === vi.index && (
+                    <>
+                      <MarqueeSelectionOverlay
+                        top={selection.top}
+                        height={selection.height}
+                        startAt={selection.startAt}
+                        endAt={selection.endAt}
+                        clockFormat={clockFormat}
+                      />
+                      <CalendarQuickCreatePopover
+                        anchorRect={selection.anchorRect}
+                        startAt={selection.startAt}
+                        endAt={selection.endAt}
+                        isAllDay={false}
+                        onSave={async (draft) => {
+                          await onQuickSave?.(draft)
+                          clearSelection()
+                        }}
+                        onDismiss={clearSelection}
+                        onOpenFullEditor={(draft) => {
+                          onCreateEventWithRange?.(draft.startAt, draft.endAt, false)
+                          clearSelection()
+                        }}
+                      />
+                    </>
+                  )}
+                </div>
+              )
+            })}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/calendar/date-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/date-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { localInputToIso } from './date-utils'
+import { dateFromDayIndex, dayIndexFromDate, localInputToIso } from './date-utils'
 
 describe('localInputToIso', () => {
   it('converts a timed local input into an ISO 8601 UTC string ending in Z', () => {
@@ -14,5 +14,53 @@ describe('localInputToIso', () => {
 
   it('throws when the input cannot be parsed as a date', () => {
     expect(() => localInputToIso('not-a-date', false)).toThrow(/invalid/i)
+  })
+})
+
+describe('dayIndexFromDate / dateFromDayIndex', () => {
+  it('returns 0 for the epoch date', () => {
+    // #given / #when
+    const index = dayIndexFromDate('2020-01-01')
+    // #then
+    expect(index).toBe(0)
+  })
+
+  it('maps dateFromDayIndex(0) back to epoch', () => {
+    // #given / #when
+    const date = dateFromDayIndex(0)
+    // #then
+    expect(date).toBe('2020-01-01')
+  })
+
+  it('round-trips arbitrary local dates stably', () => {
+    // #given
+    const samples = ['2020-01-01', '2021-03-01', '2024-02-29', '2026-04-17', '2030-12-31']
+    // #when / #then
+    for (const value of samples) {
+      expect(dateFromDayIndex(dayIndexFromDate(value))).toBe(value)
+    }
+  })
+
+  it('increments by one per calendar day across a DST boundary', () => {
+    // #given — spring forward in US: 2026-03-08
+    const before = dayIndexFromDate('2026-03-07')
+    const after = dayIndexFromDate('2026-03-08')
+    // #then
+    expect(after - before).toBe(1)
+  })
+
+  it('supports negative indices (dates before the epoch)', () => {
+    // #given / #when
+    const index = dayIndexFromDate('2019-12-31')
+    // #then
+    expect(index).toBe(-1)
+    expect(dateFromDayIndex(-1)).toBe('2019-12-31')
+  })
+
+  it('returns 7 days between two dates one week apart', () => {
+    // #given / #when
+    const diff = dayIndexFromDate('2026-04-24') - dayIndexFromDate('2026-04-17')
+    // #then
+    expect(diff).toBe(7)
   })
 })

--- a/apps/desktop/src/renderer/src/components/calendar/date-utils.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/date-utils.ts
@@ -90,6 +90,24 @@ export function isSameMonth(dateStr: string, anchorDate: string): boolean {
   return dateStr.slice(0, 7) === anchorDate.slice(0, 7)
 }
 
+const DAY_INDEX_EPOCH = '2020-01-01'
+const MS_PER_DAY = 86_400_000
+
+export function dayIndexFromDate(value: string): number {
+  const date = parseLocalDate(value)
+  const epoch = parseLocalDate(DAY_INDEX_EPOCH)
+  const dateMs = Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  const epochMs = Date.UTC(epoch.getFullYear(), epoch.getMonth(), epoch.getDate())
+  return Math.round((dateMs - epochMs) / MS_PER_DAY)
+}
+
+export function dateFromDayIndex(index: number): string {
+  const epoch = parseLocalDate(DAY_INDEX_EPOCH)
+  const utc = new Date(Date.UTC(epoch.getFullYear(), epoch.getMonth(), epoch.getDate()))
+  utc.setUTCDate(utc.getUTCDate() + index)
+  return `${utc.getUTCFullYear()}-${pad(utc.getUTCMonth() + 1)}-${pad(utc.getUTCDate())}`
+}
+
 export function getMonthGridDaysMondayStart(anchorDate: string): string[] {
   const anchor = parseLocalDate(anchorDate)
   const year = anchor.getFullYear()

--- a/apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.ts
@@ -69,6 +69,7 @@ interface UseTimeGridMarqueeOptions {
   columnCount?: number
   hourHeight?: number
   snapMinutes?: number
+  getColumnElement?: (columnIndex: number) => HTMLElement | null
 }
 
 interface UseTimeGridMarqueeResult {
@@ -100,7 +101,8 @@ function buildSelection(
   date: string,
   gridRef: RefObject<HTMLDivElement | null>,
   hourHeight: number,
-  columnCount: number
+  columnCount: number,
+  getColumnElement?: (columnIndex: number) => HTMLElement | null
 ): TimeGridSelection {
   const pxPerMinute = hourHeight / 60
   const top = Math.round(startMinutes * pxPerMinute)
@@ -108,8 +110,9 @@ function buildSelection(
   const el = gridRef.current
   const gridRect = el?.getBoundingClientRect()
   const scrollTop = el?.scrollTop ?? 0
-  const children = el?.children
-  const columnEl = children?.[columnIndex + 1] as HTMLElement | undefined
+  const columnEl = getColumnElement
+    ? getColumnElement(columnIndex)
+    : ((el?.children?.[columnIndex + 1] as HTMLElement | undefined) ?? null)
   const colRect = columnEl?.getBoundingClientRect()
   const anchorRect = {
     x: colRect?.x ?? gridRect?.x ?? 0,
@@ -133,7 +136,8 @@ export function useTimeGridMarquee({
   dateForColumn,
   columnCount = 1,
   hourHeight = HOUR_HEIGHT,
-  snapMinutes = SNAP_MINUTES
+  snapMinutes = SNAP_MINUTES,
+  getColumnElement
 }: UseTimeGridMarqueeOptions): UseTimeGridMarqueeResult {
   const [selection, setSelection] = useState<TimeGridSelection | null>(null)
   const [isDragging, setIsDragging] = useState(false)
@@ -171,7 +175,8 @@ export function useTimeGridMarquee({
           date,
           gridRef,
           hourHeight,
-          columnCount
+          columnCount,
+          getColumnElement
         )
       )
 
@@ -204,7 +209,7 @@ export function useTimeGridMarquee({
         dragState.current.rafId = requestAnimationFrame(scroll)
       }
     },
-    [gridRef, dateForColumn, hourHeight, snapMinutes]
+    [gridRef, dateForColumn, hourHeight, snapMinutes, columnCount, getColumnElement]
   )
 
   const handleMouseUp = useCallback(() => {
@@ -252,11 +257,12 @@ export function useTimeGridMarquee({
           date,
           gridRef,
           hourHeight,
-          columnCount
+          columnCount,
+          getColumnElement
         )
       )
     },
-    [gridRef, dateForColumn, hourHeight, snapMinutes]
+    [gridRef, dateForColumn, hourHeight, snapMinutes, columnCount, getColumnElement]
   )
 
   return {

--- a/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.ts
@@ -1,0 +1,153 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject
+} from 'react'
+import { useVirtualizer, type Virtualizer } from '@tanstack/react-virtual'
+import { dateFromDayIndex, dayIndexFromDate } from './date-utils'
+
+const COLUMNS_PER_PAGE = 7
+const DEFAULT_TOTAL_DAYS = 36_525
+const MIN_COLUMN_WIDTH = 48
+const INSTANT_JUMP_THRESHOLD_DAYS = 14
+
+interface UseWeekInfiniteScrollOptions {
+  initialDate: string
+  gutterWidth: number
+  totalDays?: number
+  onVisibleDayStartChange?: (dayIndex: number) => void
+}
+
+export interface UseWeekInfiniteScrollResult {
+  scrollContainerRef: RefObject<HTMLDivElement | null>
+  virtualizer: Virtualizer<HTMLDivElement, Element>
+  columnWidth: number
+  visibleDayStart: number
+  scrollToDay: (dayIndex: number, opts?: { smooth?: boolean }) => void
+  scrollToDate: (date: string, opts?: { smooth?: boolean }) => void
+  dateForDayIndex: (index: number) => string
+}
+
+export function useWeekInfiniteScroll({
+  initialDate,
+  gutterWidth,
+  totalDays = DEFAULT_TOTAL_DAYS,
+  onVisibleDayStartChange
+}: UseWeekInfiniteScrollOptions): UseWeekInfiniteScrollResult {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const [containerWidth, setContainerWidth] = useState(0)
+
+  const columnWidth = useMemo(() => {
+    if (containerWidth <= gutterWidth) return MIN_COLUMN_WIDTH
+    return Math.max(MIN_COLUMN_WIDTH, (containerWidth - gutterWidth) / COLUMNS_PER_PAGE)
+  }, [containerWidth, gutterWidth])
+
+  const initialIndex = useMemo(() => dayIndexFromDate(initialDate), [initialDate])
+  const [visibleDayStart, setVisibleDayStart] = useState(initialIndex)
+
+  const onVisibleDayStartChangeRef = useRef(onVisibleDayStartChange)
+  useEffect(() => {
+    onVisibleDayStartChangeRef.current = onVisibleDayStartChange
+  })
+
+  const lastNotifiedIndexRef = useRef(initialIndex)
+
+  const virtualizer = useVirtualizer({
+    horizontal: true,
+    count: totalDays,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => columnWidth,
+    overscan: 3
+  })
+
+  useLayoutEffect(() => {
+    const el = scrollContainerRef.current
+    if (!el) return
+    const measure = (): void => {
+      setContainerWidth(el.clientWidth)
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    virtualizer.measure()
+  }, [columnWidth, virtualizer])
+
+  const didInitialScrollRef = useRef(false)
+  useLayoutEffect(() => {
+    if (didInitialScrollRef.current) return
+    if (columnWidth <= MIN_COLUMN_WIDTH) return
+    const el = scrollContainerRef.current
+    if (!el) return
+    el.scrollLeft = initialIndex * columnWidth
+    didInitialScrollRef.current = true
+  }, [columnWidth, initialIndex])
+
+  useEffect(() => {
+    const el = scrollContainerRef.current
+    if (!el) return
+    const onScroll = (): void => {
+      if (columnWidth <= 0) return
+      const nextStart = Math.floor(el.scrollLeft / columnWidth)
+      if (nextStart === lastNotifiedIndexRef.current) return
+      lastNotifiedIndexRef.current = nextStart
+      setVisibleDayStart(nextStart)
+      onVisibleDayStartChangeRef.current?.(nextStart)
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [columnWidth])
+
+  useEffect(() => {
+    const el = scrollContainerRef.current
+    if (!el) return
+    const onWheel = (event: WheelEvent): void => {
+      if (!event.shiftKey) return
+      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return
+      event.preventDefault()
+      el.scrollLeft += event.deltaY
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [])
+
+  const scrollToDay = useCallback(
+    (dayIndex: number, opts?: { smooth?: boolean }): void => {
+      const el = scrollContainerRef.current
+      if (!el || columnWidth <= 0) return
+      const target = dayIndex * columnWidth
+      const distance = Math.abs(target - el.scrollLeft)
+      const wantSmooth = opts?.smooth ?? true
+      const farJump = distance > INSTANT_JUMP_THRESHOLD_DAYS * columnWidth
+      const behavior: ScrollBehavior = wantSmooth && !farJump ? 'smooth' : 'auto'
+      el.scrollTo({ left: target, behavior })
+    },
+    [columnWidth]
+  )
+
+  const scrollToDate = useCallback(
+    (date: string, opts?: { smooth?: boolean }): void => {
+      scrollToDay(dayIndexFromDate(date), opts)
+    },
+    [scrollToDay]
+  )
+
+  const dateForDayIndex = useCallback((index: number): string => dateFromDayIndex(index), [])
+
+  return {
+    scrollContainerRef,
+    virtualizer,
+    columnWidth,
+    visibleDayStart,
+    scrollToDay,
+    scrollToDate,
+    dateForDayIndex
+  }
+}

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -66,8 +66,8 @@ function getRangeForView(
   if (view === 'week') {
     const weekStart = getStartOfWeek(anchorDate)
     return {
-      startAt: toStartOfLocalDayIso(weekStart),
-      endAt: toStartOfLocalDayIso(addLocalDays(weekStart, 7))
+      startAt: toStartOfLocalDayIso(addLocalDays(weekStart, -7)),
+      endAt: toStartOfLocalDayIso(addLocalDays(weekStart, 14))
     }
   }
 
@@ -350,6 +350,7 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
         setEditorState((current) => (current ? { ...current, draft } : current))
       }
       onAnchorChange={(date) => setAnchorDate(date)}
+      onWeekVisibleRangeChange={(startDate) => setAnchorDate(startDate)}
       onEditorSave={() => void handleSaveEditor()}
       onQuickSave={handleQuickSave}
       onCreateEventWithRange={handleCreateEventWithRange}

--- a/apps/desktop/tests/e2e/calendar-week-scroll.e2e.ts
+++ b/apps/desktop/tests/e2e/calendar-week-scroll.e2e.ts
@@ -1,0 +1,119 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
+
+async function openCalendarWeekView(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Calendar' }).click()
+  await expect(page.getByTestId('calendar-page')).toBeVisible()
+  await page.getByTestId('calendar-page').getByRole('button', { name: 'Week', exact: true }).click()
+  await expect(page.getByTestId('calendar-view')).toHaveAttribute('data-view', 'week')
+  await expect(page.getByTestId('calendar-week-scroll')).toBeVisible()
+}
+
+async function getScrollLeft(page: Page): Promise<number> {
+  return await page
+    .getByTestId('calendar-week-scroll')
+    .evaluate((el) => (el as HTMLElement).scrollLeft)
+}
+
+async function scrollBy(page: Page, deltaX: number): Promise<void> {
+  await page
+    .getByTestId('calendar-week-scroll')
+    .evaluate((el, dx) => (el as HTMLElement).scrollBy({ left: dx, behavior: 'auto' }), deltaX)
+}
+
+async function waitForScrollSettle(page: Page, ms = 400): Promise<void> {
+  await page.waitForTimeout(ms)
+}
+
+test.describe('Calendar week view infinite horizontal scroll', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+  })
+
+  test('scrolls right and stays at the new position (no snap-back to today)', async ({ page }) => {
+    // #given — calendar opened on Week view
+    await openCalendarWeekView(page)
+    const initial = await getScrollLeft(page)
+
+    // #when — scroll right by ~2 day columns worth of pixels
+    await scrollBy(page, 400)
+    await waitForScrollSettle(page)
+
+    // #then — scrollLeft advanced and did NOT snap back
+    const afterScroll = await getScrollLeft(page)
+    expect(afterScroll).toBeGreaterThan(initial + 100)
+
+    // #and — wait a bit longer; still no snap-back
+    await waitForScrollSettle(page, 600)
+    const afterWait = await getScrollLeft(page)
+    expect(afterWait).toBeGreaterThanOrEqual(afterScroll - 10)
+  })
+
+  test('scrolls left and stays at the new position', async ({ page }) => {
+    // #given — calendar opened on Week view, then user scrolled forward first
+    await openCalendarWeekView(page)
+    const initial = await getScrollLeft(page)
+    await scrollBy(page, 800)
+    await waitForScrollSettle(page)
+    const forward = await getScrollLeft(page)
+    expect(forward).toBeGreaterThan(initial + 400)
+
+    // #when — scroll back left
+    await scrollBy(page, -500)
+    await waitForScrollSettle(page)
+
+    // #then — scrollLeft decreased and did not snap forward
+    const afterLeft = await getScrollLeft(page)
+    expect(afterLeft).toBeLessThan(forward - 200)
+    expect(afterLeft).toBeGreaterThan(initial - 10)
+
+    await waitForScrollSettle(page, 600)
+    const afterWait = await getScrollLeft(page)
+    expect(Math.abs(afterWait - afterLeft)).toBeLessThan(20)
+  })
+
+  test('Today button smooth-scrolls back to todays week after scrolling forward', async ({
+    page
+  }) => {
+    // #given — user has scrolled far forward
+    await openCalendarWeekView(page)
+    const initial = await getScrollLeft(page)
+    await scrollBy(page, 1200)
+    await waitForScrollSettle(page)
+    const advanced = await getScrollLeft(page)
+    expect(advanced).toBeGreaterThan(initial + 500)
+
+    // #when — click Today
+    await page
+      .getByTestId('calendar-page')
+      .getByRole('button', { name: 'Today', exact: true })
+      .click()
+    await waitForScrollSettle(page, 800)
+
+    // #then — scroll returns near the original position
+    const afterToday = await getScrollLeft(page)
+    expect(Math.abs(afterToday - initial)).toBeLessThan(50)
+  })
+
+  test('Next button advances the visible week by 7 days worth of scroll', async ({ page }) => {
+    // #given — week view at today
+    await openCalendarWeekView(page)
+    const initial = await getScrollLeft(page)
+
+    // #when — click Next
+    await page.getByTestId('calendar-page').getByRole('button', { name: 'Next period' }).click()
+    await waitForScrollSettle(page, 800)
+
+    // #then — scroll advanced by ~7 columns (lower bound to accommodate any column-width variance)
+    const afterNext = await getScrollLeft(page)
+    expect(afterNext).toBeGreaterThan(initial + 200)
+
+    // #and — Previous brings it back
+    await page.getByTestId('calendar-page').getByRole('button', { name: 'Previous period' }).click()
+    await waitForScrollSettle(page, 800)
+    const afterPrev = await getScrollLeft(page)
+    expect(Math.abs(afterPrev - initial)).toBeLessThan(50)
+  })
+})


### PR DESCRIPTION
## What

Replace the fixed 7-day CSS grid in Calendar Week view with a continuously-scrollable horizontal day strip. Trackpad horizontal swipes (and Shift + mouse wheel) pan the visible range day-by-day; the toolbar month/year label updates live as columns slide. Prev/Next/Today buttons smooth-scroll to their target and share one source of truth with the gesture scroll.

## Why

The old week view was a dead-end pager — seven columns, click Next to advance seven days. On a trackpad-centric macOS app users expect to scroll horizontally through time the same way they scroll vertically through hours. "Infinite" horizontal scroll also unifies the gesture + button navigation paths so the header label, fetch range, and scroll position never desync.

## How

**Core state shift.** `anchorDate` is no longer the primary state — the scroll offset in pixels is. A `2020-01-01` day-index epoch keeps virtualization math simple (all dates become non-negative integer column indices). `visibleDayStart = floor(scrollLeft / columnWidth)`; header label and fetch range derive from it.

**Virtualization.** `@tanstack/react-virtual` with `horizontal: true` renders only the visible columns + overscan over a logically 100-year-wide strip. Column width is `(containerWidth − gutterWidth) / 7` tracked via `ResizeObserver`.

**Layout.** Mirrored scroll containers — the body owns the 2D scroll, a header strip (`overflow-hidden`) mirrors its `scrollLeft`, and the time gutter (`overflow-hidden`) mirrors its `scrollTop`. Simpler than sticky-top + sticky-left stacking in a single 2D container and keeps `useScrollToCurrentTime` working unchanged.

**Flicker + scroll-back bug fixes.** Two subtle issues surfaced during review:
1. Hook's scroll listener had `onVisibleDayStartChange` in its `useEffect` deps, and the shell passed an inline arrow — every parent re-render unregistered + re-added the listener, losing scroll events mid-gesture → flicker. Fixed by storing the callback in a ref so the effect deps are just `[columnWidth]`.
2. The scroll handler was calling `onVisibleDayStartChange` inside a `setVisibleDayStart` updater function. That breaks React 18 auto-batching — the hook's `visibleDayStart` update and the page's `setAnchorDate` could commit in separate renders, and in the intermediate render the anchor-sync effect saw a mismatch and smooth-scrolled back to today. Fixed by calling both as siblings in the same native event handler + adding a `lastEmittedAnchorRef` in the view so self-initiated anchor updates don't re-trigger the anchor-sync effect.

**Data.** Week view fetch range widened to `[weekStart − 7, weekStart + 14)` so the React Query cache keeps ±1 week around the visible range loaded. Single expanded query is simpler than three parallel queries and the cache behavior is the same in practice.

**Marquee.** `useTimeGridMarquee` now accepts an optional `getColumnElement` resolver — the virtualized grid uses a `data-day-index` attribute lookup so drag-select and the quick-create popover anchor correctly against absolute day indices.

**Scrollbar.** Body scrollbar hidden via the existing `.scrollbar-none` utility — functionality unchanged.

## Type

- [x] `feat` — new feature

## Test plan

- [x] Unit tests added/updated — 6 new tests for `dayIndexFromDate` / `dateFromDayIndex` round-trip, DST boundary crossing, negative-index support
- [ ] Integration tests added/updated
- [x] E2E tests added — `calendar-week-scroll.e2e.ts` covers scroll right without snap-back, scroll left from a forward position, Today button after scrolling far, and Prev/Next round-trip
- [x] Manual testing — trackpad horizontal swipe, Shift + mouse wheel, Prev/Next/Today buttons, window resize stability

Verification run:
- `pnpm typecheck:web` clean
- `pnpm lint` 0 errors (all warnings pre-existing in unrelated files)
- `pnpm test` 6918 passed, 1 skipped
- E2E suite needs a fresh electron-vite build before running (per CLAUDE.md gotchas) — not executed in CI-blocking form from this worktree

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns