### PR TITLE
feat(calendar): context-aware sidebar date clicks (Calendar view vs Journal)

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import { DragProvider, type DragState } from '@/contexts/drag-context'
 import { DroppedPriorityProvider } from '@/contexts/dropped-priority-context'
 import { AIInlineProvider } from '@/contexts/ai-inline-context'
 import { DayPanelProvider } from '@/contexts/day-panel-context'
+import { CalendarViewProvider } from '@/contexts/calendar-view-context'
 import { SidebarDrillDownProvider } from '@/contexts/sidebar-drill-down'
 import { SelectedFolderProvider } from '@/contexts/selected-folder-context'
 import { GlobalDayPanel } from '@/components/day-panel'
@@ -361,25 +362,27 @@ function App(): React.JSX.Element {
         getOrderedTasks={taskOrder.getOrderedTasks}
       >
         <DayPanelProvider>
-          <AIInlineProvider>
-            <HintModeProvider>
-              <TabProvider>
-                <TabPersistenceManager>
-                  <SettingsModalProvider>
-                    <SelectedFolderProvider>
-                      <SidebarDrillDownProvider>
-                        <AppSidebar currentPage={currentPage} viewCounts={viewCounts} />
-                        <SidebarInset className="flex flex-col overflow-hidden">
-                          <AppContent />
-                        </SidebarInset>
-                      </SidebarDrillDownProvider>
-                      <TaskDragOverlay projects={projectsWithCounts} />
-                    </SelectedFolderProvider>
-                  </SettingsModalProvider>
-                </TabPersistenceManager>
-              </TabProvider>
-            </HintModeProvider>
-          </AIInlineProvider>
+          <CalendarViewProvider>
+            <AIInlineProvider>
+              <HintModeProvider>
+                <TabProvider>
+                  <TabPersistenceManager>
+                    <SettingsModalProvider>
+                      <SelectedFolderProvider>
+                        <SidebarDrillDownProvider>
+                          <AppSidebar currentPage={currentPage} viewCounts={viewCounts} />
+                          <SidebarInset className="flex flex-col overflow-hidden">
+                            <AppContent />
+                          </SidebarInset>
+                        </SidebarDrillDownProvider>
+                        <TaskDragOverlay projects={projectsWithCounts} />
+                      </SelectedFolderProvider>
+                    </SettingsModalProvider>
+                  </TabPersistenceManager>
+                </TabProvider>
+              </HintModeProvider>
+            </AIInlineProvider>
+          </CalendarViewProvider>
         </DayPanelProvider>
       </TasksProvider>
     </TabErrorBoundary>

--- a/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
@@ -6,7 +6,8 @@ import {
   DAY_PANEL_WIDTH_MIN_PX,
   DAY_PANEL_WIDTH_MAX_PX
 } from '@/contexts/day-panel-context'
-import { useTabs } from '@/contexts/tabs'
+import { useTabs, useActiveTab } from '@/contexts/tabs'
+import { useCalendarView } from '@/contexts/calendar-view-context'
 import { DatePickerCalendar } from '@/components/tasks/date-picker-calendar'
 import { JournalDayPanel } from '@/components/journal'
 import { useJournalHeatmap } from '@/hooks/use-journal'
@@ -76,6 +77,9 @@ function DayPanelResizeRail() {
 export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
   const { isOpen, selectedDate, width, isResizing, setDate } = useDayPanel()
   const { openTab } = useTabs()
+  const activeTab = useActiveTab()
+  const { setAnchorDate } = useCalendarView()
+  const isCalendarTabActive = activeTab?.type === 'calendar'
 
   const selectedDateObj = parseISODate(selectedDate)
   const currentYear = selectedDateObj.getFullYear()
@@ -111,16 +115,24 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
       if (!date) return
       const iso = formatDateToISO(date)
       setDate(iso)
+      if (isCalendarTabActive) {
+        setAnchorDate(iso)
+        return
+      }
       navigateToJournal(iso)
     },
-    [setDate, navigateToJournal]
+    [isCalendarTabActive, setDate, setAnchorDate, navigateToJournal]
   )
 
   const handleTodayClick = useCallback(() => {
     const today = getTodayString()
     setDate(today)
+    if (isCalendarTabActive) {
+      setAnchorDate(today)
+      return
+    }
     navigateToJournal(today)
-  }, [setDate, navigateToJournal])
+  }, [isCalendarTabActive, setDate, setAnchorDate, navigateToJournal])
 
   return (
     <div

--- a/apps/desktop/src/renderer/src/contexts/calendar-view-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/calendar-view-context.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react'
+import { toLocalDateString } from '@/components/calendar/date-utils'
+
+export interface CalendarViewContextValue {
+  anchorDate: string
+  setAnchorDate: React.Dispatch<React.SetStateAction<string>>
+}
+
+interface CalendarViewProviderProps {
+  children: ReactNode
+}
+
+const CalendarViewContext = createContext<CalendarViewContextValue | null>(null)
+
+export const useCalendarView = (): CalendarViewContextValue => {
+  const context = useContext(CalendarViewContext)
+  if (!context) {
+    throw new Error('useCalendarView must be used within a CalendarViewProvider')
+  }
+  return context
+}
+
+function getTodayAnchor(): string {
+  return toLocalDateString(new Date())
+}
+
+export const CalendarViewProvider = ({
+  children
+}: CalendarViewProviderProps): React.JSX.Element => {
+  const [anchorDate, setAnchorDate] = useState<string>(getTodayAnchor)
+
+  const value = useMemo<CalendarViewContextValue>(
+    () => ({ anchorDate, setAnchorDate }),
+    [anchorDate]
+  )
+
+  return <CalendarViewContext.Provider value={value}>{children}</CalendarViewContext.Provider>
+}
+
+export default CalendarViewProvider

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -25,6 +25,7 @@ import {
   type CalendarSourceRecord
 } from '@/services/calendar-service'
 import { useDayPanel } from '@/contexts/day-panel-context'
+import { useCalendarView } from '@/contexts/calendar-view-context'
 
 interface CalendarPageProps {
   className?: string
@@ -158,7 +159,7 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
       /* localStorage unavailable */
     }
   }
-  const [anchorDate, setAnchorDate] = useState(getTodayDate)
+  const { anchorDate, setAnchorDate } = useCalendarView()
   const [showMemryItems, setShowMemryItems] = useState(true)
   const [showImportedCalendars, setShowImportedCalendars] = useState(true)
   const [selectedImportedSourceIds, setSelectedImportedSourceIds] = useState<string[]>([])

--- a/apps/desktop/tests/utils/render.tsx
+++ b/apps/desktop/tests/utils/render.tsx
@@ -8,6 +8,7 @@ import { render, RenderOptions, RenderResult } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi } from 'vitest'
 import { DayPanelProvider } from '@/contexts/day-panel-context'
+import { CalendarViewProvider } from '@/contexts/calendar-view-context'
 
 // Re-export everything from testing-library
 export * from '@testing-library/react'
@@ -58,7 +59,9 @@ function AllProviders({ children, queryClient }: AllProvidersProps): ReactElemen
 
   return (
     <QueryClientProvider client={client}>
-      <DayPanelProvider>{children}</DayPanelProvider>
+      <DayPanelProvider>
+        <CalendarViewProvider>{children}</CalendarViewProvider>
+      </DayPanelProvider>
     </QueryClientProvider>
   )
 }


### PR DESCRIPTION
## What

The global right-sidebar mini-calendar now behaves based on the active tab:

| Active tab | Sidebar day click |
| --- | --- |
| Calendar | Re-anchors the current calendar view (day/week/month/year) in place |
| Anything else | Opens/focuses Journal at that date *(unchanged)* |

The Today button in the sidebar follows the same branch.

## Why

Before this change, every sidebar day click navigated to the Journal tab — disruptive when the user is actively working in Calendar, since it yanked them out of their Month/Week/Year view just to focus a date. Making the sidebar context-aware lets the same UI serve both workflows: fast navigation inside Calendar, and quick journaling from anywhere else.

## How

- **New `CalendarViewContext`** (`apps/desktop/src/renderer/src/contexts/calendar-view-context.tsx`) — holds the single `anchorDate` shared between `CalendarPage` and `GlobalDayPanel`. Mirrors the `DayPanelContext` pattern (null sentinel + throwing hook).
- **`GlobalDayPanel`** branches `handleDateSelect` / `handleTodayClick` on `useActiveTab()?.type === 'calendar'`.
- **`CalendarPage`** swaps its local `useState(getTodayDate)` for `useCalendarView()`. No other handler changes — the React `useState` setter identity is preserved through context, so `setAnchorDate((current) => ...)` functional updates in `handlePrevious` / `handleNext` keep working.
- **All four views handled by one branch**: `getRangeForView(view, anchorDate)` already derives day/week/month/year ranges from a single anchor, so setting `anchorDate = clickedDate` re-centers whichever view is active. No per-view code.
- **Test wrapper updated**: `tests/utils/render.tsx` wraps the new provider inside the existing `DayPanelProvider` — one edit fixed all 3 calendar test files without per-test churn.

## Type

- [x] `feat` — new feature

## Test plan

- [x] Unit tests updated (central `renderWithProviders` wrapper)
- [x] Manual testing TODO:
  - [ ] Notes tab → click sidebar day → Journal opens at date *(regression)*
  - [ ] Journal tab → click sidebar day → Journal re-focuses date *(regression)*
  - [ ] Calendar / Month view → click sidebar day in another month → Month view scrolls, no tab switch
  - [ ] Calendar / Week view → click sidebar day → week grid re-centers
  - [ ] Calendar / Year view → click sidebar day in another year → year grid changes
  - [ ] Calendar / Day view → click sidebar day → Day view and sidebar stay in sync
  - [ ] Today button from Calendar tab → anchor jumps to today, no tab switch
- Verification run in this branch: `pnpm --filter desktop typecheck:web` clean, `pnpm lint` 0 errors, `pnpm test` — **6912 passed, 0 failed**.

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns