### PR TITLE
fix(calendar): M1 — propagate Google pull-side updates and deletes

### DIFF
--- a/apps/desktop/src/main/calendar/google/sync-service.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.test.ts
@@ -806,6 +806,98 @@ describe('google calendar sync service', () => {
     expect(refreshedBinding?.remoteVersion).toBe('"etag-new"')
   })
 
+  it('deletes the native record when a bound Google event is cancelled', async () => {
+    // #given a selected source, a native calendar_events row, and a binding
+    const now = '2026-04-18T09:00:00.000Z'
+    seedGoogleCalendarSource({
+      id: 'google-calendar:selected',
+      remoteId: 'remote-selected-calendar',
+      title: 'Personal',
+      color: null,
+      isMemryManaged: false,
+      syncCursor: 'cursor-1',
+      syncStatus: 'ok'
+    })
+
+    db.insert(calendarEvents)
+      .values({
+        id: 'event-bound-delete',
+        title: 'About to be deleted',
+        startAt: '2026-04-20T09:00:00.000Z',
+        endAt: '2026-04-20T10:00:00.000Z',
+        timezone: 'UTC',
+        isAllDay: false,
+        clock: { 'device-a': 1 },
+        createdAt: now,
+        modifiedAt: now
+      })
+      .run()
+
+    db.insert(calendarBindings)
+      .values({
+        id: 'binding-bound-delete',
+        sourceType: 'event',
+        sourceId: 'event-bound-delete',
+        provider: 'google',
+        remoteCalendarId: 'remote-selected-calendar',
+        remoteEventId: 'remote-event-bound-delete',
+        ownershipMode: 'memry_managed',
+        writebackMode: 'broad',
+        remoteVersion: '"etag-old"',
+        lastLocalSnapshot: null,
+        archivedAt: null,
+        clock: { 'device-a': 1 },
+        syncedAt: now,
+        createdAt: now,
+        modifiedAt: now
+      })
+      .run()
+
+    const client = {
+      listEvents: vi.fn(async () => ({
+        nextSyncCursor: 'cursor-2',
+        events: [
+          {
+            id: 'remote-event-bound-delete',
+            calendarId: 'remote-selected-calendar',
+            title: 'About to be deleted',
+            description: null,
+            location: null,
+            startAt: '2026-04-20T09:00:00.000Z',
+            endAt: '2026-04-20T10:00:00.000Z',
+            isAllDay: false,
+            timezone: 'UTC',
+            status: 'cancelled' as const,
+            etag: '"etag-cancelled"',
+            updatedAt: '2026-04-18T08:30:00.000Z',
+            raw: {}
+          }
+        ]
+      }))
+    }
+
+    // #when
+    await syncGoogleCalendarSource(db, 'google-calendar:selected', { client })
+
+    // #then: native row gone, binding archived, mirror untouched
+    const survivingEvent = db
+      .select()
+      .from(calendarEvents)
+      .where(eq(calendarEvents.id, 'event-bound-delete'))
+      .get()
+    expect(survivingEvent).toBeUndefined()
+
+    const archivedBinding = db
+      .select()
+      .from(calendarBindings)
+      .where(eq(calendarBindings.id, 'binding-bound-delete'))
+      .get()
+    expect(archivedBinding?.archivedAt).toBeTruthy()
+
+    const mirrorRows = db.select().from(calendarExternalEvents).all()
+    expect(mirrorRows).toHaveLength(0)
+  })
+
   describe('syncGoogleCalendarNow gating', () => {
     function buildClient() {
       return {

--- a/apps/desktop/src/main/calendar/google/sync-service.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.test.ts
@@ -694,6 +694,118 @@ describe('google calendar sync service', () => {
     expect(client.deleteEvent).not.toHaveBeenCalled()
   })
 
+  it('routes Google updates for bound events through applyGoogleCalendarWriteback instead of the mirror', async () => {
+    // #given a selected non-managed source with an active binding for one remote event
+    const now = '2026-04-18T09:00:00.000Z'
+    db.insert(calendarSources)
+      .values({
+        id: 'google-calendar:selected',
+        provider: 'google',
+        kind: 'calendar',
+        accountId: 'google-account:1',
+        remoteId: 'remote-selected-calendar',
+        title: 'Personal',
+        timezone: 'UTC',
+        color: null,
+        isPrimary: false,
+        isSelected: true,
+        isMemryManaged: false,
+        syncCursor: 'cursor-1',
+        syncStatus: 'ok',
+        metadata: null,
+        clock: { 'device-a': 1 },
+        createdAt: now,
+        modifiedAt: now
+      })
+      .run()
+
+    db.insert(calendarEvents)
+      .values({
+        id: 'event-bound-1',
+        title: 'Old title',
+        description: null,
+        location: null,
+        startAt: '2026-04-20T09:00:00.000Z',
+        endAt: '2026-04-20T10:00:00.000Z',
+        timezone: 'UTC',
+        isAllDay: false,
+        clock: { 'device-a': 1 },
+        createdAt: now,
+        modifiedAt: now
+      })
+      .run()
+
+    db.insert(calendarBindings)
+      .values({
+        id: 'binding-bound-1',
+        sourceType: 'event',
+        sourceId: 'event-bound-1',
+        provider: 'google',
+        remoteCalendarId: 'remote-selected-calendar',
+        remoteEventId: 'remote-event-bound-1',
+        ownershipMode: 'memry_managed',
+        writebackMode: 'broad',
+        remoteVersion: '"etag-old"',
+        lastLocalSnapshot: null,
+        archivedAt: null,
+        clock: { 'device-a': 1 },
+        syncedAt: now,
+        createdAt: now,
+        modifiedAt: now
+      })
+      .run()
+
+    const client = {
+      listEvents: vi.fn(async () => ({
+        nextSyncCursor: 'cursor-2',
+        events: [
+          {
+            id: 'remote-event-bound-1',
+            calendarId: 'remote-selected-calendar',
+            title: 'Updated from Google',
+            description: 'Updated description',
+            location: 'Updated location',
+            startAt: '2026-04-20T11:00:00.000Z',
+            endAt: '2026-04-20T12:00:00.000Z',
+            isAllDay: false,
+            timezone: 'UTC',
+            status: 'confirmed' as const,
+            etag: '"etag-new"',
+            updatedAt: '2026-04-18T08:00:00.000Z',
+            raw: {}
+          }
+        ]
+      }))
+    }
+
+    // #when
+    await syncGoogleCalendarSource(db, 'google-calendar:selected', { client })
+
+    // #then: the native row was updated, the mirror was NOT, the binding etag refreshed
+    const updatedEvent = db
+      .select()
+      .from(calendarEvents)
+      .where(eq(calendarEvents.id, 'event-bound-1'))
+      .get()
+    expect(updatedEvent).toMatchObject({
+      title: 'Updated from Google',
+      description: 'Updated description',
+      location: 'Updated location',
+      startAt: '2026-04-20T11:00:00.000Z',
+      endAt: '2026-04-20T12:00:00.000Z'
+    })
+
+    const mirrorRows = db.select().from(calendarExternalEvents).all()
+    expect(mirrorRows).toHaveLength(0)
+
+    const refreshedBinding = db
+      .select()
+      .from(calendarBindings)
+      .where(eq(calendarBindings.id, 'binding-bound-1'))
+      .get()
+    expect(refreshedBinding?.remoteVersion).toBe('"etag-new"')
+  })
+
   describe('syncGoogleCalendarNow gating', () => {
     function buildClient() {
       return {

--- a/apps/desktop/src/main/calendar/google/sync-service.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.test.ts
@@ -975,6 +975,49 @@ describe('google calendar sync service', () => {
     expect(mirrorRow?.archivedAt).toBeTruthy()
   })
 
+  it('does not materialize a mirror row when an unbound Google event arrives already cancelled', async () => {
+    // #given a selected source with NO existing mirror row and NO binding
+    seedGoogleCalendarSource({
+      id: 'google-calendar:selected',
+      remoteId: 'remote-selected-calendar',
+      title: 'Personal',
+      color: null,
+      isMemryManaged: false,
+      syncCursor: 'cursor-1',
+      syncStatus: 'ok'
+    })
+
+    const client = {
+      listEvents: vi.fn(async () => ({
+        nextSyncCursor: 'cursor-2',
+        events: [
+          {
+            id: 'remote-never-seen-1',
+            calendarId: 'remote-selected-calendar',
+            title: 'Cancelled before we saw it',
+            description: null,
+            location: null,
+            startAt: '2026-04-20T09:00:00.000Z',
+            endAt: '2026-04-20T10:00:00.000Z',
+            isAllDay: false,
+            timezone: 'UTC',
+            status: 'cancelled' as const,
+            etag: '"etag-cancelled"',
+            updatedAt: '2026-04-18T08:45:00.000Z',
+            raw: {}
+          }
+        ]
+      }))
+    }
+
+    // #when
+    await syncGoogleCalendarSource(db, 'google-calendar:selected', { client })
+
+    // #then: no mirror row was created (no tombstone for events we never saw)
+    const mirrorRows = db.select().from(calendarExternalEvents).all()
+    expect(mirrorRows).toHaveLength(0)
+  })
+
   describe('syncGoogleCalendarNow gating', () => {
     function buildClient() {
       return {

--- a/apps/desktop/src/main/calendar/google/sync-service.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.test.ts
@@ -898,6 +898,83 @@ describe('google calendar sync service', () => {
     expect(mirrorRows).toHaveLength(0)
   })
 
+  it('archives the mirror row when an unbound Google event is cancelled', async () => {
+    // #given a selected source with an existing mirror row and no binding
+    const now = '2026-04-18T09:00:00.000Z'
+    seedGoogleCalendarSource({
+      id: 'google-calendar:selected',
+      remoteId: 'remote-selected-calendar',
+      title: 'Personal',
+      color: null,
+      isMemryManaged: false,
+      syncCursor: 'cursor-1',
+      syncStatus: 'ok'
+    })
+
+    db.insert(calendarExternalEvents)
+      .values({
+        id: 'calendar_external_event:google-calendar:selected:remote-unbound-1',
+        sourceId: 'google-calendar:selected',
+        remoteEventId: 'remote-unbound-1',
+        remoteEtag: '"etag-old"',
+        remoteUpdatedAt: '2026-04-18T07:00:00.000Z',
+        title: 'External event',
+        description: null,
+        location: null,
+        startAt: '2026-04-20T09:00:00.000Z',
+        endAt: '2026-04-20T10:00:00.000Z',
+        timezone: 'UTC',
+        isAllDay: false,
+        status: 'confirmed',
+        recurrenceRule: null,
+        rawPayload: {},
+        archivedAt: null,
+        clock: { 'device-a': 1 },
+        createdAt: now,
+        modifiedAt: now
+      })
+      .run()
+
+    const client = {
+      listEvents: vi.fn(async () => ({
+        nextSyncCursor: 'cursor-2',
+        events: [
+          {
+            id: 'remote-unbound-1',
+            calendarId: 'remote-selected-calendar',
+            title: 'External event',
+            description: null,
+            location: null,
+            startAt: '2026-04-20T09:00:00.000Z',
+            endAt: '2026-04-20T10:00:00.000Z',
+            isAllDay: false,
+            timezone: 'UTC',
+            status: 'cancelled' as const,
+            etag: '"etag-cancelled"',
+            updatedAt: '2026-04-18T08:45:00.000Z',
+            raw: {}
+          }
+        ]
+      }))
+    }
+
+    // #when
+    await syncGoogleCalendarSource(db, 'google-calendar:selected', { client })
+
+    // #then: the mirror row is archived (archivedAt set), not deleted
+    const mirrorRow = db
+      .select()
+      .from(calendarExternalEvents)
+      .where(
+        eq(
+          calendarExternalEvents.id,
+          'calendar_external_event:google-calendar:selected:remote-unbound-1'
+        )
+      )
+      .get()
+    expect(mirrorRow?.archivedAt).toBeTruthy()
+  })
+
   describe('syncGoogleCalendarNow gating', () => {
     function buildClient() {
       return {

--- a/apps/desktop/src/main/calendar/google/sync-service.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.test.ts
@@ -1018,6 +1018,42 @@ describe('google calendar sync service', () => {
     expect(mirrorRows).toHaveLength(0)
   })
 
+  it('recovers from a 410 Gone by clearing syncCursor and re-syncing', async () => {
+    // #given a selected source with a stale syncCursor
+    seedGoogleCalendarSource({
+      id: 'google-calendar:selected',
+      remoteId: 'remote-selected-calendar',
+      title: 'Personal',
+      color: null,
+      isMemryManaged: false,
+      syncCursor: 'stale-cursor',
+      syncStatus: 'ok'
+    })
+
+    const goneError = Object.assign(new Error('Gone'), { status: 410 })
+    const listEvents = vi.fn().mockRejectedValueOnce(goneError).mockResolvedValueOnce({
+      nextSyncCursor: 'cursor-fresh',
+      events: []
+    })
+
+    const client = { listEvents }
+
+    // #when
+    await syncGoogleCalendarSource(db, 'google-calendar:selected', { client })
+
+    // #then: listEvents called twice — once with the stale cursor, once with null
+    expect(listEvents).toHaveBeenCalledTimes(2)
+    expect(listEvents.mock.calls[0]?.[0]).toMatchObject({ syncCursor: 'stale-cursor' })
+    expect(listEvents.mock.calls[1]?.[0]).toMatchObject({ syncCursor: null })
+
+    const refreshedSource = db
+      .select()
+      .from(calendarSources)
+      .where(eq(calendarSources.id, 'google-calendar:selected'))
+      .get()
+    expect(refreshedSource?.syncCursor).toBe('cursor-fresh')
+  })
+
   describe('syncGoogleCalendarNow gating', () => {
     function buildClient() {
       return {

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -532,6 +532,8 @@ export async function syncGoogleCalendarSource(
   const now = getNow()
   const isInitialSync = !source.syncCursor
 
+  // Defensive: current client returns { events: [], nextSyncCursor: null } on 410 (handled
+  // below via the cursor-invalidation branch); future client variants may throw — keep as insurance.
   let result: Awaited<ReturnType<GoogleCalendarClient['listEvents']>>
   try {
     result = await client.listEvents({

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -561,6 +561,19 @@ export async function syncGoogleCalendarSource(
 
     const record = mapGoogleEventToExternalEventRecord(source.id, remoteEvent, now)
     const existing = getCalendarExternalEventById(db, record.id)
+
+    if (remoteEvent.status === 'cancelled') {
+      if (!existing) continue
+      upsertCalendarExternalEvent(db, {
+        ...record,
+        clock: existing.clock,
+        archivedAt: now
+      })
+      markSyncedTableMutation('calendar_external_event', record.id, true)
+      emitCalendarChanged({ entityType: 'calendar_external_event', id: record.id })
+      continue
+    }
+
     upsertCalendarExternalEvent(db, {
       ...record,
       clock: existing?.clock

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -57,6 +57,15 @@ function getNow(): string {
   return new Date().toISOString()
 }
 
+function isGoneError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    (error as { status: unknown }).status === 410
+  )
+}
+
 function markSyncedTableMutation(
   entityType: 'calendar_binding' | 'calendar_source' | 'calendar_external_event',
   id: string,
@@ -523,12 +532,28 @@ export async function syncGoogleCalendarSource(
   const now = getNow()
   const isInitialSync = !source.syncCursor
 
-  const result = await client.listEvents({
-    calendarId: source.remoteId,
-    syncCursor: source.syncCursor ?? null,
-    timeMin: isInitialSync ? new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString() : null,
-    timeMax: isInitialSync ? new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString() : null
-  })
+  let result: Awaited<ReturnType<GoogleCalendarClient['listEvents']>>
+  try {
+    result = await client.listEvents({
+      calendarId: source.remoteId,
+      syncCursor: source.syncCursor ?? null,
+      timeMin: isInitialSync ? new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString() : null,
+      timeMax: isInitialSync ? new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString() : null
+    })
+  } catch (error) {
+    if (isGoneError(error) && source.syncCursor) {
+      log.warn('Google returned 410 for source; clearing cursor and re-syncing', { sourceId })
+      const freshSource = upsertCalendarSource(db, {
+        ...source,
+        syncCursor: null,
+        syncStatus: 'pending',
+        modifiedAt: now
+      })
+      markSyncedTableMutation('calendar_source', freshSource.id, true)
+      return await syncGoogleCalendarSource(db, sourceId, deps)
+    }
+    throw error
+  }
 
   if (!result.nextSyncCursor && source.syncCursor) {
     log.warn('sync cursor invalidated for source, re-syncing from scratch', { sourceId })

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -31,6 +31,7 @@ import {
   upsertCalendarExternalEvent
 } from '../repositories/calendar-external-events-repository'
 import {
+  findCalendarBindingByRemoteEvent,
   getCalendarSourceById,
   listCalendarBindingsForSource,
   listCalendarSources,
@@ -542,6 +543,18 @@ export async function syncGoogleCalendarSource(
   }
 
   for (const remoteEvent of result.events) {
+    const binding = findCalendarBindingByRemoteEvent(
+      db,
+      'google',
+      remoteEvent.calendarId,
+      remoteEvent.id
+    )
+
+    if (binding) {
+      await applyGoogleCalendarWriteback(db, binding, remoteEvent)
+      continue
+    }
+
     const record = mapGoogleEventToExternalEventRecord(source.id, remoteEvent, now)
     const existing = getCalendarExternalEventById(db, record.id)
     upsertCalendarExternalEvent(db, {

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -551,7 +551,11 @@ export async function syncGoogleCalendarSource(
     )
 
     if (binding) {
-      await applyGoogleCalendarWriteback(db, binding, remoteEvent)
+      if (remoteEvent.status === 'cancelled') {
+        await applyGoogleCalendarDelete(db, binding)
+      } else {
+        await applyGoogleCalendarWriteback(db, binding, remoteEvent)
+      }
       continue
     }
 

--- a/apps/desktop/src/main/calendar/repositories/calendar-sources-repository.test.ts
+++ b/apps/desktop/src/main/calendar/repositories/calendar-sources-repository.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createTestDataDb, type TestDatabaseResult, type TestDb } from '@tests/utils/test-db'
+import { calendarBindings } from '@memry/db-schema/schema/calendar-bindings'
+import { findCalendarBindingByRemoteEvent } from './calendar-sources-repository'
+
+describe('findCalendarBindingByRemoteEvent', () => {
+  let dbResult: TestDatabaseResult
+  let db: TestDb
+
+  beforeEach(() => {
+    dbResult = createTestDataDb()
+    db = dbResult.db
+  })
+
+  afterEach(() => {
+    dbResult.close()
+  })
+
+  it('returns the active binding matching provider + remoteCalendarId + remoteEventId', () => {
+    // #given
+    const now = '2026-04-18T09:00:00.000Z'
+    db.insert(calendarBindings)
+      .values([
+        {
+          id: 'binding-1',
+          sourceType: 'event',
+          sourceId: 'event-a',
+          provider: 'google',
+          remoteCalendarId: 'cal-1',
+          remoteEventId: 'evt-1',
+          ownershipMode: 'memry_managed',
+          writebackMode: 'broad',
+          remoteVersion: '"etag-1"',
+          lastLocalSnapshot: null,
+          archivedAt: null,
+          clock: { 'device-a': 1 },
+          syncedAt: now,
+          createdAt: now,
+          modifiedAt: now
+        },
+        {
+          id: 'binding-archived',
+          sourceType: 'task',
+          sourceId: 'task-a',
+          provider: 'google',
+          remoteCalendarId: 'cal-1',
+          remoteEventId: 'evt-2',
+          ownershipMode: 'memry_managed',
+          writebackMode: 'broad',
+          remoteVersion: null,
+          lastLocalSnapshot: null,
+          archivedAt: now,
+          clock: { 'device-a': 1 },
+          syncedAt: now,
+          createdAt: now,
+          modifiedAt: now
+        }
+      ])
+      .run()
+
+    // #when
+    const match = findCalendarBindingByRemoteEvent(db, 'google', 'cal-1', 'evt-1')
+    const archivedMatch = findCalendarBindingByRemoteEvent(db, 'google', 'cal-1', 'evt-2')
+    const missing = findCalendarBindingByRemoteEvent(db, 'google', 'cal-1', 'evt-missing')
+
+    // #then
+    expect(match?.id).toBe('binding-1')
+    expect(archivedMatch).toBeUndefined()
+    expect(missing).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/calendar/repositories/calendar-sources-repository.ts
+++ b/apps/desktop/src/main/calendar/repositories/calendar-sources-repository.ts
@@ -94,3 +94,23 @@ export function listCalendarBindingsForSource(
     )
     .all()
 }
+
+export function findCalendarBindingByRemoteEvent(
+  db: DataDb,
+  provider: string,
+  remoteCalendarId: string,
+  remoteEventId: string
+): CalendarBinding | undefined {
+  return db
+    .select()
+    .from(calendarBindings)
+    .where(
+      and(
+        eq(calendarBindings.provider, provider),
+        eq(calendarBindings.remoteCalendarId, remoteCalendarId),
+        eq(calendarBindings.remoteEventId, remoteEventId),
+        isNull(calendarBindings.archivedAt)
+      )
+    )
+    .get()
+}


### PR DESCRIPTION
## Summary

Milestone 1 of Google Calendar Phase 2. Fixes three correctness bugs in the Google pull loop so Google-side updates, deletions, and cursor-invalidation reach bound Memry records.

- Route bound-remote updates through `applyGoogleCalendarWriteback` (previously never invoked by the pull loop)
- Propagate Google cancellations through `applyGoogleCalendarDelete` (previously dropped)
- Archive the mirror row when an unbound Google event is cancelled + skip phantom materialization for never-seen cancellations
- Defensive 410 Gone handling around `client.listEvents` — insurance for future client variants; see docs commit for why current path is dormant

No schema changes, no new IPC surface, no renderer changes.

**Design:** `.claude/plans/2026-04-18-google-calendar-phase-2-design.md`
**Plan:** `.claude/plans/2026-04-18-google-calendar-phase-2-m1-correctness.md`

## Test plan

- [x] Unit: `findCalendarBindingByRemoteEvent` returns the active binding and skips archived ones
- [x] Integration: bound Google update writes through to native `calendar_events` row; mirror stays empty; binding etag refreshed
- [x] Integration: bound Google cancellation deletes the native row and archives the binding
- [x] Integration: unbound Google cancellation archives the existing mirror row
- [x] Integration: unbound Google cancellation with no pre-existing mirror does NOT materialize a phantom archived row
- [x] Integration: 410 Gone on `listEvents` clears `syncCursor` and retries with `null`
- [x] Full `pnpm --filter @memry/desktop exec vitest run` green
- [x] `pnpm typecheck:node` and `pnpm typecheck:web` clean (modulo known pre-existing test-file errors called out in CLAUDE.md)
- [x] `pnpm lint` clean