### PR TITLE
test(calendar): e2e coverage for M2 promote-external flow

### DIFF
--- a/apps/desktop/tests/e2e/calendar-comprehensive.e2e.ts
+++ b/apps/desktop/tests/e2e/calendar-comprehensive.e2e.ts
@@ -261,11 +261,10 @@ test.describe('Calendar — comprehensive coverage', () => {
       await expect(cal.eventChip(original)).toHaveCount(0)
     })
 
-    // Imported-source click behavior is governed by handleSelectItem's
-    // `sourceType !== 'event'` gate; since seeded imported items may not be
-    // sourceType:'event', the editor may not open. Skipping until the
-    // imported-event interaction contract is finalized.
-    test.skip('clicking an imported event opens the editor in edit mode', async () => {})
+    // Imported-event click behavior is finalized by M2: clicking shows the
+    // promote-external confirmation dialog, then (on confirm) opens the edit
+    // popover on the newly-promoted native row.
+    // Covered end-to-end in calendar-promote-external.e2e.ts.
   })
 
   test.describe('Loading state', () => {

--- a/apps/desktop/tests/e2e/calendar-promote-external.e2e.ts
+++ b/apps/desktop/tests/e2e/calendar-promote-external.e2e.ts
@@ -1,0 +1,206 @@
+/**
+ * M2 promote-external-event flow.
+ *
+ * Clicking an externally-owned Google event chip in Memry should open a
+ * confirmation dialog ("Edit this event in Memry?"). Confirming the dialog
+ * must create a linked calendar_events row, archive the mirror, and open the
+ * edit popover so the user can immediately make changes.
+ *
+ * This file covers the user-visible path end-to-end; internal correctness
+ * (binding ownership mode, mirror archival, idempotency) is unit-tested in
+ * src/main/calendar/promote-external-event.test.ts.
+ */
+import type { ElectronApplication } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
+
+interface SeededCalendarData {
+  day: string
+  importedTitle: string
+  taskTitle: string
+  reminderTitle: string
+  snoozeTitle: string
+}
+
+function toIsoDay(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function getSeededCalendarData(): SeededCalendarData {
+  const today = new Date()
+  return {
+    day: toIsoDay(today),
+    importedTitle: 'Imported customer call',
+    taskTitle: 'Due launch brief',
+    reminderTitle: 'Medication reminder',
+    snoozeTitle: 'Review investor email'
+  }
+}
+
+async function seedProjection(
+  electronApp: ElectronApplication,
+  input: SeededCalendarData
+): Promise<void> {
+  await electronApp.evaluate(async (_ctx, payload) => {
+    const hooks = (
+      globalThis as typeof globalThis & {
+        __memryTestHooks?: { seedCalendarProjection(d: SeededCalendarData): Promise<void> }
+      }
+    ).__memryTestHooks
+    if (!hooks) throw new Error('Memry test hooks are not registered')
+    await hooks.seedCalendarProjection(payload)
+  }, input)
+}
+
+test.describe('Calendar — M2 promote external event', () => {
+  test.beforeEach(async ({ page, electronApp }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+    await seedProjection(electronApp, getSeededCalendarData())
+
+    await page.getByRole('button', { name: 'Calendar' }).click()
+    const calendarPage = page.getByTestId('calendar-page')
+    await expect(calendarPage).toBeVisible()
+    await calendarPage.getByRole('button', { name: 'Day', exact: true }).click()
+    await expect(page.getByTestId('calendar-view')).toHaveAttribute('data-view', 'day')
+  })
+
+  test('#given an imported Google event #when the user clicks it #then the promote-external confirmation dialog appears', async ({
+    page
+  }) => {
+    const { importedTitle } = getSeededCalendarData()
+    const calendarPage = page.getByTestId('calendar-page')
+
+    // #when: click the imported event chip
+    const chip = calendarPage.getByRole('button', { name: new RegExp(importedTitle) }).first()
+    await expect(chip).toBeVisible()
+    await chip.click()
+
+    // #then: promote confirmation dialog appears with copy from the M2 design
+    const dialog = page.getByTestId('promote-external-dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByText('Edit this event in Memry?')).toBeVisible()
+    await expect(dialog.getByText(/create a linked copy/i)).toBeVisible()
+    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeVisible()
+    await expect(dialog.getByRole('button', { name: /Edit in Memry/i })).toBeVisible()
+  })
+
+  test('#given the promote dialog is open #when the user cancels #then the dialog closes and no edit popover opens', async ({
+    page
+  }) => {
+    const { importedTitle } = getSeededCalendarData()
+    const calendarPage = page.getByTestId('calendar-page')
+
+    await calendarPage
+      .getByRole('button', { name: new RegExp(importedTitle) })
+      .first()
+      .click()
+    const dialog = page.getByTestId('promote-external-dialog')
+    await expect(dialog).toBeVisible()
+
+    // #when
+    await dialog.getByRole('button', { name: 'Cancel' }).click()
+
+    // #then
+    await expect(dialog).toBeHidden()
+    await expect(page.getByTestId('event-edit-popover')).toHaveCount(0)
+
+    // The original imported chip is still shown — nothing was promoted
+    await expect(
+      calendarPage.getByRole('button', { name: new RegExp(importedTitle) }).first()
+    ).toBeVisible()
+  })
+
+  test('#given the user confirms the promote dialog #when promote succeeds #then the edit popover opens pre-populated from the external event', async ({
+    page
+  }) => {
+    const { importedTitle } = getSeededCalendarData()
+    const calendarPage = page.getByTestId('calendar-page')
+
+    await calendarPage
+      .getByRole('button', { name: new RegExp(importedTitle) })
+      .first()
+      .click()
+    const dialog = page.getByTestId('promote-external-dialog')
+    await expect(dialog).toBeVisible()
+
+    // #when
+    await dialog.getByRole('button', { name: /Edit in Memry/i }).click()
+
+    // #then: dialog gone, edit popover visible, title input carries the external event's title
+    await expect(dialog).toBeHidden()
+    const popover = page.getByTestId('event-edit-popover')
+    await expect(popover).toBeVisible()
+    await expect(popover.getByPlaceholder('New Event')).toHaveValue(importedTitle)
+  })
+
+  test('#given promote succeeded and the popover is open #when the user renames and saves #then the new title appears on the calendar', async ({
+    page
+  }) => {
+    const { importedTitle } = getSeededCalendarData()
+    const calendarPage = page.getByTestId('calendar-page')
+    const renamed = `Promoted-${Date.now()}`
+
+    await calendarPage
+      .getByRole('button', { name: new RegExp(importedTitle) })
+      .first()
+      .click()
+    await page
+      .getByTestId('promote-external-dialog')
+      .getByRole('button', { name: /Edit in Memry/i })
+      .click()
+
+    const popover = page.getByTestId('event-edit-popover')
+    await expect(popover).toBeVisible()
+    const titleInput = popover.getByPlaceholder('New Event')
+    await titleInput.fill(renamed)
+
+    // #when
+    await popover.getByTestId('event-edit-save').click()
+
+    // #then: popover closes, the renamed chip is visible
+    await expect(popover).toBeHidden()
+    await expect(
+      calendarPage.getByRole('button', { name: new RegExp(renamed) }).first()
+    ).toBeVisible()
+  })
+
+  test('#given promoteConfirmDismissed=true in settings #when the user clicks an imported event #then the dialog is skipped and the edit popover opens directly', async ({
+    page,
+    electronApp
+  }) => {
+    const { importedTitle } = getSeededCalendarData()
+
+    // #given
+    await electronApp.evaluate(async () => {
+      const api = (
+        globalThis as typeof globalThis & {
+          __memryTestHooks?: unknown
+        }
+      ).__memryTestHooks
+      if (!api) throw new Error('hooks missing')
+    })
+    // Flip the "don't ask again" flag via the renderer settings IPC (the same
+    // channel the dialog checkbox uses).
+    await page.evaluate(async () => {
+      await window.api.settings.setCalendarGoogleSettings({ promoteConfirmDismissed: true })
+    })
+
+    const calendarPage = page.getByTestId('calendar-page')
+
+    // #when
+    await calendarPage
+      .getByRole('button', { name: new RegExp(importedTitle) })
+      .first()
+      .click()
+
+    // #then: no dialog, popover opens straight away with the external title
+    await expect(page.getByTestId('promote-external-dialog')).toHaveCount(0)
+    const popover = page.getByTestId('event-edit-popover')
+    await expect(popover).toBeVisible()
+    await expect(popover.getByPlaceholder('New Event')).toHaveValue(importedTitle)
+  })
+})


### PR DESCRIPTION
## Summary

Adds end-to-end Playwright coverage for the only M1/M2/M3 user-visible flow that lacked it: **clicking an externally-owned Google calendar event and promoting it into a native Memry event**.

M1 (correctness fixes) and M3 (etag + field-clock conflict resolution) are entirely internal to the sync layer — their unit suites in \`sync-service.test.ts\`, \`field-merge-calendar.test.ts\`, \`onboarding.test.ts\`, and \`promote-external-event.test.ts\` already exercise every branch with a mocked \`GoogleCalendarClient\`. M2's promote flow is the one path that crosses main ↔ renderer ↔ DB and needed regression protection at the Playwright layer.

## What changed

- New [\`apps/desktop/tests/e2e/calendar-promote-external.e2e.ts\`](apps/desktop/tests/e2e/calendar-promote-external.e2e.ts) — 5 tests, BDD-style \`#given/#when/#then\` naming, \`data-testid\`-first selectors:
  1. Click imported chip → promote dialog appears with the M2 copy (\"Edit this event in Memry?\").
  2. Cancel → dialog closes, no popover, imported chip still present.
  3. Confirm → dialog closes, edit popover opens pre-populated with the external title.
  4. Rename after promote + save → renamed chip appears on the calendar.
  5. \`promoteConfirmDismissed=true\` in settings → dialog skipped, popover opens directly.
- Replaced the pre-M2 \`test.skip\` placeholder in [\`apps/desktop/tests/e2e/calendar-comprehensive.e2e.ts\`](apps/desktop/tests/e2e/calendar-comprehensive.e2e.ts) with a comment pointing to the new file.

Reuses the existing \`seedCalendarProjection\` test hook — no new test infrastructure.

## Test plan

- [x] \`pnpm typecheck:node\` passes
- [x] \`pnpm test\` full unit suite: 7005 passed / 1 skipped (unchanged baseline)
- [x] \`pnpm test:e2e\` filtered to \`calendar-promote-external\`: **5 passed (30.7s)** on first run against the existing M2 implementation
- [ ] CI green on full \`test:e2e\`

## Notes for reviewer

- All five tests passed on the very first run — no implementation changes were needed, so this is pure regression protection for M2's user-visible contract.
- The new file doesn't duplicate unit coverage: \`promote-external-event.test.ts\` already asserts row shape, binding ownership mode, mirror archival, and idempotency. The E2E asserts the user-visible flow (dialog copy, click wiring, popover population, persistence to the calendar view).