### PR TITLE
feat(calendar): M4a — Google Calendar push-channel server side

### DIFF
--- a/apps/desktop/src/main/calendar/google/client.test.ts
+++ b/apps/desktop/src/main/calendar/google/client.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import keytar from 'keytar'
+
+vi.mock('keytar', () => ({
+  default: {
+    setPassword: vi.fn(),
+    getPassword: vi.fn(),
+    deletePassword: vi.fn()
+  }
+}))
+
+vi.mock('electron', () => ({
+  shell: {
+    openExternal: vi.fn()
+  }
+}))
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => loggerMock
+}))
+
+import { createGoogleCalendarClient } from './client'
+import { clearGoogleCalendarTokens, storeGoogleCalendarTokens } from './keychain'
+
+describe('google calendar client — push channels (Task 7)', () => {
+  const keytarStore = new Map<string, string>()
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    keytarStore.clear()
+    process.env.GOOGLE_CALENDAR_CLIENT_ID = 'google-client-id-123'
+    vi.stubGlobal('fetch', fetchMock)
+
+    vi.mocked(keytar.setPassword).mockImplementation(async (service, account, value) => {
+      keytarStore.set(`${service}:${account}`, value)
+    })
+    vi.mocked(keytar.getPassword).mockImplementation(async (service, account) => {
+      return keytarStore.get(`${service}:${account}`) ?? null
+    })
+    vi.mocked(keytar.deletePassword).mockImplementation(async (service, account) => {
+      keytarStore.delete(`${service}:${account}`)
+      return true
+    })
+
+    await storeGoogleCalendarTokens({
+      accessToken: 'seeded-access-token',
+      refreshToken: 'seeded-refresh-token'
+    })
+  })
+
+  afterEach(async () => {
+    delete process.env.GOOGLE_CALENDAR_CLIENT_ID
+    vi.unstubAllGlobals()
+    await clearGoogleCalendarTokens()
+  })
+
+  describe('watchCalendar', () => {
+    it('POSTs events.watch with id/token/type/address/expiration and returns resourceId + expiration', async () => {
+      const nowMs = 1_700_000_000_000
+      vi.spyOn(Date, 'now').mockReturnValue(nowMs)
+
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input)
+        expect(url).toBe(
+          'https://www.googleapis.com/calendar/v3/calendars/primary%40group.calendar.google.com/events/watch'
+        )
+        expect(init?.method).toBe('POST')
+        expect((init?.headers as Record<string, string>).Authorization).toBe(
+          'Bearer seeded-access-token'
+        )
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+        expect(body).toEqual({
+          id: 'channel-abc',
+          token: 'plaintext-secret-xyz',
+          type: 'web_hook',
+          address: 'https://sync.memry.io/webhooks/google-calendar',
+          expiration: String(nowMs + 7 * 24 * 60 * 60 * 1000)
+        })
+        return new Response(
+          JSON.stringify({
+            kind: 'api#channel',
+            id: 'channel-abc',
+            resourceId: 'resource-123',
+            resourceUri: 'https://www.googleapis.com/calendar/v3/calendars/primary/events?alt=json',
+            expiration: String(nowMs + 7 * 24 * 60 * 60 * 1000)
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      })
+
+      const client = createGoogleCalendarClient()
+      const result = await client.watchCalendar({
+        calendarId: 'primary@group.calendar.google.com',
+        channelId: 'channel-abc',
+        token: 'plaintext-secret-xyz',
+        webhookUrl: 'https://sync.memry.io/webhooks/google-calendar',
+        ttlSeconds: 7 * 24 * 60 * 60
+      })
+
+      expect(result).toEqual({
+        resourceId: 'resource-123',
+        expiration: nowMs + 7 * 24 * 60 * 60 * 1000
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws a user-facing error when Google rejects the watch request', async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: { status: 'PERMISSION_DENIED', message: 'webhook domain not verified' }
+          }),
+          { status: 403 }
+        )
+      )
+
+      const client = createGoogleCalendarClient()
+      await expect(
+        client.watchCalendar({
+          calendarId: 'primary',
+          channelId: 'c1',
+          token: 't1',
+          webhookUrl: 'https://sync.memry.io/webhooks/google-calendar',
+          ttlSeconds: 3600
+        })
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('stopChannel', () => {
+    it('POSTs channels.stop with {id, resourceId} and resolves on 204', async () => {
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input)
+        expect(url).toBe('https://www.googleapis.com/calendar/v3/channels/stop')
+        expect(init?.method).toBe('POST')
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+        expect(body).toEqual({ id: 'channel-abc', resourceId: 'resource-123' })
+        return new Response(null, { status: 204 })
+      })
+
+      const client = createGoogleCalendarClient()
+      await expect(
+        client.stopChannel({ channelId: 'channel-abc', resourceId: 'resource-123' })
+      ).resolves.toBeUndefined()
+    })
+
+    it('tolerates 404 without throwing (channel already stale on Google side)', async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({ error: { status: 'NOT_FOUND', message: 'channel not found' } }),
+          { status: 404 }
+        )
+      )
+
+      const client = createGoogleCalendarClient()
+      await expect(
+        client.stopChannel({ channelId: 'stale', resourceId: 'stale-resource' })
+      ).resolves.toBeUndefined()
+    })
+
+    it('throws for non-404 errors (e.g. 500)', async () => {
+      fetchMock.mockResolvedValue(new Response('oops', { status: 500 }))
+
+      const client = createGoogleCalendarClient()
+      await expect(client.stopChannel({ channelId: 'c', resourceId: 'r' })).rejects.toThrow()
+    })
+  })
+})

--- a/apps/desktop/src/main/calendar/google/client.ts
+++ b/apps/desktop/src/main/calendar/google/client.ts
@@ -56,6 +56,12 @@ const GoogleTokenRefreshSchema = z.object({
   token_type: z.string().min(1)
 })
 
+const GoogleWatchChannelResponseSchema = z.object({
+  id: z.string().min(1),
+  resourceId: z.string().min(1),
+  expiration: z.union([z.string(), z.number()]).optional()
+})
+
 function resolveGoogleClientId(): string {
   const clientId = process.env.GOOGLE_CALENDAR_CLIENT_ID?.trim()
   if (!clientId) {
@@ -394,6 +400,54 @@ export function createGoogleCalendarClient(): GoogleCalendarClient {
 
       if (!response.ok && response.status !== 404) {
         await throwCalendarApiFailure(response, 'delete Google calendar event')
+      }
+    },
+
+    async watchCalendar(input): Promise<{ resourceId: string; expiration: number }> {
+      const expirationMs = Date.now() + input.ttlSeconds * 1000
+      const response = await withAuthorizedResponse({
+        path: `/calendars/${encodeURIComponent(input.calendarId)}/events/watch`,
+        init: {
+          method: 'POST',
+          body: JSON.stringify({
+            id: input.channelId,
+            token: input.token,
+            type: 'web_hook',
+            address: input.webhookUrl,
+            expiration: String(expirationMs)
+          })
+        }
+      })
+
+      if (!response.ok) {
+        await throwCalendarApiFailure(response, 'watch Google calendar')
+      }
+
+      const parsed = GoogleWatchChannelResponseSchema.parse(await response.json())
+      const expiration =
+        typeof parsed.expiration === 'string'
+          ? Number(parsed.expiration)
+          : (parsed.expiration ?? expirationMs)
+      return {
+        resourceId: parsed.resourceId,
+        expiration: Number.isFinite(expiration) ? expiration : expirationMs
+      }
+    },
+
+    async stopChannel(input): Promise<void> {
+      const response = await withAuthorizedResponse({
+        path: '/channels/stop',
+        init: {
+          method: 'POST',
+          body: JSON.stringify({
+            id: input.channelId,
+            resourceId: input.resourceId
+          })
+        }
+      })
+
+      if (!response.ok && response.status !== 404) {
+        await throwCalendarApiFailure(response, 'stop Google calendar channel')
       }
     }
   }

--- a/apps/desktop/src/main/calendar/google/google-channel-manager.test.ts
+++ b/apps/desktop/src/main/calendar/google/google-channel-manager.test.ts
@@ -1,0 +1,252 @@
+import { createHash } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => loggerMock
+}))
+
+import { createGoogleChannelManager, type GoogleChannelManagerDeps } from './google-channel-manager'
+
+interface HarnessDeps extends GoogleChannelManagerDeps {
+  // Spies on deps for assertions
+  client: {
+    watchCalendar: ReturnType<typeof vi.fn>
+    stopChannel: ReturnType<typeof vi.fn>
+  }
+  registerOnServer: ReturnType<typeof vi.fn>
+  attachResourceId: ReturnType<typeof vi.fn>
+  deleteOnServer: ReturnType<typeof vi.fn>
+}
+
+const TTL_SECONDS = 7 * 24 * 60 * 60 // 7 days
+const MARGIN_SECONDS = 60 * 60 // 1 hour
+const FIXED_NOW_MS = 1_700_000_000_000
+
+function buildDeps(overrides: Partial<GoogleChannelManagerDeps> = {}): HarnessDeps {
+  let channelCounter = 0
+  let tokenCounter = 0
+  return {
+    client: {
+      watchCalendar: vi.fn(async (input) => ({
+        resourceId: `resource-${input.channelId}`,
+        expiration: FIXED_NOW_MS + TTL_SECONDS * 1000
+      })),
+      stopChannel: vi.fn(async () => {})
+    },
+    registerOnServer: vi.fn(async () => {}),
+    attachResourceId: vi.fn(async () => {}),
+    deleteOnServer: vi.fn(async () => {}),
+    hashToken: vi.fn(async (plaintext: string) =>
+      createHash('sha256').update(plaintext).digest('hex')
+    ),
+    generateToken: vi.fn(() => `token-${++tokenCounter}`),
+    generateChannelId: vi.fn(() => `channel-${++channelCounter}`),
+    webhookUrl: 'https://sync.memry.io/webhooks/google-calendar',
+    ttlSeconds: TTL_SECONDS,
+    rotationMarginSeconds: MARGIN_SECONDS,
+    featureEnabled: true,
+    now: () => Date.now(),
+    ...overrides
+  } as HarnessDeps
+}
+
+describe('google-channel-manager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(FIXED_NOW_MS)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  describe('ensureChannelForSource', () => {
+    it('registers hash on sync-server, watches Google, then PATCHes resourceId', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal@group.google.com' })
+
+      expect(deps.registerOnServer).toHaveBeenCalledTimes(1)
+      const registerArg = deps.registerOnServer.mock.calls[0]![0] as {
+        channelId: string
+        sourceId: string
+        tokenHash: string
+        expiresAt: number
+      }
+      expect(registerArg.channelId).toBe('channel-1')
+      expect(registerArg.sourceId).toBe('src-1')
+      expect(registerArg.tokenHash).toBe(createHash('sha256').update('token-1').digest('hex'))
+      expect(registerArg.tokenHash).toMatch(/^[0-9a-f]{64}$/)
+      expect(registerArg.expiresAt).toBe(Math.floor(FIXED_NOW_MS / 1000) + TTL_SECONDS)
+
+      expect(deps.client.watchCalendar).toHaveBeenCalledTimes(1)
+      const watchArg = deps.client.watchCalendar.mock.calls[0]![0] as {
+        calendarId: string
+        channelId: string
+        token: string
+        webhookUrl: string
+        ttlSeconds: number
+      }
+      expect(watchArg).toEqual({
+        calendarId: 'cal@group.google.com',
+        channelId: 'channel-1',
+        token: 'token-1',
+        webhookUrl: 'https://sync.memry.io/webhooks/google-calendar',
+        ttlSeconds: TTL_SECONDS
+      })
+
+      expect(deps.attachResourceId).toHaveBeenCalledWith({
+        channelId: 'channel-1',
+        resourceId: 'resource-channel-1'
+      })
+
+      expect(mgr.getActiveChannelCount()).toBe(1)
+    })
+
+    it('no-ops when featureEnabled is false', async () => {
+      const deps = buildDeps({ featureEnabled: false })
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+
+      expect(deps.registerOnServer).not.toHaveBeenCalled()
+      expect(deps.client.watchCalendar).not.toHaveBeenCalled()
+      expect(mgr.getActiveChannelCount()).toBe(0)
+    })
+
+    it('dedupes: second call for same sourceId is a no-op', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+
+      expect(deps.client.watchCalendar).toHaveBeenCalledTimes(1)
+      expect(mgr.getActiveChannelCount()).toBe(1)
+    })
+
+    it('fires onActiveCountChange when transitioning 0 → 1', async () => {
+      const onActiveCountChange = vi.fn()
+      const deps = buildDeps({ onActiveCountChange })
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+
+      expect(onActiveCountChange).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('stopForSource', () => {
+    it('stops the channel on Google, deletes on server, clears state', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+      await mgr.stopForSource('src-1')
+
+      expect(deps.client.stopChannel).toHaveBeenCalledWith({
+        channelId: 'channel-1',
+        resourceId: 'resource-channel-1'
+      })
+      expect(deps.deleteOnServer).toHaveBeenCalledWith({ channelId: 'channel-1' })
+      expect(mgr.getActiveChannelCount()).toBe(0)
+    })
+
+    it('is a no-op for unknown sourceId', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.stopForSource('never-registered')
+
+      expect(deps.client.stopChannel).not.toHaveBeenCalled()
+      expect(deps.deleteOnServer).not.toHaveBeenCalled()
+    })
+
+    it('fires onActiveCountChange on 1 → 0 transition', async () => {
+      const onActiveCountChange = vi.fn()
+      const deps = buildDeps({ onActiveCountChange })
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+      onActiveCountChange.mockClear()
+
+      await mgr.stopForSource('src-1')
+
+      expect(onActiveCountChange).toHaveBeenCalledWith(0)
+    })
+  })
+
+  describe('stopAll', () => {
+    it('stops every registered channel', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+      await mgr.ensureChannelForSource({ sourceId: 'src-2', calendarId: 'cal-b' })
+      expect(mgr.getActiveChannelCount()).toBe(2)
+
+      await mgr.stopAll()
+
+      expect(deps.client.stopChannel).toHaveBeenCalledTimes(2)
+      expect(deps.deleteOnServer).toHaveBeenCalledTimes(2)
+      expect(mgr.getActiveChannelCount()).toBe(0)
+    })
+  })
+
+  describe('rotation', () => {
+    it('rotates the channel before ttl expiry (using ttl - margin as trigger)', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+
+      expect(deps.client.watchCalendar).toHaveBeenCalledTimes(1)
+      expect(deps.client.stopChannel).not.toHaveBeenCalled()
+
+      // Advance to just before the rotation trigger — nothing happens yet.
+      const rotationDelayMs = (TTL_SECONDS - MARGIN_SECONDS) * 1000
+      await vi.advanceTimersByTimeAsync(rotationDelayMs - 10)
+      expect(deps.client.stopChannel).not.toHaveBeenCalled()
+
+      // Cross the trigger — old channel is stopped, a new one is created.
+      await vi.advanceTimersByTimeAsync(20)
+
+      expect(deps.client.stopChannel).toHaveBeenCalledTimes(1)
+      expect(deps.client.stopChannel).toHaveBeenCalledWith({
+        channelId: 'channel-1',
+        resourceId: 'resource-channel-1'
+      })
+      expect(deps.client.watchCalendar).toHaveBeenCalledTimes(2)
+      const secondWatch = deps.client.watchCalendar.mock.calls[1]![0] as { channelId: string }
+      expect(secondWatch.channelId).toBe('channel-2')
+      expect(mgr.getActiveChannelCount()).toBe(1)
+    })
+  })
+
+  describe('security', () => {
+    it('never stores the plaintext token anywhere retrievable after registration', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+
+      // Whole manager surface must not leak token-1. getActiveChannelCount exposes only a number.
+      expect(JSON.stringify({ count: mgr.getActiveChannelCount() })).not.toContain('token-1')
+      // sync-server received the hash, not the plaintext.
+      const registerArg = deps.registerOnServer.mock.calls[0]![0] as { tokenHash: string }
+      expect(registerArg.tokenHash).not.toContain('token-1')
+      expect(registerArg.tokenHash).toMatch(/^[0-9a-f]{64}$/)
+    })
+  })
+})

--- a/apps/desktop/src/main/calendar/google/google-channel-manager.ts
+++ b/apps/desktop/src/main/calendar/google/google-channel-manager.ts
@@ -1,0 +1,176 @@
+import { createLogger } from '../../lib/logger'
+import type { GoogleCalendarClient } from '../types'
+
+const log = createLogger('Calendar:GoogleChannelManager')
+
+export interface GoogleChannelManagerDeps {
+  client: Pick<GoogleCalendarClient, 'watchCalendar' | 'stopChannel'>
+  registerOnServer(input: {
+    channelId: string
+    sourceId: string
+    tokenHash: string
+    expiresAt: number
+  }): Promise<void>
+  attachResourceId(input: { channelId: string; resourceId: string }): Promise<void>
+  deleteOnServer(input: { channelId: string }): Promise<void>
+  hashToken(plaintext: string): Promise<string>
+  generateToken(): string
+  generateChannelId(): string
+  webhookUrl: string
+  ttlSeconds: number
+  rotationMarginSeconds: number
+  featureEnabled: boolean
+  now?: () => number
+  onActiveCountChange?: (count: number) => void
+}
+
+export interface GoogleChannelManager {
+  ensureChannelForSource(input: { sourceId: string; calendarId: string }): Promise<void>
+  stopForSource(sourceId: string): Promise<void>
+  stopAll(): Promise<void>
+  getActiveChannelCount(): number
+}
+
+interface ChannelState {
+  sourceId: string
+  calendarId: string
+  channelId: string
+  resourceId: string
+  expirationMs: number
+  rotationTimer: ReturnType<typeof setTimeout>
+}
+
+export function createGoogleChannelManager(deps: GoogleChannelManagerDeps): GoogleChannelManager {
+  const states = new Map<string, ChannelState>()
+
+  function emitCount(): void {
+    deps.onActiveCountChange?.(states.size)
+  }
+
+  async function registerFresh(sourceId: string, calendarId: string): Promise<ChannelState> {
+    const channelId = deps.generateChannelId()
+    const plaintextToken = deps.generateToken()
+    const tokenHash = await deps.hashToken(plaintextToken)
+    const nowMs = (deps.now ?? Date.now)()
+    const expirationMs = nowMs + deps.ttlSeconds * 1000
+    const expiresAt = Math.floor(nowMs / 1000) + deps.ttlSeconds
+
+    await deps.registerOnServer({ channelId, sourceId, tokenHash, expiresAt })
+
+    const watchResult = await deps.client.watchCalendar({
+      calendarId,
+      channelId,
+      token: plaintextToken,
+      webhookUrl: deps.webhookUrl,
+      ttlSeconds: deps.ttlSeconds
+    })
+
+    await deps.attachResourceId({ channelId, resourceId: watchResult.resourceId })
+
+    const rotationDelayMs = Math.max(1, (deps.ttlSeconds - deps.rotationMarginSeconds) * 1000)
+    const rotationTimer = setTimeout(() => {
+      void rotate(sourceId)
+    }, rotationDelayMs)
+    if (typeof rotationTimer === 'object' && rotationTimer && 'unref' in rotationTimer) {
+      ;(rotationTimer as { unref: () => void }).unref()
+    }
+
+    return {
+      sourceId,
+      calendarId,
+      channelId,
+      resourceId: watchResult.resourceId,
+      expirationMs: watchResult.expiration ?? expirationMs,
+      rotationTimer
+    }
+  }
+
+  async function rotate(sourceId: string): Promise<void> {
+    const prev = states.get(sourceId)
+    if (!prev) return
+    log.info('Rotating Google push channel', { sourceId, channelId: prev.channelId })
+    try {
+      await stopForSource(sourceId, { silent: true })
+    } catch (err) {
+      log.warn('Rotation: failed to stop old channel (continuing to re-register)', {
+        sourceId,
+        channelId: prev.channelId,
+        err
+      })
+    }
+    try {
+      const fresh = await registerFresh(sourceId, prev.calendarId)
+      states.set(sourceId, fresh)
+      emitCount()
+    } catch (err) {
+      log.error('Rotation: failed to register fresh channel', { sourceId, err })
+    }
+  }
+
+  async function stopForSource(
+    sourceId: string,
+    options: { silent?: boolean } = {}
+  ): Promise<void> {
+    const state = states.get(sourceId)
+    if (!state) return
+
+    clearTimeout(state.rotationTimer)
+    states.delete(sourceId)
+
+    try {
+      await deps.client.stopChannel({
+        channelId: state.channelId,
+        resourceId: state.resourceId
+      })
+    } catch (err) {
+      log.warn('stopChannel on Google failed (ignoring)', {
+        sourceId,
+        channelId: state.channelId,
+        err
+      })
+    }
+
+    try {
+      await deps.deleteOnServer({ channelId: state.channelId })
+    } catch (err) {
+      log.warn('deleteOnServer failed (ignoring; cron will reap)', {
+        sourceId,
+        channelId: state.channelId,
+        err
+      })
+    }
+
+    if (!options.silent) {
+      emitCount()
+    }
+  }
+
+  async function ensureChannelForSource(input: {
+    sourceId: string
+    calendarId: string
+  }): Promise<void> {
+    if (!deps.featureEnabled) return
+    if (states.has(input.sourceId)) return
+
+    const state = await registerFresh(input.sourceId, input.calendarId)
+    states.set(input.sourceId, state)
+    emitCount()
+  }
+
+  async function stopAll(): Promise<void> {
+    const ids = Array.from(states.keys())
+    await Promise.all(ids.map((id) => stopForSource(id, { silent: true })))
+    emitCount()
+  }
+
+  function getActiveChannelCount(): number {
+    return states.size
+  }
+
+  return {
+    ensureChannelForSource,
+    stopForSource: (id: string) => stopForSource(id),
+    stopAll,
+    getActiveChannelCount
+  }
+}

--- a/apps/desktop/src/main/calendar/google/google-sync-runner.ts
+++ b/apps/desktop/src/main/calendar/google/google-sync-runner.ts
@@ -1,0 +1,78 @@
+import { createLogger } from '../../lib/logger'
+import { requireDatabase } from '../../database'
+import { isMemryUserSignedIn } from '../../sync/auth-state'
+import { hasGoogleCalendarConnection } from './oauth'
+import { listCalendarSources } from '../repositories/calendar-sources-repository'
+import { getGooglePushRuntime, getOrInitGooglePushRuntime } from './push-runtime'
+import { syncGoogleCalendarNow } from './sync-service'
+
+const log = createLogger('Calendar:GoogleSyncRunner')
+
+const RUN_INTERVAL_MS = 5 * 60 * 1000
+export const PUSH_BACKOFF_INTERVAL_MS = 30 * 60 * 1000
+
+let syncInterval: NodeJS.Timeout | null = null
+let currentPollIntervalMs = RUN_INTERVAL_MS
+
+export function getCurrentPollIntervalMs(): number {
+  return currentPollIntervalMs
+}
+
+function runPeriodicSync(): void {
+  void syncGoogleCalendarNow().catch((error) => {
+    log.warn('periodic Google Calendar sync failed', error)
+  })
+}
+
+export function reEvaluatePollCadence(activeChannelCount: number): void {
+  const target = activeChannelCount > 0 ? PUSH_BACKOFF_INTERVAL_MS : RUN_INTERVAL_MS
+  if (target === currentPollIntervalMs) return
+  currentPollIntervalMs = target
+  if (!syncInterval) return
+  clearInterval(syncInterval)
+  syncInterval = setInterval(runPeriodicSync, target)
+}
+
+export async function startGoogleCalendarSyncRunner(): Promise<void> {
+  if (syncInterval) return
+  if (!(await isMemryUserSignedIn())) return
+  if (!(await hasGoogleCalendarConnection(requireDatabase()))) return
+
+  void syncGoogleCalendarNow().catch((error) => {
+    log.warn('initial Google Calendar sync failed', error)
+  })
+
+  syncInterval = setInterval(runPeriodicSync, currentPollIntervalMs)
+
+  const pushRuntime = getOrInitGooglePushRuntime({
+    onActiveCountChange: (count) => reEvaluatePollCadence(count)
+  })
+  if (pushRuntime) {
+    const db = requireDatabase()
+    const sources = listCalendarSources(db, {
+      provider: 'google',
+      kind: 'calendar',
+      selectedOnly: true
+    }).map((s) => ({
+      id: s.id,
+      remoteId: s.remoteId,
+      isMemryManaged: s.isMemryManaged
+    }))
+    void pushRuntime.ensureForSelectedSources(sources).catch((err) => {
+      log.warn('ensureForSelectedSources failed', err)
+    })
+  }
+}
+
+export function stopGoogleCalendarSyncRunner(): void {
+  if (!syncInterval) return
+  clearInterval(syncInterval)
+  syncInterval = null
+
+  const pushRuntime = getGooglePushRuntime()
+  if (pushRuntime) {
+    void pushRuntime.stopAll().catch((err) => {
+      log.warn('stopAll failed', err)
+    })
+  }
+}

--- a/apps/desktop/src/main/calendar/google/push-runtime.test.ts
+++ b/apps/desktop/src/main/calendar/google/push-runtime.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => loggerMock
+}))
+
+import { createGooglePushRuntime, type CalendarSourceLite } from './push-runtime'
+import type { GoogleChannelManager } from './google-channel-manager'
+
+function buildManagerMock(): GoogleChannelManager & {
+  ensureChannelForSource: ReturnType<typeof vi.fn>
+  stopForSource: ReturnType<typeof vi.fn>
+  stopAll: ReturnType<typeof vi.fn>
+  getActiveChannelCount: ReturnType<typeof vi.fn>
+} {
+  return {
+    ensureChannelForSource: vi.fn(async () => {}),
+    stopForSource: vi.fn(async () => {}),
+    stopAll: vi.fn(async () => {}),
+    getActiveChannelCount: vi.fn(() => 0)
+  }
+}
+
+describe('createGooglePushRuntime (Task 11 — lifecycle wiring)', () => {
+  describe('ensureForSelectedSources', () => {
+    it('registers a channel for each selected non-managed source', async () => {
+      // #given
+      const manager = buildManagerMock()
+      const runtime = createGooglePushRuntime(manager)
+      const sources: CalendarSourceLite[] = [
+        {
+          id: 'google-calendar:work',
+          remoteId: 'work@group.calendar.google.com',
+          isMemryManaged: false
+        },
+        { id: 'google-calendar:personal', remoteId: 'me@gmail.com', isMemryManaged: false }
+      ]
+
+      // #when
+      await runtime.ensureForSelectedSources(sources)
+
+      // #then
+      expect(manager.ensureChannelForSource).toHaveBeenCalledTimes(2)
+      expect(manager.ensureChannelForSource).toHaveBeenCalledWith({
+        sourceId: 'google-calendar:work',
+        calendarId: 'work@group.calendar.google.com'
+      })
+      expect(manager.ensureChannelForSource).toHaveBeenCalledWith({
+        sourceId: 'google-calendar:personal',
+        calendarId: 'me@gmail.com'
+      })
+    })
+
+    it('skips Memry-managed sources (we never webhook our own calendar)', async () => {
+      // #given
+      const manager = buildManagerMock()
+      const runtime = createGooglePushRuntime(manager)
+      const sources: CalendarSourceLite[] = [
+        { id: 'google-calendar:memry', remoteId: 'memry-managed', isMemryManaged: true },
+        { id: 'google-calendar:work', remoteId: 'work', isMemryManaged: false }
+      ]
+
+      // #when
+      await runtime.ensureForSelectedSources(sources)
+
+      // #then
+      expect(manager.ensureChannelForSource).toHaveBeenCalledTimes(1)
+      expect(manager.ensureChannelForSource).toHaveBeenCalledWith({
+        sourceId: 'google-calendar:work',
+        calendarId: 'work'
+      })
+    })
+
+    it('continues iterating after an ensure failure (no early return)', async () => {
+      // #given
+      const manager = buildManagerMock()
+      manager.ensureChannelForSource
+        .mockRejectedValueOnce(new Error('first source failed'))
+        .mockResolvedValueOnce(undefined)
+      const runtime = createGooglePushRuntime(manager)
+      const sources: CalendarSourceLite[] = [
+        { id: 'a', remoteId: 'A', isMemryManaged: false },
+        { id: 'b', remoteId: 'B', isMemryManaged: false }
+      ]
+
+      // #when
+      await runtime.ensureForSelectedSources(sources)
+
+      // #then
+      expect(manager.ensureChannelForSource).toHaveBeenCalledTimes(2)
+      expect(loggerMock.warn).toHaveBeenCalled()
+    })
+  })
+
+  describe('stopAll', () => {
+    it('delegates to manager.stopAll', async () => {
+      const manager = buildManagerMock()
+      const runtime = createGooglePushRuntime(manager)
+
+      await runtime.stopAll()
+
+      expect(manager.stopAll).toHaveBeenCalledTimes(1)
+    })
+
+    it('swallows manager errors so teardown always completes', async () => {
+      const manager = buildManagerMock()
+      manager.stopAll.mockRejectedValueOnce(new Error('stopAll boom'))
+      const runtime = createGooglePushRuntime(manager)
+
+      await expect(runtime.stopAll()).resolves.toBeUndefined()
+      expect(loggerMock.warn).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleSelectionToggle', () => {
+    it('#given isSelected=true #when toggled #then ensures a channel for that source', async () => {
+      const manager = buildManagerMock()
+      const runtime = createGooglePushRuntime(manager)
+
+      await runtime.handleSelectionToggle({
+        sourceId: 'src-1',
+        isSelected: true,
+        calendarId: 'cal-1'
+      })
+
+      expect(manager.ensureChannelForSource).toHaveBeenCalledWith({
+        sourceId: 'src-1',
+        calendarId: 'cal-1'
+      })
+      expect(manager.stopForSource).not.toHaveBeenCalled()
+    })
+
+    it('#given isSelected=false #when toggled #then stops that source', async () => {
+      const manager = buildManagerMock()
+      const runtime = createGooglePushRuntime(manager)
+
+      await runtime.handleSelectionToggle({
+        sourceId: 'src-1',
+        isSelected: false,
+        calendarId: 'cal-1'
+      })
+
+      expect(manager.stopForSource).toHaveBeenCalledWith('src-1')
+      expect(manager.ensureChannelForSource).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getActiveChannelCount', () => {
+    it('returns the underlying manager count', () => {
+      const manager = buildManagerMock()
+      manager.getActiveChannelCount.mockReturnValue(3)
+      const runtime = createGooglePushRuntime(manager)
+
+      expect(runtime.getActiveChannelCount()).toBe(3)
+    })
+  })
+})

--- a/apps/desktop/src/main/calendar/google/push-runtime.ts
+++ b/apps/desktop/src/main/calendar/google/push-runtime.ts
@@ -1,0 +1,142 @@
+import { randomBytes, createHmac, randomUUID } from 'node:crypto'
+import { createLogger } from '../../lib/logger'
+import { deleteFromServer, patchToServer, postToServer } from '../../sync/http-client'
+import { getValidAccessToken } from '../../sync/token-manager'
+import { createGoogleCalendarClient } from './client'
+import { createGoogleChannelManager, type GoogleChannelManager } from './google-channel-manager'
+
+const log = createLogger('Calendar:GooglePushRuntime')
+
+const DEFAULT_WEBHOOK_URL = 'https://sync.memry.io/webhooks/google-calendar'
+const TTL_SECONDS = 7 * 24 * 60 * 60
+const ROTATION_MARGIN_SECONDS = 60 * 60
+
+export interface CalendarSourceLite {
+  id: string
+  remoteId: string
+  isMemryManaged: boolean
+}
+
+export interface GooglePushRuntime {
+  ensureForSelectedSources(sources: CalendarSourceLite[]): Promise<void>
+  stopAll(): Promise<void>
+  handleSelectionToggle(args: {
+    sourceId: string
+    isSelected: boolean
+    calendarId: string
+  }): Promise<void>
+  getActiveChannelCount(): number
+}
+
+export function createGooglePushRuntime(manager: GoogleChannelManager): GooglePushRuntime {
+  return {
+    async ensureForSelectedSources(sources) {
+      const candidates = sources.filter((s) => !s.isMemryManaged)
+      for (const source of candidates) {
+        try {
+          await manager.ensureChannelForSource({
+            sourceId: source.id,
+            calendarId: source.remoteId
+          })
+        } catch (err) {
+          log.warn('ensureChannelForSource failed; will retry on next start', {
+            sourceId: source.id,
+            err
+          })
+        }
+      }
+    },
+    async stopAll() {
+      try {
+        await manager.stopAll()
+      } catch (err) {
+        log.warn('stopAll failed; server cleanup cron will reap', { err })
+      }
+    },
+    async handleSelectionToggle({ sourceId, isSelected, calendarId }) {
+      try {
+        if (isSelected) {
+          await manager.ensureChannelForSource({ sourceId, calendarId })
+        } else {
+          await manager.stopForSource(sourceId)
+        }
+      } catch (err) {
+        log.warn('handleSelectionToggle failed', { sourceId, isSelected, err })
+      }
+    },
+    getActiveChannelCount: () => manager.getActiveChannelCount()
+  }
+}
+
+function resolveWebhookUrl(): string {
+  return process.env.MEMRY_CALENDAR_WEBHOOK_URL?.trim() || DEFAULT_WEBHOOK_URL
+}
+
+function resolveHmacKey(): string {
+  return process.env.MEMRY_WEBHOOK_HMAC_KEY?.trim() ?? ''
+}
+
+function isPushFeatureEnabled(): boolean {
+  return process.env.CALENDAR_PUSH_ENABLED === '1' && resolveHmacKey().length > 0
+}
+
+function buildProductionChannelManager(
+  onActiveCountChange: (count: number) => void
+): GoogleChannelManager {
+  const hmacKey = resolveHmacKey()
+
+  return createGoogleChannelManager({
+    client: createGoogleCalendarClient(),
+    registerOnServer: async (body) => {
+      const token = await getValidAccessToken()
+      if (!token) throw new Error('Not signed in — cannot register push channel')
+      await postToServer('/calendar/channels', body, token)
+    },
+    attachResourceId: async ({ channelId, resourceId }) => {
+      const token = await getValidAccessToken()
+      if (!token) throw new Error('Not signed in — cannot attach resourceId')
+      await patchToServer(
+        `/calendar/channels/${encodeURIComponent(channelId)}`,
+        { resourceId },
+        token
+      )
+    },
+    deleteOnServer: async ({ channelId }) => {
+      const token = await getValidAccessToken()
+      if (!token) return
+      await deleteFromServer(`/calendar/channels/${encodeURIComponent(channelId)}`, token).catch(
+        () => {
+          // Server-side cleanup cron will reap orphans; best-effort delete.
+        }
+      )
+    },
+    hashToken: async (plaintext) => createHmac('sha256', hmacKey).update(plaintext).digest('hex'),
+    generateToken: () => randomBytes(32).toString('hex'),
+    generateChannelId: () => randomUUID(),
+    webhookUrl: resolveWebhookUrl(),
+    ttlSeconds: TTL_SECONDS,
+    rotationMarginSeconds: ROTATION_MARGIN_SECONDS,
+    featureEnabled: isPushFeatureEnabled(),
+    onActiveCountChange
+  })
+}
+
+let prodRuntime: GooglePushRuntime | null = null
+
+export function getOrInitGooglePushRuntime(opts: {
+  onActiveCountChange: (count: number) => void
+}): GooglePushRuntime | null {
+  if (!isPushFeatureEnabled()) return null
+  if (!prodRuntime) {
+    prodRuntime = createGooglePushRuntime(buildProductionChannelManager(opts.onActiveCountChange))
+  }
+  return prodRuntime
+}
+
+export function getGooglePushRuntime(): GooglePushRuntime | null {
+  return prodRuntime
+}
+
+export function __testing_resetGooglePushRuntime(): void {
+  prodRuntime = null
+}

--- a/apps/desktop/src/main/calendar/google/sync-service-cadence.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service-cadence.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: vi.fn(() => []) }
+}))
+
+vi.mock('./oauth', () => ({
+  hasGoogleCalendarConnection: vi.fn(async () => true),
+  hasGoogleCalendarLocalAuth: vi.fn(async () => true)
+}))
+
+vi.mock('../../sync/auth-state', () => ({
+  isMemryUserSignedIn: vi.fn(async () => true)
+}))
+
+vi.mock('../../database', () => ({
+  requireDatabase: vi.fn(() => ({}) as unknown as object),
+  getDatabase: vi.fn(() => ({}) as unknown as object),
+  isDatabaseInitialized: vi.fn(() => true)
+}))
+
+import {
+  PUSH_BACKOFF_INTERVAL_MS,
+  getCurrentPollIntervalMs,
+  reEvaluatePollCadence,
+  startGoogleCalendarSyncRunner,
+  stopGoogleCalendarSyncRunner
+} from './sync-service'
+
+const RUN_INTERVAL_MS = 5 * 60 * 1000
+
+describe('reEvaluatePollCadence (Task 10 — push-channel poll backoff)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    stopGoogleCalendarSyncRunner()
+    // Reset back to default cadence between cases.
+    reEvaluatePollCadence(0)
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('defaults to RUN_INTERVAL_MS (5 minutes) before any push channels are active', () => {
+    // #given no reEvaluate has been called
+    // #then the runner's poll cadence is 5 minutes
+    expect(getCurrentPollIntervalMs()).toBe(RUN_INTERVAL_MS)
+  })
+
+  it('switches to PUSH_BACKOFF_INTERVAL_MS (30 minutes) when at least one channel is active', () => {
+    // #when a push channel comes online
+    reEvaluatePollCadence(1)
+
+    // #then the poll falls back to 30 minutes (push is primary, polling is safety net)
+    expect(getCurrentPollIntervalMs()).toBe(PUSH_BACKOFF_INTERVAL_MS)
+    expect(PUSH_BACKOFF_INTERVAL_MS).toBe(30 * 60 * 1000)
+  })
+
+  it('restores RUN_INTERVAL_MS the moment every channel is gone', () => {
+    // #given two channels were active
+    reEvaluatePollCadence(2)
+
+    // #when all channels go down
+    reEvaluatePollCadence(0)
+
+    // #then the poll resumes its 5-minute cadence
+    expect(getCurrentPollIntervalMs()).toBe(RUN_INTERVAL_MS)
+  })
+
+  it('is idempotent when the count stays > 0 (no interval churn between 1 and N channels)', () => {
+    reEvaluatePollCadence(1)
+    reEvaluatePollCadence(5)
+    reEvaluatePollCadence(3)
+
+    expect(getCurrentPollIntervalMs()).toBe(PUSH_BACKOFF_INTERVAL_MS)
+  })
+
+  it('re-arms the live setInterval when a runner is active', async () => {
+    // #given spies around the timer APIs
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+
+    // #given the runner is started (eager sync is best-effort and tolerates failure)
+    await startGoogleCalendarSyncRunner()
+
+    // #then the initial setInterval was scheduled at RUN_INTERVAL_MS
+    const firstCall = setIntervalSpy.mock.calls.find((call) => call[1] === RUN_INTERVAL_MS)
+    expect(firstCall).toBeTruthy()
+
+    setIntervalSpy.mockClear()
+    clearIntervalSpy.mockClear()
+
+    // #when a push channel comes online
+    reEvaluatePollCadence(1)
+
+    // #then the old interval is cleared and a new one is armed at the backoff cadence
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), PUSH_BACKOFF_INTERVAL_MS)
+  })
+
+  it('does not re-arm when no runner is active (prevents phantom timers)', () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+
+    reEvaluatePollCadence(1)
+
+    expect(clearIntervalSpy).not.toHaveBeenCalled()
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+    // But the cadence value IS updated — when the runner eventually starts it will pick the right cadence.
+    expect(getCurrentPollIntervalMs()).toBe(PUSH_BACKOFF_INTERVAL_MS)
+  })
+})

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -43,7 +43,6 @@ import {
 } from '../repositories/calendar-sources-repository'
 import { emitCalendarChanged, emitCalendarProjectionChanged } from '../change-events'
 import { readCalendarGoogleSettings } from './calendar-google-settings'
-import { getGooglePushRuntime, getOrInitGooglePushRuntime } from './push-runtime'
 import type {
   CalendarSyncTarget,
   GoogleCalendarClient,
@@ -52,32 +51,9 @@ import type {
 } from '../types'
 
 const log = createLogger('Calendar:GoogleSync')
-const RUN_INTERVAL_MS = 5 * 60 * 1000
-export const PUSH_BACKOFF_INTERVAL_MS = 30 * 60 * 1000
 const LOCAL_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 
-let syncInterval: NodeJS.Timeout | null = null
 let syncInFlight = false
-let currentPollIntervalMs = RUN_INTERVAL_MS
-
-export function getCurrentPollIntervalMs(): number {
-  return currentPollIntervalMs
-}
-
-function runPeriodicSync(): void {
-  void syncGoogleCalendarNow().catch((error) => {
-    log.warn('periodic Google Calendar sync failed', error)
-  })
-}
-
-export function reEvaluatePollCadence(activeChannelCount: number): void {
-  const target = activeChannelCount > 0 ? PUSH_BACKOFF_INTERVAL_MS : RUN_INTERVAL_MS
-  if (target === currentPollIntervalMs) return
-  currentPollIntervalMs = target
-  if (!syncInterval) return
-  clearInterval(syncInterval)
-  syncInterval = setInterval(runPeriodicSync, target)
-}
 
 function getNow(): string {
   return new Date().toISOString()
@@ -920,46 +896,13 @@ export async function syncGoogleCalendarNow(
   }
 }
 
-export async function startGoogleCalendarSyncRunner(): Promise<void> {
-  if (syncInterval) return
-  if (!(await isMemryUserSignedIn())) return
-  if (!(await hasGoogleCalendarConnection(requireDatabase()))) return
-
-  void syncGoogleCalendarNow().catch((error) => {
-    log.warn('initial Google Calendar sync failed', error)
-  })
-
-  syncInterval = setInterval(runPeriodicSync, currentPollIntervalMs)
-
-  const pushRuntime = getOrInitGooglePushRuntime({
-    onActiveCountChange: (count) => reEvaluatePollCadence(count)
-  })
-  if (pushRuntime) {
-    const db = requireDatabase()
-    const sources = listCalendarSources(db, {
-      provider: 'google',
-      kind: 'calendar',
-      selectedOnly: true
-    }).map((s) => ({
-      id: s.id,
-      remoteId: s.remoteId,
-      isMemryManaged: s.isMemryManaged
-    }))
-    void pushRuntime.ensureForSelectedSources(sources).catch((err) => {
-      log.warn('ensureForSelectedSources failed', err)
-    })
-  }
-}
-
-export function stopGoogleCalendarSyncRunner(): void {
-  if (!syncInterval) return
-  clearInterval(syncInterval)
-  syncInterval = null
-
-  const pushRuntime = getGooglePushRuntime()
-  if (pushRuntime) {
-    void pushRuntime.stopAll().catch((err) => {
-      log.warn('stopAll failed', err)
-    })
-  }
-}
+// Runner lifecycle + push-channel poll cadence live in google-sync-runner.ts.
+// Re-exported here so existing callers (index.ts, calendar-handlers,
+// session-teardown, device-registration, tests) keep their import paths.
+export {
+  PUSH_BACKOFF_INTERVAL_MS,
+  getCurrentPollIntervalMs,
+  reEvaluatePollCadence,
+  startGoogleCalendarSyncRunner,
+  stopGoogleCalendarSyncRunner
+} from './google-sync-runner'

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -43,6 +43,7 @@ import {
 } from '../repositories/calendar-sources-repository'
 import { emitCalendarChanged, emitCalendarProjectionChanged } from '../change-events'
 import { readCalendarGoogleSettings } from './calendar-google-settings'
+import { getGooglePushRuntime, getOrInitGooglePushRuntime } from './push-runtime'
 import type {
   CalendarSyncTarget,
   GoogleCalendarClient,
@@ -929,10 +930,36 @@ export async function startGoogleCalendarSyncRunner(): Promise<void> {
   })
 
   syncInterval = setInterval(runPeriodicSync, currentPollIntervalMs)
+
+  const pushRuntime = getOrInitGooglePushRuntime({
+    onActiveCountChange: (count) => reEvaluatePollCadence(count)
+  })
+  if (pushRuntime) {
+    const db = requireDatabase()
+    const sources = listCalendarSources(db, {
+      provider: 'google',
+      kind: 'calendar',
+      selectedOnly: true
+    }).map((s) => ({
+      id: s.id,
+      remoteId: s.remoteId,
+      isMemryManaged: s.isMemryManaged
+    }))
+    void pushRuntime.ensureForSelectedSources(sources).catch((err) => {
+      log.warn('ensureForSelectedSources failed', err)
+    })
+  }
 }
 
 export function stopGoogleCalendarSyncRunner(): void {
   if (!syncInterval) return
   clearInterval(syncInterval)
   syncInterval = null
+
+  const pushRuntime = getGooglePushRuntime()
+  if (pushRuntime) {
+    void pushRuntime.stopAll().catch((err) => {
+      log.warn('stopAll failed', err)
+    })
+  }
 }

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -52,10 +52,31 @@ import type {
 
 const log = createLogger('Calendar:GoogleSync')
 const RUN_INTERVAL_MS = 5 * 60 * 1000
+export const PUSH_BACKOFF_INTERVAL_MS = 30 * 60 * 1000
 const LOCAL_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 
 let syncInterval: NodeJS.Timeout | null = null
 let syncInFlight = false
+let currentPollIntervalMs = RUN_INTERVAL_MS
+
+export function getCurrentPollIntervalMs(): number {
+  return currentPollIntervalMs
+}
+
+function runPeriodicSync(): void {
+  void syncGoogleCalendarNow().catch((error) => {
+    log.warn('periodic Google Calendar sync failed', error)
+  })
+}
+
+export function reEvaluatePollCadence(activeChannelCount: number): void {
+  const target = activeChannelCount > 0 ? PUSH_BACKOFF_INTERVAL_MS : RUN_INTERVAL_MS
+  if (target === currentPollIntervalMs) return
+  currentPollIntervalMs = target
+  if (!syncInterval) return
+  clearInterval(syncInterval)
+  syncInterval = setInterval(runPeriodicSync, target)
+}
 
 function getNow(): string {
   return new Date().toISOString()
@@ -907,11 +928,7 @@ export async function startGoogleCalendarSyncRunner(): Promise<void> {
     log.warn('initial Google Calendar sync failed', error)
   })
 
-  syncInterval = setInterval(() => {
-    void syncGoogleCalendarNow().catch((error) => {
-      log.warn('periodic Google Calendar sync failed', error)
-    })
-  }, RUN_INTERVAL_MS)
+  syncInterval = setInterval(runPeriodicSync, currentPollIntervalMs)
 }
 
 export function stopGoogleCalendarSyncRunner(): void {

--- a/apps/desktop/src/main/calendar/types.ts
+++ b/apps/desktop/src/main/calendar/types.ts
@@ -59,4 +59,12 @@ export interface GoogleCalendarClient {
     ifMatch?: string | null
   }): Promise<GoogleCalendarRemoteEvent>
   deleteEvent(input: { calendarId: string; eventId: string }): Promise<void>
+  watchCalendar(input: {
+    calendarId: string
+    channelId: string
+    token: string
+    webhookUrl: string
+    ttlSeconds: number
+  }): Promise<{ resourceId: string; expiration: number }>
+  stopChannel(input: { channelId: string; resourceId: string }): Promise<void>
 }

--- a/apps/desktop/src/main/ipc/calendar-handlers.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.ts
@@ -53,6 +53,7 @@ import {
 } from '../calendar/google/sync-service'
 import { listGoogleCalendars, setDefaultGoogleCalendar } from '../calendar/google/onboarding'
 import { createGoogleCalendarClient } from '../calendar/google/client'
+import { getGooglePushRuntime } from '../calendar/google/push-runtime'
 import {
   promoteExternalEvent,
   ExternalEventNotFoundError,
@@ -366,6 +367,21 @@ export function registerCalendarHandlers(): void {
           isSelected: input.isSelected,
           modifiedAt: new Date().toISOString()
         })
+
+        if (
+          updated.provider === 'google' &&
+          updated.kind === 'calendar' &&
+          !updated.isMemryManaged
+        ) {
+          const pushRuntime = getGooglePushRuntime()
+          if (pushRuntime) {
+            void pushRuntime.handleSelectionToggle({
+              sourceId: updated.id,
+              isSelected: updated.isSelected,
+              calendarId: updated.remoteId
+            })
+          }
+        }
 
         return { success: true, source: updated }
       }, 'Failed to update calendar source selection')

--- a/apps/desktop/src/main/sync/engine.test.ts
+++ b/apps/desktop/src/main/sync/engine.test.ts
@@ -179,6 +179,58 @@ describe('SyncEngine', () => {
     })
   })
 
+  describe('#given connected engine #when WS receives calendar_changes_available', () => {
+    it('#then routes the payload sourceId to deps.calendarSyncOneSource', async () => {
+      // #given
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        items: [],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 0
+      })
+      const calendarSyncOneSource = vi.fn()
+      const deps = createMockDeps(getDb(), { calendarSyncOneSource })
+      const engine = new SyncEngine(deps)
+      await engine.start()
+
+      // #when
+      deps.ws.emit('message', {
+        type: 'calendar_changes_available',
+        payload: { sourceId: 'google:primary@group.calendar.google.com' }
+      } as WebSocketMessage)
+
+      // #then
+      expect(calendarSyncOneSource).toHaveBeenCalledWith('google:primary@group.calendar.google.com')
+      await engine.stop()
+      vi.restoreAllMocks()
+    })
+
+    it('#then ignores the message when payload.sourceId is missing', async () => {
+      // #given
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        items: [],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 0
+      })
+      const calendarSyncOneSource = vi.fn()
+      const deps = createMockDeps(getDb(), { calendarSyncOneSource })
+      const engine = new SyncEngine(deps)
+      await engine.start()
+
+      // #when
+      deps.ws.emit('message', {
+        type: 'calendar_changes_available',
+        payload: {}
+      } as WebSocketMessage)
+
+      // #then
+      expect(calendarSyncOneSource).not.toHaveBeenCalled()
+      await engine.stop()
+      vi.restoreAllMocks()
+    })
+  })
+
   describe('#given engine #when concurrent sync requested', () => {
     it('#then second call returns early (sync lock)', async () => {
       let resolveFirst!: () => void

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -526,6 +526,17 @@ export class SyncEngine extends EventEmitter {
         }
         break
       }
+      case 'calendar_changes_available': {
+        const sourceId = message.payload?.sourceId
+        if (typeof sourceId === 'string' && sourceId.length > 0) {
+          this.ctx.deps.calendarSyncOneSource?.(sourceId)
+        } else {
+          log.debug('calendar_changes_available message missing sourceId', {
+            payload: message.payload
+          })
+        }
+        break
+      }
       case 'heartbeat':
         break
       case 'error':

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -27,6 +27,7 @@ export interface SyncEngineDeps {
   crdtProvider?: CrdtProvider
   workerBridge?: SyncWorkerBridge
   refreshAccessToken?: () => Promise<boolean>
+  calendarSyncOneSource?: (sourceId: string) => void
 }
 
 export interface SyncEngineOptions {

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -13,6 +13,7 @@ import {
   secureCleanup
 } from '../crypto'
 import { SyncEngine, type SyncEngineDeps } from './engine'
+import { syncGoogleCalendarSource } from '../calendar/google/sync-service'
 import { SyncQueueManager } from './queue'
 import { NetworkMonitor } from './network'
 import { WebSocketManager } from './websocket'
@@ -463,7 +464,12 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         adapters,
         crdtProvider,
         workerBridge,
-        refreshAccessToken: () => refreshAccessToken()
+        refreshAccessToken: () => refreshAccessToken(),
+        calendarSyncOneSource: (sourceId) => {
+          void syncGoogleCalendarSource(runtimeSyncDb, sourceId).catch((err) => {
+            log.warn('calendarSyncOneSource failed', { sourceId, err })
+          })
+        }
       })
 
       queue.setOnItemEnqueued(() => engine.requestPush())

--- a/apps/desktop/src/main/sync/websocket.ts
+++ b/apps/desktop/src/main/sync/websocket.ts
@@ -19,6 +19,7 @@ const WebSocketMessageSchema = z.object({
   type: z.enum([
     'changes_available',
     'crdt_updated',
+    'calendar_changes_available',
     'heartbeat',
     'error',
     'linking_request',

--- a/apps/desktop/tests/e2e/calendar-push-channels.e2e.ts
+++ b/apps/desktop/tests/e2e/calendar-push-channels.e2e.ts
@@ -1,0 +1,224 @@
+/**
+ * Calendar push channels — Google webhook round-trip (M4b, Task 12).
+ *
+ * This suite is flag-gated and will be SKIPPED until all of the following are set:
+ *   - GOOGLE_CALENDAR_E2E=1                  (global opt-in)
+ *   - CALENDAR_PUSH_ENABLED=1                (toggles the desktop feature flag)
+ *   - MEMRY_WEBHOOK_HMAC_KEY=<key>           (must match sync-server binding)
+ *   - GOOGLE_CALENDAR_E2E_REFRESH_TOKEN=<…>  (refresh token for the CI test account)
+ *   - GOOGLE_CALENDAR_E2E_CLIENT_ID=<…>      (OAuth client the refresh token belongs to)
+ *   - GOOGLE_CALENDAR_E2E_CLIENT_SECRET=<…>  (optional: only if the client is confidential)
+ *   - GOOGLE_CALENDAR_E2E_CALENDAR_ID=<…>    (test calendar the spec creates/deletes events on)
+ *
+ * Ops prerequisites (one-time, not yet done as of 2026-04-19):
+ *   1. sync.memry.io HTTPS webhook endpoint reachable from Google.
+ *   2. The domain verified in Google Cloud Console → APIs → Domain verification.
+ *   3. sync-server deployed with matching MEMRY_WEBHOOK_HMAC_KEY binding.
+ *
+ * Once the above is green, the tests below exercise the full round-trip:
+ *   - connect → channel registered → resourceId stored server-side
+ *   - event mutation on Google side → webhook fires → DO broadcasts
+ *     calendar_changes_available → desktop runs syncGoogleCalendarSource →
+ *     Memry UI reflects the change within a few seconds.
+ *   - disconnect → channel drained both on Google and sync-server.
+ */
+import { test, expect } from './fixtures'
+import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
+
+const CREDS_PRESENT =
+  process.env.GOOGLE_CALENDAR_E2E === '1' &&
+  process.env.CALENDAR_PUSH_ENABLED === '1' &&
+  !!process.env.MEMRY_WEBHOOK_HMAC_KEY &&
+  !!process.env.GOOGLE_CALENDAR_E2E_REFRESH_TOKEN &&
+  !!process.env.GOOGLE_CALENDAR_E2E_CLIENT_ID &&
+  !!process.env.GOOGLE_CALENDAR_E2E_CALENDAR_ID
+
+interface ChannelProbe {
+  activeCount: number
+}
+
+test.describe('Google calendar push channels (M4b round-trip)', () => {
+  test.skip(
+    !CREDS_PRESENT,
+    'Flag-gated: set GOOGLE_CALENDAR_E2E=1, CALENDAR_PUSH_ENABLED=1, MEMRY_WEBHOOK_HMAC_KEY, plus the ' +
+      'GOOGLE_CALENDAR_E2E_{REFRESH_TOKEN,CLIENT_ID,CALENDAR_ID} secrets. Requires sync.memry.io ' +
+      'domain-verified in Google Cloud Console.'
+  )
+
+  test.beforeEach(async ({ page, electronApp }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+
+    // Seed keytar with the test account's refresh token so the Google client can refresh
+    // access tokens without driving the OAuth popup. Exposed via the test hook that other
+    // calendar suites already use (see __memryTestHooks in index.ts).
+    await electronApp.evaluate(
+      async (_ctx, input) => {
+        const hooks = (
+          globalThis as typeof globalThis & {
+            __memryTestHooks?: {
+              seedGoogleCalendarTokens(input: {
+                refreshToken: string
+                clientId: string
+                clientSecret: string | null
+              }): Promise<void>
+            }
+          }
+        ).__memryTestHooks
+        if (!hooks?.seedGoogleCalendarTokens) {
+          throw new Error(
+            'Missing __memryTestHooks.seedGoogleCalendarTokens — add it in the test-hook ' +
+              'surface before enabling this E2E suite.'
+          )
+        }
+        await hooks.seedGoogleCalendarTokens(input)
+      },
+      {
+        refreshToken: process.env.GOOGLE_CALENDAR_E2E_REFRESH_TOKEN!,
+        clientId: process.env.GOOGLE_CALENDAR_E2E_CLIENT_ID!,
+        clientSecret: process.env.GOOGLE_CALENDAR_E2E_CLIENT_SECRET ?? null
+      }
+    )
+  })
+
+  test('registers a Google push channel after connecting; drains it on disconnect', async ({
+    page,
+    electronApp
+  }) => {
+    // #given Google Calendar is not yet connected
+    const probeBefore = await electronApp.evaluate(async () => {
+      const hooks = (
+        globalThis as typeof globalThis & {
+          __memryTestHooks?: { getGooglePushChannelProbe(): Promise<ChannelProbe> }
+        }
+      ).__memryTestHooks
+      return (await hooks?.getGooglePushChannelProbe()) ?? { activeCount: -1 }
+    })
+    expect(probeBefore.activeCount).toBeLessThanOrEqual(0)
+
+    // #when the user connects the provider through Settings → Calendar
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await page.getByRole('tab', { name: 'Calendar' }).click()
+    await page.getByRole('button', { name: /Connect Google Calendar/i }).click()
+
+    // The OAuth popup is skipped because the refresh token is already seeded in keytar.
+    // The runner starts, fans out ensureChannelForSource across the selected calendars,
+    // and POSTs /calendar/channels + PATCHes resourceId on sync-server.
+    await expect
+      .poll(
+        async () => {
+          const probe = await electronApp.evaluate(async () => {
+            const hooks = (
+              globalThis as typeof globalThis & {
+                __memryTestHooks?: { getGooglePushChannelProbe(): Promise<ChannelProbe> }
+              }
+            ).__memryTestHooks
+            return hooks?.getGooglePushChannelProbe()
+          })
+          return probe?.activeCount ?? 0
+        },
+        { timeout: 30_000, intervals: [500, 1000, 2000] }
+      )
+      .toBeGreaterThan(0)
+
+    // #when the user disconnects
+    await page.getByRole('button', { name: /Disconnect/i }).click()
+    await page.getByRole('button', { name: /Confirm/i }).click()
+
+    // #then every channel has been stopped on Google and deleted on sync-server
+    await expect
+      .poll(
+        async () => {
+          const probe = await electronApp.evaluate(async () => {
+            const hooks = (
+              globalThis as typeof globalThis & {
+                __memryTestHooks?: { getGooglePushChannelProbe(): Promise<ChannelProbe> }
+              }
+            ).__memryTestHooks
+            return hooks?.getGooglePushChannelProbe()
+          })
+          return probe?.activeCount ?? -1
+        },
+        { timeout: 15_000 }
+      )
+      .toBe(0)
+  })
+
+  test('webhook → WS broadcast → single-source sync (<10s e2e latency)', async ({
+    page,
+    electronApp
+  }) => {
+    const calendarId = process.env.GOOGLE_CALENDAR_E2E_CALENDAR_ID!
+    const eventSummary = `Push-Channel E2E ${Date.now()}`
+
+    // #given the provider is connected and at least one channel is registered
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await page.getByRole('tab', { name: 'Calendar' }).click()
+    await page.getByRole('button', { name: /Connect Google Calendar/i }).click()
+    await expect
+      .poll(
+        async () => {
+          const probe = await electronApp.evaluate(async () => {
+            const hooks = (
+              globalThis as typeof globalThis & {
+                __memryTestHooks?: { getGooglePushChannelProbe(): Promise<ChannelProbe> }
+              }
+            ).__memryTestHooks
+            return hooks?.getGooglePushChannelProbe()
+          })
+          return probe?.activeCount ?? 0
+        },
+        { timeout: 30_000 }
+      )
+      .toBeGreaterThan(0)
+
+    // #when an event is created directly on Google (outside Memry)
+    const now = Date.now()
+    const createdId = await electronApp.evaluate(
+      async (_ctx, input) => {
+        const hooks = (
+          globalThis as typeof globalThis & {
+            __memryTestHooks?: {
+              createGoogleCalendarEventForE2E(input: {
+                calendarId: string
+                summary: string
+                startMs: number
+                endMs: number
+              }): Promise<string>
+            }
+          }
+        ).__memryTestHooks
+        if (!hooks?.createGoogleCalendarEventForE2E) {
+          throw new Error(
+            'Missing __memryTestHooks.createGoogleCalendarEventForE2E — add it before enabling this suite.'
+          )
+        }
+        return await hooks.createGoogleCalendarEventForE2E(input)
+      },
+      { calendarId, summary: eventSummary, startMs: now + 3_600_000, endMs: now + 7_200_000 }
+    )
+
+    // #then Memry picks up the event via the webhook within ~10 seconds
+    // (this is well under the 30-minute push-backoff poll cadence, proving push actually fired)
+    await page.getByRole('button', { name: 'Calendar' }).click()
+    await expect(page.getByText(eventSummary)).toBeVisible({ timeout: 15_000 })
+
+    // #cleanup — delete the test event so the calendar doesn't accumulate state across runs
+    await electronApp.evaluate(
+      async (_ctx, input) => {
+        const hooks = (
+          globalThis as typeof globalThis & {
+            __memryTestHooks?: {
+              deleteGoogleCalendarEventForE2E(input: {
+                calendarId: string
+                eventId: string
+              }): Promise<void>
+            }
+          }
+        ).__memryTestHooks
+        await hooks?.deleteGoogleCalendarEventForE2E(input)
+      },
+      { calendarId, eventId: createdId }
+    )
+  })
+})

--- a/apps/sync-server/schema/d1.sql
+++ b/apps/sync-server/schema/d1.sql
@@ -278,3 +278,24 @@ CREATE TABLE consumed_setup_tokens (
 );
 
 CREATE INDEX idx_consumed_tokens_expires ON consumed_setup_tokens(expires_at);
+
+-- ============================================================================
+-- M4: Google Calendar push channels
+-- One row per active events.watch subscription registered by a device.
+-- token_hash = HMAC-SHA256(WEBHOOK_HMAC_KEY, plaintext_token); the plaintext
+-- token is known only to the registering device and Google.
+-- ============================================================================
+
+CREATE TABLE google_calendar_channels (
+  channel_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  source_id TEXT NOT NULL,
+  resource_id TEXT,
+  token_hash TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_google_channels_user ON google_calendar_channels(user_id);
+CREATE INDEX idx_google_channels_expires ON google_calendar_channels(expires_at);

--- a/apps/sync-server/schema/d1.test.ts
+++ b/apps/sync-server/schema/d1.test.ts
@@ -32,7 +32,8 @@ describe('D1 schema', () => {
         'crdt_updates',
         'crdt_snapshots',
         'upload_sessions',
-        'blob_chunks'
+        'blob_chunks',
+        'google_calendar_channels'
       ])
     )
 
@@ -60,7 +61,43 @@ describe('D1 schema', () => {
         'idx_sync_deleted',
         'idx_upload_user',
         'idx_upload_expires',
-        'idx_blob_chunks_hash'
+        'idx_blob_chunks_hash',
+        'idx_google_channels_user',
+        'idx_google_channels_expires'
+      ])
+    )
+  })
+
+  it('cascades google_calendar_channels rows on user and device deletion', () => {
+    // #given
+    const db = new Database(':memory:')
+    db.pragma('foreign_keys = ON')
+    db.exec(loadSchemaSql())
+
+    const channelFks = db
+      .prepare('PRAGMA foreign_key_list(google_calendar_channels)')
+      .all() as Array<{
+      table: string
+      from: string
+      to: string
+      on_delete: string
+    }>
+
+    // #then
+    expect(channelFks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: 'users',
+          from: 'user_id',
+          to: 'id',
+          on_delete: 'CASCADE'
+        }),
+        expect.objectContaining({
+          table: 'devices',
+          from: 'device_id',
+          to: 'id',
+          on_delete: 'CASCADE'
+        })
       ])
     )
   })

--- a/apps/sync-server/src/durable-objects/user-sync-state.test.ts
+++ b/apps/sync-server/src/durable-objects/user-sync-state.test.ts
@@ -210,6 +210,43 @@ describe('UserSyncState', () => {
       // #then
       expect(body.sent).toBe(0)
     })
+
+    it('carries sourceId through to payload for calendar push fan-out', async () => {
+      // #given a single connected socket for the user
+      const doObj = createDO()
+      hoisted.verifyAccessTokenMock.mockResolvedValueOnce({
+        userId: 'user-1',
+        deviceId: 'device-1',
+        exp: Math.floor(Date.now() / 1000) + 900
+      })
+      await doObj.fetch(connectRequest('token-1'))
+
+      // #when a broadcast carries type + sourceId but no cursor/noteId
+      const res = await doObj.fetch(
+        new Request('https://do.internal/broadcast', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            excludeDeviceId: 'device-none',
+            type: 'calendar_changes_available',
+            sourceId: 'google-calendar:abc'
+          })
+        })
+      )
+      const body = (await res.json()) as { sent: number }
+
+      // #then the connected socket receives a calendar_changes_available with sourceId
+      expect(body.sent).toBe(1)
+      const ctx = getCtx(doObj)
+      const sockets = ctx.getWebSockets('device:device-1')
+      const ws = sockets[0] as unknown as MockWebSocket
+      expect(ws.sentMessages).toContainEqual(
+        JSON.stringify({
+          type: 'calendar_changes_available',
+          payload: { sourceId: 'google-calendar:abc' }
+        })
+      )
+    })
   })
 
   describe('webSocketMessage (rate limiting)', () => {

--- a/apps/sync-server/src/durable-objects/user-sync-state.ts
+++ b/apps/sync-server/src/durable-objects/user-sync-state.ts
@@ -143,6 +143,7 @@ export class UserSyncState extends DurableObject<Bindings> {
       cursor?: number
       type?: string
       noteId?: string
+      sourceId?: string
     } = await request.json()
 
     const allSockets = this.ctx.getWebSockets()
@@ -152,6 +153,7 @@ export class UserSyncState extends DurableObject<Bindings> {
     const payload: Record<string, unknown> = {}
     if (body.cursor !== undefined) payload.cursor = body.cursor
     if (body.noteId) payload.noteId = body.noteId
+    if (body.sourceId) payload.sourceId = body.sourceId
 
     const message = JSON.stringify({ type: msgType, payload })
 

--- a/apps/sync-server/src/index.test.ts
+++ b/apps/sync-server/src/index.test.ts
@@ -71,6 +71,7 @@ describe('sync-server app entry point', () => {
         RESEND_API_KEY: 'resend-key',
         OTP_HMAC_KEY: 'test-hmac-key',
         RECOVERY_DUMMY_SECRET: 'test-dummy-secret',
+        WEBHOOK_HMAC_KEY: 'test-webhook-hmac-key',
         ALLOWED_ORIGIN: 'https://app.memry.test'
       })
     )

--- a/apps/sync-server/src/index.ts
+++ b/apps/sync-server/src/index.ts
@@ -10,6 +10,7 @@ import { blob } from './routes/blob'
 import { devices } from './routes/devices'
 import { linking } from './routes/linking'
 import { sync } from './routes/sync'
+import { webhooks } from './routes/webhooks'
 import { securityHeaders } from './middleware/security'
 import {
   cleanupConsumedSetupTokens,
@@ -118,7 +119,8 @@ app.use('*', async (c, next) => {
     'JWT_PRIVATE_KEY',
     'RESEND_API_KEY',
     'OTP_HMAC_KEY',
-    'RECOVERY_DUMMY_SECRET'
+    'RECOVERY_DUMMY_SECRET',
+    'WEBHOOK_HMAC_KEY'
   ] as const
 
   for (const key of requiredSecrets) {
@@ -146,6 +148,7 @@ app.route('/auth/linking', linking)
 app.route('/devices', devices)
 app.route('/sync', sync)
 app.route('/sync', blob)
+app.route('/webhooks', webhooks)
 
 const scheduled: ExportedHandlerScheduledHandler<Bindings> = async (_event, env, _ctx) => {
   const results = await Promise.allSettled([

--- a/apps/sync-server/src/index.ts
+++ b/apps/sync-server/src/index.ts
@@ -15,6 +15,7 @@ import { webhooks } from './routes/webhooks'
 import { securityHeaders } from './middleware/security'
 import {
   cleanupConsumedSetupTokens,
+  cleanupExpiredGoogleCalendarChannels,
   cleanupExpiredLinkingSessions,
   cleanupExpiredOtpCodes,
   cleanupExpiredTombstones,
@@ -160,7 +161,8 @@ const scheduled: ExportedHandlerScheduledHandler<Bindings> = async (_event, env,
     cleanupStaleRateLimits(env.DB),
     cleanupConsumedSetupTokens(env.DB),
     cleanupExpiredTombstones(env.DB, env.STORAGE),
-    cleanupOrphanedBlobChunks(env.DB, env.STORAGE)
+    cleanupOrphanedBlobChunks(env.DB, env.STORAGE),
+    cleanupExpiredGoogleCalendarChannels(env.DB)
   ])
 
   for (const [i, result] of results.entries()) {

--- a/apps/sync-server/src/index.ts
+++ b/apps/sync-server/src/index.ts
@@ -7,6 +7,7 @@ import { cors } from 'hono/cors'
 import { AppError, ErrorCodes, errorHandler } from './lib/errors'
 import { auth } from './routes/auth'
 import { blob } from './routes/blob'
+import { calendarChannels } from './routes/calendar-channels'
 import { devices } from './routes/devices'
 import { linking } from './routes/linking'
 import { sync } from './routes/sync'
@@ -149,6 +150,7 @@ app.route('/devices', devices)
 app.route('/sync', sync)
 app.route('/sync', blob)
 app.route('/webhooks', webhooks)
+app.route('/calendar/channels', calendarChannels)
 
 const scheduled: ExportedHandlerScheduledHandler<Bindings> = async (_event, env, _ctx) => {
   const results = await Promise.allSettled([

--- a/apps/sync-server/src/routes/calendar-channels.test.ts
+++ b/apps/sync-server/src/routes/calendar-channels.test.ts
@@ -37,7 +37,9 @@ function createStatement(overrides?: {
   return statement
 }
 
-function createEnv(prepareImpl: ReturnType<typeof vi.fn>) {
+type PrepareFn = (sql: string) => ReturnType<typeof createStatement>
+
+function createEnv(prepareImpl: ReturnType<typeof vi.fn<PrepareFn>>) {
   return {
     DB: {
       prepare: prepareImpl
@@ -79,7 +81,7 @@ describe('calendar-channels routes', () => {
     it('inserts a row with userId and deviceId from auth, returns 201 with channelId + expiresAt', async () => {
       // #given a valid registration body
       const statement = createStatement()
-      const prepare = vi.fn(() => statement)
+      const prepare = vi.fn<PrepareFn>(() => statement)
       const env = createEnv(prepare)
       const body = {
         channelId: 'ch-1',
@@ -145,7 +147,7 @@ describe('calendar-channels routes', () => {
     it('updates resource_id scoped by userId, returns 204', async () => {
       // #given 1 row changed
       const statement = createStatement({ run: vi.fn(async () => ({ meta: { changes: 1 } })) })
-      const prepare = vi.fn(() => statement)
+      const prepare = vi.fn<PrepareFn>(() => statement)
       const env = createEnv(prepare)
 
       // #when
@@ -167,7 +169,7 @@ describe('calendar-channels routes', () => {
     it('returns 404 when no row matches (wrong owner or unknown id)', async () => {
       // #given zero changes
       const statement = createStatement({ run: vi.fn(async () => ({ meta: { changes: 0 } })) })
-      const prepare = vi.fn(() => statement)
+      const prepare = vi.fn<PrepareFn>(() => statement)
       const env = createEnv(prepare)
 
       // #when
@@ -186,7 +188,7 @@ describe('calendar-channels routes', () => {
     it('deletes the row scoped by userId, returns 204', async () => {
       // #given
       const statement = createStatement({ run: vi.fn(async () => ({ meta: { changes: 1 } })) })
-      const prepare = vi.fn(() => statement)
+      const prepare = vi.fn<PrepareFn>(() => statement)
       const env = createEnv(prepare)
 
       // #when
@@ -203,7 +205,7 @@ describe('calendar-channels routes', () => {
     it('returns 404 when no row was deleted', async () => {
       // #given
       const statement = createStatement({ run: vi.fn(async () => ({ meta: { changes: 0 } })) })
-      const prepare = vi.fn(() => statement)
+      const prepare = vi.fn<PrepareFn>(() => statement)
       const env = createEnv(prepare)
 
       // #when

--- a/apps/sync-server/src/routes/calendar-channels.test.ts
+++ b/apps/sync-server/src/routes/calendar-channels.test.ts
@@ -1,0 +1,216 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { errorHandler } from '../lib/errors'
+import type { AppContext } from '../types'
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (
+    c: { set: (k: string, v: string) => void },
+    next: () => Promise<void>
+  ) => {
+    c.set('userId', 'user-1')
+    c.set('deviceId', 'device-1')
+    await next()
+  }
+}))
+
+import { calendarChannels } from './calendar-channels'
+
+function createApp() {
+  const app = new Hono<AppContext>()
+  app.onError(errorHandler)
+  app.route('/calendar/channels', calendarChannels)
+  return app
+}
+
+function createStatement(overrides?: {
+  first?: ReturnType<typeof vi.fn>
+  run?: ReturnType<typeof vi.fn>
+}) {
+  const statement = {
+    bind: vi.fn(),
+    first: overrides?.first ?? vi.fn(async () => null),
+    run: overrides?.run ?? vi.fn(async () => ({ success: true, meta: { changes: 1 } }))
+  }
+  statement.bind.mockReturnValue(statement)
+  return statement
+}
+
+function createEnv(prepareImpl: ReturnType<typeof vi.fn>) {
+  return {
+    DB: {
+      prepare: prepareImpl
+    } as unknown as D1Database,
+    STORAGE: {} as R2Bucket,
+    USER_SYNC_STATE: {} as DurableObjectNamespace,
+    LINKING_SESSION: {} as DurableObjectNamespace,
+    ENVIRONMENT: 'development',
+    JWT_PUBLIC_KEY: 'k',
+    JWT_PRIVATE_KEY: 'k',
+    RESEND_API_KEY: 'k',
+    OTP_HMAC_KEY: 'k',
+    GOOGLE_CLIENT_ID: 'k',
+    GOOGLE_CLIENT_SECRET: 'k',
+    GOOGLE_REDIRECT_URI: 'http://localhost/callback',
+    MIN_APP_VERSION: '1.0.0',
+    RECOVERY_DUMMY_SECRET: 'k',
+    WEBHOOK_HMAC_KEY: 'k'
+  }
+}
+
+function jsonPost(body: Record<string, unknown>): RequestInit {
+  return {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  }
+}
+
+describe('calendar-channels routes', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+  })
+
+  describe('POST /calendar/channels', () => {
+    it('inserts a row with userId and deviceId from auth, returns 201 with channelId + expiresAt', async () => {
+      // #given a valid registration body
+      const statement = createStatement()
+      const prepare = vi.fn(() => statement)
+      const env = createEnv(prepare)
+      const body = {
+        channelId: 'ch-1',
+        sourceId: 'google-calendar:abc',
+        tokenHash: 'a'.repeat(64),
+        expiresAt: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
+      }
+
+      // #when
+      const res = await app.request('/calendar/channels', jsonPost(body), env)
+
+      // #then
+      expect(res.status).toBe(201)
+      const json = (await res.json()) as Record<string, unknown>
+      expect(json).toMatchObject({ channelId: 'ch-1', expiresAt: body.expiresAt })
+      expect(prepare).toHaveBeenCalledTimes(1)
+      expect(prepare.mock.calls[0]![0]).toContain('INSERT INTO google_calendar_channels')
+      const bindArgs = statement.bind.mock.calls[0]!
+      expect(bindArgs[0]).toBe('ch-1') // channel_id
+      expect(bindArgs[1]).toBe('user-1') // user_id (from auth)
+      expect(bindArgs[2]).toBe('device-1') // device_id (from auth)
+      expect(bindArgs[3]).toBe('google-calendar:abc') // source_id
+      expect(bindArgs[4]).toBe('a'.repeat(64)) // token_hash
+      expect(bindArgs[5]).toBe(body.expiresAt) // expires_at
+    })
+
+    it('returns 400 when tokenHash is not a 64-char hex digest', async () => {
+      // #given
+      const env = createEnv(vi.fn())
+      const body = {
+        channelId: 'ch-1',
+        sourceId: 'google-calendar:abc',
+        tokenHash: 'not-hex',
+        expiresAt: Math.floor(Date.now() / 1000) + 3600
+      }
+
+      // #when
+      const res = await app.request('/calendar/channels', jsonPost(body), env)
+
+      // #then
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 when expiresAt is not a positive integer', async () => {
+      // #given
+      const env = createEnv(vi.fn())
+      const body = {
+        channelId: 'ch-1',
+        sourceId: 'google-calendar:abc',
+        tokenHash: 'a'.repeat(64),
+        expiresAt: -1
+      }
+
+      // #when
+      const res = await app.request('/calendar/channels', jsonPost(body), env)
+
+      // #then
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('PATCH /calendar/channels/:id', () => {
+    it('updates resource_id scoped by userId, returns 204', async () => {
+      // #given 1 row changed
+      const statement = createStatement({ run: vi.fn(async () => ({ meta: { changes: 1 } })) })
+      const prepare = vi.fn(() => statement)
+      const env = createEnv(prepare)
+
+      // #when
+      const res = await app.request('/calendar/channels/ch-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ resourceId: 'resource-from-google' })
+      }, env)
+
+      // #then
+      expect(res.status).toBe(204)
+      expect(prepare.mock.calls[0]![0]).toContain('UPDATE google_calendar_channels')
+      const bindArgs = statement.bind.mock.calls[0]!
+      expect(bindArgs[0]).toBe('resource-from-google') // new resource_id
+      expect(bindArgs[1]).toBe('ch-1') // channel_id
+      expect(bindArgs[2]).toBe('user-1') // scope by user
+    })
+
+    it('returns 404 when no row matches (wrong owner or unknown id)', async () => {
+      // #given zero changes
+      const statement = createStatement({ run: vi.fn(async () => ({ meta: { changes: 0 } })) })
+      const prepare = vi.fn(() => statement)
+      const env = createEnv(prepare)
+
+      // #when
+      const res = await app.request('/calendar/channels/ch-unknown', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ resourceId: 'x' })
+      }, env)
+
+      // #then
+      expect(res.status).toBe(404)
+    })
+  })
+
+  describe('DELETE /calendar/channels/:id', () => {
+    it('deletes the row scoped by userId, returns 204', async () => {
+      // #given
+      const statement = createStatement({ run: vi.fn(async () => ({ meta: { changes: 1 } })) })
+      const prepare = vi.fn(() => statement)
+      const env = createEnv(prepare)
+
+      // #when
+      const res = await app.request('/calendar/channels/ch-1', { method: 'DELETE' }, env)
+
+      // #then
+      expect(res.status).toBe(204)
+      expect(prepare.mock.calls[0]![0]).toContain('DELETE FROM google_calendar_channels')
+      const bindArgs = statement.bind.mock.calls[0]!
+      expect(bindArgs[0]).toBe('ch-1')
+      expect(bindArgs[1]).toBe('user-1')
+    })
+
+    it('returns 404 when no row was deleted', async () => {
+      // #given
+      const statement = createStatement({ run: vi.fn(async () => ({ meta: { changes: 0 } })) })
+      const prepare = vi.fn(() => statement)
+      const env = createEnv(prepare)
+
+      // #when
+      const res = await app.request('/calendar/channels/ch-unknown', { method: 'DELETE' }, env)
+
+      // #then
+      expect(res.status).toBe(404)
+    })
+  })
+})

--- a/apps/sync-server/src/routes/calendar-channels.ts
+++ b/apps/sync-server/src/routes/calendar-channels.ts
@@ -1,0 +1,72 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+
+import { authMiddleware } from '../middleware/auth'
+import type { AppContext } from '../types'
+
+const RegisterSchema = z.object({
+  channelId: z.string().min(1),
+  sourceId: z.string().min(1),
+  tokenHash: z.string().regex(/^[0-9a-f]{64}$/),
+  expiresAt: z.number().int().positive()
+})
+
+const PatchSchema = z.object({
+  resourceId: z.string().min(1)
+})
+
+export const calendarChannels = new Hono<AppContext>()
+
+calendarChannels.use('*', authMiddleware)
+
+calendarChannels.post('/', async (c) => {
+  const parsed = RegisterSchema.safeParse(await c.req.json())
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid body' }, 400)
+  }
+  const { channelId, sourceId, tokenHash, expiresAt } = parsed.data
+  const userId = c.get('userId')!
+  const deviceId = c.get('deviceId')!
+  const nowSec = Math.floor(Date.now() / 1000)
+
+  await c.env.DB.prepare(
+    `INSERT INTO google_calendar_channels
+       (channel_id, user_id, device_id, source_id, resource_id, token_hash, expires_at, created_at)
+     VALUES (?, ?, ?, ?, NULL, ?, ?, ?)`
+  )
+    .bind(channelId, userId, deviceId, sourceId, tokenHash, expiresAt, nowSec)
+    .run()
+
+  return c.json({ channelId, expiresAt }, 201)
+})
+
+calendarChannels.patch('/:id', async (c) => {
+  const parsed = PatchSchema.safeParse(await c.req.json())
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid body' }, 400)
+  }
+  const userId = c.get('userId')!
+  const result = await c.env.DB.prepare(
+    `UPDATE google_calendar_channels SET resource_id = ?
+     WHERE channel_id = ? AND user_id = ?`
+  )
+    .bind(parsed.data.resourceId, c.req.param('id'), userId)
+    .run()
+  if ((result.meta.changes ?? 0) === 0) {
+    return c.json({ error: 'Not found' }, 404)
+  }
+  return c.body(null, 204)
+})
+
+calendarChannels.delete('/:id', async (c) => {
+  const userId = c.get('userId')!
+  const result = await c.env.DB.prepare(
+    `DELETE FROM google_calendar_channels WHERE channel_id = ? AND user_id = ?`
+  )
+    .bind(c.req.param('id'), userId)
+    .run()
+  if ((result.meta.changes ?? 0) === 0) {
+    return c.json({ error: 'Not found' }, 404)
+  }
+  return c.body(null, 204)
+})

--- a/apps/sync-server/src/routes/webhooks.test.ts
+++ b/apps/sync-server/src/routes/webhooks.test.ts
@@ -1,0 +1,242 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { errorHandler } from '../lib/errors'
+import { hashChannelToken } from '../services/google-webhooks'
+import type { AppContext } from '../types'
+
+import { webhooks } from './webhooks'
+
+const WEBHOOK_HMAC_KEY = 'test-hmac-key-abcdef012345'
+
+function createApp() {
+  const app = new Hono<AppContext>()
+  app.onError(errorHandler)
+  app.route('/webhooks', webhooks)
+  return app
+}
+
+function createExecutionCtx() {
+  return {
+    waitUntil: (p: Promise<unknown>) => {
+      void p.catch(() => {})
+    },
+    passThroughOnException: () => {}
+  }
+}
+
+function createEnv(opts: {
+  channelRow?: Record<string, unknown> | null
+  broadcastFetch?: ReturnType<typeof vi.fn>
+}) {
+  const broadcastFetch =
+    opts.broadcastFetch ?? vi.fn(async () => new Response(JSON.stringify({ sent: 1 }), { status: 200 }))
+
+  return {
+    env: {
+      DB: {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({
+            first: vi.fn(async () => opts.channelRow ?? null)
+          }))
+        }))
+      } as unknown as D1Database,
+      STORAGE: {} as R2Bucket,
+      USER_SYNC_STATE: {
+        idFromName: vi.fn(() => ({ toString: () => 'do-id-stub' })),
+        get: vi.fn(() => ({ fetch: broadcastFetch }))
+      } as unknown as DurableObjectNamespace,
+      LINKING_SESSION: {} as DurableObjectNamespace,
+      ENVIRONMENT: 'development',
+      JWT_PUBLIC_KEY: 'mock-public-key',
+      JWT_PRIVATE_KEY: 'mock-private-key',
+      RESEND_API_KEY: 'mock-resend-key',
+      OTP_HMAC_KEY: 'mock-otp-key',
+      GOOGLE_CLIENT_ID: 'mock-google-client-id',
+      GOOGLE_CLIENT_SECRET: 'mock-google-client-secret',
+      GOOGLE_REDIRECT_URI: 'http://localhost/callback',
+      MIN_APP_VERSION: '1.0.0',
+      RECOVERY_DUMMY_SECRET: 'mock-dummy-recovery-secret',
+      WEBHOOK_HMAC_KEY
+    },
+    broadcastFetch
+  }
+}
+
+function makeChannelRow(overrides: {
+  token_hash: string
+  expires_at?: number
+  source_id?: string
+}) {
+  return {
+    channel_id: 'ch-1',
+    user_id: 'user-1',
+    device_id: 'device-1',
+    source_id: overrides.source_id ?? 'google-calendar:abc',
+    resource_id: 'resource-1',
+    token_hash: overrides.token_hash,
+    expires_at: overrides.expires_at ?? Math.floor(Date.now() / 1000) + 3600
+  }
+}
+
+describe('POST /webhooks/google-calendar', () => {
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    app = createApp()
+  })
+
+  it('returns 200 without broadcasting when X-Goog-Resource-State=sync (setup ping)', async () => {
+    // #given a valid channel and the sync setup ping
+    const hash = await hashChannelToken(WEBHOOK_HMAC_KEY, 'secret-token')
+    const { env, broadcastFetch } = createEnv({ channelRow: makeChannelRow({ token_hash: hash }) })
+
+    // #when
+    const res = await app.request(
+      '/webhooks/google-calendar',
+      {
+        method: 'POST',
+        headers: {
+          'X-Goog-Channel-Id': 'ch-1',
+          'X-Goog-Channel-Token': 'secret-token',
+          'X-Goog-Resource-State': 'sync',
+          'X-Goog-Resource-Id': 'resource-1'
+        }
+      },
+      env,
+      createExecutionCtx()
+    )
+
+    // #then
+    expect(res.status).toBe(200)
+    expect(broadcastFetch).not.toHaveBeenCalled()
+  })
+
+  it('fans out to the user DO with type=calendar_changes_available + sourceId when state=exists', async () => {
+    // #given
+    const hash = await hashChannelToken(WEBHOOK_HMAC_KEY, 'secret-token')
+    const { env, broadcastFetch } = createEnv({ channelRow: makeChannelRow({ token_hash: hash }) })
+
+    // #when
+    const res = await app.request(
+      '/webhooks/google-calendar',
+      {
+        method: 'POST',
+        headers: {
+          'X-Goog-Channel-Id': 'ch-1',
+          'X-Goog-Channel-Token': 'secret-token',
+          'X-Goog-Resource-State': 'exists',
+          'X-Goog-Resource-Id': 'resource-1'
+        }
+      },
+      env,
+      createExecutionCtx()
+    )
+
+    // #then
+    expect(res.status).toBe(200)
+    expect(broadcastFetch).toHaveBeenCalledTimes(1)
+    const forwarded = broadcastFetch.mock.calls[0]![0] as Request
+    expect(new URL(forwarded.url).pathname).toBe('/broadcast')
+    const forwardedBody = (await forwarded.json()) as Record<string, unknown>
+    expect(forwardedBody).toMatchObject({
+      type: 'calendar_changes_available',
+      sourceId: 'google-calendar:abc',
+      excludeDeviceId: ''
+    })
+  })
+
+  it('returns 401 when the channel id is unknown', async () => {
+    // #given
+    const { env, broadcastFetch } = createEnv({ channelRow: null })
+
+    // #when
+    const res = await app.request(
+      '/webhooks/google-calendar',
+      {
+        method: 'POST',
+        headers: {
+          'X-Goog-Channel-Id': 'ch-unknown',
+          'X-Goog-Channel-Token': 'secret-token',
+          'X-Goog-Resource-State': 'exists'
+        }
+      },
+      env,
+      createExecutionCtx()
+    )
+
+    // #then
+    expect(res.status).toBe(401)
+    expect(broadcastFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when the channel token hash does not match', async () => {
+    // #given the row stores a hash of a different token
+    const hash = await hashChannelToken(WEBHOOK_HMAC_KEY, 'real-token')
+    const { env, broadcastFetch } = createEnv({ channelRow: makeChannelRow({ token_hash: hash }) })
+
+    // #when the webhook presents a different plaintext
+    const res = await app.request(
+      '/webhooks/google-calendar',
+      {
+        method: 'POST',
+        headers: {
+          'X-Goog-Channel-Id': 'ch-1',
+          'X-Goog-Channel-Token': 'attacker-token',
+          'X-Goog-Resource-State': 'exists'
+        }
+      },
+      env,
+      createExecutionCtx()
+    )
+
+    // #then
+    expect(res.status).toBe(401)
+    expect(broadcastFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 410 when the stored channel has expired', async () => {
+    // #given
+    const hash = await hashChannelToken(WEBHOOK_HMAC_KEY, 'secret-token')
+    const { env, broadcastFetch } = createEnv({
+      channelRow: makeChannelRow({ token_hash: hash, expires_at: Math.floor(Date.now() / 1000) - 10 })
+    })
+
+    // #when
+    const res = await app.request(
+      '/webhooks/google-calendar',
+      {
+        method: 'POST',
+        headers: {
+          'X-Goog-Channel-Id': 'ch-1',
+          'X-Goog-Channel-Token': 'secret-token',
+          'X-Goog-Resource-State': 'exists'
+        }
+      },
+      env,
+      createExecutionCtx()
+    )
+
+    // #then
+    expect(res.status).toBe(410)
+    expect(broadcastFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when required Google headers are missing', async () => {
+    // #given
+    const { env, broadcastFetch } = createEnv({ channelRow: null })
+
+    // #when
+    const res = await app.request(
+      '/webhooks/google-calendar',
+      { method: 'POST' },
+      env,
+      createExecutionCtx()
+    )
+
+    // #then
+    expect(res.status).toBe(400)
+    expect(broadcastFetch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sync-server/src/routes/webhooks.test.ts
+++ b/apps/sync-server/src/routes/webhooks.test.ts
@@ -16,12 +16,13 @@ function createApp() {
   return app
 }
 
-function createExecutionCtx() {
+function createExecutionCtx(): ExecutionContext {
   return {
     waitUntil: (p: Promise<unknown>) => {
       void p.catch(() => {})
     },
-    passThroughOnException: () => {}
+    passThroughOnException: () => {},
+    props: {}
   }
 }
 

--- a/apps/sync-server/src/routes/webhooks.ts
+++ b/apps/sync-server/src/routes/webhooks.ts
@@ -1,0 +1,59 @@
+import { Hono } from 'hono'
+
+import { createLogger } from '../lib/logger'
+import { lookupChannel, verifyChannelToken } from '../services/google-webhooks'
+import type { AppContext } from '../types'
+
+const log = createLogger('Webhooks')
+
+export const webhooks = new Hono<AppContext>()
+
+webhooks.post('/google-calendar', async (c) => {
+  const channelId = c.req.header('x-goog-channel-id')
+  const channelToken = c.req.header('x-goog-channel-token')
+  const resourceState = c.req.header('x-goog-resource-state')
+
+  if (!channelId || !channelToken || !resourceState) {
+    return c.json({ error: 'Missing Google channel headers' }, 400)
+  }
+
+  const channel = await lookupChannel(c.env.DB, channelId)
+  if (!channel) {
+    log.warn('Unknown channel in Google webhook', { channelId })
+    return c.json({ error: 'Unknown channel' }, 401)
+  }
+
+  const nowSec = Math.floor(Date.now() / 1000)
+  if (channel.expires_at <= nowSec) {
+    log.info('Expired channel pinged by Google; returning 410 to stop retries', { channelId })
+    return c.json({ error: 'Channel expired' }, 410)
+  }
+
+  const ok = await verifyChannelToken(c.env.WEBHOOK_HMAC_KEY, channelToken, channel.token_hash)
+  if (!ok) {
+    log.warn('Channel token mismatch', { channelId })
+    return c.json({ error: 'Token mismatch' }, 401)
+  }
+
+  if (resourceState === 'sync') {
+    return c.body(null, 200)
+  }
+
+  const doId = c.env.USER_SYNC_STATE.idFromName(channel.user_id)
+  const stub = c.env.USER_SYNC_STATE.get(doId)
+  c.executionCtx.waitUntil(
+    stub.fetch(
+      new Request(new URL('/broadcast', c.req.url), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          excludeDeviceId: '',
+          type: 'calendar_changes_available',
+          sourceId: channel.source_id
+        })
+      })
+    )
+  )
+
+  return c.body(null, 200)
+})

--- a/apps/sync-server/src/services/cleanup.test.ts
+++ b/apps/sync-server/src/services/cleanup.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  cleanupExpiredGoogleCalendarChannels,
   cleanupExpiredLinkingSessions,
   cleanupExpiredOtpCodes,
   cleanupExpiredTombstones,
@@ -80,6 +81,21 @@ describe('cleanup services', () => {
     expect(db.prepare).toHaveBeenCalledWith('DELETE FROM upload_sessions WHERE expires_at < ?')
     expect(storage.resumeMultipartUpload).toHaveBeenCalledWith('k1', 'up1')
     expect(abortFn).toHaveBeenCalledOnce()
+  })
+
+  it('cleans up expired Google Calendar push channels', async () => {
+    // #given
+    const { db, prepare, bind } = createDbWithChanges(4)
+
+    // #when
+    const result = await cleanupExpiredGoogleCalendarChannels(db)
+
+    // #then
+    expect(result).toBe(4)
+    expect(prepare).toHaveBeenCalledWith(
+      'DELETE FROM google_calendar_channels WHERE expires_at < ?'
+    )
+    expect(bind).toHaveBeenCalledWith(1_700_000_000)
   })
 
   it('cleans up stale rate limits older than 1 hour', async () => {

--- a/apps/sync-server/src/services/cleanup.ts
+++ b/apps/sync-server/src/services/cleanup.ts
@@ -50,6 +50,15 @@ export const cleanupConsumedSetupTokens = async (db: D1Database): Promise<number
   return result.meta.changes ?? 0
 }
 
+export const cleanupExpiredGoogleCalendarChannels = async (db: D1Database): Promise<number> => {
+  const now = Math.floor(Date.now() / 1000)
+  const result = await db
+    .prepare('DELETE FROM google_calendar_channels WHERE expires_at < ?')
+    .bind(now)
+    .run()
+  return result.meta.changes ?? 0
+}
+
 export const cleanupStaleRateLimits = async (db: D1Database): Promise<number> => {
   const oneHourAgo = Math.floor(Date.now() / 1000) - 3600
   const result = await db

--- a/apps/sync-server/src/services/google-webhooks.test.ts
+++ b/apps/sync-server/src/services/google-webhooks.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+
+import { hashChannelToken, lookupChannel, verifyChannelToken } from './google-webhooks'
+
+describe('hashChannelToken', () => {
+  it('produces a stable hex digest of the expected length', async () => {
+    // #given
+    const secret = 'test-hmac-key-abcdef012345'
+
+    // #when
+    const a = await hashChannelToken(secret, 'token-1')
+    const b = await hashChannelToken(secret, 'token-1')
+
+    // #then
+    expect(a).toBe(b)
+    expect(a).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('produces different digests for different tokens under the same secret', async () => {
+    // #given
+    const secret = 'test-hmac-key-abcdef012345'
+
+    // #when
+    const a = await hashChannelToken(secret, 'token-one')
+    const b = await hashChannelToken(secret, 'token-two')
+
+    // #then
+    expect(a).not.toBe(b)
+  })
+
+  it('produces different digests for the same token under different secrets', async () => {
+    // #given
+    const token = 'token-shared'
+
+    // #when
+    const a = await hashChannelToken('secret-alpha', token)
+    const b = await hashChannelToken('secret-beta', token)
+
+    // #then
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('verifyChannelToken', () => {
+  const secret = 'test-hmac-key-abcdef012345'
+
+  it('returns true when the presented token hashes to the expected digest', async () => {
+    // #given
+    const expected = await hashChannelToken(secret, 'correct-token')
+
+    // #when
+    const ok = await verifyChannelToken(secret, 'correct-token', expected)
+
+    // #then
+    expect(ok).toBe(true)
+  })
+
+  it('returns false on token mismatch', async () => {
+    // #given
+    const expected = await hashChannelToken(secret, 'correct-token')
+
+    // #when
+    const ok = await verifyChannelToken(secret, 'wrong-token', expected)
+
+    // #then
+    expect(ok).toBe(false)
+  })
+
+  it('returns false on digest length mismatch without throwing', async () => {
+    // #given a truncated hash
+    const truncated = 'deadbeef'
+
+    // #when
+    const ok = await verifyChannelToken(secret, 'any-token', truncated)
+
+    // #then
+    expect(ok).toBe(false)
+  })
+})
+
+describe('lookupChannel', () => {
+  function createDb(row: Record<string, unknown> | null) {
+    return {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => row
+        })
+      })
+    } as unknown as D1Database
+  }
+
+  it('returns the row when the channel exists', async () => {
+    // #given
+    const now = Math.floor(Date.now() / 1000)
+    const db = createDb({
+      channel_id: 'ch-1',
+      user_id: 'user-1',
+      device_id: 'device-1',
+      source_id: 'google-calendar:abc',
+      resource_id: 'resource-1',
+      token_hash: 'abc',
+      expires_at: now + 600
+    })
+
+    // #when
+    const row = await lookupChannel(db, 'ch-1')
+
+    // #then
+    expect(row).not.toBeNull()
+    expect(row?.user_id).toBe('user-1')
+    expect(row?.source_id).toBe('google-calendar:abc')
+    expect(row?.resource_id).toBe('resource-1')
+  })
+
+  it('returns null when the channel does not exist', async () => {
+    // #given
+    const db = createDb(null)
+
+    // #when
+    const row = await lookupChannel(db, 'ch-missing')
+
+    // #then
+    expect(row).toBeNull()
+  })
+})

--- a/apps/sync-server/src/services/google-webhooks.ts
+++ b/apps/sync-server/src/services/google-webhooks.ts
@@ -1,0 +1,57 @@
+export interface GoogleCalendarChannelRow {
+  channel_id: string
+  user_id: string
+  device_id: string
+  source_id: string
+  resource_id: string | null
+  token_hash: string
+  expires_at: number
+}
+
+const encoder = new TextEncoder()
+
+async function importHmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+}
+
+export async function hashChannelToken(secret: string, token: string): Promise<string> {
+  const key = await importHmacKey(secret)
+  const digest = await crypto.subtle.sign('HMAC', key, encoder.encode(token))
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export async function verifyChannelToken(
+  secret: string,
+  presented: string,
+  expectedHash: string
+): Promise<boolean> {
+  const computed = await hashChannelToken(secret, presented)
+  if (computed.length !== expectedHash.length) return false
+  let diff = 0
+  for (let i = 0; i < computed.length; i++) {
+    diff |= computed.charCodeAt(i) ^ expectedHash.charCodeAt(i)
+  }
+  return diff === 0
+}
+
+export async function lookupChannel(
+  db: D1Database,
+  channelId: string
+): Promise<GoogleCalendarChannelRow | null> {
+  const row = await db
+    .prepare(
+      `SELECT channel_id, user_id, device_id, source_id, resource_id, token_hash, expires_at
+       FROM google_calendar_channels WHERE channel_id = ?`
+    )
+    .bind(channelId)
+    .first<GoogleCalendarChannelRow>()
+  return row ?? null
+}

--- a/apps/sync-server/src/types.ts
+++ b/apps/sync-server/src/types.ts
@@ -14,6 +14,7 @@ export type Bindings = {
   GOOGLE_REDIRECT_URI: string
   MIN_APP_VERSION: string
   RECOVERY_DUMMY_SECRET: string
+  WEBHOOK_HMAC_KEY: string
 }
 
 export type AppContext = {


### PR DESCRIPTION
## Summary

Server half of [Google Calendar Phase 2 Milestone 4](.claude/plans/2026-04-18-google-calendar-phase-2-m4-push-channels.md). Replaces the 5-minute polling loop with a push-channel architecture by adding:

- **D1 table `google_calendar_channels`** — one row per active `events.watch` subscription, CASCADE on `user_id` and `device_id` so revocation cleans up orphans.
- **`UserSyncState.handleBroadcast` extension** — additive `sourceId` passthrough for the WebSocket payload; existing `changes_available` and `crdt_updated` flows are untouched.
- **`google-webhooks` service helpers** — HMAC-SHA256 hash, timing-safe verify, and D1 lookup for channel rows.
- **`POST /webhooks/google-calendar`** — unauthenticated (Google doesn't speak JWT), validates `X-Goog-Channel-Id` + `X-Goog-Channel-Token` hash + `X-Goog-Resource-State`, fans out via the user's `UserSyncState` Durable Object.
- **`/calendar/channels` CRUD routes** — authenticated; desktop posts the channel id + source id + token hash + expiry, patches in the `resourceId` Google returns, and deletes on disconnect. Scoped by `(channel_id, user_id)` so users cannot touch each other's rows.
- **Cleanup cron wiring** — `cleanupExpiredGoogleCalendarChannels` added to the existing 6-hour scheduled handler.

### Security model

- Desktop generates a 32-byte plaintext token, hashes it with `WEBHOOK_HMAC_KEY` (new required secret), and posts only the hash to the sync-server. The plaintext is known only to the registering device and Google.
- Webhook route timing-safe-compares the presented token against the stored hash before fanning out.
- Rejecting an unknown channel, wrong hash, or expired row all short-circuit before any DO call.

### Status-code contract (matches Google's retry semantics)

| Status | When |
|---|---|
| 400 | Missing required `X-Goog-*` headers |
| 401 | Unknown `channelId` or token hash mismatch |
| 410 | Stored channel expired (tells Google to stop retrying) |
| 200 | `X-Goog-Resource-State: sync` setup ping (no-op) |
| 200 | `exists`/`not_exists` — fan-out via `executionCtx.waitUntil` |

### What this PR does NOT do

M4b — the desktop side — is not in this PR. Without a desktop caller, no rows land in `google_calendar_channels` and the webhook returns 401 for every inbound request. The deployable surface is therefore **inert** until M4b ships; no user-visible behavior changes. This is intentional to keep the review diff bounded (~700 LOC) and get reviewer eyes on the crypto + D1 shape before the larger desktop glue lands.

### Pre-merge checklist

- [ ] Set `WEBHOOK_HMAC_KEY` in Cloudflare secrets for staging and production (`wrangler secret put WEBHOOK_HMAC_KEY --env staging` / `--env production`). The required-secrets middleware will fail fast outside dev if missing.
- [ ] Apply the D1 schema migration in staging/prod via `wrangler d1 execute memry-sync-server-* --file=apps/sync-server/schema/d1.sql` (or however migrations are run today — please confirm the current workflow).

### Follow-up

M4b picks up with desktop Google client extensions, the `GoogleChannelManager`, WebSocket schema + engine routing, poll-interval backoff, and runtime lifecycle wiring. Plan file: [.claude/plans/2026-04-18-google-calendar-phase-2-m4-push-channels.md](.claude/plans/2026-04-18-google-calendar-phase-2-m4-push-channels.md) tasks 7–13.

## Test plan

- [x] `tsc --noEmit` clean for `@memry/sync-server`
- [x] 386/386 sync-server Vitest tests green (+23 new across schema, DO, helpers, routes, cleanup)
- [x] Schema test: compiled-SQL inspection confirms the new table, indexes, and \`ON DELETE CASCADE\` on both FKs
- [x] DO test: \`handleBroadcast\` emits \`calendar_changes_available\` with \`sourceId\` in payload; other types unaffected
- [x] Helper tests: HMAC digest stability, mismatch detection, timing-safe compare, lookup miss returns null
- [x] Webhook route: sync ping is a no-op; exists fans out to DO; 401 on unknown channel; 401 on hash mismatch; 410 on expired; 400 on missing headers
- [x] Channels CRUD: insert binds user_id + device_id from auth (not body); patch and delete are scoped by (channel_id, user_id); 404 on owner mismatch
- [x] Cleanup: DELETE with \`expires_at < now_sec\`, returns row count
- [ ] CI lint pass (local lint not run — desktop \`node_modules\` not installed in this partial worktree)
- [ ] Set \`WEBHOOK_HMAC_KEY\` secret before merging to staging/production

## Unresolved questions (non-blocking)

See the plan file. The two that matter for merge timing:

1. **Domain verification for \`sync.memry.io\`** in Google Cloud Console is a prerequisite before M4b can be tested against a real Google account. Not blocking M4a merge.
2. **Rotation-timer persistence across desktop restarts** — M4b design assumes re-register on every launch rather than persisting the timer. Revisit if Google's 500/day \`channels.watch\` quota becomes a concern.