### PR TITLE
M4b: desktop half of Google Calendar push channels

### DIFF
--- a/apps/desktop/src/main/calendar/google/client.test.ts
+++ b/apps/desktop/src/main/calendar/google/client.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import keytar from 'keytar'
+
+vi.mock('keytar', () => ({
+  default: {
+    setPassword: vi.fn(),
+    getPassword: vi.fn(),
+    deletePassword: vi.fn()
+  }
+}))
+
+vi.mock('electron', () => ({
+  shell: {
+    openExternal: vi.fn()
+  }
+}))
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => loggerMock
+}))
+
+import { createGoogleCalendarClient } from './client'
+import { clearGoogleCalendarTokens, storeGoogleCalendarTokens } from './keychain'
+
+describe('google calendar client — push channels (Task 7)', () => {
+  const keytarStore = new Map<string, string>()
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    keytarStore.clear()
+    process.env.GOOGLE_CALENDAR_CLIENT_ID = 'google-client-id-123'
+    vi.stubGlobal('fetch', fetchMock)
+
+    vi.mocked(keytar.setPassword).mockImplementation(async (service, account, value) => {
+      keytarStore.set(`${service}:${account}`, value)
+    })
+    vi.mocked(keytar.getPassword).mockImplementation(async (service, account) => {
+      return keytarStore.get(`${service}:${account}`) ?? null
+    })
+    vi.mocked(keytar.deletePassword).mockImplementation(async (service, account) => {
+      keytarStore.delete(`${service}:${account}`)
+      return true
+    })
+
+    await storeGoogleCalendarTokens({
+      accessToken: 'seeded-access-token',
+      refreshToken: 'seeded-refresh-token'
+    })
+  })
+
+  afterEach(async () => {
+    delete process.env.GOOGLE_CALENDAR_CLIENT_ID
+    vi.unstubAllGlobals()
+    await clearGoogleCalendarTokens()
+  })
+
+  describe('watchCalendar', () => {
+    it('POSTs events.watch with id/token/type/address/expiration and returns resourceId + expiration', async () => {
+      const nowMs = 1_700_000_000_000
+      vi.spyOn(Date, 'now').mockReturnValue(nowMs)
+
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input)
+        expect(url).toBe(
+          'https://www.googleapis.com/calendar/v3/calendars/primary%40group.calendar.google.com/events/watch'
+        )
+        expect(init?.method).toBe('POST')
+        expect((init?.headers as Record<string, string>).Authorization).toBe(
+          'Bearer seeded-access-token'
+        )
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+        expect(body).toEqual({
+          id: 'channel-abc',
+          token: 'plaintext-secret-xyz',
+          type: 'web_hook',
+          address: 'https://sync.memry.io/webhooks/google-calendar',
+          expiration: String(nowMs + 7 * 24 * 60 * 60 * 1000)
+        })
+        return new Response(
+          JSON.stringify({
+            kind: 'api#channel',
+            id: 'channel-abc',
+            resourceId: 'resource-123',
+            resourceUri: 'https://www.googleapis.com/calendar/v3/calendars/primary/events?alt=json',
+            expiration: String(nowMs + 7 * 24 * 60 * 60 * 1000)
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      })
+
+      const client = createGoogleCalendarClient()
+      const result = await client.watchCalendar({
+        calendarId: 'primary@group.calendar.google.com',
+        channelId: 'channel-abc',
+        token: 'plaintext-secret-xyz',
+        webhookUrl: 'https://sync.memry.io/webhooks/google-calendar',
+        ttlSeconds: 7 * 24 * 60 * 60
+      })
+
+      expect(result).toEqual({
+        resourceId: 'resource-123',
+        expiration: nowMs + 7 * 24 * 60 * 60 * 1000
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws a user-facing error when Google rejects the watch request', async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: { status: 'PERMISSION_DENIED', message: 'webhook domain not verified' }
+          }),
+          { status: 403 }
+        )
+      )
+
+      const client = createGoogleCalendarClient()
+      await expect(
+        client.watchCalendar({
+          calendarId: 'primary',
+          channelId: 'c1',
+          token: 't1',
+          webhookUrl: 'https://sync.memry.io/webhooks/google-calendar',
+          ttlSeconds: 3600
+        })
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('stopChannel', () => {
+    it('POSTs channels.stop with {id, resourceId} and resolves on 204', async () => {
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input)
+        expect(url).toBe('https://www.googleapis.com/calendar/v3/channels/stop')
+        expect(init?.method).toBe('POST')
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+        expect(body).toEqual({ id: 'channel-abc', resourceId: 'resource-123' })
+        return new Response(null, { status: 204 })
+      })
+
+      const client = createGoogleCalendarClient()
+      await expect(
+        client.stopChannel({ channelId: 'channel-abc', resourceId: 'resource-123' })
+      ).resolves.toBeUndefined()
+    })
+
+    it('tolerates 404 without throwing (channel already stale on Google side)', async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({ error: { status: 'NOT_FOUND', message: 'channel not found' } }),
+          { status: 404 }
+        )
+      )
+
+      const client = createGoogleCalendarClient()
+      await expect(
+        client.stopChannel({ channelId: 'stale', resourceId: 'stale-resource' })
+      ).resolves.toBeUndefined()
+    })
+
+    it('throws for non-404 errors (e.g. 500)', async () => {
+      fetchMock.mockResolvedValue(new Response('oops', { status: 500 }))
+
+      const client = createGoogleCalendarClient()
+      await expect(client.stopChannel({ channelId: 'c', resourceId: 'r' })).rejects.toThrow()
+    })
+  })
+})

--- a/apps/desktop/src/main/calendar/google/client.ts
+++ b/apps/desktop/src/main/calendar/google/client.ts
@@ -56,6 +56,12 @@ const GoogleTokenRefreshSchema = z.object({
   token_type: z.string().min(1)
 })
 
+const GoogleWatchChannelResponseSchema = z.object({
+  id: z.string().min(1),
+  resourceId: z.string().min(1),
+  expiration: z.union([z.string(), z.number()]).optional()
+})
+
 function resolveGoogleClientId(): string {
   const clientId = process.env.GOOGLE_CALENDAR_CLIENT_ID?.trim()
   if (!clientId) {
@@ -394,6 +400,54 @@ export function createGoogleCalendarClient(): GoogleCalendarClient {
 
       if (!response.ok && response.status !== 404) {
         await throwCalendarApiFailure(response, 'delete Google calendar event')
+      }
+    },
+
+    async watchCalendar(input): Promise<{ resourceId: string; expiration: number }> {
+      const expirationMs = Date.now() + input.ttlSeconds * 1000
+      const response = await withAuthorizedResponse({
+        path: `/calendars/${encodeURIComponent(input.calendarId)}/events/watch`,
+        init: {
+          method: 'POST',
+          body: JSON.stringify({
+            id: input.channelId,
+            token: input.token,
+            type: 'web_hook',
+            address: input.webhookUrl,
+            expiration: String(expirationMs)
+          })
+        }
+      })
+
+      if (!response.ok) {
+        await throwCalendarApiFailure(response, 'watch Google calendar')
+      }
+
+      const parsed = GoogleWatchChannelResponseSchema.parse(await response.json())
+      const expiration =
+        typeof parsed.expiration === 'string'
+          ? Number(parsed.expiration)
+          : (parsed.expiration ?? expirationMs)
+      return {
+        resourceId: parsed.resourceId,
+        expiration: Number.isFinite(expiration) ? expiration : expirationMs
+      }
+    },
+
+    async stopChannel(input): Promise<void> {
+      const response = await withAuthorizedResponse({
+        path: '/channels/stop',
+        init: {
+          method: 'POST',
+          body: JSON.stringify({
+            id: input.channelId,
+            resourceId: input.resourceId
+          })
+        }
+      })
+
+      if (!response.ok && response.status !== 404) {
+        await throwCalendarApiFailure(response, 'stop Google calendar channel')
       }
     }
   }

--- a/apps/desktop/src/main/calendar/google/google-channel-manager.test.ts
+++ b/apps/desktop/src/main/calendar/google/google-channel-manager.test.ts
@@ -1,0 +1,252 @@
+import { createHash } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => loggerMock
+}))
+
+import { createGoogleChannelManager, type GoogleChannelManagerDeps } from './google-channel-manager'
+
+interface HarnessDeps extends GoogleChannelManagerDeps {
+  // Spies on deps for assertions
+  client: {
+    watchCalendar: ReturnType<typeof vi.fn>
+    stopChannel: ReturnType<typeof vi.fn>
+  }
+  registerOnServer: ReturnType<typeof vi.fn>
+  attachResourceId: ReturnType<typeof vi.fn>
+  deleteOnServer: ReturnType<typeof vi.fn>
+}
+
+const TTL_SECONDS = 7 * 24 * 60 * 60 // 7 days
+const MARGIN_SECONDS = 60 * 60 // 1 hour
+const FIXED_NOW_MS = 1_700_000_000_000
+
+function buildDeps(overrides: Partial<GoogleChannelManagerDeps> = {}): HarnessDeps {
+  let channelCounter = 0
+  let tokenCounter = 0
+  return {
+    client: {
+      watchCalendar: vi.fn(async (input) => ({
+        resourceId: `resource-${input.channelId}`,
+        expiration: FIXED_NOW_MS + TTL_SECONDS * 1000
+      })),
+      stopChannel: vi.fn(async () => {})
+    },
+    registerOnServer: vi.fn(async () => {}),
+    attachResourceId: vi.fn(async () => {}),
+    deleteOnServer: vi.fn(async () => {}),
+    hashToken: vi.fn(async (plaintext: string) =>
+      createHash('sha256').update(plaintext).digest('hex')
+    ),
+    generateToken: vi.fn(() => `token-${++tokenCounter}`),
+    generateChannelId: vi.fn(() => `channel-${++channelCounter}`),
+    webhookUrl: 'https://sync.memry.io/webhooks/google-calendar',
+    ttlSeconds: TTL_SECONDS,
+    rotationMarginSeconds: MARGIN_SECONDS,
+    featureEnabled: true,
+    now: () => Date.now(),
+    ...overrides
+  } as HarnessDeps
+}
+
+describe('google-channel-manager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(FIXED_NOW_MS)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  describe('ensureChannelForSource', () => {
+    it('registers hash on sync-server, watches Google, then PATCHes resourceId', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal@group.google.com' })
+
+      expect(deps.registerOnServer).toHaveBeenCalledTimes(1)
+      const registerArg = deps.registerOnServer.mock.calls[0]![0] as {
+        channelId: string
+        sourceId: string
+        tokenHash: string
+        expiresAt: number
+      }
+      expect(registerArg.channelId).toBe('channel-1')
+      expect(registerArg.sourceId).toBe('src-1')
+      expect(registerArg.tokenHash).toBe(createHash('sha256').update('token-1').digest('hex'))
+      expect(registerArg.tokenHash).toMatch(/^[0-9a-f]{64}$/)
+      expect(registerArg.expiresAt).toBe(Math.floor(FIXED_NOW_MS / 1000) + TTL_SECONDS)
+
+      expect(deps.client.watchCalendar).toHaveBeenCalledTimes(1)
+      const watchArg = deps.client.watchCalendar.mock.calls[0]![0] as {
+        calendarId: string
+        channelId: string
+        token: string
+        webhookUrl: string
+        ttlSeconds: number
+      }
+      expect(watchArg).toEqual({
+        calendarId: 'cal@group.google.com',
+        channelId: 'channel-1',
+        token: 'token-1',
+        webhookUrl: 'https://sync.memry.io/webhooks/google-calendar',
+        ttlSeconds: TTL_SECONDS
+      })
+
+      expect(deps.attachResourceId).toHaveBeenCalledWith({
+        channelId: 'channel-1',
+        resourceId: 'resource-channel-1'
+      })
+
+      expect(mgr.getActiveChannelCount()).toBe(1)
+    })
+
+    it('no-ops when featureEnabled is false', async () => {
+      const deps = buildDeps({ featureEnabled: false })
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+
+      expect(deps.registerOnServer).not.toHaveBeenCalled()
+      expect(deps.client.watchCalendar).not.toHaveBeenCalled()
+      expect(mgr.getActiveChannelCount()).toBe(0)
+    })
+
+    it('dedupes: second call for same sourceId is a no-op', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+
+      expect(deps.client.watchCalendar).toHaveBeenCalledTimes(1)
+      expect(mgr.getActiveChannelCount()).toBe(1)
+    })
+
+    it('fires onActiveCountChange when transitioning 0 → 1', async () => {
+      const onActiveCountChange = vi.fn()
+      const deps = buildDeps({ onActiveCountChange })
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+
+      expect(onActiveCountChange).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('stopForSource', () => {
+    it('stops the channel on Google, deletes on server, clears state', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+      await mgr.stopForSource('src-1')
+
+      expect(deps.client.stopChannel).toHaveBeenCalledWith({
+        channelId: 'channel-1',
+        resourceId: 'resource-channel-1'
+      })
+      expect(deps.deleteOnServer).toHaveBeenCalledWith({ channelId: 'channel-1' })
+      expect(mgr.getActiveChannelCount()).toBe(0)
+    })
+
+    it('is a no-op for unknown sourceId', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.stopForSource('never-registered')
+
+      expect(deps.client.stopChannel).not.toHaveBeenCalled()
+      expect(deps.deleteOnServer).not.toHaveBeenCalled()
+    })
+
+    it('fires onActiveCountChange on 1 → 0 transition', async () => {
+      const onActiveCountChange = vi.fn()
+      const deps = buildDeps({ onActiveCountChange })
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+      onActiveCountChange.mockClear()
+
+      await mgr.stopForSource('src-1')
+
+      expect(onActiveCountChange).toHaveBeenCalledWith(0)
+    })
+  })
+
+  describe('stopAll', () => {
+    it('stops every registered channel', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+      await mgr.ensureChannelForSource({ sourceId: 'src-2', calendarId: 'cal-b' })
+      expect(mgr.getActiveChannelCount()).toBe(2)
+
+      await mgr.stopAll()
+
+      expect(deps.client.stopChannel).toHaveBeenCalledTimes(2)
+      expect(deps.deleteOnServer).toHaveBeenCalledTimes(2)
+      expect(mgr.getActiveChannelCount()).toBe(0)
+    })
+  })
+
+  describe('rotation', () => {
+    it('rotates the channel before ttl expiry (using ttl - margin as trigger)', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+
+      expect(deps.client.watchCalendar).toHaveBeenCalledTimes(1)
+      expect(deps.client.stopChannel).not.toHaveBeenCalled()
+
+      // Advance to just before the rotation trigger — nothing happens yet.
+      const rotationDelayMs = (TTL_SECONDS - MARGIN_SECONDS) * 1000
+      await vi.advanceTimersByTimeAsync(rotationDelayMs - 10)
+      expect(deps.client.stopChannel).not.toHaveBeenCalled()
+
+      // Cross the trigger — old channel is stopped, a new one is created.
+      await vi.advanceTimersByTimeAsync(20)
+
+      expect(deps.client.stopChannel).toHaveBeenCalledTimes(1)
+      expect(deps.client.stopChannel).toHaveBeenCalledWith({
+        channelId: 'channel-1',
+        resourceId: 'resource-channel-1'
+      })
+      expect(deps.client.watchCalendar).toHaveBeenCalledTimes(2)
+      const secondWatch = deps.client.watchCalendar.mock.calls[1]![0] as { channelId: string }
+      expect(secondWatch.channelId).toBe('channel-2')
+      expect(mgr.getActiveChannelCount()).toBe(1)
+    })
+  })
+
+  describe('security', () => {
+    it('never stores the plaintext token anywhere retrievable after registration', async () => {
+      const deps = buildDeps()
+      const mgr = createGoogleChannelManager(deps)
+
+      await mgr.ensureChannelForSource({ sourceId: 'src-1', calendarId: 'cal-a' })
+
+      // Whole manager surface must not leak token-1. getActiveChannelCount exposes only a number.
+      expect(JSON.stringify({ count: mgr.getActiveChannelCount() })).not.toContain('token-1')
+      // sync-server received the hash, not the plaintext.
+      const registerArg = deps.registerOnServer.mock.calls[0]![0] as { tokenHash: string }
+      expect(registerArg.tokenHash).not.toContain('token-1')
+      expect(registerArg.tokenHash).toMatch(/^[0-9a-f]{64}$/)
+    })
+  })
+})

--- a/apps/desktop/src/main/calendar/google/google-channel-manager.ts
+++ b/apps/desktop/src/main/calendar/google/google-channel-manager.ts
@@ -1,0 +1,176 @@
+import { createLogger } from '../../lib/logger'
+import type { GoogleCalendarClient } from '../types'
+
+const log = createLogger('Calendar:GoogleChannelManager')
+
+export interface GoogleChannelManagerDeps {
+  client: Pick<GoogleCalendarClient, 'watchCalendar' | 'stopChannel'>
+  registerOnServer(input: {
+    channelId: string
+    sourceId: string
+    tokenHash: string
+    expiresAt: number
+  }): Promise<void>
+  attachResourceId(input: { channelId: string; resourceId: string }): Promise<void>
+  deleteOnServer(input: { channelId: string }): Promise<void>
+  hashToken(plaintext: string): Promise<string>
+  generateToken(): string
+  generateChannelId(): string
+  webhookUrl: string
+  ttlSeconds: number
+  rotationMarginSeconds: number
+  featureEnabled: boolean
+  now?: () => number
+  onActiveCountChange?: (count: number) => void
+}
+
+export interface GoogleChannelManager {
+  ensureChannelForSource(input: { sourceId: string; calendarId: string }): Promise<void>
+  stopForSource(sourceId: string): Promise<void>
+  stopAll(): Promise<void>
+  getActiveChannelCount(): number
+}
+
+interface ChannelState {
+  sourceId: string
+  calendarId: string
+  channelId: string
+  resourceId: string
+  expirationMs: number
+  rotationTimer: ReturnType<typeof setTimeout>
+}
+
+export function createGoogleChannelManager(deps: GoogleChannelManagerDeps): GoogleChannelManager {
+  const states = new Map<string, ChannelState>()
+
+  function emitCount(): void {
+    deps.onActiveCountChange?.(states.size)
+  }
+
+  async function registerFresh(sourceId: string, calendarId: string): Promise<ChannelState> {
+    const channelId = deps.generateChannelId()
+    const plaintextToken = deps.generateToken()
+    const tokenHash = await deps.hashToken(plaintextToken)
+    const nowMs = (deps.now ?? Date.now)()
+    const expirationMs = nowMs + deps.ttlSeconds * 1000
+    const expiresAt = Math.floor(nowMs / 1000) + deps.ttlSeconds
+
+    await deps.registerOnServer({ channelId, sourceId, tokenHash, expiresAt })
+
+    const watchResult = await deps.client.watchCalendar({
+      calendarId,
+      channelId,
+      token: plaintextToken,
+      webhookUrl: deps.webhookUrl,
+      ttlSeconds: deps.ttlSeconds
+    })
+
+    await deps.attachResourceId({ channelId, resourceId: watchResult.resourceId })
+
+    const rotationDelayMs = Math.max(1, (deps.ttlSeconds - deps.rotationMarginSeconds) * 1000)
+    const rotationTimer = setTimeout(() => {
+      void rotate(sourceId)
+    }, rotationDelayMs)
+    if (typeof rotationTimer === 'object' && rotationTimer && 'unref' in rotationTimer) {
+      ;(rotationTimer as { unref: () => void }).unref()
+    }
+
+    return {
+      sourceId,
+      calendarId,
+      channelId,
+      resourceId: watchResult.resourceId,
+      expirationMs: watchResult.expiration ?? expirationMs,
+      rotationTimer
+    }
+  }
+
+  async function rotate(sourceId: string): Promise<void> {
+    const prev = states.get(sourceId)
+    if (!prev) return
+    log.info('Rotating Google push channel', { sourceId, channelId: prev.channelId })
+    try {
+      await stopForSource(sourceId, { silent: true })
+    } catch (err) {
+      log.warn('Rotation: failed to stop old channel (continuing to re-register)', {
+        sourceId,
+        channelId: prev.channelId,
+        err
+      })
+    }
+    try {
+      const fresh = await registerFresh(sourceId, prev.calendarId)
+      states.set(sourceId, fresh)
+      emitCount()
+    } catch (err) {
+      log.error('Rotation: failed to register fresh channel', { sourceId, err })
+    }
+  }
+
+  async function stopForSource(
+    sourceId: string,
+    options: { silent?: boolean } = {}
+  ): Promise<void> {
+    const state = states.get(sourceId)
+    if (!state) return
+
+    clearTimeout(state.rotationTimer)
+    states.delete(sourceId)
+
+    try {
+      await deps.client.stopChannel({
+        channelId: state.channelId,
+        resourceId: state.resourceId
+      })
+    } catch (err) {
+      log.warn('stopChannel on Google failed (ignoring)', {
+        sourceId,
+        channelId: state.channelId,
+        err
+      })
+    }
+
+    try {
+      await deps.deleteOnServer({ channelId: state.channelId })
+    } catch (err) {
+      log.warn('deleteOnServer failed (ignoring; cron will reap)', {
+        sourceId,
+        channelId: state.channelId,
+        err
+      })
+    }
+
+    if (!options.silent) {
+      emitCount()
+    }
+  }
+
+  async function ensureChannelForSource(input: {
+    sourceId: string
+    calendarId: string
+  }): Promise<void> {
+    if (!deps.featureEnabled) return
+    if (states.has(input.sourceId)) return
+
+    const state = await registerFresh(input.sourceId, input.calendarId)
+    states.set(input.sourceId, state)
+    emitCount()
+  }
+
+  async function stopAll(): Promise<void> {
+    const ids = Array.from(states.keys())
+    await Promise.all(ids.map((id) => stopForSource(id, { silent: true })))
+    emitCount()
+  }
+
+  function getActiveChannelCount(): number {
+    return states.size
+  }
+
+  return {
+    ensureChannelForSource,
+    stopForSource: (id: string) => stopForSource(id),
+    stopAll,
+    getActiveChannelCount
+  }
+}

--- a/apps/desktop/src/main/calendar/google/google-sync-runner.ts
+++ b/apps/desktop/src/main/calendar/google/google-sync-runner.ts
@@ -1,0 +1,78 @@
+import { createLogger } from '../../lib/logger'
+import { requireDatabase } from '../../database'
+import { isMemryUserSignedIn } from '../../sync/auth-state'
+import { hasGoogleCalendarConnection } from './oauth'
+import { listCalendarSources } from '../repositories/calendar-sources-repository'
+import { getGooglePushRuntime, getOrInitGooglePushRuntime } from './push-runtime'
+import { syncGoogleCalendarNow } from './sync-service'
+
+const log = createLogger('Calendar:GoogleSyncRunner')
+
+const RUN_INTERVAL_MS = 5 * 60 * 1000
+export const PUSH_BACKOFF_INTERVAL_MS = 30 * 60 * 1000
+
+let syncInterval: NodeJS.Timeout | null = null
+let currentPollIntervalMs = RUN_INTERVAL_MS
+
+export function getCurrentPollIntervalMs(): number {
+  return currentPollIntervalMs
+}
+
+function runPeriodicSync(): void {
+  void syncGoogleCalendarNow().catch((error) => {
+    log.warn('periodic Google Calendar sync failed', error)
+  })
+}
+
+export function reEvaluatePollCadence(activeChannelCount: number): void {
+  const target = activeChannelCount > 0 ? PUSH_BACKOFF_INTERVAL_MS : RUN_INTERVAL_MS
+  if (target === currentPollIntervalMs) return
+  currentPollIntervalMs = target
+  if (!syncInterval) return
+  clearInterval(syncInterval)
+  syncInterval = setInterval(runPeriodicSync, target)
+}
+
+export async function startGoogleCalendarSyncRunner(): Promise<void> {
+  if (syncInterval) return
+  if (!(await isMemryUserSignedIn())) return
+  if (!(await hasGoogleCalendarConnection(requireDatabase()))) return
+
+  void syncGoogleCalendarNow().catch((error) => {
+    log.warn('initial Google Calendar sync failed', error)
+  })
+
+  syncInterval = setInterval(runPeriodicSync, currentPollIntervalMs)
+
+  const pushRuntime = getOrInitGooglePushRuntime({
+    onActiveCountChange: (count) => reEvaluatePollCadence(count)
+  })
+  if (pushRuntime) {
+    const db = requireDatabase()
+    const sources = listCalendarSources(db, {
+      provider: 'google',
+      kind: 'calendar',
+      selectedOnly: true
+    }).map((s) => ({
+      id: s.id,
+      remoteId: s.remoteId,
+      isMemryManaged: s.isMemryManaged
+    }))
+    void pushRuntime.ensureForSelectedSources(sources).catch((err) => {
+      log.warn('ensureForSelectedSources failed', err)
+    })
+  }
+}
+
+export function stopGoogleCalendarSyncRunner(): void {
+  if (!syncInterval) return
+  clearInterval(syncInterval)
+  syncInterval = null
+
+  const pushRuntime = getGooglePushRuntime()
+  if (pushRuntime) {
+    void pushRuntime.stopAll().catch((err) => {
+      log.warn('stopAll failed', err)
+    })
+  }
+}

--- a/apps/desktop/src/main/calendar/google/push-runtime.test.ts
+++ b/apps/desktop/src/main/calendar/google/push-runtime.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => loggerMock
+}))
+
+import { createGooglePushRuntime, type CalendarSourceLite } from './push-runtime'
+import type { GoogleChannelManager } from './google-channel-manager'
+
+function buildManagerMock(): GoogleChannelManager & {
+  ensureChannelForSource: ReturnType<typeof vi.fn>
+  stopForSource: ReturnType<typeof vi.fn>
+  stopAll: ReturnType<typeof vi.fn>
+  getActiveChannelCount: ReturnType<typeof vi.fn>
+} {
+  return {
+    ensureChannelForSource: vi.fn(async () => {}),
+    stopForSource: vi.fn(async () => {}),
+    stopAll: vi.fn(async () => {}),
+    getActiveChannelCount: vi.fn(() => 0)
+  }
+}
+
+describe('createGooglePushRuntime (Task 11 — lifecycle wiring)', () => {
+  describe('ensureForSelectedSources', () => {
+    it('registers a channel for each selected non-managed source', async () => {
+      // #given
+      const manager = buildManagerMock()
+      const runtime = createGooglePushRuntime(manager)
+      const sources: CalendarSourceLite[] = [
+        {
+          id: 'google-calendar:work',
+          remoteId: 'work@group.calendar.google.com',
+          isMemryManaged: false
+        },
+        { id: 'google-calendar:personal', remoteId: 'me@gmail.com', isMemryManaged: false }
+      ]
+
+      // #when
+      await runtime.ensureForSelectedSources(sources)
+
+      // #then
+      expect(manager.ensureChannelForSource).toHaveBeenCalledTimes(2)
+      expect(manager.ensureChannelForSource).toHaveBeenCalledWith({
+        sourceId: 'google-calendar:work',
+        calendarId: 'work@group.calendar.google.com'
+      })
+      expect(manager.ensureChannelForSource).toHaveBeenCalledWith({
+        sourceId: 'google-calendar:personal',
+        calendarId: 'me@gmail.com'
+      })
+    })
+
+    it('skips Memry-managed sources (we never webhook our own calendar)', async () => {
+      // #given
+      const manager = buildManagerMock()
+      const runtime = createGooglePushRuntime(manager)
+      const sources: CalendarSourceLite[] = [
+        { id: 'google-calendar:memry', remoteId: 'memry-managed', isMemryManaged: true },
+        { id: 'google-calendar:work', remoteId: 'work', isMemryManaged: false }
+      ]
+
+      // #when
+      await runtime.ensureForSelectedSources(sources)
+
+      // #then
+      expect(manager.ensureChannelForSource).toHaveBeenCalledTimes(1)
+      expect(manager.ensureChannelForSource).toHaveBeenCalledWith({
+        sourceId: 'google-calendar:work',
+        calendarId: 'work'
+      })
+    })
+
+    it('continues iterating after an ensure failure (no early return)', async () => {
+      // #given
+      const manager = buildManagerMock()
+      manager.ensureChannelForSource
+        .mockRejectedValueOnce(new Error('first source failed'))
+        .mockResolvedValueOnce(undefined)
+      const runtime = createGooglePushRuntime(manager)
+      const sources: CalendarSourceLite[] = [
+        { id: 'a', remoteId: 'A', isMemryManaged: false },
+        { id: 'b', remoteId: 'B', isMemryManaged: false }
+      ]
+
+      // #when
+      await runtime.ensureForSelectedSources(sources)
+
+      // #then
+      expect(manager.ensureChannelForSource).toHaveBeenCalledTimes(2)
+      expect(loggerMock.warn).toHaveBeenCalled()
+    })
+  })
+
+  describe('stopAll', () => {
+    it('delegates to manager.stopAll', async () => {
+      const manager = buildManagerMock()
+      const runtime = createGooglePushRuntime(manager)
+
+      await runtime.stopAll()
+
+      expect(manager.stopAll).toHaveBeenCalledTimes(1)
+    })
+
+    it('swallows manager errors so teardown always completes', async () => {
+      const manager = buildManagerMock()
+      manager.stopAll.mockRejectedValueOnce(new Error('stopAll boom'))
+      const runtime = createGooglePushRuntime(manager)
+
+      await expect(runtime.stopAll()).resolves.toBeUndefined()
+      expect(loggerMock.warn).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleSelectionToggle', () => {
+    it('#given isSelected=true #when toggled #then ensures a channel for that source', async () => {
+      const manager = buildManagerMock()
+      const runtime = createGooglePushRuntime(manager)
+
+      await runtime.handleSelectionToggle({
+        sourceId: 'src-1',
+        isSelected: true,
+        calendarId: 'cal-1'
+      })
+
+      expect(manager.ensureChannelForSource).toHaveBeenCalledWith({
+        sourceId: 'src-1',
+        calendarId: 'cal-1'
+      })
+      expect(manager.stopForSource).not.toHaveBeenCalled()
+    })
+
+    it('#given isSelected=false #when toggled #then stops that source', async () => {
+      const manager = buildManagerMock()
+      const runtime = createGooglePushRuntime(manager)
+
+      await runtime.handleSelectionToggle({
+        sourceId: 'src-1',
+        isSelected: false,
+        calendarId: 'cal-1'
+      })
+
+      expect(manager.stopForSource).toHaveBeenCalledWith('src-1')
+      expect(manager.ensureChannelForSource).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getActiveChannelCount', () => {
+    it('returns the underlying manager count', () => {
+      const manager = buildManagerMock()
+      manager.getActiveChannelCount.mockReturnValue(3)
+      const runtime = createGooglePushRuntime(manager)
+
+      expect(runtime.getActiveChannelCount()).toBe(3)
+    })
+  })
+})

--- a/apps/desktop/src/main/calendar/google/push-runtime.ts
+++ b/apps/desktop/src/main/calendar/google/push-runtime.ts
@@ -1,0 +1,142 @@
+import { randomBytes, createHmac, randomUUID } from 'node:crypto'
+import { createLogger } from '../../lib/logger'
+import { deleteFromServer, patchToServer, postToServer } from '../../sync/http-client'
+import { getValidAccessToken } from '../../sync/token-manager'
+import { createGoogleCalendarClient } from './client'
+import { createGoogleChannelManager, type GoogleChannelManager } from './google-channel-manager'
+
+const log = createLogger('Calendar:GooglePushRuntime')
+
+const DEFAULT_WEBHOOK_URL = 'https://sync.memry.io/webhooks/google-calendar'
+const TTL_SECONDS = 7 * 24 * 60 * 60
+const ROTATION_MARGIN_SECONDS = 60 * 60
+
+export interface CalendarSourceLite {
+  id: string
+  remoteId: string
+  isMemryManaged: boolean
+}
+
+export interface GooglePushRuntime {
+  ensureForSelectedSources(sources: CalendarSourceLite[]): Promise<void>
+  stopAll(): Promise<void>
+  handleSelectionToggle(args: {
+    sourceId: string
+    isSelected: boolean
+    calendarId: string
+  }): Promise<void>
+  getActiveChannelCount(): number
+}
+
+export function createGooglePushRuntime(manager: GoogleChannelManager): GooglePushRuntime {
+  return {
+    async ensureForSelectedSources(sources) {
+      const candidates = sources.filter((s) => !s.isMemryManaged)
+      for (const source of candidates) {
+        try {
+          await manager.ensureChannelForSource({
+            sourceId: source.id,
+            calendarId: source.remoteId
+          })
+        } catch (err) {
+          log.warn('ensureChannelForSource failed; will retry on next start', {
+            sourceId: source.id,
+            err
+          })
+        }
+      }
+    },
+    async stopAll() {
+      try {
+        await manager.stopAll()
+      } catch (err) {
+        log.warn('stopAll failed; server cleanup cron will reap', { err })
+      }
+    },
+    async handleSelectionToggle({ sourceId, isSelected, calendarId }) {
+      try {
+        if (isSelected) {
+          await manager.ensureChannelForSource({ sourceId, calendarId })
+        } else {
+          await manager.stopForSource(sourceId)
+        }
+      } catch (err) {
+        log.warn('handleSelectionToggle failed', { sourceId, isSelected, err })
+      }
+    },
+    getActiveChannelCount: () => manager.getActiveChannelCount()
+  }
+}
+
+function resolveWebhookUrl(): string {
+  return process.env.MEMRY_CALENDAR_WEBHOOK_URL?.trim() || DEFAULT_WEBHOOK_URL
+}
+
+function resolveHmacKey(): string {
+  return process.env.MEMRY_WEBHOOK_HMAC_KEY?.trim() ?? ''
+}
+
+function isPushFeatureEnabled(): boolean {
+  return process.env.CALENDAR_PUSH_ENABLED === '1' && resolveHmacKey().length > 0
+}
+
+function buildProductionChannelManager(
+  onActiveCountChange: (count: number) => void
+): GoogleChannelManager {
+  const hmacKey = resolveHmacKey()
+
+  return createGoogleChannelManager({
+    client: createGoogleCalendarClient(),
+    registerOnServer: async (body) => {
+      const token = await getValidAccessToken()
+      if (!token) throw new Error('Not signed in — cannot register push channel')
+      await postToServer('/calendar/channels', body, token)
+    },
+    attachResourceId: async ({ channelId, resourceId }) => {
+      const token = await getValidAccessToken()
+      if (!token) throw new Error('Not signed in — cannot attach resourceId')
+      await patchToServer(
+        `/calendar/channels/${encodeURIComponent(channelId)}`,
+        { resourceId },
+        token
+      )
+    },
+    deleteOnServer: async ({ channelId }) => {
+      const token = await getValidAccessToken()
+      if (!token) return
+      await deleteFromServer(`/calendar/channels/${encodeURIComponent(channelId)}`, token).catch(
+        () => {
+          // Server-side cleanup cron will reap orphans; best-effort delete.
+        }
+      )
+    },
+    hashToken: async (plaintext) => createHmac('sha256', hmacKey).update(plaintext).digest('hex'),
+    generateToken: () => randomBytes(32).toString('hex'),
+    generateChannelId: () => randomUUID(),
+    webhookUrl: resolveWebhookUrl(),
+    ttlSeconds: TTL_SECONDS,
+    rotationMarginSeconds: ROTATION_MARGIN_SECONDS,
+    featureEnabled: isPushFeatureEnabled(),
+    onActiveCountChange
+  })
+}
+
+let prodRuntime: GooglePushRuntime | null = null
+
+export function getOrInitGooglePushRuntime(opts: {
+  onActiveCountChange: (count: number) => void
+}): GooglePushRuntime | null {
+  if (!isPushFeatureEnabled()) return null
+  if (!prodRuntime) {
+    prodRuntime = createGooglePushRuntime(buildProductionChannelManager(opts.onActiveCountChange))
+  }
+  return prodRuntime
+}
+
+export function getGooglePushRuntime(): GooglePushRuntime | null {
+  return prodRuntime
+}
+
+export function __testing_resetGooglePushRuntime(): void {
+  prodRuntime = null
+}

--- a/apps/desktop/src/main/calendar/google/sync-service-cadence.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service-cadence.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: vi.fn(() => []) }
+}))
+
+vi.mock('./oauth', () => ({
+  hasGoogleCalendarConnection: vi.fn(async () => true),
+  hasGoogleCalendarLocalAuth: vi.fn(async () => true)
+}))
+
+vi.mock('../../sync/auth-state', () => ({
+  isMemryUserSignedIn: vi.fn(async () => true)
+}))
+
+vi.mock('../../database', () => ({
+  requireDatabase: vi.fn(() => ({}) as unknown as object),
+  getDatabase: vi.fn(() => ({}) as unknown as object),
+  isDatabaseInitialized: vi.fn(() => true)
+}))
+
+import {
+  PUSH_BACKOFF_INTERVAL_MS,
+  getCurrentPollIntervalMs,
+  reEvaluatePollCadence,
+  startGoogleCalendarSyncRunner,
+  stopGoogleCalendarSyncRunner
+} from './sync-service'
+
+const RUN_INTERVAL_MS = 5 * 60 * 1000
+
+describe('reEvaluatePollCadence (Task 10 — push-channel poll backoff)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    stopGoogleCalendarSyncRunner()
+    // Reset back to default cadence between cases.
+    reEvaluatePollCadence(0)
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('defaults to RUN_INTERVAL_MS (5 minutes) before any push channels are active', () => {
+    // #given no reEvaluate has been called
+    // #then the runner's poll cadence is 5 minutes
+    expect(getCurrentPollIntervalMs()).toBe(RUN_INTERVAL_MS)
+  })
+
+  it('switches to PUSH_BACKOFF_INTERVAL_MS (30 minutes) when at least one channel is active', () => {
+    // #when a push channel comes online
+    reEvaluatePollCadence(1)
+
+    // #then the poll falls back to 30 minutes (push is primary, polling is safety net)
+    expect(getCurrentPollIntervalMs()).toBe(PUSH_BACKOFF_INTERVAL_MS)
+    expect(PUSH_BACKOFF_INTERVAL_MS).toBe(30 * 60 * 1000)
+  })
+
+  it('restores RUN_INTERVAL_MS the moment every channel is gone', () => {
+    // #given two channels were active
+    reEvaluatePollCadence(2)
+
+    // #when all channels go down
+    reEvaluatePollCadence(0)
+
+    // #then the poll resumes its 5-minute cadence
+    expect(getCurrentPollIntervalMs()).toBe(RUN_INTERVAL_MS)
+  })
+
+  it('is idempotent when the count stays > 0 (no interval churn between 1 and N channels)', () => {
+    reEvaluatePollCadence(1)
+    reEvaluatePollCadence(5)
+    reEvaluatePollCadence(3)
+
+    expect(getCurrentPollIntervalMs()).toBe(PUSH_BACKOFF_INTERVAL_MS)
+  })
+
+  it('re-arms the live setInterval when a runner is active', async () => {
+    // #given spies around the timer APIs
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+
+    // #given the runner is started (eager sync is best-effort and tolerates failure)
+    await startGoogleCalendarSyncRunner()
+
+    // #then the initial setInterval was scheduled at RUN_INTERVAL_MS
+    const firstCall = setIntervalSpy.mock.calls.find((call) => call[1] === RUN_INTERVAL_MS)
+    expect(firstCall).toBeTruthy()
+
+    setIntervalSpy.mockClear()
+    clearIntervalSpy.mockClear()
+
+    // #when a push channel comes online
+    reEvaluatePollCadence(1)
+
+    // #then the old interval is cleared and a new one is armed at the backoff cadence
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), PUSH_BACKOFF_INTERVAL_MS)
+  })
+
+  it('does not re-arm when no runner is active (prevents phantom timers)', () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+
+    reEvaluatePollCadence(1)
+
+    expect(clearIntervalSpy).not.toHaveBeenCalled()
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+    // But the cadence value IS updated — when the runner eventually starts it will pick the right cadence.
+    expect(getCurrentPollIntervalMs()).toBe(PUSH_BACKOFF_INTERVAL_MS)
+  })
+})

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -43,7 +43,6 @@ import {
 } from '../repositories/calendar-sources-repository'
 import { emitCalendarChanged, emitCalendarProjectionChanged } from '../change-events'
 import { readCalendarGoogleSettings } from './calendar-google-settings'
-import { getGooglePushRuntime, getOrInitGooglePushRuntime } from './push-runtime'
 import type {
   CalendarSyncTarget,
   GoogleCalendarClient,
@@ -52,32 +51,9 @@ import type {
 } from '../types'
 
 const log = createLogger('Calendar:GoogleSync')
-const RUN_INTERVAL_MS = 5 * 60 * 1000
-export const PUSH_BACKOFF_INTERVAL_MS = 30 * 60 * 1000
 const LOCAL_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 
-let syncInterval: NodeJS.Timeout | null = null
 let syncInFlight = false
-let currentPollIntervalMs = RUN_INTERVAL_MS
-
-export function getCurrentPollIntervalMs(): number {
-  return currentPollIntervalMs
-}
-
-function runPeriodicSync(): void {
-  void syncGoogleCalendarNow().catch((error) => {
-    log.warn('periodic Google Calendar sync failed', error)
-  })
-}
-
-export function reEvaluatePollCadence(activeChannelCount: number): void {
-  const target = activeChannelCount > 0 ? PUSH_BACKOFF_INTERVAL_MS : RUN_INTERVAL_MS
-  if (target === currentPollIntervalMs) return
-  currentPollIntervalMs = target
-  if (!syncInterval) return
-  clearInterval(syncInterval)
-  syncInterval = setInterval(runPeriodicSync, target)
-}
 
 function getNow(): string {
   return new Date().toISOString()
@@ -920,46 +896,13 @@ export async function syncGoogleCalendarNow(
   }
 }
 
-export async function startGoogleCalendarSyncRunner(): Promise<void> {
-  if (syncInterval) return
-  if (!(await isMemryUserSignedIn())) return
-  if (!(await hasGoogleCalendarConnection(requireDatabase()))) return
-
-  void syncGoogleCalendarNow().catch((error) => {
-    log.warn('initial Google Calendar sync failed', error)
-  })
-
-  syncInterval = setInterval(runPeriodicSync, currentPollIntervalMs)
-
-  const pushRuntime = getOrInitGooglePushRuntime({
-    onActiveCountChange: (count) => reEvaluatePollCadence(count)
-  })
-  if (pushRuntime) {
-    const db = requireDatabase()
-    const sources = listCalendarSources(db, {
-      provider: 'google',
-      kind: 'calendar',
-      selectedOnly: true
-    }).map((s) => ({
-      id: s.id,
-      remoteId: s.remoteId,
-      isMemryManaged: s.isMemryManaged
-    }))
-    void pushRuntime.ensureForSelectedSources(sources).catch((err) => {
-      log.warn('ensureForSelectedSources failed', err)
-    })
-  }
-}
-
-export function stopGoogleCalendarSyncRunner(): void {
-  if (!syncInterval) return
-  clearInterval(syncInterval)
-  syncInterval = null
-
-  const pushRuntime = getGooglePushRuntime()
-  if (pushRuntime) {
-    void pushRuntime.stopAll().catch((err) => {
-      log.warn('stopAll failed', err)
-    })
-  }
-}
+// Runner lifecycle + push-channel poll cadence live in google-sync-runner.ts.
+// Re-exported here so existing callers (index.ts, calendar-handlers,
+// session-teardown, device-registration, tests) keep their import paths.
+export {
+  PUSH_BACKOFF_INTERVAL_MS,
+  getCurrentPollIntervalMs,
+  reEvaluatePollCadence,
+  startGoogleCalendarSyncRunner,
+  stopGoogleCalendarSyncRunner
+} from './google-sync-runner'

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -43,6 +43,7 @@ import {
 } from '../repositories/calendar-sources-repository'
 import { emitCalendarChanged, emitCalendarProjectionChanged } from '../change-events'
 import { readCalendarGoogleSettings } from './calendar-google-settings'
+import { getGooglePushRuntime, getOrInitGooglePushRuntime } from './push-runtime'
 import type {
   CalendarSyncTarget,
   GoogleCalendarClient,
@@ -929,10 +930,36 @@ export async function startGoogleCalendarSyncRunner(): Promise<void> {
   })
 
   syncInterval = setInterval(runPeriodicSync, currentPollIntervalMs)
+
+  const pushRuntime = getOrInitGooglePushRuntime({
+    onActiveCountChange: (count) => reEvaluatePollCadence(count)
+  })
+  if (pushRuntime) {
+    const db = requireDatabase()
+    const sources = listCalendarSources(db, {
+      provider: 'google',
+      kind: 'calendar',
+      selectedOnly: true
+    }).map((s) => ({
+      id: s.id,
+      remoteId: s.remoteId,
+      isMemryManaged: s.isMemryManaged
+    }))
+    void pushRuntime.ensureForSelectedSources(sources).catch((err) => {
+      log.warn('ensureForSelectedSources failed', err)
+    })
+  }
 }
 
 export function stopGoogleCalendarSyncRunner(): void {
   if (!syncInterval) return
   clearInterval(syncInterval)
   syncInterval = null
+
+  const pushRuntime = getGooglePushRuntime()
+  if (pushRuntime) {
+    void pushRuntime.stopAll().catch((err) => {
+      log.warn('stopAll failed', err)
+    })
+  }
 }

--- a/apps/desktop/src/main/calendar/google/sync-service.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.ts
@@ -52,10 +52,31 @@ import type {
 
 const log = createLogger('Calendar:GoogleSync')
 const RUN_INTERVAL_MS = 5 * 60 * 1000
+export const PUSH_BACKOFF_INTERVAL_MS = 30 * 60 * 1000
 const LOCAL_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 
 let syncInterval: NodeJS.Timeout | null = null
 let syncInFlight = false
+let currentPollIntervalMs = RUN_INTERVAL_MS
+
+export function getCurrentPollIntervalMs(): number {
+  return currentPollIntervalMs
+}
+
+function runPeriodicSync(): void {
+  void syncGoogleCalendarNow().catch((error) => {
+    log.warn('periodic Google Calendar sync failed', error)
+  })
+}
+
+export function reEvaluatePollCadence(activeChannelCount: number): void {
+  const target = activeChannelCount > 0 ? PUSH_BACKOFF_INTERVAL_MS : RUN_INTERVAL_MS
+  if (target === currentPollIntervalMs) return
+  currentPollIntervalMs = target
+  if (!syncInterval) return
+  clearInterval(syncInterval)
+  syncInterval = setInterval(runPeriodicSync, target)
+}
 
 function getNow(): string {
   return new Date().toISOString()
@@ -907,11 +928,7 @@ export async function startGoogleCalendarSyncRunner(): Promise<void> {
     log.warn('initial Google Calendar sync failed', error)
   })
 
-  syncInterval = setInterval(() => {
-    void syncGoogleCalendarNow().catch((error) => {
-      log.warn('periodic Google Calendar sync failed', error)
-    })
-  }, RUN_INTERVAL_MS)
+  syncInterval = setInterval(runPeriodicSync, currentPollIntervalMs)
 }
 
 export function stopGoogleCalendarSyncRunner(): void {

--- a/apps/desktop/src/main/calendar/types.ts
+++ b/apps/desktop/src/main/calendar/types.ts
@@ -59,4 +59,12 @@ export interface GoogleCalendarClient {
     ifMatch?: string | null
   }): Promise<GoogleCalendarRemoteEvent>
   deleteEvent(input: { calendarId: string; eventId: string }): Promise<void>
+  watchCalendar(input: {
+    calendarId: string
+    channelId: string
+    token: string
+    webhookUrl: string
+    ttlSeconds: number
+  }): Promise<{ resourceId: string; expiration: number }>
+  stopChannel(input: { channelId: string; resourceId: string }): Promise<void>
 }

--- a/apps/desktop/src/main/ipc/calendar-handlers.ts
+++ b/apps/desktop/src/main/ipc/calendar-handlers.ts
@@ -53,6 +53,7 @@ import {
 } from '../calendar/google/sync-service'
 import { listGoogleCalendars, setDefaultGoogleCalendar } from '../calendar/google/onboarding'
 import { createGoogleCalendarClient } from '../calendar/google/client'
+import { getGooglePushRuntime } from '../calendar/google/push-runtime'
 import {
   promoteExternalEvent,
   ExternalEventNotFoundError,
@@ -366,6 +367,21 @@ export function registerCalendarHandlers(): void {
           isSelected: input.isSelected,
           modifiedAt: new Date().toISOString()
         })
+
+        if (
+          updated.provider === 'google' &&
+          updated.kind === 'calendar' &&
+          !updated.isMemryManaged
+        ) {
+          const pushRuntime = getGooglePushRuntime()
+          if (pushRuntime) {
+            void pushRuntime.handleSelectionToggle({
+              sourceId: updated.id,
+              isSelected: updated.isSelected,
+              calendarId: updated.remoteId
+            })
+          }
+        }
 
         return { success: true, source: updated }
       }, 'Failed to update calendar source selection')

--- a/apps/desktop/src/main/sync/engine.test.ts
+++ b/apps/desktop/src/main/sync/engine.test.ts
@@ -179,6 +179,58 @@ describe('SyncEngine', () => {
     })
   })
 
+  describe('#given connected engine #when WS receives calendar_changes_available', () => {
+    it('#then routes the payload sourceId to deps.calendarSyncOneSource', async () => {
+      // #given
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        items: [],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 0
+      })
+      const calendarSyncOneSource = vi.fn()
+      const deps = createMockDeps(getDb(), { calendarSyncOneSource })
+      const engine = new SyncEngine(deps)
+      await engine.start()
+
+      // #when
+      deps.ws.emit('message', {
+        type: 'calendar_changes_available',
+        payload: { sourceId: 'google:primary@group.calendar.google.com' }
+      } as WebSocketMessage)
+
+      // #then
+      expect(calendarSyncOneSource).toHaveBeenCalledWith('google:primary@group.calendar.google.com')
+      await engine.stop()
+      vi.restoreAllMocks()
+    })
+
+    it('#then ignores the message when payload.sourceId is missing', async () => {
+      // #given
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        items: [],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 0
+      })
+      const calendarSyncOneSource = vi.fn()
+      const deps = createMockDeps(getDb(), { calendarSyncOneSource })
+      const engine = new SyncEngine(deps)
+      await engine.start()
+
+      // #when
+      deps.ws.emit('message', {
+        type: 'calendar_changes_available',
+        payload: {}
+      } as WebSocketMessage)
+
+      // #then
+      expect(calendarSyncOneSource).not.toHaveBeenCalled()
+      await engine.stop()
+      vi.restoreAllMocks()
+    })
+  })
+
   describe('#given engine #when concurrent sync requested', () => {
     it('#then second call returns early (sync lock)', async () => {
       let resolveFirst!: () => void

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -526,6 +526,17 @@ export class SyncEngine extends EventEmitter {
         }
         break
       }
+      case 'calendar_changes_available': {
+        const sourceId = message.payload?.sourceId
+        if (typeof sourceId === 'string' && sourceId.length > 0) {
+          this.ctx.deps.calendarSyncOneSource?.(sourceId)
+        } else {
+          log.debug('calendar_changes_available message missing sourceId', {
+            payload: message.payload
+          })
+        }
+        break
+      }
       case 'heartbeat':
         break
       case 'error':

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -27,6 +27,7 @@ export interface SyncEngineDeps {
   crdtProvider?: CrdtProvider
   workerBridge?: SyncWorkerBridge
   refreshAccessToken?: () => Promise<boolean>
+  calendarSyncOneSource?: (sourceId: string) => void
 }
 
 export interface SyncEngineOptions {

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -13,6 +13,7 @@ import {
   secureCleanup
 } from '../crypto'
 import { SyncEngine, type SyncEngineDeps } from './engine'
+import { syncGoogleCalendarSource } from '../calendar/google/sync-service'
 import { SyncQueueManager } from './queue'
 import { NetworkMonitor } from './network'
 import { WebSocketManager } from './websocket'
@@ -463,7 +464,12 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         adapters,
         crdtProvider,
         workerBridge,
-        refreshAccessToken: () => refreshAccessToken()
+        refreshAccessToken: () => refreshAccessToken(),
+        calendarSyncOneSource: (sourceId) => {
+          void syncGoogleCalendarSource(runtimeSyncDb, sourceId).catch((err) => {
+            log.warn('calendarSyncOneSource failed', { sourceId, err })
+          })
+        }
       })
 
       queue.setOnItemEnqueued(() => engine.requestPush())

--- a/apps/desktop/src/main/sync/websocket.ts
+++ b/apps/desktop/src/main/sync/websocket.ts
@@ -19,6 +19,7 @@ const WebSocketMessageSchema = z.object({
   type: z.enum([
     'changes_available',
     'crdt_updated',
+    'calendar_changes_available',
     'heartbeat',
     'error',
     'linking_request',

--- a/apps/desktop/tests/e2e/calendar-push-channels.e2e.ts
+++ b/apps/desktop/tests/e2e/calendar-push-channels.e2e.ts
@@ -1,0 +1,224 @@
+/**
+ * Calendar push channels — Google webhook round-trip (M4b, Task 12).
+ *
+ * This suite is flag-gated and will be SKIPPED until all of the following are set:
+ *   - GOOGLE_CALENDAR_E2E=1                  (global opt-in)
+ *   - CALENDAR_PUSH_ENABLED=1                (toggles the desktop feature flag)
+ *   - MEMRY_WEBHOOK_HMAC_KEY=<key>           (must match sync-server binding)
+ *   - GOOGLE_CALENDAR_E2E_REFRESH_TOKEN=<…>  (refresh token for the CI test account)
+ *   - GOOGLE_CALENDAR_E2E_CLIENT_ID=<…>      (OAuth client the refresh token belongs to)
+ *   - GOOGLE_CALENDAR_E2E_CLIENT_SECRET=<…>  (optional: only if the client is confidential)
+ *   - GOOGLE_CALENDAR_E2E_CALENDAR_ID=<…>    (test calendar the spec creates/deletes events on)
+ *
+ * Ops prerequisites (one-time, not yet done as of 2026-04-19):
+ *   1. sync.memry.io HTTPS webhook endpoint reachable from Google.
+ *   2. The domain verified in Google Cloud Console → APIs → Domain verification.
+ *   3. sync-server deployed with matching MEMRY_WEBHOOK_HMAC_KEY binding.
+ *
+ * Once the above is green, the tests below exercise the full round-trip:
+ *   - connect → channel registered → resourceId stored server-side
+ *   - event mutation on Google side → webhook fires → DO broadcasts
+ *     calendar_changes_available → desktop runs syncGoogleCalendarSource →
+ *     Memry UI reflects the change within a few seconds.
+ *   - disconnect → channel drained both on Google and sync-server.
+ */
+import { test, expect } from './fixtures'
+import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
+
+const CREDS_PRESENT =
+  process.env.GOOGLE_CALENDAR_E2E === '1' &&
+  process.env.CALENDAR_PUSH_ENABLED === '1' &&
+  !!process.env.MEMRY_WEBHOOK_HMAC_KEY &&
+  !!process.env.GOOGLE_CALENDAR_E2E_REFRESH_TOKEN &&
+  !!process.env.GOOGLE_CALENDAR_E2E_CLIENT_ID &&
+  !!process.env.GOOGLE_CALENDAR_E2E_CALENDAR_ID
+
+interface ChannelProbe {
+  activeCount: number
+}
+
+test.describe('Google calendar push channels (M4b round-trip)', () => {
+  test.skip(
+    !CREDS_PRESENT,
+    'Flag-gated: set GOOGLE_CALENDAR_E2E=1, CALENDAR_PUSH_ENABLED=1, MEMRY_WEBHOOK_HMAC_KEY, plus the ' +
+      'GOOGLE_CALENDAR_E2E_{REFRESH_TOKEN,CLIENT_ID,CALENDAR_ID} secrets. Requires sync.memry.io ' +
+      'domain-verified in Google Cloud Console.'
+  )
+
+  test.beforeEach(async ({ page, electronApp }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+
+    // Seed keytar with the test account's refresh token so the Google client can refresh
+    // access tokens without driving the OAuth popup. Exposed via the test hook that other
+    // calendar suites already use (see __memryTestHooks in index.ts).
+    await electronApp.evaluate(
+      async (_ctx, input) => {
+        const hooks = (
+          globalThis as typeof globalThis & {
+            __memryTestHooks?: {
+              seedGoogleCalendarTokens(input: {
+                refreshToken: string
+                clientId: string
+                clientSecret: string | null
+              }): Promise<void>
+            }
+          }
+        ).__memryTestHooks
+        if (!hooks?.seedGoogleCalendarTokens) {
+          throw new Error(
+            'Missing __memryTestHooks.seedGoogleCalendarTokens — add it in the test-hook ' +
+              'surface before enabling this E2E suite.'
+          )
+        }
+        await hooks.seedGoogleCalendarTokens(input)
+      },
+      {
+        refreshToken: process.env.GOOGLE_CALENDAR_E2E_REFRESH_TOKEN!,
+        clientId: process.env.GOOGLE_CALENDAR_E2E_CLIENT_ID!,
+        clientSecret: process.env.GOOGLE_CALENDAR_E2E_CLIENT_SECRET ?? null
+      }
+    )
+  })
+
+  test('registers a Google push channel after connecting; drains it on disconnect', async ({
+    page,
+    electronApp
+  }) => {
+    // #given Google Calendar is not yet connected
+    const probeBefore = await electronApp.evaluate(async () => {
+      const hooks = (
+        globalThis as typeof globalThis & {
+          __memryTestHooks?: { getGooglePushChannelProbe(): Promise<ChannelProbe> }
+        }
+      ).__memryTestHooks
+      return (await hooks?.getGooglePushChannelProbe()) ?? { activeCount: -1 }
+    })
+    expect(probeBefore.activeCount).toBeLessThanOrEqual(0)
+
+    // #when the user connects the provider through Settings → Calendar
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await page.getByRole('tab', { name: 'Calendar' }).click()
+    await page.getByRole('button', { name: /Connect Google Calendar/i }).click()
+
+    // The OAuth popup is skipped because the refresh token is already seeded in keytar.
+    // The runner starts, fans out ensureChannelForSource across the selected calendars,
+    // and POSTs /calendar/channels + PATCHes resourceId on sync-server.
+    await expect
+      .poll(
+        async () => {
+          const probe = await electronApp.evaluate(async () => {
+            const hooks = (
+              globalThis as typeof globalThis & {
+                __memryTestHooks?: { getGooglePushChannelProbe(): Promise<ChannelProbe> }
+              }
+            ).__memryTestHooks
+            return hooks?.getGooglePushChannelProbe()
+          })
+          return probe?.activeCount ?? 0
+        },
+        { timeout: 30_000, intervals: [500, 1000, 2000] }
+      )
+      .toBeGreaterThan(0)
+
+    // #when the user disconnects
+    await page.getByRole('button', { name: /Disconnect/i }).click()
+    await page.getByRole('button', { name: /Confirm/i }).click()
+
+    // #then every channel has been stopped on Google and deleted on sync-server
+    await expect
+      .poll(
+        async () => {
+          const probe = await electronApp.evaluate(async () => {
+            const hooks = (
+              globalThis as typeof globalThis & {
+                __memryTestHooks?: { getGooglePushChannelProbe(): Promise<ChannelProbe> }
+              }
+            ).__memryTestHooks
+            return hooks?.getGooglePushChannelProbe()
+          })
+          return probe?.activeCount ?? -1
+        },
+        { timeout: 15_000 }
+      )
+      .toBe(0)
+  })
+
+  test('webhook → WS broadcast → single-source sync (<10s e2e latency)', async ({
+    page,
+    electronApp
+  }) => {
+    const calendarId = process.env.GOOGLE_CALENDAR_E2E_CALENDAR_ID!
+    const eventSummary = `Push-Channel E2E ${Date.now()}`
+
+    // #given the provider is connected and at least one channel is registered
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await page.getByRole('tab', { name: 'Calendar' }).click()
+    await page.getByRole('button', { name: /Connect Google Calendar/i }).click()
+    await expect
+      .poll(
+        async () => {
+          const probe = await electronApp.evaluate(async () => {
+            const hooks = (
+              globalThis as typeof globalThis & {
+                __memryTestHooks?: { getGooglePushChannelProbe(): Promise<ChannelProbe> }
+              }
+            ).__memryTestHooks
+            return hooks?.getGooglePushChannelProbe()
+          })
+          return probe?.activeCount ?? 0
+        },
+        { timeout: 30_000 }
+      )
+      .toBeGreaterThan(0)
+
+    // #when an event is created directly on Google (outside Memry)
+    const now = Date.now()
+    const createdId = await electronApp.evaluate(
+      async (_ctx, input) => {
+        const hooks = (
+          globalThis as typeof globalThis & {
+            __memryTestHooks?: {
+              createGoogleCalendarEventForE2E(input: {
+                calendarId: string
+                summary: string
+                startMs: number
+                endMs: number
+              }): Promise<string>
+            }
+          }
+        ).__memryTestHooks
+        if (!hooks?.createGoogleCalendarEventForE2E) {
+          throw new Error(
+            'Missing __memryTestHooks.createGoogleCalendarEventForE2E — add it before enabling this suite.'
+          )
+        }
+        return await hooks.createGoogleCalendarEventForE2E(input)
+      },
+      { calendarId, summary: eventSummary, startMs: now + 3_600_000, endMs: now + 7_200_000 }
+    )
+
+    // #then Memry picks up the event via the webhook within ~10 seconds
+    // (this is well under the 30-minute push-backoff poll cadence, proving push actually fired)
+    await page.getByRole('button', { name: 'Calendar' }).click()
+    await expect(page.getByText(eventSummary)).toBeVisible({ timeout: 15_000 })
+
+    // #cleanup — delete the test event so the calendar doesn't accumulate state across runs
+    await electronApp.evaluate(
+      async (_ctx, input) => {
+        const hooks = (
+          globalThis as typeof globalThis & {
+            __memryTestHooks?: {
+              deleteGoogleCalendarEventForE2E(input: {
+                calendarId: string
+                eventId: string
+              }): Promise<void>
+            }
+          }
+        ).__memryTestHooks
+        await hooks?.deleteGoogleCalendarEventForE2E(input)
+      },
+      { calendarId, eventId: createdId }
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Desktop side of Google Calendar Phase 2, Milestone 4 (M4b). M4a (sync-server
webhook + `/calendar/channels` CRUD + D1 schema + cleanup cron) is
[PR #281](https://github.com/memrynote/memry/pull/281). This PR targets that
branch — will rebase onto main once M4a merges.

Shipped behind a runtime flag: `CALENDAR_PUSH_ENABLED !== '1'` is the
default; the channel manager no-ops until ops finishes domain-verifying
`sync.memry.io` in Google Cloud Console and distributes
`MEMRY_WEBHOOK_HMAC_KEY`.

### What's in it

Seven commits, each RED/GREEN/commit per the plan:

1. **Task 7** — `GoogleCalendarClient.watchCalendar` + `stopChannel` on the real
   client, wired through `withAuthorizedResponse`.
2. **Task 8** — `GoogleChannelManager` singleton: generates token + channelId
   per source, hashes the token, drops plaintext from memory, rotates via
   `setTimeout` before Google's 7-day hard cap, drains `stopAll` on disconnect.
3. **Task 9** — `WebSocketMessageSchema` accepts `calendar_changes_available`;
   the engine routes `payload.sourceId` to a new `calendarSyncOneSource` dep.
4. **Task 10** — `PUSH_BACKOFF_INTERVAL_MS = 30min` and
   `reEvaluatePollCadence(count)` that re-arms the live setInterval whenever
   the active channel count crosses 0 ↔ 1.
5. **Task 11** — `push-runtime.ts` orchestrates ensure/stopAll/toggle and
   builds a production channel manager (HMAC-SHA256 via node:crypto,
   `postToServer`/`patchToServer`/`deleteFromServer`, randomUUID channelIds).
   Hooks into `startGoogleCalendarSyncRunner` / `stopGoogleCalendarSyncRunner`,
   the UPDATE_SOURCE_SELECTION IPC handler, and the SyncEngine construction
   site so WS push → engine → `syncGoogleCalendarSource` flows end-to-end.
6. **Task 12** — flag-gated E2E scaffold at
   `apps/desktop/tests/e2e/calendar-push-channels.e2e.ts`. Skipped on every CI
   run until the secrets + domain verification ship. Two scenarios ready:
   connect→register→disconnect, and webhook→broadcast→single-source sync.
7. **Task 13 (follow-up)** — sync-service.ts crossed the 800-line ESLint
   `max-lines` ceiling after the Task 11 wiring. Extracted the runner +
   cadence into `google-sync-runner.ts`; sync-service re-exports so no import
   paths change.

### Verification

- `pnpm --filter @memry/desktop exec vitest run src/main/calendar src/main/sync` — **722/722**
- `pnpm --filter @memry/sync-server test` — **386/386** (no sync-server changes; sanity check)
- `pnpm typecheck:node` + `pnpm typecheck:web` — clean
- `pnpm exec eslint --cache .` — **0 errors**, 912 pre-existing warnings (none from this PR)

### Known follow-ups (intentionally out of scope)

- **Test-hook surface** for the E2E: `__memryTestHooks.seedGoogleCalendarTokens`,
  `getGooglePushChannelProbe`, `createGoogleCalendarEventForE2E`,
  `deleteGoogleCalendarEventForE2E` still need to be surfaced in
  `apps/desktop/src/main/index.ts`. Flipping the E2E on requires those hooks
  plus the ops checklist in the spec file's top-of-file comment.
- **Domain verification for sync.memry.io** in Google Cloud Console. This is
  the explicit ops blocker documented in the design doc's M4 Risks section.

## Test plan

- [ ] Review each commit independently — they're atomic RED/GREEN slices.
- [ ] Run `pnpm --filter @memry/desktop exec vitest run src/main/calendar src/main/sync` locally.
- [ ] Run `pnpm typecheck:node && pnpm typecheck:web` locally.
- [ ] Verify the feature stays dormant without `CALENDAR_PUSH_ENABLED=1` + a
      valid `MEMRY_WEBHOOK_HMAC_KEY`: start the app, connect Google Calendar,
      confirm no `/calendar/channels` requests hit sync-server.
- [ ] Once ops is ready, flip the flag in a dev environment and confirm the E2E
      suite collects and runs.