### PR TITLE
ci: run only changed e2e tests on PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -18,8 +19,83 @@ env:
   ELECTRON_DISABLE_SANDBOX: 1
 
 jobs:
+  # PR mode: run only e2e tests added/modified vs the PR base.
+  # Skips the whole job (including build) when no e2e files changed.
+  e2e-changed:
+    name: Playwright E2E (changed only)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve changed e2e files
+        id: changed
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          FILES=$(git diff --name-only --diff-filter=AMR "$BASE_SHA"...HEAD -- 'apps/desktop/tests/e2e/**/*.e2e.ts' \
+            | sed 's|^apps/desktop/||' \
+            | tr '\n' ' ')
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          if [ -z "$FILES" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No changed e2e tests; skipping run."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Changed e2e tests: $FILES"
+          fi
+
+      - name: Setup pnpm
+        if: steps.changed.outputs.skip == 'false'
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js
+        if: steps.changed.outputs.skip == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install system dependencies
+        if: steps.changed.outputs.skip == 'false'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsecret-1-dev gnome-keyring dbus-x11
+          npx playwright install-deps chromium
+
+      - name: Install dependencies
+        if: steps.changed.outputs.skip == 'false'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build app for E2E
+        if: steps.changed.outputs.skip == 'false'
+        run: pnpm build
+
+      - name: Run changed Electron E2E tests
+        if: steps.changed.outputs.skip == 'false'
+        env:
+          E2E_FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          dbus-run-session -- bash -c '
+            eval "$(printf "\n" | gnome-keyring-daemon --unlock)"
+            eval "$(printf "\n" | gnome-keyring-daemon --start --components=secrets)"
+            xvfb-run -a pnpm test:e2e -- $E2E_FILES
+          '
+
+      - name: Upload E2E artifacts
+        if: always() && steps.changed.outputs.skip == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results-changed
+          path: apps/desktop/test-results/
+          if-no-files-found: ignore
+
+  # Full sharded suite: push to main + manual dispatch only.
   e2e:
     name: Playwright Electron E2E (${{ matrix.shard }})
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:


### PR DESCRIPTION
## Summary

Splits the e2e workflow into two jobs based on event type:

- **`e2e-changed`** (PRs only) — resolves changed `*.e2e.ts` files against `${{ github.event.pull_request.base.sha }}` (handles rebases and stacked PRs correctly), passes them as positional args to Playwright, and short-circuits every step when no e2e files changed. The job still appears in the Checks UI as ✅ for branch-protection compatibility.
- **`e2e`** (push to `main` + `workflow_dispatch`) — unchanged, full sharded suite [1/3, 2/3, 3/3]. Still the safety net post-merge.

The trigger now also includes `pull_request`, which the existing workflow lacked entirely.

## Why this is safer than it sounds

Changed-only catches bugs in the *new test itself* but misses regressions where a source change breaks an *unchanged* e2e test. The full suite still runs on every push to `main`, so any regression that slips through PR review surfaces immediately post-merge instead of accumulating.

## ⚠️ Before merging — verify branch protection

The PR check name changes:
- **Before:** `Playwright Electron E2E (1/3)` / `(2/3)` / `(3/3)` — these never appeared on PRs anyway since the workflow had no `pull_request` trigger.
- **After:** `Playwright E2E (changed only)` on PRs.

If branch protection on `main` requires the old shard-named checks as PR gates, those rules need to be updated to require `Playwright E2E (changed only)` instead, or the rule will block all future PRs. Check repo Settings → Branches → main → Required status checks.

## Implementation notes

- Uses `fetch-depth: 0` on checkout — the default shallow clone doesn't have the PR base commit, so `git diff $BASE_SHA...HEAD` would silently return empty and skip every PR.
- `--diff-filter=AMR` covers Added + Modified + Renamed; deleted tests are correctly excluded.
- Helper-style files like `note-sync-helpers.e2e.ts` and `shared-sync-bootstrap.e2e.ts` match the glob — editing them will trigger a run on a non-spec file. Pre-existing naming quirk; rename to `*.helper.ts` later if it becomes noisy.
- Args are passed via env var (`E2E_FILES`) into the inner `dbus-run-session bash -c '...'` instead of GitHub Actions string interpolation — safer against any odd characters in filenames.

## Test plan

- [ ] Open a no-op PR (e.g. README typo) — confirm `e2e-changed` job runs, resolves zero files, and finishes in ~30s green
- [ ] Edit one e2e file in a PR — confirm `e2e-changed` runs only that file
- [ ] Confirm push-to-main still triggers the full 3-shard suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)