### PR TITLE
fix(a11y): disambiguate "Go back" aria-labels across app

### DIFF
--- a/apps/desktop/src/renderer/src/components/journal/date-breadcrumb.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/date-breadcrumb.tsx
@@ -133,7 +133,7 @@ function BackButton({ onClick, className }: BackButtonProps) {
     <button
       type="button"
       onClick={onClick}
-      aria-label="Go back"
+      aria-label="Journal back"
       className={cn(
         'inline-flex items-center gap-1 mr-2 p-1 rounded-md',
         'text-muted-foreground/60 hover:text-foreground',

--- a/apps/desktop/src/renderer/src/components/window-controls.test.tsx
+++ b/apps/desktop/src/renderer/src/components/window-controls.test.tsx
@@ -49,8 +49,8 @@ describe('WindowControls', () => {
 
   it('renders both history arrows as disabled', () => {
     renderWithSidebar(<WindowControls />)
-    const back = screen.getByLabelText('Go back')
-    const forward = screen.getByLabelText('Go forward')
+    const back = screen.getByLabelText('Browser back')
+    const forward = screen.getByLabelText('Browser forward')
     expect(back).toBeDisabled()
     expect(forward).toBeDisabled()
     expect(back).toHaveAttribute('aria-disabled', 'true')
@@ -68,8 +68,8 @@ describe('WindowControls', () => {
     const user = userEvent.setup()
     renderWithSidebar(<WindowControls />)
     // userEvent respects `disabled`; click is a no-op. Assert no explosion + no side effects.
-    await user.click(screen.getByLabelText('Go back'))
-    await user.click(screen.getByLabelText('Go forward'))
+    await user.click(screen.getByLabelText('Browser back'))
+    await user.click(screen.getByLabelText('Browser forward'))
     expect(windowApiMock.windowClose).not.toHaveBeenCalled()
     expect(windowApiMock.windowMinimize).not.toHaveBeenCalled()
   })

--- a/apps/desktop/src/renderer/src/components/window-controls.tsx
+++ b/apps/desktop/src/renderer/src/components/window-controls.tsx
@@ -51,7 +51,7 @@ export function WindowControls({ className }: WindowControlsProps): React.JSX.El
           type="button"
           disabled
           aria-disabled="true"
-          aria-label="Go back"
+          aria-label="Browser back"
           className="flex items-center justify-center size-7 rounded text-text-tertiary/40 cursor-default"
           title="Back"
         >
@@ -62,7 +62,7 @@ export function WindowControls({ className }: WindowControlsProps): React.JSX.El
           type="button"
           disabled
           aria-disabled="true"
-          aria-label="Go forward"
+          aria-label="Browser forward"
           className="flex items-center justify-center size-7 rounded text-text-tertiary/40 cursor-default"
           title="Forward"
         >

--- a/apps/desktop/tests/e2e/sidebar-window-controls.e2e.ts
+++ b/apps/desktop/tests/e2e/sidebar-window-controls.e2e.ts
@@ -57,8 +57,8 @@ test.describe('Sidebar & WindowControls', () => {
     await waitForVaultReady(page)
 
     // Expanded state
-    const backExpanded = page.getByLabel('Go back').first()
-    const forwardExpanded = page.getByLabel('Go forward').first()
+    const backExpanded = page.getByLabel('Browser back').first()
+    const forwardExpanded = page.getByLabel('Browser forward').first()
     await expect(backExpanded).toBeVisible()
     await expect(forwardExpanded).toBeVisible()
     await expect(backExpanded).toBeDisabled()
@@ -72,8 +72,8 @@ test.describe('Sidebar & WindowControls', () => {
     await page.waitForTimeout(400)
 
     // Still visible, still disabled
-    await expect(page.getByLabel('Go back').first()).toBeVisible()
-    await expect(page.getByLabel('Go forward').first()).toBeDisabled()
+    await expect(page.getByLabel('Browser back').first()).toBeVisible()
+    await expect(page.getByLabel('Browser forward').first()).toBeDisabled()
   })
 
   test('sidebar content reclaims full width when collapsed', async ({ electronApp, page }) => {


### PR DESCRIPTION
## What

Rename the titlebar history nav and journal breadcrumb back-buttons so they no longer share `aria-label="Go back"` with the sidebar tag-detail drilldown.

## Why

Three unrelated components rendered buttons with identical `aria-label="Go back"`:

- [apps/desktop/src/renderer/src/components/window-controls.tsx:54](../blob/interesting-darwin-d0743a/apps/desktop/src/renderer/src/components/window-controls.tsx#L54) — titlebar (permanently disabled history nav, **always rendered**)
- [apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.tsx:164](../blob/interesting-darwin-d0743a/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.tsx#L164) — sidebar tag drilldown
- [apps/desktop/src/renderer/src/components/journal/date-breadcrumb.tsx:136](../blob/interesting-darwin-d0743a/apps/desktop/src/renderer/src/components/journal/date-breadcrumb.tsx#L136) — journal day breadcrumb

Because the titlebar is always mounted, opening the tag drilldown produced two DOM nodes matching `button[aria-label="Go back"]`. This is a strict-mode trap for Playwright (`page.locator(...).click()` would throw) and is bad a11y — screen readers announce identical labels for semantically distinct actions.

## How

- `window-controls.tsx` → `"Browser back"` / `"Browser forward"` on the titlebar history pair.
- `date-breadcrumb.tsx` → `"Journal back"` on its internal `BackButton` (minimal one-line change; component is dead code today, but renaming defensively prevents the trap if wired up later).
- Updated the matching unit test (`window-controls.test.tsx`) and e2e test (`sidebar-window-controls.e2e.ts`) to the new labels.
- `tag-detail-view.tsx` keeps `"Go back"` — it's now the sole owner of that label, which matches the existing [`tags-rename-delete.e2e.ts`](../blob/interesting-darwin-d0743a/apps/desktop/tests/e2e/tags-rename-delete.e2e.ts#L51) selector cleanly with no filter hacks.

## Type

- [x] `fix` — bug fix (a11y + test flake)

## Test plan

- [x] Unit tests — `window-controls.test.tsx` 5/5 pass
- [x] E2E — `tags-rename-delete.e2e.ts` 2/2 pass (drilldown selector now uniquely matches)
- [x] E2E — `sidebar-window-controls.e2e.ts` 4/4 pass (new titlebar labels resolve)
- [x] `pnpm typecheck:web` passes
- [x] `pnpm exec eslint` clean on touched source files

## Notes for reviewer

- No changes to `tag-detail-view.tsx` — it keeps the short `"Go back"` label, which is now unambiguous.
- `DateBreadcrumb` is currently unused (sibling `JournalBreadcrumb` replaced it); I did the minimal one-line rename rather than deleting the component, since cleanup is out of scope.
- No `:not([disabled])` filter removal was needed in `tags-rename-delete.e2e.ts` — the current file doesn't carry one.

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns