### PR TITLE
fix(calendar): lay out overlapping events in side-by-side lanes

### DIFF
--- a/apps/desktop/src/main/test-hooks.ts
+++ b/apps/desktop/src/main/test-hooks.ts
@@ -36,6 +36,7 @@ export interface CalendarProjectionSeedInput {
   taskTitle: string
   reminderTitle: string
   snoozeTitle: string
+  overlapMemryTitle?: string
 }
 
 export interface NoteOnDeviceStatus {
@@ -437,11 +438,46 @@ export function registerTestHooks(): void {
         )
       `)
 
+      if (input.overlapMemryTitle) {
+        db.run(sql`
+          INSERT INTO calendar_events (
+            id,
+            title,
+            description,
+            start_at,
+            end_at,
+            timezone,
+            is_all_day,
+            clock,
+            created_at,
+            modified_at
+          )
+          VALUES (
+            ${'calendar-e2e-memry-overlap'},
+            ${input.overlapMemryTitle},
+            ${'Seeded overlap Memry event'},
+            ${toLocalIso(input.day, 9, 0)},
+            ${toLocalIso(input.day, 10, 0)},
+            ${timezone},
+            ${0},
+            ${JSON.stringify({ 'device-e2e': 1 })},
+            ${createdAt},
+            ${createdAt}
+          )
+        `)
+      }
+
       BrowserWindow.getAllWindows().forEach((win) => {
         win.webContents.send(CalendarChannels.events.CHANGED, {
           entityType: 'calendar_external_event',
           id: 'calendar-e2e-external'
         })
+        if (input.overlapMemryTitle) {
+          win.webContents.send(CalendarChannels.events.CHANGED, {
+            entityType: 'calendar_event',
+            id: 'calendar-e2e-memry-overlap'
+          })
+        }
         win.webContents.send(TasksChannels.events.CREATED, {
           task: { id: 'calendar-e2e-task' }
         })

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react'
 import { CalendarItemChip } from './calendar-item-chip'
 import { isToday, toLocalDateKey } from './date-utils'
+import { assignLanes } from './overlap-layout'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { formatHour } from '@/lib/time-format'
 import type { CalendarProjectionItem } from '@/services/calendar-service'
@@ -110,13 +111,20 @@ export function CalendarDayView({
             onMouseDown={(e) => handlers.onMouseDown(e, 0)}
             onDoubleClick={(e) => handlers.onDoubleClick(e, 0)}
           >
-            {timedItems.map((item) => {
+            {assignLanes(timedItems).map(({ item, lane, laneCount }) => {
               const pos = getEventPosition(item)
+              const widthPct = 100 / laneCount
+              const leftPct = lane * widthPct
               return (
                 <div
                   key={item.projectionId}
-                  className="absolute left-0.5 right-0.5 z-10 @xl:left-1 @xl:right-1"
-                  style={{ top: pos.top, height: pos.height }}
+                  className="absolute z-10 px-0.5 @xl:px-1"
+                  style={{
+                    top: pos.top,
+                    height: pos.height,
+                    left: `${leftPct}%`,
+                    width: `${widthPct}%`
+                  }}
                 >
                   <CalendarItemChip item={item} clockFormat={clockFormat} onClick={onSelectItem} />
                 </div>

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
@@ -3,6 +3,7 @@ import { CalendarItemChip } from './calendar-item-chip'
 import { dateFromDayIndex, dayIndexFromDate, isToday, toLocalDateKey } from './date-utils'
 import { MarqueeSelectionOverlay } from './marquee-selection-overlay'
 import { CalendarQuickCreateDialog } from './calendar-quick-create-dialog'
+import { assignLanes } from './overlap-layout'
 import { useTimeGridMarquee } from './use-time-grid-marquee'
 import { useScrollToCurrentTime } from './use-scroll-to-current-time'
 import { useWeekInfiniteScroll } from './use-week-infinite-scroll'
@@ -252,13 +253,20 @@ export function CalendarWeekView({
                   onMouseDown={(e) => handlers.onMouseDown(e, vi.index)}
                   onDoubleClick={(e) => handlers.onDoubleClick(e, vi.index)}
                 >
-                  {dayItems.map((item) => {
+                  {assignLanes(dayItems).map(({ item, lane, laneCount }) => {
                     const pos = getEventPosition(item)
+                    const widthPct = 100 / laneCount
+                    const leftPct = lane * widthPct
                     return (
                       <div
                         key={item.projectionId}
-                        className="absolute left-0.5 right-0.5 z-10"
-                        style={{ top: pos.top, height: pos.height }}
+                        className="absolute z-10 px-0.5"
+                        style={{
+                          top: pos.top,
+                          height: pos.height,
+                          left: `${leftPct}%`,
+                          width: `${widthPct}%`
+                        }}
                       >
                         <CalendarItemChip
                           item={item}

--- a/apps/desktop/src/renderer/src/components/calendar/overlap-layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/overlap-layout.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { assignLanes } from './overlap-layout'
+
+type Item = { id: string; startAt: string; endAt: string | null }
+
+const mk = (id: string, startAt: string, endAt: string | null): Item => ({ id, startAt, endAt })
+
+describe('assignLanes', () => {
+  it('returns an empty array for empty input', () => {
+    // #given / #when
+    const result = assignLanes<Item>([])
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('places a single event at lane 0 with laneCount 1', () => {
+    // #given
+    const items = [mk('a', '2026-04-20T09:00:00Z', '2026-04-20T10:00:00Z')]
+    // #when
+    const result = assignLanes(items)
+    // #then
+    expect(result).toEqual([{ item: items[0], lane: 0, laneCount: 1 }])
+  })
+
+  it('places two non-overlapping events each at lane 0 with laneCount 1', () => {
+    // #given
+    const a = mk('a', '2026-04-20T09:00:00Z', '2026-04-20T10:00:00Z')
+    const b = mk('b', '2026-04-20T11:00:00Z', '2026-04-20T12:00:00Z')
+    // #when
+    const result = assignLanes([a, b])
+    // #then
+    expect(result).toEqual([
+      { item: a, lane: 0, laneCount: 1 },
+      { item: b, lane: 0, laneCount: 1 }
+    ])
+  })
+
+  it('treats events that touch at the boundary as non-overlapping', () => {
+    // #given — B starts exactly when A ends
+    const a = mk('a', '2026-04-20T09:00:00Z', '2026-04-20T10:00:00Z')
+    const b = mk('b', '2026-04-20T10:00:00Z', '2026-04-20T11:00:00Z')
+    // #when
+    const result = assignLanes([a, b])
+    // #then
+    expect(result.every((r) => r.laneCount === 1)).toBe(true)
+  })
+
+  it('splits two overlapping events into lanes 0 and 1', () => {
+    // #given
+    const a = mk('a', '2026-04-20T09:00:00Z', '2026-04-20T10:00:00Z')
+    const b = mk('b', '2026-04-20T09:30:00Z', '2026-04-20T10:30:00Z')
+    // #when
+    const result = assignLanes([a, b])
+    // #then
+    const byId = Object.fromEntries(result.map((r) => [r.item.id, r]))
+    expect(byId.a.lane).toBe(0)
+    expect(byId.a.laneCount).toBe(2)
+    expect(byId.b.lane).toBe(1)
+    expect(byId.b.laneCount).toBe(2)
+  })
+
+  it('reuses a lane when an earlier event in that lane has already ended (chain overlap)', () => {
+    // #given — A (9-10), B (9:30-10:30), C (10:15-11)
+    // A and C do not overlap so C should reuse A's lane
+    const a = mk('a', '2026-04-20T09:00:00Z', '2026-04-20T10:00:00Z')
+    const b = mk('b', '2026-04-20T09:30:00Z', '2026-04-20T10:30:00Z')
+    const c = mk('c', '2026-04-20T10:15:00Z', '2026-04-20T11:00:00Z')
+    // #when
+    const result = assignLanes([a, b, c])
+    // #then
+    const byId = Object.fromEntries(result.map((r) => [r.item.id, r]))
+    expect(byId.a.lane).toBe(0)
+    expect(byId.b.lane).toBe(1)
+    expect(byId.c.lane).toBe(0)
+    // The cluster has 2 concurrent lanes at its peak
+    expect(byId.a.laneCount).toBe(2)
+    expect(byId.b.laneCount).toBe(2)
+    expect(byId.c.laneCount).toBe(2)
+  })
+
+  it('keeps separate non-overlapping clusters independent', () => {
+    // #given — [A,B overlap] then gap then [C alone]
+    const a = mk('a', '2026-04-20T09:00:00Z', '2026-04-20T10:00:00Z')
+    const b = mk('b', '2026-04-20T09:30:00Z', '2026-04-20T10:30:00Z')
+    const c = mk('c', '2026-04-20T14:00:00Z', '2026-04-20T15:00:00Z')
+    // #when
+    const result = assignLanes([a, b, c])
+    // #then
+    const byId = Object.fromEntries(result.map((r) => [r.item.id, r]))
+    expect(byId.a.laneCount).toBe(2)
+    expect(byId.b.laneCount).toBe(2)
+    expect(byId.c.laneCount).toBe(1)
+    expect(byId.c.lane).toBe(0)
+  })
+
+  it('assigns three overlapping events to lanes 0, 1, 2 with laneCount 3', () => {
+    // #given — all three overlap at 9:45
+    const a = mk('a', '2026-04-20T09:00:00Z', '2026-04-20T10:00:00Z')
+    const b = mk('b', '2026-04-20T09:15:00Z', '2026-04-20T10:15:00Z')
+    const c = mk('c', '2026-04-20T09:30:00Z', '2026-04-20T10:30:00Z')
+    // #when
+    const result = assignLanes([a, b, c])
+    // #then
+    const lanes = result.map((r) => r.lane).sort()
+    expect(lanes).toEqual([0, 1, 2])
+    expect(result.every((r) => r.laneCount === 3)).toBe(true)
+  })
+
+  it('handles events whose endAt is null by treating duration as one hour', () => {
+    // #given — A has null endAt (default 1h), B starts 30m in
+    const a = mk('a', '2026-04-20T09:00:00Z', null)
+    const b = mk('b', '2026-04-20T09:30:00Z', '2026-04-20T10:30:00Z')
+    // #when
+    const result = assignLanes([a, b])
+    // #then — they overlap (A ends 10:00, B starts 9:30)
+    expect(result.every((r) => r.laneCount === 2)).toBe(true)
+  })
+
+  it('is stable for input that is not pre-sorted by startAt', () => {
+    // #given — intentionally reversed order
+    const a = mk('a', '2026-04-20T09:00:00Z', '2026-04-20T10:00:00Z')
+    const b = mk('b', '2026-04-20T09:30:00Z', '2026-04-20T10:30:00Z')
+    // #when
+    const result = assignLanes([b, a])
+    // #then
+    const byId = Object.fromEntries(result.map((r) => [r.item.id, r]))
+    expect(byId.a.lane).toBe(0)
+    expect(byId.b.lane).toBe(1)
+  })
+
+  it('handles a nested event (short inside a longer one) with two lanes', () => {
+    // #given — big A (9-12), tiny B (10-11) fully inside A
+    const a = mk('a', '2026-04-20T09:00:00Z', '2026-04-20T12:00:00Z')
+    const b = mk('b', '2026-04-20T10:00:00Z', '2026-04-20T11:00:00Z')
+    // #when
+    const result = assignLanes([a, b])
+    // #then
+    const byId = Object.fromEntries(result.map((r) => [r.item.id, r]))
+    expect(byId.a.lane).toBe(0)
+    expect(byId.b.lane).toBe(1)
+    expect(byId.a.laneCount).toBe(2)
+    expect(byId.b.laneCount).toBe(2)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/overlap-layout.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/overlap-layout.ts
@@ -1,0 +1,64 @@
+const DEFAULT_DURATION_MS = 60 * 60 * 1000
+
+export interface LaneAssignment<T> {
+  item: T
+  lane: number
+  laneCount: number
+}
+
+interface Timed<T> {
+  item: T
+  start: number
+  end: number
+}
+
+function toTimed<T extends { startAt: string; endAt: string | null }>(item: T): Timed<T> {
+  const start = new Date(item.startAt).getTime()
+  const end = item.endAt ? new Date(item.endAt).getTime() : start + DEFAULT_DURATION_MS
+  return { item, start, end }
+}
+
+export function assignLanes<T extends { startAt: string; endAt: string | null }>(
+  items: T[]
+): LaneAssignment<T>[] {
+  if (items.length === 0) return []
+
+  const timed = items.map(toTimed)
+  timed.sort((a, b) => a.start - b.start || b.end - a.end)
+
+  const output: LaneAssignment<T>[] = []
+  let cluster: Timed<T>[] = []
+  let clusterEnd = -Infinity
+
+  const flush = (): void => {
+    if (cluster.length === 0) return
+    const laneEnds: number[] = []
+    const laneByIndex: number[] = []
+    for (let i = 0; i < cluster.length; i++) {
+      const ev = cluster[i]
+      let lane = laneEnds.findIndex((endTime) => endTime <= ev.start)
+      if (lane === -1) {
+        lane = laneEnds.length
+        laneEnds.push(ev.end)
+      } else {
+        laneEnds[lane] = ev.end
+      }
+      laneByIndex[i] = lane
+    }
+    const laneCount = laneEnds.length
+    for (let i = 0; i < cluster.length; i++) {
+      output.push({ item: cluster[i].item, lane: laneByIndex[i], laneCount })
+    }
+    cluster = []
+    clusterEnd = -Infinity
+  }
+
+  for (const ev of timed) {
+    if (ev.start >= clusterEnd) flush()
+    cluster.push(ev)
+    clusterEnd = Math.max(clusterEnd, ev.end)
+  }
+  flush()
+
+  return output
+}

--- a/apps/desktop/tests/e2e/calendar-overlap.e2e.ts
+++ b/apps/desktop/tests/e2e/calendar-overlap.e2e.ts
@@ -1,0 +1,142 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
+
+interface OverlapSeedInput {
+  day: string
+  importedTitle: string
+  taskTitle: string
+  reminderTitle: string
+  snoozeTitle: string
+  overlapMemryTitle: string
+}
+
+function toIsoDay(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+async function seedOverlap(
+  electronApp: Parameters<typeof test>[0]['electronApp'],
+  input: OverlapSeedInput
+): Promise<void> {
+  await electronApp.evaluate(async (_ctx, payload) => {
+    const hooks = (
+      globalThis as typeof globalThis & {
+        __memryTestHooks?: { seedCalendarProjection(d: OverlapSeedInput): Promise<void> }
+      }
+    ).__memryTestHooks
+    if (!hooks) throw new Error('Memry test hooks are not registered')
+    await hooks.seedCalendarProjection(payload)
+  }, input)
+}
+
+async function openCalendar(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Calendar' }).click()
+  await expect(page.getByTestId('calendar-page')).toBeVisible()
+}
+
+async function switchView(page: Page, name: 'Day' | 'Week'): Promise<void> {
+  await page.getByTestId('calendar-page').getByRole('button', { name, exact: true }).click()
+  await expect(page.getByTestId('calendar-view')).toHaveAttribute('data-view', name.toLowerCase())
+}
+
+test.describe('Calendar — overlapping events layout', () => {
+  const seed: OverlapSeedInput = {
+    day: toIsoDay(new Date()),
+    importedTitle: 'Imported customer call',
+    taskTitle: 'Due launch brief',
+    reminderTitle: 'Medication reminder',
+    snoozeTitle: 'Review investor email',
+    overlapMemryTitle: 'Prep for customer call'
+  }
+
+  test.beforeEach(async ({ page, electronApp }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+    await seedOverlap(electronApp, seed)
+  })
+
+  test('overlapping chips render side-by-side in day view with distinct hit regions', async ({
+    page
+  }) => {
+    // #given — seed creates a 9:00-10:00 Memry event and a 9:30-10:30 external event.
+    // They overlap at 9:30-10:00. Pre-fix, both rendered full-width and the later DOM
+    // element captured all clicks. Post-fix, each lands in its own lane.
+    await openCalendar(page)
+    await switchView(page, 'Day')
+
+    const grid = page.getByTestId('day-time-grid')
+    const memryChip = grid.getByRole('button', { name: new RegExp(seed.overlapMemryTitle) })
+    const externalChip = grid.getByRole('button', { name: new RegExp(seed.importedTitle) })
+
+    await expect(memryChip).toBeVisible()
+    await expect(externalChip).toBeVisible()
+
+    // Scroll to 9 AM so both chips are fully in viewport (Playwright's
+    // boundingBox reports viewport-relative coords, not document coords).
+    await memryChip.scrollIntoViewIfNeeded()
+
+    // #when — measure each chip's bounding box
+    const memryBox = await memryChip.boundingBox()
+    const externalBox = await externalChip.boundingBox()
+    if (!memryBox || !externalBox) {
+      throw new Error('expected both chips to have bounding boxes')
+    }
+
+    // #then — chips occupy disjoint horizontal regions (lane packing)
+    const memryRight = memryBox.x + memryBox.width
+    const externalRight = externalBox.x + externalBox.width
+    const disjoint = memryRight <= externalBox.x || externalRight <= memryBox.x
+    if (!disjoint) {
+      throw new Error(
+        `expected disjoint horizontal regions, got memry ${JSON.stringify(memryBox)} vs external ${JSON.stringify(externalBox)}`
+      )
+    }
+
+    // #then — the external chip receives a real click without force/dispatch tricks.
+    // Pre-fix, clicking the external chip would be intercepted by the Memry chip (or
+    // vice versa) since both spanned the same horizontal range.
+    await externalChip.click()
+    await expect(page.getByTestId('promote-external-dialog')).toBeVisible()
+  })
+
+  test('overlapping chips render side-by-side in week view with distinct hit regions', async ({
+    page
+  }) => {
+    // #given — same seed, week view
+    await openCalendar(page)
+    await switchView(page, 'Week')
+
+    const weekGrid = page.getByTestId('calendar-week-scroll')
+    const memryChip = weekGrid
+      .getByRole('button', { name: new RegExp(seed.overlapMemryTitle) })
+      .first()
+    const externalChip = weekGrid
+      .getByRole('button', { name: new RegExp(seed.importedTitle) })
+      .first()
+
+    await expect(memryChip).toBeVisible()
+    await expect(externalChip).toBeVisible()
+    await memryChip.scrollIntoViewIfNeeded()
+
+    // #when
+    const memryBox = await memryChip.boundingBox()
+    const externalBox = await externalChip.boundingBox()
+    if (!memryBox || !externalBox) {
+      throw new Error('expected both chips to have bounding boxes')
+    }
+
+    // #then — chips occupy disjoint horizontal regions even in a week column
+    const memryRight = memryBox.x + memryBox.width
+    const externalRight = externalBox.x + externalBox.width
+    const disjoint = memryRight <= externalBox.x || externalRight <= memryBox.x
+    if (!disjoint) {
+      throw new Error(
+        `expected disjoint horizontal regions, got memry ${JSON.stringify(memryBox)} vs external ${JSON.stringify(externalBox)}`
+      )
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fix day and week view rendering so overlapping events get dedicated lanes instead of stacking at full column width with identical z-index.

**The bug:** when two events overlapped in time, the later DOM sibling captured every click across the whole column — the earlier chip was visually peeking above/below but completely unclickable for real users. E2E tests had been working around this with \`.first()\` and \`{ force: true }\`.

**The fix:** standard interval graph coloring / greedy lane packing. Sort events by start (longer-first as tiebreak), greedy-assign each to the first lane whose last event has already ended. Within each overlap cluster, render at \`width = 100/laneCount\` with a lane-indexed \`left\` offset. Single events still render at full column width — no regression for the common case.

## What's in the diff

- **\`overlap-layout.ts\`** (new): pure \`assignLanes<T>()\` with 11 unit tests covering empty, single, non-overlapping, boundary-touching, two-overlap, chain overlap, multi-cluster, three-way, null-endAt, input-order stability, and nested events.
- **\`calendar-day-view.tsx\`, \`calendar-week-view.tsx\`**: wired to \`assignLanes\` with percentage-based \`left\`/\`width\` and \`px-0.5\` (\`@xl:px-1\`) inner padding for lane gutters.
- **\`test-hooks.ts\`**: optional \`overlapMemryTitle\` field on \`CalendarProjectionSeedInput\` that seeds a 9:00–10:00 Memry event overlapping the existing 9:30–10:30 external seed. Backwards compatible — existing callers that omit the field see zero behavior change.
- **\`calendar-overlap.e2e.ts\`** (new): 2 Playwright tests covering day and week views. Each asserts chips have disjoint horizontal bounding boxes; the day-view test additionally verifies clicking the external chip opens the promote-external dialog with a real Playwright click (no \`dispatchEvent\`, no \`{ force: true }\`, no \`.first()\`).

## Why this approach

Column lane packing is what Google Calendar, Apple Calendar, and Outlook all do — it's the standard UX. The alternative (stack indicator with "+N events" popover) would be inferior on busy days because titles become invisible at a glance.

Cluster-wide \`laneCount\` (rather than per-event widths based on personal overlap set) keeps the column grid visually consistent — chips align vertically like a mini CSS grid instead of jumping widths.

## Test plan

- [x] \`vitest run overlap-layout.test.ts\` — 11/11 passing
- [x] \`vitest run\` (full desktop suite) — 7123/7124 passing (1 pre-existing skip, no new failures)
- [x] \`typecheck:node\` — clean
- [x] \`typecheck:web\` — clean
- [x] \`pnpm lint\` — 0 new warnings
- [x] \`playwright test calendar-overlap.e2e.ts\` — 2/2 passing
- [ ] Manual repro: create a 9:00 Memry event that overlaps the 9:30 imported event, confirm both are independently clickable in day and week views

## Notes for the reviewer

- **Pre-existing failures (not mine).** Running the full comprehensive e2e surfaced 5 failures in \`Event creation — full editor\` / \`Event editing\` where the "New Event" drawer doesn't open in the built bundle. I stashed my changes, rebuilt, and reproduced the same 5 failures on the branch baseline — they're unrelated to this PR.