### PR TITLE
Calendar: event dots + configurable day-cell click in Day Panel

### DIFF
--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -3,2567 +3,336 @@
 /* eslint-disable max-lines */
 
 export interface MainIpcInvokeHandlers {
-  'account:getInfo': (...args: []) => Awaited<import('./account-handlers').AccountInfo>
-  'account:getRecoveryKey': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      | { success: boolean; error: string; key?: undefined }
-      | { success: boolean; key: string; error?: undefined }
-    >
-  >
-  'account:signOut': (
-    ...args: []
-  ) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean }>>
-  'ai-inline:get-server-port': (...args: []) => Awaited<number | null>
-  'ai-inline:get-settings': (
-    ...args: []
-  ) => Awaited<import('../../../../../packages/contracts/src/ai-inline-channels').AIInlineSettings>
-  'ai-inline:set-settings': (
-    ...args: [
-      Partial<import('../../../../../packages/contracts/src/ai-inline-channels').AIInlineSettings>
-    ]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'ai-inline:start-server': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; error: string; port?: undefined }
-      | { success: boolean; port: number; error?: undefined }
-    >
-  >
-  'ai-inline:stop-server': (...args: []) => Awaited<Promise<{ success: boolean }>>
-  'auth:init-oauth': (
-    ...args: [{ provider: 'google' }]
-  ) => Awaited<Promise<{ state: string }> | { success: false; error: string }>
-  'auth:refresh-token': (
-    ...args: []
-  ) => Awaited<Promise<{ success: boolean; error: string | undefined }>>
-  'auth:request-otp': (
-    ...args: [{ email: string }]
-  ) => Awaited<Promise<unknown> | { success: false; error: string }>
-  'auth:resend-otp': (
-    ...args: [{ email: string }]
-  ) => Awaited<Promise<unknown> | { success: false; error: string }>
-  'auth:verify-otp': (...args: [{ email: string; code: string }]) => Awaited<
-    | Promise<{
-        success: boolean
-        isNewUser: boolean
-        needsSetup: boolean
-        needsRecoveryInput: boolean
-      }>
-    | { success: false; error: string }
-  >
-  'bookmarks:bulk-create': (
-    ...args: [{ items: { itemType: string; itemId: string }[] }]
-  ) => Awaited<Promise<{ success: boolean; createdCount: number }>>
-  'bookmarks:bulk-delete': (
-    ...args: [{ bookmarkIds: string[] }]
-  ) => Awaited<Promise<{ success: boolean; deletedCount: number }>>
-  'bookmarks:create': (...args: [{ itemType: string; itemId: string }]) => Awaited<
-    Promise<
-      | { success: boolean; bookmark: null; error: string }
-      | {
-          success: boolean
-          bookmark: {
-            id: string
-            createdAt: string
-            position: number
-            itemType: string
-            itemId: string
-          }
-          error?: undefined
-        }
-    >
-  >
-  'bookmarks:delete': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  >
-  'bookmarks:get': (...args: [string]) => Awaited<
-    Promise<{
-      id: string
-      createdAt: string
-      position: number
-      itemType: string
-      itemId: string
-    } | null>
-  >
-  'bookmarks:get-by-item': (...args: [{ itemType: string; itemId: string }]) => Awaited<
-    Promise<{
-      id: string
-      createdAt: string
-      position: number
-      itemType: string
-      itemId: string
-    } | null>
-  >
-  'bookmarks:is-bookmarked': (
-    ...args: [{ itemType: string; itemId: string }]
-  ) => Awaited<Promise<boolean>>
-  'bookmarks:list': (
-    ...args: [
-      {
-        itemType?: string | undefined
-        sortBy?: 'createdAt' | 'position' | undefined
-        sortOrder?: 'asc' | 'desc' | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/bookmarks-api').BookmarkListResponse>
-  >
-  'bookmarks:list-by-type': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/bookmarks-api').BookmarkListResponse>
-  >
-  'bookmarks:reorder': (
-    ...args: [{ bookmarkIds: string[] }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'bookmarks:toggle': (...args: [{ itemType: string; itemId: string }]) => Awaited<
-    Promise<{
-      success: boolean
-      isBookmarked: boolean
-      bookmark: {
-        id: string
-        createdAt: string
-        position: number
-        itemType: string
-        itemId: string
-      } | null
-    }>
-  >
-  'calendar:connect-provider': (
-    ...args: [{ provider: string; accountId?: string | undefined }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarProviderMutationResponse
-    >
-  >
-  'calendar:create-event': (
-    ...args: [
-      {
-        title: string
-        startAt: string
-        description?: string | null | undefined
-        location?: string | null | undefined
-        endAt?: string | null | undefined
-        timezone?: string | undefined
-        isAllDay?: boolean | undefined
-        recurrenceRule?: Record<string, unknown> | null | undefined
-        recurrenceExceptions?: string[] | null | undefined
-        targetCalendarId?: string | null | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarEventMutationResponse
-    >
-  >
-  'calendar:delete-event': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarDeleteResponse
-    >
-  >
-  'calendar:disconnect-provider': (
-    ...args: [{ provider: string; accountId?: string | undefined }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarProviderMutationResponse
-    >
-  >
-  'calendar:get-event': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarEventRecord | null>
-  >
-  'calendar:get-provider-status': (
-    ...args: [{ provider: string; accountId?: string | undefined }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarProviderStatus>
-  >
-  'calendar:get-range': (
-    ...args: [{ startAt: string; endAt: string; includeUnselectedSources?: boolean | undefined }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarRangeResponse>
-  >
-  'calendar:list-events': (
-    ...args: [{ includeArchived?: boolean | undefined }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarEventListResponse>
-  >
-  'calendar:list-google-calendars': (
-    ...args: [Record<string, never> | undefined]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').ListGoogleCalendarsResponse
-    >
-  >
-  'calendar:list-sources': (
-    ...args: [
-      {
-        provider?: string | undefined
-        kind?: 'account' | 'calendar' | undefined
-        selectedOnly?: boolean | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarSourceListResponse>
-  >
-  'calendar:promote-external-event': (
-    ...args: [{ externalEventId: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').PromoteExternalEventResponse
-    >
-  >
-  'calendar:refresh-provider': (
-    ...args: [{ provider: string; accountId?: string | undefined }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarProviderMutationResponse
-    >
-  >
-  'calendar:retry-google-source-sync': (
-    ...args: [{ sourceId: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').RetryCalendarSourceSyncResponse
-    >
-  >
-  'calendar:set-default-google-calendar': (
-    ...args: [{ calendarId: string | null; markOnboardingComplete?: boolean | undefined }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').SetDefaultGoogleCalendarResponse
-    >
-  >
-  'calendar:update-event': (
-    ...args: [
-      {
-        id: string
-        title?: string | undefined
-        description?: string | null | undefined
-        location?: string | null | undefined
-        startAt?: string | undefined
-        endAt?: string | null | undefined
-        timezone?: string | undefined
-        isAllDay?: boolean | undefined
-        recurrenceRule?: Record<string, unknown> | null | undefined
-        recurrenceExceptions?: string[] | null | undefined
-        targetCalendarId?: string | null | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarEventMutationResponse
-    >
-  >
-  'calendar:update-source-selection': (
-    ...args: [{ id: string; isSelected: boolean }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarSourceMutationResponse
-    >
-  >
-  'context-menu:show': (
-    ...args: [
-      {
-        id: string
-        label: string
-        accelerator?: string | undefined
-        disabled?: boolean | undefined
-        type?: 'normal' | 'separator' | undefined
-      }[]
-    ]
-  ) => Awaited<Promise<string | null>>
-  'crdt:apply-update': (...args: [unknown]) => Awaited<Promise<void>>
-  'crdt:close-doc': (...args: [unknown]) => Awaited<Promise<{ success: boolean }>>
-  'crdt:open-doc': (
-    ...args: [unknown]
-  ) => Awaited<
-    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  >
-  'crdt:sync-step-1': (
-    ...args: [{ noteId: string; stateVector: number[] }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/ipc-crdt').CrdtSyncStep1Result | null>
-  >
-  'crdt:sync-step-2': (...args: [{ noteId: string; diff: number[] }]) => Awaited<Promise<void>>
-  'crypto:decrypt-item': (
-    ...args: [
-      {
-        itemId: string
-        type:
-          | 'note'
-          | 'filter'
-          | 'project'
-          | 'journal'
-          | 'task'
-          | 'settings'
-          | 'inbox'
-          | 'tag_definition'
-          | 'folder_config'
-          | 'calendar_event'
-          | 'calendar_source'
-          | 'calendar_binding'
-          | 'calendar_external_event'
-        encryptedKey: string
-        keyNonce: string
-        encryptedData: string
-        dataNonce: string
-        signature: string
-        operation?: 'create' | 'update' | 'delete' | undefined
-        deletedAt?: number | undefined
-        metadata?: Record<string, unknown> | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/ipc-crypto').DecryptItemResult>
-  >
-  'crypto:encrypt-item': (
-    ...args: [
-      {
-        itemId: string
-        type:
-          | 'note'
-          | 'filter'
-          | 'project'
-          | 'journal'
-          | 'task'
-          | 'settings'
-          | 'inbox'
-          | 'tag_definition'
-          | 'folder_config'
-          | 'calendar_event'
-          | 'calendar_source'
-          | 'calendar_binding'
-          | 'calendar_external_event'
-        content: Record<string, unknown>
-        operation?: 'create' | 'update' | 'delete' | undefined
-        deletedAt?: number | undefined
-        metadata?: Record<string, unknown> | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/ipc-crypto').EncryptItemResult>
-  >
-  'crypto:get-rotation-progress': (
-    ...args: []
-  ) => Awaited<import('../../../../../packages/contracts/src/ipc-crypto').GetRotationProgressResult>
-  'crypto:rotate-keys': (
-    ...args: [{ confirm: boolean }]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/ipc-crypto').RotateKeysResult>>
-  'crypto:verify-signature': (
-    ...args: [
-      {
-        itemId: string
-        type:
-          | 'note'
-          | 'filter'
-          | 'project'
-          | 'journal'
-          | 'task'
-          | 'settings'
-          | 'inbox'
-          | 'tag_definition'
-          | 'folder_config'
-          | 'calendar_event'
-          | 'calendar_source'
-          | 'calendar_binding'
-          | 'calendar_external_event'
-        encryptedKey: string
-        keyNonce: string
-        encryptedData: string
-        dataNonce: string
-        signature: string
-        operation?: 'create' | 'update' | 'delete' | undefined
-        deletedAt?: number | undefined
-        metadata?: Record<string, unknown> | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/ipc-crypto').VerifySignatureResult>
-  >
-  'folder-view:delete-view': (
-    ...args: [{ folderPath: string; viewName: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/folder-view-api').DeleteViewResponse
-    >
-  >
-  'folder-view:folder-exists': (...args: [string]) => Awaited<boolean>
-  'folder-view:get-available-properties': (
-    ...args: [{ folderPath: string }]
-  ) => Awaited<
-    Promise<
-      import('../../../../../packages/contracts/src/folder-view-api').GetAvailablePropertiesResponse
-    >
-  >
-  'folder-view:get-config': (
-    ...args: [{ folderPath: string }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/folder-view-api').GetConfigResponse>
-  >
-  'folder-view:get-folder-suggestions': (
-    ...args: [{ noteId: string }]
-  ) => Awaited<
-    Promise<
-      import('../../../../../packages/contracts/src/folder-view-api').GetFolderSuggestionsResponse
-    >
-  >
-  'folder-view:get-views': (
-    ...args: [{ folderPath: string }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/folder-view-api').GetViewsResponse>
-  >
-  'folder-view:list-with-properties': (
-    ...args: [
-      {
-        folderPath: string
-        properties?: string[] | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      import('../../../../../packages/contracts/src/folder-view-api').ListWithPropertiesResponse
-    >
-  >
-  'folder-view:set-config': (
-    ...args: [
-      {
-        folderPath: string
-        config: {
-          path?: string | undefined
-          template?: string | undefined
-          inherit?: boolean | undefined
-          formulas?: Record<string, string> | undefined
-          properties?:
-            | Record<
-                string,
-                {
-                  displayName?: string | undefined
-                  color?: boolean | undefined
-                  dateFormat?: string | undefined
-                  numberFormat?: string | undefined
-                  hidden?: boolean | undefined
-                }
-              >
-            | undefined
-          summaries?:
-            | Record<
-                string,
-                {
-                  type:
-                    | 'custom'
-                    | 'count'
-                    | 'sum'
-                    | 'average'
-                    | 'min'
-                    | 'max'
-                    | 'countBy'
-                    | 'countUnique'
-                  label?: string | undefined
-                  expression?: string | undefined
-                }
-              >
-            | undefined
-          views?:
-            | {
-                name: string
-                type?: 'table' | 'grid' | 'list' | 'kanban' | undefined
-                default?: boolean | undefined
-                columns?:
-                  | {
-                      id: string
-                      width?: number | undefined
-                      displayName?: string | undefined
-                      showSummary?: boolean | undefined
-                    }[]
-                  | undefined
-                filters?: unknown
-                order?: { property: string; direction: 'asc' | 'desc' }[] | undefined
-                groupBy?:
-                  | {
-                      property: string
-                      direction?: 'asc' | 'desc' | undefined
-                      collapsed?: boolean | undefined
-                      showSummary?: boolean | undefined
-                    }
-                  | undefined
-                limit?: number | undefined
-                showSummaries?: boolean | undefined
-              }[]
-            | undefined
-        }
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/folder-view-api').SetConfigResponse
-    >
-  >
-  'folder-view:set-view': (
-    ...args: [
-      {
-        folderPath: string
-        view: {
-          name: string
-          type?: 'table' | 'grid' | 'list' | 'kanban' | undefined
-          default?: boolean | undefined
-          columns?:
-            | {
-                id: string
-                width?: number | undefined
-                displayName?: string | undefined
-                showSummary?: boolean | undefined
-              }[]
-            | undefined
-          filters?: unknown
-          order?: { property: string; direction: 'asc' | 'desc' }[] | undefined
-          groupBy?:
-            | {
-                property: string
-                direction?: 'asc' | 'desc' | undefined
-                collapsed?: boolean | undefined
-                showSummary?: boolean | undefined
-              }
-            | undefined
-          limit?: number | undefined
-          showSummaries?: boolean | undefined
-        }
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/folder-view-api').SetViewResponse
-    >
-  >
-  'graph:get-graph-data': (...args: []) => Awaited<{
-    nodes: {
-      id: string
-      type: 'note' | 'project' | 'journal' | 'task'
-      label: string
-      tags: string[]
-      wordCount: number
-      connectionCount: number
-      emoji: string | null
-      color: string
-      isOrphan: boolean
-      isUnresolved: boolean
-    }[]
-    edges: {
-      id: string
-      source: string
-      target: string
-      type: 'wikilink' | 'task-note' | 'project-task' | 'tag-cooccurrence'
-      weight: number
-    }[]
-  }>
-  'graph:get-local-graph': (...args: [{ noteId: string; depth?: number | undefined }]) => Awaited<{
-    nodes: {
-      id: string
-      type: 'note' | 'project' | 'journal' | 'task'
-      label: string
-      tags: string[]
-      wordCount: number
-      connectionCount: number
-      emoji: string | null
-      color: string
-      isOrphan: boolean
-      isUnresolved: boolean
-    }[]
-    edges: {
-      id: string
-      source: string
-      target: string
-      type: 'wikilink' | 'task-note' | 'project-task' | 'tag-cooccurrence'
-      weight: number
-    }[]
-  }>
-  'inbox:add-tag': (
-    ...args: [any, any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:archive': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:bulk-archive': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
-  'inbox:bulk-file': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
-  'inbox:bulk-snooze': (...args: [any]) => Awaited<
-    Promise<{
-      success: boolean
-      processedCount: number
-      errors: { itemId: string; error: string }[]
-    }>
-  >
-  'inbox:bulk-tag': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
-  'inbox:capture-clip': (
-    ...args: [unknown]
-  ) => Awaited<Promise<{ success: boolean; item: null; error: string }>>
-  'inbox:capture-image': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
-  >
-  'inbox:capture-link': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
-  >
-  'inbox:capture-pdf': (
-    ...args: [unknown]
-  ) => Awaited<Promise<{ success: boolean; item: null; error: string }>>
-  'inbox:capture-text': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
-  >
-  'inbox:capture-voice': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
-  >
-  'inbox:convert-to-note': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/domain-inbox/src/types').InboxFileResponse>>
-  'inbox:convert-to-task': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; taskId: string | null; error?: string | undefined }>>
-  'inbox:delete-permanent': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:file': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/domain-inbox/src/types').InboxFileResponse>>
-  'inbox:file-all-stale': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
-  'inbox:get': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxItem | null>>
-  'inbox:get-filing-history': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/inbox-api').FilingHistoryResponse>
-  >
-  'inbox:get-jobs': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxJobsResponse>>
-  'inbox:get-patterns': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').CapturePattern>>
-  'inbox:get-snoozed': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/domain-inbox/src/types').SnoozedItem[]>>
-  'inbox:get-stale-threshold': (...args: []) => Awaited<Promise<number>>
-  'inbox:get-stats': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxStats>>
-  'inbox:get-suggestions': (...args: [any]) => Awaited<
-    Promise<{
-      suggestions: import('../../../../../packages/domain-inbox/src/types').InboxFilingSuggestion[]
-    }>
-  >
-  'inbox:get-tags': (...args: []) => Awaited<Promise<{ tag: string; count: number }[]>>
-  'inbox:link-to-note': (
-    ...args: [any, any, any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:list': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxListResponse>>
-  'inbox:list-archived': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/inbox-api').ArchivedListResponse>
-  >
-  'inbox:mark-viewed': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:preview-link': (...args: [string]) => Awaited<
-    Promise<
-      | {
-          title: string
-          domain: string
-          favicon: string | undefined
-          image: string | undefined
-          description: string | undefined
-        }
-      | {
-          title: string
-          domain: string
-          favicon?: undefined
-          image?: undefined
-          description?: undefined
-        }
-    >
-  >
-  'inbox:remove-tag': (
-    ...args: [any, any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:retry-metadata': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:retry-transcription': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:set-stale-threshold': (...args: [any]) => Awaited<Promise<{ success: boolean }>>
-  'inbox:snooze': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:track-suggestion': (
-    ...args: [string, string, string, string, number, string[], string[]]
-  ) => Awaited<
-    Promise<{ success: false; error: string } | { success: boolean; error?: string | undefined }>
-  >
-  'inbox:unarchive': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:undo-archive': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:undo-file': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:unsnooze': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:update': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').CaptureResponse>>
-  'journal:createEntry': (
-    ...args: [
-      {
-        date: string
-        content?: string | undefined
-        tags?: string[] | undefined
-        properties?: Record<string, unknown> | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<{
-      id: string
-      date: string
-      content: string
-      wordCount: number
-      characterCount: number
-      tags: string[]
-      createdAt: string
-      modifiedAt: string
-      properties?: Record<string, unknown> | undefined
-    }>
-  >
-  'journal:deleteEntry': (...args: [{ date: string }]) => Awaited<Promise<{ success: boolean }>>
-  'journal:getAllTags': (...args: []) => Awaited<Promise<{ tag: string; count: number }[]>>
-  'journal:getDayContext': (...args: [{ date: string }]) => Awaited<
-    Promise<{
-      date: string
-      tasks: {
-        id: string
-        title: string
-        completed: boolean
-        priority?: 'urgent' | 'high' | 'medium' | 'low' | undefined
-        isOverdue?: boolean | undefined
-      }[]
-      events: {
-        id: string
-        time: string
-        title: string
-        type: 'meeting' | 'focus' | 'event'
-        attendeeCount?: number | undefined
-      }[]
-      overdueCount: number
-    }>
-  >
-  'journal:getEntry': (...args: [{ date: string }]) => Awaited<
-    Promise<{
-      id: string
-      date: string
-      content: string
-      wordCount: number
-      characterCount: number
-      tags: string[]
-      createdAt: string
-      modifiedAt: string
-      properties?: Record<string, unknown> | undefined
-    } | null>
-  >
-  'journal:getHeatmap': (
-    ...args: [{ year: number }]
-  ) => Awaited<Promise<{ date: string; characterCount: number; level: 0 | 1 | 2 | 4 | 3 }[]>>
-  'journal:getMonthEntries': (...args: [{ year: number; month: number }]) => Awaited<
-    Promise<
-      {
-        date: string
-        preview: string
-        wordCount: number
-        characterCount: number
-        activityLevel: 0 | 1 | 2 | 4 | 3
-        tags: string[]
-      }[]
-    >
-  >
-  'journal:getStreak': (
-    ...args: []
-  ) => Awaited<
-    Promise<{ currentStreak: number; longestStreak: number; lastEntryDate: string | null }>
-  >
-  'journal:getYearStats': (...args: [{ year: number }]) => Awaited<
-    Promise<
-      {
-        year: number
-        month: number
-        entryCount: number
-        totalWordCount: number
-        totalCharacterCount: number
-        averageLevel: number
-      }[]
-    >
-  >
-  'journal:updateEntry': (
-    ...args: [
-      {
-        date: string
-        content?: string | undefined
-        tags?: string[] | undefined
-        properties?: Record<string, unknown> | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<{
-      id: string
-      date: string
-      content: string
-      wordCount: number
-      characterCount: number
-      tags: string[]
-      createdAt: string
-      modifiedAt: string
-      properties?: Record<string, unknown> | undefined
-    }>
-  >
-  'notes:add-property-option': (
-    ...args: [{ propertyName: string; option: { value: string; color: string } }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:add-status-option': (
-    ...args: [
-      {
-        propertyName: string
-        categoryKey: 'todo' | 'in_progress' | 'done'
-        option: { value: string; color: string }
-      }
-    ]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:create': (
-    ...args: [
-      {
-        title: string
-        content?: string | undefined
-        folder?: string | undefined
-        tags?: string[] | undefined
-        template?: string | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
-    | { success: false; error: string }
-  >
-  'notes:create-folder': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'notes:create-property-definition': (
-    ...args: [
-      {
-        name: string
-        type: 'number' | 'date' | 'text' | 'select' | 'checkbox' | 'url' | 'status' | 'multiselect'
-        options?: { value: string; color: string; default?: boolean | undefined }[] | undefined
-        defaultValue?: unknown
-        color?: string | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<
-        | {
-            success: true
-            definition:
-              | import('../../../../../packages/contracts/src/property-types').PropertyDefinition
-              | undefined
-          }
-        | {
-            success: true
-            definition: {
-              type: string
-              name: string
-              createdAt: string
-              options: string | null
-              defaultValue: string | null
-              color: string | null
-            }
-          }
-      >
-    | { success: false; error: string }
-  >
-  'notes:delete': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'notes:delete-attachment': (
-    ...args: [{ noteId: string; filename: string }]
-  ) => Awaited<Promise<{ success: true }> | { success: false; error: string }>
-  'notes:delete-folder': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'notes:delete-property-definition': (
-    ...args: [{ name: string }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:delete-version': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'notes:ensure-property-definition': (
-    ...args: [{ name: string; type: 'select' | 'status' | 'multiselect' }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:exists': (...args: [string]) => Awaited<Promise<boolean>>
-  'notes:export-html': (
-    ...args: [
-      {
-        noteId: string
-        includeMetadata?: boolean | undefined
-        pageSize?: 'A4' | 'Letter' | 'Legal' | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<
-        | { success: false; error: string; path?: undefined }
-        | { success: true; path: string; error?: undefined }
-      >
-    | { success: false; error: string }
-  >
-  'notes:export-pdf': (
-    ...args: [
-      {
-        noteId: string
-        includeMetadata?: boolean | undefined
-        pageSize?: 'A4' | 'Letter' | 'Legal' | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<
-        | { success: false; error: string; path?: undefined }
-        | { success: true; path: string; error?: undefined }
-      >
-    | { success: false; error: string }
-  >
-  'notes:get': (...args: [string]) => Awaited<Promise<import('../vault/notes-crud').Note | null>>
-  'notes:get-all-positions': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      { success: false; error: string } | { success: boolean; positions: Record<string, number> }
-    >
-  >
-  'notes:get-by-path': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/notes-crud').Note | null>>
-  'notes:get-file': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/notes-crud').FileMetadata | null>>
-  'notes:get-folder-config': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/templates-api').FolderConfig | null>
-  >
-  'notes:get-folder-template': (...args: [string]) => Awaited<Promise<string | null>>
-  'notes:get-folders': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/templates-api').FolderInfo[]>>
-  'notes:get-links': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/notes-crud').NoteLinksResponse>>
-  'notes:get-local-only-count': (...args: []) => Awaited<Promise<{ count: number }>>
-  'notes:get-positions': (
-    ...args: [{ folderPath: string }]
-  ) => Awaited<
-    | { success: true; positions: { path: string; position: number; folderPath: string }[] }
-    | { success: false; error: string }
-  >
-  'notes:get-property-definitions': (...args: []) => Awaited<
-    Promise<
-      {
-        type: string
-        name: string
-        createdAt: string
-        options: string | null
-        defaultValue: string | null
-        color: string | null
-      }[]
-    >
-  >
-  'notes:get-tags': (
-    ...args: []
-  ) => Awaited<Promise<{ tag: string; color: string; count: number }[]>>
-  'notes:get-version': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/notes-versions').SnapshotDetail | null>>
-  'notes:get-versions': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/notes-versions').SnapshotListItem[]>>
-  'notes:import-files': (
-    ...args: [{ sourcePaths: string[]; targetFolder?: string | undefined }]
-  ) => Awaited<
-    Promise<import('../vault/notes-crud').ImportFilesResult> | { success: false; error: string }
-  >
-  'notes:list': (
-    ...args: [
-      {
-        folder?: string | undefined
-        tags?: string[] | undefined
-        sortBy?: 'title' | 'modified' | 'created' | 'position' | undefined
-        sortOrder?: 'asc' | 'desc' | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<Promise<import('../vault/notes-crud').NoteListResponse>>
-  'notes:list-attachments': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/attachments').AttachmentInfo[]>>
-  'notes:move': (
-    ...args: [{ id: string; newFolder: string }]
-  ) => Awaited<
-    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
-    | { success: false; error: string }
-  >
-  'notes:open-external': (...args: [string]) => Awaited<Promise<void>>
-  'notes:preview-by-title': (...args: [string]) => Awaited<
-    Promise<{
-      id: string
-      title: string
-      emoji: string | null
-      snippet: string | null
-      tags: { name: string; color: string }[]
-      createdAt: string
-    } | null>
-  >
-  'notes:remove-property-option': (
-    ...args: [{ propertyName: string; optionValue: string }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:rename': (
-    ...args: [{ id: string; newTitle: string }]
-  ) => Awaited<
-    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
-    | { success: false; error: string }
-  >
-  'notes:rename-folder': (
-    ...args: [{ oldPath: string; newPath: string }]
-  ) => Awaited<Promise<{ success: true }> | { success: false; error: string }>
-  'notes:rename-property-option': (
-    ...args: [{ propertyName: string; oldValue: string; newValue: string }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:reorder': (
-    ...args: [{ folderPath: string; notePaths: string[] }]
-  ) => Awaited<{ success: true } | { success: false; error: string }>
-  'notes:resolve-by-title': (...args: [string]) => Awaited<
-    Promise<{
-      id: string
-      path: string
-      title: string
-      fileType: import('../../../../../packages/shared/src/file-types').FileType
-    } | null>
-  >
-  'notes:restore-version': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; note: import('../vault/notes-crud').Note }
-    >
-  >
-  'notes:reveal-in-finder': (...args: [string]) => Awaited<Promise<void>>
-  'notes:set-folder-config': (
-    ...args: [
-      {
-        folderPath: string
-        config: {
-          icon?: string | null | undefined
-          template?: string | undefined
-          inherit?: boolean | undefined
-        }
-      }
-    ]
-  ) => Awaited<Promise<{ success: true }> | { success: false; error: string }>
-  'notes:set-local-only': (
-    ...args: [{ id: string; localOnly: boolean }]
-  ) => Awaited<
-    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
-    | { success: false; error: string }
-  >
-  'notes:show-import-dialog': (
-    ...args: []
-  ) => Awaited<Promise<{ canceled: boolean; filePaths: string[] }>>
-  'notes:update': (
-    ...args: [
-      {
-        id: string
-        title?: string | undefined
-        content?: string | undefined
-        tags?: string[] | undefined
-        frontmatter?: Record<string, unknown> | undefined
-        emoji?: string | null | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
-    | { success: false; error: string }
-  >
-  'notes:update-option-color': (
-    ...args: [{ propertyName: string; optionValue: string; newColor: string }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:update-property-definition': (
-    ...args: [
-      {
-        name: string
-        type?:
-          | 'number'
-          | 'date'
-          | 'text'
-          | 'select'
-          | 'checkbox'
-          | 'url'
-          | 'status'
-          | 'multiselect'
-          | undefined
-        options?: { value: string; color: string; default?: boolean | undefined }[] | undefined
-        defaultValue?: unknown
-        color?: string | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<
-        | { success: false; definition: null; error: string }
-        | {
-            success: true
-            definition:
-              | import('../../../../../packages/contracts/src/property-types').PropertyDefinition
-              | undefined
-            error?: undefined
-          }
-        | {
-            success: true
-            definition:
-              | {
-                  type: string
-                  name: string
-                  createdAt: string
-                  options: string | null
-                  defaultValue: string | null
-                  color: string | null
-                }
-              | undefined
-            error?: undefined
-          }
-      >
-    | { success: false; error: string }
-  >
-  'notes:upload-attachment': (
-    ...args: [{ noteId: string; filename: string; data: ArrayBuffer | number[] }]
-  ) => Awaited<Promise<import('../vault/attachments').AttachmentResult>>
-  'properties:get': (
-    ...args: [{ entityId: string }]
-  ) => Awaited<Promise<import('../database/queries/notes/property-queries').PropertyValue[]>>
-  'properties:rename': (
-    ...args: [{ entityId: string; oldName: string; newName: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/properties-api').RenamePropertyResponse
-    >
-  >
-  'properties:set': (
-    ...args: [{ entityId: string; properties: Record<string, unknown> }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/properties-api').SetPropertiesResponse
-    >
-  >
-  'quick-capture:get-clipboard': (...args: []) => Awaited<string>
-  'reminder:bulk-dismiss': (
-    ...args: [{ reminderIds: string[] }]
-  ) => Awaited<
-    Promise<{ success: false; error: string } | { success: boolean; dismissedCount: number }>
-  >
-  'reminder:count-pending': (...args: []) => Awaited<Promise<number>>
-  'reminder:create': (
-    ...args: [
-      | {
-          targetType: 'note'
-          targetId: string
-          remindAt: string
-          title?: string | undefined
-          note?: string | undefined
-        }
-      | {
-          targetType: 'journal'
-          targetId: string
-          remindAt: string
-          title?: string | undefined
-          note?: string | undefined
-        }
-      | {
-          targetType: 'highlight'
-          targetId: string
-          highlightText: string
-          highlightStart: number
-          highlightEnd: number
-          remindAt: string
-          title?: string | undefined
-          note?: string | undefined
-        }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
-        }
-    >
-  >
-  'reminder:delete': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  >
-  'reminder:dismiss': (...args: [string]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; reminder: null; error: string }
-      | {
-          success: boolean
-          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
-          error?: undefined
-        }
-    >
-  >
-  'reminder:get': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget | null>
-  >
-  'reminder:get-due': (
-    ...args: []
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget[]>
-  >
-  'reminder:get-for-target': (
-    ...args: [{ targetType: 'note' | 'journal' | 'highlight'; targetId: string }]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/reminders-api').Reminder[]>>
-  'reminder:get-upcoming': (...args: [number | undefined]) => Awaited<
-    Promise<{
-      reminders: import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget[]
-      total: number
-      hasMore: boolean
-    }>
-  >
-  'reminder:list': (
-    ...args: [
-      {
-        targetType?: 'note' | 'journal' | 'highlight' | undefined
-        targetId?: string | undefined
-        status?:
-          | 'pending'
-          | 'triggered'
-          | 'dismissed'
-          | 'snoozed'
-          | ('pending' | 'triggered' | 'dismissed' | 'snoozed')[]
-          | undefined
-        fromDate?: string | undefined
-        toDate?: string | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<{
-      reminders: import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget[]
-      total: number
-      hasMore: boolean
-    }>
-  >
-  'reminder:snooze': (...args: [{ id: string; snoozeUntil: string }]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; reminder: null; error: string }
-      | {
-          success: boolean
-          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
-          error?: undefined
-        }
-    >
-  >
-  'reminder:update': (
-    ...args: [
-      {
-        id: string
-        remindAt?: string | undefined
-        title?: string | null | undefined
-        note?: string | null | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; reminder: null; error: string }
-      | {
-          success: boolean
-          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
-          error?: undefined
-        }
-    >
-  >
-  'saved-filters:create': (
-    ...args: [
-      {
-        name: string
-        config: {
-          filters: {
-            search?: string | undefined
-            projectIds?: string[] | undefined
-            priorities?: ('urgent' | 'high' | 'medium' | 'low' | 'none')[] | undefined
-            dueDate?:
-              | {
-                  type:
-                    | 'any'
-                    | 'custom'
-                    | 'none'
-                    | 'overdue'
-                    | 'today'
-                    | 'tomorrow'
-                    | 'this-week'
-                    | 'next-week'
-                    | 'this-month'
-                  customStart?: string | null | undefined
-                  customEnd?: string | null | undefined
-                }
-              | undefined
-            statusIds?: string[] | undefined
-            completion?: 'active' | 'completed' | 'all' | undefined
-            repeatType?: 'all' | 'repeating' | 'one-time' | undefined
-            hasTime?: 'all' | 'with-time' | 'without-time' | undefined
-          }
-          sort?:
-            | {
-                field: 'title' | 'createdAt' | 'priority' | 'dueDate' | 'completedAt' | 'project'
-                direction: 'asc' | 'desc'
-              }
-            | undefined
-          starred?: boolean | undefined
-        }
-      }
-    ]
-  ) => Awaited<
-    Promise<{
-      success: boolean
-      savedFilter: import('../../../../../packages/contracts/src/saved-filters-api').SavedFilter
-    }>
-  >
-  'saved-filters:delete': (
-    ...args: [{ id: string }]
-  ) => Awaited<
-    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  >
-  'saved-filters:list': (...args: []) => Awaited<
-    Promise<{
-      savedFilters: import('../../../../../packages/contracts/src/saved-filters-api').SavedFilter[]
-    }>
-  >
-  'saved-filters:reorder': (
-    ...args: [{ ids: string[]; positions: number[] }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'saved-filters:update': (
-    ...args: [
-      {
-        id: string
-        name?: string | undefined
-        config?:
-          | {
-              filters: {
-                search?: string | undefined
-                projectIds?: string[] | undefined
-                priorities?: ('urgent' | 'high' | 'medium' | 'low' | 'none')[] | undefined
-                dueDate?:
-                  | {
-                      type:
-                        | 'any'
-                        | 'custom'
-                        | 'none'
-                        | 'overdue'
-                        | 'today'
-                        | 'tomorrow'
-                        | 'this-week'
-                        | 'next-week'
-                        | 'this-month'
-                      customStart?: string | null | undefined
-                      customEnd?: string | null | undefined
-                    }
-                  | undefined
-                statusIds?: string[] | undefined
-                completion?: 'active' | 'completed' | 'all' | undefined
-                repeatType?: 'all' | 'repeating' | 'one-time' | undefined
-                hasTime?: 'all' | 'with-time' | 'without-time' | undefined
-              }
-              sort?:
-                | {
-                    field:
-                      | 'title'
-                      | 'createdAt'
-                      | 'priority'
-                      | 'dueDate'
-                      | 'completedAt'
-                      | 'project'
-                    direction: 'asc' | 'desc'
-                  }
-                | undefined
-              starred?: boolean | undefined
-            }
-          | undefined
-        position?: number | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: boolean; savedFilter: null; error: string }
-      | {
-          success: boolean
-          savedFilter:
-            | import('../../../../../packages/contracts/src/saved-filters-api').SavedFilter
-            | null
-          error?: undefined
-        }
-    >
-  >
-  'search:add-reason': (
-    ...args: [
-      {
-        itemId: string
-        itemType: 'note' | 'journal' | 'task' | 'inbox'
-        itemTitle: string
-        searchQuery: string
-        itemIcon?: string | null | undefined
-      }
-    ]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchReason>>
-  'search:clear-reasons': (...args: []) => Awaited<Promise<{ cleared: true }>>
-  'search:get-all-tags': (...args: []) => Awaited<Promise<string[]>>
-  'search:get-reasons': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchReason[]>>
-  'search:get-stats': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchStats>>
-  'search:query': (
-    ...args: [
-      {
-        text: string
-        types?: ('note' | 'journal' | 'task' | 'inbox')[] | undefined
-        tags?: string[] | undefined
-        dateRange?: { from: string; to: string } | null | undefined
-        projectId?: string | null | undefined
-        folderPath?: string | null | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchResponse>>
-  'search:quick': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/search-api').QuickSearchResponse>
-  >
-  'search:rebuild-index': (...args: []) => Awaited<
-    Promise<
-      | {
-          notes: number
-          tasks: number
-          inbox: number
-          durationMs: number
-          started: true
-          error?: undefined
-        }
-      | { started: false; error: string }
-    >
-  >
-  'settings:downloadVoiceModel': (
-    ...args: []
-  ) => Awaited<
-    Promise<{ success: boolean; error?: undefined } | { success: boolean; error: string }>
-  >
-  'settings:get': (...args: [string]) => Awaited<string | null>
-  'settings:getAIModelStatus': (
-    ...args: []
-  ) => Awaited<Promise<import('./settings-handlers').AIModelStatus>>
-  'settings:getAISettings': (...args: []) => Awaited<import('./settings-handlers').AISettings>
-  'settings:getBackupSettings': (...args: []) => Awaited<{
-    autoBackup: boolean
-    frequencyHours: 1 | 6 | 12 | 24
-    maxBackups: number
-    lastBackupAt: string | null
-  }>
-  'settings:getCalendarGoogleSettings': (...args: []) => Awaited<{
-    defaultTargetCalendarId: string | null
-    onboardingCompleted: boolean
-    promoteConfirmDismissed: boolean
-  }>
-  'settings:getEditorSettings': (...args: []) => Awaited<{
-    width: 'medium' | 'narrow' | 'wide'
-    spellCheck: boolean
-    autoSaveDelay: number
-    showWordCount: boolean
-    toolbarMode: 'floating' | 'sticky'
-  }>
-  'settings:getGeneralSettings': (...args: []) => Awaited<{
-    theme: 'light' | 'dark' | 'white' | 'system'
-    fontSize: 'small' | 'medium' | 'large'
-    fontFamily: 'system' | 'serif' | 'sans-serif' | 'monospace' | 'gelasio' | 'geist' | 'inter'
-    accentColor: string
-    startOnBoot: boolean
-    language: string
-    onboardingCompleted: boolean
-    createInSelectedFolder: boolean
-    clockFormat: '12h' | '24h'
-  }>
-  'settings:getGraphSettings': (...args: []) => Awaited<{
-    layout: 'forceatlas2' | 'circular' | 'random'
-    showLabels: boolean
-    showEdgeLabels: boolean
-    animateLayout: boolean
-    showTagEdges: boolean
-  }>
-  'settings:getJournalSettings': (...args: []) => Awaited<{
-    defaultTemplate: string | null
-    showSchedule: boolean
-    showTasks: boolean
-    showAIConnections: boolean
-    showStatsFooter: boolean
-  }>
-  'settings:getKeyboardSettings': (...args: []) => Awaited<{
-    overrides: Record<
-      string,
-      {
-        key: string
-        modifiers: {
-          meta?: boolean | undefined
-          ctrl?: boolean | undefined
-          shift?: boolean | undefined
-          alt?: boolean | undefined
-        }
-      }
-    >
-    globalCapture: {
-      key: string
-      modifiers: {
-        meta?: boolean | undefined
-        ctrl?: boolean | undefined
-        shift?: boolean | undefined
-        alt?: boolean | undefined
-      }
-    } | null
-  }>
-  'settings:getNoteEditorSettings': (
-    ...args: []
-  ) => Awaited<import('./settings-handlers').NoteEditorSettings>
-  'settings:getSyncSettings': (...args: []) => Awaited<{ enabled: boolean; autoSync: boolean }>
-  'settings:getTabSettings': (...args: []) => Awaited<import('./settings-handlers').TabSettings>
-  'settings:getTaskSettings': (...args: []) => Awaited<{
-    defaultProjectId: string | null
-    defaultSortOrder: 'createdAt' | 'priority' | 'dueDate' | 'manual'
-    weekStartDay: 'sunday' | 'monday'
-    staleInboxDays: number
-  }>
-  'settings:getVoiceModelStatus': (
-    ...args: []
-  ) => Awaited<import('../inbox/voice-model').VoiceModelStatus>
-  'settings:getVoiceRecordingReadiness': (
-    ...args: []
-  ) => Awaited<Promise<import('../inbox/voice-transcription-settings').VoiceRecordingReadiness>>
-  'settings:getVoiceTranscriptionOpenAIKeyStatus': (
-    ...args: []
-  ) => Awaited<Promise<import('./settings-handlers').VoiceTranscriptionOpenAIKeyStatus>>
-  'settings:getVoiceTranscriptionSettings': (
-    ...args: []
-  ) => Awaited<{ provider: 'local' | 'openai' }>
-  'settings:loadAIModel': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; message: string; error?: undefined }
-      | { success: boolean; error: string; message?: undefined }
-      | { success: boolean; message?: undefined; error?: undefined }
-    >
-  >
-  'settings:registerGlobalCapture': (
-    ...args: []
-  ) => Awaited<Promise<import('./settings-handlers').GlobalCaptureResult>>
-  'settings:reindexEmbeddings': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; computed: number; skipped: number; error?: string | undefined }
-    >
-  >
-  'settings:resetKeyboardSettings': (
-    ...args: []
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:set': (
-    ...args: [{ key: string; value: string }]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:setAISettings': (
-    ...args: [Partial<import('./settings-handlers').AISettings>]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:setBackupSettings': (
-    ...args: [
-      Partial<{
-        autoBackup: boolean
-        frequencyHours: 1 | 6 | 12 | 24
-        maxBackups: number
-        lastBackupAt: string | null
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setCalendarGoogleSettings': (
-    ...args: [
-      Partial<{
-        defaultTargetCalendarId: string | null
-        onboardingCompleted: boolean
-        promoteConfirmDismissed: boolean
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setEditorSettings': (
-    ...args: [
-      Partial<{
-        width: 'medium' | 'narrow' | 'wide'
-        spellCheck: boolean
-        autoSaveDelay: number
-        showWordCount: boolean
-        toolbarMode: 'floating' | 'sticky'
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setGeneralSettings': (
-    ...args: [
-      Partial<{
-        theme: 'light' | 'dark' | 'white' | 'system'
-        fontSize: 'small' | 'medium' | 'large'
-        fontFamily: 'system' | 'serif' | 'sans-serif' | 'monospace' | 'gelasio' | 'geist' | 'inter'
-        accentColor: string
-        startOnBoot: boolean
-        language: string
-        onboardingCompleted: boolean
-        createInSelectedFolder: boolean
-        clockFormat: '12h' | '24h'
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setGraphSettings': (
-    ...args: [
-      Partial<{
-        layout: 'forceatlas2' | 'circular' | 'random'
-        showLabels: boolean
-        showEdgeLabels: boolean
-        animateLayout: boolean
-        showTagEdges: boolean
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setJournalSettings': (
-    ...args: [Partial<import('./settings-handlers').JournalSettings>]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:setKeyboardSettings': (
-    ...args: [
-      Partial<{
-        overrides: Record<
-          string,
-          {
-            key: string
-            modifiers: {
-              meta?: boolean | undefined
-              ctrl?: boolean | undefined
-              shift?: boolean | undefined
-              alt?: boolean | undefined
-            }
-          }
-        >
-        globalCapture: {
-          key: string
-          modifiers: {
-            meta?: boolean | undefined
-            ctrl?: boolean | undefined
-            shift?: boolean | undefined
-            alt?: boolean | undefined
-          }
-        } | null
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setNoteEditorSettings': (
-    ...args: [Partial<import('./settings-handlers').NoteEditorSettings>]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:setSyncSettings': (
-    ...args: [Partial<{ enabled: boolean; autoSync: boolean }>]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setTabSettings': (
-    ...args: [Partial<import('./settings-handlers').TabSettings>]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:setTaskSettings': (
-    ...args: [
-      Partial<{
-        defaultProjectId: string | null
-        defaultSortOrder: 'createdAt' | 'priority' | 'dueDate' | 'manual'
-        weekStartDay: 'sunday' | 'monday'
-        staleInboxDays: number
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setVoiceTranscriptionOpenAIKey': (
-    ...args: [{ apiKey: string }]
-  ) => Awaited<
-    Promise<{ success: boolean; error?: undefined } | { success: boolean; error: string }>
-  >
-  'settings:setVoiceTranscriptionSettings': (
-    ...args: [Partial<{ provider: 'local' | 'openai' }>]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'sync:approve-linking': (
-    ...args: [{ sessionId: string }]
-  ) => Awaited<
-    | Promise<import('../../../../../packages/contracts/src/ipc-devices').ApproveLinkingResult>
-    | { success: false; error: string }
-  >
-  'sync:check-device-status': (...args: []) => Awaited<Promise<{ status: string }>>
-  'sync:complete-linking-qr': (
-    ...args: [{ sessionId: string }]
-  ) => Awaited<
-    | Promise<import('../../../../../packages/contracts/src/ipc-devices').CompleteLinkingQrResult>
-    | { success: false; error: string }
-  >
-  'sync:confirm-recovery-phrase': (
-    ...args: [{ confirmed: boolean }]
-  ) => Awaited<Promise<{ success: boolean }> | { success: false; error: string }>
-  'sync:download-attachment': (
-    ...args: [{ attachmentId: string; targetPath?: string | undefined }]
-  ) => Awaited<
-    | Promise<
-        | { success: boolean; error: string; filePath?: undefined }
-        | { success: boolean; filePath: string; error?: undefined }
-      >
-    | { success: false; error: string }
-  >
-  'sync:emergency-wipe': (...args: []) => Awaited<Promise<{ success: boolean }>>
-  'sync:generate-linking-qr': (
-    ...args: []
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/ipc-devices').GenerateLinkingQrResult>
-  >
-  'sync:get-devices': (...args: []) => Awaited<
-    Promise<{
-      devices: {
-        id: string
-        name: string
-        platform: 'macos' | 'windows' | 'linux' | 'ios' | 'android'
-        linkedAt: number
-        lastSyncAt: number | undefined
-        isCurrentDevice: boolean
-      }[]
-      email: string | undefined
-    }>
-  >
-  'sync:get-download-progress': (
-    ...args: [{ attachmentId: string }]
-  ) => Awaited<
-    | { progress: number; downloadedChunks: number; totalChunks: number; status: 'downloading' }
-    | null
-    | { success: false; error: string }
-  >
-  'sync:get-history': (
-    ...args: [{ limit?: number | undefined; offset?: number | undefined }]
-  ) => Awaited<
-    | {
-        entries: {
-          id: string
-          type: 'error' | 'push' | 'pull'
-          itemCount: number
-          direction: string | undefined
-          details: unknown
-          durationMs: number | undefined
-          createdAt: number
-        }[]
-        total: number
-      }
-    | { success: false; error: string }
-  >
-  'sync:get-linking-sas': (
-    ...args: [{ sessionId: string }]
-  ) => Awaited<
-    | Promise<{ verificationCode?: string | undefined; error?: string | undefined }>
-    | { success: false; error: string }
-  >
-  'sync:get-quarantined-items': (
-    ...args: []
-  ) => Awaited<import('../../../../../packages/contracts/src/ipc-events').QuarantinedItemInfo[]>
-  'sync:get-queue-size': (...args: []) => Awaited<{ pending: number; failed: number }>
-  'sync:get-recovery-phrase': (...args: []) => Awaited<string | null>
-  'sync:get-status': (
-    ...args: []
-  ) => Awaited<
-    | import('../../../../../packages/contracts/src/ipc-sync-ops').GetSyncStatusResult
-    | { status: string; pendingCount: number }
-  >
-  'sync:get-storage-breakdown': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      import('../../../../../packages/contracts/src/ipc-sync-ops').StorageBreakdownResult | null
-    >
-  >
-  'sync:get-synced-settings': (...args: []) => Awaited<{
-    general?:
-      | {
-          theme?: 'light' | 'dark' | 'white' | 'system' | undefined
-          fontSize?: 'small' | 'medium' | 'large' | undefined
-          fontFamily?:
-            | 'system'
-            | 'serif'
-            | 'sans-serif'
-            | 'monospace'
-            | 'gelasio'
-            | 'geist'
-            | 'inter'
-            | undefined
-          accentColor?: string | undefined
-          startOnBoot?: boolean | undefined
-          language?: string | undefined
-          createInSelectedFolder?: boolean | undefined
-        }
-      | undefined
-    editor?:
-      | {
-          width?: 'medium' | 'narrow' | 'wide' | undefined
-          spellCheck?: boolean | undefined
-          autoSaveDelay?: number | undefined
-          showWordCount?: boolean | undefined
-          toolbarMode?: 'floating' | 'sticky' | undefined
-        }
-      | undefined
-    tasks?:
-      | {
-          defaultProjectId?: string | null | undefined
-          defaultSortOrder?: 'createdAt' | 'priority' | 'dueDate' | 'manual' | undefined
-          weekStartDay?: 'sunday' | 'monday' | undefined
-          staleInboxDays?: number | undefined
-          showCompleted?: boolean | undefined
-          sortBy?: string | undefined
-        }
-      | undefined
-    keyboard?: { overrides?: Record<string, unknown> | undefined } | undefined
-    notes?:
-      | {
-          defaultFolder?: string | undefined
-          editorFontSize?: number | undefined
-          spellCheck?: boolean | undefined
-        }
-      | undefined
-    sync?: { autoSync?: boolean | undefined; syncIntervalMinutes?: number | undefined } | undefined
-  } | null>
-  'sync:get-upload-progress': (
-    ...args: [{ sessionId: string }]
-  ) => Awaited<
-    | { progress: number; uploadedChunks: number; totalChunks: number; status: 'uploading' }
-    | null
-    | { success: false; error: string }
-  >
-  'sync:link-via-qr': (
-    ...args: [{ qrData: string; oauthToken?: string | undefined; provider?: string | undefined }]
-  ) => Awaited<
-    | Promise<import('../../../../../packages/contracts/src/ipc-devices').LinkViaQrResult>
-    | { success: false; error: string }
-  >
-  'sync:link-via-recovery': (
-    ...args: [{ recoveryPhrase: string }]
-  ) => Awaited<
-    | Promise<
-        | { success: boolean; error: string; deviceId?: undefined }
-        | { success: boolean; deviceId: string; error?: undefined }
-      >
-    | { success: false; error: string }
-  >
-  'sync:logout': (
-    ...args: []
-  ) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean }>>
-  'sync:pause': (...args: []) => Awaited<{ success: boolean; wasPaused: boolean }>
-  'sync:remove-device': (
-    ...args: [{ deviceId: string }]
-  ) => Awaited<
-    | Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-    | { success: false; error: string }
-  >
-  'sync:rename-device': (
-    ...args: [{ deviceId: string; newName: string }]
-  ) => Awaited<
-    | Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-    | { success: false; error: string }
-  >
-  'sync:resume': (...args: []) => Awaited<{ success: boolean; pendingCount: number }>
-  'sync:setup-first-device': (
-    ...args: [{ oauthToken: string; provider: 'google'; state: string }]
-  ) => Awaited<
-    | Promise<
-        | {
-            success: boolean
-            needsRecoverySetup: boolean
-            deviceId: string
-            needsRecoveryInput?: undefined
-          }
-        | {
-            success: boolean
-            needsRecoverySetup: boolean
-            needsRecoveryInput: boolean
-            deviceId?: undefined
-          }
-      >
-    | { success: false; error: string }
-  >
-  'sync:setup-new-account': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      | { success: boolean; error: string; deviceId?: undefined }
-      | { success: boolean; deviceId: string; error?: undefined }
-    >
-  >
-  'sync:trigger-sync': (
-    ...args: []
-  ) => Awaited<Promise<{ success: boolean } | { success: boolean; error: string }>>
-  'sync:update-synced-setting': (
-    ...args: [{ fieldPath: string; value: unknown }]
-  ) => Awaited<
-    | { success: boolean; error: string }
-    | { success: boolean; error?: undefined }
-    | { success: false; error: string }
-  >
-  'sync:upload-attachment': (
-    ...args: [{ noteId: string; filePath: string }]
-  ) => Awaited<
-    | Promise<
-        | { success: boolean; error: string; attachmentId?: undefined; sessionId?: undefined }
-        | { success: boolean; attachmentId: string; sessionId: string; error?: undefined }
-      >
-    | { success: false; error: string }
-  >
-  'tags:delete': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').DeleteTagResponse
-    >
-  >
-  'tags:get-all-with-counts': (
-    ...args: []
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/tags-api').GetAllWithCountsResponse>
-  >
-  'tags:get-notes-by-tag': (
-    ...args: [
-      {
-        tag: string
-        sortBy?: 'title' | 'modified' | 'created' | undefined
-        sortOrder?: 'asc' | 'desc' | undefined
-        includeDescendants?: boolean | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/tags-api').GetNotesByTagResponse>
-  >
-  'tags:merge': (
-    ...args: [{ source: string; target: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').MergeTagResponse
-    >
-  >
-  'tags:pin-note-to-tag': (
-    ...args: [{ noteId: string; tag: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
-    >
-  >
-  'tags:remove-from-note': (
-    ...args: [{ noteId: string; tag: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
-    >
-  >
-  'tags:rename': (
-    ...args: [{ oldName: string; newName: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').RenameTagResponse
-    >
-  >
-  'tags:unpin-note-from-tag': (
-    ...args: [{ noteId: string; tag: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
-    >
-  >
-  'tags:update-color': (
-    ...args: [{ tag: string; color: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
-    >
-  >
-  'tasks:archive': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; error: string }
-      | { success: boolean; error?: undefined }
-    >
-  >
-  'tasks:bulk-archive': (
-    ...args: [{ ids: string[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
-  'tasks:bulk-complete': (
-    ...args: [{ ids: string[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
-  'tasks:bulk-delete': (
-    ...args: [{ ids: string[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
-  'tasks:bulk-move': (
-    ...args: [{ ids: string[]; projectId: string }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
-  'tasks:complete': (...args: [{ id: string; completedAt?: string | undefined }]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:convert-to-subtask': (...args: [{ taskId: string; parentId: string }]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:convert-to-task': (...args: [string]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:create': (
-    ...args: [
-      {
-        projectId: string
-        title: string
-        description?: string | null | undefined
-        priority?: number | undefined
-        statusId?: string | null | undefined
-        parentId?: string | null | undefined
-        dueDate?: string | null | undefined
-        dueTime?: string | null | undefined
-        startDate?: string | null | undefined
-        isRepeating?: boolean | undefined
-        repeatConfig?:
-          | {
-              frequency: 'daily' | 'weekly' | 'monthly' | 'yearly'
-              endType: 'never' | 'date' | 'count'
-              createdAt: string
-              interval?: number | undefined
-              daysOfWeek?: number[] | undefined
-              monthlyType?: 'dayOfMonth' | 'weekPattern' | undefined
-              dayOfMonth?: number | undefined
-              weekOfMonth?: number | undefined
-              dayOfWeekForMonth?: number | undefined
-              endDate?: string | null | undefined
-              endCount?: number | undefined
-              completedCount?: number | undefined
-            }
-          | null
-          | undefined
-        repeatFrom?: 'due' | 'completion' | null | undefined
-        tags?: string[] | undefined
-        linkedNoteIds?: string[] | undefined
-        sourceNoteId?: string | null | undefined
-        position?: number | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: import('../../../../../packages/domain-tasks/src/types').Task }
-    >
-  >
-  'tasks:delete': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:duplicate': (...args: [string]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:get': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Task | null>>
-  'tasks:get-linked-tasks': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Task[]>>
-  'tasks:get-overdue': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListEnvelope>>
-  'tasks:get-stats': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').TaskStats>>
-  'tasks:get-subtasks': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Task[]>>
-  'tasks:get-tags': (...args: []) => Awaited<Promise<{ tag: string; count: number }[]>>
-  'tasks:get-today': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListEnvelope>>
-  'tasks:get-upcoming': (
-    ...args: [{ days?: number | undefined }]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListEnvelope>>
-  'tasks:list': (
-    ...args: [
-      {
-        projectId?: string | undefined
-        statusId?: string | null | undefined
-        parentId?: string | null | undefined
-        includeCompleted?: boolean | undefined
-        includeArchived?: boolean | undefined
-        dueBefore?: string | undefined
-        dueAfter?: string | undefined
-        tags?: string[] | undefined
-        search?: string | undefined
-        sortBy?: 'modified' | 'created' | 'position' | 'priority' | 'dueDate' | undefined
-        sortOrder?: 'asc' | 'desc' | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListResult>>
-  'tasks:move': (
-    ...args: [
-      {
-        taskId: string
-        position: number
-        targetProjectId?: string | undefined
-        targetStatusId?: string | null | undefined
-        targetParentId?: string | null | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:project-archive': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; error: string }
-      | { success: boolean; error?: undefined }
-    >
-  >
-  'tasks:project-create': (
-    ...args: [
-      {
-        name: string
-        description?: string | null | undefined
-        color?: string | undefined
-        icon?: string | null | undefined
-        statuses?:
-          | {
-              name: string
-              type: 'todo' | 'in_progress' | 'done'
-              order: number
-              color?: string | undefined
-            }[]
-          | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          project: import('../../../../../packages/domain-tasks/src/types').ProjectWithStatuses
-        }
-    >
-  >
-  'tasks:project-delete': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:project-get': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      import('../../../../../packages/domain-tasks/src/types').ProjectWithStatuses | undefined
-    >
-  >
-  'tasks:project-list': (...args: []) => Awaited<
-    Promise<{
-      projects: import('../../../../../packages/domain-tasks/src/types').ProjectWithStats[]
-    }>
-  >
-  'tasks:project-reorder': (
-    ...args: [{ projectIds: string[]; positions: number[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:project-update': (
-    ...args: [
-      {
-        id: string
-        name?: string | undefined
-        description?: string | null | undefined
-        color?: string | undefined
-        icon?: string | null | undefined
-        statuses?:
-          | {
-              name: string
-              type: 'todo' | 'in_progress' | 'done'
-              order: number
-              id?: string | undefined
-              color?: string | undefined
-            }[]
-          | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; project: null; error: string }
-      | {
-          success: boolean
-          project: import('../../../../../packages/domain-tasks/src/types').ProjectWithStatuses
-          error?: undefined
-        }
-    >
-  >
-  'tasks:reorder': (
-    ...args: [{ taskIds: string[]; positions: number[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:seed-demo': (...args: []) => Awaited<Promise<{ success: boolean; message: string }>>
-  'tasks:seed-performance-test': (
-    ...args: []
-  ) => Awaited<Promise<{ success: boolean; message: string }>>
-  'tasks:status-create': (
-    ...args: [
-      { projectId: string; name: string; color?: string | undefined; isDone?: boolean | undefined }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          status: import('../../../../../packages/domain-tasks/src/types').Status
-        }
-    >
-  >
-  'tasks:status-delete': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:status-list': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Status[]>>
-  'tasks:status-reorder': (
-    ...args: [{ statusIds: string[]; positions: number[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:status-update': (
-    ...args: [
-      {
-        id: string
-        name?: string | undefined
-        color?: string | undefined
-        position?: number | undefined
-        isDefault?: boolean | undefined
-        isDone?: boolean | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; error: string; status?: undefined }
-      | {
-          success: boolean
-          status: import('../../../../../packages/domain-tasks/src/types').Status
-          error?: undefined
-        }
-    >
-  >
-  'tasks:unarchive': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; error: string }
-      | { success: boolean; error?: undefined }
-    >
-  >
-  'tasks:uncomplete': (...args: [string]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:update': (
-    ...args: [
-      {
-        id: string
-        title?: string | undefined
-        description?: string | null | undefined
-        priority?: number | undefined
-        projectId?: string | undefined
-        statusId?: string | null | undefined
-        parentId?: string | null | undefined
-        dueDate?: string | null | undefined
-        dueTime?: string | null | undefined
-        startDate?: string | null | undefined
-        isRepeating?: boolean | undefined
-        repeatConfig?:
-          | {
-              frequency: 'daily' | 'weekly' | 'monthly' | 'yearly'
-              endType: 'never' | 'date' | 'count'
-              createdAt: string
-              interval?: number | undefined
-              daysOfWeek?: number[] | undefined
-              monthlyType?: 'dayOfMonth' | 'weekPattern' | undefined
-              dayOfMonth?: number | undefined
-              weekOfMonth?: number | undefined
-              dayOfWeekForMonth?: number | undefined
-              endDate?: string | null | undefined
-              endCount?: number | undefined
-              completedCount?: number | undefined
-            }
-          | null
-          | undefined
-        repeatFrom?: 'due' | 'completion' | null | undefined
-        tags?: string[] | undefined
-        linkedNoteIds?: string[] | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'templates:create': (
-    ...args: [
-      {
-        name: string
-        description?: string | undefined
-        icon?: string | null | undefined
-        tags?: string[] | undefined
-        properties?:
-          | {
-              name: string
-              type:
-                | 'number'
-                | 'date'
-                | 'text'
-                | 'select'
-                | 'checkbox'
-                | 'url'
-                | 'multiselect'
-                | 'rating'
-              value: unknown
-              options?: string[] | undefined
-            }[]
-          | undefined
-        content?: string | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          template: import('../../../../../packages/contracts/src/templates-api').Template
-        }
-    >
-  >
-  'templates:delete': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'templates:duplicate': (...args: [{ id: string; newName: string }]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          template: import('../../../../../packages/contracts/src/templates-api').Template
-        }
-    >
-  >
-  'templates:get': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/templates-api').Template | null>
-  >
-  'templates:list': (...args: []) => Awaited<
-    Promise<{
-      templates: import('../../../../../packages/contracts/src/templates-api').TemplateListItem[]
-    }>
-  >
-  'templates:update': (
-    ...args: [
-      {
-        id: string
-        name?: string | undefined
-        description?: string | undefined
-        icon?: string | null | undefined
-        tags?: string[] | undefined
-        properties?:
-          | {
-              name: string
-              type:
-                | 'number'
-                | 'date'
-                | 'text'
-                | 'select'
-                | 'checkbox'
-                | 'url'
-                | 'multiselect'
-                | 'rating'
-              value: unknown
-              options?: string[] | undefined
-            }[]
-          | undefined
-        content?: string | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          template: import('../../../../../packages/contracts/src/templates-api').Template
-        }
-    >
-  >
-  'vault:close': (...args: []) => Awaited<Promise<void>>
-  'vault:get-all': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').GetVaultsResponse>>
-  'vault:get-config': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').VaultConfig>>
-  'vault:get-status': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').VaultStatus>>
-  'vault:reindex': (...args: []) => Awaited<Promise<void>>
-  'vault:remove': (...args: [string]) => Awaited<Promise<void>>
-  'vault:reveal': (...args: []) => Awaited<Promise<void>>
-  'vault:select': (
-    ...args: [{ path?: string | undefined }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/vault-api').SelectVaultResponse>
-  >
-  'vault:switch': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/vault-api').SelectVaultResponse>
-  >
-  'vault:update-config': (
-    ...args: [
-      {
-        excludePatterns?: string[] | undefined
-        defaultNoteFolder?: string | undefined
-        journalFolder?: string | undefined
-        attachmentsFolder?: string | undefined
-      }
-    ]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').VaultConfig>>
+  "account:getInfo": (...args: []) => Awaited<import("./account-handlers").AccountInfo>
+  "account:getRecoveryKey": (...args: []) => Awaited<Promise<{ success: boolean; error: string; key?: undefined; } | { success: boolean; key: string; error?: undefined; }>>
+  "account:signOut": (...args: []) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean; }>>
+  "ai-inline:get-server-port": (...args: []) => Awaited<number | null>
+  "ai-inline:get-settings": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ai-inline-channels").AIInlineSettings>
+  "ai-inline:set-settings": (...args: [Partial<import("../../../../../packages/contracts/src/ai-inline-channels").AIInlineSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "ai-inline:start-server": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; port?: undefined; } | { success: boolean; port: number; error?: undefined; }>>
+  "ai-inline:stop-server": (...args: []) => Awaited<Promise<{ success: boolean; }>>
+  "auth:init-oauth": (...args: [{ provider: "google"; }]) => Awaited<Promise<{ state: string; }> | { success: false; error: string }>
+  "auth:refresh-token": (...args: []) => Awaited<Promise<{ success: boolean; error: string | undefined; }>>
+  "auth:request-otp": (...args: [{ email: string; }]) => Awaited<Promise<unknown> | { success: false; error: string }>
+  "auth:resend-otp": (...args: [{ email: string; }]) => Awaited<Promise<unknown> | { success: false; error: string }>
+  "auth:verify-otp": (...args: [{ email: string; code: string; }]) => Awaited<Promise<{ success: boolean; isNewUser: boolean; needsSetup: boolean; needsRecoveryInput: boolean; }> | { success: false; error: string }>
+  "bookmarks:bulk-create": (...args: [{ items: { itemType: string; itemId: string; }[]; }]) => Awaited<Promise<{ success: boolean; createdCount: number; }>>
+  "bookmarks:bulk-delete": (...args: [{ bookmarkIds: string[]; }]) => Awaited<Promise<{ success: boolean; deletedCount: number; }>>
+  "bookmarks:create": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<{ success: boolean; bookmark: null; error: string; } | { success: boolean; bookmark: { id: string; createdAt: string; position: number; itemType: string; itemId: string; }; error?: undefined; }>>
+  "bookmarks:delete": (...args: [string]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "bookmarks:get": (...args: [string]) => Awaited<Promise<{ id: string; createdAt: string; position: number; itemType: string; itemId: string; } | null>>
+  "bookmarks:get-by-item": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<{ id: string; createdAt: string; position: number; itemType: string; itemId: string; } | null>>
+  "bookmarks:is-bookmarked": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<boolean>>
+  "bookmarks:list": (...args: [{ itemType?: string | undefined; sortBy?: "createdAt" | "position" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/bookmarks-api").BookmarkListResponse>>
+  "bookmarks:list-by-type": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/bookmarks-api").BookmarkListResponse>>
+  "bookmarks:reorder": (...args: [{ bookmarkIds: string[]; }]) => Awaited<Promise<{ success: boolean; }>>
+  "bookmarks:toggle": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<{ success: boolean; isBookmarked: boolean; bookmark: { id: string; createdAt: string; position: number; itemType: string; itemId: string; } | null; }>>
+  "calendar:connect-provider": (...args: [{ provider: string; accountId?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarProviderMutationResponse>>
+  "calendar:create-event": (...args: [{ title: string; startAt: string; description?: string | null | undefined; location?: string | null | undefined; endAt?: string | null | undefined; timezone?: string | undefined; isAllDay?: boolean | undefined; recurrenceRule?: Record<string, unknown> | null | undefined; recurrenceExceptions?: string[] | null | undefined; targetCalendarId?: string | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarEventMutationResponse>>
+  "calendar:delete-event": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarDeleteResponse>>
+  "calendar:disconnect-provider": (...args: [{ provider: string; accountId?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarProviderMutationResponse>>
+  "calendar:get-event": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarEventRecord | null>>
+  "calendar:get-provider-status": (...args: [{ provider: string; accountId?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarProviderStatus>>
+  "calendar:get-range": (...args: [{ startAt: string; endAt: string; includeUnselectedSources?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarRangeResponse>>
+  "calendar:list-events": (...args: [{ includeArchived?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarEventListResponse>>
+  "calendar:list-google-calendars": (...args: [Record<string, never> | undefined]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").ListGoogleCalendarsResponse>>
+  "calendar:list-sources": (...args: [{ provider?: string | undefined; kind?: "calendar" | "account" | undefined; selectedOnly?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarSourceListResponse>>
+  "calendar:promote-external-event": (...args: [{ externalEventId: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").PromoteExternalEventResponse>>
+  "calendar:refresh-provider": (...args: [{ provider: string; accountId?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarProviderMutationResponse>>
+  "calendar:retry-google-source-sync": (...args: [{ sourceId: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").RetryCalendarSourceSyncResponse>>
+  "calendar:set-default-google-calendar": (...args: [{ calendarId: string | null; markOnboardingComplete?: boolean | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").SetDefaultGoogleCalendarResponse>>
+  "calendar:update-event": (...args: [{ id: string; title?: string | undefined; description?: string | null | undefined; location?: string | null | undefined; startAt?: string | undefined; endAt?: string | null | undefined; timezone?: string | undefined; isAllDay?: boolean | undefined; recurrenceRule?: Record<string, unknown> | null | undefined; recurrenceExceptions?: string[] | null | undefined; targetCalendarId?: string | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarEventMutationResponse>>
+  "calendar:update-source-selection": (...args: [{ id: string; isSelected: boolean; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarSourceMutationResponse>>
+  "context-menu:show": (...args: [{ id: string; label: string; accelerator?: string | undefined; disabled?: boolean | undefined; type?: "normal" | "separator" | undefined; }[]]) => Awaited<Promise<string | null>>
+  "crdt:apply-update": (...args: [unknown]) => Awaited<Promise<void>>
+  "crdt:close-doc": (...args: [unknown]) => Awaited<Promise<{ success: boolean; }>>
+  "crdt:open-doc": (...args: [unknown]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "crdt:sync-step-1": (...args: [{ noteId: string; stateVector: number[]; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crdt").CrdtSyncStep1Result | null>>
+  "crdt:sync-step-2": (...args: [{ noteId: string; diff: number[]; }]) => Awaited<Promise<void>>
+  "crypto:decrypt-item": (...args: [{ itemId: string; type: "note" | "filter" | "project" | "journal" | "task" | "settings" | "inbox" | "tag_definition" | "folder_config" | "calendar_event" | "calendar_source" | "calendar_binding" | "calendar_external_event"; encryptedKey: string; keyNonce: string; encryptedData: string; dataNonce: string; signature: string; operation?: "create" | "update" | "delete" | undefined; deletedAt?: number | undefined; metadata?: Record<string, unknown> | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").DecryptItemResult>>
+  "crypto:encrypt-item": (...args: [{ itemId: string; type: "note" | "filter" | "project" | "journal" | "task" | "settings" | "inbox" | "tag_definition" | "folder_config" | "calendar_event" | "calendar_source" | "calendar_binding" | "calendar_external_event"; content: Record<string, unknown>; operation?: "create" | "update" | "delete" | undefined; deletedAt?: number | undefined; metadata?: Record<string, unknown> | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").EncryptItemResult>>
+  "crypto:get-rotation-progress": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-crypto").GetRotationProgressResult>
+  "crypto:rotate-keys": (...args: [{ confirm: boolean; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").RotateKeysResult>>
+  "crypto:verify-signature": (...args: [{ itemId: string; type: "note" | "filter" | "project" | "journal" | "task" | "settings" | "inbox" | "tag_definition" | "folder_config" | "calendar_event" | "calendar_source" | "calendar_binding" | "calendar_external_event"; encryptedKey: string; keyNonce: string; encryptedData: string; dataNonce: string; signature: string; operation?: "create" | "update" | "delete" | undefined; deletedAt?: number | undefined; metadata?: Record<string, unknown> | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").VerifySignatureResult>>
+  "folder-view:delete-view": (...args: [{ folderPath: string; viewName: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/folder-view-api").DeleteViewResponse>>
+  "folder-view:folder-exists": (...args: [string]) => Awaited<boolean>
+  "folder-view:get-available-properties": (...args: [{ folderPath: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetAvailablePropertiesResponse>>
+  "folder-view:get-config": (...args: [{ folderPath: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetConfigResponse>>
+  "folder-view:get-folder-suggestions": (...args: [{ noteId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetFolderSuggestionsResponse>>
+  "folder-view:get-views": (...args: [{ folderPath: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetViewsResponse>>
+  "folder-view:list-with-properties": (...args: [{ folderPath: string; properties?: string[] | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").ListWithPropertiesResponse>>
+  "folder-view:set-config": (...args: [{ folderPath: string; config: { path?: string | undefined; template?: string | undefined; inherit?: boolean | undefined; formulas?: Record<string, string> | undefined; properties?: Record<string, { displayName?: string | undefined; color?: boolean | undefined; dateFormat?: string | undefined; numberFormat?: string | undefined; hidden?: boolean | undefined; }> | undefined; summaries?: Record<string, { type: "custom" | "count" | "sum" | "average" | "min" | "max" | "countBy" | "countUnique"; label?: string | undefined; expression?: string | undefined; }> | undefined; views?: { name: string; type?: "table" | "grid" | "list" | "kanban" | undefined; default?: boolean | undefined; columns?: { id: string; width?: number | undefined; displayName?: string | undefined; showSummary?: boolean | undefined; }[] | undefined; filters?: unknown; order?: { property: string; direction: "asc" | "desc"; }[] | undefined; groupBy?: { property: string; direction?: "asc" | "desc" | undefined; collapsed?: boolean | undefined; showSummary?: boolean | undefined; } | undefined; limit?: number | undefined; showSummaries?: boolean | undefined; }[] | undefined; }; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/folder-view-api").SetConfigResponse>>
+  "folder-view:set-view": (...args: [{ folderPath: string; view: { name: string; type?: "table" | "grid" | "list" | "kanban" | undefined; default?: boolean | undefined; columns?: { id: string; width?: number | undefined; displayName?: string | undefined; showSummary?: boolean | undefined; }[] | undefined; filters?: unknown; order?: { property: string; direction: "asc" | "desc"; }[] | undefined; groupBy?: { property: string; direction?: "asc" | "desc" | undefined; collapsed?: boolean | undefined; showSummary?: boolean | undefined; } | undefined; limit?: number | undefined; showSummaries?: boolean | undefined; }; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/folder-view-api").SetViewResponse>>
+  "graph:get-graph-data": (...args: []) => Awaited<{ nodes: { id: string; type: "note" | "project" | "journal" | "task"; label: string; tags: string[]; wordCount: number; connectionCount: number; emoji: string | null; color: string; isOrphan: boolean; isUnresolved: boolean; }[]; edges: { id: string; source: string; target: string; type: "wikilink" | "task-note" | "project-task" | "tag-cooccurrence"; weight: number; }[]; }>
+  "graph:get-local-graph": (...args: [{ noteId: string; depth?: number | undefined; }]) => Awaited<{ nodes: { id: string; type: "note" | "project" | "journal" | "task"; label: string; tags: string[]; wordCount: number; connectionCount: number; emoji: string | null; color: string; isOrphan: boolean; isUnresolved: boolean; }[]; edges: { id: string; source: string; target: string; type: "wikilink" | "task-note" | "project-task" | "tag-cooccurrence"; weight: number; }[]; }>
+  "inbox:add-tag": (...args: [any, any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:archive": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:bulk-archive": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
+  "inbox:bulk-file": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
+  "inbox:bulk-snooze": (...args: [any]) => Awaited<Promise<{ success: boolean; processedCount: number; errors: { itemId: string; error: string; }[]; }>>
+  "inbox:bulk-tag": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
+  "inbox:capture-clip": (...args: [unknown]) => Awaited<Promise<{ success: boolean; item: null; error: string; }>>
+  "inbox:capture-image": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
+  "inbox:capture-link": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
+  "inbox:capture-pdf": (...args: [unknown]) => Awaited<Promise<{ success: boolean; item: null; error: string; }>>
+  "inbox:capture-text": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
+  "inbox:capture-voice": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
+  "inbox:convert-to-note": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxFileResponse>>
+  "inbox:convert-to-task": (...args: [any]) => Awaited<Promise<{ success: boolean; taskId: string | null; error?: string | undefined; }>>
+  "inbox:delete-permanent": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:file": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxFileResponse>>
+  "inbox:file-all-stale": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
+  "inbox:get": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxItem | null>>
+  "inbox:get-filing-history": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").FilingHistoryResponse>>
+  "inbox:get-jobs": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxJobsResponse>>
+  "inbox:get-patterns": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").CapturePattern>>
+  "inbox:get-snoozed": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").SnoozedItem[]>>
+  "inbox:get-stale-threshold": (...args: []) => Awaited<Promise<number>>
+  "inbox:get-stats": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxStats>>
+  "inbox:get-suggestions": (...args: [any]) => Awaited<Promise<{ suggestions: import("../../../../../packages/domain-inbox/src/types").InboxFilingSuggestion[]; }>>
+  "inbox:get-tags": (...args: []) => Awaited<Promise<{ tag: string; count: number; }[]>>
+  "inbox:link-to-note": (...args: [any, any, any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:list": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxListResponse>>
+  "inbox:list-archived": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").ArchivedListResponse>>
+  "inbox:mark-viewed": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:preview-link": (...args: [string]) => Awaited<Promise<{ title: string; domain: string; favicon: string | undefined; image: string | undefined; description: string | undefined; } | { title: string; domain: string; favicon?: undefined; image?: undefined; description?: undefined; }>>
+  "inbox:remove-tag": (...args: [any, any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:retry-metadata": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:retry-transcription": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:set-stale-threshold": (...args: [any]) => Awaited<Promise<{ success: boolean; }>>
+  "inbox:snooze": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:track-suggestion": (...args: [string, string, string, string, number, string[], string[]]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error?: string | undefined; }>>
+  "inbox:unarchive": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:undo-archive": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:undo-file": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:unsnooze": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:update": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").CaptureResponse>>
+  "journal:createEntry": (...args: [{ date: string; content?: string | undefined; tags?: string[] | undefined; properties?: Record<string, unknown> | undefined; }]) => Awaited<Promise<{ id: string; date: string; content: string; wordCount: number; characterCount: number; tags: string[]; createdAt: string; modifiedAt: string; properties?: Record<string, unknown> | undefined; }>>
+  "journal:deleteEntry": (...args: [{ date: string; }]) => Awaited<Promise<{ success: boolean; }>>
+  "journal:getAllTags": (...args: []) => Awaited<Promise<{ tag: string; count: number; }[]>>
+  "journal:getDayContext": (...args: [{ date: string; }]) => Awaited<Promise<{ date: string; tasks: { id: string; title: string; completed: boolean; priority?: "urgent" | "high" | "medium" | "low" | undefined; isOverdue?: boolean | undefined; }[]; events: { id: string; time: string; title: string; type: "meeting" | "focus" | "event"; attendeeCount?: number | undefined; }[]; overdueCount: number; }>>
+  "journal:getEntry": (...args: [{ date: string; }]) => Awaited<Promise<{ id: string; date: string; content: string; wordCount: number; characterCount: number; tags: string[]; createdAt: string; modifiedAt: string; properties?: Record<string, unknown> | undefined; } | null>>
+  "journal:getHeatmap": (...args: [{ year: number; }]) => Awaited<Promise<{ date: string; characterCount: number; level: 0 | 1 | 2 | 4 | 3; }[]>>
+  "journal:getMonthEntries": (...args: [{ year: number; month: number; }]) => Awaited<Promise<{ date: string; preview: string; wordCount: number; characterCount: number; activityLevel: 0 | 1 | 2 | 4 | 3; tags: string[]; }[]>>
+  "journal:getStreak": (...args: []) => Awaited<Promise<{ currentStreak: number; longestStreak: number; lastEntryDate: string | null; }>>
+  "journal:getYearStats": (...args: [{ year: number; }]) => Awaited<Promise<{ year: number; month: number; entryCount: number; totalWordCount: number; totalCharacterCount: number; averageLevel: number; }[]>>
+  "journal:updateEntry": (...args: [{ date: string; content?: string | undefined; tags?: string[] | undefined; properties?: Record<string, unknown> | undefined; }]) => Awaited<Promise<{ id: string; date: string; content: string; wordCount: number; characterCount: number; tags: string[]; createdAt: string; modifiedAt: string; properties?: Record<string, unknown> | undefined; }>>
+  "notes:add-property-option": (...args: [{ propertyName: string; option: { value: string; color: string; }; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:add-status-option": (...args: [{ propertyName: string; categoryKey: "todo" | "in_progress" | "done"; option: { value: string; color: string; }; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:create": (...args: [{ title: string; content?: string | undefined; folder?: string | undefined; tags?: string[] | undefined; template?: string | undefined; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
+  "notes:create-folder": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "notes:create-property-definition": (...args: [{ name: string; type: "number" | "date" | "text" | "select" | "checkbox" | "url" | "status" | "multiselect"; options?: { value: string; color: string; default?: boolean | undefined; }[] | undefined; defaultValue?: unknown; color?: string | undefined; }]) => Awaited<Promise<{ success: true; definition: import("../../../../../packages/contracts/src/property-types").PropertyDefinition | undefined; } | { success: true; definition: { type: string; name: string; createdAt: string; options: string | null; defaultValue: string | null; color: string | null; }; }> | { success: false; error: string }>
+  "notes:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "notes:delete-attachment": (...args: [{ noteId: string; filename: string; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>
+  "notes:delete-folder": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "notes:delete-property-definition": (...args: [{ name: string; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:delete-version": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "notes:ensure-property-definition": (...args: [{ name: string; type: "select" | "status" | "multiselect"; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:exists": (...args: [string]) => Awaited<Promise<boolean>>
+  "notes:export-html": (...args: [{ noteId: string; includeMetadata?: boolean | undefined; pageSize?: "A4" | "Letter" | "Legal" | undefined; }]) => Awaited<Promise<{ success: false; error: string; path?: undefined; } | { success: true; path: string; error?: undefined; }> | { success: false; error: string }>
+  "notes:export-pdf": (...args: [{ noteId: string; includeMetadata?: boolean | undefined; pageSize?: "A4" | "Letter" | "Legal" | undefined; }]) => Awaited<Promise<{ success: false; error: string; path?: undefined; } | { success: true; path: string; error?: undefined; }> | { success: false; error: string }>
+  "notes:get": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").Note | null>>
+  "notes:get-all-positions": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; positions: Record<string, number>; }>>
+  "notes:get-by-path": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").Note | null>>
+  "notes:get-file": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").FileMetadata | null>>
+  "notes:get-folder-config": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/templates-api").FolderConfig | null>>
+  "notes:get-folder-template": (...args: [string]) => Awaited<Promise<string | null>>
+  "notes:get-folders": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/templates-api").FolderInfo[]>>
+  "notes:get-links": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").NoteLinksResponse>>
+  "notes:get-local-only-count": (...args: []) => Awaited<Promise<{ count: number; }>>
+  "notes:get-positions": (...args: [{ folderPath: string; }]) => Awaited<{ success: true; positions: { path: string; position: number; folderPath: string; }[]; } | { success: false; error: string }>
+  "notes:get-property-definitions": (...args: []) => Awaited<Promise<{ type: string; name: string; createdAt: string; options: string | null; defaultValue: string | null; color: string | null; }[]>>
+  "notes:get-tags": (...args: []) => Awaited<Promise<{ tag: string; color: string; count: number; }[]>>
+  "notes:get-version": (...args: [string]) => Awaited<Promise<import("../vault/notes-versions").SnapshotDetail | null>>
+  "notes:get-versions": (...args: [string]) => Awaited<Promise<import("../vault/notes-versions").SnapshotListItem[]>>
+  "notes:import-files": (...args: [{ sourcePaths: string[]; targetFolder?: string | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").ImportFilesResult> | { success: false; error: string }>
+  "notes:list": (...args: [{ folder?: string | undefined; tags?: string[] | undefined; sortBy?: "title" | "modified" | "created" | "position" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").NoteListResponse>>
+  "notes:list-attachments": (...args: [string]) => Awaited<Promise<import("../vault/attachments").AttachmentInfo[]>>
+  "notes:move": (...args: [{ id: string; newFolder: string; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
+  "notes:open-external": (...args: [string]) => Awaited<Promise<void>>
+  "notes:preview-by-title": (...args: [string]) => Awaited<Promise<{ id: string; title: string; emoji: string | null; snippet: string | null; tags: { name: string; color: string; }[]; createdAt: string; } | null>>
+  "notes:remove-property-option": (...args: [{ propertyName: string; optionValue: string; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:rename": (...args: [{ id: string; newTitle: string; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
+  "notes:rename-folder": (...args: [{ oldPath: string; newPath: string; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>
+  "notes:rename-property-option": (...args: [{ propertyName: string; oldValue: string; newValue: string; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:reorder": (...args: [{ folderPath: string; notePaths: string[]; }]) => Awaited<{ success: true; } | { success: false; error: string }>
+  "notes:resolve-by-title": (...args: [string]) => Awaited<Promise<{ id: string; path: string; title: string; fileType: import("../../../../../packages/shared/src/file-types").FileType; } | null>>
+  "notes:restore-version": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; note: import("../vault/notes-crud").Note; }>>
+  "notes:reveal-in-finder": (...args: [string]) => Awaited<Promise<void>>
+  "notes:set-folder-config": (...args: [{ folderPath: string; config: { icon?: string | null | undefined; template?: string | undefined; inherit?: boolean | undefined; }; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>
+  "notes:set-local-only": (...args: [{ id: string; localOnly: boolean; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
+  "notes:show-import-dialog": (...args: []) => Awaited<Promise<{ canceled: boolean; filePaths: string[]; }>>
+  "notes:update": (...args: [{ id: string; title?: string | undefined; content?: string | undefined; tags?: string[] | undefined; frontmatter?: Record<string, unknown> | undefined; emoji?: string | null | undefined; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
+  "notes:update-option-color": (...args: [{ propertyName: string; optionValue: string; newColor: string; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:update-property-definition": (...args: [{ name: string; type?: "number" | "date" | "text" | "select" | "checkbox" | "url" | "status" | "multiselect" | undefined; options?: { value: string; color: string; default?: boolean | undefined; }[] | undefined; defaultValue?: unknown; color?: string | undefined; }]) => Awaited<Promise<{ success: false; definition: null; error: string; } | { success: true; definition: import("../../../../../packages/contracts/src/property-types").PropertyDefinition | undefined; error?: undefined; } | { success: true; definition: { type: string; name: string; createdAt: string; options: string | null; defaultValue: string | null; color: string | null; } | undefined; error?: undefined; }> | { success: false; error: string }>
+  "notes:upload-attachment": (...args: [{ noteId: string; filename: string; data: ArrayBuffer | number[]; }]) => Awaited<Promise<import("../vault/attachments").AttachmentResult>>
+  "properties:get": (...args: [{ entityId: string; }]) => Awaited<Promise<import("../database/queries/notes/property-queries").PropertyValue[]>>
+  "properties:rename": (...args: [{ entityId: string; oldName: string; newName: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/properties-api").RenamePropertyResponse>>
+  "properties:set": (...args: [{ entityId: string; properties: Record<string, unknown>; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/properties-api").SetPropertiesResponse>>
+  "quick-capture:get-clipboard": (...args: []) => Awaited<string>
+  "reminder:bulk-dismiss": (...args: [{ reminderIds: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; dismissedCount: number; }>>
+  "reminder:count-pending": (...args: []) => Awaited<Promise<number>>
+  "reminder:create": (...args: [{ targetType: "note"; targetId: string; remindAt: string; title?: string | undefined; note?: string | undefined; } | { targetType: "journal"; targetId: string; remindAt: string; title?: string | undefined; note?: string | undefined; } | { targetType: "highlight"; targetId: string; highlightText: string; highlightStart: number; highlightEnd: number; remindAt: string; title?: string | undefined; note?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; }>>
+  "reminder:delete": (...args: [string]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "reminder:dismiss": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: null; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; error?: undefined; }>>
+  "reminder:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget | null>>
+  "reminder:get-due": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget[]>>
+  "reminder:get-for-target": (...args: [{ targetType: "note" | "journal" | "highlight"; targetId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/reminders-api").Reminder[]>>
+  "reminder:get-upcoming": (...args: [number | undefined]) => Awaited<Promise<{ reminders: import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget[]; total: number; hasMore: boolean; }>>
+  "reminder:list": (...args: [{ targetType?: "note" | "journal" | "highlight" | undefined; targetId?: string | undefined; status?: "pending" | "triggered" | "dismissed" | "snoozed" | ("pending" | "triggered" | "dismissed" | "snoozed")[] | undefined; fromDate?: string | undefined; toDate?: string | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<{ reminders: import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget[]; total: number; hasMore: boolean; }>>
+  "reminder:snooze": (...args: [{ id: string; snoozeUntil: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: null; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; error?: undefined; }>>
+  "reminder:update": (...args: [{ id: string; remindAt?: string | undefined; title?: string | null | undefined; note?: string | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: null; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; error?: undefined; }>>
+  "saved-filters:create": (...args: [{ name: string; config: { filters: { search?: string | undefined; projectIds?: string[] | undefined; priorities?: ("urgent" | "high" | "medium" | "low" | "none")[] | undefined; dueDate?: { type: "any" | "custom" | "none" | "overdue" | "today" | "tomorrow" | "this-week" | "next-week" | "this-month"; customStart?: string | null | undefined; customEnd?: string | null | undefined; } | undefined; statusIds?: string[] | undefined; completion?: "active" | "completed" | "all" | undefined; repeatType?: "all" | "repeating" | "one-time" | undefined; hasTime?: "all" | "with-time" | "without-time" | undefined; }; sort?: { field: "title" | "createdAt" | "priority" | "dueDate" | "completedAt" | "project"; direction: "asc" | "desc"; } | undefined; starred?: boolean | undefined; }; }]) => Awaited<Promise<{ success: boolean; savedFilter: import("../../../../../packages/contracts/src/saved-filters-api").SavedFilter; }>>
+  "saved-filters:delete": (...args: [{ id: string; }]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "saved-filters:list": (...args: []) => Awaited<Promise<{ savedFilters: import("../../../../../packages/contracts/src/saved-filters-api").SavedFilter[]; }>>
+  "saved-filters:reorder": (...args: [{ ids: string[]; positions: number[]; }]) => Awaited<Promise<{ success: boolean; }>>
+  "saved-filters:update": (...args: [{ id: string; name?: string | undefined; config?: { filters: { search?: string | undefined; projectIds?: string[] | undefined; priorities?: ("urgent" | "high" | "medium" | "low" | "none")[] | undefined; dueDate?: { type: "any" | "custom" | "none" | "overdue" | "today" | "tomorrow" | "this-week" | "next-week" | "this-month"; customStart?: string | null | undefined; customEnd?: string | null | undefined; } | undefined; statusIds?: string[] | undefined; completion?: "active" | "completed" | "all" | undefined; repeatType?: "all" | "repeating" | "one-time" | undefined; hasTime?: "all" | "with-time" | "without-time" | undefined; }; sort?: { field: "title" | "createdAt" | "priority" | "dueDate" | "completedAt" | "project"; direction: "asc" | "desc"; } | undefined; starred?: boolean | undefined; } | undefined; position?: number | undefined; }]) => Awaited<Promise<{ success: boolean; savedFilter: null; error: string; } | { success: boolean; savedFilter: import("../../../../../packages/contracts/src/saved-filters-api").SavedFilter | null; error?: undefined; }>>
+  "search:add-reason": (...args: [{ itemId: string; itemType: "note" | "journal" | "task" | "inbox"; itemTitle: string; searchQuery: string; itemIcon?: string | null | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchReason>>
+  "search:clear-reasons": (...args: []) => Awaited<Promise<{ cleared: true; }>>
+  "search:get-all-tags": (...args: []) => Awaited<Promise<string[]>>
+  "search:get-reasons": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchReason[]>>
+  "search:get-stats": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchStats>>
+  "search:query": (...args: [{ text: string; types?: ("note" | "journal" | "task" | "inbox")[] | undefined; tags?: string[] | undefined; dateRange?: { from: string; to: string; } | null | undefined; projectId?: string | null | undefined; folderPath?: string | null | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchResponse>>
+  "search:quick": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").QuickSearchResponse>>
+  "search:rebuild-index": (...args: []) => Awaited<Promise<{ notes: number; tasks: number; inbox: number; durationMs: number; started: true; error?: undefined; } | { started: false; error: string; }>>
+  "settings:downloadVoiceModel": (...args: []) => Awaited<Promise<{ success: boolean; error?: undefined; } | { success: boolean; error: string; }>>
+  "settings:get": (...args: [string]) => Awaited<string | null>
+  "settings:getAIModelStatus": (...args: []) => Awaited<Promise<import("./settings-handlers").AIModelStatus>>
+  "settings:getAISettings": (...args: []) => Awaited<import("./settings-handlers").AISettings>
+  "settings:getBackupSettings": (...args: []) => Awaited<{ autoBackup: boolean; frequencyHours: 1 | 6 | 12 | 24; maxBackups: number; lastBackupAt: string | null; }>
+  "settings:getCalendarGoogleSettings": (...args: []) => Awaited<{ defaultTargetCalendarId: string | null; onboardingCompleted: boolean; promoteConfirmDismissed: boolean; }>
+  "settings:getCalendarSettings": (...args: []) => Awaited<{ dayCellClickBehavior: "journal" | "calendar"; calendarPageClickOverride: "inherit" | "journal" | "calendar"; }>
+  "settings:getEditorSettings": (...args: []) => Awaited<{ width: "medium" | "narrow" | "wide"; spellCheck: boolean; autoSaveDelay: number; showWordCount: boolean; toolbarMode: "floating" | "sticky"; }>
+  "settings:getGeneralSettings": (...args: []) => Awaited<{ theme: "light" | "dark" | "white" | "system"; fontSize: "small" | "medium" | "large"; fontFamily: "system" | "serif" | "sans-serif" | "monospace" | "gelasio" | "geist" | "inter"; accentColor: string; startOnBoot: boolean; language: string; onboardingCompleted: boolean; createInSelectedFolder: boolean; clockFormat: "12h" | "24h"; }>
+  "settings:getGraphSettings": (...args: []) => Awaited<{ layout: "forceatlas2" | "circular" | "random"; showLabels: boolean; showEdgeLabels: boolean; animateLayout: boolean; showTagEdges: boolean; }>
+  "settings:getJournalSettings": (...args: []) => Awaited<{ defaultTemplate: string | null; showSchedule: boolean; showTasks: boolean; showAIConnections: boolean; showStatsFooter: boolean; }>
+  "settings:getKeyboardSettings": (...args: []) => Awaited<{ overrides: Record<string, { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; }>; globalCapture: { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; } | null; }>
+  "settings:getNoteEditorSettings": (...args: []) => Awaited<import("./settings-handlers").NoteEditorSettings>
+  "settings:getSyncSettings": (...args: []) => Awaited<{ enabled: boolean; autoSync: boolean; }>
+  "settings:getTabSettings": (...args: []) => Awaited<import("./settings-handlers").TabSettings>
+  "settings:getTaskSettings": (...args: []) => Awaited<{ defaultProjectId: string | null; defaultSortOrder: "createdAt" | "priority" | "dueDate" | "manual"; weekStartDay: "sunday" | "monday"; staleInboxDays: number; }>
+  "settings:getVoiceModelStatus": (...args: []) => Awaited<import("../inbox/voice-model").VoiceModelStatus>
+  "settings:getVoiceRecordingReadiness": (...args: []) => Awaited<Promise<import("../inbox/voice-transcription-settings").VoiceRecordingReadiness>>
+  "settings:getVoiceTranscriptionOpenAIKeyStatus": (...args: []) => Awaited<Promise<import("./settings-handlers").VoiceTranscriptionOpenAIKeyStatus>>
+  "settings:getVoiceTranscriptionSettings": (...args: []) => Awaited<{ provider: "local" | "openai"; }>
+  "settings:loadAIModel": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; message: string; error?: undefined; } | { success: boolean; error: string; message?: undefined; } | { success: boolean; message?: undefined; error?: undefined; }>>
+  "settings:registerGlobalCapture": (...args: []) => Awaited<Promise<import("./settings-handlers").GlobalCaptureResult>>
+  "settings:reindexEmbeddings": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; computed: number; skipped: number; error?: string | undefined; }>>
+  "settings:resetKeyboardSettings": (...args: []) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:set": (...args: [{ key: string; value: string; }]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:setAISettings": (...args: [Partial<import("./settings-handlers").AISettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:setBackupSettings": (...args: [Partial<{ autoBackup: boolean; frequencyHours: 1 | 6 | 12 | 24; maxBackups: number; lastBackupAt: string | null; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setCalendarGoogleSettings": (...args: [Partial<{ defaultTargetCalendarId: string | null; onboardingCompleted: boolean; promoteConfirmDismissed: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setCalendarSettings": (...args: [Partial<{ dayCellClickBehavior: "journal" | "calendar"; calendarPageClickOverride: "inherit" | "journal" | "calendar"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setEditorSettings": (...args: [Partial<{ width: "medium" | "narrow" | "wide"; spellCheck: boolean; autoSaveDelay: number; showWordCount: boolean; toolbarMode: "floating" | "sticky"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setGeneralSettings": (...args: [Partial<{ theme: "light" | "dark" | "white" | "system"; fontSize: "small" | "medium" | "large"; fontFamily: "system" | "serif" | "sans-serif" | "monospace" | "gelasio" | "geist" | "inter"; accentColor: string; startOnBoot: boolean; language: string; onboardingCompleted: boolean; createInSelectedFolder: boolean; clockFormat: "12h" | "24h"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setGraphSettings": (...args: [Partial<{ layout: "forceatlas2" | "circular" | "random"; showLabels: boolean; showEdgeLabels: boolean; animateLayout: boolean; showTagEdges: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setJournalSettings": (...args: [Partial<import("./settings-handlers").JournalSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:setKeyboardSettings": (...args: [Partial<{ overrides: Record<string, { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; }>; globalCapture: { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; } | null; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setNoteEditorSettings": (...args: [Partial<import("./settings-handlers").NoteEditorSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:setSyncSettings": (...args: [Partial<{ enabled: boolean; autoSync: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setTabSettings": (...args: [Partial<import("./settings-handlers").TabSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:setTaskSettings": (...args: [Partial<{ defaultProjectId: string | null; defaultSortOrder: "createdAt" | "priority" | "dueDate" | "manual"; weekStartDay: "sunday" | "monday"; staleInboxDays: number; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setVoiceTranscriptionOpenAIKey": (...args: [{ apiKey: string; }]) => Awaited<Promise<{ success: boolean; error?: undefined; } | { success: boolean; error: string; }>>
+  "settings:setVoiceTranscriptionSettings": (...args: [Partial<{ provider: "local" | "openai"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "sync:approve-linking": (...args: [{ sessionId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").ApproveLinkingResult> | { success: false; error: string }>
+  "sync:check-device-status": (...args: []) => Awaited<Promise<{ status: string; }>>
+  "sync:complete-linking-qr": (...args: [{ sessionId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").CompleteLinkingQrResult> | { success: false; error: string }>
+  "sync:confirm-recovery-phrase": (...args: [{ confirmed: boolean; }]) => Awaited<Promise<{ success: boolean; }> | { success: false; error: string }>
+  "sync:download-attachment": (...args: [{ attachmentId: string; targetPath?: string | undefined; }]) => Awaited<Promise<{ success: boolean; error: string; filePath?: undefined; } | { success: boolean; filePath: string; error?: undefined; }> | { success: false; error: string }>
+  "sync:emergency-wipe": (...args: []) => Awaited<Promise<{ success: boolean; }>>
+  "sync:generate-linking-qr": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").GenerateLinkingQrResult>>
+  "sync:get-devices": (...args: []) => Awaited<Promise<{ devices: { id: string; name: string; platform: "macos" | "windows" | "linux" | "ios" | "android"; linkedAt: number; lastSyncAt: number | undefined; isCurrentDevice: boolean; }[]; email: string | undefined; }>>
+  "sync:get-download-progress": (...args: [{ attachmentId: string; }]) => Awaited<{ progress: number; downloadedChunks: number; totalChunks: number; status: "downloading"; } | null | { success: false; error: string }>
+  "sync:get-history": (...args: [{ limit?: number | undefined; offset?: number | undefined; }]) => Awaited<{ entries: { id: string; type: "error" | "push" | "pull"; itemCount: number; direction: string | undefined; details: unknown; durationMs: number | undefined; createdAt: number; }[]; total: number; } | { success: false; error: string }>
+  "sync:get-linking-sas": (...args: [{ sessionId: string; }]) => Awaited<Promise<{ verificationCode?: string | undefined; error?: string | undefined; }> | { success: false; error: string }>
+  "sync:get-quarantined-items": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-events").QuarantinedItemInfo[]>
+  "sync:get-queue-size": (...args: []) => Awaited<{ pending: number; failed: number; }>
+  "sync:get-recovery-phrase": (...args: []) => Awaited<string | null>
+  "sync:get-status": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-sync-ops").GetSyncStatusResult | { status: string; pendingCount: number; }>
+  "sync:get-storage-breakdown": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-sync-ops").StorageBreakdownResult | null>>
+  "sync:get-synced-settings": (...args: []) => Awaited<{ general?: { theme?: "light" | "dark" | "white" | "system" | undefined; fontSize?: "small" | "medium" | "large" | undefined; fontFamily?: "system" | "serif" | "sans-serif" | "monospace" | "gelasio" | "geist" | "inter" | undefined; accentColor?: string | undefined; startOnBoot?: boolean | undefined; language?: string | undefined; createInSelectedFolder?: boolean | undefined; } | undefined; editor?: { width?: "medium" | "narrow" | "wide" | undefined; spellCheck?: boolean | undefined; autoSaveDelay?: number | undefined; showWordCount?: boolean | undefined; toolbarMode?: "floating" | "sticky" | undefined; } | undefined; tasks?: { defaultProjectId?: string | null | undefined; defaultSortOrder?: "createdAt" | "priority" | "dueDate" | "manual" | undefined; weekStartDay?: "sunday" | "monday" | undefined; staleInboxDays?: number | undefined; showCompleted?: boolean | undefined; sortBy?: string | undefined; } | undefined; keyboard?: { overrides?: Record<string, unknown> | undefined; } | undefined; notes?: { defaultFolder?: string | undefined; editorFontSize?: number | undefined; spellCheck?: boolean | undefined; } | undefined; sync?: { autoSync?: boolean | undefined; syncIntervalMinutes?: number | undefined; } | undefined; } | null>
+  "sync:get-upload-progress": (...args: [{ sessionId: string; }]) => Awaited<{ progress: number; uploadedChunks: number; totalChunks: number; status: "uploading"; } | null | { success: false; error: string }>
+  "sync:link-via-qr": (...args: [{ qrData: string; oauthToken?: string | undefined; provider?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").LinkViaQrResult> | { success: false; error: string }>
+  "sync:link-via-recovery": (...args: [{ recoveryPhrase: string; }]) => Awaited<Promise<{ success: boolean; error: string; deviceId?: undefined; } | { success: boolean; deviceId: string; error?: undefined; }> | { success: false; error: string }>
+  "sync:logout": (...args: []) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean; }>>
+  "sync:pause": (...args: []) => Awaited<{ success: boolean; wasPaused: boolean; }>
+  "sync:remove-device": (...args: [{ deviceId: string; }]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }> | { success: false; error: string }>
+  "sync:rename-device": (...args: [{ deviceId: string; newName: string; }]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }> | { success: false; error: string }>
+  "sync:resume": (...args: []) => Awaited<{ success: boolean; pendingCount: number; }>
+  "sync:setup-first-device": (...args: [{ oauthToken: string; provider: "google"; state: string; }]) => Awaited<Promise<{ success: boolean; needsRecoverySetup: boolean; deviceId: string; needsRecoveryInput?: undefined; } | { success: boolean; needsRecoverySetup: boolean; needsRecoveryInput: boolean; deviceId?: undefined; }> | { success: false; error: string }>
+  "sync:setup-new-account": (...args: []) => Awaited<Promise<{ success: boolean; error: string; deviceId?: undefined; } | { success: boolean; deviceId: string; error?: undefined; }>>
+  "sync:trigger-sync": (...args: []) => Awaited<Promise<{ success: boolean; } | { success: boolean; error: string; }>>
+  "sync:update-synced-setting": (...args: [{ fieldPath: string; value: unknown; }]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; } | { success: false; error: string }>
+  "sync:upload-attachment": (...args: [{ noteId: string; filePath: string; }]) => Awaited<Promise<{ success: boolean; error: string; attachmentId?: undefined; sessionId?: undefined; } | { success: boolean; attachmentId: string; sessionId: string; error?: undefined; }> | { success: false; error: string }>
+  "tags:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").DeleteTagResponse>>
+  "tags:get-all-with-counts": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/tags-api").GetAllWithCountsResponse>>
+  "tags:get-notes-by-tag": (...args: [{ tag: string; sortBy?: "title" | "modified" | "created" | undefined; sortOrder?: "asc" | "desc" | undefined; includeDescendants?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/tags-api").GetNotesByTagResponse>>
+  "tags:merge": (...args: [{ source: string; target: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").MergeTagResponse>>
+  "tags:pin-note-to-tag": (...args: [{ noteId: string; tag: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
+  "tags:remove-from-note": (...args: [{ noteId: string; tag: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
+  "tags:rename": (...args: [{ oldName: string; newName: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").RenameTagResponse>>
+  "tags:unpin-note-from-tag": (...args: [{ noteId: string; tag: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
+  "tags:update-color": (...args: [{ tag: string; color: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
+  "tasks:archive": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "tasks:bulk-archive": (...args: [{ ids: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
+  "tasks:bulk-complete": (...args: [{ ids: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
+  "tasks:bulk-delete": (...args: [{ ids: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
+  "tasks:bulk-move": (...args: [{ ids: string[]; projectId: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
+  "tasks:complete": (...args: [{ id: string; completedAt?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:convert-to-subtask": (...args: [{ taskId: string; parentId: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:convert-to-task": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:create": (...args: [{ projectId: string; title: string; description?: string | null | undefined; priority?: number | undefined; statusId?: string | null | undefined; parentId?: string | null | undefined; dueDate?: string | null | undefined; dueTime?: string | null | undefined; startDate?: string | null | undefined; isRepeating?: boolean | undefined; repeatConfig?: { frequency: "daily" | "weekly" | "monthly" | "yearly"; endType: "never" | "date" | "count"; createdAt: string; interval?: number | undefined; daysOfWeek?: number[] | undefined; monthlyType?: "dayOfMonth" | "weekPattern" | undefined; dayOfMonth?: number | undefined; weekOfMonth?: number | undefined; dayOfWeekForMonth?: number | undefined; endDate?: string | null | undefined; endCount?: number | undefined; completedCount?: number | undefined; } | null | undefined; repeatFrom?: "due" | "completion" | null | undefined; tags?: string[] | undefined; linkedNoteIds?: string[] | undefined; sourceNoteId?: string | null | undefined; position?: number | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; }>>
+  "tasks:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:duplicate": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Task | null>>
+  "tasks:get-linked-tasks": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Task[]>>
+  "tasks:get-overdue": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListEnvelope>>
+  "tasks:get-stats": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").TaskStats>>
+  "tasks:get-subtasks": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Task[]>>
+  "tasks:get-tags": (...args: []) => Awaited<Promise<{ tag: string; count: number; }[]>>
+  "tasks:get-today": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListEnvelope>>
+  "tasks:get-upcoming": (...args: [{ days?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListEnvelope>>
+  "tasks:list": (...args: [{ projectId?: string | undefined; statusId?: string | null | undefined; parentId?: string | null | undefined; includeCompleted?: boolean | undefined; includeArchived?: boolean | undefined; dueBefore?: string | undefined; dueAfter?: string | undefined; tags?: string[] | undefined; search?: string | undefined; sortBy?: "modified" | "created" | "position" | "priority" | "dueDate" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListResult>>
+  "tasks:move": (...args: [{ taskId: string; position: number; targetProjectId?: string | undefined; targetStatusId?: string | null | undefined; targetParentId?: string | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:project-archive": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "tasks:project-create": (...args: [{ name: string; description?: string | null | undefined; color?: string | undefined; icon?: string | null | undefined; statuses?: { name: string; type: "todo" | "in_progress" | "done"; order: number; color?: string | undefined; }[] | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; project: import("../../../../../packages/domain-tasks/src/types").ProjectWithStatuses; }>>
+  "tasks:project-delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:project-get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").ProjectWithStatuses | undefined>>
+  "tasks:project-list": (...args: []) => Awaited<Promise<{ projects: import("../../../../../packages/domain-tasks/src/types").ProjectWithStats[]; }>>
+  "tasks:project-reorder": (...args: [{ projectIds: string[]; positions: number[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:project-update": (...args: [{ id: string; name?: string | undefined; description?: string | null | undefined; color?: string | undefined; icon?: string | null | undefined; statuses?: { name: string; type: "todo" | "in_progress" | "done"; order: number; id?: string | undefined; color?: string | undefined; }[] | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; project: null; error: string; } | { success: boolean; project: import("../../../../../packages/domain-tasks/src/types").ProjectWithStatuses; error?: undefined; }>>
+  "tasks:reorder": (...args: [{ taskIds: string[]; positions: number[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:seed-demo": (...args: []) => Awaited<Promise<{ success: boolean; message: string; }>>
+  "tasks:seed-performance-test": (...args: []) => Awaited<Promise<{ success: boolean; message: string; }>>
+  "tasks:status-create": (...args: [{ projectId: string; name: string; color?: string | undefined; isDone?: boolean | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; status: import("../../../../../packages/domain-tasks/src/types").Status; }>>
+  "tasks:status-delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:status-list": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Status[]>>
+  "tasks:status-reorder": (...args: [{ statusIds: string[]; positions: number[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:status-update": (...args: [{ id: string; name?: string | undefined; color?: string | undefined; position?: number | undefined; isDefault?: boolean | undefined; isDone?: boolean | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; status?: undefined; } | { success: boolean; status: import("../../../../../packages/domain-tasks/src/types").Status; error?: undefined; }>>
+  "tasks:unarchive": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "tasks:uncomplete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:update": (...args: [{ id: string; title?: string | undefined; description?: string | null | undefined; priority?: number | undefined; projectId?: string | undefined; statusId?: string | null | undefined; parentId?: string | null | undefined; dueDate?: string | null | undefined; dueTime?: string | null | undefined; startDate?: string | null | undefined; isRepeating?: boolean | undefined; repeatConfig?: { frequency: "daily" | "weekly" | "monthly" | "yearly"; endType: "never" | "date" | "count"; createdAt: string; interval?: number | undefined; daysOfWeek?: number[] | undefined; monthlyType?: "dayOfMonth" | "weekPattern" | undefined; dayOfMonth?: number | undefined; weekOfMonth?: number | undefined; dayOfWeekForMonth?: number | undefined; endDate?: string | null | undefined; endCount?: number | undefined; completedCount?: number | undefined; } | null | undefined; repeatFrom?: "due" | "completion" | null | undefined; tags?: string[] | undefined; linkedNoteIds?: string[] | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "templates:create": (...args: [{ name: string; description?: string | undefined; icon?: string | null | undefined; tags?: string[] | undefined; properties?: { name: string; type: "number" | "date" | "text" | "select" | "checkbox" | "url" | "multiselect" | "rating"; value: unknown; options?: string[] | undefined; }[] | undefined; content?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; template: import("../../../../../packages/contracts/src/templates-api").Template; }>>
+  "templates:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "templates:duplicate": (...args: [{ id: string; newName: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; template: import("../../../../../packages/contracts/src/templates-api").Template; }>>
+  "templates:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/templates-api").Template | null>>
+  "templates:list": (...args: []) => Awaited<Promise<{ templates: import("../../../../../packages/contracts/src/templates-api").TemplateListItem[]; }>>
+  "templates:update": (...args: [{ id: string; name?: string | undefined; description?: string | undefined; icon?: string | null | undefined; tags?: string[] | undefined; properties?: { name: string; type: "number" | "date" | "text" | "select" | "checkbox" | "url" | "multiselect" | "rating"; value: unknown; options?: string[] | undefined; }[] | undefined; content?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; template: import("../../../../../packages/contracts/src/templates-api").Template; }>>
+  "vault:close": (...args: []) => Awaited<Promise<void>>
+  "vault:get-all": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").GetVaultsResponse>>
+  "vault:get-config": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultConfig>>
+  "vault:get-status": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultStatus>>
+  "vault:reindex": (...args: []) => Awaited<Promise<void>>
+  "vault:remove": (...args: [string]) => Awaited<Promise<void>>
+  "vault:reveal": (...args: []) => Awaited<Promise<void>>
+  "vault:select": (...args: [{ path?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").SelectVaultResponse>>
+  "vault:switch": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").SelectVaultResponse>>
+  "vault:update-config": (...args: [{ excludePatterns?: string[] | undefined; defaultNoteFolder?: string | undefined; journalFolder?: string | undefined; attachmentsFolder?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultConfig>>
 }
 
 export type MainIpcInvokeChannel = keyof MainIpcInvokeHandlers
-export type MainIpcInvokeArgs<C extends MainIpcInvokeChannel> = Parameters<MainIpcInvokeHandlers[C]>
-export type MainIpcInvokeResult<C extends MainIpcInvokeChannel> = ReturnType<
-  MainIpcInvokeHandlers[C]
->
+export type MainIpcInvokeArgs<C extends MainIpcInvokeChannel> =
+  Parameters<MainIpcInvokeHandlers[C]>
+export type MainIpcInvokeResult<C extends MainIpcInvokeChannel> =
+  ReturnType<MainIpcInvokeHandlers[C]>

--- a/apps/desktop/src/main/ipc/settings-handlers.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.ts
@@ -17,7 +17,8 @@ import {
   SYNC_SETTINGS_DEFAULTS,
   BACKUP_SETTINGS_DEFAULTS,
   VOICE_TRANSCRIPTION_SETTINGS_DEFAULTS,
-  CALENDAR_GOOGLE_SETTINGS_DEFAULTS
+  CALENDAR_GOOGLE_SETTINGS_DEFAULTS,
+  CALENDAR_SETTINGS_DEFAULTS
 } from '@memry/contracts/settings-schemas'
 import type {
   GeneralSettings,
@@ -27,7 +28,8 @@ import type {
   SyncSettings,
   BackupSettings,
   VoiceTranscriptionSettings,
-  CalendarGoogleSettings
+  CalendarGoogleSettings,
+  CalendarSettings
 } from '@memry/contracts/settings-schemas'
 import { GRAPH_SETTINGS_DEFAULTS } from '@memry/contracts/graph-api'
 import type { GraphSettings } from '@memry/contracts/graph-api'
@@ -698,6 +700,15 @@ export function registerSettingsHandlers(): void {
       writeGroupSettings('calendar.google', CALENDAR_GOOGLE_SETTINGS_DEFAULTS, updates)
   )
 
+  ipcMain.handle(SettingsChannels.invoke.GET_CALENDAR_SETTINGS, () =>
+    readGroupSettings('calendar', CALENDAR_SETTINGS_DEFAULTS)
+  )
+  ipcMain.handle(
+    SettingsChannels.invoke.SET_CALENDAR_SETTINGS,
+    (_event, updates: Partial<CalendarSettings>) =>
+      writeGroupSettings('calendar', CALENDAR_SETTINGS_DEFAULTS, updates)
+  )
+
   // Keyboard shortcuts: reset to defaults
   ipcMain.handle(SettingsChannels.invoke.RESET_KEYBOARD_SETTINGS, () => {
     const db = getDbOrNull()
@@ -857,6 +868,8 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(SettingsChannels.invoke.SET_GRAPH_SETTINGS)
   ipcMain.removeHandler(SettingsChannels.invoke.GET_CALENDAR_GOOGLE_SETTINGS)
   ipcMain.removeHandler(SettingsChannels.invoke.SET_CALENDAR_GOOGLE_SETTINGS)
+  ipcMain.removeHandler(SettingsChannels.invoke.GET_CALENDAR_SETTINGS)
+  ipcMain.removeHandler(SettingsChannels.invoke.SET_CALENDAR_SETTINGS)
   ipcMain.removeHandler(SettingsChannels.invoke.REGISTER_GLOBAL_CAPTURE)
 
   logger.info('Settings handlers unregistered')

--- a/apps/desktop/src/preload/generated-rpc.ts
+++ b/apps/desktop/src/preload/generated-rpc.ts
@@ -2,11 +2,7 @@
 
 export type { GeneratedRpcApi } from '@memry/rpc'
 import type { GeneratedRpcApi } from '@memry/rpc'
-import type {
-  MainIpcInvokeArgs,
-  MainIpcInvokeChannel,
-  MainIpcInvokeResult
-} from '../main/ipc/generated-ipc-invoke-map'
+import type { MainIpcInvokeArgs, MainIpcInvokeChannel, MainIpcInvokeResult } from '../main/ipc/generated-ipc-invoke-map'
 
 export interface GeneratedRpcDeps {
   invoke<C extends MainIpcInvokeChannel>(
@@ -24,257 +20,119 @@ export function createGeneratedRpcApi({
 }: GeneratedRpcDeps): GeneratedRpcApi {
   return {
     notes: {
-      create: ((input) => invoke('notes:create', input)) as GeneratedRpcApi['notes']['create'],
-      get: ((id) => invoke('notes:get', id)) as GeneratedRpcApi['notes']['get'],
-      getByPath: ((path) =>
-        invoke('notes:get-by-path', path)) as GeneratedRpcApi['notes']['getByPath'],
-      getFile: ((id) => invoke('notes:get-file', id)) as GeneratedRpcApi['notes']['getFile'],
-      resolveByTitle: ((title) =>
-        invoke('notes:resolve-by-title', title)) as GeneratedRpcApi['notes']['resolveByTitle'],
-      previewByTitle: ((title) =>
-        invoke('notes:preview-by-title', title)) as GeneratedRpcApi['notes']['previewByTitle'],
-      update: ((input) => invoke('notes:update', input)) as GeneratedRpcApi['notes']['update'],
-      rename: ((id, newTitle) =>
-        invoke('notes:rename', { id, newTitle })) as GeneratedRpcApi['notes']['rename'],
-      move: ((id, newFolder) =>
-        invoke('notes:move', { id, newFolder })) as GeneratedRpcApi['notes']['move'],
-      delete: ((id) => invoke('notes:delete', id)) as GeneratedRpcApi['notes']['delete'],
-      list: ((options) => invoke('notes:list', options ?? {})) as GeneratedRpcApi['notes']['list'],
-      getTags: (() => invoke('notes:get-tags')) as GeneratedRpcApi['notes']['getTags'],
-      getLinks: ((id) => invoke('notes:get-links', id)) as GeneratedRpcApi['notes']['getLinks'],
-      getFolders: (() => invoke('notes:get-folders')) as GeneratedRpcApi['notes']['getFolders'],
-      createFolder: ((path) =>
-        invoke('notes:create-folder', path)) as GeneratedRpcApi['notes']['createFolder'],
-      renameFolder: ((oldPath, newPath) =>
-        invoke('notes:rename-folder', {
-          oldPath,
-          newPath
-        })) as GeneratedRpcApi['notes']['renameFolder'],
-      deleteFolder: ((path) =>
-        invoke('notes:delete-folder', path)) as GeneratedRpcApi['notes']['deleteFolder'],
-      exists: ((titleOrPath) =>
-        invoke('notes:exists', titleOrPath)) as GeneratedRpcApi['notes']['exists'],
-      openExternal: ((id) =>
-        invoke('notes:open-external', id)) as GeneratedRpcApi['notes']['openExternal'],
-      revealInFinder: ((id) =>
-        invoke('notes:reveal-in-finder', id)) as GeneratedRpcApi['notes']['revealInFinder'],
-      getPropertyDefinitions: (() =>
-        invoke(
-          'notes:get-property-definitions'
-        )) as GeneratedRpcApi['notes']['getPropertyDefinitions'],
-      createPropertyDefinition: ((input) =>
-        invoke(
-          'notes:create-property-definition',
-          input
-        )) as GeneratedRpcApi['notes']['createPropertyDefinition'],
-      updatePropertyDefinition: ((input) =>
-        invoke(
-          'notes:update-property-definition',
-          input
-        )) as GeneratedRpcApi['notes']['updatePropertyDefinition'],
-      ensurePropertyDefinition: ((name, type) =>
-        invoke('notes:ensure-property-definition', {
-          name,
-          type
-        })) as GeneratedRpcApi['notes']['ensurePropertyDefinition'],
-      addPropertyOption: ((propertyName, option) =>
-        invoke('notes:add-property-option', {
-          propertyName,
-          option
-        })) as GeneratedRpcApi['notes']['addPropertyOption'],
-      addStatusOption: ((propertyName, categoryKey, option) =>
-        invoke('notes:add-status-option', {
-          propertyName,
-          categoryKey,
-          option
-        })) as GeneratedRpcApi['notes']['addStatusOption'],
-      removePropertyOption: ((propertyName, optionValue) =>
-        invoke('notes:remove-property-option', {
-          propertyName,
-          optionValue
-        })) as GeneratedRpcApi['notes']['removePropertyOption'],
-      renamePropertyOption: ((propertyName, oldValue, newValue) =>
-        invoke('notes:rename-property-option', {
-          propertyName,
-          oldValue,
-          newValue
-        })) as GeneratedRpcApi['notes']['renamePropertyOption'],
-      updateOptionColor: ((propertyName, optionValue, newColor) =>
-        invoke('notes:update-option-color', {
-          propertyName,
-          optionValue,
-          newColor
-        })) as GeneratedRpcApi['notes']['updateOptionColor'],
-      deletePropertyDefinition: ((name) =>
-        invoke('notes:delete-property-definition', {
-          name
-        })) as GeneratedRpcApi['notes']['deletePropertyDefinition'],
+      create: ((input) => invoke("notes:create", input)) as GeneratedRpcApi["notes"]["create"],
+      get: ((id) => invoke("notes:get", id)) as GeneratedRpcApi["notes"]["get"],
+      getByPath: ((path) => invoke("notes:get-by-path", path)) as GeneratedRpcApi["notes"]["getByPath"],
+      getFile: ((id) => invoke("notes:get-file", id)) as GeneratedRpcApi["notes"]["getFile"],
+      resolveByTitle: ((title) => invoke("notes:resolve-by-title", title)) as GeneratedRpcApi["notes"]["resolveByTitle"],
+      previewByTitle: ((title) => invoke("notes:preview-by-title", title)) as GeneratedRpcApi["notes"]["previewByTitle"],
+      update: ((input) => invoke("notes:update", input)) as GeneratedRpcApi["notes"]["update"],
+      rename: ((id, newTitle) => invoke("notes:rename", { id, newTitle })) as GeneratedRpcApi["notes"]["rename"],
+      move: ((id, newFolder) => invoke("notes:move", { id, newFolder })) as GeneratedRpcApi["notes"]["move"],
+      delete: ((id) => invoke("notes:delete", id)) as GeneratedRpcApi["notes"]["delete"],
+      list: ((options) => invoke("notes:list", options ?? {})) as GeneratedRpcApi["notes"]["list"],
+      getTags: (() => invoke("notes:get-tags")) as GeneratedRpcApi["notes"]["getTags"],
+      getLinks: ((id) => invoke("notes:get-links", id)) as GeneratedRpcApi["notes"]["getLinks"],
+      getFolders: (() => invoke("notes:get-folders")) as GeneratedRpcApi["notes"]["getFolders"],
+      createFolder: ((path) => invoke("notes:create-folder", path)) as GeneratedRpcApi["notes"]["createFolder"],
+      renameFolder: ((oldPath, newPath) => invoke("notes:rename-folder", { oldPath, newPath })) as GeneratedRpcApi["notes"]["renameFolder"],
+      deleteFolder: ((path) => invoke("notes:delete-folder", path)) as GeneratedRpcApi["notes"]["deleteFolder"],
+      exists: ((titleOrPath) => invoke("notes:exists", titleOrPath)) as GeneratedRpcApi["notes"]["exists"],
+      openExternal: ((id) => invoke("notes:open-external", id)) as GeneratedRpcApi["notes"]["openExternal"],
+      revealInFinder: ((id) => invoke("notes:reveal-in-finder", id)) as GeneratedRpcApi["notes"]["revealInFinder"],
+      getPropertyDefinitions: (() => invoke("notes:get-property-definitions")) as GeneratedRpcApi["notes"]["getPropertyDefinitions"],
+      createPropertyDefinition: ((input) => invoke("notes:create-property-definition", input)) as GeneratedRpcApi["notes"]["createPropertyDefinition"],
+      updatePropertyDefinition: ((input) => invoke("notes:update-property-definition", input)) as GeneratedRpcApi["notes"]["updatePropertyDefinition"],
+      ensurePropertyDefinition: ((name, type) => invoke("notes:ensure-property-definition", { name, type })) as GeneratedRpcApi["notes"]["ensurePropertyDefinition"],
+      addPropertyOption: ((propertyName, option) => invoke("notes:add-property-option", { propertyName, option })) as GeneratedRpcApi["notes"]["addPropertyOption"],
+      addStatusOption: ((propertyName, categoryKey, option) => invoke("notes:add-status-option", { propertyName, categoryKey, option })) as GeneratedRpcApi["notes"]["addStatusOption"],
+      removePropertyOption: ((propertyName, optionValue) => invoke("notes:remove-property-option", { propertyName, optionValue })) as GeneratedRpcApi["notes"]["removePropertyOption"],
+      renamePropertyOption: ((propertyName, oldValue, newValue) => invoke("notes:rename-property-option", { propertyName, oldValue, newValue })) as GeneratedRpcApi["notes"]["renamePropertyOption"],
+      updateOptionColor: ((propertyName, optionValue, newColor) => invoke("notes:update-option-color", { propertyName, optionValue, newColor })) as GeneratedRpcApi["notes"]["updateOptionColor"],
+      deletePropertyDefinition: ((name) => invoke("notes:delete-property-definition", { name })) as GeneratedRpcApi["notes"]["deletePropertyDefinition"],
       uploadAttachment: (async (noteId, file) =>
-        invoke('notes:upload-attachment', {
+        invoke("notes:upload-attachment", {
           noteId,
           filename: file.name,
           data: Array.from(new Uint8Array(await file.arrayBuffer()))
-        })) as GeneratedRpcApi['notes']['uploadAttachment'],
-      listAttachments: ((noteId) =>
-        invoke('notes:list-attachments', noteId)) as GeneratedRpcApi['notes']['listAttachments'],
-      deleteAttachment: ((noteId, filename) =>
-        invoke('notes:delete-attachment', {
-          noteId,
-          filename
-        })) as GeneratedRpcApi['notes']['deleteAttachment'],
-      getFolderConfig: ((folderPath) =>
-        invoke(
-          'notes:get-folder-config',
-          folderPath
-        )) as GeneratedRpcApi['notes']['getFolderConfig'],
-      setFolderConfig: ((folderPath, config) =>
-        invoke('notes:set-folder-config', {
-          folderPath,
-          config
-        })) as GeneratedRpcApi['notes']['setFolderConfig'],
-      getFolderTemplate: ((folderPath) =>
-        invoke(
-          'notes:get-folder-template',
-          folderPath
-        )) as GeneratedRpcApi['notes']['getFolderTemplate'],
-      exportPdf: ((input) =>
-        invoke('notes:export-pdf', input)) as GeneratedRpcApi['notes']['exportPdf'],
-      exportHtml: ((input) =>
-        invoke('notes:export-html', input)) as GeneratedRpcApi['notes']['exportHtml'],
-      getVersions: ((noteId) =>
-        invoke('notes:get-versions', noteId)) as GeneratedRpcApi['notes']['getVersions'],
-      getVersion: ((snapshotId) =>
-        invoke('notes:get-version', snapshotId)) as GeneratedRpcApi['notes']['getVersion'],
-      restoreVersion: ((snapshotId) =>
-        invoke('notes:restore-version', snapshotId)) as GeneratedRpcApi['notes']['restoreVersion'],
-      deleteVersion: ((snapshotId) =>
-        invoke('notes:delete-version', snapshotId)) as GeneratedRpcApi['notes']['deleteVersion'],
-      getPositions: ((folderPath) =>
-        invoke('notes:get-positions', { folderPath })) as GeneratedRpcApi['notes']['getPositions'],
-      getAllPositions: (() =>
-        invoke('notes:get-all-positions')) as GeneratedRpcApi['notes']['getAllPositions'],
-      reorder: ((folderPath, notePaths) =>
-        invoke('notes:reorder', { folderPath, notePaths })) as GeneratedRpcApi['notes']['reorder'],
-      importFiles: ((sourcePaths, targetFolder) =>
-        invoke('notes:import-files', {
-          sourcePaths,
-          targetFolder
-        })) as GeneratedRpcApi['notes']['importFiles'],
-      showImportDialog: (() =>
-        invoke('notes:show-import-dialog')) as GeneratedRpcApi['notes']['showImportDialog'],
-      setLocalOnly: ((id, localOnly) =>
-        invoke('notes:set-local-only', {
-          id,
-          localOnly
-        })) as GeneratedRpcApi['notes']['setLocalOnly'],
-      getLocalOnlyCount: (() =>
-        invoke('notes:get-local-only-count')) as GeneratedRpcApi['notes']['getLocalOnlyCount']
+        })) as GeneratedRpcApi["notes"]["uploadAttachment"],
+      listAttachments: ((noteId) => invoke("notes:list-attachments", noteId)) as GeneratedRpcApi["notes"]["listAttachments"],
+      deleteAttachment: ((noteId, filename) => invoke("notes:delete-attachment", { noteId, filename })) as GeneratedRpcApi["notes"]["deleteAttachment"],
+      getFolderConfig: ((folderPath) => invoke("notes:get-folder-config", folderPath)) as GeneratedRpcApi["notes"]["getFolderConfig"],
+      setFolderConfig: ((folderPath, config) => invoke("notes:set-folder-config", { folderPath, config })) as GeneratedRpcApi["notes"]["setFolderConfig"],
+      getFolderTemplate: ((folderPath) => invoke("notes:get-folder-template", folderPath)) as GeneratedRpcApi["notes"]["getFolderTemplate"],
+      exportPdf: ((input) => invoke("notes:export-pdf", input)) as GeneratedRpcApi["notes"]["exportPdf"],
+      exportHtml: ((input) => invoke("notes:export-html", input)) as GeneratedRpcApi["notes"]["exportHtml"],
+      getVersions: ((noteId) => invoke("notes:get-versions", noteId)) as GeneratedRpcApi["notes"]["getVersions"],
+      getVersion: ((snapshotId) => invoke("notes:get-version", snapshotId)) as GeneratedRpcApi["notes"]["getVersion"],
+      restoreVersion: ((snapshotId) => invoke("notes:restore-version", snapshotId)) as GeneratedRpcApi["notes"]["restoreVersion"],
+      deleteVersion: ((snapshotId) => invoke("notes:delete-version", snapshotId)) as GeneratedRpcApi["notes"]["deleteVersion"],
+      getPositions: ((folderPath) => invoke("notes:get-positions", { folderPath })) as GeneratedRpcApi["notes"]["getPositions"],
+      getAllPositions: (() => invoke("notes:get-all-positions")) as GeneratedRpcApi["notes"]["getAllPositions"],
+      reorder: ((folderPath, notePaths) => invoke("notes:reorder", { folderPath, notePaths })) as GeneratedRpcApi["notes"]["reorder"],
+      importFiles: ((sourcePaths, targetFolder) => invoke("notes:import-files", { sourcePaths, targetFolder })) as GeneratedRpcApi["notes"]["importFiles"],
+      showImportDialog: (() => invoke("notes:show-import-dialog")) as GeneratedRpcApi["notes"]["showImportDialog"],
+      setLocalOnly: ((id, localOnly) => invoke("notes:set-local-only", { id, localOnly })) as GeneratedRpcApi["notes"]["setLocalOnly"],
+      getLocalOnlyCount: (() => invoke("notes:get-local-only-count")) as GeneratedRpcApi["notes"]["getLocalOnlyCount"],
     },
     tasks: {
-      create: ((input) => invoke('tasks:create', input)) as GeneratedRpcApi['tasks']['create'],
-      get: ((id) => invoke('tasks:get', id)) as GeneratedRpcApi['tasks']['get'],
-      update: ((input) => invoke('tasks:update', input)) as GeneratedRpcApi['tasks']['update'],
-      delete: ((id) => invoke('tasks:delete', id)) as GeneratedRpcApi['tasks']['delete'],
-      list: ((options) => invoke('tasks:list', options ?? {})) as GeneratedRpcApi['tasks']['list'],
-      complete: ((input) =>
-        invoke('tasks:complete', input)) as GeneratedRpcApi['tasks']['complete'],
-      uncomplete: ((id) =>
-        invoke('tasks:uncomplete', id)) as GeneratedRpcApi['tasks']['uncomplete'],
-      archive: ((id) => invoke('tasks:archive', id)) as GeneratedRpcApi['tasks']['archive'],
-      unarchive: ((id) => invoke('tasks:unarchive', id)) as GeneratedRpcApi['tasks']['unarchive'],
-      move: ((input) => invoke('tasks:move', input)) as GeneratedRpcApi['tasks']['move'],
-      reorder: ((taskIds, positions) =>
-        invoke('tasks:reorder', { taskIds, positions })) as GeneratedRpcApi['tasks']['reorder'],
-      duplicate: ((id) => invoke('tasks:duplicate', id)) as GeneratedRpcApi['tasks']['duplicate'],
-      getSubtasks: ((parentId) =>
-        invoke('tasks:get-subtasks', parentId)) as GeneratedRpcApi['tasks']['getSubtasks'],
-      convertToSubtask: ((taskId, parentId) =>
-        invoke('tasks:convert-to-subtask', {
-          taskId,
-          parentId
-        })) as GeneratedRpcApi['tasks']['convertToSubtask'],
-      convertToTask: ((taskId) =>
-        invoke('tasks:convert-to-task', taskId)) as GeneratedRpcApi['tasks']['convertToTask'],
-      createProject: ((input) =>
-        invoke('tasks:project-create', input)) as GeneratedRpcApi['tasks']['createProject'],
-      getProject: ((id) =>
-        invoke('tasks:project-get', id)) as GeneratedRpcApi['tasks']['getProject'],
-      updateProject: ((input) =>
-        invoke('tasks:project-update', input)) as GeneratedRpcApi['tasks']['updateProject'],
-      deleteProject: ((id) =>
-        invoke('tasks:project-delete', id)) as GeneratedRpcApi['tasks']['deleteProject'],
-      listProjects: (() =>
-        invoke('tasks:project-list')) as GeneratedRpcApi['tasks']['listProjects'],
-      archiveProject: ((id) =>
-        invoke('tasks:project-archive', id)) as GeneratedRpcApi['tasks']['archiveProject'],
-      reorderProjects: ((projectIds, positions) =>
-        invoke('tasks:project-reorder', {
-          projectIds,
-          positions
-        })) as GeneratedRpcApi['tasks']['reorderProjects'],
-      createStatus: ((input) =>
-        invoke('tasks:status-create', input)) as GeneratedRpcApi['tasks']['createStatus'],
-      updateStatus: ((id, updates) =>
-        invoke('tasks:status-update', {
-          id,
-          ...updates
-        })) as GeneratedRpcApi['tasks']['updateStatus'],
-      deleteStatus: ((id) =>
-        invoke('tasks:status-delete', id)) as GeneratedRpcApi['tasks']['deleteStatus'],
-      reorderStatuses: ((statusIds, positions) =>
-        invoke('tasks:status-reorder', {
-          statusIds,
-          positions
-        })) as GeneratedRpcApi['tasks']['reorderStatuses'],
-      listStatuses: ((projectId) =>
-        invoke('tasks:status-list', projectId)) as GeneratedRpcApi['tasks']['listStatuses'],
-      getTags: (() => invoke('tasks:get-tags')) as GeneratedRpcApi['tasks']['getTags'],
-      bulkComplete: ((ids) =>
-        invoke('tasks:bulk-complete', { ids })) as GeneratedRpcApi['tasks']['bulkComplete'],
-      bulkDelete: ((ids) =>
-        invoke('tasks:bulk-delete', { ids })) as GeneratedRpcApi['tasks']['bulkDelete'],
-      bulkMove: ((ids, projectId) =>
-        invoke('tasks:bulk-move', { ids, projectId })) as GeneratedRpcApi['tasks']['bulkMove'],
-      bulkArchive: ((ids) =>
-        invoke('tasks:bulk-archive', { ids })) as GeneratedRpcApi['tasks']['bulkArchive'],
-      getStats: (() => invoke('tasks:get-stats')) as GeneratedRpcApi['tasks']['getStats'],
-      getToday: (() => invoke('tasks:get-today')) as GeneratedRpcApi['tasks']['getToday'],
-      getUpcoming: ((days) =>
-        invoke('tasks:get-upcoming', {
-          days: days ?? 7
-        })) as GeneratedRpcApi['tasks']['getUpcoming'],
-      getOverdue: (() => invoke('tasks:get-overdue')) as GeneratedRpcApi['tasks']['getOverdue'],
-      getLinkedTasks: ((noteId) =>
-        invoke('tasks:get-linked-tasks', noteId)) as GeneratedRpcApi['tasks']['getLinkedTasks'],
-      seedPerformanceTest: (() =>
-        invoke('tasks:seed-performance-test')) as GeneratedRpcApi['tasks']['seedPerformanceTest'],
-      seedDemo: (() => invoke('tasks:seed-demo')) as GeneratedRpcApi['tasks']['seedDemo']
+      create: ((input) => invoke("tasks:create", input)) as GeneratedRpcApi["tasks"]["create"],
+      get: ((id) => invoke("tasks:get", id)) as GeneratedRpcApi["tasks"]["get"],
+      update: ((input) => invoke("tasks:update", input)) as GeneratedRpcApi["tasks"]["update"],
+      delete: ((id) => invoke("tasks:delete", id)) as GeneratedRpcApi["tasks"]["delete"],
+      list: ((options) => invoke("tasks:list", options ?? {})) as GeneratedRpcApi["tasks"]["list"],
+      complete: ((input) => invoke("tasks:complete", input)) as GeneratedRpcApi["tasks"]["complete"],
+      uncomplete: ((id) => invoke("tasks:uncomplete", id)) as GeneratedRpcApi["tasks"]["uncomplete"],
+      archive: ((id) => invoke("tasks:archive", id)) as GeneratedRpcApi["tasks"]["archive"],
+      unarchive: ((id) => invoke("tasks:unarchive", id)) as GeneratedRpcApi["tasks"]["unarchive"],
+      move: ((input) => invoke("tasks:move", input)) as GeneratedRpcApi["tasks"]["move"],
+      reorder: ((taskIds, positions) => invoke("tasks:reorder", { taskIds, positions })) as GeneratedRpcApi["tasks"]["reorder"],
+      duplicate: ((id) => invoke("tasks:duplicate", id)) as GeneratedRpcApi["tasks"]["duplicate"],
+      getSubtasks: ((parentId) => invoke("tasks:get-subtasks", parentId)) as GeneratedRpcApi["tasks"]["getSubtasks"],
+      convertToSubtask: ((taskId, parentId) => invoke("tasks:convert-to-subtask", { taskId, parentId })) as GeneratedRpcApi["tasks"]["convertToSubtask"],
+      convertToTask: ((taskId) => invoke("tasks:convert-to-task", taskId)) as GeneratedRpcApi["tasks"]["convertToTask"],
+      createProject: ((input) => invoke("tasks:project-create", input)) as GeneratedRpcApi["tasks"]["createProject"],
+      getProject: ((id) => invoke("tasks:project-get", id)) as GeneratedRpcApi["tasks"]["getProject"],
+      updateProject: ((input) => invoke("tasks:project-update", input)) as GeneratedRpcApi["tasks"]["updateProject"],
+      deleteProject: ((id) => invoke("tasks:project-delete", id)) as GeneratedRpcApi["tasks"]["deleteProject"],
+      listProjects: (() => invoke("tasks:project-list")) as GeneratedRpcApi["tasks"]["listProjects"],
+      archiveProject: ((id) => invoke("tasks:project-archive", id)) as GeneratedRpcApi["tasks"]["archiveProject"],
+      reorderProjects: ((projectIds, positions) => invoke("tasks:project-reorder", { projectIds, positions })) as GeneratedRpcApi["tasks"]["reorderProjects"],
+      createStatus: ((input) => invoke("tasks:status-create", input)) as GeneratedRpcApi["tasks"]["createStatus"],
+      updateStatus: ((id, updates) => invoke("tasks:status-update", { id, ...updates })) as GeneratedRpcApi["tasks"]["updateStatus"],
+      deleteStatus: ((id) => invoke("tasks:status-delete", id)) as GeneratedRpcApi["tasks"]["deleteStatus"],
+      reorderStatuses: ((statusIds, positions) => invoke("tasks:status-reorder", { statusIds, positions })) as GeneratedRpcApi["tasks"]["reorderStatuses"],
+      listStatuses: ((projectId) => invoke("tasks:status-list", projectId)) as GeneratedRpcApi["tasks"]["listStatuses"],
+      getTags: (() => invoke("tasks:get-tags")) as GeneratedRpcApi["tasks"]["getTags"],
+      bulkComplete: ((ids) => invoke("tasks:bulk-complete", { ids })) as GeneratedRpcApi["tasks"]["bulkComplete"],
+      bulkDelete: ((ids) => invoke("tasks:bulk-delete", { ids })) as GeneratedRpcApi["tasks"]["bulkDelete"],
+      bulkMove: ((ids, projectId) => invoke("tasks:bulk-move", { ids, projectId })) as GeneratedRpcApi["tasks"]["bulkMove"],
+      bulkArchive: ((ids) => invoke("tasks:bulk-archive", { ids })) as GeneratedRpcApi["tasks"]["bulkArchive"],
+      getStats: (() => invoke("tasks:get-stats")) as GeneratedRpcApi["tasks"]["getStats"],
+      getToday: (() => invoke("tasks:get-today")) as GeneratedRpcApi["tasks"]["getToday"],
+      getUpcoming: ((days) => invoke("tasks:get-upcoming", { days: days ?? 7 })) as GeneratedRpcApi["tasks"]["getUpcoming"],
+      getOverdue: (() => invoke("tasks:get-overdue")) as GeneratedRpcApi["tasks"]["getOverdue"],
+      getLinkedTasks: ((noteId) => invoke("tasks:get-linked-tasks", noteId)) as GeneratedRpcApi["tasks"]["getLinkedTasks"],
+      seedPerformanceTest: (() => invoke("tasks:seed-performance-test")) as GeneratedRpcApi["tasks"]["seedPerformanceTest"],
+      seedDemo: (() => invoke("tasks:seed-demo")) as GeneratedRpcApi["tasks"]["seedDemo"],
     },
     inbox: {
-      captureText: ((input) =>
-        invoke('inbox:capture-text', input)) as GeneratedRpcApi['inbox']['captureText'],
-      captureLink: ((input) =>
-        invoke('inbox:capture-link', input)) as GeneratedRpcApi['inbox']['captureLink'],
-      previewLink: ((url) =>
-        invoke('inbox:preview-link', url)) as GeneratedRpcApi['inbox']['previewLink'],
-      captureImage: ((input) =>
-        invoke('inbox:capture-image', input)) as GeneratedRpcApi['inbox']['captureImage'],
-      captureVoice: ((input) =>
-        invoke('inbox:capture-voice', input)) as GeneratedRpcApi['inbox']['captureVoice'],
-      captureClip: ((input) =>
-        invoke('inbox:capture-clip', input)) as GeneratedRpcApi['inbox']['captureClip'],
-      capturePdf: ((input) =>
-        invoke('inbox:capture-pdf', input)) as GeneratedRpcApi['inbox']['capturePdf'],
-      get: ((id) => invoke('inbox:get', id)) as GeneratedRpcApi['inbox']['get'],
-      list: ((options) => invoke('inbox:list', options ?? {})) as GeneratedRpcApi['inbox']['list'],
-      update: ((input) => invoke('inbox:update', input)) as GeneratedRpcApi['inbox']['update'],
-      archive: ((id) => invoke('inbox:archive', id)) as GeneratedRpcApi['inbox']['archive'],
-      file: ((input) => invoke('inbox:file', input)) as GeneratedRpcApi['inbox']['file'],
-      getSuggestions: ((itemId) =>
-        invoke('inbox:get-suggestions', itemId)) as GeneratedRpcApi['inbox']['getSuggestions'],
+      captureText: ((input) => invoke("inbox:capture-text", input)) as GeneratedRpcApi["inbox"]["captureText"],
+      captureLink: ((input) => invoke("inbox:capture-link", input)) as GeneratedRpcApi["inbox"]["captureLink"],
+      previewLink: ((url) => invoke("inbox:preview-link", url)) as GeneratedRpcApi["inbox"]["previewLink"],
+      captureImage: ((input) => invoke("inbox:capture-image", input)) as GeneratedRpcApi["inbox"]["captureImage"],
+      captureVoice: ((input) => invoke("inbox:capture-voice", input)) as GeneratedRpcApi["inbox"]["captureVoice"],
+      captureClip: ((input) => invoke("inbox:capture-clip", input)) as GeneratedRpcApi["inbox"]["captureClip"],
+      capturePdf: ((input) => invoke("inbox:capture-pdf", input)) as GeneratedRpcApi["inbox"]["capturePdf"],
+      get: ((id) => invoke("inbox:get", id)) as GeneratedRpcApi["inbox"]["get"],
+      list: ((options) => invoke("inbox:list", options ?? {})) as GeneratedRpcApi["inbox"]["list"],
+      update: ((input) => invoke("inbox:update", input)) as GeneratedRpcApi["inbox"]["update"],
+      archive: ((id) => invoke("inbox:archive", id)) as GeneratedRpcApi["inbox"]["archive"],
+      file: ((input) => invoke("inbox:file", input)) as GeneratedRpcApi["inbox"]["file"],
+      getSuggestions: ((itemId) => invoke("inbox:get-suggestions", itemId)) as GeneratedRpcApi["inbox"]["getSuggestions"],
       trackSuggestion: ((input) =>
         invoke(
-          'inbox:track-suggestion',
+          "inbox:track-suggestion",
           input.itemId,
           input.itemType,
           input.suggestedTo,
@@ -282,133 +140,59 @@ export function createGeneratedRpcApi({
           input.confidence,
           input.suggestedTags ?? [],
           input.actualTags ?? []
-        )) as GeneratedRpcApi['inbox']['trackSuggestion'],
-      convertToNote: ((itemId) =>
-        invoke('inbox:convert-to-note', itemId)) as GeneratedRpcApi['inbox']['convertToNote'],
-      convertToTask: ((itemId) =>
-        invoke('inbox:convert-to-task', itemId)) as GeneratedRpcApi['inbox']['convertToTask'],
-      linkToNote: ((itemId, noteId, tags) =>
-        invoke(
-          'inbox:link-to-note',
-          itemId,
-          noteId,
-          tags ?? []
-        )) as GeneratedRpcApi['inbox']['linkToNote'],
-      addTag: ((itemId, tag) =>
-        invoke('inbox:add-tag', itemId, tag)) as GeneratedRpcApi['inbox']['addTag'],
-      removeTag: ((itemId, tag) =>
-        invoke('inbox:remove-tag', itemId, tag)) as GeneratedRpcApi['inbox']['removeTag'],
-      getTags: (() => invoke('inbox:get-tags')) as GeneratedRpcApi['inbox']['getTags'],
-      snooze: ((input) => invoke('inbox:snooze', input)) as GeneratedRpcApi['inbox']['snooze'],
-      unsnooze: ((itemId) =>
-        invoke('inbox:unsnooze', itemId)) as GeneratedRpcApi['inbox']['unsnooze'],
-      getSnoozed: (() => invoke('inbox:get-snoozed')) as GeneratedRpcApi['inbox']['getSnoozed'],
-      markViewed: ((itemId) =>
-        invoke('inbox:mark-viewed', itemId)) as GeneratedRpcApi['inbox']['markViewed'],
-      bulkFile: ((input) =>
-        invoke('inbox:bulk-file', input)) as GeneratedRpcApi['inbox']['bulkFile'],
-      bulkArchive: ((input) =>
-        invoke('inbox:bulk-archive', input)) as GeneratedRpcApi['inbox']['bulkArchive'],
-      bulkTag: ((input) => invoke('inbox:bulk-tag', input)) as GeneratedRpcApi['inbox']['bulkTag'],
-      bulkSnooze: ((input) =>
-        invoke('inbox:bulk-snooze', input)) as GeneratedRpcApi['inbox']['bulkSnooze'],
-      fileAllStale: (() =>
-        invoke('inbox:file-all-stale')) as GeneratedRpcApi['inbox']['fileAllStale'],
-      retryTranscription: ((itemId) =>
-        invoke(
-          'inbox:retry-transcription',
-          itemId
-        )) as GeneratedRpcApi['inbox']['retryTranscription'],
-      retryMetadata: ((itemId) =>
-        invoke('inbox:retry-metadata', itemId)) as GeneratedRpcApi['inbox']['retryMetadata'],
-      getStats: (() => invoke('inbox:get-stats')) as GeneratedRpcApi['inbox']['getStats'],
-      getJobs: ((options) =>
-        invoke('inbox:get-jobs', options ?? {})) as GeneratedRpcApi['inbox']['getJobs'],
-      getPatterns: (() => invoke('inbox:get-patterns')) as GeneratedRpcApi['inbox']['getPatterns'],
-      getStaleThreshold: (() =>
-        invoke('inbox:get-stale-threshold')) as GeneratedRpcApi['inbox']['getStaleThreshold'],
-      setStaleThreshold: ((days) =>
-        invoke('inbox:set-stale-threshold', days)) as GeneratedRpcApi['inbox']['setStaleThreshold'],
-      listArchived: ((options) =>
-        invoke('inbox:list-archived', options ?? {})) as GeneratedRpcApi['inbox']['listArchived'],
-      unarchive: ((id) => invoke('inbox:unarchive', id)) as GeneratedRpcApi['inbox']['unarchive'],
-      deletePermanent: ((id) =>
-        invoke('inbox:delete-permanent', id)) as GeneratedRpcApi['inbox']['deletePermanent'],
-      getFilingHistory: ((options) =>
-        invoke(
-          'inbox:get-filing-history',
-          options ?? {}
-        )) as GeneratedRpcApi['inbox']['getFilingHistory'],
-      undoFile: ((id) => invoke('inbox:undo-file', id)) as GeneratedRpcApi['inbox']['undoFile'],
-      undoArchive: ((id) =>
-        invoke('inbox:undo-archive', id)) as GeneratedRpcApi['inbox']['undoArchive']
+        )) as GeneratedRpcApi["inbox"]["trackSuggestion"],
+      convertToNote: ((itemId) => invoke("inbox:convert-to-note", itemId)) as GeneratedRpcApi["inbox"]["convertToNote"],
+      convertToTask: ((itemId) => invoke("inbox:convert-to-task", itemId)) as GeneratedRpcApi["inbox"]["convertToTask"],
+      linkToNote: ((itemId, noteId, tags) => invoke("inbox:link-to-note", itemId, noteId, tags ?? [])) as GeneratedRpcApi["inbox"]["linkToNote"],
+      addTag: ((itemId, tag) => invoke("inbox:add-tag", itemId, tag)) as GeneratedRpcApi["inbox"]["addTag"],
+      removeTag: ((itemId, tag) => invoke("inbox:remove-tag", itemId, tag)) as GeneratedRpcApi["inbox"]["removeTag"],
+      getTags: (() => invoke("inbox:get-tags")) as GeneratedRpcApi["inbox"]["getTags"],
+      snooze: ((input) => invoke("inbox:snooze", input)) as GeneratedRpcApi["inbox"]["snooze"],
+      unsnooze: ((itemId) => invoke("inbox:unsnooze", itemId)) as GeneratedRpcApi["inbox"]["unsnooze"],
+      getSnoozed: (() => invoke("inbox:get-snoozed")) as GeneratedRpcApi["inbox"]["getSnoozed"],
+      markViewed: ((itemId) => invoke("inbox:mark-viewed", itemId)) as GeneratedRpcApi["inbox"]["markViewed"],
+      bulkFile: ((input) => invoke("inbox:bulk-file", input)) as GeneratedRpcApi["inbox"]["bulkFile"],
+      bulkArchive: ((input) => invoke("inbox:bulk-archive", input)) as GeneratedRpcApi["inbox"]["bulkArchive"],
+      bulkTag: ((input) => invoke("inbox:bulk-tag", input)) as GeneratedRpcApi["inbox"]["bulkTag"],
+      bulkSnooze: ((input) => invoke("inbox:bulk-snooze", input)) as GeneratedRpcApi["inbox"]["bulkSnooze"],
+      fileAllStale: (() => invoke("inbox:file-all-stale")) as GeneratedRpcApi["inbox"]["fileAllStale"],
+      retryTranscription: ((itemId) => invoke("inbox:retry-transcription", itemId)) as GeneratedRpcApi["inbox"]["retryTranscription"],
+      retryMetadata: ((itemId) => invoke("inbox:retry-metadata", itemId)) as GeneratedRpcApi["inbox"]["retryMetadata"],
+      getStats: (() => invoke("inbox:get-stats")) as GeneratedRpcApi["inbox"]["getStats"],
+      getJobs: ((options) => invoke("inbox:get-jobs", options ?? {})) as GeneratedRpcApi["inbox"]["getJobs"],
+      getPatterns: (() => invoke("inbox:get-patterns")) as GeneratedRpcApi["inbox"]["getPatterns"],
+      getStaleThreshold: (() => invoke("inbox:get-stale-threshold")) as GeneratedRpcApi["inbox"]["getStaleThreshold"],
+      setStaleThreshold: ((days) => invoke("inbox:set-stale-threshold", days)) as GeneratedRpcApi["inbox"]["setStaleThreshold"],
+      listArchived: ((options) => invoke("inbox:list-archived", options ?? {})) as GeneratedRpcApi["inbox"]["listArchived"],
+      unarchive: ((id) => invoke("inbox:unarchive", id)) as GeneratedRpcApi["inbox"]["unarchive"],
+      deletePermanent: ((id) => invoke("inbox:delete-permanent", id)) as GeneratedRpcApi["inbox"]["deletePermanent"],
+      getFilingHistory: ((options) => invoke("inbox:get-filing-history", options ?? {})) as GeneratedRpcApi["inbox"]["getFilingHistory"],
+      undoFile: ((id) => invoke("inbox:undo-file", id)) as GeneratedRpcApi["inbox"]["undoFile"],
+      undoArchive: ((id) => invoke("inbox:undo-archive", id)) as GeneratedRpcApi["inbox"]["undoArchive"],
     },
     settings: {
-      get: ((key) => invoke('settings:get', key)) as GeneratedRpcApi['settings']['get'],
-      set: ((key, value) =>
-        invoke('settings:set', { key, value })) as GeneratedRpcApi['settings']['set'],
-      getJournalSettings: (() =>
-        invoke('settings:getJournalSettings')) as GeneratedRpcApi['settings']['getJournalSettings'],
-      setJournalSettings: ((settings) =>
-        invoke(
-          'settings:setJournalSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setJournalSettings'],
-      getAISettings: (() =>
-        invoke('settings:getAISettings')) as GeneratedRpcApi['settings']['getAISettings'],
-      setAISettings: ((settings) =>
-        invoke('settings:setAISettings', settings)) as GeneratedRpcApi['settings']['setAISettings'],
-      getVoiceTranscriptionSettings: (() =>
-        invoke(
-          'settings:getVoiceTranscriptionSettings'
-        )) as GeneratedRpcApi['settings']['getVoiceTranscriptionSettings'],
-      setVoiceTranscriptionSettings: ((settings) =>
-        invoke(
-          'settings:setVoiceTranscriptionSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setVoiceTranscriptionSettings'],
-      getVoiceModelStatus: (() =>
-        invoke(
-          'settings:getVoiceModelStatus'
-        )) as GeneratedRpcApi['settings']['getVoiceModelStatus'],
-      downloadVoiceModel: (() =>
-        invoke('settings:downloadVoiceModel')) as GeneratedRpcApi['settings']['downloadVoiceModel'],
-      getVoiceRecordingReadiness: (() =>
-        invoke(
-          'settings:getVoiceRecordingReadiness'
-        )) as GeneratedRpcApi['settings']['getVoiceRecordingReadiness'],
-      getVoiceTranscriptionOpenAIKeyStatus: (() =>
-        invoke(
-          'settings:getVoiceTranscriptionOpenAIKeyStatus'
-        )) as GeneratedRpcApi['settings']['getVoiceTranscriptionOpenAIKeyStatus'],
-      setVoiceTranscriptionOpenAIKey: ((apiKey) =>
-        invoke('settings:setVoiceTranscriptionOpenAIKey', {
-          apiKey
-        })) as GeneratedRpcApi['settings']['setVoiceTranscriptionOpenAIKey'],
-      getAIModelStatus: (() =>
-        invoke('settings:getAIModelStatus')) as GeneratedRpcApi['settings']['getAIModelStatus'],
-      loadAIModel: (() =>
-        invoke('settings:loadAIModel')) as GeneratedRpcApi['settings']['loadAIModel'],
-      reindexEmbeddings: (() =>
-        invoke('settings:reindexEmbeddings')) as GeneratedRpcApi['settings']['reindexEmbeddings'],
-      getTabSettings: (() =>
-        invoke('settings:getTabSettings')) as GeneratedRpcApi['settings']['getTabSettings'],
-      setTabSettings: ((settings) =>
-        invoke(
-          'settings:setTabSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setTabSettings'],
-      getNoteEditorSettings: (() =>
-        invoke(
-          'settings:getNoteEditorSettings'
-        )) as GeneratedRpcApi['settings']['getNoteEditorSettings'],
-      setNoteEditorSettings: ((settings) =>
-        invoke(
-          'settings:setNoteEditorSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setNoteEditorSettings'],
+      get: ((key) => invoke("settings:get", key)) as GeneratedRpcApi["settings"]["get"],
+      set: ((key, value) => invoke("settings:set", { key, value })) as GeneratedRpcApi["settings"]["set"],
+      getJournalSettings: (() => invoke("settings:getJournalSettings")) as GeneratedRpcApi["settings"]["getJournalSettings"],
+      setJournalSettings: ((settings) => invoke("settings:setJournalSettings", settings)) as GeneratedRpcApi["settings"]["setJournalSettings"],
+      getAISettings: (() => invoke("settings:getAISettings")) as GeneratedRpcApi["settings"]["getAISettings"],
+      setAISettings: ((settings) => invoke("settings:setAISettings", settings)) as GeneratedRpcApi["settings"]["setAISettings"],
+      getVoiceTranscriptionSettings: (() => invoke("settings:getVoiceTranscriptionSettings")) as GeneratedRpcApi["settings"]["getVoiceTranscriptionSettings"],
+      setVoiceTranscriptionSettings: ((settings) => invoke("settings:setVoiceTranscriptionSettings", settings)) as GeneratedRpcApi["settings"]["setVoiceTranscriptionSettings"],
+      getVoiceModelStatus: (() => invoke("settings:getVoiceModelStatus")) as GeneratedRpcApi["settings"]["getVoiceModelStatus"],
+      downloadVoiceModel: (() => invoke("settings:downloadVoiceModel")) as GeneratedRpcApi["settings"]["downloadVoiceModel"],
+      getVoiceRecordingReadiness: (() => invoke("settings:getVoiceRecordingReadiness")) as GeneratedRpcApi["settings"]["getVoiceRecordingReadiness"],
+      getVoiceTranscriptionOpenAIKeyStatus: (() => invoke("settings:getVoiceTranscriptionOpenAIKeyStatus")) as GeneratedRpcApi["settings"]["getVoiceTranscriptionOpenAIKeyStatus"],
+      setVoiceTranscriptionOpenAIKey: ((apiKey) => invoke("settings:setVoiceTranscriptionOpenAIKey", { apiKey })) as GeneratedRpcApi["settings"]["setVoiceTranscriptionOpenAIKey"],
+      getAIModelStatus: (() => invoke("settings:getAIModelStatus")) as GeneratedRpcApi["settings"]["getAIModelStatus"],
+      loadAIModel: (() => invoke("settings:loadAIModel")) as GeneratedRpcApi["settings"]["loadAIModel"],
+      reindexEmbeddings: (() => invoke("settings:reindexEmbeddings")) as GeneratedRpcApi["settings"]["reindexEmbeddings"],
+      getTabSettings: (() => invoke("settings:getTabSettings")) as GeneratedRpcApi["settings"]["getTabSettings"],
+      setTabSettings: ((settings) => invoke("settings:setTabSettings", settings)) as GeneratedRpcApi["settings"]["setTabSettings"],
+      getNoteEditorSettings: (() => invoke("settings:getNoteEditorSettings")) as GeneratedRpcApi["settings"]["getNoteEditorSettings"],
+      setNoteEditorSettings: ((settings) => invoke("settings:setNoteEditorSettings", settings)) as GeneratedRpcApi["settings"]["setNoteEditorSettings"],
       getStartupThemeSync: (() => {
-        const raw = invokeSync('settings:getStartupThemeSync') as
+        const raw = invokeSync("settings:getStartupThemeSync") as
           | 'light'
           | 'dark'
           | 'white'
@@ -416,209 +200,76 @@ export function createGeneratedRpcApi({
           | { theme?: 'light' | 'dark' | 'white' | 'system' }
           | null
           | undefined
-        return typeof raw === 'string' ? raw : (raw?.theme ?? 'system')
-      }) as GeneratedRpcApi['settings']['getStartupThemeSync'],
-      getGeneralSettings: (() =>
-        invoke('settings:getGeneralSettings')) as GeneratedRpcApi['settings']['getGeneralSettings'],
-      setGeneralSettings: ((settings) =>
-        invoke(
-          'settings:setGeneralSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setGeneralSettings'],
-      getEditorSettings: (() =>
-        invoke('settings:getEditorSettings')) as GeneratedRpcApi['settings']['getEditorSettings'],
-      setEditorSettings: ((settings) =>
-        invoke(
-          'settings:setEditorSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setEditorSettings'],
-      getTaskSettings: (() =>
-        invoke('settings:getTaskSettings')) as GeneratedRpcApi['settings']['getTaskSettings'],
-      setTaskSettings: ((settings) =>
-        invoke(
-          'settings:setTaskSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setTaskSettings'],
-      getKeyboardSettings: (() =>
-        invoke(
-          'settings:getKeyboardSettings'
-        )) as GeneratedRpcApi['settings']['getKeyboardSettings'],
-      setKeyboardSettings: ((settings) =>
-        invoke(
-          'settings:setKeyboardSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setKeyboardSettings'],
-      resetKeyboardSettings: (() =>
-        invoke(
-          'settings:resetKeyboardSettings'
-        )) as GeneratedRpcApi['settings']['resetKeyboardSettings'],
-      getSyncSettings: (() =>
-        invoke('settings:getSyncSettings')) as GeneratedRpcApi['settings']['getSyncSettings'],
-      setSyncSettings: ((settings) =>
-        invoke(
-          'settings:setSyncSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setSyncSettings'],
-      getBackupSettings: (() =>
-        invoke('settings:getBackupSettings')) as GeneratedRpcApi['settings']['getBackupSettings'],
-      setBackupSettings: ((settings) =>
-        invoke(
-          'settings:setBackupSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setBackupSettings'],
-      getGraphSettings: (() =>
-        invoke('settings:getGraphSettings')) as GeneratedRpcApi['settings']['getGraphSettings'],
-      setGraphSettings: ((settings) =>
-        invoke(
-          'settings:setGraphSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setGraphSettings'],
-      getCalendarGoogleSettings: (() =>
-        invoke(
-          'settings:getCalendarGoogleSettings'
-        )) as GeneratedRpcApi['settings']['getCalendarGoogleSettings'],
-      setCalendarGoogleSettings: ((settings) =>
-        invoke(
-          'settings:setCalendarGoogleSettings',
-          settings
-        )) as GeneratedRpcApi['settings']['setCalendarGoogleSettings'],
-      registerGlobalCapture: (() =>
-        invoke(
-          'settings:registerGlobalCapture'
-        )) as GeneratedRpcApi['settings']['registerGlobalCapture']
+        return typeof raw === 'string' ? raw : raw?.theme ?? 'system'
+      }) as GeneratedRpcApi["settings"]["getStartupThemeSync"],
+      getGeneralSettings: (() => invoke("settings:getGeneralSettings")) as GeneratedRpcApi["settings"]["getGeneralSettings"],
+      setGeneralSettings: ((settings) => invoke("settings:setGeneralSettings", settings)) as GeneratedRpcApi["settings"]["setGeneralSettings"],
+      getEditorSettings: (() => invoke("settings:getEditorSettings")) as GeneratedRpcApi["settings"]["getEditorSettings"],
+      setEditorSettings: ((settings) => invoke("settings:setEditorSettings", settings)) as GeneratedRpcApi["settings"]["setEditorSettings"],
+      getTaskSettings: (() => invoke("settings:getTaskSettings")) as GeneratedRpcApi["settings"]["getTaskSettings"],
+      setTaskSettings: ((settings) => invoke("settings:setTaskSettings", settings)) as GeneratedRpcApi["settings"]["setTaskSettings"],
+      getKeyboardSettings: (() => invoke("settings:getKeyboardSettings")) as GeneratedRpcApi["settings"]["getKeyboardSettings"],
+      setKeyboardSettings: ((settings) => invoke("settings:setKeyboardSettings", settings)) as GeneratedRpcApi["settings"]["setKeyboardSettings"],
+      resetKeyboardSettings: (() => invoke("settings:resetKeyboardSettings")) as GeneratedRpcApi["settings"]["resetKeyboardSettings"],
+      getSyncSettings: (() => invoke("settings:getSyncSettings")) as GeneratedRpcApi["settings"]["getSyncSettings"],
+      setSyncSettings: ((settings) => invoke("settings:setSyncSettings", settings)) as GeneratedRpcApi["settings"]["setSyncSettings"],
+      getBackupSettings: (() => invoke("settings:getBackupSettings")) as GeneratedRpcApi["settings"]["getBackupSettings"],
+      setBackupSettings: ((settings) => invoke("settings:setBackupSettings", settings)) as GeneratedRpcApi["settings"]["setBackupSettings"],
+      getGraphSettings: (() => invoke("settings:getGraphSettings")) as GeneratedRpcApi["settings"]["getGraphSettings"],
+      setGraphSettings: ((settings) => invoke("settings:setGraphSettings", settings)) as GeneratedRpcApi["settings"]["setGraphSettings"],
+      getCalendarGoogleSettings: (() => invoke("settings:getCalendarGoogleSettings")) as GeneratedRpcApi["settings"]["getCalendarGoogleSettings"],
+      setCalendarGoogleSettings: ((settings) => invoke("settings:setCalendarGoogleSettings", settings)) as GeneratedRpcApi["settings"]["setCalendarGoogleSettings"],
+      getCalendarSettings: (() => invoke("settings:getCalendarSettings")) as GeneratedRpcApi["settings"]["getCalendarSettings"],
+      setCalendarSettings: ((settings) => invoke("settings:setCalendarSettings", settings)) as GeneratedRpcApi["settings"]["setCalendarSettings"],
+      registerGlobalCapture: (() => invoke("settings:registerGlobalCapture")) as GeneratedRpcApi["settings"]["registerGlobalCapture"],
     },
     calendar: {
-      createEvent: ((input) =>
-        invoke('calendar:create-event', input)) as GeneratedRpcApi['calendar']['createEvent'],
-      getEvent: ((id) =>
-        invoke('calendar:get-event', id)) as GeneratedRpcApi['calendar']['getEvent'],
-      updateEvent: ((input) =>
-        invoke('calendar:update-event', input)) as GeneratedRpcApi['calendar']['updateEvent'],
-      deleteEvent: ((id) =>
-        invoke('calendar:delete-event', id)) as GeneratedRpcApi['calendar']['deleteEvent'],
-      listEvents: ((options) =>
-        invoke('calendar:list-events', options ?? {})) as GeneratedRpcApi['calendar']['listEvents'],
-      getRange: ((input) =>
-        invoke('calendar:get-range', input)) as GeneratedRpcApi['calendar']['getRange'],
-      listSources: ((options) =>
-        invoke(
-          'calendar:list-sources',
-          options ?? {}
-        )) as GeneratedRpcApi['calendar']['listSources'],
-      updateSourceSelection: ((input) =>
-        invoke(
-          'calendar:update-source-selection',
-          input
-        )) as GeneratedRpcApi['calendar']['updateSourceSelection'],
-      getProviderStatus: ((input) =>
-        invoke(
-          'calendar:get-provider-status',
-          input
-        )) as GeneratedRpcApi['calendar']['getProviderStatus'],
-      connectProvider: ((input) =>
-        invoke(
-          'calendar:connect-provider',
-          input
-        )) as GeneratedRpcApi['calendar']['connectProvider'],
-      disconnectProvider: ((input) =>
-        invoke(
-          'calendar:disconnect-provider',
-          input
-        )) as GeneratedRpcApi['calendar']['disconnectProvider'],
-      refreshProvider: ((input) =>
-        invoke(
-          'calendar:refresh-provider',
-          input
-        )) as GeneratedRpcApi['calendar']['refreshProvider'],
-      listGoogleCalendars: ((options) =>
-        invoke(
-          'calendar:list-google-calendars',
-          options ?? {}
-        )) as GeneratedRpcApi['calendar']['listGoogleCalendars'],
-      setDefaultGoogleCalendar: ((input) =>
-        invoke(
-          'calendar:set-default-google-calendar',
-          input
-        )) as GeneratedRpcApi['calendar']['setDefaultGoogleCalendar'],
-      promoteExternalEvent: ((input) =>
-        invoke(
-          'calendar:promote-external-event',
-          input
-        )) as GeneratedRpcApi['calendar']['promoteExternalEvent'],
-      retryGoogleCalendarSourceSync: ((input) =>
-        invoke(
-          'calendar:retry-google-source-sync',
-          input
-        )) as GeneratedRpcApi['calendar']['retryGoogleCalendarSourceSync']
+      createEvent: ((input) => invoke("calendar:create-event", input)) as GeneratedRpcApi["calendar"]["createEvent"],
+      getEvent: ((id) => invoke("calendar:get-event", id)) as GeneratedRpcApi["calendar"]["getEvent"],
+      updateEvent: ((input) => invoke("calendar:update-event", input)) as GeneratedRpcApi["calendar"]["updateEvent"],
+      deleteEvent: ((id) => invoke("calendar:delete-event", id)) as GeneratedRpcApi["calendar"]["deleteEvent"],
+      listEvents: ((options) => invoke("calendar:list-events", options ?? {})) as GeneratedRpcApi["calendar"]["listEvents"],
+      getRange: ((input) => invoke("calendar:get-range", input)) as GeneratedRpcApi["calendar"]["getRange"],
+      listSources: ((options) => invoke("calendar:list-sources", options ?? {})) as GeneratedRpcApi["calendar"]["listSources"],
+      updateSourceSelection: ((input) => invoke("calendar:update-source-selection", input)) as GeneratedRpcApi["calendar"]["updateSourceSelection"],
+      getProviderStatus: ((input) => invoke("calendar:get-provider-status", input)) as GeneratedRpcApi["calendar"]["getProviderStatus"],
+      connectProvider: ((input) => invoke("calendar:connect-provider", input)) as GeneratedRpcApi["calendar"]["connectProvider"],
+      disconnectProvider: ((input) => invoke("calendar:disconnect-provider", input)) as GeneratedRpcApi["calendar"]["disconnectProvider"],
+      refreshProvider: ((input) => invoke("calendar:refresh-provider", input)) as GeneratedRpcApi["calendar"]["refreshProvider"],
+      listGoogleCalendars: ((options) => invoke("calendar:list-google-calendars", options ?? {})) as GeneratedRpcApi["calendar"]["listGoogleCalendars"],
+      setDefaultGoogleCalendar: ((input) => invoke("calendar:set-default-google-calendar", input)) as GeneratedRpcApi["calendar"]["setDefaultGoogleCalendar"],
+      promoteExternalEvent: ((input) => invoke("calendar:promote-external-event", input)) as GeneratedRpcApi["calendar"]["promoteExternalEvent"],
+      retryGoogleCalendarSourceSync: ((input) => invoke("calendar:retry-google-source-sync", input)) as GeneratedRpcApi["calendar"]["retryGoogleCalendarSourceSync"],
     },
-    onNoteCreated: ((callback) =>
-      subscribe('notes:created', callback)) as GeneratedRpcApi['onNoteCreated'],
-    onNoteUpdated: ((callback) =>
-      subscribe('notes:updated', callback)) as GeneratedRpcApi['onNoteUpdated'],
-    onNoteDeleted: ((callback) =>
-      subscribe('notes:deleted', callback)) as GeneratedRpcApi['onNoteDeleted'],
-    onNoteRenamed: ((callback) =>
-      subscribe('notes:renamed', callback)) as GeneratedRpcApi['onNoteRenamed'],
-    onNoteMoved: ((callback) =>
-      subscribe('notes:moved', callback)) as GeneratedRpcApi['onNoteMoved'],
-    onNoteExternalChange: ((callback) =>
-      subscribe('notes:external-change', callback)) as GeneratedRpcApi['onNoteExternalChange'],
-    onTagsChanged: ((callback) =>
-      subscribe('notes:tags-changed', callback)) as GeneratedRpcApi['onTagsChanged'],
-    onFolderConfigUpdated: ((callback) =>
-      subscribe(
-        'notes:folder-config-updated',
-        callback
-      )) as GeneratedRpcApi['onFolderConfigUpdated'],
-    onTaskCreated: ((callback) =>
-      subscribe('tasks:created', callback)) as GeneratedRpcApi['onTaskCreated'],
-    onTaskUpdated: ((callback) =>
-      subscribe('tasks:updated', callback)) as GeneratedRpcApi['onTaskUpdated'],
-    onTaskDeleted: ((callback) =>
-      subscribe('tasks:deleted', callback)) as GeneratedRpcApi['onTaskDeleted'],
-    onTaskCompleted: ((callback) =>
-      subscribe('tasks:completed', callback)) as GeneratedRpcApi['onTaskCompleted'],
-    onTaskMoved: ((callback) =>
-      subscribe('tasks:moved', callback)) as GeneratedRpcApi['onTaskMoved'],
-    onProjectCreated: ((callback) =>
-      subscribe('tasks:project-created', callback)) as GeneratedRpcApi['onProjectCreated'],
-    onProjectUpdated: ((callback) =>
-      subscribe('tasks:project-updated', callback)) as GeneratedRpcApi['onProjectUpdated'],
-    onProjectDeleted: ((callback) =>
-      subscribe('tasks:project-deleted', callback)) as GeneratedRpcApi['onProjectDeleted'],
-    onInboxCaptured: ((callback) =>
-      subscribe('inbox:captured', callback)) as GeneratedRpcApi['onInboxCaptured'],
-    onInboxUpdated: ((callback) =>
-      subscribe('inbox:updated', callback)) as GeneratedRpcApi['onInboxUpdated'],
-    onInboxArchived: ((callback) =>
-      subscribe('inbox:archived', callback)) as GeneratedRpcApi['onInboxArchived'],
-    onInboxFiled: ((callback) =>
-      subscribe('inbox:filed', callback)) as GeneratedRpcApi['onInboxFiled'],
-    onInboxSnoozed: ((callback) =>
-      subscribe('inbox:snoozed', callback)) as GeneratedRpcApi['onInboxSnoozed'],
-    onInboxSnoozeDue: ((callback) =>
-      subscribe('inbox:snooze-due', callback)) as GeneratedRpcApi['onInboxSnoozeDue'],
-    onInboxTranscriptionComplete: ((callback) =>
-      subscribe(
-        'inbox:transcription-complete',
-        callback
-      )) as GeneratedRpcApi['onInboxTranscriptionComplete'],
-    onInboxMetadataComplete: ((callback) =>
-      subscribe('inbox:metadata-complete', callback)) as GeneratedRpcApi['onInboxMetadataComplete'],
-    onInboxProcessingError: ((callback) =>
-      subscribe('inbox:processing-error', callback)) as GeneratedRpcApi['onInboxProcessingError'],
-    onSettingsChanged: ((callback) =>
-      subscribe('settings:changed', callback)) as GeneratedRpcApi['onSettingsChanged'],
-    onEmbeddingProgress: ((callback) =>
-      subscribe('settings:embeddingProgress', callback)) as GeneratedRpcApi['onEmbeddingProgress'],
-    onVoiceModelProgress: ((callback) =>
-      subscribe(
-        'settings:voiceModelProgress',
-        callback
-      )) as GeneratedRpcApi['onVoiceModelProgress'],
-    onSettingsOpenRequested: ((callback) =>
-      subscribe('settings:openSection', callback)) as GeneratedRpcApi['onSettingsOpenRequested'],
-    onCalendarChanged: ((callback) =>
-      subscribe('calendar:changed', callback)) as GeneratedRpcApi['onCalendarChanged']
+    onNoteCreated: ((callback) => subscribe("notes:created", callback)) as GeneratedRpcApi["onNoteCreated"],
+    onNoteUpdated: ((callback) => subscribe("notes:updated", callback)) as GeneratedRpcApi["onNoteUpdated"],
+    onNoteDeleted: ((callback) => subscribe("notes:deleted", callback)) as GeneratedRpcApi["onNoteDeleted"],
+    onNoteRenamed: ((callback) => subscribe("notes:renamed", callback)) as GeneratedRpcApi["onNoteRenamed"],
+    onNoteMoved: ((callback) => subscribe("notes:moved", callback)) as GeneratedRpcApi["onNoteMoved"],
+    onNoteExternalChange: ((callback) => subscribe("notes:external-change", callback)) as GeneratedRpcApi["onNoteExternalChange"],
+    onTagsChanged: ((callback) => subscribe("notes:tags-changed", callback)) as GeneratedRpcApi["onTagsChanged"],
+    onFolderConfigUpdated: ((callback) => subscribe("notes:folder-config-updated", callback)) as GeneratedRpcApi["onFolderConfigUpdated"],
+    onTaskCreated: ((callback) => subscribe("tasks:created", callback)) as GeneratedRpcApi["onTaskCreated"],
+    onTaskUpdated: ((callback) => subscribe("tasks:updated", callback)) as GeneratedRpcApi["onTaskUpdated"],
+    onTaskDeleted: ((callback) => subscribe("tasks:deleted", callback)) as GeneratedRpcApi["onTaskDeleted"],
+    onTaskCompleted: ((callback) => subscribe("tasks:completed", callback)) as GeneratedRpcApi["onTaskCompleted"],
+    onTaskMoved: ((callback) => subscribe("tasks:moved", callback)) as GeneratedRpcApi["onTaskMoved"],
+    onProjectCreated: ((callback) => subscribe("tasks:project-created", callback)) as GeneratedRpcApi["onProjectCreated"],
+    onProjectUpdated: ((callback) => subscribe("tasks:project-updated", callback)) as GeneratedRpcApi["onProjectUpdated"],
+    onProjectDeleted: ((callback) => subscribe("tasks:project-deleted", callback)) as GeneratedRpcApi["onProjectDeleted"],
+    onInboxCaptured: ((callback) => subscribe("inbox:captured", callback)) as GeneratedRpcApi["onInboxCaptured"],
+    onInboxUpdated: ((callback) => subscribe("inbox:updated", callback)) as GeneratedRpcApi["onInboxUpdated"],
+    onInboxArchived: ((callback) => subscribe("inbox:archived", callback)) as GeneratedRpcApi["onInboxArchived"],
+    onInboxFiled: ((callback) => subscribe("inbox:filed", callback)) as GeneratedRpcApi["onInboxFiled"],
+    onInboxSnoozed: ((callback) => subscribe("inbox:snoozed", callback)) as GeneratedRpcApi["onInboxSnoozed"],
+    onInboxSnoozeDue: ((callback) => subscribe("inbox:snooze-due", callback)) as GeneratedRpcApi["onInboxSnoozeDue"],
+    onInboxTranscriptionComplete: ((callback) => subscribe("inbox:transcription-complete", callback)) as GeneratedRpcApi["onInboxTranscriptionComplete"],
+    onInboxMetadataComplete: ((callback) => subscribe("inbox:metadata-complete", callback)) as GeneratedRpcApi["onInboxMetadataComplete"],
+    onInboxProcessingError: ((callback) => subscribe("inbox:processing-error", callback)) as GeneratedRpcApi["onInboxProcessingError"],
+    onSettingsChanged: ((callback) => subscribe("settings:changed", callback)) as GeneratedRpcApi["onSettingsChanged"],
+    onEmbeddingProgress: ((callback) => subscribe("settings:embeddingProgress", callback)) as GeneratedRpcApi["onEmbeddingProgress"],
+    onVoiceModelProgress: ((callback) => subscribe("settings:voiceModelProgress", callback)) as GeneratedRpcApi["onVoiceModelProgress"],
+    onSettingsOpenRequested: ((callback) => subscribe("settings:openSection", callback)) as GeneratedRpcApi["onSettingsOpenRequested"],
+    onCalendarChanged: ((callback) => subscribe("calendar:changed", callback)) as GeneratedRpcApi["onCalendarChanged"],
   }
 }

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-item-chip.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-item-chip.tsx
@@ -32,6 +32,10 @@ interface CalendarItemChipProps {
   onDeleteItem?: (item: CalendarProjectionItem) => void
 }
 
+function canDeleteEvent(item: CalendarProjectionItem): boolean {
+  return item.sourceType === 'event' && item.editability.canDelete
+}
+
 export function CalendarItemChip({
   item,
   clockFormat = '12h',
@@ -40,25 +44,27 @@ export function CalendarItemChip({
   onDeleteItem
 }: CalendarItemChipProps): React.JSX.Element {
   const timeLabel = item.isAllDay ? 'All day' : formatTimeOfDay(new Date(item.startAt), clockFormat)
+  const deletable = Boolean(onDeleteItem) && canDeleteEvent(item)
   const cls = cn(
     'flex h-full w-full items-start justify-between gap-0.5 rounded-[6px] border px-1 py-0.5 text-left transition-colors @xl:px-2 @xl:py-1',
     isSelected ? INVERTED_CHIP_STYLES[item.visualType] : CHIP_STYLES[item.visualType],
-    (onClick || onDeleteItem) && 'cursor-pointer hover:brightness-95'
+    (onClick || deletable) && 'cursor-pointer hover:brightness-95'
   )
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
+      if (!deletable || !onDeleteItem) return
       e.preventDefault()
 
-      const menuItems = [{ id: 'delete', label: 'Delete', accelerator: 'Backspace' }]
+      const menuItems = [{ id: 'delete', label: 'Delete event', accelerator: 'Backspace' }]
 
       void window.api.showContextMenu(menuItems).then((selectedId) => {
         if (selectedId === 'delete') {
-          onDeleteItem?.(item)
+          onDeleteItem(item)
         }
       })
     },
-    [item, onDeleteItem]
+    [item, onDeleteItem, deletable]
   )
 
   const content = (
@@ -70,7 +76,7 @@ export function CalendarItemChip({
     </>
   )
 
-  if (onClick || onDeleteItem) {
+  if (onClick || deletable) {
     return (
       <button
         type="button"
@@ -84,7 +90,7 @@ export function CalendarItemChip({
             height: rect.height
           })
         }}
-        onContextMenu={handleContextMenu}
+        onContextMenu={deletable ? handleContextMenu : undefined}
         data-visual-type={item.visualType}
       >
         {content}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
@@ -342,6 +342,9 @@ describe('CalendarPage', () => {
   })
 
   it('deletes a Memry-native event via the right-click menu without Google wording', async () => {
+    const showContextMenu = vi.mocked(window.api.showContextMenu)
+    showContextMenu.mockResolvedValueOnce('delete')
+
     const user = userEvent.setup()
     renderWithProviders(<CalendarPage />)
 
@@ -352,8 +355,10 @@ describe('CalendarPage', () => {
 
     fireEvent.contextMenu(trigger)
 
-    const menuItem = await screen.findByRole('menuitem', { name: /delete event/i })
-    await user.click(menuItem)
+    await waitFor(() => expect(showContextMenu).toHaveBeenCalled())
+    expect(showContextMenu.mock.lastCall?.[0]).toEqual([
+      expect.objectContaining({ id: 'delete', label: 'Delete event' })
+    ])
 
     const dialog = await screen.findByRole('alertdialog', { name: /delete event/i })
     expect(dialog).toHaveTextContent(/planning block/i)
@@ -365,6 +370,8 @@ describe('CalendarPage', () => {
   })
 
   it('warns about Google Calendar when deleting a Google-bound event', async () => {
+    vi.mocked(window.api.showContextMenu).mockResolvedValueOnce('delete')
+
     const user = userEvent.setup()
     renderWithProviders(<CalendarPage />)
 
@@ -374,7 +381,6 @@ describe('CalendarPage', () => {
     expect(trigger).not.toBeNull()
 
     fireEvent.contextMenu(trigger)
-    await user.click(await screen.findByRole('menuitem', { name: /delete event/i }))
 
     const dialog = await screen.findByRole('alertdialog', { name: /delete event/i })
     expect(dialog).toHaveTextContent(/google calendar/i)
@@ -384,6 +390,8 @@ describe('CalendarPage', () => {
   })
 
   it('cancels delete without calling the mutation', async () => {
+    vi.mocked(window.api.showContextMenu).mockResolvedValueOnce('delete')
+
     const user = userEvent.setup()
     renderWithProviders(<CalendarPage />)
 
@@ -391,13 +399,15 @@ describe('CalendarPage', () => {
     const chip = await screen.findByText('Planning block')
     fireEvent.contextMenu(chip.closest('[data-visual-type]') as HTMLElement)
 
-    await user.click(await screen.findByRole('menuitem', { name: /delete event/i }))
+    await screen.findByRole('alertdialog', { name: /delete event/i })
     await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
     expect(mockDeleteEvent).not.toHaveBeenCalled()
   })
 
   it('does not show a delete menu for non-event projection items', async () => {
+    const showContextMenu = vi.mocked(window.api.showContextMenu)
+
     const user = userEvent.setup()
     renderWithProviders(<CalendarPage />)
 
@@ -405,6 +415,6 @@ describe('CalendarPage', () => {
     const taskChip = (await screen.findAllByText('Due draft'))[0]
     fireEvent.contextMenu(taskChip.closest('[data-visual-type]') as HTMLElement)
 
-    expect(screen.queryByRole('menuitem', { name: /delete event/i })).not.toBeInTheDocument()
+    expect(showContextMenu).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
@@ -11,6 +11,17 @@ import { useCalendarView } from '@/contexts/calendar-view-context'
 import { DatePickerCalendar } from '@/components/tasks/date-picker-calendar'
 import { JournalDayPanel } from '@/components/journal'
 import { useJournalHeatmap } from '@/hooks/use-journal'
+import { useCalendarRange } from '@/hooks/use-calendar-range'
+import {
+  useCalendarPreferences,
+  resolveDayCellClickBehavior
+} from '@/hooks/use-calendar-preferences'
+import {
+  addLocalDays,
+  getMonthGridDays,
+  toLocalDateKey,
+  toStartOfLocalDayIso
+} from '@/components/calendar/date-utils'
 import { formatDateToISO, parseISODate, getTodayString } from '@/lib/journal-utils'
 
 interface GlobalDayPanelProps {
@@ -79,19 +90,44 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
   const { openTab } = useTabs()
   const activeTab = useActiveTab()
   const { setAnchorDate } = useCalendarView()
+  const { settings: calendarPrefs } = useCalendarPreferences()
   const isCalendarTabActive = activeTab?.type === 'calendar'
 
   const selectedDateObj = parseISODate(selectedDate)
   const currentYear = selectedDateObj.getFullYear()
   const { data: heatmapData } = useJournalHeatmap(currentYear)
 
-  const calendarActivityData = useMemo(() => {
+  const monthRangeInput = useMemo(() => {
+    const gridDays = getMonthGridDays(selectedDate)
+    const first = gridDays[0]
+    const last = gridDays[gridDays.length - 1]
+    return {
+      startAt: toStartOfLocalDayIso(first),
+      endAt: toStartOfLocalDayIso(addLocalDays(last, 1)),
+      includeUnselectedSources: true
+    }
+  }, [selectedDate])
+
+  const { items: eventItems } = useCalendarRange(monthRangeInput)
+
+  const journalActivityData = useMemo(() => {
     const map: Record<string, number> = {}
     for (const entry of heatmapData) {
       map[entry.date] = entry.level
     }
     return map
   }, [heatmapData])
+
+  const eventActivityData = useMemo(() => {
+    const map: Record<string, number> = {}
+    for (const item of eventItems) {
+      const key = toLocalDateKey(item.startAt)
+      map[key] = Math.min(4, (map[key] ?? 0) + 1)
+    }
+    return map
+  }, [eventItems])
+
+  const calendarActivityData = isCalendarTabActive ? eventActivityData : journalActivityData
 
   const navigateToJournal = useCallback(
     (date: string) => {
@@ -110,29 +146,49 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
     [openTab]
   )
 
+  const navigateToCalendar = useCallback(
+    (date: string) => {
+      setAnchorDate(date)
+      if (isCalendarTabActive) return
+      openTab({
+        type: 'calendar',
+        title: 'Calendar',
+        icon: 'calendar',
+        path: '/calendar',
+        isPinned: false,
+        isModified: false,
+        isPreview: false,
+        isDeleted: false
+      })
+    },
+    [isCalendarTabActive, openTab, setAnchorDate]
+  )
+
   const handleDateSelect = useCallback(
     (date: Date | undefined) => {
       if (!date) return
       const iso = formatDateToISO(date)
       setDate(iso)
-      if (isCalendarTabActive) {
-        setAnchorDate(iso)
+      const target = resolveDayCellClickBehavior(calendarPrefs, isCalendarTabActive)
+      if (target === 'calendar') {
+        navigateToCalendar(iso)
         return
       }
       navigateToJournal(iso)
     },
-    [isCalendarTabActive, setDate, setAnchorDate, navigateToJournal]
+    [calendarPrefs, isCalendarTabActive, setDate, navigateToCalendar, navigateToJournal]
   )
 
   const handleTodayClick = useCallback(() => {
     const today = getTodayString()
     setDate(today)
-    if (isCalendarTabActive) {
-      setAnchorDate(today)
+    const target = resolveDayCellClickBehavior(calendarPrefs, isCalendarTabActive)
+    if (target === 'calendar') {
+      navigateToCalendar(today)
       return
     }
     navigateToJournal(today)
-  }, [isCalendarTabActive, setDate, setAnchorDate, navigateToJournal])
+  }, [calendarPrefs, isCalendarTabActive, setDate, navigateToCalendar, navigateToJournal])
 
   return (
     <div

--- a/apps/desktop/src/renderer/src/contexts/settings-modal-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/settings-modal-context.tsx
@@ -6,6 +6,7 @@ export type SettingsSection =
   | 'templates'
   | 'journal'
   | 'tasks'
+  | 'calendar'
   | 'vault'
   | 'appearance'
   | 'ai'

--- a/apps/desktop/src/renderer/src/hooks/use-calendar-preferences.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-calendar-preferences.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { resolveDayCellClickBehavior } from './use-calendar-preferences'
+import type { CalendarSettings } from '@memry/contracts/settings-schemas'
+
+const make = (overrides: Partial<CalendarSettings> = {}): CalendarSettings => ({
+  dayCellClickBehavior: 'journal',
+  calendarPageClickOverride: 'calendar',
+  ...overrides
+})
+
+describe('resolveDayCellClickBehavior', () => {
+  describe('non-calendar tab', () => {
+    it('uses global journal', () => {
+      const s = make({ dayCellClickBehavior: 'journal' })
+      expect(resolveDayCellClickBehavior(s, false)).toBe('journal')
+    })
+
+    it('uses global calendar', () => {
+      const s = make({ dayCellClickBehavior: 'calendar' })
+      expect(resolveDayCellClickBehavior(s, false)).toBe('calendar')
+    })
+
+    it('ignores the calendar-page override', () => {
+      const s = make({ dayCellClickBehavior: 'journal', calendarPageClickOverride: 'calendar' })
+      expect(resolveDayCellClickBehavior(s, false)).toBe('journal')
+    })
+  })
+
+  describe('calendar tab', () => {
+    it('override=calendar wins over global=journal', () => {
+      const s = make({ dayCellClickBehavior: 'journal', calendarPageClickOverride: 'calendar' })
+      expect(resolveDayCellClickBehavior(s, true)).toBe('calendar')
+    })
+
+    it('override=journal wins over global=calendar', () => {
+      const s = make({ dayCellClickBehavior: 'calendar', calendarPageClickOverride: 'journal' })
+      expect(resolveDayCellClickBehavior(s, true)).toBe('journal')
+    })
+
+    it('override=inherit falls through to global=journal', () => {
+      const s = make({ dayCellClickBehavior: 'journal', calendarPageClickOverride: 'inherit' })
+      expect(resolveDayCellClickBehavior(s, true)).toBe('journal')
+    })
+
+    it('override=inherit falls through to global=calendar', () => {
+      const s = make({ dayCellClickBehavior: 'calendar', calendarPageClickOverride: 'inherit' })
+      expect(resolveDayCellClickBehavior(s, true)).toBe('calendar')
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-calendar-preferences.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-calendar-preferences.ts
@@ -1,0 +1,78 @@
+import { useState, useEffect, useCallback } from 'react'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import {
+  CALENDAR_SETTINGS_DEFAULTS,
+  type CalendarSettings
+} from '@memry/contracts/settings-schemas'
+
+export type DayCellClickBehavior = 'journal' | 'calendar'
+
+interface UseCalendarPreferencesReturn {
+  settings: CalendarSettings
+  isLoading: boolean
+  error: string | null
+  updateSettings: (updates: Partial<CalendarSettings>) => Promise<boolean>
+}
+
+export function useCalendarPreferences(): UseCalendarPreferencesReturn {
+  const [settings, setSettings] = useState<CalendarSettings>(CALENDAR_SETTINGS_DEFAULTS)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    const load = async (): Promise<void> => {
+      try {
+        const result = await window.api.settings.getCalendarSettings()
+        if (mounted) setSettings(result)
+      } catch (err) {
+        if (mounted) setError(extractErrorMessage(err, 'Failed to load calendar preferences'))
+      } finally {
+        if (mounted) setIsLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  useEffect(() => {
+    const unsubscribe = window.api.onSettingsChanged((event) => {
+      if (event.key === 'calendar') {
+        setSettings((prev) => ({ ...prev, ...(event.value as Partial<CalendarSettings>) }))
+      }
+    })
+    return unsubscribe
+  }, [])
+
+  const updateSettings = useCallback(
+    async (updates: Partial<CalendarSettings>): Promise<boolean> => {
+      try {
+        const result = await window.api.settings.setCalendarSettings(updates)
+        if (result.success) {
+          setSettings((prev) => ({ ...prev, ...updates }))
+          return true
+        }
+        setError(result.error ?? 'Update failed')
+        return false
+      } catch (err) {
+        setError(extractErrorMessage(err, 'Failed to update calendar preferences'))
+        return false
+      }
+    },
+    []
+  )
+
+  return { settings, isLoading, error, updateSettings }
+}
+
+export function resolveDayCellClickBehavior(
+  settings: CalendarSettings,
+  isCalendarTabActive: boolean
+): DayCellClickBehavior {
+  if (isCalendarTabActive && settings.calendarPageClickOverride !== 'inherit') {
+    return settings.calendarPageClickOverride
+  }
+  return settings.dayCellClickBehavior
+}

--- a/apps/desktop/src/renderer/src/pages/settings.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings.tsx
@@ -12,7 +12,8 @@ import {
   ListChecks,
   List,
   Key,
-  User
+  User,
+  CalendarDays
 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { GeneralSettings } from './settings/general-section'
@@ -26,6 +27,7 @@ import { IntegrationsSettings } from './settings/integrations-section'
 import { TagsSettings } from './settings/tags-section'
 import { PropertiesSettings } from './settings/properties-section'
 import { TasksSettings } from './settings/tasks-section'
+import { CalendarSettingsSection } from './settings/calendar-section'
 import { ShortcutsSettings } from './settings/shortcuts-section'
 import { AccountSettings } from './settings/account-section'
 import { useSettingsModal } from '@/contexts/settings-modal-context'
@@ -78,6 +80,12 @@ export function SettingsPage() {
             label="Tasks"
             isActive={activeSection === 'tasks'}
             onClick={() => setActiveSection('tasks')}
+          />
+          <SettingsNavItem
+            icon={<CalendarDays className="w-3.5 h-3.5" />}
+            label="Calendar"
+            isActive={activeSection === 'calendar'}
+            onClick={() => setActiveSection('calendar')}
           />
         </SettingsNavGroup>
 
@@ -141,6 +149,7 @@ export function SettingsPage() {
             {activeSection === 'templates' && <TemplatesSettings />}
             {activeSection === 'journal' && <JournalSettings />}
             {activeSection === 'tasks' && <TasksSettings />}
+            {activeSection === 'calendar' && <CalendarSettingsSection />}
             {activeSection === 'vault' && <VaultSettings />}
             {activeSection === 'appearance' && <AppearanceSettings />}
             {activeSection === 'ai' && <AISettings />}

--- a/apps/desktop/src/renderer/src/pages/settings/calendar-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/calendar-section.tsx
@@ -1,0 +1,104 @@
+import { useCallback } from 'react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { useCalendarPreferences } from '@/hooks/use-calendar-preferences'
+import { toast } from 'sonner'
+import {
+  SettingsHeader,
+  SettingsGroup,
+  SettingRow,
+  COMPACT_SELECT
+} from '@/components/settings/settings-primitives'
+import type { CalendarSettings } from '@memry/contracts/settings-schemas'
+
+const GLOBAL_CLICK_OPTIONS = [
+  { value: 'journal', label: 'Open Journal' },
+  { value: 'calendar', label: 'Open Calendar' }
+] as const
+
+const OVERRIDE_OPTIONS = [
+  { value: 'inherit', label: 'Use global setting' },
+  { value: 'calendar', label: 'Open Calendar' },
+  { value: 'journal', label: 'Open Journal' }
+] as const
+
+export function CalendarSettingsSection() {
+  const { settings, isLoading, updateSettings } = useCalendarPreferences()
+
+  const handleGlobalChange = useCallback(
+    async (value: string) => {
+      const next = value as CalendarSettings['dayCellClickBehavior']
+      const success = await updateSettings({ dayCellClickBehavior: next })
+      if (!success) toast.error('Failed to update day click behavior')
+    },
+    [updateSettings]
+  )
+
+  const handleOverrideChange = useCallback(
+    async (value: string) => {
+      const next = value as CalendarSettings['calendarPageClickOverride']
+      const success = await updateSettings({ calendarPageClickOverride: next })
+      if (!success) toast.error('Failed to update calendar page override')
+    },
+    [updateSettings]
+  )
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col">
+        <SettingsHeader title="Calendar" subtitle="Loading settings..." />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col text-xs/4">
+      <SettingsHeader title="Calendar" subtitle="Configure day-cell behavior in the Day Panel" />
+
+      <SettingsGroup label="Day Cell Click">
+        <SettingRow
+          label="Default behavior"
+          description="When clicking a day in the Day Panel calendar from any non-calendar tab"
+        >
+          <Select value={settings.dayCellClickBehavior} onValueChange={handleGlobalChange}>
+            <SelectTrigger className={COMPACT_SELECT}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {GLOBAL_CLICK_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SettingRow>
+
+        <SettingRow
+          label="Calendar page override"
+          description="Behavior when the Calendar tab is active (defaults to Open Calendar)"
+        >
+          <Select value={settings.calendarPageClickOverride} onValueChange={handleOverrideChange}>
+            <SelectTrigger className={COMPACT_SELECT}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {OVERRIDE_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SettingRow>
+      </SettingsGroup>
+    </div>
+  )
+}
+
+export default CalendarSettingsSection

--- a/apps/desktop/tests/setup-dom.ts
+++ b/apps/desktop/tests/setup-dom.ts
@@ -201,7 +201,12 @@ const createMockApi = () => ({
       onboardingCompleted: true,
       promoteConfirmDismissed: false
     }),
-    setCalendarGoogleSettings: vi.fn().mockResolvedValue({ success: true })
+    setCalendarGoogleSettings: vi.fn().mockResolvedValue({ success: true }),
+    getCalendarSettings: vi.fn().mockResolvedValue({
+      dayCellClickBehavior: 'journal',
+      calendarPageClickOverride: 'calendar'
+    }),
+    setCalendarSettings: vi.fn().mockResolvedValue({ success: true })
   },
 
   // Inbox API

--- a/apps/desktop/tests/setup-dom.ts
+++ b/apps/desktop/tests/setup-dom.ts
@@ -45,6 +45,9 @@ const createMockApi = () => ({
   windowMaximize: vi.fn(),
   windowClose: vi.fn(),
 
+  // Native context menu bridge (main-process IPC in production)
+  showContextMenu: vi.fn().mockResolvedValue(null),
+
   // Vault API
   vault: {
     select: vi.fn().mockResolvedValue({ success: true, path: '/mock/vault' }),

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -374,6 +374,10 @@ export const SettingsChannels = {
     GET_CALENDAR_GOOGLE_SETTINGS: 'settings:getCalendarGoogleSettings',
     /** M2: update Google Calendar defaults (partial merge) */
     SET_CALENDAR_GOOGLE_SETTINGS: 'settings:setCalendarGoogleSettings',
+    /** Get calendar preferences (day panel dot source + click behavior) */
+    GET_CALENDAR_SETTINGS: 'settings:getCalendarSettings',
+    /** Update calendar preferences (partial merge) */
+    SET_CALENDAR_SETTINGS: 'settings:setCalendarSettings',
     /** Store API key in OS keychain (never in DB) */
     SET_API_KEY: 'settings:setApiKey',
     /** Test API provider connection */

--- a/packages/contracts/src/settings-schemas.ts
+++ b/packages/contracts/src/settings-schemas.ts
@@ -158,6 +158,22 @@ export const VOICE_TRANSCRIPTION_SETTINGS_DEFAULTS: VoiceTranscriptionSettings =
 }
 
 // ============================================================================
+// Calendar Settings (Day Panel dot source + click behavior)
+// ============================================================================
+
+export const CalendarSettingsSchema = z.object({
+  dayCellClickBehavior: z.enum(['journal', 'calendar']),
+  calendarPageClickOverride: z.enum(['inherit', 'journal', 'calendar'])
+})
+
+export type CalendarSettings = z.infer<typeof CalendarSettingsSchema>
+
+export const CALENDAR_SETTINGS_DEFAULTS: CalendarSettings = {
+  dayCellClickBehavior: 'journal',
+  calendarPageClickOverride: 'calendar'
+}
+
+// ============================================================================
 // Calendar — Google Settings (M2)
 // ============================================================================
 

--- a/packages/rpc/src/settings.ts
+++ b/packages/rpc/src/settings.ts
@@ -1,6 +1,7 @@
 import type {
   BackupSettings,
   CalendarGoogleSettings,
+  CalendarSettings,
   EditorSettings,
   GeneralSettings,
   KeyboardShortcuts,
@@ -260,6 +261,15 @@ export const settingsRpc = defineDomain({
       (settings: Partial<CalendarGoogleSettings>) => SuccessResponse
     >({
       channel: SettingsChannels.invoke.SET_CALENDAR_GOOGLE_SETTINGS,
+      params: ['settings']
+    }),
+    getCalendarSettings: defineMethod<() => Promise<CalendarSettings>>({
+      channel: SettingsChannels.invoke.GET_CALENDAR_SETTINGS
+    }),
+    setCalendarSettings: defineMethod<
+      (settings: Partial<CalendarSettings>) => SuccessResponse
+    >({
+      channel: SettingsChannels.invoke.SET_CALENDAR_SETTINGS,
       params: ['settings']
     }),
     registerGlobalCapture: defineMethod<


### PR DESCRIPTION
## Summary

- **Calendar tab** — Day Panel mini-calendar now shows dots driven by **event counts** (from `useCalendarRange`) instead of the journal heatmap. Other tabs keep the journal heatmap unchanged.
- **Configurable day-cell click** — clicking a day in the Day Panel now routes through a new user preference:
  - **Global** setting: `journal` (default) or `calendar`.
  - **Calendar-page override**: `inherit` / `journal` / `calendar`. Default `calendar` so today's behavior is preserved when the Calendar tab is active.
- Clicking a day from a non-calendar tab with global = `calendar` opens a Calendar tab and sets the anchor date.
- New **Calendar** section in Settings (side nav → Workspace → below Tasks) with two selects.

## Why

The right-sidebar Day Panel is useful on every tab, but on the Calendar tab the journal heatmap dots don't match what the user is actually looking at. The user also wanted control over where a day click leads — Journal for note-centric users, Calendar for calendar-centric users — with a per-page override so the Calendar tab can always mean "stay in Calendar."

## What changed

**Contracts / RPC**
- `packages/contracts/src/settings-schemas.ts` — adds `CalendarSettingsSchema` + `CALENDAR_SETTINGS_DEFAULTS` (distinct from existing `calendar.google` group).
- `packages/contracts/src/ipc-channels.ts` — adds `GET_CALENDAR_SETTINGS` / `SET_CALENDAR_SETTINGS`.
- `packages/rpc/src/settings.ts` — exposes the new methods on the generated RPC API.

**Main (Electron)**
- `apps/desktop/src/main/ipc/settings-handlers.ts` — registers + tears down the two handlers using existing `readGroupSettings` / `writeGroupSettings` helpers with key `'calendar'`.

**Renderer**
- `apps/desktop/src/renderer/src/hooks/use-calendar-preferences.ts` — new hook + pure `resolveDayCellClickBehavior(settings, isCalendarTabActive)` helper.
- `apps/desktop/src/renderer/src/hooks/use-calendar-preferences.test.ts` — 7 unit tests covering the full truth table (global × override × tab-active).
- `apps/desktop/src/renderer/src/pages/settings/calendar-section.tsx` — new settings UI (two `Select` rows).
- `apps/desktop/src/renderer/src/pages/settings.tsx` — adds `Calendar` nav entry (uses existing `CalendarDays` icon).
- `apps/desktop/src/renderer/src/contexts/settings-modal-context.tsx` — extends `SettingsSection` union with `'calendar'`.
- `apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx` — queries the visible month via `useCalendarRange`, swaps activity source based on `isCalendarTabActive`, and routes clicks + today through the resolver. Opens a new Calendar tab when needed.

**Tests**
- `apps/desktop/tests/setup-dom.ts` — adds `getCalendarSettings` / `setCalendarSettings` to the `window.api.settings` mock so existing tests that touch the Day Panel keep working.

## Generated-file churn (flagging for reviewer)

`apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts` and `apps/desktop/src/preload/generated-rpc.ts` have a ~3100-line drop that is **not my hand edit**. Running `pnpm ipc:generate` produced a different format than what was stored in the repo, suggesting pre-existing drift between the committed files and the current generator output. `pnpm ipc:check` passes after regeneration. Happy to revert if there's a preferred CI path (e.g., regenerate in a follow-up) — flagging so it isn't a surprise in review.

## Test plan

- [x] `pnpm typecheck:node` + `pnpm typecheck:web` — both clean.
- [x] `pnpm ipc:check` — up to date.
- [x] `pnpm exec vitest run` — 7139 pass. The 3 failures in `calendar-page.test.tsx` are pre-existing (`window.api.showContextMenu is not a function` — unrelated to this PR).
- [x] New resolver tests — 7 / 7 pass.
- [ ] Manual smoke (`pnpm dev`):
  - Calendar tab + Day Panel open → dots reflect event counts per day; click a day → stays in calendar, anchor moves.
  - Notes tab + Day Panel open → dots reflect journal activity (unchanged); click a day → opens Journal at that date.
  - Change override to `journal` in Settings → click day on Calendar tab opens Journal.
  - Change global to `calendar` → click day from Notes tab opens a Calendar tab.
  - Toggle settings live → Day Panel updates without reload (via `onSettingsChanged` broadcast).
- [ ] E2E (follow-up — planned specs: `right-sidebar-event-dots.spec.ts`, `sidebar-day-click-behavior.spec.ts`). Not included here to keep this PR focused; remember `npx electron-vite build` before `pnpm test:e2e` per CLAUDE.md.

## Open design question

Event dots and journal dots currently share the `ACTIVITY_DOT_COLORS` ramp (green-family, quantized 0–4). Consider adding a distinct ramp (e.g., tint/blue) for events so the swap is visually obvious. Trivial to add a `dotColorVariant` prop on `DatePickerCalendar` if desired.