### PR TITLE
Add desktop release pipeline and updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,8 +123,6 @@ jobs:
           APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
-          WIN_CSC_LINK: ${{ matrix.platform == 'win' && secrets.WINDOWS_CERTIFICATE_PFX || '' }}
-          WIN_CSC_KEY_PASSWORD: ${{ matrix.platform == 'win' && secrets.WINDOWS_CERTIFICATE_PASSWORD || '' }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,16 @@
-name: Desktop Release Build
+name: Desktop Release
 
 on:
-  push:
-    tags:
-      - v*
   workflow_dispatch:
     inputs:
-      platform:
-        description: Platform to build
-        type: choice
-        options:
-          - all
-          - mac
-          - win
-          - linux
-        default: all
+      version:
+        description: Calendar version in YYYY.M.D format. Leave blank to use the UTC date.
+        required: false
+        type: string
+      release_notes:
+        description: Markdown release notes prepended to GitHub-generated release notes.
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -27,24 +23,72 @@ env:
   CI: true
 
 jobs:
+  prepare:
+    name: Prepare release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_name: ${{ steps.version.outputs.release_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Require main branch
+        if: github.ref_name != 'main'
+        run: |
+          echo "Desktop releases must be created from main. Current ref: ${{ github.ref_name }}"
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION="$(date -u '+%Y.%-m.%-d')"
+          fi
+          node scripts/set-desktop-version.mjs --validate-only "$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_name=Memry $VERSION" >> "$GITHUB_OUTPUT"
+
   build:
-    name: Build ${{ matrix.platform }}
+    name: Build ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
+    needs: prepare
     timeout-minutes: 75
-    if: github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == matrix.platform
     strategy:
       fail-fast: false
       matrix:
         include:
-          - platform: mac
-            os: macos-latest
-            script: build:mac
-          - platform: win
+          - label: mac x64
+            platform: mac
+            arch: x64
+            os: macos-15-intel
+            artifact_name: release-mac-x64
+            build_command: pnpm --filter @memry/desktop exec electron-builder --config config/electron-builder.yml --mac --x64 --publish never
+          - label: mac arm64
+            platform: mac
+            arch: arm64
+            os: macos-15
+            artifact_name: release-mac-arm64
+            build_command: pnpm --filter @memry/desktop exec electron-builder --config config/electron-builder.yml --mac --arm64 --publish never
+          - label: win x64
+            platform: win
+            arch: x64
             os: windows-latest
-            script: build:win
-          - platform: linux
+            artifact_name: release-win
+            build_command: pnpm --filter @memry/desktop exec electron-builder --config config/electron-builder.yml --win --x64 --publish never
+          - label: linux x64
+            platform: linux
+            arch: x64
             os: ubuntu-latest
-            script: build:linux
+            artifact_name: release-linux
+            build_command: pnpm --filter @memry/desktop exec electron-builder --config config/electron-builder.yml --linux AppImage deb --x64 --publish never
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,34 +101,97 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      - name: Set release version
+        run: node scripts/set-desktop-version.mjs "${{ needs.prepare.outputs.version }}"
+
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'linux'
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build desktop package
-        run: pnpm ${{ matrix.script }}
+      - name: Build desktop bundle
+        run: pnpm --filter @memry/desktop build
+
+      - name: Package desktop artifacts
+        run: ${{ matrix.build_command }}
+        env:
+          CSC_LINK: ${{ matrix.platform == 'mac' && secrets.MACOS_CERTIFICATE_P12 || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.MACOS_CERTIFICATE_PASSWORD || '' }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.platform == 'mac' && 'false' || '' }}
+          APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
+          WIN_CSC_LINK: ${{ matrix.platform == 'win' && secrets.WINDOWS_CERTIFICATE_PFX || '' }}
+          WIN_CSC_KEY_PASSWORD: ${{ matrix.platform == 'win' && secrets.WINDOWS_CERTIFICATE_PASSWORD || '' }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-${{ matrix.platform }}
-          path: dist/**
+          name: ${{ matrix.artifact_name }}
+          path: apps/desktop/dist/**
           if-no-files-found: error
 
   publish:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
     needs:
+      - prepare
       - build
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
 
+      - name: Merge mac updater metadata
+        shell: bash
+        run: |
+          ruby <<'RUBY'
+          require 'yaml'
+          require 'pathname'
+
+          root = Pathname.new('artifacts')
+          metadata_files = Dir[root.join('**', 'latest-mac.yml').to_s]
+
+          exit 0 if metadata_files.length <= 1
+
+          payloads = metadata_files.map { |file| [file, YAML.load_file(file) || {}] }
+          merged_files = payloads.flat_map do |_, data|
+            files = data['files']
+            next files if files.is_a?(Array) && !files.empty?
+
+            if data['path'] && data['sha512']
+              [{ 'url' => data['path'], 'sha512' => data['sha512'] }]
+            else
+              []
+            end
+          end
+
+          merged_files.uniq! { |entry| [entry['url'], entry['sha512']] }
+          raise 'No mac update files found to merge' if merged_files.empty?
+
+          base = payloads.first.last
+          preferred = merged_files.find { |entry| entry['url'].include?('x64') && entry['url'].end_with?('.zip') } ||
+            merged_files.find { |entry| entry['url'].end_with?('.zip') } ||
+            merged_files.first
+
+          base['files'] = merged_files
+          base['path'] = preferred['url']
+          base['sha512'] = preferred['sha512']
+
+          metadata_files.each { |file| File.delete(file) }
+          File.write(root.join('latest-mac.yml'), YAML.dump(base))
+          RUBY
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.prepare.outputs.version }}
+          name: ${{ needs.prepare.outputs.release_name }}
+          target_commitish: ${{ github.sha }}
           files: artifacts/**/*
+          body: ${{ inputs.release_notes }}
           generate_release_notes: true
           fail_on_unmatched_files: false

--- a/apps/desktop/config/dev-app-update.yml
+++ b/apps/desktop/config/dev-app-update.yml
@@ -1,3 +1,6 @@
-provider: generic
-url: https://example.com/auto-updates
+provider: github
+owner: memrynote
+repo: memry
+releaseType: release
+tagNamePrefix: ''
 updaterCacheDirName: memry-updater

--- a/apps/desktop/config/electron-builder.yml
+++ b/apps/desktop/config/electron-builder.yml
@@ -1,5 +1,6 @@
-appId: com.electron.app
+appId: com.memrynote.memry
 productName: memry
+electronUpdaterCompatibility: '>=2.16'
 directories:
   buildResources: build
 files:
@@ -15,32 +16,33 @@ asarUnpack:
 win:
   executableName: memry
 nsis:
-  artifactName: ${name}-${version}-setup.${ext}
+  artifactName: memry-${version}-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
 mac:
+  artifactName: memry-${version}-${arch}.${ext}
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: false
-dmg:
-  artifactName: ${name}-${version}.${ext}
+  notarize: true
 linux:
   target:
     - AppImage
-    - snap
     - deb
   maintainer: electronjs.org
   category: Utility
 appImage:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: memry-${version}.${ext}
 npmRebuild: false
 publish:
-  provider: generic
-  url: https://example.com/auto-updates
+  provider: github
+  owner: memrynote
+  repo: memry
+  releaseType: release
+  tagNamePrefix: ''
 electronDownload:
   mirror: https://npmmirror.com/mirrors/electron/

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,13 +3,17 @@
   "version": "1.0.0",
   "private": true,
   "license": "GPL-3.0",
-  "description": "An Electron application with React and TypeScript",
+  "description": "Memry desktop app",
   "main": "./out/main/index.js",
   "engines": {
     "node": "24.x"
   },
-  "author": "example.com",
-  "homepage": "https://electron-vite.org",
+  "author": "Memry",
+  "homepage": "https://github.com/memrynote/memry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/memrynote/memry.git"
+  },
   "scripts": {
     "format": "prettier --write .",
     "repair:links": "node ../../scripts/repair-package-links.js apps/desktop",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -46,6 +46,7 @@ import { toAbsolutePath, createSnapshot } from './vault/notes'
 import { safeRead } from './vault/file-ops'
 import { SnapshotReasons } from '@memry/db-schema/schema/notes-cache'
 import { SettingsChannels } from '@memry/contracts/ipc-channels'
+import { initializeUpdater } from './updater'
 
 if (process.type === 'browser') {
   log.initialize()
@@ -651,6 +652,7 @@ void app.whenReady().then(async () => {
   }
 
   createWindow()
+  initializeUpdater()
 
   // Open the last vault and start schedulers concurrently with renderer load.
   // The renderer subscribes to vault status events and updates automatically.

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -319,6 +319,10 @@ export interface MainIpcInvokeHandlers {
   "templates:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/templates-api").Template | null>>
   "templates:list": (...args: []) => Awaited<Promise<{ templates: import("../../../../../packages/contracts/src/templates-api").TemplateListItem[]; }>>
   "templates:update": (...args: [{ id: string; name?: string | undefined; description?: string | undefined; icon?: string | null | undefined; tags?: string[] | undefined; properties?: { name: string; type: "number" | "date" | "text" | "select" | "checkbox" | "url" | "multiselect" | "rating"; value: unknown; options?: string[] | undefined; }[] | undefined; content?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; template: import("../../../../../packages/contracts/src/templates-api").Template; }>>
+  "updater:check-for-updates": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>>
+  "updater:download-update": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>>
+  "updater:get-state": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>
+  "updater:quit-and-install": (...args: []) => Awaited<void>
   "vault:close": (...args: []) => Awaited<Promise<void>>
   "vault:get-all": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").GetVaultsResponse>>
   "vault:get-config": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultConfig>>

--- a/apps/desktop/src/main/ipc/index.test.ts
+++ b/apps/desktop/src/main/ipc/index.test.ts
@@ -42,6 +42,8 @@ const hoisted = vi.hoisted(() => ({
   unregisterAIInlineHandlers: vi.fn(),
   registerAccountHandlers: vi.fn(),
   unregisterAccountHandlers: vi.fn(),
+  registerUpdaterHandlers: vi.fn(),
+  unregisterUpdaterHandlers: vi.fn(),
   registerCrdtIpcHandlers: vi.fn()
 }))
 
@@ -126,6 +128,10 @@ vi.mock('./account-handlers', () => ({
   registerAccountHandlers: hoisted.registerAccountHandlers,
   unregisterAccountHandlers: hoisted.unregisterAccountHandlers
 }))
+vi.mock('./updater-handlers', () => ({
+  registerUpdaterHandlers: hoisted.registerUpdaterHandlers,
+  unregisterUpdaterHandlers: hoisted.unregisterUpdaterHandlers
+}))
 vi.mock('./crdt-handlers', () => ({
   registerCrdtIpcHandlers: hoisted.registerCrdtIpcHandlers
 }))
@@ -146,6 +152,7 @@ describe('ipc index registration lifecycle', () => {
     expect(hoisted.registerSyncHandlers).toHaveBeenCalledTimes(1)
     expect(hoisted.registerCryptoHandlers).toHaveBeenCalledTimes(1)
     expect(hoisted.registerTagsHandlers).toHaveBeenCalledTimes(1)
+    expect(hoisted.registerUpdaterHandlers).toHaveBeenCalledTimes(1)
     expect(hoisted.registerCrdtIpcHandlers).toHaveBeenCalledTimes(1)
   })
 
@@ -156,6 +163,7 @@ describe('ipc index registration lifecycle', () => {
     expect(hoisted.registerVaultHandlers).toHaveBeenCalledTimes(1)
     expect(hoisted.registerSyncHandlers).toHaveBeenCalledTimes(1)
     expect(hoisted.registerCryptoHandlers).toHaveBeenCalledTimes(1)
+    expect(hoisted.registerUpdaterHandlers).toHaveBeenCalledTimes(1)
   })
 
   it('unregisters all handlers and resets state', () => {
@@ -167,6 +175,7 @@ describe('ipc index registration lifecycle', () => {
     expect(hoisted.unregisterVaultHandlers).toHaveBeenCalledTimes(1)
     expect(hoisted.unregisterSyncHandlers).toHaveBeenCalledTimes(1)
     expect(hoisted.unregisterCryptoHandlers).toHaveBeenCalledTimes(1)
+    expect(hoisted.unregisterUpdaterHandlers).toHaveBeenCalledTimes(1)
   })
 
   it('is a no-op to unregister when handlers are not registered', () => {
@@ -175,6 +184,7 @@ describe('ipc index registration lifecycle', () => {
     expect(hoisted.unregisterVaultHandlers).not.toHaveBeenCalled()
     expect(hoisted.unregisterSyncHandlers).not.toHaveBeenCalled()
     expect(hoisted.unregisterCryptoHandlers).not.toHaveBeenCalled()
+    expect(hoisted.unregisterUpdaterHandlers).not.toHaveBeenCalled()
     expect(areHandlersRegistered()).toBe(false)
   })
 })

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -26,6 +26,7 @@ import { registerGraphHandlers, unregisterGraphHandlers } from './graph-handlers
 import { registerAIInlineHandlers, unregisterAIInlineHandlers } from './ai-inline-handlers'
 import { registerAccountHandlers, unregisterAccountHandlers } from './account-handlers'
 import { registerCrdtIpcHandlers } from './crdt-handlers'
+import { registerUpdaterHandlers, unregisterUpdaterHandlers } from './updater-handlers'
 import { createLogger } from '../lib/logger'
 
 const ipcLog = createLogger('IPC')
@@ -114,6 +115,9 @@ export function registerAllHandlers(): void {
   // Register account handlers
   registerAccountHandlers()
 
+  // Register updater handlers
+  registerUpdaterHandlers()
+
   // Register CRDT IPC handlers (app-scoped, survive sign-out/sign-in)
   registerCrdtIpcHandlers()
 
@@ -149,6 +153,7 @@ export function unregisterAllHandlers(): void {
   unregisterGraphHandlers()
   unregisterAIInlineHandlers()
   unregisterAccountHandlers()
+  unregisterUpdaterHandlers()
 
   handlersRegistered = false
   ipcLog.info('all handlers unregistered')
@@ -184,3 +189,4 @@ export { registerCryptoHandlers, unregisterCryptoHandlers } from './crypto-handl
 export { registerSearchHandlers, unregisterSearchHandlers } from './search-handlers'
 export { registerGraphHandlers, unregisterGraphHandlers } from './graph-handlers'
 export { registerAIInlineHandlers, unregisterAIInlineHandlers } from './ai-inline-handlers'
+export { registerUpdaterHandlers, unregisterUpdaterHandlers } from './updater-handlers'

--- a/apps/desktop/src/main/ipc/updater-handlers.ts
+++ b/apps/desktop/src/main/ipc/updater-handlers.ts
@@ -1,0 +1,19 @@
+import { ipcMain } from 'electron'
+import { UpdaterChannels } from '@memry/contracts/ipc-updater'
+import { checkForUpdates, downloadUpdate, getUpdateState, quitAndInstall } from '../updater'
+
+export function registerUpdaterHandlers(): void {
+  ipcMain.handle(UpdaterChannels.invoke.GET_STATE, () => getUpdateState())
+  ipcMain.handle(UpdaterChannels.invoke.CHECK_FOR_UPDATES, () => checkForUpdates())
+  ipcMain.handle(UpdaterChannels.invoke.DOWNLOAD_UPDATE, () => downloadUpdate())
+  ipcMain.handle(UpdaterChannels.invoke.QUIT_AND_INSTALL, () => {
+    quitAndInstall()
+  })
+}
+
+export function unregisterUpdaterHandlers(): void {
+  ipcMain.removeHandler(UpdaterChannels.invoke.GET_STATE)
+  ipcMain.removeHandler(UpdaterChannels.invoke.CHECK_FOR_UPDATES)
+  ipcMain.removeHandler(UpdaterChannels.invoke.DOWNLOAD_UPDATE)
+  ipcMain.removeHandler(UpdaterChannels.invoke.QUIT_AND_INSTALL)
+}

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -13,9 +13,9 @@ let downloadPromptVisible = false
 let restartPromptVisible = false
 
 let state: AppUpdateState = {
-  currentVersion: app.getVersion(),
-  status: app.isPackaged ? 'idle' : 'unavailable',
-  updateSupported: app.isPackaged,
+  currentVersion: getCurrentVersion(),
+  status: isUpdateSupported() ? 'idle' : 'unavailable',
+  updateSupported: isUpdateSupported(),
   availableVersion: null,
   releaseName: null,
   releaseDate: null,
@@ -172,10 +172,18 @@ function setState(patch: Partial<AppUpdateState>): void {
   state = {
     ...state,
     ...patch,
-    currentVersion: app.getVersion(),
-    updateSupported: app.isPackaged
+    currentVersion: getCurrentVersion(),
+    updateSupported: isUpdateSupported()
   }
   broadcastState()
+}
+
+function getCurrentVersion(): string {
+  return typeof app.getVersion === 'function' ? app.getVersion() : '0.0.0'
+}
+
+function isUpdateSupported(): boolean {
+  return app.isPackaged === true
 }
 
 function broadcastState(): void {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,0 +1,270 @@
+import { app, BrowserWindow, dialog } from 'electron'
+import { autoUpdater, type UpdateInfo } from 'electron-updater'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
+import { UpdaterChannels } from '@memry/contracts/ipc-updater'
+import { createLogger } from './lib/logger'
+
+const logger = createLogger('Updater')
+
+let initialized = false
+let activeCheck: Promise<AppUpdateState> | null = null
+let activeDownload: Promise<AppUpdateState> | null = null
+let downloadPromptVisible = false
+let restartPromptVisible = false
+
+let state: AppUpdateState = {
+  currentVersion: app.getVersion(),
+  status: app.isPackaged ? 'idle' : 'unavailable',
+  updateSupported: app.isPackaged,
+  availableVersion: null,
+  releaseName: null,
+  releaseDate: null,
+  releaseNotes: null,
+  downloadProgressPercent: null,
+  lastCheckedAt: null,
+  error: null
+}
+
+export function initializeUpdater(): void {
+  if (initialized || !app.isPackaged) {
+    return
+  }
+
+  initialized = true
+  autoUpdater.autoDownload = false
+  autoUpdater.autoInstallOnAppQuit = true
+
+  autoUpdater.on('checking-for-update', () => {
+    logger.info('checking for updates')
+    setState({
+      status: 'checking',
+      error: null,
+      lastCheckedAt: Date.now(),
+      downloadProgressPercent: null
+    })
+  })
+
+  autoUpdater.on('update-available', (info) => {
+    logger.info('update available', { version: info.version })
+    setState({
+      status: 'available',
+      availableVersion: info.version,
+      releaseName: info.releaseName ?? null,
+      releaseDate: info.releaseDate ?? null,
+      releaseNotes: normalizeReleaseNotes(info),
+      downloadProgressPercent: null,
+      error: null
+    })
+    void promptToDownload(info)
+  })
+
+  autoUpdater.on('update-not-available', () => {
+    logger.info('no update available')
+    setState({
+      status: 'up-to-date',
+      availableVersion: null,
+      releaseName: null,
+      releaseDate: null,
+      releaseNotes: null,
+      downloadProgressPercent: null,
+      error: null
+    })
+  })
+
+  autoUpdater.on('download-progress', (progress) => {
+    setState({
+      status: 'downloading',
+      downloadProgressPercent: Math.max(0, Math.min(100, Math.round(progress.percent)))
+    })
+  })
+
+  autoUpdater.on('update-downloaded', (info) => {
+    logger.info('update downloaded', { version: info.version })
+    setState({
+      status: 'downloaded',
+      availableVersion: info.version,
+      releaseName: info.releaseName ?? null,
+      releaseDate: info.releaseDate ?? null,
+      releaseNotes: normalizeReleaseNotes(info),
+      downloadProgressPercent: 100,
+      error: null
+    })
+    void promptToRestart(info)
+  })
+
+  autoUpdater.on('error', (error) => {
+    const message = error instanceof Error ? error.message : 'Update failed'
+    logger.error('updater error', error)
+    setState({
+      status: 'error',
+      error: message
+    })
+  })
+
+  void checkForUpdates().catch((error) => {
+    logger.warn('startup update check failed', error)
+  })
+}
+
+export function getUpdateState(): AppUpdateState {
+  return { ...state }
+}
+
+export async function checkForUpdates(): Promise<AppUpdateState> {
+  if (!state.updateSupported) {
+    return getUpdateState()
+  }
+
+  if (activeCheck) {
+    return activeCheck
+  }
+
+  activeCheck = autoUpdater
+    .checkForUpdates()
+    .then(() => getUpdateState())
+    .finally(() => {
+      activeCheck = null
+    })
+
+  return activeCheck
+}
+
+export async function downloadUpdate(): Promise<AppUpdateState> {
+  if (!state.updateSupported) {
+    return getUpdateState()
+  }
+
+  if (state.status === 'downloaded') {
+    return getUpdateState()
+  }
+
+  if (activeDownload) {
+    return activeDownload
+  }
+
+  logger.info('starting update download')
+  setState({
+    status: 'downloading',
+    error: null,
+    downloadProgressPercent: state.downloadProgressPercent ?? 0
+  })
+
+  activeDownload = autoUpdater
+    .downloadUpdate()
+    .then(() => getUpdateState())
+    .finally(() => {
+      activeDownload = null
+    })
+
+  return activeDownload
+}
+
+export function quitAndInstall(): void {
+  if (state.status !== 'downloaded') {
+    throw new Error('No downloaded update is ready to install')
+  }
+
+  logger.info('quitting to install update', { version: state.availableVersion })
+  setImmediate(() => autoUpdater.quitAndInstall())
+}
+
+function setState(patch: Partial<AppUpdateState>): void {
+  state = {
+    ...state,
+    ...patch,
+    currentVersion: app.getVersion(),
+    updateSupported: app.isPackaged
+  }
+  broadcastState()
+}
+
+function broadcastState(): void {
+  const snapshot = getUpdateState()
+  BrowserWindow.getAllWindows().forEach((window) => {
+    window.webContents.send(UpdaterChannels.events.STATE_CHANGED, snapshot)
+  })
+}
+
+async function promptToDownload(info: UpdateInfo): Promise<void> {
+  if (downloadPromptVisible) {
+    return
+  }
+
+  downloadPromptVisible = true
+  try {
+    const detail = buildPromptDetail(info, 'Download the update now?')
+    const result = await dialog.showMessageBox({
+      type: 'info',
+      buttons: ['Download', 'Later'],
+      defaultId: 0,
+      cancelId: 1,
+      title: 'Update available',
+      message: `Memry ${info.version} is available.`,
+      detail
+    })
+
+    if (result.response === 0) {
+      await downloadUpdate()
+    }
+  } finally {
+    downloadPromptVisible = false
+  }
+}
+
+async function promptToRestart(info: UpdateInfo): Promise<void> {
+  if (restartPromptVisible) {
+    return
+  }
+
+  restartPromptVisible = true
+  try {
+    const detail = buildPromptDetail(info, 'Restart Memry to finish installing the update.')
+    const result = await dialog.showMessageBox({
+      type: 'info',
+      buttons: ['Restart now', 'Later'],
+      defaultId: 0,
+      cancelId: 1,
+      title: 'Update ready',
+      message: `Memry ${info.version} has been downloaded.`,
+      detail
+    })
+
+    if (result.response === 0) {
+      quitAndInstall()
+    }
+  } finally {
+    restartPromptVisible = false
+  }
+}
+
+function buildPromptDetail(info: UpdateInfo, fallback: string): string {
+  const notes = normalizeReleaseNotes(info)
+  if (!notes) {
+    return fallback
+  }
+
+  const trimmedNotes = notes.length > 1200 ? `${notes.slice(0, 1197)}...` : notes
+  return `${fallback}\n\nRelease notes:\n${trimmedNotes}`
+}
+
+function normalizeReleaseNotes(info: UpdateInfo): string | null {
+  const { releaseNotes } = info
+
+  if (!releaseNotes) {
+    return null
+  }
+
+  if (typeof releaseNotes === 'string') {
+    return releaseNotes.trim() || null
+  }
+
+  const combined = releaseNotes
+    .map((entry) => {
+      const heading = entry.version ? `${entry.version}\n` : ''
+      return `${heading}${entry.note}`.trim()
+    })
+    .filter(Boolean)
+    .join('\n\n')
+
+  return combined || null
+}

--- a/apps/desktop/src/preload/api/updater.ts
+++ b/apps/desktop/src/preload/api/updater.ts
@@ -1,0 +1,16 @@
+import { UpdaterChannels, type AppUpdateState } from '@memry/contracts/ipc-updater'
+import { invoke, subscribe } from '../lib/ipc'
+
+export const updaterApi = {
+  getState: (): Promise<AppUpdateState> => invoke<AppUpdateState>(UpdaterChannels.invoke.GET_STATE),
+  checkForUpdates: (): Promise<AppUpdateState> =>
+    invoke<AppUpdateState>(UpdaterChannels.invoke.CHECK_FOR_UPDATES),
+  downloadUpdate: (): Promise<AppUpdateState> =>
+    invoke<AppUpdateState>(UpdaterChannels.invoke.DOWNLOAD_UPDATE),
+  quitAndInstall: (): Promise<void> => invoke<void>(UpdaterChannels.invoke.QUIT_AND_INSTALL)
+}
+
+export const updaterEvents = {
+  onUpdaterStateChanged: (callback: (state: AppUpdateState) => void): (() => void) =>
+    subscribe<AppUpdateState>(UpdaterChannels.events.STATE_CHANGED, callback)
+}

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -3,6 +3,7 @@ import type { GeneratedRpcApi } from '@memry/rpc'
 import type * as InboxRpc from '@memry/rpc/inbox'
 import type * as NotesRpc from '@memry/rpc/notes'
 import type * as TasksRpc from '@memry/rpc/tasks'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
 import type {
   SyncStatusChangedEvent,
   ItemSyncedEvent,
@@ -1611,6 +1612,12 @@ interface API extends WindowAPI, GeneratedRpcApi {
   syncOps: SyncOpsClientAPI
   crypto: CryptoClientAPI
   syncAttachments: SyncAttachmentsClientAPI
+  updater: {
+    getState: () => Promise<AppUpdateState>
+    checkForUpdates: () => Promise<AppUpdateState>
+    downloadUpdate: () => Promise<AppUpdateState>
+    quitAndInstall: () => Promise<void>
+  }
   syncCrdt: {
     openDoc: (input: { noteId: string }) => Promise<void>
     closeDoc: (input: { noteId: string }) => Promise<void>
@@ -1698,6 +1705,7 @@ interface API extends WindowAPI, GeneratedRpcApi {
   onClockSkewWarning: (callback: (event: ClockSkewWarningEvent) => void) => () => void
   onSecurityWarning: (callback: (event: SecurityWarningEvent) => void) => () => void
   onCertificatePinFailed: (callback: (event: CertificatePinFailedEvent) => void) => () => void
+  onUpdaterStateChanged: (callback: (state: AppUpdateState) => void) => () => void
   onCrdtStateChanged: (
     callback: (data: { noteId: string; update: number[]; origin: string }) => void
   ) => () => void

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -16,6 +16,7 @@ import { searchApi, graphApi, searchEvents } from './api/search'
 import { syncAuth, syncSetup, syncLinking, accountApi, syncDevices } from './api/sync-identity'
 import { syncOps, cryptoApi, syncAttachments, syncCrdt, onCrdtStateChanged } from './api/sync-ops'
 import { syncEvents } from './api/sync-events'
+import { updaterApi, updaterEvents } from './api/updater'
 
 const logger = createLogger('Preload')
 
@@ -77,9 +78,11 @@ export const api = {
   crypto: cryptoApi,
   syncAttachments,
   syncCrdt,
+  updater: updaterApi,
 
   onCrdtStateChanged,
   ...syncEvents,
+  ...updaterEvents,
   ...flushApi
 }
 

--- a/apps/desktop/src/renderer/src/hooks/use-app-updater.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-app-updater.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useState } from 'react'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
+
+const DEFAULT_STATE: AppUpdateState = {
+  currentVersion: '0.0.0',
+  status: 'unavailable',
+  updateSupported: false,
+  availableVersion: null,
+  releaseName: null,
+  releaseDate: null,
+  releaseNotes: null,
+  downloadProgressPercent: null,
+  lastCheckedAt: null,
+  error: null
+}
+
+interface UseAppUpdaterResult {
+  state: AppUpdateState
+  isLoading: boolean
+  error: string | null
+  checkForUpdates: () => Promise<AppUpdateState>
+  downloadUpdate: () => Promise<AppUpdateState>
+  quitAndInstall: () => Promise<void>
+}
+
+export function useAppUpdater(): UseAppUpdaterResult {
+  const [state, setState] = useState<AppUpdateState>(DEFAULT_STATE)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+
+    void window.api.updater
+      .getState()
+      .then((nextState) => {
+        if (mounted) {
+          setState(nextState)
+        }
+      })
+      .catch((err) => {
+        if (mounted) {
+          setError(extractErrorMessage(err, 'Failed to load updater state'))
+        }
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsLoading(false)
+        }
+      })
+
+    const unsubscribe = window.api.onUpdaterStateChanged((nextState) => {
+      setState(nextState)
+      setError(null)
+    })
+
+    return () => {
+      mounted = false
+      unsubscribe()
+    }
+  }, [])
+
+  const checkForUpdates = useCallback(async (): Promise<AppUpdateState> => {
+    try {
+      const nextState = await window.api.updater.checkForUpdates()
+      setState(nextState)
+      setError(null)
+      return nextState
+    } catch (err) {
+      const message = extractErrorMessage(err, 'Failed to check for updates')
+      setError(message)
+      throw new Error(message)
+    }
+  }, [])
+
+  const downloadUpdate = useCallback(async (): Promise<AppUpdateState> => {
+    try {
+      const nextState = await window.api.updater.downloadUpdate()
+      setState(nextState)
+      setError(null)
+      return nextState
+    } catch (err) {
+      const message = extractErrorMessage(err, 'Failed to download update')
+      setError(message)
+      throw new Error(message)
+    }
+  }, [])
+
+  const quitAndInstall = useCallback(async (): Promise<void> => {
+    try {
+      await window.api.updater.quitAndInstall()
+      setError(null)
+    } catch (err) {
+      const message = extractErrorMessage(err, 'Failed to install update')
+      setError(message)
+      throw new Error(message)
+    }
+  }, [])
+
+  return {
+    state,
+    isLoading,
+    error,
+    checkForUpdates,
+    downloadUpdate,
+    quitAndInstall
+  }
+}

--- a/apps/desktop/src/renderer/src/pages/settings/general-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/general-section.tsx
@@ -1,4 +1,6 @@
 import { useCallback } from 'react'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
+import { Button } from '@/components/ui/button'
 import {
   Select,
   SelectContent,
@@ -8,6 +10,7 @@ import {
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { useTabPreferences } from '@/hooks/use-tab-preferences'
+import { useAppUpdater } from '@/hooks/use-app-updater'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { useTabs } from '@/contexts/tabs'
 import { toast } from 'sonner'
@@ -15,6 +18,7 @@ import {
   SettingsHeader,
   SettingsGroup,
   SettingRow,
+  SettingRowTall,
   ACCENT_SWITCH,
   COMPACT_SELECT
 } from '@/components/settings/settings-primitives'
@@ -30,6 +34,14 @@ export function GeneralSettings() {
     isLoading: generalLoading,
     updateSettings: updateGeneralSettings
   } = useGeneralSettings()
+  const {
+    state: updateState,
+    isLoading: updaterLoading,
+    error: updaterError,
+    checkForUpdates,
+    downloadUpdate,
+    quitAndInstall
+  } = useAppUpdater()
   const { updateSettings: updateContextSettings } = useTabs()
 
   const isLoading = tabLoading || generalLoading
@@ -94,6 +106,43 @@ export function GeneralSettings() {
     [updateTabSettings, updateContextSettings]
   )
 
+  const handleUpdateAction = useCallback(async () => {
+    try {
+      if (!updateState.updateSupported) {
+        toast.info('Auto-updates are available in packaged releases only')
+        return
+      }
+
+      if (updateState.status === 'available') {
+        await downloadUpdate()
+        return
+      }
+
+      if (updateState.status === 'downloaded') {
+        await quitAndInstall()
+        return
+      }
+
+      const nextState = await checkForUpdates()
+      if (nextState.status === 'up-to-date') {
+        toast.success(`Memry ${nextState.currentVersion} is up to date`)
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Update action failed')
+    }
+  }, [
+    checkForUpdates,
+    downloadUpdate,
+    quitAndInstall,
+    updateState.status,
+    updateState.updateSupported
+  ])
+
+  const updateDescription = getUpdateDescription(updateState, updaterError)
+  const updateActionLabel = getUpdateActionLabel(updateState)
+  const isUpdateActionDisabled =
+    updaterLoading || updateState.status === 'checking' || updateState.status === 'downloading'
+
   if (isLoading) {
     return (
       <div className="flex flex-col">
@@ -114,6 +163,28 @@ export function GeneralSettings() {
             className={ACCENT_SWITCH}
           />
         </SettingRow>
+      </SettingsGroup>
+
+      <SettingsGroup label="Updates">
+        <SettingRowTall label="App Updates" description={updateDescription}>
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex flex-col gap-1 text-xs/4 text-muted-foreground">
+              <span>Installed version {updateState.currentVersion}</span>
+              {updateState.availableVersion && (
+                <span>Available version {updateState.availableVersion}</span>
+              )}
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant={updateState.status === 'downloaded' ? 'default' : 'outline'}
+              disabled={isUpdateActionDisabled}
+              onClick={() => void handleUpdateAction()}
+            >
+              {updateActionLabel}
+            </Button>
+          </div>
+        </SettingRowTall>
       </SettingsGroup>
 
       <SettingsGroup label="Date &amp; Time">
@@ -181,4 +252,52 @@ export function GeneralSettings() {
       </SettingsGroup>
     </div>
   )
+}
+
+function getUpdateActionLabel(state: AppUpdateState): string {
+  switch (state.status) {
+    case 'checking':
+      return 'Checking...'
+    case 'available':
+      return 'Download Update'
+    case 'downloading':
+      return state.downloadProgressPercent == null
+        ? 'Downloading...'
+        : `Downloading ${state.downloadProgressPercent}%`
+    case 'downloaded':
+      return 'Restart to Install'
+    default:
+      return 'Check for Updates'
+  }
+}
+
+function getUpdateDescription(state: AppUpdateState, updaterError: string | null): string {
+  if (!state.updateSupported) {
+    return 'Packaged builds can check, download, and install updates from GitHub Releases'
+  }
+
+  if (updaterError) {
+    return updaterError
+  }
+
+  if (state.error) {
+    return state.error
+  }
+
+  switch (state.status) {
+    case 'available':
+      return `Memry ${state.availableVersion ?? ''} is available to download`
+    case 'downloading':
+      return state.downloadProgressPercent == null
+        ? 'Downloading the latest release'
+        : `Downloading the latest release (${state.downloadProgressPercent}%)`
+    case 'downloaded':
+      return `Memry ${state.availableVersion ?? ''} is ready to install`
+    case 'up-to-date':
+      return 'This installation is on the latest published release'
+    case 'checking':
+      return 'Checking GitHub Releases for a newer version'
+    default:
+      return 'Check for new releases and install them without leaving the app'
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@10.30.3",
   "scripts": {
     "repair:links": "node scripts/repair-package-links.js .",
+    "release:version": "node scripts/set-desktop-version.mjs",
     "dev": "pnpm dev:desktop",
     "dev:desktop": "node scripts/run-turbo.js run dev --filter=@memry/desktop",
     "dev:sync-server": "node scripts/run-turbo.js run dev --filter=@memry/sync-server",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -25,6 +25,7 @@
     "./ipc-events": "./src/ipc-events.ts",
     "./ipc-sync": "./src/ipc-sync.ts",
     "./ipc-sync-ops": "./src/ipc-sync-ops.ts",
+    "./ipc-updater": "./src/ipc-updater.ts",
     "./journal-api": "./src/journal-api.ts",
     "./linking-api": "./src/linking-api.ts",
     "./notes-api": "./src/notes-api.ts",

--- a/packages/contracts/src/ipc-updater.ts
+++ b/packages/contracts/src/ipc-updater.ts
@@ -1,0 +1,34 @@
+export const UpdaterChannels = {
+  invoke: {
+    GET_STATE: 'updater:get-state',
+    CHECK_FOR_UPDATES: 'updater:check-for-updates',
+    DOWNLOAD_UPDATE: 'updater:download-update',
+    QUIT_AND_INSTALL: 'updater:quit-and-install'
+  },
+  events: {
+    STATE_CHANGED: 'updater:state-changed'
+  }
+} as const
+
+export type UpdaterStatus =
+  | 'unavailable'
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'downloading'
+  | 'downloaded'
+  | 'up-to-date'
+  | 'error'
+
+export interface AppUpdateState {
+  currentVersion: string
+  status: UpdaterStatus
+  updateSupported: boolean
+  availableVersion: string | null
+  releaseName: string | null
+  releaseDate: string | null
+  releaseNotes: string | null
+  downloadProgressPercent: number | null
+  lastCheckedAt: number | null
+  error: string | null
+}

--- a/scripts/set-desktop-version.mjs
+++ b/scripts/set-desktop-version.mjs
@@ -1,0 +1,57 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const [, , maybeFlag, maybeVersion] = process.argv
+
+const validateOnly = maybeFlag === '--validate-only'
+const version = validateOnly ? maybeVersion : maybeFlag
+
+if (!version) {
+  console.error('Usage: node scripts/set-desktop-version.mjs [--validate-only] <calendar-version>')
+  process.exit(1)
+}
+
+validateCalendarVersion(version)
+
+if (validateOnly) {
+  console.log(version)
+  process.exit(0)
+}
+
+const packageJsonPath = resolve('apps/desktop/package.json')
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+
+packageJson.version = version
+
+writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)
+
+console.log(version)
+
+function validateCalendarVersion(input) {
+  if (input.startsWith('v')) {
+    throw new Error('Version must not include a v prefix')
+  }
+
+  const match = /^(\d{4})\.(\d{1,2})\.(\d{1,2})$/.exec(input)
+  if (!match) {
+    throw new Error('Version must match YYYY.M.D')
+  }
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+
+  if (month < 1 || month > 12) {
+    throw new Error('Month must be between 1 and 12')
+  }
+
+  const candidate = new Date(Date.UTC(year, month - 1, day))
+  const isValidDate =
+    candidate.getUTCFullYear() === year &&
+    candidate.getUTCMonth() === month - 1 &&
+    candidate.getUTCDate() === day
+
+  if (!isValidDate) {
+    throw new Error('Day is not valid for the given month/year')
+  }
+}


### PR DESCRIPTION
## What changed
- replace the desktop release workflow with a manual CI release flow that uses UTC calendar versions and prepends manual notes to GitHub-generated release notes
- build and publish updater-compatible desktop artifacts for Windows, Linux, and separate macOS `x64` and `arm64` releases, including merged mac updater metadata
- add Electron updater IPC, main-process orchestration, and a settings UI so users can check, download, and install updates in-app

## Why
The previous release workflow depended on tag pushes and root-level build paths that did not match the desktop package layout, and the app had no in-product update flow.

## Impact
- maintainers can cut GitHub releases from CI with date-based versions like `2026.4.23`
- desktop users can update from inside the app instead of going to the release page
- release notes now serve both the GitHub release and the in-app updater prompt

## Validation
- `pnpm ipc:check`
- `pnpm typecheck:desktop`
