### PR TITLE
Split desktop draft release and asset publishing

### DIFF
--- a/.github/workflows/desktop-draft-release.yml
+++ b/.github/workflows/desktop-draft-release.yml
@@ -1,0 +1,68 @@
+name: Desktop Draft Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: desktop-draft-release-main
+  cancel-in-progress: false
+
+jobs:
+  draft:
+    name: Create draft GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Resolve release metadata
+        id: metadata
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RELEASE_DATE="$(date -u '+%Y.%-m.%-d')"
+
+          git fetch --tags --force
+          {
+            git tag -l 'v*'
+            gh release list --limit 200 --json tagName --jq '.[].tagName'
+          } | sort -u > "$RUNNER_TEMP/desktop-release-tags.txt"
+
+          node scripts/desktop-release-metadata.mjs \
+            --resolve \
+            --date "$RELEASE_DATE" \
+            --existing-tags-file "$RUNNER_TEMP/desktop-release-tags.txt" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Draft GitHub release
+        id: release_drafter
+        uses: release-drafter/release-drafter@v7
+        with:
+          tag: ${{ steps.metadata.outputs.release_tag }}
+          name: ${{ steps.metadata.outputs.release_name }}
+          version: ${{ steps.metadata.outputs.release_tag }}
+          publish: false
+          latest: false
+          commitish: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Summary
+        run: |
+          echo "Draft release: ${{ steps.release_drafter.outputs.html_url }}"
+          echo "Tag: ${{ steps.metadata.outputs.release_tag }}"
+          echo "App version: ${{ steps.metadata.outputs.app_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,15 @@
-name: Desktop Release
+name: Desktop Release Assets
 
 on:
-  workflow_dispatch:
-    inputs:
-      release_date:
-        description: Release date in YYYY.M.D format. Leave blank to use the UTC date.
-        required: false
-        type: string
-      release_notes:
-        description: Markdown release notes prepended to GitHub-generated release notes.
-        required: false
-        type: string
+  release:
+    types:
+      - published
 
 permissions:
   contents: write
-  pull-requests: read
 
 concurrency:
-  group: release-${{ github.workflow }}-${{ github.ref }}
+  group: desktop-release-assets-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 env:
@@ -25,7 +17,7 @@ env:
 
 jobs:
   prepare:
-    name: Prepare release metadata
+    name: Prepare published release metadata
     runs-on: ubuntu-latest
     outputs:
       app_version: ${{ steps.metadata.outputs.app_version }}
@@ -36,13 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-
-      - name: Require main branch
-        if: github.ref_name != 'main'
-        run: |
-          echo "Desktop releases must be created from main. Current ref: ${{ github.ref_name }}"
-          exit 1
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -51,25 +37,10 @@ jobs:
 
       - name: Resolve release metadata
         id: metadata
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          RELEASE_DATE="${{ inputs.release_date }}"
-          if [ -z "$RELEASE_DATE" ]; then
-            RELEASE_DATE="$(date -u '+%Y.%-m.%-d')"
-          fi
-
-          git fetch --tags --force
-          {
-            git tag -l 'v*'
-            gh release list --limit 200 --json tagName --jq '.[].tagName'
-          } | sort -u > "$RUNNER_TEMP/desktop-release-tags.txt"
-
           node scripts/desktop-release-metadata.mjs \
-            --resolve \
-            --date "$RELEASE_DATE" \
-            --existing-tags-file "$RUNNER_TEMP/desktop-release-tags.txt" \
+            --from-tag \
+            --tag "${{ github.event.release.tag_name }}" \
             --github-output "$GITHUB_OUTPUT"
 
   build:
@@ -108,9 +79,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release_tag }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -151,8 +125,8 @@ jobs:
           path: apps/desktop/dist/**
           if-no-files-found: error
 
-  publish:
-    name: Create draft GitHub Release
+  upload:
+    name: Upload release assets
     runs-on: ubuntu-latest
     needs:
       - prepare
@@ -229,23 +203,9 @@ jobs:
 
           find release-assets -maxdepth 1 -type f -print | sort
 
-      - name: Draft GitHub release
-        id: release_drafter
-        uses: release-drafter/release-drafter@v7
-        with:
-          tag: ${{ needs.prepare.outputs.release_tag }}
-          name: ${{ needs.prepare.outputs.release_name }}
-          version: ${{ needs.prepare.outputs.app_version }}
-          publish: false
-          latest: false
-          commitish: ${{ github.sha }}
-          header: ${{ inputs.release_notes }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
       - name: Upload release assets
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ steps.release_drafter.outputs.tag_name }}" release-assets/* --clobber
+          gh release upload "${{ needs.prepare.outputs.release_tag }}" release-assets/* --clobber

--- a/scripts/desktop-release-metadata.mjs
+++ b/scripts/desktop-release-metadata.mjs
@@ -92,6 +92,19 @@ export function resolveReleaseMetadata({ date, existingTags }) {
   }
 }
 
+export function resolveReleaseMetadataFromTag(tag) {
+  const parsed = parseReleaseTag(tag)
+  const appVersion = formatAppVersion(parsed.date, parsed.index)
+
+  return {
+    appVersion,
+    releaseDate: parsed.date,
+    releaseIndex: parsed.index,
+    releaseName: `Memry ${parsed.tag}`,
+    releaseTag: parsed.tag
+  }
+}
+
 function formatReleaseTag(date, index) {
   if (index === 1) {
     return `v${date}`
@@ -133,6 +146,17 @@ function parseArgs(argv) {
 
     if (arg === '--resolve') {
       options.mode = 'resolve'
+      continue
+    }
+
+    if (arg === '--from-tag') {
+      options.mode = 'from-tag'
+      continue
+    }
+
+    if (arg === '--tag') {
+      options.tag = readRequiredValue(argv, index, arg)
+      index += 1
       continue
     }
 
@@ -222,8 +246,19 @@ function main() {
     return
   }
 
+  if (options.mode === 'from-tag') {
+    const metadata = resolveReleaseMetadataFromTag(options.tag)
+
+    if (options.githubOutput) {
+      writeGitHubOutputs(options.githubOutput, metadata)
+    }
+
+    console.log(JSON.stringify(metadata, null, 2))
+    return
+  }
+
   throw new Error(
-    'Usage: node scripts/desktop-release-metadata.mjs --resolve --date <YYYY.M.D> [--existing-tags-file path] [--github-output path]'
+    'Usage: node scripts/desktop-release-metadata.mjs --resolve --date <YYYY.M.D> [--existing-tags-file path] [--github-output path] OR --from-tag --tag <vYYYY.M.D[-NNN]>'
   )
 }
 

--- a/scripts/desktop-release-metadata.test.mjs
+++ b/scripts/desktop-release-metadata.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test'
 import {
   parseReleaseTag,
   resolveReleaseMetadata,
+  resolveReleaseMetadataFromTag,
   validateAppVersion,
   validateReleaseDate
 } from './desktop-release-metadata.mjs'
@@ -44,6 +45,16 @@ describe('desktop release metadata', () => {
     assert.equal(metadata.releaseTag, 'v2026.4.27-003')
     assert.equal(metadata.appVersion, '2026.427.3')
     assert.equal(metadata.releaseIndex, 3)
+  })
+
+  it('derives app metadata from a published release tag', () => {
+    assert.deepEqual(resolveReleaseMetadataFromTag('v2026.4.27-002'), {
+      appVersion: '2026.427.2',
+      releaseDate: '2026.4.27',
+      releaseIndex: 2,
+      releaseName: 'Memry v2026.4.27-002',
+      releaseTag: 'v2026.4.27-002'
+    })
   })
 
   it('parses supported release tag formats', () => {


### PR DESCRIPTION
## Summary
- create draft desktop releases automatically on pushes to main using Release Drafter
- build and upload desktop assets only after a draft release is published
- derive the desktop app version from the published release tag before packaging

## Verification
- node --test scripts/desktop-release-metadata.test.mjs
- node scripts/desktop-release-metadata.mjs --from-tag --tag v2026.4.27-002
- ruby -e "require 'yaml'; Dir['.github/workflows/*.yml'].each { |f| YAML.load_file(f) }; YAML.load_file('.github/release-drafter.yml'); puts 'yaml-ok'"\n- pnpm exec prettier --check .github/workflows/desktop-draft-release.yml .github/workflows/release.yml scripts/desktop-release-metadata.mjs scripts/desktop-release-metadata.test.mjs\n- git diff --check -- .github/workflows/desktop-draft-release.yml .github/workflows/release.yml scripts/desktop-release-metadata.mjs scripts/desktop-release-metadata.test.mjs