### PR TITLE
Fix desktop release asset builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,18 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to build and attach assets for, e.g. v2026.4.28.
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 concurrency:
-  group: desktop-release-assets-${{ github.event.release.tag_name }}
+  group: desktop-release-assets-${{ github.event.release.tag_name || inputs.release_tag }}
   cancel-in-progress: false
 
 env:
@@ -21,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       app_version: ${{ steps.metadata.outputs.app_version }}
+      checkout_ref: ${{ steps.refs.outputs.checkout_ref }}
       release_date: ${{ steps.metadata.outputs.release_date }}
       release_name: ${{ steps.metadata.outputs.release_name }}
       release_tag: ${{ steps.metadata.outputs.release_tag }}
@@ -28,7 +35,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.release.tag_name }}
+
+      - name: Resolve checkout ref
+        id: refs
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "checkout_ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "checkout_ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -40,7 +57,7 @@ jobs:
         run: |
           node scripts/desktop-release-metadata.mjs \
             --from-tag \
-            --tag "${{ github.event.release.tag_name }}" \
+            --tag "${{ github.event.release.tag_name || inputs.release_tag }}" \
             --github-output "$GITHUB_OUTPUT"
 
   build:
@@ -80,7 +97,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.release_tag }}
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -102,7 +119,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build desktop bundle
-        run: pnpm --filter @memry/desktop build
+        run: |
+          pnpm --filter @memry/desktop repair:links
+          pnpm --filter @memry/desktop exec electron-vite build
 
       - name: Package desktop artifacts
         run: ${{ matrix.build_command }}

--- a/apps/desktop/config/electron-builder.yml
+++ b/apps/desktop/config/electron-builder.yml
@@ -31,7 +31,7 @@ nsis:
   createDesktopShortcut: always
 mac:
   artifactName: memry-${version}-${arch}.${ext}
-  entitlementsInherit: build/entitlements.mac.plist
+  entitlementsInherit: config/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.

--- a/apps/desktop/config/entitlements.mac.plist
+++ b/apps/desktop/config/entitlements.mac.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.files.downloads.read-write</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/desktop/scripts/build-packaged-app.js
+++ b/apps/desktop/scripts/build-packaged-app.js
@@ -15,6 +15,7 @@ const stageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-desktop-package-')
 const distDir = path.join(appRoot, 'dist')
 const defaultConfigPath = 'config/electron-builder.staged.yml'
 const nativeModules = ['better-sqlite3', 'classic-level', 'keytar']
+const generateIconsScript = path.join(appRoot, 'scripts', 'generate-icons.mjs')
 
 function removePath(targetPath) {
   const stat = fs.lstatSync(targetPath, { throwIfNoEntry: false })
@@ -109,6 +110,12 @@ function relativizeInternalSymlinks(rootPath) {
   }
 }
 
+function ensureBuildResources() {
+  run(process.execPath, [generateIconsScript], {
+    cwd: appRoot
+  })
+}
+
 function main() {
   const { args, configPath } = parseElectronBuilderArgs(process.argv.slice(2))
 
@@ -126,6 +133,7 @@ function main() {
     }
   })
 
+  ensureBuildResources()
   syncIntoStage('build')
   syncIntoStage('config')
   syncIntoStage('out')

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
       "undici": ">=7.24.0",
       "flatted": ">=3.4.2",
       "lodash": ">=4.18.1",
-      "@xmldom/xmldom": "0.8.12",
       "path-to-regexp": ">=8.4.0",
       "picomatch": ">=4.0.4",
       "vite": "^7.3.2",


### PR DESCRIPTION
## Summary
- generate desktop build resources before staged packaging
- move mac entitlements to tracked config so fresh CI checkouts can sign/package
- let Desktop Release Assets rerun against an existing release tag, while building from the workflow ref for manual backfills
- use direct electron-vite build in the release workflow to avoid the Windows-only architecture-check path issue
- remove the duplicate @xmldom override key

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release-yaml-ok'"
- pnpm exec prettier --check package.json .github/workflows/release.yml apps/desktop/config/electron-builder.yml apps/desktop/scripts/build-packaged-app.js
- git diff --check -- package.json .github/workflows/release.yml apps/desktop/config/electron-builder.yml apps/desktop/config/entitlements.mac.plist apps/desktop/scripts/build-packaged-app.js
- plutil -lint apps/desktop/config/entitlements.mac.plist
- node -c apps/desktop/scripts/build-packaged-app.js
- node --test scripts/desktop-release-metadata.test.mjs
- pnpm --filter @memry/desktop repair:links
- pnpm --filter @memry/desktop exec electron-vite build
- CSC_IDENTITY_AUTO_DISCOVERY=false node apps/desktop/scripts/build-packaged-app.js --dir --publish never