### PR TITLE
feat(calendar): make inbox-snooze chips clickable with action popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-04-30 — Calendar: clickable inbox-snooze chips
+
+### Added
+- Inbox-snooze chips on the calendar are now clickable. Clicking opens a small floating popover next to the chip with three actions: **Open in inbox** (jumps to the inbox tab), **Unsnooze now** (clears the snooze and removes the chip), and **Reschedule** (reuses the standard `<SnoozePicker>` preset list + custom date/time dialog). Previously the click was a silent no-op.
+- New `<CalendarInboxSnoozePopover>` component (presentational; receives data + callbacks) mirroring the positioning + dismiss pattern of `<CalendarEventPopover>`. The outside-click handler explicitly excludes Radix popper portals so the nested SnoozePicker dropdown/dialog don't dismiss the popover mid-interaction.
+- E2E coverage in `calendar-inbox-snooze-click.e2e.ts`: chip-click → popover with three actions + Escape dismiss; Unsnooze removes the chip; Open in inbox tears down the calendar surface (singleton inbox tab takes over).
+
+### Changed
+- After Unsnooze and Reschedule the calendar range query is invalidated so the chip moves or disappears immediately.
+- Reminder click handling (`sourceType === 'reminder'`) is intentionally still a no-op — its 4-state lifecycle needs its own design pass and ships separately.
+
+---
+
 ## 2026-04-29 — Multi-language Support (English, Turkish, Arabic) with RTL
 
 ### Added

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -3,2592 +3,343 @@
 /* eslint-disable max-lines */
 
 export interface MainIpcInvokeHandlers {
-  'account:getInfo': (...args: []) => Awaited<import('./account-handlers').AccountInfo>
-  'account:getRecoveryKey': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      | { success: boolean; error: string; key?: undefined }
-      | { success: boolean; key: string; error?: undefined }
-    >
-  >
-  'account:signOut': (
-    ...args: []
-  ) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean }>>
-  'ai-inline:get-server-port': (...args: []) => Awaited<number | null>
-  'ai-inline:get-settings': (
-    ...args: []
-  ) => Awaited<import('../../../../../packages/contracts/src/ai-inline-channels').AIInlineSettings>
-  'ai-inline:set-settings': (
-    ...args: [
-      Partial<import('../../../../../packages/contracts/src/ai-inline-channels').AIInlineSettings>
-    ]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'ai-inline:start-server': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; error: string; port?: undefined }
-      | { success: boolean; port: number; error?: undefined }
-    >
-  >
-  'ai-inline:stop-server': (...args: []) => Awaited<Promise<{ success: boolean }>>
-  'auth:init-oauth': (
-    ...args: [{ provider: 'google' }]
-  ) => Awaited<Promise<{ state: string }> | { success: false; error: string }>
-  'auth:refresh-token': (
-    ...args: []
-  ) => Awaited<Promise<{ success: boolean; error: string | undefined }>>
-  'auth:request-otp': (
-    ...args: [{ email: string }]
-  ) => Awaited<Promise<unknown> | { success: false; error: string }>
-  'auth:resend-otp': (
-    ...args: [{ email: string }]
-  ) => Awaited<Promise<unknown> | { success: false; error: string }>
-  'auth:verify-otp': (...args: [{ email: string; code: string }]) => Awaited<
-    | Promise<{
-        success: boolean
-        isNewUser: boolean
-        needsSetup: boolean
-        needsRecoveryInput: boolean
-      }>
-    | { success: false; error: string }
-  >
-  'bookmarks:bulk-create': (
-    ...args: [{ items: { itemType: string; itemId: string }[] }]
-  ) => Awaited<Promise<{ success: boolean; createdCount: number }>>
-  'bookmarks:bulk-delete': (
-    ...args: [{ bookmarkIds: string[] }]
-  ) => Awaited<Promise<{ success: boolean; deletedCount: number }>>
-  'bookmarks:create': (...args: [{ itemType: string; itemId: string }]) => Awaited<
-    Promise<
-      | { success: boolean; bookmark: null; error: string }
-      | {
-          success: boolean
-          bookmark: {
-            id: string
-            createdAt: string
-            position: number
-            itemType: string
-            itemId: string
-          }
-          error?: undefined
-        }
-    >
-  >
-  'bookmarks:delete': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  >
-  'bookmarks:get': (...args: [string]) => Awaited<
-    Promise<{
-      id: string
-      createdAt: string
-      position: number
-      itemType: string
-      itemId: string
-    } | null>
-  >
-  'bookmarks:get-by-item': (...args: [{ itemType: string; itemId: string }]) => Awaited<
-    Promise<{
-      id: string
-      createdAt: string
-      position: number
-      itemType: string
-      itemId: string
-    } | null>
-  >
-  'bookmarks:is-bookmarked': (
-    ...args: [{ itemType: string; itemId: string }]
-  ) => Awaited<Promise<boolean>>
-  'bookmarks:list': (
-    ...args: [
-      {
-        itemType?: string | undefined
-        sortBy?: 'createdAt' | 'position' | undefined
-        sortOrder?: 'asc' | 'desc' | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/bookmarks-api').BookmarkListResponse>
-  >
-  'bookmarks:list-by-type': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/bookmarks-api').BookmarkListResponse>
-  >
-  'bookmarks:reorder': (
-    ...args: [{ bookmarkIds: string[] }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'bookmarks:toggle': (...args: [{ itemType: string; itemId: string }]) => Awaited<
-    Promise<{
-      success: boolean
-      isBookmarked: boolean
-      bookmark: {
-        id: string
-        createdAt: string
-        position: number
-        itemType: string
-        itemId: string
-      } | null
-    }>
-  >
-  'calendar:connect-provider': (
-    ...args: [{ provider: string; accountId?: string | undefined }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarProviderMutationResponse
-    >
-  >
-  'calendar:create-event': (
-    ...args: [
-      {
-        title: string
-        startAt: string
-        description?: string | null | undefined
-        location?: string | null | undefined
-        endAt?: string | null | undefined
-        timezone?: string | undefined
-        isAllDay?: boolean | undefined
-        recurrenceRule?: Record<string, unknown> | null | undefined
-        recurrenceExceptions?: string[] | null | undefined
-        targetCalendarId?: string | null | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarEventMutationResponse
-    >
-  >
-  'calendar:delete-event': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarDeleteResponse
-    >
-  >
-  'calendar:disconnect-provider': (
-    ...args: [{ provider: string; accountId?: string | undefined }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarProviderMutationResponse
-    >
-  >
-  'calendar:get-event': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarEventRecord | null>
-  >
-  'calendar:get-provider-status': (
-    ...args: [{ provider: string; accountId?: string | undefined }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarProviderStatus>
-  >
-  'calendar:get-range': (
-    ...args: [{ startAt: string; endAt: string; includeUnselectedSources?: boolean | undefined }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarRangeResponse>
-  >
-  'calendar:list-events': (
-    ...args: [{ includeArchived?: boolean | undefined }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarEventListResponse>
-  >
-  'calendar:list-google-calendars': (
-    ...args: [Record<string, never> | undefined]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').ListGoogleCalendarsResponse
-    >
-  >
-  'calendar:list-sources': (
-    ...args: [
-      {
-        provider?: string | undefined
-        kind?: 'calendar' | 'account' | undefined
-        selectedOnly?: boolean | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/calendar-api').CalendarSourceListResponse>
-  >
-  'calendar:promote-external-event': (
-    ...args: [{ externalEventId: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').PromoteExternalEventResponse
-    >
-  >
-  'calendar:refresh-provider': (
-    ...args: [{ provider: string; accountId?: string | undefined }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarProviderMutationResponse
-    >
-  >
-  'calendar:retry-google-source-sync': (
-    ...args: [{ sourceId: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').RetryCalendarSourceSyncResponse
-    >
-  >
-  'calendar:set-default-google-calendar': (
-    ...args: [{ calendarId: string | null; markOnboardingComplete?: boolean | undefined }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').SetDefaultGoogleCalendarResponse
-    >
-  >
-  'calendar:update-event': (
-    ...args: [
-      {
-        id: string
-        title?: string | undefined
-        description?: string | null | undefined
-        location?: string | null | undefined
-        startAt?: string | undefined
-        endAt?: string | null | undefined
-        timezone?: string | undefined
-        isAllDay?: boolean | undefined
-        recurrenceRule?: Record<string, unknown> | null | undefined
-        recurrenceExceptions?: string[] | null | undefined
-        targetCalendarId?: string | null | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarEventMutationResponse
-    >
-  >
-  'calendar:update-source-selection': (
-    ...args: [{ id: string; isSelected: boolean }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/calendar-api').CalendarSourceMutationResponse
-    >
-  >
-  'context-menu:show': (
-    ...args: [
-      {
-        id: string
-        label: string
-        accelerator?: string | undefined
-        disabled?: boolean | undefined
-        type?: 'normal' | 'separator' | undefined
-      }[]
-    ]
-  ) => Awaited<Promise<string | null>>
-  'crdt:apply-update': (...args: [unknown]) => Awaited<Promise<void>>
-  'crdt:close-doc': (...args: [unknown]) => Awaited<Promise<{ success: boolean }>>
-  'crdt:open-doc': (
-    ...args: [unknown]
-  ) => Awaited<
-    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  >
-  'crdt:sync-step-1': (
-    ...args: [{ noteId: string; stateVector: number[] }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/ipc-crdt').CrdtSyncStep1Result | null>
-  >
-  'crdt:sync-step-2': (...args: [{ noteId: string; diff: number[] }]) => Awaited<Promise<void>>
-  'crypto:decrypt-item': (
-    ...args: [
-      {
-        itemId: string
-        type:
-          | 'note'
-          | 'filter'
-          | 'project'
-          | 'journal'
-          | 'task'
-          | 'settings'
-          | 'inbox'
-          | 'tag_definition'
-          | 'folder_config'
-          | 'calendar_event'
-          | 'calendar_source'
-          | 'calendar_binding'
-          | 'calendar_external_event'
-        encryptedKey: string
-        keyNonce: string
-        encryptedData: string
-        dataNonce: string
-        signature: string
-        operation?: 'create' | 'update' | 'delete' | undefined
-        deletedAt?: number | undefined
-        metadata?: Record<string, unknown> | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/ipc-crypto').DecryptItemResult>
-  >
-  'crypto:encrypt-item': (
-    ...args: [
-      {
-        itemId: string
-        type:
-          | 'note'
-          | 'filter'
-          | 'project'
-          | 'journal'
-          | 'task'
-          | 'settings'
-          | 'inbox'
-          | 'tag_definition'
-          | 'folder_config'
-          | 'calendar_event'
-          | 'calendar_source'
-          | 'calendar_binding'
-          | 'calendar_external_event'
-        content: Record<string, unknown>
-        operation?: 'create' | 'update' | 'delete' | undefined
-        deletedAt?: number | undefined
-        metadata?: Record<string, unknown> | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/ipc-crypto').EncryptItemResult>
-  >
-  'crypto:get-rotation-progress': (
-    ...args: []
-  ) => Awaited<import('../../../../../packages/contracts/src/ipc-crypto').GetRotationProgressResult>
-  'crypto:rotate-keys': (
-    ...args: [{ confirm: boolean }]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/ipc-crypto').RotateKeysResult>>
-  'crypto:verify-signature': (
-    ...args: [
-      {
-        itemId: string
-        type:
-          | 'note'
-          | 'filter'
-          | 'project'
-          | 'journal'
-          | 'task'
-          | 'settings'
-          | 'inbox'
-          | 'tag_definition'
-          | 'folder_config'
-          | 'calendar_event'
-          | 'calendar_source'
-          | 'calendar_binding'
-          | 'calendar_external_event'
-        encryptedKey: string
-        keyNonce: string
-        encryptedData: string
-        dataNonce: string
-        signature: string
-        operation?: 'create' | 'update' | 'delete' | undefined
-        deletedAt?: number | undefined
-        metadata?: Record<string, unknown> | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/ipc-crypto').VerifySignatureResult>
-  >
-  'folder-view:delete-view': (
-    ...args: [{ folderPath: string; viewName: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/folder-view-api').DeleteViewResponse
-    >
-  >
-  'folder-view:folder-exists': (...args: [string]) => Awaited<boolean>
-  'folder-view:get-available-properties': (
-    ...args: [{ folderPath: string }]
-  ) => Awaited<
-    Promise<
-      import('../../../../../packages/contracts/src/folder-view-api').GetAvailablePropertiesResponse
-    >
-  >
-  'folder-view:get-config': (
-    ...args: [{ folderPath: string }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/folder-view-api').GetConfigResponse>
-  >
-  'folder-view:get-folder-suggestions': (
-    ...args: [{ noteId: string }]
-  ) => Awaited<
-    Promise<
-      import('../../../../../packages/contracts/src/folder-view-api').GetFolderSuggestionsResponse
-    >
-  >
-  'folder-view:get-views': (
-    ...args: [{ folderPath: string }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/folder-view-api').GetViewsResponse>
-  >
-  'folder-view:list-with-properties': (
-    ...args: [
-      {
-        folderPath: string
-        properties?: string[] | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      import('../../../../../packages/contracts/src/folder-view-api').ListWithPropertiesResponse
-    >
-  >
-  'folder-view:set-config': (
-    ...args: [
-      {
-        folderPath: string
-        config: {
-          path?: string | undefined
-          template?: string | undefined
-          inherit?: boolean | undefined
-          formulas?: Record<string, string> | undefined
-          properties?:
-            | Record<
-                string,
-                {
-                  displayName?: string | undefined
-                  color?: boolean | undefined
-                  dateFormat?: string | undefined
-                  numberFormat?: string | undefined
-                  hidden?: boolean | undefined
-                }
-              >
-            | undefined
-          summaries?:
-            | Record<
-                string,
-                {
-                  type:
-                    | 'custom'
-                    | 'count'
-                    | 'sum'
-                    | 'average'
-                    | 'min'
-                    | 'max'
-                    | 'countBy'
-                    | 'countUnique'
-                  label?: string | undefined
-                  expression?: string | undefined
-                }
-              >
-            | undefined
-          views?:
-            | {
-                name: string
-                type?: 'table' | 'grid' | 'list' | 'kanban' | undefined
-                default?: boolean | undefined
-                columns?:
-                  | {
-                      id: string
-                      width?: number | undefined
-                      displayName?: string | undefined
-                      showSummary?: boolean | undefined
-                    }[]
-                  | undefined
-                filters?: unknown
-                order?: { property: string; direction: 'asc' | 'desc' }[] | undefined
-                groupBy?:
-                  | {
-                      property: string
-                      direction?: 'asc' | 'desc' | undefined
-                      collapsed?: boolean | undefined
-                      showSummary?: boolean | undefined
-                    }
-                  | undefined
-                limit?: number | undefined
-                showSummaries?: boolean | undefined
-              }[]
-            | undefined
-        }
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/folder-view-api').SetConfigResponse
-    >
-  >
-  'folder-view:set-view': (
-    ...args: [
-      {
-        folderPath: string
-        view: {
-          name: string
-          type?: 'table' | 'grid' | 'list' | 'kanban' | undefined
-          default?: boolean | undefined
-          columns?:
-            | {
-                id: string
-                width?: number | undefined
-                displayName?: string | undefined
-                showSummary?: boolean | undefined
-              }[]
-            | undefined
-          filters?: unknown
-          order?: { property: string; direction: 'asc' | 'desc' }[] | undefined
-          groupBy?:
-            | {
-                property: string
-                direction?: 'asc' | 'desc' | undefined
-                collapsed?: boolean | undefined
-                showSummary?: boolean | undefined
-              }
-            | undefined
-          limit?: number | undefined
-          showSummaries?: boolean | undefined
-        }
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/folder-view-api').SetViewResponse
-    >
-  >
-  'graph:get-graph-data': (...args: []) => Awaited<{
-    nodes: {
-      id: string
-      type: 'note' | 'project' | 'journal' | 'task'
-      label: string
-      tags: string[]
-      wordCount: number
-      connectionCount: number
-      emoji: string | null
-      color: string
-      isOrphan: boolean
-      isUnresolved: boolean
-    }[]
-    edges: {
-      id: string
-      source: string
-      target: string
-      type: 'wikilink' | 'task-note' | 'project-task' | 'tag-cooccurrence'
-      weight: number
-    }[]
-  }>
-  'graph:get-local-graph': (...args: [{ noteId: string; depth?: number | undefined }]) => Awaited<{
-    nodes: {
-      id: string
-      type: 'note' | 'project' | 'journal' | 'task'
-      label: string
-      tags: string[]
-      wordCount: number
-      connectionCount: number
-      emoji: string | null
-      color: string
-      isOrphan: boolean
-      isUnresolved: boolean
-    }[]
-    edges: {
-      id: string
-      source: string
-      target: string
-      type: 'wikilink' | 'task-note' | 'project-task' | 'tag-cooccurrence'
-      weight: number
-    }[]
-  }>
-  'inbox:add-tag': (
-    ...args: [any, any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:archive': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:bulk-archive': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
-  'inbox:bulk-file': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
-  'inbox:bulk-snooze': (...args: [any]) => Awaited<
-    Promise<{
-      success: boolean
-      processedCount: number
-      errors: { itemId: string; error: string }[]
-    }>
-  >
-  'inbox:bulk-tag': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
-  'inbox:capture-clip': (
-    ...args: [unknown]
-  ) => Awaited<Promise<{ success: boolean; item: null; error: string }>>
-  'inbox:capture-image': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
-  >
-  'inbox:capture-link': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
-  >
-  'inbox:capture-pdf': (
-    ...args: [unknown]
-  ) => Awaited<Promise<{ success: boolean; item: null; error: string }>>
-  'inbox:capture-text': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
-  >
-  'inbox:capture-voice': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/domain-inbox/src/types').InboxCaptureResponse>
-  >
-  'inbox:convert-to-note': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/domain-inbox/src/types').InboxFileResponse>>
-  'inbox:convert-to-task': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; taskId: string | null; error?: string | undefined }>>
-  'inbox:delete-permanent': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:file': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/domain-inbox/src/types').InboxFileResponse>>
-  'inbox:file-all-stale': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').BulkResponse>>
-  'inbox:get': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxItem | null>>
-  'inbox:get-filing-history': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/inbox-api').FilingHistoryResponse>
-  >
-  'inbox:get-jobs': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxJobsResponse>>
-  'inbox:get-patterns': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').CapturePattern>>
-  'inbox:get-snoozed': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/domain-inbox/src/types').SnoozedItem[]>>
-  'inbox:get-stale-threshold': (...args: []) => Awaited<Promise<number>>
-  'inbox:get-stats': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxStats>>
-  'inbox:get-suggestions': (...args: [any]) => Awaited<
-    Promise<{
-      suggestions: import('../../../../../packages/domain-inbox/src/types').InboxFilingSuggestion[]
-    }>
-  >
-  'inbox:get-tags': (...args: []) => Awaited<Promise<{ tag: string; count: number }[]>>
-  'inbox:link-to-note': (
-    ...args: [any, any, any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:list': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').InboxListResponse>>
-  'inbox:list-archived': (
-    ...args: [any]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/inbox-api').ArchivedListResponse>
-  >
-  'inbox:mark-viewed': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:preview-link': (...args: [string]) => Awaited<
-    Promise<
-      | {
-          title: string
-          domain: string
-          favicon: string | undefined
-          image: string | undefined
-          description: string | undefined
-        }
-      | {
-          title: string
-          domain: string
-          favicon?: undefined
-          image?: undefined
-          description?: undefined
-        }
-    >
-  >
-  'inbox:remove-tag': (
-    ...args: [any, any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:retry-metadata': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:retry-transcription': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:set-stale-threshold': (...args: [any]) => Awaited<Promise<{ success: boolean }>>
-  'inbox:snooze': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:track-suggestion': (
-    ...args: [string, string, string, string, number, string[], string[]]
-  ) => Awaited<
-    Promise<{ success: false; error: string } | { success: boolean; error?: string | undefined }>
-  >
-  'inbox:unarchive': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:undo-archive': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:undo-file': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:unsnooze': (
-    ...args: [any]
-  ) => Awaited<Promise<{ success: boolean; error?: string | undefined }>>
-  'inbox:update': (
-    ...args: [any]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/inbox-api').CaptureResponse>>
-  'journal:createEntry': (
-    ...args: [
-      {
-        date: string
-        content?: string | undefined
-        tags?: string[] | undefined
-        properties?: Record<string, unknown> | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<{
-      id: string
-      date: string
-      content: string
-      wordCount: number
-      characterCount: number
-      tags: string[]
-      createdAt: string
-      modifiedAt: string
-      properties?: Record<string, unknown> | undefined
-    }>
-  >
-  'journal:deleteEntry': (...args: [{ date: string }]) => Awaited<Promise<{ success: boolean }>>
-  'journal:getAllTags': (...args: []) => Awaited<Promise<{ tag: string; count: number }[]>>
-  'journal:getDayContext': (...args: [{ date: string }]) => Awaited<
-    Promise<{
-      date: string
-      tasks: {
-        id: string
-        title: string
-        completed: boolean
-        priority?: 'urgent' | 'high' | 'medium' | 'low' | undefined
-        isOverdue?: boolean | undefined
-      }[]
-      events: {
-        id: string
-        time: string
-        title: string
-        type: 'meeting' | 'focus' | 'event'
-        attendeeCount?: number | undefined
-      }[]
-      overdueCount: number
-    }>
-  >
-  'journal:getEntry': (...args: [{ date: string }]) => Awaited<
-    Promise<{
-      id: string
-      date: string
-      content: string
-      wordCount: number
-      characterCount: number
-      tags: string[]
-      createdAt: string
-      modifiedAt: string
-      properties?: Record<string, unknown> | undefined
-    } | null>
-  >
-  'journal:getHeatmap': (
-    ...args: [{ year: number }]
-  ) => Awaited<Promise<{ date: string; characterCount: number; level: 0 | 1 | 2 | 4 | 3 }[]>>
-  'journal:getMonthEntries': (...args: [{ year: number; month: number }]) => Awaited<
-    Promise<
-      {
-        date: string
-        preview: string
-        wordCount: number
-        characterCount: number
-        activityLevel: 0 | 1 | 2 | 4 | 3
-        tags: string[]
-      }[]
-    >
-  >
-  'journal:getStreak': (
-    ...args: []
-  ) => Awaited<
-    Promise<{ currentStreak: number; longestStreak: number; lastEntryDate: string | null }>
-  >
-  'journal:getYearStats': (...args: [{ year: number }]) => Awaited<
-    Promise<
-      {
-        year: number
-        month: number
-        entryCount: number
-        totalWordCount: number
-        totalCharacterCount: number
-        averageLevel: number
-      }[]
-    >
-  >
-  'journal:updateEntry': (
-    ...args: [
-      {
-        date: string
-        content?: string | undefined
-        tags?: string[] | undefined
-        properties?: Record<string, unknown> | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<{
-      id: string
-      date: string
-      content: string
-      wordCount: number
-      characterCount: number
-      tags: string[]
-      createdAt: string
-      modifiedAt: string
-      properties?: Record<string, unknown> | undefined
-    }>
-  >
-  'locale:get': (...args: []) => Awaited<'en' | 'tr' | 'ar'>
-  'locale:list': (...args: []) => Awaited<('en' | 'tr' | 'ar')[]>
-  'locale:set': (...args: [unknown]) => Awaited<Promise<void>>
-  'notes:add-property-option': (
-    ...args: [{ propertyName: string; option: { value: string; color: string } }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:add-status-option': (
-    ...args: [
-      {
-        propertyName: string
-        categoryKey: 'todo' | 'in_progress' | 'done'
-        option: { value: string; color: string }
-      }
-    ]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:create': (
-    ...args: [
-      {
-        title: string
-        content?: string | undefined
-        folder?: string | undefined
-        tags?: string[] | undefined
-        template?: string | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
-    | { success: false; error: string }
-  >
-  'notes:create-folder': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'notes:create-property-definition': (
-    ...args: [
-      {
-        name: string
-        type: 'number' | 'date' | 'text' | 'select' | 'checkbox' | 'url' | 'status' | 'multiselect'
-        options?: { value: string; color: string; default?: boolean | undefined }[] | undefined
-        defaultValue?: unknown
-        color?: string | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<
-        | {
-            success: true
-            definition:
-              | import('../../../../../packages/contracts/src/property-types').PropertyDefinition
-              | undefined
-          }
-        | {
-            success: true
-            definition: {
-              type: string
-              name: string
-              createdAt: string
-              options: string | null
-              defaultValue: string | null
-              color: string | null
-            }
-          }
-      >
-    | { success: false; error: string }
-  >
-  'notes:delete': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'notes:delete-attachment': (
-    ...args: [{ noteId: string; filename: string }]
-  ) => Awaited<Promise<{ success: true }> | { success: false; error: string }>
-  'notes:delete-folder': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'notes:delete-property-definition': (
-    ...args: [{ name: string }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:delete-version': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'notes:ensure-property-definition': (
-    ...args: [{ name: string; type: 'select' | 'status' | 'multiselect' }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:exists': (...args: [string]) => Awaited<Promise<boolean>>
-  'notes:export-html': (
-    ...args: [
-      {
-        noteId: string
-        includeMetadata?: boolean | undefined
-        pageSize?: 'A4' | 'Letter' | 'Legal' | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<
-        | { success: false; error: string; path?: undefined }
-        | { success: true; path: string; error?: undefined }
-      >
-    | { success: false; error: string }
-  >
-  'notes:export-pdf': (
-    ...args: [
-      {
-        noteId: string
-        includeMetadata?: boolean | undefined
-        pageSize?: 'A4' | 'Letter' | 'Legal' | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<
-        | { success: false; error: string; path?: undefined }
-        | { success: true; path: string; error?: undefined }
-      >
-    | { success: false; error: string }
-  >
-  'notes:get': (...args: [string]) => Awaited<Promise<import('../vault/notes-crud').Note | null>>
-  'notes:get-all-positions': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      { success: false; error: string } | { success: boolean; positions: Record<string, number> }
-    >
-  >
-  'notes:get-by-path': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/notes-crud').Note | null>>
-  'notes:get-file': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/notes-crud').FileMetadata | null>>
-  'notes:get-folder-config': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/templates-api').FolderConfig | null>
-  >
-  'notes:get-folder-template': (...args: [string]) => Awaited<Promise<string | null>>
-  'notes:get-folders': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/templates-api').FolderInfo[]>>
-  'notes:get-links': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/notes-crud').NoteLinksResponse>>
-  'notes:get-local-only-count': (...args: []) => Awaited<Promise<{ count: number }>>
-  'notes:get-positions': (
-    ...args: [{ folderPath: string }]
-  ) => Awaited<
-    | { success: true; positions: { path: string; position: number; folderPath: string }[] }
-    | { success: false; error: string }
-  >
-  'notes:get-property-definitions': (...args: []) => Awaited<
-    Promise<
-      {
-        type: string
-        name: string
-        createdAt: string
-        options: string | null
-        defaultValue: string | null
-        color: string | null
-      }[]
-    >
-  >
-  'notes:get-tags': (
-    ...args: []
-  ) => Awaited<Promise<{ tag: string; color: string; count: number }[]>>
-  'notes:get-version': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/notes-versions').SnapshotDetail | null>>
-  'notes:get-versions': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/notes-versions').SnapshotListItem[]>>
-  'notes:import-files': (
-    ...args: [{ sourcePaths: string[]; targetFolder?: string | undefined }]
-  ) => Awaited<
-    Promise<import('../vault/notes-crud').ImportFilesResult> | { success: false; error: string }
-  >
-  'notes:list': (
-    ...args: [
-      {
-        folder?: string | undefined
-        tags?: string[] | undefined
-        sortBy?: 'title' | 'modified' | 'created' | 'position' | undefined
-        sortOrder?: 'asc' | 'desc' | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<Promise<import('../vault/notes-crud').NoteListResponse>>
-  'notes:list-attachments': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../vault/attachments').AttachmentInfo[]>>
-  'notes:move': (
-    ...args: [{ id: string; newFolder: string }]
-  ) => Awaited<
-    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
-    | { success: false; error: string }
-  >
-  'notes:open-external': (...args: [string]) => Awaited<Promise<void>>
-  'notes:preview-by-title': (...args: [string]) => Awaited<
-    Promise<{
-      id: string
-      title: string
-      emoji: string | null
-      snippet: string | null
-      tags: { name: string; color: string }[]
-      createdAt: string
-    } | null>
-  >
-  'notes:remove-property-option': (
-    ...args: [{ propertyName: string; optionValue: string }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:rename': (
-    ...args: [{ id: string; newTitle: string }]
-  ) => Awaited<
-    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
-    | { success: false; error: string }
-  >
-  'notes:rename-folder': (
-    ...args: [{ oldPath: string; newPath: string }]
-  ) => Awaited<Promise<{ success: true }> | { success: false; error: string }>
-  'notes:rename-property-option': (
-    ...args: [{ propertyName: string; oldValue: string; newValue: string }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:reorder': (
-    ...args: [{ folderPath: string; notePaths: string[] }]
-  ) => Awaited<{ success: true } | { success: false; error: string }>
-  'notes:resolve-by-title': (...args: [string]) => Awaited<
-    Promise<{
-      id: string
-      path: string
-      title: string
-      fileType: import('../../../../../packages/shared/src/file-types').FileType
-    } | null>
-  >
-  'notes:restore-version': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; note: import('../vault/notes-crud').Note }
-    >
-  >
-  'notes:reveal-in-finder': (...args: [string]) => Awaited<Promise<void>>
-  'notes:set-folder-config': (
-    ...args: [
-      {
-        folderPath: string
-        config: {
-          icon?: string | null | undefined
-          template?: string | undefined
-          inherit?: boolean | undefined
-        }
-      }
-    ]
-  ) => Awaited<Promise<{ success: true }> | { success: false; error: string }>
-  'notes:set-local-only': (
-    ...args: [{ id: string; localOnly: boolean }]
-  ) => Awaited<
-    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
-    | { success: false; error: string }
-  >
-  'notes:show-import-dialog': (
-    ...args: []
-  ) => Awaited<Promise<{ canceled: boolean; filePaths: string[] }>>
-  'notes:update': (
-    ...args: [
-      {
-        id: string
-        title?: string | undefined
-        content?: string | undefined
-        tags?: string[] | undefined
-        frontmatter?: Record<string, unknown> | undefined
-        emoji?: string | null | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<{ success: true; note: import('../vault/notes-crud').Note }>
-    | { success: false; error: string }
-  >
-  'notes:update-option-color': (
-    ...args: [{ propertyName: string; optionValue: string; newColor: string }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'notes:update-property-definition': (
-    ...args: [
-      {
-        name: string
-        type?:
-          | 'number'
-          | 'date'
-          | 'text'
-          | 'select'
-          | 'checkbox'
-          | 'url'
-          | 'status'
-          | 'multiselect'
-          | undefined
-        options?: { value: string; color: string; default?: boolean | undefined }[] | undefined
-        defaultValue?: unknown
-        color?: string | undefined
-      }
-    ]
-  ) => Awaited<
-    | Promise<
-        | { success: false; definition: null; error: string }
-        | {
-            success: true
-            definition:
-              | import('../../../../../packages/contracts/src/property-types').PropertyDefinition
-              | undefined
-            error?: undefined
-          }
-        | {
-            success: true
-            definition:
-              | {
-                  type: string
-                  name: string
-                  createdAt: string
-                  options: string | null
-                  defaultValue: string | null
-                  color: string | null
-                }
-              | undefined
-            error?: undefined
-          }
-      >
-    | { success: false; error: string }
-  >
-  'notes:upload-attachment': (
-    ...args: [{ noteId: string; filename: string; data: ArrayBuffer | number[] }]
-  ) => Awaited<Promise<import('../vault/attachments').AttachmentResult>>
-  'properties:get': (
-    ...args: [{ entityId: string }]
-  ) => Awaited<Promise<import('../database/queries/notes/property-queries').PropertyValue[]>>
-  'properties:rename': (
-    ...args: [{ entityId: string; oldName: string; newName: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/properties-api').RenamePropertyResponse
-    >
-  >
-  'properties:set': (
-    ...args: [{ entityId: string; properties: Record<string, unknown> }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/properties-api').SetPropertiesResponse
-    >
-  >
-  'quick-capture:get-clipboard': (...args: []) => Awaited<string>
-  'reminder:bulk-dismiss': (
-    ...args: [{ reminderIds: string[] }]
-  ) => Awaited<
-    Promise<{ success: false; error: string } | { success: boolean; dismissedCount: number }>
-  >
-  'reminder:count-pending': (...args: []) => Awaited<Promise<number>>
-  'reminder:create': (
-    ...args: [
-      | {
-          targetType: 'note'
-          targetId: string
-          remindAt: string
-          title?: string | undefined
-          note?: string | undefined
-        }
-      | {
-          targetType: 'journal'
-          targetId: string
-          remindAt: string
-          title?: string | undefined
-          note?: string | undefined
-        }
-      | {
-          targetType: 'highlight'
-          targetId: string
-          highlightText: string
-          highlightStart: number
-          highlightEnd: number
-          remindAt: string
-          title?: string | undefined
-          note?: string | undefined
-        }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
-        }
-    >
-  >
-  'reminder:delete': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  >
-  'reminder:dismiss': (...args: [string]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; reminder: null; error: string }
-      | {
-          success: boolean
-          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
-          error?: undefined
-        }
-    >
-  >
-  'reminder:get': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget | null>
-  >
-  'reminder:get-due': (
-    ...args: []
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget[]>
-  >
-  'reminder:get-for-target': (
-    ...args: [{ targetType: 'note' | 'journal' | 'highlight'; targetId: string }]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/reminders-api').Reminder[]>>
-  'reminder:get-upcoming': (...args: [number | undefined]) => Awaited<
-    Promise<{
-      reminders: import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget[]
-      total: number
-      hasMore: boolean
-    }>
-  >
-  'reminder:list': (
-    ...args: [
-      {
-        targetType?: 'note' | 'journal' | 'highlight' | undefined
-        targetId?: string | undefined
-        status?:
-          | 'pending'
-          | 'triggered'
-          | 'dismissed'
-          | 'snoozed'
-          | ('pending' | 'triggered' | 'dismissed' | 'snoozed')[]
-          | undefined
-        fromDate?: string | undefined
-        toDate?: string | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<{
-      reminders: import('../../../../../packages/contracts/src/reminders-api').ReminderWithTarget[]
-      total: number
-      hasMore: boolean
-    }>
-  >
-  'reminder:snooze': (...args: [{ id: string; snoozeUntil: string }]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; reminder: null; error: string }
-      | {
-          success: boolean
-          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
-          error?: undefined
-        }
-    >
-  >
-  'reminder:update': (
-    ...args: [
-      {
-        id: string
-        remindAt?: string | undefined
-        title?: string | null | undefined
-        note?: string | null | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; reminder: null; error: string }
-      | {
-          success: boolean
-          reminder: import('../../../../../packages/contracts/src/reminders-api').Reminder
-          error?: undefined
-        }
-    >
-  >
-  'saved-filters:create': (
-    ...args: [
-      {
-        name: string
-        config: {
-          filters: {
-            search?: string | undefined
-            projectIds?: string[] | undefined
-            priorities?: ('urgent' | 'high' | 'medium' | 'low' | 'none')[] | undefined
-            dueDate?:
-              | {
-                  type:
-                    | 'any'
-                    | 'custom'
-                    | 'none'
-                    | 'overdue'
-                    | 'today'
-                    | 'tomorrow'
-                    | 'this-week'
-                    | 'next-week'
-                    | 'this-month'
-                  customStart?: string | null | undefined
-                  customEnd?: string | null | undefined
-                }
-              | undefined
-            statusIds?: string[] | undefined
-            completion?: 'active' | 'completed' | 'all' | undefined
-            repeatType?: 'all' | 'repeating' | 'one-time' | undefined
-            hasTime?: 'all' | 'with-time' | 'without-time' | undefined
-          }
-          sort?:
-            | {
-                field: 'title' | 'createdAt' | 'priority' | 'dueDate' | 'completedAt' | 'project'
-                direction: 'asc' | 'desc'
-              }
-            | undefined
-          starred?: boolean | undefined
-        }
-      }
-    ]
-  ) => Awaited<
-    Promise<{
-      success: boolean
-      savedFilter: import('../../../../../packages/contracts/src/saved-filters-api').SavedFilter
-    }>
-  >
-  'saved-filters:delete': (
-    ...args: [{ id: string }]
-  ) => Awaited<
-    Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  >
-  'saved-filters:list': (...args: []) => Awaited<
-    Promise<{
-      savedFilters: import('../../../../../packages/contracts/src/saved-filters-api').SavedFilter[]
-    }>
-  >
-  'saved-filters:reorder': (
-    ...args: [{ ids: string[]; positions: number[] }]
-  ) => Awaited<Promise<{ success: boolean }>>
-  'saved-filters:update': (
-    ...args: [
-      {
-        id: string
-        name?: string | undefined
-        config?:
-          | {
-              filters: {
-                search?: string | undefined
-                projectIds?: string[] | undefined
-                priorities?: ('urgent' | 'high' | 'medium' | 'low' | 'none')[] | undefined
-                dueDate?:
-                  | {
-                      type:
-                        | 'any'
-                        | 'custom'
-                        | 'none'
-                        | 'overdue'
-                        | 'today'
-                        | 'tomorrow'
-                        | 'this-week'
-                        | 'next-week'
-                        | 'this-month'
-                      customStart?: string | null | undefined
-                      customEnd?: string | null | undefined
-                    }
-                  | undefined
-                statusIds?: string[] | undefined
-                completion?: 'active' | 'completed' | 'all' | undefined
-                repeatType?: 'all' | 'repeating' | 'one-time' | undefined
-                hasTime?: 'all' | 'with-time' | 'without-time' | undefined
-              }
-              sort?:
-                | {
-                    field:
-                      | 'title'
-                      | 'createdAt'
-                      | 'priority'
-                      | 'dueDate'
-                      | 'completedAt'
-                      | 'project'
-                    direction: 'asc' | 'desc'
-                  }
-                | undefined
-              starred?: boolean | undefined
-            }
-          | undefined
-        position?: number | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: boolean; savedFilter: null; error: string }
-      | {
-          success: boolean
-          savedFilter:
-            | import('../../../../../packages/contracts/src/saved-filters-api').SavedFilter
-            | null
-          error?: undefined
-        }
-    >
-  >
-  'search:add-reason': (
-    ...args: [
-      {
-        itemId: string
-        itemType: 'note' | 'journal' | 'task' | 'inbox'
-        itemTitle: string
-        searchQuery: string
-        itemIcon?: string | null | undefined
-      }
-    ]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchReason>>
-  'search:clear-reasons': (...args: []) => Awaited<Promise<{ cleared: true }>>
-  'search:get-all-tags': (...args: []) => Awaited<Promise<string[]>>
-  'search:get-reasons': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchReason[]>>
-  'search:get-stats': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchStats>>
-  'search:query': (
-    ...args: [
-      {
-        text: string
-        types?: ('note' | 'journal' | 'task' | 'inbox')[] | undefined
-        tags?: string[] | undefined
-        dateRange?: { from: string; to: string } | null | undefined
-        projectId?: string | null | undefined
-        folderPath?: string | null | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/search-api').SearchResponse>>
-  'search:quick': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/search-api').QuickSearchResponse>
-  >
-  'search:rebuild-index': (...args: []) => Awaited<
-    Promise<
-      | {
-          notes: number
-          tasks: number
-          inbox: number
-          durationMs: number
-          started: true
-          error?: undefined
-        }
-      | { started: false; error: string }
-    >
-  >
-  'settings:downloadVoiceModel': (
-    ...args: []
-  ) => Awaited<
-    Promise<{ success: boolean; error?: undefined } | { success: boolean; error: string }>
-  >
-  'settings:get': (...args: [string]) => Awaited<string | null>
-  'settings:getAIModelStatus': (
-    ...args: []
-  ) => Awaited<Promise<import('./settings-handlers').AIModelStatus>>
-  'settings:getAISettings': (...args: []) => Awaited<import('./settings-handlers').AISettings>
-  'settings:getBackupSettings': (...args: []) => Awaited<{
-    autoBackup: boolean
-    frequencyHours: 1 | 6 | 12 | 24
-    maxBackups: number
-    lastBackupAt: string | null
-  }>
-  'settings:getCalendarGoogleSettings': (...args: []) => Awaited<{
-    defaultTargetCalendarId: string | null
-    onboardingCompleted: boolean
-    promoteConfirmDismissed: boolean
-  }>
-  'settings:getCalendarSettings': (...args: []) => Awaited<{
-    dayCellClickBehavior: 'journal' | 'calendar'
-    calendarPageClickOverride: 'inherit' | 'journal' | 'calendar'
-  }>
-  'settings:getEditorSettings': (...args: []) => Awaited<{
-    width: 'medium' | 'narrow' | 'wide'
-    spellCheck: boolean
-    autoSaveDelay: number
-    showWordCount: boolean
-    toolbarMode: 'floating' | 'sticky'
-  }>
-  'settings:getGeneralSettings': (...args: []) => Awaited<{
-    theme: 'system' | 'light' | 'dark' | 'white'
-    fontSize: 'small' | 'medium' | 'large'
-    fontFamily: 'system' | 'serif' | 'sans-serif' | 'monospace' | 'gelasio' | 'geist' | 'inter'
-    accentColor: string
-    startOnBoot: boolean
-    language: 'en' | 'tr' | 'ar'
-    onboardingCompleted: boolean
-    createInSelectedFolder: boolean
-    clockFormat: '12h' | '24h'
-  }>
-  'settings:getGraphSettings': (...args: []) => Awaited<{
-    layout: 'forceatlas2' | 'circular' | 'random'
-    showLabels: boolean
-    showEdgeLabels: boolean
-    animateLayout: boolean
-    showTagEdges: boolean
-  }>
-  'settings:getJournalSettings': (...args: []) => Awaited<{
-    defaultTemplate: string | null
-    showSchedule: boolean
-    showTasks: boolean
-    showAIConnections: boolean
-    showStatsFooter: boolean
-  }>
-  'settings:getKeyboardSettings': (...args: []) => Awaited<{
-    overrides: Record<
-      string,
-      {
-        key: string
-        modifiers: {
-          meta?: boolean | undefined
-          ctrl?: boolean | undefined
-          shift?: boolean | undefined
-          alt?: boolean | undefined
-        }
-      }
-    >
-    globalCapture: {
-      key: string
-      modifiers: {
-        meta?: boolean | undefined
-        ctrl?: boolean | undefined
-        shift?: boolean | undefined
-        alt?: boolean | undefined
-      }
-    } | null
-  }>
-  'settings:getNoteEditorSettings': (
-    ...args: []
-  ) => Awaited<import('./settings-handlers').NoteEditorSettings>
-  'settings:getSyncSettings': (...args: []) => Awaited<{ enabled: boolean; autoSync: boolean }>
-  'settings:getTabSettings': (...args: []) => Awaited<import('./settings-handlers').TabSettings>
-  'settings:getTaskSettings': (...args: []) => Awaited<{
-    defaultProjectId: string | null
-    defaultSortOrder: 'createdAt' | 'priority' | 'dueDate' | 'manual'
-    weekStartDay: 'sunday' | 'monday'
-    staleInboxDays: number
-  }>
-  'settings:getVoiceModelStatus': (
-    ...args: []
-  ) => Awaited<import('../inbox/voice-model').VoiceModelStatus>
-  'settings:getVoiceRecordingReadiness': (
-    ...args: []
-  ) => Awaited<Promise<import('../inbox/voice-transcription-settings').VoiceRecordingReadiness>>
-  'settings:getVoiceTranscriptionOpenAIKeyStatus': (
-    ...args: []
-  ) => Awaited<Promise<import('./settings-handlers').VoiceTranscriptionOpenAIKeyStatus>>
-  'settings:getVoiceTranscriptionSettings': (
-    ...args: []
-  ) => Awaited<{ provider: 'local' | 'openai' }>
-  'settings:loadAIModel': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; message: string; error?: undefined }
-      | { success: boolean; error: string; message?: undefined }
-      | { success: boolean; message?: undefined; error?: undefined }
-    >
-  >
-  'settings:registerGlobalCapture': (
-    ...args: []
-  ) => Awaited<Promise<import('./settings-handlers').GlobalCaptureResult>>
-  'settings:reindexEmbeddings': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; computed: number; skipped: number; error?: string | undefined }
-    >
-  >
-  'settings:resetKeyboardSettings': (
-    ...args: []
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:set': (
-    ...args: [{ key: string; value: string }]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:setAISettings': (
-    ...args: [Partial<import('./settings-handlers').AISettings>]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:setBackupSettings': (
-    ...args: [
-      Partial<{
-        autoBackup: boolean
-        frequencyHours: 1 | 6 | 12 | 24
-        maxBackups: number
-        lastBackupAt: string | null
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setCalendarGoogleSettings': (
-    ...args: [
-      Partial<{
-        defaultTargetCalendarId: string | null
-        onboardingCompleted: boolean
-        promoteConfirmDismissed: boolean
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setCalendarSettings': (
-    ...args: [
-      Partial<{
-        dayCellClickBehavior: 'journal' | 'calendar'
-        calendarPageClickOverride: 'inherit' | 'journal' | 'calendar'
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setEditorSettings': (
-    ...args: [
-      Partial<{
-        width: 'medium' | 'narrow' | 'wide'
-        spellCheck: boolean
-        autoSaveDelay: number
-        showWordCount: boolean
-        toolbarMode: 'floating' | 'sticky'
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setGeneralSettings': (
-    ...args: [
-      Partial<{
-        theme: 'system' | 'light' | 'dark' | 'white'
-        fontSize: 'small' | 'medium' | 'large'
-        fontFamily: 'system' | 'serif' | 'sans-serif' | 'monospace' | 'gelasio' | 'geist' | 'inter'
-        accentColor: string
-        startOnBoot: boolean
-        language: 'en' | 'tr' | 'ar'
-        onboardingCompleted: boolean
-        createInSelectedFolder: boolean
-        clockFormat: '12h' | '24h'
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setGraphSettings': (
-    ...args: [
-      Partial<{
-        layout: 'forceatlas2' | 'circular' | 'random'
-        showLabels: boolean
-        showEdgeLabels: boolean
-        animateLayout: boolean
-        showTagEdges: boolean
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setJournalSettings': (
-    ...args: [Partial<import('./settings-handlers').JournalSettings>]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:setKeyboardSettings': (
-    ...args: [
-      Partial<{
-        overrides: Record<
-          string,
-          {
-            key: string
-            modifiers: {
-              meta?: boolean | undefined
-              ctrl?: boolean | undefined
-              shift?: boolean | undefined
-              alt?: boolean | undefined
-            }
-          }
-        >
-        globalCapture: {
-          key: string
-          modifiers: {
-            meta?: boolean | undefined
-            ctrl?: boolean | undefined
-            shift?: boolean | undefined
-            alt?: boolean | undefined
-          }
-        } | null
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setNoteEditorSettings': (
-    ...args: [Partial<import('./settings-handlers').NoteEditorSettings>]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:setSyncSettings': (
-    ...args: [Partial<{ enabled: boolean; autoSync: boolean }>]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setTabSettings': (
-    ...args: [Partial<import('./settings-handlers').TabSettings>]
-  ) => Awaited<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-  'settings:setTaskSettings': (
-    ...args: [
-      Partial<{
-        defaultProjectId: string | null
-        defaultSortOrder: 'createdAt' | 'priority' | 'dueDate' | 'manual'
-        weekStartDay: 'sunday' | 'monday'
-        staleInboxDays: number
-      }>
-    ]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'settings:setVoiceTranscriptionOpenAIKey': (
-    ...args: [{ apiKey: string }]
-  ) => Awaited<
-    Promise<{ success: boolean; error?: undefined } | { success: boolean; error: string }>
-  >
-  'settings:setVoiceTranscriptionSettings': (
-    ...args: [Partial<{ provider: 'local' | 'openai' }>]
-  ) => Awaited<{ success: boolean; error?: string | undefined }>
-  'sync:approve-linking': (
-    ...args: [{ sessionId: string }]
-  ) => Awaited<
-    | Promise<import('../../../../../packages/contracts/src/ipc-devices').ApproveLinkingResult>
-    | { success: false; error: string }
-  >
-  'sync:check-device-status': (...args: []) => Awaited<Promise<{ status: string }>>
-  'sync:complete-linking-qr': (
-    ...args: [{ sessionId: string }]
-  ) => Awaited<
-    | Promise<import('../../../../../packages/contracts/src/ipc-devices').CompleteLinkingQrResult>
-    | { success: false; error: string }
-  >
-  'sync:confirm-recovery-phrase': (
-    ...args: [{ confirmed: boolean }]
-  ) => Awaited<Promise<{ success: boolean }> | { success: false; error: string }>
-  'sync:download-attachment': (
-    ...args: [{ attachmentId: string; targetPath?: string | undefined }]
-  ) => Awaited<
-    | Promise<
-        | { success: boolean; error: string; filePath?: undefined }
-        | { success: boolean; filePath: string; error?: undefined }
-      >
-    | { success: false; error: string }
-  >
-  'sync:emergency-wipe': (...args: []) => Awaited<Promise<{ success: boolean }>>
-  'sync:generate-linking-qr': (
-    ...args: []
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/ipc-devices').GenerateLinkingQrResult>
-  >
-  'sync:get-devices': (...args: []) => Awaited<
-    Promise<{
-      devices: {
-        id: string
-        name: string
-        platform: 'macos' | 'windows' | 'linux' | 'ios' | 'android'
-        linkedAt: number
-        lastSyncAt: number | undefined
-        isCurrentDevice: boolean
-      }[]
-      email: string | undefined
-    }>
-  >
-  'sync:get-download-progress': (
-    ...args: [{ attachmentId: string }]
-  ) => Awaited<
-    | { progress: number; downloadedChunks: number; totalChunks: number; status: 'downloading' }
-    | null
-    | { success: false; error: string }
-  >
-  'sync:get-history': (
-    ...args: [{ limit?: number | undefined; offset?: number | undefined }]
-  ) => Awaited<
-    | {
-        entries: {
-          id: string
-          type: 'error' | 'push' | 'pull'
-          itemCount: number
-          direction: string | undefined
-          details: unknown
-          durationMs: number | undefined
-          createdAt: number
-        }[]
-        total: number
-      }
-    | { success: false; error: string }
-  >
-  'sync:get-linking-sas': (
-    ...args: [{ sessionId: string }]
-  ) => Awaited<
-    | Promise<{ verificationCode?: string | undefined; error?: string | undefined }>
-    | { success: false; error: string }
-  >
-  'sync:get-quarantined-items': (
-    ...args: []
-  ) => Awaited<import('../../../../../packages/contracts/src/ipc-events').QuarantinedItemInfo[]>
-  'sync:get-queue-size': (...args: []) => Awaited<{ pending: number; failed: number }>
-  'sync:get-recovery-phrase': (...args: []) => Awaited<string | null>
-  'sync:get-status': (
-    ...args: []
-  ) => Awaited<
-    | import('../../../../../packages/contracts/src/ipc-sync-ops').GetSyncStatusResult
-    | { status: string; pendingCount: number }
-  >
-  'sync:get-storage-breakdown': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      import('../../../../../packages/contracts/src/ipc-sync-ops').StorageBreakdownResult | null
-    >
-  >
-  'sync:get-synced-settings': (...args: []) => Awaited<{
-    general?:
-      | {
-          theme?: 'system' | 'light' | 'dark' | 'white' | undefined
-          fontSize?: 'small' | 'medium' | 'large' | undefined
-          fontFamily?:
-            | 'system'
-            | 'serif'
-            | 'sans-serif'
-            | 'monospace'
-            | 'gelasio'
-            | 'geist'
-            | 'inter'
-            | undefined
-          accentColor?: string | undefined
-          startOnBoot?: boolean | undefined
-          language?: string | undefined
-          createInSelectedFolder?: boolean | undefined
-        }
-      | undefined
-    editor?:
-      | {
-          width?: 'medium' | 'narrow' | 'wide' | undefined
-          spellCheck?: boolean | undefined
-          autoSaveDelay?: number | undefined
-          showWordCount?: boolean | undefined
-          toolbarMode?: 'floating' | 'sticky' | undefined
-        }
-      | undefined
-    tasks?:
-      | {
-          defaultProjectId?: string | null | undefined
-          defaultSortOrder?: 'createdAt' | 'priority' | 'dueDate' | 'manual' | undefined
-          weekStartDay?: 'sunday' | 'monday' | undefined
-          staleInboxDays?: number | undefined
-          showCompleted?: boolean | undefined
-          sortBy?: string | undefined
-        }
-      | undefined
-    keyboard?: { overrides?: Record<string, unknown> | undefined } | undefined
-    notes?:
-      | {
-          defaultFolder?: string | undefined
-          editorFontSize?: number | undefined
-          spellCheck?: boolean | undefined
-        }
-      | undefined
-    sync?: { autoSync?: boolean | undefined; syncIntervalMinutes?: number | undefined } | undefined
-  } | null>
-  'sync:get-upload-progress': (
-    ...args: [{ sessionId: string }]
-  ) => Awaited<
-    | { progress: number; uploadedChunks: number; totalChunks: number; status: 'uploading' }
-    | null
-    | { success: false; error: string }
-  >
-  'sync:link-via-qr': (
-    ...args: [{ qrData: string; oauthToken?: string | undefined; provider?: string | undefined }]
-  ) => Awaited<
-    | Promise<import('../../../../../packages/contracts/src/ipc-devices').LinkViaQrResult>
-    | { success: false; error: string }
-  >
-  'sync:link-via-recovery': (
-    ...args: [{ recoveryPhrase: string }]
-  ) => Awaited<
-    | Promise<
-        | { success: boolean; error: string; deviceId?: undefined }
-        | { success: boolean; deviceId: string; error?: undefined }
-      >
-    | { success: false; error: string }
-  >
-  'sync:logout': (
-    ...args: []
-  ) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean }>>
-  'sync:pause': (...args: []) => Awaited<{ success: boolean; wasPaused: boolean }>
-  'sync:remove-device': (
-    ...args: [{ deviceId: string }]
-  ) => Awaited<
-    | Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-    | { success: false; error: string }
-  >
-  'sync:rename-device': (
-    ...args: [{ deviceId: string; newName: string }]
-  ) => Awaited<
-    | Promise<{ success: boolean; error: string } | { success: boolean; error?: undefined }>
-    | { success: false; error: string }
-  >
-  'sync:resume': (...args: []) => Awaited<{ success: boolean; pendingCount: number }>
-  'sync:setup-first-device': (
-    ...args: [{ oauthToken: string; provider: 'google'; state: string }]
-  ) => Awaited<
-    | Promise<
-        | {
-            success: boolean
-            needsRecoverySetup: boolean
-            deviceId: string
-            needsRecoveryInput?: undefined
-          }
-        | {
-            success: boolean
-            needsRecoverySetup: boolean
-            needsRecoveryInput: boolean
-            deviceId?: undefined
-          }
-      >
-    | { success: false; error: string }
-  >
-  'sync:setup-new-account': (
-    ...args: []
-  ) => Awaited<
-    Promise<
-      | { success: boolean; error: string; deviceId?: undefined }
-      | { success: boolean; deviceId: string; error?: undefined }
-    >
-  >
-  'sync:trigger-sync': (
-    ...args: []
-  ) => Awaited<Promise<{ success: boolean } | { success: boolean; error: string }>>
-  'sync:update-synced-setting': (
-    ...args: [{ fieldPath: string; value: unknown }]
-  ) => Awaited<
-    | { success: boolean; error: string }
-    | { success: boolean; error?: undefined }
-    | { success: false; error: string }
-  >
-  'sync:upload-attachment': (
-    ...args: [{ noteId: string; filePath: string }]
-  ) => Awaited<
-    | Promise<
-        | { success: boolean; error: string; attachmentId?: undefined; sessionId?: undefined }
-        | { success: boolean; attachmentId: string; sessionId: string; error?: undefined }
-      >
-    | { success: false; error: string }
-  >
-  'tags:delete': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').DeleteTagResponse
-    >
-  >
-  'tags:get-all-with-counts': (
-    ...args: []
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/tags-api').GetAllWithCountsResponse>
-  >
-  'tags:get-notes-by-tag': (
-    ...args: [
-      {
-        tag: string
-        sortBy?: 'title' | 'modified' | 'created' | undefined
-        sortOrder?: 'asc' | 'desc' | undefined
-        includeDescendants?: boolean | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/tags-api').GetNotesByTagResponse>
-  >
-  'tags:merge': (
-    ...args: [{ source: string; target: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').MergeTagResponse
-    >
-  >
-  'tags:pin-note-to-tag': (
-    ...args: [{ noteId: string; tag: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
-    >
-  >
-  'tags:remove-from-note': (
-    ...args: [{ noteId: string; tag: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
-    >
-  >
-  'tags:rename': (
-    ...args: [{ oldName: string; newName: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').RenameTagResponse
-    >
-  >
-  'tags:unpin-note-from-tag': (
-    ...args: [{ noteId: string; tag: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
-    >
-  >
-  'tags:update-color': (
-    ...args: [{ tag: string; color: string }]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | import('../../../../../packages/contracts/src/tags-api').TagOperationResponse
-    >
-  >
-  'tasks:archive': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; error: string }
-      | { success: boolean; error?: undefined }
-    >
-  >
-  'tasks:bulk-archive': (
-    ...args: [{ ids: string[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
-  'tasks:bulk-complete': (
-    ...args: [{ ids: string[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
-  'tasks:bulk-delete': (
-    ...args: [{ ids: string[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
-  'tasks:bulk-move': (
-    ...args: [{ ids: string[]; projectId: string }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean; count: number }>>
-  'tasks:complete': (...args: [{ id: string; completedAt?: string | undefined }]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:convert-to-subtask': (...args: [{ taskId: string; parentId: string }]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:convert-to-task': (...args: [string]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:create': (
-    ...args: [
-      {
-        projectId: string
-        title: string
-        description?: string | null | undefined
-        priority?: number | undefined
-        statusId?: string | null | undefined
-        parentId?: string | null | undefined
-        dueDate?: string | null | undefined
-        dueTime?: string | null | undefined
-        startDate?: string | null | undefined
-        isRepeating?: boolean | undefined
-        repeatConfig?:
-          | {
-              frequency: 'daily' | 'weekly' | 'monthly' | 'yearly'
-              endType: 'never' | 'date' | 'count'
-              createdAt: string
-              interval?: number | undefined
-              daysOfWeek?: number[] | undefined
-              monthlyType?: 'dayOfMonth' | 'weekPattern' | undefined
-              dayOfMonth?: number | undefined
-              weekOfMonth?: number | undefined
-              dayOfWeekForMonth?: number | undefined
-              endDate?: string | null | undefined
-              endCount?: number | undefined
-              completedCount?: number | undefined
-            }
-          | null
-          | undefined
-        repeatFrom?: 'due' | 'completion' | null | undefined
-        tags?: string[] | undefined
-        linkedNoteIds?: string[] | undefined
-        sourceNoteId?: string | null | undefined
-        position?: number | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: import('../../../../../packages/domain-tasks/src/types').Task }
-    >
-  >
-  'tasks:delete': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:duplicate': (...args: [string]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:get': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Task | null>>
-  'tasks:get-linked-tasks': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Task[]>>
-  'tasks:get-overdue': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListEnvelope>>
-  'tasks:get-stats': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').TaskStats>>
-  'tasks:get-subtasks': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Task[]>>
-  'tasks:get-tags': (...args: []) => Awaited<Promise<{ tag: string; count: number }[]>>
-  'tasks:get-today': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListEnvelope>>
-  'tasks:get-upcoming': (
-    ...args: [{ days?: number | undefined }]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListEnvelope>>
-  'tasks:list': (
-    ...args: [
-      {
-        projectId?: string | undefined
-        statusId?: string | null | undefined
-        parentId?: string | null | undefined
-        includeCompleted?: boolean | undefined
-        includeArchived?: boolean | undefined
-        dueBefore?: string | undefined
-        dueAfter?: string | undefined
-        tags?: string[] | undefined
-        search?: string | undefined
-        sortBy?: 'modified' | 'created' | 'position' | 'priority' | 'dueDate' | undefined
-        sortOrder?: 'asc' | 'desc' | undefined
-        limit?: number | undefined
-        offset?: number | undefined
-      }
-    ]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/queries').TaskListResult>>
-  'tasks:move': (
-    ...args: [
-      {
-        taskId: string
-        position: number
-        targetProjectId?: string | undefined
-        targetStatusId?: string | null | undefined
-        targetParentId?: string | null | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:project-archive': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; error: string }
-      | { success: boolean; error?: undefined }
-    >
-  >
-  'tasks:project-create': (
-    ...args: [
-      {
-        name: string
-        description?: string | null | undefined
-        color?: string | undefined
-        icon?: string | null | undefined
-        statuses?:
-          | {
-              name: string
-              type: 'todo' | 'in_progress' | 'done'
-              order: number
-              color?: string | undefined
-            }[]
-          | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          project: import('../../../../../packages/domain-tasks/src/types').ProjectWithStatuses
-        }
-    >
-  >
-  'tasks:project-delete': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:project-get': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      import('../../../../../packages/domain-tasks/src/types').ProjectWithStatuses | undefined
-    >
-  >
-  'tasks:project-list': (...args: []) => Awaited<
-    Promise<{
-      projects: import('../../../../../packages/domain-tasks/src/types').ProjectWithStats[]
-    }>
-  >
-  'tasks:project-reorder': (
-    ...args: [{ projectIds: string[]; positions: number[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:project-update': (
-    ...args: [
-      {
-        id: string
-        name?: string | undefined
-        description?: string | null | undefined
-        color?: string | undefined
-        icon?: string | null | undefined
-        statuses?:
-          | {
-              name: string
-              type: 'todo' | 'in_progress' | 'done'
-              order: number
-              id?: string | undefined
-              color?: string | undefined
-            }[]
-          | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; project: null; error: string }
-      | {
-          success: boolean
-          project: import('../../../../../packages/domain-tasks/src/types').ProjectWithStatuses
-          error?: undefined
-        }
-    >
-  >
-  'tasks:reorder': (
-    ...args: [{ taskIds: string[]; positions: number[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:seed-demo': (...args: []) => Awaited<Promise<{ success: boolean; message: string }>>
-  'tasks:seed-performance-test': (
-    ...args: []
-  ) => Awaited<Promise<{ success: boolean; message: string }>>
-  'tasks:status-create': (
-    ...args: [
-      { projectId: string; name: string; color?: string | undefined; isDone?: boolean | undefined }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          status: import('../../../../../packages/domain-tasks/src/types').Status
-        }
-    >
-  >
-  'tasks:status-delete': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:status-list': (
-    ...args: [string]
-  ) => Awaited<Promise<import('../../../../../packages/domain-tasks/src/types').Status[]>>
-  'tasks:status-reorder': (
-    ...args: [{ statusIds: string[]; positions: number[] }]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'tasks:status-update': (
-    ...args: [
-      {
-        id: string
-        name?: string | undefined
-        color?: string | undefined
-        position?: number | undefined
-        isDefault?: boolean | undefined
-        isDone?: boolean | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; error: string; status?: undefined }
-      | {
-          success: boolean
-          status: import('../../../../../packages/domain-tasks/src/types').Status
-          error?: undefined
-        }
-    >
-  >
-  'tasks:unarchive': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; error: string }
-      | { success: boolean; error?: undefined }
-    >
-  >
-  'tasks:uncomplete': (...args: [string]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'tasks:update': (
-    ...args: [
-      {
-        id: string
-        title?: string | undefined
-        description?: string | null | undefined
-        priority?: number | undefined
-        projectId?: string | undefined
-        statusId?: string | null | undefined
-        parentId?: string | null | undefined
-        dueDate?: string | null | undefined
-        dueTime?: string | null | undefined
-        startDate?: string | null | undefined
-        isRepeating?: boolean | undefined
-        repeatConfig?:
-          | {
-              frequency: 'daily' | 'weekly' | 'monthly' | 'yearly'
-              endType: 'never' | 'date' | 'count'
-              createdAt: string
-              interval?: number | undefined
-              daysOfWeek?: number[] | undefined
-              monthlyType?: 'dayOfMonth' | 'weekPattern' | undefined
-              dayOfMonth?: number | undefined
-              weekOfMonth?: number | undefined
-              dayOfWeekForMonth?: number | undefined
-              endDate?: string | null | undefined
-              endCount?: number | undefined
-              completedCount?: number | undefined
-            }
-          | null
-          | undefined
-        repeatFrom?: 'due' | 'completion' | null | undefined
-        tags?: string[] | undefined
-        linkedNoteIds?: string[] | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | { success: boolean; task: null; error: string }
-      | {
-          success: boolean
-          task: import('../../../../../packages/domain-tasks/src/types').Task
-          error?: undefined
-        }
-    >
-  >
-  'templates:create': (
-    ...args: [
-      {
-        name: string
-        description?: string | undefined
-        icon?: string | null | undefined
-        tags?: string[] | undefined
-        properties?:
-          | {
-              name: string
-              type:
-                | 'number'
-                | 'date'
-                | 'text'
-                | 'select'
-                | 'checkbox'
-                | 'url'
-                | 'multiselect'
-                | 'rating'
-              value: unknown
-              options?: string[] | undefined
-            }[]
-          | undefined
-        content?: string | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          template: import('../../../../../packages/contracts/src/templates-api').Template
-        }
-    >
-  >
-  'templates:delete': (
-    ...args: [string]
-  ) => Awaited<Promise<{ success: false; error: string } | { success: boolean }>>
-  'templates:duplicate': (...args: [{ id: string; newName: string }]) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          template: import('../../../../../packages/contracts/src/templates-api').Template
-        }
-    >
-  >
-  'templates:get': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/templates-api').Template | null>
-  >
-  'templates:list': (...args: []) => Awaited<
-    Promise<{
-      templates: import('../../../../../packages/contracts/src/templates-api').TemplateListItem[]
-    }>
-  >
-  'templates:update': (
-    ...args: [
-      {
-        id: string
-        name?: string | undefined
-        description?: string | undefined
-        icon?: string | null | undefined
-        tags?: string[] | undefined
-        properties?:
-          | {
-              name: string
-              type:
-                | 'number'
-                | 'date'
-                | 'text'
-                | 'select'
-                | 'checkbox'
-                | 'url'
-                | 'multiselect'
-                | 'rating'
-              value: unknown
-              options?: string[] | undefined
-            }[]
-          | undefined
-        content?: string | undefined
-      }
-    ]
-  ) => Awaited<
-    Promise<
-      | { success: false; error: string }
-      | {
-          success: boolean
-          template: import('../../../../../packages/contracts/src/templates-api').Template
-        }
-    >
-  >
-  'updater:check-for-updates': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/ipc-updater').AppUpdateState>>
-  'updater:download-update': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/ipc-updater').AppUpdateState>>
-  'updater:get-state': (
-    ...args: []
-  ) => Awaited<import('../../../../../packages/contracts/src/ipc-updater').AppUpdateState>
-  'updater:quit-and-install': (...args: []) => Awaited<void>
-  'vault:close': (...args: []) => Awaited<Promise<void>>
-  'vault:get-all': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').GetVaultsResponse>>
-  'vault:get-config': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').VaultConfig>>
-  'vault:get-status': (
-    ...args: []
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').VaultStatus>>
-  'vault:reindex': (...args: []) => Awaited<Promise<void>>
-  'vault:remove': (...args: [string]) => Awaited<Promise<void>>
-  'vault:reveal': (...args: []) => Awaited<Promise<void>>
-  'vault:select': (
-    ...args: [{ path?: string | undefined }]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/vault-api').SelectVaultResponse>
-  >
-  'vault:switch': (
-    ...args: [string]
-  ) => Awaited<
-    Promise<import('../../../../../packages/contracts/src/vault-api').SelectVaultResponse>
-  >
-  'vault:update-config': (
-    ...args: [
-      {
-        excludePatterns?: string[] | undefined
-        defaultNoteFolder?: string | undefined
-        journalFolder?: string | undefined
-        attachmentsFolder?: string | undefined
-      }
-    ]
-  ) => Awaited<Promise<import('../../../../../packages/contracts/src/vault-api').VaultConfig>>
+  "account:getInfo": (...args: []) => Awaited<import("./account-handlers").AccountInfo>
+  "account:getRecoveryKey": (...args: []) => Awaited<Promise<{ success: boolean; error: string; key?: undefined; } | { success: boolean; key: string; error?: undefined; }>>
+  "account:signOut": (...args: []) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean; }>>
+  "ai-inline:get-server-port": (...args: []) => Awaited<number | null>
+  "ai-inline:get-settings": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ai-inline-channels").AIInlineSettings>
+  "ai-inline:set-settings": (...args: [Partial<import("../../../../../packages/contracts/src/ai-inline-channels").AIInlineSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "ai-inline:start-server": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; port?: undefined; } | { success: boolean; port: number; error?: undefined; }>>
+  "ai-inline:stop-server": (...args: []) => Awaited<Promise<{ success: boolean; }>>
+  "auth:init-oauth": (...args: [{ provider: "google"; }]) => Awaited<Promise<{ state: string; }> | { success: false; error: string }>
+  "auth:refresh-token": (...args: []) => Awaited<Promise<{ success: boolean; error: string | undefined; }>>
+  "auth:request-otp": (...args: [{ email: string; }]) => Awaited<Promise<unknown> | { success: false; error: string }>
+  "auth:resend-otp": (...args: [{ email: string; }]) => Awaited<Promise<unknown> | { success: false; error: string }>
+  "auth:verify-otp": (...args: [{ email: string; code: string; }]) => Awaited<Promise<{ success: boolean; isNewUser: boolean; needsSetup: boolean; needsRecoveryInput: boolean; }> | { success: false; error: string }>
+  "bookmarks:bulk-create": (...args: [{ items: { itemType: string; itemId: string; }[]; }]) => Awaited<Promise<{ success: boolean; createdCount: number; }>>
+  "bookmarks:bulk-delete": (...args: [{ bookmarkIds: string[]; }]) => Awaited<Promise<{ success: boolean; deletedCount: number; }>>
+  "bookmarks:create": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<{ success: boolean; bookmark: null; error: string; } | { success: boolean; bookmark: { id: string; createdAt: string; position: number; itemType: string; itemId: string; }; error?: undefined; }>>
+  "bookmarks:delete": (...args: [string]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "bookmarks:get": (...args: [string]) => Awaited<Promise<{ id: string; createdAt: string; position: number; itemType: string; itemId: string; } | null>>
+  "bookmarks:get-by-item": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<{ id: string; createdAt: string; position: number; itemType: string; itemId: string; } | null>>
+  "bookmarks:is-bookmarked": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<boolean>>
+  "bookmarks:list": (...args: [{ itemType?: string | undefined; sortBy?: "createdAt" | "position" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/bookmarks-api").BookmarkListResponse>>
+  "bookmarks:list-by-type": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/bookmarks-api").BookmarkListResponse>>
+  "bookmarks:reorder": (...args: [{ bookmarkIds: string[]; }]) => Awaited<Promise<{ success: boolean; }>>
+  "bookmarks:toggle": (...args: [{ itemType: string; itemId: string; }]) => Awaited<Promise<{ success: boolean; isBookmarked: boolean; bookmark: { id: string; createdAt: string; position: number; itemType: string; itemId: string; } | null; }>>
+  "calendar:connect-provider": (...args: [{ provider: string; accountId?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarProviderMutationResponse>>
+  "calendar:create-event": (...args: [{ title: string; startAt: string; description?: string | null | undefined; location?: string | null | undefined; endAt?: string | null | undefined; timezone?: string | undefined; isAllDay?: boolean | undefined; recurrenceRule?: Record<string, unknown> | null | undefined; recurrenceExceptions?: string[] | null | undefined; targetCalendarId?: string | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarEventMutationResponse>>
+  "calendar:delete-event": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarDeleteResponse>>
+  "calendar:disconnect-provider": (...args: [{ provider: string; accountId?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarProviderMutationResponse>>
+  "calendar:get-event": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarEventRecord | null>>
+  "calendar:get-provider-status": (...args: [{ provider: string; accountId?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarProviderStatus>>
+  "calendar:get-range": (...args: [{ startAt: string; endAt: string; includeUnselectedSources?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarRangeResponse>>
+  "calendar:list-events": (...args: [{ includeArchived?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarEventListResponse>>
+  "calendar:list-google-calendars": (...args: [Record<string, never> | undefined]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").ListGoogleCalendarsResponse>>
+  "calendar:list-sources": (...args: [{ provider?: string | undefined; kind?: "calendar" | "account" | undefined; selectedOnly?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/calendar-api").CalendarSourceListResponse>>
+  "calendar:promote-external-event": (...args: [{ externalEventId: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").PromoteExternalEventResponse>>
+  "calendar:refresh-provider": (...args: [{ provider: string; accountId?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarProviderMutationResponse>>
+  "calendar:retry-google-source-sync": (...args: [{ sourceId: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").RetryCalendarSourceSyncResponse>>
+  "calendar:set-default-google-calendar": (...args: [{ calendarId: string | null; markOnboardingComplete?: boolean | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").SetDefaultGoogleCalendarResponse>>
+  "calendar:update-event": (...args: [{ id: string; title?: string | undefined; description?: string | null | undefined; location?: string | null | undefined; startAt?: string | undefined; endAt?: string | null | undefined; timezone?: string | undefined; isAllDay?: boolean | undefined; recurrenceRule?: Record<string, unknown> | null | undefined; recurrenceExceptions?: string[] | null | undefined; targetCalendarId?: string | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarEventMutationResponse>>
+  "calendar:update-source-selection": (...args: [{ id: string; isSelected: boolean; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/calendar-api").CalendarSourceMutationResponse>>
+  "context-menu:show": (...args: [{ id: string; label: string; accelerator?: string | undefined; disabled?: boolean | undefined; type?: "normal" | "separator" | undefined; }[]]) => Awaited<Promise<string | null>>
+  "crdt:apply-update": (...args: [unknown]) => Awaited<Promise<void>>
+  "crdt:close-doc": (...args: [unknown]) => Awaited<Promise<{ success: boolean; }>>
+  "crdt:open-doc": (...args: [unknown]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "crdt:sync-step-1": (...args: [{ noteId: string; stateVector: number[]; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crdt").CrdtSyncStep1Result | null>>
+  "crdt:sync-step-2": (...args: [{ noteId: string; diff: number[]; }]) => Awaited<Promise<void>>
+  "crypto:decrypt-item": (...args: [{ itemId: string; type: "note" | "filter" | "project" | "journal" | "task" | "settings" | "inbox" | "tag_definition" | "folder_config" | "calendar_event" | "calendar_source" | "calendar_binding" | "calendar_external_event"; encryptedKey: string; keyNonce: string; encryptedData: string; dataNonce: string; signature: string; operation?: "create" | "update" | "delete" | undefined; deletedAt?: number | undefined; metadata?: Record<string, unknown> | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").DecryptItemResult>>
+  "crypto:encrypt-item": (...args: [{ itemId: string; type: "note" | "filter" | "project" | "journal" | "task" | "settings" | "inbox" | "tag_definition" | "folder_config" | "calendar_event" | "calendar_source" | "calendar_binding" | "calendar_external_event"; content: Record<string, unknown>; operation?: "create" | "update" | "delete" | undefined; deletedAt?: number | undefined; metadata?: Record<string, unknown> | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").EncryptItemResult>>
+  "crypto:get-rotation-progress": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-crypto").GetRotationProgressResult>
+  "crypto:rotate-keys": (...args: [{ confirm: boolean; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").RotateKeysResult>>
+  "crypto:verify-signature": (...args: [{ itemId: string; type: "note" | "filter" | "project" | "journal" | "task" | "settings" | "inbox" | "tag_definition" | "folder_config" | "calendar_event" | "calendar_source" | "calendar_binding" | "calendar_external_event"; encryptedKey: string; keyNonce: string; encryptedData: string; dataNonce: string; signature: string; operation?: "create" | "update" | "delete" | undefined; deletedAt?: number | undefined; metadata?: Record<string, unknown> | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-crypto").VerifySignatureResult>>
+  "folder-view:delete-view": (...args: [{ folderPath: string; viewName: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/folder-view-api").DeleteViewResponse>>
+  "folder-view:folder-exists": (...args: [string]) => Awaited<boolean>
+  "folder-view:get-available-properties": (...args: [{ folderPath: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetAvailablePropertiesResponse>>
+  "folder-view:get-config": (...args: [{ folderPath: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetConfigResponse>>
+  "folder-view:get-folder-suggestions": (...args: [{ noteId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetFolderSuggestionsResponse>>
+  "folder-view:get-views": (...args: [{ folderPath: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").GetViewsResponse>>
+  "folder-view:list-with-properties": (...args: [{ folderPath: string; properties?: string[] | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/folder-view-api").ListWithPropertiesResponse>>
+  "folder-view:set-config": (...args: [{ folderPath: string; config: { path?: string | undefined; template?: string | undefined; inherit?: boolean | undefined; formulas?: Record<string, string> | undefined; properties?: Record<string, { displayName?: string | undefined; color?: boolean | undefined; dateFormat?: string | undefined; numberFormat?: string | undefined; hidden?: boolean | undefined; }> | undefined; summaries?: Record<string, { type: "custom" | "count" | "sum" | "average" | "min" | "max" | "countBy" | "countUnique"; label?: string | undefined; expression?: string | undefined; }> | undefined; views?: { name: string; type?: "table" | "grid" | "list" | "kanban" | undefined; default?: boolean | undefined; columns?: { id: string; width?: number | undefined; displayName?: string | undefined; showSummary?: boolean | undefined; }[] | undefined; filters?: unknown; order?: { property: string; direction: "asc" | "desc"; }[] | undefined; groupBy?: { property: string; direction?: "asc" | "desc" | undefined; collapsed?: boolean | undefined; showSummary?: boolean | undefined; } | undefined; limit?: number | undefined; showSummaries?: boolean | undefined; }[] | undefined; }; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/folder-view-api").SetConfigResponse>>
+  "folder-view:set-view": (...args: [{ folderPath: string; view: { name: string; type?: "table" | "grid" | "list" | "kanban" | undefined; default?: boolean | undefined; columns?: { id: string; width?: number | undefined; displayName?: string | undefined; showSummary?: boolean | undefined; }[] | undefined; filters?: unknown; order?: { property: string; direction: "asc" | "desc"; }[] | undefined; groupBy?: { property: string; direction?: "asc" | "desc" | undefined; collapsed?: boolean | undefined; showSummary?: boolean | undefined; } | undefined; limit?: number | undefined; showSummaries?: boolean | undefined; }; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/folder-view-api").SetViewResponse>>
+  "graph:get-graph-data": (...args: []) => Awaited<{ nodes: { id: string; type: "note" | "project" | "journal" | "task"; label: string; tags: string[]; wordCount: number; connectionCount: number; emoji: string | null; color: string; isOrphan: boolean; isUnresolved: boolean; }[]; edges: { id: string; source: string; target: string; type: "wikilink" | "task-note" | "project-task" | "tag-cooccurrence"; weight: number; }[]; }>
+  "graph:get-local-graph": (...args: [{ noteId: string; depth?: number | undefined; }]) => Awaited<{ nodes: { id: string; type: "note" | "project" | "journal" | "task"; label: string; tags: string[]; wordCount: number; connectionCount: number; emoji: string | null; color: string; isOrphan: boolean; isUnresolved: boolean; }[]; edges: { id: string; source: string; target: string; type: "wikilink" | "task-note" | "project-task" | "tag-cooccurrence"; weight: number; }[]; }>
+  "inbox:add-tag": (...args: [any, any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:archive": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:bulk-archive": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
+  "inbox:bulk-file": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
+  "inbox:bulk-snooze": (...args: [any]) => Awaited<Promise<{ success: boolean; processedCount: number; errors: { itemId: string; error: string; }[]; }>>
+  "inbox:bulk-tag": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
+  "inbox:capture-clip": (...args: [unknown]) => Awaited<Promise<{ success: boolean; item: null; error: string; }>>
+  "inbox:capture-image": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
+  "inbox:capture-link": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
+  "inbox:capture-pdf": (...args: [unknown]) => Awaited<Promise<{ success: boolean; item: null; error: string; }>>
+  "inbox:capture-text": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
+  "inbox:capture-voice": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxCaptureResponse>>
+  "inbox:convert-to-note": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxFileResponse>>
+  "inbox:convert-to-task": (...args: [any]) => Awaited<Promise<{ success: boolean; taskId: string | null; error?: string | undefined; }>>
+  "inbox:delete-permanent": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:file": (...args: [any]) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").InboxFileResponse>>
+  "inbox:file-all-stale": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").BulkResponse>>
+  "inbox:get": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxItem | null>>
+  "inbox:get-filing-history": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").FilingHistoryResponse>>
+  "inbox:get-jobs": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxJobsResponse>>
+  "inbox:get-patterns": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").CapturePattern>>
+  "inbox:get-snoozed": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-inbox/src/types").SnoozedItem[]>>
+  "inbox:get-stale-threshold": (...args: []) => Awaited<Promise<number>>
+  "inbox:get-stats": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxStats>>
+  "inbox:get-suggestions": (...args: [any]) => Awaited<Promise<{ suggestions: import("../../../../../packages/domain-inbox/src/types").InboxFilingSuggestion[]; }>>
+  "inbox:get-tags": (...args: []) => Awaited<Promise<{ tag: string; count: number; }[]>>
+  "inbox:link-to-note": (...args: [any, any, any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:list": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").InboxListResponse>>
+  "inbox:list-archived": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").ArchivedListResponse>>
+  "inbox:mark-viewed": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:preview-link": (...args: [string]) => Awaited<Promise<{ title: string; domain: string; favicon: string | undefined; image: string | undefined; description: string | undefined; } | { title: string; domain: string; favicon?: undefined; image?: undefined; description?: undefined; }>>
+  "inbox:remove-tag": (...args: [any, any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:retry-metadata": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:retry-transcription": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:set-stale-threshold": (...args: [any]) => Awaited<Promise<{ success: boolean; }>>
+  "inbox:snooze": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:track-suggestion": (...args: [string, string, string, string, number, string[], string[]]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error?: string | undefined; }>>
+  "inbox:unarchive": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:undo-archive": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:undo-file": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:unsnooze": (...args: [any]) => Awaited<Promise<{ success: boolean; error?: string | undefined; }>>
+  "inbox:update": (...args: [any]) => Awaited<Promise<import("../../../../../packages/contracts/src/inbox-api").CaptureResponse>>
+  "journal:createEntry": (...args: [{ date: string; content?: string | undefined; tags?: string[] | undefined; properties?: Record<string, unknown> | undefined; }]) => Awaited<Promise<{ id: string; date: string; content: string; wordCount: number; characterCount: number; tags: string[]; createdAt: string; modifiedAt: string; properties?: Record<string, unknown> | undefined; }>>
+  "journal:deleteEntry": (...args: [{ date: string; }]) => Awaited<Promise<{ success: boolean; }>>
+  "journal:getAllTags": (...args: []) => Awaited<Promise<{ tag: string; count: number; }[]>>
+  "journal:getDayContext": (...args: [{ date: string; }]) => Awaited<Promise<{ date: string; tasks: { id: string; title: string; completed: boolean; priority?: "urgent" | "high" | "medium" | "low" | undefined; isOverdue?: boolean | undefined; }[]; events: { id: string; time: string; title: string; type: "meeting" | "focus" | "event"; attendeeCount?: number | undefined; }[]; overdueCount: number; }>>
+  "journal:getEntry": (...args: [{ date: string; }]) => Awaited<Promise<{ id: string; date: string; content: string; wordCount: number; characterCount: number; tags: string[]; createdAt: string; modifiedAt: string; properties?: Record<string, unknown> | undefined; } | null>>
+  "journal:getHeatmap": (...args: [{ year: number; }]) => Awaited<Promise<{ date: string; characterCount: number; level: 0 | 1 | 2 | 4 | 3; }[]>>
+  "journal:getMonthEntries": (...args: [{ year: number; month: number; }]) => Awaited<Promise<{ date: string; preview: string; wordCount: number; characterCount: number; activityLevel: 0 | 1 | 2 | 4 | 3; tags: string[]; }[]>>
+  "journal:getStreak": (...args: []) => Awaited<Promise<{ currentStreak: number; longestStreak: number; lastEntryDate: string | null; }>>
+  "journal:getYearStats": (...args: [{ year: number; }]) => Awaited<Promise<{ year: number; month: number; entryCount: number; totalWordCount: number; totalCharacterCount: number; averageLevel: number; }[]>>
+  "journal:updateEntry": (...args: [{ date: string; content?: string | undefined; tags?: string[] | undefined; properties?: Record<string, unknown> | undefined; }]) => Awaited<Promise<{ id: string; date: string; content: string; wordCount: number; characterCount: number; tags: string[]; createdAt: string; modifiedAt: string; properties?: Record<string, unknown> | undefined; }>>
+  "locale:get": (...args: []) => Awaited<"en" | "tr" | "ar">
+  "locale:list": (...args: []) => Awaited<("en" | "tr" | "ar")[]>
+  "locale:set": (...args: [unknown]) => Awaited<Promise<void>>
+  "notes:add-property-option": (...args: [{ propertyName: string; option: { value: string; color: string; }; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:add-status-option": (...args: [{ propertyName: string; categoryKey: "todo" | "in_progress" | "done"; option: { value: string; color: string; }; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:create": (...args: [{ title: string; content?: string | undefined; folder?: string | undefined; tags?: string[] | undefined; template?: string | undefined; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
+  "notes:create-folder": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "notes:create-property-definition": (...args: [{ name: string; type: "number" | "date" | "text" | "select" | "checkbox" | "url" | "status" | "multiselect"; options?: { value: string; color: string; default?: boolean | undefined; }[] | undefined; defaultValue?: unknown; color?: string | undefined; }]) => Awaited<Promise<{ success: true; definition: import("../../../../../packages/contracts/src/property-types").PropertyDefinition | undefined; } | { success: true; definition: { type: string; name: string; createdAt: string; options: string | null; defaultValue: string | null; color: string | null; }; }> | { success: false; error: string }>
+  "notes:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "notes:delete-attachment": (...args: [{ noteId: string; filename: string; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>
+  "notes:delete-folder": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "notes:delete-property-definition": (...args: [{ name: string; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:delete-version": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "notes:ensure-property-definition": (...args: [{ name: string; type: "select" | "status" | "multiselect"; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:exists": (...args: [string]) => Awaited<Promise<boolean>>
+  "notes:export-html": (...args: [{ noteId: string; includeMetadata?: boolean | undefined; pageSize?: "A4" | "Letter" | "Legal" | undefined; }]) => Awaited<Promise<{ success: false; error: string; path?: undefined; } | { success: true; path: string; error?: undefined; }> | { success: false; error: string }>
+  "notes:export-pdf": (...args: [{ noteId: string; includeMetadata?: boolean | undefined; pageSize?: "A4" | "Letter" | "Legal" | undefined; }]) => Awaited<Promise<{ success: false; error: string; path?: undefined; } | { success: true; path: string; error?: undefined; }> | { success: false; error: string }>
+  "notes:get": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").Note | null>>
+  "notes:get-all-positions": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; positions: Record<string, number>; }>>
+  "notes:get-by-path": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").Note | null>>
+  "notes:get-file": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").FileMetadata | null>>
+  "notes:get-folder-config": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/templates-api").FolderConfig | null>>
+  "notes:get-folder-template": (...args: [string]) => Awaited<Promise<string | null>>
+  "notes:get-folders": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/templates-api").FolderInfo[]>>
+  "notes:get-links": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").NoteLinksResponse>>
+  "notes:get-local-only-count": (...args: []) => Awaited<Promise<{ count: number; }>>
+  "notes:get-positions": (...args: [{ folderPath: string; }]) => Awaited<{ success: true; positions: { path: string; position: number; folderPath: string; }[]; } | { success: false; error: string }>
+  "notes:get-property-definitions": (...args: []) => Awaited<Promise<{ type: string; name: string; createdAt: string; options: string | null; defaultValue: string | null; color: string | null; }[]>>
+  "notes:get-tags": (...args: []) => Awaited<Promise<{ tag: string; color: string; count: number; }[]>>
+  "notes:get-version": (...args: [string]) => Awaited<Promise<import("../vault/notes-versions").SnapshotDetail | null>>
+  "notes:get-versions": (...args: [string]) => Awaited<Promise<import("../vault/notes-versions").SnapshotListItem[]>>
+  "notes:import-files": (...args: [{ sourcePaths: string[]; targetFolder?: string | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").ImportFilesResult> | { success: false; error: string }>
+  "notes:list": (...args: [{ folder?: string | undefined; tags?: string[] | undefined; sortBy?: "title" | "modified" | "created" | "position" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../vault/notes-crud").NoteListResponse>>
+  "notes:list-attachments": (...args: [string]) => Awaited<Promise<import("../vault/attachments").AttachmentInfo[]>>
+  "notes:move": (...args: [{ id: string; newFolder: string; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
+  "notes:open-external": (...args: [string]) => Awaited<Promise<void>>
+  "notes:preview-by-title": (...args: [string]) => Awaited<Promise<{ id: string; title: string; emoji: string | null; snippet: string | null; tags: { name: string; color: string; }[]; createdAt: string; } | null>>
+  "notes:remove-property-option": (...args: [{ propertyName: string; optionValue: string; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:rename": (...args: [{ id: string; newTitle: string; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
+  "notes:rename-folder": (...args: [{ oldPath: string; newPath: string; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>
+  "notes:rename-property-option": (...args: [{ propertyName: string; oldValue: string; newValue: string; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:reorder": (...args: [{ folderPath: string; notePaths: string[]; }]) => Awaited<{ success: true; } | { success: false; error: string }>
+  "notes:resolve-by-title": (...args: [string]) => Awaited<Promise<{ id: string; path: string; title: string; fileType: import("../../../../../packages/shared/src/file-types").FileType; } | null>>
+  "notes:restore-version": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; note: import("../vault/notes-crud").Note; }>>
+  "notes:reveal-in-finder": (...args: [string]) => Awaited<Promise<void>>
+  "notes:set-folder-config": (...args: [{ folderPath: string; config: { icon?: string | null | undefined; template?: string | undefined; inherit?: boolean | undefined; }; }]) => Awaited<Promise<{ success: true; }> | { success: false; error: string }>
+  "notes:set-local-only": (...args: [{ id: string; localOnly: boolean; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
+  "notes:show-import-dialog": (...args: []) => Awaited<Promise<{ canceled: boolean; filePaths: string[]; }>>
+  "notes:update": (...args: [{ id: string; title?: string | undefined; content?: string | undefined; tags?: string[] | undefined; frontmatter?: Record<string, unknown> | undefined; emoji?: string | null | undefined; }]) => Awaited<Promise<{ success: true; note: import("../vault/notes-crud").Note; }> | { success: false; error: string }>
+  "notes:update-option-color": (...args: [{ propertyName: string; optionValue: string; newColor: string; }]) => Awaited<Promise<{ success: boolean; }>>
+  "notes:update-property-definition": (...args: [{ name: string; type?: "number" | "date" | "text" | "select" | "checkbox" | "url" | "status" | "multiselect" | undefined; options?: { value: string; color: string; default?: boolean | undefined; }[] | undefined; defaultValue?: unknown; color?: string | undefined; }]) => Awaited<Promise<{ success: false; definition: null; error: string; } | { success: true; definition: import("../../../../../packages/contracts/src/property-types").PropertyDefinition | undefined; error?: undefined; } | { success: true; definition: { type: string; name: string; createdAt: string; options: string | null; defaultValue: string | null; color: string | null; } | undefined; error?: undefined; }> | { success: false; error: string }>
+  "notes:upload-attachment": (...args: [{ noteId: string; filename: string; data: ArrayBuffer | number[]; }]) => Awaited<Promise<import("../vault/attachments").AttachmentResult>>
+  "properties:get": (...args: [{ entityId: string; }]) => Awaited<Promise<import("../database/queries/notes/property-queries").PropertyValue[]>>
+  "properties:rename": (...args: [{ entityId: string; oldName: string; newName: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/properties-api").RenamePropertyResponse>>
+  "properties:set": (...args: [{ entityId: string; properties: Record<string, unknown>; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/properties-api").SetPropertiesResponse>>
+  "quick-capture:get-clipboard": (...args: []) => Awaited<string>
+  "reminder:bulk-dismiss": (...args: [{ reminderIds: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; dismissedCount: number; }>>
+  "reminder:count-pending": (...args: []) => Awaited<Promise<number>>
+  "reminder:create": (...args: [{ targetType: "note"; targetId: string; remindAt: string; title?: string | undefined; note?: string | undefined; } | { targetType: "journal"; targetId: string; remindAt: string; title?: string | undefined; note?: string | undefined; } | { targetType: "highlight"; targetId: string; highlightText: string; highlightStart: number; highlightEnd: number; remindAt: string; title?: string | undefined; note?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; }>>
+  "reminder:delete": (...args: [string]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "reminder:dismiss": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: null; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; error?: undefined; }>>
+  "reminder:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget | null>>
+  "reminder:get-due": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget[]>>
+  "reminder:get-for-target": (...args: [{ targetType: "note" | "journal" | "highlight"; targetId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/reminders-api").Reminder[]>>
+  "reminder:get-upcoming": (...args: [number | undefined]) => Awaited<Promise<{ reminders: import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget[]; total: number; hasMore: boolean; }>>
+  "reminder:list": (...args: [{ targetType?: "note" | "journal" | "highlight" | undefined; targetId?: string | undefined; status?: "pending" | "triggered" | "dismissed" | "snoozed" | ("pending" | "triggered" | "dismissed" | "snoozed")[] | undefined; fromDate?: string | undefined; toDate?: string | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<{ reminders: import("../../../../../packages/contracts/src/reminders-api").ReminderWithTarget[]; total: number; hasMore: boolean; }>>
+  "reminder:snooze": (...args: [{ id: string; snoozeUntil: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: null; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; error?: undefined; }>>
+  "reminder:update": (...args: [{ id: string; remindAt?: string | undefined; title?: string | null | undefined; note?: string | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; reminder: null; error: string; } | { success: boolean; reminder: import("../../../../../packages/contracts/src/reminders-api").Reminder; error?: undefined; }>>
+  "saved-filters:create": (...args: [{ name: string; config: { filters: { search?: string | undefined; projectIds?: string[] | undefined; priorities?: ("urgent" | "high" | "medium" | "low" | "none")[] | undefined; dueDate?: { type: "any" | "custom" | "none" | "overdue" | "today" | "tomorrow" | "this-week" | "next-week" | "this-month"; customStart?: string | null | undefined; customEnd?: string | null | undefined; } | undefined; statusIds?: string[] | undefined; completion?: "active" | "completed" | "all" | undefined; repeatType?: "all" | "repeating" | "one-time" | undefined; hasTime?: "all" | "with-time" | "without-time" | undefined; }; sort?: { field: "title" | "createdAt" | "priority" | "dueDate" | "completedAt" | "project"; direction: "asc" | "desc"; } | undefined; starred?: boolean | undefined; }; }]) => Awaited<Promise<{ success: boolean; savedFilter: import("../../../../../packages/contracts/src/saved-filters-api").SavedFilter; }>>
+  "saved-filters:delete": (...args: [{ id: string; }]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "saved-filters:list": (...args: []) => Awaited<Promise<{ savedFilters: import("../../../../../packages/contracts/src/saved-filters-api").SavedFilter[]; }>>
+  "saved-filters:reorder": (...args: [{ ids: string[]; positions: number[]; }]) => Awaited<Promise<{ success: boolean; }>>
+  "saved-filters:update": (...args: [{ id: string; name?: string | undefined; config?: { filters: { search?: string | undefined; projectIds?: string[] | undefined; priorities?: ("urgent" | "high" | "medium" | "low" | "none")[] | undefined; dueDate?: { type: "any" | "custom" | "none" | "overdue" | "today" | "tomorrow" | "this-week" | "next-week" | "this-month"; customStart?: string | null | undefined; customEnd?: string | null | undefined; } | undefined; statusIds?: string[] | undefined; completion?: "active" | "completed" | "all" | undefined; repeatType?: "all" | "repeating" | "one-time" | undefined; hasTime?: "all" | "with-time" | "without-time" | undefined; }; sort?: { field: "title" | "createdAt" | "priority" | "dueDate" | "completedAt" | "project"; direction: "asc" | "desc"; } | undefined; starred?: boolean | undefined; } | undefined; position?: number | undefined; }]) => Awaited<Promise<{ success: boolean; savedFilter: null; error: string; } | { success: boolean; savedFilter: import("../../../../../packages/contracts/src/saved-filters-api").SavedFilter | null; error?: undefined; }>>
+  "search:add-reason": (...args: [{ itemId: string; itemType: "note" | "journal" | "task" | "inbox"; itemTitle: string; searchQuery: string; itemIcon?: string | null | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchReason>>
+  "search:clear-reasons": (...args: []) => Awaited<Promise<{ cleared: true; }>>
+  "search:get-all-tags": (...args: []) => Awaited<Promise<string[]>>
+  "search:get-reasons": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchReason[]>>
+  "search:get-stats": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchStats>>
+  "search:query": (...args: [{ text: string; types?: ("note" | "journal" | "task" | "inbox")[] | undefined; tags?: string[] | undefined; dateRange?: { from: string; to: string; } | null | undefined; projectId?: string | null | undefined; folderPath?: string | null | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchResponse>>
+  "search:quick": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").QuickSearchResponse>>
+  "search:rebuild-index": (...args: []) => Awaited<Promise<{ notes: number; tasks: number; inbox: number; durationMs: number; started: true; error?: undefined; } | { started: false; error: string; }>>
+  "settings:downloadVoiceModel": (...args: []) => Awaited<Promise<{ success: boolean; error?: undefined; } | { success: boolean; error: string; }>>
+  "settings:get": (...args: [string]) => Awaited<string | null>
+  "settings:getAIModelStatus": (...args: []) => Awaited<Promise<import("./settings-handlers").AIModelStatus>>
+  "settings:getAISettings": (...args: []) => Awaited<import("./settings-handlers").AISettings>
+  "settings:getBackupSettings": (...args: []) => Awaited<{ autoBackup: boolean; frequencyHours: 1 | 6 | 12 | 24; maxBackups: number; lastBackupAt: string | null; }>
+  "settings:getCalendarGoogleSettings": (...args: []) => Awaited<{ defaultTargetCalendarId: string | null; onboardingCompleted: boolean; promoteConfirmDismissed: boolean; }>
+  "settings:getCalendarSettings": (...args: []) => Awaited<{ dayCellClickBehavior: "journal" | "calendar"; calendarPageClickOverride: "inherit" | "journal" | "calendar"; }>
+  "settings:getEditorSettings": (...args: []) => Awaited<{ width: "medium" | "narrow" | "wide"; spellCheck: boolean; autoSaveDelay: number; showWordCount: boolean; toolbarMode: "floating" | "sticky"; }>
+  "settings:getGeneralSettings": (...args: []) => Awaited<{ theme: "system" | "light" | "dark" | "white"; fontSize: "small" | "medium" | "large"; fontFamily: "system" | "serif" | "sans-serif" | "monospace" | "gelasio" | "geist" | "inter"; accentColor: string; startOnBoot: boolean; language: "en" | "tr" | "ar"; onboardingCompleted: boolean; createInSelectedFolder: boolean; clockFormat: "12h" | "24h"; }>
+  "settings:getGraphSettings": (...args: []) => Awaited<{ layout: "forceatlas2" | "circular" | "random"; showLabels: boolean; showEdgeLabels: boolean; animateLayout: boolean; showTagEdges: boolean; }>
+  "settings:getJournalSettings": (...args: []) => Awaited<{ defaultTemplate: string | null; showSchedule: boolean; showTasks: boolean; showAIConnections: boolean; showStatsFooter: boolean; }>
+  "settings:getKeyboardSettings": (...args: []) => Awaited<{ overrides: Record<string, { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; }>; globalCapture: { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; } | null; }>
+  "settings:getNoteEditorSettings": (...args: []) => Awaited<import("./settings-handlers").NoteEditorSettings>
+  "settings:getSyncSettings": (...args: []) => Awaited<{ enabled: boolean; autoSync: boolean; }>
+  "settings:getTabSettings": (...args: []) => Awaited<import("./settings-handlers").TabSettings>
+  "settings:getTaskSettings": (...args: []) => Awaited<{ defaultProjectId: string | null; defaultSortOrder: "createdAt" | "priority" | "dueDate" | "manual"; weekStartDay: "sunday" | "monday"; staleInboxDays: number; }>
+  "settings:getVoiceModelStatus": (...args: []) => Awaited<import("../inbox/voice-model").VoiceModelStatus>
+  "settings:getVoiceRecordingReadiness": (...args: []) => Awaited<Promise<import("../inbox/voice-transcription-settings").VoiceRecordingReadiness>>
+  "settings:getVoiceTranscriptionOpenAIKeyStatus": (...args: []) => Awaited<Promise<import("./settings-handlers").VoiceTranscriptionOpenAIKeyStatus>>
+  "settings:getVoiceTranscriptionSettings": (...args: []) => Awaited<{ provider: "local" | "openai"; }>
+  "settings:loadAIModel": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; message: string; error?: undefined; } | { success: boolean; error: string; message?: undefined; } | { success: boolean; message?: undefined; error?: undefined; }>>
+  "settings:registerGlobalCapture": (...args: []) => Awaited<Promise<import("./settings-handlers").GlobalCaptureResult>>
+  "settings:reindexEmbeddings": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; computed: number; skipped: number; error?: string | undefined; }>>
+  "settings:resetKeyboardSettings": (...args: []) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:set": (...args: [{ key: string; value: string; }]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:setAISettings": (...args: [Partial<import("./settings-handlers").AISettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:setBackupSettings": (...args: [Partial<{ autoBackup: boolean; frequencyHours: 1 | 6 | 12 | 24; maxBackups: number; lastBackupAt: string | null; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setCalendarGoogleSettings": (...args: [Partial<{ defaultTargetCalendarId: string | null; onboardingCompleted: boolean; promoteConfirmDismissed: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setCalendarSettings": (...args: [Partial<{ dayCellClickBehavior: "journal" | "calendar"; calendarPageClickOverride: "inherit" | "journal" | "calendar"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setEditorSettings": (...args: [Partial<{ width: "medium" | "narrow" | "wide"; spellCheck: boolean; autoSaveDelay: number; showWordCount: boolean; toolbarMode: "floating" | "sticky"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setGeneralSettings": (...args: [Partial<{ theme: "system" | "light" | "dark" | "white"; fontSize: "small" | "medium" | "large"; fontFamily: "system" | "serif" | "sans-serif" | "monospace" | "gelasio" | "geist" | "inter"; accentColor: string; startOnBoot: boolean; language: "en" | "tr" | "ar"; onboardingCompleted: boolean; createInSelectedFolder: boolean; clockFormat: "12h" | "24h"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setGraphSettings": (...args: [Partial<{ layout: "forceatlas2" | "circular" | "random"; showLabels: boolean; showEdgeLabels: boolean; animateLayout: boolean; showTagEdges: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setJournalSettings": (...args: [Partial<import("./settings-handlers").JournalSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:setKeyboardSettings": (...args: [Partial<{ overrides: Record<string, { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; }>; globalCapture: { key: string; modifiers: { meta?: boolean | undefined; ctrl?: boolean | undefined; shift?: boolean | undefined; alt?: boolean | undefined; }; } | null; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setNoteEditorSettings": (...args: [Partial<import("./settings-handlers").NoteEditorSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:setSyncSettings": (...args: [Partial<{ enabled: boolean; autoSync: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setTabSettings": (...args: [Partial<import("./settings-handlers").TabSettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
+  "settings:setTaskSettings": (...args: [Partial<{ defaultProjectId: string | null; defaultSortOrder: "createdAt" | "priority" | "dueDate" | "manual"; weekStartDay: "sunday" | "monday"; staleInboxDays: number; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setVoiceTranscriptionOpenAIKey": (...args: [{ apiKey: string; }]) => Awaited<Promise<{ success: boolean; error?: undefined; } | { success: boolean; error: string; }>>
+  "settings:setVoiceTranscriptionSettings": (...args: [Partial<{ provider: "local" | "openai"; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "sync:approve-linking": (...args: [{ sessionId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").ApproveLinkingResult> | { success: false; error: string }>
+  "sync:check-device-status": (...args: []) => Awaited<Promise<{ status: string; }>>
+  "sync:complete-linking-qr": (...args: [{ sessionId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").CompleteLinkingQrResult> | { success: false; error: string }>
+  "sync:confirm-recovery-phrase": (...args: [{ confirmed: boolean; }]) => Awaited<Promise<{ success: boolean; }> | { success: false; error: string }>
+  "sync:download-attachment": (...args: [{ attachmentId: string; targetPath?: string | undefined; }]) => Awaited<Promise<{ success: boolean; error: string; filePath?: undefined; } | { success: boolean; filePath: string; error?: undefined; }> | { success: false; error: string }>
+  "sync:emergency-wipe": (...args: []) => Awaited<Promise<{ success: boolean; }>>
+  "sync:generate-linking-qr": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").GenerateLinkingQrResult>>
+  "sync:get-devices": (...args: []) => Awaited<Promise<{ devices: { id: string; name: string; platform: "macos" | "windows" | "linux" | "ios" | "android"; linkedAt: number; lastSyncAt: number | undefined; isCurrentDevice: boolean; }[]; email: string | undefined; }>>
+  "sync:get-download-progress": (...args: [{ attachmentId: string; }]) => Awaited<{ progress: number; downloadedChunks: number; totalChunks: number; status: "downloading"; } | null | { success: false; error: string }>
+  "sync:get-history": (...args: [{ limit?: number | undefined; offset?: number | undefined; }]) => Awaited<{ entries: { id: string; type: "error" | "push" | "pull"; itemCount: number; direction: string | undefined; details: unknown; durationMs: number | undefined; createdAt: number; }[]; total: number; } | { success: false; error: string }>
+  "sync:get-linking-sas": (...args: [{ sessionId: string; }]) => Awaited<Promise<{ verificationCode?: string | undefined; error?: string | undefined; }> | { success: false; error: string }>
+  "sync:get-quarantined-items": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-events").QuarantinedItemInfo[]>
+  "sync:get-queue-size": (...args: []) => Awaited<{ pending: number; failed: number; }>
+  "sync:get-recovery-phrase": (...args: []) => Awaited<string | null>
+  "sync:get-status": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-sync-ops").GetSyncStatusResult | { status: string; pendingCount: number; }>
+  "sync:get-storage-breakdown": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-sync-ops").StorageBreakdownResult | null>>
+  "sync:get-synced-settings": (...args: []) => Awaited<{ general?: { theme?: "system" | "light" | "dark" | "white" | undefined; fontSize?: "small" | "medium" | "large" | undefined; fontFamily?: "system" | "serif" | "sans-serif" | "monospace" | "gelasio" | "geist" | "inter" | undefined; accentColor?: string | undefined; startOnBoot?: boolean | undefined; language?: string | undefined; createInSelectedFolder?: boolean | undefined; } | undefined; editor?: { width?: "medium" | "narrow" | "wide" | undefined; spellCheck?: boolean | undefined; autoSaveDelay?: number | undefined; showWordCount?: boolean | undefined; toolbarMode?: "floating" | "sticky" | undefined; } | undefined; tasks?: { defaultProjectId?: string | null | undefined; defaultSortOrder?: "createdAt" | "priority" | "dueDate" | "manual" | undefined; weekStartDay?: "sunday" | "monday" | undefined; staleInboxDays?: number | undefined; showCompleted?: boolean | undefined; sortBy?: string | undefined; } | undefined; keyboard?: { overrides?: Record<string, unknown> | undefined; } | undefined; notes?: { defaultFolder?: string | undefined; editorFontSize?: number | undefined; spellCheck?: boolean | undefined; } | undefined; sync?: { autoSync?: boolean | undefined; syncIntervalMinutes?: number | undefined; } | undefined; } | null>
+  "sync:get-upload-progress": (...args: [{ sessionId: string; }]) => Awaited<{ progress: number; uploadedChunks: number; totalChunks: number; status: "uploading"; } | null | { success: false; error: string }>
+  "sync:link-via-qr": (...args: [{ qrData: string; oauthToken?: string | undefined; provider?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-devices").LinkViaQrResult> | { success: false; error: string }>
+  "sync:link-via-recovery": (...args: [{ recoveryPhrase: string; }]) => Awaited<Promise<{ success: boolean; error: string; deviceId?: undefined; } | { success: boolean; deviceId: string; error?: undefined; }> | { success: false; error: string }>
+  "sync:logout": (...args: []) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean; }>>
+  "sync:pause": (...args: []) => Awaited<{ success: boolean; wasPaused: boolean; }>
+  "sync:remove-device": (...args: [{ deviceId: string; }]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }> | { success: false; error: string }>
+  "sync:rename-device": (...args: [{ deviceId: string; newName: string; }]) => Awaited<Promise<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }> | { success: false; error: string }>
+  "sync:resume": (...args: []) => Awaited<{ success: boolean; pendingCount: number; }>
+  "sync:setup-first-device": (...args: [{ oauthToken: string; provider: "google"; state: string; }]) => Awaited<Promise<{ success: boolean; needsRecoverySetup: boolean; deviceId: string; needsRecoveryInput?: undefined; } | { success: boolean; needsRecoverySetup: boolean; needsRecoveryInput: boolean; deviceId?: undefined; }> | { success: false; error: string }>
+  "sync:setup-new-account": (...args: []) => Awaited<Promise<{ success: boolean; error: string; deviceId?: undefined; } | { success: boolean; deviceId: string; error?: undefined; }>>
+  "sync:trigger-sync": (...args: []) => Awaited<Promise<{ success: boolean; } | { success: boolean; error: string; }>>
+  "sync:update-synced-setting": (...args: [{ fieldPath: string; value: unknown; }]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; } | { success: false; error: string }>
+  "sync:upload-attachment": (...args: [{ noteId: string; filePath: string; }]) => Awaited<Promise<{ success: boolean; error: string; attachmentId?: undefined; sessionId?: undefined; } | { success: boolean; attachmentId: string; sessionId: string; error?: undefined; }> | { success: false; error: string }>
+  "tags:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").DeleteTagResponse>>
+  "tags:get-all-with-counts": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/tags-api").GetAllWithCountsResponse>>
+  "tags:get-notes-by-tag": (...args: [{ tag: string; sortBy?: "title" | "modified" | "created" | undefined; sortOrder?: "asc" | "desc" | undefined; includeDescendants?: boolean | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/tags-api").GetNotesByTagResponse>>
+  "tags:merge": (...args: [{ source: string; target: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").MergeTagResponse>>
+  "tags:pin-note-to-tag": (...args: [{ noteId: string; tag: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
+  "tags:remove-from-note": (...args: [{ noteId: string; tag: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
+  "tags:rename": (...args: [{ oldName: string; newName: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").RenameTagResponse>>
+  "tags:unpin-note-from-tag": (...args: [{ noteId: string; tag: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
+  "tags:update-color": (...args: [{ tag: string; color: string; }]) => Awaited<Promise<{ success: false; error: string; } | import("../../../../../packages/contracts/src/tags-api").TagOperationResponse>>
+  "tasks:archive": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "tasks:bulk-archive": (...args: [{ ids: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
+  "tasks:bulk-complete": (...args: [{ ids: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
+  "tasks:bulk-delete": (...args: [{ ids: string[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
+  "tasks:bulk-move": (...args: [{ ids: string[]; projectId: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; count: number; }>>
+  "tasks:complete": (...args: [{ id: string; completedAt?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:convert-to-subtask": (...args: [{ taskId: string; parentId: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:convert-to-task": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:create": (...args: [{ projectId: string; title: string; description?: string | null | undefined; priority?: number | undefined; statusId?: string | null | undefined; parentId?: string | null | undefined; dueDate?: string | null | undefined; dueTime?: string | null | undefined; startDate?: string | null | undefined; isRepeating?: boolean | undefined; repeatConfig?: { frequency: "daily" | "weekly" | "monthly" | "yearly"; endType: "never" | "date" | "count"; createdAt: string; interval?: number | undefined; daysOfWeek?: number[] | undefined; monthlyType?: "dayOfMonth" | "weekPattern" | undefined; dayOfMonth?: number | undefined; weekOfMonth?: number | undefined; dayOfWeekForMonth?: number | undefined; endDate?: string | null | undefined; endCount?: number | undefined; completedCount?: number | undefined; } | null | undefined; repeatFrom?: "due" | "completion" | null | undefined; tags?: string[] | undefined; linkedNoteIds?: string[] | undefined; sourceNoteId?: string | null | undefined; position?: number | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; }>>
+  "tasks:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:duplicate": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Task | null>>
+  "tasks:get-linked-tasks": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Task[]>>
+  "tasks:get-overdue": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListEnvelope>>
+  "tasks:get-stats": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").TaskStats>>
+  "tasks:get-subtasks": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Task[]>>
+  "tasks:get-tags": (...args: []) => Awaited<Promise<{ tag: string; count: number; }[]>>
+  "tasks:get-today": (...args: []) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListEnvelope>>
+  "tasks:get-upcoming": (...args: [{ days?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListEnvelope>>
+  "tasks:list": (...args: [{ projectId?: string | undefined; statusId?: string | null | undefined; parentId?: string | null | undefined; includeCompleted?: boolean | undefined; includeArchived?: boolean | undefined; dueBefore?: string | undefined; dueAfter?: string | undefined; tags?: string[] | undefined; search?: string | undefined; sortBy?: "modified" | "created" | "position" | "priority" | "dueDate" | undefined; sortOrder?: "asc" | "desc" | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/queries").TaskListResult>>
+  "tasks:move": (...args: [{ taskId: string; position: number; targetProjectId?: string | undefined; targetStatusId?: string | null | undefined; targetParentId?: string | null | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:project-archive": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "tasks:project-create": (...args: [{ name: string; description?: string | null | undefined; color?: string | undefined; icon?: string | null | undefined; statuses?: { name: string; type: "todo" | "in_progress" | "done"; order: number; color?: string | undefined; }[] | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; project: import("../../../../../packages/domain-tasks/src/types").ProjectWithStatuses; }>>
+  "tasks:project-delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:project-get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").ProjectWithStatuses | undefined>>
+  "tasks:project-list": (...args: []) => Awaited<Promise<{ projects: import("../../../../../packages/domain-tasks/src/types").ProjectWithStats[]; }>>
+  "tasks:project-reorder": (...args: [{ projectIds: string[]; positions: number[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:project-update": (...args: [{ id: string; name?: string | undefined; description?: string | null | undefined; color?: string | undefined; icon?: string | null | undefined; statuses?: { name: string; type: "todo" | "in_progress" | "done"; order: number; id?: string | undefined; color?: string | undefined; }[] | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; project: null; error: string; } | { success: boolean; project: import("../../../../../packages/domain-tasks/src/types").ProjectWithStatuses; error?: undefined; }>>
+  "tasks:reorder": (...args: [{ taskIds: string[]; positions: number[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:seed-demo": (...args: []) => Awaited<Promise<{ success: boolean; message: string; }>>
+  "tasks:seed-performance-test": (...args: []) => Awaited<Promise<{ success: boolean; message: string; }>>
+  "tasks:status-create": (...args: [{ projectId: string; name: string; color?: string | undefined; isDone?: boolean | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; status: import("../../../../../packages/domain-tasks/src/types").Status; }>>
+  "tasks:status-delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:status-list": (...args: [string]) => Awaited<Promise<import("../../../../../packages/domain-tasks/src/types").Status[]>>
+  "tasks:status-reorder": (...args: [{ statusIds: string[]; positions: number[]; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "tasks:status-update": (...args: [{ id: string; name?: string | undefined; color?: string | undefined; position?: number | undefined; isDefault?: boolean | undefined; isDone?: boolean | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; status?: undefined; } | { success: boolean; status: import("../../../../../packages/domain-tasks/src/types").Status; error?: undefined; }>>
+  "tasks:unarchive": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; error: string; } | { success: boolean; error?: undefined; }>>
+  "tasks:uncomplete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "tasks:update": (...args: [{ id: string; title?: string | undefined; description?: string | null | undefined; priority?: number | undefined; projectId?: string | undefined; statusId?: string | null | undefined; parentId?: string | null | undefined; dueDate?: string | null | undefined; dueTime?: string | null | undefined; startDate?: string | null | undefined; isRepeating?: boolean | undefined; repeatConfig?: { frequency: "daily" | "weekly" | "monthly" | "yearly"; endType: "never" | "date" | "count"; createdAt: string; interval?: number | undefined; daysOfWeek?: number[] | undefined; monthlyType?: "dayOfMonth" | "weekPattern" | undefined; dayOfMonth?: number | undefined; weekOfMonth?: number | undefined; dayOfWeekForMonth?: number | undefined; endDate?: string | null | undefined; endCount?: number | undefined; completedCount?: number | undefined; } | null | undefined; repeatFrom?: "due" | "completion" | null | undefined; tags?: string[] | undefined; linkedNoteIds?: string[] | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; task: null; error: string; } | { success: boolean; task: import("../../../../../packages/domain-tasks/src/types").Task; error?: undefined; }>>
+  "templates:create": (...args: [{ name: string; description?: string | undefined; icon?: string | null | undefined; tags?: string[] | undefined; properties?: { name: string; type: "number" | "date" | "text" | "select" | "checkbox" | "url" | "multiselect" | "rating"; value: unknown; options?: string[] | undefined; }[] | undefined; content?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; template: import("../../../../../packages/contracts/src/templates-api").Template; }>>
+  "templates:delete": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
+  "templates:duplicate": (...args: [{ id: string; newName: string; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; template: import("../../../../../packages/contracts/src/templates-api").Template; }>>
+  "templates:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/templates-api").Template | null>>
+  "templates:list": (...args: []) => Awaited<Promise<{ templates: import("../../../../../packages/contracts/src/templates-api").TemplateListItem[]; }>>
+  "templates:update": (...args: [{ id: string; name?: string | undefined; description?: string | undefined; icon?: string | null | undefined; tags?: string[] | undefined; properties?: { name: string; type: "number" | "date" | "text" | "select" | "checkbox" | "url" | "multiselect" | "rating"; value: unknown; options?: string[] | undefined; }[] | undefined; content?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; template: import("../../../../../packages/contracts/src/templates-api").Template; }>>
+  "updater:check-for-updates": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>>
+  "updater:download-update": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>>
+  "updater:get-state": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>
+  "updater:quit-and-install": (...args: []) => Awaited<void>
+  "vault:close": (...args: []) => Awaited<Promise<void>>
+  "vault:get-all": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").GetVaultsResponse>>
+  "vault:get-config": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultConfig>>
+  "vault:get-status": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultStatus>>
+  "vault:reindex": (...args: []) => Awaited<Promise<void>>
+  "vault:remove": (...args: [string]) => Awaited<Promise<void>>
+  "vault:reveal": (...args: []) => Awaited<Promise<void>>
+  "vault:select": (...args: [{ path?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").SelectVaultResponse>>
+  "vault:switch": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").SelectVaultResponse>>
+  "vault:update-config": (...args: [{ excludePatterns?: string[] | undefined; defaultNoteFolder?: string | undefined; journalFolder?: string | undefined; attachmentsFolder?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultConfig>>
 }
 
 export type MainIpcInvokeChannel = keyof MainIpcInvokeHandlers
-export type MainIpcInvokeArgs<C extends MainIpcInvokeChannel> = Parameters<MainIpcInvokeHandlers[C]>
-export type MainIpcInvokeResult<C extends MainIpcInvokeChannel> = ReturnType<
-  MainIpcInvokeHandlers[C]
->
+export type MainIpcInvokeArgs<C extends MainIpcInvokeChannel> =
+  Parameters<MainIpcInvokeHandlers[C]>
+export type MainIpcInvokeResult<C extends MainIpcInvokeChannel> =
+  ReturnType<MainIpcInvokeHandlers[C]>

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-inbox-snooze-popover.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-inbox-snooze-popover.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithProviders, screen, userEvent } from '@tests/utils/render'
+import { CalendarInboxSnoozePopover } from './calendar-inbox-snooze-popover'
+import type { CalendarProjectionItem } from '@/services/calendar-service'
+
+const baseItem: CalendarProjectionItem = {
+  projectionId: 'inbox_snooze:item-123',
+  sourceType: 'inbox_snooze',
+  sourceId: 'item-123',
+  title: 'Read this article',
+  descriptionPreview: 'A long preview of inbox content.',
+  startAt: '2026-04-30T09:00:00.000Z',
+  endAt: null,
+  isAllDay: false,
+  timezone: 'UTC',
+  visualType: 'snooze',
+  editability: { canMove: false, canResize: false, canEditText: false, canDelete: true },
+  source: {
+    provider: null,
+    calendarSourceId: null,
+    title: 'Memry Inbox',
+    color: null,
+    kind: null,
+    isMemryManaged: true
+  },
+  binding: null,
+  snoozeOffsetMinutes: null
+}
+
+const baseAnchor = { x: 100, y: 100, width: 120, height: 24 }
+
+describe('CalendarInboxSnoozePopover', () => {
+  it('renders the inbox item title and preview', () => {
+    renderWithProviders(
+      <CalendarInboxSnoozePopover
+        item={baseItem}
+        anchorRect={baseAnchor}
+        onOpenInInbox={vi.fn()}
+        onUnsnooze={vi.fn()}
+        onReschedule={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Read this article')).toBeInTheDocument()
+    expect(screen.getByText(/A long preview/)).toBeInTheDocument()
+  })
+
+  it('calls onOpenInInbox with the item id when "Open in inbox" is clicked', async () => {
+    const user = userEvent.setup()
+    const onOpenInInbox = vi.fn()
+    renderWithProviders(
+      <CalendarInboxSnoozePopover
+        item={baseItem}
+        anchorRect={baseAnchor}
+        onOpenInInbox={onOpenInInbox}
+        onUnsnooze={vi.fn()}
+        onReschedule={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /open in inbox/i }))
+    expect(onOpenInInbox).toHaveBeenCalledWith('item-123')
+  })
+
+  it('calls onUnsnooze with the item id when "Unsnooze now" is clicked', async () => {
+    const user = userEvent.setup()
+    const onUnsnooze = vi.fn()
+    renderWithProviders(
+      <CalendarInboxSnoozePopover
+        item={baseItem}
+        anchorRect={baseAnchor}
+        onOpenInInbox={vi.fn()}
+        onUnsnooze={onUnsnooze}
+        onReschedule={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /unsnooze now/i }))
+    expect(onUnsnooze).toHaveBeenCalledWith('item-123')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-inbox-snooze-popover.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-inbox-snooze-popover.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from 'react'
+import { useT } from '@memry/i18n/renderer'
+
+import { Button } from '@/components/ui/button'
+import { SnoozePicker } from '@/components/snooze/snooze-picker'
+import { Inbox, Bell, Clock } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+import type { AnchorRect } from './types'
+import { POPOVER_WIDTH, computePopoverPosition } from './popover-position'
+import type { CalendarProjectionItem } from '@/services/calendar-service'
+
+interface CalendarInboxSnoozePopoverProps {
+  item: CalendarProjectionItem
+  anchorRect: AnchorRect
+  onOpenInInbox: (itemId: string) => void
+  onUnsnooze: (itemId: string) => void | Promise<void>
+  onReschedule: (itemId: string, snoozeUntil: string) => void | Promise<void>
+  onDismiss: () => void
+}
+
+function isInsidePopperPortal(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false
+  return Boolean(target.closest('[data-radix-popper-content-wrapper], [role="dialog"]'))
+}
+
+export function CalendarInboxSnoozePopover({
+  item,
+  anchorRect,
+  onOpenInInbox,
+  onUnsnooze,
+  onReschedule,
+  onDismiss
+}: CalendarInboxSnoozePopoverProps): React.JSX.Element {
+  const { t } = useT('calendar')
+  const containerRef = useRef<HTMLDivElement>(null)
+  const { top, left } = computePopoverPosition(anchorRect, { estimatedHeight: 220 })
+
+  useEffect(() => {
+    function handlePointerDown(event: PointerEvent) {
+      if (!containerRef.current) return
+      if (containerRef.current.contains(event.target as Node)) return
+      // SnoozePicker's Radix DropdownMenu/Dialog render in a portal outside this
+      // tree. Treat clicks on those as inside so the popover doesn't dismiss
+      // mid-interaction.
+      if (isInsidePopperPortal(event.target)) return
+      onDismiss()
+    }
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') onDismiss()
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [onDismiss])
+
+  return (
+    <div
+      ref={containerRef}
+      role="dialog"
+      aria-label={t('phaseI.inboxSnoozePopover.title')}
+      data-testid="calendar-inbox-snooze-popover"
+      style={{ position: 'fixed', top, left, width: POPOVER_WIDTH }}
+      className={cn(
+        'z-50 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-lg',
+        'flex flex-col gap-3'
+      )}
+    >
+      <div className="flex flex-col gap-1">
+        <h3 className="text-sm font-semibold text-foreground">{item.title}</h3>
+        {item.descriptionPreview ? (
+          <p className="line-clamp-2 text-xs text-muted-foreground">{item.descriptionPreview}</p>
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="justify-start"
+          onClick={() => onOpenInInbox(item.sourceId)}
+        >
+          <Inbox className="me-2 h-4 w-4" />
+          {t('phaseI.inboxSnoozePopover.openInInbox')}
+        </Button>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="justify-start"
+          onClick={() => void onUnsnooze(item.sourceId)}
+        >
+          <Bell className="me-2 h-4 w-4" />
+          {t('phaseI.inboxSnoozePopover.unsnoozeNow')}
+        </Button>
+
+        <SnoozePicker
+          onSnooze={(snoozeUntil) => void onReschedule(item.sourceId, snoozeUntil)}
+          trigger={
+            <Button type="button" variant="ghost" size="sm" className="justify-start">
+              <Clock className="me-2 h-4 w-4" />
+              {t('phaseI.inboxSnoozePopover.reschedule')}
+            </Button>
+          }
+        />
+      </div>
+    </div>
+  )
+}
+
+export default CalendarInboxSnoozePopover

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
@@ -8,17 +8,28 @@ import type {
   CalendarSourceRecord
 } from '@/services/calendar-service'
 
-const { mockUseCalendarRange, mockListSources, mockCreateEvent, mockUpdateEvent, mockDeleteEvent } =
-  vi.hoisted(() => ({
-    mockUseCalendarRange: vi.fn(),
-    mockListSources: vi.fn(),
-    mockCreateEvent: vi.fn(),
-    mockUpdateEvent: vi.fn(),
-    mockDeleteEvent: vi.fn()
-  }))
+const {
+  mockUseCalendarRange,
+  mockListSources,
+  mockCreateEvent,
+  mockUpdateEvent,
+  mockDeleteEvent,
+  mockOpenTab
+} = vi.hoisted(() => ({
+  mockUseCalendarRange: vi.fn(),
+  mockListSources: vi.fn(),
+  mockCreateEvent: vi.fn(),
+  mockUpdateEvent: vi.fn(),
+  mockDeleteEvent: vi.fn(),
+  mockOpenTab: vi.fn()
+}))
 
 vi.mock('@/hooks/use-calendar-range', () => ({
   useCalendarRange: mockUseCalendarRange
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabActions: () => ({ openTab: mockOpenTab })
 }))
 
 vi.mock('@/services/calendar-service', () => {

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
@@ -5,6 +5,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { RefreshCw, SlidersHorizontal } from '@/lib/icons'
 import { CalendarDayView } from './calendar-day-view'
 import { CalendarEventPopover, type CalendarEventReadOnlyMetadata } from './calendar-event-popover'
+import { CalendarInboxSnoozePopover } from './calendar-inbox-snooze-popover'
 import { CalendarMonthView } from './calendar-month-view'
 import { CalendarToolbar, type CalendarWorkspaceView } from './calendar-toolbar'
 import { CalendarWeekView } from './calendar-week-view'
@@ -39,6 +40,14 @@ interface CalendarShellProps {
     /** M5: rich read-only metadata surfaced below the editor in edit mode. */
     readOnlyMetadata?: CalendarEventReadOnlyMetadata
   } | null
+  inboxSnoozePopoverState: {
+    item: CalendarProjectionItem
+    anchorRect: AnchorRect
+  } | null
+  onInboxSnoozeOpenInInbox: (itemId: string) => void
+  onInboxSnoozeUnsnooze: (itemId: string) => void | Promise<void>
+  onInboxSnoozeReschedule: (itemId: string, snoozeUntil: string) => void | Promise<void>
+  onInboxSnoozePopoverDismiss: () => void
   isSaving: boolean
   onViewChange: (view: CalendarWorkspaceView) => void
   onPrevious: () => void
@@ -77,6 +86,11 @@ export function CalendarShell({
   selectedVisualTypes,
   selectedItemId,
   popoverState,
+  inboxSnoozePopoverState,
+  onInboxSnoozeOpenInInbox,
+  onInboxSnoozeUnsnooze,
+  onInboxSnoozeReschedule,
+  onInboxSnoozePopoverDismiss,
   isSaving,
   onViewChange,
   onPrevious,
@@ -293,6 +307,17 @@ export function CalendarShell({
           onSave={onPopoverSave}
           onDismiss={onPopoverDismiss}
           readOnlyMetadata={popoverState.readOnlyMetadata}
+        />
+      )}
+
+      {inboxSnoozePopoverState && (
+        <CalendarInboxSnoozePopover
+          item={inboxSnoozePopoverState.item}
+          anchorRect={inboxSnoozePopoverState.anchorRect}
+          onOpenInInbox={onInboxSnoozeOpenInInbox}
+          onUnsnooze={onInboxSnoozeUnsnooze}
+          onReschedule={onInboxSnoozeReschedule}
+          onDismiss={onInboxSnoozePopoverDismiss}
         />
       )}
     </div>

--- a/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.test.tsx
@@ -145,7 +145,7 @@ describe('TagDetailView rename + delete actions', () => {
       await waitFor(() =>
         expect(mockRenameTag).toHaveBeenCalledWith({ oldName: 'react', newName: 'typescript' })
       )
-      expect(mockToastSuccess).toHaveBeenCalledWith('Renamed #react to #typescript')
+      expect(mockToastSuccess).toHaveBeenCalledWith('Renamed "react" to "typescript"')
       expect(mockGoBack).toHaveBeenCalled()
     })
 
@@ -193,7 +193,7 @@ describe('TagDetailView rename + delete actions', () => {
       await user.click(screen.getByRole('button', { name: 'Delete tag' }))
 
       await waitFor(() => expect(mockDeleteTag).toHaveBeenCalledWith('react'))
-      expect(mockToastSuccess).toHaveBeenCalledWith('Deleted #react')
+      expect(mockToastSuccess).toHaveBeenCalledWith('Deleted "react" from 0 items')
       expect(mockGoBack).toHaveBeenCalled()
     })
 

--- a/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
@@ -12,18 +12,24 @@ const {
   mockCreateEvent,
   mockUpdateEvent,
   mockUseTimeGridMarquee,
-  mockClearSelection
+  mockClearSelection,
+  mockOpenTab
 } = vi.hoisted(() => ({
   mockUseCalendarRange: vi.fn(),
   mockListSources: vi.fn(),
   mockCreateEvent: vi.fn(),
   mockUpdateEvent: vi.fn(),
   mockUseTimeGridMarquee: vi.fn(),
-  mockClearSelection: vi.fn()
+  mockClearSelection: vi.fn(),
+  mockOpenTab: vi.fn()
 }))
 
 vi.mock('@/hooks/use-calendar-range', () => ({
   useCalendarRange: mockUseCalendarRange
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabActions: () => ({ openTab: mockOpenTab })
 }))
 
 vi.mock('@/services/calendar-service', () => ({

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -34,7 +34,9 @@ import { extractErrorMessage } from '@/lib/ipc-error'
 import { createLogger } from '@/lib/logger'
 import { useDayPanel } from '@/contexts/day-panel-context'
 import { useCalendarView } from '@/contexts/calendar-view-context'
+import { useTabActions } from '@/contexts/tabs'
 import { DeleteCalendarEventDialog } from '@/components/calendar/delete-calendar-event-dialog'
+import { inboxService } from '@/services/inbox-service'
 import { getI18n } from 'react-i18next'
 
 const log = createLogger('CalendarPage')
@@ -191,6 +193,11 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     anchorRect: AnchorRect
     readOnlyMetadata?: import('@/components/calendar/calendar-event-popover').CalendarEventReadOnlyMetadata
   } | null>(null)
+  const [inboxSnoozePopoverState, setInboxSnoozePopoverState] = useState<{
+    item: CalendarProjectionItem
+    anchorRect: AnchorRect
+  } | null>(null)
+  const { openTab } = useTabActions()
   const [isSaving, setIsSaving] = useState(false)
   const [pendingPromote, setPendingPromote] = useState<{
     item: CalendarProjectionItem
@@ -380,6 +387,11 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
       return
     }
 
+    if (item.sourceType === 'inbox_snooze') {
+      setInboxSnoozePopoverState({ item, anchorRect: rect })
+      return
+    }
+
     if (item.sourceType !== 'external_event') return
 
     const settings = await window.api.settings.getCalendarGoogleSettings()
@@ -389,6 +401,52 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     }
 
     setPendingPromote({ item, anchorRect: rect })
+  }
+
+  const handleInboxSnoozeOpenInInbox = (_itemId: string) => {
+    setInboxSnoozePopoverState(null)
+    openTab({
+      type: 'inbox',
+      title: 'Inbox',
+      icon: 'inbox',
+      path: '/inbox',
+      isPinned: false,
+      isModified: false,
+      isPreview: false,
+      isDeleted: false
+    })
+  }
+
+  const handleInboxSnoozeUnsnooze = async (itemId: string) => {
+    try {
+      const result = await inboxService.unsnooze(itemId)
+      if (!result.success) {
+        throw new Error(result.error ?? 'Unsnooze failed.')
+      }
+      await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
+      setInboxSnoozePopoverState(null)
+    } catch (err) {
+      log.error('Failed to unsnooze inbox item', {
+        itemId,
+        error: extractErrorMessage(err, 'Could not unsnooze.')
+      })
+    }
+  }
+
+  const handleInboxSnoozeReschedule = async (itemId: string, snoozeUntil: string) => {
+    try {
+      const result = await inboxService.snooze({ itemId, snoozeUntil })
+      if (!result.success) {
+        throw new Error(result.error ?? 'Reschedule failed.')
+      }
+      await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
+      setInboxSnoozePopoverState(null)
+    } catch (err) {
+      log.error('Failed to reschedule inbox item', {
+        itemId,
+        error: extractErrorMessage(err, 'Could not reschedule.')
+      })
+    }
   }
 
   const handlePopoverSave = async () => {
@@ -548,6 +606,11 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
         }
         onSelectItem={handleSelectItem}
         onDeleteItem={handleDeleteItem}
+        inboxSnoozePopoverState={inboxSnoozePopoverState}
+        onInboxSnoozeOpenInInbox={handleInboxSnoozeOpenInInbox}
+        onInboxSnoozeUnsnooze={handleInboxSnoozeUnsnooze}
+        onInboxSnoozeReschedule={handleInboxSnoozeReschedule}
+        onInboxSnoozePopoverDismiss={() => setInboxSnoozePopoverState(null)}
         onPopoverDismiss={() => setPopoverState(null)}
         onPopoverDraftChange={(draft) =>
           setPopoverState((current) => (current ? { ...current, draft } : current))

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -418,33 +418,35 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
   }
 
   const handleInboxSnoozeUnsnooze = async (itemId: string) => {
+    const tCalendar = getI18n().getFixedT(null, 'calendar')
     try {
       const result = await inboxService.unsnooze(itemId)
       if (!result.success) {
-        throw new Error(result.error ?? 'Unsnooze failed.')
+        throw new Error(result.error ?? tCalendar('phaseI.errors.couldNotUnsnoozeInboxItem'))
       }
       await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
       setInboxSnoozePopoverState(null)
     } catch (err) {
       log.error('Failed to unsnooze inbox item', {
         itemId,
-        error: extractErrorMessage(err, 'Could not unsnooze.')
+        error: extractErrorMessage(err, tCalendar('phaseI.errors.couldNotUnsnoozeInboxItem'))
       })
     }
   }
 
   const handleInboxSnoozeReschedule = async (itemId: string, snoozeUntil: string) => {
+    const tCalendar = getI18n().getFixedT(null, 'calendar')
     try {
       const result = await inboxService.snooze({ itemId, snoozeUntil })
       if (!result.success) {
-        throw new Error(result.error ?? 'Reschedule failed.')
+        throw new Error(result.error ?? tCalendar('phaseI.errors.couldNotRescheduleInboxItem'))
       }
       await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
       setInboxSnoozePopoverState(null)
     } catch (err) {
       log.error('Failed to reschedule inbox item', {
         itemId,
-        error: extractErrorMessage(err, 'Could not reschedule.')
+        error: extractErrorMessage(err, tCalendar('phaseI.errors.couldNotRescheduleInboxItem'))
       })
     }
   }

--- a/apps/desktop/tests/e2e/calendar-inbox-snooze-click.e2e.ts
+++ b/apps/desktop/tests/e2e/calendar-inbox-snooze-click.e2e.ts
@@ -1,0 +1,113 @@
+import { test, expect } from './fixtures'
+import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
+
+interface SeededCalendarData {
+  day: string
+  importedTitle: string
+  taskTitle: string
+  reminderTitle: string
+  snoozeTitle: string
+}
+
+function toIsoDay(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function getSeededCalendarData(): SeededCalendarData {
+  const today = new Date()
+  return {
+    day: toIsoDay(today),
+    importedTitle: 'Imported customer call',
+    taskTitle: 'Due launch brief',
+    reminderTitle: 'Medication reminder',
+    snoozeTitle: 'Review investor email'
+  }
+}
+
+async function seedAndOpenDay(
+  electronApp: Parameters<typeof test>[0]['electronApp'],
+  page: Parameters<typeof test>[0]['page']
+): Promise<void> {
+  await waitForAppReady(page)
+  await waitForVaultReady(page)
+
+  await electronApp.evaluate(async (_context, input) => {
+    const hooks = (
+      globalThis as typeof globalThis & {
+        __memryTestHooks?: {
+          seedCalendarProjection(input: SeededCalendarData): Promise<void>
+        }
+      }
+    ).__memryTestHooks
+
+    if (!hooks) {
+      throw new Error('Memry test hooks are not registered')
+    }
+
+    await hooks.seedCalendarProjection(input)
+  }, getSeededCalendarData())
+
+  await page.getByRole('button', { name: 'Calendar' }).click()
+  await expect(page.getByTestId('calendar-page')).toBeVisible()
+  await page.getByTestId('calendar-page').getByRole('button', { name: 'Day', exact: true }).click()
+  await expect(page.getByTestId('calendar-view')).toHaveAttribute('data-view', 'day')
+}
+
+test.describe('Calendar: snoozed inbox item click', () => {
+  test('opens popover with three actions and dismisses on Escape', async ({
+    electronApp,
+    page
+  }) => {
+    await seedAndOpenDay(electronApp, page)
+
+    const calendarPage = page.getByTestId('calendar-page')
+    const chip = calendarPage.getByRole('button', { name: /Review investor email/i }).first()
+    await expect(chip).toBeVisible()
+    await chip.click()
+
+    const popover = page.getByTestId('calendar-inbox-snooze-popover')
+    await expect(popover).toBeVisible()
+    await expect(popover.getByRole('button', { name: /open in inbox/i })).toBeVisible()
+    await expect(popover.getByRole('button', { name: /unsnooze now/i })).toBeVisible()
+    await expect(popover.getByRole('button', { name: /reschedule/i })).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(popover).toBeHidden()
+  })
+
+  test('Unsnooze now removes the chip from the calendar', async ({ electronApp, page }) => {
+    await seedAndOpenDay(electronApp, page)
+
+    const calendarPage = page.getByTestId('calendar-page')
+    const chip = calendarPage.getByRole('button', { name: /Review investor email/i }).first()
+    await chip.click()
+
+    const popover = page.getByTestId('calendar-inbox-snooze-popover')
+    await expect(popover).toBeVisible()
+    await popover.getByRole('button', { name: /unsnooze now/i }).click()
+
+    await expect(popover).toBeHidden()
+    await expect(
+      calendarPage.getByRole('button', { name: /Review investor email/i })
+    ).toHaveCount(0, { timeout: 5_000 })
+  })
+
+  test('Open in inbox navigates away from the calendar', async ({ electronApp, page }) => {
+    await seedAndOpenDay(electronApp, page)
+
+    const calendarPage = page.getByTestId('calendar-page')
+    const chip = calendarPage.getByRole('button', { name: /Review investor email/i }).first()
+    await chip.click()
+
+    const popover = page.getByTestId('calendar-inbox-snooze-popover')
+    await expect(popover).toBeVisible()
+    await popover.getByRole('button', { name: /open in inbox/i }).click()
+
+    // Inbox is a singleton tab; activating it tears down the calendar surface
+    // (the active group's content area renders the inbox tab instead).
+    await expect(calendarPage).toBeHidden()
+  })
+})

--- a/packages/i18n/src/locales/en/calendar.json
+++ b/packages/i18n/src/locales/en/calendar.json
@@ -118,7 +118,9 @@
       "failedToLoadCalendarPreferences": "Failed to load calendar preferences",
       "failedToUpdateCalendarPreferences": "Failed to update calendar preferences",
       "couldNotEditThisEventTryAgain": "Could not edit this event. Try again.",
-      "failedToDeleteEvent": "Failed to delete event"
+      "failedToDeleteEvent": "Failed to delete event",
+      "couldNotUnsnoozeInboxItem": "Could not unsnooze.",
+      "couldNotRescheduleInboxItem": "Could not reschedule."
     },
     "inboxSnoozePopover": {
       "title": "Snoozed inbox item",

--- a/packages/i18n/src/locales/en/calendar.json
+++ b/packages/i18n/src/locales/en/calendar.json
@@ -119,6 +119,12 @@
       "failedToUpdateCalendarPreferences": "Failed to update calendar preferences",
       "couldNotEditThisEventTryAgain": "Could not edit this event. Try again.",
       "failedToDeleteEvent": "Failed to delete event"
+    },
+    "inboxSnoozePopover": {
+      "title": "Snoozed inbox item",
+      "openInInbox": "Open in inbox",
+      "unsnoozeNow": "Unsnooze now",
+      "reschedule": "Reschedule"
     }
   }
 }


### PR DESCRIPTION
## What

Inbox-snooze chips on the calendar are now clickable. Clicking opens a small floating popover anchored to the chip with three actions:

- **Open in inbox** — jumps to the inbox tab focused on the item
- **Unsnooze now** — clears the snooze (chip disappears immediately)
- **Reschedule** — reuses the standard `<SnoozePicker>` preset list + custom date/time dialog

Previously the chip click was a silent no-op.

## Why

Snooze chips were rendered on the calendar as a hint that something was scheduled to surface later, but there was no way to act on them without leaving the calendar surface. Users had to navigate to the inbox, find the right item, and then unsnooze or reschedule. This closes that loop in-place.

## How

- New presentational `<CalendarInboxSnoozePopover>` mirroring the positioning + dismiss pattern of `<CalendarEventPopover>`.
- Outside-click handler **explicitly excludes Radix popper portals** so the nested SnoozePicker dropdown/dialog don't dismiss the popover mid-interaction. This is the same gotcha pattern as other calendar popovers.
- `handleSelectItem` in `calendar.tsx` forks on `sourceType`: `inbox_snooze` opens the popover, other sourceTypes route as before.
- After Unsnooze and Reschedule, the calendar range query is invalidated so the chip moves or disappears immediately rather than waiting for next focus.
- Reminder click handling (`sourceType === 'reminder'`) is intentionally still a no-op — its 4-state lifecycle needs its own design pass and ships separately.

Sidecar: `fix(tags): align toast assertions with i18n format` updates two stale assertions in `tag-detail-view.test.tsx` left red after `d1228ee8 chore(i18n): migrate ... tag toasts` reformatted the toast strings. Unblocks main CI.

## Type

- [x] \`feat\` — new feature
- [x] \`fix\` — bug fix (sidecar tag-detail-view test fix)

## Test plan

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing (describe below)

Coverage:
- 3 new unit tests in \`calendar-inbox-snooze-popover.test.tsx\` (render, Open-in-inbox, Unsnooze)
- Updated existing \`calendar-page.test.tsx\` and \`calendar-quick-create.test.tsx\` for shell wiring
- New E2E in \`calendar-inbox-snooze-click.e2e.ts\`: chip-click → popover with three actions + Escape dismiss; Unsnooze removes the chip; Open in inbox tears down the calendar surface (singleton inbox tab takes over)

Local verify: lint clean, typecheck clean (\`:node\` + \`:web\`), 7233/7233 vitest pass.

## Checklist

- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC (largest new file: \`calendar-inbox-snooze-popover.tsx\` at 116 LOC)
- [x] Follows immutable data patterns