### PR TITLE
feat: use date-based release versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,8 @@ name: Release (Stable)
 
 on:
   push:
-    tags:
-      - 'stable-v*'
-      - 'v20*'
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -14,8 +13,8 @@ env:
   NODE_OPTIONS: --max-old-space-size=4096
 
 concurrency:
-  group: release-stable-${{ github.ref }}
-  cancel-in-progress: true
+  group: release-stable-main
+  cancel-in-progress: false
 
 jobs:
   version:
@@ -24,12 +23,15 @@ jobs:
     outputs:
       app_version: ${{ steps.metadata.outputs.app_version }}
       display_version: ${{ steps.metadata.outputs.display_version }}
+      release_asset_version: ${{ steps.metadata.outputs.release_asset_version }}
       release_name: ${{ steps.metadata.outputs.release_name }}
       tag: ${{ steps.metadata.outputs.release_tag }}
       version: ${{ steps.metadata.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -39,15 +41,43 @@ jobs:
       - name: Resolve release metadata
         id: metadata
         run: |
+          git fetch --tags --force
+          git tag --list > existing-tags.txt
+          git tag --points-at HEAD > current-tags.txt
+
           node scripts/desktop-release-metadata.mjs \
-            --from-tag \
-            --tag "${GITHUB_REF_NAME}" \
+            --resolve \
+            --date "$(date -u +%F)" \
+            --existing-tags-file existing-tags.txt \
+            --current-tags-file current-tags.txt \
             --github-output "$GITHUB_OUTPUT"
+
+      - name: Create or reuse release tag
+        run: |
+          tag="${{ steps.metadata.outputs.release_tag }}"
+          head_sha="$(git rev-parse HEAD)"
+
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            tag_sha="$(git rev-list -n 1 "$tag")"
+            if [ "$tag_sha" != "$head_sha" ]; then
+              echo "::error::Release tag $tag already exists at $tag_sha, not HEAD $head_sha"
+              exit 1
+            fi
+
+            echo "Reusing release tag $tag at HEAD"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$tag"
+          git push origin "refs/tags/$tag"
 
       - name: Summary
         run: |
           echo "### Stable version: \`${{ steps.metadata.outputs.display_version }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "App version: \`${{ steps.metadata.outputs.app_version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Release asset version: \`${{ steps.metadata.outputs.release_asset_version }}\`" >> "$GITHUB_STEP_SUMMARY"
 
   build:
     name: Build ${{ matrix.label }}
@@ -259,6 +289,9 @@ jobs:
 
       - name: Collect release assets
         shell: bash
+        env:
+          APP_VERSION: ${{ needs.version.outputs.app_version }}
+          RELEASE_ASSET_VERSION: ${{ needs.version.outputs.release_asset_version }}
         run: |
           mkdir -p release-assets
           find artifacts -type f \
@@ -277,8 +310,34 @@ jobs:
               -o -name 'latest*.yml' \
             \) \
             -print0 | while IFS= read -r -d '' file; do
-              cp "$file" "release-assets/$(basename "$file")"
+              filename="$(basename "$file")"
+              filename="${filename//$APP_VERSION/$RELEASE_ASSET_VERSION}"
+
+              cp "$file" "release-assets/$filename"
             done
+
+          ruby <<'RUBY'
+          require 'yaml'
+
+          app_version = ENV.fetch('APP_VERSION')
+          asset_version = ENV.fetch('RELEASE_ASSET_VERSION')
+
+          Dir['release-assets/latest*.yml'].each do |path|
+            data = YAML.load_file(path) || {}
+            rewrite = ->(value) { value.is_a?(String) ? value.gsub(app_version, asset_version) : value }
+
+            data['path'] = rewrite.call(data['path'])
+            if data['files'].is_a?(Array)
+              data['files'].each do |entry|
+                next unless entry.is_a?(Hash)
+
+                entry['url'] = rewrite.call(entry['url'])
+              end
+            end
+
+            File.write(path, YAML.dump(data))
+          end
+          RUBY
 
           asset_count="$(find release-assets -maxdepth 1 -type f | wc -l | tr -d ' ')"
           if [ "$asset_count" -eq 0 ]; then
@@ -291,7 +350,8 @@ jobs:
       - name: Build stable-latest.json
         shell: bash
         env:
-          VERSION: ${{ needs.version.outputs.app_version }}
+          APP_VERSION: ${{ needs.version.outputs.app_version }}
+          DISPLAY_VERSION: ${{ needs.version.outputs.display_version }}
           TAG: ${{ needs.version.outputs.tag }}
         run: |
           python3 <<'PY'
@@ -301,7 +361,8 @@ jobs:
           import sys
           from datetime import datetime, timezone
 
-          version = os.environ['VERSION']
+          app_version = os.environ['APP_VERSION']
+          display_version = os.environ['DISPLAY_VERSION']
           tag = os.environ['TAG']
           repo = os.environ['GITHUB_REPOSITORY']
           owner, repo_name = repo.split('/', 1)
@@ -333,7 +394,8 @@ jobs:
           linux_deb = pick('linux deb', ['*.deb'])
 
           payload = {
-              'version': version,
+              'version': display_version,
+              'app_version': app_version,
               'notes': f'Stable release. See {pages_url} for full release notes.',
               'pub_date': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
               'platforms': {
@@ -391,7 +453,7 @@ jobs:
           {
             echo ""
             echo "---"
-            echo "**Stable release - manually promoted from \`main\`**"
+            echo "**Stable release - published from \`main\`**"
             echo ""
             echo "**Includes macOS (Apple Silicon and Intel), Windows x64, and Linux x64 bundles**"
             echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,25 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-05-07 — Date-based Release Versioning
+
+### Changed
+
+- Publish stable desktop releases from `main` with public date tags such as `v2026-05-06`, using `.2`, `.3`, and later suffixes for additional UTC-day releases.
+- Show the same public date version in Settings and update dialogs while keeping updater and package metadata semver-safe.
+
+---
+
 ## 2026-04-30 — Calendar: clickable inbox-snooze chips
 
 ### Added
+
 - Inbox-snooze chips on the calendar are now clickable. Clicking opens a small floating popover next to the chip with three actions: **Open in inbox** (jumps to the inbox tab), **Unsnooze now** (clears the snooze and removes the chip), and **Reschedule** (reuses the standard `<SnoozePicker>` preset list + custom date/time dialog). Previously the click was a silent no-op.
 - New `<CalendarInboxSnoozePopover>` component (presentational; receives data + callbacks) mirroring the positioning + dismiss pattern of `<CalendarEventPopover>`. The outside-click handler explicitly excludes Radix popper portals so the nested SnoozePicker dropdown/dialog don't dismiss the popover mid-interaction.
 - E2E coverage in `calendar-inbox-snooze-click.e2e.ts`: chip-click → popover with three actions + Escape dismiss; Unsnooze removes the chip; Open in inbox tears down the calendar surface (singleton inbox tab takes over).
 
 ### Changed
+
 - After Unsnooze and Reschedule the calendar range query is invalidated so the chip moves or disappears immediately.
 - Reminder click handling (`sourceType === 'reminder'`) is intentionally still a no-op — its 4-state lifecycle needs its own design pass and ships separately.
 
@@ -21,6 +32,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-29 — Multi-language Support (English, Turkish, Arabic) with RTL
 
 ### Added
+
 - Full multi-language support: pick English, Turkish (`Türkçe`), or Arabic (`العربية`) from Settings → General → Language. Switching reloads UI strings across every surface — buttons, dialogs, settings panels, calendar, tasks, inbox, journal, notes, graph, and the native Electron menu — without requiring an app restart.
 - Right-to-left (RTL) layout when Arabic is selected. The renderer applies `dir="rtl"` to `<html>`, mirrors directional UI (close buttons, sidebars, scrollbars), and flips Tailwind logical-property classes (`ms-*`, `me-*`, `ps-*`, `pe-*`, `start-*`, `end-*`, `text-start`, `text-end`, `border-s`, `border-e`, `rounded-s-*`, `rounded-e-*`) automatically.
 - ICU pluralization in user-visible counters (e.g. note property "used in N notes", column-selector usage counts) using locale-correct plural rules: English `one/other`, Turkish `other` (no plural form), Arabic `zero/one/two/few/many/other`. Powered by a custom `IcuFormatter` plugin since the published `i18next-icu` is broken under pure ESM.
@@ -33,11 +45,13 @@ Format: weekly entries grouped by feature area.
 - Documentation: "Adding a Locale" checklist, Tailwind logical-property rule in CLAUDE.md.
 
 ### Changed
+
 - ~120 user-visible English strings across the renderer migrated from hardcoded literals to namespaced `t()` calls: settings shell, general/appearance/account/sync/workspace panels, calendar toolbar/filters/dialogs/event editor, tasks page, inbox (toolbar, list, detail, filing, triage, archived, bulk actions, content preview, insights), notes page, journal, graph (page, controls, menu, tooltips), folder view, search aria-labels, unsaved-changes dialog, bulk-delete dialog, note-tree/task/calendar delete-cancel buttons.
 - Main-process error and menu surfaces resolve through namespaces (`errors:*`, `menu:*`) instead of inline strings.
 - `GeneralSettings.language` tightened to `LocaleSchema` (compile-time validation prevents drift between settings and supported locales).
 
 ### Fixed
+
 - Replace broken `i18next-icu` with a custom `IcuFormatter`. The published package's ESM bundle does `import IntlMessageFormat from 'intl-messageformat'`, but `intl-messageformat` 10.x exports the constructor as a named export — the default-import resolves to the module namespace and `new IntlMessageFormat(...)` throws "is not a constructor". The custom plugin uses the correct named import and falls back to the raw template string on parse error so consumers see the bug instead of an empty string.
 - Avoid renderer provider barrel import that created a circular dependency through the i18n package boundary.
 
@@ -46,6 +60,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-21 — Calendar Sidebar Typed Indicator Dots
 
 ### Added
+
 - Show typed indicator dots on the right-sidebar mini-calendar when viewing the Calendar tab. Each day cell renders up to 3 side-by-side colored dots, one per item, with colors matching the item's visual type: purple for events, green for imported events, blue for tasks, pink for reminders, orange for snoozes. Days with more items than available slots prioritize diversity — one dot per unique type first, then filling remaining slots with duplicates. For example, a day with 3 events, 2 tasks, and 1 snooze shows one purple, one blue, and one orange dot rather than three purple dots. The Journal tab keeps its single emerald/amber activity-intensity dot unchanged, so switching tabs visibly changes what the sidebar tells you.
 
 ---
@@ -53,6 +68,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-20 — Calendar Sync Triggers
 
 ### Fixed
+
 - Sync Google Calendar events on focus, resume, and manual refresh. Calendar now automatically updates when the app window regains focus, when the app resumes from background, and when the user clicks the manual refresh button, ensuring calendar data stays current without relying only on periodic sync intervals.
 
 ---
@@ -60,9 +76,11 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-18 — Calendar Day View All-Day Strip + E2E Stabilization
 
 ### Fixed
+
 - Restore visibility of all-day items (tasks with `due_date` only, reminders on date targets, user-created all-day events) in Calendar Day view. Render a compact "All day" strip above the hour grid so projected and user-created all-day items no longer disappear after PR #266 moved the in-page right sidebar out. Fixes shard 1/3 e2e regressions in `calendar.e2e.ts` and `calendar-comprehensive.e2e.ts`
 
 ### Changed
+
 - Replace the fixed 5×30s convergence loop in `body-crdt-coverage-variants` V6 with `expect.poll` (120s timeout, backoff intervals) so CI xvfb load no longer exhausts the loop before noteB replicates to device A
 
 ---
@@ -70,12 +88,14 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-18 — Calendar Week View Infinite Horizontal Scroll
 
 ### Added
+
 - Infinite horizontal day scroll in Week view: trackpad swipes (and Shift + mouse wheel) pan the 7 visible day columns continuously across week boundaries, with the toolbar label updating live. Prev/Next/Today buttons now smooth-scroll to their target, and event data prefetches ±1 week around the visible range
 - `dayIndexFromDate` / `dateFromDayIndex` helpers in `date-utils.ts`, anchored at a `2020-01-01` epoch for virtualization math
 - `useWeekInfiniteScroll` hook owning a horizontal `@tanstack/react-virtual` virtualizer, `ResizeObserver`-driven column width, stable ref-backed visible-day callback, and a far-jump fallback inside `scrollToDay`
 - E2E tests in `calendar-week-scroll.e2e.ts` covering scroll right, scroll left, Today button, and Next/Prev buttons (no snap-back assertions)
 
 ### Changed
+
 - Week view rewritten around horizontal virtualization with mirrored header + time-gutter scroll containers and a `data-testid="calendar-week-scroll"` hook point for e2e
 - Calendar page fetch range for Week view expanded to `[weekStart − 7, weekStart + 14)` for ±1 week prefetch via the existing `useCalendarRange` query key cache
 - `useTimeGridMarquee` now accepts an optional `getColumnElement` resolver so drag-select + quick-create popover anchoring work against absolute day indices in the virtualized grid
@@ -86,6 +106,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-17 — Calendar Quick-Create Surfaces Silent IPC Failures
 
 ### Fixed
+
 - Fix calendar quick-create and event editor silently closing without persisting when the create/update IPC resolves with `{ success: false }`. The handlers now throw the returned error message so the popover stays open and shows a destructive inline message instead of discarding the user's input with no feedback
 
 ---
@@ -93,6 +114,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-17 — Calendar Day View Uses Global Right Sidebar (#266)
 
 ### Changed
+
 - Remove the in-page right sidebar from Calendar Day view in favor of the global right sidebar
 - Auto-open the global right sidebar on Day view entry and close it on leaving Day view — unless the user had opened it manually, in which case it stays open
 
@@ -101,6 +123,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-17 — Google Calendar Settings Row Compact Layout
 
 ### Changed
+
 - Simplify Google Calendar integration settings: remove the "Memry Calendar" label/value block and the bordered card wrapper around the imported calendars list, leaving a flatter, more compact layout after connection
 
 ---
@@ -108,6 +131,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-17 — Google Calendar OAuth Error Diagnostics
 
 ### Fixed
+
 - Fix silent 400 on Google Calendar token exchange: log structured error details (`status`, `error`, `error_description`) and throw user-friendly messages instead of raw status codes
 - Replace raw API/token errors across OAuth flow and Calendar API client with contextual friendly messages mapped from RFC 6749 error codes and Google API status codes
 - Warn at startup when `GOOGLE_CALENDAR_CLIENT_SECRET` is set (Desktop OAuth clients do not require a secret)
@@ -118,6 +142,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-17 — CRDT Handler Lifecycle on Signout
 
 ### Fixed
+
 - Fix "No handler registered for 'crdt:close-doc'" error logged on signout by registering CRDT IPC handlers at app bootstrap instead of tearing them down with the provider; handlers now route through `getCrdtProvider()` on every call and no-op safely after teardown
 
 ---
@@ -125,10 +150,12 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-17 — Calendar Marquee Quick-Create Fix
 
 ### Fixed
+
 - Fix calendar marquee drag to persist the event when the user submits a title via Enter or Save
 - Keep the quick-create popover mounted and show an inline destructive message when event creation fails, instead of closing silently
 
 ### Changed
+
 - Decouple calendar UI refresh from sync queue health so newly created events appear immediately even when background sync is unavailable
 - Extract `localInputToIso` helper for local-input-to-ISO conversion with explicit NaN guarding
 
@@ -137,6 +164,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-17 — Calendar Auto-scroll to Current Time
 
 ### Added
+
 - Auto-scroll calendar day and week views on mount so the current-time indicator sits ~40% from the top of the viewport; fall back to 7 AM when the visible range does not contain today
 
 ---
@@ -144,15 +172,16 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-14 — Calendar Marquee Live Preview
 
 ### Changed
+
 - Show a rich "New Event" preview with a live `HH:MM–HH:MM` range while dragging on the day and week grids instead of the previous empty tinted box
 - Migrate `CalendarQuickCreatePopover` to the shadcn/Radix `Popover` with a virtual anchor at the selection rect, automatic side/align collision handling, and a directional arrow pointing back at the selection
 - Add a shared `PopoverArrow` export on the shadcn popover wrapper so any popover can opt into an anchor-pointing arrow
 - Remove hand-rolled Escape and outside-click listeners from the quick-create popover now that Radix owns dismissal
 
-
 ## 2026-04-14 — Vim Hint Mode (#202)
 
 ### Added
+
 - Add Vim-style hint mode: Alt+F overlays typed labels on clickable elements for mouseless navigation, with single-char mnemonics, two-char fallback on first-letter collisions, backspace undo, and Escape to dismiss
 
 ---
@@ -160,6 +189,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-12 — Windows Inbox Folder Filing Fix
 
 ### Fixed
+
 - Fix Windows inbox filing so creating a folder inline no longer leaves the item in Inbox after restart
 - Normalize vault-relative paths and folder picker matching so newly created folders resolve consistently across macOS and Windows
 
@@ -168,6 +198,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-12 — Sidebar Nav Alignment
 
 ### Changed
+
 - Align sidebar nav rows (Inbox, Journal, Tasks) with folder/file row styling for visual consistency — match height, padding, border-radius, font size, and gap from the tree node primitive
 
 ---
@@ -175,9 +206,11 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-11 — Settings Modal Scroll Fix and Sidebar Action Reorder
 
 ### Changed
+
 - Move search and new-note actions to the top of the sidebar for faster access
 
 ### Fixed
+
 - Restore scrolling inside the Settings modal so long sections (Shortcuts, Account, etc.) are fully reachable when the window is short — the Radix `DialogContent` grid layout was preventing nested `ScrollArea` from computing a bounded height
 
 ---
@@ -185,6 +218,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-09 — Sync Adapter Registry and Architecture Reset
 
 ### Added
+
 - Add `local-mutations.ts` sync adapter registry centralizing all domain sync dispatch behind `enqueueLocalSyncCreate/Update/Delete`
 - Add `insertItemWithTags` transactional helper for atomic inbox item+tag persistence
 - Add `normalizeBinaryInput` shared helper for Electron IPC binary buffer deserialization
@@ -192,6 +226,7 @@ Format: weekly entries grouped by feature area.
 - Add `check-architecture-boundaries.js` rules blocking direct IPC sync-module and query imports
 
 ### Changed
+
 - Migrate note-sync from direct index-DB writes to projection events with flush
 - Extract note mutation commands into dedicated domain layer (notes/domain.ts)
 - Move all runtime-effects modules (tasks, inbox, notes, journal, tags, settings, filters) from direct sync service calls to adapter registry dispatch
@@ -201,6 +236,7 @@ Format: weekly entries grouped by feature area.
 - Simplify `TasksProvider` to self-load workspace data when no props provided
 
 ### Fixed
+
 - Restore canonical property-type guard to prevent LWW type overwrites on sync
 - Add projection flush to sync handlers, journal handlers, and CRDT writeback
 - Wrap `handleConvertToNote`, `handleConvertToTask`, `handleLinkToNote` with `withErrorHandler` preventing unhandled IPC rejections
@@ -214,6 +250,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-08 — Marquee Selection Indent/Outdent
 
 ### Added
+
 - Add Tab/Shift+Tab indent/outdent support to marquee selections
 
 ---
@@ -221,6 +258,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-07 — Security Fixes
 
 ### Fixed
+
 - Patch 4 critical Electron RCE CVEs and HIGH transitive CVEs
 - Narrow refresh token rotation grace window to 10s
 - Harden /recovery against account enumeration timing leak
@@ -230,6 +268,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-07 — Inline Subtasks in Notes
 
 ### Added
+
 - Support inline subtasks within notes: add parentTaskId, indented rendering, serialization, and recursive normalization
 - Auto-detect indented checkboxes under task blocks as subtasks
 - Promote subtask to standalone task when un-indented (Shift+Tab)
@@ -237,6 +276,7 @@ Format: weekly entries grouped by feature area.
 - Debounced auto-promote and auto-demote handlers for keyboard navigation
 
 ### Fixed
+
 - Delete taskBlock on Backspace in empty title; prevent cascade deletion
 - Preserve nested children when converting checkListItem to taskBlock
 - Sanitize theme values to prevent corruption
@@ -247,6 +287,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-07 — Tasks Tab State Persistence
 
 ### Added
+
 - Persist tasks tab view state (active view, internal tab, selected project, detail drawer) across tab navigation using the existing tab viewState mechanism
 
 ---
@@ -254,6 +295,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-07 — Remove Home Tab
 
 ### Removed
+
 - Remove unused Home tab from sidebar navigation, tab types, content routing, and icon mappings
 - Remove SidebarHome SVG icon component
 - Renumber sidebar keyboard shortcuts (Journal → ⌘⌥2, Tasks → ⌘⌥3)
@@ -263,6 +305,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-07 — Inline Task Blocks
 
 ### Added
+
 - Add custom task block for BlockNote editor with live DB sync and inline editing
 - Add `[] ` bracket shortcut and `/task` slash command to create task blocks
 - Add right-click context menu to promote checkboxes to linked tasks
@@ -274,12 +317,14 @@ Format: weekly entries grouped by feature area.
 - Add task block markdown serialization with `{task:id}` suffix round-trip
 
 ### Fixed
+
 - Fix focus jumping to previous task block when pressing Enter before async task creation completes
 - Fix sync effect reverting title to stale DB value during save (hold syncingRef across async boundary)
 - Fix paragraph conversion from task block not receiving browser focus (add editor.focus() after cursor placement)
 - Fix task deletion scan race condition with debounced block scanning
 
 ### Changed
+
 - Add `renderTitle` prop to TaskRow for inline title editing in task blocks
 
 ---
@@ -287,6 +332,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-06 — Vertical Sidebar Navigation
 
 ### Changed
+
 - Replace horizontal nav with vertical sidebar nav using shadcn SidebarMenu primitives
 - Move navigation (Inbox, Journal, Tasks) from sidebar header to sidebar content area
 - Simplify SidebarHeaderContent to only render traffic lights and vault switcher
@@ -296,6 +342,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-06 — Split View Polish
 
 ### Fixed
+
 - Hide sidebar collapse icon in split view panes (only show in primary/leftmost pane)
 
 ---
@@ -303,6 +350,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-06 — Linked Task Navigation Fix
 
 ### Fixed
+
 - Fix linked task click in note page to open task page with project filter, "all" section, detail panel, and row highlight
 
 ---
@@ -310,14 +358,17 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-05 — Inbox Detail Panel Polish
 
 ### Added
+
 - Show folder emoji/icon in filing dropdown and selected folder display
 - Show note emoji/icon for AI-suggested notes in filing section
 - Surface `emoji` field from note cache through suggestions pipeline
 
 ### Fixed
+
 - Fix checkbox and text vertical misalignment in note task lists
 
 ### Changed
+
 - Stack "File to" and "Tags" vertically instead of side by side
 - Narrow inbox detail panel from 460px to 380px to match task detail drawer
 - Align inbox and task detail panels to tab bar bottom edge (top-[37px])
@@ -330,6 +381,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-04 — Inbox Create Folder
 
 ### Added
+
 - Add inline folder creation to inbox filing dropdown with search-to-create flow
 - Add subfolder hint in folder search input for nested path creation
 
@@ -338,6 +390,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-04 — Link Embeds and Mentions
 
 ### Added
+
 - Add YouTube embed block with inline player and markdown round-trip
 - Add link mention inline content for BlockNote editor
 - Add paste link menu with URL, mention, and embed options
@@ -345,6 +398,7 @@ Format: weekly entries grouped by feature area.
 - Add Reddit JSON API metadata extraction with bot detection bypass
 
 ### Changed
+
 - Use mention and embed format for inbox link filing
 - Update Content Security Policy for YouTube iframe embeds
 
@@ -353,6 +407,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-04 — Voice Transcription
 
 ### Added
+
 - Add local Whisper Small transcription via whisper-node worker thread
 - Add OpenAI BYOK voice transcription with OS keychain storage
 - Add voice provider selector (local / OpenAI) in AI settings
@@ -363,6 +418,7 @@ Format: weekly entries grouped by feature area.
 - Add `settings:openSection` event for cross-window settings navigation
 
 ### Changed
+
 - Replace env-var OpenAI key with per-user keychain secret for voice
 - Refactor transcription module to route by provider setting
 - Extract failure-result helper to reduce duplication in transcription error paths
@@ -372,6 +428,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-03 — Dead Code Cleanup
 
 ### Changed
+
 - Remove 6 unused files and 11 unused exports across monorepo (~762 lines)
 - Remove superseded per-type reminder schemas in favor of unified `CreateReminderSchema`
 - Un-export internal-only `ReminderTargetTypeSchema` and `ReminderStatusSchema`
@@ -381,6 +438,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-03 — Clean Code Audit
 
 ### Changed
+
 - Split task-utils.ts (1,349 LOC, 60 functions) into 5 focused modules: date-utils, formatting, status-helpers, view-helpers, filters
 - Split queries/notes.ts (1,595 LOC, 78 functions) into 7 sub-modules: CRUD, tags, journal, properties, snapshots, links, helpers
 - Decompose ContentArea.tsx (1,482 → 331 lines) into 6 single-responsibility hooks
@@ -388,7 +446,7 @@ Format: weekly entries grouped by feature area.
 - Split use-inbox.ts (993 lines) into query, mutation, and operation modules
 - Decompose notes-tree.tsx (2,089 → 542 lines) into 7 modules with shared utilities across both tree variants
 - Add withDb/withErrorHandler HOFs to eliminate 112 repetitive try/catch blocks across 14 IPC handler files
-- Replace raw console.* calls in sync-server with structured createLogger utility
+- Replace raw console.\* calls in sync-server with structured createLogger utility
 - Add type-safe DB mock factories to reduce as-any casts in sync test files
 
 ---
@@ -396,9 +454,11 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-03 — Sidebar Chevron Always Visible
 
 ### Added
+
 - Add always-visible expand/collapse chevron to folder rows in sidebar tree
 
 ### Changed
+
 - Remove hover-dependent show/hide pattern for folder chevrons
 - Simplify tree node expand animation by removing slide transition
 
@@ -407,6 +467,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-03 — Tag Sort Picker
 
 ### Changed
+
 - Replace DropdownMenu with Picker component for sidebar tag sort control
 - Shorten sort labels to compact single-line names (Most used, Least used, A → Z, Z → A)
 - Add leading icons to all sort options for visual clarity
@@ -416,12 +477,14 @@ Format: weekly entries grouped by feature area.
 ## 2026-04-02 — Journal Redesign and Task Improvements
 
 ### Added
+
 - Add resizable journal page with sidebar, day panel, calendar, and task list
 - Add hierarchical `#parent/child` tags with prefix queries, cascade operations, tree sidebar, and autocomplete
 - Add task deletion from drawer and deep-link from journal
 - Add focusAtEnd click-to-focus behavior and auto-open for select-type property pickers
 
 ### Fixed
+
 - Fix find-in-page to scroll to match on search and navigation
 - Fix task status rollback from completed state
 - Fix graph panel overflow and settings shortcut capture in input fields
@@ -429,6 +492,7 @@ Format: weekly entries grouped by feature area.
 - Fix vault indexer and editor plugins for hierarchical tags
 
 ### Changed
+
 - Redesign journal day view with ghost affordance layout and tab bar toggle
 - Convert right panels to fixed overlays with dynamic day panel width
 - Remove AI Agent panel and all related code
@@ -439,6 +503,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-03-29 — Settings Config.json Migration
 
 ### Changed
+
 - Move portable user preferences (theme, font, editor width) from SQLite to config.json as source of truth
 - Propagate synced remote settings to config.json and broadcast CHANGED events to renderer (fixes sync gap)
 - Populate SQLite settings cache from config.json on vault open with one-time migration for old vaults
@@ -448,6 +513,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-03-29 — Note Page
 
 ### Added
+
 - Redesign note page header with compact Paper-inspired layout
 - Add full-width toggle for note pages
 - Add hover preview cards for wiki-links and note tabs
@@ -463,11 +529,13 @@ Format: weekly entries grouped by feature area.
 - Add ghost affordance row for note metadata
 
 ### Fixed
+
 - Persist emoji in tab state for icon restoration on reopen
 - Omit current year in compact inbox date format
 - Quit app on all windows closed regardless of platform
 
 ### Changed
+
 - Migrate popups, menus, and form controls to Picker primitive (tags, properties, tasks, reminders, inbox filter, vault switcher, overflow menu)
 - Simplify NoteTitle to display-only emoji
 - Remove Instrument Serif font
@@ -478,9 +546,11 @@ Format: weekly entries grouped by feature area.
 ## 2026-03-25 — Settings Modal & Sidebar Polish
 
 ### Added
+
 - Add settings modal dialog with `SettingsModalProvider` context, replacing settings-as-tab pattern
 
 ### Changed
+
 - Remove `settings` tab type from TabType union and singleton list
 - Replace tint-mixed sidebar accent with neutral background tones across all themes
 - Switch active sidebar indicators from `bg-sidebar-accent-foreground` to `bg-tint`
@@ -493,6 +563,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-03-25 — Desktop Polish
 
 ### Added
+
 - Add inbox redesign with toolbar, filters, triage mode, link previews, and waveform visualizer
 - Add embedded tweet rendering with TweetCard component
 - Add reminder detail view with content routing
@@ -509,12 +580,14 @@ Format: weekly entries grouped by feature area.
 - Add Gelasio, Geist, and Inter font families
 
 ### Fixed
+
 - Fix inbox filing auto-link and metascraper field mapping
 - Fix graph crash on null node data
 - Fix tag count casting and prune orphaned definitions
 - Fix project ID resolution before creating onboarding task
 
 ### Changed
+
 - Extract shared settings primitives and redesign all settings pages
 - Replace custom toast notifications with Sonner
 - Remove non-Twitter platform support and simplify social URL parsing
@@ -523,6 +596,7 @@ Format: weekly entries grouped by feature area.
 - Migrate task design tokens and wire undoable task actions
 
 ### Performance
+
 - Parallelize vault open with window creation to reduce cold-start time
 - Optimize startup I/O and large-vault indexing speed
 
@@ -531,6 +605,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-03-19 — Tasks Refinement
 
 ### Added
+
 - Add kanban board view with priority and status column drops
 - Add cross-section parent task reordering via drag-drop
 - Add inline status and priority popover editors in task rows
@@ -548,11 +623,13 @@ Format: weekly entries grouped by feature area.
 - Hide project badge in single-project view
 
 ### Fixed
+
 - Fix kanban cross-column detection to use pointer position
 - Exclude subtasks from completed-task lists and preserve subtaskIds on complete
 - Fix subtask visibility in Today, Week, and Upcoming views
 
 ### Changed
+
 - Redesign task rows with Linear-style status indicators and compact layout
 - Replace task detail panel with slide-out drawer
 - Redesign kanban cards with updated badge layout
@@ -572,18 +649,21 @@ Format: weekly entries grouped by feature area.
 ## 2026-03-14 — White Theme, Tag Sync Fixes, Sidebar Polish
 
 ### Added
+
 - Add tag search and sort (by count/name) to sidebar tag section with localStorage persistence
 - Add `--graph-label-color` semantic token for theme-aware graph labels
 - Add `tagsOverride` parameter to `syncNoteToCache` for authoritative tag syncing
 - Add pasted text tag extraction to `extractInlineTags` (not just hashTag nodes)
 
 ### Fixed
+
 - Fix tag removal from editor not updating frontmatter and UI
 - Fix pasted tags not being highlighted or synced to frontmatter
 - Fix graph colors not updating on theme switch (dimmed nodes, edges, labels)
 - Fix graph labels defaulting to invisible color in dark mode
 
 ### Changed
+
 - Redesign sidebar quick actions as horizontal search bar + compact new-note button
 - Replace sidebar accordion mount/unmount with CSS grid-rows transition (no remount)
 - Remove tree provider entry animation (opacity/translate) for instant render
@@ -596,6 +676,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-03-13 — Inline AI Editing, Editor Polish, Domain Migration
 
 ### Added
+
 - Add BlockNote xl-ai inline editing with local HTTP chat server (Ollama, OpenAI, Anthropic)
 - Add AI commands: rewrite, summarize, expand, simplify, fix grammar, continue writing, translate
 - Add custom AI menu with selection-aware command sets and Cmd+J shortcut
@@ -603,19 +684,22 @@ Format: weekly entries grouped by feature area.
 - Add graceful SIGINT/SIGTERM shutdown with EIO-safe console transport
 
 ### Fixed
+
 - Fix Cmd+W to close window when only inbox tab remains (matching native macOS behavior)
 
 ### Changed
+
 - Migrate CSP connect-src domain from memry.app to memrynote.com
 - Upgrade BlockNote from 0.45.0 to 0.47.1
 - Increase editor bottom padding to 30vh for scroll breathing room
-- Allow http://127.0.0.1:* in CSP for local AI chat server
+- Allow http://127.0.0.1:\* in CSP for local AI chat server
 
 ---
 
 ## 2026-03-09 → 2026-03-12 — Graph View, Editor Tags, Design System
 
 ### Added
+
 - Add interactive knowledge graph view with Sigma.js and Graphology
 - Add tags as first-class graph nodes with entity-tag edges
 - Add inline hash-tag system in editor with space-to-complete
@@ -625,11 +709,13 @@ Format: weekly entries grouped by feature area.
 - Add synchronous theme preload to eliminate flash on startup
 
 ### Fixed
+
 - Fix graph node overlapping by spreading nodes and reducing sizes
 - Fix pre-compute force layout so graph opens without animation jitter
 - Fix UI state reset when switching vaults
 
 ### Changed
+
 - Redesign sidebar with warm editorial palette
 - Redesign note title with editorial typography
 - Redesign backlinks as horizontal compact cards
@@ -643,6 +729,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-03-02 → 2026-03-08 — Global Search, Inbox Redesign, Monorepo (#97, #98, #99)
 
 ### Added
+
 - Add FTS5 search backend with fuzzy fallback and Cmd+K command palette (#97)
 - Add settings system with decomposed sections, tag management, and preferences (#98)
 - Add triage mode with AI note suggestions for inbox (#99)
@@ -656,12 +743,14 @@ Format: weekly entries grouped by feature area.
 - Add convert-to-task IPC and note suggestion types
 
 ### Fixed
+
 - Fix voice recorder autoStart and inbox transcription refresh
 - Fix link filing for folder, note, and multi-note targets
 - Fix date serialization to use local-time and prevent off-by-one day shift
 - Fix async CRDT close destroying reopened docs
 
 ### Changed
+
 - Migrate to turborepo monorepo structure
 - Bump Node to 24
 - Remove Upcoming tab from task navigation
@@ -676,6 +765,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-02-23 → 2026-03-01 — Sync E2EE Phases 8–15, Security Hardening (#95)
 
 ### Added
+
 - Add field-level merge logic for tasks and projects with per-field vector clocks
 - Add offline clock management for deviceless editing
 - Add attachment upload/download service with chunked transfer and thumbnails
@@ -700,6 +790,7 @@ Format: weekly entries grouped by feature area.
 - Add alarm-cycle revocation fallback for WebSocket connections
 
 ### Fixed
+
 - Fix queue dequeue to atomically mark items in-flight
 - Fix binary file handling in applyUpsert (no .md writes for binaries)
 - Fix token rotation UNIQUE collision with retry
@@ -709,12 +800,14 @@ Format: weekly entries grouped by feature area.
 - Zero newVaultKey and newMasterKey after key rotation
 
 ### Changed
+
 - Extract SyncEngine God Object (2086 LOC) into focused modules
 - Harden engine with mutex, key cleanup, bounded retry, and pull validation
 - Streamline session management and logout process
 - Decouple auth from sync for instant post-auth redirect
 
 ### Performance
+
 - Parallelize CRDT snapshots and prefetch pull pages
 - Cache device public keys during pull cycle
 - Skip push when sync queue is empty
@@ -724,6 +817,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-02-16 → 2026-02-22 — Sync E2EE Phases 3–7, CRDT Architecture
 
 ### Added
+
 - Add hybrid CRDT sync architecture with Yjs for notes and journals
 - Add CRDT incremental update endpoints on server
 - Add Yjs collaboration to BlockNote editor with initial sync progress
@@ -738,6 +832,7 @@ Format: weekly entries grouped by feature area.
 - Add CRDT snapshot creation during writeback
 
 ### Fixed
+
 - Fix server security: remove DELETE bypass, rate-limit endpoints, check device revocation
 - Fix dead contentHash removal, crypto version validation
 - Fix sync engine decryption error handling and manifest integrity checks
@@ -748,6 +843,7 @@ Format: weekly entries grouped by feature area.
 - Fix sidebar note list invalidation on notes:updated event
 
 ### Changed
+
 - Extract per-type item handler strategy pattern for sync
 - Extract ContentSyncService base class from note/journal sync
 - Add periodic pull interval with skip logging
@@ -758,6 +854,7 @@ Format: weekly entries grouped by feature area.
 ## 2026-02-09 → 2026-02-15 — Sync E2EE Phases 1–2, Foundation (#95)
 
 ### Added
+
 - Add sync/E2EE dependencies (libsodium, cborg, keytar)
 - Scaffold sync and crypto directory structure
 - Add D1 database schema with 14 tables for sync infrastructure
@@ -774,12 +871,14 @@ Format: weekly entries grouped by feature area.
 - Add contract sync automation to prevent client/server drift
 
 ### Fixed
+
 - Fix server security: rate limiter schema, cleanup timestamps, JWT type validation
 - Fix crypto security: proper KDF derivation, buffer zeroing on exceptions
 - Fix 4xx client error retry (skip all except 429)
 - Fix clipboard promise rejection in recovery phrase cleanup
 
 ### Changed
+
 - Split ipc-sync.ts omnibus into domain-specific contract files
 - Replace preload duplicate type declarations with shared contract imports
 
@@ -794,6 +893,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 ## 2026-01-19 → 2026-01-25 — Sync Specification
 
 ### Added
+
 - Add passwordless email OTP authentication specification
 - Add Ed25519 device-level signing specification
 - Add CRDT architecture plan (Yjs, IPC-backed provider, y-leveldb)
@@ -801,6 +901,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 - Add Google OAuth integration specification
 
 ### Changed
+
 - Transition sync spec from y-indexeddb to y-leveldb
 - Refine OAuth integration to support only Google authentication
 
@@ -809,6 +910,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 ## 2026-01-12 → 2026-01-18 — Journal Polish, Properties, Sync Spec
 
 ### Added
+
 - Add journal settings for sidebar visibility and stats footer
 - Add settings keyboard shortcut
 - Add property renaming functionality
@@ -818,9 +920,11 @@ _Sync E2EE specification and architecture planning. No code changes._
 - Add sync specification with key derivation, encryption, and rate limiting
 
 ### Fixed
+
 - Fix journal entry handling for serialized frontmatter properties
 
 ### Changed
+
 - Unify properties API for notes and journal entries
 - Integrate SidebarDrillDownProvider for folder view components
 
@@ -829,6 +933,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 ## 2026-01-05 → 2026-01-11 — Folder View PR, Platform Polish (#94)
 
 ### Added
+
 - Add FTS and embedding queue systems for batched updates
 - Add WikiLink resolution for note and file navigation
 - Add inbox video file support
@@ -837,10 +942,12 @@ _Sync E2EE specification and architecture planning. No code changes._
 - Add advanced search with operators and filters
 
 ### Fixed
+
 - Fix tab component re-renders with memoization and useCallback
 - Fix FTS queue update error handling
 
 ### Changed
+
 - Merge PR #94: Folder View
 - Consolidate notes hooks into use-notes-query
 - Replace useTabs with useTabActions across components
@@ -848,6 +955,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 - Remove electron-devtools-installer (use session.extensions API)
 
 ### Performance
+
 - Optimize TabContent and sidebar navigation rendering
 - Add batch tag queries for note retrieval
 
@@ -856,6 +964,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 ## 2025-12-29 → 2026-01-04 — Inbox Completion, Folder View, Test Infrastructure
 
 ### Added
+
 - Add social media post extraction with dedicated social card component
 - Add AI filing suggestions with feedback tracking
 - Add sqlite-vec for local embedding vector similarity search
@@ -874,17 +983,20 @@ _Sync E2EE specification and architecture planning. No code changes._
 - Add database seeding for tests
 
 ### Fixed
+
 - Fix inbox archive to use soft deletion instead of hard delete
 - Fix note deletion to clean up links and refresh backlinks
 - Fix TitleInput to trigger onChange only on blur (not every keystroke)
 
 ### Changed
+
 - Replace delete operations with archive actions in inbox
 - Remove CardView and InboxCard components
 - Remove RemindersPanel from sidebar
 - Unify inbox detail panel (replace separate filing/preview panels)
 
 ### Performance
+
 - Memoize property cells and group header rows in folder view
 - Add AST caching for formula expression evaluator
 - Virtualize folder view rows for large datasets
@@ -894,6 +1006,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 ## 2025-12-22 → 2025-12-28 — Task Data Layer, Notes Features, Journal System, Inbox Capture
 
 ### Added
+
 - Add task data layer with RepeatConfig, priority levels 0-4, project management
 - Add task persistence for kanban drag-drop and status changes
 - Add TanStack virtual scrolling for task lists
@@ -916,9 +1029,11 @@ _Sync E2EE specification and architecture planning. No code changes._
 - Add inline tag editing in inbox preview panel
 
 ### Fixed
+
 - Fix note titles to fetch asynchronously in task detail and note page
 
 ### Changed
+
 - Migrate rich text editor from Tiptap to BlockNote
 
 ---
@@ -926,6 +1041,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 ## 2025-12-15 → 2025-12-21 — Core Data Layer, Specifications
 
 ### Added
+
 - Add core data layer with Drizzle ORM and SQLite (tasks T001-T093)
 - Add database migrations and schema for notes, tasks, projects, settings
 - Add vault management system
@@ -938,9 +1054,11 @@ _Sync E2EE specification and architecture planning. No code changes._
 - Add feature specifications for tasks, notes, journal, inbox, sync, and search
 
 ### Fixed
+
 - Fix shift+click selection to include folders
 
 ### Changed
+
 - Move action icons to COLLECTIONS section header
 - Remove virtual folder concept
 - Initialize speckit tooling and constitution documents
@@ -951,6 +1069,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 ## 2025-12-08 → 2025-12-14 — Tab System, Journal, Note Page, AI Composer
 
 ### Added
+
 - Add split view tab system with drag-and-drop between panes
 - Add keyboard shortcuts for tab and split view management
 - Add browser-like tab styling with rounded active tabs
@@ -971,6 +1090,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 - Add global AI agent panel
 
 ### Changed
+
 - Extract tab drag-and-drop logic into dedicated provider
 - Remove Inbox 2 page and consolidate navigation
 - Derive task selection from active tab instead of props
@@ -980,6 +1100,7 @@ _Sync E2EE specification and architecture planning. No code changes._
 ## 2025-12-01 → 2025-12-07 — Initial UI Scaffold, Task Management
 
 ### Added
+
 - Add sidebar with navigation, dropdown menus, and icon management
 - Add file tree component with drag-and-drop
 - Add IconPicker component for selecting icons
@@ -997,8 +1118,10 @@ _Sync E2EE specification and architecture planning. No code changes._
 - Add custom scrollbar styles
 
 ### Changed
+
 - Lift drag-and-drop context from TasksPage to App.tsx
 - Remove FileTree component after redesign
 
 ### Performance
+
 - Replace React state focus with direct DOM focus in TreeNodeTrigger

--- a/apps/desktop/src/main/lib/app-version-display.test.ts
+++ b/apps/desktop/src/main/lib/app-version-display.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { formatAppVersionForDisplay } from './app-version-display'
+
+describe('formatAppVersionForDisplay', () => {
+  it('formats semver-safe release versions as public date versions', () => {
+    expect(formatAppVersionForDisplay('2026.506.1')).toBe('v2026-05-06')
+    expect(formatAppVersionForDisplay('2026.506.2')).toBe('v2026-05-06.2')
+    expect(formatAppVersionForDisplay('2026.1101.3')).toBe('v2026-11-01.3')
+  })
+
+  it('falls back to the raw value for unknown or invalid versions', () => {
+    expect(formatAppVersionForDisplay('1.0.0')).toBe('1.0.0')
+    expect(formatAppVersionForDisplay('v2026-05-06')).toBe('v2026-05-06')
+    expect(formatAppVersionForDisplay('2026.132.1')).toBe('2026.132.1')
+  })
+})

--- a/apps/desktop/src/main/lib/app-version-display.ts
+++ b/apps/desktop/src/main/lib/app-version-display.ts
@@ -1,0 +1,40 @@
+const appVersionPattern = /^(\d{4})\.(\d{3,4})\.(\d+)$/
+
+export function formatAppVersionForDisplay(version: string): string {
+  const match = appVersionPattern.exec(version)
+  if (!match) {
+    return version
+  }
+
+  const [, yearText, monthDayText, releaseIndexText] = match
+  const releaseIndex = Number(releaseIndexText)
+  if (releaseIndex < 1) {
+    return version
+  }
+
+  const monthText = monthDayText.length === 3 ? monthDayText.slice(0, 1) : monthDayText.slice(0, 2)
+  const dayText = monthDayText.length === 3 ? monthDayText.slice(1) : monthDayText.slice(2)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const year = Number(yearText)
+
+  if (!isValidUtcDate(year, month, day)) {
+    return version
+  }
+
+  const suffix = releaseIndex === 1 ? '' : `.${releaseIndex}`
+  return `v${yearText}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}${suffix}`
+}
+
+function isValidUtcDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12) {
+    return false
+  }
+
+  const candidate = new Date(Date.UTC(year, month - 1, day))
+  return (
+    candidate.getUTCFullYear() === year &&
+    candidate.getUTCMonth() === month - 1 &&
+    candidate.getUTCDate() === day
+  )
+}

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -4,6 +4,7 @@ import type { AppUpdateState } from '@memry/contracts/ipc-updater'
 import { UpdaterChannels } from '@memry/contracts/ipc-updater'
 import { createLogger } from './lib/logger'
 import { getMainI18n } from './lib/main-i18n'
+import { formatAppVersionForDisplay } from './lib/app-version-display'
 
 const logger = createLogger('Updater')
 
@@ -14,7 +15,7 @@ let downloadPromptVisible = false
 let restartPromptVisible = false
 
 let state: AppUpdateState = {
-  currentVersion: getCurrentVersion(),
+  currentVersion: getCurrentDisplayVersion(),
   status: isUpdateSupported() ? 'idle' : 'unavailable',
   updateSupported: isUpdateSupported(),
   availableVersion: null,
@@ -47,9 +48,10 @@ export function initializeUpdater(): void {
 
   autoUpdater.on('update-available', (info) => {
     logger.info('update available', { version: info.version })
+    const displayVersion = formatUpdateVersion(info)
     setState({
       status: 'available',
-      availableVersion: info.version,
+      availableVersion: displayVersion,
       releaseName: info.releaseName ?? null,
       releaseDate: info.releaseDate ?? null,
       releaseNotes: normalizeReleaseNotes(info),
@@ -81,9 +83,10 @@ export function initializeUpdater(): void {
 
   autoUpdater.on('update-downloaded', (info) => {
     logger.info('update downloaded', { version: info.version })
+    const displayVersion = formatUpdateVersion(info)
     setState({
       status: 'downloaded',
-      availableVersion: info.version,
+      availableVersion: displayVersion,
       releaseName: info.releaseName ?? null,
       releaseDate: info.releaseDate ?? null,
       releaseNotes: normalizeReleaseNotes(info),
@@ -174,7 +177,7 @@ function setState(patch: Partial<AppUpdateState>): void {
   state = {
     ...state,
     ...patch,
-    currentVersion: getCurrentVersion(),
+    currentVersion: getCurrentDisplayVersion(),
     updateSupported: isUpdateSupported()
   }
   broadcastState()
@@ -182,6 +185,14 @@ function setState(patch: Partial<AppUpdateState>): void {
 
 function getCurrentVersion(): string {
   return typeof app.getVersion === 'function' ? app.getVersion() : '0.0.0'
+}
+
+function getCurrentDisplayVersion(): string {
+  return formatAppVersionForDisplay(getCurrentVersion())
+}
+
+function formatUpdateVersion(info: UpdateInfo): string {
+  return formatAppVersionForDisplay(info.version)
 }
 
 function isUpdateSupported(): boolean {
@@ -210,7 +221,7 @@ async function promptToDownload(info: UpdateInfo): Promise<void> {
       defaultId: 0,
       cancelId: 1,
       title: t('dialog.update.availableTitle'),
-      message: t('dialog.update.availableMessage', { version: info.version }),
+      message: t('dialog.update.availableMessage', { version: formatUpdateVersion(info) }),
       detail
     })
 
@@ -237,7 +248,7 @@ async function promptToRestart(info: UpdateInfo): Promise<void> {
       defaultId: 0,
       cancelId: 1,
       title: t('dialog.update.readyTitle'),
-      message: t('dialog.update.readyMessage', { version: info.version }),
+      message: t('dialog.update.readyMessage', { version: formatUpdateVersion(info) }),
       detail
     })
 
@@ -273,7 +284,7 @@ function normalizeReleaseNotes(info: UpdateInfo): string | null {
 
   const combined = releaseNotes
     .map((entry) => {
-      const heading = entry.version ? `${entry.version}\n` : ''
+      const heading = entry.version ? `${formatAppVersionForDisplay(entry.version)}\n` : ''
       return `${heading}${entry.note}`.trim()
     })
     .filter(Boolean)

--- a/apps/desktop/src/renderer/src/pages/settings/general-section.i18n.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/general-section.i18n.test.tsx
@@ -130,4 +130,19 @@ describe('GeneralSettings i18n', () => {
       expect(toast.error).toHaveBeenCalledWith('Failed to change language. Please try again.')
     })
   })
+
+  it('renders public date versions from updater state', async () => {
+    api.updater.getState = vi.fn().mockResolvedValue({
+      ...updateState,
+      currentVersion: 'v2026-05-06',
+      status: 'available',
+      updateSupported: true,
+      availableVersion: 'v2026-05-06.2'
+    })
+
+    renderGeneral(i18n)
+
+    expect(await screen.findByText('Installed version v2026-05-06')).toBeInTheDocument()
+    expect(screen.getByText('Available version v2026-05-06.2')).toBeInTheDocument()
+  })
 })

--- a/scripts/desktop-release-metadata.mjs
+++ b/scripts/desktop-release-metadata.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url'
 
 const releaseDatePattern = /^(\d{4})\.(\d{1,2})\.(\d{1,2})$/
 const isoReleaseDatePattern = /^(\d{4})-(\d{2})-(\d{2})$/
-const releaseTagPattern = /^v(\d{4})-(\d{2})-(\d{2})$/
+const releaseTagPattern = /^v(\d{4})-(\d{2})-(\d{2})(?:\.([2-9]\d*))?$/
 const legacyStableTagPattern = /^stable-v(\d{4})\.(\d{1,2})\.(\d{1,2})$/
 const appVersionPattern = /^(\d{4})\.(\d{3,4})\.(\d+)$/
 
@@ -46,9 +46,10 @@ export function validateAppVersion(input) {
 export function parseReleaseTag(tag) {
   const stableMatch = releaseTagPattern.exec(tag)
   if (stableMatch) {
-    const [, yearText, monthText, dayText] = stableMatch
+    const [, yearText, monthText, dayText, releaseIndexText] = stableMatch
     const date = validateCalendarDate(yearText, monthText, dayText)
-    return { date, displayVersion: tag, index: 1, tag }
+    const index = releaseIndexText ? Number(releaseIndexText) : 1
+    return { date, displayVersion: tag, index, tag }
   }
 
   const legacyMatch = legacyStableTagPattern.exec(tag)
@@ -61,12 +62,24 @@ export function parseReleaseTag(tag) {
   throw new Error(`Invalid desktop release tag: ${tag}`)
 }
 
-export function resolveReleaseMetadata({ date }) {
+export function resolveReleaseMetadata({ date, existingTags = [], currentTags = [] }) {
+  const currentRelease = resolveCurrentRelease(currentTags)
+  if (currentRelease) {
+    return buildMetadata({
+      displayVersion: currentRelease.displayVersion,
+      releaseDate: currentRelease.date,
+      releaseIndex: currentRelease.index,
+      releaseTag: currentRelease.tag
+    })
+  }
+
   const releaseDate = validateReleaseDate(date)
-  const releaseTag = formatReleaseTag(releaseDate)
+  const releaseIndex = resolveNextReleaseIndex(releaseDate, existingTags)
+  const releaseTag = formatReleaseTag(releaseDate, releaseIndex)
   return buildMetadata({
     displayVersion: releaseTag,
     releaseDate,
+    releaseIndex,
     releaseTag
   })
 }
@@ -76,22 +89,72 @@ export function resolveReleaseMetadataFromTag(tag) {
   return buildMetadata({
     displayVersion: parsed.displayVersion,
     releaseDate: parsed.date,
+    releaseIndex: parsed.index,
     releaseTag: parsed.tag
   })
 }
 
-function buildMetadata({ displayVersion, releaseDate, releaseTag }) {
-  const releaseIndex = 1
+function buildMetadata({ displayVersion, releaseDate, releaseIndex, releaseTag }) {
   const appVersion = formatAppVersion(releaseDate, releaseIndex)
+  const releaseAssetVersion = formatReleaseAssetVersion({ releaseDate, releaseTag })
 
   return {
     appVersion,
     displayVersion,
+    releaseAssetVersion,
     releaseDate,
     releaseIndex,
     releaseName: `Memry ${displayVersion}`,
     releaseTag
   }
+}
+
+function resolveCurrentRelease(currentTags) {
+  const releases = currentTags.map(parseReleaseTagOrNull).filter(Boolean)
+  if (releases.length === 0) {
+    return null
+  }
+
+  return releases.sort(compareReleaseTags).at(-1)
+}
+
+function resolveNextReleaseIndex(releaseDate, existingTags) {
+  const indexes = existingTags
+    .map(parseReleaseTagOrNull)
+    .filter((release) => release?.date === releaseDate)
+    .map((release) => release.index)
+
+  return indexes.length === 0 ? 1 : Math.max(...indexes) + 1
+}
+
+function parseReleaseTagOrNull(tag) {
+  try {
+    return parseReleaseTag(tag)
+  } catch {
+    return null
+  }
+}
+
+function compareReleaseTags(left, right) {
+  return (
+    compareDate(left.date, right.date) ||
+    left.index - right.index ||
+    left.tag.localeCompare(right.tag)
+  )
+}
+
+function compareDate(left, right) {
+  const [leftYear, leftMonth, leftDay] = left.split('.').map(Number)
+  const [rightYear, rightMonth, rightDay] = right.split('.').map(Number)
+  return leftYear - rightYear || leftMonth - rightMonth || leftDay - rightDay
+}
+
+function formatReleaseAssetVersion({ releaseDate, releaseTag }) {
+  if (releaseTag.startsWith('v')) {
+    return releaseTag.slice(1)
+  }
+
+  return releaseDate
 }
 
 function validateCalendarDate(yearText, monthText, dayText) {
@@ -116,14 +179,16 @@ function validateCalendarDate(yearText, monthText, dayText) {
   return `${year}.${month}.${day}`
 }
 
-function formatReleaseTag(date) {
+function formatReleaseTag(date, index) {
   const [year, month, day] = date.split('.').map(Number)
-  return `v${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+  const suffix = index === 1 ? '' : `.${index}`
+  return `v${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}${suffix}`
 }
 
 function formatAppVersion(date, index) {
   const [year, month, day] = date.split('.').map(Number)
-  return validateAppVersion(`${year}.${Number(`${month}${String(day).padStart(2, '0')}`)}.${index}`)
+  const monthDay = Number(`${month}${String(day).padStart(2, '0')}`)
+  return validateAppVersion(`${year}.${monthDay}.${index}`)
 }
 
 function hasLeadingZero(value) {
@@ -132,6 +197,7 @@ function hasLeadingZero(value) {
 
 function parseArgs(argv) {
   const options = {
+    currentTags: [],
     existingTags: []
   }
 
@@ -187,6 +253,19 @@ function parseArgs(argv) {
       continue
     }
 
+    if (arg === '--current-tag') {
+      options.currentTags.push(readRequiredValue(argv, index, arg))
+      index += 1
+      continue
+    }
+
+    if (arg === '--current-tags-file') {
+      const tagsPath = readRequiredValue(argv, index, arg)
+      options.currentTags.push(...readTagsFile(tagsPath))
+      index += 1
+      continue
+    }
+
     if (arg === '--github-output') {
       options.githubOutput = readRequiredValue(argv, index, arg)
       index += 1
@@ -220,6 +299,7 @@ function writeGitHubOutputs(outputPath, metadata) {
     `app_version=${metadata.appVersion}`,
     `display_version=${metadata.displayVersion}`,
     `release_date=${metadata.releaseDate}`,
+    `release_asset_version=${metadata.releaseAssetVersion}`,
     `release_index=${metadata.releaseIndex}`,
     `release_name=${metadata.releaseName}`,
     `release_tag=${metadata.releaseTag}`,
@@ -246,6 +326,7 @@ function main() {
   if (options.mode === 'resolve') {
     const metadata = resolveReleaseMetadata({
       date: options.date,
+      currentTags: options.currentTags,
       existingTags: options.existingTags
     })
 
@@ -269,7 +350,7 @@ function main() {
   }
 
   throw new Error(
-    'Usage: node scripts/desktop-release-metadata.mjs --resolve --date <YYYY.M.D|YYYY-MM-DD> [--github-output path] OR --from-tag --tag <vYYYY-MM-DD|stable-vYYYY.M.D>'
+    'Usage: node scripts/desktop-release-metadata.mjs --resolve --date <YYYY.M.D|YYYY-MM-DD> [--existing-tags-file path] [--current-tags-file path] [--github-output path] OR --from-tag --tag <vYYYY-MM-DD[.N]|stable-vYYYY.M.D>'
   )
 }
 

--- a/scripts/desktop-release-metadata.test.mjs
+++ b/scripts/desktop-release-metadata.test.mjs
@@ -19,6 +19,7 @@ describe('desktop release metadata', () => {
     assert.deepEqual(metadata, {
       appVersion: '2026.427.1',
       displayVersion: 'v2026-04-27',
+      releaseAssetVersion: '2026-04-27',
       releaseDate: '2026.4.27',
       releaseIndex: 1,
       releaseName: 'Memry v2026-04-27',
@@ -26,15 +27,44 @@ describe('desktop release metadata', () => {
     })
   })
 
-  it('keeps the stable date tag stable even when older same-day releases exist', () => {
+  it('allocates the second same-day release when the base date tag exists', () => {
     const metadata = resolveReleaseMetadata({
       date: '2026.4.27',
       existingTags: ['v2026-04-27']
     })
 
-    assert.equal(metadata.releaseTag, 'v2026-04-27')
-    assert.equal(metadata.appVersion, '2026.427.1')
-    assert.equal(metadata.releaseIndex, 1)
+    assert.equal(metadata.releaseTag, 'v2026-04-27.2')
+    assert.equal(metadata.appVersion, '2026.427.2')
+    assert.equal(metadata.releaseIndex, 2)
+  })
+
+  it('allocates the next same-day release suffix after prior date releases', () => {
+    const metadata = resolveReleaseMetadata({
+      date: '2026.4.27',
+      existingTags: ['v2026-04-27', 'v2026-04-27.2', 'v2026-04-27.4']
+    })
+
+    assert.deepEqual(metadata, {
+      appVersion: '2026.427.5',
+      displayVersion: 'v2026-04-27.5',
+      releaseAssetVersion: '2026-04-27.5',
+      releaseDate: '2026.4.27',
+      releaseIndex: 5,
+      releaseName: 'Memry v2026-04-27.5',
+      releaseTag: 'v2026-04-27.5'
+    })
+  })
+
+  it('reuses a valid release tag already pointing at the current commit', () => {
+    const metadata = resolveReleaseMetadata({
+      date: '2026.4.28',
+      existingTags: ['v2026-04-27', 'v2026-04-27.2'],
+      currentTags: ['v2026-04-27.2']
+    })
+
+    assert.equal(metadata.releaseTag, 'v2026-04-27.2')
+    assert.equal(metadata.appVersion, '2026.427.2')
+    assert.equal(metadata.releaseIndex, 2)
   })
 
   it('ignores unrelated tags when resolving date metadata', () => {
@@ -49,13 +79,14 @@ describe('desktop release metadata', () => {
   })
 
   it('derives app metadata from a published release tag', () => {
-    assert.deepEqual(resolveReleaseMetadataFromTag('v2026-04-27'), {
-      appVersion: '2026.427.1',
-      displayVersion: 'v2026-04-27',
+    assert.deepEqual(resolveReleaseMetadataFromTag('v2026-04-27.2'), {
+      appVersion: '2026.427.2',
+      displayVersion: 'v2026-04-27.2',
+      releaseAssetVersion: '2026-04-27.2',
       releaseDate: '2026.4.27',
-      releaseIndex: 1,
-      releaseName: 'Memry v2026-04-27',
-      releaseTag: 'v2026-04-27'
+      releaseIndex: 2,
+      releaseName: 'Memry v2026-04-27.2',
+      releaseTag: 'v2026-04-27.2'
     })
   })
 
@@ -66,6 +97,12 @@ describe('desktop release metadata', () => {
       index: 1,
       tag: 'v2026-04-27'
     })
+    assert.deepEqual(parseReleaseTag('v2026-04-27.2'), {
+      date: '2026.4.27',
+      displayVersion: 'v2026-04-27.2',
+      index: 2,
+      tag: 'v2026-04-27.2'
+    })
     assert.deepEqual(parseReleaseTag('stable-v2026.4.27'), {
       date: '2026.4.27',
       displayVersion: '2026.4.27',
@@ -74,11 +111,25 @@ describe('desktop release metadata', () => {
     })
   })
 
+  it('keeps legacy release asset versions compatible with legacy tags', () => {
+    assert.deepEqual(resolveReleaseMetadataFromTag('stable-v2026.4.27'), {
+      appVersion: '2026.427.1',
+      displayVersion: '2026.4.27',
+      releaseAssetVersion: '2026.4.27',
+      releaseDate: '2026.4.27',
+      releaseIndex: 1,
+      releaseName: 'Memry 2026.4.27',
+      releaseTag: 'stable-v2026.4.27'
+    })
+  })
+
   it('rejects invalid release dates and tag suffixes', () => {
     assert.throws(() => validateReleaseDate('2026.04.27'), /zero-padded/)
     assert.throws(() => validateReleaseDate('2026.2.31'), /valid/)
     assert.throws(() => parseReleaseTag('v2026.4.27'), /release tag/)
     assert.throws(() => parseReleaseTag('2026-04-27'), /release tag/)
+    assert.throws(() => parseReleaseTag('v2026-04-27.1'), /release tag/)
+    assert.throws(() => parseReleaseTag('v2026-04-27.02'), /release tag/)
   })
 
   it('validates semver-safe app versions derived from release metadata', () => {


### PR DESCRIPTION
## What
Add date-based public release tags and visible app versions for desktop releases.

## Why
Stable releases should publish from `main` with public versions like `v2026-05-06`, with `.2`, `.3`, etc. for additional UTC-day releases, while Electron/updater internals keep semver-safe versions.

## How
- Extend desktop release metadata allocation to reuse current HEAD tags and allocate same-day suffixes.
- Update the main release workflow to create/reuse release tags from `main` and publish public v-date release metadata/assets while preserving updater metadata versions.
- Add a display formatter so Settings and update dialogs show public v-date versions.

## Type
- [x] `feat` - new feature
- [ ] `fix` - bug fix
- [ ] `refactor` - restructure without behavior change
- [ ] `style` - visual/UI only
- [ ] `perf` - performance improvement
- [x] `test` - adding or updating tests
- [ ] `chore` - tooling, deps, config
- [x] `ci` - CI/CD changes

## Test plan
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing (describe below)

Passed:
- `pnpm lint`
- `pnpm typecheck`
- `node --test scripts/desktop-release-metadata.test.mjs`
- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project main src/main/lib/app-version-display.test.ts`
- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/pages/settings/general-section.i18n.test.tsx`
- `git diff --check`
- Normal pre-push hook on retry: contract checks, architecture checks, lint, IPC check, typecheck, and desktop test suite (`410 passed | 1 skipped`, `7399 passed | 1 skipped`)

Notes:
- Initial full `pnpm test` hit a local `better-sqlite3` native module mismatch; fixed locally with `bash apps/desktop/scripts/ensure-native.sh node`.
- One push attempt hit two test timeouts in the pre-push hook (`src/main/index.phase2.test.ts`, `src/renderer/src/pages/settings/settings-page.i18n.test.tsx`). Both passed in isolation immediately after, and the normal pre-push hook passed on retry.

## Screenshots
N/A

## Checklist
- [x] Self-reviewed the diff
- [x] No hardcoded secrets or credentials
- [x] Files stay under ~500 LOC
- [x] Follows immutable data patterns