### PR TITLE
Keep marquee selection block-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-05-07 — Notes and Journal Block Marquee Selection
+
+### Fixed
+- Fix block marquee selection in notes and journals so dragging selects only blocks, not the text content inside selected blocks. Backspace/Delete and block indent/outdent shortcuts continue to operate on the selected blocks.
+
+---
+
 ## 2026-04-30 — Calendar: clickable inbox-snooze chips
 
 ### Added

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { TextSelection } from 'prosemirror-state'
-import type { Node as PMNode } from 'prosemirror-model'
 import { createLogger } from '@/lib/logger'
 import { classifyBlocks, indentTaskBlock, outdentTaskBlock } from './task-block-marquee-indent'
 
@@ -83,32 +81,6 @@ function getOrderedBlockIds(container: HTMLElement, ids: ReadonlySet<string>): s
   return ordered
 }
 
-interface BlockContainerEntry {
-  pos: number
-  node: PMNode
-}
-
-// Walk the PM doc once to find positions of every blockContainer node whose
-// id is in `ids`. Returns a flat lookup keyed by BlockNote block id. Recurses
-// into nested children (taskBlock subtasks etc.) so the position map matches
-// the DOM-flat order returned by getOrderedBlockIds.
-function findBlockContainerPositions(
-  doc: PMNode,
-  ids: ReadonlySet<string>
-): Map<string, BlockContainerEntry> {
-  const out = new Map<string, BlockContainerEntry>()
-  if (ids.size === 0) return out
-  doc.descendants((node, pos) => {
-    if (node.type.name !== 'blockContainer') return true
-    const id = node.attrs?.id as string | undefined
-    if (id && ids.has(id) && !out.has(id)) {
-      out.set(id, { pos, node })
-    }
-    return true
-  })
-  return out
-}
-
 export function useBlockMarqueeSelection({
   editor,
   blockContainerRef,
@@ -122,13 +94,6 @@ export function useBlockMarqueeSelection({
 
   const selectedRef = useRef<Set<string>>(new Set())
   const hasSelectionRef = useRef(false)
-  const isApplyingPmSelectionRef = useRef(false)
-  // True when applyPmSelection actually dispatched a real PM selection
-  // backing the marquee. False for the all-non-textblock branch where
-  // we keep the visual highlight + selectedRef as the source of truth
-  // and let our own Backspace handler do the work. Drives whether the
-  // editor.onSelectionChange listener is allowed to clear us.
-  const pmSelectionBackedRef = useRef(false)
   const teardownDragRef = useRef<(() => void) | null>(null)
 
   const clearSelection = useCallback((): void => {
@@ -140,7 +105,6 @@ export function useBlockMarqueeSelection({
     setMarqueeRect(null)
     setIsActive(false)
     hasSelectionRef.current = false
-    pmSelectionBackedRef.current = false
     if (triggerContainerEl) triggerContainerEl.removeAttribute(ACTIVE_ATTR)
   }, [triggerContainerEl])
 
@@ -193,10 +157,6 @@ export function useBlockMarqueeSelection({
   // (now carrying B as a child), so C also nests directly under A as
   // B's sibling.
   //
-  // isApplyingPmSelectionRef is held true across the whole loop so the
-  // editor.onSelectionChange listener (which exists to clear the marquee
-  // on cursor moves) doesn't fire on our own setTextCursorPosition /
-  // replaceBlocks dispatches.
   const indentSelectedBlocks = useCallback((): void => {
     const container = blockContainerRef.current
     if (!container) return
@@ -212,7 +172,6 @@ export function useBlockMarqueeSelection({
     } catch (err) {
       log.debug('Failed to focus PM view before indent', err)
     }
-    isApplyingPmSelectionRef.current = true
     try {
       for (const id of textblocks) {
         try {
@@ -233,12 +192,7 @@ export function useBlockMarqueeSelection({
         }
       }
     } finally {
-      // rAF so the guard outlives the tail selectionchange tick that
-      // the final setTextCursorPosition / replaceBlocks triggered.
-      requestAnimationFrame(() => {
-        isApplyingPmSelectionRef.current = false
-        recomputeHighlightRects()
-      })
+      requestAnimationFrame(recomputeHighlightRects)
     }
   }, [editor, blockContainerRef, recomputeHighlightRects])
 
@@ -266,7 +220,6 @@ export function useBlockMarqueeSelection({
     } catch (err) {
       log.debug('Failed to focus PM view before outdent', err)
     }
-    isApplyingPmSelectionRef.current = true
     try {
       for (let i = textblocks.length - 1; i >= 0; i -= 1) {
         const id = textblocks[i]
@@ -289,10 +242,7 @@ export function useBlockMarqueeSelection({
         }
       }
     } finally {
-      requestAnimationFrame(() => {
-        isApplyingPmSelectionRef.current = false
-        recomputeHighlightRects()
-      })
+      requestAnimationFrame(recomputeHighlightRects)
     }
   }, [editor, blockContainerRef, recomputeHighlightRects])
 
@@ -420,100 +370,6 @@ export function useBlockMarqueeSelection({
         }
       }
 
-      const applyPmSelection = (finalIds: ReadonlySet<string>): boolean => {
-        const ordered = getOrderedBlockIds(blockContainer, finalIds)
-        if (ordered.length === 0) return false
-
-        const view = editor?.prosemirrorView
-        if (!view) return false
-        const { state } = view
-
-        // One PM-doc walk for every selected block id.
-        const positions = findBlockContainerPositions(state.doc, new Set(ordered))
-        if (positions.size === 0) return false
-
-        // If EVERY selected block is non-textblock (taskBlock, file,
-        // youtubeEmbed — all the content:'none' custom blocks), skip
-        // setting a PM selection altogether. PM has no valid TextSelection
-        // anchor in such a range and would either throw, snap to a
-        // textblock OUTSIDE the range, or silently degrade. The
-        // marquee-side Backspace handler operates on selectedRef.current
-        // via editor.removeBlocks, so the visual highlight stays the
-        // authoritative source of truth and Backspace works uniformly.
-        const allNonTextblock = ordered.every((id) => {
-          const entry = positions.get(id)
-          const innerBlock = entry?.node.firstChild
-          return innerBlock != null && !innerBlock.type.isTextblock
-        })
-        if (allNonTextblock) {
-          // No PM selection to set. Mark the marquee as NOT backed by
-          // a PM selection so the onSelectionChange listener (which
-          // exists to clear the marquee when the user moves the cursor)
-          // doesn't fire on spurious editor selection events from async
-          // re-renders. Backspace, Escape, and click-outside still clear
-          // via their own listeners.
-          pmSelectionBackedRef.current = false
-          return true
-        }
-
-        try {
-          isApplyingPmSelectionRef.current = true
-          pmSelectionBackedRef.current = true
-
-          if (ordered.length === 1) {
-            const entry = positions.get(ordered[0])
-            if (!entry) return false
-
-            // Single textblock — preserve the existing TextSelection
-            // path so the regression at marquee-selection.e2e.ts:409
-            // (selectedText.toContain('Tall heading')) keeps passing.
-            const innerBlock = entry.node.firstChild
-            if (!innerBlock) return false
-            const innerStart = entry.pos + 2
-            const innerEnd = innerStart + innerBlock.content.size
-            const tr = state.tr.setSelection(TextSelection.create(state.doc, innerStart, innerEnd))
-            view.dispatch(tr)
-          } else {
-            // Multi-block path: build a TextSelection whose endpoints
-            // bracket the first/last selected blockContainer nodes at
-            // depth 0. PM walks the range to find valid textblock
-            // anchors — works for mixed (textblock + non-textblock)
-            // ranges because at least one textblock is reachable.
-            const firstEntry = positions.get(ordered[0])
-            const lastEntry = positions.get(ordered[ordered.length - 1])
-            if (!firstEntry || !lastEntry) return false
-
-            const from = firstEntry.pos
-            const to = lastEntry.pos + lastEntry.node.nodeSize
-
-            const $from = state.doc.resolve(from)
-            const $to = state.doc.resolve(to)
-            const tr = state.tr.setSelection(TextSelection.between($from, $to))
-            view.dispatch(tr)
-          }
-
-          // Re-focus the editor so keyboard actions (Backspace, Cmd+C,
-          // Cmd+A) reach ProseMirror — promote() blurred it.
-          try {
-            editor.prosemirrorView?.focus?.()
-          } catch (err) {
-            log.debug('Failed to refocus PM after marquee', err)
-          }
-          // requestAnimationFrame (not queueMicrotask) so the guard
-          // outlives the secondary onSelectionChange tick that
-          // view.focus() triggers — otherwise the listener at the bottom
-          // of this hook clears our just-set selection.
-          requestAnimationFrame(() => {
-            isApplyingPmSelectionRef.current = false
-          })
-          return true
-        } catch (err) {
-          isApplyingPmSelectionRef.current = false
-          log.debug('PM selection apply failed (marquee fallback to clear)', err)
-          return false
-        }
-      }
-
       const finalize = (): void => {
         const finalIds = new Set(selectedRef.current)
         setMarqueeRect(null)
@@ -527,18 +383,14 @@ export function useBlockMarqueeSelection({
           return
         }
 
-        const ok = applyPmSelection(finalIds)
-        if (ok) {
-          setSelectedBlockIds(finalIds)
-          hasSelectionRef.current = true
-        } else {
-          // Couldn't produce a real editor-owned selection — clear the
-          // marquee highlight instead of leaving a visual-only (inert)
-          // selection on screen that Backspace/Cmd+C/Cmd+A can't act on.
-          setHighlightRects([])
-          setSelectedBlockIds(new Set())
-          hasSelectionRef.current = false
+        try {
+          window.getSelection()?.removeAllRanges()
+        } catch (err) {
+          log.warn('Failed to clear native selection on marquee finalize', err)
         }
+
+        setSelectedBlockIds(finalIds)
+        hasSelectionRef.current = true
       }
 
       const teardown = (): void => {
@@ -598,11 +450,8 @@ export function useBlockMarqueeSelection({
 
       // Backspace / Delete on a marquee selection: remove every
       // visually-selected block. This intentionally bypasses PM's
-      // native cross-block deletion so it works uniformly for
-      // textblocks AND non-textblock custom blocks (taskBlock, file,
-      // youtubeEmbed) — applyPmSelection can only set a real PM
-      // selection on textblock content, so we keep selectedRef as the
-      // authoritative source of truth for what the marquee covers.
+      // native cross-block deletion so textblocks and custom blocks
+      // (taskBlock, file, youtubeEmbed) share the same block-only path.
       if (event.key === 'Backspace' || event.key === 'Delete') {
         const ids = Array.from(selectedRef.current)
         if (ids.length === 0) return
@@ -631,28 +480,6 @@ export function useBlockMarqueeSelection({
     document.addEventListener('mousedown', onMouseDown, true)
     return () => document.removeEventListener('mousedown', onMouseDown, true)
   }, [clearSelection, triggerContainerEl])
-
-  useEffect(() => {
-    if (!editor?.onSelectionChange) return
-    const unsubscribe = editor.onSelectionChange(() => {
-      if (isApplyingPmSelectionRef.current) return
-      if (!hasSelectionRef.current) return
-      // When the marquee isn't backed by a PM selection (all-non-
-      // textblock case), editor selection changes are unrelated to
-      // the marquee and must NOT clear it. Async task block re-renders,
-      // IPC callbacks, focus changes, etc. all emit selectionchange
-      // events that would otherwise destroy the marquee state.
-      if (!pmSelectionBackedRef.current) return
-      clearSelection()
-    })
-    return () => {
-      try {
-        unsubscribe?.()
-      } catch (err) {
-        log.warn('Failed to unsubscribe from editor.onSelectionChange', err)
-      }
-    }
-  }, [editor, clearSelection])
 
   return {
     marqueeRect,

--- a/apps/desktop/tests/e2e/marquee-selection-block-types.e2e.ts
+++ b/apps/desktop/tests/e2e/marquee-selection-block-types.e2e.ts
@@ -14,10 +14,9 @@
  * the visual highlight on release — taskBlock marquee selection was
  * completely broken end-to-end.
  *
- * The fix routes single non-textblock blocks through PM NodeSelection, and
- * multi-block selections through TextSelection.between at depth-0 endpoints.
- * Test #3 below (mixed paragraph + taskBlock + heading + paragraph) is the
- * critical regression gate.
+ * The fix keeps block marquee selection as visual block state and routes
+ * Backspace through editor.removeBlocks, so textblocks and custom blocks share
+ * the same deletion path.
  *
  * NOTE: youtubeEmbed and file blocks are intentionally NOT covered here.
  * They share the same `content: 'none'` schema as taskBlock, so the fix
@@ -203,9 +202,7 @@ test.describe('Marquee selection — block types', () => {
     await waitForVaultReady(page)
   })
 
-  test('1. single taskBlock — visual highlight + PM NodeSelection + Backspace deletes', async ({
-    page
-  }) => {
+  test('1. single taskBlock — visual highlight + Backspace deletes', async ({ page }) => {
     await createNote(page, `Marquee Single TaskBlock ${Date.now()}`)
     await focusEditor(page)
 
@@ -223,10 +220,9 @@ test.describe('Marquee selection — block types', () => {
 
     await expect(page.locator(HIGHLIGHTED_SELECTOR)).toHaveCount(1)
 
-    // The marquee overlay is the primary visual signal. The marquee-side
-    // Backspace handler operates on the selectedBlockIds set directly via
-    // editor.removeBlocks, so PM selection state is secondary — what
-    // matters end-to-end is that Backspace removes the highlighted block.
+    // The marquee-side Backspace handler operates on the selectedBlockIds set
+    // directly via editor.removeBlocks, so what matters end-to-end is that
+    // Backspace removes the highlighted block.
     await page.keyboard.press('Backspace')
     await page.waitForTimeout(300)
     expect(await getBlockCount(page)).toBeLessThan(startCount)
@@ -301,10 +297,9 @@ test.describe('Marquee selection — block types', () => {
     const startCount = await getBlockCount(page)
     await marqueeAcross(page, 0, 3)
 
-    // All four blocks visually highlighted post-release. This is the
-    // exact regression that was broken: previously, the catch path on
-    // applyPmSelection cleared the highlights when the range included a
-    // taskBlock.
+    // All four blocks visually highlighted post-release. This is the exact
+    // mixed-block regression gate: paragraph + taskBlock + heading + paragraph
+    // must remain one block marquee selection.
     expect(await page.locator(HIGHLIGHTED_SELECTOR).count()).toBeGreaterThanOrEqual(4)
 
     await page.keyboard.press('Backspace')
@@ -410,10 +405,8 @@ test.describe('Marquee selection — block types', () => {
 
     await marqueeAcross(page, 0, 2)
 
-    // The fix uses requestAnimationFrame (not queueMicrotask) for the
-    // isApplyingPmSelectionRef guard reset. Without rAF, the secondary
-    // onSelectionChange tick from view.focus() would clear our highlight
-    // ~1 tick after release. 200ms is well past that race window.
+    // Wait past the release/finalize tick so the persisted highlight is the
+    // stable post-marquee state, not just the mid-drag overlay state.
     await page.waitForTimeout(200)
     expect(await page.locator(HIGHLIGHTED_SELECTOR).count()).toBeGreaterThanOrEqual(3)
   })

--- a/apps/desktop/tests/e2e/marquee-selection-journal.e2e.ts
+++ b/apps/desktop/tests/e2e/marquee-selection-journal.e2e.ts
@@ -52,6 +52,19 @@ async function getMarqueeZoneBox(page: Page) {
   return box
 }
 
+async function expectNoNativeTextSelection(page: Page): Promise<void> {
+  const selectionState = await page.evaluate(() => {
+    const sel = window.getSelection()
+    return {
+      hasNonCollapsedRange: sel !== null && sel.rangeCount > 0 && !sel.isCollapsed,
+      selectedText: sel?.toString() ?? ''
+    }
+  })
+
+  expect(selectionState.hasNonCollapsedRange).toBe(false)
+  expect(selectionState.selectedText).toBe('')
+}
+
 test.describe('Journal block marquee selection', () => {
   test.beforeEach(async ({ page }) => {
     await waitForAppReady(page)
@@ -96,6 +109,7 @@ test.describe('Journal block marquee selection', () => {
     // Overlay gone after release; highlights persist.
     await expect(page.locator(OVERLAY_SELECTOR)).toHaveCount(0)
     expect(await page.locator(HIGHLIGHTED_SELECTOR).count()).toBeGreaterThanOrEqual(3)
+    await expectNoNativeTextSelection(page)
   })
 
   test('Backspace deletes marquee-selected journal blocks', async ({ page }) => {

--- a/apps/desktop/tests/e2e/marquee-selection.e2e.ts
+++ b/apps/desktop/tests/e2e/marquee-selection.e2e.ts
@@ -4,7 +4,7 @@
  *
  * Finder-style rubber-band selection over BlockNote blocks.
  * Drag from non-text area → rectangle overlay → soft highlight on
- * intersected blocks → PM setSelection for native Backspace/Cmd+C/Cmd+A.
+ * intersected blocks → block-only marquee state for keyboard actions.
  */
 
 import { test, expect, type Page } from './fixtures'
@@ -47,6 +47,19 @@ async function getMarqueeZoneBox(page: Page) {
   const box = await page.locator(MARQUEE_ZONE_SELECTOR).first().boundingBox()
   if (!box) throw new Error('marquee zone not found')
   return box
+}
+
+async function expectNoNativeTextSelection(page: Page): Promise<void> {
+  const selectionState = await page.evaluate(() => {
+    const sel = window.getSelection()
+    return {
+      hasNonCollapsedRange: sel !== null && sel.rangeCount > 0 && !sel.isCollapsed,
+      selectedText: sel?.toString() ?? ''
+    }
+  })
+
+  expect(selectionState.hasNonCollapsedRange).toBe(false)
+  expect(selectionState.selectedText).toBe('')
 }
 
 test.describe('Block marquee selection', () => {
@@ -95,6 +108,7 @@ test.describe('Block marquee selection', () => {
 
     // At least 3 blocks remain highlighted post-release.
     expect(await page.locator(HIGHLIGHTED_SELECTOR).count()).toBeGreaterThanOrEqual(3)
+    await expectNoNativeTextSelection(page)
   })
 
   test('Escape clears marquee selection', async ({ page }) => {
@@ -403,9 +417,7 @@ test.describe('Block marquee selection', () => {
     await expect(page.locator(HIGHLIGHTED_SELECTOR)).toHaveCount(0)
   })
 
-  test('single-block marquee → produces real editor selection (no inert state)', async ({
-    page
-  }) => {
+  test('single-block marquee selects only the block, not its text content', async ({ page }) => {
     await createNote(page, `Marquee Single ${Date.now()}`)
     await focusEditor(page)
     // H1 heading is visually tall enough that a vertical drag fits
@@ -442,25 +454,13 @@ test.describe('Block marquee selection', () => {
     await page.mouse.up()
     await page.waitForTimeout(200)
 
-    // Critical regression gate: the fix must turn the visual marquee
-    // highlight into a REAL editor-owned selection. Previously, single-
-    // block drags left the editor blurred and the window selection
-    // empty → Backspace/Cmd+C/Cmd+A did nothing (inert state).
-    const selectionState = await page.evaluate(() => {
-      const sel = window.getSelection()
-      const active = document.activeElement
-      const isEditorFocused =
-        active instanceof HTMLElement && active.closest('[contenteditable="true"]') !== null
-      return {
-        isEditorFocused,
-        hasNonCollapsedRange: sel !== null && sel.rangeCount > 0 && !sel.isCollapsed,
-        selectedText: sel?.toString() ?? ''
-      }
-    })
+    expect(await page.locator(HIGHLIGHTED_SELECTOR).count()).toBe(1)
+    await expectNoNativeTextSelection(page)
 
-    expect(selectionState.isEditorFocused).toBe(true)
-    expect(selectionState.hasNonCollapsedRange).toBe(true)
-    expect(selectionState.selectedText).toContain('Tall heading')
+    await page.keyboard.press('Backspace')
+    await page.waitForTimeout(400)
+
+    expect(await getBlockCount(page)).toBeLessThan(startCount)
   })
 
   test('regression: non-editor panels carry data-marquee-ignore so gestures are skipped', async ({


### PR DESCRIPTION
## Summary
- keep note and journal marquee selection block-only by avoiding editor text selection when blocks are selected
- clear native text selection at marquee finalize so selected block contents are not highlighted
- cover note, journal, block-type, and delete-key marquee behavior in E2E tests

## Validation
- `pnpm --dir apps/desktop exec electron-vite build`
- `pnpm --dir apps/desktop exec eslint src/renderer/src/components/note/content-area/hooks/use-block-marquee-selection.ts`
- `pnpm --dir apps/desktop typecheck:web`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (pre-push rerun passed: 409 files passed, 1 skipped; 7396 tests passed, 1 skipped)
- targeted Playwright marquee selection checks