### PR TITLE
Add user-facing release notes workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@
 ## Type
 
 <!-- Check one -->
+
 - [ ] `feat` — new feature
 - [ ] `fix` — bug fix
 - [ ] `refactor` — restructure without behavior change
@@ -26,6 +27,7 @@
 ## Test plan
 
 <!-- How was this tested? Check all that apply -->
+
 - [ ] Unit tests added/updated
 - [ ] Integration tests added/updated
 - [ ] Manual testing (describe below)
@@ -33,6 +35,12 @@
 ## Screenshots
 
 <!-- UI changes? Drop before/after screenshots here. Delete section if N/A -->
+
+## Release notes
+
+<!-- User-facing changes should add docs/releases/unreleased/<short-name>.md -->
+
+- [ ] Added user-facing release note, or this PR is internal only
 
 ## Checklist
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,28 +1,73 @@
-name-template: '$RESOLVED_VERSION'
-tag-template: '$RESOLVED_VERSION'
+name-template: 'Memry Draft Release'
+tag-template: 'memry-draft'
+categories:
+  - title: '🚀 Features and Improvements'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '💥️ Breaking Change'
+    labels:
+      - 'change'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '⚙️️ Tests'
+    labels:
+      - 'test'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'maintenance'
+  - title: '⬆️ Dependency'
+    labels:
+      - 'dependencies'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
-no-changes-template: '- No merged pull requests in this release window.'
-categories:
-  - title: Features
-    labels:
-      - feature
-      - enhancement
-  - title: Fixes
-    labels:
-      - bug
-      - fix
-      - regression
-  - title: Maintenance
-    labels:
-      - chore
-      - dependencies
-      - maintenance
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+      - '**/*.md'
+      - 'docs/**/*'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+      - '/bugfix\/.+/'
+    title:
+      - '/fix/i'
+      - '/bug/i'
+  - label: 'enhancement'
+    branch:
+      - '/feat\/.+/'
+      - '/feature\/.+/'
+      - '/BE-[0-9]{1,4}\/.+/'
+      - '/ES-[0-9]{1,4}\/.+/'
+    body:
+      - '/BE-[0-9]{1,4}/'
+      - '/ES-[0-9]{1,4}/'
+  - label: 'test'
+    files:
+      - '**/*.test.ts'
+      - '**/*.test.tsx'
+      - '**/*.spec.ts'
+      - '**/*.spec.tsx'
+      - 'tests/**/*'
+  - label: 'dependencies'
+    files:
+      - 'package.json'
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+    branch:
+      - '/deps\/.+/'
+      - '/dependencies\/.+/'
 template: |
-  ## Changes
+  ## What's Changed
 
   $CHANGES
-
-  ## Contributors
-
-  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    name: Update draft release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,38 @@
+name: Release Notes
+
+on:
+  pull_request:
+    paths:
+      - 'docs/releases/**'
+      - 'scripts/release-notes.mjs'
+      - 'scripts/release-notes.test.mjs'
+      - '.github/workflows/release-notes.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/releases/**'
+      - 'scripts/release-notes.mjs'
+      - 'scripts/release-notes.test.mjs'
+      - '.github/workflows/release-notes.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate release-note fragments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Test release-note tooling
+        run: node --test scripts/release-notes.test.mjs
+
+      - name: Validate release-note fragments
+        run: node scripts/release-notes.mjs check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release (Stable)
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      draft_tag:
+        description: 'Draft release tag to publish. Leave blank to publish the latest Release Drafter draft.'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -18,13 +21,15 @@ concurrency:
 
 jobs:
   version:
-    name: Compute stable version
+    name: Resolve draft release
     runs-on: ubuntu-latest
     outputs:
       app_version: ${{ steps.metadata.outputs.app_version }}
       display_version: ${{ steps.metadata.outputs.display_version }}
       release_asset_version: ${{ steps.metadata.outputs.release_asset_version }}
+      release_id: ${{ steps.draft.outputs.release_id }}
       release_name: ${{ steps.metadata.outputs.release_name }}
+      release_sha: ${{ steps.commit.outputs.release_sha }}
       tag: ${{ steps.metadata.outputs.release_tag }}
       version: ${{ steps.metadata.outputs.version }}
     steps:
@@ -38,12 +43,70 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Resolve draft release
+        id: draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_DRAFT_TAG: ${{ inputs.draft_tag }}
+        run: |
+          if [ -n "$INPUT_DRAFT_TAG" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$INPUT_DRAFT_TAG" > draft-release.json
+          else
+            gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+              --jq '[.[] | select(.draft == true)] | first // empty' > draft-release.json
+          fi
+
+          if [ ! -s draft-release.json ]; then
+            echo "::error::No draft release found. Merge to main first so Release Drafter can create one."
+            exit 1
+          fi
+
+          node <<'NODE'
+          const { appendFileSync, readFileSync } = require('node:fs')
+
+          const release = JSON.parse(readFileSync('draft-release.json', 'utf8'))
+          if (!release.draft) {
+            throw new Error(`Release ${release.tag_name} is not a draft release`)
+          }
+
+          const outputs = {
+            release_id: release.id,
+            release_tag: release.tag_name,
+            target_commitish: release.target_commitish || 'main'
+          }
+
+          appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            Object.entries(outputs)
+              .map(([key, value]) => `${key}=${value}`)
+              .join('\n') + '\n'
+          )
+          NODE
+
+      - name: Resolve release commit
+        id: commit
+        run: |
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*' --tags --force
+
+          target="${{ steps.draft.outputs.target_commitish }}"
+          if git rev-parse -q --verify "${target}^{commit}" >/dev/null; then
+            release_sha="$(git rev-parse "${target}^{commit}")"
+          elif git rev-parse -q --verify "origin/${target}^{commit}" >/dev/null; then
+            release_sha="$(git rev-parse "origin/${target}^{commit}")"
+          else
+            git fetch origin "$target"
+            release_sha="$(git rev-parse FETCH_HEAD)"
+          fi
+
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+          echo "Release commit: $release_sha"
+
       - name: Resolve release metadata
         id: metadata
         run: |
           git fetch --tags --force
           git tag --list > existing-tags.txt
-          git tag --points-at HEAD > current-tags.txt
+          git tag --points-at "${{ steps.commit.outputs.release_sha }}" > current-tags.txt
 
           node scripts/desktop-release-metadata.mjs \
             --resolve \
@@ -55,22 +118,22 @@ jobs:
       - name: Create or reuse release tag
         run: |
           tag="${{ steps.metadata.outputs.release_tag }}"
-          head_sha="$(git rev-parse HEAD)"
+          release_sha="${{ steps.commit.outputs.release_sha }}"
 
           if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
             tag_sha="$(git rev-list -n 1 "$tag")"
-            if [ "$tag_sha" != "$head_sha" ]; then
-              echo "::error::Release tag $tag already exists at $tag_sha, not HEAD $head_sha"
+            if [ "$tag_sha" != "$release_sha" ]; then
+              echo "::error::Release tag $tag already exists at $tag_sha, not release commit $release_sha"
               exit 1
             fi
 
-            echo "Reusing release tag $tag at HEAD"
+            echo "Reusing release tag $tag at $release_sha"
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "$tag"
+          git tag "$tag" "$release_sha"
           git push origin "refs/tags/$tag"
 
       - name: Summary
@@ -241,6 +304,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ needs.version.outputs.tag }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -429,46 +493,73 @@ jobs:
           print(json.dumps(payload, indent=2))
           PY
 
-      - name: Generate release notes
+      - name: Generate curated release notes
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.version.outputs.release_id }}
+          RELEASE_NAME: ${{ needs.version.outputs.release_name }}
+          RELEASE_SHA: ${{ needs.version.outputs.release_sha }}
           TAG: ${{ needs.version.outputs.tag }}
         run: |
-          NOTES_FILE="release-notes/${TAG}.md"
-          if [ -f "$NOTES_FILE" ]; then
-            cat "$NOTES_FILE" > release_notes.md
-          else
-            PREV_TAG=$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags/v20* refs/tags/stable-v* | grep -vx "$TAG" | head -n 1 || echo "")
-            if [ -z "$PREV_TAG" ]; then
-              NOTES=$(git log --oneline --no-merges -20)
-            else
-              NOTES=$(git log --oneline --no-merges "${PREV_TAG}..${TAG}")
-            fi
-            {
-              echo "## What's Changed"
-              echo ""
-              echo "$NOTES" | while IFS= read -r line; do echo "- $line"; done
-            } > release_notes.md
+          git fetch --tags --force
+
+          PREV_TAG=$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags/v* refs/tags/stable-v* | grep -vx "$TAG" | head -n 1 || echo "")
+          args=(generate --tag "$TAG" --head-ref "$TAG" --output release_notes.md)
+          if [ -n "$PREV_TAG" ]; then
+            args+=(--base-ref "$PREV_TAG")
           fi
+
+          node scripts/release-notes.mjs "${args[@]}"
+
           {
             echo ""
             echo "---"
-            echo "**Stable release - published from \`main\`**"
+            echo "**Stable release**"
             echo ""
             echo "**Includes macOS (Apple Silicon and Intel), Windows x64, and Linux x64 bundles**"
             echo ""
             echo "*Built from \`$(git rev-parse --short "$TAG")\` on $(date -u +%Y-%m-%d)*"
           } >> release_notes.md
 
-      - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.version.outputs.tag }}
-          name: ${{ needs.version.outputs.release_name }}
-          body_path: release_notes.md
-          draft: false
-          prerelease: false
-          files: release-assets/*
+          node <<'NODE'
+          const { readFileSync, writeFileSync } = require('node:fs')
+
+          writeFileSync(
+            'release-notes-patch.json',
+            JSON.stringify({
+              body: readFileSync('release_notes.md', 'utf8'),
+              name: process.env.RELEASE_NAME,
+              tag_name: process.env.TAG,
+              target_commitish: process.env.RELEASE_SHA
+            })
+          )
+          NODE
+
+          gh api \
+            --method PATCH \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            --input release-notes-patch.json
+
+      - name: Upload release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.version.outputs.tag }}
+        run: |
+          gh release upload "$TAG" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.version.outputs.release_id }}
+        run: |
+          gh api \
+            --method PATCH \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            -F draft=false \
+            -F prerelease=false \
+            -F make_latest=true
 
   pages:
     name: Update release history page

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,28 @@
+# User Release Notes
+
+`CHANGELOG.md` stays technical. User-facing release notes come from fragments in
+`docs/releases/unreleased/`.
+
+Add one fragment for each user-visible PR:
+
+```md
+---
+category: improvement
+emoji: '🧱'
+title: 'Improved Editor Blocks'
+---
+
+Dragging across note and journal blocks now selects the blocks themselves.
+```
+
+Rules:
+
+- `category` must be `new`, `improvement`, `fix`, `security`, or `maintenance`.
+- `emoji` must contain exactly one emoji.
+- `title` should name the user-visible change.
+- Body must be one user-facing sentence ending with a period.
+- Avoid implementation details, commit IDs, and raw technical wording.
+
+Release Drafter creates a draft release after changes land on `main`. The manual stable release
+workflow renders fragments changed since the previous release tag into that draft body before
+publishing the actual date tag, such as `v2026-05-07` or `v2026-05-07.2`.

--- a/docs/releases/unreleased/readable-release-notes.md
+++ b/docs/releases/unreleased/readable-release-notes.md
@@ -1,0 +1,7 @@
+---
+category: new
+emoji: '📄'
+title: 'Readable Release Notes'
+---
+
+Stable releases now show curated notes written for users instead of raw commit lists.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "repair:links": "node scripts/repair-package-links.js .",
     "release:version": "node scripts/set-desktop-version.mjs",
+    "release:notes:check": "node scripts/release-notes.mjs check",
+    "release:notes:generate": "node scripts/release-notes.mjs generate",
+    "test:release-notes": "node --test scripts/release-notes.test.mjs",
     "dev": "pnpm dev:desktop",
     "dev:desktop": "node scripts/run-turbo.js run dev --filter=@memry/desktop",
     "dev:sync-server": "node scripts/run-turbo.js run dev --filter=@memry/sync-server",

--- a/scripts/desktop-release-metadata.test.mjs
+++ b/scripts/desktop-release-metadata.test.mjs
@@ -126,6 +126,7 @@ describe('desktop release metadata', () => {
   it('rejects invalid release dates and tag suffixes', () => {
     assert.throws(() => validateReleaseDate('2026.04.27'), /zero-padded/)
     assert.throws(() => validateReleaseDate('2026.2.31'), /valid/)
+    assert.throws(() => parseReleaseTag('v1.4.2'), /release tag/)
     assert.throws(() => parseReleaseTag('v2026.4.27'), /release tag/)
     assert.throws(() => parseReleaseTag('2026-04-27'), /release tag/)
     assert.throws(() => parseReleaseTag('v2026-04-27.1'), /release tag/)

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const defaultFragmentsDir = 'docs/releases/unreleased'
+const frontmatterPattern = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/
+const emojiPattern = /\p{Extended_Pictographic}/gu
+
+const categoryConfig = {
+  new: {
+    aliases: ['add', 'added', 'feature', 'new'],
+    heading: 'New Features',
+    order: 1
+  },
+  improvement: {
+    aliases: ['change', 'changed', 'improve', 'improved', 'improvement'],
+    heading: 'Improvements',
+    order: 2
+  },
+  fix: {
+    aliases: ['fix', 'fixed', 'stability'],
+    heading: 'Stability and Fixes',
+    order: 3
+  },
+  security: {
+    aliases: ['security'],
+    heading: 'Security',
+    order: 4
+  },
+  maintenance: {
+    aliases: ['build', 'chore', 'maintenance', 'release'],
+    heading: 'Maintenance',
+    order: 5
+  }
+}
+
+export function parseReleaseNoteFragment(filePath, text) {
+  const match = frontmatterPattern.exec(text)
+  if (!match) {
+    throw new Error(`${filePath}: release-note fragments must start with YAML frontmatter`)
+  }
+
+  const [, frontmatter, rawBody] = match
+  const metadata = parseFrontmatter(frontmatter, filePath)
+  const fragment = {
+    body: rawBody.trim(),
+    category: normalizeCategory(metadata.category, filePath),
+    emoji: metadata.emoji ?? '',
+    path: filePath,
+    title: metadata.title ?? ''
+  }
+
+  validateReleaseNoteFragment(fragment)
+  return fragment
+}
+
+export function validateReleaseNoteFragment(fragment) {
+  if (!fragment.path) {
+    throw new Error('release-note fragment path is required')
+  }
+
+  if (!fragment.title.trim()) {
+    throw new Error(`${fragment.path}: title is required`)
+  }
+
+  if (!fragment.body.trim()) {
+    throw new Error(`${fragment.path}: body is required`)
+  }
+
+  if (!fragment.body.trim().endsWith('.')) {
+    throw new Error(`${fragment.path}: body must be a user-facing sentence ending with a period`)
+  }
+
+  if (!fragment.emoji.trim()) {
+    throw new Error(`${fragment.path}: emoji is required`)
+  }
+
+  const emojis = [...fragment.emoji.matchAll(emojiPattern)]
+  if (
+    emojis.length !== 1 ||
+    fragment.emoji.replace(emojiPattern, '').replace(/\uFE0F/g, '') !== ''
+  ) {
+    throw new Error(`${fragment.path}: emoji must contain exactly one emoji`)
+  }
+
+  if (!categoryConfig[fragment.category]) {
+    throw new Error(`${fragment.path}: unsupported category "${fragment.category}"`)
+  }
+}
+
+export function renderReleaseNotes({ fragments, tag }) {
+  const validFragments = fragments.map((fragment) => {
+    validateReleaseNoteFragment(fragment)
+    return fragment
+  })
+
+  if (validFragments.length === 0) {
+    validFragments.push({
+      body: 'This release includes internal improvements and maintenance updates.',
+      category: 'maintenance',
+      emoji: '📦',
+      path: 'generated',
+      title: 'Maintenance Release'
+    })
+  }
+
+  const sections = Object.entries(categoryConfig)
+    .map(([category, config]) => ({
+      category,
+      fragments: validFragments.filter((fragment) => fragment.category === category),
+      heading: config.heading,
+      order: config.order
+    }))
+    .filter((section) => section.fragments.length > 0)
+    .sort((left, right) => left.order - right.order)
+
+  const lines = [`# Memry ${tag}`, '']
+
+  for (const section of sections) {
+    lines.push(`## ${section.heading}`, '')
+
+    for (const fragment of section.fragments) {
+      lines.push(`${fragment.emoji} **${fragment.title}** — ${fragment.body}`)
+    }
+
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+function parseFrontmatter(frontmatter, filePath) {
+  const metadata = {}
+
+  for (const line of frontmatter.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) {
+      continue
+    }
+
+    const separatorIndex = trimmed.indexOf(':')
+    if (separatorIndex === -1) {
+      throw new Error(`${filePath}: invalid frontmatter line "${trimmed}"`)
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim()
+    const value = trimmed.slice(separatorIndex + 1).trim()
+    metadata[key] = stripYamlStringQuotes(value)
+  }
+
+  return metadata
+}
+
+function stripYamlStringQuotes(value) {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1)
+  }
+
+  return value
+}
+
+function normalizeCategory(category, filePath) {
+  const normalized = category?.trim().toLowerCase()
+  if (!normalized) {
+    throw new Error(`${filePath}: category is required`)
+  }
+
+  for (const [key, config] of Object.entries(categoryConfig)) {
+    if (config.aliases.includes(normalized)) {
+      return key
+    }
+  }
+
+  throw new Error(`${filePath}: unsupported category "${category}"`)
+}
+
+function readFragment(filePath) {
+  return parseReleaseNoteFragment(filePath, readFileSync(filePath, 'utf8'))
+}
+
+function listMarkdownFiles(dir) {
+  if (!existsSync(dir)) {
+    return []
+  }
+
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => path.join(dir, entry.name))
+    .sort()
+}
+
+function listChangedFragmentFiles({ baseRef, fragmentsDir, headRef }) {
+  if (!baseRef) {
+    return listMarkdownFiles(fragmentsDir)
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${baseRef}..${headRef}`], {
+    encoding: 'utf8'
+  })
+
+  return output
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(
+      (file) => file.startsWith(`${fragmentsDir}/`) && file.endsWith('.md') && existsSync(file)
+    )
+    .sort()
+}
+
+function parseArgs(argv) {
+  const options = {
+    fragmentsDir: defaultFragmentsDir,
+    headRef: 'HEAD'
+  }
+
+  const [command, ...rest] = argv
+  options.command = command
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index]
+
+    if (arg === '--base-ref') {
+      options.baseRef = readRequiredValue(rest, index, arg)
+      index += 1
+      continue
+    }
+
+    if (arg === '--fragments-dir') {
+      options.fragmentsDir = readRequiredValue(rest, index, arg)
+      index += 1
+      continue
+    }
+
+    if (arg === '--head-ref') {
+      options.headRef = readRequiredValue(rest, index, arg)
+      index += 1
+      continue
+    }
+
+    if (arg === '--output') {
+      options.output = readRequiredValue(rest, index, arg)
+      index += 1
+      continue
+    }
+
+    if (arg === '--tag') {
+      options.tag = readRequiredValue(rest, index, arg)
+      index += 1
+      continue
+    }
+
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  return options
+}
+
+function readRequiredValue(argv, index, arg) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${arg} requires a value`)
+  }
+
+  return value
+}
+
+function runCli() {
+  const options = parseArgs(process.argv.slice(2))
+
+  if (options.command === 'check') {
+    const files = listMarkdownFiles(options.fragmentsDir)
+    files.forEach(readFragment)
+    console.log(`Checked ${files.length} release-note fragment(s).`)
+    return
+  }
+
+  if (options.command === 'generate') {
+    if (!options.tag) {
+      throw new Error('generate requires --tag')
+    }
+
+    const files = listChangedFragmentFiles(options)
+    const fragments = files.map(readFragment)
+    const output = renderReleaseNotes({ fragments, tag: options.tag })
+
+    if (options.output) {
+      writeFileSync(options.output, output, 'utf8')
+    } else {
+      process.stdout.write(output)
+    }
+    return
+  }
+
+  throw new Error('Usage: release-notes.mjs check|generate [--tag <tag>] [--output <file>]')
+}
+
+if (process.argv[1]?.endsWith('/release-notes.mjs')) {
+  runCli()
+}

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  parseReleaseNoteFragment,
+  renderReleaseNotes,
+  validateReleaseNoteFragment
+} from './release-notes.mjs'
+
+describe('release notes', () => {
+  it('parses a release-note fragment with emoji-backed frontmatter', () => {
+    const fragment = parseReleaseNoteFragment(
+      'docs/releases/unreleased/readable-release-notes.md',
+      `---
+category: new
+emoji: "📄"
+title: "Readable Release Notes"
+---
+
+View stable releases through curated notes written for users instead of raw commit lists.
+`
+    )
+
+    assert.deepEqual(fragment, {
+      body: 'View stable releases through curated notes written for users instead of raw commit lists.',
+      category: 'new',
+      emoji: '📄',
+      path: 'docs/releases/unreleased/readable-release-notes.md',
+      title: 'Readable Release Notes'
+    })
+  })
+
+  it('rejects fragments without exactly one emoji and a user-facing sentence', () => {
+    assert.throws(
+      () =>
+        validateReleaseNoteFragment({
+          body: 'Fixed IPC crash.',
+          category: 'fix',
+          emoji: '',
+          path: 'docs/releases/unreleased/fix.md',
+          title: 'IPC fix'
+        }),
+      /emoji/
+    )
+
+    assert.throws(
+      () =>
+        validateReleaseNoteFragment({
+          body: 'Fixed IPC crash.',
+          category: 'fix',
+          emoji: '🛠️🧱',
+          path: 'docs/releases/unreleased/fix.md',
+          title: 'IPC fix'
+        }),
+      /exactly one emoji/
+    )
+
+    assert.throws(
+      () =>
+        validateReleaseNoteFragment({
+          body: '',
+          category: 'fix',
+          emoji: '🛠️',
+          path: 'docs/releases/unreleased/fix.md',
+          title: 'IPC fix'
+        }),
+      /body/
+    )
+  })
+
+  it('renders categorized release notes with one emoji per row', () => {
+    const output = renderReleaseNotes({
+      fragments: [
+        {
+          body: 'View stable releases through curated notes written for users instead of raw commit lists.',
+          category: 'new',
+          emoji: '📄',
+          path: 'docs/releases/unreleased/readable-release-notes.md',
+          title: 'Readable Release Notes'
+        },
+        {
+          body: 'Dragging across note and journal blocks now selects the blocks themselves.',
+          category: 'improvement',
+          emoji: '🧱',
+          path: 'docs/releases/unreleased/block-selection.md',
+          title: 'Improved Editor Blocks'
+        },
+        {
+          body: 'Calendar snooze chips now recover more gracefully after quick actions.',
+          category: 'fix',
+          emoji: '🛠️',
+          path: 'docs/releases/unreleased/calendar-snooze.md',
+          title: 'More Reliable Calendar Snoozes'
+        }
+      ],
+      tag: 'v2026-05-07'
+    })
+
+    assert.equal(
+      output,
+      `# Memry v2026-05-07
+
+## New Features
+
+📄 **Readable Release Notes** — View stable releases through curated notes written for users instead of raw commit lists.
+
+## Improvements
+
+🧱 **Improved Editor Blocks** — Dragging across note and journal blocks now selects the blocks themselves.
+
+## Stability and Fixes
+
+🛠️ **More Reliable Calendar Snoozes** — Calendar snooze chips now recover more gracefully after quick actions.
+`
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add PR-authored user-facing release note fragments under `docs/releases/unreleased`
- add release note validation/generation scripts with emoji-prefixed rows
- wire release-note checks into PR validation and stable release publishing
- keep stable release tags date-based (`vYYYY-MM-DD`, then `.2`, `.3`, etc. for same-day releases) and reject semver-style release tags

## Checks
- `node --test scripts/desktop-release-metadata.test.mjs scripts/release-notes.test.mjs`
- `pnpm release:notes:check`
- `pnpm release:notes:generate --tag v2026-05-07`
- `node scripts/desktop-release-metadata.mjs --from-tag --tag v2026-05-07`
- `node scripts/desktop-release-metadata.mjs --resolve --date 2026-05-07 --existing-tag v2026-05-07`
- `node scripts/desktop-release-metadata.mjs --from-tag --tag v1.4.2` (expected failure)
- Ruby YAML parse for release workflows/config
- pre-push hook: links repair, contracts, architecture, package typecheck, desktop lint, IPC check, desktop typecheck, desktop tests, sync-server typecheck, sync-server tests