### PR TITLE
ci: scope desktop workflow + skip e2e on PRs unless tests change

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -2,7 +2,23 @@ name: Desktop CI
 
 on:
   pull_request:
+    paths:
+      - 'apps/desktop/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - '.github/workflows/desktop-ci.yml'
   push:
+    paths:
+      - 'apps/desktop/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - '.github/workflows/desktop-ci.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -199,6 +199,7 @@ jobs:
 
   e2e-full:
     name: Electron E2E full (${{ matrix.shard }})
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -265,6 +266,7 @@ jobs:
 
   package-smoke:
     name: Packaged runtime smoke
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: macos-latest
     timeout-minutes: 45
     env:

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -138,8 +138,39 @@ jobs:
           name: desktop
           fail_ci_if_error: true
 
-  e2e-smoke:
-    name: Electron E2E smoke
+  detect-e2e:
+    name: Detect changed E2E tests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      files: ${{ steps.changed.outputs.files }}
+      has_changes: ${{ steps.changed.outputs.has_changes }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Find changed E2E test files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only --diff-filter=AM "$BASE_SHA"...HEAD -- 'apps/desktop/tests/e2e/*.e2e.ts' | sed 's|^apps/desktop/||' | tr '\n' ' ')
+          echo "Changed e2e files: $changed"
+          echo "files=$changed" >> "$GITHUB_OUTPUT"
+          if [ -n "$changed" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  e2e-changed:
+    name: Electron E2E (changed tests)
+    needs: detect-e2e
+    if: needs.detect-e2e.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 35
 
@@ -177,23 +208,23 @@ jobs:
           bash apps/desktop/scripts/ensure-native.sh electron
           pnpm --filter @memry/desktop exec electron-vite build
 
-      - name: Run Electron smoke tests
+      - name: Run changed E2E tests
+        env:
+          E2E_FILES: ${{ needs.detect-e2e.outputs.files }}
         run: |
           dbus-run-session -- bash -c '
             eval "$(printf "\n" | gnome-keyring-daemon --unlock)"
             eval "$(printf "\n" | gnome-keyring-daemon --start --components=secrets)"
             xvfb-run -a pnpm --filter @memry/desktop exec playwright test \
               --config config/playwright.config.ts \
-              tests/e2e/vault.e2e.ts \
-              tests/e2e/notes.e2e.ts \
-              tests/e2e/tasks.e2e.ts
+              '"$E2E_FILES"'
           '
 
       - name: Upload E2E failure artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-smoke-results
+          name: e2e-changed-results
           path: apps/desktop/test-results/
           if-no-files-found: ignore
 

--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -11,28 +11,20 @@ export default defineConfig({
     siteTitle: 'Memry Docs',
     nav: [
       { text: 'Guide', link: '/guide/install' },
-      { text: 'Features', link: '/features' },
+      { text: 'User Guide', link: '/user-guide/notes/editing' },
+      { text: 'Architecture', link: '/architecture' },
       { text: 'Contribute', link: '/contributing' },
       { text: 'GitHub', link: 'https://github.com/memrynote/memry' }
     ],
-    sidebar: [
-      {
-        text: 'Start Here',
-        items: [
-          { text: 'Overview', link: '/' },
-          { text: 'Install Memry', link: '/guide/install' },
-          { text: 'Features', link: '/features' }
-        ]
-      },
-      {
-        text: 'Project',
-        items: [
-          { text: 'Architecture', link: '/architecture' },
-          { text: 'Contributing', link: '/contributing' },
-          { text: 'Roadmap', link: '/roadmap' }
-        ]
-      }
-    ],
+    sidebar: {
+      '/guide/': sidebarStartHere(),
+      '/user-guide/': sidebarUserGuide(),
+      '/architecture': sidebarArchitecture(),
+      '/architecture/': sidebarArchitecture(),
+      '/contributing': sidebarContribute(),
+      '/contribute/': sidebarContribute(),
+      '/': sidebarStartHere()
+    },
     search: {
       provider: 'local'
     },
@@ -50,3 +42,142 @@ export default defineConfig({
     }
   }
 })
+
+function sidebarStartHere() {
+  return [
+    {
+      text: 'Start Here',
+      items: [
+        { text: 'Overview', link: '/' },
+        { text: 'Install Memry', link: '/guide/install' },
+        { text: 'First Run & Vault Setup', link: '/guide/first-run' },
+        { text: 'A Tour of Memry', link: '/guide/tour' }
+      ]
+    },
+    {
+      text: 'Project',
+      items: [
+        { text: 'Features Overview', link: '/features' },
+        { text: 'Architecture', link: '/architecture' },
+        { text: 'Contributing', link: '/contributing' },
+        { text: 'Roadmap', link: '/roadmap' }
+      ]
+    }
+  ]
+}
+
+function sidebarUserGuide() {
+  return [
+    {
+      text: 'Notes',
+      collapsed: false,
+      items: [
+        { text: 'Creating & Editing', link: '/user-guide/notes/editing' },
+        { text: 'Wiki Links & Backlinks', link: '/user-guide/notes/wiki-links' },
+        { text: 'Properties & Tags', link: '/user-guide/notes/properties-tags' },
+        { text: 'Attachments', link: '/user-guide/notes/attachments' },
+        { text: 'Bookmarks & Reminders', link: '/user-guide/notes/bookmarks-reminders' },
+        { text: 'Find in Page', link: '/user-guide/notes/find-in-page' },
+        { text: 'Version History', link: '/user-guide/notes/version-history' }
+      ]
+    },
+    {
+      text: 'Journal',
+      collapsed: true,
+      items: [
+        { text: 'Daily Entries', link: '/user-guide/journal/daily-entries' },
+        { text: 'Calendar Navigation', link: '/user-guide/journal/calendar-navigation' },
+        { text: 'Templates & Settings', link: '/user-guide/journal/templates-settings' }
+      ]
+    },
+    {
+      text: 'Tasks',
+      collapsed: true,
+      items: [
+        { text: 'Capturing Tasks', link: '/user-guide/tasks/capturing' },
+        { text: 'List vs Kanban', link: '/user-guide/tasks/list-vs-kanban' },
+        { text: 'Filters & Sorting', link: '/user-guide/tasks/filters-sorting' },
+        { text: 'Subtasks & Recurrence', link: '/user-guide/tasks/subtasks-recurrence' },
+        { text: 'Bulk Actions', link: '/user-guide/tasks/bulk-actions' },
+        { text: 'Drag & Drop', link: '/user-guide/tasks/drag-and-drop' }
+      ]
+    },
+    {
+      text: 'Workspace',
+      collapsed: true,
+      items: [
+        { text: 'Projects', link: '/user-guide/projects' },
+        { text: 'Inbox', link: '/user-guide/inbox' },
+        { text: 'Calendar', link: '/user-guide/calendar' },
+        { text: 'Search & Command Palette', link: '/user-guide/search' },
+        { text: 'Templates', link: '/user-guide/templates' },
+        { text: 'Tabs & Split View', link: '/user-guide/tabs-split-view' },
+        { text: 'Folder View', link: '/user-guide/folder-view' },
+        { text: 'Day Panel', link: '/user-guide/day-panel' },
+        { text: 'Snooze & Reminders', link: '/user-guide/snooze-reminders' }
+      ]
+    },
+    {
+      text: 'AI Features',
+      collapsed: true,
+      items: [
+        { text: 'Inline AI Menu', link: '/user-guide/ai/inline-menu' },
+        { text: 'Embeddings & Semantic Search', link: '/user-guide/ai/embeddings-search' },
+        { text: 'Voice Transcription', link: '/user-guide/ai/voice-transcription' },
+        { text: 'Provider Setup', link: '/user-guide/ai/provider-setup' }
+      ]
+    },
+    {
+      text: 'Sync & Devices',
+      collapsed: true,
+      items: [
+        { text: 'How Sync Works', link: '/user-guide/sync/how-sync-works' },
+        { text: 'Linking Another Device', link: '/user-guide/sync/linking-devices' },
+        { text: 'Recovery Key & Rotation', link: '/user-guide/sync/recovery-rotation' },
+        { text: 'Conflict & Health', link: '/user-guide/sync/conflict-health' }
+      ]
+    },
+    {
+      text: 'Reference',
+      collapsed: true,
+      items: [
+        { text: 'Settings Reference', link: '/user-guide/settings' },
+        { text: 'Keyboard Shortcuts', link: '/user-guide/keyboard-shortcuts' }
+      ]
+    }
+  ]
+}
+
+function sidebarArchitecture() {
+  return [
+    {
+      text: 'Architecture',
+      items: [
+        { text: 'Overview', link: '/architecture' },
+        { text: 'Monorepo Layout', link: '/architecture/monorepo' },
+        { text: 'Local Storage (Dual SQLite)', link: '/architecture/local-storage' },
+        { text: 'IPC Boundary', link: '/architecture/ipc' },
+        { text: 'CRDT & Notes Sync', link: '/architecture/crdt' },
+        { text: 'Sync Protocol', link: '/architecture/sync-protocol' },
+        { text: 'Cryptography', link: '/architecture/cryptography' },
+        { text: 'Sync Item Handlers', link: '/architecture/sync-handlers' },
+        { text: 'Observability & Telemetry', link: '/architecture/observability' }
+      ]
+    }
+  ]
+}
+
+function sidebarContribute() {
+  return [
+    {
+      text: 'Contribute',
+      items: [
+        { text: 'Setting Up', link: '/contributing' },
+        { text: 'Repo Workflow', link: '/contribute/workflow' },
+        { text: 'Testing', link: '/contribute/testing' },
+        { text: 'Common Gotchas', link: '/contribute/gotchas' },
+        { text: 'Releasing', link: '/contribute/releasing' }
+      ]
+    }
+  ]
+}

--- a/apps/docs/src/architecture.md
+++ b/apps/docs/src/architecture.md
@@ -1,36 +1,58 @@
 # Architecture
 
-Memry is a pnpm monorepo with a desktop app, sync server, and shared TypeScript packages.
+Memry is a pnpm + Turborepo monorepo with an Electron desktop app, a Cloudflare Workers sync server, and shared TypeScript packages.
 
-## Main Packages
+## Top-Level Map
 
-| Path                 | Purpose                                                         |
-| -------------------- | --------------------------------------------------------------- |
-| `apps/desktop`       | Electron, React, Vite, main process, renderer, and preload code |
-| `apps/sync-server`   | Cloudflare Workers sync API backed by D1 and R2                 |
-| `packages/contracts` | Shared IPC and API contract definitions                         |
-| `packages/db-schema` | Drizzle schemas for local and index databases                   |
-| `packages/shared`    | Shared utilities used across packages                           |
+| Path                 | Purpose                                                   |
+| -------------------- | --------------------------------------------------------- |
+| `apps/desktop`       | Electron 39 + React 19 + Vite. Main / renderer / preload. |
+| `apps/sync-server`   | Cloudflare Workers + Hono. D1 + R2.                       |
+| `apps/docs`          | This documentation site (VitePress).                      |
+| `packages/contracts` | IPC and API contracts (Zod).                              |
+| `packages/db-schema` | Drizzle ORM schemas.                                      |
+| `packages/shared`    | Shared utilities.                                         |
 
-## Privacy Model
+## Trust Boundary
 
-Memry treats the local device as the trusted boundary. Workspace data is encrypted before
-sync and decrypted only on user devices. The sync server coordinates delivery and storage,
-but it is not designed to read plaintext note content.
+The user's device is trusted. The server is not. Everything that leaves the device is encrypted; the server stores ciphertext and serves it back.
 
-## Local Data
+## Local Storage
 
-The desktop app uses local SQLite storage for workspace data. This keeps core app flows
-available offline and makes sync an enhancement rather than a hard dependency.
+Two SQLite databases via better-sqlite3 + Drizzle:
 
-## Sync Data
+- **Data DB** — notes, journals, tasks, projects, inbox, templates, settings.
+- **Index DB** — full-text search, link graph, embedding vectors.
 
-The sync system stores metadata in Cloudflare D1 and encrypted payloads in R2. Large sync
-items avoid D1 row-size limits by keeping encrypted payload data in object storage.
+→ [Local Storage (Dual SQLite)](/architecture/local-storage)
+
+## Sync
+
+- **D1**: encrypted sync item metadata (vector clocks, blob keys, hashes).
+- **R2**: encrypted payload blobs (avoids the 1 MB D1 row limit).
+- **Hybrid sync**: bulk snapshots through `SyncItemHandler` plus incremental Yjs updates through `/sync/crdt/updates`.
+
+→ [Sync Protocol](/architecture/sync-protocol) · [CRDT & Notes Sync](/architecture/crdt) · [Sync Item Handlers](/architecture/sync-handlers)
+
+## Cryptography
+
+XChaCha20-Poly1305 + Ed25519 + Argon2id, all via libsodium. Per-device sealing of the vault key. Constant-time comparisons.
+
+→ [Cryptography](/architecture/cryptography)
+
+## IPC Boundary
+
+Shared Zod contracts in `packages/contracts`. Validated at typecheck time via `pnpm ipc:check`.
+
+→ [IPC Boundary](/architecture/ipc)
+
+## Observability
+
+Local logging via electron-log; opt-in telemetry that ships only enums and surface names.
+
+→ [Observability & Telemetry](/architecture/observability)
 
 ## Verification Gates
-
-Common repo checks:
 
 ```bash
 pnpm lint

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -1,0 +1,26 @@
+# CRDT & Notes Sync
+
+Notes and journal entries use Yjs CRDTs so concurrent edits merge cleanly across devices.
+
+## Source of Truth
+
+The Y.Doc is canonical. Markdown export is a derived, lossy representation.
+
+## Where Y.Docs Live
+
+The main process owns Y.Doc instances and persists them via y-leveldb. The renderer talks to them through an IPC provider (`yjs-ipc-provider.ts`).
+
+## IPC Loop Prevention
+
+- Updates are tagged with `sourceWindowId`.
+- Local, IPC-originated, and network updates are distinguished by Y.Doc origin parameters.
+
+## Hybrid Sync
+
+- Bulk state moves through the SyncItemHandler pipeline (encrypted snapshots).
+- Incremental updates flow through `/sync/crdt/updates` with binary `Uint8Array` payloads.
+- A dedicated `CrdtUpdateQueue` orders updates per `noteId` and respects sequence ordering.
+
+## Sign-Out / Sign-In
+
+Pull from the server first; only then run `seedExistingCrdtDocs` (fire-and-forget) to fill gaps for orphaned notes. CRDT snapshots are pushed pre-batch so other devices receive correct state.

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -1,0 +1,35 @@
+# Cryptography
+
+Memry's threat model treats the device as the trusted boundary. The server stores ciphertext only.
+
+## Primitives (libsodium)
+
+- **Symmetric**: XChaCha20-Poly1305 (AEAD) with random 24-byte nonces.
+- **Signing**: Ed25519 for device keys.
+- **Key derivation**: Argon2id from passphrase + per-vault salt.
+
+## Key Hierarchy
+
+1. Passphrase + Argon2id → wrapping key
+2. Wrapping key → vault key (decrypted locally)
+3. Vault key → per-payload data keys
+
+## Per-Device Keys
+
+Each device generates an Ed25519 keypair on link. The vault key is sealed for each device's public key so revoking a device cuts off its access without rotating the vault.
+
+## Nonces
+
+All XChaCha20 operations use `sodium.randombytes_buf(24)` via a dedicated nonce utility. Nonces are stored alongside ciphertext.
+
+## Constant-Time Comparison
+
+All authentication code paths use `sodium.memcmp` to avoid timing leaks.
+
+## Tombstone Signing
+
+`deleted_at` is included in the signed payload so a hostile server cannot forge deletions.
+
+## Argon2id Parameters
+
+Spec calls for parallelism = 4; libsodium pins 1. Memry documents 1 as canonical.

--- a/apps/docs/src/architecture/ipc.md
+++ b/apps/docs/src/architecture/ipc.md
@@ -1,0 +1,27 @@
+# IPC Boundary
+
+Renderer ↔ main process communication is type-checked end-to-end via shared contracts.
+
+## Shape
+
+- Contracts live in `packages/contracts` and are Zod-typed.
+- The preload script exposes a typed `window.api` surface.
+- Main-side handlers register against the same contract types.
+
+## Invoke Map
+
+`pnpm ipc:generate` regenerates the invoke map from contracts. `pnpm ipc:check` validates the boundary at typecheck time.
+
+## When to Run These
+
+- After adding or renaming an IPC channel
+- After changing a request / response Zod schema
+- Before opening a PR that touches the renderer / main boundary
+
+## Error Propagation
+
+Renderer-side errors from IPC use `extractErrorMessage(err, fallback)` from `@/lib/ipc-error` to strip Electron noise before display.
+
+## Logging
+
+Both sides use `createLogger(scope)` from electron-log; never `console.*`.

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -1,0 +1,29 @@
+# Local Storage (Dual SQLite)
+
+Memry stores all workspace data locally in two SQLite databases via better-sqlite3 + Drizzle ORM.
+
+## Data Database
+
+The primary, user-visible store. Holds notes, journals, tasks, projects, inbox items, templates, settings, and metadata.
+
+## Index Database
+
+A derived store optimized for fast lookups: full-text search, tag indexes, link graph, and (when enabled) embedding vectors.
+
+## Why Split?
+
+- **Crash isolation**: rebuilding the index never threatens user data.
+- **Reset cost**: the index can be dropped and rebuilt without sync churn.
+- **Performance**: heavy read indexes don't compete with write paths in the data DB.
+
+## Schemas
+
+Drizzle schemas live in `packages/db-schema`. Migrations are hand-written from `0020` onward — see [Common Gotchas](/contribute/gotchas).
+
+## Migrations
+
+```bash
+pnpm db:generate  # propose migration SQL from schema diff
+pnpm db:push      # apply pending migrations
+pnpm db:studio    # open Drizzle Studio
+```

--- a/apps/docs/src/architecture/monorepo.md
+++ b/apps/docs/src/architecture/monorepo.md
@@ -1,0 +1,35 @@
+# Monorepo Layout
+
+Memry is a pnpm + Turborepo monorepo.
+
+## Apps
+
+| Path               | Purpose                                             |
+| ------------------ | --------------------------------------------------- |
+| `apps/desktop`     | Electron + React + Vite. Main / renderer / preload. |
+| `apps/sync-server` | Cloudflare Workers + Hono. D1 + R2.                 |
+| `apps/docs`        | This documentation site (VitePress).                |
+
+## Packages
+
+| Path                 | Purpose                                               |
+| -------------------- | ----------------------------------------------------- |
+| `packages/contracts` | Shared IPC and API contract definitions (Zod).        |
+| `packages/db-schema` | Drizzle ORM schemas for the data and index databases. |
+| `packages/shared`    | Minimal shared utilities.                             |
+
+## Tooling
+
+- **Package manager**: pnpm 10.30+
+- **Task runner**: Turborepo
+- **Node**: pinned via `.nvmrc`
+
+## Cross-Cutting Scripts
+
+```bash
+pnpm dev          # desktop dev
+pnpm test         # vitest across packages
+pnpm lint         # ESLint flat config
+pnpm typecheck    # TypeScript across packages
+pnpm ipc:check    # validate IPC contract types
+```

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -1,0 +1,34 @@
+# Observability & Telemetry
+
+Local logs and an optional, opt-in telemetry stream.
+
+## Logging
+
+- Use `createLogger(scope)` from electron-log everywhere — never `console.*`.
+- Logs land in the OS-standard log directory, rotated by electron-log.
+- Renderer and main process logs are separate files.
+
+## Telemetry
+
+- Opt-in via [Settings → General](/user-guide/settings#general).
+- Only enums and event names ship — never note titles, file paths, or note IDs.
+- Surfaces are tracked at tab-type level (`notes`, `journal`, `tasks`, `inbox`, `calendar`, `search`, `graph`).
+
+## Surfaces
+
+`TelemetrySurface` in `packages/contracts/telemetry-api` lists every legal surface value.
+
+## Tracking Pattern
+
+```ts
+void trackTelemetry('page_viewed', { surface, action: 'viewed' })
+```
+
+Use `void` so the call is fire-and-forget and can never block UI.
+
+## What Is Never Sent
+
+- Note content
+- Note titles
+- Identifiers (note IDs, task IDs, project IDs)
+- Search queries

--- a/apps/docs/src/architecture/sync-handlers.md
+++ b/apps/docs/src/architecture/sync-handlers.md
@@ -1,0 +1,32 @@
+# Sync Item Handlers
+
+Per-type handlers encapsulate how each sync item is encoded, decoded, and merged.
+
+## Pattern
+
+A registry maps each `type` (note, journal, task, project, inbox, template, …) to a handler implementing a shared interface.
+
+```ts
+const handler = getHandler(item.type)
+handler.applyUpsert(...)
+handler.applyDelete(...)
+```
+
+## Files
+
+Handlers live in `apps/desktop/src/main/sync/item-handlers/`.
+
+## Conflict Resolution
+
+Each handler uses the shared `resolveClockConflict()` helper for vector clock compare and merge.
+
+## Atomicity
+
+All `applyUpsert` paths run inside `db.transaction()` so partial writes can't corrupt the data DB.
+
+## Adding a New Type
+
+1. Define a new handler implementing the interface.
+2. Register it in the handler registry.
+3. Add migration for any new columns or tables.
+4. Update the contract types in `packages/contracts`.

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -1,0 +1,35 @@
+# Sync Protocol
+
+Encrypted payloads move between devices through a Cloudflare Workers API backed by D1 and R2.
+
+## Storage Split
+
+- **D1**: sync item metadata (id, type, vector clock, blob key, size, content hash)
+- **R2**: encrypted payload blobs (avoids the 1 MB D1 row limit)
+
+## Sync Items
+
+Each domain object syncs as a `sync_item`: an opaque encrypted blob with a doc-level vector clock.
+
+## Vector Clocks (Doc-Level)
+
+Used by the server to order changes from each device. The server never sees field contents.
+
+## Field-Level Merge (Tasks & Projects)
+
+Inside the encrypted blob, tasks and projects carry per-field vector clocks (`field_clocks`). Concurrent edits to non-overlapping fields merge without conflict; same-field edits resolve last-writer-wins by tick-sum.
+
+## Cursors
+
+`server_cursor_sequence` tracks per-device pull progress.
+
+## Tombstones
+
+Deletions include `deleted_at` inside the Ed25519-signed payload to prevent server-forged deletions.
+
+## Endpoints
+
+- `POST /sync/push` — upload new sync items
+- `POST /sync/pull` — fetch updates since cursor
+- `POST /sync/crdt/updates` — incremental Yjs updates
+- Auth, device, and key endpoints surrounding the above

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -1,0 +1,40 @@
+# Common Gotchas
+
+Issues you'll hit, and the canonical fixes.
+
+## better-sqlite3 NODE_MODULE_VERSION mismatch
+
+`ERR_DLOPEN_FAILED` means the native module was built for the wrong runtime.
+
+- **Node tests**: `pnpm rebuild better-sqlite3` (or `bash apps/desktop/scripts/ensure-native.sh node`)
+- **Electron app / E2E**: `bash apps/desktop/scripts/ensure-native.sh electron` (or `pnpm rebuild:electron`)
+
+Using the Node fix for Electron leaves `autoOpenLastVault` silently failing; the app falls through to the "Welcome to Memry" screen and E2E tests time out on `.bn-container`.
+
+## Zod v4
+
+`z.record(z.unknown())` throws in `safeParse`. Use `z.record(z.string(), z.unknown())` instead.
+
+## Drizzle nullable JSON columns
+
+Insert `null`, not `undefined`, in `.values()`.
+
+## Migrations Are Hand-Written Since 0020
+
+`pnpm db:generate` proposes unrelated renames because meta snapshots stop at 0020. Hand-write the SQL and journal entry instead.
+
+## Submit-Buttons Disabling Mid-Click
+
+If `onClick` calls a handler that synchronously sets `disabled={isSubmitting}`, the browser suppresses the click between `pointerdown` and `click`. Fire submit from `onPointerDown` and keep `onClick` as a keyboard fallback. See `calendar-quick-create-dialog.tsx`.
+
+## Lazy URL Resolution
+
+http-client resolves URLs per-call (not at import time) to avoid throws in tests.
+
+## Pre-existing Type Errors
+
+`websocket.test.ts`, `folders.test.ts`, and a couple of others have known typecheck errors unrelated to source. Ignore them when running `pnpm typecheck`.
+
+## Virtualized UI Tests
+
+`@tanstack/react-virtual` + jsdom renders zero items. Cover virtualized calendar / week / list UIs at the Playwright E2E layer only.

--- a/apps/docs/src/contribute/releasing.md
+++ b/apps/docs/src/contribute/releasing.md
@@ -1,0 +1,31 @@
+# Releasing
+
+How packaged builds and changelogs are produced.
+
+## Versioning
+
+The repo follows semver. Versions live in `package.json` and propagate to packaged installers.
+
+## CHANGELOG
+
+`CHANGELOG.md` at the repo root is the source of truth for human-readable release notes. Update during `/merge` (the workflow enforces it).
+
+## Release Drafter
+
+Release Drafter aggregates merged PRs into a draft release based on PR labels. Branch labels are narrowed to release-relevant changes.
+
+## Packaged Installers
+
+Electron installers are produced via electron-vite + electron-builder. Targets: macOS (.dmg), Windows (.exe), Linux (.AppImage / .deb).
+
+## Sync Server Deploy
+
+The Cloudflare Workers app is deployed via `wrangler` on its own cadence. Migrations to D1 are applied separately from Worker code.
+
+## Pre-Release Checklist
+
+- [ ] All gates green: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm test:e2e`
+- [ ] CHANGELOG entry merged
+- [ ] Version bumped
+- [ ] Sync server compatible with the desktop release
+- [ ] Migrations safe under concurrent writes

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -1,0 +1,46 @@
+# Testing
+
+Vitest for unit / integration, Playwright for E2E (Electron).
+
+## Unit + Integration (Vitest)
+
+```bash
+pnpm test                 # all packages via Turborepo
+pnpm --filter @memry/desktop test
+```
+
+## E2E (Playwright)
+
+```bash
+pnpm test:e2e
+```
+
+E2E tests run against the **built bundle** (`out/main/index.js`), not source. Rebuild after edits:
+
+```bash
+npx electron-vite build
+pnpm test:e2e
+```
+
+## IPC Contract Check
+
+After editing renderer / main contracts:
+
+```bash
+pnpm ipc:check
+pnpm ipc:generate    # regenerate invoke map
+```
+
+## Focused Typecheck
+
+```bash
+pnpm typecheck:node     # main process
+pnpm typecheck:web      # renderer
+```
+
+These skip the flaky `ipc:check` pre-hook and known pre-existing errors.
+
+## Coverage Targets
+
+- Pre-production: pragmatic coverage, with strong tests around sync, CRDT, and crypto.
+- Test files with known type errors (e.g. `websocket.test.ts`, `folders.test.ts`) are tracked and excluded from gating.

--- a/apps/docs/src/contribute/workflow.md
+++ b/apps/docs/src/contribute/workflow.md
@@ -1,0 +1,40 @@
+# Repo Workflow
+
+Branches, commits, atomic changes, and shipping.
+
+## Branches
+
+Branch off `main`:
+
+```bash
+git checkout -b feat/your-feature main
+```
+
+## Commits
+
+- Conventional Commits format (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:`, `perf:`).
+- One logical change per commit.
+- Use the atomic-commit skill (`/atomic-commit`) when staging multi-purpose diffs.
+
+## Pull Requests
+
+- Title under 70 characters.
+- Body covers Summary and Test plan as a bulleted checklist.
+- Run focused checks before pushing.
+
+## Pre-Land Checks
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm ipc:check   # if you touched the renderer/main boundary
+```
+
+## Shipping
+
+`/ship` and `/merge` skills wrap the standard PR + CI + merge flow. They generate changelog entries and atomic commits as needed.
+
+## CHANGELOG
+
+Always update root `CHANGELOG.md` during a merge. Release Drafter handles ongoing aggregation per label.

--- a/apps/docs/src/contributing.md
+++ b/apps/docs/src/contributing.md
@@ -2,7 +2,7 @@
 
 Thanks for helping build Memry. Keep changes small, focused, and easy to review.
 
-## Start
+## Setup
 
 ```bash
 git clone https://github.com/memrynote/memry.git
@@ -16,42 +16,43 @@ pnpm dev
 
 - Check [open issues](https://github.com/memrynote/memry/issues)
 - Comment before starting larger work
-- Open an issue first when the behavior or product direction is unclear
+- Open an issue first when behavior or product direction is unclear
 
-## Branches
+## Branch & Commit
 
-Create a branch from `main` with a name that describes the work.
+Create a branch from `main`:
 
 ```bash
 git checkout -b feat/your-feature main
 ```
+
+Commit with Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:`, `perf:`).
 
 ## Code Style
 
 - TypeScript strict mode
 - Small, direct changes
 - Tests for new behavior and regressions
-- Renderer and main process boundaries through shared contracts
-- User-facing renderer errors through the existing IPC error helpers
+- Renderer ↔ main goes through `packages/contracts`
+- User-facing renderer errors via `extractErrorMessage(err, fallback)` from `@/lib/ipc-error`
+- Logging via `createLogger('Scope')` from electron-log — never `console.*`
 
-## Checks
-
-Run the checks that match your change before opening a pull request.
+## Pre-PR Checks
 
 ```bash
 pnpm lint
 pnpm typecheck
 pnpm test
+pnpm ipc:check     # if you touched the renderer/main boundary
 ```
 
-Run the IPC contract check after editing renderer/main boundary types.
+## Deeper Reading
 
-```bash
-pnpm ipc:check
-```
+- [Repo Workflow](/contribute/workflow)
+- [Testing](/contribute/testing)
+- [Common Gotchas](/contribute/gotchas)
+- [Releasing](/contribute/releasing)
 
 ## Security Issues
 
-Do not open public issues for vulnerabilities. Follow the
-[security policy](https://github.com/memrynote/memry/blob/main/SECURITY.md) and report
-privately.
+Do not open public issues for vulnerabilities. Follow the [security policy](https://github.com/memrynote/memry/blob/main/SECURITY.md) and report privately.

--- a/apps/docs/src/features.md
+++ b/apps/docs/src/features.md
@@ -1,33 +1,64 @@
-# Features
+# Features Overview
 
-Memry combines writing, reflection, and planning in one private workspace.
+A high-level map of what Memry does. Each section links to dedicated pages in the [User Guide](/user-guide/notes/editing).
 
 ## Notes
 
-- Rich text editing for long-form notes
-- Markdown-friendly writing
-- Wiki-style `[[links]]` between notes
-- Backlinks and graph-oriented navigation
+Rich-text editing with BlockNote, wiki links, backlinks, properties, attachments, reminders, and version history.
+
+→ [Notes](/user-guide/notes/editing)
 
 ## Journal
 
-- Daily note space for reflection
-- Calendar-oriented browsing
-- Activity context for building a writing habit
+A daily writing space with calendar navigation (day / month / year), heatmap, stats, and templates.
 
-## Tasks and Projects
+→ [Journal](/user-guide/journal/daily-entries)
 
-- Tasks live alongside notes instead of in a separate system
-- Priorities, due dates, and project organization
-- Drag-and-drop planning flows
+## Tasks & Projects
 
-## Offline-First Storage
+Tasks live alongside notes. Multi-view (list / kanban), filters, saved filters, subtasks, recurrence, bulk actions, and drag-drop. Group tasks under projects with custom statuses.
 
-Memry stores workspace data locally so core flows do not depend on a network connection.
-The desktop app uses SQLite-backed local storage and keeps the server out of the critical
-path for everyday writing.
+→ [Tasks](/user-guide/tasks/list-vs-kanban) · [Projects](/user-guide/projects)
 
-## Private Sync
+## Inbox
 
-Sync is designed around end-to-end encryption. Devices encrypt data before it leaves the
-machine, and the server stores encrypted payloads it cannot read.
+A capture surface for links, files, voice, video, PDFs, clips, and social posts — with a focused triage flow, snooze, and a health view.
+
+→ [Inbox](/user-guide/inbox)
+
+## Calendar
+
+Day / week / month / year views over events and date-bound tasks. Optional Google Calendar integration.
+
+→ [Calendar](/user-guide/calendar)
+
+## Search
+
+A global command palette (<kbd>Cmd</kbd>+<kbd>K</kbd>) with scoped filters, tag search, recents, and (when AI is enabled) semantic ranking.
+
+→ [Search](/user-guide/search)
+
+## Workspace Surfaces
+
+- [Tabs & Split View](/user-guide/tabs-split-view)
+- [Folder View](/user-guide/folder-view)
+- [Day Panel](/user-guide/day-panel)
+- [Templates](/user-guide/templates)
+- [Snooze & Reminders](/user-guide/snooze-reminders)
+
+## AI Features
+
+Inline AI menu in the editor, on-device embedding model for semantic search, voice transcription, and pluggable providers (Ollama / OpenAI / Anthropic).
+
+→ [AI Features](/user-guide/ai/inline-menu)
+
+## Sync & Devices
+
+End-to-end encrypted sync, multi-device linking with QR + linking code, recovery phrase, and key rotation.
+
+→ [Sync & Devices](/user-guide/sync/how-sync-works)
+
+## Reference
+
+- [Settings Reference](/user-guide/settings)
+- [Keyboard Shortcuts](/user-guide/keyboard-shortcuts)

--- a/apps/docs/src/guide/first-run.md
+++ b/apps/docs/src/guide/first-run.md
@@ -1,0 +1,33 @@
+# First Run & Vault Setup
+
+What happens the first time you open Memry: choosing a vault location, setting a passphrase, and saving the recovery phrase.
+
+<!-- screenshot: first-run welcome overlay -->
+
+## Welcome Overlay
+
+Briefly explains the local-first model and what to expect from setup.
+
+## Choosing a Vault Location
+
+The vault is a folder Memry owns on disk. It holds your encrypted SQLite databases and attachments.
+
+<!-- screenshot: vault picker dialog -->
+
+## Setting a Passphrase
+
+Your passphrase encrypts the vault locally and is required at every sign-in.
+
+## Recovery Phrase
+
+A list of words you must save outside Memry. It is the only way to decrypt your data if you lose the passphrase.
+
+<!-- screenshot: recovery phrase confirmation step -->
+
+## Email & OTP
+
+If you enable sync, Memry verifies your email with a one-time code before linking the device.
+
+## What Gets Created
+
+Lists the files Memry writes on first run (data DB, index DB, attachment dir).

--- a/apps/docs/src/guide/tour.md
+++ b/apps/docs/src/guide/tour.md
@@ -1,0 +1,37 @@
+# A Tour of Memry
+
+A 60-second lap through the parts of the app you'll use most.
+
+<!-- screenshot: full app window with sidebar, tabs, editor, day panel -->
+
+## The Sidebar
+
+Notes, Projects, Tags, Bookmarks, Graph, Journal — your primary navigation.
+
+## Tabs
+
+Open many notes, tasks, or views at once. Pin tabs you want to keep around.
+
+## The Editor
+
+Rich text via BlockNote. Type `[[` to link to another note. Slash commands open the block menu.
+
+## The Day Panel
+
+A right-side panel with calendar, tasks for the day, and your schedule.
+
+## Inbox & Triage
+
+A capture surface for links, files, and quick notes you'll process later.
+
+## Tasks & Projects
+
+Manage tasks in list or kanban view. Group them under projects with custom statuses.
+
+## Search
+
+Press <kbd>Cmd</kbd>+<kbd>K</kbd> to find anything across notes, journals, and tasks.
+
+## Settings
+
+Press <kbd>Cmd</kbd>+<kbd>,</kbd> to open the modal. Reference docs live in [Settings Reference](/user-guide/settings).

--- a/apps/docs/src/index.md
+++ b/apps/docs/src/index.md
@@ -4,38 +4,45 @@ layout: home
 hero:
   name: Memry
   text: Private notes, journals, and tasks.
-  tagline: An offline-first workspace with encrypted sync that never exposes your data to the server.
+  tagline: An offline-first workspace with end-to-end encrypted sync. Your data starts and stays on your device.
   actions:
     - theme: brand
       text: Install Memry
       link: /guide/install
     - theme: alt
-      text: View Features
-      link: /features
+      text: Take a Tour
+      link: /guide/tour
+    - theme: alt
+      text: User Guide
+      link: /user-guide/notes/editing
 
 features:
   - title: Local-first by default
-    details: Your workspace lives in a local SQLite vault, so core writing and planning flows keep working offline.
+    details: Your workspace lives in a local SQLite vault. Notes, journals, and tasks keep working offline.
   - title: End-to-end encrypted sync
-    details: Notes sync through encrypted payloads. The server stores data it cannot read.
+    details: Devices encrypt before upload. The Cloudflare-backed sync server stores ciphertext only.
   - title: Notes, journal, and tasks together
-    details: Capture ideas, daily reflections, projects, and tasks without splitting your personal knowledge across apps.
+    details: Capture ideas, daily reflections, projects, and tasks in one private workspace.
+  - title: Yjs CRDT for notes
+    details: Concurrent edits across devices merge cleanly. Your writing flow survives flaky networks.
+  - title: Field-level merge for tasks
+    details: Per-field vector clocks let you and another device edit the same task without losing changes.
+  - title: Open source
+    details: GPL v3.0. Built in the open with a thorough architecture and contributor guide.
 ---
 
 ## What is Memry?
 
 Memry is a private workspace for people who want their notes, journals, tasks, and linked
-ideas in one local-first app. It is built around ownership: your data starts on your
-device, sync is designed around end-to-end encryption, and the server is not trusted with
-plaintext.
+ideas in one local-first app. The vault lives on your device. Sync is end-to-end encrypted,
+so the server can never read your content.
 
-Memry is under active development and has not shipped a public release yet. The docs will
-track setup, features, contribution workflow, and release guidance as the project moves
-toward its first stable build.
+Memry is under active development. The docs cover everything that's shipped, where it lives
+in the app, and how to set it up.
 
-## Quick Links
+## Where to start
 
-- [Install Memry](/guide/install)
-- [Feature Overview](/features)
-- [Architecture Notes](/architecture)
-- [Contributing Guide](/contributing)
+- **New to Memry?** Read [Install Memry](/guide/install) and [First Run & Vault Setup](/guide/first-run), then take [A Tour of Memry](/guide/tour).
+- **Want to know what it does?** Browse the [User Guide](/user-guide/notes/editing) — every feature has its own page.
+- **Curious how it works?** See [Architecture](/architecture).
+- **Want to contribute?** Start with [Contributing](/contributing).

--- a/apps/docs/src/user-guide/ai/embeddings-search.md
+++ b/apps/docs/src/user-guide/ai/embeddings-search.md
@@ -1,0 +1,26 @@
+# Embeddings & Semantic Search
+
+Run a local embedding model so search ranks by meaning, not just keywords.
+
+<!-- screenshot: embeddings model status in settings -->
+
+## What This Powers
+
+- Semantic ranking in [Search](/user-guide/search)
+- AI Connections in [Journal](/user-guide/journal/daily-entries)
+
+## Enabling
+
+Toggle "Enable AI" in [Settings → AI](/user-guide/settings#ai). Pick an embedding model and load it.
+
+## Model Management
+
+Models are downloaded once and cached locally. Unload to free memory.
+
+## Reindexing
+
+Reindex after enabling embeddings for the first time, or after switching models. Progress shows in settings.
+
+## Privacy
+
+Embeddings are computed on-device. Vectors are stored in the local index database and are never sent to a server.

--- a/apps/docs/src/user-guide/ai/inline-menu.md
+++ b/apps/docs/src/user-guide/ai/inline-menu.md
@@ -1,0 +1,28 @@
+# Inline AI Menu
+
+Transform selected text in the editor without leaving it.
+
+<!-- screenshot: inline AI menu open over a text selection -->
+
+## Opening the Menu
+
+Select text in the editor; the AI affordance appears in the formatting toolbar. Click to open the prompt menu.
+
+## Built-in Actions
+
+- Fix grammar
+- Adjust tone (formal, casual, friendly)
+- Adjust length (expand, condense, summarize)
+- Rephrase
+
+## Custom Prompt
+
+Enter a free-form instruction for ad-hoc transformations.
+
+## Provider
+
+Inline AI uses the provider configured in [Settings → AI Inline](/user-guide/settings#ai-inline). Supported: Ollama (local), OpenAI, Anthropic.
+
+## Privacy
+
+Requests go to whichever provider you configured. Local providers (Ollama) keep content on your machine.

--- a/apps/docs/src/user-guide/ai/provider-setup.md
+++ b/apps/docs/src/user-guide/ai/provider-setup.md
@@ -1,0 +1,31 @@
+# Provider Setup
+
+Configure the LLM provider used by the inline AI menu.
+
+<!-- screenshot: AI inline provider configuration in settings -->
+
+## Supported Providers
+
+- Ollama (local)
+- OpenAI
+- Anthropic
+
+## Ollama
+
+Run Ollama locally and point Memry at the base URL (default `http://localhost:11434`). Pick a model from the dropdown.
+
+## OpenAI
+
+Enter your API key. Pick a model preset; advanced users can override the model name.
+
+## Anthropic
+
+Enter your API key. Pick a Claude model preset.
+
+## Test Connection
+
+The "Test connection" button verifies the URL and key.
+
+## Where Keys Are Stored
+
+API keys are stored locally in the vault and are never sent to the Memry sync server.

--- a/apps/docs/src/user-guide/ai/voice-transcription.md
+++ b/apps/docs/src/user-guide/ai/voice-transcription.md
@@ -1,0 +1,22 @@
+# Voice Transcription
+
+Transcribe captured voice memos into text.
+
+<!-- screenshot: voice settings panel -->
+
+## Backends
+
+- Local Whisper-style model (private, runs on-device)
+- OpenAI Whisper API (cloud, requires API key)
+
+## Choosing a Backend
+
+[Settings → AI → Voice](/user-guide/settings#ai). Pick a backend; if local, choose a model size and download it.
+
+## Model Sizes
+
+Larger models are more accurate but slower. Memory and disk usage are shown next to each option.
+
+## Where Voice Items Appear
+
+In the [Inbox](/user-guide/inbox) under the voice content type filter.

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -1,0 +1,29 @@
+# Calendar
+
+Day, week, month, and year views over events and date-bound tasks.
+
+<!-- screenshot: week view with tasks and events -->
+
+## Views
+
+Switch between day, week, month, and year from the calendar toolbar.
+
+## Quick Create
+
+Click an empty slot to create an event inline.
+
+## Tasks on the Calendar
+
+Tasks with due dates show on the day they're due. Click to open in a popover.
+
+## Drag to Reschedule
+
+Drag an event or task to a new slot to reschedule.
+
+## External Calendar Integration
+
+If Google Calendar is connected, external events appear alongside vault events. See [Settings → Integrations](/user-guide/settings#integrations).
+
+## Promote External Events
+
+Move a one-off external event into your vault to add notes, tags, or reminders.

--- a/apps/docs/src/user-guide/day-panel.md
+++ b/apps/docs/src/user-guide/day-panel.md
@@ -1,0 +1,25 @@
+# Day Panel
+
+A right-side panel showing calendar, tasks, and the schedule for a selected date.
+
+<!-- screenshot: day panel docked on the right -->
+
+## Calendar Picker
+
+Month grid with heatmap dots indicating activity. Click a date to set focus.
+
+## Today's Tasks
+
+Tasks with a due date matching the focused date.
+
+## Schedule
+
+Events and journal preview for the focused date.
+
+## Resizing
+
+Drag the left edge to resize. Double-click to reset to default width. Width persists per device.
+
+## Hiding the Panel
+
+Toggle from the header. The panel state persists across restarts.

--- a/apps/docs/src/user-guide/folder-view.md
+++ b/apps/docs/src/user-guide/folder-view.md
@@ -1,0 +1,29 @@
+# Folder View
+
+A table view over a collection of notes with sortable columns and grouping.
+
+<!-- screenshot: folder view as a sortable table -->
+
+## When to Use
+
+When you want a database-like overview of notes by tag, folder, or property — especially useful with custom properties.
+
+## Columns
+
+Show or hide title, tags, created date, modified date, and any custom property. Drag headers to reorder.
+
+## Sorting
+
+Click a header to sort. Shift-click for secondary sort.
+
+## Grouping
+
+Group by folder, tag, or property value. Group headers count rows.
+
+## Density
+
+Compact / normal / spacious row heights, persisted per device.
+
+## Inline Editing
+
+Click a cell to edit a property in place where supported.

--- a/apps/docs/src/user-guide/inbox.md
+++ b/apps/docs/src/user-guide/inbox.md
@@ -1,0 +1,29 @@
+# Inbox
+
+A capture surface for things you want to process later: links, files, voice notes, clips, social posts, and more.
+
+<!-- screenshot: inbox view with mixed item types -->
+
+## Capture
+
+Add items via the inbox capture input, drag-drop, or external integrations.
+
+## Triage Mode
+
+A focused, card-based workflow. Each card offers archive, snooze, file, or quick edit.
+
+## Content Type Filters
+
+Icon-based picker filters by type (link, note, image, voice, video, clip, PDF, social).
+
+## Snooze
+
+Defer an item to reappear at a chosen time. See [Snooze & Reminders](/user-guide/snooze-reminders).
+
+## Archive
+
+Items you've processed move to an archive view; full-text search still finds them.
+
+## Health
+
+The Health tab shows failed sync jobs and items that need attention.

--- a/apps/docs/src/user-guide/journal/calendar-navigation.md
+++ b/apps/docs/src/user-guide/journal/calendar-navigation.md
@@ -1,0 +1,25 @@
+# Calendar Navigation
+
+Browse journal entries by day, month, or year with a heatmap calendar.
+
+<!-- screenshot: month view heatmap showing entry density -->
+
+## Day View
+
+Default writing surface for a single date. Move between days with prev / next arrows or the date picker.
+
+## Month View
+
+A heatmap calendar where each square's intensity reflects entry length. Click a date to open that day.
+
+## Year View
+
+Annual statistics: entries per month, streaks, and totals.
+
+## Date Picker
+
+Jump to any date from the breadcrumb or the picker icon.
+
+## Day Panel Integration
+
+Selecting a date in the [Day Panel](/user-guide/day-panel) also opens that journal entry.

--- a/apps/docs/src/user-guide/journal/daily-entries.md
+++ b/apps/docs/src/user-guide/journal/daily-entries.md
@@ -1,0 +1,25 @@
+# Daily Entries
+
+A dated note per day for reflection. Memry creates one on demand and remembers where you left off.
+
+<!-- screenshot: journal day view with full-width writing -->
+
+## Opening Today
+
+Click Journal in the sidebar, or press the keyboard shortcut to open today's entry.
+
+## Writing
+
+The same BlockNote editor is used for journal entries. Wiki links, attachments, and AI inline work the same way as notes.
+
+## Full-Width Mode
+
+Toggle a wider writing column from the journal header.
+
+## Sidebar Toggles
+
+Show or hide the schedule, tasks, AI connections, and stats footer from [Journal Settings](/user-guide/journal/templates-settings).
+
+## Stats Footer
+
+Word count, character count, and entry count appear at the bottom of the writing column.

--- a/apps/docs/src/user-guide/journal/templates-settings.md
+++ b/apps/docs/src/user-guide/journal/templates-settings.md
@@ -1,0 +1,22 @@
+# Journal Templates & Settings
+
+Choose a default template for new journal entries and toggle the side panels.
+
+<!-- screenshot: journal settings panel -->
+
+## Default Template
+
+Pick a [template](/user-guide/templates) that's used as the starting content for new entries.
+
+## Sidebar Toggles
+
+- Show schedule
+- Show tasks
+- Show AI connections
+- Show stats footer
+
+Toggles persist per device.
+
+## Where to Find These
+
+[Settings → Journal](/user-guide/settings#journal).

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -1,0 +1,55 @@
+# Keyboard Shortcuts
+
+A printable cheatsheet. Rebind any of these in [Settings → Keyboard Shortcuts](/user-guide/settings#keyboard-shortcuts).
+
+> Shortcuts use <kbd>Cmd</kbd> on macOS and <kbd>Ctrl</kbd> on Windows / Linux.
+
+## Global
+
+| Action                         | Shortcut                    |
+| ------------------------------ | --------------------------- |
+| New note                       | <kbd>Cmd</kbd>+<kbd>N</kbd> |
+| Open command palette / search  | <kbd>Cmd</kbd>+<kbd>K</kbd> |
+| Open settings                  | <kbd>Cmd</kbd>+<kbd>,</kbd> |
+| Toggle hint mode               | <kbd>Cmd</kbd>+<kbd>/</kbd> |
+| Show keyboard shortcuts dialog | <kbd>Cmd</kbd>+<kbd>?</kbd> |
+
+## Tabs
+
+| Action       | Shortcut                                       |
+| ------------ | ---------------------------------------------- |
+| Close tab    | <kbd>Cmd</kbd>+<kbd>W</kbd>                    |
+| Next tab     | <kbd>Cmd</kbd>+<kbd>Tab</kbd>                  |
+| Previous tab | <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd> |
+
+## Editor
+
+| Action           | Shortcut                                     |
+| ---------------- | -------------------------------------------- |
+| Find in page     | <kbd>Cmd</kbd>+<kbd>F</kbd>                  |
+| Undo             | <kbd>Cmd</kbd>+<kbd>Z</kbd>                  |
+| Redo             | <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> |
+| Insert wiki link | Type `[[`                                    |
+| Open block menu  | Type `/`                                     |
+
+## Search Palette
+
+| Action           | Shortcut     |
+| ---------------- | ------------ |
+| Scope to notes   | <kbd>1</kbd> |
+| Scope to journal | <kbd>2</kbd> |
+| Scope to tasks   | <kbd>3</kbd> |
+| Scope to inbox   | <kbd>4</kbd> |
+| Tag filter       | Type `#tag`  |
+
+## Tasks
+
+| Action                   | Shortcut                    |
+| ------------------------ | --------------------------- |
+| Quick add (when focused) | <kbd>Enter</kbd>            |
+| Multi-select range       | <kbd>Shift</kbd>+click      |
+| Undo bulk action         | <kbd>Cmd</kbd>+<kbd>Z</kbd> |
+
+## Hint Mode
+
+Press <kbd>Cmd</kbd>+<kbd>/</kbd> to overlay numeric hints on interactive elements. Type the number to activate.

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -1,0 +1,25 @@
+# Attachments
+
+Drop files onto a note to attach them. PDFs preview inline; other types show as download blocks.
+
+<!-- screenshot: PDF preview block inside a note -->
+
+## Adding Files
+
+Drag and drop, or use the slash menu File block. Files are copied into the vault attachments directory.
+
+## PDF Inline Preview
+
+PDFs render in a scrollable embedded viewer.
+
+## Other File Types
+
+Non-PDF attachments show as a block with name, size, and a download button.
+
+## Removing or Replacing
+
+Click the file block menu to delete or replace the attachment.
+
+## Storage
+
+Attachments live in the vault. See storage breakdown in [Settings → Vault](/user-guide/settings#vault).

--- a/apps/docs/src/user-guide/notes/bookmarks-reminders.md
+++ b/apps/docs/src/user-guide/notes/bookmarks-reminders.md
@@ -1,0 +1,21 @@
+# Bookmarks & Reminders
+
+Mark notes you want quick access to, and schedule reminders that fire as in-app toasts.
+
+<!-- screenshot: reminder picker open on a note -->
+
+## Bookmarking
+
+Toggle a note's bookmark from the note toolbar. Bookmarked notes appear under the sidebar Bookmarks section.
+
+## Reminders
+
+Open the reminder picker from the note toolbar. Choose a date and time; Memry shows an in-app toast when the reminder fires.
+
+## Snoozing a Reminder
+
+Toast actions let you snooze 5 min, 10 min, or to a custom time, or dismiss the reminder.
+
+## Where Reminders Live
+
+A reminder badge appears on notes with upcoming reminders. See also [Snooze & Reminders](/user-guide/snooze-reminders) for the cross-cutting view.

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -1,0 +1,33 @@
+# Creating & Editing Notes
+
+Memry uses a BlockNote-based rich text editor with markdown support and a slash-command block menu.
+
+<!-- screenshot: note editor with slash menu open -->
+
+## Creating a Note
+
+Press <kbd>Cmd</kbd>+<kbd>N</kbd> or click the "+" affordance in the sidebar.
+
+## Block Types
+
+Headings, paragraphs, lists, code blocks, quotes, dividers, files, images, and tables.
+
+## Slash Commands
+
+Type `/` to insert a block from the menu.
+
+## Markdown Shortcuts
+
+Markdown shortcuts work inline (e.g. `**bold**`, `# heading`, `- list`).
+
+## Title
+
+The note title is editable inline at the top of the editor and renames the note in real time.
+
+## Drag-and-Drop Blocks
+
+Reorder blocks by dragging the handle on the left of each block.
+
+## Saving
+
+Saves are automatic and debounced. Changes flush on tab close, app quit, and sync.

--- a/apps/docs/src/user-guide/notes/find-in-page.md
+++ b/apps/docs/src/user-guide/notes/find-in-page.md
@@ -1,0 +1,21 @@
+# Find in Page
+
+Search the current note with <kbd>Cmd</kbd>+<kbd>F</kbd>.
+
+<!-- screenshot: find-in-page bar at the top of a note -->
+
+## Opening the Bar
+
+Press <kbd>Cmd</kbd>+<kbd>F</kbd> while a note is focused.
+
+## Navigating Matches
+
+Use the up/down arrows in the bar or <kbd>Enter</kbd> / <kbd>Shift</kbd>+<kbd>Enter</kbd>.
+
+## Closing
+
+Press <kbd>Esc</kbd> or click the close icon.
+
+## Scope
+
+Find-in-page is local to the current note. For global search across notes, journals, and tasks see [Search & Command Palette](/user-guide/search).

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -1,0 +1,25 @@
+# Properties & Tags
+
+Add structured metadata to notes with custom properties and free-form tags.
+
+<!-- screenshot: properties panel and tags row -->
+
+## Tags Row
+
+Add tags inline at the top of a note. Tags are global and clickable from the sidebar.
+
+## Properties Panel
+
+A collapsible section for custom fields. Property types include text, number, date, select, multi-select, and checkbox.
+
+## Defining Properties
+
+Create and edit property definitions in [Settings → Properties](/user-guide/settings#properties).
+
+## Filtering by Tag
+
+Click any tag to open a tag detail view with all notes that share it. See [Sidebar drill-down](/user-guide/tabs-split-view) for context.
+
+## Renaming or Deleting Tags
+
+Manage tags from [Settings → Tags](/user-guide/settings#tags). Renames apply across all notes.

--- a/apps/docs/src/user-guide/notes/version-history.md
+++ b/apps/docs/src/user-guide/notes/version-history.md
@@ -1,0 +1,21 @@
+# Version History
+
+Browse prior versions of a note and restore one if needed.
+
+<!-- screenshot: version history panel showing timeline -->
+
+## Opening History
+
+Open the note menu and choose "Version history."
+
+## Browsing Versions
+
+Versions are listed by timestamp. Selecting one shows a read-only preview.
+
+## Restoring
+
+The "Restore" action replaces the current note content with the selected version. The previous state is itself recorded as a new version.
+
+## Retention
+
+Memry keeps a rolling history of recent saves locally. Older history is pruned automatically.

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -1,0 +1,27 @@
+# Wiki Links & Backlinks
+
+Connect notes with `[[wiki links]]` and discover incoming references from the backlinks panel.
+
+<!-- screenshot: wiki link autocomplete in the editor -->
+
+## Creating a Link
+
+Type `[[` followed by a title. Autocomplete suggests existing notes; pressing Enter creates a new note if none match.
+
+## Following a Link
+
+Click a link to open the linked note in a new tab.
+
+## Backlinks Panel
+
+The backlinks section at the bottom of every note shows other notes that link to it, with snippet previews.
+
+<!-- screenshot: backlinks section under a note -->
+
+## Graph View
+
+A visual map of how notes connect. Open from the sidebar Graph entry.
+
+## Renaming Targets
+
+Renaming a note updates display text in incoming links. The link target itself uses a stable identifier and survives renames.

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -1,0 +1,30 @@
+# Projects
+
+Group tasks under a project with a custom status workflow.
+
+<!-- screenshot: sidebar projects tree with task counts -->
+
+## Project Tree
+
+Projects appear in the sidebar with incomplete-task counts. Drag to reorder.
+
+## Creating a Project
+
+Use the "+" affordance in the sidebar Projects section. Pick a name, color, and icon.
+
+## Statuses
+
+Each project has its own ordered list of statuses. Statuses have a type (e.g. todo, in-progress, done) used for grouping and progress.
+
+## Editing Statuses
+
+Open the status editor from the project header to add, rename, recolor, or reorder statuses.
+
+## Deleting
+
+Deleting a project asks where its tasks should go (move to another project, or delete with the project).
+
+## See Also
+
+- [Tasks](/user-guide/tasks/list-vs-kanban)
+- [Filters & Sorting](/user-guide/tasks/filters-sorting)

--- a/apps/docs/src/user-guide/search.md
+++ b/apps/docs/src/user-guide/search.md
@@ -1,0 +1,29 @@
+# Search & Command Palette
+
+Press <kbd>Cmd</kbd>+<kbd>K</kbd> for global search and command execution.
+
+<!-- screenshot: command palette open with results -->
+
+## Opening
+
+<kbd>Cmd</kbd>+<kbd>K</kbd> from anywhere. <kbd>Esc</kbd> closes it.
+
+## Scoped Search
+
+Number shortcuts <kbd>1</kbd>–<kbd>4</kbd> scope to notes, journals, tasks, or inbox.
+
+## Tag Filtering
+
+Type `#tagname` to filter by tag inside the palette.
+
+## Result Groups
+
+Results are grouped by content type with snippet previews and relative dates.
+
+## Recents
+
+Recent queries and frequently used searches appear when the palette is empty.
+
+## Semantic Search
+
+If embeddings are enabled, search ranks results by semantic similarity in addition to keyword match. See [Embeddings & Semantic Search](/user-guide/ai/embeddings-search).

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -1,0 +1,112 @@
+# Settings Reference
+
+Every panel in the Memry settings modal, in one searchable page.
+
+Open the settings modal with <kbd>Cmd</kbd>+<kbd>,</kbd> or from the sidebar menu.
+
+<!-- screenshot: settings modal with section list -->
+
+## Account
+
+- Sign in / sign out
+- Email display
+- Storage usage breakdown (notes, attachments, CRDT, other)
+- Linked devices: list, rename, revoke
+- Link a new device (QR + linking code)
+- Recovery key: re-display, key rotation wizard
+- Sync status indicator
+
+## Vault
+
+- Vault path (with "Reveal in Finder" on macOS)
+- Storage usage bar
+- Storage breakdown by category
+
+## AI
+
+- Enable / disable
+- Embedding model picker
+- Load / unload model
+- Reindex progress
+- Voice transcription backend (local vs OpenAI) and model management
+
+## AI Inline
+
+- Enable / disable
+- Provider (Ollama / OpenAI / Anthropic)
+- Model presets per provider
+- Base URL
+- API key (with show / hide toggle)
+- Test connection
+
+## Appearance
+
+- Theme: Light / Dark / White / System
+- Accent color (8 presets + custom hex)
+- Font size: Small / Medium / Large
+- Font family: System / Sans / Serif / Monospace / Gelasio / Geist / Inter
+
+## General
+
+- Language
+- Start on boot
+- Tab preview mode
+- Restore session on launch
+- Create in selected folder
+- Check for updates
+- Auto-update toggle
+- Telemetry opt-out
+
+## Keyboard Shortcuts
+
+- Full rebinding UI per shortcut
+- Conflict detection
+- Search / filter
+- Reset to defaults
+- Export / import bindings
+
+## Journal
+
+- Default template
+- Show schedule (sidebar)
+- Show tasks (sidebar)
+- Show AI connections (sidebar)
+- Show stats footer
+
+## Calendar
+
+- External calendar integration toggle
+- Week start day
+
+## Editor
+
+- Rich text toggles
+- Code block styling
+- Link behavior
+
+## Tasks
+
+- Default project for new tasks
+- Kanban column customization
+
+## Properties
+
+- Manage custom property definitions
+- Property types: text, number, date, select, checkbox, multi-select
+- Default values
+
+## Tags
+
+- Tag list management
+- Global rename
+
+## Templates
+
+- Manage all templates
+- Preview
+- Delete
+
+## Integrations
+
+- Google Calendar (link, choose calendar source, unlink)
+- Future integrations land here

--- a/apps/docs/src/user-guide/snooze-reminders.md
+++ b/apps/docs/src/user-guide/snooze-reminders.md
@@ -1,0 +1,32 @@
+# Snooze & Reminders
+
+Defer items and get nudged later. Works on inbox items, tasks, and notes with reminders.
+
+<!-- screenshot: snooze picker with presets and custom option -->
+
+## Snooze Presets
+
+- 30 min
+- 1 hour
+- 3 hours
+- Tomorrow morning (9 AM)
+- Tomorrow afternoon (2 PM)
+- Next week
+- Custom date and time
+
+## Custom Snooze
+
+The custom dialog lets you pick any date and time.
+
+## Countdown Display
+
+Snoozed items show a "wakes in X" countdown until they reappear.
+
+## Reminders
+
+Reminders on notes and tasks fire as in-app toasts. From the toast you can snooze 5 / 10 minutes or to a custom time, or dismiss.
+
+## See Also
+
+- [Bookmarks & Reminders](/user-guide/notes/bookmarks-reminders)
+- [Inbox](/user-guide/inbox)

--- a/apps/docs/src/user-guide/sync/conflict-health.md
+++ b/apps/docs/src/user-guide/sync/conflict-health.md
@@ -1,0 +1,29 @@
+# Conflict & Health
+
+How Memry handles conflicting edits and where to see sync health.
+
+<!-- screenshot: sync history panel showing recent activity -->
+
+## Conflict Resolution
+
+- **Notes and journal entries** merge automatically via CRDT (Yjs).
+- **Tasks and projects** use field-level vector clocks; non-overlapping field edits merge cleanly. Concurrent edits to the same field resolve by last-writer-wins after tick comparison.
+
+## Conflict Indicators
+
+If a conflict can't be resolved automatically (rare), Memry surfaces a banner on the affected item and asks you to choose a side.
+
+## Sync History
+
+A panel that lists recent sync events with timestamps and outcomes.
+
+## Health View
+
+[Inbox → Health](/user-guide/inbox) shows failed sync jobs and items that need user input.
+
+## Common Causes of Sync Errors
+
+- Offline / flaky network
+- Auth expired (sign back in)
+- Quota exceeded (see [Settings → Vault](/user-guide/settings#vault))
+- Server temporarily unavailable

--- a/apps/docs/src/user-guide/sync/how-sync-works.md
+++ b/apps/docs/src/user-guide/sync/how-sync-works.md
@@ -1,0 +1,33 @@
+# How Sync Works
+
+Memry sync is end-to-end encrypted. The server stores ciphertext and never sees note content.
+
+<!-- screenshot: sync status indicator in the app chrome -->
+
+## Status Indicator
+
+A small indicator shows the current state: idle, syncing, paused, error.
+
+## Pause / Resume
+
+Pause sync from the indicator menu when working offline or troubleshooting. Resume to push and pull queued changes.
+
+## What Gets Synced
+
+- Notes (Yjs CRDT)
+- Journal entries
+- Tasks (field-level vector clocks)
+- Projects
+- Inbox items
+- Templates
+- Settings (selected, opt-in)
+
+## What Does Not Get Synced
+
+- Local app state (open tabs, sidebar collapse)
+- Cached AI models and embeddings
+- Voice and AI provider keys
+
+## Frequency
+
+Sync runs continuously while the app is open and online, with backoff during errors.

--- a/apps/docs/src/user-guide/sync/linking-devices.md
+++ b/apps/docs/src/user-guide/sync/linking-devices.md
@@ -1,0 +1,25 @@
+# Linking Another Device
+
+Add a second device that decrypts and syncs the same vault.
+
+<!-- screenshot: device linking screen with QR code -->
+
+## Starting from the Existing Device
+
+Open [Settings → Account](/user-guide/settings#account) and choose "Link a device." Memry shows a QR code and a short linking code.
+
+## Approving the New Device
+
+Open the new device, sign in to the same email, and scan the QR code (or enter the linking code). The existing device shows an approval prompt with the new device's name and fingerprint.
+
+## What Happens After Approval
+
+The vault key is sealed for the new device's public key. The new device pulls all encrypted state from the server and decrypts it locally.
+
+## Removing a Device
+
+[Settings → Account → Devices](/user-guide/settings#account) lists all linked devices. Revoke the ones you no longer use.
+
+## Lost Device
+
+If you lose access to a device, revoke it and rotate the vault key. See [Recovery Key & Rotation](/user-guide/sync/recovery-rotation).

--- a/apps/docs/src/user-guide/sync/recovery-rotation.md
+++ b/apps/docs/src/user-guide/sync/recovery-rotation.md
@@ -1,0 +1,27 @@
+# Recovery Key & Rotation
+
+What the recovery phrase is for and when to rotate the vault key.
+
+<!-- screenshot: recovery phrase display screen -->
+
+## Recovery Phrase
+
+A list of words generated at vault creation. It is the only way to decrypt your data if you lose the passphrase.
+
+## Storing It Safely
+
+Memry never stores the recovery phrase in the cloud. Write it down or use a password manager.
+
+## Re-Displaying
+
+You can re-show the recovery phrase from [Settings → Account](/user-guide/settings#account) after passphrase confirmation.
+
+## Key Rotation
+
+Rotate the vault key when you suspect a device or backup may be compromised. The key rotation wizard re-encrypts payloads with a new key and reseals it for each linked device.
+
+## When You Must Rotate
+
+- Lost or stolen device that was not yet revoked
+- Recovery phrase exposed or lost
+- Major OS or backup compromise

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -1,0 +1,35 @@
+# Tabs & Split View
+
+Open many things at once. Pin the ones you want around. Split the workspace into panes.
+
+<!-- screenshot: split view with two panes and several tabs each -->
+
+## Tabs
+
+Every note, view, search, or page opens in a tab. Tabs persist across app restarts when session restore is enabled.
+
+## Pinning
+
+Pin a tab to keep it at the front of the bar; pinned tabs ignore middle-click close and survive bulk close actions.
+
+## Tab Context Menu
+
+Close, close others, close to right, duplicate, pin / unpin.
+
+## Preview Mode
+
+Single-clicking certain things opens a preview tab (italic title) that's reused for the next preview. Double-click or edit to "promote" it to a permanent tab.
+
+## Split View
+
+Drag a tab to the side of the window to open a second pane. Tabs can move between panes.
+
+<!-- screenshot: tab being dragged into a drop zone to create a split -->
+
+## Resizing Panes
+
+Drag the divider between panes to resize. Double-click to reset.
+
+## Keyboard Shortcuts
+
+See [Keyboard Shortcuts](/user-guide/keyboard-shortcuts) for the full list.

--- a/apps/docs/src/user-guide/tasks/bulk-actions.md
+++ b/apps/docs/src/user-guide/tasks/bulk-actions.md
@@ -1,0 +1,26 @@
+# Bulk Actions
+
+Select multiple tasks and act on them in one step.
+
+<!-- screenshot: bulk action bar with multiple tasks selected -->
+
+## Selecting Tasks
+
+Click checkboxes on rows, or shift-click to range-select.
+
+## Available Actions
+
+- Change status
+- Change priority
+- Set or clear due date
+- Tag / untag
+- Move to project
+- Delete
+
+## Undo
+
+Cmd+Z reverses the most recent bulk change. The undo history covers the last several actions.
+
+## See Also
+
+- [Drag & Drop](/user-guide/tasks/drag-and-drop) for moving multiple selected tasks at once

--- a/apps/docs/src/user-guide/tasks/capturing.md
+++ b/apps/docs/src/user-guide/tasks/capturing.md
@@ -1,0 +1,26 @@
+# Capturing Tasks
+
+Quick add, inline create, and turning a note into a task.
+
+<!-- screenshot: quick-add input at top of tasks view -->
+
+## Quick Add
+
+Type into the quick-add input above any task list. Press <kbd>Enter</kbd> to create.
+
+## Natural Language Dates
+
+Phrases like "tomorrow," "next Friday," or "in 3 days" parse into due dates as you type.
+
+## From a Project View
+
+Quick-add inside a project assigns the task to that project automatically.
+
+## Subtasks
+
+Indent within the quick-add or use the inline "+" on a parent row to create a subtask.
+
+## See Also
+
+- [List vs Kanban](/user-guide/tasks/list-vs-kanban)
+- [Subtasks & Recurrence](/user-guide/tasks/subtasks-recurrence)

--- a/apps/docs/src/user-guide/tasks/drag-and-drop.md
+++ b/apps/docs/src/user-guide/tasks/drag-and-drop.md
@@ -1,0 +1,25 @@
+# Drag & Drop
+
+Reorder tasks, move between statuses, and re-parent subtasks.
+
+<!-- screenshot: a task being dragged across kanban columns -->
+
+## In List View
+
+Drag rows to reorder within a list or group. Cross-group drags update the grouping field (e.g. priority).
+
+## In Kanban View
+
+Drag cards between columns to change status. Drag within a column to reorder.
+
+## Multi-Select Drag
+
+If multiple tasks are selected, dragging any of them moves the whole selection.
+
+## Re-Parenting Subtasks
+
+Drag a subtask onto another parent to move it. Drag to the top level to promote it.
+
+## Project Reorder
+
+Drag projects in the sidebar to reorder. The order persists across devices via sync.

--- a/apps/docs/src/user-guide/tasks/filters-sorting.md
+++ b/apps/docs/src/user-guide/tasks/filters-sorting.md
@@ -1,0 +1,25 @@
+# Filters & Sorting
+
+Filter, sort, and group tasks; save filter sets for reuse.
+
+<!-- screenshot: filter bar with active filters and saved filters dropdown -->
+
+## Filter Bar
+
+Filter by status, priority, project, due date, assignee, or tag. Active filters show as removable chips.
+
+## Saved Filters
+
+Save a filter combination to reuse later. Saved filters appear in the toolbar.
+
+## Quick Filter Chips
+
+Pre-built chips for common needs (e.g. Today, Overdue, No project).
+
+## Sorting
+
+Sort by priority, due date, creation date, or name. Direction toggles per column.
+
+## Grouping
+
+Group by status, project, priority, or due date. Group headers count and roll up subtasks.

--- a/apps/docs/src/user-guide/tasks/list-vs-kanban.md
+++ b/apps/docs/src/user-guide/tasks/list-vs-kanban.md
@@ -1,0 +1,27 @@
+# List vs Kanban
+
+Two views over the same tasks. Switch from the view toggle in the tasks toolbar.
+
+<!-- screenshot: side-by-side list and kanban -->
+
+## List View
+
+Default. Tasks are flat or grouped, with inline editing of title, status, priority, and due date.
+
+## Kanban View
+
+Columns reflect statuses (or another grouping). Drag cards across columns to update status.
+
+## Internal Tabs
+
+Tasks page also has tabs for "All," "Today," and "Completed" to scope results without changing filters.
+
+## When to Use Which
+
+- List: long sessions of triage, sorting, or bulk actions
+- Kanban: weekly planning and status-focused work
+
+## See Also
+
+- [Filters & Sorting](/user-guide/tasks/filters-sorting)
+- [Drag & Drop](/user-guide/tasks/drag-and-drop)

--- a/apps/docs/src/user-guide/tasks/subtasks-recurrence.md
+++ b/apps/docs/src/user-guide/tasks/subtasks-recurrence.md
@@ -1,0 +1,25 @@
+# Subtasks & Recurrence
+
+Nest tasks under parents and schedule repeating tasks.
+
+<!-- screenshot: parent task with expanded subtasks and recurrence picker -->
+
+## Subtasks
+
+Tasks can have multiple levels of subtasks. Parents show progress bars and badges based on subtask completion.
+
+## Adding Subtasks
+
+Inline "+" on the parent row, or indent in quick-add. Drag-drop to re-parent.
+
+## Recurrence
+
+Schedule daily, weekly, monthly, or custom repeats. Optionally cap with a repeat count.
+
+## Completion of Recurring Tasks
+
+Marking a recurring task done generates the next occurrence based on the recurrence rule.
+
+## Due Dates & Priorities
+
+Each task and subtask carries its own due date and priority. See [Capturing Tasks](/user-guide/tasks/capturing) for natural language date input.

--- a/apps/docs/src/user-guide/templates.md
+++ b/apps/docs/src/user-guide/templates.md
@@ -1,0 +1,29 @@
+# Templates
+
+Reusable starting content for notes and journal entries.
+
+<!-- screenshot: template gallery -->
+
+## Template Gallery
+
+Browse built-in and custom templates. Each shows an icon, name, and short description.
+
+## Built-in Templates
+
+Memry-provided templates are read-only. Duplicate them to create an editable version.
+
+## Custom Templates
+
+Create your own from the gallery, or duplicate an existing one. Edit in the template editor.
+
+## Template Editor
+
+Same BlockNote editor used for notes. Use template variables (where supported) for date and title insertion.
+
+## Default Journal Template
+
+Pick a default for new journal entries from [Settings → Journal](/user-guide/settings#journal).
+
+## Using a Template
+
+When creating a note, pick a template from the create dialog. The template content seeds the new note.


### PR DESCRIPTION
## Summary
- **Path filters** on `desktop-ci.yml` (mirrors `sync-server-ci.yml`): Desktop CI only runs when `apps/desktop/**`, `packages/**`, or root workspace config changes.
- **No e2e on PRs by default.** A new `detect-e2e` job diffs the PR against its base, finds changed `apps/desktop/tests/e2e/*.e2e.ts` files, and only spins up `e2e-changed` if any. That job runs Playwright against just the edited test files.
- `e2e-full` (38 tests, 3 shards) and `package-smoke` (macOS) only run on push to `main` or manual `workflow_dispatch`.

## What runs where after this PR

| Job | PR (no e2e edits) | PR (edits e2e) | Push to main | manual |
|---|---|---|---|---|
| static | yes | yes | yes | yes |
| unit | yes | yes | yes | yes |
| detect-e2e | yes (~30s) | yes | no | no |
| e2e-changed | no | yes (only edited files) | no | no |
| e2e-full (3 shards) | no | no | yes | yes |
| package-smoke (macOS) | no | no | yes | yes |

## Tradeoffs / notes
- A regression in source code that breaks e2e but doesn't touch the test file lands silently and is caught only on main. Acceptable for this pre-prod app.
- Need to validate e2e on a PR before merge? Run `workflow_dispatch` from the Actions tab, or touch the relevant test file.
- Files with shell-special chars in their names would break the file-list passthrough. All current e2e files are kebab-case, no risk.

## Test plan
- [ ] Confirm Desktop CI on this PR runs `static + unit + detect-e2e` and skips `e2e-changed`, `e2e-full`, `package-smoke`.
- [ ] After merge, push a desktop-only change (no e2e edits) and confirm only `static + unit + detect-e2e` run on the PR.
- [ ] Push a PR that edits `apps/desktop/tests/e2e/vault.e2e.ts` and confirm `e2e-changed` runs only that file.
- [ ] Confirm push to main runs the full matrix (`e2e-full` + `package-smoke`).
- [ ] Push a sync-server-only change and confirm Desktop CI is skipped entirely.