### PR TITLE
ci(release-drafter): humanize draft name and prefix bullets with category emoji

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -80,7 +80,7 @@ jobs:
         uses: release-drafter/release-drafter@v7
         with:
           token: ${{ github.token }}
-          name: ${{ steps.metadata.outputs.release_tag }}
+          name: ${{ steps.metadata.outputs.release_name }}
           tag: ${{ steps.metadata.outputs.release_tag }}
           commitish: ${{ github.sha }}
           publish: false
@@ -90,6 +90,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.metadata.outputs.release_tag }}
+          RELEASE_NAME: ${{ steps.metadata.outputs.release_name }}
         run: |
           gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" > draft-release.json
           gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" > releases.json
@@ -100,6 +101,7 @@ jobs:
           const release = JSON.parse(readFileSync('draft-release.json', 'utf8'))
           const releases = JSON.parse(readFileSync('releases.json', 'utf8'))
           const tag = process.env.TAG
+          const releaseName = process.env.RELEASE_NAME
           const repo = process.env.GITHUB_REPOSITORY
           const tagPattern = /^v20\d{2}-\d{2}-\d{2}(?:\.[2-9]\d*)?$/
           const previous = releases.find(
@@ -118,7 +120,7 @@ jobs:
             'release-patch.json',
             JSON.stringify({
               body: patchedBody,
-              name: tag,
+              name: releaseName,
               tag_name: tag
             })
           )

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -86,7 +86,7 @@ jobs:
           publish: false
           latest: false
 
-      - name: Patch full changelog link
+      - name: Patch release body
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.metadata.outputs.release_tag }}
@@ -113,8 +113,31 @@ jobs:
           const compareUrl = previous
             ? `https://github.com/${repo}/compare/${previous.tag_name}...${tag}`
             : `https://github.com/${repo}/commits/${tag}`
-          const body = (release.body || '').replace(/\n\n\*\*Full Changelog\*\*: .+$/s, '')
-          const patchedBody = `${body.trimEnd()}\n\n**Full Changelog**: ${compareUrl}\n`
+
+          function prefixBulletsWithSectionEmoji(input) {
+            const lines = input.split('\n')
+            const output = []
+            let sectionEmoji = ''
+            for (const line of lines) {
+              const headingMatch = line.match(/^##\s+(\S+)/)
+              if (headingMatch) {
+                const token = headingMatch[1]
+                sectionEmoji = /^\p{Extended_Pictographic}/u.test(token) ? token : ''
+                output.push(line)
+                continue
+              }
+              if (sectionEmoji && line.startsWith('- ') && !line.startsWith(`- ${sectionEmoji}`)) {
+                output.push(`- ${sectionEmoji} ${line.slice(2)}`)
+                continue
+              }
+              output.push(line)
+            }
+            return output.join('\n')
+          }
+
+          const stripped = (release.body || '').replace(/\n\n\*\*Full Changelog\*\*: .+$/s, '')
+          const withEmojis = prefixBulletsWithSectionEmoji(stripped)
+          const patchedBody = `${withEmojis.trimEnd()}\n\n**Full Changelog**: ${compareUrl}\n`
 
           writeFileSync(
             'release-patch.json',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,20 +55,20 @@ jobs:
             gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" > releases.json
 
             node <<'NODE'
-            const { readFileSync, writeFileSync } = require('node:fs')
+          const { readFileSync, writeFileSync } = require('node:fs')
 
-            const releases = JSON.parse(readFileSync('releases.json', 'utf8'))
-            const tagPattern = /^v20\d{2}-\d{2}-\d{2}(?:\.[2-9]\d*)?$/
-            const draft = releases.find(
-              (release) => release.draft && tagPattern.test(release.tag_name || '')
-            )
+          const releases = JSON.parse(readFileSync('releases.json', 'utf8'))
+          const tagPattern = /^v20\d{2}-\d{2}-\d{2}(?:\.[2-9]\d*)?$/
+          const draft = releases.find(
+            (release) => release.draft && tagPattern.test(release.tag_name || '')
+          )
 
-            if (!draft) {
-              throw new Error('No date draft release found. Merge to main first.')
-            }
+          if (!draft) {
+            throw new Error('No date draft release found. Merge to main first.')
+          }
 
-            writeFileSync('draft-release.json', JSON.stringify(draft, null, 2))
-            NODE
+          writeFileSync('draft-release.json', JSON.stringify(draft, null, 2))
+          NODE
           fi
 
           node <<'NODE'


### PR DESCRIPTION
## Summary

Three changes to the date-based draft release flow:

- **`release-drafter.yml` — draft name now reads `Memry v2026-MM-DD`** to match published releases. The `desktop-release-metadata.mjs` script already exposed `release_name`; we just weren't passing it through to the action and the trailing PATCH call.
- **`release-drafter.yml` — each bullet in the release body now starts with its section's emoji** (e.g. `- 🐛 fix: …`, `- 🚀 feat: …`). Walks `## 🚀 …` / `## 🐛 …` headings, captures the leading pictograph, and prepends it to every `- ` line in that section. `## What's Changed` and any non-emoji headings are skipped. Idempotent.
- **`release.yml` — fix heredoc terminator that broke the workflow when `draft_tag` was left blank.** The closing `NODE` on the `if/else`'s inner heredoc was indented 12 spaces while the surrounding bash sat at 10. YAML literal blocks strip only the minimum common indent (10), so bash saw the terminator at column 2 — and `<<'NODE'` requires column 0. The entire rest of the script got swallowed into the heredoc and bash hit EOF mid-heredoc. Past runs worked because an explicit `draft_tag` took the `if` branch and never executed the broken `else`. Caught while testing the polish above.

## Test plan

- [ ] Merge a PR to main and confirm the date draft is named `Memry v2026-MM-DD` (not just `v2026-MM-DD`).
- [ ] Confirm bullets in each section are emoji-prefixed: `- 🚀 …` under Features, `- 🐛 …` under Bug Fixes, etc.
- [ ] Confirm the `**Full Changelog**: …` compare link is still appended at the bottom.
- [ ] Run `release.yml` (workflow_dispatch) with **blank** `draft_tag` — should resolve the latest date draft and succeed (previously failed with `syntax error: unexpected end of file`).
- [ ] Confirm the resulting publish attaches all platform assets to the now-public release.