### PR TITLE
Add task row linked note indicator

### DIFF
--- a/apps/desktop/src/renderer/src/components/tasks/drag-drop/sortable-parent-task-row.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/drag-drop/sortable-parent-task-row.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
 import { SortableParentTaskRow } from './sortable-parent-task-row'
+import { notesService } from '@/services/notes-service'
 import type { Task, Priority } from '@/data/task-model'
 import type { Project, Status, StatusType } from '@/data/tasks-data'
 
@@ -32,6 +33,12 @@ vi.mock('@/contexts/drag-context', () => ({
 
 vi.mock('@/contexts/dropped-priority-context', () => ({
   useDroppedPriorities: () => useDroppedPrioritiesMock()
+}))
+
+vi.mock('@/services/notes-service', () => ({
+  notesService: {
+    get: vi.fn()
+  }
 }))
 
 const createStatus = (overrides: Partial<Status> = {}): Status => ({
@@ -81,6 +88,14 @@ const createTask = (overrides: Partial<Task> = {}): Task => ({
   ...overrides
 })
 
+const createNote = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'note-1',
+    title: 'Parent Note',
+    emoji: null,
+    ...overrides
+  }) as Awaited<ReturnType<typeof notesService.get>>
+
 describe('SortableParentTaskRow', () => {
   const setNodeRef = vi.fn()
 
@@ -89,6 +104,8 @@ describe('SortableParentTaskRow', () => {
     useDragContextMock.mockReset()
     useDroppedPrioritiesMock.mockReset()
     setNodeRef.mockReset()
+    vi.mocked(notesService.get).mockReset()
+    vi.mocked(notesService.get).mockResolvedValue(null)
 
     useSortableMock.mockReturnValue({
       attributes: { role: 'button' },
@@ -116,6 +133,31 @@ describe('SortableParentTaskRow', () => {
     })
 
     useDroppedPrioritiesMock.mockReturnValue(new Map())
+  })
+
+  it('shows a linked note affordance for parent tasks', async () => {
+    const project = createProject()
+    vi.mocked(notesService.get).mockResolvedValueOnce(createNote({ title: 'Parent Planning' }))
+
+    render(
+      <SortableParentTaskRow
+        task={createTask({ linkedNoteIds: ['note-1'] })}
+        project={project}
+        projects={[project]}
+        subtasks={[createTask({ id: 'subtask-1', parentId: 'task-1', title: 'Child Task' })]}
+        progress={{ completed: 0, total: 1 }}
+        isExpanded={false}
+        isCompleted={false}
+        sectionId="status-todo"
+        sectionTaskIds={['task-1']}
+        columnId="status-todo"
+        onToggleExpand={vi.fn()}
+        onToggleComplete={vi.fn()}
+        onNoteClick={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByText('Parent Planning')).toBeInTheDocument()
   })
 
   it('registers the parent row as a sortable list item with full drop metadata', () => {

--- a/apps/desktop/src/renderer/src/components/tasks/drag-drop/task-row.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/drag-drop/task-row.test.tsx
@@ -1,9 +1,17 @@
-import { describe, it, expect, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
 import { TaskRow } from './task-row'
+import { notesService } from '@/services/notes-service'
 import type { Task, Priority } from '@/data/task-model'
 import type { Project, StatusType, Status } from '@/data/tasks-data'
+
+vi.mock('@/services/notes-service', () => ({
+  notesService: {
+    get: vi.fn()
+  }
+}))
 
 const createStatus = (overrides: Partial<Status> = {}): Status => ({
   id: 'status-todo',
@@ -60,6 +68,78 @@ const defaultProps = {
   onToggleComplete: vi.fn(),
   onClick: vi.fn()
 }
+
+const createNote = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'note-1',
+    title: 'Linked Note',
+    emoji: null,
+    ...overrides
+  }) as Awaited<ReturnType<typeof notesService.get>>
+
+beforeEach(() => {
+  vi.mocked(notesService.get).mockReset()
+  vi.mocked(notesService.get).mockResolvedValue(null)
+})
+
+describe('TaskRow — Linked Notes', () => {
+  it('shows the first linked note title and extra count', async () => {
+    vi.mocked(notesService.get).mockResolvedValueOnce(createNote({ title: 'Planning Note' }))
+
+    render(
+      <TaskRow
+        {...defaultProps}
+        task={createTask({ linkedNoteIds: ['note-1', 'note-2'] })}
+        onNoteClick={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByText('Planning Note')).toBeInTheDocument()
+    expect(screen.getByText('+1')).toBeInTheDocument()
+  })
+
+  it('falls back to sourceNoteId when linkedNoteIds is empty', async () => {
+    vi.mocked(notesService.get).mockResolvedValueOnce(createNote({ id: 'source-note' }))
+
+    render(
+      <TaskRow
+        {...defaultProps}
+        task={createTask({ linkedNoteIds: [], sourceNoteId: 'source-note' })}
+        onNoteClick={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByText('Linked Note')).toBeInTheDocument()
+    expect(notesService.get).toHaveBeenCalledWith('source-note')
+  })
+
+  it('opens the linked note without opening the task row', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    const onNoteClick = vi.fn()
+    vi.mocked(notesService.get).mockResolvedValueOnce(createNote({ title: 'Research Note' }))
+
+    render(
+      <TaskRow
+        {...defaultProps}
+        task={createTask({ linkedNoteIds: ['note-1'] })}
+        onClick={onClick}
+        onNoteClick={onNoteClick}
+      />
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'Open note Research Note' }))
+
+    expect(onNoteClick).toHaveBeenCalledWith('note-1')
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('does not show a linked note affordance without note relationships', () => {
+    render(<TaskRow {...defaultProps} onNoteClick={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: /open note/i })).not.toBeInTheDocument()
+  })
+})
 
 describe('TaskRow — Whole-Row Drag', () => {
   it('applies cursor-grab when dragHandleListeners are provided', () => {

--- a/apps/desktop/src/renderer/src/components/tasks/drag-drop/task-row.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/drag-drop/task-row.tsx
@@ -9,6 +9,7 @@ import { InlineStatusPopover } from '@/components/tasks/inline-status-popover'
 import { InlinePriorityPopover } from '@/components/tasks/inline-priority-popover'
 import { SelectionCheckbox } from '@/components/tasks/bulk-actions'
 import { RepeatIndicator } from '@/components/tasks/repeat-indicator'
+import { TaskLinkedNoteIndicator } from '@/components/tasks/task-linked-note-indicator'
 import { InsertionIndicator } from './insertion-indicator'
 import type { SectionDragState } from './list-section-drag-state'
 
@@ -26,6 +27,7 @@ interface TaskRowProps {
   showProjectBadge?: boolean
   onToggleComplete: (taskId: string) => void
   onUpdateTask?: (taskId: string, updates: Partial<Task>) => void
+  onNoteClick?: (noteId: string) => void
   onClick?: (taskId: string) => void
   className?: string
   isSelectionMode?: boolean
@@ -57,6 +59,10 @@ const arePropsEqual = (prevProps: TaskRowProps, nextProps: TaskRowProps): boolea
   if (prevProps.task.isRepeating !== nextProps.task.isRepeating) return false
   if (prevProps.task.repeatConfig !== nextProps.task.repeatConfig) return false
   if (prevProps.task.projectId !== nextProps.task.projectId) return false
+  if (prevProps.task.sourceNoteId !== nextProps.task.sourceNoteId) return false
+  if (prevProps.task.linkedNoteIds.join(',') !== nextProps.task.linkedNoteIds.join(',')) {
+    return false
+  }
   const prevDate = prevProps.task.dueDate?.getTime() ?? null
   const nextDate = nextProps.task.dueDate?.getTime() ?? null
   if (prevDate !== nextDate) return false
@@ -106,6 +112,7 @@ const TaskRowComponent = ({
   showProjectBadge = false,
   onToggleComplete,
   onUpdateTask,
+  onNoteClick,
   onClick,
   className,
   isSelectionMode = false,
@@ -329,6 +336,8 @@ const TaskRowComponent = ({
           {dueDateDisplay.text}
         </div>
       )}
+
+      {!isOverlay && <TaskLinkedNoteIndicator task={task} onNoteClick={onNoteClick} />}
 
       {!isOverlay && droppedPriority && (
         <div className="flex items-center shrink-0 gap-1 px-2 py-0.5 bg-primary/10 rounded text-[10px] font-medium text-primary animate-fade-out">

--- a/apps/desktop/src/renderer/src/components/tasks/parent-task-row.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/parent-task-row.tsx
@@ -15,6 +15,7 @@ import { StatusIcon } from '@/components/tasks/status-icon'
 import { InlineStatusPopover } from '@/components/tasks/inline-status-popover'
 import { InlinePriorityPopover } from '@/components/tasks/inline-priority-popover'
 import { SubtaskProgressIndicator } from '@/components/tasks/subtask-progress-indicator'
+import { TaskLinkedNoteIndicator } from '@/components/tasks/task-linked-note-indicator'
 import { PriorityBars } from '@/components/tasks/task-icons'
 import type { Priority, Task } from '@/data/task-model'
 import type { Project, Status } from '@/data/tasks-data'
@@ -33,6 +34,7 @@ export interface ParentTaskRowProps {
   onToggleExpand: (taskId: string) => void
   onToggleComplete: (taskId: string) => void
   onUpdateTask?: (taskId: string, updates: Partial<Task>) => void
+  onNoteClick?: (noteId: string) => void
   onToggleSubtaskComplete?: (subtaskId: string) => void
   onClick?: (taskId: string) => void
   className?: string
@@ -89,6 +91,7 @@ export const ParentTaskRow = ({
   onToggleExpand,
   onToggleComplete,
   onUpdateTask,
+  onNoteClick,
   onToggleSubtaskComplete,
   onClick,
   className,
@@ -354,6 +357,8 @@ export const ParentTaskRow = ({
             {dueDateDisplay.text}
           </div>
         )}
+
+        {!isOverlay && <TaskLinkedNoteIndicator task={task} onNoteClick={onNoteClick} />}
 
         {!isOverlay && droppedPriority && (
           <div className="flex items-center shrink-0 gap-1 px-2 py-0.5 bg-primary/10 rounded text-[10px] font-medium text-primary animate-fade-out">

--- a/apps/desktop/src/renderer/src/components/tasks/project/virtualized-project-task-list.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project/virtualized-project-task-list.tsx
@@ -35,6 +35,7 @@ interface VirtualizedProjectTaskListProps {
   onUpdateTask?: (taskId: string, updates: Partial<Task>) => void
   onToggleSubtaskComplete?: (subtaskId: string) => void
   onTaskClick?: (taskId: string) => void
+  onNoteClick?: (noteId: string) => void
   onQuickAdd: (
     title: string,
     parsedData?: {
@@ -98,6 +99,7 @@ interface VirtualItemRendererProps {
   onUpdateTask?: (taskId: string, updates: Partial<Task>) => void
   onToggleSubtaskComplete?: (subtaskId: string) => void
   onTaskClick?: (taskId: string) => void
+  onNoteClick?: (noteId: string) => void
   isSelectionMode?: boolean
   selectedIds?: Set<string>
   onToggleSelect?: (taskId: string) => void
@@ -119,6 +121,7 @@ const VirtualItemRenderer = memo(
     onUpdateTask,
     onToggleSubtaskComplete,
     onTaskClick,
+    onNoteClick,
     isSelectionMode = false,
     selectedIds,
     onToggleSelect,
@@ -164,6 +167,7 @@ const VirtualItemRenderer = memo(
             onToggleComplete={onToggleComplete}
             onUpdateTask={onUpdateTask}
             onClick={onTaskClick}
+            onNoteClick={onNoteClick}
             isSelectionMode={isSelectionMode}
             isCheckedForSelection={isCheckedForSelection}
             onToggleSelect={onToggleSelect}
@@ -198,6 +202,7 @@ const VirtualItemRenderer = memo(
             onUpdateTask={onUpdateTask}
             onToggleSubtaskComplete={onToggleSubtaskComplete}
             onClick={onTaskClick}
+            onNoteClick={onNoteClick}
             isSelectionMode={isSelectionMode}
             isCheckedForSelection={isCheckedForSelection}
             onToggleSelect={onToggleSelect}
@@ -228,6 +233,7 @@ export const VirtualizedProjectTaskList = ({
   onUpdateTask,
   onToggleSubtaskComplete,
   onTaskClick,
+  onNoteClick,
   onQuickAdd,
   className,
   isSelectionMode = false,
@@ -352,6 +358,7 @@ export const VirtualizedProjectTaskList = ({
                     onUpdateTask={onUpdateTask}
                     onToggleSubtaskComplete={onToggleSubtaskComplete}
                     onTaskClick={onTaskClick}
+                    onNoteClick={onNoteClick}
                     isSelectionMode={isSelectionMode}
                     selectedIds={selectedIds}
                     onToggleSelect={onToggleSelect}

--- a/apps/desktop/src/renderer/src/components/tasks/projects/projects-tab-content.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/projects-tab-content.tsx
@@ -20,6 +20,7 @@ interface ProjectsTabContentProps {
   onUpdateTask?: (taskId: string, updates: Partial<Task>) => void
   onToggleSubtaskComplete: (taskId: string) => void
   onTaskClick: (taskId: string) => void
+  onNoteClick?: (noteId: string) => void
   onQuickAdd: (
     title: string,
     parsedData?: {
@@ -53,6 +54,7 @@ export const ProjectsTabContent = ({
   onUpdateTask,
   onToggleSubtaskComplete,
   onTaskClick,
+  onNoteClick,
   onQuickAdd,
   onProjectEdit,
   onProjectArchive,
@@ -145,6 +147,7 @@ export const ProjectsTabContent = ({
             onUpdateTask={onUpdateTask}
             onToggleSubtaskComplete={onToggleSubtaskComplete}
             onTaskClick={onTaskClick}
+            onNoteClick={onNoteClick}
             onQuickAdd={handleQuickAdd}
             isSelectionMode={isSelectionMode}
             selectedIds={selectedIds}

--- a/apps/desktop/src/renderer/src/components/tasks/task-linked-note-indicator.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-linked-note-indicator.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react'
+
+import { ArrowUpRight, FileText } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { notesService } from '@/services/notes-service'
+import type { Task } from '@/data/task-model'
+
+const FALLBACK_NOTE_TITLE = 'Linked note'
+
+interface TaskLinkedNoteIndicatorProps {
+  task: Task
+  onNoteClick?: (noteId: string) => void
+  className?: string
+}
+
+const getRelatedNoteIds = (task: Task): string[] => {
+  if (task.linkedNoteIds.length > 0) {
+    return task.linkedNoteIds
+  }
+  return task.sourceNoteId ? [task.sourceNoteId] : []
+}
+
+export function TaskLinkedNoteIndicator({
+  task,
+  onNoteClick,
+  className
+}: TaskLinkedNoteIndicatorProps): React.JSX.Element | null {
+  const noteIds = getRelatedNoteIds(task)
+  const primaryNoteId = noteIds[0]
+  const extraCount = Math.max(noteIds.length - 1, 0)
+  const [loadedNote, setLoadedNote] = useState<{ noteId: string; title: string } | null>(null)
+  const noteTitle =
+    loadedNote && loadedNote.noteId === primaryNoteId ? loadedNote.title : FALLBACK_NOTE_TITLE
+
+  useEffect(() => {
+    if (!primaryNoteId) return
+
+    let isCurrent = true
+
+    void notesService
+      .get(primaryNoteId)
+      .then((note) => {
+        if (!isCurrent) return
+        setLoadedNote({
+          noteId: primaryNoteId,
+          title: note?.title?.trim() || FALLBACK_NOTE_TITLE
+        })
+      })
+      .catch(() => {
+        if (!isCurrent) return
+        setLoadedNote({ noteId: primaryNoteId, title: FALLBACK_NOTE_TITLE })
+      })
+
+    return () => {
+      isCurrent = false
+    }
+  }, [primaryNoteId])
+
+  if (!primaryNoteId) return null
+
+  const handleOpenNote = (event: React.MouseEvent<HTMLButtonElement>): void => {
+    event.stopPropagation()
+    onNoteClick?.(primaryNoteId)
+  }
+
+  const stopRowInteraction = (event: React.SyntheticEvent): void => {
+    event.stopPropagation()
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={`Open note ${noteTitle}`}
+      title={noteTitle}
+      onClick={handleOpenNote}
+      onPointerDown={stopRowInteraction}
+      onMouseDown={stopRowInteraction}
+      className={cn(
+        'inline-flex h-6 max-w-6 shrink-0 items-center justify-end gap-1 overflow-hidden',
+        'rounded-sm border border-transparent px-1.5 text-[11px] leading-none',
+        'text-text-tertiary transition-[max-width,color,background-color,border-color] duration-150',
+        'hover:border-border hover:bg-background/80 hover:text-text-secondary',
+        'focus-visible:max-w-[180px] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        'group-hover:max-w-[180px] group-focus-within:max-w-[180px]',
+        className
+      )}
+    >
+      <FileText className="size-3 shrink-0" aria-hidden="true" />
+      <span
+        className={cn(
+          'min-w-0 max-w-0 truncate opacity-0 transition-[max-width,opacity] duration-150',
+          'group-hover:max-w-[120px] group-hover:opacity-100',
+          'group-focus-within:max-w-[120px] group-focus-within:opacity-100',
+          'focus-visible:max-w-[120px] focus-visible:opacity-100'
+        )}
+      >
+        {noteTitle}
+      </span>
+      {extraCount > 0 && (
+        <span
+          className={cn(
+            'shrink-0 opacity-0 transition-opacity duration-150',
+            'group-hover:opacity-100 group-focus-within:opacity-100'
+          )}
+        >
+          +{extraCount}
+        </span>
+      )}
+      <ArrowUpRight
+        className={cn(
+          'size-3 shrink-0 opacity-0 transition-opacity duration-150',
+          'group-hover:opacity-100 group-focus-within:opacity-100'
+        )}
+        aria-hidden="true"
+      />
+    </button>
+  )
+}
+
+export default TaskLinkedNoteIndicator

--- a/apps/desktop/src/renderer/src/components/tasks/task-list.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-list.tsx
@@ -17,6 +17,7 @@ interface TaskListProps {
   onUpdateTask?: (taskId: string, updates: Partial<Task>) => void
   onToggleSubtaskComplete?: (subtaskId: string) => void
   onTaskClick?: (taskId: string) => void
+  onNoteClick?: (noteId: string) => void
   onQuickAdd: (
     title: string,
     parsedData?: {
@@ -56,6 +57,7 @@ export const TaskList = ({
   onUpdateTask,
   onToggleSubtaskComplete,
   onTaskClick,
+  onNoteClick,
   onQuickAdd,
   className,
   // Selection props
@@ -86,6 +88,7 @@ export const TaskList = ({
         onUpdateTask={onUpdateTask}
         onToggleSubtaskComplete={onToggleSubtaskComplete}
         onTaskClick={onTaskClick}
+        onNoteClick={onNoteClick}
         onQuickAdd={onQuickAdd}
         className={className}
         isSelectionMode={isSelectionMode}
@@ -108,6 +111,7 @@ export const TaskList = ({
       onUpdateTask={onUpdateTask}
       onToggleSubtaskComplete={onToggleSubtaskComplete}
       onTaskClick={onTaskClick}
+      onNoteClick={onNoteClick}
       onQuickAdd={onQuickAdd}
       className={className}
       storageKey={selectedId}

--- a/apps/desktop/src/renderer/src/components/tasks/virtualized-all-tasks-view.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/virtualized-all-tasks-view.tsx
@@ -38,6 +38,7 @@ interface VirtualizedAllTasksViewProps {
   onUpdateTask?: (taskId: string, updates: Partial<Task>) => void
   onToggleSubtaskComplete?: (subtaskId: string) => void
   onTaskClick?: (taskId: string) => void
+  onNoteClick?: (noteId: string) => void
   onQuickAdd: (
     title: string,
     parsedData?: {
@@ -75,6 +76,7 @@ interface VirtualItemRendererProps {
   onUpdateTask?: (taskId: string, updates: Partial<Task>) => void
   onToggleSubtaskComplete?: (subtaskId: string) => void
   onTaskClick?: (taskId: string) => void
+  onNoteClick?: (noteId: string) => void
   isSelectionMode?: boolean
   selectedIds?: Set<string>
   onToggleSelect?: (taskId: string) => void
@@ -98,6 +100,7 @@ const VirtualItemRenderer = memo(
     onUpdateTask,
     onToggleSubtaskComplete,
     onTaskClick,
+    onNoteClick,
     isSelectionMode = false,
     selectedIds,
     onToggleSelect,
@@ -162,6 +165,7 @@ const VirtualItemRenderer = memo(
             onToggleComplete={onToggleComplete}
             onUpdateTask={onUpdateTask}
             onClick={onTaskClick}
+            onNoteClick={onNoteClick}
             isSelectionMode={isSelectionMode}
             isCheckedForSelection={isCheckedForSelection}
             onToggleSelect={onToggleSelect}
@@ -195,6 +199,7 @@ const VirtualItemRenderer = memo(
             onUpdateTask={onUpdateTask}
             onToggleSubtaskComplete={onToggleSubtaskComplete}
             onClick={onTaskClick}
+            onNoteClick={onNoteClick}
             isSelectionMode={isSelectionMode}
             isCheckedForSelection={isCheckedForSelection}
             onToggleSelect={onToggleSelect}
@@ -225,6 +230,7 @@ export const VirtualizedAllTasksView = ({
   onUpdateTask,
   onToggleSubtaskComplete,
   onTaskClick,
+  onNoteClick,
   onQuickAdd,
   className,
   isSelectionMode = false,
@@ -394,6 +400,7 @@ export const VirtualizedAllTasksView = ({
                     onUpdateTask={onUpdateTask}
                     onToggleSubtaskComplete={onToggleSubtaskComplete}
                     onTaskClick={onTaskClick}
+                    onNoteClick={onNoteClick}
                     isSelectionMode={isSelectionMode}
                     selectedIds={selectedIds}
                     onToggleSelect={onToggleSelect}

--- a/apps/desktop/src/renderer/src/pages/tasks.tsx
+++ b/apps/desktop/src/renderer/src/pages/tasks.tsx
@@ -1070,6 +1070,7 @@ export const TasksPage = ({
                 onToggleSubtaskComplete={subtaskManagement.handleCompleteSubtask}
                 onQuickAdd={handleQuickAdd}
                 onTaskClick={handleTaskClick}
+                onNoteClick={(...args) => void handleNoteClick(...args)}
                 selectedTaskId={detailTaskId}
                 isSelectionMode={selection.isSelectionMode}
                 selectedIds={selection.selectedIds}
@@ -1106,6 +1107,7 @@ export const TasksPage = ({
                   onToggleSubtaskComplete={subtaskManagement.handleCompleteSubtask}
                   onQuickAdd={handleQuickAdd}
                   onTaskClick={handleTaskClick}
+                  onNoteClick={(...args) => void handleNoteClick(...args)}
                   selectedTaskId={detailTaskId}
                   isSelectionMode={selection.isSelectionMode}
                   selectedIds={selection.selectedIds}

--- a/apps/docs/src/user-guide/tasks/list-vs-kanban.md
+++ b/apps/docs/src/user-guide/tasks/list-vs-kanban.md
@@ -15,6 +15,9 @@ Default. Tasks render as flat or grouped rows with inline editing of:
 - Project
 - Tags
 
+Tasks linked to notes show a compact note indicator at the end of the list row.
+Hover or focus the row to preview the note title, then click the indicator to open the note.
+
 Rows can be drag-reordered. Multi-select with shift-click for bulk actions.
 
 When grouping is on, group headers show counts and roll up subtask progress.


### PR DESCRIPTION
## Summary
- Add a task-row linked-note indicator that uses `linkedNoteIds` with `sourceNoteId` fallback.
- Show the first note title and `+N` extra count on row hover/focus, with an open-note affordance.
- Wire note-opening callbacks through task list renderers for normal and parent task rows.

## Validation
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project renderer src/components/tasks/drag-drop/task-row.test.tsx src/components/tasks/drag-drop/sortable-parent-task-row.test.tsx`
- `pnpm lint` (passes with existing unrelated warnings)
- `pnpm typecheck`
- `pnpm docs:impact --strict`
- `git diff --check`
- `npx -y react-doctor@latest apps/desktop --verbose --diff` (existing warnings only)
