### PR TITLE
Add shortcut help dialog

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -37,7 +37,8 @@ import {
   useUndoKeyboardShortcut,
   useReminderNotifications,
   useSearchShortcut,
-  useHintActivation
+  useHintActivation,
+  isInputFocused
 } from '@/hooks'
 import { HintModeProvider } from '@/contexts/hint-mode'
 import { HintOverlay, HintIndicator } from '@/components/hint-overlay'
@@ -176,6 +177,8 @@ const AppContent = (): React.JSX.Element => {
   useReminderNotifications() // T231-T233: In-app toast notifications for reminders
   useFolderViewEvents() // Global cache invalidation for folder-view tabs
   const toggleSearch = useCallback(() => setSearchOpen((prev) => !prev), [])
+  const openShortcutsDialog = useCallback(() => setShowShortcutsDialog(true), [])
+  const toggleShortcutsDialog = useCallback(() => setShowShortcutsDialog((prev) => !prev), [])
   useSearchShortcut(toggleSearch)
   useHintActivation()
 
@@ -184,6 +187,29 @@ const AppContent = (): React.JSX.Element => {
     window.addEventListener('memry:open-search', openSearch)
     return () => window.removeEventListener('memry:open-search', openSearch)
   }, [])
+
+  useEffect(() => {
+    window.addEventListener('memry:open-shortcuts', openShortcutsDialog)
+    return () => window.removeEventListener('memry:open-shortcuts', openShortcutsDialog)
+  }, [openShortcutsDialog])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      const isQuestionShortcut =
+        event.key === '?' && !event.metaKey && !event.ctrlKey && !event.altKey
+      const isSlashShortcut = (event.metaKey || event.ctrlKey) && event.key === '/'
+
+      if (!isQuestionShortcut && !isSlashShortcut) return
+      if (isQuestionShortcut && isInputFocused()) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      toggleShortcutsDialog()
+    }
+
+    window.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
+  }, [toggleShortcutsDialog])
 
   useEffect(() => {
     const openTestNote = (
@@ -484,7 +510,7 @@ function App(): React.JSX.Element {
           {/* Last child so paint order puts the chrome overlay above the tab-bar's
               drag-region (OS-level -webkit-app-region hit test picks the topmost
               layer; a drag-region painted over no-drag children eats clicks). */}
-          <WindowControls className="pointer-events-auto fixed top-0 left-0 z-[60] w-[var(--chrome-width)]" />
+          <WindowControls className="pointer-events-auto fixed top-0 start-0 z-[60] w-[var(--chrome-width)]" />
         </SidebarProvider>
         {/* First-run onboarding overlay — shown until user completes or dismisses */}
         {!generalSettingsLoading && !generalSettings.onboardingCompleted && (

--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   ChevronsUp,
   FilePlus,
   FolderPlus,
+  HelpCircle,
   Plus,
   Upload
 } from '@/lib/icons'
@@ -381,6 +382,12 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
     openSettings('account')
   }, [openSettings])
 
+  const handleOpenShortcuts = useCallback(() => {
+    window.dispatchEvent(new CustomEvent('memry:open-shortcuts'))
+  }, [])
+  const shortcutsLabel = 'Open keyboard shortcuts'
+  const shortcutsTooltipLabel = 'Keyboard shortcuts'
+
   return (
     <Sidebar collapsible="offcanvas" {...props}>
       <SidebarHeaderContent />
@@ -410,6 +417,22 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
       </SidebarContent>
       <SidebarFooter className="gap-0 p-2">
         <div className="flex items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleOpenShortcuts}
+                aria-label={shortcutsLabel}
+                title={shortcutsLabel}
+                className="shrink-0 size-7 rounded flex items-center justify-center hover:bg-sidebar-accent text-muted-foreground transition-colors"
+              >
+                <HelpCircle className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-xs">
+              {shortcutsTooltipLabel}
+            </TooltipContent>
+          </Tooltip>
           {authState.status === 'authenticated' ? (
             <div className="shrink-0 w-7 [&>button]:w-7 [&>button]:justify-center">
               <SyncStatus onOpenSettings={handleSyncClick} iconOnly />

--- a/apps/desktop/src/renderer/src/components/keyboard/keyboard-shortcuts-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/keyboard/keyboard-shortcuts-dialog.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { KeyboardShortcutsDialog } from './keyboard-shortcuts-dialog'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string) => {
+      if (key.endsWith('keyboardShortcuts')) return 'Keyboard Shortcuts'
+      if (key.endsWith('press')) return 'Press'
+      if (key.endsWith('toToggleThisDialog')) return 'to open and close this dialog'
+      return key
+    }
+  })
+}))
+
+describe('KeyboardShortcutsDialog', () => {
+  it('renders the full shortcut section catalog', () => {
+    render(<KeyboardShortcutsDialog isOpen onClose={vi.fn()} />)
+
+    for (const section of [
+      'General',
+      'Tabs & Splits',
+      'Inbox',
+      'Journal',
+      'Notes / Editor',
+      'Tasks',
+      'Settings'
+    ]) {
+      expect(screen.getByRole('heading', { name: section })).toBeInTheDocument()
+    }
+  })
+
+  it('renders readable key chips for the global help shortcut', () => {
+    render(<KeyboardShortcutsDialog isOpen onClose={vi.fn()} />)
+
+    const dialog = screen.getByRole('dialog', { name: 'Keyboard Shortcuts' })
+
+    expect(within(dialog).getAllByText('?').length).toBeGreaterThan(0)
+    expect(within(dialog).getAllByText('/').length).toBeGreaterThan(0)
+    expect(within(dialog).getAllByText(/⌘|Ctrl/).length).toBeGreaterThan(0)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/keyboard/keyboard-shortcuts-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/keyboard/keyboard-shortcuts-dialog.tsx
@@ -3,22 +3,26 @@
  * Shows all available keyboard shortcuts
  */
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
 import { isMac } from '@/hooks/use-keyboard-shortcuts-base'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
 
-// =============================================================================
-// TYPES
-// =============================================================================
-
 interface ShortcutDefinition {
-  keys: string[]
+  combos: string[][]
   description: string
+  detail?: string
 }
 
 interface ShortcutGroup {
   title: string
+  description: string
   shortcuts: ShortcutDefinition[]
 }
 
@@ -29,59 +33,173 @@ interface KeyboardShortcutsDialogProps {
   onClose: () => void
 }
 
-// =============================================================================
-// SHORTCUT DEFINITIONS
-// =============================================================================
+const DIALOG_DESCRIPTION =
+  'Fast paths for moving around Memry, capturing thoughts, and processing work.'
+const COMBO_OR_LABEL = 'or'
+const SEQUENCE_THEN_LABEL = 'then'
 
-const getShortcutGroups = (): ShortcutGroup[] => {
+export const getShortcutGroups = (): ShortcutGroup[] => {
   const mod = isMac ? '⌘' : 'Ctrl'
   const shift = isMac ? '⇧' : 'Shift'
   const alt = isMac ? '⌥' : 'Alt'
+  const backspace = isMac ? '⌫' : 'Backspace'
 
   return [
     {
-      title: 'Tab Management',
+      title: 'General',
+      description: 'App-wide navigation and help.',
       shortcuts: [
-        { keys: [mod, 'T'], description: 'New tab' },
-        { keys: [mod, 'W'], description: 'Close tab' },
-        { keys: [mod, shift, 'W'], description: 'Close all tabs' },
-        { keys: [mod, shift, 'T'], description: 'Reopen closed tab' },
-        { keys: ['Ctrl', 'Tab'], description: 'Next tab' },
-        { keys: ['Ctrl', shift, 'Tab'], description: 'Previous tab' },
-        { keys: [mod, '1-8'], description: 'Go to tab by number' },
-        { keys: [mod, '9'], description: 'Go to last tab' },
-        { keys: [mod, shift, 'P'], description: 'Pin/Unpin tab' },
-        { keys: [mod, shift, 'D'], description: 'Duplicate tab' }
+        {
+          combos: [
+            [mod, 'K'],
+            [mod, 'P']
+          ],
+          description: 'Open quick search'
+        },
+        { combos: [[mod, 'N']], description: 'Create a note' },
+        { combos: [[mod, ',']], description: 'Open settings' },
+        { combos: [['?'], [mod, '/']], description: 'Open keyboard shortcuts' },
+        { combos: [[mod, 'Z']], description: 'Undo last task action' },
+        { combos: [[mod, 'B']], description: 'Toggle the sidebar' }
       ]
     },
     {
-      title: 'Split View',
+      title: 'Tabs & Splits',
+      description: 'Move between tabs and panes.',
       shortcuts: [
-        { keys: [mod, '\\'], description: 'Split right' },
-        { keys: [mod, shift, '\\'], description: 'Split down' },
-        { keys: [mod, alt, 'W'], description: 'Close split pane' },
-        { keys: [mod, 'K', mod, '→'], description: 'Focus right pane' },
-        { keys: [mod, 'K', mod, '←'], description: 'Focus left pane' },
-        { keys: [mod, 'K', mod, '↑'], description: 'Focus pane above' },
-        { keys: [mod, 'K', mod, '↓'], description: 'Focus pane below' }
+        { combos: [[mod, 'T']], description: 'Open the new tab menu' },
+        { combos: [[mod, 'W']], description: 'Close tab' },
+        { combos: [[mod, shift, 'W']], description: 'Close all tabs in pane' },
+        { combos: [['Ctrl', 'Tab']], description: 'Next tab' },
+        { combos: [['Ctrl', shift, 'Tab']], description: 'Previous tab' },
+        {
+          combos: [
+            [mod, '1-8'],
+            [mod, '9']
+          ],
+          description: 'Jump to tab'
+        },
+        { combos: [[mod, shift, 'P']], description: 'Pin or unpin tab' },
+        { combos: [[mod, shift, 'D']], description: 'Duplicate tab' },
+        { combos: [[mod, '\\']], description: 'Split right' },
+        { combos: [[mod, shift, '\\']], description: 'Split down' },
+        { combos: [[mod, alt, 'W']], description: 'Close split pane' },
+        { combos: [[mod, 'K', 'then', mod, '←/→/↑/↓']], description: 'Focus another pane' },
+        { combos: [[mod, 'K', 'then', mod, shift, '←/→']], description: 'Move tab to pane' },
+        { combos: [[mod, 'K', 'then', 'M']], description: 'Maximize current pane' }
       ]
     },
     {
-      title: 'Navigation',
+      title: 'Inbox',
+      description: 'Process captured items quickly.',
       shortcuts: [
-        { keys: [mod, 'P'], description: 'Quick open' },
-        { keys: [mod, ','], description: 'Settings' },
-        { keys: [mod, 'F'], description: 'Search in view' },
-        { keys: [mod, shift, 'F'], description: 'Search everywhere' },
-        { keys: ['?'], description: 'Show shortcuts' }
+        { combos: [['↓'], ['J']], description: 'Next item' },
+        { combos: [['↑'], ['K']], description: 'Previous item' },
+        { combos: [['Home'], ['End']], description: 'First or last item' },
+        { combos: [['PageUp'], ['PageDown']], description: 'Jump by page' },
+        { combos: [['Space']], description: 'Toggle preview panel' },
+        { combos: [['X']], description: 'Select item' },
+        { combos: [[mod, 'A']], description: 'Select all visible items' },
+        { combos: [['Esc']], description: 'Clear selection or close quick file' },
+        { combos: [['.'], ['F']], description: 'Open quick file' },
+        { combos: [['1-5']], description: 'Choose a quick-file result' },
+        { combos: [['Delete'], [backspace]], description: 'Archive selected item' },
+        { combos: [['O']], description: 'Open original link' },
+        { combos: [['R']], description: 'Refresh inbox' },
+        { combos: [[mod, 'Enter']], description: 'Confirm filing panel' }
+      ]
+    },
+    {
+      title: 'Journal',
+      description: 'Navigate journal views and focus the writing area.',
+      shortcuts: [
+        { combos: [['Esc']], description: 'Return from month or year view' },
+        { combos: [[mod, '\\']], description: 'Toggle full-width journal' },
+        { combos: [[mod, 'F']], description: 'Find in journal' },
+        { combos: [[mod, 'B']], description: 'Bold selected text' },
+        { combos: [[mod, 'I']], description: 'Italic selected text' },
+        { combos: [[mod, 'U']], description: 'Underline selected text' },
+        { combos: [[mod, 'K']], description: 'Add or edit link' }
+      ]
+    },
+    {
+      title: 'Notes / Editor',
+      description: 'Write, format, and search notes.',
+      shortcuts: [
+        { combos: [[mod, 'N']], description: 'Create a note' },
+        { combos: [[mod, 'S']], description: 'Save current note' },
+        { combos: [[mod, 'F']], description: 'Find in note' },
+        { combos: [[mod, 'B']], description: 'Bold' },
+        { combos: [[mod, 'I']], description: 'Italic' },
+        { combos: [[mod, 'U']], description: 'Underline' },
+        { combos: [[mod, 'K']], description: 'Add or edit link' },
+        { combos: [['/']], description: 'Open editor command menu' },
+        { combos: [['Esc']], description: 'Close editor overlays' }
+      ]
+    },
+    {
+      title: 'Tasks',
+      description: 'Filter, select, and complete tasks.',
+      shortcuts: [
+        { combos: [[shift, 'F']], description: 'Clear visible filters' },
+        { combos: [[mod, 'A']], description: 'Select all visible tasks' },
+        { combos: [['Esc']], description: 'Clear task selection' },
+        { combos: [[mod, 'Enter']], description: 'Complete selected tasks' },
+        { combos: [[mod, backspace]], description: 'Delete selected tasks' },
+        { combos: [['R']], description: 'Configure repeat on focused task' },
+        { combos: [[shift, 'S']], description: 'Skip repeat occurrence' },
+        { combos: [[shift, 'X']], description: 'Stop repeating task' }
+      ]
+    },
+    {
+      title: 'Settings',
+      description: 'Open settings and customize shortcuts.',
+      shortcuts: [
+        { combos: [[mod, ',']], description: 'Open settings' },
+        { combos: [['Shortcuts tab']], description: 'Customize keyboard shortcuts' },
+        { combos: [['Click row']], description: 'Record a new shortcut' },
+        { combos: [['Esc']], description: 'Cancel shortcut recording' },
+        { combos: [['Reset']], description: 'Restore a shortcut default' }
       ]
     }
   ]
 }
 
-// =============================================================================
-// COMPONENT
-// =============================================================================
+const ShortcutCombo = ({ keys }: { keys: string[] }): React.JSX.Element => (
+  <span className="inline-flex items-center gap-1">
+    {keys.map((key, index) =>
+      key === 'then' ? (
+        <span key={`${key}-${index}`} className="px-0.5 text-[11px] text-muted-foreground/70">
+          {SEQUENCE_THEN_LABEL}
+        </span>
+      ) : (
+        <kbd
+          key={`${key}-${index}`}
+          className={cn(
+            'inline-flex min-w-6 items-center justify-center rounded border border-border',
+            'bg-background px-1.5 py-0.5 font-mono text-[11px] font-medium leading-4',
+            'text-foreground shadow-[inset_0_-1px_0_rgba(0,0,0,0.08)]'
+          )}
+        >
+          {key}
+        </kbd>
+      )
+    )}
+  </span>
+)
+
+const ShortcutCombos = ({ combos }: { combos: string[][] }): React.JSX.Element => (
+  <div className="flex flex-wrap items-center justify-end gap-1.5">
+    {combos.map((keys, index) => (
+      <span key={`${keys.join('-')}-${index}`} className="inline-flex items-center gap-1.5">
+        {index > 0 && (
+          <span className="text-[11px] text-muted-foreground/60">{COMBO_OR_LABEL}</span>
+        )}
+        <ShortcutCombo keys={keys} />
+      </span>
+    ))}
+  </div>
+)
 
 /**
  * Dialog showing all keyboard shortcuts
@@ -95,52 +213,56 @@ export const KeyboardShortcutsDialog = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-w-2xl max-h-[80vh] overflow-auto">
-        <DialogHeader>
-          <DialogTitle>
+      <DialogContent className="max-h-[86vh] max-w-[960px] gap-0 overflow-hidden p-0">
+        <DialogHeader className="border-b border-border bg-muted/20 px-6 py-5 text-start">
+          <DialogTitle className="text-xl">
             {tPhaseF('phaseF.componentsKeyboardKeyboardShortcutsDialog.keyboardShortcuts')}
           </DialogTitle>
+          <DialogDescription>{DIALOG_DESCRIPTION}</DialogDescription>
         </DialogHeader>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-4">
-          {shortcutGroups.map((group) => (
-            <div key={group.title}>
-              <h3 className="font-semibold text-sm text-foreground mb-3">{group.title}</h3>
-              <div className="space-y-2">
-                {group.shortcuts.map((shortcut) => (
-                  <div
-                    key={shortcut.description}
-                    className="flex items-center justify-between gap-4"
-                  >
-                    <span className="text-sm text-muted-foreground">{shortcut.description}</span>
-                    <div className="flex gap-1 flex-shrink-0">
-                      {shortcut.keys.map((key) => (
-                        <kbd
-                          key={key}
-                          className={cn(
-                            'px-1.5 py-0.5 text-xs font-mono',
-                            'bg-muted',
-                            'border border-border',
-                            'rounded'
-                          )}
-                        >
-                          {key}
-                        </kbd>
-                      ))}
+        <div className="max-h-[calc(86vh-8.75rem)] overflow-y-auto px-6 py-5">
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {shortcutGroups.map((group) => (
+              <section
+                key={group.title}
+                className="rounded-lg border border-border bg-card/60 p-4 shadow-sm"
+              >
+                <div className="mb-3">
+                  <h3 className="text-sm font-semibold text-foreground">{group.title}</h3>
+                  <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                    {group.description}
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  {group.shortcuts.map((shortcut) => (
+                    <div
+                      key={shortcut.description}
+                      className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-md px-2 py-1.5 hover:bg-muted/45"
+                    >
+                      <div className="min-w-0">
+                        <p className="text-sm leading-5 text-foreground">{shortcut.description}</p>
+                        {shortcut.detail && (
+                          <p className="text-xs leading-5 text-muted-foreground">
+                            {shortcut.detail}
+                          </p>
+                        )}
+                      </div>
+                      <ShortcutCombos combos={shortcut.combos} />
                     </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
         </div>
 
-        <div className="mt-6 pt-4 border-t border-border">
-          <p className="text-xs text-muted-foreground text-center">
-            {tPhaseF('phaseF.componentsKeyboardKeyboardShortcutsDialog.press')}
-            <kbd className="px-1 py-0.5 bg-muted rounded text-xs">?</kbd>{' '}
+        <div className="flex items-center justify-center gap-2 border-t border-border bg-muted/20 px-6 py-3 text-xs text-muted-foreground">
+          <span>{tPhaseF('phaseF.componentsKeyboardKeyboardShortcutsDialog.press')}</span>
+          <ShortcutCombos combos={[[isMac ? '⌘' : 'Ctrl', '/'], ['?']]} />
+          <span>
             {tPhaseF('phaseF.componentsKeyboardKeyboardShortcutsDialog.toToggleThisDialog')}
-          </p>
+          </span>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/desktop/src/renderer/src/hooks/use-inbox-keyboard.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-inbox-keyboard.ts
@@ -6,13 +6,11 @@ import { getI18n } from 'react-i18next'
 
 export interface UseInboxKeyboardOptions {
   enabled: boolean
-  isShortcutsModalOpen: boolean
   isDetailPanelOpen: boolean
   isBulkFilePanelOpen: boolean
   isInBulkMode: boolean
   focusedItemId: string | null
   items: InboxItemListItem[]
-  onOpenShortcutsModal: () => void
   onRefresh: () => void
   onArchiveFocusedItem: (itemId: string, nextItemId: string | null) => void
   onOpenBulkArchiveDialog: () => void
@@ -22,13 +20,11 @@ export interface UseInboxKeyboardOptions {
 export function useInboxKeyboard(options: UseInboxKeyboardOptions): void {
   const {
     enabled,
-    isShortcutsModalOpen,
     isDetailPanelOpen,
     isBulkFilePanelOpen,
     isInBulkMode,
     focusedItemId,
     items,
-    onOpenShortcutsModal,
     onRefresh,
     onArchiveFocusedItem,
     onOpenBulkArchiveDialog,
@@ -39,13 +35,7 @@ export function useInboxKeyboard(options: UseInboxKeyboardOptions): void {
     if (!enabled) return
 
     const handleGlobalKeyDown = (e: KeyboardEvent): void => {
-      if (isShortcutsModalOpen || isDetailPanelOpen || isBulkFilePanelOpen) return
-
-      if (e.key === '?' || ((e.metaKey || e.ctrlKey) && e.key === '/')) {
-        e.preventDefault()
-        onOpenShortcutsModal()
-        return
-      }
+      if (isDetailPanelOpen || isBulkFilePanelOpen) return
 
       if (isInputFocused()) return
 
@@ -91,13 +81,11 @@ export function useInboxKeyboard(options: UseInboxKeyboardOptions): void {
     return () => window.removeEventListener('keydown', handleGlobalKeyDown)
   }, [
     enabled,
-    isShortcutsModalOpen,
     isDetailPanelOpen,
     isBulkFilePanelOpen,
     isInBulkMode,
     focusedItemId,
     items,
-    onOpenShortcutsModal,
     onRefresh,
     onArchiveFocusedItem,
     onOpenBulkArchiveDialog,

--- a/apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx
@@ -13,7 +13,6 @@ import { BulkFilePanel } from '@/components/bulk/bulk-file-panel'
 import { BulkTagPopover } from '@/components/bulk/bulk-tag-popover'
 import { ArchiveConfirmationDialog } from '@/components/bulk/archive-confirmation-dialog'
 import { EmptyState } from '@/components/empty-state/empty-state'
-import { KeyboardShortcutsModal } from '@/components/keyboard-shortcuts-modal'
 import { inboxService } from '@/services/inbox-service'
 import type { ReminderMetadata, InboxItemType } from '@memry/contracts/inbox-api'
 import { detectClusters, getClusterKey } from '@/lib/ai-clustering'
@@ -49,7 +48,7 @@ export function InboxListView({
   selectedTypes,
   showSnoozedItems,
   focusItemId = null,
-  focusToken = null
+  focusToken
 }: InboxListViewProps): React.JSX.Element {
   const { t } = useT('inbox')
   const queryClient = useQueryClient()
@@ -80,10 +79,10 @@ export function InboxListView({
   const [isBulkFilePanelOpen, setIsBulkFilePanelOpen] = useState(false)
   const [isBulkTagPopoverOpen, setIsBulkTagPopoverOpen] = useState(false)
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false)
-  const [isShortcutsModalOpen, setIsShortcutsModalOpen] = useState(false)
   const [focusedItemIdState, setFocusedItemIdState] = useState<string | null>(null)
   const emptyStateDelayRef = useRef<number | null>(null)
   const lastConsumedFocusTokenRef = useRef<number | null>(null)
+  const focusSequence = focusToken ?? null
 
   const isDetailPanelOpen = activeDetailItemId !== null
   const isInBulkMode = selectedItemIds.size > 0
@@ -132,15 +131,15 @@ export function InboxListView({
   // user closes the panel, and so switching tabs away and back does not
   // re-trigger after consumption.
   useEffect(() => {
-    if (!focusItemId || focusToken === null) return
-    if (lastConsumedFocusTokenRef.current === focusToken) return
-    lastConsumedFocusTokenRef.current = focusToken
+    if (!focusItemId || focusSequence === null) return
+    if (lastConsumedFocusTokenRef.current === focusSequence) return
+    lastConsumedFocusTokenRef.current = focusSequence
     const focusTimer = window.setTimeout(() => {
       setActiveDetailItemId(focusItemId)
       setFocusedItemIdState(focusItemId)
     }, 0)
     return () => window.clearTimeout(focusTimer)
-  }, [focusItemId, focusToken])
+  }, [focusItemId, focusSequence])
 
   // Computed values
   const selectedItems = useMemo(
@@ -215,13 +214,11 @@ export function InboxListView({
   // === KEYBOARD SHORTCUTS ===
   useInboxKeyboard({
     enabled: true,
-    isShortcutsModalOpen,
     isDetailPanelOpen,
     isBulkFilePanelOpen,
     isInBulkMode,
     focusedItemId,
     items,
-    onOpenShortcutsModal: () => setIsShortcutsModalOpen(true),
     onRefresh: () => refetch(),
     onArchiveFocusedItem: (itemId, nextItemId) => void archiveWithAnimation(itemId, nextItemId),
     onOpenBulkArchiveDialog: () => setIsArchiveDialogOpen(true),
@@ -924,11 +921,6 @@ export function InboxListView({
           itemCount={selectedCount}
           onConfirm={handleBulkArchiveConfirm}
           onCancel={() => setIsArchiveDialogOpen(false)}
-        />
-
-        <KeyboardShortcutsModal
-          isOpen={isShortcutsModalOpen}
-          onClose={() => setIsShortcutsModalOpen(false)}
         />
       </div>
 

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -6,87 +6,91 @@ Default shortcuts. Every entry in the Navigation, Tabs, Editor, and View categor
 
 ## Navigation
 
-| Action | Shortcut |
-| --- | --- |
-| New note | <kbd>⌘</kbd>+<kbd>N</kbd> |
-| New task | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>T</kbd> |
-| Go to Inbox | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>I</kbd> |
-| Go to Notes | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>E</kbd> |
-| Go to Tasks | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>K</kbd> |
-| Open search | <kbd>⌘</kbd>+<kbd>F</kbd> |
-| Open settings | <kbd>⌘</kbd>+<kbd>,</kbd> |
+| Action        | Shortcut                               |
+| ------------- | -------------------------------------- |
+| New note      | <kbd>⌘</kbd>+<kbd>N</kbd>              |
+| New task      | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>T</kbd> |
+| Go to Inbox   | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>I</kbd> |
+| Go to Notes   | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>E</kbd> |
+| Go to Tasks   | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>K</kbd> |
+| Open search   | <kbd>⌘</kbd>+<kbd>F</kbd>              |
+| Open settings | <kbd>⌘</kbd>+<kbd>,</kbd>              |
 
 ## Tabs
 
-| Action | Shortcut |
-| --- | --- |
-| New tab | <kbd>⌘</kbd>+<kbd>T</kbd> |
-| Close tab | <kbd>⌘</kbd>+<kbd>W</kbd> |
-| Close all tabs | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>W</kbd> |
-| Reopen closed tab | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>T</kbd> |
-| Next tab | <kbd>Ctrl</kbd>+<kbd>Tab</kbd> |
-| Previous tab | <kbd>Ctrl</kbd>+<kbd>⇧</kbd>+<kbd>Tab</kbd> |
-| Go to tab 1–8 | <kbd>⌘</kbd>+<kbd>1</kbd> … <kbd>⌘</kbd>+<kbd>8</kbd> |
-| Go to last tab | <kbd>⌘</kbd>+<kbd>9</kbd> |
-| Pin / unpin tab | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>P</kbd> |
-| Duplicate tab | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>D</kbd> |
+| Action            | Shortcut                                              |
+| ----------------- | ----------------------------------------------------- |
+| New tab           | <kbd>⌘</kbd>+<kbd>T</kbd>                             |
+| Close tab         | <kbd>⌘</kbd>+<kbd>W</kbd>                             |
+| Close all tabs    | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>W</kbd>                |
+| Reopen closed tab | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>T</kbd>                |
+| Next tab          | <kbd>Ctrl</kbd>+<kbd>Tab</kbd>                        |
+| Previous tab      | <kbd>Ctrl</kbd>+<kbd>⇧</kbd>+<kbd>Tab</kbd>           |
+| Go to tab 1–8     | <kbd>⌘</kbd>+<kbd>1</kbd> … <kbd>⌘</kbd>+<kbd>8</kbd> |
+| Go to last tab    | <kbd>⌘</kbd>+<kbd>9</kbd>                             |
+| Pin / unpin tab   | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>P</kbd>                |
+| Duplicate tab     | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>D</kbd>                |
 
 ## Split View
 
 Some commands use a chord — press <kbd>⌘</kbd>+<kbd>K</kbd>, release, then press the next key.
 
-| Action | Shortcut |
-| --- | --- |
-| Split right | <kbd>⌘</kbd>+<kbd>\\</kbd> |
-| Split down | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>\\</kbd> |
-| Close split pane | <kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>W</kbd> |
-| Focus right pane | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>⌘</kbd>+<kbd>→</kbd> |
-| Focus left pane | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>⌘</kbd>+<kbd>←</kbd> |
-| Focus pane above | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>⌘</kbd>+<kbd>↑</kbd> |
-| Focus pane below | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>⌘</kbd>+<kbd>↓</kbd> |
-| Toggle maximize pane | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>M</kbd> |
-| Reset split ratios | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>=</kbd> |
+| Action               | Shortcut                                                  |
+| -------------------- | --------------------------------------------------------- |
+| Split right          | <kbd>⌘</kbd>+<kbd>\\</kbd>                                |
+| Split down           | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>\\</kbd>                   |
+| Close split pane     | <kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>W</kbd>                    |
+| Focus right pane     | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>⌘</kbd>+<kbd>→</kbd> |
+| Focus left pane      | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>⌘</kbd>+<kbd>←</kbd> |
+| Focus pane above     | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>⌘</kbd>+<kbd>↑</kbd> |
+| Focus pane below     | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>⌘</kbd>+<kbd>↓</kbd> |
+| Toggle maximize pane | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>M</kbd>              |
+| Reset split ratios   | <kbd>⌘</kbd>+<kbd>K</kbd>, then <kbd>=</kbd>              |
 
 A chord indicator briefly flashes when the prefix is active.
 
 ## Editor
 
-| Action | Shortcut |
-| --- | --- |
+| Action              | Shortcut                  |
+| ------------------- | ------------------------- |
 | Save (manual flush) | <kbd>⌘</kbd>+<kbd>S</kbd> |
-| Bold | <kbd>⌘</kbd>+<kbd>B</kbd> |
-| Italic | <kbd>⌘</kbd>+<kbd>I</kbd> |
-| Underline | <kbd>⌘</kbd>+<kbd>U</kbd> |
-| Insert wiki link | Type `[[` |
-| Open block menu | Type `/` |
-| Find in page | <kbd>⌘</kbd>+<kbd>F</kbd> |
+| Bold                | <kbd>⌘</kbd>+<kbd>B</kbd> |
+| Italic              | <kbd>⌘</kbd>+<kbd>I</kbd> |
+| Underline           | <kbd>⌘</kbd>+<kbd>U</kbd> |
+| Insert wiki link    | Type `[[`                 |
+| Open block menu     | Type `/`                  |
+| Find in page        | <kbd>⌘</kbd>+<kbd>F</kbd> |
 
 ## View
 
-| Action | Shortcut |
-| --- | --- |
-| Toggle sidebar | <kbd>⌘</kbd>+<kbd>B</kbd> |
+| Action                         | Shortcut                                  |
+| ------------------------------ | ----------------------------------------- |
+| Toggle sidebar                 | <kbd>⌘</kbd>+<kbd>B</kbd>                 |
 | Show keyboard shortcuts dialog | <kbd>⌘</kbd>+<kbd>/</kbd> or <kbd>?</kbd> |
+
+The same shortcut reference opens from the question-mark button in the sidebar footer.
+It groups shortcuts into General, Tabs & Splits, Inbox, Journal, Notes / Editor, Tasks,
+and Settings sections so you can scan by workflow.
 
 ## Inbox
 
 When the inbox or a card has focus:
 
-| Action | Shortcut |
-| --- | --- |
-| Refresh | <kbd>R</kbd> |
-| Open source URL | <kbd>O</kbd> |
-| Archive | <kbd>Delete</kbd> or <kbd>Backspace</kbd> |
+| Action          | Shortcut                                  |
+| --------------- | ----------------------------------------- |
+| Refresh         | <kbd>R</kbd>                              |
+| Open source URL | <kbd>O</kbd>                              |
+| Archive         | <kbd>Delete</kbd> or <kbd>Backspace</kbd> |
 
 ## Hint Mode
 
 Hint mode overlays numeric badges on interactive elements so you can act without the mouse.
 
-| Action | Shortcut |
-| --- | --- |
+| Action             | Shortcut                                  |
+| ------------------ | ----------------------------------------- |
 | Activate hint mode | <kbd>F</kbd> or <kbd>⌥</kbd>+<kbd>F</kbd> |
-| Pick a target | Type the number shown |
-| Exit | <kbd>Esc</kbd> |
+| Pick a target      | Type the number shown                     |
+| Exit               | <kbd>Esc</kbd>                            |
 
 ## Global Undo (Tasks)
 


### PR DESCRIPTION
## Summary
- add a global shortcut help dialog opened from the sidebar footer, ? key, and Cmd/Ctrl+/
- expand the help dialog into General, Tabs & Splits, Inbox, Journal, Notes / Editor, Tasks, and Settings sections
- route Inbox shortcut help through the global dialog and remove the local modal wiring
- document the sidebar question-mark help entry in the keyboard shortcuts guide

## Validation
- pnpm --filter @memry/desktop test:renderer
- pnpm --filter @memry/desktop typecheck:web
- pnpm lint:desktop (passes with 3 existing warnings in telemetry/settings files)
- pnpm docs:impact --strict
- pnpm docs:impact --base fa383df585fbe083654190a346c3d1c82887531a --strict
- pnpm docs:build
- pre-push: docs impact/build, contract and architecture checks, ipc check, desktop typecheck, full desktop test