### PR TITLE
Fix markdown task block reload

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
@@ -1,0 +1,164 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useEditorSync } from './use-editor-sync'
+import { fetchLinkPreview } from '@/lib/url-metadata'
+
+vi.mock('@/lib/url-metadata', () => ({
+  fetchLinkPreview: vi.fn().mockResolvedValue({
+    domain: 'example.com',
+    title: 'Example',
+    favicon: 'https://example.com/favicon.ico'
+  })
+}))
+
+vi.mock('../file-block', () => ({
+  FILE_BLOCK_REGEX: /<!-- file:(\{[^}]+\}) -->/g,
+  createFileBlockContent: vi.fn((props) => ({ type: 'file', props })),
+  serializeFileBlock: vi.fn((props) => `<!-- file:${JSON.stringify(props)} -->`)
+}))
+
+function createEditor(parsedBlocks: any[] = []) {
+  let document = [{ id: 'initial', type: 'paragraph', props: {}, content: [], children: [] }]
+
+  return {
+    get document() {
+      return document
+    },
+    replaceBlocks: vi.fn((_current: any[], next: any[]) => {
+      document = next
+    }),
+    tryParseMarkdownToBlocks: vi.fn().mockResolvedValue(parsedBlocks),
+    tryParseHTMLToBlocks: vi.fn().mockResolvedValue(parsedBlocks),
+    blocksToMarkdownLossy: vi.fn().mockResolvedValue(''),
+    updateBlock: vi.fn((block: any, update: any) => {
+      if ('content' in update) block.content = update.content
+      if ('props' in update) block.props = { ...block.props, ...update.props }
+    })
+  }
+}
+
+function collectIds(blocks: any[]): string[] {
+  const ids: string[] = []
+
+  for (const block of blocks) {
+    if ('id' in block) ids.push(block.id ?? '')
+    if (Array.isArray(block.children)) ids.push(...collectIds(block.children))
+  }
+
+  return ids
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useEditorSync', () => {
+  it('hydrates link mentions without crashing on non-array block content', async () => {
+    const nestedMention = {
+      id: 'nested-mention',
+      type: 'paragraph',
+      props: {},
+      content: [
+        {
+          type: 'linkMention',
+          props: { url: 'https://example.com', domain: 'example.com', title: 'Example' }
+        }
+      ],
+      children: []
+    }
+    const editor = createEditor([
+      { id: 'string-content', type: 'paragraph', props: {}, content: 'plain string', children: [] },
+      {
+        id: 'table-content',
+        type: 'table',
+        props: {},
+        content: { type: 'tableContent', rows: [] },
+        children: []
+      },
+      {
+        id: 'task-content-none',
+        type: 'taskBlock',
+        props: { taskId: 'task-1', title: 'Task', checked: false, parentTaskId: '' },
+        content: undefined,
+        children: [nestedMention]
+      }
+    ])
+
+    renderHook(() =>
+      useEditorSync({
+        editor,
+        initialContent: 'content',
+        contentType: 'markdown'
+      })
+    )
+
+    await waitFor(() => expect(fetchLinkPreview).toHaveBeenCalledWith('https://example.com'))
+    await waitFor(() =>
+      expect(editor.updateBlock).toHaveBeenCalledWith(nestedMention, expect.anything())
+    )
+  })
+
+  it('does not mark markdown content ready when parsing fails', async () => {
+    vi.useFakeTimers()
+
+    const editor = createEditor()
+    editor.tryParseMarkdownToBlocks.mockRejectedValueOnce(new Error('parse failed'))
+    const onMarkdownChange = vi.fn()
+
+    const { result } = renderHook(() =>
+      useEditorSync({
+        editor,
+        initialContent: '- [ ] broken task',
+        contentType: 'markdown',
+        onMarkdownChange
+      })
+    )
+
+    await waitFor(() => expect(editor.tryParseMarkdownToBlocks).toHaveBeenCalled())
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(result.current.isContentReadyRef.current).toBe(false)
+
+    act(() => {
+      result.current.handleChange()
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(onMarkdownChange).not.toHaveBeenCalled()
+  })
+
+  it('strips empty parsed ids before replacing converted task blocks', async () => {
+    const editor = createEditor([
+      {
+        id: '',
+        type: 'checkListItem',
+        props: { isChecked: false },
+        content: [{ type: 'text', text: 'Sync v1 {task:task-1}', styles: {} }],
+        children: [
+          {
+            id: '',
+            type: 'paragraph',
+            props: {},
+            content: [{ type: 'text', text: 'Nested note', styles: {} }],
+            children: []
+          }
+        ]
+      }
+    ])
+
+    renderHook(() =>
+      useEditorSync({
+        editor,
+        initialContent: '- [ ] Sync v1 {task:task-1}',
+        contentType: 'markdown'
+      })
+    )
+
+    await waitFor(() => expect(editor.replaceBlocks).toHaveBeenCalled())
+
+    const [, nextBlocks] = editor.replaceBlocks.mock.calls[0]
+    expect(collectIds(nextBlocks)).not.toContain('')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
@@ -11,7 +11,11 @@ import {
 import { normalizeHashTags, extractInlineTags } from '../hash-tag'
 import { normalizeTaskBlocks } from '../task-block/task-block-utils'
 import { FILE_BLOCK_REGEX, createFileBlockContent, serializeFileBlock } from '../file-block'
-import { parseMarkdownPreservingBlanks, serializeBlocksPreservingBlanks } from '../markdown-utils'
+import {
+  parseMarkdownPreservingBlanks,
+  sanitizeBlockIds,
+  serializeBlocksPreservingBlanks
+} from '../markdown-utils'
 import { createLinkMentionContent } from '../link-mention'
 import { fetchLinkPreview } from '@/lib/url-metadata'
 import type { HeadingInfo } from '../types'
@@ -24,12 +28,14 @@ function hydrateLinkMentionFavicons(editor: any): void {
 
   const walk = (blocks: any[]): void => {
     for (const block of blocks) {
-      const content = (block.content ?? []) as any[]
-      content.forEach((c: any, i: number) => {
-        if (c.type === 'linkMention' && c.props?.url && !c.props.favicon) {
-          mentions.push({ block, index: i, url: c.props.url })
-        }
-      })
+      const content = block.content
+      if (Array.isArray(content)) {
+        content.forEach((c: any, i: number) => {
+          if (c.type === 'linkMention' && c.props?.url && !c.props.favicon) {
+            mentions.push({ block, index: i, url: c.props.url })
+          }
+        })
+      }
       if (block.children?.length) walk(block.children)
     }
   }
@@ -39,7 +45,8 @@ function hydrateLinkMentionFavicons(editor: any): void {
   for (const { block, index, url } of mentions) {
     fetchLinkPreview(url)
       .then((metadata) => {
-        const current = (block.content ?? []) as any[]
+        const current = block.content
+        if (!Array.isArray(current)) return
         if (current[index]?.type !== 'linkMention') return
         const updated = [...current]
         updated[index] = createLinkMentionContent(
@@ -130,6 +137,7 @@ export function useEditorSync({
     }
 
     async function loadContent(): Promise<void> {
+      let loadedSuccessfully = false
       try {
         if (typeof initialContent === 'string' && initialContent.trim()) {
           try {
@@ -178,8 +186,10 @@ export function useEditorSync({
               lastNormalizedTagsRef.current = noteTags.slice().sort().join(',')
             }
 
+            normalizedBlocks = sanitizeBlockIds(normalizedBlocks)
             editor.replaceBlocks(editor.document, normalizedBlocks)
             hydrateLinkMentionFavicons(editor)
+            loadedSuccessfully = true
           } catch (error) {
             log.error(`Failed to parse ${contentType} content`, error)
           }
@@ -195,11 +205,17 @@ export function useEditorSync({
             lastNormalizedTagsRef.current = noteTags.slice().sort().join(',')
           }
 
+          normalizedBlocks = sanitizeBlockIds(normalizedBlocks)
           editor.replaceBlocks(editor.document, normalizedBlocks)
+          loadedSuccessfully = true
+        } else {
+          loadedSuccessfully = true
         }
       } finally {
-        isContentReadyRef.current = true
-        if (!cancelled) {
+        if (loadedSuccessfully) {
+          isContentReadyRef.current = true
+        }
+        if (!cancelled && loadedSuccessfully) {
           if (onHeadingsChange) {
             const headings = extractHeadings(editor.document as Block[])
             onHeadingsChange(headings)

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+import { parseMarkdownPreservingBlanks, sanitizeBlockIds } from './markdown-utils'
+
+function collectIds(blocks: Array<{ id?: string; children?: unknown[] }>): string[] {
+  const ids: string[] = []
+
+  for (const block of blocks) {
+    if ('id' in block) ids.push(block.id ?? '')
+    if (Array.isArray(block.children)) {
+      ids.push(...collectIds(block.children as Array<{ id?: string; children?: unknown[] }>))
+    }
+  }
+
+  return ids
+}
+
+describe('parseMarkdownPreservingBlanks', () => {
+  it('does not create blank-line placeholder blocks with empty ids', async () => {
+    let id = 0
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) =>
+        markdown
+          .split('\n')
+          .filter((line) => line.trim())
+          .map((line) => ({
+            id: `parsed-${++id}`,
+            type: line.trimStart().startsWith('- [') ? 'checkListItem' : 'paragraph',
+            props: line.includes('[x]') ? { isChecked: true } : { isChecked: false },
+            content: [{ type: 'text', text: line.trim(), styles: {} }],
+            children: []
+          }))
+      )
+    }
+
+    const blocks = await parseMarkdownPreservingBlanks(
+      editor,
+      [
+        'Intro',
+        '',
+        '',
+        '- [ ] Parent task {task:parent-1}',
+        '  - [x] Child task {task:child-1}'
+      ].join('\n')
+    )
+
+    expect(collectIds(blocks as any[])).not.toContain('')
+  })
+})
+
+describe('sanitizeBlockIds', () => {
+  it('removes empty ids recursively and preserves valid ids', () => {
+    const blocks = [
+      {
+        id: '',
+        type: 'taskBlock',
+        props: { taskId: 'task-1', title: 'Parent', checked: false, parentTaskId: '' },
+        content: undefined,
+        children: [
+          {
+            id: '',
+            type: 'paragraph',
+            props: {},
+            content: [],
+            children: []
+          },
+          {
+            id: 'valid-child',
+            type: 'paragraph',
+            props: {},
+            content: [],
+            children: []
+          }
+        ]
+      }
+    ]
+
+    const sanitized = sanitizeBlockIds(blocks as any[])
+
+    expect(collectIds(sanitized as any[])).toEqual(['valid-child'])
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
@@ -17,6 +17,36 @@ export function isEmptyParagraph(block: Block): boolean {
   return !content || content.length === 0
 }
 
+export function sanitizeBlockIds(blocks: Block[]): Block[] {
+  let didChange = false
+
+  const sanitizeBlock = (block: Block): Block => {
+    let nextBlock = block
+    const id = (block as { id?: unknown }).id
+
+    if (id !== undefined && (typeof id !== 'string' || id.length === 0)) {
+      const rest = { ...(block as Block & { id?: unknown }) }
+      delete rest.id
+      nextBlock = rest as Block
+      didChange = true
+    }
+
+    if (Array.isArray(block.children) && block.children.length > 0) {
+      const nextChildren = block.children.map((child) => sanitizeBlock(child as Block))
+      const childrenChanged = nextChildren.some((child, index) => child !== block.children[index])
+      if (childrenChanged) {
+        nextBlock = { ...nextBlock, children: nextChildren } as Block
+        didChange = true
+      }
+    }
+
+    return nextBlock
+  }
+
+  const nextBlocks = blocks.map(sanitizeBlock)
+  return didChange ? nextBlocks : blocks
+}
+
 export async function parseMarkdownPreservingBlanks(
   editor: any,
   markdown: string
@@ -55,7 +85,6 @@ export async function parseMarkdownPreservingBlanks(
               type: 'paragraph',
               content: [],
               children: [],
-              id: '',
               props: {}
             } as unknown as Block)
           }

--- a/apps/desktop/tests/e2e/inline-subtasks.e2e.ts
+++ b/apps/desktop/tests/e2e/inline-subtasks.e2e.ts
@@ -73,6 +73,22 @@ async function waitForTaskBlockCount(page, expected: number, timeout = 8000) {
     .toBe(expected)
 }
 
+async function expectEditorToContainVisibleText(page, text: string): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const editor = page.locator('[aria-label="Rich text editor"]').first()
+        const textContent = (await editor.textContent()) ?? ''
+        const inputValues = await editor
+          .locator('input')
+          .evaluateAll((inputs) => inputs.map((input) => (input as HTMLInputElement).value))
+        return textContent.includes(text) || inputValues.some((value) => value.includes(text))
+      },
+      { timeout: 8000, intervals: [200, 400, 800] }
+    )
+    .toBe(true)
+}
+
 // Create a real DB task via IPC and return its id. We make tasks via the
 // existing tasks-handlers IPC so the rows match what convertCheckboxToTask
 // would create on the live edit path.
@@ -365,6 +381,102 @@ test.describe('Inline Subtasks', () => {
     const editorText = await page.locator('[aria-label="Rich text editor"]').first().textContent()
     expect(editorText).toContain(parentTitle)
     expect(editorText).toContain(subTitle)
+  })
+
+  test('markdown checklist with task refs and blank lines survives tab switch and reload', async ({
+    page,
+    testVaultPath
+  }) => {
+    const parseErrors: string[] = []
+    page.on('console', (msg) => {
+      if (msg.type() !== 'error') return
+      const text = msg.text()
+      if (
+        text.includes('content.forEach') ||
+        text.includes("Block doesn't have id") ||
+        text.includes('Failed to parse markdown content')
+      ) {
+        parseErrors.push(text)
+      }
+    })
+
+    const noteId = `markdown-checklist-reload-${Date.now()}`
+    const title = `Markdown Checklist Reload ${Date.now()}`
+    const firstTask = `Review markdown reload ${Date.now()}`
+    const secondTask = `Verify tab switch ${Date.now()}`
+    const rawTask = `Capture raw checklist ${Date.now()}`
+    const md = [
+      '---',
+      `id: ${noteId}`,
+      `title: ${title}`,
+      'tags:',
+      '  - projects/memry',
+      '  - active',
+      '---',
+      '',
+      '## Launch plan',
+      '',
+      'Intro before tasks.',
+      '',
+      '',
+      `- [ ] ${firstTask} {task:${noteId}-task-1}`,
+      '',
+      '',
+      `- [ ] ${secondTask} {task:${noteId}-task-2}`,
+      '',
+      '',
+      `- [ ] ${rawTask}`,
+      '',
+      '## Risks',
+      '',
+      '> [!warning]',
+      '> Scope creep is the biggest risk.',
+      '',
+      '## Tech debts',
+      '',
+      '* See [[Drizzle ORM]] for the JSON-column gotcha',
+      '',
+      'Outro after tasks.',
+      '',
+      '#projects/memry #active',
+      ''
+    ].join('\n')
+    fs.writeFileSync(path.join(testVaultPath, 'notes', `${noteId}.md`), md)
+
+    await page.waitForTimeout(2000)
+
+    await page.keyboard.press(`${process.platform === 'darwin' ? 'Meta' : 'Control'}+k`)
+    await page.waitForTimeout(400)
+    const searchInput = page.locator('input[placeholder*="Search"], input[role="combobox"]').first()
+    if (await searchInput.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await searchInput.fill(title)
+      await page.waitForTimeout(500)
+      await page.keyboard.press('Enter')
+    }
+
+    await waitForTaskBlockCount(page, 3, 12000)
+    let editorText = await page.locator('[aria-label="Rich text editor"]').first().textContent()
+    expect(editorText).toContain('Intro before tasks.')
+    await expectEditorToContainVisibleText(page, firstTask)
+    await expectEditorToContainVisibleText(page, secondTask)
+    await expectEditorToContainVisibleText(page, rawTask)
+    expect(editorText).toContain('Scope creep is the biggest risk.')
+    expect(editorText).toContain('Drizzle ORM')
+    expect(editorText).toContain('Outro after tasks.')
+
+    await createNote(page, `Switch Away ${Date.now()}`)
+    await page.getByRole('tab', { name: new RegExp(title) }).click()
+
+    await waitForTaskBlockCount(page, 3, 12000)
+    editorText = await page.locator('[aria-label="Rich text editor"]').first().textContent()
+    expect(editorText).toContain('Intro before tasks.')
+    await expectEditorToContainVisibleText(page, firstTask)
+    await expectEditorToContainVisibleText(page, secondTask)
+    await expectEditorToContainVisibleText(page, rawTask)
+    expect(editorText).toContain('Scope creep is the biggest risk.')
+    expect(editorText).toContain('Drizzle ORM')
+    expect(editorText).toContain('Outro after tasks.')
+    expect(parseErrors).toEqual([])
   })
 
   test('should wire DB parent_id when an existing top-level task is Tab-indented under another', async ({


### PR DESCRIPTION
## Summary
- Guard link favicon hydration so task/table/string block content does not crash markdown load.
- Strip empty parsed block ids before BlockNote replacement and stop emitting empty ids for blank-line placeholders.
- Keep markdown saves disabled when parse/replace fails, and cover task-ref checklist reload with unit and E2E tests.

## Verification
- Red tests failed first on the active checkout for empty ids, non-array content, and parse-failure save readiness.
- pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/components/note/content-area
- pnpm --dir apps/desktop test:e2e inline-subtasks.e2e.ts -g "markdown checklist"
- pnpm docs:impact
- pnpm docs:impact --strict
- pnpm docs:build
- pnpm --dir apps/desktop exec prettier --check src/renderer/src/components/note/content-area/markdown-utils.ts src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts src/renderer/src/components/note/content-area/markdown-utils.test.ts src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx tests/e2e/inline-subtasks.e2e.ts
- git diff --check