### PR TITLE
feat: add unified pnpm seed command for demo vault

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -85,7 +85,8 @@
     "rpc:check": "node --experimental-strip-types --experimental-transform-types scripts/generate-rpc-bindings.ts --check",
     "ipc:generate": "pnpm rpc:generate && node scripts/generate-ipc-invoke-map.js",
     "ipc:check": "pnpm rpc:check && node scripts/generate-ipc-invoke-map.js --check",
-    "generate:icons": "node scripts/generate-icons.mjs"
+    "generate:icons": "node scripts/generate-icons.mjs",
+    "seed:vault": "bash scripts/ensure-native.sh node && npx tsx scripts/seed-vault.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",

--- a/apps/desktop/scripts/seed-data/calendar.ts
+++ b/apps/desktop/scripts/seed-data/calendar.ts
@@ -1,0 +1,480 @@
+import { generateId } from '../../src/main/lib/id'
+import type { SeedCalendarEvent, SeedCalendarSource } from '../seed-vault/db-writer'
+
+const TODAY = new Date('2026-05-08T12:00:00.000Z')
+
+const isoDateAt = (days: number, hour: number, minute = 0): string => {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() + days)
+  d.setUTCHours(hour, minute, 0, 0)
+  return d.toISOString()
+}
+
+const allDayStart = (days: number): string => {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() + days)
+  d.setUTCHours(0, 0, 0, 0)
+  return d.toISOString()
+}
+
+const allDayEnd = (days: number): string => {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() + days + 1)
+  d.setUTCHours(0, 0, 0, 0)
+  return d.toISOString()
+}
+
+const TOKYO_OFFSET_MS = 9 * 60 * 60 * 1000
+const tokyoLocalAt = (days: number, hour: number, minute = 0): string => {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() + days)
+  d.setUTCHours(hour, minute, 0, 0)
+  d.setTime(d.getTime() - TOKYO_OFFSET_MS)
+  return d.toISOString()
+}
+
+// ============================================================================
+// Calendar Sources (one local, one stub Google)
+// ============================================================================
+
+export const CALENDAR_SOURCES: SeedCalendarSource[] = [
+  {
+    id: generateId(),
+    provider: 'memry',
+    kind: 'calendar',
+    remoteId: 'local-default',
+    title: 'Memry Local',
+    color: '#6366f1',
+    isPrimary: true,
+    isSelected: true,
+    isMemryManaged: true,
+    syncStatus: 'idle'
+  },
+  {
+    id: generateId(),
+    provider: 'google',
+    kind: 'account',
+    remoteId: 'kaan@example.com',
+    title: 'kaan@example.com',
+    color: '#4285f4',
+    isPrimary: false,
+    isSelected: true,
+    syncStatus: 'ok',
+    lastSyncedAt: isoDateAt(0, 9, 45)
+  }
+]
+
+// ============================================================================
+// Events
+// ============================================================================
+
+export const CALENDAR_EVENTS: SeedCalendarEvent[] = [
+  // ========================================================================
+  // Recurring weekday standup
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'Daily standup',
+    description: 'Quick sync, what shipped, what is blocked.',
+    startAt: isoDateAt(-29, 9),
+    endAt: isoDateAt(-29, 9, 15),
+    timezone: 'America/Los_Angeles',
+    recurrenceRule: {
+      freq: 'WEEKLY',
+      interval: 1,
+      byDay: ['MO', 'TU', 'WE', 'TH', 'FR']
+    },
+    location: 'Hangout — meet.google.com/abc-defg-hij',
+    colorId: '6366f1',
+    reminders: { useDefault: false, overrides: [{ method: 'popup', minutes: 5 }] },
+    conferenceData: {
+      conferenceSolution: { name: 'Google Meet' },
+      entryPoints: [
+        {
+          entryPointType: 'video',
+          uri: 'https://meet.google.com/abc-defg-hij',
+          label: 'meet.google.com/abc-defg-hij'
+        }
+      ]
+    }
+  },
+
+  // ========================================================================
+  // Bi-weekly sprint planning
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'Sprint planning',
+    description: 'Plan next two weeks. Decisions, not status.',
+    startAt: isoDateAt(-26, 10),
+    endAt: isoDateAt(-26, 11, 30),
+    timezone: 'America/Los_Angeles',
+    recurrenceRule: {
+      freq: 'WEEKLY',
+      interval: 2,
+      byDay: ['MO']
+    },
+    colorId: '6366f1'
+  },
+
+  // ========================================================================
+  // Weekly 1:1
+  // ========================================================================
+  {
+    id: generateId(),
+    title: '1:1 with K.',
+    description: 'Career, blockers, anything.',
+    startAt: isoDateAt(-28, 14),
+    endAt: isoDateAt(-28, 14, 30),
+    timezone: 'America/Los_Angeles',
+    recurrenceRule: { freq: 'WEEKLY', interval: 1, byDay: ['WE'] },
+    colorId: '8b5cf6',
+    attendees: [
+      { email: 'self@example.com', responseStatus: 'accepted', self: true, organizer: true },
+      { email: 'k@example.com', displayName: 'K.', responseStatus: 'accepted' }
+    ]
+  },
+
+  // ========================================================================
+  // Monthly review
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'Monthly review',
+    description: 'Pull up [[Year in Review 2025]] template. What worked, what didn\'t.',
+    startAt: isoDateAt(-3, 16),
+    endAt: isoDateAt(-3, 17),
+    timezone: 'America/Los_Angeles',
+    recurrenceRule: { freq: 'MONTHLY', interval: 1, byMonthDay: -1 },
+    colorId: '10b981'
+  },
+
+  // ========================================================================
+  // All-day birthday
+  // ========================================================================
+  {
+    id: generateId(),
+    title: "M.'s birthday",
+    isAllDay: true,
+    startAt: allDayStart(11),
+    endAt: allDayEnd(11),
+    timezone: 'UTC',
+    recurrenceRule: { freq: 'YEARLY', interval: 1 },
+    colorId: 'f59e0b'
+  },
+
+  // ========================================================================
+  // Multi-day conference (all-day, 3 days)
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'LocalFirst Conf',
+    description: 'Speaking on day 2 — see [[Conference Talk]].',
+    location: 'Berlin, Germany',
+    isAllDay: true,
+    startAt: allDayStart(130),
+    endAt: allDayEnd(132),
+    timezone: 'Europe/Berlin',
+    colorId: 'ec4899'
+  },
+
+  // ========================================================================
+  // Doctor appointment with reminder
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'Annual physical',
+    description: 'Bring blood-work request.',
+    location: 'Mission Bay Medical Center, Suite 240',
+    startAt: isoDateAt(8, 15),
+    endAt: isoDateAt(8, 16),
+    timezone: 'America/Los_Angeles',
+    colorId: '10b981',
+    reminders: {
+      useDefault: false,
+      overrides: [
+        { method: 'popup', minutes: 30 },
+        { method: 'email', minutes: 1440 }
+      ]
+    }
+  },
+
+  // ========================================================================
+  // Travel block — 5 days, all-day, private
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'Iceland — Ring Road',
+    description: 'See [[Iceland Ring Road]].',
+    isAllDay: true,
+    startAt: allDayStart(96),
+    endAt: allDayEnd(105),
+    timezone: 'Atlantic/Reykjavik',
+    visibility: 'private',
+    colorId: 'ec4899'
+  },
+
+  // ========================================================================
+  // Friend dinner with attendees
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'Dinner — Kura',
+    description: 'Try the omakase. Reservations under M.',
+    location: '1518 Sutter St, San Francisco',
+    startAt: isoDateAt(2, 19),
+    endAt: isoDateAt(2, 21, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: 'f59e0b',
+    attendees: [
+      { email: 'self@example.com', responseStatus: 'accepted', self: true, organizer: true },
+      { email: 'm@example.com', displayName: 'M.', responseStatus: 'accepted' },
+      { email: 'd@example.com', displayName: 'D.', responseStatus: 'tentative' },
+      { email: 'r@example.com', displayName: 'R.', responseStatus: 'declined' }
+    ]
+  },
+
+  // ========================================================================
+  // Online course with conference data
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'CMU 15-445: Query Optimization (replay)',
+    description: 'See [[CMU Database Course]].',
+    startAt: isoDateAt(4, 18),
+    endAt: isoDateAt(4, 19, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: '0ea5e9',
+    conferenceData: {
+      conferenceSolution: { name: 'YouTube' },
+      entryPoints: [
+        {
+          entryPointType: 'video',
+          uri: 'https://youtube.com/playlist?list=PLSE8ODhjZXjbohkNBWQs_otTrBTrjyohi',
+          label: 'youtube.com — CMU 15-445'
+        }
+      ]
+    }
+  },
+
+  // ========================================================================
+  // Tokyo time-zone event (a Tokyo dinner from past trip retained for screenshot)
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'Dinner — Tonkatsu Maisen',
+    description: 'See [[Tokyo Trip]].',
+    location: 'Aoyama, Tokyo',
+    startAt: tokyoLocalAt(-25, 19, 30),
+    endAt: tokyoLocalAt(-25, 21),
+    timezone: 'Asia/Tokyo',
+    colorId: 'ec4899'
+  },
+
+  // ========================================================================
+  // Cancelled event
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'Coffee with R. (cancelled)',
+    description: 'Rescheduled — moved to next month.',
+    location: 'Sightglass, SoMa',
+    startAt: isoDateAt(1, 9, 30),
+    endAt: isoDateAt(1, 10, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: '6b7280',
+    visibility: 'default'
+  },
+
+  // ========================================================================
+  // Deep work blocks (a few, scattered)
+  // ========================================================================
+  {
+    id: generateId(),
+    title: '🧠 Deep work — Memry',
+    description: 'No notifications. See [[Memry Launch]].',
+    startAt: isoDateAt(0, 6),
+    endAt: isoDateAt(0, 9),
+    timezone: 'America/Los_Angeles',
+    colorId: '6366f1'
+  },
+  {
+    id: generateId(),
+    title: '🧠 Deep work — writing',
+    startAt: isoDateAt(1, 6),
+    endAt: isoDateAt(1, 8),
+    timezone: 'America/Los_Angeles',
+    colorId: '6366f1'
+  },
+  {
+    id: generateId(),
+    title: '🧠 Deep work — Memry',
+    startAt: isoDateAt(2, 6),
+    endAt: isoDateAt(2, 9),
+    timezone: 'America/Los_Angeles',
+    colorId: '6366f1'
+  },
+  {
+    id: generateId(),
+    title: '🧠 Deep work — writing',
+    startAt: isoDateAt(3, 6),
+    endAt: isoDateAt(3, 8),
+    timezone: 'America/Los_Angeles',
+    colorId: '6366f1'
+  },
+
+  // ========================================================================
+  // Workouts
+  // ========================================================================
+  {
+    id: generateId(),
+    title: '🏋️ Lift — Lower',
+    description: 'See [[Training Split]].',
+    location: 'Home gym',
+    startAt: isoDateAt(0, 17),
+    endAt: isoDateAt(0, 18, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: '10b981'
+  },
+  {
+    id: generateId(),
+    title: '🏋️ Lift — Upper',
+    location: 'Home gym',
+    startAt: isoDateAt(2, 17),
+    endAt: isoDateAt(2, 18, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: '10b981'
+  },
+  {
+    id: generateId(),
+    title: '🏃 Cardio — Zone 2',
+    location: 'Park',
+    startAt: isoDateAt(1, 17),
+    endAt: isoDateAt(1, 17, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: '10b981'
+  },
+  {
+    id: generateId(),
+    title: '🏃 Cardio — Intervals',
+    startAt: isoDateAt(4, 8),
+    endAt: isoDateAt(4, 8, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: '10b981'
+  },
+
+  // ========================================================================
+  // Random life
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'Dentist cleaning',
+    location: '1822 Lombard St',
+    startAt: isoDateAt(7, 14),
+    endAt: isoDateAt(7, 14, 45),
+    timezone: 'America/Los_Angeles',
+    colorId: 'f59e0b',
+    reminders: { useDefault: false, overrides: [{ method: 'popup', minutes: 60 }] }
+  },
+  {
+    id: generateId(),
+    title: 'Coffee with M.',
+    location: 'Sightglass, SoMa',
+    startAt: isoDateAt(3, 9, 30),
+    endAt: isoDateAt(3, 10, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: 'f59e0b',
+    attendees: [
+      { email: 'self@example.com', responseStatus: 'accepted', self: true, organizer: true },
+      { email: 'm@example.com', displayName: 'M.', responseStatus: 'accepted' }
+    ]
+  },
+  {
+    id: generateId(),
+    title: 'Movie — Dune Part Two',
+    description: 'See [[Watchlist 2026]].',
+    location: 'Alamo Drafthouse',
+    startAt: isoDateAt(6, 19, 15),
+    endAt: isoDateAt(6, 22),
+    timezone: 'America/Los_Angeles',
+    colorId: 'ec4899'
+  },
+  {
+    id: generateId(),
+    title: 'Friend wedding',
+    isAllDay: true,
+    startAt: allDayStart(45),
+    endAt: allDayEnd(45),
+    timezone: 'America/Los_Angeles',
+    colorId: 'ec4899'
+  },
+  {
+    id: generateId(),
+    title: 'Quarterly tax estimate',
+    description: 'Q2 estimate. See [[Finances]].',
+    startAt: isoDateAt(40, 10),
+    endAt: isoDateAt(40, 11),
+    timezone: 'America/Los_Angeles',
+    colorId: '6b7280'
+  },
+  {
+    id: generateId(),
+    title: 'Annual checkup — eye doctor',
+    location: 'Berkeley Eye Center',
+    startAt: isoDateAt(28, 11),
+    endAt: isoDateAt(28, 12),
+    timezone: 'America/Los_Angeles',
+    colorId: '10b981'
+  },
+
+  // ========================================================================
+  // Past — completed events (for the calendar history view)
+  // ========================================================================
+  {
+    id: generateId(),
+    title: 'Tokyo flight',
+    description: 'See [[Tokyo Trip]].',
+    isAllDay: false,
+    startAt: isoDateAt(-26, 16),
+    endAt: isoDateAt(-26, 23, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: 'ec4899'
+  },
+  {
+    id: generateId(),
+    title: 'Tokyo — Ghibli Museum',
+    location: 'Mitaka, Tokyo',
+    startAt: tokyoLocalAt(-22, 11),
+    endAt: tokyoLocalAt(-22, 13),
+    timezone: 'Asia/Tokyo',
+    colorId: 'ec4899'
+  },
+  {
+    id: generateId(),
+    title: 'Squat PR session',
+    description: 'See [[Cutting Log]].',
+    location: 'Home gym',
+    startAt: isoDateAt(-27, 17),
+    endAt: isoDateAt(-27, 18, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: '10b981'
+  },
+  {
+    id: generateId(),
+    title: 'Inbox snooze ship review',
+    description: 'PR landed. See [[Memry Launch]].',
+    startAt: isoDateAt(-12, 11),
+    endAt: isoDateAt(-12, 12),
+    timezone: 'America/Los_Angeles',
+    colorId: '6366f1'
+  },
+  {
+    id: generateId(),
+    title: 'Lunch — D.',
+    location: 'Mensho',
+    startAt: isoDateAt(-14, 12, 30),
+    endAt: isoDateAt(-14, 13, 30),
+    timezone: 'America/Los_Angeles',
+    colorId: 'f59e0b'
+  }
+]

--- a/apps/desktop/scripts/seed-data/inbox.ts
+++ b/apps/desktop/scripts/seed-data/inbox.ts
@@ -1,0 +1,314 @@
+import { generateId } from '../../src/main/lib/id'
+import type { SeedFilingHistory, SeedInboxItem } from '../seed-vault/db-writer'
+
+const TODAY = new Date('2026-05-08T12:00:00.000Z')
+
+const offsetISO = (days: number, hours = 11): string => {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() + days)
+  d.setUTCHours(hours, 17, 0, 0)
+  return d.toISOString()
+}
+
+const id = (prefix: string): string => `inbox_${prefix}_${generateId().slice(0, 12)}`
+
+export const INBOX_ITEMS: SeedInboxItem[] = [
+  // ========================================================================
+  // Unfiled link — today
+  // ========================================================================
+  {
+    id: id('lnk'),
+    type: 'link',
+    title: 'How (and why) we built a CRDT for our editor',
+    content:
+      'Engineering blog post on building a CRDT-backed editor. Worth reading before the next CRDT review.',
+    sourceUrl: 'https://example.com/crdt-editor-deep-dive',
+    sourceTitle: 'How (and why) we built a CRDT for our editor — Engineering Blog',
+    captureSource: 'browser-extension',
+    metadata: {
+      author: 'Mira S.',
+      publisher: 'Engineering Blog',
+      image: 'https://example.com/og/crdt-editor.png',
+      readingTime: 14
+    },
+    createdAt: offsetISO(0, 8),
+    modifiedAt: offsetISO(0, 8),
+    tags: ['research', 'tech/sync']
+  },
+
+  // ========================================================================
+  // GitHub repo — yjs/yjs
+  // ========================================================================
+  {
+    id: id('lnk'),
+    type: 'link',
+    title: 'yjs/yjs — Shared data types for collaborative apps',
+    content:
+      'Repo I keep referring back to. Star count grew 4× since 2023. Maintained by Kevin Jahns.',
+    sourceUrl: 'https://github.com/yjs/yjs',
+    sourceTitle: 'yjs/yjs — GitHub',
+    captureSource: 'browser-extension',
+    metadata: {
+      publisher: 'GitHub',
+      stars: 17400,
+      language: 'JavaScript',
+      lastCommit: '2026-05-06'
+    },
+    createdAt: offsetISO(-1, 14),
+    modifiedAt: offsetISO(-1, 14),
+    tags: ['tech/sync', 'reference']
+  },
+
+  // ========================================================================
+  // Snoozed link — Twitter/X thread
+  // ========================================================================
+  {
+    id: id('lnk'),
+    type: 'link',
+    title: 'Thread on E2EE key rotation in messaging apps',
+    content: 'Long thread, want to read with full attention.',
+    sourceUrl: 'https://x.com/example/status/1234567890',
+    captureSource: 'quick-capture',
+    snoozedUntil: offsetISO(1, 9),
+    snoozeReason: 'Read tomorrow with coffee, not while scrolling',
+    metadata: { platform: 'x', authorHandle: '@cryptodev' },
+    createdAt: offsetISO(-2, 22),
+    modifiedAt: offsetISO(-2, 22),
+    tags: ['tech/security']
+  },
+
+  // ========================================================================
+  // Quick note — text capture
+  // ========================================================================
+  {
+    id: id('nt'),
+    type: 'note',
+    title: 'Try Bun for the build pipeline',
+    content:
+      'Could replace tsx + esbuild on the dev path. Worth a 30-minute spike before the next quarter.',
+    captureSource: 'quick-capture',
+    createdAt: offsetISO(0, 7),
+    modifiedAt: offsetISO(0, 7),
+    tags: ['idea', 'tech/build']
+  },
+
+  // ========================================================================
+  // Voice memo with transcription
+  // ========================================================================
+  {
+    id: id('vcr'),
+    type: 'voice',
+    title: 'Voice memo — 2026-05-07 22:14',
+    content: 'Transcription pending review',
+    transcription:
+      'OK so the inbox suggestion thing — the model is too eager about the "linked" action. Need a confidence threshold of 0.7 minimum before we offer it as the default. Right now anything above 0.4 wins which is too low. Also Manny suggested we add a "no, just inbox" rejection bucket for training. Worth doing. Reminder me on Monday.',
+    transcriptionStatus: 'complete',
+    captureSource: 'quick-capture',
+    attachmentPath: 'attachments/inbox/voice-2026-05-07.m4a',
+    createdAt: offsetISO(-1, 22),
+    modifiedAt: offsetISO(-1, 22),
+    tags: ['projects/memry', 'inbox', 'ai']
+  },
+
+  // ========================================================================
+  // Voice memo — second one
+  // ========================================================================
+  {
+    id: id('vcr'),
+    type: 'voice',
+    title: 'Voice memo — Idea for Memry export',
+    transcription:
+      'For the v0.1 launch, we should let people export their entire vault as a zip with a pretty index.html. Not for sync, just for "I am leaving." That story matters more than the import story.',
+    transcriptionStatus: 'complete',
+    captureSource: 'quick-capture',
+    attachmentPath: 'attachments/inbox/voice-2026-05-05.m4a',
+    createdAt: offsetISO(-3, 21),
+    modifiedAt: offsetISO(-3, 21),
+    tags: ['projects/memry', 'export']
+  },
+
+  // ========================================================================
+  // Image — screenshot from extension
+  // ========================================================================
+  {
+    id: id('img'),
+    type: 'image',
+    title: 'Screenshot — calendar grid bug',
+    content: 'All-day events overflow on Mondays when the week wraps. See if the gap is a tz issue.',
+    captureSource: 'browser-extension',
+    attachmentPath: 'attachments/inbox/screenshot-cal-bug.png',
+    thumbnailPath: 'attachments/inbox/screenshot-cal-bug.thumb.png',
+    metadata: { width: 1840, height: 1080 },
+    createdAt: offsetISO(0, 9),
+    modifiedAt: offsetISO(0, 9),
+    tags: ['projects/memry', 'bug']
+  },
+
+  // ========================================================================
+  // Research PDF
+  // ========================================================================
+  {
+    id: id('pdf'),
+    type: 'pdf',
+    title: 'Local-First Software (Kleppmann et al, 2019)',
+    content:
+      "The paper that named the movement. Worth re-reading before the conference talk.",
+    sourceUrl: 'https://www.inkandswitch.com/local-first/',
+    captureSource: 'browser-extension',
+    attachmentPath: 'attachments/inbox/local-first-software.pdf',
+    metadata: { pages: 28, fileSize: 1830000 },
+    createdAt: offsetISO(-4, 13),
+    modifiedAt: offsetISO(-4, 13),
+    tags: ['research', 'projects/memry']
+  },
+
+  // ========================================================================
+  // Reminder — re-read item
+  // ========================================================================
+  {
+    id: id('rmd'),
+    type: 'reminder',
+    title: 'Re-read Dune Chapter 3',
+    content:
+      'The Bene Gesserit "litany against fear" passage. The opening sequence. Want to see how Herbert structures the world-building.',
+    captureSource: 'reminder',
+    metadata: { sourceNoteId: 'reference-to-dune-note' },
+    createdAt: offsetISO(-5, 9),
+    modifiedAt: offsetISO(-5, 9),
+    tags: ['reading', 'reminders']
+  },
+
+  // ========================================================================
+  // Web clip with sourceTitle
+  // ========================================================================
+  {
+    id: id('clp'),
+    type: 'clip',
+    title: 'Excerpt: "Productivity is the wrong god."',
+    content:
+      'Excerpt from an essay on Four Thousand Weeks. The line about "the productivity stack as denial of mortality" — worth pulling into [[Four Thousand Weeks]].',
+    sourceUrl: 'https://example.com/essay/productivity-wrong-god',
+    sourceTitle: 'Productivity is the wrong god — Substack',
+    captureSource: 'browser-extension',
+    metadata: { publisher: 'Substack', author: 'A. Banner' },
+    createdAt: offsetISO(-2, 15),
+    modifiedAt: offsetISO(-2, 15),
+    tags: ['reading', 'reflection']
+  },
+
+  // ========================================================================
+  // Filed link (filedAt set) — example of a processed item
+  // ========================================================================
+  {
+    id: id('lnk'),
+    type: 'link',
+    title: 'Drizzle: Better SQL through stricter types',
+    sourceUrl: 'https://example.com/drizzle-typed-sql',
+    captureSource: 'browser-extension',
+    filedAt: offsetISO(-3, 16),
+    filedTo: 'notes/tech/Drizzle ORM.md',
+    filedAction: 'note',
+    metadata: { publisher: 'Engineering blog', readingTime: 8 },
+    createdAt: offsetISO(-4, 11),
+    modifiedAt: offsetISO(-3, 16),
+    tags: ['tech/sql', 'reference']
+  },
+
+  // ========================================================================
+  // Snoozed note with reason
+  // ========================================================================
+  {
+    id: id('nt'),
+    type: 'note',
+    title: 'Look into Astro view transitions',
+    content:
+      'Could use this in the [[Blog Redesign]] migration. View transitions API + Astro.',
+    captureSource: 'quick-capture',
+    snoozedUntil: offsetISO(7, 9),
+    snoozeReason: 'Pick up after the [[Memry Launch]] hits a quieter week',
+    createdAt: offsetISO(-1, 11),
+    modifiedAt: offsetISO(-1, 11),
+    tags: ['idea', 'web']
+  },
+
+  // ========================================================================
+  // Reddit social post
+  // ========================================================================
+  {
+    id: id('soc'),
+    type: 'social',
+    title: 'Reddit — what programming book changed your career?',
+    content:
+      'Long thread. Skimming for candidates beyond [[On Writing]] and [[Atomic Habits]] which I already have.',
+    sourceUrl: 'https://reddit.com/r/programming/comments/abcdefg/',
+    sourceTitle: 'r/programming — what programming book changed your career?',
+    captureSource: 'browser-extension',
+    metadata: { platform: 'reddit', upvotes: 1820, comments: 432 },
+    createdAt: offsetISO(0, 12),
+    modifiedAt: offsetISO(0, 12),
+    tags: ['reading', 'idea']
+  },
+
+  // ========================================================================
+  // Article link — long content excerpt
+  // ========================================================================
+  {
+    id: id('lnk'),
+    type: 'link',
+    title: 'On the Use and Misuse of Synthetic Data',
+    content:
+      'Long-form piece on training-data ethics. Worth keeping for the [[Memry GTM]] conversation around what we do (and don\'t) collect.',
+    sourceUrl: 'https://example.com/synthetic-data-essay',
+    sourceTitle: 'On the Use and Misuse of Synthetic Data',
+    captureSource: 'browser-extension',
+    metadata: { author: 'L. Yu', readingTime: 22 },
+    createdAt: offsetISO(-2, 9),
+    modifiedAt: offsetISO(-2, 9),
+    tags: ['tech/ai', 'ethics']
+  },
+
+  // ========================================================================
+  // Old archived item
+  // ========================================================================
+  {
+    id: id('nt'),
+    type: 'note',
+    title: 'Old idea — meeting cost calculator',
+    content: 'Did this already, didn\'t ship. Archived.',
+    captureSource: 'quick-capture',
+    archivedAt: offsetISO(-95, 18),
+    createdAt: offsetISO(-180, 11),
+    modifiedAt: offsetISO(-95, 18),
+    tags: ['idea']
+  }
+]
+
+export const FILING_HISTORY_ROWS: SeedFilingHistory[] = [
+  {
+    id: generateId(),
+    itemType: 'link',
+    itemContent: 'Drizzle: Better SQL through stricter types — engineering blog post on type-safe ORM',
+    filedTo: 'notes/tech/Drizzle ORM.md',
+    filedAction: 'note',
+    tags: ['tech/sql', 'reference'],
+    filedAt: offsetISO(-3, 16)
+  },
+  {
+    id: generateId(),
+    itemType: 'link',
+    itemContent: 'Yjs deep dive — collaborative editing internals',
+    filedTo: 'notes/tech/CRDT Architecture.md',
+    filedAction: 'note',
+    tags: ['tech/sync', 'reference'],
+    filedAt: offsetISO(-9, 14)
+  },
+  {
+    id: generateId(),
+    itemType: 'note',
+    itemContent: 'Idea: lazy-load graph view past 500 nodes',
+    filedTo: 'notes/projects/Memry Launch.md',
+    filedAction: 'note',
+    tags: ['projects/memry', 'perf'],
+    filedAt: offsetISO(-15, 11)
+  }
+]

--- a/apps/desktop/scripts/seed-data/journal.ts
+++ b/apps/desktop/scripts/seed-data/journal.ts
@@ -1,0 +1,276 @@
+import { generateJournalId } from '../../src/main/lib/id'
+import type { NoteFile } from '../seed-vault/file-writer'
+
+interface JournalSpec {
+  date: string
+  mood: number
+  tags: string[]
+  body: string
+}
+
+const ENTRIES: JournalSpec[] = [
+  {
+    date: '2026-04-09',
+    mood: 4,
+    tags: ['daily', 'planning'],
+    body: `Started the week sketching out the [[2026 Cut]] plan in earnest. Numbers feel doable. Trick is to *not* eyeball it.
+
+Coffee was good. Slept poorly. Lifted anyway.
+
+- Wrote 600 words on [[Memry Launch]] post
+- Fixed a sync edge case in CRDT push order
+- Walked 8k steps`
+  },
+  {
+    date: '2026-04-10',
+    mood: 3,
+    tags: ['daily', 'work'],
+    body: `Brain fog all morning. Took a walk before lunch and it cleared. Wrote down everything I was *supposed* to do today and then just did the top one.
+
+Started reading [[Sapiens]]. Slow start, characteristically Harari.`
+  },
+  {
+    date: '2026-04-11',
+    mood: 5,
+    tags: ['daily', 'flow'],
+    body: `Best day of the month. 06:00–10:00 in the cave on the [[Memry Architecture]] doc. No notifications, no Slack.
+
+Lifted heavy in the afternoon. Squat PR (140kg × 5).
+
+> "The only way out is through." — old climbing instructor; turns out it applies to writing too.`
+  },
+  {
+    date: '2026-04-12',
+    mood: 5,
+    tags: ['daily', 'travel', 'tokyo'],
+    body: `Departure day. [[Tokyo Trip]] begins. Up at 04:30. Coffee in the airport lounge — see [[Airport Lounges]].
+
+15 hours later, Haneda. The light is different. The air is different. *Everything* is different and I haven't even left the airport.`
+  },
+  {
+    date: '2026-04-13',
+    mood: 5,
+    tags: ['daily', 'travel'],
+    body: `Tokyo Tower. Onigiri. A tiny bookstore in Jimbocho where I bought a book I cannot read. Still bought it.
+
+Walked 22,000 steps. Feet hurt but the *good* kind.`
+  },
+  {
+    date: '2026-04-14',
+    mood: 4,
+    tags: ['daily', 'travel'],
+    body: `Shibuya scramble at 18:00. Fewer people than the YouTube videos suggest. More than I'd want to *be* in regularly.
+
+Late ramen — see [[Tokyo Cafes]] for where. Already plotting return.`
+  },
+  // skip 2026-04-15 to leave a gap, then add it back as a heavy day
+  {
+    date: '2026-04-15',
+    mood: 5,
+    tags: ['daily', 'travel', 'kyoto'],
+    body: `[[Kyoto Day Trip]] — left at 06:30, back at 22:00, my legs are *gone*. Worth it.
+
+Fushimi Inari at dawn was the moment. The torii gates with no one in them, the way the light filtered through. I will remember this.`
+  },
+  {
+    date: '2026-04-16',
+    mood: 4,
+    tags: ['daily', 'travel'],
+    body: `Ghibli Museum. Don't take photos. *Don't take photos.* They mean it. And honestly, you don't want to.
+
+Watched [[Spirited Away]] on the train back. Tenth time. Still cried.`
+  },
+  {
+    date: '2026-04-17',
+    mood: 5,
+    tags: ['daily', 'travel'],
+    body: `Coffee crawl day. Five spots, [[Tokyo Cafes]] updated.
+
+Best espresso of my life at Bear Pond. They closed at noon, sharp.`
+  },
+  {
+    date: '2026-04-18',
+    mood: 4,
+    tags: ['daily', 'travel'],
+    body: `Disney Sea. Yes I'm an adult. Yes I bought the Toy Story popcorn bucket. No regrets.`
+  },
+  {
+    date: '2026-04-19',
+    mood: 3,
+    tags: ['daily', 'travel', 'goodbye'],
+    body: `Last day. Walked Tokyo Station for 90 minutes. Bought too many KitKats.
+
+Cried on the escalator. *Cried on an escalator.* This place got me.
+
+Flight home tonight.`
+  },
+  // gap — 2026-04-20 traveling/jetlagged
+  {
+    date: '2026-04-21',
+    mood: 2,
+    tags: ['daily', 'jetlag'],
+    body: `Home. Jetlagged. Slept from 16:00 to 22:00 and now I'm wide awake at 02:00 writing this.
+
+Skipped lifting. Will get back tomorrow.`
+  },
+  {
+    date: '2026-04-22',
+    mood: 3,
+    tags: ['daily', 'fitness'],
+    body: `Sunday weigh-in: 85.5 kg. Down 1.6 kg over Tokyo (which I expected to be flat). Walking 22k steps for a week is a hell of a thing.
+
+Updated [[Cutting Log]].`
+  },
+  {
+    date: '2026-04-23',
+    mood: 4,
+    tags: ['daily', 'work'],
+    body: `Back in the swing. [[Memry Launch]] is now my main thread. Next 8 weeks are about *finishing*, not adding.
+
+Said no to a side project today. Felt good.`
+  },
+  {
+    date: '2026-04-24',
+    mood: 4,
+    tags: ['daily', 'work', 'meetings'],
+    body: `Sprint planning. Team is *into* the Inbox redesign. Validates the call.
+
+Lunch with M. — first time in a month. Wonderful.`
+  },
+  {
+    date: '2026-04-25',
+    mood: 3,
+    tags: ['daily', 'low-energy'],
+    body: `Slow day. Didn't push it. Read [[Atomic Habits]] for an hour. Walked. Made dinner with my partner.
+
+Some days are maintenance days.`
+  },
+  {
+    date: '2026-04-26',
+    mood: 4,
+    tags: ['daily', 'fitness'],
+    body: `Sunday weigh-in: 85.0 kg. Stalled vs. last week. Patient. Will trust the plan.
+
+Pushed lifts hard. Squat felt heavy. Bench was good.`
+  },
+  {
+    date: '2026-04-27',
+    mood: 4,
+    tags: ['daily', 'work'],
+    body: `Inbox snooze feature in the can. PR up. Quick review and out.
+
+Started [[The Mystery Guest]]. Cozy, easy.`
+  },
+  {
+    date: '2026-04-28',
+    mood: 5,
+    tags: ['daily', 'flow', 'work'],
+    body: `Three uninterrupted hours on the calendar IPC layer. Solved a TZ bug that's been nagging since [[Tokyo Trip]] (turns out: events from Asia/Tokyo were drifting on West Coast displays).
+
+Pair with [[Drizzle ORM]] note — \`field_clocks\` saved me here.`
+  },
+  {
+    date: '2026-04-29',
+    mood: 4,
+    tags: ['daily', 'reading'],
+    body: `Reading [[The Almanack of Naval Ravikant]]. Some bits are slick startup-broism, some bits genuinely cracked something open.
+
+Lifted. Felt strong. 3rd lift week of the [[2026 Cut]] and lifts haven't dropped.`
+  },
+  {
+    date: '2026-04-30',
+    mood: 4,
+    tags: ['daily', 'reflection'],
+    body: `End of April. Net: solid. Tokyo, the cut, Memry doc landed. Three good things.
+
+Three improvements: write more in public, sleep on schedule, *do not check phone before 09:00*.`
+  },
+  {
+    date: '2026-05-01',
+    mood: 4,
+    tags: ['daily', 'fitness'],
+    body: `May. New month, same plan.
+
+[[Cutting Log]] update: 84.8 kg → moving.`
+  },
+  {
+    date: '2026-05-02',
+    mood: 5,
+    tags: ['daily', 'flow', 'writing'],
+    body: `Wrote 1100 words on the [[Conference Talk]] outline. Best stretch of writing in weeks.
+
+Mackerel teishoku for lunch — see [[Food Diary]]. Easily a 4/5.`
+  },
+  {
+    date: '2026-05-03',
+    mood: 5,
+    tags: ['daily', 'fitness'],
+    body: `Sunday weigh-in: 84.0 kg. Whoosh week. Trusting the plan paid off.
+
+Long walk with my partner in the afternoon. Talked about [[Iceland Ring Road]] plans.`
+  },
+  // gap — 2026-05-04 (I genuinely didn't journal that day, leaving it that way)
+  {
+    date: '2026-05-05',
+    mood: 4,
+    tags: ['daily', 'work'],
+    body: `Finished the inbox suggestions UI. The little "AI suggests filing here" pill is *cute*. Hard not to smile when you see it work.
+
+Linked tasks under [[Memry Launch]] are all moving.`
+  },
+  {
+    date: '2026-05-06',
+    mood: 4,
+    tags: ['daily', 'reading'],
+    body: `Korean BBQ tonight. Stayed lean — see [[Food Diary]].
+
+More [[Sapiens]]. Chapter on agriculture. The wheat take feels stretched but in a productive *huh* way.`
+  },
+  {
+    date: '2026-05-07',
+    mood: 5,
+    tags: ['daily', 'flow', 'work'],
+    body: `Wrote, lifted, shipped.
+
+Best day this week. The morning routine — see [[Morning Routine]] — is *paying for itself.* Two months in.`
+  },
+  {
+    date: '2026-05-08',
+    mood: 5,
+    tags: ['daily', 'fitness', 'flow'],
+    body: `Friday. Sunday weigh-in expected to land us under 82 kg if the trajectory holds.
+
+Reread part of [[On Reading]] this morning. Forgot how good the *empathy as flight simulator* line was.
+
+Looking forward to a quiet weekend.`
+  }
+]
+
+const TODAY_ISO = new Date('2026-05-08T12:00:00.000Z').toISOString()
+
+const dateToCreatedISO = (date: string): string => {
+  const d = new Date(date + 'T08:30:00.000Z')
+  return d.toISOString()
+}
+
+const dateToModifiedISO = (date: string): string => {
+  const d = new Date(date + 'T22:30:00.000Z')
+  return d.toISOString()
+}
+
+export const JOURNAL_NOTES: NoteFile[] = ENTRIES.map((entry) => ({
+  relativePath: `journal/${entry.date}.md`,
+  frontmatter: {
+    id: generateJournalId(entry.date),
+    title: entry.date,
+    created: dateToCreatedISO(entry.date),
+    modified: dateToModifiedISO(entry.date),
+    date: entry.date,
+    journalDate: entry.date,
+    mood: entry.mood,
+    tags: entry.tags
+  },
+  body: entry.body
+}))
+
+export const JOURNAL_TODAY_ISO = TODAY_ISO

--- a/apps/desktop/scripts/seed-data/notes.ts
+++ b/apps/desktop/scripts/seed-data/notes.ts
@@ -1,0 +1,2085 @@
+import { generateNoteId } from '../../src/main/lib/id'
+import type { NoteFile } from '../seed-vault/file-writer'
+
+const TODAY = new Date('2026-05-08T12:00:00.000Z')
+
+const dayOffset = (days: number, hour = 12): string => {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() + days)
+  d.setUTCHours(hour, 30, 0, 0)
+  return d.toISOString()
+}
+
+export const NOTE_IDS = {
+  // Books
+  bookDune: generateNoteId(),
+  bookProjectHailMary: generateNoteId(),
+  bookAtomicHabits: generateNoteId(),
+  bookDeepWork: generateNoteId(),
+  bookTheMartian: generateNoteId(),
+  bookSapiens: generateNoteId(),
+  bookMisteryHotel: generateNoteId(),
+  bookOnWriting: generateNoteId(),
+  bookKitchenConfidential: generateNoteId(),
+  bookAlmanackOfNaval: generateNoteId(),
+  bookFourThousandWeeks: generateNoteId(),
+  bookManSearchMeaning: generateNoteId(),
+  // Movies
+  movieDune2021: generateNoteId(),
+  movieInterstellar: generateNoteId(),
+  movieTheMatrix: generateNoteId(),
+  movieEverythingEverywhere: generateNoteId(),
+  movieAnewHope: generateNoteId(),
+  movieAriival: generateNoteId(),
+  movieTheMartianFilm: generateNoteId(),
+  movieParasite: generateNoteId(),
+  movieSpiritedAway: generateNoteId(),
+  movieWatchlist2026: generateNoteId(),
+  movieBladerunner: generateNoteId(),
+  movieGoodfellas: generateNoteId(),
+  // Weight
+  weightCut2026: generateNoteId(),
+  weightCuttingLog: generateNoteId(),
+  weightProteinTargets: generateNoteId(),
+  weightTrainingSplit: generateNoteId(),
+  weightSundayWeighIn: generateNoteId(),
+  weightCardioPlan: generateNoteId(),
+  weightFoodDiary: generateNoteId(),
+  weightProgressPhotos: generateNoteId(),
+  // Life
+  lifeMyWhy: generateNoteId(),
+  lifeOnReading: generateNoteId(),
+  lifeYearReview2025: generateNoteId(),
+  lifeMorningRoutine: generateNoteId(),
+  lifeFinances: generateNoteId(),
+  lifeOnFear: generateNoteId(),
+  lifeRelationships: generateNoteId(),
+  lifeWhatBringsJoy: generateNoteId(),
+  // Projects
+  projMemryLaunch: generateNoteId(),
+  projMemryArchitecture: generateNoteId(),
+  projMemryRoadmap: generateNoteId(),
+  projMemryGTM: generateNoteId(),
+  projGardenSchedule: generateNoteId(),
+  projHomeRenovation: generateNoteId(),
+  projBlogRedesign: generateNoteId(),
+  projOpenSourceFork: generateNoteId(),
+  projSideProjectIdeas: generateNoteId(),
+  projConferenceTalk: generateNoteId(),
+  // Tech
+  techTypescriptPatterns: generateNoteId(),
+  techDrizzleORM: generateNoteId(),
+  techCRDTArchitecture: generateNoteId(),
+  techPostgresIndexing: generateNoteId(),
+  techCMUDatabaseCourse: generateNoteId(),
+  techKipThorneBlackHoles: generateNoteId(),
+  techElectronGotchas: generateNoteId(),
+  techSqliteVec: generateNoteId(),
+  techVimMotions: generateNoteId(),
+  techGitWorkflow: generateNoteId(),
+  techRustNotes: generateNoteId(),
+  techDockerCheatsheet: generateNoteId(),
+  // Travel
+  travelTokyoTrip: generateNoteId(),
+  travelKyotoDayTrip: generateNoteId(),
+  travelLisbonNotes: generateNoteId(),
+  travelIcelandRingRoad: generateNoteId(),
+  travelPackingList: generateNoteId(),
+  travelSeoulFood: generateNoteId(),
+  travelMexicoCityArt: generateNoteId(),
+  travelOsakaRamen: generateNoteId(),
+  travelTokyoCafes: generateNoteId(),
+  travelAirportLounges: generateNoteId()
+} as const
+
+export const FOLDER_CONFIGS: Array<{ path: string; icon: string }> = [
+  { path: 'notes/books', icon: '📚' },
+  { path: 'notes/movies', icon: '🎬' },
+  { path: 'notes/weight', icon: '💪' },
+  { path: 'notes/life', icon: '🌳' },
+  { path: 'notes/projects', icon: '📦' },
+  { path: 'notes/tech', icon: '💻' },
+  { path: 'notes/travel', icon: '✈️' }
+]
+
+interface NoteSpec {
+  id: string
+  relativePath: string
+  title: string
+  emoji?: string
+  tags: string[]
+  aliases?: string[]
+  customProps?: Record<string, unknown>
+  daysAgoCreated: number
+  daysAgoModified: number
+  body: string
+}
+
+const SPECS: NoteSpec[] = [
+  // ============================================================================
+  // BOOKS
+  // ============================================================================
+  {
+    id: NOTE_IDS.bookDune,
+    relativePath: 'notes/books/Dune.md',
+    title: 'Dune',
+    emoji: '🪐',
+    tags: ['fiction', 'sci-fi', 'classic', 'reread'],
+    aliases: ['Dune (1965)'],
+    customProps: { author: 'Frank Herbert', year: 1965, pages: 688, status: 'done', rating: 5 },
+    daysAgoCreated: -120,
+    daysAgoModified: -8,
+    body: `## Why it still matters
+
+Sixty years on, *Dune* still sets the bar for political-sci-fi worldbuilding. Reread it before catching [[Dune (2021)|the film]] again.
+
+## The lessons that stuck
+
+- **Power is information.** The Bene Gesserit win because they think in centuries.
+- **Ecology is plot.** Frank Herbert built the climate before he built the characters.
+- **Fear is the mind-killer.** Best opening litany in the genre.
+
+> "He who controls the spice controls the universe."
+
+#books/fiction #sci-fi
+
+## Pair with
+
+- [[Project Hail Mary]] — same chewy hard-sci-fi appetite
+- [[Sapiens]] — for the *humans-shape-environment* throughline
+`
+  },
+  {
+    id: NOTE_IDS.bookProjectHailMary,
+    relativePath: 'notes/books/Project Hail Mary.md',
+    title: 'Project Hail Mary',
+    emoji: '🚀',
+    tags: ['fiction', 'sci-fi', 'andy-weir'],
+    customProps: { author: 'Andy Weir', year: 2021, pages: 476, status: 'done', rating: 5 },
+    daysAgoCreated: -90,
+    daysAgoModified: -22,
+    body: `## Plot stretch goal
+
+Lone astronaut wakes up on a starship with amnesia and has to save earth. *Of course* he does.
+
+## What worked
+
+- The friendship is genuinely earned — most aliens-meet-humans stories skip this.
+- Andy Weir does **engineering exposition** better than anyone.
+- Rocky. Just Rocky.
+
+## What dragged
+
+The chemistry-by-flashlight beats run a touch long. Worth it.
+
+See also: [[The Martian]] — same flavor, drier.
+
+#books/fiction #sci-fi
+`
+  },
+  {
+    id: NOTE_IDS.bookAtomicHabits,
+    relativePath: 'notes/books/Atomic Habits.md',
+    title: 'Atomic Habits',
+    emoji: '⚛️',
+    tags: ['nonfiction', 'productivity', 'habits'],
+    customProps: { author: 'James Clear', year: 2018, pages: 320, status: 'done', rating: 4 },
+    daysAgoCreated: -210,
+    daysAgoModified: -45,
+    body: `## The four laws
+
+| Law | Make it | Example |
+|-----|---------|---------|
+| 1 | Obvious | Lay out gym clothes the night before |
+| 2 | Attractive | Stack a habit you want with one you love |
+| 3 | Easy | Two-minute rule |
+| 4 | Satisfying | Tracker, streak, reward |
+
+## Quotes I wrote on a sticky note
+
+> You do not rise to the level of your goals. You fall to the level of your systems.
+
+> Every action you take is a vote for the type of person you wish to become.
+
+## Where I applied it
+
+- **Reading**: kindle on the pillow → 20 minutes a night minimum
+- **Strength**: see [[2026 Cut]] and [[Training Split]]
+- **Writing**: morning, before the inbox opens
+
+#books/nonfiction #habits
+`
+  },
+  {
+    id: NOTE_IDS.bookDeepWork,
+    relativePath: 'notes/books/Deep Work.md',
+    title: 'Deep Work',
+    emoji: '🧠',
+    tags: ['nonfiction', 'productivity', 'focus'],
+    customProps: {
+      author: 'Cal Newport',
+      year: 2016,
+      pages: 304,
+      status: 'done',
+      rating: 4
+    },
+    daysAgoCreated: -300,
+    daysAgoModified: -60,
+    body: `## Core idea
+
+Cognitive demand is the new luxury good. Defend three to four hours a day or surrender them.
+
+## My deep work blocks
+
+- 06:00–08:00 — writing, no exceptions
+- 09:30–12:00 — engineering, slack closed
+- 14:00–15:00 — reading
+
+## Anti-patterns I caught myself doing
+
+- Phantom-checking notifications mid-flow
+- "Quick" Slack threads that weren't quick
+- Email as a procrastination ritual
+
+#books/nonfiction #focus
+`
+  },
+  {
+    id: NOTE_IDS.bookTheMartian,
+    relativePath: 'notes/books/The Martian.md',
+    title: 'The Martian',
+    emoji: '🥔',
+    tags: ['fiction', 'sci-fi', 'andy-weir'],
+    customProps: {
+      author: 'Andy Weir',
+      year: 2011,
+      pages: 369,
+      status: 'done',
+      rating: 4
+    },
+    daysAgoCreated: -250,
+    daysAgoModified: -150,
+    body: `## The pitch
+
+Astronaut botanist gets stranded on Mars. Survives mostly through math and stubbornness.
+
+The film [[The Martian (Film)]] cuts the chemistry but keeps the heart. Andy Weir has clearly done this trick again with [[Project Hail Mary]].
+
+## Lines that hit
+
+> I'm gonna have to science the shit out of this.
+
+## When to reread
+
+When motivation is thin. Watney's *I-am-not-going-to-die-today* energy is contagious.
+
+#books/fiction #sci-fi
+`
+  },
+  {
+    id: NOTE_IDS.bookSapiens,
+    relativePath: 'notes/books/Sapiens.md',
+    title: 'Sapiens',
+    emoji: '🌍',
+    tags: ['nonfiction', 'history', 'big-ideas'],
+    customProps: {
+      author: 'Yuval Noah Harari',
+      year: 2014,
+      pages: 464,
+      status: 'reading',
+      rating: 4
+    },
+    daysAgoCreated: -45,
+    daysAgoModified: -1,
+    body: `## Where I am
+
+Chapter 9. Cognitive revolution → agricultural revolution → unification of humankind.
+
+## What I'm thinking about
+
+- Money, religion, and limited liability companies are all *fictions we agree on*. Memry sync is a fiction we agree on, too.
+- Wheat domesticated humans, not the other way around.
+
+## Open questions
+
+- Does Harari oversell the wheat takeover?
+- Is "happiness research" rigorous enough to lean on this much?
+
+#books/nonfiction #history
+`
+  },
+  {
+    id: NOTE_IDS.bookMisteryHotel,
+    relativePath: 'notes/books/The Mystery Guest.md',
+    title: 'The Mystery Guest',
+    emoji: '🔍',
+    tags: ['fiction', 'mystery', 'cozy'],
+    customProps: {
+      author: 'Nita Prose',
+      year: 2023,
+      pages: 304,
+      status: 'reading',
+      rating: 3
+    },
+    daysAgoCreated: -10,
+    daysAgoModified: -1,
+    body: `Cozy hotel mystery. Easy palette cleanser between heavier reads.
+
+Half through. The narrator's voice is the appeal more than the puzzle.
+
+#books/fiction #mystery
+`
+  },
+  {
+    id: NOTE_IDS.bookOnWriting,
+    relativePath: 'notes/books/On Writing.md',
+    title: 'On Writing',
+    emoji: '✍️',
+    tags: ['nonfiction', 'craft', 'writing'],
+    customProps: {
+      author: 'Stephen King',
+      year: 2000,
+      pages: 288,
+      status: 'done',
+      rating: 5
+    },
+    daysAgoCreated: -400,
+    daysAgoModified: -180,
+    body: `## Memoir + craft, in equal parts
+
+Read it twice now. The memoir is great; the toolkit is *brutal*:
+
+- *Read a lot. Write a lot.* No shortcut.
+- *Adverbs are not your friend.*
+- *The road to hell is paved with adverbs.*
+- *Write with the door closed. Edit with the door open.*
+
+Pair with [[Deep Work]] for the *defend the time* angle.
+
+#books/nonfiction #writing
+`
+  },
+  {
+    id: NOTE_IDS.bookKitchenConfidential,
+    relativePath: 'notes/books/Kitchen Confidential.md',
+    title: 'Kitchen Confidential',
+    emoji: '🔪',
+    tags: ['nonfiction', 'memoir', 'food'],
+    customProps: {
+      author: 'Anthony Bourdain',
+      year: 2000,
+      pages: 312,
+      status: 'done',
+      rating: 5
+    },
+    daysAgoCreated: -340,
+    daysAgoModified: -110,
+    body: `## Why I love it
+
+Bourdain wrote like he cooked: fast, no apologies, with violence and grace. Best food memoir of the century.
+
+Also see [[Tokyo Cafes]] — different cuisine, same reverence.
+
+> Your body is not a temple, it's an amusement park.
+
+#books/nonfiction #memoir
+`
+  },
+  {
+    id: NOTE_IDS.bookAlmanackOfNaval,
+    relativePath: 'notes/books/The Almanack of Naval Ravikant.md',
+    title: 'The Almanack of Naval Ravikant',
+    emoji: '🧭',
+    tags: ['nonfiction', 'philosophy', 'wealth'],
+    customProps: {
+      author: 'Eric Jorgenson',
+      year: 2020,
+      pages: 244,
+      status: 'reading',
+      rating: 4
+    },
+    daysAgoCreated: -30,
+    daysAgoModified: -3,
+    body: `Notes-as-essays from Naval Ravikant. The wealth section is fine. The happiness section is the part to reread.
+
+> Desire is a contract you make with yourself to be unhappy until you get what you want.
+
+Pairs with [[On Reading]] and [[My Why]].
+
+#books/nonfiction #philosophy
+`
+  },
+  {
+    id: NOTE_IDS.bookFourThousandWeeks,
+    relativePath: 'notes/books/Four Thousand Weeks.md',
+    title: 'Four Thousand Weeks',
+    emoji: '⏳',
+    tags: ['nonfiction', 'productivity', 'mortality'],
+    customProps: {
+      author: 'Oliver Burkeman',
+      year: 2021,
+      pages: 288,
+      status: 'done',
+      rating: 5
+    },
+    daysAgoCreated: -160,
+    daysAgoModified: -90,
+    body: `## The reframe
+
+You only get ~4000 weeks. The "productivity stack" is, mostly, a way to pretend you don't.
+
+Hard counterweight to [[Atomic Habits]] and [[Deep Work]] — those say *get more out of every hour*. This one says *give up first*.
+
+#books/nonfiction #mortality
+`
+  },
+  {
+    id: NOTE_IDS.bookManSearchMeaning,
+    relativePath: "notes/books/Man's Search for Meaning.md",
+    title: "Man's Search for Meaning",
+    emoji: '🕯️',
+    tags: ['nonfiction', 'philosophy', 'memoir'],
+    customProps: {
+      author: 'Viktor Frankl',
+      year: 1946,
+      pages: 200,
+      status: 'done',
+      rating: 5
+    },
+    daysAgoCreated: -700,
+    daysAgoModified: -360,
+    body: `## Logotherapy in 200 pages
+
+Frankl's central claim: *meaning* — not pleasure, not even purpose — is what carries you. Pair with [[On Reading]].
+
+> When we are no longer able to change a situation, we are challenged to change ourselves.
+
+#books/nonfiction #philosophy
+`
+  },
+
+  // ============================================================================
+  // MOVIES
+  // ============================================================================
+  {
+    id: NOTE_IDS.movieDune2021,
+    relativePath: 'notes/movies/Dune (2021).md',
+    title: 'Dune (2021)',
+    emoji: '🪐',
+    tags: ['movies/sci-fi', 'denis-villeneuve', 'rewatch'],
+    aliases: ['Dune Part One'],
+    customProps: { year: 2021, director: 'Denis Villeneuve', genre: 'sci-fi', status: 'watched', rating: 5 },
+    daysAgoCreated: -120,
+    daysAgoModified: -8,
+    body: `## The adaptation that finally landed
+
+After 56 years and several misfires, Villeneuve cracked it. The film is the [[Dune|book]] in spirit, not in plot density. That's the right call.
+
+## What sells it
+
+- Hans Zimmer's score — unsettling without being theatrical
+- The sandworm reveal: lit in negative space, doesn't show too much
+- Stilgar's restraint. Bardem refused to ham it up.
+
+Watch trailer: https://www.youtube.com/watch?v=8g18jFHCLXk
+
+## What I'd cut
+
+The Salusa Secundus scene needs ten more seconds. Hardly a crime.
+
+#movies/sci-fi #adaptation
+`
+  },
+  {
+    id: NOTE_IDS.movieInterstellar,
+    relativePath: 'notes/movies/Interstellar.md',
+    title: 'Interstellar',
+    emoji: '🌌',
+    tags: ['movies/sci-fi', 'christopher-nolan', 'rewatch'],
+    customProps: { year: 2014, director: 'Christopher Nolan', genre: 'sci-fi', status: 'watched', rating: 5 },
+    daysAgoCreated: -280,
+    daysAgoModified: -40,
+    body: `## Nolan's most emotional film
+
+Nolan turned Kip Thorne's whitepaper into the most *devastating* sci-fi film since 2001. The black hole render is the work of [[Kip Thorne — Black Holes]] himself.
+
+## The bookcase scene
+
+Plot-mechanically nonsense. Emotionally undefeated. I will fight on this.
+
+> Do not go gentle into that good night.
+
+#movies/sci-fi #emotional
+`
+  },
+  {
+    id: NOTE_IDS.movieTheMatrix,
+    relativePath: 'notes/movies/The Matrix.md',
+    title: 'The Matrix',
+    emoji: '💊',
+    tags: ['movies/sci-fi', 'wachowski', 'classic'],
+    customProps: { year: 1999, director: 'Wachowski Sisters', genre: 'sci-fi', status: 'watched', rating: 5 },
+    daysAgoCreated: -500,
+    daysAgoModified: -200,
+    body: `Still holds up. The bullet-time was the marketing; the philosophy was the staying power.
+
+> What is real? How do you define real?
+
+#movies/sci-fi #classic
+`
+  },
+  {
+    id: NOTE_IDS.movieEverythingEverywhere,
+    relativePath: 'notes/movies/Everything Everywhere All at Once.md',
+    title: 'Everything Everywhere All at Once',
+    emoji: '🥯',
+    tags: ['movies/scifi', 'a24', 'absurd'],
+    customProps: { year: 2022, director: 'Daniels', genre: 'sci-fi', status: 'watched', rating: 5 },
+    daysAgoCreated: -180,
+    daysAgoModified: -55,
+    body: `## Why it works
+
+Multiverse-as-feeling instead of multiverse-as-plot. Michelle Yeoh as the laundromat lady saving the universe by **doing taxes** is the joke that becomes the heart.
+
+## What it owes
+
+- Wong Kar-wai for the longing scenes
+- Hong Kong action choreography for the fanny-pack fight
+- Pixar for the rocks
+
+#movies/sci-fi #a24
+`
+  },
+  {
+    id: NOTE_IDS.movieAnewHope,
+    relativePath: 'notes/movies/Star Wars Episode IV.md',
+    title: 'Star Wars Episode IV',
+    emoji: '⚔️',
+    tags: ['movies/sci-fi', 'star-wars', 'classic'],
+    aliases: ['A New Hope', 'Star Wars (1977)'],
+    customProps: { year: 1977, director: 'George Lucas', genre: 'sci-fi', status: 'watched', rating: 4 },
+    daysAgoCreated: -650,
+    daysAgoModified: -300,
+    body: `Hero's journey, as catalogued by Joseph Campbell, with laser swords. Still works.
+
+#movies/sci-fi #classic
+`
+  },
+  {
+    id: NOTE_IDS.movieAriival,
+    relativePath: 'notes/movies/Arrival.md',
+    title: 'Arrival',
+    emoji: '🛸',
+    tags: ['movies/sci-fi', 'denis-villeneuve', 'thoughtful'],
+    customProps: { year: 2016, director: 'Denis Villeneuve', genre: 'sci-fi', status: 'watched', rating: 5 },
+    daysAgoCreated: -370,
+    daysAgoModified: -120,
+    body: `Sapir-Whorf as a love letter. Best contact-with-aliens movie since 2001. Pair with [[Dune (2021)]] — same director, same ear for silence.
+
+#movies/sci-fi #thoughtful
+`
+  },
+  {
+    id: NOTE_IDS.movieTheMartianFilm,
+    relativePath: 'notes/movies/The Martian (Film).md',
+    title: 'The Martian (Film)',
+    emoji: '🥔',
+    tags: ['movies/sci-fi', 'ridley-scott'],
+    customProps: { year: 2015, director: 'Ridley Scott', genre: 'sci-fi', status: 'watched', rating: 4 },
+    daysAgoCreated: -240,
+    daysAgoModified: -150,
+    body: `Cleaner than [[The Martian|the book]] but loses the chemistry monologues. Watney is still Watney.
+
+#movies/sci-fi
+`
+  },
+  {
+    id: NOTE_IDS.movieParasite,
+    relativePath: 'notes/movies/Parasite.md',
+    title: 'Parasite',
+    emoji: '🪳',
+    tags: ['movies/drama', 'bong-joon-ho', 'foreign'],
+    customProps: { year: 2019, director: 'Bong Joon-ho', genre: 'thriller', status: 'watched', rating: 5 },
+    daysAgoCreated: -310,
+    daysAgoModified: -100,
+    body: `Class warfare as black comedy as horror. The pivot at the basement reveal is the best plot turn of the decade.
+
+#movies/foreign
+`
+  },
+  {
+    id: NOTE_IDS.movieSpiritedAway,
+    relativePath: 'notes/movies/Spirited Away.md',
+    title: 'Spirited Away',
+    emoji: '🐉',
+    tags: ['movies/animation', 'studio-ghibli'],
+    customProps: { year: 2001, director: 'Hayao Miyazaki', genre: 'animation', status: 'watched', rating: 5 },
+    daysAgoCreated: -380,
+    daysAgoModified: -200,
+    body: `Watching it after [[Tokyo Trip]] hit different — the bathhouse aesthetic isn't a fantasy, it's a memory.
+
+#movies/animation #ghibli
+`
+  },
+  {
+    id: NOTE_IDS.movieWatchlist2026,
+    relativePath: 'notes/movies/Watchlist 2026.md',
+    title: 'Watchlist 2026',
+    emoji: '🎞️',
+    tags: ['movies', 'watchlist'],
+    customProps: { year: 2026, status: 'active' },
+    daysAgoCreated: -125,
+    daysAgoModified: -2,
+    body: `## Want to watch
+
+- [ ] **Dune: Part Two** — bumped because [[Dune (2021)]] was so good
+- [ ] **Poor Things** — Yorgos Lanthimos
+- [ ] **Past Lives** — heard it's devastating
+- [x] **Everything Everywhere All at Once** — see [[Everything Everywhere All at Once]]
+- [ ] **Anatomy of a Fall** — French legal thriller
+- [ ] **The Zone of Interest** — quiet horror
+- [x] **Parasite** — see [[Parasite]]
+
+## Comparison
+
+| Film | Year | Genre | Length |
+|------|------|-------|--------|
+| Dune Part Two | 2024 | sci-fi | 166 min |
+| Poor Things | 2023 | drama | 141 min |
+| Past Lives | 2023 | romance | 105 min |
+| Anatomy of a Fall | 2023 | thriller | 152 min |
+
+#movies #watchlist
+`
+  },
+  {
+    id: NOTE_IDS.movieBladerunner,
+    relativePath: 'notes/movies/Blade Runner 2049.md',
+    title: 'Blade Runner 2049',
+    emoji: '🌆',
+    tags: ['movies/sci-fi', 'denis-villeneuve'],
+    customProps: { year: 2017, director: 'Denis Villeneuve', genre: 'sci-fi', status: 'watched', rating: 5 },
+    daysAgoCreated: -290,
+    daysAgoModified: -120,
+    body: `Slow. Achingly beautiful. The yellow-fog Las Vegas sequence is one of the most committed visuals in the medium.
+
+#movies/sci-fi
+`
+  },
+  {
+    id: NOTE_IDS.movieGoodfellas,
+    relativePath: 'notes/movies/Goodfellas.md',
+    title: 'Goodfellas',
+    emoji: '🍝',
+    tags: ['movies/crime', 'scorsese'],
+    customProps: { year: 1990, director: 'Martin Scorsese', genre: 'crime', status: 'watched', rating: 5 },
+    daysAgoCreated: -460,
+    daysAgoModified: -260,
+    body: `The Copacabana tracking shot does in three minutes what most films can't do in three hours.
+
+> As far back as I can remember, I always wanted to be a gangster.
+
+#movies/crime
+`
+  },
+
+  // ============================================================================
+  // WEIGHT
+  // ============================================================================
+  {
+    id: NOTE_IDS.weightCut2026,
+    relativePath: 'notes/weight/2026 Cut.md',
+    title: '2026 Cut',
+    emoji: '💪',
+    tags: ['fitness', 'cut'],
+    customProps: {
+      status: 'active',
+      startDate: '2026-04-01',
+      endDate: '2026-06-15',
+      weight: 82.4,
+      bodyFat: 18,
+      mood: 4
+    },
+    daysAgoCreated: -38,
+    daysAgoModified: 0,
+    body: `## Targets
+
+- **Start**: 87.1 kg / 21% BF (2026-04-01)
+- **Target**: 78 kg / 14% BF (by 2026-06-15)
+- **Pace**: ~0.5 kg / week — sustainable, hold strength
+
+## Strategy
+
+- 2200 kcal weekdays, 2400 weekends
+- Protein floor 180g — see [[Protein Targets]]
+- 4×5 strength + 2×low-impact cardio per [[Training Split]]
+- Sunday weigh-in only — see [[Sunday Weigh-in]]
+
+## Progress
+
+See running table in [[Cutting Log]]. Wikilinked journal entries: [[2026-04-22]], [[2026-05-01]], [[2026-05-08]].
+
+> [!info]
+> The cut isn't the diet. The cut is *not getting bored*.
+
+#fitness #cut
+`
+  },
+  {
+    id: NOTE_IDS.weightCuttingLog,
+    relativePath: 'notes/weight/Cutting Log.md',
+    title: 'Cutting Log',
+    emoji: '📊',
+    tags: ['fitness', 'log'],
+    customProps: { status: 'active' },
+    daysAgoCreated: -38,
+    daysAgoModified: 0,
+    body: `## Weekly weigh-in
+
+| Date | Weight (kg) | BF % | Notes |
+|------|-------------|------|-------|
+| 2026-04-05 | 87.1 | 21.0 | Starting line |
+| 2026-04-12 | 86.4 | 20.4 | Easy week |
+| 2026-04-19 | 85.5 | 19.6 | Cardio added |
+| 2026-04-26 | 85.0 | 19.1 | Stalled, kept patient |
+| 2026-05-03 | 84.0 | 18.4 | Whoosh |
+| 2026-05-08 | 82.4 | 18.0 | On pace |
+
+## Observations
+
+- Protein at 180g is non-negotiable; below it I lose strength
+- 7 hours sleep correlates with better Sunday numbers
+- Travel weeks ≠ progress weeks (see [[Tokyo Trip]])
+
+#fitness #log
+`
+  },
+  {
+    id: NOTE_IDS.weightProteinTargets,
+    relativePath: 'notes/weight/Protein Targets.md',
+    title: 'Protein Targets',
+    emoji: '🍳',
+    tags: ['fitness', 'nutrition'],
+    customProps: { status: 'active' },
+    daysAgoCreated: -38,
+    daysAgoModified: -12,
+    body: `## Daily floor: 180g
+
+Spread across 4 meals (~45g each):
+
+- **Breakfast** — 4 eggs + Greek yogurt + cottage cheese (~50g)
+- **Lunch** — 200g chicken or 250g cod (~45g)
+- **Snack** — protein shake (~30g)
+- **Dinner** — 200g lean beef or salmon (~45g)
+
+## Whey is a tool not a crutch
+
+Real food first. Powder fills gaps after lifting.
+
+#fitness #nutrition
+`
+  },
+  {
+    id: NOTE_IDS.weightTrainingSplit,
+    relativePath: 'notes/weight/Training Split.md',
+    title: 'Training Split',
+    emoji: '🏋️',
+    tags: ['fitness', 'strength'],
+    customProps: { status: 'active' },
+    daysAgoCreated: -90,
+    daysAgoModified: -10,
+    body: `## 4-day upper/lower
+
+- **Mon** — Lower (squat heavy, RDL, walking lunges)
+- **Tue** — Upper (bench, weighted pull-ups, DB row)
+- **Thu** — Lower (DL heavy, front squat, leg curl)
+- **Fri** — Upper (OHP, pull-ups, dips, curls)
+
+Wed and Sat are [[Cardio Plan]]. Sun rest.
+
+## Cues
+
+- Squat: brace, feet wide enough to see toes
+- DL: bar over mid-foot, lats engaged before lift
+- Bench: tucked elbows, leg drive
+
+#fitness #strength
+`
+  },
+  {
+    id: NOTE_IDS.weightSundayWeighIn,
+    relativePath: 'notes/weight/Sunday Weigh-in.md',
+    title: 'Sunday Weigh-in',
+    emoji: '⚖️',
+    tags: ['fitness', 'tracking'],
+    customProps: { status: 'active' },
+    daysAgoCreated: -150,
+    daysAgoModified: -7,
+    body: `Once a week. Sunday morning, after the bathroom, before water.
+
+Daily weighing is noise.
+
+Goes into [[Cutting Log]].
+
+#fitness
+`
+  },
+  {
+    id: NOTE_IDS.weightCardioPlan,
+    relativePath: 'notes/weight/Cardio Plan.md',
+    title: 'Cardio Plan',
+    emoji: '🏃',
+    tags: ['fitness', 'cardio'],
+    customProps: { status: 'active' },
+    daysAgoCreated: -90,
+    daysAgoModified: -25,
+    body: `Two sessions per week:
+
+- Wed — 30 min zone-2 (treadmill, easy nose-breathing)
+- Sat — 20 min interval (8 × 30s sprint / 60s walk)
+
+Heart rate monitor on, not optional.
+
+#fitness #cardio
+`
+  },
+  {
+    id: NOTE_IDS.weightFoodDiary,
+    relativePath: 'notes/weight/Food Diary.md',
+    title: 'Food Diary',
+    emoji: '🥗',
+    tags: ['fitness', 'food'],
+    customProps: { status: 'active' },
+    daysAgoCreated: -38,
+    daysAgoModified: -1,
+    body: `Loose log — only the meals that surprised me.
+
+- 2026-05-06 — Korean BBQ. Stayed lean by stacking veg first; came in under 1100 kcal.
+- 2026-05-04 — Pizza Saturday. Two slices, walked an hour after.
+- 2026-05-02 — Found a great mackerel teishoku spot near the office.
+
+#fitness #food
+`
+  },
+  {
+    id: NOTE_IDS.weightProgressPhotos,
+    relativePath: 'notes/weight/Progress Photos.md',
+    title: 'Progress Photos',
+    emoji: '📸',
+    tags: ['fitness', 'tracking'],
+    customProps: { status: 'active' },
+    daysAgoCreated: -38,
+    daysAgoModified: -1,
+    body: `Friday morning, kitchen window light, same angles. No flexing for the front shot — natural shoulders.
+
+Compares to [[2026 Cut]] start.
+
+![Front 2026-05-08](attachments/weight-front-may.jpg)
+
+#fitness
+`
+  },
+
+  // ============================================================================
+  // LIFE
+  // ============================================================================
+  {
+    id: NOTE_IDS.lifeMyWhy,
+    relativePath: 'notes/life/My Why.md',
+    title: 'My Why',
+    emoji: '🌳',
+    tags: ['life', 'reflection', 'mission'],
+    customProps: { mood: 5 },
+    daysAgoCreated: -700,
+    daysAgoModified: -7,
+    body: `## Why I'm building [[Memry Launch|Memry]]
+
+I lost five years of journal entries to a SaaS that pivoted, then sunset their consumer product. Two months notice and a CSV that didn't include any of the formatting.
+
+I'm building Memry so my **future self** can read my **current self** without asking permission from a vendor.
+
+Local first. End-to-end encrypted. Open file format. Sync optional.
+
+> The default settings of the universe should not include "your data is at risk because we ran out of runway."
+
+#life #mission
+`
+  },
+  {
+    id: NOTE_IDS.lifeOnReading,
+    relativePath: 'notes/life/On Reading.md',
+    title: 'On Reading',
+    emoji: '📖',
+    tags: ['life', 'reading', 'reflection'],
+    customProps: { mood: 4 },
+    daysAgoCreated: -200,
+    daysAgoModified: -20,
+    body: `## Why I keep at it
+
+Three reasons, in increasing order of importance:
+
+1. **Information** — useful, but Wikipedia handles this
+2. **Empathy** — fiction is a flight simulator for other lives
+3. **Slowness** — books make me *think slower*, which I cannot get anywhere else
+
+## What I avoid
+
+~~Self-help books that should have been blog posts.~~ Most of them.
+
+I'd rather read [[Atomic Habits]] (one good idea, executed well) than another *7 Habits Of...* knockoff.
+
+## What I keep coming back to
+
+- [[Deep Work]] — for the *defend the time* argument
+- [[Man's Search for Meaning]] — when things are hard
+
+#life #reading
+`
+  },
+  {
+    id: NOTE_IDS.lifeYearReview2025,
+    relativePath: 'notes/life/Year in Review 2025.md',
+    title: 'Year in Review 2025',
+    emoji: '📅',
+    tags: ['life', 'annual', 'reflection'],
+    customProps: { mood: 4 },
+    daysAgoCreated: -130,
+    daysAgoModified: -125,
+    body: `## What I shipped
+
+- Memry MVP, sync v1
+- 12kg lost (and kept off through holidays)
+- Trip to [[Tokyo Trip]] — first long flight since 2019
+
+## What I read (highlights)
+
+- [[Project Hail Mary]] — best fiction of the year
+- [[Four Thousand Weeks]] — the book I needed
+- [[On Writing]] — second time, hit harder
+
+## What didn't work
+
+- Two side projects abandoned at 60% — see [[Side Project Ideas]]
+- Three-month gap in journaling (Q3, no good reason)
+
+## 2026 themes
+
+- *Ship Memry to friends*
+- *Lose the last 6kg*
+- *Write more in public*
+
+#life #annual
+`
+  },
+  {
+    id: NOTE_IDS.lifeMorningRoutine,
+    relativePath: 'notes/life/Morning Routine.md',
+    title: 'Morning Routine',
+    emoji: '☀️',
+    tags: ['life', 'habits'],
+    customProps: { mood: 5 },
+    daysAgoCreated: -150,
+    daysAgoModified: -30,
+    body: `## 05:45 — 08:00
+
+- 05:45 — Up, water, no phone
+- 06:00 — 20 min journal — see today's entry
+- 06:30 — Coffee + read 30 min
+- 07:00 — Write (Memry, blog, journal)
+- 08:00 — Shower, breakfast, day starts
+
+## Rules
+
+1. No notifications until 09:00
+2. Phone in another room until 06:30
+3. *Coffee is the reward, not the start*
+
+Inspired by [[Deep Work]]. Codified after [[Atomic Habits]].
+
+#life #habits
+`
+  },
+  {
+    id: NOTE_IDS.lifeFinances,
+    relativePath: 'notes/life/Finances.md',
+    title: 'Finances',
+    emoji: '💸',
+    tags: ['life', 'money'],
+    customProps: { mood: 4 },
+    daysAgoCreated: -300,
+    daysAgoModified: -10,
+    body: `## Allocation (target)
+
+| Bucket | % | Vehicle |
+|--------|---|---------|
+| Index funds | 60 | Boring 3-fund portfolio |
+| Cash buffer | 20 | 6 months expenses |
+| Speculative | 10 | Crypto, individual stocks |
+| Cause/giving | 5 | Effective altruism + local |
+| Fun | 5 | Travel + a guilt-free buffer |
+
+## Rules I keep
+
+- *Pay myself first.* Auto-transfer on payday.
+- *No new credit cards.* The points game is a tax on attention.
+- *One big purchase per year* — last year was the [[Tokyo Trip]].
+
+#life #money
+`
+  },
+  {
+    id: NOTE_IDS.lifeOnFear,
+    relativePath: 'notes/life/On Fear.md',
+    title: 'On Fear',
+    emoji: '🌑',
+    tags: ['life', 'reflection'],
+    customProps: { mood: 3 },
+    daysAgoCreated: -90,
+    daysAgoModified: -45,
+    body: `## What I'm afraid of, in 2026
+
+- Building Memry "wrong" — the wrong abstractions, the wrong scope
+- Going public before it's ready
+- Going public after it's *too* ready (waited too long)
+
+## What I do about it
+
+Read [[Man's Search for Meaning]] when it's bad. Talk to my partner. Run hard. Sleep more.
+
+> The fear of suffering is worse than the suffering itself.
+
+#life #reflection
+`
+  },
+  {
+    id: NOTE_IDS.lifeRelationships,
+    relativePath: 'notes/life/Relationships.md',
+    title: 'Relationships',
+    emoji: '🫶',
+    tags: ['life', 'people'],
+    customProps: { mood: 5 },
+    daysAgoCreated: -250,
+    daysAgoModified: -10,
+    body: `## Inner ring
+
+People I want to invest in this year:
+
+- M. — see them every quarter, not less
+- D. — one long phone call per month
+- Two old friends I haven't seen since 2023
+
+## Mid ring
+
+Birthdays, occasional dinners. Loose contact, real warmth.
+
+## "Calendar weight"
+
+If a relationship is important, it should show up *in the calendar*, not just in my head.
+
+#life #people
+`
+  },
+  {
+    id: NOTE_IDS.lifeWhatBringsJoy,
+    relativePath: 'notes/life/What Brings Me Joy.md',
+    title: 'What Brings Me Joy',
+    emoji: '😄',
+    tags: ['life', 'gratitude', 'joy'],
+    customProps: { mood: 5 },
+    daysAgoCreated: -45,
+    daysAgoModified: -3,
+    body: `Running list. Adding when something hits, never editing.
+
+- The sound of espresso pulling
+- A good problem at 06:30 with no one awake
+- [[Spirited Away]] for the tenth time
+- The smell of a new bookstore (looking at you, [[Tokyo Cafes|Tokyo book cafes]])
+- The first 5 minutes of a long walk
+- Discovering my younger self made a smart decision I'd forgotten
+
+#life #joy
+`
+  },
+
+  // ============================================================================
+  // PROJECTS
+  // ============================================================================
+  {
+    id: NOTE_IDS.projMemryLaunch,
+    relativePath: 'notes/projects/Memry Launch.md',
+    title: 'Memry Launch',
+    emoji: '🚀',
+    tags: ['projects/memry', 'projects/active'],
+    customProps: {
+      status: 'active',
+      priority: 'high',
+      deadline: '2026-07-01',
+      owner: 'Kaan'
+    },
+    daysAgoCreated: -90,
+    daysAgoModified: 0,
+    body: `## Launch plan
+
+Aim for 2026-07-01. Soft launch to ~50 friends + IndieHackers.
+
+## What's left
+
+- [x] Sync v1 — see [[CRDT Architecture]]
+- [x] Calendar v1
+- [x] Inbox capture
+- [ ] Mobile read-only
+- [ ] Public landing
+- [ ] Pricing decision
+- [ ] Launch post on HN — see [[Conference Talk]] for the speech version
+
+## Risks
+
+> [!warning]
+> The biggest risk is *scope creep*, not bugs. Every "what about graph view 2.0" is two weeks I don't have.
+
+## Tech debts I'm carrying
+
+- See [[Drizzle ORM]] for the JSON-column gotcha
+- See [[Electron Gotchas]] for native-build pain
+- Postgres was almost the choice — see [[Postgres Indexing]]
+
+## Linked tasks
+
+Tasks tagged \`#projects/memry\` show up under "Memry Launch" project — these are the granular execution items.
+
+#projects/memry #active
+`
+  },
+  {
+    id: NOTE_IDS.projMemryArchitecture,
+    relativePath: 'notes/projects/Memry Architecture.md',
+    title: 'Memry Architecture',
+    emoji: '🏛️',
+    tags: ['projects/memry', 'architecture'],
+    customProps: {
+      status: 'active',
+      priority: 'high',
+      deadline: '2026-06-01',
+      owner: 'Kaan'
+    },
+    daysAgoCreated: -200,
+    daysAgoModified: -3,
+    body: `## Boundaries
+
+- **Renderer** — React 19, no Node access
+- **Main** — Electron, owns SQLite + Y.Docs
+- **Sync** — Cloudflare Workers + D1 + R2; never sees plaintext
+- **Contracts** — Zod-typed IPC + API
+
+See [[CRDT Architecture]] and [[Drizzle ORM]] for the data layer.
+
+## Why Electron
+
+Local-first means *all* data is on disk. Browser sandbox is a non-starter.
+
+#projects/memry #architecture
+`
+  },
+  {
+    id: NOTE_IDS.projMemryRoadmap,
+    relativePath: 'notes/projects/Memry Roadmap.md',
+    title: 'Memry Roadmap',
+    emoji: '🗺️',
+    tags: ['projects/memry', 'planning'],
+    customProps: {
+      status: 'active',
+      priority: 'medium',
+      deadline: '2026-12-31',
+      owner: 'Kaan'
+    },
+    daysAgoCreated: -150,
+    daysAgoModified: -7,
+    body: `## Q2 2026
+
+- v0.1 launch — see [[Memry Launch]]
+- Mobile read-only
+- iCal sync polish
+
+## Q3 2026
+
+- Mobile capture
+- Plugin API draft
+- First paid tier
+
+## Q4 2026
+
+- Plugin marketplace
+- Workspace sharing (selective)
+
+#projects/memry #planning
+`
+  },
+  {
+    id: NOTE_IDS.projMemryGTM,
+    relativePath: 'notes/projects/Memry GTM.md',
+    title: 'Memry GTM',
+    emoji: '📣',
+    tags: ['projects/memry', 'gtm'],
+    customProps: {
+      status: 'active',
+      priority: 'medium',
+      deadline: '2026-07-01',
+      owner: 'Kaan'
+    },
+    daysAgoCreated: -60,
+    daysAgoModified: -2,
+    body: `## Audience
+
+People who already journal but resent their tool. Bonus: programmers, researchers, knowledge workers.
+
+## Channels
+
+1. HN launch post — see [[Conference Talk]] for the long-form version
+2. IndieHackers + Twitter
+3. One thoughtful blog post per month
+
+## Anti-patterns
+
+- No paid ads. Not yet.
+- No "Notion alternative" framing. We are *not* Notion.
+
+#projects/memry #gtm
+`
+  },
+  {
+    id: NOTE_IDS.projGardenSchedule,
+    relativePath: 'notes/projects/Garden Schedule.md',
+    title: 'Garden Schedule',
+    emoji: '🌱',
+    tags: ['projects/home', 'garden'],
+    customProps: {
+      status: 'active',
+      priority: 'low',
+      deadline: '2026-09-15',
+      owner: 'Self'
+    },
+    daysAgoCreated: -45,
+    daysAgoModified: -1,
+    body: `## Spring
+
+- [x] Tomato seedlings — done 2026-04-12
+- [x] Basil — three pots
+- [ ] Bell peppers — week of 5/15
+- [ ] Mint divider barriers (it'll take over otherwise)
+
+## Summer plan
+
+Focus on what survives a heat dome: peppers, eggplant, zucchini.
+
+#projects/home
+`
+  },
+  {
+    id: NOTE_IDS.projHomeRenovation,
+    relativePath: 'notes/projects/Home Renovation.md',
+    title: 'Home Renovation',
+    emoji: '🔨',
+    tags: ['projects/home', 'renovation'],
+    customProps: {
+      status: 'backlog',
+      priority: 'medium',
+      deadline: '2026-10-01',
+      owner: 'Self'
+    },
+    daysAgoCreated: -30,
+    daysAgoModified: -15,
+    body: `## Punch list
+
+- [ ] Replace kitchen lights (LED retrofit)
+- [ ] Sand and stain back deck
+- [ ] Insulate attic crawl-space
+- [ ] Replace bathroom fan
+
+## Budget
+
+| Item | Estimate |
+|------|----------|
+| Kitchen lights | $400 |
+| Deck refinish | $800 |
+| Attic insulation | $1500 |
+| Bathroom fan | $250 |
+| **Total** | **$2950** |
+
+#projects/home
+`
+  },
+  {
+    id: NOTE_IDS.projBlogRedesign,
+    relativePath: 'notes/projects/Blog Redesign.md',
+    title: 'Blog Redesign',
+    emoji: '✏️',
+    tags: ['projects/personal', 'web'],
+    customProps: {
+      status: 'active',
+      priority: 'low',
+      deadline: '2026-06-15',
+      owner: 'Self'
+    },
+    daysAgoCreated: -25,
+    daysAgoModified: -3,
+    body: `Migrating from a static-site to Astro. Mostly to relearn the tooling, partly because I want better RSS.
+
+Tracking related work: [[TypeScript Patterns]], [[Vim Motions]].
+
+#projects/personal #web
+`
+  },
+  {
+    id: NOTE_IDS.projOpenSourceFork,
+    relativePath: 'notes/projects/Open Source Fork.md',
+    title: 'Open Source Fork',
+    emoji: '🌿',
+    tags: ['projects/personal', 'oss'],
+    customProps: {
+      status: 'idea',
+      priority: 'low',
+      owner: 'Self'
+    },
+    daysAgoCreated: -10,
+    daysAgoModified: -2,
+    body: `Considering a fork of an inactive markdown-link-checker. Not much code — but it'd save the team 30 minutes a week.
+
+Move only if a real maintainer disappears for ~6 months.
+
+#projects/oss
+`
+  },
+  {
+    id: NOTE_IDS.projSideProjectIdeas,
+    relativePath: 'notes/projects/Side Project Ideas.md',
+    title: 'Side Project Ideas',
+    emoji: '💡',
+    tags: ['projects/personal', 'ideas'],
+    customProps: {
+      status: 'idea',
+      priority: 'low',
+      owner: 'Self'
+    },
+    daysAgoCreated: -180,
+    daysAgoModified: -3,
+    body: `Running list — most won't ship, that's fine.
+
+- **CSV → graph** — drop a CSV, get an opinionated chart
+- **Reading retreats** — a service that books you a forced offline weekend
+- **Espresso log** — local-first, niche, mine
+- **Anti-newsletter** — subscriptions you *cancel* together
+- **Calendar diff tool** — compare meetings between two weeks
+
+Linked: [[Year in Review 2025]] (the *abandoned-at-60%* problem).
+
+#projects/personal #ideas
+`
+  },
+  {
+    id: NOTE_IDS.projConferenceTalk,
+    relativePath: 'notes/projects/Conference Talk.md',
+    title: 'Conference Talk',
+    emoji: '🎤',
+    tags: ['projects/personal', 'speaking'],
+    customProps: {
+      status: 'active',
+      priority: 'medium',
+      deadline: '2026-09-15',
+      owner: 'Self'
+    },
+    daysAgoCreated: -55,
+    daysAgoModified: -5,
+    body: `## Title (working)
+
+*Local-first is a choice, not a feature.*
+
+## Outline
+
+1. The cloud is a great default — most of the time
+2. The four times it isn't (vendor death, churn, latency, jurisdiction)
+3. What "local-first" actually means (Kleppmann, 2019)
+4. Memry as a worked example
+5. The trade-offs nobody likes to talk about
+
+## Submitted to
+
+- StrangeLoop — pending
+- LocalFirst Conf — accepted, talk on 2026-09-15
+
+#projects/personal #speaking
+`
+  },
+
+  // ============================================================================
+  // TECH
+  // ============================================================================
+  {
+    id: NOTE_IDS.techTypescriptPatterns,
+    relativePath: 'notes/tech/TypeScript Patterns.md',
+    title: 'TypeScript Patterns',
+    emoji: '🟦',
+    tags: ['tech/typescript', 'reference'],
+    customProps: { language: 'typescript', level: 'intermediate', status: 'active' },
+    daysAgoCreated: -240,
+    daysAgoModified: -2,
+    body: `## Discriminated unions for IPC
+
+\`\`\`typescript
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E }
+
+function parse(json: string): Result<unknown> {
+  try {
+    return { ok: true, value: JSON.parse(json) }
+  } catch (e) {
+    return { ok: false, error: e as Error }
+  }
+}
+\`\`\`
+
+## Branded types for IDs
+
+\`\`\`typescript
+type NoteId = string & { readonly _brand: unique symbol }
+const asNoteId = (s: string): NoteId => s as NoteId
+\`\`\`
+
+## Why I don't use \`any\`
+
+Because the moment I do, I've thrown away the only reason to write TypeScript. Use \`unknown\` and refine.
+
+Linked: [[Drizzle ORM]] for type inference details, [[Memry Architecture]] for the IPC boundary.
+
+#tech/typescript #reference
+`
+  },
+  {
+    id: NOTE_IDS.techDrizzleORM,
+    relativePath: 'notes/tech/Drizzle ORM.md',
+    title: 'Drizzle ORM',
+    emoji: '🦉',
+    tags: ['tech/sql', 'tech/typescript', 'reference'],
+    customProps: { language: 'typescript', level: 'intermediate', status: 'active' },
+    daysAgoCreated: -180,
+    daysAgoModified: -1,
+    body: `## Why I picked it
+
+Type-safe, no codegen runtime, ergonomics close to writing SQL by hand. Pairs well with [[TypeScript Patterns]].
+
+## Schema example
+
+\`\`\`typescript
+export const tasks = sqliteTable('tasks', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  status: text('status').$type<TaskStatus>(),
+  metadata: text('metadata', { mode: 'json' }).$type<Metadata | null>()
+})
+\`\`\`
+
+> [!warning]
+> Nullable JSON columns require \`null\` not \`undefined\` in \`.values()\` inserts. Otherwise Drizzle silently drops them and SQLite stores \`'undefined'\` as a string. Burned me twice.
+
+## Migrations
+
+Hand-written since 0020 — see commit \`b4c3f2\`. The autogenerated diffs got noisy after meta snapshots stopped being honest.
+
+\`\`\`bash
+pnpm db:generate    # schema → SQL
+pnpm db:push        # apply
+pnpm db:studio      # browse
+\`\`\`
+
+#tech/sql #tech/typescript
+`
+  },
+  {
+    id: NOTE_IDS.techCRDTArchitecture,
+    relativePath: 'notes/tech/CRDT Architecture.md',
+    title: 'CRDT Architecture',
+    emoji: '🧩',
+    tags: ['tech/sync', 'tech/architecture'],
+    customProps: { level: 'advanced', status: 'active' },
+    daysAgoCreated: -120,
+    daysAgoModified: -2,
+    body: `## Why Yjs
+
+CRDT for rich text. Built-in awareness. Battle-tested.
+
+## Sync flow
+
+\`\`\`mermaid
+sequenceDiagram
+    participant A as Device A
+    participant S as Sync Server
+    participant B as Device B
+    A->>S: push update (encrypted)
+    S->>B: notify
+    B->>S: pull updates
+    S-->>B: encrypted bytes
+    B->>B: decrypt + apply
+\`\`\`
+
+## Field-level vector clocks
+
+For tasks/projects — see the [[Drizzle ORM]] schema for \`field_clocks\` JSON column. This avoids whole-row LWW for structured records.
+
+## Footnote on naming
+
+Yes, "CRDT" is overloaded[^1]. Yjs implements a state-based CRDT (specifically a YATA variant).
+
+[^1]: Operational vs state vs delta-state CRDTs are all called "CRDTs" in conversation. Worth being precise in PR reviews.
+
+#tech/sync #tech/architecture
+`
+  },
+  {
+    id: NOTE_IDS.techPostgresIndexing,
+    relativePath: 'notes/tech/Postgres Indexing.md',
+    title: 'Postgres Indexing',
+    emoji: '🐘',
+    tags: ['tech/sql', 'tech/postgres'],
+    customProps: { language: 'sql', level: 'intermediate' },
+    daysAgoCreated: -160,
+    daysAgoModified: -50,
+    body: `## When B-tree isn't enough
+
+\`\`\`sql
+-- Partial index for hot path
+CREATE INDEX idx_tasks_active
+  ON tasks (project_id, modified_at DESC)
+  WHERE archived_at IS NULL;
+
+-- GIN for tag arrays
+CREATE INDEX idx_tasks_tags
+  ON tasks USING GIN (tags);
+
+-- BRIN for time-series, low maintenance
+CREATE INDEX idx_events_brin
+  ON events USING BRIN (created_at);
+\`\`\`
+
+## Pair with EXPLAIN ANALYZE
+
+Always. Otherwise you're index-cargo-culting.
+
+## Reference
+
+[[CMU Database Course]] — the deep dive that finally made this stick.
+
+#tech/sql #tech/postgres
+`
+  },
+  {
+    id: NOTE_IDS.techCMUDatabaseCourse,
+    relativePath: 'notes/tech/CMU Database Course.md',
+    title: 'CMU Database Course',
+    emoji: '🎓',
+    tags: ['tech/sql', 'learning'],
+    customProps: { level: 'advanced' },
+    daysAgoCreated: -210,
+    daysAgoModified: -90,
+    body: `Andy Pavlo's *Intro to Database Systems* (15-445). Watched all of fall 2024.
+
+The B+ tree section unstuck me. The query optimizer one terrified me — in a good way.
+
+Pair with [[Postgres Indexing]] for practice.
+
+#tech/sql #learning
+`
+  },
+  {
+    id: NOTE_IDS.techKipThorneBlackHoles,
+    relativePath: 'notes/tech/Kip Thorne — Black Holes.md',
+    title: 'Kip Thorne — Black Holes',
+    emoji: '⚫',
+    tags: ['tech/physics', 'reference'],
+    customProps: { level: 'intermediate' },
+    daysAgoCreated: -290,
+    daysAgoModified: -100,
+    body: `## Why I read this in 2026
+
+Watched [[Interstellar]] for the fourth time. Wanted to understand Gargantua, not just gawk at it.
+
+## Highlights
+
+- Schwarzschild radius is *that* simple: $r_s = \\frac{2GM}{c^2}$
+- Spinning black holes have an ergosphere — energy can be extracted
+- The hairy theorem: a black hole has only mass, charge, and spin[^1]
+
+[^1]: Kerr-Newman, technically.
+
+> Black holes are not dragons. They are *predictions*.
+
+#tech/physics
+`
+  },
+  {
+    id: NOTE_IDS.techElectronGotchas,
+    relativePath: 'notes/tech/Electron Gotchas.md',
+    title: 'Electron Gotchas',
+    emoji: '⚡',
+    tags: ['tech/electron', 'reference'],
+    customProps: { language: 'javascript', level: 'intermediate' },
+    daysAgoCreated: -100,
+    daysAgoModified: -5,
+    body: `## Native module ABI
+
+\`better-sqlite3\` must be rebuilt against the *target* runtime.
+
+\`\`\`bash
+# For node tests
+pnpm rebuild better-sqlite3
+
+# For electron app
+pnpm exec electron-rebuild -f -o better-sqlite3
+\`\`\`
+
+> [!error]
+> Forget this and you'll get \`ERR_DLOPEN_FAILED\` and the app falls through to the welcome screen. Spent two hours on this once.
+
+## IPC contract drift
+
+Run \`pnpm ipc:check\` after editing any contract type. Renderer will lie about preload until you do.
+
+#tech/electron
+`
+  },
+  {
+    id: NOTE_IDS.techSqliteVec,
+    relativePath: 'notes/tech/sqlite-vec.md',
+    title: 'sqlite-vec',
+    emoji: '🧮',
+    tags: ['tech/sql', 'tech/embeddings'],
+    customProps: { language: 'sql', level: 'intermediate' },
+    daysAgoCreated: -50,
+    daysAgoModified: -8,
+    body: `## Setup
+
+\`\`\`typescript
+import * as sqliteVec from 'sqlite-vec'
+sqliteVec.load(sqliteDb)
+
+sqliteDb.exec(\`
+  CREATE VIRTUAL TABLE vec_notes USING vec0(
+    note_id TEXT PRIMARY KEY,
+    embedding float[384] distance_metric=cosine
+  )
+\`)
+\`\`\`
+
+## Querying
+
+\`\`\`sql
+SELECT note_id, distance
+FROM vec_notes
+WHERE embedding MATCH ?
+  AND k = 10
+ORDER BY distance;
+\`\`\`
+
+#tech/sql #tech/embeddings
+`
+  },
+  {
+    id: NOTE_IDS.techVimMotions,
+    relativePath: 'notes/tech/Vim Motions.md',
+    title: 'Vim Motions',
+    emoji: '⌨️',
+    tags: ['tech/editor', 'reference'],
+    customProps: { level: 'intermediate' },
+    daysAgoCreated: -800,
+    daysAgoModified: -30,
+    body: `## Motions I use daily
+
+- \`ciw\` — change inner word
+- \`dap\` — delete a paragraph
+- \`%\` — match brace
+- \`f<char>\` and \`t<char>\` — jump to char
+- \`gd\` — go to definition
+
+## Plugins
+
+- vim-surround
+- vim-commentary
+- fzf.vim
+
+#tech/editor
+`
+  },
+  {
+    id: NOTE_IDS.techGitWorkflow,
+    relativePath: 'notes/tech/Git Workflow.md',
+    title: 'Git Workflow',
+    emoji: '🌿',
+    tags: ['tech/git', 'reference'],
+    customProps: { level: 'intermediate' },
+    daysAgoCreated: -350,
+    daysAgoModified: -14,
+    body: `## Daily
+
+\`\`\`bash
+git switch -c feat/inbox-snooze
+# work...
+git add -p
+git commit -m "feat: snooze inbox items with reason"
+git push -u origin HEAD
+gh pr create --fill
+\`\`\`
+
+## Rebase, don't merge
+
+Until the branch lands. After that, it's history.
+
+#tech/git
+`
+  },
+  {
+    id: NOTE_IDS.techRustNotes,
+    relativePath: 'notes/tech/Rust Notes.md',
+    title: 'Rust Notes',
+    emoji: '🦀',
+    tags: ['tech/rust', 'learning'],
+    customProps: { language: 'rust', level: 'beginner', status: 'active' },
+    daysAgoCreated: -75,
+    daysAgoModified: -10,
+    body: `Picking it up for fun and possible Memry-CLI tooling.
+
+\`\`\`rust
+fn main() {
+    let nums = vec![1, 2, 3, 4, 5];
+    let sum: i32 = nums.iter().sum();
+    println!("sum: {}", sum);
+}
+\`\`\`
+
+Borrow checker is exactly as advertised. The first week is rough; the second week clicks.
+
+#tech/rust #learning
+`
+  },
+  {
+    id: NOTE_IDS.techDockerCheatsheet,
+    relativePath: 'notes/tech/Docker Cheatsheet.md',
+    title: 'Docker Cheatsheet',
+    emoji: '🐳',
+    tags: ['tech/docker', 'reference'],
+    customProps: { language: 'shell', level: 'intermediate' },
+    daysAgoCreated: -420,
+    daysAgoModified: -25,
+    body: `\`\`\`bash
+docker ps -a
+docker logs -f <container>
+docker exec -it <container> /bin/bash
+docker compose up -d
+docker compose down -v
+docker system prune -af --volumes
+\`\`\`
+
+#tech/docker
+`
+  },
+
+  // ============================================================================
+  // TRAVEL
+  // ============================================================================
+  {
+    id: NOTE_IDS.travelTokyoTrip,
+    relativePath: 'notes/travel/Tokyo Trip.md',
+    title: 'Tokyo Trip',
+    emoji: '🗼',
+    tags: ['travel/asia', 'travel/japan', 'memoir'],
+    customProps: {
+      location: 'Tokyo, Japan',
+      startDate: '2026-04-12',
+      endDate: '2026-04-19',
+      status: 'done'
+    },
+    daysAgoCreated: -60,
+    daysAgoModified: -19,
+    body: `## Day-by-day
+
+- **Day 1** — Land at Haneda 16:00. Tokyo Tower. Onigiri at Narita-zushi.
+- **Day 2** — Shibuya, Meiji Jingu, late ramen at [[Osaka Ramen|the place I keep going to]] (technically Tokyo branch).
+- **Day 3** — Ghibli Museum. See [[Spirited Away]] before the trip — pays off here.
+- **Day 4** — Day trip to Kyoto — see [[Kyoto Day Trip]].
+- **Day 5** — Tsukiji. Coffee crawl — see [[Tokyo Cafes]].
+- **Day 6** — Disney Sea (yes).
+- **Day 7** — Last day. Souvenirs. Cried at Tokyo Station.
+- **Day 8** — Fly home.
+
+## Spending
+
+| Bucket | ¥ | $ |
+|--------|---|---|
+| Flights | 145000 | 970 |
+| Hotel | 110000 | 735 |
+| Food | 75000 | 500 |
+| Trains | 25000 | 165 |
+| Souvenirs | 30000 | 200 |
+| **Total** | **385000** | **2570** |
+
+## Photos
+
+![Tokyo Tower at dusk](attachments/tokyo-tower.jpg)
+
+Linked journal entries: [[2026-04-15]], [[2026-04-17]].
+
+#travel/asia #japan
+`
+  },
+  {
+    id: NOTE_IDS.travelKyotoDayTrip,
+    relativePath: 'notes/travel/Kyoto Day Trip.md',
+    title: 'Kyoto Day Trip',
+    emoji: '⛩️',
+    tags: ['travel/asia', 'travel/japan'],
+    customProps: {
+      location: 'Kyoto, Japan',
+      startDate: '2026-04-15',
+      endDate: '2026-04-15',
+      status: 'done'
+    },
+    daysAgoCreated: -23,
+    daysAgoModified: -23,
+    body: `06:30 Shinkansen. Sit on the right side for Fuji.
+
+## Hits
+
+- Fushimi Inari at 09:00 — climb the back path, skip the gates Instagrammers
+- Coffee + matcha at Kurasu (near the station)
+- Kinkaku-ji in the afternoon light
+
+## Misses
+
+- Skipped Arashiyama on purpose. Save for a longer trip.
+
+Linked: [[Tokyo Trip]] (the parent), journal [[2026-04-15]].
+
+#travel/asia
+`
+  },
+  {
+    id: NOTE_IDS.travelLisbonNotes,
+    relativePath: 'notes/travel/Lisbon Notes.md',
+    title: 'Lisbon Notes',
+    emoji: '🐠',
+    tags: ['travel/europe', 'travel/portugal'],
+    customProps: {
+      location: 'Lisbon, Portugal',
+      startDate: '2025-11-08',
+      endDate: '2025-11-13',
+      status: 'done'
+    },
+    daysAgoCreated: -190,
+    daysAgoModified: -180,
+    body: `## What I'd repeat
+
+- Tram 28 — but at 07:30, not 11:00
+- Pastel de nata at Manteigaria, not the famous one
+- Sunset at Miradouro da Senhora do Monte
+
+## What I'd skip
+
+- Time-out market — fine but tourist-priced
+
+#travel/europe
+`
+  },
+  {
+    id: NOTE_IDS.travelIcelandRingRoad,
+    relativePath: 'notes/travel/Iceland Ring Road.md',
+    title: 'Iceland Ring Road',
+    emoji: '🌋',
+    tags: ['travel/europe', 'travel/iceland', 'planning'],
+    customProps: {
+      location: 'Iceland',
+      startDate: '2026-08-12',
+      endDate: '2026-08-22',
+      status: 'planning'
+    },
+    daysAgoCreated: -40,
+    daysAgoModified: -2,
+    body: `## Plan
+
+10 days, counterclockwise. Camper van with kitchen.
+
+## Key stops
+
+- Snæfellsnes peninsula
+- Westfjords (extra 2 days, worth it)
+- Lake Mývatn
+- Höfn (lobster)
+- Vik
+
+## Watchlist before going
+
+- *The Secret Life of Walter Mitty*
+- *Fjall* documentary
+- See [[Packing List]] — different from Tokyo
+
+#travel/europe #planning
+`
+  },
+  {
+    id: NOTE_IDS.travelPackingList,
+    relativePath: 'notes/travel/Packing List.md',
+    title: 'Packing List',
+    emoji: '🎒',
+    tags: ['travel', 'reference'],
+    customProps: { status: 'active' },
+    daysAgoCreated: -180,
+    daysAgoModified: -10,
+    body: `## Always
+
+- Passport, IDs, two credit cards (separate bags)
+- Phone, charger, plug adapter
+- Kindle (loaded), eye mask, earplugs
+- Two t-shirts, one nice shirt, jeans, gym shorts
+- Running shoes (always)
+
+## Trip-specific
+
+- Tokyo: light layers, walking shoes — see [[Tokyo Trip]]
+- Iceland: rain shell, gloves, base layers — see [[Iceland Ring Road]]
+- Lisbon: linen everything — see [[Lisbon Notes]]
+
+#travel #reference
+`
+  },
+  {
+    id: NOTE_IDS.travelSeoulFood,
+    relativePath: 'notes/travel/Seoul Food.md',
+    title: 'Seoul Food',
+    emoji: '🌶️',
+    tags: ['travel/asia', 'travel/korea', 'food'],
+    customProps: {
+      location: 'Seoul, South Korea',
+      startDate: '2025-09-12',
+      endDate: '2025-09-18',
+      status: 'done'
+    },
+    daysAgoCreated: -240,
+    daysAgoModified: -200,
+    body: `Best meals:
+
+- **Mapo Galbi** — Mapo-gu. Ribs at 22:00, no English menu.
+- **Café Onion** — yes it's instagrammed. Yes, the bread is still that good.
+- **Tteokbokki street stalls** — the one in Myeongdong with the ahjumma in the orange apron.
+
+#travel/asia #food
+`
+  },
+  {
+    id: NOTE_IDS.travelMexicoCityArt,
+    relativePath: 'notes/travel/Mexico City Art.md',
+    title: 'Mexico City Art',
+    emoji: '🎨',
+    tags: ['travel/americas', 'travel/mexico', 'art'],
+    customProps: {
+      location: 'Mexico City',
+      startDate: '2025-06-04',
+      endDate: '2025-06-10',
+      status: 'done'
+    },
+    daysAgoCreated: -340,
+    daysAgoModified: -310,
+    body: `Casa Estudio Luis Barragán was the trip. The water on the staircase. The pink wall. Architecture as quiet drama.
+
+#travel/americas #art
+`
+  },
+  {
+    id: NOTE_IDS.travelOsakaRamen,
+    relativePath: 'notes/travel/Osaka Ramen.md',
+    title: 'Osaka Ramen',
+    emoji: '🍜',
+    tags: ['travel/asia', 'travel/japan', 'food'],
+    customProps: {
+      location: 'Osaka, Japan',
+      status: 'reference'
+    },
+    daysAgoCreated: -60,
+    daysAgoModified: -19,
+    body: `## Spots that earned a return
+
+- **Kamukura** — light shoyu, weirdly veggie-forward. Tokyo branch shows up in [[Tokyo Trip]].
+- **Ichiran** — yeah it's a chain. The booths still rule for jet-lagged solo eating.
+- **Ramen Yashichi** — taiwanese-style. Spicy.
+
+#travel/asia #food
+`
+  },
+  {
+    id: NOTE_IDS.travelTokyoCafes,
+    relativePath: 'notes/travel/Tokyo Cafes.md',
+    title: 'Tokyo Cafes',
+    emoji: '☕',
+    tags: ['travel/asia', 'travel/japan', 'coffee'],
+    customProps: {
+      location: 'Tokyo, Japan',
+      status: 'reference'
+    },
+    daysAgoCreated: -50,
+    daysAgoModified: -19,
+    body: `Working list. Tokyo coffee is *peculiar* — slow, careful, Sunday-mass quiet.
+
+| Cafe | Neighborhood | What to order |
+|------|--------------|---------------|
+| Glitch Coffee | Jimbocho | Filter, single origin |
+| Onibus Coffee | Nakameguro | Espresso outside |
+| Fuglen | Shibuya | Norwegian-Japanese fusion vibe |
+| % Arabica | Various | Insta but yes, the latte |
+| Bear Pond | Shimokitazawa | Closes at noon — show up |
+
+Pair with [[Kitchen Confidential]] for the *travel-as-eating* mindset.
+
+#travel/asia #coffee
+`
+  },
+  {
+    id: NOTE_IDS.travelAirportLounges,
+    relativePath: 'notes/travel/Airport Lounges.md',
+    title: 'Airport Lounges',
+    emoji: '🛫',
+    tags: ['travel', 'logistics'],
+    customProps: { status: 'reference' },
+    daysAgoCreated: -300,
+    daysAgoModified: -19,
+    body: `## Worth a visit
+
+- Cathay Pacific The Pier — HKG. The cabanas are real.
+- ANA Suite — HND. The dining room.
+
+## Skip
+
+- Most "premier" Priority Pass options. Fine, not great.
+
+#travel #logistics
+`
+  }
+]
+
+const TODAY_ISO = TODAY.toISOString()
+
+export const NOTES: NoteFile[] = SPECS.map((spec) => {
+  const created = dayOffset(spec.daysAgoCreated)
+  const modified = dayOffset(spec.daysAgoModified)
+  return {
+    relativePath: spec.relativePath,
+    frontmatter: {
+      id: spec.id,
+      title: spec.title,
+      created,
+      modified,
+      tags: spec.tags,
+      ...(spec.aliases ? { aliases: spec.aliases } : {}),
+      ...(spec.emoji ? { emoji: spec.emoji } : {}),
+      ...(spec.customProps ?? {})
+    },
+    body: spec.body
+  }
+})
+
+export const TODAY_REFERENCE_ISO = TODAY_ISO

--- a/apps/desktop/scripts/seed-data/tasks.ts
+++ b/apps/desktop/scripts/seed-data/tasks.ts
@@ -1,0 +1,827 @@
+import { generateId } from '../../src/main/lib/id'
+import { NOTE_IDS } from './notes'
+import type {
+  SeedProject,
+  SeedStatus,
+  SeedTask,
+  SeedTaskNote,
+  SeedTaskTag
+} from '../seed-vault/db-writer'
+
+const TODAY = new Date('2026-05-08T12:00:00.000Z')
+
+const dateOffset = (days: number): string => {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
+const datetimeOffset = (days: number, hours = 12): string => {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() + days)
+  d.setUTCHours(hours, 0, 0, 0)
+  return d.toISOString()
+}
+
+// ============================================================================
+// Project + Status IDs
+// ============================================================================
+
+export const PROJECT_IDS = {
+  inbox: generateId(),
+  memry: generateId(),
+  reading: generateId(),
+  fitness: generateId(),
+  tokyo: generateId(),
+  side: generateId()
+} as const
+
+const STATUS_IDS = {
+  // Inbox
+  inboxTodo: generateId(),
+  // Memry
+  memryBacklog: generateId(),
+  memryDoing: generateId(),
+  memryReview: generateId(),
+  memryDone: generateId(),
+  // Reading
+  readingWant: generateId(),
+  readingReading: generateId(),
+  readingDone: generateId(),
+  // Fitness
+  fitnessToday: generateId(),
+  fitnessUpcoming: generateId(),
+  fitnessDone: generateId(),
+  // Tokyo
+  tokyoPlanning: generateId(),
+  tokyoBooked: generateId(),
+  tokyoDone: generateId(),
+  // Side
+  sideIdea: generateId(),
+  sideBuilding: generateId(),
+  sideShipped: generateId()
+} as const
+
+// ============================================================================
+// Projects
+// ============================================================================
+
+export const PROJECTS: SeedProject[] = [
+  {
+    id: PROJECT_IDS.inbox,
+    name: 'Inbox',
+    description: 'Quick capture, no project assigned yet.',
+    color: '#6b7280',
+    icon: '📥',
+    position: 0,
+    isInbox: true
+  },
+  {
+    id: PROJECT_IDS.memry,
+    name: 'Memry Launch',
+    description: 'Ship Memry v0.1 to ~50 friends + IndieHackers.',
+    color: '#6366f1',
+    icon: '🚀',
+    position: 1
+  },
+  {
+    id: PROJECT_IDS.reading,
+    name: 'Reading',
+    description: '2026 reading queue and finished list.',
+    color: '#f59e0b',
+    icon: '📚',
+    position: 2
+  },
+  {
+    id: PROJECT_IDS.fitness,
+    name: 'Fitness 2026',
+    description: 'Cut, train, sleep, repeat.',
+    color: '#10b981',
+    icon: '💪',
+    position: 3
+  },
+  {
+    id: PROJECT_IDS.tokyo,
+    name: 'Travel: Tokyo',
+    description: 'April 2026 Tokyo trip — past, mostly closed out.',
+    color: '#ec4899',
+    icon: '🗼',
+    position: 4
+  },
+  {
+    id: PROJECT_IDS.side,
+    name: 'Side Projects',
+    description: 'Personal experiments, half-baked, sometimes shipped.',
+    color: '#8b5cf6',
+    icon: '✨',
+    position: 5
+  }
+]
+
+// ============================================================================
+// Statuses
+// ============================================================================
+
+export const STATUSES: SeedStatus[] = [
+  // Inbox
+  {
+    id: STATUS_IDS.inboxTodo,
+    projectId: PROJECT_IDS.inbox,
+    name: 'To Do',
+    color: '#6b7280',
+    position: 0,
+    isDefault: true
+  },
+  // Memry
+  {
+    id: STATUS_IDS.memryBacklog,
+    projectId: PROJECT_IDS.memry,
+    name: 'Backlog',
+    color: '#94a3b8',
+    position: 0,
+    isDefault: true
+  },
+  {
+    id: STATUS_IDS.memryDoing,
+    projectId: PROJECT_IDS.memry,
+    name: 'Doing',
+    color: '#6366f1',
+    position: 1
+  },
+  {
+    id: STATUS_IDS.memryReview,
+    projectId: PROJECT_IDS.memry,
+    name: 'Review',
+    color: '#f59e0b',
+    position: 2
+  },
+  {
+    id: STATUS_IDS.memryDone,
+    projectId: PROJECT_IDS.memry,
+    name: 'Done',
+    color: '#10b981',
+    position: 3,
+    isDone: true
+  },
+  // Reading
+  {
+    id: STATUS_IDS.readingWant,
+    projectId: PROJECT_IDS.reading,
+    name: 'Want to Read',
+    color: '#94a3b8',
+    position: 0,
+    isDefault: true
+  },
+  {
+    id: STATUS_IDS.readingReading,
+    projectId: PROJECT_IDS.reading,
+    name: 'Reading',
+    color: '#f59e0b',
+    position: 1
+  },
+  {
+    id: STATUS_IDS.readingDone,
+    projectId: PROJECT_IDS.reading,
+    name: 'Done',
+    color: '#10b981',
+    position: 2,
+    isDone: true
+  },
+  // Fitness
+  {
+    id: STATUS_IDS.fitnessToday,
+    projectId: PROJECT_IDS.fitness,
+    name: 'Today',
+    color: '#ef4444',
+    position: 0,
+    isDefault: true
+  },
+  {
+    id: STATUS_IDS.fitnessUpcoming,
+    projectId: PROJECT_IDS.fitness,
+    name: 'Upcoming',
+    color: '#f59e0b',
+    position: 1
+  },
+  {
+    id: STATUS_IDS.fitnessDone,
+    projectId: PROJECT_IDS.fitness,
+    name: 'Done',
+    color: '#10b981',
+    position: 2,
+    isDone: true
+  },
+  // Tokyo
+  {
+    id: STATUS_IDS.tokyoPlanning,
+    projectId: PROJECT_IDS.tokyo,
+    name: 'Planning',
+    color: '#94a3b8',
+    position: 0,
+    isDefault: true
+  },
+  {
+    id: STATUS_IDS.tokyoBooked,
+    projectId: PROJECT_IDS.tokyo,
+    name: 'Booked',
+    color: '#f59e0b',
+    position: 1
+  },
+  {
+    id: STATUS_IDS.tokyoDone,
+    projectId: PROJECT_IDS.tokyo,
+    name: 'Done',
+    color: '#10b981',
+    position: 2,
+    isDone: true
+  },
+  // Side
+  {
+    id: STATUS_IDS.sideIdea,
+    projectId: PROJECT_IDS.side,
+    name: 'Idea',
+    color: '#94a3b8',
+    position: 0,
+    isDefault: true
+  },
+  {
+    id: STATUS_IDS.sideBuilding,
+    projectId: PROJECT_IDS.side,
+    name: 'Building',
+    color: '#8b5cf6',
+    position: 1
+  },
+  {
+    id: STATUS_IDS.sideShipped,
+    projectId: PROJECT_IDS.side,
+    name: 'Shipped',
+    color: '#10b981',
+    position: 2,
+    isDone: true
+  }
+]
+
+// ============================================================================
+// Tasks
+// ============================================================================
+
+interface TaskBuilder {
+  key: string
+  projectId: string
+  statusId: string
+  title: string
+  description?: string
+  priority?: number
+  dueDate?: string
+  dueTime?: string
+  startDate?: string
+  repeatConfig?: Record<string, unknown> | null
+  repeatFrom?: string | null
+  sourceNoteId?: string | null
+  parentKey?: string | null
+  completedAt?: string | null
+  tags?: string[]
+  noteRefs?: string[]
+}
+
+const TASK_BUILDERS: TaskBuilder[] = [
+  // ========================================================================
+  // Inbox project — the catch-all
+  // ========================================================================
+  {
+    key: 'inbox-call-mom',
+    projectId: PROJECT_IDS.inbox,
+    statusId: STATUS_IDS.inboxTodo,
+    title: 'Call Mom about birthday plans',
+    priority: 1,
+    dueDate: dateOffset(2),
+    tags: ['family']
+  },
+  {
+    key: 'inbox-renew-license',
+    projectId: PROJECT_IDS.inbox,
+    statusId: STATUS_IDS.inboxTodo,
+    title: 'Renew driver license',
+    description: 'Online renewal — needs the old card number.',
+    priority: 2,
+    dueDate: dateOffset(14),
+    tags: ['admin']
+  },
+  {
+    key: 'inbox-dentist',
+    projectId: PROJECT_IDS.inbox,
+    statusId: STATUS_IDS.inboxTodo,
+    title: 'Book dentist cleaning',
+    priority: 1,
+    dueDate: dateOffset(7),
+    tags: ['health']
+  },
+  {
+    key: 'inbox-followup',
+    projectId: PROJECT_IDS.inbox,
+    statusId: STATUS_IDS.inboxTodo,
+    title: 'Follow up with M. about coffee Saturday',
+    priority: 1,
+    dueDate: dateOffset(1),
+    tags: ['friends']
+  },
+  {
+    key: 'inbox-tax-docs',
+    projectId: PROJECT_IDS.inbox,
+    statusId: STATUS_IDS.inboxTodo,
+    title: 'File 2025 tax extension paperwork',
+    priority: 3,
+    dueDate: dateOffset(-3), // overdue
+    tags: ['admin']
+  },
+
+  // ========================================================================
+  // Memry Launch
+  // ========================================================================
+  {
+    key: 'memry-mobile-readonly',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryBacklog,
+    title: 'Mobile read-only viewer',
+    description: 'iOS + Android: open vault, read notes, tap wikilinks, zero edit.',
+    priority: 2,
+    dueDate: dateOffset(30),
+    sourceNoteId: NOTE_IDS.projMemryRoadmap,
+    tags: ['projects/memry', 'mobile'],
+    noteRefs: [NOTE_IDS.projMemryLaunch, NOTE_IDS.projMemryRoadmap]
+  },
+  {
+    key: 'memry-public-landing',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryDoing,
+    title: 'Build public landing page',
+    description: 'One page. Hero, three benefits, screenshot, waitlist.',
+    priority: 3,
+    dueDate: dateOffset(10),
+    sourceNoteId: NOTE_IDS.projMemryGTM,
+    tags: ['projects/memry', 'web', 'launch'],
+    noteRefs: [NOTE_IDS.projMemryGTM, NOTE_IDS.projMemryLaunch]
+  },
+  {
+    key: 'memry-pricing',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryDoing,
+    title: 'Decide on pricing',
+    description: 'Free + paid sync? One-time? Open source + hosted? Pick one.',
+    priority: 3,
+    dueDate: dateOffset(5),
+    sourceNoteId: NOTE_IDS.projMemryGTM,
+    tags: ['projects/memry', 'gtm']
+  },
+  {
+    key: 'memry-launch-post',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryBacklog,
+    title: 'Draft Hacker News launch post',
+    priority: 2,
+    dueDate: dateOffset(20),
+    sourceNoteId: NOTE_IDS.projMemryGTM,
+    tags: ['projects/memry', 'gtm', 'writing']
+  },
+  {
+    key: 'memry-crdt-sync-v1',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryDone,
+    title: 'CRDT sync v1',
+    description: 'Yjs over the contract layer. End-to-end working between two devices.',
+    priority: 3,
+    completedAt: datetimeOffset(-12, 18),
+    sourceNoteId: NOTE_IDS.techCRDTArchitecture,
+    tags: ['projects/memry', 'sync'],
+    noteRefs: [NOTE_IDS.techCRDTArchitecture, NOTE_IDS.projMemryArchitecture]
+  },
+  {
+    key: 'memry-calendar-v1',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryDone,
+    title: 'Calendar v1 (local + Google)',
+    priority: 2,
+    completedAt: datetimeOffset(-25, 14),
+    sourceNoteId: NOTE_IDS.projMemryRoadmap,
+    tags: ['projects/memry', 'calendar']
+  },
+  {
+    key: 'memry-inbox-snooze',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryDone,
+    title: 'Inbox snooze with reason',
+    priority: 1,
+    completedAt: datetimeOffset(-11, 11),
+    tags: ['projects/memry', 'inbox']
+  },
+  {
+    key: 'memry-inbox-suggestions',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryReview,
+    title: 'Inbox AI filing suggestions',
+    description: 'Suggest a destination folder + tags based on filing history.',
+    priority: 2,
+    dueDate: dateOffset(2),
+    tags: ['projects/memry', 'inbox', 'ai']
+  },
+  {
+    key: 'memry-graph-view-perf',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryBacklog,
+    title: 'Graph view: lazy load > 500 nodes',
+    description: 'Hits a wall around 800 notes. Force-atlas runs at 4 fps. Lazy load.',
+    priority: 1,
+    dueDate: dateOffset(35),
+    tags: ['projects/memry', 'perf']
+  },
+  {
+    key: 'memry-tasks-recurring',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryDoing,
+    title: 'Recurring tasks: repeat-from-completed',
+    description: 'When a recurring task is completed, schedule next from completion, not due date.',
+    priority: 2,
+    dueDate: dateOffset(7),
+    tags: ['projects/memry', 'tasks']
+  },
+  {
+    key: 'memry-conf-talk',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryBacklog,
+    title: 'Prep LocalFirst Conf talk slides',
+    priority: 2,
+    dueDate: dateOffset(120),
+    sourceNoteId: NOTE_IDS.projConferenceTalk,
+    tags: ['projects/memry', 'speaking'],
+    noteRefs: [NOTE_IDS.projConferenceTalk]
+  },
+  {
+    key: 'memry-tests-e2e',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryDoing,
+    title: 'Stabilize Playwright e2e suite in CI',
+    description: 'Flaky on xvfb timing. Pre-built electron bundle is the fix.',
+    priority: 1,
+    dueDate: dateOffset(4),
+    tags: ['projects/memry', 'tests']
+  },
+
+  // Subtask tree under "Mobile read-only viewer"
+  {
+    key: 'memry-mobile-iOS',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryBacklog,
+    title: 'iOS — wrap WKWebView',
+    priority: 2,
+    dueDate: dateOffset(28),
+    parentKey: 'memry-mobile-readonly',
+    tags: ['projects/memry', 'mobile', 'ios']
+  },
+  {
+    key: 'memry-mobile-android',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryBacklog,
+    title: 'Android — wrap WebView',
+    priority: 2,
+    dueDate: dateOffset(35),
+    parentKey: 'memry-mobile-readonly',
+    tags: ['projects/memry', 'mobile', 'android']
+  },
+  {
+    key: 'memry-mobile-bundle',
+    projectId: PROJECT_IDS.memry,
+    statusId: STATUS_IDS.memryBacklog,
+    title: 'Mobile — shared bundle build pipeline',
+    parentKey: 'memry-mobile-readonly',
+    priority: 2,
+    dueDate: dateOffset(15),
+    tags: ['projects/memry', 'mobile', 'tooling']
+  },
+
+  // ========================================================================
+  // Reading
+  // ========================================================================
+  {
+    key: 'read-sapiens',
+    projectId: PROJECT_IDS.reading,
+    statusId: STATUS_IDS.readingReading,
+    title: 'Finish reading Sapiens',
+    priority: 1,
+    dueDate: dateOffset(21),
+    sourceNoteId: NOTE_IDS.bookSapiens,
+    tags: ['reading', 'nonfiction'],
+    noteRefs: [NOTE_IDS.bookSapiens]
+  },
+  {
+    key: 'read-mystery-guest',
+    projectId: PROJECT_IDS.reading,
+    statusId: STATUS_IDS.readingReading,
+    title: 'Finish The Mystery Guest',
+    priority: 0,
+    dueDate: dateOffset(7),
+    sourceNoteId: NOTE_IDS.bookMisteryHotel,
+    tags: ['reading', 'fiction'],
+    noteRefs: [NOTE_IDS.bookMisteryHotel]
+  },
+  {
+    key: 'read-naval',
+    projectId: PROJECT_IDS.reading,
+    statusId: STATUS_IDS.readingReading,
+    title: 'Finish The Almanack of Naval Ravikant',
+    priority: 0,
+    dueDate: dateOffset(14),
+    sourceNoteId: NOTE_IDS.bookAlmanackOfNaval,
+    tags: ['reading', 'nonfiction'],
+    noteRefs: [NOTE_IDS.bookAlmanackOfNaval]
+  },
+  {
+    key: 'read-dune-messiah',
+    projectId: PROJECT_IDS.reading,
+    statusId: STATUS_IDS.readingWant,
+    title: 'Read Dune Messiah',
+    description: 'Sequel to [[Dune]]. Heard it splits the fanbase.',
+    priority: 0,
+    sourceNoteId: NOTE_IDS.bookDune,
+    tags: ['reading', 'fiction', 'sci-fi'],
+    noteRefs: [NOTE_IDS.bookDune]
+  },
+  {
+    key: 'read-borders',
+    projectId: PROJECT_IDS.reading,
+    statusId: STATUS_IDS.readingWant,
+    title: 'Read All the Light We Cannot See',
+    priority: 0,
+    tags: ['reading', 'fiction']
+  },
+  {
+    key: 'read-hailmary-done',
+    projectId: PROJECT_IDS.reading,
+    statusId: STATUS_IDS.readingDone,
+    title: 'Read Project Hail Mary',
+    completedAt: datetimeOffset(-22, 21),
+    sourceNoteId: NOTE_IDS.bookProjectHailMary,
+    tags: ['reading', 'fiction', 'sci-fi'],
+    noteRefs: [NOTE_IDS.bookProjectHailMary]
+  },
+  {
+    key: 'read-4kweeks-done',
+    projectId: PROJECT_IDS.reading,
+    statusId: STATUS_IDS.readingDone,
+    title: 'Read Four Thousand Weeks',
+    completedAt: datetimeOffset(-90, 22),
+    sourceNoteId: NOTE_IDS.bookFourThousandWeeks,
+    tags: ['reading', 'nonfiction'],
+    noteRefs: [NOTE_IDS.bookFourThousandWeeks]
+  },
+  {
+    key: 'read-onwriting-done',
+    projectId: PROJECT_IDS.reading,
+    statusId: STATUS_IDS.readingDone,
+    title: 'Read On Writing',
+    completedAt: datetimeOffset(-180, 22),
+    sourceNoteId: NOTE_IDS.bookOnWriting,
+    tags: ['reading', 'nonfiction', 'craft']
+  },
+
+  // ========================================================================
+  // Fitness 2026
+  // ========================================================================
+  {
+    key: 'fit-weighin',
+    projectId: PROJECT_IDS.fitness,
+    statusId: STATUS_IDS.fitnessToday,
+    title: 'Sunday weigh-in',
+    description: 'Sunday morning, after the bathroom, before water. Update [[Cutting Log]].',
+    priority: 1,
+    dueDate: dateOffset(2),
+    repeatConfig: { freq: 'weekly', byDay: 'SU' },
+    repeatFrom: 'due',
+    sourceNoteId: NOTE_IDS.weightSundayWeighIn,
+    tags: ['fitness', 'recurring'],
+    noteRefs: [NOTE_IDS.weightSundayWeighIn, NOTE_IDS.weightCuttingLog]
+  },
+  {
+    key: 'fit-lower-mon',
+    projectId: PROJECT_IDS.fitness,
+    statusId: STATUS_IDS.fitnessToday,
+    title: 'Lower (Squat day)',
+    description: '5×5 back squat, 4×8 RDL, 3×10 walking lunges.',
+    priority: 1,
+    dueDate: dateOffset(3),
+    sourceNoteId: NOTE_IDS.weightTrainingSplit,
+    tags: ['fitness', 'lift'],
+    noteRefs: [NOTE_IDS.weightTrainingSplit]
+  },
+  {
+    key: 'fit-cardio-wed',
+    projectId: PROJECT_IDS.fitness,
+    statusId: STATUS_IDS.fitnessUpcoming,
+    title: 'Zone 2 cardio (30 min)',
+    priority: 0,
+    dueDate: dateOffset(5),
+    sourceNoteId: NOTE_IDS.weightCardioPlan,
+    tags: ['fitness', 'cardio']
+  },
+  {
+    key: 'fit-meal-prep',
+    projectId: PROJECT_IDS.fitness,
+    statusId: STATUS_IDS.fitnessUpcoming,
+    title: 'Sunday meal prep',
+    priority: 1,
+    dueDate: dateOffset(2),
+    sourceNoteId: NOTE_IDS.weightProteinTargets,
+    tags: ['fitness', 'food'],
+    noteRefs: [NOTE_IDS.weightProteinTargets]
+  },
+  {
+    key: 'fit-progress-photo',
+    projectId: PROJECT_IDS.fitness,
+    statusId: STATUS_IDS.fitnessUpcoming,
+    title: 'Friday progress photos',
+    priority: 0,
+    dueDate: dateOffset(7),
+    sourceNoteId: NOTE_IDS.weightProgressPhotos,
+    tags: ['fitness', 'tracking']
+  },
+  {
+    key: 'fit-overdue',
+    projectId: PROJECT_IDS.fitness,
+    statusId: STATUS_IDS.fitnessToday,
+    title: 'Refill creatine',
+    priority: 0,
+    dueDate: dateOffset(-2),
+    tags: ['fitness']
+  },
+  {
+    key: 'fit-done-1',
+    projectId: PROJECT_IDS.fitness,
+    statusId: STATUS_IDS.fitnessDone,
+    title: 'Last week — completed split',
+    completedAt: datetimeOffset(-5, 19),
+    tags: ['fitness']
+  },
+  {
+    key: 'fit-done-2',
+    projectId: PROJECT_IDS.fitness,
+    statusId: STATUS_IDS.fitnessDone,
+    title: 'Squat 140kg × 5 (PR)',
+    completedAt: datetimeOffset(-27, 18),
+    tags: ['fitness', 'pr']
+  },
+
+  // ========================================================================
+  // Travel: Tokyo
+  // ========================================================================
+  {
+    key: 'tokyo-flight-booked',
+    projectId: PROJECT_IDS.tokyo,
+    statusId: STATUS_IDS.tokyoDone,
+    title: 'Book flights',
+    completedAt: datetimeOffset(-90, 14),
+    sourceNoteId: NOTE_IDS.travelTokyoTrip,
+    tags: ['travel/japan'],
+    noteRefs: [NOTE_IDS.travelTokyoTrip]
+  },
+  {
+    key: 'tokyo-hotel',
+    projectId: PROJECT_IDS.tokyo,
+    statusId: STATUS_IDS.tokyoDone,
+    title: 'Book hotel (Park Hyatt)',
+    completedAt: datetimeOffset(-85, 11),
+    sourceNoteId: NOTE_IDS.travelTokyoTrip,
+    tags: ['travel/japan']
+  },
+  {
+    key: 'tokyo-jr-pass',
+    projectId: PROJECT_IDS.tokyo,
+    statusId: STATUS_IDS.tokyoDone,
+    title: 'JR Pass (7-day)',
+    completedAt: datetimeOffset(-50, 9),
+    tags: ['travel/japan']
+  },
+  {
+    key: 'tokyo-kyoto-day',
+    projectId: PROJECT_IDS.tokyo,
+    statusId: STATUS_IDS.tokyoDone,
+    title: 'Day trip — Kyoto',
+    completedAt: datetimeOffset(-23, 21),
+    sourceNoteId: NOTE_IDS.travelKyotoDayTrip,
+    tags: ['travel/japan'],
+    noteRefs: [NOTE_IDS.travelKyotoDayTrip]
+  },
+  {
+    key: 'tokyo-cafes-list',
+    projectId: PROJECT_IDS.tokyo,
+    statusId: STATUS_IDS.tokyoDone,
+    title: 'Coffee crawl',
+    completedAt: datetimeOffset(-21, 17),
+    sourceNoteId: NOTE_IDS.travelTokyoCafes,
+    tags: ['travel/japan', 'coffee'],
+    noteRefs: [NOTE_IDS.travelTokyoCafes]
+  },
+  {
+    key: 'tokyo-thank-you',
+    projectId: PROJECT_IDS.tokyo,
+    statusId: STATUS_IDS.tokyoBooked,
+    title: 'Send thank-you note to host',
+    priority: 1,
+    dueDate: dateOffset(3),
+    tags: ['travel/japan', 'gratitude']
+  },
+
+  // ========================================================================
+  // Side Projects
+  // ========================================================================
+  {
+    key: 'side-csv-graph',
+    projectId: PROJECT_IDS.side,
+    statusId: STATUS_IDS.sideIdea,
+    title: 'CSV → opinionated chart',
+    description: 'Drop a CSV, get one chart, no config. Chart picks itself.',
+    priority: 0,
+    sourceNoteId: NOTE_IDS.projSideProjectIdeas,
+    tags: ['side-projects'],
+    noteRefs: [NOTE_IDS.projSideProjectIdeas]
+  },
+  {
+    key: 'side-espresso-log',
+    projectId: PROJECT_IDS.side,
+    statusId: STATUS_IDS.sideIdea,
+    title: 'Espresso log app',
+    description: 'Niche, mine, local-first. Track shots, dose, ratio, dial-in journal.',
+    priority: 0,
+    sourceNoteId: NOTE_IDS.projSideProjectIdeas,
+    tags: ['side-projects', 'coffee']
+  },
+  {
+    key: 'side-blog-redesign',
+    projectId: PROJECT_IDS.side,
+    statusId: STATUS_IDS.sideBuilding,
+    title: 'Blog redesign — migrate to Astro',
+    priority: 1,
+    dueDate: dateOffset(38),
+    sourceNoteId: NOTE_IDS.projBlogRedesign,
+    tags: ['side-projects', 'web'],
+    noteRefs: [NOTE_IDS.projBlogRedesign]
+  },
+  {
+    key: 'side-rust-cli',
+    projectId: PROJECT_IDS.side,
+    statusId: STATUS_IDS.sideBuilding,
+    title: 'Rust CLI for vault stats',
+    description: 'A vault-stats binary in Rust — note count, word count, link density.',
+    priority: 0,
+    dueDate: dateOffset(50),
+    sourceNoteId: NOTE_IDS.techRustNotes,
+    tags: ['side-projects', 'rust'],
+    noteRefs: [NOTE_IDS.techRustNotes]
+  },
+  {
+    key: 'side-shipped-1',
+    projectId: PROJECT_IDS.side,
+    statusId: STATUS_IDS.sideShipped,
+    title: 'Anti-newsletter MVP',
+    description: 'Shipped to 3 users. They liked it. Did not scale.',
+    completedAt: datetimeOffset(-200, 18),
+    tags: ['side-projects']
+  },
+  {
+    key: 'side-shipped-2',
+    projectId: PROJECT_IDS.side,
+    statusId: STATUS_IDS.sideShipped,
+    title: 'Calendar diff tool',
+    completedAt: datetimeOffset(-310, 12),
+    tags: ['side-projects']
+  }
+]
+
+// Resolve task IDs and parent links
+const taskIdByKey = new Map<string, string>(TASK_BUILDERS.map((b) => [b.key, generateId()]))
+
+export const TASKS: SeedTask[] = TASK_BUILDERS.map((b, idx) => ({
+  id: taskIdByKey.get(b.key)!,
+  projectId: b.projectId,
+  statusId: b.statusId,
+  parentId: b.parentKey ? taskIdByKey.get(b.parentKey)! : null,
+  title: b.title,
+  description: b.description ?? null,
+  priority: b.priority ?? 0,
+  position: idx,
+  dueDate: b.dueDate ?? null,
+  dueTime: b.dueTime ?? null,
+  startDate: b.startDate ?? null,
+  repeatConfig: b.repeatConfig ?? null,
+  repeatFrom: b.repeatFrom ?? null,
+  sourceNoteId: b.sourceNoteId ?? null,
+  completedAt: b.completedAt ?? null
+}))
+
+export const TASK_NOTES: SeedTaskNote[] = TASK_BUILDERS.flatMap((b) => {
+  const taskId = taskIdByKey.get(b.key)!
+  return (b.noteRefs ?? []).map((noteId) => ({ taskId, noteId }))
+})
+
+export const TASK_TAGS: SeedTaskTag[] = TASK_BUILDERS.flatMap((b) => {
+  const taskId = taskIdByKey.get(b.key)!
+  return (b.tags ?? []).map((tag) => ({ taskId, tag }))
+})

--- a/apps/desktop/scripts/seed-vault.ts
+++ b/apps/desktop/scripts/seed-vault.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env npx tsx
+/**
+ * Unified seed command — populates a dedicated demo vault with notes, tasks,
+ * calendar, journal, and inbox content for screenshots and exploration.
+ *
+ * Default target: ~/MemryDemoVault. Override with --vault=<path>.
+ * Always wipes and re-seeds.
+ */
+
+import { existsSync, writeFileSync } from 'fs'
+import { resolve } from 'path'
+import { homedir } from 'os'
+
+import { wipeVault } from './seed-vault/wipe'
+import { writeNoteFiles } from './seed-vault/file-writer'
+import {
+  insertCalendarEvents,
+  insertCalendarSources,
+  insertFilingHistory,
+  insertFolderConfigs,
+  insertInboxItems,
+  insertProjects,
+  insertPropertyDefinitions,
+  insertStatuses,
+  insertTagDefinitions,
+  insertTaskNotes,
+  insertTasks,
+  insertTaskTags,
+  openDataDb
+} from './seed-vault/db-writer'
+
+import { FOLDER_CONFIGS, NOTES } from './seed-data/notes'
+import { JOURNAL_NOTES } from './seed-data/journal'
+import { PROJECTS, STATUSES, TASKS, TASK_NOTES, TASK_TAGS } from './seed-data/tasks'
+import { CALENDAR_EVENTS, CALENDAR_SOURCES } from './seed-data/calendar'
+import { FILING_HISTORY_ROWS, INBOX_ITEMS } from './seed-data/inbox'
+
+interface CliArgs {
+  vaultPath: string
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: Partial<CliArgs> = {}
+  for (const raw of argv) {
+    if (raw.startsWith('--vault=')) {
+      args.vaultPath = resolve(raw.slice('--vault='.length))
+    }
+  }
+  return {
+    vaultPath: args.vaultPath ?? resolve(homedir(), 'MemryDemoVault')
+  }
+}
+
+const TAG_PALETTE = [
+  { name: 'research', color: '#3b82f6' },
+  { name: 'active', color: '#10b981' },
+  { name: 'archive', color: '#6b7280' },
+  { name: 'sci-fi', color: '#8b5cf6' },
+  { name: 'fiction', color: '#f59e0b' },
+  { name: 'nonfiction', color: '#ec4899' },
+  { name: 'classic', color: '#a855f7' },
+  { name: 'reread', color: '#0ea5e9' },
+  { name: 'tech/typescript', color: '#0ea5e9' },
+  { name: 'tech/sql', color: '#a855f7' },
+  { name: 'tech/sync', color: '#22c55e' },
+  { name: 'tech/rust', color: '#dc2626' },
+  { name: 'tech/electron', color: '#9333ea' },
+  { name: 'tech/postgres', color: '#0284c7' },
+  { name: 'tech/python', color: '#22c55e' },
+  { name: 'projects/memry', color: '#6366f1' },
+  { name: 'projects/active', color: '#14b8a6' },
+  { name: 'projects/personal', color: '#f97316' },
+  { name: 'projects/home', color: '#84cc16' },
+  { name: 'travel/asia', color: '#f97316' },
+  { name: 'travel/europe', color: '#0ea5e9' },
+  { name: 'travel/japan', color: '#ef4444' },
+  { name: 'fitness', color: '#84cc16' },
+  { name: 'reading', color: '#f59e0b' },
+  { name: 'daily', color: '#6366f1' },
+  { name: 'flow', color: '#10b981' },
+  { name: 'reflection', color: '#a855f7' }
+]
+
+const PROPERTY_DEFS = [
+  { name: 'rating', type: 'number', color: '#f59e0b' },
+  { name: 'status', type: 'text', color: '#6366f1' },
+  { name: 'priority', type: 'text', color: '#ef4444' },
+  { name: 'mood', type: 'number', color: '#a855f7' },
+  { name: 'weight', type: 'number', color: '#84cc16' },
+  { name: 'bodyFat', type: 'number', color: '#84cc16' },
+  { name: 'author', type: 'text', color: '#0ea5e9' },
+  { name: 'director', type: 'text', color: '#ec4899' },
+  { name: 'genre', type: 'text', color: '#8b5cf6' },
+  { name: 'language', type: 'text', color: '#10b981' },
+  { name: 'level', type: 'text', color: '#6b7280' },
+  { name: 'location', type: 'text', color: '#f97316' },
+  { name: 'year', type: 'number', color: '#6366f1' },
+  { name: 'pages', type: 'number', color: '#f59e0b' },
+  { name: 'deadline', type: 'date', color: '#ef4444' },
+  { name: 'startDate', type: 'date', color: '#10b981' },
+  { name: 'endDate', type: 'date', color: '#10b981' },
+  { name: 'owner', type: 'text', color: '#6b7280' }
+]
+
+function writeMinimalConfig(vaultPath: string): void {
+  const configPath = resolve(vaultPath, '.memry', 'config.json')
+  if (existsSync(configPath)) return
+  writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        version: 1,
+        title: 'Memry Demo Vault',
+        excludePatterns: ['.git', 'node_modules', '.DS_Store']
+      },
+      null,
+      2
+    ),
+    'utf8'
+  )
+}
+
+function main(): void {
+  const { vaultPath } = parseArgs(process.argv.slice(2))
+
+  console.log(`Seeding demo vault at: ${vaultPath}`)
+
+  console.log('  → Wiping existing contents...')
+  wipeVault(vaultPath)
+
+  console.log('  → Writing .memry/config.json')
+  writeMinimalConfig(vaultPath)
+
+  const dataDbPath = resolve(vaultPath, '.memry', 'data.db')
+  console.log(`  → Opening + migrating data.db at ${dataDbPath}`)
+  const { db, close } = openDataDb(dataDbPath)
+
+  try {
+    const tagCount = insertTagDefinitions(db, TAG_PALETTE)
+    console.log(`  → tag_definitions: ${tagCount}`)
+
+    const folderCount = insertFolderConfigs(db, FOLDER_CONFIGS)
+    console.log(`  → folder_configs: ${folderCount}`)
+
+    const propCount = insertPropertyDefinitions(db, PROPERTY_DEFS)
+    console.log(`  → property_definitions: ${propCount}`)
+
+    const projectCount = insertProjects(db, PROJECTS)
+    console.log(`  → projects: ${projectCount}`)
+
+    const statusCount = insertStatuses(db, STATUSES)
+    console.log(`  → statuses: ${statusCount}`)
+
+    const taskCount = insertTasks(db, TASKS)
+    console.log(`  → tasks: ${taskCount}`)
+
+    const taskNoteCount = insertTaskNotes(db, TASK_NOTES)
+    console.log(`  → task_notes: ${taskNoteCount}`)
+
+    const taskTagCount = insertTaskTags(db, TASK_TAGS)
+    console.log(`  → task_tags: ${taskTagCount}`)
+
+    const calendarSourceCount = insertCalendarSources(db, CALENDAR_SOURCES)
+    console.log(`  → calendar_sources: ${calendarSourceCount}`)
+
+    const calendarEventCount = insertCalendarEvents(db, CALENDAR_EVENTS)
+    console.log(`  → calendar_events: ${calendarEventCount}`)
+
+    const inboxCount = insertInboxItems(db, INBOX_ITEMS)
+    console.log(`  → inbox_items: ${inboxCount}`)
+
+    const filingCount = insertFilingHistory(db, FILING_HISTORY_ROWS)
+    console.log(`  → filing_history: ${filingCount}`)
+  } finally {
+    close()
+  }
+
+  console.log(`  → Writing ${NOTES.length} note files`)
+  const notesWritten = writeNoteFiles(vaultPath, NOTES)
+
+  console.log(`  → Writing ${JOURNAL_NOTES.length} journal files`)
+  const journalsWritten = writeNoteFiles(vaultPath, JOURNAL_NOTES)
+
+  console.log('')
+  console.log('Done.')
+  console.log(
+    `Seeded ${notesWritten} notes, ${journalsWritten} journal entries, ${TASKS.length} tasks, ${CALENDAR_EVENTS.length} events, ${INBOX_ITEMS.length} inbox items.`
+  )
+  console.log(`Vault path: ${vaultPath}`)
+  console.log('')
+  console.log('Open Memry → Switch Vault → choose this path to view.')
+}
+
+main()

--- a/apps/desktop/scripts/seed-vault/db-writer.ts
+++ b/apps/desktop/scripts/seed-vault/db-writer.ts
@@ -1,0 +1,430 @@
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import * as schema from '@memry/db-schema/schema'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const DATA_MIGRATIONS = resolve(__dirname, '../../src/main/database/drizzle-data')
+
+export type DataDb = ReturnType<typeof drizzle<typeof schema>>
+
+export interface OpenedDb {
+  db: DataDb
+  raw: Database.Database
+  close: () => void
+}
+
+export function openDataDb(dataDbPath: string): OpenedDb {
+  const raw = new Database(dataDbPath)
+  raw.pragma('journal_mode = WAL')
+  raw.pragma('foreign_keys = ON')
+  raw.pragma('synchronous = NORMAL')
+  raw.pragma('busy_timeout = 5000')
+
+  const db = drizzle(raw, { schema })
+  migrate(db, { migrationsFolder: DATA_MIGRATIONS })
+
+  return {
+    db,
+    raw,
+    close: () => raw.close()
+  }
+}
+
+export interface SeedTagDefinition {
+  name: string
+  color: string
+}
+
+export function insertTagDefinitions(db: DataDb, tags: SeedTagDefinition[]): number {
+  if (tags.length === 0) return 0
+  db.insert(schema.tagDefinitions)
+    .values(
+      tags.map((t) => ({
+        name: t.name,
+        color: t.color
+      }))
+    )
+    .run()
+  return tags.length
+}
+
+export interface SeedFolderConfig {
+  path: string
+  icon: string | null
+}
+
+export function insertFolderConfigs(db: DataDb, folders: SeedFolderConfig[]): number {
+  if (folders.length === 0) return 0
+  db.insert(schema.folderConfigs)
+    .values(
+      folders.map((f) => ({
+        path: f.path,
+        icon: f.icon
+      }))
+    )
+    .run()
+  return folders.length
+}
+
+export interface SeedPropertyDefinition {
+  name: string
+  type: string
+  options?: string[] | null
+  defaultValue?: string | null
+  color?: string | null
+}
+
+export function insertPropertyDefinitions(db: DataDb, defs: SeedPropertyDefinition[]): number {
+  if (defs.length === 0) return 0
+  db.insert(schema.propertyDefinitions)
+    .values(
+      defs.map((d) => ({
+        name: d.name,
+        type: d.type,
+        options: d.options ? JSON.stringify(d.options) : null,
+        defaultValue: d.defaultValue ?? null,
+        color: d.color ?? null
+      }))
+    )
+    .run()
+  return defs.length
+}
+
+export interface SeedProject {
+  id: string
+  name: string
+  description?: string | null
+  color: string
+  icon?: string | null
+  position: number
+  isInbox?: boolean
+}
+
+export function insertProjects(db: DataDb, projects: SeedProject[]): number {
+  if (projects.length === 0) return 0
+  db.insert(schema.projects)
+    .values(
+      projects.map((p) => ({
+        id: p.id,
+        name: p.name,
+        description: p.description ?? null,
+        color: p.color,
+        icon: p.icon ?? null,
+        position: p.position,
+        isInbox: p.isInbox ?? false
+      }))
+    )
+    .run()
+  return projects.length
+}
+
+export interface SeedStatus {
+  id: string
+  projectId: string
+  name: string
+  color: string
+  position: number
+  isDefault?: boolean
+  isDone?: boolean
+}
+
+export function insertStatuses(db: DataDb, statuses: SeedStatus[]): number {
+  if (statuses.length === 0) return 0
+  db.insert(schema.statuses)
+    .values(
+      statuses.map((s) => ({
+        id: s.id,
+        projectId: s.projectId,
+        name: s.name,
+        color: s.color,
+        position: s.position,
+        isDefault: s.isDefault ?? false,
+        isDone: s.isDone ?? false
+      }))
+    )
+    .run()
+  return statuses.length
+}
+
+export interface SeedTask {
+  id: string
+  projectId: string
+  statusId?: string | null
+  parentId?: string | null
+  title: string
+  description?: string | null
+  priority?: number
+  position?: number
+  dueDate?: string | null
+  dueTime?: string | null
+  startDate?: string | null
+  repeatConfig?: Record<string, unknown> | null
+  repeatFrom?: string | null
+  sourceNoteId?: string | null
+  completedAt?: string | null
+  archivedAt?: string | null
+  createdAt?: string
+  modifiedAt?: string
+}
+
+export function insertTasks(db: DataDb, tasks: SeedTask[]): number {
+  if (tasks.length === 0) return 0
+  for (const t of tasks) {
+    db.insert(schema.tasks)
+      .values({
+        id: t.id,
+        projectId: t.projectId,
+        statusId: t.statusId ?? null,
+        parentId: t.parentId ?? null,
+        title: t.title,
+        description: t.description ?? null,
+        priority: t.priority ?? 0,
+        position: t.position ?? 0,
+        dueDate: t.dueDate ?? null,
+        dueTime: t.dueTime ?? null,
+        startDate: t.startDate ?? null,
+        repeatConfig: t.repeatConfig ?? null,
+        repeatFrom: t.repeatFrom ?? null,
+        sourceNoteId: t.sourceNoteId ?? null,
+        completedAt: t.completedAt ?? null,
+        archivedAt: t.archivedAt ?? null,
+        ...(t.createdAt ? { createdAt: t.createdAt } : {}),
+        ...(t.modifiedAt ? { modifiedAt: t.modifiedAt } : {})
+      })
+      .run()
+  }
+  return tasks.length
+}
+
+export interface SeedTaskNote {
+  taskId: string
+  noteId: string
+}
+
+export function insertTaskNotes(db: DataDb, links: SeedTaskNote[]): number {
+  if (links.length === 0) return 0
+  db.insert(schema.taskNotes)
+    .values(
+      links.map((l) => ({
+        taskId: l.taskId,
+        noteId: l.noteId
+      }))
+    )
+    .run()
+  return links.length
+}
+
+export interface SeedTaskTag {
+  taskId: string
+  tag: string
+}
+
+export function insertTaskTags(db: DataDb, taskTags: SeedTaskTag[]): number {
+  if (taskTags.length === 0) return 0
+  db.insert(schema.taskTags)
+    .values(
+      taskTags.map((tt) => ({
+        taskId: tt.taskId,
+        tag: tt.tag
+      }))
+    )
+    .run()
+  return taskTags.length
+}
+
+export type SeedCalendarEvent = {
+  id: string
+  title: string
+  description?: string | null
+  location?: string | null
+  startAt: string
+  endAt?: string | null
+  timezone?: string
+  isAllDay?: boolean
+  recurrenceRule?: Record<string, unknown> | null
+  recurrenceExceptions?: string[] | null
+  attendees?: schema.CalendarAttendee[] | null
+  reminders?: schema.CalendarReminders | null
+  visibility?: schema.CalendarVisibility | null
+  colorId?: string | null
+  conferenceData?: schema.CalendarConferenceData | null
+  parentEventId?: string | null
+  originalStartTime?: string | null
+  targetCalendarId?: string | null
+  createdAt?: string
+  modifiedAt?: string
+}
+
+export function insertCalendarEvents(db: DataDb, events: SeedCalendarEvent[]): number {
+  if (events.length === 0) return 0
+  for (const e of events) {
+    db.insert(schema.calendarEvents)
+      .values({
+        id: e.id,
+        title: e.title,
+        description: e.description ?? null,
+        location: e.location ?? null,
+        startAt: e.startAt,
+        endAt: e.endAt ?? null,
+        timezone: e.timezone ?? 'UTC',
+        isAllDay: e.isAllDay ?? false,
+        recurrenceRule: e.recurrenceRule ?? null,
+        recurrenceExceptions: e.recurrenceExceptions ?? null,
+        attendees: e.attendees ?? null,
+        reminders: e.reminders ?? null,
+        visibility: e.visibility ?? null,
+        colorId: e.colorId ?? null,
+        conferenceData: e.conferenceData ?? null,
+        parentEventId: e.parentEventId ?? null,
+        originalStartTime: e.originalStartTime ?? null,
+        targetCalendarId: e.targetCalendarId ?? null,
+        ...(e.createdAt ? { createdAt: e.createdAt } : {}),
+        ...(e.modifiedAt ? { modifiedAt: e.modifiedAt } : {})
+      })
+      .run()
+  }
+  return events.length
+}
+
+export interface SeedCalendarSource {
+  id: string
+  provider: string
+  kind: schema.CalendarSourceKind
+  accountId?: string | null
+  remoteId: string
+  title: string
+  timezone?: string | null
+  color?: string | null
+  isPrimary?: boolean
+  isSelected?: boolean
+  isMemryManaged?: boolean
+  syncStatus?: schema.CalendarSourceSyncStatus
+  lastSyncedAt?: string | null
+}
+
+export function insertCalendarSources(db: DataDb, sources: SeedCalendarSource[]): number {
+  if (sources.length === 0) return 0
+  db.insert(schema.calendarSources)
+    .values(
+      sources.map((s) => ({
+        id: s.id,
+        provider: s.provider,
+        kind: s.kind,
+        accountId: s.accountId ?? null,
+        remoteId: s.remoteId,
+        title: s.title,
+        timezone: s.timezone ?? null,
+        color: s.color ?? null,
+        isPrimary: s.isPrimary ?? false,
+        isSelected: s.isSelected ?? false,
+        isMemryManaged: s.isMemryManaged ?? false,
+        syncStatus: s.syncStatus ?? 'idle',
+        lastSyncedAt: s.lastSyncedAt ?? null
+      }))
+    )
+    .run()
+  return sources.length
+}
+
+export interface SeedInboxItem {
+  id: string
+  type: string
+  title: string
+  content?: string | null
+  filedAt?: string | null
+  filedTo?: string | null
+  filedAction?: string | null
+  snoozedUntil?: string | null
+  snoozeReason?: string | null
+  viewedAt?: string | null
+  processingStatus?: string
+  metadata?: Record<string, unknown> | null
+  attachmentPath?: string | null
+  thumbnailPath?: string | null
+  transcription?: string | null
+  transcriptionStatus?: string | null
+  sourceUrl?: string | null
+  sourceTitle?: string | null
+  captureSource?: string | null
+  archivedAt?: string | null
+  createdAt?: string
+  modifiedAt?: string
+  tags?: string[]
+}
+
+export function insertInboxItems(db: DataDb, items: SeedInboxItem[]): number {
+  if (items.length === 0) return 0
+  for (const item of items) {
+    db.insert(schema.inboxItems)
+      .values({
+        id: item.id,
+        type: item.type,
+        title: item.title,
+        content: item.content ?? null,
+        filedAt: item.filedAt ?? null,
+        filedTo: item.filedTo ?? null,
+        filedAction: item.filedAction ?? null,
+        snoozedUntil: item.snoozedUntil ?? null,
+        snoozeReason: item.snoozeReason ?? null,
+        viewedAt: item.viewedAt ?? null,
+        processingStatus: item.processingStatus ?? 'complete',
+        metadata: item.metadata ?? null,
+        attachmentPath: item.attachmentPath ?? null,
+        thumbnailPath: item.thumbnailPath ?? null,
+        transcription: item.transcription ?? null,
+        transcriptionStatus: item.transcriptionStatus ?? null,
+        sourceUrl: item.sourceUrl ?? null,
+        sourceTitle: item.sourceTitle ?? null,
+        captureSource: item.captureSource ?? null,
+        archivedAt: item.archivedAt ?? null,
+        ...(item.createdAt ? { createdAt: item.createdAt } : {}),
+        ...(item.modifiedAt ? { modifiedAt: item.modifiedAt } : {})
+      })
+      .run()
+
+    if (item.tags && item.tags.length > 0) {
+      db.insert(schema.inboxItemTags)
+        .values(
+          item.tags.map((tag, i) => ({
+            id: `${item.id}_tag_${i}`,
+            itemId: item.id,
+            tag
+          }))
+        )
+        .run()
+    }
+  }
+  return items.length
+}
+
+export interface SeedFilingHistory {
+  id: string
+  itemType: string
+  itemContent?: string | null
+  filedTo: string
+  filedAction: string
+  tags?: string[] | null
+  filedAt?: string
+}
+
+export function insertFilingHistory(db: DataDb, history: SeedFilingHistory[]): number {
+  if (history.length === 0) return 0
+  for (const h of history) {
+    db.insert(schema.filingHistory)
+      .values({
+        id: h.id,
+        itemType: h.itemType,
+        itemContent: h.itemContent ?? null,
+        filedTo: h.filedTo,
+        filedAction: h.filedAction,
+        tags: h.tags ?? null,
+        ...(h.filedAt ? { filedAt: h.filedAt } : {})
+      })
+      .run()
+  }
+  return history.length
+}

--- a/apps/desktop/scripts/seed-vault/file-writer.ts
+++ b/apps/desktop/scripts/seed-vault/file-writer.ts
@@ -1,0 +1,32 @@
+import { writeFileSync, mkdirSync } from 'fs'
+import { dirname, resolve } from 'path'
+import matter from 'gray-matter'
+
+export interface NoteFile {
+  /** Relative path inside the vault (e.g. "notes/movies/Dune.md") */
+  relativePath: string
+  /** Frontmatter object — id/title/created/modified must be set by the caller. */
+  frontmatter: Record<string, unknown>
+  /** Markdown body without YAML frontmatter. */
+  body: string
+}
+
+function serialize(frontmatter: Record<string, unknown>, body: string): string {
+  const cleanFrontmatter = Object.fromEntries(
+    Object.entries(frontmatter).filter(([, v]) => v !== undefined)
+  )
+  return matter.stringify(body.trim(), cleanFrontmatter).replace(/(?:\r?\n)+$/g, '') + '\n'
+}
+
+export function writeNoteFile(vaultRoot: string, file: NoteFile): void {
+  const absolute = resolve(vaultRoot, file.relativePath)
+  mkdirSync(dirname(absolute), { recursive: true })
+  writeFileSync(absolute, serialize(file.frontmatter, file.body), 'utf8')
+}
+
+export function writeNoteFiles(vaultRoot: string, files: NoteFile[]): number {
+  for (const file of files) {
+    writeNoteFile(vaultRoot, file)
+  }
+  return files.length
+}

--- a/apps/desktop/scripts/seed-vault/wipe.ts
+++ b/apps/desktop/scripts/seed-vault/wipe.ts
@@ -1,0 +1,37 @@
+import { existsSync, rmSync, mkdirSync } from 'fs'
+import { resolve, sep } from 'path'
+import { homedir } from 'os'
+
+const FORBIDDEN_PATHS = new Set(
+  ['/', homedir(), resolve(homedir(), 'Documents'), resolve(homedir(), 'Desktop')].map((p) =>
+    resolve(p)
+  )
+)
+
+export function ensureSafeVaultPath(vaultPath: string): string {
+  const absolute = resolve(vaultPath)
+
+  if (FORBIDDEN_PATHS.has(absolute)) {
+    throw new Error(`Refusing to operate on protected path: ${absolute}`)
+  }
+
+  if (absolute.split(sep).filter(Boolean).length < 2) {
+    throw new Error(`Vault path looks too shallow, refusing: ${absolute}`)
+  }
+
+  return absolute
+}
+
+export function wipeVault(vaultPath: string): void {
+  const absolute = ensureSafeVaultPath(vaultPath)
+
+  if (existsSync(absolute)) {
+    rmSync(absolute, { recursive: true, force: true })
+  }
+
+  mkdirSync(absolute, { recursive: true })
+  mkdirSync(resolve(absolute, '.memry'), { recursive: true })
+  mkdirSync(resolve(absolute, 'notes'), { recursive: true })
+  mkdirSync(resolve(absolute, 'journal'), { recursive: true })
+  mkdirSync(resolve(absolute, 'attachments'), { recursive: true })
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "docs:build": "pnpm --filter @memry/docs build",
     "docs:preview": "pnpm --filter @memry/docs preview",
     "release": "node scripts/release.mjs",
+    "seed": "pnpm --filter @memry/desktop seed:vault",
     "release:humanize": "node scripts/humanize-release-notes.mjs",
     "docs:impact": "node scripts/docs-impact.mjs",
     "docs:ai-update": "node scripts/docs-ai-update.mjs",


### PR DESCRIPTION
## Summary

Adds a single \`pnpm seed\` command that builds a dedicated demo vault for screenshots and exploration. Default path is \`~/MemryDemoVault\` (override with \`--vault=<path>\`). Wipes and re-seeds every run, never touching the user's real vault.

## What gets seeded

- **72 notes** across \`movies / books / weight / life / projects / tech / travel\` — cross-folder wikilinks, tags, callouts, code blocks (TS/Python/SQL/sh), tables, footnotes, mermaid, custom frontmatter properties (rating, status, author, director, weight, mood, etc.), aliases, emojis
- **28 journal entries** ending today, with deliberate gaps so the heatmap looks lived-in
- **48 tasks** across 6 projects (\`Inbox\`, \`Memry Launch\`, \`Reading\`, \`Fitness 2026\`, \`Travel: Tokyo\`, \`Side Projects\`) — every status, mix of overdue/today/this-week/later, recurring config, subtask trees, \`sourceNoteId\` + \`task_notes\` cross-links to notes
- **31 calendar events** — recurring weekday standup, bi-weekly sprint planning, weekly 1:1, monthly review, all-day birthday, multi-day Iceland block, doctor with reminders, attendees with mixed RSVPs, Google Meet conference data, one Asia/Tokyo TZ event, one cancelled event, deep-work + workout blocks
- **15 inbox items** covering all 8 types (\`link\`, \`note\`, \`image\`, \`voice\`, \`pdf\`, \`clip\`, \`social\`, \`reminder\`) and every state (unfiled, snoozed, filed, archived)
- **27 tag definitions** with curated colors, **18 property definitions**, **7 folder configs** with icons

## Architecture

\`\`\`
apps/desktop/scripts/
├── seed-vault.ts                  # Orchestrator + CLI entry
├── seed-data/
│   ├── notes.ts                   # 72 notes, organized by folder
│   ├── journal.ts                 # 28 journal entries
│   ├── tasks.ts                   # Projects + tasks + relations
│   ├── calendar.ts                # Events + sources
│   └── inbox.ts                   # Items + filing history
└── seed-vault/
    ├── wipe.ts                    # rm -rf + path safety guards
    ├── db-writer.ts               # Open data.db, run migrations, insert helpers
    └── file-writer.ts             # gray-matter serialize + write .md
\`\`\`

Notes and journal entries are written as \`.md\` files; the app's vault watcher indexes them on first open (so wikilinks resolve naturally and \`note_links\`/\`note_tags\` populate without duplicating indexer logic). Tasks/projects/calendar/inbox are inserted directly into a pre-migrated \`.memry/data.db\` via Drizzle.

## Test plan

- [x] \`pnpm seed --vault=/tmp/memry-seed-test\` runs end-to-end
- [x] Verified file counts: 72 notes / 28 journal entries
- [x] Verified DB counts: 48 tasks / 31 events / 15 inbox / 27 tags / 18 prop defs
- [x] Idempotent — second run wipes and re-seeds cleanly
- [x] Cross-references intact: \`tasks.source_note_id\` resolves to real note ids; recurring config preserved as JSON; calendar attendees + conference data round-trip
- [ ] Open the seeded vault in \`pnpm dev\` and visually inspect each surface (notes editor, calendar week/month, journal heatmap, inbox filter, tasks sidebar, graph view)

## Notes

- \`pnpm seed\` from the root delegates to \`pnpm --filter @memry/desktop seed:vault\`, which runs \`bash scripts/ensure-native.sh node && npx tsx scripts/seed-vault.ts\`. The native rebuild step is required because \`better-sqlite3\` ABI must match Node, not Electron — same pattern existing scripts use.
- Safety guards in \`wipe.ts\` refuse to operate on \`/\`, \`~\`, \`~/Documents\`, \`~/Desktop\`, or any path shallower than two segments.