### PR TITLE
Fix journal footer interpolation

### DIFF
--- a/apps/desktop/src/renderer/src/components/journal/journal-i18n.test.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-i18n.test.tsx
@@ -8,6 +8,7 @@ import { JournalEntryListItem } from './journal-entry-list-item'
 import { JournalBreadcrumb } from './journal-breadcrumb'
 import { JournalNavigationRow } from './journal-navigation-row'
 import { AIConnectionsPanel } from './ai-connections-panel'
+import { JournalStatsFooter } from './journal-stats-footer'
 
 type TestLocale = 'en' | 'tr' | 'ar'
 
@@ -125,5 +126,22 @@ describe('journal i18n', () => {
 
     expect(screen.getByText('No related journal history')).toBeInTheDocument()
     expect(screen.getByText('Keep writing for matches')).toBeInTheDocument()
+  })
+
+  it('renders footer statistics without raw interpolation tokens', async () => {
+    await renderWithI18n(
+      <JournalStatsFooter
+        wordCount={201}
+        characterCount={1234}
+        createdAt={null}
+        modifiedAt="2026-04-14T12:00:00.000Z"
+      />
+    )
+
+    expect(screen.getByText('201 words')).toBeInTheDocument()
+    expect(screen.getByText('1234 chars')).toBeInTheDocument()
+    expect(screen.getByText('2 min read')).toBeInTheDocument()
+    expect(screen.getByText('Modified Apr 14, 2026')).toBeInTheDocument()
+    expect(screen.queryByText(/\{\{/)).not.toBeInTheDocument()
   })
 })

--- a/packages/i18n/src/locales/en/journal.json
+++ b/packages/i18n/src/locales/en/journal.json
@@ -25,8 +25,8 @@
     "createNote": "Create Note",
     "createNewNote": "Create new note",
     "showLess": "Show less",
-    "showMoreNotes": "Show {{count}} more note",
-    "showMoreNotes_plural": "Show {{count}} more notes",
+    "showMoreNotes": "Show {count} more note",
+    "showMoreNotes_plural": "Show {count} more notes",
     "showFewerNotes": "Show fewer notes",
     "startBlank": "Start blank instead",
     "changeTemplate": "Change template",
@@ -156,7 +156,7 @@
     "dayContext": "Day context: tasks and schedule",
     "scheduleEvents": "Schedule events",
     "tasks": "Tasks",
-    "notesCreatedToday": "{{count}} notes created today"
+    "notesCreatedToday": "{count} notes created today"
   },
   "empty": {
     "noEntry": "No entry",
@@ -181,7 +181,7 @@
     "error": {
       "loadFailed": "Couldn't load connections"
     },
-    "connectionAria": "Connection to {{label}}, {{scorePercent}}% match"
+    "connectionAria": "Connection to {label}, {scorePercent}% match"
   },
   "count": {
     "item": "item",
@@ -197,17 +197,17 @@
     "task": "task",
     "tasks": "tasks",
     "todo": "to do",
-    "people": "{{count}} people",
-    "moreConnections": "+ {{count}} more connection",
-    "moreConnections_plural": "+ {{count}} more connections",
-    "moreNotes": "+ {{count}} more note",
-    "moreNotes_plural": "+ {{count}} more notes",
+    "people": "{count} people",
+    "moreConnections": "+ {count} more connection",
+    "moreConnections_plural": "+ {count} more connections",
+    "moreNotes": "+ {count} more note",
+    "moreNotes_plural": "+ {count} more notes",
     "daysWithEntries": "days with entries",
     "charactersWritten": "characters written",
-    "words": "{{count}} words",
-    "characters": "{{count}} chars",
-    "completed": "{{count}} completed",
-    "overdue": "{{count}} overdue"
+    "words": "{count} words",
+    "characters": "{count} chars",
+    "completed": "{count} completed",
+    "overdue": "{count} overdue"
   },
   "stats": {
     "wordCount": "Word count",
@@ -215,26 +215,26 @@
     "readingTime": "Estimated reading time",
     "lastModified": "Last modified",
     "lessThanOneMinute": "< 1 min",
-    "minutes": "{{minutes}} min",
-    "read": "{{readingTime}} read",
-    "modified": "Modified {{date}}"
+    "minutes": "{minutes} min",
+    "read": "{readingTime} read",
+    "modified": "Modified {date}"
   },
   "task": {
     "completed": "Completed",
     "notCompleted": "Not completed",
-    "priority": "{{priority}} priority",
+    "priority": "{priority} priority",
     "overdue": "overdue",
-    "markComplete": "Mark \"{{title}}\" as completed",
-    "markNotComplete": "Mark \"{{title}}\" as not completed"
+    "markComplete": "Mark \"{title}\" as completed",
+    "markNotComplete": "Mark \"{title}\" as not completed"
   },
   "template": {
-    "using": "Using \"{{templateName}}\""
+    "using": "Using \"{templateName}\""
   },
   "reminder": {
     "hasReminders": "Has reminders",
     "setToRevisit": "Set reminder to revisit",
-    "tooltip": "Reminder: {{date}}",
-    "tooltipMore": "Reminder: {{date}} (+{{count}} more)",
+    "tooltip": "Reminder: {date}",
+    "tooltipMore": "Reminder: {date} (+{count} more)",
     "success": {
       "set": "Reminder set for this journal entry",
       "deleted": "Reminder deleted",
@@ -250,17 +250,17 @@
   },
   "toast": {
     "unsavedRetry": "Your content is still in memory. Click to retry saving.",
-    "noteNotFound": "Note \"{{target}}\" not found",
-    "fileNotFound": "File not found: {{target}}",
+    "noteNotFound": "Note \"{target}\" not found",
+    "fileNotFound": "File not found: {target}",
     "openLinkedItemFailed": "Failed to open linked item",
     "errorPrefix": "Error:"
   },
   "export": {
-    "noteTitle": "Journal - {{month}} {{day}}, {{year}}"
+    "noteTitle": "Journal - {month} {day}, {year}"
   },
   "note": {
-    "generatedTitle": "Note - {{date}}",
-    "openAria": "Open {{title}}, created at {{time}}"
+    "generatedTitle": "Note - {date}",
+    "openAria": "Open {title}, created at {time}"
   },
   "tag": {
     "suggestionsAria": "Tag suggestions",
@@ -269,8 +269,8 @@
       "description": "Type to create a new tag"
     },
     "groupTitle": "Tags",
-    "create": "Create #{{query}}",
-    "ariaLabel": "Tag: {{tag}}, click to filter"
+    "create": "Create #{query}",
+    "ariaLabel": "Tag: {tag}, click to filter"
   },
   "wiki": {
     "suggestionsAria": "Page suggestions",
@@ -280,13 +280,13 @@
     "groupRecent": "Recent",
     "groupAllPages": "All Pages",
     "createNewPage": "Create new page",
-    "ariaLabel": "Link to {{title}}"
+    "ariaLabel": "Link to {title}"
   },
   "error": {
     "title": "Journal Error",
-    "description": "The journal encountered an error for {{date}}. Your recent changes may not have been saved.",
+    "description": "The journal encountered an error for {date}. Your recent changes may not have been saved.",
     "descriptionNoDate": "The journal encountered an error. Your recent changes may not have been saved.",
-    "unsavedContent": "Unsaved content detected ({{length}} characters)"
+    "unsavedContent": "Unsaved content detected ({length} characters)"
   },
   "phaseF": {
     "componentsJournalJournalYearView": {

--- a/packages/i18n/src/locales/tr/journal.json
+++ b/packages/i18n/src/locales/tr/journal.json
@@ -25,8 +25,8 @@
     "createNote": "Not Oluştur",
     "createNewNote": "Yeni not oluştur",
     "showLess": "Daha az göster",
-    "showMoreNotes": "{{count}} not daha göster",
-    "showMoreNotes_plural": "{{count}} not daha göster",
+    "showMoreNotes": "{count} not daha göster",
+    "showMoreNotes_plural": "{count} not daha göster",
     "showFewerNotes": "Daha az not göster",
     "startBlank": "Bunun yerine boş başlayın",
     "changeTemplate": "Şablonu değiştir",
@@ -156,7 +156,7 @@
     "dayContext": "Gün bağlamı: görevler ve program",
     "scheduleEvents": "Program etkinlikleri",
     "tasks": "Görevler",
-    "notesCreatedToday": "Bugün {{count}} not oluşturuldu"
+    "notesCreatedToday": "Bugün {count} not oluşturuldu"
   },
   "empty": {
     "noEntry": "Giriş yok",
@@ -181,7 +181,7 @@
     "error": {
       "loadFailed": "Bağlantılar yüklenemedi"
     },
-    "connectionAria": "Bağlantı {{label}}, {{scorePercent}}% eşleşme"
+    "connectionAria": "Bağlantı {label}, {scorePercent}% eşleşme"
   },
   "count": {
     "item": "öğe",
@@ -197,17 +197,17 @@
     "task": "görev",
     "tasks": "görevler",
     "todo": "yapılacak",
-    "people": "{{count}} kişi",
-    "moreConnections": "+ {{count}} daha fazla bağlantı",
-    "moreConnections_plural": "+ {{count}} daha fazla bağlantı",
-    "moreNotes": "+ {{count}} daha fazla not",
-    "moreNotes_plural": "+ {{count}} daha fazla not",
+    "people": "{count} kişi",
+    "moreConnections": "+ {count} daha fazla bağlantı",
+    "moreConnections_plural": "+ {count} daha fazla bağlantı",
+    "moreNotes": "+ {count} daha fazla not",
+    "moreNotes_plural": "+ {count} daha fazla not",
     "daysWithEntries": "girişlerin olduğu günler",
     "charactersWritten": "yazılı karakterler",
-    "words": "{{count}} kelime",
-    "characters": "{{count}} karakter",
-    "completed": "{{count}} tamamlandı",
-    "overdue": "{{count}} vadesi geçmiş"
+    "words": "{count} kelime",
+    "characters": "{count} karakter",
+    "completed": "{count} tamamlandı",
+    "overdue": "{count} vadesi geçmiş"
   },
   "stats": {
     "wordCount": "Kelime sayısı",
@@ -215,26 +215,26 @@
     "readingTime": "Tahmini okuma süresi",
     "lastModified": "Son değiştirilme tarihi",
     "lessThanOneMinute": "< 1 dakika",
-    "minutes": "{{minutes}} dk",
-    "read": "{{readingTime}} okuma",
-    "modified": "Değiştirildi {{date}}"
+    "minutes": "{minutes} dk",
+    "read": "{readingTime} okuma",
+    "modified": "Değiştirildi {date}"
   },
   "task": {
     "completed": "Tamamlandı",
     "notCompleted": "Tamamlanmadı",
-    "priority": "{{priority}} öncelikli",
+    "priority": "{priority} öncelikli",
     "overdue": "vadesi geçmiş",
-    "markComplete": "\"{{title}}\" görevini tamamlandı olarak işaretle",
-    "markNotComplete": "\"{{title}}\" görevini tamamlanmadı olarak işaretle"
+    "markComplete": "\"{title}\" görevini tamamlandı olarak işaretle",
+    "markNotComplete": "\"{title}\" görevini tamamlanmadı olarak işaretle"
   },
   "template": {
-    "using": "\"{{templateName}}\" kullanılıyor"
+    "using": "\"{templateName}\" kullanılıyor"
   },
   "reminder": {
     "hasReminders": "Hatırlatıcıları var",
     "setToRevisit": "Tekrar ziyaret etmek için hatırlatıcı ayarlayın",
-    "tooltip": "Hatırlatma: {{date}}",
-    "tooltipMore": "Hatırlatma: {{date}} (+{{count}} daha fazla)",
+    "tooltip": "Hatırlatma: {date}",
+    "tooltipMore": "Hatırlatma: {date} (+{count} daha fazla)",
     "success": {
       "set": "Bu günlük girişi için hatırlatıcı ayarlandı",
       "deleted": "Hatırlatıcı silindi",
@@ -250,17 +250,17 @@
   },
   "toast": {
     "unsavedRetry": "İçeriğiniz hâlâ bellekte. Kaydetmeyi yeniden denemek için tıklayın.",
-    "noteNotFound": "Not \"{{target}}\" bulunamadı",
-    "fileNotFound": "Dosya bulunamadı: {{target}}",
+    "noteNotFound": "Not \"{target}\" bulunamadı",
+    "fileNotFound": "Dosya bulunamadı: {target}",
     "openLinkedItemFailed": "Bağlantılı öğe açılamadı",
     "errorPrefix": "Hata:"
   },
   "export": {
-    "noteTitle": "Günlük - {{day}} {{month}} {{year}}"
+    "noteTitle": "Günlük - {day} {month} {year}"
   },
   "note": {
-    "generatedTitle": "Not - {{date}}",
-    "openAria": "{{title}} notunu aç, oluşturulma zamanı: {{time}}"
+    "generatedTitle": "Not - {date}",
+    "openAria": "{title} notunu aç, oluşturulma zamanı: {time}"
   },
   "tag": {
     "suggestionsAria": "Etiket önerileri",
@@ -269,8 +269,8 @@
       "description": "Yeni bir etiket oluşturmak için yazın"
     },
     "groupTitle": "Etiketler",
-    "create": "Oluştur #{{query}}",
-    "ariaLabel": "Etiket: {{tag}}, filtrelemek için tıklayın"
+    "create": "Oluştur #{query}",
+    "ariaLabel": "Etiket: {tag}, filtrelemek için tıklayın"
   },
   "wiki": {
     "suggestionsAria": "Sayfa önerileri",
@@ -280,13 +280,13 @@
     "groupRecent": "Son",
     "groupAllPages": "Tüm Sayfalar",
     "createNewPage": "Yeni sayfa oluştur",
-    "ariaLabel": "{{title}} sayfasına bağlantı"
+    "ariaLabel": "{title} sayfasına bağlantı"
   },
   "error": {
     "title": "Günlük Hatası",
-    "description": "{{date}} için günlükte bir hata oluştu. Son değişiklikleriniz kaydedilmemiş olabilir.",
+    "description": "{date} için günlükte bir hata oluştu. Son değişiklikleriniz kaydedilmemiş olabilir.",
     "descriptionNoDate": "Günlük bir hatayla karşılaştı. Son değişiklikleriniz kaydedilmemiş olabilir.",
-    "unsavedContent": "Kaydedilmemiş içerik algılandı ({{length}} karakter)"
+    "unsavedContent": "Kaydedilmemiş içerik algılandı ({length} karakter)"
   },
   "phaseF": {
     "componentsJournalJournalYearView": {


### PR DESCRIPTION
## Summary
- Normalize journal i18n placeholders to ICU syntax so stats footer values render instead of raw tokens.
- Add regression coverage for the journal stats footer.

## Validation
- pnpm --filter @memry/desktop test:renderer -- src/renderer/src/components/journal/journal-i18n.test.tsx (script ran full renderer suite: 165 files, 3527 tests)
- pnpm --filter @memry/i18n test
- pnpm --filter @memry/desktop i18n:check
- pnpm docs:impact --strict
- pnpm docs:build