### PR TITLE
Fix journal template seeding

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-journal-entry.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-journal-entry.ts
@@ -11,6 +11,7 @@ import {
   onJournalExternalChange,
   onJournalEntryCreated
 } from '@/services/journal-service'
+import { getTemplate, type Template } from '@/services/templates-service'
 import { addDays, formatDateToISO, parseISODate } from '@/lib/journal-utils'
 import {
   journalKeys,
@@ -22,6 +23,58 @@ import {
 import { getI18n } from 'react-i18next'
 
 const log = createLogger('Hook:JournalEntry')
+
+type AppliedJournalTemplate = {
+  content: string
+  tags: string[]
+  properties: Record<string, unknown>
+}
+
+function formatDateToken(date: Date, pattern: string | undefined, locale: string): string {
+  const year = String(date.getFullYear())
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  if (pattern) {
+    return pattern.replace(/YYYY/g, year).replace(/MM/g, month).replace(/DD/g, day)
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  }).format(date)
+}
+
+function applyJournalTemplate(template: Template, date: string): AppliedJournalTemplate {
+  const locale = getI18n().language || 'en-US'
+  const dateObj = parseISODate(date)
+  const time = new Intl.DateTimeFormat(locale, {
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(new Date())
+  const dayOfWeek = new Intl.DateTimeFormat(locale, { weekday: 'long' }).format(dateObj)
+
+  const content = template.content
+    .replace(/\{\{title\}\}/g, date)
+    .replace(/\{\{date(?::([^}]+))?\}\}/g, (_match, pattern: string | undefined) =>
+      formatDateToken(dateObj, pattern, locale)
+    )
+    .replace(/\{\{time\}\}/g, time)
+    .replace(/\{\{day-of-week\}\}/g, dayOfWeek)
+
+  const properties: Record<string, unknown> = {}
+  for (const property of template.properties) {
+    properties[property.name] = property.value
+  }
+
+  return {
+    content,
+    tags: [...template.tags],
+    properties
+  }
+}
 
 export interface UseJournalEntryResult {
   entry: JournalEntry | null
@@ -56,7 +109,9 @@ export function useJournalEntry(date: string): UseJournalEntryResult {
   const currentDateRef = useRef(date)
   const isDirtyRef = useRef(isDirty)
   const isSavingRef = useRef(false)
+  const templateSeedKeyRef = useRef<string | null>(null)
   const performSaveRef = useRef<() => Promise<void>>(async () => {})
+  const [isSeedingFromTemplate, setIsSeedingFromTemplate] = useState(false)
 
   useEffect(() => {
     isDirtyRef.current = isDirty
@@ -143,6 +198,53 @@ export function useJournalEntry(date: string): UseJournalEntryResult {
       void queryClient.invalidateQueries({ queryKey: journalKeys.heatmap(year) })
     }
   })
+
+  useEffect(() => {
+    if (isLoading || queryError || entry !== null) return
+
+    let cancelled = false
+
+    void (async () => {
+      try {
+        const settings = await window.api.settings.getJournalSettings()
+        const templateId = settings.defaultTemplate
+        if (!templateId) return
+
+        const seedKey = `${date}:${templateId}`
+        if (templateSeedKeyRef.current === seedKey) return
+        templateSeedKeyRef.current = seedKey
+        setIsSeedingFromTemplate(true)
+
+        const template = await getTemplate(templateId)
+        if (!template) return
+        if (cancelled || currentDateRef.current !== date) return
+
+        const applied = applyJournalTemplate(template, date)
+        const createdEntry = await journalService.createEntry({
+          date,
+          content: applied.content,
+          tags: applied.tags,
+          properties: applied.properties
+        })
+
+        if (cancelled) return
+
+        queryClient.setQueryData(journalKeys.entry(createdEntry.date), createdEntry)
+        const year = parseInt(createdEntry.date.slice(0, 4), 10)
+        void queryClient.invalidateQueries({ queryKey: journalKeys.heatmap(year) })
+      } catch (err) {
+        log.error('Failed to seed journal entry from default template:', err)
+      } finally {
+        if (!cancelled) {
+          setIsSeedingFromTemplate(false)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [date, entry, isLoading, queryClient, queryError])
 
   const deleteMutation = useMutation({
     mutationFn: async (dateToDelete: string) => {
@@ -362,12 +464,12 @@ export function useJournalEntry(date: string): UseJournalEntryResult {
     }
   }, [queryClient])
 
-  const loadedForDate = isLoading ? null : date
+  const loadedForDateResult = isLoading || isSeedingFromTemplate ? null : date
 
   return {
     entry,
-    isLoading,
-    loadedForDate,
+    isLoading: isLoading || isSeedingFromTemplate,
+    loadedForDate: loadedForDateResult,
     error: queryError ? extractErrorMessage(queryError) : null,
     isSaving,
     isDirty,

--- a/apps/desktop/src/renderer/src/hooks/use-journal.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-journal.test.tsx
@@ -82,6 +82,51 @@ describe('useJournalEntry', () => {
       expect(result.current.loadedForDate).toBe('2026-01-03')
     })
 
+    it('should create a missing entry from the default journal template', async () => {
+      const createdEntry = createMockJournalEntry({
+        date: '2026-01-03',
+        content: '# 2026-01-03\n\nSaturday\n\n2026-01-03',
+        tags: ['reflection']
+      })
+
+      ;(window.api.journal.get as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+      ;(window.api.settings.getJournalSettings as ReturnType<typeof vi.fn>).mockResolvedValue({
+        defaultTemplate: 'daily-reflection',
+        showSchedule: true,
+        showTasks: true,
+        showAIConnections: true,
+        showStatsFooter: false
+      })
+      ;(window.api.templates.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'daily-reflection',
+        name: 'Daily Reflection',
+        description: 'Reflect on the day',
+        icon: null,
+        isBuiltIn: true,
+        tags: ['reflection'],
+        properties: [{ name: 'mood', type: 'select', value: 'neutral' }],
+        content: '# {{date:YYYY-MM-DD}}\n\n{{day-of-week}}\n\n{{title}}',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        modifiedAt: '2026-01-01T00:00:00.000Z'
+      })
+      ;(window.api.journal.create as ReturnType<typeof vi.fn>).mockResolvedValue(createdEntry)
+
+      const { result } = renderHook(() => useJournalEntry('2026-01-03'), { wrapper })
+
+      await waitFor(() => {
+        expect(window.api.journal.create).toHaveBeenCalledWith({
+          date: '2026-01-03',
+          content: '# 2026-01-03\n\nSaturday\n\n2026-01-03',
+          tags: ['reflection'],
+          properties: { mood: 'neutral' }
+        })
+      })
+
+      await waitFor(() => {
+        expect(result.current.entry).toEqual(createdEntry)
+      })
+    })
+
     it('should handle load errors', async () => {
       ;(window.api.journal.get as ReturnType<typeof vi.fn>).mockRejectedValue(
         new Error('Failed to load journal')

--- a/apps/desktop/tests/utils/hook-test-wrapper.tsx
+++ b/apps/desktop/tests/utils/hook-test-wrapper.tsx
@@ -45,6 +45,8 @@ export interface MockAPIConfig {
   notes?: Partial<MockNotesAPI>
   tasks?: Partial<MockTasksAPI>
   search?: Partial<MockSearchAPI>
+  settings?: Partial<MockSettingsAPI>
+  templates?: Partial<MockTemplatesAPI>
   journal?: Partial<MockJournalAPI>
   inbox?: Partial<MockInboxAPI>
   bookmarks?: Partial<MockBookmarksAPI>
@@ -117,6 +119,20 @@ interface MockSearchAPI {
   clearReasons: Mock
   getStats: Mock
   rebuildIndex: Mock
+}
+
+interface MockSettingsAPI {
+  getJournalSettings: Mock
+  setJournalSettings: Mock
+}
+
+interface MockTemplatesAPI {
+  list: Mock
+  get: Mock
+  create: Mock
+  update: Mock
+  delete: Mock
+  duplicate: Mock
 }
 
 interface MockJournalAPI {
@@ -271,6 +287,30 @@ export function createMockAPI(config?: MockAPIConfig): Record<string, unknown> {
       getStats: vi.fn().mockResolvedValue({ indexed: 0, pending: 0 }),
       rebuildIndex: vi.fn().mockResolvedValue({ success: true }),
       ...config?.search
+    },
+
+    // Settings API
+    settings: {
+      getJournalSettings: vi.fn().mockResolvedValue({
+        defaultTemplate: null,
+        showSchedule: true,
+        showTasks: true,
+        showAIConnections: true,
+        showStatsFooter: false
+      }),
+      setJournalSettings: vi.fn().mockResolvedValue({ success: true }),
+      ...config?.settings
+    },
+
+    // Templates API
+    templates: {
+      list: vi.fn().mockResolvedValue({ templates: [] }),
+      get: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ success: true, template: null }),
+      update: vi.fn().mockResolvedValue({ success: true, template: null }),
+      delete: vi.fn().mockResolvedValue({ success: true }),
+      duplicate: vi.fn().mockResolvedValue({ success: true, template: null }),
+      ...config?.templates
     },
 
     // Journal API


### PR DESCRIPTION
## Summary
- Seed missing journal entries from the configured default journal template when a date is opened.
- Resolve journal template variables and carry template tags/properties into the created entry.
- Add hook regression coverage for the missing-entry template path.

## Root Cause
Right-sidebar calendar day clicks only navigated to the journal date. If that date had no entry yet, the journal hook returned `null` and the editor rendered empty content. No path created the missing entry from the selected template.

## Validation
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/use-journal.test.tsx`
- `pnpm --filter @memry/desktop exec tsc --noEmit -p tsconfig.web.json --composite false`
- `pnpm docs:impact --base origin/main --strict`
- `pnpm docs:build`
- `pnpm --filter @memry/desktop exec eslint src/renderer/src/hooks/use-journal-entry.ts`