### PR TITLE
Fix task row dropdown click handling

### DIFF
--- a/apps/desktop/src/renderer/src/components/tasks/drag-drop/task-row.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/drag-drop/task-row.test.tsx
@@ -141,6 +141,41 @@ describe('TaskRow — Linked Notes', () => {
   })
 })
 
+describe('TaskRow — Row Click Boundaries', () => {
+  it('opens the task row when clicking the row body', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    render(<TaskRow {...defaultProps} onClick={onClick} />)
+
+    await user.click(screen.getByLabelText(/^Task: Test Task/))
+
+    expect(onClick).toHaveBeenCalledWith('task-1')
+  })
+
+  it('does not open the task row when clicking the status trigger', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    render(<TaskRow {...defaultProps} onClick={onClick} />)
+
+    await user.click(screen.getByRole('button', { name: /status: to do/i }))
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('does not open the task row when clicking the priority trigger', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    render(<TaskRow {...defaultProps} onClick={onClick} />)
+
+    await user.click(screen.getByRole('button', { name: /priority: medium/i }))
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})
+
 describe('TaskRow — Whole-Row Drag', () => {
   it('applies cursor-grab when dragHandleListeners are provided', () => {
     const listeners = { onPointerDown: vi.fn() }

--- a/apps/desktop/src/renderer/src/components/tasks/inline-priority-popover.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/inline-priority-popover.tsx
@@ -5,6 +5,10 @@ import { Picker } from '@/components/ui/picker'
 import { priorityConfig, type Priority } from '@/data/task-model'
 import { PriorityBars, PriorityIcon } from './task-icons'
 
+const stopTriggerPropagation = (event: React.SyntheticEvent): void => {
+  event.stopPropagation()
+}
+
 const PRIORITY_OPTIONS: { value: Priority; label: string; shortcut: string }[] = [
   { value: 'urgent', label: priorityConfig.urgent.label ?? 'Urgent', shortcut: '1' },
   { value: 'high', label: priorityConfig.high.label ?? 'High', shortcut: '2' },
@@ -50,6 +54,9 @@ export const InlinePriorityPopover = ({
             disabled && 'pointer-events-none'
           )}
           aria-label={`Priority: ${config.label || 'none'}. Click to change.`}
+          onClick={stopTriggerPropagation}
+          onPointerDown={stopTriggerPropagation}
+          onKeyDown={stopTriggerPropagation}
         >
           <PriorityBars priority={priority} />
         </button>

--- a/apps/desktop/src/renderer/src/components/tasks/inline-status-popover.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/inline-status-popover.tsx
@@ -5,6 +5,10 @@ import { Picker } from '@/components/ui/picker'
 import type { Status } from '@/data/tasks-data'
 import { StatusIcon } from './status-icon'
 
+const stopTriggerPropagation = (event: React.SyntheticEvent): void => {
+  event.stopPropagation()
+}
+
 interface InlineStatusPopoverProps {
   statusId: string
   statuses: Status[]
@@ -55,6 +59,9 @@ export const InlineStatusPopover = ({
             disabled && 'pointer-events-none'
           )}
           aria-label={`Status: ${currentStatus?.name || 'Unknown'}. Click to change.`}
+          onClick={stopTriggerPropagation}
+          onPointerDown={stopTriggerPropagation}
+          onKeyDown={stopTriggerPropagation}
         >
           <StatusIcon type={effectiveType} color={statusColor} size="lg" />
         </button>

--- a/apps/docs/src/user-guide/tasks/list-vs-kanban.md
+++ b/apps/docs/src/user-guide/tasks/list-vs-kanban.md
@@ -18,6 +18,8 @@ Default. Tasks render as flat or grouped rows with inline editing of:
 Tasks linked to notes show a compact note indicator at the end of the list row.
 Hover or focus the row to preview the note title, then click the indicator to open the note.
 
+Click the row body to open the task detail drawer. Inline status and priority controls open their own pickers without opening the drawer.
+
 Rows can be drag-reordered. Multi-select with shift-click for bulk actions.
 
 When grouping is on, group headers show counts and roll up subtask progress.
@@ -47,11 +49,11 @@ Columns reflect statuses. Drag cards across columns to update status.
 
 Above both views, internal tabs scope without changing filters:
 
-| Tab | Scope |
-| --- | --- |
-| All | Everything that matches current filters |
-| Today | Due today (or earlier, undone) |
-| Completed | Recently completed (last 30 days) |
+| Tab       | Scope                                   |
+| --------- | --------------------------------------- |
+| All       | Everything that matches current filters |
+| Today     | Due today (or earlier, undone)          |
+| Completed | Recently completed (last 30 days)       |
 
 Internal tabs are not filters in the saveable sense — they're shortcuts for the most common scopes.
 
@@ -65,11 +67,11 @@ Each [project](/user-guide/projects) has its own list/kanban. A project's kanban
 
 ## Drag Behavior
 
-| In list | In kanban |
-| --- | --- |
-| Reorder within a list | Reorder within a column |
+| In list                                     | In kanban                        |
+| ------------------------------------------- | -------------------------------- |
+| Reorder within a list                       | Reorder within a column          |
 | Cross-group drag updates the grouping field | Cross-column drag updates status |
-| Multi-select drag moves the whole selection | Same |
+| Multi-select drag moves the whole selection | Same                             |
 
 See [Drag & Drop](/user-guide/tasks/drag-and-drop) for the full reference.
 


### PR DESCRIPTION
## Summary
- Stop task-row status and priority trigger events from bubbling into row handlers.
- Keep normal row body clicks opening the task detail drawer.
- Add regression coverage for status/priority trigger clicks and row-body clicks.
- Add a short task list docs note for the inline picker behavior.

## Root Cause
The inline status and priority trigger buttons lived inside clickable task rows, so trigger click/pointer/keyboard events could bubble into the row and open the drawer while also opening the picker.

## Validation
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/components/tasks/drag-drop/task-row.test.tsx`
- `pnpm docs:impact --base origin/main --strict`
- `pnpm docs:build`
- `git diff --check HEAD~1..HEAD`
- Pre-push hook: docs impact/build, desktop lint, IPC check, desktop typecheck, full desktop test suite: 413 files passed, 7406 tests passed, 1 skipped.
