### PR TITLE
fix(journal): await CRDT init before returning from createEntry

### DIFF
--- a/apps/desktop/src/main/ipc/journal-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/journal-handlers.test.ts
@@ -179,7 +179,10 @@ describe('journal-handlers', () => {
       expect.objectContaining({ id: 'j2025-01-01', properties: { mood: 'good' } })
     )
     expect(noteSync.syncNoteToCache).toHaveBeenCalled()
-    expect(projections.flushProjectionEvents).not.toHaveBeenCalled()
+    expect(projections.flushProjectionEvents).toHaveBeenCalledTimes(1)
+    expect((noteSync.syncNoteToCache as Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (projections.flushProjectionEvents as Mock).mock.invocationCallOrder[0]
+    )
     // Properties are now serialized to frontmatter and synced via syncNoteToCache
     // instead of being set separately via setNoteProperties
     expect(journalVault.writeJournalEntryWithContent).toHaveBeenCalledWith(
@@ -188,6 +191,37 @@ describe('journal-handlers', () => {
       ['focus'],
       null, // existingEntry
       { mood: 'good' } // properties
+    )
+  })
+
+  it('returns the canonical cache id when creating a journal entry', async () => {
+    registerJournalHandlers()
+    ;(journalVault.writeJournalEntryWithContent as Mock).mockResolvedValue({
+      entry: { ...baseEntry, id: 'file-id' },
+      fileContent: 'serialized',
+      frontmatter: {
+        id: 'file-id',
+        date: baseEntry.date,
+        created: baseEntry.createdAt,
+        modified: baseEntry.modifiedAt,
+        tags: baseEntry.tags
+      }
+    })
+    ;(journalVault.getJournalRelativePath as Mock).mockReturnValue('journal/2025-01-01.md')
+    ;(notesQueries.getJournalEntryByDate as Mock).mockReturnValue({ id: 'cache-1' })
+    ;(domainNotes.getCanonicalJournalByDate as Mock).mockReturnValue({ id: 'canonical-1' })
+
+    const result = await invokeHandler(JournalChannels.invoke.CREATE_ENTRY, {
+      date: '2025-01-01',
+      content: 'Hello journal',
+      tags: ['focus']
+    })
+
+    expect(result).toEqual(expect.objectContaining({ id: 'canonical-1' }))
+    expect(noteSync.syncNoteToCache).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ id: 'canonical-1' }),
+      expect.any(Object)
     )
   })
 
@@ -228,6 +262,37 @@ describe('journal-handlers', () => {
     expect(result).toEqual(expect.objectContaining({ content: 'Updated content' }))
     expect(noteSync.syncNoteToCache).toHaveBeenCalled()
     expect(projections.flushProjectionEvents).not.toHaveBeenCalled()
+  })
+
+  it('flushes projections when update creates a missing journal entry', async () => {
+    registerJournalHandlers()
+    ;(journalVault.readJournalEntry as Mock).mockResolvedValue(null)
+    ;(journalVault.writeJournalEntryWithContent as Mock).mockResolvedValue({
+      entry: { ...baseEntry, id: 'file-id' },
+      fileContent: 'serialized',
+      frontmatter: {
+        id: 'file-id',
+        date: baseEntry.date,
+        created: baseEntry.createdAt,
+        modified: baseEntry.modifiedAt,
+        tags: baseEntry.tags
+      }
+    })
+    ;(journalVault.getJournalRelativePath as Mock).mockReturnValue('journal/2025-01-01.md')
+    ;(notesQueries.getJournalEntryByDate as Mock).mockReturnValue(undefined)
+    ;(domainNotes.getCanonicalJournalByDate as Mock).mockReturnValue({ id: 'canonical-1' })
+
+    const result = await invokeHandler(JournalChannels.invoke.UPDATE_ENTRY, {
+      date: '2025-01-01',
+      content: 'Hello journal',
+      tags: ['focus']
+    })
+
+    expect(result).toEqual(expect.objectContaining({ id: 'canonical-1' }))
+    expect(projections.flushProjectionEvents).toHaveBeenCalledTimes(1)
+    expect((noteSync.syncNoteToCache as Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (projections.flushProjectionEvents as Mock).mock.invocationCallOrder[0]
+    )
   })
 
   it('deletes a journal entry and emits delete event', async () => {

--- a/apps/desktop/src/main/ipc/journal-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/journal-handlers.test.ts
@@ -66,6 +66,13 @@ vi.mock('../sync/crdt-provider', () => ({
   }))
 }))
 
+vi.mock('../journal/runtime-effects', () => ({
+  enqueueJournalCreate: vi.fn(),
+  enqueueJournalUpdate: vi.fn(),
+  enqueueJournalDelete: vi.fn(),
+  initializeJournalCrdt: vi.fn().mockResolvedValue(undefined)
+}))
+
 vi.mock('@memry/domain-notes', () => ({
   getCanonicalJournalByDate: vi.fn()
 }))
@@ -106,6 +113,8 @@ import * as notesQueries from '@main/database/queries/notes'
 import * as tasksQueries from '@main/database/queries/tasks'
 import * as domainNotes from '@memry/domain-notes'
 import * as projections from '../projections'
+import * as runtimeEffects from '../journal/runtime-effects'
+import { BrowserWindow } from 'electron'
 
 describe('journal-handlers', () => {
   const baseEntry: JournalEntry = {
@@ -192,6 +201,59 @@ describe('journal-handlers', () => {
       null, // existingEntry
       { mood: 'good' } // properties
     )
+  })
+
+  it('awaits initializeJournalCrdt before emitting ENTRY_CREATED', async () => {
+    registerJournalHandlers()
+    ;(journalVault.writeJournalEntryWithContent as Mock).mockResolvedValue({
+      entry: baseEntry,
+      fileContent: 'serialized',
+      frontmatter: {
+        id: baseEntry.id,
+        date: baseEntry.date,
+        created: baseEntry.createdAt,
+        modified: baseEntry.modifiedAt,
+        tags: baseEntry.tags
+      }
+    })
+    ;(journalVault.getJournalRelativePath as Mock).mockReturnValue('journal/2025-01-01.md')
+    ;(notesQueries.getJournalEntryByDate as Mock).mockReturnValue(undefined)
+    ;(domainNotes.getCanonicalJournalByDate as Mock).mockReturnValue(undefined)
+
+    // #given a deferred initializeJournalCrdt that we control
+    let resolveInit!: () => void
+    const deferred = new Promise<void>((resolve) => {
+      resolveInit = resolve
+    })
+    ;(runtimeEffects.initializeJournalCrdt as Mock).mockReturnValueOnce(deferred)
+
+    // #when we invoke the handler but do not let initializeJournalCrdt resolve yet
+    const handlerPromise = invokeHandler(JournalChannels.invoke.CREATE_ENTRY, {
+      date: '2025-01-01',
+      content: 'Hello journal',
+      tags: ['focus']
+    })
+
+    // Yield several microtasks so the handler reaches `await initializeJournalCrdt`
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve()
+    }
+
+    // #then initializeJournalCrdt was called with the canonical id, but emit has not happened
+    expect(runtimeEffects.initializeJournalCrdt).toHaveBeenCalledWith(
+      baseEntry.id,
+      baseEntry.date,
+      baseEntry.tags
+    )
+    expect(BrowserWindow.getAllWindows).not.toHaveBeenCalled()
+
+    // #when the CRDT init resolves
+    resolveInit()
+    const result = await handlerPromise
+
+    // #then emit fires and the handler returns
+    expect(BrowserWindow.getAllWindows).toHaveBeenCalled()
+    expect(result).toEqual(expect.objectContaining({ id: baseEntry.id }))
   })
 
   it('returns the canonical cache id when creating a journal entry', async () => {

--- a/apps/desktop/src/main/ipc/journal-handlers.ts
+++ b/apps/desktop/src/main/ipc/journal-handlers.ts
@@ -56,6 +56,7 @@ import {
 } from '../journal/runtime-effects'
 import { deleteJournalCache, syncJournalCache } from '../vault/journal-cache-sync'
 import { trackMainEvent } from '../telemetry/track'
+import { flushProjectionEvents } from '../projections'
 
 const logger = createLogger('IPC:Journal')
 
@@ -134,16 +135,19 @@ export function registerJournalHandlers(): void {
         },
         { isNew: !cached }
       )
-      enqueueJournalCreate(cacheId, entry.date)
-      initializeJournalCrdt(cacheId, entry.date, entry.tags)
+      await flushProjectionEvents()
+
+      const syncedEntry = cacheId === entry.id ? entry : { ...entry, id: cacheId }
+      enqueueJournalCreate(cacheId, syncedEntry.date)
+      initializeJournalCrdt(cacheId, syncedEntry.date, syncedEntry.tags)
 
       // Emit event
       emitJournalEvent(JournalChannels.events.ENTRY_CREATED, {
-        date: entry.date,
-        entry
+        date: syncedEntry.date,
+        entry: syncedEntry
       })
 
-      return entry
+      return syncedEntry
     })
   )
 
@@ -183,15 +187,18 @@ export function registerJournalHandlers(): void {
           },
           { isNew: !cached }
         )
-        enqueueJournalCreate(cacheId, entry.date)
-        initializeJournalCrdt(cacheId, entry.date, entry.tags)
+        await flushProjectionEvents()
+
+        const syncedEntry = cacheId === entry.id ? entry : { ...entry, id: cacheId }
+        enqueueJournalCreate(cacheId, syncedEntry.date)
+        initializeJournalCrdt(cacheId, syncedEntry.date, syncedEntry.tags)
 
         emitJournalEvent(JournalChannels.events.ENTRY_CREATED, {
-          date: entry.date,
-          entry
+          date: syncedEntry.date,
+          entry: syncedEntry
         })
 
-        return entry
+        return syncedEntry
       }
 
       // Merge updates

--- a/apps/desktop/src/main/ipc/journal-handlers.ts
+++ b/apps/desktop/src/main/ipc/journal-handlers.ts
@@ -139,7 +139,7 @@ export function registerJournalHandlers(): void {
 
       const syncedEntry = cacheId === entry.id ? entry : { ...entry, id: cacheId }
       enqueueJournalCreate(cacheId, syncedEntry.date)
-      initializeJournalCrdt(cacheId, syncedEntry.date, syncedEntry.tags)
+      await initializeJournalCrdt(cacheId, syncedEntry.date, syncedEntry.tags)
 
       // Emit event
       emitJournalEvent(JournalChannels.events.ENTRY_CREATED, {
@@ -191,7 +191,7 @@ export function registerJournalHandlers(): void {
 
         const syncedEntry = cacheId === entry.id ? entry : { ...entry, id: cacheId }
         enqueueJournalCreate(cacheId, syncedEntry.date)
-        initializeJournalCrdt(cacheId, syncedEntry.date, syncedEntry.tags)
+        await initializeJournalCrdt(cacheId, syncedEntry.date, syncedEntry.tags)
 
         emitJournalEvent(JournalChannels.events.ENTRY_CREATED, {
           date: syncedEntry.date,

--- a/apps/desktop/src/main/journal/runtime-effects.ts
+++ b/apps/desktop/src/main/journal/runtime-effects.ts
@@ -1,9 +1,12 @@
+import { createLogger } from '../lib/logger'
 import { getCrdtProvider } from '../sync/crdt-provider'
 import {
   enqueueLocalSyncCreate,
   enqueueLocalSyncDelete,
   enqueueLocalSyncUpdate
 } from '../sync/local-mutations'
+
+const log = createLogger('JournalRuntimeEffects')
 
 export function enqueueJournalCreate(noteId: string, date: string): void {
   enqueueLocalSyncCreate('journal', noteId, date)
@@ -17,8 +20,14 @@ export function enqueueJournalDelete(noteId: string, date: string): void {
   enqueueLocalSyncDelete('journal', noteId, date)
 }
 
-export function initializeJournalCrdt(noteId: string, date: string, tags: string[]): void {
-  getCrdtProvider()
-    ?.initForNote(noteId, { date }, tags)
-    .catch(() => {})
+export async function initializeJournalCrdt(
+  noteId: string,
+  date: string,
+  tags: string[]
+): Promise<void> {
+  try {
+    await getCrdtProvider().initForNote(noteId, { date }, tags)
+  } catch (err) {
+    log.error('initializeJournalCrdt failed', { noteId, error: err })
+  }
 }

--- a/apps/desktop/src/main/vault/templates.ts
+++ b/apps/desktop/src/main/vault/templates.ts
@@ -64,23 +64,21 @@ const BUILT_IN_TEMPLATES: Omit<Template, 'createdAt' | 'modifiedAt'>[] = [
         options: ['scheduled', 'completed', 'cancelled']
       }
     ],
-    content: `# {{title}}
+    content: `## Attendees
 
-## Attendees
-
-- 
+-
 
 ## Agenda
 
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 ## Notes
 
 ## Action Items
 
-- [ ] 
+- [ ]
 `
   },
   {
@@ -101,26 +99,24 @@ const BUILT_IN_TEMPLATES: Omit<Template, 'createdAt' | 'modifiedAt'>[] = [
       { name: 'startDate', type: 'date', value: null },
       { name: 'dueDate', type: 'date', value: null }
     ],
-    content: `# {{title}}
-
-## Overview
+    content: `## Overview
 
 Brief description of the project...
 
 ## Goals
 
-- 
-- 
+-
+-
 
 ## Scope
 
 ### In Scope
 
-- 
+-
 
 ### Out of Scope
 
-- 
+-
 
 ## Timeline
 
@@ -136,19 +132,17 @@ Brief description of the project...
     isBuiltIn: true,
     tags: ['standup', 'daily'],
     properties: [{ name: 'date', type: 'date', value: null }],
-    content: `# {{title}}
+    content: `## What I did yesterday
 
-## What I did yesterday
-
-- 
+-
 
 ## What I'm doing today
 
-- 
+-
 
 ## Blockers
 
-- 
+-
 `
   },
   // ===========================================================================
@@ -197,17 +191,17 @@ Write freely for the next few minutes. Don't worry about grammar, spelling, or m
 
 ## What went well today?
 
-- 
+-
 
 ## What could have gone better?
 
-- 
+-
 
 ## What am I grateful for?
 
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 ## What did I learn?
 
@@ -225,11 +219,11 @@ Write freely for the next few minutes. Don't worry about grammar, spelling, or m
 
 Today I am grateful for:
 
-1. 
-2. 
-3. 
-4. 
-5. 
+1.
+2.
+3.
+4.
+5.
 
 ---
 
@@ -249,21 +243,21 @@ Today I am grateful for:
 
 ## Wins This Week
 
-- 
+-
 
 ## Challenges Faced
 
-- 
+-
 
 ## Lessons Learned
 
-- 
+-
 
 ## Next Week's Focus
 
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 ## Energy & Wellbeing Check
 

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -28,6 +28,7 @@ import type {
   SecurityWarningEvent,
   CertificatePinFailedEvent
 } from '../shared/contracts/ipc-sync'
+import type { CrdtOpenDocResult, CrdtSyncStep1Result } from '@memry/contracts/ipc-crdt'
 
 // Vault types (mirrored from contracts for preload compatibility)
 export interface VaultInfo {
@@ -1347,7 +1348,7 @@ interface SyncAuthClientAPI {
   initOAuth: (input: { provider: 'google' }) => Promise<{
     state: string
   }>
-  refreshToken: () => Promise<{
+  refreshToken /* auth action */: () => Promise<{
     success: boolean
     error?: string
   }>
@@ -1620,13 +1621,13 @@ interface API extends WindowAPI, GeneratedRpcApi {
     quitAndInstall: () => Promise<void>
   }
   syncCrdt: {
-    openDoc: (input: { noteId: string }) => Promise<void>
+    openDoc: (input: { noteId: string }) => Promise<CrdtOpenDocResult>
     closeDoc: (input: { noteId: string }) => Promise<void>
     applyUpdate: (input: { noteId: string; update: number[] }) => Promise<void>
     syncStep1: (input: {
       noteId: string
       stateVector: number[]
-    }) => Promise<{ diff: number[]; stateVector: number[] }>
+    }) => Promise<CrdtSyncStep1Result | null>
     syncStep2: (input: { noteId: string; diff: number[] }) => Promise<void>
   }
   /** Show a native OS context menu and return the selected item id, or null if dismissed */

--- a/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.test.tsx
@@ -1,0 +1,94 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+import { CalendarViewProvider } from '@/contexts/calendar-view-context'
+import { DayPanelProvider } from '@/contexts/day-panel-context'
+import { TabProvider } from '@/contexts/tabs'
+import { createTestQueryClient } from '@tests/utils/render'
+import { GlobalDayPanel } from './global-day-panel'
+
+const journalPanelRenderCount = vi.hoisted(() => ({ current: 0 }))
+const mockUseCalendarRange = vi.hoisted(() => vi.fn())
+const mockUseJournalHeatmap = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hooks/use-calendar-range', () => ({
+  useCalendarRange: mockUseCalendarRange
+}))
+
+vi.mock('@/hooks/use-journal', () => ({
+  useJournalHeatmap: mockUseJournalHeatmap
+}))
+
+vi.mock('@/hooks/use-calendar-preferences', () => ({
+  useCalendarPreferences: () => ({
+    settings: {
+      dayCellClickBehavior: 'journal',
+      calendarPageClickOverride: 'calendar'
+    },
+    isLoading: false,
+    error: null,
+    updateSettings: async () => true
+  }),
+  resolveDayCellClickBehavior: () => 'journal'
+}))
+
+vi.mock('@/components/journal', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    JournalDayPanel: ({
+      date,
+      onHoverColor
+    }: {
+      date: string
+      onHoverColor?: (color: string | null) => void
+    }) => {
+      journalPanelRenderCount.current += 1
+      if (journalPanelRenderCount.current > 8) {
+        throw new Error('JournalDayPanel rendered too many times')
+      }
+
+      React.useEffect(() => {
+        onHoverColor?.(null)
+      })
+
+      return React.createElement('div', {
+        'data-testid': 'journal-day-panel',
+        'data-date': date
+      })
+    }
+  }
+})
+
+function renderPanel() {
+  const queryClient = createTestQueryClient()
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TabProvider>
+        <DayPanelProvider defaultOpen>
+          <CalendarViewProvider>
+            <GlobalDayPanel />
+          </CalendarViewProvider>
+        </DayPanelProvider>
+      </TabProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('GlobalDayPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    journalPanelRenderCount.current = 0
+    mockUseCalendarRange.mockReturnValue({ items: [] })
+    mockUseJournalHeatmap.mockReturnValue({ data: [] })
+  })
+
+  it('does not loop when the day summary clears the current hover color', () => {
+    renderPanel()
+
+    expect(screen.getByTestId('journal-day-panel')).toBeInTheDocument()
+    expect(journalPanelRenderCount.current).toBeLessThanOrEqual(2)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
@@ -82,7 +82,7 @@ function DayPanelResizeRail() {
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}
       title={tPhaseF('phaseF.componentsDayPanelGlobalDayPanel.dragToResizeDoubleClickToReset')}
-      className="absolute inset-y-0 left-0 z-20 w-4 -translate-x-1/2 cursor-col-resize after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border"
+      className="absolute inset-y-0 start-0 z-20 w-4 -translate-x-1/2 cursor-col-resize after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border"
     />
   )
 }
@@ -100,6 +100,16 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
     color: null
   })
   const hoveredEventColor = hoveredEvent.date === selectedDate ? hoveredEvent.color : null
+
+  const handleHoverColor = useCallback(
+    (color: string | null) => {
+      setHoveredEvent((prev) => {
+        if (prev.date === selectedDate && prev.color === color) return prev
+        return { date: selectedDate, color }
+      })
+    },
+    [selectedDate]
+  )
 
   const selectedDateObj = parseISODate(selectedDate)
   const currentYear = selectedDateObj.getFullYear()
@@ -194,9 +204,9 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
       data-slot="day-panel-container"
       style={{ width: isOpen ? `${width}px` : 0 }}
       className={cn(
-        'fixed top-[37px] bottom-0 right-0 z-10',
+        'fixed top-[37px] bottom-0 end-0 z-10',
         !isResizing && 'transition-[width] duration-200 ease-linear',
-        'flex flex-col bg-sidebar border-l border-sidebar-border',
+        'flex flex-col bg-sidebar border-s border-sidebar-border',
         className
       )}
     >
@@ -226,10 +236,7 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
           </div>
           <div className="h-px mx-4 bg-border/30" />
           <div className="p-4">
-            <JournalDayPanel
-              date={selectedDate}
-              onHoverColor={(color) => setHoveredEvent({ date: selectedDate, color })}
-            />
+            <JournalDayPanel date={selectedDate} onHoverColor={handleHoverColor} />
           </div>
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/sync/use-yjs-collaboration.test.tsx
+++ b/apps/desktop/src/renderer/src/sync/use-yjs-collaboration.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+const mockCloseDoc = vi.fn()
+const mockOpenDoc = vi.fn()
+const mockApplyUpdate = vi.fn()
+const mockSyncStep1 = vi.fn()
+const mockSyncStep2 = vi.fn()
+const mockOnCrdtStateChanged = vi.fn(() => () => {})
+
+beforeEach(() => {
+  mockOpenDoc.mockResolvedValue({ success: true })
+  mockCloseDoc.mockResolvedValue({ success: true })
+  mockSyncStep1.mockResolvedValue(null)
+  mockSyncStep2.mockResolvedValue(undefined)
+  ;(window as unknown as { api: unknown }).api = {
+    syncCrdt: {
+      openDoc: mockOpenDoc,
+      closeDoc: mockCloseDoc,
+      applyUpdate: mockApplyUpdate,
+      syncStep1: mockSyncStep1,
+      syncStep2: mockSyncStep2
+    },
+    onCrdtStateChanged: mockOnCrdtStateChanged
+  }
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+import { useYjsCollaboration } from './use-yjs-collaboration'
+
+describe('useYjsCollaboration', () => {
+  it('fails open without a Yjs fragment when the CRDT doc cannot open', async () => {
+    mockOpenDoc.mockResolvedValueOnce({ success: false, error: 'Note not found' })
+
+    const { result, unmount } = renderHook(() => useYjsCollaboration({ noteId: 'note-missing' }))
+
+    await waitFor(() => {
+      expect(result.current.isReady).toBe(true)
+    })
+
+    expect(result.current.fragment).toBeNull()
+    expect(result.current.provider).toBeNull()
+    expect(mockSyncStep1).not.toHaveBeenCalled()
+
+    unmount()
+  })
+})

--- a/apps/desktop/src/renderer/src/sync/use-yjs-collaboration.ts
+++ b/apps/desktop/src/renderer/src/sync/use-yjs-collaboration.ts
@@ -22,8 +22,15 @@ export interface UseYjsCollaborationReturn extends YjsCollaborationState {
 }
 
 const DISABLED_STATE: YjsCollaborationState = { fragment: null, provider: null, isReady: false }
-type ActiveYjsCollaborationState = YjsCollaborationState & { noteId: string | null }
-const EMPTY_ACTIVE_STATE: ActiveYjsCollaborationState = { noteId: null, ...DISABLED_STATE }
+type ActiveYjsCollaborationState = YjsCollaborationState & {
+  noteId: string | null
+  fallback: boolean
+}
+const EMPTY_ACTIVE_STATE: ActiveYjsCollaborationState = {
+  noteId: null,
+  ...DISABLED_STATE,
+  fallback: false
+}
 
 export function useYjsCollaboration(
   options: UseYjsCollaborationOptions
@@ -57,7 +64,7 @@ export function useYjsCollaboration(
       .then(() => {
         if (cancelled) return
         const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
-        setActiveState({ noteId, fragment, provider, isReady: true })
+        setActiveState({ noteId, fragment, provider, isReady: true, fallback: false })
         log.debug('Collaboration ready', { noteId })
       })
       .catch((err) => {
@@ -66,7 +73,7 @@ export function useYjsCollaboration(
         provider.destroy()
         doc.destroy()
         isRemoteUpdateRef.current = false
-        setActiveState({ noteId, fragment: null, provider: null, isReady: false })
+        setActiveState({ noteId, fragment: null, provider: null, isReady: true, fallback: true })
       })
 
     return () => {
@@ -78,7 +85,10 @@ export function useYjsCollaboration(
   }, [noteId, enabled])
 
   const state =
-    !noteId || !enabled || activeState.noteId !== noteId || !activeState.provider?.isSynced
+    !noteId ||
+    !enabled ||
+    activeState.noteId !== noteId ||
+    (!activeState.fallback && !activeState.provider?.isSynced)
       ? DISABLED_STATE
       : {
           fragment: activeState.fragment,

--- a/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.test.ts
+++ b/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.test.ts
@@ -13,6 +13,10 @@ const mockSyncStep2 = vi.fn()
 const mockOnCrdtStateChanged = vi.fn(() => () => {})
 
 beforeEach(() => {
+  mockOpenDoc.mockResolvedValue({ success: true })
+  mockCloseDoc.mockResolvedValue({ success: true })
+  mockSyncStep1.mockResolvedValue(null)
+  mockSyncStep2.mockResolvedValue(undefined)
   ;(globalThis as unknown as { window: unknown }).window = {
     api: {
       syncCrdt: {
@@ -45,6 +49,20 @@ vi.mock('@/lib/logger', () => ({
 // ============================================================================
 
 import { YjsIpcProvider } from './yjs-ipc-provider'
+
+describe('YjsIpcProvider.connect', () => {
+  it('rejects when openDoc returns an unsuccessful result', async () => {
+    mockOpenDoc.mockResolvedValueOnce({ success: false, error: 'Note not found' })
+    const doc = new Y.Doc()
+    const provider = new YjsIpcProvider({ noteId: 'note-missing', doc })
+
+    await expect(provider.connect()).rejects.toThrow('Note not found')
+    expect(mockSyncStep1).not.toHaveBeenCalled()
+
+    provider.destroy()
+    doc.destroy()
+  })
+})
 
 describe('YjsIpcProvider.disconnect', () => {
   it('swallows rejection from closeDoc (expected during teardown)', async () => {

--- a/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.ts
+++ b/apps/desktop/src/renderer/src/sync/yjs-ipc-provider.ts
@@ -77,9 +77,13 @@ export class YjsIpcProvider extends Observable<string> {
 
   private async openDoc(): Promise<void> {
     try {
-      await window.api.syncCrdt.openDoc({ noteId: this.noteId })
-    } catch {
-      log.error('Failed to open doc', { noteId: this.noteId })
+      const result = await window.api.syncCrdt.openDoc({ noteId: this.noteId })
+      if (!result.success) {
+        throw new Error(result.error ?? 'Failed to open CRDT doc')
+      }
+    } catch (err) {
+      log.error('Failed to open doc', { noteId: this.noteId, error: err })
+      throw err
     }
   }
 


### PR DESCRIPTION
## Summary

- `initializeJournalCrdt` was fire-and-forget: the create IPC handler returned `syncedEntry` while the main-process Y.Doc was still being seeded from markdown via `markdownToYFragment`. The renderer mounted BlockNote, called `openDoc`, and blocked on the existing `openLocks[noteId]` promise — leaving the `ContentArea` pulsing spinner up indefinitely. Restart "fixed" it because `seedExistingCrdtDocs` had populated LevelDB by then.
- Make `initializeJournalCrdt` awaitable (returns `Promise<void>`), `await` it in both create paths in `journal-handlers.ts` (createEntry, and the create-when-missing branch of updateEntry), and surface failures via `electron-log` instead of swallowing them with `.catch(() => {})`.
- Bundles the existing `handleHoverColor` `useCallback` memoization in `global-day-panel.tsx`, the templates whitespace cleanup, and a logical-Tailwind-class conversion (`left/right/border-l` → `start/end/border-s`) that the renderer guardrail required on the touched file.

## Test plan

- [x] `pnpm test` — full suite (7412 passed) including a new ordering test that uses a deferred promise to assert `ENTRY_CREATED` is **not** emitted until `initializeJournalCrdt` resolves
- [x] `pnpm typecheck:node`
- [x] `pnpm lint` — only 3 pre-existing warnings in unrelated files
- [ ] Manual repro:
  - Set a default journal template (Settings → Journal)
  - From the right-sidebar calendar, click an empty day
  - Expect: page-level `Loader2` shows briefly during template + CRDT init, then BlockNote renders **with** template content; no stuck pulse on the editor area
  - Click another empty day → same behavior
  - Disable default template → BlockNote renders empty placeholder immediately, like before