### PR TITLE
feat(landing): add /pricing page for three-tier sync billing

### DIFF
--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -7,6 +7,7 @@ import { Home } from '@/pages/Home'
 import { FeaturesPage } from '@/pages/Features'
 import { UseCasesPage } from '@/pages/UseCases'
 import { SecurityPage } from '@/pages/Security'
+import { PricingPage } from '@/pages/Pricing'
 import { NotFound } from '@/pages/NotFound'
 
 function ScrollToHash() {
@@ -45,6 +46,7 @@ function AppContent() {
           <Route path="/features" element={<FeaturesPage />} />
           <Route path="/use-cases" element={<UseCasesPage />} />
           <Route path="/security" element={<SecurityPage />} />
+          <Route path="/pricing" element={<PricingPage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </main>

--- a/apps/landing/src/entry-server.tsx
+++ b/apps/landing/src/entry-server.tsx
@@ -8,12 +8,14 @@ import { Home } from '@/pages/Home'
 import { FeaturesPage } from '@/pages/Features'
 import { UseCasesPage } from '@/pages/UseCases'
 import { SecurityPage } from '@/pages/Security'
+import { PricingPage } from '@/pages/Pricing'
 
 const ROUTE_MAP: Record<string, () => ReactNode> = {
   '/': () => <Home />,
   '/features': () => <FeaturesPage />,
   '/use-cases': () => <UseCasesPage />,
-  '/security': () => <SecurityPage />
+  '/security': () => <SecurityPage />,
+  '/pricing': () => <PricingPage />
 }
 
 export function render(url: string): { html: string; helmet: HelmetServerState | null } {

--- a/apps/landing/src/lib/constants.ts
+++ b/apps/landing/src/lib/constants.ts
@@ -23,7 +23,7 @@ export const TWITTER_DEV_URL = 'https://x.com/h4yfans'
 
 export const NAV_LINKS = [
   { label: 'Use Cases', href: '/use-cases' },
-  { label: 'Roadmap', href: '#roadmap' },
+  { label: 'Pricing', href: '/pricing' },
   { label: 'Security', href: '/security' },
   { label: 'Docs', href: DOCS_URL }
 ] as const
@@ -31,6 +31,7 @@ export const NAV_LINKS = [
 export const FOOTER_LINKS = {
   product: [
     { label: 'Features', href: '#features' },
+    { label: 'Pricing', href: '/pricing' },
     { label: 'Security', href: '/security' }
   ],
   social: [
@@ -420,6 +421,221 @@ export const USE_CASES = [
       'Track habits with recurring tasks',
       'Reflect in morning Journal'
     ]
+  }
+] as const
+
+export type SyncPlanId = 'standard' | 'plus' | 'believer'
+
+export type SyncPlanEmphasis = 'standard' | 'recommended' | 'founding'
+
+export type SyncPlanTier = {
+  id: SyncPlanId
+  name: string
+  tagline: string
+  monthlyPrice: number | null
+  annualPrice: number | null
+  annualMonthlyEquivalent: number | null
+  lifetimePrice: number | null
+  limits: {
+    vaults: string
+    storage: string
+    fileSize: string
+    history: string
+  }
+  features: readonly string[]
+  cta: string
+  emphasis: SyncPlanEmphasis
+  ribbon?: string
+}
+
+export const SYNC_PLAN_TIERS: readonly SyncPlanTier[] = [
+  {
+    id: 'standard',
+    name: 'Sync Standard',
+    tagline: 'One vault, encrypted, everywhere.',
+    monthlyPrice: 5,
+    annualPrice: 48,
+    annualMonthlyEquivalent: 4,
+    lifetimePrice: null,
+    limits: {
+      vaults: '1',
+      storage: '1 GiB',
+      fileSize: '5 MiB',
+      history: '30 d'
+    },
+    features: [
+      'End-to-end encrypted sync',
+      'Unlimited devices on one account',
+      'Server never sees plaintext',
+      '30 days of version history',
+      '7-day money-back guarantee'
+    ],
+    cta: 'Get Sync Standard',
+    emphasis: 'standard'
+  },
+  {
+    id: 'plus',
+    name: 'Sync Plus',
+    tagline: 'Multiple vaults. Big files. Deep history.',
+    monthlyPrice: 10,
+    annualPrice: 96,
+    annualMonthlyEquivalent: 8,
+    lifetimePrice: null,
+    limits: {
+      vaults: '10',
+      storage: '10 GiB',
+      fileSize: '200 MiB',
+      history: '365 d'
+    },
+    features: [
+      'Everything in Sync Standard',
+      'Up to 10 separate vaults',
+      'Large attachments and PDFs',
+      'A full year of version history',
+      'Priority support — straight from the founder'
+    ],
+    cta: 'Get Sync Plus',
+    emphasis: 'recommended',
+    ribbon: 'Most popular'
+  },
+  {
+    id: 'believer',
+    name: 'Believer',
+    tagline: 'Pay once. Sync forever. Every future paid feature included.',
+    monthlyPrice: null,
+    annualPrice: null,
+    annualMonthlyEquivalent: null,
+    lifetimePrice: 500,
+    limits: {
+      vaults: '10',
+      storage: '10 GiB',
+      fileSize: '200 MiB',
+      history: '365 d'
+    },
+    features: [
+      'Lifetime Sync Plus — never billed again',
+      'Every future paid feature, included forever',
+      'Recognized as a founding supporter',
+      'Direct line to the founder',
+      'Limited slots'
+    ],
+    cta: 'Become a Believer',
+    emphasis: 'founding',
+    ribbon: 'Founding supporter'
+  }
+] as const
+
+export const PLAN_LIMIT_MATRIX = {
+  headers: ['', 'Sync Standard', 'Sync Plus', 'Believer'] as const,
+  rows: [
+    { feature: 'Synced vaults', standard: '1', plus: '10', believer: '10' },
+    { feature: 'Total storage', standard: '1 GiB', plus: '10 GiB', believer: '10 GiB' },
+    { feature: 'Max file size', standard: '5 MiB', plus: '200 MiB', believer: '200 MiB' },
+    { feature: 'Version history', standard: '30 days', plus: '365 days', believer: '365 days' },
+    {
+      feature: 'Devices per account',
+      standard: 'Unlimited',
+      plus: 'Unlimited',
+      believer: 'Unlimited'
+    },
+    { feature: 'Monthly billing', standard: '$5', plus: '$10', believer: '—' },
+    { feature: 'Annual billing', standard: '$48 ($4/mo)', plus: '$96 ($8/mo)', believer: '—' },
+    { feature: 'Lifetime', standard: '—', plus: '—', believer: '$500 once' },
+    {
+      feature: 'Future paid features',
+      standard: 'In tier',
+      plus: 'In tier',
+      believer: 'Included forever'
+    }
+  ] as const
+} as const
+
+export type LifecycleTone = 'sage' | 'amber' | 'terracotta' | 'terracotta-dim' | 'ink'
+
+export const LIFECYCLE_STAGES: readonly {
+  id: string
+  label: string
+  days: string
+  description: string
+  tone: LifecycleTone
+}[] = [
+  {
+    id: 'active',
+    label: 'Active',
+    days: 'Day 0',
+    description: 'Sync runs everywhere. All limits apply per tier.',
+    tone: 'sage'
+  },
+  {
+    id: 'grace',
+    label: 'Grace',
+    days: '+ 14 days',
+    description: 'Sync keeps working. Time to fix the card or change your mind.',
+    tone: 'amber'
+  },
+  {
+    id: 'read-only',
+    label: 'Read-only',
+    days: '+ 30 days',
+    description: 'Pulls succeed, pushes blocked. Pull everything to local at your pace.',
+    tone: 'terracotta'
+  },
+  {
+    id: 'purged',
+    label: 'Purged status',
+    days: 'Day 44',
+    description: 'Server returns 402 on every request. Encrypted blobs untouched.',
+    tone: 'terracotta-dim'
+  },
+  {
+    id: 'deleted',
+    label: 'Blobs deleted',
+    days: 'Day 90',
+    description: 'Encrypted blobs physically removed from R2. Recovery ends.',
+    tone: 'ink'
+  }
+] as const
+
+export const PRICING_FAQ_ITEMS = [
+  {
+    question: 'Is the local app still free?',
+    answer:
+      'Yes. Notes, tasks, journal, and inbox stay free, forever, no account required. Sync between devices is the paid layer — and only the paid layer.'
+  },
+  {
+    question: 'What happens if my card fails or I cancel?',
+    answer:
+      'You get 14 days of grace where sync keeps working, then 30 days of read-only mode where pulls still succeed. After day 44 your account is marked purged but encrypted blobs sit untouched on our servers until day 90 — re-subscribe before then and everything restores intact.'
+  },
+  {
+    question: 'You store my data, but you cannot read it. What does that actually mean?',
+    answer:
+      'Every byte is encrypted on your device with XChaCha20-Poly1305 before it leaves. The keys live in your password manager and never touch our servers. We hold ciphertext, count bytes for billing, and that is the limit of what we see.'
+  },
+  {
+    question: 'How does the refund policy work?',
+    answer:
+      '7-day money-back guarantee on every plan, including Believer. Request it inside the app — Paddle processes the refund back to your original payment method, no questions asked.'
+  },
+  {
+    question: 'What is the Believer tier really?',
+    answer:
+      'A bet on us. You pay once, get lifetime Sync Plus, and inherit every paid feature we ship from now until forever. Roughly five years of annual Plus, with no expiry. Slots may be limited later.'
+  },
+  {
+    question: 'Can I upgrade or downgrade later?',
+    answer:
+      'Yes. Upgrades pro-rate immediately. Downgrades take effect at the end of your billing period — if you have more vaults than the new tier allows, existing data stays readable while you archive what you no longer need.'
+  },
+  {
+    question: 'Do you handle VAT and sales tax?',
+    answer:
+      'Yes. Paddle is the merchant of record and handles VAT, GST, and US sales tax across 60+ countries. The price you see at checkout is the price you pay.'
+  },
+  {
+    question: 'Which payment methods are accepted?',
+    answer:
+      'Cards, Apple Pay, Google Pay, PayPal, and several regional methods depending on your country — all processed through Paddle.'
   }
 ] as const
 

--- a/apps/landing/src/lib/seo.ts
+++ b/apps/landing/src/lib/seo.ts
@@ -38,6 +38,12 @@ export const PAGE_META: Record<string, PageMeta> = {
     description:
       'Local-first storage, XChaCha20-Poly1305 encryption, zero-knowledge sync, on-device AI. Your data never leaves your device unencrypted.',
     path: '/security'
+  },
+  pricing: {
+    title: 'Pricing — Memry Sync',
+    description:
+      'Local-first stays free, forever. Sync is paid, fair, and end-to-end encrypted. Standard from $4/mo, Plus from $8/mo, or Believer for a one-time $500.',
+    path: '/pricing'
   }
 }
 

--- a/apps/landing/src/pages/Pricing.tsx
+++ b/apps/landing/src/pages/Pricing.tsx
@@ -1,124 +1,702 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
-import { Check } from 'lucide-react'
+import {
+  Check,
+  ArrowRight,
+  Vault,
+  HardDrive,
+  FileUp,
+  History,
+  Sparkles,
+  ShieldCheck,
+  Heart
+} from 'lucide-react'
 import { Container } from '@/components/layout/Container'
-import { SectionHeading } from '@/components/shared/SectionHeading'
 import { PageHead } from '@/components/shared/PageHead'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger
 } from '@/components/ui/accordion'
-import { PRICING_TIERS } from '@/lib/constants'
+import {
+  SYNC_PLAN_TIERS,
+  PLAN_LIMIT_MATRIX,
+  LIFECYCLE_STAGES,
+  PRICING_FAQ_ITEMS,
+  type SyncPlanTier,
+  type LifecycleTone
+} from '@/lib/constants'
 import { cn } from '@/lib/utils'
 
-const pricingFAQ = [
-  {
-    question: 'Can I switch between plans?',
-    answer:
-      "Yes! You can upgrade to Supporter at any time, or cancel and continue using the free tier. Your data stays yours regardless of which plan you're on."
-  },
-  {
-    question: 'What happens if I cancel my Supporter subscription?',
-    answer:
-      'You keep all your data and can continue using Memry with all features. The Supporter tier is about supporting development and getting early access, not unlocking features.'
-  },
-  {
-    question: 'Do you offer refunds?',
-    answer:
-      'Yes, we offer a 30-day money-back guarantee for annual subscriptions. Monthly subscriptions can be cancelled anytime.'
-  },
-  {
-    question: 'Is there a team or enterprise plan?',
-    answer:
-      "We're focused on individual users for now, but team features are on our roadmap. Join the waitlist to stay updated."
-  }
-]
+type Cadence = 'monthly' | 'annual'
+
+const fadeUp = {
+  initial: { opacity: 0, y: 20 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: '-80px' },
+  transition: { duration: 0.8, ease: [0.16, 1, 0.3, 1] as [number, number, number, number] }
+}
 
 export function PricingPage() {
+  const [cadence, setCadence] = useState<Cadence>('annual')
+
   return (
-    <main className="pt-24">
+    <>
       <PageHead page="pricing" />
-      <section className="py-16">
-        <Container size="md">
-          <SectionHeading
-            title="Simple, honest pricing"
-            subtitle="Memry is free forever. The Supporter tier helps fund development and gives you early access to new features."
-          />
+      <main>
+        <Hero cadence={cadence} setCadence={setCadence} />
+        <TierGrid cadence={cadence} />
+        <BelieverNarrative />
+        <LifecycleTimeline />
+        <LimitMatrix />
+        <PricingFaq />
+        <FinalCta />
+      </main>
+    </>
+  )
+}
 
-          <div className="grid md:grid-cols-2 gap-8 max-w-3xl mx-auto mb-16">
-            {PRICING_TIERS.map((tier, index) => (
-              <motion.div
-                key={tier.name}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5, delay: index * 0.1 }}
-              >
-                <Card
-                  className={cn('h-full relative', tier.highlighted && 'border-primary shadow-lg')}
-                >
-                  {tier.highlighted && (
-                    <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-                      <span className="bg-primary text-primary-foreground text-xs font-medium px-3 py-1 rounded-full">
-                        Support us
-                      </span>
-                    </div>
-                  )}
+function Hero({ cadence, setCadence }: { cadence: Cadence; setCadence: (c: Cadence) => void }) {
+  return (
+    <section className="relative overflow-hidden pt-32 pb-16 sm:pt-40 sm:pb-20">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[420px] bg-[radial-gradient(ellipse_at_top,rgba(199,91,57,0.10),transparent_60%)]"
+      />
+      <Container size="md">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.9, ease: [0.16, 1, 0.3, 1] }}
+          className="text-center"
+        >
+          <p className="font-mono-accent text-[11px] uppercase tracking-[0.32em] text-terracotta">
+            Pricing &nbsp;·&nbsp; V.1
+          </p>
+          <h1 className="mt-5 font-serif text-5xl font-normal leading-[1.05] text-ink text-balance md:text-7xl">
+            Sync that respects
+            <br />
+            your <span className="italic text-terracotta">wallet.</span>
+          </h1>
+          <p className="mx-auto mt-7 max-w-xl text-lg leading-relaxed text-muted text-balance md:text-xl">
+            The local app stays free, forever. Sync is paid — fair, predictable, and
+            end-to-end encrypted before a single byte leaves your device.
+          </p>
 
-                  <CardHeader className="text-center pb-2">
-                    <CardTitle className="text-xl">{tier.name}</CardTitle>
-                    <div className="mt-4">
-                      <span className="text-4xl font-bold text-foreground">{tier.price}</span>
-                      <span className="text-muted ml-1">{tier.period}</span>
-                    </div>
-                    {'yearlyPrice' in tier && tier.yearlyPrice && (
-                      <p className="text-sm text-muted mt-1">or {tier.yearlyPrice}</p>
-                    )}
-                    <CardDescription className="mt-3">{tier.description}</CardDescription>
-                  </CardHeader>
-
-                  <CardContent className="pt-4">
-                    <ul className="space-y-3 mb-6">
-                      {tier.features.map((feature) => (
-                        <li key={feature} className="flex items-start gap-3 text-sm">
-                          <Check className="w-4 h-4 text-primary mt-0.5 shrink-0" />
-                          <span className="text-muted">{feature}</span>
-                        </li>
-                      ))}
-                    </ul>
-
-                    <Button
-                      variant={tier.highlighted ? 'default' : 'secondary'}
-                      className="w-full"
-                      asChild
-                    >
-                      <a href="/#waitlist">{tier.cta}</a>
-                    </Button>
-                  </CardContent>
-                </Card>
-              </motion.div>
-            ))}
+          <div className="mt-10 flex flex-col items-center gap-3">
+            <CadenceToggle cadence={cadence} setCadence={setCadence} />
+            <p className="font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted/70">
+              Switch any time. No tier change fees.
+            </p>
           </div>
+        </motion.div>
+      </Container>
+    </section>
+  )
+}
 
-          <div className="max-w-2xl mx-auto">
-            <h3 className="text-xl font-semibold text-foreground text-center mb-8">Pricing FAQ</h3>
-            <Accordion type="single" collapsible className="w-full">
-              {pricingFAQ.map((item, index) => (
-                <AccordionItem key={index} value={`item-${index}`}>
-                  <AccordionTrigger className="text-left text-foreground">
-                    {item.question}
-                  </AccordionTrigger>
-                  <AccordionContent className="text-muted leading-relaxed">
-                    {item.answer}
-                  </AccordionContent>
-                </AccordionItem>
-              ))}
-            </Accordion>
+function CadenceToggle({
+  cadence,
+  setCadence
+}: {
+  cadence: Cadence
+  setCadence: (c: Cadence) => void
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Billing cadence"
+      className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-white/65 p-1 shadow-[0_2px_18px_rgba(26,26,26,0.04)] backdrop-blur"
+    >
+      {(['monthly', 'annual'] as Cadence[]).map((option) => {
+        const active = cadence === option
+        return (
+          <button
+            key={option}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => setCadence(option)}
+            className={cn(
+              'relative inline-flex items-center gap-2 rounded-full px-5 py-2 text-sm font-medium transition-all duration-300',
+              active
+                ? 'bg-ink text-paper shadow-[0_4px_14px_rgba(26,26,26,0.18)]'
+                : 'text-muted hover:text-ink'
+            )}
+          >
+            <span className="capitalize">{option}</span>
+            {option === 'annual' && (
+              <span
+                className={cn(
+                  'rounded-full px-1.5 py-0.5 font-mono-accent text-[10px] uppercase tracking-widest transition-colors',
+                  active ? 'bg-terracotta/30 text-paper' : 'bg-terracotta/15 text-terracotta'
+                )}
+              >
+                –20%
+              </span>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function TierGrid({ cadence }: { cadence: Cadence }) {
+  return (
+    <section className="pb-24">
+      <Container size="lg">
+        <div className="grid gap-6 lg:grid-cols-3 lg:items-stretch lg:gap-7">
+          {SYNC_PLAN_TIERS.map((tier, index) => (
+            <motion.div
+              key={tier.id}
+              initial={{ opacity: 0, y: 28 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: '-80px' }}
+              transition={{
+                duration: 0.7,
+                delay: index * 0.08,
+                ease: [0.16, 1, 0.3, 1]
+              }}
+              className="h-full"
+            >
+              <TierCard tier={tier} cadence={cadence} />
+            </motion.div>
+          ))}
+        </div>
+        <p className="mt-10 text-center font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted/70">
+          All prices in USD &nbsp;·&nbsp; VAT and sales tax handled at checkout
+        </p>
+      </Container>
+    </section>
+  )
+}
+
+function TierCard({ tier, cadence }: { tier: SyncPlanTier; cadence: Cadence }) {
+  const isFounding = tier.emphasis === 'founding'
+  const isRecommended = tier.emphasis === 'recommended'
+
+  return (
+    <article
+      className={cn(
+        'relative flex h-full flex-col overflow-hidden rounded-[28px] border p-7 transition-all duration-300 sm:p-8',
+        isFounding
+          ? 'border-dark-border bg-dark text-ink-inverted shadow-[0_24px_60px_-30px_rgba(20,18,16,0.55)]'
+          : isRecommended
+            ? 'border-terracotta/35 bg-card shadow-[0_20px_60px_-32px_rgba(199,91,57,0.45)] lg:scale-[1.015]'
+            : 'border-border/60 bg-card shadow-card'
+      )}
+    >
+      {tier.ribbon && (
+        <span
+          className={cn(
+            'absolute right-6 top-6 inline-flex items-center gap-1.5 rounded-full px-3 py-1 font-mono-accent text-[10px] uppercase tracking-[0.2em]',
+            isFounding
+              ? 'bg-terracotta/15 text-terracotta'
+              : 'bg-terracotta text-paper shadow-[0_8px_22px_-8px_rgba(199,91,57,0.6)]'
+          )}
+        >
+          {isFounding ? <Heart className="h-3 w-3" aria-hidden /> : null}
+          {tier.ribbon}
+        </span>
+      )}
+
+      <header>
+        <h3
+          className={cn(
+            'font-serif text-3xl font-normal',
+            isFounding ? 'text-ink-inverted' : 'text-ink'
+          )}
+        >
+          {tier.name}
+        </h3>
+        <p
+          className={cn(
+            'mt-2 max-w-[28ch] text-sm leading-relaxed',
+            isFounding ? 'text-dark-muted' : 'text-muted'
+          )}
+        >
+          {tier.tagline}
+        </p>
+      </header>
+
+      <div className="mt-7">
+        <PriceBlock tier={tier} cadence={cadence} isFounding={isFounding} />
+      </div>
+
+      <LimitsGrid tier={tier} isFounding={isFounding} />
+
+      <ul className="mt-7 space-y-3">
+        {tier.features.map((feature) => (
+          <li key={feature} className="flex items-start gap-3 text-sm">
+            <span
+              className={cn(
+                'mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border',
+                isFounding
+                  ? 'border-terracotta/40 bg-terracotta/10 text-terracotta'
+                  : 'border-sage/35 bg-sage/10 text-sage'
+              )}
+            >
+              <Check className="h-3 w-3" strokeWidth={3} />
+            </span>
+            <span
+              className={cn(
+                'leading-relaxed',
+                isFounding ? 'text-ink-inverted/85' : 'text-ink/80'
+              )}
+            >
+              {feature}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-auto pt-8">
+        {isFounding ? (
+          <Button
+            variant="default"
+            size="lg"
+            className="w-full rounded-full bg-terracotta text-white hover:bg-terracotta-dark"
+            asChild
+          >
+            <a href="#waitlist">
+              {tier.cta}
+              <ArrowRight className="h-4 w-4" />
+            </a>
+          </Button>
+        ) : isRecommended ? (
+          <Button
+            variant="default"
+            size="lg"
+            className="w-full rounded-full"
+            asChild
+          >
+            <a href="#waitlist">
+              {tier.cta}
+              <ArrowRight className="h-4 w-4" />
+            </a>
+          </Button>
+        ) : (
+          <Button
+            variant="outline"
+            size="lg"
+            className="w-full rounded-full border-ink/15 bg-paper-alt/40 text-ink hover:bg-paper-alt"
+            asChild
+          >
+            <a href="#waitlist">
+              {tier.cta}
+              <ArrowRight className="h-4 w-4" />
+            </a>
+          </Button>
+        )}
+      </div>
+    </article>
+  )
+}
+
+function PriceBlock({
+  tier,
+  cadence,
+  isFounding
+}: {
+  tier: SyncPlanTier
+  cadence: Cadence
+  isFounding: boolean
+}) {
+  if (tier.lifetimePrice !== null) {
+    return (
+      <div>
+        <div className="flex items-baseline gap-2">
+          <span className="font-mono-accent text-5xl font-medium text-ink-inverted leading-none">
+            ${tier.lifetimePrice}
+          </span>
+          <span className="font-sans text-sm uppercase tracking-widest text-dark-muted">
+            paid once
+          </span>
+        </div>
+        <p className="mt-2 font-mono-accent text-xs uppercase tracking-[0.18em] text-terracotta">
+          Lifetime &nbsp;·&nbsp; no expiry &nbsp;·&nbsp; future features included
+        </p>
+      </div>
+    )
+  }
+
+  const showAnnual = cadence === 'annual'
+  const displayPrice = showAnnual ? tier.annualMonthlyEquivalent : tier.monthlyPrice
+
+  return (
+    <div>
+      <div className="flex items-baseline gap-2">
+        <span
+          className={cn(
+            'font-mono-accent text-5xl font-medium leading-none transition-colors',
+            isFounding ? 'text-ink-inverted' : 'text-ink'
+          )}
+        >
+          ${displayPrice}
+        </span>
+        <span
+          className={cn(
+            'font-sans text-sm',
+            isFounding ? 'text-dark-muted' : 'text-muted'
+          )}
+        >
+          / month
+        </span>
+      </div>
+      <p
+        className={cn(
+          'mt-2 font-mono-accent text-xs uppercase tracking-[0.18em]',
+          showAnnual ? 'text-terracotta' : 'text-muted/80'
+        )}
+      >
+        {showAnnual
+          ? `Billed $${tier.annualPrice} yearly · save 20%`
+          : `or $${tier.annualPrice} / yr ($${tier.annualMonthlyEquivalent}/mo billed yearly)`}
+      </p>
+    </div>
+  )
+}
+
+function LimitsGrid({ tier, isFounding }: { tier: SyncPlanTier; isFounding: boolean }) {
+  const cells = [
+    { icon: Vault, label: 'Vaults', value: tier.limits.vaults },
+    { icon: HardDrive, label: 'Storage', value: tier.limits.storage },
+    { icon: FileUp, label: 'Per file', value: tier.limits.fileSize },
+    { icon: History, label: 'History', value: tier.limits.history }
+  ]
+
+  return (
+    <div
+      className={cn(
+        'mt-7 grid grid-cols-4 gap-2 rounded-2xl border p-3',
+        isFounding
+          ? 'border-dark-border/80 bg-dark-surface/60'
+          : 'border-border/60 bg-paper-alt/55'
+      )}
+    >
+      {cells.map(({ icon: Icon, label, value }) => (
+        <div key={label} className="flex flex-col items-center gap-1.5 px-1 py-2 text-center">
+          <Icon
+            className={cn('h-3.5 w-3.5', isFounding ? 'text-terracotta' : 'text-terracotta/80')}
+          />
+          <span
+            className={cn(
+              'font-mono-accent text-base font-medium leading-none',
+              isFounding ? 'text-ink-inverted' : 'text-ink'
+            )}
+          >
+            {value}
+          </span>
+          <span
+            className={cn(
+              'font-mono-accent text-[9px] uppercase tracking-[0.14em]',
+              isFounding ? 'text-dark-muted' : 'text-muted/85'
+            )}
+          >
+            {label}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function BelieverNarrative() {
+  return (
+    <section className="relative">
+      <div className="h-[80px] bg-gradient-to-b from-paper to-dark" aria-hidden />
+      <div className="zone-dark py-24 md:py-28">
+        <Container size="md">
+          <div className="grid gap-12 md:grid-cols-[1fr_1.4fr] md:items-center">
+            <motion.div {...fadeUp} className="space-y-6">
+              <span className="inline-flex items-center gap-2 rounded-full border border-terracotta/30 bg-terracotta/10 px-3 py-1 font-mono-accent text-[10px] uppercase tracking-[0.22em] text-terracotta">
+                <Sparkles className="h-3 w-3" aria-hidden /> Believer
+              </span>
+              <h2 className="font-serif text-4xl font-normal leading-tight text-ink-inverted md:text-5xl">
+                Pay <span className="italic text-terracotta">$500 once.</span>
+                <br />
+                Sync forever.
+              </h2>
+              <p className="text-lg leading-relaxed text-dark-muted">
+                Believers fund the next chapter of Memry. In return, they get every paid feature
+                we ever ship — automatic, no extra invoice — for as long as Memry exists.
+              </p>
+            </motion.div>
+
+            <motion.figure
+              {...fadeUp}
+              transition={{ ...fadeUp.transition, delay: 0.15 }}
+              className="relative rounded-3xl border border-dark-border bg-dark-surface p-8 md:p-10"
+            >
+              <div
+                className="absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-terracotta/60 to-transparent"
+                aria-hidden
+              />
+              <blockquote className="font-serif text-xl leading-relaxed text-ink-inverted/90 md:text-2xl">
+                <span className="font-serif text-4xl text-terracotta leading-none">“</span>
+                Indie software lives or dies on the people who back it early.
+                Believers aren&apos;t buying a tier — they&apos;re buying a seat at
+                the table while we figure out what the next ten years of memry looks like.
+              </blockquote>
+              <figcaption className="mt-6 flex items-center gap-3 text-sm font-mono-accent uppercase tracking-[0.18em] text-dark-muted">
+                <span className="h-px w-8 bg-terracotta/60" aria-hidden />
+                Kaan, founder
+              </figcaption>
+            </motion.figure>
           </div>
         </Container>
-      </section>
-    </main>
+      </div>
+    </section>
+  )
+}
+
+const TONE_DOT_CLASS: Record<LifecycleTone, string> = {
+  sage: 'bg-sage shadow-[0_0_0_5px_rgba(91,127,106,0.15)]',
+  amber: 'bg-amber-500 shadow-[0_0_0_5px_rgba(217,119,6,0.18)]',
+  terracotta: 'bg-terracotta shadow-[0_0_0_5px_rgba(199,91,57,0.22)]',
+  'terracotta-dim': 'bg-terracotta/55 shadow-[0_0_0_5px_rgba(199,91,57,0.12)]',
+  ink: 'bg-ink/80 shadow-[0_0_0_5px_rgba(26,26,26,0.12)]'
+}
+
+const TONE_TEXT_CLASS: Record<LifecycleTone, string> = {
+  sage: 'text-sage',
+  amber: 'text-amber-600',
+  terracotta: 'text-terracotta',
+  'terracotta-dim': 'text-terracotta/75',
+  ink: 'text-ink/75'
+}
+
+function LifecycleTimeline() {
+  return (
+    <section className="border-t border-border/40 bg-paper-deep/40 py-24 md:py-28">
+      <Container size="md">
+        <motion.div {...fadeUp} className="mx-auto max-w-2xl text-center">
+          <span className="font-mono-accent text-[11px] uppercase tracking-[0.28em] text-muted">
+            Lapse policy
+          </span>
+          <h2 className="mt-3 font-serif text-4xl font-normal leading-tight text-ink md:text-5xl">
+            What happens if you stop paying?
+          </h2>
+          <p className="mt-5 text-lg leading-relaxed text-muted">
+            Sync gets paused, never punished. You get a long, predictable runway to recover —
+            up to 90 days before encrypted blobs are physically deleted.
+          </p>
+        </motion.div>
+
+        <div className="mt-16">
+          <div className="relative">
+            <div
+              aria-hidden
+              className="absolute left-4 top-2 hidden h-[calc(100%-1.5rem)] w-px bg-gradient-to-b from-sage/60 via-terracotta/40 to-ink/30 md:left-1/2 md:top-1/2 md:hidden md:h-px md:w-[calc(100%-3rem)] md:-translate-y-1/2"
+            />
+            <div
+              aria-hidden
+              className="absolute left-0 right-0 top-[22px] hidden h-px bg-gradient-to-r from-sage/50 via-terracotta/40 to-ink/20 md:block"
+            />
+
+            <ol className="grid gap-10 md:grid-cols-5 md:gap-4">
+              {LIFECYCLE_STAGES.map((stage, i) => (
+                <motion.li
+                  key={stage.id}
+                  {...fadeUp}
+                  transition={{ ...fadeUp.transition, delay: i * 0.08 }}
+                  className="relative flex flex-col gap-3 md:items-center md:text-center"
+                >
+                  <div
+                    className={cn(
+                      'relative z-10 inline-flex h-3 w-3 items-center justify-center rounded-full',
+                      TONE_DOT_CLASS[stage.tone]
+                    )}
+                    aria-hidden
+                  />
+                  <p
+                    className={cn(
+                      'font-mono-accent text-[11px] uppercase tracking-[0.18em]',
+                      TONE_TEXT_CLASS[stage.tone]
+                    )}
+                  >
+                    {stage.days}
+                  </p>
+                  <h3 className="font-serif text-xl text-ink leading-tight">{stage.label}</h3>
+                  <p className="text-sm leading-relaxed text-muted md:max-w-[20ch]">
+                    {stage.description}
+                  </p>
+                </motion.li>
+              ))}
+            </ol>
+          </div>
+        </div>
+
+        <motion.div
+          {...fadeUp}
+          transition={{ ...fadeUp.transition, delay: 0.4 }}
+          className="mt-14 flex flex-col items-center gap-4 rounded-2xl border border-terracotta/25 bg-terracotta/5 px-6 py-5 text-center md:flex-row md:justify-center md:text-left"
+        >
+          <ShieldCheck className="h-5 w-5 text-terracotta shrink-0" aria-hidden />
+          <p className="text-sm leading-relaxed text-ink">
+            <span className="font-medium">46-day recovery window.</span> Re-subscribe any time
+            before day 90 and your encrypted vaults restore exactly where they left off.
+          </p>
+        </motion.div>
+      </Container>
+    </section>
+  )
+}
+
+function LimitMatrix() {
+  return (
+    <section className="py-24 md:py-28">
+      <Container size="md">
+        <motion.div {...fadeUp} className="mx-auto max-w-2xl text-center">
+          <span className="font-mono-accent text-[11px] uppercase tracking-[0.28em] text-muted">
+            The full picture
+          </span>
+          <h2 className="mt-3 font-serif text-4xl font-normal leading-tight text-ink md:text-5xl">
+            Compare every limit
+          </h2>
+          <p className="mt-5 text-lg leading-relaxed text-muted">
+            All four limits — vaults, storage, file size, history — are enforced server-side.
+            Numbers are exact; no asterisks, no fair-use clauses.
+          </p>
+        </motion.div>
+
+        <motion.div
+          {...fadeUp}
+          transition={{ ...fadeUp.transition, delay: 0.1 }}
+          className="mt-12 overflow-hidden rounded-2xl border border-border/55 bg-white/55 shadow-card"
+        >
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border/60">
+                {PLAN_LIMIT_MATRIX.headers.map((header, i) => (
+                  <th
+                    key={header || 'feature'}
+                    className={cn(
+                      'px-6 py-5 font-mono-accent text-[11px] uppercase tracking-[0.18em]',
+                      i === 0 ? 'text-left text-ink' : 'text-center',
+                      i === 0 && 'min-w-[160px]',
+                      i === 2
+                        ? 'border-x border-terracotta/25 bg-terracotta/[0.04] text-terracotta'
+                        : 'text-muted'
+                    )}
+                  >
+                    {i === 2 ? (
+                      <span className="inline-flex items-center justify-center gap-2">
+                        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-terracotta" />
+                        {header}
+                      </span>
+                    ) : (
+                      header
+                    )}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {PLAN_LIMIT_MATRIX.rows.map((row) => (
+                <tr
+                  key={row.feature}
+                  className="border-b border-border/40 last:border-0 transition-colors hover:bg-paper-alt/40"
+                >
+                  <td className="px-6 py-4 text-sm font-medium text-ink">{row.feature}</td>
+                  <td className="px-6 py-4 text-center font-mono-accent text-sm text-ink/80">
+                    {row.standard}
+                  </td>
+                  <td className="border-x border-terracotta/15 bg-terracotta/[0.025] px-6 py-4 text-center font-mono-accent text-sm text-ink">
+                    {row.plus}
+                  </td>
+                  <td className="px-6 py-4 text-center font-mono-accent text-sm text-ink/80">
+                    {row.believer}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </motion.div>
+      </Container>
+    </section>
+  )
+}
+
+function PricingFaq() {
+  return (
+    <section className="border-t border-border/40 bg-paper-alt/35 py-24">
+      <Container size="sm">
+        <motion.div {...fadeUp} className="mb-12 text-center">
+          <span className="font-mono-accent text-[11px] uppercase tracking-[0.28em] text-muted">
+            FAQ
+          </span>
+          <h2 className="mt-3 font-serif text-3xl font-normal leading-tight text-ink md:text-4xl">
+            The honest billing answers
+          </h2>
+        </motion.div>
+
+        <motion.div {...fadeUp} transition={{ ...fadeUp.transition, delay: 0.1 }}>
+          <Accordion type="single" collapsible className="w-full">
+            {PRICING_FAQ_ITEMS.map((item, i) => (
+              <AccordionItem
+                key={i}
+                value={`pricing-faq-${i}`}
+                className="rounded-none border-b border-border/55 bg-transparent px-0 last:border-0 data-[state=open]:bg-transparent"
+              >
+                <AccordionTrigger className="py-5 text-left font-serif text-lg text-ink hover:text-terracotta hover:no-underline">
+                  {item.question}
+                </AccordionTrigger>
+                <AccordionContent className="pb-5 text-[17px] font-sans leading-relaxed text-muted max-w-[92%]">
+                  {item.answer}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </motion.div>
+      </Container>
+    </section>
+  )
+}
+
+function FinalCta() {
+  return (
+    <section className="relative overflow-hidden py-28">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(ellipse_at_center,rgba(199,91,57,0.10),transparent_55%)]"
+      />
+      <Container size="md">
+        <motion.div {...fadeUp} className="text-center">
+          <h2 className="mx-auto max-w-2xl font-serif text-4xl font-normal leading-tight text-ink text-balance md:text-5xl">
+            Local-first is free.{' '}
+            <span className="italic text-terracotta">Sync when you need it.</span>
+          </h2>
+          <p className="mx-auto mt-5 max-w-xl text-lg text-muted leading-relaxed">
+            Start in the free local app. Upgrade the day you want your notes on a second device —
+            not a moment sooner.
+          </p>
+
+          <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Button size="lg" className="rounded-full px-8" asChild>
+              <Link to="/#waitlist">
+                Join the waitlist
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button
+              size="lg"
+              variant="ghost"
+              className="rounded-full px-8 text-ink hover:bg-paper-alt"
+              asChild
+            >
+              <Link to="/security">
+                Read the security architecture
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+        </motion.div>
+      </Container>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- Adds the `/pricing` marketing surface for the paid-sync rollout described in `docs/superpowers/specs/2026-05-09-paid-sync-design.md`. UI only — CTAs deep-link to the existing waitlist; Paddle checkout integration ships later in the spec's Phase 5/6.
- New editorial hero with a monthly/annual cadence toggle that swaps Sync Standard / Sync Plus prices in place; Believer ($500 lifetime) stays fixed.
- Three differentiated tier cards (Standard / Plus / Believer), each with a per-card 4-cell limit grid (vaults, storage, per-file, history). Plus card carries the "Most popular" ribbon; Believer is rendered in a zone-dark card with a "Founding supporter" ribbon to anchor the founding-customer narrative.
- Lifecycle timeline visualizing the 0/14/30/44/90-day lapse policy + a 46-day recovery-window callout, a full plan-limit comparison matrix, a billing-specific FAQ, and a final CTA.
- `Pricing` link added to header `NAV_LINKS` and footer product column; `/pricing` `PAGE_META` added for SEO; route registered in both `App.tsx` and `entry-server.tsx` so the page prerenders into `dist/pricing/index.html`.

## Files
- `apps/landing/src/pages/Pricing.tsx` — full rewrite (hero, toggle, tier grid, narrative, lifecycle, matrix, FAQ, CTA)
- `apps/landing/src/lib/constants.ts` — adds `SYNC_PLAN_TIERS`, `PLAN_LIMIT_MATRIX`, `LIFECYCLE_STAGES`, `PRICING_FAQ_ITEMS`; updates `NAV_LINKS` and `FOOTER_LINKS`
- `apps/landing/src/lib/seo.ts` — adds `pricing` entry in `PAGE_META`
- `apps/landing/src/App.tsx`, `apps/landing/src/entry-server.tsx` — `/pricing` route + prerender map

## Notes
- Existing `PRICING_TIERS` constant left untouched (still consumed by the unused homepage `sections/Pricing.tsx`); deliberate to keep this PR surgical.
- Defaults to **annual** cadence so the cheaper monthly-equivalent prices ($4 / $8) anchor first.
- All four spec limits (vaults, storage, file size, version history) appear on every tier card and again in the comparison matrix; numbers come straight from the spec, no asterisks.

## Test plan
- [x] `pnpm --filter @memry/landing typecheck` — clean
- [x] `pnpm --filter @memry/landing lint` — clean
- [x] Visual QA at 1440px and 390px — hero, all three cards, narrative, lifecycle, matrix, FAQ, footer all render correctly
- [x] Cadence toggle swaps Standard $4↔$5 and Plus $8↔$10 without affecting Believer
- [ ] CI build passes (`pnpm build` runs typecheck + Vite + prerender of all routes)
- [ ] Reviewer eyes the Believer narrative copy and the founder pull-quote