### PR TITLE
feat(landing): add Terms, Privacy, and Refund pages with footer Resources column

### DIFF
--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -8,6 +8,9 @@ import { FeaturesPage } from '@/pages/Features'
 import { UseCasesPage } from '@/pages/UseCases'
 import { SecurityPage } from '@/pages/Security'
 import { PricingPage } from '@/pages/Pricing'
+import { TermsPage } from '@/pages/Terms'
+import { PrivacyPage } from '@/pages/Privacy'
+import { RefundPage } from '@/pages/Refund'
 import { NotFound } from '@/pages/NotFound'
 
 function ScrollToHash() {
@@ -47,6 +50,9 @@ function AppContent() {
           <Route path="/use-cases" element={<UseCasesPage />} />
           <Route path="/security" element={<SecurityPage />} />
           <Route path="/pricing" element={<PricingPage />} />
+          <Route path="/terms" element={<TermsPage />} />
+          <Route path="/privacy" element={<PrivacyPage />} />
+          <Route path="/refund" element={<RefundPage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </main>

--- a/apps/landing/src/components/layout/Footer.tsx
+++ b/apps/landing/src/components/layout/Footer.tsx
@@ -14,8 +14,8 @@ export function Footer() {
   return (
     <footer className="border-t border-border bg-paper py-20">
       <Container>
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-10 mb-16">
-          <div className="md:col-span-2 pr-8">
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-10 mb-16">
+          <div className="col-span-2 md:col-span-2 pe-8">
             <Link to="/" className="inline-block mb-6 group">
               <span className="font-serif text-3xl font-medium text-ink group-hover:text-terracotta transition-colors">
                 Memry.
@@ -33,6 +33,22 @@ export function Footer() {
                 <li key={link.label}>
                   <Link
                     to={footerHref(link.href, pathname)}
+                    className="text-sm text-muted hover:text-terracotta transition-colors font-medium"
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h4 className="font-serif text-lg text-ink mb-6">Resources</h4>
+            <ul className="space-y-4">
+              {FOOTER_LINKS.resources.map((link) => (
+                <li key={link.label}>
+                  <Link
+                    to={link.href}
                     className="text-sm text-muted hover:text-terracotta transition-colors font-medium"
                   >
                     {link.label}

--- a/apps/landing/src/components/shared/LegalLayout.tsx
+++ b/apps/landing/src/components/shared/LegalLayout.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from 'react'
+import { motion } from 'framer-motion'
+import { Container } from '@/components/layout/Container'
+
+interface LegalLayoutProps {
+  eyebrow: string
+  title: string
+  intro: string
+  lastUpdated: string
+  children: ReactNode
+}
+
+const EASE_OUT_EXPO = [0.16, 1, 0.3, 1] as const
+
+export function LegalLayout({ eyebrow, title, intro, lastUpdated, children }: LegalLayoutProps) {
+  return (
+    <main>
+      <section className="relative overflow-hidden pt-32 pb-12 sm:pt-40 sm:pb-16">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[360px] bg-[radial-gradient(ellipse_at_top,rgba(199,91,57,0.08),transparent_60%)]"
+        />
+        <Container size="sm">
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, ease: EASE_OUT_EXPO }}
+            className="text-center"
+          >
+            <p className="font-mono-accent text-[11px] uppercase tracking-[0.32em] text-terracotta">
+              {eyebrow}
+            </p>
+            <h1 className="mt-5 font-serif text-4xl font-normal leading-[1.05] text-ink text-balance md:text-6xl">
+              {title}
+            </h1>
+            <p className="mx-auto mt-6 max-w-xl text-lg leading-relaxed text-muted text-balance">
+              {intro}
+            </p>
+            <p className="mt-8 font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted/70">
+              Last updated · {lastUpdated}
+            </p>
+          </motion.div>
+        </Container>
+      </section>
+
+      <section className="pb-28">
+        <Container size="sm">
+          <motion.article
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.1, ease: EASE_OUT_EXPO }}
+            className="legal-prose"
+          >
+            {children}
+          </motion.article>
+        </Container>
+      </section>
+    </main>
+  )
+}

--- a/apps/landing/src/entry-server.tsx
+++ b/apps/landing/src/entry-server.tsx
@@ -9,13 +9,19 @@ import { FeaturesPage } from '@/pages/Features'
 import { UseCasesPage } from '@/pages/UseCases'
 import { SecurityPage } from '@/pages/Security'
 import { PricingPage } from '@/pages/Pricing'
+import { TermsPage } from '@/pages/Terms'
+import { PrivacyPage } from '@/pages/Privacy'
+import { RefundPage } from '@/pages/Refund'
 
 const ROUTE_MAP: Record<string, () => ReactNode> = {
   '/': () => <Home />,
   '/features': () => <FeaturesPage />,
   '/use-cases': () => <UseCasesPage />,
   '/security': () => <SecurityPage />,
-  '/pricing': () => <PricingPage />
+  '/pricing': () => <PricingPage />,
+  '/terms': () => <TermsPage />,
+  '/privacy': () => <PrivacyPage />,
+  '/refund': () => <RefundPage />
 }
 
 export function render(url: string): { html: string; helmet: HelmetServerState | null } {

--- a/apps/landing/src/index.css
+++ b/apps/landing/src/index.css
@@ -253,6 +253,78 @@ h6 {
   display: none;
 }
 
+/* Legal pages typography */
+.legal-prose {
+  color: var(--color-ink);
+  font-size: 1.0625rem;
+  line-height: 1.75;
+}
+
+.legal-prose h2 {
+  font-family: var(--font-serif);
+  font-size: 1.875rem;
+  line-height: 1.2;
+  color: var(--color-ink);
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  scroll-margin-top: 6rem;
+}
+
+.legal-prose h2:first-child {
+  margin-top: 0;
+}
+
+.legal-prose h3 {
+  font-family: var(--font-serif);
+  font-size: 1.375rem;
+  line-height: 1.3;
+  color: var(--color-ink);
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.legal-prose p {
+  color: var(--color-muted);
+  margin-bottom: 1.25rem;
+}
+
+.legal-prose ul {
+  list-style: disc;
+  padding-inline-start: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.legal-prose ul li {
+  color: var(--color-muted);
+  margin-bottom: 0.5rem;
+}
+
+.legal-prose ul li::marker {
+  color: var(--color-terracotta);
+}
+
+.legal-prose strong {
+  color: var(--color-ink);
+  font-weight: 500;
+}
+
+.legal-prose a {
+  color: var(--color-terracotta);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: color 0.2s;
+}
+
+.legal-prose a:hover {
+  color: var(--color-terracotta-dark);
+}
+
+.legal-prose hr {
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin: 2.5rem 0;
+}
+
 /* Sticky scroll container */
 .sticky-feature-image {
   position: sticky;

--- a/apps/landing/src/lib/constants.ts
+++ b/apps/landing/src/lib/constants.ts
@@ -34,6 +34,11 @@ export const FOOTER_LINKS = {
     { label: 'Pricing', href: '/pricing' },
     { label: 'Security', href: '/security' }
   ],
+  resources: [
+    { label: 'Terms of Service', href: '/terms' },
+    { label: 'Privacy Policy', href: '/privacy' },
+    { label: 'Refund Policy', href: '/refund' }
+  ],
   social: [
     { label: 'Reddit', href: 'https://www.reddit.com/r/MemryNote/' },
     { label: 'Twitter', href: 'https://x.com/h4yfans' },

--- a/apps/landing/src/lib/seo.ts
+++ b/apps/landing/src/lib/seo.ts
@@ -44,6 +44,24 @@ export const PAGE_META: Record<string, PageMeta> = {
     description:
       'Local-first stays free, forever. Sync is paid, fair, and end-to-end encrypted. Standard from $4/mo, Plus from $8/mo, or Believer for a one-time $500.',
     path: '/pricing'
+  },
+  terms: {
+    title: 'Terms of Service — Memry',
+    description:
+      'The agreement between you and Memry when you use the local app and Sync service. Plain-English terms covering accounts, billing, lapse policy, and acceptable use.',
+    path: '/terms'
+  },
+  privacy: {
+    title: 'Privacy Policy — Memry',
+    description:
+      'How Memry handles your data. The local app collects nothing. Sync uploads only ciphertext encrypted on your device. Keys never touch our servers.',
+    path: '/privacy'
+  },
+  refund: {
+    title: 'Refund Policy — Memry',
+    description:
+      'Seven-day money-back guarantee on every paid Sync plan, including Believer. Requests processed through Paddle, refunded to your original payment method.',
+    path: '/refund'
   }
 }
 

--- a/apps/landing/src/pages/Privacy.tsx
+++ b/apps/landing/src/pages/Privacy.tsx
@@ -1,0 +1,208 @@
+import { LegalLayout } from '@/components/shared/LegalLayout'
+import { PageHead } from '@/components/shared/PageHead'
+
+export function PrivacyPage() {
+  return (
+    <>
+      <PageHead page="privacy" />
+      <LegalLayout
+        eyebrow="Legal · Privacy"
+        title="Privacy Policy"
+        intro="Memry is built on a simple promise: your notes belong to you, and we cannot read them."
+        lastUpdated="May 9, 2026"
+      >
+        <h2>Summary in 30 seconds</h2>
+        <ul>
+          <li>The local app stores everything on your device. We never see it.</li>
+          <li>
+            Sync uploads only ciphertext. Every byte is encrypted on your device with
+            XChaCha20-Poly1305 before it leaves.
+          </li>
+          <li>Encryption keys live in your password manager and never touch our servers.</li>
+          <li>We collect the minimum metadata needed to bill, deliver, and secure the service.</li>
+          <li>We never sell your data. We have nothing to sell.</li>
+        </ul>
+
+        <h2>1. What this policy covers</h2>
+        <p>
+          This policy describes how Memry handles personal data in the desktop app, the marketing
+          website, and the optional Sync service. It applies to everyone who uses Memry, regardless
+          of country.
+        </p>
+
+        <h2>2. The local app collects nothing</h2>
+        <p>
+          The Memry desktop application runs entirely on your computer. Your notes, tasks, journal,
+          and files are stored as plain Markdown files in a vault folder you choose. None of that
+          content is sent to us, period.
+        </p>
+        <p>
+          We do not include analytics, telemetry, or crash reporting that transmits your content.
+          Optional update checks contact our update server, which sees only your IP address and app
+          version.
+        </p>
+
+        <h2>3. What Sync sends to our servers</h2>
+        <p>If you opt into the paid Sync service, the following is uploaded:</p>
+        <ul>
+          <li>
+            <strong>Encrypted blobs.</strong> Notes, tasks, journals, attachments, and metadata, all
+            encrypted on your device before upload. We hold ciphertext only.
+          </li>
+          <li>
+            <strong>Routing metadata.</strong> Vault IDs, blob keys, content hashes, byte counts,
+            and timestamps. These are needed to route updates to your other devices and to count
+            usage against your plan.
+          </li>
+          <li>
+            <strong>Account identifiers.</strong> Your email address, a hashed password, and
+            verification tokens.
+          </li>
+        </ul>
+        <p>
+          We do not receive plaintext titles, plaintext tags, or any contents of your vault. The
+          server&apos;s view of your notes is a stream of opaque encrypted bytes.
+        </p>
+
+        <h2>4. What the website collects</h2>
+        <p>
+          Memrynote.com uses minimal, privacy-respecting analytics to understand how people find the
+          site and which pages are useful. We do not use third-party advertising trackers and do not
+          sell visitor data.
+        </p>
+        <p>
+          If you join the waitlist or contact us, we store the email address you submit so we can
+          reply or send the messages you opted into.
+        </p>
+
+        <h2>5. How we use the data we have</h2>
+        <p>We use the data described above only to:</p>
+        <ul>
+          <li>Operate, sync, and secure your account.</li>
+          <li>Bill you, through Paddle, for the plan you chose.</li>
+          <li>
+            Send transactional email (sign-up confirmation, payment receipts, security notices).
+          </li>
+          <li>Investigate abuse, debug crashes, and improve product quality.</li>
+          <li>Comply with legal obligations.</li>
+        </ul>
+        <p>
+          We do not use your data to train models, build advertising profiles, or sell anything to
+          anyone.
+        </p>
+
+        <h2>6. Encryption details</h2>
+        <p>
+          Memry uses end-to-end encryption based on the libsodium primitives: XChaCha20-Poly1305 for
+          content, Ed25519 for signatures, and Argon2id for password-based key derivation. Your
+          master key is derived from your password on your device and is never sent to us.
+        </p>
+        <p>
+          Because we never hold your keys, we cannot decrypt your data. We cannot reset it for you,
+          and we cannot disclose its contents in response to a subpoena — we have no way to read it
+          ourselves.
+        </p>
+
+        <h2>7. Sub-processors</h2>
+        <p>
+          We use a small set of third-party services to operate Memry. Each is contractually bound
+          to handle your data only for the purpose listed:
+        </p>
+        <ul>
+          <li>
+            <strong>Cloudflare</strong> — hosts the Sync API, stores encrypted blobs in R2, and runs
+            the marketing website&apos;s edge.
+          </li>
+          <li>
+            <strong>Paddle</strong> — merchant of record for payments. Receives billing details
+            (name, billing address, payment method).
+          </li>
+          <li>
+            <strong>Postmark or a similar transactional email provider</strong> — delivers sign-up,
+            billing, and security emails.
+          </li>
+        </ul>
+        <p>
+          We do not share data with advertising networks, data brokers, or social media platforms.
+        </p>
+
+        <h2>8. International transfers</h2>
+        <p>
+          Memry is a small indie operation. Our infrastructure is global by default — encrypted
+          blobs may be served from data centers near you for performance. Where personal data
+          crosses borders, we rely on standard contractual clauses with our sub-processors.
+        </p>
+
+        <h2>9. How long we keep things</h2>
+        <ul>
+          <li>
+            <strong>Encrypted blobs:</strong> kept while your subscription is active. After a lapse,
+            kept in read-only mode for 30 days, then in cold storage until day 90, then physically
+            deleted.
+          </li>
+          <li>
+            <strong>Account record:</strong> kept while your account exists. If you delete your
+            account, the record and any remaining blobs are removed within 30 days.
+          </li>
+          <li>
+            <strong>Billing records:</strong> retained as required by tax law in your country
+            (typically 7 years).
+          </li>
+          <li>
+            <strong>Server logs:</strong> retained for up to 30 days for security and debugging.
+          </li>
+        </ul>
+
+        <h2>10. Your rights</h2>
+        <p>
+          Depending on where you live (GDPR, UK GDPR, CCPA, and similar laws), you have the right
+          to:
+        </p>
+        <ul>
+          <li>Access the personal data we hold about you.</li>
+          <li>Correct inaccurate data.</li>
+          <li>Delete your account and associated data.</li>
+          <li>Export the metadata we hold about your account.</li>
+          <li>Object to processing or restrict it in specific cases.</li>
+        </ul>
+        <p>
+          To exercise any of these rights, email{' '}
+          <a href="mailto:privacy@memrynote.com">privacy@memrynote.com</a> from the address tied to
+          your account. We respond within 30 days.
+        </p>
+        <p>
+          You can also lodge a complaint with your local data protection authority. We would rather
+          hear from you first, but you do not have to.
+        </p>
+
+        <h2>11. Children</h2>
+        <p>
+          Memry is not designed for children under 13 (or under 16 in jurisdictions that require
+          it). We do not knowingly collect data from children. If you believe a child has signed up,
+          email <a href="mailto:privacy@memrynote.com">privacy@memrynote.com</a> and we will delete
+          the account.
+        </p>
+
+        <h2>12. Security incidents</h2>
+        <p>
+          If we discover an incident that affects your data, we will notify you within 72 hours of
+          confirming the impact. Because content is end-to-end encrypted, the most likely incident
+          types are metadata exposure, billing data exposure, or account-takeover attempts — we will
+          tell you exactly what was affected.
+        </p>
+
+        <h2>13. Changes to this policy</h2>
+        <p>
+          We will update this page when our practices change. Material changes will be announced in
+          the app and via email at least 14 days before they take effect.
+        </p>
+
+        <h2>14. Contact</h2>
+        <p>
+          Privacy questions: <a href="mailto:privacy@memrynote.com">privacy@memrynote.com</a>.
+          Anything else: <a href="mailto:hi@memrynote.com">hi@memrynote.com</a>.
+        </p>
+      </LegalLayout>
+    </>
+  )
+}

--- a/apps/landing/src/pages/Privacy.tsx
+++ b/apps/landing/src/pages/Privacy.tsx
@@ -13,12 +13,17 @@ export function PrivacyPage() {
       >
         <h2>Summary in 30 seconds</h2>
         <ul>
-          <li>The local app stores everything on your device. We never see it.</li>
+          <li>Your notes, tasks, and journal stay on your device. We never see their content.</li>
           <li>
             Sync uploads only ciphertext. Every byte is encrypted on your device with
             XChaCha20-Poly1305 before it leaves.
           </li>
           <li>Encryption keys live in your password manager and never touch our servers.</li>
+          <li>
+            Anonymous usage metrics are optional, on by default, and switchable from Settings →
+            Privacy. They never include note content, search queries, file paths, emails, or raw
+            IDs.
+          </li>
           <li>We collect the minimum metadata needed to bill, deliver, and secure the service.</li>
           <li>We never sell your data. We have nothing to sell.</li>
         </ul>
@@ -30,19 +35,60 @@ export function PrivacyPage() {
           of country.
         </p>
 
-        <h2>2. The local app collects nothing</h2>
+        <h2>2. The local app keeps your content on your device</h2>
         <p>
           The Memry desktop application runs entirely on your computer. Your notes, tasks, journal,
           and files are stored as plain Markdown files in a vault folder you choose. None of that
           content is sent to us, period.
         </p>
         <p>
-          We do not include analytics, telemetry, or crash reporting that transmits your content.
           Optional update checks contact our update server, which sees only your IP address and app
           version.
         </p>
 
-        <h2>3. What Sync sends to our servers</h2>
+        <h2>3. Optional anonymous usage metrics</h2>
+        <p>
+          Memry includes an optional, anonymous telemetry stream so we can understand which features
+          get used, where the app crashes, and where it slows down. You can turn it off at any time
+          in <strong>Settings → Privacy → Share Anonymous Usage Metrics</strong>. It is on by
+          default in production builds and off in development builds.
+        </p>
+        <p>
+          Each event is one row from a fixed list — for example <em>app_started</em>,{' '}
+          <em>note_created</em>, <em>search_performed</em>, <em>sync_run_completed</em>,{' '}
+          <em>app_error_seen</em>. We do not capture free-form strings. The schema rejects any
+          dimension that looks like an email address, URL, file path, or raw identifier before the
+          event ever leaves your device.
+        </p>
+        <p>Each event ships with:</p>
+        <ul>
+          <li>The event name and a short action label (both from a fixed enum).</li>
+          <li>
+            An anonymous install ID and session ID. The install ID is a random UUID generated on
+            your device — it is not derived from your hardware, account, or any personal data.
+          </li>
+          <li>
+            App version, release channel, OS platform, CPU architecture, locale, and your timezone
+            offset.
+          </li>
+          <li>Whether you are signed in to Sync (yes/no/unknown) and whether Sync is enabled.</li>
+          <li>
+            Optional numeric metrics for the action — duration, item count, byte count, retry count.
+          </li>
+        </ul>
+        <p>
+          Events are batched in memory and uploaded to{' '}
+          <code>sync.memrynote.com/telemetry/batch</code> at most every 30 seconds. We never log
+          your IP address against your telemetry stream beyond the standard edge access logs that
+          every web server keeps for a short window.
+        </p>
+        <p>
+          Crash reporting is part of the same stream. We see that an error happened, on which
+          surface, and an error code from a fixed list — never a stack trace that could contain your
+          data.
+        </p>
+
+        <h2>4. What Sync sends to our servers</h2>
         <p>If you opt into the paid Sync service, the following is uploaded:</p>
         <ul>
           <li>
@@ -64,7 +110,7 @@ export function PrivacyPage() {
           server&apos;s view of your notes is a stream of opaque encrypted bytes.
         </p>
 
-        <h2>4. What the website collects</h2>
+        <h2>5. What the website collects</h2>
         <p>
           Memrynote.com uses minimal, privacy-respecting analytics to understand how people find the
           site and which pages are useful. We do not use third-party advertising trackers and do not
@@ -75,7 +121,7 @@ export function PrivacyPage() {
           reply or send the messages you opted into.
         </p>
 
-        <h2>5. How we use the data we have</h2>
+        <h2>6. How we use the data we have</h2>
         <p>We use the data described above only to:</p>
         <ul>
           <li>Operate, sync, and secure your account.</li>
@@ -83,15 +129,18 @@ export function PrivacyPage() {
           <li>
             Send transactional email (sign-up confirmation, payment receipts, security notices).
           </li>
-          <li>Investigate abuse, debug crashes, and improve product quality.</li>
-          <li>Comply with legal obligations.</li>
+          <li>
+            Understand which features get used and where the app crashes (if you have left anonymous
+            usage metrics on).
+          </li>
+          <li>Investigate abuse and comply with legal obligations.</li>
         </ul>
         <p>
           We do not use your data to train models, build advertising profiles, or sell anything to
           anyone.
         </p>
 
-        <h2>6. Encryption details</h2>
+        <h2>7. Encryption details</h2>
         <p>
           Memry uses end-to-end encryption based on the libsodium primitives: XChaCha20-Poly1305 for
           content, Ed25519 for signatures, and Argon2id for password-based key derivation. Your
@@ -103,7 +152,7 @@ export function PrivacyPage() {
           ourselves.
         </p>
 
-        <h2>7. Sub-processors</h2>
+        <h2>8. Sub-processors</h2>
         <p>
           We use a small set of third-party services to operate Memry. Each is contractually bound
           to handle your data only for the purpose listed:
@@ -126,14 +175,14 @@ export function PrivacyPage() {
           We do not share data with advertising networks, data brokers, or social media platforms.
         </p>
 
-        <h2>8. International transfers</h2>
+        <h2>9. International transfers</h2>
         <p>
           Memry is a small indie operation. Our infrastructure is global by default — encrypted
           blobs may be served from data centers near you for performance. Where personal data
           crosses borders, we rely on standard contractual clauses with our sub-processors.
         </p>
 
-        <h2>9. How long we keep things</h2>
+        <h2>10. How long we keep things</h2>
         <ul>
           <li>
             <strong>Encrypted blobs:</strong> kept while your subscription is active. After a lapse,
@@ -149,11 +198,15 @@ export function PrivacyPage() {
             (typically 7 years).
           </li>
           <li>
+            <strong>Anonymous usage metrics:</strong> aggregated and retained for up to 24 months,
+            then deleted. There is no way to tie an event back to a person.
+          </li>
+          <li>
             <strong>Server logs:</strong> retained for up to 30 days for security and debugging.
           </li>
         </ul>
 
-        <h2>10. Your rights</h2>
+        <h2>11. Your rights</h2>
         <p>
           Depending on where you live (GDPR, UK GDPR, CCPA, and similar laws), you have the right
           to:
@@ -175,7 +228,7 @@ export function PrivacyPage() {
           hear from you first, but you do not have to.
         </p>
 
-        <h2>11. Children</h2>
+        <h2>12. Children</h2>
         <p>
           Memry is not designed for children under 13 (or under 16 in jurisdictions that require
           it). We do not knowingly collect data from children. If you believe a child has signed up,
@@ -183,7 +236,7 @@ export function PrivacyPage() {
           the account.
         </p>
 
-        <h2>12. Security incidents</h2>
+        <h2>13. Security incidents</h2>
         <p>
           If we discover an incident that affects your data, we will notify you within 72 hours of
           confirming the impact. Because content is end-to-end encrypted, the most likely incident
@@ -191,13 +244,13 @@ export function PrivacyPage() {
           tell you exactly what was affected.
         </p>
 
-        <h2>13. Changes to this policy</h2>
+        <h2>14. Changes to this policy</h2>
         <p>
           We will update this page when our practices change. Material changes will be announced in
           the app and via email at least 14 days before they take effect.
         </p>
 
-        <h2>14. Contact</h2>
+        <h2>15. Contact</h2>
         <p>
           Privacy questions: <a href="mailto:privacy@memrynote.com">privacy@memrynote.com</a>.
           Anything else: <a href="mailto:hi@memrynote.com">hi@memrynote.com</a>.

--- a/apps/landing/src/pages/Refund.tsx
+++ b/apps/landing/src/pages/Refund.tsx
@@ -1,0 +1,155 @@
+import { LegalLayout } from '@/components/shared/LegalLayout'
+import { PageHead } from '@/components/shared/PageHead'
+
+export function RefundPage() {
+  return (
+    <>
+      <PageHead page="refund" />
+      <LegalLayout
+        eyebrow="Legal · Refunds"
+        title="Refund Policy"
+        intro="Seven days to change your mind on any paid plan, including Believer. No questions asked."
+        lastUpdated="May 9, 2026"
+      >
+        <h2>The short version</h2>
+        <ul>
+          <li>
+            <strong>7-day money-back guarantee</strong> on every Sync plan — Standard, Plus, and
+            Believer.
+          </li>
+          <li>
+            Request a refund inside the app or email{' '}
+            <a href="mailto:billing@memrynote.com">billing@memrynote.com</a> from the account
+            address.
+          </li>
+          <li>
+            Paddle, our merchant of record, returns the money to your original payment method.
+          </li>
+          <li>
+            After day 7 we honour refunds case-by-case for genuine billing problems and duplicate
+            charges.
+          </li>
+        </ul>
+
+        <h2>1. The 7-day guarantee</h2>
+        <p>
+          Every paid plan comes with a 7-day money-back guarantee, counted from the moment you first
+          complete a paid checkout. If Memry isn&apos;t for you in that window, ask for a refund and
+          we will issue it without questions.
+        </p>
+        <p>
+          The guarantee covers your first paid period only. Renewals (the second month, the second
+          year, and so on) are not eligible — see the section on renewals below.
+        </p>
+
+        <h2>2. Believer (lifetime) refunds</h2>
+        <p>
+          The Believer tier — a one-time payment for lifetime Sync Plus — is also covered by the
+          7-day guarantee. If you change your mind in the first week, ask for a refund and we will
+          process it the same way as any other plan.
+        </p>
+        <p>
+          After day 7, Believer is non-refundable. The whole point of the tier is a long-term bet in
+          both directions: you commit to us, we commit to you, and the price funds the next chapter
+          of the product.
+        </p>
+
+        <h2>3. How to request a refund</h2>
+        <p>You have two equivalent paths:</p>
+        <ul>
+          <li>
+            <strong>Inside the app:</strong> Settings → Billing → Request a refund. The button opens
+            a Paddle-hosted form. We get a copy automatically.
+          </li>
+          <li>
+            <strong>Email:</strong> send a message from the address on your account to{' '}
+            <a href="mailto:billing@memrynote.com">billing@memrynote.com</a> with the subject
+            &ldquo;Refund request.&rdquo; Mention which plan you bought and we will take it from
+            there.
+          </li>
+        </ul>
+        <p>
+          You do not need to explain why. We may ask for short feedback so we can make the product
+          better, but answering is always optional.
+        </p>
+
+        <h2>4. How long it takes</h2>
+        <ul>
+          <li>
+            <strong>We process the request</strong> within two business days of receiving it.
+          </li>
+          <li>
+            <strong>Paddle issues the refund</strong> back to your original payment method within
+            5–10 business days, depending on your bank or card network.
+          </li>
+          <li>
+            <strong>Sync access ends</strong> as soon as the refund is processed. Your local app and
+            vault remain yours; the lapse policy then applies as if the subscription had ended.
+          </li>
+        </ul>
+
+        <h2>5. Renewals</h2>
+        <p>
+          We do not refund renewal charges by default — you have unlimited time to cancel before the
+          next renewal hits. We send a reminder email seven days before each annual renewal so there
+          are no surprise charges.
+        </p>
+        <p>
+          If a renewal slipped through and you genuinely had not used Sync during the new period,
+          email us within 14 days of the charge and we will issue a one-time goodwill refund. We
+          look at usage rather than the calendar — the goal is to be fair.
+        </p>
+
+        <h2>6. Plan changes</h2>
+        <ul>
+          <li>
+            <strong>Upgrades</strong> are pro-rated immediately. You pay only the difference for the
+            remainder of the current period.
+          </li>
+          <li>
+            <strong>Downgrades</strong> take effect at the end of the current billing period.
+            Existing data above the new tier&apos;s limits stays readable while you decide what to
+            archive.
+          </li>
+        </ul>
+
+        <h2>7. Refunds we cannot give</h2>
+        <p>We will decline a refund if:</p>
+        <ul>
+          <li>
+            The 7-day window has closed and the charge in question is not a duplicate, fraudulent,
+            or otherwise erroneous transaction.
+          </li>
+          <li>
+            The account has been suspended for violating the <a href="/terms">Terms of Service</a>,
+            especially around abuse or attempted fraud.
+          </li>
+          <li>
+            The request comes from someone other than the account owner. Refunds go back to the card
+            or wallet that paid.
+          </li>
+        </ul>
+
+        <h2>8. Statutory rights</h2>
+        <p>
+          Nothing in this policy reduces the legal rights you have where you live. If the law in
+          your country gives you a longer cooling-off period or stronger consumer protections, those
+          win — tell us in your refund request and we will follow them.
+        </p>
+
+        <h2>9. Chargebacks</h2>
+        <p>
+          Please reach out before filing a chargeback with your bank. We have never said no to a
+          good-faith refund request, and a direct conversation is faster than a dispute. Accounts
+          with active chargebacks are paused while Paddle investigates.
+        </p>
+
+        <h2>10. Contact</h2>
+        <p>
+          Billing questions: <a href="mailto:billing@memrynote.com">billing@memrynote.com</a>.
+          Everything else: <a href="mailto:hi@memrynote.com">hi@memrynote.com</a>.
+        </p>
+      </LegalLayout>
+    </>
+  )
+}

--- a/apps/landing/src/pages/Terms.tsx
+++ b/apps/landing/src/pages/Terms.tsx
@@ -1,0 +1,199 @@
+import { LegalLayout } from '@/components/shared/LegalLayout'
+import { PageHead } from '@/components/shared/PageHead'
+
+export function TermsPage() {
+  return (
+    <>
+      <PageHead page="terms" />
+      <LegalLayout
+        eyebrow="Legal · Terms"
+        title="Terms of Service"
+        intro="The agreement between you and Memry when you use our local app and Sync service."
+        lastUpdated="May 9, 2026"
+      >
+        <h2>1. Who we are</h2>
+        <p>
+          Memry (&ldquo;Memry,&rdquo; &ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;) is
+          an indie productivity app made up of a free local-first desktop application and an
+          optional paid Sync service. By downloading the desktop app or signing up for Sync, you
+          agree to these Terms of Service.
+        </p>
+        <p>
+          If you do not agree, do not use the service. These Terms form a binding contract between
+          you and the operators of Memry.
+        </p>
+
+        <h2>2. The local app</h2>
+        <p>
+          The Memry desktop app is free to download and use, with no account required. Your data
+          stays on your device as plain Markdown files in a vault folder you choose. We do not
+          monitor, collect, or transmit the contents of your vault.
+        </p>
+        <p>
+          You may use the local app for personal or commercial purposes. You may not redistribute,
+          resell, or rebrand the app without written permission.
+        </p>
+
+        <h2>3. The Sync service</h2>
+        <p>
+          Sync is a paid, optional service that copies the encrypted contents of your vault between
+          your devices. You retain full ownership of everything you sync. We hold encrypted blobs on
+          your behalf and provide the infrastructure to move them between your devices.
+        </p>
+        <p>
+          By creating a Sync account you confirm that you are at least 13 years old (or the age of
+          digital consent in your country) and that the contact information you provide is accurate.
+        </p>
+
+        <h3>What we provide</h3>
+        <ul>
+          <li>End-to-end encrypted storage of your vault, scoped to the limits of your plan.</li>
+          <li>API and client software to push and pull encrypted updates between your devices.</li>
+          <li>Reasonable-effort uptime, backups of encrypted blobs, and security updates.</li>
+        </ul>
+
+        <h3>What we do not provide</h3>
+        <ul>
+          <li>
+            Access to the plaintext of your data. Encryption keys never leave your devices, so we
+            cannot recover or reset them.
+          </li>
+          <li>
+            Guaranteed uptime, real-time response, or specific recovery times. Sync is sold as-is.
+          </li>
+        </ul>
+
+        <h2>4. Your account</h2>
+        <p>
+          You are responsible for keeping your password, recovery key, and any device unlock codes
+          safe. If you lose them, we cannot recover your data — that is the trade-off for end-to-end
+          encryption.
+        </p>
+        <p>
+          You agree not to share your account, attempt to circumvent plan limits, or use Sync to
+          store data on behalf of users who do not have their own account with us.
+        </p>
+
+        <h2>5. Acceptable use</h2>
+        <p>You agree not to use Memry to:</p>
+        <ul>
+          <li>Store, distribute, or sync content that is illegal where you live.</li>
+          <li>
+            Distribute malware, spyware, or content designed to harm other people&apos;s devices.
+          </li>
+          <li>
+            Run automated tooling that materially degrades the service for other users (excessive
+            request volume, exploiting endpoints outside their documented purpose).
+          </li>
+          <li>
+            Reverse-engineer the Sync service to discover keys, decrypt other users&apos; data, or
+            impersonate other accounts.
+          </li>
+        </ul>
+        <p>
+          We may suspend accounts that violate these rules. Because we cannot read your data, any
+          such action is based on metadata, billing signals, or external reports.
+        </p>
+
+        <h2>6. Billing</h2>
+        <p>
+          Sync is billed through Paddle, our merchant of record. Paddle handles payment processing,
+          VAT, GST, and US sales tax in your country. The price you see at checkout is the price you
+          pay.
+        </p>
+        <p>
+          Plans renew automatically at the end of each billing period until you cancel. You can
+          cancel at any time inside the app — your plan stays active until the end of the period you
+          have already paid for.
+        </p>
+
+        <h2>7. What happens if billing lapses</h2>
+        <p>
+          If your card fails or you cancel, Sync follows a predictable lapse policy designed to give
+          you time to recover without losing data:
+        </p>
+        <ul>
+          <li>
+            <strong>Days 0–14 (Grace):</strong> Sync keeps working while you fix the card or change
+            your mind.
+          </li>
+          <li>
+            <strong>Days 14–44 (Read-only):</strong> Pulls keep working, pushes are blocked. Pull
+            everything to local at your pace.
+          </li>
+          <li>
+            <strong>Day 44 (Purged status):</strong> The server returns 402 Payment Required on
+            every request. Encrypted blobs sit untouched.
+          </li>
+          <li>
+            <strong>Day 90 (Blob deletion):</strong> Encrypted blobs are physically removed.
+            Recovery from our side ends here.
+          </li>
+        </ul>
+
+        <h2>8. Refunds</h2>
+        <p>
+          We offer a 7-day money-back guarantee on every plan, including Believer. See the{' '}
+          <a href="/refund">refund policy</a> for the full details on how to request one.
+        </p>
+
+        <h2>9. Pricing changes</h2>
+        <p>
+          We may change pricing for new sign-ups at any time. Existing subscribers keep their
+          current price for at least 12 months from the change. Lifetime Believer pricing applies
+          for the lifetime of the service to anyone who has paid.
+        </p>
+
+        <h2>10. Service changes and termination</h2>
+        <p>
+          Memry is pre-1.0 and evolving quickly. We may add, change, or remove features as the
+          product matures. Material removals to paid features will be announced at least 30 days in
+          advance, and you are welcome to a pro-rated refund of unused time if a removal materially
+          changes your plan.
+        </p>
+        <p>
+          You may stop using Memry at any time. We may terminate or suspend access if you violate
+          these Terms. If we shut Sync down entirely we will give at least 90 days&apos; notice and
+          provide a path to download your encrypted blobs.
+        </p>
+
+        <h2>11. Intellectual property</h2>
+        <p>
+          You own everything you put into Memry. We claim no rights over your notes, journal, tasks,
+          or files. The Memry name, branding, and the source code of the proprietary parts of the
+          service remain ours; open-source components are licensed under their respective licenses.
+        </p>
+
+        <h2>12. Disclaimers</h2>
+        <p>
+          Memry and Sync are provided &ldquo;as is&rdquo; without warranty of any kind. We do our
+          best to keep your encrypted data safe and accessible, but we cannot guarantee
+          uninterrupted service, perfect data integrity, or recovery from every failure mode. You
+          are responsible for keeping your own backups of vaults that matter to you.
+        </p>
+
+        <h2>13. Limitation of liability</h2>
+        <p>
+          To the maximum extent permitted by law, our aggregate liability for any claim arising from
+          your use of Memry is limited to the amount you paid us in the 12 months before the claim,
+          or USD $100 if you are a free user. We are not liable for indirect, consequential, or
+          incidental damages.
+        </p>
+
+        <h2>14. Changes to these Terms</h2>
+        <p>
+          We may update these Terms when the product changes or the law requires it. Material
+          changes will be announced in the app and on this page at least 14 days before they take
+          effect. Continuing to use Memry after that date counts as acceptance.
+        </p>
+
+        <h2>15. Contact</h2>
+        <p>
+          Questions, complaints, or a legal notice? Email{' '}
+          <a href="mailto:hi@memrynote.com">hi@memrynote.com</a>. We aim to reply within five
+          business days.
+        </p>
+      </LegalLayout>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds three legal pages — `/terms`, `/privacy`, `/refund` — built on a shared `LegalLayout` wrapper (hero + prose typography). Content reflects what's already published on `/pricing`: 7-day refund, Paddle merchant of record, lapse-policy timings (14d grace / 44d read-only / 90d blob deletion), XChaCha20-Poly1305 / Ed25519 / Argon2id encryption details.
- Adds a **Resources** column to the site footer linking to all three pages. Footer grid moves to 5 columns on desktop, 2 on mobile, with the brand block spanning two columns.
- Wires the new routes into both the client router (`App.tsx`) and the SSR `ROUTE_MAP` (`entry-server.tsx`) so they prerender.
- Adds `terms`, `privacy`, and `refund` entries to `PAGE_META` in `seo.ts` so each page ships its own title, description, and canonical URL.
- New `.legal-prose` typography rules in `index.css` for `h2`/`h3`/`p`/`ul`/`a` inside legal pages.

> Content is a draft — worth a legal review before going public, since it is policy text, not vetted documents. Support emails (`hi@`, `privacy@`, `billing@memrynote.com`) are placeholders; swap in real addresses if needed.

## Test plan

- [x] `pnpm --filter landing typecheck`
- [x] `pnpm --filter landing lint`
- [x] `pnpm --filter landing build` — all 8 routes prerender, including `/terms`, `/privacy`, `/refund`
- [ ] Visual smoke check: `/terms`, `/privacy`, `/refund` render with hero + prose, last-updated stamp, link styling
- [ ] Footer Resources column visible on desktop and mobile breakpoints, links navigate correctly
- [ ] `view-source:/terms` (and the other two) shows correct `<title>` and canonical