### PR TITLE
feat: add mouse tab history navigation

### DIFF
--- a/apps/desktop/src/main/app-navigation-command.test.ts
+++ b/apps/desktop/src/main/app-navigation-command.test.ts
@@ -1,0 +1,118 @@
+import { AppChannels } from '@memry/contracts/ipc-channels'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  keyboardInputToNavigationCommand,
+  sendAppNavigationCommand,
+  sendAppNavigationKeyboardCommand,
+  sendAppNavigationSwipeCommand,
+  swipeDirectionToNavigationCommand
+} from './app-navigation-command'
+
+describe('sendAppNavigationCommand', () => {
+  it('maps browser-backward app-command to the navigation IPC event', () => {
+    const target = { send: vi.fn() }
+
+    const sent = sendAppNavigationCommand(target, 'browser-backward')
+
+    expect(sent).toBe(true)
+    expect(target.send).toHaveBeenCalledWith(AppChannels.events.NAVIGATION_COMMAND, {
+      direction: 'back'
+    })
+  })
+
+  it('maps browser-forward app-command to the navigation IPC event', () => {
+    const target = { send: vi.fn() }
+
+    const sent = sendAppNavigationCommand(target, 'browser-forward')
+
+    expect(sent).toBe(true)
+    expect(target.send).toHaveBeenCalledWith(AppChannels.events.NAVIGATION_COMMAND, {
+      direction: 'forward'
+    })
+  })
+
+  it('ignores unrelated app-command values', () => {
+    const target = { send: vi.fn() }
+
+    const sent = sendAppNavigationCommand(target, 'browser-refresh')
+
+    expect(sent).toBe(false)
+    expect(target.send).not.toHaveBeenCalled()
+  })
+})
+
+describe('sendAppNavigationKeyboardCommand', () => {
+  it('maps dedicated BrowserBack keyboard input to the navigation IPC event', () => {
+    const target = { send: vi.fn() }
+
+    const sent = sendAppNavigationKeyboardCommand(target, {
+      type: 'keyDown',
+      key: 'BrowserBack'
+    })
+
+    expect(sent).toBe(true)
+    expect(target.send).toHaveBeenCalledWith(AppChannels.events.NAVIGATION_COMMAND, {
+      direction: 'back'
+    })
+  })
+
+  it('maps dedicated BrowserForward keyboard input to the navigation IPC event', () => {
+    const target = { send: vi.fn() }
+
+    const sent = sendAppNavigationKeyboardCommand(target, {
+      type: 'keyDown',
+      key: 'BrowserForward'
+    })
+
+    expect(sent).toBe(true)
+    expect(target.send).toHaveBeenCalledWith(AppChannels.events.NAVIGATION_COMMAND, {
+      direction: 'forward'
+    })
+  })
+
+  it('ignores keyup and repeated browser keyboard input', () => {
+    expect(
+      keyboardInputToNavigationCommand({
+        type: 'keyUp',
+        key: 'BrowserBack'
+      })
+    ).toBeNull()
+    expect(
+      keyboardInputToNavigationCommand({
+        type: 'keyDown',
+        key: 'BrowserBack',
+        isAutoRepeat: true
+      })
+    ).toBeNull()
+  })
+})
+
+describe('sendAppNavigationSwipeCommand', () => {
+  it('maps left swipe to back navigation for Logitech MX back button events', () => {
+    const target = { send: vi.fn() }
+
+    const sent = sendAppNavigationSwipeCommand(target, 'left')
+
+    expect(sent).toBe(true)
+    expect(target.send).toHaveBeenCalledWith(AppChannels.events.NAVIGATION_COMMAND, {
+      direction: 'back'
+    })
+  })
+
+  it('maps right swipe to forward navigation for Logitech MX next button events', () => {
+    const target = { send: vi.fn() }
+
+    const sent = sendAppNavigationSwipeCommand(target, 'right')
+
+    expect(sent).toBe(true)
+    expect(target.send).toHaveBeenCalledWith(AppChannels.events.NAVIGATION_COMMAND, {
+      direction: 'forward'
+    })
+  })
+
+  it('ignores vertical swipes', () => {
+    expect(swipeDirectionToNavigationCommand('up')).toBeNull()
+    expect(swipeDirectionToNavigationCommand('down')).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/app-navigation-command.ts
+++ b/apps/desktop/src/main/app-navigation-command.ts
@@ -1,0 +1,89 @@
+import { AppChannels, type AppNavigationCommandEvent } from '@memry/contracts/ipc-channels'
+
+interface IpcEventTarget {
+  send: (channel: string, payload: AppNavigationCommandEvent) => void
+}
+
+export interface AppNavigationKeyboardInput {
+  type: string
+  key?: string
+  code?: string
+  isAutoRepeat?: boolean
+  shift?: boolean
+  control?: boolean
+  alt?: boolean
+  meta?: boolean
+  modifiers?: string[]
+}
+
+export type AppNavigationSwipeDirection = 'left' | 'right' | 'up' | 'down'
+
+const BROWSER_BACK_KEYS = new Set(['browserback', 'browser-back', 'browser-backward', 'goback'])
+const BROWSER_FORWARD_KEYS = new Set(['browserforward', 'browser-forward', 'goforward'])
+
+const normalizeInputKey = (key: string | undefined): string => key?.toLowerCase() ?? ''
+
+export const appCommandToNavigationCommand = (
+  command: string
+): AppNavigationCommandEvent | null => {
+  if (command === 'browser-backward') return { direction: 'back' }
+  if (command === 'browser-forward') return { direction: 'forward' }
+  return null
+}
+
+export const keyboardInputToNavigationCommand = (
+  input: AppNavigationKeyboardInput
+): AppNavigationCommandEvent | null => {
+  if (input.type !== 'keyDown' || input.isAutoRepeat) return null
+
+  const keys = [normalizeInputKey(input.key), normalizeInputKey(input.code)]
+  if (keys.some((key) => BROWSER_BACK_KEYS.has(key))) return { direction: 'back' }
+  if (keys.some((key) => BROWSER_FORWARD_KEYS.has(key))) return { direction: 'forward' }
+  return null
+}
+
+export const swipeDirectionToNavigationCommand = (
+  direction: AppNavigationSwipeDirection
+): AppNavigationCommandEvent | null => {
+  if (direction === 'left') return { direction: 'back' }
+  if (direction === 'right') return { direction: 'forward' }
+  return null
+}
+
+export const sendAppNavigationDirection = (
+  target: IpcEventTarget,
+  direction: AppNavigationCommandEvent['direction']
+): void => {
+  const payload: AppNavigationCommandEvent = { direction }
+  target.send(AppChannels.events.NAVIGATION_COMMAND, payload)
+}
+
+export const sendAppNavigationCommand = (target: IpcEventTarget, command: string): boolean => {
+  const payload = appCommandToNavigationCommand(command)
+  if (!payload) return false
+
+  sendAppNavigationDirection(target, payload.direction)
+  return true
+}
+
+export const sendAppNavigationKeyboardCommand = (
+  target: IpcEventTarget,
+  input: AppNavigationKeyboardInput
+): boolean => {
+  const payload = keyboardInputToNavigationCommand(input)
+  if (!payload) return false
+
+  sendAppNavigationDirection(target, payload.direction)
+  return true
+}
+
+export const sendAppNavigationSwipeCommand = (
+  target: IpcEventTarget,
+  direction: AppNavigationSwipeDirection
+): boolean => {
+  const payload = swipeDirectionToNavigationCommand(direction)
+  if (!payload) return false
+
+  sendAppNavigationDirection(target, payload.direction)
+  return true
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -54,6 +54,12 @@ import { SettingsChannels } from '@memry/contracts/ipc-channels'
 import { initializeUpdater } from './updater'
 import { buildAppMenu } from './menu'
 import { setMainI18n } from './lib/main-i18n'
+import {
+  sendAppNavigationCommand,
+  sendAppNavigationKeyboardCommand,
+  sendAppNavigationSwipeCommand,
+  type AppNavigationSwipeDirection
+} from './app-navigation-command'
 
 if (process.type === 'browser') {
   log.initialize()
@@ -309,6 +315,22 @@ function createWindow(): void {
   mainWindow.webContents.setWindowOpenHandler((details) => {
     void shell.openExternal(details.url)
     return { action: 'deny' }
+  })
+
+  // Browser-style mouse-button navigation: Windows/Linux fire WM_APPCOMMAND for X1/X2.
+  mainWindow.on('app-command', (_event, cmd) => {
+    sendAppNavigationCommand(mainWindow.webContents, cmd)
+  })
+
+  mainWindow.on('swipe', (_event, direction) => {
+    sendAppNavigationSwipeCommand(mainWindow.webContents, direction as AppNavigationSwipeDirection)
+  })
+
+  // Some mouse drivers expose browser side buttons as dedicated keyboard keys instead.
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (sendAppNavigationKeyboardCommand(mainWindow.webContents, input)) {
+      event.preventDefault()
+    }
   })
 
   // HMR for renderer base on electron-vite cli.

--- a/apps/desktop/src/main/menu.test.ts
+++ b/apps/desktop/src/main/menu.test.ts
@@ -7,6 +7,7 @@ const { buildFromTemplate } = vi.hoisted(() => ({
 
 vi.mock('electron', () => ({
   app: { name: 'Memry' },
+  BrowserWindow: { getFocusedWindow: vi.fn() },
   Menu: { buildFromTemplate }
 }))
 
@@ -33,6 +34,8 @@ describe('buildAppMenu', () => {
     expect(template.flatMap((item) => item.submenu ?? []).map((item) => item.label)).toEqual(
       expect.arrayContaining([
         'New Note',
+        'Back',
+        'Forward',
         'Close Window',
         'Undo',
         'Redo',
@@ -42,6 +45,32 @@ describe('buildAppMenu', () => {
         'Reload',
         'Toggle Developer Tools',
         'Toggle Full Screen'
+      ])
+    )
+  })
+
+  it('registers hidden browser navigation menu accelerators', async () => {
+    const i18n = await createMainI18n({ locale: 'en' })
+
+    buildAppMenu(i18n)
+
+    const template = buildFromTemplate.mock.calls[0][0] as Array<{
+      submenu?: Array<{ label?: string; accelerator?: string; visible?: boolean }>
+    }>
+    const items = template.flatMap((item) => item.submenu ?? [])
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Back',
+          accelerator: 'CmdOrCtrl+[',
+          visible: false
+        }),
+        expect.objectContaining({
+          label: 'Forward',
+          accelerator: 'CmdOrCtrl+]',
+          visible: false
+        })
       ])
     )
   })

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -1,5 +1,13 @@
-import { app, Menu, type MenuItemConstructorOptions } from 'electron'
+import { app, BrowserWindow, Menu, type MenuItemConstructorOptions } from 'electron'
 import type { I18nInstance } from '@memry/i18n/main'
+import { sendAppNavigationDirection } from './app-navigation-command'
+
+function sendNavigationToFocusedWindow(direction: 'back' | 'forward'): void {
+  const window = BrowserWindow.getFocusedWindow()
+  if (!window || window.webContents.isDestroyed()) return
+
+  sendAppNavigationDirection(window.webContents, direction)
+}
 
 export function buildAppMenu(i18n: I18nInstance): Menu {
   const t = i18n.getFixedT(null, 'menu')
@@ -19,6 +27,20 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
         {
           label: t('file.newNote'),
           accelerator: 'CmdOrCtrl+N'
+        },
+        {
+          label: t('navigation.back'),
+          accelerator: 'CmdOrCtrl+[',
+          visible: false,
+          acceleratorWorksWhenHidden: true,
+          click: () => sendNavigationToFocusedWindow('back')
+        },
+        {
+          label: t('navigation.forward'),
+          accelerator: 'CmdOrCtrl+]',
+          visible: false,
+          acceleratorWorksWhenHidden: true,
+          click: () => sendNavigationToFocusedWindow('forward')
         },
         { type: 'separator' },
         { label: t('file.close'), role: 'close' }

--- a/apps/desktop/src/main/preload-types.test.ts
+++ b/apps/desktop/src/main/preload-types.test.ts
@@ -21,6 +21,7 @@ describe('preload type declarations', () => {
     expectTypeOf<Window['api']['crypto']['encryptItem']>().toBeFunction()
     expectTypeOf<Window['api']['syncAttachments']['upload']>().toBeFunction()
     expectTypeOf<Window['api']['onSyncStatusChanged']>().toBeFunction()
+    expectTypeOf<Window['api']['onAppNavigationCommand']>().toBeFunction()
   })
 
   it('reuses canonical rpc note, task, and inbox types', () => {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -3,6 +3,7 @@ import type { GeneratedRpcApi } from '@memry/rpc'
 import type * as InboxRpc from '@memry/rpc/inbox'
 import type * as NotesRpc from '@memry/rpc/notes'
 import type * as TasksRpc from '@memry/rpc/tasks'
+import type { AppNavigationCommandEvent } from '@memry/contracts/ipc-channels'
 import type { AppUpdateState } from '@memry/contracts/ipc-updater'
 import type { Locale, LocaleApi } from '@memry/contracts/locale-api'
 import type {
@@ -1708,6 +1709,7 @@ interface API extends WindowAPI, GeneratedRpcApi {
   onSecurityWarning: (callback: (event: SecurityWarningEvent) => void) => () => void
   onCertificatePinFailed: (callback: (event: CertificatePinFailedEvent) => void) => () => void
   onUpdaterStateChanged: (callback: (state: AppUpdateState) => void) => () => void
+  onAppNavigationCommand: (callback: (command: AppNavigationCommandEvent) => void) => () => void
   onLocaleChanged: (callback: (locale: Locale) => void) => () => void
   onCrdtStateChanged: (
     callback: (data: { noteId: string; update: number[]; origin: string }) => void

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,10 @@
 import { contextBridge } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
-import { LocaleChannels } from '@memry/contracts/ipc-channels'
+import {
+  AppChannels,
+  LocaleChannels,
+  type AppNavigationCommandEvent
+} from '@memry/contracts/ipc-channels'
 import type { Locale, LocaleApi } from '@memry/contracts/locale-api'
 import { createLogger } from './lib/logger'
 import { invoke, invokeSync, subscribe } from './lib/ipc'
@@ -94,6 +98,8 @@ export const api = {
   ...updaterEvents,
   ...flushApi,
 
+  onAppNavigationCommand: (callback: (command: AppNavigationCommandEvent) => void) =>
+    subscribe<AppNavigationCommandEvent>(AppChannels.events.NAVIGATION_COMMAND, callback),
   onLocaleChanged: (callback: (locale: Locale) => void) =>
     subscribe<Locale>(LocaleChannels.Changed, callback)
 }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -29,6 +29,7 @@ import { ChordIndicator, KeyboardShortcutsDialog } from '@/components/keyboard'
 import {
   useTabKeyboardShortcuts,
   useChordShortcuts,
+  useMouseNavButtons,
   useDragHandlers,
   useTaskOrder,
   useVault,
@@ -169,6 +170,7 @@ const AppContent = (): React.JSX.Element => {
 
   // Keyboard shortcuts
   useTabKeyboardShortcuts()
+  useMouseNavButtons()
   const isChordActive = useChordShortcuts()
   const { open: openSettings } = useSettingsModal()
   useSettingsShortcut(openSettings)

--- a/apps/desktop/src/renderer/src/components/split-view/layout-presets.ts
+++ b/apps/desktop/src/renderer/src/components/split-view/layout-presets.ts
@@ -50,7 +50,9 @@ const createGroup = (id: string, tabs: Tab[], isActive: boolean): TabGroup => {
     id,
     tabs: groupTabs,
     activeTabId: groupTabs[0]?.id ?? null,
-    isActive
+    isActive,
+    back: [],
+    forward: []
   }
 }
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/__tests__/history.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/__tests__/history.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi } from 'vitest'
+import { tabReducer } from '../reducer'
+import type { Tab, TabGroup, TabSystemState } from '../types'
+import { generateId } from '../helpers'
+
+vi.mock('crypto', () => ({
+  randomUUID: () => `test-${Math.random().toString(36).slice(2, 10)}`
+}))
+
+const makeTab = (overrides: Partial<Tab> = {}): Tab => ({
+  id: generateId(),
+  type: 'note',
+  title: 'Test Note',
+  icon: 'file-text',
+  path: '/note/test',
+  entityId: `entity-${Math.random().toString(36).slice(2, 8)}`,
+  isPinned: false,
+  isModified: false,
+  isPreview: false,
+  isDeleted: false,
+  openedAt: Date.now(),
+  lastAccessedAt: Date.now(),
+  ...overrides
+})
+
+const makeGroup = (tabs: Tab[], overrides: Partial<TabGroup> = {}): TabGroup => ({
+  id: generateId(),
+  tabs,
+  activeTabId: tabs[0]?.id ?? null,
+  isActive: true,
+  back: [],
+  forward: [],
+  ...overrides
+})
+
+const makeState = (group: TabGroup): TabSystemState => ({
+  tabGroups: { [group.id]: group },
+  layout: { type: 'leaf', tabGroupId: group.id },
+  activeGroupId: group.id,
+  settings: { previewMode: false, restoreSessionOnStart: true, tabCloseButton: 'hover' }
+})
+
+describe('tab activation history', () => {
+  describe('SET_ACTIVE_TAB', () => {
+    it('pushes the previous active id onto back and clears forward', () => {
+      // #given a group with two tabs and an existing forward stack
+      const a = makeTab({ title: 'A' })
+      const b = makeTab({ title: 'B' })
+      const group = makeGroup([a, b], { activeTabId: a.id, forward: ['stale-id'] })
+      const state = makeState(group)
+
+      // #when the user activates a different tab
+      const next = tabReducer(state, {
+        type: 'SET_ACTIVE_TAB',
+        payload: { tabId: b.id, groupId: group.id }
+      })
+
+      // #then back records the prior active and forward is wiped
+      expect(next.tabGroups[group.id].back).toEqual([a.id])
+      expect(next.tabGroups[group.id].forward).toEqual([])
+      expect(next.tabGroups[group.id].activeTabId).toBe(b.id)
+    })
+
+    it('is a history no-op when activating the already-active tab', () => {
+      // #given the active tab is already A
+      const a = makeTab()
+      const group = makeGroup([a], { activeTabId: a.id, back: ['x'], forward: ['y'] })
+      const state = makeState(group)
+
+      // #when SET_ACTIVE_TAB targets the same tab
+      const next = tabReducer(state, {
+        type: 'SET_ACTIVE_TAB',
+        payload: { tabId: a.id, groupId: group.id }
+      })
+
+      // #then history is preserved
+      expect(next.tabGroups[group.id].back).toEqual(['x'])
+      expect(next.tabGroups[group.id].forward).toEqual(['y'])
+    })
+  })
+
+  describe('NAV_BACK / NAV_FORWARD', () => {
+    it('NAV_BACK on empty stack returns the same state', () => {
+      // #given a group with no back history
+      const a = makeTab()
+      const group = makeGroup([a], { activeTabId: a.id })
+      const state = makeState(group)
+
+      // #when NAV_BACK fires
+      const next = tabReducer(state, { type: 'NAV_BACK', payload: { groupId: group.id } })
+
+      // #then state is unchanged (referentially equal)
+      expect(next).toBe(state)
+    })
+
+    it('round-trips a back/forward navigation', () => {
+      // #given the user is on B, having come from A
+      const a = makeTab({ title: 'A' })
+      const b = makeTab({ title: 'B' })
+      const group = makeGroup([a, b], { activeTabId: b.id, back: [a.id] })
+      const state = makeState(group)
+
+      // #when they go back, then forward
+      const afterBack = tabReducer(state, {
+        type: 'NAV_BACK',
+        payload: { groupId: group.id }
+      })
+      expect(afterBack.tabGroups[group.id].activeTabId).toBe(a.id)
+      expect(afterBack.tabGroups[group.id].forward).toEqual([b.id])
+
+      const afterForward = tabReducer(afterBack, {
+        type: 'NAV_FORWARD',
+        payload: { groupId: group.id }
+      })
+
+      // #then they end up back on B with A in back
+      expect(afterForward.tabGroups[group.id].activeTabId).toBe(b.id)
+      expect(afterForward.tabGroups[group.id].back).toEqual([a.id])
+      expect(afterForward.tabGroups[group.id].forward).toEqual([])
+    })
+
+    it('NAV_BACK skips ids no longer present in tabs[]', () => {
+      // #given back contains a stale id (e.g. closed tab) before a valid one
+      const a = makeTab({ title: 'A' })
+      const c = makeTab({ title: 'C' })
+      const group = makeGroup([a, c], {
+        activeTabId: c.id,
+        back: [a.id, 'stale-deleted-tab']
+      })
+      const state = makeState(group)
+
+      // #when NAV_BACK fires
+      const next = tabReducer(state, { type: 'NAV_BACK', payload: { groupId: group.id } })
+
+      // #then the stale id is popped past, A becomes active
+      expect(next.tabGroups[group.id].activeTabId).toBe(a.id)
+      expect(next.tabGroups[group.id].back).toEqual([])
+    })
+  })
+
+  describe('OPEN_TAB clears forward and records previous active', () => {
+    it('opens a fresh note tab after a back navigation, wiping forward', () => {
+      // #given user is on A with B reachable via forward
+      const a = makeTab({ title: 'A', entityId: 'a' })
+      const b = makeTab({ title: 'B', entityId: 'b' })
+      const group = makeGroup([a, b], { activeTabId: a.id, forward: [b.id] })
+      const state = makeState(group)
+
+      // #when they open a new tab
+      const next = tabReducer(state, {
+        type: 'OPEN_TAB',
+        payload: {
+          tab: {
+            type: 'note',
+            title: 'C',
+            icon: 'file-text',
+            path: '/note/c',
+            entityId: 'c',
+            isPinned: false,
+            isModified: false,
+            isPreview: false,
+            isDeleted: false
+          },
+          groupId: group.id
+        }
+      })
+
+      // #then forward is wiped and back records A
+      expect(next.tabGroups[group.id].forward).toEqual([])
+      expect(next.tabGroups[group.id].back).toEqual([a.id])
+    })
+
+    it('background OPEN_TAB does not record activation history', () => {
+      // #given user is on A
+      const a = makeTab({ title: 'A', entityId: 'a' })
+      const group = makeGroup([a], { activeTabId: a.id, back: ['previous'] })
+      const state = makeState(group)
+
+      // #when they open a tab in the background
+      const next = tabReducer(state, {
+        type: 'OPEN_TAB',
+        payload: {
+          tab: {
+            type: 'note',
+            title: 'B',
+            icon: 'file-text',
+            path: '/note/b',
+            entityId: 'b',
+            isPinned: false,
+            isModified: false,
+            isPreview: false,
+            isDeleted: false
+          },
+          groupId: group.id,
+          background: true
+        }
+      })
+
+      // #then history is unchanged and active tab stays on A
+      expect(next.tabGroups[group.id].activeTabId).toBe(a.id)
+      expect(next.tabGroups[group.id].back).toEqual(['previous'])
+      expect(next.tabGroups[group.id].forward).toEqual([])
+    })
+  })
+
+  describe('CLOSE_TAB prunes history', () => {
+    it('removes the closed tab id from both stacks', () => {
+      // #given user has A→B→C history with C active and B in back
+      const a = makeTab({ title: 'A' })
+      const b = makeTab({ title: 'B' })
+      const c = makeTab({ title: 'C' })
+      const group = makeGroup([a, b, c], {
+        activeTabId: c.id,
+        back: [a.id, b.id],
+        forward: [b.id]
+      })
+      const state = makeState(group)
+
+      // #when B is closed
+      const next = tabReducer(state, {
+        type: 'CLOSE_TAB',
+        payload: { tabId: b.id, groupId: group.id }
+      })
+
+      // #then b.id is gone from both stacks
+      expect(next.tabGroups[group.id].back).toEqual([a.id])
+      expect(next.tabGroups[group.id].forward).toEqual([])
+    })
+  })
+
+  describe('history cap', () => {
+    it('caps the back stack at 50 entries', () => {
+      // #given a back stack at the cap limit
+      const tabs = Array.from({ length: 51 }, (_, i) => makeTab({ title: `T${i}` }))
+      const tail = tabs[tabs.length - 1]
+      const back = tabs.slice(0, -1).map((t) => t.id)
+      const group = makeGroup(tabs, { activeTabId: tail.id, back })
+      const state = makeState(group)
+
+      // #when the user activates a fresh tab
+      const fresh = makeTab({ title: 'fresh' })
+      const groupWithFresh = {
+        ...group,
+        tabs: [...tabs, fresh]
+      }
+      const stateWithFresh = makeState(groupWithFresh)
+      const stateWithFreshAndBack = {
+        ...stateWithFresh,
+        tabGroups: {
+          [group.id]: { ...groupWithFresh, activeTabId: tail.id, back, forward: [] }
+        }
+      }
+      const next = tabReducer(stateWithFreshAndBack, {
+        type: 'SET_ACTIVE_TAB',
+        payload: { tabId: fresh.id, groupId: group.id }
+      })
+
+      // #then back is capped at 50 and the oldest entry was dropped
+      expect(next.tabGroups[group.id].back.length).toBe(50)
+      expect(next.tabGroups[group.id].back[0]).toBe(tabs[1].id)
+      expect(next.tabGroups[group.id].back[49]).toBe(tail.id)
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/contexts/tabs/__tests__/reducer.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/__tests__/reducer.test.ts
@@ -28,6 +28,8 @@ const makeGroup = (tabs: Tab[], overrides: Partial<TabGroup> = {}): TabGroup => 
   tabs,
   activeTabId: tabs[0]?.id ?? null,
   isActive: true,
+  back: [],
+  forward: [],
   ...overrides
 })
 
@@ -134,7 +136,9 @@ describe('tabReducer', () => {
         id: generateId(),
         tabs: [],
         activeTabId: null,
-        isActive: true
+        isActive: true,
+        back: [],
+        forward: []
       }
       const state = makeState([group])
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
@@ -103,6 +103,26 @@ interface TabContextType {
   goToTabIndex: (index: number, groupId?: string) => void
 
   /**
+   * Re-activate the previously active tab in this group (browser-style back).
+   */
+  navBack: (groupId?: string) => void
+
+  /**
+   * Redo a back navigation (browser-style forward).
+   */
+  navForward: (groupId?: string) => void
+
+  /**
+   * True when navBack would activate a tab.
+   */
+  canNavBack: boolean
+
+  /**
+   * True when navForward would activate a tab.
+   */
+  canNavForward: boolean
+
+  /**
    * Pin a tab
    */
   pinTab: (tabId: string, groupId?: string) => void
@@ -404,6 +424,26 @@ export const TabProvider = ({
     })
   }, [])
 
+  const navBack = useCallback((groupId?: string) => {
+    const actualGroupId = groupId ?? activeGroupIdRef.current
+    dispatch({ type: 'NAV_BACK', payload: { groupId: actualGroupId } })
+  }, [])
+
+  const navForward = useCallback((groupId?: string) => {
+    const actualGroupId = groupId ?? activeGroupIdRef.current
+    dispatch({ type: 'NAV_FORWARD', payload: { groupId: actualGroupId } })
+  }, [])
+
+  const canNavBack = useMemo(
+    () => (state.tabGroups[state.activeGroupId]?.back?.length ?? 0) > 0,
+    [state.tabGroups, state.activeGroupId]
+  )
+
+  const canNavForward = useMemo(
+    () => (state.tabGroups[state.activeGroupId]?.forward?.length ?? 0) > 0,
+    [state.tabGroups, state.activeGroupId]
+  )
+
   const pinTab = useCallback((tabId: string, groupId?: string) => {
     const actualGroupId = groupId ?? activeGroupIdRef.current
     dispatch({
@@ -619,6 +659,10 @@ export const TabProvider = ({
       goToNextTab,
       goToPreviousTab,
       goToTabIndex,
+      navBack,
+      navForward,
+      canNavBack,
+      canNavForward,
       pinTab,
       unpinTab,
       togglePinTab,
@@ -656,6 +700,10 @@ export const TabProvider = ({
       goToNextTab,
       goToPreviousTab,
       goToTabIndex,
+      navBack,
+      navForward,
+      canNavBack,
+      canNavForward,
       pinTab,
       unpinTab,
       togglePinTab,

--- a/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
@@ -216,7 +216,9 @@ export const createInitialTabGroup = (): TabGroup => {
     id: generateId(),
     tabs: [initialTab],
     activeTabId: initialTab.id,
-    isActive: true
+    isActive: true,
+    back: [],
+    forward: []
   }
 }
 
@@ -228,7 +230,9 @@ export const createEmptyTabGroup = (withDefaultTab: boolean = true): TabGroup =>
     id: generateId(),
     tabs: [],
     activeTabId: null,
-    isActive: false
+    isActive: false,
+    back: [],
+    forward: []
   }
 
   if (withDefaultTab) {

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.ts
@@ -98,7 +98,9 @@ export const deserializeTabState = (persisted: PersistedTabState): Partial<TabSy
       id: group.id,
       tabs: finalTabs,
       activeTabId,
-      isActive: groupId === migrated.activeGroupId
+      isActive: groupId === migrated.activeGroupId,
+      back: [],
+      forward: []
     }
   }
 
@@ -110,7 +112,9 @@ export const deserializeTabState = (persisted: PersistedTabState): Partial<TabSy
       id: defaultGroupId,
       tabs: [defaultTab],
       activeTabId: defaultTab.id,
-      isActive: true
+      isActive: true,
+      back: [],
+      forward: []
     }
   }
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducer.ts
@@ -23,6 +23,8 @@ export function tabReducer(state: TabSystemState, action: TabAction): TabSystemS
     case 'GO_TO_NEXT_TAB':
     case 'GO_TO_PREVIOUS_TAB':
     case 'GO_TO_TAB_INDEX':
+    case 'NAV_BACK':
+    case 'NAV_FORWARD':
       return tabNavReducer(state, action)
 
     case 'PIN_TAB':

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/history-helpers.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/history-helpers.ts
@@ -1,0 +1,35 @@
+import type { TabGroup } from '../types'
+
+export const HISTORY_LIMIT = 50
+
+const cap = (ids: string[]): string[] =>
+  ids.length > HISTORY_LIMIT ? ids.slice(-HISTORY_LIMIT) : ids
+
+/**
+ * Push the previous active tab id onto `back`, clear `forward`, and set the new active id.
+ * No-op if the active id is unchanged. Use this whenever a tab becomes active
+ * via user-initiated navigation (open, click) — but NOT during NAV_BACK/NAV_FORWARD,
+ * which manage the stacks directly.
+ */
+export const recordActivation = (group: TabGroup, newActiveId: string | null): TabGroup => {
+  if (group.activeTabId === newActiveId) return group
+  const back = group.activeTabId ? cap([...group.back, group.activeTabId]) : group.back
+  return {
+    ...group,
+    back,
+    forward: [],
+    activeTabId: newActiveId
+  }
+}
+
+/**
+ * Remove a set of tab ids from both history stacks of a group. Used when tabs
+ * are closed or moved out so stale ids don't surface during back/forward navigation.
+ */
+export const pruneHistory = (group: TabGroup, removedIds: Set<string>): TabGroup => {
+  if (removedIds.size === 0) return group
+  const back = group.back.filter((id) => !removedIds.has(id))
+  const forward = group.forward.filter((id) => !removedIds.has(id))
+  if (back.length === group.back.length && forward.length === group.forward.length) return group
+  return { ...group, back, forward }
+}

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/layout-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/layout-reducer.ts
@@ -2,6 +2,7 @@ import type { SplitDirection, SplitLayout, TabAction, TabGroup, TabSystemState }
 import { generateId, createDefaultTab } from '../helpers'
 import { insertSplitAtGroup } from '@/components/split-view/layout-helpers'
 import { closeGroup } from './tab-crud-reducer'
+import { pruneHistory } from './history-helpers'
 
 type LayoutAction = Extract<
   TabAction,
@@ -50,7 +51,9 @@ export function layoutReducer(state: TabSystemState, action: LayoutAction): TabS
         id: generateId(),
         tabs: [clonedTab],
         activeTabId: clonedTab.id,
-        isActive: false
+        isActive: false,
+        back: [],
+        forward: []
       }
 
       const newLayout = insertSplitAtGroup(state.layout, groupId, newGroup.id, direction)
@@ -103,10 +106,13 @@ export function layoutReducer(state: TabSystemState, action: LayoutAction): TabS
         id: generateId(),
         tabs: [{ ...tab, lastAccessedAt: Date.now() }],
         activeTabId: tab.id,
-        isActive: false
+        isActive: false,
+        back: [],
+        forward: []
       }
 
       const newFromTabs = fromGroup.tabs.filter((t) => t.id !== tabId)
+      const fromGroupAfter = pruneHistory(fromGroup, new Set([tabId]))
 
       // Map direction to split type
       const splitDirection: SplitDirection =
@@ -161,7 +167,11 @@ export function layoutReducer(state: TabSystemState, action: LayoutAction): TabS
         ...state,
         tabGroups: {
           ...state.tabGroups,
-          [fromGroupId]: { ...fromGroup, tabs: newFromTabs, activeTabId: newFromActiveTabId },
+          [fromGroupId]: {
+            ...fromGroupAfter,
+            tabs: newFromTabs,
+            activeTabId: newFromActiveTabId
+          },
           [newGroup.id]: newGroup
         },
         layout: insertSplit(state.layout),

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
@@ -9,6 +9,7 @@ import {
 } from '../helpers'
 import { removeGroupFromLayout } from '@/components/split-view/layout-helpers'
 import { createInitialState } from '../helpers'
+import { pruneHistory, recordActivation } from './history-helpers'
 
 type CrudAction = Extract<
   TabAction,
@@ -84,11 +85,12 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
             const newTabs = [...targetGroup.tabs]
             newTabs[activeTabIndex] = newTab
 
+            const pruned = pruneHistory(targetGroup, new Set([activeTab.id]))
             return {
               ...state,
               tabGroups: {
                 ...state.tabGroups,
-                [groupId]: { ...targetGroup, tabs: newTabs, activeTabId: newTab.id }
+                [groupId]: { ...pruned, tabs: newTabs, activeTabId: newTab.id }
               }
             }
           }
@@ -107,24 +109,21 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
           // Only dedup non-entity tabs to avoid cross-type collisions
           const isSameKind = existingInGroup.type === tab.type && existingInGroup.path === tab.path
           if (isSameKind) {
+            const updatedTabs = targetGroup.tabs.map((t) =>
+              t.id === existingInGroup.id
+                ? {
+                    ...t,
+                    lastAccessedAt: Date.now(),
+                    ...(tab.viewState && { viewState: { ...t.viewState, ...tab.viewState } })
+                  }
+                : t
+            )
+            const groupAfter = background
+              ? { ...targetGroup, tabs: updatedTabs }
+              : { ...recordActivation(targetGroup, existingInGroup.id), tabs: updatedTabs }
             return {
               ...state,
-              tabGroups: {
-                ...state.tabGroups,
-                [groupId]: {
-                  ...targetGroup,
-                  activeTabId: background ? targetGroup.activeTabId : existingInGroup.id,
-                  tabs: targetGroup.tabs.map((t) =>
-                    t.id === existingInGroup.id
-                      ? {
-                          ...t,
-                          lastAccessedAt: Date.now(),
-                          ...(tab.viewState && { viewState: { ...t.viewState, ...tab.viewState } })
-                        }
-                      : t
-                  )
-                }
-              },
+              tabGroups: { ...state.tabGroups, [groupId]: groupAfter },
               activeGroupId: background ? state.activeGroupId : groupId
             }
           }
@@ -139,20 +138,16 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       ) {
         const existing = findExistingTab(state, tab.type)
         if (existing) {
+          const existingGroup = state.tabGroups[existing.groupId]
+          const updatedTabs = existingGroup.tabs.map((t) =>
+            t.id === existing.tab.id ? { ...t, lastAccessedAt: Date.now() } : t
+          )
+          const groupAfter = background
+            ? { ...existingGroup, tabs: updatedTabs }
+            : { ...recordActivation(existingGroup, existing.tab.id), tabs: updatedTabs }
           return {
             ...state,
-            tabGroups: {
-              ...state.tabGroups,
-              [existing.groupId]: {
-                ...state.tabGroups[existing.groupId],
-                activeTabId: background
-                  ? state.tabGroups[existing.groupId].activeTabId
-                  : existing.tab.id,
-                tabs: state.tabGroups[existing.groupId].tabs.map((t) =>
-                  t.id === existing.tab.id ? { ...t, lastAccessedAt: Date.now() } : t
-                )
-              }
-            },
+            tabGroups: { ...state.tabGroups, [existing.groupId]: groupAfter },
             activeGroupId: background ? state.activeGroupId : existing.groupId
           }
         }
@@ -162,26 +157,23 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       if (tab.entityId) {
         const existingInGroup = findTabByEntityIdInGroup(targetGroup, tab.entityId)
         if (existingInGroup) {
+          const updatedTabs = targetGroup.tabs.map((t) =>
+            t.id === existingInGroup.id
+              ? {
+                  ...t,
+                  lastAccessedAt: Date.now(),
+                  ...(tab.viewState && {
+                    viewState: { ...t.viewState, ...tab.viewState }
+                  })
+                }
+              : t
+          )
+          const groupAfter = background
+            ? { ...targetGroup, tabs: updatedTabs }
+            : { ...recordActivation(targetGroup, existingInGroup.id), tabs: updatedTabs }
           return {
             ...state,
-            tabGroups: {
-              ...state.tabGroups,
-              [groupId]: {
-                ...targetGroup,
-                activeTabId: background ? targetGroup.activeTabId : existingInGroup.id,
-                tabs: targetGroup.tabs.map((t) =>
-                  t.id === existingInGroup.id
-                    ? {
-                        ...t,
-                        lastAccessedAt: Date.now(),
-                        ...(tab.viewState && {
-                          viewState: { ...t.viewState, ...tab.viewState }
-                        })
-                      }
-                    : t
-                )
-              }
-            },
+            tabGroups: { ...state.tabGroups, [groupId]: groupAfter },
             activeGroupId: background ? state.activeGroupId : groupId
           }
         }
@@ -191,28 +183,24 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
         if (!action.payload.groupId) {
           const existingElsewhere = findTabByEntityId(state, tab.entityId)
           if (existingElsewhere) {
+            const elsewhereGroup = state.tabGroups[existingElsewhere.groupId]
+            const updatedTabs = elsewhereGroup.tabs.map((t) =>
+              t.id === existingElsewhere.tab.id
+                ? {
+                    ...t,
+                    lastAccessedAt: Date.now(),
+                    ...(tab.viewState && {
+                      viewState: { ...t.viewState, ...tab.viewState }
+                    })
+                  }
+                : t
+            )
+            const groupAfter = background
+              ? { ...elsewhereGroup, tabs: updatedTabs }
+              : { ...recordActivation(elsewhereGroup, existingElsewhere.tab.id), tabs: updatedTabs }
             return {
               ...state,
-              tabGroups: {
-                ...state.tabGroups,
-                [existingElsewhere.groupId]: {
-                  ...state.tabGroups[existingElsewhere.groupId],
-                  activeTabId: background
-                    ? state.tabGroups[existingElsewhere.groupId].activeTabId
-                    : existingElsewhere.tab.id,
-                  tabs: state.tabGroups[existingElsewhere.groupId].tabs.map((t) =>
-                    t.id === existingElsewhere.tab.id
-                      ? {
-                          ...t,
-                          lastAccessedAt: Date.now(),
-                          ...(tab.viewState && {
-                            viewState: { ...t.viewState, ...tab.viewState }
-                          })
-                        }
-                      : t
-                  )
-                }
-              },
+              tabGroups: { ...state.tabGroups, [existingElsewhere.groupId]: groupAfter },
               activeGroupId: background ? state.activeGroupId : existingElsewhere.groupId
             }
           }
@@ -223,6 +211,7 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       if (state.settings.previewMode && tab.isPreview) {
         const previewTabIndex = targetGroup.tabs.findIndex((t) => t.isPreview)
         if (previewTabIndex !== -1) {
+          const previewTab = targetGroup.tabs[previewTabIndex]
           const newTab: Tab = {
             ...tab,
             id: generateId(),
@@ -232,16 +221,15 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
           const newTabs = [...targetGroup.tabs]
           newTabs[previewTabIndex] = newTab
 
+          const pruned = pruneHistory(targetGroup, new Set([previewTab.id]))
+          const nextActiveId = background ? pruned.activeTabId : newTab.id
+          const groupAfter =
+            background || pruned.activeTabId === nextActiveId
+              ? { ...pruned, tabs: newTabs, activeTabId: nextActiveId }
+              : { ...recordActivation(pruned, nextActiveId), tabs: newTabs }
           return {
             ...state,
-            tabGroups: {
-              ...state.tabGroups,
-              [groupId]: {
-                ...targetGroup,
-                tabs: newTabs,
-                activeTabId: background ? targetGroup.activeTabId : newTab.id
-              }
-            },
+            tabGroups: { ...state.tabGroups, [groupId]: groupAfter },
             activeGroupId: background ? state.activeGroupId : groupId
           }
         }
@@ -269,16 +257,12 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
         ...targetGroup.tabs.slice(insertIndex)
       ]
 
+      const groupAfter = background
+        ? { ...targetGroup, tabs: newTabs }
+        : { ...recordActivation(targetGroup, newTab.id), tabs: newTabs }
       return {
         ...state,
-        tabGroups: {
-          ...state.tabGroups,
-          [groupId]: {
-            ...targetGroup,
-            tabs: newTabs,
-            activeTabId: background ? targetGroup.activeTabId : newTab.id
-          }
-        },
+        tabGroups: { ...state.tabGroups, [groupId]: groupAfter },
         activeGroupId: background ? state.activeGroupId : groupId
       }
     }
@@ -300,7 +284,13 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
           return {
             ...state,
             tabGroups: {
-              [groupId]: { ...group, tabs: [defaultTab], activeTabId: defaultTab.id }
+              [groupId]: {
+                ...group,
+                tabs: [defaultTab],
+                activeTabId: defaultTab.id,
+                back: [],
+                forward: []
+              }
             }
           }
         }
@@ -313,11 +303,12 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
         newActiveTabId = newTabs[newActiveIndex].id
       }
 
+      const pruned = pruneHistory(group, new Set([tabId]))
       return {
         ...state,
         tabGroups: {
           ...state.tabGroups,
-          [groupId]: { ...group, tabs: newTabs, activeTabId: newActiveTabId }
+          [groupId]: { ...pruned, tabs: newTabs, activeTabId: newActiveTabId }
         }
       }
     }
@@ -330,12 +321,14 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       if (!group.tabs.find((t) => t.id === tabId)) return state
 
       const tabsToKeep = group.tabs.filter((t) => t.id === tabId || t.isPinned)
+      const removedIds = new Set(group.tabs.filter((t) => !tabsToKeep.includes(t)).map((t) => t.id))
+      const pruned = pruneHistory(group, removedIds)
 
       return {
         ...state,
         tabGroups: {
           ...state.tabGroups,
-          [groupId]: { ...group, tabs: tabsToKeep, activeTabId: tabId }
+          [groupId]: { ...pruned, tabs: tabsToKeep, activeTabId: tabId }
         }
       }
     }
@@ -350,12 +343,14 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       if (tabIndex === -1) return state
 
       const tabsToKeep = group.tabs.filter((t, i) => i <= tabIndex || t.isPinned)
+      const removedIds = new Set(group.tabs.filter((t) => !tabsToKeep.includes(t)).map((t) => t.id))
+      const pruned = pruneHistory(group, removedIds)
 
       return {
         ...state,
         tabGroups: {
           ...state.tabGroups,
-          [groupId]: { ...group, tabs: tabsToKeep }
+          [groupId]: { ...pruned, tabs: tabsToKeep }
         }
       }
     }
@@ -374,18 +369,27 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
           return {
             ...state,
             tabGroups: {
-              [groupId]: { ...group, tabs: [defaultTab], activeTabId: defaultTab.id }
+              [groupId]: {
+                ...group,
+                tabs: [defaultTab],
+                activeTabId: defaultTab.id,
+                back: [],
+                forward: []
+              }
             }
           }
         }
         return closeGroup(state, groupId)
       }
 
+      const removedIds = new Set(group.tabs.filter((t) => !t.isPinned).map((t) => t.id))
+      const pruned = pruneHistory(group, removedIds)
+
       return {
         ...state,
         tabGroups: {
           ...state.tabGroups,
-          [groupId]: { ...group, tabs: pinnedTabs, activeTabId: pinnedTabs[0]?.id || null }
+          [groupId]: { ...pruned, tabs: pinnedTabs, activeTabId: pinnedTabs[0]?.id || null }
         }
       }
     }

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-nav-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-nav-reducer.ts
@@ -1,4 +1,5 @@
-import type { TabAction, TabSystemState } from '../types'
+import type { TabAction, TabGroup, TabSystemState } from '../types'
+import { recordActivation } from './history-helpers'
 
 type NavAction = Extract<
   TabAction,
@@ -9,8 +10,13 @@ type NavAction = Extract<
       | 'GO_TO_NEXT_TAB'
       | 'GO_TO_PREVIOUS_TAB'
       | 'GO_TO_TAB_INDEX'
+      | 'NAV_BACK'
+      | 'NAV_FORWARD'
   }
 >
+
+const touchActiveTimestamp = (tabs: TabGroup['tabs'], activeTabId: string): TabGroup['tabs'] =>
+  tabs.map((t) => (t.id === activeTabId ? { ...t, lastAccessedAt: Date.now() } : t))
 
 export function tabNavReducer(state: TabSystemState, action: NavAction): TabSystemState {
   switch (action.type) {
@@ -20,16 +26,16 @@ export function tabNavReducer(state: TabSystemState, action: NavAction): TabSyst
 
       if (!group) return state
       if (!group.tabs.find((t) => t.id === tabId)) return state
+      if (group.activeTabId === tabId) {
+        return { ...state, activeGroupId: groupId }
+      }
 
+      const recorded = recordActivation(group, tabId)
       return {
         ...state,
         tabGroups: {
           ...state.tabGroups,
-          [groupId]: {
-            ...group,
-            activeTabId: tabId,
-            tabs: group.tabs.map((t) => (t.id === tabId ? { ...t, lastAccessedAt: Date.now() } : t))
-          }
+          [groupId]: { ...recorded, tabs: touchActiveTimestamp(recorded.tabs, tabId) }
         },
         activeGroupId: groupId
       }
@@ -60,17 +66,12 @@ export function tabNavReducer(state: TabSystemState, action: NavAction): TabSyst
       const nextIndex = (currentIndex + 1) % group.tabs.length
       const nextTab = group.tabs[nextIndex]
 
+      const recorded = recordActivation(group, nextTab.id)
       return {
         ...state,
         tabGroups: {
           ...state.tabGroups,
-          [groupId]: {
-            ...group,
-            activeTabId: nextTab.id,
-            tabs: group.tabs.map((t) =>
-              t.id === nextTab.id ? { ...t, lastAccessedAt: Date.now() } : t
-            )
-          }
+          [groupId]: { ...recorded, tabs: touchActiveTimestamp(recorded.tabs, nextTab.id) }
         }
       }
     }
@@ -85,17 +86,12 @@ export function tabNavReducer(state: TabSystemState, action: NavAction): TabSyst
       const prevIndex = currentIndex === 0 ? group.tabs.length - 1 : currentIndex - 1
       const prevTab = group.tabs[prevIndex]
 
+      const recorded = recordActivation(group, prevTab.id)
       return {
         ...state,
         tabGroups: {
           ...state.tabGroups,
-          [groupId]: {
-            ...group,
-            activeTabId: prevTab.id,
-            tabs: group.tabs.map((t) =>
-              t.id === prevTab.id ? { ...t, lastAccessedAt: Date.now() } : t
-            )
-          }
+          [groupId]: { ...recorded, tabs: touchActiveTimestamp(recorded.tabs, prevTab.id) }
         }
       }
     }
@@ -108,18 +104,93 @@ export function tabNavReducer(state: TabSystemState, action: NavAction): TabSyst
 
       const targetTab = group.tabs[index]
 
+      const recorded = recordActivation(group, targetTab.id)
       return {
         ...state,
         tabGroups: {
           ...state.tabGroups,
-          [groupId]: {
-            ...group,
-            activeTabId: targetTab.id,
-            tabs: group.tabs.map((t) =>
-              t.id === targetTab.id ? { ...t, lastAccessedAt: Date.now() } : t
-            )
-          }
+          [groupId]: { ...recorded, tabs: touchActiveTimestamp(recorded.tabs, targetTab.id) }
         }
+      }
+    }
+
+    case 'NAV_BACK': {
+      const { groupId } = action.payload
+      const group = state.tabGroups[groupId]
+      if (!group || group.back.length === 0) return state
+
+      const tabIds = new Set(group.tabs.map((t) => t.id))
+      let back = group.back
+      let target: string | null = null
+      while (back.length > 0) {
+        const candidate = back[back.length - 1]
+        back = back.slice(0, -1)
+        if (tabIds.has(candidate)) {
+          target = candidate
+          break
+        }
+      }
+      if (target === null) {
+        if (back.length === group.back.length) return state
+        return {
+          ...state,
+          tabGroups: { ...state.tabGroups, [groupId]: { ...group, back } }
+        }
+      }
+
+      const forward = group.activeTabId ? [...group.forward, group.activeTabId] : group.forward
+
+      const updated: TabGroup = {
+        ...group,
+        back,
+        forward,
+        activeTabId: target,
+        tabs: touchActiveTimestamp(group.tabs, target)
+      }
+      return {
+        ...state,
+        tabGroups: { ...state.tabGroups, [groupId]: updated },
+        activeGroupId: groupId
+      }
+    }
+
+    case 'NAV_FORWARD': {
+      const { groupId } = action.payload
+      const group = state.tabGroups[groupId]
+      if (!group || group.forward.length === 0) return state
+
+      const tabIds = new Set(group.tabs.map((t) => t.id))
+      let forward = group.forward
+      let target: string | null = null
+      while (forward.length > 0) {
+        const candidate = forward[forward.length - 1]
+        forward = forward.slice(0, -1)
+        if (tabIds.has(candidate)) {
+          target = candidate
+          break
+        }
+      }
+      if (target === null) {
+        if (forward.length === group.forward.length) return state
+        return {
+          ...state,
+          tabGroups: { ...state.tabGroups, [groupId]: { ...group, forward } }
+        }
+      }
+
+      const back = group.activeTabId ? [...group.back, group.activeTabId] : group.back
+
+      const updated: TabGroup = {
+        ...group,
+        back,
+        forward,
+        activeTabId: target,
+        tabs: touchActiveTimestamp(group.tabs, target)
+      }
+      return {
+        ...state,
+        tabGroups: { ...state.tabGroups, [groupId]: updated },
+        activeGroupId: groupId
       }
     }
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-reorder-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-reorder-reducer.ts
@@ -1,5 +1,6 @@
 import type { TabAction, TabSystemState } from '../types'
 import { closeGroup } from './tab-crud-reducer'
+import { pruneHistory } from './history-helpers'
 
 type ReorderAction = Extract<TabAction, { type: 'REORDER_TABS' | 'MOVE_TAB' }>
 
@@ -35,6 +36,7 @@ export function tabReorderReducer(state: TabSystemState, action: ReorderAction):
       if (!tab) return state
 
       const newFromTabs = fromGroup.tabs.filter((t) => t.id !== tabId)
+      const removedFromHistory = new Set([tabId])
 
       if (newFromTabs.length === 0 && Object.keys(state.tabGroups).length > 1) {
         const newToTabs = [
@@ -68,11 +70,17 @@ export function tabReorderReducer(state: TabSystemState, action: ReorderAction):
         newFromActiveTabId = newFromTabs[newIndex].id
       }
 
+      const fromGroupAfter = pruneHistory(fromGroup, removedFromHistory)
+
       return {
         ...state,
         tabGroups: {
           ...state.tabGroups,
-          [fromGroupId]: { ...fromGroup, tabs: newFromTabs, activeTabId: newFromActiveTabId },
+          [fromGroupId]: {
+            ...fromGroupAfter,
+            tabs: newFromTabs,
+            activeTabId: newFromActiveTabId
+          },
           [toGroupId]: { ...toGroup, tabs: newToTabs, activeTabId: tab.id }
         },
         activeGroupId: toGroupId

--- a/apps/desktop/src/renderer/src/contexts/tabs/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/types.ts
@@ -113,6 +113,10 @@ export interface TabGroup {
   activeTabId: string | null
   /** Is this the focused group? */
   isActive: boolean
+  /** Tab activation history: ids previously active in this group, oldest → newest. In-memory only. */
+  back: string[]
+  /** Forward stack: tab ids re-activatable after a NAV_BACK. */
+  forward: string[]
 }
 
 /**
@@ -220,6 +224,8 @@ export type TabAction =
   | { type: 'GO_TO_NEXT_TAB'; payload: { groupId: string } }
   | { type: 'GO_TO_PREVIOUS_TAB'; payload: { groupId: string } }
   | { type: 'GO_TO_TAB_INDEX'; payload: { index: number; groupId: string } }
+  | { type: 'NAV_BACK'; payload: { groupId: string } }
+  | { type: 'NAV_FORWARD'; payload: { groupId: string } }
 
   // Tab modification
   | { type: 'PIN_TAB'; payload: { tabId: string; groupId: string } }

--- a/apps/desktop/src/renderer/src/hooks/index.ts
+++ b/apps/desktop/src/renderer/src/hooks/index.ts
@@ -20,6 +20,7 @@ export {
 // Note: isMac is also exported from use-keyboard-shortcuts, using that one
 export * from './use-tab-keyboard-shortcuts'
 export * from './use-chord-shortcuts'
+export * from './use-mouse-nav-buttons'
 export * from './use-pane-navigation'
 
 // Accessibility & polish

--- a/apps/desktop/src/renderer/src/hooks/use-chord-shortcuts.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-chord-shortcuts.test.tsx
@@ -56,7 +56,9 @@ const makeGroup = (tabs: Tab[], isActive = true): TabGroup => ({
   id: `group-${Math.random().toString(36).slice(2, 8)}`,
   tabs,
   activeTabId: tabs[0]?.id ?? null,
-  isActive
+  isActive,
+  back: [],
+  forward: []
 })
 
 const makeState = (groups: TabGroup[], layout?: SplitLayout): TabSystemState => {

--- a/apps/desktop/src/renderer/src/hooks/use-mouse-nav-buttons.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-mouse-nav-buttons.test.tsx
@@ -1,0 +1,149 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMouseNavButtons } from './use-mouse-nav-buttons'
+
+const mockTabs = vi.hoisted(() => ({
+  navBack: vi.fn(),
+  navForward: vi.fn(),
+  state: {
+    activeGroupId: 'group-a'
+  }
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabs: () => mockTabs
+}))
+
+type AppNavigationCommand = { direction: 'back' | 'forward' }
+type AppNavigationCallback = (command: AppNavigationCommand) => void
+
+const setAppNavigationMock = (
+  handlerRef: { current: AppNavigationCallback | null },
+  unsubscribe = vi.fn()
+): ReturnType<typeof vi.fn> => {
+  const onAppNavigationCommand = vi.fn((callback: AppNavigationCallback) => {
+    handlerRef.current = callback
+    return unsubscribe
+  })
+
+  ;(
+    window.api as typeof window.api & {
+      onAppNavigationCommand: typeof onAppNavigationCommand
+    }
+  ).onAppNavigationCommand = onAppNavigationCommand
+
+  return onAppNavigationCommand
+}
+
+const dispatchMouseButton = (type: string, button: number): MouseEvent => {
+  const event = new MouseEvent(type, { button, bubbles: true, cancelable: true })
+  act(() => {
+    window.dispatchEvent(event)
+  })
+  return event
+}
+
+const dispatchBrowserKey = (key: string, target: EventTarget = window): KeyboardEvent => {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+  act(() => {
+    target.dispatchEvent(event)
+  })
+  return event
+}
+
+describe('useMouseNavButtons', () => {
+  let appNavigationHandler: { current: AppNavigationCallback | null }
+
+  beforeEach(() => {
+    appNavigationHandler = { current: null }
+    mockTabs.navBack.mockClear()
+    mockTabs.navForward.mockClear()
+    setAppNavigationMock(appNavigationHandler)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('navigates back on side-button mousedown', () => {
+    renderHook(() => useMouseNavButtons())
+
+    const event = dispatchMouseButton('mousedown', 3)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(mockTabs.navBack).toHaveBeenCalledWith('group-a')
+    expect(mockTabs.navForward).not.toHaveBeenCalled()
+  })
+
+  it('also catches side-button mouseup and auxclick fallbacks', () => {
+    vi.useFakeTimers()
+    renderHook(() => useMouseNavButtons())
+
+    const mouseUp = dispatchMouseButton('mouseup', 3)
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    const auxClick = dispatchMouseButton('auxclick', 4)
+
+    expect(mouseUp.defaultPrevented).toBe(true)
+    expect(auxClick.defaultPrevented).toBe(true)
+    expect(mockTabs.navBack).toHaveBeenCalledWith('group-a')
+    expect(mockTabs.navForward).toHaveBeenCalledWith('group-a')
+  })
+
+  it('handles dedicated browser back/forward keys even inside editable content', () => {
+    const editor = document.createElement('div')
+    editor.contentEditable = 'true'
+    document.body.append(editor)
+    renderHook(() => useMouseNavButtons())
+
+    const backEvent = dispatchBrowserKey('BrowserBack', editor)
+    const forwardEvent = dispatchBrowserKey('BrowserForward', editor)
+
+    expect(backEvent.defaultPrevented).toBe(true)
+    expect(forwardEvent.defaultPrevented).toBe(true)
+    expect(mockTabs.navBack).toHaveBeenCalledWith('group-a')
+    expect(mockTabs.navForward).toHaveBeenCalledWith('group-a')
+
+    editor.remove()
+  })
+
+  it('subscribes to native app navigation commands through the preload api', () => {
+    const unsubscribe = vi.fn()
+    const onAppNavigationCommand = setAppNavigationMock(appNavigationHandler, unsubscribe)
+
+    const { unmount } = renderHook(() => useMouseNavButtons())
+
+    expect(onAppNavigationCommand).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      appNavigationHandler.current?.({ direction: 'forward' })
+    })
+
+    expect(mockTabs.navForward).toHaveBeenCalledWith('group-a')
+
+    unmount()
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses duplicate native and mouse fallback commands for the same click', () => {
+    vi.useFakeTimers()
+    renderHook(() => useMouseNavButtons())
+
+    act(() => {
+      appNavigationHandler.current?.({ direction: 'back' })
+    })
+    dispatchMouseButton('mousedown', 3)
+
+    expect(mockTabs.navBack).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    dispatchMouseButton('mousedown', 3)
+
+    expect(mockTabs.navBack).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-mouse-nav-buttons.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-mouse-nav-buttons.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type {
+  AppNavigationCommandEvent,
+  AppNavigationDirection
+} from '@memry/contracts/ipc-channels'
+import { useTabs } from '@/contexts/tabs'
+
+const BACK_BUTTON = 3
+const FORWARD_BUTTON = 4
+const DUPLICATE_SUPPRESSION_MS = 75
+const MOUSE_NAV_EVENTS = ['mousedown', 'mouseup', 'auxclick'] as const
+
+const commandFromMouseButton = (button: number): AppNavigationCommandEvent | null => {
+  if (button === BACK_BUTTON) return { direction: 'back' }
+  if (button === FORWARD_BUTTON) return { direction: 'forward' }
+  return null
+}
+
+const commandFromBrowserKey = (key: string): AppNavigationCommandEvent | null => {
+  if (key === 'BrowserBack' || key === 'GoBack') return { direction: 'back' }
+  if (key === 'BrowserForward' || key === 'GoForward') return { direction: 'forward' }
+  return null
+}
+
+export const useMouseNavButtons = (): void => {
+  const { navBack, navForward, state } = useTabs()
+  const activeGroupId = state.activeGroupId
+  const lastCommandRef = useRef<{ direction: AppNavigationDirection; timestamp: number } | null>(
+    null
+  )
+
+  const navigate = useCallback(
+    (command: AppNavigationCommandEvent): void => {
+      const now = Date.now()
+      const lastCommand = lastCommandRef.current
+      if (
+        lastCommand?.direction === command.direction &&
+        now - lastCommand.timestamp < DUPLICATE_SUPPRESSION_MS
+      ) {
+        return
+      }
+
+      lastCommandRef.current = { direction: command.direction, timestamp: now }
+
+      if (command.direction === 'back') navBack(activeGroupId)
+      else navForward(activeGroupId)
+    },
+    [activeGroupId, navBack, navForward]
+  )
+
+  useEffect(() => {
+    const onMouseNavigation = (e: MouseEvent): void => {
+      const command = commandFromMouseButton(e.button)
+      if (!command) return
+
+      e.preventDefault()
+      e.stopPropagation()
+      navigate(command)
+    }
+
+    MOUSE_NAV_EVENTS.forEach((eventName) =>
+      window.addEventListener(eventName, onMouseNavigation, true)
+    )
+    return () => {
+      MOUSE_NAV_EVENTS.forEach((eventName) =>
+        window.removeEventListener(eventName, onMouseNavigation, true)
+      )
+    }
+  }, [navigate])
+
+  useEffect(() => {
+    const onBrowserKey = (e: KeyboardEvent): void => {
+      const command = commandFromBrowserKey(e.key)
+      if (!command) return
+
+      e.preventDefault()
+      e.stopPropagation()
+      navigate(command)
+    }
+
+    window.addEventListener('keydown', onBrowserKey, true)
+    return () => {
+      window.removeEventListener('keydown', onBrowserKey, true)
+    }
+  }, [navigate])
+
+  useEffect(() => window.api.onAppNavigationCommand(navigate), [navigate])
+}
+
+export default useMouseNavButtons

--- a/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.ts
@@ -11,7 +11,8 @@ import { useKeyboardShortcuts, type KeyboardShortcut } from './use-keyboard-shor
  * Hook providing all tab-related keyboard shortcuts
  */
 export const useTabKeyboardShortcuts = (): void => {
-  const { state, dispatch, openTab, closeTab, pinTab, unpinTab, splitView } = useTabs()
+  const { state, dispatch, openTab, closeTab, pinTab, unpinTab, splitView, navBack, navForward } =
+    useTabs()
 
   const shortcuts = useMemo<KeyboardShortcut[]>(() => {
     const activeGroup = state.tabGroups[state.activeGroupId]
@@ -93,6 +94,22 @@ export const useTabKeyboardShortcuts = (): void => {
           })
         },
         description: 'Previous tab'
+      },
+
+      // Navigate back in tab history (⌘[)
+      {
+        key: '[',
+        modifiers: { meta: true },
+        action: () => navBack(state.activeGroupId),
+        description: 'Navigate back'
+      },
+
+      // Navigate forward in tab history (⌘])
+      {
+        key: ']',
+        modifiers: { meta: true },
+        action: () => navForward(state.activeGroupId),
+        description: 'Navigate forward'
       },
 
       // Go to tab 1-8 (⌘1-8)
@@ -215,7 +232,9 @@ export const useTabKeyboardShortcuts = (): void => {
     closeTab,
     pinTab,
     unpinTab,
-    splitView
+    splitView,
+    navBack,
+    navForward
   ])
 
   useKeyboardShortcuts(shortcuts)

--- a/apps/desktop/src/renderer/src/lib/shortcut-registry.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcut-registry.ts
@@ -124,6 +124,22 @@ export const SHORTCUT_REGISTRY: ShortcutEntry[] = [
     category: 'Tabs',
     defaultBinding: { key: 't', modifiers: { meta: true } }
   },
+  {
+    id: 'tabs.navBack',
+    i18nKey: 'tabs.navBack',
+    label: 'Navigate Back',
+    description: 'Re-activate the previously active tab',
+    category: 'Tabs',
+    defaultBinding: { key: '[', modifiers: { meta: true } }
+  },
+  {
+    id: 'tabs.navForward',
+    i18nKey: 'tabs.navForward',
+    label: 'Navigate Forward',
+    description: 'Redo a back navigation',
+    category: 'Tabs',
+    defaultBinding: { key: ']', modifiers: { meta: true } }
+  },
 
   // Editor
   {

--- a/apps/desktop/tests/setup-dom.ts
+++ b/apps/desktop/tests/setup-dom.ts
@@ -69,6 +69,7 @@ const createMockApi = () => ({
   windowMinimize: vi.fn(),
   windowMaximize: vi.fn(),
   windowClose: vi.fn(),
+  onAppNavigationCommand: vi.fn(() => () => {}),
 
   // Native context menu bridge (main-process IPC in production)
   showContextMenu: vi.fn().mockResolvedValue(null),

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -47,6 +47,10 @@ Promote a preview to a permanent tab by:
 
 Toggle preview mode in [Settings → General → Tab Behavior](/user-guide/settings#general).
 
+## Mouse Navigation
+
+Mouse Back and Forward side buttons move through tab focus history across the whole window, including split panes. Back returns to the previously focused tab; Forward replays the next tab after a Back action. Opening or selecting another tab starts a new history path.
+
 ## Split View
 
 Drag a tab to the left, right, top, or bottom edge of the window to open a second pane.
@@ -73,14 +77,14 @@ Resize ratios persist across sessions.
 
 ### Pane Navigation (Chord)
 
-| Action | Shortcut |
-| --- | --- |
-| Split right | <kbd>⌘</kbd>+<kbd>\\</kbd> |
-| Split down | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>\\</kbd> |
-| Close split pane | <kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>W</kbd> |
-| Focus right pane | <kbd>⌘</kbd>+<kbd>K</kbd>, <kbd>⌘</kbd>+<kbd>→</kbd> |
-| Focus left pane | <kbd>⌘</kbd>+<kbd>K</kbd>, <kbd>⌘</kbd>+<kbd>←</kbd> |
-| Toggle maximize pane | <kbd>⌘</kbd>+<kbd>K</kbd>, <kbd>M</kbd> |
+| Action               | Shortcut                                             |
+| -------------------- | ---------------------------------------------------- |
+| Split right          | <kbd>⌘</kbd>+<kbd>\\</kbd>                           |
+| Split down           | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>\\</kbd>              |
+| Close split pane     | <kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>W</kbd>               |
+| Focus right pane     | <kbd>⌘</kbd>+<kbd>K</kbd>, <kbd>⌘</kbd>+<kbd>→</kbd> |
+| Focus left pane      | <kbd>⌘</kbd>+<kbd>K</kbd>, <kbd>⌘</kbd>+<kbd>←</kbd> |
+| Toggle maximize pane | <kbd>⌘</kbd>+<kbd>K</kbd>, <kbd>M</kbd>              |
 
 A chord indicator briefly flashes when the prefix is active. See [Keyboard Shortcuts](/user-guide/keyboard-shortcuts#split-view) for the full list.
 

--- a/packages/contracts/src/ipc-channels.test.ts
+++ b/packages/contracts/src/ipc-channels.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect } from 'vitest'
 import {
+  AppChannels,
   VaultChannels,
   NotesChannels,
   TagsChannels,
@@ -38,6 +39,7 @@ type ChannelGroup = {
 }
 
 const ALL_GROUPS: Array<readonly [string, ChannelGroup]> = [
+  ['AppChannels', AppChannels],
   ['VaultChannels', VaultChannels],
   ['NotesChannels', NotesChannels],
   ['TagsChannels', TagsChannels],
@@ -60,6 +62,7 @@ const ALL_GROUPS: Array<readonly [string, ChannelGroup]> = [
 ]
 
 const GROUP_PREFIXES: Record<string, string> = {
+  AppChannels: 'app:',
   VaultChannels: 'vault:',
   NotesChannels: 'notes:',
   TagsChannels: 'tags:',
@@ -126,6 +129,12 @@ describe('IPC channel constants', () => {
       }
     }
     expect(duplicates).toEqual([])
+  })
+})
+
+describe('AppChannels', () => {
+  it('exposes app navigation command events', () => {
+    expect(AppChannels.events.NAVIGATION_COMMAND).toBe('app:navigation-command')
   })
 })
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -9,6 +9,24 @@
  */
 
 // ============================================================================
+// App Channels
+// ============================================================================
+
+export type AppNavigationDirection = 'back' | 'forward'
+
+export interface AppNavigationCommandEvent {
+  direction: AppNavigationDirection
+}
+
+export const AppChannels = {
+  events: {
+    NAVIGATION_COMMAND: 'app:navigation-command'
+  }
+} as const
+
+export type AppEventChannel = (typeof AppChannels.events)[keyof typeof AppChannels.events]
+
+// ============================================================================
 // Vault Channels
 // ============================================================================
 

--- a/packages/i18n/src/locales/ar/menu.json
+++ b/packages/i18n/src/locales/ar/menu.json
@@ -3,6 +3,10 @@
     "label": "ملف",
     "newNote": "ملاحظة جديدة"
   },
+  "navigation": {
+    "back": "رجوع",
+    "forward": "تقدم"
+  },
   "edit": {
     "label": "تحرير"
   },

--- a/packages/i18n/src/locales/en/menu.json
+++ b/packages/i18n/src/locales/en/menu.json
@@ -7,6 +7,10 @@
     "newNote": "New Note",
     "close": "Close Window"
   },
+  "navigation": {
+    "back": "Back",
+    "forward": "Forward"
+  },
   "edit": {
     "label": "Edit",
     "undo": "Undo",

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -1034,6 +1034,14 @@
         "reopen": {
           "label": "Reopen Last Tab",
           "description": "Reopen the most recently closed tab"
+        },
+        "navBack": {
+          "label": "Navigate Back",
+          "description": "Re-activate the previously active tab"
+        },
+        "navForward": {
+          "label": "Navigate Forward",
+          "description": "Redo a back navigation"
         }
       },
       "editor": {

--- a/packages/i18n/src/locales/tr/menu.json
+++ b/packages/i18n/src/locales/tr/menu.json
@@ -7,6 +7,10 @@
     "newNote": "Yeni Not",
     "close": "Pencereyi Kapat"
   },
+  "navigation": {
+    "back": "Geri",
+    "forward": "İleri"
+  },
   "edit": {
     "label": "Düzenle",
     "undo": "Geri al",

--- a/packages/i18n/src/locales/tr/settings.json
+++ b/packages/i18n/src/locales/tr/settings.json
@@ -1034,6 +1034,14 @@
         "reopen": {
           "label": "Son Tab'i Yeniden Aç",
           "description": "En son kapatılan sekmeyi yeniden aç"
+        },
+        "navBack": {
+          "label": "Geri Git",
+          "description": "Önceki etkin sekmeyi yeniden etkinleştir"
+        },
+        "navForward": {
+          "label": "İleri Git",
+          "description": "Geri navigasyonu yinele"
         }
       },
       "editor": {

--- a/scripts/check-staged-secrets.mjs
+++ b/scripts/check-staged-secrets.mjs
@@ -47,8 +47,16 @@ const tokenPatterns = [
 function normalizeValue(value) {
   return value
     .trim()
+    .replace(/,$/, '')
+    .trim()
     .replace(/^['"]|['"]$/g, '')
     .trim()
+}
+
+function isCodeDeclarationValue(value) {
+  const normalized = normalizeValue(value)
+
+  return normalized.startsWith('() =>') || /^[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$/i.test(normalized)
 }
 
 function isPlaceholderValue(value) {
@@ -120,6 +128,7 @@ export function scanTextForSecrets(filePath, text) {
     if (
       tokenLines.has(index + 1) ||
       key.toUpperCase().includes('PUBLIC_KEY') ||
+      isCodeDeclarationValue(value) ||
       isPlaceholderValue(value)
     ) {
       return

--- a/scripts/check-staged-secrets.test.mjs
+++ b/scripts/check-staged-secrets.test.mjs
@@ -32,6 +32,20 @@ describe('staged secret scanner', () => {
     assert.equal(findings.length, 0)
   })
 
+  it('does not flag code declarations that contain token-like names', () => {
+    const findings = scanTextForSecrets(
+      'packages/contracts/src/ipc-channels.ts',
+      [
+        "SET_API_KEY: 'settings:setApiKey',",
+        'refreshToken: () => Promise<{',
+        '  success: boolean',
+        '}>'
+      ].join('\n')
+    )
+
+    assert.equal(findings.length, 0)
+  })
+
   it('does not scan binary asset paths', () => {
     const findings = scanTextForSecrets(
       'apps/landing/public/demos/inbox.mp4',


### PR DESCRIPTION
## Summary
- Add window-level tab focus history so Back and Forward traverse previously focused tabs across split panes.
- Wire native Electron app-command, swipe, keyboard, and renderer side-button fallbacks into tab history navigation.
- Document mouse navigation and tighten the staged secret scanner so safe IPC/type declarations do not block commits.

## Release note
Add mouse Back and Forward button support for browser-style tab history navigation across split panes.

## Test plan
- Manual: Logitech MX Master Back/Next clicks confirmed working through Electron swipe events.
- `pnpm --filter @memry/desktop test -- --run`
- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts src/main/app-navigation-command.test.ts src/renderer/src/hooks/use-mouse-nav-buttons.test.tsx src/main/menu.test.ts src/renderer/src/contexts/tabs/__tests__/history.test.ts`
- `pnpm ipc:check`
- `pnpm typecheck:desktop`
- `pnpm docs:impact --strict`
- `pnpm docs:build`
- `node --test scripts/check-staged-secrets.test.mjs`
- `git diff --check HEAD^..HEAD`
- Pre-push hook: docs impact/build, package typecheck, desktop lint, IPC check, desktop typecheck, desktop tests, sync-server typecheck/tests.
