### PR TITLE
Support vertical split view parity

### DIFF
--- a/apps/desktop/src/renderer/src/components/split-view/__tests__/split-layout-renderer-day-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/__tests__/split-layout-renderer-day-panel.test.tsx
@@ -1,0 +1,123 @@
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SplitLayout, TabGroup, TabSystemState } from '@/contexts/tabs/types'
+import { SplitLayoutRenderer } from '../split-layout-renderer'
+
+interface CapturedPaneProps {
+  groupId: string
+  reserveDayPanelSpace?: boolean
+}
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  panes: [] as CapturedPaneProps[],
+  state: null as TabSystemState | null
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabs: () => ({
+    state: mocks.state,
+    dispatch: mocks.dispatch
+  })
+}))
+
+vi.mock('../tab-pane-with-drop-zones', () => ({
+  TabPaneWithDropZones: (props: CapturedPaneProps) => {
+    mocks.panes.push(props)
+    return <div data-testid={`pane-${props.groupId}`} />
+  }
+}))
+
+vi.mock('../split-pane', () => ({
+  SplitPane: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+const makeGroup = (id: string): TabGroup => ({
+  id,
+  tabs: [],
+  activeTabId: null,
+  isActive: false,
+  back: [],
+  forward: []
+})
+
+const makeState = (layout: SplitLayout): TabSystemState => ({
+  tabGroups: {
+    g1: makeGroup('g1'),
+    g2: makeGroup('g2'),
+    g3: makeGroup('g3')
+  },
+  layout,
+  activeGroupId: 'g1',
+  settings: { previewMode: false, restoreSessionOnStart: true, tabCloseButton: 'hover' }
+})
+
+describe('SplitLayoutRenderer day panel spacing', () => {
+  beforeEach(() => {
+    mocks.dispatch.mockClear()
+    mocks.panes = []
+  })
+
+  it('does not reserve fixed day panel space inside the left pane of a horizontal split', () => {
+    const layout: SplitLayout = {
+      type: 'split',
+      direction: 'horizontal',
+      ratio: 0.5,
+      first: { type: 'leaf', tabGroupId: 'g1' },
+      second: { type: 'leaf', tabGroupId: 'g2' }
+    }
+    mocks.state = makeState(layout)
+
+    render(<SplitLayoutRenderer layout={layout} path={[]} />)
+
+    expect(mocks.panes).toEqual([
+      expect.objectContaining({ groupId: 'g1', reserveDayPanelSpace: false }),
+      expect.objectContaining({ groupId: 'g2', reserveDayPanelSpace: true })
+    ])
+  })
+
+  it('reserves fixed day panel space for both rows in a vertical split', () => {
+    const layout: SplitLayout = {
+      type: 'split',
+      direction: 'vertical',
+      ratio: 0.5,
+      first: { type: 'leaf', tabGroupId: 'g1' },
+      second: { type: 'leaf', tabGroupId: 'g2' }
+    }
+    mocks.state = makeState(layout)
+
+    render(<SplitLayoutRenderer layout={layout} path={[]} />)
+
+    expect(mocks.panes).toEqual([
+      expect.objectContaining({ groupId: 'g1', reserveDayPanelSpace: true }),
+      expect.objectContaining({ groupId: 'g2', reserveDayPanelSpace: true })
+    ])
+  })
+
+  it('only reserves space for leaves that still touch the outer inline-end edge', () => {
+    const layout: SplitLayout = {
+      type: 'split',
+      direction: 'horizontal',
+      ratio: 0.5,
+      first: { type: 'leaf', tabGroupId: 'g1' },
+      second: {
+        type: 'split',
+        direction: 'vertical',
+        ratio: 0.5,
+        first: { type: 'leaf', tabGroupId: 'g2' },
+        second: { type: 'leaf', tabGroupId: 'g3' }
+      }
+    }
+    mocks.state = makeState(layout)
+
+    render(<SplitLayoutRenderer layout={layout} path={[]} />)
+
+    expect(mocks.panes).toEqual([
+      expect.objectContaining({ groupId: 'g1', reserveDayPanelSpace: false }),
+      expect.objectContaining({ groupId: 'g2', reserveDayPanelSpace: true }),
+      expect.objectContaining({ groupId: 'g3', reserveDayPanelSpace: true })
+    ])
+  })
+})

--- a/apps/desktop/src/renderer/src/components/split-view/__tests__/split-view-axis.test.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/__tests__/split-view-axis.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ResizeHandle } from '../resize-handle'
+import { SplitDropZones } from '../split-drop-zones'
+import { SplitPreview } from '../split-preview'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string) => (key.endsWith('resizePanes') ? 'Resize panes' : key)
+  })
+}))
+
+vi.mock('@dnd-kit/core', () => ({
+  useDroppable: () => ({
+    isOver: true,
+    setNodeRef: vi.fn()
+  })
+}))
+
+describe('split view axis UI', () => {
+  it('renders top and bottom tab drop zones while dragging', () => {
+    render(<SplitDropZones groupId="group-1" isActive />)
+
+    expect(screen.getByText('Split Up')).toBeInTheDocument()
+    expect(screen.getByText('Split Down')).toBeInTheDocument()
+    expect(screen.getByText('Split Left')).toBeInTheDocument()
+    expect(screen.getByText('Split Right')).toBeInTheDocument()
+    expect(screen.getByText('Move Here')).toBeInTheDocument()
+  })
+
+  it('uses vertical preview geometry for top and bottom zones', () => {
+    const { container, rerender } = render(<SplitPreview zone="top" />)
+    const topPreview = container.firstElementChild as HTMLElement
+
+    expect(topPreview.style.height).toBe('50%')
+    expect(topPreview.style.width).toBe('')
+
+    rerender(<SplitPreview zone="bottom" />)
+    const bottomPreview = container.firstElementChild as HTMLElement
+
+    expect(bottomPreview.style.height).toBe('50%')
+    expect(bottomPreview.style.width).toBe('')
+  })
+
+  it('uses horizontal preview geometry for left and right zones', () => {
+    const { container, rerender } = render(<SplitPreview zone="left" />)
+    const leftPreview = container.firstElementChild as HTMLElement
+
+    expect(leftPreview.style.width).toBe('50%')
+    expect(leftPreview.style.height).toBe('')
+
+    rerender(<SplitPreview zone="right" />)
+    const rightPreview = container.firstElementChild as HTMLElement
+
+    expect(rightPreview.style.width).toBe('50%')
+    expect(rightPreview.style.height).toBe('')
+  })
+
+  it('maps split direction to separator orientation for resizing', () => {
+    const { rerender } = render(
+      <ResizeHandle direction="horizontal" isResizing={false} onResizeStart={vi.fn()} />
+    )
+
+    expect(screen.getByRole('separator', { name: 'Resize panes' })).toHaveAttribute(
+      'aria-orientation',
+      'vertical'
+    )
+
+    rerender(<ResizeHandle direction="vertical" isResizing={false} onResizeStart={vi.fn()} />)
+
+    expect(screen.getByRole('separator', { name: 'Resize panes' })).toHaveAttribute(
+      'aria-orientation',
+      'horizontal'
+    )
+  })
+})

--- a/apps/desktop/src/renderer/src/components/split-view/__tests__/tab-pane-with-drop-zones-day-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/__tests__/tab-pane-with-drop-zones-day-panel.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TabPaneWithDropZones } from '../tab-pane-with-drop-zones'
+
+const mocks = vi.hoisted(() => ({
+  group: {
+    id: 'g1',
+    tabs: [
+      {
+        id: 'tab-1',
+        type: 'note',
+        title: 'Note',
+        icon: 'file-text',
+        path: '/note/test',
+        isPinned: false,
+        isModified: false,
+        isPreview: false,
+        isDeleted: false,
+        openedAt: 1,
+        lastAccessedAt: 1
+      }
+    ],
+    activeTabId: 'tab-1',
+    isActive: true,
+    back: [],
+    forward: []
+  },
+  dayPanel: {
+    isOpen: true,
+    width: 320,
+    isResizing: false
+  },
+  dispatch: vi.fn()
+}))
+
+vi.mock('@dnd-kit/core', () => ({
+  useDndMonitor: vi.fn()
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabs: () => ({ dispatch: mocks.dispatch }),
+  useTabGroup: () => mocks.group
+}))
+
+vi.mock('@/contexts/day-panel-context', () => ({
+  useDayPanel: () => mocks.dayPanel
+}))
+
+vi.mock('@/components/tabs', () => ({
+  TabBarWithDrag: () => <div data-testid="tab-bar" />
+}))
+
+vi.mock('../tab-content', () => ({
+  TabContent: () => <div data-testid="tab-content" />
+}))
+
+vi.mock('../empty-pane-state', () => ({
+  EmptyPaneState: () => <div data-testid="empty-pane" />
+}))
+
+vi.mock('../split-preview', () => ({
+  SplitPreview: () => null
+}))
+
+vi.mock('../split-drop-zones', () => ({
+  SplitDropZones: () => null
+}))
+
+describe('TabPaneWithDropZones day panel spacing', () => {
+  beforeEach(() => {
+    mocks.dispatch.mockClear()
+    mocks.dayPanel.isOpen = true
+    mocks.dayPanel.width = 320
+    mocks.dayPanel.isResizing = false
+  })
+
+  it('reserves day panel width only when the pane is allowed to reserve it', () => {
+    const { rerender } = render(<TabPaneWithDropZones groupId="g1" isActive reserveDayPanelSpace />)
+
+    expect(screen.getByTestId('tab-content').parentElement).toHaveStyle({
+      marginInlineEnd: '320px'
+    })
+
+    rerender(<TabPaneWithDropZones groupId="g1" isActive reserveDayPanelSpace={false} />)
+
+    expect(screen.getByTestId('tab-content').parentElement?.style.marginInlineEnd).not.toBe('320px')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/split-view/split-drop-zones.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/split-drop-zones.tsx
@@ -24,16 +24,26 @@ export const SplitDropZones = ({
   return (
     <div className="absolute inset-0 pointer-events-none z-50">
       {/* Left zone - 25% width */}
-      <DropZone zone="left" groupId={groupId} className="absolute left-0 top-0 bottom-0 w-1/4" />
+      <DropZone zone="left" groupId={groupId} className="absolute start-0 inset-y-0 w-1/4" />
 
       {/* Right zone - 25% width */}
-      <DropZone zone="right" groupId={groupId} className="absolute right-0 top-0 bottom-0 w-1/4" />
+      <DropZone zone="right" groupId={groupId} className="absolute end-0 inset-y-0 w-1/4" />
+
+      {/* Top zone - 25% height */}
+      <DropZone zone="top" groupId={groupId} className="absolute top-0 start-1/4 end-1/4 h-1/4" />
+
+      {/* Bottom zone - 25% height */}
+      <DropZone
+        zone="bottom"
+        groupId={groupId}
+        className="absolute bottom-0 start-1/4 end-1/4 h-1/4"
+      />
 
       {/* Center zone - move to this group without splitting */}
       <DropZone
         zone="center"
         groupId={groupId}
-        className="absolute top-0 bottom-0 left-1/4 right-1/4"
+        className="absolute top-1/4 bottom-1/4 start-1/4 end-1/4"
       />
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/split-view/split-layout-renderer.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/split-layout-renderer.tsx
@@ -7,6 +7,7 @@ interface SplitLayoutRendererProps {
   layout: SplitLayout
   path: number[]
   showSidebarToggle?: boolean
+  reserveDayPanelSpace?: boolean
 }
 
 /**
@@ -23,7 +24,8 @@ const getLayoutDirection = (layout: SplitLayout): SplitDirection => {
 export const SplitLayoutRenderer = ({
   layout,
   path,
-  showSidebarToggle = true
+  showSidebarToggle = true,
+  reserveDayPanelSpace = true
 }: SplitLayoutRendererProps): React.JSX.Element | null => {
   const { state, dispatch } = useTabs()
 
@@ -36,6 +38,7 @@ export const SplitLayoutRenderer = ({
         groupId={layout.tabGroupId}
         isActive={state.activeGroupId === layout.tabGroupId}
         showSidebarToggle={showSidebarToggle}
+        reserveDayPanelSpace={reserveDayPanelSpace}
       />
     )
   }
@@ -57,8 +60,14 @@ export const SplitLayoutRenderer = ({
         layout={layout.first}
         path={[...path, 0]}
         showSidebarToggle={showSidebarToggle}
+        reserveDayPanelSpace={direction === 'horizontal' ? false : reserveDayPanelSpace}
       />
-      <SplitLayoutRenderer layout={layout.second} path={[...path, 1]} showSidebarToggle={false} />
+      <SplitLayoutRenderer
+        layout={layout.second}
+        path={[...path, 1]}
+        showSidebarToggle={false}
+        reserveDayPanelSpace={reserveDayPanelSpace}
+      />
     </SplitPane>
   )
 }

--- a/apps/desktop/src/renderer/src/components/split-view/split-layout-renderer.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/split-layout-renderer.tsx
@@ -1,7 +1,7 @@
 import { useTabs } from '@/contexts/tabs'
 import type { SplitDirection, SplitLayout } from '@/contexts/tabs/types'
 import { SplitPane } from './split-pane'
-import { TabPane } from './tab-pane'
+import { TabPaneWithDropZones } from './tab-pane-with-drop-zones'
 
 interface SplitLayoutRendererProps {
   layout: SplitLayout
@@ -32,7 +32,7 @@ export const SplitLayoutRenderer = ({
     if (!group) return null
 
     return (
-      <TabPane
+      <TabPaneWithDropZones
         groupId={layout.tabGroupId}
         isActive={state.activeGroupId === layout.tabGroupId}
         showSidebarToggle={showSidebarToggle}

--- a/apps/desktop/src/renderer/src/components/split-view/tab-pane-with-drop-zones.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-pane-with-drop-zones.tsx
@@ -22,6 +22,8 @@ interface TabPaneWithDropZonesProps {
   isActive: boolean
   /** Whether to show the sidebar collapse toggle (hidden in split panes) */
   showSidebarToggle?: boolean
+  /** Whether this pane should reserve space for the fixed day panel */
+  reserveDayPanelSpace?: boolean
   /** Additional CSS classes */
   className?: string
 }
@@ -33,6 +35,7 @@ export const TabPaneWithDropZones = ({
   groupId,
   isActive,
   showSidebarToggle = true,
+  reserveDayPanelSpace = true,
   className
 }: TabPaneWithDropZonesProps): React.JSX.Element | null => {
   const { dispatch } = useTabs()
@@ -165,7 +168,9 @@ export const TabPaneWithDropZones = ({
           'flex-1 overflow-hidden relative',
           !dayPanelResizing && 'transition-[margin] duration-200 ease-linear'
         )}
-        style={{ marginRight: isDayPanelOpen ? `${dayPanelWidth}px` : 0 }}
+        style={{
+          marginInlineEnd: reserveDayPanelSpace && isDayPanelOpen ? `${dayPanelWidth}px` : 0
+        }}
       >
         {activeTab ? (
           <TabContent tab={activeTab} groupId={groupId} />

--- a/apps/desktop/src/renderer/src/components/split-view/tab-pane-with-drop-zones.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-pane-with-drop-zones.tsx
@@ -20,6 +20,8 @@ interface TabPaneWithDropZonesProps {
   groupId: string
   /** Whether this is the active/focused pane */
   isActive: boolean
+  /** Whether to show the sidebar collapse toggle (hidden in split panes) */
+  showSidebarToggle?: boolean
   /** Additional CSS classes */
   className?: string
 }
@@ -30,6 +32,7 @@ interface TabPaneWithDropZonesProps {
 export const TabPaneWithDropZones = ({
   groupId,
   isActive,
+  showSidebarToggle = true,
   className
 }: TabPaneWithDropZonesProps): React.JSX.Element | null => {
   const { dispatch } = useTabs()
@@ -154,7 +157,7 @@ export const TabPaneWithDropZones = ({
       data-pane-active={isActive}
     >
       {/* Tab bar */}
-      <TabBarWithDrag groupId={groupId} />
+      <TabBarWithDrag groupId={groupId} showSidebarToggle={showSidebarToggle} />
 
       {/* Content area */}
       <div

--- a/apps/desktop/src/renderer/src/components/tabs/tab-context-menu.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-context-menu.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TabProvider, useTabs } from '@/contexts/tabs'
+import type { SplitLayout, Tab, TabGroup, TabSystemState } from '@/contexts/tabs/types'
+import { TabContextMenu } from './tab-context-menu'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string) => {
+      if (key.endsWith('splitDown')) return 'Split Down'
+      if (key.endsWith('splitRight')) return 'Split Right'
+      return key
+    }
+  })
+}))
+
+const makeTab = (overrides: Partial<Tab> = {}): Tab => ({
+  id: `tab-${Math.random().toString(36).slice(2, 8)}`,
+  type: 'note',
+  title: 'Test Note',
+  icon: 'file-text',
+  path: '/note/test',
+  entityId: `entity-${Math.random().toString(36).slice(2, 8)}`,
+  isPinned: false,
+  isModified: false,
+  isPreview: false,
+  isDeleted: false,
+  openedAt: Date.now(),
+  lastAccessedAt: Date.now(),
+  ...overrides
+})
+
+const makeGroup = (tabs: Tab[]): TabGroup => ({
+  id: `group-${Math.random().toString(36).slice(2, 8)}`,
+  tabs,
+  activeTabId: tabs[0]?.id ?? null,
+  isActive: true,
+  back: [],
+  forward: []
+})
+
+const makeState = (groups: TabGroup[], layout?: SplitLayout): TabSystemState => {
+  const tabGroups: Record<string, TabGroup> = {}
+  groups.forEach((group) => {
+    tabGroups[group.id] = group
+  })
+  return {
+    tabGroups,
+    layout: layout ?? { type: 'leaf', tabGroupId: groups[0].id },
+    activeGroupId: groups[0].id,
+    settings: { previewMode: false, restoreSessionOnStart: true, tabCloseButton: 'hover' }
+  }
+}
+
+const Capture = ({ onState }: { onState: (state: TabSystemState) => void }): null => {
+  const { state } = useTabs()
+  onState(state)
+  return null
+}
+
+describe('TabContextMenu', () => {
+  it('creates a vertical split for Split Down', async () => {
+    const firstTab = makeTab({ title: 'First' })
+    const secondTab = makeTab({ title: 'Second' })
+    const group = makeGroup([firstTab, secondTab])
+    const initialState = makeState([group])
+    let latestState = initialState
+
+    ;(
+      window as unknown as {
+        api: {
+          showContextMenu: ReturnType<typeof vi.fn>
+          onSettingsChanged: ReturnType<typeof vi.fn>
+        }
+      }
+    ).api = {
+      showContextMenu: vi.fn().mockResolvedValue('split-down'),
+      onSettingsChanged: vi.fn(() => vi.fn())
+    }
+
+    render(
+      <TabProvider initialState={initialState}>
+        <Capture onState={(state) => (latestState = state)} />
+        <TabContextMenu tab={secondTab} groupId={group.id}>
+          <button type="button">Second</button>
+        </TabContextMenu>
+      </TabProvider>
+    )
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'Second' }))
+
+    await waitFor(() => {
+      expect(latestState.layout.type).toBe('split')
+      if (latestState.layout.type === 'split') {
+        expect(latestState.layout.direction).toBe('vertical')
+      }
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tabs/tab-context-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-context-menu.tsx
@@ -92,7 +92,7 @@ export const TabContextMenu = ({
         case 'split-down':
           dispatch({
             type: 'MOVE_TAB_TO_NEW_SPLIT',
-            payload: { tabId: tab.id, fromGroupId: groupId, direction: 'horizontal' }
+            payload: { tabId: tab.id, fromGroupId: groupId, direction: 'down' }
           })
           break
         case 'copy-path':

--- a/apps/desktop/src/renderer/src/components/tabs/tab-drag-provider.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-drag-provider.tsx
@@ -45,6 +45,7 @@ export const TabDragProvider = ({ children }: TabDragProviderProps): React.JSX.E
       setActiveTab(null)
 
       if (!over || active.id === over.id) return
+      if (over.data.current?.type === 'split-zone') return
 
       // Get source and target group info
       const sourceGroupId = active.data.current?.groupId as string | undefined

--- a/apps/desktop/src/renderer/src/contexts/drag-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/drag-context.tsx
@@ -174,7 +174,20 @@ const createCollisionDetection = (): CollisionDetection => {
   return (args) => {
     // First check for sidebar drop zones (project, trash, archive)
     const pointerCollisions = pointerWithin(args)
+    const activeType = args.active?.data?.current?.type
     const activeSourceType = args.active?.data?.current?.sourceType
+
+    if (activeType === 'tab') {
+      const splitZoneCollision = pointerCollisions.find((collision) => {
+        const type = collision.data?.droppableContainer?.data?.current?.type
+        return type === 'split-zone'
+      })
+
+      if (splitZoneCollision) {
+        return [splitZoneCollision]
+      }
+    }
+
     const sidebarCollision = pointerCollisions.find((collision) => {
       const type = collision.data?.droppableContainer?.data?.current?.type
       return type === 'project' || type === 'trash' || type === 'archive'

--- a/apps/desktop/src/renderer/src/contexts/tabs/__tests__/reducer.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/__tests__/reducer.test.ts
@@ -385,6 +385,42 @@ describe('tabReducer', () => {
         }
       }
     })
+
+    it('splits the requested target group instead of the source group', () => {
+      const tab1 = makeTab({ title: 'Source Keep' })
+      const tab2 = makeTab({ title: 'Move Me' })
+      const targetTab = makeTab({ title: 'Target' })
+      const g1 = makeGroup([tab1, tab2])
+      const g2 = makeGroup([targetTab], { isActive: false })
+      const layout: SplitLayout = {
+        type: 'split',
+        direction: 'horizontal',
+        ratio: 0.5,
+        first: { type: 'leaf', tabGroupId: g1.id },
+        second: { type: 'leaf', tabGroupId: g2.id }
+      }
+      const state = makeState([g1, g2], layout)
+
+      const result = tabReducer(state, {
+        type: 'MOVE_TAB_TO_NEW_SPLIT',
+        payload: {
+          tabId: tab2.id,
+          fromGroupId: g1.id,
+          targetGroupId: g2.id,
+          direction: 'down'
+        }
+      })
+
+      expect(result.layout.type).toBe('split')
+      if (result.layout.type === 'split') {
+        expect(result.layout.first).toEqual({ type: 'leaf', tabGroupId: g1.id })
+        expect(result.layout.second.type).toBe('split')
+        if (result.layout.second.type === 'split') {
+          expect(result.layout.second.direction).toBe('vertical')
+          expect(result.layout.second.first).toEqual({ type: 'leaf', tabGroupId: g2.id })
+        }
+      }
+    })
   })
 
   describe('TOGGLE_MAXIMIZE_GROUP', () => {

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/layout-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/layout-reducer.ts
@@ -1,6 +1,10 @@
 import type { SplitDirection, SplitLayout, TabAction, TabGroup, TabSystemState } from '../types'
 import { generateId, createDefaultTab } from '../helpers'
-import { insertSplitAtGroup } from '@/components/split-view/layout-helpers'
+import {
+  hasGroupInLayout,
+  insertSplitAtGroup,
+  removeGroupFromLayout
+} from '@/components/split-view/layout-helpers'
 import { closeGroup } from './tab-crud-reducer'
 import { pruneHistory } from './history-helpers'
 
@@ -90,10 +94,23 @@ export function layoutReducer(state: TabSystemState, action: LayoutAction): TabS
     }
 
     case 'MOVE_TAB_TO_NEW_SPLIT': {
-      const { tabId, fromGroupId, direction } = action.payload
+      const {
+        tabId,
+        fromGroupId,
+        targetGroupId = fromGroupId,
+        direction,
+        position
+      } = action.payload
       const fromGroup = state.tabGroups[fromGroupId]
+      const targetGroup = state.tabGroups[targetGroupId]
 
-      if (!fromGroup) return state
+      if (!fromGroup || !targetGroup) return state
+      if (
+        !hasGroupInLayout(state.layout, fromGroupId) ||
+        !hasGroupInLayout(state.layout, targetGroupId)
+      ) {
+        return state
+      }
 
       const tab = fromGroup.tabs.find((t) => t.id === tabId)
       if (!tab) return state
@@ -116,42 +133,34 @@ export function layoutReducer(state: TabSystemState, action: LayoutAction): TabS
 
       // Map direction to split type
       const splitDirection: SplitDirection =
-        direction === 'up' || direction === 'down' ? 'vertical' : 'horizontal'
+        direction === 'up' || direction === 'down' || direction === 'vertical'
+          ? 'vertical'
+          : 'horizontal'
 
-      const isFirst = direction === 'left' || direction === 'up'
-
-      const insertSplit = (layout: typeof state.layout): typeof state.layout => {
-        if (layout.type === 'leaf' && layout.tabGroupId === fromGroupId) {
-          return {
-            type: 'split',
-            direction: splitDirection,
-            ratio: 0.5,
-            first: isFirst
-              ? { type: 'leaf', tabGroupId: newGroup.id }
-              : { type: 'leaf', tabGroupId: fromGroupId },
-            second: isFirst
-              ? { type: 'leaf', tabGroupId: fromGroupId }
-              : { type: 'leaf', tabGroupId: newGroup.id }
-          }
-        }
-        if (layout.type === 'split') {
-          return {
-            ...layout,
-            first: insertSplit(layout.first),
-            second: insertSplit(layout.second)
-          }
-        }
-        return layout
-      }
+      const insertPosition =
+        position ?? (direction === 'left' || direction === 'up' ? 'first' : 'second')
 
       if (newFromTabs.length === 0) {
+        if (targetGroupId === fromGroupId) return state
+
+        const layoutWithoutSource = removeGroupFromLayout(state.layout, fromGroupId)
+        if (!layoutWithoutSource || !hasGroupInLayout(layoutWithoutSource, targetGroupId))
+          return state
+
+        const nextTabGroups = { ...state.tabGroups }
+        delete nextTabGroups[fromGroupId]
+        nextTabGroups[newGroup.id] = { ...newGroup, isActive: true }
+
         return {
           ...state,
-          tabGroups: {
-            ...state.tabGroups,
-            [newGroup.id]: { ...newGroup, isActive: true }
-          },
-          layout: { type: 'leaf', tabGroupId: newGroup.id },
+          tabGroups: nextTabGroups,
+          layout: insertSplitAtGroup(
+            layoutWithoutSource,
+            targetGroupId,
+            newGroup.id,
+            splitDirection,
+            insertPosition
+          ),
           activeGroupId: newGroup.id
         }
       }
@@ -174,7 +183,13 @@ export function layoutReducer(state: TabSystemState, action: LayoutAction): TabS
           },
           [newGroup.id]: newGroup
         },
-        layout: insertSplit(state.layout),
+        layout: insertSplitAtGroup(
+          state.layout,
+          targetGroupId,
+          newGroup.id,
+          splitDirection,
+          insertPosition
+        ),
         activeGroupId: newGroup.id
       }
     }

--- a/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TabProvider, useTabs } from '@/contexts/tabs'
+import type { Tab, TabGroup, TabSystemState } from '@/contexts/tabs/types'
+import { useTabKeyboardShortcuts } from './use-tab-keyboard-shortcuts'
+
+const makeTab = (overrides: Partial<Tab> = {}): Tab => ({
+  id: `tab-${Math.random().toString(36).slice(2, 8)}`,
+  type: 'note',
+  title: 'Test Note',
+  icon: 'file-text',
+  path: '/note/test',
+  entityId: `entity-${Math.random().toString(36).slice(2, 8)}`,
+  isPinned: false,
+  isModified: false,
+  isPreview: false,
+  isDeleted: false,
+  openedAt: Date.now(),
+  lastAccessedAt: Date.now(),
+  ...overrides
+})
+
+const makeGroup = (tabs: Tab[]): TabGroup => ({
+  id: `group-${Math.random().toString(36).slice(2, 8)}`,
+  tabs,
+  activeTabId: tabs[0]?.id ?? null,
+  isActive: true,
+  back: [],
+  forward: []
+})
+
+const makeState = (): TabSystemState => {
+  const group = makeGroup([makeTab()])
+
+  return {
+    tabGroups: { [group.id]: group },
+    layout: { type: 'leaf', tabGroupId: group.id },
+    activeGroupId: group.id,
+    settings: { previewMode: false, restoreSessionOnStart: true, tabCloseButton: 'hover' }
+  }
+}
+
+const Harness = ({ onState }: { onState: (state: TabSystemState) => void }): null => {
+  const { state } = useTabs()
+  useTabKeyboardShortcuts()
+
+  useEffect(() => {
+    onState(state)
+  }, [onState, state])
+
+  return null
+}
+
+describe('useTabKeyboardShortcuts', () => {
+  it('creates a horizontal split for Cmd+\\', async () => {
+    const initialState = makeState()
+    let latestState = initialState
+
+    ;(
+      window as unknown as {
+        api: { onSettingsChanged: ReturnType<typeof vi.fn>; windowClose: ReturnType<typeof vi.fn> }
+      }
+    ).api = {
+      onSettingsChanged: vi.fn(() => vi.fn()),
+      windowClose: vi.fn()
+    }
+
+    render(
+      <TabProvider initialState={initialState}>
+        <Harness onState={(state) => (latestState = state)} />
+      </TabProvider>
+    )
+
+    fireEvent.keyDown(window, { key: '\\', metaKey: true, ctrlKey: true })
+
+    await waitFor(() => {
+      expect(latestState.layout.type).toBe('split')
+      if (latestState.layout.type === 'split') {
+        expect(latestState.layout.direction).toBe('horizontal')
+      }
+    })
+  })
+
+  it('creates a vertical split for Cmd+Shift+\\', async () => {
+    const initialState = makeState()
+    let latestState = initialState
+
+    ;(
+      window as unknown as {
+        api: { onSettingsChanged: ReturnType<typeof vi.fn>; windowClose: ReturnType<typeof vi.fn> }
+      }
+    ).api = {
+      onSettingsChanged: vi.fn(() => vi.fn()),
+      windowClose: vi.fn()
+    }
+
+    render(
+      <TabProvider initialState={initialState}>
+        <Harness onState={(state) => (latestState = state)} />
+      </TabProvider>
+    )
+
+    fireEvent.keyDown(window, { key: '\\', metaKey: true, ctrlKey: true, shiftKey: true })
+
+    await waitFor(() => {
+      expect(latestState.layout.type).toBe('split')
+      if (latestState.layout.type === 'split') {
+        expect(latestState.layout.direction).toBe('vertical')
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fix Split Down to create a vertical top/bottom split.
- Render split-aware tab panes with left, right, top, bottom, and center drop zones.
- Make split-zone drops authoritative and split the hovered target pane instead of falling through to generic tab move/reorder handling.
- Keep fixed right day-panel spacing only on split panes that touch the outer inline-end edge, so opening the right sidebar no longer adds a blank day-panel-width gap inside the left split pane.
- Add reducer, split-view UI, right-sidebar spacing, context-menu, and keyboard shortcut coverage for both axes.

## Validation
- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/contexts/tabs/__tests__/reducer.test.ts src/renderer/src/components/split-view/__tests__ src/renderer/src/components/tabs/tab-context-menu.test.tsx src/renderer/src/hooks/use-tab-keyboard-shortcuts.test.tsx`
- `pnpm docs:impact --strict`
- `git diff --check`

## Known check blockers
- `pnpm --dir apps/desktop typecheck:web` currently fails outside this split-view change: `packages/i18n/src/shared/config.ts(24,3): Object literal may only specify known properties, and "cs" does not exist in type Record<"tr" | "en" | "ar", string>`.
- `pnpm typecheck:desktop` previously stopped before TypeScript on an existing stale IPC invoke map check: `IPC invoke map is out of date`. This PR does not touch IPC/contracts.