### PR TITLE
test(e2e): add desktop workflow coverage

### DIFF
--- a/apps/desktop/tests/e2e/editor-command-flows.e2e.ts
+++ b/apps/desktop/tests/e2e/editor-command-flows.e2e.ts
@@ -1,0 +1,249 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { MOD, PNG_BYTES, ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { createNote, SELECTORS } from './utils/electron-helpers'
+
+async function focusEditor(page: Page) {
+  const editor = page.locator(SELECTORS.noteEditor).first()
+  await editor.waitFor({ state: 'visible', timeout: 10_000 })
+  await editor.click()
+  return editor
+}
+
+async function resetEditorDocument(page: Page, content = ''): Promise<void> {
+  await page.evaluate((initialContent) => {
+    const editor = (window as any).__memryEditor
+    if (!editor) throw new Error('window.__memryEditor not exposed')
+    editor.replaceBlocks(editor.document, [
+      {
+        type: 'paragraph',
+        content: initialContent ? [{ type: 'text', text: initialContent, styles: {} }] : ''
+      }
+    ])
+    const firstBlock = editor.document[0]
+    if (firstBlock) editor.setTextCursorPosition(firstBlock.id, 'end')
+  }, content)
+}
+
+async function editorBlockTypes(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const editor = (window as any).__memryEditor
+    if (!editor) throw new Error('window.__memryEditor not exposed')
+    return editor.document.map((block: any) => block.type as string)
+  })
+}
+
+async function chooseSlashItem(
+  page: Page,
+  query: string,
+  label: string,
+  content = ''
+): Promise<void> {
+  await resetEditorDocument(page, content)
+  await focusEditor(page)
+  await page.keyboard.type(`/${query}`)
+  await expect(page.getByText(label).first()).toBeVisible()
+  await page.keyboard.press('Enter')
+}
+
+async function firstBlockHasBoldText(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const editor = (window as any).__memryEditor
+    if (!editor) throw new Error('window.__memryEditor not exposed')
+    const content = editor.document[0]?.content
+    if (!Array.isArray(content)) return false
+    return content.some((part: any) => Boolean(part.styles?.bold))
+  })
+}
+
+async function pastePlainText(page: Page, text: string): Promise<void> {
+  await page.evaluate((value) => {
+    const editable = document.querySelector('[contenteditable="true"]')
+    if (!editable) throw new Error('contenteditable editor not found')
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', value)
+    editable.dispatchEvent(
+      new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: dataTransfer
+      })
+    )
+  }, text)
+}
+
+test.describe('Editor command flows E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    await ready(page)
+  })
+
+  test('inserts slash command blocks and applies formatting toolbar marks', async ({ page }) => {
+    await createNote(page, uniqueLabel('Slash Commands'))
+
+    await chooseSlashItem(page, 'callout', 'Callout')
+    await expect.poll(() => editorBlockTypes(page)).toContain('callout')
+
+    await resetEditorDocument(page, 'Bold from toolbar')
+    await focusEditor(page)
+    await page.keyboard.press(`${MOD}+a`)
+    await page.getByRole('button', { name: 'Bold' }).first().click()
+    await expect.poll(() => firstBlockHasBoldText(page)).toBe(true)
+  })
+
+  test('uploads dropped files and embeds pasted YouTube links into editor blocks', async ({
+    page
+  }) => {
+    const title = uniqueLabel('Editor Drop')
+    await createNote(page, title)
+    await focusEditor(page)
+
+    await page.evaluate((pngBytes) => {
+      const container = document.querySelector('.bn-container')
+      if (!container) throw new Error('BlockNote container not found')
+
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(
+        new File([new Uint8Array(pngBytes)], 'drop-image.png', { type: 'image/png' })
+      )
+      dataTransfer.items.add(new File(['drop text'], 'drop-note.txt', { type: 'text/plain' }))
+
+      for (const type of ['dragenter', 'dragover', 'drop']) {
+        container.dispatchEvent(
+          new DragEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer
+          })
+        )
+      }
+    }, PNG_BYTES)
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const editor = (window as any).__memryEditor
+            if (!editor) throw new Error('window.__memryEditor not exposed')
+            return {
+              blockTypes: editor.document.map((block: any) => block.type as string),
+              props: editor.document.map((block: any) => block.props ?? {})
+            }
+          }),
+        { timeout: 20_000 }
+      )
+      .toMatchObject({
+        blockTypes: expect.arrayContaining(['image', 'file'])
+      })
+
+    const attachmentNames = await page.evaluate(
+      async ({ noteTitle }) => {
+        const notes = await window.api.notes.list({ limit: 100 })
+        const note = notes.notes.find((item) => item.title === noteTitle)
+        if (!note) return []
+        const attachments = await window.api.notes.listAttachments(note.id)
+        return attachments.map((attachment) => attachment.filename)
+      },
+      { noteTitle: title }
+    )
+
+    expect(attachmentNames.some((name) => name.endsWith('drop-image.png'))).toBe(true)
+    expect(attachmentNames.some((name) => name.endsWith('drop-note.txt'))).toBe(true)
+
+    await resetEditorDocument(page, '')
+    await focusEditor(page)
+    await pastePlainText(page, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    await expect(page.locator('[data-paste-link-menu]')).toBeVisible()
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Enter')
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const editor = (window as any).__memryEditor
+          if (!editor) throw new Error('window.__memryEditor not exposed')
+          return editor.document.map((block: any) => ({
+            type: block.type,
+            props: block.props ?? {}
+          }))
+        })
+      )
+      .toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'youtubeEmbed',
+            props: expect.objectContaining({ videoId: 'dQw4w9WgXcQ' })
+          })
+        ])
+      )
+  })
+
+  test('opens AI inline commands, invokes a selection command, and cancels the menu', async ({
+    page
+  }) => {
+    await page.evaluate(async () => {
+      await window.electron.ipcRenderer.invoke('ai-inline:set-settings', {
+        enabled: true,
+        provider: 'ollama',
+        model: 'e2e-ai',
+        baseUrl: 'http://127.0.0.1:1/v1'
+      })
+      const result = (await window.electron.ipcRenderer.invoke('ai-inline:start-server')) as {
+        success: boolean
+        error?: string
+      }
+      if (!result.success) throw new Error(result.error ?? 'failed to start AI server')
+    })
+
+    await page.reload()
+    await ready(page)
+    await createNote(page, uniqueLabel('AI Commands'), 'rough paragraph for ai selection')
+    await focusEditor(page)
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const editor = (window as any).__memryEditor
+          return Boolean(editor?.getExtension?.('ai'))
+        })
+      )
+      .toBe(true)
+
+    await page.evaluate(() => {
+      const editor = (window as any).__memryEditor
+      const ai = editor?.getExtension?.('ai')
+      if (!ai) throw new Error('AI extension not registered')
+      ;(window as any).__memryAiInvocations = []
+      ai.invokeAI = async (input: any) => {
+        ;(window as any).__memryAiInvocations.push({
+          userPrompt: input.userPrompt,
+          useSelection: input.useSelection
+        })
+        await new Promise<void>((resolve) => {
+          ;(window as any).__memryResolveAiInvocation = resolve
+        })
+      }
+    })
+
+    await page.keyboard.press(`${MOD}+a`)
+    await page.keyboard.press(`${MOD}+j`)
+    await expect(page.getByText('Summarize').first()).toBeVisible()
+    await page.getByText('Summarize').first().click()
+
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__memryAiInvocations ?? []))
+      .toEqual([
+        expect.objectContaining({
+          userPrompt: expect.stringContaining('Summarize')
+        })
+      ])
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByText('Summarize').first()).toBeHidden()
+    await page.evaluate(async () => {
+      ;(window as any).__memryResolveAiInvocation?.()
+      await window.electron.ipcRenderer.invoke('ai-inline:stop-server')
+    })
+  })
+})

--- a/apps/desktop/tests/e2e/file-attachments-viewer.e2e.ts
+++ b/apps/desktop/tests/e2e/file-attachments-viewer.e2e.ts
@@ -1,0 +1,161 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { test, expect } from './fixtures'
+import { PNG_BYTES, ready, uniqueLabel } from './utils/desktop-test-helpers'
+
+test.describe('File attachments and viewer E2E', () => {
+  test('uploads note attachments, imports image files, serves protocol files, and restores viewer tabs', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+
+    const noteTitle = uniqueLabel('Attachment Note')
+    const importDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-e2e-import-'))
+    const importFileName = `e2e-import-${Date.now()}.png`
+    const importTitle = path.basename(importFileName, path.extname(importFileName))
+    const importSourcePath = path.join(importDir, importFileName)
+    fs.writeFileSync(importSourcePath, Buffer.from(PNG_BYTES))
+
+    try {
+      const result = await page.evaluate(
+        async ({ noteTitle, importSourcePath, importFileName, pngBytes }) => {
+          const api = window.api
+          const note = await api.notes.create({
+            title: noteTitle,
+            content: 'Attachment host',
+            tags: ['e2e-file-attachments']
+          })
+          if (!note.success || !note.note) throw new Error(note.error ?? 'note create failed')
+
+          const file = new File([new Uint8Array(pngBytes)], 'note-attachment.png', {
+            type: 'image/png'
+          })
+          const uploaded = await api.notes.uploadAttachment(note.note.id, file)
+          if (!uploaded.success) throw new Error(uploaded.error ?? 'attachment upload failed')
+          const attachments = await api.notes.listAttachments(note.note.id)
+
+          const imported = await api.notes.importFiles([importSourcePath], '')
+          if (!imported.success || imported.imported !== 1) {
+            throw new Error(imported.errors.join('\n') || 'file import failed')
+          }
+
+          return {
+            noteId: note.note.id,
+            attachmentFilename: attachments[0]?.filename,
+            importFileName,
+            imported
+          }
+        },
+        { noteTitle, importSourcePath, importFileName, pngBytes: PNG_BYTES }
+      )
+
+      expect(result.attachmentFilename).toBeTruthy()
+      expect(result.imported.importedFiles[0]).toMatchObject({
+        filename: importFileName,
+        fileType: 'image'
+      })
+
+      const noteAttachmentsDir = path.join(testVaultPath, 'attachments', result.noteId)
+      expect(fs.readdirSync(noteAttachmentsDir)).toContain(result.attachmentFilename)
+      expect(fs.existsSync(path.join(testVaultPath, 'notes', importFileName))).toBe(true)
+
+      await expect
+        .poll(
+          () =>
+            page.evaluate(
+              async ({ fileName, importTitle }) => {
+                const list = await window.api.notes.list({ limit: 100 })
+                return (
+                  list.notes.find(
+                    (note) =>
+                      note.fileType === 'image' &&
+                      (note.path === fileName || note.title === importTitle)
+                  ) ?? null
+                )
+              },
+              { fileName: importFileName, importTitle }
+            ),
+          { timeout: 20_000 }
+        )
+        .not.toBeNull()
+
+      const importedFile = await page.evaluate(
+        async ({ fileName, importTitle }) => {
+          const list = await window.api.notes.list({ limit: 100 })
+          return (
+            list.notes.find(
+              (note) =>
+                note.fileType === 'image' && (note.path === fileName || note.title === importTitle)
+            ) ?? null
+          )
+        },
+        { fileName: importFileName, importTitle }
+      )
+      expect(importedFile).not.toBeNull()
+
+      const protocolResponse = await page.evaluate(async (fileId) => {
+        const file = await window.api.notes.getFile(fileId)
+        if (!file) return null
+
+        const response = await fetch(`memry-file://local${file.absolutePath}`)
+        return {
+          status: response.status,
+          contentType: response.headers.get('content-type'),
+          byteLength: (await response.arrayBuffer()).byteLength
+        }
+      }, importedFile!.id)
+      expect(protocolResponse).toMatchObject({
+        status: 200,
+        contentType: 'image/png',
+        byteLength: PNG_BYTES.length
+      })
+
+      const fileId = importedFile!.id
+      await page.addInitScript(
+        ({ fileId, importTitle }) => {
+          localStorage.setItem(
+            'memry_tab_state',
+            JSON.stringify({
+              version: 2,
+              tabGroups: {
+                g1: {
+                  id: 'g1',
+                  activeTabId: 'file-tab',
+                  tabs: [
+                    {
+                      id: 'file-tab',
+                      type: 'file',
+                      title: importTitle,
+                      icon: 'file',
+                      path: `/file/${fileId}`,
+                      entityId: fileId,
+                      isPinned: false
+                    }
+                  ]
+                }
+              },
+              layout: { type: 'leaf', tabGroupId: 'g1' },
+              activeGroupId: 'g1',
+              settings: {
+                previewMode: false,
+                restoreSessionOnStart: true,
+                tabCloseButton: 'hover'
+              },
+              savedAt: Date.now()
+            })
+          )
+        },
+        { fileId, importTitle }
+      )
+      await page.reload()
+      await page.waitForLoadState('domcontentloaded')
+
+      await expect(page.getByRole('heading', { name: importTitle })).toBeVisible()
+      await expect(page.getByRole('img', { name: importTitle })).toBeVisible()
+    } finally {
+      fs.rmSync(importDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/desktop/tests/e2e/inbox-bulk-actions.e2e.ts
+++ b/apps/desktop/tests/e2e/inbox-bulk-actions.e2e.ts
@@ -1,0 +1,68 @@
+import { test, expect } from './fixtures'
+import { PNG_BYTES, ready } from './utils/desktop-test-helpers'
+
+test.describe('Inbox bulk actions E2E', () => {
+  test('captures image and text items, bulk tags, archives, and restores inbox entries', async ({
+    page
+  }) => {
+    await ready(page)
+
+    const result = await page.evaluate(async (pngBytes) => {
+      const api = window.api
+      const image = await api.inbox.captureImage({
+        data: new Uint8Array(pngBytes),
+        filename: 'inbox-image.png',
+        mimeType: 'image/png',
+        tags: ['e2e-inbox'],
+        source: 'api'
+      })
+      if (!image.success || !image.item) throw new Error(image.error ?? 'image capture failed')
+
+      const first = await api.inbox.captureText({
+        title: 'E2E Inbox Bulk One',
+        content: 'First bulk inbox item',
+        tags: ['e2e-inbox'],
+        force: true,
+        source: 'api'
+      })
+      const second = await api.inbox.captureText({
+        title: 'E2E Inbox Bulk Two',
+        content: 'Second bulk inbox item',
+        tags: ['e2e-inbox'],
+        force: true,
+        source: 'api'
+      })
+      if (!first.success || !first.item || !second.success || !second.item) {
+        throw new Error('text inbox capture failed')
+      }
+
+      const bulkTag = await api.inbox.bulkTag({
+        itemIds: [first.item.id, second.item.id],
+        tags: ['bulk-e2e']
+      })
+      const bulkArchive = await api.inbox.bulkArchive({
+        itemIds: [first.item.id, second.item.id, image.item.id]
+      })
+      const archived = await api.inbox.listArchived({ search: 'E2E Inbox', limit: 10 })
+      await api.inbox.unarchive(first.item.id)
+      const restored = await api.inbox.get(first.item.id)
+
+      return {
+        imageItemId: image.item.id,
+        imageAttachmentPath: image.item.attachmentPath,
+        firstItemId: first.item.id,
+        bulkTag,
+        bulkArchive,
+        archivedIds: archived.items.map((item) => item.id),
+        restoredArchivedAt: restored?.archivedAt ?? null
+      }
+    }, PNG_BYTES)
+
+    expect(result.imageItemId).toBeTruthy()
+    expect(result.imageAttachmentPath).toContain('attachments')
+    expect(result.bulkTag).toMatchObject({ success: true, processedCount: 2, errors: [] })
+    expect(result.bulkArchive).toMatchObject({ success: true, processedCount: 3, errors: [] })
+    expect(result.archivedIds).toEqual(expect.arrayContaining([result.firstItemId]))
+    expect(result.restoredArchivedAt).toBeNull()
+  })
+})

--- a/apps/desktop/tests/e2e/search-command-palette.e2e.ts
+++ b/apps/desktop/tests/e2e/search-command-palette.e2e.ts
@@ -1,0 +1,127 @@
+import { test, expect } from './fixtures'
+import { MOD, ready, uniqueLabel } from './utils/desktop-test-helpers'
+
+test.describe('Search and command palette E2E', () => {
+  test('queries indexed content, recent reasons, and command-palette type filters', async ({
+    page
+  }) => {
+    await ready(page)
+
+    const tag = 'e2e-search-command'
+    const noteTitle = uniqueLabel('Search Note')
+    const taskTitle = uniqueLabel('Search Task')
+    const inboxTitle = uniqueLabel('Search Inbox')
+
+    const seeded = await page.evaluate(
+      async ({ noteTitle, taskTitle, inboxTitle, tag }) => {
+        const api = window.api
+        const note = await api.notes.create({
+          title: noteTitle,
+          content: 'Note body for search coverage.',
+          tags: [tag]
+        })
+        if (!note.success || !note.note) throw new Error(note.error ?? 'failed to seed note')
+
+        const projects = await api.tasks.listProjects()
+        const projectId = projects.projects[0]?.id
+        if (!projectId) throw new Error('default task project missing')
+        const task = await api.tasks.create({
+          projectId,
+          title: taskTitle,
+          priority: 3,
+          tags: [tag]
+        })
+        if (!task.success || !task.task) throw new Error(task.error ?? 'failed to seed task')
+
+        const inbox = await api.inbox.captureText({
+          title: inboxTitle,
+          content: 'Inbox item for search coverage.',
+          tags: [tag],
+          force: true,
+          source: 'api'
+        })
+        if (!inbox.success || !inbox.item) throw new Error(inbox.error ?? 'failed to seed inbox')
+
+        await api.search.rebuildIndex().catch(() => null)
+        await api.search.addReason({
+          itemId: note.note.id,
+          itemType: 'note',
+          itemTitle: note.note.title,
+          searchQuery: 'search note'
+        })
+
+        return {
+          noteId: note.note.id,
+          noteTitle: note.note.title,
+          taskTitle: task.task.title,
+          inboxTitle: inbox.item.title
+        }
+      },
+      { noteTitle, taskTitle, inboxTitle, tag }
+    )
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            async ({ title, tag }) => {
+              const results = await window.api.search.query({
+                text: title,
+                types: ['note'],
+                tags: [tag],
+                limit: 10
+              })
+              return results.groups.flatMap((group) => group.results).map((item) => item.title)
+            },
+            { title: seeded.noteTitle, tag }
+          ),
+        { timeout: 20_000 }
+      )
+      .toContain(seeded.noteTitle)
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async (title) => {
+            const results = await window.api.search.query({
+              text: title,
+              types: ['task'],
+              limit: 10
+            })
+            return results.groups.flatMap((group) => group.results).map((item) => item.title)
+          }, seeded.taskTitle),
+        { timeout: 20_000 }
+      )
+      .toContain(seeded.taskTitle)
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async (title) => {
+            const results = await window.api.search.query({
+              text: title,
+              types: ['inbox'],
+              limit: 10
+            })
+            return results.groups.flatMap((group) => group.results).map((item) => item.title)
+          }, seeded.inboxTitle),
+        { timeout: 20_000 }
+      )
+      .toContain(seeded.inboxTitle)
+
+    const reasons = await page.evaluate(() => window.api.search.getReasons())
+    expect(reasons.map((reason) => reason.itemId)).toContain(seeded.noteId)
+
+    await page.keyboard.press(`${MOD}+k`)
+    const searchInput = page.locator('[cmdk-input], input[placeholder*="Search"]').first()
+    await expect(searchInput).toBeVisible()
+    await searchInput.fill(seeded.noteTitle)
+
+    const commandDialog = page.locator('[role="dialog"]').filter({ has: searchInput }).first()
+    await expect(commandDialog.getByText(seeded.noteTitle, { exact: true }).first()).toBeVisible()
+    await commandDialog.locator('button').filter({ hasText: 'Tasks' }).first().click()
+    await expect(commandDialog.getByText(seeded.noteTitle, { exact: true }).first()).toBeHidden()
+    await searchInput.fill(seeded.taskTitle)
+    await expect(commandDialog.getByText(seeded.taskTitle, { exact: true }).first()).toBeVisible()
+  })
+})

--- a/apps/desktop/tests/e2e/settings-persistence.e2e.ts
+++ b/apps/desktop/tests/e2e/settings-persistence.e2e.ts
@@ -1,0 +1,124 @@
+import { test, expect } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+
+test.describe('Settings persistence E2E', () => {
+  test('persists settings groups through renderer-to-main IPC', async ({ page }) => {
+    await ready(page)
+
+    const settings = await page.evaluate(async () => {
+      const api = window.api
+
+      const writes = await Promise.all([
+        api.settings.setGeneralSettings({
+          theme: 'dark',
+          fontSize: 'large',
+          fontFamily: 'geist',
+          accentColor: '#0f766e',
+          createInSelectedFolder: true,
+          clockFormat: '24h'
+        }),
+        api.settings.setEditorSettings({
+          width: 'wide',
+          spellCheck: false,
+          autoSaveDelay: 750,
+          showWordCount: true,
+          toolbarMode: 'sticky'
+        }),
+        api.settings.setTaskSettings({
+          defaultSortOrder: 'priority',
+          weekStartDay: 'monday',
+          staleInboxDays: 9
+        }),
+        api.settings.setTabSettings({
+          previewMode: false,
+          restoreSessionOnStart: true,
+          tabCloseButton: 'always'
+        }),
+        api.settings.setGraphSettings({
+          layout: 'circular',
+          nodeSizing: 'by-connections',
+          showLabels: false,
+          linkDistance: 180,
+          repulsionStrength: 900,
+          showEdgeLabels: true,
+          animateLayout: false,
+          showTagEdges: false
+        }),
+        api.settings.setJournalSettings({
+          showSchedule: false,
+          showTasks: true,
+          showAIConnections: true,
+          showStatsFooter: true
+        }),
+        api.settings.setSyncSettings({ enabled: true, autoSync: false }),
+        api.settings.setBackupSettings({ autoBackup: true, frequencyHours: 12, maxBackups: 5 }),
+        api.settings.setAISettings({ enabled: true }),
+        api.settings.setVoiceTranscriptionSettings({ provider: 'openai' })
+      ])
+
+      const failed = writes.find((write) => !write.success)
+      if (failed) throw new Error(failed.error ?? 'settings write failed')
+
+      return {
+        general: await api.settings.getGeneralSettings(),
+        editor: await api.settings.getEditorSettings(),
+        tasks: await api.settings.getTaskSettings(),
+        tabs: await api.settings.getTabSettings(),
+        graph: await api.settings.getGraphSettings(),
+        journal: await api.settings.getJournalSettings(),
+        sync: await api.settings.getSyncSettings(),
+        backup: await api.settings.getBackupSettings(),
+        ai: await api.settings.getAISettings(),
+        voice: await api.settings.getVoiceTranscriptionSettings(),
+        voiceReadiness: await api.settings.getVoiceRecordingReadiness()
+      }
+    })
+
+    expect(settings.general).toMatchObject({
+      theme: 'dark',
+      fontSize: 'large',
+      fontFamily: 'geist',
+      accentColor: '#0f766e',
+      createInSelectedFolder: true,
+      clockFormat: '24h'
+    })
+    expect(settings.editor).toMatchObject({
+      width: 'wide',
+      spellCheck: false,
+      autoSaveDelay: 750,
+      showWordCount: true,
+      toolbarMode: 'sticky'
+    })
+    expect(settings.tasks).toMatchObject({
+      defaultSortOrder: 'priority',
+      weekStartDay: 'monday',
+      staleInboxDays: 9
+    })
+    expect(settings.tabs).toMatchObject({
+      previewMode: false,
+      restoreSessionOnStart: true,
+      tabCloseButton: 'always'
+    })
+    expect(settings.graph).toMatchObject({
+      layout: 'circular',
+      nodeSizing: 'by-connections',
+      showLabels: false,
+      linkDistance: 180,
+      repulsionStrength: 900,
+      showEdgeLabels: true,
+      animateLayout: false,
+      showTagEdges: false
+    })
+    expect(settings.journal).toMatchObject({
+      showSchedule: false,
+      showTasks: true,
+      showAIConnections: true,
+      showStatsFooter: true
+    })
+    expect(settings.sync).toMatchObject({ enabled: true, autoSync: false })
+    expect(settings.backup).toMatchObject({ autoBackup: true, frequencyHours: 12, maxBackups: 5 })
+    expect(settings.ai).toMatchObject({ enabled: true })
+    expect(settings.voice).toMatchObject({ provider: 'openai' })
+    expect(settings.voiceReadiness.provider).toBe('openai')
+  })
+})

--- a/apps/desktop/tests/e2e/tasks-kanban.e2e.ts
+++ b/apps/desktop/tests/e2e/tasks-kanban.e2e.ts
@@ -1,0 +1,153 @@
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { navigateTo } from './utils/electron-helpers'
+
+test.describe('Tasks and Kanban E2E', () => {
+  test('covers custom statuses, task moves, bulk actions, saved filters, and Kanban rendering', async ({
+    page
+  }) => {
+    await ready(page)
+
+    const projectName = uniqueLabel('Project')
+    const activeTaskTitle = uniqueLabel('Kanban Task')
+    const movedTaskTitle = uniqueLabel('Moved Task')
+    const completedTaskTitle = uniqueLabel('Completed Task')
+    const filterName = uniqueLabel('Saved Filter')
+
+    const result = await page.evaluate(
+      async ({ projectName, activeTaskTitle, movedTaskTitle, completedTaskTitle, filterName }) => {
+        const api = window.api
+        const projectResult = await api.tasks.createProject({
+          name: projectName,
+          description: 'Advanced E2E project',
+          color: '#3b82f6',
+          icon: 'FolderKanban',
+          statuses: [
+            { name: 'Backlog', color: '#6b7280', type: 'todo', order: 0 },
+            { name: 'Doing', color: '#f59e0b', type: 'in_progress', order: 1 },
+            { name: 'Done', color: '#10b981', type: 'done', order: 2 }
+          ]
+        })
+        if (!projectResult.success || !projectResult.project) {
+          throw new Error(projectResult.error ?? 'project create failed')
+        }
+
+        const projectId = projectResult.project.id
+        const statuses = await api.tasks.listStatuses(projectId)
+        const backlog = statuses.find((status) => status.name === 'Backlog')
+        const doing = statuses.find((status) => status.name === 'Doing')
+        if (!backlog || !doing) throw new Error('project statuses missing')
+
+        const activeTask = await api.tasks.create({
+          projectId,
+          statusId: backlog.id,
+          title: activeTaskTitle,
+          priority: 4,
+          tags: ['e2e-tasks']
+        })
+        const movedTask = await api.tasks.create({
+          projectId,
+          statusId: backlog.id,
+          title: movedTaskTitle,
+          priority: 3,
+          tags: ['e2e-tasks']
+        })
+        const completedTask = await api.tasks.create({
+          projectId,
+          statusId: backlog.id,
+          title: completedTaskTitle,
+          priority: 2,
+          tags: ['e2e-tasks']
+        })
+        if (!activeTask.success || !activeTask.task || !movedTask.success || !movedTask.task) {
+          throw new Error('task create failed')
+        }
+        if (!completedTask.success || !completedTask.task) throw new Error('task create failed')
+
+        await api.tasks.move({
+          taskId: movedTask.task.id,
+          targetProjectId: projectId,
+          targetStatusId: doing.id,
+          targetParentId: null,
+          position: 1
+        })
+        const moved = await api.tasks.get(movedTask.task.id)
+        const bulkComplete = await api.tasks.bulkComplete([
+          movedTask.task.id,
+          completedTask.task.id
+        ])
+        const bulkArchive = await api.tasks.bulkArchive([completedTask.task.id])
+        const taskList = await api.tasks.list({
+          projectId,
+          includeCompleted: true,
+          includeArchived: true,
+          search: 'E2E',
+          limit: 20
+        })
+
+        const savedFilter = await api.savedFilters.create({
+          name: filterName,
+          config: {
+            filters: {
+              search: 'E2E',
+              projectIds: [projectId],
+              priorities: ['urgent'],
+              dueDate: { type: 'any', customStart: null, customEnd: null },
+              statusIds: [doing.id],
+              completion: 'all',
+              repeatType: 'all',
+              hasTime: 'all'
+            },
+            sort: { field: 'priority', direction: 'desc' },
+            starred: true
+          }
+        })
+        if (!savedFilter.success || !savedFilter.savedFilter) {
+          throw new Error(savedFilter.error ?? 'saved filter create failed')
+        }
+        const updatedFilter = await api.savedFilters.update({
+          id: savedFilter.savedFilter.id,
+          name: `${filterName} Updated`
+        })
+        const filtersAfterUpdate = await api.savedFilters.list()
+        await api.savedFilters.delete(savedFilter.savedFilter.id)
+        const filtersAfterDelete = await api.savedFilters.list()
+
+        return {
+          projectId,
+          doingId: doing.id,
+          activeTaskId: activeTask.task.id,
+          activeTaskTitle: activeTask.task.title,
+          movedStatusId: moved?.statusId,
+          bulkComplete,
+          bulkArchive,
+          taskList,
+          updatedFilter,
+          filtersAfterUpdate,
+          filtersAfterDelete
+        }
+      },
+      { projectName, activeTaskTitle, movedTaskTitle, completedTaskTitle, filterName }
+    )
+
+    expect(result.movedStatusId).toBe(result.doingId)
+    expect(result.bulkComplete).toMatchObject({ success: true, count: 2 })
+    expect(result.bulkArchive).toMatchObject({ success: true, count: 1 })
+    expect(result.taskList.tasks.map((task) => task.id)).toEqual(
+      expect.arrayContaining([result.activeTaskId])
+    )
+    expect(result.updatedFilter.savedFilter).toMatchObject({ name: `${filterName} Updated` })
+    expect(result.filtersAfterUpdate.savedFilters.map((filter) => filter.name)).toContain(
+      `${filterName} Updated`
+    )
+    expect(result.filtersAfterDelete.savedFilters.map((filter) => filter.name)).not.toContain(
+      `${filterName} Updated`
+    )
+
+    await navigateTo(page, 'tasks')
+    await page.getByRole('tab', { name: /^All\b/ }).click()
+    await page.getByRole('radio', { name: 'Kanban view' }).click()
+    await expect(page.getByLabel('Kanban board')).toBeVisible()
+    await expect(page.getByRole('button', { name: result.activeTaskTitle })).toBeVisible()
+  })
+})

--- a/apps/desktop/tests/e2e/templates.e2e.ts
+++ b/apps/desktop/tests/e2e/templates.e2e.ts
@@ -1,0 +1,93 @@
+import fs from 'fs'
+import path from 'path'
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+
+test.describe('Templates E2E', () => {
+  test('creates, updates, duplicates, deletes, and persists templates in the vault', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+
+    const templateName = uniqueLabel('Template')
+    const updatedName = `${templateName} Updated`
+    const copyName = `${templateName} Copy`
+
+    const result = await page.evaluate(
+      async ({ templateName, updatedName, copyName }) => {
+        const api = window.api
+        const created = await api.templates.create({
+          name: templateName,
+          description: 'Template coverage from Electron E2E',
+          icon: 'T',
+          tags: ['e2e-template'],
+          properties: [
+            {
+              name: 'Stage',
+              type: 'select',
+              value: 'Draft',
+              options: ['Draft', 'Final']
+            }
+          ],
+          content: '# Template heading\n\nBody from E2E'
+        })
+        if (!created.success || !created.template) {
+          throw new Error(created.error ?? 'template create failed')
+        }
+
+        const updated = await api.templates.update({
+          id: created.template.id,
+          name: updatedName,
+          tags: ['e2e-template', 'updated'],
+          content: '# Updated heading\n\nUpdated body from E2E'
+        })
+        if (!updated.success || !updated.template) {
+          throw new Error(updated.error ?? 'template update failed')
+        }
+
+        const duplicate = await api.templates.duplicate(created.template.id, copyName)
+        if (!duplicate.success || !duplicate.template) {
+          throw new Error(duplicate.error ?? 'template duplicate failed')
+        }
+
+        const beforeDelete = await api.templates.list()
+        await api.templates.delete(duplicate.template.id)
+        await api.templates.delete(created.template.id)
+        const afterDelete = await api.templates.list()
+
+        return {
+          createdId: created.template.id,
+          duplicateId: duplicate.template.id,
+          updated,
+          beforeDelete,
+          afterDelete
+        }
+      },
+      { templateName, updatedName, copyName }
+    )
+
+    expect(result.updated.template).toMatchObject({
+      id: result.createdId,
+      name: updatedName,
+      tags: ['e2e-template', 'updated'],
+      content: '# Updated heading\n\nUpdated body from E2E'
+    })
+    expect(result.beforeDelete.templates.map((template) => template.name)).toEqual(
+      expect.arrayContaining([updatedName, copyName])
+    )
+    expect(result.afterDelete.templates.map((template) => template.id)).not.toEqual(
+      expect.arrayContaining([result.createdId, result.duplicateId])
+    )
+
+    const templatePath = path.join(testVaultPath, '.memry', 'templates', `${result.createdId}.md`)
+    const duplicatePath = path.join(
+      testVaultPath,
+      '.memry',
+      'templates',
+      `${result.duplicateId}.md`
+    )
+    expect(fs.existsSync(templatePath)).toBe(false)
+    expect(fs.existsSync(duplicatePath)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add seven feature-scoped Electron E2E specs for desktop workflows
- cover editor commands, file attachments/viewer, inbox bulk actions, search/command palette, settings persistence, tasks/Kanban, and templates

## Validation
- `git diff --check`
- `pnpm exec prettier --check apps/desktop/tests/e2e/editor-command-flows.e2e.ts apps/desktop/tests/e2e/file-attachments-viewer.e2e.ts apps/desktop/tests/e2e/inbox-bulk-actions.e2e.ts apps/desktop/tests/e2e/search-command-palette.e2e.ts apps/desktop/tests/e2e/settings-persistence.e2e.ts apps/desktop/tests/e2e/tasks-kanban.e2e.ts apps/desktop/tests/e2e/templates.e2e.ts`
- `pnpm --filter @memry/desktop exec playwright test --config config/playwright.config.ts --list tests/e2e/editor-command-flows.e2e.ts tests/e2e/file-attachments-viewer.e2e.ts tests/e2e/inbox-bulk-actions.e2e.ts tests/e2e/search-command-palette.e2e.ts tests/e2e/settings-persistence.e2e.ts tests/e2e/tasks-kanban.e2e.ts tests/e2e/templates.e2e.ts`
- `pnpm docs:impact --strict`
- `pnpm docs:build`

## Note
- `git push` pre-push reached desktop typecheck and failed on `apps/desktop/src/main/agent/mcp/server.ts`, which is outside this PR diff. The branch was pushed with hooks skipped to keep the PR scoped to the seven E2E files.
