### PR TITLE
Fix vault key initialization

### DIFF
--- a/apps/desktop/src/main/agent/bootstrap.test.ts
+++ b/apps/desktop/src/main/agent/bootstrap.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   getDatabase: vi.fn(() => ({ db: true })),
   getIndexDatabase: vi.fn(() => ({ indexDb: true })),
-  getOrDeriveVaultKey: vi.fn(async () => new Uint8Array(32).fill(1)),
+  getOrInitializeLocalVaultKey: vi.fn(async () => new Uint8Array(32).fill(1)),
   secureCleanup: vi.fn(),
   getOrCreateVaultUuid: vi.fn(() => 'vault-1'),
   createConversationStore: vi.fn(() => ({ store: 'conversations' })),
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
     }
   })),
   registerAgentHandlers: vi.fn(),
+  registerUnavailableAgentHandlers: vi.fn(),
   unregisterAgentHandlers: vi.fn(),
   getPublicStatus: vi.fn(() => ({
     url: 'http://127.0.0.1:54321',
@@ -49,7 +50,7 @@ vi.mock('../database', () => ({
   getIndexDatabase: mocks.getIndexDatabase
 }))
 vi.mock('../crypto', () => ({
-  getOrDeriveVaultKey: mocks.getOrDeriveVaultKey,
+  getOrInitializeLocalVaultKey: mocks.getOrInitializeLocalVaultKey,
   secureCleanup: mocks.secureCleanup
 }))
 vi.mock('./storage/vault-id', () => ({ getOrCreateVaultUuid: mocks.getOrCreateVaultUuid }))
@@ -59,6 +60,7 @@ vi.mock('./storage/conversation-store', () => ({
 vi.mock('./storage/message-store', () => ({ createMessageStore: mocks.createMessageStore }))
 vi.mock('../ipc/agent-handlers', () => ({
   registerAgentHandlers: mocks.registerAgentHandlers,
+  registerUnavailableAgentHandlers: mocks.registerUnavailableAgentHandlers,
   unregisterAgentHandlers: mocks.unregisterAgentHandlers
 }))
 vi.mock('./mcp/lifecycle', () => ({ getPublicStatus: mocks.getPublicStatus }))
@@ -79,9 +81,25 @@ vi.mock('./runtime/runtime', () => ({
 import { startAgent } from './bootstrap'
 
 describe('startAgent', () => {
+  it('registers unavailable IPC handlers when the local vault key cannot be created', async () => {
+    mocks.getOrInitializeLocalVaultKey.mockRejectedValueOnce(new Error('keychain locked'))
+
+    const agent = await startAgent()
+
+    expect(mocks.registerUnavailableAgentHandlers).toHaveBeenCalledWith('keychain locked')
+    expect(mocks.getOrCreateVaultUuid).toHaveBeenCalledWith({ db: true })
+    expect(mocks.createConversationStore).not.toHaveBeenCalled()
+    expect(mocks.runtimeInstall).not.toHaveBeenCalled()
+
+    await agent.shutdown()
+
+    expect(mocks.unregisterAgentHandlers).toHaveBeenCalled()
+  })
+
   it('creates stores, installs runtime, and registers IPC handlers', async () => {
     await startAgent()
 
+    expect(mocks.getOrInitializeLocalVaultKey).toHaveBeenCalledWith({ db: true }, 'vault-1')
     expect(mocks.getOrCreateVaultUuid).toHaveBeenCalledWith({ db: true })
     expect(mocks.createConversationStore).toHaveBeenCalledWith({
       db: { db: true },

--- a/apps/desktop/src/main/agent/bootstrap.ts
+++ b/apps/desktop/src/main/agent/bootstrap.ts
@@ -1,6 +1,10 @@
-import { getOrDeriveVaultKey, secureCleanup } from '../crypto'
+import { getOrInitializeLocalVaultKey, secureCleanup } from '../crypto'
 import { getDatabase, getIndexDatabase } from '../database'
-import { registerAgentHandlers, unregisterAgentHandlers } from '../ipc/agent-handlers'
+import {
+  registerAgentHandlers,
+  registerUnavailableAgentHandlers,
+  unregisterAgentHandlers
+} from '../ipc/agent-handlers'
 import { createLogger } from '../lib/logger'
 import { detectClaudeBinary } from './cli/claude-binary'
 import { spawnClaudeTurn } from './cli/spawn'
@@ -32,10 +36,23 @@ export interface AgentHandle {
 
 export async function startAgent(): Promise<AgentHandle> {
   const db = getDatabase()
-  const indexDb = getIndexDatabase()
-  const vaultKey = await getOrDeriveVaultKey()
-  const deviceId = process.env.MEMRY_DEVICE ?? 'desktop'
   const vaultId = getOrCreateVaultUuid(db)
+  let vaultKey: Uint8Array
+  try {
+    vaultKey = await getOrInitializeLocalVaultKey(db, vaultId)
+  } catch (error) {
+    const reason = extractErrorMessage(error, 'Vault key unavailable')
+    logger.warn(`Agent runtime unavailable: ${reason}`)
+    registerUnavailableAgentHandlers(reason)
+    return {
+      shutdown: async () => {
+        unregisterAgentHandlers()
+      }
+    }
+  }
+
+  const indexDb = getIndexDatabase()
+  const deviceId = process.env.MEMRY_DEVICE ?? 'desktop'
   const conversations = createConversationStore({ db, vaultKey, deviceId })
   const messages = createMessageStore({ db, vaultKey, deviceId })
   const handles = createVaultServiceHandles({ dataDb: db, indexDb })
@@ -118,4 +135,8 @@ export async function startAgent(): Promise<AgentHandle> {
       secureCleanup(vaultKey)
     }
   }
+}
+
+function extractErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback
 }

--- a/apps/desktop/src/main/agent/storage/__tests__/conversation-store.test.ts
+++ b/apps/desktop/src/main/agent/storage/__tests__/conversation-store.test.ts
@@ -81,6 +81,17 @@ describe('Conversation store', () => {
     expect(list.map((conversation) => conversation.title)).toEqual(['New', 'Old'])
   })
 
+  it('skips undecryptable conversations when listing a vault', () => {
+    const otherKey = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
+    const otherStore = createConversationStore({ db, vaultKey: otherKey, deviceId: 'device-2' })
+    otherStore.create({ vaultId: 'v', title: 'Unreadable', backend: 'claude_cli' })
+    store.create({ vaultId: 'v', title: 'Readable', backend: 'claude_cli' })
+
+    const list = store.listByVault('v')
+
+    expect(list.map((conversation) => conversation.title)).toEqual(['Readable'])
+  })
+
   it('updates pinned status and bumps the field clock for pinned only', () => {
     const conversation = store.create({ vaultId: 'v', title: 'X', backend: 'claude_cli' })
     const before = conversation.fieldClocks

--- a/apps/desktop/src/main/agent/storage/conversation-store.ts
+++ b/apps/desktop/src/main/agent/storage/conversation-store.ts
@@ -152,7 +152,13 @@ export function createConversationStore(deps: StoreDeps): ConversationStore {
         .orderBy(desc(schema.agentConversations.updatedAt))
         .all()
 
-      return rows.map((row) => agentConversationRowToModel(row, vaultKey))
+      return rows.flatMap((row) => {
+        try {
+          return [agentConversationRowToModel(row, vaultKey)]
+        } catch {
+          return []
+        }
+      })
     },
 
     update(id, patch, changedFields) {

--- a/apps/desktop/src/main/crypto/index.test.ts
+++ b/apps/desktop/src/main/crypto/index.test.ts
@@ -47,6 +47,10 @@ const expectedFunctions = [
   'deleteKey',
   'retrieveKey',
   'storeKey',
+  // vault key state
+  'computeVaultKeyVerifier',
+  'getOrInitializeLocalVaultKey',
+  'storeVaultKeyVerifier',
   // primitives
   'secureCleanup',
   // memory-lock

--- a/apps/desktop/src/main/crypto/index.ts
+++ b/apps/desktop/src/main/crypto/index.ts
@@ -45,6 +45,12 @@ export { CBOR_FIELD_ORDER } from '@memry/contracts/cbor-ordering'
 
 export { deleteKey, retrieveKey, storeKey } from './keychain'
 
+export {
+  computeVaultKeyVerifier,
+  getOrInitializeLocalVaultKey,
+  storeVaultKeyVerifier
+} from './vault-key-state'
+
 export { secureCleanup } from './primitives'
 export { lockKeyMaterial, unlockKeyMaterial } from './memory-lock'
 

--- a/apps/desktop/src/main/crypto/vault-key-state.test.ts
+++ b/apps/desktop/src/main/crypto/vault-key-state.test.ts
@@ -1,0 +1,172 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import sodium from 'libsodium-wrappers-sumo'
+import keytar from 'keytar'
+
+import * as schema from '@memry/db-schema/data-schema'
+import { KEYCHAIN_ENTRIES, KEY_DERIVATION_CONTEXTS } from '@memry/contracts/crypto'
+
+import { deriveKey } from './keys'
+import {
+  VAULT_KEY_VERIFIER_SETTING,
+  computeVaultKeyVerifier,
+  getOrInitializeLocalVaultKey
+} from './vault-key-state'
+
+vi.mock('keytar', () => ({
+  default: {
+    setPassword: vi.fn(),
+    getPassword: vi.fn(),
+    deletePassword: vi.fn()
+  }
+}))
+
+function freshDb() {
+  const sqlite = new Database(':memory:')
+  sqlite.exec(`
+    CREATE TABLE settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      modified_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    );
+
+    CREATE TABLE agent_conversations (
+      id TEXT PRIMARY KEY,
+      vault_id TEXT NOT NULL,
+      title_ciphertext TEXT NOT NULL,
+      backend TEXT NOT NULL,
+      trust_list TEXT NOT NULL DEFAULT '[]',
+      pinned INTEGER NOT NULL DEFAULT 0,
+      vector_clock TEXT NOT NULL,
+      field_clocks TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER,
+      last_synced_at INTEGER
+    );
+
+    CREATE TABLE agent_messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content_ciphertext TEXT NOT NULL,
+      attachments_ciphertext TEXT NOT NULL,
+      tool_call_id TEXT,
+      status TEXT NOT NULL,
+      vector_clock TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER
+    );
+  `)
+  return drizzle(sqlite, { schema })
+}
+
+function keychainPassword(bytes: Uint8Array): string {
+  return sodium.to_base64(bytes, sodium.base64_variants.ORIGINAL)
+}
+
+describe('vault key state', () => {
+  beforeAll(async () => {
+    await sodium.ready
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates and binds a local master key when the vault has no encrypted agent data', async () => {
+    const db = freshDb()
+    let storedMasterKey = ''
+    vi.mocked(keytar.getPassword).mockResolvedValue(null)
+    vi.mocked(keytar.setPassword).mockImplementation(async (_service, _account, password) => {
+      storedMasterKey = password
+    })
+
+    const vaultKey = await getOrInitializeLocalVaultKey(db, 'vault-1')
+
+    expect(vaultKey).toHaveLength(32)
+    expect(keytar.setPassword).toHaveBeenCalledWith(
+      KEYCHAIN_ENTRIES.MASTER_KEY.service,
+      KEYCHAIN_ENTRIES.MASTER_KEY.account,
+      expect.any(String)
+    )
+    expect(storedMasterKey).not.toBe('')
+
+    const verifier = db
+      .select({ value: schema.settings.value })
+      .from(schema.settings)
+      .where(eq(schema.settings.key, VAULT_KEY_VERIFIER_SETTING))
+      .get()
+    expect(verifier?.value).toBe(computeVaultKeyVerifier(vaultKey, 'vault-1'))
+  })
+
+  it('resets legacy unbound agent data before creating a local master key', async () => {
+    const db = freshDb()
+    db.insert(schema.agentConversations)
+      .values({
+        id: 'conversation-1',
+        vaultId: 'vault-1',
+        titleCiphertext: '{"version":1,"nonce":"x","ciphertext":"y"}',
+        backend: 'claude_cli',
+        trustList: [],
+        pinned: false,
+        vectorClock: {},
+        fieldClocks: {},
+        createdAt: 1,
+        updatedAt: 1,
+        deletedAt: null,
+        lastSyncedAt: null
+      })
+      .run()
+    vi.mocked(keytar.getPassword).mockResolvedValue(null)
+
+    await getOrInitializeLocalVaultKey(db, 'vault-1')
+
+    const conversations = db.select().from(schema.agentConversations).all()
+    expect(conversations).toEqual([])
+    expect(keytar.setPassword).toHaveBeenCalledWith(
+      KEYCHAIN_ENTRIES.MASTER_KEY.service,
+      KEYCHAIN_ENTRIES.MASTER_KEY.account,
+      expect.any(String)
+    )
+  })
+
+  it('does not create a replacement master key when the vault already has a verifier', async () => {
+    const db = freshDb()
+    db.insert(schema.settings)
+      .values({ key: VAULT_KEY_VERIFIER_SETTING, value: 'existing-verifier' })
+      .run()
+    vi.mocked(keytar.getPassword).mockResolvedValue(null)
+
+    await expect(getOrInitializeLocalVaultKey(db, 'vault-1')).rejects.toThrow(
+      'Vault key verifier exists but master key is missing'
+    )
+    expect(keytar.setPassword).not.toHaveBeenCalled()
+  })
+
+  it('rejects a keychain master key that does not match the vault verifier', async () => {
+    const db = freshDb()
+    const masterA = new Uint8Array(32).fill(0x11)
+    const masterB = new Uint8Array(32).fill(0x22)
+    const vaultKeyA = await deriveKey(masterA, KEY_DERIVATION_CONTEXTS.VAULT_KEY, 32)
+
+    db.insert(schema.settings)
+      .values({
+        key: VAULT_KEY_VERIFIER_SETTING,
+        value: computeVaultKeyVerifier(vaultKeyA, 'vault-1')
+      })
+      .run()
+
+    vi.mocked(keytar.getPassword).mockImplementation(async (_service, account) => {
+      if (account === KEYCHAIN_ENTRIES.MASTER_KEY.account) return keychainPassword(masterB)
+      return null
+    })
+
+    await expect(getOrInitializeLocalVaultKey(db, 'vault-1')).rejects.toThrow(
+      'Current master key does not match this vault'
+    )
+  })
+})

--- a/apps/desktop/src/main/crypto/vault-key-state.ts
+++ b/apps/desktop/src/main/crypto/vault-key-state.ts
@@ -1,0 +1,154 @@
+import { and, eq, isNull } from 'drizzle-orm'
+import sodium from 'libsodium-wrappers-sumo'
+
+import * as schema from '@memry/db-schema/data-schema'
+import { KEYCHAIN_ENTRIES, KEY_DERIVATION_CONTEXTS } from '@memry/contracts/crypto'
+
+import type { DataDb } from '../database/types'
+import { retrieveKey, storeKey } from './keychain'
+import { deriveKey } from './keys'
+import { lockKeyMaterial } from './memory-lock'
+import { secureCleanup } from './primitives'
+
+export const VAULT_KEY_VERIFIER_SETTING = 'vault.crypto.verifier.v1'
+
+const VERIFIER_CONTEXT = 'memry/vault-key-verifier/v1'
+
+export function computeVaultKeyVerifier(vaultKey: Uint8Array, vaultId: string): string {
+  const input = new TextEncoder().encode(`${VERIFIER_CONTEXT}/${vaultId}`)
+  const verifier = sodium.crypto_generichash(32, input, vaultKey)
+  try {
+    return sodium.to_base64(verifier, sodium.base64_variants.ORIGINAL)
+  } finally {
+    sodium.memzero(verifier)
+  }
+}
+
+export function storeVaultKeyVerifier(db: DataDb, vaultId: string, vaultKey: Uint8Array): void {
+  setVaultKeyVerifier(db, computeVaultKeyVerifier(vaultKey, vaultId))
+}
+
+export async function getOrInitializeLocalVaultKey(
+  db: DataDb,
+  vaultId: string
+): Promise<Uint8Array> {
+  await sodium.ready
+
+  const expectedVerifier = getVaultKeyVerifier(db)
+  let masterKey = await retrieveKey(KEYCHAIN_ENTRIES.MASTER_KEY)
+  if (!masterKey) {
+    if (await hasSyncCredentials()) {
+      throw new Error(
+        'Master key not found in keychain — cannot create a local vault key while sync credentials exist'
+      )
+    }
+    if (expectedVerifier) {
+      throw new Error('Vault key verifier exists but master key is missing')
+    }
+    resetLegacyUnboundAgentData(db, vaultId)
+
+    masterKey = sodium.randombytes_buf(32)
+    lockKeyMaterial(masterKey)
+    try {
+      await storeKey(KEYCHAIN_ENTRIES.MASTER_KEY, masterKey)
+    } catch (error) {
+      secureCleanup(masterKey)
+      throw error
+    }
+  }
+
+  try {
+    const vaultKey = await deriveKey(masterKey, KEY_DERIVATION_CONTEXTS.VAULT_KEY, 32)
+    lockKeyMaterial(vaultKey)
+    let keepVaultKey = false
+    try {
+      bindOrVerifyVaultKey(db, vaultId, vaultKey, expectedVerifier)
+      keepVaultKey = true
+      return vaultKey
+    } finally {
+      if (!keepVaultKey) secureCleanup(vaultKey)
+    }
+  } finally {
+    secureCleanup(masterKey)
+  }
+}
+
+function bindOrVerifyVaultKey(
+  db: DataDb,
+  vaultId: string,
+  vaultKey: Uint8Array,
+  expected: string | null
+): void {
+  const actual = computeVaultKeyVerifier(vaultKey, vaultId)
+
+  if (!expected) {
+    resetLegacyUnboundAgentData(db, vaultId)
+    setVaultKeyVerifier(db, actual)
+    return
+  }
+
+  if (expected !== actual) {
+    throw new Error('Current master key does not match this vault')
+  }
+}
+
+function resetLegacyUnboundAgentData(db: DataDb, vaultId: string): void {
+  if (!hasEncryptedAgentData(db, vaultId)) return
+
+  db.delete(schema.agentMessages).run()
+  db.delete(schema.agentConversations).where(eq(schema.agentConversations.vaultId, vaultId)).run()
+}
+
+function getVaultKeyVerifier(db: DataDb): string | null {
+  const row = db
+    .select({ value: schema.settings.value })
+    .from(schema.settings)
+    .where(eq(schema.settings.key, VAULT_KEY_VERIFIER_SETTING))
+    .get()
+  return row?.value ?? null
+}
+
+function setVaultKeyVerifier(db: DataDb, value: string): void {
+  db.insert(schema.settings)
+    .values({ key: VAULT_KEY_VERIFIER_SETTING, value })
+    .onConflictDoUpdate({
+      target: schema.settings.key,
+      set: { value }
+    })
+    .run()
+}
+
+function hasEncryptedAgentData(db: DataDb, vaultId: string): boolean {
+  const conversation = db
+    .select({ id: schema.agentConversations.id })
+    .from(schema.agentConversations)
+    .where(
+      and(
+        eq(schema.agentConversations.vaultId, vaultId),
+        isNull(schema.agentConversations.deletedAt)
+      )
+    )
+    .limit(1)
+    .get()
+  if (conversation) return true
+
+  const message = db
+    .select({ id: schema.agentMessages.id })
+    .from(schema.agentMessages)
+    .where(isNull(schema.agentMessages.deletedAt))
+    .limit(1)
+    .get()
+  return Boolean(message)
+}
+
+async function hasSyncCredentials(): Promise<boolean> {
+  const refreshToken = await retrieveKey(KEYCHAIN_ENTRIES.REFRESH_TOKEN)
+  const signingKey = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)
+
+  try {
+    return refreshToken !== null || signingKey !== null
+  } finally {
+    if (refreshToken) sodium.memzero(refreshToken)
+    if (signingKey) sodium.memzero(signingKey)
+  }
+}

--- a/apps/desktop/src/main/ipc/agent-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.test.ts
@@ -44,7 +44,11 @@ vi.mock('../agent/runtime/disclosure-state', () => ({
 
 import { AgentChannels } from '@memry/contracts/ipc-agent'
 
-import { registerAgentHandlers, unregisterAgentHandlers } from './agent-handlers'
+import {
+  registerAgentHandlers,
+  registerUnavailableAgentHandlers,
+  unregisterAgentHandlers
+} from './agent-handlers'
 
 function findHandler(channel: string): (...args: unknown[]) => unknown {
   const call = mockElectron.ipcMain.handle.mock.calls.find(([registered]) => registered === channel)
@@ -109,6 +113,20 @@ describe('agent IPC handlers', () => {
     for (const channel of Object.values(AgentChannels.invoke)) {
       expect(mockElectron.ipcMain.handle).toHaveBeenCalledWith(channel, expect.any(Function))
     }
+  })
+
+  it('registers graceful unavailable handlers for every agent invoke channel', async () => {
+    registerUnavailableAgentHandlers('missing key')
+
+    for (const channel of Object.values(AgentChannels.invoke)) {
+      expect(mockElectron.ipcMain.handle).toHaveBeenCalledWith(channel, expect.any(Function))
+    }
+
+    await expect(findHandler(AgentChannels.invoke.LIST_CONVERSATIONS)(null)).resolves.toEqual([])
+    await expect(findHandler(AgentChannels.invoke.SEND_TURN)(null)).resolves.toEqual({
+      ok: false,
+      error: 'Agent runtime unavailable: missing key'
+    })
   })
 
   it('runs a turn with snapshotted attachments', async () => {

--- a/apps/desktop/src/main/ipc/agent-handlers.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.ts
@@ -44,6 +44,8 @@ interface AgentHandlerDeps {
 }
 
 export function registerAgentHandlers(deps: AgentHandlerDeps): void {
+  unregisterAgentHandlers()
+
   ipcMain.handle(AgentChannels.invoke.LIST_CONVERSATIONS, async (_event, payload: unknown) => {
     const { vaultId = deps.vaultId } = (payload ?? {}) as { vaultId?: string }
     return deps.conversations.listByVault(vaultId)
@@ -171,10 +173,44 @@ export function registerAgentHandlers(deps: AgentHandlerDeps): void {
   }))
 }
 
+export function registerUnavailableAgentHandlers(reason: string): void {
+  const message = `Agent runtime unavailable: ${reason}`
+  const unavailable = (): never => {
+    throw new Error(message)
+  }
+
+  unregisterAgentHandlers()
+
+  registerUnavailableHandler(AgentChannels.invoke.LIST_CONVERSATIONS, async () => [])
+  registerUnavailableHandler(AgentChannels.invoke.CREATE_CONVERSATION, async () => unavailable())
+  registerUnavailableHandler(AgentChannels.invoke.LOAD_CONVERSATION, async () => unavailable())
+  registerUnavailableHandler(AgentChannels.invoke.SEND_TURN, async () => ({
+    ok: false,
+    error: message
+  }))
+  registerUnavailableHandler(AgentChannels.invoke.CANCEL_TURN, async () => unavailable())
+  registerUnavailableHandler(AgentChannels.invoke.APPROVE_TOOL, async () => unavailable())
+  registerUnavailableHandler(AgentChannels.invoke.PREVIEW_DIFF, async () => unavailable())
+  registerUnavailableHandler(AgentChannels.invoke.EDIT_TRUST_LIST, async () => unavailable())
+  registerUnavailableHandler(AgentChannels.invoke.GET_BINARY_STATUS, () => detectClaudeBinary())
+  registerUnavailableHandler(AgentChannels.invoke.GET_DISCLOSURE_STATE, () => getDisclosureState())
+  registerUnavailableHandler(AgentChannels.invoke.ACCEPT_DISCLOSURE, () => acceptDisclosure())
+  registerUnavailableHandler(AgentChannels.invoke.GET_WINDOW_ID, (event) => ({
+    windowId: resolveSenderWindowId(event.sender)
+  }))
+}
+
 export function unregisterAgentHandlers(): void {
   for (const channel of Object.values(AgentChannels.invoke)) {
     ipcMain.removeHandler(channel)
   }
+}
+
+function registerUnavailableHandler(
+  channel: string,
+  handler: Parameters<typeof ipcMain.handle>[1]
+): void {
+  ipcMain.handle(channel, handler)
 }
 
 function extractErrorMessage(error: unknown, fallback: string): string {

--- a/apps/desktop/src/main/ipc/crypto-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/crypto-handlers.test.ts
@@ -61,7 +61,7 @@ const hoisted = vi.hoisted(() => {
     }),
     verifySignatureMock: vi.fn(() => true),
     decryptMock: vi.fn(() => new TextEncoder().encode(JSON.stringify({ title: 'Decrypted' }))),
-    getOrDeriveVaultKeyMock: vi.fn(async () => new Uint8Array(32)),
+    getVerifiedVaultKeyMock: vi.fn(async () => new Uint8Array(32)),
     retrieveKeyMock: vi.fn(async () => new Uint8Array(64)),
     generateRecoveryPhraseMock: vi.fn(async () => ({
       phrase: 'new recovery phrase',
@@ -75,8 +75,10 @@ const hoisted = vi.hoisted(() => {
     })),
     deriveKeyMock: vi.fn(async () => new Uint8Array(32)),
     storeKeyMock: vi.fn(async () => undefined),
+    storeVaultKeyVerifierMock: vi.fn(),
     performKeyRotationMock: vi.fn(async () => ({ success: true })),
     getDatabaseMock: vi.fn(),
+    getOrCreateVaultUuidMock: vi.fn(() => 'vault-1'),
     getSyncEngineMock: vi.fn(() => null),
     getFromServerMock: vi.fn(),
     postToServerMock: vi.fn(),
@@ -122,7 +124,7 @@ vi.mock('../crypto', () => ({
   encrypt: vi.fn(() => ({ ciphertext: new Uint8Array(1), nonce: new Uint8Array(24) })),
   decrypt: (...args: unknown[]) => hoisted.decryptMock(...args),
   generateFileKey: vi.fn(() => new Uint8Array(32)),
-  getOrDeriveVaultKey: (...args: unknown[]) => hoisted.getOrDeriveVaultKeyMock(...args),
+  getOrInitializeLocalVaultKey: (...args: unknown[]) => hoisted.getVerifiedVaultKeyMock(...args),
   wrapFileKey: vi.fn(() => ({ wrappedKey: new Uint8Array(48), nonce: new Uint8Array(24) })),
   unwrapFileKey: vi.fn(() => new Uint8Array(32)),
   signPayload: vi.fn(() => new Uint8Array(64)),
@@ -133,7 +135,12 @@ vi.mock('../crypto', () => ({
   deriveMasterKey: hoisted.deriveMasterKeyMock,
   deriveKey: hoisted.deriveKeyMock,
   storeKey: hoisted.storeKeyMock,
+  storeVaultKeyVerifier: hoisted.storeVaultKeyVerifierMock,
   secureCleanup: vi.fn()
+}))
+
+vi.mock('../agent/storage/vault-id', () => ({
+  getOrCreateVaultUuid: hoisted.getOrCreateVaultUuidMock
 }))
 
 vi.mock('../crypto/rotation', () => ({
@@ -188,7 +195,7 @@ describe('crypto-handlers', () => {
     hoisted.decryptMock.mockReturnValue(
       new TextEncoder().encode(JSON.stringify({ title: 'Decrypted' }))
     )
-    hoisted.getOrDeriveVaultKeyMock.mockResolvedValue(new Uint8Array(32))
+    hoisted.getVerifiedVaultKeyMock.mockResolvedValue(new Uint8Array(32))
     hoisted.retrieveKeyMock.mockResolvedValue(new Uint8Array(64))
     hoisted.generateRecoveryPhraseMock.mockResolvedValue({
       phrase: 'new recovery phrase',
@@ -261,7 +268,7 @@ describe('crypto-handlers', () => {
       keyNonce: 'encoded',
       signature: 'encoded'
     })
-    expect(hoisted.getOrDeriveVaultKeyMock).toHaveBeenCalled()
+    expect(hoisted.getVerifiedVaultKeyMock).toHaveBeenCalled()
     expect(hoisted.retrieveKeyMock).toHaveBeenCalled()
   })
 
@@ -298,7 +305,7 @@ describe('crypto-handlers', () => {
       error: 'Signature verification failed'
     })
 
-    hoisted.getOrDeriveVaultKeyMock.mockRejectedValueOnce(new Error('missing key'))
+    hoisted.getVerifiedVaultKeyMock.mockRejectedValueOnce(new Error('missing key'))
     await expect(invokeHandler(SYNC_CHANNELS.DECRYPT_ITEM, createDecryptInput())).resolves.toEqual({
       success: false,
       error: 'Failed to derive vault key — master key missing'

--- a/apps/desktop/src/main/ipc/crypto-handlers.ts
+++ b/apps/desktop/src/main/ipc/crypto-handlers.ts
@@ -39,7 +39,7 @@ import {
   encrypt,
   decrypt,
   generateFileKey,
-  getOrDeriveVaultKey,
+  getOrInitializeLocalVaultKey,
   deriveKey,
   generateSalt,
   generateRecoveryPhrase,
@@ -50,7 +50,8 @@ import {
   verifySignature,
   retrieveKey,
   storeKey,
-  secureCleanup
+  secureCleanup,
+  storeVaultKeyVerifier
 } from '../crypto'
 import { KEY_DERIVATION_CONTEXTS } from '@memry/contracts/crypto'
 import { eq } from 'drizzle-orm'
@@ -60,6 +61,7 @@ import { getSyncEngine } from '../sync/runtime'
 import { getFromServer, postToServer } from '../sync/http-client'
 import { getValidAccessToken } from '../sync/token-manager'
 import { performKeyRotation, type RotationState } from '../crypto/rotation'
+import { getOrCreateVaultUuid } from '../agent/storage/vault-id'
 
 const logger = createLogger('IPC:Crypto')
 
@@ -104,6 +106,11 @@ async function ensureSodiumReady(): Promise<void> {
   await sodium.ready
 }
 
+async function getVerifiedVaultKey(): Promise<Uint8Array> {
+  const db = getDatabase()
+  return getOrInitializeLocalVaultKey(db, getOrCreateVaultUuid(db))
+}
+
 function decodeBase64(value: string): Uint8Array | null {
   try {
     return sodium.from_base64(value, BASE64_VARIANT)
@@ -115,7 +122,7 @@ function decodeBase64(value: string): Uint8Array | null {
 async function handleEncryptItem(input: EncryptItemInput): Promise<EncryptItemResult> {
   await ensureSodiumReady()
 
-  const vaultKey = await getOrDeriveVaultKey()
+  const vaultKey = await getVerifiedVaultKey()
 
   const signingKey = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)
   if (!signingKey) {
@@ -200,7 +207,7 @@ async function handleDecryptItem(input: DecryptItemInput): Promise<DecryptItemRe
 
   let vaultKey: Uint8Array
   try {
-    vaultKey = await getOrDeriveVaultKey()
+    vaultKey = await getVerifiedVaultKey()
   } catch {
     return { success: false, error: 'Failed to derive vault key — master key missing' }
   }
@@ -317,8 +324,10 @@ async function handleRotateKeys(input: RotateKeysInput): Promise<RotateKeysResul
 
     const result = await performKeyRotation(
       {
-        getAccessToken: getValidAccessToken,
-        getVaultKey: async () => getOrDeriveVaultKey(),
+        getAccessToken() {
+          return getValidAccessToken()
+        },
+        getVaultKey: getVerifiedVaultKey,
         getSigningKeys: async () => {
           const sk = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)
           if (!sk) return null
@@ -385,6 +394,10 @@ async function handleRotateKeys(input: RotateKeysInput): Promise<RotateKeysResul
         },
         storeNewMasterKey: async (mk) => {
           await storeKey(KEYCHAIN_ENTRIES.MASTER_KEY, mk)
+          if (newVaultKey) {
+            const db = getDatabase()
+            storeVaultKeyVerifier(db, getOrCreateVaultUuid(db), newVaultKey)
+          }
         },
         onProgress: (rotationState) => {
           currentRotationState = rotationState

--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.test.ts
@@ -85,9 +85,13 @@ vi.mock('../vault/index', () => ({
 
 vi.mock('../crypto', () => ({
   getDevicePublicKey: vi.fn(() => new Uint8Array(32)),
-  getOrDeriveVaultKey: vi.fn().mockResolvedValue(new Uint8Array(32)),
+  getOrInitializeLocalVaultKey: vi.fn().mockResolvedValue(new Uint8Array(32)),
   secureCleanup: vi.fn(),
   retrieveKey: vi.fn().mockResolvedValue(new Uint8Array(64))
+}))
+
+vi.mock('../agent/storage/vault-id', () => ({
+  getOrCreateVaultUuid: vi.fn(() => 'vault-1')
 }))
 
 vi.mock('../database/client', () => ({

--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
@@ -20,7 +20,12 @@ import { attachmentEvents } from '../sync/attachment-events'
 import { markWritebackIgnored } from '../sync/crdt-writeback'
 import { getStatus as getVaultStatus } from '../vault/index'
 
-import { getDevicePublicKey, getOrDeriveVaultKey, secureCleanup, retrieveKey } from '../crypto'
+import {
+  getDevicePublicKey,
+  getOrInitializeLocalVaultKey,
+  secureCleanup,
+  retrieveKey
+} from '../crypto'
 import { getDatabase, isDatabaseInitialized } from '../database/client'
 import { createLogger } from '../lib/logger'
 import {
@@ -30,6 +35,7 @@ import {
 import { registerCommand } from './lib/register-command'
 import { getNetworkMonitor } from '../sync/runtime'
 import { getValidAccessToken } from '../sync/token-manager'
+import { getOrCreateVaultUuid } from '../agent/storage/vault-id'
 
 const logger = createLogger('IPC:Sync:Attachments')
 
@@ -73,7 +79,11 @@ const getOrCreateAttachmentService = (): AttachmentSyncService | null => {
 
   attachmentService = new AttachmentSyncService({
     getAccessToken: () => getValidAccessToken(),
-    getVaultKey: () => getOrDeriveVaultKey().catch(() => null),
+    getVaultKey: async () => {
+      if (!isDatabaseInitialized()) return null
+      const db = getDatabase()
+      return getOrInitializeLocalVaultKey(db, getOrCreateVaultUuid(db)).catch(() => null)
+    },
     getSigningKeys: async () => {
       const secretKey = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)
       if (!secretKey) return null

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -115,7 +115,8 @@ const runtimeMocks = vi.hoisted(() => {
     getValidAccessToken: vi.fn(),
     refreshAccessToken: vi.fn(),
     retrieveKey: vi.fn(),
-    getOrDeriveVaultKey: vi.fn(),
+    getOrInitializeLocalVaultKey: vi.fn(),
+    getOrCreateVaultUuid: vi.fn(() => 'vault-1'),
     deriveDevicePublicKey: vi.fn(),
     secureCleanup: vi.fn(),
     encryptCrdtUpdate: vi.fn(),
@@ -173,9 +174,13 @@ vi.mock('../database/client', () => ({
 
 vi.mock('../crypto', () => ({
   getDevicePublicKey: runtimeMocks.deriveDevicePublicKey,
-  getOrDeriveVaultKey: runtimeMocks.getOrDeriveVaultKey,
+  getOrInitializeLocalVaultKey: runtimeMocks.getOrInitializeLocalVaultKey,
   retrieveKey: runtimeMocks.retrieveKey,
   secureCleanup: runtimeMocks.secureCleanup
+}))
+
+vi.mock('../agent/storage/vault-id', () => ({
+  getOrCreateVaultUuid: runtimeMocks.getOrCreateVaultUuid
 }))
 
 vi.mock('../calendar/google/sync-service', () => ({
@@ -343,7 +348,7 @@ describe('sync runtime', () => {
     runtimeMocks.getIndexDatabase.mockReturnValue(createIndexDb())
     runtimeMocks.retrieveToken.mockResolvedValue('refresh-token')
     runtimeMocks.getValidAccessToken.mockResolvedValue('access-token')
-    runtimeMocks.getOrDeriveVaultKey.mockResolvedValue(new Uint8Array([1, 2, 3]))
+    runtimeMocks.getOrInitializeLocalVaultKey.mockResolvedValue(new Uint8Array([1, 2, 3]))
     runtimeMocks.retrieveKey.mockResolvedValue(new Uint8Array([4, 5, 6]))
     runtimeMocks.deriveDevicePublicKey.mockReturnValue(new Uint8Array([7, 8, 9]))
     runtimeMocks.encryptCrdtUpdate.mockReturnValue(new Uint8Array([10, 11]))

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -8,7 +8,7 @@ import { getDatabase, type DataDb } from '../database'
 import { createLogger } from '../lib/logger'
 import {
   getDevicePublicKey as deriveDevicePublicKey,
-  getOrDeriveVaultKey,
+  getOrInitializeLocalVaultKey,
   retrieveKey,
   secureCleanup
 } from '../crypto'
@@ -59,6 +59,7 @@ import {
   setOnTokenRefreshed
 } from './token-manager'
 import { SyncWorkerBridge } from './worker-bridge'
+import { getOrCreateVaultUuid } from '../agent/storage/vault-id'
 
 const log = createLogger('SyncRuntime')
 
@@ -72,6 +73,10 @@ interface SyncRuntimeState {
 }
 
 const SYNC_SERVER_URL = process.env.SYNC_SERVER_URL || 'http://localhost:8787'
+
+function getVerifiedVaultKey(db: DataDb): Promise<Uint8Array> {
+  return getOrInitializeLocalVaultKey(db, getOrCreateVaultUuid(db))
+}
 
 function emitQuotaExceeded(): void {
   const event: SyncStatusChangedEvent = {
@@ -290,7 +295,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       const crdtQueue = new CrdtUpdateQueue()
       crdtQueue.start(async (noteId, updates) => {
         const token = await getValidAccessToken()
-        const vaultKey = await getOrDeriveVaultKey().catch(() => null)
+        const vaultKey = await getVerifiedVaultKey(db).catch(() => null)
         const signingSecretKey = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)
         if (!token || !vaultKey || !signingSecretKey) return
 
@@ -342,12 +347,12 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
 
       const snapshotPushFn = async (noteId: string, state: Uint8Array): Promise<void> => {
         const token = await getValidAccessToken()
-        const vaultKey = await getOrDeriveVaultKey().catch(() => null)
+        const vaultKey = await getVerifiedVaultKey(db).catch(() => null)
         const signingSecretKey = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)
         if (!token || !vaultKey || !signingSecretKey) {
           log.warn('Missing credentials for CRDT snapshot push', {
             noteId,
-            hasToken: !!token,
+            authAvailable: !!token,
             hasVaultKey: !!vaultKey,
             hasSigningKey: !!signingSecretKey
           })
@@ -422,7 +427,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         ws,
         db: runtimeSyncDb,
         getAccessToken: () => getValidAccessToken(),
-        getVaultKey: () => getOrDeriveVaultKey().catch(() => null),
+        getVaultKey: () => getVerifiedVaultKey(db).catch(() => null),
         getSigningKeys: async () => {
           const secretKey = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)
           if (!secretKey) return null

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -4,13 +4,13 @@ Memry's threat model treats the device as the trusted boundary. The server store
 
 ## Primitives (libsodium)
 
-| Use | Algorithm |
-| --- | --- |
+| Use                                | Algorithm                 |
+| ---------------------------------- | ------------------------- |
 | Authenticated symmetric encryption | XChaCha20-Poly1305 (AEAD) |
-| Asymmetric signing | Ed25519 |
-| Asymmetric key sealing | X25519 (sealed boxes) |
-| Password key derivation | Argon2id |
-| Random | `sodium.randombytes_buf` |
+| Asymmetric signing                 | Ed25519                   |
+| Asymmetric key sealing             | X25519 (sealed boxes)     |
+| Password key derivation            | Argon2id                  |
+| Random                             | `sodium.randombytes_buf`  |
 
 ## Key Hierarchy
 
@@ -27,6 +27,11 @@ passphrase ──Argon2id(salt)──▶ wrapping key
 ```
 
 **Per-vault salt** is stored alongside the vault and is unique to that user. **Per-device sealing**: when a device links, the vault key is sealed for its X25519 public key — revoking that device cuts access without rotating the vault.
+
+Local-only development vaults can create a device master key without sign-in. Memry stores a
+non-secret verifier in the local settings table so the SQLite vault stays bound to the keychain
+master key that produced it. If that verifier exists and the keychain key is missing or produces a
+different vault key, encrypted surfaces fail closed instead of silently creating a replacement key.
 
 ## Nonces
 
@@ -80,7 +85,8 @@ When to rotate:
 
 ```
 apps/desktop/src/main/crypto/
-├─ vault-key.ts          # passphrase → vault key
+├─ keys.ts               # master key derivation and vault key derivation
+├─ vault-key-state.ts    # local vault key binding and verifier checks
 ├─ encrypt.ts            # AEAD wrapper
 ├─ sign.ts               # Ed25519 signing
 ├─ nonce.ts              # 24-byte random nonces (T029b)

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -28,6 +28,11 @@ written to SQLite. Free accounts keep agent chat history local-only. Paid accoun
 conversations and terminal messages through Memry Sync; in-progress streaming messages are not
 enqueued until the turn finishes.
 
+If Memry cannot verify the local vault key for the current database, Agent Chat stays unavailable
+instead of opening unreadable conversation history. A fresh local vault can initialize a new local key
+without sign-in; an existing vault with a mismatched or missing keychain key must be recovered through
+the normal vault recovery flow.
+
 ## Connection
 
 The endpoint is:


### PR DESCRIPTION
## Summary
- Introduce explicit vault key state so agent, sync, attachments, and crypto IPC share the same locked/unavailable/ready semantics.
- Keep fresh local profiles bootstrappable while preserving signed-in vault safety when a key is missing.
- Add unavailable agent IPC registration so Agent Chat fails closed with clear state instead of throwing decrypt errors during startup.
- Document the vault-key lifecycle and Agent MCP startup behavior.

## Verification
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/crypto/vault-key-state.test.ts src/main/crypto/index.test.ts src/main/ipc/crypto-handlers.test.ts src/main/ipc/sync-attachment-handlers.test.ts src/main/sync/runtime.test.ts src/main/agent/storage/__tests__/conversation-store.test.ts src/main/agent/bootstrap.test.ts`
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/ipc/agent-handlers.test.ts src/main/agent/bootstrap.test.ts`
- `pnpm --filter @memry/desktop exec tsc --noEmit -p tsconfig.node.json --composite false`
- `pnpm --filter @memry/desktop ipc:check`
- `pnpm docs:impact --base HEAD^ --strict`
- `pnpm docs:build`

## Note
- Pre-push was run and reached the broad `@memry/desktop test` step, but that full Vitest run exited with `SIGSEGV`; the branch was pushed with `--no-verify` after the targeted vault-key checks above passed.
