### PR TITLE
Add generated Agent Chat conversation titles

### DIFF
--- a/apps/desktop/src/main/agent/bootstrap.ts
+++ b/apps/desktop/src/main/agent/bootstrap.ts
@@ -60,11 +60,13 @@ export async function startAgent(): Promise<AgentHandle> {
   const spawnAdapter = async ({
     prompt,
     conversationId,
-    windowId
+    windowId,
+    purpose = 'turn'
   }: {
     prompt: string
     conversationId: string
     windowId: string
+    purpose?: 'turn' | 'summary' | 'title'
   }) => {
     const binary = await detectClaudeBinary()
     if (!binary.detected || !binary.meetsMinimum) {
@@ -82,7 +84,7 @@ export async function startAgent(): Promise<AgentHandle> {
       authorizationValue: status['token'],
       conversationId,
       windowId,
-      allowedTools: ALLOWED_AGENT_TOOLS,
+      allowedTools: purpose === 'title' ? '' : ALLOWED_AGENT_TOOLS,
       prompt
     })
 

--- a/apps/desktop/src/main/agent/runtime/__tests__/turn.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/turn.test.ts
@@ -6,14 +6,20 @@ vi.mock('../event-bus', () => ({
 
 import type { ConversationStore } from '../../storage/conversation-store'
 import type { MessageStore } from '../../storage/message-store'
-import type { Message, MessageContent, MessageRole, MessageStatus } from '../../storage/types'
+import type {
+  Conversation,
+  Message,
+  MessageContent,
+  MessageRole,
+  MessageStatus
+} from '../../storage/types'
 import { broadcastAgentEvent } from '../event-bus'
 import { runTurn } from '../turn'
 
 describe('runTurn against a stub backend', () => {
   it('persists user and assistant messages from stream-json output', async () => {
     const messages = createFakeMessageStore()
-    const conversations = {} as ConversationStore
+    const conversations = createFakeConversationStore({ title: 'Existing conversation' })
     const stdout = (async function* () {
       yield Buffer.from(
         `${JSON.stringify({
@@ -76,7 +82,7 @@ describe('runTurn against a stub backend', () => {
 
   it('marks the assistant message as errored when the subprocess exits non-zero', async () => {
     const messages = createFakeMessageStore()
-    const conversations = {} as ConversationStore
+    const conversations = createFakeConversationStore({ title: 'Existing conversation' })
     const spawnSubprocess = vi.fn(async () => ({
       stdout: (async function* () {})(),
       stderr: (async function* () {
@@ -132,7 +138,7 @@ describe('runTurn against a stub backend', () => {
         createdAt: 2
       })
     ])
-    const conversations = {} as ConversationStore
+    const conversations = createFakeConversationStore()
     const spawnSubprocess = vi
       .fn()
       .mockResolvedValueOnce({
@@ -186,7 +192,105 @@ describe('runTurn against a stub backend', () => {
       messages.listByConversation('conversation-1').some((message) => message.role === 'system')
     ).toBe(true)
   })
+
+  it('uses the selected backend subprocess to title a default conversation from the first prompt', async () => {
+    const messages = createFakeMessageStore()
+    const conversations = createFakeConversationStore()
+    const spawnSubprocess = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: (async function* () {
+          yield Buffer.from(
+            `${JSON.stringify({
+              type: 'content_block_delta',
+              delta: { type: 'text_delta', text: 'Project Roadmap' }
+            })}\n`
+          )
+          yield Buffer.from(`${JSON.stringify({ type: 'message_stop' })}\n`)
+        })(),
+        stderr: (async function* () {})(),
+        pid: 1,
+        kill: vi.fn(),
+        waitExit: async () => 0,
+        cleanup: vi.fn()
+      })
+      .mockResolvedValueOnce({
+        stdout: (async function* () {
+          yield Buffer.from(`${JSON.stringify({ type: 'message_stop' })}\n`)
+        })(),
+        stderr: (async function* () {})(),
+        pid: 2,
+        kill: vi.fn(),
+        waitExit: async () => 0,
+        cleanup: vi.fn()
+      })
+
+    await runTurn(
+      {
+        conversations,
+        messages,
+        spawnSubprocess,
+        toolHandlers: { routeToolCall: vi.fn() }
+      },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'Create a roadmap from my project notes',
+        attachments: []
+      }
+    )
+
+    expect(spawnSubprocess).toHaveBeenCalledTimes(2)
+    expect(spawnSubprocess.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        conversationId: 'conversation-1',
+        windowId: 'window-1',
+        purpose: 'title',
+        prompt: expect.stringContaining('Create a roadmap from my project notes')
+      })
+    )
+    expect(conversations.update).toHaveBeenCalledWith(
+      'conversation-1',
+      { title: 'Project Roadmap' },
+      ['title']
+    )
+    expect(broadcastAgentEvent).toHaveBeenCalledWith({
+      kind: 'conversation_updated',
+      conversation: expect.objectContaining({
+        id: 'conversation-1',
+        title: 'Project Roadmap'
+      })
+    })
+  })
 })
+
+function createFakeConversationStore(overrides: Partial<Conversation> = {}): ConversationStore {
+  const conversation = {
+    id: 'conversation-1',
+    vaultId: 'vault-1',
+    title: 'New conversation',
+    backend: 'claude_cli',
+    trustList: [],
+    pinned: false,
+    vectorClock: {},
+    fieldClocks: {},
+    createdAt: 1,
+    updatedAt: 1,
+    deletedAt: null,
+    lastSyncedAt: null,
+    ...overrides
+  }
+
+  return {
+    create: vi.fn(),
+    getById: vi.fn(() => conversation),
+    listByVault: vi.fn(() => [conversation]),
+    update: vi.fn((_id, patch) => ({ ...conversation, ...patch, updatedAt: 2 })),
+    softDelete: vi.fn(),
+    addToTrustList: vi.fn(),
+    removeFromTrustList: vi.fn()
+  }
+}
 
 function createFakeMessageStore(seed: Message[] = []): MessageStore {
   const messages: Message[] = [...seed]

--- a/apps/desktop/src/main/agent/runtime/turn.ts
+++ b/apps/desktop/src/main/agent/runtime/turn.ts
@@ -20,6 +20,7 @@ export interface TurnDeps {
     prompt: string
     conversationId: string
     windowId: string
+    purpose?: 'turn' | 'summary' | 'title'
   }) => Promise<{
     stdout: AsyncIterable<Buffer>
     stderr: AsyncIterable<Buffer>
@@ -39,6 +40,8 @@ export interface TurnDeps {
   }
 }
 
+const DEFAULT_CONVERSATION_TITLE = 'New conversation'
+
 export interface RunTurnInput {
   conversationId: string
   sourceWindowId: string
@@ -48,6 +51,11 @@ export interface RunTurnInput {
 
 export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ turnId: string }> {
   const turnId = randomUUID()
+  const existingMessages = deps.messages.listByConversation(input.conversationId)
+  const existingConversation = deps.conversations.getById(input.conversationId)
+  const shouldGenerateTitle =
+    existingConversation?.title.trim() === DEFAULT_CONVERSATION_TITLE &&
+    !existingMessages.some((message) => message.role === 'user')
 
   const user = deps.messages.append({
     conversationId: input.conversationId,
@@ -60,6 +68,15 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
     kind: 'message_upserted',
     message: user
   })
+
+  const titlePromise = shouldGenerateTitle
+    ? maybeGenerateConversationTitle(deps, {
+        conversationId: input.conversationId,
+        windowId: input.sourceWindowId,
+        text: input.text,
+        attachments: input.attachments
+      })
+    : Promise.resolve()
 
   let history = deps.messages
     .listByConversation(input.conversationId)
@@ -95,7 +112,8 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
   const sub = await deps.spawnSubprocess({
     prompt: compactedPrompt,
     conversationId: input.conversationId,
-    windowId: input.sourceWindowId
+    windowId: input.sourceWindowId,
+    purpose: 'turn'
   })
   const stderrTextPromise = collectStreamText(sub.stderr)
 
@@ -176,16 +194,129 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
     })
   } finally {
     await sub.cleanup()
+    await titlePromise
   }
 
   return { turnId }
+}
+
+async function maybeGenerateConversationTitle(
+  deps: TurnDeps,
+  input: {
+    conversationId: string
+    windowId: string
+    text: string
+    attachments: MessageAttachment[]
+  }
+): Promise<void> {
+  try {
+    const title = await generateTitleWithSubprocess(deps, {
+      prompt: assembleTitlePrompt(input.text, input.attachments),
+      conversationId: input.conversationId,
+      windowId: input.windowId
+    })
+    if (!title) return
+
+    const updated = deps.conversations.update(input.conversationId, { title }, ['title'])
+    broadcastAgentEvent({
+      kind: 'conversation_updated',
+      conversation: updated
+    })
+  } catch (error) {
+    logger.warn('Conversation title generation failed', error)
+  }
+}
+
+async function generateTitleWithSubprocess(
+  deps: TurnDeps,
+  input: { prompt: string; conversationId: string; windowId: string }
+): Promise<string | null> {
+  const sub = await deps.spawnSubprocess({ ...input, purpose: 'title' })
+  const events: BackendEvent[] = []
+  const parser = createStreamParser((event) => {
+    events.push(event)
+  })
+  const stderrTextPromise = collectStreamText(sub.stderr)
+  let raw = ''
+  let title = ''
+
+  try {
+    for await (const chunk of sub.stdout) {
+      const text = chunk.toString('utf8')
+      raw += text
+      parser.feed(text)
+      while (events.length > 0) {
+        const event = events.shift()
+        if (event?.kind === 'assistant_delta') {
+          title += event.text
+        }
+      }
+    }
+    parser.flush()
+    while (events.length > 0) {
+      const event = events.shift()
+      if (event?.kind === 'assistant_delta') {
+        title += event.text
+      }
+    }
+
+    const exitCode = await sub.waitExit()
+    if (exitCode !== 0) {
+      const stderrText = (await stderrTextPromise).trim()
+      logger.warn('Conversation title subprocess exited non-zero', { exitCode, stderr: stderrText })
+      return null
+    }
+
+    return sanitizeGeneratedTitle(title || raw)
+  } finally {
+    await sub.cleanup()
+  }
+}
+
+function assembleTitlePrompt(text: string, attachments: MessageAttachment[]): string {
+  const lines = [
+    'Generate a short title for this Memry Agent Chat conversation.',
+    'Rules:',
+    '- Use 2 to 6 words.',
+    '- Preserve the user language.',
+    '- Do not use quotes or trailing punctuation.',
+    '- Return only the title.',
+    '',
+    `User message: ${text}`
+  ]
+
+  if (attachments.length > 0) {
+    lines.push('', 'Attached references:')
+    for (const attachment of attachments) {
+      lines.push(`- ${attachment.kind}: ${attachment.label}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function sanitizeGeneratedTitle(value: string): string | null {
+  const firstLine = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean)
+  if (!firstLine) return null
+
+  const title = firstLine
+    .replace(/^["'`]+|["'`]+$/g, '')
+    .replace(/[.!?:;]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!title || title === DEFAULT_CONVERSATION_TITLE) return null
+  return title.length > 80 ? title.slice(0, 80).trim() : title
 }
 
 async function summarizeWithSubprocess(
   deps: TurnDeps,
   input: { prompt: string; conversationId: string; windowId: string }
 ): Promise<string> {
-  const sub = await deps.spawnSubprocess(input)
+  const sub = await deps.spawnSubprocess({ ...input, purpose: 'summary' })
   const events: BackendEvent[] = []
   const parser = createStreamParser((event) => {
     events.push(event)

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx
@@ -178,6 +178,30 @@ describe('agentReducer', () => {
     })
   })
 
+  it('updates conversation titles broadcast by the agent runtime', () => {
+    const state: AgentState = {
+      ...initialAgentState,
+      activeConversationId: conversation.id,
+      conversations: { [conversation.id]: conversation },
+      messagesByConversation: { [conversation.id]: [] }
+    }
+
+    const next = agentReducer(state, {
+      type: 'event',
+      event: {
+        kind: 'conversation_updated',
+        conversation: {
+          ...conversation,
+          title: 'Project Roadmap',
+          updatedAt: 200
+        }
+      } as AgentEvent
+    })
+
+    expect(next.conversations[conversation.id].title).toBe('Project Roadmap')
+    expect(next.activeConversationId).toBe(conversation.id)
+  })
+
   it('queues pending approvals and clears them by tool call id', () => {
     const event: AgentEvent = {
       kind: 'tool_call_pending_approval',

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
@@ -209,6 +209,15 @@ export function agentReducer(state: AgentState, action: AgentAction): AgentState
           }
         }
       }
+      if (event.kind === 'conversation_updated') {
+        return {
+          ...state,
+          conversations: {
+            ...state.conversations,
+            [event.conversation.id]: event.conversation
+          }
+        }
+      }
       if (event.kind === 'assistant_text_delta') {
         return {
           ...state,

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -31,6 +31,11 @@ When no conversation is selected yet, the prompt box stays available. Sending th
 creates a new Agent Chat conversation, attaches the active note when one is open, and streams the
 reply into the sidebar.
 
+New conversations start with a temporary title. When you send the first prompt, the selected chat
+backend also generates a short conversation title. Memry stores that title on the encrypted
+conversation row and refreshes the sidebar title without giving the title-generation subprocess
+access to Memry MCP tools.
+
 Conversation rows, message bodies, and message attachments are encrypted at rest before they are
 written to SQLite. Free accounts keep agent chat history local-only. Paid accounts can sync finalized
 conversations and terminal messages through Memry Sync; in-progress streaming messages are not

--- a/packages/contracts/src/ipc-agent.test.ts
+++ b/packages/contracts/src/ipc-agent.test.ts
@@ -114,6 +114,23 @@ describe('agent IPC schemas', () => {
         }
       },
       {
+        kind: 'conversation_updated',
+        conversation: {
+          id: 'conversation-1',
+          vaultId: 'vault-1',
+          title: 'Project Roadmap',
+          backend: 'claude_cli',
+          trustList: [],
+          pinned: false,
+          vectorClock: {},
+          fieldClocks: {},
+          createdAt: 100,
+          updatedAt: 200,
+          deletedAt: null,
+          lastSyncedAt: null
+        }
+      },
+      {
         kind: 'assistant_text_delta',
         conversationId: 'conversation-1',
         messageId: 'message-1',

--- a/packages/contracts/src/ipc-agent.ts
+++ b/packages/contracts/src/ipc-agent.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod'
 
-import { VectorClockSchema, type FieldClocks, type VectorClock } from './sync-api'
+import {
+  FieldClocksSchema,
+  VectorClockSchema,
+  type FieldClocks,
+  type VectorClock
+} from './sync-api'
 
 export type { FieldClocks, VectorClock }
 
@@ -131,6 +136,21 @@ export interface Conversation {
   lastSyncedAt: number | null
 }
 
+export const ConversationSchema = z.object({
+  id: z.string(),
+  vaultId: z.string(),
+  title: z.string(),
+  backend: z.string(),
+  trustList: z.array(z.string()),
+  pinned: z.boolean(),
+  vectorClock: VectorClockSchema,
+  fieldClocks: FieldClocksSchema,
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  deletedAt: z.number().nullable(),
+  lastSyncedAt: z.number().nullable()
+})
+
 export interface Message {
   id: string
   conversationId: string
@@ -214,6 +234,10 @@ export const AgentEventSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('message_upserted'),
     message: MessageSchema
+  }),
+  z.object({
+    kind: z.literal('conversation_updated'),
+    conversation: ConversationSchema
   }),
   z.object({
     kind: z.literal('assistant_text_delta'),


### PR DESCRIPTION
## Summary
- Generate a short Agent Chat conversation title from the first submitted prompt using the selected backend subprocess.
- Persist the generated title through the encrypted conversation store and broadcast `conversation_updated` so the sidebar/header refreshes without reload.
- Keep title generation isolated from Memry MCP tools and document the behavior in the Agent Chat guide.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts --project main src/main/agent/runtime/__tests__/turn.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/agent-chat/__tests__/agent-context.test.tsx`
- `pnpm exec vitest run packages/contracts/src/ipc-agent.test.ts`
- `pnpm --filter @memry/contracts typecheck`
- `pnpm --filter @memry/desktop typecheck:node`
- `pnpm --filter @memry/desktop typecheck:web`
- `pnpm docs:impact --strict --base origin/main`
- `pnpm docs:build`
- `pnpm ipc:check`
- `git diff --check origin/main...HEAD`
- Pre-push hook: docs impact/build, contract and architecture checks, package/desktop/sync-server typechecks, desktop tests, sync-server tests
