### PR TITLE
fix: prevent Agent Chat final result duplication

### DIFF
--- a/apps/desktop/src/main/agent/cli/__tests__/stream-parser.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/stream-parser.test.ts
@@ -148,6 +148,33 @@ describe('Claude stream-json parser', () => {
     expect(events[0]).toEqual({ kind: 'assistant_delta', text: 'The note was created.' })
   })
 
+  it('does not replay Claude Code final result after streaming partial text', () => {
+    const events: unknown[] = []
+    const parser = createStreamParser((event) => events.push(event))
+
+    parser.feed(
+      `${JSON.stringify({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: '12 notes in /tech' }
+        }
+      })}\n`
+    )
+    parser.feed(
+      `${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: '12 notes in /tech'
+      })}\n`
+    )
+
+    expect(events).toEqual([
+      { kind: 'assistant_delta', text: '12 notes in /tech' },
+      { kind: 'noop' }
+    ])
+  })
+
   it('ignores known Claude Code lifecycle events', () => {
     const events: unknown[] = []
     const parser = createStreamParser((event) => events.push(event))

--- a/apps/desktop/src/main/agent/cli/stream-parser.ts
+++ b/apps/desktop/src/main/agent/cli/stream-parser.ts
@@ -7,6 +7,15 @@ export interface StreamParser {
 
 export function createStreamParser(onEvent: (event: BackendEvent) => void): StreamParser {
   let buffer = ''
+  let emittedAssistantText = false
+
+  const emitBufferedLine = (line: string): void => {
+    const event = parseLine(line, emittedAssistantText)
+    if (event.kind === 'assistant_delta') {
+      emittedAssistantText = true
+    }
+    onEvent(event)
+  }
 
   return {
     feed(chunk) {
@@ -18,28 +27,28 @@ export function createStreamParser(onEvent: (event: BackendEvent) => void): Stre
         if (!line) {
           continue
         }
-        emitLine(line, onEvent)
+        emitBufferedLine(line)
       }
     },
     flush() {
       if (buffer.trim()) {
-        emitLine(buffer, onEvent)
+        emitBufferedLine(buffer)
       }
       buffer = ''
     }
   }
 }
 
-function emitLine(line: string, onEvent: (event: BackendEvent) => void): void {
+function parseLine(line: string, emittedAssistantText: boolean): BackendEvent {
   try {
     const obj = JSON.parse(line) as Record<string, unknown>
-    onEvent(translate(obj))
+    return translate(obj, emittedAssistantText)
   } catch {
-    onEvent({ kind: 'unknown', raw: line })
+    return { kind: 'unknown', raw: line }
   }
 }
 
-function translate(obj: Record<string, unknown>): BackendEvent {
+function translate(obj: Record<string, unknown>, emittedAssistantText: boolean): BackendEvent {
   const event = unwrapClaudeCodeEvent(obj)
   const type = event.type
   if (type === 'content_block_delta') {
@@ -102,6 +111,7 @@ function translate(obj: Record<string, unknown>): BackendEvent {
   }
 
   if (type === 'result' && typeof event.result === 'string') {
+    if (emittedAssistantText) return { kind: 'noop' }
     return { kind: 'assistant_delta', text: event.result }
   }
 

--- a/apps/desktop/src/main/agent/runtime/__tests__/turn.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/turn.test.ts
@@ -34,6 +34,13 @@ describe('runTurn against a stub backend', () => {
         })}\n`
       )
       yield Buffer.from(`${JSON.stringify({ type: 'message_stop' })}\n`)
+      yield Buffer.from(
+        `${JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          result: 'Hello world'
+        })}\n`
+      )
     })()
     const spawnSubprocess = vi.fn(async () => ({
       stdout,
@@ -207,6 +214,13 @@ describe('runTurn against a stub backend', () => {
             })}\n`
           )
           yield Buffer.from(`${JSON.stringify({ type: 'message_stop' })}\n`)
+          yield Buffer.from(
+            `${JSON.stringify({
+              type: 'result',
+              subtype: 'success',
+              result: 'Project Roadmap'
+            })}\n`
+          )
         })(),
         stderr: (async function* () {})(),
         pid: 1,


### PR DESCRIPTION
## Summary
- Treat Claude Code final `result` output as a fallback only after no streamed assistant text was emitted
- Add parser coverage for partial text followed by final result output
- Extend runtime coverage so assistant messages and generated chat titles do not duplicate at completion

## Root cause
Claude Code emits streamed `content_block_delta` text and then a final `result` event containing the full response. The parser treated both as assistant deltas, so Agent Chat appended the full text again after the session completed.

## Validation
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/agent/cli/__tests__/stream-parser.test.ts src/main/agent/runtime/__tests__/turn.test.ts`
- `pnpm --filter @memry/desktop typecheck:node`
- `pnpm docs:impact --strict`
- `pnpm docs:build`
