### PR TITLE
Simplify wikilink suggestions

### DIFF
--- a/apps/desktop/src/renderer/src/components/cold-major-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/cold-major-components.test.tsx
@@ -946,6 +946,9 @@ describe('cold major renderer components', () => {
         command={wikiCommand}
       />
     )
+    const pageFourOption = screen.getByRole('option', { name: 'Page four' })
+    expect(pageFourOption.querySelector('svg')).toBeNull()
+
     fireEvent.click(screen.getByText('Page four'))
     expect(wikiCommand).toHaveBeenCalledWith({ href: 'p4', title: 'Page four', exists: false })
     act(() => {

--- a/apps/desktop/src/renderer/src/components/journal/extensions/wiki-link/wiki-link-autocomplete.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/extensions/wiki-link/wiki-link-autocomplete.tsx
@@ -14,7 +14,6 @@ import {
 import type { SuggestionProps } from '@tiptap/suggestion'
 import { FileText, Plus } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { formatRelativeTime } from '@/lib/wiki-link-utils'
 import type { Page } from '@/hooks/use-pages'
 import { useT } from '@memry/i18n/renderer'
 
@@ -135,7 +134,7 @@ export const WikiLinkAutocomplete = forwardRef<
                   key={item.id}
                   className={cn(
                     'wiki-link-autocomplete-item',
-                    'relative flex w-full cursor-pointer select-none items-start gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
+                    'relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
                     'hover:bg-accent hover:text-accent-foreground',
                     selectedIndex === index &&
                       'bg-accent text-accent-foreground wiki-link-autocomplete-item-selected'
@@ -144,13 +143,7 @@ export const WikiLinkAutocomplete = forwardRef<
                   role="option"
                   aria-selected={selectedIndex === index}
                 >
-                  <FileText className="mt-0.5 h-4 w-4 shrink-0 opacity-70" />
-                  <div className="flex flex-1 flex-col gap-0.5">
-                    <div className="font-medium">{item.title}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {formatRelativeTime(item.lastEdited)}
-                    </div>
-                  </div>
+                  <div className="min-w-0 flex-1 truncate text-start font-medium">{item.title}</div>
                 </button>
               ))}
             </div>
@@ -169,7 +162,7 @@ export const WikiLinkAutocomplete = forwardRef<
                     key={item.id}
                     className={cn(
                       'wiki-link-autocomplete-item',
-                      'relative flex w-full cursor-pointer select-none items-start gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
+                      'relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
                       'hover:bg-accent hover:text-accent-foreground',
                       selectedIndex === actualIndex &&
                         'bg-accent text-accent-foreground wiki-link-autocomplete-item-selected'
@@ -178,12 +171,8 @@ export const WikiLinkAutocomplete = forwardRef<
                     role="option"
                     aria-selected={selectedIndex === actualIndex}
                   >
-                    <FileText className="mt-0.5 h-4 w-4 shrink-0 opacity-70" />
-                    <div className="flex flex-1 flex-col gap-0.5">
-                      <div className="font-medium">{item.title}</div>
-                      <div className="text-xs text-muted-foreground">
-                        {formatRelativeTime(item.lastEdited)}
-                      </div>
+                    <div className="min-w-0 flex-1 truncate text-start font-medium">
+                      {item.title}
                     </div>
                   </button>
                 )

--- a/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/wiki-link-menu.tsx
@@ -5,7 +5,6 @@
 import type { SuggestionMenuProps } from '@blocknote/react'
 import { FileText, Plus } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { formatRelativeTime } from '@/lib/wiki-link-utils'
 import { useT } from '@memry/i18n/renderer'
 
 export type WikiLinkSuggestionItem = {
@@ -62,7 +61,7 @@ export function WikiLinkMenu({
             key={`${item.type}-${item.id}-${item.target}`}
             className={cn(
               'wiki-link-menu-item',
-              'relative flex w-full cursor-pointer select-none items-start gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
+              'relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
               'hover:bg-accent hover:text-accent-foreground',
               isSelected && 'bg-accent text-accent-foreground'
             )}
@@ -70,26 +69,15 @@ export function WikiLinkMenu({
             role="option"
             aria-selected={isSelected}
           >
-            {item.type === 'create' ? (
-              <Plus className="mt-0.5 h-4 w-4 shrink-0" />
-            ) : (
-              <FileText className="mt-0.5 h-4 w-4 shrink-0 opacity-70" />
-            )}
-            <div className="flex flex-1 flex-col gap-0.5 text-left">
+            {item.type === 'create' ? <Plus className="mt-0.5 h-4 w-4 shrink-0" /> : null}
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5 text-start">
               {item.type === 'create' ? (
                 <>
                   <div className="font-medium">{t('menus.wiki.create')}</div>
                   <div className="text-xs text-muted-foreground">{item.target}</div>
                 </>
               ) : (
-                <>
-                  <div className="font-medium">{item.title}</div>
-                  {item.lastEdited && (
-                    <div className="text-xs text-muted-foreground">
-                      {formatRelativeTime(item.lastEdited)}
-                    </div>
-                  )}
-                </>
+                <div className="truncate font-medium">{item.title}</div>
               )}
             </div>
           </button>

--- a/apps/desktop/src/renderer/src/components/small-zero-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/small-zero-surfaces.test.tsx
@@ -161,6 +161,9 @@ describe('small zero-line renderer surfaces', () => {
         onItemClick={onItemClick}
       />
     )
+    const existingOption = screen.getByRole('option', { name: 'Existing Note' })
+    expect(existingOption.querySelector('svg')).toBeNull()
+
     fireEvent.click(screen.getByText('Existing Note'))
     fireEvent.click(screen.getByText('create'))
 


### PR DESCRIPTION
## Summary
- show only the note or journal title for existing wikilink suggestions
- keep create and empty states unchanged
- update focused renderer coverage for title-only suggestion rows

## Checks
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/components/small-zero-surfaces.test.tsx src/renderer/src/components/cold-major-components.test.tsx`
- `pnpm --filter @memry/desktop exec eslint src/renderer/src/components/note/content-area/wiki-link-menu.tsx src/renderer/src/components/journal/extensions/wiki-link/wiki-link-autocomplete.tsx --max-warnings=0`
- `pnpm --filter @memry/desktop typecheck:web`
- `git diff --check`

Note: the normal pre-push hook ran the full desktop suite and failed on unrelated tests (`use-bookmarks`, `conversation-view`) plus the existing `better-sqlite3` Node module mismatch in storage-data tests.