### PR TITLE
Show reminders in inbox snoozed view

### DIFF
--- a/apps/desktop/src/renderer/src/pages/inbox.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox.test.tsx
@@ -221,6 +221,15 @@ describe('InboxPage', () => {
     expect(screen.getByTestId('inbox-list')).toHaveAttribute('data-types', '')
   })
 
+  it('counts reminder inbox items in the snoozed view button', () => {
+    mocks.items = [{ id: 'reminder-1', type: 'reminder' }]
+    mocks.snoozedItems = []
+
+    render(<InboxPage />)
+
+    expect(screen.getByTitle('view.snoozed.showWithCount:1')).toBeInTheDocument()
+  })
+
   it('switches views, searches archived items, and closes search when leaving archive', () => {
     render(<InboxPage />)
 

--- a/apps/desktop/src/renderer/src/pages/inbox.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox.tsx
@@ -75,7 +75,11 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
   const { activeCount: activeJobCount, failedCount: failedJobCount } = useInboxJobs(
     items.map((item) => item.id)
   )
-  const snoozedCount = snoozedItems.length
+  const reminderCount = useMemo(
+    () => items.filter((item) => item.type === 'reminder').length,
+    [items]
+  )
+  const snoozedViewCount = snoozedItems.length + reminderCount
 
   const activeTab = useActiveTab()
   const focusInboxItemId =
@@ -286,8 +290,8 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
                   title={
                     showSnoozedItems
                       ? t('view.snoozed.hide')
-                      : snoozedCount > 0
-                        ? t('view.snoozed.showWithCount', { count: snoozedCount })
+                      : snoozedViewCount > 0
+                        ? t('view.snoozed.showWithCount', { count: snoozedViewCount })
                         : t('view.snoozed.show')
                   }
                   className={cn(
@@ -298,7 +302,7 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
                   )}
                 >
                   <AlarmClock className="size-3" />
-                  {snoozedCount > 0 && (
+                  {snoozedViewCount > 0 && (
                     <span
                       className={cn(
                         'flex items-center justify-center size-[14px] rounded-full text-[9px] font-bold',
@@ -307,7 +311,7 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
                           : 'bg-foreground/15 text-text-secondary'
                       )}
                     >
-                      {snoozedCount}
+                      {snoozedViewCount}
                     </span>
                   )}
                 </button>

--- a/apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.test.tsx
@@ -145,7 +145,9 @@ vi.mock('@/components/list-view', () => ({
     onFocusedItemChange: (id: string | null) => void
   }) => (
     <div>
-      <span>{items[0]?.title}</span>
+      {items.map((item) => (
+        <span key={item.id}>{item.title}</span>
+      ))}
       <button type="button" onClick={() => onPreview('item-1')}>
         Preview item
       </button>
@@ -396,6 +398,30 @@ describe('InboxListView', () => {
     mocks.inboxState.items = []
     rerender(<InboxListView selectedTypes={new Set()} showSnoozedItems={false} />)
     expect(screen.getByText('Empty 2/7/3')).toBeInTheDocument()
+  })
+
+  it('shows snoozed inbox rows and reminder rows in the snoozed view', () => {
+    mocks.inboxState.items = [
+      item,
+      {
+        ...item,
+        id: 'snoozed-1',
+        title: 'Snoozed Link',
+        snoozedUntil: new Date('2026-05-12T09:00:00.000Z')
+      },
+      {
+        ...item,
+        id: 'reminder-1',
+        type: 'reminder',
+        title: 'Reminder Note'
+      }
+    ]
+
+    renderWithProviders(<InboxListView selectedTypes={new Set()} showSnoozedItems />)
+
+    expect(screen.queryByText('Saved Link')).not.toBeInTheDocument()
+    expect(screen.getByText('Snoozed Link')).toBeInTheDocument()
+    expect(screen.getByText('Reminder Note')).toBeInTheDocument()
   })
 
   it('previews, files, archives, and snoozes individual items', async () => {

--- a/apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx
@@ -90,12 +90,16 @@ export function InboxListView({
 
   // Filtered items
   const items = useMemo(() => {
-    return backendItems.filter((item) => {
+    const visibleItems = showSnoozedItems
+      ? backendItems.filter((item) => item.snoozedUntil || item.type === 'reminder')
+      : backendItems
+
+    return visibleItems.filter((item) => {
       if (pendingArchiveIds.has(item.id)) return false
       if (selectedTypes.size > 0 && !selectedTypes.has(item.type)) return false
       return true
     })
-  }, [backendItems, pendingArchiveIds, selectedTypes])
+  }, [backendItems, pendingArchiveIds, selectedTypes, showSnoozedItems])
 
   // Empty state data
   const { stats: inboxStats } = useInboxStats()

--- a/apps/docs/src/user-guide/inbox/snooze-archive.md
+++ b/apps/docs/src/user-guide/inbox/snooze-archive.md
@@ -24,7 +24,7 @@ The custom dialog accepts any future date and time. Past times are rejected.
 
 ### Snoozed View
 
-A separate view tab lists currently snoozed items with a wakes-in countdown. From a snoozed row you can:
+A separate view tab lists currently snoozed items and reminder rows generated from fired note reminders. Snoozed rows show a wakes-in countdown. From a snoozed row you can:
 
 - **Wake now** — return to the inbox immediately
 - **Reschedule** — pick a different wake time


### PR DESCRIPTION
## Summary
- include fired reminder inbox rows in the inbox snoozed view
- count reminder inbox rows in the snoozed-view toolbar badge
- document the reminder-row behavior in the inbox snooze docs

## Verification
- `/Users/h4yfans/sideproject/memry/node_modules/.bin/vitest run --config config/vitest.config.ts --project renderer src/renderer/src/pages/inbox.test.tsx src/renderer/src/pages/inbox/inbox-list-view.test.tsx`
- `/Users/h4yfans/sideproject/memry/node_modules/.bin/tsc --noEmit -p tsconfig.web.json --composite false`
- `node scripts/docs-impact.mjs --base origin/main --strict`
- `/Users/h4yfans/sideproject/memry/node_modules/.bin/vitepress build src`