### PR TITLE
Keep pre-push docs-only

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -31,9 +31,6 @@ has_changes() {
 }
 
 code_changed='^(apps/desktop|apps/sync-server|packages|scripts|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|eslint.config.mjs|lint-staged.config.mjs|tsconfig|turbo.json)'
-package_changed='^(packages|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|tsconfig|turbo.json)'
-desktop_changed='^(apps/desktop|packages|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|eslint.config.mjs|lint-staged.config.mjs|tsconfig|turbo.json)'
-sync_server_changed='^(apps/sync-server|packages/(contracts|shared|sync-core)|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|tsconfig|turbo.json)'
 
 if ! has_changes "$code_changed"; then
   exit 0
@@ -72,35 +69,4 @@ if [ "${MEMRY_DOCS_IMPACT_SKIP:-0}" != "1" ]; then
 
     exit 1
   fi
-fi
-
-if [ "${MEMRY_HOOK_STRICT:-0}" != "1" ]; then
-  printf '\npre-push: quick checks passed. Full lint/typecheck/test/docs build run in CI.\n' >&2
-  printf 'pre-push: use `MEMRY_HOOK_STRICT=1 git push` for full local verification.\n' >&2
-  printf 'pre-push: use `git push --no-verify` only after focused checks for an urgent bypass.\n\n' >&2
-  exit 0
-fi
-
-if has_changes '^apps/docs/'; then
-  pnpm docs:build
-fi
-
-pnpm repair:links
-pnpm check:contracts
-pnpm check:architecture
-
-if has_changes "$package_changed"; then
-  pnpm typecheck:packages
-fi
-
-if has_changes "$desktop_changed"; then
-  pnpm lint:desktop
-  pnpm ipc:check
-  pnpm typecheck:desktop
-  pnpm test:desktop
-fi
-
-if has_changes "$sync_server_changed"; then
-  pnpm typecheck:sync-server
-  pnpm test:sync-server
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -56,26 +56,33 @@ if [ "${MEMRY_DOCS_IMPACT_SKIP:-0}" != "1" ]; then
       exit 1
     fi
 
-    if [ "${MEMRY_DOCS_AI_AUTO:-1}" = "1" ]; then
+    if [ "${MEMRY_DOCS_AI_AUTO:-0}" = "1" ]; then
       printf '\npre-push: running AI docs updater for desktop/sync-server changes...\n\n' >&2
       pnpm docs:ai-update --base "$base_commit"
 
       if ! git diff --quiet -- apps/docs/src; then
-        pnpm docs:build
-        printf '\npre-push: AI updated docs. Review, commit, and push again.\n\n' >&2
+        printf '\npre-push: AI updated docs. Review, verify, commit, and push again.\n\n' >&2
       else
         printf '\npre-push: AI did not change docs. If no docs are needed, retry with MEMRY_DOCS_IMPACT_SKIP=1.\n\n' >&2
       fi
     else
-      printf '\npre-push: run `pnpm docs:ai-update --base %s` or update apps/docs/src manually.\n\n' "$base_commit" >&2
+      printf '\npre-push: docs update required. Run `pnpm docs:ai-update --base %s` or update apps/docs/src manually.\n' "$base_commit" >&2
+      printf 'pre-push: set MEMRY_DOCS_AI_AUTO=1 to let this hook run the updater.\n\n' >&2
     fi
 
     exit 1
   fi
+fi
 
-  if has_changes '^apps/docs/'; then
-    pnpm docs:build
-  fi
+if [ "${MEMRY_HOOK_STRICT:-0}" != "1" ]; then
+  printf '\npre-push: quick checks passed. Full lint/typecheck/test/docs build run in CI.\n' >&2
+  printf 'pre-push: use `MEMRY_HOOK_STRICT=1 git push` for full local verification.\n' >&2
+  printf 'pre-push: use `git push --no-verify` only after focused checks for an urgent bypass.\n\n' >&2
+  exit 0
+fi
+
+if has_changes '^apps/docs/'; then
+  pnpm docs:build
 fi
 
 pnpm repair:links

--- a/apps/docs/src/contribute/workflow.md
+++ b/apps/docs/src/contribute/workflow.md
@@ -58,24 +58,20 @@ pnpm docs:impact --strict
 pnpm docs:build
 ```
 
-`docs:ai-update` uses the Codex CLI to inspect the branch diff and update only `apps/docs/src`. The pre-push hook runs the same impact check; when docs are missing, it stops the push and points you to the manual updater. Set `MEMRY_DOCS_AI_AUTO=1` only when you want the hook to run the updater for that push.
+`docs:ai-update` uses the Codex CLI to inspect the branch diff and update only `apps/docs/src`. The pre-push hook only runs the docs impact check; when docs are missing, it stops the push and points you to the manual updater. Set `MEMRY_DOCS_AI_AUTO=1` only when you want the hook to run the updater for that push. Lint, typecheck, and test suites run in GitHub Actions.
 
 If a change truly has no docs impact, use the `docs:not-needed` PR label for CI and `MEMRY_DOCS_IMPACT_SKIP=1 git push` for the local hook.
 
 ## Pre-Land Checks
 
-Before opening a PR:
+Before opening a PR, make sure docs are current:
 
 ```bash
-pnpm lint
-pnpm typecheck
-pnpm test
 pnpm docs:impact --strict
 pnpm docs:build
-pnpm ipc:check     # if you touched the renderer/main boundary
 ```
 
-For desktop-only changes, focused checks are faster:
+GitHub Actions run lint, typecheck, and test suites. For faster local feedback before pushing, run focused checks for the area you touched:
 
 ```bash
 pnpm typecheck:node     # main process

--- a/apps/docs/src/contribute/workflow.md
+++ b/apps/docs/src/contribute/workflow.md
@@ -58,7 +58,7 @@ pnpm docs:impact --strict
 pnpm docs:build
 ```
 
-`docs:ai-update` uses the Codex CLI to inspect the branch diff and update only `apps/docs/src`. The pre-push hook runs the same impact check; when docs are missing, it runs the AI updater, stops the push, and leaves the docs patch for review and commit.
+`docs:ai-update` uses the Codex CLI to inspect the branch diff and update only `apps/docs/src`. The pre-push hook runs the same impact check; when docs are missing, it stops the push and points you to the manual updater. Set `MEMRY_DOCS_AI_AUTO=1` only when you want the hook to run the updater for that push.
 
 If a change truly has no docs impact, use the `docs:not-needed` PR label for CI and `MEMRY_DOCS_IMPACT_SKIP=1 git push` for the local hook.
 
@@ -94,7 +94,7 @@ The `/ship` and `/merge` skills wrap the standard PR + CI + merge flow:
 
 ## Don'ts
 
-- Never `--no-verify`
+- Use `--no-verify` only for urgent bypasses after focused checks pass
 - Never `--amend` after a hook failure (creates a new commit instead)
 - Never `git add -A` or `git add .` (stage explicit paths)
 - Never commit `.env` or anything that looks like a secret

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typecheck:landing": "pnpm --filter @memry/landing typecheck",
     "typecheck:sync-server": "pnpm --filter @memry/sync-server typecheck",
     "test": "pnpm repair:links && node scripts/run-turbo.js run test --filter=@memry/desktop --filter=@memry/sync-server",
-    "test:release": "node --test scripts/release-utils.test.mjs scripts/release-notes-utils.test.mjs",
+    "test:release": "node --test scripts/release-utils.test.mjs scripts/release-notes-utils.test.mjs scripts/pre-push-policy.test.mjs",
     "test:desktop": "pnpm --filter @memry/desktop test",
     "test:sync-server": "pnpm --filter @memry/sync-server test",
     "test:coverage": "pnpm --filter @memry/desktop test:coverage",

--- a/scripts/pre-push-policy.test.mjs
+++ b/scripts/pre-push-policy.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { describe, it } from 'node:test'
+
+const prePush = readFileSync(new URL('../.husky/pre-push', import.meta.url), 'utf8')
+
+describe('pre-push hook policy', () => {
+  it('keeps heavy checks behind explicit strict mode', () => {
+    assert.match(prePush, /MEMRY_HOOK_STRICT/)
+
+    const strictModeStart = prePush.indexOf('MEMRY_HOOK_STRICT')
+    assert.notEqual(strictModeStart, -1)
+
+    const strictModeSection = prePush.slice(strictModeStart)
+    for (const command of [
+      'pnpm repair:links',
+      'pnpm check:contracts',
+      'pnpm check:architecture',
+      'pnpm typecheck:packages',
+      'pnpm lint:desktop',
+      'pnpm ipc:check',
+      'pnpm typecheck:desktop',
+      'pnpm test:desktop',
+      'pnpm typecheck:sync-server',
+      'pnpm test:sync-server'
+    ]) {
+      assert.match(strictModeSection, new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    }
+  })
+
+  it('keeps docs AI updates opt-in instead of running them on every push', () => {
+    assert.match(prePush, /MEMRY_DOCS_AI_AUTO:-0/)
+
+    const docsAutoStart = prePush.indexOf('MEMRY_DOCS_AI_AUTO:-0')
+    const docsUpdaterCommand = prePush.indexOf('pnpm docs:ai-update --base "$base_commit"')
+    assert.notEqual(docsAutoStart, -1)
+    assert.notEqual(docsUpdaterCommand, -1)
+    assert.ok(docsUpdaterCommand > docsAutoStart)
+  })
+
+  it('does not build docs unless strict mode is requested', () => {
+    const strictModeStart = prePush.indexOf('MEMRY_HOOK_STRICT')
+    assert.notEqual(strictModeStart, -1)
+
+    const quickModeSection = prePush.slice(0, strictModeStart)
+    assert.doesNotMatch(quickModeSection, /pnpm docs:build/)
+  })
+})

--- a/scripts/pre-push-policy.test.mjs
+++ b/scripts/pre-push-policy.test.mjs
@@ -5,13 +5,9 @@ import { describe, it } from 'node:test'
 const prePush = readFileSync(new URL('../.husky/pre-push', import.meta.url), 'utf8')
 
 describe('pre-push hook policy', () => {
-  it('keeps heavy checks behind explicit strict mode', () => {
-    assert.match(prePush, /MEMRY_HOOK_STRICT/)
+  it('leaves lint, typecheck, and test suites to GitHub Actions', () => {
+    assert.doesNotMatch(prePush, /MEMRY_HOOK_STRICT/)
 
-    const strictModeStart = prePush.indexOf('MEMRY_HOOK_STRICT')
-    assert.notEqual(strictModeStart, -1)
-
-    const strictModeSection = prePush.slice(strictModeStart)
     for (const command of [
       'pnpm repair:links',
       'pnpm check:contracts',
@@ -24,7 +20,7 @@ describe('pre-push hook policy', () => {
       'pnpm typecheck:sync-server',
       'pnpm test:sync-server'
     ]) {
-      assert.match(strictModeSection, new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+      assert.doesNotMatch(prePush, new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
     }
   })
 
@@ -38,11 +34,8 @@ describe('pre-push hook policy', () => {
     assert.ok(docsUpdaterCommand > docsAutoStart)
   })
 
-  it('does not build docs unless strict mode is requested', () => {
-    const strictModeStart = prePush.indexOf('MEMRY_HOOK_STRICT')
-    assert.notEqual(strictModeStart, -1)
-
-    const quickModeSection = prePush.slice(0, strictModeStart)
-    assert.doesNotMatch(quickModeSection, /pnpm docs:build/)
+  it('keeps the docs impact gate in the pre-push hook', () => {
+    assert.match(prePush, /pnpm docs:impact --base "\$base_commit" --strict/)
+    assert.doesNotMatch(prePush, /pnpm docs:build/)
   })
 })


### PR DESCRIPTION
## Summary
- Keep pre-push focused on branch-name guardrails and the docs impact gate.
- Remove `MEMRY_HOOK_STRICT` and local lint/typecheck/test execution from the hook; GitHub Actions owns those suites.
- Keep docs AI updates opt-in with `MEMRY_DOCS_AI_AUTO=1` and update workflow docs to match.
- Add a Node test that locks the hook policy.

## Verification
- `node --test scripts/pre-push-policy.test.mjs`
- `pnpm test:release`
- `sh -n .husky/pre-push && git diff --check`
- `git diff --cached --check`
- `git push` succeeded and exercised the pre-push docs gate.

## Not run
- `pnpm docs:build` could not run in this worktree because docs dependencies are missing (`vitepress: command not found`).