### PR TITLE
Fix preload IPC listener fanout

### DIFF
--- a/apps/desktop/src/preload/api/preload-api.test.ts
+++ b/apps/desktop/src/preload/api/preload-api.test.ts
@@ -130,6 +130,34 @@ describe('preload api wrappers', () => {
     unsubscribeFlush()
   })
 
+  it('fans out same-channel subscriptions through one Electron listener', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+
+    const unsubscribeFirst = subscribe('settings:changed', first)
+    const unsubscribeSecond = subscribe('settings:changed', second)
+
+    expect(electronMock.ipcRenderer.on).toHaveBeenCalledTimes(1)
+    const [[channel, handler]] = electronMock.ipcRenderer.on.mock.calls
+    expect(channel).toBe('settings:changed')
+
+    handler({}, { key: 'general', value: { theme: 'dark' } })
+    expect(first).toHaveBeenCalledWith({ key: 'general', value: { theme: 'dark' } })
+    expect(second).toHaveBeenCalledWith({ key: 'general', value: { theme: 'dark' } })
+
+    unsubscribeFirst()
+    handler({}, { key: 'general', value: { theme: 'light' } })
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenLastCalledWith({ key: 'general', value: { theme: 'light' } })
+    expect(electronMock.ipcRenderer.removeListener).not.toHaveBeenCalled()
+
+    unsubscribeSecond()
+    expect(electronMock.ipcRenderer.removeListener).toHaveBeenCalledWith(
+      'settings:changed',
+      handler
+    )
+  })
+
   it('normalizes startup theme cache, sync fallback, and root classes', () => {
     const classList = {
       values: new Set<string>(),

--- a/apps/desktop/src/preload/lib/ipc.ts
+++ b/apps/desktop/src/preload/lib/ipc.ts
@@ -22,8 +22,48 @@ export function send(channel: string, ...args: unknown[]): void {
   ipcRenderer.send(channel, ...args)
 }
 
+type IpcCallback = (payload: unknown) => void
+
+interface ChannelSubscription {
+  callbacks: IpcCallback[]
+  handler: (_event: Electron.IpcRendererEvent, payload: unknown) => void
+}
+
+const channelSubscriptions = new Map<string, ChannelSubscription>()
+
 export function subscribe<T>(channel: string, callback: (payload: T) => void): () => void {
-  const handler = (_event: Electron.IpcRendererEvent, payload: T): void => callback(payload)
-  ipcRenderer.on(channel, handler)
-  return () => ipcRenderer.removeListener(channel, handler)
+  let subscription = channelSubscriptions.get(channel)
+  if (!subscription) {
+    const callbacks: IpcCallback[] = []
+    const handler = (_event: Electron.IpcRendererEvent, payload: unknown): void => {
+      for (const current of [...callbacks]) {
+        current(payload)
+      }
+    }
+    subscription = { callbacks, handler }
+    channelSubscriptions.set(channel, subscription)
+    ipcRenderer.on(channel, handler)
+  }
+
+  const wrapped = callback as IpcCallback
+  subscription.callbacks.push(wrapped)
+
+  let unsubscribed = false
+  return () => {
+    if (unsubscribed) return
+    unsubscribed = true
+
+    const current = channelSubscriptions.get(channel)
+    if (!current) return
+
+    const index = current.callbacks.indexOf(wrapped)
+    if (index !== -1) {
+      current.callbacks.splice(index, 1)
+    }
+
+    if (current.callbacks.length === 0) {
+      ipcRenderer.removeListener(channel, current.handler)
+      channelSubscriptions.delete(channel)
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Coalesce preload IPC event subscriptions so each channel has a single `ipcRenderer.on(...)` listener.
- Fan out payloads to renderer callbacks from preload and remove the Electron listener when the last callback unsubscribes.
- Add regression coverage proving multiple `settings:changed` subscribers share one Electron listener and still unsubscribe cleanly.

## Root cause

Startup mounted more than ten legitimate `settings:changed` subscribers. The preload bridge attached each renderer callback directly to Electron's shared `IpcRenderer`, crossing Node's default listener warning threshold even though React cleanup paths existed.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/preload/api/preload-api.test.ts`
- `pnpm exec tsc --noEmit -p tsconfig.node.json --composite false`
- `NODE_OPTIONS=--trace-warnings pnpm dev`
- `pnpm docs:impact --strict`
- `pnpm docs:build`
- `git diff --check`