### PR TITLE
Refine right sidebar switch

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockUseAgentOptional = vi.hoisted(() => vi.fn())
@@ -10,9 +10,9 @@ vi.mock('../agent-context', () => ({
 
 import { SidebarTabs } from '../sidebar-tabs'
 
-function renderTabs() {
+function renderTabs(props: { dayLabel?: string; agentLabel?: string } = {}) {
   return render(
-    <SidebarTabs>
+    <SidebarTabs {...props}>
       {{
         day: <div>Day content</div>,
         agent: <div>Agent content</div>
@@ -37,6 +37,23 @@ describe('SidebarTabs', () => {
 
     expect(screen.getByText('Agent content')).toBeInTheDocument()
     expect(localStorage.getItem('right-sidebar-tab')).toBe('agent')
+  })
+
+  it('keeps the switch compact with icon-only tab buttons and one active label', async () => {
+    const user = userEvent.setup()
+    renderTabs({ dayLabel: 'Today' })
+
+    const dayTab = screen.getByRole('tab', { name: 'Day' })
+    const agentTab = screen.getByRole('tab', { name: 'Agent' })
+
+    expect(within(dayTab).queryByText('Day')).not.toBeInTheDocument()
+    expect(within(agentTab).queryByText('Agent')).not.toBeInTheDocument()
+    expect(screen.getByText('Today')).toBeInTheDocument()
+
+    await user.click(agentTab)
+
+    expect(screen.getByText('Agent')).toBeInTheDocument()
+    expect(within(agentTab).queryByText('Agent')).not.toBeInTheDocument()
   })
 
   it('restores the persisted active tab', () => {

--- a/apps/desktop/src/renderer/src/agent-chat/sidebar-tabs.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/sidebar-tabs.tsx
@@ -13,6 +13,8 @@ const RIGHT_SIDEBAR_TABS: RightSidebarTab[] = ['day', 'agent']
 interface SidebarTabsProps {
   children: { day: ReactNode; agent: ReactNode }
   defaultTab?: RightSidebarTab
+  dayLabel?: string
+  agentLabel?: string
 }
 
 function readInitialTab(defaultTab: RightSidebarTab): RightSidebarTab {
@@ -25,10 +27,18 @@ function readInitialTab(defaultTab: RightSidebarTab): RightSidebarTab {
   return defaultTab
 }
 
-export function SidebarTabs({ children, defaultTab = 'day' }: SidebarTabsProps): React.JSX.Element {
+export function SidebarTabs({
+  children,
+  defaultTab = 'day',
+  dayLabel,
+  agentLabel
+}: SidebarTabsProps): React.JSX.Element {
   const { t } = useT('common')
   const [active, setActive] = useState<RightSidebarTab>(() => readInitialTab(defaultTab))
   const agent = useAgentOptional()
+  const dayTabLabel = t('agentChat.sidebar.day')
+  const agentTabLabel = t('agentChat.sidebar.agent')
+  const activeLabel = active === 'day' ? (dayLabel ?? dayTabLabel) : (agentLabel ?? agentTabLabel)
 
   useEffect(() => {
     try {
@@ -52,22 +62,31 @@ export function SidebarTabs({ children, defaultTab = 'day' }: SidebarTabsProps):
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="border-b border-sidebar-border px-3 py-2">
+      <div className="flex h-9 shrink-0 items-center justify-between gap-3 border-b border-sidebar-border px-3">
+        <span className="min-w-0 truncate text-xs font-semibold text-sidebar-foreground">
+          {activeLabel}
+        </span>
         <div
           role="tablist"
           aria-label={t('agentChat.sidebar.label')}
-          className="grid h-8 grid-cols-2 rounded-md border border-sidebar-border bg-sidebar-accent/30 p-0.5"
+          className="inline-flex h-7 shrink-0 items-center gap-0.5 rounded-md border border-transparent bg-[#212021] p-0.5 hover:border-sidebar-border focus-within:border-sidebar-border"
         >
-          <SidebarTabButton active={active === 'day'} onClick={() => setActive('day')}>
-            <CalendarDays className="size-3.5" aria-hidden="true" />
-            <span>{t('agentChat.sidebar.day')}</span>
+          <SidebarTabButton
+            active={active === 'day'}
+            label={dayTabLabel}
+            onClick={() => setActive('day')}
+          >
+            <CalendarDays className="size-4" aria-hidden="true" />
           </SidebarTabButton>
-          <SidebarTabButton active={active === 'agent'} onClick={() => setActive('agent')}>
-            <Bot className="size-3.5" aria-hidden="true" />
-            <span>{t('agentChat.sidebar.agent')}</span>
+          <SidebarTabButton
+            active={active === 'agent'}
+            label={agentTabLabel}
+            onClick={() => setActive('agent')}
+          >
+            <Bot className="size-4" aria-hidden="true" />
             {hasBackgroundActivity && (
               <span
-                className="ms-1 size-1.5 rounded-full bg-primary"
+                className="absolute end-1 top-1 size-1.5 rounded-full bg-primary"
                 aria-label={
                   pendingApprovalCount > 0
                     ? t('agentChat.sidebar.pendingApproval', { count: pendingApprovalCount })
@@ -87,10 +106,12 @@ export function SidebarTabs({ children, defaultTab = 'day' }: SidebarTabsProps):
 
 function SidebarTabButton({
   active,
+  label,
   onClick,
   children
 }: {
   active: boolean
+  label: string
   onClick: () => void
   children: ReactNode
 }): React.JSX.Element {
@@ -98,13 +119,15 @@ function SidebarTabButton({
     <button
       type="button"
       role="tab"
+      aria-label={label}
       aria-selected={active}
+      title={label}
       onClick={onClick}
       className={cn(
-        'inline-flex min-w-0 items-center justify-center gap-1.5 rounded-[5px] px-2 text-xs font-medium transition-colors',
+        'relative inline-flex size-6 items-center justify-center rounded-[5px] transition-colors',
         active
-          ? 'bg-background text-foreground shadow-sm'
-          : 'text-muted-foreground hover:bg-background/60 hover:text-foreground'
+          ? 'bg-[#303030] text-[color-mix(in_srgb,var(--foreground)_35%,white)] shadow-sm'
+          : 'text-muted-foreground hover:bg-[#303030] hover:text-[color-mix(in_srgb,var(--foreground)_35%,white)]'
       )}
     >
       {children}

--- a/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
@@ -90,6 +90,7 @@ function DayPanelResizeRail() {
 }
 
 export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
+  const { t, i18n } = useT('journal')
   const { isOpen, selectedDate, width, isResizing, setDate } = useDayPanel()
   const { openTab } = useTabs()
   const activeTab = useActiveTab()
@@ -114,6 +115,10 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
   )
 
   const selectedDateObj = parseISODate(selectedDate)
+  const dayPanelLabel =
+    selectedDate === getTodayString()
+      ? t('date.relative.today')
+      : selectedDateObj.toLocaleDateString(i18n.language, { month: 'short', day: 'numeric' })
   const currentYear = selectedDateObj.getFullYear()
   const { data: heatmapData } = useJournalHeatmap(currentYear)
 
@@ -223,7 +228,7 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
       >
         {isOpen && <DayPanelResizeRail />}
 
-        <SidebarTabs>
+        <SidebarTabs dayLabel={dayPanelLabel}>
           {{
             day: (
               <div className="h-full overflow-y-auto pt-3">


### PR DESCRIPTION
## Summary
- Replaces the right sidebar Day/Agent segmented control with a compact header switch.
- Keeps the active Day label in the header while using icon-only Day/Agent controls.
- Tunes switch spacing, icon size, hover/selected treatment, and activity dot placement.

## Validation
- pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts src/agent-chat/__tests__/sidebar-tabs.test.tsx src/components/day-panel/global-day-panel.test.tsx
- pnpm --filter @memry/desktop exec eslint src/renderer/src/agent-chat/sidebar-tabs.tsx src/renderer/src/components/day-panel/global-day-panel.tsx
- pnpm --filter @memry/desktop exec tsc --noEmit -p tsconfig.web.json --composite false
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build
- npx -y react-doctor@latest . --verbose --diff (from apps/desktop)
