### PR TITLE
Fix AI inline server duplicate startup

### DIFF
--- a/apps/desktop/src/main/ai-inline/ai-chat-server.test.ts
+++ b/apps/desktop/src/main/ai-inline/ai-chat-server.test.ts
@@ -92,6 +92,29 @@ describe('AI inline chat server', () => {
     expect(getServerPort()).toBeNull()
   })
 
+  it('returns the running port instead of restarting when settings are unchanged', async () => {
+    const firstPort = await startChatServer(settings)
+    mocks.logInfo.mockClear()
+
+    const secondPort = await startChatServer({ ...settings })
+
+    expect(secondPort).toBe(firstPort)
+    expect(getServerPort()).toBe(firstPort)
+    expect(mocks.createLanguageModel).toHaveBeenCalledTimes(1)
+    expect(mocks.logInfo).not.toHaveBeenCalledWith('Stopped')
+  })
+
+  it('coalesces concurrent starts when settings are unchanged', async () => {
+    const [firstPort, secondPort] = await Promise.all([
+      startChatServer(settings),
+      startChatServer({ ...settings })
+    ])
+
+    expect(secondPort).toBe(firstPort)
+    expect(getServerPort()).toBe(firstPort)
+    expect(mocks.createLanguageModel).toHaveBeenCalledTimes(1)
+  })
+
   it('streams valid chat requests through the model and returns 404 for other paths', async () => {
     const port = await startChatServer(settings)
 

--- a/apps/desktop/src/main/ai-inline/ai-chat-server.ts
+++ b/apps/desktop/src/main/ai-inline/ai-chat-server.ts
@@ -14,6 +14,24 @@ const logger = createLogger('AI:ChatServer')
 
 let server: http.Server | null = null
 let currentPort: number | null = null
+let currentSettingsKey: string | null = null
+let startInFlight: { key: string; promise: Promise<number> } | null = null
+
+function getSettingsKey(settings: AIInlineSettings): string {
+  return JSON.stringify({
+    enabled: settings.enabled,
+    provider: settings.provider,
+    model: settings.model,
+    apiKey: settings.apiKey,
+    baseUrl: settings.baseUrl
+  })
+}
+
+function getRunningPortFor(settingsKey: string): number | null {
+  if (!server?.listening) return null
+  if (currentPort === null || currentSettingsKey !== settingsKey) return null
+  return currentPort
+}
 
 export function getServerPort(): number | null {
   if (!server?.listening) return null
@@ -21,14 +39,31 @@ export function getServerPort(): number | null {
 }
 
 export async function startChatServer(settings: AIInlineSettings): Promise<number> {
+  const settingsKey = getSettingsKey(settings)
+  const runningPort = getRunningPortFor(settingsKey)
+  if (runningPort !== null) {
+    return runningPort
+  }
+
+  if (startInFlight) {
+    if (startInFlight.key === settingsKey) {
+      return startInFlight.promise
+    }
+
+    await startInFlight.promise.catch(() => undefined)
+    const portAfterPendingStart = getRunningPortFor(settingsKey)
+    if (portAfterPendingStart !== null) {
+      return portAfterPendingStart
+    }
+  }
+
   if (server) {
     await stopChatServer()
   }
 
   const model = createLanguageModel(settings)
-
-  return new Promise((resolve, reject) => {
-    server = http.createServer((req, res) => {
+  const startPromise = new Promise<number>((resolve, reject) => {
+    const nextServer = http.createServer((req, res) => {
       res.setHeader('Access-Control-Allow-Origin', '*')
       res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
       res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
@@ -54,10 +89,15 @@ export async function startChatServer(settings: AIInlineSettings): Promise<numbe
       res.end('Not found')
     })
 
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server!.address()
+    server = nextServer
+    currentPort = null
+    currentSettingsKey = null
+
+    nextServer.listen(0, '127.0.0.1', () => {
+      const addr = nextServer.address()
       if (addr && typeof addr === 'object') {
         currentPort = addr.port
+        currentSettingsKey = settingsKey
         logger.info(`Started on port ${currentPort}`)
         resolve(currentPort)
       } else {
@@ -65,22 +105,59 @@ export async function startChatServer(settings: AIInlineSettings): Promise<numbe
       }
     })
 
-    server.on('error', (err) => {
+    nextServer.on('error', (err) => {
+      if (server === nextServer) {
+        server = null
+        currentPort = null
+        currentSettingsKey = null
+      }
       logger.error('Server error:', err)
       reject(err)
     })
   })
+
+  startInFlight = { key: settingsKey, promise: startPromise }
+
+  try {
+    return await startPromise
+  } finally {
+    if (startInFlight?.promise === startPromise) {
+      startInFlight = null
+    }
+  }
 }
 
 export async function stopChatServer(): Promise<void> {
+  const pendingStart = startInFlight?.promise
+  if (pendingStart) {
+    await pendingStart.catch(() => undefined)
+  }
+
   return new Promise((resolve) => {
     if (!server) {
+      currentPort = null
+      currentSettingsKey = null
       resolve()
       return
     }
-    server.close(() => {
-      server = null
-      currentPort = null
+
+    const closingServer = server
+    if (!closingServer.listening) {
+      if (server === closingServer) {
+        server = null
+        currentPort = null
+        currentSettingsKey = null
+      }
+      resolve()
+      return
+    }
+
+    closingServer.close(() => {
+      if (server === closingServer) {
+        server = null
+        currentPort = null
+        currentSettingsKey = null
+      }
       logger.info('Stopped')
       resolve()
     })

--- a/apps/docs/src/user-guide/ai/provider-setup.md
+++ b/apps/docs/src/user-guide/ai/provider-setup.md
@@ -6,11 +6,11 @@ Configure the LLM provider used by the inline AI menu in the editor. Open from [
 
 ## Supported Providers
 
-| Provider | Runs | Needs |
-| --- | --- | --- |
-| **Ollama** | Locally on your machine | Ollama installed and running |
-| **OpenAI** | OpenAI cloud | API key |
-| **Anthropic** | Anthropic cloud | API key |
+| Provider      | Runs                    | Needs                        |
+| ------------- | ----------------------- | ---------------------------- |
+| **Ollama**    | Locally on your machine | Ollama installed and running |
+| **OpenAI**    | OpenAI cloud            | API key                      |
+| **Anthropic** | Anthropic cloud         | API key                      |
 
 Each provider has its own model presets in the dropdown.
 
@@ -77,6 +77,8 @@ A status indicator (green / yellow / red) shows the most recent test result.
 
 You can change provider at any time. Memory of past prompts is local — switching doesn't carry conversation state.
 
+Memry keeps one local inline-AI bridge running for the active provider settings. Re-opening the editor or another window reuses that bridge when settings are unchanged; changing provider, model, base URL, or API key restarts it with the new configuration.
+
 ## Where Keys Live
 
 API keys are stored **locally**, in the vault, encrypted with the vault key. They:
@@ -89,12 +91,12 @@ Rotating a key in the provider's dashboard requires updating it here too.
 
 ## Troubleshooting
 
-| Symptom | Likely cause |
-| --- | --- |
-| "Cannot connect" with Ollama | Ollama not running; check `http://localhost:11434/v1/models` |
-| "Unauthorized" with OpenAI / Anthropic | Wrong key, expired, or rate-limited |
-| "Model not found" | Model name typo or not pulled (Ollama) / not enabled in your account |
-| Test passes but inline menu doesn't appear | AI Inline toggle off in settings |
+| Symptom                                    | Likely cause                                                         |
+| ------------------------------------------ | -------------------------------------------------------------------- |
+| "Cannot connect" with Ollama               | Ollama not running; check `http://localhost:11434/v1/models`         |
+| "Unauthorized" with OpenAI / Anthropic     | Wrong key, expired, or rate-limited                                  |
+| "Model not found"                          | Model name typo or not pulled (Ollama) / not enabled in your account |
+| Test passes but inline menu doesn't appear | AI Inline toggle off in settings                                     |
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- Make the AI inline chat server idempotent for unchanged settings so duplicate renderer startup calls reuse the same local bridge instead of stopping and restarting it.
- Coalesce concurrent same-settings starts while preserving intentional restarts when provider settings change.
- Document the inline-AI bridge lifecycle in provider setup docs.

## Root Cause
React dev StrictMode can invoke the renderer startup effect twice. The main-process singleton server restarted whenever `startChatServer()` was called while a server already existed, even if the settings were identical.

## Verification
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/ai-inline/ai-chat-server.test.ts`
- `pnpm --filter @memry/desktop exec tsc --noEmit -p tsconfig.node.json --composite false`
- `pnpm docs:impact --base 676cbc2b1158aaf021877e1ac0ff813ca5865234 --strict`
- `pnpm docs:build`
- `pnpm --filter @memry/desktop exec prettier --check src/main/ai-inline/ai-chat-server.ts src/main/ai-inline/ai-chat-server.test.ts`
- `git diff --check`
