### PR TITLE
Add agent chat model selection

### DIFF
--- a/apps/desktop/src/main/agent/backends/__tests__/claude-cli-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/claude-cli-backend.test.ts
@@ -50,7 +50,7 @@ describe('ClaudeCliBackend', () => {
       prompt: 'User: create a task',
       conversationId: 'conversation-1',
       windowId: 'window-1',
-      options: { backend: 'claude_cli', claudeEffort: 'sonnet' }
+      options: { backend: 'claude_cli', claudeEffort: 'high', model: 'sonnet' }
     })
 
     const events = []
@@ -60,7 +60,8 @@ describe('ClaudeCliBackend', () => {
       prompt: 'User: create a task',
       conversationId: 'conversation-1',
       windowId: 'window-1',
-      effort: 'sonnet',
+      effort: 'high',
+      model: 'sonnet',
       purpose: 'turn'
     })
     expect(events).toEqual([
@@ -84,7 +85,7 @@ describe('ClaudeCliBackend', () => {
       prompt: 'Title this conversation',
       conversationId: 'conversation-1',
       windowId: 'window-1',
-      options: { backend: 'claude_cli', claudeEffort: 'opus' }
+      options: { backend: 'claude_cli', claudeEffort: 'low', model: 'opus' }
     })
     await backend.summarize({
       prompt: 'Summarize this conversation',
@@ -94,7 +95,10 @@ describe('ClaudeCliBackend', () => {
     })
     backend.cancel('conversation-1')
 
-    expect(spawn).toHaveBeenNthCalledWith(1, expect.objectContaining({ purpose: 'title' }))
+    expect(spawn).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ purpose: 'title', model: 'opus' })
+    )
     expect(spawn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ purpose: 'summary', effort: DEFAULT_CLAUDE_EFFORT })

--- a/apps/desktop/src/main/agent/backends/__tests__/codex-cli-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/codex-cli-backend.test.ts
@@ -27,7 +27,7 @@ describe('CodexCliBackend', () => {
       prompt: 'User: ping',
       conversationId: 'conversation-1',
       windowId: 'window-1',
-      options: { backend: 'codex_cli', reasoningEffort: 'high' }
+      options: { backend: 'codex_cli', reasoningEffort: 'high', model: 'gpt-5.5' }
     })
 
     const events = []
@@ -38,6 +38,7 @@ describe('CodexCliBackend', () => {
       conversationId: 'conversation-1',
       windowId: 'window-1',
       reasoningEffort: 'high',
+      model: 'gpt-5.5',
       purpose: 'turn'
     })
     expect(events).toEqual([{ kind: 'assistant_delta', text: 'pong' }])

--- a/apps/desktop/src/main/agent/backends/claude-cli-backend.ts
+++ b/apps/desktop/src/main/agent/backends/claude-cli-backend.ts
@@ -49,11 +49,13 @@ export class ClaudeCliBackend implements AgentBackend {
   private async run(input: AgentBackendRunInput, purpose: 'turn' | 'summary' | 'title') {
     const effort =
       input.options.backend === 'claude_cli' ? input.options.claudeEffort : DEFAULT_CLAUDE_EFFORT
+    const model = input.options.backend === 'claude_cli' ? input.options.model : undefined
     const subprocess = await this.deps.spawn({
       prompt: input.prompt,
       conversationId: input.conversationId,
       windowId: input.windowId,
       effort,
+      model,
       purpose
     })
 

--- a/apps/desktop/src/main/agent/backends/codex-cli-backend.ts
+++ b/apps/desktop/src/main/agent/backends/codex-cli-backend.ts
@@ -47,11 +47,13 @@ export class CodexCliBackend implements AgentBackend {
   private async run(input: AgentBackendRunInput, purpose: 'turn' | 'summary' | 'title') {
     const reasoningEffort =
       input.options.backend === 'codex_cli' ? input.options.reasoningEffort : 'medium'
+    const model = input.options.backend === 'codex_cli' ? input.options.model : undefined
     const subprocess = await this.deps.spawn({
       prompt: input.prompt,
       conversationId: input.conversationId,
       windowId: input.windowId,
       reasoningEffort,
+      model,
       purpose
     })
 

--- a/apps/desktop/src/main/agent/backends/types.ts
+++ b/apps/desktop/src/main/agent/backends/types.ts
@@ -41,6 +41,7 @@ export interface ClaudeCliSpawnInput {
   conversationId: string
   windowId: string
   effort: ClaudeEffort
+  model?: string
   purpose?: 'turn' | 'summary' | 'title'
 }
 
@@ -49,6 +50,7 @@ export interface CodexCliSpawnInput {
   conversationId: string
   windowId: string
   reasoningEffort: CodexReasoningEffort
+  model?: string
   purpose?: 'turn' | 'summary' | 'title'
 }
 

--- a/apps/desktop/src/main/agent/bootstrap.test.ts
+++ b/apps/desktop/src/main/agent/bootstrap.test.ts
@@ -147,7 +147,7 @@ describe('startAgent', () => {
       prompt: 'hello',
       conversationId: 'conversation-1',
       windowId: 'window-1',
-      options: { backend: 'claude_cli', claudeEffort: 'low' }
+      options: { backend: 'claude_cli', claudeEffort: 'low', model: 'sonnet' }
     })
 
     expect(mocks.spawnClaudeTurn).toHaveBeenCalledWith(
@@ -158,6 +158,7 @@ describe('startAgent', () => {
         conversationId: 'conversation-1',
         windowId: 'window-1',
         effort: 'low',
+        model: 'sonnet',
         prompt: 'hello'
       })
     )
@@ -171,7 +172,7 @@ describe('startAgent', () => {
       prompt: 'hello',
       conversationId: 'conversation-1',
       windowId: 'window-1',
-      options: { backend: 'codex_cli', reasoningEffort: 'high' }
+      options: { backend: 'codex_cli', reasoningEffort: 'high', model: 'gpt-5.5' }
     })
     await deps.backends.get('codex_cli').generateTitle({
       prompt: 'title',
@@ -186,6 +187,7 @@ describe('startAgent', () => {
         binaryPath: 'codex',
         prompt: 'hello',
         reasoningEffort: 'high',
+        model: 'gpt-5.5',
         mcp: {
           serverUrl: 'http://127.0.0.1:54321',
           authorizationValue: 'local-auth-value',

--- a/apps/desktop/src/main/agent/bootstrap.ts
+++ b/apps/desktop/src/main/agent/bootstrap.ts
@@ -79,6 +79,7 @@ export async function startAgent(): Promise<AgentHandle> {
     conversationId,
     windowId,
     effort,
+    model,
     purpose = 'turn'
   }: ClaudeCliSpawnInput) => {
     const binary = await detectClaudeBinary()
@@ -99,6 +100,7 @@ export async function startAgent(): Promise<AgentHandle> {
       windowId,
       allowedTools: purpose === 'turn' ? ALLOWED_AGENT_TOOLS : '',
       effort,
+      model,
       prompt
     })
 
@@ -126,6 +128,7 @@ export async function startAgent(): Promise<AgentHandle> {
     conversationId,
     windowId,
     reasoningEffort,
+    model,
     purpose = 'turn'
   }: CodexCliSpawnInput) => {
     const binary = await detectCodexBinary()
@@ -142,6 +145,7 @@ export async function startAgent(): Promise<AgentHandle> {
       binaryPath: 'codex',
       prompt,
       reasoningEffort,
+      model,
       ...(status?.url && status['token']
         ? {
             mcp: {

--- a/apps/desktop/src/main/agent/cli/__tests__/codex-spawn.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/codex-spawn.test.ts
@@ -71,6 +71,23 @@ describe('spawnCodexTurn', () => {
 
     const args = vi.mocked(spawn).mock.calls[0][1] as string[]
     expect(args.at(-1)).toBe('PROMPT BODY')
+    expect(args).not.toContain('--model')
+  })
+
+  it('passes an explicit Codex model when selected', async () => {
+    const fakeProc = makeFakeProc()
+    vi.mocked(spawn).mockReturnValue(fakeProc)
+
+    await spawnCodexTurn({
+      binaryPath: 'codex',
+      reasoningEffort: 'medium',
+      model: 'gpt-5.5',
+      prompt: 'PROMPT BODY'
+    })
+
+    const args = vi.mocked(spawn).mock.calls[0][1] as string[]
+    expect(args).toContain('--model')
+    expect(args).toContain('gpt-5.5')
   })
 
   it('omits MCP config and Memry env vars for title and summary prompts', async () => {

--- a/apps/desktop/src/main/agent/cli/__tests__/spawn.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/spawn.test.ts
@@ -68,6 +68,28 @@ describe('spawnClaudeTurn', () => {
     expect(args).toContain('--mcp-config')
     expect(args).toContain('--effort')
     expect(args).toContain('low')
+    expect(args).not.toContain('--model')
+  })
+
+  it('passes an explicit Claude model when selected', async () => {
+    const fakeProc = makeFakeProc()
+    vi.mocked(spawn).mockReturnValue(fakeProc)
+
+    await spawnClaudeTurn({
+      binaryPath: '/usr/local/bin/claude',
+      mcpServerUrl: 'http://127.0.0.1:54321',
+      authorizationValue: 'test-auth-value',
+      conversationId: 'c',
+      windowId: 'w',
+      allowedTools: 'a',
+      effort: 'xhigh',
+      model: 'opus',
+      prompt: 'p'
+    })
+
+    const args = vi.mocked(spawn).mock.calls[0][1] as string[]
+    expect(args).toContain('--model')
+    expect(args).toContain('opus')
   })
 
   it('writes the prompt to stdin and closes it', async () => {

--- a/apps/desktop/src/main/agent/cli/codex-spawn.ts
+++ b/apps/desktop/src/main/agent/cli/codex-spawn.ts
@@ -13,6 +13,7 @@ export interface CodexSpawnOptions {
   binaryPath: string
   prompt: string
   reasoningEffort: CodexReasoningEffort
+  model?: string
   mcp?: {
     serverUrl: string
     authorizationValue: string
@@ -49,6 +50,9 @@ export async function spawnCodexTurn(opts: CodexSpawnOptions): Promise<CodexSubp
     '-c',
     `model_reasoning_effort="${opts.reasoningEffort}"`
   ]
+  if (opts.model) {
+    args.push('--model', opts.model)
+  }
 
   if (opts.mcp) {
     args.push(

--- a/apps/desktop/src/main/agent/cli/spawn.ts
+++ b/apps/desktop/src/main/agent/cli/spawn.ts
@@ -17,6 +17,7 @@ export interface SpawnOptions {
   windowId: string
   allowedTools: string
   effort: ClaudeEffort
+  model?: string
   prompt: string
 }
 
@@ -64,6 +65,9 @@ export async function spawnClaudeTurn(opts: SpawnOptions): Promise<ClaudeSubproc
     '--effort',
     opts.effort
   ]
+  if (opts.model) {
+    args.push('--model', opts.model)
+  }
 
   logger.info(`Spawning claude with strict MCP config`)
   const proc = spawn(opts.binaryPath, args, {

--- a/apps/desktop/src/main/ipc/agent-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.test.ts
@@ -202,6 +202,33 @@ describe('agent IPC handlers', () => {
     expect(deps.backends.get).toHaveBeenCalledWith('local_openai_compatible')
   })
 
+  it('returns suggested CLI backend models with custom model support', async () => {
+    registerAgentHandlers(deps)
+
+    await expect(
+      findHandler(AgentChannels.invoke.LIST_BACKEND_MODELS)(null, { backend: 'claude_cli' })
+    ).resolves.toEqual({
+      backend: 'claude_cli',
+      supportsCustomModel: true,
+      models: [
+        { id: 'sonnet', label: 'Sonnet' },
+        { id: 'haiku', label: 'Haiku' },
+        { id: 'opus', label: 'Opus' }
+      ]
+    })
+    await expect(
+      findHandler(AgentChannels.invoke.LIST_BACKEND_MODELS)(null, { backend: 'codex_cli' })
+    ).resolves.toEqual({
+      backend: 'codex_cli',
+      supportsCustomModel: true,
+      models: [
+        { id: 'gpt-5.5', label: 'GPT-5.5' },
+        { id: 'gpt-5.4', label: 'GPT-5.4' },
+        { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' }
+      ]
+    })
+  })
+
   it('runs a turn with snapshotted attachments', async () => {
     registerAgentHandlers(deps)
 
@@ -239,6 +266,24 @@ describe('agent IPC handlers', () => {
           }
         ]
       })
+    )
+  })
+
+  it('stores selected CLI model metadata on the conversation before running a turn', async () => {
+    registerAgentHandlers(deps)
+
+    await findHandler(AgentChannels.invoke.SEND_TURN)(null, {
+      conversationId: 'conversation-1',
+      sourceWindowId: 'window-1',
+      text: 'hi',
+      attachments: [],
+      backendOptions: { backend: 'claude_cli', claudeEffort: 'low', model: 'sonnet' }
+    })
+
+    expect(deps.conversations.update).toHaveBeenCalledWith(
+      'conversation-1',
+      { backend: 'claude_cli', backendModel: 'sonnet' },
+      ['backendModel']
     )
   })
 

--- a/apps/desktop/src/main/ipc/agent-handlers.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.ts
@@ -2,11 +2,13 @@ import { BrowserWindow, ipcMain, type WebContents } from 'electron'
 
 import {
   AgentBackendIdSchema,
+  AgentBackendModelListRequestSchema,
   AgentChannels,
   AgentLocalProviderSettingsUpdateSchema,
   ApproveToolRequestSchema,
   PreviewDiffRequestSchema,
   type AgentBackendOptions,
+  type AgentBackendModelList,
   type AgentLocalModelList,
   type AgentLocalProviderProbeResult,
   type AgentLocalProviderSettings,
@@ -29,6 +31,27 @@ import { broadcastAgentEvent } from '../agent/runtime/event-bus'
 import { createLogger } from '../lib/logger'
 
 const logger = createLogger('IPC:Agent')
+
+const CLI_MODEL_OPTIONS: Record<'claude_cli' | 'codex_cli', AgentBackendModelList> = {
+  claude_cli: {
+    backend: 'claude_cli',
+    supportsCustomModel: true,
+    models: [
+      { id: 'sonnet', label: 'Sonnet' },
+      { id: 'haiku', label: 'Haiku' },
+      { id: 'opus', label: 'Opus' }
+    ]
+  },
+  codex_cli: {
+    backend: 'codex_cli',
+    supportsCustomModel: true,
+    models: [
+      { id: 'gpt-5.5', label: 'GPT-5.5' },
+      { id: 'gpt-5.4', label: 'GPT-5.4' },
+      { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' }
+    ]
+  }
+}
 
 interface AgentHandlerDeps {
   runtime: Pick<
@@ -227,6 +250,10 @@ export function registerAgentHandlers(deps: AgentHandlerDeps): void {
   })
 
   ipcMain.handle(AgentChannels.invoke.GET_BACKEND_STATUSES, () => getBackendStatuses(deps))
+  ipcMain.handle(AgentChannels.invoke.LIST_BACKEND_MODELS, async (_event, payload: unknown) => {
+    const request = AgentBackendModelListRequestSchema.parse(payload)
+    return CLI_MODEL_OPTIONS[request.backend]
+  })
   ipcMain.handle(AgentChannels.invoke.GET_LOCAL_PROVIDER_SETTINGS, () =>
     deps.localProvider.getSettings()
   )
@@ -284,6 +311,10 @@ export function registerUnavailableAgentHandlers(reason: string): void {
       detail: message
     }
   }))
+  registerUnavailableHandler(AgentChannels.invoke.LIST_BACKEND_MODELS, (_event, payload) => {
+    const request = AgentBackendModelListRequestSchema.parse(payload)
+    return CLI_MODEL_OPTIONS[request.backend]
+  })
   registerUnavailableHandler(AgentChannels.invoke.GET_LOCAL_PROVIDER_SETTINGS, async () =>
     unavailable()
   )
@@ -321,7 +352,9 @@ async function backendModelFromOptions(
   options: AgentBackendOptions,
   deps: AgentHandlerDeps
 ): Promise<string | null> {
-  if (options.backend !== 'local_openai_compatible') return null
+  if (options.backend === 'claude_cli' || options.backend === 'codex_cli') {
+    return options.model ?? null
+  }
   if (options.model) return options.model
   const settings = await deps.localProvider.getSettings()
   return settings.model || null

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -16,6 +16,7 @@ export interface MainIpcInvokeHandlers {
   "agent:getDisclosureState": (...args: []) => Awaited<import("../agent/runtime/disclosure-state").DisclosureState>
   "agent:getLocalProviderSettings": (...args: []) => Awaited<Promise<{ preset: "custom" | "ollama" | "lm_studio" | "llama_cpp"; baseUrl: string; model: string; apiKeyConfigured: boolean; allowNonLoopback: boolean; }>>
   "agent:getWindowId": (...args: []) => Awaited<{ windowId: string | null; }>
+  "agent:listBackendModels": (...args: [unknown]) => Awaited<Promise<{ backend: "claude_cli" | "codex_cli"; supportsCustomModel: boolean; models: { id: string; label: string; }[]; }>>
   "agent:listConversations": (...args: [unknown]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-agent").Conversation[]>>
   "agent:listLocalModels": (...args: []) => Awaited<Promise<{ models: string[]; }>>
   "agent:loadConversation": (...args: [unknown]) => Awaited<Promise<{ conversation: import("../../../../../packages/contracts/src/ipc-agent").Conversation | null; messages: import("../../../../../packages/contracts/src/ipc-agent").Message[]; }>>

--- a/apps/desktop/src/preload/api/agent.ts
+++ b/apps/desktop/src/preload/api/agent.ts
@@ -1,6 +1,8 @@
 import type {
   AgentEvent,
   AgentBackendId,
+  AgentBackendModelList,
+  AgentBackendModelListRequest,
   AgentLocalModelList,
   AgentLocalProviderProbeResult,
   AgentLocalProviderSettings,
@@ -46,6 +48,8 @@ export const agentApi = {
   }): Promise<Conversation | null> => invoke(AgentChannels.invoke.EDIT_TRUST_LIST, input),
   getBackendStatuses: (): Promise<BackendStatusesResponse> =>
     invoke(AgentChannels.invoke.GET_BACKEND_STATUSES),
+  listBackendModels: (input: AgentBackendModelListRequest): Promise<AgentBackendModelList> =>
+    invoke(AgentChannels.invoke.LIST_BACKEND_MODELS, input),
   getLocalProviderSettings: (): Promise<AgentLocalProviderSettings> =>
     invoke(AgentChannels.invoke.GET_LOCAL_PROVIDER_SETTINGS),
   setLocalProviderSettings: (

--- a/apps/desktop/src/preload/api/preload-api.test.ts
+++ b/apps/desktop/src/preload/api/preload-api.test.ts
@@ -853,6 +853,11 @@ describe('preload api wrappers', () => {
       AgentChannels.invoke.GET_BACKEND_STATUSES
     )
     await expectInvoke(
+      () => agentApi.listBackendModels({ backend: 'codex_cli' }),
+      AgentChannels.invoke.LIST_BACKEND_MODELS,
+      { backend: 'codex_cli' }
+    )
+    await expectInvoke(
       () => agentApi.getLocalProviderSettings(),
       AgentChannels.invoke.GET_LOCAL_PROVIDER_SETTINGS
     )

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -8,6 +8,8 @@ import type { AgentMcpStatus } from '@memry/contracts/agent-mcp-channels'
 import type {
   AgentEvent,
   AgentBackendId,
+  AgentBackendModelList,
+  AgentBackendModelListRequest,
   AgentLocalModelList,
   AgentLocalProviderProbeResult,
   AgentLocalProviderSettings,
@@ -1634,6 +1636,7 @@ interface AgentClientAPI {
     remove?: string[]
   }) => Promise<Conversation | null>
   getBackendStatuses: () => Promise<BackendStatusesResponse>
+  listBackendModels: (input: AgentBackendModelListRequest) => Promise<AgentBackendModelList>
   getLocalProviderSettings: () => Promise<AgentLocalProviderSettings>
   setLocalProviderSettings: (
     input: AgentLocalProviderSettingsUpdate

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
@@ -231,6 +231,55 @@ describe('Composer', () => {
     })
   })
 
+  it('shows supported Codex reasoning settings next to the selected provider', async () => {
+    render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent provider: Claude' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }))
+    await screen.findByRole('button', { name: 'Agent model: GPT-5.5' })
+
+    const settingsTrigger = screen.getByRole('button', {
+      name: 'Agent settings: Medium'
+    })
+    expect(settingsTrigger).toHaveClass('rounded-full')
+
+    fireEvent.pointerDown(settingsTrigger)
+
+    expect(screen.getByText('Reasoning')).toBeInTheDocument()
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Medium (default)' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    )
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Low' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitemcheckbox', { name: 'High' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Extra High' })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitemcheckbox', { name: 'Max' })).not.toBeInTheDocument()
+  })
+
+  it('passes the selected Codex reasoning with the prompt', async () => {
+    render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent provider: Claude' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }))
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent settings: Medium' }))
+    fireEvent.click(screen.getByRole('menuitemcheckbox', { name: 'High' }))
+
+    const textbox = screen.getByRole('textbox')
+    fireEvent.change(textbox, { target: { value: 'create a task' } })
+    await act(async () => {
+      fireEvent.keyDown(textbox, { key: 'Enter' })
+      await Promise.resolve()
+    })
+
+    expect(mockSendTurn).toHaveBeenCalledWith({
+      conversationId: 'conversation-1',
+      sourceWindowId: 'window-1',
+      text: 'create a task',
+      attachments: [],
+      backendOptions: { backend: 'codex_cli', reasoningEffort: 'high', model: 'gpt-5.5' }
+    })
+  })
+
   it('passes the selected Codex model with the prompt', async () => {
     render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
 

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
@@ -48,6 +48,22 @@ describe('Composer', () => {
       cancelTurn: mockCancelTurn
     })
     vi.mocked(window.api.search.query).mockImplementation(mockSearchQuery)
+    vi.mocked(window.api.agent.listBackendModels).mockImplementation(async ({ backend }) => ({
+      backend,
+      supportsCustomModel: true,
+      models:
+        backend === 'claude_cli'
+          ? [
+              { id: 'sonnet', label: 'Sonnet' },
+              { id: 'haiku', label: 'Haiku' },
+              { id: 'opus', label: 'Opus' }
+            ]
+          : [
+              { id: 'gpt-5.4', label: 'GPT-5.4' },
+              { id: 'gpt-5.5', label: 'GPT-5.5' },
+              { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' }
+            ]
+    }))
   })
 
   it('submits on Enter', async () => {
@@ -65,7 +81,7 @@ describe('Composer', () => {
       sourceWindowId: 'window-1',
       text: 'hello',
       attachments: [],
-      backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh' }
+      backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh', model: 'opus' }
     })
   })
 
@@ -166,7 +182,30 @@ describe('Composer', () => {
       sourceWindowId: 'window-1',
       text: 'quick answer',
       attachments: [],
-      backendOptions: { backend: 'claude_cli', claudeEffort: 'low' }
+      backendOptions: { backend: 'claude_cli', claudeEffort: 'low', model: 'opus' }
+    })
+  })
+
+  it('passes the selected Claude model with the prompt', async () => {
+    render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Agent model: Opus' }))
+    expect(screen.queryByRole('menuitem', { name: 'Default' })).not.toBeInTheDocument()
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Sonnet' }))
+
+    const textbox = screen.getByRole('textbox')
+    fireEvent.change(textbox, { target: { value: 'deep answer' } })
+    await act(async () => {
+      fireEvent.keyDown(textbox, { key: 'Enter' })
+      await Promise.resolve()
+    })
+
+    expect(mockSendTurn).toHaveBeenCalledWith({
+      conversationId: 'conversation-1',
+      sourceWindowId: 'window-1',
+      text: 'deep answer',
+      attachments: [],
+      backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh', model: 'sonnet' }
     })
   })
 
@@ -188,7 +227,101 @@ describe('Composer', () => {
       sourceWindowId: 'window-1',
       text: 'create a task',
       attachments: [],
-      backendOptions: { backend: 'codex_cli', reasoningEffort: 'medium' }
+      backendOptions: { backend: 'codex_cli', reasoningEffort: 'medium', model: 'gpt-5.5' }
+    })
+  })
+
+  it('passes the selected Codex model with the prompt', async () => {
+    render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent provider: Claude' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }))
+    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Agent model: GPT-5.5' }))
+    expect(screen.queryByRole('menuitem', { name: 'Default' })).not.toBeInTheDocument()
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'GPT-5.4' }))
+
+    const textbox = screen.getByRole('textbox')
+    fireEvent.change(textbox, { target: { value: 'create a task' } })
+    await act(async () => {
+      fireEvent.keyDown(textbox, { key: 'Enter' })
+      await Promise.resolve()
+    })
+
+    expect(mockSendTurn).toHaveBeenCalledWith({
+      conversationId: 'conversation-1',
+      sourceWindowId: 'window-1',
+      text: 'create a task',
+      attachments: [],
+      backendOptions: { backend: 'codex_cli', reasoningEffort: 'medium', model: 'gpt-5.4' }
+    })
+  })
+
+  it('uses the highest suggested Codex model as the Memry default', async () => {
+    vi.mocked(window.api.agent.listBackendModels).mockImplementation(async ({ backend }) => ({
+      backend,
+      supportsCustomModel: true,
+      models:
+        backend === 'codex_cli'
+          ? [
+              { id: 'gpt-5.4', label: 'GPT-5.4' },
+              { id: 'gpt-5.6', label: 'GPT-5.6' },
+              { id: 'gpt-5.5', label: 'GPT-5.5' }
+            ]
+          : [
+              { id: 'sonnet', label: 'Sonnet' },
+              { id: 'haiku', label: 'Haiku' },
+              { id: 'opus', label: 'Opus' }
+            ]
+    }))
+    render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent provider: Claude' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }))
+
+    expect(await screen.findByRole('button', { name: 'Agent model: GPT-5.6' })).toBeInTheDocument()
+
+    const textbox = screen.getByRole('textbox')
+    fireEvent.change(textbox, { target: { value: 'create a task' } })
+    await act(async () => {
+      fireEvent.keyDown(textbox, { key: 'Enter' })
+      await Promise.resolve()
+    })
+
+    expect(mockSendTurn).toHaveBeenCalledWith({
+      conversationId: 'conversation-1',
+      sourceWindowId: 'window-1',
+      text: 'create a task',
+      attachments: [],
+      backendOptions: { backend: 'codex_cli', reasoningEffort: 'medium', model: 'gpt-5.6' }
+    })
+  })
+
+  it('allows a custom Claude model id', async () => {
+    render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Agent model: Opus' }))
+    fireEvent.change(screen.getByLabelText('Custom model ID'), {
+      target: { value: 'claude-sonnet-4-6' }
+    })
+    fireEvent.keyDown(screen.getByLabelText('Custom model ID'), { key: 'Enter' })
+
+    const textbox = screen.getByRole('textbox')
+    fireEvent.change(textbox, { target: { value: 'custom model' } })
+    await act(async () => {
+      fireEvent.keyDown(textbox, { key: 'Enter' })
+      await Promise.resolve()
+    })
+
+    expect(mockSendTurn).toHaveBeenCalledWith({
+      conversationId: 'conversation-1',
+      sourceWindowId: 'window-1',
+      text: 'custom model',
+      attachments: [],
+      backendOptions: {
+        backend: 'claude_cli',
+        claudeEffort: 'xhigh',
+        model: 'claude-sonnet-4-6'
+      }
     })
   })
 
@@ -202,15 +335,37 @@ describe('Composer', () => {
       await Promise.resolve()
     })
 
-    expect(mockCreateConversation).toHaveBeenCalledWith({ backend: 'claude_cli' })
+    expect(mockCreateConversation).toHaveBeenCalledWith({
+      backend: 'claude_cli',
+      backendModel: 'opus'
+    })
     await waitFor(() => {
       expect(mockSendTurn).toHaveBeenCalledWith({
         conversationId: 'conversation-2',
         sourceWindowId: 'window-1',
         text: 'draft a plan',
         attachments: [],
-        backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh' }
+        backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh', model: 'opus' }
       })
+    })
+  })
+
+  it('creates a new conversation with selected backend model metadata', async () => {
+    render(<Composer conversationId={null} sourceWindowId="window-1" />)
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Agent model: Opus' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Sonnet' }))
+
+    const textbox = screen.getByRole('textbox')
+    fireEvent.change(textbox, { target: { value: 'draft a plan' } })
+    await act(async () => {
+      fireEvent.keyDown(textbox, { key: 'Enter' })
+      await Promise.resolve()
+    })
+
+    expect(mockCreateConversation).toHaveBeenCalledWith({
+      backend: 'claude_cli',
+      backendModel: 'sonnet'
     })
   })
 
@@ -284,7 +439,7 @@ describe('Composer', () => {
       sourceWindowId: 'window-1',
       text: 'summarize this',
       attachments: [{ kind: 'note', ref_id: 'note-1', label: 'Planning note' }],
-      backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh' }
+      backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh', model: 'opus' }
     })
   })
 
@@ -309,7 +464,7 @@ describe('Composer', () => {
       sourceWindowId: 'window-1',
       text: 'summarize',
       attachments: [{ kind: 'current_note', ref_id: '__current__', label: 'Current brief' }],
-      backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh' }
+      backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh', model: 'opus' }
     })
   })
 

--- a/apps/desktop/src/renderer/src/agent-chat/composer.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/composer.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 
 import type {
   AgentBackendId,
+  AgentBackendModelList,
+  AgentCliBackendId,
   AgentBackendOptions,
   AttachmentInput,
   ClaudeEffort
@@ -18,6 +20,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { useActiveTab } from '@/contexts/tabs'
 import { ChatGpt, Check, ChevronDown, Claude, Computer, Send, Square, X } from '@/lib/icons'
@@ -30,6 +33,31 @@ interface ComposerProps {
 }
 
 type AgentProvider = 'claude_cli' | 'codex_cli' | 'local_openai_compatible'
+
+const DEFAULT_CLAUDE_MODEL = 'opus'
+
+const DEFAULT_SELECTED_MODELS: Record<AgentCliBackendId, string | null> = {
+  claude_cli: DEFAULT_CLAUDE_MODEL,
+  codex_cli: null
+}
+
+const EMPTY_MODEL_OPTIONS: Record<AgentCliBackendId, AgentBackendModelList | null> = {
+  claude_cli: null,
+  codex_cli: null
+}
+
+const MODEL_LABEL_FALLBACKS: Record<AgentCliBackendId, Record<string, string>> = {
+  claude_cli: {
+    sonnet: 'Sonnet',
+    haiku: 'Haiku',
+    opus: 'Opus'
+  },
+  codex_cli: {
+    'gpt-5.5': 'GPT-5.5',
+    'gpt-5.4': 'GPT-5.4',
+    'gpt-5.4-mini': 'GPT-5.4 Mini'
+  }
+}
 
 const claudeReasoningOptions: Array<{
   value: ClaudeEffort
@@ -73,16 +101,68 @@ function resizePromptTextarea(textarea: HTMLTextAreaElement): void {
   textarea.style.height = `${textarea.scrollHeight}px`
 }
 
+function isCliProvider(provider: AgentProvider): provider is AgentCliBackendId {
+  return provider === 'claude_cli' || provider === 'codex_cli'
+}
+
+function codexModelVersion(modelId: string): number[] | null {
+  const match = /^gpt[-_]?(\d+(?:[.-]\d+)*)(?:-.+)?$/i.exec(modelId)
+  if (!match) return null
+  return match[1].split(/[.-]/).map((segment) => Number(segment))
+}
+
+function compareCodexModels(left: string, right: string): number {
+  const leftVersion = codexModelVersion(left)
+  const rightVersion = codexModelVersion(right)
+  if (!leftVersion && !rightVersion) return 0
+  if (leftVersion && !rightVersion) return 1
+  if (!leftVersion && rightVersion) return -1
+
+  const maxLength = Math.max(leftVersion!.length, rightVersion!.length)
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftPart = leftVersion![index] ?? 0
+    const rightPart = rightVersion![index] ?? 0
+    if (leftPart !== rightPart) return leftPart - rightPart
+  }
+  return 0
+}
+
+function latestCodexModel(modelIds: string[]): string | null {
+  return modelIds.reduce<string | null>((latest, modelId) => {
+    if (!latest) return modelId
+    return compareCodexModels(modelId, latest) > 0 ? modelId : latest
+  }, null)
+}
+
+function defaultModelForProvider(
+  provider: AgentCliBackendId,
+  modelOptions: AgentBackendModelList | null
+): string | null {
+  if (provider === 'claude_cli') return DEFAULT_CLAUDE_MODEL
+  const codexModelIds =
+    modelOptions?.models.length === 0 || !modelOptions
+      ? Object.keys(MODEL_LABEL_FALLBACKS.codex_cli)
+      : modelOptions.models.map((model) => model.id)
+  return latestCodexModel(codexModelIds)
+}
+
 export function Composer({ conversationId, sourceWindowId }: ComposerProps): React.JSX.Element {
   const { t } = useT('common')
   const agent = useAgentOptional()
   const activeTab = useActiveTab()
+  const customModelInputId = useId()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [text, setText] = useState('')
   const [attachments, setAttachments] = useState<AttachmentInput[]>([])
   const [pickerOpen, setPickerOpen] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [selectedProvider, setSelectedProvider] = useState<AgentProvider>('claude_cli')
+  const [modelMenuOpen, setModelMenuOpen] = useState(false)
+  const [selectedModels, setSelectedModels] =
+    useState<Record<AgentCliBackendId, string | null>>(DEFAULT_SELECTED_MODELS)
+  const [modelOptions, setModelOptions] =
+    useState<Record<AgentCliBackendId, AgentBackendModelList | null>>(EMPTY_MODEL_OPTIONS)
+  const [customModelDraft, setCustomModelDraft] = useState('')
   const [claudeReasoning, setClaudeReasoning] = useState<ClaudeEffort>(DEFAULT_CLAUDE_EFFORT)
 
   useEffect(() => {
@@ -109,8 +189,20 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
 
   useEffect(() => {
     const activeConversation = conversationId ? agent?.state.conversations[conversationId] : null
-    if (activeConversation) setSelectedProvider(activeConversation.backend)
+    if (activeConversation) {
+      setSelectedProvider(activeConversation.backend)
+      if (isCliProvider(activeConversation.backend)) {
+        setSelectedModels((current) => ({
+          ...current,
+          [activeConversation.backend]: activeConversation.backendModel
+        }))
+      }
+    }
   }, [agent?.state.conversations, conversationId])
+
+  const selectedModelOptions = isCliProvider(selectedProvider)
+    ? modelOptions[selectedProvider]
+    : null
 
   useEffect(() => {
     if (textareaRef.current) resizePromptTextarea(textareaRef.current)
@@ -136,6 +228,15 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
     local_openai_compatible: localProviderLabel
   }
   const selectedProviderLabel = providerLabelById[selectedProvider]
+  const selectedBackendModel = isCliProvider(selectedProvider)
+    ? (selectedModels[selectedProvider] ??
+      defaultModelForProvider(selectedProvider, selectedModelOptions))
+    : null
+  const selectedModelLabel = selectedBackendModel
+    ? (selectedModelOptions?.models.find((model) => model.id === selectedBackendModel)?.label ??
+      MODEL_LABEL_FALLBACKS[selectedProvider as AgentCliBackendId][selectedBackendModel] ??
+      selectedBackendModel)
+    : t('agentChat.composer.models.default')
   const SelectedProviderIcon =
     selectedProvider === 'local_openai_compatible'
       ? Computer
@@ -153,9 +254,56 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
       return { backend: 'local_openai_compatible', toolsEnabled: true }
     }
     if (selectedProvider === 'codex_cli') {
-      return { backend: 'codex_cli', reasoningEffort: 'medium' }
+      return {
+        backend: 'codex_cli',
+        reasoningEffort: 'medium',
+        ...(selectedBackendModel ? { model: selectedBackendModel } : {})
+      }
     }
-    return { backend: 'claude_cli', claudeEffort: claudeReasoning }
+    return {
+      backend: 'claude_cli',
+      claudeEffort: claudeReasoning,
+      ...(selectedBackendModel ? { model: selectedBackendModel } : {})
+    }
+  }
+  const selectModel = (model: string | null): void => {
+    if (!isCliProvider(selectedProvider)) return
+    setSelectedModels((current) => ({ ...current, [selectedProvider]: model }))
+  }
+  const applyCustomModel = (): void => {
+    const model = customModelDraft.trim()
+    if (!model) return
+    selectModel(model)
+    setCustomModelDraft('')
+    setModelMenuOpen(false)
+  }
+  const loadModelOptions = async (provider: AgentCliBackendId): Promise<void> => {
+    if (modelOptions[provider]) return
+    try {
+      const result = await window.api.agent.listBackendModels({ backend: provider })
+      setModelOptions((current) => ({ ...current, [provider]: result }))
+    } catch {
+      setModelOptions((current) => ({
+        ...current,
+        [provider]: {
+          backend: provider,
+          supportsCustomModel: true,
+          models: []
+        }
+      }))
+    }
+  }
+  const handleModelMenuOpenChange = (open: boolean): void => {
+    setModelMenuOpen(open)
+    if (open && isCliProvider(selectedProvider)) {
+      void loadModelOptions(selectedProvider)
+    }
+  }
+  const selectProvider = (provider: AgentProvider): void => {
+    setSelectedProvider(provider)
+    if (isCliProvider(provider)) {
+      void loadModelOptions(provider)
+    }
   }
 
   async function submit(): Promise<void> {
@@ -168,7 +316,8 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
         conversationId ??
         (
           await agent.createConversation({
-            backend: selectedProvider as AgentBackendId
+            backend: selectedProvider as AgentBackendId,
+            ...(selectedBackendModel ? { backendModel: selectedBackendModel } : {})
           })
         ).id
       await agent.sendTurn({
@@ -284,7 +433,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
             <DropdownMenuContent align="start" className="min-w-36 border-0">
               <DropdownMenuItem
                 disabled={claudeDisabled}
-                onSelect={() => setSelectedProvider('claude_cli')}
+                onSelect={() => selectProvider('claude_cli')}
                 className="text-xs focus:bg-transparent focus:text-foreground"
               >
                 <Claude className="size-4 text-muted-foreground" aria-hidden="true" />
@@ -295,7 +444,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
               </DropdownMenuItem>
               <DropdownMenuItem
                 disabled={codexDisabled}
-                onSelect={() => setSelectedProvider('codex_cli')}
+                onSelect={() => selectProvider('codex_cli')}
                 className="text-xs focus:bg-transparent focus:text-foreground"
               >
                 <ChatGpt className="size-4 text-muted-foreground" aria-hidden="true" />
@@ -305,7 +454,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
                 )}
               </DropdownMenuItem>
               <DropdownMenuItem
-                onSelect={() => setSelectedProvider('local_openai_compatible')}
+                onSelect={() => selectProvider('local_openai_compatible')}
                 className="text-xs focus:bg-transparent focus:text-foreground"
               >
                 <Computer className="size-4 text-muted-foreground" aria-hidden="true" />
@@ -316,6 +465,58 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          {isCliProvider(selectedProvider) && (
+            <DropdownMenu open={modelMenuOpen} onOpenChange={handleModelMenuOpenChange}>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={t('agentChat.composer.modelLabel', {
+                    model: selectedModelLabel
+                  })}
+                  className="inline-flex h-8 max-w-28 items-center gap-1 rounded-full bg-muted px-2 text-xs text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  <span className="truncate">{selectedModelLabel}</span>
+                  <ChevronDown className="size-3 shrink-0" aria-hidden="true" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="min-w-52 border-border/60 p-1.5">
+                {(selectedModelOptions?.models ?? []).map((model) => (
+                  <DropdownMenuItem
+                    key={model.id}
+                    onSelect={() => selectModel(model.id)}
+                    className="text-xs focus:bg-transparent focus:text-foreground"
+                  >
+                    <span>{model.label}</span>
+                    {selectedBackendModel === model.id && (
+                      <Check className="ms-auto size-3 text-muted-foreground" aria-hidden="true" />
+                    )}
+                  </DropdownMenuItem>
+                ))}
+                <div
+                  className="mt-1 border-t border-border/60 pt-1"
+                  onKeyDown={(event) => event.stopPropagation()}
+                  onPointerDown={(event) => event.stopPropagation()}
+                >
+                  <label htmlFor={customModelInputId} className="sr-only">
+                    {t('agentChat.composer.customModelLabel')}
+                  </label>
+                  <Input
+                    id={customModelInputId}
+                    value={customModelDraft}
+                    onChange={(event) => setCustomModelDraft(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        event.preventDefault()
+                        applyCustomModel()
+                      }
+                    }}
+                    placeholder={t('agentChat.composer.customModelPlaceholder')}
+                    className="h-8 text-xs"
+                  />
+                </div>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
           {selectedProvider === 'claude_cli' && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/apps/desktop/src/renderer/src/agent-chat/composer.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/composer.tsx
@@ -6,6 +6,7 @@ import type {
   AgentCliBackendId,
   AgentBackendOptions,
   AttachmentInput,
+  CodexReasoningEffort,
   ClaudeEffort
 } from '@memry/contracts/ipc-agent'
 import { DEFAULT_CLAUDE_EFFORT } from '@memry/contracts/ipc-agent'
@@ -35,6 +36,7 @@ interface ComposerProps {
 type AgentProvider = 'claude_cli' | 'codex_cli' | 'local_openai_compatible'
 
 const DEFAULT_CLAUDE_MODEL = 'opus'
+const DEFAULT_CODEX_REASONING: CodexReasoningEffort = 'medium'
 
 const DEFAULT_SELECTED_MODELS: Record<AgentCliBackendId, string | null> = {
   claude_cli: DEFAULT_CLAUDE_MODEL,
@@ -59,11 +61,13 @@ const MODEL_LABEL_FALLBACKS: Record<AgentCliBackendId, Record<string, string>> =
   }
 }
 
-const claudeReasoningOptions: Array<{
-  value: ClaudeEffort
+type ReasoningOption<Value extends string> = {
+  value: Value
   labelKey: string
   summaryKey: string
-}> = [
+}
+
+const claudeReasoningOptions: Array<ReasoningOption<ClaudeEffort>> = [
   {
     value: 'low',
     labelKey: 'agentChat.composer.claudeSettings.reasoning.low',
@@ -88,6 +92,29 @@ const claudeReasoningOptions: Array<{
     value: 'max',
     labelKey: 'agentChat.composer.claudeSettings.reasoning.max',
     summaryKey: 'agentChat.composer.claudeSettings.reasoning.max'
+  }
+]
+
+const codexReasoningOptions: Array<ReasoningOption<CodexReasoningEffort>> = [
+  {
+    value: 'low',
+    labelKey: 'agentChat.composer.codexSettings.reasoning.low',
+    summaryKey: 'agentChat.composer.codexSettings.reasoning.low'
+  },
+  {
+    value: 'medium',
+    labelKey: 'agentChat.composer.codexSettings.reasoning.mediumDefault',
+    summaryKey: 'agentChat.composer.codexSettings.reasoning.medium'
+  },
+  {
+    value: 'high',
+    labelKey: 'agentChat.composer.codexSettings.reasoning.high',
+    summaryKey: 'agentChat.composer.codexSettings.reasoning.high'
+  },
+  {
+    value: 'xhigh',
+    labelKey: 'agentChat.composer.codexSettings.reasoning.extraHigh',
+    summaryKey: 'agentChat.composer.codexSettings.reasoning.extraHigh'
   }
 ]
 
@@ -164,6 +191,8 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
     useState<Record<AgentCliBackendId, AgentBackendModelList | null>>(EMPTY_MODEL_OPTIONS)
   const [customModelDraft, setCustomModelDraft] = useState('')
   const [claudeReasoning, setClaudeReasoning] = useState<ClaudeEffort>(DEFAULT_CLAUDE_EFFORT)
+  const [codexReasoning, setCodexReasoning] =
+    useState<CodexReasoningEffort>(DEFAULT_CODEX_REASONING)
 
   useEffect(() => {
     if (activeTab?.type !== 'note' || !activeTab.entityId) return
@@ -246,8 +275,16 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
   const selectedClaudeReasoning =
     claudeReasoningOptions.find((option) => option.value === claudeReasoning) ??
     claudeReasoningOptions[3]
-  const claudeSettingsSummary = t('agentChat.composer.settingsSummary', {
-    reasoning: t(selectedClaudeReasoning.summaryKey)
+  const selectedCodexReasoning =
+    codexReasoningOptions.find((option) => option.value === codexReasoning) ??
+    codexReasoningOptions[1]
+  const selectedReasoning =
+    selectedProvider === 'codex_cli' ? selectedCodexReasoning : selectedClaudeReasoning
+  const selectedReasoningOptions =
+    selectedProvider === 'codex_cli' ? codexReasoningOptions : claudeReasoningOptions
+  const selectedReasoningValue = selectedProvider === 'codex_cli' ? codexReasoning : claudeReasoning
+  const settingsSummary = t('agentChat.composer.settingsSummary', {
+    reasoning: t(selectedReasoning.summaryKey)
   })
   const backendOptions = (): AgentBackendOptions => {
     if (selectedProvider === 'local_openai_compatible') {
@@ -256,7 +293,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
     if (selectedProvider === 'codex_cli') {
       return {
         backend: 'codex_cli',
-        reasoningEffort: 'medium',
+        reasoningEffort: codexReasoning,
         ...(selectedBackendModel ? { model: selectedBackendModel } : {})
       }
     }
@@ -276,6 +313,13 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
     selectModel(model)
     setCustomModelDraft('')
     setModelMenuOpen(false)
+  }
+  const selectReasoning = (value: ClaudeEffort | CodexReasoningEffort): void => {
+    if (selectedProvider === 'codex_cli') {
+      setCodexReasoning(value as CodexReasoningEffort)
+      return
+    }
+    setClaudeReasoning(value as ClaudeEffort)
   }
   const loadModelOptions = async (provider: AgentCliBackendId): Promise<void> => {
     if (modelOptions[provider]) return
@@ -517,17 +561,17 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-          {selectedProvider === 'claude_cli' && (
+          {isCliProvider(selectedProvider) && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
                   aria-label={t('agentChat.composer.settingsLabel', {
-                    settings: claudeSettingsSummary
+                    settings: settingsSummary
                   })}
                   className="inline-flex h-8 min-w-0 items-center gap-1 rounded-full bg-muted px-2 text-xs text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
-                  <span className="truncate">{claudeSettingsSummary}</span>
+                  <span className="truncate">{settingsSummary}</span>
                   <ChevronDown className="size-3 shrink-0" aria-hidden="true" />
                 </button>
               </DropdownMenuTrigger>
@@ -535,11 +579,11 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
                 <DropdownMenuLabel className="px-2 py-1 text-[11px] font-medium text-muted-foreground">
                   {t('agentChat.composer.settings.reasoning')}
                 </DropdownMenuLabel>
-                {claudeReasoningOptions.map((option) => (
+                {selectedReasoningOptions.map((option) => (
                   <DropdownMenuCheckboxItem
                     key={option.value}
-                    checked={claudeReasoning === option.value}
-                    onCheckedChange={() => setClaudeReasoning(option.value)}
+                    checked={selectedReasoningValue === option.value}
+                    onCheckedChange={() => selectReasoning(option.value)}
                     className="text-xs"
                   >
                     {t(option.labelKey)}

--- a/apps/desktop/tests/setup-dom.ts
+++ b/apps/desktop/tests/setup-dom.ts
@@ -408,6 +408,21 @@ const createMockApi = () => ({
         detail: null
       }
     }),
+    listBackendModels: vi.fn().mockImplementation(async ({ backend }) => ({
+      backend,
+      supportsCustomModel: true,
+      models:
+        backend === 'claude_cli'
+          ? [
+              { id: 'sonnet', label: 'Sonnet' },
+              { id: 'opus', label: 'Opus' }
+            ]
+          : [
+              { id: 'gpt-5.5', label: 'GPT-5.5' },
+              { id: 'gpt-5.4', label: 'GPT-5.4' },
+              { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' }
+            ]
+    })),
     getLocalProviderSettings: vi.fn().mockResolvedValue({
       preset: 'ollama',
       baseUrl: 'http://localhost:11434/v1',

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -39,6 +39,11 @@ it after messages exist updates the conversation and records the switch in the c
 also exposes prompt-time reasoning effort settings, with provider-specific settings shown only for
 the active provider.
 
+Claude and Codex conversations also have a per-conversation model selector. Memry starts Claude on
+`opus` and Codex on the highest suggested GPT version, then passes the selected model through to the
+CLI for each turn. The built-in model list is only a shortcut for common CLI aliases; type a custom
+model ID when you want to pin another CLI-supported model.
+
 Local model support uses OpenAI-compatible HTTP APIs. Memry ships presets for Ollama, LM Studio, and
 llama.cpp server, plus a Custom endpoint. Local tool access is gated by a capability probe. If the
 model can emit tool calls and continue after a tool result, Memry enables the full vault tool set. If

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -36,8 +36,8 @@ exposing Memry MCP tools.
 
 The prompt bar shows the selected agent provider. The provider is pinned per conversation; changing
 it after messages exist updates the conversation and records the switch in the chat history. Claude
-also exposes prompt-time reasoning effort settings, with provider-specific settings shown only for
-the active provider.
+and Codex expose prompt-time reasoning effort settings, with provider-specific settings shown only
+for the active provider.
 
 Claude and Codex conversations also have a per-conversation model selector. Memry starts Claude on
 `opus` and Codex on the highest suggested GPT version, then passes the selected model through to the

--- a/packages/contracts/src/ipc-agent.test.ts
+++ b/packages/contracts/src/ipc-agent.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   AgentBackendIdSchema,
+  AgentBackendModelListSchema,
   BackendStatusesResponseSchema,
   AgentBackendOptionsSchema,
   AgentChannels,
@@ -31,6 +32,7 @@ describe('AgentChannels', () => {
         PREVIEW_DIFF: 'agent:previewDiff',
         EDIT_TRUST_LIST: 'agent:editTrustList',
         GET_BACKEND_STATUSES: 'agent:getBackendStatuses',
+        LIST_BACKEND_MODELS: 'agent:listBackendModels',
         GET_LOCAL_PROVIDER_SETTINGS: 'agent:getLocalProviderSettings',
         SET_LOCAL_PROVIDER_SETTINGS: 'agent:setLocalProviderSettings',
         LIST_LOCAL_MODELS: 'agent:listLocalModels',
@@ -59,13 +61,15 @@ describe('agent IPC schemas', () => {
     expect(
       AgentBackendOptionsSchema.safeParse({
         backend: 'claude_cli',
-        claudeEffort: 'xhigh'
+        claudeEffort: 'xhigh',
+        model: 'sonnet'
       }).success
     ).toBe(true)
     expect(
       AgentBackendOptionsSchema.safeParse({
         backend: 'codex_cli',
-        reasoningEffort: 'high'
+        reasoningEffort: 'high',
+        model: 'gpt-5.5'
       }).success
     ).toBe(true)
     expect(
@@ -79,6 +83,34 @@ describe('agent IPC schemas', () => {
       AgentBackendOptionsSchema.safeParse({
         backend: 'local_openai_compatible',
         claudeEffort: 'xhigh'
+      }).success
+    ).toBe(false)
+    expect(
+      AgentBackendOptionsSchema.safeParse({
+        backend: 'claude_cli',
+        claudeEffort: 'xhigh',
+        reasoningEffort: 'medium'
+      }).success
+    ).toBe(false)
+  })
+
+  it('validates CLI backend model suggestion lists with custom entry support', () => {
+    expect(
+      AgentBackendModelListSchema.safeParse({
+        backend: 'codex_cli',
+        supportsCustomModel: true,
+        models: [
+          { id: 'gpt-5.5', label: 'GPT-5.5' },
+          { id: 'gpt-5.4', label: 'GPT-5.4' }
+        ]
+      }).success
+    ).toBe(true)
+
+    expect(
+      AgentBackendModelListSchema.safeParse({
+        backend: 'local_openai_compatible',
+        supportsCustomModel: true,
+        models: []
       }).success
     ).toBe(false)
   })

--- a/packages/contracts/src/ipc-agent.ts
+++ b/packages/contracts/src/ipc-agent.ts
@@ -20,6 +20,7 @@ export const AgentChannels = {
     PREVIEW_DIFF: 'agent:previewDiff',
     EDIT_TRUST_LIST: 'agent:editTrustList',
     GET_BACKEND_STATUSES: 'agent:getBackendStatuses',
+    LIST_BACKEND_MODELS: 'agent:listBackendModels',
     GET_LOCAL_PROVIDER_SETTINGS: 'agent:getLocalProviderSettings',
     SET_LOCAL_PROVIDER_SETTINGS: 'agent:setLocalProviderSettings',
     LIST_LOCAL_MODELS: 'agent:listLocalModels',
@@ -52,6 +53,9 @@ export const AgentBackendIdSchema = z.enum(['claude_cli', 'codex_cli', 'local_op
 export type AgentBackendId = z.infer<typeof AgentBackendIdSchema>
 export const DEFAULT_AGENT_BACKEND_ID: AgentBackendId = 'claude_cli'
 
+export const AgentCliBackendIdSchema = z.enum(['claude_cli', 'codex_cli'])
+export type AgentCliBackendId = z.infer<typeof AgentCliBackendIdSchema>
+
 export const CodexReasoningEffortSchema = z.enum(['low', 'medium', 'high', 'xhigh'])
 export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>
 
@@ -63,13 +67,15 @@ export const AgentBackendOptionsSchema = z
     z
       .object({
         backend: z.literal('claude_cli'),
-        claudeEffort: ClaudeEffortSchema.default(DEFAULT_CLAUDE_EFFORT)
+        claudeEffort: ClaudeEffortSchema.default(DEFAULT_CLAUDE_EFFORT),
+        model: z.string().min(1).optional()
       })
       .strict(),
     z
       .object({
         backend: z.literal('codex_cli'),
-        reasoningEffort: CodexReasoningEffortSchema.default('medium')
+        reasoningEffort: CodexReasoningEffortSchema.default('medium'),
+        model: z.string().min(1).optional()
       })
       .strict(),
     z
@@ -82,6 +88,30 @@ export const AgentBackendOptionsSchema = z
   ])
   .default({ backend: 'claude_cli', claudeEffort: DEFAULT_CLAUDE_EFFORT })
 export type AgentBackendOptions = z.infer<typeof AgentBackendOptionsSchema>
+
+export const AgentBackendModelListRequestSchema = z
+  .object({
+    backend: AgentCliBackendIdSchema
+  })
+  .strict()
+export type AgentBackendModelListRequest = z.infer<typeof AgentBackendModelListRequestSchema>
+
+export const AgentBackendModelOptionSchema = z
+  .object({
+    id: z.string().min(1),
+    label: z.string().min(1)
+  })
+  .strict()
+export type AgentBackendModelOption = z.infer<typeof AgentBackendModelOptionSchema>
+
+export const AgentBackendModelListSchema = z
+  .object({
+    backend: AgentCliBackendIdSchema,
+    supportsCustomModel: z.boolean(),
+    models: z.array(AgentBackendModelOptionSchema)
+  })
+  .strict()
+export type AgentBackendModelList = z.infer<typeof AgentBackendModelListSchema>
 
 export const AgentLocalProviderSettingsSchema = z
   .object({

--- a/packages/i18n/src/locales/ar/common.json
+++ b/packages/i18n/src/locales/ar/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/cs/common.json
+++ b/packages/i18n/src/locales/cs/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/da/common.json
+++ b/packages/i18n/src/locales/da/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/de/common.json
+++ b/packages/i18n/src/locales/de/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/el/common.json
+++ b/packages/i18n/src/locales/el/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -183,6 +183,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     },
     "refPicker": {

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -158,12 +158,18 @@
       "placeholder": "Ask Agent",
       "send": "Send",
       "providerLabel": "Agent provider: {provider}",
+      "modelLabel": "Agent model: {model}",
       "settingsLabel": "Agent settings: {settings}",
       "settingsSummary": "{reasoning}",
+      "customModelLabel": "Custom model ID",
+      "customModelPlaceholder": "Custom model ID",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Local"
+      },
+      "models": {
+        "default": "Default"
       },
       "settings": {
         "reasoning": "Reasoning"

--- a/packages/i18n/src/locales/es/common.json
+++ b/packages/i18n/src/locales/es/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/fi/common.json
+++ b/packages/i18n/src/locales/fi/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/fil/common.json
+++ b/packages/i18n/src/locales/fil/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/he/common.json
+++ b/packages/i18n/src/locales/he/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/hr/common.json
+++ b/packages/i18n/src/locales/hr/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/hu/common.json
+++ b/packages/i18n/src/locales/hu/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/id/common.json
+++ b/packages/i18n/src/locales/id/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/it/common.json
+++ b/packages/i18n/src/locales/it/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/ja/common.json
+++ b/packages/i18n/src/locales/ja/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/ko/common.json
+++ b/packages/i18n/src/locales/ko/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/ms/common.json
+++ b/packages/i18n/src/locales/ms/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/nl/common.json
+++ b/packages/i18n/src/locales/nl/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/no/common.json
+++ b/packages/i18n/src/locales/no/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/pl/common.json
+++ b/packages/i18n/src/locales/pl/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/pt/common.json
+++ b/packages/i18n/src/locales/pt/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/ro/common.json
+++ b/packages/i18n/src/locales/ro/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/ru/common.json
+++ b/packages/i18n/src/locales/ru/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/sk/common.json
+++ b/packages/i18n/src/locales/sk/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/sv/common.json
+++ b/packages/i18n/src/locales/sv/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/th/common.json
+++ b/packages/i18n/src/locales/th/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/tr/common.json
+++ b/packages/i18n/src/locales/tr/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/uk/common.json
+++ b/packages/i18n/src/locales/uk/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/vi/common.json
+++ b/packages/i18n/src/locales/vi/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/zh-CN/common.json
+++ b/packages/i18n/src/locales/zh-CN/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }

--- a/packages/i18n/src/locales/zh-TW/common.json
+++ b/packages/i18n/src/locales/zh-TW/common.json
@@ -390,6 +390,15 @@
           "extraHighDefault": "Extra High (default)",
           "max": "Max"
         }
+      },
+      "codexSettings": {
+        "reasoning": {
+          "low": "Low",
+          "medium": "Medium",
+          "mediumDefault": "Medium (default)",
+          "high": "High",
+          "extraHigh": "Extra High"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add per-conversation Claude CLI and Codex CLI model selection
- pass selected model IDs through contracts, IPC, preload, backend adapters, and CLI spawn flags
- default Claude to opus and Codex to the highest suggested GPT version while keeping custom model ID entry
- document Agent Chat model selection behavior

## Validation
- pnpm exec vitest run packages/contracts/src/ipc-agent.test.ts
- pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project main src/main/agent/cli/__tests__/spawn.test.ts src/main/agent/cli/__tests__/codex-spawn.test.ts src/main/agent/backends/__tests__/claude-cli-backend.test.ts src/main/agent/backends/__tests__/codex-cli-backend.test.ts src/main/agent/bootstrap.test.ts src/main/ipc/agent-handlers.test.ts
- pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/agent-chat/__tests__/composer.test.tsx
- pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project preload src/preload/api/preload-api.test.ts
- pnpm --dir apps/desktop ipc:check
- pnpm --filter @memry/contracts typecheck
- pnpm --dir apps/desktop typecheck:node
- pnpm --dir apps/desktop typecheck:web
- pnpm docs:impact --strict
- pnpm docs:build
- git diff --check