### PR TITLE
Polish settings panel accents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-05-13 — Settings Panel Accent Polish
+
+### Changed
+
+- Use the active settings surface color for bordered settings sections, remove the redundant settings sidebar title, and make orange the default accent preset.
+
 ## 2026-05-07 — Notes and Journal Block Marquee Selection
 
 ### Fixed

--- a/apps/desktop/src/main/ipc/settings-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
 import { mockIpcMain, resetIpcMocks, invokeHandler } from '@tests/utils/mock-ipc'
 import { SettingsChannels } from '@memry/contracts/ipc-channels'
+import { GENERAL_SETTINGS_DEFAULTS } from '@memry/contracts/settings-schemas'
 
 const handleCalls: unknown[][] = []
 const removeHandlerCalls: string[] = []
@@ -893,7 +894,7 @@ describe('settings-handlers', () => {
         SettingsChannels.sync.GET_STARTUP_THEME
       )
 
-      expect(result).toEqual({ theme: 'white', accentColor: '#6366f1' })
+      expect(result).toEqual({ theme: 'white', accentColor: GENERAL_SETTINGS_DEFAULTS.accentColor })
     })
 
     it('#given no settings in db #when startup theme requested #then returns defaults', () => {
@@ -904,7 +905,10 @@ describe('settings-handlers', () => {
         SettingsChannels.sync.GET_STARTUP_THEME
       )
 
-      expect(result).toEqual({ theme: 'system', accentColor: '#6366f1' })
+      expect(result).toEqual({
+        theme: 'system',
+        accentColor: GENERAL_SETTINGS_DEFAULTS.accentColor
+      })
     })
   })
 

--- a/apps/desktop/src/main/vault/settings-cache.test.ts
+++ b/apps/desktop/src/main/vault/settings-cache.test.ts
@@ -93,7 +93,7 @@ describe('populateSettingsCacheFromConfig', () => {
     const generalRaw = getSetting(testDb.db as any, 'general')
     const general = JSON.parse(generalRaw!)
     expect(general.theme).toBe('system')
-    expect(general.accentColor).toBe('#6366f1')
+    expect(general.accentColor).toBe(GENERAL_SETTINGS_DEFAULTS.accentColor)
   })
 
   it('#given existing machine-local settings in SQLite #then preserves them', () => {

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -1330,7 +1330,8 @@ del.bn-inline-content {
 :root,
 .white,
 .dark {
-  --tint: var(--user-accent-color, #6366f1);
+  --default-user-accent-color: #f97316;
+  --tint: var(--user-accent-color, var(--default-user-accent-color));
   --tint-foreground: #ffffff;
   --tint-hover: color-mix(in srgb, var(--tint) 85%, black);
   --tint-light: color-mix(in srgb, var(--tint) 15%, transparent);

--- a/apps/desktop/src/renderer/src/components/settings/integration-list.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/integration-list.tsx
@@ -59,7 +59,7 @@ export function IntegrationList(): React.JSX.Element {
   const integrations = getAvailableIntegrations()
 
   return (
-    <div className="flex flex-col rounded-lg overflow-clip border border-border">
+    <div className="flex flex-col rounded-lg overflow-clip border border-border bg-surface-active">
       {integrations.map((integration, i) => {
         return (
           <div key={integration.id}>

--- a/apps/desktop/src/renderer/src/components/settings/settings-primitives.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/settings-primitives.tsx
@@ -38,7 +38,7 @@ export function SettingsGroup({ label, children }: SettingsGroupProps) {
           {label}
         </h4>
       )}
-      <div className="flex flex-col rounded-lg overflow-clip border border-border">
+      <div className="flex flex-col rounded-lg overflow-clip border border-border bg-surface-active">
         {items.map((child, i) => (
           <div key={i}>
             {i > 0 && <div className="h-px bg-border" />}

--- a/apps/desktop/src/renderer/src/components/settings/tag-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/tag-manager.tsx
@@ -167,7 +167,7 @@ export function TagManager() {
         />
       </div>
 
-      <div className="flex flex-col rounded-lg overflow-y-auto max-h-[60vh] border border-border">
+      <div className="flex flex-col rounded-lg overflow-y-auto max-h-[60vh] border border-border bg-surface-active">
         {filteredTags.length === 0 && (
           <p className="text-xs/4 text-muted-foreground py-4 text-center">
             {t('tags.noMatch', { query: search })}

--- a/apps/desktop/src/renderer/src/hooks/use-general-settings.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-general-settings.ts
@@ -1,19 +1,10 @@
 import { useState, useEffect, useCallback } from 'react'
+import { GENERAL_SETTINGS_DEFAULTS } from '@memry/contracts/settings-schemas'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import type { GeneralSettingsDTO } from '../../../preload/index.d'
 import { getI18n } from 'react-i18next'
 
-const DEFAULTS: GeneralSettingsDTO = {
-  theme: 'system',
-  fontSize: 'medium',
-  fontFamily: 'system',
-  accentColor: '#6366f1',
-  startOnBoot: false,
-  language: 'en',
-  onboardingCompleted: false,
-  createInSelectedFolder: true,
-  clockFormat: '12h'
-}
+const DEFAULTS: GeneralSettingsDTO = GENERAL_SETTINGS_DEFAULTS
 
 interface UseGeneralSettingsReturn {
   settings: GeneralSettingsDTO

--- a/apps/desktop/src/renderer/src/pages/settings.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings.tsx
@@ -43,12 +43,6 @@ export function SettingsPage() {
   return (
     <div className="flex-1 min-h-0 flex">
       <div className="w-60 shrink-0 pt-5 pb-4 overflow-y-auto min-h-0 bg-sidebar border-e border-border text-xs/4 font-[family-name:var(--font-sans)]">
-        <div className="flex items-center pb-4 px-5">
-          <span className="text-sm/4.5 font-semibold text-foreground tracking-[-0.01em]">
-            {t('page.title')}
-          </span>
-        </div>
-
         <SettingsNavGroup label={t('page.nav.groups.workspace')}>
           <SettingsNavItem
             icon={<User className="w-3.5 h-3.5" />}

--- a/apps/desktop/src/renderer/src/pages/settings/properties-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/properties-section.tsx
@@ -251,7 +251,7 @@ function PropertyManager() {
         />
       </div>
 
-      <div className="flex flex-col rounded-lg overflow-y-auto max-h-[60vh] border border-border">
+      <div className="flex flex-col rounded-lg overflow-y-auto max-h-[60vh] border border-border bg-surface-active">
         {selectDefs.length === 0 && (
           <p className="text-xs/4 text-muted-foreground py-4 text-center">
             {t('properties.noMatch', { query: search })}

--- a/apps/desktop/src/renderer/src/pages/settings/settings-page.i18n.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/settings-page.i18n.test.tsx
@@ -54,7 +54,7 @@ describe('SettingsPage i18n', () => {
       </I18nextProvider>
     )
 
-    expect(screen.getByText('Settings')).toBeInTheDocument()
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument()
 
     for (const label of ['Workspace', 'Preferences', 'Services', 'Data']) {
       expect(screen.getByText(label)).toBeInTheDocument()

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -156,7 +156,7 @@ Light, White, Dark, or System (follow OS).
 
 ### Accent Color
 
-Eight presets — indigo, amber, emerald, red, violet, cyan, pink, orange — plus a custom `#RRGGBB` input.
+Eight presets — indigo, amber, emerald, red, violet, cyan, pink, orange — plus a custom `#RRGGBB` input. Orange is the default accent.
 
 ### Typography
 

--- a/packages/contracts/src/settings-schemas.test.ts
+++ b/packages/contracts/src/settings-schemas.test.ts
@@ -35,13 +35,19 @@ import {
   TestConnectionRequestSchema,
   TestConnectionResultSchema,
   CalendarGoogleSettingsSchema,
-  CALENDAR_GOOGLE_SETTINGS_DEFAULTS
+  CALENDAR_GOOGLE_SETTINGS_DEFAULTS,
+  DEFAULT_ACCENT_COLOR
 } from './settings-schemas'
 
 describe('GeneralSettingsSchema', () => {
   it('accepts the shipped default payload', () => {
     const result = GeneralSettingsSchema.safeParse(GENERAL_SETTINGS_DEFAULTS)
     expect(result.success).toBe(true)
+  })
+
+  it('uses the shipped orange accent preset as default', () => {
+    expect(GENERAL_SETTINGS_DEFAULTS.accentColor).toBe(DEFAULT_ACCENT_COLOR)
+    expect(DEFAULT_ACCENT_COLOR).toBe('#f97316')
   })
 
   it('accepts a custom accent color with 6-digit hex', () => {

--- a/packages/contracts/src/settings-schemas.ts
+++ b/packages/contracts/src/settings-schemas.ts
@@ -28,11 +28,13 @@ export const GeneralSettingsSchema = z.object({
 
 export type GeneralSettings = z.infer<typeof GeneralSettingsSchema>
 
+export const DEFAULT_ACCENT_COLOR = '#f97316'
+
 export const GENERAL_SETTINGS_DEFAULTS: GeneralSettings = {
   theme: 'system',
   fontSize: 'medium',
   fontFamily: 'system',
-  accentColor: '#6366f1',
+  accentColor: DEFAULT_ACCENT_COLOR,
   startOnBoot: false,
   language: 'en',
   onboardingCompleted: false,

--- a/scripts/check-staged-secrets.mjs
+++ b/scripts/check-staged-secrets.mjs
@@ -79,6 +79,7 @@ function isSourceCodeReferenceValue(filePath, value) {
   return (
     isTypeScriptTypeValue(normalized) ||
     /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+$/.test(normalized) ||
+    /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*(?:\([^;]*\))?)+$/.test(normalized) ||
     /^[A-Za-z_$][\w$]*(?:\[[^\]]+\])+$/.test(normalized) ||
     /^[A-Za-z_$][\w$]*\([^;]*\)$/.test(normalized)
   )

--- a/scripts/check-staged-secrets.mjs
+++ b/scripts/check-staged-secrets.mjs
@@ -69,6 +69,16 @@ function isTypeScriptTypeValue(value) {
   return new RegExp(`^${typeAtom}(?:\\s*\\|\\s*${typeAtom})*$`).test(value)
 }
 
+function isChainedCodeCallValue(value) {
+  const parts = value.split('.')
+
+  return (
+    parts.length > 1 &&
+    /^[A-Za-z_$][\w$]*$/.test(parts[0]) &&
+    parts.slice(1).every((part) => /^[A-Za-z_$][\w$]*(?:\([^;\n]*\))?$/.test(part))
+  )
+}
+
 function isSourceCodeReferenceValue(filePath, value) {
   if (!sourceCodePathPattern.test(filePath) || isQuotedValue(value)) {
     return false
@@ -79,7 +89,7 @@ function isSourceCodeReferenceValue(filePath, value) {
   return (
     isTypeScriptTypeValue(normalized) ||
     /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+$/.test(normalized) ||
-    /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*(?:\([^;]*\))?)+$/.test(normalized) ||
+    isChainedCodeCallValue(normalized) ||
     /^[A-Za-z_$][\w$]*(?:\[[^\]]+\])+$/.test(normalized) ||
     /^[A-Za-z_$][\w$]*\([^;]*\)$/.test(normalized)
   )

--- a/scripts/check-staged-secrets.test.mjs
+++ b/scripts/check-staged-secrets.test.mjs
@@ -46,6 +46,15 @@ describe('staged secret scanner', () => {
     assert.equal(findings.length, 0)
   })
 
+  it('does not flag schema validators that contain token-like names', () => {
+    const findings = scanTextForSecrets(
+      'packages/contracts/src/settings-schemas.ts',
+      ['reAuthToken: z.string().min(1)', 'tokenStatus: z.enum(["valid", "invalid"])'].join('\n')
+    )
+
+    assert.equal(findings.length, 0)
+  })
+
   it('does not flag generic secret-shaped assignments in test files', () => {
     const findings = scanTextForSecrets(
       'apps/sync-server/src/routes/auth.test.ts',


### PR DESCRIPTION
## Summary
- use the theme-aware active surface background for settings section shells
- remove the redundant Settings label from the settings sidebar
- switch the default accent color to the existing orange preset and document it
- keep staged secret scanning from flagging chained schema validators as literal secrets

## Validation
- pnpm --filter @memry/contracts exec vitest run src/settings-schemas.test.ts
- pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/hooks/use-theme-sync.test.ts
- pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/vault/settings-cache.test.ts
- pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/ipc/settings-handlers.test.ts
- node --test scripts/check-staged-secrets.test.mjs
- pnpm --filter @memry/desktop typecheck:web
- pnpm --filter @memry/contracts typecheck
- pnpm exec prettier --check packages/contracts/src/settings-schemas.ts packages/contracts/src/settings-schemas.test.ts apps/desktop/src/renderer/src/hooks/use-general-settings.ts apps/desktop/src/renderer/src/assets/base.css apps/desktop/src/main/vault/settings-cache.test.ts apps/desktop/src/main/ipc/settings-handlers.test.ts
- pnpm exec prettier --check scripts/check-staged-secrets.mjs scripts/check-staged-secrets.test.mjs
- pnpm check:staged-secrets
- pnpm docs:impact --base cf46c96f3a226a632ab75a736dd4089c0e659811 --strict
- pnpm docs:build
- npx -y react-doctor@latest . --verbose --diff