### PR TITLE
Compact AI settings

### DIFF
--- a/apps/desktop/src/renderer/src/pages/settings.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings.tsx
@@ -13,8 +13,7 @@ import {
   List,
   Key,
   User,
-  CalendarDays,
-  Server
+  CalendarDays
 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { GeneralSettings } from './settings/general-section'
@@ -24,7 +23,6 @@ import { JournalSettings } from './settings/journal-section'
 import { VaultSettings } from './settings/vault-section'
 import { AppearanceSettings } from './settings/appearance-section'
 import { AISettings } from './settings/ai-section'
-import { AgentProvidersSection } from './settings/agent-providers-section'
 import { IntegrationsSettings } from './settings/integrations-section'
 import { TagsSettings } from './settings/tags-section'
 import { PropertiesSettings } from './settings/properties-section'
@@ -32,13 +30,16 @@ import { TasksSettings } from './settings/tasks-section'
 import { CalendarSettingsSection } from './settings/calendar-section'
 import { ShortcutsSettings } from './settings/shortcuts-section'
 import { AccountSettings } from './settings/account-section'
-import { AgentMcpSection } from './settings/agent-mcp-section'
 import { useSettingsModal } from '@/contexts/settings-modal-context'
 import { useT } from '@memry/i18n/renderer'
 
 export function SettingsPage() {
   const { activeSection, setActiveSection } = useSettingsModal()
   const { t } = useT('settings')
+  const isAssistantSection =
+    activeSection === 'ai' || activeSection === 'agent-providers' || activeSection === 'agent-mcp'
+  const initialAssistantPanel =
+    activeSection === 'agent-providers' || activeSection === 'agent-mcp' ? activeSection : undefined
 
   return (
     <div className="flex-1 min-h-0 flex">
@@ -113,20 +114,8 @@ export function SettingsPage() {
           <SettingsNavItem
             icon={<Brain className="w-3.5 h-3.5" />}
             label={t('page.nav.items.ai')}
-            isActive={activeSection === 'ai'}
+            isActive={isAssistantSection}
             onClick={() => setActiveSection('ai')}
-          />
-          <SettingsNavItem
-            icon={<Server className="w-3.5 h-3.5" />}
-            label={t('page.nav.items.agentProviders')}
-            isActive={activeSection === 'agent-providers'}
-            onClick={() => setActiveSection('agent-providers')}
-          />
-          <SettingsNavItem
-            icon={<Server className="w-3.5 h-3.5" />}
-            label={t('page.nav.items.agentMcp')}
-            isActive={activeSection === 'agent-mcp'}
-            onClick={() => setActiveSection('agent-mcp')}
           />
           <SettingsNavItem
             icon={<Plug className="w-3.5 h-3.5" />}
@@ -169,9 +158,7 @@ export function SettingsPage() {
             {activeSection === 'calendar' && <CalendarSettingsSection />}
             {activeSection === 'vault' && <VaultSettings />}
             {activeSection === 'appearance' && <AppearanceSettings />}
-            {activeSection === 'ai' && <AISettings />}
-            {activeSection === 'agent-providers' && <AgentProvidersSection />}
-            {activeSection === 'agent-mcp' && <AgentMcpSection />}
+            {isAssistantSection && <AISettings initialOpenPanel={initialAssistantPanel} />}
             {activeSection === 'integrations' && <IntegrationsSettings />}
             {activeSection === 'tags' && <TagsSettings />}
             {activeSection === 'properties' && <PropertiesSettings />}

--- a/apps/desktop/src/renderer/src/pages/settings/agent-mcp-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/agent-mcp-section.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/settings/settings-primitives'
 import { useT } from '@memry/i18n/renderer'
 
-export function AgentMcpSection() {
+export function AgentMcpSection({ embedded = false }: { embedded?: boolean }) {
   const { t } = useT('settings')
   const [status, setStatus] = useState<AgentMcpStatus | null>(null)
   const [isRotating, setIsRotating] = useState(false)
@@ -45,17 +45,19 @@ export function AgentMcpSection() {
 
   return (
     <div>
-      <SettingsHeader
-        title={t('agentMcp.header.title')}
-        subtitle={t('agentMcp.header.subtitle')}
-        action={
-          status && (
-            <span className="rounded-md border border-border bg-muted/50 px-2 py-1 text-xs/4 text-muted-foreground">
-              {t('agentMcp.toolsBadge', { count: toolCount })}
-            </span>
-          )
-        }
-      />
+      {!embedded && (
+        <SettingsHeader
+          title={t('agentMcp.header.title')}
+          subtitle={t('agentMcp.header.subtitle')}
+          action={
+            status && (
+              <span className="rounded-md border border-border bg-muted/50 px-2 py-1 text-xs/4 text-muted-foreground">
+                {t('agentMcp.toolsBadge', { count: toolCount })}
+              </span>
+            )
+          }
+        />
+      )}
 
       <SettingsGroup label={t('agentMcp.groups.connection')}>
         <SettingRowTall label={urlLabel} description={t('agentMcp.fields.url.description')}>

--- a/apps/desktop/src/renderer/src/pages/settings/agent-providers-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/agent-providers-section.tsx
@@ -30,7 +30,11 @@ const PRESET_DEFAULTS: Record<Exclude<AgentLocalProviderPreset, 'custom'>, strin
   llama_cpp: 'http://127.0.0.1:8080/v1'
 }
 
-export function AgentProvidersSection(): React.JSX.Element | null {
+export function AgentProvidersSection({
+  embedded = false
+}: {
+  embedded?: boolean
+}): React.JSX.Element | null {
   const { t } = useT('settings')
   const [settings, setSettings] = useState<AgentLocalProviderSettings | null>(null)
   const [apiKey, setApiKey] = useState('')
@@ -123,11 +127,13 @@ export function AgentProvidersSection(): React.JSX.Element | null {
 
   return (
     <div>
-      <SettingsHeader
-        title={t('agentProviders.header.title')}
-        subtitle={t('agentProviders.header.subtitle')}
-        action={<StatusBadge status={status} />}
-      />
+      {!embedded && (
+        <SettingsHeader
+          title={t('agentProviders.header.title')}
+          subtitle={t('agentProviders.header.subtitle')}
+          action={<StatusBadge status={status} />}
+        />
+      )}
 
       <SettingsGroup label={t('agentProviders.groups.local')}>
         <SettingRow label={t('agentProviders.fields.preset.label')}>

--- a/apps/desktop/src/renderer/src/pages/settings/ai-section.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/ai-section.test.tsx
@@ -16,6 +16,14 @@ vi.mock('./ai-inline-section', () => ({
   AIInlineSettings: () => <div>Inline AI panel</div>
 }))
 
+vi.mock('./agent-providers-section', () => ({
+  AgentProvidersSection: () => <div data-testid="agent-providers-panel" />
+}))
+
+vi.mock('./agent-mcp-section', () => ({
+  AgentMcpSection: () => <div data-testid="agent-mcp-panel" />
+}))
+
 type EmbeddingProgressEvent = {
   phase: string
   progress?: number
@@ -112,6 +120,27 @@ describe('AISettings', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Rebuild' }))
     expect(api.settings.reindexEmbeddings).toHaveBeenCalled()
     expect(toast.success).toHaveBeenCalledWith('Embeddings reindexed: 3 computed, 1 skipped')
+  })
+
+  it('keeps agent provider and MCP controls collapsed inside AI settings', async () => {
+    render(<AISettings />)
+
+    await waitFor(() => expect(screen.getByText('Agent Providers')).toBeInTheDocument())
+    expect(screen.queryByTestId('agent-providers-panel')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('agent-mcp-panel')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /Agent Providers/ }))
+    expect(screen.getByTestId('agent-providers-panel')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /Agent MCP/ }))
+    expect(screen.getByTestId('agent-mcp-panel')).toBeInTheDocument()
+  })
+
+  it('opens the matching advanced panel for legacy agent settings sections', async () => {
+    render(<AISettings initialOpenPanel="agent-mcp" />)
+
+    await waitFor(() => expect(screen.getByTestId('agent-mcp-panel')).toBeInTheDocument())
+    expect(screen.queryByTestId('agent-providers-panel')).not.toBeInTheDocument()
   })
 
   it('handles voice OpenAI key saving, model download, and progress events', async () => {

--- a/apps/desktop/src/renderer/src/pages/settings/ai-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/ai-section.tsx
@@ -1,12 +1,26 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, type ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
-import { Brain, Loader2, CheckCircle, XCircle, RefreshCw, Mic, Eye, EyeOff } from '@/lib/icons'
+import {
+  Bot,
+  Brain,
+  ChevronRight,
+  Loader2,
+  CheckCircle,
+  XCircle,
+  RefreshCw,
+  Mic,
+  Eye,
+  EyeOff,
+  Server
+} from '@/lib/icons'
 import { toast } from 'sonner'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { createLogger } from '@/lib/logger'
 import { AIInlineSettings as AIInlineSettingsPanel } from './ai-inline-section'
+import { AgentProvidersSection } from './agent-providers-section'
+import { AgentMcpSection } from './agent-mcp-section'
 import { useT } from '@memry/i18n/renderer'
 import {
   Select,
@@ -23,6 +37,7 @@ import {
   COMPACT_SELECT,
   ACCENT_SWITCH
 } from '@/components/settings/settings-primitives'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 
 const log = createLogger('Page:Settings:AI')
 
@@ -47,7 +62,13 @@ interface VoiceModelStatus {
   error: string | null
 }
 
-export function AISettings() {
+type AssistantAdvancedPanel = 'agent-providers' | 'agent-mcp'
+
+interface AISettingsProps {
+  initialOpenPanel?: AssistantAdvancedPanel
+}
+
+export function AISettings({ initialOpenPanel }: AISettingsProps = {}) {
   const { t } = useT('settings')
   const [settings, setSettings] = useState<{ enabled: boolean }>({ enabled: false })
   const [modelStatus, setModelStatus] = useState<AIModelStatus | null>(null)
@@ -562,6 +583,58 @@ export function AISettings() {
       </SettingsGroup>
 
       <AIInlineSettingsPanel />
+
+      <div className="flex flex-col pb-6 gap-2">
+        <AssistantAdvancedPanel
+          title={t('agentProviders.header.title')}
+          description={t('agentProviders.header.subtitle')}
+          icon={<Bot className="size-3.5" />}
+          defaultOpen={initialOpenPanel === 'agent-providers'}
+        >
+          <AgentProvidersSection embedded />
+        </AssistantAdvancedPanel>
+
+        <AssistantAdvancedPanel
+          title={t('agentMcp.header.title')}
+          description={t('agentMcp.header.subtitle')}
+          icon={<Server className="size-3.5" />}
+          defaultOpen={initialOpenPanel === 'agent-mcp'}
+        >
+          <AgentMcpSection embedded />
+        </AssistantAdvancedPanel>
+      </div>
     </div>
+  )
+}
+
+function AssistantAdvancedPanel({
+  title,
+  description,
+  icon,
+  defaultOpen,
+  children
+}: {
+  title: string
+  description: string
+  icon: ReactNode
+  defaultOpen: boolean
+  children: ReactNode
+}) {
+  return (
+    <Collapsible defaultOpen={defaultOpen}>
+      <CollapsibleTrigger className="group flex min-h-12 w-full items-center justify-between gap-3 rounded-lg border border-border bg-background px-4 py-3 text-start transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+            {icon}
+          </span>
+          <span className="flex min-w-0 flex-col gap-px">
+            <span className="font-medium text-[13px]/4 text-foreground">{title}</span>
+            <span className="truncate text-xs/4 text-muted-foreground">{description}</span>
+          </span>
+        </span>
+        <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="pt-3">{children}</CollapsibleContent>
+    </Collapsible>
   )
 }

--- a/apps/desktop/src/renderer/src/pages/settings/settings-page.i18n.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/settings-page.i18n.test.tsx
@@ -22,9 +22,6 @@ vi.mock('./appearance-section', () => ({
   AppearanceSettings: () => <div data-testid="appearance-panel" />
 }))
 vi.mock('./ai-section', () => ({ AISettings: () => <div data-testid="ai-panel" /> }))
-vi.mock('./agent-mcp-section', () => ({
-  AgentMcpSection: () => <div data-testid="agent-mcp-panel" />
-}))
 vi.mock('./integrations-section', () => ({
   IntegrationsSettings: () => <div data-testid="integrations-panel" />
 }))
@@ -71,7 +68,6 @@ describe('SettingsPage i18n', () => {
       'Appearance',
       'Shortcuts',
       'AI Assistant',
-      'Agent MCP',
       'Integrations',
       'Vault',
       'Tags',
@@ -79,6 +75,9 @@ describe('SettingsPage i18n', () => {
     ]) {
       expect(screen.getByRole('button', { name: label })).toBeInTheDocument()
     }
+
+    expect(screen.queryByRole('button', { name: 'Agent Providers' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Agent MCP' })).not.toBeInTheDocument()
   })
 
   it('switches every settings section from the sidebar', async () => {
@@ -104,7 +103,6 @@ describe('SettingsPage i18n', () => {
       ['Appearance', 'appearance-panel'],
       ['Shortcuts', 'shortcuts-panel'],
       ['AI Assistant', 'ai-panel'],
-      ['Agent MCP', 'agent-mcp-panel'],
       ['Integrations', 'integrations-panel'],
       ['Vault', 'vault-panel'],
       ['Tags', 'tags-panel'],

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -8,15 +8,15 @@ conversation.
 
 The same MCP endpoint can also be copied into other desktop AI clients for vault read tools.
 
-Open [Settings -> Agent MCP](/user-guide/settings#agent-mcp) to copy the current endpoint and
-bearer token.
+Open [Settings -> AI Assistant -> Agent MCP](/user-guide/settings#agent-mcp) to copy the current
+endpoint and bearer token.
 
 ## Agent Chat
 
 Open the right sidebar, choose **Agent**, and pick a provider. For Claude CLI, Memry checks that
 `claude` is available on `PATH`, that it reports version `2.1.0` or newer, and that the Agent
 disclosure has been accepted. For local models, configure a compatible server in
-[Settings -> Agent Providers](/user-guide/settings#agent-providers) first.
+[Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
 
 Agent Chat can:
 

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -6,7 +6,7 @@ Settings are organized into four groups:
 
 - **Workspace** — how Memry behaves day-to-day (Account, General, Templates, Editor, Journal, Tasks, Calendar)
 - **Preferences** — your personal taste (Appearance, Keyboard Shortcuts)
-- **Services** — external integrations and AI (AI, Agent Providers, Agent MCP, Integrations)
+- **Services** — external integrations and AI (AI Assistant, Integrations)
 - **Data** — what's on disk and metadata (Vault, Tags, Properties)
 
 <!-- screenshot: settings modal with sidebar of sections -->
@@ -213,9 +213,10 @@ Inline editor AI menu (grammar, tone, length, custom prompt).
 - **Base URL** — defaults to `http://localhost:11434/v1` for Ollama
 - **Test Connection** — verifies URL + key
 
-## Agent Providers
+### Agent Providers
 
-Agent Chat backend settings. These are machine-local and are not synced between devices.
+Agent Chat backend settings are now collapsed inside the AI Assistant page. These are machine-local
+and are not synced between devices.
 
 - **Preset** — Ollama, LM Studio, llama.cpp, or Custom
 - **Base URL** — OpenAI-compatible endpoint, such as `http://localhost:11434/v1`
@@ -227,9 +228,9 @@ Agent Chat backend settings. These are machine-local and are not synced between 
 Loopback endpoints are treated as local. Custom non-loopback endpoints require an explicit
 not-fully-local acknowledgement because prompts and tool results are sent to that server.
 
-## Agent MCP
+### Agent MCP
 
-Local MCP server controls for external desktop AI clients.
+Local MCP server controls are also collapsed inside AI Assistant for external desktop AI clients.
 
 - **Server URL** — localhost endpoint copied into an MCP client
 - **Bearer Token** — per-launch in-memory token copied as an authorization header


### PR DESCRIPTION
## Summary
- Consolidate Agent Providers and Agent MCP under the AI Assistant settings page
- Keep legacy agent settings section ids routed into AI Assistant with the matching panel open
- Update settings docs to reflect the compact AI surface

## Verification
- pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/pages/settings/settings-page.i18n.test.tsx src/renderer/src/pages/settings/ai-section.test.tsx
- pnpm --dir apps/desktop typecheck:web
- pnpm --dir apps/desktop exec eslint --no-warn-ignored src/renderer/src/pages/settings.tsx src/renderer/src/pages/settings/ai-section.tsx src/renderer/src/pages/settings/agent-providers-section.tsx src/renderer/src/pages/settings/agent-mcp-section.tsx src/renderer/src/pages/settings/ai-section.test.tsx src/renderer/src/pages/settings/settings-page.i18n.test.tsx
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build
- git diff --check