### PR TITLE
feat: polish agent chat right sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-05-13 — Agent Chat Right Sidebar Polish
+
+### Changed
+
+- Move Agent Chat history and new-conversation actions into the right-sidebar header, with compact hover states for the provider and history dropdowns.
+- Let the right sidebar open from the tab bar edge, reserve tab bar space while open, and keep the collapse control anchored at the far right.
+- Align right-sidebar background, borders, labels, and Day/Agent switch chrome with the main layout.
+
+---
+
 ## 2026-05-07 — Notes and Journal Block Marquee Selection
 
 ### Fixed

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-pane.test.tsx
@@ -104,6 +104,17 @@ describe('AgentPane', () => {
     expect(screen.queryByRole('button', { name: 'New conversation' })).not.toBeInTheDocument()
   })
 
+  it('uses the main layout background for the agent shell', () => {
+    mockUseAgentOptional.mockReturnValue(null)
+
+    render(<AgentPane />)
+
+    const shell = screen.getByLabelText('Agent chat')
+
+    expect(shell).toHaveClass('bg-background')
+    expect(shell).not.toHaveClass('bg-sidebar')
+  })
+
   it('keeps the empty chat composer visible when the Claude CLI is unavailable', () => {
     mockAgentState({
       backendStatuses: {
@@ -126,8 +137,7 @@ describe('AgentPane', () => {
     expect(screen.queryByRole('button', { name: 'New conversation' })).not.toBeInTheDocument()
   })
 
-  it('renders the active conversation header and switches conversations', async () => {
-    const user = userEvent.setup()
+  it('renders the active conversation header', () => {
     mockUseAgentOptional.mockReturnValue({
       state: {
         backendStatuses: readyStatuses,
@@ -177,9 +187,7 @@ describe('AgentPane', () => {
 
     render(<AgentPane />)
 
-    await user.click(screen.getByRole('button', { name: /Planning/ }))
-    await user.click(screen.getByRole('button', { name: 'Inbox cleanup' }))
-
-    expect(mockLoadConversation).toHaveBeenCalledWith('conversation-2')
+    expect(screen.getByText('Planning')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Conversation history' })).not.toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
@@ -101,12 +101,14 @@ describe('Composer', () => {
 
     const providerTrigger = screen.getByRole('button', { name: 'Agent provider: Claude' })
     expect(providerTrigger).not.toHaveClass('border')
-    expect(providerTrigger).toHaveClass('hover:bg-transparent')
-    expect(providerTrigger).toHaveClass('hover:text-foreground')
+    expect(providerTrigger).toHaveClass('hover:bg-accent')
+    expect(providerTrigger).toHaveClass('hover:text-accent-foreground')
+    expect(providerTrigger).toHaveClass('data-[state=open]:bg-accent')
 
     fireEvent.pointerDown(providerTrigger)
 
-    expect(screen.getByRole('menuitem', { name: /claude/i })).toHaveClass('focus:bg-transparent')
+    expect(screen.getByRole('menuitem', { name: /claude/i })).toHaveClass('hover:bg-accent')
+    expect(screen.getByRole('menuitem', { name: /claude/i })).toHaveClass('focus:bg-accent')
     expect(screen.getByRole('menuitem', { name: /codex/i })).not.toHaveAttribute('data-disabled')
     expect(screen.getByRole('menuitem', { name: /local/i })).not.toHaveAttribute('data-disabled')
   })

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/conversation-header.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/conversation-header.test.tsx
@@ -1,6 +1,5 @@
-import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { Conversation } from '@memry/contracts/ipc-agent'
 
@@ -40,41 +39,15 @@ const conversations: Conversation[] = [
 ]
 
 describe('ConversationHeader', () => {
-  it('opens the switcher and selects another conversation', async () => {
-    const user = userEvent.setup()
-    const onSelectConversation = vi.fn()
+  it('renders the active conversation title', () => {
+    render(<ConversationHeader conversation={conversations[0]} />)
 
-    render(
-      <ConversationHeader
-        conversation={conversations[0]}
-        conversations={conversations}
-        onCreateConversation={vi.fn()}
-        onSelectConversation={onSelectConversation}
-      />
-    )
+    const title = screen.getByText('Planning')
+    const header = title.closest('header')
 
-    await user.click(screen.getByRole('button', { name: /Planning/ }))
-    await user.click(screen.getByRole('button', { name: 'Inbox cleanup' }))
-
-    expect(onSelectConversation).toHaveBeenCalledWith('conversation-2')
-  })
-
-  it('creates a new conversation from the switcher', async () => {
-    const user = userEvent.setup()
-    const onCreateConversation = vi.fn()
-
-    render(
-      <ConversationHeader
-        conversation={conversations[0]}
-        conversations={conversations}
-        onCreateConversation={onCreateConversation}
-        onSelectConversation={vi.fn()}
-      />
-    )
-
-    await user.click(screen.getByRole('button', { name: /Planning/ }))
-    await user.click(screen.getByRole('button', { name: 'New conversation' }))
-
-    expect(onCreateConversation).toHaveBeenCalledTimes(1)
+    expect(title).toBeInTheDocument()
+    expect(header).toHaveClass('border-t')
+    expect(header).not.toHaveClass('border-b')
+    expect(screen.queryByRole('button', { name: 'Conversation history' })).not.toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/conversation-view.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/conversation-view.test.tsx
@@ -72,8 +72,55 @@ describe('ConversationView', () => {
 
     render(<ConversationView conversationId="conversation-1" />)
 
-    expect(screen.getByRole('button', { name: /Planning/ })).toBeInTheDocument()
+    const shell = screen.getByLabelText('Agent chat')
+
+    expect(shell).toHaveClass('bg-background')
+    expect(shell).not.toHaveClass('bg-sidebar')
+    expect(screen.getByText('Planning')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Conversation history' })).not.toBeInTheDocument()
     expect(screen.getByText('Hello from agent')).toBeInTheDocument()
+  })
+
+  it('keeps the empty conversation view passive before the first prompt is sent', () => {
+    const loadConversation = vi.fn()
+    mockUseAgentOptional.mockReturnValue({
+      state: {
+        backendStatuses,
+        disclosureAccepted: true,
+        sourceWindowId: '42',
+        activeConversationId: null,
+        conversations: {
+          'conversation-1': {
+            id: 'conversation-1',
+            vaultId: 'vault-1',
+            title: 'Planning',
+            backend: 'claude_cli',
+            backendModel: null,
+            trustList: [],
+            pinned: false,
+            vectorClock: {},
+            fieldClocks: {},
+            createdAt: 100,
+            updatedAt: 100,
+            deletedAt: null,
+            lastSyncedAt: null
+          }
+        },
+        messagesByConversation: {},
+        pendingApprovals: [],
+        inFlight: {},
+        error: null
+      },
+      createConversation: vi.fn(),
+      loadConversation,
+      cancelTurn: vi.fn()
+    })
+
+    render(<ConversationView conversationId={null} />)
+
+    expect(screen.queryByText('New conversation')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Conversation history' })).not.toBeInTheDocument()
+    expect(loadConversation).not.toHaveBeenCalled()
   })
 
   it('cancels an in-flight turn from Stop and Escape', () => {

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event'
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockUseAgentOptional = vi.hoisted(() => vi.fn())
@@ -10,7 +10,9 @@ vi.mock('../agent-context', () => ({
 
 import { SidebarTabs } from '../sidebar-tabs'
 
-function renderTabs(props: { dayLabel?: string; agentLabel?: string } = {}) {
+function renderTabs(
+  props: { dayLabel?: string; agentLabel?: string; defaultTab?: 'day' | 'agent' } = {}
+) {
   return render(
     <SidebarTabs {...props}>
       {{
@@ -19,6 +21,57 @@ function renderTabs(props: { dayLabel?: string; agentLabel?: string } = {}) {
       }}
     </SidebarTabs>
   )
+}
+
+function mockAgentWithConversations() {
+  const loadConversation = vi.fn()
+  const createConversation = vi.fn()
+
+  mockUseAgentOptional.mockReturnValue({
+    state: {
+      disclosureAccepted: true,
+      activeConversationId: 'conversation-1',
+      conversations: {
+        'conversation-1': {
+          id: 'conversation-1',
+          vaultId: 'vault-1',
+          title: 'Planning',
+          backend: 'claude_cli',
+          backendModel: null,
+          trustList: [],
+          pinned: false,
+          vectorClock: {},
+          fieldClocks: {},
+          createdAt: 100,
+          updatedAt: 100,
+          deletedAt: null,
+          lastSyncedAt: null
+        },
+        'conversation-2': {
+          id: 'conversation-2',
+          vaultId: 'vault-1',
+          title: 'Inbox cleanup',
+          backend: 'claude_cli',
+          backendModel: null,
+          trustList: [],
+          pinned: false,
+          vectorClock: {},
+          fieldClocks: {},
+          createdAt: 200,
+          updatedAt: 200,
+          deletedAt: null,
+          lastSyncedAt: null
+        }
+      },
+      pendingApprovals: [],
+      messagesByConversation: {},
+      inFlight: {}
+    },
+    createConversation,
+    loadConversation
+  })
+
+  return { createConversation, loadConversation }
 }
 
 describe('SidebarTabs', () => {
@@ -52,8 +105,32 @@ describe('SidebarTabs', () => {
 
     await user.click(agentTab)
 
-    expect(screen.getByText('Agent')).toBeInTheDocument()
+    expect(screen.queryByText('Agent')).not.toBeInTheDocument()
     expect(within(agentTab).queryByText('Agent')).not.toBeInTheDocument()
+  })
+
+  it('matches the active label typography and vertical rhythm to tab titles', () => {
+    renderTabs({ dayLabel: 'Today' })
+
+    const activeLabel = screen.getByText('Today')
+    const labelRow = activeLabel.parentElement
+
+    expect(activeLabel).toHaveClass('text-[13px]')
+    expect(activeLabel).toHaveClass('tracking-[-0.01em]')
+    expect(activeLabel).toHaveClass('font-medium')
+    expect(activeLabel).toHaveClass('text-foreground')
+    expect(activeLabel).not.toHaveClass('text-sidebar-foreground')
+    expect(labelRow).toHaveClass('h-9')
+    expect(labelRow).toHaveClass('pt-0.5')
+  })
+
+  it('places the day and agent switch before the active label', () => {
+    renderTabs({ dayLabel: 'Today' })
+
+    const tabSwitch = screen.getByRole('tablist', { name: 'Right sidebar' })
+    const activeLabel = screen.getByText('Today')
+
+    expect(tabSwitch.compareDocumentPosition(activeLabel)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
   })
 
   it('restores the persisted active tab', () => {
@@ -85,5 +162,27 @@ describe('SidebarTabs', () => {
     renderTabs()
 
     expect(screen.getByLabelText('1 pending approval')).toBeInTheDocument()
+  })
+
+  it('shows new conversation and history actions without the Agent label', () => {
+    const { createConversation, loadConversation } = mockAgentWithConversations()
+
+    renderTabs({ defaultTab: 'agent' })
+
+    expect(screen.queryByText('Agent')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'New conversation' }))
+    expect(createConversation).toHaveBeenCalledTimes(1)
+
+    const historyTrigger = screen.getByRole('button', { name: 'Conversation history' })
+    expect(historyTrigger).toBeInTheDocument()
+    expect(historyTrigger).toHaveClass('hover:bg-[#303030]')
+
+    fireEvent.pointerDown(historyTrigger)
+    expect(screen.queryByRole('menuitem', { name: 'New conversation' })).not.toBeInTheDocument()
+    const historyItem = screen.getByRole('menuitem', { name: 'Inbox cleanup' })
+    expect(historyItem).toHaveClass('hover:bg-accent')
+    fireEvent.click(historyItem)
+
+    expect(loadConversation).toHaveBeenCalledWith('conversation-2')
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/agent-pane.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-pane.tsx
@@ -11,7 +11,7 @@ export function AgentPane(): React.JSX.Element {
   if (!agent) {
     return (
       <section
-        className="flex h-full min-h-0 flex-col bg-sidebar"
+        className="flex h-full min-h-0 flex-col bg-background"
         aria-label={t('agentChat.title')}
       >
         <div className="border-b border-sidebar-border px-4 py-3">

--- a/apps/desktop/src/renderer/src/agent-chat/composer.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/composer.tsx
@@ -467,7 +467,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
                 aria-label={t('agentChat.composer.providerLabel', {
                   provider: selectedProviderLabel
                 })}
-                className="inline-flex h-8 items-center gap-1.5 rounded-full bg-transparent px-1.5 text-xs text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="inline-flex h-8 items-center gap-1.5 rounded-full bg-transparent px-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:bg-accent data-[state=open]:text-accent-foreground"
               >
                 <SelectedProviderIcon className="size-4" aria-hidden="true" />
                 <span>{selectedProviderLabel}</span>
@@ -478,7 +478,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
               <DropdownMenuItem
                 disabled={claudeDisabled}
                 onSelect={() => selectProvider('claude_cli')}
-                className="text-xs focus:bg-transparent focus:text-foreground"
+                className="text-xs hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
               >
                 <Claude className="size-4 text-muted-foreground" aria-hidden="true" />
                 <span>{claudeProviderLabel}</span>
@@ -489,7 +489,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
               <DropdownMenuItem
                 disabled={codexDisabled}
                 onSelect={() => selectProvider('codex_cli')}
-                className="text-xs focus:bg-transparent focus:text-foreground"
+                className="text-xs hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
               >
                 <ChatGpt className="size-4 text-muted-foreground" aria-hidden="true" />
                 <span>{codexProviderLabel}</span>
@@ -499,7 +499,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
               </DropdownMenuItem>
               <DropdownMenuItem
                 onSelect={() => selectProvider('local_openai_compatible')}
-                className="text-xs focus:bg-transparent focus:text-foreground"
+                className="text-xs hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
               >
                 <Computer className="size-4 text-muted-foreground" aria-hidden="true" />
                 <span>{localProviderLabel}</span>

--- a/apps/desktop/src/renderer/src/agent-chat/conversation-header.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/conversation-header.tsx
@@ -1,60 +1,14 @@
-import { useState } from 'react'
-
 import type { Conversation } from '@memry/contracts/ipc-agent'
-
-import { Button } from '@/components/ui/button'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { ChevronDown } from '@/lib/icons'
-import { ConversationList } from './conversation-list'
-
 interface ConversationHeaderProps {
   conversation: Conversation
-  conversations: Conversation[]
-  onCreateConversation: () => void | Promise<void>
-  onSelectConversation: (id: string) => void | Promise<void>
 }
 
-export function ConversationHeader({
-  conversation,
-  conversations,
-  onCreateConversation,
-  onSelectConversation
-}: ConversationHeaderProps): React.JSX.Element {
-  const [open, setOpen] = useState(false)
-
-  async function handleCreateConversation(): Promise<void> {
-    await onCreateConversation()
-    setOpen(false)
-  }
-
-  async function handleSelectConversation(id: string): Promise<void> {
-    await onSelectConversation(id)
-    setOpen(false)
-  }
-
+export function ConversationHeader({ conversation }: ConversationHeaderProps): React.JSX.Element {
   return (
-    <header className="border-b border-sidebar-border px-3 py-2">
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-8 max-w-full justify-start gap-1.5 px-2 text-sm font-semibold"
-          >
-            <span className="min-w-0 truncate">{conversation.title}</span>
-            <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent align="start" className="w-72 p-0">
-          <ConversationList
-            conversations={conversations}
-            activeConversationId={conversation.id}
-            onCreateConversation={handleCreateConversation}
-            onSelectConversation={handleSelectConversation}
-          />
-        </PopoverContent>
-      </Popover>
+    <header className="flex min-h-[49px] items-center border-t border-sidebar-border px-3 py-2">
+      <span className="min-w-0 truncate px-2 text-sm font-semibold text-foreground">
+        {conversation.title}
+      </span>
     </header>
   )
 }

--- a/apps/desktop/src/renderer/src/agent-chat/conversation-list.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/conversation-list.tsx
@@ -1,45 +1,31 @@
 import type { Conversation } from '@memry/contracts/ipc-agent'
-import { useT } from '@memry/i18n/renderer'
 
-import { Check, Plus } from '@/lib/icons'
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
+import { Check } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
 interface ConversationListProps {
   conversations: Conversation[]
-  activeConversationId: string
-  onCreateConversation: () => void | Promise<void>
+  activeConversationId: string | null
   onSelectConversation: (id: string) => void | Promise<void>
 }
 
 export function ConversationList({
   conversations,
   activeConversationId,
-  onCreateConversation,
   onSelectConversation
 }: ConversationListProps): React.JSX.Element {
-  const { t } = useT('common')
-
   return (
-    <div className="flex max-h-80 flex-col overflow-y-auto p-1">
-      <button
-        type="button"
-        onClick={() => void onCreateConversation()}
-        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-start text-sm font-medium hover:bg-accent hover:text-accent-foreground"
-      >
-        <Plus className="size-4 text-muted-foreground" aria-hidden="true" />
-        <span className="truncate">{t('agentChat.newConversation')}</span>
-      </button>
-      {conversations.length > 0 && <div className="my-1 h-px bg-border" />}
+    <div className="flex max-h-80 flex-col overflow-y-auto">
       {conversations.map((conversation) => {
         const active = conversation.id === activeConversationId
         return (
-          <button
+          <DropdownMenuItem
             key={conversation.id}
-            type="button"
             aria-current={active ? 'true' : undefined}
-            onClick={() => void onSelectConversation(conversation.id)}
+            onSelect={() => void onSelectConversation(conversation.id)}
             className={cn(
-              'flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-start text-sm hover:bg-accent hover:text-accent-foreground',
+              'min-w-0 text-xs hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground',
               active && 'bg-accent/70 text-accent-foreground'
             )}
           >
@@ -47,7 +33,7 @@ export function ConversationList({
             {active && (
               <Check className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
             )}
-          </button>
+          </DropdownMenuItem>
         )
       })}
     </div>

--- a/apps/desktop/src/renderer/src/agent-chat/conversation-view.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/conversation-view.tsx
@@ -32,9 +32,6 @@ export function ConversationView({ conversationId }: ConversationViewProps): Rea
     )
   }
 
-  const conversations = Object.values(state.conversations).sort((left, right) => {
-    return right.updatedAt - left.updatedAt
-  })
   const messages = conversationId ? (state.messagesByConversation[conversationId] ?? []) : []
   const inFlight = conversationId ? state.inFlight[conversationId] === true : false
   const currentAgent = agent
@@ -46,7 +43,7 @@ export function ConversationView({ conversationId }: ConversationViewProps): Rea
 
   return (
     <section
-      className="flex h-full min-h-0 flex-col bg-sidebar"
+      className="flex h-full min-h-0 flex-col bg-background"
       aria-label={t('agentChat.title')}
       tabIndex={-1}
       onKeyDown={(event) => {
@@ -55,16 +52,7 @@ export function ConversationView({ conversationId }: ConversationViewProps): Rea
         cancelTurn()
       }}
     >
-      {conversation && (
-        <ConversationHeader
-          conversation={conversation}
-          conversations={conversations}
-          onCreateConversation={async () => {
-            await currentAgent.createConversation()
-          }}
-          onSelectConversation={currentAgent.loadConversation}
-        />
-      )}
+      {conversation && <ConversationHeader conversation={conversation} />}
       <MessageStream messages={messages} />
       <Composer conversationId={conversationId} sourceWindowId={state.sourceWindowId} />
     </section>

--- a/apps/desktop/src/renderer/src/agent-chat/sidebar-tabs.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/sidebar-tabs.tsx
@@ -1,9 +1,17 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { History } from 'lucide-react'
 import { useT } from '@memry/i18n/renderer'
 
-import { Bot, CalendarDays } from '@/lib/icons'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Bot, CalendarDays, PlusSignIcon } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { useAgentOptional } from './agent-context'
+import { ConversationList } from './conversation-list'
 
 export type RightSidebarTab = 'day' | 'agent'
 
@@ -15,6 +23,7 @@ interface SidebarTabsProps {
   defaultTab?: RightSidebarTab
   dayLabel?: string
   agentLabel?: string
+  endAccessory?: ReactNode
 }
 
 function readInitialTab(defaultTab: RightSidebarTab): RightSidebarTab {
@@ -31,14 +40,14 @@ export function SidebarTabs({
   children,
   defaultTab = 'day',
   dayLabel,
-  agentLabel
+  endAccessory
 }: SidebarTabsProps): React.JSX.Element {
   const { t } = useT('common')
   const [active, setActive] = useState<RightSidebarTab>(() => readInitialTab(defaultTab))
   const agent = useAgentOptional()
   const dayTabLabel = t('agentChat.sidebar.day')
   const agentTabLabel = t('agentChat.sidebar.agent')
-  const activeLabel = active === 'day' ? (dayLabel ?? dayTabLabel) : (agentLabel ?? agentTabLabel)
+  const activeLabel = dayLabel ?? dayTabLabel
 
   useEffect(() => {
     try {
@@ -62,10 +71,7 @@ export function SidebarTabs({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex h-9 shrink-0 items-center justify-between gap-3 border-b border-sidebar-border px-3">
-        <span className="min-w-0 truncate text-xs font-semibold text-sidebar-foreground">
-          {activeLabel}
-        </span>
+      <div className={cn('flex h-9 shrink-0 items-center gap-3 ps-3', !endAccessory && 'pe-3')}>
         <div
           role="tablist"
           aria-label={t('agentChat.sidebar.label')}
@@ -96,11 +102,106 @@ export function SidebarTabs({
             )}
           </SidebarTabButton>
         </div>
+        <div
+          data-slot="day-panel-header-actions"
+          className="ms-auto flex shrink-0 items-center gap-2"
+        >
+          <div className="flex h-9 min-w-0 items-center gap-1.5 pt-0.5">
+            {active === 'day' ? (
+              <span className="min-w-0 truncate text-[13px] font-medium tracking-[-0.01em] text-foreground transition-colors duration-150">
+                {activeLabel}
+              </span>
+            ) : (
+              <AgentConversationActions />
+            )}
+          </div>
+          {endAccessory && (
+            <div data-slot="day-panel-toggle-slot" className="flex shrink-0 items-center pe-[13px]">
+              {endAccessory}
+            </div>
+          )}
+        </div>
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">
         {active === 'day' ? children.day : children.agent}
       </div>
     </div>
+  )
+}
+
+function AgentConversationActions(): React.JSX.Element | null {
+  const { t } = useT('common')
+  const agent = useAgentOptional()
+
+  if (!agent || agent.state.disclosureAccepted !== true) return null
+
+  const newConversationLabel = t('agentChat.newConversation')
+
+  return (
+    <div className="flex items-center gap-1">
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={newConversationLabel}
+              title={newConversationLabel}
+              onClick={() => void agent.createConversation()}
+              className="inline-flex size-6 shrink-0 items-center justify-center rounded-[5px] text-muted-foreground transition-colors hover:bg-[#303030] hover:text-[color-mix(in_srgb,var(--foreground)_35%,white)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <PlusSignIcon className="size-3.5" aria-hidden="true" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="text-xs">
+            {newConversationLabel}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <AgentHistoryMenu />
+    </div>
+  )
+}
+
+function AgentHistoryMenu(): React.JSX.Element | null {
+  const { t } = useT('common')
+  const agent = useAgentOptional()
+
+  if (!agent || agent.state.disclosureAccepted !== true) return null
+
+  const conversations = Object.values(agent.state.conversations).sort((left, right) => {
+    return right.updatedAt - left.updatedAt
+  })
+  const historyLabel = t('agentChat.history')
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label={historyLabel}
+                title={historyLabel}
+                className="inline-flex size-6 shrink-0 items-center justify-center rounded-[5px] text-muted-foreground transition-colors hover:bg-[#303030] hover:text-[color-mix(in_srgb,var(--foreground)_35%,white)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:bg-[#303030] data-[state=open]:text-[color-mix(in_srgb,var(--foreground)_35%,white)]"
+              >
+                <History className="size-3.5" aria-hidden="true" />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="text-xs">
+            {historyLabel}
+          </TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="start" className="w-72 border-0 p-1">
+          <ConversationList
+            conversations={conversations}
+            activeConversationId={agent.state.activeConversationId}
+            onSelectConversation={(id) => void agent.loadConversation(id)}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </TooltipProvider>
   )
 }
 

--- a/apps/desktop/src/renderer/src/components/cold-major-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/cold-major-components.test.tsx
@@ -44,6 +44,8 @@ const mocks = vi.hoisted(() => ({
   openTab: vi.fn(),
   activeTab: null as Record<string, unknown> | null,
   dayPanelOpen: false,
+  dayPanelWidth: 320,
+  dayPanelResizing: false,
   toggleDayPanel: vi.fn(),
   tabGroup: null as Record<string, any> | null,
   logger: { error: vi.fn() }
@@ -123,7 +125,12 @@ vi.mock('@/hooks/use-sidebar-navigation', () => ({
 }))
 
 vi.mock('@/contexts/day-panel-context', () => ({
-  useDayPanel: () => ({ isOpen: mocks.dayPanelOpen, toggle: mocks.toggleDayPanel })
+  useDayPanel: () => ({
+    isOpen: mocks.dayPanelOpen,
+    width: mocks.dayPanelWidth,
+    isResizing: mocks.dayPanelResizing,
+    toggle: mocks.toggleDayPanel
+  })
 }))
 
 vi.mock('@/contexts/tabs', () => ({
@@ -646,6 +653,8 @@ beforeEach(() => {
   mocks.openTab.mockClear()
   mocks.activeTab = null
   mocks.dayPanelOpen = false
+  mocks.dayPanelWidth = 320
+  mocks.dayPanelResizing = false
   mocks.tabGroup = {
     id: 'group-1',
     activeTabId: 'tab-2',
@@ -1096,10 +1105,18 @@ describe('cold major renderer components', () => {
     rerender(<TabBarWithDrag groupId="group-1" />)
     expect(screen.getByText('pinned Pinned')).toBeInTheDocument()
     expect(screen.getByText('tab Regular')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('phaseF.componentsTabsTabBarWithDrag.graphG'))
-    expect(mocks.openTab).toHaveBeenCalledWith(expect.objectContaining({ type: 'graph' }))
-    fireEvent.click(screen.getByText('phaseF.componentsTabsTabBarWithDrag.dayPanel'))
+    expect(screen.queryByText('phaseF.componentsTabsTabBarWithDrag.graphG')).not.toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', { name: 'phaseF.componentsTabsTabBarWithDrag.dayPanel' })
+    )
     expect(mocks.toggleDayPanel).toHaveBeenCalled()
+
+    mocks.dayPanelOpen = true
+    rerender(<TabBarWithDrag groupId="group-1" />)
+    expect(screen.getByRole('tablist')).toHaveStyle({ marginInlineEnd: '320px' })
+    expect(
+      screen.queryByRole('button', { name: 'phaseF.componentsTabsTabBarWithDrag.dayPanel' })
+    ).not.toBeInTheDocument()
 
     mocks.tabGroup = null
     rerender(<TabBarWithDrag groupId="missing" />)

--- a/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.test.tsx
@@ -104,4 +104,37 @@ describe('GlobalDayPanel', () => {
     expect(screen.getByText('Agent chat')).toBeInTheDocument()
     expect(screen.queryByTestId('journal-day-panel')).not.toBeInTheDocument()
   })
+
+  it('covers the tab bar instead of starting below it', () => {
+    renderPanel()
+
+    const container = document.querySelector('[data-slot="day-panel-container"]')
+
+    expect(container).toHaveClass('top-0')
+    expect(container).not.toHaveClass('top-[37px]')
+  })
+
+  it('renders with only a left border edge', () => {
+    renderPanel()
+
+    const container = document.querySelector('[data-slot="day-panel-container"]')
+
+    expect(container).toHaveClass('bg-background')
+    expect(container).not.toHaveClass('bg-sidebar')
+    expect(container).toHaveClass('border-s')
+    expect(container).toHaveClass('border-border')
+    expect(container).not.toHaveClass('border-b')
+  })
+
+  it('keeps the day panel toggle at the far edge when open', () => {
+    renderPanel()
+
+    const headerActions = document.querySelector('[data-slot="day-panel-header-actions"]')
+    const toggleSlot = document.querySelector('[data-slot="day-panel-toggle-slot"]')
+
+    expect(headerActions).toBeInTheDocument()
+    expect(headerActions).toHaveClass('ms-auto')
+    expect(toggleSlot).toBeInTheDocument()
+    expect(toggleSlot).toHaveClass('pe-[13px]')
+  })
 })

--- a/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
@@ -2,12 +2,15 @@ import { useCallback, useMemo, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { AgentPane } from '@/agent-chat/agent-pane'
 import { SidebarTabs } from '@/agent-chat/sidebar-tabs'
+import { TabBarAction } from '@/components/tabs/tab-bar-action'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import {
   useDayPanel,
   DAY_PANEL_WIDTH_DEFAULT_PX,
   DAY_PANEL_WIDTH_MIN_PX,
   DAY_PANEL_WIDTH_MAX_PX
 } from '@/contexts/day-panel-context'
+import { PanelRightIcon } from '@/lib/icons'
 import { useTabs, useActiveTab } from '@/contexts/tabs'
 import { useCalendarView } from '@/contexts/calendar-view-context'
 import { DatePickerCalendar } from '@/components/tasks/date-picker-calendar'
@@ -91,7 +94,8 @@ function DayPanelResizeRail() {
 
 export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
   const { t, i18n } = useT('journal')
-  const { isOpen, selectedDate, width, isResizing, setDate } = useDayPanel()
+  const { t: tCommon } = useT('common')
+  const { isOpen, selectedDate, width, isResizing, setDate, toggle } = useDayPanel()
   const { openTab } = useTabs()
   const activeTab = useActiveTab()
   const { setAnchorDate } = useCalendarView()
@@ -211,9 +215,9 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
       data-slot="day-panel-container"
       style={{ width: isOpen ? `${width}px` : 0 }}
       className={cn(
-        'fixed top-[37px] bottom-0 end-0 z-10',
+        'fixed top-0 bottom-0 end-0 z-10',
         !isResizing && 'transition-[width] duration-200 ease-linear',
-        'flex flex-col bg-sidebar border-s border-sidebar-border',
+        'flex flex-col border-s border-border bg-background',
         className
       )}
     >
@@ -228,7 +232,23 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
       >
         {isOpen && <DayPanelResizeRail />}
 
-        <SidebarTabs dayLabel={dayPanelLabel}>
+        <SidebarTabs
+          dayLabel={dayPanelLabel}
+          endAccessory={
+            isOpen ? (
+              <TooltipProvider delayDuration={300}>
+                <TabBarAction
+                  icon={
+                    <PanelRightIcon className="w-4 h-4 text-tint transition-colors duration-150" />
+                  }
+                  tooltip={tCommon('phaseF.componentsTabsTabBarWithDrag.dayPanel')}
+                  onClick={toggle}
+                  isActive
+                />
+              </TooltipProvider>
+            ) : null
+          }
+        >
           {{
             day: (
               <div className="h-full overflow-y-auto pt-3">

--- a/apps/desktop/src/renderer/src/components/split-view/__tests__/tab-pane-with-drop-zones-day-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/__tests__/tab-pane-with-drop-zones-day-panel.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
     width: 320,
     isResizing: false
   },
+  tabBars: [] as Array<{ reserveDayPanelSpace?: boolean }>,
   dispatch: vi.fn()
 }))
 
@@ -48,7 +49,10 @@ vi.mock('@/contexts/day-panel-context', () => ({
 }))
 
 vi.mock('@/components/tabs', () => ({
-  TabBarWithDrag: () => <div data-testid="tab-bar" />
+  TabBarWithDrag: (props: { reserveDayPanelSpace?: boolean }) => {
+    mocks.tabBars.push(props)
+    return <div data-testid="tab-bar" />
+  }
 }))
 
 vi.mock('../tab-content', () => ({
@@ -73,6 +77,7 @@ describe('TabPaneWithDropZones day panel spacing', () => {
     mocks.dayPanel.isOpen = true
     mocks.dayPanel.width = 320
     mocks.dayPanel.isResizing = false
+    mocks.tabBars = []
   })
 
   it('reserves day panel width only when the pane is allowed to reserve it', () => {
@@ -81,9 +86,11 @@ describe('TabPaneWithDropZones day panel spacing', () => {
     expect(screen.getByTestId('tab-content').parentElement).toHaveStyle({
       marginInlineEnd: '320px'
     })
+    expect(mocks.tabBars[0]).toEqual(expect.objectContaining({ reserveDayPanelSpace: true }))
 
     rerender(<TabPaneWithDropZones groupId="g1" isActive reserveDayPanelSpace={false} />)
 
     expect(screen.getByTestId('tab-content').parentElement?.style.marginInlineEnd).not.toBe('320px')
+    expect(mocks.tabBars[1]).toEqual(expect.objectContaining({ reserveDayPanelSpace: false }))
   })
 })

--- a/apps/desktop/src/renderer/src/components/split-view/tab-pane-with-drop-zones.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-pane-with-drop-zones.tsx
@@ -161,7 +161,11 @@ export const TabPaneWithDropZones = ({
       data-pane-active={isActive}
     >
       {/* Tab bar */}
-      <TabBarWithDrag groupId={groupId} showSidebarToggle={showSidebarToggle} />
+      <TabBarWithDrag
+        groupId={groupId}
+        showSidebarToggle={showSidebarToggle}
+        reserveDayPanelSpace={reserveDayPanelSpace}
+      />
 
       {/* Content area */}
       <div

--- a/apps/desktop/src/renderer/src/components/split-view/tab-pane.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-pane.tsx
@@ -51,7 +51,7 @@ export const TabPane = ({
           'flex-1 overflow-hidden',
           !dayPanelResizing && 'transition-[margin] duration-200 ease-linear'
         )}
-        style={{ marginRight: isDayPanelOpen ? `${dayPanelWidth}px` : 0 }}
+        style={{ marginInlineEnd: isDayPanelOpen ? `${dayPanelWidth}px` : 0 }}
       >
         {activeTab ? (
           <TabContent tab={activeTab} groupId={groupId} />

--- a/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
@@ -6,10 +6,9 @@
 
 import { useRef, useState, useLayoutEffect, useCallback } from 'react'
 import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortable'
-import { ChevronLeft, ChevronRight, LayoutAlignRightIcon, PanelRightIcon } from '@/lib/icons'
-import { SidebarGraph } from '@/lib/icons/sidebar-nav-icons'
+import { ChevronLeft, ChevronRight, LayoutAlignRightIcon } from '@/lib/icons'
 import { useDayPanel } from '@/contexts/day-panel-context'
-import { useTabGroup, useTabs } from '@/contexts/tabs'
+import { useTabGroup } from '@/contexts/tabs'
 import { useSidebar } from '@/components/ui/sidebar'
 import { SortableTab } from './sortable-tab'
 import { PinnedTab } from './pinned-tab'
@@ -25,6 +24,8 @@ interface TabBarWithDragProps {
   groupId: string
   /** Whether to show the sidebar collapse toggle (hidden in split panes) */
   showSidebarToggle?: boolean
+  /** Whether this tab bar should reserve space for the fixed day panel */
+  reserveDayPanelSpace?: boolean
   /** Additional CSS classes */
   className?: string
 }
@@ -36,30 +37,20 @@ interface TabBarWithDragProps {
 export const TabBarWithDrag = ({
   groupId,
   showSidebarToggle = true,
+  reserveDayPanelSpace = true,
   className
 }: TabBarWithDragProps): React.JSX.Element | null => {
   const { t: tPhaseF } = useT('common')
   const group = useTabGroup(groupId)
-  const { toggle: toggleDayPanel, isOpen: isDayPanelOpen } = useDayPanel()
-  const { openTab, getActiveTab } = useTabs()
+  const {
+    toggle: toggleDayPanel,
+    isOpen: isDayPanelOpen,
+    width: dayPanelWidth,
+    isResizing: isDayPanelResizing
+  } = useDayPanel()
   const { state: sidebarState } = useSidebar()
   const needsChromeSpacer = sidebarState === 'collapsed' && showSidebarToggle
-
-  const isGraphActive = getActiveTab()?.type === 'graph'
-  const DayPanelIcon = isDayPanelOpen ? PanelRightIcon : LayoutAlignRightIcon
-
-  const handleGraphClick = useCallback(() => {
-    openTab({
-      type: 'graph',
-      title: 'Graph',
-      icon: 'graph',
-      path: '/graph',
-      isPinned: false,
-      isModified: false,
-      isPreview: false,
-      isDeleted: false
-    })
-  }, [openTab])
+  const shouldReserveDayPanelSpace = reserveDayPanelSpace && isDayPanelOpen
 
   // Scroll state
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -118,10 +109,13 @@ export const TabBarWithDrag = ({
           'bg-transparent',
           'relative',
           'border-b border-border',
-          'transition-[padding-left] duration-200 ease-linear',
-          needsChromeSpacer && 'pl-[var(--chrome-width)]',
+          isDayPanelResizing
+            ? 'transition-[padding-inline-start] duration-200 ease-linear'
+            : 'transition-[padding-inline-start,margin-inline-end] duration-200 ease-linear',
+          needsChromeSpacer && 'ps-[var(--chrome-width)]',
           className
         )}
+        style={{ marginInlineEnd: shouldReserveDayPanelSpace ? `${dayPanelWidth}px` : 0 }}
         role="tablist"
         aria-label={tPhaseF('phaseF.componentsTabsTabBarWithDrag.openTabs')}
         aria-orientation="horizontal"
@@ -154,7 +148,7 @@ export const TabBarWithDrag = ({
               'bg-gradient-to-r from-muted/95 via-muted/70 to-transparent',
               'hover:from-surface-active/95',
               'transition-all duration-150 ease-out z-20',
-              'absolute left-0 bottom-px'
+              'absolute start-0 bottom-px'
             )}
             aria-label={tPhaseF('phaseF.componentsTabsTabBarWithDrag.scrollTabsLeft')}
           >
@@ -170,8 +164,8 @@ export const TabBarWithDrag = ({
             'scroll-smooth',
             'scrollbar-none [&::-webkit-scrollbar]:hidden',
             '[-ms-overflow-style:none] [scrollbar-width:none]',
-            canScrollLeft && 'pl-7',
-            canScrollRight && 'pr-7'
+            canScrollLeft && 'ps-7',
+            canScrollRight && 'pe-7'
           )}
         >
           <SortableContext
@@ -207,7 +201,7 @@ export const TabBarWithDrag = ({
               'bg-gradient-to-l from-muted/95 via-muted/70 to-transparent',
               'hover:from-surface-active/95',
               'transition-all duration-150 ease-out z-20',
-              'absolute right-[72px] bottom-px'
+              isDayPanelOpen ? 'absolute end-0 bottom-px' : 'absolute end-[48px] bottom-px'
             )}
             aria-label={tPhaseF('phaseF.componentsTabsTabBarWithDrag.scrollTabsRight')}
           >
@@ -216,40 +210,15 @@ export const TabBarWithDrag = ({
         )}
 
         {/* Tab actions */}
-        <div
-          className={cn(
-            'no-drag flex items-center pr-[13px] pl-2 gap-1 ml-auto',
-            isDayPanelOpen
-              ? 'self-stretch bg-sidebar border-l border-sidebar-border rounded-tl-md relative z-10 mb-[-1px] pb-px'
-              : 'self-center'
-          )}
-        >
-          <TabBarAction
-            icon={
-              <SidebarGraph
-                className={cn(
-                  'w-4 h-4 transition-colors duration-150',
-                  isGraphActive && 'text-tint'
-                )}
-              />
-            }
-            tooltip={tPhaseF('phaseF.componentsTabsTabBarWithDrag.graphG')}
-            onClick={handleGraphClick}
-          />
-          <TabBarAction
-            icon={
-              <DayPanelIcon
-                className={cn(
-                  'w-4 h-4 transition-colors duration-150',
-                  isDayPanelOpen && 'text-tint'
-                )}
-              />
-            }
-            tooltip={tPhaseF('phaseF.componentsTabsTabBarWithDrag.dayPanel')}
-            onClick={toggleDayPanel}
-            isActive={isDayPanelOpen}
-          />
-        </div>
+        {!isDayPanelOpen && (
+          <div className="no-drag ms-auto flex items-center gap-1 self-center pe-[13px] ps-2">
+            <TabBarAction
+              icon={<LayoutAlignRightIcon className="w-4 h-4 transition-colors duration-150" />}
+              tooltip={tPhaseF('phaseF.componentsTabsTabBarWithDrag.dayPanel')}
+              onClick={toggleDayPanel}
+            />
+          </div>
+        )}
       </div>
     </TabBarContextMenu>
   )

--- a/apps/desktop/src/renderer/src/lib/icons/icon-map.ts
+++ b/apps/desktop/src/renderer/src/lib/icons/icon-map.ts
@@ -209,7 +209,7 @@ import {
   NodeMoveUpIcon,
   PanelLeftIcon,
   PencilEdit01Icon,
-  PlusSignIcon,
+  PlusSignIcon as HugePlusSignIcon,
   PreviousIcon,
   Refresh01Icon,
   RotateLeft01Icon,
@@ -546,7 +546,8 @@ export const Computer = createIcon(ComputerIcon)
 export const Brain = createIcon(BrainIcon)
 export const History = createIcon(WorkHistoryIcon)
 export const LogOut = createIcon(Logout01Icon)
-export const Plus = createIcon(PlusSignIcon)
+export const Plus = createIcon(HugePlusSignIcon)
+export const PlusSignIcon = createIcon(HugePlusSignIcon)
 export const Minus = createIcon(MinusSignIcon)
 export const TrendingUp = createIcon(ChartIncreaseIcon)
 export const ZoomIn = createIcon(ZoomInAreaIcon)

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -13,9 +13,10 @@ endpoint and bearer token.
 
 ## Agent Chat
 
-Open the right sidebar, choose **Agent**, and pick a provider. For Claude CLI, Memry checks that
-`claude` is available on `PATH`, that it reports version `2.1.0` or newer, and that the Agent
-disclosure has been accepted. For local models, configure a compatible server in
+Open the right sidebar, choose **Agent**, and pick a provider. The Agent header includes a
+new-conversation button and a history menu for switching back to recent conversations. For Claude
+CLI, Memry checks that `claude` is available on `PATH`, that it reports version `2.1.0` or newer,
+and that the Agent disclosure has been accepted. For local models, configure a compatible server in
 [Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
 
 Agent Chat can:

--- a/apps/docs/src/user-guide/day-panel.md
+++ b/apps/docs/src/user-guide/day-panel.md
@@ -50,6 +50,10 @@ If the [Google Calendar integration](/user-guide/settings#integrations) is linke
 
 Toggle the panel from the workspace header or with the panel's collapse button.
 
+When the panel is open, it starts at the tab bar edge and the tab bar reserves that space. The
+collapse button stays at the far right of the panel, so opening and closing the sidebar uses the
+same pointer location.
+
 When the panel is hidden, focus state still tracks (so reopening the panel restores the previously focused date).
 
 ## Why a Panel and a Calendar Tab?

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -112,6 +112,7 @@
     "conversationLoading": "Conversation loading...",
     "startTitle": "Start chatting with your vault",
     "newConversation": "New conversation",
+    "history": "Conversation history",
     "stop": "Stop",
     "thinking": "Agent is thinking",
     "binary": {


### PR DESCRIPTION
## Summary
- Move Agent Chat new-conversation and history controls into the right-sidebar Agent header.
- Make the right sidebar reserve tab-bar space while open and keep the collapse control anchored at the far right.
- Align right-sidebar background, borders, labels, and dropdown hover states with the main layout.

## Release note
Polished Agent Chat right-sidebar controls, history access, and open/close behavior.

## Test plan
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm ipc:check
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build