### PR TITLE
Make agent tool confirmations optional

### DIFF
--- a/apps/desktop/src/main/agent/bootstrap.ts
+++ b/apps/desktop/src/main/agent/bootstrap.ts
@@ -29,6 +29,7 @@ import { getPublicStatus } from './mcp/lifecycle'
 import { createVaultServiceHandles } from './mcp/tools/handles-adapter'
 import { ALL_TOOL_NAMES } from './mcp/tools/schemas'
 import { AgentRuntime } from './runtime/runtime'
+import { getAgentPreferences, setAgentPreferences } from './settings'
 import { createConversationStore } from './storage/conversation-store'
 import { createMessageStore } from './storage/message-store'
 import { getOrCreateVaultUuid } from './storage/vault-id'
@@ -189,7 +190,7 @@ export async function startAgent(): Promise<AgentHandle> {
     local: localBackend
   })
 
-  const runtime = new AgentRuntime({ conversations, messages })
+  const runtime = new AgentRuntime({ conversations, messages, getPreferences: getAgentPreferences })
   runtime.install()
 
   registerAgentHandlers({
@@ -224,6 +225,10 @@ export async function startAgent(): Promise<AgentHandle> {
         return testOpenAiCompatibleConnection(settings, fetch, await getLocalProviderApiKey())
       },
       probeTools: () => localBackend.probeCapabilities()
+    },
+    preferences: {
+      get: getAgentPreferences,
+      set: setAgentPreferences
     },
     vaultId
   })

--- a/apps/desktop/src/main/agent/runtime/__tests__/permission-gate.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/permission-gate.test.ts
@@ -3,11 +3,28 @@ import { describe, expect, it } from 'vitest'
 import { decideToolGate } from '../permission-gate'
 
 describe('decideToolGate', () => {
+  it('auto-approves write tools by default', () => {
+    const createDecision = decideToolGate({
+      toolName: 'vault_create_task',
+      trustList: [],
+      pendingDecision: null
+    })
+    const updateDecision = decideToolGate({
+      toolName: 'vault_update_note',
+      trustList: [],
+      pendingDecision: null
+    })
+
+    expect(createDecision).toEqual({ outcome: 'auto_approve' })
+    expect(updateDecision).toEqual({ outcome: 'auto_approve' })
+  })
+
   it('auto-approves read tools regardless of trust list', () => {
     const decision = decideToolGate({
       toolName: 'vault_read_note',
       trustList: [],
-      pendingDecision: null
+      pendingDecision: null,
+      toolApprovalMode: 'ask'
     })
 
     expect(decision).toEqual({ outcome: 'auto_approve' })
@@ -17,27 +34,30 @@ describe('decideToolGate', () => {
     const decision = decideToolGate({
       toolName: 'vault_create_task',
       trustList: ['vault_create_task'],
-      pendingDecision: null
+      pendingDecision: null,
+      toolApprovalMode: 'ask'
     })
 
     expect(decision).toEqual({ outcome: 'auto_approve' })
   })
 
-  it('asks for approval on create tools not in trust list', () => {
+  it('asks for approval on create tools not in trust list when manual approval is enabled', () => {
     const decision = decideToolGate({
       toolName: 'vault_create_task',
       trustList: [],
-      pendingDecision: null
+      pendingDecision: null,
+      toolApprovalMode: 'ask'
     })
 
     expect(decision).toEqual({ outcome: 'await_user', requiresDiff: false })
   })
 
-  it('always asks on update tools, regardless of trust list', () => {
+  it('asks on update tools, regardless of trust list, when manual approval is enabled', () => {
     const decision = decideToolGate({
       toolName: 'vault_update_note',
       trustList: ['vault_update_note', 'vault_add_tag'],
-      pendingDecision: null
+      pendingDecision: null,
+      toolApprovalMode: 'ask'
     })
 
     expect(decision).toEqual({ outcome: 'await_user', requiresDiff: true })
@@ -47,7 +67,8 @@ describe('decideToolGate', () => {
     const decision = decideToolGate({
       toolName: 'vault_update_note',
       trustList: [],
-      pendingDecision: null
+      pendingDecision: null,
+      toolApprovalMode: 'ask'
     })
 
     expect(decision).toMatchObject({ requiresDiff: true })

--- a/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
@@ -17,7 +17,7 @@ import type { ConversationStore } from '../../storage/conversation-store'
 import type { MessageStore } from '../../storage/message-store'
 import { AgentRuntime } from '../runtime'
 
-function createRuntime() {
+function createRuntime(toolApprovalMode: 'always_accept' | 'ask' = 'always_accept') {
   const conversations = {
     getById: vi.fn(),
     addToTrustList: vi.fn()
@@ -25,7 +25,7 @@ function createRuntime() {
   const runtime = new AgentRuntime({
     conversations: conversations as unknown as ConversationStore,
     messages: {} as MessageStore,
-    spawn: vi.fn() as never
+    getPreferences: () => ({ toolApprovalMode })
   })
 
   return { runtime, conversations }
@@ -59,8 +59,26 @@ describe('AgentRuntime approval gate', () => {
     ).resolves.toEqual({ approved: false, reason: 'Unknown conversation' })
   })
 
-  it('auto-approves read and trusted create tools', async () => {
+  it('auto-approves write tools by default without queuing an approval', async () => {
     const { runtime, conversations } = createRuntime()
+    conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
+
+    runtime.install()
+    const gate = installedGate()
+
+    await expect(
+      gate({
+        conversationId: 'conversation-1',
+        toolName: 'vault_update_note',
+        parsedArgs: { id: 'note-1', content_markdown: 'Draft' }
+      })
+    ).resolves.toEqual({ approved: true })
+    expect(mocks.broadcastAgentEvent).not.toHaveBeenCalled()
+    expect(runtime.getPendingApproval('gate-100-i')).toBeNull()
+  })
+
+  it('auto-approves read and trusted create tools in manual mode', async () => {
+    const { runtime, conversations } = createRuntime('ask')
     conversations.getById.mockReturnValue({
       id: 'conversation-1',
       trustList: ['vault_create_task']
@@ -83,7 +101,7 @@ describe('AgentRuntime approval gate', () => {
   })
 
   it('waits for user approval and applies allow-always trust changes', async () => {
-    const { runtime, conversations } = createRuntime()
+    const { runtime, conversations } = createRuntime('ask')
     conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
 
     runtime.install()
@@ -117,7 +135,7 @@ describe('AgentRuntime approval gate', () => {
   })
 
   it('returns edited args and denial decisions from pending approvals', async () => {
-    const { runtime, conversations } = createRuntime()
+    const { runtime, conversations } = createRuntime('ask')
     conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
 
     runtime.install()

--- a/apps/desktop/src/main/agent/runtime/permission-gate.ts
+++ b/apps/desktop/src/main/agent/runtime/permission-gate.ts
@@ -1,4 +1,4 @@
-import type { ApproveToolDecision } from '@memry/contracts/ipc-agent'
+import type { AgentToolApprovalMode, ApproveToolDecision } from '@memry/contracts/ipc-agent'
 
 import {
   CREATE_TOOL_NAMES,
@@ -15,6 +15,7 @@ export interface GateInput {
   toolName: string
   trustList: string[]
   pendingDecision: ApproveToolDecision | null
+  toolApprovalMode?: AgentToolApprovalMode
 }
 
 export type GateDecision =
@@ -25,6 +26,10 @@ export type GateDecision =
 export function decideToolGate(input: GateInput): GateDecision {
   if (input.pendingDecision) {
     return { outcome: 'apply_decision', decision: input.pendingDecision }
+  }
+
+  if ((input.toolApprovalMode ?? 'always_accept') === 'always_accept') {
+    return { outcome: 'auto_approve' }
   }
 
   if (READ_TOOLS.has(input.toolName)) {

--- a/apps/desktop/src/main/agent/runtime/runtime.ts
+++ b/apps/desktop/src/main/agent/runtime/runtime.ts
@@ -1,4 +1,4 @@
-import type { ApproveToolDecision } from '@memry/contracts/ipc-agent'
+import type { AgentPreferences, ApproveToolDecision } from '@memry/contracts/ipc-agent'
 
 import { createLogger } from '../../lib/logger'
 import { setWriteGate as setMcpWriteGate } from '../mcp/lifecycle'
@@ -27,6 +27,7 @@ interface TrackedSubprocess {
 export interface AgentRuntimeDeps {
   conversations: ConversationStore
   messages: MessageStore
+  getPreferences?: () => AgentPreferences
 }
 
 export type PendingApprovalSnapshot = Omit<PendingApproval, 'resolve'>
@@ -49,7 +50,8 @@ export class AgentRuntime {
       const decision = decideToolGate({
         toolName: ctx.toolName,
         trustList: conversation.trustList,
-        pendingDecision: null
+        pendingDecision: null,
+        toolApprovalMode: this.deps.getPreferences?.().toolApprovalMode
       })
       if (decision.outcome === 'auto_approve') {
         return { approved: true }

--- a/apps/desktop/src/main/agent/settings.test.ts
+++ b/apps/desktop/src/main/agent/settings.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storeState = vi.hoisted(() => ({
+  agent: {} as Record<string, unknown>
+}))
+
+vi.mock('../store', () => ({
+  store: {
+    get: vi.fn((key: string) => {
+      if (key === 'agent') return storeState.agent
+      return undefined
+    }),
+    set: vi.fn((key: string, value: unknown) => {
+      if (key === 'agent') storeState.agent = value as Record<string, unknown>
+    })
+  }
+}))
+
+import { getAgentPreferences, setAgentPreferences } from './settings'
+
+describe('agent preferences', () => {
+  beforeEach(() => {
+    storeState.agent = {}
+  })
+
+  it('defaults tool approval to always accept', () => {
+    expect(getAgentPreferences()).toEqual({ toolApprovalMode: 'always_accept' })
+  })
+
+  it('persists manual tool approval mode', () => {
+    expect(setAgentPreferences({ toolApprovalMode: 'ask' })).toEqual({
+      toolApprovalMode: 'ask'
+    })
+    expect(getAgentPreferences()).toEqual({ toolApprovalMode: 'ask' })
+  })
+
+  it('keeps the current preference when an empty update is saved', () => {
+    setAgentPreferences({ toolApprovalMode: 'ask' })
+
+    expect(setAgentPreferences({})).toEqual({ toolApprovalMode: 'ask' })
+  })
+})

--- a/apps/desktop/src/main/agent/settings.ts
+++ b/apps/desktop/src/main/agent/settings.ts
@@ -1,0 +1,29 @@
+import {
+  AgentPreferencesSchema,
+  AgentPreferencesUpdateSchema,
+  type AgentPreferences,
+  type AgentPreferencesUpdate
+} from '@memry/contracts/ipc-agent'
+
+import { store } from '../store'
+
+const DEFAULT_AGENT_PREFERENCES: AgentPreferences = {
+  toolApprovalMode: 'always_accept'
+}
+
+export function getAgentPreferences(): AgentPreferences {
+  const agent = store.get('agent')
+  return AgentPreferencesSchema.parse({
+    ...DEFAULT_AGENT_PREFERENCES,
+    toolApprovalMode: agent.toolApprovalMode
+  })
+}
+
+export function setAgentPreferences(input: AgentPreferencesUpdate): AgentPreferences {
+  const update = AgentPreferencesUpdateSchema.parse(input)
+  store.set('agent', {
+    ...store.get('agent'),
+    ...update
+  })
+  return getAgentPreferences()
+}

--- a/apps/desktop/src/main/ipc/agent-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.test.ts
@@ -14,7 +14,11 @@ const mocks = vi.hoisted(() => ({
     }
   ]),
   getDisclosureState: vi.fn(() => ({ accepted: false })),
-  acceptDisclosure: vi.fn(() => ({ accepted: true }))
+  acceptDisclosure: vi.fn(() => ({ accepted: true })),
+  getAgentPreferences: vi.fn(() => ({ toolApprovalMode: 'always_accept' })),
+  setAgentPreferences: vi.fn((input: { toolApprovalMode?: 'always_accept' | 'ask' }) => ({
+    toolApprovalMode: input.toolApprovalMode ?? 'always_accept'
+  }))
 }))
 
 vi.mock('electron', () => ({
@@ -30,6 +34,10 @@ vi.mock('../agent/runtime/attachment-snapshotter', () => ({
 vi.mock('../agent/runtime/disclosure-state', () => ({
   getDisclosureState: mocks.getDisclosureState,
   acceptDisclosure: mocks.acceptDisclosure
+}))
+vi.mock('../agent/settings', () => ({
+  getAgentPreferences: mocks.getAgentPreferences,
+  setAgentPreferences: mocks.setAgentPreferences
 }))
 
 import { AgentChannels } from '@memry/contracts/ipc-agent'
@@ -193,6 +201,15 @@ describe('agent IPC handlers', () => {
         available: false
       })
     })
+    expect(findHandler(AgentChannels.invoke.GET_PREFERENCES)(null)).toEqual({
+      toolApprovalMode: 'always_accept'
+    })
+    expect(
+      findHandler(AgentChannels.invoke.SET_PREFERENCES)(null, { toolApprovalMode: 'ask' })
+    ).toEqual({
+      toolApprovalMode: 'ask'
+    })
+    expect(mocks.setAgentPreferences).toHaveBeenCalledWith({ toolApprovalMode: 'ask' })
   })
 
   it('returns unified backend statuses keyed by backend id', async () => {

--- a/apps/desktop/src/main/ipc/agent-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.test.ts
@@ -148,6 +148,10 @@ describe('agent IPC handlers', () => {
         detail: null
       }))
     },
+    preferences: {
+      get: vi.fn(() => ({ toolApprovalMode: 'always_accept' })),
+      set: vi.fn((input) => input)
+    },
     vaultId: 'vault-1'
   } as never
 
@@ -227,6 +231,18 @@ describe('agent IPC handlers', () => {
         { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' }
       ]
     })
+  })
+
+  it('gets and sets agent preferences', async () => {
+    registerAgentHandlers(deps)
+
+    await expect(findHandler(AgentChannels.invoke.GET_PREFERENCES)(null)).resolves.toEqual({
+      toolApprovalMode: 'always_accept'
+    })
+    await expect(
+      findHandler(AgentChannels.invoke.SET_PREFERENCES)(null, { toolApprovalMode: 'ask' })
+    ).resolves.toEqual({ toolApprovalMode: 'ask' })
+    expect(deps.preferences.set).toHaveBeenCalledWith({ toolApprovalMode: 'ask' })
   })
 
   it('runs a turn with snapshotted attachments', async () => {

--- a/apps/desktop/src/main/ipc/agent-handlers.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.ts
@@ -5,6 +5,7 @@ import {
   AgentBackendModelListRequestSchema,
   AgentChannels,
   AgentLocalProviderSettingsUpdateSchema,
+  AgentPreferencesUpdateSchema,
   ApproveToolRequestSchema,
   PreviewDiffRequestSchema,
   type AgentBackendOptions,
@@ -13,12 +14,15 @@ import {
   type AgentLocalProviderProbeResult,
   type AgentLocalProviderSettings,
   type AgentLocalProviderSettingsUpdate,
+  type AgentPreferences,
+  type AgentPreferencesUpdate,
   type BackendStatusesResponse,
   type PreviewDiffResponse,
   SendTurnRequestSchema
 } from '@memry/contracts/ipc-agent'
 
 import { TOOL_SCHEMAS } from '../agent/mcp/tools/schemas'
+import { getAgentPreferences, setAgentPreferences } from '../agent/settings'
 import type { AgentRuntime } from '../agent/runtime/runtime'
 import { acceptDisclosure, getDisclosureState } from '../agent/runtime/disclosure-state'
 import { snapshotAttachments } from '../agent/runtime/attachment-snapshotter'
@@ -78,6 +82,10 @@ interface AgentHandlerDeps {
     listModels: () => Promise<AgentLocalModelList>
     testConnection: () => Promise<AgentLocalProviderProbeResult>
     probeTools: () => Promise<AgentLocalProviderProbeResult>
+  }
+  preferences: {
+    get: () => AgentPreferences
+    set: (input: AgentPreferencesUpdate) => AgentPreferences
   }
   vaultId: string
 }
@@ -260,6 +268,10 @@ export function registerAgentHandlers(deps: AgentHandlerDeps): void {
   ipcMain.handle(AgentChannels.invoke.SET_LOCAL_PROVIDER_SETTINGS, (_event, payload: unknown) => {
     return deps.localProvider.setSettings(AgentLocalProviderSettingsUpdateSchema.parse(payload))
   })
+  ipcMain.handle(AgentChannels.invoke.GET_PREFERENCES, async () => deps.preferences.get())
+  ipcMain.handle(AgentChannels.invoke.SET_PREFERENCES, async (_event, payload: unknown) => {
+    return deps.preferences.set(AgentPreferencesUpdateSchema.parse(payload))
+  })
   ipcMain.handle(AgentChannels.invoke.LIST_LOCAL_MODELS, () => deps.localProvider.listModels())
   ipcMain.handle(AgentChannels.invoke.TEST_LOCAL_PROVIDER, () =>
     deps.localProvider.testConnection()
@@ -321,6 +333,10 @@ export function registerUnavailableAgentHandlers(reason: string): void {
   registerUnavailableHandler(AgentChannels.invoke.SET_LOCAL_PROVIDER_SETTINGS, async () =>
     unavailable()
   )
+  registerUnavailableHandler(AgentChannels.invoke.GET_PREFERENCES, () => getAgentPreferences())
+  registerUnavailableHandler(AgentChannels.invoke.SET_PREFERENCES, (_event, payload) => {
+    return setAgentPreferences(AgentPreferencesUpdateSchema.parse(payload))
+  })
   registerUnavailableHandler(AgentChannels.invoke.LIST_LOCAL_MODELS, async () => unavailable())
   registerUnavailableHandler(AgentChannels.invoke.TEST_LOCAL_PROVIDER, async () => unavailable())
   registerUnavailableHandler(AgentChannels.invoke.PROBE_LOCAL_PROVIDER, async () => unavailable())

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -15,6 +15,7 @@ export interface MainIpcInvokeHandlers {
   "agent:getBackendStatuses": (...args: []) => Awaited<Promise<{ claude_cli: { backend: "claude_cli" | "codex_cli" | "local_openai_compatible"; available: boolean; reason?: string | null | undefined; detail?: string | null | undefined; version?: string | null | undefined; minimumRequired?: string | null | undefined; }; codex_cli: { backend: "claude_cli" | "codex_cli" | "local_openai_compatible"; available: boolean; reason?: string | null | undefined; detail?: string | null | undefined; version?: string | null | undefined; minimumRequired?: string | null | undefined; }; local_openai_compatible: { backend: "claude_cli" | "codex_cli" | "local_openai_compatible"; available: boolean; reason?: string | null | undefined; detail?: string | null | undefined; version?: string | null | undefined; minimumRequired?: string | null | undefined; }; }>>
   "agent:getDisclosureState": (...args: []) => Awaited<import("../agent/runtime/disclosure-state").DisclosureState>
   "agent:getLocalProviderSettings": (...args: []) => Awaited<Promise<{ preset: "custom" | "ollama" | "lm_studio" | "llama_cpp"; baseUrl: string; model: string; apiKeyConfigured: boolean; allowNonLoopback: boolean; }>>
+  "agent:getPreferences": (...args: []) => Awaited<Promise<{ toolApprovalMode: "always_accept" | "ask"; }>>
   "agent:getWindowId": (...args: []) => Awaited<{ windowId: string | null; }>
   "agent:listBackendModels": (...args: [unknown]) => Awaited<Promise<{ backend: "claude_cli" | "codex_cli"; supportsCustomModel: boolean; models: { id: string; label: string; }[]; }>>
   "agent:listConversations": (...args: [unknown]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-agent").Conversation[]>>
@@ -24,6 +25,7 @@ export interface MainIpcInvokeHandlers {
   "agent:probeLocalProvider": (...args: []) => Awaited<Promise<{ connected: boolean; modelAvailable: boolean; streamingSupported: boolean; toolCallingSupported: boolean; toolContinuationSupported: boolean; toolsEnabled: boolean; detail: string | null; }>>
   "agent:sendTurn": (...args: [unknown]) => Awaited<Promise<{ ok: boolean; error: string; } | { ok: boolean; error?: undefined; }>>
   "agent:setLocalProviderSettings": (...args: [unknown]) => Awaited<Promise<{ preset: "custom" | "ollama" | "lm_studio" | "llama_cpp"; baseUrl: string; model: string; apiKeyConfigured: boolean; allowNonLoopback: boolean; }>>
+  "agent:setPreferences": (...args: [unknown]) => Awaited<Promise<{ toolApprovalMode: "always_accept" | "ask"; }>>
   "agent:testLocalProvider": (...args: []) => Awaited<Promise<{ connected: boolean; modelAvailable: boolean; streamingSupported: boolean; toolCallingSupported: boolean; toolContinuationSupported: boolean; toolsEnabled: boolean; detail: string | null; }>>
   "ai-inline:get-server-port": (...args: []) => Awaited<number | null>
   "ai-inline:get-settings": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ai-inline-channels").AIInlineSettings>

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -27,6 +27,7 @@ export interface SyncStoreData {
 
 export interface AgentStoreData {
   disclosureAccepted?: boolean
+  toolApprovalMode?: 'always_accept' | 'ask'
   localProvider?: {
     preset?: 'ollama' | 'lm_studio' | 'llama_cpp' | 'custom'
     baseUrl?: string

--- a/apps/desktop/src/preload/api/agent.ts
+++ b/apps/desktop/src/preload/api/agent.ts
@@ -7,6 +7,8 @@ import type {
   AgentLocalProviderProbeResult,
   AgentLocalProviderSettings,
   AgentLocalProviderSettingsUpdate,
+  AgentPreferences,
+  AgentPreferencesUpdate,
   ApproveToolRequest,
   BackendStatusesResponse,
   PreviewDiffRequest,
@@ -56,6 +58,9 @@ export const agentApi = {
     input: AgentLocalProviderSettingsUpdate
   ): Promise<AgentLocalProviderSettings> =>
     invoke(AgentChannels.invoke.SET_LOCAL_PROVIDER_SETTINGS, input),
+  getPreferences: (): Promise<AgentPreferences> => invoke(AgentChannels.invoke.GET_PREFERENCES),
+  setPreferences: (input: AgentPreferencesUpdate): Promise<AgentPreferences> =>
+    invoke(AgentChannels.invoke.SET_PREFERENCES, input),
   listLocalModels: (): Promise<AgentLocalModelList> =>
     invoke(AgentChannels.invoke.LIST_LOCAL_MODELS),
   testLocalProvider: (): Promise<AgentLocalProviderProbeResult> =>

--- a/apps/desktop/src/preload/api/preload-api.test.ts
+++ b/apps/desktop/src/preload/api/preload-api.test.ts
@@ -834,6 +834,12 @@ describe('preload api wrappers', () => {
       AgentChannels.invoke.PREVIEW_DIFF,
       { conversationId: 'conversation-1', callId: 'call-1' }
     )
+    await expectInvoke(() => agentApi.getPreferences(), AgentChannels.invoke.GET_PREFERENCES)
+    await expectInvoke(
+      () => agentApi.setPreferences({ toolApprovalMode: 'ask' }),
+      AgentChannels.invoke.SET_PREFERENCES,
+      { toolApprovalMode: 'ask' }
+    )
     await expectInvoke(
       () =>
         agentApi.editTrustList({

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -14,6 +14,8 @@ import type {
   AgentLocalProviderProbeResult,
   AgentLocalProviderSettings,
   AgentLocalProviderSettingsUpdate,
+  AgentPreferences,
+  AgentPreferencesUpdate,
   ApproveToolRequest,
   BackendStatusesResponse,
   PreviewDiffRequest,
@@ -1641,6 +1643,8 @@ interface AgentClientAPI {
   setLocalProviderSettings: (
     input: AgentLocalProviderSettingsUpdate
   ) => Promise<AgentLocalProviderSettings>
+  getPreferences: () => Promise<AgentPreferences>
+  setPreferences: (input: AgentPreferencesUpdate) => Promise<AgentPreferences>
   listLocalModels: () => Promise<AgentLocalModelList>
   testLocalProvider: () => Promise<AgentLocalProviderProbeResult>
   probeLocalProvider: () => Promise<AgentLocalProviderProbeResult>

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx
@@ -427,6 +427,26 @@ describe('agentReducer', () => {
         error: { code: 'PERMISSION_DENIED', message: 'Denied' }
       }
     })
+
+    const errored = agentReducer(started, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_failed',
+        conversationId: conversation.id,
+        toolCallId: 'tool-1',
+        error: { code: 'INTERNAL', message: 'Connection timeout' }
+      }
+    })
+
+    expect(errored.messagesByConversation[conversation.id][0]?.content).toEqual({
+      role: 'tool_call',
+      data: {
+        tool: 'vault_read_note',
+        args: { id: 'note-1' },
+        status: 'output-error',
+        error: { code: 'INTERNAL', message: 'Connection timeout' }
+      }
+    })
   })
 
   it('clears in-flight state when a turn ends', () => {

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx
@@ -290,7 +290,7 @@ describe('agentReducer', () => {
           data: {
             tool: 'vault_create_task',
             args: { title: 'Buy milk' },
-            status: 'pending'
+            status: 'approval-requested'
           }
         }
       })
@@ -328,7 +328,103 @@ describe('agentReducer', () => {
       data: {
         tool: 'vault_create_task',
         args: { title: 'Buy milk' },
-        status: 'approved'
+        status: 'approval-responded'
+      }
+    })
+  })
+
+  it('creates an inline tool message for auto-accepted started calls', () => {
+    const state: AgentState = {
+      ...initialAgentState,
+      activeConversationId: conversation.id,
+      conversations: { [conversation.id]: conversation },
+      messagesByConversation: { [conversation.id]: [] }
+    }
+    const event: AgentEvent = {
+      kind: 'tool_call_started',
+      conversationId: conversation.id,
+      toolCallId: 'tool-1',
+      name: 'vault_read_note',
+      args: { id: 'note-1' }
+    }
+
+    const next = agentReducer(state, { type: 'event', event })
+
+    expect(next.messagesByConversation[conversation.id][0]).toEqual(
+      expect.objectContaining({
+        id: 'tool-call-tool-1',
+        role: 'tool_call',
+        toolCallId: 'tool-1',
+        status: 'streaming',
+        content: {
+          role: 'tool_call',
+          data: {
+            tool: 'vault_read_note',
+            args: { id: 'note-1' },
+            status: 'input-available'
+          }
+        }
+      })
+    )
+  })
+
+  it('stores completed and failed tool outputs on the tool message', () => {
+    const started = agentReducer(
+      {
+        ...initialAgentState,
+        activeConversationId: conversation.id,
+        conversations: { [conversation.id]: conversation },
+        messagesByConversation: { [conversation.id]: [] }
+      },
+      {
+        type: 'event',
+        event: {
+          kind: 'tool_call_started',
+          conversationId: conversation.id,
+          toolCallId: 'tool-1',
+          name: 'vault_read_note',
+          args: { id: 'note-1' }
+        }
+      }
+    )
+
+    const completed = agentReducer(started, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_completed',
+        conversationId: conversation.id,
+        toolCallId: 'tool-1',
+        result: { title: 'Planning' }
+      }
+    })
+
+    expect(completed.messagesByConversation[conversation.id][0]?.content).toEqual({
+      role: 'tool_call',
+      data: {
+        tool: 'vault_read_note',
+        args: { id: 'note-1' },
+        status: 'output-available',
+        output: { title: 'Planning' }
+      }
+    })
+
+    const failed = agentReducer(started, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_failed',
+        conversationId: conversation.id,
+        toolCallId: 'tool-1',
+        error: { code: 'PERMISSION_DENIED', message: 'Denied' }
+      }
+    })
+
+    expect(failed.messagesByConversation[conversation.id][0]?.content).toEqual({
+      role: 'tool_call',
+      data: {
+        tool: 'vault_read_note',
+        args: { id: 'note-1' },
+        status: 'output-denied',
+        error: { code: 'PERMISSION_DENIED', message: 'Denied' }
       }
     })
   })

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
@@ -157,7 +157,7 @@ describe('MessageStream', () => {
     expect(screen.getByRole('status', { name: 'Agent is thinking' })).toBeInTheDocument()
   })
 
-  it('renders tool calls as collapsible tool details', () => {
+  it('renders tool calls as collapsed tool details by default', () => {
     render(
       <MessageStream
         messages={[
@@ -170,7 +170,7 @@ describe('MessageStream', () => {
               data: {
                 tool: 'vault_create_task',
                 args: { title: 'Buy milk' },
-                status: 'pending'
+                status: 'input-available'
               }
             }
           })
@@ -179,7 +179,41 @@ describe('MessageStream', () => {
     )
 
     expect(screen.getByRole('button', { name: /vault_create_task/i })).toBeInTheDocument()
+    expect(screen.queryByText('Parameters')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /vault_create_task/i }))
+
     expect(screen.getByText('Parameters')).toBeInTheDocument()
+  })
+
+  it('renders completed tool output in the same collapsed tool block', () => {
+    render(
+      <MessageStream
+        messages={[
+          message({
+            id: 'tool-call-1',
+            role: 'tool_call',
+            toolCallId: 'tool-1',
+            content: {
+              role: 'tool_call',
+              data: {
+                tool: 'vault_read_note',
+                args: { id: 'note-1' },
+                status: 'output-available',
+                output: { title: 'Planning' }
+              }
+            }
+          })
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /vault_read_note/i })).toBeInTheDocument()
+    expect(screen.queryByText('Planning')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /vault_read_note/i }))
+
+    expect(screen.getByText(/Planning/)).toBeInTheDocument()
   })
 
   it('approves pending tool calls inline without a dialog', async () => {
@@ -221,6 +255,7 @@ describe('MessageStream', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
+    fireEvent.click(screen.getByRole('button', { name: /vault_create_task/i }))
     fireEvent.click(screen.getByRole('button', { name: 'Allow once' }))
 
     await waitFor(() => {
@@ -269,6 +304,7 @@ describe('MessageStream', () => {
       />
     )
 
+    fireEvent.click(screen.getByRole('button', { name: /vault_create_task/i }))
     fireEvent.click(screen.getByRole('button', { name: 'Edit and allow' }))
     fireEvent.change(screen.getByRole('textbox'), { target: { value: '{"title":"Edited"}' } })
     fireEvent.click(screen.getByRole('button', { name: 'Apply edits' }))
@@ -329,6 +365,7 @@ describe('MessageStream', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
+    fireEvent.click(screen.getByRole('button', { name: /vault_update_note/i }))
     const candidate = await screen.findByRole('textbox', { name: 'Candidate' })
     fireEvent.change(candidate, { target: { value: 'edited full note' } })
     fireEvent.click(screen.getByRole('button', { name: 'Apply edited' }))

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
@@ -2,7 +2,8 @@ import type {
   AgentEvent,
   BackendStatusesResponse,
   Conversation,
-  Message
+  Message,
+  ToolCallStatus
 } from '@memry/contracts/ipc-agent'
 
 export type PendingToolApproval = Extract<AgentEvent, { kind: 'tool_call_pending_approval' }>
@@ -79,6 +80,7 @@ function upsertToolCallMessage(
     toolCallId: string
     name: string
     args: unknown
+    status: ToolCallStatus
   }
 ): Message[] {
   const newest = messages.reduce((max, message) => Math.max(max, message.createdAt), 0)
@@ -94,7 +96,7 @@ function upsertToolCallMessage(
           input.args && typeof input.args === 'object' && !Array.isArray(input.args)
             ? (input.args as Record<string, unknown>)
             : {},
-        status: 'pending'
+        status: input.status
       }
     },
     toolCallId: input.toolCallId,
@@ -110,18 +112,25 @@ function upsertToolCallMessage(
 function updateToolCallStatus(
   messages: Message[],
   toolCallId: string,
-  status: 'approved' | 'completed' | 'denied' | 'failed'
+  status: ToolCallStatus,
+  patch?: { output?: unknown; error?: { code: string; message: string } }
 ): Message[] {
   return messages.map((message) => {
     if (message.toolCallId !== toolCallId || message.content.role !== 'tool_call') return message
     return {
       ...message,
-      status: status === 'completed' ? 'completed' : status === 'failed' ? 'error' : message.status,
+      status:
+        status === 'completed' || status === 'output-available'
+          ? 'completed'
+          : status === 'failed' || status === 'output-error' || status === 'output-denied'
+            ? 'error'
+            : message.status,
       content: {
         role: 'tool_call',
         data: {
           ...message.content.data,
-          status
+          status,
+          ...patch
         }
       }
     }
@@ -131,12 +140,13 @@ function updateToolCallStatus(
 function updateToolCallStatusEverywhere(
   messagesByConversation: AgentState['messagesByConversation'],
   toolCallId: string,
-  status: 'approved' | 'completed' | 'denied' | 'failed'
+  status: ToolCallStatus,
+  patch?: { output?: unknown; error?: { code: string; message: string } }
 ): AgentState['messagesByConversation'] {
   return Object.fromEntries(
     Object.entries(messagesByConversation).map(([conversationId, messages]) => [
       conversationId,
-      updateToolCallStatus(messages, toolCallId, status)
+      updateToolCallStatus(messages, toolCallId, status, patch)
     ])
   )
 }
@@ -199,7 +209,7 @@ export function agentReducer(state: AgentState, action: AgentAction): AgentState
           ? updateToolCallStatusEverywhere(
               state.messagesByConversation,
               action.toolCallId,
-              action.status
+              action.status === 'denied' ? 'output-denied' : 'approval-responded'
             )
           : state.messagesByConversation
       }
@@ -250,13 +260,34 @@ export function agentReducer(state: AgentState, action: AgentAction): AgentState
                 conversationId: event.conversationId,
                 toolCallId: event.toolCallId,
                 name: event.name,
-                args: event.args
+                args: event.args,
+                status: 'approval-requested'
+              }
+            )
+          }
+        }
+      }
+      if (event.kind === 'tool_call_started') {
+        return {
+          ...state,
+          messagesByConversation: {
+            ...state.messagesByConversation,
+            [event.conversationId]: upsertToolCallMessage(
+              state.messagesByConversation[event.conversationId] ?? [],
+              {
+                conversationId: event.conversationId,
+                toolCallId: event.toolCallId,
+                name: event.name,
+                args: event.args,
+                status: 'input-available'
               }
             )
           }
         }
       }
       if (event.kind === 'tool_call_completed' || event.kind === 'tool_call_failed') {
+        const failedAsDenied =
+          event.kind === 'tool_call_failed' && event.error.code === 'PERMISSION_DENIED'
         return {
           ...state,
           pendingApprovals: state.pendingApprovals.filter(
@@ -265,7 +296,12 @@ export function agentReducer(state: AgentState, action: AgentAction): AgentState
           messagesByConversation: updateToolCallStatusEverywhere(
             state.messagesByConversation,
             event.toolCallId,
-            event.kind === 'tool_call_completed' ? 'completed' : 'failed'
+            event.kind === 'tool_call_completed'
+              ? 'output-available'
+              : failedAsDenied
+                ? 'output-denied'
+                : 'output-error',
+            event.kind === 'tool_call_completed' ? { output: event.result } : { error: event.error }
           )
         }
       }

--- a/apps/desktop/src/renderer/src/agent-chat/messages/tool-call-message.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/messages/tool-call-message.tsx
@@ -14,7 +14,7 @@ import {
   ConfirmationActions,
   ConfirmationTitle
 } from '@/components/ai-elements/confirmation'
-import { Tool, ToolContent, ToolHeader, ToolInput } from '@/components/ai-elements/tool'
+import { Tool, ToolContent, ToolHeader, ToolInput, ToolOutput } from '@/components/ai-elements/tool'
 import { Textarea } from '@/components/ui/textarea'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { useAgentOptional } from '../agent-context'
@@ -201,11 +201,14 @@ export function ToolCallMessage({ message }: { message: Message }): React.JSX.El
     }
   }
 
+  const errorText = message.content.data.error?.message
+
   return (
-    <Tool defaultOpen={message.content.data.status === 'pending'}>
+    <Tool defaultOpen={false}>
       <ToolHeader title={message.content.data.tool} state={message.content.data.status} />
       <ToolContent>
         <ToolInput input={message.content.data.args} label={t('agentChat.toolCall.parameters')} />
+        <ToolOutput errorText={errorText} output={message.content.data.output} />
         {agent && pending?.requiresDiff && (
           <InlineDiffApproval key={pending.toolCallId} agent={agent} pending={pending} />
         )}

--- a/apps/desktop/src/renderer/src/components/ai-elements/confirmation.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ai-elements/confirmation.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  Confirmation,
+  ConfirmationAccepted,
+  ConfirmationAction,
+  ConfirmationActions,
+  ConfirmationRejected,
+  ConfirmationRequest,
+  ConfirmationTitle
+} from './confirmation'
+
+describe('Confirmation', () => {
+  it('renders confirmation content and actions for approval states', () => {
+    const onAccept = vi.fn()
+
+    render(
+      <Confirmation
+        approval={{ approved: true, id: 'approval-1' }}
+        data-testid="confirmation"
+        state="approval-requested"
+      >
+        <ConfirmationTitle>
+          <ConfirmationRequest>Approve this tool call?</ConfirmationRequest>
+          <ConfirmationAccepted>Accepted</ConfirmationAccepted>
+          <ConfirmationRejected>Rejected</ConfirmationRejected>
+        </ConfirmationTitle>
+        <ConfirmationActions>
+          <ConfirmationAction onClick={onAccept}>Accept</ConfirmationAction>
+        </ConfirmationActions>
+      </Confirmation>
+    )
+
+    expect(screen.getByTestId('confirmation')).toHaveAttribute('data-approved', 'true')
+    expect(screen.getByText('Approve this tool call?')).toBeInTheDocument()
+    expect(screen.getByText('Accepted')).toBeInTheDocument()
+    expect(screen.getByText('Rejected')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }))
+
+    expect(onAccept).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render for running-only tool states', () => {
+    const { container } = render(
+      <Confirmation state="input-available">
+        <ConfirmationTitle>Hidden</ConfirmationTitle>
+      </Confirmation>
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/ai-elements/confirmation.tsx
+++ b/apps/desktop/src/renderer/src/components/ai-elements/confirmation.tsx
@@ -1,18 +1,45 @@
-import type { ComponentProps } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
 export type ConfirmationProps = ComponentProps<'div'> & {
-  state: 'approved' | 'completed' | 'denied' | 'failed' | 'pending'
+  approval?: {
+    approved?: boolean
+    id?: string
+    reason?: string
+  }
+  state:
+    | 'approved'
+    | 'completed'
+    | 'denied'
+    | 'failed'
+    | 'pending'
+    | 'approval-requested'
+    | 'approval-responded'
+    | 'input-available'
+    | 'input-streaming'
+    | 'output-available'
+    | 'output-denied'
+    | 'output-error'
 }
 
 export function Confirmation({
+  approval,
   className,
   state,
   ...props
 }: ConfirmationProps): React.JSX.Element | null {
-  if (state !== 'pending') return null
+  const visible =
+    state === 'pending' ||
+    state === 'approval-requested' ||
+    state === 'approval-responded' ||
+    state === 'output-available' ||
+    state === 'output-denied' ||
+    state === 'denied' ||
+    state === 'completed' ||
+    state === 'failed'
+  if (!visible) return null
 
   return (
     <div
@@ -20,6 +47,7 @@ export function Confirmation({
         'flex flex-col gap-2 rounded-md border border-sidebar-border bg-background p-3',
         className
       )}
+      data-approved={approval?.approved}
       {...props}
     />
   )
@@ -32,6 +60,37 @@ export function ConfirmationTitle({
   ...props
 }: ConfirmationTitleProps): React.JSX.Element {
   return <p className={cn('text-sm text-foreground', className)} {...props} />
+}
+
+export type ConfirmationRequestProps = ComponentProps<'span'>
+
+export function ConfirmationRequest({
+  className,
+  ...props
+}: ConfirmationRequestProps): React.JSX.Element {
+  return <span className={className} {...props} />
+}
+
+export type ConfirmationAcceptedProps = ComponentProps<'span'> & {
+  children: ReactNode
+}
+
+export function ConfirmationAccepted({
+  className,
+  ...props
+}: ConfirmationAcceptedProps): React.JSX.Element {
+  return <span className={cn('inline-flex items-center gap-1.5', className)} {...props} />
+}
+
+export type ConfirmationRejectedProps = ComponentProps<'span'> & {
+  children: ReactNode
+}
+
+export function ConfirmationRejected({
+  className,
+  ...props
+}: ConfirmationRejectedProps): React.JSX.Element {
+  return <span className={cn('inline-flex items-center gap-1.5', className)} {...props} />
 }
 
 export type ConfirmationActionsProps = ComponentProps<'div'>

--- a/apps/desktop/src/renderer/src/components/ai-elements/tool.tsx
+++ b/apps/desktop/src/renderer/src/components/ai-elements/tool.tsx
@@ -6,21 +6,47 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { CheckCircle, ChevronDown, Clock, Terminal, XCircle } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
-export type ToolState = 'approved' | 'completed' | 'denied' | 'failed' | 'pending'
+export type ToolState =
+  | 'approved'
+  | 'completed'
+  | 'denied'
+  | 'failed'
+  | 'pending'
+  | 'input-streaming'
+  | 'approval-requested'
+  | 'approval-responded'
+  | 'input-available'
+  | 'output-available'
+  | 'output-error'
+  | 'output-denied'
 
 const statusLabels: Record<ToolState, string> = {
   approved: 'Approved',
+  'approval-requested': 'Awaiting approval',
+  'approval-responded': 'Responded',
   completed: 'Completed',
   denied: 'Denied',
   failed: 'Failed',
+  'input-available': 'Running',
+  'input-streaming': 'Pending',
+  'output-available': 'Completed',
+  'output-denied': 'Denied',
+  'output-error': 'Error',
   pending: 'Pending'
 }
 
 const statusIcons: Record<ToolState, ReactNode> = {
   approved: <Clock className="size-3" aria-hidden="true" />,
+  'approval-requested': <Clock className="size-3" aria-hidden="true" />,
+  'approval-responded': <Clock className="size-3" aria-hidden="true" />,
   completed: <CheckCircle className="size-3" aria-hidden="true" />,
   denied: <XCircle className="size-3" aria-hidden="true" />,
   failed: <XCircle className="size-3" aria-hidden="true" />,
+  'input-available': <Clock className="size-3" aria-hidden="true" />,
+  'input-streaming': <Clock className="size-3" aria-hidden="true" />,
+  'output-available': <CheckCircle className="size-3" aria-hidden="true" />,
+  'output-denied': <XCircle className="size-3" aria-hidden="true" />,
+  'output-error': <XCircle className="size-3" aria-hidden="true" />,
   pending: <Clock className="size-3" aria-hidden="true" />
 }
 
@@ -40,15 +66,19 @@ export function Tool({ className, ...props }: ToolProps): React.JSX.Element {
 
 export type ToolHeaderProps = ComponentProps<typeof CollapsibleTrigger> & {
   state: ToolState
-  title: string
+  title?: string
+  type?: string
 }
 
 export function ToolHeader({
   className,
   state,
   title,
+  type,
   ...props
 }: ToolHeaderProps): React.JSX.Element {
+  const label = title ?? type?.replace(/^tool-/, '') ?? 'tool'
+
   return (
     <CollapsibleTrigger
       className={cn('flex w-full items-center justify-between gap-2 p-3 text-start', className)}
@@ -56,7 +86,7 @@ export function ToolHeader({
     >
       <span className="flex min-w-0 items-center gap-2">
         <Terminal className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-        <span className="truncate font-medium text-foreground">{title}</span>
+        <span className="truncate font-medium text-foreground">{label}</span>
       </span>
       <span className="flex shrink-0 items-center gap-2">
         <Badge variant="secondary" className="gap-1">
@@ -80,7 +110,7 @@ export function ToolContent({ className, ...props }: ToolContentProps): React.JS
 
 export type ToolInputProps = ComponentProps<'div'> & {
   input: unknown
-  label: string
+  label?: string
 }
 
 export function ToolInput({
@@ -91,7 +121,7 @@ export function ToolInput({
 }: ToolInputProps): React.JSX.Element {
   return (
     <div className={cn('space-y-2 overflow-hidden', className)} {...props}>
-      <h4 className="font-medium text-muted-foreground text-xs uppercase">{label}</h4>
+      <h4 className="font-medium text-muted-foreground text-xs uppercase">{label ?? 'Input'}</h4>
       <pre className="max-h-36 overflow-auto rounded-md bg-background p-2 text-muted-foreground">
         {JSON.stringify(input, null, 2)}
       </pre>

--- a/apps/desktop/src/renderer/src/pages/settings/agent-providers-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/agent-providers-section.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type {
   AgentLocalProviderPreset,
   AgentLocalProviderProbeResult,
-  AgentLocalProviderSettings
+  AgentLocalProviderSettings,
+  AgentPreferences,
+  AgentToolApprovalMode
 } from '@memry/contracts/ipc-agent'
 import { useT } from '@memry/i18n/renderer'
 
@@ -37,6 +39,7 @@ export function AgentProvidersSection({
 }): React.JSX.Element | null {
   const { t } = useT('settings')
   const [settings, setSettings] = useState<AgentLocalProviderSettings | null>(null)
+  const [preferences, setPreferences] = useState<AgentPreferences | null>(null)
   const [apiKey, setApiKey] = useState('')
   const [models, setModels] = useState<string[]>([])
   const [status, setStatus] = useState<AgentLocalProviderProbeResult | null>(null)
@@ -44,8 +47,13 @@ export function AgentProvidersSection({
 
   useEffect(() => {
     let cancelled = false
-    void window.api.agent.getLocalProviderSettings().then((next) => {
-      if (!cancelled) setSettings(next)
+    void Promise.all([
+      window.api.agent.getLocalProviderSettings(),
+      window.api.agent.getPreferences()
+    ]).then(([nextSettings, nextPreferences]) => {
+      if (cancelled) return
+      setSettings(nextSettings)
+      setPreferences(nextPreferences)
     })
     return () => {
       cancelled = true
@@ -95,6 +103,12 @@ export function AgentProvidersSection({
     }
   }, [apiKey, settings])
 
+  const changeToolApprovalMode = useCallback(async (toolApprovalMode: AgentToolApprovalMode) => {
+    setPreferences((current) => (current ? { ...current, toolApprovalMode } : current))
+    const saved = await window.api.agent.setPreferences({ toolApprovalMode })
+    setPreferences(saved)
+  }, [])
+
   const loadModels = useCallback(async () => {
     setBusy('models')
     try {
@@ -123,7 +137,7 @@ export function AgentProvidersSection({
     }
   }, [])
 
-  if (!settings) return null
+  if (!settings || !preferences) return null
 
   return (
     <div>
@@ -136,6 +150,25 @@ export function AgentProvidersSection({
       )}
 
       <SettingsGroup label={t('agentProviders.groups.local')}>
+        <SettingRow
+          label={t('agentProviders.approval.label')}
+          description={t('agentProviders.approval.description')}
+        >
+          <Select
+            value={preferences.toolApprovalMode}
+            onValueChange={(value) => void changeToolApprovalMode(value as AgentToolApprovalMode)}
+          >
+            <SelectTrigger className="h-8 w-44 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="always_accept">
+                {t('agentProviders.approval.alwaysAccept')}
+              </SelectItem>
+              <SelectItem value="ask">{t('agentProviders.approval.ask')}</SelectItem>
+            </SelectContent>
+          </Select>
+        </SettingRow>
         <SettingRow label={t('agentProviders.fields.preset.label')}>
           <Select
             value={settings.preset}

--- a/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
@@ -281,6 +281,10 @@ function installWindowApi() {
         apiKeyConfigured: false,
         allowNonLoopback: false
       }),
+      getPreferences: vi.fn().mockResolvedValue({
+        toolApprovalMode: 'always_accept'
+      }),
+      setPreferences: vi.fn(async (input) => input),
       setLocalProviderSettings: vi.fn(async (input) => ({
         preset: input.preset,
         baseUrl: input.baseUrl,
@@ -511,6 +515,14 @@ describe('settings section coverage', () => {
 
     expect(await screen.findByText('agentProviders.header.title')).toBeInTheDocument()
     expect(window.api.agent.getLocalProviderSettings).toHaveBeenCalled()
+    expect(window.api.agent.getPreferences).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText('agentProviders.approval.ask'))
+    await waitFor(() =>
+      expect(window.api.agent.setPreferences).toHaveBeenCalledWith({
+        toolApprovalMode: 'ask'
+      })
+    )
 
     fireEvent.click(screen.getByText('agentProviders.presets.lmStudio'))
     expect(screen.getByDisplayValue('http://localhost:1234/v1')).toBeInTheDocument()

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -23,7 +23,7 @@ Agent Chat can:
 - keep local conversation history in the vault database
 - attach the active note as context for a turn
 - stream assistant text back into the sidebar
-- show tool calls, tool results, and approvals inline in the chat stream
+- show collapsed tool calls, tool results, and optional approvals inline in the chat stream
 - stop an in-flight turn
 - compact older conversation history when a prompt grows too large
 
@@ -108,7 +108,7 @@ Read tools are available to Agent Chat and external MCP clients:
 - `vault_list_inbox_items`
 - `vault_get_tags`
 
-Create and update tools require Agent Chat context and explicit approval:
+Create and update tools require Agent Chat context:
 
 - `vault_create_note`
 - `vault_create_task`
@@ -120,11 +120,15 @@ Create and update tools require Agent Chat context and explicit approval:
 - `vault_remove_tag`
 - `vault_move_to_folder`
 
-When a chat backend requests one of these tools from Agent Chat, Memry pauses the turn and shows an
-inline approval card in the conversation. You can allow the request once, allow create tools always
-for that conversation, deny it, or edit the arguments before allowing. Note updates load a
-before/after diff before the write is applied. Unauthenticated or context-free write requests
-continue to be denied.
+By default, Agent Chat accepts these tool calls automatically. The chat still shows each requested
+tool in a collapsed tool row, including running, completed, error, and denied states, so you can open
+the row to inspect parameters and results.
+
+If you switch tool confirmations to **Ask first** in settings, Memry pauses the turn and shows inline
+approval controls inside the tool row. You can allow the request once, allow create tools always for
+that conversation, deny it, or edit the arguments before allowing. Note updates load a before/after
+diff before the write is applied. Unauthenticated or context-free write requests continue to be
+denied.
 
 ## Current Note
 
@@ -135,8 +139,9 @@ of guessing.
 ## Privacy
 
 The MCP server binds only to localhost. Read tools still expose the content they return to the
-client you configure, so only paste the token into clients you trust on this machine. Write tools are
-only applied after the in-app approval gate resolves for the active Agent Chat conversation.
+client you configure, so only paste the token into clients you trust on this machine. Write tools
+still require an active Agent Chat conversation context, and the in-app tool confirmation setting
+decides whether that conversation pauses for approval or accepts the call automatically.
 
 Provider privacy depends on the selected backend:
 

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -221,6 +221,7 @@ and are not synced between devices.
 - **Preset** — Ollama, LM Studio, llama.cpp, or Custom
 - **Base URL** — OpenAI-compatible endpoint, such as `http://localhost:11434/v1`
 - **Model** — choose from `/v1/models` when available or type a model manually
+- **Tool Confirmations** — always accept Agent Chat tool calls by default, or require inline approval first
 - **API Key** — optional, stored in the OS keychain
 - **Test Connection** — checks the endpoint and selected model
 - **Probe Tools** — verifies tool-call emission and tool-result continuation before vault tools are enabled
@@ -237,9 +238,10 @@ Local MCP server controls are also collapsed inside AI Assistant for external de
 - **Rotate Token** — immediately invalidates the previous token
 - **Registered Tools** — count of exposed vault tools
 
-Agent Chat backends use this same server for vault tools. Read tools do not prompt; create tools can
-be trusted per conversation; update tools always require the in-app approval and diff flow. Plain
-external clients can use read tools, but context-free writes are denied. See
+Agent Chat backends use this same server for vault tools. Read tools do not prompt. Create and
+update tools require active Agent Chat context; by default they are accepted automatically and shown
+as collapsed tool rows, or they can require inline approval when **Tool Confirmations** is set to
+**Ask first**. Plain external clients can use read tools, but context-free writes are denied. See
 [Agent MCP Server](/user-guide/ai/agent-mcp).
 
 ---

--- a/packages/contracts/src/ipc-agent.test.ts
+++ b/packages/contracts/src/ipc-agent.test.ts
@@ -9,6 +9,9 @@ import {
   AgentEventSchema,
   AgentLocalProviderProbeResultSchema,
   AgentLocalProviderSettingsSchema,
+  AgentPreferencesSchema,
+  AgentPreferencesUpdateSchema,
+  AgentToolApprovalModeSchema,
   ApproveToolRequestSchema,
   BinaryStatusSchema,
   ConversationSchema,
@@ -35,6 +38,8 @@ describe('AgentChannels', () => {
         LIST_BACKEND_MODELS: 'agent:listBackendModels',
         GET_LOCAL_PROVIDER_SETTINGS: 'agent:getLocalProviderSettings',
         SET_LOCAL_PROVIDER_SETTINGS: 'agent:setLocalProviderSettings',
+        GET_PREFERENCES: 'agent:getPreferences',
+        SET_PREFERENCES: 'agent:setPreferences',
         LIST_LOCAL_MODELS: 'agent:listLocalModels',
         TEST_LOCAL_PROVIDER: 'agent:testLocalProvider',
         PROBE_LOCAL_PROVIDER: 'agent:probeLocalProvider',
@@ -235,6 +240,14 @@ describe('agent IPC schemas', () => {
   })
 
   it('validates approval decisions and binary status', () => {
+    expect(AgentToolApprovalModeSchema.safeParse('always_accept').success).toBe(true)
+    expect(AgentToolApprovalModeSchema.safeParse('ask').success).toBe(true)
+    expect(AgentToolApprovalModeSchema.safeParse('prompt').success).toBe(false)
+    expect(AgentPreferencesSchema.safeParse({ toolApprovalMode: 'always_accept' }).success).toBe(
+      true
+    )
+    expect(AgentPreferencesUpdateSchema.parse({})).toEqual({})
+
     expect(
       ApproveToolRequestSchema.safeParse({
         conversationId: 'conversation-1',

--- a/packages/contracts/src/ipc-agent.ts
+++ b/packages/contracts/src/ipc-agent.ts
@@ -23,6 +23,8 @@ export const AgentChannels = {
     LIST_BACKEND_MODELS: 'agent:listBackendModels',
     GET_LOCAL_PROVIDER_SETTINGS: 'agent:getLocalProviderSettings',
     SET_LOCAL_PROVIDER_SETTINGS: 'agent:setLocalProviderSettings',
+    GET_PREFERENCES: 'agent:getPreferences',
+    SET_PREFERENCES: 'agent:setPreferences',
     LIST_LOCAL_MODELS: 'agent:listLocalModels',
     TEST_LOCAL_PROVIDER: 'agent:testLocalProvider',
     PROBE_LOCAL_PROVIDER: 'agent:probeLocalProvider',
@@ -113,6 +115,23 @@ export const AgentBackendModelListSchema = z
   .strict()
 export type AgentBackendModelList = z.infer<typeof AgentBackendModelListSchema>
 
+export const AgentToolApprovalModeSchema = z.enum(['always_accept', 'ask'])
+export type AgentToolApprovalMode = z.infer<typeof AgentToolApprovalModeSchema>
+
+export const AgentPreferencesSchema = z
+  .object({
+    toolApprovalMode: AgentToolApprovalModeSchema.default('always_accept')
+  })
+  .strict()
+export type AgentPreferences = z.infer<typeof AgentPreferencesSchema>
+
+export const AgentPreferencesUpdateSchema = z
+  .object({
+    toolApprovalMode: AgentToolApprovalModeSchema.optional()
+  })
+  .strict()
+export type AgentPreferencesUpdate = z.infer<typeof AgentPreferencesUpdateSchema>
+
 export const AgentLocalProviderSettingsSchema = z
   .object({
     preset: AgentLocalProviderPresetSchema,
@@ -187,11 +206,29 @@ export type MessageStatus = z.infer<typeof MessageStatusSchema>
 
 export const UserContentSchema = z.object({ text: z.string() })
 export const AssistantContentSchema = z.object({ text: z.string() })
+export const ToolCallStatusSchema = z.enum([
+  'pending',
+  'approved',
+  'denied',
+  'completed',
+  'failed',
+  'input-streaming',
+  'approval-requested',
+  'approval-responded',
+  'input-available',
+  'output-available',
+  'output-error',
+  'output-denied'
+])
+export type ToolCallStatus = z.infer<typeof ToolCallStatusSchema>
+
 export const ToolCallContentSchema = z.object({
   tool: z.string(),
   args: z.record(z.string(), z.unknown()),
-  status: z.enum(['pending', 'approved', 'denied', 'completed', 'failed']),
-  approvedArgs: z.record(z.string(), z.unknown()).optional()
+  status: ToolCallStatusSchema,
+  approvedArgs: z.record(z.string(), z.unknown()).optional(),
+  output: z.unknown().optional(),
+  error: z.object({ code: z.string(), message: z.string() }).optional()
 })
 export const ToolResultContentSchema = z.object({
   ok: z.boolean(),

--- a/packages/contracts/src/sync-payloads.ts
+++ b/packages/contracts/src/sync-payloads.ts
@@ -211,8 +211,23 @@ const AgentMessageContentSchema = z.discriminatedUnion('role', [
     data: z.object({
       tool: z.string(),
       args: z.record(z.string(), z.unknown()),
-      status: z.enum(['pending', 'approved', 'denied', 'completed', 'failed']),
-      approvedArgs: z.record(z.string(), z.unknown()).optional()
+      status: z.enum([
+        'pending',
+        'approved',
+        'denied',
+        'completed',
+        'failed',
+        'input-streaming',
+        'approval-requested',
+        'approval-responded',
+        'input-available',
+        'output-available',
+        'output-error',
+        'output-denied'
+      ]),
+      approvedArgs: z.record(z.string(), z.unknown()).optional(),
+      output: z.unknown().optional(),
+      error: z.object({ code: z.string(), message: z.string() }).optional()
     })
   }),
   z.object({

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -1197,6 +1197,12 @@
       "local": "Local OpenAI-compatible provider",
       "actions": "Connection checks"
     },
+    "approval": {
+      "label": "Tool confirmations",
+      "description": "Choose whether write tools run automatically or wait for approval in chat.",
+      "alwaysAccept": "Always accept",
+      "ask": "Ask first"
+    },
     "presets": {
       "ollama": "Ollama",
       "lmStudio": "LM Studio",


### PR DESCRIPTION
## Summary

- Add an Agent Chat tool confirmation preference with `Always accept` as the default and `Ask first` as the manual approval mode.
- Keep tool-call details visible in chat as collapsed tool rows across running, completed, error, denied, and approval states.
- Wire the preference through contracts, IPC, preload, settings UI, runtime gating, sync payloads, and docs.

## Validation

- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts src/main/agent/runtime/__tests__/permission-gate.test.ts src/main/agent/runtime/__tests__/runtime-approval.test.ts src/main/agent/settings.test.ts src/main/ipc/agent-handlers.test.ts src/preload/api/preload-api.test.ts src/renderer/src/agent-chat/__tests__/agent-context.test.tsx src/renderer/src/agent-chat/__tests__/message-stream.test.tsx src/renderer/src/pages/settings/settings-sections.test.tsx ../../packages/contracts/src/ipc-agent.test.ts`
- `pnpm typecheck:desktop`
- `pnpm --filter @memry/contracts typecheck`
- `pnpm ipc:check`
- `pnpm i18n:check`
- `pnpm docs:impact --base f2e73d93a899043aa859b4c90a07c14bab19dc99 --strict`
- `pnpm docs:build`
- `pnpm lint:desktop`