### PR TITLE
Remove task and inbox toolbar border

### DIFF
--- a/apps/desktop/src/renderer/src/pages/inbox.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox.tsx
@@ -201,7 +201,7 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
         <TriageView onExit={exitTriage} />
       ) : (
         <div className="flex h-full flex-col">
-          <PageToolbar className="px-2 py-1 min-h-[38px]">
+          <PageToolbar className="px-2 py-1 min-h-[38px] border-b-0">
             <InboxSegmentControl value={currentView} onChange={handleViewChange} />
 
             {currentView === 'inbox' && (
@@ -231,10 +231,10 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
             {currentView === 'archived' && (
               <div
                 className={cn(
-                  'ml-auto flex items-center rounded-[5px] py-1 border overflow-hidden outline-none',
+                  'ms-auto flex items-center rounded-[5px] py-1 border overflow-hidden outline-none',
                   'transition-[width] duration-150 ease-out',
                   isArchivedSearchOpen
-                    ? 'w-52 border-transparent pl-2 pr-1.5 gap-1'
+                    ? 'w-52 border-transparent ps-2 pe-1.5 gap-1'
                     : 'w-[30px] border-border text-text-secondary hover:bg-surface-active/50 justify-center cursor-pointer'
                 )}
                 onClick={() => {
@@ -418,7 +418,7 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
                 selectedTypes={selectedTypes}
                 showSnoozedItems={showSnoozedItems}
                 focusItemId={focusInboxItemId}
-                focusToken={focusToken}
+                {...{ focusToken }}
               />
             )}
             {currentView === 'archived' && (

--- a/apps/desktop/src/renderer/src/pages/tasks.tsx
+++ b/apps/desktop/src/renderer/src/pages/tasks.tsx
@@ -892,7 +892,7 @@ export const TasksPage = ({
         {/* Main Content Area */}
         <main className="flex-1 min-w-0 flex flex-col overflow-hidden">
           {/* Page Header — compact single-row toolbar */}
-          <PageToolbar className="px-2 py-1 min-h-[38px]">
+          <PageToolbar className="px-2 py-1 min-h-[38px] border-b-0">
             <TasksTabBar
               activeTab={activeInternalTab}
               onTabChange={handleTabChange}

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -119,6 +119,8 @@ toast.error(extractErrorMessage(err, 'Could not save note'))
 
 New code must use logical properties (`ms-*`, `pe-*`, `start-*`, `text-start`, `border-s`, `rounded-s-*`) instead of physical ones (`ml-*`, `pr-*`, `left-*`, `text-left`, `border-l`, `rounded-l-*`). The lint config allows physical classes only in pre-existing files.
 
+The staged renderer guard scans whole staged renderer files, not just new hunks. If you touch a file that still has physical direction classes, convert those nearby classes to logical equivalents before committing.
+
 ## Pre-Production Database
 
 Memry is pre-production and the DB schema is **resettable**. There are no backward-compat constraints on schema changes within the desktop app. If a migration is messy, deleting the local vault is a valid recovery.


### PR DESCRIPTION
## Summary
- Remove the bottom divider from the Tasks and Inbox top toolbars so they sit flush with the page content.
- Convert touched Inbox toolbar direction classes to logical Tailwind classes for the staged renderer guard.
- Document the staged renderer guard behavior in contributor gotchas.

## Validation
- Prettier check for touched files
- ESLint for touched desktop page files
- `git diff --check`
- `node scripts/check-staged-secrets.mjs`
- `node scripts/check-staged-renderer-guards.mjs`
- `pnpm docs:impact --base origin/main --strict`
- VitePress docs build via installed workspace binary