### PR TITLE
Open Agent Chat conversations in tabs

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -67,6 +67,7 @@ import { getFilteredTasks } from '@/lib/task-utils'
 import { useAgentMcpCurrentNoteResponder } from '@/agent-mcp/current-note-handler'
 import { useAgentMcpDesktopApiResponder } from '@/agent-mcp/desktop-api-handler'
 import { AgentProvider } from '@/agent-chat/agent-context'
+import { AgentTabTitleSync } from '@/agent-chat/agent-tab-title-sync'
 
 const log = createLogger('App')
 const startupTheme = getStartupTheme()
@@ -282,6 +283,7 @@ const AppContent = (): React.JSX.Element => {
 
   return (
     <TabDragProvider>
+      <AgentTabTitleSync />
       <div className="flex flex-1 overflow-hidden bg-background" id="main-content">
         <SplitViewContainer />
       </div>

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx
@@ -123,6 +123,64 @@ describe('agentReducer', () => {
     expect(next.messagesByConversation[conversation.id]).toEqual([assistant])
   })
 
+  it('stores loaded messages without activating the conversation', () => {
+    const existingConversation: Conversation = {
+      ...conversation,
+      id: 'conversation-existing',
+      title: 'Existing chat'
+    }
+    const loadedConversation: Conversation = {
+      ...conversation,
+      id: 'conversation-loaded',
+      title: 'Loaded chat'
+    }
+    const assistant = message({
+      id: 'message-1',
+      conversationId: loadedConversation.id,
+      role: 'assistant',
+      text: 'Loaded',
+      status: 'completed'
+    })
+    const state: AgentState = {
+      ...initialAgentState,
+      activeConversationId: existingConversation.id,
+      conversations: { [existingConversation.id]: existingConversation },
+      messagesByConversation: { [existingConversation.id]: [] }
+    }
+
+    const next = agentReducer(state, {
+      type: 'set_conversation_messages',
+      conversation: loadedConversation,
+      messages: [assistant]
+    })
+
+    expect(next.activeConversationId).toBe(existingConversation.id)
+    expect(next.conversations[loadedConversation.id]).toEqual(loadedConversation)
+    expect(next.messagesByConversation[loadedConversation.id]).toEqual([assistant])
+  })
+
+  it('clears the active conversation without dropping cached conversations or messages', () => {
+    const assistant = message({
+      id: 'message-1',
+      conversationId: conversation.id,
+      role: 'assistant',
+      text: 'Cached',
+      status: 'completed'
+    })
+    const state: AgentState = {
+      ...initialAgentState,
+      activeConversationId: conversation.id,
+      conversations: { [conversation.id]: conversation },
+      messagesByConversation: { [conversation.id]: [assistant] }
+    }
+
+    const next = agentReducer(state, { type: 'clear_active_conversation' })
+
+    expect(next.activeConversationId).toBeNull()
+    expect(next.conversations[conversation.id]).toEqual(conversation)
+    expect(next.messagesByConversation[conversation.id]).toEqual([assistant])
+  })
+
   it('appends assistant text deltas to an existing streaming message', () => {
     const state: AgentState = {
       ...initialAgentState,

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-conversation-tab.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-conversation-tab.test.tsx
@@ -9,15 +9,23 @@ vi.mock('../agent-context', () => ({
 }))
 
 vi.mock('../conversation-view', () => ({
-  ConversationView: ({ conversationId }: { conversationId: string | null }) => (
-    <div data-testid="conversation-view">{conversationId}</div>
+  ConversationView: ({
+    conversationId,
+    layout
+  }: {
+    conversationId: string | null
+    layout?: string
+  }) => (
+    <div data-testid="conversation-view" data-layout={layout}>
+      {conversationId}
+    </div>
   )
 }))
 
 import { AgentConversationTab } from '../agent-conversation-tab'
 
 describe('AgentConversationTab', () => {
-  it('centers popped-out conversations using the note editor reading column', () => {
+  it('uses the workspace conversation layout for popped-out conversations', () => {
     mockUseAgentOptional.mockReturnValue({
       state: {
         conversations: {
@@ -30,14 +38,10 @@ describe('AgentConversationTab', () => {
       loadConversation: mockLoadConversation
     })
 
-    const { container } = render(<AgentConversationTab conversationId="conversation-1" />)
+    render(<AgentConversationTab conversationId="conversation-1" />)
 
-    const shell = container.firstElementChild
-    expect(shell).toHaveClass('mx-auto', 'max-w-[64rem]', 'px-8', 'lg:px-24')
-
-    const column = shell?.firstElementChild
-    expect(column).toHaveClass('mx-auto', 'max-w-[640px]')
     expect(screen.getByTestId('conversation-view')).toHaveTextContent('conversation-1')
+    expect(screen.getByTestId('conversation-view')).toHaveAttribute('data-layout', 'workspace')
     expect(mockLoadConversation).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-conversation-tab.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-conversation-tab.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const mockUseAgentOptional = vi.hoisted(() => vi.fn())
+const mockLoadConversation = vi.hoisted(() => vi.fn())
+
+vi.mock('../agent-context', () => ({
+  useAgentOptional: mockUseAgentOptional
+}))
+
+vi.mock('../conversation-view', () => ({
+  ConversationView: ({ conversationId }: { conversationId: string | null }) => (
+    <div data-testid="conversation-view">{conversationId}</div>
+  )
+}))
+
+import { AgentConversationTab } from '../agent-conversation-tab'
+
+describe('AgentConversationTab', () => {
+  it('centers popped-out conversations using the note editor reading column', () => {
+    mockUseAgentOptional.mockReturnValue({
+      state: {
+        conversations: {
+          'conversation-1': { id: 'conversation-1' }
+        },
+        messagesByConversation: {
+          'conversation-1': []
+        }
+      },
+      loadConversation: mockLoadConversation
+    })
+
+    const { container } = render(<AgentConversationTab conversationId="conversation-1" />)
+
+    const shell = container.firstElementChild
+    expect(shell).toHaveClass('mx-auto', 'max-w-[64rem]', 'px-8', 'lg:px-24')
+
+    const column = shell?.firstElementChild
+    expect(column).toHaveClass('mx-auto', 'max-w-[640px]')
+    expect(screen.getByTestId('conversation-view')).toHaveTextContent('conversation-1')
+    expect(mockLoadConversation).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
@@ -163,6 +163,21 @@ describe('AgentProvider', () => {
     await waitFor(() =>
       expect(result.current.state.messagesByConversation[conversation.id]).toEqual([message])
     )
+    expect(result.current.state.activeConversationId).toBe(conversation.id)
+
+    await act(async () => {
+      await result.current.loadConversation(conversation.id, { activate: false })
+    })
+    await waitFor(() =>
+      expect(result.current.state.messagesByConversation[conversation.id]).toEqual([message])
+    )
+    expect(result.current.state.activeConversationId).toBe(conversation.id)
+
+    await act(async () => {
+      result.current.clearActiveConversation()
+    })
+    expect(result.current.state.activeConversationId).toBeNull()
+    expect(result.current.state.messagesByConversation[conversation.id]).toEqual([message])
 
     await act(async () => {
       await result.current.sendTurn({

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-tab-title-sync.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-tab-title-sync.test.tsx
@@ -1,0 +1,89 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const mockUseAgentOptional = vi.hoisted(() => vi.fn())
+const mockUpdateTabTitle = vi.hoisted(() => vi.fn())
+
+vi.mock('../agent-context', () => ({
+  useAgentOptional: mockUseAgentOptional
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabs: () => ({
+    state: {
+      tabGroups: {
+        main: {
+          id: 'main',
+          activeTabId: 'agent-tab',
+          isActive: true,
+          back: [],
+          forward: [],
+          tabs: [
+            {
+              id: 'agent-tab',
+              type: 'agent-chat',
+              title: 'New conversation',
+              icon: 'bot',
+              path: '/agent-chat/conversation-1',
+              entityId: 'conversation-1',
+              isPinned: false,
+              isModified: false,
+              isPreview: false,
+              isDeleted: false,
+              openedAt: 1,
+              lastAccessedAt: 1
+            },
+            {
+              id: 'note-tab',
+              type: 'note',
+              title: 'New conversation',
+              icon: 'file-text',
+              path: '/note/conversation-1',
+              entityId: 'conversation-1',
+              isPinned: false,
+              isModified: false,
+              isPreview: false,
+              isDeleted: false,
+              openedAt: 1,
+              lastAccessedAt: 1
+            }
+          ]
+        }
+      }
+    },
+    updateTabTitle: mockUpdateTabTitle
+  })
+}))
+
+import { AgentTabTitleSync } from '../agent-tab-title-sync'
+
+describe('AgentTabTitleSync', () => {
+  it('keeps agent chat tab titles aligned to generated conversation titles', () => {
+    mockUseAgentOptional.mockReturnValue({
+      state: {
+        conversations: {
+          'conversation-1': {
+            id: 'conversation-1',
+            vaultId: 'vault-1',
+            title: 'Project roadmap',
+            backend: 'claude_cli',
+            backendModel: null,
+            trustList: [],
+            pinned: false,
+            vectorClock: {},
+            fieldClocks: {},
+            createdAt: 100,
+            updatedAt: 200,
+            deletedAt: null,
+            lastSyncedAt: null
+          }
+        }
+      }
+    })
+
+    render(<AgentTabTitleSync />)
+
+    expect(mockUpdateTabTitle).toHaveBeenCalledTimes(1)
+    expect(mockUpdateTabTitle).toHaveBeenCalledWith('agent-tab', 'Project roadmap', 'main')
+  })
+})

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/conversation-view.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/conversation-view.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 const mockUseAgentOptional = vi.hoisted(() => vi.fn())
@@ -7,167 +7,51 @@ vi.mock('../agent-context', () => ({
   useAgentOptional: mockUseAgentOptional
 }))
 
-vi.mock('@/contexts/tabs', () => ({
-  useActiveTab: () => null
+vi.mock('../composer', () => ({
+  Composer: () => <div data-testid="composer" />
+}))
+
+vi.mock('../conversation-header', () => ({
+  ConversationHeader: () => <div data-testid="conversation-header" />
 }))
 
 import { ConversationView } from '../conversation-view'
 
 describe('ConversationView', () => {
-  const backendStatuses = {
-    claude_cli: { backend: 'claude_cli', available: true },
-    codex_cli: { backend: 'codex_cli', available: true },
-    local_openai_compatible: { backend: 'local_openai_compatible', available: true }
-  }
-
-  it('renders the active conversation header and stored messages', () => {
-    const cancelTurn = vi.fn()
+  it('keeps the workspace scrollbar full-width while centering chat content', () => {
     mockUseAgentOptional.mockReturnValue({
       state: {
-        backendStatuses,
-        disclosureAccepted: true,
-        activeConversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
         conversations: {
           'conversation-1': {
             id: 'conversation-1',
-            vaultId: 'vault-1',
-            title: 'Planning',
-            backend: 'claude_cli',
-            backendModel: null,
-            trustList: [],
-            pinned: false,
-            vectorClock: {},
-            fieldClocks: {},
-            createdAt: 100,
-            updatedAt: 100,
-            deletedAt: null,
-            lastSyncedAt: null
+            title: 'Planning'
           }
         },
         messagesByConversation: {
-          'conversation-1': [
-            {
-              id: 'message-1',
-              conversationId: 'conversation-1',
-              role: 'assistant',
-              content: { role: 'assistant', data: { text: 'Hello from agent' } },
-              toolCallId: null,
-              attachments: [],
-              status: 'completed',
-              vectorClock: {},
-              createdAt: 100,
-              updatedAt: 100,
-              deletedAt: null
-            }
-          ]
+          'conversation-1': []
         },
-        pendingApprovals: [],
-        inFlight: {},
-        error: null
+        inFlight: {}
       },
-      createConversation: vi.fn(),
-      loadConversation: vi.fn(),
-      cancelTurn
-    })
-
-    render(<ConversationView conversationId="conversation-1" />)
-
-    const shell = screen.getByLabelText('Agent chat')
-
-    expect(shell).toHaveClass('bg-background')
-    expect(shell).not.toHaveClass('bg-sidebar')
-    expect(screen.getByText('Planning')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Conversation history' })).not.toBeInTheDocument()
-    expect(screen.getByText('Hello from agent')).toBeInTheDocument()
-  })
-
-  it('keeps the empty conversation view passive before the first prompt is sent', () => {
-    const loadConversation = vi.fn()
-    mockUseAgentOptional.mockReturnValue({
-      state: {
-        backendStatuses,
-        disclosureAccepted: true,
-        sourceWindowId: '42',
-        activeConversationId: null,
-        conversations: {
-          'conversation-1': {
-            id: 'conversation-1',
-            vaultId: 'vault-1',
-            title: 'Planning',
-            backend: 'claude_cli',
-            backendModel: null,
-            trustList: [],
-            pinned: false,
-            vectorClock: {},
-            fieldClocks: {},
-            createdAt: 100,
-            updatedAt: 100,
-            deletedAt: null,
-            lastSyncedAt: null
-          }
-        },
-        messagesByConversation: {},
-        pendingApprovals: [],
-        inFlight: {},
-        error: null
-      },
-      createConversation: vi.fn(),
-      loadConversation,
       cancelTurn: vi.fn()
     })
 
-    render(<ConversationView conversationId={null} />)
+    render(<ConversationView conversationId="conversation-1" layout="workspace" />)
 
-    expect(screen.queryByText('New conversation')).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Conversation history' })).not.toBeInTheDocument()
-    expect(loadConversation).not.toHaveBeenCalled()
-  })
+    const scrollRegion = screen.getByRole('log')
+    expect(scrollRegion).toHaveClass('overflow-y-auto')
+    expect(scrollRegion).not.toHaveClass('max-w-[640px]')
 
-  it('cancels an in-flight turn from Stop and Escape', () => {
-    const cancelTurn = vi.fn()
-    mockUseAgentOptional.mockReturnValue({
-      state: {
-        backendStatuses,
-        disclosureAccepted: true,
-        sourceWindowId: '42',
-        activeConversationId: 'conversation-1',
-        conversations: {
-          'conversation-1': {
-            id: 'conversation-1',
-            vaultId: 'vault-1',
-            title: 'Planning',
-            backend: 'claude_cli',
-            backendModel: null,
-            trustList: [],
-            pinned: false,
-            vectorClock: {},
-            fieldClocks: {},
-            createdAt: 100,
-            updatedAt: 100,
-            deletedAt: null,
-            lastSyncedAt: null
-          }
-        },
-        messagesByConversation: { 'conversation-1': [] },
-        pendingApprovals: [],
-        inFlight: { 'conversation-1': true },
-        error: null
-      },
-      createConversation: vi.fn(),
-      loadConversation: vi.fn(),
-      cancelTurn
-    })
+    const messageShell = scrollRegion.firstElementChild
+    expect(messageShell).toHaveClass('max-w-[64rem]', 'px-8', 'lg:px-24')
+    expect(messageShell?.firstElementChild).toHaveClass('max-w-[640px]')
 
-    render(<ConversationView conversationId="conversation-1" />)
+    const header = screen.getByTestId('conversation-header')
+    expect(header.parentElement).toHaveClass('max-w-[640px]')
+    expect(header.parentElement?.parentElement).toHaveClass('max-w-[64rem]', 'px-8', 'lg:px-24')
 
-    const stopButton = screen.getByRole('button', { name: 'Stop' })
-    expect(stopButton).toHaveAttribute('type', 'button')
-    expect(screen.queryByRole('button', { name: 'Send' })).not.toBeInTheDocument()
-
-    fireEvent.click(stopButton)
-    fireEvent.keyDown(screen.getByLabelText('Agent chat'), { key: 'Escape' })
-
-    expect(cancelTurn).toHaveBeenCalledTimes(2)
-    expect(cancelTurn).toHaveBeenCalledWith('conversation-1')
+    const composer = screen.getByTestId('composer')
+    expect(composer.parentElement).toHaveClass('max-w-[640px]')
+    expect(composer.parentElement?.parentElement).toHaveClass('max-w-[64rem]', 'pb-10')
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/conversation-view.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/conversation-view.test.tsx
@@ -44,7 +44,7 @@ describe('ConversationView', () => {
 
     const messageShell = scrollRegion.firstElementChild
     expect(messageShell).toHaveClass('max-w-[64rem]', 'px-8', 'lg:px-24')
-    expect(messageShell?.firstElementChild).toHaveClass('max-w-[640px]')
+    expect(messageShell?.firstElementChild).toHaveClass('max-w-[640px]', 'px-2')
 
     expect(screen.queryByTestId('conversation-header')).not.toBeInTheDocument()
 
@@ -53,7 +53,7 @@ describe('ConversationView', () => {
     expect(composer.parentElement?.parentElement).toHaveClass('max-w-[64rem]', 'pb-10')
   })
 
-  it('keeps the conversation title in the right sidebar layout', () => {
+  it('keeps the conversation title and aligns messages with the composer in the right sidebar layout', () => {
     mockUseAgentOptional.mockReturnValue({
       state: {
         sourceWindowId: 'window-1',
@@ -74,5 +74,8 @@ describe('ConversationView', () => {
     render(<ConversationView conversationId="conversation-1" />)
 
     expect(screen.getByTestId('conversation-header')).toBeInTheDocument()
+
+    const scrollRegion = screen.getByRole('log')
+    expect(scrollRegion.firstElementChild).toHaveClass('px-2')
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/conversation-view.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/conversation-view.test.tsx
@@ -46,12 +46,33 @@ describe('ConversationView', () => {
     expect(messageShell).toHaveClass('max-w-[64rem]', 'px-8', 'lg:px-24')
     expect(messageShell?.firstElementChild).toHaveClass('max-w-[640px]')
 
-    const header = screen.getByTestId('conversation-header')
-    expect(header.parentElement).toHaveClass('max-w-[640px]')
-    expect(header.parentElement?.parentElement).toHaveClass('max-w-[64rem]', 'px-8', 'lg:px-24')
+    expect(screen.queryByTestId('conversation-header')).not.toBeInTheDocument()
 
     const composer = screen.getByTestId('composer')
     expect(composer.parentElement).toHaveClass('max-w-[640px]')
     expect(composer.parentElement?.parentElement).toHaveClass('max-w-[64rem]', 'pb-10')
+  })
+
+  it('keeps the conversation title in the right sidebar layout', () => {
+    mockUseAgentOptional.mockReturnValue({
+      state: {
+        sourceWindowId: 'window-1',
+        conversations: {
+          'conversation-1': {
+            id: 'conversation-1',
+            title: 'Planning'
+          }
+        },
+        messagesByConversation: {
+          'conversation-1': []
+        },
+        inFlight: {}
+      },
+      cancelTurn: vi.fn()
+    })
+
+    render(<ConversationView conversationId="conversation-1" />)
+
+    expect(screen.getByTestId('conversation-header')).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
@@ -3,9 +3,19 @@ import { fireEvent, render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockUseAgentOptional = vi.hoisted(() => vi.fn())
+const mockOpenTab = vi.hoisted(() => vi.fn())
+const mockCloseDayPanel = vi.hoisted(() => vi.fn())
 
 vi.mock('../agent-context', () => ({
   useAgentOptional: mockUseAgentOptional
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabs: () => ({ openTab: mockOpenTab })
+}))
+
+vi.mock('@/contexts/day-panel-context', () => ({
+  useDayPanel: () => ({ close: mockCloseDayPanel })
 }))
 
 import { SidebarTabs } from '../sidebar-tabs'
@@ -26,6 +36,7 @@ function renderTabs(
 function mockAgentWithConversations() {
   const loadConversation = vi.fn()
   const createConversation = vi.fn()
+  const clearActiveConversation = vi.fn()
 
   mockUseAgentOptional.mockReturnValue({
     state: {
@@ -68,16 +79,19 @@ function mockAgentWithConversations() {
       inFlight: {}
     },
     createConversation,
-    loadConversation
+    loadConversation,
+    clearActiveConversation
   })
 
-  return { createConversation, loadConversation }
+  return { createConversation, loadConversation, clearActiveConversation }
 }
 
 describe('SidebarTabs', () => {
   beforeEach(() => {
     localStorage.clear()
     mockUseAgentOptional.mockReturnValue(null)
+    mockOpenTab.mockReset()
+    mockCloseDayPanel.mockReset()
   })
 
   it('switches tabs and persists the active tab', async () => {
@@ -193,5 +207,49 @@ describe('SidebarTabs', () => {
     fireEvent.click(historyItem)
 
     expect(loadConversation).toHaveBeenCalledWith('conversation-2')
+  })
+
+  it('opens the active conversation in a workspace tab and resets the sidebar chat', () => {
+    const { clearActiveConversation } = mockAgentWithConversations()
+
+    renderTabs({ defaultTab: 'agent' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open conversation in tab' }))
+
+    expect(mockOpenTab).toHaveBeenCalledWith({
+      type: 'agent-chat',
+      title: 'Planning',
+      icon: 'bot',
+      path: '/agent-chat/conversation-1',
+      entityId: 'conversation-1',
+      isPinned: false,
+      isModified: false,
+      isPreview: false,
+      isDeleted: false
+    })
+    expect(mockCloseDayPanel).toHaveBeenCalledTimes(1)
+    expect(clearActiveConversation).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show the pop-out action before a conversation exists', () => {
+    mockUseAgentOptional.mockReturnValue({
+      state: {
+        disclosureAccepted: true,
+        activeConversationId: null,
+        conversations: {},
+        pendingApprovals: [],
+        messagesByConversation: {},
+        inFlight: {}
+      },
+      createConversation: vi.fn(),
+      loadConversation: vi.fn(),
+      clearActiveConversation: vi.fn()
+    })
+
+    renderTabs({ defaultTab: 'agent' })
+
+    expect(
+      screen.queryByRole('button', { name: 'Open conversation in tab' })
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
@@ -30,6 +30,12 @@ export type AgentAction =
       conversation: Conversation | null
       messages: Message[]
     }
+  | {
+      type: 'set_conversation_messages'
+      conversation: Conversation | null
+      messages: Message[]
+    }
+  | { type: 'clear_active_conversation' }
   | { type: 'set_in_flight'; conversationId: string; inFlight: boolean }
   | { type: 'set_error'; error: string | null }
   | { type: 'event'; event: AgentEvent }
@@ -189,6 +195,24 @@ export function agentReducer(state: AgentState, action: AgentAction): AgentState
           ...state.messagesByConversation,
           [action.conversation.id]: action.messages
         }
+      }
+    case 'set_conversation_messages':
+      if (!action.conversation) return state
+      return {
+        ...state,
+        conversations: {
+          ...state.conversations,
+          [action.conversation.id]: action.conversation
+        },
+        messagesByConversation: {
+          ...state.messagesByConversation,
+          [action.conversation.id]: action.messages
+        }
+      }
+    case 'clear_active_conversation':
+      return {
+        ...state,
+        activeConversationId: null
       }
     case 'set_in_flight':
       return {

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
@@ -61,7 +61,8 @@ interface AgentContextValue {
     backend?: AgentBackendId
     backendModel?: string | null
   }) => Promise<Conversation>
-  loadConversation: (id: string) => Promise<void>
+  loadConversation: (id: string, options?: { activate?: boolean }) => Promise<void>
+  clearActiveConversation: () => void
   sendTurn: (input: {
     conversationId: string
     sourceWindowId: string
@@ -126,10 +127,15 @@ export function AgentProvider({ children }: { children: ReactNode }): React.JSX.
   }, [t])
 
   const loadConversation = useCallback(
-    async (id: string) => {
+    async (id: string, options?: { activate?: boolean }) => {
       try {
         const { conversation, messages } = await getAgentApi().loadConversation({ id })
-        dispatch({ type: 'set_active_conversation', conversation, messages })
+        dispatch({
+          type:
+            options?.activate === false ? 'set_conversation_messages' : 'set_active_conversation',
+          conversation,
+          messages
+        })
       } catch (error) {
         dispatch({
           type: 'set_error',
@@ -139,6 +145,10 @@ export function AgentProvider({ children }: { children: ReactNode }): React.JSX.
     },
     [t]
   )
+
+  const clearActiveConversation = useCallback(() => {
+    dispatch({ type: 'clear_active_conversation' })
+  }, [])
 
   const createConversation = useCallback(
     async (input?: { backend?: AgentBackendId; backendModel?: string | null }) => {
@@ -323,6 +333,7 @@ export function AgentProvider({ children }: { children: ReactNode }): React.JSX.
       refreshConversations,
       createConversation,
       loadConversation,
+      clearActiveConversation,
       sendTurn,
       cancelTurn,
       approveTool,
@@ -334,6 +345,7 @@ export function AgentProvider({ children }: { children: ReactNode }): React.JSX.
       refreshConversations,
       createConversation,
       loadConversation,
+      clearActiveConversation,
       sendTurn,
       cancelTurn,
       approveTool,

--- a/apps/desktop/src/renderer/src/agent-chat/agent-conversation-tab.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-conversation-tab.tsx
@@ -23,5 +23,11 @@ export function AgentConversationTab({
     void agent.loadConversation(conversationId, { activate: false })
   }, [agent, conversationId, hasConversation, hasMessages])
 
-  return <ConversationView conversationId={conversationId ?? null} />
+  return (
+    <div className="mx-auto flex h-full min-h-0 w-full max-w-[64rem] flex-col bg-background px-8 pb-10 pt-6 transition-[max-width] duration-300 ease-in-out lg:px-24">
+      <div className="mx-auto flex h-full min-h-0 w-full max-w-[640px] flex-col">
+        <ConversationView conversationId={conversationId ?? null} />
+      </div>
+    </div>
+  )
 }

--- a/apps/desktop/src/renderer/src/agent-chat/agent-conversation-tab.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-conversation-tab.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+
+import { ConversationView } from './conversation-view'
+import { useAgentOptional } from './agent-context'
+
+interface AgentConversationTabProps {
+  conversationId?: string
+}
+
+export function AgentConversationTab({
+  conversationId
+}: AgentConversationTabProps): React.JSX.Element {
+  const agent = useAgentOptional()
+  const hasConversation = conversationId
+    ? Boolean(agent?.state.conversations[conversationId])
+    : false
+  const hasMessages = conversationId
+    ? agent?.state.messagesByConversation[conversationId] !== undefined
+    : false
+
+  useEffect(() => {
+    if (!agent || !conversationId || (hasConversation && hasMessages)) return
+    void agent.loadConversation(conversationId, { activate: false })
+  }, [agent, conversationId, hasConversation, hasMessages])
+
+  return <ConversationView conversationId={conversationId ?? null} />
+}

--- a/apps/desktop/src/renderer/src/agent-chat/agent-conversation-tab.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-conversation-tab.tsx
@@ -23,11 +23,5 @@ export function AgentConversationTab({
     void agent.loadConversation(conversationId, { activate: false })
   }, [agent, conversationId, hasConversation, hasMessages])
 
-  return (
-    <div className="mx-auto flex h-full min-h-0 w-full max-w-[64rem] flex-col bg-background px-8 pb-10 pt-6 transition-[max-width] duration-300 ease-in-out lg:px-24">
-      <div className="mx-auto flex h-full min-h-0 w-full max-w-[640px] flex-col">
-        <ConversationView conversationId={conversationId ?? null} />
-      </div>
-    </div>
-  )
+  return <ConversationView conversationId={conversationId ?? null} layout="workspace" />
 }

--- a/apps/desktop/src/renderer/src/agent-chat/agent-tab-title-sync.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-tab-title-sync.tsx
@@ -6,10 +6,11 @@ import { useAgentOptional } from './agent-context'
 export function AgentTabTitleSync(): null {
   const agent = useAgentOptional()
   const { state, updateTabTitle } = useTabs()
+  const tabGroups = state?.tabGroups
 
   useEffect(() => {
-    if (!agent) return
-    for (const [groupId, group] of Object.entries(state.tabGroups)) {
+    if (!agent || !tabGroups) return
+    for (const [groupId, group] of Object.entries(tabGroups)) {
       for (const tab of group.tabs) {
         if (tab.type !== 'agent-chat' || !tab.entityId) continue
         const conversation = agent.state.conversations[tab.entityId]
@@ -17,7 +18,7 @@ export function AgentTabTitleSync(): null {
         updateTabTitle(tab.id, conversation.title, groupId)
       }
     }
-  }, [agent, state.tabGroups, updateTabTitle])
+  }, [agent, tabGroups, updateTabTitle])
 
   return null
 }

--- a/apps/desktop/src/renderer/src/agent-chat/agent-tab-title-sync.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-tab-title-sync.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+import { useTabs } from '@/contexts/tabs'
+import { useAgentOptional } from './agent-context'
+
+export function AgentTabTitleSync(): null {
+  const agent = useAgentOptional()
+  const { state, updateTabTitle } = useTabs()
+
+  useEffect(() => {
+    if (!agent) return
+    for (const [groupId, group] of Object.entries(state.tabGroups)) {
+      for (const tab of group.tabs) {
+        if (tab.type !== 'agent-chat' || !tab.entityId) continue
+        const conversation = agent.state.conversations[tab.entityId]
+        if (!conversation || conversation.title === tab.title) continue
+        updateTabTitle(tab.id, conversation.title, groupId)
+      }
+    }
+  }, [agent, state.tabGroups, updateTabTitle])
+
+  return null
+}

--- a/apps/desktop/src/renderer/src/agent-chat/conversation-view.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/conversation-view.tsx
@@ -14,6 +14,7 @@ interface ConversationViewProps {
 const workspaceOuterClassName =
   'mx-auto w-full max-w-[64rem] px-8 transition-[max-width] duration-300 ease-in-out lg:px-24'
 const workspaceColumnClassName = 'mx-auto w-full max-w-[640px]'
+const workspaceMessageListClassName = cn(workspaceColumnClassName, 'px-2')
 
 export function ConversationView({
   conversationId,
@@ -66,7 +67,7 @@ export function ConversationView({
       <MessageStream
         messages={messages}
         contentClassName={isWorkspace ? cn(workspaceOuterClassName, 'pb-3 pt-6') : undefined}
-        messageListClassName={isWorkspace ? workspaceColumnClassName : undefined}
+        messageListClassName={isWorkspace ? workspaceMessageListClassName : undefined}
       />
       {isWorkspace ? (
         <div className={cn(workspaceOuterClassName, 'shrink-0 pb-10')}>

--- a/apps/desktop/src/renderer/src/agent-chat/conversation-view.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/conversation-view.tsx
@@ -4,14 +4,24 @@ import { Composer } from './composer'
 import { ConversationHeader } from './conversation-header'
 import { useAgentOptional } from './agent-context'
 import { MessageStream } from './message-stream'
+import { cn } from '@/lib/utils'
 
 interface ConversationViewProps {
   conversationId: string | null
+  layout?: 'sidebar' | 'workspace'
 }
 
-export function ConversationView({ conversationId }: ConversationViewProps): React.JSX.Element {
+const workspaceOuterClassName =
+  'mx-auto w-full max-w-[64rem] px-8 transition-[max-width] duration-300 ease-in-out lg:px-24'
+const workspaceColumnClassName = 'mx-auto w-full max-w-[640px]'
+
+export function ConversationView({
+  conversationId,
+  layout = 'sidebar'
+}: ConversationViewProps): React.JSX.Element {
   const { t } = useT('common')
   const agent = useAgentOptional()
+  const isWorkspace = layout === 'workspace'
 
   if (!agent) {
     return (
@@ -52,9 +62,32 @@ export function ConversationView({ conversationId }: ConversationViewProps): Rea
         cancelTurn()
       }}
     >
-      {conversation && <ConversationHeader conversation={conversation} />}
-      <MessageStream messages={messages} />
-      <Composer conversationId={conversationId} sourceWindowId={state.sourceWindowId} />
+      {conversation &&
+        (isWorkspace ? (
+          <div className={cn(workspaceOuterClassName, 'shrink-0 pt-6')}>
+            <div className={workspaceColumnClassName}>
+              <ConversationHeader conversation={conversation} />
+            </div>
+          </div>
+        ) : (
+          <ConversationHeader conversation={conversation} />
+        ))}
+      <MessageStream
+        messages={messages}
+        contentClassName={
+          isWorkspace ? cn(workspaceOuterClassName, conversation ? 'py-3' : 'pb-3 pt-6') : undefined
+        }
+        messageListClassName={isWorkspace ? workspaceColumnClassName : undefined}
+      />
+      {isWorkspace ? (
+        <div className={cn(workspaceOuterClassName, 'shrink-0 pb-10')}>
+          <div className={workspaceColumnClassName}>
+            <Composer conversationId={conversationId} sourceWindowId={state.sourceWindowId} />
+          </div>
+        </div>
+      ) : (
+        <Composer conversationId={conversationId} sourceWindowId={state.sourceWindowId} />
+      )}
     </section>
   )
 }

--- a/apps/desktop/src/renderer/src/agent-chat/conversation-view.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/conversation-view.tsx
@@ -62,21 +62,10 @@ export function ConversationView({
         cancelTurn()
       }}
     >
-      {conversation &&
-        (isWorkspace ? (
-          <div className={cn(workspaceOuterClassName, 'shrink-0 pt-6')}>
-            <div className={workspaceColumnClassName}>
-              <ConversationHeader conversation={conversation} />
-            </div>
-          </div>
-        ) : (
-          <ConversationHeader conversation={conversation} />
-        ))}
+      {conversation && !isWorkspace && <ConversationHeader conversation={conversation} />}
       <MessageStream
         messages={messages}
-        contentClassName={
-          isWorkspace ? cn(workspaceOuterClassName, conversation ? 'py-3' : 'pb-3 pt-6') : undefined
-        }
+        contentClassName={isWorkspace ? cn(workspaceOuterClassName, 'pb-3 pt-6') : undefined}
         messageListClassName={isWorkspace ? workspaceColumnClassName : undefined}
       />
       {isWorkspace ? (

--- a/apps/desktop/src/renderer/src/agent-chat/message-stream.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/message-stream.tsx
@@ -1,6 +1,7 @@
 import type { Message } from '@memry/contracts/ipc-agent'
 
 import { Conversation, ConversationContent } from '@/components/ai-elements/conversation'
+import { cn } from '@/lib/utils'
 
 import { AssistantMessage } from './messages/assistant-message'
 import { SystemMessage } from './messages/system-message'
@@ -10,28 +11,40 @@ import { UserMessage } from './messages/user-message'
 
 interface MessageStreamProps {
   messages: Message[]
+  contentClassName?: string
+  messageListClassName?: string
 }
 
-export function MessageStream({ messages }: MessageStreamProps): React.JSX.Element {
+export function MessageStream({
+  messages,
+  contentClassName,
+  messageListClassName
+}: MessageStreamProps): React.JSX.Element {
+  const renderedMessages = messages.map((message) => {
+    if (message.role === 'user') return <UserMessage key={message.id} message={message} />
+    if (message.role === 'assistant') {
+      return <AssistantMessage key={message.id} message={message} />
+    }
+    if (message.role === 'tool_call') {
+      return <ToolCallMessage key={message.id} message={message} />
+    }
+    if (message.role === 'tool_result') {
+      return <ToolResultMessage key={message.id} message={message} />
+    }
+    if (message.role === 'system') {
+      return <SystemMessage key={message.id} message={message} />
+    }
+    return null
+  })
+
   return (
     <Conversation className="select-text">
-      <ConversationContent>
-        {messages.map((message) => {
-          if (message.role === 'user') return <UserMessage key={message.id} message={message} />
-          if (message.role === 'assistant') {
-            return <AssistantMessage key={message.id} message={message} />
-          }
-          if (message.role === 'tool_call') {
-            return <ToolCallMessage key={message.id} message={message} />
-          }
-          if (message.role === 'tool_result') {
-            return <ToolResultMessage key={message.id} message={message} />
-          }
-          if (message.role === 'system') {
-            return <SystemMessage key={message.id} message={message} />
-          }
-          return null
-        })}
+      <ConversationContent className={contentClassName}>
+        {messageListClassName ? (
+          <div className={cn('flex flex-col gap-3', messageListClassName)}>{renderedMessages}</div>
+        ) : (
+          renderedMessages
+        )}
       </ConversationContent>
     </Conversation>
   )

--- a/apps/desktop/src/renderer/src/agent-chat/messages/__tests__/assistant-message.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/messages/__tests__/assistant-message.test.tsx
@@ -1,0 +1,62 @@
+import type { Message } from '@memry/contracts/ipc-agent'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { AssistantMessage } from '../assistant-message'
+
+function assistantMessage(text: string): Message {
+  return {
+    id: 'message-1',
+    conversationId: 'conversation-1',
+    role: 'assistant',
+    content: { role: 'assistant', data: { text } },
+    toolCallId: null,
+    attachments: [],
+    status: 'completed',
+    vectorClock: {},
+    createdAt: 100,
+    updatedAt: 100,
+    deletedAt: null
+  }
+}
+
+function streamingAssistantMessage(): Message {
+  return {
+    ...assistantMessage(''),
+    status: 'streaming'
+  }
+}
+
+describe('AssistantMessage', () => {
+  it('renders assistant responses full width without bubble chrome', () => {
+    const { container } = render(<AssistantMessage message={assistantMessage('Plan looks good')} />)
+
+    expect(screen.getByText('Plan looks good')).toBeInTheDocument()
+
+    const message = container.querySelector('[data-role="assistant"]')
+    expect(message).toHaveClass('max-w-full')
+
+    const content = message?.firstElementChild
+    expect(content).toHaveClass(
+      'w-full',
+      'max-w-none',
+      'overflow-visible',
+      'border-0',
+      'bg-transparent',
+      'px-0',
+      'py-0'
+    )
+    expect(content).not.toHaveClass('rounded-lg', 'border-sidebar-border')
+  })
+
+  it('keeps the empty streaming indicator unframed', () => {
+    const { container } = render(<AssistantMessage message={streamingAssistantMessage()} />)
+
+    const message = container.querySelector('[data-role="assistant"]')
+    expect(message).toHaveClass('max-w-full')
+
+    const content = screen.getByRole('status')
+    expect(content).toHaveClass('overflow-visible', 'border-0', 'bg-transparent', 'px-0', 'py-0')
+    expect(content).not.toHaveClass('rounded-full', 'border-sidebar-border/70', 'shadow-sm')
+  })
+})

--- a/apps/desktop/src/renderer/src/agent-chat/messages/__tests__/assistant-message.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/messages/__tests__/assistant-message.test.tsx
@@ -43,7 +43,7 @@ describe('AssistantMessage', () => {
       'overflow-visible',
       'border-0',
       'bg-transparent',
-      'px-0',
+      'px-3',
       'py-0'
     )
     expect(content).not.toHaveClass('rounded-lg', 'border-sidebar-border')
@@ -56,7 +56,7 @@ describe('AssistantMessage', () => {
     expect(message).toHaveClass('max-w-full')
 
     const content = screen.getByRole('status')
-    expect(content).toHaveClass('overflow-visible', 'border-0', 'bg-transparent', 'px-0', 'py-0')
+    expect(content).toHaveClass('overflow-visible', 'border-0', 'bg-transparent', 'px-3', 'py-0')
     expect(content).not.toHaveClass('rounded-full', 'border-sidebar-border/70', 'shadow-sm')
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/messages/assistant-message.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/messages/assistant-message.tsx
@@ -13,11 +13,11 @@ export function AssistantMessage({ message }: { message: Message }): React.JSX.E
 
   if (message.status === 'streaming' && message.content.data.text.trim().length === 0) {
     return (
-      <AIMessage from="assistant">
+      <AIMessage from="assistant" className="max-w-full">
         <MessageContent
           role="status"
           aria-label={t('agentChat.thinking')}
-          className="min-w-10 rounded-full border border-sidebar-border/70 bg-background/80 px-3 py-2 shadow-sm"
+          className="min-w-10 overflow-visible border-0 bg-transparent px-0 py-0 shadow-none"
         >
           <span className="flex items-center gap-1.5" aria-hidden="true">
             <span className="size-2 animate-pulse rounded-full bg-foreground/60" />
@@ -30,8 +30,8 @@ export function AssistantMessage({ message }: { message: Message }): React.JSX.E
   }
 
   return (
-    <AIMessage from="assistant">
-      <MessageContent className="max-w-[92%] rounded-lg border border-sidebar-border bg-background px-3 py-2">
+    <AIMessage from="assistant" className="max-w-full">
+      <MessageContent className="w-full max-w-none overflow-visible rounded-none border-0 bg-transparent px-0 py-0">
         <MessageResponse>{message.content.data.text}</MessageResponse>
       </MessageContent>
     </AIMessage>

--- a/apps/desktop/src/renderer/src/agent-chat/messages/assistant-message.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/messages/assistant-message.tsx
@@ -17,7 +17,7 @@ export function AssistantMessage({ message }: { message: Message }): React.JSX.E
         <MessageContent
           role="status"
           aria-label={t('agentChat.thinking')}
-          className="min-w-10 overflow-visible border-0 bg-transparent px-0 py-0 shadow-none"
+          className="min-w-10 overflow-visible border-0 bg-transparent px-3 py-0 shadow-none"
         >
           <span className="flex items-center gap-1.5" aria-hidden="true">
             <span className="size-2 animate-pulse rounded-full bg-foreground/60" />
@@ -31,7 +31,7 @@ export function AssistantMessage({ message }: { message: Message }): React.JSX.E
 
   return (
     <AIMessage from="assistant" className="max-w-full">
-      <MessageContent className="w-full max-w-none overflow-visible rounded-none border-0 bg-transparent px-0 py-0">
+      <MessageContent className="w-full max-w-none overflow-visible rounded-none border-0 bg-transparent px-3 py-0">
         <MessageResponse>{message.content.data.text}</MessageResponse>
       </MessageContent>
     </AIMessage>

--- a/apps/desktop/src/renderer/src/agent-chat/sidebar-tabs.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/sidebar-tabs.tsx
@@ -3,13 +3,15 @@ import { History } from 'lucide-react'
 import { useT } from '@memry/i18n/renderer'
 
 import { useAISettingsContext } from '@/contexts/ai-settings-context'
+import { useDayPanel } from '@/contexts/day-panel-context'
+import { useTabs } from '@/contexts/tabs'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { Bot, CalendarDays, PlusSignIcon } from '@/lib/icons'
+import { Bot, CalendarDays, Expand, PlusSignIcon } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { useAgentOptional } from './agent-context'
 import { ConversationList } from './conversation-list'
@@ -141,10 +143,35 @@ export function SidebarTabs({
 function AgentConversationActions(): React.JSX.Element | null {
   const { t } = useT('common')
   const agent = useAgentOptional()
+  const { openTab } = useTabs()
+  const { close } = useDayPanel()
 
   if (!agent || agent.state.disclosureAccepted !== true) return null
 
+  const currentAgent = agent
   const newConversationLabel = t('agentChat.newConversation')
+  const openInTabLabel = t('agentChat.openInTab')
+  const activeConversationId = currentAgent.state.activeConversationId
+  const activeConversation = activeConversationId
+    ? currentAgent.state.conversations[activeConversationId]
+    : null
+
+  function openActiveConversationInTab(): void {
+    if (!activeConversation) return
+    openTab({
+      type: 'agent-chat',
+      title: activeConversation.title,
+      icon: 'bot',
+      path: `/agent-chat/${activeConversation.id}`,
+      entityId: activeConversation.id,
+      isPinned: false,
+      isModified: false,
+      isPreview: false,
+      isDeleted: false
+    })
+    close()
+    currentAgent.clearActiveConversation()
+  }
 
   return (
     <div className="flex items-center gap-1">
@@ -155,7 +182,7 @@ function AgentConversationActions(): React.JSX.Element | null {
               type="button"
               aria-label={newConversationLabel}
               title={newConversationLabel}
-              onClick={() => void agent.createConversation()}
+              onClick={() => void currentAgent.createConversation()}
               className="inline-flex size-6 shrink-0 items-center justify-center rounded-[5px] text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
               <PlusSignIcon className="size-3.5" aria-hidden="true" />
@@ -166,6 +193,26 @@ function AgentConversationActions(): React.JSX.Element | null {
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
+      {activeConversation && (
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={openInTabLabel}
+                title={openInTabLabel}
+                onClick={openActiveConversationInTab}
+                className="inline-flex size-6 shrink-0 items-center justify-center rounded-[5px] text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <Expand className="size-3.5" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              {openInTabLabel}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
       <AgentHistoryMenu />
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/ai-elements/conversation.tsx
+++ b/apps/desktop/src/renderer/src/components/ai-elements/conversation.tsx
@@ -33,5 +33,5 @@ export function ConversationContent({
   className,
   ...props
 }: ConversationContentProps): React.JSX.Element {
-  return <div className={cn('flex flex-col gap-3 px-4 py-3', className)} {...props} />
+  return <div className={cn('flex flex-col gap-3 px-2 py-3', className)} {...props} />
 }

--- a/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
@@ -26,6 +26,7 @@ import { TemplatesPage } from '@/pages/templates'
 import { GraphPage } from '@/components/graph/graph-page'
 import { useT } from '@memry/i18n/renderer'
 import { stringifyUnknown } from '@/lib/stringify-unknown'
+import { AgentConversationTab } from '@/agent-chat/agent-conversation-tab'
 
 // =============================================================================
 // MEMOIZED PAGE COMPONENTS
@@ -42,6 +43,7 @@ const MemoizedFolderViewPage = React.memo(FolderViewPage)
 const MemoizedTemplateEditorPage = React.memo(TemplateEditorPage)
 const MemoizedTemplatesPage = React.memo(TemplatesPage)
 const MemoizedGraphPage = React.memo(GraphPage)
+const MemoizedAgentConversationTab = React.memo(AgentConversationTab)
 
 interface TabContentProps {
   /** Tab data */
@@ -168,6 +170,9 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
 
       case 'graph':
         return <MemoizedGraphPage />
+
+      case 'agent-chat':
+        return <MemoizedAgentConversationTab conversationId={tab.entityId} />
 
       case 'collection':
         return (

--- a/apps/desktop/src/renderer/src/components/tabs/tab-icon.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-icon.tsx
@@ -24,7 +24,8 @@ import {
   GitGraph,
   Image,
   Music,
-  Video
+  Video,
+  Bot
 } from '@/lib/icons'
 import type { TabType } from '@/contexts/tabs/types'
 import { cn } from '@/lib/utils'
@@ -65,7 +66,8 @@ const ICON_COMPONENTS: Record<string, React.ComponentType<{ className?: string }
   'file-image': Image,
   'file-audio': Music,
   'file-video': Video,
-  'git-graph': GitGraph
+  'git-graph': GitGraph,
+  bot: Bot
 }
 
 /**
@@ -87,7 +89,8 @@ const TYPE_TO_ICON: Record<TabType, string> = {
   collection: 'bookmark',
   'template-editor': 'layout-template',
   templates: 'layout-template',
-  graph: 'git-graph'
+  graph: 'git-graph',
+  'agent-chat': 'bot'
 }
 
 /**

--- a/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
@@ -99,7 +99,8 @@ const TAB_ICONS: Record<TabType, string> = {
   collection: 'bookmark',
   'template-editor': 'layout-template',
   templates: 'layout-template',
-  graph: 'git-graph'
+  graph: 'git-graph',
+  'agent-chat': 'bot'
 }
 
 /**
@@ -144,6 +145,8 @@ export const getDefaultPath = (type: TabType, entityId?: string): string => {
       return `/search/${entityId}`
     case 'collection':
       return `/collection/${entityId}`
+    case 'agent-chat':
+      return `/agent-chat/${entityId}`
     default:
       return '/'
   }

--- a/apps/desktop/src/renderer/src/contexts/tabs/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/types.ts
@@ -27,6 +27,7 @@ export type TabType =
   | 'template-editor' // Template editing (Phase 15)
   | 'templates' // Template list/management (Phase 15)
   | 'graph' // Knowledge graph visualization
+  | 'agent-chat' // Agent conversation
 
 /**
  * Singleton tab types - only one instance allowed

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -22,9 +22,10 @@ new-conversation button, a history menu for switching back to recent conversatio
 button for moving the current conversation into a workspace tab. Popped-out conversations keep the
 generated conversation title as the tab name, use the same centered reading column as notes, and
 leave the right sidebar ready for a new chat. The popped-out tab keeps the scroll bar at the window
-edge while the chat content stays centered. For Claude CLI, Memry checks that `claude` is available
-on `PATH`, that it reports version `2.1.0` or newer, and that the Agent disclosure has been
-accepted. For local models, configure a compatible server in
+edge while the chat content stays centered, and the tab name is the only conversation title shown in
+that workspace view. For Claude CLI, Memry checks that `claude` is available on `PATH`, that it
+reports version `2.1.0` or newer, and that the Agent disclosure has been accepted. For local models,
+configure a compatible server in
 [Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
 If the global AI switch is off in [Settings -> AI](/user-guide/settings#ai), the Agent tab and Agent
 MCP current-note bridge are hidden and inactive.

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -24,9 +24,9 @@ generated conversation title as the tab name, use the same centered reading colu
 leave the right sidebar ready for a new chat. The popped-out tab keeps the scroll bar at the window
 edge while the chat content stays centered, and the tab name is the only conversation title shown in
 that workspace view. Assistant responses render as full-width text in both the sidebar and popped-out
-tabs instead of bordered bubbles. For Claude CLI, Memry checks that `claude` is available on `PATH`,
-that it reports version `2.1.0` or newer, and that the Agent disclosure has been accepted. For local
-models, configure a compatible server in
+tabs instead of bordered bubbles, with text aligned to the prompt input. For Claude CLI, Memry checks
+that `claude` is available on `PATH`, that it reports version `2.1.0` or newer, and that the Agent
+disclosure has been accepted. For local models, configure a compatible server in
 [Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
 If the global AI switch is off in [Settings -> AI](/user-guide/settings#ai), the Agent tab and Agent
 MCP current-note bridge are hidden and inactive.

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -23,9 +23,10 @@ button for moving the current conversation into a workspace tab. Popped-out conv
 generated conversation title as the tab name, use the same centered reading column as notes, and
 leave the right sidebar ready for a new chat. The popped-out tab keeps the scroll bar at the window
 edge while the chat content stays centered, and the tab name is the only conversation title shown in
-that workspace view. For Claude CLI, Memry checks that `claude` is available on `PATH`, that it
-reports version `2.1.0` or newer, and that the Agent disclosure has been accepted. For local models,
-configure a compatible server in
+that workspace view. Assistant responses render as full-width text in both the sidebar and popped-out
+tabs instead of bordered bubbles. For Claude CLI, Memry checks that `claude` is available on `PATH`,
+that it reports version `2.1.0` or newer, and that the Agent disclosure has been accepted. For local
+models, configure a compatible server in
 [Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
 If the global AI switch is off in [Settings -> AI](/user-guide/settings#ai), the Agent tab and Agent
 MCP current-note bridge are hidden and inactive.

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -18,10 +18,12 @@ endpoint and bearer token.
 
 Open the right sidebar, choose **Agent**, and pick a provider. The compact Day/Agent switch keeps
 the active view highlighted at the top of the right sidebar. The Agent header includes a
-new-conversation button and a history menu for switching back to recent conversations. For Claude
-CLI, Memry checks that `claude` is available on `PATH`, that it reports version `2.1.0` or newer,
-and that the Agent disclosure has been accepted. For local models, configure a compatible server in
-[Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
+new-conversation button, a history menu for switching back to recent conversations, and a pop-out
+button for moving the current conversation into a workspace tab. Popped-out conversations keep the
+generated conversation title as the tab name and leave the right sidebar ready for a new chat. For
+Claude CLI, Memry checks that `claude` is available on `PATH`, that it reports version `2.1.0` or
+newer, and that the Agent disclosure has been accepted. For local models, configure a compatible
+server in [Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
 If the global AI switch is off in [Settings -> AI](/user-guide/settings#ai), the Agent tab and Agent
 MCP current-note bridge are hidden and inactive.
 

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -20,10 +20,11 @@ Open the right sidebar, choose **Agent**, and pick a provider. The compact Day/A
 the active view highlighted at the top of the right sidebar. The Agent header includes a
 new-conversation button, a history menu for switching back to recent conversations, and a pop-out
 button for moving the current conversation into a workspace tab. Popped-out conversations keep the
-generated conversation title as the tab name and leave the right sidebar ready for a new chat. For
-Claude CLI, Memry checks that `claude` is available on `PATH`, that it reports version `2.1.0` or
-newer, and that the Agent disclosure has been accepted. For local models, configure a compatible
-server in [Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
+generated conversation title as the tab name, use the same centered reading column as notes, and
+leave the right sidebar ready for a new chat. For Claude CLI, Memry checks that `claude` is
+available on `PATH`, that it reports version `2.1.0` or newer, and that the Agent disclosure has
+been accepted. For local models, configure a compatible server in
+[Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
 If the global AI switch is off in [Settings -> AI](/user-guide/settings#ai), the Agent tab and Agent
 MCP current-note bridge are hidden and inactive.
 

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -21,9 +21,10 @@ the active view highlighted at the top of the right sidebar. The Agent header in
 new-conversation button, a history menu for switching back to recent conversations, and a pop-out
 button for moving the current conversation into a workspace tab. Popped-out conversations keep the
 generated conversation title as the tab name, use the same centered reading column as notes, and
-leave the right sidebar ready for a new chat. For Claude CLI, Memry checks that `claude` is
-available on `PATH`, that it reports version `2.1.0` or newer, and that the Agent disclosure has
-been accepted. For local models, configure a compatible server in
+leave the right sidebar ready for a new chat. The popped-out tab keeps the scroll bar at the window
+edge while the chat content stays centered. For Claude CLI, Memry checks that `claude` is available
+on `PATH`, that it reports version `2.1.0` or newer, and that the Agent disclosure has been
+accepted. For local models, configure a compatible server in
 [Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
 If the global AI switch is off in [Settings -> AI](/user-guide/settings#ai), the Agent tab and Agent
 MCP current-note bridge are hidden and inactive.

--- a/packages/i18n/src/locales/ar/common.json
+++ b/packages/i18n/src/locales/ar/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "جارٍ تحميل المحادثة...",
     "newConversation": "محادثة جديدة",
     "history": "سجل المحادثات",
+    "openInTab": "فتح المحادثة في علامة تبويب",
     "stop": "توقف",
     "thinking": "Agent يفكر",
     "enable": {

--- a/packages/i18n/src/locales/cs/common.json
+++ b/packages/i18n/src/locales/cs/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Načítání konverzace...",
     "newConversation": "Nová konverzace",
     "history": "Historie konverzace",
+    "openInTab": "Otevřít konverzaci na kartě",
     "stop": "Zastávka",
     "thinking": "Agent přemýšlí",
     "enable": {

--- a/packages/i18n/src/locales/da/common.json
+++ b/packages/i18n/src/locales/da/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Samtalen indlæses...",
     "newConversation": "Ny samtale",
     "history": "Samtalehistorik",
+    "openInTab": "Åbn samtale i fane",
     "stop": "Stop",
     "thinking": "Agent tænker",
     "enable": {

--- a/packages/i18n/src/locales/de/common.json
+++ b/packages/i18n/src/locales/de/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Konversation wird geladen...",
     "newConversation": "Neues Gespräch",
     "history": "Gesprächsverlauf",
+    "openInTab": "Unterhaltung in Tab öffnen",
     "stop": "Stopp",
     "thinking": "Agent denkt nach",
     "enable": {

--- a/packages/i18n/src/locales/el/common.json
+++ b/packages/i18n/src/locales/el/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Φόρτωση συνομιλίας...",
     "newConversation": "Νέα συνομιλία",
     "history": "Ιστορικό συνομιλιών",
+    "openInTab": "Άνοιγμα συνομιλίας σε καρτέλα",
     "stop": "Σταματήστε",
     "thinking": "Το Agent σκέφτεται",
     "enable": {

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -76,6 +76,7 @@
     "conversationLoading": "Conversation loading...",
     "newConversation": "New conversation",
     "history": "Conversation history",
+    "openInTab": "Open conversation in tab",
     "stop": "Stop",
     "thinking": "Agent is thinking",
     "enable": {

--- a/packages/i18n/src/locales/es/common.json
+++ b/packages/i18n/src/locales/es/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Cargando conversación...",
     "newConversation": "Nueva conversación",
     "history": "Historial de conversaciones",
+    "openInTab": "Abrir conversación en pestaña",
     "stop": "Detener",
     "thinking": "Agent está pensando",
     "enable": {

--- a/packages/i18n/src/locales/fi/common.json
+++ b/packages/i18n/src/locales/fi/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Keskustelua ladataan...",
     "newConversation": "Uusi keskustelu",
     "history": "Keskusteluhistoria",
+    "openInTab": "Avaa keskustelu välilehdessä",
     "stop": "Pysähdy",
     "thinking": "Agent ajattelee",
     "enable": {

--- a/packages/i18n/src/locales/fil/common.json
+++ b/packages/i18n/src/locales/fil/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Naglo-load ang pag-uusap...",
     "newConversation": "Bagong pag-uusap",
     "history": "History ng pag-uusap",
+    "openInTab": "Buksan ang pag-uusap sa tab",
     "stop": "Tumigil ka",
     "thinking": "Agent ay nag-iisip",
     "enable": {

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Chargement de la conversation...",
     "newConversation": "Nouvelle conversation",
     "history": "Historique des conversations",
+    "openInTab": "Ouvrir la conversation dans un onglet",
     "stop": "Arrêter",
     "thinking": "Agent réfléchit",
     "enable": {

--- a/packages/i18n/src/locales/he/common.json
+++ b/packages/i18n/src/locales/he/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "טעינת השיחה...",
     "newConversation": "שיחה חדשה",
     "history": "היסטוריית שיחות",
+    "openInTab": "פתח שיחה בכרטיסייה",
     "stop": "עצור",
     "thinking": "Agent חושב",
     "enable": {

--- a/packages/i18n/src/locales/hr/common.json
+++ b/packages/i18n/src/locales/hr/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Razgovor se učitava...",
     "newConversation": "Novi razgovor",
     "history": "Povijest razgovora",
+    "openInTab": "Otvori razgovor u kartici",
     "stop": "Stani",
     "thinking": "Agent razmišlja",
     "enable": {

--- a/packages/i18n/src/locales/hu/common.json
+++ b/packages/i18n/src/locales/hu/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Beszélgetés betöltése...",
     "newConversation": "Új beszélgetés",
     "history": "Beszélgetés előzményei",
+    "openInTab": "Beszélgetés megnyitása lapon",
     "stop": "Állj",
     "thinking": "Agent gondolkodik",
     "enable": {

--- a/packages/i18n/src/locales/id/common.json
+++ b/packages/i18n/src/locales/id/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Percakapan sedang dimuat...",
     "newConversation": "Percakapan baru",
     "history": "Riwayat percakapan",
+    "openInTab": "Buka percakapan di tab",
     "stop": "Berhenti",
     "thinking": "Agent sedang berpikir",
     "enable": {

--- a/packages/i18n/src/locales/it/common.json
+++ b/packages/i18n/src/locales/it/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Caricamento conversazione...",
     "newConversation": "Nuova conversazione",
     "history": "Cronologia delle conversazioni",
+    "openInTab": "Apri conversazione in scheda",
     "stop": "Fermati",
     "thinking": "Agent sta pensando",
     "enable": {

--- a/packages/i18n/src/locales/ja/common.json
+++ b/packages/i18n/src/locales/ja/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "会話を読み込み中...",
     "newConversation": "新しい会話",
     "history": "会話履歴",
+    "openInTab": "会話をタブで開く",
     "stop": "停止",
     "thinking": "Agent は考えています",
     "enable": {

--- a/packages/i18n/src/locales/ko/common.json
+++ b/packages/i18n/src/locales/ko/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "대화 로드 중...",
     "newConversation": "새 대화",
     "history": "대화 기록",
+    "openInTab": "대화를 탭에서 열기",
     "stop": "중지",
     "thinking": "Agent는 생각 중입니다.",
     "enable": {

--- a/packages/i18n/src/locales/ms/common.json
+++ b/packages/i18n/src/locales/ms/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Memuatkan perbualan...",
     "newConversation": "Perbualan baharu",
     "history": "Sejarah perbualan",
+    "openInTab": "Buka perbualan dalam tab",
     "stop": "Berhenti",
     "thinking": "Agent sedang berfikir",
     "enable": {

--- a/packages/i18n/src/locales/nl/common.json
+++ b/packages/i18n/src/locales/nl/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Gesprek wordt geladen...",
     "newConversation": "Nieuw gesprek",
     "history": "Gespreksgeschiedenis",
+    "openInTab": "Gesprek openen in tabblad",
     "stop": "Stoppen",
     "thinking": "Agent denkt na",
     "enable": {

--- a/packages/i18n/src/locales/no/common.json
+++ b/packages/i18n/src/locales/no/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Samtalen lastes inn...",
     "newConversation": "Ny samtale",
     "history": "Samtalehistorikk",
+    "openInTab": "Åpne samtale i fane",
     "stop": "Stopp",
     "thinking": "Agent tenker",
     "enable": {

--- a/packages/i18n/src/locales/pl/common.json
+++ b/packages/i18n/src/locales/pl/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Ładowanie rozmowy...",
     "newConversation": "Nowa rozmowa",
     "history": "Historia rozmów",
+    "openInTab": "Otwórz rozmowę w karcie",
     "stop": "Zatrzymaj się",
     "thinking": "Agent myśli",
     "enable": {

--- a/packages/i18n/src/locales/pt/common.json
+++ b/packages/i18n/src/locales/pt/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Conversa carregando...",
     "newConversation": "Nova conversa",
     "history": "Histórico de conversas",
+    "openInTab": "Abrir conversa em aba",
     "stop": "Parar",
     "thinking": "Agent está pensando",
     "enable": {

--- a/packages/i18n/src/locales/ro/common.json
+++ b/packages/i18n/src/locales/ro/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Se încarcă conversația...",
     "newConversation": "Conversație nouă",
     "history": "Istoricul conversațiilor",
+    "openInTab": "Deschide conversația într-o filă",
     "stop": "Opriți",
     "thinking": "Agent se gândește",
     "enable": {

--- a/packages/i18n/src/locales/ru/common.json
+++ b/packages/i18n/src/locales/ru/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Разговор загружается...",
     "newConversation": "Новый разговор",
     "history": "История разговора",
+    "openInTab": "Открыть разговор во вкладке",
     "stop": "Стоп",
     "thinking": "Agent думает",
     "enable": {

--- a/packages/i18n/src/locales/sk/common.json
+++ b/packages/i18n/src/locales/sk/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Načítava sa konverzácia...",
     "newConversation": "Nová konverzácia",
     "history": "História konverzácií",
+    "openInTab": "Otvoriť konverzáciu na karte",
     "stop": "Stop",
     "thinking": "Agent premýšľa",
     "enable": {

--- a/packages/i18n/src/locales/sv/common.json
+++ b/packages/i18n/src/locales/sv/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Konversationen laddas...",
     "newConversation": "Ny konversation",
     "history": "Konversationshistorik",
+    "openInTab": "Öppna konversation i flik",
     "stop": "Stopp",
     "thinking": "Agent tänker",
     "enable": {

--- a/packages/i18n/src/locales/th/common.json
+++ b/packages/i18n/src/locales/th/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "กำลังโหลดการสนทนา...",
     "newConversation": "บทสนทนาใหม่",
     "history": "ประวัติการสนทนา",
+    "openInTab": "เปิดการสนทนาในแท็บ",
     "stop": "หยุด",
     "thinking": "Agent กำลังคิด",
     "enable": {

--- a/packages/i18n/src/locales/tr/common.json
+++ b/packages/i18n/src/locales/tr/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Konuşma yükleniyor...",
     "newConversation": "Yeni görüşme",
     "history": "Konuşma geçmişi",
+    "openInTab": "Konuşmayı sekmede aç",
     "stop": "Durdur",
     "thinking": "Agent düşünüyor",
     "enable": {

--- a/packages/i18n/src/locales/uk/common.json
+++ b/packages/i18n/src/locales/uk/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Розмова завантажується...",
     "newConversation": "Нова розмова",
     "history": "Історія розмов",
+    "openInTab": "Відкрити розмову у вкладці",
     "stop": "Стоп",
     "thinking": "Agent думає",
     "enable": {

--- a/packages/i18n/src/locales/vi/common.json
+++ b/packages/i18n/src/locales/vi/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "Đang tải cuộc trò chuyện...",
     "newConversation": "Cuộc trò chuyện mới",
     "history": "Lịch sử hội thoại",
+    "openInTab": "Mở cuộc trò chuyện trong tab",
     "stop": "Dừng lại",
     "thinking": "Agent đang suy nghĩ",
     "enable": {

--- a/packages/i18n/src/locales/zh-CN/common.json
+++ b/packages/i18n/src/locales/zh-CN/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "对话加载中...",
     "newConversation": "新对话",
     "history": "对话历史记录",
+    "openInTab": "在标签页中打开对话",
     "stop": "停止",
     "thinking": "Agent 正在思考",
     "enable": {

--- a/packages/i18n/src/locales/zh-TW/common.json
+++ b/packages/i18n/src/locales/zh-TW/common.json
@@ -337,6 +337,7 @@
     "conversationLoading": "對話載入中...",
     "newConversation": "新對話",
     "history": "對話歷史記錄",
+    "openInTab": "在分頁中開啟對話",
     "stop": "停止",
     "thinking": "Agent 正在思考",
     "enable": {


### PR DESCRIPTION
## Summary

- Add a pop-out action to the Agent Chat right-sidebar header that opens the active conversation as a workspace tab.
- Keep the right sidebar ready for a fresh chat after pop-out while preserving the popped-out conversation in the main tab area.
- Sync Agent Chat tab titles to generated conversation names and document the behavior in the Agent Chat guide.

## Verification

- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/agent-chat/__tests__/agent-context.test.tsx src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx src/renderer/src/agent-chat/__tests__/agent-tab-title-sync.test.tsx`
- `pnpm --filter @memry/desktop i18n:check`
- `pnpm --filter @memry/desktop typecheck`
- `pnpm --dir apps/desktop exec eslint src/renderer/src/App.tsx src/renderer/src/agent-chat/agent-context.reducer.ts src/renderer/src/agent-chat/agent-context.tsx src/renderer/src/agent-chat/sidebar-tabs.tsx src/renderer/src/agent-chat/agent-conversation-tab.tsx src/renderer/src/agent-chat/agent-tab-title-sync.tsx src/renderer/src/components/split-view/tab-content.tsx src/renderer/src/components/tabs/tab-icon.tsx src/renderer/src/contexts/tabs/helpers.ts src/renderer/src/contexts/tabs/types.ts`
- `pnpm docs:impact --base 34571e9901a59cbd62d297be57839cef8318ebbf --strict`
- `pnpm docs:build`
