### PR TITLE
Fix Agent Chat source icons

### DIFF
--- a/apps/desktop/src/main/agent/mcp/tools/handles-adapter.test.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles-adapter.test.ts
@@ -209,7 +209,7 @@ describe('createVaultServiceHandles', () => {
               id: 'note-1',
               title: 'Alpha',
               snippet: null,
-              metadata: { type: 'note', path: 'notes/work/alpha.md' }
+              metadata: { type: 'note', path: 'notes/work/alpha.md', emoji: '🎬' }
             },
             {
               id: 'note-2',
@@ -225,7 +225,7 @@ describe('createVaultServiceHandles', () => {
     await expect(
       handles.notes.search({ query: 'alpha', folderId: '/work', limit: 5 })
     ).resolves.toEqual([
-      { id: 'note-1', title: 'Alpha', snippet: '', folder_path: '/work' },
+      { id: 'note-1', title: 'Alpha', snippet: '', folder_path: '/work', icon: '🎬' },
       { id: 'note-2', title: 'Loose', snippet: 'loose snippet', folder_path: null }
     ])
     expect(mocks.searchAll).toHaveBeenCalledWith(
@@ -240,7 +240,8 @@ describe('createVaultServiceHandles', () => {
       content: 'Current',
       tags: ['Team'],
       path: 'notes/work/alpha.md',
-      frontmatter: { owner: 'Kaan' }
+      frontmatter: { owner: 'Kaan' },
+      emoji: '📚'
     })
     await expect(handles.notes.read('note-1')).resolves.toEqual({
       id: 'note-1',
@@ -248,7 +249,8 @@ describe('createVaultServiceHandles', () => {
       content_markdown: 'Current',
       tags: ['Team'],
       folder_path: '/work',
-      frontmatter: { owner: 'Kaan' }
+      frontmatter: { owner: 'Kaan' },
+      icon: '📚'
     })
 
     mocks.createNoteCommand.mockResolvedValue({ id: 'note-created' })
@@ -350,14 +352,14 @@ describe('createVaultServiceHandles', () => {
     ])
     mocks.listNotes.mockReturnValue({
       notes: [
-        { id: 'note-1', title: 'Client', path: 'notes/work/client.md' },
+        { id: 'note-1', title: 'Client', path: 'notes/work/client.md', emoji: '💼' },
         { id: 'note-2', title: 'Deep', path: 'notes/work/client/deep.md' }
       ]
     })
 
     await expect(handles.folders.list({ path: '/work', recursive: false })).resolves.toEqual([
       { kind: 'folder', id: '/work/client', name: 'client', path: '/work/client' },
-      { kind: 'note', id: 'note-1', name: 'Client', path: '/work/client.md' }
+      { kind: 'note', id: 'note-1', name: 'Client', path: '/work/client.md', icon: '💼' }
     ])
     expect(mocks.listNotes).toHaveBeenCalledWith({
       folder: 'notes/work',
@@ -375,7 +377,7 @@ describe('createVaultServiceHandles', () => {
         path: '/work/client/archive'
       },
       { kind: 'folder', id: '/personal', name: 'personal', path: '/personal' },
-      { kind: 'note', id: 'note-1', name: 'Client', path: '/work/client.md' },
+      { kind: 'note', id: 'note-1', name: 'Client', path: '/work/client.md', icon: '💼' },
       { kind: 'note', id: 'note-2', name: 'Deep', path: '/work/client/deep.md' }
     ])
 
@@ -672,21 +674,22 @@ describe('createVaultServiceHandles', () => {
         items: [
           {
             id: 'inbox-1',
-            sourceUrl: 'https://example.com',
+            sourceUrl: 'https://x.com/memry/status/1',
             captureSource: null,
-            type: 'text',
+            type: 'social',
             title: 'Unread',
             content: null,
             transcription: null,
             excerpt: 'Excerpt',
             viewedAt: null,
-            createdAt: new Date('2026-05-12T00:00:00Z')
+            createdAt: new Date('2026-05-12T00:00:00Z'),
+            metadata: { platform: 'twitter' }
           },
           {
             id: 'inbox-2',
             sourceUrl: null,
             captureSource: 'share',
-            type: 'text',
+            type: 'clip',
             title: 'Read',
             content: 'Read body',
             transcription: null,
@@ -701,7 +704,9 @@ describe('createVaultServiceHandles', () => {
     await expect(handles.inbox.list({ unread_only: true })).resolves.toEqual([
       {
         id: 'inbox-1',
-        source: 'https://example.com',
+        type: 'social',
+        visual_type: 'twitter',
+        source: 'https://x.com/memry/status/1',
         title: 'Unread',
         snippet: 'Excerpt',
         captured_at: new Date('2026-05-12T00:00:00Z').getTime()
@@ -709,7 +714,12 @@ describe('createVaultServiceHandles', () => {
     ])
     await expect(handles.inbox.list({ unread_only: false })).resolves.toEqual([
       expect.objectContaining({ id: 'inbox-1', snippet: 'Excerpt' }),
-      expect.objectContaining({ id: 'inbox-2', source: 'share', snippet: 'Read body' })
+      expect.objectContaining({
+        id: 'inbox-2',
+        source: 'share',
+        snippet: 'Read body',
+        visual_type: 'quote'
+      })
     ])
     await expect(
       handles.inbox.add({ source: 'api', title: 'Captured', content: 'Body' })

--- a/apps/desktop/src/main/agent/mcp/tools/handles-adapter.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles-adapter.ts
@@ -139,6 +139,39 @@ function assertSuccess(result: { success: boolean; error?: string }, fallback: s
   }
 }
 
+function inboxVisualType(item: {
+  type?: string
+  sourceUrl?: string | null
+  metadata?: unknown
+}): string | undefined {
+  if (item.type === 'clip') return 'quote'
+
+  const metadata = item.metadata && typeof item.metadata === 'object' ? item.metadata : null
+  const platform =
+    metadata && 'platform' in metadata && typeof metadata.platform === 'string'
+      ? metadata.platform
+      : null
+
+  if (item.type === 'social' && platform === 'twitter') return 'twitter'
+  if ((item.type === 'social' || item.type === 'link') && item.sourceUrl) {
+    try {
+      const host = new URL(item.sourceUrl).hostname.toLowerCase()
+      if (
+        host === 'x.com' ||
+        host.endsWith('.x.com') ||
+        host === 'twitter.com' ||
+        host.endsWith('.twitter.com')
+      ) {
+        return 'twitter'
+      }
+    } catch {
+      return item.type === 'social' ? 'social' : undefined
+    }
+  }
+
+  return item.type === 'social' ? 'social' : undefined
+}
+
 export function createVaultServiceHandles({ dataDb, indexDb }: AdapterDeps): VaultServiceHandles {
   return {
     notes: {
@@ -160,20 +193,28 @@ export function createVaultServiceHandles({ dataDb, indexDb }: AdapterDeps): Vau
             id: note.id,
             title: note.title,
             snippet: note.snippet ?? '',
-            folder_path: metadata?.path ? folderPathFromNotePath(metadata.path) : null
+            folder_path: metadata?.path ? folderPathFromNotePath(metadata.path) : null,
+            ...(metadata?.emoji ? { icon: metadata.emoji } : {})
           }
         })
       },
       async read(id) {
         const note = await getNoteById(id)
         if (!note) return null
+        const icon =
+          typeof note.emoji === 'string'
+            ? note.emoji
+            : typeof note.frontmatter.emoji === 'string'
+              ? note.frontmatter.emoji
+              : null
         return {
           id: note.id,
           title: note.title,
           content_markdown: note.content,
           tags: note.tags,
           folder_path: folderPathFromNotePath(note.path),
-          frontmatter: note.frontmatter
+          frontmatter: note.frontmatter,
+          ...(icon ? { icon } : {})
         }
       },
       async create(input) {
@@ -253,7 +294,8 @@ export function createVaultServiceHandles({ dataDb, indexDb }: AdapterDeps): Vau
           kind: 'note',
           id: note.id,
           name: note.title,
-          path: toolPathFromVaultRelativePath(note.path)
+          path: toolPathFromVaultRelativePath(note.path),
+          ...(note.emoji ? { icon: note.emoji } : {})
         }))
 
         return [...folderEntries, ...noteEntries]
@@ -582,13 +624,18 @@ export function createVaultServiceHandles({ dataDb, indexDb }: AdapterDeps): Vau
         })
         return result.items
           .filter((item) => !unread_only || !item.viewedAt)
-          .map<InboxSummary>((item) => ({
-            id: item.id,
-            source: item.sourceUrl ?? item.captureSource ?? item.type,
-            title: item.title,
-            snippet: item.content ?? item.transcription ?? item.excerpt ?? '',
-            captured_at: item.createdAt.getTime()
-          }))
+          .map<InboxSummary>((item) => {
+            const visualType = inboxVisualType(item)
+            return {
+              id: item.id,
+              type: item.type,
+              ...(visualType ? { visual_type: visualType } : {}),
+              source: item.sourceUrl ?? item.captureSource ?? item.type,
+              title: item.title,
+              snippet: item.content ?? item.transcription ?? item.excerpt ?? '',
+              captured_at: item.createdAt.getTime()
+            }
+          })
       },
       async get(id) {
         return createDesktopInboxCrudHandlers().handleGet(id)

--- a/apps/desktop/src/main/agent/mcp/tools/handles.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles.ts
@@ -11,6 +11,7 @@ export interface NoteSummary {
   title: string
   snippet: string
   folder_path: string | null
+  icon?: string | null
 }
 
 export interface NoteFull {
@@ -20,6 +21,7 @@ export interface NoteFull {
   tags: string[]
   folder_path: string | null
   frontmatter: Record<string, unknown>
+  icon?: string | null
 }
 
 export interface FolderEntry {
@@ -27,6 +29,7 @@ export interface FolderEntry {
   id: string
   name: string
   path: string
+  icon?: string | null
 }
 
 export interface TaskSummary {
@@ -59,6 +62,8 @@ export interface JournalSummary {
 
 export interface InboxSummary {
   id: string
+  type?: string
+  visual_type?: string
   source: string
   title: string
   snippet: string

--- a/apps/desktop/src/main/agent/runtime/__tests__/turn.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/turn.test.ts
@@ -153,7 +153,7 @@ describe('runTurn against a stub backend', () => {
           kind: 'tool_result',
           toolUseId: 'tool-1',
           ok: true,
-          data: [{ id: 'note-1', title: 'Movies', snippet: '', folder_path: null }]
+          data: [{ id: 'note-1', title: 'Movies', snippet: '', folder_path: null, icon: '🎬' }]
         },
         {
           kind: 'assistant_delta',
@@ -183,7 +183,80 @@ describe('runTurn against a stub backend', () => {
       role: 'assistant',
       data: {
         text: 'Found [Movies](memry://note/note-1).',
-        sources: [{ kind: 'note', id: 'note-1', title: 'Movies', href: 'memry://note/note-1' }]
+        sources: [
+          { kind: 'note', id: 'note-1', title: 'Movies', href: 'memry://note/note-1', icon: '🎬' }
+        ]
+      }
+    })
+  })
+
+  it('persists assistant source refs from wrapped MCP tool results', async () => {
+    const messages = createFakeMessageStore()
+    const conversations = createFakeConversationStore({ title: 'Existing conversation' })
+    const toolResult = [
+      {
+        id: 'inbox-1',
+        title: 'Tweet',
+        type: 'social',
+        visual_type: 'twitter',
+        href: 'memry://inbox/inbox-1',
+        source_ref: {
+          kind: 'inbox',
+          id: 'inbox-1',
+          title: 'Tweet',
+          href: 'memry://inbox/inbox-1',
+          itemType: 'social',
+          visualType: 'twitter'
+        }
+      }
+    ]
+    const backend = createFakeBackend({
+      turn: [
+        { kind: 'tool_use', toolUseId: 'tool-1', name: 'vault_list_inbox_items', args: {} },
+        {
+          kind: 'tool_result',
+          toolUseId: 'tool-1',
+          ok: true,
+          data: { content: [{ type: 'text', text: JSON.stringify(toolResult) }] }
+        },
+        {
+          kind: 'assistant_delta',
+          text: 'Found [Tweet](memry://inbox/inbox-1).'
+        },
+        { kind: 'message_stop' }
+      ]
+    })
+
+    await runTurn(
+      {
+        conversations,
+        messages,
+        backends: createFakeRegistry(backend)
+      },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'list inbox',
+        attachments: [],
+        backendOptions: { backend: 'codex_cli', reasoningEffort: 'medium' }
+      }
+    )
+
+    const all = messages.listByConversation('conversation-1')
+    expect(all[1].content).toEqual({
+      role: 'assistant',
+      data: {
+        text: 'Found [Tweet](memry://inbox/inbox-1).',
+        sources: [
+          {
+            kind: 'inbox',
+            id: 'inbox-1',
+            title: 'Tweet',
+            href: 'memry://inbox/inbox-1',
+            itemType: 'social',
+            visualType: 'twitter'
+          }
+        ]
       }
     })
   })

--- a/apps/desktop/src/main/agent/source-refs.test.ts
+++ b/apps/desktop/src/main/agent/source-refs.test.ts
@@ -27,6 +27,173 @@ describe('Agent source refs', () => {
     ])
   })
 
+  it('preserves item icon metadata for note, inbox, and calendar refs', () => {
+    const refs = extractAgentSourceRefs(
+      'vault_desktop_read',
+      { operation: 'calendar.getRange', args: [] },
+      {
+        items: [
+          {
+            sourceType: 'event',
+            sourceId: 'event-1',
+            title: 'Planning',
+            startAt: '2026-05-13T09:00:00.000Z',
+            visualType: 'event'
+          },
+          {
+            sourceType: 'inbox_snooze',
+            sourceId: 'inbox-1',
+            title: 'Read later',
+            startAt: '2026-05-13T10:00:00.000Z',
+            visualType: 'snooze'
+          }
+        ]
+      }
+    )
+
+    expect(refs).toEqual([
+      {
+        kind: 'calendar_event',
+        id: 'event-1',
+        title: 'Planning',
+        href: 'memry://calendar/event/event-1?date=2026-05-13',
+        visualType: 'event'
+      },
+      {
+        kind: 'inbox',
+        id: 'inbox-1',
+        title: 'Read later',
+        href: 'memry://inbox/inbox-1',
+        visualType: 'snooze'
+      }
+    ])
+
+    expect(
+      extractAgentSourceRefs('vault_search_notes', {}, [
+        { id: 'note-1', title: 'Movies', icon: '🎬' }
+      ])
+    ).toEqual([
+      { kind: 'note', id: 'note-1', title: 'Movies', href: 'memry://note/note-1', icon: '🎬' }
+    ])
+
+    expect(
+      extractAgentSourceRefs(
+        'vault_read_note',
+        {},
+        {
+          id: 'note-2',
+          title: 'Books',
+          emoji: '📚'
+        }
+      )
+    ).toEqual([
+      { kind: 'note', id: 'note-2', title: 'Books', href: 'memry://note/note-2', icon: '📚' }
+    ])
+
+    expect(
+      extractAgentSourceRefs('vault_list_inbox_items', {}, [
+        { id: 'inbox-2', title: 'Spec PDF', type: 'pdf' },
+        { id: 'inbox-3', title: 'Tweet', type: 'social', visual_type: 'twitter' },
+        { id: 'inbox-4', title: 'Quote', type: 'clip' }
+      ])
+    ).toEqual([
+      {
+        kind: 'inbox',
+        id: 'inbox-2',
+        title: 'Spec PDF',
+        href: 'memry://inbox/inbox-2',
+        itemType: 'pdf'
+      },
+      {
+        kind: 'inbox',
+        id: 'inbox-3',
+        title: 'Tweet',
+        href: 'memry://inbox/inbox-3',
+        itemType: 'social',
+        visualType: 'twitter'
+      },
+      {
+        kind: 'inbox',
+        id: 'inbox-4',
+        title: 'Quote',
+        href: 'memry://inbox/inbox-4',
+        itemType: 'clip',
+        visualType: 'quote'
+      }
+    ])
+  })
+
+  it('extracts icon metadata from MCP content wrappers', () => {
+    const noteResult = [
+      {
+        id: 'note-1',
+        title: 'Movies',
+        href: 'memry://note/note-1',
+        source_ref: {
+          kind: 'note',
+          id: 'note-1',
+          title: 'Movies',
+          href: 'memry://note/note-1',
+          icon: '🎬'
+        }
+      }
+    ]
+    const inboxResult = [
+      {
+        id: 'inbox-1',
+        title: 'Tweet',
+        type: 'social',
+        visual_type: 'twitter',
+        href: 'memry://inbox/inbox-1',
+        source_ref: {
+          kind: 'inbox',
+          id: 'inbox-1',
+          title: 'Tweet',
+          href: 'memry://inbox/inbox-1',
+          itemType: 'social',
+          visualType: 'twitter'
+        }
+      }
+    ]
+
+    expect(
+      extractAgentSourceRefs(
+        'vault_search_notes',
+        {},
+        {
+          content: [{ type: 'text', text: JSON.stringify(noteResult) }]
+        }
+      )
+    ).toEqual([
+      {
+        kind: 'note',
+        id: 'note-1',
+        title: 'Movies',
+        href: 'memry://note/note-1',
+        icon: '🎬'
+      }
+    ])
+
+    expect(
+      extractAgentSourceRefs(
+        'vault_list_inbox_items',
+        {},
+        {
+          content: [{ type: 'text', text: JSON.stringify(inboxResult) }]
+        }
+      )
+    ).toEqual([
+      {
+        kind: 'inbox',
+        id: 'inbox-1',
+        title: 'Tweet',
+        href: 'memry://inbox/inbox-1',
+        itemType: 'social',
+        visualType: 'twitter'
+      }
+    ])
+  })
+
   it('extracts calendar event refs from desktop calendar range results', () => {
     const refs = extractAgentSourceRefs(
       'vault_desktop_read',

--- a/apps/desktop/src/main/agent/source-refs.ts
+++ b/apps/desktop/src/main/agent/source-refs.ts
@@ -1,6 +1,11 @@
 import type { AgentSourceKind, AgentSourceRef } from '@memry/contracts/ipc-agent'
 
 type JsonRecord = Record<string, unknown>
+type SourceRefMeta = {
+  icon?: string | null
+  itemType?: string | null
+  visualType?: string | null
+}
 
 export function extractAgentSourceRefs(
   toolName: string,
@@ -8,19 +13,20 @@ export function extractAgentSourceRefs(
   result: unknown
 ): AgentSourceRef[] {
   const normalizedToolName = normalizeToolName(toolName)
+  const resultPayloads = toolResultPayloads(result)
   const refs: AgentSourceRef[] = []
-  refs.push(...extractExistingRefs(result))
+  for (const payload of resultPayloads) refs.push(...extractExistingRefs(payload))
 
   switch (normalizedToolName) {
     case 'vault_search_notes':
-      refs.push(...refsFromArray(result, noteRefFromRecord))
+      refs.push(...refsFromPayloadArrays(resultPayloads, noteRefFromRecord))
       break
     case 'vault_read_note':
     case 'vault_get_current_note':
-      refs.push(...maybeRef(result, noteRefFromRecord))
+      refs.push(...maybeRefFromPayloads(resultPayloads, noteRefFromRecord))
       break
     case 'vault_list_folder':
-      refs.push(...refsFromArray(result, folderEntryRefFromRecord))
+      refs.push(...refsFromPayloadArrays(resultPayloads, folderEntryRefFromRecord))
       break
     case 'vault_create_note':
     case 'vault_rename_note':
@@ -28,17 +34,17 @@ export function extractAgentSourceRefs(
     case 'vault_add_note_tag':
     case 'vault_remove_note_tag':
     case 'vault_move_to_folder':
-      refs.push(...maybeRefFromResultAndArgs(result, args, 'note'))
+      refs.push(...refsFromPayloadsAndArgs(resultPayloads, args, 'note'))
       break
     case 'vault_create_folder':
     case 'vault_rename_folder':
-      refs.push(...maybeRefFromResultAndArgs(result, args, 'folder'))
+      refs.push(...refsFromPayloadsAndArgs(resultPayloads, args, 'folder'))
       break
     case 'vault_list_tasks':
-      refs.push(...refsFromArray(result, taskRefFromRecord))
+      refs.push(...refsFromPayloadArrays(resultPayloads, taskRefFromRecord))
       break
     case 'vault_get_task':
-      refs.push(...maybeRef(result, taskRefFromRecord))
+      refs.push(...maybeRefFromPayloads(resultPayloads, taskRefFromRecord))
       break
     case 'vault_create_task':
     case 'vault_update_task':
@@ -52,34 +58,34 @@ export function extractAgentSourceRefs(
     case 'vault_convert_subtask_to_task':
     case 'vault_add_task_tag':
     case 'vault_remove_task_tag':
-      refs.push(...maybeRefFromResultAndArgs(result, args, 'task'))
+      refs.push(...refsFromPayloadsAndArgs(resultPayloads, args, 'task'))
       break
     case 'vault_list_projects':
-      refs.push(...refsFromArray(result, projectRefFromRecord))
+      refs.push(...refsFromPayloadArrays(resultPayloads, projectRefFromRecord))
       break
     case 'vault_get_project':
-      refs.push(...maybeRef(result, projectRefFromRecord))
+      refs.push(...maybeRefFromPayloads(resultPayloads, projectRefFromRecord))
       break
     case 'vault_create_project':
     case 'vault_update_project':
     case 'vault_archive_project':
-      refs.push(...maybeRefFromResultAndArgs(result, args, 'project'))
+      refs.push(...refsFromPayloadsAndArgs(resultPayloads, args, 'project'))
       break
     case 'vault_get_journal_entry':
-      refs.push(...maybeRef(result, journalRefFromRecord))
+      refs.push(...maybeRefFromPayloads(resultPayloads, journalRefFromRecord))
       break
     case 'vault_list_journal_entries':
-      refs.push(...refsFromArray(result, journalRefFromRecord))
+      refs.push(...refsFromPayloadArrays(resultPayloads, journalRefFromRecord))
       break
     case 'vault_create_journal_entry':
     case 'vault_update_journal_entry':
-      refs.push(...maybeRefFromResultAndArgs(result, args, 'journal'))
+      refs.push(...refsFromPayloadsAndArgs(resultPayloads, args, 'journal'))
       break
     case 'vault_list_inbox_items':
-      refs.push(...refsFromArray(result, inboxRefFromRecord))
+      refs.push(...refsFromPayloadArrays(resultPayloads, inboxRefFromRecord))
       break
     case 'vault_get_inbox_item':
-      refs.push(...maybeRef(result, inboxRefFromRecord))
+      refs.push(...maybeRefFromPayloads(resultPayloads, inboxRefFromRecord))
       break
     case 'vault_add_to_inbox':
     case 'vault_update_inbox_item':
@@ -87,11 +93,11 @@ export function extractAgentSourceRefs(
     case 'vault_unarchive_inbox_item':
     case 'vault_add_inbox_tag':
     case 'vault_remove_inbox_tag':
-      refs.push(...maybeRefFromResultAndArgs(result, args, 'inbox'))
+      refs.push(...refsFromPayloadsAndArgs(resultPayloads, args, 'inbox'))
       break
     case 'vault_desktop_read':
     case 'vault_desktop_write':
-      refs.push(...desktopOperationRefs(args, result))
+      for (const payload of resultPayloads) refs.push(...desktopOperationRefs(args, payload))
       break
   }
 
@@ -165,6 +171,13 @@ function refsFromArray(
   return value.flatMap((item) => maybeRef(item, factory))
 }
 
+function refsFromPayloadArrays(
+  payloads: unknown[],
+  factory: (record: JsonRecord) => AgentSourceRef | null
+): AgentSourceRef[] {
+  return payloads.flatMap((payload) => refsFromArray(payload, factory))
+}
+
 function maybeRef(
   value: unknown,
   factory: (record: JsonRecord) => AgentSourceRef | null
@@ -172,6 +185,21 @@ function maybeRef(
   if (!isRecord(value)) return []
   const ref = factory(value)
   return ref ? [ref] : []
+}
+
+function maybeRefFromPayloads(
+  payloads: unknown[],
+  factory: (record: JsonRecord) => AgentSourceRef | null
+): AgentSourceRef[] {
+  return payloads.flatMap((payload) => maybeRef(payload, factory))
+}
+
+function refsFromPayloadsAndArgs(
+  payloads: unknown[],
+  args: unknown,
+  kind: AgentSourceKind
+): AgentSourceRef[] {
+  return payloads.flatMap((payload) => maybeRefFromResultAndArgs(payload, args, kind))
 }
 
 function maybeRefFromResultAndArgs(
@@ -212,28 +240,41 @@ function noteRefFromRecord(record: JsonRecord): AgentSourceRef | null {
   const id = firstString(record.id)
   const title = firstString(record.title, record.name)
   if (!id || !title) return null
-  return buildRef('note', id, title)
+  return buildRef('note', id, title, { icon: noteIconFromRecord(record) })
 }
 
 function taskRefFromRecord(record: JsonRecord): AgentSourceRef | null {
   const id = firstString(record.id, record.sourceId)
   const title = firstString(record.title, record.name)
   if (!id || !title) return null
-  return buildRef('task', id, title)
+  return buildRef('task', id, title, { visualType: firstString(record.visualType) })
 }
 
 function inboxRefFromRecord(record: JsonRecord): AgentSourceRef | null {
   const id = firstString(record.id, record.sourceId)
   const title = firstString(record.title, record.name)
   if (!id || !title) return null
-  return buildRef('inbox', id, title)
+  const metadata: JsonRecord = isRecord(record.metadata) ? record.metadata : {}
+  const directType = firstString(record.itemType, record.item_type, metadata.itemType)
+  const recordType = firstString(record.type)
+  const itemType = directType ?? (recordType && recordType !== 'inbox' ? recordType : null)
+  return buildRef('inbox', id, title, {
+    itemType,
+    visualType:
+      firstString(
+        record.visualType,
+        record.visual_type,
+        metadata.visualType,
+        metadata.visual_type
+      ) ?? inboxVisualTypeFromRecord(record, metadata, itemType)
+  })
 }
 
 function projectRefFromRecord(record: JsonRecord): AgentSourceRef | null {
   const id = firstString(record.id)
   const title = firstString(record.name, record.title)
   if (!id || !title) return null
-  return buildRef('project', id, title)
+  return buildRef('project', id, title, { icon: firstString(record.icon) })
 }
 
 function folderEntryRefFromRecord(record: JsonRecord): AgentSourceRef | null {
@@ -287,7 +328,7 @@ function desktopOperationRefs(args: unknown, result: unknown): AgentSourceRef[] 
     const title = firstString(result.title, firstArg.title)
     const startAt = firstString(result.startAt, firstArg.startAt)
     if (!id || !title || !startAt) return []
-    return [buildCalendarEventRef(id, title, dateFromIso(startAt))]
+    return [buildCalendarEventRef(id, title, dateFromIso(startAt), firstString(result.visualType))]
   }
 
   if (operation === 'calendar.promoteExternalEvent' && isRecord(result)) {
@@ -302,7 +343,7 @@ function calendarEventRefFromRecord(record: JsonRecord): AgentSourceRef | null {
   const title = firstString(record.title)
   const startAt = firstString(record.startAt)
   if (!id || !title || !startAt) return null
-  return buildCalendarEventRef(id, title, dateFromIso(startAt))
+  return buildCalendarEventRef(id, title, dateFromIso(startAt), firstString(record.visualType))
 }
 
 function calendarProjectionRefFromRecord(record: JsonRecord): AgentSourceRef | null {
@@ -310,24 +351,36 @@ function calendarProjectionRefFromRecord(record: JsonRecord): AgentSourceRef | n
   const title = firstString(record.title)
   const startAt = firstString(record.startAt)
   if (!id || !title || !startAt) return null
-  return buildCalendarEventRef(id, title, dateFromIso(startAt))
+  return buildCalendarEventRef(id, title, dateFromIso(startAt), firstString(record.visualType))
 }
 
-function buildRef(kind: AgentSourceKind, id: string, title: string): AgentSourceRef {
+function buildRef(
+  kind: AgentSourceKind,
+  id: string,
+  title: string,
+  meta: SourceRefMeta = {}
+): AgentSourceRef {
   return {
     kind,
     id,
     title,
-    href: `memry://${hrefPathForKind(kind, id)}`
+    href: `memry://${hrefPathForKind(kind, id)}`,
+    ...sourceMeta(meta)
   }
 }
 
-function buildCalendarEventRef(id: string, title: string, date: string): AgentSourceRef {
+function buildCalendarEventRef(
+  id: string,
+  title: string,
+  date: string,
+  visualType?: string | null
+): AgentSourceRef {
   return {
     kind: 'calendar_event',
     id,
     title,
-    href: `memry://calendar/event/${encodeURIComponent(id)}?date=${encodeURIComponent(date)}`
+    href: `memry://calendar/event/${encodeURIComponent(id)}?date=${encodeURIComponent(date)}`,
+    ...sourceMeta({ visualType })
   }
 }
 
@@ -366,7 +419,17 @@ function parseSourceRef(value: JsonRecord): AgentSourceRef | null {
   const href = firstString(value.href)
   if (!kind || !id || !title || !href) return null
   if (!isAgentSourceKind(kind)) return null
-  return { kind, id, title, href }
+  return {
+    kind,
+    id,
+    title,
+    href,
+    ...sourceMeta({
+      icon: firstString(value.icon),
+      itemType: firstString(value.itemType),
+      visualType: firstString(value.visualType)
+    })
+  }
 }
 
 function isAgentSourceKind(kind: string): kind is AgentSourceKind {
@@ -401,4 +464,89 @@ function firstString(...values: unknown[]): string | null {
 
 function isRecord(value: unknown): value is JsonRecord {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function noteIconFromRecord(record: JsonRecord): string | null {
+  const metadata: JsonRecord = isRecord(record.metadata) ? record.metadata : {}
+  const frontmatter: JsonRecord = isRecord(record.frontmatter) ? record.frontmatter : {}
+  return firstString(record.icon, record.emoji, metadata.emoji, frontmatter.emoji, frontmatter.icon)
+}
+
+function sourceMeta(
+  meta: SourceRefMeta
+): Partial<Pick<AgentSourceRef, 'icon' | 'itemType' | 'visualType'>> {
+  return {
+    ...(meta.icon ? { icon: meta.icon } : {}),
+    ...(meta.itemType ? { itemType: meta.itemType } : {}),
+    ...(meta.visualType ? { visualType: meta.visualType } : {})
+  }
+}
+
+function toolResultPayloads(result: unknown): unknown[] {
+  const payloads: unknown[] = [result]
+  if (!isRecord(result)) return payloads
+
+  if ('structuredContent' in result) {
+    const structuredContent = result.structuredContent
+    payloads.push(structuredContent)
+    if (isRecord(structuredContent) && 'result' in structuredContent) {
+      payloads.push(structuredContent.result)
+    }
+  }
+
+  const content = result.content
+  if (Array.isArray(content)) {
+    for (const entry of content) {
+      if (!isRecord(entry) || typeof entry.text !== 'string') continue
+      const parsed = parseJson(entry.text)
+      if (parsed !== undefined) payloads.push(parsed)
+    }
+  }
+
+  return payloads
+}
+
+function parseJson(value: string): unknown | undefined {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return undefined
+  }
+}
+
+function inboxVisualTypeFromRecord(
+  record: JsonRecord,
+  metadata: JsonRecord,
+  itemType: string | null
+): string | null {
+  if (itemType === 'clip') return 'quote'
+
+  const platform = firstString(metadata.platform)
+  if (itemType === 'social' && platform === 'twitter') return 'twitter'
+
+  const sourceUrl = firstString(
+    record.sourceUrl,
+    record.source_url,
+    record.source,
+    metadata.postUrl
+  )
+  if ((itemType === 'social' || itemType === 'link') && sourceUrl && isTwitterUrl(sourceUrl)) {
+    return 'twitter'
+  }
+
+  return itemType === 'social' ? 'social' : null
+}
+
+function isTwitterUrl(value: string): boolean {
+  try {
+    const host = new URL(value).hostname.toLowerCase()
+    return (
+      host === 'x.com' ||
+      host.endsWith('.x.com') ||
+      host === 'twitter.com' ||
+      host.endsWith('.twitter.com')
+    )
+  } catch {
+    return false
+  }
 }

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
@@ -162,7 +162,8 @@ describe('MessageStream', () => {
                     kind: 'note',
                     id: 'note-1',
                     title: 'Movies',
-                    href: 'memry://note/note-1'
+                    href: 'memry://note/note-1',
+                    icon: '🎬'
                   }
                 ]
               }
@@ -176,6 +177,8 @@ describe('MessageStream', () => {
     expect(link).toHaveAttribute('href', 'memry://note/note-1')
     expect(link).toHaveClass('text-[#81B4E5]')
     expect(link).toHaveClass('hover:decoration-dotted')
+    expect(link).toHaveTextContent('🎬Movies')
+    expect(link.querySelector('[data-agent-link-icon="note-custom"]')).not.toBeNull()
     const sourcesTrigger = screen.getByRole('button', { name: /Used 1 source/i })
     expect(sourcesTrigger).toBeInTheDocument()
 
@@ -192,6 +195,172 @@ describe('MessageStream', () => {
 
     fireEvent.click(sourcesTrigger)
     expect(screen.getAllByRole('link', { name: 'Movies' })).toHaveLength(2)
+    expect(
+      screen
+        .getAllByRole('link', { name: 'Movies' })[1]
+        ?.querySelector('[data-agent-link-icon="note-custom"]')
+    ).not.toBeNull()
+  })
+
+  it('repaints live Memry links when source metadata arrives after the text', () => {
+    const assistantWithoutSources = message({
+      id: 'assistant-1',
+      role: 'assistant',
+      content: {
+        role: 'assistant',
+        data: { text: 'See [Movies](memry://note/note-1).' }
+      }
+    })
+    const assistantWithSources = message({
+      id: 'assistant-1',
+      role: 'assistant',
+      content: {
+        role: 'assistant',
+        data: {
+          text: 'See [Movies](memry://note/note-1).',
+          sources: [
+            {
+              kind: 'note',
+              id: 'note-1',
+              title: 'Movies',
+              href: 'memry://note/note-1',
+              icon: '🎬'
+            }
+          ]
+        }
+      }
+    })
+
+    const { rerender } = render(<MessageStream messages={[assistantWithoutSources]} />)
+
+    expect(
+      screen
+        .getByRole('link', { name: 'Movies' })
+        .querySelector('[data-agent-link-icon="note-default"]')
+    ).not.toBeNull()
+
+    rerender(<MessageStream messages={[assistantWithSources]} />)
+
+    const link = screen.getByRole('link', { name: 'Movies' })
+    expect(link.querySelector('[data-agent-link-icon="note-custom"]')).not.toBeNull()
+    expect(link.querySelector('[data-agent-link-icon="note-default"]')).toBeNull()
+  })
+
+  it('uses the source icon instead of duplicating a provider-emitted note icon label', () => {
+    render(
+      <MessageStream
+        messages={[
+          message({
+            id: 'assistant-1',
+            role: 'assistant',
+            content: {
+              role: 'assistant',
+              data: {
+                text: 'See [🎬 Movies](memry://note/note-1).',
+                sources: [
+                  {
+                    kind: 'note',
+                    id: 'note-1',
+                    title: 'Movies',
+                    href: 'memry://note/note-1',
+                    icon: '🎬'
+                  }
+                ]
+              }
+            }
+          })
+        ]}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'Movies' })
+    expect(link.querySelector('[data-agent-link-icon="note-custom"]')).not.toBeNull()
+    expect(link.querySelector('[data-agent-link-label]')).toHaveTextContent('Movies')
+  })
+
+  it('renders item-type icons for non-note Memry links', () => {
+    render(
+      <MessageStream
+        messages={[
+          message({
+            id: 'assistant-1',
+            role: 'assistant',
+            content: {
+              role: 'assistant',
+              data: {
+                text: [
+                  '[Spec](memry://inbox/inbox-1)',
+                  '[Tweet](memry://inbox/inbox-2)',
+                  '[Quote](memry://inbox/inbox-3)',
+                  '[Today](memry://journal/2026-05-13)',
+                  '[Planning](memry://calendar/event/event-1?date=2026-05-13)'
+                ].join(' '),
+                sources: [
+                  {
+                    kind: 'inbox',
+                    id: 'inbox-1',
+                    title: 'Spec',
+                    href: 'memry://inbox/inbox-1',
+                    itemType: 'pdf'
+                  },
+                  {
+                    kind: 'inbox',
+                    id: 'inbox-2',
+                    title: 'Tweet',
+                    href: 'memry://inbox/inbox-2',
+                    itemType: 'social',
+                    visualType: 'twitter'
+                  },
+                  {
+                    kind: 'inbox',
+                    id: 'inbox-3',
+                    title: 'Quote',
+                    href: 'memry://inbox/inbox-3',
+                    itemType: 'clip',
+                    visualType: 'quote'
+                  },
+                  {
+                    kind: 'journal',
+                    id: '2026-05-13',
+                    title: 'Today',
+                    href: 'memry://journal/2026-05-13'
+                  },
+                  {
+                    kind: 'calendar_event',
+                    id: 'event-1',
+                    title: 'Planning',
+                    href: 'memry://calendar/event/event-1?date=2026-05-13',
+                    visualType: 'event'
+                  }
+                ]
+              }
+            }
+          })
+        ]}
+      />
+    )
+
+    expect(
+      screen.getByRole('link', { name: 'Spec' }).querySelector('[data-agent-link-icon="inbox-pdf"]')
+    ).not.toBeNull()
+    expect(
+      screen
+        .getByRole('link', { name: 'Tweet' })
+        .querySelector('[data-agent-link-icon="inbox-twitter"]')
+    ).not.toBeNull()
+    expect(
+      screen
+        .getByRole('link', { name: 'Quote' })
+        .querySelector('[data-agent-link-icon="inbox-quote"]')
+    ).not.toBeNull()
+    expect(
+      screen.getByRole('link', { name: 'Today' }).querySelector('[data-agent-link-icon="journal"]')
+    ).not.toBeNull()
+    expect(
+      screen
+        .getByRole('link', { name: 'Planning' })
+        .querySelector('[data-agent-link-icon="calendar-event"]')
+    ).not.toBeNull()
   })
 
   it('omits the assistant sources footer when no Memry refs exist', () => {

--- a/apps/desktop/src/renderer/src/agent-chat/messages/assistant-message.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/messages/assistant-message.tsx
@@ -1,5 +1,7 @@
 import type { Message } from '@memry/contracts/ipc-agent'
 import type { AgentSourceRef } from '@memry/contracts/ipc-agent'
+import type { ComponentProps } from 'react'
+import { useMemo } from 'react'
 import { useT } from '@memry/i18n/renderer'
 
 import {
@@ -9,14 +11,37 @@ import {
 } from '@/components/ai-elements/message'
 import { Source, Sources, SourcesContent, SourcesTrigger } from '@/components/ai-elements/sources'
 import { cn } from '@/lib/utils'
-import { MemryLink, memryLinkClassName, useMemryLinkNavigation } from './memry-links'
+import { MemryLink, MemryLinkIcon, memryLinkClassName, useMemryLinkNavigation } from './memry-links'
 
-const markdownComponents = { a: MemryLink }
+type AssistantMessageModel = Message & {
+  content: Extract<Message['content'], { role: 'assistant' }>
+}
 
 export function AssistantMessage({ message }: { message: Message }): React.JSX.Element | null {
-  const { t } = useT('common')
   if (message.content.role !== 'assistant') return null
-  const sources = uniqueSources(message.content.data.sources)
+  return <AssistantMessageContent message={message as AssistantMessageModel} />
+}
+
+function AssistantMessageContent({
+  message
+}: {
+  message: AssistantMessageModel
+}): React.JSX.Element {
+  const { t } = useT('common')
+  const sourceRefs = 'sources' in message.content.data ? message.content.data.sources : undefined
+  const sources = useMemo(() => uniqueSources(sourceRefs), [sourceRefs])
+  const sourceSignature = useMemo(() => signatureForSources(sources), [sources])
+  const markdownComponents = useMemo(() => {
+    const sourceByHref = new Map(sources.map((source) => [source.href, source]))
+    return {
+      a: (props: ComponentProps<'a'>) => (
+        <MemryLink
+          {...props}
+          source={typeof props.href === 'string' ? sourceByHref.get(props.href) : null}
+        />
+      )
+    }
+  }, [sources])
 
   if (message.status === 'streaming' && message.content.data.text.trim().length === 0) {
     return (
@@ -39,7 +64,7 @@ export function AssistantMessage({ message }: { message: Message }): React.JSX.E
   return (
     <AIMessage from="assistant" className="max-w-full">
       <MessageContent className="w-full max-w-none overflow-visible rounded-none border-0 bg-transparent px-3 py-0">
-        <MessageResponse components={markdownComponents}>
+        <MessageResponse key={sourceSignature} components={markdownComponents}>
           {message.content.data.text}
         </MessageResponse>
         {sources.length > 0 && <AssistantSources sources={sources} />}
@@ -73,7 +98,10 @@ function AssistantSources({ sources }: { sources: AgentSourceRef[] }): React.JSX
               navigateMemryLink(source.href, source.title)
             }}
             title={source.title}
-          />
+          >
+            <MemryLinkIcon href={source.href} source={source} />
+            <span className="block font-medium">{source.title}</span>
+          </Source>
         ))}
       </SourcesContent>
     </Sources>
@@ -90,4 +118,13 @@ function uniqueSources(sources: AgentSourceRef[] | undefined): AgentSourceRef[] 
     result.push(source)
   }
   return result
+}
+
+function signatureForSources(sources: AgentSourceRef[]): string {
+  return sources
+    .map(
+      (source) =>
+        `${source.href}:${source.icon ?? ''}:${source.itemType ?? ''}:${source.visualType ?? ''}`
+    )
+    .join('\u0000')
 }

--- a/apps/desktop/src/renderer/src/agent-chat/messages/memry-links.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/messages/memry-links.tsx
@@ -1,9 +1,30 @@
-import type { ComponentProps, MouseEvent, ReactNode } from 'react'
+import type { ComponentProps, ComponentType, MouseEvent } from 'react'
 import { useCallback } from 'react'
 
+import type { AgentSourceRef } from '@memry/contracts/ipc-agent'
+import type { InboxItemType } from '@memry/contracts/inbox-api'
 import type { Tab } from '@/contexts/tabs/types'
 import { useTabActions } from '@/contexts/tabs'
 import { cn } from '@/lib/utils'
+import { NoteIconDisplay } from '@/lib/render-note-icon'
+import {
+  AlarmClock,
+  Bell,
+  Calendar2,
+  CheckSquare3,
+  FilePdf,
+  FileText,
+  Folder,
+  Image,
+  Link2,
+  Mic,
+  MessageCircle,
+  NotificationSnooze,
+  Quote,
+  Share2,
+  Video
+} from '@/lib/icons'
+import { SidebarCalendar, SidebarJournal, SidebarTasks } from '@/lib/icons/sidebar-nav-icons'
 
 const memryLinkClassName =
   'text-[#81B4E5] hover:underline hover:decoration-dotted underline-offset-2'
@@ -28,29 +49,184 @@ export function MemryLink({
   className,
   href,
   children,
+  source,
   onClick,
   ...props
-}: ComponentProps<'a'>): React.JSX.Element {
+}: ComponentProps<'a'> & { source?: AgentSourceRef | null }): React.JSX.Element {
   const navigate = useMemryLinkNavigation()
   const isMemryLink = typeof href === 'string' && href.startsWith('memry://')
+  const labelChildren = isMemryLink && source?.title ? source.title : children
 
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     onClick?.(event)
     if (event.defaultPrevented || !isMemryLink || typeof href !== 'string') return
 
     event.preventDefault()
-    navigate(href, textFromChildren(children))
+    navigate(href, source?.title ?? textFromLink(event.currentTarget))
   }
 
   return (
     <a
-      className={cn(isMemryLink && memryLinkClassName, className)}
+      className={cn(
+        isMemryLink && memryLinkClassName,
+        isMemryLink && 'inline-flex items-baseline gap-1',
+        className
+      )}
       href={href}
       onClick={handleClick}
       {...props}
     >
-      {children}
+      {isMemryLink ? (
+        <>
+          <MemryLinkIcon href={href} source={source} />
+          <span data-agent-link-label>{labelChildren}</span>
+        </>
+      ) : (
+        children
+      )}
     </a>
+  )
+}
+
+type LinkIconComponent = ComponentType<{ className?: string }>
+type LinkIconDescriptor =
+  | { kind: 'component'; label: string; Icon: LinkIconComponent }
+  | { kind: 'note'; label: string; noteIcon: string }
+  | { kind: 'glyph'; label: string; glyph: string }
+
+const INBOX_TYPE_ICONS: Record<InboxItemType, LinkIconComponent> = {
+  link: Link2,
+  note: FileText,
+  image: Image,
+  voice: Mic,
+  video: Video,
+  clip: Quote,
+  pdf: FilePdf,
+  social: Share2,
+  reminder: Bell
+}
+
+const INBOX_VISUAL_TYPE_ICONS: Record<string, LinkIconComponent> = {
+  quote: Quote,
+  social: MessageCircle
+}
+
+const CALENDAR_VISUAL_TYPE_ICONS: Record<string, LinkIconComponent> = {
+  event: Calendar2,
+  external_event: Calendar2,
+  task: CheckSquare3,
+  reminder: AlarmClock,
+  snooze: NotificationSnooze
+}
+
+function resolveMemryLinkIcon(
+  href?: string,
+  source?: AgentSourceRef | null
+): LinkIconDescriptor | null {
+  const parsed = typeof href === 'string' ? parseMemryHref(href) : null
+  const kind = source?.kind ?? parsed?.kind
+  if (!kind) return null
+
+  if (kind === 'note') {
+    return source?.icon
+      ? { kind: 'note', label: 'note-custom', noteIcon: source.icon }
+      : { kind: 'component', label: 'note-default', Icon: FileText }
+  }
+
+  if (kind === 'task') return { kind: 'component', label: 'task', Icon: SidebarTasks }
+
+  if (kind === 'inbox') {
+    const visualIcon = iconForCalendarVisualType(source?.visualType)
+    if (visualIcon) {
+      return { kind: 'component', label: `calendar-${source?.visualType}`, Icon: visualIcon }
+    }
+
+    if (source?.visualType === 'twitter') {
+      return { kind: 'glyph', label: 'inbox-twitter', glyph: 'X' }
+    }
+
+    const inboxVisualIcon = iconForInboxVisualType(source?.visualType)
+    if (inboxVisualIcon) {
+      return {
+        kind: 'component',
+        label: `inbox-${source?.visualType}`,
+        Icon: inboxVisualIcon
+      }
+    }
+
+    const inboxIcon = iconForInboxType(source?.itemType)
+    return {
+      kind: 'component',
+      label: `inbox-${source?.itemType ?? 'default'}`,
+      Icon: inboxIcon
+    }
+  }
+
+  if (kind === 'journal') return { kind: 'component', label: 'journal', Icon: SidebarJournal }
+
+  if (kind === 'calendar_event') {
+    return {
+      kind: 'component',
+      label: `calendar-${source?.visualType ?? 'event'}`,
+      Icon: iconForCalendarVisualType(source?.visualType) ?? SidebarCalendar
+    }
+  }
+
+  if (kind === 'project' || kind === 'folder') {
+    return { kind: 'component', label: kind, Icon: Folder }
+  }
+
+  return null
+}
+
+function iconForInboxType(value: string | undefined): LinkIconComponent {
+  return isInboxItemType(value) ? INBOX_TYPE_ICONS[value] : FileText
+}
+
+function iconForInboxVisualType(value: string | undefined): LinkIconComponent | null {
+  return value ? (INBOX_VISUAL_TYPE_ICONS[value] ?? null) : null
+}
+
+function isInboxItemType(value: string | undefined): value is InboxItemType {
+  return Boolean(value && value in INBOX_TYPE_ICONS)
+}
+
+function iconForCalendarVisualType(value: string | undefined): LinkIconComponent | null {
+  return value ? (CALENDAR_VISUAL_TYPE_ICONS[value] ?? null) : null
+}
+
+export function MemryLinkIcon({
+  href,
+  source,
+  className
+}: {
+  href?: string
+  source?: AgentSourceRef | null
+  className?: string
+}): React.JSX.Element | null {
+  const resolved = resolveMemryLinkIcon(href, source)
+  if (!resolved) return null
+  const iconClassName = cn('size-3.5 shrink-0', className)
+
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-flex shrink-0 items-center justify-center align-[-0.125em]"
+      data-agent-link-icon={resolved.label}
+    >
+      {resolved.kind === 'note' ? (
+        <NoteIconDisplay
+          value={resolved.noteIcon}
+          className={cn(iconClassName, 'text-[0.8125rem]')}
+        />
+      ) : resolved.kind === 'glyph' ? (
+        <span className={cn(iconClassName, 'font-heading text-[0.75rem] font-bold leading-none')}>
+          {resolved.glyph}
+        </span>
+      ) : (
+        <resolved.Icon className={iconClassName} />
+      )}
+    </span>
   )
 }
 
@@ -191,17 +367,8 @@ function parseMemryHref(href: string): ParsedMemryHref | null {
   return null
 }
 
-function textFromChildren(children: ReactNode): string | undefined {
-  if (typeof children === 'string') return children
-  if (typeof children === 'number') return String(children)
-  if (!Array.isArray(children)) return undefined
-
-  const text = children
-    .map((child) => textFromChildren(child))
-    .filter((value): value is string => Boolean(value))
-    .join('')
-    .trim()
-
+function textFromLink(link: HTMLAnchorElement): string | undefined {
+  const text = link.querySelector('[data-agent-link-label]')?.textContent?.trim()
   return text || undefined
 }
 

--- a/apps/desktop/src/renderer/src/components/ai-elements/message.tsx
+++ b/apps/desktop/src/renderer/src/components/ai-elements/message.tsx
@@ -96,7 +96,9 @@ export const MessageResponse = memo(
   ),
   (previousProps, nextProps) =>
     previousProps.children === nextProps.children &&
-    previousProps.isAnimating === nextProps.isAnimating
+    previousProps.isAnimating === nextProps.isAnimating &&
+    previousProps.className === nextProps.className &&
+    previousProps.components === nextProps.components
 )
 
 MessageResponse.displayName = 'MessageResponse'

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -49,8 +49,10 @@ also link the affected item when the tool returns its ID or journal date. The re
 collapsible Sources section only when the assistant message contains those Memry item links.
 
 Memry only links explicit tool-provided references. Plain titles without an ID or date stay as
-normal text. Clickable item mentions use Memry's standard link color and show a dotted underline on
-hover.
+normal text. Clickable item mentions use Memry's standard link color, show a dotted underline on
+hover, and display the matching item icon before the title. Notes use their custom note icon when
+one exists, inbox items use their capture-type icon, and journal, calendar, and task links use the
+same visual language as the main app surfaces.
 
 Press <kbd>Enter</kbd> to send the prompt. Press <kbd>Shift</kbd>+<kbd>Enter</kbd> to insert a
 new line in the prompt box.

--- a/packages/contracts/src/ipc-agent.test.ts
+++ b/packages/contracts/src/ipc-agent.test.ts
@@ -296,7 +296,22 @@ describe('agent IPC schemas', () => {
               kind: 'note',
               id: 'note-1',
               title: 'Movies',
-              href: 'memry://note/note-1'
+              href: 'memry://note/note-1',
+              icon: '🎬'
+            },
+            {
+              kind: 'inbox',
+              id: 'inbox-1',
+              title: 'Inbox PDF',
+              href: 'memry://inbox/inbox-1',
+              itemType: 'pdf'
+            },
+            {
+              kind: 'calendar_event',
+              id: 'event-1',
+              title: 'Planning',
+              href: 'memry://calendar/event/event-1?date=2026-05-13',
+              visualType: 'event'
             }
           ]
         }

--- a/packages/contracts/src/ipc-agent.ts
+++ b/packages/contracts/src/ipc-agent.ts
@@ -221,7 +221,10 @@ export const AgentSourceRefSchema = z
     kind: AgentSourceKindSchema,
     id: z.string().min(1),
     title: z.string().min(1),
-    href: z.string().min(1)
+    href: z.string().min(1),
+    icon: z.string().min(1).nullable().optional(),
+    itemType: z.string().min(1).optional(),
+    visualType: z.string().min(1).optional()
   })
   .strict()
 export type AgentSourceRef = z.infer<typeof AgentSourceRefSchema>


### PR DESCRIPTION
## Summary
- Render source-aware icons beside Agent Chat Memry links and source footer rows.
- Preserve note icons, inbox item type/visual metadata, calendar item visuals, and journal/task/sidebar-style icons across MCP results.
- Repaint live assistant markdown when source metadata arrives after streamed text, and avoid duplicated provider-emitted note emoji labels.
- Document Agent Chat item-link icons in the user guide.

## Root Cause
Live assistant text could render before final `sources` metadata was attached, so inline links initially used fallback icons. Reopening history worked because persisted messages already included sources on first render. Claude could also include the note emoji in the markdown label, which made the rendered icon plus label emoji look duplicated.

## Verification
- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts src/main/agent/source-refs.test.ts src/main/agent/mcp/tools/handles-adapter.test.ts src/main/agent/runtime/__tests__/turn.test.ts src/renderer/src/agent-chat/__tests__/message-stream.test.tsx`
- `pnpm --dir packages/contracts exec vitest run src/ipc-agent.test.ts`
- `pnpm --dir packages/contracts typecheck`
- `pnpm --dir apps/desktop typecheck:node`
- `pnpm --dir apps/desktop typecheck:web`
- `pnpm --dir apps/desktop ipc:check`
- `pnpm docs:impact --base dce7a206c75a0a7db46985ee743e0cb55e20dbe1 --strict`
- `pnpm docs:build`
- `npx -y react-doctor@latest . --verbose --diff`
- `git diff --check`
