### PR TITLE
fix: normalize calendar MCP desktop read args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-05-14 — Agent Calendar MCP Reads
+
+### Fixed
+
+- Fix Agent calendar desktop reads so provider status, event lists, and date ranges accept common MCP argument shapes.
+
+---
+
 ## 2026-05-14 — Voice Memos and Related Items
 
 ### Added

--- a/apps/desktop/src/main/agent/mcp/tools/schemas.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/schemas.ts
@@ -150,7 +150,11 @@ export const TOOL_SCHEMAS = {
   },
   vault_desktop_read: {
     input: desktopReadSchema,
-    description: 'Run an allowlisted read-only desktop API operation through the Memry window.'
+    description:
+      'Run an allowlisted read-only desktop API operation through the Memry window. ' +
+      'Calendar examples: calendar.getProviderStatus with args [{"provider":"google"}], ' +
+      'calendar.listEvents with args [{}], calendar.getRange with args ' +
+      '[{"startAt":"2026-05-14T00:00:00.000Z","endAt":"2026-06-15T00:00:00.000Z"}].'
   },
   vault_create_note: {
     input: z.object({

--- a/apps/desktop/src/renderer/src/agent-mcp/desktop-api-handler.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-mcp/desktop-api-handler.test.tsx
@@ -21,6 +21,9 @@ describe('useAgentMcpDesktopApiResponder', () => {
   let respondToMainInvoke: ReturnType<typeof vi.fn>
   let templatesList: ReturnType<typeof vi.fn>
   let templatesCreate: ReturnType<typeof vi.fn>
+  let calendarGetProviderStatus: ReturnType<typeof vi.fn>
+  let calendarGetRange: ReturnType<typeof vi.fn>
+  let calendarListEvents: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     onMainInvokeCallback = undefined
@@ -30,6 +33,9 @@ describe('useAgentMcpDesktopApiResponder', () => {
       success: true,
       template: { id: 'template-1', name: 'Template' }
     })
+    calendarGetProviderStatus = vi.fn().mockResolvedValue({ connected: true })
+    calendarGetRange = vi.fn().mockResolvedValue({ items: [] })
+    calendarListEvents = vi.fn().mockResolvedValue({ events: [] })
     mocks.logError.mockReset()
     ;(window as Window & { api: unknown }).api = {
       onMainInvoke: vi.fn(
@@ -48,6 +54,11 @@ describe('useAgentMcpDesktopApiResponder', () => {
       templates: {
         list: templatesList,
         create: templatesCreate
+      },
+      calendar: {
+        getProviderStatus: calendarGetProviderStatus,
+        getRange: calendarGetRange,
+        listEvents: calendarListEvents
       }
     }
   })
@@ -93,6 +104,155 @@ describe('useAgentMcpDesktopApiResponder', () => {
         template: { id: 'template-1', name: 'Template' }
       }
     })
+  })
+
+  it('defaults calendar provider status args to google when omitted', async () => {
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await onMainInvokeCallback?.({
+      requestId: 'request-calendar-status-default',
+      channel: AgentMcpDesktopApiChannel,
+      payload: { operation: 'calendar.getProviderStatus' }
+    })
+
+    expect(calendarGetProviderStatus).toHaveBeenCalledWith({ provider: 'google' })
+    expect(respondToMainInvoke).toHaveBeenCalledWith('request-calendar-status-default', {
+      ok: true,
+      data: { connected: true }
+    })
+  })
+
+  it('parses stringified empty args for calendar provider status', async () => {
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await onMainInvokeCallback?.({
+      requestId: 'request-calendar-status-string',
+      channel: AgentMcpDesktopApiChannel,
+      payload: { operation: 'calendar.getProviderStatus', args: ['{}'] }
+    })
+
+    expect(calendarGetProviderStatus).toHaveBeenCalledWith({ provider: 'google' })
+  })
+
+  it('preserves explicit calendar provider status args', async () => {
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await onMainInvokeCallback?.({
+      requestId: 'request-calendar-status-explicit',
+      channel: AgentMcpDesktopApiChannel,
+      payload: {
+        operation: 'calendar.getProviderStatus',
+        args: [{ provider: 'google', accountId: 'account-1' }]
+      }
+    })
+
+    expect(calendarGetProviderStatus).toHaveBeenCalledWith({
+      provider: 'google',
+      accountId: 'account-1'
+    })
+  })
+
+  it('normalizes positional date args for calendar range reads', async () => {
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await onMainInvokeCallback?.({
+      requestId: 'request-calendar-range-positional',
+      channel: AgentMcpDesktopApiChannel,
+      payload: { operation: 'calendar.getRange', args: ['2026-05-14', '2026-06-14'] }
+    })
+
+    expect(calendarGetRange).toHaveBeenCalledWith({
+      startAt: localDayIso('2026-05-14'),
+      endAt: localDayIso('2026-06-15')
+    })
+  })
+
+  it('normalizes stringified calendar range objects', async () => {
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await onMainInvokeCallback?.({
+      requestId: 'request-calendar-range-string',
+      channel: AgentMcpDesktopApiChannel,
+      payload: {
+        operation: 'calendar.getRange',
+        args: ['{"start":"2026-05-14","end":"2026-06-14"}']
+      }
+    })
+
+    expect(calendarGetRange).toHaveBeenCalledWith({
+      startAt: localDayIso('2026-05-14'),
+      endAt: localDayIso('2026-06-15')
+    })
+  })
+
+  it('preserves calendar range datetime args and include-unselected flag', async () => {
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await onMainInvokeCallback?.({
+      requestId: 'request-calendar-range-datetime',
+      channel: AgentMcpDesktopApiChannel,
+      payload: {
+        operation: 'calendar.getRange',
+        args: [
+          {
+            startAt: '2026-05-14T09:00:00.000Z',
+            endAt: '2026-05-14T10:00:00.000Z',
+            includeUnselectedSources: true
+          }
+        ]
+      }
+    })
+
+    expect(calendarGetRange).toHaveBeenCalledWith({
+      startAt: '2026-05-14T09:00:00.000Z',
+      endAt: '2026-05-14T10:00:00.000Z',
+      includeUnselectedSources: true
+    })
+  })
+
+  it('parses stringified empty args for calendar event lists', async () => {
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await onMainInvokeCallback?.({
+      requestId: 'request-calendar-list-string',
+      channel: AgentMcpDesktopApiChannel,
+      payload: { operation: 'calendar.listEvents', args: ['{}'] }
+    })
+
+    expect(calendarListEvents).toHaveBeenCalledWith({})
+  })
+
+  it('preserves calendar event list filters', async () => {
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await onMainInvokeCallback?.({
+      requestId: 'request-calendar-list-filtered',
+      channel: AgentMcpDesktopApiChannel,
+      payload: { operation: 'calendar.listEvents', args: [{ includeArchived: true }] }
+    })
+
+    expect(calendarListEvents).toHaveBeenCalledWith({ includeArchived: true })
+  })
+
+  it('falls back to empty calendar event list args for malformed string args', async () => {
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await onMainInvokeCallback?.({
+      requestId: 'request-calendar-list-malformed',
+      channel: AgentMcpDesktopApiChannel,
+      payload: { operation: 'calendar.listEvents', args: ['not-json'] }
+    })
+
+    expect(calendarListEvents).toHaveBeenCalledWith({})
   })
 
   it('rejects operations outside the desktop CRUD allowlist', async () => {
@@ -167,3 +327,8 @@ describe('useAgentMcpDesktopApiResponder', () => {
     expect(mocks.logError).toHaveBeenCalled()
   })
 })
+
+function localDayIso(value: string): string {
+  const [year, month, day] = value.split('-').map(Number)
+  return new Date(year, month - 1, day, 0, 0, 0, 0).toISOString()
+}

--- a/apps/desktop/src/renderer/src/agent-mcp/desktop-api-handler.ts
+++ b/apps/desktop/src/renderer/src/agent-mcp/desktop-api-handler.ts
@@ -10,6 +10,9 @@ import { createLogger } from '@/lib/logger'
 import { extractErrorMessage } from '@/lib/ipc-error'
 
 const log = createLogger('AgentMcpDesktopApi')
+const isoDateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/
+
+type JsonRecord = Record<string, unknown>
 
 function resolveDesktopApiOperation(operation: string): (...args: unknown[]) => unknown {
   let target: unknown = window.api
@@ -25,6 +28,86 @@ function resolveDesktopApiOperation(operation: string): (...args: unknown[]) => 
   }
 
   return target as (...args: unknown[]) => unknown
+}
+
+function normalizeDesktopApiArgs(operation: string, args: unknown[]): unknown[] {
+  switch (operation) {
+    case 'calendar.getProviderStatus':
+      return [normalizeCalendarProviderStatusInput(args)]
+    case 'calendar.listEvents':
+      return [normalizeCalendarListEventsInput(args)]
+    case 'calendar.getRange':
+      return [normalizeCalendarRangeInput(args)]
+    default:
+      return args
+  }
+}
+
+function normalizeCalendarProviderStatusInput(args: unknown[]): JsonRecord {
+  const input = objectArg(args[0]) ?? {}
+  const provider = stringValue(input.provider) ?? 'google'
+  const accountId = stringValue(input.accountId)
+  return { provider, ...(accountId ? { accountId } : {}) }
+}
+
+function normalizeCalendarListEventsInput(args: unknown[]): JsonRecord {
+  return objectArg(args[0]) ?? {}
+}
+
+function normalizeCalendarRangeInput(args: unknown[]): JsonRecord {
+  const input =
+    typeof args[0] === 'string' && typeof args[1] === 'string'
+      ? { start: args[0], end: args[1] }
+      : (objectArg(args[0]) ?? {})
+  const start = stringValue(input.startAt, input.start)
+  const end = stringValue(input.endAt, input.end)
+  return {
+    startAt: start ? normalizeCalendarRangeBound(start, 'start') : start,
+    endAt: end ? normalizeCalendarRangeBound(end, 'end') : end,
+    ...(typeof input.includeUnselectedSources === 'boolean'
+      ? { includeUnselectedSources: input.includeUnselectedSources }
+      : {})
+  }
+}
+
+function objectArg(value: unknown): JsonRecord | null {
+  if (typeof value === 'string') {
+    try {
+      return objectArg(JSON.parse(value))
+    } catch {
+      return null
+    }
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as JsonRecord
+}
+
+function stringValue(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value
+  }
+  return undefined
+}
+
+function normalizeCalendarRangeBound(value: string, side: 'start' | 'end'): string {
+  if (!isoDateOnlyPattern.test(value)) return value
+  return localDayIso(side === 'end' ? addLocalDays(value, 1) : value)
+}
+
+function localDayIso(value: string): string {
+  const [year, month, day] = value.split('-').map(Number)
+  return new Date(year, month - 1, day, 0, 0, 0, 0).toISOString()
+}
+
+function addLocalDays(value: string, amount: number): string {
+  const [year, month, day] = value.split('-').map(Number)
+  const date = new Date(year, month - 1, day, 0, 0, 0, 0)
+  date.setDate(date.getDate() + amount)
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0')
 }
 
 export function useAgentMcpDesktopApiResponder({
@@ -48,7 +131,7 @@ export function useAgentMcpDesktopApiResponder({
 
       try {
         const fn = resolveDesktopApiOperation(parsed.data.operation)
-        const data = await fn(...parsed.data.args)
+        const data = await fn(...normalizeDesktopApiArgs(parsed.data.operation, parsed.data.args))
         const response: AgentMcpDesktopApiResponse = { ok: true, data }
         window.api.respondToMainInvoke(requestId, response)
       } catch (error) {

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.test.tsx
@@ -1,0 +1,272 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CalendarDayView } from './calendar-day-view'
+import type { CalendarProjectionItem } from '@/services/calendar-service'
+
+const mocks = vi.hoisted(() => ({
+  marquee: {
+    selection: null as null | {
+      top: number
+      height: number
+      startAt: string
+      endAt: string
+      anchorRect: { x: number; y: number; width: number; height: number }
+    },
+    isDragging: false,
+    onMouseDown: vi.fn(),
+    onDoubleClick: vi.fn(),
+    clearSelection: vi.fn()
+  },
+  scrollToCurrentTime: vi.fn()
+}))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@/hooks/use-general-settings', () => ({
+  useGeneralSettings: () => ({
+    settings: { clockFormat: '12h' }
+  })
+}))
+
+vi.mock('./use-scroll-to-current-time', () => ({
+  useScrollToCurrentTime: (...args: unknown[]) => mocks.scrollToCurrentTime(...args)
+}))
+
+vi.mock('./use-time-grid-marquee', () => ({
+  useTimeGridMarquee: ({ dateForColumn }: { dateForColumn: (columnIndex: number) => string }) => {
+    dateForColumn(0)
+    return {
+      selection: mocks.marquee.selection,
+      isDragging: mocks.marquee.isDragging,
+      handlers: {
+        onMouseDown: mocks.marquee.onMouseDown,
+        onDoubleClick: mocks.marquee.onDoubleClick
+      },
+      clearSelection: mocks.marquee.clearSelection
+    }
+  }
+}))
+
+vi.mock('./marquee-selection-overlay', () => ({
+  MarqueeSelectionOverlay: ({ startAt, endAt }: { startAt: string; endAt: string }) => (
+    <div data-testid="marquee-selection">
+      {startAt} {endAt}
+    </div>
+  )
+}))
+
+vi.mock('./calendar-item-chip', () => ({
+  CalendarItemChip: ({
+    item,
+    isSelected,
+    onClick,
+    onDeleteItem
+  }: {
+    item: CalendarProjectionItem
+    isSelected: boolean
+    onClick?: (item: CalendarProjectionItem, rect: DOMRect) => void
+    onDeleteItem?: (item: CalendarProjectionItem) => void
+  }) => (
+    <div>
+      <button
+        type="button"
+        data-selected={isSelected ? 'true' : 'false'}
+        onClick={() => onClick?.(item, new DOMRect(1, 2, 3, 4))}
+      >
+        {item.title}
+      </button>
+      <button type="button" onClick={() => onDeleteItem?.(item)}>
+        delete {item.title}
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('./calendar-quick-create-dialog', () => ({
+  CalendarQuickCreateDialog: ({
+    onDismiss,
+    onOpenFullEditor,
+    onSave,
+    startAt,
+    endAt,
+    isAllDay
+  }: {
+    onDismiss: () => void
+    onOpenFullEditor: (draft: { startAt: string; endAt: string }) => void
+    onSave: (draft: { title: string; startAt: string; endAt: string; isAllDay: boolean }) => void
+    startAt: string
+    endAt: string
+    isAllDay: boolean
+  }) => (
+    <div data-testid="quick-create-dialog">
+      <span>
+        {startAt} {endAt} {String(isAllDay)}
+      </span>
+      <button
+        type="button"
+        onClick={() => onSave({ title: 'Quick event', startAt, endAt, isAllDay })}
+      >
+        quick save
+      </button>
+      <button type="button" onClick={() => onOpenFullEditor({ startAt, endAt })}>
+        open full editor
+      </button>
+      <button type="button" onClick={onDismiss}>
+        dismiss quick create
+      </button>
+    </div>
+  )
+}))
+
+function eventItem(overrides: Partial<CalendarProjectionItem>): CalendarProjectionItem {
+  return {
+    projectionId: 'projection-1',
+    sourceId: 'event-1',
+    sourceType: 'event',
+    title: 'Planning',
+    descriptionPreview: null,
+    startAt: '2026-05-14T09:00',
+    endAt: '2026-05-14T10:00',
+    isAllDay: false,
+    color: '#64748b',
+    eventType: 'external',
+    sourceCalendarId: null,
+    sourceCalendarName: null,
+    googleHtmlLink: null,
+    sourceNoteId: null,
+    taskStatus: null,
+    taskPriority: null,
+    taskDueDate: null,
+    taskDueTime: null,
+    taskProjectId: null,
+    taskProjectName: null,
+    reminderId: null,
+    inboxItemId: null,
+    ...overrides
+  } as CalendarProjectionItem
+}
+
+describe('CalendarDayView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.marquee.selection = null
+    mocks.marquee.isDragging = false
+  })
+
+  it('renders all-day and timed items and forwards grid and item actions', () => {
+    const allDayItem = eventItem({
+      projectionId: 'all-day',
+      sourceId: 'event-all-day',
+      title: 'All-day offsite',
+      isAllDay: true,
+      startAt: '2026-05-14',
+      endAt: '2026-05-15'
+    })
+    const timedItem = eventItem({
+      projectionId: 'timed',
+      sourceId: 'event-timed',
+      title: 'Timed sync'
+    })
+    const onSelectItem = vi.fn()
+    const onDeleteItem = vi.fn()
+
+    render(
+      <CalendarDayView
+        anchorDate="2026-05-14"
+        items={[allDayItem, timedItem, eventItem({ startAt: '2026-05-15T09:00' })]}
+        selectedItemId="event-timed"
+        onSelectItem={onSelectItem}
+        onDeleteItem={onDeleteItem}
+      />
+    )
+
+    expect(screen.getByTestId('day-all-day-strip')).toBeInTheDocument()
+    expect(screen.getByText('All-day offsite')).toBeInTheDocument()
+    expect(screen.getByText('Timed sync')).toHaveAttribute('data-selected', 'true')
+    expect(screen.queryByText('Planning')).not.toBeInTheDocument()
+
+    fireEvent.mouseDown(screen.getByTestId('day-time-grid'))
+    fireEvent.doubleClick(screen.getByTestId('day-time-grid'))
+    expect(mocks.marquee.onMouseDown).toHaveBeenCalled()
+    expect(mocks.marquee.onDoubleClick).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText('Timed sync'))
+    fireEvent.click(screen.getByText('delete Timed sync'))
+    expect(onSelectItem).toHaveBeenCalledWith(timedItem, expect.any(DOMRect))
+    expect(onDeleteItem).toHaveBeenCalledWith(timedItem)
+  })
+
+  it('shows quick create from a settled selection and clears after actions', async () => {
+    mocks.marquee.selection = {
+      top: 96,
+      height: 48,
+      startAt: '2026-05-14T11:00',
+      endAt: '2026-05-14T12:00',
+      anchorRect: { x: 10, y: 20, width: 30, height: 40 }
+    }
+    const onQuickSave = vi.fn().mockResolvedValue(undefined)
+    const onCreateEventWithRange = vi.fn()
+
+    render(
+      <CalendarDayView
+        anchorDate="2026-05-14"
+        items={[]}
+        selectedItemId={null}
+        onQuickSave={onQuickSave}
+        onCreateEventWithRange={onCreateEventWithRange}
+      />
+    )
+
+    expect(screen.getByTestId('marquee-selection')).toHaveTextContent('2026-05-14T11:00')
+    expect(screen.getByTestId('quick-create-dialog')).toHaveTextContent('false')
+
+    fireEvent.click(screen.getByText('quick save'))
+    await waitFor(() =>
+      expect(onQuickSave).toHaveBeenCalledWith({
+        title: 'Quick event',
+        startAt: '2026-05-14T11:00',
+        endAt: '2026-05-14T12:00',
+        isAllDay: false
+      })
+    )
+    expect(mocks.marquee.clearSelection).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('open full editor'))
+    expect(onCreateEventWithRange).toHaveBeenCalledWith(
+      '2026-05-14T11:00',
+      '2026-05-14T12:00',
+      false,
+      { x: 10, y: 20, width: 30, height: 40 }
+    )
+    expect(mocks.marquee.clearSelection).toHaveBeenCalledTimes(2)
+
+    fireEvent.click(screen.getByText('dismiss quick create'))
+    expect(mocks.marquee.clearSelection).toHaveBeenCalledTimes(3)
+  })
+
+  it('shows the marquee overlay while dragging without opening quick create', () => {
+    mocks.marquee.selection = {
+      top: 48,
+      height: 48,
+      startAt: '2026-05-14T10:00',
+      endAt: '2026-05-14T11:00',
+      anchorRect: { x: 4, y: 8, width: 12, height: 16 }
+    }
+    mocks.marquee.isDragging = true
+
+    render(
+      <CalendarDayView
+        anchorDate="2026-05-14"
+        items={[]}
+        selectedItemId={null}
+        onQuickSave={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('marquee-selection')).toHaveTextContent('2026-05-14T10:00')
+    expect(screen.queryByTestId('quick-create-dialog')).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-event-popover.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-event-popover.test.tsx
@@ -229,6 +229,14 @@ describe('CalendarEventPopover', () => {
     expect(screen.getByText('choose calendar')).toBeDisabled()
     expect(screen.getByTestId('event-edit-save')).toHaveTextContent('state.saving')
 
+    fireEvent.click(screen.getAllByText('pick date')[0])
+    expect(onDraftChange).toHaveBeenCalledWith({
+      ...baseDraft,
+      isAllDay: true,
+      startAt: '2026-05-12',
+      endAt: ''
+    })
+
     fireEvent.click(screen.getByRole('checkbox', { name: 'time.all-day' }))
     expect(onDraftChange).toHaveBeenCalledWith({
       ...baseDraft,
@@ -268,5 +276,34 @@ describe('CalendarEventPopover', () => {
 
     fireEvent.click(screen.getByTestId('event-edit-save'))
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2))
+  })
+
+  it('falls back for invalid date values and ignores save attempts while saving', () => {
+    const onDraftChange = vi.fn()
+    const onSave = vi.fn()
+
+    render(
+      <CalendarEventPopover
+        anchorRect={{ x: 0, y: 0, width: 0, height: 0 }}
+        mode="edit"
+        draft={{ ...baseDraft, startAt: '', endAt: 'bad-date' }}
+        isSaving
+        onDraftChange={onDraftChange}
+        onSave={onSave}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText('time.pick-a-date')).toHaveLength(2)
+
+    fireEvent.click(screen.getAllByText('pick date')[1])
+    expect(onDraftChange).toHaveBeenCalledWith({
+      ...baseDraft,
+      startAt: '',
+      endAt: '2026-05-12T09:00'
+    })
+
+    fireEvent.keyDown(screen.getByPlaceholderText('form.new-event-placeholder'), { key: 'Enter' })
+    expect(onSave).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-event-popover.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-event-popover.test.tsx
@@ -205,4 +205,68 @@ describe('CalendarEventPopover', () => {
     fireEvent.keyDown(screen.getByPlaceholderText('form.new-event-placeholder'), { key: 'Enter' })
     expect(onSave).not.toHaveBeenCalled()
   })
+
+  it('shows loading calendar defaults and restores timed values from all-day drafts', () => {
+    mocks.googleCalendars = {
+      data: undefined,
+      isLoading: true
+    }
+    const onDraftChange = vi.fn()
+
+    render(
+      <CalendarEventPopover
+        anchorRect={{ x: 0, y: 0, width: 0, height: 0 }}
+        mode="create"
+        draft={{ ...baseDraft, isAllDay: true, startAt: '2026-05-10', endAt: '' }}
+        isSaving
+        onDraftChange={onDraftChange}
+        onSave={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('form.use-memry-calendar-default')).toBeInTheDocument()
+    expect(screen.getByText('choose calendar')).toBeDisabled()
+    expect(screen.getByTestId('event-edit-save')).toHaveTextContent('state.saving')
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'time.all-day' }))
+    expect(onDraftChange).toHaveBeenCalledWith({
+      ...baseDraft,
+      isAllDay: false,
+      startAt: '2026-05-10T09:00',
+      endAt: '2026-05-10T10:00'
+    })
+  })
+
+  it('saves with Enter and edits the end date controls', async () => {
+    const onDraftChange = vi.fn()
+    const onSave = vi.fn()
+
+    render(
+      <CalendarEventPopover
+        anchorRect={{ x: 0, y: 0, width: 0, height: 0 }}
+        mode="edit"
+        draft={baseDraft}
+        isSaving={false}
+        onDraftChange={onDraftChange}
+        onSave={onSave}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    fireEvent.keyDown(screen.getByPlaceholderText('form.new-event-placeholder'), { key: 'Enter' })
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getAllByText('pick date')[1])
+    expect(onDraftChange).toHaveBeenCalledWith({ ...baseDraft, endAt: '2026-05-12T10:00' })
+
+    fireEvent.click(screen.getAllByText('pick time')[1])
+    expect(onDraftChange).toHaveBeenCalledWith({ ...baseDraft, endAt: '2026-05-10T14:30' })
+
+    fireEvent.pointerDown(screen.getByTestId('event-edit-save'), { button: 1 })
+    expect(onSave).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByTestId('event-edit-save'))
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2))
+  })
 })

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-inbox-snooze-popover.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-inbox-snooze-popover.test.tsx
@@ -1,81 +1,84 @@
-import { describe, expect, it, vi } from 'vitest'
-import { renderWithProviders, screen, userEvent } from '@tests/utils/render'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { CalendarInboxSnoozePopover } from './calendar-inbox-snooze-popover'
-import type { CalendarProjectionItem } from '@/services/calendar-service'
 
-const baseItem: CalendarProjectionItem = {
-  projectionId: 'inbox_snooze:item-123',
-  sourceType: 'inbox_snooze',
-  sourceId: 'item-123',
-  title: 'Read this article',
-  descriptionPreview: 'A long preview of inbox content.',
-  startAt: '2026-04-30T09:00:00.000Z',
-  endAt: null,
-  isAllDay: false,
-  timezone: 'UTC',
-  visualType: 'snooze',
-  editability: { canMove: false, canResize: false, canEditText: false, canDelete: true },
-  source: {
-    provider: null,
-    calendarSourceId: null,
-    title: 'Memry Inbox',
-    color: null,
-    kind: null,
-    isMemryManaged: true
-  },
-  binding: null,
-  snoozeOffsetMinutes: null
-}
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string) => key
+  })
+}))
 
-const baseAnchor = { x: 100, y: 100, width: 120, height: 24 }
+vi.mock('@/components/snooze/snooze-picker', () => ({
+  SnoozePicker: ({
+    onSnooze,
+    trigger
+  }: {
+    onSnooze: (snoozeUntil: string) => void
+    trigger: React.ReactNode
+  }) => (
+    <div>
+      {trigger}
+      <button type="button" onClick={() => onSnooze('2026-05-15T09:00:00.000Z')}>
+        pick snooze
+      </button>
+    </div>
+  )
+}))
 
 describe('CalendarInboxSnoozePopover', () => {
-  it('renders the inbox item title and preview', () => {
-    renderWithProviders(
-      <CalendarInboxSnoozePopover
-        item={baseItem}
-        anchorRect={baseAnchor}
-        onOpenInInbox={vi.fn()}
-        onUnsnooze={vi.fn()}
-        onReschedule={vi.fn()}
-        onDismiss={vi.fn()}
-      />
-    )
-    expect(screen.getByText('Read this article')).toBeInTheDocument()
-    expect(screen.getByText(/A long preview/)).toBeInTheDocument()
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
-  it('calls onOpenInInbox with the item id when "Open in inbox" is clicked', async () => {
+  it('routes actions and only dismisses for outside interactions', async () => {
     const user = userEvent.setup()
     const onOpenInInbox = vi.fn()
-    renderWithProviders(
-      <CalendarInboxSnoozePopover
-        item={baseItem}
-        anchorRect={baseAnchor}
-        onOpenInInbox={onOpenInInbox}
-        onUnsnooze={vi.fn()}
-        onReschedule={vi.fn()}
-        onDismiss={vi.fn()}
-      />
-    )
-    await user.click(screen.getByRole('button', { name: /open in inbox/i }))
-    expect(onOpenInInbox).toHaveBeenCalledWith('item-123')
-  })
-
-  it('calls onUnsnooze with the item id when "Unsnooze now" is clicked', async () => {
-    const user = userEvent.setup()
     const onUnsnooze = vi.fn()
-    renderWithProviders(
+    const onReschedule = vi.fn()
+    const onDismiss = vi.fn()
+
+    render(
       <CalendarInboxSnoozePopover
-        item={baseItem}
-        anchorRect={baseAnchor}
-        onOpenInInbox={vi.fn()}
+        item={
+          {
+            sourceId: 'inbox-1',
+            title: 'Read launch notes',
+            descriptionPreview: 'Follow up next week'
+          } as never
+        }
+        anchorRect={{ x: 20, y: 30, width: 40, height: 50 }}
+        onOpenInInbox={onOpenInInbox}
         onUnsnooze={onUnsnooze}
-        onReschedule={vi.fn()}
-        onDismiss={vi.fn()}
+        onReschedule={onReschedule}
+        onDismiss={onDismiss}
       />
     )
-    await user.click(screen.getByRole('button', { name: /unsnooze now/i }))
-    expect(onUnsnooze).toHaveBeenCalledWith('item-123')
+
+    expect(screen.getByText('Read launch notes')).toBeInTheDocument()
+    expect(screen.getByText('Follow up next week')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /openInInbox/ }))
+    await user.click(screen.getByRole('button', { name: /unsnoozeNow/ }))
+    await user.click(screen.getByRole('button', { name: 'pick snooze' }))
+    expect(onOpenInInbox).toHaveBeenCalledWith('inbox-1')
+    expect(onUnsnooze).toHaveBeenCalledWith('inbox-1')
+    expect(onReschedule).toHaveBeenCalledWith('inbox-1', '2026-05-15T09:00:00.000Z')
+
+    fireEvent.pointerDown(screen.getByTestId('calendar-inbox-snooze-popover'))
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    const portalTarget = document.createElement('div')
+    portalTarget.setAttribute('role', 'dialog')
+    document.body.appendChild(portalTarget)
+    fireEvent.pointerDown(portalTarget)
+    expect(onDismiss).not.toHaveBeenCalled()
+    portalTarget.remove()
+
+    fireEvent.pointerDown(document)
+    fireEvent.pointerDown(document.body)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onDismiss).toHaveBeenCalledTimes(3)
   })
 })

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-item-chip.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-item-chip.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { CalendarItemChip } from './calendar-item-chip'
+import type { CalendarProjectionItem } from '@/services/calendar-service'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string) => key
+  })
+}))
+
+function eventItem(overrides: Partial<CalendarProjectionItem> = {}): CalendarProjectionItem {
+  return {
+    projectionId: 'projection-1',
+    sourceId: 'event-1',
+    sourceType: 'event',
+    visualType: 'event',
+    title: 'Planning',
+    descriptionPreview: null,
+    startAt: '2026-05-14T09:00',
+    endAt: '2026-05-14T10:00',
+    isAllDay: false,
+    color: '#64748b',
+    eventType: 'memry',
+    sourceCalendarId: null,
+    sourceCalendarName: null,
+    googleHtmlLink: null,
+    sourceNoteId: null,
+    taskStatus: null,
+    taskPriority: null,
+    taskDueDate: null,
+    taskDueTime: null,
+    taskProjectId: null,
+    taskProjectName: null,
+    reminderId: null,
+    inboxItemId: null,
+    editability: { canUpdate: false, canDelete: false },
+    ...overrides
+  } as CalendarProjectionItem
+}
+
+describe('CalendarItemChip', () => {
+  it('renders a static chip when no item actions are available', () => {
+    render(<CalendarItemChip item={eventItem()} />)
+
+    expect(screen.getByText('Planning')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
@@ -18,7 +18,8 @@ const {
   mockPromoteExternal,
   mockSnooze,
   mockUnsnooze,
-  mockOpenTab
+  mockOpenTab,
+  mockUseActiveTab
 } = vi.hoisted(() => ({
   mockUseCalendarRange: vi.fn(),
   mockListSources: vi.fn(),
@@ -29,7 +30,8 @@ const {
   mockPromoteExternal: vi.fn(),
   mockSnooze: vi.fn(),
   mockUnsnooze: vi.fn(),
-  mockOpenTab: vi.fn()
+  mockOpenTab: vi.fn(),
+  mockUseActiveTab: vi.fn()
 }))
 
 vi.mock('@/hooks/use-calendar-range', () => ({
@@ -37,6 +39,7 @@ vi.mock('@/hooks/use-calendar-range', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
+  useActiveTab: mockUseActiveTab,
   useTabActions: () => ({ openTab: mockOpenTab })
 }))
 
@@ -98,6 +101,15 @@ function isoAtLocalTime(hour: number, minute = 0, dayOffset = 0): string {
   date.setDate(date.getDate() + dayOffset)
   date.setHours(hour, minute, 0, 0)
   return date.toISOString()
+}
+
+function localDateString(dayOffset = 0): string {
+  const date = new Date(SAMPLE_DAY)
+  date.setDate(date.getDate() + dayOffset)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 const SAMPLE_ITEMS: CalendarProjectionItem[] = [
@@ -257,6 +269,7 @@ describe('CalendarPage', () => {
     mockUnsnooze.mockReset()
     mockListSources.mockReset()
     mockUseCalendarRange.mockReset()
+    mockUseActiveTab.mockReset()
 
     mockDeleteEvent.mockResolvedValue({ success: true })
     mockGetEvent.mockResolvedValue(null)
@@ -277,6 +290,7 @@ describe('CalendarPage', () => {
       isFetching: false,
       error: null
     })
+    mockUseActiveTab.mockReturnValue(null)
   })
 
   it('switches between day, week, month, and year views', async () => {
@@ -376,6 +390,62 @@ describe('CalendarPage', () => {
     await user.click(screen.getByText('Planning block'))
 
     expect(await screen.findByRole('dialog', { name: 'Edit calendar event' })).toBeInTheDocument()
+  })
+
+  it('opens a focused calendar event from active tab view state', async () => {
+    mockUseActiveTab.mockReturnValue({
+      viewState: {
+        focusCalendarEventId: 'event-1',
+        focusDate: localDateString(),
+        focusedAt: 123
+      }
+    })
+
+    renderWithProviders(<CalendarPage />)
+
+    expect(await screen.findByRole('dialog', { name: 'Edit calendar event' })).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Planning block')).toBeInTheDocument()
+  })
+
+  it('saves a newly created all-day event from the editor', async () => {
+    const user = userEvent.setup()
+    mockCreateEvent.mockResolvedValue({ success: true })
+
+    renderWithProviders(<CalendarPage />)
+
+    await user.click(screen.getByRole('button', { name: 'Create event' }))
+    await user.type(await screen.findByPlaceholderText('New Event'), 'Launch day')
+    await user.click(screen.getByRole('checkbox', { name: 'All day' }))
+    fireEvent.pointerDown(screen.getByTestId('event-edit-save'), { button: 0 })
+
+    await waitFor(() => expect(mockCreateEvent).toHaveBeenCalled())
+    expect(mockCreateEvent.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        title: 'Launch day',
+        isAllDay: true,
+        startAt: expect.any(String),
+        endAt: expect.any(String)
+      })
+    )
+  })
+
+  it('saves edits from the edit popover', async () => {
+    const user = userEvent.setup()
+    mockUpdateEvent.mockResolvedValueOnce({ success: true })
+
+    renderWithProviders(<CalendarPage />)
+
+    await user.click(await screen.findByText('Planning block'))
+    fireEvent.pointerDown(await screen.findByTestId('event-edit-save'), { button: 0 })
+
+    await waitFor(() =>
+      expect(mockUpdateEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'event-1',
+          title: 'Planning block'
+        })
+      )
+    )
   })
 
   it('renders projected task, reminder, and snooze items with distinct styling markers', async () => {

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-shell.test.tsx
@@ -1,0 +1,394 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CalendarShell } from './calendar-shell'
+import type { CalendarEventDraft } from './types'
+
+const calendarApi = vi.hoisted(() => ({
+  refreshGoogleCalendarProvider: vi.fn()
+}))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    warn: vi.fn()
+  })
+}))
+
+vi.mock('@/services/calendar-service', () => ({
+  refreshGoogleCalendarProvider: calendarApi.refreshGoogleCalendarProvider
+}))
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('./calendar-toolbar', () => ({
+  CalendarToolbar: ({
+    extraActions,
+    onCreateEvent,
+    onNext,
+    onPrevious,
+    onToday,
+    onViewChange
+  }: {
+    extraActions: React.ReactNode
+    onCreateEvent: (rect: { x: number; y: number; width: number; height: number }) => void
+    onNext: () => void
+    onPrevious: () => void
+    onToday: () => void
+    onViewChange: (view: string) => void
+  }) => (
+    <div>
+      {extraActions}
+      <button type="button" onClick={() => onCreateEvent({ x: 1, y: 2, width: 3, height: 4 })}>
+        create
+      </button>
+      <button type="button" onClick={onPrevious}>
+        previous
+      </button>
+      <button type="button" onClick={onToday}>
+        today
+      </button>
+      <button type="button" onClick={onNext}>
+        next
+      </button>
+      <button type="button" onClick={() => onViewChange('month')}>
+        month
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('./calendar-day-view', () => ({
+  CalendarDayView: () => <div data-testid="day-view" />
+}))
+
+vi.mock('./calendar-week-view', () => ({
+  CalendarWeekView: ({
+    onCreateEventWithRange,
+    onQuickSave,
+    onSelectItem,
+    onVisibleDayStartChange
+  }: {
+    onCreateEventWithRange?: (
+      startAt: string,
+      endAt: string,
+      isAllDay: boolean,
+      rect: { x: number; y: number; width: number; height: number }
+    ) => void
+    onQuickSave?: (draft: CalendarEventDraft) => void
+    onSelectItem: (
+      item: { id: string; title: string },
+      rect: { x: number; y: number; width: number; height: number }
+    ) => void
+    onVisibleDayStartChange?: (index: number, startDate: string) => void
+  }) => (
+    <div data-testid="week-view">
+      <button
+        type="button"
+        onClick={() =>
+          onSelectItem({ id: 'event-1', title: 'Event' }, { x: 0, y: 1, width: 2, height: 3 })
+        }
+      >
+        select week item
+      </button>
+      <button type="button" onClick={() => onVisibleDayStartChange?.(1, '2026-05-18')}>
+        visible week
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onCreateEventWithRange?.('2026-05-14T09:00:00.000Z', '2026-05-14T10:00:00.000Z', false, {
+            x: 4,
+            y: 5,
+            width: 6,
+            height: 7
+          })
+        }
+      >
+        create range
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onQuickSave?.({
+            title: 'Quick',
+            description: '',
+            location: '',
+            startAt: '2026-05-14T09:00',
+            endAt: '2026-05-14T10:00',
+            isAllDay: false,
+            targetCalendarId: null
+          })
+        }
+      >
+        quick save
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('./calendar-month-view', () => ({
+  CalendarMonthView: () => <div data-testid="month-view" />
+}))
+
+vi.mock('./calendar-year-view', () => ({
+  CalendarYearView: ({
+    onAnchorChange,
+    onViewChange
+  }: {
+    onAnchorChange?: (date: string) => void
+    onViewChange: (view: string) => void
+  }) => (
+    <div data-testid="year-view">
+      <button type="button" onClick={() => onAnchorChange?.('2027-01-01')}>
+        change anchor
+      </button>
+      <button type="button" onClick={() => onViewChange('day')}>
+        open day
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('./calendar-event-popover', () => ({
+  CalendarEventPopover: ({
+    onDismiss,
+    onDraftChange,
+    onSave
+  }: {
+    onDismiss: () => void
+    onDraftChange: (draft: CalendarEventDraft) => void
+    onSave: () => void
+  }) => (
+    <div data-testid="event-popover">
+      <button
+        type="button"
+        onClick={() =>
+          onDraftChange({
+            title: 'Changed',
+            description: '',
+            location: '',
+            startAt: '2026-05-14T09:00',
+            endAt: '2026-05-14T10:00',
+            isAllDay: false,
+            targetCalendarId: null
+          })
+        }
+      >
+        change draft
+      </button>
+      <button type="button" onClick={onSave}>
+        save popover
+      </button>
+      <button type="button" onClick={onDismiss}>
+        dismiss popover
+      </button>
+    </div>
+  )
+}))
+
+vi.mock('./calendar-inbox-snooze-popover', () => ({
+  CalendarInboxSnoozePopover: ({
+    onDismiss,
+    onOpenInInbox,
+    onReschedule,
+    onUnsnooze
+  }: {
+    onDismiss: () => void
+    onOpenInInbox: (itemId: string) => void
+    onReschedule: (itemId: string, snoozeUntil: string) => void
+    onUnsnooze: (itemId: string) => void
+  }) => (
+    <div data-testid="snooze-popover">
+      <button type="button" onClick={() => onOpenInInbox('inbox-1')}>
+        open inbox
+      </button>
+      <button type="button" onClick={() => onUnsnooze('inbox-1')}>
+        unsnooze inbox
+      </button>
+      <button type="button" onClick={() => onReschedule('inbox-1', '2026-05-15T09:00:00.000Z')}>
+        reschedule inbox
+      </button>
+      <button type="button" onClick={onDismiss}>
+        dismiss snooze
+      </button>
+    </div>
+  )
+}))
+
+function createProps(overrides: Partial<React.ComponentProps<typeof CalendarShell>> = {}) {
+  return {
+    view: 'week',
+    anchorDate: '2026-05-14',
+    items: [],
+    importedSources: [{ id: 'source-1', title: 'Work Calendar' }],
+    isLoading: false,
+    showMemryItems: true,
+    showImportedCalendars: false,
+    selectedImportedSourceIds: ['source-1'],
+    selectedVisualTypes: ['event'],
+    selectedItemId: null,
+    popoverState: null,
+    inboxSnoozePopoverState: null,
+    onInboxSnoozeOpenInInbox: vi.fn(),
+    onInboxSnoozeUnsnooze: vi.fn(),
+    onInboxSnoozeReschedule: vi.fn(),
+    onInboxSnoozePopoverDismiss: vi.fn(),
+    isSaving: false,
+    onViewChange: vi.fn(),
+    onPrevious: vi.fn(),
+    onNext: vi.fn(),
+    onToday: vi.fn(),
+    onCreateEvent: vi.fn(),
+    onToggleMemryItems: vi.fn(),
+    onToggleImportedCalendars: vi.fn(),
+    onToggleImportedSource: vi.fn(),
+    onToggleVisualType: vi.fn(),
+    onSelectItem: vi.fn(),
+    onDeleteItem: vi.fn(),
+    onPopoverDismiss: vi.fn(),
+    onPopoverDraftChange: vi.fn(),
+    onPopoverSave: vi.fn(),
+    onAnchorChange: vi.fn(),
+    onWeekVisibleRangeChange: vi.fn(),
+    onQuickSave: vi.fn(),
+    onCreateEventWithRange: vi.fn(),
+    ...overrides
+  } satisfies React.ComponentProps<typeof CalendarShell>
+}
+
+describe('CalendarShell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    calendarApi.refreshGoogleCalendarProvider.mockResolvedValue({ success: true })
+  })
+
+  it('drives toolbar, filter, refresh, week, and popover actions', async () => {
+    const user = userEvent.setup()
+    const props = createProps({
+      showImportedCalendars: true,
+      popoverState: {
+        mode: 'create',
+        draft: {
+          title: 'Draft',
+          description: '',
+          location: '',
+          startAt: '2026-05-14T09:00',
+          endAt: '2026-05-14T10:00',
+          isAllDay: false,
+          targetCalendarId: null
+        },
+        anchorRect: { x: 0, y: 0, width: 10, height: 10 }
+      },
+      inboxSnoozePopoverState: {
+        item: { id: 'snooze-1', sourceId: 'inbox-1', title: 'Snoozed inbox item' } as never,
+        anchorRect: { x: 5, y: 5, width: 10, height: 10 }
+      }
+    })
+
+    render(<CalendarShell {...props} />)
+
+    await user.click(screen.getByRole('button', { name: 'filter.refresh-google-calendars' }))
+    await waitFor(() => expect(calendarApi.refreshGoogleCalendarProvider).toHaveBeenCalledTimes(1))
+
+    await user.click(screen.getByRole('checkbox', { name: 'filter.memry-items' }))
+    await user.click(screen.getByRole('checkbox', { name: 'filter.imported-calendars' }))
+    await user.click(screen.getByRole('checkbox', { name: 'visual-type.task' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Work Calendar' }))
+    expect(props.onToggleMemryItems).toHaveBeenCalledTimes(1)
+    expect(props.onToggleImportedCalendars).toHaveBeenCalledTimes(1)
+    expect(props.onToggleVisualType).toHaveBeenCalledWith('task')
+    expect(props.onToggleImportedSource).toHaveBeenCalledWith('source-1')
+
+    for (const label of ['create', 'previous', 'today', 'next', 'month']) {
+      await user.click(screen.getByRole('button', { name: label }))
+    }
+    expect(props.onCreateEvent).toHaveBeenCalledWith({ x: 1, y: 2, width: 3, height: 4 })
+    expect(props.onPrevious).toHaveBeenCalledTimes(1)
+    expect(props.onToday).toHaveBeenCalledTimes(1)
+    expect(props.onNext).toHaveBeenCalledTimes(1)
+    expect(props.onViewChange).toHaveBeenCalledWith('month')
+
+    await user.click(screen.getByRole('button', { name: 'select week item' }))
+    await user.click(screen.getByRole('button', { name: 'visible week' }))
+    await user.click(screen.getByRole('button', { name: 'create range' }))
+    await user.click(screen.getByRole('button', { name: 'quick save' }))
+    expect(props.onSelectItem).toHaveBeenCalledWith(
+      { id: 'event-1', title: 'Event' },
+      { x: 0, y: 1, width: 2, height: 3 }
+    )
+    expect(props.onWeekVisibleRangeChange).toHaveBeenCalledWith('2026-05-18')
+    expect(props.onCreateEventWithRange).toHaveBeenCalledWith(
+      '2026-05-14T09:00:00.000Z',
+      '2026-05-14T10:00:00.000Z',
+      false,
+      { x: 4, y: 5, width: 6, height: 7 }
+    )
+    expect(props.onQuickSave).toHaveBeenCalledWith(expect.objectContaining({ title: 'Quick' }))
+
+    await user.click(screen.getByRole('button', { name: 'change draft' }))
+    await user.click(screen.getByRole('button', { name: 'save popover' }))
+    await user.click(screen.getByRole('button', { name: 'dismiss popover' }))
+    expect(props.onPopoverDraftChange).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Changed' })
+    )
+    expect(props.onPopoverSave).toHaveBeenCalledTimes(1)
+    expect(props.onPopoverDismiss).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole('button', { name: 'open inbox' }))
+    await user.click(screen.getByRole('button', { name: 'unsnooze inbox' }))
+    await user.click(screen.getByRole('button', { name: 'reschedule inbox' }))
+    await user.click(screen.getByRole('button', { name: 'dismiss snooze' }))
+    expect(props.onInboxSnoozeOpenInInbox).toHaveBeenCalledWith('inbox-1')
+    expect(props.onInboxSnoozeUnsnooze).toHaveBeenCalledWith('inbox-1')
+    expect(props.onInboxSnoozeReschedule).toHaveBeenCalledWith(
+      'inbox-1',
+      '2026-05-15T09:00:00.000Z'
+    )
+    expect(props.onInboxSnoozePopoverDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders loading and alternate views while handling refresh failures', async () => {
+    const user = userEvent.setup()
+    const props = createProps({ isLoading: true, importedSources: [] })
+    const { rerender } = render(<CalendarShell {...props} />)
+
+    expect(screen.getByText('state.loading-calendar')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'filter.refresh-google-calendars' })
+    ).not.toBeInTheDocument()
+
+    calendarApi.refreshGoogleCalendarProvider.mockResolvedValueOnce({
+      success: false,
+      error: 'nope'
+    })
+    rerender(<CalendarShell {...createProps({ view: 'day' })} />)
+    expect(screen.getByTestId('day-view')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'filter.refresh-google-calendars' }))
+    await waitFor(() => expect(calendarApi.refreshGoogleCalendarProvider).toHaveBeenCalledTimes(1))
+
+    calendarApi.refreshGoogleCalendarProvider.mockRejectedValueOnce(new Error('network down'))
+    await user.click(screen.getByRole('button', { name: 'filter.refresh-google-calendars' }))
+    await waitFor(() => expect(calendarApi.refreshGoogleCalendarProvider).toHaveBeenCalledTimes(2))
+
+    rerender(<CalendarShell {...createProps({ view: 'month' })} />)
+    expect(screen.getByTestId('month-view')).toBeInTheDocument()
+
+    const yearProps = createProps({ view: 'year' })
+    rerender(<CalendarShell {...yearProps} />)
+    await user.click(screen.getByRole('button', { name: 'change anchor' }))
+    await user.click(screen.getByRole('button', { name: 'open day' }))
+    expect(yearProps.onAnchorChange).toHaveBeenCalledWith('2027-01-01')
+    expect(yearProps.onViewChange).toHaveBeenCalledWith('day')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/use-month-grid-marquee.test.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-month-grid-marquee.test.ts
@@ -100,6 +100,59 @@ describe('useMonthGridMarquee', () => {
     expect(result.current.selection).toBeNull()
   })
 
+  it('ignores non-element targets', () => {
+    const ref = createMockGridRef()
+    const { result } = renderHook(() => useMonthGridMarquee({ gridRef: ref }))
+
+    act(() => {
+      result.current.handlers.onMouseDown({
+        target: null,
+        button: 0,
+        preventDefault: vi.fn()
+      } as unknown as React.MouseEvent)
+      result.current.handlers.onDoubleClick({
+        target: null,
+        button: 0,
+        preventDefault: vi.fn()
+      } as unknown as React.MouseEvent)
+    })
+
+    expect(result.current.selection).toBeNull()
+    expect(result.current.isDragging).toBe(false)
+  })
+
+  it('falls back to an empty anchor rect when the grid or target cell is unavailable', () => {
+    const ref = { current: null } as RefObject<HTMLDivElement | null>
+    const { result, rerender } = renderHook(({ gridRef }) => useMonthGridMarquee({ gridRef }), {
+      initialProps: { gridRef: ref }
+    })
+    const cell = createCell('2026-04-14')
+
+    act(() => {
+      result.current.handlers.onDoubleClick({
+        target: cell,
+        button: 0,
+        preventDefault: vi.fn()
+      } as unknown as React.MouseEvent)
+    })
+
+    expect(result.current.selection?.anchorRect).toEqual({ x: 0, y: 0, width: 0, height: 0 })
+
+    const grid = document.createElement('div')
+    ref.current = grid
+    rerender({ gridRef: ref })
+
+    act(() => {
+      result.current.handlers.onDoubleClick({
+        target: cell,
+        button: 0,
+        preventDefault: vi.fn()
+      } as unknown as React.MouseEvent)
+    })
+
+    expect(result.current.selection?.anchorRect).toEqual({ x: 0, y: 0, width: 0, height: 0 })
+  })
+
   it('starts dragging on mousedown but does not create selection until mousemove', () => {
     const ref = createMockGridRef()
     const { result } = renderHook(() => useMonthGridMarquee({ gridRef: ref }))
@@ -115,6 +168,32 @@ describe('useMonthGridMarquee', () => {
     })
     expect(result.current.isDragging).toBe(true)
     expect(result.current.selection).toBeNull()
+  })
+
+  it('clears click-only drags on mouseup and ignores mousemove without a date target', () => {
+    const ref = createMockGridRef()
+    const { result } = renderHook(() => useMonthGridMarquee({ gridRef: ref }))
+    const cell = createCell('2026-04-10')
+    const emptyTarget = document.createElement('div')
+    ref.current!.append(cell, emptyTarget)
+
+    act(() => {
+      result.current.handlers.onMouseDown({
+        target: cell,
+        button: 0,
+        preventDefault: vi.fn()
+      } as unknown as React.MouseEvent)
+    })
+
+    act(() => {
+      const moveEvent = new MouseEvent('mousemove', { bubbles: true })
+      Object.defineProperty(moveEvent, 'target', { value: emptyTarget })
+      document.dispatchEvent(moveEvent)
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    })
+
+    expect(result.current.selection).toBeNull()
+    expect(result.current.isDragging).toBe(false)
   })
 
   it('ignores non-left-button mousedown', () => {

--- a/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useWeekInfiniteScroll, type UseWeekInfiniteScrollResult } from './use-week-infinite-scroll'
+
+const virtualizerMocks = vi.hoisted(() => ({
+  measure: vi.fn(),
+  options: [] as Array<{
+    horizontal: boolean
+    count: number
+    getScrollElement: () => HTMLDivElement | null
+    estimateSize: () => number
+    overscan: number
+  }>
+}))
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: (options: (typeof virtualizerMocks.options)[number]) => {
+    virtualizerMocks.options.push(options)
+    return {
+      measure: virtualizerMocks.measure,
+      getVirtualItems: vi.fn(() => []),
+      getTotalSize: vi.fn(() => 0)
+    }
+  }
+}))
+
+class ResizeObserverMock {
+  static instances: ResizeObserverMock[] = []
+
+  observe = vi.fn()
+  disconnect = vi.fn()
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    ResizeObserverMock.instances.push(this)
+  }
+
+  trigger(): void {
+    this.callback([], this as unknown as ResizeObserver)
+  }
+}
+
+function defineReadonlyNumber(target: HTMLElement, key: 'clientWidth', value: number): void {
+  Object.defineProperty(target, key, { configurable: true, value })
+}
+
+describe('useWeekInfiniteScroll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    virtualizerMocks.options = []
+    ResizeObserverMock.instances = []
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  })
+
+  it('measures columns, tracks visible days, translates shift-wheel, and scrolls programmatically', () => {
+    let current: UseWeekInfiniteScrollResult | null = null
+    const onVisibleDayStartChange = vi.fn()
+
+    function Harness(): React.JSX.Element {
+      current = useWeekInfiniteScroll({
+        initialDate: '2026-05-14',
+        gutterWidth: 48,
+        totalDays: 90,
+        onVisibleDayStartChange
+      })
+      return <div data-testid="week-scroller" ref={current.scrollContainerRef} />
+    }
+
+    const { getByTestId } = render(<Harness />)
+    const scroller = getByTestId('week-scroller') as HTMLDivElement
+    defineReadonlyNumber(scroller, 'clientWidth', 748)
+    scroller.scrollTo = vi.fn(({ left }) => {
+      scroller.scrollLeft = Number(left)
+    })
+
+    expect(current?.columnWidth).toBe(48)
+    expect(virtualizerMocks.options.at(-1)).toMatchObject({
+      horizontal: true,
+      count: 90,
+      overscan: 3
+    })
+    expect(virtualizerMocks.options.at(-1)?.getScrollElement()).toBe(scroller)
+
+    act(() => {
+      ResizeObserverMock.instances[0].trigger()
+    })
+
+    expect(current?.columnWidth).toBe(100)
+    expect(virtualizerMocks.options.at(-1)?.estimateSize()).toBe(100)
+    expect(scroller.scrollLeft).toBeGreaterThan(0)
+    expect(virtualizerMocks.measure).toHaveBeenCalled()
+
+    act(() => {
+      scroller.scrollLeft = 250
+      scroller.dispatchEvent(new Event('scroll'))
+    })
+
+    expect(current?.visibleDayStart).toBe(2)
+    expect(onVisibleDayStartChange).toHaveBeenCalledWith(2)
+
+    const wheel = new WheelEvent('wheel', {
+      shiftKey: true,
+      deltaY: 40,
+      deltaX: 0,
+      cancelable: true
+    })
+    act(() => {
+      scroller.dispatchEvent(wheel)
+    })
+
+    expect(wheel.defaultPrevented).toBe(true)
+    expect(scroller.scrollLeft).toBe(290)
+
+    const beforeDominantX = scroller.scrollLeft
+    act(() => {
+      scroller.dispatchEvent(new WheelEvent('wheel', { shiftKey: true, deltaY: 10, deltaX: 20 }))
+      scroller.dispatchEvent(new WheelEvent('wheel', { shiftKey: false, deltaY: 50, deltaX: 0 }))
+    })
+    expect(scroller.scrollLeft).toBe(beforeDominantX)
+
+    act(() => {
+      current?.scrollToDay(4, { smooth: true })
+    })
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({ left: 400, behavior: 'smooth' })
+
+    act(() => {
+      current?.scrollToDay(40, { smooth: true })
+    })
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({ left: 4000, behavior: 'auto' })
+    expect(current?.visibleDayStart).toBe(40)
+
+    act(() => {
+      current?.scrollToDate('2026-05-20', { smooth: false })
+    })
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ behavior: 'auto' })
+    )
+    expect(current?.dateForDayIndex(0)).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
@@ -344,6 +344,7 @@ vi.mock('@/contexts/day-panel-context', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
+  useActiveTab: () => null,
   useTabActions: () => ({ openTab: mocks.openTab })
 }))
 

--- a/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
@@ -29,6 +29,7 @@ vi.mock('@/hooks/use-calendar-range', () => ({
 }))
 
 vi.mock('@/contexts/tabs', () => ({
+  useActiveTab: () => null,
   useTabActions: () => ({ openTab: mockOpenTab })
 }))
 

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -195,6 +195,12 @@ flows, provider connect/disconnect/refresh actions, app updater actions, externa
 actions, and raw secret writes. Unsupported or unavailable desktop API operations return a structured
 MCP error instead of falling back to an arbitrary desktop call.
 
+Calendar desktop reads accept the same single-object shape as the renderer bridge. For example:
+`calendar.getProviderStatus` with no args or `args: [{}]` checks Google provider status,
+`calendar.listEvents` accepts `args: [{}]`, and `calendar.getRange` accepts either
+`args: ["2026-05-14", "2026-06-14"]` or
+`args: [{"startAt": "2026-05-14T00:00:00.000Z", "endAt": "2026-06-15T00:00:00.000Z"}]`.
+
 By default, Agent Chat accepts these tool calls automatically. The chat still shows each requested
 tool in a collapsed tool row, including running, completed, error, and denied states, so you can open
 the row to inspect parameters and results.


### PR DESCRIPTION
## Summary
- Normalize calendar desktop read args before invoking the renderer bridge, covering empty args, stringified objects, positional date ranges, and date-only local-day bounds.
- Default calendar provider status reads to Google when the provider is omitted.
- Document the accepted calendar `vault_desktop_read` shapes.

## Release note
Fix Agent calendar reads from the local MCP bridge when checking provider status, listing events, or reading a date range.

## Test plan
- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/agent-mcp/desktop-api-handler.test.tsx`
- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project main src/main/agent/mcp/tools/__tests__/schemas.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm ipc:check`
- `pnpm docs:impact --base 92045b234d0c50c38b61e8de5ea24fa6f7201558 --strict`
- `pnpm docs:build`

Note: local full `pnpm test` currently fails on unrelated broad-suite surfaces outside this patch: calendar test mocks missing `useActiveTab`, two linking-service assertions, and three renderer timeouts. The changed MCP handler and schema tests pass.
