### PR TITLE
Move note metadata actions above titles

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/ghost-affordance-row.tsx
+++ b/apps/desktop/src/renderer/src/components/note/ghost-affordance-row.tsx
@@ -14,8 +14,8 @@ export interface GhostAffordanceRowProps {
   onAddTag: (tagId: string) => void
   onCreateTag: (name: string, color: string) => void
   onAddProperty: (property: NewProperty) => void
-  hasTags?: boolean
   disabled?: boolean
+  className?: string
 }
 
 export const GhostAffordanceRow = memo(function GhostAffordanceRow({
@@ -25,8 +25,8 @@ export const GhostAffordanceRow = memo(function GhostAffordanceRow({
   onAddTag,
   onCreateTag,
   onAddProperty,
-  hasTags = false,
-  disabled = false
+  disabled = false,
+  className
 }: GhostAffordanceRowProps) {
   const { t } = useT('notes')
   const [isTagPopupOpen, setIsTagPopupOpen] = useState(false)
@@ -45,7 +45,8 @@ export const GhostAffordanceRow = memo(function GhostAffordanceRow({
               'opacity-0 pointer-events-none',
               'group-hover/metadata:opacity-100 group-hover/metadata:pointer-events-auto',
               'group-focus-within/metadata:opacity-100 group-focus-within/metadata:pointer-events-auto'
-            ]
+            ],
+        className
       )}
     >
       <AddPropertyPopup
@@ -72,35 +73,33 @@ export const GhostAffordanceRow = memo(function GhostAffordanceRow({
         </button>
       </AddPropertyPopup>
 
-      {!hasTags && (
-        <TagInputPopup
-          availableTags={availableTags}
-          recentTags={recentTags}
-          currentTagIds={currentTagIds}
-          onAddTag={onAddTag}
-          onCreateTag={onCreateTag}
-          open={isTagPopupOpen}
-          onOpenChange={setIsTagPopupOpen}
+      <TagInputPopup
+        availableTags={availableTags}
+        recentTags={recentTags}
+        currentTagIds={currentTagIds}
+        onAddTag={onAddTag}
+        onCreateTag={onCreateTag}
+        open={isTagPopupOpen}
+        onOpenChange={setIsTagPopupOpen}
+        disabled={disabled}
+      >
+        <button
+          type="button"
           disabled={disabled}
+          className={cn(
+            'flex items-center gap-1.5',
+            'rounded-md px-2 py-1',
+            'border border-dashed border-border',
+            'text-[12px] text-text-tertiary',
+            'transition-colors duration-150',
+            'hover:border-muted-foreground hover:text-muted-foreground',
+            'disabled:pointer-events-none disabled:opacity-50'
+          )}
         >
-          <button
-            type="button"
-            disabled={disabled}
-            className={cn(
-              'flex items-center gap-1.5',
-              'rounded-md px-2 py-1',
-              'border border-dashed border-border',
-              'text-[12px] text-text-tertiary',
-              'transition-colors duration-150',
-              'hover:border-muted-foreground hover:text-muted-foreground',
-              'disabled:pointer-events-none disabled:opacity-50'
-            )}
-          >
-            <Plus className="h-3 w-3" strokeWidth={2} />
-            {t('tagsRow.add')}
-          </button>
-        </TagInputPopup>
-      )}
+          <Plus className="h-3 w-3" strokeWidth={2} />
+          {t('tagsRow.add')}
+        </button>
+      </TagInputPopup>
     </div>
   )
 })

--- a/apps/desktop/src/renderer/src/components/note/tags-row/TagsRow.tsx
+++ b/apps/desktop/src/renderer/src/components/note/tags-row/TagsRow.tsx
@@ -16,6 +16,7 @@ export interface TagsRowProps {
   disabled?: boolean
   className?: string
   hideWhenEmpty?: boolean
+  hideAddButton?: boolean
 }
 
 export const TagsRow = memo(function TagsRow({
@@ -28,7 +29,8 @@ export const TagsRow = memo(function TagsRow({
   onTagClick,
   disabled = false,
   className,
-  hideWhenEmpty = false
+  hideWhenEmpty = false,
+  hideAddButton = false
 }: TagsRowProps) {
   const { t } = useT('notes')
   const currentTagIds = tags.map((t) => t.id)
@@ -51,16 +53,18 @@ export const TagsRow = memo(function TagsRow({
         />
       ))}
 
-      <TagInputPopup
-        availableTags={availableTags}
-        recentTags={recentTags}
-        currentTagIds={currentTagIds}
-        onAddTag={onAddTag}
-        onCreateTag={onCreateTag}
-        disabled={disabled}
-      >
-        <AddTagButton disabled={disabled} />
-      </TagInputPopup>
+      {!hideAddButton && (
+        <TagInputPopup
+          availableTags={availableTags}
+          recentTags={recentTags}
+          currentTagIds={currentTagIds}
+          onAddTag={onAddTag}
+          onCreateTag={onCreateTag}
+          disabled={disabled}
+        >
+          <AddTagButton disabled={disabled} />
+        </TagInputPopup>
+      )}
 
       {tags.length === 0 && !hideWhenEmpty && (
         <span className="text-[13px] text-stone-400">{t('tagsRow.empty')}</span>

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -694,7 +694,7 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
             onClose={findInPage.close}
           />
 
-          <div className="flex items-center justify-between h-9 py-2 pl-6 pr-3 shrink-0 text-xs/4 [font-synthesis:none]">
+          <div className="flex items-center justify-between h-9 py-2 ps-6 pe-3 shrink-0 text-xs/4 [font-synthesis:none]">
             <JournalBreadcrumb
               viewState={currentViewState}
               isToday={isToday}
@@ -742,6 +742,15 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
                   {currentViewState.type === 'day' && (
                     <>
                       <div className="group/metadata flex flex-col pb-[15px]" data-marquee-ignore>
+                        <GhostAffordanceRow
+                          availableTags={availableTags}
+                          recentTags={recentTags}
+                          currentTagIds={journalTags.map((t) => t.id)}
+                          onAddTag={handleAddTag}
+                          onCreateTag={handleCreateTag}
+                          onAddProperty={handleAddPropertyWithExpand}
+                          className="mb-2"
+                        />
                         <JournalDateDisplay viewState={currentViewState} dateParts={dateParts} />
                         <TagsRow
                           tags={journalTags}
@@ -752,6 +761,7 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
                           onRemoveTag={handleRemoveTag}
                           className="mb-0"
                           hideWhenEmpty
+                          hideAddButton
                         />
                         {properties.length > 0 && (
                           <InfoSection
@@ -768,15 +778,6 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
                             hideAddButton
                           />
                         )}
-                        <GhostAffordanceRow
-                          availableTags={availableTags}
-                          recentTags={recentTags}
-                          currentTagIds={journalTags.map((t) => t.id)}
-                          onAddTag={handleAddTag}
-                          onCreateTag={handleCreateTag}
-                          onAddProperty={handleAddPropertyWithExpand}
-                          hasTags={journalTags.length > 0}
-                        />
                       </div>
 
                       <div

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -1018,6 +1018,18 @@ export function NotePage({ noteId }: NotePageProps) {
       >
         {/* Title + Metadata zone — ghost affordance appears on hover */}
         <div className="group/metadata flex flex-col pb-[15px]" data-marquee-ignore>
+          {/* Ghost affordance: fades in on hover/focus */}
+          <GhostAffordanceRow
+            availableTags={availableTags}
+            recentTags={recentTags}
+            currentTagIds={noteTags.map((t) => t.id)}
+            onAddTag={(...args) => void handleAddTag(...args)}
+            onCreateTag={(...args) => void handleCreateTag(...args)}
+            onAddProperty={handleAddPropertyWithExpand}
+            disabled={isDeleted}
+            className="mb-2"
+          />
+
           <NoteTitle
             emoji={null}
             title={note.title}
@@ -1035,6 +1047,7 @@ export function NotePage({ noteId }: NotePageProps) {
             onRemoveTag={(...args) => void handleRemoveTag(...args)}
             onTagClick={(tag) => openTag(tag.name, tag.color)}
             hideWhenEmpty
+            hideAddButton
           />
 
           {properties.length > 0 && (
@@ -1053,18 +1066,6 @@ export function NotePage({ noteId }: NotePageProps) {
               hideAddButton
             />
           )}
-
-          {/* Ghost affordance: fades in on hover/focus */}
-          <GhostAffordanceRow
-            availableTags={availableTags}
-            recentTags={recentTags}
-            currentTagIds={noteTags.map((t) => t.id)}
-            onAddTag={(...args) => void handleAddTag(...args)}
-            onCreateTag={(...args) => void handleCreateTag(...args)}
-            onAddProperty={handleAddPropertyWithExpand}
-            hasTags={noteTags.length > 0}
-            disabled={isDeleted}
-          />
         </div>
 
         {/* Main content - BlockNote Editor */}

--- a/apps/docs/src/user-guide/journal/daily-entries.md
+++ b/apps/docs/src/user-guide/journal/daily-entries.md
@@ -14,6 +14,8 @@ If today's entry doesn't exist yet, it's created on first focus, seeded by your 
 
 The same BlockNote editor is used for journal entries — slash commands, markdown shortcuts, wiki links, attachments, AI inline. Anything you can do in a note works here too.
 
+Use **Add property** or **Add tag** above the date heading to organize a daily entry before writing.
+
 ## Full-Width Mode
 
 A toggle in the journal header widens the writing column. Useful on big monitors when the default narrow column feels cramped.
@@ -38,12 +40,12 @@ Toggle from [Settings → Journal](/user-guide/settings#journal).
 
 ## Navigating Days
 
-| How | Action |
-| --- | --- |
-| Header arrows | Previous / next day |
-| Date breadcrumb | Click for the date picker |
+| How                                | Action                        |
+| ---------------------------------- | ----------------------------- |
+| Header arrows                      | Previous / next day           |
+| Date breadcrumb                    | Click for the date picker     |
 | [Day Panel](/user-guide/day-panel) | Calendar grid; click any date |
-| Calendar nav | Day / month / year views |
+| Calendar nav                       | Day / month / year views      |
 
 See [Calendar Navigation](/user-guide/journal/calendar-navigation) for the larger views.
 

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -4,9 +4,11 @@ Add structured metadata to notes with custom **properties** and free-form **tags
 
 <!-- screenshot: properties panel and tags row at the top of a note -->
 
+Use **Add property** or **Add tag** above the note title to attach metadata before you start writing.
+
 ## Tags Row
 
-A row at the top of every note for free-form labels.
+A row under the title shows the note's free-form labels.
 
 - Click the tag area to add a tag
 - Comma or space confirms
@@ -24,15 +26,15 @@ A collapsible section under the title for **structured** metadata. Properties ar
 
 ### Property Types
 
-| Type | Use for | Example |
-| --- | --- | --- |
-| Text | Free-form short strings | "Author" |
-| Number | Numeric values | "Pages" |
-| Date | Dates and date ranges | "Started", "Due" |
-| Select | One value from a defined set | "Status: Draft / Live" |
-| Multi-select | Many values from a defined set | "Topics: Coding, Health" |
-| Checkbox | Boolean | "Archived" |
-| Status | Workflow stage with color | "Todo / In progress / Done" |
+| Type         | Use for                        | Example                     |
+| ------------ | ------------------------------ | --------------------------- |
+| Text         | Free-form short strings        | "Author"                    |
+| Number       | Numeric values                 | "Pages"                     |
+| Date         | Dates and date ranges          | "Started", "Due"            |
+| Select       | One value from a defined set   | "Status: Draft / Live"      |
+| Multi-select | Many values from a defined set | "Topics: Coding, Health"    |
+| Checkbox     | Boolean                        | "Archived"                  |
+| Status       | Workflow stage with color      | "Todo / In progress / Done" |
 
 ### Defining Properties
 
@@ -46,12 +48,12 @@ In the property panel, click **Add property** and pick from the list. Set the va
 
 ## Tags vs Properties — When to Use Which
 
-| Need | Use |
-| --- | --- |
-| Quick free-form labels you don't pre-define | Tags |
-| A controlled vocabulary across many notes | Multi-select property |
-| A single workflow state per note | Status property |
-| A date or numeric value | Typed property |
+| Need                                        | Use                   |
+| ------------------------------------------- | --------------------- |
+| Quick free-form labels you don't pre-define | Tags                  |
+| A controlled vocabulary across many notes   | Multi-select property |
+| A single workflow state per note            | Status property       |
+| A date or numeric value                     | Typed property        |
 
 Tags are zero-cost and discoverable. Properties are structured and great for filtering [Folder View](/user-guide/folder-view).
 


### PR DESCRIPTION
## Summary
- Move the note and journal Add property/Add tag affordance above the title/date header.
- Keep existing tags and properties rendered below the title/date while suppressing duplicate inline add-tag controls on these pages.
- Update the note and journal guide docs to match the new metadata action placement.

## Validation
- pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/pages/note.test.tsx src/renderer/src/pages/journal.test.tsx
- pnpm --filter @memry/desktop typecheck:web
- npx -y react-doctor@latest . --verbose --diff
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build
- git diff --check