### PR TITLE
Update Agent Chat composer placeholder

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-pane.test.tsx
@@ -98,7 +98,9 @@ describe('AgentPane', () => {
 
     render(<AgentPane />)
 
-    expect(screen.getByRole('textbox')).toHaveAccessibleName('Ask Agent')
+    expect(screen.getByRole('textbox')).toHaveAccessibleName(
+      'Ask Memry anything. @ to use mention file'
+    )
     expect(screen.queryByText('Start chatting with your vault')).not.toBeInTheDocument()
     expect(screen.queryByText(/claude .*detected and ready/)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'New conversation' })).not.toBeInTheDocument()
@@ -132,7 +134,9 @@ describe('AgentPane', () => {
 
     render(<AgentPane />)
 
-    expect(screen.getByRole('textbox')).toHaveAccessibleName('Ask Agent')
+    expect(screen.getByRole('textbox')).toHaveAccessibleName(
+      'Ask Memry anything. @ to use mention file'
+    )
     expect(screen.queryByText(/claude not found/)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'New conversation' })).not.toBeInTheDocument()
   })

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-prompt-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-prompt-editor.test.tsx
@@ -4,10 +4,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
-import {
-  AgentPromptEditor,
-  type AgentPromptEditorHandle
-} from '../agent-prompt-editor'
+import { AgentPromptEditor, type AgentPromptEditorHandle } from '../agent-prompt-editor'
 import type { MentionAttachment } from '../mention-icons'
 
 function renderPromptEditor() {
@@ -22,7 +19,7 @@ function renderPromptEditor() {
     <AgentPromptEditor
       ref={ref}
       disabled={false}
-      placeholder="Ask Agent"
+      placeholder="Ask Memry anything. @ to use mention file"
       onEscape={onEscape}
       onMentionKeyDown={onMentionKeyDown}
       onMentionQueryChange={onMentionQueryChange}

--- a/apps/desktop/tests/e2e/utils/agent-chat-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/agent-chat-helpers.ts
@@ -22,7 +22,9 @@ export async function openAgentChat(page: Page): Promise<void> {
 }
 
 export function getAgentComposer(page: Page): Locator {
-  return page.getByRole('textbox', { name: 'Ask Agent' })
+  return page.getByRole('textbox', {
+    name: 'Ask Memry anything. @ to use mention file'
+  })
 }
 
 export async function enableManualAgentToolApproval(page: Page): Promise<void> {

--- a/packages/i18n/src/locales/ar/common.json
+++ b/packages/i18n/src/locales/ar/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "المذكرة الحالية",
       "removeAttachment": "قم بإزالة {label}",
-      "placeholder": "اسأل Agent",
+      "placeholder": "اسأل Memry أي شيء. @ لذكر ملف",
       "send": "أرسل",
       "providerLabel": "مزود Agent: {provider}",
       "modelLabel": "موديل Agent: {model}",

--- a/packages/i18n/src/locales/cs/common.json
+++ b/packages/i18n/src/locales/cs/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Aktuální poznámka",
       "removeAttachment": "Odebrat {label}",
-      "placeholder": "Zeptejte se Agent",
+      "placeholder": "Zeptejte se Memry na cokoli. @ pro zmínku o souboru",
       "send": "Odeslat",
       "providerLabel": "Poskytovatel Agent: {provider}",
       "modelLabel": "Model Agent: {model}",

--- a/packages/i18n/src/locales/da/common.json
+++ b/packages/i18n/src/locales/da/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Aktuel note",
       "removeAttachment": "Fjern {label}",
-      "placeholder": "Spørg Agent",
+      "placeholder": "Spørg Memry om hvad som helst. @ for at nævne en fil",
       "send": "Sende",
       "providerLabel": "Agent udbyder: {provider}",
       "modelLabel": "Agentmodel: {model}",

--- a/packages/i18n/src/locales/de/common.json
+++ b/packages/i18n/src/locales/de/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Aktuelle Notiz",
       "removeAttachment": "{label} entfernen",
-      "placeholder": "Fragen Sie Agent",
+      "placeholder": "Fragen Sie Memry alles. @, um eine Datei zu erwähnen",
       "send": "Senden",
       "providerLabel": "Agent Anbieter: {provider}",
       "modelLabel": "Agent Modell: {model}",

--- a/packages/i18n/src/locales/el/common.json
+++ b/packages/i18n/src/locales/el/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Τρέχουσα σημείωση",
       "removeAttachment": "Κατάργηση {label}",
-      "placeholder": "Ρωτήστε το Agent",
+      "placeholder": "Ρωτήστε το Memry οτιδήποτε. @ για αναφορά αρχείου",
       "send": "Αποστολή",
       "providerLabel": "Agent πάροχος: {provider}",
       "modelLabel": "Agent μοντέλο: {model}",

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -112,7 +112,7 @@
     "composer": {
       "currentNote": "Current note",
       "removeAttachment": "Remove {label}",
-      "placeholder": "Ask Agent",
+      "placeholder": "Ask Memry anything. @ to use mention file",
       "send": "Send",
       "providerLabel": "Agent provider: {provider}",
       "modelLabel": "Agent model: {model}",

--- a/packages/i18n/src/locales/es/common.json
+++ b/packages/i18n/src/locales/es/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Nota actual",
       "removeAttachment": "Eliminar {label}",
-      "placeholder": "Preguntar Agent",
+      "placeholder": "Pregunta cualquier cosa a Memry. @ para mencionar un archivo",
       "send": "Enviar",
       "providerLabel": "Proveedor Agent: {provider}",
       "modelLabel": "Agent modelo: {model}",

--- a/packages/i18n/src/locales/fi/common.json
+++ b/packages/i18n/src/locales/fi/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Nykyinen huomautus",
       "removeAttachment": "Poista {label}",
-      "placeholder": "Kysy Agent",
+      "placeholder": "Kysy Memryltä mitä tahansa. @ tiedoston mainitsemiseen",
       "send": "Lähetä",
       "providerLabel": "Agent -toimittaja: {provider}",
       "modelLabel": "Agent malli: {model}",

--- a/packages/i18n/src/locales/fil/common.json
+++ b/packages/i18n/src/locales/fil/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Kasalukuyang tala",
       "removeAttachment": "Alisin ang {label}",
-      "placeholder": "Tanungin ang Agent",
+      "placeholder": "Tanungin ang Memry ng kahit ano. @ para banggitin ang file",
       "send": "Ipadala",
       "providerLabel": "Tagapagbigay ng Agent: {provider}",
       "modelLabel": "Agent modelo: {model}",

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Note actuelle",
       "removeAttachment": "Supprimer {label}",
-      "placeholder": "Demandez à Agent",
+      "placeholder": "Demandez n’importe quoi à Memry. @ pour mentionner un fichier",
       "send": "Envoyer",
       "providerLabel": "Fournisseur Agent: {provider}",
       "modelLabel": "Modèle Agent: {model}",

--- a/packages/i18n/src/locales/he/common.json
+++ b/packages/i18n/src/locales/he/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "הערה נוכחית",
       "removeAttachment": "הסר את {label}",
-      "placeholder": "שאל את Agent",
+      "placeholder": "שאלו את Memry כל דבר. @ כדי להזכיר קובץ",
       "send": "שלח",
       "providerLabel": "ספק Agent: {provider}",
       "modelLabel": "דגם Agent: {model}",

--- a/packages/i18n/src/locales/hr/common.json
+++ b/packages/i18n/src/locales/hr/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Trenutna bilješka",
       "removeAttachment": "Ukloni {label}",
-      "placeholder": "Pitajte Agent",
+      "placeholder": "Pitajte Memry bilo što. @ za spominjanje datoteke",
       "send": "Pošalji",
       "providerLabel": "Agent pružatelj: {provider}",
       "modelLabel": "Model Agent: {model}",

--- a/packages/i18n/src/locales/hu/common.json
+++ b/packages/i18n/src/locales/hu/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Aktuális megjegyzés",
       "removeAttachment": "Távolítsa el az {label} elemet",
-      "placeholder": "Kérdezze meg az Agent-t",
+      "placeholder": "Kérdezz bármit a Memry-től. @ fájl megemlítéséhez",
       "send": "Küldés",
       "providerLabel": "Agent szolgáltató: {provider}",
       "modelLabel": "Agent modell: {model}",

--- a/packages/i18n/src/locales/id/common.json
+++ b/packages/i18n/src/locales/id/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Catatan terkini",
       "removeAttachment": "Hapus {label}",
-      "placeholder": "Tanyakan Agent",
+      "placeholder": "Tanyakan apa saja kepada Memry. @ untuk menyebut file",
       "send": "Kirim",
       "providerLabel": "Penyedia Agent: {provider}",
       "modelLabel": "Model Agent: {model}",

--- a/packages/i18n/src/locales/it/common.json
+++ b/packages/i18n/src/locales/it/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Nota corrente",
       "removeAttachment": "Rimuovi {label}",
-      "placeholder": "Chiedi a Agent",
+      "placeholder": "Chiedi qualsiasi cosa a Memry. @ per menzionare un file",
       "send": "Invia",
       "providerLabel": "Fornitore Agent: {provider}",
       "modelLabel": "Modello Agent: {model}",

--- a/packages/i18n/src/locales/ja/common.json
+++ b/packages/i18n/src/locales/ja/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "現在のメモ",
       "removeAttachment": "{label} を削除します",
-      "placeholder": "Agent に質問する",
+      "placeholder": "Memryに何でも聞いてください。@でファイルをメンション",
       "send": "送信",
       "providerLabel": "Agent プロバイダ: {provider}",
       "modelLabel": "Agent モデル: {model}",

--- a/packages/i18n/src/locales/ko/common.json
+++ b/packages/i18n/src/locales/ko/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "현재 메모",
       "removeAttachment": "{label} 제거",
-      "placeholder": "Agent에게 물어보세요",
+      "placeholder": "Memry에게 무엇이든 물어보세요. @로 파일 멘션",
       "send": "보내기",
       "providerLabel": "Agent 공급자: {provider}",
       "modelLabel": "Agent 모델: {model}",

--- a/packages/i18n/src/locales/ms/common.json
+++ b/packages/i18n/src/locales/ms/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Nota semasa",
       "removeAttachment": "Alih keluar {label}",
-      "placeholder": "Tanya Agent",
+      "placeholder": "Tanya Memry apa-apa sahaja. @ untuk menyebut fail",
       "send": "Hantar",
       "providerLabel": "Pembekal Agent: {provider}",
       "modelLabel": "Model Agent: {model}",

--- a/packages/i18n/src/locales/nl/common.json
+++ b/packages/i18n/src/locales/nl/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Huidige opmerking",
       "removeAttachment": "{label} verwijderen",
-      "placeholder": "Vraag Agent",
+      "placeholder": "Vraag Memry alles. @ om een bestand te vermelden",
       "send": "Verzenden",
       "providerLabel": "Agent-aanbieder: {provider}",
       "modelLabel": "Agent-model: {model}",

--- a/packages/i18n/src/locales/no/common.json
+++ b/packages/i18n/src/locales/no/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Gjeldende merknad",
       "removeAttachment": "Fjern {label}",
-      "placeholder": "Spør Agent",
+      "placeholder": "Spør Memry om hva som helst. @ for å nevne en fil",
       "send": "Sende",
       "providerLabel": "Agent-leverandør: {provider}",
       "modelLabel": "Agent modell: {model}",

--- a/packages/i18n/src/locales/pl/common.json
+++ b/packages/i18n/src/locales/pl/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Aktualna notatka",
       "removeAttachment": "Usuń {label}",
-      "placeholder": "Zapytaj Agent",
+      "placeholder": "Zapytaj Memry o cokolwiek. @, aby wspomnieć plik",
       "send": "Wyślij",
       "providerLabel": "Dostawca Agent: {provider}",
       "modelLabel": "Model Agent: {model}",

--- a/packages/i18n/src/locales/pt/common.json
+++ b/packages/i18n/src/locales/pt/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Nota atual",
       "removeAttachment": "Remover {label}",
-      "placeholder": "Pergunte a Agent",
+      "placeholder": "Pergunte qualquer coisa ao Memry. @ para mencionar um arquivo",
       "send": "Enviar",
       "providerLabel": "Provedor Agent: {provider}",
       "modelLabel": "Modelo Agent: {model}",

--- a/packages/i18n/src/locales/ro/common.json
+++ b/packages/i18n/src/locales/ro/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Notă curentă",
       "removeAttachment": "Eliminați {label}",
-      "placeholder": "Întrebați Agent",
+      "placeholder": "Întreabă Memry orice. @ pentru a menționa un fișier",
       "send": "Trimite",
       "providerLabel": "Furnizor Agent: {provider}",
       "modelLabel": "Model Agent: {model}",

--- a/packages/i18n/src/locales/ru/common.json
+++ b/packages/i18n/src/locales/ru/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Текущая заметка",
       "removeAttachment": "Удалить {label}",
-      "placeholder": "Спросить Agent",
+      "placeholder": "Спросите Memry о чем угодно. @, чтобы упомянуть файл",
       "send": "Отправить",
       "providerLabel": "Поставщик Agent: {provider}",
       "modelLabel": "Модель Agent: {model}",

--- a/packages/i18n/src/locales/sk/common.json
+++ b/packages/i18n/src/locales/sk/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Aktuálna poznámka",
       "removeAttachment": "Odstrániť {label}",
-      "placeholder": "Opýtajte sa Agent",
+      "placeholder": "Opýtajte sa Memry na čokoľvek. @ na zmienku o súbore",
       "send": "Odoslať",
       "providerLabel": "Poskytovateľ Agent: {provider}",
       "modelLabel": "Model Agent: {model}",

--- a/packages/i18n/src/locales/sv/common.json
+++ b/packages/i18n/src/locales/sv/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Aktuell not",
       "removeAttachment": "Ta bort {label}",
-      "placeholder": "Fråga Agent",
+      "placeholder": "Fråga Memry vad som helst. @ för att nämna en fil",
       "send": "Skicka",
       "providerLabel": "Agent-leverantör: {provider}",
       "modelLabel": "Agent modell: {model}",

--- a/packages/i18n/src/locales/th/common.json
+++ b/packages/i18n/src/locales/th/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "บันทึกปัจจุบัน",
       "removeAttachment": "ลบ {label}",
-      "placeholder": "สอบถาม Agent",
+      "placeholder": "ถาม Memry ได้ทุกเรื่อง @ เพื่อกล่าวถึงไฟล์",
       "send": "ส่ง",
       "providerLabel": "ผู้ให้บริการ Agent: {provider}",
       "modelLabel": "รุ่น Agent: {model}",

--- a/packages/i18n/src/locales/tr/common.json
+++ b/packages/i18n/src/locales/tr/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Güncel not",
       "removeAttachment": "{label}'yi kaldır",
-      "placeholder": "Agent'e sorun",
+      "placeholder": "Memry’ye her şeyi sorun. Dosyadan bahsetmek için @ kullanın",
       "send": "Gönder",
       "providerLabel": "Agent sağlayıcısı: {provider}",
       "modelLabel": "Agent modeli: {model}",

--- a/packages/i18n/src/locales/uk/common.json
+++ b/packages/i18n/src/locales/uk/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Актуальна примітка",
       "removeAttachment": "Видалити {label}",
-      "placeholder": "Запитайте Agent",
+      "placeholder": "Запитайте Memry про що завгодно. @, щоб згадати файл",
       "send": "Надіслати",
       "providerLabel": "Постачальник Agent: {provider}",
       "modelLabel": "Модель Agent: {model}",

--- a/packages/i18n/src/locales/vi/common.json
+++ b/packages/i18n/src/locales/vi/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "Ghi chú hiện tại",
       "removeAttachment": "Xóa {label}",
-      "placeholder": "Hỏi Agent",
+      "placeholder": "Hỏi Memry bất cứ điều gì. @ để nhắc đến tệp",
       "send": "Gửi",
       "providerLabel": "Nhà cung cấp Agent: {provider}",
       "modelLabel": "Model Agent: {model}",

--- a/packages/i18n/src/locales/zh-CN/common.json
+++ b/packages/i18n/src/locales/zh-CN/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "当前注释",
       "removeAttachment": "删除 {label}",
-      "placeholder": "询问Agent",
+      "placeholder": "向 Memry 询问任何事。@ 可提及文件",
       "send": "发送",
       "providerLabel": "Agent 提供商：{provider}",
       "modelLabel": "Agent 型号：{model}",

--- a/packages/i18n/src/locales/zh-TW/common.json
+++ b/packages/i18n/src/locales/zh-TW/common.json
@@ -373,7 +373,7 @@
     "composer": {
       "currentNote": "目前註釋",
       "removeAttachment": "刪除 {label}",
-      "placeholder": "詢問Agent",
+      "placeholder": "向 Memry 詢問任何事。@ 可提及檔案",
       "send": "傳送",
       "providerLabel": "Agent 提供者：{provider}",
       "modelLabel": "Agent 型號：{model}",


### PR DESCRIPTION
## Summary
- Update the Agent Chat composer placeholder to: `Ask Memry anything. @ to use mention file`.
- Keep the placeholder i18n-backed across every locale resource.
- Update Agent Chat unit expectations and the E2E composer helper selector.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/agent-chat/__tests__/agent-pane.test.tsx src/renderer/src/agent-chat/__tests__/agent-prompt-editor.test.tsx --project renderer` from `apps/desktop`
- `pnpm --filter @memry/desktop i18n:check`
- `pnpm --filter @memry/i18n test`
- `pnpm docs:impact --base origin/main --strict`
- `pnpm docs:build`
- `git diff --check`

## Notes
- `pnpm --filter @memry/desktop test:i18n-tools` currently fails on existing non-English missing-key coverage outside this placeholder key.
