### PR TITLE
fix(desktop): isolate dev profiles by worktree

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -426,6 +426,19 @@ describe('main index phase2 exports', () => {
     expect(dotenvConfigMock).toHaveBeenCalledWith({ quiet: true })
   })
 
+  it('scopes the default dev profile by worktree path', async () => {
+    process.env.MEMRY_DEVICE = 'dev'
+
+    await importMainModule()
+
+    expect(process.env.MEMRY_DEVICE).toMatch(/^dev-[a-f0-9]{8}$/)
+    expect(process.env.MEMRY_DEVICE).not.toBe('dev')
+    expect(setPathMock).toHaveBeenCalledWith(
+      'userData',
+      `/mock/userData-${process.env.MEMRY_DEVICE}`
+    )
+  })
+
   it('skips the single-instance lock for multi-device test launches', async () => {
     process.env.NODE_ENV = 'test'
     process.env.MEMRY_DEVICE = 'A'

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,6 +13,7 @@ import {
   Menu,
   MenuItem
 } from 'electron'
+import { createHash } from 'node:crypto'
 import { join, resolve, normalize } from 'path'
 import { homedir } from 'node:os'
 import { existsSync, readdirSync, statSync, createReadStream } from 'node:fs'
@@ -66,8 +67,23 @@ if (process.type === 'browser') {
   log.initialize()
 }
 
-const deviceId = process.env.MEMRY_DEVICE
+function resolveDeviceId(): string | undefined {
+  const deviceId = process.env.MEMRY_DEVICE
+  if (deviceId !== 'dev' || app.isPackaged) {
+    return deviceId
+  }
+
+  // Plain pnpm dev runs in every worktree; scope its persisted state by checkout path.
+  const worktreeHash = createHash('sha256')
+    .update(normalize(app.getAppPath()))
+    .digest('hex')
+    .slice(0, 8)
+  return `dev-${worktreeHash}`
+}
+
+const deviceId = resolveDeviceId()
 if (deviceId) {
+  process.env.MEMRY_DEVICE = deviceId
   app.name = `memry-${deviceId}`
   const deviceUserData = `${app.getPath('userData')}-${deviceId}`
   app.setPath('userData', deviceUserData)


### PR DESCRIPTION
## Summary
- Scope plain `pnpm dev` desktop profiles by worktree path instead of sharing the global `dev` profile.
- Keep explicit `MEMRY_DEVICE` values like A/B/C unchanged.
- Add main-process regression coverage for the derived worktree dev profile.

## Root Cause
Every worktree launched plain dev with `MEMRY_DEVICE=dev`, so Electron `userData` and OS keychain accounts were shared across worktrees. A signed-in sync test in one checkout could leak auth/device/vault state into another checkout.

## Validation
- `pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/index.phase2.test.ts`
- `pnpm --filter @memry/desktop typecheck:node`
- `pnpm --filter @memry/desktop exec prettier --check src/main/index.ts src/main/index.phase2.test.ts`
- `git diff --check`
- `pnpm docs:impact --base origin/main --strict`
- `pnpm docs:build`