### PR TITLE
Link Agent Chat user mentions

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
@@ -138,6 +138,44 @@ describe('MessageStream', () => {
     expect(screen.getByText('Planning note')).toBeInTheDocument()
   })
 
+  it('renders inline user mention refs as clickable tags', () => {
+    render(
+      <MessageStream
+        messages={[
+          message({
+            id: 'user-1',
+            role: 'user',
+            content: { role: 'user', data: { text: '@Vim Motions what is about?' } },
+            attachments: [
+              {
+                kind: 'note',
+                refId: 'note-vim',
+                label: 'Vim Motions',
+                snapshotAt: 100,
+                snapshot: { mode: 'reference_only', id: 'note-vim' }
+              }
+            ]
+          })
+        ]}
+      />
+    )
+
+    const mention = screen.getByRole('link', { name: '@Vim Motions' })
+    expect(mention).toHaveClass('rounded-full')
+    expect(mention.getAttribute('href')).toBe('memry://note/note-vim')
+
+    fireEvent.click(mention)
+
+    expect(mockOpenTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'note',
+        title: 'Vim Motions',
+        path: '/note/note-vim',
+        entityId: 'note-vim'
+      })
+    )
+  })
+
   it('ignores non-user content in user message rendering', () => {
     render(
       <MessageStream

--- a/apps/desktop/src/renderer/src/agent-chat/messages/user-message.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/messages/user-message.tsx
@@ -1,27 +1,154 @@
-import type { Message } from '@memry/contracts/ipc-agent'
+import type { Message, MessageAttachment } from '@memry/contracts/ipc-agent'
+import type { MouseEvent } from 'react'
 
 import { Message as AIMessage, MessageContent } from '@/components/ai-elements/message'
 
+import { MemryLinkIcon, useMemryLinkNavigation } from './memry-links'
+
+const userMentionTagClassName =
+  'mx-0.5 inline-flex max-w-full items-center gap-1 rounded-full bg-primary-foreground/15 px-1.5 py-0.5 align-baseline text-xs font-medium text-primary-foreground ring-1 ring-primary-foreground/20 transition-colors hover:bg-primary-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground/50'
+const memryHrefKinds: Partial<Record<MessageAttachment['kind'], string>> = {
+  note: 'note',
+  task: 'task',
+  inbox: 'inbox',
+  journal: 'journal',
+  project: 'project',
+  folder: 'folder'
+}
+
 export function UserMessage({ message }: { message: Message }): React.JSX.Element | null {
+  const navigateMemryLink = useMemryLinkNavigation()
+
   if (message.content.role !== 'user') return null
+
+  const renderedText = renderUserTextWithMentions({
+    text: message.content.data.text,
+    attachments: message.attachments,
+    navigateMemryLink
+  })
+  const remainingAttachments = message.attachments.filter(
+    (attachment) => !renderedText.inlinedAttachmentKeys.has(attachmentKey(attachment))
+  )
 
   return (
     <AIMessage from="user" className="max-w-[85%]">
       <MessageContent className="bg-primary text-primary-foreground">
-        <p className="whitespace-pre-wrap break-words">{message.content.data.text}</p>
-        {message.attachments.length > 0 && (
+        <p className="whitespace-pre-wrap break-words">{renderedText.content}</p>
+        {remainingAttachments.length > 0 && (
           <div className="mt-2 flex flex-wrap justify-end gap-1">
-            {message.attachments.map((attachment) => (
-              <span
-                key={`${attachment.kind}-${attachment.refId}`}
-                className="rounded-full bg-primary-foreground/15 px-2 py-0.5 text-xs"
-              >
-                {attachment.label}
-              </span>
+            {remainingAttachments.map((attachment) => (
+              <UserAttachmentTag
+                key={attachmentKey(attachment)}
+                attachment={attachment}
+                label={attachment.label}
+                navigateMemryLink={navigateMemryLink}
+              />
             ))}
           </div>
         )}
       </MessageContent>
     </AIMessage>
   )
+}
+
+function renderUserTextWithMentions({
+  text,
+  attachments,
+  navigateMemryLink
+}: {
+  text: string
+  attachments: MessageAttachment[]
+  navigateMemryLink: (href: string, title?: string) => boolean
+}): {
+  content: string | Array<string | React.JSX.Element>
+  inlinedAttachmentKeys: Set<string>
+} {
+  const inlinedAttachmentKeys = new Set<string>()
+  let content: Array<string | React.JSX.Element> = [text]
+
+  for (const attachment of [...attachments].sort((a, b) => b.label.length - a.label.length)) {
+    const href = hrefForAttachment(attachment)
+    if (!href) continue
+
+    const label = `@${attachment.label}`
+    const nextContent: Array<string | React.JSX.Element> = []
+    let replaced = false
+
+    for (const part of content) {
+      if (replaced || typeof part !== 'string') {
+        nextContent.push(part)
+        continue
+      }
+
+      const start = part.indexOf(label)
+      if (start < 0) {
+        nextContent.push(part)
+        continue
+      }
+
+      if (start > 0) nextContent.push(part.slice(0, start))
+      nextContent.push(
+        <UserAttachmentTag
+          key={attachmentKey(attachment)}
+          attachment={attachment}
+          label={label}
+          navigateMemryLink={navigateMemryLink}
+        />
+      )
+      if (start + label.length < part.length) {
+        nextContent.push(part.slice(start + label.length))
+      }
+
+      inlinedAttachmentKeys.add(attachmentKey(attachment))
+      replaced = true
+    }
+
+    content = nextContent
+  }
+
+  return {
+    content: content.length === 1 && typeof content[0] === 'string' ? content[0] : content,
+    inlinedAttachmentKeys
+  }
+}
+
+function UserAttachmentTag({
+  attachment,
+  label,
+  navigateMemryLink
+}: {
+  attachment: MessageAttachment
+  label: string
+  navigateMemryLink: (href: string, title?: string) => boolean
+}): React.JSX.Element {
+  const href = hrefForAttachment(attachment)
+
+  if (!href) {
+    return <span className={userMentionTagClassName}>{label}</span>
+  }
+  const targetHref = href
+
+  function handleClick(event: MouseEvent<HTMLAnchorElement>): void {
+    event.preventDefault()
+    navigateMemryLink(targetHref, attachment.label)
+  }
+
+  return (
+    <a href={targetHref} className={userMentionTagClassName} onClick={handleClick}>
+      <MemryLinkIcon href={targetHref} className="text-primary-foreground/90" />
+      <span className="min-w-0">{label}</span>
+    </a>
+  )
+}
+
+function hrefForAttachment(attachment: MessageAttachment): string | null {
+  const id = encodeURIComponent(attachment.refId)
+  if (attachment.kind === 'calendar_event') return `memry://calendar/event/${id}`
+
+  const hrefKind = memryHrefKinds[attachment.kind]
+  return hrefKind ? `memry://${hrefKind}/${id}` : null
+}
+
+function attachmentKey(attachment: MessageAttachment): string {
+  return `${attachment.kind}:${attachment.refId}`
 }


### PR DESCRIPTION
## Summary
- Render structured @ references inside user Agent Chat bubbles as clickable tags.
- Keep unmatched user attachments as fallback chips.
- Add renderer coverage for @Vim Motions opening the linked note.

## Release note
Agent Chat user prompts now show referenced @ items as clickable tags.

## Test plan
- pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
- pnpm --dir apps/desktop typecheck:web
- pnpm --dir apps/desktop exec eslint src/renderer/src/agent-chat/messages/user-message.tsx
- pnpm docs:impact --base origin/main --strict
- git diff --check