### PR TITLE
Compact Agent Chat tool call rows

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
@@ -109,7 +109,7 @@ describe('MessageStream', () => {
 
     expect(screen.getByText('Create a task')).toBeInTheDocument()
     expect(screen.getByText('I can do that.')).toBeInTheDocument()
-    expect(screen.getByText('vault_create_task')).toBeInTheDocument()
+    expect(screen.getByText('Creating task')).toBeInTheDocument()
     expect(screen.getByText('Tool result')).toBeInTheDocument()
     expect(screen.getByText('context_attached')).toBeInTheDocument()
   })
@@ -577,12 +577,14 @@ describe('MessageStream', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: /vault_create_task/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Creating task/i })).toBeInTheDocument()
+    expect(screen.queryByText('vault_create_task')).not.toBeInTheDocument()
     expect(screen.queryByText('Parameters')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /vault_create_task/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Creating task/i }))
 
     expect(screen.getByText('Parameters')).toBeInTheDocument()
+    expect(screen.getByText('vault_create_task')).toBeInTheDocument()
   })
 
   it('renders completed tool output in the same collapsed tool block', () => {
@@ -607,12 +609,43 @@ describe('MessageStream', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: /vault_read_note/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Reading note/i })).toBeInTheDocument()
+    expect(screen.queryByText('vault_read_note')).not.toBeInTheDocument()
     expect(screen.queryByText('Planning')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /vault_read_note/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Reading note/i }))
 
+    expect(screen.getByText('vault_read_note')).toBeInTheDocument()
     expect(screen.getByText(/Planning/)).toBeInTheDocument()
+  })
+
+  it('humanizes MCP tool names and marks active tool labels for the sweep treatment', () => {
+    render(
+      <MessageStream
+        messages={[
+          message({
+            id: 'tool-call-1',
+            role: 'tool_call',
+            toolCallId: 'tool-1',
+            content: {
+              role: 'tool_call',
+              data: {
+                tool: 'mcp__memry__vault_read_note',
+                args: { id: 'note-1' },
+                status: 'input-available'
+              }
+            }
+          })
+        ]}
+      />
+    )
+
+    expect(screen.getByText('Reading note')).toHaveClass('agent-tool-label-active')
+    expect(screen.queryByText('mcp__memry__vault_read_note')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Reading note/i }))
+
+    expect(screen.getByText('mcp__memry__vault_read_note')).toBeInTheDocument()
   })
 
   it('approves pending tool calls inline without a dialog', async () => {
@@ -654,7 +687,7 @@ describe('MessageStream', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /vault_create_task/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Creating task/i }))
     fireEvent.click(screen.getByRole('button', { name: 'Allow once' }))
 
     await waitFor(() => {
@@ -703,7 +736,7 @@ describe('MessageStream', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /vault_create_task/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Creating task/i }))
     fireEvent.click(screen.getByRole('button', { name: 'Edit and allow' }))
     fireEvent.change(screen.getByRole('textbox'), { target: { value: '{"title":"Edited"}' } })
     fireEvent.click(screen.getByRole('button', { name: 'Apply edits' }))
@@ -764,7 +797,7 @@ describe('MessageStream', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /vault_update_note/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Updating note/i }))
     const candidate = await screen.findByRole('textbox', { name: 'Candidate' })
     fireEvent.change(candidate, { target: { value: 'edited full note' } })
     fireEvent.click(screen.getByRole('button', { name: 'Apply edited' }))

--- a/apps/desktop/src/renderer/src/agent-chat/messages/tool-call-message.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/messages/tool-call-message.tsx
@@ -14,7 +14,14 @@ import {
   ConfirmationActions,
   ConfirmationTitle
 } from '@/components/ai-elements/confirmation'
-import { Tool, ToolContent, ToolHeader, ToolInput, ToolOutput } from '@/components/ai-elements/tool'
+import {
+  Tool,
+  ToolContent,
+  ToolHeader,
+  ToolInput,
+  ToolOutput,
+  ToolText
+} from '@/components/ai-elements/tool'
 import { Textarea } from '@/components/ui/textarea'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { useAgentOptional } from '../agent-context'
@@ -26,8 +33,116 @@ function isUpdateTool(name: string): boolean {
   return name.startsWith('vault_update_') || updateToolNames.has(name)
 }
 
+const toolLabels: Record<string, string> = {
+  vault_search_notes: 'Searching notes',
+  vault_read_note: 'Reading note',
+  vault_list_folder: 'Reading folder',
+  vault_get_current_note: 'Reading current note',
+  vault_list_tasks: 'Reading tasks',
+  vault_get_task: 'Reading task',
+  vault_list_projects: 'Reading projects',
+  vault_get_project: 'Reading project',
+  vault_list_statuses: 'Reading statuses',
+  vault_get_journal_entry: 'Reading journal',
+  vault_list_journal_entries: 'Reading journals',
+  vault_list_inbox_items: 'Reading inbox',
+  vault_get_inbox_item: 'Reading inbox item',
+  vault_get_tags: 'Reading tags',
+  vault_desktop_read: 'Reading app data',
+  vault_create_note: 'Creating note',
+  vault_rename_note: 'Renaming note',
+  vault_delete_note: 'Deleting note',
+  vault_create_folder: 'Creating folder',
+  vault_rename_folder: 'Renaming folder',
+  vault_delete_folder: 'Deleting folder',
+  vault_create_task: 'Creating task',
+  vault_delete_task: 'Deleting task',
+  vault_complete_task: 'Completing task',
+  vault_uncomplete_task: 'Reopening task',
+  vault_archive_task: 'Archiving task',
+  vault_unarchive_task: 'Restoring task',
+  vault_move_task: 'Moving task',
+  vault_reorder_tasks: 'Reordering tasks',
+  vault_duplicate_task: 'Duplicating task',
+  vault_convert_task_to_subtask: 'Converting task',
+  vault_convert_subtask_to_task: 'Converting subtask',
+  vault_create_project: 'Creating project',
+  vault_update_project: 'Updating project',
+  vault_delete_project: 'Deleting project',
+  vault_archive_project: 'Archiving project',
+  vault_reorder_projects: 'Reordering projects',
+  vault_create_status: 'Creating status',
+  vault_update_status: 'Updating status',
+  vault_delete_status: 'Deleting status',
+  vault_reorder_statuses: 'Reordering statuses',
+  vault_create_journal_entry: 'Creating journal',
+  vault_update_journal_entry: 'Updating journal',
+  vault_delete_journal_entry: 'Deleting journal',
+  vault_add_to_inbox: 'Adding to inbox',
+  vault_update_inbox_item: 'Updating inbox item',
+  vault_snooze_inbox_item: 'Snoozing inbox item',
+  vault_archive_inbox_item: 'Archiving inbox item',
+  vault_unarchive_inbox_item: 'Restoring inbox item',
+  vault_delete_inbox_item: 'Deleting inbox item',
+  vault_add_inbox_tag: 'Adding inbox tag',
+  vault_remove_inbox_tag: 'Removing inbox tag',
+  vault_update_note: 'Updating note',
+  vault_update_task: 'Updating task',
+  vault_add_tag: 'Adding tag',
+  vault_remove_tag: 'Removing tag',
+  vault_move_to_folder: 'Moving note',
+  vault_desktop_write: 'Updating app data'
+}
+
+const activeToolStatuses = new Set([
+  'approved',
+  'pending',
+  'input-streaming',
+  'approval-requested',
+  'approval-responded',
+  'input-available'
+])
+
 function formatArgs(args: unknown): string {
   return JSON.stringify(args, null, 2)
+}
+
+function normalizeToolName(name: string): string {
+  if (name.startsWith('mcp__memry__')) return name.slice('mcp__memry__'.length)
+  if (name.startsWith('mcp_memry_')) return name.slice('mcp_memry_'.length)
+  return name
+}
+
+function getDesktopToolLabel(tool: string, args: unknown): string | null {
+  if (tool !== 'vault_desktop_read' && tool !== 'vault_desktop_write') return null
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return null
+
+  const operation = (args as { operation?: unknown }).operation
+  if (typeof operation !== 'string') return null
+  if (operation.startsWith('calendar.')) {
+    return tool === 'vault_desktop_read' ? 'Checking calendar' : 'Updating calendar'
+  }
+  if (operation.startsWith('notes.')) return 'Reading notes'
+  if (operation.startsWith('tasks.')) return 'Reading tasks'
+  if (operation.startsWith('inbox.')) return 'Reading inbox'
+
+  return null
+}
+
+function humanizeToolName(name: string, args: unknown): string {
+  const normalized = normalizeToolName(name)
+  const desktopLabel = getDesktopToolLabel(normalized, args)
+  if (desktopLabel) return desktopLabel
+
+  const label = toolLabels[normalized]
+  if (label) return label
+
+  return normalized
+    .replace(/^vault_/, '')
+    .split('_')
+    .filter(Boolean)
+    .join(' ')
+    .replace(/^\w/, (letter) => letter.toUpperCase())
 }
 
 interface AgentDiffApi {
@@ -202,11 +317,14 @@ export function ToolCallMessage({ message }: { message: Message }): React.JSX.El
   }
 
   const errorText = message.content.data.error?.message
+  const toolLabel = humanizeToolName(message.content.data.tool, message.content.data.args)
+  const toolActive = activeToolStatuses.has(message.content.data.status)
 
   return (
     <Tool defaultOpen={false}>
-      <ToolHeader title={message.content.data.tool} state={message.content.data.status} />
+      <ToolHeader active={toolActive} title={toolLabel} state={message.content.data.status} />
       <ToolContent>
+        <ToolText value={message.content.data.tool} />
         <ToolInput input={message.content.data.args} label={t('agentChat.toolCall.parameters')} />
         <ToolOutput errorText={errorText} output={message.content.data.output} />
         {agent && pending?.requiresDiff && (

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -877,6 +877,23 @@ div.react-sigma {
       transform var(--duration-instant) var(--ease-out);
   }
 
+  .agent-tool-label-active {
+    color: transparent;
+    background: linear-gradient(
+      90deg,
+      var(--foreground) 0%,
+      var(--foreground) 35%,
+      color-mix(in srgb, var(--accent-orange) 70%, var(--foreground)) 50%,
+      var(--foreground) 65%,
+      var(--foreground) 100%
+    );
+    background-size: 220% 100%;
+    background-position: 110% 0;
+    -webkit-background-clip: text;
+    background-clip: text;
+    animation: agent-tool-label-sweep 1.45s var(--ease-in-out) infinite;
+  }
+
   .group:hover .quick-actions-reveal,
   .group:focus-within .quick-actions-reveal {
     opacity: 1;
@@ -1153,6 +1170,16 @@ div.react-sigma {
   }
 }
 
+@keyframes agent-tool-label-sweep {
+  0% {
+    background-position: 110% 0;
+  }
+
+  100% {
+    background-position: -110% 0;
+  }
+}
+
 /* Count number pulse */
 @keyframes count-pulse {
   0% {
@@ -1253,6 +1280,11 @@ div.react-sigma {
     animation: none;
     opacity: 1;
     transform: none;
+  }
+
+  .agent-tool-label-active {
+    color: var(--foreground);
+    background: none;
   }
 
   .settings-focus-heartbeat {

--- a/apps/desktop/src/renderer/src/components/ai-elements/tool.tsx
+++ b/apps/desktop/src/renderer/src/components/ai-elements/tool.tsx
@@ -1,9 +1,8 @@
-import type { ComponentProps, ReactNode } from 'react'
+import type { ComponentProps } from 'react'
 import { isValidElement } from 'react'
 
-import { Badge } from '@/components/ui/badge'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { CheckCircle, ChevronDown, Clock, Terminal, XCircle } from '@/lib/icons'
+import { ChevronDown } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
 export type ToolState =
@@ -35,21 +34,6 @@ const statusLabels: Record<ToolState, string> = {
   pending: 'Pending'
 }
 
-const statusIcons: Record<ToolState, ReactNode> = {
-  approved: <Clock className="size-3" aria-hidden="true" />,
-  'approval-requested': <Clock className="size-3" aria-hidden="true" />,
-  'approval-responded': <Clock className="size-3" aria-hidden="true" />,
-  completed: <CheckCircle className="size-3" aria-hidden="true" />,
-  denied: <XCircle className="size-3" aria-hidden="true" />,
-  failed: <XCircle className="size-3" aria-hidden="true" />,
-  'input-available': <Clock className="size-3" aria-hidden="true" />,
-  'input-streaming': <Clock className="size-3" aria-hidden="true" />,
-  'output-available': <CheckCircle className="size-3" aria-hidden="true" />,
-  'output-denied': <XCircle className="size-3" aria-hidden="true" />,
-  'output-error': <XCircle className="size-3" aria-hidden="true" />,
-  pending: <Clock className="size-3" aria-hidden="true" />
-}
-
 export type ToolProps = ComponentProps<typeof Collapsible>
 
 export function Tool({ className, ...props }: ToolProps): React.JSX.Element {
@@ -65,12 +49,14 @@ export function Tool({ className, ...props }: ToolProps): React.JSX.Element {
 }
 
 export type ToolHeaderProps = ComponentProps<typeof CollapsibleTrigger> & {
+  active?: boolean
   state: ToolState
   title?: string
   type?: string
 }
 
 export function ToolHeader({
+  active = false,
   className,
   state,
   title,
@@ -81,23 +67,30 @@ export function ToolHeader({
 
   return (
     <CollapsibleTrigger
-      className={cn('flex w-full items-center justify-between gap-2 p-3 text-start', className)}
+      className={cn(
+        'flex w-full items-center justify-between gap-2 px-3 py-1.5 text-start',
+        className
+      )}
       {...props}
     >
-      <span className="flex min-w-0 items-center gap-2">
-        <Terminal className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-        <span className="truncate font-medium text-foreground">{label}</span>
+      <span className="flex min-w-0 items-center gap-1.5">
+        <span className="shrink-0 text-muted-foreground" aria-hidden="true">
+          &gt;
+        </span>
+        <span
+          className={cn(
+            'truncate font-medium text-foreground',
+            active && 'agent-tool-label-active'
+          )}
+        >
+          {label}
+        </span>
+        <span className="sr-only">{statusLabels[state]}</span>
       </span>
-      <span className="flex shrink-0 items-center gap-2">
-        <Badge variant="secondary" className="gap-1">
-          {statusIcons[state]}
-          {statusLabels[state]}
-        </Badge>
-        <ChevronDown
-          className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
-          aria-hidden="true"
-        />
-      </span>
+      <ChevronDown
+        className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
+        aria-hidden="true"
+      />
     </CollapsibleTrigger>
   )
 }
@@ -111,6 +104,22 @@ export function ToolContent({ className, ...props }: ToolContentProps): React.JS
 export type ToolInputProps = ComponentProps<'div'> & {
   input: unknown
   label?: string
+}
+
+export type ToolTextProps = ComponentProps<'div'> & {
+  label?: string
+  value: string
+}
+
+export function ToolText({ className, label, value, ...props }: ToolTextProps): React.JSX.Element {
+  return (
+    <div className={cn('space-y-2 overflow-hidden', className)} {...props}>
+      <h4 className="font-medium text-muted-foreground text-xs uppercase">{label ?? 'Tool'}</h4>
+      <pre className="max-h-36 overflow-auto rounded-md bg-background p-2 text-muted-foreground">
+        {value}
+      </pre>
+    </div>
+  )
 }
 
 export function ToolInput({

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -212,8 +212,9 @@ Calendar desktop reads accept the same single-object shape as the renderer bridg
 `args: [{"startAt": "2026-05-14T00:00:00.000Z", "endAt": "2026-06-15T00:00:00.000Z"}]`.
 
 By default, Agent Chat accepts these tool calls automatically. The chat still shows each requested
-tool in a collapsed tool row, including running, completed, error, and denied states, so you can open
-the row to inspect parameters and results.
+tool in a compact collapsed row with a readable label such as `Reading note` or `Creating task`.
+Running and waiting tools animate the label while the turn continues. Open the row to inspect the
+raw MCP tool name, parameters, and results.
 
 If you switch tool confirmations to **Ask first** in settings, Memry pauses the turn and shows inline
 approval controls inside the tool row. You can allow the request once, allow create tools always for


### PR DESCRIPTION
## Summary
- Replace raw MCP tool names in collapsed Agent Chat tool rows with readable labels like `Reading note` and `Creating task`.
- Keep raw MCP tool names, parameters, and results available inside the expanded row details.
- Add active-state sweep styling for running or waiting tool calls and document the visible behavior.

## Validation
- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/agent-chat/__tests__/message-stream.test.tsx`
- `pnpm --filter @memry/desktop typecheck:web`
- `pnpm docs:impact --base f4877bc661da631fd64209b00f8dd5fa86336d36 --strict`
- `pnpm docs:build`
- `git diff --check HEAD~1..HEAD`