### PR TITLE
Fix vault key binding after signup

### DIFF
--- a/apps/desktop/src/main/crypto/index.test.ts
+++ b/apps/desktop/src/main/crypto/index.test.ts
@@ -48,6 +48,7 @@ const expectedFunctions = [
   'retrieveKey',
   'storeKey',
   // vault key state
+  'bindLocalVaultToMasterKey',
   'computeVaultKeyVerifier',
   'getOrInitializeLocalVaultKey',
   'storeVaultKeyVerifier',

--- a/apps/desktop/src/main/crypto/index.ts
+++ b/apps/desktop/src/main/crypto/index.ts
@@ -46,6 +46,7 @@ export { CBOR_FIELD_ORDER } from '@memry/contracts/cbor-ordering'
 export { deleteKey, retrieveKey, storeKey } from './keychain'
 
 export {
+  bindLocalVaultToMasterKey,
   computeVaultKeyVerifier,
   getOrInitializeLocalVaultKey,
   storeVaultKeyVerifier

--- a/apps/desktop/src/main/crypto/vault-key-state.test.ts
+++ b/apps/desktop/src/main/crypto/vault-key-state.test.ts
@@ -11,6 +11,7 @@ import { KEYCHAIN_ENTRIES, KEY_DERIVATION_CONTEXTS } from '@memry/contracts/cryp
 import { deriveKey } from './keys'
 import {
   VAULT_KEY_VERIFIER_SETTING,
+  bindLocalVaultToMasterKey,
   computeVaultKeyVerifier,
   getOrInitializeLocalVaultKey
 } from './vault-key-state'
@@ -170,5 +171,63 @@ describe('vault key state', () => {
     await expect(getOrInitializeLocalVaultKey(db, 'vault-1')).rejects.toThrow(
       'Current master key does not match this vault'
     )
+  })
+
+  it('rebinds the verifier to a new account master key and clears old encrypted agent data', async () => {
+    const db = freshDb()
+    const localMaster = new Uint8Array(32).fill(0x11)
+    const accountMaster = new Uint8Array(32).fill(0x22)
+    const localVaultKey = await deriveKey(localMaster, KEY_DERIVATION_CONTEXTS.VAULT_KEY, 32)
+    const accountVaultKey = await deriveKey(accountMaster, KEY_DERIVATION_CONTEXTS.VAULT_KEY, 32)
+
+    db.insert(schema.settings)
+      .values({
+        key: VAULT_KEY_VERIFIER_SETTING,
+        value: computeVaultKeyVerifier(localVaultKey, 'vault-1')
+      })
+      .run()
+    db.insert(schema.agentConversations)
+      .values({
+        id: 'conversation-1',
+        vaultId: 'vault-1',
+        titleCiphertext: '{"version":1,"nonce":"x","ciphertext":"y"}',
+        backend: 'claude_cli',
+        backendModel: null,
+        trustList: [],
+        pinned: false,
+        vectorClock: {},
+        fieldClocks: {},
+        createdAt: 1,
+        updatedAt: 1,
+        deletedAt: null,
+        lastSyncedAt: null
+      })
+      .run()
+    db.insert(schema.agentMessages)
+      .values({
+        id: 'message-1',
+        conversationId: 'conversation-1',
+        role: 'assistant',
+        contentCiphertext: '{"version":1,"nonce":"x","ciphertext":"y"}',
+        attachmentsCiphertext: '{"version":1,"nonce":"x","ciphertext":"y"}',
+        toolCallId: null,
+        status: 'complete',
+        vectorClock: {},
+        createdAt: 1,
+        updatedAt: 1,
+        deletedAt: null
+      })
+      .run()
+
+    await bindLocalVaultToMasterKey(db, 'vault-1', accountMaster)
+
+    const verifier = db
+      .select({ value: schema.settings.value })
+      .from(schema.settings)
+      .where(eq(schema.settings.key, VAULT_KEY_VERIFIER_SETTING))
+      .get()
+    expect(verifier?.value).toBe(computeVaultKeyVerifier(accountVaultKey, 'vault-1'))
+    expect(db.select().from(schema.agentConversations).all()).toEqual([])
+    expect(db.select().from(schema.agentMessages).all()).toEqual([])
   })
 })

--- a/apps/desktop/src/main/crypto/vault-key-state.ts
+++ b/apps/desktop/src/main/crypto/vault-key-state.ts
@@ -28,6 +28,27 @@ export function storeVaultKeyVerifier(db: DataDb, vaultId: string, vaultKey: Uin
   setVaultKeyVerifier(db, computeVaultKeyVerifier(vaultKey, vaultId))
 }
 
+export async function bindLocalVaultToMasterKey(
+  db: DataDb,
+  vaultId: string,
+  masterKey: Uint8Array
+): Promise<void> {
+  await sodium.ready
+
+  const vaultKey = await deriveKey(masterKey, KEY_DERIVATION_CONTEXTS.VAULT_KEY, 32)
+  lockKeyMaterial(vaultKey)
+  try {
+    const current = getVaultKeyVerifier(db)
+    const next = computeVaultKeyVerifier(vaultKey, vaultId)
+    if (current === next) return
+
+    resetLegacyUnboundAgentData(db, vaultId)
+    setVaultKeyVerifier(db, next)
+  } finally {
+    secureCleanup(vaultKey)
+  }
+}
+
 export async function getOrInitializeLocalVaultKey(
   db: DataDb,
   vaultId: string

--- a/apps/desktop/src/main/sync/device-registration.test.ts
+++ b/apps/desktop/src/main/sync/device-registration.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   scheduleTokenRefresh: vi.fn(),
   extractJtiFromToken: vi.fn(),
   getDatabase: vi.fn(),
+  getOrCreateVaultUuid: vi.fn(() => 'vault-1'),
   getSyncEngine: vi.fn(),
   startSyncRuntime: vi.fn(),
   startGoogleCalendarSyncRunner: vi.fn(),
@@ -27,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   logError: vi.fn(),
   toBase64: vi.fn(),
   sign: vi.fn(),
+  bindLocalVaultToMasterKey: vi.fn(),
   dbDelete: vi.fn(),
   dbWhere: vi.fn(),
   dbRun: vi.fn(),
@@ -67,11 +69,16 @@ vi.mock('@memry/contracts/auth-api', () => ({
 vi.mock('../crypto', () => ({
   storeKey: (...args: unknown[]) => mocks.storeKey(...args),
   deleteKey: (...args: unknown[]) => mocks.deleteKey(...args),
-  getDevicePublicKey: (...args: unknown[]) => mocks.getDevicePublicKey(...args)
+  getDevicePublicKey: (...args: unknown[]) => mocks.getDevicePublicKey(...args),
+  bindLocalVaultToMasterKey: (...args: unknown[]) => mocks.bindLocalVaultToMasterKey(...args)
 }))
 
 vi.mock('../database/client', () => ({
   getDatabase: (...args: unknown[]) => mocks.getDatabase(...args)
+}))
+
+vi.mock('../agent/storage/vault-id', () => ({
+  getOrCreateVaultUuid: (...args: unknown[]) => mocks.getOrCreateVaultUuid(...args)
 }))
 
 vi.mock('./http-client', () => ({
@@ -143,6 +150,7 @@ describe('device registration', () => {
     mocks.storeToken.mockResolvedValue(undefined)
     mocks.deleteKey.mockResolvedValue(undefined)
     mocks.deleteFromServer.mockResolvedValue({})
+    mocks.bindLocalVaultToMasterKey.mockResolvedValue(undefined)
   })
 
   it('registers a device, stores tokens and keys, seeds the local device row, and activates sync', async () => {
@@ -180,6 +188,11 @@ describe('device registration', () => {
       'access'
     )
     expect(mocks.storeKey).toHaveBeenCalledWith(keychainEntries.MASTER_KEY, new Uint8Array([5]))
+    expect(mocks.bindLocalVaultToMasterKey).toHaveBeenCalledWith(
+      mocks.getDatabase.mock.results[0].value,
+      'vault-1',
+      new Uint8Array([5])
+    )
     expect(mocks.dbInsert).toHaveBeenCalled()
     expect(mocks.activate).toHaveBeenCalled()
     expect(mocks.startGoogleCalendarSyncRunner).toHaveBeenCalled()

--- a/apps/desktop/src/main/sync/device-registration.ts
+++ b/apps/desktop/src/main/sync/device-registration.ts
@@ -11,12 +11,13 @@ import {
   type DeviceRegisterResponse
 } from '@memry/contracts/auth-api'
 
-import { deleteKey, getDevicePublicKey, storeKey } from '../crypto'
+import { bindLocalVaultToMasterKey, deleteKey, getDevicePublicKey, storeKey } from '../crypto'
 import { getDatabase } from '../database/client'
 import { createLogger } from '../lib/logger'
 import { deleteFromServer, postToServer } from './http-client'
 import { getSyncEngine, startSyncRuntime } from './runtime'
 import { startGoogleCalendarSyncRunner } from '../calendar/google/sync-service'
+import { getOrCreateVaultUuid } from '../agent/storage/vault-id'
 import {
   ACCESS_TOKEN_EXPIRY_SECONDS,
   extractJtiFromToken,
@@ -146,6 +147,8 @@ export const persistKeysAndRegisterDevice = async (
   }
 
   const db = getDatabase()
+  await bindLocalVaultToMasterKey(db, getOrCreateVaultUuid(db), masterKey)
+
   const pubKey = getDevicePublicKey(signingSecretKey)
   const pubKeyBase64 = sodium.to_base64(pubKey, sodium.base64_variants.ORIGINAL)
 

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -32,6 +32,10 @@ Local-only development vaults can create a device master key without sign-in. Me
 non-secret verifier in the local settings table so the SQLite vault stays bound to the keychain
 master key that produced it. If that verifier exists and the keychain key is missing or produces a
 different vault key, encrypted surfaces fail closed instead of silently creating a replacement key.
+When a local-only vault later signs up as the first sync device, device registration stores the
+account master key and rebinds this verifier before the sync runtime activates. That keeps notes
+created before sign-in on the same encrypted sync path instead of leaving the push queue without a
+usable vault key.
 
 ## Nonces
 


### PR DESCRIPTION
## Summary
- Rebind the local vault verifier to the account master key during first-device registration.
- Keep pre-signup local notes on the encrypted sync path after signup.
- Add focused regression coverage and update the cryptography docs note.

## Root Cause
Local-only vault startup can create and bind a vault-key verifier before the user signs in. Signup later stored the account master key, but the verifier still matched the earlier local key. Sync then failed to derive a usable vault key and the push queue stopped at `Push aborted: no vault key`.

## Verification
- `pnpm --filter @memry/desktop rebuild:node`
- `pnpm exec vitest run --config config/vitest.config.ts --project main src/main/crypto/index.test.ts src/main/sync/device-registration.test.ts src/main/crypto/vault-key-state.test.ts`
- `pnpm --filter @memry/desktop typecheck:node`
- `pnpm --filter @memry/desktop test:main`
- `pnpm docs:impact --base 9ee0827c73b7daac6781817cf3e66d27072974bf --strict`
- `pnpm docs:build`
- `git diff --check`