### PR TITLE
Avoid manifest re-pull for local notes

### DIFF
--- a/apps/desktop/src/main/sync/manifest-check.test.ts
+++ b/apps/desktop/src/main/sync/manifest-check.test.ts
@@ -12,6 +12,7 @@ import { inboxItems } from '@memry/db-schema/schema/inbox'
 import { settings } from '@memry/db-schema/schema/settings'
 import { tagDefinitions } from '@memry/db-schema/schema/tag-definitions'
 import { noteCache } from '@memry/db-schema/schema/notes-cache'
+import { noteMetadata } from '@memry/db-schema/data-schema'
 import type { VectorClock } from '@memry/contracts/sync-api'
 import { SyncQueueManager } from './queue'
 
@@ -252,6 +253,43 @@ describe('checkManifestIntegrity', () => {
           clock,
           createdAt: new Date().toISOString(),
           modifiedAt: new Date().toISOString()
+        })
+        .run()
+
+      vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        items: [{ id: 'note-1', type: 'note', version: 1, modifiedAt: 1000, size: 50 }],
+        serverTime: Math.floor(Date.now() / 1000)
+      })
+
+      const { checkManifestIntegrity } = await import('./manifest-check')
+
+      // #when
+      const result = await checkManifestIntegrity({
+        db: asSyncDb(testDb.db),
+        queue,
+        getAccessToken: async () => 'test-token',
+        isOnline: () => true
+      })
+
+      // #then
+      expect(result.rePullNeeded).toBe(false)
+      expect(result.serverOnlyCount).toBe(0)
+    })
+  })
+
+  describe('#given note with clock only in data db #when check runs', () => {
+    it('#then recognizes note as local and does not trigger re-pull', async () => {
+      // #given
+      const clock: VectorClock = { 'device-A': 1 }
+      testDb.db
+        .insert(noteMetadata)
+        .values({
+          id: 'note-1',
+          path: 'notes/test.md',
+          title: 'Test Note',
+          clock,
+          createdAt: '2026-05-15T08:00:00.000Z',
+          modifiedAt: '2026-05-15T08:01:00.000Z'
         })
         .run()
 

--- a/apps/desktop/src/main/sync/manifest-check.ts
+++ b/apps/desktop/src/main/sync/manifest-check.ts
@@ -1,6 +1,7 @@
-import { and, eq, isNotNull, isNull } from 'drizzle-orm'
+import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm'
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
 import type * as schema from '@memry/db-schema/data-schema'
+import { noteMetadata } from '@memry/db-schema/data-schema'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
 import { inboxItems } from '@memry/db-schema/schema/inbox'
@@ -114,25 +115,31 @@ interface LocalSyncableItem {
 
 function getLocalSyncableItems(db: DrizzleDb): LocalSyncableItem[] {
   const items: LocalSyncableItem[] = []
+  const localIds = new Set<string>()
+  const addLocalItem = (item: LocalSyncableItem) => {
+    if (localIds.has(item.id)) return
+    localIds.add(item.id)
+    items.push(item)
+  }
 
   const syncedTasks = db.select().from(tasks).where(isNotNull(tasks.clock)).all()
   for (const t of syncedTasks) {
-    items.push({ id: t.id, type: 'task', payload: JSON.stringify(t) })
+    addLocalItem({ id: t.id, type: 'task', payload: JSON.stringify(t) })
   }
 
   const syncedProjects = db.select().from(projects).where(isNotNull(projects.clock)).all()
   for (const p of syncedProjects) {
-    items.push({ id: p.id, type: 'project', payload: JSON.stringify(p) })
+    addLocalItem({ id: p.id, type: 'project', payload: JSON.stringify(p) })
   }
 
   const syncedInbox = db.select().from(inboxItems).where(isNotNull(inboxItems.clock)).all()
   for (const i of syncedInbox) {
-    items.push({ id: i.id, type: 'inbox', payload: JSON.stringify(i) })
+    addLocalItem({ id: i.id, type: 'inbox', payload: JSON.stringify(i) })
   }
 
   const syncedFilters = db.select().from(savedFilters).where(isNotNull(savedFilters.clock)).all()
   for (const f of syncedFilters) {
-    items.push({ id: f.id, type: 'filter', payload: JSON.stringify(f) })
+    addLocalItem({ id: f.id, type: 'filter', payload: JSON.stringify(f) })
   }
 
   const syncedTagDefs = db
@@ -141,12 +148,25 @@ function getLocalSyncableItems(db: DrizzleDb): LocalSyncableItem[] {
     .where(isNotNull(tagDefinitions.clock))
     .all()
   for (const td of syncedTagDefs) {
-    items.push({ id: td.name, type: 'tag_definition', payload: JSON.stringify(td) })
+    addLocalItem({ id: td.name, type: 'tag_definition', payload: JSON.stringify(td) })
   }
 
   const syncedSettings = db.select().from(settings).where(eq(settings.key, 'synced_settings')).get()
   if (syncedSettings) {
-    items.push({ id: 'synced_settings', type: 'settings', payload: JSON.stringify(syncedSettings) })
+    addLocalItem({
+      id: 'synced_settings',
+      type: 'settings',
+      payload: JSON.stringify(syncedSettings)
+    })
+  }
+
+  const syncedNoteMetadata = db
+    .select({ id: noteMetadata.id, journalDate: noteMetadata.journalDate })
+    .from(noteMetadata)
+    .where(and(isNotNull(noteMetadata.clock), sql`${noteMetadata.localOnly} IS NOT 1`))
+    .all()
+  for (const n of syncedNoteMetadata) {
+    addLocalItem({ id: n.id, type: n.journalDate ? 'journal' : 'note', payload: '' })
   }
 
   const indexDb = getIndexDatabase()
@@ -157,7 +177,7 @@ function getLocalSyncableItems(db: DrizzleDb): LocalSyncableItem[] {
     .where(and(isNotNull(noteCache.clock), isNull(noteCache.date)))
     .all()
   for (const n of syncedNotes) {
-    items.push({ id: n.id, type: 'note', payload: '' })
+    addLocalItem({ id: n.id, type: 'note', payload: '' })
   }
 
   const syncedJournals = indexDb
@@ -166,7 +186,7 @@ function getLocalSyncableItems(db: DrizzleDb): LocalSyncableItem[] {
     .where(and(isNotNull(noteCache.clock), isNotNull(noteCache.date)))
     .all()
   for (const j of syncedJournals) {
-    items.push({ id: j.id, type: 'journal', payload: '' })
+    addLocalItem({ id: j.id, type: 'journal', payload: '' })
   }
 
   return items

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -68,6 +68,12 @@ terminal status.
 
 `server_cursor_sequence` tracks per-device pull progress. Pull is incremental: fetch everything strictly after the cursor, advance, repeat.
 
+## Manifest Integrity
+
+Desktop periodically compares `/sync/manifest` with local syncable records. Notes and journals are
+matched from canonical `note_metadata` first, with the rebuildable index cache as a fallback, so a
+freshly pushed note is not treated as server-only while indexing catches up.
+
 ## Tombstones
 
 Deletions include `deleted_at` inside the **Ed25519-signed** payload — preventing a hostile server from forging deletions.


### PR DESCRIPTION
## Summary
- Include canonical note metadata in manifest local-item detection before the rebuildable index cache.
- Deduplicate local manifest candidates so metadata/cache overlap does not enqueue twice.
- Document the manifest integrity rule in the sync protocol notes.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts --project main src/main/sync/manifest-check.test.ts
- pnpm --filter @memry/desktop typecheck:node
- pnpm docs:impact --base 6d3270720919a6d42418da2361d743238952e545 --strict
- pnpm docs:build
- git diff --check