### PR TITLE
Fix Agent MCP concurrency

### DIFF
--- a/apps/desktop/src/main/agent/bootstrap.test.ts
+++ b/apps/desktop/src/main/agent/bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   getDatabase: vi.fn(() => ({ db: true })),
@@ -58,6 +58,34 @@ const mocks = vi.hoisted(() => ({
     },
     cleanup: vi.fn()
   })),
+  getLocalProviderSettings: vi.fn(async () => ({
+    preset: 'ollama',
+    baseUrl: 'http://localhost:11434/v1',
+    model: '',
+    apiKeyConfigured: false,
+    allowNonLoopback: false
+  })),
+  setLocalProviderSettings: vi.fn(),
+  getLocalProviderApiKey: vi.fn(async () => null),
+  listOpenAiCompatibleModels: vi.fn(async () => ['llama3.2']),
+  testOpenAiCompatibleConnection: vi.fn(async () => ({
+    connected: true,
+    modelAvailable: true,
+    streamingSupported: true,
+    toolCallingSupported: false,
+    toolContinuationSupported: false,
+    toolsEnabled: false,
+    detail: null
+  })),
+  localProbeCapabilities: vi.fn(async () => ({
+    connected: true,
+    modelAvailable: true,
+    streamingSupported: true,
+    toolCallingSupported: false,
+    toolContinuationSupported: false,
+    toolsEnabled: false,
+    detail: null
+  })),
   runtimeInstall: vi.fn(),
   runtimeKillAll: vi.fn(async () => {})
 }))
@@ -88,6 +116,22 @@ vi.mock('./cli/claude-binary', () => ({ detectClaudeBinary: mocks.detectClaudeBi
 vi.mock('./cli/codex-binary', () => ({ detectCodexBinary: mocks.detectCodexBinary }))
 vi.mock('./cli/spawn', () => ({ spawnClaudeTurn: mocks.spawnClaudeTurn }))
 vi.mock('./cli/codex-spawn', () => ({ spawnCodexTurn: mocks.spawnCodexTurn }))
+vi.mock('./backends/local-provider-settings', () => ({
+  getLocalProviderSettings: mocks.getLocalProviderSettings,
+  setLocalProviderSettings: mocks.setLocalProviderSettings
+}))
+vi.mock('./backends/local-provider-keychain', () => ({
+  getLocalProviderApiKey: mocks.getLocalProviderApiKey
+}))
+vi.mock('./backends/local-openai-compatible-backend', () => ({
+  listOpenAiCompatibleModels: mocks.listOpenAiCompatibleModels,
+  testOpenAiCompatibleConnection: mocks.testOpenAiCompatibleConnection,
+  LocalOpenAICompatibleBackend: vi.fn().mockImplementation(function LocalOpenAICompatibleBackend() {
+    return {
+      probeCapabilities: mocks.localProbeCapabilities
+    }
+  })
+}))
 vi.mock('./runtime/runtime', () => ({
   AgentRuntime: vi.fn().mockImplementation(function AgentRuntime() {
     return {
@@ -100,6 +144,10 @@ vi.mock('./runtime/runtime', () => ({
 import { startAgent } from './bootstrap'
 
 describe('startAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('registers unavailable IPC handlers when the local vault key cannot be created', async () => {
     mocks.getOrInitializeLocalVaultKey.mockRejectedValueOnce(new Error('keychain locked'))
 
@@ -153,14 +201,51 @@ describe('startAgent', () => {
     expect(mocks.spawnClaudeTurn).toHaveBeenCalledWith(
       expect.objectContaining({
         binaryPath: 'claude',
-        mcpServerUrl: 'http://127.0.0.1:54321',
-        authorizationValue: 'local-auth-value',
-        conversationId: 'conversation-1',
-        windowId: 'window-1',
+        mcp: {
+          serverUrl: 'http://127.0.0.1:54321',
+          authorizationValue: 'local-auth-value',
+          conversationId: 'conversation-1',
+          windowId: 'window-1',
+          allowedTools: expect.stringContaining('mcp__memry__')
+        },
         effort: 'low',
         model: 'sonnet',
         prompt: 'hello'
       })
+    )
+  })
+
+  it('adapts Claude subprocess spawn with native MCP only for normal turns', async () => {
+    await startAgent()
+    const deps = mocks.registerAgentHandlers.mock.calls[0][0]
+
+    await deps.backends.get('claude_cli').runTurn({
+      prompt: 'hello',
+      conversationId: 'conversation-1',
+      windowId: 'window-1',
+      options: { backend: 'claude_cli', claudeEffort: 'low' }
+    })
+    await deps.backends.get('claude_cli').generateTitle({
+      prompt: 'title',
+      conversationId: 'conversation-1',
+      windowId: 'window-1',
+      options: { backend: 'claude_cli', claudeEffort: 'low' }
+    })
+
+    expect(mocks.spawnClaudeTurn).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        mcp: expect.objectContaining({
+          serverUrl: 'http://127.0.0.1:54321',
+          authorizationValue: 'local-auth-value',
+          conversationId: 'conversation-1',
+          windowId: 'window-1'
+        })
+      })
+    )
+    expect(mocks.spawnClaudeTurn).toHaveBeenNthCalledWith(
+      2,
+      expect.not.objectContaining({ mcp: expect.anything() })
     )
   })
 
@@ -217,6 +302,14 @@ describe('startAgent', () => {
       current: 'old',
       candidate: 'old\n\nnew'
     })
+  })
+
+  it('returns an empty local model list when the provider is not listening', async () => {
+    mocks.listOpenAiCompatibleModels.mockRejectedValueOnce(new TypeError('fetch failed'))
+    await startAgent()
+    const deps = mocks.registerAgentHandlers.mock.calls[0][0]
+
+    await expect(deps.localProvider.listModels()).resolves.toEqual({ models: [] })
   })
 
   it('kills runtime and unregisters handlers on shutdown', async () => {

--- a/apps/desktop/src/main/agent/bootstrap.ts
+++ b/apps/desktop/src/main/agent/bootstrap.ts
@@ -88,18 +88,24 @@ export async function startAgent(): Promise<AgentHandle> {
       throw new Error(binary.installHint ?? 'Claude CLI unavailable')
     }
 
-    const status = getPublicStatus()
-    if (!status.url || !status['token']) {
+    const status = purpose === 'turn' ? getPublicStatus() : null
+    if (purpose === 'turn' && (!status?.url || !status['token'])) {
       throw new Error('Agent MCP server not running')
     }
 
     const sub = await spawnClaudeTurn({
       binaryPath: 'claude',
-      mcpServerUrl: status.url,
-      authorizationValue: status['token'],
-      conversationId,
-      windowId,
-      allowedTools: purpose === 'turn' ? ALLOWED_AGENT_TOOLS : '',
+      ...(status?.url && status['token']
+        ? {
+            mcp: {
+              serverUrl: status.url,
+              authorizationValue: status['token'],
+              conversationId,
+              windowId,
+              allowedTools: ALLOWED_AGENT_TOOLS
+            }
+          }
+        : {}),
       effort,
       model,
       prompt
@@ -212,12 +218,19 @@ export async function startAgent(): Promise<AgentHandle> {
       setSettings: setLocalProviderSettings,
       listModels: async () => {
         const settings = await getLocalProviderSettings()
-        return {
-          models: await listOpenAiCompatibleModels(
-            settings.baseUrl,
-            fetch,
-            await getLocalProviderApiKey()
+        try {
+          return {
+            models: await listOpenAiCompatibleModels(
+              settings.baseUrl,
+              fetch,
+              await getLocalProviderApiKey()
+            )
+          }
+        } catch (error) {
+          logger.warn(
+            `Local provider model listing failed: ${extractErrorMessage(error, 'unknown')}`
           )
+          return { models: [] }
         }
       },
       testConnection: async () => {

--- a/apps/desktop/src/main/agent/cli/__tests__/spawn.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/spawn.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('node:fs/promises', () => ({
   mkdtemp: vi.fn(async () => '/tmp/fake-dir'),
@@ -13,17 +13,23 @@ import { writeFile } from 'node:fs/promises'
 import { spawnClaudeTurn } from '../spawn'
 
 describe('spawnClaudeTurn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('writes mcp-config.json with bearer + conversation/window headers', async () => {
     const fakeProc = makeFakeProc()
     vi.mocked(spawn).mockReturnValue(fakeProc)
 
     await spawnClaudeTurn({
       binaryPath: '/usr/local/bin/claude',
-      mcpServerUrl: 'http://127.0.0.1:54321',
-      authorizationValue: 'test-auth-value',
-      conversationId: 'conv-1',
-      windowId: 'win-1',
-      allowedTools: 'mcp__memry__vault_read_note',
+      mcp: {
+        serverUrl: 'http://127.0.0.1:54321',
+        authorizationValue: 'test-auth-value',
+        conversationId: 'conv-1',
+        windowId: 'win-1',
+        allowedTools: 'mcp__memry__vault_read_note'
+      },
       effort: 'xhigh',
       prompt: 'hello'
     })
@@ -42,11 +48,13 @@ describe('spawnClaudeTurn', () => {
 
     await spawnClaudeTurn({
       binaryPath: '/usr/local/bin/claude',
-      mcpServerUrl: 'http://127.0.0.1:54321',
-      authorizationValue: 'test-auth-value',
-      conversationId: 'c',
-      windowId: 'w',
-      allowedTools: 'mcp__memry__vault_read_note',
+      mcp: {
+        serverUrl: 'http://127.0.0.1:54321',
+        authorizationValue: 'test-auth-value',
+        conversationId: 'c',
+        windowId: 'w',
+        allowedTools: 'mcp__memry__vault_read_note'
+      },
       effort: 'low',
       prompt: 'p'
     })
@@ -77,11 +85,13 @@ describe('spawnClaudeTurn', () => {
 
     await spawnClaudeTurn({
       binaryPath: '/usr/local/bin/claude',
-      mcpServerUrl: 'http://127.0.0.1:54321',
-      authorizationValue: 'test-auth-value',
-      conversationId: 'c',
-      windowId: 'w',
-      allowedTools: 'a',
+      mcp: {
+        serverUrl: 'http://127.0.0.1:54321',
+        authorizationValue: 'test-auth-value',
+        conversationId: 'c',
+        windowId: 'w',
+        allowedTools: 'a'
+      },
       effort: 'xhigh',
       model: 'opus',
       prompt: 'p'
@@ -98,17 +108,36 @@ describe('spawnClaudeTurn', () => {
 
     await spawnClaudeTurn({
       binaryPath: '/usr/local/bin/claude',
-      mcpServerUrl: 'http://127.0.0.1:54321',
-      authorizationValue: 'test-auth-value',
-      conversationId: 'c',
-      windowId: 'w',
-      allowedTools: 'a',
+      mcp: {
+        serverUrl: 'http://127.0.0.1:54321',
+        authorizationValue: 'test-auth-value',
+        conversationId: 'c',
+        windowId: 'w',
+        allowedTools: 'a'
+      },
       effort: 'xhigh',
       prompt: 'PROMPT BODY'
     })
 
     expect(fakeProc.stdin.write).toHaveBeenCalledWith('PROMPT BODY')
     expect(fakeProc.stdin.end).toHaveBeenCalled()
+  })
+
+  it('does not write MCP config or pass MCP flags for tool-free runs', async () => {
+    const fakeProc = makeFakeProc()
+    vi.mocked(spawn).mockReturnValue(fakeProc)
+
+    await spawnClaudeTurn({
+      binaryPath: '/usr/local/bin/claude',
+      effort: 'xhigh',
+      prompt: 'title only'
+    })
+
+    const args = vi.mocked(spawn).mock.calls[0][1] as string[]
+    expect(writeFile).not.toHaveBeenCalled()
+    expect(args).not.toContain('--mcp-config')
+    expect(args).not.toContain('--strict-mcp-config')
+    expect(args).not.toContain('--allowed-tools')
   })
 })
 

--- a/apps/desktop/src/main/agent/cli/spawn.ts
+++ b/apps/desktop/src/main/agent/cli/spawn.ts
@@ -11,11 +11,13 @@ const logger = createLogger('AgentCli:Spawn')
 
 export interface SpawnOptions {
   binaryPath: string
-  mcpServerUrl: string
-  authorizationValue: string
-  conversationId: string
-  windowId: string
-  allowedTools: string
+  mcp?: {
+    serverUrl: string
+    authorizationValue: string
+    conversationId: string
+    windowId: string
+    allowedTools: string
+  }
   effort: ClaudeEffort
   model?: string
   prompt: string
@@ -30,21 +32,6 @@ export interface ClaudeSubprocess {
 export async function spawnClaudeTurn(opts: SpawnOptions): Promise<ClaudeSubprocess> {
   const dir = await mkdtemp(path.join(tmpdir(), 'memry-claude-'))
   const configPath = path.join(dir, 'mcp-config.json')
-  const config = {
-    mcpServers: {
-      memry: {
-        type: 'http',
-        url: `${opts.mcpServerUrl}/mcp`,
-        headers: {
-          Authorization: `Bearer ${opts.authorizationValue}`,
-          'X-Memry-Conversation': opts.conversationId,
-          'X-Memry-Window': opts.windowId
-        }
-      }
-    }
-  }
-
-  await writeFile(configPath, JSON.stringify(config))
 
   const args = [
     '-p',
@@ -54,22 +41,38 @@ export async function spawnClaudeTurn(opts: SpawnOptions): Promise<ClaudeSubproc
     'stream-json',
     '--include-partial-messages',
     '--verbose',
-    '--mcp-config',
-    configPath,
-    '--strict-mcp-config',
     '--no-session-persistence',
     '--tools',
     '',
-    '--allowed-tools',
-    opts.allowedTools,
     '--effort',
     opts.effort
   ]
+  if (opts.mcp) {
+    const config = {
+      mcpServers: {
+        memry: {
+          type: 'http',
+          url: `${opts.mcp.serverUrl}/mcp`,
+          headers: {
+            Authorization: `Bearer ${opts.mcp.authorizationValue}`,
+            'X-Memry-Conversation': opts.mcp.conversationId,
+            'X-Memry-Window': opts.mcp.windowId
+          }
+        }
+      }
+    }
+
+    await writeFile(configPath, JSON.stringify(config))
+    args.splice(7, 0, '--mcp-config', configPath, '--strict-mcp-config')
+    args.splice(args.indexOf('--effort'), 0, '--allowed-tools', opts.mcp.allowedTools)
+  }
   if (opts.model) {
     args.push('--model', opts.model)
   }
 
-  logger.info(`Spawning claude with strict MCP config`)
+  logger.info(
+    opts.mcp ? 'Spawning claude with strict MCP config' : 'Spawning claude without MCP config'
+  )
   const proc = spawn(opts.binaryPath, args, {
     cwd: dir,
     env: { ...process.env }

--- a/apps/desktop/src/main/agent/mcp/__tests__/server.test.ts
+++ b/apps/desktop/src/main/agent/mcp/__tests__/server.test.ts
@@ -91,6 +91,50 @@ describe('Agent MCP server tool round-trip', () => {
     }
   })
 
+  it('serves overlapping MCP tool calls without sharing a connected transport', async () => {
+    let releaseFirst!: () => void
+    let resolveFirstStarted!: () => void
+    const firstStarted = new Promise<void>((resolve) => {
+      resolveFirstStarted = resolve
+    })
+    const firstCanFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const handle = await startAgentMcpServer({
+      toolRegistrations: [
+        {
+          name: 'slow_echo_tool',
+          description: 'echo input after an optional delay',
+          inputSchema: z.object({ msg: z.string() }),
+          handler: async (input) => {
+            const msg = (input as { msg: string }).msg
+            if (msg === 'first') {
+              resolveFirstStarted()
+              await firstCanFinish
+            }
+            return { echoed: msg }
+          }
+        }
+      ]
+    })
+
+    try {
+      const first = callTool(handle, 'slow_echo_tool', { msg: 'first' })
+      await firstStarted
+      const second = callTool(handle, 'slow_echo_tool', { msg: 'second' })
+      await new Promise((resolve) => setTimeout(resolve, 25))
+      releaseFirst()
+
+      const [firstResponse, secondResponse] = await Promise.all([first, second])
+      expect(firstResponse.status).toBe(200)
+      expect(secondResponse.status).toBe(200)
+      expect(await firstResponse.text()).toContain('"echoed":"first"')
+      expect(await secondResponse.text()).toContain('"echoed":"second"')
+    } finally {
+      await handle.stop()
+    }
+  })
+
   it('decorates Memry tool results with source refs for MCP clients', async () => {
     const handle = await startAgentMcpServer({
       toolRegistrations: [
@@ -171,3 +215,24 @@ describe('Agent MCP server tool round-trip', () => {
     }
   })
 })
+
+function callTool(
+  handle: AgentMcpServerHandle,
+  name: string,
+  args: Record<string, unknown>
+): Promise<Response> {
+  return fetch(`${handle.url}/mcp`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${handle.token}`,
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: crypto.randomUUID(),
+      method: 'tools/call',
+      params: { name, arguments: args }
+    })
+  })
+}

--- a/apps/desktop/src/main/agent/mcp/server.ts
+++ b/apps/desktop/src/main/agent/mcp/server.ts
@@ -1,6 +1,6 @@
 import http from 'node:http'
 
-import { McpServer, type RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import type { ZodTypeAny } from 'zod'
 
@@ -36,35 +36,38 @@ export interface AgentMcpServerHandle {
 export async function startAgentMcpServer(opts: StartOptions): Promise<AgentMcpServerHandle> {
   const session = createMcpSession()
   const tools = new Map<string, ToolRegistration>()
-  const registeredTools = new Map<string, RegisteredTool>()
-  const mcp = new McpServer({ name: 'memry-vault', version: '1.0.0' })
 
   function bindTool(reg: ToolRegistration): void {
-    registeredTools.get(reg.name)?.remove()
-    const registered = mcp.registerTool(
-      reg.name,
-      { description: reg.description, inputSchema: reg.inputSchema },
-      async (input, extra) => {
-        const reqHeaders = extra.requestInfo?.headers ?? {}
-        const ctx = session.contextFromHeaders(reqHeaders)
-        try {
-          const result = await reg.handler(input, ctx)
-          const decorated = decorateToolResultWithAgentSources(reg.name, input, result)
-          return {
-            content: [{ type: 'text', text: JSON.stringify(decorated) }],
-            structuredContent: toStructuredContent(decorated)
-          }
-        } catch (err) {
-          logger.error(`Tool ${reg.name} failed`, err)
-          return toMcpToolErrorContent(err)
-        }
-      }
-    )
     tools.set(reg.name, reg)
-    registeredTools.set(reg.name, registered)
   }
 
   for (const reg of opts.toolRegistrations) bindTool(reg)
+
+  function createMcpServer(): McpServer {
+    const mcp = new McpServer({ name: 'memry-vault', version: '1.0.0' })
+    for (const reg of tools.values()) {
+      mcp.registerTool(
+        reg.name,
+        { description: reg.description, inputSchema: reg.inputSchema },
+        async (input, extra) => {
+          const reqHeaders = extra.requestInfo?.headers ?? {}
+          const ctx = session.contextFromHeaders(reqHeaders)
+          try {
+            const result = await reg.handler(input, ctx)
+            const decorated = decorateToolResultWithAgentSources(reg.name, input, result)
+            return {
+              content: [{ type: 'text', text: JSON.stringify(decorated) }],
+              structuredContent: toStructuredContent(decorated)
+            }
+          } catch (err) {
+            logger.error(`Tool ${reg.name} failed`, err)
+            return toMcpToolErrorContent(err)
+          }
+        }
+      )
+    }
+    return mcp
+  }
 
   const server = http.createServer((req, res) => {
     void handleRequest(req, res)
@@ -87,6 +90,7 @@ export async function startAgentMcpServer(opts: StartOptions): Promise<AgentMcpS
 
     if (req.method === 'POST' && req.url === '/mcp') {
       const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+      const mcp = createMcpServer()
       try {
         await mcp.connect(transport)
         const body = await readJson(req)
@@ -98,7 +102,7 @@ export async function startAgentMcpServer(opts: StartOptions): Promise<AgentMcpS
           res.end(JSON.stringify({ error: 'internal' }))
         }
       } finally {
-        await transport.close()
+        await mcp.close()
       }
       return
     }

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -89,6 +89,10 @@ model can emit tool calls and continue after a tool result, Memry enables the fu
 the probe fails, local chat can still answer from attached context, but vault tool calls stay
 disabled.
 
+If the configured local provider is not running, the model picker returns no discovered models
+instead of treating the settings page as an Agent runtime error. Start the provider, then load models
+or test the connection again.
+
 When no conversation is selected yet, the prompt box stays available. Sending the first prompt
 creates a new Agent Chat conversation, attaches the active note when one is open, and streams the
 reply into the sidebar.
@@ -124,6 +128,10 @@ Authorization: Bearer <token>
 
 The token is generated in memory for the current app launch. It is not saved to disk, changes when
 Memry restarts, and can be rotated manually from settings. Missing or stale tokens receive `401`.
+
+The localhost MCP endpoint can serve overlapping Agent Chat turns and external read requests. Memry
+keeps the URL/token stable for the app session, but handles each MCP request with an isolated
+transport so one client connection does not block another.
 
 Client-specific config keys vary. Use the copied URL as the MCP server URL and the copied token as a
 Bearer authorization header. Plain external clients can use read tools, but they do not get the


### PR DESCRIPTION
## Summary
- isolate MCP request handling so overlapping Agent Chat/external MCP requests do not reuse one connected transport
- omit Memry MCP config from Claude title/summary subprocesses while keeping normal turns on the strict MCP allowlist
- return an empty local model list when the configured OpenAI-compatible provider is offline, and document the behavior

## Release note
Fixes Agent Chat MCP connection errors during overlapping turns and keeps local model discovery from surfacing provider-offline errors as handler failures.

## Test plan
- pnpm --filter @memry/desktop exec vitest run src/main/agent/mcp/__tests__/server.test.ts src/main/agent/cli/__tests__/spawn.test.ts src/main/agent/bootstrap.test.ts
- pnpm --filter @memry/desktop typecheck:node
- pnpm --filter @memry/desktop test:main
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build
- git diff --check