### PR TITLE
fix(agent-chat): simplify tool rows

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
@@ -686,6 +686,44 @@ describe('MessageStream', () => {
     expect(screen.getByText('mcp__memry__vault_read_note')).toBeInTheDocument()
   })
 
+  it('renders MCP tool rows borderless and toggles details from the visible label', () => {
+    render(
+      <MessageStream
+        messages={[
+          message({
+            id: 'tool-call-1',
+            role: 'tool_call',
+            toolCallId: 'tool-1',
+            content: {
+              role: 'tool_call',
+              data: {
+                tool: 'mcp__memry__vault_create_note',
+                args: { title: 'Draft' },
+                status: 'input-available'
+              }
+            }
+          })
+        ]}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /Creating note/i })
+    const toolRoot = trigger.parentElement as HTMLElement
+
+    expect(toolRoot).not.toHaveClass('border')
+    expect(toolRoot).not.toHaveClass('border-sidebar-border')
+    expect(trigger.querySelector('svg')).not.toBeInTheDocument()
+    expect(screen.queryByText('Parameters')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Creating note'))
+
+    expect(screen.getByText('Parameters')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Creating note'))
+
+    expect(screen.queryByText('Parameters')).not.toBeInTheDocument()
+  })
+
   it('approves pending tool calls inline without a dialog', async () => {
     mockUseAgentOptional.mockReturnValue({
       state: {

--- a/apps/desktop/src/renderer/src/components/ai-elements/tool.tsx
+++ b/apps/desktop/src/renderer/src/components/ai-elements/tool.tsx
@@ -2,7 +2,6 @@ import type { ComponentProps } from 'react'
 import { isValidElement } from 'react'
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { ChevronDown } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
 export type ToolState =
@@ -38,13 +37,7 @@ export type ToolProps = ComponentProps<typeof Collapsible>
 
 export function Tool({ className, ...props }: ToolProps): React.JSX.Element {
   return (
-    <Collapsible
-      className={cn(
-        'group rounded-md border border-sidebar-border bg-sidebar-accent/40 text-xs',
-        className
-      )}
-      {...props}
-    />
+    <Collapsible className={cn('rounded-md bg-sidebar-accent/40 text-xs', className)} {...props} />
   )
 }
 
@@ -67,10 +60,7 @@ export function ToolHeader({
 
   return (
     <CollapsibleTrigger
-      className={cn(
-        'flex w-full items-center justify-between gap-2 px-3 py-1.5 text-start',
-        className
-      )}
+      className={cn('flex w-full items-center gap-2 px-3 py-1.5 text-start', className)}
       {...props}
     >
       <span className="flex min-w-0 items-center gap-1.5">
@@ -87,10 +77,6 @@ export function ToolHeader({
         </span>
         <span className="sr-only">{statusLabels[state]}</span>
       </span>
-      <ChevronDown
-        className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
-        aria-hidden="true"
-      />
     </CollapsibleTrigger>
   )
 }

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -213,8 +213,8 @@ Calendar desktop reads accept the same single-object shape as the renderer bridg
 
 By default, Agent Chat accepts these tool calls automatically. The chat still shows each requested
 tool in a compact collapsed row with a readable label such as `Reading note` or `Creating task`.
-Running and waiting tools animate the label while the turn continues. Open the row to inspect the
-raw MCP tool name, parameters, and results.
+Running and waiting tools animate the label while the turn continues. Click the row label to open
+or close the borderless details area with the raw MCP tool name, parameters, and results.
 
 If you switch tool confirmations to **Ask first** in settings, Memry pauses the turn and shows inline
 approval controls inside the tool row. You can allow the request once, allow create tools always for


### PR DESCRIPTION
## Summary
- Remove the border and chevron icon from Agent Chat tool rows.
- Keep raw MCP details collapsed behind the readable tool label.
- Document the borderless label-click behavior in the Agent MCP guide.

## Release note
Polish Agent Chat tool rows so MCP tool details open from the readable label without extra border or icon chrome.

## Test plan
- pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
- pnpm --filter @memry/desktop typecheck:web
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build
- git diff --check HEAD~1..HEAD