### PR TITLE
feat(agent-chat): add turn permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format: weekly entries grouped by feature area.
 
 ---
 
+## 2026-05-15 — Agent Chat Turn Permissions
+
+### Added
+
+- Add per-turn Agent Chat access controls for vault-only mode, computer access, and web search.
+
+### Changed
+
+- Move Agent permissions into Settings and tighten the composer controls for model, reasoning, and permissions.
+
 ## 2026-05-14 — Agent Chat Inbox Snooze Tool
 
 ### Added
@@ -14,6 +24,7 @@ Format: weekly entries grouped by feature area.
 ### Changed
 
 - Make the Agent Chat system prompt use concrete Memry workflows and exact MCP tool names for current notes, folders, tags, journals, inbox triage, and links.
+
 ## 2026-05-14 — Agent Chat Inline Mentions
 
 ### Added
@@ -23,6 +34,7 @@ Format: weekly entries grouped by feature area.
 ### Changed
 
 - Keep picked Agent references inside the prompt instead of showing a separate attachment row, and focus the composer after creating a new conversation from the sidebar plus action.
+
 ## 2026-05-14 — Agent Calendar MCP Reads
 
 ### Fixed

--- a/apps/desktop/src/main/agent/backends/__tests__/claude-cli-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/claude-cli-backend.test.ts
@@ -105,6 +105,25 @@ describe('ClaudeCliBackend', () => {
     )
   })
 
+  it('forwards turn permissions to the Claude subprocess adapter', async () => {
+    const spawn = vi.fn(async () => createHandle(''))
+    const backend = new ClaudeCliBackend({ spawn })
+
+    await backend.runTurn({
+      prompt: 'User: inspect',
+      conversationId: 'conversation-1',
+      windowId: 'window-1',
+      options: { backend: 'claude_cli', claudeEffort: 'low' },
+      permissions: { accessMode: 'computer_access', webSearchEnabled: true }
+    })
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        permissions: { accessMode: 'computer_access', webSearchEnabled: true }
+      })
+    )
+  })
+
   it('reports Claude CLI availability through the unified backend status shape', async () => {
     const backend = new ClaudeCliBackend({ spawn: vi.fn() })
 

--- a/apps/desktop/src/main/agent/backends/__tests__/codex-cli-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/codex-cli-backend.test.ts
@@ -66,6 +66,25 @@ describe('CodexCliBackend', () => {
     expect(spawn).toHaveBeenNthCalledWith(2, expect.objectContaining({ purpose: 'summary' }))
   })
 
+  it('forwards turn permissions to the Codex subprocess adapter', async () => {
+    const spawn = vi.fn(async () => createHandle(''))
+    const backend = new CodexCliBackend({ spawn })
+
+    await backend.runTurn({
+      prompt: 'User: inspect',
+      conversationId: 'conversation-1',
+      windowId: 'window-1',
+      options: { backend: 'codex_cli', reasoningEffort: 'medium' },
+      permissions: { accessMode: 'computer_access', webSearchEnabled: true }
+    })
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        permissions: { accessMode: 'computer_access', webSearchEnabled: true }
+      })
+    )
+  })
+
   it('reports Codex CLI availability through the unified backend status shape', async () => {
     const backend = new CodexCliBackend({ spawn: vi.fn() })
 

--- a/apps/desktop/src/main/agent/backends/claude-cli-backend.ts
+++ b/apps/desktop/src/main/agent/backends/claude-cli-backend.ts
@@ -56,6 +56,7 @@ export class ClaudeCliBackend implements AgentBackend {
       windowId: input.windowId,
       effort,
       model,
+      ...(input.permissions ? { permissions: input.permissions } : {}),
       purpose
     })
 

--- a/apps/desktop/src/main/agent/backends/codex-cli-backend.ts
+++ b/apps/desktop/src/main/agent/backends/codex-cli-backend.ts
@@ -54,6 +54,7 @@ export class CodexCliBackend implements AgentBackend {
       windowId: input.windowId,
       reasoningEffort,
       model,
+      ...(input.permissions ? { permissions: input.permissions } : {}),
       purpose
     })
 

--- a/apps/desktop/src/main/agent/backends/types.ts
+++ b/apps/desktop/src/main/agent/backends/types.ts
@@ -3,6 +3,7 @@ import type {
   AgentBackendOptions,
   AgentBackendStatus,
   AgentLocalProviderProbeResult,
+  AgentTurnPermissions,
   ClaudeEffort,
   CodexReasoningEffort
 } from '@memry/contracts/ipc-agent'
@@ -23,6 +24,7 @@ export interface AgentBackendRunInput {
   conversationId: string
   windowId: string
   options: AgentBackendOptions
+  permissions?: AgentTurnPermissions
   purpose?: 'turn' | 'summary' | 'title'
 }
 
@@ -42,6 +44,7 @@ export interface ClaudeCliSpawnInput {
   windowId: string
   effort: ClaudeEffort
   model?: string
+  permissions?: AgentTurnPermissions
   purpose?: 'turn' | 'summary' | 'title'
 }
 
@@ -51,6 +54,7 @@ export interface CodexCliSpawnInput {
   windowId: string
   reasoningEffort: CodexReasoningEffort
   model?: string
+  permissions?: AgentTurnPermissions
   purpose?: 'turn' | 'summary' | 'title'
 }
 

--- a/apps/desktop/src/main/agent/bootstrap.ts
+++ b/apps/desktop/src/main/agent/bootstrap.ts
@@ -81,6 +81,7 @@ export async function startAgent(): Promise<AgentHandle> {
     windowId,
     effort,
     model,
+    permissions,
     purpose = 'turn'
   }: ClaudeCliSpawnInput) => {
     const binary = await detectClaudeBinary()
@@ -108,6 +109,7 @@ export async function startAgent(): Promise<AgentHandle> {
         : {}),
       effort,
       model,
+      ...(permissions ? { permissions } : {}),
       prompt
     })
 
@@ -136,6 +138,7 @@ export async function startAgent(): Promise<AgentHandle> {
     windowId,
     reasoningEffort,
     model,
+    permissions,
     purpose = 'turn'
   }: CodexCliSpawnInput) => {
     const binary = await detectCodexBinary()
@@ -153,6 +156,7 @@ export async function startAgent(): Promise<AgentHandle> {
       prompt,
       reasoningEffort,
       model,
+      ...(permissions ? { permissions } : {}),
       ...(status?.url && status['token']
         ? {
             mcp: {

--- a/apps/desktop/src/main/agent/cli/__tests__/codex-spawn.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/codex-spawn.test.ts
@@ -59,6 +59,41 @@ describe('spawnCodexTurn', () => {
     expect(options.env.MEMRY_AGENT_WINDOW).toBe('window-1')
   })
 
+  it('passes native web search without opening the filesystem sandbox', async () => {
+    const fakeProc = makeFakeProc()
+    vi.mocked(spawn).mockReturnValue(fakeProc)
+
+    await spawnCodexTurn({
+      binaryPath: '/opt/homebrew/bin/codex',
+      prompt: 'search for this',
+      reasoningEffort: 'medium',
+      permissions: { accessMode: 'vault_only', webSearchEnabled: true }
+    })
+
+    const args = vi.mocked(spawn).mock.calls[0][1] as string[]
+    expect(args).toContain('--search')
+    expect(args).toContain('--disable')
+    expect(args).toContain('shell_tool')
+    expect(args[args.indexOf('--sandbox') + 1]).toBe('read-only')
+  })
+
+  it('uses danger-full-access and native tools when computer access is requested', async () => {
+    const fakeProc = makeFakeProc()
+    vi.mocked(spawn).mockReturnValue(fakeProc)
+
+    await spawnCodexTurn({
+      binaryPath: '/opt/homebrew/bin/codex',
+      prompt: 'inspect files',
+      reasoningEffort: 'medium',
+      permissions: { accessMode: 'computer_access', webSearchEnabled: false }
+    })
+
+    const args = vi.mocked(spawn).mock.calls[0][1] as string[]
+    expect(args).not.toContain('shell_tool')
+    expect(args).not.toContain('apply_patch_freeform')
+    expect(args[args.indexOf('--sandbox') + 1]).toBe('danger-full-access')
+  })
+
   it('passes the prompt as the final exec argument', async () => {
     const fakeProc = makeFakeProc()
     vi.mocked(spawn).mockReturnValue(fakeProc)

--- a/apps/desktop/src/main/agent/cli/__tests__/spawn.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/spawn.test.ts
@@ -79,6 +79,59 @@ describe('spawnClaudeTurn', () => {
     expect(args).not.toContain('--model')
   })
 
+  it('keeps vault access scoped while enabling web tools when requested', async () => {
+    const fakeProc = makeFakeProc()
+    vi.mocked(spawn).mockReturnValue(fakeProc)
+
+    await spawnClaudeTurn({
+      binaryPath: '/usr/local/bin/claude',
+      mcp: {
+        serverUrl: 'http://127.0.0.1:54321',
+        authorizationValue: 'test-auth-value',
+        conversationId: 'c',
+        windowId: 'w',
+        allowedTools: 'mcp__memry__vault_read_note'
+      },
+      effort: 'low',
+      permissions: { accessMode: 'vault_only', webSearchEnabled: true },
+      prompt: 'p'
+    })
+
+    const args = vi.mocked(spawn).mock.calls[0][1] as string[]
+    expect(args[args.indexOf('--tools') + 1]).toBe('WebSearch,WebFetch')
+    expect(args[args.indexOf('--allowed-tools') + 1]).toBe(
+      'mcp__memry__vault_read_note,WebSearch,WebFetch'
+    )
+    expect(args).not.toContain('--permission-mode')
+  })
+
+  it('enables default Claude tools without allowlisting when computer access is requested', async () => {
+    const fakeProc = makeFakeProc()
+    vi.mocked(spawn).mockReturnValue(fakeProc)
+
+    await spawnClaudeTurn({
+      binaryPath: '/usr/local/bin/claude',
+      mcp: {
+        serverUrl: 'http://127.0.0.1:54321',
+        authorizationValue: 'test-auth-value',
+        conversationId: 'c',
+        windowId: 'w',
+        allowedTools: 'mcp__memry__vault_read_note'
+      },
+      effort: 'low',
+      permissions: { accessMode: 'computer_access', webSearchEnabled: false },
+      prompt: 'p'
+    })
+
+    const args = vi.mocked(spawn).mock.calls[0][1] as string[]
+    expect(args[args.indexOf('--tools') + 1]).toBe('default')
+    expect(args).toContain('--add-dir')
+    expect(args[args.indexOf('--add-dir') + 1]).toBe('/')
+    expect(args).toContain('--permission-mode')
+    expect(args[args.indexOf('--permission-mode') + 1]).toBe('dontAsk')
+    expect(args).not.toContain('--allowed-tools')
+  })
+
   it('passes an explicit Claude model when selected', async () => {
     const fakeProc = makeFakeProc()
     vi.mocked(spawn).mockReturnValue(fakeProc)

--- a/apps/desktop/src/main/agent/cli/codex-spawn.ts
+++ b/apps/desktop/src/main/agent/cli/codex-spawn.ts
@@ -3,17 +3,22 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
-import type { CodexReasoningEffort } from '@memry/contracts/ipc-agent'
+import type { AgentTurnPermissions, CodexReasoningEffort } from '@memry/contracts/ipc-agent'
 
 import { createLogger } from '../../lib/logger'
 
 const logger = createLogger('AgentCli:CodexSpawn')
+const DEFAULT_TURN_PERMISSIONS: AgentTurnPermissions = {
+  accessMode: 'vault_only',
+  webSearchEnabled: false
+}
 
 export interface CodexSpawnOptions {
   binaryPath: string
   prompt: string
   reasoningEffort: CodexReasoningEffort
   model?: string
+  permissions?: AgentTurnPermissions
   mcp?: {
     serverUrl: string
     authorizationValue: string
@@ -30,17 +35,19 @@ export interface CodexSubprocess {
 
 export async function spawnCodexTurn(opts: CodexSpawnOptions): Promise<CodexSubprocess> {
   const dir = await mkdtemp(path.join(tmpdir(), 'memry-codex-'))
-  const args = [
-    '--ask-for-approval',
-    'never',
-    '--disable',
-    'shell_tool',
-    '--disable',
-    'apply_patch_freeform',
+  const permissions = opts.permissions ?? DEFAULT_TURN_PERMISSIONS
+  const args = ['--ask-for-approval', 'never']
+  if (permissions.webSearchEnabled) {
+    args.push('--search')
+  }
+  if (permissions.accessMode === 'vault_only') {
+    args.push('--disable', 'shell_tool', '--disable', 'apply_patch_freeform')
+  }
+  args.push(
     'exec',
     '--json',
     '--sandbox',
-    'read-only',
+    permissions.accessMode === 'computer_access' ? 'danger-full-access' : 'read-only',
     '--ephemeral',
     '--ignore-user-config',
     '--ignore-rules',
@@ -49,7 +56,7 @@ export async function spawnCodexTurn(opts: CodexSpawnOptions): Promise<CodexSubp
     dir,
     '-c',
     `model_reasoning_effort="${opts.reasoningEffort}"`
-  ]
+  )
   if (opts.model) {
     args.push('--model', opts.model)
   }

--- a/apps/desktop/src/main/agent/cli/spawn.ts
+++ b/apps/desktop/src/main/agent/cli/spawn.ts
@@ -3,11 +3,16 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
-import type { ClaudeEffort } from '@memry/contracts/ipc-agent'
+import type { AgentTurnPermissions, ClaudeEffort } from '@memry/contracts/ipc-agent'
 
 import { createLogger } from '../../lib/logger'
 
 const logger = createLogger('AgentCli:Spawn')
+const DEFAULT_TURN_PERMISSIONS: AgentTurnPermissions = {
+  accessMode: 'vault_only',
+  webSearchEnabled: false
+}
+const CLAUDE_WEB_TOOLS = ['WebSearch', 'WebFetch']
 
 export interface SpawnOptions {
   binaryPath: string
@@ -20,6 +25,7 @@ export interface SpawnOptions {
   }
   effort: ClaudeEffort
   model?: string
+  permissions?: AgentTurnPermissions
   prompt: string
 }
 
@@ -32,6 +38,13 @@ export interface ClaudeSubprocess {
 export async function spawnClaudeTurn(opts: SpawnOptions): Promise<ClaudeSubprocess> {
   const dir = await mkdtemp(path.join(tmpdir(), 'memry-claude-'))
   const configPath = path.join(dir, 'mcp-config.json')
+  const permissions = opts.permissions ?? DEFAULT_TURN_PERMISSIONS
+  const builtInTools =
+    permissions.accessMode === 'computer_access'
+      ? 'default'
+      : permissions.webSearchEnabled
+        ? CLAUDE_WEB_TOOLS.join(',')
+        : ''
 
   const args = [
     '-p',
@@ -43,10 +56,13 @@ export async function spawnClaudeTurn(opts: SpawnOptions): Promise<ClaudeSubproc
     '--verbose',
     '--no-session-persistence',
     '--tools',
-    '',
+    builtInTools,
     '--effort',
     opts.effort
   ]
+  if (permissions.accessMode === 'computer_access') {
+    args.splice(args.indexOf('--effort'), 0, '--add-dir', '/', '--permission-mode', 'dontAsk')
+  }
   if (opts.mcp) {
     const config = {
       mcpServers: {
@@ -64,7 +80,13 @@ export async function spawnClaudeTurn(opts: SpawnOptions): Promise<ClaudeSubproc
 
     await writeFile(configPath, JSON.stringify(config))
     args.splice(7, 0, '--mcp-config', configPath, '--strict-mcp-config')
-    args.splice(args.indexOf('--effort'), 0, '--allowed-tools', opts.mcp.allowedTools)
+    if (permissions.accessMode !== 'computer_access') {
+      const allowedTools = [
+        opts.mcp.allowedTools,
+        ...(permissions.webSearchEnabled ? CLAUDE_WEB_TOOLS : [])
+      ].join(',')
+      args.splice(args.indexOf('--effort'), 0, '--allowed-tools', allowedTools)
+    }
   }
   if (opts.model) {
     args.push('--model', opts.model)

--- a/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
@@ -25,7 +25,7 @@ function createRuntime(toolApprovalMode: 'always_accept' | 'ask' = 'always_accep
   const runtime = new AgentRuntime({
     conversations: conversations as unknown as ConversationStore,
     messages: {} as MessageStore,
-    getPreferences: () => ({ toolApprovalMode })
+    getPreferences: () => ({ accessMode: 'vault_only', toolApprovalMode })
   })
 
   return { runtime, conversations }

--- a/apps/desktop/src/main/agent/runtime/__tests__/turn.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/turn.test.ts
@@ -67,6 +67,42 @@ describe('runTurn against a stub backend', () => {
     )
   })
 
+  it('passes active permissions to the backend run policy and prompt', async () => {
+    const messages = createFakeMessageStore()
+    const conversations = createFakeConversationStore({ title: 'Existing conversation' })
+    const backend = createFakeBackend({
+      turn: [{ kind: 'message_stop' }]
+    })
+
+    await runTurn(
+      {
+        conversations,
+        messages,
+        backends: createFakeRegistry(backend)
+      },
+      {
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'search then inspect files',
+        attachments: [],
+        backendOptions: { backend: 'codex_cli', reasoningEffort: 'medium' },
+        permissions: { accessMode: 'computer_access', webSearchEnabled: true }
+      }
+    )
+
+    expect(backend.runTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        permissions: { accessMode: 'computer_access', webSearchEnabled: true },
+        prompt: expect.stringContaining('# Active Permissions')
+      })
+    )
+    expect(backend.runTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining('Computer access requested for this turn.')
+      })
+    )
+  })
+
   it('marks the assistant message as errored when the subprocess exits non-zero', async () => {
     const messages = createFakeMessageStore()
     const conversations = createFakeConversationStore({ title: 'Existing conversation' })

--- a/apps/desktop/src/main/agent/runtime/prompt-assembler.ts
+++ b/apps/desktop/src/main/agent/runtime/prompt-assembler.ts
@@ -1,3 +1,5 @@
+import type { AgentTurnPermissions } from '@memry/contracts/ipc-agent'
+
 import type { Message, MessageAttachment } from '../storage/types'
 
 export const SYSTEM_PROMPT_HEADER = [
@@ -17,7 +19,7 @@ export const SYSTEM_PROMPT_HEADER = [
   '- Do not scan the whole vault unless the user asks for broad analysis. Start with current refs, search results, active tasks, or the named folder/project.',
   '- If a tool errors, surface the error plainly. Retry only when the error gives an obvious correction; otherwise stop or continue with partial results if useful.',
   '- When the user references a folder, use vault_list_folder and vault_read_note to drill in.',
-  "- Stay inside this user's vault. Refuse requests to access other users, network resources, system files, secrets, or non-allowlisted desktop operations.",
+  "- Stay inside this user's vault by default. Refuse requests to access other users, system files, secrets, or non-allowlisted desktop operations. Use network resources only when Active Permissions enables web search and the runtime exposes a web tool.",
   '',
   '# Memry Objects',
   '- Use notes for durable knowledge.',
@@ -62,6 +64,7 @@ export interface AssembleInput {
   history: Message[]
   userMessage: string
   attachments: MessageAttachment[]
+  permissions?: AgentTurnPermissions
   context?: PromptContext
 }
 
@@ -70,6 +73,10 @@ export function assemblePrompt(input: AssembleInput): string {
 
   if (input.context) {
     lines.push(...renderContext(input.context), '')
+  }
+
+  if (input.permissions) {
+    lines.push(...renderPermissions(input.permissions), '')
   }
 
   if (input.attachments.length > 0) {
@@ -90,6 +97,23 @@ export function assemblePrompt(input: AssembleInput): string {
 
   lines.push(`User: ${input.userMessage}`)
   return lines.join('\n')
+}
+
+function renderPermissions(permissions: AgentTurnPermissions): string[] {
+  const access =
+    permissions.accessMode === 'computer_access'
+      ? 'Computer access requested for this turn.'
+      : 'Vault-only access for this turn.'
+  const web = permissions.webSearchEnabled
+    ? 'Web search requested for this turn.'
+    : 'Web search is off for this turn.'
+
+  return [
+    '# Active Permissions',
+    access,
+    web,
+    'Use only tools exposed by this runtime. If a requested capability is not available, say so instead of pretending it ran.'
+  ]
 }
 
 function renderContext(context: PromptContext): string[] {

--- a/apps/desktop/src/main/agent/runtime/turn.ts
+++ b/apps/desktop/src/main/agent/runtime/turn.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 
-import type { AgentBackendOptions } from '@memry/contracts/ipc-agent'
+import type { AgentBackendOptions, AgentTurnPermissions } from '@memry/contracts/ipc-agent'
 
 import { createLogger } from '../../lib/logger'
 import type { BackendEvent } from '../cli/types'
@@ -26,12 +26,17 @@ export interface TurnDeps {
 }
 
 const DEFAULT_CONVERSATION_TITLE = 'New conversation'
+const DEFAULT_TURN_PERMISSIONS: AgentTurnPermissions = {
+  accessMode: 'vault_only',
+  webSearchEnabled: false
+}
 
 export interface RunTurnInput {
   conversationId: string
   sourceWindowId: string
   text: string
   backendOptions: AgentBackendOptions
+  permissions?: AgentTurnPermissions
   attachments: MessageAttachment[]
 }
 
@@ -40,6 +45,7 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
   const existingMessages = deps.messages.listByConversation(input.conversationId)
   const existingConversation = deps.conversations.getById(input.conversationId)
   const backend = deps.backends.get(input.backendOptions.backend)
+  const permissions = input.permissions ?? DEFAULT_TURN_PERMISSIONS
   const shouldGenerateTitle =
     existingConversation?.title.trim() === DEFAULT_CONVERSATION_TITLE &&
     !existingMessages.some((message) => message.role === 'user')
@@ -75,6 +81,7 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
     history,
     userMessage: input.text,
     attachments: input.attachments,
+    permissions,
     context: promptContext
   })
 
@@ -100,6 +107,7 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
     history,
     userMessage: input.text,
     attachments: input.attachments,
+    permissions,
     context: promptContext
   })
 
@@ -108,6 +116,7 @@ export async function runTurn(deps: TurnDeps, input: RunTurnInput): Promise<{ tu
     conversationId: input.conversationId,
     windowId: input.sourceWindowId,
     options: input.backendOptions,
+    permissions,
     purpose: 'turn'
   })
   const sub = deps.trackRunHandle?.(input.conversationId, rawSub) ?? rawSub

--- a/apps/desktop/src/main/agent/settings.test.ts
+++ b/apps/desktop/src/main/agent/settings.test.ts
@@ -23,20 +23,37 @@ describe('agent preferences', () => {
     storeState.agent = {}
   })
 
-  it('defaults tool approval to always accept', () => {
-    expect(getAgentPreferences()).toEqual({ toolApprovalMode: 'always_accept' })
+  it('defaults agent permissions to vault access with automatic confirmations', () => {
+    expect(getAgentPreferences()).toEqual({
+      accessMode: 'vault_only',
+      toolApprovalMode: 'always_accept'
+    })
   })
 
   it('persists manual tool approval mode', () => {
     expect(setAgentPreferences({ toolApprovalMode: 'ask' })).toEqual({
+      accessMode: 'vault_only',
       toolApprovalMode: 'ask'
     })
-    expect(getAgentPreferences()).toEqual({ toolApprovalMode: 'ask' })
+    expect(getAgentPreferences()).toEqual({
+      accessMode: 'vault_only',
+      toolApprovalMode: 'ask'
+    })
+  })
+
+  it('persists default access mode', () => {
+    expect(setAgentPreferences({ accessMode: 'computer_access' })).toEqual({
+      accessMode: 'computer_access',
+      toolApprovalMode: 'always_accept'
+    })
   })
 
   it('keeps the current preference when an empty update is saved', () => {
     setAgentPreferences({ toolApprovalMode: 'ask' })
 
-    expect(setAgentPreferences({})).toEqual({ toolApprovalMode: 'ask' })
+    expect(setAgentPreferences({})).toEqual({
+      accessMode: 'vault_only',
+      toolApprovalMode: 'ask'
+    })
   })
 })

--- a/apps/desktop/src/main/agent/settings.ts
+++ b/apps/desktop/src/main/agent/settings.ts
@@ -8,6 +8,7 @@ import {
 import { store } from '../store'
 
 const DEFAULT_AGENT_PREFERENCES: AgentPreferences = {
+  accessMode: 'vault_only',
   toolApprovalMode: 'always_accept'
 }
 
@@ -15,6 +16,7 @@ export function getAgentPreferences(): AgentPreferences {
   const agent = store.get('agent')
   return AgentPreferencesSchema.parse({
     ...DEFAULT_AGENT_PREFERENCES,
+    accessMode: agent.accessMode,
     toolApprovalMode: agent.toolApprovalMode
   })
 }

--- a/apps/desktop/src/main/ipc/agent-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.test.ts
@@ -15,10 +15,19 @@ const mocks = vi.hoisted(() => ({
   ]),
   getDisclosureState: vi.fn(() => ({ accepted: false })),
   acceptDisclosure: vi.fn(() => ({ accepted: true })),
-  getAgentPreferences: vi.fn(() => ({ toolApprovalMode: 'always_accept' })),
-  setAgentPreferences: vi.fn((input: { toolApprovalMode?: 'always_accept' | 'ask' }) => ({
-    toolApprovalMode: input.toolApprovalMode ?? 'always_accept'
-  }))
+  getAgentPreferences: vi.fn(() => ({
+    accessMode: 'vault_only',
+    toolApprovalMode: 'always_accept'
+  })),
+  setAgentPreferences: vi.fn(
+    (input: {
+      accessMode?: 'vault_only' | 'computer_access'
+      toolApprovalMode?: 'always_accept' | 'ask'
+    }) => ({
+      accessMode: input.accessMode ?? 'vault_only',
+      toolApprovalMode: input.toolApprovalMode ?? 'always_accept'
+    })
+  )
 }))
 
 vi.mock('electron', () => ({
@@ -158,8 +167,12 @@ describe('agent IPC handlers', () => {
       }))
     },
     preferences: {
-      get: vi.fn(() => ({ toolApprovalMode: 'always_accept' })),
-      set: vi.fn((input) => input)
+      get: vi.fn(() => ({ accessMode: 'vault_only', toolApprovalMode: 'always_accept' })),
+      set: vi.fn((input) => ({
+        accessMode: 'vault_only',
+        toolApprovalMode: 'always_accept',
+        ...input
+      }))
     },
     vaultId: 'vault-1'
   } as never
@@ -203,11 +216,13 @@ describe('agent IPC handlers', () => {
       })
     })
     expect(findHandler(AgentChannels.invoke.GET_PREFERENCES)(null)).toEqual({
+      accessMode: 'vault_only',
       toolApprovalMode: 'always_accept'
     })
     expect(
       findHandler(AgentChannels.invoke.SET_PREFERENCES)(null, { toolApprovalMode: 'ask' })
     ).toEqual({
+      accessMode: 'vault_only',
       toolApprovalMode: 'ask'
     })
     expect(mocks.setAgentPreferences).toHaveBeenCalledWith({ toolApprovalMode: 'ask' })
@@ -255,11 +270,12 @@ describe('agent IPC handlers', () => {
     registerAgentHandlers(deps)
 
     await expect(findHandler(AgentChannels.invoke.GET_PREFERENCES)(null)).resolves.toEqual({
+      accessMode: 'vault_only',
       toolApprovalMode: 'always_accept'
     })
     await expect(
       findHandler(AgentChannels.invoke.SET_PREFERENCES)(null, { toolApprovalMode: 'ask' })
-    ).resolves.toEqual({ toolApprovalMode: 'ask' })
+    ).resolves.toEqual({ accessMode: 'vault_only', toolApprovalMode: 'ask' })
     expect(deps.preferences.set).toHaveBeenCalledWith({ toolApprovalMode: 'ask' })
   })
 

--- a/apps/desktop/src/main/ipc/agent-handlers.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.ts
@@ -200,6 +200,7 @@ export function registerAgentHandlers(deps: AgentHandlerDeps): void {
         sourceWindowId: request.sourceWindowId,
         text: request.text,
         backendOptions: request.backendOptions,
+        permissions: request.permissions,
         attachments
       }
     )

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -15,7 +15,7 @@ export interface MainIpcInvokeHandlers {
   "agent:getBackendStatuses": (...args: []) => Awaited<Promise<{ claude_cli: { backend: "claude_cli" | "codex_cli" | "local_openai_compatible"; available: boolean; reason?: string | null | undefined; detail?: string | null | undefined; version?: string | null | undefined; minimumRequired?: string | null | undefined; }; codex_cli: { backend: "claude_cli" | "codex_cli" | "local_openai_compatible"; available: boolean; reason?: string | null | undefined; detail?: string | null | undefined; version?: string | null | undefined; minimumRequired?: string | null | undefined; }; local_openai_compatible: { backend: "claude_cli" | "codex_cli" | "local_openai_compatible"; available: boolean; reason?: string | null | undefined; detail?: string | null | undefined; version?: string | null | undefined; minimumRequired?: string | null | undefined; }; }>>
   "agent:getDisclosureState": (...args: []) => Awaited<import("../agent/runtime/disclosure-state").DisclosureState>
   "agent:getLocalProviderSettings": (...args: []) => Awaited<Promise<{ preset: "custom" | "ollama" | "lm_studio" | "llama_cpp"; baseUrl: string; model: string; apiKeyConfigured: boolean; allowNonLoopback: boolean; }>>
-  "agent:getPreferences": (...args: []) => Awaited<Promise<{ toolApprovalMode: "always_accept" | "ask"; }>>
+  "agent:getPreferences": (...args: []) => Awaited<Promise<{ accessMode: "vault_only" | "computer_access"; toolApprovalMode: "always_accept" | "ask"; }>>
   "agent:getWindowId": (...args: []) => Awaited<{ windowId: string | null; }>
   "agent:listBackendModels": (...args: [unknown]) => Awaited<Promise<{ backend: "claude_cli" | "codex_cli"; supportsCustomModel: boolean; models: { id: string; label: string; }[]; }>>
   "agent:listConversations": (...args: [unknown]) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-agent").Conversation[]>>
@@ -25,7 +25,7 @@ export interface MainIpcInvokeHandlers {
   "agent:probeLocalProvider": (...args: []) => Awaited<Promise<{ connected: boolean; modelAvailable: boolean; streamingSupported: boolean; toolCallingSupported: boolean; toolContinuationSupported: boolean; toolsEnabled: boolean; detail: string | null; }>>
   "agent:sendTurn": (...args: [unknown]) => Awaited<Promise<{ ok: boolean; error: string; } | { ok: boolean; error?: undefined; }>>
   "agent:setLocalProviderSettings": (...args: [unknown]) => Awaited<Promise<{ preset: "custom" | "ollama" | "lm_studio" | "llama_cpp"; baseUrl: string; model: string; apiKeyConfigured: boolean; allowNonLoopback: boolean; }>>
-  "agent:setPreferences": (...args: [unknown]) => Awaited<Promise<{ toolApprovalMode: "always_accept" | "ask"; }>>
+  "agent:setPreferences": (...args: [unknown]) => Awaited<Promise<{ accessMode: "vault_only" | "computer_access"; toolApprovalMode: "always_accept" | "ask"; }>>
   "agent:testLocalProvider": (...args: []) => Awaited<Promise<{ connected: boolean; modelAvailable: boolean; streamingSupported: boolean; toolCallingSupported: boolean; toolContinuationSupported: boolean; toolsEnabled: boolean; detail: string | null; }>>
   "ai-inline:get-server-port": (...args: []) => Awaited<number | null>
   "ai-inline:get-settings": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ai-inline-channels").AIInlineSettings>

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -27,6 +27,7 @@ export interface SyncStoreData {
 
 export interface AgentStoreData {
   disclosureAccepted?: boolean
+  accessMode?: 'vault_only' | 'computer_access'
   toolApprovalMode?: 'always_accept' | 'ask'
   localProvider?: {
     preset?: 'ollama' | 'lm_studio' | 'llama_cpp' | 'custom'

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/composer.test.tsx
@@ -91,6 +91,10 @@ describe('Composer', () => {
               { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' }
             ]
     }))
+    vi.mocked(window.api.agent.getPreferences).mockResolvedValue({
+      accessMode: 'vault_only',
+      toolApprovalMode: 'always_accept'
+    })
   })
 
   it('submits on Enter', async () => {
@@ -153,6 +157,75 @@ describe('Composer', () => {
     expect(screen.getByRole('menuitem', { name: /local/i })).not.toHaveAttribute('data-disabled')
   })
 
+  it('passes selected access mode and web search intent with the prompt', async () => {
+    render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
+
+    const permissionsTrigger = await screen.findByRole('button', {
+      name: 'Agent permissions: Vault only, web search Off'
+    })
+    expect(permissionsTrigger).toHaveClass('size-8')
+    expect(
+      screen.queryByRole('button', { name: 'Agent access: Vault only' })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Web search: Off' })).not.toBeInTheDocument()
+
+    fireEvent.pointerDown(permissionsTrigger)
+    expect(screen.getByText('Permissions')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Computer access' }))
+    fireEvent.click(screen.getByRole('menuitemcheckbox', { name: 'Web search' }))
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' })
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: 'Agent permissions: Computer access, web search On'
+        })
+      ).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Agent permissions: Computer access, web search On'
+      })
+    ).toHaveClass('size-8')
+
+    await setPromptText('check the launch page')
+    await submitPrompt()
+
+    expect(mockSendTurn).toHaveBeenCalledWith({
+      conversationId: 'conversation-1',
+      sourceWindowId: 'window-1',
+      text: 'check the launch page',
+      attachments: [],
+      backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh', model: 'opus' },
+      permissions: { accessMode: 'computer_access', webSearchEnabled: true }
+    })
+  })
+
+  it('combines model and reasoning controls into one compact menu', async () => {
+    render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
+
+    const modelSettingsTrigger = await screen.findByRole('button', {
+      name: 'Agent model settings: Opus, Extra High'
+    })
+    expect(modelSettingsTrigger).toHaveClass('max-w-36')
+    expect(screen.queryByRole('button', { name: 'Agent model: Opus' })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Agent settings: Extra High' })
+    ).not.toBeInTheDocument()
+
+    fireEvent.pointerDown(modelSettingsTrigger)
+
+    expect(screen.getByRole('menu')).toHaveClass('floating-content-motion')
+    expect(screen.getByText('Model')).toBeInTheDocument()
+    expect(await screen.findByRole('menuitem', { name: 'Sonnet' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Custom model ID')).not.toBeInTheDocument()
+    expect(screen.getByText('Reasoning')).toBeInTheDocument()
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Extra High (default)' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    )
+  })
+
   it('disables unavailable CLI providers from the backend status map', () => {
     mockUseAgentOptional.mockReturnValue({
       state: {
@@ -183,12 +256,13 @@ describe('Composer', () => {
     render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
 
     const settingsTrigger = screen.getByRole('button', {
-      name: 'Agent settings: Extra High'
+      name: 'Agent model settings: Opus, Extra High'
     })
     expect(settingsTrigger).toHaveClass('rounded-full')
 
     fireEvent.pointerDown(settingsTrigger)
 
+    expect(screen.getByText('Model')).toBeInTheDocument()
     expect(screen.getByText('Reasoning')).toBeInTheDocument()
     expect(screen.getByRole('menuitemcheckbox', { name: 'Extra High (default)' })).toHaveAttribute(
       'aria-checked',
@@ -201,7 +275,7 @@ describe('Composer', () => {
 
     expect(
       screen.getByRole('button', {
-        name: 'Agent settings: Low'
+        name: 'Agent model settings: Opus, Low'
       })
     ).toBeInTheDocument()
   })
@@ -209,7 +283,9 @@ describe('Composer', () => {
   it('passes the selected Claude effort with the prompt', async () => {
     render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
 
-    fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent settings: Extra High' }))
+    fireEvent.pointerDown(
+      screen.getByRole('button', { name: 'Agent model settings: Opus, Extra High' })
+    )
     fireEvent.click(screen.getByRole('menuitemcheckbox', { name: 'Low' }))
 
     await setPromptText('quick answer')
@@ -227,7 +303,9 @@ describe('Composer', () => {
   it('passes the selected Claude model with the prompt', async () => {
     render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
 
-    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Agent model: Opus' }))
+    fireEvent.pointerDown(
+      await screen.findByRole('button', { name: 'Agent model settings: Opus, Extra High' })
+    )
     expect(screen.queryByRole('menuitem', { name: 'Default' })).not.toBeInTheDocument()
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Sonnet' }))
 
@@ -266,10 +344,10 @@ describe('Composer', () => {
 
     fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent provider: Claude' }))
     fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }))
-    await screen.findByRole('button', { name: 'Agent model: GPT-5.5' })
+    await screen.findByRole('button', { name: 'Agent model settings: GPT-5.5, Medium' })
 
     const settingsTrigger = screen.getByRole('button', {
-      name: 'Agent settings: Medium'
+      name: 'Agent model settings: GPT-5.5, Medium'
     })
     expect(settingsTrigger).toHaveClass('rounded-full')
 
@@ -291,7 +369,9 @@ describe('Composer', () => {
 
     fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent provider: Claude' }))
     fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }))
-    fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent settings: Medium' }))
+    fireEvent.pointerDown(
+      screen.getByRole('button', { name: 'Agent model settings: GPT-5.5, Medium' })
+    )
     fireEvent.click(screen.getByRole('menuitemcheckbox', { name: 'High' }))
 
     await setPromptText('create a task')
@@ -311,7 +391,9 @@ describe('Composer', () => {
 
     fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent provider: Claude' }))
     fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }))
-    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Agent model: GPT-5.5' }))
+    fireEvent.pointerDown(
+      await screen.findByRole('button', { name: 'Agent model settings: GPT-5.5, Medium' })
+    )
     expect(screen.queryByRole('menuitem', { name: 'Default' })).not.toBeInTheDocument()
     fireEvent.click(await screen.findByRole('menuitem', { name: 'GPT-5.4' }))
 
@@ -349,7 +431,9 @@ describe('Composer', () => {
     fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent provider: Claude' }))
     fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }))
 
-    expect(await screen.findByRole('button', { name: 'Agent model: GPT-5.6' })).toBeInTheDocument()
+    expect(
+      await screen.findByRole('button', { name: 'Agent model settings: GPT-5.6, Medium' })
+    ).toBeInTheDocument()
 
     await setPromptText('create a task')
     await submitPrompt()
@@ -360,31 +444,6 @@ describe('Composer', () => {
       text: 'create a task',
       attachments: [],
       backendOptions: { backend: 'codex_cli', reasoningEffort: 'medium', model: 'gpt-5.6' }
-    })
-  })
-
-  it('allows a custom Claude model id', async () => {
-    render(<Composer conversationId="conversation-1" sourceWindowId="window-1" />)
-
-    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Agent model: Opus' }))
-    fireEvent.change(screen.getByLabelText('Custom model ID'), {
-      target: { value: 'claude-sonnet-4-6' }
-    })
-    fireEvent.keyDown(screen.getByLabelText('Custom model ID'), { key: 'Enter' })
-
-    await setPromptText('custom model')
-    await submitPrompt()
-
-    expect(mockSendTurn).toHaveBeenCalledWith({
-      conversationId: 'conversation-1',
-      sourceWindowId: 'window-1',
-      text: 'custom model',
-      attachments: [],
-      backendOptions: {
-        backend: 'claude_cli',
-        claudeEffort: 'xhigh',
-        model: 'claude-sonnet-4-6'
-      }
     })
   })
 
@@ -412,7 +471,9 @@ describe('Composer', () => {
   it('creates a new conversation with selected backend model metadata', async () => {
     render(<Composer conversationId={null} sourceWindowId="window-1" />)
 
-    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Agent model: Opus' }))
+    fireEvent.pointerDown(
+      await screen.findByRole('button', { name: 'Agent model settings: Opus, Extra High' })
+    )
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Sonnet' }))
 
     await setPromptText('draft a plan')

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream.test.tsx
@@ -718,7 +718,7 @@ describe('MessageStream', () => {
     expect(toolRoot).not.toHaveClass('border-sidebar-border')
     expect(toolRoot).not.toHaveClass('bg-sidebar-accent/40')
     expect(trigger).toHaveClass('text-muted-foreground')
-    expect(trigger.querySelector('svg')).not.toBeInTheDocument()
+    expect(trigger.querySelector('svg')).toBeInTheDocument()
     expect(screen.queryByText('Parameters')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByText('Creating note'))

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
@@ -5,6 +5,7 @@ import type {
   AgentEvent,
   AgentBackendId,
   AgentBackendOptions,
+  AgentTurnPermissions,
   ApproveToolRequest,
   AttachmentInput,
   BackendStatusesResponse,
@@ -68,6 +69,7 @@ interface AgentContextValue {
     sourceWindowId: string
     text: string
     backendOptions: AgentBackendOptions
+    permissions?: AgentTurnPermissions
     attachments?: AttachmentInput[]
   }) => Promise<void>
   cancelTurn: (conversationId: string) => Promise<void>
@@ -171,6 +173,7 @@ export function AgentProvider({ children }: { children: ReactNode }): React.JSX.
       sourceWindowId: string
       text: string
       backendOptions: AgentBackendOptions
+      permissions?: AgentTurnPermissions
       attachments?: AttachmentInput[]
     }) => {
       dispatch({ type: 'set_in_flight', conversationId: input.conversationId, inFlight: true })
@@ -182,6 +185,7 @@ export function AgentProvider({ children }: { children: ReactNode }): React.JSX.
           sourceWindowId: input.sourceWindowId,
           text: input.text,
           backendOptions: input.backendOptions,
+          permissions: input.permissions,
           attachments: input.attachments ?? []
         })
         if (!result.ok) {

--- a/apps/desktop/src/renderer/src/agent-chat/composer.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/composer.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type {
+  AgentAccessMode,
   AgentBackendId,
   AgentBackendModelList,
   AgentCliBackendId,
@@ -18,12 +19,22 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { useActiveTab } from '@/contexts/tabs'
-import { ChatGpt, Check, ChevronDown, Claude, Computer, Send, Square } from '@/lib/icons'
+import {
+  AiWebBrowsing,
+  ChatGpt,
+  Check,
+  ChevronDown,
+  Claude,
+  Computer,
+  Send,
+  Shield,
+  Square
+} from '@/lib/icons'
 import {
   AgentPromptEditor,
   type AgentPromptEditorHandle,
@@ -42,6 +53,7 @@ type AgentProvider = 'claude_cli' | 'codex_cli' | 'local_openai_compatible'
 
 const DEFAULT_CLAUDE_MODEL = 'opus'
 const DEFAULT_CODEX_REASONING: CodexReasoningEffort = 'medium'
+const DEFAULT_ACCESS_MODE: AgentAccessMode = 'vault_only'
 
 const DEFAULT_SELECTED_MODELS: Record<AgentCliBackendId, string | null> = {
   claude_cli: DEFAULT_CLAUDE_MODEL,
@@ -182,7 +194,6 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
   const { t } = useT('common')
   const agent = useAgentOptional()
   const activeTab = useActiveTab()
-  const customModelInputId = useId()
   const promptEditorRef = useRef<AgentPromptEditorHandle>(null)
   const [promptValue, setPromptValue] = useState<AgentPromptValue>({
     text: '',
@@ -195,15 +206,30 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
   const [selectedPickerIndex, setSelectedPickerIndex] = useState(-1)
   const [submitting, setSubmitting] = useState(false)
   const [selectedProvider, setSelectedProvider] = useState<AgentProvider>('claude_cli')
+  const [accessMode, setAccessMode] = useState<AgentAccessMode>(DEFAULT_ACCESS_MODE)
+  const [webSearchEnabled, setWebSearchEnabled] = useState(false)
   const [modelMenuOpen, setModelMenuOpen] = useState(false)
   const [selectedModels, setSelectedModels] =
     useState<Record<AgentCliBackendId, string | null>>(DEFAULT_SELECTED_MODELS)
   const [modelOptions, setModelOptions] =
     useState<Record<AgentCliBackendId, AgentBackendModelList | null>>(EMPTY_MODEL_OPTIONS)
-  const [customModelDraft, setCustomModelDraft] = useState('')
   const [claudeReasoning, setClaudeReasoning] = useState<ClaudeEffort>(DEFAULT_CLAUDE_EFFORT)
   const [codexReasoning, setCodexReasoning] =
     useState<CodexReasoningEffort>(DEFAULT_CODEX_REASONING)
+
+  useEffect(() => {
+    let cancelled = false
+    void window.api.agent
+      .getPreferences()
+      .then((preferences) => {
+        if (cancelled) return
+        setAccessMode(preferences.accessMode)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     if (activeTab?.type !== 'note' || !activeTab.entityId) return
@@ -264,6 +290,19 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
     local_openai_compatible: localProviderLabel
   }
   const selectedProviderLabel = providerLabelById[selectedProvider]
+  const accessLabelById: Record<AgentAccessMode, string> = {
+    vault_only: t('agentChat.composer.access.vaultOnly'),
+    computer_access: t('agentChat.composer.access.computerAccess')
+  }
+  const selectedAccessLabel = accessLabelById[accessMode]
+  const selectedWebSearchLabel = webSearchEnabled
+    ? t('agentChat.composer.webSearch.on')
+    : t('agentChat.composer.webSearch.off')
+  const permissionsAriaLabel = t('agentChat.composer.permissionsLabel', {
+    access: selectedAccessLabel,
+    webSearch: selectedWebSearchLabel
+  })
+  const permissionsActive = accessMode !== DEFAULT_ACCESS_MODE || webSearchEnabled
   const selectedBackendModel = isCliProvider(selectedProvider)
     ? (selectedModels[selectedProvider] ??
       defaultModelForProvider(selectedProvider, selectedModelOptions))
@@ -293,6 +332,11 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
   const settingsSummary = t('agentChat.composer.settingsSummary', {
     reasoning: t(selectedReasoning.summaryKey)
   })
+  const modelSettingsSummary = `${selectedModelLabel} · ${settingsSummary}`
+  const modelSettingsAriaLabel = t('agentChat.composer.modelSettingsLabel', {
+    model: selectedModelLabel,
+    settings: settingsSummary
+  })
   const backendOptions = (): AgentBackendOptions => {
     if (selectedProvider === 'local_openai_compatible') {
       return { backend: 'local_openai_compatible', toolsEnabled: true }
@@ -310,16 +354,13 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
       ...(selectedBackendModel ? { model: selectedBackendModel } : {})
     }
   }
+  const turnPermissions = () =>
+    accessMode !== DEFAULT_ACCESS_MODE || webSearchEnabled
+      ? { accessMode, webSearchEnabled }
+      : undefined
   const selectModel = (model: string | null): void => {
     if (!isCliProvider(selectedProvider)) return
     setSelectedModels((current) => ({ ...current, [selectedProvider]: model }))
-  }
-  const applyCustomModel = (): void => {
-    const model = customModelDraft.trim()
-    if (!model) return
-    selectModel(model)
-    setCustomModelDraft('')
-    setModelMenuOpen(false)
   }
   const selectReasoning = (value: ClaudeEffort | CodexReasoningEffort): void => {
     if (selectedProvider === 'codex_cli') {
@@ -433,6 +474,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
         sourceWindowId,
         text: currentText,
         backendOptions: backendOptions(),
+        permissions: turnPermissions(),
         attachments: currentAttachments
       })
       promptEditorRef.current?.clear()
@@ -546,21 +588,96 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label={permissionsAriaLabel}
+                className={[
+                  'relative inline-flex size-8 items-center justify-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
+                  permissionsActive
+                    ? 'bg-accent text-accent-foreground hover:bg-accent/90'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground'
+                ].join(' ')}
+              >
+                {accessMode === 'computer_access' ? (
+                  <Computer className="size-4" aria-hidden="true" />
+                ) : (
+                  <Shield className="size-4" aria-hidden="true" />
+                )}
+                {webSearchEnabled && (
+                  <span className="absolute -end-0.5 -top-0.5 inline-flex size-3 items-center justify-center rounded-full bg-background text-foreground ring-1 ring-border">
+                    <AiWebBrowsing className="size-2" aria-hidden="true" />
+                  </span>
+                )}
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="min-w-52 border-border/60 p-1.5">
+              <DropdownMenuLabel className="px-2 py-1 text-xs font-medium">
+                {t('agentChat.composer.permissions.label')}
+              </DropdownMenuLabel>
+              <DropdownMenuLabel className="px-2 pb-1 pt-2 text-[11px] font-medium uppercase text-muted-foreground">
+                {t('agentChat.composer.permissions.access')}
+              </DropdownMenuLabel>
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault()
+                  setAccessMode('vault_only')
+                }}
+                className="text-xs hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+              >
+                <Shield className="size-4 text-muted-foreground" aria-hidden="true" />
+                <span>{t('agentChat.composer.access.vaultOnly')}</span>
+                {accessMode === 'vault_only' && (
+                  <Check className="ms-auto size-3 text-muted-foreground" aria-hidden="true" />
+                )}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault()
+                  setAccessMode('computer_access')
+                }}
+                className="text-xs hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+              >
+                <Computer className="size-4 text-muted-foreground" aria-hidden="true" />
+                <span>{t('agentChat.composer.access.computerAccess')}</span>
+                {accessMode === 'computer_access' && (
+                  <Check className="ms-auto size-3 text-muted-foreground" aria-hidden="true" />
+                )}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="px-2 pb-1 pt-2 text-[11px] font-medium uppercase text-muted-foreground">
+                {t('agentChat.composer.permissions.tools')}
+              </DropdownMenuLabel>
+              <DropdownMenuCheckboxItem
+                checked={webSearchEnabled}
+                onCheckedChange={(checked) => setWebSearchEnabled(checked === true)}
+                onSelect={(event) => event.preventDefault()}
+                className="text-xs focus:bg-accent focus:text-accent-foreground"
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <AiWebBrowsing className="size-4 text-muted-foreground" aria-hidden="true" />
+                  <span>{t('agentChat.composer.webSearch.label')}</span>
+                </span>
+              </DropdownMenuCheckboxItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
           {isCliProvider(selectedProvider) && (
             <DropdownMenu open={modelMenuOpen} onOpenChange={handleModelMenuOpenChange}>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  aria-label={t('agentChat.composer.modelLabel', {
-                    model: selectedModelLabel
-                  })}
-                  className="inline-flex h-8 max-w-28 items-center gap-1 rounded-full bg-muted px-2 text-xs text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  aria-label={modelSettingsAriaLabel}
+                  className="inline-flex h-8 max-w-36 items-center gap-1 rounded-full bg-muted px-2 text-xs text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
-                  <span className="truncate">{selectedModelLabel}</span>
+                  <span className="truncate">{modelSettingsSummary}</span>
                   <ChevronDown className="size-3 shrink-0" aria-hidden="true" />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="min-w-52 border-border/60 p-1.5">
+                <DropdownMenuLabel className="px-2 py-1 text-[11px] font-medium text-muted-foreground">
+                  {t('agentChat.composer.models.label')}
+                </DropdownMenuLabel>
                 {(selectedModelOptions?.models ?? []).map((model) => (
                   <DropdownMenuItem
                     key={model.id}
@@ -573,46 +690,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
                     )}
                   </DropdownMenuItem>
                 ))}
-                <div
-                  className="mt-1 border-t border-border/60 pt-1"
-                  onKeyDown={(event) => event.stopPropagation()}
-                  onPointerDown={(event) => event.stopPropagation()}
-                >
-                  <label htmlFor={customModelInputId} className="sr-only">
-                    {t('agentChat.composer.customModelLabel')}
-                  </label>
-                  <Input
-                    id={customModelInputId}
-                    value={customModelDraft}
-                    onChange={(event) => setCustomModelDraft(event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
-                        event.preventDefault()
-                        applyCustomModel()
-                      }
-                    }}
-                    placeholder={t('agentChat.composer.customModelPlaceholder')}
-                    className="h-8 text-xs"
-                  />
-                </div>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-          {isCliProvider(selectedProvider) && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={t('agentChat.composer.settingsLabel', {
-                    settings: settingsSummary
-                  })}
-                  className="inline-flex h-8 min-w-0 items-center gap-1 rounded-full bg-muted px-2 text-xs text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                >
-                  <span className="truncate">{settingsSummary}</span>
-                  <ChevronDown className="size-3 shrink-0" aria-hidden="true" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="min-w-44 border-border/60 p-1.5">
+                <DropdownMenuSeparator />
                 <DropdownMenuLabel className="px-2 py-1 text-[11px] font-medium text-muted-foreground">
                   {t('agentChat.composer.settings.reasoning')}
                 </DropdownMenuLabel>

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -6,6 +6,63 @@
 
 @custom-variant dark (&:is(.dark *));
 
+@keyframes floating-content-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes floating-content-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(3px) scale(0.99);
+  }
+}
+
+.floating-content-motion {
+  transform-origin: var(
+    --radix-dropdown-menu-content-transform-origin,
+    var(
+      --radix-popover-content-transform-origin,
+      var(
+        --radix-select-content-transform-origin,
+        var(
+          --radix-context-menu-content-transform-origin,
+          var(--radix-hover-card-content-transform-origin, top center)
+        )
+      )
+    )
+  );
+  will-change: opacity, transform;
+}
+
+.floating-content-motion[data-state='open'] {
+  animation: floating-content-in 160ms var(--ease-out) both;
+}
+
+.floating-content-motion[data-state='closed'] {
+  animation: floating-content-out 90ms var(--ease-in) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .floating-content-motion[data-state='open'],
+  .floating-content-motion[data-state='closed'] {
+    animation: none;
+    transform: none;
+  }
+}
+
 /* ===== BLOCKNOTE EDITOR CUSTOMIZATION ===== */
 /* Override BlockNote's CSS variables + defaults to match app theme.
    Uses CSS inheritance (not a wildcard * rule) so Shiki inline token styles still work. */

--- a/apps/desktop/src/renderer/src/components/ai-elements/tool.tsx
+++ b/apps/desktop/src/renderer/src/components/ai-elements/tool.tsx
@@ -2,6 +2,7 @@ import type { ComponentProps } from 'react'
 import { isValidElement } from 'react'
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { ChevronRight } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
 export type ToolState =
@@ -63,9 +64,7 @@ export function ToolHeader({
       {...props}
     >
       <span className="flex min-w-0 items-center gap-1.5">
-        <span className="shrink-0" aria-hidden="true">
-          &gt;
-        </span>
+        <ChevronRight className="size-3 shrink-0" aria-hidden="true" />
         <span className="truncate">{label}</span>
         <span className="sr-only">{statusLabels[state]}</span>
       </span>

--- a/apps/desktop/src/renderer/src/components/tasks/tasks-tab-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/tasks-tab-bar.test.tsx
@@ -124,6 +124,9 @@ describe('TasksTabBar', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /writing/i }))
 
+    expect(document.body.querySelector('[data-state="open"][data-side]')).toHaveClass(
+      'floating-content-motion'
+    )
     expect(screen.getAllByText('All projects').length).toBeGreaterThan(0)
     expect(screen.getByText('Work')).toBeInTheDocument()
     expect(screen.queryByText('Archive')).not.toBeInTheDocument()

--- a/apps/desktop/src/renderer/src/components/ui/context-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/context-menu.tsx
@@ -51,7 +51,7 @@ function ContextMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto" />
+      <ChevronRightIcon className="ms-auto" />
     </ContextMenuPrimitive.SubTrigger>
   )
 }
@@ -65,6 +65,7 @@ function ContextMenuSubContent({
       data-slot="context-menu-sub-content"
       className={cn(
         'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'floating-content-motion',
         className
       )}
       {...props}
@@ -87,6 +88,7 @@ function ContextMenuContent({
         }}
         className={cn(
           'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          'floating-content-motion',
           className
         )}
         {...props}
@@ -128,13 +130,13 @@ function ContextMenuCheckboxItem({
     <ContextMenuPrimitive.CheckboxItem
       data-slot="context-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pe-2 ps-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+      <span className="pointer-events-none absolute start-2 flex size-3.5 items-center justify-center">
         <ContextMenuPrimitive.ItemIndicator>
           <CheckIcon className="size-4" />
         </ContextMenuPrimitive.ItemIndicator>
@@ -153,12 +155,12 @@ function ContextMenuRadioItem({
     <ContextMenuPrimitive.RadioItem
       data-slot="context-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pe-2 ps-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+      <span className="pointer-events-none absolute start-2 flex size-3.5 items-center justify-center">
         <ContextMenuPrimitive.ItemIndicator>
           <CircleIcon className="size-2 fill-current" />
         </ContextMenuPrimitive.ItemIndicator>
@@ -202,7 +204,7 @@ function ContextMenuShortcut({ className, ...props }: React.ComponentProps<'span
   return (
     <span
       data-slot="context-menu-shortcut"
-      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      className={cn('text-muted-foreground ms-auto text-xs tracking-widest', className)}
       {...props}
     />
   )

--- a/apps/desktop/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -47,6 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
     ref={ref}
     className={cn(
       'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
+      'floating-content-motion',
       className
     )}
     {...props}
@@ -65,6 +66,7 @@ const DropdownMenuContent = React.forwardRef<
       className={cn(
         'z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
+        'floating-content-motion',
         className
       )}
       {...props}

--- a/apps/desktop/src/renderer/src/components/ui/hover-card.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/hover-card.tsx
@@ -17,6 +17,7 @@ const HoverCardContent = React.forwardRef<
     sideOffset={sideOffset}
     className={cn(
       'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]',
+      'floating-content-motion',
       className
     )}
     {...props}

--- a/apps/desktop/src/renderer/src/components/ui/popover.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/popover.tsx
@@ -20,6 +20,7 @@ const PopoverContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
+        'floating-content-motion',
         className
       )}
       {...props}

--- a/apps/desktop/src/renderer/src/components/ui/select.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/select.tsx
@@ -67,6 +67,7 @@ const SelectContent = React.forwardRef<
       ref={ref}
       className={cn(
         'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
+        'floating-content-motion',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className

--- a/apps/desktop/src/renderer/src/components/ui/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/sidebar.test.tsx
@@ -92,7 +92,7 @@ describe('SidebarProvider shortcuts', () => {
     fireEvent.mouseMove(document, { clientX: 10 })
 
     expect(screen.getByTestId('sidebar-state')).toHaveTextContent('collapsed')
-    expect(screen.getByTestId('sidebar-width')).toHaveTextContent('244')
+    expect(screen.getByTestId('sidebar-width')).toHaveTextContent('171')
 
     fireEvent.mouseUp(document)
   })

--- a/apps/desktop/src/renderer/src/components/ui/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/sidebar.tsx
@@ -25,7 +25,7 @@ const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH_MOBILE = '18rem'
 const SIDEBAR_WIDTH_ICON = '3rem'
 const SIDEBAR_WIDTH_DEFAULT_PX = 256
-const SIDEBAR_WIDTH_MIN_PX = 244
+const SIDEBAR_WIDTH_MIN_PX = 171
 const SIDEBAR_WIDTH_MAX_PX = 480
 const SIDEBAR_STORAGE_KEY = 'sidebar_width'
 
@@ -266,14 +266,15 @@ function Sidebar({
         data-slot="sidebar-container"
         className={cn(
           'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) md:flex',
-          !isResizing && 'transition-[left,right,width] duration-200 ease-linear',
+          !isResizing &&
+            'transition-[inset-inline-start,inset-inline-end,width] duration-200 ease-linear',
           side === 'left'
-            ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
-            : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
+            ? 'start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]'
+            : 'end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]',
           // Adjust the padding for floating and inset variants.
           variant === 'floating' || variant === 'inset'
             ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
+            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-e group-data-[side=right]:border-s',
           className
         )}
         {...props}
@@ -399,11 +400,11 @@ function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
       onDoubleClick={handleDoubleClick}
       title={tPhaseF('phaseF.componentsUiSidebar.dragToResizeDoubleClickToReset')}
       className={cn(
-        'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex',
+        'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-end-4 group-data-[side=right]:start-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] sm:flex',
         'cursor-col-resize',
-        'hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full',
-        '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
-        '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
+        'hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:start-full',
+        '[[data-side=left][data-collapsible=offcanvas]_&]:-end-2',
+        '[[data-side=right][data-collapsible=offcanvas]_&]:-start-2',
         className
       )}
       {...props}
@@ -527,7 +528,7 @@ function SidebarGroupAction({
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
-        'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform [&>svg]:size-4 [&>svg]:shrink-0',
+        'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 end-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 md:after:hidden',
         'group-data-[collapsible=icon]:hidden',
@@ -572,7 +573,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-foreground',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-start text-sm outline-hidden transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pe-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-foreground',
   {
     variants: {
       variant: {
@@ -659,7 +660,7 @@ function SidebarMenuAction({
       data-slot="sidebar-menu-action"
       data-sidebar="menu-action"
       className={cn(
-        'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform [&>svg]:size-4 [&>svg]:shrink-0',
+        'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 end-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 md:after:hidden',
         'peer-data-[size=sm]/menu-button:top-1',
@@ -681,7 +682,7 @@ function SidebarMenuBadge({ className, ...props }: React.ComponentProps<'div'>) 
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        'text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none',
+        'text-sidebar-foreground pointer-events-none absolute end-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none',
         'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
         'peer-data-[size=sm]/menu-button:top-1',
         'peer-data-[size=default]/menu-button:top-1.5',
@@ -730,7 +731,7 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<'ul'>) {
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        'border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5',
+        'border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-s px-2.5 py-0.5',
         'group-data-[collapsible=icon]:hidden',
         className
       )}

--- a/apps/desktop/src/renderer/src/lib/icons/icon-map.ts
+++ b/apps/desktop/src/renderer/src/lib/icons/icon-map.ts
@@ -2,6 +2,7 @@ import {
   // Direct matches
   AlertCircleIcon,
   AlignLeftIcon,
+  AiWebBrowsingIcon,
   Archive03Icon,
   ArchiveIcon,
   ArrowDown01Icon,
@@ -540,6 +541,7 @@ export const Paperclip = createIcon(Attachment01Icon)
 export const Smile = createIcon(SmileIcon)
 export const Sparkles = createIcon(SparklesIcon)
 export const Bot = createIcon(BotIcon)
+export const AiWebBrowsing = createIcon(AiWebBrowsingIcon)
 export const Claude = createIcon(ClaudeIcon)
 export const ChatGpt = createIcon(ChatGptIcon)
 export const Computer = createIcon(ComputerIcon)

--- a/apps/desktop/src/renderer/src/pages/settings/agent-providers-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/agent-providers-section.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type {
+  AgentAccessMode,
   AgentLocalProviderPreset,
   AgentLocalProviderProbeResult,
   AgentLocalProviderSettings,
@@ -109,6 +110,12 @@ export function AgentProvidersSection({
     setPreferences(saved)
   }, [])
 
+  const changeAccessMode = useCallback(async (accessMode: AgentAccessMode) => {
+    setPreferences((current) => (current ? { ...current, accessMode } : current))
+    const saved = await window.api.agent.setPreferences({ accessMode })
+    setPreferences(saved)
+  }, [])
+
   const loadModels = useCallback(async () => {
     setBusy('models')
     try {
@@ -149,10 +156,31 @@ export function AgentProvidersSection({
         />
       )}
 
-      <SettingsGroup label={t('agentProviders.groups.local')}>
+      <SettingsGroup label={t('agentProviders.permissions.group')}>
         <SettingRow
-          label={t('agentProviders.approval.label')}
-          description={t('agentProviders.approval.description')}
+          label={t('agentProviders.permissions.access.label')}
+          description={t('agentProviders.permissions.access.description')}
+        >
+          <Select
+            value={preferences.accessMode}
+            onValueChange={(value) => void changeAccessMode(value as AgentAccessMode)}
+          >
+            <SelectTrigger className="h-8 w-44 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="vault_only">
+                {t('agentProviders.permissions.access.vaultOnly')}
+              </SelectItem>
+              <SelectItem value="computer_access">
+                {t('agentProviders.permissions.access.computerAccess')}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </SettingRow>
+        <SettingRow
+          label={t('agentProviders.permissions.confirm.label')}
+          description={t('agentProviders.permissions.confirm.description')}
         >
           <Select
             value={preferences.toolApprovalMode}
@@ -163,12 +191,17 @@ export function AgentProvidersSection({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="always_accept">
-                {t('agentProviders.approval.alwaysAccept')}
+                {t('agentProviders.permissions.confirm.alwaysAllow')}
               </SelectItem>
-              <SelectItem value="ask">{t('agentProviders.approval.ask')}</SelectItem>
+              <SelectItem value="ask">
+                {t('agentProviders.permissions.confirm.askBeforeChanges')}
+              </SelectItem>
             </SelectContent>
           </Select>
         </SettingRow>
+      </SettingsGroup>
+
+      <SettingsGroup label={t('agentProviders.groups.local')}>
         <SettingRow label={t('agentProviders.fields.preset.label')}>
           <Select
             value={settings.preset}

--- a/apps/desktop/src/renderer/src/pages/settings/ai-section.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/ai-section.test.tsx
@@ -141,11 +141,11 @@ describe('AISettings', () => {
   it('keeps agent provider and MCP controls collapsed inside AI settings', async () => {
     render(<AISettings />)
 
-    await waitFor(() => expect(screen.getByText('Agent Providers')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('Agent Permissions')).toBeInTheDocument())
     expect(screen.queryByTestId('agent-providers-panel')).not.toBeInTheDocument()
     expect(screen.queryByTestId('agent-mcp-panel')).not.toBeInTheDocument()
 
-    await userEvent.click(screen.getByRole('button', { name: /Agent Providers/ }))
+    await userEvent.click(screen.getByRole('button', { name: /Agent Permissions/ }))
     expect(screen.getByTestId('agent-providers-panel')).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: /Agent MCP/ }))

--- a/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
@@ -272,6 +272,10 @@ vi.mock('@/components/settings/recovery-key-dialog', () => ({
 }))
 
 function installWindowApi() {
+  const agentPreferences = {
+    accessMode: 'vault_only',
+    toolApprovalMode: 'always_accept'
+  }
   window.api = {
     ...window.api,
     agent: {
@@ -282,10 +286,8 @@ function installWindowApi() {
         apiKeyConfigured: false,
         allowNonLoopback: false
       }),
-      getPreferences: vi.fn().mockResolvedValue({
-        toolApprovalMode: 'always_accept'
-      }),
-      setPreferences: vi.fn(async (input) => input),
+      getPreferences: vi.fn().mockResolvedValue(agentPreferences),
+      setPreferences: vi.fn(async (input) => ({ ...agentPreferences, ...input })),
       setLocalProviderSettings: vi.fn(async (input) => ({
         preset: input.preset,
         baseUrl: input.baseUrl,
@@ -605,7 +607,16 @@ describe('settings section coverage', () => {
     expect(window.api.agent.getLocalProviderSettings).toHaveBeenCalled()
     expect(window.api.agent.getPreferences).toHaveBeenCalled()
 
-    fireEvent.click(screen.getByText('agentProviders.approval.ask'))
+    expect(await screen.findByText('agentProviders.permissions.group')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('agentProviders.permissions.access.computerAccess'))
+    await waitFor(() =>
+      expect(window.api.agent.setPreferences).toHaveBeenCalledWith({
+        accessMode: 'computer_access'
+      })
+    )
+
+    fireEvent.click(screen.getByText('agentProviders.permissions.confirm.askBeforeChanges'))
     await waitFor(() =>
       expect(window.api.agent.setPreferences).toHaveBeenCalledWith({
         toolApprovalMode: 'ask'

--- a/apps/desktop/tests/setup-dom.ts
+++ b/apps/desktop/tests/setup-dom.ts
@@ -437,6 +437,14 @@ const createMockApi = () => ({
       apiKeyConfigured: false,
       allowNonLoopback: false
     }),
+    getPreferences: vi.fn().mockResolvedValue({
+      accessMode: 'vault_only',
+      toolApprovalMode: 'always_accept'
+    }),
+    setPreferences: vi.fn().mockImplementation(async (input) => ({
+      accessMode: input?.accessMode ?? 'vault_only',
+      toolApprovalMode: input?.toolApprovalMode ?? 'always_accept'
+    })),
     listLocalModels: vi.fn().mockResolvedValue({ models: [] }),
     testLocalProvider: vi.fn().mockResolvedValue({
       connected: false,

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -12,7 +12,9 @@ active turns, clears pending tool approvals, and restarts the Agent services for
 The same MCP endpoint can also be copied into other desktop AI clients for vault read tools.
 
 Open [Settings -> AI Assistant -> Agent MCP](/user-guide/settings#agent-mcp) to copy the current
-endpoint and bearer token.
+endpoint and bearer token. Open
+[Settings -> AI Assistant -> Agent Permissions](/user-guide/settings#agent-permissions) to set the
+default Agent Chat access mode and action-confirmation behavior.
 
 ## Agent Chat
 
@@ -27,7 +29,7 @@ that workspace view. Assistant responses render as full-width text in both the s
 tabs instead of bordered bubbles, with text aligned to the prompt input. For Claude CLI, Memry checks
 that `claude` is available on `PATH`, that it reports version `2.1.0` or newer, and that the Agent
 disclosure has been accepted. For local models, configure a compatible server in
-[Settings -> AI Assistant -> Agent Providers](/user-guide/settings#agent-providers) first.
+[Settings -> AI Assistant -> Agent Permissions](/user-guide/settings#agent-permissions) first.
 If the global AI switch is off in [Settings -> AI](/user-guide/settings#ai), the Agent tab and Agent
 MCP current-note bridge are hidden and inactive.
 
@@ -76,7 +78,13 @@ exposing Memry MCP tools.
 The prompt bar shows the selected agent provider. The provider is pinned per conversation; changing
 it after messages exist updates the conversation and records the switch in the chat history. Claude
 and Codex expose prompt-time reasoning effort settings, with provider-specific settings shown only
-for the active provider.
+for the active provider. The same compact prompt bar has a per-turn permissions menu. It starts from
+your default Agent Permissions setting, then lets you send a single turn as **Vault only** or
+**Computer access**, and optionally allow web search for that turn.
+
+**Vault only** keeps the CLI backend constrained to Memry vault tools. **Computer access** gives the
+backend broader local CLI access for that turn. Web search is passed through only when the selected
+backend supports it.
 
 Claude and Codex conversations also have a per-conversation model selector. Memry starts Claude on
 `opus` and Codex on the highest suggested GPT version, then passes the selected model through to the
@@ -157,8 +165,8 @@ Read tools are available to Agent Chat and external MCP clients:
 - `vault_get_tags`
 - `vault_desktop_read`
 
-Create, update, delete, archive, move, and reorder tools require Agent Chat context and explicit
-approval:
+Create, update, delete, archive, move, and reorder tools require Agent Chat context. They can be
+auto-accepted or shown for inline approval depending on the Agent Permissions setting:
 
 - `vault_create_note`
 - `vault_rename_note`

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -218,18 +218,23 @@ Inline editor AI menu (grammar, tone, length, custom prompt).
 - **Base URL** — defaults to `http://localhost:11434/v1` for Ollama
 - **Test Connection** — verifies URL + key
 
-### Agent Providers
+### Agent Permissions
 
-Agent Chat backend settings are now collapsed inside the AI Assistant page. These are machine-local
-and are not synced between devices.
+Agent Chat backend and permission settings are now collapsed inside the AI Assistant page. These are
+machine-local and are not synced between devices.
 
+- **Default Access** — starts each new Agent turn in **Vault only** or **Computer access**
+- **Confirm Actions** — always accept Agent Chat tool calls by default, or require inline approval first
 - **Preset** — Ollama, LM Studio, llama.cpp, or Custom
 - **Base URL** — OpenAI-compatible endpoint, such as `http://localhost:11434/v1`
 - **Model** — choose from `/v1/models` when available or type a model manually
-- **Tool Confirmations** — always accept Agent Chat tool calls by default, or require inline approval first
 - **API Key** — optional, stored in the OS keychain
 - **Test Connection** — checks the endpoint and selected model
 - **Probe Tools** — verifies tool-call emission and tool-result continuation before vault tools are enabled
+
+The Agent Chat prompt bar can override access for one turn and can enable web search when the active
+backend supports it. Vault-only turns keep the CLI backend constrained to Memry tools; computer
+access turns grant broader local CLI access for that turn.
 
 Loopback endpoints are treated as local. Custom non-loopback endpoints require an explicit
 not-fully-local acknowledgement because prompts and tool results are sent to that server.

--- a/packages/contracts/src/ipc-agent.test.ts
+++ b/packages/contracts/src/ipc-agent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  AgentAccessModeSchema,
   AgentBackendIdSchema,
   AgentBackendModelListSchema,
   BackendStatusesResponseSchema,
@@ -155,6 +156,23 @@ describe('agent IPC schemas', () => {
     ).toBe(false)
   })
 
+  it('validates per-turn agent permissions', () => {
+    expect(AgentAccessModeSchema.safeParse('vault_only').success).toBe(true)
+    expect(AgentAccessModeSchema.safeParse('computer_access').success).toBe(true)
+    expect(AgentAccessModeSchema.safeParse('vault_web').success).toBe(false)
+
+    expect(
+      SendTurnRequestSchema.safeParse({
+        conversationId: 'conversation-1',
+        sourceWindowId: 'window-1',
+        text: 'search this',
+        attachments: [],
+        backendOptions: { backend: 'claude_cli', claudeEffort: 'xhigh' },
+        permissions: { accessMode: 'vault_only', webSearchEnabled: true }
+      }).success
+    ).toBe(true)
+  })
+
   it('validates stored message attachments for inbox and calendar refs', () => {
     for (const kind of ['inbox', 'calendar_event'] as const) {
       expect(
@@ -271,9 +289,12 @@ describe('agent IPC schemas', () => {
     expect(AgentToolApprovalModeSchema.safeParse('always_accept').success).toBe(true)
     expect(AgentToolApprovalModeSchema.safeParse('ask').success).toBe(true)
     expect(AgentToolApprovalModeSchema.safeParse('prompt').success).toBe(false)
-    expect(AgentPreferencesSchema.safeParse({ toolApprovalMode: 'always_accept' }).success).toBe(
-      true
-    )
+    expect(
+      AgentPreferencesSchema.safeParse({
+        accessMode: 'vault_only',
+        toolApprovalMode: 'always_accept'
+      }).success
+    ).toBe(true)
     expect(AgentPreferencesUpdateSchema.parse({})).toEqual({})
 
     expect(

--- a/packages/contracts/src/ipc-agent.ts
+++ b/packages/contracts/src/ipc-agent.ts
@@ -70,6 +70,17 @@ export type AgentCliBackendId = z.infer<typeof AgentCliBackendIdSchema>
 export const CodexReasoningEffortSchema = z.enum(['low', 'medium', 'high', 'xhigh'])
 export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>
 
+export const AgentAccessModeSchema = z.enum(['vault_only', 'computer_access'])
+export type AgentAccessMode = z.infer<typeof AgentAccessModeSchema>
+
+export const AgentTurnPermissionsSchema = z
+  .object({
+    accessMode: AgentAccessModeSchema.default('vault_only'),
+    webSearchEnabled: z.boolean().default(false)
+  })
+  .strict()
+export type AgentTurnPermissions = z.infer<typeof AgentTurnPermissionsSchema>
+
 export const AgentLocalProviderPresetSchema = z.enum(['ollama', 'lm_studio', 'llama_cpp', 'custom'])
 export type AgentLocalProviderPreset = z.infer<typeof AgentLocalProviderPresetSchema>
 
@@ -129,6 +140,7 @@ export type AgentToolApprovalMode = z.infer<typeof AgentToolApprovalModeSchema>
 
 export const AgentPreferencesSchema = z
   .object({
+    accessMode: AgentAccessModeSchema.default('vault_only'),
     toolApprovalMode: AgentToolApprovalModeSchema.default('always_accept')
   })
   .strict()
@@ -136,6 +148,7 @@ export type AgentPreferences = z.infer<typeof AgentPreferencesSchema>
 
 export const AgentPreferencesUpdateSchema = z
   .object({
+    accessMode: AgentAccessModeSchema.optional(),
     toolApprovalMode: AgentToolApprovalModeSchema.optional()
   })
   .strict()
@@ -402,7 +415,8 @@ export const SendTurnRequestSchema = z.object({
   sourceWindowId: z.string(),
   text: z.string(),
   attachments: z.array(AttachmentInputSchema),
-  backendOptions: AgentBackendOptionsSchema
+  backendOptions: AgentBackendOptionsSchema,
+  permissions: AgentTurnPermissionsSchema.optional()
 })
 export type SendTurnRequest = z.infer<typeof SendTurnRequestSchema>
 

--- a/packages/i18n/src/locales/ar/common.json
+++ b/packages/i18n/src/locales/ar/common.json
@@ -376,18 +376,15 @@
       "placeholder": "اسأل Memry أي شيء. @ لذكر ملف",
       "send": "أرسل",
       "providerLabel": "مزود Agent: {provider}",
-      "modelLabel": "موديل Agent: {model}",
-      "settingsLabel": "إعدادات Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "معرف النموذج المخصص",
-      "customModelPlaceholder": "معرف النموذج المخصص",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "محلي"
       },
       "models": {
-        "default": "الافتراضي"
+        "default": "الافتراضي",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "الاستدلال"
@@ -410,7 +407,23 @@
           "high": "عالية",
           "extraHigh": "ارتفاع إضافي"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "لا توجد تطابقات"

--- a/packages/i18n/src/locales/ar/settings.json
+++ b/packages/i18n/src/locales/ar/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/cs/common.json
+++ b/packages/i18n/src/locales/cs/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Zeptejte se Memry na cokoli. @ pro zmínku o souboru",
       "send": "Odeslat",
       "providerLabel": "Poskytovatel Agent: {provider}",
-      "modelLabel": "Model Agent: {model}",
-      "settingsLabel": "Nastavení Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID vlastního modelu",
-      "customModelPlaceholder": "ID vlastního modelu",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Místní"
       },
       "models": {
-        "default": "Výchozí"
+        "default": "Výchozí",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Zdůvodnění"
@@ -410,7 +407,23 @@
           "high": "Vysoká",
           "extraHigh": "Extra vysoká"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Žádné shody"

--- a/packages/i18n/src/locales/cs/settings.json
+++ b/packages/i18n/src/locales/cs/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/da/common.json
+++ b/packages/i18n/src/locales/da/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Spørg Memry om hvad som helst. @ for at nævne en fil",
       "send": "Sende",
       "providerLabel": "Agent udbyder: {provider}",
-      "modelLabel": "Agentmodel: {model}",
-      "settingsLabel": "Agent indstillinger: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Brugerdefineret model-id",
-      "customModelPlaceholder": "Brugerdefineret model-id",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Lokal"
       },
       "models": {
-        "default": "Standard"
+        "default": "Standard",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Begrundelse"
@@ -410,7 +407,23 @@
           "high": "Høj",
           "extraHigh": "Ekstra høj"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Ingen resultater"

--- a/packages/i18n/src/locales/da/settings.json
+++ b/packages/i18n/src/locales/da/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/de/common.json
+++ b/packages/i18n/src/locales/de/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Fragen Sie Memry alles. @, um eine Datei zu erwähnen",
       "send": "Senden",
       "providerLabel": "Agent Anbieter: {provider}",
-      "modelLabel": "Agent Modell: {model}",
-      "settingsLabel": "Agent-Einstellungen: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Benutzerdefinierte Modell-ID",
-      "customModelPlaceholder": "Benutzerdefinierte Modell-ID",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Lokal"
       },
       "models": {
-        "default": "Standard"
+        "default": "Standard",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Begründung"
@@ -410,7 +407,23 @@
           "high": "Hoch",
           "extraHigh": "Extra hoch"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Keine Übereinstimmungen"

--- a/packages/i18n/src/locales/de/settings.json
+++ b/packages/i18n/src/locales/de/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/el/common.json
+++ b/packages/i18n/src/locales/el/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Ρωτήστε το Memry οτιδήποτε. @ για αναφορά αρχείου",
       "send": "Αποστολή",
       "providerLabel": "Agent πάροχος: {provider}",
-      "modelLabel": "Agent μοντέλο: {model}",
-      "settingsLabel": "Ρυθμίσεις Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Αναγνωριστικό προσαρμοσμένου μοντέλου",
-      "customModelPlaceholder": "Αναγνωριστικό προσαρμοσμένου μοντέλου",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Τοπικό"
       },
       "models": {
-        "default": "Προεπιλογή"
+        "default": "Προεπιλογή",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Συλλογισμός"
@@ -410,7 +407,23 @@
           "high": "Ψηλά",
           "extraHigh": "Πολύ υψηλό"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Δεν υπάρχουν αντιστοιχίες"

--- a/packages/i18n/src/locales/el/settings.json
+++ b/packages/i18n/src/locales/el/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -115,18 +115,24 @@
       "placeholder": "Ask Memry anything. @ to use mention file",
       "send": "Send",
       "providerLabel": "Agent provider: {provider}",
-      "modelLabel": "Agent model: {model}",
-      "settingsLabel": "Agent settings: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Custom model ID",
-      "customModelPlaceholder": "Custom model ID",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Local"
       },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
       "models": {
-        "default": "Default"
+        "default": "Default",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Reasoning"
@@ -149,7 +155,14 @@
           "high": "High",
           "extraHigh": "Extra High"
         }
-      }
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "No matches"

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -1226,18 +1226,27 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
       "actions": "Connection checks"
     },
-    "approval": {
-      "label": "Tool confirmations",
-      "description": "Choose whether write tools run automatically or wait for approval in chat.",
-      "alwaysAccept": "Always accept",
-      "ask": "Ask first"
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     },
     "presets": {
       "ollama": "Ollama",

--- a/packages/i18n/src/locales/es/common.json
+++ b/packages/i18n/src/locales/es/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Pregunta cualquier cosa a Memry. @ para mencionar un archivo",
       "send": "Enviar",
       "providerLabel": "Proveedor Agent: {provider}",
-      "modelLabel": "Agent modelo: {model}",
-      "settingsLabel": "Configuración de Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID de modelo personalizado",
-      "customModelPlaceholder": "ID de modelo personalizado",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Locales"
       },
       "models": {
-        "default": "Predeterminado"
+        "default": "Predeterminado",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Razonamiento"
@@ -410,7 +407,23 @@
           "high": "Alto",
           "extraHigh": "Extra Alto"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "No hay coincidencias"

--- a/packages/i18n/src/locales/es/settings.json
+++ b/packages/i18n/src/locales/es/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/fi/common.json
+++ b/packages/i18n/src/locales/fi/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Kysy Memryltä mitä tahansa. @ tiedoston mainitsemiseen",
       "send": "Lähetä",
       "providerLabel": "Agent -toimittaja: {provider}",
-      "modelLabel": "Agent malli: {model}",
-      "settingsLabel": "Agent-asetukset: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Mukautetun mallin tunnus",
-      "customModelPlaceholder": "Mukautetun mallin tunnus",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Paikallinen"
       },
       "models": {
-        "default": "Oletus"
+        "default": "Oletus",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Päättely"
@@ -410,7 +407,23 @@
           "high": "Korkea",
           "extraHigh": "Erittäin korkea"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Ei osumia"

--- a/packages/i18n/src/locales/fi/settings.json
+++ b/packages/i18n/src/locales/fi/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/fil/common.json
+++ b/packages/i18n/src/locales/fil/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Tanungin ang Memry ng kahit ano. @ para banggitin ang file",
       "send": "Ipadala",
       "providerLabel": "Tagapagbigay ng Agent: {provider}",
-      "modelLabel": "Agent modelo: {model}",
-      "settingsLabel": "Mga setting ng Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Custom na ID ng modelo",
-      "customModelPlaceholder": "Custom na ID ng modelo",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Lokal"
       },
       "models": {
-        "default": "Paunang setting"
+        "default": "Paunang setting",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Pangangatwiran"
@@ -410,7 +407,23 @@
           "high": "Mataas",
           "extraHigh": "Napakataas"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Walang tugma"

--- a/packages/i18n/src/locales/fil/settings.json
+++ b/packages/i18n/src/locales/fil/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Demandez n’importe quoi à Memry. @ pour mentionner un fichier",
       "send": "Envoyer",
       "providerLabel": "Fournisseur Agent: {provider}",
-      "modelLabel": "Modèle Agent: {model}",
-      "settingsLabel": "Paramètres Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID de modèle personnalisé",
-      "customModelPlaceholder": "ID de modèle personnalisé",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Locale"
       },
       "models": {
-        "default": "Par défaut"
+        "default": "Par défaut",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Raisonnement"
@@ -410,7 +407,23 @@
           "high": "Élevé",
           "extraHigh": "Très élevé"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Aucune correspondance"

--- a/packages/i18n/src/locales/fr/settings.json
+++ b/packages/i18n/src/locales/fr/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/he/common.json
+++ b/packages/i18n/src/locales/he/common.json
@@ -376,18 +376,15 @@
       "placeholder": "שאלו את Memry כל דבר. @ כדי להזכיר קובץ",
       "send": "שלח",
       "providerLabel": "ספק Agent: {provider}",
-      "modelLabel": "דגם Agent: {model}",
-      "settingsLabel": "הגדרות Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "מזהה דגם מותאם אישית",
-      "customModelPlaceholder": "מזהה דגם מותאם אישית",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "מקומי"
       },
       "models": {
-        "default": "ברירת מחדל"
+        "default": "ברירת מחדל",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "נימוק"
@@ -410,7 +407,23 @@
           "high": "גבוה",
           "extraHigh": "גבוה במיוחד"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "אין התאמות"

--- a/packages/i18n/src/locales/he/settings.json
+++ b/packages/i18n/src/locales/he/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/hr/common.json
+++ b/packages/i18n/src/locales/hr/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Pitajte Memry bilo što. @ za spominjanje datoteke",
       "send": "Pošalji",
       "providerLabel": "Agent pružatelj: {provider}",
-      "modelLabel": "Model Agent: {model}",
-      "settingsLabel": "Agent postavke: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID prilagođenog modela",
-      "customModelPlaceholder": "ID prilagođenog modela",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Lokalno"
       },
       "models": {
-        "default": "Zadano"
+        "default": "Zadano",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Obrazloženje"
@@ -410,7 +407,23 @@
           "high": "Visoko",
           "extraHigh": "Ekstra visoko"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Nema podudaranja"

--- a/packages/i18n/src/locales/hr/settings.json
+++ b/packages/i18n/src/locales/hr/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/hu/common.json
+++ b/packages/i18n/src/locales/hu/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Kérdezz bármit a Memry-től. @ fájl megemlítéséhez",
       "send": "Küldés",
       "providerLabel": "Agent szolgáltató: {provider}",
-      "modelLabel": "Agent modell: {model}",
-      "settingsLabel": "Agent beállítások: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Egyéni modellazonosító",
-      "customModelPlaceholder": "Egyéni modellazonosító",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Helyi"
       },
       "models": {
-        "default": "Alapértelmezett"
+        "default": "Alapértelmezett",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Indoklás"
@@ -410,7 +407,23 @@
           "high": "Magas",
           "extraHigh": "Extra magas"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Nincs találat"

--- a/packages/i18n/src/locales/hu/settings.json
+++ b/packages/i18n/src/locales/hu/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/id/common.json
+++ b/packages/i18n/src/locales/id/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Tanyakan apa saja kepada Memry. @ untuk menyebut file",
       "send": "Kirim",
       "providerLabel": "Penyedia Agent: {provider}",
-      "modelLabel": "Model Agent: {model}",
-      "settingsLabel": "Pengaturan Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID model khusus",
-      "customModelPlaceholder": "ID model khusus",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Lokal"
       },
       "models": {
-        "default": "Bawaan"
+        "default": "Bawaan",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Penalaran"
@@ -410,7 +407,23 @@
           "high": "Tinggi",
           "extraHigh": "Ekstra Tinggi"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Tidak ada kecocokan"

--- a/packages/i18n/src/locales/id/settings.json
+++ b/packages/i18n/src/locales/id/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/it/common.json
+++ b/packages/i18n/src/locales/it/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Chiedi qualsiasi cosa a Memry. @ per menzionare un file",
       "send": "Invia",
       "providerLabel": "Fornitore Agent: {provider}",
-      "modelLabel": "Modello Agent: {model}",
-      "settingsLabel": "Impostazioni Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID modello personalizzato",
-      "customModelPlaceholder": "ID modello personalizzato",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Locale"
       },
       "models": {
-        "default": "Predefinito"
+        "default": "Predefinito",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Ragionamento"
@@ -410,7 +407,23 @@
           "high": "Alto",
           "extraHigh": "Molto alto"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Nessuna corrispondenza"

--- a/packages/i18n/src/locales/it/settings.json
+++ b/packages/i18n/src/locales/it/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/ja/common.json
+++ b/packages/i18n/src/locales/ja/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Memryに何でも聞いてください。@でファイルをメンション",
       "send": "送信",
       "providerLabel": "Agent プロバイダ: {provider}",
-      "modelLabel": "Agent モデル: {model}",
-      "settingsLabel": "Agent 設定: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "カスタムモデル ID",
-      "customModelPlaceholder": "カスタムモデル ID",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "ローカル"
       },
       "models": {
-        "default": "デフォルト"
+        "default": "デフォルト",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "推論"
@@ -410,7 +407,23 @@
           "high": "高",
           "extraHigh": "エクストラハイ"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "一致しません"

--- a/packages/i18n/src/locales/ja/settings.json
+++ b/packages/i18n/src/locales/ja/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/ko/common.json
+++ b/packages/i18n/src/locales/ko/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Memry에게 무엇이든 물어보세요. @로 파일 멘션",
       "send": "보내기",
       "providerLabel": "Agent 공급자: {provider}",
-      "modelLabel": "Agent 모델: {model}",
-      "settingsLabel": "Agent 설정: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "맞춤 모델 ID",
-      "customModelPlaceholder": "맞춤 모델 ID",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "로컬"
       },
       "models": {
-        "default": "기본값"
+        "default": "기본값",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "추론"
@@ -410,7 +407,23 @@
           "high": "높음",
           "extraHigh": "매우 높음"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "일치하는 항목이 없습니다."

--- a/packages/i18n/src/locales/ko/settings.json
+++ b/packages/i18n/src/locales/ko/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/ms/common.json
+++ b/packages/i18n/src/locales/ms/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Tanya Memry apa-apa sahaja. @ untuk menyebut fail",
       "send": "Hantar",
       "providerLabel": "Pembekal Agent: {provider}",
-      "modelLabel": "Model Agent: {model}",
-      "settingsLabel": "Tetapan Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID model tersuai",
-      "customModelPlaceholder": "ID model tersuai",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Setempat"
       },
       "models": {
-        "default": "Lalai"
+        "default": "Lalai",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Penaakulan"
@@ -410,7 +407,23 @@
           "high": "Tinggi",
           "extraHigh": "Lebih Tinggi"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Tiada padanan"

--- a/packages/i18n/src/locales/ms/settings.json
+++ b/packages/i18n/src/locales/ms/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/nl/common.json
+++ b/packages/i18n/src/locales/nl/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Vraag Memry alles. @ om een bestand te vermelden",
       "send": "Verzenden",
       "providerLabel": "Agent-aanbieder: {provider}",
-      "modelLabel": "Agent-model: {model}",
-      "settingsLabel": "Agent-instellingen: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Aangepaste model-ID",
-      "customModelPlaceholder": "Aangepaste model-ID",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Lokaal"
       },
       "models": {
-        "default": "Standaard"
+        "default": "Standaard",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Redenering"
@@ -410,7 +407,23 @@
           "high": "Hoog",
           "extraHigh": "Extra hoog"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Geen overeenkomsten"

--- a/packages/i18n/src/locales/nl/settings.json
+++ b/packages/i18n/src/locales/nl/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/no/common.json
+++ b/packages/i18n/src/locales/no/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Spør Memry om hva som helst. @ for å nevne en fil",
       "send": "Sende",
       "providerLabel": "Agent-leverandør: {provider}",
-      "modelLabel": "Agent modell: {model}",
-      "settingsLabel": "Agent-innstillinger: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Egendefinert modell-ID",
-      "customModelPlaceholder": "Egendefinert modell-ID",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Lokalt"
       },
       "models": {
-        "default": "Standard"
+        "default": "Standard",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Begrunnelse"
@@ -410,7 +407,23 @@
           "high": "Høy",
           "extraHigh": "Ekstra høy"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Ingen treff"

--- a/packages/i18n/src/locales/no/settings.json
+++ b/packages/i18n/src/locales/no/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/pl/common.json
+++ b/packages/i18n/src/locales/pl/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Zapytaj Memry o cokolwiek. @, aby wspomnieć plik",
       "send": "Wyślij",
       "providerLabel": "Dostawca Agent: {provider}",
-      "modelLabel": "Model Agent: {model}",
-      "settingsLabel": "Ustawienia Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Niestandardowy identyfikator modelu",
-      "customModelPlaceholder": "Niestandardowy identyfikator modelu",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Lokalnie"
       },
       "models": {
-        "default": "Domyślne"
+        "default": "Domyślne",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Rozumowanie"
@@ -410,7 +407,23 @@
           "high": "Wysoki",
           "extraHigh": "Bardzo wysoka"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Brak dopasowań"

--- a/packages/i18n/src/locales/pl/settings.json
+++ b/packages/i18n/src/locales/pl/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/pt/common.json
+++ b/packages/i18n/src/locales/pt/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Pergunte qualquer coisa ao Memry. @ para mencionar um arquivo",
       "send": "Enviar",
       "providerLabel": "Provedor Agent: {provider}",
-      "modelLabel": "Modelo Agent: {model}",
-      "settingsLabel": "Configurações Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID do modelo personalizado",
-      "customModelPlaceholder": "ID do modelo personalizado",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Locais"
       },
       "models": {
-        "default": "Padrão"
+        "default": "Padrão",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Raciocínio"
@@ -410,7 +407,23 @@
           "high": "Alto",
           "extraHigh": "Extra Alto"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Sem correspondências"

--- a/packages/i18n/src/locales/pt/settings.json
+++ b/packages/i18n/src/locales/pt/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/ro/common.json
+++ b/packages/i18n/src/locales/ro/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Întreabă Memry orice. @ pentru a menționa un fișier",
       "send": "Trimite",
       "providerLabel": "Furnizor Agent: {provider}",
-      "modelLabel": "Model Agent: {model}",
-      "settingsLabel": "Setări Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID model personalizat",
-      "customModelPlaceholder": "ID model personalizat",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Local"
       },
       "models": {
-        "default": "Implicit"
+        "default": "Implicit",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Raționament"
@@ -410,7 +407,23 @@
           "high": "Mare",
           "extraHigh": "Extra mare"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Nicio potrivire"

--- a/packages/i18n/src/locales/ro/settings.json
+++ b/packages/i18n/src/locales/ro/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/ru/common.json
+++ b/packages/i18n/src/locales/ru/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Спросите Memry о чем угодно. @, чтобы упомянуть файл",
       "send": "Отправить",
       "providerLabel": "Поставщик Agent: {provider}",
-      "modelLabel": "Модель Agent: {model}",
-      "settingsLabel": "Настройки Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Идентификатор пользовательской модели",
-      "customModelPlaceholder": "Идентификатор пользовательской модели",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Местный"
       },
       "models": {
-        "default": "По умолчанию"
+        "default": "По умолчанию",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Рассуждение"
@@ -410,7 +407,23 @@
           "high": "Высокий",
           "extraHigh": "Очень высокий"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Нет совпадений"

--- a/packages/i18n/src/locales/ru/settings.json
+++ b/packages/i18n/src/locales/ru/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/sk/common.json
+++ b/packages/i18n/src/locales/sk/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Opýtajte sa Memry na čokoľvek. @ na zmienku o súbore",
       "send": "Odoslať",
       "providerLabel": "Poskytovateľ Agent: {provider}",
-      "modelLabel": "Model Agent: {model}",
-      "settingsLabel": "Nastavenia Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID vlastného modelu",
-      "customModelPlaceholder": "ID vlastného modelu",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Miestne"
       },
       "models": {
-        "default": "Predvolené"
+        "default": "Predvolené",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Zdôvodnenie"
@@ -410,7 +407,23 @@
           "high": "Vysoká",
           "extraHigh": "Extra vysoká"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Žiadne zhody"

--- a/packages/i18n/src/locales/sk/settings.json
+++ b/packages/i18n/src/locales/sk/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/sv/common.json
+++ b/packages/i18n/src/locales/sv/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Fråga Memry vad som helst. @ för att nämna en fil",
       "send": "Skicka",
       "providerLabel": "Agent-leverantör: {provider}",
-      "modelLabel": "Agent modell: {model}",
-      "settingsLabel": "Agent-inställningar: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Anpassad modell-ID",
-      "customModelPlaceholder": "Anpassad modell-ID",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Lokal"
       },
       "models": {
-        "default": "Standard"
+        "default": "Standard",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Resonemang"
@@ -410,7 +407,23 @@
           "high": "Hög",
           "extraHigh": "Extra hög"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Inga matchningar"

--- a/packages/i18n/src/locales/sv/settings.json
+++ b/packages/i18n/src/locales/sv/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/th/common.json
+++ b/packages/i18n/src/locales/th/common.json
@@ -376,18 +376,15 @@
       "placeholder": "ถาม Memry ได้ทุกเรื่อง @ เพื่อกล่าวถึงไฟล์",
       "send": "ส่ง",
       "providerLabel": "ผู้ให้บริการ Agent: {provider}",
-      "modelLabel": "รุ่น Agent: {model}",
-      "settingsLabel": "การตั้งค่า Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "รหัสโมเดลที่กำหนดเอง",
-      "customModelPlaceholder": "รหัสโมเดลที่กำหนดเอง",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "ท้องถิ่น"
       },
       "models": {
-        "default": "ค่าเริ่มต้น"
+        "default": "ค่าเริ่มต้น",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "การใช้เหตุผล"
@@ -410,7 +407,23 @@
           "high": "สูง",
           "extraHigh": "สูงพิเศษ"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "ไม่มีการแข่งขัน"

--- a/packages/i18n/src/locales/th/settings.json
+++ b/packages/i18n/src/locales/th/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/tr/common.json
+++ b/packages/i18n/src/locales/tr/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Memry’ye her şeyi sorun. Dosyadan bahsetmek için @ kullanın",
       "send": "Gönder",
       "providerLabel": "Agent sağlayıcısı: {provider}",
-      "modelLabel": "Agent modeli: {model}",
-      "settingsLabel": "Agent ayarları: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Özel model kimliği",
-      "customModelPlaceholder": "Özel model kimliği",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Yerel"
       },
       "models": {
-        "default": "Varsayılan"
+        "default": "Varsayılan",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Akıl yürütme"
@@ -410,7 +407,23 @@
           "high": "Yüksek",
           "extraHigh": "Ekstra Yüksek"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Eşleşme yok"

--- a/packages/i18n/src/locales/tr/settings.json
+++ b/packages/i18n/src/locales/tr/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/uk/common.json
+++ b/packages/i18n/src/locales/uk/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Запитайте Memry про що завгодно. @, щоб згадати файл",
       "send": "Надіслати",
       "providerLabel": "Постачальник Agent: {provider}",
-      "modelLabel": "Модель Agent: {model}",
-      "settingsLabel": "Налаштування Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "Спеціальний ідентифікатор моделі",
-      "customModelPlaceholder": "Спеціальний ідентифікатор моделі",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Місцевий"
       },
       "models": {
-        "default": "За замовчуванням"
+        "default": "За замовчуванням",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Міркування"
@@ -410,7 +407,23 @@
           "high": "Високий",
           "extraHigh": "Надвисокий"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Немає збігів"

--- a/packages/i18n/src/locales/uk/settings.json
+++ b/packages/i18n/src/locales/uk/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/vi/common.json
+++ b/packages/i18n/src/locales/vi/common.json
@@ -376,18 +376,15 @@
       "placeholder": "Hỏi Memry bất cứ điều gì. @ để nhắc đến tệp",
       "send": "Gửi",
       "providerLabel": "Nhà cung cấp Agent: {provider}",
-      "modelLabel": "Model Agent: {model}",
-      "settingsLabel": "Cài đặt Agent: {settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "ID mẫu tùy chỉnh",
-      "customModelPlaceholder": "ID mẫu tùy chỉnh",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "Địa phương"
       },
       "models": {
-        "default": "Mặc định"
+        "default": "Mặc định",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "Lý luận"
@@ -410,7 +407,23 @@
           "high": "Cao",
           "extraHigh": "Cực cao"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "Không có kết quả phù hợp"

--- a/packages/i18n/src/locales/vi/settings.json
+++ b/packages/i18n/src/locales/vi/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/zh-CN/common.json
+++ b/packages/i18n/src/locales/zh-CN/common.json
@@ -376,18 +376,15 @@
       "placeholder": "向 Memry 询问任何事。@ 可提及文件",
       "send": "发送",
       "providerLabel": "Agent 提供商：{provider}",
-      "modelLabel": "Agent 型号：{model}",
-      "settingsLabel": "Agent 设置：{settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "自定义模型 ID",
-      "customModelPlaceholder": "自定义模型 ID",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "本地"
       },
       "models": {
-        "default": "默认"
+        "default": "默认",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "推理"
@@ -410,7 +407,23 @@
           "high": "高",
           "extraHigh": "超高"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "没有匹配项"

--- a/packages/i18n/src/locales/zh-CN/settings.json
+++ b/packages/i18n/src/locales/zh-CN/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }

--- a/packages/i18n/src/locales/zh-TW/common.json
+++ b/packages/i18n/src/locales/zh-TW/common.json
@@ -376,18 +376,15 @@
       "placeholder": "向 Memry 詢問任何事。@ 可提及檔案",
       "send": "傳送",
       "providerLabel": "Agent 提供者：{provider}",
-      "modelLabel": "Agent 型號：{model}",
-      "settingsLabel": "Agent 設定：{settings}",
       "settingsSummary": "{reasoning}",
-      "customModelLabel": "自訂模型 ID",
-      "customModelPlaceholder": "自訂模型 ID",
       "providers": {
         "claude": "Claude",
         "codex": "Codex",
         "local": "本地"
       },
       "models": {
-        "default": "預設"
+        "default": "預設",
+        "label": "Model"
       },
       "settings": {
         "reasoning": "推理"
@@ -410,7 +407,23 @@
           "high": "高",
           "extraHigh": "超高"
         }
-      }
+      },
+      "access": {
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "webSearch": {
+        "on": "On",
+        "off": "Off",
+        "label": "Web search"
+      },
+      "permissionsLabel": "Agent permissions: {access}, web search {webSearch}",
+      "permissions": {
+        "label": "Permissions",
+        "access": "Access",
+        "tools": "Tools"
+      },
+      "modelSettingsLabel": "Agent model settings: {model}, {settings}"
     },
     "refPicker": {
       "noMatches": "沒有符合項"

--- a/packages/i18n/src/locales/zh-TW/settings.json
+++ b/packages/i18n/src/locales/zh-TW/settings.json
@@ -1179,8 +1179,8 @@
   },
   "agentProviders": {
     "header": {
-      "title": "Agent Providers",
-      "subtitle": "Configure local OpenAI-compatible models for Agent Chat."
+      "title": "Agent Permissions",
+      "subtitle": "Choose default access, confirmations, and local providers for Agent Chat."
     },
     "groups": {
       "local": "Local OpenAI-compatible provider",
@@ -1224,6 +1224,21 @@
       "disconnected": "Disconnected",
       "toolsDisabled": "Tools disabled",
       "fullTools": "Full tools enabled"
+    },
+    "permissions": {
+      "group": "Agent permissions",
+      "access": {
+        "label": "Default access",
+        "description": "Sets the starting access mode for new Agent turns.",
+        "vaultOnly": "Vault only",
+        "computerAccess": "Computer access"
+      },
+      "confirm": {
+        "label": "Confirm actions",
+        "description": "Choose whether tool calls run automatically or wait for approval in chat.",
+        "alwaysAllow": "Always allow",
+        "askBeforeChanges": "Ask before changes"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add per-turn Agent Chat permission contracts for vault-only/computer access and web search intent
- map those permissions through Claude/Codex CLI runs and prompt assembly
- add compact composer/settings controls and docs for Agent Permissions

## Release note
Agent Chat now supports per-turn access and web search controls.

## Test plan
- pnpm lint
- pnpm typecheck
- pnpm --filter @memry/desktop test:renderer -- src/renderer/src/agent-chat/__tests__/message-stream.test.tsx src/renderer/src/pages/settings/ai-section.test.tsx
- pnpm test
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build
- git diff --check