### PR TITLE
Stop idle voice transcription utility

### DIFF
--- a/apps/desktop/src/main/inbox/voice-model.test.ts
+++ b/apps/desktop/src/main/inbox/voice-model.test.ts
@@ -190,6 +190,76 @@ describe('voice model', () => {
     await expect(transcribePromise).resolves.toBe('voice memo')
   })
 
+  it('shuts down the utility process after transcription stays idle', async () => {
+    vi.useFakeTimers()
+    const transcribePromise = transcribeWithLocalModel(Buffer.from('audio'))
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+
+    const requestMessage = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      requestId: string
+    }
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'transcribe-result',
+      requestId: requestMessage.requestId,
+      transcription: 'voice memo'
+    })
+
+    await expect(transcribePromise).resolves.toBe('voice memo')
+    expect(mockUtilityProcessInstance.postMessage).not.toHaveBeenCalledWith({ type: 'shutdown' })
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mockUtilityProcessInstance.postMessage).toHaveBeenLastCalledWith({ type: 'shutdown' })
+  })
+
+  it('keeps the utility process alive when another transcription starts before idle shutdown', async () => {
+    vi.useFakeTimers()
+    const firstTranscribe = transcribeWithLocalModel(Buffer.from('first'))
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+
+    const firstRequest = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      requestId: string
+    }
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'transcribe-result',
+      requestId: firstRequest.requestId,
+      transcription: 'first memo'
+    })
+
+    await expect(firstTranscribe).resolves.toBe('first memo')
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    const secondTranscribe = transcribeWithLocalModel(Buffer.from('second'))
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(2)
+    })
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(mockUtilityProcessInstance.postMessage).not.toHaveBeenCalledWith({ type: 'shutdown' })
+
+    const secondRequest = mockUtilityProcessInstance.postMessage.mock.calls[1]?.[0] as {
+      requestId: string
+    }
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'transcribe-result',
+      requestId: secondRequest.requestId,
+      transcription: 'second memo'
+    })
+
+    await expect(secondTranscribe).resolves.toBe('second memo')
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mockUtilityProcessInstance.postMessage).toHaveBeenLastCalledWith({ type: 'shutdown' })
+  })
+
   it('returns false for worker errors and unexpected download responses', async () => {
     const failedDownload = downloadVoiceModel()
 

--- a/apps/desktop/src/main/inbox/voice-model.ts
+++ b/apps/desktop/src/main/inbox/voice-model.ts
@@ -18,6 +18,7 @@ const MODEL_NAME = 'Whisper Small'
 const REQUEST_TIMEOUT_MS = 5 * 60_000
 const START_TIMEOUT_MS = 10_000
 const SHUTDOWN_TIMEOUT_MS = 3_000
+const IDLE_SHUTDOWN_MS = 30_000
 
 export interface VoiceModelStatus {
   name: string
@@ -60,6 +61,7 @@ class VoiceModelBridge {
   private loading = false
   private error: string | null = null
   private shuttingDown = false
+  private idleShutdownTimer: ReturnType<typeof setTimeout> | null = null
 
   get isLoaded(): boolean {
     return this.loaded
@@ -113,6 +115,8 @@ class VoiceModelBridge {
   }
 
   async stop(): Promise<void> {
+    this.clearIdleShutdown()
+
     if (!this.process) {
       this.readyPromise = null
       return
@@ -144,6 +148,7 @@ class VoiceModelBridge {
 
   reset(): void {
     this.shuttingDown = true
+    this.clearIdleShutdown()
     this.process?.kill()
     this.process = null
     this.readyPromise = null
@@ -155,6 +160,8 @@ class VoiceModelBridge {
   }
 
   private async start(): Promise<void> {
+    this.clearIdleShutdown()
+
     if (this.process) {
       await this.readyPromise
       return
@@ -258,10 +265,12 @@ class VoiceModelBridge {
         if (message.type === 'error') {
           this.error = message.error
           this.loading = false
+          this.scheduleIdleShutdown()
           pending.reject(new Error(message.error))
           return
         }
 
+        this.scheduleIdleShutdown()
         pending.resolve(message)
       }
     })
@@ -308,9 +317,12 @@ class VoiceModelBridge {
       return Promise.reject(new Error('Voice transcription utility is not running'))
     }
 
+    this.clearIdleShutdown()
+
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingRequests.delete(message.requestId)
+        this.scheduleIdleShutdown()
         reject(new Error(`Voice transcription request timed out: ${message.type}`))
       }, REQUEST_TIMEOUT_MS)
 
@@ -325,6 +337,7 @@ class VoiceModelBridge {
   }
 
   private failProcess(error: Error): void {
+    this.clearIdleShutdown()
     if (this.process) {
       this.process = null
     }
@@ -341,6 +354,36 @@ class VoiceModelBridge {
       pending.reject(error)
       this.pendingRequests.delete(requestId)
     }
+  }
+
+  private scheduleIdleShutdown(): void {
+    this.clearIdleShutdown()
+
+    if (!this.process || this.pendingRequests.size > 0 || this.shuttingDown) {
+      return
+    }
+
+    this.idleShutdownTimer = setTimeout(() => {
+      this.idleShutdownTimer = null
+      if (!this.process || this.pendingRequests.size > 0 || this.shuttingDown) {
+        return
+      }
+
+      void this.stop().catch((error) => {
+        logger.warn('Voice transcription utility idle shutdown failed', {
+          error: error instanceof Error ? error.message : String(error)
+        })
+      })
+    }, IDLE_SHUTDOWN_MS)
+  }
+
+  private clearIdleShutdown(): void {
+    if (!this.idleShutdownTimer) {
+      return
+    }
+
+    clearTimeout(this.idleShutdownTimer)
+    this.idleShutdownTimer = null
   }
 }
 

--- a/apps/docs/src/user-guide/ai/voice-transcription.md
+++ b/apps/docs/src/user-guide/ai/voice-transcription.md
@@ -25,6 +25,10 @@ Memry uses Whisper Small as the default local model — a balance of accuracy an
 
 Model files are stored locally in the app data directory. Disk usage is shown next to each option.
 
+Local transcription starts a native helper process while Whisper runs. After a transcription request
+finishes and no new voice work starts, Memry shuts that helper down after a short idle period so the
+model can release memory.
+
 ### Languages
 
 Whisper Small handles dozens of languages well. For unusual languages, larger Whisper models tend to do better — see the open-source Whisper docs for tradeoffs.


### PR DESCRIPTION
## Summary
- shut down the local Whisper utility process after 30 seconds of idle time
- cancel the idle shutdown when another transcription request starts
- document the helper process memory behavior in voice transcription docs

## Root cause
Local voice transcription started an Electron Node utility process for Whisper/ONNX work, but completed requests left the process and model loaded until explicit teardown.

## Validation
- pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project main src/main/inbox/voice-model.test.ts
- pnpm --filter @memry/desktop typecheck:node
- pnpm docs:build
- pnpm docs:impact --base 39fdfc50860afac139db0886023a8ac4a842a143 --strict
- git diff --check