### PR TITLE
feat(landing): add Vercel event analytics

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -17,6 +17,7 @@
     "@paddle/paddle-node-sdk": "^3.8.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-slot": "^1.2.4",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.24.7",

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { HelmetProvider } from 'react-helmet-async'
+import { Analytics } from '@vercel/analytics/react'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 import { SmoothScroll } from '@/components/layout/SmoothScroll'
@@ -21,6 +22,14 @@ import { PrivacyPage } from '@/pages/Privacy'
 import { RefundPage } from '@/pages/Refund'
 import { NotFound } from '@/pages/NotFound'
 import { scrollToLandingTarget } from '@/lib/smooth-scroll'
+import { trackLandingEvent, type LandingEventName } from '@/lib/analytics'
+
+const SCROLL_DEPTH_EVENTS: readonly { depth: number; event: LandingEventName }[] = [
+  { depth: 25, event: 'landing_scroll_25' },
+  { depth: 50, event: 'landing_scroll_50' },
+  { depth: 75, event: 'landing_scroll_75' },
+  { depth: 100, event: 'landing_scroll_100' }
+]
 
 function ScrollToHash() {
   const { pathname, hash } = useLocation()
@@ -47,11 +56,52 @@ function ScrollToHash() {
   return null
 }
 
+function ScrollDepthAnalytics() {
+  const { pathname } = useLocation()
+  const firedDepthsRef = useRef<Set<number>>(new Set())
+
+  useEffect(() => {
+    firedDepthsRef.current = new Set()
+    let frame = 0
+
+    const measure = () => {
+      frame = 0
+      const maxScroll = document.documentElement.scrollHeight - window.innerHeight
+      const depth = maxScroll <= 0 ? 100 : Math.min((window.scrollY / maxScroll) * 100, 100)
+
+      for (const { depth: threshold, event } of SCROLL_DEPTH_EVENTS) {
+        if (depth >= threshold && !firedDepthsRef.current.has(threshold)) {
+          firedDepthsRef.current.add(threshold)
+          trackLandingEvent(event, `scroll:${threshold}`)
+        }
+      }
+    }
+
+    const scheduleMeasure = () => {
+      if (frame) return
+      frame = window.requestAnimationFrame(measure)
+    }
+
+    measure()
+    window.addEventListener('scroll', scheduleMeasure, { passive: true })
+    window.addEventListener('resize', scheduleMeasure)
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame)
+      window.removeEventListener('scroll', scheduleMeasure)
+      window.removeEventListener('resize', scheduleMeasure)
+    }
+  }, [pathname])
+
+  return null
+}
+
 function AppContent() {
   return (
     <div className="min-h-screen flex flex-col">
       <SmoothScroll />
       <ScrollToHash />
+      <ScrollDepthAnalytics />
       <Header />
       <main className="flex-1">
         <Routes>
@@ -83,6 +133,7 @@ export default function App() {
     <HelmetProvider>
       <BrowserRouter>
         <AppContent />
+        <Analytics />
       </BrowserRouter>
     </HelmetProvider>
   )

--- a/apps/landing/src/components/demo/DemoScene.tsx
+++ b/apps/landing/src/components/demo/DemoScene.tsx
@@ -68,6 +68,7 @@ export function DemoScene({
             style={{ pointerEvents: isActive ? 'auto' : 'none' }}
           >
             <Scene
+              clipId={clip.id}
               playing={isActive && playing}
               muted={muted}
               onMutedChange={onMutedChange}

--- a/apps/landing/src/components/demo/DemoShowcase.tsx
+++ b/apps/landing/src/components/demo/DemoShowcase.tsx
@@ -3,7 +3,12 @@ import { MockupFrame } from '@/components/shared/MockupFrame'
 import { DemoTabs } from './DemoTabs'
 import { DemoScene } from './DemoScene'
 import { useShowcaseTimer } from './hooks/useShowcaseTimer'
-import type { SeekRequest } from './types'
+import { CLIPS, type SeekRequest, type TabId } from './types'
+import { trackLandingEvent, type LandingEventName } from '@/lib/analytics'
+
+function demoTarget(clipId: TabId) {
+  return `demo:${clipId}`
+}
 
 export function DemoShowcase() {
   const [activeIndex, setActiveIndex] = useState(0)
@@ -12,15 +17,26 @@ export function DemoShowcase() {
   const [videoDuration, setVideoDuration] = useState<number | null>(null)
   const [seekRequest, setSeekRequest] = useState<SeekRequest | null>(null)
 
+  const handleProgressMilestone = useCallback((clipId: TabId, milestone: 25 | 50 | 75) => {
+    trackLandingEvent(`landing_demo_progress_${milestone}` as LandingEventName, demoTarget(clipId))
+  }, [])
+
+  const handleClipComplete = useCallback((clipId: TabId) => {
+    trackLandingEvent('landing_demo_complete', demoTarget(clipId))
+  }, [])
+
   const { progress, goTo, seekTo } = useShowcaseTimer(
     activeIndex,
     setActiveIndex,
     paused,
-    videoDuration
+    videoDuration,
+    handleClipComplete,
+    handleProgressMilestone
   )
 
   const handleTabClick = useCallback(
     (index: number) => {
+      trackLandingEvent('landing_demo_tab_click', demoTarget(CLIPS[index].id))
       setVideoDuration(null)
       goTo(index)
       setPaused(false)
@@ -29,8 +45,12 @@ export function DemoShowcase() {
   )
 
   const handleToggle = useCallback(() => {
+    trackLandingEvent(
+      paused ? 'landing_demo_resume' : 'landing_demo_pause',
+      demoTarget(CLIPS[activeIndex].id)
+    )
     setPaused((p) => !p)
-  }, [])
+  }, [activeIndex, paused])
 
   const handleDurationDetected = useCallback((ms: number) => {
     setVideoDuration(ms)
@@ -38,13 +58,15 @@ export function DemoShowcase() {
 
   const handleActiveTabSeek = useCallback(
     (nextProgress: number) => {
+      const eventName = nextProgress < progress.get() ? 'landing_demo_rewind' : 'landing_demo_seek'
+      trackLandingEvent(eventName, demoTarget(CLIPS[activeIndex].id))
       seekTo(nextProgress)
       setSeekRequest((current) => ({
         progress: nextProgress,
         requestId: (current?.requestId ?? 0) + 1
       }))
     },
-    [seekTo]
+    [activeIndex, progress, seekTo]
   )
 
   return (

--- a/apps/landing/src/components/demo/hooks/useShowcaseTimer.ts
+++ b/apps/landing/src/components/demo/hooks/useShowcaseTimer.ts
@@ -1,19 +1,38 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { useMotionValue } from 'framer-motion'
-import { CLIPS } from '../types'
+import { CLIPS, type TabId } from '../types'
+
+type ProgressMilestone = 25 | 50 | 75
+
+const PROGRESS_MILESTONES: readonly ProgressMilestone[] = [25, 50, 75]
 
 export function useShowcaseTimer(
   activeIndex: number,
   setActiveIndex: (updater: (prev: number) => number) => void,
   paused: boolean,
-  durationOverride: number | null
+  durationOverride: number | null,
+  onClipComplete?: (clipId: TabId) => void,
+  onProgressMilestone?: (clipId: TabId, milestone: ProgressMilestone) => void
 ) {
   const progress = useMotionValue(0)
   const startTimeRef = useRef<number | null>(null)
   const pausedAtRef = useRef(0)
   const rafRef = useRef<number>(0)
+  const firedMilestonesRef = useRef<Set<ProgressMilestone>>(new Set())
 
   const duration = durationOverride ?? CLIPS[activeIndex].duration
+
+  const resetProgressMilestones = useCallback(() => {
+    firedMilestonesRef.current = new Set()
+  }, [])
+
+  const pruneProgressMilestones = useCallback((nextProgress: number) => {
+    for (const milestone of firedMilestonesRef.current) {
+      if (milestone / 100 > nextProgress) {
+        firedMilestonesRef.current.delete(milestone)
+      }
+    }
+  }, [])
 
   useEffect(() => {
     if (paused) {
@@ -32,9 +51,18 @@ export function useShowcaseTimer(
       const p = Math.min(elapsed / duration, 1)
       progress.set(p)
 
+      for (const milestone of PROGRESS_MILESTONES) {
+        if (p >= milestone / 100 && !firedMilestonesRef.current.has(milestone)) {
+          firedMilestonesRef.current.add(milestone)
+          onProgressMilestone?.(CLIPS[activeIndex].id, milestone)
+        }
+      }
+
       if (p >= 1) {
+        onClipComplete?.(CLIPS[activeIndex].id)
         startTimeRef.current = null
         pausedAtRef.current = 0
+        resetProgressMilestones()
         progress.set(0)
         setActiveIndex((prev) => (prev + 1) % CLIPS.length)
       } else {
@@ -44,17 +72,27 @@ export function useShowcaseTimer(
 
     rafRef.current = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(rafRef.current)
-  }, [paused, duration, progress, setActiveIndex])
+  }, [
+    activeIndex,
+    duration,
+    onClipComplete,
+    onProgressMilestone,
+    paused,
+    progress,
+    resetProgressMilestones,
+    setActiveIndex
+  ])
 
   const goTo = useCallback(
     (index: number) => {
       cancelAnimationFrame(rafRef.current)
       startTimeRef.current = null
       pausedAtRef.current = 0
+      resetProgressMilestones()
       progress.set(0)
       setActiveIndex(() => index)
     },
-    [progress, setActiveIndex]
+    [progress, resetProgressMilestones, setActiveIndex]
   )
 
   const seekTo = useCallback(
@@ -62,9 +100,10 @@ export function useShowcaseTimer(
       const clampedProgress = Math.min(Math.max(nextProgress, 0), 1)
       progress.set(clampedProgress)
       pausedAtRef.current = clampedProgress
+      pruneProgressMilestones(clampedProgress)
       startTimeRef.current = paused ? null : performance.now() - clampedProgress * duration
     },
-    [duration, paused, progress]
+    [duration, paused, progress, pruneProgressMilestones]
   )
 
   return { progress, goTo, seekTo }

--- a/apps/landing/src/components/demo/scenes/InboxScene.tsx
+++ b/apps/landing/src/components/demo/scenes/InboxScene.tsx
@@ -2,6 +2,7 @@ import { VideoScene } from './VideoScene'
 import type { SceneProps } from '../types'
 
 export function InboxScene({
+  clipId,
   playing,
   muted,
   onMutedChange,
@@ -10,6 +11,7 @@ export function InboxScene({
 }: SceneProps) {
   return (
     <VideoScene
+      clipId={clipId}
       src="/demos/InboxVoice.mp4"
       playing={playing}
       muted={muted}

--- a/apps/landing/src/components/demo/scenes/JournalScene.tsx
+++ b/apps/landing/src/components/demo/scenes/JournalScene.tsx
@@ -2,6 +2,7 @@ import { VideoScene } from './VideoScene'
 import type { SceneProps } from '../types'
 
 export function JournalScene({
+  clipId,
   playing,
   muted,
   onMutedChange,
@@ -10,6 +11,7 @@ export function JournalScene({
 }: SceneProps) {
   return (
     <VideoScene
+      clipId={clipId}
       src="/demos/JournalVoice.mp4"
       playing={playing}
       muted={muted}

--- a/apps/landing/src/components/demo/scenes/NotesScene.tsx
+++ b/apps/landing/src/components/demo/scenes/NotesScene.tsx
@@ -2,6 +2,7 @@ import { VideoScene } from './VideoScene'
 import type { SceneProps } from '../types'
 
 export function NotesScene({
+  clipId,
   playing,
   muted,
   onMutedChange,
@@ -10,6 +11,7 @@ export function NotesScene({
 }: SceneProps) {
   return (
     <VideoScene
+      clipId={clipId}
       src="/demos/NoteVoice.mp4"
       playing={playing}
       muted={muted}

--- a/apps/landing/src/components/demo/scenes/TasksScene.tsx
+++ b/apps/landing/src/components/demo/scenes/TasksScene.tsx
@@ -2,6 +2,7 @@ import { VideoScene } from './VideoScene'
 import type { SceneProps } from '../types'
 
 export function TasksScene({
+  clipId,
   playing,
   muted,
   onMutedChange,
@@ -10,6 +11,7 @@ export function TasksScene({
 }: SceneProps) {
   return (
     <VideoScene
+      clipId={clipId}
       src="/demos/TaskVoice.mp4"
       playing={playing}
       muted={muted}

--- a/apps/landing/src/components/demo/scenes/VideoScene.tsx
+++ b/apps/landing/src/components/demo/scenes/VideoScene.tsx
@@ -2,12 +2,14 @@ import { useRef, useEffect, useState, type MouseEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { Maximize2, Minimize2, Volume2, VolumeX } from 'lucide-react'
 import type { SceneProps } from '../types'
+import { trackLandingEvent } from '@/lib/analytics'
 
 interface VideoSceneProps extends SceneProps {
   src: string
 }
 
 export function VideoScene({
+  clipId,
   src,
   playing,
   muted,
@@ -100,6 +102,7 @@ export function VideoScene({
 
   const handleMuteToggle = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation()
+    trackLandingEvent(muted ? 'landing_demo_unmute' : 'landing_demo_mute', `demo:${clipId}`)
     onMutedChange(!muted)
   }
 
@@ -109,6 +112,7 @@ export function VideoScene({
       closeExpanded()
       return
     }
+    trackLandingEvent('landing_demo_expand', `demo:${clipId}`)
     setExpanded(true)
   }
 

--- a/apps/landing/src/components/demo/types.ts
+++ b/apps/landing/src/components/demo/types.ts
@@ -7,6 +7,7 @@ export interface ClipConfig {
 }
 
 export interface SceneProps {
+  clipId: TabId
   playing: boolean
   muted: boolean
   onMutedChange: (muted: boolean) => void

--- a/apps/landing/src/components/layout/Footer.tsx
+++ b/apps/landing/src/components/layout/Footer.tsx
@@ -2,10 +2,17 @@ import type { ReactNode } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { Container } from './Container'
 import { FOOTER_LINKS, TWITTER_DEV_URL } from '@/lib/constants'
+import { trackLandingEvent } from '@/lib/analytics'
 
 function footerHref(href: string, pathname: string): string {
   if (href.startsWith('#') && pathname !== '/') return '/' + href
   return href
+}
+
+function footerTarget(label: ReactNode) {
+  return `footer:${String(label)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')}`
 }
 
 function FooterLink({ href, children }: { href: string; children: ReactNode }) {
@@ -13,14 +20,24 @@ function FooterLink({ href, children }: { href: string; children: ReactNode }) {
 
   if (href.startsWith('http')) {
     return (
-      <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+        onClick={() => trackLandingEvent('landing_external_click', footerTarget(children))}
+      >
         {children}
       </a>
     )
   }
 
   return (
-    <Link to={href} className={className}>
+    <Link
+      to={href}
+      className={className}
+      onClick={() => trackLandingEvent('landing_nav_click', footerTarget(children))}
+    >
       {children}
     </Link>
   )
@@ -35,7 +52,11 @@ export function Footer() {
       <Container>
         <div className="grid grid-cols-2 md:grid-cols-5 gap-10 mb-16">
           <div className="col-span-2 md:col-span-2 pe-8">
-            <Link to="/" className="inline-block mb-6 group">
+            <Link
+              to="/"
+              className="inline-block mb-6 group"
+              onClick={() => trackLandingEvent('landing_nav_click', 'footer:logo')}
+            >
               <span className="font-serif text-3xl font-medium text-ink group-hover:text-terracotta transition-colors">
                 memry
               </span>
@@ -53,6 +74,7 @@ export function Footer() {
                   <Link
                     to={footerHref(link.href, pathname)}
                     className="text-sm text-muted hover:text-terracotta transition-colors font-medium"
+                    onClick={() => trackLandingEvent('landing_nav_click', footerTarget(link.label))}
                   >
                     {link.label}
                   </Link>
@@ -82,6 +104,9 @@ export function Footer() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-sm text-muted hover:text-terracotta transition-colors font-medium"
+                    onClick={() =>
+                      trackLandingEvent('landing_external_click', footerTarget(link.label))
+                    }
                   >
                     {link.label}
                   </a>
@@ -102,6 +127,7 @@ export function Footer() {
               target="_blank"
               rel="noopener noreferrer"
               className="text-terracotta hover:underline"
+              onClick={() => trackLandingEvent('landing_external_click', 'footer:founder-twitter')}
             >
               @h4yfans
             </a>

--- a/apps/landing/src/components/layout/Header.tsx
+++ b/apps/landing/src/components/layout/Header.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import { scrollToLandingTarget } from '@/lib/smooth-scroll'
+import { trackLandingEvent, type LandingEventName } from '@/lib/analytics'
 
 function useScrollToSection() {
   const navigate = useNavigate()
@@ -42,16 +43,33 @@ function formatStarCount(count: number) {
   return new Intl.NumberFormat('en-US').format(count)
 }
 
+function analyticsTarget(scope: string, label: string) {
+  return `${scope}:${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`
+}
+
+function dropdownEvent(label: string): LandingEventName {
+  return label === 'Download' ? 'landing_download_click' : 'landing_nav_click'
+}
+
 function NavLink({ href, label }: { href: string; label: string }) {
   const className =
     'rounded-full px-3 py-2 text-sm font-medium text-muted transition-colors hover:text-ink'
+  const eventName = isExternalHref(href) ? 'landing_external_click' : 'landing_nav_click'
 
   return isExternalHref(href) ? (
-    <a href={href} className={className}>
+    <a
+      href={href}
+      className={className}
+      onClick={() => trackLandingEvent(eventName, analyticsTarget('nav', label))}
+    >
       {label}
     </a>
   ) : (
-    <Link to={href} className={className}>
+    <Link
+      to={href}
+      className={className}
+      onClick={() => trackLandingEvent(eventName, analyticsTarget('nav', label))}
+    >
       {label}
     </Link>
   )
@@ -75,7 +93,10 @@ function GitHubStarWidget({
       href={GITHUB_URL}
       target="_blank"
       rel="noreferrer"
-      onClick={onClick}
+      onClick={() => {
+        trackLandingEvent('landing_external_click', 'external:github')
+        onClick?.()
+      }}
       aria-label={`${formattedStars} GitHub stars`}
     >
       <svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" aria-hidden>
@@ -120,7 +141,13 @@ function DropdownIcon({ item, className }: { item: LandingDropdownItem; classNam
   return <Icon className={className} strokeWidth={2.4} aria-hidden />
 }
 
-function DropdownItem({ item }: { item: LandingDropdownItem }) {
+function DropdownItem({
+  item,
+  eventName
+}: {
+  item: LandingDropdownItem
+  eventName: LandingEventName
+}) {
   const className = cn(
     'flex min-h-[68px] items-start gap-4 rounded-2xl px-4 py-3 text-start transition-colors',
     item.disabled
@@ -146,17 +173,18 @@ function DropdownItem({ item }: { item: LandingDropdownItem }) {
       </span>
     </>
   )
+  const handleClick = () => trackLandingEvent(eventName, analyticsTarget('dropdown', item.label))
 
   return item.disabled ? (
     <button type="button" className={className} aria-disabled="true" tabIndex={-1}>
       {content}
     </button>
   ) : isExternalHref(item.href) ? (
-    <a href={item.href} className={className}>
+    <a href={item.href} className={className} onClick={handleClick}>
       {content}
     </a>
   ) : (
-    <Link to={item.href} className={className}>
+    <Link to={item.href} className={className} onClick={handleClick}>
       {content}
     </Link>
   )
@@ -173,6 +201,8 @@ function DesktopDropdown({
   icon?: LucideIcon
   columns?: 1 | 2
 }) {
+  const eventName = dropdownEvent(label)
+
   return (
     <div className="group relative">
       <DropdownTrigger label={label} icon={icon} />
@@ -185,7 +215,7 @@ function DesktopDropdown({
         >
           <div className={cn('grid gap-2', columns === 2 ? 'grid-cols-2' : 'grid-cols-1')}>
             {items.map((item) => (
-              <DropdownItem key={item.label} item={item} />
+              <DropdownItem key={item.label} item={item} eventName={eventName} />
             ))}
           </div>
         </div>
@@ -203,6 +233,8 @@ function MobileDropdownSection({
   items: readonly LandingDropdownItem[]
   onNavigate: () => void
 }) {
+  const eventName = dropdownEvent(title)
+
   return (
     <div className="rounded-2xl border border-border/60 bg-card/65 p-3">
       <p className="px-2 pb-2 font-mono-accent text-[10px] uppercase tracking-[0.18em] text-muted">
@@ -234,6 +266,10 @@ function MobileDropdownSection({
             'flex items-center gap-3 rounded-xl px-2 py-2 text-start transition-colors',
             item.disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-paper-alt'
           )
+          const handleClick = () => {
+            trackLandingEvent(eventName, analyticsTarget('mobile-dropdown', item.label))
+            onNavigate()
+          }
 
           return item.disabled ? (
             <button
@@ -246,11 +282,11 @@ function MobileDropdownSection({
               {content}
             </button>
           ) : isExternalHref(item.href) ? (
-            <a key={item.label} href={item.href} className={className} onClick={onNavigate}>
+            <a key={item.label} href={item.href} className={className} onClick={handleClick}>
               {content}
             </a>
           ) : (
-            <Link key={item.label} to={item.href} className={className} onClick={onNavigate}>
+            <Link key={item.label} to={item.href} className={className} onClick={handleClick}>
               {content}
             </Link>
           )
@@ -280,6 +316,8 @@ export function Header() {
   }, [])
 
   const handleLogoClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    trackLandingEvent('landing_nav_click', 'nav:logo')
+
     if (location.pathname !== '/') {
       setMobileMenuOpen(false)
       return
@@ -330,7 +368,13 @@ export function Header() {
             <ThemeToggle />
             <GitHubStarWidget />
             <Button variant="default" size="sm" className="rounded-full px-6" asChild>
-              <a href="#waitlist" onClick={(e) => scrollToSection(e, '#waitlist')}>
+              <a
+                href="#waitlist"
+                onClick={(e) => {
+                  trackLandingEvent('landing_nav_click', 'nav:join')
+                  scrollToSection(e, '#waitlist')
+                }}
+              >
                 Join
                 <ArrowUpRight className="w-4 h-4" />
               </a>
@@ -376,7 +420,13 @@ export function Header() {
                     <a
                       key={link.href}
                       href={link.href}
-                      onClick={() => setMobileMenuOpen(false)}
+                      onClick={() => {
+                        trackLandingEvent(
+                          'landing_external_click',
+                          analyticsTarget('mobile-nav', link.label)
+                        )
+                        setMobileMenuOpen(false)
+                      }}
                       className="rounded-2xl border border-border/60 bg-card/65 px-4 py-3 text-xl font-serif font-medium text-ink transition-colors hover:text-terracotta"
                     >
                       {link.label}
@@ -385,7 +435,13 @@ export function Header() {
                     <Link
                       key={link.href}
                       to={link.href}
-                      onClick={() => setMobileMenuOpen(false)}
+                      onClick={() => {
+                        trackLandingEvent(
+                          'landing_nav_click',
+                          analyticsTarget('mobile-nav', link.label)
+                        )
+                        setMobileMenuOpen(false)
+                      }}
                       className="rounded-2xl border border-border/60 bg-card/65 px-4 py-3 text-xl font-serif font-medium text-ink transition-colors hover:text-terracotta"
                     >
                       {link.label}
@@ -398,6 +454,7 @@ export function Header() {
                   <a
                     href="#waitlist"
                     onClick={(e) => {
+                      trackLandingEvent('landing_nav_click', 'mobile-nav:join')
                       scrollToSection(e, '#waitlist')
                       setMobileMenuOpen(false)
                     }}

--- a/apps/landing/src/components/sections/FlowShowcase.tsx
+++ b/apps/landing/src/components/sections/FlowShowcase.tsx
@@ -5,11 +5,16 @@ import { MockupFrame } from '@/components/shared/MockupFrame'
 import { DemoTabs } from '@/components/demo/DemoTabs'
 import { DemoScene } from '@/components/demo/DemoScene'
 import { useShowcaseTimer } from '@/components/demo/hooks/useShowcaseTimer'
-import { CLIPS, type SeekRequest } from '@/components/demo/types'
+import { CLIPS, type SeekRequest, type TabId } from '@/components/demo/types'
 import { FLOW_STEPS } from '@/lib/constants'
 import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from '@/lib/motion'
+import { trackLandingEvent, type LandingEventName } from '@/lib/analytics'
 
 const INTERACTIVE_STEPS = FLOW_STEPS.filter((s) => CLIPS.some((c) => c.id === s.id))
+
+function demoTarget(clipId: TabId) {
+  return `demo:${clipId}`
+}
 
 function CompetitorBar({ activeIndex }: { activeIndex: number }) {
   const step = INTERACTIVE_STEPS[activeIndex]
@@ -54,11 +59,21 @@ export function FlowShowcase() {
   const [videoDuration, setVideoDuration] = useState<number | null>(null)
   const [seekRequest, setSeekRequest] = useState<SeekRequest | null>(null)
 
+  const handleProgressMilestone = useCallback((clipId: TabId, milestone: 25 | 50 | 75) => {
+    trackLandingEvent(`landing_demo_progress_${milestone}` as LandingEventName, demoTarget(clipId))
+  }, [])
+
+  const handleClipComplete = useCallback((clipId: TabId) => {
+    trackLandingEvent('landing_demo_complete', demoTarget(clipId))
+  }, [])
+
   const { progress, goTo, seekTo } = useShowcaseTimer(
     activeIndex,
     setActiveIndex,
     paused || !started,
-    videoDuration
+    videoDuration,
+    handleClipComplete,
+    handleProgressMilestone
   )
 
   const restartActiveVideo = useCallback(() => {
@@ -69,21 +84,26 @@ export function FlowShowcase() {
   }, [])
 
   const handleStart = useCallback(() => {
+    trackLandingEvent('landing_demo_start', demoTarget(CLIPS[activeIndex].id))
     setStarted(true)
     setPaused(false)
     seekTo(0)
     restartActiveVideo()
-  }, [restartActiveVideo, seekTo])
+  }, [activeIndex, restartActiveVideo, seekTo])
 
   const handleStepClick = useCallback(
     (index: number) => {
+      trackLandingEvent('landing_demo_tab_click', demoTarget(CLIPS[index].id))
+      if (!started) {
+        trackLandingEvent('landing_demo_start', demoTarget(CLIPS[index].id))
+      }
       setVideoDuration(null)
       goTo(index)
       restartActiveVideo()
       setStarted(true)
       setPaused(false)
     },
-    [goTo, restartActiveVideo]
+    [goTo, restartActiveVideo, started]
   )
 
   const handleToggle = useCallback(() => {
@@ -92,8 +112,12 @@ export function FlowShowcase() {
       return
     }
 
+    trackLandingEvent(
+      paused ? 'landing_demo_resume' : 'landing_demo_pause',
+      demoTarget(CLIPS[activeIndex].id)
+    )
     setPaused((p) => !p)
-  }, [handleStart, started])
+  }, [activeIndex, handleStart, paused, started])
 
   const handleDurationDetected = useCallback((ms: number) => {
     setVideoDuration(ms)
@@ -106,13 +130,15 @@ export function FlowShowcase() {
         return
       }
 
+      const eventName = nextProgress < progress.get() ? 'landing_demo_rewind' : 'landing_demo_seek'
+      trackLandingEvent(eventName, demoTarget(CLIPS[activeIndex].id))
       seekTo(nextProgress)
       setSeekRequest((current) => ({
         progress: nextProgress,
         requestId: (current?.requestId ?? 0) + 1
       }))
     },
-    [handleStart, seekTo, started]
+    [activeIndex, handleStart, progress, seekTo, started]
   )
 
   return (

--- a/apps/landing/src/components/sections/FounderStory.tsx
+++ b/apps/landing/src/components/sections/FounderStory.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion'
 import { Container } from '@/components/layout/Container'
 import { GITHUB_URL, TWITTER_DEV_URL } from '@/lib/constants'
+import { trackLandingEvent } from '@/lib/analytics'
 
 export function FounderStory() {
   return (
@@ -71,6 +72,7 @@ export function FounderStory() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-sm font-medium text-terracotta hover:underline"
+                    onClick={() => trackLandingEvent('landing_external_click', 'founder:twitter')}
                   >
                     Follow @h4yfans for updates →
                   </a>
@@ -79,6 +81,7 @@ export function FounderStory() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-sm text-muted hover:text-ink transition-colors"
+                    onClick={() => trackLandingEvent('landing_external_click', 'founder:github')}
                   >
                     GitHub
                   </a>

--- a/apps/landing/src/components/sections/Roadmap.tsx
+++ b/apps/landing/src/components/sections/Roadmap.tsx
@@ -2,6 +2,7 @@ import { motion } from 'framer-motion'
 import { Check } from 'lucide-react'
 import { Container } from '@/components/layout/Container'
 import { GITHUB_URL, ROADMAP_DATA, TWITTER_DEV_URL } from '@/lib/constants'
+import { trackLandingEvent } from '@/lib/analytics'
 
 const STATUS_CONFIG = {
   done: {
@@ -165,6 +166,7 @@ export function Roadmap() {
             target="_blank"
             rel="noopener noreferrer"
             className="text-terracotta hover:underline font-medium"
+            onClick={() => trackLandingEvent('landing_external_click', 'roadmap:github-issues')}
           >
             Request a feature →
           </a>
@@ -174,6 +176,7 @@ export function Roadmap() {
             target="_blank"
             rel="noopener noreferrer"
             className="text-terracotta hover:underline font-medium"
+            onClick={() => trackLandingEvent('landing_external_click', 'roadmap:twitter')}
           >
             Follow @h4yfans for updates →
           </a>

--- a/apps/landing/src/components/shared/WaitlistForm.tsx
+++ b/apps/landing/src/components/shared/WaitlistForm.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, Check, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { trackLandingEvent } from '@/lib/analytics'
 
 interface WaitlistFormProps {
   variant?: 'hero' | 'inline' | 'centered'
@@ -19,6 +20,7 @@ export function WaitlistForm({ variant = 'hero', className }: WaitlistFormProps)
     e.preventDefault()
     if (!email || status === 'loading') return
 
+    trackLandingEvent('landing_waitlist_submit', `waitlist:${variant}`)
     setStatus('loading')
     setErrorMessage('')
 
@@ -34,13 +36,16 @@ export function WaitlistForm({ variant = 'hero', className }: WaitlistFormProps)
       const data = await response.json()
 
       if (response.ok && data.success) {
+        trackLandingEvent('landing_waitlist_success', `waitlist:${variant}`)
         setStatus('success')
         setEmail('')
       } else {
+        trackLandingEvent('landing_waitlist_error', `waitlist:${variant}`)
         setErrorMessage(data.error || 'Something went wrong')
         setStatus('error')
       }
     } catch {
+      trackLandingEvent('landing_waitlist_error', `waitlist:${variant}`)
       setErrorMessage('Network error. Please try again.')
       setStatus('error')
     }

--- a/apps/landing/src/lib/analytics.test.ts
+++ b/apps/landing/src/lib/analytics.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { createLandingEventData } from './analytics.ts'
+
+describe('landing analytics event data', () => {
+  it('keeps Vercel event data to page and target only', () => {
+    assert.deepEqual(createLandingEventData('pricing:plus', '/pricing'), {
+      page: '/pricing',
+      target: 'pricing:plus'
+    })
+  })
+
+  it('strips query strings and hashes from event data', () => {
+    assert.deepEqual(
+      createLandingEventData(
+        'download:https://github.com/memrynote/memry/releases?token=secret',
+        '/pricing?checkout=success#plans'
+      ),
+      {
+        page: '/pricing',
+        target: 'download:https://github.com/memrynote/memry/releases'
+      }
+    )
+  })
+})

--- a/apps/landing/src/lib/analytics.ts
+++ b/apps/landing/src/lib/analytics.ts
@@ -1,0 +1,50 @@
+import { track } from '@vercel/analytics'
+
+export type LandingEventName =
+  | 'landing_scroll_25'
+  | 'landing_scroll_50'
+  | 'landing_scroll_75'
+  | 'landing_scroll_100'
+  | 'landing_nav_click'
+  | 'landing_waitlist_submit'
+  | 'landing_waitlist_success'
+  | 'landing_waitlist_error'
+  | 'landing_pricing_cadence_change'
+  | 'landing_pricing_cta_click'
+  | 'landing_download_click'
+  | 'landing_external_click'
+  | 'landing_demo_start'
+  | 'landing_demo_pause'
+  | 'landing_demo_resume'
+  | 'landing_demo_tab_click'
+  | 'landing_demo_seek'
+  | 'landing_demo_rewind'
+  | 'landing_demo_progress_25'
+  | 'landing_demo_progress_50'
+  | 'landing_demo_progress_75'
+  | 'landing_demo_complete'
+  | 'landing_demo_mute'
+  | 'landing_demo_unmute'
+  | 'landing_demo_expand'
+
+export type LandingEventData = {
+  page: string
+  target: string
+}
+
+function stripQueryAndHash(value: string): string {
+  return value.split(/[?#]/)[0] || 'unknown'
+}
+
+export function createLandingEventData(target: string, pathname: string): LandingEventData {
+  return {
+    page: stripQueryAndHash(pathname),
+    target: stripQueryAndHash(target)
+  }
+}
+
+export function trackLandingEvent(name: LandingEventName, target: string): void {
+  if (typeof window === 'undefined') return
+
+  track(name, createLandingEventData(target, window.location.pathname))
+}

--- a/apps/landing/src/pages/DownloadDesktop.tsx
+++ b/apps/landing/src/pages/DownloadDesktop.tsx
@@ -39,6 +39,7 @@ import {
 import { GITHUB_RELEASES_URL, GITHUB_URL } from '@/lib/constants'
 import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from '@/lib/motion'
 import { cn } from '@/lib/utils'
+import { trackLandingEvent } from '@/lib/analytics'
 
 const EASE_OUT_EXPO = [0.16, 1, 0.3, 1] as const
 
@@ -75,6 +76,10 @@ const getServerOS = (): DetectedOS => null
 
 function useDetectedOS(): DetectedOS {
   return useSyncExternalStore(subscribeOS, detectOS, getServerOS)
+}
+
+function downloadTarget(label: string) {
+  return `download:${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`
 }
 
 export function DownloadDesktopPage() {
@@ -142,7 +147,12 @@ function DesktopHero({ detected }: { detected: DetectedOS }) {
 
           <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <Button size="lg" className="rounded-full px-7" asChild>
-              <a href={GITHUB_RELEASES_URL} target="_blank" rel="noreferrer">
+              <a
+                href={GITHUB_RELEASES_URL}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => trackLandingEvent('landing_download_click', downloadTarget(label))}
+              >
                 <Download className="h-4 w-4" />
                 {detected ? `Download for ${label}` : 'Download Memry'}
               </a>
@@ -153,7 +163,12 @@ function DesktopHero({ detected }: { detected: DetectedOS }) {
               className="rounded-full px-6 text-ink hover:bg-paper-alt"
               asChild
             >
-              <a href={GITHUB_URL} target="_blank" rel="noreferrer">
+              <a
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => trackLandingEvent('landing_external_click', 'download:github')}
+              >
                 <Github className="h-4 w-4" />
                 View on GitHub
               </a>
@@ -484,7 +499,14 @@ function PlatformCard({ platform, highlighted }: { platform: PlatformInfo; highl
           )}
           asChild
         >
-          <a href={GITHUB_RELEASES_URL} target="_blank" rel="noreferrer">
+          <a
+            href={GITHUB_RELEASES_URL}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() =>
+              trackLandingEvent('landing_download_click', downloadTarget(platform.label))
+            }
+          >
             <Download className="h-4 w-4" />
             Download for {platform.label}
           </a>
@@ -835,7 +857,14 @@ function ReleaseChannel() {
             </p>
             <div className="mt-6 flex flex-wrap gap-3">
               <Button variant="default" className="rounded-full px-5" asChild>
-                <a href={GITHUB_RELEASES_URL} target="_blank" rel="noreferrer">
+                <a
+                  href={GITHUB_RELEASES_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() =>
+                    trackLandingEvent('landing_download_click', 'download:latest-release')
+                  }
+                >
                   Latest release
                   <ExternalLink className="h-4 w-4" />
                 </a>
@@ -845,7 +874,14 @@ function ReleaseChannel() {
                 className="rounded-full px-5 text-ink hover:bg-paper-alt"
                 asChild
               >
-                <a href={GITHUB_URL} target="_blank" rel="noreferrer">
+                <a
+                  href={GITHUB_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() =>
+                    trackLandingEvent('landing_external_click', 'download:source-github')
+                  }
+                >
                   Source on GitHub
                   <Github className="h-4 w-4" />
                 </a>
@@ -958,7 +994,17 @@ function DownloadFinalCta({ detected }: { detected: DetectedOS }) {
 
           <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <Button size="lg" className="rounded-full px-8" asChild>
-              <a href={GITHUB_RELEASES_URL} target="_blank" rel="noreferrer">
+              <a
+                href={GITHUB_RELEASES_URL}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() =>
+                  trackLandingEvent(
+                    'landing_download_click',
+                    detected ? downloadTarget(label) : 'download:memry'
+                  )
+                }
+              >
                 <Download className="h-4 w-4" />
                 {detected ? `Download for ${label}` : 'Download Memry'}
               </a>
@@ -969,7 +1015,10 @@ function DownloadFinalCta({ detected }: { detected: DetectedOS }) {
               className="rounded-full px-8 text-ink hover:bg-paper-alt"
               asChild
             >
-              <Link to="/security">
+              <Link
+                to="/security"
+                onClick={() => trackLandingEvent('landing_nav_click', 'download:security')}
+              >
                 Security architecture
                 <ArrowRight className="h-4 w-4" />
               </Link>

--- a/apps/landing/src/pages/Pricing.tsx
+++ b/apps/landing/src/pages/Pricing.tsx
@@ -24,6 +24,7 @@ import {
 import { openPaddleCheckout, type PaddleCheckoutCadence } from '@/lib/paddle-checkout'
 import { cn } from '@/lib/utils'
 import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from '@/lib/motion'
+import { trackLandingEvent } from '@/lib/analytics'
 
 type Cadence = 'monthly' | 'annual'
 type CheckoutState = {
@@ -48,6 +49,7 @@ export function PricingPage() {
     const checkoutCadence = getCheckoutCadence(tier, cadence)
     const pendingKey = getCheckoutKey(tier.checkoutPlanId, checkoutCadence)
 
+    trackLandingEvent('landing_pricing_cta_click', pricingTarget(tier.id, checkoutCadence))
     setCheckout({ pendingKey, error: null })
     try {
       await openPaddleCheckout(tier.checkoutPlanId, checkoutCadence)
@@ -82,6 +84,10 @@ function getCheckoutCadence(tier: SyncPlanTier, cadence: Cadence): PaddleCheckou
 
 function getCheckoutKey(planId: CheckoutPlanId, cadence: PaddleCheckoutCadence) {
   return `${planId}:${cadence}`
+}
+
+function pricingTarget(tierId: string, cadence: string) {
+  return `pricing:${tierId}:${cadence}`
 }
 
 function Hero({ cadence, setCadence }: { cadence: Cadence; setCadence: (c: Cadence) => void }) {
@@ -138,7 +144,10 @@ function CadenceToggle({
             type="button"
             role="tab"
             aria-selected={active}
-            onClick={() => setCadence(option)}
+            onClick={() => {
+              trackLandingEvent('landing_pricing_cadence_change', `pricing-cadence:${option}`)
+              setCadence(option)
+            }}
             className={cn(
               'relative inline-flex items-center gap-2 rounded-full px-5 py-2 text-sm font-medium transition-all duration-300',
               active
@@ -339,7 +348,14 @@ function TierCard({
             className="w-full rounded-full border-ink/15 bg-paper-alt/40 text-ink hover:bg-paper-alt"
             asChild
           >
-            <Link to="/#waitlist">{tier.cta}</Link>
+            <Link
+              to="/#waitlist"
+              onClick={() =>
+                trackLandingEvent('landing_pricing_cta_click', pricingTarget(tier.id, cadence))
+              }
+            >
+              {tier.cta}
+            </Link>
           </Button>
         ) : isFounding ? (
           <Button
@@ -686,7 +702,17 @@ function LimitMatrix({
                             className="h-8 rounded-full px-3 text-xs"
                             asChild
                           >
-                            <Link to="/#waitlist">Get started</Link>
+                            <Link
+                              to="/#waitlist"
+                              onClick={() =>
+                                trackLandingEvent(
+                                  'landing_pricing_cta_click',
+                                  pricingTarget(tier.id, cadence)
+                                )
+                              }
+                            >
+                              Get started
+                            </Link>
                           </Button>
                         ) : (
                           <Button

--- a/apps/landing/tsconfig.app.json
+++ b/apps/landing/tsconfig.app.json
@@ -24,5 +24,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,7 +677,7 @@ importers:
     dependencies:
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(vue@3.5.34(typescript@5.9.3))
+        version: 2.0.1(react@19.2.4)(vue@3.5.34(typescript@5.9.3))
     devDependencies:
       vitepress:
         specifier: ^1.6.4
@@ -703,6 +703,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.13)(react@19.2.4)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.4)(vue@3.5.34(typescript@5.9.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -14659,8 +14662,9 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(vue@3.5.34(typescript@5.9.3))':
+  '@vercel/analytics@2.0.1(react@19.2.4)(vue@3.5.34(typescript@5.9.3))':
     optionalDependencies:
+      react: 19.2.4
       vue: 3.5.34(typescript@5.9.3)
 
   '@vercel/backends@0.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.8.1)(encoding@0.1.13)(rollup@4.60.1)(typescript@5.9.3)':


### PR DESCRIPTION
## Summary
- Add Vercel Web Analytics to the landing app and a privacy-safe event helper that only sends `page` and `target`.
- Track landing scroll depth, navigation/external clicks, waitlist outcomes, pricing/download CTAs, and demo-video engagement.
- Add a small analytics helper test and exclude landing source test files from the app TypeScript build.

## Release note
Add privacy-safe landing behavior analytics for Vercel Web Analytics.

## Test plan
- `node --test apps/landing/src/lib/analytics.test.ts`
- `pnpm --filter @memry/landing typecheck`
- `pnpm --filter @memry/landing lint`
- `pnpm --filter @memry/landing build`
- Browser smoke on `/`, `/pricing`, and `/download/desktop`; Vercel dev debug showed page views and custom events with only `page` and `target`.
- `git diff --check`
- `npx -y react-doctor@latest . --verbose --diff`