### PR TITLE
Add dedicated /roadmap landing page

### DIFF
--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -17,6 +17,7 @@ import { DownloadDesktopPage } from '@/pages/DownloadDesktop'
 import { UseCasesPage } from '@/pages/UseCases'
 import { SecurityPage } from '@/pages/Security'
 import { PricingPage } from '@/pages/Pricing'
+import { RoadmapPage } from '@/pages/Roadmap'
 import { TermsPage } from '@/pages/Terms'
 import { PrivacyPage } from '@/pages/Privacy'
 import { RefundPage } from '@/pages/Refund'
@@ -117,6 +118,7 @@ function AppContent() {
           <Route path="/use-cases" element={<UseCasesPage />} />
           <Route path="/security" element={<SecurityPage />} />
           <Route path="/pricing" element={<PricingPage />} />
+          <Route path="/roadmap" element={<RoadmapPage />} />
           <Route path="/terms" element={<TermsPage />} />
           <Route path="/privacy" element={<PrivacyPage />} />
           <Route path="/refund" element={<RefundPage />} />

--- a/apps/landing/src/entry-server.tsx
+++ b/apps/landing/src/entry-server.tsx
@@ -16,6 +16,7 @@ import { DownloadDesktopPage } from '@/pages/DownloadDesktop'
 import { UseCasesPage } from '@/pages/UseCases'
 import { SecurityPage } from '@/pages/Security'
 import { PricingPage } from '@/pages/Pricing'
+import { RoadmapPage } from '@/pages/Roadmap'
 import { TermsPage } from '@/pages/Terms'
 import { PrivacyPage } from '@/pages/Privacy'
 import { RefundPage } from '@/pages/Refund'
@@ -33,6 +34,7 @@ const ROUTE_MAP: Record<string, () => ReactNode> = {
   '/use-cases': () => <UseCasesPage />,
   '/security': () => <SecurityPage />,
   '/pricing': () => <PricingPage />,
+  '/roadmap': () => <RoadmapPage />,
   '/terms': () => <TermsPage />,
   '/privacy': () => <PrivacyPage />,
   '/refund': () => <RefundPage />

--- a/apps/landing/src/lib/seo.ts
+++ b/apps/landing/src/lib/seo.ts
@@ -87,6 +87,12 @@ export const PAGE_META: Record<string, PageMeta> = {
       'Local-first stays free, forever. Plus adds 1 GB sync, Pro adds 10 GB and 10 vaults, and Believer supports independent software with 50 GB and unlimited vaults.',
     path: '/pricing'
   },
+  roadmap: {
+    title: 'Roadmap — Memry',
+    description:
+      'What is shipping now, what is planned next, and what we have already launched. We update this page as we ship.',
+    path: '/roadmap'
+  },
   terms: {
     title: 'Terms of Service — Memry',
     description:

--- a/apps/landing/src/pages/Roadmap.tsx
+++ b/apps/landing/src/pages/Roadmap.tsx
@@ -207,17 +207,21 @@ export function RoadmapPage() {
         </section>
 
         <section className="border-b border-border py-12">
-          <div className="mb-6">
-            <StatusPill label="Active" tone="sage" count={ACTIVE_ITEMS.length} />
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-[140px_1fr] md:gap-10">
+            <div className="md:pt-5">
+              <StatusPill label="Active" tone="sage" count={ACTIVE_ITEMS.length} />
+            </div>
+            <RoadmapList items={ACTIVE_ITEMS} />
           </div>
-          <RoadmapList items={ACTIVE_ITEMS} />
         </section>
 
         <section className="border-b border-border py-12">
-          <div className="mb-6">
-            <StatusPill label="Planned" tone="terracotta" count={PLANNED_ITEMS.length} />
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-[140px_1fr] md:gap-10">
+            <div className="md:pt-5">
+              <StatusPill label="Planned" tone="terracotta" count={PLANNED_ITEMS.length} />
+            </div>
+            <RoadmapList items={PLANNED_ITEMS} />
           </div>
-          <RoadmapList items={PLANNED_ITEMS} />
         </section>
 
         <section className="pt-12">

--- a/apps/landing/src/pages/Roadmap.tsx
+++ b/apps/landing/src/pages/Roadmap.tsx
@@ -81,6 +81,7 @@ const LAUNCHED_GROUPS: LaunchedGroup[] = [
         title: 'Voice memos with transcription and related items',
         caption: 'Inline recorder, transcript previews, and audio-aware mention picker.'
       },
+      { title: 'Memry CLI' },
       { title: 'Landing demo refresh, founder story, and event analytics' }
     ]
   },
@@ -121,7 +122,47 @@ const LAUNCHED_GROUPS: LaunchedGroup[] = [
       },
       { title: 'CRDT sync for notes and journals (Yjs)' },
       { title: 'Field-level vector clocks for tasks and projects' },
-      { title: 'Memry CLI' }
+      { title: 'Sync E2EE rollout: Phases 1 through 15' }
+    ]
+  },
+  {
+    period: 'January 2026',
+    items: [
+      { title: 'Folder view with table layout, columns, filters, and formulas' },
+      { title: 'Advanced search with operators and filters' },
+      { title: 'Reminders for notes, journals, and highlights' },
+      { title: 'Templates with folder defaults and version history' },
+      { title: 'AI filing suggestions with feedback tracking' },
+      { title: 'Local embedding vector search via sqlite-vec' },
+      { title: 'Property drag-and-drop, renaming, and unified API' },
+      { title: 'Test infrastructure: Vitest and Playwright with seeded fixtures' },
+      { title: 'Sync E2EE architecture and specification' }
+    ]
+  },
+  {
+    period: 'December 2025',
+    items: [
+      { title: 'Initial app scaffold and sidebar navigation' },
+      {
+        title: 'Task system v1',
+        caption:
+          'List, Kanban, subtasks, due dates, priorities, recurring rules, drag-and-drop, and bulk actions.'
+      },
+      { title: 'Split-view tab system with drag-and-drop between panes' },
+      {
+        title: 'Rich-text note editor',
+        caption:
+          'Slash commands, callouts, wiki-links, tags, properties, attachments, and version history.'
+      },
+      {
+        title: 'Journal v1',
+        caption: 'Day cards, calendar heatmap, focus mode, and AI suggestions.'
+      },
+      {
+        title: 'Inbox capture: text, URLs, images, and voice',
+        caption: 'Quick-capture window with a global shortcut.'
+      },
+      { title: 'Vault management and full-text search (Drizzle + SQLite + FTS5)' }
     ]
   }
 ]

--- a/apps/landing/src/pages/Roadmap.tsx
+++ b/apps/landing/src/pages/Roadmap.tsx
@@ -233,8 +233,11 @@ export function RoadmapPage() {
             className="space-y-10"
           >
             {LAUNCHED_GROUPS.map((group) => (
-              <div key={group.period}>
-                <h3 className="font-mono-accent text-xs uppercase tracking-[0.18em] text-muted mb-3">
+              <div
+                key={group.period}
+                className="grid grid-cols-1 gap-3 md:grid-cols-[140px_1fr] md:gap-10"
+              >
+                <h3 className="font-mono-accent text-xs uppercase tracking-[0.18em] text-muted md:pt-5">
                   {group.period}
                 </h3>
                 <ul className="border-t border-border/60">

--- a/apps/landing/src/pages/Roadmap.tsx
+++ b/apps/landing/src/pages/Roadmap.tsx
@@ -1,9 +1,8 @@
 import { motion } from 'framer-motion'
-import { ArrowUpRight, Map } from 'lucide-react'
+import { ArrowRight } from 'lucide-react'
 import { Container } from '@/components/layout/Container'
 import { PageHead } from '@/components/shared/PageHead'
-import { CHANGELOG_URL, GITHUB_URL } from '@/lib/constants'
-import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from '@/lib/motion'
+import { GITHUB_URL } from '@/lib/constants'
 
 const EASE_OUT_EXPO = [0.16, 1, 0.3, 1] as const
 
@@ -177,63 +176,51 @@ const TOTAL_LAUNCHED = LAUNCHED_GROUPS.reduce((sum, group) => sum + group.items.
 
 export function RoadmapPage() {
   return (
-    <main className="pt-24">
+    <main className="pt-32 pb-24 md:pt-40">
       <PageHead page="roadmap" />
-
-      <section className="py-20">
-        <Container size="md">
-          <motion.div
-            initial={BLUR_REVEAL_INITIAL}
-            animate={BLUR_REVEAL_ANIMATE}
-            transition={BLUR_REVEAL_TRANSITION}
-            className="text-center"
-          >
-            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-terracotta/30 bg-terracotta/5 text-terracotta text-sm font-medium mb-8">
-              <Map className="w-4 h-4" />
-              Roadmap
-            </div>
-            <h1 className="font-serif text-5xl md:text-6xl lg:text-7xl text-ink mb-6 leading-[1.1]">
-              What we&apos;re building,
-              <br />
-              <span className="text-terracotta">in the open.</span>
-            </h1>
-            <p className="text-xl text-muted font-sans max-w-2xl mx-auto leading-relaxed mb-6">
-              What is shipping now, what is planned next, and what we have already launched. This
-              page updates as we ship.
-            </p>
+      <Container size="md">
+        <section className="border-b border-border pb-12">
+          <p className="font-mono-accent text-xs uppercase tracking-[0.18em] text-terracotta">
+            Building in public
+          </p>
+          <h1 className="mt-4 font-serif text-5xl leading-[1.05] text-ink md:text-6xl">Roadmap</h1>
+          <p className="mt-5 max-w-2xl text-lg leading-relaxed text-muted">
+            What is available, what is active, and what is planned next. This is direction, not a
+            release promise.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3 text-sm">
             <a
-              href={CHANGELOG_URL}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-ink/80 hover:text-terracotta transition-colors"
+              href={`${GITHUB_URL}/releases`}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 font-medium text-ink transition-colors hover:border-terracotta/30 hover:text-terracotta"
             >
-              See full changelog
-              <ArrowUpRight className="w-3.5 h-3.5" />
+              Changelog
+              <ArrowRight className="h-4 w-4" aria-hidden />
             </a>
-          </motion.div>
-        </Container>
-      </section>
+            <a
+              href={`${GITHUB_URL}/issues`}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 font-medium text-ink transition-colors hover:border-terracotta/30 hover:text-terracotta"
+            >
+              Request a feature
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </a>
+          </div>
+        </section>
 
-      <section className="py-12">
-        <Container size="md">
+        <section className="border-b border-border py-12">
           <div className="mb-6">
             <StatusPill label="Active" tone="sage" count={ACTIVE_ITEMS.length} />
           </div>
           <RoadmapList items={ACTIVE_ITEMS} />
-        </Container>
-      </section>
+        </section>
 
-      <section className="py-12 bg-paper-alt">
-        <Container size="md">
+        <section className="border-b border-border py-12">
           <div className="mb-6">
             <StatusPill label="Planned" tone="terracotta" count={PLANNED_ITEMS.length} />
           </div>
           <RoadmapList items={PLANNED_ITEMS} />
-        </Container>
-      </section>
+        </section>
 
-      <section className="py-12">
-        <Container size="md">
+        <section className="pt-12">
           <div className="mb-6">
             <StatusPill label="Launched" tone="muted" count={TOTAL_LAUNCHED} />
           </div>
@@ -258,34 +245,8 @@ export function RoadmapPage() {
               </div>
             ))}
           </motion.div>
-        </Container>
-      </section>
-
-      <section className="py-24">
-        <Container size="sm">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6, ease: EASE_OUT_EXPO }}
-            className="text-center"
-          >
-            <h2 className="font-serif text-3xl text-ink mb-4">Have an idea?</h2>
-            <p className="text-lg text-muted mb-8 max-w-lg mx-auto leading-relaxed">
-              Open an issue on GitHub or send us a note — we read everything.
-            </p>
-            <a
-              href={`${GITHUB_URL}/issues`}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-ink text-paper font-medium text-sm hover:bg-ink/90 transition-colors"
-            >
-              Open an issue
-              <ArrowUpRight className="w-4 h-4" />
-            </a>
-          </motion.div>
-        </Container>
-      </section>
+        </section>
+      </Container>
     </main>
   )
 }

--- a/apps/landing/src/pages/Roadmap.tsx
+++ b/apps/landing/src/pages/Roadmap.tsx
@@ -1,0 +1,291 @@
+import { motion } from 'framer-motion'
+import { ArrowUpRight, Map } from 'lucide-react'
+import { Container } from '@/components/layout/Container'
+import { PageHead } from '@/components/shared/PageHead'
+import { CHANGELOG_URL, GITHUB_URL } from '@/lib/constants'
+import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from '@/lib/motion'
+
+const EASE_OUT_EXPO = [0.16, 1, 0.3, 1] as const
+
+const stagger = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.04 } }
+}
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 16 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: EASE_OUT_EXPO } }
+}
+
+type StatusTone = 'sage' | 'terracotta' | 'muted'
+
+interface RoadmapItem {
+  title: string
+  caption?: string
+}
+
+interface LaunchedGroup {
+  period: string
+  items: RoadmapItem[]
+}
+
+const ACTIVE_ITEMS: RoadmapItem[] = [
+  {
+    title: 'Web clipper',
+    caption: 'Save pages, highlights, and snippets straight into your Inbox from any browser.'
+  },
+  {
+    title: 'Importers',
+    caption: 'Bring your knowledge base over from Obsidian, Notion, Roam, or any Markdown folder.'
+  },
+  {
+    title: 'AI Agent public release polish',
+    caption:
+      'Stable provider settings, smoother streaming, and approval-gated writes for everyday use.'
+  }
+]
+
+const PLANNED_ITEMS: RoadmapItem[] = [
+  {
+    title: 'Mobile apps — iOS and Android',
+    caption: 'Capture, triage, and read on the go. Targeting late 2026.'
+  },
+  {
+    title: 'Public and shared vaults',
+    caption: 'Publish notes to the web or collaborate on a shared workspace.'
+  },
+  {
+    title: 'Plugin API',
+    caption: 'Extend Memry with your own tools, integrations, and views.'
+  },
+  {
+    title: 'Templates marketplace',
+    caption: 'Share and discover note, task, and journal templates.'
+  },
+  {
+    title: 'Self-hosted sync server',
+    caption: 'Run the encrypted sync layer on your own infrastructure.'
+  }
+]
+
+const LAUNCHED_GROUPS: LaunchedGroup[] = [
+  {
+    period: 'May 2026',
+    items: [
+      {
+        title: 'Agent Chat: per-turn permissions',
+        caption: 'Vault-only, computer access, and web search controls in the composer.'
+      },
+      { title: 'Agent Chat: inline mention tags for notes, tasks, journals, inbox, and calendar' },
+      { title: 'Agent inbox snooze write tool' },
+      {
+        title: 'Voice memos with transcription and related items',
+        caption: 'Inline recorder, transcript previews, and audio-aware mention picker.'
+      },
+      { title: 'Landing demo refresh, founder story, and event analytics' }
+    ]
+  },
+  {
+    period: 'April 2026',
+    items: [
+      {
+        title: 'Multi-language support',
+        caption: 'English, Turkish, and Arabic — full RTL layout, ICU plurals, localized menus.'
+      },
+      { title: 'Calendar week view with infinite horizontal scroll' },
+      { title: 'Google Calendar sync triggers and OAuth diagnostics' },
+      { title: 'Calendar inbox-snooze chips with open / unsnooze / reschedule actions' },
+      { title: 'Vim hint mode' },
+      { title: 'Inline subtasks and inline task blocks in notes' },
+      { title: 'Inbox redesign with triage, snooze, and folder creation' },
+      { title: 'Sync adapter registry and architecture reset' }
+    ]
+  },
+  {
+    period: 'March 2026',
+    items: [
+      { title: 'White theme and settings panel polish' },
+      { title: 'Inline AI editing in the editor' },
+      { title: 'Graph view' },
+      { title: 'Global search' },
+      { title: 'Journal redesign with day context and templates' },
+      { title: 'Note page with link autocomplete and embeds' }
+    ]
+  },
+  {
+    period: 'February 2026',
+    items: [
+      {
+        title: 'End-to-end encrypted sync',
+        caption:
+          'XChaCha20-Poly1305, Ed25519, and Argon2id via libsodium. Server never sees plaintext.'
+      },
+      { title: 'CRDT sync for notes and journals (Yjs)' },
+      { title: 'Field-level vector clocks for tasks and projects' },
+      { title: 'Memry CLI' }
+    ]
+  }
+]
+
+const TONE_CLASSES: Record<StatusTone, string> = {
+  sage: 'bg-sage/10 text-sage border-sage/30',
+  terracotta: 'bg-terracotta/10 text-terracotta border-terracotta/30',
+  muted: 'bg-ink/5 text-muted border-border'
+}
+
+function StatusPill({ label, tone, count }: { label: string; tone: StatusTone; count: number }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 font-mono-accent text-[11px] uppercase tracking-[0.18em] ${TONE_CLASSES[tone]}`}
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-current" />
+      {label}
+      <span className="opacity-60">· {count}</span>
+    </span>
+  )
+}
+
+function RoadmapRow({ item }: { item: RoadmapItem }) {
+  return (
+    <motion.li
+      variants={fadeUp}
+      className="flex flex-col gap-1 border-b border-border/60 py-4 last:border-b-0"
+    >
+      <span className="font-serif text-lg text-ink leading-snug">{item.title}</span>
+      {item.caption && <span className="text-sm text-muted leading-relaxed">{item.caption}</span>}
+    </motion.li>
+  )
+}
+
+function RoadmapList({ items }: { items: RoadmapItem[] }) {
+  return (
+    <motion.ul
+      variants={stagger}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: '-60px' }}
+      className="border-t border-border/60"
+    >
+      {items.map((item) => (
+        <RoadmapRow key={item.title} item={item} />
+      ))}
+    </motion.ul>
+  )
+}
+
+const TOTAL_LAUNCHED = LAUNCHED_GROUPS.reduce((sum, group) => sum + group.items.length, 0)
+
+export function RoadmapPage() {
+  return (
+    <main className="pt-24">
+      <PageHead page="roadmap" />
+
+      <section className="py-20">
+        <Container size="md">
+          <motion.div
+            initial={BLUR_REVEAL_INITIAL}
+            animate={BLUR_REVEAL_ANIMATE}
+            transition={BLUR_REVEAL_TRANSITION}
+            className="text-center"
+          >
+            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-terracotta/30 bg-terracotta/5 text-terracotta text-sm font-medium mb-8">
+              <Map className="w-4 h-4" />
+              Roadmap
+            </div>
+            <h1 className="font-serif text-5xl md:text-6xl lg:text-7xl text-ink mb-6 leading-[1.1]">
+              What we&apos;re building,
+              <br />
+              <span className="text-terracotta">in the open.</span>
+            </h1>
+            <p className="text-xl text-muted font-sans max-w-2xl mx-auto leading-relaxed mb-6">
+              What is shipping now, what is planned next, and what we have already launched. This
+              page updates as we ship.
+            </p>
+            <a
+              href={CHANGELOG_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-ink/80 hover:text-terracotta transition-colors"
+            >
+              See full changelog
+              <ArrowUpRight className="w-3.5 h-3.5" />
+            </a>
+          </motion.div>
+        </Container>
+      </section>
+
+      <section className="py-12">
+        <Container size="md">
+          <div className="mb-6">
+            <StatusPill label="Active" tone="sage" count={ACTIVE_ITEMS.length} />
+          </div>
+          <RoadmapList items={ACTIVE_ITEMS} />
+        </Container>
+      </section>
+
+      <section className="py-12 bg-paper-alt">
+        <Container size="md">
+          <div className="mb-6">
+            <StatusPill label="Planned" tone="terracotta" count={PLANNED_ITEMS.length} />
+          </div>
+          <RoadmapList items={PLANNED_ITEMS} />
+        </Container>
+      </section>
+
+      <section className="py-12">
+        <Container size="md">
+          <div className="mb-6">
+            <StatusPill label="Launched" tone="muted" count={TOTAL_LAUNCHED} />
+          </div>
+
+          <motion.div
+            variants={stagger}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, margin: '-60px' }}
+            className="space-y-10"
+          >
+            {LAUNCHED_GROUPS.map((group) => (
+              <div key={group.period}>
+                <h3 className="font-mono-accent text-xs uppercase tracking-[0.18em] text-muted mb-3">
+                  {group.period}
+                </h3>
+                <ul className="border-t border-border/60">
+                  {group.items.map((item) => (
+                    <RoadmapRow key={item.title} item={item} />
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </motion.div>
+        </Container>
+      </section>
+
+      <section className="py-24">
+        <Container size="sm">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6, ease: EASE_OUT_EXPO }}
+            className="text-center"
+          >
+            <h2 className="font-serif text-3xl text-ink mb-4">Have an idea?</h2>
+            <p className="text-lg text-muted mb-8 max-w-lg mx-auto leading-relaxed">
+              Open an issue on GitHub or send us a note — we read everything.
+            </p>
+            <a
+              href={`${GITHUB_URL}/issues`}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-ink text-paper font-medium text-sm hover:bg-ink/90 transition-colors"
+            >
+              Open an issue
+              <ArrowUpRight className="w-4 h-4" />
+            </a>
+          </motion.div>
+        </Container>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a `/roadmap` route on the landing site, wiring the link that already lives in the header and footer nav.
- Reuses the homepage roadmap hero ("Building in public" + "Roadmap" + Changelog / Request a feature actions) for the new page.
- Single-column layout with section dividers and a shared two-column rhythm for **Active**, **Planned**, and **Launched** — status pill or month label sits in the start-side column, items list takes the end-side column. Stacks vertically on mobile.
- **Launched** timeline covers every month since the project began: December 2025 through May 2026.
- Adds the corresponding `PAGE_META` entry plus a prerender entry so `/roadmap` ships as a static HTML page.

## Test plan

- [ ] `pnpm --filter @memry/landing typecheck` passes
- [ ] `pnpm --filter @memry/landing build` produces `dist/roadmap/index.html` with the expected title and meta
- [ ] Visit `/roadmap` in `pnpm dev:landing` and confirm:
  - [ ] Header nav "Roadmap" link resolves (no longer dead)
  - [ ] Footer "Roadmap" link resolves
  - [ ] Active, Planned, and Launched share the same left-column alignment on md+
  - [ ] Sections stack vertically on a narrow viewport
  - [ ] "Changelog" button opens GitHub Releases; "Request a feature" opens GitHub Issues