### PR TITLE
Implement paid sync purchase loop

### DIFF
--- a/apps/desktop/src/main/billing/paddle-billing.ts
+++ b/apps/desktop/src/main/billing/paddle-billing.ts
@@ -1,0 +1,117 @@
+import { shell } from 'electron'
+import { getFromServer, postToServer } from '../sync/http-client'
+import { getValidAccessToken } from '../sync/token-manager'
+import { getSyncEngine } from '../sync/runtime'
+import { createLogger } from '../lib/logger'
+
+const log = createLogger('Billing')
+const LANDING_CHECKOUT_URL = 'https://memrynote.com/pricing'
+
+export type BillingPlanId = 'plus' | 'pro' | 'believer'
+export type BillingCadence = 'monthly' | 'annual' | 'lifetime'
+export type BillingStatusValue = 'inactive' | 'active' | 'past_due' | 'paused' | 'canceled'
+export type BillingPlan = 'free' | BillingPlanId
+
+export interface BillingStatus {
+  plan: BillingPlan
+  status: BillingStatusValue
+  source: string
+  limits: {
+    storageLimit: number
+    maxFileSize: number
+    maxVaults: number | null
+    versionHistoryDays: number
+  }
+  usage: {
+    storageUsed: number
+  }
+  expiresAt: number | null
+  canManageBilling: boolean
+}
+
+export interface BillingActionResult {
+  success: boolean
+  error?: string
+}
+
+export async function startBillingCheckout(input: {
+  plan: BillingPlanId
+  cadence: BillingCadence
+}): Promise<BillingActionResult & { checkoutUrl?: string }> {
+  const token = await getValidAccessToken()
+  if (!token) return { success: false, error: 'Sign in to start checkout' }
+
+  const cadence = input.plan === 'believer' ? 'lifetime' : input.cadence
+  const response = await postToServer<{ checkoutToken: string }>(
+    '/auth/checkout-token',
+    { plan: input.plan, cadence },
+    token
+  )
+  const checkoutUrl = buildLandingCheckoutUrl(input.plan, cadence, response.checkoutToken)
+  await shell.openExternal(checkoutUrl)
+
+  return { success: true, checkoutUrl }
+}
+
+export async function getBillingStatus(): Promise<
+  BillingStatus | (BillingActionResult & { status?: never })
+> {
+  const token = await getValidAccessToken()
+  if (!token) return { success: false, error: 'Sign in to view billing' }
+  return getFromServer<BillingStatus>('/auth/billing', token)
+}
+
+export async function refreshBillingStatus(input?: {
+  transactionId?: string
+}): Promise<BillingStatus | (BillingActionResult & { status?: never })> {
+  const token = await getValidAccessToken()
+  if (!token) return { success: false, error: 'Sign in to refresh billing' }
+  return postToServer<BillingStatus>(
+    '/auth/billing/reconcile',
+    input?.transactionId ? { transactionId: input.transactionId } : {},
+    token
+  )
+}
+
+export async function openBillingPortal(): Promise<BillingActionResult & { portalUrl?: string }> {
+  const token = await getValidAccessToken()
+  if (!token) return { success: false, error: 'Sign in to manage billing' }
+
+  const response = await postToServer<{ portalUrl: string }>(
+    '/auth/billing/portal-session',
+    {},
+    token
+  )
+  await shell.openExternal(response.portalUrl)
+  return { success: true, portalUrl: response.portalUrl }
+}
+
+export async function reconcileBillingAndSync(input?: { transactionId?: string }): Promise<void> {
+  try {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const status = await refreshBillingStatus(input)
+      if ('status' in status && status.status === 'active') {
+        await getSyncEngine()?.fullSync()
+        return
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+    }
+  } catch (error) {
+    log.warn('Failed to reconcile billing from deep link', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+function buildLandingCheckoutUrl(
+  plan: BillingPlanId,
+  cadence: BillingCadence,
+  checkoutToken: string
+): string {
+  const params = new URLSearchParams({
+    checkout_plan: plan,
+    checkout_cadence: cadence,
+    checkout_token: checkoutToken
+  })
+  return `${LANDING_CHECKOUT_URL}#${params.toString()}`
+}

--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -76,6 +76,8 @@ const getHeadlessCliArgsMock = vi.fn((argv: string[]) => {
   return cliIndex === -1 ? null : argv.slice(cliIndex + 1)
 })
 const runHeadlessCliMock = vi.fn(async () => undefined)
+const startBillingCheckoutMock = vi.fn(async () => ({ success: true }))
+const reconcileBillingAndSyncMock = vi.fn(async () => undefined)
 const browserWindows: Array<ReturnType<typeof createBrowserWindowMock>> = []
 
 function createBrowserWindowMock() {
@@ -243,6 +245,11 @@ vi.mock('./app-navigation-command', () => ({
 vi.mock('./cli/headless', () => ({
   getHeadlessCliArgs: getHeadlessCliArgsMock,
   runHeadlessCli: runHeadlessCliMock
+}))
+
+vi.mock('./billing/paddle-billing', () => ({
+  startBillingCheckout: startBillingCheckoutMock,
+  reconcileBillingAndSync: reconcileBillingAndSyncMock
 }))
 
 vi.mock('./lib/logger', () => {
@@ -899,6 +906,30 @@ describe('main index phase2 exports', () => {
     })
 
     expect(() => openUrlHandler({ preventDefault }, 'not a valid url')).not.toThrow()
+  })
+
+  it('routes billing deep links through checkout and reconciliation handlers', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const openUrlHandler = appOnMock.mock.calls.find(([event]) => event === 'open-url')?.[1] as (
+      event: { preventDefault: () => void },
+      url: string
+    ) => void
+    const preventDefault = vi.fn()
+
+    openUrlHandler({ preventDefault }, 'memry://billing/start?plan=plus&cadence=monthly')
+    expect(preventDefault).toHaveBeenCalled()
+    expect(browserWindows[0].webContents.send).toHaveBeenCalledWith(
+      SettingsChannels.events.OPEN_SECTION,
+      'account'
+    )
+    expect(startBillingCheckoutMock).toHaveBeenCalledWith({ plan: 'plus', cadence: 'monthly' })
+
+    openUrlHandler({ preventDefault }, 'memry://billing/complete?transactionId=txn_123')
+    expect(reconcileBillingAndSyncMock).toHaveBeenCalledWith({ transactionId: 'txn_123' })
   })
 
   it('handles window control IPC and native context menu resolution', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -69,6 +69,12 @@ import {
   type AppNavigationSwipeDirection
 } from './app-navigation-command'
 import { getHeadlessCliArgs, runHeadlessCli } from './cli/headless'
+import {
+  reconcileBillingAndSync,
+  startBillingCheckout,
+  type BillingCadence,
+  type BillingPlanId
+} from './billing/paddle-billing'
 
 if (process.type === 'browser') {
   log.initialize()
@@ -481,6 +487,20 @@ export const registerOAuthState = (state: string): void => {
   setTimeout(() => pendingOAuthStates.delete(state), 10 * 60 * 1000)
 }
 
+function parseBillingPlan(value: string | null): BillingPlanId {
+  if (value === 'plus' || value === 'pro' || value === 'believer') return value
+  return 'pro'
+}
+
+function parseBillingCadence(value: string | null, plan: BillingPlanId): BillingCadence {
+  if (value === 'monthly' || value === 'annual' || value === 'lifetime') return value
+  return plan === 'believer' ? 'lifetime' : 'annual'
+}
+
+function openAccountSettings(mainWindow: BrowserWindow): void {
+  mainWindow.webContents.send(SettingsChannels.events.OPEN_SECTION, 'account')
+}
+
 function handleDeepLink(url: string): void {
   try {
     const parsed = new URL(url)
@@ -488,6 +508,19 @@ function handleDeepLink(url: string): void {
 
     const mainWindow = BrowserWindow.getAllWindows()[0]
     if (!mainWindow) return
+
+    if (parsed.hostname === 'billing') {
+      if (parsed.pathname === '/start') {
+        const plan = parseBillingPlan(parsed.searchParams.get('plan'))
+        const cadence = parseBillingCadence(parsed.searchParams.get('cadence'), plan)
+        openAccountSettings(mainWindow)
+        void startBillingCheckout({ plan, cadence })
+      } else if (parsed.pathname === '/complete') {
+        const transactionId = parsed.searchParams.get('transactionId') ?? undefined
+        openAccountSettings(mainWindow)
+        void reconcileBillingAndSync({ transactionId })
+      }
+    }
 
     if (parsed.hostname === 'oauth' || parsed.pathname.startsWith('/oauth')) {
       const code = parsed.searchParams.get('code')

--- a/apps/desktop/src/main/ipc/account-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/account-handlers.test.ts
@@ -16,6 +16,9 @@ const mocks = vi.hoisted(() => ({
   teardownSession: vi.fn(),
   retrieveKey: vi.fn(),
   getValidAccessToken: vi.fn(),
+  getFromServer: vi.fn(),
+  postToServer: vi.fn(),
+  shellOpenExternal: vi.fn(),
   toBase64: vi.fn(),
   logger: {
     info: vi.fn(),
@@ -33,6 +36,9 @@ vi.mock('electron', () => ({
     removeHandler: vi.fn((channel: string) => {
       mockIpcMain.removeHandler(channel)
     })
+  },
+  shell: {
+    openExternal: (...args: unknown[]) => mocks.shellOpenExternal(...args)
   }
 }))
 
@@ -57,6 +63,15 @@ vi.mock('../crypto', () => ({
 
 vi.mock('../sync/token-manager', () => ({
   getValidAccessToken: (...args: unknown[]) => mocks.getValidAccessToken(...args)
+}))
+
+vi.mock('../sync/http-client', () => ({
+  getFromServer: (...args: unknown[]) => mocks.getFromServer(...args),
+  postToServer: (...args: unknown[]) => mocks.postToServer(...args)
+}))
+
+vi.mock('../sync/runtime', () => ({
+  getSyncEngine: vi.fn().mockReturnValue(null)
 }))
 
 vi.mock('../lib/logger', () => ({
@@ -85,6 +100,16 @@ describe('account-handlers', () => {
     mocks.storeGet.mockReturnValue({ email: 'kaan@example.com' })
     mocks.teardownSession.mockResolvedValue({ keychainFailures: [] })
     mocks.getValidAccessToken.mockResolvedValue('token-1')
+    mocks.postToServer.mockResolvedValue({ checkoutToken: 'checkout-token-1' })
+    mocks.getFromServer.mockResolvedValue({
+      plan: 'free',
+      status: 'inactive',
+      limits: { storageLimit: 0, maxFileSize: 0, maxVaults: 0, versionHistoryDays: 0 },
+      usage: { storageUsed: 0 },
+      expiresAt: null,
+      canManageBilling: false
+    })
+    mocks.shellOpenExternal.mockResolvedValue('')
     mocks.retrieveKey.mockResolvedValue(new Uint8Array([1, 2, 3]))
     mocks.toBase64.mockReturnValue('recovery-key')
     vi.mocked(isDatabaseInitialized).mockReturnValue(false)
@@ -159,6 +184,55 @@ describe('account-handlers', () => {
     expect(mocks.logger.error).toHaveBeenCalledWith(
       'Failed to retrieve recovery key',
       expect.any(Error)
+    )
+  })
+
+  it('starts checkout by minting a token and opening landing with a fragment', async () => {
+    registerAccountHandlers()
+
+    await expect(
+      invokeHandler(AccountChannels.invoke.START_CHECKOUT, { plan: 'pro', cadence: 'annual' })
+    ).resolves.toEqual({
+      success: true,
+      checkoutUrl:
+        'https://memrynote.com/pricing#checkout_plan=pro&checkout_cadence=annual&checkout_token=checkout-token-1'
+    })
+
+    expect(mocks.postToServer).toHaveBeenCalledWith(
+      '/auth/checkout-token',
+      { plan: 'pro', cadence: 'annual' },
+      'token-1'
+    )
+    expect(mocks.shellOpenExternal).toHaveBeenCalledWith(
+      'https://memrynote.com/pricing#checkout_plan=pro&checkout_cadence=annual&checkout_token=checkout-token-1'
+    )
+  })
+
+  it('rejects checkout start without an authenticated sync account', async () => {
+    mocks.getValidAccessToken.mockResolvedValueOnce(null)
+    registerAccountHandlers()
+
+    await expect(
+      invokeHandler(AccountChannels.invoke.START_CHECKOUT, { plan: 'pro', cadence: 'annual' })
+    ).resolves.toEqual({ success: false, error: 'Sign in to start checkout' })
+
+    expect(mocks.shellOpenExternal).not.toHaveBeenCalled()
+  })
+
+  it('opens a fresh Paddle portal URL from the sync server', async () => {
+    mocks.postToServer.mockResolvedValueOnce({
+      portalUrl: 'https://customer-portal.paddle.com/cpl_1?action=overview&token=tmp'
+    })
+    registerAccountHandlers()
+
+    await expect(invokeHandler(AccountChannels.invoke.OPEN_BILLING_PORTAL)).resolves.toEqual({
+      success: true,
+      portalUrl: 'https://customer-portal.paddle.com/cpl_1?action=overview&token=tmp'
+    })
+
+    expect(mocks.postToServer).toHaveBeenCalledWith('/auth/billing/portal-session', {}, 'token-1')
+    expect(mocks.shellOpenExternal).toHaveBeenCalledWith(
+      'https://customer-portal.paddle.com/cpl_1?action=overview&token=tmp'
     )
   })
 })

--- a/apps/desktop/src/main/ipc/account-handlers.ts
+++ b/apps/desktop/src/main/ipc/account-handlers.ts
@@ -19,6 +19,12 @@ import { store } from '../store'
 import { teardownSession } from '../sync/session-teardown'
 import { retrieveKey } from '../crypto'
 import { getValidAccessToken } from '../sync/token-manager'
+import {
+  getBillingStatus,
+  openBillingPortal,
+  refreshBillingStatus,
+  startBillingCheckout
+} from '../billing/paddle-billing'
 
 const log = createLogger('IPC:Account')
 
@@ -82,10 +88,34 @@ export function registerAccountHandlers(): void {
       return { success: false, error: 'Failed to retrieve recovery key' }
     }
   })
+
+  ipcMain.handle(AccountChannels.invoke.START_CHECKOUT, async (_event, input) => {
+    log.info('account:startCheckout requested')
+    return startBillingCheckout(input)
+  })
+
+  ipcMain.handle(AccountChannels.invoke.GET_BILLING_STATUS, async () => {
+    log.info('account:getBillingStatus requested')
+    return getBillingStatus()
+  })
+
+  ipcMain.handle(AccountChannels.invoke.REFRESH_BILLING_STATUS, async (_event, input) => {
+    log.info('account:refreshBillingStatus requested')
+    return refreshBillingStatus(input)
+  })
+
+  ipcMain.handle(AccountChannels.invoke.OPEN_BILLING_PORTAL, async () => {
+    log.info('account:openBillingPortal requested')
+    return openBillingPortal()
+  })
 }
 
 export function unregisterAccountHandlers(): void {
   ipcMain.removeHandler(AccountChannels.invoke.GET_INFO)
   ipcMain.removeHandler(AccountChannels.invoke.SIGN_OUT)
   ipcMain.removeHandler(AccountChannels.invoke.GET_RECOVERY_KEY)
+  ipcMain.removeHandler(AccountChannels.invoke.START_CHECKOUT)
+  ipcMain.removeHandler(AccountChannels.invoke.GET_BILLING_STATUS)
+  ipcMain.removeHandler(AccountChannels.invoke.REFRESH_BILLING_STATUS)
+  ipcMain.removeHandler(AccountChannels.invoke.OPEN_BILLING_PORTAL)
 }

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -2,9 +2,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export interface MainIpcInvokeHandlers {
+  "account:getBillingStatus": (...args: []) => Awaited<Promise<import("../billing/paddle-billing").BillingStatus | (import("../billing/paddle-billing").BillingActionResult & { status?: undefined; })>>
   "account:getInfo": (...args: []) => Awaited<import("./account-handlers").AccountInfo>
   "account:getRecoveryKey": (...args: []) => Awaited<Promise<{ success: boolean; error: string; key?: undefined; } | { success: boolean; key: string; error?: undefined; }>>
+  "account:openBillingPortal": (...args: []) => Awaited<Promise<import("../billing/paddle-billing").BillingActionResult & { portalUrl?: string | undefined; }>>
+  "account:refreshBillingStatus": (...args: [any]) => Awaited<Promise<import("../billing/paddle-billing").BillingStatus | (import("../billing/paddle-billing").BillingActionResult & { status?: undefined; })>>
   "account:signOut": (...args: []) => Awaited<Promise<{ keychainWarning?: string | undefined; success: boolean; }>>
+  "account:startCheckout": (...args: [any]) => Awaited<Promise<import("../billing/paddle-billing").BillingActionResult & { checkoutUrl?: string | undefined; }>>
   "agent_mcp:get_status": (...args: []) => Awaited<{ url: string | null; token: string | null; toolCount: number; }>
   "agent_mcp:rotate_token": (...args: []) => Awaited<{ url: string | null; token: string | null; toolCount: number; }>
   "agent:acceptDisclosure": (...args: []) => Awaited<import("../agent/runtime/disclosure-state").DisclosureState>

--- a/apps/desktop/src/preload/api/preload-api.test.ts
+++ b/apps/desktop/src/preload/api/preload-api.test.ts
@@ -664,6 +664,24 @@ describe('preload api wrappers', () => {
     await expectInvoke(() => accountApi.getInfo(), AccountChannels.invoke.GET_INFO)
     await expectInvoke(() => accountApi.signOut(), AccountChannels.invoke.SIGN_OUT)
     await expectInvoke(() => accountApi.getRecoveryKey(), AccountChannels.invoke.GET_RECOVERY_KEY)
+    await expectInvoke(
+      () => accountApi.startCheckout({ plan: 'pro', cadence: 'annual' }),
+      AccountChannels.invoke.START_CHECKOUT,
+      { plan: 'pro', cadence: 'annual' }
+    )
+    await expectInvoke(
+      () => accountApi.getBillingStatus(),
+      AccountChannels.invoke.GET_BILLING_STATUS
+    )
+    await expectInvoke(
+      () => accountApi.refreshBillingStatus({ transactionId: 'txn_1' }),
+      AccountChannels.invoke.REFRESH_BILLING_STATUS,
+      { transactionId: 'txn_1' }
+    )
+    await expectInvoke(
+      () => accountApi.openBillingPortal(),
+      AccountChannels.invoke.OPEN_BILLING_PORTAL
+    )
     await expectInvoke(() => syncDevices.getDevices(), SYNC_CHANNELS.GET_DEVICES)
     await expectInvoke(
       () => syncDevices.removeDevice({ deviceId: 'd1' }),

--- a/apps/desktop/src/preload/api/sync-identity.ts
+++ b/apps/desktop/src/preload/api/sync-identity.ts
@@ -37,7 +37,13 @@ export const syncLinking = {
 export const accountApi = {
   getInfo: () => invoke(AccountChannels.invoke.GET_INFO),
   signOut: () => invoke(AccountChannels.invoke.SIGN_OUT),
-  getRecoveryKey: () => invoke(AccountChannels.invoke.GET_RECOVERY_KEY)
+  getRecoveryKey: () => invoke(AccountChannels.invoke.GET_RECOVERY_KEY),
+  startCheckout: (input: { plan: 'plus' | 'pro' | 'believer'; cadence: 'monthly' | 'annual' }) =>
+    invoke(AccountChannels.invoke.START_CHECKOUT, input),
+  getBillingStatus: () => invoke(AccountChannels.invoke.GET_BILLING_STATUS),
+  refreshBillingStatus: (input?: { transactionId?: string }) =>
+    invoke(AccountChannels.invoke.REFRESH_BILLING_STATUS, input),
+  openBillingPortal: () => invoke(AccountChannels.invoke.OPEN_BILLING_PORTAL)
 }
 
 export const syncDevices = {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1433,10 +1433,46 @@ interface SyncLinkingClientAPI {
 }
 
 // Account API
+type BillingPlanId = 'plus' | 'pro' | 'believer'
+type BillingCadence = 'monthly' | 'annual' | 'lifetime'
+type BillingPlan = 'free' | BillingPlanId
+type BillingStatusValue = 'inactive' | 'active' | 'past_due' | 'paused' | 'canceled'
+
+interface BillingStatus {
+  plan: BillingPlan
+  status: BillingStatusValue
+  source: string
+  limits: {
+    storageLimit: number
+    maxFileSize: number
+    maxVaults: number | null
+    versionHistoryDays: number
+  }
+  usage: {
+    storageUsed: number
+  }
+  expiresAt: number | null
+  canManageBilling: boolean
+}
+
+interface BillingActionResult {
+  success: boolean
+  error?: string
+}
+
 interface AccountClientAPI {
   getInfo: () => Promise<{ email: string | null; joinedAt: number | null }>
   signOut: () => Promise<{ success: boolean; keychainWarning?: string }>
   getRecoveryKey: () => Promise<{ success: boolean; key?: string; error?: string }>
+  startCheckout: (input: {
+    plan: BillingPlanId
+    cadence: Exclude<BillingCadence, 'lifetime'>
+  }) => Promise<BillingActionResult & { checkoutUrl?: string }>
+  getBillingStatus: () => Promise<BillingStatus | (BillingActionResult & { status?: never })>
+  refreshBillingStatus: (input?: {
+    transactionId?: string
+  }) => Promise<BillingStatus | (BillingActionResult & { status?: never })>
+  openBillingPortal: () => Promise<BillingActionResult & { portalUrl?: string }>
 }
 
 // Device Management API

--- a/apps/desktop/src/renderer/src/components/nav-user.tsx
+++ b/apps/desktop/src/renderer/src/components/nav-user.tsx
@@ -1,4 +1,5 @@
 import { BadgeCheck, Bell, ChevronsUpDown, CreditCard, LogOut, Sparkles } from '@/lib/icons'
+import { useState } from 'react'
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
@@ -17,6 +18,9 @@ import {
   SidebarMenuItem,
   useSidebar
 } from '@/components/ui/sidebar'
+import { useSettingsModal } from '@/contexts/settings-modal-context'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { toast } from 'sonner'
 
 export function NavUser({
   user
@@ -28,7 +32,26 @@ export function NavUser({
   }
 }) {
   const { t: tPhaseF } = useT('common')
+  const { t: tSettings } = useT('settings')
   const { isMobile } = useSidebar()
+  const { open: openSettings } = useSettingsModal()
+  const [isStartingCheckout, setIsStartingCheckout] = useState(false)
+
+  const handleUpgrade = async (): Promise<void> => {
+    setIsStartingCheckout(true)
+    try {
+      const result = await window.api.account.startCheckout({ plan: 'pro', cadence: 'annual' })
+      if (!result.success) {
+        toast.error(result.error ?? tSettings('account.billing.toasts.checkoutFailed'))
+        return
+      }
+      toast.success(tSettings('account.billing.toasts.checkoutOpened'))
+    } catch (error: unknown) {
+      toast.error(extractErrorMessage(error, tSettings('account.billing.toasts.checkoutFailed')))
+    } finally {
+      setIsStartingCheckout(false)
+    }
+  }
 
   return (
     <SidebarMenu>
@@ -45,11 +68,11 @@ export function NavUser({
                   {tPhaseF('phaseF.componentsNavUser.cn')}
                 </AvatarFallback>
               </Avatar>
-              <div className="grid flex-1 text-left text-sm leading-tight">
+              <div className="grid flex-1 text-start text-sm leading-tight">
                 <span className="truncate font-semibold">{user.name}</span>
                 <span className="truncate text-xs">{user.email}</span>
               </div>
-              <ChevronsUpDown className="ml-auto size-4" />
+              <ChevronsUpDown className="ms-auto size-4" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
@@ -59,14 +82,14 @@ export function NavUser({
             sideOffset={4}
           >
             <DropdownMenuLabel className="p-0 font-normal">
-              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+              <div className="flex items-center gap-2 px-1 py-1.5 text-start text-sm">
                 <Avatar className="h-8 w-8 rounded-md">
                   <AvatarImage src={user.avatar} alt={user.name} />
                   <AvatarFallback className="rounded-md">
                     {tPhaseF('phaseF.componentsNavUser.cn2')}
                   </AvatarFallback>
                 </Avatar>
-                <div className="grid flex-1 text-left text-sm leading-tight">
+                <div className="grid flex-1 text-start text-sm leading-tight">
                   <span className="truncate font-semibold">{user.name}</span>
                   <span className="truncate text-xs">{user.email}</span>
                 </div>
@@ -74,7 +97,13 @@ export function NavUser({
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={isStartingCheckout}
+                onSelect={(event) => {
+                  event.preventDefault()
+                  void handleUpgrade()
+                }}
+              >
                 <Sparkles />
 
                 {tPhaseF('phaseF.componentsNavUser.upgradeToPro')}
@@ -82,12 +111,12 @@ export function NavUser({
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => openSettings('account')}>
                 <BadgeCheck />
 
                 {tPhaseF('phaseF.componentsNavUser.account')}
               </DropdownMenuItem>
-              <DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => openSettings('account')}>
                 <CreditCard />
 
                 {tPhaseF('phaseF.componentsNavUser.billing')}

--- a/apps/desktop/src/renderer/src/pages/settings/account-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/account-section.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { Switch } from '@/components/ui/switch'
-import { RefreshCw } from '@/lib/icons'
+import { CreditCard, ExternalLink, RefreshCw } from '@/lib/icons'
 import { toast } from 'sonner'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { useAuth } from '@/contexts/auth-context'
@@ -37,6 +37,26 @@ const MEMRY_REPOSITORY_URL = 'https://github.com/memrynote/memry'
 const MEMRY_ISSUES_URL =
   'https://github.com/memrynote/memry/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+'
 const MEMRY_ICON_SRC = new URL('../../../../../build/icon.png', import.meta.url).href
+const BILLING_SUPPORT_EMAIL = 'billing@memrynote.com'
+
+type BillingPlan = 'free' | 'plus' | 'pro' | 'believer'
+type BillingStatusValue = 'inactive' | 'active' | 'past_due' | 'paused' | 'canceled'
+
+interface BillingStatus {
+  plan: BillingPlan
+  status: BillingStatusValue
+  limits: {
+    storageLimit: number
+    maxFileSize: number
+    maxVaults: number | null
+    versionHistoryDays: number
+  }
+  usage: {
+    storageUsed: number
+  }
+  expiresAt: number | null
+  canManageBilling: boolean
+}
 
 function AccountCommunityFooter() {
   const { t } = useT('settings')
@@ -75,9 +95,21 @@ function AccountCommunityFooter() {
 }
 
 function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+  if (unitIndex === 0) return `${value} ${units[unitIndex]}`
+  return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${units[unitIndex]}`
+}
+
+function isBillingStatus(value: unknown): value is BillingStatus {
+  return Boolean(
+    value && typeof value === 'object' && 'plan' in value && 'status' in value && 'limits' in value
+  )
 }
 
 const STORAGE_COLORS: Record<string, string> = {
@@ -91,15 +123,22 @@ export function AccountSettings() {
   const { t } = useT('settings')
   const { t: tCommon } = useT('common')
   const { state, logout } = useAuth()
-  const { linkingRequest, clearLinkingRequest } = useSync()
+  const { linkingRequest, clearLinkingRequest, triggerSync } = useSync()
   const syncStatus = useSyncStatus()
   const [storage, setStorage] = useState<StorageBreakdownResult | null>(null)
+  const [billing, setBilling] = useState<BillingStatus | null>(null)
+  const [billingError, setBillingError] = useState<string | null>(null)
+  const [activationPending, setActivationPending] = useState(false)
   const [showSignOutDialog, setShowSignOutDialog] = useState(false)
   const [signingOut, setSigningOut] = useState(false)
   const [showLinkingQr, setShowLinkingQr] = useState(false)
   const [showRotationWizard, setShowRotationWizard] = useState(false)
   const [showRecoveryKey, setShowRecoveryKey] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
+  const [isBillingRefreshing, setIsBillingRefreshing] = useState(false)
+  const [isCheckoutStarting, setIsCheckoutStarting] = useState(false)
+  const [isPortalOpening, setIsPortalOpening] = useState(false)
+  const billingLoadFailed = t('account.billing.toasts.loadFailed')
 
   const loadStorage = useCallback(async () => {
     if (state.status !== 'authenticated') return
@@ -118,6 +157,26 @@ export function AccountSettings() {
     void loadStorage()
   }, [loadStorage])
 
+  const loadBilling = useCallback(async () => {
+    if (state.status !== 'authenticated') return
+    setBillingError(null)
+    try {
+      const result = await window.api.account.getBillingStatus()
+      if (isBillingStatus(result)) {
+        setBilling(result)
+        setActivationPending(result.plan !== 'free' && result.status !== 'active')
+      } else {
+        setBillingError(result.error ?? billingLoadFailed)
+      }
+    } catch (error: unknown) {
+      setBillingError(extractErrorMessage(error, billingLoadFailed))
+    }
+  }, [billingLoadFailed, state.status])
+
+  useEffect(() => {
+    void loadBilling()
+  }, [loadBilling])
+
   const handleSignOut = useCallback(async () => {
     setSigningOut(true)
     try {
@@ -130,6 +189,66 @@ export function AccountSettings() {
       setShowSignOutDialog(false)
     }
   }, [logout, t])
+
+  const handleStartCheckout = useCallback(async () => {
+    setIsCheckoutStarting(true)
+    setActivationPending(true)
+    try {
+      const result = await window.api.account.startCheckout({ plan: 'pro', cadence: 'annual' })
+      if (!result.success) {
+        setActivationPending(false)
+        toast.error(result.error ?? t('account.billing.toasts.checkoutFailed'))
+        return
+      }
+      toast.success(t('account.billing.toasts.checkoutOpened'))
+    } catch (error: unknown) {
+      setActivationPending(false)
+      toast.error(extractErrorMessage(error, t('account.billing.toasts.checkoutFailed')))
+    } finally {
+      setIsCheckoutStarting(false)
+    }
+  }, [t])
+
+  const handleRefreshBilling = useCallback(async () => {
+    setIsBillingRefreshing(true)
+    setBillingError(null)
+    try {
+      const result = await window.api.account.refreshBillingStatus()
+      if (!isBillingStatus(result)) {
+        throw new Error(result.error ?? t('account.billing.toasts.refreshFailed'))
+      }
+      setBilling(result)
+      const isActive = result.status === 'active'
+      setActivationPending(result.plan !== 'free' && !isActive)
+      await loadStorage()
+      if (isActive) {
+        await triggerSync()
+        toast.success(t('account.billing.toasts.billingActive'))
+      } else {
+        toast.info(t('account.billing.toasts.activationPending'))
+      }
+    } catch (error: unknown) {
+      const message = extractErrorMessage(error, t('account.billing.toasts.refreshFailed'))
+      setBillingError(message)
+      toast.error(message)
+    } finally {
+      setIsBillingRefreshing(false)
+    }
+  }, [loadStorage, t, triggerSync])
+
+  const handleOpenBillingPortal = useCallback(async () => {
+    setIsPortalOpening(true)
+    try {
+      const result = await window.api.account.openBillingPortal()
+      if (!result.success) {
+        toast.error(result.error ?? t('account.billing.toasts.portalFailed'))
+      }
+    } catch (error: unknown) {
+      toast.error(extractErrorMessage(error, t('account.billing.toasts.portalFailed')))
+    } finally {
+      setIsPortalOpening(false)
+    }
+  }, [t])
 
   if (state.status === 'checking') {
     return (
@@ -201,6 +320,124 @@ export function AccountSettings() {
             onCheckedChange={(checked) => void (checked ? syncStatus.resume() : syncStatus.pause())}
             className={ACCENT_SWITCH}
           />
+        </div>
+      </SettingsGroup>
+
+      <SettingsGroup label={t('account.groups.billing')}>
+        <div className="space-y-3 px-4 py-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-2">
+              <CreditCard className="size-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0">
+                <div className="font-medium text-[13px]/4 text-foreground">
+                  {billing
+                    ? t(`account.billing.plans.${billing.plan}`)
+                    : t('account.billing.planStatus')}
+                </div>
+                <div className="text-xs/4 text-muted-foreground">
+                  {billing
+                    ? t(`account.billing.statuses.${billing.status}`)
+                    : t('account.billing.checking')}
+                </div>
+              </div>
+            </div>
+            {billing && (
+              <span
+                className={`shrink-0 rounded-full px-2 py-0.5 text-[11px]/4 font-medium ${
+                  billing.status === 'active'
+                    ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+                    : 'bg-amber-500/10 text-amber-700 dark:text-amber-300'
+                }`}
+              >
+                {t(`account.billing.statuses.${billing.status}`)}
+              </span>
+            )}
+          </div>
+
+          {billing && (
+            <div className="grid gap-2 text-xs/4 text-muted-foreground sm:grid-cols-2">
+              <div>
+                <span className="font-medium text-foreground">
+                  {t('account.billing.labels.storage')}
+                </span>{' '}
+                {formatBytes(billing.usage.storageUsed)} /{' '}
+                {formatBytes(billing.limits.storageLimit)}
+              </div>
+              <div>
+                <span className="font-medium text-foreground">
+                  {t('account.billing.labels.maxFile')}
+                </span>{' '}
+                {formatBytes(billing.limits.maxFileSize)}
+              </div>
+              <div>
+                <span className="font-medium text-foreground">
+                  {t('account.billing.labels.vaults')}
+                </span>{' '}
+                {billing.limits.maxVaults ?? t('account.billing.unlimited')}
+              </div>
+              <div>
+                <span className="font-medium text-foreground">
+                  {t('account.billing.labels.history')}
+                </span>{' '}
+                {t('account.billing.historyDays', {
+                  days: billing.limits.versionHistoryDays
+                })}
+              </div>
+            </div>
+          )}
+
+          {(activationPending || billingError) && (
+            <div className="rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs/4 text-amber-900 dark:text-amber-200">
+              {billingError ?? (
+                <>
+                  {t('account.billing.activationPendingPrefix')}{' '}
+                  <a
+                    className="font-medium underline underline-offset-2"
+                    href={`mailto:${BILLING_SUPPORT_EMAIL}`}
+                  >
+                    {BILLING_SUPPORT_EMAIL}
+                  </a>
+                  .
+                </>
+              )}
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => void handleStartCheckout()}
+              disabled={isCheckoutStarting || billing?.status === 'active'}
+              className="h-7 px-3 text-xs/4"
+            >
+              {isCheckoutStarting
+                ? t('account.billing.actions.opening')
+                : t('account.billing.actions.upgrade')}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void handleRefreshBilling()}
+              disabled={isBillingRefreshing}
+              className="h-7 px-3 text-xs/4"
+            >
+              <RefreshCw
+                className={`me-1.5 size-3.5 ${isBillingRefreshing ? 'animate-spin' : ''}`}
+              />
+              {t('account.billing.actions.refresh')}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void handleOpenBillingPortal()}
+              disabled={isPortalOpening || !billing?.canManageBilling}
+              className="h-7 px-3 text-xs/4"
+            >
+              <ExternalLink className="me-1.5 size-3.5" />
+              {t('account.billing.actions.manage')}
+            </Button>
+          </div>
         </div>
       </SettingsGroup>
 

--- a/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/settings-sections.test.tsx
@@ -15,7 +15,8 @@ const mocks = vi.hoisted(() => ({
   logout: vi.fn(),
   syncContext: {
     linkingRequest: null as unknown,
-    clearLinkingRequest: vi.fn()
+    clearLinkingRequest: vi.fn(),
+    triggerSync: vi.fn()
   },
   syncStatus: {
     status: 'idle',
@@ -83,7 +84,8 @@ vi.mock('@memry/i18n/renderer', () => ({
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
-    error: vi.fn()
+    error: vi.fn(),
+    info: vi.fn()
   }
 }))
 
@@ -322,6 +324,41 @@ function installWindowApi() {
         breakdown: { notes: 1024, attachments: 256, crdt: 128, other: 128 }
       })
     },
+    account: {
+      getBillingStatus: vi.fn().mockResolvedValue({
+        plan: 'free',
+        status: 'inactive',
+        source: 'none',
+        limits: {
+          storageLimit: 0,
+          maxFileSize: 0,
+          maxVaults: 0,
+          versionHistoryDays: 0
+        },
+        usage: { storageUsed: 0 },
+        expiresAt: null,
+        canManageBilling: false
+      }),
+      refreshBillingStatus: vi.fn().mockResolvedValue({
+        plan: 'pro',
+        status: 'active',
+        source: 'paddle',
+        limits: {
+          storageLimit: 10 * 1024 * 1024 * 1024,
+          maxFileSize: 200 * 1024 * 1024,
+          maxVaults: 10,
+          versionHistoryDays: 365
+        },
+        usage: { storageUsed: 1536 },
+        expiresAt: null,
+        canManageBilling: true
+      }),
+      startCheckout: vi.fn().mockResolvedValue({ success: true, checkoutUrl: 'https://checkout' }),
+      openBillingPortal: vi.fn().mockResolvedValue({
+        success: true,
+        portalUrl: 'https://paddle.test/portal'
+      })
+    },
     settings: {
       ...window.api.settings,
       getTerminalCommandStatus: vi.fn().mockResolvedValue({
@@ -429,6 +466,7 @@ describe('settings section coverage', () => {
     installWindowApi()
     mocks.authState = { status: 'authenticated', email: 'kaan@example.com' }
     mocks.syncContext.linkingRequest = null
+    mocks.syncContext.triggerSync.mockResolvedValue(undefined)
     mocks.generalSettings.isLoading = false
     mocks.generalSettings.updateSettings.mockResolvedValue(true)
     mocks.calendarPreferences.isLoading = false
@@ -456,6 +494,7 @@ describe('settings section coverage', () => {
     mocks.syncContext.linkingRequest = { code: '123456' }
     rerender(<AccountSettings />)
     expect(await screen.findByText('kaan@example.com')).toBeInTheDocument()
+    expect(await screen.findByText('account.billing.plans.free')).toBeInTheDocument()
     expect(screen.getByText(/account.storage.used/)).toBeInTheDocument()
     expect(screen.getByText('account.community.prompt')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'account.community.star' })).toHaveAttribute(
@@ -482,6 +521,26 @@ describe('settings section coverage', () => {
     fireEvent.click(screen.getByText('approve link'))
     expect(mocks.syncContext.clearLinkingRequest).toHaveBeenCalled()
     expect(toast.success).toHaveBeenCalledWith('account.toasts.deviceLinked')
+  })
+
+  it('starts checkout, refreshes billing, and opens Paddle portal from account settings', async () => {
+    render(<AccountSettings />)
+    expect(await screen.findByText('account.billing.plans.free')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('account.billing.actions.upgrade'))
+    await waitFor(() =>
+      expect(window.api.account.startCheckout).toHaveBeenCalledWith({
+        plan: 'pro',
+        cadence: 'annual'
+      })
+    )
+
+    fireEvent.click(screen.getByText('account.billing.actions.refresh'))
+    await waitFor(() => expect(screen.getByText('account.billing.plans.pro')).toBeInTheDocument())
+    expect(mocks.syncContext.triggerSync).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText('account.billing.actions.manage'))
+    await waitFor(() => expect(window.api.account.openBillingPortal).toHaveBeenCalled())
   })
 
   it('renders setup while recovery confirmation is still pending', () => {

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -27,6 +27,25 @@ Inactive, past-due, paused, canceled, or expired entitlements return `SYNC_PAYME
 sync data is read or written. Vault and file-size limits return `SYNC_VAULT_LIMIT_EXCEEDED` and
 `STORAGE_FILE_TOO_LARGE`.
 
+Desktop checkout is account-owned. The app requests `/auth/checkout-token`, opens
+`memrynote.com/pricing` with the token in the URL fragment, and the landing page passes that token
+to the Paddle checkout transaction API. After payment, Paddle webhooks are the primary entitlement
+writer. Desktop can also call `/auth/billing/reconcile` with the returned transaction id; the server
+fetches the Paddle transaction, verifies the embedded memrynote user id, and provisions the
+entitlement only for completed transactions.
+
+Billing status and customer management stay on authenticated account routes:
+
+| Path                                | Purpose                                                         |
+| ----------------------------------- | --------------------------------------------------------------- |
+| `GET /auth/billing`                 | Return current plan, status, limits, usage, expiry, portal flag |
+| `POST /auth/billing/reconcile`      | Reconcile an optional Paddle transaction id into entitlement    |
+| `POST /auth/billing/portal-session` | Create a temporary Paddle customer portal URL                   |
+
+Portal URLs are temporary authenticated links from Paddle and are never cached. Refund and
+chargeback automation is intentionally out of scope; support handles those from email and the Paddle
+dashboard.
+
 ## Sync Items
 
 Every domain object syncs as a `sync_item`. The server sees:

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -23,6 +23,17 @@ The signed-in email and current subscription plan. Read-only — sign in or out 
 
 A toggle to enable or pause cloud sync, plus a status indicator and the time of the last successful sync.
 
+### Billing
+
+Shows the current sync plan, activation state, storage limit, max file size, synced vault limit, and
+version-history window. **Upgrade** starts Paddle checkout in the browser, **Refresh status** asks
+the sync server to reconcile the latest Paddle transaction, and **Manage billing** opens Paddle's
+hosted customer portal when the account has a Paddle customer id.
+
+If checkout succeeds before the webhook finishes, Billing shows **Activation pending**. Use
+**Refresh status** after a moment, or contact the billing support email shown in the panel for
+refunds, chargebacks, or manual help.
+
 ### Storage
 
 A breakdown of vault size by category — notes, attachments, CRDT data, and other. The refresh button recomputes totals on demand. Visible only when signed in.

--- a/apps/docs/src/user-guide/sync/how-sync-works.md
+++ b/apps/docs/src/user-guide/sync/how-sync-works.md
@@ -25,6 +25,16 @@ active.
 All record sync, CRDT sync, WebSocket sync notifications, and encrypted blob uploads are gated by
 the active plan on the sync server. The server still stores only ciphertext.
 
+Start a paid plan from **Settings -> Account -> Billing** or **Upgrade to Pro** in the sidebar
+account menu. memrynote opens checkout on `memrynote.com/pricing`; after Paddle completes payment,
+return to the app from the success page so the desktop can reconcile the transaction and refresh
+sync. If the webhook is still processing, Billing shows **Activation pending** with a refresh button
+and the billing support email.
+
+Billing management uses Paddle's hosted customer portal from the same Billing section. Refunds and
+chargebacks are handled by emailing support for now; memrynote does not automate those flows inside
+the app.
+
 ## Status Indicator
 
 A small indicator in the app chrome shows the current state:

--- a/apps/landing/api/paddle-checkout-client.test.mjs
+++ b/apps/landing/api/paddle-checkout-client.test.mjs
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { readCheckoutResponse } from '../src/lib/paddle-checkout.ts'
+import {
+  buildCheckoutSuccessUrl,
+  buildMemryBillingCompleteUrl,
+  buildMemryBillingStartUrl,
+  parseCheckoutHash,
+  readCheckoutResponse
+} from '../src/lib/paddle-checkout.ts'
 
 describe('paddle checkout response parsing', () => {
   it('turns non-JSON server failures into a checkout error', async () => {
@@ -11,5 +17,32 @@ describe('paddle checkout response parsing', () => {
     })
 
     await assert.rejects(readCheckoutResponse(response), /Could not start checkout/)
+  })
+
+  it('parses and strips desktop checkout intents from the URL fragment', () => {
+    const href =
+      'https://memrynote.com/pricing#checkout_plan=pro&checkout_cadence=annual&checkout_token=tok_123'
+    const url = new URL(href)
+
+    assert.deepEqual(parseCheckoutHash(url.hash), {
+      plan: 'pro',
+      cadence: 'annual',
+      checkoutToken: 'tok_123'
+    })
+  })
+
+  it('builds purchase handoff URLs without leaking checkout tokens into query params', () => {
+    assert.equal(
+      buildMemryBillingStartUrl('pro', 'annual'),
+      'memry://billing/start?plan=pro&cadence=annual'
+    )
+    assert.equal(
+      buildMemryBillingCompleteUrl('txn_123'),
+      'memry://billing/complete?transactionId=txn_123'
+    )
+
+    const successUrl = buildCheckoutSuccessUrl('https://memrynote.com', 'txn_123')
+    assert.equal(successUrl, 'https://memrynote.com/pricing?checkout=success&transactionId=txn_123')
+    assert.equal(successUrl.includes('checkout_token'), false)
   })
 })

--- a/apps/landing/src/lib/paddle-checkout.ts
+++ b/apps/landing/src/lib/paddle-checkout.ts
@@ -1,8 +1,15 @@
-import { initializePaddle, type Paddle } from '@paddle/paddle-js'
+import { initializePaddle, type Paddle, type PaddleEventData } from '@paddle/paddle-js'
 
-import type { SyncPlanId } from './constants'
+import type { CheckoutPlanId, SyncPlanId } from './constants'
 
 export type PaddleCheckoutCadence = 'monthly' | 'annual' | 'lifetime'
+export type PaddleCheckoutEventHandler = (event: PaddleEventData) => void
+
+export interface CheckoutHashIntent {
+  plan: CheckoutPlanId
+  cadence: PaddleCheckoutCadence
+  checkoutToken: string
+}
 
 type CheckoutResponse = {
   transactionId: string
@@ -10,6 +17,7 @@ type CheckoutResponse = {
 }
 
 let paddlePromise: Promise<Paddle | undefined> | null = null
+let activeCheckoutEventHandler: PaddleCheckoutEventHandler | null = null
 
 function getPaddleClient() {
   const token = import.meta.env.VITE_PADDLE_CLIENT_TOKEN
@@ -19,6 +27,9 @@ function getPaddleClient() {
     token,
     environment:
       import.meta.env.VITE_PADDLE_ENVIRONMENT === 'production' ? 'production' : 'sandbox',
+    eventCallback: (event) => {
+      activeCheckoutEventHandler?.(event)
+    },
     checkout: {
       settings: {
         displayMode: 'overlay',
@@ -30,6 +41,31 @@ function getPaddleClient() {
   })
 
   return paddlePromise
+}
+
+export function parseCheckoutHash(hash: string): CheckoutHashIntent | null {
+  const params = new URLSearchParams(hash.replace(/^#/, ''))
+  const plan = params.get('checkout_plan')
+  const cadence = params.get('checkout_cadence')
+  const checkoutToken = params.get('checkout_token')?.trim()
+
+  if (!isCheckoutPlan(plan) || !isCheckoutCadence(cadence) || !checkoutToken) return null
+  return { plan, cadence, checkoutToken }
+}
+
+export function buildMemryBillingStartUrl(plan: CheckoutPlanId, cadence: PaddleCheckoutCadence) {
+  const params = new URLSearchParams({ plan, cadence })
+  return `memry://billing/start?${params.toString()}`
+}
+
+export function buildMemryBillingCompleteUrl(transactionId: string) {
+  const params = new URLSearchParams({ transactionId })
+  return `memry://billing/complete?${params.toString()}`
+}
+
+export function buildCheckoutSuccessUrl(origin: string, transactionId: string) {
+  const params = new URLSearchParams({ checkout: 'success', transactionId })
+  return `${origin}/pricing?${params.toString()}`
 }
 
 async function readJsonBody(response: Response) {
@@ -63,7 +99,8 @@ export async function readCheckoutResponse(response: Response): Promise<Checkout
 export async function openPaddleCheckout(
   plan: SyncPlanId,
   cadence: PaddleCheckoutCadence,
-  checkoutToken?: string
+  checkoutToken?: string,
+  onEvent?: PaddleCheckoutEventHandler
 ) {
   const normalizedCheckoutToken = checkoutToken?.trim()
   if (!normalizedCheckoutToken) {
@@ -79,19 +116,28 @@ export async function openPaddleCheckout(
   const paddle = await getPaddleClient()
 
   if (paddle) {
+    activeCheckoutEventHandler = onEvent ?? null
     paddle.Checkout.open({
       transactionId: checkout.transactionId,
       settings: {
-        successUrl: `${window.location.origin}/pricing?checkout=success`
+        successUrl: buildCheckoutSuccessUrl(window.location.origin, checkout.transactionId)
       }
     })
-    return
+    return checkout
   }
 
   if (checkout.checkoutUrl) {
     window.location.assign(checkout.checkoutUrl)
-    return
+    return checkout
   }
 
   throw new Error('Paddle client token is missing')
+}
+
+function isCheckoutPlan(value: string | null): value is CheckoutPlanId {
+  return value === 'plus' || value === 'pro' || value === 'believer'
+}
+
+function isCheckoutCadence(value: string | null): value is PaddleCheckoutCadence {
+  return value === 'monthly' || value === 'annual' || value === 'lifetime'
 }

--- a/apps/landing/src/pages/Pricing.tsx
+++ b/apps/landing/src/pages/Pricing.tsx
@@ -1,7 +1,7 @@
-import { Fragment, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
-import { Check, ArrowRight, Sparkles, ShieldCheck, Heart } from 'lucide-react'
+import { Check, ArrowRight, Sparkles, ShieldCheck, Heart, ExternalLink } from 'lucide-react'
 import { Container } from '@/components/layout/Container'
 import { PageHead } from '@/components/shared/PageHead'
 import { Button } from '@/components/ui/button'
@@ -22,7 +22,13 @@ import {
   type SyncPlanTier,
   type LifecycleTone
 } from '@/lib/constants'
-import { openPaddleCheckout, type PaddleCheckoutCadence } from '@/lib/paddle-checkout'
+import {
+  buildMemryBillingCompleteUrl,
+  buildMemryBillingStartUrl,
+  openPaddleCheckout,
+  parseCheckoutHash,
+  type PaddleCheckoutCadence
+} from '@/lib/paddle-checkout'
 import { cn } from '@/lib/utils'
 import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from '@/lib/motion'
 import { trackLandingEvent } from '@/lib/analytics'
@@ -31,7 +37,14 @@ type Cadence = 'monthly' | 'annual'
 type CheckoutState = {
   pendingKey: string | null
   error: string | null
+  notice: CheckoutNotice | null
 }
+type CheckoutNotice =
+  | { type: 'success'; transactionId: string | null }
+  | { type: 'pending'; transactionId: string | null }
+  | { type: 'failed' }
+  | { type: 'canceled' }
+  | { type: 'desktop'; url: string }
 
 const PURCHASES_ENABLED = false
 
@@ -44,25 +57,79 @@ const fadeUp = {
 
 export function PricingPage() {
   const [cadence, setCadence] = useState<Cadence>('annual')
-  const [checkout, setCheckout] = useState<CheckoutState>({ pendingKey: null, error: null })
+  const [checkout, setCheckout] = useState<CheckoutState>({
+    pendingKey: null,
+    error: null,
+    notice: null
+  })
+  const consumedCheckoutIntent = useRef(false)
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('checkout') === 'success') {
+      setCheckout({
+        pendingKey: null,
+        error: null,
+        notice: { type: 'success', transactionId: params.get('transactionId') }
+      })
+      return
+    }
+
+    if (consumedCheckoutIntent.current) return
+    const intent = parseCheckoutHash(window.location.hash)
+    if (!intent) return
+
+    consumedCheckoutIntent.current = true
+    window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`)
+    if (intent.cadence === 'monthly' || intent.cadence === 'annual') {
+      setCadence(intent.cadence)
+    }
+
+    const pendingKey = getCheckoutKey(intent.plan, intent.cadence)
+    setCheckout({ pendingKey, error: null, notice: null })
+    let checkoutTransactionId: string | null = null
+    let checkoutCompleted = false
+    void openPaddleCheckout(intent.plan, intent.cadence, intent.checkoutToken, (event) => {
+      if (event.name === 'checkout.completed') {
+        checkoutCompleted = true
+        setCheckout({
+          pendingKey: null,
+          error: null,
+          notice: { type: 'success', transactionId: checkoutTransactionId }
+        })
+      } else if (event.name === 'checkout.closed' && !checkoutCompleted) {
+        setCheckout({ pendingKey: null, error: null, notice: { type: 'canceled' } })
+      } else if (event.name === 'checkout.payment.failed') {
+        setCheckout({ pendingKey: null, error: null, notice: { type: 'failed' } })
+      }
+    })
+      .then((result) => {
+        checkoutTransactionId = result.transactionId
+      })
+      .catch((error) => {
+        setCheckout({
+          pendingKey: null,
+          error: error instanceof Error ? error.message : 'Could not start checkout',
+          notice: null
+        })
+      })
+  }, [])
 
   const handleCheckout = async (tier: SyncPlanTier) => {
     if (!PURCHASES_ENABLED || !tier.checkoutPlanId) return
 
     const checkoutCadence = getCheckoutCadence(tier, cadence)
     const pendingKey = getCheckoutKey(tier.checkoutPlanId, checkoutCadence)
+    const desktopUrl = buildMemryBillingStartUrl(tier.checkoutPlanId, checkoutCadence)
 
     trackLandingEvent('landing_pricing_cta_click', pricingTarget(tier.id, checkoutCadence))
-    setCheckout({ pendingKey, error: null })
-    try {
-      await openPaddleCheckout(tier.checkoutPlanId, checkoutCadence)
-      setCheckout({ pendingKey: null, error: null })
-    } catch (error) {
-      setCheckout({
-        pendingKey: null,
-        error: error instanceof Error ? error.message : 'Could not start checkout'
-      })
-    }
+    setCheckout({ pendingKey, error: null, notice: { type: 'desktop', url: desktopUrl } })
+    window.location.href = desktopUrl
+    window.setTimeout(() => {
+      setCheckout((current) =>
+        current.pendingKey === pendingKey ? { ...current, pendingKey: null } : current
+      )
+    }, 1000)
   }
 
   return (
@@ -70,8 +137,9 @@ export function PricingPage() {
       <PageHead page="pricing" />
       <main>
         <Hero cadence={cadence} setCadence={setCadence} />
+        <CheckoutNoticeBanner notice={checkout.notice} />
         <TierGrid cadence={cadence} checkout={checkout} onCheckout={handleCheckout} />
-        <LimitMatrix cadence={cadence} />
+        <LimitMatrix cadence={cadence} onCheckout={handleCheckout} />
         <BelieverNarrative />
         <LifecycleTimeline />
         <PricingFaq />
@@ -91,6 +159,77 @@ function getCheckoutKey(planId: CheckoutPlanId, cadence: PaddleCheckoutCadence) 
 
 function pricingTarget(tierId: string, cadence: string) {
   return `pricing:${tierId}:${cadence}`
+}
+
+function CheckoutNoticeBanner({ notice }: { notice: CheckoutNotice | null }) {
+  if (!notice) return null
+
+  const tone =
+    notice.type === 'failed'
+      ? 'border-terracotta/30 bg-terracotta/5 text-terracotta'
+      : notice.type === 'canceled'
+        ? 'border-amber-500/30 bg-amber-500/5 text-amber-700'
+        : 'border-sage/30 bg-sage/5 text-sage'
+
+  const title =
+    notice.type === 'success'
+      ? 'Purchase complete'
+      : notice.type === 'pending'
+        ? 'Activation pending'
+        : notice.type === 'failed'
+          ? 'Payment failed'
+          : notice.type === 'canceled'
+            ? 'Checkout canceled'
+            : 'Open Memry to continue'
+
+  const body =
+    notice.type === 'success'
+      ? 'Memry will activate hosted sync after Paddle confirms the transaction.'
+      : notice.type === 'pending'
+        ? 'Paddle is confirming the purchase. If Memry is open, refresh billing in Account.'
+        : notice.type === 'failed'
+          ? 'The payment was not completed. You can try again from Memry when ready.'
+          : notice.type === 'canceled'
+            ? 'No charge was made. Start again from Memry when you are ready.'
+            : 'Memry desktop signs the checkout request so the purchase lands on your account.'
+
+  const transactionId =
+    notice.type === 'success' || notice.type === 'pending' ? notice.transactionId : null
+  const openMemryUrl = transactionId ? buildMemryBillingCompleteUrl(transactionId) : 'memry://'
+
+  return (
+    <section className="pb-8">
+      <Container size="md">
+        <div
+          className={cn(
+            'flex flex-col gap-4 rounded-2xl border px-5 py-4 text-sm shadow-card sm:flex-row sm:items-center sm:justify-between',
+            tone
+          )}
+          role={notice.type === 'failed' ? 'alert' : 'status'}
+        >
+          <div>
+            <p className="font-mono-accent text-[11px] uppercase tracking-[0.18em]">{title}</p>
+            <p className="mt-1 text-ink/75">{body}</p>
+          </div>
+          {(notice.type === 'success' ||
+            notice.type === 'pending' ||
+            notice.type === 'desktop') && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="shrink-0 rounded-full border-ink/15 bg-paper-alt/40 text-ink hover:bg-paper-alt"
+              asChild
+            >
+              <a href={notice.type === 'desktop' ? notice.url : openMemryUrl}>
+                <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+                Open Memry
+              </a>
+            </Button>
+          )}
+        </div>
+      </Container>
+    </section>
+  )
 }
 
 function Hero({ cadence, setCadence }: { cadence: Cadence; setCadence: (c: Cadence) => void }) {
@@ -627,7 +766,13 @@ function LifecycleTimeline() {
   )
 }
 
-function LimitMatrix({ cadence }: { cadence: Cadence }) {
+function LimitMatrix({
+  cadence,
+  onCheckout
+}: {
+  cadence: Cadence
+  onCheckout: (tier: SyncPlanTier) => void
+}) {
   const plans = PLAN_COMPARISON_MATRIX.plans.map((planId) => {
     const tier = SYNC_PLAN_TIERS.find((item) => item.id === planId)
     if (!tier) {
@@ -713,10 +858,11 @@ function LimitMatrix({ cadence }: { cadence: Cadence }) {
                           <Button
                             variant={isRecommended ? 'default' : 'outline'}
                             size="sm"
-                            disabled
+                            disabled={!PURCHASES_ENABLED}
+                            onClick={() => onCheckout(tier)}
                             className="h-8 rounded-full px-3 text-xs"
                           >
-                            End of June
+                            {PURCHASES_ENABLED ? tier.cta : 'End of June'}
                           </Button>
                         )}
                       </div>

--- a/apps/sync-server/src/index.test.ts
+++ b/apps/sync-server/src/index.test.ts
@@ -21,6 +21,7 @@ function createEnv(overrides?: Partial<Record<string, unknown>>) {
     WEBHOOK_HMAC_KEY: '',
     PADDLE_WEBHOOK_SECRET: '',
     PADDLE_CHECKOUT_TOKEN_SECRET: '',
+    PADDLE_API_KEY: '',
     TELEMETRY_HMAC_KEY: '',
     ...overrides
   }
@@ -78,6 +79,7 @@ describe('sync-server app entry point', () => {
         WEBHOOK_HMAC_KEY: 'test-webhook-hmac-key',
         PADDLE_WEBHOOK_SECRET: 'test-paddle-webhook-secret',
         PADDLE_CHECKOUT_TOKEN_SECRET: 'test-checkout-token-secret',
+        PADDLE_API_KEY: 'test-paddle-api-key',
         TELEMETRY_HMAC_KEY: 'test-telemetry-hmac-key',
         ALLOWED_ORIGIN: 'https://app.memry.test'
       })
@@ -105,6 +107,7 @@ describe('sync-server app entry point', () => {
         WEBHOOK_HMAC_KEY: 'test-webhook-hmac-key',
         PADDLE_WEBHOOK_SECRET: 'test-paddle-webhook-secret',
         PADDLE_CHECKOUT_TOKEN_SECRET: 'test-checkout-token-secret',
+        PADDLE_API_KEY: 'test-paddle-api-key',
         TELEMETRY_HMAC_KEY: ''
       })
     )

--- a/apps/sync-server/src/index.ts
+++ b/apps/sync-server/src/index.ts
@@ -131,6 +131,7 @@ app.use('*', async (c, next) => {
     'WEBHOOK_HMAC_KEY',
     'PADDLE_WEBHOOK_SECRET',
     'PADDLE_CHECKOUT_TOKEN_SECRET',
+    'PADDLE_API_KEY',
     'TELEMETRY_HMAC_KEY'
   ] as const
 

--- a/apps/sync-server/src/middleware/paid-sync.test.ts
+++ b/apps/sync-server/src/middleware/paid-sync.test.ts
@@ -15,6 +15,9 @@ function entitlement(overrides: Partial<SyncEntitlement> = {}): SyncEntitlement 
     max_file_size: SYNC_PLAN_LIMITS.plus.maxFileSize,
     max_vaults: SYNC_PLAN_LIMITS.plus.maxVaults,
     version_history_days: SYNC_PLAN_LIMITS.plus.versionHistoryDays,
+    paddle_customer_id: null,
+    paddle_subscription_id: null,
+    paddle_transaction_id: null,
     expires_at: null,
     ...overrides
   }

--- a/apps/sync-server/src/routes/auth.test.ts
+++ b/apps/sync-server/src/routes/auth.test.ts
@@ -150,24 +150,38 @@ const createD1Statement = () => {
   return statement
 }
 
-const createEnv = () => ({
-  DB: {
-    prepare: vi.fn().mockReturnValue(createD1Statement())
-  } as unknown as D1Database,
-  STORAGE: {} as R2Bucket,
-  USER_SYNC_STATE: {} as DurableObjectNamespace,
-  LINKING_SESSION: {} as DurableObjectNamespace,
-  ENVIRONMENT: 'development',
-  JWT_PUBLIC_KEY: 'mock-public-key',
-  JWT_PRIVATE_KEY: 'mock-private-key',
-  RESEND_API_KEY: 'mock-resend-key',
-  OTP_HMAC_KEY: 'mock-otp-hmac-key',
-  GOOGLE_CLIENT_ID: 'mock-google-client-id',
-  GOOGLE_CLIENT_SECRET: 'mock-google-client-secret',
-  GOOGLE_REDIRECT_URI: 'http://localhost/callback',
-  RECOVERY_DUMMY_SECRET: 'mock-dummy-recovery-secret',
-  PADDLE_CHECKOUT_TOKEN_SECRET: 'mock-checkout-token-secret'
-})
+const createEnv = (options?: {
+  firstRows?: unknown[]
+  paddleFetch?: typeof fetch
+  paddleApiKey?: string
+}) => {
+  const firstRows = [...(options?.firstRows ?? [])]
+  return {
+    DB: {
+      prepare: vi.fn().mockImplementation(() => {
+        const statement = createD1Statement()
+        statement.first.mockImplementation(() => Promise.resolve(firstRows.shift() ?? null))
+        return statement
+      })
+    } as unknown as D1Database,
+    STORAGE: {} as R2Bucket,
+    USER_SYNC_STATE: {} as DurableObjectNamespace,
+    LINKING_SESSION: {} as DurableObjectNamespace,
+    ENVIRONMENT: 'development',
+    JWT_PUBLIC_KEY: 'mock-public-key',
+    JWT_PRIVATE_KEY: 'mock-private-key',
+    RESEND_API_KEY: 'mock-resend-key',
+    OTP_HMAC_KEY: 'mock-otp-hmac-key',
+    GOOGLE_CLIENT_ID: 'mock-google-client-id',
+    GOOGLE_CLIENT_SECRET: 'mock-google-client-secret',
+    GOOGLE_REDIRECT_URI: 'http://localhost/callback',
+    RECOVERY_DUMMY_SECRET: 'mock-dummy-recovery-secret',
+    PADDLE_CHECKOUT_TOKEN_SECRET: 'mock-checkout-token-secret',
+    PADDLE_API_KEY: options?.paddleApiKey ?? 'pdl_sandbox_key',
+    PADDLE_ENVIRONMENT: 'sandbox',
+    fetch: options?.paddleFetch
+  }
+}
 
 const jsonPost = (path: string, body: Record<string, unknown>) => ({
   method: 'POST' as const,
@@ -288,6 +302,208 @@ describe('auth routes', () => {
       expect(res.status).toBe(200)
       expect(await res.json()).toEqual({ success: true, expiresIn: 600 })
       expect(checkEmailRateLimit).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('billing routes', () => {
+    it('returns free billing status when no paid entitlement exists', async () => {
+      env = createEnv({
+        firstRows: [
+          {
+            user_id: 'user-1',
+            storage_used: 0,
+            plan: 'free',
+            status: 'inactive',
+            source: 'none',
+            storage_limit: 0,
+            max_file_size: 0,
+            max_vaults: 0,
+            version_history_days: 0,
+            paddle_customer_id: null,
+            paddle_subscription_id: null,
+            paddle_transaction_id: null,
+            expires_at: null
+          }
+        ]
+      })
+
+      const res = await app.request('/auth/billing', { method: 'GET' }, env)
+
+      expect(res.status).toBe(200)
+      await expect(res.json()).resolves.toMatchObject({
+        plan: 'free',
+        status: 'inactive',
+        limits: { storageLimit: 0 },
+        usage: { storageUsed: 0 },
+        canManageBilling: false
+      })
+    })
+
+    it('reconciles a completed Paddle transaction for the authenticated user', async () => {
+      const paddleFetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: {
+              id: 'txn_1',
+              status: 'completed',
+              customer_id: 'ctm_1',
+              subscription_id: 'sub_1',
+              billing_period: { ends_at: '2026-06-01T00:00:00Z' },
+              custom_data: {
+                app: 'memry',
+                entitlement: 'sync',
+                plan: 'pro',
+                userId: 'user-1'
+              }
+            }
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      env = createEnv({
+        paddleFetch,
+        firstRows: [
+          {
+            user_id: 'user-1',
+            storage_used: 128,
+            plan: 'pro',
+            status: 'active',
+            source: 'paddle',
+            storage_limit: 10,
+            max_file_size: 5,
+            max_vaults: 10,
+            version_history_days: 365,
+            paddle_customer_id: 'ctm_1',
+            paddle_subscription_id: 'sub_1',
+            paddle_transaction_id: 'txn_1',
+            expires_at: 1_780_272_000
+          }
+        ]
+      })
+
+      const res = await app.request(
+        '/auth/billing/reconcile',
+        jsonPost('/auth/billing/reconcile', { transactionId: 'txn_1' }),
+        env
+      )
+
+      expect(res.status).toBe(200)
+      expect(paddleFetch).toHaveBeenCalledWith(
+        'https://sandbox-api.paddle.com/transactions/txn_1',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer pdl_sandbox_key' })
+        })
+      )
+      await expect(res.json()).resolves.toMatchObject({
+        plan: 'pro',
+        status: 'active',
+        canManageBilling: true
+      })
+    })
+
+    it('rejects reconcile when transaction custom data belongs to another user', async () => {
+      const paddleFetch = vi.fn().mockResolvedValue(
+        Response.json({
+          data: {
+            id: 'txn_1',
+            status: 'completed',
+            customer_id: 'ctm_1',
+            custom_data: {
+              app: 'memry',
+              entitlement: 'sync',
+              plan: 'pro',
+              userId: 'user-2'
+            }
+          }
+        })
+      )
+      env = createEnv({ paddleFetch })
+
+      const res = await app.request(
+        '/auth/billing/reconcile',
+        jsonPost('/auth/billing/reconcile', { transactionId: 'txn_1' }),
+        env
+      )
+
+      expect(res.status).toBe(403)
+    })
+
+    it('rejects reconcile when transaction is not completed', async () => {
+      const paddleFetch = vi.fn().mockResolvedValue(
+        Response.json({
+          data: {
+            id: 'txn_1',
+            status: 'paid',
+            customer_id: 'ctm_1',
+            custom_data: {
+              app: 'memry',
+              entitlement: 'sync',
+              plan: 'pro',
+              userId: 'user-1'
+            }
+          }
+        })
+      )
+      env = createEnv({ paddleFetch })
+
+      const res = await app.request(
+        '/auth/billing/reconcile',
+        jsonPost('/auth/billing/reconcile', { transactionId: 'txn_1' }),
+        env
+      )
+
+      expect(res.status).toBe(409)
+    })
+
+    it('creates a temporary Paddle portal session when a customer exists', async () => {
+      const paddleFetch = vi.fn().mockResolvedValue(
+        Response.json(
+          {
+            data: {
+              urls: {
+                general: {
+                  overview: 'https://customer-portal.paddle.com/cpl_1?action=overview&token=tmp'
+                }
+              }
+            }
+          },
+          { status: 201 }
+        )
+      )
+      env = createEnv({
+        paddleFetch,
+        firstRows: [{ paddle_customer_id: 'ctm_1', paddle_subscription_id: 'sub_1' }]
+      })
+
+      const res = await app.request(
+        '/auth/billing/portal-session',
+        { method: 'POST', body: '{}', headers: { 'Content-Type': 'application/json' } },
+        env
+      )
+
+      expect(res.status).toBe(200)
+      expect(paddleFetch).toHaveBeenCalledWith(
+        'https://sandbox-api.paddle.com/customers/ctm_1/portal-sessions',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ subscription_ids: ['sub_1'] })
+        })
+      )
+      await expect(res.json()).resolves.toEqual({
+        portalUrl: 'https://customer-portal.paddle.com/cpl_1?action=overview&token=tmp'
+      })
+    })
+
+    it('returns 409 for portal sessions before Paddle customer creation', async () => {
+      env = createEnv({ firstRows: [{ paddle_customer_id: null, paddle_subscription_id: null }] })
+
+      const res = await app.request(
+        '/auth/billing/portal-session',
+        { method: 'POST', body: '{}', headers: { 'Content-Type': 'application/json' } },
+        env
+      )
+
+      expect(res.status).toBe(409)
     })
   })
 

--- a/apps/sync-server/src/routes/auth.ts
+++ b/apps/sync-server/src/routes/auth.ts
@@ -36,6 +36,11 @@ import {
 } from '../services/otp'
 import { getOrCreateUserByEmail, getUserByEmail, getUserById, updateUser } from '../services/user'
 import { signCheckoutToken, type CheckoutCadence } from '../services/checkout-token'
+import {
+  createPaddlePortalSession,
+  getBillingStatus,
+  reconcilePaddleTransaction
+} from '../services/paddle-billing'
 import type { AppContext } from '../types'
 
 const logger = createLogger('Auth')
@@ -450,6 +455,9 @@ const CheckoutTokenSchema = z.object({
   plan: z.enum(['plus', 'pro', 'believer']),
   cadence: z.enum(['monthly', 'annual', 'lifetime'])
 })
+const BillingReconcileSchema = z.object({
+  transactionId: z.string().trim().min(1).optional()
+})
 
 async function generateDummyRecoveryData(
   email: string,
@@ -568,6 +576,31 @@ auth.post('/checkout-token', authMiddleware, async (c) => {
   })
 
   return c.json({ checkoutToken, expiresAt })
+})
+
+auth.get('/billing', authMiddleware, async (c) => {
+  const userId = c.get('userId')!
+  return c.json(await getBillingStatus(c.env.DB, userId))
+})
+
+auth.post('/billing/reconcile', authMiddleware, async (c) => {
+  const body = await c.req.json()
+  const parsed = BillingReconcileSchema.safeParse(body)
+  if (!parsed.success) {
+    throw new AppError(ErrorCodes.VALIDATION_ERROR, 'Invalid billing reconcile request', 400)
+  }
+
+  const userId = c.get('userId')!
+  if (parsed.data.transactionId) {
+    await reconcilePaddleTransaction(c.env, userId, parsed.data.transactionId)
+  }
+
+  return c.json(await getBillingStatus(c.env.DB, userId))
+})
+
+auth.post('/billing/portal-session', authMiddleware, async (c) => {
+  const userId = c.get('userId')!
+  return c.json(await createPaddlePortalSession(c.env, userId))
 })
 
 // POST /refresh

--- a/apps/sync-server/src/services/entitlements.test.ts
+++ b/apps/sync-server/src/services/entitlements.test.ts
@@ -40,6 +40,9 @@ function entitlementRow(overrides: Partial<SyncEntitlement> = {}): SyncEntitleme
     max_file_size: SYNC_PLAN_LIMITS.plus.maxFileSize,
     max_vaults: SYNC_PLAN_LIMITS.plus.maxVaults,
     version_history_days: SYNC_PLAN_LIMITS.plus.versionHistoryDays,
+    paddle_customer_id: null,
+    paddle_subscription_id: null,
+    paddle_transaction_id: null,
     expires_at: null,
     ...overrides
   }

--- a/apps/sync-server/src/services/entitlements.ts
+++ b/apps/sync-server/src/services/entitlements.ts
@@ -24,6 +24,9 @@ export interface SyncEntitlement {
   max_file_size: number
   max_vaults: number | null
   version_history_days: number
+  paddle_customer_id: string | null
+  paddle_subscription_id: string | null
+  paddle_transaction_id: string | null
   expires_at: number | null
 }
 
@@ -88,6 +91,9 @@ export async function getSyncEntitlement(db: D1Database, userId: string): Promis
          COALESCE(e.max_file_size, 0) as max_file_size,
          e.max_vaults,
          COALESCE(e.version_history_days, 0) as version_history_days,
+         e.paddle_customer_id,
+         e.paddle_subscription_id,
+         e.paddle_transaction_id,
          e.expires_at
        FROM users u
        LEFT JOIN sync_entitlements e ON e.user_id = u.id

--- a/apps/sync-server/src/services/paddle-billing.ts
+++ b/apps/sync-server/src/services/paddle-billing.ts
@@ -1,0 +1,240 @@
+import { AppError, ErrorCodes } from '../lib/errors'
+import {
+  getSyncEntitlement,
+  upsertSyncEntitlement,
+  type SyncEntitlement,
+  type SyncPlan
+} from './entitlements'
+import type { Bindings } from '../types'
+
+export interface BillingStatusResponse {
+  plan: SyncEntitlement['plan']
+  status: SyncEntitlement['status']
+  source: SyncEntitlement['source']
+  limits: {
+    storageLimit: number
+    maxFileSize: number
+    maxVaults: number | null
+    versionHistoryDays: number
+  }
+  usage: {
+    storageUsed: number
+  }
+  expiresAt: number | null
+  canManageBilling: boolean
+}
+
+interface PaddleTransaction {
+  id?: string
+  status?: string
+  customer_id?: string | null
+  customerId?: string | null
+  subscription_id?: string | null
+  subscriptionId?: string | null
+  custom_data?: Record<string, unknown> | null
+  customData?: Record<string, unknown> | null
+  billing_period?: { ends_at?: string | null; endsAt?: string | null } | null
+  billingPeriod?: { ends_at?: string | null; endsAt?: string | null } | null
+}
+
+interface PaddleResponse<T> {
+  data?: T
+}
+
+export function formatBillingStatus(entitlement: SyncEntitlement): BillingStatusResponse {
+  return {
+    plan: entitlement.plan,
+    status: entitlement.status,
+    source: entitlement.source,
+    limits: {
+      storageLimit: entitlement.storage_limit,
+      maxFileSize: entitlement.max_file_size,
+      maxVaults: entitlement.max_vaults,
+      versionHistoryDays: entitlement.version_history_days
+    },
+    usage: {
+      storageUsed: entitlement.storage_used
+    },
+    expiresAt: entitlement.expires_at,
+    canManageBilling: Boolean(entitlement.paddle_customer_id)
+  }
+}
+
+export async function getBillingStatus(
+  db: D1Database,
+  userId: string
+): Promise<BillingStatusResponse> {
+  return formatBillingStatus(await getSyncEntitlement(db, userId))
+}
+
+export async function reconcilePaddleTransaction(
+  env: Bindings,
+  userId: string,
+  transactionId: string
+): Promise<void> {
+  const transaction = await fetchPaddleTransaction(env, transactionId)
+  if (transaction.status !== 'completed') {
+    throw new AppError(ErrorCodes.VALIDATION_ERROR, 'Transaction is not completed yet', 409)
+  }
+
+  const customData = readCustomData(transaction)
+  const transactionUserId = asString(customData.userId ?? customData.user_id)
+  const plan = normalizePlan(customData.plan)
+
+  if (!transactionUserId || !plan) {
+    throw new AppError(ErrorCodes.VALIDATION_ERROR, 'Transaction is not a Memry sync checkout', 400)
+  }
+  if (transactionUserId !== userId) {
+    throw new AppError(ErrorCodes.STORAGE_UNAUTHORIZED, 'Transaction belongs to another user', 403)
+  }
+
+  await upsertSyncEntitlement(env.DB, {
+    userId,
+    plan,
+    status: 'active',
+    source: 'paddle',
+    paddleCustomerId: asString(transaction.customer_id ?? transaction.customerId),
+    paddleSubscriptionId: asString(transaction.subscription_id ?? transaction.subscriptionId),
+    paddleTransactionId: asString(transaction.id) ?? transactionId,
+    expiresAt: parseTimestamp(readBillingPeriodEndsAt(transaction))
+  })
+}
+
+export async function createPaddlePortalSession(
+  env: Bindings,
+  userId: string
+): Promise<{ portalUrl: string }> {
+  const entitlement = await env.DB.prepare(
+    `SELECT paddle_customer_id, paddle_subscription_id
+     FROM sync_entitlements
+     WHERE user_id = ?`
+  )
+    .bind(userId)
+    .first<{ paddle_customer_id: string | null; paddle_subscription_id: string | null }>()
+
+  if (!entitlement?.paddle_customer_id) {
+    throw new AppError(
+      ErrorCodes.VALIDATION_ERROR,
+      'Billing portal is not available until Paddle creates a customer',
+      409
+    )
+  }
+
+  const apiKey = normalizePaddleApiKey(env.PADDLE_API_KEY)
+  if (!apiKey) {
+    throw new AppError(ErrorCodes.INTERNAL_ERROR, 'Paddle API key is not configured', 503)
+  }
+
+  const body =
+    entitlement.paddle_subscription_id != null
+      ? { subscription_ids: [entitlement.paddle_subscription_id] }
+      : {}
+  const response = await (env.fetch ?? fetch)(
+    `${getPaddleBaseUrl(env)}/customers/${encodeURIComponent(
+      entitlement.paddle_customer_id
+    )}/portal-sessions`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      },
+      body: JSON.stringify(body)
+    }
+  )
+
+  if (!response.ok) {
+    throw new AppError(ErrorCodes.INTERNAL_ERROR, 'Could not create billing portal session', 502)
+  }
+
+  const payload = (await response.json()) as PaddleResponse<{
+    urls?: { general?: { overview?: string } }
+  }>
+  const portalUrl = payload.data?.urls?.general?.overview
+  if (!portalUrl) {
+    throw new AppError(
+      ErrorCodes.INTERNAL_ERROR,
+      'Paddle portal session did not include a URL',
+      502
+    )
+  }
+
+  return { portalUrl }
+}
+
+async function fetchPaddleTransaction(
+  env: Bindings,
+  transactionId: string
+): Promise<PaddleTransaction> {
+  const apiKey = normalizePaddleApiKey(env.PADDLE_API_KEY)
+  if (!apiKey) {
+    throw new AppError(ErrorCodes.INTERNAL_ERROR, 'Paddle API key is not configured', 503)
+  }
+
+  const response = await (env.fetch ?? fetch)(
+    `${getPaddleBaseUrl(env)}/transactions/${encodeURIComponent(transactionId)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json'
+      }
+    }
+  )
+
+  if (response.status === 404) {
+    throw new AppError(ErrorCodes.NOT_FOUND, 'Paddle transaction not found', 404)
+  }
+  if (!response.ok) {
+    throw new AppError(ErrorCodes.INTERNAL_ERROR, 'Could not fetch Paddle transaction', 502)
+  }
+
+  const payload = (await response.json()) as PaddleResponse<PaddleTransaction>
+  if (!payload.data) {
+    throw new AppError(ErrorCodes.NOT_FOUND, 'Paddle transaction not found', 404)
+  }
+  return payload.data
+}
+
+function getPaddleBaseUrl(env: Pick<Bindings, 'PADDLE_ENVIRONMENT'>): string {
+  return env.PADDLE_ENVIRONMENT === 'production'
+    ? 'https://api.paddle.com'
+    : 'https://sandbox-api.paddle.com'
+}
+
+function readCustomData(transaction: PaddleTransaction): Record<string, unknown> {
+  const value = transaction.custom_data ?? transaction.customData
+  if (!value || typeof value !== 'object') return {}
+  if (value.app !== 'memry' || value.entitlement !== 'sync') return {}
+  return value
+}
+
+function normalizePlan(value: unknown): SyncPlan | null {
+  if (value === 'plus' || value === 'pro' || value === 'believer') return value
+  return null
+}
+
+function readBillingPeriodEndsAt(transaction: PaddleTransaction): unknown {
+  const value = transaction.billing_period ?? transaction.billingPeriod
+  if (!value || typeof value !== 'object') return null
+  return value.ends_at ?? value.endsAt
+}
+
+function parseTimestamp(value: unknown): number | null {
+  if (typeof value !== 'string') return null
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? null : Math.floor(timestamp / 1000)
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function normalizePaddleApiKey(value: string | undefined): string | undefined {
+  const trimmed = value
+    ?.trim()
+    .replace(/^Authorization:\s*/i, '')
+    .replace(/^Bearer\s+/i, '')
+  if (!trimmed) return undefined
+  return trimmed.replace(/^["']|["']$/g, '')
+}

--- a/apps/sync-server/src/types.ts
+++ b/apps/sync-server/src/types.ts
@@ -18,9 +18,12 @@ export type Bindings = {
   WEBHOOK_HMAC_KEY: string
   PADDLE_WEBHOOK_SECRET: string
   PADDLE_CHECKOUT_TOKEN_SECRET: string
+  PADDLE_API_KEY?: string
+  PADDLE_ENVIRONMENT?: string
   TELEMETRY_HMAC_KEY: string
   POSTHOG_API_KEY?: string
   POSTHOG_HOST?: string
+  fetch?: typeof fetch
 }
 
 export type AppContext = {

--- a/apps/sync-server/wrangler.test.ts
+++ b/apps/sync-server/wrangler.test.ts
@@ -24,11 +24,13 @@ describe('wrangler config', () => {
     expect(toml).toContain('name = "memry-sync-server-staging"')
     expect(toml).toContain('[env.staging.vars]')
     expect(toml).toContain('ENVIRONMENT = "staging"')
+    expect(toml).toContain('PADDLE_ENVIRONMENT = "sandbox"')
 
     expect(toml).toContain('[env.production]')
     expect(toml).toContain('name = "memry-sync-server-production"')
     expect(toml).toContain('[env.production.vars]')
     expect(toml).toContain('ENVIRONMENT = "production"')
+    expect(toml).toContain('PADDLE_ENVIRONMENT = "production"')
   })
 
   it('routes staging and production workers to separate sync hostnames', () => {

--- a/apps/sync-server/wrangler.toml
+++ b/apps/sync-server/wrangler.toml
@@ -6,6 +6,7 @@ compatibility_date = "2025-01-01"
 ENVIRONMENT = "development"
 MIN_APP_VERSION = "0.1.0"
 POSTHOG_HOST = "https://us.i.posthog.com"
+PADDLE_ENVIRONMENT = "sandbox"
 
 [[d1_databases]]
 binding = "DB"
@@ -40,6 +41,7 @@ ENVIRONMENT = "staging"
 ALLOWED_ORIGIN = "https://staging.memrynote.com"
 MIN_APP_VERSION = "0.1.0"
 POSTHOG_HOST = "https://us.i.posthog.com"
+PADDLE_ENVIRONMENT = "sandbox"
 
 [[env.staging.routes]]
 pattern = "sync-staging.memrynote.com/*"
@@ -71,6 +73,7 @@ ENVIRONMENT = "production"
 ALLOWED_ORIGIN = "https://memrynote.com"
 MIN_APP_VERSION = "0.1.0"
 POSTHOG_HOST = "https://us.i.posthog.com"
+PADDLE_ENVIRONMENT = "production"
 
 [[env.production.routes]]
 pattern = "sync.memrynote.com/*"

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -452,7 +452,15 @@ export const AccountChannels = {
     /** Sign out and clear local synced data */
     SIGN_OUT: 'account:signOut',
     /** Get recovery key (requires re-auth token) */
-    GET_RECOVERY_KEY: 'account:getRecoveryKey'
+    GET_RECOVERY_KEY: 'account:getRecoveryKey',
+    /** Start a signed Paddle checkout from the desktop app */
+    START_CHECKOUT: 'account:startCheckout',
+    /** Get current billing status */
+    GET_BILLING_STATUS: 'account:getBillingStatus',
+    /** Reconcile Paddle transaction and refresh billing status */
+    REFRESH_BILLING_STATUS: 'account:refreshBillingStatus',
+    /** Open Paddle customer portal */
+    OPEN_BILLING_PORTAL: 'account:openBillingPortal'
   }
 } as const
 

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -389,6 +389,7 @@
     "groups": {
       "identity": "Identity",
       "sync": "Sync",
+      "billing": "Billing",
       "storage": "Storage",
       "devices": "Devices",
       "security": "Security"
@@ -413,6 +414,47 @@
         "changesPending": "{count, plural, one {# change pending} other {# changes pending}}",
         "offlinePending": "Offline ({count, plural, one {# change pending} other {# changes pending}})",
         "never": "Never"
+      }
+    },
+    "billing": {
+      "planStatus": "Plan status",
+      "checking": "Checking billing status",
+      "plans": {
+        "free": "Free plan",
+        "plus": "Plus plan",
+        "pro": "Pro plan",
+        "believer": "Believer plan"
+      },
+      "statuses": {
+        "inactive": "Inactive",
+        "active": "Active",
+        "past_due": "Past due",
+        "paused": "Paused",
+        "canceled": "Canceled"
+      },
+      "labels": {
+        "storage": "Storage",
+        "maxFile": "Max file",
+        "vaults": "Vaults",
+        "history": "History"
+      },
+      "unlimited": "Unlimited",
+      "historyDays": "{days} days",
+      "activationPendingPrefix": "Activation pending. Paddle can take a moment to confirm checkout. Refresh status or email",
+      "actions": {
+        "upgrade": "Upgrade",
+        "opening": "Opening...",
+        "refresh": "Refresh status",
+        "manage": "Manage billing"
+      },
+      "toasts": {
+        "loadFailed": "Could not load billing status",
+        "checkoutFailed": "Could not start checkout",
+        "checkoutOpened": "Checkout opened in your browser",
+        "refreshFailed": "Could not refresh billing status",
+        "billingActive": "Billing is active",
+        "activationPending": "Activation pending",
+        "portalFailed": "Could not open billing portal"
       }
     },
     "storage": {


### PR DESCRIPTION
## Summary

- add desktop-owned checkout, billing status, reconcile, and Paddle portal flows
- wire landing pricing to Paddle checkout tokens, success/cancel/failure states, and Memry deep links
- add sync-server billing status, reconcile, and portal session APIs
- document the paid sync billing loop and entitlement endpoints

## Notes

Refunds and chargebacks stay manual via email/Paddle dashboard for this pass.

## Verification

- node --import tsx --test apps/landing/api/paddle-checkout-client.test.mjs
- pnpm --dir apps/desktop exec vitest run src/main/ipc/account-handlers.test.ts --config config/vitest.config.ts --project main
- pnpm --filter @memry/sync-server test -- src/routes/auth.test.ts
- pnpm --dir apps/desktop exec vitest run src/renderer/src/pages/settings/settings-sections.test.tsx --config config/vitest.config.ts --project renderer
- pnpm --dir apps/desktop exec vitest run src/preload/api/preload-api.test.ts --config config/vitest.config.ts --project preload
- pnpm --dir apps/desktop exec vitest run src/main/index.phase2.test.ts --config config/vitest.config.ts --project main
- pnpm --filter @memry/desktop typecheck:node
- pnpm --filter @memry/desktop typecheck:web
- pnpm --filter @memry/landing typecheck
- pnpm --filter @memry/sync-server typecheck
- pnpm ipc:generate
- pnpm ipc:check
- npx -y react-doctor@latest . --verbose --diff
- pnpm docs:impact --base c89597458b33f49881975da9fde91e0faed5370d --strict
- pnpm docs:build
- pnpm --dir apps/desktop i18n:codemod:todo:check
- pnpm --dir apps/desktop i18n:check
- git diff --check