### PR TITLE
Add landing search crawl signals

### DIFF
--- a/apps/landing/scripts/prerender.ts
+++ b/apps/landing/scripts/prerender.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createServer } from 'vite'
+import { buildRobotsTxt, buildSitemapXml } from '../src/lib/crawl-files.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
@@ -38,6 +39,10 @@ function stripSeoTags(html: string): string {
   return cleaned
 }
 
+function markHelmetManagedHeadTags(headTags: string): string {
+  return headTags.replace(/<(title|meta|link|script)\b(?![^>]*\bdata-rh=)/g, '<$1 data-rh="true"')
+}
+
 async function prerender() {
   const vite = await createServer({
     root: ROOT,
@@ -55,7 +60,8 @@ async function prerender() {
 
     for (const route of ROUTES as string[]) {
       const { html: appHtml } = render(route)
-      const { cleaned: cleanedAppHtml, headTags } = extractSeoTags(appHtml)
+      const { cleaned: cleanedAppHtml, headTags: embeddedHeadTags } = extractSeoTags(appHtml)
+      const headTags = markHelmetManagedHeadTags(embeddedHeadTags)
 
       let page = templateWithoutSeo.replace(
         '<div id="root"></div>',
@@ -73,8 +79,20 @@ async function prerender() {
         route === '/' ? path.resolve(DIST, 'index.html') : path.resolve(dir, 'index.html')
 
       fs.writeFileSync(outFile, page)
+
+      if (route !== '/') {
+        const flatOutFile = path.resolve(DIST, `${route.slice(1)}.html`)
+        fs.mkdirSync(path.dirname(flatOutFile), { recursive: true })
+        fs.writeFileSync(flatOutFile, page)
+      }
+
       console.log(`  prerendered: ${route} -> ${path.relative(ROOT, outFile)}`)
     }
+
+    fs.writeFileSync(path.resolve(DIST, 'sitemap.xml'), buildSitemapXml())
+    fs.writeFileSync(path.resolve(DIST, 'robots.txt'), buildRobotsTxt())
+    console.log('  wrote: dist/sitemap.xml')
+    console.log('  wrote: dist/robots.txt')
 
     console.log(`\n  ${ROUTES.length} routes prerendered.`)
   } finally {

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -16,6 +16,7 @@ import { DownloadDesktopPage } from '@/pages/DownloadDesktop'
 import { UseCasesPage } from '@/pages/UseCases'
 import { SecurityPage } from '@/pages/Security'
 import { PricingPage } from '@/pages/Pricing'
+import { ChangelogPage } from '@/pages/Changelog'
 import { RoadmapPage } from '@/pages/Roadmap'
 import { TermsPage } from '@/pages/Terms'
 import { PrivacyPage } from '@/pages/Privacy'
@@ -128,6 +129,7 @@ function AppContent() {
           <Route path="/use-cases" element={<UseCasesPage />} />
           <Route path="/security" element={<SecurityPage />} />
           <Route path="/pricing" element={<PricingPage />} />
+          <Route path="/changelog" element={<ChangelogPage />} />
           <Route path="/roadmap" element={<RoadmapPage />} />
           <Route path="/terms" element={<TermsPage />} />
           <Route path="/privacy" element={<PrivacyPage />} />

--- a/apps/landing/src/entry-server.tsx
+++ b/apps/landing/src/entry-server.tsx
@@ -16,6 +16,7 @@ import { DownloadDesktopPage } from '@/pages/DownloadDesktop'
 import { UseCasesPage } from '@/pages/UseCases'
 import { SecurityPage } from '@/pages/Security'
 import { PricingPage } from '@/pages/Pricing'
+import { ChangelogPage } from '@/pages/Changelog'
 import { RoadmapPage } from '@/pages/Roadmap'
 import { TermsPage } from '@/pages/Terms'
 import { PrivacyPage } from '@/pages/Privacy'
@@ -34,6 +35,7 @@ const ROUTE_MAP: Record<string, () => ReactNode> = {
   '/use-cases': () => <UseCasesPage />,
   '/security': () => <SecurityPage />,
   '/pricing': () => <PricingPage />,
+  '/changelog': () => <ChangelogPage />,
   '/roadmap': () => <RoadmapPage />,
   '/terms': () => <TermsPage />,
   '/privacy': () => <PrivacyPage />,

--- a/apps/landing/src/lib/constants.ts
+++ b/apps/landing/src/lib/constants.ts
@@ -125,9 +125,8 @@ export const DOWNLOAD_NAV_ITEMS: readonly LandingDropdownItem[] = [
   {
     label: 'memrynote for Desktop',
     description: DESKTOP_RELEASE_TIMING,
-    href: '#',
-    icon: Monitor,
-    disabled: true
+    href: '/download/desktop',
+    icon: Monitor
   },
   {
     label: 'memrynote CLI',
@@ -140,13 +139,16 @@ export const DOWNLOAD_NAV_ITEMS: readonly LandingDropdownItem[] = [
 
 export const DIRECT_NAV_LINKS = [
   { label: 'Pricing', href: '/pricing' },
-  { label: 'Roadmap', href: '/roadmap' }
+  { label: 'Roadmap', href: '/roadmap' },
+  { label: 'Changelog', href: '/changelog' }
 ] as const
 
 export const FOOTER_LINKS = {
   product: [
-    { label: 'Features', href: '#features' },
+    { label: 'Features', href: '/features' },
+    { label: 'Download', href: '/download/desktop' },
     { label: 'Pricing', href: '/pricing' },
+    { label: 'Changelog', href: '/changelog' },
     { label: 'Security', href: '/security' }
   ],
   resources: [

--- a/apps/landing/src/lib/crawl-files.test.ts
+++ b/apps/landing/src/lib/crawl-files.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { buildRobotsTxt, buildSitemapXml, getIndexablePaths } from './crawl-files.ts'
+import { BASE_URL, SITELINK_CANDIDATE_PATHS } from './seo.ts'
+
+describe('landing crawl files', () => {
+  it('indexes every metadata-backed route once', () => {
+    const paths = getIndexablePaths()
+
+    assert.equal(new Set(paths).size, paths.length)
+
+    for (const path of SITELINK_CANDIDATE_PATHS) {
+      assert.ok(paths.includes(path), `${path} is missing from indexable paths`)
+    }
+  })
+
+  it('builds an XML sitemap with absolute memrynote.com URLs', () => {
+    const sitemap = buildSitemapXml(['/', '/pricing', '/changelog'])
+
+    assert.match(sitemap, /^<\?xml version="1\.0" encoding="UTF-8"\?>/)
+    assert.match(sitemap, /<loc>https:\/\/memrynote\.com\/<\/loc>/)
+    assert.match(sitemap, /<loc>https:\/\/memrynote\.com\/pricing<\/loc>/)
+    assert.match(sitemap, /<loc>https:\/\/memrynote\.com\/changelog<\/loc>/)
+    assert.doesNotMatch(sitemap, /memrynote\.ai/)
+  })
+
+  it('builds robots.txt pointing crawlers at the sitemap', () => {
+    assert.equal(buildRobotsTxt(), `User-agent: *\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml\n`)
+  })
+})

--- a/apps/landing/src/lib/crawl-files.ts
+++ b/apps/landing/src/lib/crawl-files.ts
@@ -1,0 +1,36 @@
+import { BASE_URL, PAGE_META } from './seo'
+
+function toAbsoluteUrl(path: string) {
+  return path === '/' ? `${BASE_URL}/` : `${BASE_URL}${path}`
+}
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}
+
+export function getIndexablePaths(): string[] {
+  return Object.values(PAGE_META).map((meta) => meta.path)
+}
+
+export function buildSitemapXml(paths: readonly string[] = getIndexablePaths()): string {
+  const urls = paths
+    .map((path) => `  <url>\n    <loc>${escapeXml(toAbsoluteUrl(path))}</loc>\n  </url>`)
+    .join('\n')
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    urls,
+    '</urlset>',
+    ''
+  ].join('\n')
+}
+
+export function buildRobotsTxt(): string {
+  return `User-agent: *\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml\n`
+}

--- a/apps/landing/src/lib/seo.test.ts
+++ b/apps/landing/src/lib/seo.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { describe, it } from 'node:test'
+
+import { DIRECT_NAV_LINKS, DOWNLOAD_NAV_ITEMS, FOOTER_LINKS } from './constants.ts'
+import {
+  BASE_URL,
+  getCanonicalUrl,
+  getWebsiteJsonLd,
+  PAGE_META,
+  SITELINK_CANDIDATE_PATHS
+} from './seo.ts'
+
+describe('landing SEO signals', () => {
+  it('uses memrynote.com as the canonical host', () => {
+    assert.equal(BASE_URL, 'https://memrynote.com')
+    assert.equal(getCanonicalUrl('/pricing'), 'https://memrynote.com/pricing')
+    assert.doesNotMatch(JSON.stringify(PAGE_META), /memrynote\.ai/)
+  })
+
+  it('keeps landing deployment config focused on memrynote.com', () => {
+    const vercelConfig = readFileSync(new URL('../../vercel.json', import.meta.url), 'utf8')
+
+    assert.doesNotMatch(vercelConfig, /memrynote\.ai/)
+  })
+
+  it('keeps the main sitelink candidates as real route metadata', () => {
+    assert.deepEqual(SITELINK_CANDIDATE_PATHS, [
+      '/',
+      '/features',
+      '/pricing',
+      '/download/desktop',
+      '/changelog',
+      '/roadmap'
+    ])
+
+    const indexedPaths = new Set(Object.values(PAGE_META).map((meta) => meta.path))
+
+    for (const path of SITELINK_CANDIDATE_PATHS) {
+      assert.ok(indexedPaths.has(path), `${path} is missing PAGE_META`)
+    }
+  })
+
+  it('links the main sitelink candidates from visible navigation surfaces', () => {
+    assert.ok(DIRECT_NAV_LINKS.some((link) => link.href === '/changelog'))
+    assert.ok(FOOTER_LINKS.product.some((link) => link.href === '/features'))
+    assert.ok(FOOTER_LINKS.product.some((link) => link.href === '/changelog'))
+
+    const desktopDownload = DOWNLOAD_NAV_ITEMS.find((item) => item.href === '/download/desktop')
+
+    assert.equal(desktopDownload?.label, 'memrynote for Desktop')
+    assert.notEqual(desktopDownload?.disabled, true)
+  })
+
+  it('emits WebSite JSON-LD for Google site identity', () => {
+    const website = JSON.parse(getWebsiteJsonLd())
+
+    assert.equal(website['@context'], 'https://schema.org')
+    assert.equal(website['@type'], 'WebSite')
+    assert.equal(website.name, 'memrynote')
+    assert.deepEqual(website.alternateName, ['Memry Note', 'memrynote.com'])
+    assert.equal(website.url, 'https://memrynote.com/')
+    assert.equal(website.potentialAction, undefined)
+  })
+})

--- a/apps/landing/src/lib/seo.ts
+++ b/apps/landing/src/lib/seo.ts
@@ -1,5 +1,6 @@
 export const BASE_URL = 'https://memrynote.com'
 export const SITE_NAME = 'memrynote'
+export const ALTERNATE_SITE_NAMES = ['Memry Note', 'memrynote.com'] as const
 export const TWITTER_HANDLE = '@h4yfans'
 export const SOCIAL_IMAGE_PATH = '/og-image.png'
 export const SOCIAL_IMAGE_URL = `${BASE_URL}${SOCIAL_IMAGE_PATH}`
@@ -87,8 +88,14 @@ export const PAGE_META: Record<string, PageMeta> = {
       'Local-first stays free, forever. Plus adds 1 GB sync, Pro adds 10 GB and 10 vaults, and Believer supports independent software with 50 GB and unlimited vaults.',
     path: '/pricing'
   },
+  changelog: {
+    title: 'Changelog — memrynote',
+    description:
+      'Follow the latest memrynote product updates, release notes, fixes, and shipped features.',
+    path: '/changelog'
+  },
   roadmap: {
-    title: 'Roadmap — Memry',
+    title: 'Roadmap — memrynote',
     description:
       'What is shipping now, what is planned next, and what we have already launched. We update this page as we ship.',
     path: '/roadmap'
@@ -113,13 +120,29 @@ export const PAGE_META: Record<string, PageMeta> = {
   }
 }
 
+export const SITELINK_CANDIDATE_PATHS = [
+  '/',
+  '/features',
+  '/pricing',
+  '/download/desktop',
+  '/changelog',
+  '/roadmap'
+] as const
+
 export function getCanonicalUrl(path: string): string {
   return `${BASE_URL}${path}`
 }
 
-export function getJsonLd(): string {
-  return JSON.stringify({
-    '@context': 'https://schema.org',
+function getWebsiteJsonLdObject() {
+  return {
+    name: 'memrynote',
+    alternateName: ALTERNATE_SITE_NAMES,
+    url: `${BASE_URL}/`
+  }
+}
+
+function getSoftwareApplicationJsonLdObject() {
+  return {
     '@type': 'SoftwareApplication',
     name: 'memrynote',
     applicationCategory: 'ProductivityApplication',
@@ -157,5 +180,26 @@ export function getJsonLd(): string {
       name: 'memrynote',
       url: BASE_URL
     }
+  }
+}
+
+export function getWebsiteJsonLd(): string {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    ...getWebsiteJsonLdObject(),
+    '@type': 'WebSite'
+  })
+}
+
+export function getJsonLd(): string {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        ...getWebsiteJsonLdObject(),
+        '@type': 'WebSite'
+      },
+      getSoftwareApplicationJsonLdObject()
+    ]
   })
 }

--- a/apps/landing/src/main.tsx
+++ b/apps/landing/src/main.tsx
@@ -4,7 +4,13 @@ import 'lenis/dist/lenis.css'
 import './index.css'
 import App from './App.tsx'
 
-createRoot(document.getElementById('root')!).render(
+const root = document.getElementById('root')!
+
+if (root.hasChildNodes()) {
+  document.head.querySelectorAll('[data-rh="true"]').forEach((node) => node.remove())
+}
+
+createRoot(root).render(
   <StrictMode>
     <App />
   </StrictMode>

--- a/apps/landing/src/pages/Changelog.tsx
+++ b/apps/landing/src/pages/Changelog.tsx
@@ -1,0 +1,156 @@
+import rawChangelog from '../../../../CHANGELOG.md?raw'
+import { ArrowRight, FileText } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { Container } from '@/components/layout/Container'
+import { PageHead } from '@/components/shared/PageHead'
+import { GITHUB_URL } from '@/lib/constants'
+import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from '@/lib/motion'
+
+interface ChangelogSection {
+  label: string
+  items: string[]
+}
+
+interface ChangelogEntry {
+  date: string
+  title: string
+  sections: ChangelogSection[]
+}
+
+const ENTRY_HEADING = /^##\s+(\d{4}-\d{2}-\d{2})\s+—\s+(.+)$/
+const SECTION_HEADING = /^###\s+(.+)$/
+const MAX_ENTRIES = 12
+
+function parseChangelog(markdown: string): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = []
+  let currentEntry: ChangelogEntry | null = null
+  let currentSection: ChangelogSection | null = null
+
+  for (const line of markdown.split('\n')) {
+    const entryMatch = line.match(ENTRY_HEADING)
+
+    if (entryMatch) {
+      currentEntry = {
+        date: entryMatch[1],
+        title: entryMatch[2],
+        sections: []
+      }
+      entries.push(currentEntry)
+      currentSection = null
+      continue
+    }
+
+    if (!currentEntry) continue
+
+    const sectionMatch = line.match(SECTION_HEADING)
+
+    if (sectionMatch) {
+      currentSection = {
+        label: sectionMatch[1],
+        items: []
+      }
+      currentEntry.sections.push(currentSection)
+      continue
+    }
+
+    if (currentSection && line.startsWith('- ')) {
+      currentSection.items.push(cleanChangelogText(line.slice(2)))
+    }
+  }
+
+  return entries
+    .map((entry) => ({
+      ...entry,
+      sections: entry.sections.filter((section) => section.items.length > 0)
+    }))
+    .filter((entry) => entry.sections.length > 0)
+}
+
+function cleanChangelogText(text: string) {
+  return text.replace(/`([^`]+)`/g, '$1').replace(/\*\*([^*]+)\*\*/g, '$1')
+}
+
+const CHANGELOG_ENTRIES = parseChangelog(rawChangelog).slice(0, MAX_ENTRIES)
+
+export function ChangelogPage() {
+  return (
+    <>
+      <PageHead page="changelog" />
+      <main className="pt-32 pb-24 md:pt-40">
+        <Container size="md">
+          <motion.section
+            initial={BLUR_REVEAL_INITIAL}
+            animate={BLUR_REVEAL_ANIMATE}
+            transition={BLUR_REVEAL_TRANSITION}
+            className="border-b border-border pb-12"
+          >
+            <p className="font-mono-accent text-xs uppercase tracking-[0.18em] text-terracotta">
+              Release notes
+            </p>
+            <h1 className="mt-4 font-serif text-5xl leading-[1.05] text-ink md:text-6xl">
+              Changelog
+            </h1>
+            <p className="mt-5 max-w-2xl text-lg leading-relaxed text-muted">
+              Recent product updates, fixes, and shipped Memry work. For every tagged desktop
+              release, use GitHub releases.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3 text-sm">
+              <a
+                href={`${GITHUB_URL}/releases`}
+                className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 font-medium text-ink transition-colors hover:border-terracotta/30 hover:text-terracotta"
+              >
+                GitHub releases
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </a>
+              <Link
+                to="/roadmap"
+                className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 font-medium text-ink transition-colors hover:border-terracotta/30 hover:text-terracotta"
+              >
+                Roadmap
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </Link>
+            </div>
+          </motion.section>
+
+          <section className="divide-y divide-border">
+            {CHANGELOG_ENTRIES.map((entry) => (
+              <article key={`${entry.date}-${entry.title}`} className="py-10">
+                <div className="grid gap-5 md:grid-cols-[150px_1fr] md:gap-10">
+                  <div>
+                    <p className="font-mono-accent text-xs uppercase tracking-[0.18em] text-muted">
+                      {entry.date}
+                    </p>
+                  </div>
+                  <div>
+                    <h2 className="font-serif text-2xl leading-tight text-ink md:text-3xl">
+                      {entry.title}
+                    </h2>
+                    <div className="mt-6 grid gap-6">
+                      {entry.sections.map((section) => (
+                        <section key={`${entry.date}-${section.label}`}>
+                          <h3 className="inline-flex items-center gap-2 font-mono-accent text-xs uppercase tracking-[0.18em] text-terracotta">
+                            <FileText className="h-3.5 w-3.5" aria-hidden />
+                            {section.label}
+                          </h3>
+                          <ul className="mt-3 grid gap-3 text-base leading-relaxed text-muted">
+                            {section.items.map((item) => (
+                              <li key={item} className="flex gap-3">
+                                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-terracotta/70" />
+                                <span>{item}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </section>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </section>
+        </Container>
+      </main>
+    </>
+  )
+}

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -11,18 +11,6 @@
       "has": [{ "type": "host", "value": "www.memrynote.com" }],
       "destination": "https://memrynote.com/:path",
       "permanent": true
-    },
-    {
-      "source": "/:path(.*)",
-      "has": [{ "type": "host", "value": "memrynote.ai" }],
-      "destination": "https://memrynote.com/:path",
-      "permanent": true
-    },
-    {
-      "source": "/:path(.*)",
-      "has": [{ "type": "host", "value": "www.memrynote.ai" }],
-      "destination": "https://memrynote.com/:path",
-      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a real /changelog landing route sourced from CHANGELOG.md
- generate sitemap.xml and robots.txt from landing page metadata during prerender
- add WebSite JSON-LD, stronger sitelink candidate metadata, and .com-only deployment config
- link key crawl targets from landing nav/footer and keep hydrated canonical tags clean

## Validation
- pnpm --filter @memry/landing exec tsx --test src/lib/seo.test.ts src/lib/crawl-files.test.ts
- pnpm --filter @memry/landing lint
- pnpm --filter @memry/landing build
- git diff --check origin/main..HEAD
- .ai reference scan outside node_modules/dist
- Playwright smoke for /changelog title, H1, canonical, and nav links

## Manual follow-up
- remove memrynote.ai / www.memrynote.ai from Vercel/DNS if fully dropping the domain
- submit https://memrynote.com/sitemap.xml in Google Search Console
- request indexing for /, /features, /pricing, /download/desktop, /changelog, /roadmap