### PR TITLE
Add PostHog diagnostics and server error capture

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -37,6 +37,7 @@ import { stopVoiceModel } from './inbox/voice-model'
 import { startReminderScheduler, stopReminderScheduler } from './lib/reminders'
 import { disposeTelemetryRuntime, initializeTelemetryRuntime } from './telemetry/runtime'
 import { getTelemetryAuthState, getTelemetrySyncState } from './telemetry/state'
+import { trackLaunchPhase, trackMainError, trackMainLog } from './telemetry/diagnostics'
 import {
   startGoogleCalendarSyncRunner,
   stopGoogleCalendarSyncRunner,
@@ -88,6 +89,38 @@ function resolveDeviceId(): string | undefined {
 }
 
 const deviceId = resolveDeviceId()
+const launchStartedAt = Date.now()
+
+let mainDiagnosticsRegistered = false
+
+function registerMainDiagnostics(): void {
+  if (mainDiagnosticsRegistered) return
+  mainDiagnosticsRegistered = true
+
+  process.on('uncaughtException', (error) => {
+    trackMainError('main_process', 'uncaught_exception', error)
+  })
+
+  process.on('unhandledRejection', (reason) => {
+    trackMainError('main_process', 'unhandled_rejection', reason)
+  })
+
+  app.on('render-process-gone', (_event, _webContents, details) => {
+    trackMainLog('error', {
+      scope: 'Electron',
+      action: 'render_process_gone',
+      errorCode: details.reason
+    })
+  })
+
+  app.on('child-process-gone', (_event, details) => {
+    trackMainLog('error', {
+      scope: 'Electron',
+      action: 'child_process_gone',
+      errorCode: details.type
+    })
+  })
+}
 if (deviceId) {
   process.env.MEMRY_DEVICE = deviceId
   app.name = `memry-${deviceId}`
@@ -376,6 +409,7 @@ function createWindow(): void {
       sandbox: false
     }
   })
+  trackLaunchPhase('window_created', Date.now() - launchStartedAt)
 
   const unsubscribeVaultStatus = onVaultStatusChanged((status) => {
     resizeWindowIfNeeded(
@@ -389,6 +423,11 @@ function createWindow(): void {
     // Zoom out once (equivalent to Cmd+-)
     // mainWindow.webContents.setZoomLevel(-0.8)
     mainWindow.show()
+    trackLaunchPhase('window_ready_to_show', Date.now() - launchStartedAt)
+  })
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    trackLaunchPhase('window_did_finish_load', Date.now() - launchStartedAt)
   })
 
   mainWindow.on('focus', () => {
@@ -660,6 +699,8 @@ void app.whenReady().then(async () => {
     authStateProvider: getTelemetryAuthState,
     syncStateProvider: getTelemetrySyncState
   })
+  registerMainDiagnostics()
+  trackLaunchPhase('app_ready', Date.now() - launchStartedAt)
 
   registerAllHandlers({ i18n: mainI18n, rebuildMenu })
 
@@ -846,17 +887,35 @@ void app.whenReady().then(async () => {
         startSnoozeScheduler()
       } catch (error) {
         mainLog.warn('snooze scheduler failed to start:', error)
+        trackMainLog('warn', {
+          scope: 'Startup',
+          action: 'snooze_scheduler_start_failed',
+          errorCode: error instanceof Error ? error.name : 'UnknownError'
+        })
       }
       try {
         startReminderScheduler()
       } catch (error) {
         mainLog.warn('reminder scheduler failed to start:', error)
+        trackMainLog('warn', {
+          scope: 'Startup',
+          action: 'reminder_scheduler_start_failed',
+          errorCode: error instanceof Error ? error.name : 'UnknownError'
+        })
       }
       void startGoogleCalendarSyncRunner().catch((error) => {
         mainLog.warn('Google Calendar sync runner failed to start:', error)
+        trackMainLog('warn', {
+          scope: 'Startup',
+          action: 'google_calendar_sync_start_failed',
+          errorCode: error instanceof Error ? error.name : 'UnknownError'
+        })
       })
     })
-    .catch((err) => mainLog.error('autoOpenLastVault failed:', err))
+    .catch((err) => {
+      mainLog.error('autoOpenLastVault failed:', err)
+      trackMainError('main_process', 'auto_open_last_vault_failed', err)
+    })
 
   app.on('activate', function () {
     // On macOS it's common to re-create a window in the app when the

--- a/apps/desktop/src/main/telemetry/diagnostics.test.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { trackMainEventMock } = vi.hoisted(() => ({
+  trackMainEventMock: vi.fn()
+}))
+
+vi.mock('./track', () => ({
+  trackMainEvent: trackMainEventMock
+}))
+
+import { trackLaunchPhase, trackMainError, trackMainLog } from './diagnostics'
+
+describe('telemetry diagnostics', () => {
+  beforeEach(() => {
+    trackMainEventMock.mockReset()
+  })
+
+  it('emits sanitized main-process errors without raw messages', () => {
+    // #given an error containing private-looking text in the message
+    const error = new TypeError('failed at /Users/kaan/private-note.md')
+
+    // #when tracking the error
+    trackMainError('main_process', 'unhandled_exception', error)
+
+    // #then only stable diagnostic metadata is sent
+    expect(trackMainEventMock).toHaveBeenCalledWith(
+      'app_error_seen',
+      expect.objectContaining({
+        surface: 'app',
+        action: 'unhandled_exception',
+        objectType: 'exception',
+        source: 'main_process',
+        result: 'failed',
+        errorCode: 'TypeError'
+      })
+    )
+    expect(JSON.stringify(trackMainEventMock.mock.calls[0])).not.toContain('private-note')
+  })
+
+  it('emits structured remote log breadcrumbs', () => {
+    // #given a warning from a known app scope
+    trackMainLog('warn', {
+      scope: 'TelemetryRuntime',
+      action: 'flush_failed',
+      errorCode: 'NetworkError'
+    })
+
+    // #then it becomes a typed log event
+    expect(trackMainEventMock).toHaveBeenCalledWith('app_log_recorded', {
+      surface: 'app',
+      action: 'warn',
+      objectType: 'log',
+      source: 'TelemetryRuntime',
+      result: 'failed',
+      errorCode: 'NetworkError',
+      dimensions: { log_action: 'flush_failed' }
+    })
+  })
+
+  it('emits launch phase timings', () => {
+    // #given a completed launch phase
+    trackLaunchPhase('renderer_ready', 128)
+
+    // #then phase and duration are recorded without free-form text
+    expect(trackMainEventMock).toHaveBeenCalledWith('app_launch_phase_completed', {
+      surface: 'app',
+      action: 'renderer_ready',
+      source: 'main_process',
+      result: 'success',
+      metrics: { durationMs: 128 }
+    })
+  })
+})

--- a/apps/desktop/src/main/telemetry/diagnostics.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.ts
@@ -1,0 +1,76 @@
+import type { TelemetryResult } from '@memry/contracts/telemetry-api'
+
+import { trackMainEvent, type TrackMainEventOptions } from './track'
+
+type DiagnosticLevel = 'debug' | 'info' | 'warn' | 'error'
+
+const SAFE_TOKEN = /^(?!.*@)(?!.*:\/\/)(?!.*[/\\]).{1,64}$/
+
+const toSafeToken = (value: unknown, fallback: string): string => {
+  const raw = value instanceof Error ? value.name : String(value ?? '')
+  const token = raw.replace(/[^A-Za-z0-9_.:-]/g, '_').slice(0, 64)
+  return SAFE_TOKEN.test(token) ? token : fallback
+}
+
+const toErrorCode = (error: unknown): string => {
+  if (error instanceof Error && error.name) {
+    return toSafeToken(error.name, 'Error')
+  }
+  if (error && typeof error === 'object' && error.constructor?.name) {
+    return toSafeToken(error.constructor.name, 'UnknownError')
+  }
+  if (typeof error === 'string') return 'StringError'
+  return 'UnknownError'
+}
+
+const resultForLevel = (level: DiagnosticLevel): TelemetryResult =>
+  level === 'error' || level === 'warn' ? 'failed' : 'success'
+
+export const trackMainError = (source: string, action: string, error: unknown): void => {
+  trackMainEvent('app_error_seen', {
+    surface: 'app',
+    action: toSafeToken(action, 'error'),
+    objectType: 'exception',
+    source: toSafeToken(source, 'main_process'),
+    result: 'failed',
+    errorCode: toErrorCode(error)
+  })
+}
+
+export const trackMainLog = (
+  level: DiagnosticLevel,
+  options: {
+    scope: string
+    action: string
+    errorCode?: string
+    metrics?: { durationMs?: number; itemCount?: number; queueCount?: number; retryCount?: number }
+  }
+): void => {
+  const eventOptions: TrackMainEventOptions = {
+    surface: 'app',
+    action: level,
+    objectType: 'log',
+    source: toSafeToken(options.scope, 'main_process'),
+    result: resultForLevel(level),
+    dimensions: { log_action: toSafeToken(options.action, 'event') }
+  }
+
+  if (options.errorCode) {
+    eventOptions.errorCode = toSafeToken(options.errorCode, 'LogError')
+  }
+  if (options.metrics) {
+    eventOptions.metrics = options.metrics
+  }
+
+  trackMainEvent('app_log_recorded', eventOptions)
+}
+
+export const trackLaunchPhase = (phase: string, durationMs: number): void => {
+  trackMainEvent('app_launch_phase_completed', {
+    surface: 'app',
+    action: toSafeToken(phase, 'phase'),
+    source: 'main_process',
+    result: 'success',
+    metrics: { durationMs: Math.max(0, Math.round(durationMs)) }
+  })
+}

--- a/apps/desktop/src/renderer/src/components/journal/journal-error-boundary.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-error-boundary.tsx
@@ -13,6 +13,7 @@ import { Translation } from 'react-i18next'
 import { AlertTriangle, RefreshCw, Calendar } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { createLogger } from '@/lib/logger'
+import { trackRendererError } from '@/lib/telemetry-diagnostics'
 
 const log = createLogger('Component:JournalErrorBoundary')
 
@@ -53,6 +54,7 @@ export class JournalErrorBoundary extends Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     log.error('Journal crash', error, errorInfo)
+    trackRendererError('journal_error_boundary', error)
     this.props.onError?.(error, errorInfo)
   }
 
@@ -114,7 +116,7 @@ export class JournalErrorBoundary extends Component<
                     <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
                       {t('section.technicalDetails')}
                     </summary>
-                    <code className="mt-2 block text-xs bg-muted p-2 rounded overflow-auto max-h-24 text-left">
+                    <code className="mt-2 block text-xs bg-muted p-2 rounded overflow-auto max-h-24 text-start">
                       {this.state.error.message}
                       {this.state.error.stack && (
                         <>
@@ -132,7 +134,7 @@ export class JournalErrorBoundary extends Component<
                     size="sm"
                     aria-label={t('action.reloadJournal')}
                   >
-                    <RefreshCw className="w-4 h-4 mr-2" aria-hidden="true" />
+                    <RefreshCw className="w-4 h-4 me-2" aria-hidden="true" />
                     {t('action.reloadJournal')}
                   </Button>
                   <Button
@@ -141,7 +143,7 @@ export class JournalErrorBoundary extends Component<
                     size="sm"
                     aria-label={t('action.goToToday')}
                   >
-                    <Calendar className="w-4 h-4 mr-2" aria-hidden="true" />
+                    <Calendar className="w-4 h-4 me-2" aria-hidden="true" />
                     {t('action.goToToday')}
                   </Button>
                 </div>

--- a/apps/desktop/src/renderer/src/components/note/editor-error-boundary.tsx
+++ b/apps/desktop/src/renderer/src/components/note/editor-error-boundary.tsx
@@ -12,6 +12,7 @@ import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { AlertTriangle, RefreshCw } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { createLogger } from '@/lib/logger'
+import { trackRendererError } from '@/lib/telemetry-diagnostics'
 import { useT } from '@memry/i18n/renderer'
 
 const log = createLogger('Component:EditorErrorBoundary')
@@ -59,6 +60,7 @@ class EditorErrorBoundaryImpl extends Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     log.error('Editor crash', error, errorInfo)
+    trackRendererError('editor_error_boundary', error)
     this.props.onError?.(error, errorInfo)
   }
 
@@ -91,7 +93,7 @@ class EditorErrorBoundaryImpl extends Component<
                 <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
                   {labels.technicalDetails}
                 </summary>
-                <code className="mt-2 block text-xs bg-muted p-2 rounded overflow-auto max-h-24 text-left">
+                <code className="mt-2 block text-xs bg-muted p-2 rounded overflow-auto max-h-24 text-start">
                   {this.state.error.message}
                   {this.state.error.stack && (
                     <>
@@ -109,7 +111,7 @@ class EditorErrorBoundaryImpl extends Component<
               className="mt-2"
               aria-label={labels.reloadAria}
             >
-              <RefreshCw className="w-4 h-4 mr-2" aria-hidden="true" />
+              <RefreshCw className="w-4 h-4 me-2" aria-hidden="true" />
               {labels.reload}
             </Button>
           </div>

--- a/apps/desktop/src/renderer/src/components/tabs/tab-error-boundary.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-error-boundary.tsx
@@ -6,6 +6,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { AlertTriangle, RefreshCw } from '@/lib/icons'
 import { createLogger } from '@/lib/logger'
+import { trackRendererError } from '@/lib/telemetry-diagnostics'
 import { useT } from '@memry/i18n/renderer'
 
 const log = createLogger('Component:TabErrorBoundary')
@@ -47,6 +48,7 @@ class TabErrorBoundaryImpl extends Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     log.error('Tab content error', error, errorInfo)
+    trackRendererError('tab_error_boundary', error)
     this.props.onError?.(error, errorInfo)
   }
 

--- a/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.test.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { trackTelemetryMock } = vi.hoisted(() => ({
+  trackTelemetryMock: vi.fn()
+}))
+
+vi.mock('./telemetry', () => ({
+  trackTelemetry: trackTelemetryMock
+}))
+
+import { trackRendererError, trackRendererLog, trackRendererReady } from './telemetry-diagnostics'
+
+describe('renderer telemetry diagnostics', () => {
+  beforeEach(() => {
+    trackTelemetryMock.mockReset()
+  })
+
+  it('emits sanitized renderer errors without raw messages', () => {
+    // #given an error with private-looking message text
+    const error = new TypeError('failed at /Users/kaan/private-note.md')
+
+    // #when tracking it
+    trackRendererError('unhandled_rejection', error)
+
+    // #then only stable metadata leaves the renderer
+    expect(trackTelemetryMock).toHaveBeenCalledWith(
+      'app_error_seen',
+      expect.objectContaining({
+        surface: 'app',
+        action: 'unhandled_rejection',
+        objectType: 'exception',
+        source: 'renderer',
+        result: 'failed',
+        errorCode: 'TypeError'
+      })
+    )
+    expect(JSON.stringify(trackTelemetryMock.mock.calls[0])).not.toContain('private-note')
+  })
+
+  it('emits structured renderer logs', () => {
+    // #given a warning breadcrumb
+    trackRendererLog('warn', 'boot_failed', 'RendererBoot')
+
+    // #then it is a typed telemetry log event
+    expect(trackTelemetryMock).toHaveBeenCalledWith('app_log_recorded', {
+      surface: 'app',
+      action: 'warn',
+      objectType: 'log',
+      source: 'RendererBoot',
+      result: 'failed',
+      dimensions: { log_action: 'boot_failed' }
+    })
+  })
+
+  it('emits renderer-ready launch timing', () => {
+    // #given renderer boot completed
+    trackRendererReady(64)
+
+    // #then the duration is captured as a launch phase
+    expect(trackTelemetryMock).toHaveBeenCalledWith('app_launch_phase_completed', {
+      surface: 'app',
+      action: 'renderer_ready',
+      source: 'renderer',
+      result: 'success',
+      metrics: { durationMs: 64 }
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.ts
@@ -1,0 +1,73 @@
+import type { TelemetryResult } from '@memry/contracts/telemetry-api'
+
+import { trackTelemetry } from './telemetry'
+
+type DiagnosticLevel = 'debug' | 'info' | 'warn' | 'error'
+
+const SAFE_TOKEN = /^(?!.*@)(?!.*:\/\/)(?!.*[/\\]).{1,64}$/
+
+const toSafeToken = (value: unknown, fallback: string): string => {
+  const raw = value instanceof Error ? value.name : String(value ?? '')
+  const token = raw.replace(/[^A-Za-z0-9_.:-]/g, '_').slice(0, 64)
+  return SAFE_TOKEN.test(token) ? token : fallback
+}
+
+const toErrorCode = (error: unknown): string => {
+  if (error instanceof Error && error.name) {
+    return toSafeToken(error.name, 'Error')
+  }
+  if (error && typeof error === 'object' && error.constructor?.name) {
+    return toSafeToken(error.constructor.name, 'UnknownError')
+  }
+  if (typeof error === 'string') return 'StringError'
+  return 'UnknownError'
+}
+
+const resultForLevel = (level: DiagnosticLevel): TelemetryResult =>
+  level === 'error' || level === 'warn' ? 'failed' : 'success'
+
+export const trackRendererError = (action: string, error: unknown): void => {
+  void trackTelemetry('app_error_seen', {
+    surface: 'app',
+    action: toSafeToken(action, 'error'),
+    objectType: 'exception',
+    source: 'renderer',
+    result: 'failed',
+    errorCode: toErrorCode(error)
+  })
+}
+
+export const trackRendererLog = (
+  level: DiagnosticLevel,
+  action: string,
+  scope = 'renderer'
+): void => {
+  void trackTelemetry('app_log_recorded', {
+    surface: 'app',
+    action: level,
+    objectType: 'log',
+    source: toSafeToken(scope, 'renderer'),
+    result: resultForLevel(level),
+    dimensions: { log_action: toSafeToken(action, 'event') }
+  })
+}
+
+export const trackRendererReady = (durationMs: number): void => {
+  void trackTelemetry('app_launch_phase_completed', {
+    surface: 'app',
+    action: 'renderer_ready',
+    source: 'renderer',
+    result: 'success',
+    metrics: { durationMs: Math.max(0, Math.round(durationMs)) }
+  })
+}
+
+export const registerRendererDiagnostics = (): void => {
+  window.addEventListener('error', (event) => {
+    trackRendererError('window_error', event.error ?? event.message)
+  })
+
+  window.addEventListener('unhandledrejection', (event) => {
+    trackRendererError('unhandled_rejection', event.reason)
+  })
+}

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -26,6 +26,13 @@ import { AuthProvider } from './contexts/auth-context'
 import { SyncProvider } from './contexts/sync-context'
 import { AISettingsProvider } from './contexts/ai-settings-context'
 import { getStartupTheme, THEME_STORAGE_KEY } from './lib/startup-theme'
+import { createLogger } from './lib/logger'
+import {
+  registerRendererDiagnostics,
+  trackRendererError,
+  trackRendererLog,
+  trackRendererReady
+} from './lib/telemetry-diagnostics'
 
 // Create a client with default options for the entire app
 const queryClient = new QueryClient({
@@ -42,6 +49,10 @@ const queryClient = new QueryClient({
     }
   }
 })
+
+const log = createLogger('RendererBoot')
+const rendererStartedAt = performance.now()
+registerRendererDiagnostics()
 
 // Sanitize a stale or corrupted theme value in localStorage before next-themes
 // reads it. A pre-existing bug elsewhere can write `[object Object]` here,
@@ -113,6 +124,11 @@ async function boot(): Promise<void> {
   )
 
   createRoot(document.getElementById('root')!).render(rootComponent)
+  trackRendererReady(performance.now() - rendererStartedAt)
 }
 
-void boot()
+void boot().catch((error) => {
+  log.error('Renderer boot failed', error)
+  trackRendererError('boot_failed', error)
+  trackRendererLog('error', 'boot_failed', 'RendererBoot')
+})

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -1,10 +1,11 @@
 # Observability & Telemetry
 
-Local logs for debugging plus an opt-in, content-free telemetry stream for product metrics.
+Local logs for debugging plus an opt-in, content-free telemetry stream for product metrics,
+launch diagnostics, and sanitized errors.
 
 ## Logging
 
-Use `createLogger(scope)` from electron-log everywhere:
+Use `createLogger(scope)` from electron-log everywhere in the desktop app:
 
 ```ts
 import { createLogger } from '@/lib/logger'
@@ -16,6 +17,8 @@ log.error('pull failed', err)
 - **Never** use `console.*`. A pre-commit hook flags it.
 - Logs land in the OS-standard log directory and rotate automatically.
 - Renderer and main process logs are separate files.
+- Important launch, renderer, and main-process errors are mirrored as telemetry events when
+  product telemetry is enabled.
 
 ### Log Locations
 
@@ -75,9 +78,42 @@ The `void` makes the call non-blocking and unfailable from the UI's point of vie
 | Sync health   | `sync_push_succeeded`, `sync_pull_failed` (counts only) |
 | Auth          | `signin_started`, `signin_succeeded`                    |
 
-## Crash Reporting
+## PostHog Export
 
-Currently disabled. Errors are written to local logs and surfaced in-app where appropriate. A future opt-in crash reporter is on the [Roadmap](/roadmap).
+The sync server always writes accepted desktop telemetry batches to Cloudflare Analytics Engine.
+When `POSTHOG_API_KEY` and `POSTHOG_HOST` are configured on the sync server, the same
+content-free events are mirrored to PostHog's batch endpoint.
+
+Additional PostHog events:
+
+| Event                        | Source                                    |
+| ---------------------------- | ----------------------------------------- |
+| `app_launch_phase_completed` | Electron main/renderer startup milestones |
+| `app_log_recorded`           | Sanitized desktop diagnostic breadcrumbs  |
+| `app_error_seen`             | Renderer, React boundary, and main errors |
+| `server_error_seen`          | Sync-server request/background failures   |
+| `server_log_recorded`        | Structured sync-server diagnostic logs    |
+
+## Error Reporting
+
+Desktop error reporting remains opt-in with product telemetry. Captured errors include process
+area, component/source, action, phase, and stable error codes. They do not include note content,
+titles, file paths, search text, stack traces, or raw exception messages.
+
+Sync-server error reporting is server-side and uses only sanitized routing metadata: method,
+normalized path, route area, source, action, status code, error type, and error code. Dynamic path
+segments and query strings are removed before export.
+
+## Server Configuration
+
+Set these sync-server variables to enable PostHog mirroring:
+
+```bash
+POSTHOG_API_KEY=phc_...
+POSTHOG_HOST=https://us.i.posthog.com
+```
+
+Use `https://eu.i.posthog.com` for EU Cloud projects.
 
 ## Performance
 

--- a/apps/sync-server/src/lib/errors.test.ts
+++ b/apps/sync-server/src/lib/errors.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AppError, ErrorCodes, errorHandler, formatErrorResponse } from './errors'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('sync-server error utilities', () => {
   it('creates and formats AppError responses', () => {
@@ -51,5 +55,55 @@ describe('sync-server error utilities', () => {
       }
     })
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('"code":"UNHANDLED_ERROR"'))
+  })
+
+  it('schedules sanitized PostHog capture for unexpected request errors', async () => {
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
+      return new Response(JSON.stringify({ status: 1 }), { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const scheduled: Promise<unknown>[] = []
+    const json = vi.fn(
+      (payload: unknown, init: number) => new Response(JSON.stringify(payload), { status: init })
+    )
+    const context = {
+      json,
+      env: {
+        POSTHOG_API_KEY: 'phc_test_project',
+        POSTHOG_HOST: 'https://us.i.posthog.com',
+        ENVIRONMENT: 'development'
+      },
+      req: {
+        method: 'POST',
+        path: '/sync/records/push/550e8400-e29b-41d4-a716-446655440000'
+      },
+      executionCtx: {
+        waitUntil: vi.fn((promise: Promise<unknown>) => {
+          scheduled.push(promise)
+        })
+      }
+    } as unknown as Parameters<typeof errorHandler>[1]
+
+    const response = errorHandler(new Error('private-note-title'), context)
+    await scheduled[0]
+
+    expect(response.status).toBe(500)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const init = fetchMock.mock.calls[0]?.[1]
+    expect(init?.body).toBeDefined()
+    const body = JSON.parse(init?.body as string) as {
+      batch: Array<{ event: string; properties: Record<string, unknown> }>
+    }
+    expect(body.batch[0].event).toBe('server_error_seen')
+    expect(body.batch[0].properties).toMatchObject({
+      method: 'POST',
+      path: '/sync/records/push/:value',
+      error_code: 'UNHANDLED_ERROR',
+      status_code: 500,
+      handled: 0
+    })
+    const payloadText = JSON.stringify(body)
+    expect(payloadText).not.toContain('550e8400-e29b-41d4-a716-446655440000')
+    expect(payloadText).not.toContain('private-note-title')
   })
 })

--- a/apps/sync-server/src/lib/errors.ts
+++ b/apps/sync-server/src/lib/errors.ts
@@ -2,6 +2,8 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type { Context } from 'hono'
 
 import { createLogger } from './logger'
+import { captureServerError } from '../services/posthog'
+import type { AppContext } from '../types'
 
 const logger = createLogger('ErrorHandler')
 
@@ -88,12 +90,55 @@ export const formatErrorResponse = (
   }
 })
 
-export const errorHandler = (err: Error, c: Context): Response => {
+const scheduleServerErrorCapture = (
+  err: Error,
+  c: Context<AppContext>,
+  metadata: {
+    statusCode: number
+    errorCode: string
+    handled: boolean
+  }
+): void => {
+  if (!c.env?.POSTHOG_API_KEY || !c.env.POSTHOG_HOST || !c.req) return
+
+  let executionCtx: { waitUntil?: (promise: Promise<unknown>) => void } | undefined
+  try {
+    executionCtx = c.executionCtx
+  } catch {
+    return
+  }
+  if (!executionCtx?.waitUntil) return
+
+  executionCtx.waitUntil(
+    captureServerError(c.env, {
+      error: err,
+      method: c.req.method,
+      path: c.req.path,
+      source: 'ErrorHandler',
+      action: 'request_failed',
+      statusCode: metadata.statusCode,
+      errorCode: metadata.errorCode,
+      handled: metadata.handled
+    })
+  )
+}
+
+export const errorHandler = (err: Error, c: Context<AppContext>): Response => {
   if (err instanceof AppError) {
+    scheduleServerErrorCapture(err, c, {
+      statusCode: err.statusCode,
+      errorCode: err.code,
+      handled: true
+    })
     return c.json(formatErrorResponse(err), { status: err.statusCode as ContentfulStatusCode })
   }
 
   logger.error(err.message, { code: 'UNHANDLED_ERROR', stack: err.stack })
+  scheduleServerErrorCapture(err, c, {
+    statusCode: 500,
+    errorCode: 'UNHANDLED_ERROR',
+    handled: false
+  })
   const fallback = new AppError(ErrorCodes.INTERNAL_ERROR, 'Internal server error', 500)
   return c.json(formatErrorResponse(fallback), 500)
 }

--- a/apps/sync-server/src/routes/linking.ts
+++ b/apps/sync-server/src/routes/linking.ts
@@ -11,6 +11,7 @@ import {
   transitionToApproved,
   transitionToCompleted
 } from '../services/linking'
+import { waitUntilWithPostHog } from '../services/posthog'
 import type { AppContext } from '../types'
 
 const linkingRateLimit = createRateLimiter({
@@ -124,7 +125,8 @@ linking.post('/scan', linkingRateLimit, async (c) => {
 
   const syncDoId = c.env.USER_SYNC_STATE.idFromName(userId)
   const syncStub = c.env.USER_SYNC_STATE.get(syncDoId)
-  c.executionCtx.waitUntil(
+  waitUntilWithPostHog(
+    c,
     syncStub.fetch(
       new Request(new URL('/notify-linking', c.req.url), {
         method: 'POST',
@@ -139,7 +141,8 @@ linking.post('/scan', linkingRateLimit, async (c) => {
           }
         })
       })
-    )
+    ),
+    { source: 'UserSyncState', action: 'linking_request_notify_failed' }
   )
 
   return c.json({ success: true, status: 'scanned' })
@@ -214,7 +217,8 @@ linking.post('/approve', authMiddleware, linkingRateLimit, async (c) => {
   if (session) {
     const syncDoId = c.env.USER_SYNC_STATE.idFromName(userId)
     const syncStub = c.env.USER_SYNC_STATE.get(syncDoId)
-    c.executionCtx.waitUntil(
+    waitUntilWithPostHog(
+      c,
       syncStub.fetch(
         new Request(new URL('/notify-linking', c.req.url), {
           method: 'POST',
@@ -225,7 +229,8 @@ linking.post('/approve', authMiddleware, linkingRateLimit, async (c) => {
             payload: { sessionId }
           })
         })
-      )
+      ),
+      { source: 'UserSyncState', action: 'linking_approved_notify_failed' }
     )
   }
 

--- a/apps/sync-server/src/routes/sync.test.ts
+++ b/apps/sync-server/src/routes/sync.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { AppError, ErrorCodes, errorHandler } from '../lib/errors'
 import type { AppContext } from '../types'
@@ -214,6 +214,10 @@ describe('sync routes', () => {
     mockDoStub.fetch.mockResolvedValue(Response.json({ sent: 0 }))
     app = createApp()
     env = createEnv()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   // ==========================================================================
@@ -724,6 +728,51 @@ describe('sync routes', () => {
       expect(res.status).toBe(413)
       expect(updateDeviceCursor).not.toHaveBeenCalled()
       expect(updateDevice).not.toHaveBeenCalled()
+    })
+
+    it('captures background broadcast failures without failing the push response', async () => {
+      const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
+        return new Response(JSON.stringify({ status: 1 }), { status: 200 })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      mockDoStub.fetch.mockRejectedValueOnce(new Error(`broadcast failed ${VALID_UUID}`))
+      const scheduled: Promise<unknown>[] = []
+      const localExecutionCtx = {
+        waitUntil: vi.fn((promise: Promise<unknown>) => {
+          scheduled.push(promise)
+        }),
+        passThroughOnException: vi.fn(),
+        props: {}
+      }
+      const localEnv = {
+        ...env,
+        POSTHOG_API_KEY: 'phc_test_project',
+        POSTHOG_HOST: 'https://us.i.posthog.com'
+      }
+
+      const res = await app.request(
+        'http://localhost/sync/push',
+        jsonPost('/sync/push', { items: [makePushItem()] }),
+        localEnv,
+        localExecutionCtx
+      )
+      await scheduled[0]
+
+      expect(res.status).toBe(200)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const init = fetchMock.mock.calls[0]?.[1]
+      expect(init?.body).toBeDefined()
+      const body = JSON.parse(init?.body as string) as {
+        batch: Array<{ event: string; properties: Record<string, unknown> }>
+      }
+      expect(body.batch[0].event).toBe('server_error_seen')
+      expect(body.batch[0].properties).toMatchObject({
+        source: 'UserSyncState',
+        action: 'record_push_broadcast_failed',
+        path: '/sync/push',
+        error_code: 'WAIT_UNTIL_REJECTED'
+      })
+      expect(JSON.stringify(body)).not.toContain(VALID_UUID)
     })
   })
 

--- a/apps/sync-server/src/routes/sync.ts
+++ b/apps/sync-server/src/routes/sync.ts
@@ -23,6 +23,7 @@ import {
   logRecordQueryBatch,
   logSyncValidationFailure
 } from '../services/sync-telemetry'
+import { waitUntilWithPostHog } from '../services/posthog'
 import { updateDevice } from '../services/device'
 import { getStorageBreakdown } from '../services/storage'
 import {
@@ -277,14 +278,16 @@ const handleRecordPush = async (c: Context<AppContext>): Promise<Response> => {
     })
     const doId = c.env.USER_SYNC_STATE.idFromName(userId)
     const stub = c.env.USER_SYNC_STATE.get(doId)
-    c.executionCtx.waitUntil(
+    waitUntilWithPostHog(
+      c,
       stub.fetch(
         new Request(new URL('/broadcast', c.req.url), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ excludeDeviceId: deviceId, cursor: result.maxCursor, vaultId })
         })
-      )
+      ),
+      { source: 'UserSyncState', action: 'record_push_broadcast_failed' }
     )
   }
 
@@ -450,7 +453,8 @@ const handleCrdtUpdatePush = async (c: Context<AppContext>): Promise<Response> =
 
   const doId = c.env.USER_SYNC_STATE.idFromName(userId)
   const stub = c.env.USER_SYNC_STATE.get(doId)
-  c.executionCtx.waitUntil(
+  waitUntilWithPostHog(
+    c,
     stub.fetch(
       new Request(new URL('/broadcast', c.req.url), {
         method: 'POST',
@@ -462,7 +466,8 @@ const handleCrdtUpdatePush = async (c: Context<AppContext>): Promise<Response> =
           noteId: parsed.noteId
         })
       })
-    )
+    ),
+    { source: 'UserSyncState', action: 'crdt_update_broadcast_failed' }
   )
 
   logCrdtTraffic({

--- a/apps/sync-server/src/routes/webhooks.ts
+++ b/apps/sync-server/src/routes/webhooks.ts
@@ -1,13 +1,38 @@
 import { Hono } from 'hono'
+import type { Context } from 'hono'
 
 import { createLogger } from '../lib/logger'
 import { applyPaddleWebhook, verifyPaddleWebhookSignature } from '../services/paddle-webhooks'
 import { lookupChannel, verifyChannelToken } from '../services/google-webhooks'
+import { captureServerLog, waitUntilWithPostHog } from '../services/posthog'
 import type { AppContext } from '../types'
 
 const log = createLogger('Webhooks')
 
 export const webhooks = new Hono<AppContext>()
+
+const captureWebhookLog = (
+  c: Context<AppContext>,
+  input: {
+    level: 'info' | 'warn' | 'error'
+    source: string
+    action: string
+    statusCode: number
+  }
+): void => {
+  if (!c.env.POSTHOG_API_KEY || !c.env.POSTHOG_HOST) return
+  try {
+    c.executionCtx.waitUntil(
+      captureServerLog(c.env, {
+        ...input,
+        method: c.req.method,
+        path: c.req.path
+      })
+    )
+  } catch {
+    // Preserve webhook behavior if the runtime cannot schedule background work.
+  }
+}
 
 webhooks.post('/paddle', async (c) => {
   const rawBody = await c.req.text()
@@ -21,6 +46,12 @@ webhooks.post('/paddle', async (c) => {
     })
   } catch {
     log.warn('Invalid Paddle webhook signature')
+    captureWebhookLog(c, {
+      level: 'warn',
+      source: 'PaddleWebhook',
+      action: 'invalid_signature',
+      statusCode: 401
+    })
     return c.json({ error: 'Invalid Paddle signature' }, 401)
   }
 
@@ -28,6 +59,12 @@ webhooks.post('/paddle', async (c) => {
   try {
     payload = JSON.parse(rawBody)
   } catch {
+    captureWebhookLog(c, {
+      level: 'warn',
+      source: 'PaddleWebhook',
+      action: 'invalid_json',
+      statusCode: 400
+    })
     return c.json({ error: 'Invalid JSON payload' }, 400)
   }
 
@@ -41,24 +78,48 @@ webhooks.post('/google-calendar', async (c) => {
   const resourceState = c.req.header('x-goog-resource-state')
 
   if (!channelId || !channelToken || !resourceState) {
+    captureWebhookLog(c, {
+      level: 'warn',
+      source: 'GoogleWebhook',
+      action: 'missing_headers',
+      statusCode: 400
+    })
     return c.json({ error: 'Missing Google channel headers' }, 400)
   }
 
   const channel = await lookupChannel(c.env.DB, channelId)
   if (!channel) {
     log.warn('Unknown channel in Google webhook', { channelId })
+    captureWebhookLog(c, {
+      level: 'warn',
+      source: 'GoogleWebhook',
+      action: 'unknown_channel',
+      statusCode: 401
+    })
     return c.json({ error: 'Unknown channel' }, 401)
   }
 
   const nowSec = Math.floor(Date.now() / 1000)
   if (channel.expires_at <= nowSec) {
     log.info('Expired channel pinged by Google; returning 410 to stop retries', { channelId })
+    captureWebhookLog(c, {
+      level: 'info',
+      source: 'GoogleWebhook',
+      action: 'expired_channel',
+      statusCode: 410
+    })
     return c.json({ error: 'Channel expired' }, 410)
   }
 
   const ok = await verifyChannelToken(c.env.WEBHOOK_HMAC_KEY, channelToken, channel.token_hash)
   if (!ok) {
     log.warn('Channel token mismatch', { channelId })
+    captureWebhookLog(c, {
+      level: 'warn',
+      source: 'GoogleWebhook',
+      action: 'token_mismatch',
+      statusCode: 401
+    })
     return c.json({ error: 'Token mismatch' }, 401)
   }
 
@@ -68,7 +129,8 @@ webhooks.post('/google-calendar', async (c) => {
 
   const doId = c.env.USER_SYNC_STATE.idFromName(channel.user_id)
   const stub = c.env.USER_SYNC_STATE.get(doId)
-  c.executionCtx.waitUntil(
+  waitUntilWithPostHog(
+    c,
     stub.fetch(
       new Request(new URL('/broadcast', c.req.url), {
         method: 'POST',
@@ -79,7 +141,8 @@ webhooks.post('/google-calendar', async (c) => {
           sourceId: channel.source_id
         })
       })
-    )
+    ),
+    { source: 'UserSyncState', action: 'calendar_webhook_broadcast_failed' }
   )
 
   return c.body(null, 200)

--- a/apps/sync-server/src/services/posthog.test.ts
+++ b/apps/sync-server/src/services/posthog.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { captureServerError, captureServerLog, waitUntilWithPostHog } from './posthog'
+
+const env = {
+  POSTHOG_API_KEY: 'phc_test_project',
+  POSTHOG_HOST: 'https://us.i.posthog.com/',
+  ENVIRONMENT: 'development'
+}
+
+const UUID = '550e8400-e29b-41d4-a716-446655440000'
+
+const readPostHogBody = () => {
+  const fetchMock = vi.mocked(fetch)
+  const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+  expect(init?.body).toBeDefined()
+  return JSON.parse(init?.body as string) as {
+    api_key: string
+    batch: Array<{
+      event: string
+      distinct_id: string
+      properties: Record<string, unknown>
+    }>
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('sync-server PostHog capture', () => {
+  it('captures sanitized server errors without raw messages, ids, or query strings', async () => {
+    // #given a configured PostHog project and an error with sensitive-looking details
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ status: 1 }), { status: 200 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const error = Object.assign(new Error(`private-note-title ${UUID}`), {
+      name: 'QuotaFailure',
+      code: 'STORAGE_QUOTA_EXCEEDED',
+      statusCode: 507
+    })
+
+    // #when capturing the server error
+    await captureServerError(env, {
+      error,
+      method: 'GET',
+      path: `/sync/items/${UUID}?token=secret-token`,
+      source: 'ErrorHandler',
+      action: 'request_failed',
+      handled: false
+    })
+
+    // #then PostHog receives only sanitized routing metadata
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://us.i.posthog.com/batch/',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+    const body = readPostHogBody()
+    expect(body.api_key).toBe('phc_test_project')
+    expect(body.batch).toHaveLength(1)
+    expect(body.batch[0]).toMatchObject({
+      event: 'server_error_seen',
+      distinct_id: 'memry_sync_server_development'
+    })
+    expect(body.batch[0].properties).toMatchObject({
+      service_name: 'memry-sync-server',
+      environment: 'development',
+      method: 'GET',
+      path: '/sync/items/:value',
+      route_area: 'sync',
+      source: 'ErrorHandler',
+      action: 'request_failed',
+      level: 'error',
+      error_type: 'QuotaFailure',
+      error_code: 'STORAGE_QUOTA_EXCEEDED',
+      status_code: 507,
+      handled: 0
+    })
+    const payloadText = JSON.stringify(body)
+    expect(payloadText).not.toContain(UUID)
+    expect(payloadText).not.toContain('private-note-title')
+    expect(payloadText).not.toContain('secret-token')
+  })
+
+  it('captures structured server logs when configured', async () => {
+    // #given a configured PostHog project
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ status: 1 }), { status: 200 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when capturing a structured server log
+    await captureServerLog(env, {
+      level: 'warn',
+      method: 'POST',
+      path: '/webhooks/google-calendar',
+      source: 'GoogleWebhook',
+      action: 'channel_token_mismatch',
+      statusCode: 401
+    })
+
+    // #then the log is represented as a filterable PostHog event
+    const body = readPostHogBody()
+    expect(body.batch[0]).toMatchObject({
+      event: 'server_log_recorded',
+      distinct_id: 'memry_sync_server_development'
+    })
+    expect(body.batch[0].properties).toMatchObject({
+      service_name: 'memry-sync-server',
+      environment: 'development',
+      level: 'warn',
+      method: 'POST',
+      path: '/webhooks/google-calendar',
+      route_area: 'webhooks',
+      source: 'GoogleWebhook',
+      action: 'channel_token_mismatch',
+      status_code: 401
+    })
+  })
+
+  it('reports rejected waitUntil tasks through PostHog', async () => {
+    // #given a context with a background promise that rejects
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ status: 1 }), { status: 200 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const scheduled: Promise<unknown>[] = []
+    const context = {
+      env,
+      req: {
+        method: 'POST',
+        path: `/sync/records/push/${UUID}`
+      },
+      executionCtx: {
+        waitUntil: vi.fn((promise: Promise<unknown>) => {
+          scheduled.push(promise)
+        })
+      }
+    }
+
+    // #when the waitUntil work is wrapped
+    waitUntilWithPostHog(context, Promise.reject(new Error(`broadcast ${UUID}`)), {
+      source: 'UserSyncState',
+      action: 'record_push_broadcast_failed'
+    })
+    await scheduled[0]
+
+    // #then the rejection is captured without surfacing raw error details
+    const body = readPostHogBody()
+    expect(body.batch[0].event).toBe('server_error_seen')
+    expect(body.batch[0].properties).toMatchObject({
+      source: 'UserSyncState',
+      action: 'record_push_broadcast_failed',
+      method: 'POST',
+      path: '/sync/records/push/:value',
+      error_code: 'WAIT_UNTIL_REJECTED',
+      handled: 0
+    })
+    expect(JSON.stringify(body)).not.toContain(UUID)
+    expect(JSON.stringify(body)).not.toContain('broadcast failed')
+  })
+})

--- a/apps/sync-server/src/services/posthog.ts
+++ b/apps/sync-server/src/services/posthog.ts
@@ -1,0 +1,233 @@
+import { createLogger } from '../lib/logger'
+import type { Bindings } from '../types'
+
+const POSTHOG_BATCH_PATH = '/batch/'
+const SERVER_SERVICE_NAME = 'memry-sync-server'
+const UUID_SEGMENT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const SAFE_SEGMENT = /^[a-z0-9_.:-]{1,32}$/i
+
+const logger = createLogger('PostHog')
+
+export interface PostHogEnv {
+  POSTHOG_API_KEY?: Bindings['POSTHOG_API_KEY']
+  POSTHOG_HOST?: Bindings['POSTHOG_HOST']
+  ENVIRONMENT?: Bindings['ENVIRONMENT']
+}
+
+export interface PostHogEventPayload {
+  event: string
+  distinct_id: string
+  timestamp?: string
+  properties: Record<string, string | number | boolean>
+}
+
+export interface PostHogBatchPayload {
+  api_key: string
+  batch: PostHogEventPayload[]
+}
+
+export interface ServerErrorCaptureInput {
+  error: unknown
+  method?: string
+  path?: string
+  source: string
+  action: string
+  statusCode?: number
+  errorCode?: string
+  handled: boolean
+}
+
+export interface ServerLogCaptureInput {
+  level: 'debug' | 'info' | 'warn' | 'error'
+  method?: string
+  path?: string
+  source: string
+  action: string
+  statusCode?: number
+}
+
+interface WaitUntilContext {
+  env: PostHogEnv
+  req: {
+    method?: string
+    path?: string
+    url?: string
+  }
+  executionCtx: {
+    waitUntil(promise: Promise<unknown>): void
+  }
+}
+
+const normalizePostHogHost = (host: string): string => host.replace(/\/+$/, '')
+
+const safeLabel = (value: string | undefined, fallback: string): string => {
+  if (!value) return fallback
+  return value.replace(/[^a-zA-Z0-9_.:-]/g, '_').slice(0, 80) || fallback
+}
+
+const normalizePathSegment = (segment: string, index: number): string => {
+  if (index > 2 || UUID_SEGMENT.test(segment) || !SAFE_SEGMENT.test(segment)) {
+    return ':value'
+  }
+  return segment
+}
+
+const normalizeServerPath = (path: string | undefined): string => {
+  if (!path) return '/'
+  let pathname = path
+  try {
+    pathname = new URL(path).pathname
+  } catch {
+    pathname = path.split('?')[0] ?? '/'
+  }
+
+  const segments = pathname
+    .split('/')
+    .filter(Boolean)
+    .map((segment, index) => normalizePathSegment(segment, index))
+
+  return segments.length > 0 ? `/${segments.join('/')}` : '/'
+}
+
+const getRouteArea = (path: string): string => {
+  const first = path.split('/').filter(Boolean)[0]
+  return safeLabel(first, 'root')
+}
+
+const getStatusCode = (error: unknown, fallback: number): number => {
+  if (error && typeof error === 'object' && 'statusCode' in error) {
+    const statusCode = (error as { statusCode?: unknown }).statusCode
+    if (typeof statusCode === 'number' && Number.isFinite(statusCode)) return statusCode
+  }
+  return fallback
+}
+
+const getErrorCode = (error: unknown, fallback: string): string => {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as { code?: unknown }).code
+    if (typeof code === 'string' && code.length > 0) return safeLabel(code, fallback)
+  }
+  return fallback
+}
+
+const getErrorType = (error: unknown): string => {
+  if (error instanceof Error && error.name) return safeLabel(error.name, 'Error')
+  if (error && typeof error === 'object' && 'name' in error) {
+    const name = (error as { name?: unknown }).name
+    if (typeof name === 'string' && name.length > 0) return safeLabel(name, 'Error')
+  }
+  return typeof error === 'string' ? 'StringError' : 'UnknownError'
+}
+
+const getRequestPath = (req: WaitUntilContext['req']): string => req.path ?? req.url ?? '/'
+
+const serverDistinctId = (env: PostHogEnv): string =>
+  `memry_sync_server_${safeLabel(env.ENVIRONMENT, 'unknown')}`
+
+export const toPostHogBatchPayload = (
+  apiKey: string,
+  batch: PostHogEventPayload[]
+): PostHogBatchPayload => ({
+  api_key: apiKey,
+  batch
+})
+
+export const sendPostHogBatch = async (
+  env: PostHogEnv,
+  batch: PostHogEventPayload[]
+): Promise<void> => {
+  if (!env.POSTHOG_API_KEY || !env.POSTHOG_HOST || batch.length === 0) return
+
+  try {
+    const response = await fetch(`${normalizePostHogHost(env.POSTHOG_HOST)}${POSTHOG_BATCH_PATH}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(toPostHogBatchPayload(env.POSTHOG_API_KEY, batch))
+    })
+
+    if (!response.ok) {
+      logger.warn('PostHog batch rejected', { status: response.status })
+    }
+  } catch (error) {
+    logger.warn('PostHog batch failed', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+export const captureServerError = async (
+  env: PostHogEnv,
+  input: ServerErrorCaptureInput
+): Promise<void> => {
+  const path = normalizeServerPath(input.path)
+  await sendPostHogBatch(env, [
+    {
+      event: 'server_error_seen',
+      distinct_id: serverDistinctId(env),
+      timestamp: new Date().toISOString(),
+      properties: {
+        service_name: SERVER_SERVICE_NAME,
+        environment: safeLabel(env.ENVIRONMENT, 'unknown'),
+        method: safeLabel(input.method?.toUpperCase(), 'UNKNOWN'),
+        path,
+        route_area: getRouteArea(path),
+        source: safeLabel(input.source, 'server'),
+        action: safeLabel(input.action, 'error'),
+        level: 'error',
+        error_type: getErrorType(input.error),
+        error_code: safeLabel(
+          input.errorCode ?? getErrorCode(input.error, 'UNHANDLED_ERROR'),
+          'UNHANDLED_ERROR'
+        ),
+        status_code: input.statusCode ?? getStatusCode(input.error, 500),
+        handled: input.handled ? 1 : 0
+      }
+    }
+  ])
+}
+
+export const captureServerLog = async (
+  env: PostHogEnv,
+  input: ServerLogCaptureInput
+): Promise<void> => {
+  const path = normalizeServerPath(input.path)
+  await sendPostHogBatch(env, [
+    {
+      event: 'server_log_recorded',
+      distinct_id: serverDistinctId(env),
+      timestamp: new Date().toISOString(),
+      properties: {
+        service_name: SERVER_SERVICE_NAME,
+        environment: safeLabel(env.ENVIRONMENT, 'unknown'),
+        level: input.level,
+        method: safeLabel(input.method?.toUpperCase(), 'UNKNOWN'),
+        path,
+        route_area: getRouteArea(path),
+        source: safeLabel(input.source, 'server'),
+        action: safeLabel(input.action, 'log'),
+        ...(typeof input.statusCode === 'number' ? { status_code: input.statusCode } : {})
+      }
+    }
+  ])
+}
+
+export const waitUntilWithPostHog = (
+  c: WaitUntilContext,
+  promise: Promise<unknown>,
+  metadata: { source: string; action: string }
+): void => {
+  c.executionCtx.waitUntil(
+    promise.catch((error) =>
+      captureServerError(c.env, {
+        error,
+        method: c.req.method,
+        path: getRequestPath(c.req),
+        source: metadata.source,
+        action: metadata.action,
+        errorCode: 'WAIT_UNTIL_REJECTED',
+        statusCode: 500,
+        handled: false
+      })
+    )
+  )
+}

--- a/apps/sync-server/src/services/telemetry.test.ts
+++ b/apps/sync-server/src/services/telemetry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { TelemetryBatch } from '@memry/contracts/telemetry-api'
 
@@ -54,15 +54,26 @@ function createDataset(): { dataset: AnalyticsEngineDataset; calls: WriteCall[] 
   return { dataset, calls }
 }
 
-function createEnv(dataset: AnalyticsEngineDataset, hmacKey = HMAC_KEY) {
+function createEnv(
+  dataset: AnalyticsEngineDataset,
+  hmacKey = HMAC_KEY,
+  overrides: Record<string, unknown> = {}
+) {
   return {
     PRODUCT_TELEMETRY: dataset,
-    TELEMETRY_HMAC_KEY: hmacKey
+    TELEMETRY_HMAC_KEY: hmacKey,
+    ...overrides
   } as unknown as {
     PRODUCT_TELEMETRY: AnalyticsEngineDataset
     TELEMETRY_HMAC_KEY: string
+    POSTHOG_API_KEY?: string
+    POSTHOG_HOST?: string
   }
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('hashTelemetryId', () => {
   it('returns a stable hex HMAC for the same input', async () => {
@@ -299,5 +310,59 @@ describe('writeTelemetryBatch', () => {
     expect(blobsJoined.includes(VALID_INSTALL_ID)).toBe(false)
     expect(blobsJoined.includes(VALID_SESSION_ID)).toBe(false)
     expect(blobsJoined.includes(HMAC_KEY)).toBe(false)
+  })
+
+  it('mirrors accepted telemetry events into PostHog batch when configured', async () => {
+    // #given a configured PostHog project and a telemetry batch
+    const { dataset } = createDataset()
+    const fetchMock = vi.fn(async (_input: string | URL, _init?: RequestInit) => {
+      return new Response(JSON.stringify({ status: 1 }), { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when writing
+    await writeTelemetryBatch(
+      createEnv(dataset, HMAC_KEY, {
+        POSTHOG_API_KEY: 'phc_test_project',
+        POSTHOG_HOST: 'https://us.i.posthog.com'
+      }),
+      baseBatch
+    )
+
+    // #then the batch is mirrored to PostHog without raw local identifiers
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://us.i.posthog.com/batch/',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+    const init = fetchMock.mock.calls[0]?.[1]
+    expect(init).toBeDefined()
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      api_key: string
+      batch: Array<{
+        event: string
+        distinct_id: string
+        properties: Record<string, unknown>
+      }>
+    }
+    expect(body.api_key).toBe('phc_test_project')
+    expect(body.batch).toHaveLength(1)
+    expect(body.batch[0].event).toBe('app_started')
+    expect(body.batch[0].distinct_id).toMatch(/^[0-9a-f]{64}$/)
+    expect(body.batch[0].properties).toMatchObject({
+      app_version: '0.1.0',
+      build_channel: 'development',
+      platform: 'darwin',
+      surface: 'app',
+      action: 'started',
+      result: 'success'
+    })
+    const payloadText = JSON.stringify(body)
+    expect(payloadText.includes(VALID_INSTALL_ID)).toBe(false)
+    expect(payloadText.includes(VALID_SESSION_ID)).toBe(false)
+    expect(payloadText.includes(HMAC_KEY)).toBe(false)
   })
 })

--- a/apps/sync-server/src/services/telemetry.ts
+++ b/apps/sync-server/src/services/telemetry.ts
@@ -2,10 +2,10 @@ import type { TelemetryBatch, TelemetryEvent } from '@memry/contracts/telemetry-
 
 import { AppError, ErrorCodes } from '../lib/errors'
 import type { Bindings } from '../types'
+import { sendPostHogBatch, type PostHogBatchPayload, type PostHogEventPayload } from './posthog'
 
 const TELEMETRY_BLOB_COUNT = 20
 const TELEMETRY_DOUBLE_COUNT = 13
-
 const requireHmacKey = (key: string): string => {
   if (typeof key !== 'string' || key.length === 0) {
     throw new AppError(ErrorCodes.INTERNAL_ERROR, 'Telemetry HMAC key is not configured', 500)
@@ -52,7 +52,7 @@ const padArray = <T>(arr: T[], length: number, fill: T): T[] => {
   return [...arr, ...Array.from({ length: length - arr.length }, () => fill)]
 }
 
-interface BatchHashes {
+export interface BatchHashes {
   installHash: string
   sessionHash: string
 }
@@ -129,6 +129,98 @@ export const toDataPoint = (
 export interface TelemetryEnv {
   PRODUCT_TELEMETRY: Bindings['PRODUCT_TELEMETRY']
   TELEMETRY_HMAC_KEY: Bindings['TELEMETRY_HMAC_KEY']
+  POSTHOG_API_KEY?: Bindings['POSTHOG_API_KEY']
+  POSTHOG_HOST?: Bindings['POSTHOG_HOST']
+  ENVIRONMENT?: Bindings['ENVIRONMENT']
+}
+
+const addStringProperty = (
+  properties: Record<string, string | number>,
+  key: string,
+  value: string | undefined
+): void => {
+  if (typeof value === 'string' && value.length > 0) {
+    properties[key] = value
+  }
+}
+
+const addNumberProperty = (
+  properties: Record<string, string | number>,
+  key: string,
+  value: number | undefined
+): void => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    properties[key] = value
+  }
+}
+
+export const toPostHogEvent = (
+  batch: TelemetryBatch,
+  event: TelemetryEvent,
+  hashes: BatchHashes,
+  environment?: string
+): PostHogEventPayload => {
+  const dim = firstDimension(event.dimensions)
+  const metrics = event.metrics ?? {}
+  const properties: Record<string, string | number> = {
+    app_version: batch.appVersion,
+    build_channel: batch.buildChannel,
+    platform: batch.platform,
+    arch: batch.arch,
+    locale: batch.locale,
+    timezone_bucket: timezoneBucket(batch.timezoneOffsetMinutes),
+    auth_state: batch.authState,
+    sync_state: batch.syncState,
+    surface: event.surface,
+    action: event.action,
+    telemetry_session_id: hashes.sessionHash,
+    batch_size: batch.events.length
+  }
+
+  addStringProperty(properties, 'environment', environment)
+  addStringProperty(properties, 'object_type', event.objectType)
+  addStringProperty(properties, 'source', event.source)
+  addStringProperty(properties, 'result', event.result)
+  addStringProperty(properties, 'error_code', event.errorCode)
+  addStringProperty(properties, 'dimension_key', dim.key)
+  addStringProperty(properties, 'dimension_value', dim.value)
+  addNumberProperty(properties, 'duration_ms', metrics.durationMs)
+  addNumberProperty(properties, 'item_count', metrics.itemCount)
+  addNumberProperty(properties, 'byte_count', metrics.byteCount)
+  addNumberProperty(properties, 'queue_count', metrics.queueCount)
+  addNumberProperty(properties, 'result_count', metrics.resultCount)
+  addNumberProperty(properties, 'retry_count', metrics.retryCount)
+  addNumberProperty(properties, 'active_seconds', metrics.activeSeconds)
+  addNumberProperty(properties, 'value', metrics.value)
+  addNumberProperty(properties, 'client_queue_depth', batch.clientQueueDepth)
+
+  return {
+    event: event.name,
+    distinct_id: hashes.installHash,
+    timestamp: event.occurredAt,
+    properties
+  }
+}
+
+export const toPostHogBatchPayload = (
+  apiKey: string,
+  batch: TelemetryBatch,
+  hashes: BatchHashes,
+  environment?: string
+): PostHogBatchPayload => ({
+  api_key: apiKey,
+  batch: batch.events.map((event) => toPostHogEvent(batch, event, hashes, environment))
+})
+
+const mirrorTelemetryBatchToPostHog = async (
+  env: TelemetryEnv,
+  batch: TelemetryBatch,
+  hashes: BatchHashes
+): Promise<void> => {
+  if (!env.POSTHOG_API_KEY || !env.POSTHOG_HOST) return
+
+  const payload = toPostHogBatchPayload(env.POSTHOG_API_KEY, batch, hashes, env.ENVIRONMENT)
+  await sendPostHogBatch(env, payload.batch)
 }
 
 export const writeTelemetryBatch = async (
@@ -137,15 +229,18 @@ export const writeTelemetryBatch = async (
 ): Promise<{ accepted: number }> => {
   const installHash = await hashTelemetryId(env.TELEMETRY_HMAC_KEY, batch.installId)
   const sessionHash = await hashTelemetryId(env.TELEMETRY_HMAC_KEY, batch.sessionId)
+  const hashes = { installHash, sessionHash }
 
   for (const event of batch.events) {
-    const point = toDataPoint(batch, event, { installHash, sessionHash })
+    const point = toDataPoint(batch, event, hashes)
     env.PRODUCT_TELEMETRY.writeDataPoint({
       blobs: point.blobs,
       doubles: point.doubles,
       indexes: point.indexes
     })
   }
+
+  await mirrorTelemetryBatchToPostHog(env, batch, hashes)
 
   return { accepted: batch.events.length }
 }

--- a/apps/sync-server/src/types.ts
+++ b/apps/sync-server/src/types.ts
@@ -19,6 +19,8 @@ export type Bindings = {
   PADDLE_WEBHOOK_SECRET: string
   PADDLE_CHECKOUT_TOKEN_SECRET: string
   TELEMETRY_HMAC_KEY: string
+  POSTHOG_API_KEY?: string
+  POSTHOG_HOST?: string
 }
 
 export type AppContext = {

--- a/apps/sync-server/wrangler.toml
+++ b/apps/sync-server/wrangler.toml
@@ -5,6 +5,7 @@ compatibility_date = "2025-01-01"
 [vars]
 ENVIRONMENT = "development"
 MIN_APP_VERSION = "0.1.0"
+POSTHOG_HOST = "https://us.i.posthog.com"
 
 [[d1_databases]]
 binding = "DB"
@@ -38,6 +39,7 @@ name = "memry-sync-server-staging"
 ENVIRONMENT = "staging"
 ALLOWED_ORIGIN = "https://staging.memrynote.com"
 MIN_APP_VERSION = "0.1.0"
+POSTHOG_HOST = "https://us.i.posthog.com"
 
 [[env.staging.routes]]
 pattern = "sync-staging.memrynote.com/*"
@@ -68,6 +70,7 @@ name = "memry-sync-server-production"
 ENVIRONMENT = "production"
 ALLOWED_ORIGIN = "https://memrynote.com"
 MIN_APP_VERSION = "0.1.0"
+POSTHOG_HOST = "https://us.i.posthog.com"
 
 [[env.production.routes]]
 pattern = "sync.memrynote.com/*"

--- a/packages/contracts/src/telemetry-api.test.ts
+++ b/packages/contracts/src/telemetry-api.test.ts
@@ -93,6 +93,47 @@ describe('TelemetryBatchSchema', () => {
       // #then it parses successfully
       expect(result.success).toBe(true)
     })
+
+    it('accepts launch, log, and error diagnostic events', () => {
+      // #given a batch with app diagnostics that use only enum-like metadata
+      const batch = {
+        ...baseBatch,
+        events: [
+          {
+            ...baseEvent,
+            name: 'app_launch_phase_completed',
+            action: 'renderer_ready',
+            source: 'renderer',
+            metrics: { durationMs: 42 }
+          },
+          {
+            ...baseEvent,
+            id: '550e8400-e29b-41d4-a716-446655440003',
+            name: 'app_log_recorded',
+            action: 'warn',
+            source: 'SyncRuntime',
+            objectType: 'log',
+            dimensions: { log_action: 'flush_failed' }
+          },
+          {
+            ...baseEvent,
+            id: '550e8400-e29b-41d4-a716-446655440004',
+            name: 'app_error_seen',
+            action: 'unhandled_rejection',
+            source: 'main_process',
+            objectType: 'exception',
+            result: 'failed',
+            errorCode: 'TypeError'
+          }
+        ]
+      }
+
+      // #when validating the batch
+      const result = TelemetryBatchSchema.safeParse(batch)
+
+      // #then diagnostic events stay inside the typed telemetry allowlist
+      expect(result.success).toBe(true)
+    })
   })
 
   describe('rejects unsafe event names', () => {

--- a/packages/contracts/src/telemetry-api.ts
+++ b/packages/contracts/src/telemetry-api.ts
@@ -4,6 +4,8 @@ export const TelemetryEventNameSchema = z.enum([
   'app_started',
   'app_backgrounded',
   'app_active_heartbeat',
+  'app_launch_phase_completed',
+  'app_log_recorded',
   'onboarding_started',
   'onboarding_completed',
   'vault_created',


### PR DESCRIPTION
## Summary
- Add telemetry event names and desktop diagnostics for launch phases, renderer/main errors, and structured app log breadcrumbs.
- Mirror accepted sync-server telemetry batches to PostHog and capture sanitized server-side request/background failures.
- Document the observability model, privacy boundaries, and required PostHog sync-server configuration.

## Privacy
- PostHog payloads contain sanitized metadata only.
- No raw error messages, stacks, note content, file paths, identifiers, headers, or query strings are exported.

## Validation
- pnpm exec vitest run src/services/posthog.test.ts src/services/telemetry.test.ts src/lib/errors.test.ts src/routes/sync.test.ts src/routes/linking.test.ts src/routes/webhooks.test.ts
- pnpm --filter @memry/sync-server typecheck
- pnpm exec vitest run packages/contracts/src/telemetry-api.test.ts
- pnpm exec vitest run --config config/vitest.config.ts --project main src/main/telemetry/diagnostics.test.ts
- pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/lib/telemetry-diagnostics.test.ts
- pnpm --filter @memry/desktop typecheck:node
- pnpm --filter @memry/desktop typecheck:web
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build
- git diff --check
- pre-commit: prettier, staged secret scan, renderer guards, IPC check
- pre-push: docs impact gate passed