### PR TITLE
Add PostHog landing reverse proxy

### DIFF
--- a/apps/landing/.env.example
+++ b/apps/landing/.env.example
@@ -17,8 +17,9 @@ VITE_PADDLE_ENVIRONMENT=sandbox
 VITE_PADDLE_CLIENT_TOKEN=replace-me-with-paddle-client-side-token
 
 # PostHog public analytics (client-side). Leave blank locally to disable tracking.
+# Vercel deployments should use /mry so browser requests go through the same-site proxy.
 VITE_POSTHOG_KEY=
-VITE_POSTHOG_HOST=
+VITE_POSTHOG_HOST=/mry
 
 # PostHog server-side analytics (API routes). Same project key as VITE_POSTHOG_KEY.
 POSTHOG_API_KEY=

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -34,14 +34,15 @@ Fill in your environment variables:
 | `RESEND_SEGMENT_ID` | No       | Segment ID to group waitlist contacts     |
 
 PostHog analytics is optional in local development. Production should set the public project key
-and host so landing pageviews and explicit CTA/demo/waitlist events are captured.
+and use the `/mry` same-site proxy so landing pageviews and explicit CTA/demo/waitlist events
+are captured without sending browser traffic directly to PostHog's ingestion domain.
 
 | Variable            | Required | Description                                         |
 | ------------------- | -------- | --------------------------------------------------- |
 | `VITE_POSTHOG_KEY`  | No       | Public PostHog project key; blank disables tracking |
-| `VITE_POSTHOG_HOST` | No       | PostHog ingestion host; blank disables tracking     |
+| `VITE_POSTHOG_HOST` | No       | Browser ingestion host; use `/mry` on Vercel        |
 | `POSTHOG_API_KEY`   | No       | Server-side project key for API route events        |
-| `POSTHOG_HOST`      | No       | Server-side ingestion host                          |
+| `POSTHOG_HOST`      | No       | Server-side PostHog ingestion host                  |
 
 Paddle checkout uses a serverless function so the Paddle API key stays server-side. Checkout
 requests must include an account-bound checkout token minted by the sync server so Paddle webhook
@@ -113,6 +114,7 @@ set the Vercel project Root Directory to `apps/landing` so Vercel reads this pac
 - `api/waitlist.ts` runs as a serverless function
 - SPA is served as static output from `vite build`
 - Domain redirects configured in `vercel.json` (www + .ai variants → memrynote.com)
+- PostHog browser analytics proxied through `/mry/*` Vercel rewrites
 
 ## Design Tokens
 

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -5,6 +5,20 @@
       "*": false
     }
   },
+  "rewrites": [
+    {
+      "source": "/mry/static/:path(.*)",
+      "destination": "https://us-assets.i.posthog.com/static/:path"
+    },
+    {
+      "source": "/mry/array/:path(.*)",
+      "destination": "https://us-assets.i.posthog.com/array/:path"
+    },
+    {
+      "source": "/mry/:path(.*)",
+      "destination": "https://us.i.posthog.com/:path"
+    }
+  ],
   "redirects": [
     {
       "source": "/:path(.*)",


### PR DESCRIPTION
## Summary
- create PostHog managed reverse proxy at e.memrynote.com
- configure landing PostHog SDK to use e.memrynote.com as api_host and https://us.posthog.com as ui_host
- document the managed proxy host for landing analytics

## Live setup
- PostHog proxy: e.memrynote.com -> a957034b4b800e52e008.cf-prod-us-proxy.proxyhog.com
- Cloudflare DNS: CNAME e.memrynote.com, DNS-only / unproxied
- Vercel production VITE_POSTHOG_HOST: https://e.memrynote.com
- Vercel branch preview VITE_POSTHOG_HOST: https://e.memrynote.com

## Verification
- pnpm --filter @memry/landing build
- pnpm docs:impact --base origin/main --strict
- git diff --check
- PostHog proxy status: valid
- https://e.memrynote.com/static/array.js returns 200
- Vercel production deploy dpl_6VVBDnHbozYE2aw9QZ2z7KBfGGJF is Ready
- live bundle initializes PostHog with api_host https://e.memrynote.com and ui_host https://us.posthog.com