### PR TITLE
Fix telemetry privacy review findings

### DIFF
--- a/apps/desktop/src/main/telemetry/runtime.test.ts
+++ b/apps/desktop/src/main/telemetry/runtime.test.ts
@@ -70,7 +70,8 @@ describe('initializeTelemetryRuntime', () => {
     const runtime = initializeTelemetryRuntime({
       fetch: fetchMock,
       buildChannel: 'production',
-      endpoint: 'https://example.test/telemetry/batch'
+      endpoint: 'https://example.test/telemetry/batch',
+      initialEnabled: true
     })
 
     expect(runtime.client.getQueueDepth()).toBe(1)
@@ -82,7 +83,8 @@ describe('initializeTelemetryRuntime', () => {
     const runtime = initializeTelemetryRuntime({
       fetch: fetchMock,
       buildChannel: 'production',
-      endpoint: 'https://example.test/telemetry/batch'
+      endpoint: 'https://example.test/telemetry/batch',
+      initialEnabled: true
     })
 
     await runtime.flush('manual')
@@ -97,7 +99,8 @@ describe('initializeTelemetryRuntime', () => {
     const runtime = initializeTelemetryRuntime({
       fetch: fetchMock,
       buildChannel: 'production',
-      endpoint: 'https://example.test/telemetry/batch'
+      endpoint: 'https://example.test/telemetry/batch',
+      initialEnabled: true
     })
 
     expect(runtime.client.getQueueDepth()).toBeGreaterThan(0)
@@ -145,6 +148,19 @@ describe('initializeTelemetryRuntime', () => {
     expect(runtime.client.getQueueDepth()).toBe(0)
   })
 
+  it('disabled-by-default in production unless explicitly enabled', () => {
+    const { fetchMock } = createFetch()
+
+    const runtime = initializeTelemetryRuntime({
+      fetch: fetchMock,
+      buildChannel: 'production',
+      endpoint: 'https://example.test/telemetry/batch'
+    })
+
+    expect(runtime.getSettings().enabled).toBe(false)
+    expect(runtime.client.getQueueDepth()).toBe(0)
+  })
+
   it('respects the persisted disabled setting in production', () => {
     fs.writeFileSync(
       path.join(tempDir, TELEMETRY_CONFIG_FILENAME),
@@ -170,7 +186,8 @@ describe('initializeTelemetryRuntime', () => {
     const runtime = initializeTelemetryRuntime({
       fetch: fetchMock,
       buildChannel: 'production',
-      endpoint: 'https://example.test/telemetry/batch'
+      endpoint: 'https://example.test/telemetry/batch',
+      initialEnabled: true
     })
 
     runtime.track({

--- a/apps/desktop/src/main/telemetry/runtime.ts
+++ b/apps/desktop/src/main/telemetry/runtime.ts
@@ -88,14 +88,9 @@ const resolveEndpoint = (override?: string, channel?: TelemetryBuildChannel): st
   return `${DEV_DEFAULT_SYNC_SERVER}/telemetry/batch`
 }
 
-const computeInitialEnabled = (
-  channel: TelemetryBuildChannel,
-  storedEnabled: boolean | undefined,
-  override?: boolean
-): boolean => {
+const computeInitialEnabled = (storedEnabled: boolean | undefined, override?: boolean): boolean => {
   if (typeof override === 'boolean') return override
   if (typeof storedEnabled === 'boolean') return storedEnabled
-  if (channel === 'production') return true
   return process.env.MEMRY_TELEMETRY_ENABLED === 'true'
 }
 
@@ -115,7 +110,7 @@ export const initializeTelemetryRuntime = (deps?: TelemetryRuntimeDeps): Telemet
   const sessionId = deps?.sessionId ?? randomUUID()
   const platform = detectPlatform(deps?.platform)
   const stored = readTelemetryConfig()
-  const initialEnabled = computeInitialEnabled(channel, stored.enabled, deps?.initialEnabled)
+  const initialEnabled = computeInitialEnabled(stored.enabled, deps?.initialEnabled)
   const endpoint = resolveEndpoint(deps?.endpoint, channel)
 
   const context: TelemetryClientContext = {

--- a/apps/desktop/src/renderer/src/hooks/use-telemetry-settings.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-telemetry-settings.test.ts
@@ -30,7 +30,7 @@ describe('useTelemetrySettings', () => {
     expect(result.current.enabled).toBe(true)
   })
 
-  it('falls back to enabled = true if the runtime reports an error', async () => {
+  it('falls back to enabled = false if the runtime reports an error', async () => {
     const apiMock = window.api as unknown as {
       telemetry: { getSettings: ReturnType<typeof vi.fn>; setEnabled: ReturnType<typeof vi.fn> }
     }
@@ -41,7 +41,7 @@ describe('useTelemetrySettings', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    expect(result.current.enabled).toBe(true)
+    expect(result.current.enabled).toBe(false)
   })
 
   it('toggles via setEnabled and forwards the new value to the runtime', async () => {

--- a/apps/desktop/src/renderer/src/hooks/use-telemetry-settings.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-telemetry-settings.ts
@@ -21,7 +21,7 @@ export interface UseTelemetrySettingsReturn {
 }
 
 export function useTelemetrySettings(): UseTelemetrySettingsReturn {
-  const [enabled, setEnabledState] = useState(true)
+  const [enabled, setEnabledState] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -36,7 +36,7 @@ export function useTelemetrySettings(): UseTelemetrySettingsReturn {
         const result = await api.getSettings()
         if (mounted) setEnabledState(result.enabled)
       } catch (error) {
-        logger.warn('Failed to load telemetry settings; falling back to enabled', error)
+        logger.warn('Failed to load telemetry settings; falling back to disabled', error)
       } finally {
         if (mounted) setIsLoading(false)
       }

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -42,7 +42,8 @@ trackTelemetry('page_viewed', { surface: 'notes', action: 'viewed' })
 
 Recognized surfaces (`TelemetrySurface` in `packages/contracts/telemetry-api`):
 
-`onboarding`, `notes`, `journal`, `tasks`, `inbox`, `calendar`, `search`, `graph`, `templates`, `settings`.
+`app`, `onboarding`, `vault`, `notes`, `journal`, `tasks`, `inbox`, `calendar`, `search`,
+`graph`, `settings`, `sync`, `ai`, `voice`, `updater`.
 
 ### What Never Ships
 
@@ -84,6 +85,10 @@ The sync server always writes accepted desktop telemetry batches to Cloudflare A
 When `POSTHOG_API_KEY` and `POSTHOG_HOST` are configured on the sync server, the same
 content-free events are mirrored to PostHog's batch endpoint.
 
+PostHog mirroring does not use install IDs, session IDs, or their hashes as person identifiers.
+Desktop telemetry is grouped under a server-level `memry_desktop_<environment>` distinct ID while
+filterable dimensions stay in event properties.
+
 Additional PostHog events:
 
 | Event                        | Source                                    |
@@ -117,4 +122,7 @@ Use `https://eu.i.posthog.com` for EU Cloud projects.
 
 ## Performance
 
-`trackTelemetry` is debounced and batched. Calls during the first second of startup are deferred until after the vault is open so they never delay first paint.
+`trackTelemetry` is debounced and batched. Calls during the first second of startup are deferred
+until after the vault is open so they never delay first paint. On the sync server, Analytics Engine
+writes finish before `/telemetry/batch` responds, while optional PostHog mirroring runs in
+`waitUntil` so third-party telemetry cannot block the request path.

--- a/apps/sync-server/src/routes/telemetry.test.ts
+++ b/apps/sync-server/src/routes/telemetry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../middleware/rate-limit', () => ({
   createRateLimiter: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next())
@@ -34,6 +34,10 @@ const sampleBatch = {
   syncState: 'disabled',
   events: [sampleEvent]
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 function createDataset() {
   const writeDataPoint = vi.fn()
@@ -81,6 +85,50 @@ describe('POST /telemetry/batch', () => {
     const body = (await response.json()) as { accepted: number }
     expect(body.accepted).toBe(1)
     expect(writeDataPoint).toHaveBeenCalledTimes(1)
+  })
+
+  it('schedules PostHog mirroring in waitUntil without blocking the response', async () => {
+    // #given a PostHog mirror that has not resolved yet
+    const { env } = createEnv({
+      POSTHOG_API_KEY: 'phc_test_project',
+      POSTHOG_HOST: 'https://us.i.posthog.com'
+    })
+    let resolveFetch: (() => void) | undefined
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = () => resolve(new Response(JSON.stringify({ status: 1 }), { status: 200 }))
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => fetchPromise)
+    )
+
+    const waitUntilPromises: Promise<unknown>[] = []
+    const executionCtx = {
+      waitUntil: vi.fn((promise: Promise<unknown>) => {
+        waitUntilPromises.push(promise)
+      })
+    } as unknown as ExecutionContext
+    const request = new Request('http://localhost/telemetry/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(sampleBatch)
+    })
+
+    // #when posting through the route
+    const responsePromise = Promise.resolve(app.request(request, {}, env, executionCtx))
+    const result = await Promise.race([
+      responsePromise,
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 25))
+    ])
+    resolveFetch?.()
+    await responsePromise.catch(() => undefined)
+
+    // #then the request is accepted before PostHog finishes
+    expect(result).not.toBe('timeout')
+    expect((result as Response).status).toBe(202)
+    expect(executionCtx.waitUntil).toHaveBeenCalledWith(expect.any(Promise))
+    expect(waitUntilPromises).toHaveLength(1)
+    await Promise.all(waitUntilPromises)
   })
 
   it('does not require an Authorization header', async () => {

--- a/apps/sync-server/src/routes/telemetry.ts
+++ b/apps/sync-server/src/routes/telemetry.ts
@@ -21,6 +21,8 @@ telemetry.post('/batch', async (c) => {
     throw new AppError(ErrorCodes.VALIDATION_ERROR, 'Invalid telemetry payload', 400)
   }
 
-  const result = await writeTelemetryBatch(c.env, parsed.data)
+  const result = await writeTelemetryBatch(c.env, parsed.data, {
+    waitUntil: (promise) => c.executionCtx.waitUntil(promise)
+  })
   return c.json(result, 202)
 })

--- a/apps/sync-server/src/services/posthog.test.ts
+++ b/apps/sync-server/src/services/posthog.test.ts
@@ -9,6 +9,7 @@ const env = {
 }
 
 const UUID = '550e8400-e29b-41d4-a716-446655440000'
+const DEVICE_ID = 'aabbccdd00112233aabbccdd00112233'
 
 const readPostHogBody = () => {
   const fetchMock = vi.mocked(fetch)
@@ -83,6 +84,51 @@ describe('sync-server PostHog capture', () => {
     const payloadText = JSON.stringify(body)
     expect(payloadText).not.toContain(UUID)
     expect(payloadText).not.toContain('private-note-title')
+    expect(payloadText).not.toContain('secret-token')
+  })
+
+  it('redacts non-UUID path identifiers and file-shaped paths', async () => {
+    // #given sensitive-looking path segments that are not UUID-shaped
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ status: 1 }), { status: 200 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when capturing a route error with a device id in the path
+    await captureServerError(env, {
+      error: new Error('device lookup failed'),
+      method: 'PATCH',
+      path: `/devices/${DEVICE_ID}`,
+      source: 'ErrorHandler',
+      action: 'request_failed',
+      handled: true
+    })
+
+    // #then the identifier is replaced with a route placeholder
+    const deviceBody = readPostHogBody()
+    expect(deviceBody.batch[0].properties.path).toBe('/devices/:value')
+    expect(JSON.stringify(deviceBody)).not.toContain(DEVICE_ID)
+
+    fetchMock.mockClear()
+
+    // #when a file-shaped path accidentally reaches the sanitizer
+    await captureServerLog(env, {
+      level: 'error',
+      method: 'GET',
+      path: '/Users/kaan/private-vault/secret-note.md?token=secret-token',
+      source: 'Filesystem',
+      action: 'read_failed',
+      statusCode: 500
+    })
+
+    // #then no directory or filename segment survives
+    const fileBody = readPostHogBody()
+    const payloadText = JSON.stringify(fileBody)
+    expect(fileBody.batch[0].properties.path).toBe('/:value/:value/:value/:value')
+    expect(payloadText).not.toContain('Users')
+    expect(payloadText).not.toContain('kaan')
+    expect(payloadText).not.toContain('private-vault')
+    expect(payloadText).not.toContain('secret-note')
     expect(payloadText).not.toContain('secret-token')
   })
 

--- a/apps/sync-server/src/services/posthog.ts
+++ b/apps/sync-server/src/services/posthog.ts
@@ -3,8 +3,56 @@ import type { Bindings } from '../types'
 
 const POSTHOG_BATCH_PATH = '/batch/'
 const SERVER_SERVICE_NAME = 'memry-sync-server'
-const UUID_SEGMENT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-const SAFE_SEGMENT = /^[a-z0-9_.:-]{1,32}$/i
+const STATIC_ROUTE_SEGMENTS = new Set([
+  'approve',
+  'attachments',
+  'auth',
+  'batch',
+  'blob',
+  'calendar',
+  'callback',
+  'channels',
+  'changes',
+  'checkout-token',
+  'chunk',
+  'chunks',
+  'complete',
+  'crdt',
+  'devices',
+  'github',
+  'google',
+  'google-calendar',
+  'health',
+  'initiate',
+  'items',
+  'linking',
+  'logout',
+  'manifest',
+  'oauth',
+  'otp',
+  'paddle',
+  'pull',
+  'push',
+  'records',
+  'recovery',
+  'recovery-info',
+  'refresh',
+  'request',
+  'resend',
+  'scan',
+  'session',
+  'setup',
+  'snapshot',
+  'status',
+  'storage',
+  'sync',
+  'telemetry',
+  'updates',
+  'upload',
+  'verify',
+  'webhooks',
+  'ws'
+])
 
 const logger = createLogger('PostHog')
 
@@ -65,12 +113,8 @@ const safeLabel = (value: string | undefined, fallback: string): string => {
   return value.replace(/[^a-zA-Z0-9_.:-]/g, '_').slice(0, 80) || fallback
 }
 
-const normalizePathSegment = (segment: string, index: number): string => {
-  if (index > 2 || UUID_SEGMENT.test(segment) || !SAFE_SEGMENT.test(segment)) {
-    return ':value'
-  }
-  return segment
-}
+const normalizePathSegment = (segment: string): string =>
+  STATIC_ROUTE_SEGMENTS.has(segment.toLowerCase()) ? segment.toLowerCase() : ':value'
 
 const normalizeServerPath = (path: string | undefined): string => {
   if (!path) return '/'
@@ -84,7 +128,7 @@ const normalizeServerPath = (path: string | undefined): string => {
   const segments = pathname
     .split('/')
     .filter(Boolean)
-    .map((segment, index) => normalizePathSegment(segment, index))
+    .map((segment) => normalizePathSegment(segment))
 
   return segments.length > 0 ? `/${segments.join('/')}` : '/'
 }

--- a/apps/sync-server/src/services/telemetry.test.ts
+++ b/apps/sync-server/src/services/telemetry.test.ts
@@ -68,6 +68,7 @@ function createEnv(
     TELEMETRY_HMAC_KEY: string
     POSTHOG_API_KEY?: string
     POSTHOG_HOST?: string
+    ENVIRONMENT?: string
   }
 }
 
@@ -312,7 +313,7 @@ describe('writeTelemetryBatch', () => {
     expect(blobsJoined.includes(HMAC_KEY)).toBe(false)
   })
 
-  it('mirrors accepted telemetry events into PostHog batch when configured', async () => {
+  it('mirrors accepted telemetry events into PostHog batch without stable client identifiers', async () => {
     // #given a configured PostHog project and a telemetry batch
     const { dataset } = createDataset()
     const fetchMock = vi.fn(async (_input: string | URL, _init?: RequestInit) => {
@@ -324,7 +325,8 @@ describe('writeTelemetryBatch', () => {
     await writeTelemetryBatch(
       createEnv(dataset, HMAC_KEY, {
         POSTHOG_API_KEY: 'phc_test_project',
-        POSTHOG_HOST: 'https://us.i.posthog.com'
+        POSTHOG_HOST: 'https://us.i.posthog.com',
+        ENVIRONMENT: 'development'
       }),
       baseBatch
     )
@@ -351,15 +353,17 @@ describe('writeTelemetryBatch', () => {
     expect(body.api_key).toBe('phc_test_project')
     expect(body.batch).toHaveLength(1)
     expect(body.batch[0].event).toBe('app_started')
-    expect(body.batch[0].distinct_id).toMatch(/^[0-9a-f]{64}$/)
+    expect(body.batch[0].distinct_id).toBe('memry_desktop_development')
     expect(body.batch[0].properties).toMatchObject({
       app_version: '0.1.0',
       build_channel: 'development',
+      environment: 'development',
       platform: 'darwin',
       surface: 'app',
       action: 'started',
       result: 'success'
     })
+    expect(body.batch[0].properties.telemetry_session_id).toBeUndefined()
     const payloadText = JSON.stringify(body)
     expect(payloadText.includes(VALID_INSTALL_ID)).toBe(false)
     expect(payloadText.includes(VALID_SESSION_ID)).toBe(false)

--- a/apps/sync-server/src/services/telemetry.ts
+++ b/apps/sync-server/src/services/telemetry.ts
@@ -134,6 +134,10 @@ export interface TelemetryEnv {
   ENVIRONMENT?: Bindings['ENVIRONMENT']
 }
 
+export interface TelemetryWriteOptions {
+  waitUntil?: (promise: Promise<unknown>) => void
+}
+
 const addStringProperty = (
   properties: Record<string, string | number>,
   key: string,
@@ -154,10 +158,17 @@ const addNumberProperty = (
   }
 }
 
+const safePostHogLabel = (value: string | undefined, fallback: string): string => {
+  if (!value) return fallback
+  return value.replace(/[^a-zA-Z0-9_.:-]/g, '_').slice(0, 80) || fallback
+}
+
+const desktopDistinctId = (batch: TelemetryBatch, environment?: string): string =>
+  `memry_desktop_${safePostHogLabel(environment ?? batch.buildChannel, 'unknown')}`
+
 export const toPostHogEvent = (
   batch: TelemetryBatch,
   event: TelemetryEvent,
-  hashes: BatchHashes,
   environment?: string
 ): PostHogEventPayload => {
   const dim = firstDimension(event.dimensions)
@@ -173,7 +184,6 @@ export const toPostHogEvent = (
     sync_state: batch.syncState,
     surface: event.surface,
     action: event.action,
-    telemetry_session_id: hashes.sessionHash,
     batch_size: batch.events.length
   }
 
@@ -196,7 +206,7 @@ export const toPostHogEvent = (
 
   return {
     event: event.name,
-    distinct_id: hashes.installHash,
+    distinct_id: desktopDistinctId(batch, environment),
     timestamp: event.occurredAt,
     properties
   }
@@ -205,27 +215,29 @@ export const toPostHogEvent = (
 export const toPostHogBatchPayload = (
   apiKey: string,
   batch: TelemetryBatch,
-  hashes: BatchHashes,
   environment?: string
 ): PostHogBatchPayload => ({
   api_key: apiKey,
-  batch: batch.events.map((event) => toPostHogEvent(batch, event, hashes, environment))
+  batch: batch.events.map((event) => toPostHogEvent(batch, event, environment))
 })
+
+const shouldMirrorTelemetryBatch = (env: TelemetryEnv): boolean =>
+  Boolean(env.POSTHOG_API_KEY && env.POSTHOG_HOST)
 
 const mirrorTelemetryBatchToPostHog = async (
   env: TelemetryEnv,
-  batch: TelemetryBatch,
-  hashes: BatchHashes
+  batch: TelemetryBatch
 ): Promise<void> => {
   if (!env.POSTHOG_API_KEY || !env.POSTHOG_HOST) return
 
-  const payload = toPostHogBatchPayload(env.POSTHOG_API_KEY, batch, hashes, env.ENVIRONMENT)
+  const payload = toPostHogBatchPayload(env.POSTHOG_API_KEY, batch, env.ENVIRONMENT)
   await sendPostHogBatch(env, payload.batch)
 }
 
 export const writeTelemetryBatch = async (
   env: TelemetryEnv,
-  batch: TelemetryBatch
+  batch: TelemetryBatch,
+  options: TelemetryWriteOptions = {}
 ): Promise<{ accepted: number }> => {
   const installHash = await hashTelemetryId(env.TELEMETRY_HMAC_KEY, batch.installId)
   const sessionHash = await hashTelemetryId(env.TELEMETRY_HMAC_KEY, batch.sessionId)
@@ -240,7 +252,14 @@ export const writeTelemetryBatch = async (
     })
   }
 
-  await mirrorTelemetryBatchToPostHog(env, batch, hashes)
+  if (shouldMirrorTelemetryBatch(env)) {
+    const mirrorPromise = mirrorTelemetryBatchToPostHog(env, batch)
+    if (options.waitUntil) {
+      options.waitUntil(mirrorPromise)
+    } else {
+      await mirrorPromise
+    }
+  }
 
   return { accepted: batch.events.length }
 }


### PR DESCRIPTION
## Summary

- Default desktop telemetry to disabled unless explicitly enabled or persisted by the user.
- Redact all dynamic sync-server path segments before PostHog export and fail closed in renderer telemetry settings.
- Move optional PostHog telemetry mirroring onto `waitUntil` and avoid install/session IDs or hashes as PostHog identifiers.
- Update observability docs to match runtime behavior.

## Validation

- `pnpm --dir apps/sync-server exec vitest run src/services/posthog.test.ts src/routes/telemetry.test.ts src/services/telemetry.test.ts`
- `pnpm --dir apps/desktop exec vitest run src/main/telemetry/runtime.test.ts --config config/vitest.config.ts --project main`
- `pnpm --dir apps/desktop exec vitest run src/renderer/src/hooks/use-telemetry-settings.test.ts --config config/vitest.config.ts --project renderer`
- `pnpm --filter @memry/sync-server typecheck`
- `pnpm --filter @memry/desktop typecheck:node`
- `pnpm --filter @memry/desktop typecheck:web`
- `pnpm docs:impact --base origin/main --strict`
- `pnpm docs:build`
- `git diff --check`

Pre-push also ran `pnpm docs:impact --base 27febc8e7ff4328359f62349d2c02560e4ae7e72 --strict`.