### PR TITLE
Move embeddings to a utility process

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -75,6 +75,7 @@ export default defineConfig({
       rollupOptions: {
         input: {
           index: resolve(appRoot, 'src/main/index.ts'),
+          'embedding-worker': resolve(appRoot, 'src/main/lib/embedding-worker.ts'),
           'sync-worker': resolve(appRoot, 'src/main/sync/worker.ts'),
           'voice-transcription-worker': resolve(
             appRoot,

--- a/apps/desktop/src/main/inbox/suggestions.test.ts
+++ b/apps/desktop/src/main/inbox/suggestions.test.ts
@@ -296,7 +296,7 @@ describe('inbox suggestions', () => {
     expect(rawDb.prepare).toHaveBeenCalledWith('DELETE FROM vec_notes')
   })
 
-  it('combines similar-note folder and direct-note suggestions', async () => {
+  it('combines similar-note folder and direct-note suggestions when model starts cold', async () => {
     const now = new Date().toISOString()
     const { rawDb, statement } = createRawDbMock()
     statement.all.mockReturnValue([
@@ -304,7 +304,7 @@ describe('inbox suggestions', () => {
       { note_id: 'note-too-far', distance: 1.5 }
     ])
     vi.mocked(getRawIndexDatabase).mockReturnValue(rawDb as never)
-    mockIsModelLoaded.mockReturnValue(true)
+    mockIsModelLoaded.mockReturnValue(false)
     mockGenerateEmbedding.mockResolvedValue(new Float32Array([0.1, 0.2]))
 
     testDb.db
@@ -333,6 +333,9 @@ describe('inbox suggestions', () => {
 
     const suggestions = await getSuggestions('item-similar')
 
+    expect(mockGenerateEmbedding).toHaveBeenCalledWith(
+      'Research memo\n\nlong enough content for matching'
+    )
     expect(suggestions).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/apps/desktop/src/main/inbox/suggestions.ts
+++ b/apps/desktop/src/main/inbox/suggestions.ts
@@ -502,11 +502,6 @@ export async function getSuggestions(itemId: string): Promise<FilingSuggestion[]
     return []
   }
 
-  // Check if model is loaded (don't block on loading)
-  if (!isModelLoaded()) {
-    log.debug('Model not loaded, returning history-based suggestions only')
-  }
-
   try {
     const db = requireDatabase()
     const item = db.select().from(inboxItems).where(eq(inboxItems.id, itemId)).get()
@@ -525,7 +520,7 @@ export async function getSuggestions(itemId: string): Promise<FilingSuggestion[]
     // 1. Find similar notes → suggest both folders AND direct note links
     const noteSuggestions: FilingSuggestion[] = []
 
-    if (isModelLoaded() && content.length >= MIN_CONTENT_LENGTH) {
+    if (content.length >= MIN_CONTENT_LENGTH) {
       const similarNotes = await findSimilarNotes(content, 8)
 
       for (const note of similarNotes) {
@@ -785,8 +780,8 @@ export async function getNoteFolderSuggestions(noteId: string): Promise<FolderSu
     // Build content for similarity search
     const content = [note.title, note.content].filter(Boolean).join('\n\n')
 
-    // 1. Find similar notes and suggest their folders (only if model is loaded)
-    if (isModelLoaded() && content.length >= MIN_CONTENT_LENGTH) {
+    // 1. Find similar notes and suggest their folders
+    if (content.length >= MIN_CONTENT_LENGTH) {
       const similarNotes = await findSimilarNotes(content, 10)
 
       for (const similar of similarNotes) {

--- a/apps/desktop/src/main/lib/embedding-model-protocol.ts
+++ b/apps/desktop/src/main/lib/embedding-model-protocol.ts
@@ -1,0 +1,42 @@
+export type EmbeddingProgressPhase = 'downloading' | 'loading' | 'ready' | 'error'
+
+export interface EmbeddingProgressMessage {
+  type: 'progress'
+  phase: EmbeddingProgressPhase
+  progress: number
+  status: string
+}
+
+export type EmbeddingMainToWorkerMessage =
+  | {
+      type: 'load-model'
+      requestId: string
+    }
+  | {
+      type: 'embed'
+      requestId: string
+      text: string
+    }
+  | {
+      type: 'shutdown'
+    }
+
+export type EmbeddingWorkerToMainMessage =
+  | {
+      type: 'ready'
+    }
+  | EmbeddingProgressMessage
+  | {
+      type: 'load-model-result'
+      requestId: string
+    }
+  | {
+      type: 'embed-result'
+      requestId: string
+      embedding: number[]
+    }
+  | {
+      type: 'error'
+      requestId: string
+      error: string
+    }

--- a/apps/desktop/src/main/lib/embedding-worker.test.ts
+++ b/apps/desktop/src/main/lib/embedding-worker.test.ts
@@ -1,0 +1,108 @@
+import { EventEmitter } from 'events'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EMBEDDING_DIMENSION } from './embeddings-constants'
+
+const mockPipeline = vi.hoisted(() => vi.fn())
+const mockEnv = vi.hoisted(() => ({ cacheDir: '' }))
+
+class MockParentPort extends EventEmitter {
+  postMessage = vi.fn()
+}
+
+vi.mock('@huggingface/transformers', () => ({
+  pipeline: mockPipeline,
+  env: mockEnv
+}))
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+describe('embedding worker', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-embedding-worker-'))
+    process.env.MEMRY_USER_DATA_PATH = tempDir
+    mockPipeline.mockReset()
+    mockEnv.cacheDir = ''
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(process, 'parentPort')
+    Reflect.deleteProperty(process.env, 'MEMRY_USER_DATA_PATH')
+    fs.rmSync(tempDir, { recursive: true, force: true })
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('announces ready through process.parentPort on startup', async () => {
+    const port = new MockParentPort()
+    Object.defineProperty(process, 'parentPort', {
+      configurable: true,
+      writable: true,
+      value: port
+    })
+
+    await import('./embedding-worker')
+
+    expect(port.postMessage).toHaveBeenCalledWith({ type: 'ready' })
+  })
+
+  it('loads the feature-extraction pipeline and returns a serializable embedding', async () => {
+    const port = new MockParentPort()
+    Object.defineProperty(process, 'parentPort', {
+      configurable: true,
+      writable: true,
+      value: port
+    })
+
+    const mockExtractor = vi.fn().mockResolvedValue({
+      data: new Float32Array(EMBEDDING_DIMENSION)
+    })
+    mockPipeline.mockImplementationOnce(async (_task, _model, options) => {
+      options?.progress_callback?.({ status: 'progress', progress: 42 })
+      options?.progress_callback?.({ status: 'done' })
+      return mockExtractor
+    })
+
+    await import('./embedding-worker')
+
+    port.emit('message', {
+      data: {
+        type: 'embed',
+        requestId: 'req-1',
+        text: 'a'.repeat(2500)
+      }
+    })
+
+    await vi.waitFor(() => {
+      expect(port.postMessage).toHaveBeenCalledWith({
+        type: 'embed-result',
+        requestId: 'req-1',
+        embedding: Array.from(new Float32Array(EMBEDDING_DIMENSION))
+      })
+    })
+
+    expect(mockEnv.cacheDir).toBe(path.join(tempDir, 'models', 'transformers'))
+    expect(mockPipeline).toHaveBeenCalledWith(
+      'feature-extraction',
+      'Xenova/all-MiniLM-L6-v2',
+      expect.objectContaining({
+        dtype: 'fp32'
+      })
+    )
+    expect(mockExtractor).toHaveBeenCalledWith('a'.repeat(2000), {
+      pooling: 'mean',
+      normalize: true
+    })
+  })
+})

--- a/apps/desktop/src/main/lib/embedding-worker.ts
+++ b/apps/desktop/src/main/lib/embedding-worker.ts
@@ -1,0 +1,179 @@
+import path from 'path'
+
+import { createLogger } from './logger'
+import { EMBEDDING_DIMENSION } from './embeddings-constants'
+import type {
+  EmbeddingMainToWorkerMessage,
+  EmbeddingProgressPhase,
+  EmbeddingWorkerToMainMessage
+} from './embedding-model-protocol'
+
+const logger = createLogger('Embeddings:Worker')
+
+const MODEL_NAME = 'Xenova/all-MiniLM-L6-v2'
+const MAX_CONTENT_LENGTH = 2000
+
+interface ModelProgress {
+  status: string
+  progress?: number
+}
+
+const parentPort = process.parentPort
+
+if (!parentPort) {
+  throw new Error('embedding-worker.ts must be run as an Electron utility process')
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let extractor: any = null
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let loadPromise: Promise<any> | null = null
+
+function getUserDataPath(): string {
+  const userDataPath = process.env.MEMRY_USER_DATA_PATH
+
+  if (!userDataPath) {
+    throw new Error('MEMRY_USER_DATA_PATH is not configured')
+  }
+
+  return userDataPath
+}
+
+function getTransformersCacheDir(): string {
+  return path.join(getUserDataPath(), 'models', 'transformers')
+}
+
+function emitProgress(phase: EmbeddingProgressPhase, progress: number, status: string): void {
+  parentPort.postMessage({
+    type: 'progress',
+    phase,
+    progress,
+    status
+  } satisfies EmbeddingWorkerToMainMessage)
+}
+
+async function loadEmbeddingPipeline() {
+  if (extractor) {
+    return extractor
+  }
+
+  if (loadPromise) {
+    return loadPromise
+  }
+
+  emitProgress('loading', 0, 'Initializing embedding model...')
+
+  loadPromise = (async () => {
+    const { pipeline, env } = await import('@huggingface/transformers')
+    env.cacheDir = getTransformersCacheDir()
+
+    extractor = await pipeline('feature-extraction', MODEL_NAME, {
+      dtype: 'fp32',
+      progress_callback: (progress: ModelProgress) => {
+        if (progress.status === 'progress') {
+          const pct = Math.round(progress.progress ?? 0)
+          emitProgress('downloading', pct, `Downloading model: ${pct}%`)
+          return
+        }
+
+        if (progress.status === 'done') {
+          emitProgress('loading', 95, 'Finalizing model...')
+        }
+      }
+    })
+
+    emitProgress('ready', 100, 'Model ready')
+    logger.info('Embedding model ready')
+    return extractor
+  })()
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error)
+      extractor = null
+      emitProgress('error', 0, `Error: ${message}`)
+      logger.error('Failed to load embedding model', { message })
+      throw error
+    })
+    .finally(() => {
+      loadPromise = null
+    })
+
+  return loadPromise
+}
+
+async function handleLoadModel(
+  message: Extract<EmbeddingMainToWorkerMessage, { type: 'load-model' }>
+): Promise<void> {
+  try {
+    await loadEmbeddingPipeline()
+    parentPort.postMessage({
+      type: 'load-model-result',
+      requestId: message.requestId
+    } satisfies EmbeddingWorkerToMainMessage)
+  } catch (error) {
+    const failure = error instanceof Error ? error.message : String(error)
+    parentPort.postMessage({
+      type: 'error',
+      requestId: message.requestId,
+      error: failure
+    } satisfies EmbeddingWorkerToMainMessage)
+  }
+}
+
+async function handleEmbed(
+  message: Extract<EmbeddingMainToWorkerMessage, { type: 'embed' }>
+): Promise<void> {
+  try {
+    const pipeline = await loadEmbeddingPipeline()
+    const output = (await pipeline(message.text.substring(0, MAX_CONTENT_LENGTH), {
+      pooling: 'mean',
+      normalize: true
+    })) as { data: ArrayLike<number> }
+    const embedding = Array.from(output.data)
+
+    if (embedding.length !== EMBEDDING_DIMENSION) {
+      throw new Error(`Unexpected dimension: ${embedding.length} (expected ${EMBEDDING_DIMENSION})`)
+    }
+
+    parentPort.postMessage({
+      type: 'embed-result',
+      requestId: message.requestId,
+      embedding
+    } satisfies EmbeddingWorkerToMainMessage)
+  } catch (error) {
+    const failure = error instanceof Error ? error.message : String(error)
+    parentPort.postMessage({
+      type: 'error',
+      requestId: message.requestId,
+      error: failure
+    } satisfies EmbeddingWorkerToMainMessage)
+  }
+}
+
+parentPort.on('message', (event) => {
+  const message = event.data as EmbeddingMainToWorkerMessage
+
+  switch (message.type) {
+    case 'load-model':
+      void handleLoadModel(message)
+      break
+    case 'embed':
+      void handleEmbed(message)
+      break
+    case 'shutdown':
+      process.exit(0)
+  }
+})
+
+process.on('uncaughtException', (error) => {
+  logger.error('Uncaught embedding worker error', {
+    message: error instanceof Error ? error.message : String(error)
+  })
+})
+
+process.on('unhandledRejection', (reason) => {
+  logger.error('Unhandled embedding worker rejection', {
+    message: reason instanceof Error ? reason.message : String(reason)
+  })
+})
+
+parentPort.postMessage({ type: 'ready' } satisfies EmbeddingWorkerToMainMessage)

--- a/apps/desktop/src/main/lib/embeddings.test.ts
+++ b/apps/desktop/src/main/lib/embeddings.test.ts
@@ -1,23 +1,51 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import path from 'path'
-import { SettingsChannels } from '@memry/contracts/ipc-channels'
-import { mockApp, MockBrowserWindow } from '@tests/utils/mock-electron'
+import { EventEmitter } from 'events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { BrowserWindow } from 'electron'
+import { SettingsChannels } from '@memry/contracts/ipc-channels'
 
-const mockPipeline = vi.fn()
-const mockEnv = { cacheDir: '' }
+const mockApp = vi.hoisted(() => ({
+  getPath: vi.fn((name: string) => `/mock/${name}`)
+}))
+const getAllWindows = vi.hoisted(() => vi.fn())
+const mockFork = vi.hoisted(() => vi.fn())
+
+class MockUtilityProcess extends EventEmitter {
+  postMessage = vi.fn()
+  kill = vi.fn().mockReturnValue(true)
+  stdout = null
+  stderr = null
+  pid = 1234
+
+  simulateMessage(message: unknown): void {
+    this.emit('message', message)
+  }
+}
+
+class MockBrowserWindow {
+  webContents = {
+    send: vi.fn()
+  }
+}
+
+let mockUtilityProcessInstance: MockUtilityProcess
 
 vi.mock('electron', () => ({
   app: mockApp,
   BrowserWindow: {
-    getAllWindows: vi.fn()
+    getAllWindows
+  },
+  utilityProcess: {
+    fork: (...args: unknown[]) => {
+      mockUtilityProcessInstance = new MockUtilityProcess()
+      mockFork(...args)
+      return mockUtilityProcessInstance
+    }
   }
 }))
 
-vi.mock('@huggingface/transformers', () => ({
-  pipeline: mockPipeline,
-  env: mockEnv
-}))
+vi.mock('@huggingface/transformers', () => {
+  throw new Error('@huggingface/transformers should only load inside embedding-worker')
+})
 
 import {
   EMBEDDING_DIMENSION,
@@ -32,8 +60,7 @@ import {
 describe('embeddings', () => {
   beforeEach(() => {
     unloadModel()
-    mockPipeline.mockReset()
-    mockEnv.cacheDir = ''
+    mockFork.mockReset()
     mockApp.getPath.mockImplementation((name: string) =>
       name === 'userData' ? '/mock/user-data' : `/mock/${name}`
     )
@@ -42,71 +69,112 @@ describe('embeddings', () => {
 
   afterEach(() => {
     unloadModel()
+    vi.useRealTimers()
     vi.clearAllMocks()
   })
 
-  it('loads the model, configures cache dir, and emits progress events', async () => {
+  it('loads the model through a utility process and forwards progress events', async () => {
     const window = new MockBrowserWindow()
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([window])
 
-    const mockExtractor = vi.fn().mockResolvedValue({
-      data: new Float32Array(EMBEDDING_DIMENSION)
+    const loadPromise = initEmbeddingModel()
+
+    expect(mockFork).toHaveBeenCalledOnce()
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
     })
 
-    mockPipeline.mockImplementationOnce(async (_task, _model, options) => {
-      options?.progress_callback?.({ status: 'progress', progress: 42 })
-      options?.progress_callback?.({ status: 'done' })
-      return mockExtractor
+    const [, , options] = mockFork.mock.calls[0] ?? []
+    expect(options).toEqual(
+      expect.objectContaining({
+        serviceName: 'Embeddings',
+        env: expect.objectContaining({
+          MEMRY_USER_DATA_PATH: '/mock/user-data'
+        })
+      })
+    )
+
+    const requestMessage = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      type: string
+      requestId: string
+    }
+    expect(requestMessage.type).toBe('load-model')
+
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'progress',
+      phase: 'downloading',
+      progress: 42,
+      status: 'Downloading model: 42%'
+    })
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'progress',
+      phase: 'ready',
+      progress: 100,
+      status: 'Model ready'
+    })
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'load-model-result',
+      requestId: requestMessage.requestId
     })
 
-    const result = await initEmbeddingModel()
-
-    expect(result).toBe(true)
-    expect(mockEnv.cacheDir).toBe(path.join('/mock/user-data', 'models', 'transformers'))
+    await expect(loadPromise).resolves.toBe(true)
     expect(getModelInfo().loaded).toBe(true)
-
-    const phases = window.webContents.send.mock.calls
-      .filter(([channel]) => channel === SettingsChannels.events.EMBEDDING_PROGRESS)
-      .map(([, payload]) => (payload as { phase: string }).phase)
-
-    expect(phases).toEqual(expect.arrayContaining(['loading', 'downloading', 'ready']))
-  })
-
-  it('returns false and surfaces errors when model load fails', async () => {
-    const window = new MockBrowserWindow()
-    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([window])
-
-    mockPipeline.mockImplementationOnce(async () => {
-      throw new Error('load failed')
-    })
-
-    const result = await initEmbeddingModel()
-
-    expect(result).toBe(false)
-    expect(getModelInfo().error).toBe('load failed')
 
     expect(window.webContents.send).toHaveBeenCalledWith(
       SettingsChannels.events.EMBEDDING_PROGRESS,
-      expect.objectContaining({ phase: 'error' })
+      expect.objectContaining({
+        phase: 'downloading',
+        progress: 42
+      })
     )
   })
 
+  it('returns false and surfaces errors when model load fails', async () => {
+    const loadPromise = initEmbeddingModel()
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+
+    const requestMessage = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      requestId: string
+    }
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'error',
+      requestId: requestMessage.requestId,
+      error: 'load failed'
+    })
+
+    await expect(loadPromise).resolves.toBe(false)
+    expect(getModelInfo().error).toBe('load failed')
+  })
+
   it('tracks loading state and unloads the model', async () => {
-    const mockExtractor = vi.fn()
-    let resolvePipeline: () => void
-    const pipelineReady = new Promise<void>((resolve) => {
-      resolvePipeline = resolve
-    })
-
-    mockPipeline.mockImplementationOnce(async () => {
-      await pipelineReady
-      return mockExtractor
-    })
-
     const loading = initEmbeddingModel()
     expect(isModelLoading()).toBe(true)
 
-    resolvePipeline!()
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+    expect(isModelLoading()).toBe(true)
+
+    const requestMessage = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      requestId: string
+    }
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'progress',
+      phase: 'ready',
+      progress: 100,
+      status: 'Model ready'
+    })
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'load-model-result',
+      requestId: requestMessage.requestId
+    })
+
     await loading
 
     expect(isModelLoading()).toBe(false)
@@ -116,39 +184,103 @@ describe('embeddings', () => {
     expect(isModelLoaded()).toBe(false)
   })
 
-  it('returns null for text below the minimum length', async () => {
+  it('returns null for text below the minimum length without starting the worker', async () => {
     const result = await generateEmbedding('short')
+
     expect(result).toBeNull()
+    expect(mockFork).not.toHaveBeenCalled()
   })
 
   it('truncates long text and returns an embedding', async () => {
-    const mockExtractor = vi.fn().mockResolvedValue({
-      data: new Float32Array(EMBEDDING_DIMENSION)
+    const longText = 'a'.repeat(2500)
+    const embeddingPromise = generateEmbedding(longText)
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
     })
 
-    mockPipeline.mockImplementationOnce(async () => mockExtractor)
+    const requestMessage = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      type: string
+      requestId: string
+      text: string
+    }
+    expect(requestMessage.type).toBe('embed')
+    expect(requestMessage.text.length).toBe(2000)
 
-    const longText = 'a'.repeat(2500)
-    const embedding = await generateEmbedding(longText)
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'embed-result',
+      requestId: requestMessage.requestId,
+      embedding: Array.from(new Float32Array(EMBEDDING_DIMENSION))
+    })
 
+    const embedding = await embeddingPromise
     expect(embedding).toBeInstanceOf(Float32Array)
     expect(embedding?.length).toBe(EMBEDDING_DIMENSION)
-    expect(mockExtractor).toHaveBeenCalled()
-
-    const [inputText] = mockExtractor.mock.calls[0]
-    expect(typeof inputText).toBe('string')
-    expect((inputText as string).length).toBe(2000)
   })
 
   it('returns null when embedding dimension is unexpected', async () => {
-    const mockExtractor = vi.fn().mockResolvedValue({
-      data: new Float32Array(10)
+    const embeddingPromise = generateEmbedding('this is long enough for embeddings')
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
     })
 
-    mockPipeline.mockImplementationOnce(async () => mockExtractor)
+    const requestMessage = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      requestId: string
+    }
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'embed-result',
+      requestId: requestMessage.requestId,
+      embedding: Array.from(new Float32Array(10))
+    })
 
-    const embedding = await generateEmbedding('this is long enough for embeddings')
+    await expect(embeddingPromise).resolves.toBeNull()
+  })
 
-    expect(embedding).toBeNull()
+  it('reuses the utility process while active and shuts it down after idling', async () => {
+    vi.useFakeTimers()
+    const firstEmbedding = generateEmbedding('first content long enough')
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+
+    const firstRequest = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      requestId: string
+    }
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'embed-result',
+      requestId: firstRequest.requestId,
+      embedding: Array.from(new Float32Array(EMBEDDING_DIMENSION))
+    })
+
+    await expect(firstEmbedding).resolves.toBeInstanceOf(Float32Array)
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    const secondEmbedding = generateEmbedding('second content long enough')
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(2)
+    })
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(mockUtilityProcessInstance.postMessage).not.toHaveBeenCalledWith({ type: 'shutdown' })
+
+    const secondRequest = mockUtilityProcessInstance.postMessage.mock.calls[1]?.[0] as {
+      requestId: string
+    }
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'embed-result',
+      requestId: secondRequest.requestId,
+      embedding: Array.from(new Float32Array(EMBEDDING_DIMENSION))
+    })
+
+    await expect(secondEmbedding).resolves.toBeInstanceOf(Float32Array)
+    expect(mockFork).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(mockUtilityProcessInstance.postMessage).toHaveBeenLastCalledWith({ type: 'shutdown' })
   })
 })

--- a/apps/desktop/src/main/lib/embeddings.ts
+++ b/apps/desktop/src/main/lib/embeddings.ts
@@ -1,35 +1,26 @@
 /**
  * Local Embedding Service
  *
- * Generates text embeddings locally using @huggingface/transformers
- * with the all-MiniLM-L6-v2 model (384 dimensions).
+ * Coordinates local text embeddings through an Electron utility process.
  *
  * Model is downloaded on first use (~23MB) and cached in app data directory.
  *
  * @module main/lib/embeddings
  */
 
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, utilityProcess } from 'electron'
 import path from 'path'
-import type { FeatureExtractionPipeline } from '@huggingface/transformers'
 import { SettingsChannels } from '@memry/contracts/ipc-channels'
+import type {
+  EmbeddingMainToWorkerMessage,
+  EmbeddingProgressMessage,
+  EmbeddingProgressPhase,
+  EmbeddingWorkerToMainMessage
+} from './embedding-model-protocol'
 import { EMBEDDING_DIMENSION } from './embeddings-constants'
 import { createLogger } from './logger'
 
 const logger = createLogger('Embeddings')
-
-// ============================================================================
-// Types
-// ============================================================================
-
-interface ModelProgress {
-  status: string
-  name?: string
-  file?: string
-  progress?: number
-  loaded?: number
-  total?: number
-}
 
 export interface ModelInfo {
   name: string
@@ -44,7 +35,7 @@ export interface ModelInfo {
 // ============================================================================
 
 /** Model to use for embeddings */
-const MODEL_NAME = 'Xenova/all-MiniLM-L6-v2'
+const MODEL_NAME = 'all-MiniLM-L6-v2'
 
 export { EMBEDDING_DIMENSION } from './embeddings-constants'
 
@@ -53,34 +44,25 @@ const MIN_CONTENT_LENGTH = 10
 
 /** Maximum characters for embedding input (~512 tokens) */
 const MAX_CONTENT_LENGTH = 2000
-
-// ============================================================================
-// State
-// ============================================================================
-
-let extractor: FeatureExtractionPipeline | null = null
-let isLoading = false
-let loadError: string | null = null
+const REQUEST_TIMEOUT_MS = 5 * 60_000
+const START_TIMEOUT_MS = 10_000
+const SHUTDOWN_TIMEOUT_MS = 3_000
+const IDLE_SHUTDOWN_MS = 30_000
 
 // ============================================================================
 // Helper Functions
 // ============================================================================
 
-/**
- * Get the cache directory for transformer models
- */
-function getModelCacheDir(): string {
-  return path.join(app.getPath('userData'), 'models', 'transformers')
+type PendingRequest = {
+  resolve: (value: EmbeddingWorkerToMainMessage) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
 }
 
 /**
  * Emit model loading progress to all renderer windows
  */
-function emitProgress(
-  phase: 'downloading' | 'loading' | 'ready' | 'error',
-  progress: number,
-  status: string
-): void {
+function emitProgress(phase: EmbeddingProgressPhase, progress: number, status: string): void {
   BrowserWindow.getAllWindows().forEach((win) => {
     win.webContents.send(SettingsChannels.events.EMBEDDING_PROGRESS, {
       phase,
@@ -90,6 +72,387 @@ function emitProgress(
   })
 }
 
+class EmbeddingModelBridge {
+  private process: ReturnType<typeof utilityProcess.fork> | null = null
+  private pendingRequests = new Map<string, PendingRequest>()
+  private readyPromise: Promise<void> | null = null
+  private requestCounter = 0
+  private loaded = false
+  private loading = false
+  private error: string | null = null
+  private shuttingDown = false
+  private idleShutdownTimer: ReturnType<typeof setTimeout> | null = null
+
+  get isLoaded(): boolean {
+    return this.loaded
+  }
+
+  get isLoading(): boolean {
+    return this.loading
+  }
+
+  get info(): ModelInfo {
+    return {
+      name: MODEL_NAME,
+      dimension: EMBEDDING_DIMENSION,
+      loaded: this.loaded,
+      loading: this.loading,
+      error: this.error
+    }
+  }
+
+  async loadModel(): Promise<boolean> {
+    try {
+      this.loading = !this.loaded
+      await this.start()
+      const requestId = this.nextRequestId()
+      const response = await this.sendRequest({
+        type: 'load-model',
+        requestId
+      })
+
+      if (response.type === 'error') {
+        this.error = response.error
+        this.loading = false
+        return false
+      }
+
+      if (response.type !== 'load-model-result') {
+        this.error = `Unexpected response type: ${response.type}`
+        this.loading = false
+        return false
+      }
+
+      this.loaded = true
+      this.loading = false
+      this.error = null
+      return true
+    } catch (error) {
+      this.loading = false
+      this.error = error instanceof Error ? error.message : String(error)
+      return false
+    }
+  }
+
+  async embed(text: string): Promise<Float32Array | null> {
+    try {
+      this.loading = !this.loaded
+      await this.start()
+      const requestId = this.nextRequestId()
+      const response = await this.sendRequest({
+        type: 'embed',
+        requestId,
+        text: text.substring(0, MAX_CONTENT_LENGTH)
+      })
+
+      if (response.type === 'error') {
+        this.error = response.error
+        this.loading = false
+        logger.warn('Embedding worker failed:', response.error)
+        return null
+      }
+
+      if (response.type !== 'embed-result') {
+        this.error = `Unexpected response type: ${response.type}`
+        this.loading = false
+        return null
+      }
+
+      const embedding = new Float32Array(response.embedding)
+      if (embedding.length !== EMBEDDING_DIMENSION) {
+        logger.error(`Unexpected dimension: ${embedding.length} (expected ${EMBEDDING_DIMENSION})`)
+        return null
+      }
+
+      this.loaded = true
+      this.loading = false
+      this.error = null
+      return embedding
+    } catch (error) {
+      this.loading = false
+      this.error = error instanceof Error ? error.message : String(error)
+      logger.error('Generation failed:', error)
+      return null
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.clearIdleShutdown()
+
+    if (!this.process) {
+      this.readyPromise = null
+      this.loaded = false
+      this.loading = false
+      return
+    }
+
+    const activeProcess = this.process
+    this.shuttingDown = true
+    this.loaded = false
+    this.loading = false
+
+    activeProcess.postMessage({ type: 'shutdown' } satisfies EmbeddingMainToWorkerMessage)
+
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        activeProcess.kill()
+        resolve()
+      }, SHUTDOWN_TIMEOUT_MS)
+
+      activeProcess.once('exit', () => {
+        clearTimeout(timeout)
+        resolve()
+      })
+    })
+
+    this.process = null
+    this.readyPromise = null
+    this.shuttingDown = false
+  }
+
+  reset(): void {
+    this.shuttingDown = true
+    this.clearIdleShutdown()
+    this.process?.kill()
+    this.process = null
+    this.readyPromise = null
+    this.rejectAll(new Error('Embedding utility reset'))
+    this.loaded = false
+    this.loading = false
+    this.error = null
+    this.shuttingDown = false
+  }
+
+  private async start(): Promise<void> {
+    this.clearIdleShutdown()
+
+    if (this.process) {
+      await this.readyPromise
+      return
+    }
+
+    const workerPath = path.join(__dirname, 'embedding-worker.js')
+    const child = utilityProcess.fork(workerPath, [], {
+      serviceName: 'Embeddings',
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        MEMRY_USER_DATA_PATH: app.getPath('userData')
+      },
+      allowLoadingUnsignedLibraries: process.platform === 'darwin'
+    })
+
+    this.process = child
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      const output = chunk.toString().trim()
+      if (output) {
+        logger.info(`Embedding utility stdout: ${output}`)
+      }
+    })
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      const output = chunk.toString().trim()
+      if (output) {
+        logger.error(`Embedding utility stderr: ${output}`)
+      }
+    })
+
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const error = new Error('Embedding utility failed to start within timeout')
+        logger.error('Embedding utility start timeout', {
+          workerPath,
+          pid: child.pid
+        })
+        this.failProcess(error)
+        reject(error)
+      }, START_TIMEOUT_MS)
+
+      const cleanup = (): void => {
+        clearTimeout(timeout)
+        child.off('message', onMessage)
+        child.off('error', onFatalError)
+        child.off('exit', onExitBeforeReady)
+      }
+
+      const onMessage = (message: EmbeddingWorkerToMainMessage): void => {
+        if (message.type !== 'ready') return
+
+        cleanup()
+        this.setupProcessHandlers(child)
+        logger.info('Embedding utility ready')
+        resolve()
+      }
+
+      const onFatalError = (type: string, location: string, report: string): void => {
+        cleanup()
+        const error = new Error(`Embedding utility fatal error: ${type} at ${location}`)
+        logger.error('Embedding utility fatal error', { type, location, report })
+        this.failProcess(error)
+        reject(error)
+      }
+
+      const onExitBeforeReady = (code: number): void => {
+        cleanup()
+        const error = new Error(`Embedding utility exited unexpectedly (code ${code})`)
+        this.failProcess(error)
+        reject(error)
+      }
+
+      child.on('message', onMessage)
+      child.on('error', onFatalError)
+      child.on('exit', onExitBeforeReady)
+    })
+
+    await this.readyPromise
+  }
+
+  private setupProcessHandlers(child: ReturnType<typeof utilityProcess.fork>): void {
+    child.on('message', (message: EmbeddingWorkerToMainMessage) => {
+      if (message.type === 'ready') {
+        return
+      }
+
+      if (message.type === 'progress') {
+        this.applyProgress(message)
+        return
+      }
+
+      if ('requestId' in message) {
+        const pending = this.pendingRequests.get(message.requestId)
+        if (!pending) {
+          return
+        }
+
+        clearTimeout(pending.timer)
+        this.pendingRequests.delete(message.requestId)
+
+        if (message.type === 'error') {
+          this.error = message.error
+          this.loading = false
+          this.scheduleIdleShutdown()
+          pending.resolve(message)
+          return
+        }
+
+        this.scheduleIdleShutdown()
+        pending.resolve(message)
+      }
+    })
+
+    child.on('error', (type: string, location: string, report: string) => {
+      const error = new Error(`Embedding utility fatal error: ${type} at ${location}`)
+      logger.error('Embedding utility fatal error', { type, location, report })
+      this.failProcess(error)
+    })
+
+    child.on('exit', (code: number) => {
+      if (this.shuttingDown && code === 0) {
+        this.process = null
+        this.readyPromise = null
+        return
+      }
+
+      const error = new Error(`Embedding utility exited unexpectedly (code ${code})`)
+      this.failProcess(error)
+    })
+  }
+
+  private applyProgress(message: EmbeddingProgressMessage): void {
+    if (message.phase === 'ready') {
+      this.loaded = true
+      this.loading = false
+      this.error = null
+    } else if (message.phase === 'error') {
+      this.loaded = false
+      this.loading = false
+      this.error = message.status
+    } else {
+      this.loading = true
+      this.error = null
+    }
+
+    emitProgress(message.phase, message.progress, message.status)
+  }
+
+  private sendRequest(
+    message: Extract<EmbeddingMainToWorkerMessage, { requestId: string }>
+  ): Promise<EmbeddingWorkerToMainMessage> {
+    if (!this.process) {
+      return Promise.reject(new Error('Embedding utility is not running'))
+    }
+
+    this.clearIdleShutdown()
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(message.requestId)
+        this.scheduleIdleShutdown()
+        reject(new Error(`Embedding request timed out: ${message.type}`))
+      }, REQUEST_TIMEOUT_MS)
+
+      this.pendingRequests.set(message.requestId, { resolve, reject, timer })
+      this.process!.postMessage(message)
+    })
+  }
+
+  private nextRequestId(): string {
+    this.requestCounter += 1
+    return `embedding_${this.requestCounter}_${Date.now()}`
+  }
+
+  private failProcess(error: Error): void {
+    this.clearIdleShutdown()
+    if (this.process) {
+      this.process = null
+    }
+    this.readyPromise = null
+    this.loaded = false
+    this.loading = false
+    this.error = error.message
+    this.rejectAll(error)
+  }
+
+  private rejectAll(error: Error): void {
+    for (const [requestId, pending] of this.pendingRequests) {
+      clearTimeout(pending.timer)
+      pending.reject(error)
+      this.pendingRequests.delete(requestId)
+    }
+  }
+
+  private scheduleIdleShutdown(): void {
+    this.clearIdleShutdown()
+
+    if (!this.process || this.pendingRequests.size > 0 || this.shuttingDown) {
+      return
+    }
+
+    this.idleShutdownTimer = setTimeout(() => {
+      this.idleShutdownTimer = null
+      if (!this.process || this.pendingRequests.size > 0 || this.shuttingDown) {
+        return
+      }
+
+      void this.stop().catch((error) => {
+        logger.warn('Embedding utility idle shutdown failed', {
+          error: error instanceof Error ? error.message : String(error)
+        })
+      })
+    }, IDLE_SHUTDOWN_MS)
+  }
+
+  private clearIdleShutdown(): void {
+    if (!this.idleShutdownTimer) {
+      return
+    }
+
+    clearTimeout(this.idleShutdownTimer)
+    this.idleShutdownTimer = null
+  }
+}
+
+const bridge = new EmbeddingModelBridge()
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -97,68 +460,11 @@ function emitProgress(
 /**
  * Initialize the embedding model.
  * Downloads the model on first use (~23MB).
- * Should be called when vault opens for background loading.
  *
  * @returns true if model loaded successfully
  */
 export async function initEmbeddingModel(): Promise<boolean> {
-  // Already loaded
-  if (extractor) {
-    return true
-  }
-
-  // Already loading - wait for it
-  if (isLoading) {
-    logger.info('Model already loading, waiting...')
-    while (isLoading) {
-      await new Promise((resolve) => setTimeout(resolve, 100))
-    }
-    return extractor !== null
-  }
-
-  isLoading = true
-  loadError = null
-
-  try {
-    emitProgress('loading', 0, 'Initializing embedding model...')
-
-    // Dynamic import to avoid loading at startup
-    const { pipeline, env } = await import('@huggingface/transformers')
-
-    // Configure cache directory
-    env.cacheDir = getModelCacheDir()
-    logger.debug('Cache directory:', env.cacheDir)
-
-    emitProgress('downloading', 5, 'Loading model (downloading if first time)...')
-
-    // Explicitly set dtype to fp32 for CPU (silences "dtype not specified" warning).
-    // `pipeline('feature-extraction', ...)` returns a union over all task pipelines that TS
-    // reports as "too complex to represent"; route through `unknown` to narrow to the concrete type.
-    const loaded: unknown = await pipeline('feature-extraction', MODEL_NAME, {
-      dtype: 'fp32',
-      progress_callback: (progress: ModelProgress) => {
-        if (progress.status === 'progress' && progress.progress !== undefined) {
-          const pct = Math.round(progress.progress)
-          emitProgress('downloading', pct, `Downloading model: ${pct}%`)
-        } else if (progress.status === 'done') {
-          emitProgress('loading', 95, 'Finalizing model...')
-        }
-      }
-    })
-    extractor = loaded as FeatureExtractionPipeline
-
-    emitProgress('ready', 100, 'Model ready')
-    logger.info('Model loaded successfully')
-    return true
-  } catch (error) {
-    loadError = error instanceof Error ? error.message : String(error)
-    logger.error('Failed to load model:', loadError)
-    emitProgress('error', 0, `Error: ${loadError}`)
-    extractor = null
-    return false
-  } finally {
-    isLoading = false
-  }
+  return bridge.loadModel()
 }
 
 /**
@@ -173,72 +479,38 @@ export async function generateEmbedding(text: string): Promise<Float32Array | nu
     return null
   }
 
-  if (!extractor) {
-    await initEmbeddingModel()
-  }
-
-  const extractorInstance = extractor
-  if (!extractorInstance) {
-    logger.warn('Model not available, skipping embedding')
-    return null
-  }
-
-  try {
-    const truncated = text.substring(0, MAX_CONTENT_LENGTH)
-
-    const output = (await extractorInstance(truncated, {
-      pooling: 'mean',
-      normalize: true
-    })) as { data: ArrayLike<number> }
-
-    // Extract data as Float32Array
-    const embedding = new Float32Array(output.data)
-
-    // Verify dimension
-    if (embedding.length !== EMBEDDING_DIMENSION) {
-      logger.error(`Unexpected dimension: ${embedding.length} (expected ${EMBEDDING_DIMENSION})`)
-      return null
-    }
-
-    return embedding
-  } catch (error) {
-    logger.error('Generation failed:', error)
-    return null
-  }
+  return bridge.embed(text)
 }
 
 /**
  * Check if the embedding model is loaded
  */
 export function isModelLoaded(): boolean {
-  return extractor !== null
+  return bridge.isLoaded
 }
 
 /**
  * Check if the model is currently loading
  */
 export function isModelLoading(): boolean {
-  return isLoading
+  return bridge.isLoading
 }
 
 /**
  * Get model information
  */
 export function getModelInfo(): ModelInfo {
-  return {
-    name: 'all-MiniLM-L6-v2',
-    dimension: EMBEDDING_DIMENSION,
-    loaded: extractor !== null,
-    loading: isLoading,
-    error: loadError
-  }
+  return bridge.info
 }
 
 /**
  * Unload the model to free memory
  */
 export function unloadModel(): void {
-  extractor = null
-  loadError = null
+  bridge.reset()
   logger.info('Model unloaded')
+}
+
+export async function stopEmbeddingModel(): Promise<void> {
+  await bridge.stop()
 }

--- a/apps/desktop/src/main/vault/index.test.ts
+++ b/apps/desktop/src/main/vault/index.test.ts
@@ -283,7 +283,7 @@ describe('vault lifecycle', () => {
     expect(mocks.indexVault).toHaveBeenCalledWith('/vault/work')
     expect(mocks.startWatcher).toHaveBeenCalledWith('/vault/work')
     expect(mocks.startSyncRuntime).toHaveBeenCalled()
-    expect(mocks.initEmbeddingModel).toHaveBeenCalled()
+    expect(mocks.initEmbeddingModel).not.toHaveBeenCalled()
     expect(mocks.startAgentMcpLifecycle).toHaveBeenCalled()
     expect(mocks.startAgent).toHaveBeenCalled()
     expect(mocks.currentVaultPath).toBe('/vault/work')

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -47,7 +47,6 @@ import { VaultChannels } from '@memry/contracts/ipc-channels'
 import { VaultError, VaultErrorCode } from '../lib/errors'
 import { startWatcher, stopWatcher } from './watcher'
 import { indexVault, rebuildIndex } from './indexer'
-import { initEmbeddingModel, isModelLoaded, isModelLoading } from '../lib/embeddings'
 import { createLogger } from '../lib/logger'
 import { getMainI18n } from '../lib/main-i18n'
 import { startSyncRuntime, stopSyncRuntime } from '../sync/runtime'
@@ -305,14 +304,6 @@ async function openVault(vaultPath: string): Promise<void> {
   await startWatcher(vaultPath)
 
   await startSyncRuntime()
-
-  // Start loading embedding model in background (non-blocking)
-  // This ensures the model is ready when user needs AI suggestions
-  if (!isModelLoaded() && !isModelLoading()) {
-    initEmbeddingModel().catch((err) => {
-      logger.error('Background embedding model load failed:', err)
-    })
-  }
 
   await startVaultAgentServices()
 

--- a/apps/docs/src/user-guide/ai/embeddings-search.md
+++ b/apps/docs/src/user-guide/ai/embeddings-search.md
@@ -35,6 +35,11 @@ The status line shows:
 
 You can **Unload** the model from settings to free memory; reload as needed.
 
+memrynote does not load the embedding model just because a vault opens. Semantic surfaces such as
+search, inbox linked-note suggestions, related notes, and reindexing start the local model on first
+use. The model runs in a separate utility process and shuts down after an idle period so regular note
+reading does not keep the embedding runtime resident forever.
+
 ## Model Size
 
 Models trade off accuracy vs disk and memory. The default is tuned for desktop hardware. The settings page shows dimensions and the current count of embedded notes.


### PR DESCRIPTION
## Summary

- Move local embedding generation into a lazily started Electron utility process so Electron main no longer imports or retains `@huggingface/transformers` / ONNX on vault open.
- Reuse the embedding utility process while requests are active, then shut it down after the idle window.
- Preserve first-request embeddings for semantic surfaces, including inbox linked-note suggestions when the model starts cold.
- Update docs for the lazy utility-process model lifecycle.

Closes #430.

## Verification

- `pnpm --filter @memry/desktop rebuild:node`
- `pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project main src/main/inbox/suggestions.test.ts src/main/lib/embeddings.test.ts src/main/lib/embedding-worker.test.ts`
- `pnpm --filter @memry/desktop typecheck:node`
- `pnpm docs:impact --base 8675d46bb3ccf4d66292af6805c9067083912f88 --strict`
- `pnpm docs:build`
- `git diff --check HEAD~1..HEAD`

## Manual Memory Check

- Branch vault-open Electron group: 797 MiB RSS; main process: 290 MiB RSS; no ONNX/transformers handles in main.
- Main-branch vault-open Electron group: 968 MiB RSS initially / 859 MiB later; main process: 402 MiB / 397 MiB RSS; ONNX runtime handles loaded in main.
- Main-process reduction after vault open: about 107-112 MiB RSS in this dev benchmark.