### PR TITLE
Move image processing to a utility process

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
           index: resolve(appRoot, 'src/main/index.ts'),
           'embedding-worker': resolve(appRoot, 'src/main/lib/embedding-worker.ts'),
           'sync-worker': resolve(appRoot, 'src/main/sync/worker.ts'),
+          'image-processing-worker': resolve(appRoot, 'src/main/image-processing/worker.ts'),
           'voice-transcription-worker': resolve(
             appRoot,
             'src/main/inbox/voice-transcription-worker.ts'

--- a/apps/desktop/src/main/image-processing/bridge.test.ts
+++ b/apps/desktop/src/main/image-processing/bridge.test.ts
@@ -1,0 +1,220 @@
+import { EventEmitter } from 'events'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+const mockApp = vi.hoisted(() => ({
+  getPath: vi.fn((name: string) => `/mock/${name}`)
+}))
+
+class MockUtilityProcess extends EventEmitter {
+  postMessage = vi.fn()
+  kill = vi.fn().mockReturnValue(true)
+  stdout = null
+  stderr = null
+  pid = 4321
+
+  simulateMessage(message: unknown): void {
+    this.emit('message', message)
+  }
+
+  simulateExit(code: number): void {
+    this.emit('exit', code)
+  }
+}
+
+const mockFork = vi.hoisted(() => vi.fn())
+let mockUtilityProcessInstance: MockUtilityProcess
+
+vi.mock('electron', () => ({
+  app: mockApp,
+  utilityProcess: {
+    fork: (...args: unknown[]) => {
+      mockUtilityProcessInstance = new MockUtilityProcess()
+      mockFork(...args)
+      return mockUtilityProcessInstance
+    }
+  }
+}))
+
+vi.mock('sharp', () => {
+  throw new Error('image-processing bridge must not import sharp in the main process')
+})
+
+import {
+  generateThumbnailInImageProcess,
+  processInboxImageAttachment,
+  resetImageProcessingForTests,
+  stopImageProcessing
+} from './bridge'
+
+describe('image-processing bridge', () => {
+  beforeEach(() => {
+    resetImageProcessingForTests()
+    mockFork.mockReset()
+    mockApp.getPath.mockImplementation((name: string) => `/mock/${name}`)
+  })
+
+  afterEach(() => {
+    resetImageProcessingForTests()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('does not start the utility process until image work is requested', () => {
+    expect(mockFork).not.toHaveBeenCalled()
+  })
+
+  it('generates thumbnails in a utility process and shuts down after staying idle', async () => {
+    vi.useFakeTimers()
+    const thumbnailPromise = generateThumbnailInImageProcess('/tmp/photo.jpg', 'image/jpeg')
+
+    expect(mockFork).toHaveBeenCalledOnce()
+    const [, , options] = mockFork.mock.calls[0] ?? []
+    expect(options).toEqual(
+      expect.objectContaining({
+        serviceName: 'ImageProcessing'
+      })
+    )
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+
+    const requestMessage = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      type: string
+      requestId: string
+      filePath: string
+      mimeType: string
+    }
+    expect(requestMessage).toEqual(
+      expect.objectContaining({
+        type: 'generate-thumbnail',
+        filePath: '/tmp/photo.jpg',
+        mimeType: 'image/jpeg'
+      })
+    )
+
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'thumbnail-result',
+      requestId: requestMessage.requestId,
+      result: {
+        data: new Uint8Array(Buffer.from('fake-webp')),
+        width: 150,
+        height: 100,
+        format: 'webp'
+      }
+    })
+
+    await expect(thumbnailPromise).resolves.toEqual({
+      data: Buffer.from('fake-webp'),
+      width: 150,
+      height: 100,
+      format: 'webp'
+    })
+    expect(mockUtilityProcessInstance.postMessage).not.toHaveBeenCalledWith({ type: 'shutdown' })
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mockUtilityProcessInstance.postMessage).toHaveBeenLastCalledWith({ type: 'shutdown' })
+  })
+
+  it('processes inbox image metadata and thumbnails through the utility process', async () => {
+    const processPromise = processInboxImageAttachment('/tmp/inbox/photo.jpg')
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+
+    const requestMessage = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      type: string
+      requestId: string
+      filePath: string
+    }
+    expect(requestMessage).toEqual(
+      expect.objectContaining({
+        type: 'process-inbox-image',
+        filePath: '/tmp/inbox/photo.jpg'
+      })
+    )
+
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'inbox-image-result',
+      requestId: requestMessage.requestId,
+      result: {
+        metadata: {
+          format: 'jpeg',
+          width: 640,
+          height: 480,
+          hasExif: true
+        },
+        thumbnailData: new Uint8Array(Buffer.from('thumb'))
+      }
+    })
+
+    await expect(processPromise).resolves.toEqual({
+      metadata: {
+        format: 'jpeg',
+        width: 640,
+        height: 480,
+        hasExif: true
+      },
+      thumbnailData: Buffer.from('thumb')
+    })
+  })
+
+  it('rejects image work when the utility process reports an error or exits', async () => {
+    const failedProcess = processInboxImageAttachment('/tmp/bad.jpg')
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+    const failedRequest = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      requestId: string
+    }
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'error',
+      requestId: failedRequest.requestId,
+      error: 'corrupt image'
+    })
+
+    await expect(failedProcess).rejects.toThrow('corrupt image')
+
+    resetImageProcessingForTests()
+    const exitedProcess = processInboxImageAttachment('/tmp/exit.jpg')
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+    mockUtilityProcessInstance.simulateExit(9)
+
+    await expect(exitedProcess).rejects.toThrow(
+      'Image processing utility exited unexpectedly (code 9)'
+    )
+  })
+
+  it('stops a running utility process gracefully', async () => {
+    const thumbnailPromise = generateThumbnailInImageProcess('/tmp/photo.jpg', 'image/jpeg')
+
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+    const requestMessage = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+      requestId: string
+    }
+    mockUtilityProcessInstance.simulateMessage({
+      type: 'thumbnail-result',
+      requestId: requestMessage.requestId,
+      result: null
+    })
+    await expect(thumbnailPromise).resolves.toBeNull()
+
+    const stopPromise = stopImageProcessing()
+    expect(mockUtilityProcessInstance.postMessage).toHaveBeenLastCalledWith({ type: 'shutdown' })
+    mockUtilityProcessInstance.simulateExit(0)
+
+    await expect(stopPromise).resolves.toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/image-processing/bridge.ts
+++ b/apps/desktop/src/main/image-processing/bridge.ts
@@ -1,0 +1,367 @@
+import { app, utilityProcess } from 'electron'
+import path from 'path'
+
+import { createLogger } from '../lib/logger'
+import type {
+  ImageProcessingMainToWorkerMessage,
+  ImageProcessingWorkerToMainMessage,
+  InboxImageMetadataPayload
+} from './protocol'
+
+const logger = createLogger('ImageProcessing')
+
+const REQUEST_TIMEOUT_MS = 60_000
+const START_TIMEOUT_MS = 10_000
+const SHUTDOWN_TIMEOUT_MS = 3_000
+const IDLE_SHUTDOWN_MS = 30_000
+
+export interface ImageProcessingThumbnailResult {
+  data: Buffer
+  width: number
+  height: number
+  format: 'webp' | 'png'
+}
+
+export interface InboxImageProcessingResult {
+  metadata: InboxImageMetadataPayload
+  thumbnailData: Buffer | null
+}
+
+type PendingRequest = {
+  resolve: (value: ImageProcessingWorkerToMainMessage) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+class ImageProcessingBridge {
+  private process: ReturnType<typeof utilityProcess.fork> | null = null
+  private pendingRequests = new Map<string, PendingRequest>()
+  private readyPromise: Promise<void> | null = null
+  private requestCounter = 0
+  private shuttingDown = false
+  private idleShutdownTimer: ReturnType<typeof setTimeout> | null = null
+
+  async generateThumbnail(
+    filePath: string,
+    mimeType: string
+  ): Promise<ImageProcessingThumbnailResult | null> {
+    await this.start()
+    const requestId = this.nextRequestId()
+    const response = await this.sendRequest({
+      type: 'generate-thumbnail',
+      requestId,
+      filePath,
+      mimeType
+    })
+
+    if (response.type === 'error') {
+      throw new Error(response.error)
+    }
+
+    if (response.type !== 'thumbnail-result') {
+      throw new Error(`Unexpected response type: ${response.type}`)
+    }
+
+    if (!response.result) {
+      return null
+    }
+
+    return {
+      data: Buffer.from(response.result.data),
+      width: response.result.width,
+      height: response.result.height,
+      format: response.result.format
+    }
+  }
+
+  async processInboxImage(filePath: string): Promise<InboxImageProcessingResult | null> {
+    await this.start()
+    const requestId = this.nextRequestId()
+    const response = await this.sendRequest({
+      type: 'process-inbox-image',
+      requestId,
+      filePath
+    })
+
+    if (response.type === 'error') {
+      throw new Error(response.error)
+    }
+
+    if (response.type !== 'inbox-image-result') {
+      throw new Error(`Unexpected response type: ${response.type}`)
+    }
+
+    if (!response.result) {
+      return null
+    }
+
+    return {
+      metadata: response.result.metadata,
+      thumbnailData: response.result.thumbnailData
+        ? Buffer.from(response.result.thumbnailData)
+        : null
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.clearIdleShutdown()
+
+    if (!this.process) {
+      this.readyPromise = null
+      return
+    }
+
+    const activeProcess = this.process
+    this.shuttingDown = true
+    activeProcess.postMessage({ type: 'shutdown' } satisfies ImageProcessingMainToWorkerMessage)
+
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        activeProcess.kill()
+        resolve()
+      }, SHUTDOWN_TIMEOUT_MS)
+
+      activeProcess.once('exit', () => {
+        clearTimeout(timeout)
+        resolve()
+      })
+    })
+
+    this.process = null
+    this.readyPromise = null
+    this.shuttingDown = false
+  }
+
+  reset(): void {
+    this.shuttingDown = true
+    this.clearIdleShutdown()
+    this.process?.kill()
+    this.process = null
+    this.readyPromise = null
+    this.rejectAll(new Error('Image processing utility reset'))
+    this.shuttingDown = false
+  }
+
+  private async start(): Promise<void> {
+    this.clearIdleShutdown()
+
+    if (this.process) {
+      await this.readyPromise
+      return
+    }
+
+    const workerPath = path.join(__dirname, 'image-processing-worker.js')
+    const child = utilityProcess.fork(workerPath, [], {
+      serviceName: 'ImageProcessing',
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        MEMRY_USER_DATA_PATH: app.getPath('userData')
+      },
+      allowLoadingUnsignedLibraries: process.platform === 'darwin'
+    })
+
+    this.process = child
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      const output = chunk.toString().trim()
+      if (output) {
+        logger.info(`Image processing utility stdout: ${output}`)
+      }
+    })
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      const output = chunk.toString().trim()
+      if (output) {
+        logger.error(`Image processing utility stderr: ${output}`)
+      }
+    })
+
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const error = new Error('Image processing utility failed to start within timeout')
+        logger.error('Image processing utility start timeout', {
+          workerPath,
+          pid: child.pid
+        })
+        this.failProcess(error)
+        reject(error)
+      }, START_TIMEOUT_MS)
+
+      const cleanup = (): void => {
+        clearTimeout(timeout)
+        child.off('message', onMessage)
+        child.off('error', onFatalError)
+        child.off('exit', onExitBeforeReady)
+      }
+
+      const onMessage = (message: ImageProcessingWorkerToMainMessage): void => {
+        if (message.type !== 'ready') return
+
+        cleanup()
+        this.setupProcessHandlers(child)
+        logger.info('Image processing utility ready')
+        resolve()
+      }
+
+      const onFatalError = (type: string, location: string, report: string): void => {
+        cleanup()
+        const error = new Error(`Image processing utility fatal error: ${type} at ${location}`)
+        logger.error('Image processing utility fatal error', { type, location, report })
+        this.failProcess(error)
+        reject(error)
+      }
+
+      const onExitBeforeReady = (code: number): void => {
+        cleanup()
+        const error = new Error(`Image processing utility exited unexpectedly (code ${code})`)
+        this.failProcess(error)
+        reject(error)
+      }
+
+      child.on('message', onMessage)
+      child.on('error', onFatalError)
+      child.on('exit', onExitBeforeReady)
+    })
+
+    await this.readyPromise
+  }
+
+  private setupProcessHandlers(child: ReturnType<typeof utilityProcess.fork>): void {
+    child.on('message', (message: ImageProcessingWorkerToMainMessage) => {
+      if (message.type === 'ready') {
+        return
+      }
+
+      if ('requestId' in message) {
+        const pending = this.pendingRequests.get(message.requestId)
+        if (!pending) {
+          return
+        }
+
+        clearTimeout(pending.timer)
+        this.pendingRequests.delete(message.requestId)
+
+        if (message.type === 'error') {
+          this.scheduleIdleShutdown()
+          pending.reject(new Error(message.error))
+          return
+        }
+
+        this.scheduleIdleShutdown()
+        pending.resolve(message)
+      }
+    })
+
+    child.on('error', (type: string, location: string, report: string) => {
+      const error = new Error(`Image processing utility fatal error: ${type} at ${location}`)
+      logger.error('Image processing utility fatal error', { type, location, report })
+      this.failProcess(error)
+    })
+
+    child.on('exit', (code: number) => {
+      if (this.shuttingDown && code === 0) {
+        this.process = null
+        this.readyPromise = null
+        return
+      }
+
+      const error = new Error(`Image processing utility exited unexpectedly (code ${code})`)
+      this.failProcess(error)
+    })
+  }
+
+  private sendRequest(
+    message: Extract<ImageProcessingMainToWorkerMessage, { requestId: string }>
+  ): Promise<ImageProcessingWorkerToMainMessage> {
+    if (!this.process) {
+      return Promise.reject(new Error('Image processing utility is not running'))
+    }
+
+    this.clearIdleShutdown()
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(message.requestId)
+        this.scheduleIdleShutdown()
+        reject(new Error(`Image processing request timed out: ${message.type}`))
+      }, REQUEST_TIMEOUT_MS)
+
+      this.pendingRequests.set(message.requestId, { resolve, reject, timer })
+      this.process!.postMessage(message)
+    })
+  }
+
+  private nextRequestId(): string {
+    this.requestCounter += 1
+    return `image_${this.requestCounter}_${Date.now()}`
+  }
+
+  private failProcess(error: Error): void {
+    this.clearIdleShutdown()
+    if (this.process) {
+      this.process = null
+    }
+    this.readyPromise = null
+    this.rejectAll(error)
+  }
+
+  private rejectAll(error: Error): void {
+    for (const [requestId, pending] of this.pendingRequests) {
+      clearTimeout(pending.timer)
+      pending.reject(error)
+      this.pendingRequests.delete(requestId)
+    }
+  }
+
+  private scheduleIdleShutdown(): void {
+    this.clearIdleShutdown()
+
+    if (!this.process || this.pendingRequests.size > 0 || this.shuttingDown) {
+      return
+    }
+
+    this.idleShutdownTimer = setTimeout(() => {
+      this.idleShutdownTimer = null
+      if (!this.process || this.pendingRequests.size > 0 || this.shuttingDown) {
+        return
+      }
+
+      void this.stop().catch((error) => {
+        logger.warn('Image processing utility idle shutdown failed', {
+          error: error instanceof Error ? error.message : String(error)
+        })
+      })
+    }, IDLE_SHUTDOWN_MS)
+  }
+
+  private clearIdleShutdown(): void {
+    if (!this.idleShutdownTimer) {
+      return
+    }
+
+    clearTimeout(this.idleShutdownTimer)
+    this.idleShutdownTimer = null
+  }
+}
+
+const bridge = new ImageProcessingBridge()
+
+export function generateThumbnailInImageProcess(
+  filePath: string,
+  mimeType: string
+): Promise<ImageProcessingThumbnailResult | null> {
+  return bridge.generateThumbnail(filePath, mimeType)
+}
+
+export function processInboxImageAttachment(
+  filePath: string
+): Promise<InboxImageProcessingResult | null> {
+  return bridge.processInboxImage(filePath)
+}
+
+export function resetImageProcessingForTests(): void {
+  bridge.reset()
+}
+
+export async function stopImageProcessing(): Promise<void> {
+  await bridge.stop()
+}

--- a/apps/desktop/src/main/image-processing/operations.test.ts
+++ b/apps/desktop/src/main/image-processing/operations.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSharp = vi.hoisted(() => vi.fn())
+const mockExecFile = vi.hoisted(() => vi.fn())
+
+vi.mock('sharp', () => ({
+  default: mockSharp
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: mockExecFile
+}))
+
+vi.mock('node:util', () => ({
+  promisify: (fn: unknown) => fn
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+import { generateThumbnailInWorker, processInboxImageFile } from './operations'
+
+function mockSharpPipeline(options: {
+  metadata?: Record<string, unknown>
+  thumbnail?: Buffer
+  webp?: Buffer
+  width?: number
+  height?: number
+}) {
+  return {
+    metadata: vi.fn().mockResolvedValue(
+      options.metadata ?? {
+        width: 640,
+        height: 480,
+        format: 'jpeg',
+        exif: Buffer.from([1])
+      }
+    ),
+    clone: vi.fn(() => ({
+      resize: vi.fn(() => ({
+        jpeg: vi.fn(() => ({
+          toBuffer: vi.fn().mockResolvedValue(options.thumbnail ?? Buffer.from('thumb'))
+        }))
+      }))
+    })),
+    resize: vi.fn().mockReturnThis(),
+    webp: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue({
+      data: options.webp ?? Buffer.from('fake-webp'),
+      info: {
+        width: options.width ?? 150,
+        height: options.height ?? 100
+      }
+    })
+  }
+}
+
+describe('image-processing operations', () => {
+  beforeEach(() => {
+    mockSharp.mockReset()
+    mockExecFile.mockReset()
+    mockSharp.mockImplementation(() => mockSharpPipeline({}))
+  })
+
+  it('reads inbox image metadata and creates a jpeg thumbnail from a file path', async () => {
+    const result = await processInboxImageFile('/tmp/photo.jpg')
+
+    expect(mockSharp).toHaveBeenCalledWith('/tmp/photo.jpg')
+    expect(result).toEqual({
+      metadata: {
+        format: 'jpeg',
+        width: 640,
+        height: 480,
+        hasExif: true
+      },
+      thumbnailData: Buffer.from('thumb')
+    })
+  })
+
+  it('generates image and PDF thumbnails without main-process sharp imports', async () => {
+    await expect(generateThumbnailInWorker('/tmp/image.png', 'image/png')).resolves.toEqual({
+      data: Buffer.from('fake-webp'),
+      width: 150,
+      height: 100,
+      format: 'webp'
+    })
+
+    await expect(generateThumbnailInWorker('/tmp/doc.pdf', 'application/pdf')).resolves.toEqual({
+      data: Buffer.from('fake-webp'),
+      width: 150,
+      height: 100,
+      format: 'webp'
+    })
+  })
+
+  it('generates video thumbnails when ffmpeg is available', async () => {
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '/usr/local/bin/ffmpeg\n' })
+      .mockResolvedValueOnce({ stdout: Buffer.from('fake-png-frame') })
+
+    await expect(generateThumbnailInWorker('/tmp/video.mp4', 'video/mp4')).resolves.toEqual({
+      data: Buffer.from('fake-webp'),
+      width: 150,
+      height: 100,
+      format: 'webp'
+    })
+    expect(mockSharp).toHaveBeenLastCalledWith(Buffer.from('fake-png-frame'))
+  })
+
+  it('returns null for unsupported types and processing failures', async () => {
+    await expect(generateThumbnailInWorker('/tmp/song.mp3', 'audio/mpeg')).resolves.toBeNull()
+
+    mockSharp.mockImplementationOnce(() => ({
+      resize: vi.fn().mockReturnThis(),
+      webp: vi.fn().mockReturnThis(),
+      toBuffer: vi.fn().mockRejectedValue(new Error('corrupt image'))
+    }))
+    await expect(generateThumbnailInWorker('/tmp/bad.png', 'image/png')).resolves.toBeNull()
+  })
+})

--- a/apps/desktop/src/main/image-processing/operations.ts
+++ b/apps/desktop/src/main/image-processing/operations.ts
@@ -1,0 +1,180 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { createLogger } from '../lib/logger'
+import type { ImageProcessingThumbnailPayload, InboxImageProcessingPayload } from './protocol'
+
+const log = createLogger('ImageProcessing')
+const execFileAsync = promisify(execFile)
+
+const MAX_THUMBNAIL_DIMENSION = 200
+const MAX_INBOX_THUMBNAIL_DIMENSION = 400
+
+const IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'])
+const VIDEO_TYPES = new Set(['video/mp4', 'video/webm'])
+
+type SharpFactory = typeof import('sharp')
+
+let sharpPromise: Promise<SharpFactory> | null = null
+let cachedFfmpegPath: string | null | undefined
+
+async function loadSharp(): Promise<SharpFactory> {
+  sharpPromise ??= import('sharp').then((mod) => {
+    const loaded = mod as unknown as { default?: SharpFactory }
+    return loaded.default ?? (mod as unknown as SharpFactory)
+  })
+  return sharpPromise
+}
+
+export async function processInboxImageFile(
+  filePath: string
+): Promise<InboxImageProcessingPayload | null> {
+  const sharp = await loadSharp()
+  const pipeline = sharp(filePath)
+  const metadata = await pipeline.metadata()
+
+  if (!metadata.width || !metadata.height) {
+    return null
+  }
+
+  let thumbnailData: Buffer | null = null
+  try {
+    thumbnailData = await pipeline
+      .clone()
+      .resize(MAX_INBOX_THUMBNAIL_DIMENSION, MAX_INBOX_THUMBNAIL_DIMENSION, {
+        fit: 'inside',
+        withoutEnlargement: true
+      })
+      .jpeg({ quality: 80 })
+      .toBuffer()
+  } catch (error) {
+    log.warn('inbox image thumbnail generation failed', { filePath, error })
+  }
+
+  return {
+    metadata: {
+      format: metadata.format || 'unknown',
+      width: metadata.width,
+      height: metadata.height,
+      hasExif: Boolean(metadata.exif || metadata.icc)
+    },
+    thumbnailData
+  }
+}
+
+export async function generateThumbnailInWorker(
+  filePath: string,
+  mimeType: string
+): Promise<ImageProcessingThumbnailPayload | null> {
+  try {
+    if (IMAGE_TYPES.has(mimeType)) {
+      return await generateImageThumbnail(filePath)
+    }
+    if (mimeType === 'application/pdf') {
+      return await generatePdfPlaceholder()
+    }
+    if (VIDEO_TYPES.has(mimeType)) {
+      return await generateVideoThumbnail(filePath)
+    }
+    return null
+  } catch (error) {
+    log.warn('thumbnail generation failed', { filePath, mimeType, error })
+    return null
+  }
+}
+
+async function generateImageThumbnail(filePath: string): Promise<ImageProcessingThumbnailPayload> {
+  const sharp = await loadSharp()
+  const result = await sharp(filePath)
+    .resize(MAX_THUMBNAIL_DIMENSION, MAX_THUMBNAIL_DIMENSION, {
+      fit: 'inside',
+      withoutEnlargement: true
+    })
+    .webp({ quality: 80 })
+    .toBuffer({ resolveWithObject: true })
+
+  return {
+    data: result.data,
+    width: result.info.width,
+    height: result.info.height,
+    format: 'webp'
+  }
+}
+
+async function generatePdfPlaceholder(): Promise<ImageProcessingThumbnailPayload> {
+  const sharp = await loadSharp()
+  const width = 160
+  const height = 200
+  const svg = `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+    <rect width="${width}" height="${height}" rx="8" fill="#DC2626"/>
+    <text x="50%" y="45%" dominant-baseline="middle" text-anchor="middle"
+          font-family="sans-serif" font-size="36" font-weight="bold" fill="white">PDF</text>
+    <text x="50%" y="70%" dominant-baseline="middle" text-anchor="middle"
+          font-family="sans-serif" font-size="11" fill="rgba(255,255,255,0.8)">Document</text>
+  </svg>`
+
+  const result = await sharp(Buffer.from(svg))
+    .webp({ quality: 80 })
+    .toBuffer({ resolveWithObject: true })
+
+  return {
+    data: result.data,
+    width: result.info.width,
+    height: result.info.height,
+    format: 'webp'
+  }
+}
+
+async function generateVideoThumbnail(
+  filePath: string
+): Promise<ImageProcessingThumbnailPayload | null> {
+  const ffmpegPath = await findFfmpeg()
+  if (!ffmpegPath) {
+    log.debug('ffmpeg not found, skipping video thumbnail')
+    return null
+  }
+
+  const { stdout } = await execFileAsync(
+    ffmpegPath,
+    [
+      '-i',
+      filePath,
+      '-ss',
+      '1',
+      '-vframes',
+      '1',
+      '-vf',
+      `scale=${MAX_THUMBNAIL_DIMENSION}:${MAX_THUMBNAIL_DIMENSION}:force_original_aspect_ratio=decrease`,
+      '-f',
+      'image2pipe',
+      '-vcodec',
+      'png',
+      '-'
+    ],
+    { encoding: 'buffer', timeout: 10_000 }
+  )
+
+  const sharp = await loadSharp()
+  const result = await sharp(stdout).webp({ quality: 80 }).toBuffer({ resolveWithObject: true })
+
+  return {
+    data: result.data,
+    width: result.info.width,
+    height: result.info.height,
+    format: 'webp'
+  }
+}
+
+async function findFfmpeg(): Promise<string | null> {
+  if (cachedFfmpegPath !== undefined) return cachedFfmpegPath
+
+  try {
+    const { stdout } = await execFileAsync('which', ['ffmpeg'], { timeout: 3_000 })
+    const found = stdout.trim()
+    cachedFfmpegPath = found || null
+    return cachedFfmpegPath
+  } catch {
+    cachedFfmpegPath = null
+    return null
+  }
+}

--- a/apps/desktop/src/main/image-processing/protocol.ts
+++ b/apps/desktop/src/main/image-processing/protocol.ts
@@ -1,0 +1,54 @@
+export interface ImageProcessingThumbnailPayload {
+  data: Uint8Array
+  width: number
+  height: number
+  format: 'webp' | 'png'
+}
+
+export interface InboxImageMetadataPayload {
+  format: string
+  width: number
+  height: number
+  hasExif: boolean
+}
+
+export interface InboxImageProcessingPayload {
+  metadata: InboxImageMetadataPayload
+  thumbnailData: Uint8Array | null
+}
+
+export type ImageProcessingMainToWorkerMessage =
+  | {
+      type: 'generate-thumbnail'
+      requestId: string
+      filePath: string
+      mimeType: string
+    }
+  | {
+      type: 'process-inbox-image'
+      requestId: string
+      filePath: string
+    }
+  | {
+      type: 'shutdown'
+    }
+
+export type ImageProcessingWorkerToMainMessage =
+  | {
+      type: 'ready'
+    }
+  | {
+      type: 'thumbnail-result'
+      requestId: string
+      result: ImageProcessingThumbnailPayload | null
+    }
+  | {
+      type: 'inbox-image-result'
+      requestId: string
+      result: InboxImageProcessingPayload | null
+    }
+  | {
+      type: 'error'
+      requestId: string
+      error: string
+    }

--- a/apps/desktop/src/main/image-processing/worker.ts
+++ b/apps/desktop/src/main/image-processing/worker.ts
@@ -1,0 +1,82 @@
+import { createLogger } from '../lib/logger'
+import { generateThumbnailInWorker, processInboxImageFile } from './operations'
+import type {
+  ImageProcessingMainToWorkerMessage,
+  ImageProcessingWorkerToMainMessage
+} from './protocol'
+
+const logger = createLogger('ImageProcessingWorker')
+const parentPort = process.parentPort
+
+if (!parentPort) {
+  throw new Error('image-processing worker must be run as an Electron utility process')
+}
+
+async function handleGenerateThumbnail(
+  message: Extract<ImageProcessingMainToWorkerMessage, { type: 'generate-thumbnail' }>
+): Promise<void> {
+  try {
+    const result = await generateThumbnailInWorker(message.filePath, message.mimeType)
+    parentPort.postMessage({
+      type: 'thumbnail-result',
+      requestId: message.requestId,
+      result
+    } satisfies ImageProcessingWorkerToMainMessage)
+  } catch (error) {
+    const failure = error instanceof Error ? error.message : String(error)
+    parentPort.postMessage({
+      type: 'error',
+      requestId: message.requestId,
+      error: failure
+    } satisfies ImageProcessingWorkerToMainMessage)
+  }
+}
+
+async function handleProcessInboxImage(
+  message: Extract<ImageProcessingMainToWorkerMessage, { type: 'process-inbox-image' }>
+): Promise<void> {
+  try {
+    const result = await processInboxImageFile(message.filePath)
+    parentPort.postMessage({
+      type: 'inbox-image-result',
+      requestId: message.requestId,
+      result
+    } satisfies ImageProcessingWorkerToMainMessage)
+  } catch (error) {
+    const failure = error instanceof Error ? error.message : String(error)
+    parentPort.postMessage({
+      type: 'error',
+      requestId: message.requestId,
+      error: failure
+    } satisfies ImageProcessingWorkerToMainMessage)
+  }
+}
+
+parentPort.on('message', (event) => {
+  const message = event.data as ImageProcessingMainToWorkerMessage
+
+  switch (message.type) {
+    case 'generate-thumbnail':
+      void handleGenerateThumbnail(message)
+      break
+    case 'process-inbox-image':
+      void handleProcessInboxImage(message)
+      break
+    case 'shutdown':
+      process.exit(0)
+  }
+})
+
+process.on('uncaughtException', (error) => {
+  logger.error('Uncaught image-processing worker error', {
+    message: error instanceof Error ? error.message : String(error)
+  })
+})
+
+process.on('unhandledRejection', (reason) => {
+  logger.error('Unhandled image-processing worker rejection', {
+    message: reason instanceof Error ? reason.message : String(reason)
+  })
+})
+
+parentPort.postMessage({ type: 'ready' } satisfies ImageProcessingWorkerToMainMessage)

--- a/apps/desktop/src/main/inbox/attachments.ts
+++ b/apps/desktop/src/main/inbox/attachments.ts
@@ -154,6 +154,10 @@ export function getInboxAttachmentsDir(): string {
   return path.join(vaultPath, 'attachments', 'inbox')
 }
 
+export function resolveInboxAttachmentFilePath(relativePath: string): string {
+  return path.join(requireVaultPath(), relativePath)
+}
+
 /**
  * Get the attachments directory for a specific inbox item
  */

--- a/apps/desktop/src/main/inbox/domain.test.ts
+++ b/apps/desktop/src/main/inbox/domain.test.ts
@@ -17,6 +17,7 @@ const mockQueueTranscriptionJob = vi.fn()
 const mockPublishInboxUpserted = vi.fn()
 const mockSyncInboxCreate = vi.fn()
 const mockExtractSocialPost = vi.fn()
+const mockProcessInboxImageAttachment = vi.hoisted(() => vi.fn())
 
 vi.mock('electron', () => ({
   BrowserWindow: {
@@ -24,23 +25,9 @@ vi.mock('electron', () => ({
   }
 }))
 
-vi.mock('sharp', () => ({
-  default: vi.fn(() => ({
-    metadata: vi.fn().mockResolvedValue({
-      width: 640,
-      height: 480,
-      format: 'jpeg',
-      exif: Buffer.from([1])
-    }),
-    clone: vi.fn(() => ({
-      resize: vi.fn(() => ({
-        jpeg: vi.fn(() => ({
-          toBuffer: vi.fn().mockResolvedValue(Buffer.from('thumb'))
-        }))
-      }))
-    }))
-  }))
-}))
+vi.mock('sharp', () => {
+  throw new Error('inbox domain must not import sharp in the main process')
+})
 
 vi.mock('../database', () => ({
   getDatabase: vi.fn(),
@@ -53,8 +40,13 @@ vi.mock('./attachments', () => ({
   ALLOWED_VIDEO_TYPES: ['video/mp4'],
   ALLOWED_DOCUMENT_TYPES: ['application/pdf'],
   resolveAttachmentUrl: (path: string | null) => (path ? `memry-file://${path}` : null),
+  resolveInboxAttachmentFilePath: (path: string) => `/vault/${path}`,
   storeInboxAttachment: (...args: unknown[]) => mockStoreInboxAttachment(...args),
   storeThumbnail: (...args: unknown[]) => mockStoreThumbnail(...args)
+}))
+
+vi.mock('../image-processing/bridge', () => ({
+  processInboxImageAttachment: (...args: unknown[]) => mockProcessInboxImageAttachment(...args)
 }))
 
 vi.mock('./capture', () => ({
@@ -138,6 +130,15 @@ describe('createDesktopInboxDomain', () => {
     mockStoreThumbnail
       .mockReset()
       .mockResolvedValue({ success: true, thumbnailPath: 'inbox/thumb.jpg' })
+    mockProcessInboxImageAttachment.mockReset().mockResolvedValue({
+      metadata: {
+        format: 'jpeg',
+        width: 640,
+        height: 480,
+        hasExif: true
+      },
+      thumbnailData: Buffer.from('thumb')
+    })
     mockCaptureVoice.mockReset().mockResolvedValue({
       success: true,
       item: {
@@ -245,6 +246,7 @@ describe('createDesktopInboxDomain', () => {
       Buffer.from('thumb'),
       'jpg'
     )
+    expect(mockProcessInboxImageAttachment).toHaveBeenCalledWith('/vault/inbox/file.bin')
 
     const pdfResult = await domain.captureImage({
       data: { type: 'Buffer', data: [5, 6, 7] },
@@ -254,6 +256,7 @@ describe('createDesktopInboxDomain', () => {
 
     expect(pdfResult.success).toBe(true)
     expect(pdfResult.item).toEqual(expect.objectContaining({ type: 'pdf', title: 'brief' }))
+    expect(mockProcessInboxImageAttachment).toHaveBeenCalledTimes(1)
 
     await expect(
       domain.captureImage({

--- a/apps/desktop/src/main/inbox/domain.ts
+++ b/apps/desktop/src/main/inbox/domain.ts
@@ -1,6 +1,5 @@
 import { BrowserWindow } from 'electron'
 import { eq } from 'drizzle-orm'
-import sharp from 'sharp'
 import {
   createInboxCommands,
   createInboxQueries,
@@ -22,6 +21,7 @@ import { generateId } from '../lib/id'
 import { createLogger } from '../lib/logger'
 import {
   resolveAttachmentUrl,
+  resolveInboxAttachmentFilePath,
   storeInboxAttachment,
   storeThumbnail,
   ALLOWED_IMAGE_TYPES,
@@ -29,6 +29,7 @@ import {
   ALLOWED_VIDEO_TYPES,
   ALLOWED_DOCUMENT_TYPES
 } from './attachments'
+import { processInboxImageAttachment } from '../image-processing/bridge'
 import { titleFromUrl } from './metadata'
 import { captureVoice } from './capture'
 import { findDuplicateByContent, findDuplicateByUrl } from './duplicates'
@@ -298,31 +299,29 @@ async function captureImageItem(input: CaptureImageInput): Promise<InboxCaptureR
 
     if (isImage) {
       try {
-        const pipeline = sharp(fileBuffer)
-        const metadata = await pipeline.metadata()
-        if (metadata.width && metadata.height) {
+        if (storeResult.path) {
+          const imageResult = await processInboxImageAttachment(
+            resolveInboxAttachmentFilePath(storeResult.path)
+          )
+          const metadata = imageResult?.metadata
+          if (!metadata) {
+            throw new Error('No image metadata returned')
+          }
+
           itemMetadata = {
             originalFilename: input.filename,
-            format: metadata.format || 'unknown',
+            format: metadata.format,
             width: metadata.width,
             height: metadata.height,
             fileSize: fileBuffer.length,
-            hasExif: !!(metadata.exif || metadata.icc)
+            hasExif: metadata.hasExif
           }
 
-          try {
-            const thumbnailBuffer = await pipeline
-              .clone()
-              .resize(400, 400, { fit: 'inside', withoutEnlargement: true })
-              .jpeg({ quality: 80 })
-              .toBuffer()
-
-            const thumbnailResult = await storeThumbnail(id, thumbnailBuffer, 'jpg')
+          if (imageResult.thumbnailData) {
+            const thumbnailResult = await storeThumbnail(id, imageResult.thumbnailData, 'jpg')
             if (thumbnailResult.success && thumbnailResult.thumbnailPath) {
               thumbnailPath = thumbnailResult.thumbnailPath
             }
-          } catch (thumbnailError) {
-            logger.warn('Failed to generate thumbnail', thumbnailError)
           }
         }
       } catch (metadataError) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -34,6 +34,7 @@ import { readPreferences } from './vault/vault-preferences'
 import { getCurrentVaultPath, getStoredLocale } from './store'
 import { startSnoozeScheduler, stopSnoozeScheduler, checkDueItemsOnStartup } from './inbox/snooze'
 import { stopVoiceModel } from './inbox/voice-model'
+import { stopImageProcessing } from './image-processing/bridge'
 import { startReminderScheduler, stopReminderScheduler } from './lib/reminders'
 import { disposeTelemetryRuntime, initializeTelemetryRuntime } from './telemetry/runtime'
 import { getTelemetryAuthState, getTelemetrySyncState } from './telemetry/state'
@@ -1220,6 +1221,10 @@ app.on('before-quit', (event) => {
     .then(() => {
       shutdownLog.info('stopping voice transcription utility...')
       return stopVoiceModel()
+    })
+    .then(() => {
+      shutdownLog.info('stopping image processing utility...')
+      return stopImageProcessing()
     })
     .then(() => {
       shutdownLog.info('flushing telemetry runtime...')

--- a/apps/desktop/src/main/sync/thumbnails.test.ts
+++ b/apps/desktop/src/main/sync/thumbnails.test.ts
@@ -1,23 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGenerateThumbnailInImageProcess = vi.hoisted(() => vi.fn())
 
 vi.mock('sharp', () => {
-  const mockSharp = vi.fn(() => ({
-    resize: vi.fn().mockReturnThis(),
-    webp: vi.fn().mockReturnThis(),
-    toBuffer: vi.fn().mockResolvedValue({
-      data: Buffer.from('fake-webp'),
-      info: { width: 150, height: 100 }
-    })
-  }))
-  return { default: mockSharp }
+  throw new Error('sync thumbnails must not import sharp in the main process')
 })
 
-vi.mock('node:child_process', () => ({
-  execFile: vi.fn()
-}))
-
-vi.mock('node:util', () => ({
-  promisify: (fn: unknown) => fn
+vi.mock('../image-processing/bridge', () => ({
+  generateThumbnailInImageProcess: (...args: unknown[]) =>
+    mockGenerateThumbnailInImageProcess(...args)
 }))
 
 vi.mock('../lib/logger', () => ({
@@ -34,31 +25,12 @@ describe('thumbnails', () => {
 
   beforeEach(async () => {
     vi.resetModules()
-    vi.doMock('sharp', () => {
-      const mockSharp = vi.fn(() => ({
-        resize: vi.fn().mockReturnThis(),
-        webp: vi.fn().mockReturnThis(),
-        toBuffer: vi.fn().mockResolvedValue({
-          data: Buffer.from('fake-webp'),
-          info: { width: 150, height: 100 }
-        })
-      }))
-      return { default: mockSharp }
+    mockGenerateThumbnailInImageProcess.mockReset().mockResolvedValue({
+      data: Buffer.from('fake-webp'),
+      width: 150,
+      height: 100,
+      format: 'webp'
     })
-    vi.doMock('node:child_process', () => ({
-      execFile: vi.fn()
-    }))
-    vi.doMock('node:util', () => ({
-      promisify: (fn: unknown) => fn
-    }))
-    vi.doMock('../lib/logger', () => ({
-      createLogger: () => ({
-        info: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn(),
-        error: vi.fn()
-      })
-    }))
 
     const mod = await import('./thumbnails')
     generateThumbnail = mod.generateThumbnail
@@ -71,6 +43,10 @@ describe('thumbnails', () => {
       expect(result!.format).toBe('webp')
       expect(result!.width).toBe(150)
       expect(result!.height).toBe(100)
+      expect(mockGenerateThumbnailInImageProcess).toHaveBeenCalledWith(
+        '/path/to/image.png',
+        'image/png'
+      )
     })
 
     it('handles JPEG', async () => {
@@ -100,68 +76,44 @@ describe('thumbnails', () => {
       const result = await generateThumbnail('/path/to/doc.pdf', 'application/pdf')
       expect(result).not.toBeNull()
       expect(result!.format).toBe('webp')
+      expect(mockGenerateThumbnailInImageProcess).toHaveBeenCalledWith(
+        '/path/to/doc.pdf',
+        'application/pdf'
+      )
     })
   })
 
   describe('video thumbnails', () => {
-    it('returns null when ffmpeg is not available', async () => {
-      const { execFile } = await import('node:child_process')
-      const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>
-      mockExecFile.mockRejectedValue(new Error('not found'))
-
-      const result = await generateThumbnail('/path/to/video.mp4', 'video/mp4')
-      expect(result).toBeNull()
-    })
-
-    it('generates thumbnail when ffmpeg is available', async () => {
-      const { execFile } = await import('node:child_process')
-      const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>
-      mockExecFile
-        .mockResolvedValueOnce({ stdout: '/usr/local/bin/ffmpeg\n' })
-        .mockResolvedValueOnce({ stdout: Buffer.from('fake-png-frame') })
-
+    it('generates thumbnails for videos through the image utility process', async () => {
       const result = await generateThumbnail('/path/to/clip.mp4', 'video/mp4')
       expect(result).not.toBeNull()
       expect(result!.format).toBe('webp')
+      expect(mockGenerateThumbnailInImageProcess).toHaveBeenCalledWith(
+        '/path/to/clip.mp4',
+        'video/mp4'
+      )
     })
   })
 
   describe('unsupported types', () => {
-    it('returns null for unsupported mime types', async () => {
+    it('returns null for unsupported mime types without starting image processing', async () => {
       const result = await generateThumbnail('/path/to/file.zip', 'application/zip')
       expect(result).toBeNull()
+      expect(mockGenerateThumbnailInImageProcess).not.toHaveBeenCalled()
     })
 
-    it('returns null for audio files', async () => {
+    it('returns null for audio files without starting image processing', async () => {
       const result = await generateThumbnail('/path/to/song.mp3', 'audio/mpeg')
       expect(result).toBeNull()
+      expect(mockGenerateThumbnailInImageProcess).not.toHaveBeenCalled()
     })
   })
 
   describe('error handling', () => {
-    it('returns null when sharp throws', async () => {
-      vi.doMock('sharp', () => {
-        const mockSharp = vi.fn(() => ({
-          resize: vi.fn().mockReturnThis(),
-          webp: vi.fn().mockReturnThis(),
-          toBuffer: vi.fn().mockRejectedValue(new Error('corrupt image'))
-        }))
-        return { default: mockSharp }
-      })
-      vi.resetModules()
-      vi.doMock('node:child_process', () => ({ execFile: vi.fn() }))
-      vi.doMock('node:util', () => ({ promisify: (fn: unknown) => fn }))
-      vi.doMock('../lib/logger', () => ({
-        createLogger: () => ({
-          info: vi.fn(),
-          warn: vi.fn(),
-          debug: vi.fn(),
-          error: vi.fn()
-        })
-      }))
+    it('returns null when the image utility process throws', async () => {
+      mockGenerateThumbnailInImageProcess.mockRejectedValue(new Error('corrupt image'))
 
-      const mod = await import('./thumbnails')
-      const result = await mod.generateThumbnail('/path/to/bad.png', 'image/png')
+      const result = await generateThumbnail('/path/to/bad.png', 'image/png')
       expect(result).toBeNull()
     })
   })

--- a/apps/desktop/src/main/sync/thumbnails.ts
+++ b/apps/desktop/src/main/sync/thumbnails.ts
@@ -1,12 +1,7 @@
-import sharp from 'sharp'
-import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
+import { generateThumbnailInImageProcess } from '../image-processing/bridge'
 import { createLogger } from '../lib/logger'
 
 const log = createLogger('Thumbnails')
-const execFileAsync = promisify(execFile)
-
-const MAX_DIMENSION = 200
 
 export interface ThumbnailResult {
   data: Buffer
@@ -24,108 +19,12 @@ export async function generateThumbnail(
   mimeType: string
 ): Promise<ThumbnailResult | null> {
   try {
-    if (IMAGE_TYPES.has(mimeType)) {
-      return await generateImageThumbnail(filePath)
-    }
-    if (mimeType === 'application/pdf') {
-      return await generatePdfPlaceholder(filePath)
-    }
-    if (VIDEO_TYPES.has(mimeType)) {
-      return await generateVideoThumbnail(filePath)
+    if (IMAGE_TYPES.has(mimeType) || mimeType === 'application/pdf' || VIDEO_TYPES.has(mimeType)) {
+      return await generateThumbnailInImageProcess(filePath, mimeType)
     }
     return null
   } catch (err) {
     log.warn('thumbnail generation failed', { filePath, mimeType, err })
-    return null
-  }
-}
-
-async function generateImageThumbnail(filePath: string): Promise<ThumbnailResult | null> {
-  const result = await sharp(filePath)
-    .resize(MAX_DIMENSION, MAX_DIMENSION, { fit: 'inside', withoutEnlargement: true })
-    .webp({ quality: 80 })
-    .toBuffer({ resolveWithObject: true })
-
-  return {
-    data: result.data,
-    width: result.info.width,
-    height: result.info.height,
-    format: 'webp'
-  }
-}
-
-async function generatePdfPlaceholder(_filePath: string): Promise<ThumbnailResult | null> {
-  const width = 160
-  const height = 200
-  const svg = `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
-    <rect width="${width}" height="${height}" rx="8" fill="#DC2626"/>
-    <text x="50%" y="45%" dominant-baseline="middle" text-anchor="middle"
-          font-family="sans-serif" font-size="36" font-weight="bold" fill="white">PDF</text>
-    <text x="50%" y="70%" dominant-baseline="middle" text-anchor="middle"
-          font-family="sans-serif" font-size="11" fill="rgba(255,255,255,0.8)">Document</text>
-  </svg>`
-
-  const result = await sharp(Buffer.from(svg))
-    .webp({ quality: 80 })
-    .toBuffer({ resolveWithObject: true })
-
-  return {
-    data: result.data,
-    width: result.info.width,
-    height: result.info.height,
-    format: 'webp'
-  }
-}
-
-async function generateVideoThumbnail(filePath: string): Promise<ThumbnailResult | null> {
-  const ffmpegPath = await findFfmpeg()
-  if (!ffmpegPath) {
-    log.debug('ffmpeg not found, skipping video thumbnail')
-    return null
-  }
-
-  const { stdout } = await execFileAsync(
-    ffmpegPath,
-    [
-      '-i',
-      filePath,
-      '-ss',
-      '1',
-      '-vframes',
-      '1',
-      '-vf',
-      `scale=${MAX_DIMENSION}:${MAX_DIMENSION}:force_original_aspect_ratio=decrease`,
-      '-f',
-      'image2pipe',
-      '-vcodec',
-      'png',
-      '-'
-    ],
-    { encoding: 'buffer', timeout: 10_000 }
-  )
-
-  const result = await sharp(stdout).webp({ quality: 80 }).toBuffer({ resolveWithObject: true })
-
-  return {
-    data: result.data,
-    width: result.info.width,
-    height: result.info.height,
-    format: 'webp'
-  }
-}
-
-let cachedFfmpegPath: string | null | undefined
-
-async function findFfmpeg(): Promise<string | null> {
-  if (cachedFfmpegPath !== undefined) return cachedFfmpegPath
-
-  try {
-    const { stdout } = await execFileAsync('which', ['ffmpeg'], { timeout: 3_000 })
-    const found = stdout.trim()
-    cachedFfmpegPath = found || null
-    return cachedFfmpegPath
-  } catch {
-    cachedFfmpegPath = null
     return null
   }
 }

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -53,6 +53,14 @@ pnpm db:studio      # open GUI
 
 better-sqlite3 is synchronous and single-process. The main process is the only writer. The renderer never touches SQLite directly — all reads and writes go through IPC.
 
+## Native Media Processing
+
+Image, PDF, and video thumbnail generation stays local, but the native image stack is not part of
+the always-on main process. The desktop app starts an image-processing utility process only when
+thumbnail or inbox image metadata work is requested. That worker owns the lazy `sharp` / `libvips`
+load, returns the generated metadata or thumbnail bytes over IPC, and shuts down after it has been
+idle.
+
 ## better-sqlite3 ABI Quirk
 
 The native module must match the JS runtime. If you see `ERR_DLOPEN_FAILED`, rebuild for the right target:


### PR DESCRIPTION
## Summary

- Move `sharp`/`libvips` thumbnail and inbox image metadata work behind a lazily started image-processing utility process.
- Keep thumbnail/image behavior intact while avoiding `sharp`/`libvips` in the normal main-process vault-open path.
- Stop the background embedding preload on vault open because the transformers Node build was also loading `sharp`/`libvips` into main.
- Document the native media-processing runtime boundary.

Closes #429

## Verification

- `pnpm exec vitest run src/main/image-processing/bridge.test.ts src/main/image-processing/operations.test.ts src/main/sync/thumbnails.test.ts src/main/inbox/domain.test.ts src/main/vault/index.test.ts --config config/vitest.config.ts --project main`
- `pnpm --filter @memry/desktop typecheck:node`
- `pnpm docs:impact --base origin/main --strict`
- `pnpm docs:build`
- `git diff --check origin/main...HEAD`
- Manual benchmark: `pnpm run dev`, picker state first, opened `/Users/h4yfans/sideproject/vaults/MemryA`; patched branch showed no `sharp`/`libvips` mappings in Electron processes and measured 599.9 MiB summed RSS vs 727.8 MiB on fb91, where main mapped both `sharp-darwin-arm64.node` and `libvips-cpp.8.17.3.dylib`.
