### PR TITLE
Bound CRDT doc memory

### DIFF
--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -306,6 +306,34 @@ describe('CrdtProvider', () => {
     )
   })
 
+  it('exposes aggregate open-doc metrics with per-doc size and window counts', async () => {
+    createWindow(1)
+    await provider.open('note-1', 1, { skipSeed: true })
+    await provider.open('sync-only-note', undefined, { skipSeed: true })
+
+    provider.updateMeta('note-1', { title: 'Active editor' })
+    provider.updateMeta('sync-only-note', { title: 'Sync only' })
+
+    const metrics = provider.getOpenDocMetrics()
+
+    expect(metrics.count).toBe(2)
+    expect(metrics.totalEncodedSizeBytes).toBeGreaterThan(0)
+    expect(metrics.docs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          noteId: 'note-1',
+          encodedSizeBytes: expect.any(Number),
+          windowCount: 1
+        }),
+        expect.objectContaining({
+          noteId: 'sync-only-note',
+          encodedSizeBytes: expect.any(Number),
+          windowCount: 0
+        })
+      ])
+    )
+  })
+
   it('keeps shared docs open until the last window closes', async () => {
     createWindow(1)
     createWindow(2)
@@ -320,6 +348,49 @@ describe('CrdtProvider', () => {
     await provider.close('note-1', 2)
     expect(provider.getDoc('note-1')).toBeUndefined()
     expect(mocks.persistenceInstances[0].flushDocument).toHaveBeenCalledWith('note-1')
+  })
+
+  it('closes sync-only docs only while they remain inactive', async () => {
+    await provider.open('sync-only-note', undefined, { skipSeed: true })
+
+    await expect(provider.closeIfInactive('sync-only-note')).resolves.toBe(true)
+    expect(provider.getDoc('sync-only-note')).toBeUndefined()
+    expect(mocks.persistenceInstances[0].flushDocument).toHaveBeenCalledWith('sync-only-note')
+
+    createWindow(8)
+    const activeDoc = await provider.open('active-note', 8, { skipSeed: true })
+
+    await expect(provider.closeIfInactive('active-note')).resolves.toBe(false)
+    expect(provider.getDoc('active-note')).toBe(activeDoc)
+  })
+
+  it('evicts least-recently-used inactive docs without evicting active editor docs', async () => {
+    let now = 1_000
+    const cappedProvider = new CrdtProvider({
+      inactiveDocLimit: 2,
+      now: () => now
+    })
+    await cappedProvider.init(queue as any, pushSnapshot)
+    createWindow(9)
+
+    await cappedProvider.open('active-note', 9, { skipSeed: true })
+    now += 1
+    await cappedProvider.open('inactive-a', undefined, { skipSeed: true })
+    now += 1
+    await cappedProvider.open('inactive-b', undefined, { skipSeed: true })
+    now += 1
+    await cappedProvider.open('inactive-c', undefined, { skipSeed: true })
+
+    expect(cappedProvider.getDoc('active-note')).toBeDefined()
+    expect(cappedProvider.getDoc('inactive-a')).toBeUndefined()
+    expect(cappedProvider.getDoc('inactive-b')).toBeDefined()
+    expect(cappedProvider.getDoc('inactive-c')).toBeDefined()
+
+    const cappedMetrics = cappedProvider.getOpenDocMetrics()
+    expect(cappedMetrics.count).toBe(3)
+    expect(cappedMetrics.docs.filter((doc) => doc.windowCount === 0)).toHaveLength(2)
+
+    await cappedProvider.destroy()
   })
 
   it('pushes only pending snapshots and resets pending byte counters', async () => {

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -28,8 +28,30 @@ export const ORIGIN_LOCAL = 'local'
 const SIZE_CHECK_INTERVAL_MS = 60_000
 const ENCODED_SIZE_COMPACTION_THRESHOLD = 1024 * 1024
 const ACCUMULATED_BYTES_RECHECK_THRESHOLD = 512 * 1024
+const DEFAULT_INACTIVE_DOC_LIMIT = 32
 
 export type SnapshotPushFn = (noteId: string, state: Uint8Array) => Promise<void>
+
+export interface CrdtProviderOptions {
+  inactiveDocLimit?: number
+  now?: () => number
+}
+
+export interface CrdtDocSizeMetric {
+  noteId: string
+  encodedSizeBytes: number
+  accumulatedBytes: number
+  pendingSnapshotBytes: number
+  windowCount: number
+  lastTouchedAt: number
+}
+
+export interface CrdtOpenDocMetrics {
+  count: number
+  totalEncodedSizeBytes: number
+  totalAccumulatedBytes: number
+  docs: CrdtDocSizeMetric[]
+}
 
 interface ActiveDoc {
   doc: Y.Doc
@@ -38,6 +60,7 @@ interface ActiveDoc {
   pendingSnapshotBytes: number
   lastEncodedSize: number
   lastSizeCheckAt: number
+  lastTouchedAt: number
   closing?: boolean
 }
 
@@ -55,11 +78,18 @@ export class CrdtProvider {
   private persistence: CrdtPersistence | null = null
   private updateQueue: CrdtUpdateQueue | null = null
   private snapshotPushFn: SnapshotPushFn | null = null
+  private readonly inactiveDocLimit: number
+  private readonly now: () => number
   private compactingDocs = new Set<string>()
   private compactionBuffers = new Map<string, Uint8Array[]>()
   private networkBatcher = new MicrotaskBatchBroadcaster((noteId, merged) => {
     this.broadcastToWindows(noteId, merged, ORIGIN_NETWORK, undefined)
   })
+
+  constructor(options: CrdtProviderOptions = {}) {
+    this.inactiveDocLimit = Math.max(1, options.inactiveDocLimit ?? DEFAULT_INACTIVE_DOC_LIMIT)
+    this.now = options.now ?? Date.now
+  }
 
   async init(queue?: CrdtUpdateQueue, snapshotPush?: SnapshotPushFn): Promise<void> {
     await this.initPersistence()
@@ -87,9 +117,11 @@ export class CrdtProvider {
     const existing = this.docs.get(noteId)
     if (existing && !existing.closing) {
       if (windowId) existing.windowIds.add(windowId)
+      this.touchDoc(existing)
       if (!options?.skipSeed) {
         await this.seedFromMarkdown(noteId, existing.doc)
       }
+      await this.evictInactiveDocsIfNeeded()
       return existing.doc
     }
 
@@ -97,10 +129,14 @@ export class CrdtProvider {
     if (pending) {
       const doc = await pending
       const entry = this.docs.get(noteId)
-      if (entry && windowId) entry.windowIds.add(windowId)
+      if (entry) {
+        if (windowId) entry.windowIds.add(windowId)
+        this.touchDoc(entry)
+      }
       if (!options?.skipSeed) {
         await this.seedFromMarkdown(noteId, doc)
       }
+      await this.evictInactiveDocsIfNeeded()
       return doc
     }
 
@@ -142,13 +178,16 @@ export class CrdtProvider {
       accumulatedBytes: 0,
       pendingSnapshotBytes: 0,
       lastEncodedSize: 0,
-      lastSizeCheckAt: 0
+      lastSizeCheckAt: 0,
+      lastTouchedAt: this.now()
     }
     this.docs.set(noteId, entry)
 
     doc.on('update', (update: Uint8Array, origin: unknown) => {
       this.onDocUpdate(noteId, update, origin)
     })
+
+    await this.evictInactiveDocsIfNeeded()
 
     return doc
   }
@@ -188,6 +227,14 @@ export class CrdtProvider {
     log.debug('Doc closed', { noteId })
   }
 
+  async closeIfInactive(noteId: string): Promise<boolean> {
+    const entry = this.docs.get(noteId)
+    if (!entry || entry.closing || entry.windowIds.size > 0) return false
+
+    await this.close(noteId)
+    return !this.docs.has(noteId)
+  }
+
   async purge(noteId: string): Promise<void> {
     await this.close(noteId)
     await this.persistence?.clearDocument(noteId)
@@ -208,6 +255,8 @@ export class CrdtProvider {
       log.debug('Ignoring remote update for closing doc', { noteId })
       return
     }
+
+    this.touchDoc(entry)
 
     log.debug('applyRemoteUpdate', {
       noteId,
@@ -233,12 +282,14 @@ export class CrdtProvider {
   getStateVector(noteId: string): Uint8Array | null {
     const entry = this.docs.get(noteId)
     if (!entry) return null
+    this.touchDoc(entry)
     return Y.encodeStateVector(entry.doc)
   }
 
   getDiff(noteId: string, remoteStateVector: Uint8Array): Uint8Array | null {
     const entry = this.docs.get(noteId)
     if (!entry) return null
+    this.touchDoc(entry)
     return Y.encodeStateAsUpdate(entry.doc, remoteStateVector)
   }
 
@@ -278,18 +329,20 @@ export class CrdtProvider {
     return Array.from(this.docs.keys())
   }
 
-  getDocSizeMetrics(): Array<{
-    noteId: string
-    encodedSizeBytes: number
-    accumulatedBytes: number
-    windowCount: number
-  }> {
-    return Array.from(this.docs.entries()).map(([noteId, entry]) => ({
-      noteId,
-      encodedSizeBytes: entry.lastEncodedSize,
-      accumulatedBytes: entry.accumulatedBytes,
-      windowCount: entry.windowIds.size
-    }))
+  getDocSizeMetrics(): CrdtDocSizeMetric[] {
+    return Array.from(this.docs.entries()).map(([noteId, entry]) =>
+      this.measureDocSize(noteId, entry)
+    )
+  }
+
+  getOpenDocMetrics(): CrdtOpenDocMetrics {
+    const docs = this.getDocSizeMetrics()
+    return {
+      count: docs.length,
+      totalEncodedSizeBytes: docs.reduce((total, doc) => total + doc.encodedSizeBytes, 0),
+      totalAccumulatedBytes: docs.reduce((total, doc) => total + doc.accumulatedBytes, 0),
+      docs
+    }
   }
 
   async wipeStorage(): Promise<void> {
@@ -426,6 +479,7 @@ export class CrdtProvider {
   updateMeta(noteId: string, meta: { title?: string; date?: string }): void {
     const entry = this.docs.get(noteId)
     if (!entry) return
+    this.touchDoc(entry)
 
     entry.doc.transact(() => {
       const metaMap = entry.doc.getMap('meta')
@@ -479,6 +533,7 @@ export class CrdtProvider {
     const entry = this.docs.get(noteId)
     if (!entry) return
 
+    this.touchDoc(entry)
     entry.accumulatedBytes += update.byteLength
     if (origin !== ORIGIN_NETWORK) {
       entry.pendingSnapshotBytes += update.byteLength
@@ -591,6 +646,37 @@ export class CrdtProvider {
     await this.persistence.flushDocument(noteId)
   }
 
+  private touchDoc(entry: ActiveDoc): void {
+    entry.lastTouchedAt = this.now()
+  }
+
+  private measureDocSize(noteId: string, entry: ActiveDoc): CrdtDocSizeMetric {
+    const encodedSizeBytes = Y.encodeStateAsUpdate(entry.doc).byteLength
+    entry.lastEncodedSize = encodedSizeBytes
+    return {
+      noteId,
+      encodedSizeBytes,
+      accumulatedBytes: entry.accumulatedBytes,
+      pendingSnapshotBytes: entry.pendingSnapshotBytes,
+      windowCount: entry.windowIds.size,
+      lastTouchedAt: entry.lastTouchedAt
+    }
+  }
+
+  private async evictInactiveDocsIfNeeded(): Promise<void> {
+    const inactiveDocs = Array.from(this.docs.entries()).filter(
+      ([, entry]) => entry.windowIds.size === 0 && !entry.closing
+    )
+    const overflow = inactiveDocs.length - this.inactiveDocLimit
+    if (overflow <= 0) return
+
+    inactiveDocs.sort(([, left], [, right]) => left.lastTouchedAt - right.lastTouchedAt)
+
+    for (const [noteId] of inactiveDocs.slice(0, overflow)) {
+      await this.closeIfInactive(noteId)
+    }
+  }
+
   async compactDoc(noteId: string): Promise<void> {
     const entry = this.docs.get(noteId)
     if (!entry) return
@@ -677,6 +763,7 @@ export class CrdtProvider {
   applyIpcUpdate(noteId: string, updateArr: number[], sourceWindowId: number): void {
     const entry = this.docs.get(noteId)
     if (!entry) return
+    this.touchDoc(entry)
 
     const update = new Uint8Array(updateArr)
     const origin: IpcOrigin = { source: 'ipc', windowId: sourceWindowId }
@@ -686,6 +773,7 @@ export class CrdtProvider {
   applyIpcSyncStep2(noteId: string, diffArr: number[]): void {
     const entry = this.docs.get(noteId)
     if (!entry) return
+    this.touchDoc(entry)
     const diff = new Uint8Array(diffArr)
     Y.applyUpdate(entry.doc, diff, { source: 'ipc', windowId: -1 } satisfies IpcOrigin)
   }

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -56,6 +56,8 @@ describe('CrdtSyncCoordinator', () => {
   it('applies single-note incrementals, skips unknown signers, and seeds empty local docs', async () => {
     const applyRemoteUpdate = vi.fn()
     const open = vi.fn().mockResolvedValue({})
+    const closeIfInactive = vi.fn().mockResolvedValue(true)
+    const getDoc = vi.fn().mockReturnValue(undefined)
     const getStateVector = vi.fn().mockReturnValue(new Uint8Array([1, 2]))
     const seedFromMarkdownPublic = vi.fn()
 
@@ -81,7 +83,9 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          getDoc,
           open,
+          closeIfInactive,
           applyRemoteUpdate,
           getStateVector,
           seedFromMarkdownPublic
@@ -101,12 +105,48 @@ describe('CrdtSyncCoordinator', () => {
     await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4, 5, 6]))
 
     expect(open).toHaveBeenCalledWith('note-1', undefined, { skipSeed: true })
+    expect(closeIfInactive).toHaveBeenCalledWith('note-1')
     expect(getFromServerMock).toHaveBeenCalledWith(
       '/sync/crdt/updates?note_id=note-1&since=0&limit=100',
       'token-1'
     )
     expect(applyRemoteUpdate).toHaveBeenCalledWith('note-1', new Uint8Array([7, 7, 7]))
     expect(seedFromMarkdownPublic).toHaveBeenCalledWith('note-1')
+  })
+
+  it('does not close single-note incrementals that were already open', async () => {
+    const openDoc = {}
+    const open = vi.fn().mockResolvedValue(openDoc)
+    const closeIfInactive = vi.fn()
+
+    getFromServerMock.mockResolvedValue({
+      updates: [],
+      hasMore: false
+    })
+
+    const ctx = {
+      deps: {
+        crdtProvider: {
+          getDoc: vi.fn().mockReturnValue(openDoc),
+          open,
+          closeIfInactive,
+          applyRemoteUpdate: vi.fn(),
+          getStateVector: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+          seedFromMarkdownPublic: vi.fn()
+        }
+      },
+      abortController: new AbortController()
+    } as unknown as SyncContext
+
+    const coordinator = new CrdtSyncCoordinator(
+      ctx,
+      vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
+    )
+
+    await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4, 5, 6]))
+
+    expect(open).toHaveBeenCalledWith('note-1', undefined, { skipSeed: true })
+    expect(closeIfInactive).not.toHaveBeenCalled()
   })
 
   it('pullCrdtForNote exits without credentials and cleans up the vault key after pulls', async () => {
@@ -148,6 +188,7 @@ describe('CrdtSyncCoordinator', () => {
   it('uses the latest server snapshot as the batch baseline even when the local doc is non-empty', async () => {
     const applyRemoteUpdate = vi.fn()
     const open = vi.fn().mockResolvedValue({})
+    const closeIfInactive = vi.fn().mockResolvedValue(true)
     const getStateVector = vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4]))
 
     fetchCrdtSnapshotMock.mockResolvedValue({
@@ -168,7 +209,9 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          getDoc: vi.fn().mockReturnValue(undefined),
           open,
+          closeIfInactive,
           applyRemoteUpdate,
           getStateVector,
           seedFromMarkdownPublic: vi.fn()
@@ -193,6 +236,54 @@ describe('CrdtSyncCoordinator', () => {
       },
       'token-1'
     )
+    expect(closeIfInactive).toHaveBeenCalledWith('note-1')
+  })
+
+  it('closes only batch docs opened by sync and leaves already-open docs alone', async () => {
+    const openDoc = {}
+    const getDoc = vi.fn().mockReturnValueOnce(undefined).mockReturnValueOnce(openDoc)
+    const closeIfInactive = vi.fn().mockResolvedValue(true)
+
+    postToServerMock.mockResolvedValue({
+      notes: {
+        'sync-only-note': {
+          updates: [],
+          hasMore: false
+        },
+        'active-note': {
+          updates: [],
+          hasMore: false
+        }
+      }
+    })
+
+    const ctx = {
+      deps: {
+        crdtProvider: {
+          getDoc,
+          open: vi.fn().mockResolvedValue({}),
+          closeIfInactive,
+          applyRemoteUpdate: vi.fn(),
+          getStateVector: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+          seedFromMarkdownPublic: vi.fn()
+        }
+      },
+      abortController: new AbortController()
+    } as unknown as SyncContext
+
+    const coordinator = new CrdtSyncCoordinator(
+      ctx,
+      vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
+    )
+
+    await coordinator.applyCrdtBatch(
+      ['sync-only-note', 'active-note'],
+      'token-1',
+      new Uint8Array([4, 5, 6])
+    )
+
+    expect(closeIfInactive).toHaveBeenCalledTimes(1)
+    expect(closeIfInactive).toHaveBeenCalledWith('sync-only-note')
   })
 
   it('reuses the highest applied CRDT sequence as the next batch baseline', async () => {
@@ -240,7 +331,9 @@ describe('CrdtSyncCoordinator', () => {
     const ctx = {
       deps: {
         crdtProvider: {
+          getDoc: vi.fn().mockReturnValue(undefined),
           open,
+          closeIfInactive: vi.fn().mockResolvedValue(true),
           applyRemoteUpdate,
           getStateVector,
           seedFromMarkdownPublic: vi.fn()

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -83,13 +83,15 @@ export class CrdtSyncCoordinator {
     vaultKey: Uint8Array,
     signal?: AbortSignal
   ): Promise<void> {
-    if (!this.ctx.deps.crdtProvider) return
+    const crdtProvider = this.ctx.deps.crdtProvider
+    if (!crdtProvider) return
 
     const effectiveSignal = signal ?? this.ctx.abortController?.signal
     if (!effectiveSignal) return
 
+    const wasOpen = crdtProvider.getDoc(noteId) != null
     try {
-      const doc = await this.ctx.deps.crdtProvider.open(noteId, undefined, { skipSeed: true })
+      const doc = await crdtProvider.open(noteId, undefined, { skipSeed: true })
       if (!doc) return
 
       let since = await this.applySnapshotBaseline(noteId, token, vaultKey, 'single')
@@ -146,16 +148,16 @@ export class CrdtSyncCoordinator {
           }
 
           const decrypted = decryptCrdtUpdate(packed, vaultKey, noteId, signerPubKey)
-          this.ctx.deps.crdtProvider.applyRemoteUpdate(noteId, decrypted)
+          crdtProvider.applyRemoteUpdate(noteId, decrypted)
           since = this.rememberAppliedSequence(noteId, entry.sequenceNum)
         }
 
         hasMore = result.hasMore
       }
 
-      const postVector = this.ctx.deps.crdtProvider.getStateVector(noteId)
+      const postVector = crdtProvider.getStateVector(noteId)
       if (!postVector || postVector.length <= 2) {
-        await this.ctx.deps.crdtProvider.seedFromMarkdownPublic(noteId)
+        await crdtProvider.seedFromMarkdownPublic(noteId)
         log.debug('applyCrdtIncrementals: seeded from markdown as fallback (no server CRDT)', {
           noteId
         })
@@ -169,18 +171,26 @@ export class CrdtSyncCoordinator {
         noteId,
         error: err instanceof Error ? err.message : String(err)
       })
+    } finally {
+      if (!wasOpen) {
+        await crdtProvider.closeIfInactive(noteId)
+      }
     }
   }
 
   async applyCrdtBatch(noteIds: string[], token: string, vaultKey: Uint8Array): Promise<void> {
-    if (!this.ctx.deps.crdtProvider || !this.ctx.abortController) return
+    const crdtProvider = this.ctx.deps.crdtProvider
+    if (!crdtProvider || !this.ctx.abortController) return
 
+    const syncOpenedNoteIds = new Set<string>()
     try {
       const sinceMap = new Map<string, number>()
 
       for (const noteId of noteIds) {
+        const wasOpen = crdtProvider.getDoc(noteId) != null
         try {
-          await this.ctx.deps.crdtProvider.open(noteId, undefined, { skipSeed: true })
+          await crdtProvider.open(noteId, undefined, { skipSeed: true })
+          if (!wasOpen) syncOpenedNoteIds.add(noteId)
         } catch (err) {
           log.warn('Failed to open CRDT doc, skipping note in batch', {
             noteId,
@@ -235,7 +245,7 @@ export class CrdtSyncCoordinator {
               continue
             }
             const decrypted = decryptCrdtUpdate(packed, vaultKey, noteId, pubKey)
-            this.ctx.deps.crdtProvider.applyRemoteUpdate(noteId, decrypted)
+            crdtProvider.applyRemoteUpdate(noteId, decrypted)
             activeSince.set(noteId, this.rememberAppliedSequence(noteId, entry.sequenceNum))
           }
 
@@ -251,9 +261,9 @@ export class CrdtSyncCoordinator {
       }
 
       for (const noteId of noteIds) {
-        const postVector = this.ctx.deps.crdtProvider.getStateVector(noteId)
+        const postVector = crdtProvider.getStateVector(noteId)
         if (!postVector || postVector.length <= 2) {
-          await this.ctx.deps.crdtProvider.seedFromMarkdownPublic(noteId)
+          await crdtProvider.seedFromMarkdownPublic(noteId)
           log.debug('applyCrdtBatch: seeded from markdown as fallback (no server CRDT)', {
             noteId
           })
@@ -267,6 +277,10 @@ export class CrdtSyncCoordinator {
       log.warn('Failed to apply CRDT batch', {
         error: err instanceof Error ? err.message : String(err)
       })
+    } finally {
+      for (const noteId of syncOpenedNoteIds) {
+        await crdtProvider.closeIfInactive(noteId)
+      }
     }
   }
 

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -22,6 +22,17 @@ renderer  ──Yjs IPC provider──▶  main (Y.Doc)  ──y-leveldb──�
 - Persistence via y-leveldb is a Node-side concern.
 - Main can broadcast updates to multiple renderer windows (when split view exists).
 
+## Open Doc Lifecycle
+
+Main keeps a Y.Doc open while an editor window is attached to it. Sync pulls may also
+open a Y.Doc without a window so remote updates can be applied, but those sync-only
+docs are closed again after the pull if they are still inactive.
+
+Inactive docs are capped with least-recently-used eviction. The eviction path only
+targets docs with zero attached windows, so active editor docs are never evicted. The
+provider metrics expose the open doc count, encoded size, and per-doc `windowCount`
+so memory growth can be observed without inspecting private provider state.
+
 ## IPC Loop Prevention
 
 Three pieces of metadata prevent feedback loops:


### PR DESCRIPTION
## Summary

- Close sync-only CRDT docs after pull paths finish, while preserving docs that were already open in an editor.
- Add inactive-doc LRU cleanup and open-doc metrics for count, encoded size, and per-doc window count.
- Document CRDT open-doc lifecycle and memory observation surface.

Closes #428.

## Verification

- pnpm --filter @memry/desktop rebuild:node
- pnpm exec vitest run --config config/vitest.config.ts --project main src/main/sync/crdt-provider.test.ts src/main/sync/engine/crdt-sync-coordinator.test.ts src/main/sync/crdt-ipc-handlers.test.ts src/main/sync/runtime.test.ts src/main/sync/engine-crdt.test.ts
- pnpm --filter @memry/desktop typecheck:node
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build
- git diff --check origin/main...HEAD

## Benchmark

500 sync-only CRDT docs with 8 KiB payload each:

| run | retained docs | retained encoded size | RSS delta | heap delta |
| --- | ---: | ---: | ---: | ---: |
| baseline | 500 | 3.93 MiB | 40.3 MiB | 12.0 MiB |
| patched | 32 | 0.25 MiB | 22.5 MiB | 2.4 MiB |