### PR TITLE
Tune SQLite memory budget

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -63,6 +63,7 @@
     "db:push:index": "drizzle-kit push --config config/drizzle-index.config.ts",
     "db:studio:data": "drizzle-kit studio --config config/drizzle-data.config.ts",
     "db:studio:index": "drizzle-kit studio --config config/drizzle-index.config.ts",
+    "db:benchmark": "node --expose-gc --import tsx scripts/sqlite-memory-benchmark.ts",
     "build:unpack": "pnpm build && node scripts/build-packaged-app.js --dir",
     "build:win": "pnpm build && electron-builder --config config/electron-builder.yml --win",
     "build:mac": "pnpm build && node scripts/build-packaged-app.js --mac",

--- a/apps/desktop/scripts/sqlite-memory-benchmark.ts
+++ b/apps/desktop/scripts/sqlite-memory-benchmark.ts
@@ -1,0 +1,509 @@
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as dataSchema from '@memry/db-schema/data-schema'
+import * as indexSchema from '@memry/db-schema/index-schema'
+import * as sqliteVec from 'sqlite-vec'
+import { createFtsTable } from '../src/main/database/fts'
+import { createFtsInboxTable } from '../src/main/database/fts-inbox'
+import { createFtsTasksTable } from '../src/main/database/fts-tasks'
+import { getGraphData } from '../src/main/database/queries/graph'
+import { searchAll } from '../src/main/database/queries/search'
+import { listTasks } from '../src/main/database/queries/tasks'
+import {
+  SQLITE_DATA_CACHE_KIB,
+  SQLITE_INDEX_CACHE_KIB,
+  SQLITE_TEMP_STORE
+} from '../src/main/database/client'
+import { EMBEDDING_DIMENSION } from '../src/main/lib/embeddings-constants'
+import type { DataDb, IndexDb } from '../src/main/database/types'
+
+type TempStore = 'DEFAULT' | 'FILE' | 'MEMORY'
+
+interface Options {
+  notes: number
+  tasks: number
+  inbox: number
+  iterations: number
+  dataCacheKiB: number
+  indexCacheKiB: number
+  tempStore: TempStore
+  keep: boolean
+}
+
+interface TimingSummary {
+  min: number
+  p50: number
+  p95: number
+  max: number
+  avg: number
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const desktopRoot = path.resolve(scriptDir, '..')
+const dataMigrations = path.join(desktopRoot, 'src/main/database/drizzle-data')
+const indexMigrations = path.join(desktopRoot, 'src/main/database/drizzle-index')
+
+const defaultOptions: Options = {
+  notes: 2500,
+  tasks: 1200,
+  inbox: 500,
+  iterations: 40,
+  dataCacheKiB: SQLITE_DATA_CACHE_KIB,
+  indexCacheKiB: SQLITE_INDEX_CACHE_KIB,
+  tempStore: SQLITE_TEMP_STORE as TempStore,
+  keep: false
+}
+
+function parseNumber(value: string, flag: string): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive number`)
+  }
+  return Math.floor(parsed)
+}
+
+function parseArgs(argv: string[]): Options {
+  const options = { ...defaultOptions }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const next = argv[i + 1]
+
+    switch (arg) {
+      case '--':
+        break
+      case '--notes':
+        if (!next) throw new Error('--notes requires a value')
+        options.notes = parseNumber(next, arg)
+        i += 1
+        break
+      case '--tasks':
+        if (!next) throw new Error('--tasks requires a value')
+        options.tasks = parseNumber(next, arg)
+        i += 1
+        break
+      case '--inbox':
+        if (!next) throw new Error('--inbox requires a value')
+        options.inbox = parseNumber(next, arg)
+        i += 1
+        break
+      case '--iterations':
+        if (!next) throw new Error('--iterations requires a value')
+        options.iterations = parseNumber(next, arg)
+        i += 1
+        break
+      case '--data-cache-kib':
+        if (!next) throw new Error('--data-cache-kib requires a value')
+        options.dataCacheKiB = parseNumber(next, arg)
+        i += 1
+        break
+      case '--index-cache-kib':
+        if (!next) throw new Error('--index-cache-kib requires a value')
+        options.indexCacheKiB = parseNumber(next, arg)
+        i += 1
+        break
+      case '--temp-store':
+        if (!next) throw new Error('--temp-store requires a value')
+        if (!['DEFAULT', 'FILE', 'MEMORY'].includes(next)) {
+          throw new Error('--temp-store must be DEFAULT, FILE, or MEMORY')
+        }
+        options.tempStore = next as TempStore
+        i += 1
+        break
+      case '--keep':
+        options.keep = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+function printHelp(): void {
+  console.log(`Usage: pnpm db:benchmark [options]
+
+Options:
+  --notes <n>             Note rows to seed, default ${defaultOptions.notes}
+  --tasks <n>             Task rows to seed, default ${defaultOptions.tasks}
+  --inbox <n>             Inbox rows to seed, default ${defaultOptions.inbox}
+  --iterations <n>        Query iterations, default ${defaultOptions.iterations}
+  --data-cache-kib <n>    data.db page-cache cap in KiB, default product value
+  --index-cache-kib <n>   index.db page-cache cap in KiB, default product value
+  --temp-store <mode>     DEFAULT, FILE, or MEMORY, default product value
+  --keep                  Keep the generated temp vault for inspection
+`)
+}
+
+function bytesToMiB(value: number): string {
+  return (value / 1024 / 1024).toFixed(1)
+}
+
+function measureMemoryMiB(): number {
+  if (typeof global.gc === 'function') global.gc()
+  return Number(bytesToMiB(process.memoryUsage().rss))
+}
+
+function summarize(values: number[]): TimingSummary {
+  const sorted = [...values].sort((a, b) => a - b)
+  const percentile = (p: number): number =>
+    sorted[Math.min(sorted.length - 1, Math.floor(p * (sorted.length - 1)))]
+  const avg = sorted.reduce((sum, value) => sum + value, 0) / sorted.length
+  return {
+    min: Number(sorted[0].toFixed(2)),
+    p50: Number(percentile(0.5).toFixed(2)),
+    p95: Number(percentile(0.95).toFixed(2)),
+    max: Number(sorted[sorted.length - 1].toFixed(2)),
+    avg: Number(avg.toFixed(2))
+  }
+}
+
+function measure(label: string, iterations: number, fn: () => unknown): [string, TimingSummary] {
+  const durations: number[] = []
+
+  for (let i = 0; i < iterations; i += 1) {
+    const start = performance.now()
+    fn()
+    durations.push(performance.now() - start)
+  }
+
+  return [label, summarize(durations)]
+}
+
+function configure(
+  sqlite: Database.Database,
+  cacheKiB: number,
+  tempStore: TempStore,
+  foreignKeys: boolean
+): void {
+  sqlite.pragma('journal_mode = WAL')
+  if (foreignKeys) sqlite.pragma('foreign_keys = ON')
+  sqlite.pragma('synchronous = NORMAL')
+  sqlite.pragma('busy_timeout = 5000')
+  sqlite.pragma(`cache_size = -${cacheKiB}`)
+  sqlite.pragma(`temp_store = ${tempStore}`)
+}
+
+function runMigrations(dbPath: string, migrationsFolder: string): void {
+  const sqlite = new Database(dbPath)
+  sqlite.pragma('journal_mode = WAL')
+  migrate(drizzle(sqlite), { migrationsFolder })
+  sqlite.close()
+}
+
+function phrase(i: number): string {
+  const topic = i % 5 === 0 ? 'sqlite memory search graph tasks' : 'memry local first notes'
+  return `${topic} benchmark row ${i} with repeated searchable content and linked context`
+}
+
+function seedIndex(indexSqlite: Database.Database, indexDb: IndexDb, notes: number): void {
+  createFtsTable(indexDb)
+
+  sqliteVec.load(indexSqlite)
+  indexSqlite.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS vec_notes USING vec0(
+      note_id TEXT PRIMARY KEY,
+      embedding float[${EMBEDDING_DIMENSION}] distance_metric=cosine
+    )
+  `)
+
+  const insertNote = indexSqlite.prepare(`
+    INSERT INTO note_cache (
+      id, path, title, file_type, emoji, content_hash, word_count, character_count,
+      snippet, date, created_at, modified_at, indexed_at
+    ) VALUES (?, ?, ?, 'markdown', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+  const insertFts = indexSqlite.prepare(`
+    INSERT INTO fts_notes (id, title, content, tags) VALUES (?, ?, ?, ?)
+  `)
+  const insertTag = indexSqlite.prepare(`
+    INSERT INTO note_tags (note_id, tag, position) VALUES (?, ?, ?)
+  `)
+  const insertLink = indexSqlite.prepare(`
+    INSERT INTO note_links (source_id, target_id, target_title) VALUES (?, ?, ?)
+  `)
+  const insertVec = indexSqlite.prepare(`
+    INSERT INTO vec_notes (note_id, embedding) VALUES (?, ?)
+  `)
+  const now = new Date('2026-05-21T12:00:00.000Z').toISOString()
+
+  const transaction = indexSqlite.transaction(() => {
+    for (let i = 0; i < notes; i += 1) {
+      const id = `note-${i}`
+      const title = i % 5 === 0 ? `SQLite memory note ${i}` : `Local note ${i}`
+      const content = phrase(i)
+      const date = i % 10 === 0 ? `2026-05-${String((i % 28) + 1).padStart(2, '0')}` : null
+
+      insertNote.run(
+        id,
+        `notes/${id}.md`,
+        title,
+        null,
+        `hash-${i}`,
+        content.split(/\s+/).length,
+        content.length,
+        content.slice(0, 120),
+        date,
+        now,
+        now,
+        now
+      )
+      insertFts.run(id, title, content, i % 5 === 0 ? 'sqlite memory search' : 'local notes')
+      insertTag.run(id, i % 5 === 0 ? 'sqlite' : 'notes', 0)
+
+      if (i > 0) {
+        insertLink.run(id, `note-${i - 1}`, `Local note ${i - 1}`)
+      }
+
+      if (i < 250) {
+        const embedding = new Float32Array(EMBEDDING_DIMENSION)
+        for (let j = 0; j < EMBEDDING_DIMENSION; j += 1) {
+          embedding[j] = ((i + j) % 17) / 17
+        }
+        insertVec.run(id, embedding)
+      }
+    }
+  })
+
+  transaction()
+}
+
+function seedData(
+  dataSqlite: Database.Database,
+  dataDb: DataDb,
+  tasks: number,
+  inbox: number
+): void {
+  createFtsTasksTable(dataDb)
+  createFtsInboxTable(dataDb)
+
+  const now = new Date('2026-05-21T12:00:00.000Z').toISOString()
+  const insertProject = dataSqlite.prepare(`
+    INSERT INTO projects (
+      id, name, description, color, icon, position, is_inbox, created_at, modified_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+  const insertStatus = dataSqlite.prepare(`
+    INSERT INTO statuses (
+      id, project_id, name, color, position, is_default, is_done, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+  const insertTask = dataSqlite.prepare(`
+    INSERT INTO tasks (
+      id, project_id, status_id, title, description, priority, position,
+      due_date, created_at, modified_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+  const insertTaskFts = dataSqlite.prepare(`
+    INSERT INTO fts_tasks (id, title, description, tags) VALUES (?, ?, ?, ?)
+  `)
+  const insertInbox = dataSqlite.prepare(`
+    INSERT INTO inbox_items (
+      id, type, title, content, source_title, source_url, capture_source,
+      processing_status, created_at, modified_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'complete', ?, ?)
+  `)
+  const insertInboxFts = dataSqlite.prepare(`
+    INSERT INTO fts_inbox (id, title, content, transcription, source_title)
+    VALUES (?, ?, ?, '', ?)
+  `)
+
+  const transaction = dataSqlite.transaction(() => {
+    for (let i = 0; i < 5; i += 1) {
+      insertProject.run(
+        `project-${i}`,
+        `Project ${i}`,
+        'Benchmark project',
+        '#6366f1',
+        'folder',
+        i,
+        i === 0 ? 1 : 0,
+        now,
+        now
+      )
+      insertStatus.run(`status-${i}`, `project-${i}`, 'To Do', '#6b7280', 0, 1, 0, now)
+    }
+
+    for (let i = 0; i < tasks; i += 1) {
+      const project = `project-${i % 5}`
+      const status = `status-${i % 5}`
+      const title = i % 5 === 0 ? `SQLite memory task ${i}` : `Task ${i}`
+      const description = phrase(i)
+      insertTask.run(
+        `task-${i}`,
+        project,
+        status,
+        title,
+        description,
+        i % 4,
+        i,
+        `2026-06-${String((i % 28) + 1).padStart(2, '0')}`,
+        now,
+        now
+      )
+      insertTaskFts.run(`task-${i}`, title, description, i % 5 === 0 ? 'sqlite memory' : 'tasks')
+    }
+
+    for (let i = 0; i < inbox; i += 1) {
+      const title = i % 5 === 0 ? `SQLite memory inbox ${i}` : `Inbox item ${i}`
+      const content = phrase(i)
+      insertInbox.run(
+        `inbox-${i}`,
+        i % 3 === 0 ? 'link' : 'note',
+        title,
+        content,
+        `Source ${i}`,
+        `https://example.com/${i}`,
+        'quick-capture',
+        now,
+        now
+      )
+      insertInboxFts.run(`inbox-${i}`, title, content, `Source ${i}`)
+    }
+  })
+
+  transaction()
+}
+
+function benchmark(options: Options): void {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-sqlite-benchmark-'))
+  const dataPath = path.join(tempDir, 'data.db')
+  const indexPath = path.join(tempDir, 'index.db')
+
+  let dataSqlite: Database.Database | null = null
+  let indexSqlite: Database.Database | null = null
+
+  try {
+    const memoryStart = measureMemoryMiB()
+    runMigrations(dataPath, dataMigrations)
+    runMigrations(indexPath, indexMigrations)
+
+    dataSqlite = new Database(dataPath)
+    indexSqlite = new Database(indexPath)
+    configure(dataSqlite, options.dataCacheKiB, options.tempStore, true)
+    configure(indexSqlite, options.indexCacheKiB, options.tempStore, false)
+
+    const dataDb = drizzle(dataSqlite, { schema: dataSchema })
+    const indexDb = drizzle(indexSqlite, { schema: indexSchema })
+
+    const openLatencyStart = performance.now()
+    const dataCache = dataSqlite.pragma('cache_size', { simple: true })
+    const indexCache = indexSqlite.pragma('cache_size', { simple: true })
+    const dataTempStore = dataSqlite.pragma('temp_store', { simple: true })
+    const indexTempStore = indexSqlite.pragma('temp_store', { simple: true })
+    const openLatencyMs = performance.now() - openLatencyStart
+
+    seedData(dataSqlite, dataDb, options.tasks, options.inbox)
+    seedIndex(indexSqlite, indexDb, options.notes)
+    const memoryAfterSeed = measureMemoryMiB()
+
+    const query = {
+      text: 'sqlite memory',
+      types: [],
+      tags: [],
+      dateRange: null,
+      projectId: null,
+      folderPath: null,
+      limit: 20,
+      offset: 0
+    }
+
+    searchAll(indexDb, dataDb, query)
+    getGraphData(indexDb, dataDb)
+    listTasks(dataDb, { limit: 100 })
+    dataSqlite
+      .prepare(
+        `SELECT id, title FROM inbox_items
+         WHERE filed_at IS NULL AND archived_at IS NULL
+         ORDER BY created_at DESC LIMIT 100`
+      )
+      .all()
+    indexSqlite
+      .prepare(
+        `SELECT note_id, distance FROM vec_notes
+         WHERE embedding MATCH ? AND k = 5
+         ORDER BY distance`
+      )
+      .all(new Float32Array(EMBEDDING_DIMENSION))
+
+    const memoryAfterWarmup = measureMemoryMiB()
+    const results = [
+      measure('searchAll', options.iterations, () => searchAll(indexDb, dataDb, query)),
+      measure('getGraphData', options.iterations, () => getGraphData(indexDb, dataDb)),
+      measure('listTasks', options.iterations, () => listTasks(dataDb, { limit: 100 })),
+      measure('listInbox', options.iterations, () =>
+        dataSqlite
+          ?.prepare(
+            `SELECT id, title FROM inbox_items
+             WHERE filed_at IS NULL AND archived_at IS NULL
+             ORDER BY created_at DESC LIMIT 100`
+          )
+          .all()
+      ),
+      measure('vectorKnn', options.iterations, () =>
+        indexSqlite
+          ?.prepare(
+            `SELECT note_id, distance FROM vec_notes
+             WHERE embedding MATCH ? AND k = 5
+             ORDER BY distance`
+          )
+          .all(new Float32Array(EMBEDDING_DIMENSION))
+      )
+    ]
+
+    console.log(
+      JSON.stringify(
+        {
+          config: {
+            notes: options.notes,
+            tasks: options.tasks,
+            inbox: options.inbox,
+            iterations: options.iterations,
+            dataCacheKiB: options.dataCacheKiB,
+            indexCacheKiB: options.indexCacheKiB,
+            tempStore: options.tempStore,
+            reportedPragmas: {
+              dataCache,
+              indexCache,
+              dataTempStore,
+              indexTempStore
+            }
+          },
+          memoryMiB: {
+            start: memoryStart,
+            afterSeed: memoryAfterSeed,
+            afterWarmup: memoryAfterWarmup
+          },
+          openLatencyMs: Number(openLatencyMs.toFixed(2)),
+          timingsMs: Object.fromEntries(results),
+          tempDir: options.keep ? tempDir : undefined
+        },
+        null,
+        2
+      )
+    )
+  } finally {
+    dataSqlite?.close()
+    indexSqlite?.close()
+    if (!options.keep) {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  }
+}
+
+try {
+  benchmark(parseArgs(process.argv.slice(2)))
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+}

--- a/apps/desktop/src/main/database/client.test.ts
+++ b/apps/desktop/src/main/database/client.test.ts
@@ -12,7 +12,9 @@ import {
   getRawIndexDatabase,
   closeAllDatabases,
   checkIndexHealth,
-  withTimeout
+  withTimeout,
+  SQLITE_DATA_CACHE_KIB,
+  SQLITE_INDEX_CACHE_KIB
 } from './client'
 
 describe('database client', () => {
@@ -41,6 +43,8 @@ describe('database client', () => {
     expect(client.pragma('foreign_keys', { simple: true })).toBe(1)
     expect(client.pragma('busy_timeout', { simple: true })).toBe(5000)
     expect(client.pragma('synchronous', { simple: true })).toBe(1)
+    expect(client.pragma('cache_size', { simple: true })).toBe(-SQLITE_DATA_CACHE_KIB)
+    expect(client.pragma('temp_store', { simple: true })).toBe(2)
   })
 
   it('initializes the index database with vec table and cache settings', () => {
@@ -54,7 +58,8 @@ describe('database client', () => {
 
     expect(vecTable?.name).toBe('vec_notes')
     expect(String(raw.pragma('journal_mode', { simple: true })).toLowerCase()).toBe('wal')
-    expect(raw.pragma('cache_size', { simple: true })).toBe(-128000)
+    expect(raw.pragma('cache_size', { simple: true })).toBe(-SQLITE_INDEX_CACHE_KIB)
+    expect(raw.pragma('temp_store', { simple: true })).toBe(2)
   })
 
   it('closes databases and resets getters', () => {

--- a/apps/desktop/src/main/database/client.ts
+++ b/apps/desktop/src/main/database/client.ts
@@ -14,6 +14,10 @@ let indexDb: IndexDb | null = null
 let sqliteDataDb: Database.Database | null = null
 let sqliteIndexDb: Database.Database | null = null
 
+export const SQLITE_DATA_CACHE_KIB = 16000
+export const SQLITE_INDEX_CACHE_KIB = 32000
+export const SQLITE_TEMP_STORE = 'MEMORY'
+
 export function initDatabase(dbPath: string): DataDb {
   sqliteDataDb = new Database(dbPath)
 
@@ -29,11 +33,11 @@ export function initDatabase(dbPath: string): DataDb {
   // Wait up to 5 seconds for locks
   sqliteDataDb.pragma('busy_timeout = 5000')
 
-  // Increase cache size for better performance (64MB)
-  sqliteDataDb.pragma('cache_size = -64000')
+  // Keep a bounded page cache; benchmarked as flat for current search/task query latency.
+  sqliteDataDb.pragma(`cache_size = -${SQLITE_DATA_CACHE_KIB}`)
 
   // Store temp tables in memory
-  sqliteDataDb.pragma('temp_store = MEMORY')
+  sqliteDataDb.pragma(`temp_store = ${SQLITE_TEMP_STORE}`)
 
   dataDb = drizzle(sqliteDataDb, { schema: dataSchema })
   return dataDb
@@ -53,11 +57,11 @@ export function initIndexDatabase(dbPath: string): IndexDb {
   // Wait up to 5 seconds for locks
   sqliteIndexDb.pragma('busy_timeout = 5000')
 
-  // Larger cache for search performance (128MB)
-  sqliteIndexDb.pragma('cache_size = -128000')
+  // Keep the rebuildable index cache larger than data.db without reserving old 128MB headroom.
+  sqliteIndexDb.pragma(`cache_size = -${SQLITE_INDEX_CACHE_KIB}`)
 
   // Store temp tables in memory
-  sqliteIndexDb.pragma('temp_store = MEMORY')
+  sqliteIndexDb.pragma(`temp_store = ${SQLITE_TEMP_STORE}`)
 
   // Load sqlite-vec extension for vector search
   sqliteVec.load(sqliteIndexDb)

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -53,6 +53,33 @@ pnpm db:studio      # open GUI
 
 better-sqlite3 is synchronous and single-process. The main process is the only writer. The renderer never touches SQLite directly — all reads and writes go through IPC.
 
+## SQLite Memory Budget
+
+The desktop main process opens both databases with bounded SQLite page caches:
+
+- `data.db`: `PRAGMA cache_size = -16000` (about 16 MiB)
+- `index.db`: `PRAGMA cache_size = -32000` (about 32 MiB)
+- both databases use WAL, `synchronous = NORMAL`, and `temp_store = MEMORY`
+
+The previous caps were about 64 MiB for `data.db` and 128 MiB for `index.db`. A controlled
+main-process benchmark with 15,000 notes, 5,000 tasks, 2,000 inbox items, FTS, graph links, and
+`sqlite-vec` showed the smaller caches kept focused query latency flat while reducing the maximum
+SQLite page-cache budget by about 144 MiB. Observed warm RSS was effectively flat because SQLite
+does not preallocate the full cache cap.
+
+| Configuration                               |  Warm RSS | Search p50 / p95 |  Graph p50 / p95 | Tasks p50 / p95 | Inbox p50 / p95 | Vector p50 / p95 |
+| ------------------------------------------- | --------: | ---------------: | ---------------: | --------------: | --------------: | ---------------: |
+| 64 MiB data / 128 MiB index / `MEMORY` temp | 173.1 MiB |   8.86 / 9.56 ms | 35.56 / 40.95 ms |  0.83 / 1.12 ms |  0.19 / 0.24 ms |   0.34 / 0.46 ms |
+| 16 MiB data / 32 MiB index / `MEMORY` temp  | 174.1 MiB |   8.75 / 9.33 ms | 34.45 / 37.65 ms |  0.74 / 0.92 ms |  0.18 / 0.19 ms |   0.30 / 0.58 ms |
+
+`temp_store = MEMORY` stays in place because an isolation run with smaller caches and `FILE` temp
+store did not reduce RSS in the smaller smoke benchmark and slightly worsened graph p50. Re-run the
+benchmark when search, graph, inbox, or vector query shapes change:
+
+```bash
+pnpm --filter @memry/desktop db:benchmark -- --iterations 25
+```
+
 ## Native Media Processing
 
 Image, PDF, and video thumbnail generation stays local, but the native image stack is not part of

--- a/packages/app-core/src/database.ts
+++ b/packages/app-core/src/database.ts
@@ -20,6 +20,10 @@ export interface OpenedDatabases {
   close(): void
 }
 
+const dataCacheKiB = 16000
+const indexCacheKiB = 32000
+const sqliteTempStore = 'MEMORY'
+
 const lockWaitBuffer = new Int32Array(new SharedArrayBuffer(4))
 const initLockTimeoutMs = 30_000
 const staleInitLockMs = 5 * 60_000
@@ -30,7 +34,7 @@ function configure(sqlite: Database.Database, cacheSize: number): void {
   sqlite.pragma('synchronous = NORMAL')
   sqlite.pragma('busy_timeout = 5000')
   sqlite.pragma(`cache_size = ${cacheSize}`)
-  sqlite.pragma('temp_store = MEMORY')
+  sqlite.pragma(`temp_store = ${sqliteTempStore}`)
 }
 
 function sleepSync(ms: number): void {
@@ -158,7 +162,7 @@ export function openDatabases(vaultPath: string): OpenedDatabases {
     )
 
     const seedSqlite = new Database(dataDbPath)
-    configure(seedSqlite, -64000)
+    configure(seedSqlite, -dataCacheKiB)
     try {
       ensureDefaultTaskProject(drizzle(seedSqlite, { schema: dataSchema }))
     } finally {
@@ -168,8 +172,8 @@ export function openDatabases(vaultPath: string): OpenedDatabases {
 
   const dataSqlite = new Database(dataDbPath)
   const indexSqlite = new Database(indexDbPath)
-  configure(dataSqlite, -64000)
-  configure(indexSqlite, -128000)
+  configure(dataSqlite, -dataCacheKiB)
+  configure(indexSqlite, -indexCacheKiB)
 
   const dataDb = drizzle(dataSqlite, { schema: dataSchema })
   const indexDb = drizzle(indexSqlite, { schema: indexSchema })


### PR DESCRIPTION
## Summary

- reduce SQLite page-cache caps from 64 MiB/128 MiB to 16 MiB/32 MiB for `data.db` and `index.db`
- add a focused SQLite memory/query benchmark script for cache and temp-store comparisons
- document the measurement result and keep the dual-DB topology: durable `data.db`, rebuildable `index.db`

Closes #433.

## Measurements

Controlled benchmark with 15,000 notes, 5,000 tasks, 2,000 inbox items, FTS, graph links, and sqlite-vec:

- Old 64 MiB data / 128 MiB index / MEMORY temp: warm RSS 173.1 MiB, search p50/p95 8.86/9.56 ms, graph p50/p95 35.56/40.95 ms
- New 16 MiB data / 32 MiB index / MEMORY temp: warm RSS 174.1 MiB, search p50/p95 8.75/9.33 ms, graph p50/p95 34.45/37.65 ms

The change reduces SQLite's maximum page-cache budget by about 144 MiB. Observed warm RSS was effectively flat because SQLite does not preallocate the full cache cap, but focused query latency stayed flat.

## Verification

- `pnpm --filter @memry/desktop db:benchmark -- --notes 15000 --tasks 5000 --inbox 2000 --iterations 10 --data-cache-kib 64000 --index-cache-kib 128000 --temp-store MEMORY`
- `pnpm --filter @memry/desktop db:benchmark -- --notes 15000 --tasks 5000 --inbox 2000 --iterations 10`
- `pnpm --filter @memry/desktop test:main -- database vault/indexer.test.ts projections/projectors/search-projector.test.ts`
- `pnpm --filter @memry/app-core test`
- `pnpm --filter @memry/desktop typecheck:node`
- `pnpm --filter @memry/app-core typecheck`
- `pnpm docs:impact --base origin/main --strict`
- `pnpm docs:build`
- `git diff --check`
