### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,78 @@
+name: Bug
+description: Report something broken in MemryNote.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when existing behavior is broken, surprising, or risks data correctness.
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened?
+      description: Describe the broken behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: Describe the correct behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Notes
+        - Journal
+        - Inbox
+        - Tasks
+        - Calendar
+        - Sync
+        - Agent
+        - Landing
+        - Docs
+        - Project Ops
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: data_risk
+    attributes:
+      label: Data risk
+      options:
+        - None known
+        - Possible display-only issue
+        - Possible unsaved changes
+        - Possible data corruption or loss
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: App version, OS, vault/sync state, browser if relevant.
+      placeholder: "macOS ..., Memry ..."
+    validations:
+      required: false
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Logs, screenshots, recordings
+      description: Paste logs or attach screenshots/recordings if available.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: MemryNote website
+    url: https://memrynote.com
+    about: Product information and launch updates.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,83 @@
+name: Feature
+description: Propose a new MemryNote capability.
+title: "[Feature]: "
+labels: ["enhancement", "needs-design"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for new product capabilities, user workflows, or larger feature ideas.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem or workflow gap does this solve?
+      placeholder: "I want to..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should MemryNote do?
+      placeholder: "When I..., Memry should..."
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Notes
+        - Journal
+        - Inbox
+        - Tasks
+        - Calendar
+        - Sync
+        - Agent
+        - Landing
+        - Docs
+        - Project Ops
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0 - blocking or data-loss risk
+        - P1 - important user workflow
+        - P2 - useful improvement
+        - P3 - polish or later
+    validations:
+      required: true
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Phase
+      options:
+        - MVP
+        - V2
+        - V3
+        - Later
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What must be true before this is done?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Context, screenshots, links
+      description: Add examples, related issues, sketches, docs, or screenshots.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,67 @@
+name: Improvement
+description: Suggest a smaller polish, workflow, or quality improvement.
+title: "[Improvement]: "
+labels: ["improvement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for changes that improve an existing behavior without introducing a whole new feature surface.
+  - type: textarea
+    id: friction
+    attributes:
+      label: Current friction
+      description: What is awkward, slow, unclear, noisy, or harder than it should be?
+    validations:
+      required: true
+  - type: textarea
+    id: better
+    attributes:
+      label: Better behavior
+      description: What should be different?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Notes
+        - Journal
+        - Inbox
+        - Tasks
+        - Calendar
+        - Sync
+        - Agent
+        - Landing
+        - Docs
+        - Project Ops
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: size
+    attributes:
+      label: Expected size
+      options:
+        - S - small polish
+        - M - focused implementation
+        - L - multi-file change
+        - XL - needs design/spec first
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: success
+    attributes:
+      label: Success signal
+      description: How will we know this improvement worked?
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Context, screenshots, links
+      description: Add examples, related issues, sketches, docs, or screenshots.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add public GitHub issue forms for features, bugs, and improvements.
- Add issue-template config with the MemryNote website contact link.
- Set up the MemryNote Improvements public GitHub Project and seed the comments roadmap issues.

## Release note
None

## Test plan
- `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`\n- `git diff --check`\n- `env -u GH_TOKEN gh project view 5 --owner memrynote --format json`\n- `env -u GH_TOKEN gh issue list -R memrynote/memry --state open --search '"[Comments" in:title' --json number,title,url,labels --limit 20`\n\n## GitHub project\n- https://github.com/orgs/memrynote/projects/5\n\n## Seeded comments issues\n- https://github.com/memrynote/memry/issues/452\n- https://github.com/memrynote/memry/issues/453\n- https://github.com/memrynote/memry/issues/454\n- https://github.com/memrynote/memry/issues/455\n- https://github.com/memrynote/memry/issues/456\n- https://github.com/memrynote/memry/issues/457