### PR TITLE
Reduce renderer memory with feature lazy loading

### DIFF
--- a/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/day-panel/global-day-panel.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
-import { AgentPane } from '@/agent-chat/agent-pane'
 import { SidebarTabs } from '@/agent-chat/sidebar-tabs'
 import { TabBarAction } from '@/components/tabs/tab-bar-action'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -33,6 +32,10 @@ import { useT } from '@memry/i18n/renderer'
 interface GlobalDayPanelProps {
   className?: string
 }
+
+const LazyAgentPane = lazy(async () => ({
+  default: (await import('@/agent-chat/agent-pane')).AgentPane
+}))
 
 function DayPanelResizeRail() {
   const { t: tPhaseF } = useT('common')
@@ -93,9 +96,28 @@ function DayPanelResizeRail() {
 }
 
 export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
+  const { isOpen, width, isResizing } = useDayPanel()
+
+  return (
+    <div
+      data-slot="day-panel-container"
+      style={{ width: isOpen ? `${width}px` : 0 }}
+      className={cn(
+        'fixed top-0 bottom-0 end-0 z-10',
+        !isResizing && 'transition-[width] duration-200 ease-linear',
+        'flex flex-col border-s border-border bg-background',
+        className
+      )}
+    >
+      {isOpen && <GlobalDayPanelContent width={width} />}
+    </div>
+  )
+}
+
+function GlobalDayPanelContent({ width }: { width: number }): React.JSX.Element {
   const { t, i18n } = useT('journal')
   const { t: tCommon } = useT('common')
-  const { isOpen, selectedDate, width, isResizing, setDate, toggle } = useDayPanel()
+  const { selectedDate, setDate, toggle } = useDayPanel()
   const { openTab } = useTabs()
   const activeTab = useActiveTab()
   const { setAnchorDate } = useCalendarView()
@@ -212,68 +234,53 @@ export function GlobalDayPanel({ className }: GlobalDayPanelProps) {
 
   return (
     <div
-      data-slot="day-panel-container"
-      style={{ width: isOpen ? `${width}px` : 0 }}
-      className={cn(
-        'fixed top-0 bottom-0 end-0 z-10',
-        !isResizing && 'transition-[width] duration-200 ease-linear',
-        'flex flex-col border-s border-border bg-background',
-        className
-      )}
+      data-slot="day-panel-inner"
+      style={{ width: `${width}px` }}
+      className={cn('relative flex h-full flex-col', 'transition-opacity duration-200 opacity-100')}
     >
-      <div
-        data-slot="day-panel-inner"
-        style={{ width: `${width}px` }}
-        className={cn(
-          'relative flex h-full flex-col',
-          'transition-opacity duration-200',
-          isOpen ? 'opacity-100' : 'opacity-0'
-        )}
-      >
-        {isOpen && <DayPanelResizeRail />}
+      <DayPanelResizeRail />
 
-        <SidebarTabs
-          dayLabel={dayPanelLabel}
-          endAccessory={
-            isOpen ? (
-              <TooltipProvider delayDuration={300}>
-                <TabBarAction
-                  icon={
-                    <PanelRightIcon className="w-4 h-4 text-tint transition-colors duration-150" />
-                  }
-                  tooltip={tCommon('phaseF.componentsTabsTabBarWithDrag.dayPanel')}
-                  onClick={toggle}
-                  isActive
+      <SidebarTabs
+        dayLabel={dayPanelLabel}
+        endAccessory={
+          <TooltipProvider delayDuration={300}>
+            <TabBarAction
+              icon={<PanelRightIcon className="w-4 h-4 text-tint transition-colors duration-150" />}
+              tooltip={tCommon('phaseF.componentsTabsTabBarWithDrag.dayPanel')}
+              onClick={toggle}
+              isActive
+            />
+          </TooltipProvider>
+        }
+      >
+        {{
+          day: (
+            <div className="h-full overflow-y-auto pt-3">
+              <div className="px-4 pb-3">
+                <DatePickerCalendar
+                  selected={selectedDateObj}
+                  onSelect={handleDateSelect}
+                  activityData={isCalendarTabActive ? undefined : journalActivityData}
+                  dayDots={isCalendarTabActive ? dayDotsData : undefined}
+                  hoveredEventColor={hoveredEventColor}
+                  className="w-full"
+                  showWeekNumbers
+                  onTodayClick={handleTodayClick}
                 />
-              </TooltipProvider>
-            ) : null
-          }
-        >
-          {{
-            day: (
-              <div className="h-full overflow-y-auto pt-3">
-                <div className="px-4 pb-3">
-                  <DatePickerCalendar
-                    selected={selectedDateObj}
-                    onSelect={handleDateSelect}
-                    activityData={isCalendarTabActive ? undefined : journalActivityData}
-                    dayDots={isCalendarTabActive ? dayDotsData : undefined}
-                    hoveredEventColor={hoveredEventColor}
-                    className="w-full"
-                    showWeekNumbers
-                    onTodayClick={handleTodayClick}
-                  />
-                </div>
-                <div className="h-px mx-4 bg-border/30" />
-                <div className="p-4">
-                  <JournalDayPanel date={selectedDate} onHoverColor={handleHoverColor} />
-                </div>
               </div>
-            ),
-            agent: <AgentPane />
-          }}
-        </SidebarTabs>
-      </div>
+              <div className="h-px mx-4 bg-border/30" />
+              <div className="p-4">
+                <JournalDayPanel date={selectedDate} onHoverColor={handleHoverColor} />
+              </div>
+            </div>
+          ),
+          agent: (
+            <Suspense fallback={null}>
+              <LazyAgentPane />
+            </Suspense>
+          )
+        }}
+      </SidebarTabs>
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/folder-icon-button.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-icon-button.tsx
@@ -1,10 +1,13 @@
-import { useCallback, useState } from 'react'
+import { lazy, Suspense, useCallback, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Folder, FolderOpen, ArrowRight } from '@/lib/icons'
 import { NoteIconDisplay } from '@/lib/render-note-icon'
-import { EmojiPicker } from '@/components/note/note-title/EmojiPicker'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
+
+const LazyEmojiPicker = lazy(async () => ({
+  default: (await import('@/components/note/note-title/EmojiPicker')).EmojiPicker
+}))
 
 interface FolderIconButtonProps {
   icon: string | null
@@ -134,13 +137,15 @@ export function FolderIconButton({
             className="fixed z-[100]"
             style={{ top: portalPosition.top, left: portalPosition.left }}
           >
-            <EmojiPicker
-              isOpen
-              onClose={handleClose}
-              onSelect={handleSelect}
-              onRemove={handleRemove}
-              hasEmoji={!!icon}
-            />
+            <Suspense fallback={null}>
+              <LazyEmojiPicker
+                isOpen
+                onClose={handleClose}
+                onSelect={handleSelect}
+                onRemove={handleRemove}
+                hasEmoji={!!icon}
+              />
+            </Suspense>
           </div>,
           document.body
         )}

--- a/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
@@ -15,18 +15,8 @@ import { useTabActions } from '@/contexts/tabs'
 import { useTasksOptional } from '@/contexts/tasks'
 import { cn } from '@/lib/utils'
 import { InboxPage } from '@/pages/inbox'
-import { CalendarPage } from '@/pages/calendar'
-import { JournalPage } from '@/pages/journal'
-import { TasksPage } from '@/pages/tasks'
-import { NotePage } from '@/pages/note'
-import { FilePage } from '@/pages/file'
-import { FolderViewPage } from '@/pages/folder-view'
-import { TemplateEditorPage } from '@/pages/template-editor'
-import { TemplatesPage } from '@/pages/templates'
-import { GraphPage } from '@/components/graph/graph-page'
 import { useT } from '@memry/i18n/renderer'
 import { stringifyUnknown } from '@/lib/stringify-unknown'
-import { AgentConversationTab } from '@/agent-chat/agent-conversation-tab'
 
 // =============================================================================
 // MEMOIZED PAGE COMPONENTS
@@ -34,16 +24,36 @@ import { AgentConversationTab } from '@/agent-chat/agent-conversation-tab'
 // =============================================================================
 
 const MemoizedInboxPage = React.memo(InboxPage)
-const MemoizedCalendarPage = React.memo(CalendarPage)
-const MemoizedJournalPage = React.memo(JournalPage)
-const MemoizedTasksPage = React.memo(TasksPage)
-const MemoizedNotePage = React.memo(NotePage)
-const MemoizedFilePage = React.memo(FilePage)
-const MemoizedFolderViewPage = React.memo(FolderViewPage)
-const MemoizedTemplateEditorPage = React.memo(TemplateEditorPage)
-const MemoizedTemplatesPage = React.memo(TemplatesPage)
-const MemoizedGraphPage = React.memo(GraphPage)
-const MemoizedAgentConversationTab = React.memo(AgentConversationTab)
+const LazyCalendarPage = React.lazy(async () => ({
+  default: (await import('@/pages/calendar')).CalendarPage
+}))
+const LazyJournalPage = React.lazy(async () => ({
+  default: (await import('@/pages/journal')).JournalPage
+}))
+const LazyTasksPage = React.lazy(async () => ({
+  default: (await import('@/pages/tasks')).TasksPage
+}))
+const LazyNotePage = React.lazy(async () => ({
+  default: (await import('@/pages/note')).NotePage
+}))
+const LazyFilePage = React.lazy(async () => ({
+  default: (await import('@/pages/file')).FilePage
+}))
+const LazyFolderViewPage = React.lazy(async () => ({
+  default: (await import('@/pages/folder-view')).FolderViewPage
+}))
+const LazyTemplateEditorPage = React.lazy(async () => ({
+  default: (await import('@/pages/template-editor')).TemplateEditorPage
+}))
+const LazyTemplatesPage = React.lazy(async () => ({
+  default: (await import('@/pages/templates')).TemplatesPage
+}))
+const LazyGraphPage = React.lazy(async () => ({
+  default: (await import('@/components/graph/graph-page')).GraphPage
+}))
+const LazyAgentConversationTab = React.lazy(async () => ({
+  default: (await import('@/agent-chat/agent-conversation-tab')).AgentConversationTab
+}))
 
 interface TabContentProps {
   /** Tab data */
@@ -99,7 +109,7 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
         return <MemoizedInboxPage />
 
       case 'calendar':
-        return <MemoizedCalendarPage />
+        return <LazyCalendarPage />
 
       case 'tasks':
       case 'all-tasks':
@@ -118,7 +128,7 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
           const selectionType = tab.type === 'project' ? 'project' : 'view'
 
           return (
-            <MemoizedTasksPage
+            <LazyTasksPage
               selectedId={selectionId}
               selectedType={selectionType}
               tasks={tasksContext.tasks}
@@ -142,16 +152,16 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
       }
 
       case 'note':
-        return <MemoizedNotePage noteId={tab.entityId} />
+        return <LazyNotePage noteId={tab.entityId} />
 
       case 'file':
-        return <MemoizedFilePage fileId={tab.entityId} />
+        return <LazyFilePage fileId={tab.entityId} />
 
       case 'folder':
-        return <MemoizedFolderViewPage folderPath={tab.entityId} />
+        return <LazyFolderViewPage folderPath={tab.entityId} />
 
       case 'journal':
-        return <MemoizedJournalPage />
+        return <LazyJournalPage />
 
       case 'search':
         return (
@@ -163,16 +173,16 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
         )
 
       case 'template-editor':
-        return <MemoizedTemplateEditorPage templateId={tab.entityId} />
+        return <LazyTemplateEditorPage templateId={tab.entityId} />
 
       case 'templates':
-        return <MemoizedTemplatesPage />
+        return <LazyTemplatesPage />
 
       case 'graph':
-        return <MemoizedGraphPage />
+        return <LazyGraphPage />
 
       case 'agent-chat':
-        return <MemoizedAgentConversationTab conversationId={tab.entityId} />
+        return <LazyAgentConversationTab conversationId={tab.entityId} />
 
       case 'collection':
         return (
@@ -201,7 +211,7 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
       className={cn('h-full overflow-y-auto overflow-x-hidden', className)}
       data-tab-content={tab.id}
     >
-      {content}
+      <React.Suspense fallback={null}>{content}</React.Suspense>
     </div>
   )
 }

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -39,6 +39,11 @@ Useful for: today's journal, your "now" note, the shared project.
 
 Single-clicking a note, view, search result, or sidebar item opens a permanent tab. If that item is already open, memrynote focuses the existing tab instead of creating another copy.
 
+Inactive workspace surfaces stay unloaded until first use. Inbox remains ready on cold open, while
+heavier surfaces such as Tasks, Calendar, Graph, and the right-side Agent/Day Panel mount when the
+user opens them. This keeps startup memory tied to the visible workspace instead of every possible
+feature surface.
+
 ## Mouse Navigation
 
 Mouse Back and Forward side buttons move through tab focus history across the whole window, including split panes. Back returns to the previously focused tab; Forward replays the next tab after a Back action. Opening or selecting another tab starts a new history path.


### PR DESCRIPTION
Fixes #441

## Summary
- Lazy-load non-inbox tab surfaces so cold open only mounts the visible workspace.
- Defer the right-side Agent/Day Panel content until the panel is opened.
- Mount the folder emoji picker only while the picker is open.
- Document the cold-start lazy-surface behavior.

## Benchmark

Baseline commit: `11cac8de07a55c2acd373597c1eec40b16604d50`
Implementation commit: `0e5f62162168c50f0bdb5d04eace82334fe64fb0`
PR head: `c11ee67a`
Branch: `memory-441-feature-lazy-loading`
Command: `MEMRY_ENV=development MEMRY_DEVICE=memory-441-bench pnpm --filter @memry/desktop exec electron-vite dev --mode=dev --remoteDebuggingPort 9331`
Scenario: cold open Inbox, then open note `joswvbtium3r` / `tokyo-trip` through the test-open-note event.

| Scenario | Process | origin/main MiB | Feature MiB | Delta MiB |
|---|---:|---:|---:|---:|
| Cold open | Main | 239.8 | 257.8 | +18.0 |
| Cold open | Renderer | 306.3 | 207.4 | -98.9 |
| Cold open | GPU | 47.7 | 30.8 | -16.9 |
| Cold open | Utility/helper | 12.0 | 18.3 | +6.3 |
| Cold open | Total | 605.8 | 514.2 | -91.6 |
| Note path | Main | 241.5 | 252.7 | +11.2 |
| Note path | Renderer | 284.4 | 208.2 | -76.2 |
| Note path | GPU | 45.9 | 38.5 | -7.4 |
| Note path | Utility/helper | 12.0 | 15.7 | +3.7 |
| Note path | Total | 583.9 | 515.0 | -68.9 |

Decision: keep. Material renderer and total footprint win on cold open and note path.

## Verification
- `pnpm --filter @memry/desktop typecheck:web`
- focused ESLint on touched renderer files
- `git diff --check`
- `pnpm docs:build`
- `pnpm docs:impact --base 11cac8de07a55c2acd373597c1eec40b16604d50 --strict`
