### PR TITLE
Lazy load i18n locale resources

### DIFF
--- a/apps/desktop/src/renderer/src/lib/error-messages.ts
+++ b/apps/desktop/src/renderer/src/lib/error-messages.ts
@@ -1,5 +1,5 @@
 import type { SyncErrorCategory } from '@memry/contracts/ipc-sync-ops'
-import { RESOURCES } from '@memry/i18n/locales'
+import { enErrors } from '@memry/i18n/locales/en-errors'
 import { getI18n } from 'react-i18next'
 
 export const ERROR_CODES = {
@@ -100,7 +100,7 @@ const SYNC_ERROR_KEYS: Record<SyncErrorCategory, string> = {
 }
 
 function getEnglishErrorResource(key: string): string | undefined {
-  let current: unknown = RESOURCES.en.errors
+  let current: unknown = enErrors
   for (const segment of key.split('.')) {
     if (!current || typeof current !== 'object' || !(segment in current)) return undefined
     current = (current as Record<string, unknown>)[segment]

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -68,6 +68,10 @@ Shows the installed version. If a newer version is available, a button lets you 
 - **Language** — UI locale dropdown
 - **Clock Format** — 12-hour or 24-hour
 
+The desktop app loads the active language bundle at startup and fetches another locale when the
+language setting changes. English fallback messages remain available for errors before the selected
+locale has finished loading.
+
 ### Tab Behavior
 
 - **Restore Session** — reopen the previous session's tabs on launch

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -8,7 +8,8 @@
     "./main": "./src/main/index.ts",
     "./renderer": "./src/renderer/index.ts",
     "./shared": "./src/shared/index.ts",
-    "./locales": "./src/locales/index.ts"
+    "./locales": "./src/locales/index.ts",
+    "./locales/en-errors": "./src/locales/en-errors.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/i18n/src/locales/en-errors.ts
+++ b/packages/i18n/src/locales/en-errors.ts
@@ -1,0 +1,3 @@
+import enErrors from './en/errors.json'
+
+export { enErrors }

--- a/packages/i18n/src/locales/load.ts
+++ b/packages/i18n/src/locales/load.ts
@@ -1,0 +1,49 @@
+import resourcesToBackend from 'i18next-resources-to-backend'
+import type { Locale } from '../shared/config'
+import {
+  FALLBACK_LOCALE,
+  I18N_NAMESPACES,
+  LocaleSchema,
+  type I18nNamespace
+} from '../shared/config'
+
+export type NamespaceResource = Record<string, unknown>
+export type LocaleResources = Record<I18nNamespace, NamespaceResource>
+
+function parseLocale(language: string): Locale | null {
+  const result = LocaleSchema.safeParse(language)
+  return result.success ? result.data : null
+}
+
+function parseNamespace(namespace: string): I18nNamespace | null {
+  return I18N_NAMESPACES.includes(namespace as I18nNamespace) ? (namespace as I18nNamespace) : null
+}
+
+export async function loadLocaleNamespace(
+  locale: Locale,
+  namespace: I18nNamespace
+): Promise<NamespaceResource> {
+  const module = await import(`./${locale}/${namespace}.json`)
+  return module.default as NamespaceResource
+}
+
+export async function loadLocaleResources(locale: Locale): Promise<LocaleResources> {
+  const namespaces = await Promise.all(
+    I18N_NAMESPACES.map(async (namespace) => {
+      const resource = await loadLocaleNamespace(locale, namespace)
+      return [namespace, resource] as const
+    })
+  )
+
+  return Object.fromEntries(namespaces) as LocaleResources
+}
+
+export function createLocaleBackend() {
+  return resourcesToBackend(async (language: string, namespace: string) => {
+    const locale = parseLocale(language) ?? FALLBACK_LOCALE
+    const parsedNamespace = parseNamespace(namespace)
+    if (!parsedNamespace) return null
+
+    return loadLocaleNamespace(locale, parsedNamespace)
+  })
+}

--- a/packages/i18n/src/main/index.test.ts
+++ b/packages/i18n/src/main/index.test.ts
@@ -17,6 +17,11 @@ describe('createMainI18n', () => {
     expect(i18n.t('tasks:page.tabs.today')).toBe('اليوم')
   })
 
+  it('does not load inactive locale resources on startup', async () => {
+    const i18n = await createMainI18n({ locale: 'en' })
+    expect(i18n.hasResourceBundle('tr', 'common')).toBe(false)
+  })
+
   it('returns the key for nonexistent translations', async () => {
     const i18n = await createMainI18n({ locale: 'tr' })
     expect(i18n.t('menu:nonexistent.key')).toBe('menu:nonexistent.key')
@@ -27,5 +32,6 @@ describe('createMainI18n', () => {
     expect(i18n.t('menu:file.label')).toBe('File')
     await i18n.changeLanguage('tr')
     expect(i18n.t('menu:file.label')).toBe('Dosya')
+    expect(i18n.hasResourceBundle('tr', 'menu')).toBe(true)
   })
 })

--- a/packages/i18n/src/main/index.ts
+++ b/packages/i18n/src/main/index.ts
@@ -4,9 +4,10 @@ import {
   type Locale,
   FALLBACK_LOCALE,
   I18N_NAMESPACES,
-  DEFAULT_NAMESPACE
+  DEFAULT_NAMESPACE,
+  SUPPORTED_LOCALES
 } from '../shared/config'
-import { RESOURCES } from '../locales'
+import { createLocaleBackend } from '../locales/load'
 
 interface CreateMainI18nOptions {
   locale: Locale
@@ -15,26 +16,26 @@ interface CreateMainI18nOptions {
 /**
  * Creates an i18next instance for the Electron main process.
  *
- * Synchronous resource loading: all namespaces for all SUPPORTED_LOCALES
- * are bundled into the main-process JS bundle via the static RESOURCES
- * import. No filesystem I/O, no async race with menu construction.
+ * Locale JSON is loaded through the i18next backend before this factory
+ * resolves, so menu construction still sees a fully initialized instance.
  */
-export async function createMainI18n(
-  options: CreateMainI18nOptions
-): Promise<I18nInstance> {
+export async function createMainI18n(options: CreateMainI18nOptions): Promise<I18nInstance> {
   const instance = i18next.createInstance()
-  await instance.use(IcuFormatter).init({
-    lng: options.locale,
-    fallbackLng: FALLBACK_LOCALE,
-    ns: I18N_NAMESPACES,
-    defaultNS: DEFAULT_NAMESPACE,
-    resources: RESOURCES,
-    interpolation: {
-      escapeValue: false // main process renders no HTML
-    },
-    appendNamespaceToMissingKey: true,
-    initImmediate: false // synchronous init
-  })
+  await instance
+    .use(IcuFormatter)
+    .use(createLocaleBackend())
+    .init({
+      lng: options.locale,
+      fallbackLng: FALLBACK_LOCALE,
+      supportedLngs: [...SUPPORTED_LOCALES],
+      ns: I18N_NAMESPACES,
+      defaultNS: DEFAULT_NAMESPACE,
+      interpolation: {
+        escapeValue: false // main process renders no HTML
+      },
+      appendNamespaceToMissingKey: true,
+      initImmediate: false // synchronous init
+    })
   return instance
 }
 

--- a/packages/i18n/src/main/load-resources.test.ts
+++ b/packages/i18n/src/main/load-resources.test.ts
@@ -2,15 +2,15 @@ import { describe, it, expect } from 'vitest'
 import { loadResources } from './load-resources'
 
 describe('loadResources', () => {
-  it('returns all namespaces for English', () => {
-    const result = loadResources('en')
+  it('returns all namespaces for English', async () => {
+    const result = await loadResources('en')
     expect(result.common).toBeDefined()
     expect(result.settings).toBeDefined()
     expect(result.menu).toBeDefined()
   })
 
-  it('returns the actual translated strings', () => {
-    const result = loadResources('tr')
+  it('returns the actual translated strings', async () => {
+    const result = await loadResources('tr')
     expect(result.menu.file.label).toBe('Dosya')
   })
 })

--- a/packages/i18n/src/main/load-resources.ts
+++ b/packages/i18n/src/main/load-resources.ts
@@ -1,11 +1,9 @@
 import type { Locale } from '../shared/config'
-import { RESOURCES } from '../locales'
+import { loadLocaleResources, type LocaleResources } from '../locales/load'
 
 /**
- * Returns the full set of namespaces for a locale, loaded eagerly via the
- * static RESOURCES map. Used by the main-process i18next instance, which
- * must initialize synchronously before the native menu is built.
+ * Returns the full set of namespaces for a locale.
  */
-export function loadResources(locale: Locale): (typeof RESOURCES)[Locale] {
-  return RESOURCES[locale]
+export function loadResources(locale: Locale): Promise<LocaleResources> {
+  return loadLocaleResources(locale)
 }

--- a/packages/i18n/src/renderer/index.test.ts
+++ b/packages/i18n/src/renderer/index.test.ts
@@ -17,6 +17,11 @@ describe('createRendererI18n', () => {
     expect(i18n.t('tasks:task.add')).toBe('Add Task')
   })
 
+  it('does not load inactive locale resources on startup', async () => {
+    const i18n = await createRendererI18n({ locale: 'en' })
+    expect(i18n.hasResourceBundle('tr', 'common')).toBe(false)
+  })
+
   it('translates Turkish tasks namespace strings', async () => {
     const i18n = await createRendererI18n({ locale: 'tr' })
     expect(i18n.t('tasks:task.add')).toBe('Görev Ekle')
@@ -47,5 +52,6 @@ describe('createRendererI18n', () => {
     const i18n = await createRendererI18n({ locale: 'en' })
     await i18n.changeLanguage('ar')
     expect(i18n.language).toBe('ar')
+    expect(i18n.t('tasks:page.tabs.today')).toBe('اليوم')
   })
 })

--- a/packages/i18n/src/renderer/index.ts
+++ b/packages/i18n/src/renderer/index.ts
@@ -5,9 +5,10 @@ import {
   type Locale,
   FALLBACK_LOCALE,
   I18N_NAMESPACES,
-  DEFAULT_NAMESPACE
+  DEFAULT_NAMESPACE,
+  SUPPORTED_LOCALES
 } from '../shared/config'
-import { RESOURCES } from '../locales'
+import { createLocaleBackend } from '../locales/load'
 
 interface CreateRendererI18nOptions {
   locale: Locale
@@ -16,9 +17,8 @@ interface CreateRendererI18nOptions {
 /**
  * Creates an i18next instance for the renderer process.
  *
- * Resources are bundled eagerly into the renderer JS bundle. For Phase A,
- * the string set is intentionally tiny; this can move to lazy namespace
- * loading when translation volume grows.
+ * Locale JSON is loaded through the i18next backend so startup only pulls
+ * the active locale plus fallback resources.
  */
 export async function createRendererI18n(
   options: CreateRendererI18nOptions
@@ -26,13 +26,14 @@ export async function createRendererI18n(
   const instance = i18next.createInstance()
   await instance
     .use(IcuFormatter)
+    .use(createLocaleBackend())
     .use(initReactI18next)
     .init({
       lng: options.locale,
       fallbackLng: FALLBACK_LOCALE,
+      supportedLngs: [...SUPPORTED_LOCALES],
       ns: I18N_NAMESPACES,
       defaultNS: DEFAULT_NAMESPACE,
-      resources: RESOURCES,
       interpolation: {
         escapeValue: false
       },


### PR DESCRIPTION
Fixes #442

## Summary
- Replace eager locale resource bundling with an i18next backend that dynamically imports locale namespaces.
- Keep English fallback error messages available without loading every locale.
- Preserve runtime language switching and document lazy language loading.

## Benchmark

Baseline commit: `11cac8de07a55c2acd373597c1eec40b16604d50`
Implementation commit: `6a75d1f295ac6f8df92e7c898de645f044c53d39`
PR head: `f1f04acd`
Branch: `memory-442-lazy-i18n-locales`
Command: `MEMRY_ENV=development MEMRY_DEVICE=memory-442-bench pnpm --filter @memry/desktop exec electron-vite dev --mode=dev --remoteDebuggingPort 9331`
Scenario: cold English open, then `window.api.locale.set('tr')`, wait for `document.documentElement.lang === 'tr'`, restore English.

| Scenario | Process | origin/main MiB | Feature MiB | Delta MiB |
|---|---:|---:|---:|---:|
| Cold open | Main | 282.5 | 219.8 | -62.7 |
| Cold open | Renderer | 368.9 | 269.6 | -99.3 |
| Cold open | GPU | 30.3 | 31.7 | +1.4 |
| Cold open | Utility/helper | 20.0 | 14.4 | -5.6 |
| Cold open | Total | 701.7 | 535.5 | -166.2 |
| Locale switch | Main | 245.6 | 211.5 | -34.1 |
| Locale switch | Renderer | 280.4 | 246.6 | -33.8 |
| Locale switch | GPU | 30.6 | 30.6 | 0.0 |
| Locale switch | Utility/helper | 20.1 | 12.5 | -7.6 |
| Locale switch | Total | 576.6 | 501.2 | -75.4 |

Decision: keep. Material cold and exercised-path memory win while preserving live locale switching.

## Verification
- `pnpm --filter @memry/i18n test`
- `pnpm --filter @memry/i18n typecheck`
- `pnpm --filter @memry/desktop typecheck:web`
- focused renderer/i18n Vitest and ESLint checks
- dev app language switch: English -> Turkish -> English
- `git diff --check`
- `pnpm docs:build`
- `pnpm docs:impact --base 11cac8de07a55c2acd373597c1eec40b16604d50 --strict`
