### PR TITLE
Lazy load inbox metadata scraper

### DIFF
--- a/apps/desktop/src/main/inbox/domain.test.ts
+++ b/apps/desktop/src/main/inbox/domain.test.ts
@@ -65,7 +65,7 @@ vi.mock('./jobs', () => ({
   teardownInboxJobScheduler: vi.fn()
 }))
 
-vi.mock('./metadata', () => ({
+vi.mock('./metadata-utils', () => ({
   titleFromUrl: (url: string) => `Title for ${url}`
 }))
 

--- a/apps/desktop/src/main/inbox/domain.ts
+++ b/apps/desktop/src/main/inbox/domain.ts
@@ -30,7 +30,7 @@ import {
   ALLOWED_DOCUMENT_TYPES
 } from './attachments'
 import { processInboxImageAttachment } from '../image-processing/bridge'
-import { titleFromUrl } from './metadata'
+import { titleFromUrl } from './metadata-utils'
 import { captureVoice } from './capture'
 import { findDuplicateByContent, findDuplicateByUrl } from './duplicates'
 import { getSuggestions, trackSuggestionFeedback } from './suggestions'

--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -22,7 +22,7 @@ import { eq } from 'drizzle-orm'
 import { InboxChannels, TasksChannels } from '@memry/contracts/ipc-channels'
 import { resolveAttachmentUrl, deleteInboxAttachments } from './attachments'
 import { extractYouTubeVideoId } from '@memry/shared/youtube'
-import { extractDomain } from './metadata'
+import { extractDomain } from './metadata-utils'
 import { publishProjectionEvent } from '../projections'
 import { syncTaskCreate } from '../tasks/runtime-effects'
 

--- a/apps/desktop/src/main/inbox/jobs.test.ts
+++ b/apps/desktop/src/main/inbox/jobs.test.ts
@@ -25,7 +25,10 @@ vi.mock('../database', () => ({
 
 vi.mock('./metadata', () => ({
   fetchUrlMetadata: mockFetchUrlMetadata,
-  downloadImage: mockDownloadImage,
+  downloadImage: mockDownloadImage
+}))
+
+vi.mock('./metadata-utils', () => ({
   isBotPageTitle: vi.fn(() => false),
   titleFromUrl: vi.fn((url: string) => url)
 }))
@@ -114,6 +117,7 @@ describe('inbox jobs', () => {
 
     resumeInboxJobs()
     await vi.runAllTimersAsync()
+    await vi.dynamicImportSettled()
 
     const item = testDb.db.select().from(inboxItems).where(eq(inboxItems.id, 'item-1')).get()
     const job = testDb.db.select().from(inboxJobs).where(eq(inboxJobs.id, 'job-1')).get()
@@ -227,6 +231,7 @@ describe('inbox jobs', () => {
     })
 
     await vi.runOnlyPendingTimersAsync()
+    await vi.dynamicImportSettled()
 
     const retryJob = testDb.db.select().from(inboxJobs).where(eq(inboxJobs.id, retryId)).get()
     expect(retryJob).toMatchObject({
@@ -256,6 +261,7 @@ describe('inbox jobs', () => {
     })
 
     await vi.runOnlyPendingTimersAsync()
+    await vi.dynamicImportSettled()
 
     const item = testDb.db.select().from(inboxItems).where(eq(inboxItems.id, 'terminal-item')).get()
     const failedJob = testDb.db.select().from(inboxJobs).where(eq(inboxJobs.id, failedId)).get()

--- a/apps/desktop/src/main/inbox/jobs.ts
+++ b/apps/desktop/src/main/inbox/jobs.ts
@@ -12,7 +12,7 @@ import { requireDatabase, type DataDb } from '../database'
 import { createLogger } from '../lib/logger'
 import { generateId } from '../lib/id'
 import { getItemAttachmentsDir } from './attachments'
-import { downloadImage, fetchUrlMetadata, isBotPageTitle, titleFromUrl } from './metadata'
+import { isBotPageTitle, titleFromUrl } from './metadata-utils'
 import { transcribeAudio } from './transcription'
 import { publishProjectionEvent } from '../projections'
 
@@ -219,6 +219,7 @@ async function processMetadataJob(db: DataDb, job: JobRow): Promise<void> {
   emitUpdated(job.itemId, { processingStatus: 'processing' })
 
   try {
+    const { downloadImage, fetchUrlMetadata } = await import('./metadata')
     const metadata = await fetchUrlMetadata(sourceUrl)
 
     let thumbnailPath: string | null = null

--- a/apps/desktop/src/main/inbox/metadata-utils.ts
+++ b/apps/desktop/src/main/inbox/metadata-utils.ts
@@ -1,0 +1,48 @@
+import { extractDomain as extractDomainNullable } from '../lib/url-utils'
+
+const BOT_PAGE_TITLES = [
+  'just a moment...',
+  'attention required!',
+  'access denied',
+  'please wait',
+  'verify you are human',
+  'checking your browser'
+]
+
+export function extractDomain(url: string): string {
+  return extractDomainNullable(url) ?? url
+}
+
+export function isBotPageTitle(title: string): boolean {
+  if (!title) return false
+  const lower = title.toLowerCase()
+  return BOT_PAGE_TITLES.some((bot) => lower.includes(bot))
+}
+
+export function titleFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    const segments = parsed.pathname.split('/').filter(Boolean)
+
+    if (segments.length === 0) {
+      return parsed.hostname.replace(/^www\./, '')
+    }
+
+    const last = segments[segments.length - 1]
+
+    const cleaned = last
+      .replace(/\.[a-z]+$/, '')
+      .replace(/--\d+$/, '')
+      .replace(/-\d+$/, '')
+      .replace(/[-_]+/g, ' ')
+      .trim()
+
+    if (!cleaned) {
+      return parsed.hostname.replace(/^www\./, '')
+    }
+
+    return cleaned.replace(/\b\w/g, (c) => c.toUpperCase())
+  } catch {
+    return url
+  }
+}

--- a/apps/desktop/src/main/inbox/metadata.ts
+++ b/apps/desktop/src/main/inbox/metadata.ts
@@ -21,6 +21,9 @@ import { createWriteStream } from 'fs'
 import { mkdir } from 'fs/promises'
 import { pipeline } from 'stream/promises'
 import { join, extname } from 'path'
+import { isBotPageTitle } from './metadata-utils'
+
+export { extractDomain, isBotPageTitle, titleFromUrl } from './metadata-utils'
 
 const log = createLogger('Inbox:Metadata')
 
@@ -306,54 +309,5 @@ export function isValidUrl(str: string): boolean {
     return url.protocol === 'http:' || url.protocol === 'https:'
   } catch {
     return false
-  }
-}
-
-import { extractDomain as extractDomainNullable } from '../lib/url-utils'
-
-export function extractDomain(url: string): string {
-  return extractDomainNullable(url) ?? url
-}
-
-const BOT_PAGE_TITLES = [
-  'just a moment...',
-  'attention required!',
-  'access denied',
-  'please wait',
-  'verify you are human',
-  'checking your browser'
-]
-
-export function isBotPageTitle(title: string): boolean {
-  if (!title) return false
-  const lower = title.toLowerCase()
-  return BOT_PAGE_TITLES.some((bot) => lower.includes(bot))
-}
-
-export function titleFromUrl(url: string): string {
-  try {
-    const parsed = new URL(url)
-    const segments = parsed.pathname.split('/').filter(Boolean)
-
-    if (segments.length === 0) {
-      return parsed.hostname.replace(/^www\./, '')
-    }
-
-    const last = segments[segments.length - 1]
-
-    const cleaned = last
-      .replace(/\.[a-z]+$/, '')
-      .replace(/--\d+$/, '')
-      .replace(/-\d+$/, '')
-      .replace(/[-_]+/g, ' ')
-      .trim()
-
-    if (!cleaned) {
-      return parsed.hostname.replace(/^www\./, '')
-    }
-
-    return cleaned.replace(/\b\w/g, (c) => c.toUpperCase())
-  } catch {
-    return url
   }
 }

--- a/apps/desktop/src/main/ipc/inbox-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/inbox-handlers.test.ts
@@ -69,7 +69,10 @@ vi.mock('../inbox/attachments', () => ({
 
 vi.mock('../inbox/metadata', () => ({
   fetchUrlMetadata: vi.fn(),
-  downloadImage: vi.fn(),
+  downloadImage: vi.fn()
+}))
+
+vi.mock('../inbox/metadata-utils', () => ({
   titleFromUrl: vi.fn((url: string) => url),
   isBotPageTitle: vi.fn(() => false),
   extractDomain: vi.fn((url: string) => {

--- a/apps/desktop/src/main/ipc/inbox-handlers.ts
+++ b/apps/desktop/src/main/ipc/inbox-handlers.ts
@@ -8,7 +8,7 @@ import {
 } from '@memry/contracts/inbox-api'
 import { InboxChannels } from '@memry/contracts/ipc-channels'
 import { createLogger } from '../lib/logger'
-import { extractDomain, fetchUrlMetadata, isBotPageTitle, titleFromUrl } from '../inbox/metadata'
+import { extractDomain, isBotPageTitle, titleFromUrl } from '../inbox/metadata-utils'
 import {
   createDesktopInboxBatchHandlers,
   createDesktopInboxCrudHandlers,
@@ -168,6 +168,7 @@ export function registerInboxHandlers(): void {
 
   ipcMain.handle(InboxChannels.invoke.PREVIEW_LINK, async (_, url: string) => {
     try {
+      const { fetchUrlMetadata } = await import('../inbox/metadata')
       const metadata = await fetchUrlMetadata(url)
       const domain = extractDomain(url)
       const title =

--- a/apps/docs/src/user-guide/inbox/capturing.md
+++ b/apps/docs/src/user-guide/inbox/capturing.md
@@ -44,6 +44,10 @@ When the browser extension (or quick-share integrations) are available, sharing 
 
 Web clips appear under the **clips** content type filter.
 
+Link metadata scraping runs when a capture or preview needs it. The desktop app keeps the heavier
+metadata scraper out of the cold inbox startup path so opening a vault does not load web-preview
+dependencies before they are used.
+
 ## Social Posts
 
 If you've connected social capture (e.g. saving tweets), those land in inbox under the **social** content type. The original URL is preserved so you can revisit the source.


### PR DESCRIPTION
Fixes #444

## Summary
- Split lightweight inbox metadata utilities from the heavy metadata scraper module.
- Keep domain, filing, jobs, and IPC paths on pure helpers until preview/scrape work needs the scraper.
- Dynamically load metadata scraping only for preview and metadata jobs.
- Document that web-preview dependencies stay off the cold inbox path.

## Benchmark

Baseline commit: `735f59efdd28ada39335601d0037276a2e259bfc`
Implementation commit: `4555d9dd17e251551c5e1530404f00d1b336a4c0`
PR head: `e22cedb8`
Branch: `memory-444-lazy-ipc-handlers`
Command: `MEMRY_ENV=development MEMRY_DEVICE=memory-444-bench pnpm --filter @memry/desktop exec electron-vite dev --mode=dev --remoteDebuggingPort 9331`
Scenario: cold open Inbox, then call `window.api.graph.getData()` and `window.api.inbox.previewLink('https://example.com/')`.

| Scenario | Process | origin/main MiB | Feature MiB | Delta MiB |
|---|---:|---:|---:|---:|
| Cold open | Main | 282.1 | 271.4 | -10.7 |
| Cold open | Renderer | 370.5 | 313.9 | -56.6 |
| Cold open | GPU | 31.7 | 38.0 | +6.3 |
| Cold open | Utility/helper | 20.9 | 20.1 | -0.8 |
| Cold open | Total | 705.3 | 643.4 | -61.9 |
| Graph + preview | Main | 244.0 | 235.7 | -8.3 |
| Graph + preview | Renderer | 333.6 | 332.1 | -1.5 |
| Graph + preview | GPU | 32.5 | 29.4 | -3.1 |
| Graph + preview | Utility/helper | 19.8 | 15.1 | -4.7 |
| Graph + preview | Total | 629.9 | 612.3 | -17.6 |

Decision: keep. Cold open and preview path both improve, with a clear main-process boot reduction.

## Verification
- `pnpm --filter @memry/desktop typecheck:node`
- focused main Vitest for metadata/jobs/domain/inbox handlers
- focused ESLint checks
- `git diff --check`
- `pnpm docs:build`
- `pnpm docs:impact --base 735f59efdd28ada39335601d0037276a2e259bfc --strict`
