### PR TITLE
Add memory snapshot harness

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -64,6 +64,8 @@
     "db:studio:data": "drizzle-kit studio --config config/drizzle-data.config.ts",
     "db:studio:index": "drizzle-kit studio --config config/drizzle-index.config.ts",
     "db:benchmark": "node --expose-gc --import tsx scripts/sqlite-memory-benchmark.ts",
+    "memory:snapshot": "node --import tsx scripts/memory-snapshot.ts",
+    "memory:compare": "node --import tsx scripts/memory-compare.ts",
     "build:unpack": "pnpm build && node scripts/build-packaged-app.js --dir",
     "build:win": "pnpm build && electron-builder --config config/electron-builder.yml --win",
     "build:mac": "pnpm build && node scripts/build-packaged-app.js --mac",

--- a/apps/desktop/scripts/memory-compare.ts
+++ b/apps/desktop/scripts/memory-compare.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { formatMemoryComparison } from '../src/main/debug/memory-compare'
+
+function printHelp(): void {
+  console.log('Usage: pnpm memory:compare <main.json> <branch.json>')
+}
+
+function resolveInputPath(inputPath: string): string {
+  if (path.isAbsolute(inputPath)) return inputPath
+  return path.resolve(process.env.INIT_CWD ?? process.cwd(), inputPath)
+}
+
+function readJson(inputPath: string): unknown {
+  return JSON.parse(readFileSync(resolveInputPath(inputPath), 'utf-8'))
+}
+
+const [, , baselinePath, candidatePath] = process.argv
+
+if (!baselinePath || !candidatePath || baselinePath === '--help') {
+  printHelp()
+  process.exit(baselinePath === '--help' ? 0 : 1)
+}
+
+console.log(
+  formatMemoryComparison(readJson(baselinePath) as never, readJson(candidatePath) as never)
+)

--- a/apps/desktop/scripts/memory-snapshot.ts
+++ b/apps/desktop/scripts/memory-snapshot.ts
@@ -1,0 +1,58 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createMemoryControlClient } from '../src/main/debug/memory-control-client'
+import {
+  captureMemorySamples,
+  getCurrentGitBranch,
+  parseMemorySnapshotArgs,
+  writeMemoryCaptureFile
+} from '../src/main/debug/memory-snapshot-cli'
+
+function printHelp(): void {
+  console.log(`Usage: pnpm memory:snapshot --scenario <boot|idle-60s> --vault <path> --label <name>
+
+Options:
+  --scenario <name>    Scenario to capture. Currently boot or idle-60s.
+  --vault <path>       Vault that must be active before capture.
+  --label <name>       Snapshot label, for example feat or main-baseline.
+  --port <port>        Memory control port, default MEMRY_DEBUG_MEMORY_PORT or 17345.
+  --output-dir <path>  Output directory, default tmp/memory at repo root.
+`)
+}
+
+async function main(): Promise<void> {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+  const repoRoot = path.resolve(scriptDir, '../../..')
+  const invocationCwd = process.env.INIT_CWD ?? repoRoot
+
+  let options
+  try {
+    options = parseMemorySnapshotArgs(process.argv.slice(2), {
+      outputDir: path.join(repoRoot, 'tmp', 'memory'),
+      cwd: invocationCwd
+    })
+  } catch (error) {
+    if (error instanceof Error && error.message === 'help') {
+      printHelp()
+      return
+    }
+    throw error
+  }
+
+  const capture = await captureMemorySamples({
+    client: createMemoryControlClient(options.port),
+    scenario: options.scenario,
+    vaultPath: options.vaultPath,
+    label: options.label,
+    branch: getCurrentGitBranch(repoRoot),
+    wait: (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+  })
+
+  const outputPath = await writeMemoryCaptureFile(capture, options.outputDir)
+  console.log(outputPath)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/apps/desktop/src/main/debug/memory-compare.test.ts
+++ b/apps/desktop/src/main/debug/memory-compare.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { buildMemoryComparisonRows, formatMemoryComparison } from './memory-compare'
+import type { MemoryCaptureFile } from './memory-snapshot-types'
+
+function capture(label: string, usedJSHeapSize: number, rss: number): MemoryCaptureFile {
+  return {
+    version: 1,
+    scenario: 'boot',
+    label,
+    branch: label,
+    vaultPath: '/vault',
+    hostname: 'test-host',
+    capturedAt: '2026-05-22T00:00:00.000Z',
+    samples: [
+      {
+        phase: 'T0',
+        snapshot: {
+          timestamp: '2026-05-22T00:00:00.000Z',
+          main: {
+            rss,
+            heapUsed: 50 * 1024 * 1024,
+            heapTotal: 80 * 1024 * 1024,
+            external: 1 * 1024 * 1024,
+            arrayBuffers: 1 * 1024 * 1024
+          },
+          renderer: {
+            jsHeapSizeLimit: 2000 * 1024 * 1024,
+            totalJSHeapSize: 200 * 1024 * 1024,
+            usedJSHeapSize
+          },
+          workers: [{ name: 'worker-a', rss: 30 * 1024 * 1024 }],
+          metadata: {
+            vaultPath: '/vault',
+            scenario: 'boot',
+            branch: label,
+            label,
+            hostname: 'test-host',
+            capturedAt: '2026-05-22T00:00:00.000Z'
+          }
+        }
+      }
+    ]
+  }
+}
+
+describe('buildMemoryComparisonRows', () => {
+  it('calculates absolute and percent deltas per process metric', () => {
+    const rows = buildMemoryComparisonRows(
+      capture('main', 100 * 1024 * 1024, 500 * 1024 * 1024),
+      capture('feat', 80 * 1024 * 1024, 450 * 1024 * 1024)
+    )
+
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        phase: 'T0',
+        process: 'renderer',
+        metric: 'usedJSHeapSize',
+        deltaBytes: -20 * 1024 * 1024,
+        deltaPercent: -20
+      })
+    )
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        process: 'main',
+        metric: 'rss',
+        deltaBytes: -50 * 1024 * 1024,
+        deltaPercent: -10
+      })
+    )
+  })
+})
+
+describe('formatMemoryComparison', () => {
+  it('prints a readable delta table', () => {
+    const output = formatMemoryComparison(
+      capture('main', 100 * 1024 * 1024, 500 * 1024 * 1024),
+      capture('feat', 80 * 1024 * 1024, 450 * 1024 * 1024)
+    )
+
+    expect(output).toContain('Memory comparison: main -> feat')
+    expect(output).toContain('renderer')
+    expect(output).toContain('usedJSHeapSize')
+    expect(output).toContain('-20.0 MiB')
+  })
+})

--- a/apps/desktop/src/main/debug/memory-compare.ts
+++ b/apps/desktop/src/main/debug/memory-compare.ts
@@ -1,0 +1,137 @@
+import type {
+  DebugMemorySnapshot,
+  MemoryCaptureFile,
+  MemorySample,
+  MemorySamplePhase
+} from './memory-snapshot-types'
+
+export interface MemoryComparisonRow {
+  phase: MemorySamplePhase
+  process: string
+  metric: string
+  baselineBytes: number
+  candidateBytes: number
+  deltaBytes: number
+  deltaPercent: number | null
+}
+
+type MemoryComparable = MemoryCaptureFile | DebugMemorySnapshot
+
+function isCaptureFile(value: MemoryComparable): value is MemoryCaptureFile {
+  return 'samples' in value
+}
+
+function samplesOf(value: MemoryComparable): MemorySample[] {
+  if (isCaptureFile(value)) return value.samples
+  return [{ phase: 'T0', snapshot: value }]
+}
+
+function labelOf(value: MemoryComparable): string {
+  if (isCaptureFile(value)) return value.label
+  return value.metadata.label
+}
+
+function collectMetrics(sample: MemorySample): Array<[string, string, number | null | undefined]> {
+  const { snapshot } = sample
+  const metrics: Array<[string, string, number | null | undefined]> = [
+    ['main', 'rss', snapshot.main.rss],
+    ['main', 'heapUsed', snapshot.main.heapUsed],
+    ['main', 'heapTotal', snapshot.main.heapTotal],
+    ['main', 'external', snapshot.main.external],
+    ['main', 'arrayBuffers', snapshot.main.arrayBuffers],
+    ['renderer', 'jsHeapSizeLimit', snapshot.renderer.jsHeapSizeLimit],
+    ['renderer', 'totalJSHeapSize', snapshot.renderer.totalJSHeapSize],
+    ['renderer', 'usedJSHeapSize', snapshot.renderer.usedJSHeapSize],
+    [
+      'renderer',
+      'measureUserAgentSpecificMemory.bytes',
+      snapshot.renderer.measureUserAgentSpecificMemory?.bytes
+    ]
+  ]
+
+  for (const worker of snapshot.workers) {
+    metrics.push([`worker:${worker.name}`, 'rss', worker.rss])
+  }
+
+  return metrics
+}
+
+export function buildMemoryComparisonRows(
+  baseline: MemoryComparable,
+  candidate: MemoryComparable
+): MemoryComparisonRow[] {
+  const candidateByPhase = new Map(samplesOf(candidate).map((sample) => [sample.phase, sample]))
+  const rows: MemoryComparisonRow[] = []
+
+  for (const baselineSample of samplesOf(baseline)) {
+    const candidateSample = candidateByPhase.get(baselineSample.phase)
+    if (!candidateSample) continue
+
+    const candidateMetrics = new Map(
+      collectMetrics(candidateSample).map(([processName, metric, value]) => [
+        `${processName}:${metric}`,
+        value
+      ])
+    )
+
+    for (const [processName, metric, baselineValue] of collectMetrics(baselineSample)) {
+      const candidateValue = candidateMetrics.get(`${processName}:${metric}`)
+      if (typeof baselineValue !== 'number' || typeof candidateValue !== 'number') continue
+
+      const deltaBytes = candidateValue - baselineValue
+      rows.push({
+        phase: baselineSample.phase,
+        process: processName,
+        metric,
+        baselineBytes: baselineValue,
+        candidateBytes: candidateValue,
+        deltaBytes,
+        deltaPercent: baselineValue === 0 ? null : (deltaBytes / baselineValue) * 100
+      })
+    }
+  }
+
+  return rows
+}
+
+function formatMiB(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`
+}
+
+function formatPercent(value: number | null): string {
+  return value === null ? 'n/a' : `${value >= 0 ? '+' : ''}${value.toFixed(1)}%`
+}
+
+function pad(value: string, width: number): string {
+  return value.padEnd(width, ' ')
+}
+
+export function formatMemoryComparison(
+  baseline: MemoryComparable,
+  candidate: MemoryComparable
+): string {
+  const rows = buildMemoryComparisonRows(baseline, candidate)
+  const header = ['phase', 'process', 'metric', 'baseline', 'candidate', 'delta', 'delta%']
+  const tableRows = rows.map((row) => [
+    row.phase,
+    row.process,
+    row.metric,
+    formatMiB(row.baselineBytes),
+    formatMiB(row.candidateBytes),
+    `${row.deltaBytes >= 0 ? '+' : ''}${formatMiB(row.deltaBytes)}`,
+    formatPercent(row.deltaPercent)
+  ])
+
+  const widths = header.map((heading, index) =>
+    Math.max(heading.length, ...tableRows.map((row) => row[index].length))
+  )
+
+  const lines = [
+    `Memory comparison: ${labelOf(baseline)} -> ${labelOf(candidate)}`,
+    header.map((cell, index) => pad(cell, widths[index])).join(' | '),
+    widths.map((width) => '-'.repeat(width)).join('-|-'),
+    ...tableRows.map((row) => row.map((cell, index) => pad(cell, widths[index])).join(' | '))
+  ]
+
+  return lines.join('\n')
+}

--- a/apps/desktop/src/main/debug/memory-control-client.ts
+++ b/apps/desktop/src/main/debug/memory-control-client.ts
@@ -1,0 +1,68 @@
+import { MEMORY_DEBUG_DEFAULT_PORT, MEMORY_DEBUG_HOST } from './memory-snapshot-types'
+import type { DebugMemorySnapshot, MemoryScenario } from './memory-snapshot-types'
+
+interface JsonObject {
+  [key: string]: unknown
+}
+
+export interface MemoryControlClient {
+  getVaultPath(): Promise<string | null>
+  openVault(vaultPath: string): Promise<string | null>
+  captureSnapshot(input: {
+    scenario: MemoryScenario
+    label: string
+    branch: string
+  }): Promise<DebugMemorySnapshot>
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  const text = await response.text()
+  const payload = text ? JSON.parse(text) : null
+
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === 'object' && 'error' in payload
+        ? String((payload as { error: unknown }).error)
+        : `Memory control request failed with HTTP ${response.status}`
+    throw new Error(message)
+  }
+
+  return payload as T
+}
+
+async function requestJson<T>(
+  port: number,
+  pathname: string,
+  init?: RequestInit & { body?: BodyInit | null }
+): Promise<T> {
+  const response = await fetch(`http://${MEMORY_DEBUG_HOST}:${port}${pathname}`, init)
+  return readJson<T>(response)
+}
+
+function postBody(body: JsonObject): RequestInit {
+  return {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  }
+}
+
+export function createMemoryControlClient(port = MEMORY_DEBUG_DEFAULT_PORT): MemoryControlClient {
+  return {
+    async getVaultPath() {
+      const status = await requestJson<{ vaultPath: string | null }>(port, '/vault/status')
+      return status.vaultPath
+    },
+    async openVault(vaultPath: string) {
+      const status = await requestJson<{ vaultPath: string | null }>(
+        port,
+        '/vault/open',
+        postBody({ vaultPath })
+      )
+      return status.vaultPath
+    },
+    captureSnapshot(input) {
+      return requestJson<DebugMemorySnapshot>(port, '/memory/snapshot', postBody(input))
+    }
+  }
+}

--- a/apps/desktop/src/main/debug/memory-control-server.ts
+++ b/apps/desktop/src/main/debug/memory-control-server.ts
@@ -1,0 +1,136 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import {
+  MEMORY_DEBUG_DEFAULT_PORT,
+  MEMORY_DEBUG_HOST,
+  type MemorySnapshotRequest,
+  type MemoryScenario
+} from './memory-snapshot-types'
+import { createLogger } from '../lib/logger'
+import { getStatus, switchVault } from '../vault'
+import { captureDebugMemorySnapshot, isMemoryDebugEnabled } from './memory-snapshot'
+
+const log = createLogger('MemoryControl')
+const validScenarios = new Set<MemoryScenario>(['boot', 'idle-60s'])
+
+let server: Server | null = null
+
+function getPort(): number {
+  const port = Number(process.env.MEMRY_DEBUG_MEMORY_PORT ?? MEMORY_DEBUG_DEFAULT_PORT)
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : MEMORY_DEBUG_DEFAULT_PORT
+}
+
+function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.writeHead(statusCode, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store'
+  })
+  response.end(`${JSON.stringify(payload)}\n`)
+}
+
+async function readBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+
+  if (chunks.length === 0) return {}
+  return JSON.parse(Buffer.concat(chunks).toString('utf-8'))
+}
+
+function parseSnapshotRequest(payload: unknown): MemorySnapshotRequest {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Snapshot request body must be an object')
+  }
+
+  const candidate = payload as Record<string, unknown>
+  if (!validScenarios.has(candidate.scenario as MemoryScenario)) {
+    throw new Error('scenario must be boot or idle-60s')
+  }
+  if (typeof candidate.label !== 'string' || candidate.label.length === 0) {
+    throw new Error('label is required')
+  }
+  if (typeof candidate.branch !== 'string' || candidate.branch.length === 0) {
+    throw new Error('branch is required')
+  }
+
+  return {
+    scenario: candidate.scenario as MemoryScenario,
+    label: candidate.label,
+    branch: candidate.branch
+  }
+}
+
+async function handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const url = new URL(request.url ?? '/', `http://${MEMORY_DEBUG_HOST}`)
+
+  if (request.method === 'GET' && url.pathname === '/vault/status') {
+    sendJson(response, 200, { vaultPath: getStatus().path ?? null })
+    return
+  }
+
+  if (request.method === 'POST' && url.pathname === '/vault/open') {
+    const payload = await readBody(request)
+    const vaultPath =
+      payload && typeof payload === 'object' ? (payload as { vaultPath?: unknown }).vaultPath : null
+
+    if (typeof vaultPath !== 'string' || vaultPath.length === 0) {
+      throw new Error('vaultPath is required')
+    }
+
+    const result = await switchVault(vaultPath)
+    if (!result.success) {
+      throw new Error(result.error ?? `Failed to open vault: ${vaultPath}`)
+    }
+
+    sendJson(response, 200, { vaultPath: getStatus().path ?? result.vault?.path ?? null })
+    return
+  }
+
+  if (request.method === 'POST' && url.pathname === '/memory/snapshot') {
+    const snapshotRequest = parseSnapshotRequest(await readBody(request))
+    const snapshot = await captureDebugMemorySnapshot(snapshotRequest)
+    sendJson(response, 200, snapshot)
+    return
+  }
+
+  sendJson(response, 404, { error: 'Not found' })
+}
+
+export function startMemoryControlServer(): void {
+  if (!isMemoryDebugEnabled() || server) return
+
+  server = createServer((request, response) => {
+    handleRequest(request, response).catch((error) => {
+      const message = error instanceof Error ? error.message : 'Memory control request failed'
+      sendJson(response, 400, { error: message })
+    })
+  })
+
+  server.on('error', (error) => {
+    log.error('memory control server failed', error)
+  })
+
+  server.listen(getPort(), MEMORY_DEBUG_HOST, () => {
+    const address = server?.address()
+    const port = typeof address === 'object' && address ? address.port : getPort()
+    log.info(`memory control server listening on ${MEMORY_DEBUG_HOST}:${port}`)
+  })
+}
+
+export async function stopMemoryControlServer(): Promise<void> {
+  if (!server) return
+
+  const activeServer = server
+  server = null
+
+  await new Promise<void>((resolve, reject) => {
+    activeServer.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}

--- a/apps/desktop/src/main/debug/memory-ipc-handlers.test.ts
+++ b/apps/desktop/src/main/debug/memory-ipc-handlers.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const ipcMainHandle = vi.hoisted(() => vi.fn())
+const ipcMainRemoveHandler = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: ipcMainHandle,
+    removeHandler: ipcMainRemoveHandler
+  }
+}))
+
+describe('registerDebugMemoryHandlers', () => {
+  afterEach(() => {
+    delete process.env.MEMRY_DEBUG_MEMORY
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('does not register the debug memory IPC handler by default', async () => {
+    const { registerDebugMemoryHandlers } = await import('./memory-ipc-handlers')
+
+    registerDebugMemoryHandlers()
+
+    expect(ipcMainHandle).not.toHaveBeenCalled()
+  })
+
+  it('registers the debug memory IPC handler when explicitly enabled', async () => {
+    process.env.MEMRY_DEBUG_MEMORY = '1'
+    const { registerDebugMemoryHandlers } = await import('./memory-ipc-handlers')
+
+    registerDebugMemoryHandlers()
+
+    expect(ipcMainHandle).toHaveBeenCalledWith('debug:memory-snapshot', expect.any(Function))
+  })
+})

--- a/apps/desktop/src/main/debug/memory-ipc-handlers.ts
+++ b/apps/desktop/src/main/debug/memory-ipc-handlers.ts
@@ -1,0 +1,34 @@
+import { ipcMain } from 'electron'
+import { z } from 'zod'
+import { DebugMemoryChannels } from '@memry/contracts/ipc-channels'
+import { createValidatedHandler } from '../ipc/validate'
+import { captureDebugMemorySnapshot, isMemoryDebugEnabled } from './memory-snapshot'
+
+type OptionalIpcMain = {
+  handle?: typeof ipcMain.handle
+  removeHandler?: typeof ipcMain.removeHandler
+}
+
+const DebugMemorySnapshotSchema = z.preprocess(
+  (input) => input ?? {},
+  z.object({
+    scenario: z.enum(['boot', 'idle-60s']).default('boot'),
+    label: z.string().min(1).default('ipc'),
+    branch: z.string().min(1).default('unknown')
+  })
+)
+
+export function registerDebugMemoryHandlers(): void {
+  if (!isMemoryDebugEnabled()) return
+
+  const memoryIpcMain = ipcMain as OptionalIpcMain | undefined
+  memoryIpcMain?.handle?.(
+    DebugMemoryChannels.invoke.MEMORY_SNAPSHOT,
+    createValidatedHandler(DebugMemorySnapshotSchema, captureDebugMemorySnapshot)
+  )
+}
+
+export function unregisterDebugMemoryHandlers(): void {
+  const memoryIpcMain = ipcMain as OptionalIpcMain | undefined
+  memoryIpcMain?.removeHandler?.(DebugMemoryChannels.invoke.MEMORY_SNAPSHOT)
+}

--- a/apps/desktop/src/main/debug/memory-snapshot-cli.test.ts
+++ b/apps/desktop/src/main/debug/memory-snapshot-cli.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  parseMemorySnapshotArgs,
+  captureMemorySamples,
+  normalizeVaultPath
+} from './memory-snapshot-cli'
+import type { DebugMemorySnapshot } from './memory-snapshot-types'
+
+function snapshot(label: string, vaultPath: string): DebugMemorySnapshot {
+  return {
+    timestamp: `2026-05-22T00:00:00.000Z-${label}`,
+    main: {
+      rss: 100,
+      heapUsed: 50,
+      heapTotal: 75,
+      external: 5,
+      arrayBuffers: 2
+    },
+    renderer: {
+      jsHeapSizeLimit: 1000,
+      totalJSHeapSize: 200,
+      usedJSHeapSize: 150
+    },
+    workers: [],
+    metadata: {
+      vaultPath,
+      scenario: 'boot',
+      branch: 'feat/test',
+      label,
+      hostname: 'test-host',
+      capturedAt: `2026-05-22T00:00:00.000Z-${label}`
+    }
+  }
+}
+
+describe('parseMemorySnapshotArgs', () => {
+  it('requires scenario, vault, and label', () => {
+    expect(() => parseMemorySnapshotArgs(['--scenario', 'boot', '--vault', '/vault'])).toThrow(
+      '--label is required'
+    )
+  })
+
+  it('accepts boot and idle-60s scenarios', () => {
+    expect(
+      parseMemorySnapshotArgs(['--scenario', 'idle-60s', '--vault', '/vault', '--label', 'feat'])
+    ).toMatchObject({
+      scenario: 'idle-60s',
+      vaultPath: '/vault',
+      label: 'feat'
+    })
+  })
+
+  it('resolves relative paths from the provided invocation cwd', () => {
+    expect(
+      parseMemorySnapshotArgs(
+        ['--scenario', 'boot', '--vault', 'vaults/MemryA', '--label', 'feat'],
+        { cwd: '/repo' }
+      )
+    ).toMatchObject({
+      vaultPath: '/repo/vaults/MemryA'
+    })
+  })
+})
+
+describe('normalizeVaultPath', () => {
+  it('expands home-relative vault paths', () => {
+    expect(normalizeVaultPath('~/sideproject/vaults/MemryA', '/Users/test')).toBe(
+      '/Users/test/sideproject/vaults/MemryA'
+    )
+  })
+})
+
+describe('captureMemorySamples', () => {
+  it('reopens the requested vault before capturing samples', async () => {
+    const client = {
+      getVaultPath: vi.fn().mockResolvedValueOnce('/vault'),
+      openVault: vi.fn().mockResolvedValue('/vault'),
+      captureSnapshot: vi
+        .fn()
+        .mockResolvedValueOnce(snapshot('t0', '/vault'))
+        .mockResolvedValueOnce(snapshot('t1', '/vault'))
+        .mockResolvedValueOnce(snapshot('t2', '/vault'))
+    }
+
+    const result = await captureMemorySamples({
+      client,
+      scenario: 'boot',
+      vaultPath: '/vault',
+      label: 'feat',
+      branch: 'feat/test',
+      wait: vi.fn().mockResolvedValue(undefined)
+    })
+
+    expect(client.openVault).toHaveBeenCalledWith('/vault')
+    expect(result.samples.map((sample) => sample.phase)).toEqual(['T0', 'T1', 'T2'])
+  })
+
+  it('fails when the active vault still differs after opening', async () => {
+    const client = {
+      getVaultPath: vi.fn().mockResolvedValue('/other'),
+      openVault: vi.fn().mockResolvedValue('/other'),
+      captureSnapshot: vi.fn()
+    }
+
+    await expect(
+      captureMemorySamples({
+        client,
+        scenario: 'boot',
+        vaultPath: '/vault',
+        label: 'feat',
+        branch: 'feat/test',
+        wait: vi.fn().mockResolvedValue(undefined)
+      })
+    ).rejects.toThrow('Active vault mismatch')
+  })
+})

--- a/apps/desktop/src/main/debug/memory-snapshot-cli.ts
+++ b/apps/desktop/src/main/debug/memory-snapshot-cli.ts
@@ -1,0 +1,180 @@
+import { execFileSync } from 'node:child_process'
+import { mkdir, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  MEMORY_DEBUG_DEFAULT_PORT,
+  type MemoryCaptureFile,
+  type MemoryScenario,
+  type MemorySnapshotRequest,
+  type MemorySample
+} from './memory-snapshot-types'
+import type { MemoryControlClient } from './memory-control-client'
+
+export interface MemorySnapshotOptions {
+  scenario: MemoryScenario
+  vaultPath: string
+  label: string
+  port: number
+  outputDir: string
+}
+
+interface CaptureOptions extends MemorySnapshotRequest {
+  client: MemoryControlClient
+  vaultPath: string
+  wait: (ms: number) => Promise<void>
+}
+
+const scenarios = new Set<MemoryScenario>(['boot', 'idle-60s'])
+const vaultOpenSettleMs = 5_000
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return value
+}
+
+export function normalizeVaultPath(
+  vaultPath: string,
+  homeDir = os.homedir(),
+  cwd = process.cwd()
+): string {
+  if (vaultPath === '~') return homeDir
+  if (vaultPath.startsWith('~/')) {
+    return path.resolve(homeDir, vaultPath.slice(2))
+  }
+  return path.resolve(cwd, vaultPath)
+}
+
+export function parseMemorySnapshotArgs(
+  argv: string[],
+  defaults: { outputDir?: string; port?: number; cwd?: string } = {}
+): MemorySnapshotOptions {
+  let scenario: MemoryScenario | null = null
+  let vaultPath: string | null = null
+  let label: string | null = null
+  let port =
+    defaults.port ?? Number(process.env.MEMRY_DEBUG_MEMORY_PORT ?? MEMORY_DEBUG_DEFAULT_PORT)
+  let outputDir = defaults.outputDir ?? path.join('tmp', 'memory')
+  const cwd = defaults.cwd ?? process.cwd()
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+
+    switch (arg) {
+      case '--scenario': {
+        const value = requireValue(argv, i, arg)
+        if (!scenarios.has(value as MemoryScenario)) {
+          throw new Error('--scenario must be boot or idle-60s')
+        }
+        scenario = value as MemoryScenario
+        i += 1
+        break
+      }
+      case '--vault':
+        vaultPath = normalizeVaultPath(requireValue(argv, i, arg), os.homedir(), cwd)
+        i += 1
+        break
+      case '--label':
+        label = requireValue(argv, i, arg)
+        i += 1
+        break
+      case '--port':
+        port = Number(requireValue(argv, i, arg))
+        if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+          throw new Error('--port must be a valid TCP port')
+        }
+        i += 1
+        break
+      case '--output-dir':
+        outputDir = path.resolve(cwd, requireValue(argv, i, arg))
+        i += 1
+        break
+      case '--help':
+        throw new Error('help')
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!scenario) throw new Error('--scenario is required')
+  if (!vaultPath) throw new Error('--vault is required')
+  if (!label) throw new Error('--label is required')
+
+  return { scenario, vaultPath, label, port, outputDir }
+}
+
+function samePath(a: string | null, b: string): boolean {
+  return a !== null && path.resolve(a) === path.resolve(b)
+}
+
+export async function captureMemorySamples(options: CaptureOptions): Promise<MemoryCaptureFile> {
+  await options.client.openVault(options.vaultPath)
+
+  const activeVaultPath = await options.client.getVaultPath()
+  if (!samePath(activeVaultPath, options.vaultPath)) {
+    throw new Error(
+      `Active vault mismatch: expected ${options.vaultPath}, got ${activeVaultPath ?? 'none'}`
+    )
+  }
+  await options.wait(vaultOpenSettleMs)
+
+  const samples: MemorySample[] = []
+  const capture = async (phase: MemorySample['phase']): Promise<void> => {
+    samples.push({
+      phase,
+      snapshot: await options.client.captureSnapshot({
+        scenario: options.scenario,
+        label: options.label,
+        branch: options.branch
+      })
+    })
+  }
+
+  await capture('T0')
+  if (options.scenario === 'idle-60s') {
+    await options.wait(60_000)
+  }
+  await capture('T1')
+  await options.wait(60_000)
+  await capture('T2')
+
+  const capturedAt = samples[0]?.snapshot.metadata.capturedAt ?? new Date().toISOString()
+  const hostname = samples[0]?.snapshot.metadata.hostname ?? os.hostname()
+
+  return {
+    version: 1,
+    scenario: options.scenario,
+    label: options.label,
+    branch: options.branch,
+    vaultPath: options.vaultPath,
+    hostname,
+    capturedAt,
+    samples
+  }
+}
+
+export function getCurrentGitBranch(cwd = process.cwd()): string {
+  try {
+    return execFileSync('git', ['branch', '--show-current'], {
+      cwd,
+      encoding: 'utf-8'
+    }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+export async function writeMemoryCaptureFile(
+  capture: MemoryCaptureFile,
+  outputDir: string
+): Promise<string> {
+  const stamp = capture.capturedAt.replace(/[:.]/g, '-')
+  const fileName = `${capture.label}-${capture.scenario}-${stamp}.json`
+  const outputPath = path.resolve(outputDir, fileName)
+  await mkdir(path.dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, `${JSON.stringify(capture, null, 2)}\n`, 'utf-8')
+  return outputPath
+}

--- a/apps/desktop/src/main/debug/memory-snapshot-types.ts
+++ b/apps/desktop/src/main/debug/memory-snapshot-types.ts
@@ -1,0 +1,78 @@
+export const MEMORY_DEBUG_HOST = '127.0.0.1'
+export const MEMORY_DEBUG_DEFAULT_PORT = 17345
+
+export type MemoryScenario = 'boot' | 'idle-60s'
+export type MemorySamplePhase = 'T0' | 'T1' | 'T2'
+
+export interface ProcessMemorySnapshot {
+  rss: number
+  heapUsed: number
+  heapTotal: number
+  external: number
+  arrayBuffers: number
+}
+
+export interface RendererSpecificMemoryBreakdown {
+  bytes: number
+  types?: string[]
+  attribution?: Array<{
+    url?: string
+    scope?: string
+  }>
+}
+
+export interface RendererSpecificMemorySnapshot {
+  bytes: number
+  breakdown?: RendererSpecificMemoryBreakdown[]
+}
+
+export interface RendererMemorySnapshot {
+  jsHeapSizeLimit: number | null
+  totalJSHeapSize: number | null
+  usedJSHeapSize: number | null
+  measureUserAgentSpecificMemory?: RendererSpecificMemorySnapshot
+}
+
+export interface WorkerMemorySnapshot {
+  name: string
+  rss: number
+}
+
+export interface DebugMemoryMetadata {
+  vaultPath: string | null
+  scenario: MemoryScenario
+  branch: string
+  label: string
+  hostname: string
+  capturedAt: string
+}
+
+export interface DebugMemorySnapshot {
+  timestamp: string
+  main: ProcessMemorySnapshot
+  renderer: RendererMemorySnapshot
+  workers: WorkerMemorySnapshot[]
+  metadata: DebugMemoryMetadata
+}
+
+export interface MemorySample {
+  phase: MemorySamplePhase
+  snapshot: DebugMemorySnapshot
+}
+
+export interface MemoryCaptureFile {
+  version: 1
+  scenario: MemoryScenario
+  label: string
+  branch: string
+  vaultPath: string
+  hostname: string
+  capturedAt: string
+  samples: MemorySample[]
+}
+
+export interface MemorySnapshotRequest {
+  scenario: MemoryScenario
+  label: string
+  branch: string
+}

--- a/apps/desktop/src/main/debug/memory-snapshot.ts
+++ b/apps/desktop/src/main/debug/memory-snapshot.ts
@@ -1,0 +1,159 @@
+import { execFile } from 'node:child_process'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { BrowserWindow } from 'electron'
+import { getStatus } from '../vault'
+import type {
+  DebugMemorySnapshot,
+  MemorySnapshotRequest,
+  ProcessMemorySnapshot,
+  RendererMemorySnapshot,
+  WorkerMemorySnapshot
+} from './memory-snapshot-types'
+
+const execFileAsync = promisify(execFile)
+
+const rendererMemoryScript = `
+(async () => {
+  const memory = performance.memory || {}
+  let specific
+
+  if (typeof performance.measureUserAgentSpecificMemory === 'function') {
+    try {
+      const measured = await performance.measureUserAgentSpecificMemory()
+      specific = {
+        bytes: Number(measured?.bytes ?? 0),
+        breakdown: Array.isArray(measured?.breakdown)
+          ? measured.breakdown.map((entry) => ({
+              bytes: Number(entry?.bytes ?? 0),
+              types: Array.isArray(entry?.types) ? entry.types.map(String) : undefined,
+              attribution: Array.isArray(entry?.attribution)
+                ? entry.attribution.map((item) => ({
+                    url: typeof item?.url === 'string' ? item.url : undefined,
+                    scope: typeof item?.scope === 'string' ? item.scope : undefined
+                  }))
+                : undefined
+            }))
+          : undefined
+      }
+    } catch {
+      specific = undefined
+    }
+  }
+
+  const numberOrNull = (value) => Number.isFinite(value) ? Number(value) : null
+
+  return {
+    jsHeapSizeLimit: numberOrNull(memory.jsHeapSizeLimit),
+    totalJSHeapSize: numberOrNull(memory.totalJSHeapSize),
+    usedJSHeapSize: numberOrNull(memory.usedJSHeapSize),
+    measureUserAgentSpecificMemory: specific
+  }
+})()
+`
+
+export function isMemoryDebugEnabled(): boolean {
+  return process.env.MEMRY_DEBUG_MEMORY === '1'
+}
+
+function collectMainMemory(): ProcessMemorySnapshot {
+  const usage = process.memoryUsage()
+  return {
+    rss: usage.rss,
+    heapUsed: usage.heapUsed,
+    heapTotal: usage.heapTotal,
+    external: usage.external,
+    arrayBuffers: usage.arrayBuffers
+  }
+}
+
+function findRendererWindow(): Electron.BrowserWindow {
+  const window = BrowserWindow.getAllWindows().find((candidate) => {
+    if (candidate.isDestroyed()) return false
+    return !candidate.webContents.isDestroyed()
+  })
+
+  if (!window) {
+    throw new Error('No active renderer window is available for memory snapshot')
+  }
+
+  return window
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+async function collectRendererMemory(): Promise<RendererMemorySnapshot> {
+  const window = findRendererWindow()
+  const result = (await window.webContents.executeJavaScript(
+    rendererMemoryScript,
+    true
+  )) as RendererMemorySnapshot
+
+  return {
+    jsHeapSizeLimit: numberOrNull(result.jsHeapSizeLimit),
+    totalJSHeapSize: numberOrNull(result.totalJSHeapSize),
+    usedJSHeapSize: numberOrNull(result.usedJSHeapSize),
+    measureUserAgentSpecificMemory: result.measureUserAgentSpecificMemory
+  }
+}
+
+function parsePsOutput(stdout: string): WorkerMemorySnapshot[] {
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/)
+      if (!match) return []
+
+      const [, ppid, pid, rssKiB, command] = match
+      if (Number(ppid) !== process.pid) return []
+
+      return [
+        {
+          name: `${path.basename(command)}:${pid}`,
+          rss: Number(rssKiB) * 1024
+        }
+      ]
+    })
+}
+
+async function collectWorkerMemory(): Promise<WorkerMemorySnapshot[]> {
+  if (process.platform === 'win32') return []
+
+  try {
+    const { stdout } = await execFileAsync('ps', ['-axo', 'ppid=,pid=,rss=,comm='])
+    return parsePsOutput(stdout)
+  } catch {
+    return []
+  }
+}
+
+export async function captureDebugMemorySnapshot(
+  request: MemorySnapshotRequest
+): Promise<DebugMemorySnapshot> {
+  if (!isMemoryDebugEnabled()) {
+    throw new Error('Memory snapshot debug harness requires MEMRY_DEBUG_MEMORY=1')
+  }
+
+  const capturedAt = new Date().toISOString()
+  const vaultPath = getStatus().path ?? null
+
+  return {
+    timestamp: capturedAt,
+    main: collectMainMemory(),
+    renderer: await collectRendererMemory(),
+    workers: await collectWorkerMemory(),
+    metadata: {
+      vaultPath,
+      scenario: request.scenario,
+      branch: request.branch,
+      label: request.label,
+      hostname: os.hostname(),
+      capturedAt
+    }
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -76,6 +76,7 @@ import {
   type BillingCadence,
   type BillingPlanId
 } from './billing/paddle-billing'
+import { startMemoryControlServer, stopMemoryControlServer } from './debug/memory-control-server'
 
 if (process.type === 'browser') {
   log.initialize()
@@ -910,6 +911,7 @@ void app.whenReady().then(async () => {
   }
 
   createWindow()
+  startMemoryControlServer()
   initializeUpdater()
 
   // Open the last vault and start schedulers concurrently with renderer load.
@@ -1208,6 +1210,12 @@ app.on('before-quit', (event) => {
   // Flush pending saves from all renderer windows before closing vault
   flushAllWindows()
     .then(() => createCloseSnapshots())
+    .then(() => {
+      shutdownLog.info('stopping memory control server...')
+      void stopMemoryControlServer().catch((error) => {
+        shutdownLog.warn('memory control server failed to stop:', error)
+      })
+    })
     .then(() => {
       shutdownLog.info('stopping snooze scheduler...')
       stopSnoozeScheduler()

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -29,6 +29,10 @@ import { registerCrdtIpcHandlers } from './crdt-handlers'
 import { registerTelemetryHandlers, unregisterTelemetryHandlers } from './telemetry-handlers'
 import { registerUpdaterHandlers, unregisterUpdaterHandlers } from './updater-handlers'
 import { registerAgentMcpHandlers, unregisterAgentMcpHandlers } from './agent-mcp-handlers'
+import {
+  registerDebugMemoryHandlers,
+  unregisterDebugMemoryHandlers
+} from '../debug/memory-ipc-handlers'
 import { registerLocaleHandlers, type RebuildMenuFn } from './locale-handler'
 import type { I18nInstance } from '@memry/i18n/main'
 import { createLogger } from '../lib/logger'
@@ -141,6 +145,9 @@ export function registerAllHandlers(deps?: IpcDeps): void {
   // Register Agent MCP settings/status handlers
   registerAgentMcpHandlers()
 
+  // Register env-gated debug memory benchmark handler
+  registerDebugMemoryHandlers()
+
   handlersRegistered = true
 }
 
@@ -176,6 +183,7 @@ export function unregisterAllHandlers(): void {
   unregisterUpdaterHandlers()
   unregisterTelemetryHandlers()
   unregisterAgentMcpHandlers()
+  unregisterDebugMemoryHandlers()
 
   handlersRegistered = false
   ipcLog.info('all handlers unregistered')

--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -154,6 +154,7 @@ function unifiedSidebar() {
         { text: 'Monorepo Layout', link: '/architecture/monorepo' },
         { text: 'Local Storage (Dual SQLite)', link: '/architecture/local-storage' },
         { text: 'IPC Boundary', link: '/architecture/ipc' },
+        { text: 'Memory Benchmarks', link: '/architecture/memory' },
         { text: 'CRDT & Notes Sync', link: '/architecture/crdt' },
         { text: 'Sync Protocol', link: '/architecture/sync-protocol' },
         { text: 'Cryptography', link: '/architecture/cryptography' },

--- a/apps/docs/src/architecture.md
+++ b/apps/docs/src/architecture.md
@@ -46,6 +46,13 @@ Shared Zod contracts in `packages/contracts`. Validated at typecheck time via `p
 
 → [IPC Boundary](/architecture/ipc)
 
+## Memory Benchmarks
+
+Development-mode memory captures use a loopback-only debug harness and the shared `MemryA` test
+vault.
+
+→ [Memory Benchmarks](/architecture/memory)
+
 ## Observability
 
 Local logging via electron-log; switchable telemetry that ships only enums and surface names.

--- a/apps/docs/src/architecture/memory.md
+++ b/apps/docs/src/architecture/memory.md
@@ -1,0 +1,59 @@
+# Memory Benchmarks
+
+Memry desktop memory benchmarks run against the development Electron app. They never use a
+production build.
+
+## Test Vault
+
+Use `~/sideproject/vaults/MemryA` for every capture in the memory-footprint PR series. The
+snapshot CLI opens that vault through the local debug control server and then confirms the active
+vault before any sample is captured. If the active vault still differs, the command aborts.
+
+## Debug Harness
+
+Start the desktop app with the memory harness enabled:
+
+```bash
+MEMRY_DEBUG_MEMORY=1 pnpm --filter @memry/desktop dev
+```
+
+The app binds a local control server to `127.0.0.1:17345`. Override the port with
+`MEMRY_DEBUG_MEMORY_PORT` when another local process already uses it. The server is available only
+when `MEMRY_DEBUG_MEMORY=1`.
+
+The harness records:
+
+- main-process `process.memoryUsage()` values
+- renderer heap values from the visible Electron window
+- `performance.measureUserAgentSpecificMemory()` when Chromium exposes it
+- direct child-process RSS values reported by `ps`
+- metadata for vault path, scenario, branch, label, hostname, and capture time
+
+## Capture Workflow
+
+In another shell from the same worktree:
+
+```bash
+MEMRY_DEBUG_MEMORY=1 pnpm memory:snapshot \
+  --scenario boot \
+  --vault ~/sideproject/vaults/MemryA \
+  --label feat
+```
+
+The command writes `tmp/memory/<label>-<scenario>-<timestamp>.json` at the repo root. Each file
+contains T0, T1, and T2 samples. The CLI reopens the requested vault for each run, waits 5 seconds
+for post-open renderer work to settle, then records T0. `boot` captures T1 immediately after T0,
+then T2 after 60 seconds idle. `idle-60s` waits 60 seconds before T1 and another 60 seconds before
+T2.
+
+## Compare Workflow
+
+Capture the same scenario on `main` and the feature branch on the same machine, within the same
+hour:
+
+```bash
+pnpm memory:compare tmp/memory/main-baseline-boot-*.json tmp/memory/feat-boot-*.json
+```
+
+The comparison prints per-phase, per-process, per-metric deltas in MiB and percent. Attach both JSON
+files and the comparison output to the draft PR.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "release:reddit": "node scripts/build-reddit-release-post.mjs",
     "docs:impact": "node scripts/docs-impact.mjs",
     "docs:ai-update": "node scripts/docs-ai-update.mjs",
+    "memory:snapshot": "pnpm --filter @memry/desktop memory:snapshot",
+    "memory:compare": "pnpm --filter @memry/desktop memory:compare",
     "build": "pnpm build:desktop",
     "build:desktop": "pnpm --filter @memry/desktop build",
     "build:landing": "pnpm --filter @memry/landing build",

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -27,6 +27,19 @@ export const AppChannels = {
 export type AppEventChannel = (typeof AppChannels.events)[keyof typeof AppChannels.events]
 
 // ============================================================================
+// Debug Channels
+// ============================================================================
+
+export const DebugMemoryChannels = {
+  invoke: {
+    MEMORY_SNAPSHOT: 'debug:memory-snapshot'
+  }
+} as const
+
+export type DebugMemoryInvokeChannel =
+  (typeof DebugMemoryChannels.invoke)[keyof typeof DebugMemoryChannels.invoke]
+
+// ============================================================================
 // Vault Channels
 // ============================================================================
 


### PR DESCRIPTION
Closes #446

## Summary
- Adds an env-gated desktop memory harness with a loopback control server and debug IPC snapshot channel.
- Adds `pnpm memory:snapshot` and `pnpm memory:compare` for T0/T1/T2 capture and delta tables.
- Documents the MemryA workflow, dev-only guard, and 5-second post-open settle before T0.

## Benchmark artifacts
- Secret gist: https://gist.github.com/h4yfans/d9f65857e00b178c794872099883decb
- Same-branch determinism: `feat-settle-a` vs `feat-settle-b` T0 renderer `usedJSHeapSize` delta = 1.56 MiB (< 5 MiB).

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @memry/desktop typecheck:node`
- `pnpm --filter @memry/desktop typecheck:web`
- `pnpm ipc:generate && pnpm ipc:check`
- `pnpm lint`
- `pnpm --filter @memry/desktop test`
- `pnpm docs:impact --base origin/main --strict`
- `git diff --check`
- `MEMRY_DEBUG_MEMORY=1 pnpm --filter @memry/desktop dev`
- `MEMRY_DEBUG_MEMORY=1 pnpm memory:snapshot --scenario boot --vault /Users/h4yfans/sideproject/vaults/MemryA --label feat-settle-a`
- `MEMRY_DEBUG_MEMORY=1 pnpm memory:snapshot --scenario boot --vault /Users/h4yfans/sideproject/vaults/MemryA --label feat-settle-b`
- `pnpm memory:compare tmp/memory/feat-settle-a-boot-2026-05-22T00-49-28-525Z.json tmp/memory/feat-settle-b-boot-2026-05-22T00-50-37-543Z.json`