### PR TITLE
docs: add 30-day twitter schedule for may-jun 2026

### DIFF
--- a/marketing/twitter-schedule-may-june-2026.md
+++ b/marketing/twitter-schedule-may-june-2026.md
@@ -1,0 +1,1712 @@
+# MemryNote Twitter Schedule — May 22 to June 20, 2026
+
+30-day daily-posting plan, 5 tweets per day, US-optimized time slots.
+
+## How to use
+
+- Each day = 5 tweets, one theme, five angles.
+- Each slot = ready-to-post text + a media note describing what to attach.
+- Copy text directly. Replace media notes with actual screenshots, GIFs, or short videos before posting.
+- Real screenshot paths listed where they exist in `apps/landing/public/screenshots/`. Everything else is a capture prompt.
+- Primary CTA across the month: https://memrynote.com
+- Author handle to namedrop in replies: @h4yfans
+
+## Time slots
+
+Five posts per day. Slot times pick up east-coast attention first, fold in west-coast as the day rolls.
+
+| Slot | East        | Pacific     | Notes                                   |
+| ---- | ----------- | ----------- | --------------------------------------- |
+| 1    | 9:00 AM ET  | 6:00 AM PT  | East commute, early-bird devs           |
+| 2    | 12:00 PM ET | 9:00 AM PT  | East lunch, West start-of-day           |
+| 3    | 3:00 PM ET  | 12:00 PM PT | East afternoon, West lunch              |
+| 4    | 5:00 PM ET  | 2:00 PM PT  | East end-of-workday, West mid-afternoon |
+| 5    | 8:00 PM ET  | 5:00 PM PT  | East evening scroll, West dinner        |
+
+Skip a slot if you don't have a media asset ready. Better to post 3 strong tweets than 5 with broken images.
+
+---
+
+# Week 1 — Core surfaces
+
+## Day 1 — Friday, May 22, 2026
+
+**Theme:** Inbox — universal capture
+
+### 9:00 AM ET / 6:00 AM PT
+
+The inbox is shaping up the way I always wanted.
+
+Links, screenshots, voice notes, PDFs, half-finished thoughts. Everything lands in one queue and waits for me.
+
+Then I triage. Note. Task. Calendar block. Archive. Done.
+
+📷 `apps/landing/public/screenshots/inbox_black.png`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Forwarded an email to my Memry inbox at breakfast. By lunch it was a task with a due date.
+
+That's the loop. Capture rough. Triage later. No app-switching gymnastics in between.
+
+📹 `<30s screencap: email forward → inbox card → convert to task with date>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Voice notes go straight into the inbox queue.
+
+Walking the dog, talking to myself, and the random product idea doesn't evaporate. It's there when I sit down.
+
+Still wiring transcription. The audio file alone has saved me a dozen times already.
+
+🎙️ `<screenshot: inbox showing a voice note card with waveform thumbnail>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Screenshot anything. Paste it into Memry's inbox. It sits there until you decide what it is.
+
+Stopped being precious about where things go. The inbox catches everything, organizing comes later.
+
+📷 `<screenshot: inbox with a freshly-pasted screenshot card>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Inbox zero on Memry isn't processing 200 emails.
+
+It's looking at 5 things you saved on purpose and asking: note, task, calendar, or archive?
+
+90-second nightly ritual, not a chore.
+
+📷 `<screenshot: empty inbox "all clear" state>`
+
+---
+
+## Day 2 — Saturday, May 23, 2026
+
+**Theme:** Notes — block editor + markdown freedom
+
+### 9:00 AM ET / 6:00 AM PT
+
+Memry's editor is BlockNote under the hood. Every paragraph is a block. Drag, indent, convert to code, embed an image, all without leaving the keyboard.
+
+Closest thing to Notion that still saves as plain markdown.
+
+📷 `apps/landing/public/screenshots/note_black.png`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Every note is a `.md` file on disk. Open it in VS Code. Edit it in vim. Push it to a git repo.
+
+Memry doesn't own your notes. It gives them a home.
+
+📷 `<screenshot: finder window showing .md files inside vault folder>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+`[[Backlinks]]` in Memry feel like the obvious answer.
+
+Mention another note. Memry tracks it. Open either side, the link goes both directions.
+
+This is how my brain actually works, except now I can search it.
+
+📷 `<screenshot: backlink panel under a note showing incoming references>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+`#tags` you can actually browse.
+
+Click any tag. Get every note that mentions it. Nest tags. Multi-filter. The whole thing is just metadata in the frontmatter.
+
+📷 `<screenshot: tag detail page showing list of tagged notes>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Keeping notes as files on disk has paid off so many times.
+
+When I want to grep my vault, `rg` just works. When I want to back it up, `rsync` just works. When I want to leave Memry someday, my notes come with me.
+
+📷 `<screenshot: terminal running ripgrep across the vault>`
+
+---
+
+## Day 3 — Sunday, May 24, 2026
+
+**Theme:** Daily journal — one file per day
+
+### 9:00 AM ET / 6:00 AM PT
+
+Sunday journal entry: `cmd+J`. Memry opens today's file. If it doesn't exist yet, it creates one from my template.
+
+Three keystrokes between the urge to write and the cursor blinking.
+
+📷 `apps/landing/public/screenshots/journal_black.png`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+One file per day. The whole journal is a folder of dated `.md` files.
+
+`2026-05-24.md`
+`2026-05-23.md`
+`2026-05-22.md`
+
+Boring on purpose. Means I can rsync the folder anywhere and the journal still works.
+
+📷 `<screenshot: file tree of journal folder showing dated files>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Daily template auto-fills frontmatter. Date, day-of-week, week-number, mood, intentions, end-of-day reflection.
+
+Most of it I skip. The fields I touch feel earned, not prescribed.
+
+📷 `<screenshot: journal entry with frontmatter expanded>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Yesterday/tomorrow arrow keys in the journal view.
+
+I scroll back through last week the way I used to flip a paper notebook. Just faster, and search works.
+
+📹 `<short video: arrow-key navigation through past week of journal entries>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Daily journals are how I clear my head, not how I document for posterity.
+
+Memry treats them that way. Cheap capture. Good search. No streak counter making me feel bad for missing a day.
+
+📷 `<screenshot: weekly review pane summarizing 7 journal days>`
+
+---
+
+## Day 4 — Monday, May 25, 2026 (Memorial Day)
+
+**Theme:** Tasks — quick add, recurrence, field-level merge
+
+### 9:00 AM ET / 6:00 AM PT
+
+Memorial Day morning. Coffee in hand. Quick add for tasks: `cmd+K`.
+
+Dropped 8 things into Memry in under 30 seconds. Errands. Calls. One side-project idea.
+
+Now they're out of my head.
+
+📷 `<screenshot: quick-add task palette open with text typed>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Due dates, priorities, projects, recurrence. Memry's task system is real, not a checkbox list pretending.
+
+Subtasks indent like an outline. Drag to reorder. Hit space to toggle done.
+
+📷 `apps/landing/public/screenshots/task_black.png`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Recurring tasks that don't litter the list. Memry shows only the next instance.
+
+Brush teeth tonight. Pay rent on the 1st. Standup tomorrow at 10. They appear when due, not as 365 phantom rows.
+
+📷 `<screenshot: today view with a single recurring task instance>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Field-level merge for tasks is the unsung hero.
+
+You edit the title on your laptop. I check it off on my desktop. Both edits land. Both stick. No "who won" modal.
+
+📷 `<diagram: two devices, one task, different fields edited, both arrive>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Holiday task move: filter to "no due date" and clean house.
+
+Memry slices tasks by project, tag, priority, due date, or any combo. Save the view. Re-open it next week.
+
+📷 `<screenshot: filtered task view "no due date + low priority">`
+
+---
+
+## Day 5 — Tuesday, May 26, 2026
+
+**Theme:** Calendar — time-blocking
+
+### 9:00 AM ET / 6:00 AM PT
+
+My morning open: Memry calendar in week view.
+
+Tasks I time-blocked yesterday show up as colored slots. Empty hours show up as empty hours. Both useful.
+
+📷 `apps/landing/public/screenshots/calendar_black.png`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Drag a task onto the calendar. It becomes a time block. Drag it to a new slot. It reschedules. Drag its edge. It resizes.
+
+Calendar interactions should feel physical. Memry's getting close.
+
+📹 `<short video: drag task → calendar block → resize block>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Quick create dialog: click an empty calendar slot, type, hit enter, done.
+
+I keep reaching for it instead of opening Google Calendar.
+
+📷 `<screenshot: quick-create dialog open on an empty time slot>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Day view in the calendar is the focus mode I didn't know I needed.
+
+Three columns: time grid, today's tasks, journal note. Whole day in one screen.
+
+📷 `<screenshot: day view with all three columns visible>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Time-blocking a Memry task pulls the priority, project, and description into the calendar block.
+
+Click the block. See the task. Check it off. The block stays.
+
+Now your calendar shows where time actually went, not where you wished it would go.
+
+📷 `<screenshot: calendar block popover showing task metadata>`
+
+---
+
+## Day 6 — Wednesday, May 27, 2026
+
+**Theme:** Projects — group work without losing context
+
+### 9:00 AM ET / 6:00 AM PT
+
+Projects in Memry are folders with opinions.
+
+A project has its own page. Its own task list. Its own attached notes. Its own status. Use as much or as little as you want.
+
+📷 `<screenshot: project page with rolled-up tasks + notes panel>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Every note can be filed under a project. Every task can belong to one. The project page rolls it all up.
+
+Means I can browse "what's happening with this thing" without 14 tabs open.
+
+📷 `<screenshot: project page showing notes section + tasks section>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Project status: planning / active / paused / done.
+
+Filter your project list by status. Stops the "active projects" tab from being 38 items long. Most of those are paused, you know it.
+
+📷 `<screenshot: project list filtered to active, showing 4 items>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Memry projects don't auto-create folders or impose a layout.
+
+It's just a label that ties notes and tasks together. Use it for big things. Skip it for small things.
+
+📷 `<screenshot: calendar week colored by project>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Side project workflow that's been working for me:
+
+1. Create project
+2. Brain-dump notes under it for a week
+3. Convert the good ideas to tasks
+4. Time-block them on the calendar
+5. Ship
+
+Memry holds every step.
+
+📷 `<screenshot: project page mid-flow with notes + tasks + recent activity>`
+
+---
+
+## Day 7 — Thursday, May 28, 2026
+
+**Theme:** AI Agent — bring your own model
+
+### 9:00 AM ET / 6:00 AM PT
+
+The agent panel sits next to your notes. You bring the model.
+
+Claude CLI. Codex CLI. Local Ollama. OpenAI-compatible endpoint. Switch between them per conversation. Memry doesn't lock you in.
+
+📷 `<screenshot: agent chat panel with provider dropdown open>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Memry's agent reaches your vault through a localhost MCP server.
+
+Whatever model you pointed at it can read your notes, search them, draft new ones. Writes require approval. Reads stay scoped.
+
+📷 `<diagram: agent ↔ localhost MCP server ↔ vault, with trust boundaries>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Asked my Memry agent: "what did I commit to last week that I haven't done?"
+
+It pulled tasks created last week, cross-checked against status, returned 4 items. Two were stale. Two needed today.
+
+📷 `<screenshot: agent conversation showing the prompt and the result list>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Codex CLI as your agent in Memry. Same vault access. Same approval UI for writes. Different model, different vibe.
+
+If you have an OpenAI key, this is a one-click setup.
+
+📷 `<screenshot: agent settings panel with Codex CLI selected>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Why MCP for the agent layer?
+
+Because the same server that powers Memry's in-app agent can serve Cursor, Claude Desktop, or any MCP client on your machine.
+
+Your vault, your tools.
+
+📷 `<screenshot: external MCP client reading a Memry note>`
+
+---
+
+# Week 2 — Sync, encryption, agent depth
+
+## Day 8 — Friday, May 29, 2026
+
+**Theme:** End-to-end encryption
+
+### 9:00 AM ET / 6:00 AM PT
+
+Memry's sync is end-to-end encrypted.
+
+XChaCha20-Poly1305 for content. Ed25519 for signatures. Argon2id for key derivation.
+
+The server stores ciphertext blobs and metadata. Nothing readable.
+
+📷 `<diagram: client encrypts → server stores blob → other client decrypts>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+What can the Memry server see about you?
+
+Your account email. The size of your encrypted blobs. The shape of your sync graph. Zero plaintext.
+
+Even if I wanted to read your notes, the keys never leave your device.
+
+📷 `<diagram: trust boundary showing what server sees vs. what's encrypted>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Argon2id is the password hashing function Memry uses to derive your vault key.
+
+Slow on purpose. Brute-force attacks get expensive. Costs me 700ms on login. Costs an attacker years per password guess.
+
+📷 `<screenshot: vault unlock screen with subtle spinner>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+AI companies train on your notes if you let them.
+
+Memry's encrypted blobs can't be trained on. The server has no plaintext to feed anyone. The agent runs on your machine with the model you chose.
+
+That's the whole point.
+
+📷 `<architecture diagram with the "no training data" annotation>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+E2E encryption matters most for the boring stuff.
+
+Daily journal entries. Half-formed product ideas. Therapy notes. Health info. The mundane content you'd never put on Notion if you thought about it.
+
+📷 `<screenshot: journal entry with the encrypted-state indicator visible>`
+
+---
+
+## Day 9 — Saturday, May 30, 2026
+
+**Theme:** CRDT sync
+
+### 9:00 AM ET / 6:00 AM PT
+
+Notes in Memry sync via Yjs. CRDTs all the way down.
+
+Two devices, two simultaneous edits, no conflict modal. The doc merges. That's the whole point of CRDTs.
+
+📹 `<short video: two devices editing the same note in real time>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Tasks and projects use field-level vector clocks instead of full-doc CRDTs.
+
+Title changes on device A. Status changes on device B. Both land. No "one of these wins" decision.
+
+📷 `<diagram: per-field clocks from two devices merging>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Memry sync doesn't show a conflict modal because conflicts get resolved automatically.
+
+If two edits truly hit the same field at the same nanosecond, the deterministic tie-breaker picks one. Rare. Logged. Reversible.
+
+📷 `<screenshot: sync status panel with recent merge entries>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Concurrent edit demo: open the same note on laptop and desktop. Type into both at once.
+
+Letters interleave. Cursor stays where I left it on each device. Vault stays consistent.
+
+📹 `<video: simultaneous typing on two devices, same note>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Vector clocks track which device made which edit and when.
+
+Boring engineering plumbing that means "my desktop and my laptop never fight again."
+
+📷 `<screenshot: sync log with per-device entries and timestamps>`
+
+---
+
+## Day 10 — Sunday, May 31, 2026
+
+**Theme:** Offline-first
+
+### 9:00 AM ET / 6:00 AM PT
+
+Memry on a plane. Tunnel. Coffee shop with bad wifi. Doesn't matter. Everything works.
+
+Your vault is on disk. Reads and writes are local. Sync waits for connectivity and catches up.
+
+📷 `<screenshot: app working with airplane mode toggle visible on menu bar>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Why SQLite for the local store?
+
+Single file. Fast. Battle-tested. Boring in the way you want infrastructure to be boring.
+
+Memry uses two: one for content, one for the search index.
+
+📷 `<screenshot: SQLite browser viewing Memry's data DB tables>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Sync catches up gracefully when you come back online.
+
+A queue holds the writes you made offline. They flush in order. The other devices receive them via CRDT updates. Nothing duplicates.
+
+📷 `<screenshot: sync queue panel showing offline writes flushing on reconnect>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+No loading spinner when I open a note in Memry. The note is already on my disk.
+
+Sounds obvious. Hasn't been the standard for 10 years of notes apps.
+
+📹 `<short video: opening 20 notes back to back, all instant>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Your Memry vault is a folder. You can back it up to Dropbox. Sync it with Syncthing. Copy it to a USB stick.
+
+Cloud sync is the cherry on top, not the foundation.
+
+📷 `<screenshot: Finder window showing the vault folder structure>`
+
+---
+
+## Day 11 — Monday, June 1, 2026
+
+**Theme:** Vault MCP server
+
+### 9:00 AM ET / 6:00 AM PT
+
+Memry runs a localhost MCP server that exposes your vault.
+
+Any MCP-compatible client on your machine can read your notes. Cursor. Claude Desktop. The Memry agent itself. All point at the same source of truth.
+
+📷 `<architecture diagram: clients → localhost MCP → vault>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Reads from the MCP server are scoped. Writes need approval.
+
+External clients (anything outside Memry) are read-only by default. To write, you start a Memry agent conversation and approve each change in the UI.
+
+📷 `<screenshot: approval UI for an agent-requested note edit>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Why approval UI for agent writes?
+
+I don't trust any model with silent write access to my vault. Yet. Memry shows you the diff before anything saves.
+
+📷 `<screenshot: diff view of an agent-proposed note edit, approve/reject buttons>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+With Vault MCP running, Cursor can read your Memry notes while you code.
+
+"What did I write down about this bug last month" becomes a one-liner. Without leaving the editor.
+
+📷 `<screenshot: Cursor IDE showing a Memry note returned via MCP query>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Localhost MCP means your vault is reachable by any local tool but not by the internet.
+
+No server roundtrip for agent reads. No tokens to manage. Just a process on 127.0.0.1.
+
+📷 `<architecture diagram showing the localhost-only scope>`
+
+---
+
+## Day 12 — Tuesday, June 2, 2026
+
+**Theme:** Multi-device
+
+### 9:00 AM ET / 6:00 AM PT
+
+Memry on two machines today. Desktop at home. MacBook at the coffee shop. Same vault. Same notes. Same tasks.
+
+Editing in both sessions for an hour. Everything merged when I checked tonight.
+
+📷 `<split-screen: two devices showing the same vault state>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Three+ devices on the same vault is supported. The CRDT design assumes it.
+
+Edit on whichever device is closest. Sync handles the fan-out. New device joins, it catches up from server state.
+
+📷 `<screenshot: settings showing 3 paired devices with last-seen timestamps>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Each Memry device gets its own profile. Settings, layout, open tabs stay local. Notes and tasks sync.
+
+Means my laptop's compact layout doesn't ruin my desktop's split-pane view.
+
+📷 `<screenshot: settings panel comparing two device profiles>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Lose a device? Revoke it from any other device.
+
+The revoked device can't decrypt new updates and can't push to the server. Old offline copies stay readable on the lost device, which you should treat as compromised either way.
+
+📷 `<screenshot: device revocation confirmation modal>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Mobile is on the roadmap.
+
+For now: desktop on Mac, Windows, Linux. Same vault across all three OSes. Same encrypted sync. Same Yjs document graph.
+
+📷 `<photo: Memry running on three OSes side by side>`
+
+---
+
+## Day 13 — Wednesday, June 3, 2026
+
+**Theme:** Bring your own model
+
+### 9:00 AM ET / 6:00 AM PT
+
+Pick your model. Memry doesn't care.
+
+Claude Sonnet, Claude Opus, GPT-5, local Ollama (Llama, Qwen, Mistral), any OpenAI-compatible endpoint. Set per conversation.
+
+📷 `<screenshot: provider dropdown listing all options>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Per-conversation provider settings stick.
+
+Started a planning chat with Opus. Started a code chat with Codex CLI. Started a quick lookup with a local 7B model.
+
+Reopen any of them, same model loaded.
+
+📷 `<screenshot: 3 conversation tabs each with a model badge>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Cost transparency in the agent panel.
+
+Each conversation shows token spend. Each provider shows its rate. You see why Opus costs and Haiku is fast.
+
+📷 `<screenshot: agent conversation footer with token counter + cost>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Reasoning toggles per conversation. Want deep thinking? Flip it on. Want a quick answer? Off.
+
+Sonnet 4.6 reasons. Opus reasons hard. GPT-5 has reasoning. Memry surfaces the option where it makes sense.
+
+📷 `<screenshot: reasoning toggle inside agent conversation settings>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Resuming a Memry agent conversation feels like opening a long Slack DM.
+
+Full history. Same model. Same context. Pick up exactly where you left off.
+
+📷 `<screenshot: two-week-old conversation reopening with full thread visible>`
+
+---
+
+## Day 14 — Thursday, June 4, 2026
+
+**Theme:** Inbox → everywhere
+
+### 9:00 AM ET / 6:00 AM PT
+
+Inbox → note conversion is one click.
+
+The card lifts out of the inbox queue, opens as a new note with the original content embedded. Edit. Save. Inbox shrinks by one.
+
+📹 `<short video: inbox card → new note transition>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Inbox → task conversion in one keystroke.
+
+Hover a card, hit `T`. Date picker opens. Pick a day, hit enter. Now it's a task.
+
+📹 `<video: card → task with date picker>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Inbox → calendar event conversion: drag the card onto a time slot.
+
+It becomes a calendar block with the inbox content as the description. Two-second flow, zero context switch.
+
+📹 `<video: drag inbox card onto calendar week view slot>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Archive vs delete in the Memry inbox.
+
+Delete removes the item entirely. Archive moves it to a searchable archive folder. Default is archive, because tomorrow-me sometimes regrets today-me's deletions.
+
+📷 `<screenshot: archive view of older inbox items>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+My nightly Memry ritual: 90 seconds of inbox triage.
+
+Glance at each card. Convert or archive. Close the laptop. Tomorrow's queue is clean.
+
+📷 `<screenshot: empty inbox "all clear" state, end of day>`
+
+---
+
+# Week 3 — Workflows + integrations
+
+## Day 15 — Friday, June 5, 2026
+
+**Theme:** Backlinks + graph
+
+### 9:00 AM ET / 6:00 AM PT
+
+`[[Wiki links]]` in Memry work the way they should.
+
+Type two brackets, autocomplete suggests notes. Pick one, link created. Visit the linked note, see the backlink.
+
+📹 `<video: typing a wiki link with autocomplete suggestions>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Backlink panel sits at the bottom of every note.
+
+Shows everywhere else that mentions this one. Click any backlink, jump there. Click back, you're home.
+
+📷 `<screenshot: backlink panel with 8 incoming references>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Graph view shows my vault as a network of notes connected by links.
+
+Mostly I don't use it. When I do, it's to see what's orphaned, what's central, what's drifting.
+
+📷 `<screenshot: graph view zoomed to ~50 nodes>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Orphan detection: which notes have zero backlinks and link to nothing?
+
+Sometimes intentional (a one-off). Sometimes a sign I forgot to connect a new idea to existing context.
+
+📷 `<screenshot: orphan-notes list in sidebar>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Backlinks turn a notes app into a personal wiki.
+
+Three weeks in, you stop searching by filename. You start traversing by relevance. That's when you've crossed over.
+
+📹 `<video: jumping across 4 notes via backlinks>`
+
+---
+
+## Day 16 — Saturday, June 6, 2026
+
+**Theme:** Quick capture, everywhere
+
+### 9:00 AM ET / 6:00 AM PT
+
+`cmd+N` from anywhere in Memry opens a blank capture note.
+
+Idea floats by, hit the hotkey, type, hit save. The note files itself in your daily journal folder unless you specify otherwise.
+
+📹 `<video: cmd+N capture flow from start to save>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Global capture hotkey: even with Memry not focused, a system hotkey pops a tiny capture window.
+
+Type the thing. Hit enter. It goes to your inbox. The window closes. You're back in whatever you were doing.
+
+📹 `<video: triggering global hotkey from another app>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Quick capture via the system tray icon.
+
+Sometimes I don't want to open Memry. I want to dump a thought. The tray menu has "New inbox item" as the first option.
+
+📷 `<screenshot: macOS menu bar with Memry tray menu expanded>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Voice memo capture: hold a hotkey, talk for 30 seconds, release. The audio lands in your inbox as a card.
+
+Transcription queues for when you're back at the desk.
+
+📹 `<video: voice memo capture from menu bar>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Capture-first is the philosophy. Organize-later is the consequence.
+
+If capturing takes more than 2 seconds, you don't capture. Memry shaves that to under 1.
+
+📷 `<screenshot: capture stats panel showing median capture time>`
+
+---
+
+## Day 17 — Sunday, June 7, 2026
+
+**Theme:** Templates + frontmatter
+
+### 9:00 AM ET / 6:00 AM PT
+
+Daily journal template runs every morning when I open today's entry.
+
+Frontmatter pre-filled. Three sections waiting: yesterday's wins, today's intent, end-of-day note. I fill what I want, skip what I don't.
+
+📷 `<screenshot: morning journal entry rendered from template>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Meeting note template in Memry.
+
+Date, attendees, agenda, decisions, action items. Action items auto-link to your task list when you save.
+
+That last part is the magic. No copy-paste between apps.
+
+📷 `<screenshot: meeting note with action items showing as linked tasks>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Project template: status block at top, milestone list, open questions, attached notes section.
+
+Drop one on every new project. Means the bare project page is never blank-page-syndrome territory.
+
+📷 `<screenshot: fresh project page populated from template>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Frontmatter fields are how Memry turns markdown into something queryable.
+
+`date`, `tags`, `status`, `priority`, `project`, `mood`. Memry reads them. So does any other markdown tool you point at the file.
+
+📷 `<screenshot: note with rich frontmatter block visible>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Custom templates: drop a `.md` file into the templates folder. Shows up in the "new from template" menu.
+
+That's the whole API. No template DSL. No special syntax. Just files.
+
+📷 `<screenshot: templates folder open in finder>`
+
+---
+
+## Day 18 — Monday, June 8, 2026
+
+**Theme:** Task ↔ calendar
+
+### 9:00 AM ET / 6:00 AM PT
+
+Drag a Memry task onto the calendar. Time block created.
+
+Task and block stay linked. Check off the task, the block shows complete. Drag the block to a new time, the task's scheduled time updates.
+
+📹 `<video: drag task from list onto calendar grid>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Time-blocking the day in Memry takes 5 minutes.
+
+Pull tasks from the list onto the calendar in priority order. Adjust durations. Drag breaks in. Now you have a plan, not a wishlist.
+
+📹 `<video: morning ritual of dragging today's tasks onto calendar>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Drag a calendar block to a new slot. The task underneath reschedules.
+
+Three-second flow that used to be "open task, change date, change time, save, close." Death of a thousand clicks. Gone.
+
+📹 `<video: dragging a calendar block to a later slot>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Recurring time blocks for the recurring work.
+
+Standup at 10:00 Mon–Fri. Deep work 2–4pm Tue/Thu. Office hours Friday afternoon. Set once, lives in the calendar forever.
+
+📷 `<screenshot: calendar week showing recurring blocks colored differently>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Tasks that didn't get done today auto-roll to tomorrow's view, if you want.
+
+Or stay in "overdue," if you want. Or get archived, if you really want. Three settings. Pick yours.
+
+📷 `<screenshot: settings panel showing rollover options>`
+
+---
+
+## Day 19 — Tuesday, June 9, 2026
+
+**Theme:** Search
+
+### 9:00 AM ET / 6:00 AM PT
+
+`cmd+K` opens Memry's command bar. Type anything.
+
+Notes match by title and content. Tasks match by title and project. Journal entries match by date or content. One bar, all surfaces.
+
+📷 `<screenshot: cmd+K palette with mixed-type results>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Tag filter in search: prefix `#`.
+
+`#client/acme` finds every note, task, and journal entry tagged with that. Faster than navigating folders. Doesn't care where things live.
+
+📷 `<screenshot: search bar with active #tag filter>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Memry indexes locally. Search hits SQLite on your machine, not a remote API.
+
+Results in under 50ms for vaults under 10K notes. Tested.
+
+📷 `<screenshot: dev tools showing sub-50ms query time>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Recent searches show in the `cmd+K` bar before you type.
+
+Half the time the thing I'm looking for is the thing I looked at yesterday. Memry knows.
+
+📷 `<screenshot: cmd+K showing recent searches list>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Fuzzy search forgives my typos.
+
+`pjct meta` finds `project metadata note`. `aget design` finds `agent design doc`. My memory is leaky. Search shouldn't punish me for it.
+
+📹 `<video: typing fuzzy queries that still resolve to the right note>`
+
+---
+
+## Day 20 — Wednesday, June 10, 2026
+
+**Theme:** Agent context awareness
+
+### 9:00 AM ET / 6:00 AM PT
+
+The Memry agent knows what's in your vault. Ask "what did I write about X" and it searches first, answers second.
+
+It doesn't hallucinate. It cites. Click the cite, jump to the note.
+
+📷 `<screenshot: agent answer with cited note references>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+"Summarize last week's journal entries" to the Memry agent.
+
+Pulls the 7 entries. Reads them. Returns a paragraph in my voice, since it's reading my words. Useful for a Sunday review.
+
+📷 `<screenshot: agent summarizing a week of journal entries>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+"Find notes related to this one" surfaces semantic neighbors.
+
+Not just keyword overlap. The agent reads the note, searches the vault for adjacent ideas, returns a list. Often surprises me.
+
+📷 `<screenshot: related-notes panel on the side of an open note>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+"Create a task for follow-up" from inside a meeting note conversation.
+
+Agent drafts the task with the right title, due date inferred from context, project assigned. Approval prompt. Save.
+
+📹 `<video: agent drafting and submitting a task from a meeting note>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+"Write the next section" for a long-form note I'm drafting.
+
+Agent reads what I've written. Suggests 2–3 paragraphs in my voice. I keep what I like, rewrite what I don't.
+
+Not magic. Pair-writing.
+
+📷 `<screenshot: agent drafting a continuation in the editor>`
+
+---
+
+## Day 21 — Thursday, June 11, 2026
+
+**Theme:** Tags
+
+### 9:00 AM ET / 6:00 AM PT
+
+`#tags` everywhere in Memry. Notes, tasks, journal entries, projects.
+
+Same tag means the same thing across surfaces. Click a tag, see every appearance, regardless of type.
+
+📷 `<screenshot: tag detail page mixing notes and tasks>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Autocomplete kicks in as you type a tag.
+
+Stops me from creating `#project` and `#projects` as two separate things. The tag namespace stays clean.
+
+📹 `<video: tag autocomplete dropdown while typing>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Tag pages aren't manually curated. They're a query.
+
+Every note/task/entry with this tag, sorted by date. Add a tag to a thing, it appears on the page. Remove the tag, it leaves.
+
+📷 `<screenshot: tag page with mixed-type content>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Multi-tag filter: `#client/acme + #priority/high`.
+
+The intersection. Useful when one tag returns too much.
+
+📷 `<screenshot: multi-tag filter showing 4 matching tasks>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Tag vs folder: pick one as your primary organizer.
+
+Tags scale better (one note can have 5 tags but only 1 folder). Folders feel calmer.
+
+Memry has both. Use one for spine, the other for cross-cuts.
+
+📷 `<screenshot: vault sidebar showing folders + active tags side-by-side>`
+
+---
+
+# Week 4 — Comparisons + power user
+
+## Day 22 — Friday, June 12, 2026
+
+**Theme:** Markdown freedom
+
+### 9:00 AM ET / 6:00 AM PT
+
+Every Memry note is a markdown file with frontmatter.
+
+Open it in Obsidian. Edit it in Typora. Render it on a static site. Memry doesn't own the format.
+
+📷 `<screenshot: same .md file open in Memry and in VS Code side by side>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Memry export: there's nothing to export. Your notes are already files on your disk.
+
+Copy the vault folder. You have your notes. The end.
+
+📷 `<screenshot: Finder copy-paste of vault to external drive>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Migrating into Memry from Obsidian is a folder copy.
+
+Drop your existing vault into Memry's vault path. Memry indexes it. Backlinks work. Tags work. Frontmatter respected.
+
+📷 `<screenshot: an Obsidian vault opening cleanly in Memry>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Edit a Memry note in vim while Memry is open.
+
+Save the file. Memry picks up the change in under a second and refreshes the editor. No lock-in. No proprietary format. Files all the way down.
+
+📹 `<video: vim edit on left, Memry auto-refresh on right>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+The "will I be able to leave this app in 5 years" question matters more than feature lists.
+
+Memry's answer: your notes are already in a format every editor on earth can read. Walking away is a folder copy.
+
+📷 `<screenshot: vault folder structure with .md files visible>`
+
+---
+
+## Day 23 — Saturday, June 13, 2026
+
+**Theme:** vs Obsidian
+
+### 9:00 AM ET / 6:00 AM PT
+
+Memry shares Obsidian's local-first, markdown-files DNA.
+
+Where they diverge: Memry ships with tasks, calendar, journal, inbox, and an AI agent built in. Obsidian gets you there through plugins, if you find the right ones.
+
+📷 `<side-by-side: Memry feature surface vs. Obsidian + plugin stack>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Obsidian's plugin ecosystem is a feature and a tax.
+
+Every install you stack adds maintenance, breakage risk, and a learning curve. Memry bundles the core six.
+
+Both approaches valid. Different bets.
+
+📷 `<screenshot: Memry feature-toggle screen, no plugins to manage>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Obsidian Sync is $4/month. Memry sync is free with end-to-end encryption baked in.
+
+Don't read this as "Memry is better." Read it as "there's a different model that works."
+
+📷 `<screenshot: Memry sync setup flow>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+If you like Obsidian, you might like Memry.
+
+If you wish Obsidian had tasks, calendar, and an agent without 8 plugins, you'll like Memry more.
+
+📷 `<screenshot: Memry's six surfaces visible in one app window>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Obsidian made local-first markdown mainstream. Memry builds on that foundation.
+
+The respect goes both ways. Memry imports Obsidian vaults cleanly. Your work survives the switch.
+
+📷 `<screenshot: imported Obsidian vault running in Memry with backlinks intact>`
+
+---
+
+## Day 24 — Sunday, June 14, 2026
+
+**Theme:** Toggle philosophy
+
+### 9:00 AM ET / 6:00 AM PT
+
+Every Memry feature is a toggle.
+
+Don't want a calendar? Turn it off. Sidebar shrinks. UI simplifies. The calendar surface disappears.
+
+📷 `<screenshot: settings panel with calendar feature toggled off>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Don't want AI? Turn it off too.
+
+Memry becomes a notes + tasks + journal + calendar + inbox app. No agent panel. No mention of LLMs anywhere.
+
+📷 `<screenshot: app with agent toggle off, showing cleaner UI>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Minimal mode: notes only.
+
+Toggle off tasks, calendar, journal, inbox, agent. You get a markdown editor with backlinks. Nothing else.
+
+Some weeks that's the right mode.
+
+📷 `<screenshot: minimal Memry, just the editor + sidebar>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Adopt features when you need them.
+
+Started Memry last month on notes only. Added the journal. Then tasks. Calendar came after time-blocking became a habit.
+
+Each toggle was a conscious choice.
+
+📷 `<screenshot: feature toggle adoption progression chart>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+No app should tell you "you have to use this."
+
+Memry's toggles aren't a marketing gimmick. They're the architectural commitment to your attention.
+
+📷 `<screenshot: empty "features" settings page showing all toggles>`
+
+---
+
+## Day 25 — Monday, June 15, 2026
+
+**Theme:** ADHD design
+
+### 9:00 AM ET / 6:00 AM PT
+
+Memry exists because I have ADHD and seven open apps is too many open apps.
+
+Inbox here. Calendar over there. Tasks in a third place. Notes in a fourth. By 10am my brain has already lost the thread.
+
+📷 `<photo: messy desktop showing the 7-app problem before Memry>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Capture-first is an ADHD design choice.
+
+If capturing is fast and friction-free, the idea doesn't evaporate. If capturing requires deciding "is this a note, task, or calendar event?" the idea is already gone.
+
+📷 `<screenshot: capture box with no type selector, just text input>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Memry's UI is intentionally calm.
+
+No badges. No streak counters. No "you have 47 unread." Notifications are opt-in per surface. Default is quiet.
+
+📷 `<screenshot: notification settings showing quiet defaults>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+No-FOMO design.
+
+You won't see "people who use Memry also do X." No weekly engagement nudges. The app is a tool, not a relationship.
+
+📷 `<screenshot: settings "engagement" section with all toggles off>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Memry isn't a productivity system. It's the place where your ADHD brain stops paying app-switching tax.
+
+That's enough. Everything else is gravy.
+
+📷 `<photo: clean desk, one app open, focused workspace>`
+
+---
+
+## Day 26 — Tuesday, June 16, 2026
+
+**Theme:** BlockNote editor
+
+### 9:00 AM ET / 6:00 AM PT
+
+Memry's editor is built on BlockNote.
+
+Every paragraph, image, list, code block is a block. Drag the handle to move. Hit `/` for the slash menu. Convert types inline.
+
+📹 `<video: block drag-handle reordering paragraphs>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Slash menu in the editor: hit `/`, type "code", tab, write code.
+
+Or "image" to paste an image. Or "embed" to drop a YouTube link. Same pattern, every block type.
+
+📹 `<video: slash menu navigation inserting a code block then an image>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Images paste from clipboard. Embedded inline. Saved to the vault's assets folder. Reference becomes a markdown image link.
+
+No upload-to-cloud step. The image lives with the note.
+
+📷 `<screenshot: pasted image with the vault assets path visible in the link>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Code blocks get syntax highlighting for 100+ languages.
+
+Useful for code-adjacent notes, snippets I want to remember, terminal commands I copy-paste a lot.
+
+📷 `<screenshot: code block with TypeScript syntax highlighting>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+BlockNote round-trips to markdown losslessly.
+
+Every block has a markdown representation. Open the `.md` in any other editor, structure intact. Open it back in Memry, same blocks, same arrangement.
+
+📷 `<split screen: same note rendered as blocks in Memry and as raw markdown in VS Code>`
+
+---
+
+## Day 27 — Wednesday, June 17, 2026
+
+**Theme:** Voice notes
+
+### 9:00 AM ET / 6:00 AM PT
+
+Voice notes go straight to the Memry inbox.
+
+Hit the menu bar mic, talk, release. The recording lands as a card. Auto-transcription queues up.
+
+📹 `<video: menu bar voice capture from idle to inbox card>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+On-device transcription via Whisper.
+
+Your audio doesn't leave your machine. The transcript appears under the voice card a few seconds later.
+
+📷 `<screenshot: voice card with transcript rendered beneath>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Voice → text → task in one chain.
+
+Capture a voice memo with "remind me to call back tomorrow." Transcribe. Convert to task. Date auto-detected from speech.
+
+📹 `<video: voice → transcript → task with date populated>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Walking + capture is my favorite Memry workflow.
+
+I think better moving. Voice memos let me think out loud and have the words waiting when I'm back at the desk.
+
+📷 `<photo: phone showing Memry capture during a walk outdoors>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Driving + capture: dictate to your phone, sync to your desktop, triage when you sit down.
+
+Memry doesn't ship its own driving mode. Your phone's voice memo + email forward + Memry inbox gets you there today.
+
+📷 `<screenshot: forwarded voice memo card in inbox>`
+
+---
+
+## Day 28 — Thursday, June 18, 2026
+
+**Theme:** Recurrence + reminders
+
+### 9:00 AM ET / 6:00 AM PT
+
+Daily standup as a recurring task. Set once, repeats forever (or until I cancel).
+
+Memry only shows the next instance, never a year's worth of phantom rows.
+
+📷 `<screenshot: recurring task creation panel>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Weekly review task on Sunday evenings.
+
+Recurring template. When I check it off, Memry archives that instance and queues next Sunday's.
+
+📷 `<screenshot: weekly review task with embedded checklist sub-items>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Monthly recurring bills, rent, subscriptions.
+
+Tag them `#finance`. Get a tag page that shows the month's money obligations at a glance. Tick off as paid.
+
+📷 `<screenshot: #finance tag page showing this month's recurring bills>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Snooze a task in Memry: pick a duration, the task hides until then.
+
+For things you're aware of but can't act on right now. Don't lose them. Don't have them shouting at you either.
+
+📷 `<screenshot: snooze duration dropdown on a task>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+System notifications for time-block reminders.
+
+5 minutes before a calendar block starts, OS notification fires. Click it, jump into the block. Skip it, the block still happens.
+
+📷 `<screenshot: macOS notification banner from Memry>`
+
+---
+
+# Week 5 — Behind the scenes + wrap
+
+## Day 29 — Friday, June 19, 2026 (Juneteenth)
+
+**Theme:** Behind the scenes
+
+### 9:00 AM ET / 6:00 AM PT
+
+Memry is one developer (hi, I'm Kaan) and a lot of late nights.
+
+No team. No funding round. No "go-to-market." A tool I needed to exist, and I have enough Electron + React in my bones to build it.
+
+📷 `<photo: my desk with Memry on screen, soft morning light>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Stack: Electron 39 for the shell. React 19 + Vite for the renderer. Cloudflare Workers + D1 + R2 for sync. BlockNote for the editor. SQLite via better-sqlite3 for local storage.
+
+Boring choices make boring product. Boring is good.
+
+📷 `<architecture diagram showing the stack at a glance>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Sync server is on Cloudflare Workers because it's the cheapest credible way to ship E2E encrypted sync to a few thousand users.
+
+D1 for sync metadata. R2 for encrypted blobs. No EC2. No Kubernetes. No infra team.
+
+📷 `<screenshot: Cloudflare dashboard for Memry, traffic chart visible>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Why I built Memry: I tried Obsidian + Todoist + Google Calendar + Reflect for a year and the seams between them ate my focus.
+
+The seams aren't features missing in those apps. The seams are that they're four apps. Memry collapses them.
+
+📷 `<collage: 4 app icons (Obsidian, Todoist, GCal, Reflect) crossed out, Memry icon next to them>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+ETA for a stable public Memry build: late July 2026.
+
+Right now: pre-release, daily-driven by me, rough edges visible. Join the waitlist at https://memrynote.com and I'll email when it's ready.
+
+📷 `<screenshot: clean waitlist signup form>`
+
+---
+
+## Day 30 — Saturday, June 20, 2026
+
+**Theme:** Wrap + waitlist
+
+### 9:00 AM ET / 6:00 AM PT
+
+30 days of Memry tweets. Almost there.
+
+If you followed along: inbox, notes, tasks, journal, calendar, projects, AI agent, encrypted sync. That's the product. One app, no cloud lock-in.
+
+📷 `<collage: greatest-hits screenshots from the month>`
+
+---
+
+### 12:00 PM ET / 9:00 AM PT
+
+Waitlist link if you want to try the stable build first: https://memrynote.com
+
+You'll get one email when it's ready. No drip campaign. No "are you still interested?" check-ins.
+
+📷 `<screenshot: clean waitlist landing page>`
+
+---
+
+### 3:00 PM ET / 12:00 PM PT
+
+Feedback: I'd love it.
+
+Reply to any of these. DM me @h4yfans. Comment on the next post. I read everything. The product gets shaped by what early users tell me works and what doesn't.
+
+📷 `<screenshot: Memry feedback widget or DM thread snippet>`
+
+---
+
+### 5:00 PM ET / 2:00 PM PT
+
+Memry source is MIT licensed. https://github.com/memrynote/memry
+
+Read the code. Fork it. File issues. Send PRs. The boring infrastructure decisions are visible. The encryption is auditable.
+
+📷 `<screenshot: github repo page>`
+
+---
+
+### 8:00 PM ET / 5:00 PM PT
+
+Thanks for following along on the first 30 days.
+
+Next 30: more shipping, more screenshots, the public build, and whatever feedback shapes the roadmap. Stay subscribed.
+
+📷 `<photo: roadmap whiteboard or a visible plan, end-of-day light>`
+
+---
+
+# Notes for the next round
+
+- Replace placeholder media notes with real screenshots/GIFs before posting.
+- Re-record videos any time UI changes — a 6-month-old screen recording looks dated fast.
+- Track which tweets drive waitlist signups; double down on those angles next month.
+- Skip a slot when you don't have a media asset ready; better to post 3 strong than 5 with broken images.
+- Don't auto-schedule the entire month. Re-read each day's tweets the morning of, edit for current context (a shipped feature, a reply trend, a relevant news beat).


### PR DESCRIPTION
## Summary

Adds `marketing/twitter-schedule-may-jun-2026.md`: a 30-day MemryNote Twitter posting plan (May 22 → June 20, 2026), 5 tweets per day, US-optimized time slots.

- **150 tweets total**, one theme per day across 30 days
- **5 US time slots/day** (9am, 12pm, 3pm, 5pm, 8pm ET with PT shown)
- **Themes rotate across every Memry surface:** inbox, notes, journal, tasks, calendar, projects, AI agent, encryption, CRDT sync, offline-first, vault MCP server, multi-device, BYO model, backlinks, quick capture, templates, search, tags, markdown freedom, vs-Obsidian, toggle philosophy, ADHD design, BlockNote, voice notes, recurrence, build story, wrap
- **Real screenshot paths** wired in where they exist (`apps/landing/public/screenshots/{inbox,note,journal,task,calendar}_black.png`)
- **Capture prompts** (`<...>`) for everything else, so it's clear what to record before posting
- Voice matches the existing `marketing/twitter-launch.md` draft: personal, anti-SaaS, ADHD-aware

## How to use

Copy each slot's text directly. Replace `<media notes>` with actual screenshots, GIFs, or short videos before posting. Skip a slot if a media asset isn't ready.

## Test plan

- [x] Prettier formatted the file via pre-commit lint-staged
- [x] No secrets / renderer-guards triggered
- [ ] Sanity-read the schedule end-to-end and confirm voice/themes feel right
- [ ] Verify each referenced screenshot path under `apps/landing/public/screenshots/` exists (they do as of this commit)
- [ ] Pick the first week's media assets and start posting May 22