### PR TITLE
Add compact editor tooltip toolbar

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -297,6 +297,90 @@
   height: 28px !important;
 }
 
+.content-area .bn-formatting-toolbar:has(.review-formatting-toolbar-compact) {
+  width: 168px !important;
+  min-width: 168px !important;
+  padding: 6px !important;
+  background: var(--popover) !important;
+  color: var(--popover-foreground) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 12px !important;
+  box-shadow: 0 16px 40px color-mix(in srgb, black 24%, transparent) !important;
+}
+
+.review-formatting-toolbar-compact {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.review-formatting-toolbar-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 28px);
+  justify-content: center;
+  gap: 4px;
+}
+
+.review-formatting-toolbar-compact .review-block-type-trigger.bn-button {
+  width: 100% !important;
+  min-width: 0 !important;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 0 8px !important;
+}
+
+.review-block-type-trigger-label {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-align: start;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.review-block-type-trigger-chevron {
+  margin-inline-start: auto;
+  opacity: 0.72;
+}
+
+.review-formatting-toolbar-compact .bn-button {
+  width: 28px !important;
+  min-width: 28px !important;
+  height: 28px !important;
+  justify-content: center;
+  padding: 0 !important;
+  border-radius: 7px !important;
+  color: inherit !important;
+}
+
+.review-formatting-toolbar-compact .bn-button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.review-formatting-toolbar-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 4px;
+  padding-top: 6px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+}
+
+.review-formatting-toolbar-actions .bn-button {
+  width: 100% !important;
+  min-width: 0 !important;
+  gap: 4px;
+  padding: 0 6px !important;
+  font-size: 11px !important;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.review-formatting-toolbar-menu {
+  min-width: 180px !important;
+}
+
 /* ===== COMPACT SLASH MENU (Suggestion Menu) ===== */
 /* BlockNote uses .bn-suggestion-menu class and [role="option"] for items */
 .bn-suggestion-menu {

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.test.tsx
@@ -235,6 +235,11 @@ vi.mock('./paste-link-menu', () => ({
     isOpen ? <div data-testid="paste-link-menu" /> : null
 }))
 
+vi.mock('./review-formatting-toolbar', () => ({
+  ReviewFormattingToolbar: () => <div data-testid="review-toolbar" />,
+  ReviewFormattingToolbarController: () => <div data-testid="review-toolbar-controller" />
+}))
+
 vi.mock('./ai-menu', () => ({
   CustomAIMenu: () => null
 }))

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -40,6 +40,10 @@ import { formatDateKey } from '@/lib/task-utils'
 import { editorSchema } from './editor-schema'
 import { analyzeTaskIntents } from './scan-task-intents'
 import { useSidebarDrillDown } from '@/contexts/sidebar-drill-down'
+import {
+  ReviewFormattingToolbar,
+  ReviewFormattingToolbarController
+} from './review-formatting-toolbar'
 
 import {
   useBlockNoteSetup,
@@ -107,7 +111,8 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   focusAtEndRef,
   yjsFragment,
   isRemoteUpdateRef,
-  marqueeZoneEl
+  marqueeZoneEl,
+  review
 }: ContentAreaEditorProps) {
   const { t } = useT('notes')
   const { t: tCommon } = useT('common')
@@ -767,10 +772,25 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
             knownTaskBlockIdsRef.current = intents.currentTaskIds
           }}
           theme={editorTheme}
-          formattingToolbar={!stickyToolbar}
+          formattingToolbar={!stickyToolbar && !review}
           slashMenu={false}
         >
-          {stickyToolbar && <FormattingToolbar />}
+          {stickyToolbar &&
+            (review ? (
+              <ReviewFormattingToolbar
+                variant="sticky"
+                onAddComment={review.onAddComment}
+                onStartSuggestionMode={review.onStartSuggestionMode}
+              />
+            ) : (
+              <FormattingToolbar />
+            ))}
+          {!stickyToolbar && review && (
+            <ReviewFormattingToolbarController
+              onAddComment={review.onAddComment}
+              onStartSuggestionMode={review.onStartSuggestionMode}
+            />
+          )}
           {aiEnabled && aiReady && <AIMenuController aiMenu={CustomAIMenu} />}
           <SuggestionMenuController
             triggerCharacter="/"

--- a/apps/desktop/src/renderer/src/components/note/content-area/index.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/index.ts
@@ -10,4 +10,11 @@ export { ContentArea } from './ContentArea'
 export { ContentDivider } from './ContentDivider'
 
 // Types
-export type { ContentAreaProps, HeadingInfo, HighlightInfo, SelectionInfo, Block } from './types'
+export type {
+  ContentAreaProps,
+  HeadingInfo,
+  HighlightInfo,
+  SelectionInfo,
+  ReviewSelection,
+  Block
+} from './types'

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
@@ -1,0 +1,272 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ReviewFormattingToolbar } from './review-formatting-toolbar'
+
+const toolbarMocks = vi.hoisted(() => {
+  const selectedBlock = {
+    id: 'block-1',
+    type: 'paragraph',
+    props: {},
+    content: []
+  }
+
+  const Icon = () => <span data-testid="block-type-icon" />
+
+  return {
+    selectedBlock,
+    blockTypeItems: [
+      { name: 'Normal text', type: 'paragraph', icon: Icon },
+      { name: 'Heading 1', type: 'heading', props: { level: 1 }, icon: Icon }
+    ],
+    editor: {
+      dictionary: {},
+      isEditable: true,
+      prosemirrorState: {
+        selection: { empty: false, from: 1, to: 5 },
+        doc: { textBetween: vi.fn(() => 'selected text') }
+      },
+      getSelection: vi.fn(() => ({ blocks: [selectedBlock] })),
+      getTextCursorPosition: vi.fn(() => ({ block: selectedBlock })),
+      focus: vi.fn(),
+      transact: vi.fn((callback: () => void) => callback()),
+      updateBlock: vi.fn()
+    }
+  }
+})
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string) => {
+      if (key === 'comments.toolbarComment') return 'Comment'
+      if (key === 'comments.toolbarSuggest') return 'Suggest edit'
+      return key
+    }
+  })
+}))
+
+vi.mock('@/lib/icons', () => ({
+  ChevronDown: () => <span data-testid="chevron-down-icon" />,
+  MessageCircle: ({ size }: { size?: number }) => (
+    <span data-testid="comment-icon" data-size={size} />
+  ),
+  PenLine: ({ size }: { size?: number }) => <span data-testid="suggest-icon" data-size={size} />
+}))
+
+vi.mock('@blocknote/react', () => ({
+  FormattingToolbar: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="formatting-toolbar">{children}</div>
+  ),
+  FormattingToolbarController: ({
+    formattingToolbar
+  }: {
+    formattingToolbar: (props: Record<string, unknown>) => React.ReactNode
+  }) => <>{formattingToolbar({ blockTypeSelectItems: toolbarMocks.blockTypeItems })}</>,
+  BasicTextStyleButton: ({ basicTextStyle }: { basicTextStyle: string }) => (
+    <button type="button" data-testid={`style-${basicTextStyle}`}>
+      {basicTextStyle}
+    </button>
+  ),
+  TextAlignButton: ({ textAlignment }: { textAlignment: string }) => (
+    <button type="button" data-testid={`align-${textAlignment}`}>
+      {textAlignment}
+    </button>
+  ),
+  ColorStyleButton: () => (
+    <button type="button" data-testid="colors">
+      colors
+    </button>
+  ),
+  NestBlockButton: () => (
+    <button type="button" data-testid="nest">
+      nest
+    </button>
+  ),
+  UnnestBlockButton: () => (
+    <button type="button" data-testid="unnest">
+      unnest
+    </button>
+  ),
+  CreateLinkButton: () => (
+    <button type="button" data-testid="create-link">
+      link
+    </button>
+  ),
+  blockTypeSelectItems: () => toolbarMocks.blockTypeItems,
+  getFormattingToolbarItems: () => [<button key="default">default toolbar</button>],
+  useBlockNoteEditor: () => toolbarMocks.editor,
+  useComponentsContext: () => ({
+    FormattingToolbar: {
+      Button: ({
+        label,
+        icon,
+        onClick,
+        onPointerDown,
+        onMouseDown,
+        isDisabled,
+        className,
+        children,
+        ...props
+      }: {
+        label: string
+        icon?: React.ReactNode
+        onClick?: () => void
+        onPointerDown?: React.PointerEventHandler<HTMLButtonElement>
+        onMouseDown?: React.MouseEventHandler<HTMLButtonElement>
+        isDisabled?: boolean
+        className?: string
+        children?: React.ReactNode
+      }) => (
+        <button
+          type="button"
+          className={className}
+          data-test={props['data-test' as keyof typeof props] as string}
+          disabled={isDisabled}
+          onClick={onClick}
+          onPointerDown={onPointerDown}
+          onMouseDown={onMouseDown}
+        >
+          {icon}
+          {children ?? label}
+        </button>
+      )
+    },
+    Generic: {
+      Menu: {
+        Root: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+        Trigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+        Button: ({
+          children,
+          className,
+          label
+        }: {
+          children?: React.ReactNode
+          className?: string
+          label: string
+        }) => (
+          <button type="button" className={className} aria-label={label}>
+            {children ?? label}
+          </button>
+        ),
+        Dropdown: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+          <div className={className}>{children}</div>
+        ),
+        Item: ({
+          children,
+          icon,
+          onClick
+        }: {
+          children: React.ReactNode
+          icon?: React.ReactNode
+          onClick?: () => void
+        }) => (
+          <button type="button" onClick={onClick}>
+            {icon}
+            {children}
+          </button>
+        )
+      }
+    }
+  }),
+  useEditorState: ({ selector }: { selector: (payload: { editor: unknown }) => unknown }) =>
+    selector({ editor: toolbarMocks.editor })
+}))
+
+describe('ReviewFormattingToolbar', () => {
+  beforeEach(() => {
+    toolbarMocks.editor.prosemirrorState.selection.empty = false
+    toolbarMocks.editor.updateBlock.mockClear()
+    toolbarMocks.editor.focus.mockClear()
+    toolbarMocks.editor.transact.mockClear()
+  })
+
+  it('renders the compact floating grid with visible review actions', () => {
+    render(
+      <ReviewFormattingToolbar
+        blockTypeSelectItems={toolbarMocks.blockTypeItems as any}
+        onAddComment={vi.fn()}
+        onStartSuggestionMode={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('style-bold')).toBeInTheDocument()
+    expect(screen.getByTestId('style-italic')).toBeInTheDocument()
+    expect(screen.getByTestId('style-underline')).toBeInTheDocument()
+    expect(screen.getByTestId('style-strike')).toBeInTheDocument()
+    expect(screen.getByTestId('align-left')).toBeInTheDocument()
+    expect(screen.getByTestId('align-center')).toBeInTheDocument()
+    expect(screen.getByTestId('align-right')).toBeInTheDocument()
+    expect(screen.getByTestId('colors')).toBeInTheDocument()
+    expect(screen.getByTestId('nest')).toBeInTheDocument()
+    expect(screen.getByTestId('unnest')).toBeInTheDocument()
+    expect(screen.getByTestId('create-link')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Normal text' })[0]).toHaveClass(
+      'review-block-type-trigger'
+    )
+    expect(screen.getByTestId('chevron-down-icon')).toBeInTheDocument()
+    expect(screen.getByText('Comment')).toBeInTheDocument()
+    expect(screen.getByTestId('comment-icon')).toHaveAttribute('data-size', '16')
+    expect(screen.getByText('Suggest edit')).toBeInTheDocument()
+    expect(screen.getByTestId('suggest-icon')).toHaveAttribute('data-size', '16')
+  })
+
+  it('disables Comment when the editor selection is empty', () => {
+    toolbarMocks.editor.prosemirrorState.selection.empty = true
+
+    render(
+      <ReviewFormattingToolbar
+        blockTypeSelectItems={toolbarMocks.blockTypeItems as any}
+        onAddComment={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Comment')).toBeDisabled()
+  })
+
+  it('starts suggestion mode from the visible action row', () => {
+    const onStartSuggestionMode = vi.fn()
+
+    render(
+      <ReviewFormattingToolbar
+        blockTypeSelectItems={toolbarMocks.blockTypeItems as any}
+        onStartSuggestionMode={onStartSuggestionMode}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Suggest edit'))
+
+    expect(onStartSuggestionMode).toHaveBeenCalledTimes(1)
+  })
+
+  it('captures the selected range before the toolbar click can collapse it', () => {
+    const onAddComment = vi.fn()
+
+    render(
+      <ReviewFormattingToolbar
+        blockTypeSelectItems={toolbarMocks.blockTypeItems as any}
+        onAddComment={onAddComment}
+      />
+    )
+
+    fireEvent.pointerDown(screen.getByText('Comment'))
+
+    expect(onAddComment).toHaveBeenCalledWith({
+      text: 'selected text',
+      isEmpty: false,
+      from: 1,
+      to: 5
+    })
+  })
+
+  it('applies block type conversion from the block type menu', () => {
+    render(<ReviewFormattingToolbar blockTypeSelectItems={toolbarMocks.blockTypeItems as any} />)
+
+    fireEvent.click(screen.getByText('Heading 1'))
+
+    expect(toolbarMocks.editor.focus).toHaveBeenCalledTimes(1)
+    expect(toolbarMocks.editor.transact).toHaveBeenCalledTimes(1)
+    expect(toolbarMocks.editor.updateBlock).toHaveBeenCalledWith(toolbarMocks.selectedBlock, {
+      type: 'heading',
+      props: { level: 1 }
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
@@ -1,0 +1,251 @@
+import type { BlockNoteEditor } from '@blocknote/core'
+import { useRef, type MouseEvent, type PointerEvent } from 'react'
+import {
+  BasicTextStyleButton,
+  blockTypeSelectItems as defaultBlockTypeSelectItems,
+  ColorStyleButton,
+  CreateLinkButton,
+  FormattingToolbar,
+  FormattingToolbarController,
+  getFormattingToolbarItems,
+  NestBlockButton,
+  TextAlignButton,
+  UnnestBlockButton,
+  useBlockNoteEditor,
+  useComponentsContext,
+  useEditorState,
+  type BlockTypeSelectItem,
+  type FormattingToolbarProps
+} from '@blocknote/react'
+import { ChevronDown, MessageCircle, PenLine } from '@/lib/icons'
+import type { ReviewSelection } from './types'
+import { useT } from '@memry/i18n/renderer'
+
+type ReviewFormattingToolbarVariant = 'floating' | 'sticky'
+
+interface ReviewFormattingToolbarProps {
+  variant?: ReviewFormattingToolbarVariant
+  onAddComment?: (selection: ReviewSelection) => void
+  onStartSuggestionMode?: () => void
+}
+
+export function ReviewFormattingToolbarController(props: ReviewFormattingToolbarProps) {
+  return (
+    <FormattingToolbarController
+      formattingToolbar={(toolbarProps) => (
+        <ReviewFormattingToolbar {...toolbarProps} {...props} variant="floating" />
+      )}
+    />
+  )
+}
+
+export function ReviewFormattingToolbar({
+  variant = 'floating',
+  onAddComment,
+  onStartSuggestionMode,
+  ...toolbarProps
+}: FormattingToolbarProps & ReviewFormattingToolbarProps) {
+  if (variant === 'sticky') {
+    return (
+      <FormattingToolbar {...toolbarProps}>
+        {getFormattingToolbarItems(toolbarProps.blockTypeSelectItems)}
+        <ReviewToolbarButton kind="comment" onSelect={onAddComment} />
+        <ReviewToolbarButton kind="suggestion" onStartSuggestionMode={onStartSuggestionMode} />
+      </FormattingToolbar>
+    )
+  }
+
+  return (
+    <FormattingToolbar {...toolbarProps}>
+      <div className="review-formatting-toolbar-compact">
+        <ReviewBlockTypeMenu blockTypeSelectItems={toolbarProps.blockTypeSelectItems} />
+        <div className="review-formatting-toolbar-grid">
+          <BasicTextStyleButton basicTextStyle="bold" />
+          <BasicTextStyleButton basicTextStyle="italic" />
+          <BasicTextStyleButton basicTextStyle="underline" />
+          <BasicTextStyleButton basicTextStyle="strike" />
+          <TextAlignButton textAlignment="left" />
+          <TextAlignButton textAlignment="center" />
+          <TextAlignButton textAlignment="right" />
+          <ColorStyleButton />
+          <NestBlockButton />
+          <UnnestBlockButton />
+          <CreateLinkButton />
+        </div>
+        <div className="review-formatting-toolbar-actions">
+          <ReviewToolbarButton kind="comment" onSelect={onAddComment} />
+          <ReviewToolbarButton kind="suggestion" onStartSuggestionMode={onStartSuggestionMode} />
+        </div>
+      </div>
+    </FormattingToolbar>
+  )
+}
+
+function ReviewBlockTypeMenu({
+  blockTypeSelectItems
+}: {
+  blockTypeSelectItems?: BlockTypeSelectItem[]
+}) {
+  const Components = useComponentsContext()
+  const editor = useBlockNoteEditor()
+  const selectedBlocks = useEditorState({
+    editor,
+    selector: ({ editor }) =>
+      editor.getSelection()?.blocks || [editor.getTextCursorPosition().block]
+  })
+  const firstSelectedBlock = selectedBlocks[0]
+
+  if (!Components || !editor.isEditable || !firstSelectedBlock) return null
+
+  const items = blockTypeSelectItems ?? defaultBlockTypeSelectItems(editor.dictionary)
+  const selectedItem =
+    items.find((item) => {
+      const typeMatches = item.type === firstSelectedBlock.type
+      const propsMatch = Object.entries(item.props || {}).every(
+        ([propName, propValue]) => firstSelectedBlock.props[propName] === propValue
+      )
+
+      return typeMatches && propsMatch
+    }) ?? items[0]
+
+  if (!selectedItem) return null
+
+  const SelectedIcon = selectedItem.icon
+
+  return (
+    <Components.Generic.Menu.Root position="bottom-start">
+      <Components.Generic.Menu.Trigger>
+        <Components.Generic.Menu.Button
+          className="bn-button review-block-type-trigger"
+          label={selectedItem.name}
+        >
+          <SelectedIcon size={16} />
+          <span className="review-block-type-trigger-label">{selectedItem.name}</span>
+          <ChevronDown className="review-block-type-trigger-chevron" />
+        </Components.Generic.Menu.Button>
+      </Components.Generic.Menu.Trigger>
+      <Components.Generic.Menu.Dropdown className="review-formatting-toolbar-menu">
+        {items.map((item) => {
+          const Icon = item.icon
+          const isSelected =
+            item.type === firstSelectedBlock.type &&
+            Object.entries(item.props || {}).every(
+              ([propName, propValue]) => firstSelectedBlock.props[propName] === propValue
+            )
+
+          return (
+            <Components.Generic.Menu.Item
+              key={`${item.type}:${JSON.stringify(item.props ?? {})}`}
+              checked={isSelected}
+              icon={<Icon size={16} />}
+              onClick={() => {
+                editor.focus()
+                editor.transact(() => {
+                  for (const block of selectedBlocks) {
+                    editor.updateBlock(block, {
+                      type: item.type as any,
+                      props: item.props as any
+                    })
+                  }
+                })
+              }}
+            >
+              {item.name}
+            </Components.Generic.Menu.Item>
+          )
+        })}
+      </Components.Generic.Menu.Dropdown>
+    </Components.Generic.Menu.Root>
+  )
+}
+
+function ReviewToolbarButton({
+  kind,
+  onSelect,
+  onStartSuggestionMode
+}: {
+  kind: 'comment' | 'suggestion'
+  onSelect?: (selection: ReviewSelection) => void
+  onStartSuggestionMode?: () => void
+}) {
+  const { t } = useT('notes')
+  const Components = useComponentsContext()
+  const editor = useBlockNoteEditor()
+  const ignoreNextClickRef = useRef(false)
+  const hasSelection = useEditorState({
+    editor,
+    selector: ({ editor }) => !getProseMirrorState(editor).selection.empty
+  })
+
+  if (!Components) return null
+  if (kind === 'comment' && !onSelect) return null
+  if (kind === 'suggestion' && !onStartSuggestionMode) return null
+
+  const label = kind === 'comment' ? t('comments.toolbarComment') : t('comments.toolbarSuggest')
+  const Icon = kind === 'comment' ? MessageCircle : PenLine
+  const isDisabled = kind === 'comment' && !hasSelection
+  const runAction = () => {
+    if (kind === 'suggestion') {
+      onStartSuggestionMode?.()
+      return
+    }
+
+    const selection = getEditorSelection(editor)
+    if (selection.isEmpty) return
+    onSelect?.(selection)
+  }
+
+  const markPointerHandled = () => {
+    ignoreNextClickRef.current = true
+    window.setTimeout(() => {
+      ignoreNextClickRef.current = false
+    }, 0)
+  }
+
+  const handlePreClickSelection = (
+    event: PointerEvent<HTMLElement> | MouseEvent<HTMLElement>
+  ): void => {
+    if (kind !== 'comment' || isDisabled) return
+    event.preventDefault()
+    if (ignoreNextClickRef.current) return
+    markPointerHandled()
+    runAction()
+  }
+
+  return (
+    <span onPointerDown={handlePreClickSelection} onMouseDown={handlePreClickSelection}>
+      <Components.FormattingToolbar.Button
+        className="bn-button"
+        data-test={kind === 'comment' ? 'review-comment' : 'review-suggest'}
+        label={label}
+        mainTooltip={label}
+        isDisabled={isDisabled}
+        icon={<Icon size={16} />}
+        onClick={() => {
+          if (ignoreNextClickRef.current) {
+            ignoreNextClickRef.current = false
+            return
+          }
+          runAction()
+        }}
+      />
+    </span>
+  )
+}
+
+function getEditorSelection(editor: BlockNoteEditor): ReviewSelection {
+  const state = getProseMirrorState(editor)
+  const selection = state.selection
+  if (selection.empty) return { text: '', isEmpty: true }
+
+  return {
+    text: state.doc.textBetween(selection.from, selection.to, '\n').trim(),
+    isEmpty: false,
+    from: selection.from,
+    to: selection.to
+  }
+}
+
+function getProseMirrorState(editor: BlockNoteEditor) {
+  return (editor as any)._tiptapEditor?.state ?? editor.prosemirrorState
+}

--- a/apps/desktop/src/renderer/src/components/note/content-area/types.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/types.ts
@@ -42,6 +42,17 @@ export interface SelectionInfo {
   isEmpty: boolean
 }
 
+export interface ReviewSelection {
+  /** Selected text visible in the editor */
+  text: string
+  /** Whether selection is empty/collapsed */
+  isEmpty: boolean
+  /** ProseMirror start position for the selected text, when available */
+  from?: number
+  /** ProseMirror end position for the selected text, when available */
+  to?: number
+}
+
 // =============================================================================
 // CONTENT AREA PROPS
 // =============================================================================
@@ -112,6 +123,11 @@ export interface ContentAreaProps {
    * still get the original behavior.
    */
   marqueeZoneEl?: HTMLDivElement | null
+  /** Optional review actions for the formatting toolbar */
+  review?: {
+    onAddComment?: (selection: ReviewSelection) => void
+    onStartSuggestionMode?: () => void
+  }
 }
 
 // =============================================================================

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -84,6 +84,7 @@ Toggle browser spellcheck in [Settings → Editor](/user-guide/settings#editor).
 ## Toolbar
 
 The formatting toolbar can be sticky at the top or float above selections — choose in [Settings → Editor](/user-guide/settings#editor).
+Floating mode opens a compact selection toolbar with block type, text formatting, color, link, indent, and review actions when those actions are enabled.
 
 ## What Notes Are Made Of
 

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -164,6 +164,10 @@
     "showMore": "Show {count} more backlinks",
     "more": "{count} more"
   },
+  "comments": {
+    "toolbarComment": "Comment",
+    "toolbarSuggest": "Suggest edit"
+  },
   "tagsRow": {
     "aria": "Tags",
     "empty": "Add tags",


### PR DESCRIPTION
## Summary
- Add a compact floating editor toolbar for note and journal selections with block type, formatting, color, link, indent, and review actions when enabled.
- Wire ContentArea review action props and toolbar labels.
- Document the floating selection toolbar behavior.

## Tests
- pnpm exec vitest run src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx --config config/vitest.config.ts --project renderer
- pnpm --filter @memry/desktop i18n:check
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build
- git diff --check origin/main...HEAD