### PR TITLE
Fix Electron E2E binary install in CI

### DIFF
--- a/apps/desktop/scripts/ensure-native.sh
+++ b/apps/desktop/scripts/ensure-native.sh
@@ -48,6 +48,16 @@ has_electron_binary() {
   [ -f "$ELECTRON_DIR/dist/$electron_path" ]
 }
 
+install_electron_binary() {
+  ELECTRON_OVERRIDE_DIST_PATH= ELECTRON_SKIP_BINARY_DOWNLOAD= force_no_cache=true node "$ELECTRON_INSTALL_SCRIPT"
+
+  if ! has_electron_binary; then
+    echo "[electron] install finished, but no Electron binary was found under $ELECTRON_DIR/dist." >&2
+    echo "[electron] Check ELECTRON_SKIP_BINARY_DOWNLOAD and Electron cache settings." >&2
+    exit 1
+  fi
+}
+
 if [ "$CURRENT_STAMP" = "$TARGET" ] && has_native_binary; then
   if [ "$TARGET" != "electron" ] || has_electron_binary; then
     echo "[native] already built for $TARGET — skipping"
@@ -73,7 +83,7 @@ if [ "$TARGET" = "electron" ]; then
 
   if ! has_electron_binary; then
     echo "[electron] binary missing — installing..."
-    node "$ELECTRON_INSTALL_SCRIPT"
+    install_electron_binary
   fi
 
   echo "[native] rebuilding $MODULES for Electron..."

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -159,6 +159,8 @@ will ship instead of depending on the workspace `electron` package binary.
 The desktop unit coverage job sets `ELECTRON_OVERRIDE_DIST_PATH=/usr/bin` before Vitest so
 main-process tests can import `electron` for IPC and `BrowserWindow` mocks even when the workspace
 Electron binary download is unavailable on the runner.
+Main-push E2E jobs still need the workspace `electron` package binary; `ensure-native.sh electron`
+clears fallback install env and verifies `path.txt` before Playwright launches Electron.
 
 Release builds create one staged dependency tree per macOS architecture. Build x64 on an Intel
 runner and arm64 on an Apple Silicon runner; do not build `--x64 --arm64` from the same staged


### PR DESCRIPTION
## Summary
- force Electron binary install in ensure-native when the workspace binary is missing
- clear fallback install env before running Electron's installer
- document the main-push E2E binary requirement

## Verification
- bash -n apps/desktop/scripts/ensure-native.sh
- git diff --check
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build