### PR TITLE
Fix Electron E2E install mirror in CI

### DIFF
--- a/apps/desktop/scripts/ensure-native.sh
+++ b/apps/desktop/scripts/ensure-native.sh
@@ -49,7 +49,13 @@ has_electron_binary() {
 }
 
 install_electron_binary() {
-  ELECTRON_OVERRIDE_DIST_PATH= ELECTRON_SKIP_BINARY_DOWNLOAD= force_no_cache=true node "$ELECTRON_INSTALL_SCRIPT"
+  ELECTRON_OVERRIDE_DIST_PATH= \
+    ELECTRON_SKIP_BINARY_DOWNLOAD= \
+    ELECTRON_MIRROR=https://github.com/electron/electron/releases/download/ \
+    npm_config_electron_mirror=https://github.com/electron/electron/releases/download/ \
+    NPM_CONFIG_ELECTRON_MIRROR=https://github.com/electron/electron/releases/download/ \
+    force_no_cache=true \
+    node "$ELECTRON_INSTALL_SCRIPT"
 
   if ! has_electron_binary; then
     echo "[electron] install finished, but no Electron binary was found under $ELECTRON_DIR/dist." >&2

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -161,6 +161,8 @@ main-process tests can import `electron` for IPC and `BrowserWindow` mocks even 
 Electron binary download is unavailable on the runner.
 Main-push E2E jobs still need the workspace `electron` package binary; `ensure-native.sh electron`
 clears fallback install env and verifies `path.txt` before Playwright launches Electron.
+That install path pins Electron's official mirror so CI is not dependent on the repo-level mirror
+cache.
 
 Release builds create one staged dependency tree per macOS architecture. Build x64 on an Intel
 runner and arm64 on an Apple Silicon runner; do not build `--x64 --arm64` from the same staged


### PR DESCRIPTION
## Summary
- force the Electron E2E install path to use Electron's official mirror
- keep clearing fallback/skip env before install
- document the CI mirror requirement

## Verification
- bash -n apps/desktop/scripts/ensure-native.sh
- git diff --check
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build