### PR TITLE
Recheck Electron binary before E2E launch

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -182,6 +182,7 @@ jobs:
 
       - name: Run Electron smoke tests
         run: |
+          bash apps/desktop/scripts/ensure-native.sh electron
           dbus-run-session -- bash -c '
             eval "$(printf "\n" | gnome-keyring-daemon --unlock)"
             eval "$(printf "\n" | gnome-keyring-daemon --start --components=secrets)"
@@ -251,6 +252,7 @@ jobs:
           GOOGLE_CALENDAR_E2E_CLIENT_ID: ${{ secrets.GOOGLE_CALENDAR_E2E_CLIENT_ID }}
           GOOGLE_CALENDAR_E2E_CLIENT_SECRET: ${{ secrets.GOOGLE_CALENDAR_E2E_CLIENT_SECRET }}
         run: |
+          bash apps/desktop/scripts/ensure-native.sh electron
           dbus-run-session -- bash -c '
             eval "$(printf "\n" | gnome-keyring-daemon --unlock)"
             eval "$(printf "\n" | gnome-keyring-daemon --start --components=secrets)"

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -163,7 +163,9 @@ Main-push E2E jobs still need the workspace `electron` package binary; `ensure-n
 clears fallback install env and verifies `path.txt` before Playwright launches Electron.
 That path uses a direct installer helper pinned to Electron's official mirror, then verifies the
 extracted binary before native rebuild starts. `ensure-native.sh` trusts that helper-level check
-instead of rerunning the package installer's `path.txt` probe.
+instead of rerunning the package installer's `path.txt` probe. CI also reruns the helper at the
+start of each E2E step, after `electron-vite build`, so Playwright sees a fresh workspace Electron
+binary immediately before launch.
 
 Release builds create one staged dependency tree per macOS architecture. Build x64 on an Intel
 runner and arm64 on an Apple Silicon runner; do not build `--x64 --arm64` from the same staged


### PR DESCRIPTION
## Summary
- rerun the Electron native/binary helper immediately before main-only Playwright E2E jobs
- document the pre-launch recheck in the testing guide

## Tests
- git diff --check
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build