### PR TITLE
Pass explicit Electron binary to E2E launcher

### DIFF
--- a/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
+++ b/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
@@ -12,11 +12,13 @@
  */
 
 import { _electron as electron, ElectronApplication, Page } from '@playwright/test'
+import { createRequire } from 'node:module'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 
 const MAIN_ENTRY = path.join(__dirname, '../../../out/main/index.js')
+const require = createRequire(__filename)
 const isCI = !!process.env.CI
 
 const FIRST_WINDOW_MS = 30_000
@@ -35,6 +37,14 @@ export interface LaunchedElectron {
   userDataDir: string
   resolvedUserDataDir: string
   mainLogs: string[]
+}
+
+function getElectronExecutablePath(): string {
+  const electronPath = require('electron')
+  if (typeof electronPath !== 'string') {
+    throw new Error('Expected the electron package to resolve to an executable path')
+  }
+  return electronPath
 }
 
 export async function destroyElectronApp(app: ElectronApplication, dirs: string[]): Promise<void> {
@@ -79,6 +89,7 @@ async function launchOnce(opts: LaunchOptions): Promise<LaunchedElectron> {
   delete env.ELECTRON_RUN_AS_NODE
 
   const app = await electron.launch({
+    executablePath: getElectronExecutablePath(),
     args: [
       ...(isCI ? ['--no-sandbox', '--disable-gpu'] : []),
       `--user-data-dir=${userDataDir}`,

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -165,7 +165,9 @@ That path uses a direct installer helper pinned to Electron's official mirror, t
 extracted binary before native rebuild starts. `ensure-native.sh` trusts that helper-level check
 instead of rerunning the package installer's `path.txt` probe. CI also reruns the helper at the
 start of each E2E step, after `electron-vite build`, so Playwright sees a fresh workspace Electron
-binary immediately before launch.
+binary immediately before launch. The E2E launcher passes that resolved package binary as
+Playwright's explicit `executablePath` so Playwright does not fall back to resolving Electron from
+its own package directory.
 
 Release builds create one staged dependency tree per macOS architecture. Build x64 on an Intel
 runner and arm64 on an Apple Silicon runner; do not build `--x64 --arm64` from the same staged


### PR DESCRIPTION
## Summary
- resolve the desktop workspace Electron executable in the E2E launcher
- pass it as Playwright `executablePath` so CI does not use Playwright-core's implicit Electron resolver
- document the explicit E2E binary path

## Tests
- git diff --check
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build
- pnpm --filter @memry/desktop exec playwright test --config config/playwright.config.ts tests/e2e/vault.e2e.ts --list
- pnpm --filter @memry/desktop exec node -e "const fs=require('fs'); const electron=require('electron'); if (typeof electron !== 'string' || !fs.existsSync(electron)) throw new Error('bad electron path: '+electron); console.log(electron)"