### PR TITLE
Fix Electron E2E launcher binary repair

### DIFF
--- a/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
+++ b/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
@@ -12,12 +12,14 @@
  */
 
 import { _electron as electron, ElectronApplication, Page } from '@playwright/test'
+import { spawnSync } from 'child_process'
 import { createRequire } from 'node:module'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 
 const MAIN_ENTRY = path.join(__dirname, '../../../out/main/index.js')
+const ELECTRON_INSTALLER = path.join(__dirname, '../../../scripts/install-electron-binary.cjs')
 const require = createRequire(__filename)
 const isCI = !!process.env.CI
 
@@ -40,11 +42,49 @@ export interface LaunchedElectron {
 }
 
 function getElectronExecutablePath(): string {
-  const electronPath = require('electron')
-  if (typeof electronPath !== 'string') {
-    throw new Error('Expected the electron package to resolve to an executable path')
+  const electronPackageDir = path.dirname(require.resolve('electron/package.json'))
+  const installedPath = readElectronExecutablePath(electronPackageDir)
+  if (installedPath) {
+    return installedPath
   }
-  return electronPath
+
+  installElectronBinary(electronPackageDir)
+  const repairedPath = readElectronExecutablePath(electronPackageDir)
+  if (repairedPath) {
+    return repairedPath
+  }
+
+  throw new Error(`Electron binary was not found after install: ${electronPackageDir}`)
+}
+
+function readElectronExecutablePath(electronPackageDir: string): string | null {
+  try {
+    const relativePath = fs.readFileSync(path.join(electronPackageDir, 'path.txt'), 'utf8').trim()
+    if (!relativePath) {
+      return null
+    }
+
+    const executablePath = path.join(electronPackageDir, 'dist', relativePath)
+    return fs.existsSync(executablePath) ? executablePath : null
+  } catch {
+    return null
+  }
+}
+
+function installElectronBinary(electronPackageDir: string): void {
+  const result = spawnSync(process.execPath, [ELECTRON_INSTALLER, electronPackageDir], {
+    cwd: path.join(__dirname, '../../..'),
+    env: process.env,
+    stdio: 'inherit'
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`Electron binary install failed with exit code ${result.status ?? 'unknown'}`)
+  }
 }
 
 export async function destroyElectronApp(app: ElectronApplication, dirs: string[]): Promise<void> {

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -167,7 +167,9 @@ instead of rerunning the package installer's `path.txt` probe. CI also reruns th
 start of each E2E step, after `electron-vite build`, so Playwright sees a fresh workspace Electron
 binary immediately before launch. The E2E launcher passes that resolved package binary as
 Playwright's explicit `executablePath` so Playwright does not fall back to resolving Electron from
-its own package directory.
+its own package directory. If CI still reaches the launcher with a missing `path.txt` or executable,
+the launcher runs the same installer helper once and reads the package path directly instead of
+importing `electron/index.js`.
 
 Release builds create one staged dependency tree per macOS architecture. Build x64 on an Intel
 runner and arm64 on an Apple Silicon runner; do not build `--x64 --arm64` from the same staged


### PR DESCRIPTION
## Summary
- make the E2E launcher resolve Electron from package files instead of importing electron/index.js
- run the existing Electron installer helper once if path.txt or the executable is missing at launch time
- document the launcher-level CI repair path

## Verification
- git diff --check
- pnpm --filter @memry/desktop exec tsc --noEmit -p tsconfig.node.json --composite false
- pnpm --filter @memry/desktop exec playwright test --config config/playwright.config.ts tests/e2e/vault.e2e.ts --list
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build