### PR TITLE
Trust Electron E2E installer path

### DIFF
--- a/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
+++ b/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
@@ -48,13 +48,7 @@ function getElectronExecutablePath(): string {
     return installedPath
   }
 
-  installElectronBinary(electronPackageDir)
-  const repairedPath = readElectronExecutablePath(electronPackageDir)
-  if (repairedPath) {
-    return repairedPath
-  }
-
-  throw new Error(`Electron binary was not found after install: ${electronPackageDir}`)
+  return installElectronBinary(electronPackageDir)
 }
 
 function readElectronExecutablePath(electronPackageDir: string): string | null {
@@ -71,7 +65,7 @@ function readElectronExecutablePath(electronPackageDir: string): string | null {
   }
 }
 
-function installElectronBinary(electronPackageDir: string): void {
+function installElectronBinary(electronPackageDir: string): string {
   const result = spawnSync(process.execPath, [ELECTRON_INSTALLER, electronPackageDir], {
     cwd: path.join(__dirname, '../../..'),
     env: process.env,
@@ -84,6 +78,23 @@ function installElectronBinary(electronPackageDir: string): void {
 
   if (result.status !== 0) {
     throw new Error(`Electron binary install failed with exit code ${result.status ?? 'unknown'}`)
+  }
+
+  return path.join(electronPackageDir, 'dist', getElectronPlatformPath())
+}
+
+function getElectronPlatformPath(): string {
+  switch (process.platform) {
+    case 'darwin':
+      return 'Electron.app/Contents/MacOS/Electron'
+    case 'freebsd':
+    case 'openbsd':
+    case 'linux':
+      return 'electron'
+    case 'win32':
+      return 'electron.exe'
+    default:
+      throw new Error(`Electron builds are not available on platform: ${process.platform}`)
   }
 }
 

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -168,8 +168,8 @@ start of each E2E step, after `electron-vite build`, so Playwright sees a fresh 
 binary immediately before launch. The E2E launcher passes that resolved package binary as
 Playwright's explicit `executablePath` so Playwright does not fall back to resolving Electron from
 its own package directory. If CI still reaches the launcher with a missing `path.txt` or executable,
-the launcher runs the same installer helper once and reads the package path directly instead of
-importing `electron/index.js`.
+the launcher runs the same installer helper once, trusts the helper's validation, and passes the
+platform-specific package executable path directly instead of importing `electron/index.js`.
 
 Release builds create one staged dependency tree per macOS architecture. Build x64 on an Intel
 runner and arm64 on an Apple Silicon runner; do not build `--x64 --arm64` from the same staged


### PR DESCRIPTION
## Summary
- trust the Electron installer helper after it exits successfully
- return the platform-specific package executable path directly after repair
- document that the launcher avoids electron/index.js and relies on helper validation

## Verification
- pnpm exec prettier --check apps/desktop/tests/e2e/utils/electron-lifecycle.ts apps/docs/src/contribute/testing.md
- git diff --check
- pnpm --filter @memry/desktop exec tsc --noEmit -p tsconfig.node.json --composite false
- pnpm --filter @memry/desktop exec playwright test --config config/playwright.config.ts tests/e2e/vault.e2e.ts --list
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build