### PR TITLE
Fix Electron binary installer process

### DIFF
--- a/apps/desktop/scripts/install-electron-binary.cjs
+++ b/apps/desktop/scripts/install-electron-binary.cjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 const childProcess = require('child_process')
+const crypto = require('crypto')
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 
 const electronDir = process.argv[2]
@@ -12,8 +14,6 @@ if (!electronDir) {
   process.exit(2)
 }
 
-const { downloadArtifact } = require(require.resolve('@electron/get', { paths: [electronDir] }))
-const extract = require(require.resolve('extract-zip', { paths: [electronDir] }))
 const { version } = require(path.join(electronDir, 'package.json'))
 const checksums = require(path.join(electronDir, 'checksums.json'))
 
@@ -61,51 +61,85 @@ function getArch(platform) {
   return arch
 }
 
-async function main() {
+function downloadArtifact(zipUrl, zipPath) {
+  childProcess.execFileSync(
+    'curl',
+    [
+      '--fail',
+      '--location',
+      '--show-error',
+      '--silent',
+      '--retry',
+      '3',
+      '--retry-delay',
+      '2',
+      '--output',
+      zipPath,
+      zipUrl
+    ],
+    { stdio: 'inherit' }
+  )
+}
+
+function extractArtifact(zipPath, distDir) {
+  childProcess.execFileSync('unzip', ['-q', zipPath, '-d', distDir], { stdio: 'inherit' })
+}
+
+function validateChecksum(zipPath, expectedHash) {
+  const actualHash = crypto.createHash('sha256').update(fs.readFileSync(zipPath)).digest('hex')
+  if (actualHash !== expectedHash) {
+    throw new Error(`Electron checksum mismatch: expected ${expectedHash}, got ${actualHash}`)
+  }
+}
+
+function main() {
   const platform = process.env.npm_config_platform || process.platform
   const arch = getArch(platform)
   const platformPath = getPlatformPath(platform)
   const distDir = path.join(electronDir, 'dist')
   const pathFile = path.join(electronDir, 'path.txt')
+  const zipName = `electron-v${version}-${platform}-${arch}.zip`
+  const expectedHash = checksums[zipName]
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-electron-'))
+  const zipPath = path.join(tempDir, zipName)
 
-  await fs.promises.rm(distDir, { recursive: true, force: true })
-  await fs.promises.rm(pathFile, { force: true })
+  if (!expectedHash) {
+    throw new Error(`No Electron checksum found for ${zipName}`)
+  }
+
+  fs.rmSync(distDir, { recursive: true, force: true })
+  fs.rmSync(pathFile, { force: true })
 
   console.log(`[electron] installing ${version} for ${platform}-${arch} from ${officialMirror}`)
 
-  const zipPath = await downloadArtifact({
-    version,
-    artifactName: 'electron',
-    force: true,
-    cacheRoot: process.env.electron_config_cache,
-    checksums,
-    platform,
-    arch,
-    mirrorOptions: {
-      mirror: officialMirror
-    }
-  })
-
-  await extract(zipPath, { dir: distDir })
-
-  const typeDefinitionsPath = path.join(distDir, 'electron.d.ts')
-  if (fs.existsSync(typeDefinitionsPath)) {
-    const targetTypeDefinitionsPath = path.join(electronDir, 'electron.d.ts')
-    await fs.promises.rm(targetTypeDefinitionsPath, { force: true })
-    await fs.promises.rename(typeDefinitionsPath, targetTypeDefinitionsPath)
-  }
-
-  await fs.promises.writeFile(pathFile, platformPath)
-
   const executablePath = path.join(distDir, platformPath)
-  if (!fs.existsSync(executablePath)) {
-    throw new Error(`Electron binary was not found after install: ${executablePath}`)
-  }
+  try {
+    downloadArtifact(`${officialMirror}v${version}/${zipName}`, zipPath)
+    validateChecksum(zipPath, expectedHash)
+    extractArtifact(zipPath, distDir)
 
-  console.log(`[electron] installed ${version} for ${platform}-${arch}`)
+    const typeDefinitionsPath = path.join(distDir, 'electron.d.ts')
+    if (fs.existsSync(typeDefinitionsPath)) {
+      const targetTypeDefinitionsPath = path.join(electronDir, 'electron.d.ts')
+      fs.rmSync(targetTypeDefinitionsPath, { force: true })
+      fs.renameSync(typeDefinitionsPath, targetTypeDefinitionsPath)
+    }
+
+    fs.writeFileSync(pathFile, platformPath)
+
+    if (!fs.existsSync(executablePath)) {
+      throw new Error(`Electron binary was not found after install: ${executablePath}`)
+    }
+
+    console.log(`[electron] installed ${version} for ${platform}-${arch}: ${executablePath}`)
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
 }
 
-main().catch((error) => {
+try {
+  main()
+} catch (error) {
   console.error(error.stack || String(error))
   process.exit(1)
-})
+}

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -161,15 +161,16 @@ main-process tests can import `electron` for IPC and `BrowserWindow` mocks even 
 Electron binary download is unavailable on the runner.
 Main-push E2E jobs still need the workspace `electron` package binary; `ensure-native.sh electron`
 clears fallback install env and verifies `path.txt` before Playwright launches Electron.
-That path uses a direct installer helper pinned to Electron's official mirror, then verifies the
-extracted binary before native rebuild starts. `ensure-native.sh` trusts that helper-level check
-instead of rerunning the package installer's `path.txt` probe. CI also reruns the helper at the
-start of each E2E step, after `electron-vite build`, so Playwright sees a fresh workspace Electron
-binary immediately before launch. The E2E launcher passes that resolved package binary as
-Playwright's explicit `executablePath` so Playwright does not fall back to resolving Electron from
-its own package directory. If CI still reaches the launcher with a missing `path.txt` or executable,
-the launcher runs the same installer helper once, trusts the helper's validation, and passes the
-platform-specific package executable path directly instead of importing `electron/index.js`.
+That path uses a blocking installer helper pinned to Electron's official release mirror, checks the
+downloaded archive against Electron's packaged checksum, then verifies the extracted binary before
+native rebuild starts. `ensure-native.sh` trusts that helper-level check instead of rerunning the
+package installer's `path.txt` probe. CI also reruns the helper at the start of each E2E step, after
+`electron-vite build`, so Playwright sees a fresh workspace Electron binary immediately before
+launch. The E2E launcher passes that resolved package binary as Playwright's explicit
+`executablePath` so Playwright does not fall back to resolving Electron from its own package
+directory. If CI still reaches the launcher with a missing `path.txt` or executable, the launcher
+runs the same installer helper once, trusts the helper's validation, and passes the platform-specific
+package executable path directly instead of importing `electron/index.js`.
 
 Release builds create one staged dependency tree per macOS architecture. Build x64 on an Intel
 runner and arm64 on an Apple Silicon runner; do not build `--x64 --arm64` from the same staged


### PR DESCRIPTION
## Summary
- install the Electron package binary with blocking curl/unzip steps pinned to the official release mirror
- validate the downloaded archive checksum and extracted executable before E2E launch
- update E2E testing docs for the helper contract

## Verification
- node --check apps/desktop/scripts/install-electron-binary.cjs
- pnpm exec prettier --check apps/desktop/scripts/install-electron-binary.cjs apps/docs/src/contribute/testing.md
- temp linux-x64 helper install smoke
- git diff --check
- pnpm --filter @memry/desktop exec tsc --noEmit -p tsconfig.node.json --composite false
- pnpm --filter @memry/desktop exec playwright test --config config/playwright.config.ts tests/e2e/vault.e2e.ts --list
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build