### PR TITLE
Fix E2E note open helper flake

### DIFF
--- a/apps/desktop/tests/e2e/utils/note-sync-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/note-sync-helpers.ts
@@ -83,11 +83,23 @@ function bodyToParagraphBlocks(body: string) {
 }
 
 async function openNoteInUi(page: Page, note: NoteHandle): Promise<void> {
-  await page.evaluate((detail) => {
-    window.dispatchEvent(new CustomEvent('memry:test-open-note', { detail }))
-  }, note)
+  await expect
+    .poll(
+      async () => {
+        await page.evaluate((detail) => {
+          window.dispatchEvent(new CustomEvent('memry:test-open-note', { detail }))
+        }, note)
 
-  await expect(page.locator(SELECTORS.noteTitle).first()).toHaveValue(note.title)
+        const titleInput = page.locator(SELECTORS.noteTitle).first()
+        await titleInput.waitFor({ state: 'visible', timeout: 1_000 }).catch(() => {})
+        return titleInput.inputValue().catch(() => null)
+      },
+      {
+        intervals: [100, 250, 500, 1_000],
+        timeout: 20_000
+      }
+    )
+    .toBe(note.title)
 }
 
 async function waitForPersistedNoteBody(page: Page, noteId: string, body: string): Promise<void> {


### PR DESCRIPTION
## Summary
- retry the test-only note-open event until the note title input is actually mounted
- keeps the fix scoped to the E2E helper that failed on main after #485

## Verification
- pnpm exec prettier --check apps/desktop/tests/e2e/utils/note-sync-helpers.ts
- pnpm --filter @memry/desktop exec tsc --noEmit -p tsconfig.node.json --composite false
- pnpm --filter @memry/desktop exec playwright test --config config/playwright.config.ts tests/e2e/note-sync-helpers.e2e.ts --list
- pnpm docs:impact --base origin/main --strict
- git diff --check