### PR TITLE
fix(ci): give full desktop e2e more headroom

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -205,7 +205,7 @@ jobs:
     name: Electron E2E full (${{ matrix.shard }})
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- increase full desktop E2E job timeout from 45 to 75 minutes
- keep the change scoped to the GitHub Actions workflow only

## Verification
- git diff --check
- pnpm docs:impact --base origin/main --strict