### PR TITLE
fix: stabilize desktop e2e runtime waits

### DIFF
--- a/apps/desktop/config/playwright.config.ts
+++ b/apps/desktop/config/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test'
 
 const isCi = process.env.CI === 'true'
-const testTimeoutMs = isCi ? 90_000 : 60_000
-const expectTimeoutMs = isCi ? 45_000 : 20_000
+const testTimeoutMs = isCi ? 180_000 : 60_000
+const expectTimeoutMs = isCi ? 60_000 : 20_000
 
 export default defineConfig({
   testDir: '../tests/e2e',
@@ -10,7 +10,7 @@ export default defineConfig({
   timeout: testTimeoutMs,
 
   expect: {
-    // Sync, agent, and CRDT polls can exceed 20s on GitHub's Linux runners
+    // Sync, agent, and CRDT polls can exceed local budgets on GitHub's Linux runners
     // even when the app eventually converges.
     timeout: expectTimeoutMs
   },

--- a/apps/desktop/tests/e2e/agent-chat-codex-create-task.e2e.ts
+++ b/apps/desktop/tests/e2e/agent-chat-codex-create-task.e2e.ts
@@ -21,7 +21,7 @@ import {
   waitForVaultReady
 } from './utils/electron-helpers'
 
-const AGENT_TASK_CREATE_TIMEOUT_MS = process.env.CI ? 45_000 : 20_000
+const AGENT_TASK_CREATE_TIMEOUT_MS = process.env.CI ? 60_000 : 20_000
 
 test.describe('Agent chat Codex create-task flow', () => {
   let launched: LaunchedElectron | null = null

--- a/apps/desktop/tests/e2e/agent-chat-create-task.e2e.ts
+++ b/apps/desktop/tests/e2e/agent-chat-create-task.e2e.ts
@@ -23,7 +23,7 @@ import {
   waitForVaultReady
 } from './utils/electron-helpers'
 
-const AGENT_TASK_CREATE_TIMEOUT_MS = process.env.CI ? 45_000 : 20_000
+const AGENT_TASK_CREATE_TIMEOUT_MS = process.env.CI ? 60_000 : 20_000
 
 test.describe('Agent chat create-task flow', () => {
   let launched: LaunchedElectron | null = null

--- a/apps/desktop/tests/e2e/agent-mcp-external-client.e2e.ts
+++ b/apps/desktop/tests/e2e/agent-mcp-external-client.e2e.ts
@@ -13,7 +13,7 @@ type JsonRpcEnvelope = {
   error?: unknown
 }
 
-const AGENT_MCP_STATUS_TIMEOUT_MS = process.env.CI ? 45_000 : 20_000
+const AGENT_MCP_STATUS_TIMEOUT_MS = process.env.CI ? 75_000 : 20_000
 
 async function waitForAgentStatus(page: Parameters<typeof waitForAppReady>[0]): Promise<{
   url: string

--- a/apps/desktop/tests/e2e/body-crdt-create-propagation.e2e.ts
+++ b/apps/desktop/tests/e2e/body-crdt-create-propagation.e2e.ts
@@ -89,11 +89,11 @@ async function runReceiverOfflineCreatePropagationCase({
 
   await syncBothAndWait(creatorPage, receiverPage)
 
-  await waitForNoteReplicated(offlineApp, created.id, body)
-  expect(await getNoteFileBodyById(receiverPage, created.id)).toBe(body)
-
   await openNoteByHandle(receiverPage, created)
   await expectNoteBody(receiverPage, body)
+
+  await waitForNoteReplicated(offlineApp, created.id, body)
+  expect(await getNoteFileBodyById(receiverPage, created.id)).toBe(body)
 }
 
 test.describe('Body CRDT create propagation', () => {

--- a/apps/desktop/tests/e2e/utils/agent-chat-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/agent-chat-helpers.ts
@@ -1,17 +1,23 @@
 import { expect, type Locator, type Page } from '@playwright/test'
 
+const AGENT_CHAT_OPEN_TIMEOUT_MS = process.env.CI ? 60_000 : 30_000
+
 export async function openAgentChat(page: Page): Promise<void> {
   await page.getByRole('button', { name: 'Day Panel' }).click()
-  await page.getByRole('tab', { name: 'Agent', exact: true }).click()
 
+  const agentTab = page.getByRole('tab', { name: 'Agent', exact: true })
   const enableButton = page.getByRole('button', { name: 'Enable Agent chat' })
   const agentChat = page.getByRole('region', { name: 'Agent chat' })
   await expect
     .poll(
-      async () =>
-        (await enableButton.isVisible().catch(() => false)) ||
-        (await agentChat.isVisible().catch(() => false)),
-      { timeout: 30_000 }
+      async () => {
+        await agentTab.click().catch(() => {})
+        return (
+          (await enableButton.isVisible().catch(() => false)) ||
+          (await agentChat.isVisible().catch(() => false))
+        )
+      },
+      { timeout: AGENT_CHAT_OPEN_TIMEOUT_MS }
     )
     .toBe(true)
 

--- a/apps/desktop/tests/e2e/utils/note-sync-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/note-sync-helpers.ts
@@ -18,7 +18,7 @@ export interface NoteHandle {
   emoji?: string | null
 }
 
-const NOTE_OPEN_TIMEOUT_MS = process.env.CI ? 45_000 : 20_000
+const NOTE_OPEN_TIMEOUT_MS = process.env.CI ? 75_000 : 20_000
 
 export async function findNoteHandle(
   page: Page,

--- a/apps/desktop/tests/e2e/utils/wait-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/wait-helpers.ts
@@ -39,8 +39,9 @@ export async function readNoteOnDevice(
   }
 }
 
-const DEFAULT_WAIT_TIMEOUT_MS = 30_000
+const DEFAULT_WAIT_TIMEOUT_MS = process.env.CI ? 60_000 : 30_000
 const DEFAULT_WAIT_INTERVALS = [250, 500, 1_000, 2_000] as const
+const NOTE_REPLICATION_TIMEOUT_MS = process.env.CI ? 150_000 : 90_000
 
 export async function getVisibleDayStart(page: Page): Promise<number> {
   const value = await page.getByTestId('calendar-view').getAttribute('data-visible-day-start')
@@ -79,7 +80,7 @@ export async function waitForNoteReplicated(
   expectedBody: string,
   opts: { timeout?: number } = {}
 ): Promise<void> {
-  const timeout = opts.timeout ?? 90_000
+  const timeout = opts.timeout ?? NOTE_REPLICATION_TIMEOUT_MS
   const normalizedExpected = normalizeBodyText(expectedBody)
   await expect
     .poll(() => readNoteOnDevice(electronApp, noteId), {

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -71,8 +71,8 @@ pnpm test:e2e -- tests/notes.spec.ts    # one file
 > Skipping the rebuild is the #1 source of "passes locally, fails in CI" surprises.
 
 Main-push Desktop CI runs the full Electron E2E suite across 16 Playwright shards. Local E2E keeps
-the default 60s test timeout and 20s assertion timeout, while CI raises those to 90s and 45s so
-sync, Agent, and CRDT polls can survive slower Linux runners without changing local feedback speed.
+the default 60s test timeout and 20s assertion timeout, while CI raises those to 180s and 60s, with
+helper-specific headroom for sync replication and Agent/MCP startup on slower Linux runners.
 
 ### E2E Test Hooks
 


### PR DESCRIPTION
## Summary
- increase CI-only E2E budgets for slow Agent/MCP startup and CRDT waits
- retry Agent tab activation in the E2E helper
- open receiver-offline-created notes before asserting CRDT body state so the lazy body fetch path runs
- update testing docs for the new CI timeout budgets

## Verification
- pnpm exec prettier --check apps/desktop/config/playwright.config.ts apps/desktop/tests/e2e/utils/agent-chat-helpers.ts apps/desktop/tests/e2e/utils/note-sync-helpers.ts apps/desktop/tests/e2e/utils/wait-helpers.ts apps/desktop/tests/e2e/agent-chat-codex-create-task.e2e.ts apps/desktop/tests/e2e/agent-chat-create-task.e2e.ts apps/desktop/tests/e2e/agent-mcp-external-client.e2e.ts apps/desktop/tests/e2e/body-crdt-create-propagation.e2e.ts apps/docs/src/contribute/testing.md
- git diff --check
- pnpm --filter @memry/desktop exec tsc --noEmit -p tsconfig.node.json --composite false
- pnpm --filter @memry/desktop exec playwright test --config config/playwright.config.ts --list --shard=1/16
- pnpm --filter @memry/desktop exec playwright test --config config/playwright.config.ts --list --shard=2/16
- pnpm docs:impact --base origin/main --strict
- pnpm docs:build

Note: focused local C3 E2E is not listed as passing because local Electron app B launch timed out on this machine; this PR targets the Linux CI failure path.