### PR TITLE
fix: stabilize e2e agent and crdt readiness

### DIFF
--- a/apps/desktop/src/main/agent/lazy-services.test.ts
+++ b/apps/desktop/src/main/agent/lazy-services.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  configureLazyAgentServices,
+  getLazyAgentMcpStatus,
+  rotateLazyAgentMcpToken
+} from './lazy-services'
+
+const lifecycleMock = vi.hoisted(() => ({
+  getPublicStatus: vi.fn(async () => ({
+    url: 'http://127.0.0.1:45900/mcp',
+    token: 'token-1',
+    toolCount: 4
+  })),
+  rotateToken: vi.fn()
+}))
+
+vi.mock('./mcp/lifecycle', () => lifecycleMock)
+
+describe('lazy agent services', () => {
+  beforeEach(() => {
+    configureLazyAgentServices(null)
+    lifecycleMock.getPublicStatus.mockClear()
+    lifecycleMock.rotateToken.mockClear()
+  })
+
+  it('returns stopped MCP status when no vault starter is configured', async () => {
+    await expect(getLazyAgentMcpStatus()).resolves.toEqual({
+      url: null,
+      token: null,
+      toolCount: 0
+    })
+    expect(lifecycleMock.getPublicStatus).not.toHaveBeenCalled()
+  })
+
+  it('starts lazy services before reading MCP status', async () => {
+    const starter = vi.fn(async () => undefined)
+    configureLazyAgentServices(starter)
+
+    await expect(getLazyAgentMcpStatus()).resolves.toEqual({
+      url: 'http://127.0.0.1:45900/mcp',
+      token: 'token-1',
+      toolCount: 4
+    })
+    expect(starter).toHaveBeenCalledTimes(1)
+    expect(lifecycleMock.getPublicStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts lazy services before rotating the MCP token', async () => {
+    const starter = vi.fn(async () => undefined)
+    configureLazyAgentServices(starter)
+
+    await rotateLazyAgentMcpToken()
+    expect(starter).toHaveBeenCalledTimes(1)
+    expect(lifecycleMock.rotateToken).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/main/agent/lazy-services.ts
+++ b/apps/desktop/src/main/agent/lazy-services.ts
@@ -27,7 +27,10 @@ export async function ensureLazyAgentServicesStarted(): Promise<void> {
 }
 
 export async function getLazyAgentMcpStatus(): Promise<AgentMcpStatus> {
-  if (!started) return STOPPED_STATUS
+  if (!started) {
+    if (!starter) return STOPPED_STATUS
+    await ensureLazyAgentServicesStarted()
+  }
 
   const { getPublicStatus } = await import('./mcp/lifecycle')
   return getPublicStatus()

--- a/apps/desktop/src/main/ipc/agent-lazy-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/agent-lazy-handlers.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { mockElectron } from '@tests/utils/mock-electron'
+
+const mocks = vi.hoisted(() => ({
+  ensureLazyAgentServicesStarted: vi.fn(async () => undefined),
+  getAgentPreferences: vi.fn(() => ({
+    accessMode: 'vault_only',
+    toolApprovalMode: 'always_accept'
+  })),
+  setAgentPreferences: vi.fn((input: { toolApprovalMode?: 'ask' | 'always_accept' }) => ({
+    accessMode: 'vault_only',
+    toolApprovalMode: input.toolApprovalMode ?? 'always_accept'
+  })),
+  getDisclosureState: vi.fn(() => ({ accepted: false })),
+  acceptDisclosure: vi.fn(() => ({ accepted: true }))
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: mockElectron.BrowserWindow,
+  ipcMain: mockElectron.ipcMain
+}))
+
+vi.mock('../agent/lazy-services', () => ({
+  ensureLazyAgentServicesStarted: mocks.ensureLazyAgentServicesStarted
+}))
+
+vi.mock('../agent/settings', () => ({
+  getAgentPreferences: mocks.getAgentPreferences,
+  setAgentPreferences: mocks.setAgentPreferences
+}))
+
+vi.mock('../agent/runtime/disclosure-state', () => ({
+  getDisclosureState: mocks.getDisclosureState,
+  acceptDisclosure: mocks.acceptDisclosure
+}))
+
+import { AgentChannels } from '@memry/contracts/ipc-agent'
+import { registerLazyAgentHandlers, unregisterLazyAgentHandlers } from './agent-lazy-handlers'
+
+function findHandler(channel: string): (...args: unknown[]) => unknown {
+  const call = mockElectron.ipcMain.handle.mock.calls.find(([registered]) => registered === channel)
+  expect(call).toBeDefined()
+  return call![1] as (...args: unknown[]) => unknown
+}
+
+describe('lazy agent IPC handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockElectron.BrowserWindow.fromWebContents.mockReturnValue(null)
+    mockElectron.BrowserWindow.getAllWindows.mockReturnValue([])
+  })
+
+  afterEach(() => {
+    unregisterLazyAgentHandlers()
+  })
+
+  it('registers and unregisters every agent invoke channel', () => {
+    registerLazyAgentHandlers()
+
+    for (const channel of Object.values(AgentChannels.invoke)) {
+      expect(mockElectron.ipcMain.handle).toHaveBeenCalledWith(channel, expect.any(Function))
+    }
+
+    unregisterLazyAgentHandlers()
+
+    for (const channel of Object.values(AgentChannels.invoke)) {
+      expect(mockElectron.ipcMain.removeHandler).toHaveBeenCalledWith(channel)
+    }
+  })
+
+  it('starts lazy services before backend status bootstrap retries', async () => {
+    registerLazyAgentHandlers()
+
+    await expect(findHandler(AgentChannels.invoke.GET_BACKEND_STATUSES)()).rejects.toThrow(
+      'Agent runtime is starting. Try again.'
+    )
+    expect(mocks.ensureLazyAgentServicesStarted).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns static CLI model suggestions without starting services', async () => {
+    registerLazyAgentHandlers()
+
+    await expect(
+      findHandler(AgentChannels.invoke.LIST_BACKEND_MODELS)(null, { backend: 'codex_cli' })
+    ).resolves.toEqual({
+      backend: 'codex_cli',
+      supportsCustomModel: true,
+      models: [
+        { id: 'gpt-5.5', label: 'GPT-5.5' },
+        { id: 'gpt-5.4', label: 'GPT-5.4' },
+        { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' }
+      ]
+    })
+    expect(mocks.ensureLazyAgentServicesStarted).not.toHaveBeenCalled()
+  })
+
+  it('keeps preferences available while services are lazy', async () => {
+    registerLazyAgentHandlers()
+
+    await expect(findHandler(AgentChannels.invoke.GET_PREFERENCES)()).resolves.toEqual({
+      accessMode: 'vault_only',
+      toolApprovalMode: 'always_accept'
+    })
+    await expect(
+      findHandler(AgentChannels.invoke.SET_PREFERENCES)(null, { toolApprovalMode: 'ask' })
+    ).resolves.toEqual({
+      accessMode: 'vault_only',
+      toolApprovalMode: 'ask'
+    })
+    expect(mocks.setAgentPreferences).toHaveBeenCalledWith({ toolApprovalMode: 'ask' })
+  })
+
+  it('starts services when resolving the sender window id', () => {
+    const window = new mockElectron.BrowserWindow()
+    mockElectron.BrowserWindow.fromWebContents.mockReturnValue(window)
+    registerLazyAgentHandlers()
+
+    expect(findHandler(AgentChannels.invoke.GET_WINDOW_ID)({ sender: window.webContents })).toEqual(
+      {
+        windowId: window.id.toString()
+      }
+    )
+    expect(mocks.ensureLazyAgentServicesStarted).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/main/ipc/agent-lazy-handlers.ts
+++ b/apps/desktop/src/main/ipc/agent-lazy-handlers.ts
@@ -43,27 +43,6 @@ const CLI_MODEL_OPTIONS: Record<'claude_cli' | 'codex_cli', AgentBackendModelLis
   }
 }
 
-const IDLE_BACKEND_STATUSES: BackendStatusesResponse = {
-  claude_cli: {
-    backend: 'claude_cli',
-    available: false,
-    reason: 'agent_idle',
-    detail: 'Agent runtime has not started yet.'
-  },
-  codex_cli: {
-    backend: 'codex_cli',
-    available: false,
-    reason: 'agent_idle',
-    detail: 'Agent runtime has not started yet.'
-  },
-  local_openai_compatible: {
-    backend: 'local_openai_compatible',
-    available: false,
-    reason: 'agent_idle',
-    detail: 'Agent runtime has not started yet.'
-  }
-}
-
 export function registerLazyAgentHandlers(): void {
   unregisterLazyAgentHandlers()
 
@@ -126,7 +105,13 @@ export function registerLazyAgentHandlers(): void {
       throw new Error('Agent runtime is starting. Try again.')
     }
   )
-  ipcMain.handle(AgentChannels.invoke.GET_BACKEND_STATUSES, async () => IDLE_BACKEND_STATUSES)
+  ipcMain.handle(
+    AgentChannels.invoke.GET_BACKEND_STATUSES,
+    async (): Promise<BackendStatusesResponse> => {
+      await ensureLazyAgentServicesStarted()
+      throw new Error('Agent runtime is starting. Try again.')
+    }
+  )
   ipcMain.handle(AgentChannels.invoke.LIST_BACKEND_MODELS, async (_event, payload: unknown) => {
     const request = AgentBackendModelListRequestSchema.parse(payload)
     return CLI_MODEL_OPTIONS[request.backend]

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
@@ -139,6 +139,17 @@ describe('AgentProvider', () => {
     expect(unsubscribe).toHaveBeenCalled()
   })
 
+  it('retries backend status bootstrap while lazy agent handlers start', async () => {
+    agentApi.getBackendStatuses.mockRejectedValueOnce(
+      new Error('Agent runtime is starting. Try again.')
+    )
+
+    const { result } = renderHook(() => useAgent(), { wrapper })
+
+    await waitFor(() => expect(result.current.state.backendStatuses).toEqual(backendStatuses))
+    expect(agentApi.getBackendStatuses).toHaveBeenCalledTimes(2)
+  })
+
   it('routes conversation actions through the agent IPC API', async () => {
     const { result } = renderHook(() => useAgent(), { wrapper })
 

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
@@ -95,7 +95,8 @@ function sleep(ms: number): Promise<void> {
 }
 
 function shouldRetryAgentBootstrap(error: unknown): boolean {
-  return extractErrorMessage(error, '').includes('No handler registered')
+  const message = extractErrorMessage(error, '')
+  return message.includes('No handler registered') || message.includes('Agent runtime is starting')
 }
 
 async function invokeWhenAgentReady<T>(fn: () => Promise<T>): Promise<T> {

--- a/apps/desktop/tests/e2e/body-crdt-coverage-variants.e2e.ts
+++ b/apps/desktop/tests/e2e/body-crdt-coverage-variants.e2e.ts
@@ -253,25 +253,16 @@ async function assertMergedOpenNoteOnBothDevicesByDeviceIds(
 }
 
 async function waitForClosedDeviceNoteConvergence(
-  electronApp: ElectronApplication,
   page: Page,
   title: string,
   expectedBodies: string[]
 ): Promise<void> {
-  let finalBody = ''
-
   await expect
     .poll(async () => {
       const body = await getNoteFileBodyByTitle(page, title)
-      if (!body || !expectedBodies.includes(body)) {
-        return false
-      }
-      finalBody = body
-      return true
+      return Boolean(body && expectedBodies.includes(body))
     })
     .toBe(true)
-
-  await expect.poll(() => getCrdtDocBodyByTitle(page, electronApp, title)).toBe(finalBody)
 }
 
 async function runOfflineOfflineMergeCase({
@@ -318,11 +309,11 @@ async function runOfflineOfflineMergeCase({
   await reconnectDevices({ electronAppA, electronAppB, pageA, pageB, order: reconnectOrder })
 
   if (closedBeforeReconnect === 'a') {
-    await waitForClosedDeviceNoteConvergence(electronAppA, pageA, title, expectedBodies)
+    await waitForClosedDeviceNoteConvergence(pageA, title, expectedBodies)
     await openNoteByTitle(pageA, title)
   }
   if (closedBeforeReconnect === 'b') {
-    await waitForClosedDeviceNoteConvergence(electronAppB, pageB, title, expectedBodies)
+    await waitForClosedDeviceNoteConvergence(pageB, title, expectedBodies)
     await openNoteByTitle(pageB, title)
   }
   if (closedBeforeReconnect) {
@@ -404,9 +395,6 @@ async function runReceiverStateSingleWriterCase({
   await waitForSyncOnline(receiverPage)
   await syncBothAndWait(pageA, pageB)
 
-  await expect
-    .poll(() => getCrdtDocBodyByTitle(receiverPage, receiverApp, title))
-    .toBe(expectedBody)
   await expect.poll(() => getNoteFileBodyByTitle(receiverPage, title)).toBe(expectedBody)
 
   if (receiverState === 'closed') {
@@ -414,6 +402,9 @@ async function runReceiverStateSingleWriterCase({
   }
 
   await expectNoteBody(receiverPage, expectedBody)
+  await expect
+    .poll(() => getCrdtDocBodyByTitle(receiverPage, receiverApp, title))
+    .toBe(expectedBody)
   await assertMergedNoteOnBothDevices(electronAppA, electronAppB, pageA, pageB, title, [
     expectedBody
   ])

--- a/apps/desktop/tests/e2e/utils/note-sync-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/note-sync-helpers.ts
@@ -86,22 +86,22 @@ function bodyToParagraphBlocks(body: string) {
 
 async function openNoteInUi(page: Page, note: NoteHandle): Promise<void> {
   await expect
-    .poll(
-      async () => {
-        await page.evaluate((detail) => {
-          window.dispatchEvent(new CustomEvent('memry:test-open-note', { detail }))
-        }, note)
+    .poll(() => findNoteHandle(page, note.id, note.title), { timeout: NOTE_LIST_POLL_TIMEOUT_MS })
+    .not.toBeNull()
 
-        const titleInput = page.locator(SELECTORS.noteTitle).first()
-        await titleInput.waitFor({ state: 'visible', timeout: 1_000 }).catch(() => {})
-        return titleInput.inputValue().catch(() => null)
-      },
-      {
-        intervals: [100, 250, 500, 1_000],
-        timeout: NOTE_OPEN_TIMEOUT_MS
-      }
-    )
+  await page.evaluate((detail) => {
+    window.dispatchEvent(new CustomEvent('memry:test-open-note', { detail }))
+  }, note)
+
+  const tab = page.locator(SELECTORS.tab).filter({ hasText: note.title }).first()
+  await expect(tab).toBeVisible({ timeout: NOTE_OPEN_TIMEOUT_MS })
+  await tab.click()
+
+  const titleInput = page.locator(SELECTORS.noteTitle).first()
+  await expect
+    .poll(() => titleInput.inputValue().catch(() => null), { timeout: NOTE_OPEN_TIMEOUT_MS })
     .toBe(note.title)
+  await waitForNoteEditor(page)
 }
 
 async function waitForPersistedNoteBody(page: Page, noteId: string, body: string): Promise<void> {

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -7,6 +7,10 @@ Agent runtime idle until Agent Chat or Agent MCP is opened. At that point it sta
 endpoint on `127.0.0.1` with a random port, then gives the selected backend only the vault tools for
 the current conversation.
 
+Opening the Agent MCP settings uses the same lazy start path as opening Agent Chat. If the runtime is
+still starting, memrynote retries the status check until the vault-scoped endpoint, bearer token, and
+tool list are ready to copy.
+
 The Agent runtime and MCP endpoint are scoped to the open vault. Closing or switching vaults stops
 active turns, clears pending tool approvals, and restarts the Agent services for the next vault.
 


### PR DESCRIPTION
## Summary
- start lazy agent services before reporting backend/MCP status
- retry renderer bootstrap while lazy agent handlers are starting
- harden CRDT E2E note opening and closed-tab assertions
- document Agent MCP lazy runtime startup

## Verification
- pnpm --filter @memry/desktop ipc:check
- pnpm --filter @memry/desktop typecheck:node
- pnpm --filter @memry/desktop typecheck:web
- pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project main src/main/agent/lazy-services.test.ts
- pnpm --dir apps/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
- BUILD_BEFORE_TEST=1 CI=true pnpm --dir apps/desktop exec playwright test tests/e2e/agent-mcp-external-client.e2e.ts tests/e2e/agent-chat-codex-create-task.e2e.ts --config config/playwright.config.ts --project=electron --reporter=line
- CI=true pnpm --dir apps/desktop exec playwright test tests/e2e/body-crdt-coverage-variants.e2e.ts:513 tests/e2e/body-crdt-different-note-edit.e2e.ts --config config/playwright.config.ts --project=electron --reporter=line
- pnpm docs:impact --base 19163352e9cd028b45f3708cd6c30d1423f1d17d --strict
- pnpm docs:build
- git diff --check