### PR TITLE
Add checkout success landing page

### DIFF
--- a/apps/landing/api/paddle-checkout-client.test.mjs
+++ b/apps/landing/api/paddle-checkout-client.test.mjs
@@ -42,7 +42,7 @@ describe('paddle checkout response parsing', () => {
     )
 
     const successUrl = buildCheckoutSuccessUrl('https://memrynote.com', 'txn_123')
-    assert.equal(successUrl, 'https://memrynote.com/pricing?checkout=success&transactionId=txn_123')
+    assert.equal(successUrl, 'https://memrynote.com/checkout/success?transactionId=txn_123')
     assert.equal(successUrl.includes('checkout_token'), false)
   })
 })

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -16,6 +16,7 @@ import { DownloadDesktopPage } from '@/pages/DownloadDesktop'
 import { UseCasesPage } from '@/pages/UseCases'
 import { SecurityPage } from '@/pages/Security'
 import { PricingPage } from '@/pages/Pricing'
+import { CheckoutSuccessPage } from '@/pages/CheckoutSuccess'
 import { ChangelogPage } from '@/pages/Changelog'
 import { RoadmapPage } from '@/pages/Roadmap'
 import { TermsPage } from '@/pages/Terms'
@@ -129,6 +130,7 @@ function AppContent() {
           <Route path="/use-cases" element={<UseCasesPage />} />
           <Route path="/security" element={<SecurityPage />} />
           <Route path="/pricing" element={<PricingPage />} />
+          <Route path="/checkout/success" element={<CheckoutSuccessPage />} />
           <Route path="/changelog" element={<ChangelogPage />} />
           <Route path="/roadmap" element={<RoadmapPage />} />
           <Route path="/terms" element={<TermsPage />} />

--- a/apps/landing/src/entry-server.tsx
+++ b/apps/landing/src/entry-server.tsx
@@ -16,6 +16,7 @@ import { DownloadDesktopPage } from '@/pages/DownloadDesktop'
 import { UseCasesPage } from '@/pages/UseCases'
 import { SecurityPage } from '@/pages/Security'
 import { PricingPage } from '@/pages/Pricing'
+import { CheckoutSuccessPage } from '@/pages/CheckoutSuccess'
 import { ChangelogPage } from '@/pages/Changelog'
 import { RoadmapPage } from '@/pages/Roadmap'
 import { TermsPage } from '@/pages/Terms'
@@ -35,6 +36,7 @@ const ROUTE_MAP: Record<string, () => ReactNode> = {
   '/use-cases': () => <UseCasesPage />,
   '/security': () => <SecurityPage />,
   '/pricing': () => <PricingPage />,
+  '/checkout/success': () => <CheckoutSuccessPage />,
   '/changelog': () => <ChangelogPage />,
   '/roadmap': () => <RoadmapPage />,
   '/terms': () => <TermsPage />,

--- a/apps/landing/src/lib/paddle-checkout.ts
+++ b/apps/landing/src/lib/paddle-checkout.ts
@@ -64,8 +64,8 @@ export function buildMemryBillingCompleteUrl(transactionId: string) {
 }
 
 export function buildCheckoutSuccessUrl(origin: string, transactionId: string) {
-  const params = new URLSearchParams({ checkout: 'success', transactionId })
-  return `${origin}/pricing?${params.toString()}`
+  const params = new URLSearchParams({ transactionId })
+  return `${origin}/checkout/success?${params.toString()}`
 }
 
 async function readJsonBody(response: Response) {

--- a/apps/landing/src/pages/CheckoutSuccess.test.ts
+++ b/apps/landing/src/pages/CheckoutSuccess.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { describe, it } from 'node:test'
+
+describe('checkout success page', () => {
+  it('tells paid users payment completed and to sign in in the app for device sync', () => {
+    const source = readFileSync(new URL('./CheckoutSuccess.tsx', import.meta.url), 'utf8')
+
+    assert.match(source, /Payment completed/)
+    assert.match(source, /Sign in to the app to use sync across all your devices/)
+  })
+})

--- a/apps/landing/src/pages/CheckoutSuccess.tsx
+++ b/apps/landing/src/pages/CheckoutSuccess.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
+import { motion } from 'framer-motion'
+import { CheckCircle2, Download, ExternalLink, ShieldCheck } from 'lucide-react'
+import { Container } from '@/components/layout/Container'
+import { Button } from '@/components/ui/button'
+import { BASE_URL, SITE_NAME } from '@/lib/seo'
+import { buildMemryBillingCompleteUrl } from '@/lib/paddle-checkout'
+import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from '@/lib/motion'
+
+export function CheckoutSuccessPage() {
+  const location = useLocation()
+  const transactionId = useMemo(() => {
+    const value = new URLSearchParams(location.search).get('transactionId')?.trim()
+    return value || null
+  }, [location.search])
+  const openMemryUrl = transactionId ? buildMemryBillingCompleteUrl(transactionId) : 'memry://'
+
+  return (
+    <>
+      <Helmet>
+        <title>{`Payment completed - ${SITE_NAME}`}</title>
+        <meta
+          name="description"
+          content="Your memrynote Sync payment completed. Sign in to the app to use sync across all your devices."
+        />
+        <meta name="robots" content="noindex,nofollow" />
+        <link rel="canonical" href={`${BASE_URL}/checkout/success`} />
+      </Helmet>
+      <main>
+        <section className="relative overflow-hidden pt-32 pb-20 md:pt-40 md:pb-28">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[420px] bg-[radial-gradient(ellipse_at_top,rgba(97,132,101,0.16),transparent_60%)]"
+          />
+          <Container size="md">
+            <motion.div
+              initial={BLUR_REVEAL_INITIAL}
+              animate={BLUR_REVEAL_ANIMATE}
+              transition={BLUR_REVEAL_TRANSITION}
+              className="mx-auto flex max-w-2xl flex-col items-center text-center"
+            >
+              <span className="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-sage/12 text-sage">
+                <CheckCircle2 className="h-7 w-7" strokeWidth={2.2} aria-hidden />
+              </span>
+              <p className="mt-6 font-mono-accent text-[11px] uppercase tracking-[0.24em] text-sage">
+                Paddle checkout
+              </p>
+              <h1 className="mt-4 font-serif text-4xl font-normal leading-[1.05] text-ink text-balance md:text-6xl">
+                Payment completed
+              </h1>
+              <p className="mt-6 max-w-xl text-base leading-relaxed text-muted md:text-lg">
+                Sign in to the app to use sync across all your devices. Memry will unlock hosted
+                sync for the account that started this checkout.
+              </p>
+              <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg">
+                  <a href={openMemryUrl}>
+                    <ExternalLink className="h-4 w-4" aria-hidden />
+                    Open Memry
+                  </a>
+                </Button>
+                <Button
+                  asChild
+                  size="lg"
+                  variant="outline"
+                  className="border-ink/15 bg-paper-alt/40 text-ink hover:bg-paper-alt"
+                >
+                  <Link to="/download/desktop">
+                    <Download className="h-4 w-4" aria-hidden />
+                    Download app
+                  </Link>
+                </Button>
+              </div>
+              <div className="mt-10 grid w-full gap-3 text-start sm:grid-cols-2">
+                <div className="rounded-2xl border border-border/60 bg-card p-5 shadow-card">
+                  <ShieldCheck className="h-5 w-5 text-sage" strokeWidth={2} aria-hidden />
+                  <h2 className="mt-4 font-serif text-xl text-ink">End-to-end encrypted</h2>
+                  <p className="mt-2 text-sm leading-relaxed text-muted">
+                    Sync data is encrypted on your device before it leaves the app.
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-border/60 bg-card p-5 shadow-card">
+                  <CheckCircle2 className="h-5 w-5 text-sage" strokeWidth={2} aria-hidden />
+                  <h2 className="mt-4 font-serif text-xl text-ink">All devices</h2>
+                  <p className="mt-2 text-sm leading-relaxed text-muted">
+                    After signing in, the same vault can stay current across desktop devices.
+                  </p>
+                </div>
+              </div>
+            </motion.div>
+          </Container>
+        </section>
+      </main>
+    </>
+  )
+}

--- a/apps/landing/src/pages/Pricing.tsx
+++ b/apps/landing/src/pages/Pricing.tsx
@@ -48,6 +48,39 @@ type CheckoutNotice =
 
 const PURCHASES_ENABLED = false
 
+function getInitialCadence(): Cadence {
+  if (typeof window === 'undefined') return 'annual'
+
+  const intent = parseCheckoutHash(window.location.hash)
+  return intent?.cadence === 'monthly' || intent?.cadence === 'annual' ? intent.cadence : 'annual'
+}
+
+function getInitialCheckoutState(): CheckoutState {
+  if (typeof window === 'undefined') {
+    return { pendingKey: null, error: null, notice: null }
+  }
+
+  const params = new URLSearchParams(window.location.search)
+  if (params.get('checkout') === 'success') {
+    return {
+      pendingKey: null,
+      error: null,
+      notice: { type: 'success', transactionId: params.get('transactionId') }
+    }
+  }
+
+  const intent = parseCheckoutHash(window.location.hash)
+  if (intent) {
+    return {
+      pendingKey: getCheckoutKey(intent.plan, intent.cadence),
+      error: null,
+      notice: null
+    }
+  }
+
+  return { pendingKey: null, error: null, notice: null }
+}
+
 const fadeUp = {
   initial: { opacity: 0, y: 20 },
   whileInView: { opacity: 1, y: 0 },
@@ -56,22 +89,13 @@ const fadeUp = {
 }
 
 export function PricingPage() {
-  const [cadence, setCadence] = useState<Cadence>('annual')
-  const [checkout, setCheckout] = useState<CheckoutState>({
-    pendingKey: null,
-    error: null,
-    notice: null
-  })
+  const [cadence, setCadence] = useState<Cadence>(getInitialCadence)
+  const [checkout, setCheckout] = useState<CheckoutState>(getInitialCheckoutState)
   const consumedCheckoutIntent = useRef(false)
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     if (params.get('checkout') === 'success') {
-      setCheckout({
-        pendingKey: null,
-        error: null,
-        notice: { type: 'success', transactionId: params.get('transactionId') }
-      })
       return
     }
 
@@ -81,12 +105,7 @@ export function PricingPage() {
 
     consumedCheckoutIntent.current = true
     window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`)
-    if (intent.cadence === 'monthly' || intent.cadence === 'annual') {
-      setCadence(intent.cadence)
-    }
 
-    const pendingKey = getCheckoutKey(intent.plan, intent.cadence)
-    setCheckout({ pendingKey, error: null, notice: null })
     let checkoutTransactionId: string | null = null
     let checkoutCompleted = false
     void openPaddleCheckout(intent.plan, intent.cadence, intent.checkoutToken, (event) => {


### PR DESCRIPTION
## Summary
- add a dedicated `/checkout/success` landing route and prerender entry
- send Paddle checkout success redirects to the new success page
- keep pricing checkout intent state initialized on first render and cover success copy/URL behavior

## Tests
- `node --import tsx --test apps/landing/api/paddle-checkout-client.test.mjs apps/landing/src/pages/CheckoutSuccess.test.ts`
- `pnpm --filter @memry/landing lint`
- `pnpm --filter @memry/landing build`
- `git diff --check`