### PR TITLE
fix: preserve editor block indentation

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { markdownToBlocks, yDocToMarkdown } from './blocknote-converter'
+import { markdownToBlocks, yDocToMarkdown, blocksToYFragment } from './blocknote-converter'
 import * as Y from 'yjs'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 
@@ -107,5 +107,47 @@ describe('blocknote-converter code block language', () => {
     expect(result).toContain('Alpha')
     expect(result).toContain('Beta')
     expect(result).toContain('\n\n\n\n')
+  })
+
+  it('preserves nested paragraph indentation through markdown writeback', async () => {
+    const doc = new Y.Doc()
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    const ok = blocksToYFragment(
+      [
+        {
+          id: 'parent',
+          type: 'paragraph',
+          props: { backgroundColor: 'default', textColor: 'default', textAlignment: 'left' },
+          content: [{ type: 'text', text: 'Parent', styles: {} }],
+          children: [
+            {
+              id: 'child',
+              type: 'paragraph',
+              props: { backgroundColor: 'default', textColor: 'default', textAlignment: 'left' },
+              content: [{ type: 'text', text: 'Child', styles: {} }],
+              children: []
+            }
+          ]
+        }
+      ] as never,
+      fragment
+    )
+
+    expect(ok).toBe(true)
+    const markdown = await yDocToMarkdown(doc)
+    expect(markdown).toContain('<!-- memry:block-nesting-level=1 -->')
+
+    const blocks = await markdownToBlocks(markdown!)
+    expect(blocks).toEqual([
+      expect.objectContaining({
+        content: [{ type: 'text', text: 'Parent', styles: {} }],
+        children: [
+          expect.objectContaining({
+            content: [{ type: 'text', text: 'Child', styles: {} }],
+            children: []
+          })
+        ]
+      })
+    ])
   })
 })

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -14,6 +14,11 @@ import {
   assembleMarkdownWithBlanks,
   type MarkdownSegment
 } from '@memry/shared/empty-lines'
+import {
+  createBlockNestingMarker,
+  restoreBlockNesting,
+  splitMarkdownByBlockNestingMarkers
+} from '@memry/shared/block-nesting'
 import { createLogger } from '../lib/logger'
 
 const log = createLogger('BlockNoteConverter')
@@ -96,6 +101,7 @@ export async function yFragmentToBlocks(fragment: Y.XmlFragment): Promise<Block[
 
 function isEmptyParagraph(block: Block): boolean {
   if (block.type !== 'paragraph') return false
+  if (block.children?.length) return false
   const content = block.content as unknown[]
   return !content || content.length === 0
 }
@@ -110,6 +116,80 @@ function createEmptyParagraph(): Block {
   } as unknown as Block
 }
 
+const MARKDOWN_LIST_BLOCK_TYPES = new Set(['bulletListItem', 'numberedListItem', 'checkListItem'])
+
+function canSerializeChildNatively(parent: Block, child: Block): boolean {
+  return (
+    MARKDOWN_LIST_BLOCK_TYPES.has(parent.type as string) &&
+    MARKDOWN_LIST_BLOCK_TYPES.has(child.type as string)
+  )
+}
+
+function hasMarkerSerializedChildren(block: Block): boolean {
+  const children = (block.children ?? []) as Block[]
+  if (children.length === 0) return false
+
+  return children.some(
+    (child) => !canSerializeChildNatively(block, child) || hasMarkerSerializedChildren(child)
+  )
+}
+
+async function parseMarkdownChunkPreservingNesting(
+  editor: ServerBlockNoteEditor,
+  markdown: string
+): Promise<Block[]> {
+  const chunks = splitMarkdownByBlockNestingMarkers(markdown)
+  if (chunks.length === 0) return []
+
+  if (chunks.length === 1 && chunks[0].level === 0) {
+    return editor.tryParseMarkdownToBlocks(chunks[0].text)
+  }
+
+  const blocks: Block[] = []
+  const levels: number[] = []
+
+  for (const chunk of chunks) {
+    const parsed = await editor.tryParseMarkdownToBlocks(chunk.text)
+    blocks.push(...(parsed as Block[]))
+    levels.push(...parsed.map(() => chunk.level))
+  }
+
+  return restoreBlockNesting(blocks, levels)
+}
+
+async function serializeBlocksWithNestingMarkers(
+  editor: ServerBlockNoteEditor,
+  blocks: Block[]
+): Promise<string> {
+  const parts: string[] = []
+  let currentLevel = 0
+
+  const appendBlock = async (block: Block, level: number): Promise<void> => {
+    if (level !== currentLevel) {
+      parts.push(createBlockNestingMarker(level))
+      currentLevel = level
+    }
+
+    const shallowBlock = { ...block, children: [] } as Block
+    const markdown = (await editor.blocksToMarkdownLossy([shallowBlock] as PartialBlock[])).trim()
+    if (markdown) parts.push(markdown)
+
+    for (const child of (block.children ?? []) as Block[]) {
+      await appendBlock(child, level + 1)
+    }
+  }
+
+  for (const block of blocks) {
+    await appendBlock(block, 0)
+  }
+
+  if (currentLevel !== 0) {
+    parts.push(createBlockNestingMarker(0))
+  }
+
+  return parts.join('\n\n')
+}
+
 async function markdownToBlocksPreserving(
   editor: ServerBlockNoteEditor,
   markdown: string
@@ -119,7 +199,7 @@ async function markdownToBlocksPreserving(
 
   for (const seg of segments) {
     if (seg.type === 'content') {
-      const parsed = await editor.tryParseMarkdownToBlocks(seg.text)
+      const parsed = await parseMarkdownChunkPreservingNesting(editor, seg.text)
       blocks.push(...parsed)
     } else {
       for (let i = 0; i < seg.extraLines; i++) {
@@ -147,6 +227,20 @@ async function blocksToMarkdownPreserving(
         contentGroup = []
       }
       emptyCount++
+    } else if (hasMarkerSerializedChildren(block)) {
+      if (contentGroup.length > 0) {
+        const md = await editor.blocksToMarkdownLossy(contentGroup as PartialBlock[])
+        segments.push({ type: 'content', text: md })
+        contentGroup = []
+      }
+      if (emptyCount > 0) {
+        segments.push({ type: 'gap', extraLines: emptyCount })
+        emptyCount = 0
+      }
+      segments.push({
+        type: 'content',
+        text: await serializeBlocksWithNestingMarkers(editor, [block])
+      })
     } else {
       if (emptyCount > 0) {
         segments.push({ type: 'gap', extraLines: emptyCount })

--- a/apps/desktop/src/renderer/src/components/component-gap-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/component-gap-surfaces.test.tsx
@@ -417,4 +417,19 @@ describe('major renderer gap surfaces', () => {
     )
     expect(screen.getByTestId('blocknote-view')).toHaveAttribute('data-editable', 'false')
   })
+
+  it('restores inbox editor indentation from BlockNote nesting metadata', async () => {
+    const parent = { type: 'paragraph', content: 'Parent', children: [] }
+    const child = { type: 'paragraph', content: 'Child', children: [] }
+    mocks.tryParseHTMLToBlocks.mockReturnValueOnce([parent, child])
+
+    render(<InboxContentEditor initialContent='<p>Parent</p><p data-nesting-level="1">Child</p>' />)
+
+    await waitFor(() =>
+      expect(mocks.replaceBlocks).toHaveBeenCalledWith(
+        [{ type: 'paragraph', content: 'First title' }],
+        [{ ...parent, children: [{ ...child, children: [] }] }]
+      )
+    )
+  })
 })

--- a/apps/desktop/src/renderer/src/components/inbox-detail/inbox-content-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/inbox-content-editor.tsx
@@ -17,8 +17,19 @@ import { cn } from '@/lib/utils'
 import { createLogger } from '@/lib/logger'
 import { extractTitleFromBlocks } from '@/lib/blocknote-title'
 import { useT } from '@memry/i18n/renderer'
+import { restoreBlockNesting } from '@memry/shared/block-nesting'
 
 const log = createLogger('Component:InboxContentEditor')
+
+function extractTopLevelNestingLevels(html: string): number[] {
+  const template = document.createElement('template')
+  template.innerHTML = html
+
+  return Array.from(template.content.children).map((element) => {
+    const value = Number(element.getAttribute('data-nesting-level') ?? 0)
+    return Number.isInteger(value) && value > 0 ? value : 0
+  })
+}
 
 interface InboxContentEditorProps {
   /** Initial content (plain text or HTML) */
@@ -87,8 +98,13 @@ export const InboxContentEditor = memo(function InboxContentEditor({
           // Try to parse as HTML first, fallback to plain text
           try {
             const blocks = editor.tryParseHTMLToBlocks(initialContent)
-            if (blocks.length > 0) {
-              editor.replaceBlocks(editor.document, blocks)
+            const nestingLevels = extractTopLevelNestingLevels(initialContent)
+            const nextBlocks =
+              nestingLevels.some((level) => level > 0) && nestingLevels.length === blocks.length
+                ? restoreBlockNesting(blocks, nestingLevels)
+                : blocks
+            if (nextBlocks.length > 0) {
+              editor.replaceBlocks(editor.document, nextBlocks)
             } else {
               // If HTML parsing gives empty result, try as plain text
               const plainTextBlock = {

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
@@ -305,6 +305,74 @@ describe('serializeBlocksPreservingBlanks', () => {
       expect.objectContaining({ type: 'file' })
     ])
   })
+
+  it('round-trips nested paragraph indentation with hidden markdown markers', async () => {
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) =>
+        markdown
+          .split(/\n\n+/)
+          .filter((line) => line.trim())
+          .map((line) => ({
+            type: 'paragraph',
+            props: {},
+            content: [{ type: 'text', text: line.trim(), styles: {} }],
+            children: []
+          }))
+      ),
+      blocksToMarkdownLossy: vi.fn(async (blocks: any[]) =>
+        blocks
+          .map((block) =>
+            Array.isArray(block.content)
+              ? block.content.map((content: any) => content.text ?? '').join('')
+              : ''
+          )
+          .filter(Boolean)
+          .join('\n\n')
+      )
+    }
+
+    const markdown = await serializeBlocksPreservingBlanks(editor, [
+      {
+        type: 'paragraph',
+        props: {},
+        content: [{ type: 'text', text: 'Parent', styles: {} }],
+        children: [
+          {
+            type: 'paragraph',
+            props: {},
+            content: [{ type: 'text', text: 'Child', styles: {} }],
+            children: []
+          }
+        ]
+      },
+      {
+        type: 'paragraph',
+        props: {},
+        content: [{ type: 'text', text: 'Sibling', styles: {} }],
+        children: []
+      }
+    ] as any[])
+
+    expect(markdown).toContain('<!-- memry:block-nesting-level=1 -->')
+    expect(markdown).toContain('<!-- memry:block-nesting-level=0 -->')
+
+    const blocks = await parseMarkdownPreservingBlanks(editor, markdown)
+    expect(blocks).toEqual([
+      expect.objectContaining({
+        content: [{ type: 'text', text: 'Parent', styles: {} }],
+        children: [
+          expect.objectContaining({
+            content: [{ type: 'text', text: 'Child', styles: {} }],
+            children: []
+          })
+        ]
+      }),
+      expect.objectContaining({
+        content: [{ type: 'text', text: 'Sibling', styles: {} }],
+        children: []
+      })
+    ])
+  })
 })
 
 describe('isEmptyParagraph', () => {
@@ -312,6 +380,7 @@ describe('isEmptyParagraph', () => {
     expect(isEmptyParagraph({ type: 'heading', content: [] } as any)).toBe(false)
     expect(isEmptyParagraph({ type: 'paragraph', content: undefined } as any)).toBe(true)
     expect(isEmptyParagraph({ type: 'paragraph', content: [] } as any)).toBe(true)
+    expect(isEmptyParagraph({ type: 'paragraph', content: [], children: [{}] } as any)).toBe(false)
     expect(isEmptyParagraph({ type: 'paragraph', content: ['text'] } as any)).toBe(false)
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
@@ -6,6 +6,11 @@ import {
   assembleMarkdownWithBlanks,
   type MarkdownSegment
 } from '@memry/shared/empty-lines'
+import {
+  createBlockNestingMarker,
+  restoreBlockNesting,
+  splitMarkdownByBlockNestingMarkers
+} from '@memry/shared/block-nesting'
 import { splitMarkdownByCallouts, serializeCalloutBlock } from './callout-block'
 import { extractYouTubeVideoId } from '@/lib/youtube-utils'
 import { serializeYoutubeEmbed } from './youtube-embed-block'
@@ -14,8 +19,80 @@ import { parseFileBlockMarker, serializeFileBlock, type FileBlockProps } from '.
 
 export function isEmptyParagraph(block: Block): boolean {
   if (block.type !== 'paragraph') return false
+  if (block.children?.length) return false
   const content = block.content as unknown[]
   return !content || content.length === 0
+}
+
+const MARKDOWN_LIST_BLOCK_TYPES = new Set(['bulletListItem', 'numberedListItem', 'checkListItem'])
+
+function canSerializeChildNatively(parent: Block, child: Block): boolean {
+  return (
+    MARKDOWN_LIST_BLOCK_TYPES.has(parent.type as string) &&
+    MARKDOWN_LIST_BLOCK_TYPES.has(child.type as string)
+  )
+}
+
+function hasMarkerSerializedChildren(block: Block): boolean {
+  const children = (block.children ?? []) as Block[]
+  if (children.length === 0) return false
+
+  return children.some(
+    (child) => !canSerializeChildNatively(block, child) || hasMarkerSerializedChildren(child)
+  )
+}
+
+async function parseMarkdownChunkPreservingNesting(
+  editor: any,
+  markdown: string
+): Promise<Block[]> {
+  const chunks = splitMarkdownByBlockNestingMarkers(markdown)
+  if (chunks.length === 0) return []
+
+  if (chunks.length === 1 && chunks[0].level === 0) {
+    return editor.tryParseMarkdownToBlocks(chunks[0].text)
+  }
+
+  const blocks: Block[] = []
+  const levels: number[] = []
+
+  for (const chunk of chunks) {
+    const parsed = await editor.tryParseMarkdownToBlocks(chunk.text)
+    blocks.push(...parsed)
+    levels.push(...parsed.map(() => chunk.level))
+  }
+
+  return restoreBlockNesting(blocks, levels)
+}
+
+async function serializeBlocksWithNestingMarkers(editor: any, blocks: Block[]): Promise<string> {
+  const parts: string[] = []
+  let currentLevel = 0
+
+  const appendBlock = async (block: Block, level: number): Promise<void> => {
+    if (level !== currentLevel) {
+      parts.push(createBlockNestingMarker(level))
+      currentLevel = level
+    }
+
+    const shallowBlock = { ...block, children: [] } as Block
+    const markdown = (await editor.blocksToMarkdownLossy([shallowBlock])).trim()
+    if (markdown) parts.push(markdown)
+
+    for (const child of (block.children ?? []) as Block[]) {
+      await appendBlock(child, level + 1)
+    }
+  }
+
+  for (const block of blocks) {
+    await appendBlock(block, 0)
+  }
+
+  if (currentLevel !== 0) {
+    parts.push(createBlockNestingMarker(0))
+  }
+
+  return parts.join('\n\n')
 }
 
 export function sanitizeBlockIds(blocks: Block[]): Block[] {
@@ -80,7 +157,7 @@ export async function parseMarkdownPreservingBlanks(
                 props: part.props
               } as unknown as Block)
             } else {
-              const parsed = await editor.tryParseMarkdownToBlocks(part.text)
+              const parsed = await parseMarkdownChunkPreservingNesting(editor, part.text)
               blocks.push(...parsed)
             }
           }
@@ -167,6 +244,13 @@ export async function serializeBlocksPreservingBlanks(
     } else if (isEmptyParagraph(block)) {
       await flushContent()
       emptyCount++
+    } else if (hasMarkerSerializedChildren(block)) {
+      await flushContent()
+      flushGap()
+      segments.push({
+        type: 'content',
+        text: await serializeBlocksWithNestingMarkers(editor, [block])
+      })
     } else {
       flushGap()
       contentGroup.push(block)

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -73,6 +73,8 @@ A separate queue from `SyncQueueManager`:
 
 BlockNote uses Yjs natively. The renderer's BlockNote editor binds to the renderer-side Y.Doc proxy provided by the IPC provider; edits flow through main and back to disk.
 
+Markdown cannot represent arbitrary nested BlockNote paragraphs. Note markdown export and CRDT writeback preserve those unsupported child blocks with hidden nesting markers, then restore them when a note reloads. Inbox note reload also reads BlockNote's saved `data-nesting-level` HTML metadata so captured note indentation round-trips through the editor.
+
 ## Files Worth Knowing
 
 ```

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -74,6 +74,7 @@ A separate queue from `SyncQueueManager`:
 BlockNote uses Yjs natively. The renderer's BlockNote editor binds to the renderer-side Y.Doc proxy provided by the IPC provider; edits flow through main and back to disk.
 
 Markdown cannot represent arbitrary nested BlockNote paragraphs. Note markdown export and CRDT writeback preserve those unsupported child blocks with hidden nesting markers, then restore them when a note reloads. Inbox note reload also reads BlockNote's saved `data-nesting-level` HTML metadata so captured note indentation round-trips through the editor.
+Marker parsing trims imported markdown with a linear scan so malformed or very large note bodies cannot trigger regex backtracking during reload.
 
 ## Files Worth Knowing
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
     "./utc": "./src/utc.ts",
     "./file-types": "./src/file-types.ts",
     "./empty-lines": "./src/empty-lines.ts",
+    "./block-nesting": "./src/block-nesting.ts",
     "./youtube": "./src/youtube.ts"
   },
   "types": "./src/index.ts",

--- a/packages/shared/src/block-nesting.test.ts
+++ b/packages/shared/src/block-nesting.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createBlockNestingMarker,
+  restoreBlockNesting,
+  splitMarkdownByBlockNestingMarkers
+} from './block-nesting'
+
+describe('block nesting helpers', () => {
+  it('splits markdown by hidden nesting markers', () => {
+    const markdown = [
+      'Parent',
+      '',
+      createBlockNestingMarker(1),
+      'Child',
+      '',
+      createBlockNestingMarker(0),
+      'Sibling'
+    ].join('\n')
+
+    expect(splitMarkdownByBlockNestingMarkers(markdown)).toEqual([
+      { level: 0, text: 'Parent' },
+      { level: 1, text: 'Child' },
+      { level: 0, text: 'Sibling' }
+    ])
+  })
+
+  it('ignores marker-looking text inside code fences', () => {
+    const markdown = [
+      '```html',
+      '<!-- memry:block-nesting-level=1 -->',
+      '```',
+      '',
+      createBlockNestingMarker(1),
+      'Child'
+    ].join('\n')
+
+    expect(splitMarkdownByBlockNestingMarkers(markdown)).toEqual([
+      { level: 0, text: '```html\n<!-- memry:block-nesting-level=1 -->\n```' },
+      { level: 1, text: 'Child' }
+    ])
+  })
+
+  it('rebuilds nested block children from flat blocks and levels', () => {
+    const blocks = [
+      { id: 'parent', children: [] },
+      { id: 'child', children: [] },
+      { id: 'sibling', children: [] }
+    ]
+
+    expect(restoreBlockNesting(blocks, [0, 1, 0])).toEqual([
+      { id: 'parent', children: [{ id: 'child', children: [] }] },
+      { id: 'sibling', children: [] }
+    ])
+  })
+})

--- a/packages/shared/src/block-nesting.ts
+++ b/packages/shared/src/block-nesting.ts
@@ -91,5 +91,11 @@ function normalizeNestingLevel(level: number): number {
 }
 
 function trimEdgeNewlines(text: string): string {
-  return text.replace(/^\n+/, '').replace(/\n+$/, '')
+  let start = 0
+  let end = text.length
+
+  while (start < end && text.charCodeAt(start) === 10) start += 1
+  while (end > start && text.charCodeAt(end - 1) === 10) end -= 1
+
+  return text.slice(start, end)
 }

--- a/packages/shared/src/block-nesting.ts
+++ b/packages/shared/src/block-nesting.ts
@@ -1,0 +1,95 @@
+export interface BlockWithChildren<T> {
+  children?: T[]
+}
+
+export interface MarkdownBlockNestingChunk {
+  level: number
+  text: string
+}
+
+const BLOCK_NESTING_MARKER_REGEX = /^<!--\s*memry:block-nesting-level=(\d+)\s*-->$/
+
+export function createBlockNestingMarker(level: number): string {
+  return `<!-- memry:block-nesting-level=${normalizeNestingLevel(level)} -->`
+}
+
+export function splitMarkdownByBlockNestingMarkers(markdown: string): MarkdownBlockNestingChunk[] {
+  const chunks: MarkdownBlockNestingChunk[] = []
+  const lines = markdown.split('\n')
+  let currentLevel = 0
+  let buffer: string[] = []
+  let inCodeFence = false
+  let openFence = ''
+
+  const flush = (): void => {
+    const text = trimEdgeNewlines(buffer.join('\n'))
+    if (text.trim()) chunks.push({ level: currentLevel, text })
+    buffer = []
+  }
+
+  for (const line of lines) {
+    const fenceMatch = line.match(/^( {0,3})(```|~~~)/)
+    if (fenceMatch) {
+      buffer.push(line)
+      const fence = fenceMatch[2]
+      if (!inCodeFence) {
+        inCodeFence = true
+        openFence = fence
+      } else if (fence === openFence) {
+        inCodeFence = false
+        openFence = ''
+      }
+      continue
+    }
+
+    const markerMatch = inCodeFence ? null : line.match(BLOCK_NESTING_MARKER_REGEX)
+    if (markerMatch) {
+      flush()
+      currentLevel = normalizeNestingLevel(Number(markerMatch[1]))
+      continue
+    }
+
+    buffer.push(line)
+  }
+
+  flush()
+  return chunks
+}
+
+export function restoreBlockNesting<T extends BlockWithChildren<T>>(
+  blocks: readonly T[],
+  levels: readonly number[]
+): T[] {
+  const roots: T[] = []
+  const stack: T[] = []
+
+  blocks.forEach((block, index) => {
+    const level = normalizeNestingLevel(levels[index] ?? 0)
+    const nextBlock = {
+      ...block,
+      children: Array.isArray(block.children) ? [...block.children] : []
+    } as T
+
+    if (level === 0 || !stack[level - 1]) {
+      roots.push(nextBlock)
+      stack[0] = nextBlock
+      stack.length = 1
+      return
+    }
+
+    const parent = stack[level - 1]
+    parent.children = [...(parent.children ?? []), nextBlock]
+    stack[level] = nextBlock
+    stack.length = level + 1
+  })
+
+  return roots
+}
+
+function normalizeNestingLevel(level: number): number {
+  return Number.isInteger(level) && level > 0 ? level : 0
+}
+
+function trimEdgeNewlines(text: string): string {
+  return text.replace(/^\n+/, '').replace(/\n+$/, '')
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './utc'
 export * from './file-types'
 export * from './empty-lines'
+export * from './block-nesting'
 export * from './youtube'


### PR DESCRIPTION
## Summary
- Preserve non-list BlockNote child indentation in note markdown saves and CRDT writeback with hidden nesting markers.
- Restore Inbox note indentation from BlockNote HTML nesting metadata on reload.
- Document the persistence behavior.

Fixes #438

## Verification
- pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/components/note/content-area/markdown-utils.test.ts src/renderer/src/components/component-gap-surfaces.test.tsx
- pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/sync/blocknote-converter.test.ts
- pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project shared ../../packages/shared/src/block-nesting.test.ts
- pnpm --filter @memry/shared typecheck && pnpm --filter @memry/desktop typecheck:web && pnpm --filter @memry/desktop typecheck:node
- PYTHON=/usr/bin/python3 pnpm --filter @memry/desktop rebuild:node
- PYTHON=/usr/bin/python3 pnpm --filter @memry/desktop rebuild:electron
- pnpm docs:impact --base 6d79508120f9df6bd9360a9a435440c6c44ebe52 --strict
- pnpm docs:build
- git diff --check