### PR TITLE
fix: scope undo to suggestions while suggestion mode is active

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/review/review-ui.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-ui.test.tsx
@@ -1218,6 +1218,96 @@ describe('review UI', () => {
     expect(result.current.marks).toHaveLength(1)
   })
 
+  it('undoes a typed suggestion via Mod+Z', () => {
+    const { result } = renderHook(() =>
+      useCriticMarkupReview({ markdown: 'base', onMarkdownChange: vi.fn() })
+    )
+
+    act(() => {
+      result.current.startSuggestionMode()
+      result.current.addSuggestionMark({ kind: 'addition', visibleText: ' added', start: 4 })
+    })
+    expect(result.current.marks).toHaveLength(1)
+
+    const undoEvent = new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    act(() => {
+      document.dispatchEvent(undoEvent)
+    })
+
+    expect(undoEvent.defaultPrevented).toBe(true)
+    expect(result.current.plainMarkdown).toBe('base')
+    expect(result.current.marks).toHaveLength(0)
+  })
+
+  it('coalesces a contiguous typing run into a single undo step', () => {
+    const { result } = renderHook(() =>
+      useCriticMarkupReview({ markdown: 'base', onMarkdownChange: vi.fn() })
+    )
+
+    act(() => {
+      result.current.startSuggestionMode()
+      result.current.addSuggestionMark({ kind: 'addition', visibleText: 'a', start: 4 })
+      result.current.addSuggestionMark({ kind: 'addition', visibleText: 'b', start: 5 })
+    })
+    expect(result.current.marks).toHaveLength(1)
+    expect(result.current.marks[0]).toMatchObject({ kind: 'addition', visibleText: 'ab' })
+
+    act(() => {
+      expect(result.current.undoLastReviewAction()).toBe(true)
+    })
+
+    expect(result.current.plainMarkdown).toBe('base')
+    expect(result.current.marks).toHaveLength(0)
+  })
+
+  it('blocks Mod+Z from the note body while suggestion mode is active', () => {
+    const { result } = renderHook(() =>
+      useCriticMarkupReview({ markdown: 'base', onMarkdownChange: vi.fn() })
+    )
+
+    act(() => {
+      result.current.startSuggestionMode()
+    })
+
+    const undoEvent = new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    act(() => {
+      document.dispatchEvent(undoEvent)
+    })
+
+    expect(undoEvent.defaultPrevented).toBe(true)
+    expect(result.current.plainMarkdown).toBe('base')
+  })
+
+  it('lets Mod+Z reach the note body when suggestion mode is inactive', () => {
+    const { result } = renderHook(() =>
+      useCriticMarkupReview({ markdown: 'base', onMarkdownChange: vi.fn() })
+    )
+
+    expect(result.current.isSuggestionModeActive).toBe(false)
+
+    const undoEvent = new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    act(() => {
+      document.dispatchEvent(undoEvent)
+    })
+
+    expect(undoEvent.defaultPrevented).toBe(false)
+  })
+
   it('serializes a repeated-letter deletion at the provided source offset', () => {
     const markdown = `## Why I keep at it
 

--- a/apps/desktop/src/renderer/src/components/note/review/use-critic-markup-review.ts
+++ b/apps/desktop/src/renderer/src/components/note/review/use-critic-markup-review.ts
@@ -19,6 +19,14 @@ import {
   proseMirrorDocPosToEditorOffset,
   proseMirrorVisibleText
 } from '../content-area/critic-markup-offset-map'
+import {
+  isNativeTextInput,
+  isUndoKeyboardShortcut,
+  pushReviewUndoEntry,
+  snapshotReviewState,
+  type ReviewUndoEntry,
+  type ReviewUndoSnapshot
+} from './review-undo'
 
 interface UseCriticMarkupReviewParams {
   markdown: string
@@ -37,16 +45,6 @@ export interface DraftSelectionRect {
   bottom: number
   left: number
   right: number
-}
-
-interface ReviewUndoEntry {
-  before: ReviewUndoSnapshot
-  afterSerialized: string
-}
-
-interface ReviewUndoSnapshot {
-  plainMarkdown: string
-  marks: CriticMarkupMark[]
 }
 
 export interface AddSuggestionMarkInput {
@@ -307,6 +305,24 @@ export function useCriticMarkupReview({
       if (input.start === undefined) return
       const start = input.start
 
+      // Snapshot before any mutation. handlePlainMarkdownChange is debounced
+      // while this runs synchronously in beforeinput, so the refs still hold the
+      // pre-keystroke state here — the correct `before` for the undo entry.
+      // Snapshot before any mutation. handlePlainMarkdownChange is debounced
+      // while this runs synchronously in beforeinput, so the refs still hold the
+      // pre-keystroke state here — the correct `before` for the undo entry.
+      // coalesceKey is the edited mark id: consecutive keystrokes on the same
+      // suggestion collapse into one undo step.
+      const before = snapshotReviewState(plainMarkdownRef.current, marksRef.current)
+      const commit = (
+        nextPlainMarkdown: string,
+        nextMarks: CriticMarkupMark[],
+        coalesceKey: string
+      ): void => {
+        pushReviewUndoEntry(undoStackRef.current, before, nextPlainMarkdown, nextMarks, coalesceKey)
+        persist(nextPlainMarkdown, nextMarks)
+      }
+
       let nextPlainMarkdown = plainMarkdownRef.current
       let currentMarks = marksRef.current
 
@@ -351,14 +367,15 @@ export function useCriticMarkupReview({
               }
             : mark
         )
-        persist(nextPlainMarkdown, nextMarks)
+        commit(nextPlainMarkdown, nextMarks, previousMark.id)
         return
       }
 
       if (input.kind === 'deletion') {
+        const deletionRunKey = previousMark?.kind === 'deletion' ? previousMark.id : undefined
         const mergedDeletionMarks = mergeAdjacentDeletionMark(currentMarks, input, start)
-        if (mergedDeletionMarks) {
-          persist(nextPlainMarkdown, mergedDeletionMarks)
+        if (mergedDeletionMarks && deletionRunKey) {
+          commit(nextPlainMarkdown, mergedDeletionMarks, deletionRunKey)
           return
         }
       }
@@ -384,7 +401,7 @@ export function useCriticMarkupReview({
           end
         }
       ]
-      persist(nextPlainMarkdown, nextMarks)
+      commit(nextPlainMarkdown, nextMarks, id)
     },
     [persist]
   )
@@ -471,10 +488,20 @@ export function useCriticMarkupReview({
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (!isUndoKeyboardShortcut(event)) return
       if (isNativeTextInput(event.target)) return
-      if (!undoLastReviewAction()) return
 
-      event.preventDefault()
-      event.stopPropagation()
+      if (undoLastReviewAction()) {
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+
+      // Nothing left in the suggestion undo stack. While suggestion mode is
+      // active, keep undo scoped to suggestions — never let it reach the note
+      // body.
+      if (isSuggestionModeActiveRef.current) {
+        event.preventDefault()
+        event.stopPropagation()
+      }
     }
 
     document.addEventListener('keydown', handleKeyDown, true)
@@ -544,37 +571,6 @@ export function useCriticMarkupReview({
     setMarkPositions: updateMarkPositions,
     replaceMarksFromYjs
   }
-}
-
-function snapshotReviewState(plainMarkdown: string, marks: CriticMarkupMark[]): ReviewUndoSnapshot {
-  return {
-    plainMarkdown,
-    marks: marks.map((mark) => ({ ...mark }))
-  }
-}
-
-function pushReviewUndoEntry(
-  stack: ReviewUndoEntry[],
-  before: ReviewUndoSnapshot,
-  afterPlainMarkdown: string,
-  afterMarks: CriticMarkupMark[]
-): void {
-  stack.push({
-    before,
-    afterSerialized: serializeCriticMarkup(afterPlainMarkdown, afterMarks)
-  })
-  if (stack.length > 50) stack.splice(0, stack.length - 50)
-}
-
-function isUndoKeyboardShortcut(event: KeyboardEvent): boolean {
-  if (event.key.toLowerCase() !== 'z') return false
-  if (event.altKey || event.shiftKey) return false
-  return event.metaKey || event.ctrlKey
-}
-
-function isNativeTextInput(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false
-  return Boolean(target.closest('input, textarea, select'))
 }
 
 function areCriticMarkupMarksEqual(first: CriticMarkupMark[], second: CriticMarkupMark[]): boolean {

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -91,6 +91,8 @@ Select text to open the floating toolbar. **Comment** creates an anchored review
 
 While suggestion mode is active, inserts, deletes, and replacements stay visible as review marks instead of raw CriticMarkup. Selected text deleted with Backspace remains visible as a deletion suggestion, including mouse-drag and block-marquee selections, so reopening the note or journal entry restores the deletion card and inline mark. The right rail aligns each card beside the marked text. Comment cards can be resolved or deleted; suggestion cards can be accepted or rejected.
 
+While suggestion mode is active, undo (`Cmd/Ctrl+Z`) is scoped to suggestions: it steps back through your typed suggestions and accept/reject/comment actions — a continuous typing run undoes as one step — and never touches the underlying note body. Once there are no suggestion changes left to undo, the shortcut does nothing. Turn suggestion mode off to undo the note itself again.
+
 ## What Notes Are Made Of
 
 Under the hood, every note is a Yjs CRDT (`Y.Doc`). Markdown is a derived export, not the canonical form — this is what lets edits from two devices merge cleanly. See [CRDT & Notes Sync](/architecture/crdt) for details.


### PR DESCRIPTION
## Problem

In the note editor, `Cmd/Ctrl+Z` fell through to ProseMirror/Yjs and undid the **note body** once the suggestion-review undo stack was empty. Worse, typed suggestions are dispatched with `addToHistory: false` (so they never enter editor history and were never pushed to the review undo stack) — so typing a suggestion then pressing undo skipped past it and hit the underlying note. Result: undo hit the note instead of the suggestion.

## Change

While **suggestion mode is active** (the `Suggesting…` pill):
- Undo is scoped to suggestions and **never reaches the note body**. When the suggestion stack is empty, the shortcut is a no-op. Outside suggestion mode, behavior is unchanged (review undo first, then native note undo).
- **Typed suggestions are now undoable.** `addSuggestionMark` — the single funnel for typed additions/deletions/substitutions — records review-undo entries. The `before` snapshot is correct because it is taken synchronously in `beforeinput`, while `handlePlainMarkdownChange` is debounced. A contiguous typing run on one mark coalesces into a single undo step (via `coalesceKey` = mark id).

## Cleanup

The hook carried stale local copies of `snapshotReviewState` / `pushReviewUndoEntry` / `isUndoKeyboardShortcut` / `isNativeTextInput`, while an orphaned `review-undo.ts` already had better versions — including a pre-staged `coalesceKey` built for exactly this feature. Wired the hook to `review-undo.ts` and deleted the duplicates. This also clears a pre-existing `max-lines` lint error (the file was 808 > 800 on `main`).

## Verification

- `pnpm --filter @memry/desktop typecheck:web` — clean
- `pnpm --filter @memry/desktop lint` — 0 errors (was 1 pre-existing)
- `review-ui.test.tsx` — 40 passed, incl. 4 new cases: typed-suggestion undo, run coalescing, note-body blocked in suggestion mode, note-body reachable when inactive
- `pnpm docs:impact --base origin/main --strict` — covered; `pnpm docs:build` — passes

E2E not yet run (needs `out/` rebuild). Can add a `critic-markup-review.e2e.ts` case if wanted.