### PR TITLE
test(desktop): block real OS keychain access with a global keytar mock

### DIFF
--- a/apps/desktop/tests/setup.ts
+++ b/apps/desktop/tests/setup.ts
@@ -15,6 +15,26 @@ if (!globalWithJest.jest) {
   globalWithJest.jest = vi
 }
 
+// Block real OS keychain access from tests. Unmocked transitive imports of keytar
+// (e.g. local-sync-effects → isMemryUserSignedIn → retrieveKey) otherwise read the
+// real 'com.memry.sync' items, triggering macOS "node wants to use your confidential
+// information" prompts on every suite run. Per-file vi.mock('keytar', ...) factories
+// still take precedence. The env check must live inside the factory: vi.mock calls
+// are hoisted, so an `if` around the call is bypassed. KEYCHAIN_E2E=1 opts back into
+// the real keychain for keychain.e2e.test.ts, which roundtrips 'com.memry.sync.test'.
+vi.mock('keytar', async (importOriginal) => {
+  if (process.env.KEYCHAIN_E2E === '1') return importOriginal()
+  return {
+    default: {
+      getPassword: vi.fn(async () => null),
+      setPassword: vi.fn(async () => undefined),
+      deletePassword: vi.fn(async () => false),
+      findPassword: vi.fn(async () => null),
+      findCredentials: vi.fn(async () => [])
+    }
+  }
+})
+
 // Mock crypto.randomUUID for consistent IDs in tests
 if (typeof globalThis.crypto === 'undefined') {
   Object.defineProperty(globalThis, 'crypto', {


### PR DESCRIPTION
## Problem

Running the desktop main vitest suite triggers macOS prompts: **"node wants to use your confidential information store in 'com.memry.sync' in your keychain"** — randomly, even with the app closed.

Instrumenting `process.dlopen` showed the suite makes **32 real `keytar.getPassword('com.memry.sync', 'refresh-token')` calls** per run (real binding loaded in 28 workers). The path: tests exercising task/calendar mutation side effects → `local-sync-effects.ts` → `syncLocalSourceToGoogleCalendar` → `isMemryUserSignedIn` (`auth-state.ts`) → `retrieveKey(REFRESH_TOKEN)` → real OS keychain. Most test files mock keytar; files reaching this path transitively mock neither `keytar` nor `auth-state`.

Prompts never stop because dev Electron (`adhoc,linker-signed`) and the packaged app (`adhoc`) have no stable code-signing identity, and token rotation re-creates the keychain item — resetting any "Always Allow" granted to `node`. Tests also end up reading the developer's real production refresh token.

## Fix

Global `vi.mock('keytar', ...)` in `apps/desktop/tests/setup.ts` returning inert defaults (`getPassword` → `null`, etc.). Per-file `vi.mock('keytar', ...)` factories still take precedence.

Gotcha: the `KEYCHAIN_E2E` check must live **inside** the mock factory via `importOriginal` — `vi.mock` calls are hoisted, so wrapping the call in a conditional is silently bypassed (verified: it broke the real-keychain e2e test).

## Verification

- Before: 41 real keytar loads / 32 real keychain calls per `test:main` run (dlopen shim)
- After: **zero** real keytar loads or calls
- Suite: 3007 passed; 1 pre-existing failure (`inbox-query-handlers` heatmap, fails identically on the unmodified tree, no keytar involvement)
- `KEYCHAIN_E2E=1` keychain.e2e.test.ts: PASS against the real OS keychain (`com.memry.sync.test`)
- Lint 0 errors, `typecheck:node` clean, docs gate: no docs-relevant changes

## Follow-ups (not in this PR)

- Clean up ~150 stale `*-e2e-<uuid>-A/B` items polluting `com.memry.sync`; point two-device E2E runs at a dedicated `com.memry.sync.e2e` service
- Timezone-dependent `inbox-query-handlers` heatmap test flake