### PR TITLE
fix(notes): stop blank line growing above inline tasks on reopen

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -106,7 +106,11 @@ describe('blocknote-converter code block language', () => {
     ).toBe(true)
     expect(result).toContain('Alpha')
     expect(result).toContain('Beta')
-    expect(result).toContain('\n\n\n\n')
+    // The single extra blank line is preserved exactly, not grown. Before the
+    // serializer trimmed the trailing newline blocksToMarkdownLossy appends, this
+    // round-trip emitted 'Alpha\n\n\n\nBeta' — one extra blank line per save (the
+    // inline-task "new line above the task on reopen" bug).
+    expect(result).toBe('Alpha\n\n\nBeta')
   })
 
   it('applies block color markers when parsing markdown to blocks', async () => {
@@ -186,6 +190,28 @@ describe('blocknote-converter code block language', () => {
       expect.objectContaining({ kind: 'deletion', visibleText: 'deleted', start: 5, end: 12 }),
       expect.objectContaining({ kind: 'addition', visibleText: 'added', start: 17, end: 22 })
     ])
+  })
+
+  it('does not accumulate blank lines around inline task list items on reopen', async () => {
+    // Reproduces the inline-task bug: a task checklist followed by a gap and more
+    // content. Each markdown → Yjs → markdown round-trip models one note reopen;
+    // it must be a fixed point, otherwise a blank line grows above the tasks every
+    // time the note is opened.
+    const roundTrip = async (md: string): Promise<string> => {
+      const doc = new Y.Doc()
+      const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+      const { markdownToYFragment } = await import('./blocknote-converter')
+      await markdownToYFragment(md, fragment)
+      return (await yDocToMarkdown(doc)) ?? ''
+    }
+
+    const original =
+      '- [ ] Buy milk {task:t1}\n- [ ] Call mom {task:t2}\n- [ ] Ship the PR {task:t3}\n\n\n\nWrap-up notes'
+
+    const once = await roundTrip(original)
+    const twice = await roundTrip(once)
+
+    expect(twice).toBe(once)
   })
 
   it('preserves nested paragraph indentation through markdown writeback', async () => {

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -270,14 +270,14 @@ async function blocksToMarkdownPreserving(
     if (isEmptyParagraph(block)) {
       if (contentGroup.length > 0) {
         const md = await editor.blocksToMarkdownLossy(contentGroup as PartialBlock[])
-        segments.push({ type: 'content', text: md })
+        segments.push({ type: 'content', text: md.trim() })
         contentGroup = []
       }
       emptyCount++
     } else if (hasNonDefaultColors(block.props as BlockColors)) {
       if (contentGroup.length > 0) {
         const md = await editor.blocksToMarkdownLossy(contentGroup as PartialBlock[])
-        segments.push({ type: 'content', text: md })
+        segments.push({ type: 'content', text: md.trim() })
         contentGroup = []
       }
       if (emptyCount > 0) {
@@ -292,7 +292,7 @@ async function blocksToMarkdownPreserving(
     } else if (hasMarkerSerializedChildren(block)) {
       if (contentGroup.length > 0) {
         const md = await editor.blocksToMarkdownLossy(contentGroup as PartialBlock[])
-        segments.push({ type: 'content', text: md })
+        segments.push({ type: 'content', text: md.trim() })
         contentGroup = []
       }
       if (emptyCount > 0) {
@@ -314,7 +314,9 @@ async function blocksToMarkdownPreserving(
 
   if (contentGroup.length > 0) {
     const md = await editor.blocksToMarkdownLossy(contentGroup as PartialBlock[])
-    segments.push({ type: 'content', text: md })
+    // Trim the trailing newline BlockNote appends to list/heading groups; left
+    // untrimmed it re-parses as a growing blank-line gap on every writeback.
+    segments.push({ type: 'content', text: md.trim() })
   }
   if (emptyCount > 0) {
     segments.push({ type: 'gap', extraLines: emptyCount })

--- a/apps/desktop/src/renderer/src/components/note/content-area/critic-markup-offset-map.integration.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/critic-markup-offset-map.integration.test.ts
@@ -243,13 +243,12 @@ describe('CriticMarkup offset map vs real doc projection for atom inline nodes',
 // that, serialization must be a fixed point for everything.
 const ROUND_TRIP_FIXTURES_PASSING: Array<{ markdown: string }> = [
   { markdown: '* alpha\n* bravo\n* charlie' },
-  { markdown: '1. first launch\n2. second channel\n3. third post' }
-]
-
-// Blocked: serializer adds trailing '\n' to loose lists and heading blocks,
-// so canonical=true fixtures don't round-trip identically. Fix: strip the
-// trailing newline in serializeBlocksPreservingBlanks.
-const ROUND_TRIP_FIXTURES_BROKEN: Array<{ markdown: string }> = [
+  { markdown: '1. first launch\n2. second channel\n3. third post' },
+  // Loose lists and heading+list shapes. The serializer must strip the trailing
+  // '\n' that blocksToMarkdownLossy appends to list/heading blocks; otherwise the
+  // trailing newline merges with the segment join into a 3+ newline run that
+  // re-parses as a growing blank-line gap — the doc gains one blank line per list
+  // group per save (the inline-task "new line above the task on reopen" bug).
   { markdown: '* alpha\n\n* bravo\n\n* charlie' },
   { markdown: '1. first launch\n\n2. second channel\n\n3. third post' },
   {
@@ -276,12 +275,6 @@ describe('parse→serialize round-trip stability for structured markdown', () =>
         await parseMarkdownPreservingBlanks(editor, once)
       )
       expect(twice).toBe(once)
-    })
-  }
-
-  for (const { markdown } of ROUND_TRIP_FIXTURES_BROKEN) {
-    it.skip(`round-trips ${JSON.stringify(markdown.slice(0, 40))}…`, async () => {
-      // Blocked: serializer adds trailing newline making canonical round-trip fail.
     })
   }
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
@@ -206,7 +206,10 @@ export async function serializeBlocksPreservingBlanks(
   const flushContent = async (): Promise<void> => {
     if (contentGroup.length === 0) return
     const md = await editor.blocksToMarkdownLossy(contentGroup)
-    segments.push({ type: 'content', text: md })
+    // Trim the trailing newline BlockNote appends to list/heading groups; left
+    // untrimmed it merges with the segment join into a 3+ newline run that
+    // re-parses as a growing blank-line gap on every save (see round-trip tests).
+    segments.push({ type: 'content', text: md.trim() })
     contentGroup = []
   }
 
@@ -288,7 +291,7 @@ export async function serializeBlocksPreservingBlanks(
 
   if (contentGroup.length > 0) {
     const md = await editor.blocksToMarkdownLossy(contentGroup)
-    segments.push({ type: 'content', text: md })
+    segments.push({ type: 'content', text: md.trim() })
   }
   if (emptyCount > 0) {
     segments.push({ type: 'gap', extraLines: emptyCount })


### PR DESCRIPTION
## Problem

In a Note/Journal, inline tasks render as a special block. Adding several tasks and reopening the note inserts a **new blank line above the task** — and it accumulates one more blank line on every reopen. The note body silently grows.

## Root cause

The body round-trips through markdown on every open (`markdown → blocks → markdown`). `editor.blocksToMarkdownLossy(...)` appends a **trailing `\n`** to list-item / heading groups. Both block serializers pushed that result into a `content` segment **untrimmed**, and `assembleMarkdownWithBlanks` joins content segments with `\n\n`. So a task list followed by anything produced `…item\n` + `\n\n` = **three newlines**, which `splitMarkdownPreservingBlanks` re-reads as a blank-line **gap** → an empty paragraph that is re-emitted and **grows by one blank line per list group per save/reopen**.

On the CRDT (journal) path, tasks are stored as `checkListItem` (the server schema has no `taskBlock` spec) and serialized through that untrimmed path, so plain task lists are affected too.

This was already documented as a known issue in a skipped round-trip test: *"untrimmed list serializer output grew the document by one newline per list group per save."*

## Fix

Trim the serializer-injected trailing newline at every `blocksToMarkdownLossy(contentGroup)` flush, in both duplicated serializers:

- `apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts` — `serializeBlocksPreservingBlanks`
- `apps/desktop/src/main/sync/blocknote-converter.ts` — `blocksToMarkdownPreserving`

Gap segments are untouched, so intentional multi-blank-line gaps are still preserved — only the spurious trailing newline is removed. The round-trip is now a fixed point: reopening a note no longer mutates its content.

## Tests

- Added round-trip fixed-point tests for the renderer and CRDT paths (a task checklist followed by a gap + content must not grow).
- Unskipped the previously-documented loose-list / heading+list repros (real `BlockNoteEditor`); they now pass.
- Corrected one stale assertion that encoded the bug (`Alpha\n\n\n\n` → idempotent `Alpha\n\n\nBeta`).

## Verification

- `blocknote-converter` (main): 12/12
- round-trip integration + `markdown-utils` (renderer): 31/31
- full renderer suite: 4641 passed / 0 failed
- `typecheck:web` + `typecheck:node`: clean
- lint clean, `docs:impact --strict`: no docs-relevant changes