### PR TITLE
feat(landing): redesign checkout, add page glow, center roadmap/changelog headers

### DIFF
--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -4,6 +4,7 @@ import { HelmetProvider } from 'react-helmet-async'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 import { SmoothScroll } from '@/components/layout/SmoothScroll'
+import { PageGlow } from '@/components/shared/PageGlow'
 import { Home } from '@/pages/Home'
 import { FeaturesPage } from '@/pages/Features'
 import { NotesFeaturePage } from '@/pages/Notes'
@@ -116,7 +117,8 @@ function AppContent() {
       <PageViewAnalytics />
       <ScrollDepthAnalytics />
       <Header />
-      <main className="flex-1">
+      <main className="relative isolate flex-1">
+        <PageGlow />
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/features" element={<FeaturesPage />} />

--- a/apps/landing/src/components/shared/PageGlow.tsx
+++ b/apps/landing/src/components/shared/PageGlow.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * Soft terracotta radial halo painted behind page content near the top.
+ * Purely decorative. Requires a positioned ancestor (the page's `<main>` is
+ * `relative`); sits at `-z-10` so it glows over the paper background but
+ * behind everything else, and scrolls away with the page.
+ *
+ * `opacity` is applied via inline style (not a Tailwind arbitrary value) so it
+ * can be tuned per page without tripping Tailwind's build-time class scan.
+ * Override size/position with `className` (twMerge wins on conflicts).
+ */
+export function PageGlow({ className, opacity = 0.2 }: { className?: string; opacity?: number }) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute inset-x-0 top-0 -z-10 mx-auto h-[32rem] max-w-3xl',
+        className
+      )}
+      style={{
+        backgroundImage: `radial-gradient(ellipse at top, rgba(255, 103, 26, ${opacity}), transparent 70%)`
+      }}
+    />
+  )
+}

--- a/apps/landing/src/pages/Changelog.tsx
+++ b/apps/landing/src/pages/Changelog.tsx
@@ -158,7 +158,7 @@ export function ChangelogPage() {
             initial={BLUR_REVEAL_INITIAL}
             animate={BLUR_REVEAL_ANIMATE}
             transition={BLUR_REVEAL_TRANSITION}
-            className="border-b border-border pb-12"
+            className="border-b border-border pb-12 text-center"
           >
             <p className="font-mono-accent text-xs uppercase tracking-[0.18em] text-terracotta">
               Release notes
@@ -166,12 +166,12 @@ export function ChangelogPage() {
             <h1 className="mt-4 font-serif text-5xl leading-[1.05] text-ink md:text-6xl">
               Changelog
             </h1>
-            <p className="mt-5 max-w-2xl text-lg leading-relaxed text-muted">
+            <p className="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-muted">
               Major memrynote milestones from the first desktop scaffold on December 1, 2025 to the
               current launch push. Small fixes, copy changes, and operational release notes stay in
               GitHub.
             </p>
-            <div className="mt-8 flex flex-wrap gap-3 text-sm">
+            <div className="mt-8 flex flex-wrap justify-center gap-3 text-sm">
               <a
                 href={`${GITHUB_URL}/releases`}
                 className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 font-medium text-ink transition-colors hover:border-terracotta/30 hover:text-terracotta"

--- a/apps/landing/src/pages/Checkout.tsx
+++ b/apps/landing/src/pages/Checkout.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { Check, Lock } from 'lucide-react'
 import { Container } from '@/components/layout/Container'
 import { PageHead } from '@/components/shared/PageHead'
 import { Button } from '@/components/ui/button'
@@ -16,6 +17,14 @@ import { cn } from '@/lib/utils'
 const PURCHASABLE_TIERS = SYNC_PLAN_TIERS.filter((tier) => tier.checkoutPlanId)
 
 type CheckoutStatus = 'idle' | 'starting' | 'pending' | 'success' | 'failed' | 'canceled'
+
+function formatPrice(amount: number) {
+  return Number.isInteger(amount) ? `$${amount}` : `$${amount.toFixed(2)}`
+}
+
+function cadenceSuffix(label: 'Monthly' | 'Yearly' | 'One-time') {
+  return label === 'Monthly' ? '/mo' : label === 'Yearly' ? '/yr' : 'once'
+}
 
 export function CheckoutPage() {
   const [token, setToken] = useState<string | null>(null)
@@ -67,66 +76,136 @@ export function CheckoutPage() {
   return (
     <>
       <PageHead page="pricing" />
-      <main className="py-16">
-        <Container>
+      <main className="overflow-hidden py-16 md:py-24">
+        <Container size="sm">
           {!token ? (
             <NoTokenNotice />
           ) : (
-            <div className="grid gap-10 md:grid-cols-2">
-              <section>
-                <p className="text-sm text-muted">Account · Sync · Checkout</p>
-                <h1 className="mt-2 text-2xl font-semibold">Choose a sync plan</h1>
+            <div className="animate-fade-up mx-auto max-w-md">
+              <p className="font-mono-accent text-[11px] uppercase tracking-[0.22em] text-muted">
+                memrynote · sync
+              </p>
+              <h1 className="font-editorial mt-2 text-[28px] leading-none tracking-[-0.02em]">
+                Choose your plan
+              </h1>
+              <p className="mt-2 text-sm text-muted">
+                End-to-end encrypted. Cancel anytime, refund within 7 days.
+              </p>
 
-                <h2 className="mt-8 text-sm font-medium uppercase tracking-wide">Plan</h2>
-                <div className="mt-3 space-y-2">
-                  {PURCHASABLE_TIERS.map((tier) => (
-                    <button
-                      key={tier.id}
-                      type="button"
-                      onClick={() => selectPlan(tier.checkoutPlanId!)}
-                      className={cn(
-                        'flex w-full flex-col rounded-lg border p-4 text-start transition',
-                        plan === tier.checkoutPlanId
-                          ? 'border-primary ring-1 ring-primary'
-                          : 'border-border hover:border-foreground/30'
-                      )}
-                    >
-                      <span className="font-medium">{tier.name}</span>
-                      <span className="text-sm text-muted">{tier.tagline}</span>
-                    </button>
-                  ))}
+              <div className="mt-7 overflow-hidden rounded-2xl border border-border bg-card shadow-card">
+                <div role="radiogroup" aria-label="Plan" className="space-y-1 p-2">
+                  {PURCHASABLE_TIERS.map((tier) => {
+                    const id = tier.checkoutPlanId!
+                    const selected = plan === id
+                    const rowSummary = getCheckoutSummary(id, normalizeCadenceForPlan(id, cadence))
+                    return (
+                      <button
+                        key={tier.id}
+                        type="button"
+                        role="radio"
+                        aria-checked={selected}
+                        onClick={() => selectPlan(id)}
+                        className={cn(
+                          'flex w-full items-center gap-3 rounded-xl px-3 py-3 text-start transition-colors duration-200',
+                          selected
+                            ? 'bg-[var(--color-paper-alt)]'
+                            : 'hover:bg-[var(--color-paper-alt)]/60'
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border transition-colors',
+                            selected
+                              ? 'border-terracotta bg-terracotta text-white'
+                              : 'border-border text-transparent'
+                          )}
+                        >
+                          <Check className="h-2.5 w-2.5" strokeWidth={3.5} />
+                        </span>
+
+                        <span className="min-w-0 flex-1">
+                          <span className="flex items-center gap-2">
+                            <span className="text-sm font-medium text-ink">{tier.name}</span>
+                            {tier.ribbon && (
+                              <span className="rounded-full bg-terracotta/10 px-1.5 py-0.5 text-[10px] font-medium text-terracotta">
+                                {tier.ribbon}
+                              </span>
+                            )}
+                          </span>
+                          <span className="mt-0.5 block truncate text-xs text-muted">
+                            {tier.tagline}
+                          </span>
+                        </span>
+
+                        {rowSummary && (
+                          <span className="text-end leading-tight">
+                            <span className="font-mono-accent text-sm font-medium tabular-nums text-ink">
+                              {formatPrice(rowSummary.amount)}
+                            </span>
+                            <span className="ms-0.5 text-[11px] text-muted">
+                              {cadenceSuffix(rowSummary.billingFrequencyLabel)}
+                            </span>
+                          </span>
+                        )}
+                      </button>
+                    )
+                  })}
                 </div>
 
                 {cadenceOptions.length > 1 && (
-                  <>
-                    <h2 className="mt-8 text-sm font-medium uppercase tracking-wide">
-                      Renewal frequency
-                    </h2>
-                    <div className="mt-3 space-y-2">
-                      {cadenceOptions.map((option) => (
-                        <button
-                          key={option}
-                          type="button"
-                          onClick={() => setCadence(option)}
-                          className={cn(
-                            'flex w-full items-center justify-between rounded-lg border p-4 text-start transition',
-                            effectiveCadence === option
-                              ? 'border-primary ring-1 ring-primary'
-                              : 'border-border hover:border-foreground/30'
-                          )}
-                        >
-                          <span>{option === 'annual' ? 'Yearly' : 'Monthly'}</span>
-                          {option === 'annual' && (
-                            <span className="text-xs font-medium text-emerald-600">SAVE 20%</span>
-                          )}
-                        </button>
-                      ))}
+                  <div className="px-3 pb-3">
+                    <div
+                      role="radiogroup"
+                      aria-label="Renewal frequency"
+                      className="flex rounded-full border border-border bg-[var(--color-paper-alt)] p-1"
+                    >
+                      {cadenceOptions.map((option) => {
+                        const active = effectiveCadence === option
+                        return (
+                          <button
+                            key={option}
+                            type="button"
+                            role="radio"
+                            aria-checked={active}
+                            onClick={() => setCadence(option)}
+                            className={cn(
+                              'flex flex-1 items-center justify-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-200',
+                              active ? 'bg-card text-ink shadow-sm' : 'text-muted hover:text-ink'
+                            )}
+                          >
+                            {option === 'annual' ? 'Yearly' : 'Monthly'}
+                            {option === 'annual' && (
+                              <span className="font-semibold text-sage">−20%</span>
+                            )}
+                          </button>
+                        )
+                      })}
                     </div>
-                  </>
+                  </div>
                 )}
-              </section>
 
-              <OrderSummary summary={summary} status={status} error={error} onProceed={proceed} />
+                <OrderSummary summary={summary} status={status} error={error} onProceed={proceed} />
+              </div>
+
+              <p className="mt-4 flex items-center justify-center gap-1.5 text-xs text-muted">
+                <Lock className="h-3 w-3" strokeWidth={2} />
+                Secured by Paddle · VAT included · 7-day refund
+              </p>
+
+              <p className="mt-2 text-center text-xs text-muted">
+                Need help?{' '}
+                <a
+                  href="mailto:billing@memrynote.com"
+                  className="text-terracotta underline-offset-2 hover:underline"
+                >
+                  Contact us
+                </a>
+                .{' '}
+                <Link to="/refund" className="text-terracotta underline-offset-2 hover:underline">
+                  Refund policy
+                </Link>
+                .
+              </p>
             </div>
           )}
         </Container>
@@ -148,34 +227,37 @@ function OrderSummary({
 }) {
   if (!summary) {
     return (
-      <aside className="rounded-lg border border-border p-6">
+      <div className="border-t border-border px-5 py-5">
         <p className="text-sm text-muted">This plan is not available for purchase.</p>
-      </aside>
+      </div>
     )
   }
 
   const isBusy = status === 'starting' || status === 'pending'
+  const recurring = summary.billingFrequencyLabel !== 'One-time'
 
   return (
-    <aside className="rounded-lg border border-border bg-card p-6">
-      <div className="flex items-center justify-between text-sm">
-        <span className="text-muted">Billing frequency</span>
-        <span className="font-medium">{summary.billingFrequencyLabel}</span>
-      </div>
-      <div className="mt-4 flex items-center justify-between text-sm">
-        <span>{summary.lineItemLabel}</span>
-        <span>${summary.amount.toFixed(2)}</span>
-      </div>
-      <hr className="my-6 border-border" />
-      <div className="flex items-center justify-between">
-        <span className="text-lg font-semibold">Total</span>
-        <span className="text-lg font-semibold">
-          {summary.currency} ${summary.amount.toFixed(2)}
-        </span>
+    <div className="border-t border-border px-5 py-5">
+      <div className="flex items-end justify-between">
+        <div>
+          <p className="font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted">
+            Total due today
+          </p>
+          <p className="mt-1 text-xs text-muted">
+            {summary.lineItemLabel}
+            {recurring && ` · renews ${summary.billingFrequencyLabel.toLowerCase()}`}
+          </p>
+        </div>
+        <p className="shrink-0 text-end">
+          <span className="font-mono-accent text-[28px] font-medium leading-none tabular-nums text-ink">
+            {formatPrice(summary.amount)}
+          </span>
+          <span className="ms-1 align-top text-xs text-muted">{summary.currency}</span>
+        </p>
       </div>
 
       {status === 'success' && (
-        <p role="status" className="mt-4 text-sm text-emerald-600">
+        <p role="status" className="mt-4 text-sm text-sage">
           Payment complete. Return to Memry to finish activation.
         </p>
       )}
@@ -195,22 +277,32 @@ function OrderSummary({
         </p>
       )}
 
-      <Button type="button" className="mt-6 w-full" disabled={isBusy} onClick={onProceed}>
-        {isBusy ? 'Opening…' : 'Proceed to payment'}
+      <Button type="button" className="mt-5 w-full" disabled={isBusy} onClick={onProceed}>
+        {isBusy ? (
+          'Opening…'
+        ) : (
+          <>
+            <Lock className="h-3.5 w-3.5" strokeWidth={2.25} />
+            Proceed to payment
+          </>
+        )}
       </Button>
-    </aside>
+    </div>
   )
 }
 
 function NoTokenNotice() {
   return (
-    <div className="mx-auto max-w-md rounded-lg border border-border p-8 text-center">
-      <h1 className="text-xl font-semibold">Open Memry to upgrade</h1>
+    <div className="animate-fade-up mx-auto max-w-sm rounded-2xl border border-border bg-card p-8 text-center shadow-card">
+      <span className="mx-auto flex h-11 w-11 items-center justify-center rounded-full bg-terracotta/10 text-terracotta">
+        <Lock className="h-5 w-5" strokeWidth={2} />
+      </span>
+      <h1 className="font-editorial mt-5 text-xl tracking-[-0.01em]">Open Memry to upgrade</h1>
       <p className="mt-3 text-sm text-muted">
-        Start checkout from <strong>Settings → Account</strong> in the Memry desktop app so we can
-        link the purchase to your account.
+        Start checkout from <strong className="font-medium text-ink">Settings → Account</strong> in
+        the Memry desktop app so we can link the purchase to your account.
       </p>
-      <Button asChild className="mt-6">
+      <Button asChild className="mt-6 w-full">
         <Link to="/download/desktop">Download Memry</Link>
       </Button>
     </div>

--- a/apps/landing/src/pages/Roadmap.tsx
+++ b/apps/landing/src/pages/Roadmap.tsx
@@ -3,6 +3,7 @@ import { ArrowRight } from 'lucide-react'
 import { Container } from '@/components/layout/Container'
 import { PageHead } from '@/components/shared/PageHead'
 import { GITHUB_URL } from '@/lib/constants'
+import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from '@/lib/motion'
 
 const EASE_OUT_EXPO = [0.16, 1, 0.3, 1] as const
 
@@ -240,16 +241,21 @@ export function RoadmapPage() {
     <main className="pt-32 pb-24 md:pt-40">
       <PageHead page="roadmap" />
       <Container size="md">
-        <section className="border-b border-border pb-12">
+        <motion.section
+          initial={BLUR_REVEAL_INITIAL}
+          animate={BLUR_REVEAL_ANIMATE}
+          transition={BLUR_REVEAL_TRANSITION}
+          className="border-b border-border pb-12 text-center"
+        >
           <p className="font-mono-accent text-xs uppercase tracking-[0.18em] text-terracotta">
             Building in public
           </p>
           <h1 className="mt-4 font-serif text-5xl leading-[1.05] text-ink md:text-6xl">Roadmap</h1>
-          <p className="mt-5 max-w-2xl text-lg leading-relaxed text-muted">
+          <p className="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-muted">
             What is available, what is active, and what is planned next. This is direction, not a
             release promise.
           </p>
-          <div className="mt-8 flex flex-wrap gap-3 text-sm">
+          <div className="mt-8 flex flex-wrap justify-center gap-3 text-sm">
             <a
               href={`${GITHUB_URL}/releases`}
               className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 font-medium text-ink transition-colors hover:border-terracotta/30 hover:text-terracotta"
@@ -265,7 +271,7 @@ export function RoadmapPage() {
               <ArrowRight className="h-4 w-4" aria-hidden />
             </a>
           </div>
-        </section>
+        </motion.section>
 
         <section className="border-b border-border py-12">
           <div className="grid grid-cols-1 gap-3 md:grid-cols-[140px_1fr] md:gap-10">


### PR DESCRIPTION
## Summary
A focused landing UI pass:

- **Checkout redesign** — compact single-card layout: mono tabular price numerals, selectable plan rows, segmented Monthly/Yearly cadence toggle, a "total due today" summary, a restyled no-token notice, and a `Need help? Contact us · Refund policy` footer (`billing@memrynote.com` + `/refund`). All existing logic preserved (token gating, plan/cadence state, Paddle handler, status/error).
- **Page glow** — new reusable `PageGlow` component rendered once inside an isolated global `<main>`, so the terracotta halo shows on **every** route (including future pages) in both light and dark themes. The `isolate` makes `<main>` a stacking context so the `-z-10` glow paints above the opaque body background.
- **Centered headers** — roadmap + changelog page headers now match the centered style of terms/security/pricing.
- **Roadmap fade-in** — roadmap header gained the same `BLUR_REVEAL` entry animation changelog already had (it previously appeared instantly).

## Test plan
- [x] `pnpm --filter @memry/landing typecheck` clean
- [x] Verified glow renders in light + dark across home, checkout, roadmap, changelog, terms, security, pricing, features
- [x] Verified centered headers + roadmap blur-reveal entry (probed mid-animation: opacity ~0.01, blur ~14px)
- [ ] Visual review on the deployed preview

## Notes
- Checkout now uses the same uniform glow intensity as the rest of the site (slightly stronger than the earlier subtle `0.12`). Easy to dial back to a per-page subtle value if preferred.