### PR TITLE
feat(sidebar): compact tag-notes drill-down panel

### DIFF
--- a/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.tsx
@@ -159,48 +159,47 @@ export function TagDetailView({ tag, color, className }: TagDetailViewProps): Re
 
   return (
     <div className={cn('flex flex-col h-full', className)}>
-      {/* Header */}
-      <div className="flex items-center gap-2 px-3 py-3 border-b">
+      {/* Header — single compact row */}
+      <div className="flex items-center gap-1.5 px-2.5 py-2 border-b border-border/60">
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7 shrink-0"
+          className="h-6 w-6 shrink-0"
           onClick={goBack}
           aria-label={tPhaseF('phaseF.componentsSidebarTagDetailView.goBack')}
         >
-          <ArrowLeft className="h-4 w-4" />
+          <ArrowLeft className="h-3.5 w-3.5" />
         </Button>
 
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <span
-              className="w-2.5 h-2.5 rounded-full shrink-0"
-              style={{
-                backgroundColor: tagColors.background,
-                border: `1.5px solid ${tagColors.text}`
-              }}
-            />
-            <span className="font-medium truncate">
-              {tag.includes('/') ? (
-                <span className="flex items-center gap-0.5">
-                  {tag.split('/').map((segment, i, arr) => (
-                    <span key={i} className="flex items-center gap-0.5">
-                      {i > 0 && <span className="text-muted-foreground/40 text-xs">/</span>}
-                      <span className={i < arr.length - 1 ? 'text-muted-foreground' : ''}>
-                        {segment}
-                      </span>
-                    </span>
-                  ))}
+        <span
+          className="w-2.5 h-2.5 rounded-full shrink-0"
+          style={{
+            backgroundColor: tagColors.background,
+            border: `1.5px solid ${tagColors.text}`
+          }}
+        />
+
+        <div
+          className="flex-1 min-w-0 truncate text-[13px] font-medium leading-5"
+          title={`${tag} · ${count} ${tPhaseF('phaseF.componentsSidebarTagDetailView.notes')}`}
+        >
+          {tag.includes('/') ? (
+            <span className="inline-flex items-center gap-0.5 align-middle">
+              {tag.split('/').map((segment, i, arr) => (
+                <span key={i} className="inline-flex items-center gap-0.5">
+                  {i > 0 && <span className="text-muted-foreground/40 text-xs">/</span>}
+                  <span className={i < arr.length - 1 ? 'text-muted-foreground' : ''}>
+                    {segment}
+                  </span>
                 </span>
-              ) : (
-                tag
-              )}
+              ))}
             </span>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            {count} {tPhaseF('phaseF.componentsSidebarTagDetailView.notes')}
-          </p>
+          ) : (
+            tag
+          )}
         </div>
+
+        <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/60">{count}</span>
 
         {/* Overflow menu */}
         <TagOverflowMenu
@@ -227,8 +226,14 @@ export function TagDetailView({ tag, color, className }: TagDetailViewProps): Re
       {/* Content */}
       <ScrollArea className="flex-1">
         {isLoading ? (
-          <div className="px-3 py-8 text-center text-sm text-muted-foreground">
-            {tPhaseF('phaseF.componentsSidebarTagDetailView.loadingNotes')}
+          <div
+            className="py-1.5"
+            aria-busy="true"
+            aria-label={tPhaseF('phaseF.componentsSidebarTagDetailView.loadingNotes')}
+          >
+            <NoteRowSkeleton />
+            <NoteRowSkeleton />
+            <NoteRowSkeleton />
           </div>
         ) : error ? (
           <div className="px-3 py-8 text-center text-sm text-destructive">{error}</div>
@@ -240,13 +245,12 @@ export function TagDetailView({ tag, color, className }: TagDetailViewProps): Re
             </p>
           </div>
         ) : (
-          <div className="py-2">
+          <div className="py-1.5">
             {/* Pinned section */}
             {pinnedNotes.length > 0 && (
               <>
-                <div className="px-3 py-1.5 text-xs font-medium text-muted-foreground flex items-center gap-1.5">
-                  <Pin className="h-3 w-3" />
-
+                <div className="px-3 pt-1.5 pb-1 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                  <Pin className="h-2.5 w-2.5" />
                   {tPhaseF('phaseF.componentsSidebarTagDetailView.pinned')}
                 </div>
                 {pinnedNotes.map((note) => (
@@ -259,12 +263,12 @@ export function TagDetailView({ tag, color, className }: TagDetailViewProps): Re
                     onUnpin={() => void unpinNote(note.id)}
                   />
                 ))}
-                <Separator className="my-2" />
+                <Separator className="my-1.5" />
               </>
             )}
 
             {/* All notes section */}
-            <div className="px-3 py-1.5 text-xs font-medium text-muted-foreground flex items-center justify-between">
+            <div className="px-3 pt-1.5 pb-1 flex items-center justify-between text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
               <span>{tPhaseF('phaseF.componentsSidebarTagDetailView.allNotes')}</span>
               <SortDropdown sortBy={sortBy} onSortChange={setSortBy} />
             </div>
@@ -329,7 +333,7 @@ function NoteItem({ note, isPinned, onClick, onPin, onUnpin }: NoteItemProps): R
 
   return (
     <div
-      className="group/noteitem px-3 py-2 hover:bg-accent/50 cursor-pointer relative"
+      className="group/noteitem flex items-center gap-2 mx-1.5 px-1.5 py-1 rounded-md hover:bg-accent/50 cursor-pointer"
       role="button"
       tabIndex={0}
       onClick={onClick}
@@ -340,59 +344,63 @@ function NoteItem({ note, isPinned, onClick, onPin, onUnpin }: NoteItemProps): R
         }
       }}
     >
-      <div className="flex items-start gap-2">
-        {/* Icon */}
-        <div className="mt-0.5 shrink-0">
-          {note.emoji ? (
-            <NoteIconDisplay value={note.emoji} className="text-sm" />
-          ) : (
-            <FileText className="h-4 w-4 text-muted-foreground" />
-          )}
-        </div>
-
-        {/* Content */}
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium truncate">{note.title}</p>
-          <p className="text-xs text-muted-foreground mt-0.5">{formatDate(note.modified)}</p>
-        </div>
-
-        {/* Pin button - always visible when pinned, only on hover when unpinned */}
-        {isPinned ? (
-          <TooltipProvider delayDuration={300}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={handlePinClick}
-                  className="shrink-0 mt-0.5 p-1 rounded-sm transition-colors hover:bg-accent text-primary"
-                  aria-label={tPhaseF('phaseF.componentsSidebarTagDetailView.unpinFromTag')}
-                >
-                  <Pin className="h-3.5 w-3.5 fill-current" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="left" className="text-xs">
-                {tPhaseF('phaseF.componentsSidebarTagDetailView.unpin')}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+      {/* Icon */}
+      <span className="shrink-0 flex w-4 items-center justify-center">
+        {note.emoji ? (
+          <NoteIconDisplay value={note.emoji} className="text-[13px]" />
         ) : (
-          <TooltipProvider delayDuration={300}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={handlePinClick}
-                  className="shrink-0 mt-0.5 p-1 rounded-sm transition-all hover:bg-accent text-muted-foreground hover:text-foreground opacity-0 group-hover/noteitem:opacity-100"
-                  aria-label={tPhaseF('phaseF.componentsSidebarTagDetailView.pinToTag')}
-                >
-                  <Pin className="h-3.5 w-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="left" className="text-xs">
-                {tPhaseF('phaseF.componentsSidebarTagDetailView.pin')}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <FileText className="h-3.5 w-3.5 text-muted-foreground/70" />
         )}
-      </div>
+      </span>
+
+      {/* Title */}
+      <span className="flex-1 min-w-0 truncate text-[13px] leading-5">{note.title}</span>
+
+      {/* Date + pin — pin slot reserved so hover never shifts the row */}
+      <span className="ms-auto shrink-0 flex items-center gap-1">
+        <span className="text-[10px] tabular-nums text-muted-foreground/60">
+          {formatDate(note.modified)}
+        </span>
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={handlePinClick}
+                className={cn(
+                  'flex size-5 items-center justify-center rounded-sm transition-all hover:bg-accent',
+                  isPinned
+                    ? 'text-primary'
+                    : 'text-muted-foreground/70 opacity-0 hover:text-foreground group-hover/noteitem:opacity-100'
+                )}
+                aria-label={tPhaseF(
+                  isPinned
+                    ? 'phaseF.componentsSidebarTagDetailView.unpinFromTag'
+                    : 'phaseF.componentsSidebarTagDetailView.pinToTag'
+                )}
+              >
+                <Pin className={cn('h-3 w-3', isPinned && 'fill-current')} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left" className="text-xs">
+              {tPhaseF(
+                isPinned
+                  ? 'phaseF.componentsSidebarTagDetailView.unpin'
+                  : 'phaseF.componentsSidebarTagDetailView.pin'
+              )}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </span>
+    </div>
+  )
+}
+
+// Loading placeholder row matching the single-line note layout.
+function NoteRowSkeleton(): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-2 mx-1.5 px-1.5 py-1">
+      <span className="shrink-0 size-3.5 rounded bg-muted animate-pulse" />
+      <span className="h-3 w-3/5 rounded bg-muted animate-pulse" />
     </div>
   )
 }
@@ -445,21 +453,21 @@ function TagOverflowMenu({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7 shrink-0"
+          className="h-6 w-6 shrink-0"
           aria-label={tPhaseF('phaseF.componentsSidebarTagDetailView.tagActions')}
         >
-          <MoreHorizontal className="h-4 w-4" />
+          <MoreHorizontal className="h-3.5 w-3.5" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48">
         <DropdownMenuItem onClick={onRequestRename}>
-          <Pencil className="h-4 w-4 mr-2" />
+          <Pencil className="h-4 w-4 me-2" />
 
           {tPhaseF('phaseF.componentsSidebarTagDetailView.editTagName')}
         </DropdownMenuItem>
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
-            <Palette className="h-4 w-4 mr-2" />
+            <Palette className="h-4 w-4 me-2" />
 
             {tPhaseF('phaseF.componentsSidebarTagDetailView.changeColor')}
           </DropdownMenuSubTrigger>
@@ -489,7 +497,7 @@ function TagOverflowMenu({
           onClick={onRequestDelete}
           className="text-destructive focus:text-destructive"
         >
-          <Trash2 className="h-4 w-4 mr-2" />
+          <Trash2 className="h-4 w-4 me-2" />
 
           {tPhaseF('phaseF.componentsSidebarTagDetailView.deleteTag')}
         </DropdownMenuItem>
@@ -515,17 +523,17 @@ function SortDropdown({ sortBy, onSortChange }: SortDropdownProps): React.JSX.El
       <DropdownMenuContent align="end" className="w-40">
         <DropdownMenuRadioGroup value={sortBy} onValueChange={(v) => onSortChange(v as TagSortBy)}>
           <DropdownMenuRadioItem value="modified">
-            <Clock className="h-4 w-4 mr-2" />
+            <Clock className="h-4 w-4 me-2" />
 
             {tPhaseF('phaseF.componentsSidebarTagDetailView.recent')}
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem value="created">
-            <Calendar className="h-4 w-4 mr-2" />
+            <Calendar className="h-4 w-4 me-2" />
 
             {tPhaseF('phaseF.componentsSidebarTagDetailView.created')}
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem value="title">
-            <SortAsc className="h-4 w-4 mr-2" />
+            <SortAsc className="h-4 w-4 me-2" />
 
             {tPhaseF('phaseF.componentsSidebarTagDetailView.alphabetical')}
           </DropdownMenuRadioItem>

--- a/docs/superpowers/specs/2026-06-12-tag-notes-sidebar-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-12-tag-notes-sidebar-redesign-design.md
@@ -1,0 +1,108 @@
+# Tag-notes sidebar panel — compact redesign
+
+**Date:** 2026-06-12
+**Branch:** `tag-notes-sidebar-redesign`
+**Scope:** Visual-only restyle of the existing tag drill-down panel. No wiring, IPC, contract, hook, or data changes.
+
+## Context
+
+Clicking a tag in `SidebarTagList` already drives `SidebarDrillDownProvider.openTag` →
+`SidebarDrillDownContainer` (slide animation) → `TagDetailView`, which lists the tag's notes
+in the sidebar. The feature works; it is just visually loose:
+
+- Header is two lines (tag name + "N notes" below).
+- `NoteItem` rows are two lines (title + date), ~40px tall, with generous padding.
+
+Goal: make the panel compact, clean, and UX-friendly while keeping **all** current behavior.
+
+## Decisions (locked with user)
+
+- **Restyle only** — keep slide-in drill-down + every action.
+- **Single-line note rows** — icon + title on one line, relative date right-aligned.
+- **Keep:** sort control, pin/unpin, tag actions `⋯` menu (rename / color / delete), note count.
+- **Loading:** 3 skeleton rows matching the new row layout (replaces "Loading notes…" text).
+
+## Files touched
+
+- `apps/desktop/src/renderer/src/components/sidebar/tag-detail-view.tsx`
+  - `TagDetailView` — header + section structure restyle.
+  - `NoteItem` — two-line → single-line.
+  - Add a small local `NoteRowSkeleton` for the loading state.
+- (No changes to `sidebar-drill-down-container.tsx`, `sidebar-drill-down.tsx`,
+  `use-tag-detail.ts`, `tags-service.ts`, contracts, or dialogs.)
+
+## Layout spec
+
+### Header — collapse 2 lines → 1 row (~36px)
+
+```
+[‹]  ● design-systems · 12              ⋯
+─────────────────────────────────────────
+```
+
+- Back button: ghost, `size-6` (was `h-7 w-7`).
+- Color dot: `size-2.5`, current style (bg = tag background, ring = tag text color).
+- Tag name: keep hierarchy rendering (`parent / leaf`, parent muted, leaf normal weight).
+- Count: inline muted `· {count}` after the name. Full "{count} notes" string moves to the
+  tag name `title` tooltip (reuse existing i18n; no second line).
+- Overflow `⋯`: ghost `size-6`, far end.
+- `border-b` lightened (`border-b border-border/60`).
+
+### Pinned section (only when `pinnedNotes.length > 0`)
+
+```
+PINNED                                       ← text-[10px] uppercase tracking-wide muted, px-2 py-1
+📄 Color tokens spec                     📌
+📄 Spacing scale                         📌
+──────────────────────────────────────────  ← hairline (border-border/50), my-1.5
+```
+
+### All-notes header + sort (one slim row)
+
+```
+ALL NOTES                                ⇅   ← label left, SortDropdown right (size-5 ghost)
+```
+
+- Sort options unchanged (Recent / Created / Alphabetical), same `setSortBy`.
+
+### Note row — single-line (~28px), the core change
+
+- Container: `group/noteitem flex items-center gap-2 rounded-md px-2 py-1 hover:bg-accent/50
+  cursor-pointer`, keeps `role="button"`, `tabIndex={0}`, Enter/Space handler.
+- Icon: emoji via `NoteIconDisplay` or `FileText` `size-3.5 text-muted-foreground`, `shrink-0`.
+- Title: `flex-1 min-w-0 truncate text-[13px] leading-5`.
+- Right cluster (`ml-auto flex items-center gap-1`, fixed min-width to avoid layout shift):
+  - Relative date: `text-[10px] tabular-nums text-muted-foreground/70` (existing `formatDate`).
+  - Pin toggle: `size-5` button.
+    - Unpinned: `opacity-0 group-hover/noteitem:opacity-100`; date visible at rest.
+    - Pinned: filled pin always visible, tag/primary tint; click = unpin.
+  - Reserve the pin slot width at rest so hover reveal causes no horizontal jump.
+
+### States
+
+- **Loading:** `NoteRowSkeleton` ×3 — `flex items-center gap-2 px-2 py-1` with an `animate-pulse`
+  `size-3.5` muted square + a muted bar (`h-3 w-3/4 rounded`).
+- **Empty (`count === 0`):** keep existing compact centered copy + i18n keys.
+- **Error:** keep existing compact centered destructive text.
+
+## Principles (frontend-design)
+
+- One accent only = the tag color (dot + pinned pin tint). No new borders/gradients/shadows.
+- Tight vertical rhythm; tabular-nums dates; hover-reveal affordances.
+- Type scale matches `SidebarTagList` (`text-[11px]/[13px]`, `size-3.5` icons).
+- RTL-safe: use logical classes (`ms-*`/`me-*`, `ps-*`/`pe-*`) for any new spacing.
+
+## Out of scope
+
+Drill-down slide animation, `useTagDetail`, `tagsService`, contracts/IPC, rename/delete/color
+dialogs, the tag tree in `SidebarTagList`. Behavior is identical; only markup + classes change.
+
+## Verification
+
+- `pnpm --filter @memry/desktop typecheck:web`
+- `pnpm lint` (RTL logical-class rule, no `console.*`)
+- Existing `sidebar-tag-list.test.tsx` stays green (untouched behavior).
+- Add a light render test for `TagDetailView` asserting: renders note titles, pin toggle present,
+  sort control present, skeleton on loading — locks structure without pixel assertions.
+- Visual confirmation in the running app (`/design-review`): density, hover, pinned tint, RTL.
+- `pnpm docs:impact --base <base> --strict` (renderer change; expect no doc routing, restyle only).


### PR DESCRIPTION
## What

Visual-only restyle of the tag drill-down panel (`TagDetailView`) — the panel that slides in when you click a tag in the sidebar and lists that tag's notes. Goal: compact, clean, UX-friendly.

**No behavior, wiring, IPC, contract, hook, or data changes.** Same drill-down flow, same actions.

## Changes

- **Header:** two lines → one compact row (`‹  ● tag · count … ⋯`); full "N notes" string moved to the tag-name tooltip; lighter border; smaller back/overflow buttons.
- **Note rows:** two-line → **single-line** (icon + title + right-aligned relative date). ~28px rows, inset hover pill.
- **Pin affordance:** consolidated the two pin branches into one; pin slot is reserved so hover reveal never shifts the row; pinned notes keep the filled pin in the tag/primary tint.
- **Loading:** skeleton rows that match the new row layout (replaces the "Loading notes…" text).
- **Sections:** tighter uppercase micro-labels for Pinned / All notes.
- Converted 6 pre-existing `mr-2` → `me-2` in this file (required by the renderer RTL guard once the file is staged).

Kept intact: sort control, pin/unpin, tag actions menu (rename / color / delete), note count, keyboard activation, i18n keys.

## Verification

- `pnpm --filter @memry/desktop typecheck:web` — green
- `eslint` on the file — clean
- Existing `sidebar-tag-list.test.tsx` unaffected (does not import this component)
- Spec: `docs/superpowers/specs/2026-06-12-tag-notes-sidebar-redesign-design.md`

## Notes

- Docs gate flagged `missing-docs`, but this is intentionally non-docs: the feature/behavior is unchanged, only markup + Tailwind classes. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`.
- **Remaining:** in-app visual QA (density, hover, pinned tint, RTL) not yet run — recommended before marking ready.