### PR TITLE
fix(desktop): fade sidebar tag label only when its name is clipped

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -2544,6 +2544,38 @@ del.bn-inline-content {
   );
 }
 
+/* Fade mask only — pair with `truncate`/`min-w-0` and apply conditionally so the
+   fade appears solely when the label actually overflows (e.g. sidebar tag pills
+   that shrink-wrap their text). */
+.sidebar-label-fade-mask {
+  --sidebar-label-fade-width: 1.75rem;
+  -webkit-mask-image: linear-gradient(
+    to right,
+    #000 calc(100% - var(--sidebar-label-fade-width)),
+    rgba(0, 0, 0, 0.2) 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    #000 calc(100% - var(--sidebar-label-fade-width)),
+    rgba(0, 0, 0, 0.2) 100%
+  );
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+}
+
+[dir='rtl'] .sidebar-label-fade-mask {
+  -webkit-mask-image: linear-gradient(
+    to left,
+    #000 calc(100% - var(--sidebar-label-fade-width)),
+    rgba(0, 0, 0, 0.2) 100%
+  );
+  mask-image: linear-gradient(
+    to left,
+    #000 calc(100% - var(--sidebar-label-fade-width)),
+    rgba(0, 0, 0, 0.2) 100%
+  );
+}
+
 /* ============================================
    Outline Indicator (T078)
    Heading outline navigation component

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-tag-list.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-tag-list.test.tsx
@@ -138,4 +138,32 @@ describe('SidebarTagList', () => {
     fireEvent.keyDown(input, { key: 'Escape' })
     expect(screen.queryByPlaceholderText('filterTags')).not.toBeInTheDocument()
   })
+
+  it('fades the tag label only when its text overflows the available width', () => {
+    mocks.query.tags = [{ tag: 'travel', count: 42, color: 'red' }]
+
+    // jsdom default: scrollWidth === clientWidth === 0 → text fits → no fade mask
+    const fits = render(<SidebarTagList />)
+    expect(screen.getByText('travel').className).not.toContain('sidebar-label-fade-mask')
+    fits.unmount()
+
+    // scrollWidth > clientWidth → text overflows → fade mask applied
+    const scroll = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth')
+    const client = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      get: () => 100
+    })
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 40
+    })
+    try {
+      render(<SidebarTagList />)
+      expect(screen.getByText('travel').className).toContain('sidebar-label-fade-mask')
+    } finally {
+      if (scroll) Object.defineProperty(HTMLElement.prototype, 'scrollWidth', scroll)
+      if (client) Object.defineProperty(HTMLElement.prototype, 'clientWidth', client)
+    }
+  })
 })

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-tag-list.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-tag-list.tsx
@@ -91,6 +91,21 @@ function TagTreeItem({
   const colors = node.color ? getTagColors(node.color) : null
   const isSelected = selectedTag === node.fullPath
 
+  // The tag pill shrink-wraps its label, so the fade mask must only apply when
+  // the name is actually clipped — otherwise short names fade with room to spare.
+  const labelRef = React.useRef<HTMLSpanElement>(null)
+  const [isLabelTruncated, setIsLabelTruncated] = React.useState(false)
+
+  React.useLayoutEffect(() => {
+    const el = labelRef.current
+    if (!el) return
+    const measure = (): void => setIsLabelTruncated(el.scrollWidth > el.clientWidth)
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [node.name])
+
   const handleChevronClick = (e: React.MouseEvent) => {
     e.stopPropagation()
     onToggle(node.fullPath)
@@ -145,10 +160,15 @@ function TagTreeItem({
                 : { backgroundColor: 'var(--muted-foreground)' }
             }
           />
-          <span className="sidebar-label-fade">{node.name}</span>
+          <span
+            ref={labelRef}
+            className={cn('min-w-0 truncate', isLabelTruncated && 'sidebar-label-fade-mask')}
+          >
+            {node.name}
+          </span>
         </button>
 
-        <span className="ml-auto pr-2.5 text-[10px] text-muted-foreground/40 tabular-nums opacity-0 group-hover:opacity-100 transition-opacity">
+        <span className="ms-auto pe-2.5 text-[10px] text-muted-foreground/40 tabular-nums opacity-0 group-hover:opacity-100 transition-opacity">
           {node.totalCount}
         </span>
       </div>
@@ -411,7 +431,7 @@ export function SidebarTagList({
           <button
             type="button"
             onClick={() => setShowAll(!showAll)}
-            className="rounded-sm py-0.5 px-2 ml-6 text-[11px] font-medium leading-3.5 text-sidebar-muted hover:text-sidebar-foreground transition-colors text-left"
+            className="rounded-sm py-0.5 px-2 ms-6 text-[11px] font-medium leading-3.5 text-sidebar-muted hover:text-sidebar-foreground transition-colors text-start"
           >
             {showAll
               ? t('action.showLess')


### PR DESCRIPTION
## Problem

Sidebar **tag** pills showed the fade/shadow on the trailing edge of *every* label, even short names with plenty of room (`travel`, `daily`, `tech`…). Collections look fine by comparison.

## Root cause

`.sidebar-label-fade` applies its `mask-image` gradient **unconditionally** — it always fades the trailing `1.75rem` of the element's own box. For short labels the box shrink-wraps the text, so the fade zone lands on real characters. This affects every consumer of the class; it's just far more visible on the tag's colored pill than on a transparent collection/nav row. (Measured: a short tag and a short collection both render faded with `scrollWidth === clientWidth`, i.e. not actually overflowing.)

CSS masks can't know whether text overflows, so the fade fires even when it fits.

## Fix

Make the fade **conditional on real truncation** — the existing pattern in this codebase (`truncated-tab-title.tsx`, `property-cell.tsx`).

- `base.css`: add a mask-only class `.sidebar-label-fade-mask` (+ RTL). The shared `.sidebar-label-fade` is left untouched, so collections / nav / folders / bookmarks keep their current behavior.
- `sidebar-tag-list.tsx`: `TagTreeItem` measures `scrollWidth > clientWidth` in `useLayoutEffect` + a `ResizeObserver` (the sidebar is resizable). The label is `min-w-0 truncate` always, and the fade mask is applied only when the name is actually clipped.
- Converted the panel's pre-existing physical Tailwind classes (`ml-auto`, `pr-2.5`, `ml-6`, `text-left`) to logical equivalents to satisfy the renderer guardrail on the now-staged file.

## Test plan

- Added unit test: tag label gets `sidebar-label-fade-mask` only when `scrollWidth > clientWidth` (RED before fix → GREEN after).
- `typecheck:web` clean · `eslint` clean · 13/13 sidebar tests pass.
- Visual: short tags render crisp with no fade; long tags fade + ellipsize.

## Notes

- Docs gate skipped on push (`MEMRY_DOCS_IMPACT_SKIP=1`): visual-only renderer change, no documented behavior surface.
- In-app visual QA still worth a glance before marking ready.