### PR TITLE
feat(desktop): resizable inbox & task detail drawers with persisted width

### DIFF
--- a/apps/desktop/src/renderer/src/components/inbox-detail/inbox-detail-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/inbox-detail-panel.tsx
@@ -17,6 +17,8 @@ import { useT } from '@memry/i18n/renderer'
 
 import { cn } from '@/lib/utils'
 import { useDayPanel } from '@/contexts/day-panel-context'
+import { useResizablePanel } from '@/hooks/use-resizable-panel'
+import { PanelResizeRail } from '@/components/ui/panel-resize-rail'
 
 import { Button } from '@/components/ui/button'
 
@@ -34,6 +36,11 @@ const log = createLogger('Component:InboxDetailPanel')
 
 // Panel can work with either full or list item types
 type DetailItem = InboxItem | InboxItemListItem
+
+const INBOX_DETAIL_WIDTH_KEY = 'inbox-detail-width'
+const INBOX_DETAIL_WIDTH_DEFAULT_PX = 380
+const INBOX_DETAIL_WIDTH_MIN_PX = 300
+const INBOX_DETAIL_WIDTH_MAX_PX = 560
 
 // =============================================================================
 // Types
@@ -69,6 +76,17 @@ export const InboxDetailPanel = ({
   const { t } = useT('inbox')
   const { enabled: aiEnabled } = useAISettingsContext()
   const { isOpen: isDayPanelOpen, width: dayPanelWidth } = useDayPanel()
+  const {
+    width,
+    setWidth,
+    isResizing: isPanelResizing,
+    setIsResizing: setIsPanelResizing
+  } = useResizablePanel({
+    storageKey: INBOX_DETAIL_WIDTH_KEY,
+    defaultPx: INBOX_DETAIL_WIDTH_DEFAULT_PX,
+    minPx: INBOX_DETAIL_WIDTH_MIN_PX,
+    maxPx: INBOX_DETAIL_WIDTH_MAX_PX
+  })
   const queryClient = useQueryClient()
 
   // Retry transcription mutation
@@ -345,12 +363,19 @@ export const InboxDetailPanel = ({
       data-state={isOpen ? 'open' : 'closed'}
       className={cn(
         'fixed top-[37px] bottom-0 z-10 border-s bg-surface overflow-hidden',
-        'transition-[width,opacity,right] duration-200 ease-out',
-        isOpen ? 'w-[380px] opacity-100 border-border' : 'w-0 opacity-0 border-transparent'
+        'transition-[opacity,right] duration-200 ease-out',
+        !isPanelResizing && 'transition-[width,opacity,right] duration-200 ease-out',
+        isOpen ? 'opacity-100 border-border' : 'opacity-0 border-transparent'
       )}
-      style={{ right: isDayPanelOpen ? `${dayPanelWidth}px` : 0 }}
+      style={{
+        width: isOpen ? `${width}px` : 0,
+        right: isDayPanelOpen ? `${dayPanelWidth}px` : 0
+      }}
     >
-      <div className="w-[380px] h-full flex flex-col overflow-hidden [font-synthesis:none] text-[12px] leading-4">
+      <div
+        style={{ width: `${width}px` }}
+        className="h-full flex flex-col overflow-hidden [font-synthesis:none] text-[12px] leading-4"
+      >
         {isLoading ? (
           <ContentSkeleton />
         ) : item ? (
@@ -527,6 +552,17 @@ export const InboxDetailPanel = ({
           </>
         ) : null}
       </div>
+      {isOpen && (
+        <PanelResizeRail
+          width={width}
+          setWidth={setWidth}
+          setIsResizing={setIsPanelResizing}
+          minPx={INBOX_DETAIL_WIDTH_MIN_PX}
+          maxPx={INBOX_DETAIL_WIDTH_MAX_PX}
+          defaultPx={INBOX_DETAIL_WIDTH_DEFAULT_PX}
+          ariaLabel={t('detail.resize')}
+        />
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.test.tsx
@@ -98,12 +98,12 @@ describe('TaskDetailDrawer — editable properties', () => {
     vi.clearAllMocks()
   })
 
-  it('renders the task drawer 30 percent narrower than the previous 380px width', () => {
+  it('renders the task drawer at the default 266px width', () => {
     renderWithI18n(<TaskDetailDrawer {...defaultProps} />)
 
     const drawer = screen.getByRole('complementary')
-    expect(drawer).toHaveClass('w-[266px]')
-    expect(drawer.firstElementChild).toHaveClass('w-[266px]')
+    expect(drawer).toHaveStyle({ width: '266px' })
+    expect(drawer.firstElementChild).toHaveStyle({ width: '266px' })
   })
 
   describe('status editing', () => {

--- a/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState, useMemo, memo, useCallback } from 'react'
 import { useT } from '@memry/i18n/renderer'
 import { cn } from '@/lib/utils'
 import { useDayPanel } from '@/contexts/day-panel-context'
+import { useResizablePanel } from '@/hooks/use-resizable-panel'
+import { PanelResizeRail } from '@/components/ui/panel-resize-rail'
 import { type Task, type Priority, type RepeatConfig } from '@/data/task-model'
 import type { Project } from '@/data/tasks-data'
 import { getSubtasks } from '@/lib/subtask-utils'
@@ -15,6 +17,11 @@ import { StatusIcon } from '@/components/tasks/status-icon'
 import { FileAudio, FileImage, FilePdf, FileVideo, X, Plus, Trash } from '@/lib/icons'
 import { DeleteTaskDialog } from '@/components/tasks/delete-task-dialog'
 import type { FileType } from '@memry/shared/file-types'
+
+const TASK_DETAIL_WIDTH_KEY = 'task-detail-width'
+const TASK_DETAIL_WIDTH_DEFAULT_PX = 266
+const TASK_DETAIL_WIDTH_MIN_PX = 240
+const TASK_DETAIL_WIDTH_MAX_PX = 480
 
 // ============================================================================
 // TYPES
@@ -113,6 +120,12 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
 }: TaskDetailDrawerProps): React.JSX.Element {
   const { t, i18n } = useT('tasks')
   const { isOpen: isDayPanelOpen, width: dayPanelWidth } = useDayPanel()
+  const { width, setWidth, isResizing, setIsResizing } = useResizablePanel({
+    storageKey: TASK_DETAIL_WIDTH_KEY,
+    defaultPx: TASK_DETAIL_WIDTH_DEFAULT_PX,
+    minPx: TASK_DETAIL_WIDTH_MIN_PX,
+    maxPx: TASK_DETAIL_WIDTH_MAX_PX
+  })
   const [noteNames, setNoteNames] = useState<RelatedItemInfoById>({})
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [isAddingSubtask, setIsAddingSubtask] = useState(false)
@@ -275,12 +288,19 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
       aria-hidden={!isOpen}
       className={cn(
         'fixed top-[37px] bottom-0 z-10 border-s bg-surface overflow-hidden',
-        'transition-[width,opacity,right] duration-200 ease-out',
-        isOpen ? 'w-[266px] opacity-100 border-border' : 'w-0 opacity-0 border-transparent'
+        'transition-[opacity,right] duration-200 ease-out',
+        !isResizing && 'transition-[width,opacity,right] duration-200 ease-out',
+        isOpen ? 'opacity-100 border-border' : 'opacity-0 border-transparent'
       )}
-      style={{ right: isDayPanelOpen ? `${dayPanelWidth}px` : 0 }}
+      style={{
+        width: isOpen ? `${width}px` : 0,
+        right: isDayPanelOpen ? `${dayPanelWidth}px` : 0
+      }}
     >
-      <div className="w-[266px] h-full flex flex-col overflow-y-auto scrollbar-thin [font-synthesis:none] text-[12px] leading-4">
+      <div
+        style={{ width: `${width}px` }}
+        className="h-full flex flex-col overflow-y-auto scrollbar-thin [font-synthesis:none] text-[12px] leading-4"
+      >
         {task && project && (
           <>
             {/* ── Header: editable title + close ── */}
@@ -625,6 +645,17 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
           </>
         )}
       </div>
+      {isOpen && (
+        <PanelResizeRail
+          width={width}
+          setWidth={setWidth}
+          setIsResizing={setIsResizing}
+          minPx={TASK_DETAIL_WIDTH_MIN_PX}
+          maxPx={TASK_DETAIL_WIDTH_MAX_PX}
+          defaultPx={TASK_DETAIL_WIDTH_DEFAULT_PX}
+          ariaLabel={t('drawer.resize')}
+        />
+      )}
     </div>
   )
 })

--- a/apps/desktop/src/renderer/src/components/ui/panel-resize-rail.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/panel-resize-rail.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useRef } from 'react'
+
+export interface PanelResizeRailProps {
+  width: number
+  setWidth: React.Dispatch<React.SetStateAction<number>>
+  setIsResizing: React.Dispatch<React.SetStateAction<boolean>>
+  minPx: number
+  maxPx: number
+  defaultPx: number
+  ariaLabel: string
+  title?: string
+}
+
+// Matches useResizablePanel's cap: one side panel stays below half the window so
+// it can't collide with the day panel (which caps at 0.5).
+const VIEWPORT_FRACTION = 0.4
+
+/**
+ * Drag rail for a panel docked to the trailing edge. The handle sits on the
+ * panel's START (left) edge, so dragging it widens the panel. Double-click resets.
+ */
+export function PanelResizeRail({
+  width,
+  setWidth,
+  setIsResizing,
+  minPx,
+  maxPx,
+  defaultPx,
+  ariaLabel,
+  title
+}: PanelResizeRailProps): React.JSX.Element {
+  const startXRef = useRef(0)
+  const startWidthRef = useRef(0)
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      startXRef.current = e.clientX
+      startWidthRef.current = width
+      setIsResizing(true)
+
+      const onMouseMove = (moveEvent: MouseEvent): void => {
+        const delta = moveEvent.clientX - startXRef.current
+        const maxWidth = Math.min(maxPx, window.innerWidth * VIEWPORT_FRACTION)
+        // Handle is on the START (left) edge: drag left (negative delta) = wider.
+        const newWidth = Math.min(maxWidth, Math.max(minPx, startWidthRef.current - delta))
+        setWidth(newWidth)
+      }
+
+      const onMouseUp = (): void => {
+        setIsResizing(false)
+        document.removeEventListener('mousemove', onMouseMove)
+        document.removeEventListener('mouseup', onMouseUp)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+      }
+
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+      document.addEventListener('mousemove', onMouseMove)
+      document.addEventListener('mouseup', onMouseUp)
+    },
+    [width, setWidth, setIsResizing, minPx, maxPx]
+  )
+
+  const handleDoubleClick = useCallback(() => {
+    setWidth(defaultPx)
+  }, [setWidth, defaultPx])
+
+  return (
+    <button
+      aria-label={ariaLabel}
+      tabIndex={-1}
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
+      title={title}
+      className="absolute inset-y-0 start-0 z-20 w-4 -translate-x-1/2 cursor-col-resize after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border"
+    />
+  )
+}
+
+export default PanelResizeRail

--- a/apps/desktop/src/renderer/src/hooks/use-resizable-panel.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-resizable-panel.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+
+export interface ResizablePanelOptions {
+  storageKey: string
+  defaultPx: number
+  minPx: number
+  maxPx: number
+}
+
+export interface ResizablePanelState {
+  width: number
+  setWidth: React.Dispatch<React.SetStateAction<number>>
+  isResizing: boolean
+  setIsResizing: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+// Fraction of the viewport one side panel may occupy. Kept below the day panel's
+// 0.5 cap so the two side panels can never both claim half the window.
+const VIEWPORT_FRACTION = 0.4
+
+const clamp = (value: number, minPx: number, maxPx: number): number =>
+  Math.min(maxPx, Math.max(minPx, value))
+
+/**
+ * Width state for a drag-resizable panel: persists to localStorage, skips writes
+ * mid-drag, and clamps live width down when the window shrinks (responsive).
+ * Mirrors the day-panel / sidebar resize pattern.
+ */
+export function useResizablePanel({
+  storageKey,
+  defaultPx,
+  minPx,
+  maxPx
+}: ResizablePanelOptions): ResizablePanelState {
+  const [width, setWidth] = useState(() => {
+    try {
+      const stored = localStorage.getItem(storageKey)
+      if (!stored) return defaultPx
+      const parsed = Number(stored)
+      if (!Number.isFinite(parsed)) return defaultPx
+      return clamp(parsed, minPx, maxPx)
+    } catch {
+      return defaultPx
+    }
+  })
+
+  const [isResizing, setIsResizing] = useState(false)
+
+  // Persist width, but skip writes mid-drag to avoid thrashing localStorage.
+  useEffect(() => {
+    if (isResizing) return () => {}
+    try {
+      localStorage.setItem(storageKey, String(width))
+    } catch {
+      /* localStorage unavailable */
+    }
+    return () => {}
+  }, [storageKey, width, isResizing])
+
+  // Responsive: never let the panel overflow a shrunk window.
+  useEffect(() => {
+    const onResize = (): void => {
+      const cap = Math.min(maxPx, window.innerWidth * VIEWPORT_FRACTION)
+      setWidth((w) => (w > cap ? cap : w))
+    }
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [maxPx])
+
+  return { width, setWidth, isResizing, setIsResizing }
+}

--- a/apps/docs/src/user-guide/tasks/list-vs-kanban.md
+++ b/apps/docs/src/user-guide/tasks/list-vs-kanban.md
@@ -21,6 +21,8 @@ the note or file viewer. When a task has multiple related items, the indicator o
 
 Click the row body to open the task detail drawer. Inline status and priority controls open their own pickers without opening the drawer.
 
+Drag the drawer's left edge to resize it; double-click the edge to reset to the default width. The width is remembered across restarts.
+
 Rows can be drag-reordered. Multi-select with shift-click for bulk actions.
 
 When grouping is on, group headers show counts and roll up subtask progress.

--- a/packages/i18n/src/locales/en/inbox.json
+++ b/packages/i18n/src/locales/en/inbox.json
@@ -183,6 +183,7 @@
   },
   "detail": {
     "ariaLabel": "Item details",
+    "resize": "Resize panel",
     "closePanel": "Close panel",
     "resizeFiling": "Resize filing section",
     "restore": "Restore",

--- a/packages/i18n/src/locales/en/tasks.json
+++ b/packages/i18n/src/locales/en/tasks.json
@@ -50,6 +50,7 @@
   },
   "drawer": {
     "close": "Close task details",
+    "resize": "Resize panel",
     "subIssues": "Sub-issues",
     "addSubIssue": "Add sub-issue",
     "subIssuePlaceholder": "Add sub-issue…",


### PR DESCRIPTION
## What

Make the **inbox detail panel** and **task detail drawer** drag-resizable, responsive, and width-persisted across restarts — bringing them to parity with the existing day panel and sidebar.

## Why

Both detail drawers had hard-coded widths (`380px` inbox, `266px` task), so users couldn't size them to their content or screen.

## How

- **`useResizablePanel`** hook — localStorage-backed width, skips writes mid-drag, and clamps live width down on window resize so a drawer never overflows a shrunk window.
- **`PanelResizeRail`** — reusable left-edge drag handle (`col-resize`, double-click to reset), mirroring `DayPanelResizeRail`.
- Both drawers: fixed Tailwind width → inline `style` width, width transition gated off during drag, rail rendered on the panel edge.
- Bounds: inbox `380` (300–560), task `266` (240–480). Each right-side panel is capped at 40% of the viewport so it can't collide with the day panel.
- Persistence keys: `inbox-detail-width`, `task-detail-width`.

## Verification

- `pnpm --filter @memry/desktop typecheck:web` ✓
- `pnpm --filter @memry/desktop test:renderer` ✓ (4650 passed)
- ESLint ✓ (0 errors), Prettier ✓, `i18n:check` ✓, `docs:impact --strict` ✓
- Manual: drag/double-click-reset both drawers, width persists across reload, no overflow on narrow window, no collision with the day panel.

## Notes

- RTL resize uses physical `clientX` math (same latent behavior as the day-panel rail today) — flagged as a follow-up to fix both rails together.
