### PR TITLE
fix(desktop): add full-width gutter so note/journal content clears the sidebar

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/note-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-layout.tsx
@@ -105,7 +105,7 @@ export function NoteLayout({
             className={cn(
               'mx-auto w-full pt-6 pb-10 min-h-full transition-[max-width] duration-300 ease-in-out',
               showGridRail
-                ? 'grid items-start gap-x-12 px-0 [grid-template-columns:minmax(0,var(--note-layout-content-track))_20rem] max-[920px]:max-w-[var(--note-layout-content-max)] max-[920px]:grid-cols-1 max-[920px]:px-8'
+                ? 'grid items-start gap-x-12 px-24 [grid-template-columns:minmax(0,var(--note-layout-content-track))_20rem] max-[920px]:max-w-[var(--note-layout-content-max)] max-[920px]:grid-cols-1 max-[920px]:px-8'
                 : 'px-24 flex flex-col'
             )}
             style={canvasStyle}

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -816,7 +816,10 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
               className="marquee-zone relative min-h-full w-full flex flex-col"
             >
               <div
-                className="mx-auto w-full px-8 lg:px-12 min-h-full flex flex-col pt-6 pb-10 lg:pb-16 transition-[max-width] duration-300 ease-in-out"
+                className={cn(
+                  'mx-auto w-full min-h-full flex flex-col pt-6 pb-10 lg:pb-16 transition-[max-width] duration-300 ease-in-out',
+                  isFullWidth ? 'px-24 max-[920px]:px-8' : 'px-8 lg:px-12'
+                )}
                 style={{ maxWidth: isFullWidth ? '100%' : '64rem' }}
               >
                 <div className="flex flex-col flex-1 mx-auto w-full transition-[max-width] duration-300 ease-in-out">


### PR DESCRIPTION
## Problem

In full-width mode with a comment/review rail, a note's content hugged the sidebar with **no gap** — the title and body started right at the sidebar edge. The full-width grid-rail branch in `NoteLayout` used `px-0`, so the content column had zero horizontal padding.

## Fix

- **Note (`note-layout.tsx`):** give the full-width grid-rail branch the same `px-24` gutter the rail-less full-width branch already uses. Now full-width notes have a consistent 96px gutter whether or not a comment rail is present. Narrow (`max-[920px]`) keeps `px-8`.
- **Journal (`journal.tsx`):** align full-width to the same `px-24` gutter for note↔journal consistency. Centered (non-full-width) mode is untouched (`px-8 lg:px-12`).

Symmetric `px-*` only — RTL-safe.

## Verify

- `pnpm --filter @memry/desktop typecheck:web` — clean
- renderer suite — **4650 passed, 6 skipped, 0 failed** (includes `note-sidebar-surfaces`)