### PR TITLE
feat(desktop): editorial-minimal note/journal header + journal date fog

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -2125,6 +2125,80 @@ del.bn-inline-content {
   }
 }
 
+/* Journal date fog — soft, time-of-day tinted atmosphere drifting behind the
+   date heading. Tints are provided inline via --fog-tint / --fog-tint-2 (see
+   JournalDateDisplay) so the mood follows getTimeOfDay(). */
+@keyframes journal-fog-drift-a {
+  0%,
+  100% {
+    transform: translate3d(-3%, 0, 0) scale(1);
+    opacity: 0.85;
+  }
+  50% {
+    transform: translate3d(5%, -10%, 0) scale(1.15);
+    opacity: 1;
+  }
+}
+
+@keyframes journal-fog-drift-b {
+  0%,
+  100% {
+    transform: translate3d(4%, 4%, 0) scale(1.08);
+    opacity: 0.65;
+  }
+  50% {
+    transform: translate3d(-6%, -4%, 0) scale(1.22);
+    opacity: 0.9;
+  }
+}
+
+.journal-date-fog {
+  position: absolute;
+  inset: -15% -10% -35% -10%;
+  z-index: 0;
+  pointer-events: none;
+  /* Fade the fog's own alpha to zero before it reaches the scroll/overflow
+     boundaries on every side, so the clip lands in a transparent region
+     instead of leaving a hard edge. Two linear masks (horizontal + vertical)
+     are intersected to feather all four edges symmetrically. */
+  -webkit-mask:
+    linear-gradient(to right, transparent, #000 16%, #000 84%, transparent),
+    linear-gradient(to bottom, transparent, #000 26%, #000 74%, transparent);
+  -webkit-mask-composite: source-in;
+  mask:
+    linear-gradient(to right, transparent, #000 16%, #000 84%, transparent),
+    linear-gradient(to bottom, transparent, #000 26%, #000 74%, transparent);
+  mask-composite: intersect;
+}
+
+.journal-date-fog::before,
+.journal-date-fog::after {
+  content: '';
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(36px);
+  will-change: transform, opacity;
+}
+
+.journal-date-fog::before {
+  inset: 8% 40% 24% 0;
+  background: radial-gradient(closest-side, var(--fog-tint), transparent 82%);
+  animation: journal-fog-drift-a 15s ease-in-out infinite;
+}
+
+.journal-date-fog::after {
+  inset: 18% 0 0 34%;
+  background: radial-gradient(closest-side, var(--fog-tint-2, var(--fog-tint)), transparent 80%);
+  animation: journal-fog-drift-b 19s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .journal-date-fog::before,
+  .journal-date-fog::after {
+    animation: none;
+  }
+}
+
 /* Journal animation utilities */
 .journal-animate-in {
   animation: journal-fade-in 0.6s var(--ease-out) forwards;

--- a/apps/desktop/src/renderer/src/components/journal/journal-date-display.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-date-display.tsx
@@ -1,5 +1,4 @@
-import { useMemo } from 'react'
-import { Sun, Sunset, Moon } from '@/lib/icons'
+import { useMemo, type CSSProperties } from 'react'
 import { cn } from '@/lib/utils'
 import { createJournalDateLabels, getMonthName } from '@/lib/journal-utils'
 import type { JournalViewState } from './date-breadcrumb'
@@ -21,11 +20,13 @@ export interface JournalDateDisplayProps {
   className?: string
 }
 
-const TIME_CONFIG = {
-  morning: { icon: Sun, labelKey: 'date.greeting.morning', iconColor: 'text-amber-500' },
-  afternoon: { icon: Sunset, labelKey: 'date.greeting.afternoon', iconColor: 'text-orange-500' },
-  evening: { icon: Moon, labelKey: 'date.greeting.evening', iconColor: 'text-indigo-400' },
-  night: { icon: Moon, labelKey: 'date.greeting.night', iconColor: 'text-indigo-400' }
+// Time-of-day tinted fog drifting behind the date. Two radial blobs (::before /
+// ::after) read these custom properties; see `.journal-date-fog` in base.css.
+const FOG_CONFIG: Record<TimeOfDay, { tint: string; tint2: string }> = {
+  morning: { tint: 'rgba(217, 119, 6, 0.72)', tint2: 'rgba(245, 158, 11, 0.55)' },
+  afternoon: { tint: 'rgba(234, 88, 12, 0.72)', tint2: 'rgba(249, 115, 22, 0.52)' },
+  evening: { tint: 'rgba(99, 102, 241, 0.75)', tint2: 'rgba(79, 70, 229, 0.55)' },
+  night: { tint: 'rgba(79, 70, 229, 0.82)', tint2: 'rgba(67, 56, 202, 0.62)' }
 }
 
 function getTimeOfDay(): TimeOfDay {
@@ -40,24 +41,22 @@ export function JournalDateDisplay({ viewState, dateParts, className }: JournalD
   const { t, i18n: _i18n } = useT('journal')
   const dateLabels = useMemo(() => createJournalDateLabels(t), [t])
   const timeOfDay = useMemo(() => getTimeOfDay(), [])
-  const config = TIME_CONFIG[timeOfDay]
-  const Icon = config.icon
 
   if (viewState.type === 'day' && dateParts) {
+    const fog = FOG_CONFIG[timeOfDay]
     return (
-      <div className={cn('flex flex-col', className)}>
+      <div className={cn('relative flex flex-col', className)}>
+        <div
+          className="journal-date-fog"
+          style={{ '--fog-tint': fog.tint, '--fog-tint-2': fog.tint2 } as CSSProperties}
+          aria-hidden="true"
+        />
         <h1
-          className="text-[42px] tracking-[-0.02em] leading-12 font-normal text-text-bright"
+          className="relative z-[1] text-[42px] tracking-[-0.02em] leading-12 font-normal text-text-bright"
           style={{ fontFamily: 'var(--font-heading)' }}
         >
           {dateParts.dayName}, {dateParts.month} {dateParts.day}
         </h1>
-        <div className="flex items-center gap-2 mt-1.5">
-          <Icon className={cn('size-4', config.iconColor)} />
-          <span className="font-serif text-sm italic text-muted-foreground">
-            {t(config.labelKey)}
-          </span>
-        </div>
       </div>
     )
   }

--- a/apps/desktop/src/renderer/src/components/note/info-section/InfoHeader.tsx
+++ b/apps/desktop/src/renderer/src/components/note/info-section/InfoHeader.tsx
@@ -9,60 +9,8 @@ interface InfoHeaderProps {
   propertyCount?: number
 }
 
-export function InfoHeader({
-  isExpanded,
-  onToggle,
-  variant = 'default',
-  propertyCount = 0
-}: InfoHeaderProps) {
+export function InfoHeader({ isExpanded, onToggle, propertyCount = 0 }: InfoHeaderProps) {
   const { t } = useT('notes')
-
-  if (variant === 'embedded') {
-    return (
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-expanded={isExpanded}
-        className={cn(
-          'w-full flex items-center rounded-md py-1.5 px-2 gap-2',
-          'cursor-pointer select-none',
-          'transition-colors duration-150',
-          'hover:bg-[var(--surface-active)]/50'
-        )}
-      >
-        <div
-          className={cn(
-            'w-[3px] h-3.5 shrink-0 rounded-xs transition-colors duration-150',
-            isExpanded ? 'bg-sidebar-terracotta' : 'bg-transparent'
-          )}
-        />
-        <ChevronRight
-          className={cn(
-            'h-3 w-3 shrink-0 transition-transform duration-150',
-            isExpanded ? 'text-sidebar-terracotta rotate-90' : 'text-text-tertiary'
-          )}
-        />
-        <span
-          className={cn(
-            'text-[12px] font-sans leading-4 transition-colors duration-150',
-            isExpanded ? 'text-sidebar-terracotta font-medium' : 'text-text-secondary'
-          )}
-        >
-          {t('properties.title')}
-        </span>
-        {propertyCount > 0 && (
-          <span
-            className={cn(
-              'text-[11px] font-sans leading-3.5 transition-colors duration-150',
-              isExpanded ? 'text-sidebar-terracotta/60' : 'text-text-tertiary'
-            )}
-          >
-            {propertyCount}
-          </span>
-        )}
-      </button>
-    )
-  }
 
   return (
     <button
@@ -70,40 +18,30 @@ export function InfoHeader({
       onClick={onToggle}
       aria-expanded={isExpanded}
       className={cn(
-        'w-full flex items-center rounded-md py-1.5 px-2 gap-2',
+        'group/info-header flex w-fit items-center gap-1.5 rounded-md py-1 pe-2',
         'cursor-pointer select-none',
-        'transition-colors duration-150',
-        'hover:bg-[var(--surface-active)]/50'
+        'transition-opacity duration-150'
       )}
     >
-      <div
-        className={cn(
-          'w-[3px] h-3.5 shrink-0 rounded-xs transition-colors duration-150',
-          isExpanded ? 'bg-sidebar-terracotta' : 'bg-transparent'
-        )}
-      />
       <ChevronRight
         className={cn(
           'h-3 w-3 shrink-0 transition-transform duration-150',
-          isExpanded ? 'text-sidebar-terracotta rotate-90' : 'text-text-tertiary'
+          isExpanded ? 'rotate-90 text-sidebar-terracotta' : 'text-text-tertiary',
+          'group-hover/info-header:text-sidebar-terracotta'
         )}
       />
       <span
         className={cn(
-          'text-[12px] font-sans leading-4 transition-colors duration-150',
-          isExpanded ? 'text-sidebar-terracotta font-medium' : 'text-text-secondary'
+          'text-[11px] font-semibold uppercase tracking-[0.09em] leading-4 transition-colors duration-150',
+          isExpanded ? 'text-text-secondary' : 'text-text-tertiary',
+          'group-hover/info-header:text-text-secondary'
         )}
       >
         {t('properties.title')}
       </span>
       {propertyCount > 0 && (
-        <span
-          className={cn(
-            'text-[11px] font-sans leading-3.5 transition-colors duration-150',
-            isExpanded ? 'text-sidebar-terracotta/60' : 'text-text-tertiary'
-          )}
-        >
-          {propertyCount}
+        <span className="text-[11px] font-medium leading-4 text-text-tertiary tabular-nums">
+          · {propertyCount}
         </span>
       )}
     </button>

--- a/apps/desktop/src/renderer/src/components/note/info-section/InfoSection.tsx
+++ b/apps/desktop/src/renderer/src/components/note/info-section/InfoSection.tsx
@@ -170,7 +170,10 @@ export const InfoSection = memo(function InfoSection({
 
       {/* Collapsible Content */}
       {effectiveExpanded && (
-        <div id="properties-content">
+        <div
+          id="properties-content"
+          className={cn(variant === 'embedded' && 'mt-1.5 border-t border-border/60 pt-2.5')}
+        >
           {/* Section Header */}
           {folderProperties && folderProperties.length > 0 && (
             <div className="mb-3 flex items-center gap-1">

--- a/apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.tsx
+++ b/apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.tsx
@@ -4,7 +4,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { GripVertical, Trash2 } from '@/lib/icons'
 import { format } from 'date-fns'
 import { cn } from '@/lib/utils'
-import { Property, PROPERTY_TYPE_CONFIG } from './types'
+import { Property } from './types'
 import {
   TextEditor,
   NumberEditor,
@@ -288,8 +288,6 @@ export function PropertyRow({
   const [isNameHovered, setIsNameHovered] = useState(false)
   const nameInputRef = useRef<HTMLInputElement>(null)
 
-  const config = PROPERTY_TYPE_CONFIG[property.type]
-  const IconComponent = config.icon
   const isDragEnabled = isSortable && !disabled
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -365,7 +363,7 @@ export function PropertyRow({
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       className={cn(
-        'flex items-center py-[0px]',
+        'flex items-center py-1.5',
         'transition-colors duration-150',
         isDragging && 'opacity-60 bg-muted/20 rounded'
       )}
@@ -375,9 +373,9 @@ export function PropertyRow({
         onMouseEnter={() => setIsNameHovered(true)}
         onMouseLeave={() => setIsNameHovered(false)}
       >
-        {/* Icon / Drag Handle — fixed w-5 slot */}
+        {/* Drag Handle — fixed w-5 slot, empty at rest for a clean editorial look */}
         <div className="flex items-center w-5 shrink-0">
-          {showDragHandle ? (
+          {showDragHandle && (
             <button
               type="button"
               {...attributes}
@@ -394,8 +392,6 @@ export function PropertyRow({
             >
               <GripVertical className="h-3.5 w-3.5" />
             </button>
-          ) : (
-            <IconComponent className="h-3.5 w-3.5 text-text-tertiary" aria-hidden="true" />
           )}
         </div>
 
@@ -409,7 +405,7 @@ export function PropertyRow({
             onBlur={handleEndNameEdit}
             onKeyDown={handleNameKeyDown}
             className={cn(
-              'w-24 shrink-0',
+              'w-28 shrink-0',
               'text-[13px] text-muted-foreground font-sans',
               'bg-transparent border-b border-border',
               'focus:outline-none focus:border-muted-foreground',
@@ -421,8 +417,8 @@ export function PropertyRow({
           <span
             onClick={onNameChange ? handleStartNameEdit : undefined}
             className={cn(
-              'w-24 shrink-0',
-              'text-[13px] text-muted-foreground font-sans leading-4',
+              'w-28 shrink-0',
+              'text-[13px] text-text-tertiary font-sans leading-4',
               'truncate',
               onNameChange && !disabled && 'cursor-pointer hover:text-text-secondary'
             )}
@@ -477,7 +473,7 @@ export function PropertyRow({
           onClick={onDelete}
           aria-label={`${t('properties.delete')}: ${property.name}`}
           className={cn(
-            'ml-2 flex h-6 w-6 items-center justify-center',
+            'ms-2 flex h-6 w-6 items-center justify-center',
             'rounded text-text-tertiary',
             'transition-all duration-150',
             'hover:bg-destructive/10 hover:text-destructive',

--- a/apps/desktop/src/renderer/src/components/note/tags-row/TagChip.tsx
+++ b/apps/desktop/src/renderer/src/components/note/tags-row/TagChip.tsx
@@ -27,8 +27,8 @@ export function TagChip({ tag, onRemove, onClick, isSelected, isFocused, disable
 
   const pillClasses = cn(
     '[font-synthesis:none] relative inline-flex items-center gap-1',
-    'rounded-[10px] px-2 py-0.5',
-    'text-[11px]/3.5 font-medium',
+    'rounded-full px-2.5 py-1',
+    'text-[12px]/4 font-medium',
     'shrink-0 select-none',
     'transition-colors transition-opacity duration-150',
     isClickable ? 'cursor-pointer hover:opacity-80' : 'cursor-default',
@@ -64,7 +64,7 @@ export function TagChip({ tag, onRemove, onClick, isSelected, isFocused, disable
           }}
           aria-label={t('tagsRow.removeAria', { tag: tag.name })}
           className={cn(
-            'absolute -right-1 -top-1',
+            'absolute -end-1 -top-1',
             'flex h-3.5 w-3.5 items-center justify-center',
             'rounded-full bg-stone-500 text-white',
             'shadow-sm',

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -844,16 +844,10 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
                       }
                     >
                       <div className="min-w-0 flex flex-col flex-1">
-                        <div className="group/metadata flex flex-col pb-[15px]" data-marquee-ignore>
-                          <GhostAffordanceRow
-                            availableTags={availableTags}
-                            recentTags={recentTags}
-                            currentTagIds={journalTags.map((t) => t.id)}
-                            onAddTag={handleAddTag}
-                            onCreateTag={handleCreateTag}
-                            onAddProperty={handleAddPropertyWithExpand}
-                            className="mb-2"
-                          />
+                        <div
+                          className="group/metadata flex flex-col gap-2.5 pb-[15px]"
+                          data-marquee-ignore
+                        >
                           <JournalDateDisplay viewState={currentViewState} dateParts={dateParts} />
                           <TagsRow
                             tags={journalTags}
@@ -881,6 +875,17 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
                               hideAddButton
                             />
                           )}
+
+                          {/* Ghost affordance: add tag/property — fades in on hover/focus,
+                              placed below the metadata so it never sits above the date */}
+                          <GhostAffordanceRow
+                            availableTags={availableTags}
+                            recentTags={recentTags}
+                            currentTagIds={journalTags.map((t) => t.id)}
+                            onAddTag={handleAddTag}
+                            onCreateTag={handleCreateTag}
+                            onAddProperty={handleAddPropertyWithExpand}
+                          />
                         </div>
 
                         <div

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -1040,19 +1040,7 @@ export function NotePage({ noteId }: NotePageProps) {
         style={{ maxWidth: noteContentWidth ?? '100%' }}
       >
         {/* Title + Metadata zone — ghost affordance appears on hover */}
-        <div className="group/metadata flex flex-col pb-[15px]" data-marquee-ignore>
-          {/* Ghost affordance: fades in on hover/focus */}
-          <GhostAffordanceRow
-            availableTags={availableTags}
-            recentTags={recentTags}
-            currentTagIds={noteTags.map((t) => t.id)}
-            onAddTag={(...args) => void handleAddTag(...args)}
-            onCreateTag={(...args) => void handleCreateTag(...args)}
-            onAddProperty={handleAddPropertyWithExpand}
-            disabled={isDeleted}
-            className="mb-2"
-          />
-
+        <div className="group/metadata flex flex-col gap-2.5 pb-[15px]" data-marquee-ignore>
           <NoteTitle
             emoji={null}
             title={note.title}
@@ -1089,6 +1077,18 @@ export function NotePage({ noteId }: NotePageProps) {
               hideAddButton
             />
           )}
+
+          {/* Ghost affordance: add tag/property — fades in on hover/focus, placed
+              below the metadata so it never sits above the title */}
+          <GhostAffordanceRow
+            availableTags={availableTags}
+            recentTags={recentTags}
+            currentTagIds={noteTags.map((t) => t.id)}
+            onAddTag={(...args) => void handleAddTag(...args)}
+            onCreateTag={(...args) => void handleCreateTag(...args)}
+            onAddProperty={handleAddPropertyWithExpand}
+            disabled={isDeleted}
+          />
         </div>
 
         {/* Main content - BlockNote Editor */}


### PR DESCRIPTION
## Summary

Editorial-minimal redesign of the note + journal metadata header, plus a time-of-day fog behind the journal date. The old header read like a database admin grid (`#` type-glyphs, count badge, terracotta bar, cramped rows); this makes it minimal, catchy, and UX-friendly.

## What changed

**Note + journal header (shared components)**
- **PropertyRow** — removed the type-glyph at rest (drag grip still appears on hover); added vertical rhythm; widened + muted the label so the **value** reads as the emphasis.
- **InfoHeader** — collapsed the duplicated variant branch; `▸ PROPERTIES · 5` in tracked small-caps with a terracotta chevron when open; dropped the accent bar + count-badge chrome.
- **InfoSection** — hairline divider under the header (embedded/note variant).
- **TagChip** — softer `rounded-full`, slightly larger pills.
- **note.tsx / journal.tsx** — uniform `gap` rhythm; moved the `+ Add property / + Add tag` affordances **below** the metadata so they no longer sit above the title/date (fixes inverted hierarchy).

**Journal date fog**
- Replaced the icon + "Good night" greeting line with a soft fog layer behind the date, tinted by `getTimeOfDay()` (amber morning → orange afternoon → indigo evening/night).
- `base.css`: `journal-date-fog` (two blurred radial blobs) with slow drift keyframes; an intersected horizontal+vertical `mask` feathers all four edges so the journal's `overflow-hidden` / `overflow-y-auto` clip never leaves a hard line; `prefers-reduced-motion` freezes the drift.

## Scope notes
- `InfoHeader` + `PropertyRow` are shared, so template-editor inherits the look too (loses at-rest type icons there as well — easy to gate behind a `showTypeIcon` prop if wanted).
- The `date.greeting.*` i18n keys are now orphaned (informational only; `i18n:check` does not fail on them). Left in place rather than deleting locale data.

## Verification
- `typecheck:web` — pass
- ESLint (changed files) — clean
- renderer tests (note + journal + info-section + tags) — **498 pass / 0 fail** (6 pre-existing skips)
- `git diff --check` — clean
- Docs gate: cosmetic restyle, no behavioral/API change; the only removed user-visible element (journal greeting) is not referenced in any doc → `MEMRY_DOCS_IMPACT_SKIP=1`.

## QA pending
- Visual pass in the running desktop app (fog drift, all four time-of-day tints, light/dark themes, RTL).
