### PR TITLE
feat(tabs): reopen closed tab with Cmd+Shift+T

### DIFF
--- a/apps/desktop/src/renderer/src/components/keyboard/keyboard-shortcuts-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/keyboard/keyboard-shortcuts-dialog.tsx
@@ -70,6 +70,7 @@ export const getShortcutGroups = (): ShortcutGroup[] => {
         { combos: [[mod, 'T']], description: 'Open the new tab menu' },
         { combos: [[mod, 'W']], description: 'Close tab' },
         { combos: [[mod, shift, 'W']], description: 'Close all tabs in pane' },
+        { combos: [[mod, shift, 'T']], description: 'Reopen closed tab' },
         { combos: [['Ctrl', 'Tab']], description: 'Next tab' },
         { combos: [['Ctrl', shift, 'Tab']], description: 'Previous tab' },
         {

--- a/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
@@ -120,6 +120,16 @@ interface TabContextType {
   canNavForward: boolean
 
   /**
+   * Reopen the most recently closed tab (browser-style Cmd+Shift+T).
+   */
+  reopenClosedTab: () => void
+
+  /**
+   * True when there is a closed tab available to reopen.
+   */
+  canReopenClosedTab: boolean
+
+  /**
    * Pin a tab
    */
   pinTab: (tabId: string, groupId?: string) => void
@@ -433,6 +443,15 @@ export const TabProvider = ({
     [state.tabGroups, state.activeGroupId]
   )
 
+  const reopenClosedTab = useCallback(() => {
+    dispatch({ type: 'REOPEN_CLOSED_TAB' })
+  }, [])
+
+  const canReopenClosedTab = useMemo(
+    () => (state.recentlyClosed?.length ?? 0) > 0,
+    [state.recentlyClosed]
+  )
+
   const pinTab = useCallback((tabId: string, groupId?: string) => {
     const actualGroupId = groupId ?? activeGroupIdRef.current
     dispatch({
@@ -644,6 +663,8 @@ export const TabProvider = ({
       navForward,
       canNavBack,
       canNavForward,
+      reopenClosedTab,
+      canReopenClosedTab,
       pinTab,
       unpinTab,
       togglePinTab,
@@ -684,6 +705,8 @@ export const TabProvider = ({
       navForward,
       canNavBack,
       canNavForward,
+      reopenClosedTab,
+      canReopenClosedTab,
       pinTab,
       unpinTab,
       togglePinTab,

--- a/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
@@ -289,6 +289,7 @@ export const createInitialState = (): TabSystemState => {
       tabGroupId: initialGroup.id
     },
     activeGroupId: initialGroup.id,
-    settings: { ...DEFAULT_TAB_SETTINGS }
+    settings: { ...DEFAULT_TAB_SETTINGS },
+    recentlyClosed: []
   }
 }

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.ts
@@ -133,7 +133,8 @@ export const deserializeTabState = (persisted: PersistedTabState): Partial<TabSy
     tabGroups,
     layout: validLayout,
     activeGroupId: validActiveGroupId,
-    settings: migrated.settings
+    settings: migrated.settings,
+    recentlyClosed: []
   }
 }
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducer.ts
@@ -16,6 +16,7 @@ export function tabReducer(state: TabSystemState, action: TabAction): TabSystemS
     case 'CLOSE_TABS_TO_RIGHT':
     case 'CLOSE_ALL_TABS':
     case 'CLOSE_GROUP':
+    case 'REOPEN_CLOSED_TAB':
       return tabCrudReducer(state, action)
 
     case 'SET_ACTIVE_TAB':

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.test.ts
@@ -47,6 +47,7 @@ const baseState = (overrides: Partial<TabSystemState> = {}): TabSystemState => (
     restoreSessionOnStart: true,
     tabCloseButton: 'hover'
   },
+  recentlyClosed: [],
   ...overrides
 })
 
@@ -356,5 +357,110 @@ describe('tabCrudReducer', () => {
     )
     expect(Object.values(noLayout.tabGroups)[0].tabs[0].type).toBe('inbox')
     expect(noLayout.settings).toEqual(state.settings)
+  })
+
+  it('captures a closed tab onto the recentlyClosed stack with its origin and position', () => {
+    const state = baseState()
+
+    const closed = tabCrudReducer(state, {
+      type: 'CLOSE_TAB',
+      payload: { tabId: 'tasks', groupId: 'g1' }
+    })
+
+    expect(closed.recentlyClosed).toHaveLength(1)
+    expect(closed.recentlyClosed[0]).toMatchObject({
+      groupId: 'g1',
+      index: 2,
+      tab: { type: 'tasks', path: '/tasks' }
+    })
+  })
+
+  it('reopens the most recently closed tab at its original position and focuses it', () => {
+    const state = baseState()
+
+    const closed = tabCrudReducer(state, {
+      type: 'CLOSE_TAB',
+      payload: { tabId: 'note-a', groupId: 'g1' }
+    })
+    expect(closed.tabGroups.g1.tabs.map((t) => t.id)).toEqual(['pin', 'tasks'])
+
+    const reopened = tabCrudReducer(closed, { type: 'REOPEN_CLOSED_TAB' })
+
+    expect(reopened.tabGroups.g1.tabs.map((t) => t.id)).toEqual(['pin', 'generated-1', 'tasks'])
+    expect(reopened.tabGroups.g1.tabs[1]).toMatchObject({
+      type: 'note',
+      entityId: 'note-a',
+      path: '/note/note-a'
+    })
+    expect(reopened.tabGroups.g1.activeTabId).toBe('generated-1')
+    expect(reopened.recentlyClosed).toHaveLength(0)
+  })
+
+  it('reopens closed tabs in last-in-first-out order', () => {
+    const state = baseState()
+
+    const c1 = tabCrudReducer(state, {
+      type: 'CLOSE_TAB',
+      payload: { tabId: 'note-a', groupId: 'g1' }
+    })
+    const c2 = tabCrudReducer(c1, {
+      type: 'CLOSE_TAB',
+      payload: { tabId: 'tasks', groupId: 'g1' }
+    })
+    expect(c2.recentlyClosed.map((e) => e.tab.type)).toEqual(['note', 'tasks'])
+
+    const r1 = tabCrudReducer(c2, { type: 'REOPEN_CLOSED_TAB' })
+    expect(r1.tabGroups.g1.tabs.some((t) => t.type === 'tasks')).toBe(true)
+    expect(r1.recentlyClosed.map((e) => e.tab.type)).toEqual(['note'])
+
+    const r2 = tabCrudReducer(r1, { type: 'REOPEN_CLOSED_TAB' })
+    expect(r2.tabGroups.g1.tabs.some((t) => t.type === 'note')).toBe(true)
+    expect(r2.recentlyClosed).toHaveLength(0)
+  })
+
+  it('captures every tab removed by close-all', () => {
+    const state = baseState()
+
+    const closedAll = tabCrudReducer(state, {
+      type: 'CLOSE_ALL_TABS',
+      payload: { groupId: 'g1' }
+    })
+
+    expect(closedAll.tabGroups.g1.tabs.map((t) => t.id)).toEqual(['pin'])
+    expect(closedAll.recentlyClosed.map((e) => e.tab.type)).toEqual(['note', 'tasks'])
+  })
+
+  it('returns state unchanged when reopening with an empty stack', () => {
+    const state = baseState()
+    expect(tabCrudReducer(state, { type: 'REOPEN_CLOSED_TAB' })).toBe(state)
+  })
+
+  it('focuses an already-open entity tab instead of duplicating on reopen', () => {
+    const state = baseState({
+      recentlyClosed: [
+        {
+          tab: {
+            type: 'note',
+            title: 'Note A',
+            icon: 'file',
+            path: '/note/note-a',
+            entityId: 'note-a',
+            isPinned: false,
+            isModified: false,
+            isPreview: false,
+            isDeleted: false
+          },
+          groupId: 'g1',
+          index: 1,
+          closedAt: 1
+        }
+      ]
+    })
+
+    const reopened = tabCrudReducer(state, { type: 'REOPEN_CLOSED_TAB' })
+
+    expect(reopened.tabGroups.g1.tabs.map((t) => t.id)).toEqual(['pin', 'note-a', 'tasks'])
+    expect(reopened.tabGroups.g1.activeTabId).toBe('note-a')
+    expect(reopened.recentlyClosed).toHaveLength(0)
   })
 })

--- a/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/reducers/tab-crud-reducer.ts
@@ -1,4 +1,4 @@
-import type { Tab, TabAction, TabGroup, TabSystemState } from '../types'
+import type { ClosedTabEntry, Tab, TabAction, TabGroup, TabSystemState } from '../types'
 import { SINGLETON_TAB_TYPES } from '../types'
 import {
   generateId,
@@ -21,8 +21,53 @@ type CrudAction = Extract<
       | 'CLOSE_TABS_TO_RIGHT'
       | 'CLOSE_ALL_TABS'
       | 'CLOSE_GROUP'
+      | 'REOPEN_CLOSED_TAB'
   }
 >
+
+/** Max number of closed-tab snapshots retained for reopen (Cmd+Shift+T). */
+const MAX_RECENTLY_CLOSED = 25
+
+/** Snapshot a tab being closed so it can be reopened later. */
+const snapshotClosedTab = (tab: Tab, groupId: string, index: number): ClosedTabEntry => ({
+  tab: {
+    type: tab.type,
+    title: tab.title,
+    icon: tab.icon,
+    emoji: tab.emoji,
+    path: tab.path,
+    entityId: tab.entityId,
+    isPinned: tab.isPinned,
+    isModified: false,
+    isPreview: false,
+    isDeleted: false,
+    scrollPosition: tab.scrollPosition,
+    viewState: tab.viewState
+  },
+  groupId,
+  index,
+  closedAt: Date.now()
+})
+
+/** Append closed-tab snapshots, trimming the stack to MAX_RECENTLY_CLOSED. */
+const pushClosed = (
+  stack: ClosedTabEntry[] | undefined,
+  entries: ClosedTabEntry[]
+): ClosedTabEntry[] => {
+  const next = [...(stack ?? []), ...entries]
+  return next.length > MAX_RECENTLY_CLOSED ? next.slice(next.length - MAX_RECENTLY_CLOSED) : next
+}
+
+/** Snapshot the tabs removed by a bulk close, in original (left→right) order. */
+const snapshotRemoved = (
+  group: TabGroup,
+  groupId: string,
+  isRemoved: (tab: Tab, index: number) => boolean
+): ClosedTabEntry[] =>
+  group.tabs
+    .map((tab, index) => ({ tab, index }))
+    .filter(({ tab, index }) => isRemoved(tab, index))
+    .map(({ tab, index }) => snapshotClosedTab(tab, groupId, index))
 
 const closeGroup = (state: TabSystemState, groupId: string): TabSystemState => {
   const { [groupId]: _removedGroup, ...remainingGroups } = state.tabGroups
@@ -254,12 +299,16 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       if (tabIndex === -1) return state
 
       const newTabs = group.tabs.filter((t) => t.id !== tabId)
+      const recentlyClosed = pushClosed(state.recentlyClosed, [
+        snapshotClosedTab(group.tabs[tabIndex], groupId, tabIndex)
+      ])
 
       if (newTabs.length === 0) {
         if (Object.keys(state.tabGroups).length === 1) {
           const defaultTab = createDefaultTab()
           return {
             ...state,
+            recentlyClosed,
             tabGroups: {
               [groupId]: {
                 ...group,
@@ -271,7 +320,7 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
             }
           }
         }
-        return closeGroup(state, groupId)
+        return closeGroup({ ...state, recentlyClosed }, groupId)
       }
 
       let newActiveTabId = group.activeTabId
@@ -283,6 +332,7 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       const pruned = pruneHistory(group, new Set([tabId]))
       return {
         ...state,
+        recentlyClosed,
         tabGroups: {
           ...state.tabGroups,
           [groupId]: { ...pruned, tabs: newTabs, activeTabId: newActiveTabId }
@@ -300,9 +350,14 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       const tabsToKeep = group.tabs.filter((t) => t.id === tabId || t.isPinned)
       const removedIds = new Set(group.tabs.filter((t) => !tabsToKeep.includes(t)).map((t) => t.id))
       const pruned = pruneHistory(group, removedIds)
+      const recentlyClosed = pushClosed(
+        state.recentlyClosed,
+        snapshotRemoved(group, groupId, (t) => removedIds.has(t.id))
+      )
 
       return {
         ...state,
+        recentlyClosed,
         tabGroups: {
           ...state.tabGroups,
           [groupId]: { ...pruned, tabs: tabsToKeep, activeTabId: tabId }
@@ -322,9 +377,14 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       const tabsToKeep = group.tabs.filter((t, i) => i <= tabIndex || t.isPinned)
       const removedIds = new Set(group.tabs.filter((t) => !tabsToKeep.includes(t)).map((t) => t.id))
       const pruned = pruneHistory(group, removedIds)
+      const recentlyClosed = pushClosed(
+        state.recentlyClosed,
+        snapshotRemoved(group, groupId, (t) => removedIds.has(t.id))
+      )
 
       return {
         ...state,
+        recentlyClosed,
         tabGroups: {
           ...state.tabGroups,
           [groupId]: { ...pruned, tabs: tabsToKeep }
@@ -339,12 +399,17 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       if (!group) return state
 
       const pinnedTabs = group.tabs.filter((t) => t.isPinned)
+      const recentlyClosed = pushClosed(
+        state.recentlyClosed,
+        snapshotRemoved(group, groupId, (t) => !t.isPinned)
+      )
 
       if (pinnedTabs.length === 0) {
         if (Object.keys(state.tabGroups).length === 1) {
           const defaultTab = createDefaultTab()
           return {
             ...state,
+            recentlyClosed,
             tabGroups: {
               [groupId]: {
                 ...group,
@@ -356,7 +421,7 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
             }
           }
         }
-        return closeGroup(state, groupId)
+        return closeGroup({ ...state, recentlyClosed }, groupId)
       }
 
       const removedIds = new Set(group.tabs.filter((t) => !t.isPinned).map((t) => t.id))
@@ -364,6 +429,7 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
 
       return {
         ...state,
+        recentlyClosed,
         tabGroups: {
           ...state.tabGroups,
           [groupId]: { ...pruned, tabs: pinnedTabs, activeTabId: pinnedTabs[0]?.id || null }
@@ -379,6 +445,70 @@ export function tabCrudReducer(state: TabSystemState, action: CrudAction): TabSy
       if (!state.tabGroups[groupId]) return state
 
       return closeGroup(state, groupId)
+    }
+
+    case 'REOPEN_CLOSED_TAB': {
+      const stack = state.recentlyClosed ?? []
+      if (stack.length === 0) return state
+
+      const entry = stack[stack.length - 1]
+      const recentlyClosed = stack.slice(0, -1)
+
+      // Reopen into the original group if it still exists, else the active group.
+      const targetGroupId = state.tabGroups[entry.groupId] ? entry.groupId : state.activeGroupId
+      const group = state.tabGroups[targetGroupId]
+      if (!group) return { ...state, recentlyClosed }
+
+      const snap = entry.tab
+
+      // If the entity/singleton is already open in the target group, focus it
+      // instead of creating a duplicate (mirrors OPEN_TAB dedup).
+      const existing = snap.entityId
+        ? findTabByEntityIdInGroup(group, snap.entityId)
+        : group.tabs.find(
+            (t) => t.entityId === undefined && t.type === snap.type && t.path === snap.path
+          )
+      if (existing) {
+        return {
+          ...state,
+          recentlyClosed,
+          activeGroupId: targetGroupId,
+          tabGroups: {
+            ...state.tabGroups,
+            [targetGroupId]: recordActivation(group, existing.id)
+          }
+        }
+      }
+
+      const newTab: Tab = {
+        ...snap,
+        isPreview: false,
+        id: generateId(),
+        openedAt: Date.now(),
+        lastAccessedAt: Date.now()
+      }
+
+      let insertIndex = Math.min(entry.index, group.tabs.length)
+      if (!snap.isPinned) {
+        insertIndex = Math.max(insertIndex, getInsertIndexAfterPinned(group.tabs))
+      }
+      insertIndex = Math.min(insertIndex, group.tabs.length)
+
+      const newTabs = [
+        ...group.tabs.slice(0, insertIndex),
+        newTab,
+        ...group.tabs.slice(insertIndex)
+      ]
+
+      return {
+        ...state,
+        recentlyClosed,
+        activeGroupId: targetGroupId,
+        tabGroups: {
+          ...state.tabGroups,
+          [targetGroupId]: { ...recordActivation(group, newTab.id), tabs: newTabs }
+        }
+      }
     }
 
     default:

--- a/apps/desktop/src/renderer/src/contexts/tabs/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/types.ts
@@ -154,6 +154,25 @@ export interface TabSettings {
 }
 
 // =============================================================================
+// RECENTLY CLOSED TABS
+// =============================================================================
+
+/**
+ * Snapshot of a closed tab, used to reopen it (Cmd+Shift+T).
+ * In-memory only — not persisted across restarts.
+ */
+export interface ClosedTabEntry {
+  /** Serializable snapshot of the closed tab */
+  tab: Omit<Tab, 'id' | 'openedAt' | 'lastAccessedAt'>
+  /** Group the tab was closed from */
+  groupId: string
+  /** Original position within that group's tabs */
+  index: number
+  /** Timestamp when closed */
+  closedAt: number
+}
+
+// =============================================================================
 // TAB SYSTEM STATE
 // =============================================================================
 
@@ -173,6 +192,8 @@ export interface TabSystemState {
   isMaximized?: boolean
   /** Snapshot of layout before maximize, used to restore on toggle-off */
   preMaximizeLayout?: SplitLayout
+  /** LIFO stack of recently closed tabs (in-memory, for reopen). */
+  recentlyClosed: ClosedTabEntry[]
 }
 
 // =============================================================================
@@ -216,6 +237,7 @@ export type TabAction =
   | { type: 'CLOSE_TABS_TO_RIGHT'; payload: { tabId: string; groupId: string } }
   | { type: 'CLOSE_ALL_TABS'; payload: { groupId: string } }
   | { type: 'CLOSE_GROUP'; payload: { groupId: string } }
+  | { type: 'REOPEN_CLOSED_TAB' }
 
   // Tab navigation
   | { type: 'SET_ACTIVE_TAB'; payload: { tabId: string; groupId: string } }

--- a/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   dispatch: vi.fn(),
   openTab: vi.fn(),
   closeTab: vi.fn(),
+  reopenClosedTab: vi.fn(),
   pinTab: vi.fn(),
   unpinTab: vi.fn(),
   splitView: vi.fn(),
@@ -23,6 +24,7 @@ vi.mock('@/contexts/tabs', () => ({
     dispatch: mocks.dispatch,
     openTab: mocks.openTab,
     closeTab: mocks.closeTab,
+    reopenClosedTab: mocks.reopenClosedTab,
     pinTab: mocks.pinTab,
     unpinTab: mocks.unpinTab,
     splitView: mocks.splitView,
@@ -73,10 +75,13 @@ describe('useTabKeyboardShortcuts', () => {
     window.addEventListener('memry:new-tab-menu', newTabMenu)
 
     renderHook(() => useTabKeyboardShortcuts())
-    expect(mocks.shortcuts).toHaveLength(21)
+    expect(mocks.shortcuts).toHaveLength(22)
 
     shortcut('New tab').action()
     expect(newTabMenu).toHaveBeenCalled()
+
+    shortcut('Reopen closed tab').action()
+    expect(mocks.reopenClosedTab).toHaveBeenCalled()
 
     shortcut('Close tab').action()
     expect(mocks.windowClose).toHaveBeenCalled()

--- a/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.ts
@@ -11,8 +11,18 @@ import { useKeyboardShortcuts, type KeyboardShortcut } from './use-keyboard-shor
  * Hook providing all tab-related keyboard shortcuts
  */
 export const useTabKeyboardShortcuts = (): void => {
-  const { state, dispatch, openTab, closeTab, pinTab, unpinTab, splitView, navBack, navForward } =
-    useTabs()
+  const {
+    state,
+    dispatch,
+    openTab,
+    closeTab,
+    reopenClosedTab,
+    pinTab,
+    unpinTab,
+    splitView,
+    navBack,
+    navForward
+  } = useTabs()
 
   const shortcuts = useMemo<KeyboardShortcut[]>(() => {
     const activeGroup = state.tabGroups[state.activeGroupId]
@@ -64,6 +74,16 @@ export const useTabKeyboardShortcuts = (): void => {
           })
         },
         description: 'Close all tabs'
+      },
+
+      // Reopen closed tab (⌘⇧T) — like Chrome
+      {
+        key: 't',
+        modifiers: { meta: true, shift: true },
+        action: () => {
+          reopenClosedTab()
+        },
+        description: 'Reopen closed tab'
       },
 
       // =====================================================================
@@ -230,6 +250,7 @@ export const useTabKeyboardShortcuts = (): void => {
     dispatch,
     openTab,
     closeTab,
+    reopenClosedTab,
     pinTab,
     unpinTab,
     splitView,

--- a/apps/desktop/src/renderer/src/lib/shortcut-registry.ts
+++ b/apps/desktop/src/renderer/src/lib/shortcut-registry.ts
@@ -122,7 +122,7 @@ export const SHORTCUT_REGISTRY: ShortcutEntry[] = [
     label: 'Reopen Last Tab',
     description: 'Reopen the most recently closed tab',
     category: 'Tabs',
-    defaultBinding: { key: 't', modifiers: { meta: true } }
+    defaultBinding: { key: 't', modifiers: { meta: true, shift: true } }
   },
   {
     id: 'tabs.navBack',

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -31,6 +31,8 @@ Default shortcuts. Every entry in the Navigation, Tabs, Editor, and View categor
 | Pin / unpin tab   | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>P</kbd>                |
 | Duplicate tab     | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>D</kbd>                |
 
+> **Reopen closed tab** brings back the most recently closed tab at its original position and focus. Press it repeatedly to walk back through closed tabs, most recent first — it also recovers tabs closed in bulk by **Close all tabs**. The history is kept for the current session only.
+
 ## Split View
 
 Some commands use a chord — press <kbd>⌘</kbd>+<kbd>K</kbd>, release, then press the next key.


### PR DESCRIPTION
## What

Adds Chrome-style **Reopen Closed Tab** on <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>T</kbd>. Brings back the most recently closed tab at its original group and position, focusing it. Press repeatedly to walk back through closed tabs (LIFO, most-recent first).

## Why

The tab system could close tabs but never restore them — a closed tab was gone until full session restore on next launch. The shortcut registry already advertised a "Reopen Last Tab" entry, but it was never implemented (and was mis-bound to ⌘T, which actually opens the new-tab menu). This wires up the real behavior.

## How

- New in-memory LIFO stack `recentlyClosed` on `TabSystemState` (mirrors the existing `back`/`forward` history — not persisted across restarts).
- New `REOPEN_CLOSED_TAB` reducer action: pops the stack, re-inserts the tab at its original index (respecting pinned ordering), and focuses it. If the entity/singleton is already open in the target group, it focuses that instead of duplicating (mirrors `OPEN_TAB` dedup).
- Every close path captures a snapshot before discarding: single close (<kbd>⌘</kbd>+<kbd>W</kbd>, middle-click, the × button) plus bulk **Close All / Close Others / Close to Right**. Bulk closes push each removed tab individually; reopen pops one at a time.
- Bound in `use-tab-keyboard-shortcuts.ts`; the registry entry and the keyboard-shortcuts help dialog are updated so the displayed binding is correct.

### Binding note
The dormant `nav.newTask` registry entry also nominally uses ⌘⇧T but was never wired to a live handler, so there's no functional collision — only a cosmetic one in the settings rebind UI's conflict list. Left `nav.newTask` untouched (surgical); repointing/removing it is optional follow-up.

## Testing

- `tab-crud-reducer.test.ts`: capture-on-close, reopen-at-original-position, LIFO ordering, bulk-close capture, empty-stack no-op, focus-existing-instead-of-duplicate. Written test-first.
- `use-tab-keyboard-shortcuts.test.ts`: updated count + asserts the new shortcut fires `reopenClosedTab`.
- Full renderer suite green (377 files / 4655 tests), `typecheck:web` clean, `lint` clean, `i18n:check` ok, docs gate + `docs:build` pass.

## Out of scope
- Persisting the reopen stack across app restart (in-memory only; session restore already rebuilds the prior tab set on launch).
- Native Electron menu item (the renderer keydown already covers ⌘⇧T globally).