### PR TITLE
fix(calendar): keep week view pinned on window resize

### DIFF
--- a/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.test.tsx
@@ -137,4 +137,40 @@ describe('useWeekInfiniteScroll', () => {
     )
     expect(current?.dateForDayIndex(0)).toMatch(/^\d{4}-\d{2}-\d{2}$/)
   })
+
+  it('keeps the same day pinned when the container is resized', () => {
+    let current: UseWeekInfiniteScrollResult | null = null
+
+    function Harness(): React.JSX.Element {
+      current = useWeekInfiniteScroll({
+        initialDate: '2026-05-14',
+        gutterWidth: 48,
+        totalDays: 36_525
+      })
+      return <div data-testid="week-scroller" ref={current.scrollContainerRef} />
+    }
+
+    const { getByTestId } = render(<Harness />)
+    const scroller = getByTestId('week-scroller') as HTMLDivElement
+
+    // First real layout: (748 - 48 gutter) / 7 = 100px columns.
+    defineReadonlyNumber(scroller, 'clientWidth', 748)
+    act(() => {
+      ResizeObserverMock.instances[0].trigger()
+    })
+    expect(current?.columnWidth).toBe(100)
+    const pinnedScrollLeft = scroller.scrollLeft
+    expect(pinnedScrollLeft).toBeGreaterThan(0)
+    const pinnedDay = pinnedScrollLeft / 100
+
+    // Window widened: (1098 - 48) / 7 = 150px columns. The same day must stay
+    // pinned — scrollLeft is re-derived from the day position, not left at the
+    // stale pixel offset (which would jump hundreds of days into the past/future).
+    defineReadonlyNumber(scroller, 'clientWidth', 1098)
+    act(() => {
+      ResizeObserverMock.instances[0].trigger()
+    })
+    expect(current?.columnWidth).toBe(150)
+    expect(scroller.scrollLeft).toBe(pinnedDay * 150)
+  })
 })

--- a/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-week-infinite-scroll.ts
@@ -91,14 +91,27 @@ export function useWeekInfiniteScroll({
     return () => {}
   }, [columnWidth, virtualizer])
 
-  const didInitialScrollRef = useRef(false)
+  const lastLayoutColumnWidthRef = useRef(0)
   useLayoutEffect(() => {
-    if (didInitialScrollRef.current) return
-    if (columnWidth <= MIN_COLUMN_WIDTH) return
     const el = scrollContainerRef.current
     if (!el) return
-    el.scrollLeft = initialIndex * columnWidth
-    didInitialScrollRef.current = true
+    if (columnWidth <= MIN_COLUMN_WIDTH) return
+    const prev = lastLayoutColumnWidthRef.current
+    if (prev <= MIN_COLUMN_WIDTH) {
+      // First usable layout: position on the initial date.
+      lastLayoutColumnWidthRef.current = columnWidth
+      el.scrollLeft = initialIndex * columnWidth
+      return
+    }
+    if (prev === columnWidth) return
+    // Container resized: column width changed. scrollLeft is an absolute pixel
+    // offset (= dayIndex * columnWidth) and today's index is ~2300+, so leaving
+    // it stale would re-interpret the same pixels as a day hundreds of days off
+    // and jump the view. Re-derive scrollLeft from the current day position so
+    // the same day stays pinned.
+    const dayPosition = el.scrollLeft / prev
+    lastLayoutColumnWidthRef.current = columnWidth
+    el.scrollLeft = dayPosition * columnWidth
   }, [columnWidth, initialIndex])
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

In **week view**, resizing the app window made the calendar jump horizontally (today drifting far into the future). Reported: week view focused on today, drag to resize → view scrolls to the future.

## Root cause

`use-week-infinite-scroll.ts` stores the horizontal scroll position as an **absolute pixel offset** (`el.scrollLeft = dayIndex * columnWidth`), but `columnWidth` is **derived from the container width**:

```
columnWidth = (containerWidth - gutter) / 7
```

On resize, `columnWidth` changes but the stale `scrollLeft` pixel value stays put, so the same pixels re-interpret as a **different day**. Today's day index is `~2300+` (epoch `2020-01-01`), so even a 1px column delta shifts the view by **hundreds of days** — narrowing the window shrinks `columnWidth` → same pixels map to a higher index → **jumps to the future**.

A one-shot `didInitialScrollRef` guard positioned the view on first paint and then blocked any re-anchor, so width changes were never compensated.

## Fix

Re-derive `scrollLeft` from the current day position whenever `columnWidth` changes, so the same day stays pinned across resize:

```
dayPosition = el.scrollLeft / prevColumnWidth
el.scrollLeft = dayPosition * columnWidth
```

The initial-scroll-to-date behavior is preserved (first usable layout still positions on the anchor date).

## Tests

- Added `keeps the same day pinned when the container is resized` to `use-week-infinite-scroll.test.tsx` (red → green): after a 100px→150px column resize, `scrollLeft` re-derives to keep the same day pinned instead of staying at the stale offset.
- Full calendar renderer suite: **176 tests pass** (25 files).
- `typecheck:web` clean, ESLint clean on changed files.

## Notes

- Docs gate: non-docs internal scroll-anchoring fix (no documented behavior changes), pushed with `MEMRY_DOCS_IMPACT_SKIP=1`.
- In-app manual QA of the resize gesture is the only remaining optional verification.