### PR TITLE
feat(desktop): sidebar New split button + Picker-consistent create menus

### DIFF
--- a/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
@@ -227,6 +227,41 @@ vi.mock('@/hooks/use-file-drop', () => ({
   useFileDrop: () => ({ isDraggingFiles: false, dropHandlers: {} })
 }))
 
+// Minimal stateful Picker mock: the real Radix Popover does not open on click in
+// jsdom. Content is gated on a trigger click so the create-menu items only exist
+// after the chevron is clicked (avoids colliding with other tests that query
+// buttons like "newNote").
+vi.mock('@/components/ui/picker', async () => {
+  const React = await import('react')
+  const PickerCtx = React.createContext<{ open: boolean; toggle: () => void }>({
+    open: false,
+    toggle: () => {}
+  })
+  const Picker = ({ children }: { children: ReactNode }) => {
+    const [open, setOpen] = React.useState(false)
+    return (
+      <PickerCtx.Provider value={{ open, toggle: () => setOpen((value) => !value) }}>
+        {children}
+      </PickerCtx.Provider>
+    )
+  }
+  Picker.Trigger = ({ children }: { children: ReactNode }) => {
+    const { toggle } = React.useContext(PickerCtx)
+    return <span onClick={toggle}>{children}</span>
+  }
+  Picker.Content = ({ children }: { children: ReactNode }) => {
+    const { open } = React.useContext(PickerCtx)
+    return open ? <div>{children}</div> : null
+  }
+  Picker.List = ({ children }: { children: ReactNode }) => <div>{children}</div>
+  Picker.Item = ({ label, onClick }: { label: string; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {label}
+    </button>
+  )
+  return { Picker }
+})
+
 describe('AppSidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -275,6 +310,19 @@ describe('AppSidebar', () => {
     expect(mocks.notesTreeCreateNote).toHaveBeenCalled()
     fireEvent.click(screen.getByRole('button', { name: 'newFolder' }))
     expect(mocks.notesTreeCreateFolder).toHaveBeenCalled()
+  })
+
+  it('opens the new-item menu from the chevron and routes to journal', async () => {
+    render(<AppSidebar currentPage="inbox" viewCounts={{}} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'newItemMenu' }))
+    fireEvent.click(await screen.findByText('journal'))
+
+    expect(mocks.openSidebarItem).toHaveBeenCalledWith({
+      type: 'journal',
+      title: 'Journal',
+      path: '/journal'
+    })
   })
 
   it('opens tags, bookmarks, account settings, and the settings panel via the gear', () => {

--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -6,6 +6,7 @@ import { getI18n } from 'react-i18next'
 import {
   Calendar2,
   CloudOff,
+  ChevronDown,
   ChevronsDown,
   ChevronsUp,
   FilePlus,
@@ -33,6 +34,8 @@ import { SidebarTagList } from '@/components/sidebar/sidebar-tag-list'
 import { SidebarBookmarkList } from '@/components/sidebar/sidebar-bookmark-list'
 import { SidebarDrillDownContainer } from '@/components/sidebar/sidebar-drill-down-container'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Picker } from '@/components/ui/picker'
+import { NewItemMenuItems } from '@/components/tabs/new-item-menu-items'
 import { useSelectedFolder } from '@/contexts/selected-folder-context'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
@@ -390,17 +393,45 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
       <SidebarContent className="flex flex-col overflow-hidden gap-0">
         {/* Quick Action: New — persistent, stays visible during drill-down */}
         <div className="shrink-0 flex items-center px-3 pt-2 pb-0 group-data-[collapsible=icon]:hidden">
-          <button
-            type="button"
-            onClick={() => void handleNewNote()}
-            className="flex flex-1 items-center justify-center gap-2 h-[30px] rounded-[5px] bg-sidebar-surface hover:bg-black/[0.06] dark:hover:bg-white/[0.06] transition-colors cursor-pointer"
-            title={tPhaseF('phaseF.componentsAppSidebar.newNoteN')}
-          >
-            <Plus className="size-[15px] text-muted-foreground/70" />
-            <span className="text-[13px] text-muted-foreground/70 font-normal">
-              {tPhaseF('phaseF.componentsAppSidebar.new')}
-            </span>
-          </button>
+          <div className="flex flex-1 items-center h-[30px] rounded-[5px] bg-sidebar-surface overflow-hidden">
+            <button
+              type="button"
+              onClick={() => void handleNewNote()}
+              className="flex flex-1 items-center justify-center gap-2 h-full hover:bg-black/[0.06] dark:hover:bg-white/[0.06] transition-colors cursor-pointer"
+              title={tPhaseF('phaseF.componentsAppSidebar.newNoteN')}
+            >
+              <Plus className="size-[15px] text-muted-foreground/70" />
+              <span className="text-[13px] text-muted-foreground/70 font-normal">
+                {tPhaseF('phaseF.componentsAppSidebar.new')}
+              </span>
+            </button>
+            <Picker>
+              <Picker.Trigger asChild>
+                <button
+                  type="button"
+                  aria-label={tPhaseF('phaseF.componentsAppSidebar.newItemMenu')}
+                  className="flex h-full w-7 shrink-0 items-center justify-center border-s border-black/[0.06] dark:border-white/[0.08] hover:bg-black/[0.06] dark:hover:bg-white/[0.06] transition-colors cursor-pointer"
+                >
+                  <ChevronDown className="size-3.5 text-muted-foreground/70" />
+                </button>
+              </Picker.Trigger>
+              <Picker.Content width={200} align="end" side="bottom">
+                <NewItemMenuItems
+                  actions={{
+                    onNewNote: () => void handleNewNote(),
+                    onJournal: () =>
+                      openSidebarItem({ type: 'journal', title: 'Journal', path: '/journal' }),
+                    onCalendar: () =>
+                      openSidebarItem({ type: 'calendar', title: 'Calendar', path: '/calendar' }),
+                    onInbox: () =>
+                      openSidebarItem({ type: 'inbox', title: 'Inbox', path: '/inbox' }),
+                    onTasks: () =>
+                      openSidebarItem({ type: 'tasks', title: 'Tasks', path: '/tasks' })
+                  }}
+                />
+              </Picker.Content>
+            </Picker>
+          </div>
         </div>
         <SidebarNav
           items={mainNav}

--- a/apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Picker } from '@/components/ui/picker'
+import { NewItemMenuItems, type NewItemActions } from './new-item-menu-items'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key.split('.').at(-1) ?? key })
+}))
+
+function renderMenu(actions: NewItemActions) {
+  return render(
+    <Picker open onOpenChange={() => {}}>
+      <Picker.Content>
+        <NewItemMenuItems actions={actions} />
+      </Picker.Content>
+    </Picker>
+  )
+}
+
+describe('NewItemMenuItems', () => {
+  it('fires the matching action for each item', () => {
+    const actions: NewItemActions = {
+      onNewNote: vi.fn(),
+      onJournal: vi.fn(),
+      onCalendar: vi.fn(),
+      onInbox: vi.fn(),
+      onTasks: vi.fn()
+    }
+    renderMenu(actions)
+
+    fireEvent.click(screen.getByText('newNote'))
+    expect(actions.onNewNote).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('journal'))
+    expect(actions.onJournal).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('calendar'))
+    expect(actions.onCalendar).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('inboxCapture'))
+    expect(actions.onInbox).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('tasks'))
+    expect(actions.onTasks).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.tsx
@@ -1,0 +1,54 @@
+import { FileText, BookOpen, Calendar, Inbox, ListTodo } from '@/lib/icons'
+import { Picker } from '@/components/ui/picker'
+import { useT } from '@memry/i18n/renderer'
+
+export interface NewItemActions {
+  onNewNote: () => void
+  onJournal: () => void
+  onCalendar: () => void
+  onInbox: () => void
+  onTasks: () => void
+}
+
+interface NewItemMenuItemsProps {
+  actions: NewItemActions
+}
+
+export function NewItemMenuItems({ actions }: NewItemMenuItemsProps): React.JSX.Element {
+  const { t: tPhaseF } = useT('common')
+
+  return (
+    <Picker.List>
+      <Picker.Item
+        value="note"
+        label={tPhaseF('phaseF.componentsTabsNewTabMenu.newNote')}
+        icon={<FileText className="size-4" />}
+        onClick={actions.onNewNote}
+      />
+      <Picker.Item
+        value="journal"
+        label={tPhaseF('phaseF.componentsTabsNewTabMenu.journal')}
+        icon={<BookOpen className="size-4" />}
+        onClick={actions.onJournal}
+      />
+      <Picker.Item
+        value="calendar"
+        label={tPhaseF('phaseF.componentsTabsNewTabMenu.calendar')}
+        icon={<Calendar className="size-4" />}
+        onClick={actions.onCalendar}
+      />
+      <Picker.Item
+        value="inbox"
+        label={tPhaseF('phaseF.componentsTabsNewTabMenu.inboxCapture')}
+        icon={<Inbox className="size-4" />}
+        onClick={actions.onInbox}
+      />
+      <Picker.Item
+        value="tasks"
+        label={tPhaseF('phaseF.componentsTabsNewTabMenu.tasks')}
+        icon={<ListTodo className="size-4" />}
+        onClick={actions.onTasks}
+      />
+    </Picker.List>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/tabs/new-tab-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/new-tab-menu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState, useEffect } from 'react'
-import { Plus, FileText, BookOpen, Calendar, Inbox, ListTodo } from '@/lib/icons'
+import { Plus } from '@/lib/icons'
 import { useTabs } from '@/contexts/tabs'
 import { notesService } from '@/services/notes-service'
 import { extractErrorMessage } from '@/lib/ipc-error'
@@ -10,12 +10,8 @@ import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useT } from '@memry/i18n/renderer'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger
-} from '@/components/ui/dropdown-menu'
+import { Picker } from '@/components/ui/picker'
+import { NewItemMenuItems } from './new-item-menu-items'
 import { getI18n } from 'react-i18next'
 
 const log = createLogger('NewTabMenu')
@@ -145,10 +141,10 @@ export function NewTabMenu({ groupId }: NewTabMenuProps): React.JSX.Element {
   }, [openTab, groupId])
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
+    <Picker open={open} onOpenChange={setOpen}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
+          <Picker.Trigger asChild>
             <button
               type="button"
               className={cn(
@@ -162,7 +158,7 @@ export function NewTabMenu({ groupId }: NewTabMenuProps): React.JSX.Element {
             >
               <Plus className="w-4 h-4" />
             </button>
-          </DropdownMenuTrigger>
+          </Picker.Trigger>
         </TooltipTrigger>
         <TooltipContent
           side="bottom"
@@ -171,28 +167,17 @@ export function NewTabMenu({ groupId }: NewTabMenuProps): React.JSX.Element {
           {tPhaseF('phaseF.componentsTabsNewTabMenu.newTab2')}
         </TooltipContent>
       </Tooltip>
-      <DropdownMenuContent side="bottom" align="start" className="min-w-[180px]">
-        <DropdownMenuItem onClick={() => void handleNewNote()}>
-          <FileText className="size-4" />
-          <span>{tPhaseF('phaseF.componentsTabsNewTabMenu.newNote')}</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={handleNewJournal}>
-          <BookOpen className="size-4" />
-          <span>{tPhaseF('phaseF.componentsTabsNewTabMenu.journal')}</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={handleOpenCalendar}>
-          <Calendar className="size-4" />
-          <span>{tPhaseF('phaseF.componentsTabsNewTabMenu.calendar')}</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={handleOpenInbox}>
-          <Inbox className="size-4" />
-          <span>{tPhaseF('phaseF.componentsTabsNewTabMenu.inboxCapture')}</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={handleNewTask}>
-          <ListTodo className="size-4" />
-          <span>{tPhaseF('phaseF.componentsTabsNewTabMenu.tasks')}</span>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+      <Picker.Content width={200} align="start" side="bottom">
+        <NewItemMenuItems
+          actions={{
+            onNewNote: () => void handleNewNote(),
+            onJournal: handleNewJournal,
+            onCalendar: handleOpenCalendar,
+            onInbox: handleOpenInbox,
+            onTasks: handleNewTask
+          }}
+        />
+      </Picker.Content>
+    </Picker>
   )
 }

--- a/apps/desktop/src/renderer/src/components/tabs/tabs-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tabs-components.test.tsx
@@ -206,7 +206,7 @@ describe('tabs components coverage', () => {
     act(() => {
       window.dispatchEvent(new Event('memry:new-tab-menu'))
     })
-    fireEvent.click(screen.getByRole('button', { name: /newNote/ }))
+    fireEvent.click(screen.getByRole('option', { name: /newNote/ }))
     await waitFor(() => expect(notesService.create).toHaveBeenCalled())
     expect(dispatchSpy).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'memry:expand-folder' })
@@ -216,10 +216,22 @@ describe('tabs components coverage', () => {
       { groupId: 'group-1' }
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /journal/ }))
-    fireEvent.click(screen.getByRole('button', { name: /calendar/ }))
-    fireEvent.click(screen.getByRole('button', { name: /inboxCapture/ }))
-    fireEvent.click(screen.getByRole('button', { name: /tasks/ }))
+    act(() => {
+      window.dispatchEvent(new Event('memry:new-tab-menu'))
+    })
+    fireEvent.click(screen.getByRole('option', { name: /journal/ }))
+    act(() => {
+      window.dispatchEvent(new Event('memry:new-tab-menu'))
+    })
+    fireEvent.click(screen.getByRole('option', { name: /calendar/ }))
+    act(() => {
+      window.dispatchEvent(new Event('memry:new-tab-menu'))
+    })
+    fireEvent.click(screen.getByRole('option', { name: /inboxCapture/ }))
+    act(() => {
+      window.dispatchEvent(new Event('memry:new-tab-menu'))
+    })
+    fireEvent.click(screen.getByRole('option', { name: /tasks/ }))
     expect(tabsApi.openTab).toHaveBeenCalledWith(expect.objectContaining({ type: 'journal' }), {
       groupId: 'group-1'
     })

--- a/apps/desktop/src/renderer/src/components/tabs/tabs-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tabs-components.test.tsx
@@ -75,19 +75,6 @@ vi.mock('@/components/ui/tooltip', () => ({
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
 }))
 
-vi.mock('@/components/ui/dropdown-menu', () => ({
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuItem: ({
-    children,
-    onClick
-  }: {
-    children: React.ReactNode
-    onClick?: () => void
-  }) => <button onClick={onClick}>{children}</button>,
-  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
-}))
-
 vi.mock('@/lib/render-note-icon', () => ({
   NoteIconDisplay: ({ value }: { value: string }) => <span>{value}</span>
 }))

--- a/apps/desktop/src/renderer/src/components/ui/context-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/context-menu.tsx
@@ -45,7 +45,7 @@ function ContextMenuSubTrigger({
       data-slot="context-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground text-muted-foreground flex cursor-default items-center rounded-[5px] px-2 py-1.5 text-[13px] outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -64,7 +64,7 @@ function ContextMenuSubContent({
     <ContextMenuPrimitive.SubContent
       data-slot="context-menu-sub-content"
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-[var(--shadow-card-hover)]',
         'floating-content-motion',
         className
       )}
@@ -87,7 +87,7 @@ function ContextMenuContent({
           onCloseAutoFocus?.(e)
         }}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-[var(--shadow-card-hover)]',
           'floating-content-motion',
           className
         )}
@@ -112,7 +112,7 @@ function ContextMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground text-muted-foreground relative flex cursor-default items-center gap-2 rounded-[5px] px-2 py-1.5 text-[13px] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -130,7 +130,7 @@ function ContextMenuCheckboxItem({
     <ContextMenuPrimitive.CheckboxItem
       data-slot="context-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pe-2 ps-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-[5px] py-1.5 pe-2 ps-8 text-[13px] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -155,7 +155,7 @@ function ContextMenuRadioItem({
     <ContextMenuPrimitive.RadioItem
       data-slot="context-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pe-2 ps-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-[5px] py-1.5 pe-2 ps-8 text-[13px] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -181,7 +181,10 @@ function ContextMenuLabel({
     <ContextMenuPrimitive.Label
       data-slot="context-menu-label"
       data-inset={inset}
-      className={cn('text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      className={cn(
+        'text-foreground px-2 py-1.5 text-[13px] font-medium data-[inset]:pl-8',
+        className
+      )}
       {...props}
     />
   )

--- a/apps/docs/src/guide/tour.md
+++ b/apps/docs/src/guide/tour.md
@@ -6,7 +6,11 @@ A 60-second lap through the parts of the app you'll use most.
 
 ## The Sidebar
 
-The left sidebar is your primary navigation. Sections from top to bottom:
+The left sidebar is your primary navigation.
+
+At the very top, the **New** button creates a note in one click. Click the chevron on its right to open the create menu — New Note, Journal, Calendar, Inbox, or Tasks — the same menu as the **+** on the tab bar.
+
+Sections from top to bottom:
 
 - **Notes** — recent and pinned notes
 - **Projects** — task projects with their incomplete-task counts

--- a/docs/superpowers/plans/2026-06-12-new-item-menus.md
+++ b/docs/superpowers/plans/2026-06-12-new-item-menus.md
@@ -1,0 +1,610 @@
+# New-item Menus + Picker-consistent Dropdowns Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the sidebar "New" button a split-button dropdown that opens the same create-menu as the tab "+", build both on the existing `Picker` component, and restyle the shared right-click `ContextMenu` primitive to match the Picker look.
+
+**Architecture:** A new presentational `NewItemMenuItems` renders five `Picker.Item` action rows and is reused by both the tab "+" menu and the sidebar split button (each supplies its own `Picker` shell + handlers). Right-click menus stay on Radix `ContextMenu` (cursor-anchored) but get className-only restyling to the Picker aesthetic.
+
+**Tech Stack:** React 19, TypeScript, Tailwind, Radix Popover/ContextMenu, the in-house `Picker` component (`@/components/ui/picker`), Vitest + Testing Library, `@memry/i18n`.
+
+**Worktree:** `.worktrees/new-item-menus` (branch `new-item-menus`, off `origin/main`). All paths below are relative to that worktree root. Run all commands from `apps/desktop` unless noted.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-12-new-item-menus-design.md`
+
+---
+
+## File Structure
+
+- **Create** `apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.tsx` — shared 5-item Picker action list.
+- **Create** `apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.test.tsx` — unit test for the above.
+- **Modify** `apps/desktop/src/renderer/src/components/tabs/new-tab-menu.tsx` — rebuild on `Picker`, render `NewItemMenuItems`.
+- **Modify** `apps/desktop/src/renderer/src/components/app-sidebar.tsx` — split "New" button + chevron Picker dropdown.
+- **Modify** `apps/desktop/src/renderer/src/components/app-sidebar.test.tsx` — add chevron→journal test case.
+- **Modify** `apps/desktop/src/renderer/src/components/ui/context-menu.tsx` — restyle to Picker look.
+- **Modify** `packages/i18n/src/locales/en/common.json` — add `componentsAppSidebar.newItemMenu`.
+
+---
+
+## Task 1: Add the chevron aria-label i18n key
+
+**Files:**
+
+- Modify: `packages/i18n/src/locales/en/common.json` (the `componentsAppSidebar` block, ~lines 203-215)
+
+Only the English key is required: `apps/desktop/scripts/i18n/check.mjs` fails the build (`i18n:check`) only on keys used-but-missing-in-English, unknown namespaces, untranslated source literals, or TODOs. Missing keys in the other 31 locales are reported as warnings and do **not** change the exit code.
+
+- [ ] **Step 1: Add the key**
+
+In `packages/i18n/src/locales/en/common.json`, inside `"componentsAppSidebar"`, add a `newItemMenu` entry. The block currently ends:
+
+```json
+      "newNoteN": "New note (⌘N)",
+      "new": "New",
+      "syncDisabled": "Sync disabled",
+      "syncDisabled2": "Sync disabled"
+    },
+```
+
+Change to:
+
+```json
+      "newNoteN": "New note (⌘N)",
+      "new": "New",
+      "newItemMenu": "Create new…",
+      "syncDisabled": "Sync disabled",
+      "syncDisabled2": "Sync disabled"
+    },
+```
+
+- [ ] **Step 2: Validate JSON parses**
+
+Run (from repo root): `node -e "JSON.parse(require('fs').readFileSync('packages/i18n/src/locales/en/common.json','utf8')); console.log('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/i18n/src/locales/en/common.json
+git commit -m "i18n(desktop): add componentsAppSidebar.newItemMenu label"
+```
+
+---
+
+## Task 2: Create the shared `NewItemMenuItems` component (TDD)
+
+**Files:**
+
+- Create: `apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.tsx`
+- Test: `apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.test.tsx`
+
+The component renders five `Picker.Item` action rows. `Picker.Item` calls its `onClick` prop, then (if not `preventDefault`'d) calls the Picker context's `onValueChange(value)`; with default `mode="single"` and no root `onValueChange`, that just closes the popover. So each row runs its action then the menu auto-closes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Picker } from '@/components/ui/picker'
+import { NewItemMenuItems, type NewItemActions } from './new-item-menu-items'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key.split('.').at(-1) ?? key })
+}))
+
+function renderMenu(actions: NewItemActions) {
+  return render(
+    <Picker open onOpenChange={() => {}}>
+      <Picker.Content>
+        <NewItemMenuItems actions={actions} />
+      </Picker.Content>
+    </Picker>
+  )
+}
+
+describe('NewItemMenuItems', () => {
+  it('fires the matching action for each item', () => {
+    const actions: NewItemActions = {
+      onNewNote: vi.fn(),
+      onJournal: vi.fn(),
+      onCalendar: vi.fn(),
+      onInbox: vi.fn(),
+      onTasks: vi.fn()
+    }
+    renderMenu(actions)
+
+    fireEvent.click(screen.getByText('newNote'))
+    expect(actions.onNewNote).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('journal'))
+    expect(actions.onJournal).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('calendar'))
+    expect(actions.onCalendar).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('inboxCapture'))
+    expect(actions.onInbox).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('tasks'))
+    expect(actions.onTasks).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- new-item-menu-items`
+Expected: FAIL — cannot resolve `./new-item-menu-items` (module does not exist yet).
+
+- [ ] **Step 3: Create the component**
+
+Create `apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.tsx`:
+
+```tsx
+import { FileText, BookOpen, Calendar, Inbox, ListTodo } from '@/lib/icons'
+import { Picker } from '@/components/ui/picker'
+import { useT } from '@memry/i18n/renderer'
+
+export interface NewItemActions {
+  onNewNote: () => void
+  onJournal: () => void
+  onCalendar: () => void
+  onInbox: () => void
+  onTasks: () => void
+}
+
+interface NewItemMenuItemsProps {
+  actions: NewItemActions
+}
+
+export function NewItemMenuItems({ actions }: NewItemMenuItemsProps): React.JSX.Element {
+  const { t: tPhaseF } = useT('common')
+
+  return (
+    <Picker.List>
+      <Picker.Item
+        value="note"
+        label={tPhaseF('phaseF.componentsTabsNewTabMenu.newNote')}
+        icon={<FileText className="size-4" />}
+        onClick={actions.onNewNote}
+      />
+      <Picker.Item
+        value="journal"
+        label={tPhaseF('phaseF.componentsTabsNewTabMenu.journal')}
+        icon={<BookOpen className="size-4" />}
+        onClick={actions.onJournal}
+      />
+      <Picker.Item
+        value="calendar"
+        label={tPhaseF('phaseF.componentsTabsNewTabMenu.calendar')}
+        icon={<Calendar className="size-4" />}
+        onClick={actions.onCalendar}
+      />
+      <Picker.Item
+        value="inbox"
+        label={tPhaseF('phaseF.componentsTabsNewTabMenu.inboxCapture')}
+        icon={<Inbox className="size-4" />}
+        onClick={actions.onInbox}
+      />
+      <Picker.Item
+        value="tasks"
+        label={tPhaseF('phaseF.componentsTabsNewTabMenu.tasks')}
+        icon={<ListTodo className="size-4" />}
+        onClick={actions.onTasks}
+      />
+    </Picker.List>
+  )
+}
+```
+
+Note: `React.JSX.Element` is used as the return type without importing React — this matches the sibling `new-tab-menu.tsx`, which relies on the project's global React types.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- new-item-menu-items`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.tsx apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.test.tsx
+git commit -m "feat(desktop): add shared NewItemMenuItems Picker action list"
+```
+
+---
+
+## Task 3: Rebuild the tab "+" menu on Picker
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/components/tabs/new-tab-menu.tsx`
+
+Keep every handler and the `memry:new-tab-menu` open-event logic unchanged. Only swap the Radix `DropdownMenu` shell for `Picker` and render the shared item list. This removes the now-duplicated icon imports.
+
+- [ ] **Step 1: Update imports**
+
+In `new-tab-menu.tsx`, replace the icon import (line 2):
+
+```tsx
+import { Plus, FileText, BookOpen, Calendar, Inbox, ListTodo } from '@/lib/icons'
+```
+
+with:
+
+```tsx
+import { Plus } from '@/lib/icons'
+```
+
+Replace the dropdown-menu import block (lines 13-18):
+
+```tsx
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+```
+
+with:
+
+```tsx
+import { Picker } from '@/components/ui/picker'
+import { NewItemMenuItems } from './new-item-menu-items'
+```
+
+- [ ] **Step 2: Replace the returned JSX**
+
+Replace the entire `return (...)` block (lines 147-197) with:
+
+```tsx
+return (
+  <Picker open={open} onOpenChange={setOpen}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Picker.Trigger asChild>
+          <button
+            type="button"
+            className={cn(
+              'flex h-7 w-7 items-center justify-center rounded-md',
+              'text-text-tertiary hover:text-foreground',
+              'hover:bg-surface-active/50',
+              'transition-all duration-150 ease-out',
+              'active:scale-95 active:bg-surface-active/70'
+            )}
+            aria-label={tPhaseF('phaseF.componentsTabsNewTabMenu.newTab')}
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+        </Picker.Trigger>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        className="text-xs px-2.5 py-1.5 font-medium bg-primary text-primary-foreground border-0"
+      >
+        {tPhaseF('phaseF.componentsTabsNewTabMenu.newTab2')}
+      </TooltipContent>
+    </Tooltip>
+    <Picker.Content width={200} align="start" side="bottom">
+      <NewItemMenuItems
+        actions={{
+          onNewNote: () => void handleNewNote(),
+          onJournal: handleNewJournal,
+          onCalendar: handleOpenCalendar,
+          onInbox: handleOpenInbox,
+          onTasks: handleNewTask
+        }}
+      />
+    </Picker.Content>
+  </Picker>
+)
+```
+
+- [ ] **Step 3: Typecheck the renderer**
+
+Run: `pnpm --filter @memry/desktop typecheck:web`
+Expected: PASS — no unused-import or type errors in `new-tab-menu.tsx`. (`cn` is still used by the trigger button; `Plus`, `Tooltip*`, `useT`, all handlers remain used.)
+
+- [ ] **Step 4: Run the tab test suite**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- tabs`
+Expected: PASS — existing tab tests stay green (handlers and the trigger's accessible name are unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/tabs/new-tab-menu.tsx
+git commit -m "refactor(desktop): rebuild tab new-tab menu on Picker"
+```
+
+---
+
+## Task 4: Sidebar "New" split button + dropdown
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/components/app-sidebar.tsx`
+- Test: `apps/desktop/src/renderer/src/components/app-sidebar.test.tsx`
+
+The left half keeps the instant new-note behavior and its accessible name `new`. The right half is a `ChevronDown` Picker trigger whose menu opens in the active pane via the sidebar's own `handleNewNote` and `openSidebarItem`.
+
+- [ ] **Step 1: Write the failing test case**
+
+In `app-sidebar.test.tsx`, add a new `it(...)` inside the `describe('AppSidebar', ...)` block (e.g. after the first test, around line 278):
+
+```tsx
+it('opens the new-item menu from the chevron and routes to journal', async () => {
+  render(<AppSidebar currentPage="inbox" viewCounts={{}} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'newItemMenu' }))
+  fireEvent.click(await screen.findByText('journal'))
+
+  expect(mocks.openSidebarItem).toHaveBeenCalledWith({
+    type: 'journal',
+    title: 'Journal',
+    path: '/journal'
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- app-sidebar`
+Expected: FAIL — no button named `newItemMenu` yet (chevron not implemented).
+
+- [ ] **Step 3: Update imports**
+
+In `app-sidebar.tsx`, add `ChevronDown` to the `@/lib/icons` import block (lines 6-16). It currently reads:
+
+```tsx
+import {
+  Calendar2,
+  CloudOff,
+  ChevronsDown,
+  ChevronsUp,
+  FilePlus,
+  FolderPlus,
+  Plus,
+  Settings,
+  Upload
+} from '@/lib/icons'
+```
+
+Change to:
+
+```tsx
+import {
+  Calendar2,
+  CloudOff,
+  ChevronDown,
+  ChevronsDown,
+  ChevronsUp,
+  FilePlus,
+  FolderPlus,
+  Plus,
+  Settings,
+  Upload
+} from '@/lib/icons'
+```
+
+Then add two imports next to the other component imports (e.g. after line 35, the tooltip import):
+
+```tsx
+import { Picker } from '@/components/ui/picker'
+import { NewItemMenuItems } from '@/components/tabs/new-item-menu-items'
+```
+
+- [ ] **Step 4: Replace the New button block**
+
+Replace the current New-button block (lines 395-407):
+
+```tsx
+<div className="shrink-0 flex items-center px-3 pt-2 pb-0 group-data-[collapsible=icon]:hidden">
+  <button
+    type="button"
+    onClick={() => void handleNewNote()}
+    className="flex flex-1 items-center justify-center gap-2 h-[30px] rounded-[5px] bg-sidebar-surface hover:bg-black/[0.06] dark:hover:bg-white/[0.06] transition-colors cursor-pointer"
+    title={tPhaseF('phaseF.componentsAppSidebar.newNoteN')}
+  >
+    <Plus className="size-[15px] text-muted-foreground/70" />
+    <span className="text-[13px] text-muted-foreground/70 font-normal">
+      {tPhaseF('phaseF.componentsAppSidebar.new')}
+    </span>
+  </button>
+</div>
+```
+
+with:
+
+```tsx
+<div className="shrink-0 flex items-center px-3 pt-2 pb-0 group-data-[collapsible=icon]:hidden">
+  <div className="flex flex-1 items-center h-[30px] rounded-[5px] bg-sidebar-surface overflow-hidden">
+    <button
+      type="button"
+      onClick={() => void handleNewNote()}
+      className="flex flex-1 items-center justify-center gap-2 h-full hover:bg-black/[0.06] dark:hover:bg-white/[0.06] transition-colors cursor-pointer"
+      title={tPhaseF('phaseF.componentsAppSidebar.newNoteN')}
+    >
+      <Plus className="size-[15px] text-muted-foreground/70" />
+      <span className="text-[13px] text-muted-foreground/70 font-normal">
+        {tPhaseF('phaseF.componentsAppSidebar.new')}
+      </span>
+    </button>
+    <Picker>
+      <Picker.Trigger asChild>
+        <button
+          type="button"
+          aria-label={tPhaseF('phaseF.componentsAppSidebar.newItemMenu')}
+          className="flex h-full w-7 shrink-0 items-center justify-center border-s border-black/[0.06] dark:border-white/[0.08] hover:bg-black/[0.06] dark:hover:bg-white/[0.06] transition-colors cursor-pointer"
+        >
+          <ChevronDown className="size-3.5 text-muted-foreground/70" />
+        </button>
+      </Picker.Trigger>
+      <Picker.Content width={200} align="end" side="bottom">
+        <NewItemMenuItems
+          actions={{
+            onNewNote: () => void handleNewNote(),
+            onJournal: () =>
+              openSidebarItem({ type: 'journal', title: 'Journal', path: '/journal' }),
+            onCalendar: () =>
+              openSidebarItem({ type: 'calendar', title: 'Calendar', path: '/calendar' }),
+            onInbox: () => openSidebarItem({ type: 'inbox', title: 'Inbox', path: '/inbox' }),
+            onTasks: () => openSidebarItem({ type: 'tasks', title: 'Tasks', path: '/tasks' })
+          }}
+        />
+      </Picker.Content>
+    </Picker>
+  </div>
+</div>
+```
+
+`openSidebarItem` is already destructured from `useSidebarNavigation()` at line ~144; the `{ type, title, path }` payload matches the existing `handleNavClick` shape (`SidebarItem`).
+
+- [ ] **Step 5: Run the sidebar test suite**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- app-sidebar`
+Expected: PASS — both the new chevron→journal case and the existing first test (which clicks `name: 'new'` for the left button) are green.
+
+- [ ] **Step 6: Typecheck the renderer**
+
+Run: `pnpm --filter @memry/desktop typecheck:web`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/app-sidebar.tsx apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
+git commit -m "feat(desktop): sidebar New split button with Picker create menu"
+```
+
+---
+
+## Task 5: Restyle the shared ContextMenu primitive to the Picker look
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/components/ui/context-menu.tsx`
+
+className-only edits; structure, props, and exports stay the same. Four token changes: container shadow → `shadow-[var(--shadow-card-hover)]`, item radius `rounded-sm` → `rounded-[5px]`, item text `text-sm` → `text-[13px]`, and a resting `text-muted-foreground` on the default/sub-trigger items (mirrors `Picker.Item`; `focus:bg-accent`/`focus:text-accent-foreground` still brighten on hover, and destructive items keep their red `data-[variant=destructive]` color). `--shadow-card-hover` is the same CSS var `Picker.Content` uses.
+
+- [ ] **Step 1: ContextMenuSubTrigger (line ~48)**
+
+In the `ContextMenuSubTrigger` className, change `rounded-sm` → `rounded-[5px]`, `text-sm` → `text-[13px]`, and add `text-muted-foreground`. The string becomes:
+
+```tsx
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground text-muted-foreground flex cursor-default items-center rounded-[5px] px-2 py-1.5 text-[13px] outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+```
+
+- [ ] **Step 2: ContextMenuSubContent (line ~67)**
+
+Change `shadow-lg` → `shadow-[var(--shadow-card-hover)]`:
+
+```tsx
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-[var(--shadow-card-hover)]',
+```
+
+- [ ] **Step 3: ContextMenuContent (line ~90)**
+
+Change `shadow-md` → `shadow-[var(--shadow-card-hover)]`:
+
+```tsx
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-[var(--shadow-card-hover)]',
+```
+
+- [ ] **Step 4: ContextMenuItem (line ~115)**
+
+Change `rounded-sm` → `rounded-[5px]`, `text-sm` → `text-[13px]`, and add `text-muted-foreground` (placed before `relative`):
+
+```tsx
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground text-muted-foreground relative flex cursor-default items-center gap-2 rounded-[5px] px-2 py-1.5 text-[13px] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+```
+
+- [ ] **Step 5: ContextMenuCheckboxItem (line ~133)**
+
+Change `rounded-sm` → `rounded-[5px]`, `text-sm` → `text-[13px]`:
+
+```tsx
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-[5px] py-1.5 pe-2 ps-8 text-[13px] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+```
+
+- [ ] **Step 6: ContextMenuRadioItem (line ~158)**
+
+Change `rounded-sm` → `rounded-[5px]`, `text-sm` → `text-[13px]`:
+
+```tsx
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-[5px] py-1.5 pe-2 ps-8 text-[13px] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+```
+
+- [ ] **Step 7: ContextMenuLabel (line ~184)**
+
+Change `text-sm` → `text-[13px]` (keeps `text-foreground font-medium`):
+
+```tsx
+      className={cn('text-foreground px-2 py-1.5 text-[13px] font-medium data-[inset]:pl-8', className)}
+```
+
+(`ContextMenuSeparator` already matches `Picker` — `-mx-1 my-1 h-px bg-border` — leave it unchanged.)
+
+- [ ] **Step 8: Run context-menu-dependent suites**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- notes-tree virtualized-notes-tree kibo-ui medium-ui-surfaces zero-renderer-surfaces-extra`
+Expected: PASS — these are structural tests; className-only changes don't affect them.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/ui/context-menu.tsx
+git commit -m "style(desktop): match right-click ContextMenu to Picker look"
+```
+
+---
+
+## Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck**
+
+Run: `pnpm --filter @memry/desktop typecheck:web`
+Expected: PASS.
+
+- [ ] **Step 2: Renderer tests**
+
+Run: `pnpm --filter @memry/desktop test:renderer`
+Expected: PASS (new `new-item-menu-items` test + updated `app-sidebar` test + all pre-existing renderer tests green).
+
+- [ ] **Step 3: Lint**
+
+Run (from repo root): `pnpm lint`
+Expected: PASS — no unused imports left in `new-tab-menu.tsx` or `app-sidebar.tsx`; new code uses logical (`border-s`) Tailwind classes.
+
+- [ ] **Step 4: i18n check**
+
+Run: `pnpm --filter @memry/desktop i18n:check`
+Expected: exit 0. The new `newItemMenu` key exists in English; the reused `componentsTabsNewTabMenu.*` keys remain used (no new orphans). Non-English locales may warn but do not fail.
+
+- [ ] **Step 5: Whitespace check**
+
+Run (from repo root): `git diff --check`
+Expected: no output.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Sidebar split button → Task 4. ✓
+- Tab "+" on Picker → Task 3. ✓
+- Shared `NewItemMenuItems` on Picker → Task 2. ✓
+- Context-menu restyle (shared primitive, app-wide) → Task 5. ✓
+- New i18n key → Task 1. ✓
+- Tests (new component test + sidebar case + keep suites green) → Tasks 2, 4, 5, 6. ✓
+- Verify commands (`typecheck:web`, `test:renderer`, `lint`, `i18n:check`) → Task 6. ✓
+- Out-of-scope items (no folder-logic change, dead `sidebar-item-context-menu.tsx` left alone, tab handlers/`groupId` preserved) → respected; no task touches them.
+
+**Type consistency:** `NewItemActions` (`onNewNote`/`onJournal`/`onCalendar`/`onInbox`/`onTasks`) defined in Task 2 and consumed identically in Tasks 3 and 4. `NewItemMenuItems` props (`{ actions }`) consistent across all three. `Picker.Item` `value`/`label`/`icon`/`onClick` props match the component's real API. `openSidebarItem({ type, title, path })` matches the existing `SidebarItem` shape used by `handleNavClick`.
+
+**Placeholder scan:** none — every code/className step shows the full content.

--- a/docs/superpowers/specs/2026-06-12-new-item-menus-design.md
+++ b/docs/superpowers/specs/2026-06-12-new-item-menus-design.md
@@ -1,0 +1,221 @@
+# New-item menus + Picker-consistent dropdowns — Design
+
+Date: 2026-06-12
+Branch: `new-item-menus`
+Worktree: `.worktrees/new-item-menus`
+
+## Problem
+
+The sidebar "New" button only creates a note. The tab-bar "+" opens a Radix
+`DropdownMenu` with the full create list (New Note, Journal, Calendar, Inbox,
+Tasks). Three menus across the app render in three visual styles:
+
+- Tab "+" → Radix `DropdownMenu` (`@/components/ui/dropdown-menu`)
+- Inbox filter → custom `Picker` (`@/components/ui/picker`, Popover-based, more
+  polished: `shadow-card-hover`, `rounded-[5px]` items, `text-[13px]`)
+- Right-click vault items → Radix `ContextMenu` (`@/components/ui/context-menu`)
+
+Goal: give the sidebar "New" button a dropdown affordance, and unify the look of
+all three menus on the **Picker style** (the inbox filter look).
+
+## Decisions (locked with user)
+
+1. **Sidebar "New" = split button.** Left half keeps the instant new-note click.
+   A separate chevron on the right opens the dropdown.
+2. **Tab "+" and sidebar dropdown use the real `Picker` component** (they are
+   click-triggered, so the Popover-based Picker fits). They render the same item
+   list.
+3. **Right-click vault menu cannot use the Picker** (Picker/Popover anchors to a
+   trigger; right-click menus must anchor to the cursor → must stay on Radix
+   `ContextMenu`). "Same dropdown" there means **match the Picker's visual
+   style**, achieved by restyling the shared primitive.
+4. **Restyle the shared `context-menu.tsx` primitive** (one file) so every
+   right-click menu app-wide (vault tree, folder-view rows, tab-bar) matches the
+   Picker look. Chosen over a vault-only restyle for full consistency.
+
+## Why Picker works as an action menu
+
+`Picker.Item` (`components/ui/picker/picker-item.tsx`) calls its `onClick` prop,
+then — if the event was not `preventDefault`'d — calls `onValueChange(value)`.
+With `mode="single"` (default) and no root `value`/`onValueChange`, clicking an
+item runs our handler and auto-closes the popover. So a `Picker` with action
+items behaves like a normal action dropdown. This matches existing Picker usages
+across the app (tasks filters, note editors, vault-switcher).
+
+## Components
+
+### 1. `NewItemMenuItems` (new, shared)
+
+Path: `apps/desktop/src/renderer/src/components/tabs/new-item-menu-items.tsx`
+
+Presentational. Renders `Picker.List` with five `Picker.Item`s. No open-state of
+its own; the parent supplies the `Picker` shell + `Picker.Content`.
+
+```tsx
+export interface NewItemActions {
+  onNewNote: () => void
+  onJournal: () => void
+  onCalendar: () => void
+  onInbox: () => void
+  onTasks: () => void
+}
+
+export function NewItemMenuItems({ actions }: { actions: NewItemActions }): React.JSX.Element
+```
+
+- Icons: `FileText, BookOpen, Calendar, Inbox, ListTodo` from `@/lib/icons`
+  (`size-4`).
+- Labels: reuse existing keys `phaseF.componentsTabsNewTabMenu.{newNote, journal,
+calendar, inboxCapture, tasks}` (namespace `common`). No new label keys → no
+  i18n churn for the items.
+- Each `Picker.Item` gets a stable `value` (`note`/`journal`/`calendar`/`inbox`/
+  `tasks`) and `onClick={actions.on*}`; `indicator="none"`.
+
+Rationale for sharing only presentation, not handlers: the two contexts resolve
+the target folder differently (tab menu uses `selectedFolder` + dispatches
+`memry:expand-folder`; sidebar uses `targetFolderRef` and opens in the active
+pane). Unifying note-creation would be risky. Sharing the item list guarantees an
+identical menu without disturbing either behavior.
+
+### 2. Tab "+" — `new-tab-menu.tsx` (rebuild on Picker)
+
+Replace the Radix `DropdownMenu` shell with `Picker`:
+
+```tsx
+<Picker open={open} onOpenChange={setOpen}>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Picker.Trigger asChild>
+        <button …existing "+" button styling…><Plus className="w-4 h-4" /></button>
+      </Picker.Trigger>
+    </TooltipTrigger>
+    <TooltipContent side="bottom" …>{t('…newTab2')}</TooltipContent>
+  </Tooltip>
+  <Picker.Content width={200} align="start" side="bottom">
+    <NewItemMenuItems actions={{
+      onNewNote: () => void handleNewNote(),
+      onJournal: handleNewJournal,
+      onCalendar: handleOpenCalendar,
+      onInbox: handleOpenInbox,
+      onTasks: handleNewTask
+    }} />
+  </Picker.Content>
+</Picker>
+```
+
+- Keep all existing handlers (they already pass `groupId` to `openTab`).
+- Keep the `memry:new-tab-menu` window-event listener and the `open` state.
+- Keep the tooltip and the existing trigger button styling unchanged.
+
+### 3. Sidebar "New" — `app-sidebar.tsx` (split button)
+
+Current (lines ~395-407): a single full-width button calling `handleNewNote`.
+
+New structure — a two-button pill sharing `bg-sidebar-surface`:
+
+```tsx
+<div className="shrink-0 flex items-center px-3 pt-2 pb-0 group-data-[collapsible=icon]:hidden">
+  <div className="flex flex-1 items-center h-[30px] rounded-[5px] bg-sidebar-surface overflow-hidden">
+    {/* Left: instant new note — keeps accessible name "new" */}
+    <button
+      type="button"
+      onClick={() => void handleNewNote()}
+      className="flex flex-1 items-center justify-center gap-2 h-full hover:bg-black/[0.06] dark:hover:bg-white/[0.06] transition-colors cursor-pointer"
+      title={t('phaseF.componentsAppSidebar.newNoteN')}
+    >
+      <Plus className="size-[15px] text-muted-foreground/70" />
+      <span className="text-[13px] text-muted-foreground/70 font-normal">
+        {t('phaseF.componentsAppSidebar.new')}
+      </span>
+    </button>
+    {/* Right: dropdown */}
+    <Picker>
+      <Picker.Trigger asChild>
+        <button
+          type="button"
+          aria-label={t('phaseF.componentsAppSidebar.newItemMenu')}
+          className="flex h-full w-7 shrink-0 items-center justify-center border-s border-black/[0.06] dark:border-white/[0.08] hover:bg-black/[0.06] dark:hover:bg-white/[0.06] transition-colors cursor-pointer"
+        >
+          <ChevronDown className="size-3.5 text-muted-foreground/70" />
+        </button>
+      </Picker.Trigger>
+      <Picker.Content width={200} align="end" side="bottom">
+        <NewItemMenuItems
+          actions={{
+            onNewNote: () => void handleNewNote(),
+            onJournal: () =>
+              openSidebarItem({ type: 'journal', title: 'Journal', path: '/journal' }),
+            onCalendar: () =>
+              openSidebarItem({ type: 'calendar', title: 'Calendar', path: '/calendar' }),
+            onInbox: () => openSidebarItem({ type: 'inbox', title: 'Inbox', path: '/inbox' }),
+            onTasks: () => openSidebarItem({ type: 'tasks', title: 'Tasks', path: '/tasks' })
+          }}
+        />
+      </Picker.Content>
+    </Picker>
+  </div>
+</div>
+```
+
+- `ChevronDown` is exported from `@/lib/icons` (icon-map.ts).
+- Sidebar dropdown items open in the **active pane** (no `groupId`), matching the
+  existing "New" button and sidebar nav behavior. New Note reuses the sidebar's
+  own `handleNewNote`; the four views reuse `openSidebarItem(...)` (same payload
+  shape `handleNavClick` already uses).
+- Logical Tailwind classes (`border-s`, `rounded-[5px]`) for RTL safety.
+- **One new i18n key**: `phaseF.componentsAppSidebar.newItemMenu` (aria-label for
+  the chevron; distinct from the left button's `new` so the existing
+  `getByRole('button', { name: 'new' })` test stays unambiguous). Add to the
+  `common` namespace; run `i18n:check` and add to any locales it requires.
+
+### 4. Context-menu restyle — `components/ui/context-menu.tsx`
+
+Restyle to match Picker. className-only; structure/exports unchanged.
+
+- `ContextMenuContent`: `shadow-md` → `shadow-[var(--shadow-card-hover)]`.
+- `ContextMenuSubContent`: `shadow-lg` → `shadow-[var(--shadow-card-hover)]`.
+- `ContextMenuItem` / `ContextMenuSubTrigger`: `rounded-sm` → `rounded-[5px]`,
+  `text-sm` → `text-[13px]`, add `text-muted-foreground` for the resting label
+  color (mirrors `Picker.Item`; keep `focus:bg-accent` / `focus:text-accent-foreground`
+  so the item brightens on hover/focus).
+- `ContextMenuCheckboxItem` / `ContextMenuRadioItem`: same `rounded-[5px]` +
+  `text-[13px]` for consistency.
+- `ContextMenuSeparator` already matches Picker (`-mx-1 my-1 h-px bg-border`); no
+  change.
+- Keep the existing border, overflow/scroll, animation, and destructive-variant
+  styles — only the four tokens above change. Destructive items keep their
+  `data-[variant=destructive]` treatment.
+
+## Testing
+
+New:
+
+- `new-item-menu-items.test.tsx` — render inside `<Picker open><Picker.Content>…`,
+  click each of the five items, assert the matching action callback fires.
+
+Keep green (no behavior regressions):
+
+- `app-sidebar.test.tsx` — left button (`name: 'new'`) still calls `createNote` +
+  `openTab`. Add a case: clicking the chevron (`newItemMenu`) opens the menu, then
+  clicking `journal` calls `openSidebarItem` with the journal payload.
+- Tab/tree suites: `tabs-components.test.tsx`, `notes-tree-isolated.test.tsx`,
+  `virtualized-notes-tree.test.tsx`, `kibo-ui/tree/index.test.tsx`,
+  `medium-ui-surfaces.test.tsx`, `zero-renderer-surfaces-extra.test.tsx` — the
+  context-menu restyle is className-only, structure unchanged, so these stay
+  green.
+
+Commands:
+
+- `pnpm --filter @memry/desktop typecheck:web`
+- `pnpm --filter @memry/desktop test:renderer`
+- `pnpm lint`
+- `pnpm --filter @memry/desktop i18n:check`
+
+## Out of scope
+
+- No arrow-key roving nav in the new menus (Popover-based Picker doesn't provide
+  it; consistent with existing Picker usages — accepted).
+- No change to note-creation folder logic in either context.
+- No removal of the now-dead `sidebar-item-context-menu.tsx` (pre-existing dead
+  code; flag, don't delete).
+- No migration of the tab "+" away from its existing handlers/`groupId`.

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -211,6 +211,7 @@
       "dropFilesToImport": "Drop files to import",
       "newNoteN": "New note (⌘N)",
       "new": "New",
+      "newItemMenu": "Create new…",
       "syncDisabled": "Sync disabled",
       "syncDisabled2": "Sync disabled"
     },


### PR DESCRIPTION
## What

- **Sidebar "New" is now a split button.** The left half still creates a note instantly; a chevron on its right opens a create menu — New Note · Journal · Calendar · Inbox · Tasks — the same set as the tab-bar **+**.
- **Tab "+" and the sidebar dropdown share one component.** Both render a new presentational `NewItemMenuItems` built on the existing `Picker` (the inbox-filter component), so the two menus look and behave identically.
- **Right-click menus restyled to match.** The shared Radix `ContextMenu` primitive now uses the Picker look (`shadow-card-hover` container, `rounded-[5px]` / `text-[13px]` items) app-wide — vault tree, folder-view rows, tab bar.

## Why

The sidebar "New" only created notes, while the tab "+" had the full create list in a different visual style, and right-click menus were a third style. This unifies all three on the inbox-filter dropdown look and gives "New" quick access to every item type.

## Notes / decisions

- Sidebar dropdown opens items in the **active pane** via the sidebar's own `handleNewNote` / `openSidebarItem` (matches the existing "New" button and nav). The tab "+" keeps its own handlers + `groupId` + `memry:new-tab-menu` open event.
- Right-click menus stay on Radix `ContextMenu` (cursor-anchored); the Popover-based `Picker` can't follow a right-click, so "same dropdown" there means matching the visual style via a className-only restyle.
- Reused existing `componentsTabsNewTabMenu.*` i18n keys for the items; added one new key `componentsAppSidebar.newItemMenu` for the chevron aria-label.

## Testing

- New unit test for `NewItemMenuItems` (each of the 5 items fires its action).
- New `app-sidebar` case: chevron opens the menu and routes Journal to `openSidebarItem`.
- `tabs-components` test adapted to the Picker (`role="option"`); dead dropdown-menu mock removed.
- Full gate green: `typecheck:web`, `test:renderer` (4652 passed), `lint` (0 errors), `i18n:check`, `docs:impact --strict`, `docs:build`, `git diff --check`.

## Follow-ups (not blocking)

- Visual QA of the muted (`text-muted-foreground`) resting color on right-click menu items.
- Picker-as-action-menu uses `role=option`/`listbox` semantics (accepted tradeoff to reuse the inbox-filter component); no keyboard roving in the new menus.