### PR TITLE
ci(release): skip throwaway native rebuild and typecheck in packaging

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,6 +25,10 @@ env:
   NODE_OPTIONS: --max-old-space-size=4096
   RELEASE_TIME_ZONE: Europe/Istanbul
   TURBO_TELEMETRY_DISABLED: 1
+  # Native modules are rebuilt once in the staged copy by build-packaged-app.js.
+  # Skip the throwaway rebuild that pnpm's deps-status preflight triggers via the
+  # desktop `postinstall` before each build step.
+  SKIP_ELECTRON_REBUILD: 1
 
 jobs:
   setup-release:
@@ -231,7 +235,7 @@ jobs:
             fi
           done
 
-          pnpm --filter @memry/desktop build
+          pnpm --filter @memry/desktop build:release
           node apps/desktop/scripts/build-packaged-app.js \
             --config config/electron-builder.staged-local-mac.yml \
             --mac \
@@ -408,7 +412,7 @@ jobs:
           SYNC_SERVER_URL: ${{ secrets.SYNC_SERVER_URL }}
         shell: pwsh
         run: |
-          pnpm --filter @memry/desktop build
+          pnpm --filter @memry/desktop build:release
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # electron-builder intermittently fails with "EBUSY: resource busy or
           # locked" copying .env.production -> resources/.env when Windows
@@ -553,7 +557,7 @@ jobs:
           SYNC_SERVER_URL: ${{ secrets.SYNC_SERVER_URL }}
         run: |
           set -euo pipefail
-          pnpm --filter @memry/desktop build
+          pnpm --filter @memry/desktop build:release
           node apps/desktop/scripts/build-packaged-app.js --linux --x64 --publish never
 
       - name: Stage Linux assets

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -42,6 +42,7 @@
     "clean:c": "rm -rf \"$HOME/Library/Application Support/memry-C\"",
     "clean:devices": "pnpm clean:a && pnpm clean:b && pnpm clean:c",
     "build": "cross-env MEMRY_ENV=production pnpm typecheck && cross-env MEMRY_ENV=production electron-vite build",
+    "build:release": "pnpm repair:links && cross-env MEMRY_ENV=production electron-vite build",
     "postinstall": "[ \"$SKIP_ELECTRON_REBUILD\" = '1' ] || pnpm exec electron-rebuild -o better-sqlite3,classic-level,keytar",
     "rebuild:node": "bash scripts/ensure-native.sh node",
     "rebuild:electron": "bash scripts/ensure-native.sh electron",


### PR DESCRIPTION
## Problem
macOS release jobs are the long pole (last green release: x64 33 min, arm64 22 min, Windows 12, Linux 6). The macOS x64 "Build signed macOS artifacts" step alone is ~28 min. Step-log timing showed ~3.6 min of native rebuild + ~2 min of typecheck inside the build that are pure waste.

## Why it's wasted
- `pnpm --filter @memry/desktop build` fires the `prebuild` hook → `ensure-native.sh electron` rebuilds better-sqlite3/keytar in the **source** `node_modules`. The package never uses them — `build-packaged-app.js` rebuilds natives in the **staged copy**.
- `ensure-native.sh` ignores `SKIP_ELECTRON_REBUILD`, so setting that flag alone just shifts the rebuild from `postinstall` to `prebuild`.
- typecheck is already gated by `desktop-ci` on every push.

## Change
- New `build:release` script: `repair:links && electron-vite build`. A different script name means npm never runs the `prebuild` hook → no native rebuild, no typecheck. Keeps `repair:links` for workspace-symlink safety.
- Switch macOS / Windows / Linux release jobs to `build:release`.
- `SKIP_ELECTRON_REBUILD: 1` at the workflow env level drops the residual rebuild that pnpm's deps-status preflight triggers via `postinstall`.

Both changes are needed and complementary. **Shipped binaries are identical** — the real native rebuild still runs on the staged copy via `@electron/rebuild`'s CLI directly (bypasses the `postinstall` guard).

## Expected impact
~5–6 min off each platform build job (macOS step ~28 → ~22 min). The two big immovable chunks remain: notarization (~8.6 min, Apple-side wait) and DMG/zip compression (~6.9 min).

## Verification
Rests on npm lifecycle semantics (`pre<name>` only fires for the exact name) + `build:release`'s `electron-vite build` is the same bundling that already ships under `build`. A full local package needs CI-injected `.env.production`, so the clean proof is a **`dry_run` workflow_dispatch** — it builds artifacts without uploading/publishing. Recommend running one to confirm timing before the next real release.