### PR TITLE
docs(readme): correct license to GPL-3.0 to match LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Notes, tasks, projects, journal, calendar, and an AI agent that actually has con
 [![Release](https://img.shields.io/github/v/release/memrynote/memry?include_prereleases&sort=semver)](https://github.com/memrynote/memry/releases)
 [![CI](https://github.com/memrynote/memry/actions/workflows/ci.yml/badge.svg)](https://github.com/memrynote/memry/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/memrynote/memry/branch/main/graph/badge.svg)](https://codecov.io/gh/memrynote/memry)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
 [![Standard Readme](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
 [![Electron](https://img.shields.io/badge/built%20with-Electron-47848F.svg)](https://www.electronjs.org/)
 [![React 19](https://img.shields.io/badge/React-19-61DAFB.svg)](https://react.dev/)
@@ -163,6 +163,6 @@ If you ship a workflow you love, tell us. If something is broken, tell us louder
 
 ## License
 
-MIT © Memry contributors
+GPL-3.0 © Memry contributors
 
 See [LICENSE](LICENSE) for the legal text.

--- a/plans/README.md
+++ b/plans/README.md
@@ -21,7 +21,7 @@ below — run `pnpm audit --prod` separately if you want that).
 | ---- | ------------------------------------------------------------------ | -------- | ------ | ---- | ----------------------------------------------------- | ------ |
 | 001  | Placeholder + rotate real secrets in committed `.env.example`      | P1       | S      | MED  | [#542](https://github.com/memrynote/memry/issues/542) | TODO   |
 | 002  | Flush pending CRDT write-backs on shutdown (not drop)              | P1       | S      | LOW  | [#543](https://github.com/memrynote/memry/issues/543) | TODO   |
-| 003  | Fix README license contradiction → GPL-3.0                         | P1       | S      | LOW  | [#544](https://github.com/memrynote/memry/issues/544) | TODO   |
+| 003  | Fix README license contradiction → GPL-3.0                         | P1       | S      | LOW  | [#544](https://github.com/memrynote/memry/issues/544) | DONE   |
 | 004  | Align documented Node/pnpm versions with the pinned toolchain      | P2       | S      | LOW  | [#545](https://github.com/memrynote/memry/issues/545) | TODO   |
 | 005  | Consolidate `ReminderTargetType` (fix `'task'` drift)              | P2       | S      | MED  | [#546](https://github.com/memrynote/memry/issues/546) | TODO   |
 | 006  | Remove duplicate/broken `onSearchIndex*` preload declarations      | P2       | S      | LOW  | [#547](https://github.com/memrynote/memry/issues/547) | TODO   |


### PR DESCRIPTION
Closes #544.

The README advertised **MIT** (badge + footer) while the authoritative `LICENSE` file is **GNU GPL v3** and every `package.json` declares `GPL-3.0`. A reader trusting the MIT badge would make a wrong assumption about a copyleft project. Fix is one-directional: make the docs match the license.

## Changes
- `README.md:14` — badge `License: MIT` → `License: GPL-3.0` (`GPL--3.0` renders as a single dash on shields.io)
- `README.md:166` — footer `MIT © Memry contributors` → `GPL-3.0 © Memry contributors`
- `plans/README.md` — Plan 003 status `TODO` → `DONE`

## Out of scope (unchanged)
- `LICENSE` — already correct (GPL v3)
- All `package.json` `"license"` fields — already `GPL-3.0`
- `apps/docs/src` and `apps/landing` scanned — no MIT license claims, nothing to align

## Verify
- `grep -n MIT README.md` → no matches
- `git diff --check` → clean