### PR TITLE
docs: align documented Node/pnpm versions with pinned toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Current GitHub releases are unstable preview builds. Join the [waitlist](https:/
 
 ### Build from Source
 
-Requires Node 20+ and pnpm 9+.
+Requires Node 24 (see `.nvmrc`) and pnpm 11 (the repo pins `pnpm@11.5.2` via corepack).
 
 ```bash
 git clone https://github.com/memrynote/memry.git

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Be respectful and constructive. We're building something together.
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) (v24.x; use `.nvmrc`)
-- [pnpm](https://pnpm.io/) (v10.30+)
+- [pnpm](https://pnpm.io/) (v11.5.2 — the repo pins it via `packageManager`; corepack will use the right version automatically)
 - Git
 
 ### Setup

--- a/plans/README.md
+++ b/plans/README.md
@@ -22,7 +22,7 @@ below — run `pnpm audit --prod` separately if you want that).
 | 001  | Placeholder + rotate real secrets in committed `.env.example`      | P1       | S      | MED  | [#542](https://github.com/memrynote/memry/issues/542) | TODO   |
 | 002  | Flush pending CRDT write-backs on shutdown (not drop)              | P1       | S      | LOW  | [#543](https://github.com/memrynote/memry/issues/543) | TODO   |
 | 003  | Fix README license contradiction → GPL-3.0                         | P1       | S      | LOW  | [#544](https://github.com/memrynote/memry/issues/544) | TODO   |
-| 004  | Align documented Node/pnpm versions with the pinned toolchain      | P2       | S      | LOW  | [#545](https://github.com/memrynote/memry/issues/545) | TODO   |
+| 004  | Align documented Node/pnpm versions with the pinned toolchain      | P2       | S      | LOW  | [#545](https://github.com/memrynote/memry/issues/545) | DONE   |
 | 005  | Consolidate `ReminderTargetType` (fix `'task'` drift)              | P2       | S      | MED  | [#546](https://github.com/memrynote/memry/issues/546) | TODO   |
 | 006  | Remove duplicate/broken `onSearchIndex*` preload declarations      | P2       | S      | LOW  | [#547](https://github.com/memrynote/memry/issues/547) | TODO   |
 | 007  | Concurrent (bounded) R2 reads in `pullItems`                       | P2       | M      | LOW  | [#548](https://github.com/memrynote/memry/issues/548) | TODO   |


### PR DESCRIPTION
Closes #545.

## What

Make the setup docs state the toolchain versions the repo actually pins, so a first-time contributor's first `pnpm install` doesn't fail on a packageManager mismatch.

- `README.md` — `Requires Node 20+ and pnpm 9+.` → `Requires Node 24 (see .nvmrc) and pnpm 11 (the repo pins pnpm@11.5.2 via corepack).`
- `docs/CONTRIBUTING.md` — pnpm prerequisite `v10.30+` → `v11.5.2` (pinned via `packageManager`; corepack auto-selects).
- `plans/README.md` — plan 004 status row `TODO` → `DONE`.

## Source of truth (unchanged)

- `package.json` → `"packageManager": "pnpm@11.5.2"`
- `.nvmrc` → `24`

Docs are made to match these; the source-of-truth files are deliberately untouched. The correct CONTRIBUTING Node line (`v24.x`) is left as-is.

## Verification

- `grep -rn "pnpm 9\|v10.30\|Node 20" README.md docs/CONTRIBUTING.md` → no matches
- `git diff --check` → clean
- Docs-only change (no `apps/desktop` / `apps/sync-server` code), so the docs-impact gate does not apply.