### PR TITLE
docs(plans): mark plan 001 REJECTED — .env.example secrets are a false positive

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -19,7 +19,7 @@ below — run `pnpm audit --prod` separately if you want that).
 
 | Plan | Title                                                              | Priority | Effort | Risk | Issue                                                 | Status |
 | ---- | ------------------------------------------------------------------ | -------- | ------ | ---- | ----------------------------------------------------- | ------ |
-| 001  | Placeholder + rotate real secrets in committed `.env.example`      | P1       | S      | MED  | [#542](https://github.com/memrynote/memry/issues/542) | TODO   |
+| 001  | Placeholder + rotate real secrets in committed `.env.example`      | P1       | S      | MED  | [#542](https://github.com/memrynote/memry/issues/542) | REJECTED — false positive: `.env.example` only ever held placeholders (no real secret in any commit); nothing to rotate |
 | 002  | Flush pending CRDT write-backs on shutdown (not drop)              | P1       | S      | LOW  | [#543](https://github.com/memrynote/memry/issues/543) | TODO   |
 | 003  | Fix README license contradiction → GPL-3.0                         | P1       | S      | LOW  | [#544](https://github.com/memrynote/memry/issues/544) | TODO   |
 | 004  | Align documented Node/pnpm versions with the pinned toolchain      | P2       | S      | LOW  | [#545](https://github.com/memrynote/memry/issues/545) | TODO   |


### PR DESCRIPTION
## Summary

Marks **Plan 001** (`plans/README.md`) as `REJECTED` — it is a false positive, no code change is needed.

- `apps/landing/.env.example` contains only placeholders (`replace-me-*`) for every sensitive key; `RESEND_WEBHOOK_SECRET` and PostHog keys are empty; `PADDLE_PRICE_*` are public price identifiers.
- Classified the sensitive value-lines across **all 11 commits** that have ever touched the file — every value is a placeholder or empty. **No real credential was ever committed**, so there is nothing to rotate.
- The audit flagged it because the placeholder strings are non-empty (len 30/35/38/10), which the length heuristic read as real secret-shaped values.
- Real `.env` files (`apps/landing/.env`, `apps/desktop/.env`) remain gitignored/untracked.

Resolves the disposition of #542 (closed as not-planned).

## Follow-up worth keeping

A CI secret-scanner (gitleaks) and/or extending `scripts/check-staged-secrets.mjs` to cover `.env*` example files would catch a *genuine* leak in future. Out of scope here.

## Test Plan

- [x] Docs/index-only change (one status cell in `plans/README.md`); no test or build is affected.
- [x] `git diff` confirms only the status text changed — no secret values introduced.