### PR TITLE
fix(sync): flush pending CRDT write-backs on shutdown instead of dropping them

### DIFF
--- a/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
+++ b/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
@@ -35,6 +35,7 @@ vi.mock('./crdt-compact-utils', () => ({ compactYDoc: vi.fn() }))
 vi.mock('./crdt-writeback', () => ({
   scheduleWriteback: vi.fn(),
   cancelPendingWritebacks: vi.fn(),
+  flushPendingWritebacks: vi.fn(),
   recordNetworkUpdate: vi.fn()
 }))
 vi.mock('./microtask-batch-broadcaster', () => ({

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
   markdownToYFragment: vi.fn(),
   compactYDoc: vi.fn(),
   scheduleWriteback: vi.fn(),
-  cancelPendingWritebacks: vi.fn(),
+  flushPendingWritebacks: vi.fn(),
   recordNetworkUpdate: vi.fn(),
   persistenceInstances: [] as Array<{
     getYDoc: ReturnType<typeof vi.fn>
@@ -85,7 +85,7 @@ vi.mock('./crdt-compact-utils', () => ({
 
 vi.mock('./crdt-writeback', () => ({
   scheduleWriteback: (...args: unknown[]) => mocks.scheduleWriteback(...args),
-  cancelPendingWritebacks: (...args: unknown[]) => mocks.cancelPendingWritebacks(...args),
+  flushPendingWritebacks: (...args: unknown[]) => mocks.flushPendingWritebacks(...args),
   recordNetworkUpdate: (...args: unknown[]) => mocks.recordNetworkUpdate(...args)
 }))
 
@@ -286,7 +286,7 @@ describe('CrdtProvider', () => {
     expect(mocks.persistenceInstances[0].clearDocument).toHaveBeenCalledWith('seed-a')
 
     await provider.destroy()
-    expect(mocks.cancelPendingWritebacks).toHaveBeenCalled()
+    expect(mocks.flushPendingWritebacks).toHaveBeenCalled()
     expect(mocks.persistenceInstances[0].destroy).toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -8,7 +8,7 @@ import { getIndexDatabase } from '../database/client'
 import { getNoteCacheById } from '@main/database/queries/notes'
 import type { CrdtUpdateQueue } from './crdt-queue'
 import { MicrotaskBatchBroadcaster } from './microtask-batch-broadcaster'
-import { scheduleWriteback, cancelPendingWritebacks, recordNetworkUpdate } from './crdt-writeback'
+import { scheduleWriteback, flushPendingWritebacks, recordNetworkUpdate } from './crdt-writeback'
 import { toAbsolutePath } from '../vault/notes'
 import { safeRead } from '../vault/file-ops'
 import { parseNote } from '../vault/frontmatter'
@@ -295,7 +295,7 @@ export class CrdtProvider {
   }
 
   async destroy(): Promise<void> {
-    cancelPendingWritebacks()
+    await flushPendingWritebacks()
     this.networkBatcher.flushAll()
 
     for (const [noteId] of this.docs) {

--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -104,6 +104,7 @@ vi.mock('@main/database/queries/notes', () => ({
 
 import {
   cancelPendingWritebacks,
+  flushPendingWritebacks,
   getWritebackDebugState,
   handleSyncDeletion,
   isWritebackIgnored,
@@ -352,5 +353,43 @@ describe('crdt writeback', () => {
         source: 'sync'
       }
     })
+  })
+
+  it('flushPendingWritebacks runs a scheduled write-back without advancing the debounce timer', async () => {
+    scheduleWriteback('note-1', makeDoc('Pending title', ['flush-tag']))
+    expect(mocks.atomicWrite).not.toHaveBeenCalled()
+
+    await flushPendingWritebacks()
+
+    expect(mocks.atomicWrite).toHaveBeenCalledWith(
+      '/vault/notes/Existing.md',
+      expect.stringContaining('updated markdown')
+    )
+  })
+
+  it('flushPendingWritebacks clears pending timers so they do not fire a second time', async () => {
+    scheduleWriteback('note-1', makeDoc('Pending title'))
+
+    await flushPendingWritebacks()
+    expect(mocks.atomicWrite).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(mocks.atomicWrite).toHaveBeenCalledTimes(1)
+  })
+
+  it('flushPendingWritebacks with nothing pending is a no-op', async () => {
+    await flushPendingWritebacks()
+    expect(mocks.atomicWrite).not.toHaveBeenCalled()
+  })
+
+  it('flushPendingWritebacks swallows a failing write-back and logs instead of rejecting', async () => {
+    mocks.yDocToMarkdown.mockRejectedValueOnce(new Error('conversion boom'))
+    scheduleWriteback('note-1', makeDoc('Pending title'))
+
+    await expect(flushPendingWritebacks()).resolves.toBeUndefined()
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'Write-back failed during shutdown flush',
+      expect.objectContaining({ noteId: 'note-1' })
+    )
   })
 })

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -33,7 +33,12 @@ const log = createLogger('CrdtWriteback')
 const WRITEBACK_DEBOUNCE_MS = 500
 const IGNORED_WRITE_TTL_MS = 5000
 
-const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>()
+interface PendingWriteback {
+  timer: ReturnType<typeof setTimeout>
+  doc: Y.Doc
+}
+
+const pendingTimers = new Map<string, PendingWriteback>()
 const ignoredWrites = new Map<string, number>()
 const lastNetworkUpdateMs = new Map<string, number>()
 
@@ -112,7 +117,7 @@ function emitToRenderer(channel: string, data: unknown): void {
 
 export function scheduleWriteback(noteId: string, doc: Y.Doc): void {
   const existing = pendingTimers.get(noteId)
-  if (existing) clearTimeout(existing)
+  if (existing) clearTimeout(existing.timer)
   updateDebugState(noteId, {
     pending: true,
     scheduledCount: (debugState.get(noteId)?.scheduledCount ?? 0) + 1,
@@ -131,14 +136,27 @@ export function scheduleWriteback(noteId: string, doc: Y.Doc): void {
     })
   }, WRITEBACK_DEBOUNCE_MS)
 
-  pendingTimers.set(noteId, timer)
+  pendingTimers.set(noteId, { timer, doc })
 }
 
 export function cancelPendingWritebacks(): void {
-  for (const timer of pendingTimers.values()) {
+  for (const { timer } of pendingTimers.values()) {
     clearTimeout(timer)
   }
   pendingTimers.clear()
+}
+
+export async function flushPendingWritebacks(): Promise<void> {
+  const pending = Array.from(pendingTimers.entries())
+  pendingTimers.clear()
+  for (const [, { timer }] of pending) clearTimeout(timer)
+  await Promise.all(
+    pending.map(([noteId, { doc }]) =>
+      performWriteback(noteId, doc).catch((err) => {
+        log.error('Write-back failed during shutdown flush', { noteId, error: err })
+      })
+    )
+  )
 }
 
 async function performWriteback(noteId: string, doc: Y.Doc): Promise<void> {

--- a/plans/README.md
+++ b/plans/README.md
@@ -20,7 +20,7 @@ below — run `pnpm audit --prod` separately if you want that).
 | Plan | Title                                                              | Priority | Effort | Risk | Issue                                                 | Status |
 | ---- | ------------------------------------------------------------------ | -------- | ------ | ---- | ----------------------------------------------------- | ------ |
 | 001  | Placeholder + rotate real secrets in committed `.env.example`      | P1       | S      | MED  | [#542](https://github.com/memrynote/memry/issues/542) | TODO   |
-| 002  | Flush pending CRDT write-backs on shutdown (not drop)              | P1       | S      | LOW  | [#543](https://github.com/memrynote/memry/issues/543) | TODO   |
+| 002  | Flush pending CRDT write-backs on shutdown (not drop)              | P1       | S      | LOW  | [#543](https://github.com/memrynote/memry/issues/543) | DONE   |
 | 003  | Fix README license contradiction → GPL-3.0                         | P1       | S      | LOW  | [#544](https://github.com/memrynote/memry/issues/544) | TODO   |
 | 004  | Align documented Node/pnpm versions with the pinned toolchain      | P2       | S      | LOW  | [#545](https://github.com/memrynote/memry/issues/545) | TODO   |
 | 005  | Consolidate `ReminderTargetType` (fix `'task'` drift)              | P2       | S      | MED  | [#546](https://github.com/memrynote/memry/issues/546) | TODO   |


### PR DESCRIPTION
## Summary

On shutdown, `CrdtProvider.destroy()` called `cancelPendingWritebacks()`, which cleared the debounced (500 ms) markdown write-back timers **without running them**. Any note/journal edit made within ~500 ms of quit never reached the on-disk `.md` file or the search index. The CRDT state is persisted (so the edit isn't permanently lost), but the file silently lagged the true content and did not self-heal — only a *new* edit re-triggered a write-back. For a "files on disk, not a database" product, that on-disk/UI divergence (which also propagates stale via folder sync and stale search results) is a real correctness gap.

This **flushes** pending write-backs on shutdown instead of cancelling them.

Closes #543.

## Changes

- `crdt-writeback.ts` — `pendingTimers` now stores `{ timer, doc }` per pending note (was just the timer handle, which a flush couldn't reach). New exported `async flushPendingWritebacks()`: snapshots pending entries, clears their timers, and runs every `performWriteback` to completion; per-note failures are caught and logged, so the flush never rejects. `cancelPendingWritebacks()` is retained (still used elsewhere).
- `crdt-provider.ts` — `destroy()` now `await flushPendingWritebacks()` as its **first** line, before the `entry.doc.destroy()` loop (the flush reads from the live `Y.Doc`s). `destroy()` is already awaited from `stopSyncRuntime()` → the Electron `before-quit` handler, so the async flush is awaited on the real shutdown path.

## Tests

Added 4 cases to `crdt-writeback.test.ts` (fake timers, so the only way a write happens is the flush):

1. flush runs a scheduled write-back without advancing the debounce timer
2. flush clears pending timers so they do not fire a second time
3. flush with nothing pending is a no-op
4. a failing write-back during flush is logged, not thrown (flush still resolves)

Two existing test files that mock `./crdt-writeback` and exercise `destroy()` were updated to add `flushPendingWritebacks` to their module mocks (`crdt-provider.test.ts` also flips its `destroy()` assertion to the new function).

## Verification

- `pnpm --filter @memry/desktop typecheck:node` — exit 0
- `pnpm exec vitest run --config config/vitest.config.ts --project main` for the 3 sync test files — 44 passed (incl. the 4 new)
- `pnpm lint` — exit 0 (0 errors)

## Notes

- Docs gate skipped (`MEMRY_DOCS_IMPACT_SKIP=1`): internal shutdown-sequencing correctness fix; no public API or user-facing config, and no existing doc describes the prior drop-on-quit behavior.
- Deferred (filed separately if found): the same drop-on-quit shape may exist for other debounced projections; this PR covers only the markdown write-back.