### PR TITLE
refactor(app-core): derive ReminderTargetType from canonical contracts type

### DIFF
--- a/packages/app-core/src/reminders.test.ts
+++ b/packages/app-core/src/reminders.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { reminderTargetType } from '@memry/contracts/reminder-types'
+
+test('reminder target types: canonical set is exactly the four supported targets', () => {
+  assert.deepEqual(Object.values(reminderTargetType).sort(), [
+    'highlight',
+    'journal',
+    'note',
+    'task'
+  ])
+})

--- a/packages/app-core/src/reminders.ts
+++ b/packages/app-core/src/reminders.ts
@@ -2,9 +2,9 @@ import { asc, eq } from 'drizzle-orm'
 import { reminders } from '@memry/db-schema/data-schema'
 import type { DataDb } from './database.ts'
 import { createId } from './ids.ts'
+import type { ReminderTargetType, ReminderStatus } from '@memry/contracts/reminder-types'
 
-export type ReminderTargetType = 'note' | 'journal' | 'highlight'
-export type ReminderStatus = 'pending' | 'triggered' | 'dismissed' | 'snoozed'
+export type { ReminderTargetType, ReminderStatus }
 
 export interface ReminderRecord {
   id: string

--- a/plans/README.md
+++ b/plans/README.md
@@ -23,7 +23,7 @@ below — run `pnpm audit --prod` separately if you want that).
 | 002  | Flush pending CRDT write-backs on shutdown (not drop)              | P1       | S      | LOW  | [#543](https://github.com/memrynote/memry/issues/543) | TODO   |
 | 003  | Fix README license contradiction → GPL-3.0                         | P1       | S      | LOW  | [#544](https://github.com/memrynote/memry/issues/544) | TODO   |
 | 004  | Align documented Node/pnpm versions with the pinned toolchain      | P2       | S      | LOW  | [#545](https://github.com/memrynote/memry/issues/545) | TODO   |
-| 005  | Consolidate `ReminderTargetType` (fix `'task'` drift)              | P2       | S      | MED  | [#546](https://github.com/memrynote/memry/issues/546) | TODO   |
+| 005  | Consolidate `ReminderTargetType` (fix `'task'` drift)              | P2       | S      | MED  | [#546](https://github.com/memrynote/memry/issues/546) | DONE   |
 | 006  | Remove duplicate/broken `onSearchIndex*` preload declarations      | P2       | S      | LOW  | [#547](https://github.com/memrynote/memry/issues/547) | TODO   |
 | 007  | Concurrent (bounded) R2 reads in `pullItems`                       | P2       | M      | LOW  | [#548](https://github.com/memrynote/memry/issues/548) | TODO   |
 | 008  | Allowlist `openExternal` schemes + explicit window hardening       | P2       | M      | MED  | [#549](https://github.com/memrynote/memry/issues/549) | TODO   |


### PR DESCRIPTION
Closes #546 (Plan 005).

## What

`app-core`'s `ReminderTargetType` was a hand-maintained string-literal union (`'note' | 'journal' | 'highlight'`) that had **drifted** — it was missing `'task'`, even though task reminders are shipped and the canonical type at `packages/contracts/src/reminder-types.ts` already includes it. Since `app-core` is the domain layer the CLI runs on, task-reminder values were flowing through a stale type.

This makes `app-core` re-export the canonical definition instead of keeping its own copy, fixing the drift and removing one of the four divergent sources.

## Changes

- `packages/app-core/src/reminders.ts` — replace the local `ReminderTargetType`/`ReminderStatus` literals with `import type` + `export type` from `@memry/contracts/reminder-types` (canonical 4-value type). No local literal remains.
- `packages/app-core/src/reminders.test.ts` (new) — guard test pinning the canonical target set to `note/journal/highlight/task`, so any future change is deliberate and test-breaking. Written in the existing `node:test`/`node:assert` style used across `app-core`.
- `plans/README.md` — mark plan 005 DONE.

## Notes / deviations from the plan

- The plan's Step 1 snippet used a bare `export type { … } from '…'`. A pure re-export creates no local binding, so the in-file type uses would fail to resolve — used `import type` + `export type` instead.
- The plan assumed Vitest for the guard test; `app-core` actually runs `node --test`, so the test uses `node:assert/strict`.

## Out of scope (pre-existing drift, not touched)

The same 3-value union (missing `'task'`) still exists in `packages/rpc/src/inbox.ts`, `apps/desktop/src/preload/api/reminders.ts`, and `apps/cli/src/run.ts` (a cast). These are beyond this plan's scope (collapsing all copies needs a contracts dependency / generated ambient types) and are candidate follow-ups.

## Verification

- `pnpm typecheck:packages` → 12/12 successful, exit 0 (no `'task'` exhaustiveness gaps surfaced).
- `pnpm test:cli` → app-core 3/3 (incl. new guard test), cli 5/5.
- `pnpm docs:impact --base origin/main --strict` → no docs-relevant changes.