### PR TITLE
security(desktop): allowlist openExternal schemes + explicit window hardening

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -52,6 +52,7 @@ import {
   triggerGoogleCalendarSyncNow
 } from './calendar/google/sync-service'
 import { log, createLogger, disableConsoleTransport } from './lib/logger'
+import { isAllowedExternalUrl } from './lib/external-url'
 import { registerTestHooks } from './test-hooks'
 import {
   computeSpkiHashFromPem,
@@ -417,7 +418,10 @@ function createWindow(): void {
       : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: false
+      sandbox: false,
+      contextIsolation: true,
+      nodeIntegration: false,
+      webSecurity: true
     }
   })
   trackLaunchPhase('window_created', Date.now() - launchStartedAt)
@@ -446,7 +450,11 @@ function createWindow(): void {
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
-    void shell.openExternal(details.url)
+    if (isAllowedExternalUrl(details.url)) {
+      void shell.openExternal(details.url)
+    } else {
+      log.warn('Blocked external open for disallowed URL scheme', { url: details.url })
+    }
     return { action: 'deny' }
   })
 
@@ -1015,7 +1023,10 @@ function showQuickCaptureWindow(): void {
     vibrancy: process.platform === 'darwin' ? 'popover' : undefined,
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: false
+      sandbox: false,
+      contextIsolation: true,
+      nodeIntegration: false,
+      webSecurity: true
     }
   })
 

--- a/apps/desktop/src/main/lib/external-url.test.ts
+++ b/apps/desktop/src/main/lib/external-url.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { isAllowedExternalUrl } from './external-url'
+
+describe('isAllowedExternalUrl', () => {
+  it('allows https, http, and mailto schemes', () => {
+    expect(isAllowedExternalUrl('https://example.com')).toBe(true)
+    expect(isAllowedExternalUrl('http://example.com')).toBe(true)
+    expect(isAllowedExternalUrl('mailto:hi@memrynote.com')).toBe(true)
+  })
+
+  it('blocks non-web schemes', () => {
+    expect(isAllowedExternalUrl('file:///etc/passwd')).toBe(false)
+    expect(isAllowedExternalUrl('smb://host/share')).toBe(false)
+    expect(isAllowedExternalUrl('javascript:alert(1)')).toBe(false)
+  })
+
+  it('blocks empty and unparseable input', () => {
+    expect(isAllowedExternalUrl('')).toBe(false)
+    expect(isAllowedExternalUrl('not a url')).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/lib/external-url.ts
+++ b/apps/desktop/src/main/lib/external-url.ts
@@ -1,0 +1,14 @@
+const EXTERNAL_URL_ALLOWED_SCHEMES = new Set(['https:', 'http:', 'mailto:'])
+
+/**
+ * Whether a URL is safe to hand to `shell.openExternal`. Only web/mail schemes
+ * are allowed so renderer-triggered `window.open` cannot launch arbitrary
+ * protocols (file:, smb:, custom handlers) via the OS.
+ */
+export function isAllowedExternalUrl(rawUrl: string): boolean {
+  try {
+    return EXTERNAL_URL_ALLOWED_SCHEMES.has(new URL(rawUrl).protocol)
+  } catch {
+    return false
+  }
+}

--- a/plans/README.md
+++ b/plans/README.md
@@ -26,7 +26,7 @@ below — run `pnpm audit --prod` separately if you want that).
 | 005  | Consolidate `ReminderTargetType` (fix `'task'` drift)              | P2       | S      | MED  | [#546](https://github.com/memrynote/memry/issues/546) | TODO   |
 | 006  | Remove duplicate/broken `onSearchIndex*` preload declarations      | P2       | S      | LOW  | [#547](https://github.com/memrynote/memry/issues/547) | TODO   |
 | 007  | Concurrent (bounded) R2 reads in `pullItems`                       | P2       | M      | LOW  | [#548](https://github.com/memrynote/memry/issues/548) | TODO   |
-| 008  | Allowlist `openExternal` schemes + explicit window hardening       | P2       | M      | MED  | [#549](https://github.com/memrynote/memry/issues/549) | TODO   |
+| 008  | Allowlist `openExternal` schemes + explicit window hardening       | P2       | M      | MED  | [#549](https://github.com/memrynote/memry/issues/549) | DONE   |
 | 009  | Run the cross-boundary sync protocol harness in CI                 | P3       | M      | MED  | [#550](https://github.com/memrynote/memry/issues/550) | TODO   |
 | 010  | Web clipper design spec (transport, clip contract, store timeline) | P1       | M      | LOW  | —                                                     | TODO   |
 | 011  | Importers design spec (Obsidian + Markdown folder v1)              | P1       | M      | LOW  | —                                                     | TODO   |


### PR DESCRIPTION
Closes #549 (Plan 008).

## What

Two Electron main-process hardening gaps closed in `apps/desktop/src/main/index.ts`:

1. **`shell.openExternal` is now scheme-gated.** The window-open handler previously handed *any* URL scheme straight to the OS. It now opens externally only `https:` / `http:` / `mailto:` via a new `isAllowedExternalUrl` helper; disallowed schemes (`file:`, `smb:`, `javascript:`, custom protocols) are logged (`log.warn`) and denied.
2. **Explicit `webPreferences` hardening flags** on both `BrowserWindow`s (main + quick-capture): `contextIsolation: true`, `nodeIntegration: false`, `webSecurity: true`. These equal Electron's current defaults — no behavior change — but make the posture explicit and upgrade-proof.

`sandbox: false` is intentionally **unchanged** (flipping it needs separate preload validation — deferred follow-up).

## Why sibling module

The allowlist predicate lives in `apps/desktop/src/main/lib/external-url.ts` (not exported from `index.ts`) because `index.ts` has heavy import-time side effects that make it untestable as a unit.

## Tests

New unit test `external-url.test.ts` — 3 cases / 8 assertions covering allowed (https/http/mailto) and blocked (file/smb/javascript/empty/unparseable) inputs.

## Verification

- `pnpm --filter @memry/desktop typecheck:node` → exit 0
- `pnpm lint` → exit 0 (0 errors)
- `pnpm --filter @memry/desktop test:main src/main/lib/external-url.test.ts` → 3 passed

Docs gate skipped (`MEMRY_DOCS_IMPACT_SKIP=1`): internal main-process security hardening, no user-facing feature or behavior change.