### PR TITLE
perf(sync-server): fetch R2 payloads concurrently in pullItems

### DIFF
--- a/apps/sync-server/src/services/sync.test.ts
+++ b/apps/sync-server/src/services/sync.test.ts
@@ -1265,6 +1265,174 @@ describe('pullItems', () => {
     // #then
     expect(result).toEqual([])
   })
+
+  it('should preserve server_cursor order across concurrency windows', async () => {
+    // #given — more rows than the concurrency window so reads span >1 window
+    const ROW_COUNT = 30
+    const stmt = createMockStatement()
+    stmt.all.mockResolvedValue({
+      results: Array.from({ length: ROW_COUNT }, (_, index) => ({
+        item_id: `item-${index}`,
+        item_type: 'note',
+        blob_key: `blob-${index}`,
+        crypto_version: 1,
+        operation: 'update',
+        signer_device_id: 'device-1',
+        signature: `sig-${index}`,
+        state_vector: null,
+        clock: null,
+        deleted_at: null,
+        server_cursor: index
+      }))
+    })
+    db.prepare.mockReturnValue(stmt)
+    // Resolve earlier blob keys later so completion order is roughly the reverse
+    // of input order; windowed Promise.all must still return server_cursor order.
+    vi.mocked(getBlob).mockImplementation(async (_storage, blobKey) => {
+      const index = Number(blobKey.split('-')[1])
+      await new Promise((resolve) => setTimeout(resolve, (ROW_COUNT - index) % 5))
+      return {
+        body: JSON.stringify({
+          encryptedKey: 'ek',
+          keyNonce: 'kn',
+          encryptedData: 'ed',
+          dataNonce: 'dn'
+        })
+      } as unknown as R2ObjectBody
+    })
+
+    // #when
+    const result = await pullItems(
+      db as unknown as D1Database,
+      {} as R2Bucket,
+      'user-1',
+      Array.from({ length: ROW_COUNT }, (_, index) => `item-${index}`)
+    )
+
+    // #then
+    expect(result.map((item) => item.id)).toEqual(
+      Array.from({ length: ROW_COUNT }, (_, index) => `item-${index}`)
+    )
+  })
+
+  it('should filter out unsupported item types while preserving order of the rest', async () => {
+    // #given — a middle row whose type is not a supported record type
+    const stmt = createMockStatement()
+    stmt.all.mockResolvedValue({
+      results: [
+        {
+          item_id: 'item-a',
+          item_type: 'note',
+          blob_key: 'blob-a',
+          crypto_version: 1,
+          operation: 'update',
+          signer_device_id: 'device-1',
+          signature: 'sig-a',
+          state_vector: null,
+          clock: null,
+          deleted_at: null,
+          server_cursor: 1
+        },
+        {
+          item_id: 'item-skip',
+          item_type: 'legacy_unsupported',
+          blob_key: 'blob-skip',
+          crypto_version: 1,
+          operation: 'update',
+          signer_device_id: 'device-1',
+          signature: 'sig-skip',
+          state_vector: null,
+          clock: null,
+          deleted_at: null,
+          server_cursor: 2
+        },
+        {
+          item_id: 'item-b',
+          item_type: 'task',
+          blob_key: 'blob-b',
+          crypto_version: 1,
+          operation: 'update',
+          signer_device_id: 'device-1',
+          signature: 'sig-b',
+          state_vector: null,
+          clock: null,
+          deleted_at: null,
+          server_cursor: 3
+        }
+      ]
+    })
+    db.prepare.mockReturnValue(stmt)
+    vi.mocked(getBlob).mockResolvedValue({
+      body: JSON.stringify({
+        encryptedKey: 'ek',
+        keyNonce: 'kn',
+        encryptedData: 'ed',
+        dataNonce: 'dn'
+      })
+    } as unknown as R2ObjectBody)
+
+    // #when
+    const result = await pullItems(db as unknown as D1Database, {} as R2Bucket, 'user-1', [
+      'item-a',
+      'item-skip',
+      'item-b'
+    ])
+
+    // #then — the unsupported row is dropped, surviving rows keep their order
+    expect(result.map((item) => item.id)).toEqual(['item-a', 'item-b'])
+  })
+
+  it('should bound concurrent R2 reads to the window size', async () => {
+    // #given — mirrors R2_CONCURRENCY in sync.ts; rows span more than one window
+    const R2_CONCURRENCY = 25
+    const ROW_COUNT = R2_CONCURRENCY + 10
+    const stmt = createMockStatement()
+    stmt.all.mockResolvedValue({
+      results: Array.from({ length: ROW_COUNT }, (_, index) => ({
+        item_id: `item-${index}`,
+        item_type: 'note',
+        blob_key: `blob-${index}`,
+        crypto_version: 1,
+        operation: 'update',
+        signer_device_id: 'device-1',
+        signature: `sig-${index}`,
+        state_vector: null,
+        clock: null,
+        deleted_at: null,
+        server_cursor: index
+      }))
+    })
+    db.prepare.mockReturnValue(stmt)
+    let inFlight = 0
+    let peak = 0
+    vi.mocked(getBlob).mockImplementation(async () => {
+      inFlight += 1
+      peak = Math.max(peak, inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      inFlight -= 1
+      return {
+        body: JSON.stringify({
+          encryptedKey: 'ek',
+          keyNonce: 'kn',
+          encryptedData: 'ed',
+          dataNonce: 'dn'
+        })
+      } as unknown as R2ObjectBody
+    })
+
+    // #when
+    const result = await pullItems(
+      db as unknown as D1Database,
+      {} as R2Bucket,
+      'user-1',
+      Array.from({ length: ROW_COUNT }, (_, index) => `item-${index}`)
+    )
+
+    // #then — reads overlapped (not serial) but never exceeded the bound
+    expect(result).toHaveLength(ROW_COUNT)
+    expect(peak).toBeGreaterThan(1)
+    expect(peak).toBeLessThanOrEqual(R2_CONCURRENCY)
+  })
 })
 
 describe('getItem', () => {

--- a/apps/sync-server/src/services/sync.ts
+++ b/apps/sync-server/src/services/sync.ts
@@ -667,6 +667,10 @@ export const setVaultName = async (
 
 const D1_MAX_BIND_PARAMS = 95
 
+// Upper bound on simultaneous R2 reads from pullItems. Conservative for a
+// Worker (avoids firing hundreds of subrequests at once); tune here if needed.
+const R2_CONCURRENCY = 25
+
 export const pullItems = async (
   db: D1Database,
   storage: R2Bucket,
@@ -701,16 +705,19 @@ export const pullItems = async (
 
   allDbRows.sort((a, b) => a.server_cursor - b.server_cursor)
 
-  const results: RecordPullItemResponse[] = []
+  // Fetch encrypted payloads from R2 with bounded concurrency. Map over the
+  // already server_cursor-sorted allDbRows in fixed-size windows and concatenate
+  // window results in order, so output ordering is preserved while at most
+  // R2_CONCURRENCY reads are in flight at once.
+  const settled: Array<RecordPullItemResponse | null> = []
 
-  for (const row of allDbRows) {
-    const item = await toPullItemResponse(storage, userId, row)
-    if (item) {
-      results.push(item)
-    }
+  for (let i = 0; i < allDbRows.length; i += R2_CONCURRENCY) {
+    const window = allDbRows.slice(i, i + R2_CONCURRENCY)
+    const part = await Promise.all(window.map((row) => toPullItemResponse(storage, userId, row)))
+    settled.push(...part)
   }
 
-  return results
+  return settled.filter((item): item is RecordPullItemResponse => item !== null)
 }
 
 export const getItem = async (

--- a/plans/README.md
+++ b/plans/README.md
@@ -25,7 +25,7 @@ below — run `pnpm audit --prod` separately if you want that).
 | 004  | Align documented Node/pnpm versions with the pinned toolchain      | P2       | S      | LOW  | [#545](https://github.com/memrynote/memry/issues/545) | TODO   |
 | 005  | Consolidate `ReminderTargetType` (fix `'task'` drift)              | P2       | S      | MED  | [#546](https://github.com/memrynote/memry/issues/546) | TODO   |
 | 006  | Remove duplicate/broken `onSearchIndex*` preload declarations      | P2       | S      | LOW  | [#547](https://github.com/memrynote/memry/issues/547) | TODO   |
-| 007  | Concurrent (bounded) R2 reads in `pullItems`                       | P2       | M      | LOW  | [#548](https://github.com/memrynote/memry/issues/548) | TODO   |
+| 007  | Concurrent (bounded) R2 reads in `pullItems`                       | P2       | M      | LOW  | [#548](https://github.com/memrynote/memry/issues/548) | DONE   |
 | 008  | Allowlist `openExternal` schemes + explicit window hardening       | P2       | M      | MED  | [#549](https://github.com/memrynote/memry/issues/549) | TODO   |
 | 009  | Run the cross-boundary sync protocol harness in CI                 | P3       | M      | MED  | [#550](https://github.com/memrynote/memry/issues/550) | TODO   |
 | 010  | Web clipper design spec (transport, clip contract, store timeline) | P1       | M      | LOW  | —                                                     | TODO   |


### PR DESCRIPTION
## Summary

- Replace the serial per-item R2 `for await` loop in `pullItems` with bounded-concurrency windows (`R2_CONCURRENCY = 25`): map over the already `server_cursor`-sorted rows in fixed-size windows, `await Promise.all` each window, concat in order. Cuts first-sync / large-pull latency from O(N) × per-object round-trips to overlapping reads, capped so a Worker never fires hundreds of simultaneous subrequests.
- Behavior preserved: output stays ordered by `server_cursor`, `null`s are filtered, and `pullItems`' signature/return type, `toPullItemResponse`, and the D1 batching loop are untouched.
- Implements Plan 007.

## Test plan

- [x] `pnpm typecheck:sync-server` → exit 0
- [x] `pnpm test:sync-server` → 634 pass (45 files), no flake
- [x] 3 new `pullItems` tests:
  - order preserved across concurrency windows even when R2 reads resolve out of order
  - unsupported-type rows filtered while surviving rows keep order
  - concurrency bounded — `1 < peak ≤ R2_CONCURRENCY` (this assertion is red on the old serial loop, so it pins the new behavior)

## Notes

- Docs gate: pushed with `MEMRY_DOCS_IMPACT_SKIP=1`. This is an internal performance refactor with identical inputs/outputs/ordering — no API, contract, behavior, or documented-surface change, so there is nothing to update under `apps/docs/src`.

Closes #548