### PR TITLE
fix(preload): dedupe onSearchIndex* declarations, type rebuild progress

### DIFF
--- a/apps/desktop/src/preload/api/search.ts
+++ b/apps/desktop/src/preload/api/search.ts
@@ -1,4 +1,5 @@
 import { SearchChannels, GraphChannels } from '@memry/contracts/ipc-channels'
+import type { IndexRebuildProgress } from '@memry/contracts/search-api'
 import { invoke, subscribe } from '../lib/ipc'
 
 export const graphApi = {
@@ -39,12 +40,9 @@ export const searchEvents = {
     subscribe<void>(SearchChannels.events.INDEX_REBUILD_STARTED, () => callback()),
 
   onSearchIndexRebuildProgress: (
-    callback: (progress: { phase: string; current: number; total: number; percent: number }) => void
+    callback: (progress: IndexRebuildProgress) => void
   ): (() => void) =>
-    subscribe<{ phase: string; current: number; total: number; percent: number }>(
-      SearchChannels.events.INDEX_REBUILD_PROGRESS,
-      callback
-    ),
+    subscribe<IndexRebuildProgress>(SearchChannels.events.INDEX_REBUILD_PROGRESS, callback),
 
   onSearchIndexRebuildCompleted: (callback: () => void): (() => void) =>
     subscribe<void>(SearchChannels.events.INDEX_REBUILD_COMPLETED, () => callback()),

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -761,7 +761,8 @@ import type {
   SearchResponse,
   QuickSearchResponse,
   SearchStats,
-  SearchReason
+  SearchReason,
+  IndexRebuildProgress
 } from '@memry/contracts/search-api'
 
 export interface SearchClientAPI {
@@ -1750,15 +1751,6 @@ interface API extends WindowAPI, GeneratedRpcApi {
   onVaultIndexProgress: (callback: (progress: number) => void) => () => void
   onVaultError: (callback: (error: string) => void) => () => void
   onVaultIndexRecovered: (callback: (event: IndexRecoveredEvent) => void) => () => void
-  // Search event subscriptions
-  onSearchIndexRebuildStarted: (callback: () => void) => () => void
-  onSearchIndexRebuildProgress: (
-    callback: (progress: IndexRebuildProgressEvent) => void
-  ) => () => void
-  onSearchIndexRebuildCompleted: (
-    callback: (result: IndexRebuildCompletedEvent) => void
-  ) => () => void
-  onSearchIndexCorrupt: (callback: () => void) => () => void
   // Saved Filters event subscriptions
   onSavedFilterCreated: (callback: (event: SavedFilterCreatedEvent) => void) => () => void
   onSavedFilterUpdated: (callback: (event: SavedFilterUpdatedEvent) => void) => () => void
@@ -1793,9 +1785,7 @@ interface API extends WindowAPI, GeneratedRpcApi {
   onFolderViewConfigUpdated: (callback: (event: FolderViewConfigUpdatedEvent) => void) => () => void
   // Search event subscriptions
   onSearchIndexRebuildStarted: (callback: () => void) => () => void
-  onSearchIndexRebuildProgress: (
-    callback: (progress: { phase: string; current: number; total: number; percent: number }) => void
-  ) => () => void
+  onSearchIndexRebuildProgress: (callback: (progress: IndexRebuildProgress) => void) => () => void
   onSearchIndexRebuildCompleted: (callback: () => void) => () => void
   onSearchIndexCorrupt: (callback: () => void) => () => void
   // Sync event subscriptions

--- a/plans/README.md
+++ b/plans/README.md
@@ -24,7 +24,7 @@ below — run `pnpm audit --prod` separately if you want that).
 | 003  | Fix README license contradiction → GPL-3.0                         | P1       | S      | LOW  | [#544](https://github.com/memrynote/memry/issues/544) | TODO   |
 | 004  | Align documented Node/pnpm versions with the pinned toolchain      | P2       | S      | LOW  | [#545](https://github.com/memrynote/memry/issues/545) | TODO   |
 | 005  | Consolidate `ReminderTargetType` (fix `'task'` drift)              | P2       | S      | MED  | [#546](https://github.com/memrynote/memry/issues/546) | TODO   |
-| 006  | Remove duplicate/broken `onSearchIndex*` preload declarations      | P2       | S      | LOW  | [#547](https://github.com/memrynote/memry/issues/547) | TODO   |
+| 006  | Remove duplicate/broken `onSearchIndex*` preload declarations      | P2       | S      | LOW  | [#547](https://github.com/memrynote/memry/issues/547) | DONE   |
 | 007  | Concurrent (bounded) R2 reads in `pullItems`                       | P2       | M      | LOW  | [#548](https://github.com/memrynote/memry/issues/548) | TODO   |
 | 008  | Allowlist `openExternal` schemes + explicit window hardening       | P2       | M      | MED  | [#549](https://github.com/memrynote/memry/issues/549) | TODO   |
 | 009  | Run the cross-boundary sync protocol harness in CI                 | P3       | M      | MED  | [#550](https://github.com/memrynote/memry/issues/550) | TODO   |


### PR DESCRIPTION
Closes #547 (Plan 006).

## What

The `window.api` type (`interface API` in `apps/desktop/src/preload/index.d.ts`) declared the four search-index-rebuild event subscriptions **twice** with conflicting signatures. The first copy referenced `IndexRebuildProgressEvent` / `IndexRebuildCompletedEvent` — types defined nowhere in the repo. This removes the stale block, leaving one self-consistent declaration.

## Why it grew beyond a pure delete

Deleting the stale block alone left `typecheck:web` red. Root cause: the stale `onSearchIndexRebuildProgress` typed its callback param as the undefined `IndexRebuildProgressEvent`, which resolves to `any` under `skipLibCheck` and **silently absorbed** the renderer consumer's callback. Removing it exposed a real, latent mismatch:

- canonical block + the real `searchEvents` preload (`preload/api/search.ts`) typed progress as `{ phase: string; ... }`
- the consumer (`search-service.ts`) + contract use `IndexRebuildProgress`, where `phase: IndexRebuildPhase = 'notes' | 'tasks' | 'inbox'`

Proven: with the stale block present `typecheck:web` exits 0; remove it and it errors on `search-service.ts`.

So the fix also tightens the progress callback to the contract's `IndexRebuildProgress` in both the `.d.ts` mirror and the real `searchEvents` preload (added to the existing `@memry/contracts/search-api` import).

## Changes

- `apps/desktop/src/preload/index.d.ts` — remove stale block; canonical `onSearchIndexRebuildProgress` → `IndexRebuildProgress`; import the type.
- `apps/desktop/src/preload/api/search.ts` — `searchEvents` progress callback + `subscribe<>` generic → `IndexRebuildProgress`; import the type.
- `plans/README.md` — row 006 `TODO → DONE`.

## Verification

- `grep -c onSearchIndexRebuild*` → `1` each; no `IndexRebuild*Event` references remain repo-wide
- `pnpm --filter @memry/desktop typecheck:web` → exit 0
- `pnpm --filter @memry/desktop typecheck:node` → exit 0
- `search-service.test.ts` → 14 passed
- `eslint` (changed files) → 0 errors; `ipc:check` → invoke map + RPC bindings up to date
- `git diff --check` → clean

Docs gate skipped (`MEMRY_DOCS_IMPACT_SKIP=1`): internal preload type-dedup, no user-facing or documented surface change.