### PR TITLE
ci(sync-server): run the cross-boundary sync protocol harness

### DIFF
--- a/.github/workflows/sync-server-ci.yml
+++ b/.github/workflows/sync-server-ci.yml
@@ -8,6 +8,7 @@ on:
       - 'packages/rpc/**'
       - 'packages/shared/**'
       - 'packages/sync-core/**'
+      - 'tests/sync-harness/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
@@ -20,6 +21,7 @@ on:
       - 'packages/rpc/**'
       - 'packages/shared/**'
       - 'packages/sync-core/**'
+      - 'tests/sync-harness/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
@@ -73,6 +75,12 @@ jobs:
 
       - name: Test sync-server
         run: pnpm test:sync-server
+
+      - name: Build sync-harness worker
+        run: pnpm --filter @memry/sync-harness build:worker
+
+      - name: Run sync protocol harness
+        run: pnpm --filter @memry/sync-harness test
 
       - name: Validate Worker bundle
         run: pnpm --filter @memry/sync-server exec wrangler deploy --dry-run --outdir .wrangler/ci --env staging

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:release": "node --test scripts/release-utils.test.mjs scripts/release-notes-utils.test.mjs scripts/reddit-release-utils.test.mjs scripts/pre-push-policy.test.mjs scripts/package-scripts.test.mjs apps/desktop/scripts/build-packaged-app-utils.test.cjs apps/desktop/scripts/check-packaged-runtime-deps-utils.test.cjs",
     "test:desktop": "pnpm --filter @memry/desktop test",
     "test:sync-server": "pnpm --filter @memry/sync-server test",
+    "test:sync-harness": "pnpm --filter @memry/sync-harness build:worker && pnpm --filter @memry/sync-harness test",
     "test:coverage": "pnpm --filter @memry/desktop test:coverage",
     "test:e2e": "pnpm --filter @memry/desktop test:e2e",
     "lint": "pnpm lint:desktop",

--- a/plans/README.md
+++ b/plans/README.md
@@ -31,7 +31,7 @@ below — run `pnpm audit --prod` separately if you want that).
 | 008  | Allowlist `openExternal` schemes + explicit window hardening       | P2       | M      | MED  | [#549](https://github.com/memrynote/memry/issues/549) | DONE   |
 | 007  | Concurrent (bounded) R2 reads in `pullItems`                       | P2       | M      | LOW  | [#548](https://github.com/memrynote/memry/issues/548) | DONE   |
 | 008  | Allowlist `openExternal` schemes + explicit window hardening       | P2       | M      | MED  | [#549](https://github.com/memrynote/memry/issues/549) | TODO   |
-| 009  | Run the cross-boundary sync protocol harness in CI                 | P3       | M      | MED  | [#550](https://github.com/memrynote/memry/issues/550) | TODO   |
+| 009  | Run the cross-boundary sync protocol harness in CI                 | P3       | M      | MED  | [#550](https://github.com/memrynote/memry/issues/550) | DONE   |
 | 010  | Web clipper design spec (transport, clip contract, store timeline) | P1       | M      | LOW  | —                                                     | TODO   |
 | 011  | Importers design spec (Obsidian + Markdown folder v1)              | P1       | M      | LOW  | —                                                     | TODO   |
 | 012  | Task focus mode design spec (bucket axis, focus feed, daily nudge) | P2       | M      | LOW  | —                                                     | TODO   |

--- a/tests/sync-harness/src/test-auth.ts
+++ b/tests/sync-harness/src/test-auth.ts
@@ -24,17 +24,11 @@ export async function createTestDevice(
   const vaultKey = opts.vaultKey ?? generateVaultKey()
   const { publicKey, secretKey } = generateSigningKeypair()
 
-  const authPublicKeyBase64 = sodium.to_base64(
-    publicKey,
-    sodium.base64_variants.ORIGINAL
-  )
+  const authPublicKeyBase64 = sodium.to_base64(publicKey, sodium.base64_variants.ORIGINAL)
 
   const now = Math.floor(Date.now() / 1000)
 
-  const existingUser = await db
-    .prepare('SELECT id FROM users WHERE id = ?')
-    .bind(userId)
-    .first()
+  const existingUser = await db.prepare('SELECT id FROM users WHERE id = ?').bind(userId).first()
 
   if (!existingUser) {
     await db
@@ -46,10 +40,18 @@ export async function createTestDevice(
       .run()
 
     await db
-      .prepare(
-        `INSERT INTO server_cursor_sequence (user_id, current_cursor) VALUES (?, 0)`
-      )
+      .prepare(`INSERT INTO server_cursor_sequence (user_id, current_cursor) VALUES (?, 0)`)
       .bind(userId)
+      .run()
+
+    // Sync routes are gated behind an active paid entitlement (paidSyncMiddleware →
+    // assertPaidSyncAccess). Seed a 'pro' entitlement so the harness can push/pull.
+    await db
+      .prepare(
+        `INSERT INTO sync_entitlements (user_id, plan, status, source, storage_limit, max_file_size, max_vaults, version_history_days, expires_at, updated_at)
+         VALUES (?, 'pro', 'active', 'dev_seed', ?, ?, ?, ?, NULL, ?)`
+      )
+      .bind(userId, 10 * 1024 * 1024 * 1024, 200 * 1024 * 1024, 10, 365, now)
       .run()
   }
 


### PR DESCRIPTION
## Summary

Wires `@memry/sync-harness` — the only suite that exercises the **end-to-end sync protocol across the desktop↔server boundary** (simulated devices encrypt/push/pull/converge against a Miniflare-hosted worker) — into `Sync Server CI` as a gating step, so a serialization or vector-clock-encoding bug that only manifests *between* the two sides becomes a CI gate instead of relying on someone remembering to run it by hand.

Resolves #550 (Plan 009).

### Changes
- **`.github/workflows/sync-server-ci.yml`** — adds `Build sync-harness worker` + `Run sync protocol harness` steps to the `sync-server` job (gating, between `Test sync-server` and `Validate Worker bundle`); adds `tests/sync-harness/**` to both the `pull_request` and `push` `paths` triggers.
- **`package.json`** — adds a `test:sync-harness` convenience script (`build:worker && test`).
- **`tests/sync-harness/src/test-auth.ts`** — see deviation below.
- **`plans/README.md`** — Plan 009 → DONE.

### Deviation from the plan (intentional)
The plan assumed the harness was already green and was out-of-scope to touch. It was **not**: 31/32 tests failed with `402 SYNC_PAYMENT_REQUIRED`. The sync routes are gated behind an active paid entitlement (`paidSyncMiddleware` → `assertPaidSyncAccess`, landed `8bab76f4` on 2026-05-18, predating the plan), but `createTestDevice` seeded a `users` row and never a `sync_entitlements` row, so every push was rejected. Wiring a red suite as a hard gate is worse than no gate, so `createTestDevice` now seeds an active `'pro'` entitlement for the harness user. With that, the suite is green again (32/32).

## Test plan
- [x] `pnpm test:sync-harness` → builds worker, 32/32 pass (verified 3×, incl. committed state)
- [x] Workflow YAML parses; new steps ordered correctly; `tests/sync-harness/**` present in both triggers
- [x] `prettier --check` clean; all pre-commit hooks pass; docs gate clean
- [ ] First CI run on the branch: confirm the harness step actually **ran** (not skipped) and **gates** (not `continue-on-error`)