### PR TITLE
fix(tabs): show day-panel toggle only on the top-right tab bar

### DIFF
--- a/apps/desktop/src/renderer/src/components/split-view/split-layout-renderer.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/split-layout-renderer.tsx
@@ -8,6 +8,8 @@ interface SplitLayoutRendererProps {
   path: number[]
   showSidebarToggle?: boolean
   reserveDayPanelSpace?: boolean
+  /** Whether this branch contains the single top-right pane (only it shows the day-panel toggle) */
+  showDayPanelToggle?: boolean
 }
 
 /**
@@ -25,7 +27,8 @@ export const SplitLayoutRenderer = ({
   layout,
   path,
   showSidebarToggle = true,
-  reserveDayPanelSpace = true
+  reserveDayPanelSpace = true,
+  showDayPanelToggle = true
 }: SplitLayoutRendererProps): React.JSX.Element | null => {
   const { state, dispatch } = useTabs()
 
@@ -39,6 +42,7 @@ export const SplitLayoutRenderer = ({
         isActive={state.activeGroupId === layout.tabGroupId}
         showSidebarToggle={showSidebarToggle}
         reserveDayPanelSpace={reserveDayPanelSpace}
+        showDayPanelToggle={showDayPanelToggle}
       />
     )
   }
@@ -61,12 +65,14 @@ export const SplitLayoutRenderer = ({
         path={[...path, 0]}
         showSidebarToggle={showSidebarToggle}
         reserveDayPanelSpace={direction === 'horizontal' ? false : reserveDayPanelSpace}
+        showDayPanelToggle={direction === 'vertical' ? showDayPanelToggle : false}
       />
       <SplitLayoutRenderer
         layout={layout.second}
         path={[...path, 1]}
         showSidebarToggle={false}
         reserveDayPanelSpace={reserveDayPanelSpace}
+        showDayPanelToggle={direction === 'horizontal' ? showDayPanelToggle : false}
       />
     </SplitPane>
   )

--- a/apps/desktop/src/renderer/src/components/split-view/tab-pane-with-drop-zones.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-pane-with-drop-zones.tsx
@@ -24,6 +24,8 @@ interface TabPaneWithDropZonesProps {
   showSidebarToggle?: boolean
   /** Whether this pane should reserve space for the fixed day panel */
   reserveDayPanelSpace?: boolean
+  /** Whether this pane is the top-right one that shows the day-panel toggle */
+  showDayPanelToggle?: boolean
   /** Additional CSS classes */
   className?: string
 }
@@ -36,6 +38,7 @@ export const TabPaneWithDropZones = ({
   isActive,
   showSidebarToggle = true,
   reserveDayPanelSpace = true,
+  showDayPanelToggle = true,
   className
 }: TabPaneWithDropZonesProps): React.JSX.Element | null => {
   const { dispatch } = useTabs()
@@ -165,6 +168,7 @@ export const TabPaneWithDropZones = ({
         groupId={groupId}
         showSidebarToggle={showSidebarToggle}
         reserveDayPanelSpace={reserveDayPanelSpace}
+        showDayPanelToggle={showDayPanelToggle}
       />
 
       {/* Content area */}

--- a/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
@@ -26,6 +26,8 @@ interface TabBarWithDragProps {
   showSidebarToggle?: boolean
   /** Whether this tab bar should reserve space for the fixed day panel */
   reserveDayPanelSpace?: boolean
+  /** Whether this tab bar is the top-right one that shows the day-panel toggle */
+  showDayPanelToggle?: boolean
   /** Additional CSS classes */
   className?: string
 }
@@ -38,6 +40,7 @@ export const TabBarWithDrag = ({
   groupId,
   showSidebarToggle = true,
   reserveDayPanelSpace = true,
+  showDayPanelToggle = true,
   className
 }: TabBarWithDragProps): React.JSX.Element | null => {
   const { t: tPhaseF } = useT('common')
@@ -51,6 +54,8 @@ export const TabBarWithDrag = ({
   const { state: sidebarState } = useSidebar()
   const needsChromeSpacer = sidebarState === 'collapsed' && showSidebarToggle
   const shouldReserveDayPanelSpace = reserveDayPanelSpace && isDayPanelOpen
+  // Only the top-right tab bar shows the day-panel toggle (and reserves room for it)
+  const showDayPanelToggleButton = !isDayPanelOpen && showDayPanelToggle
 
   // Scroll state
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -201,7 +206,9 @@ export const TabBarWithDrag = ({
               'bg-gradient-to-l from-muted/95 via-muted/70 to-transparent',
               'hover:from-surface-active/95',
               'transition-all duration-150 ease-out z-20',
-              isDayPanelOpen ? 'absolute end-0 bottom-px' : 'absolute end-[48px] bottom-px'
+              showDayPanelToggleButton
+                ? 'absolute end-[48px] bottom-px'
+                : 'absolute end-0 bottom-px'
             )}
             aria-label={tPhaseF('phaseF.componentsTabsTabBarWithDrag.scrollTabsRight')}
           >
@@ -210,7 +217,7 @@ export const TabBarWithDrag = ({
         )}
 
         {/* Tab actions */}
-        {!isDayPanelOpen && (
+        {showDayPanelToggleButton && (
           <div className="no-drag ms-auto flex items-center gap-1 self-center pe-[13px] ps-2">
             <TabBarAction
               icon={<LayoutAlignRightIcon className="w-4 h-4 transition-colors duration-150" />}


### PR DESCRIPTION
Closes #519.

## Problem

Each tab group renders its own `TabBarWithDrag`, and the day-panel toggle rendered whenever the panel was closed — so in a split view every pane showed the button. The ask: keep it on **only the top-right** pane.

## Fix

Thread a presentational `showDayPanelToggle` flag (default `true`) down the existing split prop chain (`split-layout-renderer` → `tab-pane-with-drop-zones` → `tab-bar-with-drag`), mirroring how `reserveDayPanelSpace` is already threaded. It stays true for the single top-right leaf only:

- horizontal split → descend `second` (rightmost)
- vertical split → descend `first` (top)

So exactly one toggle in every layout (`[A|B]`→B, `[A/B]`→A, `[A|[B/C]]`→B, `[[A/B]|C]`→C). Default `true` keeps the no-split case unchanged.

Also gates the scroll-right chevron's `end-[48px]` offset on `showDayPanelToggleButton`, so non-top-right panes don't leave a dead 48px gap when tab scrolling is active.

No i18n/state changes; `useDayPanel` and the panel-open close button are untouched.

## Verification

- `pnpm --filter @memry/desktop typecheck:web` — clean
- ESLint on the 3 changed files — 0 errors
- Manual visual QA pending: no-split, horizontal, vertical, nested splits → single top-right toggle; open/close panel.

Docs gate skipped (`MEMRY_DOCS_IMPACT_SKIP=1`): cosmetic UI-only, no documented behavior change.