### PR TITLE
fix(editor): clear slash-menu group headers when reverting the query

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -39,6 +39,7 @@ import { WikiLinkPreviewCard } from './wiki-link-preview-card'
 import { LinkMentionPreviewCard } from './link-mention-preview-card'
 import { BlockDropIndicator, EmptyDocumentDropIndicator } from './block-drop-indicator'
 import { getCalloutSlashMenuItem } from './callout-block'
+import { orderSlashMenuItemsByGroup } from './slash-menu-utils'
 import { getTaskSlashMenuItem } from './task-block'
 import { TaskPrefetchProvider } from './task-block/task-prefetch-context'
 import { tasksService } from '@/services/tasks-service'
@@ -983,7 +984,12 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
                 subtext: t('editor.callout.subtext')
               })
               const taskItem = getTaskSlashMenuItem(editor)
-              const all = [...defaults, calloutItem, taskItem, ...aiItems]
+              const all = orderSlashMenuItemsByGroup([
+                ...defaults,
+                calloutItem,
+                taskItem,
+                ...aiItems
+              ])
               if (!query) return all
               const lower = query.toLowerCase()
               return all.filter(

--- a/apps/desktop/src/renderer/src/components/note/content-area/slash-menu-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/slash-menu-utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { orderSlashMenuItemsByGroup } from './slash-menu-utils'
+
+const groups = <T extends { group?: string }>(items: T[]) => items.map((i) => i.group)
+
+describe('orderSlashMenuItemsByGroup', () => {
+  it('collapses non-contiguous duplicate groups into one contiguous run', () => {
+    // The real bug: default "Basic blocks" items appear at the front, while the
+    // appended Callout/Task items (also "Basic blocks") land at the back, so the
+    // group renders twice with the same React key and leaves ghost headers.
+    const items = [
+      { title: 'Paragraph', group: 'Basic blocks' },
+      { title: 'Image', group: 'Media' },
+      { title: 'Callout', group: 'Basic blocks' },
+      { title: 'Task', group: 'Basic blocks' }
+    ]
+
+    const ordered = orderSlashMenuItemsByGroup(items)
+
+    // "Basic blocks" must appear exactly once in the group sequence.
+    expect(groups(ordered)).toEqual(['Basic blocks', 'Basic blocks', 'Basic blocks', 'Media'])
+    expect(groups(ordered).filter((g) => g === 'Basic blocks')).toHaveLength(3)
+    expect(new Set(groups(ordered)).size).toBe(2)
+  })
+
+  it('preserves first-seen group order and within-group order', () => {
+    const items = [
+      { title: 'a', group: 'B' },
+      { title: 'b', group: 'A' },
+      { title: 'c', group: 'B' },
+      { title: 'd', group: 'A' }
+    ]
+
+    const ordered = orderSlashMenuItemsByGroup(items)
+
+    expect(ordered.map((i) => i.title)).toEqual(['a', 'c', 'b', 'd'])
+    expect(groups(ordered)).toEqual(['B', 'B', 'A', 'A'])
+  })
+
+  it('handles items without a group without throwing', () => {
+    const items = [{ title: 'x' }, { title: 'y', group: 'G' }, { title: 'z' }]
+
+    const ordered = orderSlashMenuItemsByGroup(items)
+
+    expect(ordered.map((i) => i.title)).toEqual(['x', 'z', 'y'])
+    expect(groups(ordered)).toEqual([undefined, undefined, 'G'])
+  })
+
+  it('returns an empty array unchanged', () => {
+    expect(orderSlashMenuItemsByGroup([])).toEqual([])
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/slash-menu-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/slash-menu-utils.ts
@@ -1,0 +1,21 @@
+// Stable-group slash-menu items so every item sharing a `group` is contiguous,
+// preserving first-seen group order and within-group order. BlockNote's
+// SuggestionMenu emits one group label per contiguous run, keyed by the group
+// string, so non-contiguous duplicate groups produce duplicate React keys and
+// leave ghost headers behind as the query filter changes.
+export function orderSlashMenuItemsByGroup<T extends { group?: string }>(items: T[]): T[] {
+  const order: (string | undefined)[] = []
+  const byGroup = new Map<string | undefined, T[]>()
+
+  for (const item of items) {
+    let bucket = byGroup.get(item.group)
+    if (!bucket) {
+      bucket = []
+      byGroup.set(item.group, bucket)
+      order.push(item.group)
+    }
+    bucket.push(item)
+  }
+
+  return order.flatMap((group) => byGroup.get(group)!)
+}


### PR DESCRIPTION
Fixes #520

## Problem
The `/` block selector left stacked **"BASIC BLOCKS"** group headers behind when churning the query (type `/t`, delete the `t`, type another letter, repeat). They never cleared — even when nothing matched ("No items found").

## Root cause
`getItems` built `[...defaults, calloutItem, taskItem, ...aiItems]`. Default items place the **"Basic blocks"** run near the front (before Advanced / Media / Headings / Others), while `calloutItem` (`editor.callout.group` = "Basic blocks") and `taskItem` (hardcoded "Basic blocks") are **appended at the end** → "Basic blocks" appears in **two non-contiguous runs**.

BlockNote's `SuggestionMenu` emits one `<Label key={group}>` per *contiguous* run, so the two runs produce two labels sharing `key="Basic blocks"`. Duplicate React keys break reconciliation as the filtered set changes per keystroke, so stale label nodes are never unmounted and pile up.

## Fix
Add `orderSlashMenuItemsByGroup` (pure helper) to make each group contiguous — first-seen group order and within-group order preserved — before returning from `getItems`. Each group now renders exactly once with a unique key. Callout and Task fold into the single "Basic blocks" section.

- `slash-menu-utils.ts` — new helper
- `slash-menu-utils.test.ts` — new test (4 cases, incl. the exact failing-before shape)
- `ContentArea.tsx` — wrap the assembled array + one import

## Verification
- `vitest --project renderer slash-menu-utils.test.ts` → 4/4 pass
- `tsc -p tsconfig.web.json` → exit 0
- `eslint` (changed files) → 0 errors
- Manual `pnpm dev` GUI repro: not yet run (fix is deterministic, unit-proven on the bug's exact shape)