### PR TITLE
fix(notes): strip HTML comments + markdown from preview snippets (#518)

### DIFF
--- a/apps/desktop/src/main/vault/frontmatter.test.ts
+++ b/apps/desktop/src/main/vault/frontmatter.test.ts
@@ -326,4 +326,12 @@ More text here to ensure the snippet is long enough.
   it('createSnippet returns full cleaned content when shorter than max', () => {
     expect(createSnippet('Simple note text.', 200)).toBe('Simple note text.')
   })
+
+  it('createSnippet strips memry HTML comment markers', () => {
+    const content =
+      'first <!-- memry:block-nesting-level=1 --> second <!-- colors:{"textColor":"red"} --> third'
+    const snippet = createSnippet(content, 200)
+    expect(snippet).toBe('first second third')
+    expect(snippet).not.toContain('<!--')
+  })
 })

--- a/apps/desktop/src/main/vault/frontmatter.ts
+++ b/apps/desktop/src/main/vault/frontmatter.ts
@@ -473,8 +473,11 @@ export function deserializePropertyValue(value: string | null, type: PropertyTyp
  * @returns Truncated content with ellipsis if needed
  */
 export function createSnippet(content: string, maxLength = 200): string {
+  // Remove HTML comment markers (memry block-nesting/colors/file annotations)
+  let cleaned = content.replace(/<!--[\s\S]*?-->/g, '')
+
   // Remove markdown headers
-  let cleaned = content.replace(/^#+\s+/gm, '')
+  cleaned = cleaned.replace(/^#+\s+/gm, '')
 
   // Remove links but keep text
   cleaned = cleaned.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')

--- a/packages/app-core/src/markdown.test.ts
+++ b/packages/app-core/src/markdown.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { snippet } from './markdown.ts'
+
+test('snippet: strips memry block-nesting comment markers (issue #518)', () => {
+  const content = [
+    '#test',
+    '<!-- memry:block-nesting-level=1 -->',
+    'asdasdf',
+    '<!-- memry:block-nesting-level=2 -->',
+    'adfasdfa'
+  ].join('\n')
+  const result = snippet(content)
+  assert.equal(result, '#test asdasdf adfasdfa')
+  assert.ok(!result.includes('<!--'))
+  assert.ok(!result.includes('memry:block-nesting'))
+})
+
+test('snippet: strips colors and file HTML comment markers', () => {
+  const content =
+    'text <!-- colors:{"textColor":"red"} --> more <!-- file:{"url":"x","name":"y"} -->'
+  assert.equal(snippet(content), 'text more')
+})
+
+test('snippet: strips markdown syntax to plain prose', () => {
+  const content = [
+    '# Heading',
+    'This is **bold** and *italic* and ~~strike~~.',
+    'A [label](https://example.com) link and ![alt text](img.png) image.',
+    'Some `inline code` here.',
+    'See [[Other Note]] and [[Target|Alias]].',
+    '> a quote',
+    '- bullet one',
+    '1. numbered one'
+  ].join('\n')
+  const result = snippet(content)
+  assert.equal(
+    result,
+    'Heading This is bold and italic and strike. A label link and alt text image. Some inline code here. See Other Note and Alias. a quote bullet one numbered one'
+  )
+})
+
+test('snippet: collapses whitespace and caps length at 180 chars', () => {
+  const content = `${'word '.repeat(100)}`
+  const result = snippet(content)
+  assert.ok(result.length <= 180)
+  assert.ok(!/\s{2,}/.test(result))
+})

--- a/packages/app-core/src/markdown.ts
+++ b/packages/app-core/src/markdown.ts
@@ -23,5 +23,21 @@ export function wordCount(content: string): number {
 }
 
 export function snippet(content: string): string {
-  return content.replace(/\s+/g, ' ').trim().slice(0, 180)
+  return stripMarkup(content).replace(/\s+/g, ' ').trim().slice(0, 180)
+}
+
+function stripMarkup(markdown: string): string {
+  return markdown
+    .replace(/<!--[\s\S]*?-->/g, '') // memry block/colors/file markers + any HTML comment
+    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2') // wiki link w/ alias → alias
+    .replace(/\[\[([^\]]+)\]\]/g, '$1') // wiki link → target
+    .replace(/```[\s\S]*?```/g, (block) => block.replace(/```/g, '')) // fenced code → inner text
+    .replace(/`([^`]+)`/g, '$1') // inline code
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1') // image → alt
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // link → text
+    .replace(/^#{1,6}\s+/gm, '') // headings
+    .replace(/^>\s?/gm, '') // blockquotes
+    .replace(/^\s*[-*+]\s+/gm, '') // bullet markers
+    .replace(/^\s*\d+\.\s+/gm, '') // ordered markers
+    .replace(/[*_~]{1,3}/g, '') // emphasis/strike
 }


### PR DESCRIPTION
## Problem

Closes #518. The tab hover popup (and wiki-link preview, same code path) rendered the raw note body — internal `<!-- memry:block-nesting-level=N -->` markers and bare markdown syntax:

```
#test <!-- memry:block-nesting-level=1 --> asdasdf <!-- memry:block-nesting-level=2 --> adfasdfa <!-- ...
```

Two snippet generators both leaked these annotations:

- `snippet()` in `packages/app-core/src/markdown.ts` — feeds the tab popup + wiki-link hover (`previewByTitle → readNote → snippet`). It only collapsed whitespace and truncated; **no markup stripping at all**.
- `createSnippet()` in `apps/desktop/src/main/vault/frontmatter.ts` — feeds the index cache (search-result previews). It stripped markdown but **not** the HTML comment markers.

## Fix

- Add a local `stripMarkup()` helper to `markdown.ts` that removes `<!-- ... -->` comments (block-nesting / colors / file markers) plus markdown syntax (headings, links, images, code, wiki-links, emphasis, lists, quotes) before the existing collapse + 180-char slice.
- Add a single `<!-- ... -->` strip to `createSnippet()`; existing behavior otherwise untouched.

`#test` (no space after `#`) stays literal — it isn't a markdown heading; only the unreadable comment markup is removed.

## Tests

- New `packages/app-core/src/markdown.test.ts` (4 cases incl. the exact issue repro).
- New comment-stripping case in `frontmatter.test.ts`.

| Check | Result |
|---|---|
| `markdown.test.ts` (node:test) | 4/4 |
| app-core suite | 7/7 |
| `frontmatter.test.ts` (vitest main) | 37/37 |
| app-core + desktop `typecheck:node` | clean |
| eslint | clean |

## QA

Open a note with nested blocks, hover its tab → preview reads as clean prose; hover a `[[wikilink]]` to it → same; search for it → clean snippet.