### PR TITLE
fix(notes): make /task slash command create a task like the checklist block

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -982,7 +982,7 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
                 group: t('editor.callout.group'),
                 subtext: t('editor.callout.subtext')
               })
-              const taskItem = getTaskSlashMenuItem(editor)
+              const taskItem = getTaskSlashMenuItem(editor, noteId)
               const all = [...defaults, calloutItem, taskItem, ...aiItems]
               if (!query) return all
               const lower = query.toLowerCase()

--- a/apps/desktop/src/renderer/src/components/note/content-area/task-block/index.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/task-block/index.tsx
@@ -34,18 +34,29 @@ export const createTaskBlock = createReactBlockSpec(
   }
 )
 
-export function getTaskSlashMenuItem(editor: unknown) {
+export function getTaskSlashMenuItem(editor: unknown, noteId?: string) {
   return {
     title: 'Task',
     onItemClick: async () => {
-      const taskEditor = editor as TaskBlockEditor
+      const taskEditor = editor as TaskBlockEditor & {
+        getBlock: (id: string) => TaskBlock | undefined
+      }
       const currentBlock = taskEditor.getTextCursorPosition().block
+      const blockId = currentBlock.id
       const content = currentBlock.content ?? []
       const text =
         content
           .map((c: TaskBlockInlineContent) => (typeof c === 'string' ? c : (c.text ?? '')))
           .join('')
           .trim() || ''
+
+      // Convert the block to a taskBlock immediately — same as the
+      // checklist→task conversion — so the user always sees a task even if the
+      // backing task creation below is slow, fails, or has no project yet.
+      taskEditor.updateBlock(currentBlock, {
+        type: 'taskBlock',
+        props: { taskId: '', title: text, checked: false }
+      })
 
       const res = await tasksService.listProjects()
       const projects = res.projects ?? []
@@ -64,13 +75,21 @@ export function getTaskSlashMenuItem(editor: unknown) {
         projectId: parsed.projectId ?? defaultProject.id,
         title: parsed.title,
         priority: PRIORITY_REVERSE[parsed.priority] ?? 0,
-        dueDate: parsed.dueDate ? formatDateKey(parsed.dueDate) : null
+        dueDate: parsed.dueDate ? formatDateKey(parsed.dueDate) : null,
+        linkedNoteIds: noteId ? [noteId] : []
       })
       if (result.success && result.task) {
-        taskEditor.updateBlock(currentBlock, {
+        // Re-fetch fresh: the block reference captured before the awaits above
+        // may be stale by now.
+        const freshBlock = taskEditor.getBlock(blockId) ?? currentBlock
+        const currentTitle = (freshBlock.props?.title as string) || parsed.title || text
+        taskEditor.updateBlock(freshBlock, {
           type: 'taskBlock',
-          props: { taskId: result.task.id, title: parsed.title, checked: false }
+          props: { taskId: result.task.id, title: currentTitle, checked: false }
         })
+        if (currentTitle && currentTitle !== result.task.title) {
+          void tasksService.update({ id: result.task.id, title: currentTitle })
+        }
       }
     },
     aliases: ['task', 'todo', 'action'],

--- a/apps/desktop/src/renderer/src/components/note/content-area/task-block/task-slash-menu-item.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/task-block/task-slash-menu-item.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  listProjects: vi.fn(),
+  create: vi.fn()
+}))
+
+// Keep the import graph light: the slash-menu item logic is what's under test,
+// not the React block renderer or BlockNote's spec factory.
+vi.mock('@blocknote/react', () => ({
+  createReactBlockSpec: () => ({})
+}))
+
+vi.mock('./task-block-renderer', () => ({
+  TaskBlockRenderer: () => null
+}))
+
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: {
+    listProjects: mocks.listProjects,
+    create: mocks.create
+  }
+}))
+
+import { getTaskSlashMenuItem } from './index'
+
+interface FakeBlock {
+  id: string
+  type?: string
+  content?: Array<{ text?: string } | string>
+  props?: Record<string, unknown>
+}
+
+function makeEditor(block: FakeBlock) {
+  const updateBlock = vi.fn()
+  const getBlock = vi.fn(() => block)
+  const editor = {
+    getTextCursorPosition: () => ({ block }),
+    updateBlock,
+    getBlock
+  }
+  return { editor, updateBlock, getBlock }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getTaskSlashMenuItem', () => {
+  it('converts the current block to a taskBlock immediately, even when no project exists', async () => {
+    // #given there is no default/inbox project (task creation cannot proceed)
+    mocks.listProjects.mockResolvedValue({ projects: [] })
+    const block: FakeBlock = { id: 'b1', content: [{ text: 'Buy milk' }], props: {} }
+    const { editor, updateBlock } = makeEditor(block)
+
+    // #when the user selects /task
+    await getTaskSlashMenuItem(editor).onItemClick()
+
+    // #then the block is optimistically converted so the user always sees a task
+    expect(updateBlock).toHaveBeenCalledWith(
+      block,
+      expect.objectContaining({
+        type: 'taskBlock',
+        props: expect.objectContaining({ title: 'Buy milk', checked: false })
+      })
+    )
+  })
+
+  it('creates a task linked to the note and patches the real taskId onto a fresh block', async () => {
+    // #given a default project and a successful create
+    mocks.listProjects.mockResolvedValue({ projects: [{ id: 'p1', isInbox: true }] })
+    mocks.create.mockResolvedValue({ success: true, task: { id: 'task-123', title: 'Buy milk' } })
+    const block: FakeBlock = { id: 'b1', content: [{ text: 'Buy milk' }], props: {} }
+    const { editor, updateBlock, getBlock } = makeEditor(block)
+
+    // #when the user selects /task inside note-1
+    await getTaskSlashMenuItem(editor, 'note-1').onItemClick()
+
+    // #then the task is created linked to the originating note
+    expect(mocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'p1', title: 'Buy milk', linkedNoteIds: ['note-1'] })
+    )
+    // #and the block is re-fetched fresh (not reused across the async boundary)
+    expect(getBlock).toHaveBeenCalledWith('b1')
+    // #and patched with the real taskId
+    expect(updateBlock).toHaveBeenLastCalledWith(
+      block,
+      expect.objectContaining({ props: expect.objectContaining({ taskId: 'task-123' }) })
+    )
+  })
+})


### PR DESCRIPTION
Fixes #517

## Problem
Typing `/task` in a note and selecting it (mouse or Enter) did nothing — no task was created, the block never changed.

## Root cause
`getTaskSlashMenuItem.onItemClick` ran the full async chain (`listProjects` → find default project → `create`) **before** ever converting the block, gated behind silent early-returns (`if (!defaultProject) return`, `if (result.success && result.task)`), and then called `updateBlock` on a **stale block reference** captured before two `await`s. So whenever there was no default project, `create` failed, or the captured reference went stale, the paragraph was never converted and the user saw nothing happen. The callout slash item works only because it is fully synchronous.

## Fix
Mirror the working checklist→task conversion (`convertCheckboxToTask`):
- Convert the block to a `taskBlock` **immediately / optimistically**, so the user always sees a task even if the backing create is slow, fails, or has no project yet.
- Thread `noteId` into the slash item so the created task links back to the originating note (`linkedNoteIds`), matching the checklist path.
- After `create`, re-fetch a **fresh** block via `editor.getBlock(blockId)` (not the stale reference) before patching in the real `taskId`.

## Tests
- New `task-block/task-slash-menu-item.test.ts` (TDD, red→green):
  - converts the block to a `taskBlock` immediately even when no project exists
  - creates a task linked to the note and patches the real `taskId` onto a freshly fetched block
- Existing task-block + ContentArea suites green (49/49); `typecheck:web` and ESLint clean.

## Manual QA
Open a note, type `/task`, select it → the block should convert to a task and a linked task entry should be created.