### PR TITLE
fix(ui): portal dropdown submenu so it escapes parent menu overflow clip (#516)

### DIFF
--- a/apps/desktop/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -43,15 +43,17 @@ const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
-      'floating-content-motion',
-      className
-    )}
-    {...props}
-  />
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
+        'floating-content-motion',
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
 ))
 DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
 


### PR DESCRIPTION
Fixes #516.

## Problem
Opening a tag in the sidebar → 3-dot menu → hover **Change color** rendered the color-swatch picker *clipped inside* the menu instead of as a visible submenu (squished swatches next to the scrollbar — see issue screenshot).

## Root cause
`DropdownMenuSubContent` in the shared `ui/dropdown-menu.tsx` primitive was **not** wrapped in a Radix `Portal`, while sibling `DropdownMenuContent` **is** portaled and carries `overflow-y-auto overflow-x-hidden` (needed so long menus scroll). A non-portaled submenu renders as a DOM child of that overflow-clipped container, so the swatch grid gets clipped. This is the canonical shadcn nested-submenu clipping bug.

## Fix
Wrap `DropdownMenuPrimitive.SubContent` in `DropdownMenuPrimitive.Portal` (mirrors how `Content` is already portaled). Positioning is handled by Floating UI regardless of portal, so the only behavioral change is the submenu escaping the parent's overflow clip — a strict improvement. One shared-primitive change; also repairs the same latent clip in `tasks/drag-drop/move-menu.tsx` and `folder-view/view-switcher.tsx` submenus.

## Verification
- `tag-detail-view` renderer test: 10/10 (incl. "opens the color picker menu")
- `typecheck:web`: exit 0
- eslint on the changed file: clean
- Visual QA: tag → 3-dot → **Change color** shows swatches as a visible side submenu, not clipped

## Out of scope
`ContextMenuSubContent` has the identical latent bug but no right-click submenu consumers exist today; this PR is the dropdown-only root fix.