### PR TITLE
fix(editor): guard ProseMirror view access before mount (#541)

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
@@ -80,6 +80,7 @@ describe('ReviewFormattingToolbar', () => {
     toolbarMocks.editor.prosemirrorState.selection.empty = false
     ;(toolbarMocks.editor.prosemirrorState.selection as { node?: unknown }).node = undefined
     toolbarMocks.editor.prosemirrorState.doc.textBetween.mockClear()
+    ;(toolbarMocks.editor as { _tiptapEditor?: unknown })._tiptapEditor = undefined
   })
 
   it('adds Comment to the selected text toolbar', () => {
@@ -146,5 +147,41 @@ describe('ReviewFormattingToolbar', () => {
     render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
 
     expect(screen.getByText('Comment')).toBeDisabled()
+  })
+
+  // Regression for #541: TipTap 3.x `editor.view` returns a Proxy that throws
+  // on any property access (e.g. `.dom`) until the ProseMirror view is mounted.
+  // The toolbar reads `view.dom` while reading the selection; before the guard,
+  // that threw "[tiptap error]: ... Cannot access view['dom']" and crashed the
+  // editor into its error boundary ("Editor Error") on note open.
+  it('does not crash when the ProseMirror view is not mounted yet', () => {
+    const unmountedView = new Proxy(
+      {},
+      {
+        get(_target, key) {
+          throw new Error(
+            `[tiptap error]: The editor view is not available. Cannot access view['${String(key)}']. The editor may not be mounted yet.`
+          )
+        }
+      }
+    )
+    ;(toolbarMocks.editor as { _tiptapEditor?: unknown })._tiptapEditor = {
+      state: { selection: { empty: true } },
+      view: unmountedView,
+      // editorView is the real mounted view — absent until the PM view mounts.
+      editorView: undefined
+    }
+
+    vi.useFakeTimers()
+    try {
+      expect(() => {
+        render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+        // Flush the deferred selection read in ReviewToolbarButton's effect,
+        // which also routes through `view.dom`.
+        vi.runOnlyPendingTimers()
+      }).not.toThrow()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
@@ -317,7 +317,14 @@ function getDomEditorSelection(editor: BlockNoteEditor): ReviewSelection | null 
 }
 
 function getProseMirrorView(editor: BlockNoteEditor) {
-  return (editor as any)._tiptapEditor?.view ?? (editor as any).prosemirrorView
+  const tiptap = (editor as any)._tiptapEditor
+  // TipTap 3.x `editor.view` returns a Proxy that THROWS on any property access
+  // (e.g. `.dom`) until the ProseMirror view is mounted, so `view?.dom` can't
+  // short-circuit — the Proxy is non-null. `editorView` is the real view and is
+  // only set once mounted; guard on it so reads during the pre-mount render
+  // window get `undefined` instead of crashing the editor (issue #541).
+  if (tiptap && !tiptap.editorView) return undefined
+  return tiptap?.view ?? (editor as any).prosemirrorView
 }
 
 function getProseMirrorViewDom(editor: BlockNoteEditor): HTMLElement | undefined {


### PR DESCRIPTION
Fixes #541.

## Symptom
Opening any note showed **"Editor Error"** with:

```
[tiptap error]: The editor view is not available. Cannot access view['dom']. The editor may not be mounted yet.
  at Object.get (.../app.asar/...)
```

## Root cause
TipTap 3.x changed `editor.view`: until the ProseMirror view is mounted it returns a **Proxy that throws** on any property access (e.g. `.dom`) instead of `undefined`.

```js
// @tiptap/core
get view() {
  if (this.editorView) return this.editorView   // mounted → real view
  return new Proxy(...)                          // not mounted → throws on .dom etc.
}
```

So the legacy guard `getProseMirrorView(editor)?.dom` no longer protects: `view` is a non-null Proxy, so `?.` does not short-circuit and `.dom` hits the throwing trap.

The review formatting toolbar reads `view.dom` while resolving the selection (`getDomEditorSelection` / `getSelectionTop`) from a **render-phase** `useEditorState` selector. With the **sticky toolbar** enabled, the toolbar button mounts on the first render — *before* the view is mounted — so the read throws and the editor crashes into its error boundary on every note open.

**Floating mode (the default)** only mounts the toolbar once a selection exists, by which point the view is already mounted. That is why most users (and our dev setup) never hit it, while the reporter — on sticky mode — saw it on every note.

## Fix
Guard `getProseMirrorView` on `editorView` (the real, mounted view) so reads during the pre-mount window return `undefined` instead of throwing. `getProseMirrorView` is used only in this file, so the blast radius is contained.

## Testing
- New regression test in `review-formatting-toolbar.test.tsx`: renders the toolbar with a `_tiptapEditor.view` Proxy that throws on `.dom` and `editorView: undefined` (simulating an unmounted view). Fails before the fix, passes after.
- `pnpm --filter @memry/desktop typecheck:web` — clean.
- ESLint on changed files — 0 errors (pre-existing `any` warnings only).
- Full renderer test project — only pre-existing failures remain (`info-section.test.tsx`, `remaining-zero-surfaces.test.tsx`), confirmed failing identically on `origin/main` with this change stashed.

## Repro (manual)
Settings → Editor → enable sticky toolbar → open any note → "Editor Error". With this fix the editor renders normally.

## Follow-up (not in this PR)
`use-tag-suggestions.ts` has the same unguarded-access class (`registerPlugin` → `view.updateState`, a layout-effect `view.dispatch`), but those run in post-mount effects and are not known to trigger. Left out to avoid speculative changes; can be hardened separately if needed.