### PR TITLE
fix(updater): install update on graceful quit (fixes restart-now loop)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -69,7 +69,7 @@ import { toAbsolutePath, createSnapshot } from './vault/notes'
 import { safeRead } from './vault/file-ops'
 import { SnapshotReasons } from '@memry/db-schema/schema/notes-cache'
 import { SettingsChannels } from '@memry/contracts/ipc-channels'
-import { initializeUpdater } from './updater'
+import { initializeUpdater, isQuitAndInstallRequested, performQuitAndInstall } from './updater'
 import { buildAppMenu, buildEditableTextContextMenu } from './menu'
 import { setMainI18n } from './lib/main-i18n'
 import {
@@ -1257,7 +1257,15 @@ app.on('before-quit', (event) => {
     .then(() => {
       shutdownLog.info('cleanup complete')
       clearTimeout(shutdownTimeout)
-      app.exit(0)
+      if (isQuitAndInstallRequested()) {
+        // Cleanup is done; hand off to Squirrel/NSIS to install + relaunch.
+        // The re-entrant before-quit returns early (isShuttingDown), so the
+        // install-driven quit is no longer cancelled by preventDefault.
+        shutdownLog.info('installing downloaded update and relaunching')
+        performQuitAndInstall()
+      } else {
+        app.exit(0)
+      }
     })
     .catch((error) => {
       shutdownLog.error('error during cleanup:', error)

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -28,7 +28,8 @@ const mocks = vi.hoisted(() => {
   return {
     app: {
       isPackaged: true,
-      getVersion: vi.fn(() => '1.2.3')
+      getVersion: vi.fn(() => '1.2.3'),
+      quit: vi.fn()
     },
     windows: [
       {
@@ -107,6 +108,7 @@ describe('updater', () => {
     mocks.dialog.showMessageBox.mockResolvedValue({ response: 1 })
     mocks.app.isPackaged = true
     mocks.app.getVersion.mockReturnValue('1.2.3')
+    mocks.app.quit.mockClear()
     mocks.windows[0].webContents.send.mockClear()
   })
 
@@ -234,6 +236,34 @@ describe('updater', () => {
       releaseNotes: 'Ready to install',
       downloadProgressPercent: 100
     })
+    // quitAndInstall triggers a graceful app quit (so before-quit cleanup runs)
+    // instead of installing immediately; the install runs after cleanup.
+    expect(mocks.app.quit).toHaveBeenCalledTimes(1)
+    expect(updater.isQuitAndInstallRequested()).toBe(true)
+    expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('installs the downloaded update only after graceful shutdown completes', async () => {
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+
+    mocks.autoUpdater.emit('update-downloaded', {
+      version: '1.2.7',
+      releaseNotes: 'Ready'
+    })
+    await flushAsyncWork()
+
+    expect(updater.isQuitAndInstallRequested()).toBe(false)
+
+    // User clicks "Restart now": request a graceful quit, do not install yet.
+    updater.quitAndInstall()
+    expect(mocks.app.quit).toHaveBeenCalledTimes(1)
+    expect(updater.isQuitAndInstallRequested()).toBe(true)
+    expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled()
+
+    // The shutdown handler calls performQuitAndInstall() after cleanup; only
+    // then does Squirrel install + relaunch.
+    updater.performQuitAndInstall()
     expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -14,6 +14,7 @@ let activeCheck: Promise<AppUpdateState> | null = null
 let activeDownload: Promise<AppUpdateState> | null = null
 let downloadPromptVisible = false
 let restartPromptVisible = false
+let quitAndInstallRequested = false
 
 let state: AppUpdateState = {
   currentVersion: getCurrentDisplayVersion(),
@@ -171,7 +172,22 @@ export function quitAndInstall(): void {
   }
 
   logger.info('quitting to install update', { version: state.availableVersion })
-  setImmediate(() => autoUpdater.quitAndInstall())
+  quitAndInstallRequested = true
+  // Trigger the app's graceful shutdown first. Calling autoUpdater.quitAndInstall()
+  // directly here is cancelled by the before-quit handler (event.preventDefault +
+  // app.exit), so the update never installs and the app re-prompts on every launch.
+  // The shutdown handler calls performQuitAndInstall() once cleanup completes.
+  app.quit()
+}
+
+export function isQuitAndInstallRequested(): boolean {
+  return quitAndInstallRequested
+}
+
+// Performs the real Squirrel/NSIS install + relaunch. Must run only after the
+// app's graceful shutdown (vault close, write-back flush) has completed.
+export function performQuitAndInstall(): void {
+  autoUpdater.quitAndInstall()
 }
 
 function setState(patch: Partial<AppUpdateState>): void {

--- a/docs/superpowers/specs/2026-06-15-update-notification-ambient-ui-design.md
+++ b/docs/superpowers/specs/2026-06-15-update-notification-ambient-ui-design.md
@@ -1,0 +1,169 @@
+# Ambient update notification UI
+
+Date: 2026-06-15
+Status: Design (pending review)
+Owner: Kaan
+
+## Problem
+
+Auto-update interrupts the user with native dialogs on startup: a "new version
+available → Download?" popup (`update-available`), then a "Restart now?" popup
+(`update-downloaded`). The popups are intrusive and easy to dismiss-and-forget.
+
+Goal: remove the startup popups. Surface updates as an ambient, dismissible UI
+affordance the user opens on their own time, with an in-app "What's new" view.
+
+## Decisions (locked)
+
+1. **Placement:** a slim banner row at the bottom of the left sidebar, directly
+   above the existing footer (sync / vault / settings). Visible only when an
+   update is in play; hidden otherwise.
+2. **Details action:** clicking the banner opens an in-app "What's new" modal
+   that renders the release notes already on the wire, with the primary action
+   (Download / Restart) inline and a secondary "View on GitHub" link.
+3. **Scope:** replace BOTH native popups. The banner cycles through states:
+   Update available → Downloading… N% → Restart to update. Startup is silent.
+
+## Current state (what already exists)
+
+- Main `apps/desktop/src/main/updater.ts` runs the electron-updater state
+  machine and broadcasts `AppUpdateState` to the renderer on every event
+  (`UpdaterChannels.events.STATE_CHANGED`). `autoDownload = false`,
+  `autoInstallOnAppQuit = true`.
+- `AppUpdateState` (in `@memry/contracts/ipc-updater`) already carries
+  everything the UI needs: `status`, `availableVersion`, `releaseName`,
+  `releaseDate`, `releaseNotes` (already HTML-stripped to plain text),
+  `downloadProgressPercent`, `currentVersion`, `error`.
+- Renderer hook `use-app-updater.ts` exposes `state` + `checkForUpdates`,
+  `downloadUpdate`, `quitAndInstall`. Currently consumed only by Settings →
+  General (`pages/settings/general-section.tsx`).
+- IPC handlers exist: GET_STATE, CHECK_FOR_UPDATES, DOWNLOAD_UPDATE,
+  QUIT_AND_INSTALL (`ipc/updater-handlers.ts`).
+- `quitAndInstall` was just fixed to install via graceful shutdown (PR #570).
+
+So this feature is mostly: stop auto-popping the dialogs in main, and add
+renderer UI that reads the state already broadcast.
+
+## New behavior
+
+### Main process (`updater.ts`)
+
+- Remove the auto-popup calls: delete `void promptToDownload(info)` from the
+  `update-available` handler and `void promptToRestart(info)` from the
+  `update-downloaded` handler.
+- Delete the now-unused `promptToDownload`, `promptToRestart`,
+  `downloadPromptVisible`, `restartPromptVisible`, and `buildPromptDetail`.
+  The `dialog` import becomes unused → remove it. `normalizeReleaseNotes` stays
+  (still used to populate `state.releaseNotes`).
+- Keep the full state machine and broadcasting unchanged — that is what drives
+  the new UI. `autoDownload` stays `false` (download is user-initiated from the
+  modal). `autoInstallOnAppQuit` stays `true`.
+- Net: startup performs the check silently; the renderer reacts to state.
+
+### Renderer
+
+**State → UI mapping** (single source of truth = `AppUpdateState.status`):
+
+| status        | banner                          | modal primary action |
+| ------------- | ------------------------------- | -------------------- |
+| idle/checking | hidden                          | n/a                  |
+| up-to-date    | hidden                          | n/a                  |
+| unavailable   | hidden                          | n/a                  |
+| available     | "↑ Update available · Details"  | Download             |
+| downloading   | "Downloading… N%"               | progress (disabled)  |
+| downloaded    | "Restart to update"             | Restart now          |
+| error         | "Update failed · Retry" (muted) | Retry (check again)  |
+
+**New components:**
+
+1. `contexts/updater-context.tsx` — `UpdaterProvider` + `useUpdater()`. Wraps the
+   existing `useAppUpdater` logic so the banner, the modal, and Settings share
+   ONE subscription/state, plus modal open/close state (`isDetailsOpen`,
+   `openDetails()`, `closeDetails()`). Mounted high in `App.tsx`.
+
+2. `components/sidebar/sidebar-update-banner.tsx` — the slim row. Reads
+   `useUpdater()`; returns `null` for hidden statuses. For `available`/`error`
+   click opens the modal; for `downloaded` click opens the modal (primary =
+   Restart). Shows progress text for `downloading`. Collapsed-sidebar
+   (`group-data-[collapsible=icon]`) variant: icon + dot only, tooltip with the
+   label. Uses logical Tailwind classes (RTL-safe).
+
+3. `components/updater/update-details-dialog.tsx` — the "What's new" modal built
+   on `ui/dialog.tsx`. Header: "Memrynote {availableVersion} is available"
+   (or "What's new in {currentVersion}" when already downloaded). Body: release
+   notes (`state.releaseNotes`, rendered with preserved line breaks; empty-state
+   fallback text). Footer: status-dependent primary button (Download /
+   Downloading… / Restart now / Retry) + "View on GitHub" secondary link +
+   Close. Mounted once at root next to `SettingsModal` in `App.tsx`.
+
+**Wiring:**
+
+- `app-sidebar.tsx`: render `<SidebarUpdateBanner />` between `</SidebarContent>`
+  and `<SidebarFooter>`.
+- `App.tsx`: wrap with `UpdaterProvider`; mount `<UpdateDetailsDialog />` near
+  `<SettingsModal />`.
+- `pages/settings/general-section.tsx`: switch from `useAppUpdater()` to
+  `useUpdater()` so Settings and the banner never diverge. Existing Settings
+  updater UI otherwise unchanged.
+
+### "View on GitHub" link
+
+- Requires a generic external-URL opener. No generic `openExternal(url)` exists
+  in the renderer today (only note-specific `notes.openExternal(id)`). Add a
+  small IPC: `app:open-external` in `packages/contracts`, a preload binding,
+  and a main handler that reuses the existing `lib/external-url.ts` allowlist
+  (https/http/mailto, from #549). Run `pnpm ipc:generate && pnpm ipc:check`.
+- URL: the GitHub releases page, `https://github.com/memrynote/memry/releases`
+  (link to the tag when `availableVersion` is known). NOTE: if the repo is
+  private, this page is not publicly viewable — the in-app notes are the primary
+  surface and the link is a secondary affordance. Confirm repo visibility during
+  planning; drop the link if private.
+
+## i18n
+
+Add renderer strings (en/common.json is the only gate per i18n:check):
+banner labels per status, modal title variants, button labels (Download,
+Downloading, Restart now, Retry, View on GitHub, Close), empty-notes fallback.
+Reuse existing `settings:phaseI` error strings where they fit.
+
+## Testing
+
+- **Main** (`updater.test.ts`): assert `dialog.showMessageBox` is NEVER called on
+  `update-available` or `update-downloaded` (popups removed) while `state`
+  still transitions correctly. Update/replace the existing dialog-assertion
+  tests. Keep the quitAndInstall graceful-shutdown tests from PR #570.
+- **Renderer:**
+  - `sidebar-update-banner.test.tsx`: hidden for idle/up-to-date/unavailable;
+    correct label per status; click opens modal; `downloaded` label correct.
+  - `update-details-dialog.test.tsx`: renders notes; correct primary action per
+    status; Download → `downloadUpdate`, Restart → `quitAndInstall`,
+    View on GitHub → `openExternal` with the releases URL.
+  - Mock `@/components/ui/dialog`/`picker` per the renderer jsdom convention if
+    needed.
+- `pnpm ipc:check` green after the new external-URL contract.
+
+## Edge cases
+
+- Download race: the banner reflects whatever `status` the main process
+  broadcasts; clicking Restart only calls `quitAndInstall` when `downloaded`
+  (button disabled otherwise) — consistent with the PR #570 guard.
+- `error` state: banner is muted, non-blocking; Retry re-runs `checkForUpdates`.
+- Collapsed sidebar: icon-only with a dot + tooltip.
+- Dev/unsupported builds (`status: unavailable`): banner hidden, no modal.
+
+## Out of scope
+
+- Background auto-download (kept manual; user starts it from the modal).
+- Rich markdown rendering of notes beyond line breaks (notes are already plain
+  text from `normalizeReleaseNotes`).
+- Changing the Settings → General updater layout beyond the shared-state swap.
+- Update channels / staged rollout.
+
+## Files touched (estimate)
+
+Main: `updater.ts`, `updater.test.ts`, `ipc/` (new external handler),
+`lib/external-url.ts` (reuse). Contracts: `packages/contracts` (new
+`app:open-external`), preload binding. Renderer: `contexts/updater-context.tsx`
+(new), `components/sidebar/sidebar-update-banner.tsx` (new),
+`components/updater/update-details-dialog.tsx` (new), `app-sidebar.tsx`,
+`App.tsx`, `pages/settings/general-section.tsx`, i18n `en/common.json`.


### PR DESCRIPTION
## Problem

Auto-update is stuck in a loop. The update dialog reports a new version, **Download** says it downloaded, but clicking **Restart now** does not restart or install. After a manual quit + relaunch the same "new version available" popup reappears every time. The update never actually installs.

## Root cause

`apps/desktop/src/main/index.ts` `before-quit` handler calls `event.preventDefault()` on **every** quit and then force-terminates with `app.exit(0)` after async cleanup.

When the user clicks **Restart now**, `autoUpdater.quitAndInstall()` relies on Electron's normal quit lifecycle so Squirrel.Mac (and NSIS on Windows) can swap the app bundle and relaunch. The handler cancels that quit (`preventDefault`) and then kills the process with `app.exit(0)`, which skips the `will-quit`/`quit` events the install handoff depends on (electron-updater also hooks `app.once('quit')` for `autoInstallOnAppQuit`). The staged update is never applied, so each launch re-detects the same newer version and re-prompts. This is the well-known Electron `before-quit` + `preventDefault` auto-update gotcha.

This is **not** a code-signing problem: production macOS builds are `notarize: true`.

## Fix

- `updater.ts` — `quitAndInstall()` now sets a `quitAndInstallRequested` flag and triggers a graceful `app.quit()` instead of calling `autoUpdater.quitAndInstall()` directly. New exports `isQuitAndInstallRequested()` and `performQuitAndInstall()`.
- `index.ts` — after shutdown cleanup completes, the `before-quit` handler installs + relaunches via `performQuitAndInstall()` when an update install was requested, otherwise `app.exit(0)` as before. The re-entrant `before-quit` returns early on `isShuttingDown`, so the install-driven quit is no longer cancelled.

Cleanup (vault close, write-back flush) still runs before the install, so no data loss. Cross-platform (macOS Squirrel + Windows NSIS).

## Verification

- `npx vitest run --config config/vitest.config.ts --project main src/main/updater.test.ts` → 6/6 pass, including the new regression test "installs the downloaded update only after graceful shutdown completes".
- `pnpm typecheck:node` clean, eslint clean on changed files, `git diff --check` clean.

## Still needs real-app QA before merge

Unit tests prove the control flow but cannot prove Squirrel.Mac actually swaps the bundle. Needs a signed packaged build + real GitHub release: install the old version, click **Restart now**, confirm it relaunches into the new version.

Known edge (pre-existing, not worsened): if the user clicks Restart now before Squirrel finishes staging, the install waits without a timeout. Can add a fallback if desired.