### PR TITLE
feat(vault): flat vault root + Obsidian compatibility

### DIFF
--- a/apps/desktop/scripts/seed-data/inbox.ts
+++ b/apps/desktop/scripts/seed-data/inbox.ts
@@ -197,7 +197,7 @@ export const INBOX_ITEMS: SeedInboxItem[] = [
     sourceUrl: 'https://example.com/recipes/lemon-ricotta-pancakes',
     captureSource: 'browser-extension',
     filedAt: offsetISO(-3, 16),
-    filedTo: 'notes/food/Lemon Ricotta Pancakes.md',
+    filedTo: 'food/Lemon Ricotta Pancakes.md',
     filedAction: 'note',
     metadata: { publisher: 'Kitchen Journal', readingTime: 6 },
     createdAt: offsetISO(-4, 11),
@@ -277,7 +277,7 @@ export const FILING_HISTORY_ROWS: SeedFilingHistory[] = [
     id: generateId(),
     itemType: 'link',
     itemContent: 'Recipe: lemon ricotta pancakes — weekend breakfast idea',
-    filedTo: 'notes/food/Lemon Ricotta Pancakes.md',
+    filedTo: 'food/Lemon Ricotta Pancakes.md',
     filedAction: 'note',
     tags: ['projects/personal', 'food'],
     filedAt: offsetISO(-3, 16)
@@ -286,7 +286,7 @@ export const FILING_HISTORY_ROWS: SeedFilingHistory[] = [
     id: generateId(),
     itemType: 'link',
     itemContent: 'Weekend hike in Marin — trail map and picnic stop',
-    filedTo: 'notes/travel/Marin Weekend.md',
+    filedTo: 'travel/Marin Weekend.md',
     filedAction: 'note',
     tags: ['projects/personal', 'fitness'],
     filedAt: offsetISO(-9, 14)
@@ -295,7 +295,7 @@ export const FILING_HISTORY_ROWS: SeedFilingHistory[] = [
     id: generateId(),
     itemType: 'note',
     itemContent: 'Birthday dinner ideas for Dad',
-    filedTo: 'notes/life/Birthday Plans.md',
+    filedTo: 'life/Birthday Plans.md',
     filedAction: 'note',
     tags: ['projects/personal', 'family'],
     filedAt: offsetISO(-15, 11)

--- a/apps/desktop/scripts/seed-data/notes.test.ts
+++ b/apps/desktop/scripts/seed-data/notes.test.ts
@@ -7,7 +7,7 @@ describe('notes seed data', () => {
     const istanbul = NOTES.find((note) => note.frontmatter.title === 'Istanbul')
 
     expect(istanbul).toBeDefined()
-    expect(istanbul?.relativePath).toBe('notes/travel/Istanbul.md')
+    expect(istanbul?.relativePath).toBe('travel/Istanbul.md')
     expect(istanbul?.frontmatter.tags).toEqual(['travel', 'istanbul', 'planning'])
     expect(istanbul?.frontmatter.location).toBe('Istanbul, Turkey')
     expect(istanbul?.frontmatter.status).toBe('planning')

--- a/apps/desktop/scripts/seed-data/notes.ts
+++ b/apps/desktop/scripts/seed-data/notes.ts
@@ -90,13 +90,13 @@ export const NOTE_IDS = {
 } as const
 
 export const FOLDER_CONFIGS: Array<{ path: string; icon: string }> = [
-  { path: 'notes/books', icon: '📚' },
-  { path: 'notes/movies', icon: '🎬' },
-  { path: 'notes/weight', icon: '💪' },
-  { path: 'notes/life', icon: '🌳' },
-  { path: 'notes/projects', icon: '📦' },
-  { path: 'notes/tech', icon: '💻' },
-  { path: 'notes/travel', icon: '✈️' }
+  { path: 'books', icon: '📚' },
+  { path: 'movies', icon: '🎬' },
+  { path: 'weight', icon: '💪' },
+  { path: 'life', icon: '🌳' },
+  { path: 'projects', icon: '📦' },
+  { path: 'tech', icon: '💻' },
+  { path: 'travel', icon: '✈️' }
 ]
 
 interface NoteSpec {
@@ -118,7 +118,7 @@ const SPECS: NoteSpec[] = [
   // ============================================================================
   {
     id: NOTE_IDS.bookDune,
-    relativePath: 'notes/books/Dune.md',
+    relativePath: 'books/Dune.md',
     title: 'Dune',
     emoji: '🪐',
     tags: ['fiction', 'sci-fi', 'classic', 'reread'],
@@ -148,7 +148,7 @@ Sixty years on, *Dune* still sets the bar for political-sci-fi worldbuilding. Re
   },
   {
     id: NOTE_IDS.bookProjectHailMary,
-    relativePath: 'notes/books/Project Hail Mary.md',
+    relativePath: 'books/Project Hail Mary.md',
     title: 'Project Hail Mary',
     emoji: '🚀',
     tags: ['fiction', 'sci-fi', 'andy-weir'],
@@ -176,7 +176,7 @@ See also: [[The Martian]] — same flavor, drier.
   },
   {
     id: NOTE_IDS.bookAtomicHabits,
-    relativePath: 'notes/books/Atomic Habits.md',
+    relativePath: 'books/Atomic Habits.md',
     title: 'Atomic Habits',
     emoji: '⚛️',
     tags: ['nonfiction', 'productivity', 'habits'],
@@ -209,7 +209,7 @@ See also: [[The Martian]] — same flavor, drier.
   },
   {
     id: NOTE_IDS.bookDeepWork,
-    relativePath: 'notes/books/Deep Work.md',
+    relativePath: 'books/Deep Work.md',
     title: 'Deep Work',
     emoji: '🧠',
     tags: ['nonfiction', 'productivity', 'focus'],
@@ -243,7 +243,7 @@ Cognitive demand is the new luxury good. Defend three to four hours a day or sur
   },
   {
     id: NOTE_IDS.bookTheMartian,
-    relativePath: 'notes/books/The Martian.md',
+    relativePath: 'books/The Martian.md',
     title: 'The Martian',
     emoji: '🥔',
     tags: ['fiction', 'sci-fi', 'andy-weir'],
@@ -275,7 +275,7 @@ When motivation is thin. Watney's *I-am-not-going-to-die-today* energy is contag
   },
   {
     id: NOTE_IDS.bookSapiens,
-    relativePath: 'notes/books/Sapiens.md',
+    relativePath: 'books/Sapiens.md',
     title: 'Sapiens',
     emoji: '🌍',
     tags: ['nonfiction', 'history', 'big-ideas'],
@@ -307,7 +307,7 @@ Chapter 9. Cognitive revolution → agricultural revolution → unification of h
   },
   {
     id: NOTE_IDS.bookMisteryHotel,
-    relativePath: 'notes/books/The Mystery Guest.md',
+    relativePath: 'books/The Mystery Guest.md',
     title: 'The Mystery Guest',
     emoji: '🔍',
     tags: ['fiction', 'mystery', 'cozy'],
@@ -329,7 +329,7 @@ Half through. The narrator's voice is the appeal more than the puzzle.
   },
   {
     id: NOTE_IDS.bookOnWriting,
-    relativePath: 'notes/books/On Writing.md',
+    relativePath: 'books/On Writing.md',
     title: 'On Writing',
     emoji: '✍️',
     tags: ['nonfiction', 'craft', 'writing'],
@@ -358,7 +358,7 @@ Pair with [[Deep Work]] for the *defend the time* angle.
   },
   {
     id: NOTE_IDS.bookKitchenConfidential,
-    relativePath: 'notes/books/Kitchen Confidential.md',
+    relativePath: 'books/Kitchen Confidential.md',
     title: 'Kitchen Confidential',
     emoji: '🔪',
     tags: ['nonfiction', 'memoir', 'food'],
@@ -384,7 +384,7 @@ Also see [[Tokyo Cafes]] — different cuisine, same reverence.
   },
   {
     id: NOTE_IDS.bookAlmanackOfNaval,
-    relativePath: 'notes/books/The Almanack of Naval Ravikant.md',
+    relativePath: 'books/The Almanack of Naval Ravikant.md',
     title: 'The Almanack of Naval Ravikant',
     emoji: '🧭',
     tags: ['nonfiction', 'philosophy', 'wealth'],
@@ -408,7 +408,7 @@ Pairs with [[On Reading]] and [[My Why]].
   },
   {
     id: NOTE_IDS.bookFourThousandWeeks,
-    relativePath: 'notes/books/Four Thousand Weeks.md',
+    relativePath: 'books/Four Thousand Weeks.md',
     title: 'Four Thousand Weeks',
     emoji: '⏳',
     tags: ['nonfiction', 'productivity', 'mortality'],
@@ -432,7 +432,7 @@ Hard counterweight to [[Atomic Habits]] and [[Deep Work]] — those say *get mor
   },
   {
     id: NOTE_IDS.bookManSearchMeaning,
-    relativePath: "notes/books/Man's Search for Meaning.md",
+    relativePath: "books/Man's Search for Meaning.md",
     title: "Man's Search for Meaning",
     emoji: '🕯️',
     tags: ['nonfiction', 'philosophy', 'memoir'],
@@ -460,7 +460,7 @@ Frankl's central claim: *meaning* — not pleasure, not even purpose — is what
   // ============================================================================
   {
     id: NOTE_IDS.movieDune2021,
-    relativePath: 'notes/movies/Dune (2021).md',
+    relativePath: 'movies/Dune (2021).md',
     title: 'Dune (2021)',
     emoji: '🪐',
     tags: ['movies/sci-fi', 'denis-villeneuve', 'rewatch'],
@@ -495,7 +495,7 @@ The Salusa Secundus scene needs ten more seconds. Hardly a crime.
   },
   {
     id: NOTE_IDS.movieInterstellar,
-    relativePath: 'notes/movies/Interstellar.md',
+    relativePath: 'movies/Interstellar.md',
     title: 'Interstellar',
     emoji: '🌌',
     tags: ['movies/sci-fi', 'christopher-nolan', 'rewatch'],
@@ -523,7 +523,7 @@ Plot-mechanically nonsense. Emotionally undefeated. I will fight on this.
   },
   {
     id: NOTE_IDS.movieTheMatrix,
-    relativePath: 'notes/movies/The Matrix.md',
+    relativePath: 'movies/The Matrix.md',
     title: 'The Matrix',
     emoji: '💊',
     tags: ['movies/sci-fi', 'wachowski', 'classic'],
@@ -545,7 +545,7 @@ Plot-mechanically nonsense. Emotionally undefeated. I will fight on this.
   },
   {
     id: NOTE_IDS.movieEverythingEverywhere,
-    relativePath: 'notes/movies/Everything Everywhere All at Once.md',
+    relativePath: 'movies/Everything Everywhere All at Once.md',
     title: 'Everything Everywhere All at Once',
     emoji: '🥯',
     tags: ['movies/scifi', 'a24', 'absurd'],
@@ -567,7 +567,7 @@ Multiverse-as-feeling instead of multiverse-as-plot. Michelle Yeoh as the laundr
   },
   {
     id: NOTE_IDS.movieAnewHope,
-    relativePath: 'notes/movies/Star Wars Episode IV.md',
+    relativePath: 'movies/Star Wars Episode IV.md',
     title: 'Star Wars Episode IV',
     emoji: '⚔️',
     tags: ['movies/sci-fi', 'star-wars', 'classic'],
@@ -588,7 +588,7 @@ Multiverse-as-feeling instead of multiverse-as-plot. Michelle Yeoh as the laundr
   },
   {
     id: NOTE_IDS.movieAriival,
-    relativePath: 'notes/movies/Arrival.md',
+    relativePath: 'movies/Arrival.md',
     title: 'Arrival',
     emoji: '🛸',
     tags: ['movies/sci-fi', 'denis-villeneuve', 'thoughtful'],
@@ -608,7 +608,7 @@ Multiverse-as-feeling instead of multiverse-as-plot. Michelle Yeoh as the laundr
   },
   {
     id: NOTE_IDS.movieTheMartianFilm,
-    relativePath: 'notes/movies/The Martian (Film).md',
+    relativePath: 'movies/The Martian (Film).md',
     title: 'The Martian (Film)',
     emoji: '🥔',
     tags: ['movies/sci-fi', 'ridley-scott'],
@@ -628,7 +628,7 @@ Multiverse-as-feeling instead of multiverse-as-plot. Michelle Yeoh as the laundr
   },
   {
     id: NOTE_IDS.movieParasite,
-    relativePath: 'notes/movies/Parasite.md',
+    relativePath: 'movies/Parasite.md',
     title: 'Parasite',
     emoji: '🪳',
     tags: ['movies/drama', 'bong-joon-ho', 'foreign'],
@@ -648,7 +648,7 @@ Multiverse-as-feeling instead of multiverse-as-plot. Michelle Yeoh as the laundr
   },
   {
     id: NOTE_IDS.movieSpiritedAway,
-    relativePath: 'notes/movies/Spirited Away.md',
+    relativePath: 'movies/Spirited Away.md',
     title: 'Spirited Away',
     emoji: '🐉',
     tags: ['movies/animation', 'studio-ghibli'],
@@ -668,7 +668,7 @@ Multiverse-as-feeling instead of multiverse-as-plot. Michelle Yeoh as the laundr
   },
   {
     id: NOTE_IDS.movieWatchlist2026,
-    relativePath: 'notes/movies/Watchlist 2026.md',
+    relativePath: 'movies/Watchlist 2026.md',
     title: 'Watchlist 2026',
     emoji: '🎞️',
     tags: ['movies', 'watchlist'],
@@ -699,7 +699,7 @@ Multiverse-as-feeling instead of multiverse-as-plot. Michelle Yeoh as the laundr
   },
   {
     id: NOTE_IDS.movieBladerunner,
-    relativePath: 'notes/movies/Blade Runner 2049.md',
+    relativePath: 'movies/Blade Runner 2049.md',
     title: 'Blade Runner 2049',
     emoji: '🌆',
     tags: ['movies/sci-fi', 'denis-villeneuve'],
@@ -719,7 +719,7 @@ Multiverse-as-feeling instead of multiverse-as-plot. Michelle Yeoh as the laundr
   },
   {
     id: NOTE_IDS.movieGoodfellas,
-    relativePath: 'notes/movies/Goodfellas.md',
+    relativePath: 'movies/Goodfellas.md',
     title: 'Goodfellas',
     emoji: '🍝',
     tags: ['movies/crime', 'scorsese'],
@@ -745,7 +745,7 @@ Multiverse-as-feeling instead of multiverse-as-plot. Michelle Yeoh as the laundr
   // ============================================================================
   {
     id: NOTE_IDS.weightCut2026,
-    relativePath: 'notes/weight/2026 Cut.md',
+    relativePath: 'weight/2026 Cut.md',
     title: '2026 Cut',
     emoji: '💪',
     tags: ['fitness', 'cut'],
@@ -784,7 +784,7 @@ See running table in [[Cutting Log]]. Wikilinked journal entries: [[2026-04-22]]
   },
   {
     id: NOTE_IDS.weightCuttingLog,
-    relativePath: 'notes/weight/Cutting Log.md',
+    relativePath: 'weight/Cutting Log.md',
     title: 'Cutting Log',
     emoji: '📊',
     tags: ['fitness', 'log'],
@@ -813,7 +813,7 @@ See running table in [[Cutting Log]]. Wikilinked journal entries: [[2026-04-22]]
   },
   {
     id: NOTE_IDS.weightProteinTargets,
-    relativePath: 'notes/weight/Protein Targets.md',
+    relativePath: 'weight/Protein Targets.md',
     title: 'Protein Targets',
     emoji: '🍳',
     tags: ['fitness', 'nutrition'],
@@ -838,7 +838,7 @@ Real food first. Powder fills gaps after lifting.
   },
   {
     id: NOTE_IDS.weightTrainingSplit,
-    relativePath: 'notes/weight/Training Split.md',
+    relativePath: 'weight/Training Split.md',
     title: 'Training Split',
     emoji: '🏋️',
     tags: ['fitness', 'strength'],
@@ -865,7 +865,7 @@ Wed and Sat are [[Cardio Plan]]. Sun rest.
   },
   {
     id: NOTE_IDS.weightSundayWeighIn,
-    relativePath: 'notes/weight/Sunday Weigh-in.md',
+    relativePath: 'weight/Sunday Weigh-in.md',
     title: 'Sunday Weigh-in',
     emoji: '⚖️',
     tags: ['fitness', 'tracking'],
@@ -883,7 +883,7 @@ Goes into [[Cutting Log]].
   },
   {
     id: NOTE_IDS.weightCardioPlan,
-    relativePath: 'notes/weight/Cardio Plan.md',
+    relativePath: 'weight/Cardio Plan.md',
     title: 'Cardio Plan',
     emoji: '🏃',
     tags: ['fitness', 'cardio'],
@@ -902,7 +902,7 @@ Heart rate monitor on, not optional.
   },
   {
     id: NOTE_IDS.weightFoodDiary,
-    relativePath: 'notes/weight/Food Diary.md',
+    relativePath: 'weight/Food Diary.md',
     title: 'Food Diary',
     emoji: '🥗',
     tags: ['fitness', 'food'],
@@ -920,7 +920,7 @@ Heart rate monitor on, not optional.
   },
   {
     id: NOTE_IDS.weightProgressPhotos,
-    relativePath: 'notes/weight/Progress Photos.md',
+    relativePath: 'weight/Progress Photos.md',
     title: 'Progress Photos',
     emoji: '📸',
     tags: ['fitness', 'tracking'],
@@ -942,7 +942,7 @@ Compares to [[2026 Cut]] start.
   // ============================================================================
   {
     id: NOTE_IDS.lifeMyWhy,
-    relativePath: 'notes/life/My Why.md',
+    relativePath: 'life/My Why.md',
     title: 'My Why',
     emoji: '🌳',
     tags: ['life', 'reflection', 'mission'],
@@ -964,7 +964,7 @@ Local first. End-to-end encrypted. Open file format. Sync optional.
   },
   {
     id: NOTE_IDS.lifeOnReading,
-    relativePath: 'notes/life/On Reading.md',
+    relativePath: 'life/On Reading.md',
     title: 'On Reading',
     emoji: '📖',
     tags: ['life', 'reading', 'reflection'],
@@ -995,7 +995,7 @@ I'd rather read [[Atomic Habits]] (one good idea, executed well) than another *7
   },
   {
     id: NOTE_IDS.lifeYearReview2025,
-    relativePath: 'notes/life/Year in Review 2025.md',
+    relativePath: 'life/Year in Review 2025.md',
     title: 'Year in Review 2025',
     emoji: '📅',
     tags: ['life', 'annual', 'reflection'],
@@ -1030,7 +1030,7 @@ I'd rather read [[Atomic Habits]] (one good idea, executed well) than another *7
   },
   {
     id: NOTE_IDS.lifeMorningRoutine,
-    relativePath: 'notes/life/Morning Routine.md',
+    relativePath: 'life/Morning Routine.md',
     title: 'Morning Routine',
     emoji: '☀️',
     tags: ['life', 'habits'],
@@ -1058,7 +1058,7 @@ Inspired by [[Deep Work]]. Codified after [[Atomic Habits]].
   },
   {
     id: NOTE_IDS.lifeFinances,
-    relativePath: 'notes/life/Finances.md',
+    relativePath: 'life/Finances.md',
     title: 'Finances',
     emoji: '💸',
     tags: ['life', 'money'],
@@ -1086,7 +1086,7 @@ Inspired by [[Deep Work]]. Codified after [[Atomic Habits]].
   },
   {
     id: NOTE_IDS.lifeOnFear,
-    relativePath: 'notes/life/On Fear.md',
+    relativePath: 'life/On Fear.md',
     title: 'On Fear',
     emoji: '🌑',
     tags: ['life', 'reflection'],
@@ -1110,7 +1110,7 @@ Read [[Man's Search for Meaning]] when it's bad. Talk to my partner. Run hard. S
   },
   {
     id: NOTE_IDS.lifeRelationships,
-    relativePath: 'notes/life/Relationships.md',
+    relativePath: 'life/Relationships.md',
     title: 'Relationships',
     emoji: '🫶',
     tags: ['life', 'people'],
@@ -1138,7 +1138,7 @@ If a relationship is important, it should show up *in the calendar*, not just in
   },
   {
     id: NOTE_IDS.lifeWhatBringsJoy,
-    relativePath: 'notes/life/What Brings Me Joy.md',
+    relativePath: 'life/What Brings Me Joy.md',
     title: 'What Brings Me Joy',
     emoji: '😄',
     tags: ['life', 'gratitude', 'joy'],
@@ -1163,7 +1163,7 @@ If a relationship is important, it should show up *in the calendar*, not just in
   // ============================================================================
   {
     id: NOTE_IDS.projMemryLaunch,
-    relativePath: 'notes/projects/memrynote Launch.md',
+    relativePath: 'projects/memrynote Launch.md',
     title: 'memrynote Launch',
     emoji: '🚀',
     tags: ['projects/memry', 'projects/active'],
@@ -1209,7 +1209,7 @@ Tasks tagged \`#projects/memry\` show up under "memrynote Launch" project — th
   },
   {
     id: NOTE_IDS.projMemryArchitecture,
-    relativePath: 'notes/projects/memrynote Architecture.md',
+    relativePath: 'projects/memrynote Architecture.md',
     title: 'memrynote Architecture',
     emoji: '🏛️',
     tags: ['projects/memry', 'architecture'],
@@ -1239,7 +1239,7 @@ Local-first means *all* data is on disk. Browser sandbox is a non-starter.
   },
   {
     id: NOTE_IDS.projMemryRoadmap,
-    relativePath: 'notes/projects/memrynote Roadmap.md',
+    relativePath: 'projects/memrynote Roadmap.md',
     title: 'memrynote Roadmap',
     emoji: '🗺️',
     tags: ['projects/memry', 'planning'],
@@ -1273,7 +1273,7 @@ Local-first means *all* data is on disk. Browser sandbox is a non-starter.
   },
   {
     id: NOTE_IDS.projMemryGTM,
-    relativePath: 'notes/projects/memrynote GTM.md',
+    relativePath: 'projects/memrynote GTM.md',
     title: 'memrynote GTM',
     emoji: '📣',
     tags: ['projects/memry', 'gtm'],
@@ -1305,7 +1305,7 @@ People who already journal but resent their tool. Bonus: programmers, researcher
   },
   {
     id: NOTE_IDS.projGardenSchedule,
-    relativePath: 'notes/projects/Garden Schedule.md',
+    relativePath: 'projects/Garden Schedule.md',
     title: 'Garden Schedule',
     emoji: '🌱',
     tags: ['projects/home', 'garden'],
@@ -1333,7 +1333,7 @@ Focus on what survives a heat dome: peppers, eggplant, zucchini.
   },
   {
     id: NOTE_IDS.projHomeRenovation,
-    relativePath: 'notes/projects/Home Renovation.md',
+    relativePath: 'projects/Home Renovation.md',
     title: 'Home Renovation',
     emoji: '🔨',
     tags: ['projects/home', 'renovation'],
@@ -1367,7 +1367,7 @@ Focus on what survives a heat dome: peppers, eggplant, zucchini.
   },
   {
     id: NOTE_IDS.projBlogRedesign,
-    relativePath: 'notes/projects/Blog Redesign.md',
+    relativePath: 'projects/Blog Redesign.md',
     title: 'Blog Redesign',
     emoji: '✏️',
     tags: ['projects/personal', 'web'],
@@ -1388,7 +1388,7 @@ Tracking related work: [[TypeScript Patterns]], [[Vim Motions]].
   },
   {
     id: NOTE_IDS.projOpenSourceFork,
-    relativePath: 'notes/projects/Open Source Fork.md',
+    relativePath: 'projects/Open Source Fork.md',
     title: 'Open Source Fork',
     emoji: '🌿',
     tags: ['projects/personal', 'oss'],
@@ -1408,7 +1408,7 @@ Move only if a real maintainer disappears for ~6 months.
   },
   {
     id: NOTE_IDS.projSideProjectIdeas,
-    relativePath: 'notes/projects/Side Project Ideas.md',
+    relativePath: 'projects/Side Project Ideas.md',
     title: 'Side Project Ideas',
     emoji: '💡',
     tags: ['projects/personal', 'ideas'],
@@ -1434,7 +1434,7 @@ Linked: [[Year in Review 2025]] (the *abandoned-at-60%* problem).
   },
   {
     id: NOTE_IDS.projConferenceTalk,
-    relativePath: 'notes/projects/Conference Talk.md',
+    relativePath: 'projects/Conference Talk.md',
     title: 'Conference Talk',
     emoji: '🎤',
     tags: ['projects/personal', 'speaking'],
@@ -1472,7 +1472,7 @@ Linked: [[Year in Review 2025]] (the *abandoned-at-60%* problem).
   // ============================================================================
   {
     id: NOTE_IDS.techTypescriptPatterns,
-    relativePath: 'notes/tech/TypeScript Patterns.md',
+    relativePath: 'tech/TypeScript Patterns.md',
     title: 'TypeScript Patterns',
     emoji: '🟦',
     tags: ['tech/typescript', 'reference'],
@@ -1513,7 +1513,7 @@ Linked: [[Drizzle ORM]] for type inference details, [[memrynote Architecture]] f
   },
   {
     id: NOTE_IDS.techDrizzleORM,
-    relativePath: 'notes/tech/Drizzle ORM.md',
+    relativePath: 'tech/Drizzle ORM.md',
     title: 'Drizzle ORM',
     emoji: '🦉',
     tags: ['tech/sql', 'tech/typescript', 'reference'],
@@ -1553,7 +1553,7 @@ pnpm db:studio      # browse
   },
   {
     id: NOTE_IDS.techCRDTArchitecture,
-    relativePath: 'notes/tech/CRDT Architecture.md',
+    relativePath: 'tech/CRDT Architecture.md',
     title: 'CRDT Architecture',
     emoji: '🧩',
     tags: ['tech/sync', 'tech/architecture'],
@@ -1593,7 +1593,7 @@ Yes, "CRDT" is overloaded[^1]. Yjs implements a state-based CRDT (specifically a
   },
   {
     id: NOTE_IDS.techPostgresIndexing,
-    relativePath: 'notes/tech/Postgres Indexing.md',
+    relativePath: 'tech/Postgres Indexing.md',
     title: 'Postgres Indexing',
     emoji: '🐘',
     tags: ['tech/sql', 'tech/postgres'],
@@ -1630,7 +1630,7 @@ Always. Otherwise you're index-cargo-culting.
   },
   {
     id: NOTE_IDS.techCMUDatabaseCourse,
-    relativePath: 'notes/tech/CMU Database Course.md',
+    relativePath: 'tech/CMU Database Course.md',
     title: 'CMU Database Course',
     emoji: '🎓',
     tags: ['tech/sql', 'learning'],
@@ -1648,7 +1648,7 @@ Pair with [[Postgres Indexing]] for practice.
   },
   {
     id: NOTE_IDS.techKipThorneBlackHoles,
-    relativePath: 'notes/tech/Kip Thorne — Black Holes.md',
+    relativePath: 'tech/Kip Thorne — Black Holes.md',
     title: 'Kip Thorne — Black Holes',
     emoji: '⚫',
     tags: ['tech/physics', 'reference'],
@@ -1674,7 +1674,7 @@ Watched [[Interstellar]] for the fourth time. Wanted to understand Gargantua, no
   },
   {
     id: NOTE_IDS.techElectronGotchas,
-    relativePath: 'notes/tech/Electron Gotchas.md',
+    relativePath: 'tech/Electron Gotchas.md',
     title: 'Electron Gotchas',
     emoji: '⚡',
     tags: ['tech/electron', 'reference'],
@@ -1705,7 +1705,7 @@ Run \`pnpm ipc:check\` after editing any contract type. Renderer will lie about 
   },
   {
     id: NOTE_IDS.techSqliteVec,
-    relativePath: 'notes/tech/sqlite-vec.md',
+    relativePath: 'tech/sqlite-vec.md',
     title: 'sqlite-vec',
     emoji: '🧮',
     tags: ['tech/sql', 'tech/embeddings'],
@@ -1741,7 +1741,7 @@ ORDER BY distance;
   },
   {
     id: NOTE_IDS.techVimMotions,
-    relativePath: 'notes/tech/Vim Motions.md',
+    relativePath: 'tech/Vim Motions.md',
     title: 'Vim Motions',
     emoji: '⌨️',
     tags: ['tech/editor', 'reference'],
@@ -1767,7 +1767,7 @@ ORDER BY distance;
   },
   {
     id: NOTE_IDS.techGitWorkflow,
-    relativePath: 'notes/tech/Git Workflow.md',
+    relativePath: 'tech/Git Workflow.md',
     title: 'Git Workflow',
     emoji: '🌿',
     tags: ['tech/git', 'reference'],
@@ -1794,7 +1794,7 @@ Until the branch lands. After that, it's history.
   },
   {
     id: NOTE_IDS.techRustNotes,
-    relativePath: 'notes/tech/Rust Notes.md',
+    relativePath: 'tech/Rust Notes.md',
     title: 'Rust Notes',
     emoji: '🦀',
     tags: ['tech/rust', 'learning'],
@@ -1818,7 +1818,7 @@ Borrow checker is exactly as advertised. The first week is rough; the second wee
   },
   {
     id: NOTE_IDS.techDockerCheatsheet,
-    relativePath: 'notes/tech/Docker Cheatsheet.md',
+    relativePath: 'tech/Docker Cheatsheet.md',
     title: 'Docker Cheatsheet',
     emoji: '🐳',
     tags: ['tech/docker', 'reference'],
@@ -1843,7 +1843,7 @@ docker system prune -af --volumes
   // ============================================================================
   {
     id: NOTE_IDS.travelIstanbul,
-    relativePath: 'notes/travel/Istanbul.md',
+    relativePath: 'travel/Istanbul.md',
     title: 'Istanbul',
     emoji: '🌉',
     tags: ['travel', 'istanbul', 'planning'],
@@ -1894,7 +1894,7 @@ docker system prune -af --volumes
   },
   {
     id: NOTE_IDS.travelTokyoTrip,
-    relativePath: 'notes/travel/Tokyo Trip.md',
+    relativePath: 'travel/Tokyo Trip.md',
     title: 'Tokyo Trip',
     emoji: '🗼',
     tags: ['travel/asia', 'travel/japan', 'memoir'],
@@ -1939,7 +1939,7 @@ Linked journal entries: [[2026-04-15]], [[2026-04-17]].
   },
   {
     id: NOTE_IDS.travelKyotoDayTrip,
-    relativePath: 'notes/travel/Kyoto Day Trip.md',
+    relativePath: 'travel/Kyoto Day Trip.md',
     title: 'Kyoto Day Trip',
     emoji: '⛩️',
     tags: ['travel/asia', 'travel/japan'],
@@ -1970,7 +1970,7 @@ Linked: [[Tokyo Trip]] (the parent), journal [[2026-04-15]].
   },
   {
     id: NOTE_IDS.travelLisbonNotes,
-    relativePath: 'notes/travel/Lisbon Notes.md',
+    relativePath: 'travel/Lisbon Notes.md',
     title: 'Lisbon Notes',
     emoji: '🐠',
     tags: ['travel/europe', 'travel/portugal'],
@@ -1997,7 +1997,7 @@ Linked: [[Tokyo Trip]] (the parent), journal [[2026-04-15]].
   },
   {
     id: NOTE_IDS.travelIcelandRingRoad,
-    relativePath: 'notes/travel/Iceland Ring Road.md',
+    relativePath: 'travel/Iceland Ring Road.md',
     title: 'Iceland Ring Road',
     emoji: '🌋',
     tags: ['travel/europe', 'travel/iceland', 'planning'],
@@ -2032,7 +2032,7 @@ Linked: [[Tokyo Trip]] (the parent), journal [[2026-04-15]].
   },
   {
     id: NOTE_IDS.travelPackingList,
-    relativePath: 'notes/travel/Packing List.md',
+    relativePath: 'travel/Packing List.md',
     title: 'Packing List',
     emoji: '🎒',
     tags: ['travel', 'reference'],
@@ -2058,7 +2058,7 @@ Linked: [[Tokyo Trip]] (the parent), journal [[2026-04-15]].
   },
   {
     id: NOTE_IDS.travelSeoulFood,
-    relativePath: 'notes/travel/Seoul Food.md',
+    relativePath: 'travel/Seoul Food.md',
     title: 'Seoul Food',
     emoji: '🌶️',
     tags: ['travel/asia', 'travel/korea', 'food'],
@@ -2081,7 +2081,7 @@ Linked: [[Tokyo Trip]] (the parent), journal [[2026-04-15]].
   },
   {
     id: NOTE_IDS.travelMexicoCityArt,
-    relativePath: 'notes/travel/Mexico City Art.md',
+    relativePath: 'travel/Mexico City Art.md',
     title: 'Mexico City Art',
     emoji: '🎨',
     tags: ['travel/americas', 'travel/mexico', 'art'],
@@ -2100,7 +2100,7 @@ Linked: [[Tokyo Trip]] (the parent), journal [[2026-04-15]].
   },
   {
     id: NOTE_IDS.travelOsakaRamen,
-    relativePath: 'notes/travel/Osaka Ramen.md',
+    relativePath: 'travel/Osaka Ramen.md',
     title: 'Osaka Ramen',
     emoji: '🍜',
     tags: ['travel/asia', 'travel/japan', 'food'],
@@ -2121,7 +2121,7 @@ Linked: [[Tokyo Trip]] (the parent), journal [[2026-04-15]].
   },
   {
     id: NOTE_IDS.travelTokyoCafes,
-    relativePath: 'notes/travel/Tokyo Cafes.md',
+    relativePath: 'travel/Tokyo Cafes.md',
     title: 'Tokyo Cafes',
     emoji: '☕',
     tags: ['travel/asia', 'travel/japan', 'coffee'],
@@ -2148,7 +2148,7 @@ Pair with [[Kitchen Confidential]] for the *travel-as-eating* mindset.
   },
   {
     id: NOTE_IDS.travelAirportLounges,
-    relativePath: 'notes/travel/Airport Lounges.md',
+    relativePath: 'travel/Airport Lounges.md',
     title: 'Airport Lounges',
     emoji: '🛫',
     tags: ['travel', 'logistics'],

--- a/apps/desktop/scripts/seed-vault/file-writer.ts
+++ b/apps/desktop/scripts/seed-vault/file-writer.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'path'
 import matter from 'gray-matter'
 
 export interface NoteFile {
-  /** Relative path inside the vault (e.g. "notes/movies/Dune.md") */
+  /** Relative path inside the vault (e.g. "movies/Dune.md") */
   relativePath: string
   /** Frontmatter object — id/title/created/modified must be set by the caller. */
   frontmatter: Record<string, unknown>

--- a/apps/desktop/src/main/database/queries/notes/index.ts
+++ b/apps/desktop/src/main/database/queries/notes/index.ts
@@ -83,8 +83,6 @@ export {
 } from './snapshot-queries'
 
 export {
-  JOURNAL_PATH_PREFIX,
-  JOURNAL_DATE_PATTERN,
   isJournalEntry,
   extractDateFromPath,
   generateJournalPath,

--- a/apps/desktop/src/main/database/queries/notes/journal-queries.test.ts
+++ b/apps/desktop/src/main/database/queries/notes/journal-queries.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { isJournalEntry, extractDateFromPath, generateJournalPath } from './journal-queries'
+import { setJournalConfig } from '@main/vault/journal-config'
+
+// These exercise the config-aware journal detection used by the indexer/watcher.
+// The journal-config holder is kept fresh by the vault's getConfig(); here we set
+// it directly to simulate different vault configurations.
+
+afterEach(() => {
+  setJournalConfig({ journalFolder: 'journal', journalDateFormat: 'YYYY-MM-DD' })
+})
+
+describe('journal detection (config-aware)', () => {
+  it('detects a daily note in the configured folder with the default format', () => {
+    setJournalConfig({ journalFolder: 'Daily', journalDateFormat: 'YYYY-MM-DD' })
+
+    expect(isJournalEntry('Daily/2026-06-15.md')).toBe(true)
+    expect(extractDateFromPath('Daily/2026-06-15.md')).toBe('2026-06-15')
+    expect(generateJournalPath('2026-06-15')).toBe('Daily/2026-06-15.md')
+  })
+
+  it('treats non-date and wrong-folder files as regular notes', () => {
+    setJournalConfig({ journalFolder: 'Daily', journalDateFormat: 'YYYY-MM-DD' })
+
+    expect(isJournalEntry('Daily/ideas.md')).toBe(false) // not a date filename
+    expect(isJournalEntry('Projects/2026-06-15.md')).toBe(false) // wrong folder
+    expect(isJournalEntry('Welcome.md')).toBe(false) // root note
+    expect(isJournalEntry('Daily/sub/2026-06-15.md')).toBe(false) // not a direct child
+    expect(extractDateFromPath('Daily/ideas.md')).toBeNull()
+  })
+
+  it('respects a custom date format for detection and naming', () => {
+    setJournalConfig({ journalFolder: 'Daily', journalDateFormat: 'DD-MM-YYYY' })
+
+    expect(isJournalEntry('Daily/15-06-2026.md')).toBe(true)
+    expect(extractDateFromPath('Daily/15-06-2026.md')).toBe('2026-06-15')
+    expect(generateJournalPath('2026-06-15')).toBe('Daily/15-06-2026.md')
+    // A file in the default ISO shape no longer matches the custom format
+    expect(isJournalEntry('Daily/2026-06-15.md')).toBe(false)
+  })
+
+  it('disables journal detection when the journal folder is empty', () => {
+    setJournalConfig({ journalFolder: '', journalDateFormat: 'YYYY-MM-DD' })
+
+    expect(isJournalEntry('2026-06-15.md')).toBe(false)
+    expect(isJournalEntry('journal/2026-06-15.md')).toBe(false)
+  })
+
+  it('uses the default journal folder + format out of the box', () => {
+    expect(isJournalEntry('journal/2026-06-15.md')).toBe(true)
+    expect(extractDateFromPath('journal/2026-06-15.md')).toBe('2026-06-15')
+    expect(generateJournalPath('2026-06-15')).toBe('journal/2026-06-15.md')
+  })
+})

--- a/apps/desktop/src/main/database/queries/notes/journal-queries.test.ts
+++ b/apps/desktop/src/main/database/queries/notes/journal-queries.test.ts
@@ -51,4 +51,11 @@ describe('journal detection (config-aware)', () => {
     expect(extractDateFromPath('journal/2026-06-15.md')).toBe('2026-06-15')
     expect(generateJournalPath('2026-06-15')).toBe('journal/2026-06-15.md')
   })
+
+  it('treats a regex-matching but out-of-range date as a regular note', () => {
+    // Detection range-validates, so isJournalEntry agrees with extractDateFromPath
+    // and never yields a journal with an empty date.
+    expect(isJournalEntry('journal/2026-13-01.md')).toBe(false)
+    expect(extractDateFromPath('journal/2026-13-01.md')).toBeNull()
+  })
 })

--- a/apps/desktop/src/main/database/queries/notes/journal-queries.ts
+++ b/apps/desktop/src/main/database/queries/notes/journal-queries.ts
@@ -1,26 +1,50 @@
 import { eq, desc, and, like, sql, count } from 'drizzle-orm'
 import { noteCache, type NoteCache } from '@memry/db-schema/schema/notes-cache'
+import { buildJournalRegex, parseJournalDate, formatJournalFilename } from '@memry/storage-vault'
 import type { IndexDb } from '../../types'
 import { type ActivityLevel, ACTIVITY_THRESHOLDS, calculateActivityLevel } from './query-helpers'
+import { getJournalConfig } from '@main/vault/journal-config'
 
 // ============================================================================
 // Journal Entry Utilities
+//
+// A journal entry is a direct child of the configured journal folder whose
+// filename matches the configured Obsidian-style date format. Config comes from
+// the journal-config holder, kept in sync by the vault's getConfig().
 // ============================================================================
 
-export const JOURNAL_PATH_PREFIX = 'journal/'
-export const JOURNAL_DATE_PATTERN = /^journal\/(\d{4}-\d{2}-\d{2})\.md$/
+function normalizeFolder(folder: string): string {
+  return folder.endsWith('/') ? folder.slice(0, -1) : folder
+}
+
+/** Filename stem (no extension) when `path` is a direct child of the journal folder. */
+function journalStem(path: string): string | null {
+  const folder = normalizeFolder(getJournalConfig().journalFolder)
+  if (!folder) return null
+  const prefix = `${folder}/`
+  if (!path.startsWith(prefix)) return null
+  const rest = path.slice(prefix.length)
+  if (rest.includes('/') || !rest.endsWith('.md')) return null
+  return rest.slice(0, -3)
+}
 
 export function isJournalEntry(path: string): boolean {
-  return JOURNAL_DATE_PATTERN.test(path)
+  const stem = journalStem(path)
+  if (stem === null) return false
+  return buildJournalRegex(getJournalConfig().journalDateFormat).test(stem)
 }
 
 export function extractDateFromPath(path: string): string | null {
-  const match = path.match(JOURNAL_DATE_PATTERN)
-  return match ? match[1] : null
+  const stem = journalStem(path)
+  if (stem === null) return null
+  return parseJournalDate(stem, getJournalConfig().journalDateFormat)
 }
 
 export function generateJournalPath(date: string): string {
-  return `journal/${date}.md`
+  const { journalFolder, journalDateFormat } = getJournalConfig()
+  const folder = normalizeFolder(journalFolder)
+  const filename = formatJournalFilename(date, journalDateFormat)
+  return folder ? `${folder}/${filename}.md` : `${filename}.md`
 }
 
 export function generateJournalId(date: string): string {

--- a/apps/desktop/src/main/database/queries/notes/journal-queries.ts
+++ b/apps/desktop/src/main/database/queries/notes/journal-queries.ts
@@ -1,6 +1,6 @@
 import { eq, desc, and, like, sql, count } from 'drizzle-orm'
 import { noteCache, type NoteCache } from '@memry/db-schema/schema/notes-cache'
-import { buildJournalRegex, parseJournalDate, formatJournalFilename } from '@memry/storage-vault'
+import { parseJournalDate, formatJournalFilename } from '@memry/storage-vault'
 import type { IndexDb } from '../../types'
 import { type ActivityLevel, ACTIVITY_THRESHOLDS, calculateActivityLevel } from './query-helpers'
 import { getJournalConfig } from '@main/vault/journal-config'
@@ -29,9 +29,9 @@ function journalStem(path: string): string | null {
 }
 
 export function isJournalEntry(path: string): boolean {
-  const stem = journalStem(path)
-  if (stem === null) return false
-  return buildJournalRegex(getJournalConfig().journalDateFormat).test(stem)
+  // Range-validate via parseJournalDate so detection and date extraction agree
+  // (a regex-only match like journal/2026-13-01.md is NOT a journal entry).
+  return extractDateFromPath(path) !== null
 }
 
 export function extractDateFromPath(path: string): string | null {

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -369,7 +369,7 @@ export interface MainIpcInvokeHandlers {
   "vault:reveal": (...args: []) => Awaited<Promise<void>>
   "vault:select": (...args: [{ path?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").SelectVaultResponse>>
   "vault:switch": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").SelectVaultResponse>>
-  "vault:update-config": (...args: [{ excludePatterns?: string[] | undefined; defaultNoteFolder?: string | undefined; journalFolder?: string | undefined; attachmentsFolder?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultConfig>>
+  "vault:update-config": (...args: [{ excludePatterns?: string[] | undefined; defaultNoteFolder?: string | undefined; journalFolder?: string | undefined; journalDateFormat?: string | undefined; attachmentsFolder?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").VaultConfig>>
 }
 
 export type MainIpcInvokeChannel = keyof MainIpcInvokeHandlers

--- a/apps/desktop/src/main/vault/index.test.ts
+++ b/apps/desktop/src/main/vault/index.test.ts
@@ -383,8 +383,9 @@ describe('vault lifecycle', () => {
     expect(getAllVaults().vaults).toEqual([])
     expect(getConfig()).toEqual({
       excludePatterns: [],
-      defaultNoteFolder: 'notes',
+      defaultNoteFolder: '',
       journalFolder: 'journal',
+      journalDateFormat: 'YYYY-MM-DD',
       attachmentsFolder: 'attachments'
     })
     expect(mocks.closeAllDatabases).toHaveBeenCalled()

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -261,7 +261,10 @@ async function openVault(vaultPath: string): Promise<void> {
     createInboxStatsProjector()
   ])
 
-  updateStatus({ isIndexing: true, indexProgress: 0 })
+  // Set the vault path before indexing so getConfig() (and the journal-config
+  // holder) resolve the real config.json instead of the closed-vault fallback —
+  // otherwise the initial index uses default journal config + empty excludes.
+  updateStatus({ isIndexing: true, indexProgress: 0, path: vaultPath })
 
   try {
     if (indexHealth !== 'healthy') {
@@ -451,7 +454,14 @@ export async function updateConfig(updates: Partial<VaultConfig>): Promise<Vault
 
   if (structuralChanged) {
     logger.info('Structural vault config changed, rebuilding index...')
-    await reindex()
+    updateStatus({ isIndexing: true, indexProgress: 0 })
+    try {
+      // Full rebuild, not incremental reindex: indexFile skips paths already in
+      // cache, so re-classifying existing notes/journals needs a clean rebuild.
+      await rebuildIndex(currentStatus.path)
+    } finally {
+      updateStatus({ isIndexing: false, indexProgress: 100 })
+    }
   }
 
   return newConfig

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -28,6 +28,7 @@ import {
   getDataDbPath,
   getIndexDbPath
 } from './init'
+import { setJournalConfig } from './journal-config'
 import {
   initDatabase,
   initIndexDatabase,
@@ -388,21 +389,33 @@ export function getStatus(): VaultStatus {
  */
 export function getConfig(): VaultConfig {
   if (!currentStatus.path) {
-    return {
+    const fallback: VaultConfig = {
       excludePatterns: [],
-      defaultNoteFolder: 'notes',
+      defaultNoteFolder: '',
       journalFolder: 'journal',
+      journalDateFormat: 'YYYY-MM-DD',
       attachmentsFolder: 'attachments'
     }
+    setJournalConfig({
+      journalFolder: fallback.journalFolder,
+      journalDateFormat: fallback.journalDateFormat
+    })
+    return fallback
   }
 
   const config = readVaultConfig(currentStatus.path)
-  return {
+  const resolved: VaultConfig = {
     excludePatterns: config.excludePatterns,
     defaultNoteFolder: config.defaultNoteFolder,
     journalFolder: config.journalFolder,
+    journalDateFormat: config.journalDateFormat,
     attachmentsFolder: config.attachmentsFolder
   }
+  setJournalConfig({
+    journalFolder: resolved.journalFolder,
+    journalDateFormat: resolved.journalDateFormat
+  })
+  return resolved
 }
 
 /**
@@ -426,6 +439,19 @@ export async function updateConfig(updates: Partial<VaultConfig>): Promise<Vault
     logger.info('Exclude patterns changed, restarting watcher...')
     await stopWatcher()
     await startWatcher(currentStatus.path, newConfig.excludePatterns)
+  }
+
+  // Re-index when config that affects note/journal classification changes, so the
+  // collection/journal split and folder tree update live.
+  const structuralChanged =
+    oldConfig.journalFolder !== newConfig.journalFolder ||
+    oldConfig.journalDateFormat !== newConfig.journalDateFormat ||
+    oldConfig.defaultNoteFolder !== newConfig.defaultNoteFolder ||
+    JSON.stringify(oldConfig.excludePatterns) !== JSON.stringify(newConfig.excludePatterns)
+
+  if (structuralChanged) {
+    logger.info('Structural vault config changed, rebuilding index...')
+    await reindex()
   }
 
   return newConfig

--- a/apps/desktop/src/main/vault/indexer.ts
+++ b/apps/desktop/src/main/vault/indexer.ts
@@ -307,11 +307,11 @@ export async function indexVault(vaultPath: string): Promise<IndexResult> {
     errors: 0
   }
 
-  // Get folders to scan
-  const foldersToScan = [
-    path.join(vaultPath, config.defaultNoteFolder),
-    path.join(vaultPath, config.journalFolder)
-  ]
+  // Scan the entire vault root. findVaultFiles skips dotfolders (.memry,
+  // .obsidian, .git) and excludePatterns; also exclude the attachments folder so
+  // binaries are not indexed as notes.
+  const scanExcludes = [...excludePatterns, config.attachmentsFolder].filter(Boolean)
+  const foldersToScan = [vaultPath]
 
   // Find all supported files (respecting exclude patterns)
   const allFiles: string[] = []
@@ -319,7 +319,7 @@ export async function indexVault(vaultPath: string): Promise<IndexResult> {
     try {
       const folderStat = await stat(folder)
       if (folderStat.isDirectory()) {
-        const files = await findVaultFiles(folder, vaultPath, excludePatterns)
+        const files = await findVaultFiles(folder, vaultPath, scanExcludes)
         allFiles.push(...files)
       }
     } catch {

--- a/apps/desktop/src/main/vault/init.test.ts
+++ b/apps/desktop/src/main/vault/init.test.ts
@@ -189,8 +189,9 @@ describe('initVault', () => {
     // Check config.json
     expect(fs.existsSync(path.join(tempDir.path, '.memry', 'config.json'))).toBe(true)
 
-    // Check default folders
-    expect(fs.existsSync(path.join(tempDir.path, 'notes'))).toBe(true)
+    // Check default folders — notes/ is deprecated in the flat model (new notes
+    // live at the vault root)
+    expect(fs.existsSync(path.join(tempDir.path, 'notes'))).toBe(false)
     expect(fs.existsSync(path.join(tempDir.path, 'journal'))).toBe(true)
     expect(fs.existsSync(path.join(tempDir.path, 'attachments'))).toBe(true)
     expect(fs.existsSync(path.join(tempDir.path, 'attachments', 'images'))).toBe(true)
@@ -205,8 +206,9 @@ describe('initVault', () => {
 
     expect(config.excludePatterns).toContain('.git')
     expect(config.excludePatterns).toContain('node_modules')
-    expect(config.defaultNoteFolder).toBe('notes')
+    expect(config.defaultNoteFolder).toBe('')
     expect(config.journalFolder).toBe('journal')
+    expect(config.journalDateFormat).toBe('YYYY-MM-DD')
     expect(config.attachmentsFolder).toBe('attachments')
   })
 
@@ -247,7 +249,7 @@ describe('readVaultConfig', () => {
     const config = readVaultConfig(tempDir.path)
 
     expect(config.excludePatterns).toContain('.git')
-    expect(config.defaultNoteFolder).toBe('notes')
+    expect(config.defaultNoteFolder).toBe('')
     expect(config.journalFolder).toBe('journal')
     expect(config.attachmentsFolder).toBe('attachments')
   })
@@ -277,7 +279,7 @@ describe('readVaultConfig', () => {
     const config = readVaultConfig(tempDir.path)
 
     // Should return defaults
-    expect(config.defaultNoteFolder).toBe('notes')
+    expect(config.defaultNoteFolder).toBe('')
   })
 })
 
@@ -322,7 +324,7 @@ describe('writeVaultConfig', () => {
     const result = writeVaultConfig(tempDir.path, { attachmentsFolder: 'files' })
 
     expect(result.attachmentsFolder).toBe('files')
-    expect(result.defaultNoteFolder).toBe('notes') // Default preserved
+    expect(result.defaultNoteFolder).toBe('') // Default preserved
   })
 })
 

--- a/apps/desktop/src/main/vault/init.ts
+++ b/apps/desktop/src/main/vault/init.ts
@@ -4,7 +4,7 @@ import path from 'path'
 /**
  * Default vault folder structure
  */
-const VAULT_FOLDERS = ['notes', 'journal', 'attachments', 'attachments/images', 'attachments/files']
+const VAULT_FOLDERS = ['journal', 'attachments', 'attachments/images', 'attachments/files']
 
 /**
  * Hidden Memry folder name
@@ -15,9 +15,10 @@ const MEMRY_DIR = '.memry'
  * Default vault configuration
  */
 const DEFAULT_CONFIG = {
-  excludePatterns: ['.git', 'node_modules', '.trash'],
-  defaultNoteFolder: 'notes',
+  excludePatterns: ['.git', 'node_modules', '.trash', '.obsidian', '.memry'],
+  defaultNoteFolder: '',
   journalFolder: 'journal',
+  journalDateFormat: 'YYYY-MM-DD',
   attachmentsFolder: 'attachments'
 }
 

--- a/apps/desktop/src/main/vault/journal-config.ts
+++ b/apps/desktop/src/main/vault/journal-config.ts
@@ -1,0 +1,27 @@
+/**
+ * Process-wide holder for the active vault's journal configuration.
+ *
+ * Journal detection helpers (`isJournalEntry`, `extractDateFromPath`,
+ * `generateJournalPath`) are pure path utilities called from many places that do
+ * not have the vault config in scope. Rather than thread the config through every
+ * call site, the single `getConfig()` accessor keeps this holder in sync, mirroring
+ * the existing module-level vault state pattern.
+ */
+
+export interface JournalConfig {
+  journalFolder: string
+  journalDateFormat: string
+}
+
+let current: JournalConfig = {
+  journalFolder: 'journal',
+  journalDateFormat: 'YYYY-MM-DD'
+}
+
+export function setJournalConfig(config: JournalConfig): void {
+  current = config
+}
+
+export function getJournalConfig(): JournalConfig {
+  return current
+}

--- a/apps/desktop/src/main/vault/journal.ts
+++ b/apps/desktop/src/main/vault/journal.ts
@@ -86,7 +86,8 @@ function getContentStore() {
   return createNoteContentStore({
     rootPath: vaultPath,
     notesFolder: config.defaultNoteFolder,
-    journalFolder: config.journalFolder
+    journalFolder: config.journalFolder,
+    journalDateFormat: config.journalDateFormat
   })
 }
 

--- a/apps/desktop/src/main/vault/notes-crud.ts
+++ b/apps/desktop/src/main/vault/notes-crud.ts
@@ -46,7 +46,7 @@ import type { FolderInfo } from '@memry/contracts/templates-api'
 import { readFolderConfig } from './folders'
 import { createLogger } from '../lib/logger'
 import { getFileType, getExtension } from '@memry/shared/file-types'
-import { getStatus } from './index'
+import { getStatus, getConfig } from './index'
 import { emitNoteEvent, getNotesDir, toAbsolutePath, toRelativePath } from './notes-io'
 import { maybeCreateSignificantSnapshot } from './notes-versions'
 import { noteToListItem } from './notes-queries'
@@ -625,7 +625,17 @@ export async function deleteNote(id: string): Promise<void> {
 
 export async function getFolders(): Promise<FolderInfo[]> {
   const notesDir = getNotesDir()
-  const paths = await listDirectories(notesDir, notesDir)
+  const config = getConfig()
+  // Hide structural/excluded top-level folders (journal, attachments, node_modules,
+  // etc.) from the collection tree; journals live in the Journal view.
+  const hiddenRoots = new Set(
+    [config.journalFolder, config.attachmentsFolder, ...config.excludePatterns]
+      .filter(Boolean)
+      .map((p) => p.replace(/\/+$/, '').split('/')[0])
+  )
+  const paths = (await listDirectories(notesDir, notesDir)).filter(
+    (folderPath) => !hiddenRoots.has(folderPath.split('/')[0])
+  )
   const db = getDatabase()
 
   return Promise.all(

--- a/apps/desktop/src/main/vault/watcher.test.ts
+++ b/apps/desktop/src/main/vault/watcher.test.ts
@@ -328,10 +328,7 @@ describe('vault watcher', () => {
     trigger('ready')
     await startPromise
 
-    expect(mockWatch).toHaveBeenCalledWith(
-      [path.join(vault.path, 'notes'), path.join(vault.path, 'journal')],
-      expect.any(Object)
-    )
+    expect(mockWatch).toHaveBeenCalledWith([vault.path], expect.any(Object))
 
     expect(getWatcher().isWatching()).toBe(true)
 

--- a/apps/desktop/src/main/vault/watcher.ts
+++ b/apps/desktop/src/main/vault/watcher.ts
@@ -20,7 +20,9 @@ import { syncNoteToCache, syncFileToCache, deleteNoteFromCache } from './note-sy
 import {
   getNoteCacheByPath,
   getNoteCacheById,
-  ensureTagDefinitions
+  ensureTagDefinitions,
+  isJournalEntry,
+  extractDateFromPath
 } from '@main/database/queries/notes'
 import { getDatabase, getIndexDatabase } from '../database'
 import { NotesChannels, JournalChannels } from '@memry/contracts/ipc-channels'
@@ -116,30 +118,18 @@ function emitEvent(channel: string, payload: unknown): void {
 }
 
 /**
- * Check if a path is a journal entry (in the journal folder with YYYY-MM-DD.md pattern).
+ * Check if a path is a journal entry, per the active vault's journal folder +
+ * date format (delegates to the shared config-aware detector).
  */
-function isJournalPath(relativePath: string, journalFolder: string): boolean {
-  // Get the directory part of the path
-  const lastSlash = relativePath.lastIndexOf('/')
-  const dir = lastSlash >= 0 ? relativePath.substring(0, lastSlash) : ''
-  const filename = lastSlash >= 0 ? relativePath.substring(lastSlash + 1) : relativePath
-
-  // Check if file is directly in the journal folder
-  if (dir !== journalFolder) {
-    return false
-  }
-
-  // Check for YYYY-MM-DD.md pattern
-  const datePattern = /^\d{4}-\d{2}-\d{2}\.md$/
-  return datePattern.test(filename)
+function isJournalPath(relativePath: string): boolean {
+  return isJournalEntry(relativePath)
 }
 
 /**
- * Extract date from journal path (YYYY-MM-DD).
+ * Extract the canonical ISO date (YYYY-MM-DD) from a journal path.
  */
 function extractJournalDate(relativePath: string): string {
-  const filename = relativePath.substring(relativePath.lastIndexOf('/') + 1)
-  return filename.replace('.md', '')
+  return extractDateFromPath(relativePath) ?? ''
 }
 
 // Full fragment replace on external edits: lossy but acceptable since
@@ -192,18 +182,17 @@ export class VaultWatcher {
     this.onError = onError
     this.isReady = false
 
-    // Get vault config for folder names
+    // Watch the entire vault root. The `ignored` filter below drops dotfolders
+    // (.memry, .obsidian, .git) and excluded dirs; the attachments folder is added
+    // to the exclude set so binaries are not watched/indexed as notes.
     const config = getConfig()
-    const watchPaths = [
-      path.join(vaultPath, config.defaultNoteFolder),
-      path.join(vaultPath, config.journalFolder)
-    ]
+    const watchPaths = [vaultPath]
 
     // Create debounced handlers
     this.debouncedChange = createPathDebouncer((filePath) => this.handleFileChange(filePath), 100)
 
     // Capture exclude patterns for use in ignored function
-    const userExcludePatterns = this.excludePatterns
+    const userExcludePatterns = [...this.excludePatterns, config.attachmentsFolder].filter(Boolean)
 
     // Create watcher with chokidar
     this.watcher = chokidar.watch(watchPaths, {
@@ -426,8 +415,7 @@ export class VaultWatcher {
     }
 
     // Enqueue sync push so other devices learn about the new file
-    const config = getConfig()
-    if (isJournalPath(relativePath, config.journalFolder)) {
+    if (isJournalPath(relativePath)) {
       const journalDate = extractJournalDate(relativePath)
       enqueueJournalCreate(parsed.frontmatter.id, journalDate)
       initializeJournalCrdt(parsed.frontmatter.id, journalDate, tags)
@@ -447,7 +435,7 @@ export class VaultWatcher {
     })
 
     // Also emit journal event if this is a journal entry
-    if (isJournalPath(relativePath, config.journalFolder)) {
+    if (isJournalPath(relativePath)) {
       const journalDate = extractJournalDate(relativePath)
       emitEvent(JournalChannels.events.ENTRY_CREATED, {
         date: journalDate,
@@ -648,8 +636,7 @@ export class VaultWatcher {
       logger.warn('Failed to feed external edit to CRDT', { noteId: cached.id, error: err })
     })
 
-    const config = getConfig()
-    if (isJournalPath(relativePath, config.journalFolder)) {
+    if (isJournalPath(relativePath)) {
       const journalDate = extractJournalDate(relativePath)
       emitEvent(JournalChannels.events.ENTRY_UPDATED, {
         date: journalDate,
@@ -729,9 +716,7 @@ export class VaultWatcher {
         return
       }
 
-      // Capture config for use in callback
-      const config = getConfig()
-      const isJournal = isJournalPath(relativePath, config.journalFolder)
+      const isJournal = isJournalPath(relativePath)
       const journalDate = isJournal ? extractJournalDate(relativePath) : null
 
       // Track as pending delete - wait for potential rename (matching 'add' event)

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -428,6 +428,7 @@ export interface VaultConfig {
   excludePatterns: string[]
   defaultNoteFolder: string
   journalFolder: string
+  journalDateFormat: string
   attachmentsFolder: string
 }
 

--- a/apps/desktop/src/renderer/src/components/notes-tree.test.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree.test.tsx
@@ -146,11 +146,11 @@ const createNote = (
 })
 
 const mockNotes: NoteListItem[] = [
-  createNote('note-1', 'notes/Meeting Notes.md'),
-  createNote('note-2', 'notes/Projects/Project Alpha.md'),
-  createNote('note-3', 'notes/Projects/Project Beta.md'),
-  createNote('note-4', 'notes/Archive/Old Note.md'),
-  createNote('note-5', 'notes/Daily Journal.md', { emoji: '📝' })
+  createNote('note-1', 'Meeting Notes.md'),
+  createNote('note-2', 'Projects/Project Alpha.md'),
+  createNote('note-3', 'Projects/Project Beta.md'),
+  createNote('note-4', 'Archive/Old Note.md'),
+  createNote('note-5', 'Daily Journal.md', { emoji: '📝' })
 ]
 
 const mockFolders: FolderInfo[] = [
@@ -186,7 +186,7 @@ const setupMocks = (
     createNote: {
       mutateAsync: vi
         .fn()
-        .mockResolvedValue({ success: true, note: { id: 'new-note', path: 'notes/Untitled.md' } })
+        .mockResolvedValue({ success: true, note: { id: 'new-note', path: 'Untitled.md' } })
     },
     deleteNote: {
       mutateAsync: vi.fn().mockResolvedValue({ success: true })
@@ -610,7 +610,7 @@ describe('T523: NotesTree - context-aware note/folder creation', () => {
 
     createNoteMock = vi.fn().mockResolvedValue({
       success: true,
-      note: { id: 'new-note', path: 'notes/Untitled.md' }
+      note: { id: 'new-note', path: 'Untitled.md' }
     })
     createFolderMock = vi.fn().mockResolvedValue(true)
     ;(useNotesList as ReturnType<typeof vi.fn>).mockReturnValue({

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts
@@ -109,10 +109,7 @@ export function useNoteTreeData(): NoteTreeData {
       if (note) {
         const parts = note.path.split('/')
         parts.pop()
-        if (parts.length > 1 && parts[0] === 'notes') {
-          return parts.slice(1).join('/')
-        }
-        return ''
+        return parts.join('/')
       }
 
       return ''

--- a/apps/desktop/src/renderer/src/pages/settings/general-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/general-section.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { AppUpdateState } from '@memry/contracts/ipc-updater'
 import { type Locale } from '@memry/contracts/locale-api'
 import { useT } from '@memry/i18n/renderer'
@@ -12,10 +12,12 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { Input } from '@/components/ui/input'
 import { useTabPreferences } from '@/hooks/use-tab-preferences'
 import { useAppUpdater } from '@/hooks/use-app-updater'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { useTelemetrySettings } from '@/hooks/use-telemetry-settings'
+import { useVault } from '@/hooks/use-vault'
 import { useTabs } from '@/contexts/tabs'
 import { toast } from 'sonner'
 import {
@@ -56,6 +58,13 @@ export function GeneralSettings() {
     quitAndInstall
   } = useAppUpdater()
   const { updateSettings: updateContextSettings } = useTabs()
+  const { config, updateConfig } = useVault()
+
+  const [defaultNoteFolder, setDefaultNoteFolder] = useState('')
+
+  useEffect(() => {
+    if (config) setDefaultNoteFolder(config.defaultNoteFolder)
+  }, [config])
 
   const isLoading = tabLoading || generalLoading || telemetryLoading
 
@@ -86,6 +95,12 @@ export function GeneralSettings() {
     },
     [t, updateGeneralSettings]
   )
+
+  const handleDefaultNoteFolderBlur = useCallback(() => {
+    if (config && defaultNoteFolder !== config.defaultNoteFolder) {
+      void updateConfig({ defaultNoteFolder })
+    }
+  }, [config, defaultNoteFolder, updateConfig])
 
   const handleTelemetryChange = useCallback(
     async (enabled: boolean) => {
@@ -313,6 +328,19 @@ export function GeneralSettings() {
             checked={generalSettings.createInSelectedFolder}
             onCheckedChange={(...args) => void handleCreateInSelectedFolderChange(...args)}
             className={ACCENT_SWITCH}
+          />
+        </SettingRow>
+
+        <SettingRow
+          label={t('general.fileCreation.defaultNoteFolder.label')}
+          description={t('general.fileCreation.defaultNoteFolder.description')}
+        >
+          <Input
+            value={defaultNoteFolder}
+            onChange={(e) => setDefaultNoteFolder(e.target.value)}
+            onBlur={handleDefaultNoteFolderBlur}
+            placeholder={t('general.fileCreation.defaultNoteFolder.placeholder')}
+            className="h-7 w-40 text-xs/4"
           />
         </SettingRow>
       </SettingsGroup>

--- a/apps/desktop/src/renderer/src/pages/settings/journal-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/journal-section.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import {
   Select,
   SelectContent,
@@ -7,9 +7,12 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { Input } from '@/components/ui/input'
 import { Lock } from '@/lib/icons'
 import { useTemplates } from '@/hooks/use-templates'
 import { useJournalSettings } from '@/hooks/use-journal-settings'
+import { useVault } from '@/hooks/use-vault'
+import { formatJournalFilename } from '@memry/storage-vault/journal-format'
 import { toast } from 'sonner'
 import { useT } from '@memry/i18n/renderer'
 import {
@@ -30,6 +33,34 @@ export function JournalSettings() {
     setDefaultTemplate,
     isLoading: isLoadingSettings
   } = useJournalSettings()
+  const { config, updateConfig } = useVault()
+
+  const [journalFolder, setJournalFolder] = useState('')
+  const [journalDateFormat, setJournalDateFormat] = useState('')
+
+  // Sync editable copies whenever the persisted vault config loads or changes.
+  useEffect(() => {
+    if (!config) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setJournalFolder(config.journalFolder)
+    setJournalDateFormat(config.journalDateFormat)
+  }, [config])
+
+  const handleJournalFolderBlur = useCallback(() => {
+    if (config && journalFolder !== config.journalFolder) {
+      void updateConfig({ journalFolder })
+    }
+  }, [config, journalFolder, updateConfig])
+
+  const handleJournalDateFormatBlur = useCallback(() => {
+    if (config && journalDateFormat !== config.journalDateFormat) {
+      void updateConfig({ journalDateFormat })
+    }
+  }, [config, journalDateFormat, updateConfig])
+
+  const todayIso = new Date().toISOString().slice(0, 10)
+  const previewFilename = `${formatJournalFilename(todayIso, journalDateFormat)}.md`
+  const previewPath = journalFolder ? `${journalFolder}/${previewFilename}` : previewFilename
 
   const handleTemplateChange = useCallback(
     async (value: string) => {
@@ -124,6 +155,38 @@ export function JournalSettings() {
               ))}
             </SelectContent>
           </Select>
+        </SettingRow>
+      </SettingsGroup>
+
+      <SettingsGroup label={t('journal.groups.location')}>
+        <SettingRow label={t('journal.folder.label')} description={t('journal.folder.description')}>
+          <Input
+            value={journalFolder}
+            onChange={(e) => setJournalFolder(e.target.value)}
+            onBlur={handleJournalFolderBlur}
+            placeholder={t('journal.folder.placeholder')}
+            className="h-7 w-40 text-xs/4"
+          />
+        </SettingRow>
+
+        <SettingRow
+          label={t('journal.dateFormat.label')}
+          description={t('journal.dateFormat.description')}
+        >
+          <Input
+            value={journalDateFormat}
+            onChange={(e) => setJournalDateFormat(e.target.value)}
+            onBlur={handleJournalDateFormatBlur}
+            placeholder={t('journal.dateFormat.placeholder')}
+            className="h-7 w-40 text-xs/4"
+          />
+        </SettingRow>
+
+        <SettingRow
+          label={t('journal.preview.label')}
+          description={t('journal.preview.description')}
+        >
+          <span className="font-mono text-xs/4 text-muted-foreground">{previewPath}</span>
         </SettingRow>
       </SettingsGroup>
 

--- a/docs/superpowers/specs/2026-06-15-flat-vault-root-obsidian-compat-design.md
+++ b/docs/superpowers/specs/2026-06-15-flat-vault-root-obsidian-compat-design.md
@@ -1,0 +1,238 @@
+# Flat Vault Root + Obsidian Compatibility — Design
+
+Date: 2026-06-15
+Branch: `feat/flat-vault-root`
+Status: Approved (brainstorm) → implementation
+
+## Problem
+
+Memry assumes a fixed three-folder vault layout (`notes/`, `journal/`, `attachments/`).
+When a user points Memry at an existing Obsidian vault:
+
+- The collection sidebar shows **zero items**, because the indexer only scans
+  `notes/` + `journal/` (`apps/desktop/src/main/vault/indexer.ts:310`) and the
+  notes query hard-filters `path LIKE 'notes/%'`
+  (`apps/desktop/src/main/database/queries/notes/note-crud.ts:114`). Markdown at
+  the vault root or in arbitrary subfolders is never indexed.
+- Existing journals are **invisible**, because journal detection is a hardcoded
+  folder + filename regex `^journal\/(\d{4}-\d{2}-\d{2})\.md$`
+  (`apps/desktop/src/main/database/queries/notes/journal-queries.ts:11`). Obsidian
+  daily notes live in a user-chosen folder with a user-chosen date format.
+
+Pre-production, no users → no migration or backward-compatibility constraints.
+We make the vault structure Obsidian-like: every `.md` under the vault root is a
+note; the journal folder + date format are user-configurable.
+
+## Goals
+
+1. Memry reads **every `.md` under the vault root** (root + all subfolders), not a
+   fixed `notes/` folder. The `notes/` folder is deprecated.
+2. The journal folder path **and** filename date format are user-configurable in
+   Settings (Obsidian Daily Notes parity). Memry respects that format both to
+   **detect** existing journals and to **name** new ones.
+3. Journal entries are **hidden from the collection** (they appear in the Journal
+   view only) once a journal folder is configured.
+4. The collection sidebar shows an **Obsidian-style collapsible folder tree**
+   rooted at the vault root, with the journal/attachments folders hidden.
+5. New notes are written to a **configurable default location** (default: vault
+   root).
+6. Brand-new vaults are created **flat** (no `notes/` folder).
+
+## Non-Goals
+
+- No migration / back-compat (no users).
+- No auto-detection of the journal folder on import — the user sets it manually in
+  Settings.
+- No change to attachments handling beyond keeping the existing
+  `attachmentsFolder` skip behavior.
+- Nested date-folder formats (e.g. `YYYY/MM/DD` that creates subfolders) are out
+  of scope; v1 supports a journal folder + a flat date filename format.
+- Indexing arbitrary non-`.md` files at the root as standalone collection items is
+  out of scope; only `.md` files are notes.
+
+## Architecture
+
+### B1. Config schema
+
+`VaultConfig` (`packages/contracts/src/vault-api.ts`) — **remove** `defaultNoteFolder`,
+**add** the new fields:
+
+```ts
+interface VaultConfig {
+  excludePatterns: string[] // default + '.obsidian', '.memry', '.trash'
+  journalFolder: string // default 'journal'; '' disables journals
+  journalDateFormat: string // NEW — default 'YYYY-MM-DD' (Obsidian tokens)
+  newNoteLocation: 'root' | 'current-folder' | 'folder' // NEW — default 'root'
+  newNoteFolder?: string // NEW — used only when newNoteLocation === 'folder'
+  attachmentsFolder: string // unchanged, default 'attachments'
+}
+```
+
+- `UpdateVaultConfigSchema` (zod) extended to validate the new fields.
+- `DEFAULT_CONFIG` (`apps/desktop/src/main/vault/init.ts`) and the hardcoded
+  defaults in `apps/desktop/src/main/vault/index.ts:391` updated to match.
+- Preload types + `window.api.vault` already round-trip `getConfig`/`updateConfig`
+  (`vault:get-config` / `vault:update-config`). Run `pnpm ipc:generate` then
+  `pnpm ipc:check` after editing the contract.
+
+### B2. Journal format util
+
+New module `apps/desktop/src/main/vault/journal-format.ts`:
+
+```ts
+buildJournalRegex(format: string): RegExp        // detection (anchored basename)
+parseJournalDate(filename: string, format: string): string | null  // → ISO 'YYYY-MM-DD'
+formatJournalFilename(dateIso: string, format: string): string     // naming new entries
+```
+
+- Supported tokens: `YYYY`, `YY`, `MM`, `M`, `DD`, `D`, plus literal separators
+  `-`, `_`, `.`, and space. Unknown tokens are treated as literals.
+- `parseJournalDate` converts the user's format to the canonical ISO date stored in
+  the `date` / `journal_date` columns (e.g. `15-06-2026.md` + `DD-MM-YYYY` →
+  `2026-06-15`). Returns `null` on no match.
+- Implementation prefers the date library already in the repo if it supports
+  custom parse tokens; otherwise a self-contained token→regex map. Decision made at
+  implementation time; either way the public surface above is identical and unit
+  tested.
+
+`journal-queries.ts` drops the hardcoded `JOURNAL_PATH_PREFIX` /
+`JOURNAL_DATE_PATTERN`. New config-aware predicate:
+
+```ts
+isJournalEntry(path: string, config: VaultConfig): boolean
+// true iff journalFolder !== '' AND path is inside journalFolder
+//      AND basename matches buildJournalRegex(journalDateFormat)
+```
+
+`extractDateFromPath(path, config)` delegates to `parseJournalDate` on the
+basename when `isJournalEntry` is true.
+
+### B3. Indexer
+
+`indexer.ts` (`indexVault`, ~line 299) stops building `foldersToScan` from
+`defaultNoteFolder` + `journalFolder`. Instead it walks the **entire vault root**
+recursively, skipping:
+
+- `excludePatterns` (incl. `.git`, `node_modules`, `.trash`, `.obsidian`, `.memry`),
+- any dotfolder,
+- the configured `attachmentsFolder`.
+
+Every `.md` is indexed as a note. Files matched by `isJournalEntry(path, config)`
+get their `date` (`note_cache.date`) / `journal_date` (`note_metadata`) column
+populated via `extractDateFromPath`. Non-journal `.md` get `date = null`.
+
+Re-index triggers: changing `journalFolder`, `journalDateFormat`, or
+`excludePatterns` via `updateConfig` (`index.ts:412`) must run a full re-index so
+the collection/journal split updates live.
+
+### B4. Queries
+
+`note-crud.ts:114` (`listNotesFromCache`) drops the `like(noteCache.path,
+'${folder}/%')` constraint when no explicit `folder` is requested. Collection =
+all notes with `date IS NULL` (journals already excluded by the `date` column —
+existing mechanism, unchanged). The optional `folder` filter remains for subtree
+listing.
+
+Journal path construction (`apps/desktop/src/main/vault/journal.ts`,
+`getJournalPath` / `getJournalRelativePath`, and the content store) uses
+`journalFolder` + `formatJournalFilename(date, journalDateFormat)` instead of the
+hardcoded `journal/YYYY-MM-DD.md`. Journal date-range queries (heatmap, month,
+year) read the indexed `date` column and are unaffected.
+
+### B5. Sidebar folder tree
+
+`buildTreeFromNotes` / `useNoteFoldersQuery`
+(`apps/desktop/src/renderer/src/hooks/use-note-tree-data.ts`,
+`components/notes-tree.tsx`) are re-rooted at the **vault root** instead of
+`notes/`. The configured `journalFolder` and `attachmentsFolder` are excluded from
+the tree so they do not appear as folders. Journals continue to render in the
+Journal view.
+
+Target shape:
+
+```
+Collection
+  ▾ Projects
+      • spec
+      ▾ 2026
+          • research
+  • Welcome
+  • meeting
+        (Daily/ hidden → Journal view)
+```
+
+### B6. Settings UI
+
+- **Settings → Journal** (`pages/settings/journal-section.tsx`, extend existing):
+  add **Journal folder** (text input) and **Date format** (text input) with a live
+  preview line (`{folder}/{formattedToday}.md`). Reads/writes via
+  `window.api.vault.getConfig` / `updateConfig`. Empty folder disables journals.
+- **Settings → General** (`pages/settings/general-section.tsx`): add **Default
+  location for new notes** — select of `root` / `current-folder` / `folder`, with a
+  folder text input shown when `folder` is chosen.
+- New `en/common.json` keys (only `en` is gated by `i18n:check`).
+
+### B7. New-note location
+
+`apps/desktop/src/main/vault/notes-crud.ts` (`generateNotePath`, ~line 216)
+resolves the base directory from `newNoteLocation`:
+
+- `root` → vault root,
+- `current-folder` → folder of the active/contextual note (passed through the
+  create input; falls back to root when absent),
+- `folder` → `newNoteFolder` (falls back to root when empty).
+
+Existing explicit `folder` argument on create still wins when provided (e.g.
+"new note in this folder" from the tree context menu).
+
+### B8. Vault init
+
+`init.ts:7` `VAULT_FOLDERS` no longer creates `notes/`. A fresh vault is created
+flat: the configured `journalFolder` (default `journal/`) + `attachmentsFolder`
+(+ its `images`/`files` subfolders) only.
+
+## Edge Cases
+
+- `journalFolder === ''` → journals disabled; every `.md` is a note.
+- A date-format that matches nothing → those files remain normal notes (no crash).
+- A date-named file **outside** the journal folder (e.g. `Projects/2026-06-15.md`)
+  → normal note.
+- `.obsidian` / `.memry` / `.git` / `node_modules` / `.trash` never indexed.
+- Changing `journalDateFormat` re-indexes; files that no longer match move from the
+  Journal view back into the collection (and vice-versa).
+
+## Testing
+
+Unit (vitest, main project):
+
+- `journal-format`: round-trip `parseJournalDate ↔ formatJournalFilename` for
+  `YYYY-MM-DD`, `DD-MM-YYYY`, `YYYYMMDD`, `YYYY.MM.DD`; non-match returns null.
+- `isJournalEntry`: in-folder match true; wrong folder false; non-date basename
+  false; empty journalFolder false.
+- Indexer: temp vault with root `.md`, nested `.md`, journal-folder date files,
+  `.obsidian/` → asserts note/journal split and that excluded dirs are skipped.
+- `listNotesFromCache`: rows with no `notes/` prefix are listed; journals
+  (`date != null`) excluded.
+- `generateNotePath`: each `newNoteLocation` mode resolves the expected directory.
+
+E2E (Playwright, `apps/desktop`) — added if the unit + integration coverage does
+not exercise the full open-vault → see-notes flow:
+
+- Open a fixture flat vault (root note + nested note + a `Daily/` journal folder),
+  assert the collection tree shows the notes/folders and hides `Daily/`, and the
+  Journal view shows the daily entry.
+- Set a custom journal folder/format in Settings, assert re-index moves entries
+  correctly.
+
+## Implementation Phases
+
+1. `journal-format` util + unit tests.
+2. Config schema: `VaultConfig` + `UpdateVaultConfigSchema` + defaults + preload
+   types; `pnpm ipc:generate && pnpm ipc:check`.
+3. Indexer walk-whole-root + config-aware journal detection (`journal-queries.ts`).
+4. Query (`note-crud.ts`) + journal path construction (`journal.ts`, content store).
+5. Sidebar tree re-root + hide journal/attachments folders.
+6. Settings UI: Journal folder/format + default new-note location.
+7. Vault init flat + re-index-on-config-change.
+8. Verify: lint, typecheck, unit/integration tests; add e2e if needed;
+   `docs:impact` / `docs:build`.

--- a/docs/superpowers/specs/2026-06-15-flat-vault-root-obsidian-compat-design.md
+++ b/docs/superpowers/specs/2026-06-15-flat-vault-root-obsidian-compat-design.md
@@ -50,6 +50,26 @@ note; the journal folder + date format are user-configurable.
 - Indexing arbitrary non-`.md` files at the root as standalone collection items is
   out of scope; only `.md` files are notes.
 
+## Revision (post-research, 2026-06-15)
+
+Research changed two decisions for lower risk / smaller blast radius:
+
+- **`defaultNoteFolder` is repurposed, not removed.** It has a 34-file blast
+  radius (app-core path construction, sync prefix matching in
+  `sync/note-sync.ts`, inbox filing). All sites either use
+  `path.join(vaultPath, defaultNoteFolder)` (handles `''` → vault root) or build
+  template strings passed through `normalizePath` (strips leading slash). So the
+  field stays; its **default becomes `''`** (vault root) and it doubles as the
+  configurable "default new-note folder". This is also B7's mechanism.
+- **The `newNoteLocation` / `newNoteFolder` enum is dropped (YAGNI).** A single
+  `defaultNoteFolder` string (`''` = root, else a folder) covers root + specified.
+  "Same folder as active note" is deferred to a follow-up.
+- Journal filename formatting must also be applied in `@memry/storage-vault`
+  `note-content-store.ts` (`getJournalRelativePath`), the desktop journal path
+  generator. The format util lives in a shared location both packages import.
+
+The B1/B7 sections below are read through this revision.
+
 ## Architecture
 
 ### B1. Config schema

--- a/docs/superpowers/specs/2026-06-15-flat-vault-root-obsidian-compat-plan.md
+++ b/docs/superpowers/specs/2026-06-15-flat-vault-root-obsidian-compat-plan.md
@@ -1,0 +1,106 @@
+# Flat Vault Root + Obsidian Compatibility — Implementation Plan
+
+Derived from `2026-06-15-flat-vault-root-obsidian-compat-design.md` (+ revision).
+Each phase ends green before the next. `pnpm` runs from the worktree root.
+
+## Phase 1 — `journal-format` util (pure, TDD)
+
+- New `packages/shared/src/journal-format.ts` (shared so storage-vault + desktop +
+  app-core can import):
+  - `buildJournalRegex(format)` → anchored basename `RegExp`.
+  - `parseJournalDate(filename, format)` → ISO `YYYY-MM-DD` | `null`.
+  - `formatJournalFilename(dateIso, format)` → string (no extension).
+  - tokens `YYYY YY MM M DD D`, separators `- _ . ` + space; unknown = literal.
+- Export from `packages/shared` index.
+- Test `packages/shared/src/journal-format.test.ts`: round-trips for
+  `YYYY-MM-DD`, `DD-MM-YYYY`, `YYYYMMDD`, `YYYY.MM.DD`; non-match → null.
+- Verify: `pnpm --filter @memry/shared test` (or vitest for the file).
+
+## Phase 2 — Config schema
+
+- `packages/contracts/src/vault-api.ts`: add `journalDateFormat: string` to
+  `VaultConfig` + `UpdateVaultConfigSchema`. (keep `defaultNoteFolder`)
+- `packages/app-core/src/paths.ts`: `VaultConfig` + `defaultVaultConfig`
+  (`defaultNoteFolder: ''`, add `journalDateFormat: 'YYYY-MM-DD'`,
+  excludePatterns += `.obsidian`).
+- `apps/desktop/src/main/vault/init.ts` `DEFAULT_CONFIG` + `index.ts` defaults
+  (`getConfig` fallback ~line 391): `defaultNoteFolder: ''`,
+  `journalDateFormat: 'YYYY-MM-DD'`, excludePatterns += `.obsidian`, `.memry`.
+- `apps/desktop/src/preload/index.d.ts`: add `journalDateFormat` to the config type.
+- `packages/storage-vault/src/note-content-store.ts`: add `journalDateFormat` to
+  `VaultStoreLayout`; `getJournalRelativePath` uses `formatJournalFilename`.
+- Verify: `pnpm ipc:generate && pnpm ipc:check`; `pnpm --filter @memry/contracts test`.
+
+## Phase 3 — Journal detection (config-aware)
+
+- `apps/desktop/.../queries/notes/journal-queries.ts`: replace
+  `JOURNAL_DATE_PATTERN`/`JOURNAL_PATH_PREFIX`; make `isJournalEntry(path, folder,
+format)`, `extractDateFromPath(path, folder, format)`,
+  `generateJournalPath(date, folder, format)` config-aware (delegate to
+  journal-format). Keep names.
+- Update call sites with config from `getConfig()`:
+  - `note-sync.ts:148`, `projectors/note-derived-state-projector.ts:52`,
+    `queries/notes/index.ts` re-exports.
+- Verify: `pnpm --filter @memry/desktop typecheck:node`.
+
+## Phase 4 — Indexer scans whole root
+
+- `apps/desktop/src/main/vault/indexer.ts:311`: `foldersToScan = [vaultPath]`;
+  ensure `findVaultFiles` skips `excludePatterns`, dotfolders, and
+  `config.attachmentsFolder`. Journal `date` set via config-aware
+  `extractDateFromPath`.
+- `watcher.ts`: scan whole root (line 198-199), keep `isJournalPath` but make it
+  use folder + format consistency.
+- Verify: indexer + watcher unit tests.
+
+## Phase 5 — New-note location + journal path
+
+- `notes-io.ts getNotesDir`, `folders.ts`, app-core `notes.ts notePath`,
+  `folder-view.ts notesDir/noteFolder` already handle `''` via path.join /
+  normalizePath — confirm, add guards only if a test fails.
+- Journal create/read path now flows through content-store format (Phase 2).
+- Verify: `notes`, `journal`, `folders` unit tests.
+
+## Phase 6 — Sidebar tree re-root + hide journal/attachments
+
+- `apps/desktop/.../hooks/use-note-tree-data.ts` + `components/notes-tree.tsx`:
+  tree roots at vault root (root-relative paths already do this once notes index
+  from root). Exclude `journalFolder` + `attachmentsFolder` top-level folders.
+- Confirm the notes list query is not passing `folder: 'notes'`.
+- Verify: `pnpm --filter @memry/desktop test:renderer` for tree.
+
+## Phase 7 — Vault init flat
+
+- `init.ts:7` `VAULT_FOLDERS`: drop `notes`; keep journal + attachments(+sub).
+- Verify: `init` unit tests (update expectations).
+
+## Phase 8 — Settings UI
+
+- `pages/settings/journal-section.tsx`: Journal folder + Date format inputs (live
+  preview), via `window.api.vault.getConfig/updateConfig`.
+- Default new-note folder input (Journal or General section): `defaultNoteFolder`
+  (empty = root).
+- `en/common.json` keys.
+- Verify: renderer settings test; `pnpm --filter @memry/desktop i18n:check`.
+
+## Phase 9 — Re-index on structural config change
+
+- `index.ts updateConfig`: when `journalFolder`/`journalDateFormat`/
+  `excludePatterns`/`defaultNoteFolder` change, trigger full re-index.
+- Verify: vault index test.
+
+## Phase 10 — Full verification + e2e
+
+- `pnpm lint`, `pnpm typecheck`, `pnpm test:desktop`, `pnpm test` — fix all
+  fallout (many existing tests hardcode `notes/` paths + `defaultNoteFolder:'notes'`
+  — update fixtures/expectations to the flat model; do NOT break behavior).
+- Add Playwright e2e if unit coverage does not exercise open-vault → see-notes.
+  Build `out/` first (`pnpm exec electron-vite build`), rebuild:electron as needed.
+- `git diff --check`.
+
+## Test-fallout note
+
+Many suites assert `defaultNoteFolder: 'notes'` and `journal/YYYY-MM-DD.md`. These
+are fixtures, not behavior contracts — update them to the flat model (root notes,
+`defaultNoteFolder: ''`) and config-aware journal helpers. Track that none are
+masking a real regression.

--- a/packages/app-core/src/folders.ts
+++ b/packages/app-core/src/folders.ts
@@ -13,15 +13,24 @@ export interface FoldersService {
   delete(folderPath: string): Promise<boolean>
 }
 
-async function walkFolders(root: string, current = ''): Promise<FolderRecord[]> {
+async function walkFolders(
+  root: string,
+  hiddenTopLevel: Set<string>,
+  current = ''
+): Promise<FolderRecord[]> {
   const absolute = path.join(root, current)
   const entries = await fs.readdir(absolute, { withFileTypes: true })
   const folders: FolderRecord[] = []
   for (const entry of entries) {
     if (!entry.isDirectory()) continue
+    // Skip hidden dirs (.memry, .obsidian, .git) and structural/excluded folders
+    // (journal, attachments, excludePatterns) — relevant once the notes root is
+    // the vault root (defaultNoteFolder = '').
+    if (entry.name.startsWith('.')) continue
+    if (current === '' && hiddenTopLevel.has(entry.name)) continue
     const relative = normalizePath(path.join(current, entry.name))
     folders.push({ path: relative })
-    folders.push(...(await walkFolders(root, relative)))
+    folders.push(...(await walkFolders(root, hiddenTopLevel, relative)))
   }
   return folders
 }
@@ -34,10 +43,15 @@ export function createFoldersService({
   config: VaultConfig
 }): FoldersService {
   const root = path.join(vaultPath, config.defaultNoteFolder)
+  const hiddenTopLevel = new Set(
+    [config.journalFolder, config.attachmentsFolder, ...config.excludePatterns]
+      .filter(Boolean)
+      .map((p) => normalizePath(p).split('/')[0])
+  )
 
   return {
     async list() {
-      return walkFolders(root)
+      return walkFolders(root, hiddenTopLevel)
     },
     async create(folderPath) {
       const normalized = normalizePath(folderPath)

--- a/packages/app-core/src/memry-app.test.ts
+++ b/packages/app-core/src/memry-app.test.ts
@@ -97,7 +97,7 @@ test('opens a standalone vault and exposes core note, journal, task, inbox, and 
     properties: { status: 'draft' }
   })
   assert.equal(note.title, 'CLI Note')
-  assert.equal(note.path, 'notes/Projects/CLI Note.md')
+  assert.equal(note.path, 'Projects/CLI Note.md')
   assert.deepEqual(note.properties, { status: 'draft' })
 
   const fetchedNote = await app.notes.get(note.id)
@@ -163,10 +163,7 @@ test('opens a standalone vault and exposes core note, journal, task, inbox, and 
     targetFolder: 'Projects'
   })
   assert.equal(importResult.imported, 1)
-  assert.equal(
-    importResult.importedFiles[0]?.destPath,
-    path.join(vaultPath, 'notes/Projects/import.md')
-  )
+  assert.equal(importResult.importedFiles[0]?.destPath, path.join(vaultPath, 'Projects/import.md'))
 
   const htmlExportPath = path.join(vaultPath, 'cli-note.html')
   const markdownExportPath = path.join(vaultPath, 'cli-note.md')

--- a/packages/app-core/src/notes.ts
+++ b/packages/app-core/src/notes.ts
@@ -127,6 +127,17 @@ function notePath(config: VaultConfig, title: string, folder?: string): string {
   return normalizePath(`${config.defaultNoteFolder}/${folderPart}${safeFilename(title)}.md`)
 }
 
+// Folder of a note relative to defaultNoteFolder ('' = vault root). Tolerant of
+// both the flat model (no prefix) and a legacy notes/ prefix; preserves nested
+// folders (a plain string replace would mangle multi-level paths).
+function noteFolderFromPath(notePathValue: string, defaultNoteFolder: string): string {
+  const dir = path.dirname(notePathValue)
+  const base = dir === '.' ? '' : dir
+  if (!defaultNoteFolder) return base
+  if (base === defaultNoteFolder) return ''
+  return base.startsWith(`${defaultNoteFolder}/`) ? base.slice(defaultNoteFolder.length + 1) : base
+}
+
 function journalPath(config: VaultConfig, date: string): string {
   return normalizePath(
     `${config.journalFolder}/${formatJournalFilename(date, config.journalDateFormat)}.md`
@@ -319,7 +330,7 @@ export function createNotesService({
       let nextPath = row.path
 
       if (input.title && input.title !== row.title && !row.journalDate) {
-        const folder = path.dirname(row.path).replace(`${config.defaultNoteFolder}/`, '')
+        const folder = noteFolderFromPath(row.path, config.defaultNoteFolder)
         nextPath = await ensureUniquePath(vaultPath, notePath(config, input.title, folder))
         await fs.mkdir(path.dirname(path.join(vaultPath, nextPath)), { recursive: true })
         await fs.rename(path.join(vaultPath, row.path), path.join(vaultPath, nextPath))

--- a/packages/app-core/src/notes.ts
+++ b/packages/app-core/src/notes.ts
@@ -9,6 +9,7 @@ import {
   getNoteMetadataByPath,
   listNoteMetadata
 } from '@memry/storage-data'
+import { formatJournalFilename } from '@memry/storage-vault'
 import type { DataDb } from './database.ts'
 import { createId } from './ids.ts'
 import { parseMarkdownNote, snippet, wordCount, writeMarkdownNote } from './markdown.ts'
@@ -127,7 +128,9 @@ function notePath(config: VaultConfig, title: string, folder?: string): string {
 }
 
 function journalPath(config: VaultConfig, date: string): string {
-  return normalizePath(`${config.journalFolder}/${date}.md`)
+  return normalizePath(
+    `${config.journalFolder}/${formatJournalFilename(date, config.journalDateFormat)}.md`
+  )
 }
 
 async function ensureUniquePath(vaultPath: string, relativePath: string): Promise<string> {

--- a/packages/app-core/src/paths.ts
+++ b/packages/app-core/src/paths.ts
@@ -6,13 +6,15 @@ export interface VaultConfig {
   excludePatterns: string[]
   defaultNoteFolder: string
   journalFolder: string
+  journalDateFormat: string
   attachmentsFolder: string
 }
 
 export const defaultVaultConfig: VaultConfig = {
-  excludePatterns: ['.git', 'node_modules', '.trash'],
-  defaultNoteFolder: 'notes',
+  excludePatterns: ['.git', 'node_modules', '.trash', '.obsidian', '.memry'],
+  defaultNoteFolder: '',
   journalFolder: 'journal',
+  journalDateFormat: 'YYYY-MM-DD',
   attachmentsFolder: 'attachments'
 }
 

--- a/packages/contracts/src/vault-api.ts
+++ b/packages/contracts/src/vault-api.ts
@@ -48,8 +48,11 @@ export interface VaultStatus {
 
 export interface VaultConfig {
   excludePatterns: string[]
+  /** Default folder for newly created notes; '' = vault root */
   defaultNoteFolder: string
   journalFolder: string
+  /** Obsidian-style date format for journal filenames (e.g. 'YYYY-MM-DD') */
+  journalDateFormat: string
   attachmentsFolder: string
 }
 
@@ -75,6 +78,7 @@ export const UpdateVaultConfigSchema = z.object({
   excludePatterns: z.array(z.string()).optional(),
   defaultNoteFolder: z.string().optional(),
   journalFolder: z.string().optional(),
+  journalDateFormat: z.string().optional(),
   attachmentsFolder: z.string().optional()
 })
 

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -110,6 +110,11 @@
       "createInSelectedFolder": {
         "label": "Create in Selected Folder",
         "description": "New notes and folders are created inside the currently selected folder. When off, items are always created at root."
+      },
+      "defaultNoteFolder": {
+        "label": "Default Location for New Notes",
+        "description": "Empty = vault root",
+        "placeholder": "notes"
       }
     },
     "privacy": {
@@ -278,6 +283,7 @@
     },
     "groups": {
       "defaultTemplate": "Default Template",
+      "location": "Location & Format",
       "sidebarVisibility": "Sidebar Visibility",
       "footer": "Footer"
     },
@@ -307,6 +313,20 @@
     "showStatsFooter": {
       "label": "Show Stats Footer",
       "description": "Word count, reading time, timestamps"
+    },
+    "folder": {
+      "label": "Journal Folder",
+      "description": "Folder where daily notes are stored",
+      "placeholder": "journal"
+    },
+    "dateFormat": {
+      "label": "Date Format",
+      "description": "Filename format for daily notes (e.g. YYYY-MM-DD)",
+      "placeholder": "YYYY-MM-DD"
+    },
+    "preview": {
+      "label": "Preview",
+      "description": "Today's journal file path"
     },
     "updateError": "Failed to update setting"
   },

--- a/packages/storage-vault/package.json
+++ b/packages/storage-vault/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./note-content-store": "./src/note-content-store.ts"
+    "./note-content-store": "./src/note-content-store.ts",
+    "./journal-format": "./src/journal-format.ts"
   },
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/storage-vault/src/index.ts
+++ b/packages/storage-vault/src/index.ts
@@ -1,1 +1,2 @@
 export * from './note-content-store.ts'
+export * from './journal-format.ts'

--- a/packages/storage-vault/src/journal-format.test.ts
+++ b/packages/storage-vault/src/journal-format.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildJournalRegex,
+  parseJournalDate,
+  formatJournalFilename,
+  DEFAULT_JOURNAL_DATE_FORMAT
+} from './journal-format.ts'
+
+describe('journal-format', () => {
+  const cases: { format: string; iso: string; stem: string }[] = [
+    { format: 'YYYY-MM-DD', iso: '2026-06-15', stem: '2026-06-15' },
+    { format: 'DD-MM-YYYY', iso: '2026-06-15', stem: '15-06-2026' },
+    { format: 'YYYYMMDD', iso: '2026-06-15', stem: '20260615' },
+    { format: 'YYYY.MM.DD', iso: '2026-06-15', stem: '2026.06.15' },
+    { format: 'YYYY_MM_DD', iso: '2026-01-02', stem: '2026_01_02' }
+  ]
+
+  it('round-trips format -> parse for each supported format', () => {
+    for (const { format, iso, stem } of cases) {
+      expect(formatJournalFilename(iso, format)).toBe(stem)
+      expect(parseJournalDate(stem, format)).toBe(iso)
+    }
+  })
+
+  it('matches the stem with buildJournalRegex', () => {
+    for (const { format, stem } of cases) {
+      expect(buildJournalRegex(format).test(stem)).toBe(true)
+    }
+  })
+
+  it('returns null for non-matching stems', () => {
+    expect(parseJournalDate('ideas', 'YYYY-MM-DD')).toBeNull()
+    expect(parseJournalDate('2026-06', 'YYYY-MM-DD')).toBeNull()
+    expect(parseJournalDate('2026-06-15-extra', 'YYYY-MM-DD')).toBeNull()
+  })
+
+  it('returns null for out-of-range months/days', () => {
+    expect(parseJournalDate('2026-13-01', 'YYYY-MM-DD')).toBeNull()
+    expect(parseJournalDate('2026-00-10', 'YYYY-MM-DD')).toBeNull()
+    expect(parseJournalDate('2026-06-40', 'YYYY-MM-DD')).toBeNull()
+  })
+
+  it('does not match a date-named file under a different format', () => {
+    // 15-06-2026 is valid for DD-MM-YYYY but not for YYYY-MM-DD
+    expect(parseJournalDate('15-06-2026', 'YYYY-MM-DD')).toBeNull()
+  })
+
+  it('supports 2-digit year and single-digit month/day tokens', () => {
+    expect(parseJournalDate('26-6-5', 'YY-M-D')).toBe('2026-06-05')
+    expect(formatJournalFilename('2026-06-05', 'YY-M-D')).toBe('26-6-5')
+  })
+
+  it('falls back to the default format when format is empty', () => {
+    expect(formatJournalFilename('2026-06-15', '')).toBe('2026-06-15')
+    expect(parseJournalDate('2026-06-15', '')).toBe('2026-06-15')
+    expect(DEFAULT_JOURNAL_DATE_FORMAT).toBe('YYYY-MM-DD')
+  })
+})

--- a/packages/storage-vault/src/journal-format.ts
+++ b/packages/storage-vault/src/journal-format.ts
@@ -1,0 +1,157 @@
+/**
+ * Obsidian-style journal filename date formats.
+ *
+ * A journal (daily note) filename is derived from a date using a format string
+ * built from these tokens:
+ *   YYYY (4-digit year)  YY (2-digit year)
+ *   MM   (2-digit month) M  (1-2 digit month)
+ *   DD   (2-digit day)   D  (1-2 digit day)
+ * Everything else in the format is a literal separator (e.g. `-`, `_`, `.`, ` `).
+ *
+ * The functions operate on the filename STEM (no `.md` extension). Callers add
+ * the folder and extension.
+ */
+
+export const DEFAULT_JOURNAL_DATE_FORMAT = 'YYYY-MM-DD'
+
+type DateField = 'year' | 'month' | 'day'
+
+interface TokenInfo {
+  field: DateField
+  pattern: string
+}
+
+const TOKEN_TABLE: Record<string, TokenInfo> = {
+  YYYY: { field: 'year', pattern: '\\d{4}' },
+  YY: { field: 'year', pattern: '\\d{2}' },
+  MM: { field: 'month', pattern: '\\d{2}' },
+  M: { field: 'month', pattern: '\\d{1,2}' },
+  DD: { field: 'day', pattern: '\\d{2}' },
+  D: { field: 'day', pattern: '\\d{1,2}' }
+}
+
+// Longest tokens first so `YYYY` wins over `YY` and `MM`/`DD` over `M`/`D`.
+const TOKEN_ORDER = ['YYYY', 'YY', 'MM', 'DD', 'M', 'D']
+
+function escapeLiteral(ch: string): string {
+  return ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+interface CompiledFormat {
+  regex: RegExp
+  fields: DateField[]
+}
+
+function compile(format: string): CompiledFormat {
+  const parts: string[] = []
+  const fields: DateField[] = []
+  let i = 0
+
+  while (i < format.length) {
+    let matched = false
+    for (const token of TOKEN_ORDER) {
+      if (format.startsWith(token, i)) {
+        const info = TOKEN_TABLE[token]
+        parts.push(`(${info.pattern})`)
+        fields.push(info.field)
+        i += token.length
+        matched = true
+        break
+      }
+    }
+    if (!matched) {
+      parts.push(escapeLiteral(format[i]))
+      i += 1
+    }
+  }
+
+  return { regex: new RegExp(`^${parts.join('')}$`), fields }
+}
+
+function pad(value: number, width: number): string {
+  return String(value).padStart(width, '0')
+}
+
+/**
+ * An anchored RegExp matching a journal filename stem (no extension) for `format`.
+ * Falls back to the default format when `format` is empty.
+ */
+export function buildJournalRegex(format: string): RegExp {
+  return compile(format || DEFAULT_JOURNAL_DATE_FORMAT).regex
+}
+
+/**
+ * Parse a filename stem into a canonical ISO date (`YYYY-MM-DD`), or `null` when
+ * it does not match the format or yields an invalid date.
+ */
+export function parseJournalDate(stem: string, format: string): string | null {
+  const { regex, fields } = compile(format || DEFAULT_JOURNAL_DATE_FORMAT)
+  const match = stem.match(regex)
+  if (!match) return null
+
+  let year: number | null = null
+  let month = 1
+  let day = 1
+
+  for (let g = 0; g < fields.length; g++) {
+    const value = parseInt(match[g + 1], 10)
+    if (Number.isNaN(value)) return null
+    if (fields[g] === 'year') year = value < 100 ? 2000 + value : value
+    else if (fields[g] === 'month') month = value
+    else day = value
+  }
+
+  if (year === null) return null
+  if (month < 1 || month > 12) return null
+  if (day < 1 || day > 31) return null
+
+  return `${pad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}`
+}
+
+/**
+ * Render a journal filename stem (no extension) from a canonical ISO date.
+ * Falls back to the default format when `format` is empty.
+ */
+export function formatJournalFilename(isoDate: string, format: string): string {
+  const [y, m, d] = isoDate.split('-').map((part) => parseInt(part, 10))
+  const fmt = format || DEFAULT_JOURNAL_DATE_FORMAT
+  const out: string[] = []
+  let i = 0
+
+  while (i < fmt.length) {
+    let matched = false
+    for (const token of TOKEN_ORDER) {
+      if (fmt.startsWith(token, i)) {
+        out.push(renderToken(token, y, m, d))
+        i += token.length
+        matched = true
+        break
+      }
+    }
+    if (!matched) {
+      out.push(fmt[i])
+      i += 1
+    }
+  }
+
+  return out.join('')
+}
+
+function renderToken(token: string, year: number, month: number, day: number): string {
+  switch (token) {
+    case 'YYYY':
+      return pad(year, 4)
+    case 'YY':
+      return pad(year % 100, 2)
+    case 'MM':
+      return pad(month, 2)
+    case 'M':
+      return String(month)
+    case 'DD':
+      return pad(day, 2)
+    case 'D':
+      return String(day)
+    default:
+      return token
+  }
+}

--- a/packages/storage-vault/src/note-content-store.ts
+++ b/packages/storage-vault/src/note-content-store.ts
@@ -1,11 +1,14 @@
 import fs from 'fs/promises'
 import path from 'path'
 import { randomBytes } from 'node:crypto'
+import { formatJournalFilename } from './journal-format.ts'
 
 export interface VaultStoreLayout {
   rootPath: string
   notesFolder: string
   journalFolder: string
+  /** Obsidian-style date format for journal filenames; defaults to YYYY-MM-DD */
+  journalDateFormat?: string
 }
 
 export interface NoteContentStore {
@@ -73,7 +76,8 @@ export function createNoteContentStore(layout: VaultStoreLayout): NoteContentSto
       }
     },
     getJournalRelativePath(date) {
-      return normalizeRelativePath(path.join(layout.journalFolder, `${date}.md`))
+      const filename = formatJournalFilename(date, layout.journalDateFormat ?? '')
+      return normalizeRelativePath(path.join(layout.journalFolder, `${filename}.md`))
     }
   }
 }


### PR DESCRIPTION
## Summary

Make Memry read an existing **Obsidian-style vault** instead of assuming a fixed `notes/` + `journal/` + `attachments/` layout. Opening such a vault previously showed **zero items** in the collection sidebar and **invisible journals**; this change fixes both and lets users point Memry at their existing vault.

Pre-production, no users → no migration/back-compat constraints. Existing Memry vaults keep working unchanged (their stored `config.json` pins `defaultNoteFolder: "notes"`).

## Problem

- Indexer only scanned `notes/` + `journal/`, so markdown at the vault root or in arbitrary subfolders was never indexed → empty collection.
- Journal detection was a hardcoded `^journal/(\d{4}-\d{2}-\d{2})\.md$` regex → Obsidian daily notes (custom folder, custom date format) were invisible.

## What changed

- **Whole-root scan** — indexer + watcher now scan the entire vault root recursively, excluding the attachments folder and dotfolders (`.memry`/`.obsidian`/`.git`). Every `.md` is a note.
- **Configurable journals** — `journalFolder` + Obsidian-style `journalDateFormat` (e.g. `YYYY-MM-DD`, `DD-MM-YYYY`). New pure util `@memry/storage-vault/journal-format` (build regex / parse → ISO / format) drives both detection and new-entry naming. Detection routes through a process-wide `journal-config` holder kept fresh by `getConfig()`, so the pure path helpers keep their signatures (no call-site churn).
- **`defaultNoteFolder` repurposed** to `''` = vault root (not removed — that was a 34-file blast radius). Doubles as the configurable default new-note location.
- **Sidebar tree** re-roots at the vault root; journal/attachments/excluded folders are hidden. The tree builder already handled both root-relative and legacy `notes/`-prefixed paths, so existing vaults render unchanged.
- **Settings UI** — Settings → Journal (folder + date format with a live `folder/2026-06-15.md` preview); Settings → General (default new-note folder, empty = vault root).
- Flat new-vault init (no `notes/`); changing structural config triggers a full index rebuild so the collection/journal split updates live.

## Testing

- typecheck 15/15, lint clean, `ipc:check` up to date.
- Desktop main suite: **293 pass** (the 2 failures are pre-existing `calendar-handlers` / `settings-handlers`, confirmed identical on `origin/main`).
- Renderer suite: **393 pass** (3 pre-existing failures confirmed on base).
- New unit/integration tests: `journal-format` round-trip across 4 formats (7) + config-aware journal detection incl. range validation, custom folder/format, disabled journals (6). Vault fixtures updated to the flat model.
- Self-review pass fixed 5 issues found mid-review (most notably: the initial index ran with the closed-vault fallback config because the vault path was set *after* `indexVault`; and a Settings change used incremental reindex which skips cached files — now a clean rebuild).

## Follow-ups

- **Docs** — pushed with `MEMRY_DOCS_IMPACT_SKIP=1`; `apps/docs/src` should get a vault-structure / journal-settings page (happy to do `docs:ai-update` next).
- **Manual GUI QA** on a real Obsidian vault (open vault → notes appear, set custom journal folder/format → journals detected + hidden from collection).
- MCP `handles-adapter` still defaults agent-created notes to `notes/` (no regression — they're indexed since the root is scanned).

Design + plan: `docs/superpowers/specs/2026-06-15-flat-vault-root-obsidian-compat-{design,plan}.md`.
