### PR TITLE
fix(sidebar): remove top gap in virtualized notes tree

### DIFF
--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -994,7 +994,7 @@ export function VirtualizedNotesTree({
                 left: 0,
                 width: '100%',
                 height: `${virtualRow.size}px`,
-                transform: `translateY(${virtualRow.start}px)`
+                transform: `translateY(${virtualRow.start - (usesExternalScroll ? scrollMargin : 0)}px)`
               }}
             >
               {item.type === 'folder' ? (


### PR DESCRIPTION
## Problem

A gap appears above the first folder under the **COLLECTIONS** header in the sidebar. It flickers in: the list looks normal for one frame, then a gap drops in.

## Root cause

`VirtualizedNotesTree` renders inside the **shared sidebar scroll container** (Collections + Bookmarks + Tags), so the virtualizer runs with a non-zero `scrollMargin` equal to the offset from the scroll-container top to the list top (≈ the COLLECTIONS header height).

In `@tanstack/react-virtual`:
- row `start` positions **already include** `scrollMargin` (virtual-core: `start = paddingStart + scrollMargin`)
- `getTotalSize()` **excludes** it (`end - scrollMargin + paddingEnd`)

The row transform used raw `virtualRow.start`, so every row was pushed down by `scrollMargin` inside the list container → the gap. It flickered because `scrollMargin` initializes to `0` (first paint = no gap), then a `useLayoutEffect` measures the real offset and sets it on the next frame.

Only the virtualized path hits this, and `shouldVirtualize` counts **all** notes recursively (ignoring collapse, threshold 100). The vault crossed 100+ notes after the flat vault-root scan (#571), flipping the sidebar into the virtualized path and exposing the latent bug.

## Fix

Apply the canonical TanStack external-scroll subtraction:

```diff
- transform: `translateY(${virtualRow.start}px)`
+ transform: `translateY(${virtualRow.start - (usesExternalScroll ? scrollMargin : 0)}px)`
```

Non-virtualized vaults (<100 notes) use the `TreeProvider` path and were never affected.

## Verification

- `typecheck:web` clean for this file (lone error is a pre-existing, unrelated shiki version mismatch in `ai-elements/message.tsx`)
- eslint clean
- No automated test: the gap is a layout-measurement artifact; jsdom returns zero rects so `scrollMargin` stays `0` and the bug can't reproduce in a renderer test. Verify live: open a 100+ note vault, expand COLLECTIONS, confirm rows sit flush under the header.