### PR TITLE
feat: add new note block type 'date' with date picker

### DIFF
--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const getNotes = async () => {
+  const response = await axios.get('/notes');
+  return response.data;
+};
+
+const createNote = async (note: any) => {
+  const response = await axios.post('/notes', note);
+  return response.data;
+};
+
+export { getNotes, createNote };

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+
+interface DatePickerProps {
+  date: Date;
+  onChange: (date: Date) => void;
+}
+
+const DatePicker: React.FC<DatePickerProps> = ({ date, onChange }) => {
+  const [selectedDate, setSelectedDate] = useState(date);
+
+  const handleDateChange = (date: Date) => {
+    setSelectedDate(date);
+    onChange(date);
+  };
+
+  return (
+    <input
+      type='date'
+      value={selectedDate.toISOString().split('T')[0]}
+      onChange={(e) => handleDateChange(new Date(e.target.value))}
+    />
+  );
+};
+
+export default DatePicker;

--- a/src/components/NoteBlock.tsx
+++ b/src/components/NoteBlock.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface NoteBlockProps {
+  type: string;
+  note: any;
+  onBlockTypeChange: (blockType: string) => void;
+}
+
+const NoteBlock: React.FC<NoteBlockProps> = ({ type, note, onBlockTypeChange }) => {
+  switch (type) {
+    case 'text':
+      return <div>{note.text}</div>;
+    case 'date':
+      return <div>{note.date.toLocaleDateString()}</div>;
+    default:
+      return <div>Unknown block type</div>;
+  }
+};
+
+export default NoteBlock;

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import NoteBlock from './NoteBlock';
+import DatePicker from './DatePicker';
+
+interface NoteEditorProps {
+  note: any;
+}
+
+const NoteEditor: React.FC<NoteEditorProps> = ({ note }) => {
+  const [selectedBlockType, setSelectedBlockType] = useState('text');
+  const [date, setDate] = useState(null);
+
+  const handleBlockTypeChange = (blockType: string) => {
+    setSelectedBlockType(blockType);
+  };
+
+  const handleDateChange = (date: Date) => {
+    setDate(date);
+  };
+
+  return (
+    <div>
+      <NoteBlock
+        type={selectedBlockType}
+        note={note}
+        onBlockTypeChange={handleBlockTypeChange}
+      />
+      {selectedBlockType === 'date' && (
+        <DatePicker
+          date={date}
+          onChange={handleDateChange}
+        />
+      )}
+    </div>
+  );
+};
+
+export default NoteEditor;

--- a/src/views/Calendar.tsx
+++ b/src/views/Calendar.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import NoteBlock from '../components/NoteBlock';
+
+interface CalendarProps {
+  notes: any[];
+}
+
+const Calendar: React.FC<CalendarProps> = ({ notes }) => {
+  return (
+    <div>
+      {notes.map((note) => (
+        <NoteBlock key={note.id} type={note.type} note={note} />
+      ))}
+    </div>
+  );
+};
+
+export default Calendar;


### PR DESCRIPTION
## Summary


## Release note

none

## Test plan

## Details

## Summary
Added new note block type 'date' with date picker component.

## Release note
none

## Test plan
Manually test the new feature by creating a note with the new block type and verifying its display in the calendar view.

---
*Closes #521*

> 🤖 Generated by AutoGit