### PR TITLE
feat(landing): SEO audit fixes — alternative pages, schema, headers, perf

### DIFF
--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -69,6 +69,7 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://api.fontshare.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500&family=Inter:wght@400&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"

--- a/apps/landing/scripts/prerender.ts
+++ b/apps/landing/scripts/prerender.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createServer } from 'vite'
-import { buildRobotsTxt, buildSitemapXml } from '../src/lib/crawl-files.ts'
+import { buildLlmsTxt, buildRobotsTxt, buildSitemapXml } from '../src/lib/crawl-files.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
@@ -91,8 +91,10 @@ async function prerender() {
 
     fs.writeFileSync(path.resolve(DIST, 'sitemap.xml'), buildSitemapXml())
     fs.writeFileSync(path.resolve(DIST, 'robots.txt'), buildRobotsTxt())
+    fs.writeFileSync(path.resolve(DIST, 'llms.txt'), buildLlmsTxt())
     console.log('  wrote: dist/sitemap.xml')
     console.log('  wrote: dist/robots.txt')
+    console.log('  wrote: dist/llms.txt')
 
     console.log(`\n  ${ROUTES.length} routes prerendered.`)
   } finally {

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -26,6 +26,11 @@ import { RefundPage } from '@/pages/Refund'
 import { NotFound } from '@/pages/NotFound'
 import { AuthPage } from '@/pages/Auth'
 import { AuthCallbackPage } from '@/pages/AuthCallback'
+import {
+  ObsidianAlternativePage,
+  NotionAlternativePage,
+  NotePlanAlternativePage
+} from '@/pages/AlternativePage'
 import { RequireAuth } from '@/components/account/RequireAuth'
 import { AccountLayout } from '@/components/account/AccountLayout'
 import { ProfileSection } from '@/pages/account/ProfileSection'
@@ -139,6 +144,9 @@ function AppContent() {
           <Route path="/download/desktop" element={<DownloadDesktopPage />} />
           <Route path="/use-cases" element={<UseCasesPage />} />
           <Route path="/security" element={<SecurityPage />} />
+          <Route path="/obsidian-alternative" element={<ObsidianAlternativePage />} />
+          <Route path="/notion-alternative" element={<NotionAlternativePage />} />
+          <Route path="/noteplan-alternative" element={<NotePlanAlternativePage />} />
           <Route path="/pricing" element={<PricingPage />} />
           <Route path="/checkout" element={<CheckoutPage />} />
           <Route path="/changelog" element={<ChangelogPage />} />

--- a/apps/landing/src/components/layout/Footer.tsx
+++ b/apps/landing/src/components/layout/Footer.tsx
@@ -50,7 +50,7 @@ export function Footer() {
   return (
     <footer className="border-t border-border bg-paper py-20">
       <Container>
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-10 mb-16">
+        <div className="grid grid-cols-2 md:grid-cols-6 gap-10 mb-16">
           <div className="col-span-2 md:col-span-2 pe-8">
             <Link
               to="/"
@@ -70,6 +70,23 @@ export function Footer() {
             <h4 className="font-serif text-lg text-ink mb-6">Product</h4>
             <ul className="space-y-4">
               {FOOTER_LINKS.product.map((link) => (
+                <li key={link.label}>
+                  <Link
+                    to={footerHref(link.href, pathname)}
+                    className="text-sm text-muted hover:text-terracotta transition-colors font-medium"
+                    onClick={() => trackLandingEvent('landing_nav_click', footerTarget(link.label))}
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h4 className="font-serif text-lg text-ink mb-6">Compare</h4>
+            <ul className="space-y-4">
+              {FOOTER_LINKS.compare.map((link) => (
                 <li key={link.label}>
                   <Link
                     to={footerHref(link.href, pathname)}

--- a/apps/landing/src/components/sections/Features.tsx
+++ b/apps/landing/src/components/sections/Features.tsx
@@ -130,6 +130,8 @@ function FeatureStackCard({
             <img
               src={screenshotSrc}
               alt={`${feature.title} feature screenshot`}
+              loading="lazy"
+              decoding="async"
               className="h-full w-full object-cover object-left-top transition-transform duration-700 ease-out group-hover:scale-[1.025]"
             />
             <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-ink/20 via-transparent to-white/10" />

--- a/apps/landing/src/components/sections/FlowFunnel.tsx
+++ b/apps/landing/src/components/sections/FlowFunnel.tsx
@@ -45,6 +45,10 @@ function CompetitorLogos({
             src={c.logo}
             alt={c.name}
             title={c.name}
+            width={20}
+            height={20}
+            loading="lazy"
+            decoding="async"
             className="w-5 h-5 rounded-sm opacity-50 grayscale hover:opacity-100 hover:grayscale-0 transition-all duration-200"
           />
         ))}

--- a/apps/landing/src/components/sections/FlowShowcase.tsx
+++ b/apps/landing/src/components/sections/FlowShowcase.tsx
@@ -41,6 +41,10 @@ function CompetitorBar({ activeIndex }: { activeIndex: number }) {
                 src={c.logo}
                 alt={c.name}
                 title={c.name}
+                width={18}
+                height={18}
+                loading="lazy"
+                decoding="async"
                 className="w-[18px] h-[18px] rounded-sm opacity-60 hover:opacity-100 transition-opacity"
               />
             ))}

--- a/apps/landing/src/components/sections/Hero.tsx
+++ b/apps/landing/src/components/sections/Hero.tsx
@@ -43,6 +43,7 @@ export function Hero() {
             <RevealLine inView={isInView} delay={0.05}>
               Your thoughts,
             </RevealLine>
+            {/* Whitespace text node so the two block lines extract as "thoughts, beautifully" */}{' '}
             <RevealLine inView={isInView} delay={0.18}>
               <span className="relative inline-block italic text-terracotta">
                 beautifully organized.

--- a/apps/landing/src/components/shared/PageHead.tsx
+++ b/apps/landing/src/components/shared/PageHead.tsx
@@ -1,5 +1,6 @@
 import { Helmet } from 'react-helmet-async'
 import {
+  getBreadcrumbJsonLd,
   getCanonicalUrl,
   getJsonLd,
   PAGE_META,
@@ -19,6 +20,7 @@ interface PageHeadProps {
 export function PageHead({ page, jsonLd }: PageHeadProps) {
   const meta = PAGE_META[page]
   const canonical = getCanonicalUrl(meta.path)
+  const breadcrumb = getBreadcrumbJsonLd(page)
 
   return (
     <Helmet>
@@ -45,6 +47,7 @@ export function PageHead({ page, jsonLd }: PageHeadProps) {
       <meta name="twitter:image:alt" content={SOCIAL_IMAGE_ALT} />
 
       {jsonLd && <script type="application/ld+json">{getJsonLd()}</script>}
+      {breadcrumb && <script type="application/ld+json">{breadcrumb}</script>}
     </Helmet>
   )
 }

--- a/apps/landing/src/entry-server.tsx
+++ b/apps/landing/src/entry-server.tsx
@@ -27,6 +27,11 @@ import { AuthPage } from '@/pages/Auth'
 import { AuthCallbackPage } from '@/pages/AuthCallback'
 import { RequireAuth } from '@/components/account/RequireAuth'
 import { AccountLayout } from '@/components/account/AccountLayout'
+import {
+  ObsidianAlternativePage,
+  NotionAlternativePage,
+  NotePlanAlternativePage
+} from '@/pages/AlternativePage'
 import { NotFound } from '@/pages/NotFound'
 
 // Account routes are gated by RequireAuth, which renders null until the client is
@@ -51,6 +56,9 @@ const ROUTE_MAP: Record<string, () => ReactNode> = {
   '/download/desktop': () => <DownloadDesktopPage />,
   '/use-cases': () => <UseCasesPage />,
   '/security': () => <SecurityPage />,
+  '/obsidian-alternative': () => <ObsidianAlternativePage />,
+  '/notion-alternative': () => <NotionAlternativePage />,
+  '/noteplan-alternative': () => <NotePlanAlternativePage />,
   '/pricing': () => <PricingPage />,
   '/changelog': () => <ChangelogPage />,
   '/roadmap': () => <RoadmapPage />,

--- a/apps/landing/src/lib/alternatives.ts
+++ b/apps/landing/src/lib/alternatives.ts
@@ -1,0 +1,145 @@
+import type { PAGE_META } from './seo'
+
+export type AltCell = boolean | 'partial'
+
+export type AltRow = {
+  feature: string
+  memry: AltCell
+  competitor: AltCell
+}
+
+export type AlternativeConfig = {
+  pageKey: keyof typeof PAGE_META
+  competitor: string
+  eyebrow: string
+  heading: string
+  headingAccent: string
+  // Self-contained, declarative paragraph (~120-150 words) sized for AI-search citation.
+  intro: string
+  rows: readonly AltRow[]
+  reasons: readonly { title: string; body: string }[]
+  footnote: string
+}
+
+const COMPARISON_FOOTNOTE =
+  'Comparison reflects each app’s native, out-of-the-box features as of mid-2026. Competitors may cover some rows through paid add-ons or third-party plugins.'
+
+export const ALTERNATIVES: readonly AlternativeConfig[] = [
+  {
+    pageKey: 'obsidianAlternative',
+    competitor: 'Obsidian',
+    eyebrow: 'Obsidian alternative',
+    heading: 'The Obsidian alternative with',
+    headingAccent: 'tasks, calendar & encryption built in.',
+    intro:
+      'memrynote is a local-first alternative to Obsidian that ships notes, tasks, a calendar, and a daily journal in one app — no plugins required. Like Obsidian, it stores every note as a plain Markdown file in a folder you own, with wiki-links and backlinks connecting your thoughts. Unlike Obsidian, task management, a calendar, and an inbox are built in rather than assembled from community plugins, and end-to-end encrypted sync is part of the product instead of a separate paid add-on. memrynote runs on macOS, Windows, and Linux, is open source, and works fully offline without an account.',
+    rows: [
+      { feature: 'Local Markdown files you own', memry: true, competitor: true },
+      { feature: 'Wiki-links & backlinks', memry: true, competitor: true },
+      { feature: 'Built-in task management', memry: true, competitor: 'partial' },
+      { feature: 'Built-in calendar', memry: true, competitor: false },
+      { feature: 'Daily journal', memry: true, competitor: 'partial' },
+      { feature: 'Inbox / quick capture', memry: true, competitor: 'partial' },
+      { feature: 'End-to-end encrypted sync included', memry: true, competitor: 'partial' },
+      { feature: 'Works without plugins', memry: true, competitor: false },
+      { feature: 'Open source', memry: true, competitor: false }
+    ],
+    reasons: [
+      {
+        title: 'No plugin tax',
+        body: 'Tasks, calendar, inbox, and journal are first-class features — not community plugins you maintain and debug yourself.'
+      },
+      {
+        title: 'One app, not ten',
+        body: 'Stop stitching together separate plugins for what should be a single connected workspace.'
+      },
+      {
+        title: 'Encryption included',
+        body: 'End-to-end encrypted sync is part of the product, not a separate paid subscription bolted on top.'
+      },
+      {
+        title: 'Open & cross-platform',
+        body: 'Open source, on macOS, Windows, and Linux, with your notes as portable Markdown you can read anywhere.'
+      }
+    ],
+    footnote: COMPARISON_FOOTNOTE
+  },
+  {
+    pageKey: 'notionAlternative',
+    competitor: 'Notion',
+    eyebrow: 'Private Notion alternative',
+    heading: 'The private Notion alternative that',
+    headingAccent: 'can’t read your notes.',
+    intro:
+      'memrynote is a private, end-to-end encrypted alternative to Notion. Where Notion stores your pages on its servers — where staff can technically access them — memrynote keeps every note as a plain Markdown file on your own device and encrypts sync with XChaCha20-Poly1305, so the server only ever holds ciphertext. It combines notes, tasks, a calendar, and a daily journal in one offline-first workspace, runs on macOS, Windows, and Linux, and needs no account to get started. It is open source and free for local use, so your second brain stays yours even if the company disappears.',
+    rows: [
+      { feature: 'Local-first & offline', memry: true, competitor: false },
+      { feature: 'End-to-end encryption', memry: true, competitor: false },
+      { feature: 'Plain Markdown files', memry: true, competitor: false },
+      { feature: 'Works offline', memry: true, competitor: 'partial' },
+      { feature: 'Built-in tasks', memry: true, competitor: true },
+      { feature: 'Daily journal', memry: true, competitor: 'partial' },
+      { feature: 'No vendor access to your data', memry: true, competitor: false },
+      { feature: 'Open source', memry: true, competitor: false },
+      { feature: 'Free tier', memry: true, competitor: 'partial' }
+    ],
+    reasons: [
+      {
+        title: 'Truly private',
+        body: 'Your notes are encrypted on your device before sync. The server holds ciphertext and never sees your keys.'
+      },
+      {
+        title: 'Your data, your files',
+        body: 'Notes are plain Markdown in a folder you control — not blocks locked inside a proprietary database.'
+      },
+      {
+        title: 'Offline-first',
+        body: 'The whole workspace works without internet. Sync is an option, not a requirement.'
+      },
+      {
+        title: 'No lock-in',
+        body: 'Open source and Markdown-native, so you can leave any time with everything intact.'
+      }
+    ],
+    footnote: COMPARISON_FOOTNOTE
+  },
+  {
+    pageKey: 'noteplanAlternative',
+    competitor: 'NotePlan',
+    eyebrow: 'NotePlan alternative',
+    heading: 'The cross-platform NotePlan alternative for',
+    headingAccent: 'Windows, macOS & Linux.',
+    intro:
+      'memrynote is a cross-platform alternative to NotePlan that brings notes, tasks, a calendar, and a daily journal together in one local-first app. Unlike NotePlan, which is built around Apple platforms, memrynote runs natively on macOS, Windows, and Linux. Notes are plain Markdown files in a folder you own, sync is end-to-end encrypted with zero-knowledge keys, and the app works fully offline without an account. It keeps the daily-notes, task-backlink, and calendar workflow that NotePlan users rely on — without locking you into a single operating system — and it is open source and free for local use.',
+    rows: [
+      { feature: 'macOS support', memry: true, competitor: true },
+      { feature: 'Windows support', memry: true, competitor: false },
+      { feature: 'Linux support', memry: true, competitor: false },
+      { feature: 'Plain Markdown files', memry: true, competitor: true },
+      { feature: 'Notes + tasks + calendar', memry: true, competitor: true },
+      { feature: 'Daily journal', memry: true, competitor: true },
+      { feature: 'End-to-end encrypted sync', memry: true, competitor: false },
+      { feature: 'Open source', memry: true, competitor: false },
+      { feature: 'Free tier', memry: true, competitor: 'partial' }
+    ],
+    reasons: [
+      {
+        title: 'Cross-platform',
+        body: 'Native on Windows and Linux too — not just Apple devices — so your workspace follows you everywhere.'
+      },
+      {
+        title: 'Encrypted by default',
+        body: 'Zero-knowledge end-to-end encrypted sync, instead of relying on plain iCloud storage.'
+      },
+      {
+        title: 'Same daily-notes flow',
+        body: 'Daily notes, task backlinks, and calendar scheduling — the workflow you already know.'
+      },
+      {
+        title: 'Open source',
+        body: 'Markdown files you own and an open codebase, so nothing about your notes is a black box.'
+      }
+    ],
+    footnote: COMPARISON_FOOTNOTE
+  }
+]

--- a/apps/landing/src/lib/constants.ts
+++ b/apps/landing/src/lib/constants.ts
@@ -151,6 +151,11 @@ export const FOOTER_LINKS = {
     { label: 'Changelog', href: '/changelog' },
     { label: 'Security', href: '/security' }
   ],
+  compare: [
+    { label: 'Obsidian alternative', href: '/obsidian-alternative' },
+    { label: 'Notion alternative', href: '/notion-alternative' },
+    { label: 'NotePlan alternative', href: '/noteplan-alternative' }
+  ],
   resources: [
     { label: 'Docs', href: DOCS_URL },
     { label: 'Terms of Service', href: '/terms' },

--- a/apps/landing/src/lib/crawl-files.ts
+++ b/apps/landing/src/lib/crawl-files.ts
@@ -17,9 +17,15 @@ export function getIndexablePaths(): string[] {
   return Object.values(PAGE_META).map((meta) => meta.path)
 }
 
-export function buildSitemapXml(paths: readonly string[] = getIndexablePaths()): string {
+export function buildSitemapXml(
+  paths: readonly string[] = getIndexablePaths(),
+  lastmod: string = new Date().toISOString().slice(0, 10)
+): string {
   const urls = paths
-    .map((path) => `  <url>\n    <loc>${escapeXml(toAbsoluteUrl(path))}</loc>\n  </url>`)
+    .map(
+      (path) =>
+        `  <url>\n    <loc>${escapeXml(toAbsoluteUrl(path))}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>`
+    )
     .join('\n')
 
   return [
@@ -33,4 +39,54 @@ export function buildSitemapXml(paths: readonly string[] = getIndexablePaths()):
 
 export function buildRobotsTxt(): string {
   return `User-agent: *\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml\n`
+}
+
+// AI-search discovery file (llms.txt). Crawlers like Perplexity / ChatGPT / Claude read
+// this to understand the site without reverse-engineering the HTML.
+export function buildLlmsTxt(): string {
+  const page = (path: string, desc?: string) =>
+    desc ? `- [${path}](${BASE_URL}${path}): ${desc}` : `- [${path}](${BASE_URL}${path})`
+
+  return [
+    '# memrynote',
+    '',
+    '> memrynote is a local-first, end-to-end encrypted personal knowledge management app that combines notes, tasks, a daily journal, and an inbox in one offline-first desktop workspace. Built by Kaan Karaca. Open source. Available for macOS, Windows, and Linux.',
+    '',
+    'memrynote stores notes as plain Markdown files in a folder you choose on your device. Encrypted sync across devices uses XChaCha20-Poly1305 via libsodium and is zero-knowledge: vault keys never leave your devices. No account is required to use the core app.',
+    '',
+    'Pricing: Free (local vault), Plus $5/month (1 GB encrypted sync, 1 vault), Pro $10/month (10 GB, 10 vaults), Believer $500 once (50 GB, unlimited vaults).',
+    '',
+    '## Key pages',
+    '',
+    page('/', PAGE_META.home.description),
+    page('/features', PAGE_META.features.description),
+    page('/security', PAGE_META.security.description),
+    page('/pricing', PAGE_META.pricing.description),
+    page('/use-cases', PAGE_META.useCases.description),
+    page('/download/desktop', PAGE_META.downloadDesktop.description),
+    page('/changelog', PAGE_META.changelog.description),
+    page('/roadmap', PAGE_META.roadmap.description),
+    '',
+    '## Comparisons',
+    '',
+    page('/obsidian-alternative', PAGE_META.obsidianAlternative.description),
+    page('/notion-alternative', PAGE_META.notionAlternative.description),
+    page('/noteplan-alternative', PAGE_META.noteplanAlternative.description),
+    '',
+    '## Feature pages',
+    '',
+    page('/features/notes'),
+    page('/features/inbox'),
+    page('/features/journal'),
+    page('/features/tasks'),
+    page('/features/calendar'),
+    page('/features/ai-agent'),
+    '',
+    '## About',
+    '',
+    '- Founder: Kaan Karaca (@h4yfans on X and GitHub)',
+    '- License: Open source',
+    '- Docs: https://docs.memrynote.com',
+    ''
+  ].join('\n')
 }

--- a/apps/landing/src/lib/seo.ts
+++ b/apps/landing/src/lib/seo.ts
@@ -1,7 +1,10 @@
+import { FAQ_ITEMS, FEATURES, GITHUB_URL, REDDIT_URL, TWITTER_DEV_URL } from './constants'
+
 export const BASE_URL = 'https://memrynote.com'
 export const SITE_NAME = 'memrynote'
 export const ALTERNATE_SITE_NAMES = ['Memry Note', 'memrynote.com'] as const
-export const TWITTER_HANDLE = '@h4yfans'
+// Brand handle (matches index.html). The founder's personal handle is TWITTER_DEV_URL in constants.
+export const TWITTER_HANDLE = '@memrynote'
 export const SOCIAL_IMAGE_PATH = '/og-image.png'
 export const SOCIAL_IMAGE_URL = `${BASE_URL}${SOCIAL_IMAGE_PATH}`
 export const SOCIAL_IMAGE_WIDTH = '1200'
@@ -65,9 +68,9 @@ export const PAGE_META: Record<string, PageMeta> = {
     path: '/features/ai-agent'
   },
   downloadDesktop: {
-    title: 'memrynote for Desktop — Coming at the end of June',
+    title: 'memrynote for Desktop — macOS, Windows & Linux',
     description:
-      'memrynote desktop installers for macOS, Windows, and Linux are coming at the end of June. Plain Markdown vault, end-to-end encrypted sync, open source.',
+      'memrynote desktop for macOS, Windows, and Linux. Plain Markdown vault, end-to-end encrypted sync, open source.',
     path: '/download/desktop'
   },
   useCases: {
@@ -117,6 +120,24 @@ export const PAGE_META: Record<string, PageMeta> = {
     description:
       'Seven-day money-back guarantee on every paid Sync plan, including Believer. Requests processed through Paddle, refunded to your original payment method.',
     path: '/refund'
+  },
+  obsidianAlternative: {
+    title: 'Obsidian alternative — memrynote',
+    description:
+      'Looking for an Obsidian alternative with built-in tasks, a calendar, and end-to-end encrypted sync? memrynote keeps your notes as local Markdown files — no plugin tax.',
+    path: '/obsidian-alternative'
+  },
+  notionAlternative: {
+    title: 'Private Notion alternative — memrynote',
+    description:
+      'A private, end-to-end encrypted Notion alternative. memrynote stores notes as local Markdown files on your device — offline-first, open source, no vendor access to your data.',
+    path: '/notion-alternative'
+  },
+  noteplanAlternative: {
+    title: 'NotePlan alternative — memrynote',
+    description:
+      'A cross-platform NotePlan alternative for Windows, macOS, and Linux. Notes, tasks, calendar, and a daily journal in one local-first app with end-to-end encrypted sync.',
+    path: '/noteplan-alternative'
   }
 }
 
@@ -133,53 +154,121 @@ export function getCanonicalUrl(path: string): string {
   return `${BASE_URL}${path}`
 }
 
+const ORGANIZATION_ID = `${BASE_URL}/#organization`
+
 function getWebsiteJsonLdObject() {
   return {
+    '@id': `${BASE_URL}/#website`,
     name: 'memrynote',
     alternateName: ALTERNATE_SITE_NAMES,
     url: `${BASE_URL}/`
   }
 }
 
+function getOrganizationJsonLdObject() {
+  return {
+    '@type': 'Organization',
+    '@id': ORGANIZATION_ID,
+    name: 'memrynote',
+    alternateName: ALTERNATE_SITE_NAMES,
+    url: `${BASE_URL}/`,
+    logo: {
+      '@type': 'ImageObject',
+      url: `${BASE_URL}/favicon.svg`
+    },
+    sameAs: [GITHUB_URL, TWITTER_DEV_URL, REDDIT_URL],
+    founder: {
+      '@type': 'Person',
+      name: 'Kaan Karaca',
+      sameAs: ['https://x.com/h4yfans', 'https://github.com/h4yfans']
+    }
+  }
+}
+
+const SCREENSHOT_CAPTIONS: ReadonlyArray<readonly [string, string]> = [
+  ['inbox', 'memrynote inbox'],
+  ['journal', 'memrynote daily journal'],
+  ['note', 'memrynote notes editor'],
+  ['task', 'memrynote task management'],
+  ['calendar', 'memrynote calendar view']
+]
+
 function getSoftwareApplicationJsonLdObject() {
   return {
     '@type': 'SoftwareApplication',
+    '@id': `${BASE_URL}/#app`,
     name: 'memrynote',
     applicationCategory: 'ProductivityApplication',
+    applicationSubCategory: 'Personal Knowledge Management',
     operatingSystem: 'macOS, Windows, Linux',
     description: PAGE_META.home.description,
-    url: BASE_URL,
+    url: `${BASE_URL}/`,
+    downloadUrl: `${BASE_URL}/download/desktop`,
+    screenshot: SCREENSHOT_CAPTIONS.map(([id, caption]) => ({
+      '@type': 'ImageObject',
+      url: `${BASE_URL}/screenshots/${id}_white.png`,
+      caption
+    })),
+    featureList: [
+      ...FEATURES.map((feature) => `${feature.title} — ${feature.tagline}`),
+      'End-to-end encrypted sync',
+      'Open source'
+    ],
+    creator: { '@id': ORGANIZATION_ID },
+    publisher: { '@id': ORGANIZATION_ID },
+    // aggregateRating and softwareVersion are intentionally omitted until a real rating
+    // source and release tag exist — fabricating either violates Google's policies.
     offers: [
       {
         '@type': 'Offer',
+        name: 'Free',
         price: '0',
         priceCurrency: 'USD',
+        availability: 'https://schema.org/InStock',
         description: 'Free tier — notes, tasks, journal, inbox, and local vault'
       },
       {
         '@type': 'Offer',
+        name: 'Plus',
         price: '5',
         priceCurrency: 'USD',
+        availability: 'https://schema.org/InStock',
         description: 'Plus — 1 GB encrypted sync and 1 vault'
       },
       {
         '@type': 'Offer',
+        name: 'Pro',
         price: '10',
         priceCurrency: 'USD',
+        availability: 'https://schema.org/InStock',
         description: 'Pro — 10 GB encrypted sync and 10 vaults'
       },
       {
         '@type': 'Offer',
+        name: 'Believer',
         price: '500',
         priceCurrency: 'USD',
+        availability: 'https://schema.org/InStock',
         description: 'Believer — supporter package with 50 GB and unlimited vaults'
       }
-    ],
-    author: {
-      '@type': 'Organization',
-      name: 'memrynote',
-      url: BASE_URL
-    }
+    ]
+  }
+}
+
+function getFaqPageJsonLdObject() {
+  return {
+    '@type': 'FAQPage',
+    '@id': `${BASE_URL}/#faq`,
+    // Google retired FAQ rich results (May 2026); this stays for AI-search citation
+    // (Perplexity / ChatGPT / AI Overviews), since on-page answers live in a JS accordion.
+    mainEntity: FAQ_ITEMS.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer
+      }
+    }))
   }
 }
 
@@ -197,9 +286,59 @@ export function getJsonLd(): string {
     '@graph': [
       {
         ...getWebsiteJsonLdObject(),
-        '@type': 'WebSite'
+        '@type': 'WebSite',
+        publisher: { '@id': ORGANIZATION_ID }
       },
-      getSoftwareApplicationJsonLdObject()
+      getOrganizationJsonLdObject(),
+      getSoftwareApplicationJsonLdObject(),
+      getFaqPageJsonLdObject()
     ]
+  })
+}
+
+function breadcrumbLabel(title: string): string {
+  return title.split(' — ')[0]
+}
+
+// BreadcrumbList for inner pages. Intermediate segments without their own PAGE_META
+// entry (e.g. /download) are skipped so no crumb links to a non-existent page.
+export function getBreadcrumbJsonLd(page: keyof typeof PAGE_META): string | null {
+  const meta = PAGE_META[page]
+  if (!meta || meta.path === '/') return null
+
+  const items: Array<{ '@type': 'ListItem'; position: number; name: string; item: string }> = [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/` }
+  ]
+
+  const segments = meta.path.split('/').filter(Boolean)
+  let position = 2
+  let acc = ''
+  for (let i = 0; i < segments.length; i++) {
+    acc += `/${segments[i]}`
+    const isLeaf = i === segments.length - 1
+    if (isLeaf) {
+      items.push({
+        '@type': 'ListItem',
+        position: position++,
+        name: breadcrumbLabel(meta.title),
+        item: `${BASE_URL}${meta.path}`
+      })
+      continue
+    }
+    const parent = Object.values(PAGE_META).find((m) => m.path === acc)
+    if (parent) {
+      items.push({
+        '@type': 'ListItem',
+        position: position++,
+        name: breadcrumbLabel(parent.title),
+        item: `${BASE_URL}${acc}`
+      })
+    }
+  }
+
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items
   })
 }

--- a/apps/landing/src/pages/AlternativePage.tsx
+++ b/apps/landing/src/pages/AlternativePage.tsx
@@ -1,0 +1,196 @@
+import { Link } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { Check, Minus, X } from 'lucide-react'
+import { Container } from '@/components/layout/Container'
+import { PageHead } from '@/components/shared/PageHead'
+import { Button } from '@/components/ui/button'
+import { ALTERNATIVES, type AltCell, type AlternativeConfig } from '@/lib/alternatives'
+
+const REVEAL = {
+  initial: { opacity: 0, y: 24 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: '-80px' },
+  transition: { duration: 0.7, ease: [0.16, 1, 0.3, 1] as const }
+}
+
+function CellIcon({ value }: { value: AltCell }) {
+  if (value === true) {
+    return <Check className="mx-auto h-4 w-4 text-sage" strokeWidth={2.5} aria-label="Yes" />
+  }
+  if (value === 'partial') {
+    return (
+      <Minus className="mx-auto h-4 w-4 text-terracotta" strokeWidth={2.5} aria-label="Partial" />
+    )
+  }
+  return <X className="mx-auto h-4 w-4 text-muted/40" strokeWidth={2} aria-label="No" />
+}
+
+function MobileValue({ value }: { value: AltCell }) {
+  if (value === true) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs font-medium text-sage">
+        <Check className="h-3.5 w-3.5" /> Yes
+      </span>
+    )
+  }
+  if (value === 'partial') {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs font-medium text-terracotta">
+        <Minus className="h-3.5 w-3.5" /> Partial
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs font-medium text-muted/70">
+      <X className="h-3.5 w-3.5" /> No
+    </span>
+  )
+}
+
+function AlternativePage({ config }: { config: AlternativeConfig }) {
+  return (
+    <>
+      <PageHead page={config.pageKey} />
+
+      <section className="pt-28 pb-12 md:pt-36 md:pb-16">
+        <Container size="md">
+          <motion.div {...REVEAL} className="max-w-3xl">
+            <p className="font-mono-accent text-xs uppercase tracking-[0.22em] text-terracotta">
+              {config.eyebrow}
+            </p>
+            <h1 className="mt-4 font-serif text-4xl leading-[1.08] text-ink text-balance md:text-5xl">
+              {config.heading}{' '}
+              <span className="italic text-terracotta">{config.headingAccent}</span>
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-muted">{config.intro}</p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Button asChild size="lg">
+                <Link to="/download/desktop">Download memrynote</Link>
+              </Button>
+              <Button asChild size="lg" variant="secondary">
+                <Link to="/pricing">See pricing</Link>
+              </Button>
+            </div>
+          </motion.div>
+        </Container>
+      </section>
+
+      <section className="py-16 zone-transition">
+        <Container size="md">
+          <motion.h2 {...REVEAL} className="display-section text-ink">
+            memrynote vs <span className="italic text-terracotta">{config.competitor}</span>
+          </motion.h2>
+
+          <motion.div {...REVEAL} className="mt-10 hidden md:block">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-ink/15">
+                  <th className="px-4 py-5 text-start font-mono-accent text-[11px] font-medium uppercase tracking-[0.18em] text-muted">
+                    Feature
+                  </th>
+                  <th className="bg-terracotta/[0.05] px-4 py-5 text-center font-serif text-lg font-normal italic text-terracotta">
+                    memrynote
+                  </th>
+                  <th className="px-4 py-5 text-center font-serif text-lg font-normal text-ink/80">
+                    {config.competitor}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {config.rows.map((row) => (
+                  <tr
+                    key={row.feature}
+                    className="border-b border-ink/10 transition-colors hover:bg-paper-alt/60"
+                  >
+                    <td className="px-4 py-4 font-serif text-base text-ink">{row.feature}</td>
+                    <td className="bg-terracotta/[0.05] px-4 py-4">
+                      <CellIcon value={row.memry} />
+                    </td>
+                    <td className="px-4 py-4">
+                      <CellIcon value={row.competitor} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </motion.div>
+
+          <div className="mt-8 space-y-3 md:hidden">
+            {config.rows.map((row) => (
+              <article key={row.feature} className="border-b border-ink/10 pb-4">
+                <h3 className="font-serif text-base leading-snug text-ink">{row.feature}</h3>
+                <div className="mt-3 grid grid-cols-2 gap-2">
+                  <div className="flex min-h-11 items-center justify-between gap-3 rounded-sm border border-terracotta/30 bg-terracotta/5 px-3 py-2">
+                    <span className="text-xs font-medium italic text-terracotta">memrynote</span>
+                    <MobileValue value={row.memry} />
+                  </div>
+                  <div className="flex min-h-11 items-center justify-between gap-3 rounded-sm border border-border/50 bg-paper/60 px-3 py-2">
+                    <span className="text-xs font-medium text-muted">{config.competitor}</span>
+                    <MobileValue value={row.competitor} />
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <p className="mx-auto mt-8 max-w-2xl text-xs leading-relaxed text-muted/60">
+            {config.footnote}
+          </p>
+        </Container>
+      </section>
+
+      <section className="py-16">
+        <Container size="md">
+          <div className="grid gap-8 sm:grid-cols-2">
+            {config.reasons.map((reason) => (
+              <motion.div key={reason.title} {...REVEAL}>
+                <h3 className="font-serif text-xl text-ink">{reason.title}</h3>
+                <p className="mt-2 leading-relaxed text-muted">{reason.body}</p>
+              </motion.div>
+            ))}
+          </div>
+        </Container>
+      </section>
+
+      <section className="py-20 zone-transition">
+        <Container size="md">
+          <motion.div {...REVEAL} className="text-center">
+            <h2 className="display-section text-ink">
+              Make the <span className="italic text-terracotta">switch.</span>
+            </h2>
+            <p className="mx-auto mt-4 max-w-md text-lg leading-relaxed text-muted">
+              Notes, tasks, calendar, and journal in one local-first app — private by design, open
+              at heart.
+            </p>
+            <div className="mt-8 flex flex-wrap justify-center gap-3">
+              <Button asChild size="lg">
+                <Link to="/download/desktop">Download memrynote</Link>
+              </Button>
+              <Button asChild size="lg" variant="secondary">
+                <Link to={`/features`}>Explore features</Link>
+              </Button>
+            </div>
+          </motion.div>
+        </Container>
+      </section>
+    </>
+  )
+}
+
+const byKey = (key: AlternativeConfig['pageKey']): AlternativeConfig => {
+  const config = ALTERNATIVES.find((c) => c.pageKey === key)
+  if (!config) throw new Error(`Missing alternative config: ${key}`)
+  return config
+}
+
+export function ObsidianAlternativePage() {
+  return <AlternativePage config={byKey('obsidianAlternative')} />
+}
+
+export function NotionAlternativePage() {
+  return <AlternativePage config={byKey('notionAlternative')} />
+}
+
+export function NotePlanAlternativePage() {
+  return <AlternativePage config={byKey('noteplanAlternative')} />
+}

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -5,12 +5,40 @@
       "*": false
     }
   },
+  "trailingSlash": false,
   "redirects": [
     {
       "source": "/:path(.*)",
       "has": [{ "type": "host", "value": "www.memrynote.com" }],
       "destination": "https://memrynote.com/:path",
       "permanent": true
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://*.paddle.com; script-src 'self' 'unsafe-inline' https://*.paddle.com https://*.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' data: https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: https:; connect-src 'self' https://*.posthog.com https://*.paddle.com; frame-src https://*.paddle.com"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+    },
+    {
+      "source": "/screenshots/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400" }]
     }
   ]
 }

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -77,6 +77,26 @@ export default defineConfig(({ mode }) => {
       alias: {
         '@': path.resolve(__dirname, './src')
       }
+    },
+    build: {
+      rollupOptions: {
+        output: {
+          // Split heavy vendors into separately-cacheable chunks. Static imports keep
+          // them in the initial graph, but immutable per-lib caching (see vercel.json)
+          // means a deploy that only touches app code reuses these from cache.
+          // ponytail: chunk grouping only; deferring these off first paint needs
+          // dynamic import() + a hydrateRoot() migration (createRoot replaces the
+          // prerendered DOM, so React.lazy would flash a fallback on direct loads).
+          manualChunks: {
+            'react-vendor': ['react', 'react-dom', 'react-router', 'react-router-dom'],
+            motion: ['framer-motion', 'lenis'],
+            paddle: ['@paddle/paddle-js'],
+            crypto: ['libsodium-wrappers-sumo'],
+            analytics: ['posthog-js'],
+            icons: ['lucide-react', '@hugeicons/react', '@hugeicons/core-free-icons']
+          }
+        }
+      }
     }
   }
 })


### PR DESCRIPTION
Resolves the findings from the memrynote.com SEO audit in a single landing-only PR.

## Critical
- **Comparison / alternative pages** (biggest organic lever): new `/obsidian-alternative`, `/notion-alternative`, `/noteplan-alternative`. Shared `AlternativePage` template + `src/lib/alternatives.ts` config (citable intro paragraph, per-competitor comparison table, reasons, CTAs). Wired into the SSG `ROUTE_MAP`, client router, sitemap (auto via `PAGE_META`), and a new footer **Compare** column so they aren't orphaned.
- **Trailing-slash duplicate content**: `trailingSlash: false` in `vercel.json` → `/x/` 308-redirects to `/x`.
- **Meta description**: re-verified — already present site-wide (the audit's "missing description" was a false negative from a line-broken grep; the tag is multiline). No change needed.

## High
- **Structured data** (`src/lib/seo.ts`): expanded home `@graph` — standalone `Organization` (logo, `sameAs`, founder `Person`), `SoftwareApplication` with `downloadUrl` / `screenshot[]` / `featureList` / `creator`+`publisher` refs / offer `availability`, and a `FAQPage` (for AI-search citation, since on-page answers live in a JS accordion). `BreadcrumbList` on every inner page via `PageHead`.
- **Security headers** (`vercel.json`): CSP, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and HSTS with `includeSubDomains; preload`.
- **JS splitting** (`vite.config.ts`): vendor `manualChunks` (react / motion / paddle / crypto / analytics / icons) for cacheable, parallel chunks.
- **Images**: `loading="lazy"` + dimensions on below-fold home images; `preconnect` for `api.fontshare.com`.
- **llms.txt**: generated at build (`buildLlmsTxt`).

## Medium / Low
- Immutable caching for `/assets/*`, 1-day for `/screenshots/*` (`vercel.json`).
- `<lastmod>` on every sitemap URL.
- `twitter:site` unified to the brand handle `@memrynote` (was `@h4yfans`; index.html already used the brand one).
- Evergreen `/download/desktop` title (drops the "end of June" date).
- Hero H1 keeps a space between its two animated lines so it extracts as "Your thoughts, beautifully organized." instead of "thoughts,beautifully".

## Intentionally omitted (would be misrepresentation)
- **`aggregateRating`** and **`softwareVersion`** on `SoftwareApplication** — no real rating source or release tag yet; fabricating either violates Google's structured-data policy. Add once a ProductHunt/App Store rating and a release tag exist.
- **WebSite `SearchAction`** — there is no site search; a pinned test (`seo.test.ts`) already asserts `potentialAction === undefined`. Add only if a real search page ships.

## Verification
- `pnpm typecheck` clean · `pnpm test` 33/33 · `pnpm build` prerenders all 28 routes incl. the 3 new pages + `llms.txt`.
- Prerendered output confirmed: full schema graph, breadcrumbs, sitemap lastmod + alt URLs, Hero space fix, brand handle.
- `pnpm lint`: 2 pre-existing errors in untouched files (`auth-context.tsx`, `Checkout.tsx`, `Pricing.tsx`) — not in this diff.

## Needs human QA before marking ready
- **CSP** is enforced and allow-lists Paddle + PostHog + fonts — verify **checkout** and analytics still work on a preview deploy before merge (revenue path). Loosen the relevant directive if anything is blocked.
- Trailing-slash redirect + headers are deploy-time (`vercel.json`) — confirm on a Vercel preview.
- Visual QA of the 3 alternative pages (and the footer's new 6-column layout) on mobile + desktop.

## Out of scope (not code — follow-ups)
- WebP conversion of the PNG screenshots (needs `cwebp`/`sharp`; the screenshots are below-fold, not LCP, so the lazy/dimension fixes here capture most of the field-CWV win).
- IndexNow key file (needs a Bing-issued key).
- Distribution: AlternativeTo / ProductHunt / Reddit / Show HN listings.