### PR TITLE
feat: link capture — capture modes + offline queue, keyboard, settings, add & open (Phase 4 + 5)

### DIFF
--- a/apps/desktop/src/main/capture/server.test.ts
+++ b/apps/desktop/src/main/capture/server.test.ts
@@ -9,6 +9,7 @@ const TOKEN = 'b'.repeat(64)
 let windowOpen = true
 const origins = new Set<string>()
 const openPairingWindowMock = vi.fn()
+const mockUnpair = vi.fn()
 vi.mock('./pairing', () => ({
   getCaptureToken: async () => TOKEN,
   isOriginAllowed: (o: string) => origins.has(o),
@@ -18,7 +19,8 @@ vi.mock('./pairing', () => ({
     if (!windowOpen) return null
     origins.add(o)
     return { token: TOKEN }
-  }
+  },
+  unpairCapture: mockUnpair
 }))
 
 async function req(port: number, path: string, init: RequestInit) {
@@ -32,6 +34,7 @@ describe('capture server', () => {
     origins.clear()
     ingestSpy.mockClear()
     openPairingWindowMock.mockClear()
+    mockUnpair.mockClear()
     const { startCaptureServer } = await import('./server')
     port = await startCaptureServer()
   })
@@ -232,6 +235,34 @@ describe('capture server', () => {
 
     await stop()
     port = await (await import('./server')).startCaptureServer()
+  })
+
+  it('revokes pairing for an authorized origin', async () => {
+    origins.add('chrome-extension://abc')
+    const res = await req(port, '/pair/revoke', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        Origin: 'chrome-extension://abc',
+        'X-Memry-Capture': '1'
+      }
+    })
+    expect(res.status).toBe(200)
+    expect(mockUnpair).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects revoke with a bad token', async () => {
+    origins.add('chrome-extension://abc')
+    const res = await req(port, '/pair/revoke', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer wrong',
+        Origin: 'chrome-extension://abc',
+        'X-Memry-Capture': '1'
+      }
+    })
+    expect(res.status).toBe(401)
+    expect(mockUnpair).not.toHaveBeenCalled()
   })
 
   it('single-pending guard: two concurrent /pair/request calls invoke consent only once', async () => {

--- a/apps/desktop/src/main/capture/server.test.ts
+++ b/apps/desktop/src/main/capture/server.test.ts
@@ -85,6 +85,43 @@ describe('capture server', () => {
     )
   })
 
+  it('passes a screenshot capture through to ingest', async () => {
+    origins.add('chrome-extension://abc')
+    const cap = await req(port, '/capture', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        Origin: 'chrome-extension://abc',
+        'X-Memry-Capture': '1',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        url: 'https://example.com/p',
+        mode: 'screenshot',
+        contentMarkdown: '',
+        excerpt: '',
+        extractionStatus: 'full',
+        properties: {
+          title: 'x',
+          source: 'https://example.com/p',
+          created: '2026-06-17T00:00:00.000Z',
+          tags: ['clippings']
+        },
+        screenshotDataUrl: 'data:image/png;base64,aGk=',
+        force: true
+      })
+    })
+    expect(cap.status).toBe(200)
+    expect(ingestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'screenshot',
+        screenshotDataUrl: 'data:image/png;base64,aGk=',
+        force: true
+      }),
+      'browser-extension'
+    )
+  })
+
   it('rejects /capture without the custom header', async () => {
     origins.add('chrome-extension://abc')
     const r = await req(port, '/capture', {

--- a/apps/desktop/src/main/capture/server.ts
+++ b/apps/desktop/src/main/capture/server.ts
@@ -2,7 +2,13 @@ import http from 'node:http'
 import { app } from 'electron'
 import { ArticleCaptureSchema } from '@memry/contracts/capture-api'
 import { ingestArticleCapture } from '../inbox/ingest'
-import { getCaptureToken, isOriginAllowed, claimPairing, openPairingWindow } from './pairing'
+import {
+  getCaptureToken,
+  isOriginAllowed,
+  claimPairing,
+  openPairingWindow,
+  unpairCapture
+} from './pairing'
 import { validateCaptureRequest } from './auth'
 import { createLogger } from '../lib/logger'
 
@@ -132,6 +138,26 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     }
     const result = await ingestArticleCapture(parsed.data, 'browser-extension')
     json(res, 200, { itemId: result.itemId })
+    return
+  }
+
+  if (req.method === 'POST' && req.url === '/pair/revoke') {
+    const token = await getCaptureToken()
+    const auth = validateCaptureRequest(
+      {
+        authorization: req.headers.authorization,
+        origin,
+        'x-memry-capture': req.headers['x-memry-capture'] as string | undefined
+      },
+      token,
+      isOriginAllowed
+    )
+    if (!auth.ok) {
+      json(res, 401, { error: auth.reason })
+      return
+    }
+    await unpairCapture()
+    json(res, 200, { ok: true })
     return
   }
 

--- a/apps/desktop/src/main/deeplink-utils.test.ts
+++ b/apps/desktop/src/main/deeplink-utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { parseInboxOpenItemId } from './deeplink-utils'
+
+describe('parseInboxOpenItemId', () => {
+  it('returns itemId from a valid memry://open?item=<id> url', () => {
+    expect(parseInboxOpenItemId('memry://open?item=abc-123')).toBe('abc-123')
+  })
+
+  it('returns null for a different hostname', () => {
+    expect(parseInboxOpenItemId('memry://pair?item=abc-123')).toBeNull()
+  })
+
+  it('returns null when the item param is missing', () => {
+    expect(parseInboxOpenItemId('memry://open')).toBeNull()
+  })
+
+  it('returns null for a non-memry protocol', () => {
+    expect(parseInboxOpenItemId('https://open?item=abc-123')).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/deeplink-utils.ts
+++ b/apps/desktop/src/main/deeplink-utils.ts
@@ -1,0 +1,9 @@
+export function parseInboxOpenItemId(url: string): string | null {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'memry:' || parsed.hostname !== 'open') return null
+    return parsed.searchParams.get('item')
+  } catch {
+    return null
+  }
+}

--- a/apps/desktop/src/main/inbox/filing.test.ts
+++ b/apps/desktop/src/main/inbox/filing.test.ts
@@ -98,8 +98,38 @@ import {
   convertToTask,
   linkToNote,
   linkToNotes,
-  bulkFileToFolder
+  bulkFileToFolder,
+  generateNoteContent
 } from './filing'
+
+describe('generateNoteContent', () => {
+  it('resolves a vault-relative screenshot embed in a link body to a memry-file URL', () => {
+    const item = {
+      type: 'link',
+      sourceUrl: 'https://example.com/p',
+      title: 'Example',
+      content: '![screenshot](attachments/inbox/cap-1/screenshot.png)',
+      metadata: { extractionStatus: 'full' }
+    } as unknown as Parameters<typeof generateNoteContent>[0]
+
+    const content = generateNoteContent(item)
+
+    expect(content).toContain('![screenshot](memry-file://attachments/inbox/cap-1/screenshot.png)')
+    expect(content).not.toContain('![screenshot](attachments/inbox/cap-1/screenshot.png)')
+  })
+
+  it('leaves http(s) article images untouched', () => {
+    const item = {
+      type: 'link',
+      sourceUrl: 'https://example.com/p',
+      title: 'Example',
+      content: 'Intro\n\n![hero](https://cdn.example.com/a.png)',
+      metadata: { extractionStatus: 'full' }
+    } as unknown as Parameters<typeof generateNoteContent>[0]
+
+    expect(generateNoteContent(item)).toContain('![hero](https://cdn.example.com/a.png)')
+  })
+})
 
 describe('Inbox Filing Operations', () => {
   let testDb: TestDatabaseResult

--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -240,6 +240,17 @@ function getFiledBinaryFilename(item: InboxItemRow): string {
   return `${sanitizeFiledVoiceFilenameBase(generateNoteTitle(item))}${extension}`
 }
 
+// Inbox screenshot/clip bodies embed images by their vault-relative attachment
+// path (e.g. attachments/inbox/<id>/screenshot.png). The note editor only renders
+// the memry-file:// protocol, so resolve those paths the same way thumbnails are
+// resolved below. http(s) article images are left untouched.
+function resolveInlineAttachmentPaths(markdown: string): string {
+  return markdown.replace(/!\[([^\]]*)\]\((attachments\/[^)\s]+)\)/g, (match, alt, relPath) => {
+    const url = resolveAttachmentUrl(relPath)
+    return url ? `![${alt}](${url})` : match
+  })
+}
+
 /**
  * Generate note content based on inbox item type
  */
@@ -250,7 +261,7 @@ export function generateNoteContent(item: InboxItemRow): string {
   switch (item.type) {
     case 'link': {
       const url = item.sourceUrl || ''
-      const description = item.content || ''
+      const description = resolveInlineAttachmentPaths(item.content || '')
       const metadata = item.metadata as Record<string, unknown> | null
       const title = item.title || ''
       const domain = url ? extractDomain(url) : ''

--- a/apps/desktop/src/main/inbox/ingest.ts
+++ b/apps/desktop/src/main/inbox/ingest.ts
@@ -10,7 +10,8 @@ import { createLogger } from '../lib/logger'
 import { publishProjectionEvent } from '../projections'
 import { insertItemWithTags, emitCapturedAndSync } from './domain'
 import { downloadImage } from './metadata'
-import { getItemAttachmentsDir } from './attachments'
+import { getItemAttachmentsDir, storeInboxAttachment } from './attachments'
+import { parseDataUrl } from './parse-data-url'
 
 const log = createLogger('Inbox:Ingest')
 
@@ -84,14 +85,32 @@ export async function ingestArticleCapture(
   const id = generateId()
   const now = new Date().toISOString()
   const tags = input.tags ?? input.properties.tags ?? []
-  const thumbnailPath = await downloadHero(id, input.heroImage)
+
+  // Screenshot mode: decode the data URL into an inbox attachment and make the
+  // image the note body. The extension sends contentMarkdown:'' for screenshots.
+  let content = input.contentMarkdown
+  let screenshotPath: string | null = null
+  if (input.screenshotDataUrl) {
+    const parsed = parseDataUrl(input.screenshotDataUrl)
+    if (parsed) {
+      const stored = await storeInboxAttachment(id, parsed.buffer, 'screenshot', parsed.mime)
+      if (stored.success && stored.path) {
+        screenshotPath = stored.path
+        content = `![screenshot](${stored.path})`
+      } else {
+        log.warn('screenshot attachment failed', { itemId: id, error: stored.error })
+      }
+    }
+  }
+
+  const thumbnailPath = screenshotPath ?? (await downloadHero(id, input.heroImage))
   const { row, tags: appliedTags } = insertItemWithTags(
     db,
     {
       id,
       type: input.itemType ?? 'link',
       title: input.properties.title,
-      content: input.contentMarkdown,
+      content,
       sourceUrl: input.url,
       thumbnailPath,
       createdAt: now,

--- a/apps/desktop/src/main/inbox/parse-data-url.test.ts
+++ b/apps/desktop/src/main/inbox/parse-data-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { parseDataUrl } from './parse-data-url'
+
+describe('parseDataUrl', () => {
+  it('decodes a base64 png data URL', () => {
+    // "hi" base64 = aGk=
+    const r = parseDataUrl('data:image/png;base64,aGk=')
+    expect(r).not.toBeNull()
+    expect(r?.mime).toBe('image/png')
+    expect(r?.buffer.toString('utf8')).toBe('hi')
+  })
+
+  it('returns null for a non-data string', () => {
+    expect(parseDataUrl('https://example.com/x.png')).toBeNull()
+  })
+
+  it('returns null for a data URL that is not base64', () => {
+    expect(parseDataUrl('data:image/png,plain')).toBeNull()
+  })
+
+  it('returns null for an empty payload', () => {
+    expect(parseDataUrl('data:image/png;base64,')).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/inbox/parse-data-url.ts
+++ b/apps/desktop/src/main/inbox/parse-data-url.ts
@@ -1,0 +1,11 @@
+// Parse a base64 data URL ("data:<mime>;base64,<payload>") into its MIME type
+// and decoded bytes. Returns null for anything that is not a non-empty base64
+// data URL (callers fall through to leaving the capture image-less).
+export function parseDataUrl(input: string): { mime: string; buffer: Buffer } | null {
+  const match = /^data:([a-z0-9.+/-]+);base64,(.+)$/i.exec(input.trim())
+  if (!match) return null
+  const mime = match[1].toLowerCase()
+  const buffer = Buffer.from(match[2], 'base64')
+  if (buffer.length === 0) return null
+  return { mime, buffer }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -69,7 +69,8 @@ import { getIndexDatabase } from './database/client'
 import { toAbsolutePath, createSnapshot } from './vault/notes'
 import { safeRead } from './vault/file-ops'
 import { SnapshotReasons } from '@memry/db-schema/schema/notes-cache'
-import { SettingsChannels } from '@memry/contracts/ipc-channels'
+import { SettingsChannels, InboxChannels } from '@memry/contracts/ipc-channels'
+import { parseInboxOpenItemId } from './deeplink-utils'
 import { initializeUpdater, isQuitAndInstallRequested, performQuitAndInstall } from './updater'
 import { buildAppMenu, buildEditableTextContextMenu } from './menu'
 import { setMainI18n } from './lib/main-i18n'
@@ -535,6 +536,8 @@ function handleDeepLink(url: string): void {
     if (parsed.hostname === 'open') {
       // launch/focus only — no dialog. Restore+focus happens below for any memry:// url.
       deepLinkLog.info('launch requested via memry://open')
+      const itemId = parseInboxOpenItemId(url)
+      if (itemId) mainWindow.webContents.send(InboxChannels.events.OPEN_ITEM, itemId)
     }
 
     if (parsed.hostname === 'billing') {

--- a/apps/desktop/src/preload/generated-rpc.ts
+++ b/apps/desktop/src/preload/generated-rpc.ts
@@ -30,6 +30,7 @@ const eventChannels = {
   "onInboxTranscriptionComplete": "inbox:transcription-complete",
   "onInboxMetadataComplete": "inbox:metadata-complete",
   "onInboxProcessingError": "inbox:processing-error",
+  "onInboxOpenItem": "inbox:open-item",
   "onSettingsChanged": "settings:changed",
   "onEmbeddingProgress": "settings:embeddingProgress",
   "onVoiceModelProgress": "settings:voiceModelProgress",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -302,6 +302,22 @@ const AppContent = (): React.JSX.Element => {
     })
   }, [openSettings])
 
+  useEffect(() => {
+    return window.api.onInboxOpenItem((itemId) => {
+      openTab({
+        type: 'inbox',
+        title: 'Inbox',
+        icon: 'inbox',
+        path: '/inbox',
+        isPinned: false,
+        isModified: false,
+        isPreview: false,
+        isDeleted: false,
+        viewState: { focusInboxItemId: itemId, focusedAt: Date.now() }
+      })
+    })
+  }, [openTab])
+
   return (
     <TabDragProvider>
       <AgentTabTitleSync />

--- a/apps/docs/src/user-guide/inbox/capturing.md
+++ b/apps/docs/src/user-guide/inbox/capturing.md
@@ -57,14 +57,52 @@ If voice transcription setup is incomplete, memrynote takes you to AI settings b
 
 ## Web Clips and Browser Extension
 
-When the browser extension (or quick-share integrations) are available, sharing a page from your browser creates an inbox item with:
+The memrynote browser extension captures the page you're reading straight into your inbox. Web clips
+appear under the **clips** content type filter.
 
-- The page title
-- The source URL
-- A snippet or selected text
-- Sometimes a screenshot
+### Pairing
 
-Web clips appear under the **clips** content type filter.
+The extension talks to the desktop app over a local loopback connection — nothing leaves your
+machine. The first capture prompts memrynote to show an **Allow / Deny** pairing dialog; approving it
+issues the extension a token. Until paired, the popup shows a needs-pairing state.
+
+### Capture modes
+
+The popup offers three ways to grab a page:
+
+- **Article** — the readable main content, stripped of navigation and ads (the default).
+- **Selection** — only the text you've highlighted on the page.
+- **Screenshot** — a stitched full-page image, captured by scrolling the page.
+
+Article and Selection land as text; Screenshot lands as an image attachment.
+
+### Keyboard shortcut
+
+Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> on
+macOS) to capture the current page in Article mode without opening the popup. A brief ✓ badge
+confirms the save. Rebind it at `chrome://extensions/shortcuts` if it collides with another
+extension. (The shortcut is Article-only — Selection and Screenshot need the popup.)
+
+### Offline queue
+
+If memrynote is closed when you capture, the clip is saved to a local queue instead of being lost.
+The toolbar badge shows the pending count. The extension retries about once a minute and, the moment
+memrynote is open again, the queued clips sync into your inbox and the badge clears. The popup shows
+"Saved offline" so you know it's queued, not dropped.
+
+### Add & open
+
+The popup's **Add & open in Memry** button captures the page and then jumps straight to the new item
+in memrynote's inbox. (When memrynote is closed the capture queues instead, and the open is skipped —
+there's nothing to open yet.)
+
+### Settings
+
+Open the extension's options page (right-click the toolbar icon → **Options**) to:
+
+- **Re-pair** or **Unpair** the extension (unpair clears the local token even if memrynote is closed).
+- **Rotate token** — revoke and immediately re-pair to mint a fresh token.
+- **Port override** — leave blank to auto-detect (ports 7849–7856), or pin a specific port.
 
 Link metadata scraping runs when a capture or preview needs it. The desktop app keeps the heavier
 metadata scraper out of the cold inbox startup path so opening a vault does not load web-preview

--- a/apps/extension/src/components/ModeSegmented.tsx
+++ b/apps/extension/src/components/ModeSegmented.tsx
@@ -1,20 +1,31 @@
-const MODES = [
-  { id: 'article', label: 'Article', enabled: true },
-  { id: 'selection', label: 'Selection', enabled: false },
-  { id: 'shot', label: 'Shot', enabled: false }
-] as const
+import type { CaptureMode } from '@/lib/messages'
 
-export function ModeSegmented() {
+const MODES: { id: CaptureMode; label: string }[] = [
+  { id: 'article', label: 'Article' },
+  { id: 'selection', label: 'Selection' },
+  { id: 'screenshot', label: 'Shot' }
+]
+
+export function ModeSegmented({
+  mode,
+  disabled,
+  onSelect
+}: {
+  mode: CaptureMode
+  disabled: boolean
+  onSelect: (mode: CaptureMode) => void
+}) {
   return (
     <div className="flex gap-1 rounded-md bg-surface p-1">
       {MODES.map((m) => (
         <button
           key={m.id}
           type="button"
-          disabled={!m.enabled}
+          disabled={disabled}
+          onClick={() => onSelect(m.id)}
           className={
-            'flex-1 rounded px-2 py-1 text-[12px] font-medium transition-colors ' +
-            (m.id === 'article' ? 'bg-background text-foreground shadow-sm' : 'text-text-tertiary')
+            'flex-1 rounded px-2 py-1 text-[12px] font-medium transition-colors disabled:opacity-50 ' +
+            (m.id === mode ? 'bg-background text-foreground shadow-sm' : 'text-text-tertiary')
           }
         >
           {m.label}

--- a/apps/extension/src/components/ScreenshotPreview.tsx
+++ b/apps/extension/src/components/ScreenshotPreview.tsx
@@ -1,0 +1,11 @@
+export function ScreenshotPreview({ dataUrl }: { dataUrl: string }) {
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-surface">
+      <img
+        src={dataUrl}
+        alt="Page screenshot"
+        className="max-h-48 w-full object-contain object-top"
+      />
+    </div>
+  )
+}

--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -1,5 +1,6 @@
 import type {
   CaptureResponse,
+  ExtractResponse,
   FlushResponse,
   PageMetrics,
   PairResponse,
@@ -129,6 +130,10 @@ async function setBadge(count: number): Promise<void> {
   if (count > 0) await browser.action.setBadgeBackgroundColor({ color: '#E56458' })
 }
 
+async function restoreQueueBadge(): Promise<void> {
+  await setBadge((await readQueue()).length)
+}
+
 async function ensureFlushAlarm(): Promise<void> {
   const existing = await browser.alarms.get(FLUSH_ALARM)
   if (!existing) await browser.alarms.create(FLUSH_ALARM, { periodInMinutes: 1 })
@@ -216,6 +221,31 @@ export default defineBackground(() => {
 
   browser.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === FLUSH_ALARM) void flushQueue()
+  })
+
+  browser.commands.onCommand.addListener(async (command) => {
+    if (command !== 'capture-page') return
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true })
+    if (!tab?.id) return
+    // The content script is declared on *://*/* and auto-injected, so messaging
+    // it needs no activeTab grant. It is absent on chrome://, the Web Store, and
+    // PDFs — sendMessage rejects there, which we surface as a brief error badge.
+    const extracted: ExtractResponse = await browser.tabs
+      .sendMessage(tab.id, { type: 'EXTRACT' })
+      .catch(() => ({ ok: false, error: 'no-content-script' }))
+    if (!extracted.ok) {
+      await browser.action.setBadgeText({ text: '!' })
+      await browser.action.setBadgeBackgroundColor({ color: '#E56458' })
+      setTimeout(() => void restoreQueueBadge(), 2000)
+      return
+    }
+    const res = await captureOrQueue(extracted.capture)
+    if (res.ok) {
+      await browser.action.setBadgeText({ text: '✓' })
+      await browser.action.setBadgeBackgroundColor({ color: '#3B873E' })
+      setTimeout(() => void restoreQueueBadge(), 2000)
+    }
+    // A queued save already set the count badge inside captureOrQueue.
   })
 
   // Restore the badge + retry alarm whenever the service worker (re)starts.

--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -57,7 +57,9 @@ async function capture(body: ArticleCapture): Promise<CaptureResponse> {
   return postCapture(found.port, token, body)
 }
 
-const MAX_SHOT_HEIGHT = 15000 // ponytail: cap full-page height so the PNG stays under /capture's 25MB cap
+// ponytail: best-effort cap on full-page height; very tall photo-heavy pages may still exceed
+// /capture's 25MB body cap (base64 inflates the bytes) and 413. Upgrade path: downscale or JPEG-encode.
+const MAX_SHOT_HEIGHT = 15000
 const SETTLE_MS = 400 // wait between scroll and capture; also honors captureVisibleTab's ~2/sec limit
 
 function sleep(ms: number): Promise<void> {
@@ -72,7 +74,8 @@ async function grabScreenshot(): Promise<ScreenshotResponse> {
   try {
     const metrics = (await browser.tabs.sendMessage(tabId, {
       type: 'GET_PAGE_METRICS'
-    })) as PageMetrics
+    })) as PageMetrics | undefined
+    if (!metrics) return { ok: false, error: 'no-metrics' }
     const plan = planStitch({ ...metrics, maxHeight: MAX_SHOT_HEIGHT })
     const canvas = new OffscreenCanvas(plan.width, plan.height)
     const ctx = canvas.getContext('2d')

--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -9,7 +9,15 @@ import type {
   StatusResponse
 } from '@/lib/messages'
 import type { ArticleCapture } from '@memry/article-extract'
-import { claimToken, pollUntil, postCapture, probeServer, requestPair } from '@/lib/capture-client'
+import {
+  claimToken,
+  pollUntil,
+  postCapture,
+  postRevoke,
+  PROBE_PORTS,
+  probeServer,
+  requestPair
+} from '@/lib/capture-client'
 import { bytesToDataUrl, planStitch } from '@/lib/capture-modes'
 import {
   badgeText,
@@ -31,8 +39,30 @@ async function setToken(token: string): Promise<void> {
   await browser.storage.local.set({ [TOKEN_KEY]: token })
 }
 
+const PORT_KEY = 'memry:capture-port'
+
+async function getOverridePort(): Promise<number | null> {
+  const r = await browser.storage.local.get(PORT_KEY)
+  const v = r[PORT_KEY]
+  return typeof v === 'number' && Number.isInteger(v) ? v : null
+}
+
+// Probe the override port first (if set), then the default range.
+async function probe(): Promise<Awaited<ReturnType<typeof probeServer>>> {
+  const override = await getOverridePort()
+  return override ? probeServer(fetch, [override, ...PROBE_PORTS]) : probeServer()
+}
+
+async function revoke(): Promise<{ ok: boolean }> {
+  const found = await probe()
+  const token = await getToken()
+  if (found && token) await postRevoke(found.port, token)
+  await browser.storage.local.remove(TOKEN_KEY)
+  return { ok: true }
+}
+
 async function getStatus(): Promise<StatusResponse> {
-  const found = await probeServer()
+  const found = await probe()
   if (!found) return { connection: 'app-closed', port: null }
   const token = await getToken()
   if (found.ping.paired && token) return { connection: 'ready', port: found.port }
@@ -40,7 +70,7 @@ async function getStatus(): Promise<StatusResponse> {
 }
 
 async function pair(): Promise<PairResponse> {
-  const found = await probeServer()
+  const found = await probe()
   if (!found) return { ok: false }
   const status = await requestPair(found.port)
   if (status === 'error') return { ok: false }
@@ -59,7 +89,7 @@ async function waitForServer(): Promise<{ ok: boolean }> {
 }
 
 async function capture(body: ArticleCapture): Promise<CaptureResponse> {
-  const found = await probeServer()
+  const found = await probe()
   if (!found) return { ok: false, error: 'app-closed' }
   const token = await getToken()
   if (!token) return { ok: false, error: 'bad-token' }
@@ -152,7 +182,7 @@ async function flushQueue(): Promise<FlushResponse> {
     await stopFlushAlarm()
     return { flushed: 0, remaining: 0 }
   }
-  const found = await probeServer()
+  const found = await probe()
   const token = await getToken()
   if (!found || !token) return { flushed: 0, remaining: queue.length }
   let flushed = 0
@@ -214,6 +244,8 @@ export default defineBackground(() => {
         return grabScreenshot()
       case 'FLUSH_QUEUE':
         return flushQueue()
+      case 'REVOKE':
+        return revoke()
       default:
         return undefined
     }

--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -1,6 +1,14 @@
-import type { CaptureResponse, PairResponse, PopupMessage, StatusResponse } from '@/lib/messages'
+import type {
+  CaptureResponse,
+  PageMetrics,
+  PairResponse,
+  PopupMessage,
+  ScreenshotResponse,
+  StatusResponse
+} from '@/lib/messages'
 import type { ArticleCapture } from '@memry/article-extract'
 import { claimToken, pollUntil, postCapture, probeServer, requestPair } from '@/lib/capture-client'
+import { bytesToDataUrl, planStitch } from '@/lib/capture-modes'
 
 const TOKEN_KEY = 'memry:capture-token'
 
@@ -49,6 +57,49 @@ async function capture(body: ArticleCapture): Promise<CaptureResponse> {
   return postCapture(found.port, token, body)
 }
 
+const MAX_SHOT_HEIGHT = 15000 // ponytail: cap full-page height so the PNG stays under /capture's 25MB cap
+const SETTLE_MS = 400 // wait between scroll and capture; also honors captureVisibleTab's ~2/sec limit
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+async function grabScreenshot(): Promise<ScreenshotResponse> {
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true })
+  if (!tab?.id || tab.windowId == null) return { ok: false, error: 'no-tab' }
+  const tabId = tab.id
+  const windowId = tab.windowId
+  try {
+    const metrics = (await browser.tabs.sendMessage(tabId, {
+      type: 'GET_PAGE_METRICS'
+    })) as PageMetrics
+    const plan = planStitch({ ...metrics, maxHeight: MAX_SHOT_HEIGHT })
+    const canvas = new OffscreenCanvas(plan.width, plan.height)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return { ok: false, error: 'no-canvas' }
+    try {
+      for (const slice of plan.slices) {
+        await browser.tabs.sendMessage(tabId, { type: 'SCROLL_TO', y: slice.scrollY })
+        await sleep(SETTLE_MS)
+        const shot = await browser.tabs.captureVisibleTab(windowId, { format: 'png' })
+        const bmp = await createImageBitmap(await (await fetch(shot)).blob())
+        ctx.drawImage(bmp, 0, slice.drawY)
+        bmp.close()
+      }
+    } finally {
+      // Always restore the user's scroll position, even if a capture threw.
+      await browser.tabs
+        .sendMessage(tabId, { type: 'SCROLL_TO', y: metrics.scrollY })
+        .catch(() => {})
+    }
+    const blob = await canvas.convertToBlob({ type: 'image/png' })
+    const bytes = new Uint8Array(await blob.arrayBuffer())
+    return { ok: true, dataUrl: bytesToDataUrl(bytes, 'image/png') }
+  } catch (err) {
+    return { ok: false, error: String(err) }
+  }
+}
+
 export default defineBackground(() => {
   browser.runtime.onMessage.addListener((message: PopupMessage) => {
     // Returning a Promise responds asynchronously (webextension-polyfill).
@@ -61,6 +112,8 @@ export default defineBackground(() => {
         return capture(message.capture)
       case 'WAIT_FOR_SERVER':
         return waitForServer()
+      case 'GRAB_SCREENSHOT':
+        return grabScreenshot()
       default:
         return undefined
     }

--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -1,5 +1,6 @@
 import type {
   CaptureResponse,
+  FlushResponse,
   PageMetrics,
   PairResponse,
   PopupMessage,
@@ -9,6 +10,13 @@ import type {
 import type { ArticleCapture } from '@memry/article-extract'
 import { claimToken, pollUntil, postCapture, probeServer, requestPair } from '@/lib/capture-client'
 import { bytesToDataUrl, planStitch } from '@/lib/capture-modes'
+import {
+  badgeText,
+  dequeueById,
+  enqueue,
+  isRetryable,
+  type QueuedCapture
+} from '@/lib/capture-queue'
 
 const TOKEN_KEY = 'memry:capture-token'
 
@@ -103,22 +111,117 @@ async function grabScreenshot(): Promise<ScreenshotResponse> {
   }
 }
 
+const QUEUE_KEY = 'memry:capture-queue'
+const FLUSH_ALARM = 'memry-flush'
+
+async function readQueue(): Promise<QueuedCapture[]> {
+  const r = await browser.storage.local.get(QUEUE_KEY)
+  const v = r[QUEUE_KEY]
+  return Array.isArray(v) ? (v as QueuedCapture[]) : []
+}
+
+async function writeQueue(queue: QueuedCapture[]): Promise<void> {
+  await browser.storage.local.set({ [QUEUE_KEY]: queue })
+}
+
+async function setBadge(count: number): Promise<void> {
+  await browser.action.setBadgeText({ text: badgeText(count) })
+  if (count > 0) await browser.action.setBadgeBackgroundColor({ color: '#E56458' })
+}
+
+async function ensureFlushAlarm(): Promise<void> {
+  const existing = await browser.alarms.get(FLUSH_ALARM)
+  if (!existing) await browser.alarms.create(FLUSH_ALARM, { periodInMinutes: 1 })
+}
+
+async function stopFlushAlarm(): Promise<void> {
+  await browser.alarms.clear(FLUSH_ALARM)
+}
+
+// Try the live server once and drain queued items oldest-first. Drop on success
+// or permanent failure; stop the pass (keep the rest) the moment the server is
+// unreachable again.
+async function flushQueue(): Promise<FlushResponse> {
+  let queue = await readQueue()
+  if (queue.length === 0) {
+    await stopFlushAlarm()
+    return { flushed: 0, remaining: 0 }
+  }
+  const found = await probeServer()
+  const token = await getToken()
+  if (!found || !token) return { flushed: 0, remaining: queue.length }
+  let flushed = 0
+  for (const item of [...queue]) {
+    const res = await postCapture(found.port, token, item.capture)
+    if (res.ok) {
+      queue = dequeueById(queue, item.id)
+      flushed++
+    } else if (isRetryable(res.error)) {
+      break
+    } else {
+      console.warn('[memry] dropping unsendable queued capture', item.id, res.error)
+      queue = dequeueById(queue, item.id)
+    }
+  }
+  await writeQueue(queue)
+  await setBadge(queue.length)
+  if (queue.length === 0) await stopFlushAlarm()
+  return { flushed, remaining: queue.length }
+}
+
+// Capture, or queue it for retry when the server is unreachable. Permanent
+// errors (bad token, invalid payload) pass straight through to the popup.
+async function captureOrQueue(body: ArticleCapture): Promise<CaptureResponse> {
+  const res = await capture(body)
+  if (res.ok) {
+    void flushQueue()
+    return res
+  }
+  if (isRetryable(res.error)) {
+    const queue = enqueue(await readQueue(), {
+      id: crypto.randomUUID(),
+      capture: body,
+      queuedAt: Date.now()
+    })
+    await writeQueue(queue)
+    await setBadge(queue.length)
+    await ensureFlushAlarm()
+    return { ok: false, error: 'queued' }
+  }
+  return res
+}
+
 export default defineBackground(() => {
   browser.runtime.onMessage.addListener((message: PopupMessage) => {
-    // Returning a Promise responds asynchronously (webextension-polyfill).
     switch (message.type) {
       case 'GET_STATUS':
-        return getStatus()
+        return getStatus().then((status) => {
+          if (status.connection === 'ready') void flushQueue()
+          return status
+        })
       case 'PAIR':
         return pair()
       case 'CAPTURE':
-        return capture(message.capture)
+        return captureOrQueue(message.capture)
       case 'WAIT_FOR_SERVER':
         return waitForServer()
       case 'GRAB_SCREENSHOT':
         return grabScreenshot()
+      case 'FLUSH_QUEUE':
+        return flushQueue()
       default:
         return undefined
     }
   })
+
+  browser.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === FLUSH_ALARM) void flushQueue()
+  })
+
+  // Restore the badge + retry alarm whenever the service worker (re)starts.
+  void (async () => {
+    const queue = await readQueue()
+    await setBadge(queue.length)
+    if (queue.length > 0) await ensureFlushAlarm()
+  })()
 })

--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -145,6 +145,8 @@ async function grabScreenshot(): Promise<ScreenshotResponse> {
 const QUEUE_KEY = 'memry:capture-queue'
 const FLUSH_ALARM = 'memry-flush'
 
+let flushing: Promise<FlushResponse> | null = null
+
 async function readQueue(): Promise<QueuedCapture[]> {
   const r = await browser.storage.local.get(QUEUE_KEY)
   const v = r[QUEUE_KEY]
@@ -176,32 +178,40 @@ async function stopFlushAlarm(): Promise<void> {
 // Try the live server once and drain queued items oldest-first. Drop on success
 // or permanent failure; stop the pass (keep the rest) the moment the server is
 // unreachable again.
-async function flushQueue(): Promise<FlushResponse> {
-  let queue = await readQueue()
-  if (queue.length === 0) {
-    await stopFlushAlarm()
-    return { flushed: 0, remaining: 0 }
-  }
-  const found = await probe()
-  const token = await getToken()
-  if (!found || !token) return { flushed: 0, remaining: queue.length }
-  let flushed = 0
-  for (const item of [...queue]) {
-    const res = await postCapture(found.port, token, item.capture)
-    if (res.ok) {
-      queue = dequeueById(queue, item.id)
-      flushed++
-    } else if (isRetryable(res.error)) {
-      break
-    } else {
-      console.warn('[memry] dropping unsendable queued capture', item.id, res.error)
-      queue = dequeueById(queue, item.id)
+// Re-entrancy guard: concurrent callers share ONE in-flight flush pass so the
+// same queued item is never POSTed twice.
+function flushQueue(): Promise<FlushResponse> {
+  if (flushing) return flushing
+  flushing = (async (): Promise<FlushResponse> => {
+    let queue = await readQueue()
+    if (queue.length === 0) {
+      await stopFlushAlarm()
+      return { flushed: 0, remaining: 0 }
     }
-  }
-  await writeQueue(queue)
-  await setBadge(queue.length)
-  if (queue.length === 0) await stopFlushAlarm()
-  return { flushed, remaining: queue.length }
+    const found = await probe()
+    const token = await getToken()
+    if (!found || !token) return { flushed: 0, remaining: queue.length }
+    let flushed = 0
+    for (const item of [...queue]) {
+      const res = await postCapture(found.port, token, item.capture)
+      if (res.ok) {
+        queue = dequeueById(queue, item.id)
+        flushed++
+      } else if (isRetryable(res.error)) {
+        break
+      } else {
+        console.warn('[memry] dropping unsendable queued capture', item.id, res.error)
+        queue = dequeueById(queue, item.id)
+      }
+    }
+    await writeQueue(queue)
+    await setBadge(queue.length)
+    if (queue.length === 0) await stopFlushAlarm()
+    return { flushed, remaining: queue.length }
+  })().finally(() => {
+    flushing = null
+  })
+  return flushing
 }
 
 // Capture, or queue it for retry when the server is unreachable. Permanent

--- a/apps/extension/src/entrypoints/content.ts
+++ b/apps/extension/src/entrypoints/content.ts
@@ -1,17 +1,59 @@
-import type { ContentMessage, ExtractResponse } from '@/lib/messages'
+import type { ContentMessage, ExtractResponse, PageMetrics } from '@/lib/messages'
 import { extractFromDocument } from '@memry/article-extract/browser'
+import { toSelectionCapture } from '@/lib/capture-modes'
+
+function grabSelection(): ExtractResponse {
+  const sel = window.getSelection()
+  if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+    return { ok: false, error: 'no-selection' }
+  }
+  // ponytail: first range only — multi-range (Ctrl-click) selections are rare;
+  // upgrade path = concat cloneContents() of every range.
+  const fragment = sel.getRangeAt(0).cloneContents()
+  const doc = document.implementation.createHTMLDocument(document.title)
+  doc.body.appendChild(fragment)
+  const base = extractFromDocument(doc, location.href)
+  return { ok: true, capture: toSelectionCapture(base, sel.toString(), document.title) }
+}
+
+function pageMetrics(): PageMetrics {
+  return {
+    scrollHeight: document.documentElement.scrollHeight,
+    innerHeight: window.innerHeight,
+    innerWidth: window.innerWidth,
+    dpr: window.devicePixelRatio || 1,
+    scrollY: window.scrollY
+  }
+}
 
 export default defineContentScript({
   // ponytail: declared on all web pages (standard clipper pattern); inert until messaged.
   matches: ['*://*/*'],
   main() {
-    browser.runtime.onMessage.addListener((message: ContentMessage): Promise<ExtractResponse> => {
-      if (message.type !== 'EXTRACT')
-        return Promise.resolve({ ok: false, error: 'unknown-message' })
-      try {
-        return Promise.resolve({ ok: true, capture: extractFromDocument(document, location.href) })
-      } catch (err) {
-        return Promise.resolve({ ok: false, error: String(err) })
+    browser.runtime.onMessage.addListener((message: ContentMessage) => {
+      switch (message.type) {
+        case 'EXTRACT':
+          try {
+            return Promise.resolve<ExtractResponse>({
+              ok: true,
+              capture: extractFromDocument(document, location.href)
+            })
+          } catch (err) {
+            return Promise.resolve<ExtractResponse>({ ok: false, error: String(err) })
+          }
+        case 'GRAB_SELECTION':
+          try {
+            return Promise.resolve(grabSelection())
+          } catch (err) {
+            return Promise.resolve<ExtractResponse>({ ok: false, error: String(err) })
+          }
+        case 'GET_PAGE_METRICS':
+          return Promise.resolve(pageMetrics())
+        case 'SCROLL_TO':
+          window.scrollTo(0, message.y)
+          return Promise.resolve({ ok: true })
+        default:
+          return Promise.resolve<ExtractResponse>({ ok: false, error: 'unknown-message' })
       }
     })
   }

--- a/apps/extension/src/entrypoints/options/App.tsx
+++ b/apps/extension/src/entrypoints/options/App.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react'
+import type { ConnectionState, PairResponse, StatusResponse } from '@/lib/messages'
+
+const PORT_KEY = 'memry:capture-port'
+
+export default function App() {
+  const [connection, setConnection] = useState<'unknown' | ConnectionState>('unknown')
+  const [port, setPort] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const refresh = () =>
+    browser.runtime
+      .sendMessage({ type: 'GET_STATUS' })
+      .then((r: StatusResponse) => setConnection(r.connection))
+      .catch(() => setConnection('app-closed'))
+
+  useEffect(() => {
+    void refresh()
+    browser.storage.local.get(PORT_KEY).then((r) => {
+      const v = r[PORT_KEY]
+      if (typeof v === 'number') setPort(String(v))
+    })
+  }, [])
+
+  const onPair = async () => {
+    setBusy(true)
+    const r: PairResponse = await browser.runtime.sendMessage({ type: 'PAIR' }).catch(() => ({
+      ok: false
+    }))
+    setBusy(false)
+    if (r.ok) void refresh()
+  }
+
+  const onUnpair = async () => {
+    setBusy(true)
+    await browser.runtime.sendMessage({ type: 'REVOKE' }).catch(() => {})
+    setBusy(false)
+    void refresh()
+  }
+
+  const onRotate = async () => {
+    await onUnpair()
+    await onPair()
+  }
+
+  const onSavePort = async () => {
+    const n = parseInt(port, 10)
+    if (port.trim() === '' || Number.isNaN(n)) {
+      await browser.storage.local.remove(PORT_KEY)
+    } else {
+      await browser.storage.local.set({ [PORT_KEY]: n })
+    }
+    void refresh()
+  }
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col gap-6 bg-background p-6 font-sans text-foreground">
+      <h1 className="text-lg font-semibold">Memry Web Clipper</h1>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Pairing</h2>
+        <p className="text-[13px] text-text-secondary">Status: {connection}</p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onPair}
+            className="rounded bg-primary px-3 py-1.5 text-[13px] text-primary-foreground disabled:opacity-50"
+          >
+            Re-pair
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onRotate}
+            className="rounded border border-border px-3 py-1.5 text-[13px] disabled:opacity-50"
+          >
+            Rotate token
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onUnpair}
+            className="rounded border border-border px-3 py-1.5 text-[13px] disabled:opacity-50"
+          >
+            Unpair
+          </button>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Port override</h2>
+        <p className="text-[13px] text-text-secondary">
+          Leave blank to auto-detect (ports 7849–7856).
+        </p>
+        <div className="flex gap-2">
+          <input
+            value={port}
+            onChange={(e) => setPort(e.target.value)}
+            inputMode="numeric"
+            placeholder="auto"
+            className="w-24 rounded border border-border bg-surface px-2 py-1 text-[13px]"
+          />
+          <button
+            type="button"
+            onClick={onSavePort}
+            className="rounded border border-border px-3 py-1.5 text-[13px]"
+          >
+            Save
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/extension/src/entrypoints/options/App.tsx
+++ b/apps/extension/src/entrypoints/options/App.tsx
@@ -39,8 +39,16 @@ export default function App() {
   }
 
   const onRotate = async () => {
-    await onUnpair()
-    await onPair()
+    setBusy(true)
+    try {
+      await browser.runtime.sendMessage({ type: 'REVOKE' }).catch(() => {})
+      const r: PairResponse = await browser.runtime
+        .sendMessage({ type: 'PAIR' })
+        .catch(() => ({ ok: false }))
+      if (r.ok) void refresh()
+    } finally {
+      setBusy(false)
+    }
   }
 
   const onSavePort = async () => {

--- a/apps/extension/src/entrypoints/options/index.html
+++ b/apps/extension/src/entrypoints/options/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Memry Web Clipper — Settings</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/extension/src/entrypoints/options/main.tsx
+++ b/apps/extension/src/entrypoints/options/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import '@/entrypoints/popup/tokens.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+)

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -1,24 +1,29 @@
-import { useEffect, useReducer } from 'react'
+import { useEffect, useReducer, useRef } from 'react'
 import type { ArticleCapture } from '@memry/article-extract'
 import type {
   CaptureResponse,
+  CaptureMode,
   ConnectionState,
   ExtractResponse,
   PairResponse,
+  ScreenshotResponse,
   StatusResponse
 } from '@/lib/messages'
 import { initialState, reducer, selectPhase } from '@/lib/popup-state'
+import { buildScreenshotDraft } from '@/lib/capture-modes'
 import { StatusStrip } from '@/components/StatusStrip'
 import { EditableTitle } from '@/components/EditableTitle'
 import { PropertyRows } from '@/components/PropertyRows'
 import { TagEditor } from '@/components/TagEditor'
 import { BodyPreview } from '@/components/BodyPreview'
 import { ModeSegmented } from '@/components/ModeSegmented'
+import { ScreenshotPreview } from '@/components/ScreenshotPreview'
 import { PrimaryButton } from '@/components/PrimaryButton'
 
 export default function App() {
   const [state, dispatch] = useReducer(reducer, initialState)
   const phase = selectPhase(state)
+  const articleDraftRef = useRef<ArticleCapture | null>(null)
 
   useEffect(() => {
     browser.runtime
@@ -32,14 +37,41 @@ export default function App() {
       if (!tab?.id) return dispatch({ type: 'DRAFT_READY', draft: null })
       browser.tabs
         .sendMessage(tab.id, { type: 'EXTRACT' })
-        .then((r: ExtractResponse) =>
+        .then((r: ExtractResponse) => {
+          articleDraftRef.current = r.ok ? r.capture : null
           dispatch({ type: 'DRAFT_READY', draft: r.ok ? r.capture : null })
-        )
+        })
         .catch(() => dispatch({ type: 'DRAFT_READY', draft: null }))
     })
   }, [])
 
   const setDraft = (draft: ArticleCapture) => dispatch({ type: 'EDIT', draft })
+
+  const onSelectMode = async (mode: CaptureMode) => {
+    if (mode === state.mode) return
+    dispatch({ type: 'SET_MODE', mode })
+    if (mode === 'article') {
+      dispatch({ type: 'DRAFT_READY', draft: articleDraftRef.current })
+      return
+    }
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true })
+    if (!tab?.id) return dispatch({ type: 'DRAFT_READY', draft: null })
+    if (mode === 'selection') {
+      const r: ExtractResponse = await browser.tabs
+        .sendMessage(tab.id, { type: 'GRAB_SELECTION' })
+        .catch(() => ({ ok: false, error: 'network' }))
+      dispatch({ type: 'DRAFT_READY', draft: r.ok ? r.capture : null })
+    } else {
+      const base = articleDraftRef.current
+      const r: ScreenshotResponse = await browser.runtime
+        .sendMessage({ type: 'GRAB_SCREENSHOT' })
+        .catch(() => ({ ok: false, error: 'network' }))
+      dispatch({
+        type: 'DRAFT_READY',
+        draft: r.ok && base ? buildScreenshotDraft(base, r.dataUrl) : null
+      })
+    }
+  }
 
   const onAdd = async (connectionOverride?: ConnectionState) => {
     if (!state.draft) return
@@ -85,13 +117,30 @@ export default function App() {
         </div>
       )}
 
-      {phase !== 'extracting' && phase !== 'saved' && (
+      {phase === 'capturing' && (
+        <div className="px-4 py-8 text-center text-[13px] text-text-tertiary">
+          {state.mode === 'screenshot' ? 'Capturing full page…' : 'Reading selection…'}
+        </div>
+      )}
+
+      {phase !== 'extracting' && phase !== 'capturing' && phase !== 'saved' && (
         <div
           className={
             'flex flex-col gap-2 px-4 py-3 ' +
             (phase === 'ready' || phase === 'error' ? '' : 'opacity-60')
           }
         >
+          <ModeSegmented mode={state.mode} disabled={!editable} onSelect={onSelectMode} />
+          {!draft && state.mode === 'selection' && (
+            <p className="py-6 text-center text-[12px] text-text-tertiary">
+              Select text on the page, then reopen the popup.
+            </p>
+          )}
+          {!draft && state.mode === 'screenshot' && (
+            <p className="py-6 text-center text-[12px] text-text-tertiary">
+              Couldn't capture this page.
+            </p>
+          )}
           {draft && (
             <>
               <EditableTitle
@@ -118,8 +167,11 @@ export default function App() {
                   setDraft({ ...draft, properties: { ...draft.properties, tags } })
                 }
               />
-              <ModeSegmented />
-              <BodyPreview markdown={draft.contentMarkdown} />
+              {state.mode === 'screenshot' && draft.screenshotDataUrl ? (
+                <ScreenshotPreview dataUrl={draft.screenshotDataUrl} />
+              ) : (
+                <BodyPreview markdown={draft.contentMarkdown} />
+              )}
             </>
           )}
         </div>

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -48,7 +48,10 @@ export default function App() {
   const setDraft = (draft: ArticleCapture) => dispatch({ type: 'EDIT', draft })
 
   const onSelectMode = async (mode: CaptureMode) => {
-    if (mode === state.mode) return
+    // Re-clicking article is a pure no-op (it would clobber edits with the cached draft),
+    // but re-clicking selection/screenshot re-runs the grab — that's the documented retry
+    // path ("Select text on the page, then pick Selection again").
+    if (mode === state.mode && mode === 'article') return
     dispatch({ type: 'SET_MODE', mode })
     if (mode === 'article') {
       dispatch({ type: 'DRAFT_READY', draft: articleDraftRef.current })

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -133,7 +133,7 @@ export default function App() {
           <ModeSegmented mode={state.mode} disabled={!editable} onSelect={onSelectMode} />
           {!draft && state.mode === 'selection' && (
             <p className="py-6 text-center text-[12px] text-text-tertiary">
-              Select text on the page, then reopen the popup.
+              Select text on the page, then pick Selection again.
             </p>
           )}
           {!draft && state.mode === 'screenshot' && (

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -126,59 +126,62 @@ export default function App() {
         </div>
       )}
 
-      {phase !== 'extracting' && phase !== 'capturing' && phase !== 'saved' && (
-        <div
-          className={
-            'flex flex-col gap-2 px-4 py-3 ' +
-            (phase === 'ready' || phase === 'error' ? '' : 'opacity-60')
-          }
-        >
-          <ModeSegmented mode={state.mode} disabled={!editable} onSelect={onSelectMode} />
-          {!draft && state.mode === 'selection' && (
-            <p className="py-6 text-center text-[12px] text-text-tertiary">
-              Select text on the page, then pick Selection again.
-            </p>
-          )}
-          {!draft && state.mode === 'screenshot' && (
-            <p className="py-6 text-center text-[12px] text-text-tertiary">
-              Couldn't capture this page.
-            </p>
-          )}
-          {draft && (
-            <>
-              <EditableTitle
-                value={draft.properties.title}
-                disabled={!editable}
-                onChange={(title) =>
-                  setDraft({ ...draft, properties: { ...draft.properties, title } })
-                }
-              />
-              {draft.extractionStatus === 'failed' && (
-                <p className="text-[12px] text-text-tertiary">
-                  Couldn't read this page — saving the link and title.
-                </p>
-              )}
-              <PropertyRows
-                properties={draft.properties}
-                disabled={!editable}
-                onChange={(properties) => setDraft({ ...draft, properties })}
-              />
-              <TagEditor
-                tags={draft.properties.tags}
-                disabled={!editable}
-                onChange={(tags) =>
-                  setDraft({ ...draft, properties: { ...draft.properties, tags } })
-                }
-              />
-              {state.mode === 'screenshot' && draft.screenshotDataUrl ? (
-                <ScreenshotPreview dataUrl={draft.screenshotDataUrl} />
-              ) : (
-                <BodyPreview markdown={draft.contentMarkdown} />
-              )}
-            </>
-          )}
-        </div>
-      )}
+      {phase !== 'extracting' &&
+        phase !== 'capturing' &&
+        phase !== 'saved' &&
+        phase !== 'queued' && (
+          <div
+            className={
+              'flex flex-col gap-2 px-4 py-3 ' +
+              (phase === 'ready' || phase === 'error' ? '' : 'opacity-60')
+            }
+          >
+            <ModeSegmented mode={state.mode} disabled={!editable} onSelect={onSelectMode} />
+            {!draft && state.mode === 'selection' && (
+              <p className="py-6 text-center text-[12px] text-text-tertiary">
+                Select text on the page, then pick Selection again.
+              </p>
+            )}
+            {!draft && state.mode === 'screenshot' && (
+              <p className="py-6 text-center text-[12px] text-text-tertiary">
+                Couldn't capture this page.
+              </p>
+            )}
+            {draft && (
+              <>
+                <EditableTitle
+                  value={draft.properties.title}
+                  disabled={!editable}
+                  onChange={(title) =>
+                    setDraft({ ...draft, properties: { ...draft.properties, title } })
+                  }
+                />
+                {draft.extractionStatus === 'failed' && (
+                  <p className="text-[12px] text-text-tertiary">
+                    Couldn't read this page — saving the link and title.
+                  </p>
+                )}
+                <PropertyRows
+                  properties={draft.properties}
+                  disabled={!editable}
+                  onChange={(properties) => setDraft({ ...draft, properties })}
+                />
+                <TagEditor
+                  tags={draft.properties.tags}
+                  disabled={!editable}
+                  onChange={(tags) =>
+                    setDraft({ ...draft, properties: { ...draft.properties, tags } })
+                  }
+                />
+                {state.mode === 'screenshot' && draft.screenshotDataUrl ? (
+                  <ScreenshotPreview dataUrl={draft.screenshotDataUrl} />
+                ) : (
+                  <BodyPreview markdown={draft.contentMarkdown} />
+                )}
+              </>
+            )}
+          </div>
+        )}
 
       <div className="flex flex-col gap-2 border-t border-border px-4 py-3">
         {phase === 'error' && state.errorMessage && (
@@ -192,6 +195,11 @@ export default function App() {
         {phase === 'saved' && (
           <p className="py-2 text-center text-[14px] font-medium text-foreground">
             Added to inbox ✓
+          </p>
+        )}
+        {phase === 'queued' && (
+          <p className="py-2 text-center text-[14px] font-medium text-foreground">
+            Saved offline — syncs when Memry opens ✓
           </p>
         )}
 

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -76,7 +76,9 @@ export default function App() {
     }
   }
 
-  const onAdd = async (connectionOverride?: ConnectionState) => {
+  const onAdd = async (
+    connectionOverride?: ConnectionState
+  ): Promise<CaptureResponse | undefined> => {
     if (!state.draft) return
     const connection = connectionOverride ?? state.connection
     // Pair inline if this connection isn't ready yet.
@@ -93,6 +95,16 @@ export default function App() {
       .sendMessage({ type: 'CAPTURE', capture: state.draft })
       .catch(() => ({ ok: false, error: 'network' }))
     dispatch({ type: 'SAVE_DONE', result })
+    return result
+  }
+
+  const onAddAndOpen = async () => {
+    const result = await onAdd()
+    if (result?.ok) {
+      browser.tabs
+        .create({ url: `memry://open?item=${encodeURIComponent(result.itemId)}` })
+        .catch(() => {})
+    }
   }
 
   const onLaunchAndAdd = async () => {
@@ -204,7 +216,17 @@ export default function App() {
         )}
 
         {phase === 'ready' && (
-          <PrimaryButton label="Add to Memry" onClick={() => onAdd()} disabled={!draft} />
+          <div className="flex flex-col gap-2">
+            <PrimaryButton label="Add to Memry" onClick={() => onAdd()} disabled={!draft} />
+            <button
+              type="button"
+              disabled={!draft}
+              onClick={onAddAndOpen}
+              className="rounded-md border border-border px-3 py-2 text-[13px] font-medium text-text-secondary disabled:opacity-50"
+            >
+              Add &amp; open in Memry
+            </button>
+          </div>
         )}
         {phase === 'approving' && <PrimaryButton label="Approve in Memry…" disabled />}
         {phase === 'saving' && <PrimaryButton label="Adding…" disabled />}

--- a/apps/extension/src/lib/capture-client.test.ts
+++ b/apps/extension/src/lib/capture-client.test.ts
@@ -9,8 +9,10 @@ import {
   pingUrl,
   pollUntil,
   postCapture,
+  postRevoke,
   probeServer,
-  requestPair
+  requestPair,
+  revokeUrl
 } from './capture-client'
 
 const draft: ArticleCapture = {
@@ -153,5 +155,35 @@ describe('pollUntil', () => {
       now: () => (t += 20)
     })
     expect(r).toBeNull()
+  })
+})
+
+const notOk = () => new Response('{}', { status: 500 })
+
+describe('probeServer with an explicit port list', () => {
+  test('returns the first live server in the supplied list', async () => {
+    const fetchFn = vi.fn(async (url: string) =>
+      url.includes(':9001') ? ok({ app: 'memry', paired: true, version: '1' }) : notOk()
+    ) as unknown as typeof fetch
+    const found = await probeServer(fetchFn, [9000, 9001])
+    expect(found?.port).toBe(9001)
+  })
+})
+
+describe('postRevoke', () => {
+  test('returns true on a 2xx', async () => {
+    const fetchFn = vi.fn(async () => ok({ ok: true })) as unknown as typeof fetch
+    expect(await postRevoke(7849, 'tok', fetchFn)).toBe(true)
+    expect((fetchFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(revokeUrl(7849))
+  })
+  test('returns false on a non-2xx', async () => {
+    const fetchFn = vi.fn(async () => notOk()) as unknown as typeof fetch
+    expect(await postRevoke(7849, 'tok', fetchFn)).toBe(false)
+  })
+  test('returns false when fetch throws', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('down')
+    }) as unknown as typeof fetch
+    expect(await postRevoke(7849, 'tok', fetchFn)).toBe(false)
   })
 })

--- a/apps/extension/src/lib/capture-client.ts
+++ b/apps/extension/src/lib/capture-client.ts
@@ -18,6 +18,9 @@ export function pairRequestUrl(port: number): string {
 export function captureUrl(port: number): string {
   return `http://127.0.0.1:${port}/capture`
 }
+export function revokeUrl(port: number): string {
+  return `http://127.0.0.1:${port}/pair/revoke`
+}
 
 export interface PingResponse {
   app: 'memry'
@@ -34,9 +37,10 @@ export function parsePing(data: unknown): PingResponse | null {
 
 // Probe the loopback range. Returns the first live memry server, or null.
 export async function probeServer(
-  fetchFn: typeof fetch = fetch
+  fetchFn: typeof fetch = fetch,
+  ports: number[] = PROBE_PORTS
 ): Promise<{ port: number; ping: PingResponse } | null> {
-  for (const port of PROBE_PORTS) {
+  for (const port of ports) {
     try {
       const res = await fetchFn(pingUrl(port), { method: 'GET' })
       if (!res.ok) continue
@@ -93,6 +97,19 @@ export function captureHeaders(token: string): Record<string, string> {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${token}`,
     [CAPTURE_HEADER]: '1'
+  }
+}
+
+export async function postRevoke(
+  port: number,
+  token: string,
+  fetchFn: typeof fetch = fetch
+): Promise<boolean> {
+  try {
+    const res = await fetchFn(revokeUrl(port), { method: 'POST', headers: captureHeaders(token) })
+    return res.ok
+  } catch {
+    return false
   }
 }
 

--- a/apps/extension/src/lib/capture-modes.test.ts
+++ b/apps/extension/src/lib/capture-modes.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import type { ArticleCapture } from '@memry/article-extract'
+import {
+  bytesToDataUrl,
+  buildScreenshotDraft,
+  planStitch,
+  toSelectionCapture
+} from './capture-modes'
+
+const base: ArticleCapture = {
+  url: 'https://example.com/p',
+  mode: 'article',
+  contentMarkdown: '# Real markdown',
+  excerpt: 'x',
+  extractionStatus: 'full',
+  properties: {
+    title: 'Page',
+    source: 'https://example.com/p',
+    created: 'now',
+    tags: ['clippings']
+  }
+}
+
+describe('toSelectionCapture', () => {
+  it('keeps defuddle markdown when present and marks the capture as a forced selection', () => {
+    const c = toSelectionCapture(base, 'plain selected text', 'Page')
+    expect(c.mode).toBe('selection')
+    expect(c.force).toBe(true)
+    expect(c.contentMarkdown).toBe('# Real markdown')
+    expect(c.extractionStatus).toBe('full')
+  })
+
+  it('falls back to plain selection text when markdown is empty', () => {
+    const c = toSelectionCapture({ ...base, contentMarkdown: '   ' }, 'plain selected text', 'Page')
+    expect(c.contentMarkdown).toBe('plain selected text')
+  })
+})
+
+describe('buildScreenshotDraft', () => {
+  it('builds a forced screenshot capture with an empty body', () => {
+    const c = buildScreenshotDraft(base, 'data:image/png;base64,AAAA')
+    expect(c.mode).toBe('screenshot')
+    expect(c.force).toBe(true)
+    expect(c.contentMarkdown).toBe('')
+    expect(c.screenshotDataUrl).toBe('data:image/png;base64,AAAA')
+    expect(c.properties.title).toBe('Page')
+  })
+})
+
+describe('planStitch', () => {
+  it('returns a single bottom-clipped slice for a short page', () => {
+    const p = planStitch({
+      scrollHeight: 500,
+      innerHeight: 800,
+      innerWidth: 1000,
+      dpr: 1,
+      maxHeight: 15000
+    })
+    expect(p.slices).toEqual([{ scrollY: 0, drawY: 0 }])
+    expect(p.height).toBe(500)
+    expect(p.width).toBe(1000)
+  })
+
+  it('bottom-aligns the final slice on a non-multiple page', () => {
+    const p = planStitch({
+      scrollHeight: 2000,
+      innerHeight: 800,
+      innerWidth: 1000,
+      dpr: 1,
+      maxHeight: 15000
+    })
+    expect(p.slices.map((s) => s.scrollY)).toEqual([0, 800, 1200])
+    expect(p.height).toBe(2000)
+  })
+
+  it('applies devicePixelRatio to canvas size and draw offsets', () => {
+    const p = planStitch({
+      scrollHeight: 1600,
+      innerHeight: 800,
+      innerWidth: 500,
+      dpr: 2,
+      maxHeight: 15000
+    })
+    expect(p.width).toBe(1000)
+    expect(p.height).toBe(3200)
+    expect(p.slices).toEqual([
+      { scrollY: 0, drawY: 0 },
+      { scrollY: 800, drawY: 1600 }
+    ])
+  })
+
+  it('clamps total height to maxHeight', () => {
+    const p = planStitch({
+      scrollHeight: 99999,
+      innerHeight: 800,
+      innerWidth: 100,
+      dpr: 1,
+      maxHeight: 1600
+    })
+    expect(p.height).toBe(1600)
+    expect(p.slices[p.slices.length - 1].scrollY).toBe(800)
+  })
+})
+
+describe('bytesToDataUrl', () => {
+  it('encodes bytes as a base64 data URL', () => {
+    expect(bytesToDataUrl(new Uint8Array([104, 105]), 'image/png')).toBe(
+      'data:image/png;base64,aGk='
+    )
+  })
+})

--- a/apps/extension/src/lib/capture-modes.test.ts
+++ b/apps/extension/src/lib/capture-modes.test.ts
@@ -100,6 +100,19 @@ describe('planStitch', () => {
     expect(p.height).toBe(1600)
     expect(p.slices[p.slices.length - 1].scrollY).toBe(800)
   })
+
+  it('returns a single slice without looping when innerHeight is 0', () => {
+    const p = planStitch({
+      scrollHeight: 2000,
+      innerHeight: 0,
+      innerWidth: 1000,
+      dpr: 1,
+      maxHeight: 15000
+    })
+    expect(p.slices).toEqual([{ scrollY: 0, drawY: 0 }])
+    expect(p.height).toBe(2000)
+    expect(p.width).toBe(1000)
+  })
 })
 
 describe('bytesToDataUrl', () => {

--- a/apps/extension/src/lib/capture-modes.ts
+++ b/apps/extension/src/lib/capture-modes.ts
@@ -61,6 +61,11 @@ export function planStitch(opts: {
 }): StitchPlan {
   const { scrollHeight, innerHeight, innerWidth, dpr, maxHeight } = opts
   const total = Math.min(scrollHeight, maxHeight)
+  const width = Math.round(innerWidth * dpr)
+  const height = Math.round(total * dpr)
+  // ponytail: guard a non-advancing loop — a hidden/zero-height viewport (innerHeight 0)
+  // would spin `y += innerHeight` forever. One slice, no scroll.
+  if (innerHeight <= 0) return { width, height, slices: [{ scrollY: 0, drawY: 0 }] }
   const tops: number[] = []
   for (let y = 0; y < total; y += innerHeight) tops.push(y)
   if (tops.length === 0) tops.push(0)
@@ -69,8 +74,8 @@ export function planStitch(opts: {
   else tops[tops.length - 1] = lastTop
   const unique = tops.filter((y, i) => i === 0 || y !== tops[i - 1])
   return {
-    width: Math.round(innerWidth * dpr),
-    height: Math.round(total * dpr),
+    width,
+    height,
     slices: unique.map((scrollY) => ({ scrollY, drawY: Math.round(scrollY * dpr) }))
   }
 }

--- a/apps/extension/src/lib/capture-modes.ts
+++ b/apps/extension/src/lib/capture-modes.ts
@@ -1,0 +1,87 @@
+import type { ArticleCapture } from '@memry/article-extract'
+
+// Turn a defuddle extraction of the selected fragment into a forced selection
+// capture. Falls back to the raw selection text when defuddle yields nothing.
+export function toSelectionCapture(
+  base: ArticleCapture,
+  selectionText: string,
+  title: string
+): ArticleCapture {
+  const contentMarkdown = base.contentMarkdown.trim() ? base.contentMarkdown : selectionText
+  return {
+    ...base,
+    mode: 'selection',
+    contentMarkdown,
+    excerpt: selectionText.slice(0, 200),
+    extractionStatus: 'full',
+    force: true,
+    properties: { ...base.properties, title: title || base.properties.title }
+  }
+}
+
+// Build a forced screenshot capture. The body is empty; the desktop decodes
+// screenshotDataUrl into an attachment and writes the real markdown body.
+export function buildScreenshotDraft(
+  base: ArticleCapture,
+  screenshotDataUrl: string
+): ArticleCapture {
+  return {
+    url: base.url,
+    mode: 'screenshot',
+    contentMarkdown: '',
+    excerpt: '',
+    extractionStatus: 'full',
+    force: true,
+    screenshotDataUrl,
+    properties: { ...base.properties }
+  }
+}
+
+export interface StitchSlice {
+  scrollY: number
+  drawY: number
+}
+
+export interface StitchPlan {
+  width: number
+  height: number
+  slices: StitchSlice[]
+}
+
+// Plan a full-page screenshot: which scroll positions to capture and where to
+// paint each viewport-tall slice on the stitched canvas. The final slice is
+// bottom-aligned so it never captures blank space below the page. Total height
+// is clamped to maxHeight to keep the encoded PNG under the /capture cap.
+export function planStitch(opts: {
+  scrollHeight: number
+  innerHeight: number
+  innerWidth: number
+  dpr: number
+  maxHeight: number
+}): StitchPlan {
+  const { scrollHeight, innerHeight, innerWidth, dpr, maxHeight } = opts
+  const total = Math.min(scrollHeight, maxHeight)
+  const tops: number[] = []
+  for (let y = 0; y < total; y += innerHeight) tops.push(y)
+  if (tops.length === 0) tops.push(0)
+  const lastTop = Math.max(0, total - innerHeight)
+  if (tops[tops.length - 1] < lastTop) tops.push(lastTop)
+  else tops[tops.length - 1] = lastTop
+  const unique = tops.filter((y, i) => i === 0 || y !== tops[i - 1])
+  return {
+    width: Math.round(innerWidth * dpr),
+    height: Math.round(total * dpr),
+    slices: unique.map((scrollY) => ({ scrollY, drawY: Math.round(scrollY * dpr) }))
+  }
+}
+
+// Encode bytes to a base64 data URL. Chunked to avoid blowing the call stack on
+// large screenshots when spreading into String.fromCharCode.
+export function bytesToDataUrl(bytes: Uint8Array, mime: string): string {
+  let binary = ''
+  const chunk = 0x8000
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+  }
+  return `data:${mime};base64,${btoa(binary)}`
+}

--- a/apps/extension/src/lib/capture-queue.test.ts
+++ b/apps/extension/src/lib/capture-queue.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import type { ArticleCapture } from '@memry/article-extract'
+import { badgeText, dequeueById, enqueue, isRetryable, MAX_QUEUE } from './capture-queue'
+
+const cap = { url: 'https://x.test' } as unknown as ArticleCapture
+const item = (id: string) => ({ id, capture: cap, queuedAt: 0 })
+
+describe('isRetryable', () => {
+  it('retries only unreachable-server errors', () => {
+    expect(isRetryable('app-closed')).toBe(true)
+    expect(isRetryable('network')).toBe(true)
+  })
+  it('does not retry payload/auth/4xx/5xx failures', () => {
+    expect(isRetryable('bad-token')).toBe(false)
+    expect(isRetryable('origin-not-allowed')).toBe(false)
+    expect(isRetryable('invalid-capture')).toBe(false)
+    expect(isRetryable('payload-too-large')).toBe(false)
+    expect(isRetryable('http-413')).toBe(false)
+    expect(isRetryable('http-500')).toBe(false)
+  })
+})
+
+describe('enqueue', () => {
+  it('appends to the end', () => {
+    expect(enqueue([item('a')], item('b')).map((q) => q.id)).toEqual(['a', 'b'])
+  })
+  it('drops the oldest when over the cap', () => {
+    const r = enqueue([item('a'), item('b')], item('c'), 2)
+    expect(r.map((q) => q.id)).toEqual(['b', 'c'])
+  })
+  it('defaults to MAX_QUEUE', () => {
+    expect(MAX_QUEUE).toBe(50)
+  })
+})
+
+describe('dequeueById', () => {
+  it('removes the matching item', () => {
+    expect(dequeueById([item('a'), item('b')], 'a').map((q) => q.id)).toEqual(['b'])
+  })
+})
+
+describe('badgeText', () => {
+  it('blanks at zero, caps at 99+', () => {
+    expect(badgeText(0)).toBe('')
+    expect(badgeText(5)).toBe('5')
+    expect(badgeText(150)).toBe('99+')
+  })
+})

--- a/apps/extension/src/lib/capture-queue.ts
+++ b/apps/extension/src/lib/capture-queue.ts
@@ -1,0 +1,36 @@
+import type { ArticleCapture } from '@memry/article-extract'
+
+export interface QueuedCapture {
+  id: string
+  capture: ArticleCapture
+  queuedAt: number
+}
+
+export const MAX_QUEUE = 50
+
+// Retryable = the server was unreachable, not the payload being bad. Pairing,
+// validation, 4xx and 5xx codes are permanent — retrying never helps and a 5xx
+// loop would spin forever on a server bug. ponytail: upgrade path = backoff-retry
+// 5xx a few times before dropping.
+export function isRetryable(error: string): boolean {
+  return error === 'app-closed' || error === 'network'
+}
+
+// Append, dropping the oldest when the queue would exceed `max`.
+export function enqueue(
+  queue: QueuedCapture[],
+  item: QueuedCapture,
+  max = MAX_QUEUE
+): QueuedCapture[] {
+  const next = [...queue, item]
+  return next.length > max ? next.slice(next.length - max) : next
+}
+
+export function dequeueById(queue: QueuedCapture[], id: string): QueuedCapture[] {
+  return queue.filter((q) => q.id !== id)
+}
+
+export function badgeText(count: number): string {
+  if (count <= 0) return ''
+  return count > 99 ? '99+' : String(count)
+}

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -21,6 +21,8 @@ export type PopupMessage =
   | { type: 'CAPTURE'; capture: ArticleCapture }
   | { type: 'WAIT_FOR_SERVER' }
   | { type: 'GRAB_SCREENSHOT' }
+  | { type: 'FLUSH_QUEUE' }
+  | { type: 'REVOKE' }
 
 export type ContentMessage =
   | { type: 'EXTRACT' }
@@ -39,3 +41,8 @@ export interface PageMetrics {
 }
 
 export type ScreenshotResponse = { ok: true; dataUrl: string } | { ok: false; error: string }
+
+export interface FlushResponse {
+  flushed: number
+  remaining: number
+}

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -13,12 +13,29 @@ export interface PairResponse {
 
 export type CaptureResponse = { ok: true; itemId: string } | { ok: false; error: string }
 
+export type CaptureMode = 'article' | 'selection' | 'screenshot'
+
 export type PopupMessage =
   | { type: 'GET_STATUS' }
   | { type: 'PAIR' }
   | { type: 'CAPTURE'; capture: ArticleCapture }
   | { type: 'WAIT_FOR_SERVER' }
+  | { type: 'GRAB_SCREENSHOT' }
 
-export type ContentMessage = { type: 'EXTRACT' }
+export type ContentMessage =
+  | { type: 'EXTRACT' }
+  | { type: 'GRAB_SELECTION' }
+  | { type: 'GET_PAGE_METRICS' }
+  | { type: 'SCROLL_TO'; y: number }
 
 export type ExtractResponse = { ok: true; capture: ArticleCapture } | { ok: false; error: string }
+
+export interface PageMetrics {
+  scrollHeight: number
+  innerHeight: number
+  innerWidth: number
+  dpr: number
+  scrollY: number
+}
+
+export type ScreenshotResponse = { ok: true; dataUrl: string } | { ok: false; error: string }

--- a/apps/extension/src/lib/popup-state.test.ts
+++ b/apps/extension/src/lib/popup-state.test.ts
@@ -121,6 +121,25 @@ describe('mapError', () => {
   })
 })
 
+describe('offline queue state', () => {
+  it('SAVE_DONE with a queued result is a terminal queued state, not an error', () => {
+    const mid = reducer(initialState, { type: 'SAVE_START' })
+    const s = reducer(mid, { type: 'SAVE_DONE', result: { ok: false, error: 'queued' } })
+    expect(s.action).toBe('queued')
+    expect(s.errorMessage).toBeNull()
+    expect(selectPhase(s)).toBe('queued')
+  })
+
+  it('SAVE_DONE with a real error still maps to error', () => {
+    const s = reducer(initialState, {
+      type: 'SAVE_DONE',
+      result: { ok: false, error: 'bad-token' }
+    })
+    expect(s.action).toBe('error')
+    expect(selectPhase(s)).toBe('error')
+  })
+})
+
 describe('mode switching', () => {
   it('SET_MODE to selection starts capturing and resets draftReady', () => {
     const s = reducer(

--- a/apps/extension/src/lib/popup-state.test.ts
+++ b/apps/extension/src/lib/popup-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 import type { ArticleCapture } from '@memry/article-extract'
 import { initialState, mapError, reducer, selectPhase } from './popup-state'
 
@@ -118,5 +118,34 @@ describe('mapError', () => {
     expect(mapError('bad-token')).toContain('pair')
     expect(mapError('payload-too-large')).toContain('too large')
     expect(mapError('whatever')).toContain('reach Memry')
+  })
+})
+
+describe('mode switching', () => {
+  it('SET_MODE to selection starts capturing and resets draftReady', () => {
+    const s = reducer(
+      { ...initialState, draftReady: true },
+      { type: 'SET_MODE', mode: 'selection' }
+    )
+    expect(s.mode).toBe('selection')
+    expect(s.capturing).toBe(true)
+    expect(s.draftReady).toBe(false)
+  })
+
+  it('SET_MODE to article does not enter capturing', () => {
+    const s = reducer(initialState, { type: 'SET_MODE', mode: 'article' })
+    expect(s.mode).toBe('article')
+    expect(s.capturing).toBe(false)
+  })
+
+  it('DRAFT_READY clears capturing', () => {
+    const mid = reducer(initialState, { type: 'SET_MODE', mode: 'screenshot' })
+    const done = reducer(mid, { type: 'DRAFT_READY', draft: null })
+    expect(done.capturing).toBe(false)
+    expect(done.draftReady).toBe(true)
+  })
+
+  it('selectPhase returns capturing while a grab is in flight', () => {
+    expect(selectPhase({ ...initialState, capturing: true })).toBe('capturing')
   })
 })

--- a/apps/extension/src/lib/popup-state.ts
+++ b/apps/extension/src/lib/popup-state.ts
@@ -1,8 +1,9 @@
 import type { ArticleCapture } from '@memry/article-extract'
-import type { ConnectionState } from './messages'
+import type { CaptureMode, ConnectionState } from './messages'
 
 export type Phase =
   | 'extracting'
+  | 'capturing'
   | 'app-closed'
   | 'launching'
   | 'ready'
@@ -14,6 +15,8 @@ export type Phase =
 export interface PopupState {
   draft: ArticleCapture | null
   draftReady: boolean
+  mode: CaptureMode
+  capturing: boolean
   connection: 'unknown' | ConnectionState
   port: number | null
   action: 'idle' | 'launching' | 'approving' | 'saving' | 'saved' | 'error'
@@ -32,10 +35,13 @@ export type PopupAction =
   | { type: 'LAUNCH_START' }
   | { type: 'LAUNCH_DONE'; ok: boolean }
   | { type: 'RETRY' }
+  | { type: 'SET_MODE'; mode: CaptureMode }
 
 export const initialState: PopupState = {
   draft: null,
   draftReady: false,
+  mode: 'article',
+  capturing: false,
   connection: 'unknown',
   port: null,
   action: 'idle',
@@ -62,7 +68,15 @@ export function mapError(code: string): string {
 export function reducer(state: PopupState, action: PopupAction): PopupState {
   switch (action.type) {
     case 'DRAFT_READY':
-      return { ...state, draft: action.draft, draftReady: true }
+      return { ...state, draft: action.draft, draftReady: true, capturing: false }
+    case 'SET_MODE':
+      return {
+        ...state,
+        mode: action.mode,
+        capturing: action.mode !== 'article',
+        draftReady: false,
+        errorMessage: null
+      }
     case 'STATUS':
       return { ...state, connection: action.connection, port: action.port }
     case 'EDIT':
@@ -102,6 +116,7 @@ export function selectPhase(state: PopupState): Phase {
   if (state.action === 'saving') return 'saving'
   if (state.action === 'approving') return 'approving'
   if (state.action === 'launching') return 'launching'
+  if (state.capturing) return 'capturing'
   if (state.connection === 'unknown' || !state.draftReady) return 'extracting'
   if (state.connection === 'app-closed') return 'app-closed'
   return 'ready' // 'ready' and 'needs-pairing' both render the editable miniature

--- a/apps/extension/src/lib/popup-state.ts
+++ b/apps/extension/src/lib/popup-state.ts
@@ -10,6 +10,7 @@ export type Phase =
   | 'approving'
   | 'saving'
   | 'saved'
+  | 'queued'
   | 'error'
 
 export interface PopupState {
@@ -19,7 +20,7 @@ export interface PopupState {
   capturing: boolean
   connection: 'unknown' | ConnectionState
   port: number | null
-  action: 'idle' | 'launching' | 'approving' | 'saving' | 'saved' | 'error'
+  action: 'idle' | 'launching' | 'approving' | 'saving' | 'saved' | 'queued' | 'error'
   itemId: string | null
   errorMessage: string | null
 }
@@ -94,9 +95,13 @@ export function reducer(state: PopupState, action: PopupAction): PopupState {
     case 'SAVE_START':
       return { ...state, action: 'saving', errorMessage: null }
     case 'SAVE_DONE':
-      return action.result.ok
-        ? { ...state, action: 'saved', itemId: action.result.itemId }
-        : { ...state, action: 'error', errorMessage: mapError(action.result.error) }
+      if (action.result.ok) {
+        return { ...state, action: 'saved', itemId: action.result.itemId }
+      }
+      if (action.result.error === 'queued') {
+        return { ...state, action: 'queued', errorMessage: null }
+      }
+      return { ...state, action: 'error', errorMessage: mapError(action.result.error) }
     case 'LAUNCH_START':
       return { ...state, action: 'launching', errorMessage: null }
     case 'LAUNCH_DONE':
@@ -112,6 +117,7 @@ export function reducer(state: PopupState, action: PopupAction): PopupState {
 
 export function selectPhase(state: PopupState): Phase {
   if (state.action === 'saved') return 'saved'
+  if (state.action === 'queued') return 'queued'
   if (state.action === 'error') return 'error'
   if (state.action === 'saving') return 'saving'
   if (state.action === 'approving') return 'approving'

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   manifest: {
     name: 'Memry Web Clipper',
     description: 'Save the page you are reading to Memry as a readable note.',
-    permissions: ['storage', 'activeTab'],
+    permissions: ['storage', 'activeTab', 'alarms'],
     host_permissions: ['http://127.0.0.1/*']
   },
   vite: () => ({

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -9,7 +9,13 @@ export default defineConfig({
     name: 'Memry Web Clipper',
     description: 'Save the page you are reading to Memry as a readable note.',
     permissions: ['storage', 'activeTab', 'alarms'],
-    host_permissions: ['http://127.0.0.1/*']
+    host_permissions: ['http://127.0.0.1/*'],
+    commands: {
+      'capture-page': {
+        suggested_key: { default: 'Ctrl+Shift+S', mac: 'Command+Shift+S' },
+        description: 'Capture this page to Memry'
+      }
+    }
   },
   vite: () => ({
     plugins: [tailwindcss()]

--- a/docs/superpowers/plans/2026-06-17-link-capture-phase4-capture-modes.md
+++ b/docs/superpowers/plans/2026-06-17-link-capture-phase4-capture-modes.md
@@ -1,0 +1,1330 @@
+# Link Capture Phase 4 — Selection + Screenshot Capture Modes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the popup's disabled "Selection" and "Shot" segments into working capture modes — selection clips text as a markdown note, Shot captures a full-page screenshot as an image note — both landing in the inbox via the existing `/capture` → `ingestArticleCapture` path.
+
+**Architecture:** Selection is extension-only (content script runs the same defuddle engine on the selected fragment, produces `contentMarkdown`; desktop ingests unchanged). Screenshot adds a wire field `screenshotDataUrl`: the background orchestrates a scroll+capture loop, stitches slices with `OffscreenCanvas`, and the desktop decodes the data URL into an inbox attachment and embeds it. Pure data transforms (envelope builders, stitch geometry, base64, data-URL parse) are isolated into testable helpers; DOM/canvas/React surfaces are manual-QA.
+
+**Tech Stack:** WXT MV3 + React 19 (extension), defuddle 0.19 via `@memry/article-extract`, Electron main (desktop), Zod contracts, Vitest.
+
+## Global Constraints
+
+- Prettier: single quotes, NO semicolons, 100-char width, no trailing commas — copy verbatim from `CLAUDE.md`.
+- Tailwind logical properties only: `ms/me`, `ps/pe`, `start/end`, `text-start/text-end` — never `ml/mr/pl/pr/left/right`.
+- NO `Co-Authored-By` trailer on commits.
+- Commit ONLY the task's files by explicit path. NEVER `git add -A` (an untracked `import-prompt/` dir must not be committed).
+- Import the capture contract via the subpath `@memry/contracts/capture-api`, never the barrel.
+- No new dependencies. No new extension permissions (`activeTab` already authorizes `captureVisibleTab`; selection/scroll need none).
+- Branch: `feat/link-capture-capture-modes` (already created off main; the spec commit is the first commit).
+- Spec: `docs/superpowers/specs/2026-06-17-link-capture-phase4-capture-modes-design.md`.
+
+---
+
+## File Structure
+
+**Desktop / contracts (screenshot only — selection needs nothing here):**
+
+- `packages/contracts/src/capture-api.ts` — add `screenshotDataUrl` to `ArticleCaptureSchema`.
+- `packages/contracts/src/capture-api.test.ts` — NEW, schema parse test.
+- `packages/article-extract/src/map.ts` — add `force?` + `screenshotDataUrl?` to the `ArticleCapture` envelope type (shared by extension + desktop ingest).
+- `apps/desktop/src/main/inbox/parse-data-url.ts` — NEW pure helper.
+- `apps/desktop/src/main/inbox/parse-data-url.test.ts` — NEW.
+- `apps/desktop/src/main/inbox/ingest.ts` — decode + store + embed screenshot in the create-path.
+- `apps/desktop/src/main/capture/server.test.ts` — add a screenshot pass-through case.
+
+**Extension:**
+
+- `apps/extension/src/lib/messages.ts` — `CaptureMode`, new message variants + response types.
+- `apps/extension/src/lib/popup-state.ts` — `mode` + `capturing` in state, `SET_MODE` action, `capturing` phase.
+- `apps/extension/src/lib/popup-state.test.ts` — reducer tests for the new action/phase.
+- `apps/extension/src/lib/capture-modes.ts` — NEW pure helpers (`toSelectionCapture`, `buildScreenshotDraft`, `planStitch`, `bytesToDataUrl`).
+- `apps/extension/src/lib/capture-modes.test.ts` — NEW.
+- `apps/extension/src/entrypoints/content.ts` — `GRAB_SELECTION`, `GET_PAGE_METRICS`, `SCROLL_TO` handlers.
+- `apps/extension/src/entrypoints/background.ts` — `GRAB_SCREENSHOT` orchestration + stitch.
+- `apps/extension/src/components/ModeSegmented.tsx` — interactive segments.
+- `apps/extension/src/components/ScreenshotPreview.tsx` — NEW image miniature.
+- `apps/extension/src/entrypoints/popup/App.tsx` — mode switching, capturing/empty states, per-mode body.
+
+---
+
+## Task 1: Contract field + shared envelope type (desktop foundation)
+
+**Files:**
+
+- Modify: `packages/contracts/src/capture-api.ts:13-23`
+- Test: `packages/contracts/src/capture-api.test.ts` (create)
+- Modify: `packages/article-extract/src/map.ts:11-19`
+
+**Interfaces:**
+
+- Produces: `ArticleCaptureSchema` accepting optional `screenshotDataUrl: string`; the `ArticleCapture` envelope type carrying optional `force?: boolean` and `screenshotDataUrl?: string` (consumed by Tasks 3, 5, 7, 8).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/contracts/src/capture-api.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { ArticleCaptureSchema } from './capture-api'
+
+describe('ArticleCaptureSchema', () => {
+  it('accepts a screenshot payload with screenshotDataUrl + force', () => {
+    const r = ArticleCaptureSchema.safeParse({
+      url: 'https://example.com/p',
+      mode: 'screenshot',
+      contentMarkdown: '',
+      excerpt: '',
+      extractionStatus: 'full',
+      properties: {
+        title: 't',
+        source: 'https://example.com/p',
+        created: '2026-06-17T00:00:00.000Z',
+        tags: []
+      },
+      screenshotDataUrl: 'data:image/png;base64,AAAA',
+      force: true
+    })
+    expect(r.success).toBe(true)
+    if (r.success) expect(r.data.screenshotDataUrl).toBe('data:image/png;base64,AAAA')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/contracts test -- capture-api`
+Expected: FAIL — `r.data.screenshotDataUrl` is `undefined` (Zod strips the unknown key).
+
+- [ ] **Step 3: Add the schema field**
+
+In `packages/contracts/src/capture-api.ts`, add one line to `ArticleCaptureSchema` after `heroImage`:
+
+```ts
+export const ArticleCaptureSchema = z.object({
+  url: z.string().url(),
+  mode: z.enum(['article', 'selection', 'screenshot']),
+  contentMarkdown: z.string(),
+  excerpt: z.string(),
+  extractionStatus: z.enum(['full', 'partial', 'failed']),
+  properties: ArticlePropertiesSchema,
+  heroImage: z.string().optional(),
+  screenshotDataUrl: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  force: z.boolean().optional()
+})
+```
+
+- [ ] **Step 4: Extend the shared envelope type**
+
+In `packages/article-extract/src/map.ts`, add two optional fields to the `ArticleCapture` interface (the cross-boundary capture envelope — `mode` already spans all three modes here):
+
+```ts
+export interface ArticleCapture {
+  url: string
+  mode: 'article' | 'selection' | 'screenshot'
+  contentMarkdown: string
+  excerpt: string
+  extractionStatus: 'full' | 'partial' | 'failed'
+  properties: ArticleProperties
+  heroImage?: string
+  // Capture directives (set by the extension for selection/screenshot; the
+  // extraction mapping never sets them).
+  force?: boolean
+  screenshotDataUrl?: string
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/contracts test -- capture-api`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck both packages**
+
+Run: `pnpm --filter @memry/contracts typecheck && pnpm --filter @memry/article-extract typecheck`
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/contracts/src/capture-api.ts packages/contracts/src/capture-api.test.ts packages/article-extract/src/map.ts
+git commit -m "feat(capture): add screenshotDataUrl to capture contract + envelope"
+```
+
+---
+
+## Task 2: `parseDataUrl` helper (desktop, pure)
+
+**Files:**
+
+- Create: `apps/desktop/src/main/inbox/parse-data-url.ts`
+- Test: `apps/desktop/src/main/inbox/parse-data-url.test.ts`
+
+**Interfaces:**
+
+- Produces: `parseDataUrl(s: string): { mime: string; buffer: Buffer } | null` (consumed by Task 3). Filename extension is NOT needed — `storeInboxAttachment` derives the stored extension from the MIME type itself.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/src/main/inbox/parse-data-url.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { parseDataUrl } from './parse-data-url'
+
+describe('parseDataUrl', () => {
+  it('decodes a base64 png data URL', () => {
+    // "hi" base64 = aGk=
+    const r = parseDataUrl('data:image/png;base64,aGk=')
+    expect(r).not.toBeNull()
+    expect(r?.mime).toBe('image/png')
+    expect(r?.buffer.toString('utf8')).toBe('hi')
+  })
+
+  it('returns null for a non-data string', () => {
+    expect(parseDataUrl('https://example.com/x.png')).toBeNull()
+  })
+
+  it('returns null for a data URL that is not base64', () => {
+    expect(parseDataUrl('data:image/png,plain')).toBeNull()
+  })
+
+  it('returns null for an empty payload', () => {
+    expect(parseDataUrl('data:image/png;base64,')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main parse-data-url`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/desktop/src/main/inbox/parse-data-url.ts`:
+
+```ts
+// Parse a base64 data URL ("data:<mime>;base64,<payload>") into its MIME type
+// and decoded bytes. Returns null for anything that is not a non-empty base64
+// data URL (callers fall through to leaving the capture image-less).
+export function parseDataUrl(input: string): { mime: string; buffer: Buffer } | null {
+  const match = /^data:([a-z0-9.+/-]+);base64,(.+)$/i.exec(input.trim())
+  if (!match) return null
+  const mime = match[1].toLowerCase()
+  const buffer = Buffer.from(match[2], 'base64')
+  if (buffer.length === 0) return null
+  return { mime, buffer }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:main parse-data-url`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/inbox/parse-data-url.ts apps/desktop/src/main/inbox/parse-data-url.test.ts
+git commit -m "feat(inbox): add parseDataUrl helper for screenshot decoding"
+```
+
+---
+
+## Task 3: Screenshot ingest + server pass-through test (desktop)
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/inbox/ingest.ts:12-13` (imports), `:83-114` (create-path)
+- Modify: `apps/desktop/src/main/capture/server.test.ts` (add a case)
+
+**Interfaces:**
+
+- Consumes: `parseDataUrl` (Task 2), `storeInboxAttachment(itemId, data: Buffer, filename, mimeType) → { success; path? }` (existing, `./attachments`), `input.screenshotDataUrl` (Task 1).
+- Produces: when `screenshotDataUrl` is present and decodes + stores, the new inbox item's `content` is `![screenshot](<vault-relative path>)` and its `thumbnailPath` is that path.
+
+- [ ] **Step 1: Write the failing test (server pass-through)**
+
+In `apps/desktop/src/main/capture/server.test.ts`, add this case inside the `describe('capture server', ...)` block, after the existing `'claims a token ... then serves /capture'` test:
+
+```ts
+it('passes a screenshot capture through to ingest', async () => {
+  origins.add('chrome-extension://abc')
+  const cap = await req(port, '/capture', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Origin: 'chrome-extension://abc',
+      'X-Memry-Capture': '1',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      url: 'https://example.com/p',
+      mode: 'screenshot',
+      contentMarkdown: '',
+      excerpt: '',
+      extractionStatus: 'full',
+      properties: {
+        title: 'x',
+        source: 'https://example.com/p',
+        created: '2026-06-17T00:00:00.000Z',
+        tags: ['clippings']
+      },
+      screenshotDataUrl: 'data:image/png;base64,aGk=',
+      force: true
+    })
+  })
+  expect(cap.status).toBe(200)
+  expect(ingestSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mode: 'screenshot',
+      screenshotDataUrl: 'data:image/png;base64,aGk=',
+      force: true
+    }),
+    'browser-extension'
+  )
+})
+```
+
+- [ ] **Step 2: Run test to verify it passes already (contract pass-through)**
+
+Run: `pnpm --filter @memry/desktop test:main capture/server.test.ts`
+Expected: PASS — Task 1 already added the schema field, so `screenshotDataUrl` survives validation and reaches the (mocked) ingest. (If it FAILS with `screenshotDataUrl: undefined`, Task 1 was not applied — stop and fix Task 1.)
+
+This test guards the wire contract. The decode/store/embed below is covered by `parseDataUrl` (Task 2) plus manual QA, since the embed is DB- and vault-bound.
+
+- [ ] **Step 3: Add imports to ingest.ts**
+
+In `apps/desktop/src/main/inbox/ingest.ts`, extend the attachments import (line 13) and add the helper import:
+
+```ts
+import { getItemAttachmentsDir, storeInboxAttachment } from './attachments'
+import { parseDataUrl } from './parse-data-url'
+```
+
+- [ ] **Step 4: Decode + store + embed in the create-path**
+
+In `ingest.ts`, replace the create-path block (currently lines 83-111, from `// Create a new item` through the `insertItemWithTags(...)` call) with:
+
+```ts
+// Create a new item (extension path).
+const id = generateId()
+const now = new Date().toISOString()
+const tags = input.tags ?? input.properties.tags ?? []
+
+// Screenshot mode: decode the data URL into an inbox attachment and make the
+// image the note body. The extension sends contentMarkdown:'' for screenshots.
+let content = input.contentMarkdown
+let screenshotPath: string | null = null
+if (input.screenshotDataUrl) {
+  const parsed = parseDataUrl(input.screenshotDataUrl)
+  if (parsed) {
+    const stored = await storeInboxAttachment(id, parsed.buffer, 'screenshot', parsed.mime)
+    if (stored.success && stored.path) {
+      screenshotPath = stored.path
+      content = `![screenshot](${stored.path})`
+    } else {
+      log.warn('screenshot attachment failed', { itemId: id, error: stored.error })
+    }
+  }
+}
+
+const thumbnailPath = screenshotPath ?? (await downloadHero(id, input.heroImage))
+const { row, tags: appliedTags } = insertItemWithTags(
+  db,
+  {
+    id,
+    type: input.itemType ?? 'link',
+    title: input.properties.title,
+    content,
+    sourceUrl: input.url,
+    thumbnailPath,
+    createdAt: now,
+    modifiedAt: now,
+    processingStatus: 'complete',
+    captureSource: source,
+    metadata: {
+      url: input.url,
+      fetchStatus: 'complete',
+      excerpt: input.excerpt,
+      extractionStatus: input.extractionStatus,
+      heroImage: input.heroImage,
+      properties: input.properties
+    }
+  },
+  tags
+)
+```
+
+(The `emitCapturedAndSync(row, appliedTags)` / `log.info` / `return { itemId: id }` lines below stay unchanged.)
+
+- [ ] **Step 5: Re-run the desktop capture test + typecheck**
+
+Run: `pnpm --filter @memry/desktop test:main capture/server.test.ts && pnpm --filter @memry/desktop typecheck:node`
+Expected: PASS; 0 type errors. (If `better-sqlite3` raises `ERR_DLOPEN_FAILED`, run `pnpm --filter @memry/desktop rebuild:node` and retry — the server test mocks ingest so it should not load it, but typecheck compiles ingest.ts.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/main/inbox/ingest.ts apps/desktop/src/main/capture/server.test.ts
+git commit -m "feat(inbox): ingest screenshot captures as inbox image attachments"
+```
+
+---
+
+## Task 4: Extension messages + reducer (mode + capturing)
+
+**Files:**
+
+- Modify: `apps/extension/src/lib/messages.ts`
+- Modify: `apps/extension/src/lib/popup-state.ts`
+- Test: `apps/extension/src/lib/popup-state.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  - `CaptureMode = 'article' | 'selection' | 'screenshot'`
+  - `ContentMessage` += `{ type: 'GRAB_SELECTION' }`, `{ type: 'GET_PAGE_METRICS' }`, `{ type: 'SCROLL_TO'; y: number }`
+  - `PopupMessage` += `{ type: 'GRAB_SCREENSHOT' }`
+  - `PageMetrics = { scrollHeight; innerHeight; innerWidth; dpr; scrollY }`
+  - `ScreenshotResponse = { ok: true; dataUrl: string } | { ok: false; error: string }`
+  - `PopupState` gains `mode: CaptureMode` and `capturing: boolean`; `PopupAction` gains `{ type: 'SET_MODE'; mode: CaptureMode }`; `Phase` gains `'capturing'`.
+  - Consumed by Tasks 6, 7, 8.
+
+- [ ] **Step 1: Extend messages.ts**
+
+Replace the message section of `apps/extension/src/lib/messages.ts` (from `export type PopupMessage` to end of file) with:
+
+```ts
+export type CaptureMode = 'article' | 'selection' | 'screenshot'
+
+export type PopupMessage =
+  | { type: 'GET_STATUS' }
+  | { type: 'PAIR' }
+  | { type: 'CAPTURE'; capture: ArticleCapture }
+  | { type: 'WAIT_FOR_SERVER' }
+  | { type: 'GRAB_SCREENSHOT' }
+
+export type ContentMessage =
+  | { type: 'EXTRACT' }
+  | { type: 'GRAB_SELECTION' }
+  | { type: 'GET_PAGE_METRICS' }
+  | { type: 'SCROLL_TO'; y: number }
+
+export type ExtractResponse = { ok: true; capture: ArticleCapture } | { ok: false; error: string }
+
+export interface PageMetrics {
+  scrollHeight: number
+  innerHeight: number
+  innerWidth: number
+  dpr: number
+  scrollY: number
+}
+
+export type ScreenshotResponse = { ok: true; dataUrl: string } | { ok: false; error: string }
+```
+
+- [ ] **Step 2: Write the failing reducer tests**
+
+In `apps/extension/src/lib/popup-state.test.ts`, add (the file already imports `reducer`, `initialState`, `selectPhase` — reuse those imports; if `selectPhase` is not yet imported there, add it):
+
+```ts
+describe('mode switching', () => {
+  it('SET_MODE to selection starts capturing and resets draftReady', () => {
+    const s = reducer(
+      { ...initialState, draftReady: true },
+      { type: 'SET_MODE', mode: 'selection' }
+    )
+    expect(s.mode).toBe('selection')
+    expect(s.capturing).toBe(true)
+    expect(s.draftReady).toBe(false)
+  })
+
+  it('SET_MODE to article does not enter capturing', () => {
+    const s = reducer(initialState, { type: 'SET_MODE', mode: 'article' })
+    expect(s.mode).toBe('article')
+    expect(s.capturing).toBe(false)
+  })
+
+  it('DRAFT_READY clears capturing', () => {
+    const mid = reducer(initialState, { type: 'SET_MODE', mode: 'screenshot' })
+    const done = reducer(mid, { type: 'DRAFT_READY', draft: null })
+    expect(done.capturing).toBe(false)
+    expect(done.draftReady).toBe(true)
+  })
+
+  it('selectPhase returns capturing while a grab is in flight', () => {
+    expect(selectPhase({ ...initialState, capturing: true })).toBe('capturing')
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm --filter @memry/extension test -- popup-state`
+Expected: FAIL — `SET_MODE` not handled, `capturing`/`mode` undefined, `'capturing'` phase missing.
+
+- [ ] **Step 4: Update popup-state.ts**
+
+In `apps/extension/src/lib/popup-state.ts`:
+
+Add `'capturing'` to the `Phase` union and import `CaptureMode`:
+
+```ts
+import type { CaptureMode, ConnectionState } from './messages'
+
+export type Phase =
+  | 'extracting'
+  | 'capturing'
+  | 'app-closed'
+  | 'launching'
+  | 'ready'
+  | 'approving'
+  | 'saving'
+  | 'saved'
+  | 'error'
+```
+
+Add `mode` + `capturing` to `PopupState` and `initialState`:
+
+```ts
+export interface PopupState {
+  draft: ArticleCapture | null
+  draftReady: boolean
+  mode: CaptureMode
+  capturing: boolean
+  connection: 'unknown' | ConnectionState
+  port: number | null
+  action: 'idle' | 'launching' | 'approving' | 'saving' | 'saved' | 'error'
+  itemId: string | null
+  errorMessage: string | null
+}
+```
+
+```ts
+export const initialState: PopupState = {
+  draft: null,
+  draftReady: false,
+  mode: 'article',
+  capturing: false,
+  connection: 'unknown',
+  port: null,
+  action: 'idle',
+  itemId: null,
+  errorMessage: null
+}
+```
+
+Add `SET_MODE` to `PopupAction`:
+
+```ts
+  | { type: 'SET_MODE'; mode: CaptureMode }
+```
+
+In `reducer`, update `DRAFT_READY` to clear `capturing` and add the `SET_MODE` case:
+
+```ts
+    case 'DRAFT_READY':
+      return { ...state, draft: action.draft, draftReady: true, capturing: false }
+    case 'SET_MODE':
+      return {
+        ...state,
+        mode: action.mode,
+        capturing: action.mode !== 'article',
+        draftReady: false,
+        errorMessage: null
+      }
+```
+
+In `selectPhase`, add the capturing check right after the `extracting` precondition group — place it so an in-flight grab wins over `ready` but not over an active save/error:
+
+```ts
+export function selectPhase(state: PopupState): Phase {
+  if (state.action === 'saved') return 'saved'
+  if (state.action === 'error') return 'error'
+  if (state.action === 'saving') return 'saving'
+  if (state.action === 'approving') return 'approving'
+  if (state.action === 'launching') return 'launching'
+  if (state.connection === 'unknown' || !state.draftReady) return 'extracting'
+  if (state.capturing) return 'capturing'
+  if (state.connection === 'app-closed') return 'app-closed'
+  return 'ready'
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @memry/extension test -- popup-state`
+Expected: PASS (existing + 4 new).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @memry/extension typecheck`
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/extension/src/lib/messages.ts apps/extension/src/lib/popup-state.ts apps/extension/src/lib/popup-state.test.ts
+git commit -m "feat(extension): add capture-mode state + messages"
+```
+
+---
+
+## Task 5: Pure capture-mode helpers (extension)
+
+**Files:**
+
+- Create: `apps/extension/src/lib/capture-modes.ts`
+- Test: `apps/extension/src/lib/capture-modes.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ArticleCapture` (`@memry/article-extract`).
+- Produces:
+  - `toSelectionCapture(base: ArticleCapture, selectionText: string, title: string): ArticleCapture` (Task 6)
+  - `buildScreenshotDraft(base: ArticleCapture, screenshotDataUrl: string): ArticleCapture` (Task 8)
+  - `planStitch(opts: { scrollHeight; innerHeight; innerWidth; dpr; maxHeight }): { width; height; slices: { scrollY; drawY }[] }` (Task 7)
+  - `bytesToDataUrl(bytes: Uint8Array, mime: string): string` (Task 7)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/extension/src/lib/capture-modes.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import type { ArticleCapture } from '@memry/article-extract'
+import {
+  bytesToDataUrl,
+  buildScreenshotDraft,
+  planStitch,
+  toSelectionCapture
+} from './capture-modes'
+
+const base: ArticleCapture = {
+  url: 'https://example.com/p',
+  mode: 'article',
+  contentMarkdown: '# Real markdown',
+  excerpt: 'x',
+  extractionStatus: 'full',
+  properties: {
+    title: 'Page',
+    source: 'https://example.com/p',
+    created: 'now',
+    tags: ['clippings']
+  }
+}
+
+describe('toSelectionCapture', () => {
+  it('keeps defuddle markdown when present and marks the capture as a forced selection', () => {
+    const c = toSelectionCapture(base, 'plain selected text', 'Page')
+    expect(c.mode).toBe('selection')
+    expect(c.force).toBe(true)
+    expect(c.contentMarkdown).toBe('# Real markdown')
+    expect(c.extractionStatus).toBe('full')
+  })
+
+  it('falls back to plain selection text when markdown is empty', () => {
+    const c = toSelectionCapture({ ...base, contentMarkdown: '   ' }, 'plain selected text', 'Page')
+    expect(c.contentMarkdown).toBe('plain selected text')
+  })
+})
+
+describe('buildScreenshotDraft', () => {
+  it('builds a forced screenshot capture with an empty body', () => {
+    const c = buildScreenshotDraft(base, 'data:image/png;base64,AAAA')
+    expect(c.mode).toBe('screenshot')
+    expect(c.force).toBe(true)
+    expect(c.contentMarkdown).toBe('')
+    expect(c.screenshotDataUrl).toBe('data:image/png;base64,AAAA')
+    expect(c.properties.title).toBe('Page')
+  })
+})
+
+describe('planStitch', () => {
+  it('returns a single bottom-clipped slice for a short page', () => {
+    const p = planStitch({
+      scrollHeight: 500,
+      innerHeight: 800,
+      innerWidth: 1000,
+      dpr: 1,
+      maxHeight: 15000
+    })
+    expect(p.slices).toEqual([{ scrollY: 0, drawY: 0 }])
+    expect(p.height).toBe(500)
+    expect(p.width).toBe(1000)
+  })
+
+  it('bottom-aligns the final slice on a non-multiple page', () => {
+    const p = planStitch({
+      scrollHeight: 2000,
+      innerHeight: 800,
+      innerWidth: 1000,
+      dpr: 1,
+      maxHeight: 15000
+    })
+    expect(p.slices.map((s) => s.scrollY)).toEqual([0, 800, 1200])
+    expect(p.height).toBe(2000)
+  })
+
+  it('applies devicePixelRatio to canvas size and draw offsets', () => {
+    const p = planStitch({
+      scrollHeight: 1600,
+      innerHeight: 800,
+      innerWidth: 500,
+      dpr: 2,
+      maxHeight: 15000
+    })
+    expect(p.width).toBe(1000)
+    expect(p.height).toBe(3200)
+    expect(p.slices).toEqual([
+      { scrollY: 0, drawY: 0 },
+      { scrollY: 800, drawY: 1600 }
+    ])
+  })
+
+  it('clamps total height to maxHeight', () => {
+    const p = planStitch({
+      scrollHeight: 99999,
+      innerHeight: 800,
+      innerWidth: 100,
+      dpr: 1,
+      maxHeight: 1600
+    })
+    expect(p.height).toBe(1600)
+    expect(p.slices[p.slices.length - 1].scrollY).toBe(800)
+  })
+})
+
+describe('bytesToDataUrl', () => {
+  it('encodes bytes as a base64 data URL', () => {
+    expect(bytesToDataUrl(new Uint8Array([104, 105]), 'image/png')).toBe(
+      'data:image/png;base64,aGk='
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @memry/extension test -- capture-modes`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/extension/src/lib/capture-modes.ts`:
+
+```ts
+import type { ArticleCapture } from '@memry/article-extract'
+
+// Turn a defuddle extraction of the selected fragment into a forced selection
+// capture. Falls back to the raw selection text when defuddle yields nothing.
+export function toSelectionCapture(
+  base: ArticleCapture,
+  selectionText: string,
+  title: string
+): ArticleCapture {
+  const contentMarkdown = base.contentMarkdown.trim() ? base.contentMarkdown : selectionText
+  return {
+    ...base,
+    mode: 'selection',
+    contentMarkdown,
+    excerpt: selectionText.slice(0, 200),
+    extractionStatus: 'full',
+    force: true,
+    properties: { ...base.properties, title: title || base.properties.title }
+  }
+}
+
+// Build a forced screenshot capture. The body is empty; the desktop decodes
+// screenshotDataUrl into an attachment and writes the real markdown body.
+export function buildScreenshotDraft(
+  base: ArticleCapture,
+  screenshotDataUrl: string
+): ArticleCapture {
+  return {
+    url: base.url,
+    mode: 'screenshot',
+    contentMarkdown: '',
+    excerpt: '',
+    extractionStatus: 'full',
+    force: true,
+    screenshotDataUrl,
+    properties: { ...base.properties }
+  }
+}
+
+export interface StitchSlice {
+  scrollY: number
+  drawY: number
+}
+
+export interface StitchPlan {
+  width: number
+  height: number
+  slices: StitchSlice[]
+}
+
+// Plan a full-page screenshot: which scroll positions to capture and where to
+// paint each viewport-tall slice on the stitched canvas. The final slice is
+// bottom-aligned so it never captures blank space below the page. Total height
+// is clamped to maxHeight to keep the encoded PNG under the /capture cap.
+export function planStitch(opts: {
+  scrollHeight: number
+  innerHeight: number
+  innerWidth: number
+  dpr: number
+  maxHeight: number
+}): StitchPlan {
+  const { scrollHeight, innerHeight, innerWidth, dpr, maxHeight } = opts
+  const total = Math.min(scrollHeight, maxHeight)
+  const tops: number[] = []
+  for (let y = 0; y < total; y += innerHeight) tops.push(y)
+  if (tops.length === 0) tops.push(0)
+  const lastTop = Math.max(0, total - innerHeight)
+  if (tops[tops.length - 1] < lastTop) tops.push(lastTop)
+  else tops[tops.length - 1] = lastTop
+  const unique = tops.filter((y, i) => i === 0 || y !== tops[i - 1])
+  return {
+    width: Math.round(innerWidth * dpr),
+    height: Math.round(total * dpr),
+    slices: unique.map((scrollY) => ({ scrollY, drawY: Math.round(scrollY * dpr) }))
+  }
+}
+
+// Encode bytes to a base64 data URL. Chunked to avoid blowing the call stack on
+// large screenshots when spreading into String.fromCharCode.
+export function bytesToDataUrl(bytes: Uint8Array, mime: string): string {
+  let binary = ''
+  const chunk = 0x8000
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+  }
+  return `data:${mime};base64,${btoa(binary)}`
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @memry/extension test -- capture-modes`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @memry/extension typecheck`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/extension/src/lib/capture-modes.ts apps/extension/src/lib/capture-modes.test.ts
+git commit -m "feat(extension): pure selection/screenshot/stitch helpers"
+```
+
+---
+
+## Task 6: Selection + scroll/metrics handlers in content script (extension, manual QA)
+
+**Files:**
+
+- Modify: `apps/extension/src/entrypoints/content.ts`
+
+**Interfaces:**
+
+- Consumes: `toSelectionCapture` (Task 5), `extractFromDocument` (`@memry/article-extract/browser`), `ContentMessage`/`ExtractResponse`/`PageMetrics` (Task 4).
+- Produces: content script responds to `GRAB_SELECTION` (→ `ExtractResponse`), `GET_PAGE_METRICS` (→ `PageMetrics`), `SCROLL_TO` (→ `{ ok: true }`).
+
+- [ ] **Step 1: Rewrite content.ts**
+
+Replace `apps/extension/src/entrypoints/content.ts` with:
+
+```ts
+import type { ContentMessage, ExtractResponse, PageMetrics } from '@/lib/messages'
+import { extractFromDocument } from '@memry/article-extract/browser'
+import { toSelectionCapture } from '@/lib/capture-modes'
+
+function grabSelection(): ExtractResponse {
+  const sel = window.getSelection()
+  if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+    return { ok: false, error: 'no-selection' }
+  }
+  // ponytail: first range only — multi-range (Ctrl-click) selections are rare;
+  // upgrade path = concat cloneContents() of every range.
+  const fragment = sel.getRangeAt(0).cloneContents()
+  const doc = document.implementation.createHTMLDocument(document.title)
+  doc.body.appendChild(fragment)
+  const base = extractFromDocument(doc, location.href)
+  return { ok: true, capture: toSelectionCapture(base, sel.toString(), document.title) }
+}
+
+function pageMetrics(): PageMetrics {
+  return {
+    scrollHeight: document.documentElement.scrollHeight,
+    innerHeight: window.innerHeight,
+    innerWidth: window.innerWidth,
+    dpr: window.devicePixelRatio || 1,
+    scrollY: window.scrollY
+  }
+}
+
+export default defineContentScript({
+  // ponytail: declared on all web pages (standard clipper pattern); inert until messaged.
+  matches: ['*://*/*'],
+  main() {
+    browser.runtime.onMessage.addListener((message: ContentMessage) => {
+      switch (message.type) {
+        case 'EXTRACT':
+          try {
+            return Promise.resolve<ExtractResponse>({
+              ok: true,
+              capture: extractFromDocument(document, location.href)
+            })
+          } catch (err) {
+            return Promise.resolve<ExtractResponse>({ ok: false, error: String(err) })
+          }
+        case 'GRAB_SELECTION':
+          try {
+            return Promise.resolve(grabSelection())
+          } catch (err) {
+            return Promise.resolve<ExtractResponse>({ ok: false, error: String(err) })
+          }
+        case 'GET_PAGE_METRICS':
+          return Promise.resolve(pageMetrics())
+        case 'SCROLL_TO':
+          window.scrollTo(0, message.y)
+          return Promise.resolve({ ok: true })
+        default:
+          return Promise.resolve<ExtractResponse>({ ok: false, error: 'unknown-message' })
+      }
+    })
+  }
+})
+```
+
+- [ ] **Step 2: Typecheck + build the extension**
+
+Run: `pnpm --filter @memry/extension typecheck && pnpm --filter @memry/extension build`
+Expected: 0 type errors; build succeeds (WXT entrypoints compile).
+
+- [ ] **Step 3: Run the extension unit suite (no regressions)**
+
+Run: `pnpm --filter @memry/extension test`
+Expected: PASS (content.ts has no unit tests — the selection envelope logic is covered by `capture-modes.test.ts`; this confirms nothing else broke).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/extension/src/entrypoints/content.ts
+git commit -m "feat(extension): content-script selection grab + scroll/metrics"
+```
+
+---
+
+## Task 7: Screenshot orchestration in background (extension, manual QA)
+
+**Files:**
+
+- Modify: `apps/extension/src/entrypoints/background.ts`
+
+**Interfaces:**
+
+- Consumes: `planStitch`, `bytesToDataUrl` (Task 5); `GRAB_SCREENSHOT` message, `PageMetrics`, `ScreenshotResponse` (Task 4).
+- Produces: background responds to `GRAB_SCREENSHOT` with a `ScreenshotResponse` carrying the stitched full-page PNG data URL.
+
+- [ ] **Step 1: Add the screenshot orchestration to background.ts**
+
+In `apps/extension/src/entrypoints/background.ts`, update imports and add the helper + message case.
+
+Update the imports at the top:
+
+```ts
+import type {
+  CaptureResponse,
+  PageMetrics,
+  PairResponse,
+  PopupMessage,
+  ScreenshotResponse,
+  StatusResponse
+} from '@/lib/messages'
+import type { ArticleCapture } from '@memry/article-extract'
+import { claimToken, pollUntil, postCapture, probeServer, requestPair } from '@/lib/capture-client'
+import { bytesToDataUrl, planStitch } from '@/lib/capture-modes'
+```
+
+Add constants + the `grabScreenshot` function above `export default defineBackground`:
+
+```ts
+const MAX_SHOT_HEIGHT = 15000 // ponytail: cap full-page height so the PNG stays under /capture's 25MB cap
+const SETTLE_MS = 400 // wait between scroll and capture; also honors captureVisibleTab's ~2/sec limit
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+async function grabScreenshot(): Promise<ScreenshotResponse> {
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true })
+  if (!tab?.id || tab.windowId == null) return { ok: false, error: 'no-tab' }
+  const tabId = tab.id
+  const windowId = tab.windowId
+  try {
+    const metrics = (await browser.tabs.sendMessage(tabId, {
+      type: 'GET_PAGE_METRICS'
+    })) as PageMetrics
+    const plan = planStitch({ ...metrics, maxHeight: MAX_SHOT_HEIGHT })
+    const canvas = new OffscreenCanvas(plan.width, plan.height)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return { ok: false, error: 'no-canvas' }
+    try {
+      for (const slice of plan.slices) {
+        await browser.tabs.sendMessage(tabId, { type: 'SCROLL_TO', y: slice.scrollY })
+        await sleep(SETTLE_MS)
+        const shot = await browser.tabs.captureVisibleTab(windowId, { format: 'png' })
+        const bmp = await createImageBitmap(await (await fetch(shot)).blob())
+        ctx.drawImage(bmp, 0, slice.drawY)
+        bmp.close()
+      }
+    } finally {
+      // Always restore the user's scroll position, even if a capture threw.
+      await browser.tabs
+        .sendMessage(tabId, { type: 'SCROLL_TO', y: metrics.scrollY })
+        .catch(() => {})
+    }
+    const blob = await canvas.convertToBlob({ type: 'image/png' })
+    const bytes = new Uint8Array(await blob.arrayBuffer())
+    return { ok: true, dataUrl: bytesToDataUrl(bytes, 'image/png') }
+  } catch (err) {
+    return { ok: false, error: String(err) }
+  }
+}
+```
+
+Add the case to the message switch (inside `browser.runtime.onMessage.addListener`):
+
+```ts
+      case 'GRAB_SCREENSHOT':
+        return grabScreenshot()
+```
+
+- [ ] **Step 2: Typecheck + build**
+
+Run: `pnpm --filter @memry/extension typecheck && pnpm --filter @memry/extension build`
+Expected: 0 type errors; build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/extension/src/entrypoints/background.ts
+git commit -m "feat(extension): full-page screenshot scroll+stitch in background"
+```
+
+---
+
+## Task 8: Popup mode switching + previews (extension, manual QA)
+
+**Files:**
+
+- Modify: `apps/extension/src/components/ModeSegmented.tsx`
+- Create: `apps/extension/src/components/ScreenshotPreview.tsx`
+- Modify: `apps/extension/src/entrypoints/popup/App.tsx`
+
+**Interfaces:**
+
+- Consumes: `buildScreenshotDraft` (Task 5); `SET_MODE`/`capturing`/`mode` (Task 4); `GRAB_SELECTION`/`GRAB_SCREENSHOT` messages; `ExtractResponse`/`ScreenshotResponse` (Task 4); `CaptureMode`.
+- Produces: interactive 3-mode popup. Article re-uses the initial extraction; Selection grabs from the content script; Shot triggers background capture. Read-only body for selection, image miniature for screenshot, empty-state hints, capturing spinner.
+
+- [ ] **Step 1: Make ModeSegmented interactive**
+
+Replace `apps/extension/src/components/ModeSegmented.tsx` with:
+
+```tsx
+import type { CaptureMode } from '@/lib/messages'
+
+const MODES: { id: CaptureMode; label: string }[] = [
+  { id: 'article', label: 'Article' },
+  { id: 'selection', label: 'Selection' },
+  { id: 'screenshot', label: 'Shot' }
+]
+
+export function ModeSegmented({
+  mode,
+  disabled,
+  onSelect
+}: {
+  mode: CaptureMode
+  disabled: boolean
+  onSelect: (mode: CaptureMode) => void
+}) {
+  return (
+    <div className="flex gap-1 rounded-md bg-surface p-1">
+      {MODES.map((m) => (
+        <button
+          key={m.id}
+          type="button"
+          disabled={disabled}
+          onClick={() => onSelect(m.id)}
+          className={
+            'flex-1 rounded px-2 py-1 text-[12px] font-medium transition-colors disabled:opacity-50 ' +
+            (m.id === mode ? 'bg-background text-foreground shadow-sm' : 'text-text-tertiary')
+          }
+        >
+          {m.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Add the screenshot preview component**
+
+Create `apps/extension/src/components/ScreenshotPreview.tsx`:
+
+```tsx
+export function ScreenshotPreview({ dataUrl }: { dataUrl: string }) {
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-surface">
+      <img
+        src={dataUrl}
+        alt="Page screenshot"
+        className="max-h-48 w-full object-contain object-top"
+      />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Wire mode switching into App.tsx**
+
+In `apps/extension/src/entrypoints/popup/App.tsx`:
+
+Update imports (add `useRef`, `CaptureMode`, `ScreenshotResponse`, the screenshot helper, the new component):
+
+```tsx
+import { useEffect, useReducer, useRef } from 'react'
+import type { ArticleCapture } from '@memry/article-extract'
+import type {
+  CaptureResponse,
+  CaptureMode,
+  ConnectionState,
+  ExtractResponse,
+  PairResponse,
+  ScreenshotResponse,
+  StatusResponse
+} from '@/lib/messages'
+import { initialState, reducer, selectPhase } from '@/lib/popup-state'
+import { buildScreenshotDraft } from '@/lib/capture-modes'
+import { StatusStrip } from '@/components/StatusStrip'
+import { EditableTitle } from '@/components/EditableTitle'
+import { PropertyRows } from '@/components/PropertyRows'
+import { TagEditor } from '@/components/TagEditor'
+import { BodyPreview } from '@/components/BodyPreview'
+import { ModeSegmented } from '@/components/ModeSegmented'
+import { ScreenshotPreview } from '@/components/ScreenshotPreview'
+import { PrimaryButton } from '@/components/PrimaryButton'
+```
+
+Inside the component, cache the article draft as it arrives. Change the mount effect's `DRAFT_READY` dispatch to also store the article draft in a ref:
+
+```tsx
+const [state, dispatch] = useReducer(reducer, initialState)
+const phase = selectPhase(state)
+const articleDraftRef = useRef<ArticleCapture | null>(null)
+```
+
+In the mount effect, replace the `EXTRACT` `.then` so the article draft is cached:
+
+```tsx
+browser.tabs
+  .sendMessage(tab.id, { type: 'EXTRACT' })
+  .then((r: ExtractResponse) => {
+    articleDraftRef.current = r.ok ? r.capture : null
+    dispatch({ type: 'DRAFT_READY', draft: r.ok ? r.capture : null })
+  })
+  .catch(() => dispatch({ type: 'DRAFT_READY', draft: null }))
+```
+
+Add the `onSelectMode` handler (after `setDraft`):
+
+```tsx
+const onSelectMode = async (mode: CaptureMode) => {
+  if (mode === state.mode) return
+  dispatch({ type: 'SET_MODE', mode })
+  if (mode === 'article') {
+    dispatch({ type: 'DRAFT_READY', draft: articleDraftRef.current })
+    return
+  }
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true })
+  if (!tab?.id) return dispatch({ type: 'DRAFT_READY', draft: null })
+  if (mode === 'selection') {
+    const r: ExtractResponse = await browser.tabs
+      .sendMessage(tab.id, { type: 'GRAB_SELECTION' })
+      .catch(() => ({ ok: false, error: 'network' }))
+    dispatch({ type: 'DRAFT_READY', draft: r.ok ? r.capture : null })
+  } else {
+    const base = articleDraftRef.current
+    const r: ScreenshotResponse = await browser.runtime
+      .sendMessage({ type: 'GRAB_SCREENSHOT' })
+      .catch(() => ({ ok: false, error: 'network' }))
+    dispatch({
+      type: 'DRAFT_READY',
+      draft: r.ok && base ? buildScreenshotDraft(base, r.dataUrl) : null
+    })
+  }
+}
+```
+
+- [ ] **Step 4: Render the new states**
+
+In the JSX, render `ModeSegmented` with props and branch the preview per mode. Replace the `<ModeSegmented />` + `<BodyPreview ... />` lines (currently inside the `{draft && (<> ... </>)}` block) with:
+
+```tsx
+;<ModeSegmented mode={state.mode} disabled={!editable} onSelect={onSelectMode} />
+{
+  state.mode === 'screenshot' && draft?.screenshotDataUrl ? (
+    <ScreenshotPreview dataUrl={draft.screenshotDataUrl} />
+  ) : (
+    <BodyPreview markdown={draft.contentMarkdown} />
+  )
+}
+```
+
+Add a `capturing` branch and a per-mode empty state. After the `{phase === 'extracting' && ...}` block, add:
+
+```tsx
+{
+  phase === 'capturing' && (
+    <div className="px-4 py-8 text-center text-[13px] text-text-tertiary">
+      {state.mode === 'screenshot' ? 'Capturing full page…' : 'Reading selection…'}
+    </div>
+  )
+}
+```
+
+The main editable block currently renders only when `phase !== 'extracting' && phase !== 'saved'`. Change that guard to also exclude `capturing`, and handle the no-draft case (empty selection / failed shot) with a hint. Replace the opening of that block and its inner `{draft && (` with:
+
+```tsx
+{
+  phase !== 'extracting' && phase !== 'capturing' && phase !== 'saved' && (
+    <div
+      className={
+        'flex flex-col gap-2 px-4 py-3 ' +
+        (phase === 'ready' || phase === 'error' ? '' : 'opacity-60')
+      }
+    >
+      <ModeSegmented mode={state.mode} disabled={!editable} onSelect={onSelectMode} />
+      {!draft && state.mode === 'selection' && (
+        <p className="py-6 text-center text-[12px] text-text-tertiary">
+          Select text on the page, then reopen the popup.
+        </p>
+      )}
+      {!draft && state.mode === 'screenshot' && (
+        <p className="py-6 text-center text-[12px] text-text-tertiary">
+          Couldn't capture this page.
+        </p>
+      )}
+      {draft && (
+        <>
+          <EditableTitle
+            value={draft.properties.title}
+            disabled={!editable}
+            onChange={(title) => setDraft({ ...draft, properties: { ...draft.properties, title } })}
+          />
+          {draft.extractionStatus === 'failed' && (
+            <p className="text-[12px] text-text-tertiary">
+              Couldn't read this page — saving the link and title.
+            </p>
+          )}
+          <PropertyRows
+            properties={draft.properties}
+            disabled={!editable}
+            onChange={(properties) => setDraft({ ...draft, properties })}
+          />
+          <TagEditor
+            tags={draft.properties.tags}
+            disabled={!editable}
+            onChange={(tags) => setDraft({ ...draft, properties: { ...draft.properties, tags } })}
+          />
+          {state.mode === 'screenshot' && draft.screenshotDataUrl ? (
+            <ScreenshotPreview dataUrl={draft.screenshotDataUrl} />
+          ) : (
+            <BodyPreview markdown={draft.contentMarkdown} />
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+```
+
+NOTE: `ModeSegmented` now lives at the top of this block (outside the `{draft && ...}` so it shows even in the empty state). Remove the earlier duplicated `<ModeSegmented ... />` you added in Step 3's snippet so it appears exactly once. The "Add to Memry" button already keys off `phase === 'ready'` and is disabled when `!draft` — selection/screenshot empty states therefore can't be submitted.
+
+- [ ] **Step 5: Typecheck + build + unit suite**
+
+Run: `pnpm --filter @memry/extension typecheck && pnpm --filter @memry/extension build && pnpm --filter @memry/extension test`
+Expected: 0 type errors; build succeeds; all unit tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/extension/src/components/ModeSegmented.tsx apps/extension/src/components/ScreenshotPreview.tsx apps/extension/src/entrypoints/popup/App.tsx
+git commit -m "feat(extension): wire selection + screenshot modes into the popup"
+```
+
+---
+
+## Task 9: Full gate + whole-branch review
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Extension gate**
+
+Run: `pnpm --filter @memry/extension test && pnpm --filter @memry/extension typecheck && pnpm --filter @memry/extension lint && pnpm --filter @memry/extension build`
+Expected: all green.
+
+- [ ] **Step 2: Desktop capture gate**
+
+Run: `pnpm --filter @memry/desktop test:main capture/server.test.ts && pnpm --filter @memry/desktop test:main parse-data-url && pnpm --filter @memry/desktop typecheck:node`
+Expected: all green. (If `better-sqlite3` `ERR_DLOPEN_FAILED`: `pnpm --filter @memry/desktop rebuild:node`, retry.)
+
+- [ ] **Step 3: Contracts + article-extract gate**
+
+Run: `pnpm --filter @memry/contracts test && pnpm --filter @memry/article-extract test`
+Expected: green.
+
+- [ ] **Step 4: Formatting**
+
+Run: `git diff --check`
+Expected: no whitespace errors. Confirm single-quote / no-semicolon / no-trailing-comma style in every changed file.
+
+- [ ] **Step 5: Whole-branch review (opus)**
+
+Dispatch a final review over the full branch diff (`git diff main...HEAD`) against the spec. Confirm: no `git add -A` slipped in `import-prompt/`; contract subpath import only; logical Tailwind classes; Phase 3.1 pairing/launch flow untouched; the screenshot height cap + scroll-restore are present.
+
+- [ ] **Step 6: Manual GUI QA — HUMAN-REQUIRED (acceptance gate)**
+
+This cannot be automated. The human must:
+
+1. `pnpm dev` (desktop) running.
+2. Load the unpacked extension (`apps/extension/.output/chrome-mv3`) in Chrome.
+3. **Selection:** select text on a real article → open popup → "Selection" → confirm read-only body shows the selection → "Add to Memry" → confirm a text note lands in the inbox with the selection as markdown.
+4. **Shot:** open popup → "Shot" → watch "Capturing full page…" → confirm the stitched miniature → "Add to Memry" → confirm an image note lands in the inbox showing the screenshot.
+5. **Regression:** Article mode + in-app pairing (Phase 3.1) still work; switching back to Article is instant.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Selection mode (defuddle on fragment, force, read-only preview, empty state) → Tasks 5, 6, 8. ✓
+- Screenshot full-page scroll+stitch → Tasks 5 (`planStitch`/`bytesToDataUrl`), 7 (background loop). ✓
+- Desktop screenshot ingest (schema field, parseDataUrl, embed) → Tasks 1, 2, 3. ✓
+- Messages/state/permissions (no new perms) → Task 4 (state/messages); permissions unchanged (asserted in Task 9 review). ✓
+- Tests (pure logic unit-tested; entrypoints/React/canvas manual) → parseDataUrl (T2), reducer (T4), capture-modes incl. planStitch (T5); manual QA (T6,7,8,9). ✓
+- Acceptance GUI QA flagged human-required → Task 9 Step 6. ✓
+
+**Type consistency:** `ArticleCapture` envelope (`force?`, `screenshotDataUrl?`) added in Task 1 and used identically in Tasks 3/5/8. `planStitch` signature/return matches its test (T5) and caller (T7). `ScreenshotResponse`/`PageMetrics`/`CaptureMode` defined in T4, consumed with the same shapes in T6/T7/T8. `toSelectionCapture(base, selectionText, title)` and `buildScreenshotDraft(base, dataUrl)` arities match between T5 definition, T6/T8 calls.
+
+**Placeholder scan:** none — every code step shows full content.

--- a/docs/superpowers/plans/2026-06-17-link-capture-phase5-queue-keyboard-settings-open.md
+++ b/docs/superpowers/plans/2026-06-17-link-capture-phase5-queue-keyboard-settings-open.md
@@ -1,0 +1,1320 @@
+# Link Capture Phase 5 — Offline queue, keyboard command, settings, "Add & open" — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the clipper trustworthy: queue captures when Memry is unreachable and retry on reconnect (badge shows the count), add a keyboard shortcut to capture without the popup, ship a settings options page (re-pair / unpair / port override), and an "Add & open" action that deep-links to the captured item.
+
+**Architecture:** 5.1 builds an extension-local offline queue in `browser.storage.local` with a `chrome.alarms`-driven retry and an action badge; pure queue logic is isolated into a tested helper. 5.2 reuses that queue from a `commands` keyboard handler that messages the already-declared content script (no new permission). 5.3 adds a WXT options page plus one auth-guarded desktop route `/pair/revoke` (the desktop already has `unpairCapture()`/`rotateCaptureToken()`). 5.4 adds an `InboxChannels.events.OPEN_ITEM` event, a `memry://open?item=<id>` deep-link parse, and a popup split button.
+
+**Tech Stack:** WXT MV3 + React 19 (extension), Electron main + React renderer (desktop), Zod contracts, Vitest. No new dependencies.
+
+## Global Constraints
+
+- Prettier: single quotes, NO semicolons, 100-char width, no trailing commas — copy verbatim from `CLAUDE.md`.
+- Tailwind logical properties only: `ms/me`, `ps/pe`, `start/end`, `text-start/text-end` — never `ml/mr/pl/pr/left/right`.
+- NO `Co-Authored-By` trailer on commits.
+- Commit ONLY the task's files by explicit path. NEVER `git add -A` (the working tree has untracked `import-prompt/`, `marketing/`, and unrelated `apps/marketing-emails` edits that must not be committed).
+- Import the capture contract via the subpath `@memry/contracts/capture-api`, never the barrel.
+- **No new dependencies.** The ONLY new permission is `alarms` (5.1). `commands` and `options_ui` are manifest keys, not permissions. No new `host_permissions`.
+- Branch: `feat/link-capture-capture-modes` (Phase 4, stacked). The Phase 4 carry-over fixes are already committed (`b83c60b5`, `e7568a37`); the spec is `cf9c1e73`.
+- Spec: `docs/superpowers/specs/2026-06-17-link-capture-phase5-queue-keyboard-settings-open.md`.
+- Native-module gotcha: if a desktop `test:main` run fails with `better-sqlite3 ERR_DLOPEN_FAILED` or `cleanupTestDatabase ... reading 'close'`, run `pnpm --filter @memry/desktop rebuild:node` and retry.
+
+---
+
+## File Structure
+
+**Extension (`apps/extension`):**
+
+- `src/lib/capture-queue.ts` — NEW. Pure queue logic (`isRetryable`, `enqueue`, `dequeueById`, `badgeText`, `QueuedCapture`, `MAX_QUEUE`).
+- `src/lib/capture-queue.test.ts` — NEW.
+- `src/lib/messages.ts` — add `FLUSH_QUEUE`/`REVOKE` popup messages + `FlushResponse`.
+- `src/lib/popup-state.ts` — add `'queued'` phase/action + `SAVE_DONE` branch.
+- `src/lib/popup-state.test.ts` — reducer tests for the `queued` branch.
+- `src/lib/capture-client.ts` — `probeServer(fetchFn, ports)` overload + `postRevoke` + `revokeUrl`.
+- `src/lib/capture-client.test.ts` — port-list probe + `postRevoke` tests. (Create if absent.)
+- `src/entrypoints/background.ts` — queue/badge/flush/alarms, `captureOrQueue`, `onCommand`, `REVOKE`, port-override probe.
+- `src/entrypoints/popup/App.tsx` — offline copy + "Add & open" split button.
+- `src/entrypoints/options/index.html` + `main.tsx` + `App.tsx` — NEW options page.
+- `wxt.config.ts` — `alarms` permission, `commands` block.
+
+**Desktop / contracts:**
+
+- `apps/desktop/src/main/capture/server.ts` (+ `server.test.ts`) — `POST /pair/revoke`.
+- `packages/contracts/src/inbox-channels.ts` — `OPEN_ITEM` event.
+- `apps/desktop/src/main/index.ts` — `parseInboxOpenItemId` helper + deep-link `?item=` send.
+- `apps/desktop/src/main/index.deeplink.test.ts` — NEW, pure helper test (or fold into an existing index test file).
+- A renderer inbox subscriber for the generated `OPEN_ITEM` event.
+
+---
+
+## Task 1: Capture-queue pure helpers (extension)
+
+**Files:**
+
+- Create: `apps/extension/src/lib/capture-queue.ts`
+- Test: `apps/extension/src/lib/capture-queue.test.ts`
+
+**Interfaces:**
+
+- Produces (consumed by Tasks 3, 4):
+  - `QueuedCapture = { id: string; capture: ArticleCapture; queuedAt: number }`
+  - `MAX_QUEUE = 50`
+  - `isRetryable(error: string): boolean`
+  - `enqueue(queue: QueuedCapture[], item: QueuedCapture, max?: number): QueuedCapture[]`
+  - `dequeueById(queue: QueuedCapture[], id: string): QueuedCapture[]`
+  - `badgeText(count: number): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/extension/src/lib/capture-queue.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import type { ArticleCapture } from '@memry/article-extract'
+import { badgeText, dequeueById, enqueue, isRetryable, MAX_QUEUE } from './capture-queue'
+
+const cap = { url: 'https://x.test' } as unknown as ArticleCapture
+const item = (id: string) => ({ id, capture: cap, queuedAt: 0 })
+
+describe('isRetryable', () => {
+  it('retries only unreachable-server errors', () => {
+    expect(isRetryable('app-closed')).toBe(true)
+    expect(isRetryable('network')).toBe(true)
+  })
+  it('does not retry payload/auth/4xx/5xx failures', () => {
+    expect(isRetryable('bad-token')).toBe(false)
+    expect(isRetryable('origin-not-allowed')).toBe(false)
+    expect(isRetryable('invalid-capture')).toBe(false)
+    expect(isRetryable('payload-too-large')).toBe(false)
+    expect(isRetryable('http-413')).toBe(false)
+    expect(isRetryable('http-500')).toBe(false)
+  })
+})
+
+describe('enqueue', () => {
+  it('appends to the end', () => {
+    expect(enqueue([item('a')], item('b')).map((q) => q.id)).toEqual(['a', 'b'])
+  })
+  it('drops the oldest when over the cap', () => {
+    const r = enqueue([item('a'), item('b')], item('c'), 2)
+    expect(r.map((q) => q.id)).toEqual(['b', 'c'])
+  })
+  it('defaults to MAX_QUEUE', () => {
+    expect(MAX_QUEUE).toBe(50)
+  })
+})
+
+describe('dequeueById', () => {
+  it('removes the matching item', () => {
+    expect(dequeueById([item('a'), item('b')], 'a').map((q) => q.id)).toEqual(['b'])
+  })
+})
+
+describe('badgeText', () => {
+  it('blanks at zero, caps at 99+', () => {
+    expect(badgeText(0)).toBe('')
+    expect(badgeText(5)).toBe('5')
+    expect(badgeText(150)).toBe('99+')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/extension test -- capture-queue`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/extension/src/lib/capture-queue.ts`:
+
+```ts
+import type { ArticleCapture } from '@memry/article-extract'
+
+export interface QueuedCapture {
+  id: string
+  capture: ArticleCapture
+  queuedAt: number
+}
+
+export const MAX_QUEUE = 50
+
+// Retryable = the server was unreachable, not the payload being bad. Pairing,
+// validation, 4xx and 5xx codes are permanent — retrying never helps and a 5xx
+// loop would spin forever on a server bug. ponytail: upgrade path = backoff-retry
+// 5xx a few times before dropping.
+export function isRetryable(error: string): boolean {
+  return error === 'app-closed' || error === 'network'
+}
+
+// Append, dropping the oldest when the queue would exceed `max`.
+export function enqueue(
+  queue: QueuedCapture[],
+  item: QueuedCapture,
+  max = MAX_QUEUE
+): QueuedCapture[] {
+  const next = [...queue, item]
+  return next.length > max ? next.slice(next.length - max) : next
+}
+
+export function dequeueById(queue: QueuedCapture[], id: string): QueuedCapture[] {
+  return queue.filter((q) => q.id !== id)
+}
+
+export function badgeText(count: number): string {
+  if (count <= 0) return ''
+  return count > 99 ? '99+' : String(count)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/extension test -- capture-queue`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/extension/src/lib/capture-queue.ts apps/extension/src/lib/capture-queue.test.ts
+git commit -m "feat(extension): offline capture-queue pure helpers"
+```
+
+---
+
+## Task 2: Queue messages + `queued` reducer state (extension)
+
+**Files:**
+
+- Modify: `apps/extension/src/lib/messages.ts`
+- Modify: `apps/extension/src/lib/popup-state.ts`
+- Test: `apps/extension/src/lib/popup-state.test.ts`
+
+**Interfaces:**
+
+- Produces (consumed by Tasks 3, 7, 9):
+  - `PopupMessage` += `{ type: 'FLUSH_QUEUE' }`, `{ type: 'REVOKE' }`
+  - `FlushResponse = { flushed: number; remaining: number }`
+  - `Phase` += `'queued'`; `PopupState.action` union += `'queued'`; `SAVE_DONE` with `error === 'queued'` → action `'queued'` (a success-ish terminal state, not an error).
+
+- [ ] **Step 1: Extend messages.ts**
+
+In `apps/extension/src/lib/messages.ts`, extend `PopupMessage` and add `FlushResponse` after `ScreenshotResponse`:
+
+```ts
+export type PopupMessage =
+  | { type: 'GET_STATUS' }
+  | { type: 'PAIR' }
+  | { type: 'CAPTURE'; capture: ArticleCapture }
+  | { type: 'WAIT_FOR_SERVER' }
+  | { type: 'GRAB_SCREENSHOT' }
+  | { type: 'FLUSH_QUEUE' }
+  | { type: 'REVOKE' }
+```
+
+```ts
+export interface FlushResponse {
+  flushed: number
+  remaining: number
+}
+```
+
+- [ ] **Step 2: Write the failing reducer tests**
+
+In `apps/extension/src/lib/popup-state.test.ts`, add (reuse the existing `reducer`, `initialState`, `selectPhase` imports):
+
+```ts
+describe('offline queue state', () => {
+  it('SAVE_DONE with a queued result is a terminal queued state, not an error', () => {
+    const mid = reducer(initialState, { type: 'SAVE_START' })
+    const s = reducer(mid, { type: 'SAVE_DONE', result: { ok: false, error: 'queued' } })
+    expect(s.action).toBe('queued')
+    expect(s.errorMessage).toBeNull()
+    expect(selectPhase(s)).toBe('queued')
+  })
+
+  it('SAVE_DONE with a real error still maps to error', () => {
+    const s = reducer(initialState, {
+      type: 'SAVE_DONE',
+      result: { ok: false, error: 'bad-token' }
+    })
+    expect(s.action).toBe('error')
+    expect(selectPhase(s)).toBe('error')
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm --filter @memry/extension test -- popup-state`
+Expected: FAIL — `'queued'` action/phase not handled.
+
+- [ ] **Step 4: Update popup-state.ts**
+
+Add `'queued'` to the `Phase` union (after `'saved'`):
+
+```ts
+export type Phase =
+  | 'extracting'
+  | 'capturing'
+  | 'app-closed'
+  | 'launching'
+  | 'ready'
+  | 'approving'
+  | 'saving'
+  | 'saved'
+  | 'queued'
+  | 'error'
+```
+
+Add `'queued'` to `PopupState.action`:
+
+```ts
+action: 'idle' | 'launching' | 'approving' | 'saving' | 'saved' | 'queued' | 'error'
+```
+
+Replace the `SAVE_DONE` case:
+
+```ts
+    case 'SAVE_DONE':
+      if (action.result.ok) {
+        return { ...state, action: 'saved', itemId: action.result.itemId }
+      }
+      if (action.result.error === 'queued') {
+        return { ...state, action: 'queued', errorMessage: null }
+      }
+      return { ...state, action: 'error', errorMessage: mapError(action.result.error) }
+```
+
+In `selectPhase`, add the queued check right after the `saved` check:
+
+```ts
+if (state.action === 'saved') return 'saved'
+if (state.action === 'queued') return 'queued'
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @memry/extension test -- popup-state`
+Expected: PASS (existing + 2 new).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @memry/extension typecheck`
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/extension/src/lib/messages.ts apps/extension/src/lib/popup-state.ts apps/extension/src/lib/popup-state.test.ts
+git commit -m "feat(extension): queued capture state + flush/revoke messages"
+```
+
+---
+
+## Task 3: Background queue + badge + flush + alarms (extension, manual-QA)
+
+**Files:**
+
+- Modify: `apps/extension/wxt.config.ts`
+- Modify: `apps/extension/src/entrypoints/background.ts`
+- Modify: `apps/extension/src/entrypoints/popup/App.tsx`
+
+**Interfaces:**
+
+- Consumes: `capture-queue` helpers (Task 1), `FlushResponse` + `'queued'` state (Task 2), `probeServer`/`postCapture` (`capture-client`).
+- Produces: `captureOrQueue(body)` and `flushQueue()` used by Task 4; the `'queued'` popup rendering used by Task 9.
+
+- [ ] **Step 1: Add the `alarms` permission**
+
+In `apps/extension/wxt.config.ts`, change the permissions line:
+
+```ts
+    permissions: ['storage', 'activeTab', 'alarms'],
+```
+
+- [ ] **Step 2: Add queue + badge + flush + alarm wiring to background.ts**
+
+In `apps/extension/src/entrypoints/background.ts`, update the imports:
+
+```ts
+import type {
+  CaptureResponse,
+  FlushResponse,
+  PageMetrics,
+  PairResponse,
+  PopupMessage,
+  ScreenshotResponse,
+  StatusResponse
+} from '@/lib/messages'
+import type { ArticleCapture } from '@memry/article-extract'
+import { claimToken, pollUntil, postCapture, probeServer, requestPair } from '@/lib/capture-client'
+import { bytesToDataUrl, planStitch } from '@/lib/capture-modes'
+import {
+  badgeText,
+  dequeueById,
+  enqueue,
+  isRetryable,
+  type QueuedCapture
+} from '@/lib/capture-queue'
+```
+
+Add the queue layer above `export default defineBackground` (after the existing `getToken`/`setToken` helpers):
+
+```ts
+const QUEUE_KEY = 'memry:capture-queue'
+const FLUSH_ALARM = 'memry-flush'
+
+async function readQueue(): Promise<QueuedCapture[]> {
+  const r = await browser.storage.local.get(QUEUE_KEY)
+  const v = r[QUEUE_KEY]
+  return Array.isArray(v) ? (v as QueuedCapture[]) : []
+}
+
+async function writeQueue(queue: QueuedCapture[]): Promise<void> {
+  await browser.storage.local.set({ [QUEUE_KEY]: queue })
+}
+
+async function setBadge(count: number): Promise<void> {
+  await browser.action.setBadgeText({ text: badgeText(count) })
+  if (count > 0) await browser.action.setBadgeBackgroundColor({ color: '#E56458' })
+}
+
+async function ensureFlushAlarm(): Promise<void> {
+  const existing = await browser.alarms.get(FLUSH_ALARM)
+  if (!existing) await browser.alarms.create(FLUSH_ALARM, { periodInMinutes: 1 })
+}
+
+async function stopFlushAlarm(): Promise<void> {
+  await browser.alarms.clear(FLUSH_ALARM)
+}
+
+// Try the live server once and drain queued items oldest-first. Drop on success
+// or permanent failure; stop the pass (keep the rest) the moment the server is
+// unreachable again.
+async function flushQueue(): Promise<FlushResponse> {
+  let queue = await readQueue()
+  if (queue.length === 0) {
+    await stopFlushAlarm()
+    return { flushed: 0, remaining: 0 }
+  }
+  const found = await probeServer()
+  const token = await getToken()
+  if (!found || !token) return { flushed: 0, remaining: queue.length }
+  let flushed = 0
+  for (const item of [...queue]) {
+    const res = await postCapture(found.port, token, item.capture)
+    if (res.ok) {
+      queue = dequeueById(queue, item.id)
+      flushed++
+    } else if (isRetryable(res.error)) {
+      break
+    } else {
+      console.warn('[memry] dropping unsendable queued capture', item.id, res.error)
+      queue = dequeueById(queue, item.id)
+    }
+  }
+  await writeQueue(queue)
+  await setBadge(queue.length)
+  if (queue.length === 0) await stopFlushAlarm()
+  return { flushed, remaining: queue.length }
+}
+
+// Capture, or queue it for retry when the server is unreachable. Permanent
+// errors (bad token, invalid payload) pass straight through to the popup.
+async function captureOrQueue(body: ArticleCapture): Promise<CaptureResponse> {
+  const res = await capture(body)
+  if (res.ok) {
+    void flushQueue()
+    return res
+  }
+  if (isRetryable(res.error)) {
+    const queue = enqueue(await readQueue(), {
+      id: crypto.randomUUID(),
+      capture: body,
+      queuedAt: Date.now()
+    })
+    await writeQueue(queue)
+    await setBadge(queue.length)
+    await ensureFlushAlarm()
+    return { ok: false, error: 'queued' }
+  }
+  return res
+}
+```
+
+- [ ] **Step 3: Route messages through the queue + restore badge on startup**
+
+In the `defineBackground` callback, replace the listener body so `CAPTURE` queues, `GET_STATUS` opportunistically flushes, and `FLUSH_QUEUE` is handled; then add the alarm listener and a startup badge restore:
+
+```ts
+export default defineBackground(() => {
+  browser.runtime.onMessage.addListener((message: PopupMessage) => {
+    switch (message.type) {
+      case 'GET_STATUS':
+        return getStatus().then((status) => {
+          if (status.connection === 'ready') void flushQueue()
+          return status
+        })
+      case 'PAIR':
+        return pair()
+      case 'CAPTURE':
+        return captureOrQueue(message.capture)
+      case 'WAIT_FOR_SERVER':
+        return waitForServer()
+      case 'GRAB_SCREENSHOT':
+        return grabScreenshot()
+      case 'FLUSH_QUEUE':
+        return flushQueue()
+      default:
+        return undefined
+    }
+  })
+
+  browser.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === FLUSH_ALARM) void flushQueue()
+  })
+
+  // Restore the badge + retry alarm whenever the service worker (re)starts.
+  void (async () => {
+    const queue = await readQueue()
+    await setBadge(queue.length)
+    if (queue.length > 0) await ensureFlushAlarm()
+  })()
+})
+```
+
+(`REVOKE` is added in Task 7; leave it out for now.)
+
+- [ ] **Step 4: Render the queued state in the popup**
+
+In `apps/extension/src/entrypoints/popup/App.tsx`, exclude `'queued'` from the editable block guard and add a queued message. Change the block guard:
+
+```tsx
+      {phase !== 'extracting' && phase !== 'capturing' && phase !== 'saved' && phase !== 'queued' && (
+```
+
+In the footer block, after the `{phase === 'saved' && ...}` paragraph, add:
+
+```tsx
+{
+  phase === 'queued' && (
+    <p className="py-2 text-center text-[14px] font-medium text-foreground">
+      Saved offline — syncs when Memry opens ✓
+    </p>
+  )
+}
+```
+
+- [ ] **Step 5: Typecheck + build + unit suite**
+
+Run: `pnpm --filter @memry/extension typecheck && pnpm --filter @memry/extension build && pnpm --filter @memry/extension test`
+Expected: 0 type errors; build succeeds; all unit tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/extension/wxt.config.ts apps/extension/src/entrypoints/background.ts apps/extension/src/entrypoints/popup/App.tsx
+git commit -m "feat(extension): offline queue with alarm retry + badge"
+```
+
+---
+
+## Task 4: Keyboard command — capture without the popup (extension, manual-QA)
+
+**Files:**
+
+- Modify: `apps/extension/wxt.config.ts`
+- Modify: `apps/extension/src/entrypoints/background.ts`
+
+**Interfaces:**
+
+- Consumes: `captureOrQueue`, `setBadge`, `readQueue` (Task 3); the content script `EXTRACT` handler + `ExtractResponse` (existing).
+- Produces: a `capture-page` command that captures the active tab in Article mode.
+
+- [ ] **Step 1: Add the `commands` block to the manifest**
+
+In `apps/extension/wxt.config.ts`, add a `commands` key inside `manifest` (sibling of `permissions`):
+
+```ts
+    commands: {
+      'capture-page': {
+        suggested_key: { default: 'Ctrl+Shift+S', mac: 'Command+Shift+S' },
+        description: 'Capture this page to Memry'
+      }
+    }
+```
+
+(ponytail: suggested keys silently no-op on collision; the user rebinds at `chrome://extensions/shortcuts`. `commands` is a manifest key, not a permission.)
+
+- [ ] **Step 2: Handle the command in background.ts**
+
+Add the import for `ExtractResponse` (extend the existing `@/lib/messages` import type list) and, inside the `defineBackground` callback (after the `onMessage` listener), add:
+
+```ts
+browser.commands.onCommand.addListener(async (command) => {
+  if (command !== 'capture-page') return
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true })
+  if (!tab?.id) return
+  // The content script is declared on *://*/* and auto-injected, so messaging
+  // it needs no activeTab grant. It is absent on chrome://, the Web Store, and
+  // PDFs — sendMessage rejects there, which we surface as a brief error badge.
+  const extracted: ExtractResponse = await browser.tabs
+    .sendMessage(tab.id, { type: 'EXTRACT' })
+    .catch(() => ({ ok: false, error: 'no-content-script' }))
+  if (!extracted.ok) {
+    await browser.action.setBadgeText({ text: '!' })
+    await browser.action.setBadgeBackgroundColor({ color: '#E56458' })
+    setTimeout(() => void restoreQueueBadge(), 2000)
+    return
+  }
+  const res = await captureOrQueue(extracted.capture)
+  if (res.ok) {
+    await browser.action.setBadgeText({ text: '✓' })
+    await browser.action.setBadgeBackgroundColor({ color: '#3B873E' })
+    setTimeout(() => void restoreQueueBadge(), 2000)
+  }
+  // A queued save already set the count badge inside captureOrQueue.
+})
+```
+
+Add the `restoreQueueBadge` helper next to `setBadge` (Task 3 block):
+
+```ts
+async function restoreQueueBadge(): Promise<void> {
+  await setBadge((await readQueue()).length)
+}
+```
+
+- [ ] **Step 3: Typecheck + build**
+
+Run: `pnpm --filter @memry/extension typecheck && pnpm --filter @memry/extension build`
+Expected: 0 type errors; build succeeds (WXT emits the `commands` manifest key).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/extension/wxt.config.ts apps/extension/src/entrypoints/background.ts
+git commit -m "feat(extension): keyboard command captures the active page"
+```
+
+---
+
+## Task 5: Desktop `/pair/revoke` route (desktop)
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/capture/server.ts`
+- Modify: `apps/desktop/src/main/capture/server.test.ts`
+
+**Interfaces:**
+
+- Consumes: `validateCaptureRequest` (`./auth`), `getCaptureToken`/`isOriginAllowed` (already imported), `unpairCapture` (`./pairing`, existing — line 47).
+- Produces: `POST /pair/revoke` → 200 after `unpairCapture()`, guarded by the same auth as `/capture`.
+
+- [ ] **Step 1: Write the failing server test**
+
+In `apps/desktop/src/main/capture/server.test.ts`, add `unpairCapture` to the `./pairing` mock (find the `vi.mock('./pairing', ...)` factory and add `unpairCapture: vi.fn()` to the returned object; capture it as `const mockUnpair = vi.fn()` at module scope if the file uses that style — mirror how `claimPairing` is mocked). Then add this case after the existing `/capture` test:
+
+```ts
+it('revokes pairing for an authorized origin', async () => {
+  origins.add('chrome-extension://abc')
+  const res = await req(port, '/pair/revoke', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Origin: 'chrome-extension://abc',
+      'X-Memry-Capture': '1'
+    }
+  })
+  expect(res.status).toBe(200)
+  expect(mockUnpair).toHaveBeenCalledTimes(1)
+})
+
+it('rejects revoke with a bad token', async () => {
+  origins.add('chrome-extension://abc')
+  const res = await req(port, '/pair/revoke', {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer wrong',
+      Origin: 'chrome-extension://abc',
+      'X-Memry-Capture': '1'
+    }
+  })
+  expect(res.status).toBe(401)
+  expect(mockUnpair).not.toHaveBeenCalled()
+})
+```
+
+(Match `TOKEN`, `origins`, `req`, and `port` to the existing test harness in this file. If the `/capture` test uses different helper names, reuse those.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main capture/server.test.ts`
+Expected: FAIL — `/pair/revoke` returns 404.
+
+- [ ] **Step 3: Add the route**
+
+In `apps/desktop/src/main/capture/server.ts`, add `unpairCapture` to the pairing import (line 5):
+
+```ts
+import {
+  getCaptureToken,
+  isOriginAllowed,
+  claimPairing,
+  openPairingWindow,
+  unpairCapture
+} from './pairing'
+```
+
+Add the route inside `handle`, immediately before the final `json(res, 404, ...)`:
+
+```ts
+if (req.method === 'POST' && req.url === '/pair/revoke') {
+  const token = await getCaptureToken()
+  const auth = validateCaptureRequest(
+    {
+      authorization: req.headers.authorization,
+      origin,
+      'x-memry-capture': req.headers['x-memry-capture'] as string | undefined
+    },
+    token,
+    isOriginAllowed
+  )
+  if (!auth.ok) {
+    json(res, 401, { error: auth.reason })
+    return
+  }
+  await unpairCapture()
+  json(res, 200, { ok: true })
+  return
+}
+```
+
+(ponytail: `unpairCapture()` clears the whole allowlist + token — single-extension model; per-origin revoke is a Phase 6 non-goal.)
+
+- [ ] **Step 4: Run the test + typecheck**
+
+Run: `pnpm --filter @memry/desktop test:main capture/server.test.ts && pnpm --filter @memry/desktop typecheck:node`
+Expected: PASS; 0 type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/capture/server.ts apps/desktop/src/main/capture/server.test.ts
+git commit -m "feat(capture): add auth-guarded /pair/revoke route"
+```
+
+---
+
+## Task 6: Port-override probe + revoke client (extension)
+
+**Files:**
+
+- Modify: `apps/extension/src/lib/capture-client.ts`
+- Test: `apps/extension/src/lib/capture-client.test.ts` (create if absent)
+
+**Interfaces:**
+
+- Produces (consumed by Task 7):
+  - `probeServer(fetchFn?, ports?: number[])` — probes the supplied port list (defaults to `PROBE_PORTS`).
+  - `revokeUrl(port: number): string`
+  - `postRevoke(port: number, token: string, fetchFn?): Promise<boolean>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create (or append to) `apps/extension/src/lib/capture-client.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { postRevoke, probeServer, revokeUrl } from './capture-client'
+
+const ok = (body: unknown) => ({ ok: true, json: async () => body }) as unknown as Response
+const notOk = () => ({ ok: false, json: async () => ({}) }) as unknown as Response
+
+describe('probeServer with an explicit port list', () => {
+  it('returns the first live server in the supplied list', async () => {
+    const fetchFn = vi.fn(async (url: string) =>
+      url.includes(':9001') ? ok({ app: 'memry', paired: true, version: '1' }) : notOk()
+    ) as unknown as typeof fetch
+    const found = await probeServer(fetchFn, [9000, 9001])
+    expect(found?.port).toBe(9001)
+  })
+})
+
+describe('postRevoke', () => {
+  it('returns true on a 2xx', async () => {
+    const fetchFn = vi.fn(async () => ok({ ok: true })) as unknown as typeof fetch
+    expect(await postRevoke(7849, 'tok', fetchFn)).toBe(true)
+    expect((fetchFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(revokeUrl(7849))
+  })
+  it('returns false on a non-2xx', async () => {
+    const fetchFn = vi.fn(async () => notOk()) as unknown as typeof fetch
+    expect(await postRevoke(7849, 'tok', fetchFn)).toBe(false)
+  })
+  it('returns false when fetch throws', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('down')
+    }) as unknown as typeof fetch
+    expect(await postRevoke(7849, 'tok', fetchFn)).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @memry/extension test -- capture-client`
+Expected: FAIL — `revokeUrl`/`postRevoke` not exported; `probeServer` ignores the ports arg.
+
+- [ ] **Step 3: Update capture-client.ts**
+
+Add `revokeUrl` next to the other URL builders:
+
+```ts
+export function revokeUrl(port: number): string {
+  return `http://127.0.0.1:${port}/pair/revoke`
+}
+```
+
+Change `probeServer` to accept an explicit port list:
+
+```ts
+export async function probeServer(
+  fetchFn: typeof fetch = fetch,
+  ports: number[] = PROBE_PORTS
+): Promise<{ port: number; ping: PingResponse } | null> {
+  for (const port of ports) {
+    try {
+      const res = await fetchFn(pingUrl(port), { method: 'GET' })
+      if (!res.ok) continue
+      const ping = parsePing(await res.json())
+      if (ping) return { port, ping }
+    } catch {
+      // port not listening — try the next one
+    }
+  }
+  return null
+}
+```
+
+Add `postRevoke` near `postCapture`:
+
+```ts
+export async function postRevoke(
+  port: number,
+  token: string,
+  fetchFn: typeof fetch = fetch
+): Promise<boolean> {
+  try {
+    const res = await fetchFn(revokeUrl(port), { method: 'POST', headers: captureHeaders(token) })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @memry/extension test -- capture-client`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @memry/extension typecheck`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/extension/src/lib/capture-client.ts apps/extension/src/lib/capture-client.test.ts
+git commit -m "feat(extension): port-override probe + revoke client"
+```
+
+---
+
+## Task 7: Settings options page (extension, manual-QA)
+
+**Files:**
+
+- Create: `apps/extension/src/entrypoints/options/index.html`
+- Create: `apps/extension/src/entrypoints/options/main.tsx`
+- Create: `apps/extension/src/entrypoints/options/App.tsx`
+- Modify: `apps/extension/src/entrypoints/background.ts`
+
+**Interfaces:**
+
+- Consumes: `postRevoke`, `probeServer` with a port list (Task 6); `REVOKE` message (Task 2); existing `GET_STATUS`/`PAIR`.
+- Produces: a working options page; a background `REVOKE` handler; a `memry:capture-port` override that `probeServer` honors first.
+
+- [ ] **Step 1: Thread the port override + REVOKE into background.ts**
+
+Add a port-override helper and route the probe through it. Add near the queue layer:
+
+```ts
+const PORT_KEY = 'memry:capture-port'
+
+async function getOverridePort(): Promise<number | null> {
+  const r = await browser.storage.local.get(PORT_KEY)
+  const v = r[PORT_KEY]
+  return typeof v === 'number' && Number.isInteger(v) ? v : null
+}
+
+// Probe the override port first (if set), then the default range.
+async function probe(): Promise<Awaited<ReturnType<typeof probeServer>>> {
+  const override = await getOverridePort()
+  return override ? probeServer(fetch, [override, ...PROBE_PORTS]) : probeServer()
+}
+```
+
+Add the `PROBE_PORTS` import from `@/lib/capture-client` (extend the existing import). Then replace the bare `probeServer()` calls inside `getStatus`, `capture`, and `flushQueue` with `probe()`. (Leave `waitForServer`'s `pollUntil(() => probeServer())` — it can stay on the default range, or switch to `probe` for consistency.)
+
+Add a `revoke` function and message case:
+
+```ts
+async function revoke(): Promise<{ ok: boolean }> {
+  const found = await probe()
+  const token = await getToken()
+  if (found && token) await postRevoke(found.port, token)
+  await browser.storage.local.remove(TOKEN_KEY)
+  return { ok: true }
+}
+```
+
+Import `postRevoke` from `@/lib/capture-client`, and add the case to the message switch:
+
+```ts
+      case 'REVOKE':
+        return revoke()
+```
+
+- [ ] **Step 2: Create the options entrypoint**
+
+Create `apps/extension/src/entrypoints/options/index.html` (mirror `popup/index.html` — check that file for the exact head/script shape; WXT auto-registers `options/` as `options_ui`):
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Memry Web Clipper — Settings</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>
+```
+
+Create `apps/extension/src/entrypoints/options/main.tsx` (mirror `popup/main.tsx` for the CSS import + mount):
+
+```tsx
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import '@/entrypoints/popup/style.css'
+
+createRoot(document.getElementById('root')!).render(<App />)
+```
+
+(Confirm the popup's CSS import path in `popup/main.tsx` and reuse it verbatim.)
+
+- [ ] **Step 3: Create the options App**
+
+Create `apps/extension/src/entrypoints/options/App.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react'
+import type { ConnectionState, PairResponse, StatusResponse } from '@/lib/messages'
+
+const PORT_KEY = 'memry:capture-port'
+
+export default function App() {
+  const [connection, setConnection] = useState<'unknown' | ConnectionState>('unknown')
+  const [port, setPort] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const refresh = () =>
+    browser.runtime
+      .sendMessage({ type: 'GET_STATUS' })
+      .then((r: StatusResponse) => setConnection(r.connection))
+      .catch(() => setConnection('app-closed'))
+
+  useEffect(() => {
+    void refresh()
+    browser.storage.local.get(PORT_KEY).then((r) => {
+      const v = r[PORT_KEY]
+      if (typeof v === 'number') setPort(String(v))
+    })
+  }, [])
+
+  const onPair = async () => {
+    setBusy(true)
+    const r: PairResponse = await browser.runtime.sendMessage({ type: 'PAIR' }).catch(() => ({
+      ok: false
+    }))
+    setBusy(false)
+    if (r.ok) void refresh()
+  }
+
+  const onUnpair = async () => {
+    setBusy(true)
+    await browser.runtime.sendMessage({ type: 'REVOKE' }).catch(() => {})
+    setBusy(false)
+    void refresh()
+  }
+
+  const onRotate = async () => {
+    await onUnpair()
+    await onPair()
+  }
+
+  const onSavePort = async () => {
+    const n = parseInt(port, 10)
+    if (port.trim() === '' || Number.isNaN(n)) {
+      await browser.storage.local.remove(PORT_KEY)
+    } else {
+      await browser.storage.local.set({ [PORT_KEY]: n })
+    }
+    void refresh()
+  }
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col gap-6 p-6 font-sans text-foreground">
+      <h1 className="text-lg font-semibold">Memry Web Clipper</h1>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Pairing</h2>
+        <p className="text-[13px] text-text-secondary">Status: {connection}</p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onPair}
+            className="rounded bg-accent px-3 py-1.5 text-[13px] text-white disabled:opacity-50"
+          >
+            Re-pair
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onRotate}
+            className="rounded border border-border px-3 py-1.5 text-[13px] disabled:opacity-50"
+          >
+            Rotate token
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onUnpair}
+            className="rounded border border-border px-3 py-1.5 text-[13px] disabled:opacity-50"
+          >
+            Unpair
+          </button>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Port override</h2>
+        <p className="text-[13px] text-text-secondary">
+          Leave blank to auto-detect (ports 7849–7856).
+        </p>
+        <div className="flex gap-2">
+          <input
+            value={port}
+            onChange={(e) => setPort(e.target.value)}
+            inputMode="numeric"
+            placeholder="auto"
+            className="w-24 rounded border border-border bg-surface px-2 py-1 text-[13px]"
+          />
+          <button
+            type="button"
+            onClick={onSavePort}
+            className="rounded border border-border px-3 py-1.5 text-[13px]"
+          >
+            Save
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}
+```
+
+(Confirm the actual Tailwind token names — `accent`, `text-secondary`, `border`, `surface` — against `popup/App.tsx` + the popup components; reuse whatever they use. Keep to logical properties.)
+
+- [ ] **Step 4: Typecheck + build + lint**
+
+Run: `pnpm --filter @memry/extension typecheck && pnpm --filter @memry/extension build && pnpm --filter @memry/extension lint`
+Expected: 0 errors; build emits an `options.html` entrypoint + `options_ui` in the manifest.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/extension/src/entrypoints/options apps/extension/src/entrypoints/background.ts
+git commit -m "feat(extension): settings options page — re-pair/unpair/port override"
+```
+
+---
+
+## Task 8: "Add & open" — contract event + deep-link + renderer (desktop)
+
+**Files:**
+
+- Modify: `packages/contracts/src/inbox-channels.ts`
+- Modify: `apps/desktop/src/main/index.ts`
+- Test: `apps/desktop/src/main/index.deeplink.test.ts` (create)
+- Modify: a renderer inbox subscriber (see Step 5)
+
+**Interfaces:**
+
+- Produces: `InboxChannels.events.OPEN_ITEM = 'inbox:open-item'`; `parseInboxOpenItemId(url): string | null`; the generated preload subscriber for the event; a renderer handler that focuses the captured inbox item.
+
+- [ ] **Step 1: Add the contract event**
+
+In `packages/contracts/src/inbox-channels.ts`, add to `InboxChannels.events`:
+
+```ts
+    /** Focus a specific inbox item (from the browser-extension "Add & open" deep-link) */
+    OPEN_ITEM: 'inbox:open-item',
+```
+
+- [ ] **Step 2: Regenerate + validate the IPC map**
+
+Run: `pnpm ipc:generate && pnpm ipc:check`
+Expected: the generated preload (`apps/desktop/src/preload/generated-rpc.ts`) gains a subscriber entry mapping to `inbox:open-item`; `ipc:check` passes. Note the generated subscriber method name (e.g. `onInboxOpenItem`) — Step 5 uses it.
+
+- [ ] **Step 3: Write the failing deep-link helper test**
+
+Create `apps/desktop/src/main/index.deeplink.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { parseInboxOpenItemId } from './index'
+
+describe('parseInboxOpenItemId', () => {
+  it('extracts the item id from memry://open?item=...', () => {
+    expect(parseInboxOpenItemId('memry://open?item=cap-123')).toBe('cap-123')
+  })
+  it('returns null for memry://open without an item', () => {
+    expect(parseInboxOpenItemId('memry://open')).toBeNull()
+  })
+  it('returns null for other hosts', () => {
+    expect(parseInboxOpenItemId('memry://billing?item=x')).toBeNull()
+  })
+  it('returns null for malformed input', () => {
+    expect(parseInboxOpenItemId('not a url')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 4: Add the helper + wire the deep-link**
+
+In `apps/desktop/src/main/index.ts`, export the pure helper (place it near `handleDeepLink`):
+
+```ts
+export function parseInboxOpenItemId(url: string): string | null {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'memry:' || parsed.hostname !== 'open') return null
+    return parsed.searchParams.get('item')
+  } catch {
+    return null
+  }
+}
+```
+
+In `handleDeepLink`, inside the `if (parsed.hostname === 'open')` block, after the existing log line, add the send (import `InboxChannels` from `@memry/contracts/ipc-channels` if not already imported):
+
+```ts
+if (parsed.hostname === 'open') {
+  deepLinkLog.info('launch requested via memry://open')
+  const itemId = parsed.searchParams.get('item')
+  if (itemId) mainWindow.webContents.send(InboxChannels.events.OPEN_ITEM, { itemId })
+}
+```
+
+Run the test:
+
+Run: `pnpm --filter @memry/desktop test:main index.deeplink`
+Expected: PASS (4 tests). If `index.ts` pulls in heavy main-process imports that break a unit import, instead extract `parseInboxOpenItemId` into a tiny sibling `apps/desktop/src/main/deeplink-utils.ts`, import it into `index.ts`, and point the test there.
+
+- [ ] **Step 5: Subscribe in the renderer**
+
+In the inbox page (`apps/desktop/src/renderer/src/pages/inbox.tsx`), subscribe to the generated event (method name from Step 2) and focus the item. Add an effect:
+
+```tsx
+useEffect(() => {
+  const off = window.api.inbox.onInboxOpenItem?.(({ itemId }: { itemId: string }) => {
+    // Reuse the list's existing item-open path. If the item isn't in the
+    // current filtered view, focus the inbox without selecting (don't throw).
+    openInboxItem(itemId)
+  })
+  return () => off?.()
+}, [])
+```
+
+Replace `onInboxOpenItem` with the actual generated name from Step 2, and `openInboxItem(itemId)` with the inbox list's real open/select handler (trace it from the row click in `apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx` — `onSelectionChange` / the detail-open path). The deliverable: a deep-link with `?item=<id>` brings Memry to front with that item visible/selected.
+
+- [ ] **Step 6: Typecheck + ipc:check + renderer test suite**
+
+Run: `pnpm --filter @memry/desktop typecheck:node && pnpm --filter @memry/desktop typecheck:web && pnpm ipc:check && pnpm --filter @memry/desktop test:renderer inbox`
+Expected: 0 type errors; ipc:check passes; renderer inbox tests pass (update any that assert the inbox page's effect set).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/contracts/src/inbox-channels.ts apps/desktop/src/main/index.ts apps/desktop/src/main/index.deeplink.test.ts apps/desktop/src/preload/generated-rpc.ts apps/desktop/src/renderer/src/pages/inbox.tsx
+git commit -m "feat(inbox): open a captured item via memry://open?item deep-link"
+```
+
+(Add `apps/desktop/src/main/deeplink-utils.ts` to the `git add` list if Step 4's fallback was used. Include any other files `pnpm ipc:generate` regenerated — check `git status` for the exact set, but stage them by explicit path, never `-A`.)
+
+---
+
+## Task 9: Popup "Add & open" split action (extension, manual-QA)
+
+**Files:**
+
+- Modify: `apps/extension/src/entrypoints/popup/App.tsx`
+
+**Interfaces:**
+
+- Consumes: `onAdd` + `state.itemId` (existing); the `'queued'` phase (Task 2/3).
+- Produces: an "Add & open" secondary action that deep-links to the new item on a real save.
+
+- [ ] **Step 1: Add the `onAddAndOpen` handler**
+
+In `apps/extension/src/entrypoints/popup/App.tsx`, after `onAdd`, add:
+
+```tsx
+const onAddAndOpen = async () => {
+  await onAdd()
+  // onAdd dispatched SAVE_DONE synchronously before returning; read the next
+  // state via the latest itemId. A queued (offline) save has no item to open.
+  const id = stateRef.current.itemId
+  if (id && stateRef.current.action === 'saved') {
+    browser.tabs.create({ url: `memry://open?item=${encodeURIComponent(id)}` }).catch(() => {})
+  }
+}
+```
+
+`onAdd` updates state asynchronously, so capture the latest state in a ref. Add near the top of the component:
+
+```tsx
+const stateRef = useRef(state)
+stateRef.current = state
+```
+
+(`useRef` is already imported. If `onAdd` returns before `SAVE_DONE` is committed to `stateRef`, change `onAdd` to return the `CaptureResponse` and branch on that directly instead of reading the ref — simpler and race-free:)
+
+```tsx
+const onAddAndOpen = async () => {
+  const result = await onAdd()
+  if (result?.ok) {
+    browser.tabs
+      .create({ url: `memry://open?item=${encodeURIComponent(result.itemId)}` })
+      .catch(() => {})
+  }
+}
+```
+
+To enable the race-free form, change `onAdd` to `return result` at its end (it currently dispatches `SAVE_DONE` and returns void — add `return result`). Use the race-free form.
+
+- [ ] **Step 2: Render the split action**
+
+In the footer, replace the single `ready`-phase button with a primary + secondary pair:
+
+```tsx
+{
+  phase === 'ready' && (
+    <div className="flex flex-col gap-2">
+      <PrimaryButton label="Add to Memry" onClick={() => onAdd()} disabled={!draft} />
+      <button
+        type="button"
+        disabled={!draft}
+        onClick={onAddAndOpen}
+        className="rounded-md border border-border px-3 py-2 text-[13px] font-medium text-text-secondary disabled:opacity-50"
+      >
+        Add & open in Memry
+      </button>
+    </div>
+  )
+}
+```
+
+(Match `PrimaryButton`'s wrapper styling so the two read as a stack; reuse existing token names.)
+
+- [ ] **Step 3: Typecheck + build + unit suite**
+
+Run: `pnpm --filter @memry/extension typecheck && pnpm --filter @memry/extension build && pnpm --filter @memry/extension test`
+Expected: 0 type errors; build succeeds; tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/extension/src/entrypoints/popup/App.tsx
+git commit -m "feat(extension): Add & open split action deep-links to the new item"
+```
+
+---
+
+## Task 10: Full gate + whole-branch review + manual GUI QA
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Extension gate**
+
+Run: `pnpm --filter @memry/extension test && pnpm --filter @memry/extension typecheck && pnpm --filter @memry/extension lint && pnpm --filter @memry/extension build`
+Expected: all green.
+
+- [ ] **Step 2: Desktop gate**
+
+Run: `pnpm --filter @memry/desktop test:main capture/server.test.ts && pnpm --filter @memry/desktop test:main index.deeplink && pnpm --filter @memry/desktop typecheck:node && pnpm ipc:check`
+Expected: all green. (If `better-sqlite3 ERR_DLOPEN_FAILED`: `pnpm --filter @memry/desktop rebuild:node`, retry.)
+
+- [ ] **Step 3: Contracts gate**
+
+Run: `pnpm --filter @memry/contracts test && pnpm --filter @memry/contracts typecheck`
+Expected: green.
+
+- [ ] **Step 4: Formatting**
+
+Run: `git diff --check`
+Expected: no whitespace errors. Spot-check single-quote / no-semicolon / no-trailing-comma + logical Tailwind classes in every changed file.
+
+- [ ] **Step 5: Docs gate (desktop touched)**
+
+Run: `pnpm docs:impact --base origin/main --strict`
+If it reports `missing-docs`, update `apps/docs/src/**` (browser-extension/capture page: note the new keyboard shortcut, offline queue, settings page) or run `pnpm docs:ai-update --base origin/main`, then re-run `--strict` and `pnpm docs:build`.
+
+- [ ] **Step 6: Whole-branch review (opus)**
+
+Dispatch a review over `git diff main...HEAD` against the spec. Confirm: only `alarms` added to permissions (no stray host perms); no `git add -A` swept `import-prompt/` or `marketing/`; contract subpath imports; logical Tailwind classes; Phase 3.1 pairing/launch + Phase 4 selection/screenshot untouched; `/pair/revoke` reuses `/capture` auth; the queue drops permanent failures (no wedge) and stops the alarm when empty.
+
+- [ ] **Step 7: Manual GUI QA — HUMAN-REQUIRED (acceptance gate)**
+
+Cannot be automated. With `pnpm dev` (desktop) running and the unpacked extension (`apps/extension/.output/chrome-mv3`) loaded:
+
+1. **Queue:** quit Memry → capture via popup AND via the keyboard shortcut → toolbar badge shows the count; popup says "Saved offline." Launch Memry → within ~1 min the badge clears and both items appear in the inbox.
+2. **Keyboard:** with Memry open, press the shortcut on a real article → item in the inbox, no popup, brief ✓ badge. On a `chrome://` page → brief `!` badge, no crash.
+3. **Settings:** open the options page (right-click the action → Options, or `chrome://extensions`) → status reflects pairing. Unpair → next capture shows needs-pairing. Re-pair works. Rotate token works. Set a wrong port → app looks closed; clear it → recovers.
+4. **Add & open:** "Add & open in Memry" → Memry comes to front with the just-captured item focused in the inbox. While Memry is closed → it queues and does NOT try to open.
+5. **Regression:** Phase 3.1 pairing/launch + Phase 4 Article/Selection/Shot modes all unchanged.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- 5.1 Offline queue + retry + badge → Tasks 1 (helpers), 2 (queued state), 3 (background queue/badge/alarm). ✓
+- 5.2 Keyboard command (Article, no new perm) → Task 4. ✓
+- 5.3 Settings (re-pair/unpair/rotate/port override) → Tasks 5 (`/pair/revoke`), 6 (probe/revoke client), 7 (options page + REVOKE + port thread). ✓
+- 5.4 Add & open → Tasks 8 (contract event + deep-link + renderer), 9 (popup split button). ✓
+- Permissions: only `alarms` added (Task 3); `commands` (Task 4) + `options_ui` (Task 7) are manifest keys → asserted in Task 10 Step 6. ✓
+- Tests: pure logic unit-tested (capture-queue T1, reducer T2, probe/revoke T6, deep-link helper T8, `/pair/revoke` T5); DOM/background/UI manual-QA (T10 Step 7). ✓
+
+**Type consistency:** `QueuedCapture`/`isRetryable`/`enqueue`/`dequeueById`/`badgeText` defined in T1, consumed identically in T3/T4. `FlushResponse` defined T2, returned by `flushQueue` T3. `'queued'` error code: produced by `captureOrQueue` T3, handled in `SAVE_DONE` T2, rendered T3, branched in `onAddAndOpen` T9. `probeServer(fetchFn, ports)` signature matches T6 test + T7 caller. `postRevoke(port, token, fetchFn?)` matches T6 + T7. `parseInboxOpenItemId` matches T8 test + caller. `InboxChannels.events.OPEN_ITEM` defined T8, sent in main T8, subscribed in renderer T8.
+
+**Placeholder scan:** the two genuinely environment-dependent names — the generated preload subscriber method (T8 Step 2/5) and the inbox list's open handler (T8 Step 5) — are resolved by a concrete deterministic step (run `ipc:generate`, read the generated name; trace the row-click handler), not left as TBD. Everything else ships full code.

--- a/docs/superpowers/specs/2026-06-17-link-capture-phase4-capture-modes-design.md
+++ b/docs/superpowers/specs/2026-06-17-link-capture-phase4-capture-modes-design.md
@@ -1,0 +1,172 @@
+# Link Capture Phase 4 — Selection + Screenshot capture modes
+
+Date: 2026-06-17
+Status: Approved (design)
+Builds on: `2026-06-17-link-capture-defuddle-design.md` (§Path B, §Popup UI, §Phasing).
+Predecessors merged to main: Phase 1 (paste→article), Phase 2 (loopback server), Phase 3 + 3.1 (extension MVP + in-app pairing) via PR #587.
+
+## Goal
+
+Wire the two disabled popup segments — **Selection** and **Shot** — into working capture modes.
+Selection clips the user's current text selection as a markdown note. Shot captures a
+full-page screenshot and files it as an image note. Both land in the same inbox via the same
+`/capture` → `ingestArticleCapture` convergence point the paste and article paths already use.
+
+## Non-goals (Phase 5)
+
+Offline queue/retry + toolbar badge, keyboard command, settings UI (token rotate / unpair /
+port), "Add and open note" split action.
+
+## What already exists (verified against main)
+
+- **Extension** (`apps/extension`, WXT MV3):
+  - `src/entrypoints/content.ts` — listens for `EXTRACT`, runs `extractFromDocument(document, url)`
+    from `@memry/article-extract/browser`, which is `new Defuddle(doc, { markdown: true }).parse()`
+    mapped to `ArticleCapture`.
+  - `src/entrypoints/background.ts` — owns the token + all loopback network; message switch
+    (`GET_STATUS`, `PAIR`, `CAPTURE`, `WAIT_FOR_SERVER`).
+  - `src/entrypoints/popup/App.tsx` + `src/components/*` — popup UI; `ModeSegmented` renders
+    Article (enabled) + Selection/Shot (disabled placeholders).
+  - `src/lib/messages.ts` — `PopupMessage` / `ContentMessage` / `ExtractResponse` unions.
+  - `src/lib/capture-client.ts` — URL/header builders + `postCapture` + `pollUntil`. Mode-agnostic.
+  - `src/lib/popup-state.ts` — reducer (`Phase`, `PopupAction`).
+  - `src/lib/render-markdown.ts` — `renderMarkdown(md)` = marked + DOMPurify (for body preview).
+  - Deps already present: `@memry/article-extract` (defuddle), `marked`, `dompurify`. jsdom is a devDep.
+  - Manifest perms: `['storage', 'activeTab']`, `host_permissions: ['http://127.0.0.1/*']`.
+- **Desktop capture** (`apps/desktop/src/main/capture`): `server.ts` routes `/ping`, `/pair/claim`,
+  `/pair/request`, `/capture`. `/capture` reads body (25 MB cap → 413), `ArticleCaptureSchema.safeParse`,
+  then `ingestArticleCapture(parsed.data, 'browser-extension')`. `server.test.ts` mocks `./pairing`,
+  `electron`, and `../inbox/ingest`.
+- **Ingest** (`apps/desktop/src/main/inbox/ingest.ts`): `ingestArticleCapture(input, source)`.
+  Create-path generates `id` BEFORE `insertItemWithTags`, calls `downloadHero(id, heroImage)`.
+  Enrich-path keys off `input.itemId` or URL-dedup. `force: true` bypasses URL-dedup.
+- **Inbox attachments** (`apps/desktop/src/main/inbox/attachments.ts`): `storeInboxAttachment(itemId,
+data: Buffer, filename, mimeType) → { success, path, ... }` where `path` is vault-relative
+  `attachments/inbox/{itemId}/{prefix}-{name}.{ext}`. (Note items use a different `saveAttachment`
+  returning `memry-file://` URLs — do NOT use that for inbox.)
+- **Contract** (`packages/contracts/src/capture-api.ts`, subpath `@memry/contracts/capture-api`):
+  `ArticleCaptureSchema` already has `mode: z.enum(['article','selection','screenshot'])`, plus
+  optional `tags` and `force`. It does NOT yet carry a screenshot payload.
+
+## Design
+
+### 1. Selection mode — extension-only, desktop unchanged
+
+Selection produces a ready-made `contentMarkdown` in the extension, exactly like article mode, so
+the desktop path needs zero changes (it already accepts `mode:'selection'`).
+
+- **Content script** (`content.ts`) gains a `GRAB_SELECTION` handler:
+  - `const sel = window.getSelection()`. If empty/collapsed → return `{ ok:false, error:'no-selection' }`.
+  - Clone the selected range(s) into a detached document body, run the same defuddle path as article
+    (`defuddle({ markdown: true })`) over that fragment → `contentMarkdown`.
+  - **Fallback**: if defuddle yields empty markdown, use `sel.toString()` as plain text. `// ponytail:`
+    upgrade path = swap to a dedicated fragment converter if fidelity complaints arise.
+  - Build the `ArticleCapture`: `mode:'selection'`, `url`/`properties.source` = `location.href`,
+    `properties.title` = `document.title`, `properties.created` = now, `tags: ['clippings']`,
+    `excerpt` = a trimmed prefix of the selection text, `extractionStatus:'full'`, `force: true`.
+- **Conversion location** decision: reuse defuddle (already the engine for article mode). No new dep,
+  no new converter, no desktop change.
+- **Dedup**: `force: true` — each selection is a distinct inbox item (a page can be clipped twice).
+- **Popup**: enable the Selection segment. Selecting it sends `GRAB_SELECTION` to the active tab's
+  content script and renders the result as a **read-only body preview** via `renderMarkdown`. No
+  selection → empty-state hint ("Select text on the page, then reopen the popup"); "Add to Memry"
+  disabled. The title/properties rows stay editable, consistent with article mode.
+
+### 2. Screenshot mode — full-page scroll + stitch
+
+The background orchestrates; the content script scrolls; the background captures and stitches.
+`captureVisibleTab` is privileged and cannot run in a content script, so the loop round-trips.
+
+Flow:
+
+1. Popup → background `GRAB_SCREENSHOT`.
+2. Background → content `GET_PAGE_METRICS` → `{ scrollHeight, innerHeight, innerWidth, dpr }`
+   (clamp `scrollHeight` to a max of ~15000 css-px to stay under the 25 MB cap — `// ponytail:`).
+3. Loop `y = 0 … scrollHeight` by `innerHeight` steps:
+   - content `SCROLL_TO { y }` → background waits ~350 ms settle → background
+     `chrome.tabs.captureVisibleTab(windowId, { format: 'png' })` → collect `{ dataUrl, y }`.
+   - Throttle so captures stay within `captureVisibleTab`'s ~2/sec limit.
+   - Emit progress (`n/total`) back to the popup.
+4. Restore the page's original scroll position.
+5. **Stitch** in the background via `OffscreenCanvas` sized `innerWidth*dpr × clampedHeight*dpr`:
+   `createImageBitmap` each slice, draw at `y*dpr`. The final slice's capture shows the bottom
+   viewport (overlapping the previous slice) — draw it at `(scrollHeight - innerHeight)*dpr` and
+   the geometry naturally clips. Export `canvas.convertToBlob({ type:'image/png' })` → data URL.
+6. Background returns the stitched data URL to the popup.
+
+The slice-geometry math (per-slice draw offset + final-slice clamp) is extracted into a **pure
+helper** `planStitch({ scrollHeight, innerHeight, dpr })` so it gets a unit test independent of the
+browser canvas.
+
+Known limits, each `// ponytail:`-commented with an upgrade path:
+
+- Sticky / `position:fixed` headers repeat in every slice (would need per-slice hide/restore).
+- Lazy-loaded images may still be loading when a slice is captured (350 ms settle is best-effort).
+- Total height capped (~15000 css-px) to keep the PNG under the `/capture` 25 MB cap; very tall
+  pages are truncated rather than failing with a 413.
+
+**Popup**: enable the Shot segment. Selecting it shows a `Capturing page… (n/total)` progress
+state, then the stitched **image miniature** preview. "Add to Memry" sends it.
+
+**Permissions**: none added. `activeTab` (granted when the popup opens) authorizes
+`captureVisibleTab` for the active tab from the background while the popup is open; scrolling and
+`getSelection` need no permission. `host_permissions` unchanged.
+
+### 3. Desktop — screenshot ingest
+
+Selection needs nothing here. Screenshot adds one schema field + a decode-and-embed step.
+
+- **Contract** (`@memry/contracts/capture-api`): add `screenshotDataUrl: z.string().optional()` to
+  `ArticleCaptureSchema`. Import via the subpath, never the barrel (contracts `index.test.ts` forbids
+  barrel named exports).
+- **Pure helper** `parseDataUrl(s) → { mime, ext, buffer } | null` (new small module, e.g. under
+  `apps/desktop/src/main/inbox/` or a shared util). Parses `data:<mime>;base64,<payload>`; maps mime
+  → ext (`image/jpeg`→`jpg`, `image/svg+xml`→`svg`, else subtype). Unit-tested — it's a parser.
+- **`ingestArticleCapture`** create-path: after `id` is generated, if `input.screenshotDataUrl`:
+  `parseDataUrl` → `storeInboxAttachment(id, buffer, 'screenshot.<ext>', mime)` → on success set
+  `content = ![screenshot](<result.path>)` (the image is the body) and `thumbnailPath = result.path`.
+  Article/selection paths untouched. The extension sends `contentMarkdown: ''` + `force: true` for
+  screenshot (each shot is a distinct item, same as selection); the desktop builds the real body.
+- **`server.test.ts`**: add a screenshot-body case — valid screenshot payload (`mode:'screenshot'`,
+  `screenshotDataUrl`, empty `contentMarkdown`) → `ingestArticleCapture` called with
+  `expect.objectContaining({ mode:'screenshot', screenshotDataUrl: expect.any(String) })`. The
+  decode/embed is covered by the `parseDataUrl` unit test; the DB-bound embed is manual QA.
+
+### 4. Messages / state
+
+- `messages.ts`:
+  - `ContentMessage` += `{ type:'GRAB_SELECTION' }`, `{ type:'GET_PAGE_METRICS' }`,
+    `{ type:'SCROLL_TO'; y:number }`.
+  - `PopupMessage` += `{ type:'GRAB_SCREENSHOT' }`.
+  - Response types: `SelectionResponse` (`ArticleCapture | error`), `PageMetrics`,
+    `ScreenshotResponse` (`{ ok:true; dataUrl:string } | error`). Progress can ride a
+    `runtime.connect` port or repeated messages — design leaves the simplest of the two to the plan.
+- `popup-state.ts`: add `mode: 'article'|'selection'|'screenshot'` to state + `SET_MODE` action; a
+  capturing/progress sub-state for screenshot (`capturing` phase carrying `{ done, total }`).
+  Reducer unit tests for `SET_MODE` + the capturing transitions.
+
+### 5. Tests / verification gate
+
+- **Pure logic, unit-tested**: `parseDataUrl`, reducer `SET_MODE`/capturing, `planStitch` geometry.
+- **Manual QA**: WXT content/background entrypoints, React popup components, the live scroll+stitch
+  loop, and the DB-bound screenshot embed.
+- **Gate**: `pnpm --filter @memry/extension test|typecheck|lint|build`; desktop
+  `pnpm --filter @memry/desktop test:main capture/server.test.ts` + `typecheck:node`.
+
+## Acceptance — human-required GUI QA
+
+Load the unpacked extension in Chrome, run `pnpm dev`. Confirm:
+
+- Selecting text + Selection mode + Add → a text note in the inbox with the selection as markdown.
+- Shot mode → progress → stitched preview + Add → an image note in the inbox referencing the saved
+  screenshot attachment.
+- Article mode + the Phase 3.1 in-app pairing flow are unchanged.
+
+## File touch list (estimate)
+
+Extension: `messages.ts`, `popup-state.ts` (+test), `content.ts`, `background.ts`,
+`popup/App.tsx`, `components/ModeSegmented.tsx` (+ a small selection-body / screenshot-preview
+component), a `stitch.ts` pure helper (+test).
+Desktop: `packages/contracts/src/capture-api.ts`, `apps/desktop/src/main/inbox/ingest.ts`, a
+`parse-data-url.ts` helper (+test), `apps/desktop/src/main/capture/server.test.ts`.
+No new dependencies. No new permissions.

--- a/docs/superpowers/specs/2026-06-17-link-capture-phase4-capture-modes-design.md
+++ b/docs/superpowers/specs/2026-06-17-link-capture-phase4-capture-modes-design.md
@@ -69,8 +69,10 @@ the desktop path needs zero changes (it already accepts `mode:'selection'`).
 - **Dedup**: `force: true` — each selection is a distinct inbox item (a page can be clipped twice).
 - **Popup**: enable the Selection segment. Selecting it sends `GRAB_SELECTION` to the active tab's
   content script and renders the result as a **read-only body preview** via `renderMarkdown`. No
-  selection → empty-state hint ("Select text on the page, then reopen the popup"); "Add to Memry"
-  disabled. The title/properties rows stay editable, consistent with article mode.
+  selection → empty-state hint ("Select text on the page, then pick Selection again"); "Add to
+  Memry" disabled. Re-clicking the Selection segment re-runs the grab (the documented retry path —
+  select text, then pick Selection again), unlike Article which is a pure no-op on re-click. The
+  title/properties rows stay editable, consistent with article mode.
 
 ### 2. Screenshot mode — full-page scroll + stitch
 

--- a/docs/superpowers/specs/2026-06-17-link-capture-phase5-queue-keyboard-settings-open.md
+++ b/docs/superpowers/specs/2026-06-17-link-capture-phase5-queue-keyboard-settings-open.md
@@ -1,0 +1,176 @@
+# Link Capture Phase 5 — Offline queue, keyboard command, settings, "Add & open"
+
+Date: 2026-06-17
+Status: Approved (design)
+Builds on: `2026-06-17-link-capture-phase4-capture-modes-design.md` (its "Non-goals (Phase 5)" section IS this scope).
+Branch: stacked on `feat/link-capture-capture-modes` (Phase 4, unmerged). The two Phase 4 carry-overs (broken filed-screenshot image, selection empty-state copy) are already fixed on this branch as precursor commits.
+
+## Goal
+
+Make the clipper trustworthy and fast. Four deferred items, sequenced so the queue lands first and the rest reuse it:
+
+1. **Offline queue + retry + toolbar badge** — capture when Memry is closed/unreachable; persist in `browser.storage`; retry on reconnect; badge shows pending count.
+2. **Keyboard command** — an MV3 `commands` shortcut that captures the page (Article mode) without opening the popup.
+3. **Settings options page** — the extension's first options UI: re-pair / unpair (token rotate) and a manual port override.
+4. **"Add & open" split action** — capture, then deep-link Memry to the created inbox item, building on the existing `memry://open` launch path.
+
+## Non-goals (Phase 6+)
+
+Selection/screenshot capture via the keyboard command (Article only — the others need the popup or `activeTab`). Per-origin revoke when multiple extensions are paired (v1 revoke clears the whole allowlist — single-extension model). `chrome.notifications` toasts (badge is the only feedback channel). Filing a capture straight to a note/folder from the popup. Sync-server changes (queue is local to the browser).
+
+## What already exists (verified against this branch)
+
+- **Extension** (`apps/extension`, WXT MV3):
+  - `src/entrypoints/background.ts` — owns the token + all loopback network; message switch (`GET_STATUS`, `PAIR`, `CAPTURE`, `WAIT_FOR_SERVER`, `GRAB_SCREENSHOT`). `capture(body)` (line 52) probes the server, reads the token, calls `postCapture`; returns `{ ok:false, error:'app-closed' }` when no server, `'bad-token'` when unpaired.
+  - `src/lib/capture-client.ts` — `probeServer()` walks `PROBE_PORTS` (`DEFAULT_PORT=7849`, range 8). `postCapture()` returns `{ ok:false, error:'network' }` on fetch throw, `'app-closed'`/`http-<status>`/server error code otherwise. All fns take an injectable `fetchFn` for tests.
+  - `src/lib/popup-state.ts` — reducer; `mapError(code)` maps error codes to copy. `SAVE_DONE` stores `itemId` on success.
+  - `src/entrypoints/popup/App.tsx` — popup; `onAdd()` (line 79) dispatches `SAVE_START` → `CAPTURE` → `SAVE_DONE`; `onLaunchAndAdd()` (line 98) opens `memry://open` then saves. `PrimaryButton` is the single CTA.
+  - `wxt.config.ts` — `permissions: ['storage', 'activeTab']`, `host_permissions: ['http://127.0.0.1/*']`. No `commands` key, no `options` entrypoint, no `alarms`.
+- **Desktop pairing** (`apps/desktop/src/main/capture/pairing.ts`): single shared token in the OS keychain + an origin allowlist in `store`. **`rotateCaptureToken()` and `unpairCapture()` already exist** (lines 38-52) — both clear the allowlist; rotate mints a new token, unpair deletes it. No HTTP route exposes them yet.
+- **Desktop capture server** (`apps/desktop/src/main/capture/server.ts`): routes `/ping`, `/pair/claim`, `/pair/request`, `/capture`. `/capture` is guarded by Bearer token + `X-Memry-Capture` header + allowed origin (`auth.ts`).
+- **Desktop deep-link** (`apps/desktop/src/main/index.ts:527` `handleDeepLink`): parses `memry://`; `hostname === 'open'` currently focuses the window only. Renderer navigation uses `mainWindow.webContents.send(<EventChannel>, payload)` (e.g. `openAccountSettings` sends `SettingsChannels.events.OPEN_SECTION`).
+- **Inbox** (`apps/desktop/src/renderer/src/pages/inbox.tsx`): `'inbox'` is the default page; the list view tracks item selection. `InboxChannels.events` (`packages/contracts/src/inbox-channels.ts`) has `CAPTURED`/`UPDATED`/`FILED`/… but no "open this item" event.
+
+---
+
+## Phase 5.1 — Offline queue + retry + badge (extension-only, +`alarms`)
+
+The capture path already distinguishes transient failures (`app-closed`, `network`) from permanent ones (`bad-token`, `invalid-capture`, `payload-too-large`). The queue catches the transient ones.
+
+### Storage + pure helpers (`src/lib/capture-queue.ts`, NEW, unit-tested)
+
+- Queue shape: `QueuedCapture = { id: string; capture: ArticleCapture; queuedAt: number }`, persisted at `browser.storage.local` key `memry:capture-queue` as `QueuedCapture[]`.
+- Pure helpers (no `browser.*`, fully testable):
+  - `isRetryable(error: string): boolean` — `true` for `'app-closed' | 'network'`; `false` for `'bad-token' | 'origin-not-allowed' | 'invalid-capture' | 'payload-too-large' | 'pair-timeout'` and any `http-4xx`. (A 4xx is the server rejecting the payload — retrying never helps.)
+  - `enqueue(queue, item, max)` / `dequeueById(queue, id)` — return new arrays. `enqueue` drops the **oldest** when length would exceed `max` (`MAX_QUEUE = 50`). `// ponytail:` 50 is a storage bound, not a product limit; upgrade path = surface "queue full" in the popup.
+  - `badgeText(count: number): string` — `count === 0 ? '' : count > 99 ? '99+' : String(count)`.
+
+### Background wiring (`background.ts`)
+
+- A tiny storage layer: `readQueue()`, `writeQueue(q)`, and `setBadge(count)` calling `browser.action.setBadgeText` + `setBadgeBackgroundColor` (no permission — the action is implied by the popup).
+- **On capture failure**: change the message-switch `CAPTURE` handler so that when `capture()` returns a retryable error, it enqueues the body, updates the badge, and returns a new `{ ok:false, error:'queued' }` shape so the popup can show "Saved offline" instead of an error. Permanent errors pass through unchanged.
+- **Flush** (`flushQueue()`): probe the server; if reachable + token present, `postCapture` each item oldest-first; drop on success or permanent failure (log it); keep on retryable failure and stop the pass (server likely went away again). Recompute the badge. Returns `{ flushed, remaining }`.
+- **Flush triggers** (no `alarms` needed for these): on `GET_STATUS` when the server is reachable; right after a successful manual capture; and on a new `FLUSH_QUEUE` popup message.
+- **Background retry on reconnect** — the one genuinely-background trigger needs a periodic wake, and an MV3 service worker is evicted when idle. Use **`chrome.alarms`**: while the queue is non-empty, an alarm `memry-flush` fires every 1 min → `flushQueue()`; clear the alarm when the queue drains. This is the only reliable MV3 mechanism for "retry while the popup is closed", and `alarms` is a no-install-warning permission. `// ponytail:` if we ever want to drop the permission, fall back to flush-on-popup-open only and accept that the badge lingers until the user clicks the extension.
+
+### Popup (`popup-state.ts` + `App.tsx`)
+
+- `mapError('queued')` → "Saved offline — will sync when Memry opens." `SAVE_DONE` treats `queued` as a success-ish terminal state (a new `'queued'` action/phase, or reuse `'saved'` with a different label). Reducer unit test for the `queued` branch.
+
+### Permissions
+
+Add `"alarms"` to `wxt.config.ts` `permissions`. No new host permission. Badge uses the existing action.
+
+### Gate (5.1)
+
+`pnpm --filter @memry/extension test` (capture-queue + popup-state reducer) `| typecheck | lint | build`. Background storage/alarm wiring is manual-QA (load unpacked, capture with Memry closed → badge shows count → open Memry → within ~1 min the badge clears and the item appears in the inbox).
+
+---
+
+## Phase 5.2 — Keyboard command (extension-only, +`commands` manifest key)
+
+Reuses 5.1's queue for its failure path.
+
+- **Manifest** (`wxt.config.ts`): add a `commands` block:
+  ```
+  commands: {
+    'capture-page': {
+      suggested_key: { default: 'Ctrl+Shift+S', mac: 'Command+Shift+S' },
+      description: 'Capture this page to Memry'
+    }
+  }
+  ```
+  `// ponytail:` suggested keys can silently collide with another extension; Chrome leaves them unbound and the user rebinds at `chrome://extensions/shortcuts`. `commands` is a manifest key, not a permission — no install warning.
+- **Background** (`background.ts`): `browser.commands.onCommand.addListener` for `'capture-page'`:
+  1. `browser.tabs.query({ active:true, currentWindow:true })` → active tab.
+  2. `browser.tabs.sendMessage(tabId, { type:'EXTRACT' })` → `ArticleCapture`. The content script is declared on `*://*/*` and auto-injected, so **messaging it needs no `activeTab` grant** — the keyboard command never touches `captureVisibleTab` or programmatic injection, so no new permission. On `chrome://`/PDF/extension pages the content script isn't present; `sendMessage` rejects → brief error badge, no capture.
+  3. Run the capture through the **same path as the popup** (capture → on retryable failure, enqueue + badge; reuse 5.1).
+  4. Feedback without a popup: flash the badge `'✓'` for ~2s on success (best-effort; the SW is alive immediately after handling the command), or the queue count on a queued save.
+
+### Gate (5.2)
+
+Extension `test | typecheck | lint | build`. The onCommand handler is manual-QA: press the shortcut on a real article (Memry open → item in inbox; Memry closed → badge increments).
+
+---
+
+## Phase 5.3 — Settings options page (extension + one desktop route)
+
+The extension's first options page. Re-pair / unpair / port override.
+
+- **WXT options entrypoint** (`src/entrypoints/options/` — `index.html` + `main.tsx` + `App.tsx`), reusing the popup's Tailwind setup. WXT auto-registers it as the manifest `options_ui`. No permission.
+- **Sections:**
+  - **Pairing status** — read `GET_STATUS`; show `ready` / `needs-pairing` / `app-closed`.
+  - **Re-pair** — runs the existing `PAIR` flow (rotates implicitly: see below).
+  - **Unpair** — clears the extension's stored token AND tells the desktop to forget it (below). After unpair the extension shows `needs-pairing`.
+  - **Rotate token** — presented as a single button = **unpair (revoke) then immediately re-pair**. Reuses the revoke route + existing pairing; no separate rotate route. End state = a fresh token, old token dead.
+  - **Port override** — an input storing `memry:capture-port` in `browser.storage.local`. `probeServer()` checks the override port first, then falls back to `PROBE_PORTS`. Empty = auto. Pure extension change to `capture-client.ts` (unit-testable: `probeServer` already takes an injectable `fetchFn`; add an injectable port list).
+- **Desktop — one new route** `POST /pair/revoke` (`server.ts`), guarded by the **same auth as `/capture`** (Bearer current token + `X-Memry-Capture` + allowed origin), calling the existing `unpairCapture()`. Returns 200. Only the currently-paired extension can revoke. `// ponytail:` `unpairCapture()` clears the whole allowlist + token (single-extension model); per-origin revoke is a Phase 6 concern, noted in Non-goals.
+  - Extension side: `src/lib/capture-client.ts` gains `postRevoke(port, token)`; background gains a `REVOKE` message that calls it then clears the local token.
+
+### Gate (5.3)
+
+Extension `test` (port-override probe, options reducer if any) `| typecheck | lint | build`. Desktop: `pnpm --filter @memry/desktop test:main capture/server.test.ts` (new `/pair/revoke` auth + success case mocking `./pairing`) `+ typecheck:node`. Options-page UI is manual-QA.
+
+---
+
+## Phase 5.4 — "Add & open" split action (extension + desktop deep-link + renderer)
+
+Capture, then open Memry focused on the created inbox item.
+
+- **Popup** (`App.tsx`): split the single CTA into **"Add"** + a secondary **"Add & open"** (a split button, or a second button under the primary). `onAddAndOpen()` = run `onAdd()`, await the result, and on a real save (`state.itemId` present, not a `queued` save) open `browser.tabs.create({ url: 'memry://open?item=' + itemId })`. If the save queued offline, skip the open and keep the "Saved offline" copy (there's no item to open yet).
+- **Desktop deep-link** (`index.ts` `handleDeepLink`): on `hostname === 'open'`, read `parsed.searchParams.get('item')`; if present, after focusing the window `mainWindow.webContents.send(InboxChannels.events.OPEN_ITEM, { itemId })`.
+- **Contract** (`packages/contracts/src/inbox-channels.ts`): add `OPEN_ITEM: 'inbox:open-item'` to `InboxChannels.events`. Run `pnpm ipc:generate && pnpm ipc:check` after the contract edit.
+- **Renderer**: subscribe to `OPEN_ITEM` (in the inbox page or App shell) → ensure the inbox page is active (it's the default) and open that item's detail using the inbox list's existing selection/detail mechanism. `// ponytail:` if the item isn't in the current filtered list (e.g. filtered view), fall back to focusing the inbox without selecting; don't hard-fail.
+
+### Gate (5.4)
+
+Extension `test | typecheck | lint | build`. Desktop: `pnpm --filter @memry/desktop typecheck:node` + `pnpm ipc:check`; deep-link parse is small and covered by `index.phase2.test.ts`-style coverage if present, else manual-QA. The renderer open-item is manual-QA.
+
+---
+
+## Dependency graph + sequencing
+
+```
+5.1 Offline queue + badge ─┬─> 5.2 Keyboard command   (failure path reuses the queue)
+                           └─> 5.4 Add & open          (offline edge reuses the queue)
+5.3 Settings options page  (independent — can land any time)
+```
+
+5.1 first: highest value, foundation reused by 5.2 and 5.4's offline edge. 5.2 next (cheap, extension-only). 5.3 and 5.4 are independent; 5.3 before 5.4 (smaller desktop surface — one auth-guarded route vs a new IPC event + renderer nav).
+
+## Permissions / manifest summary
+
+| Change                           | Phase | Kind                                 | Install warning?           |
+| -------------------------------- | ----- | ------------------------------------ | -------------------------- |
+| `alarms` permission              | 5.1   | permission                           | No (no-warning permission) |
+| `commands` block                 | 5.2   | manifest key                         | No                         |
+| `options` entrypoint             | 5.3   | manifest key                         | No                         |
+| `POST /pair/revoke`              | 5.3   | desktop route (reuses existing auth) | n/a                        |
+| `InboxChannels.events.OPEN_ITEM` | 5.4   | IPC event channel                    | n/a                        |
+
+No new `host_permissions`. No new `captureVisibleTab` scope. No new dependencies.
+
+## Tests / verification
+
+- **Pure logic, unit-tested**: `capture-queue` (`isRetryable`, `enqueue`/`dequeueById` cap behavior, `badgeText`), the `queued` reducer branch, the port-override probe order.
+- **Desktop unit**: `/pair/revoke` auth + success (`server.test.ts`, mocking `./pairing`).
+- **Manual QA**: background queue/alarm flush loop, badge, the keyboard onCommand handler, the options-page UI, the deep-link → renderer open-item nav.
+- **Per-phase gate** (the user's gate): `pnpm --filter @memry/extension test|typecheck|lint|build`; for desktop-touching phases (5.3, 5.4) add `pnpm --filter @memry/desktop test:main` (relevant file) `+ typecheck:node` and `pnpm ipc:check`. Run the docs gate (`pnpm docs:impact --base <base> --strict`) before any push, since 5.3/5.4 touch desktop.
+
+## Acceptance — human-required GUI QA
+
+Load the unpacked extension, run `pnpm dev`:
+
+- **Queue**: Memry closed → capture (popup and via shortcut) → toolbar badge shows the pending count, popup says "Saved offline." Open Memry → within ~1 min the badge clears and the items land in the inbox.
+- **Keyboard**: press the shortcut on a real article with Memry open → item in the inbox, no popup. On a `chrome://` page → no crash, brief error badge.
+- **Settings**: open the options page → status reflects pairing; Unpair → next capture shows `needs-pairing`; Re-pair works; a wrong port override makes the app look closed, clearing it recovers.
+- **Add & open**: "Add & open" → Memry comes to front with the just-captured item focused in the inbox. Offline → it saves to the queue and does not try to open.
+- **Regression**: Phase 3.1 pairing/launch and Phase 4 selection/screenshot modes unchanged.
+
+## File touch list (estimate)
+
+**Extension:** `wxt.config.ts` (alarms + commands + options), `src/lib/capture-queue.ts` (+test), `src/lib/messages.ts` (`FLUSH_QUEUE`/`REVOKE` + `queued` shapes), `src/lib/popup-state.ts` (+test, `queued` branch), `src/lib/capture-client.ts` (port-override probe + `postRevoke`, +test), `src/entrypoints/background.ts` (queue/badge/alarm/onCommand/revoke), `src/entrypoints/popup/App.tsx` (offline copy + Add&open), `src/entrypoints/options/*` (NEW), `src/components/*` (a settings field or two).
+
+**Desktop / contracts:** `apps/desktop/src/main/capture/server.ts` (+`server.test.ts`) for `/pair/revoke`; `apps/desktop/src/main/index.ts` (deep-link `?item=`); `packages/contracts/src/inbox-channels.ts` (`OPEN_ITEM`); a renderer inbox subscriber for `OPEN_ITEM`.
+
+No new dependencies. New permission: `alarms` only.

--- a/packages/article-extract/src/map.ts
+++ b/packages/article-extract/src/map.ts
@@ -16,6 +16,10 @@ export interface ArticleCapture {
   extractionStatus: 'full' | 'partial' | 'failed'
   properties: ArticleProperties
   heroImage?: string
+  // Capture directives (set by the extension for selection/screenshot; the
+  // extraction mapping never sets them).
+  force?: boolean
+  screenshotDataUrl?: string
 }
 
 export interface DefuddleLikeResult {

--- a/packages/contracts/src/capture-api.test.ts
+++ b/packages/contracts/src/capture-api.test.ts
@@ -30,4 +30,24 @@ describe('ArticleCaptureSchema', () => {
     })
     expect(r.success).toBe(false)
   })
+
+  it('accepts a screenshot payload with screenshotDataUrl + force', () => {
+    const r = ArticleCaptureSchema.safeParse({
+      url: 'https://example.com/p',
+      mode: 'screenshot',
+      contentMarkdown: '',
+      excerpt: '',
+      extractionStatus: 'full',
+      properties: {
+        title: 't',
+        source: 'https://example.com/p',
+        created: '2026-06-17T00:00:00.000Z',
+        tags: []
+      },
+      screenshotDataUrl: 'data:image/png;base64,AAAA',
+      force: true
+    })
+    expect(r.success).toBe(true)
+    if (r.success) expect(r.data.screenshotDataUrl).toBe('data:image/png;base64,AAAA')
+  })
 })

--- a/packages/contracts/src/capture-api.ts
+++ b/packages/contracts/src/capture-api.ts
@@ -18,6 +18,7 @@ export const ArticleCaptureSchema = z.object({
   extractionStatus: z.enum(['full', 'partial', 'failed']),
   properties: ArticlePropertiesSchema,
   heroImage: z.string().optional(),
+  screenshotDataUrl: z.string().optional(),
   tags: z.array(z.string()).optional(),
   force: z.boolean().optional()
 })

--- a/packages/contracts/src/inbox-channels.ts
+++ b/packages/contracts/src/inbox-channels.ts
@@ -142,7 +142,9 @@ export const InboxChannels = {
     /** Metadata fetch completed */
     METADATA_COMPLETE: 'inbox:metadata-complete',
     /** Processing error occurred */
-    PROCESSING_ERROR: 'inbox:processing-error'
+    PROCESSING_ERROR: 'inbox:processing-error',
+    /** Open and focus a specific inbox item */
+    OPEN_ITEM: 'inbox:open-item'
   }
 } as const
 

--- a/packages/rpc/src/inbox.ts
+++ b/packages/rpc/src/inbox.ts
@@ -608,7 +608,8 @@ export const inboxRpc = defineDomain({
     ),
     onInboxProcessingError: defineEvent<InboxProcessingErrorEvent>(
       InboxChannels.events.PROCESSING_ERROR
-    )
+    ),
+    onInboxOpenItem: defineEvent<string>(InboxChannels.events.OPEN_ITEM)
   }
 })
 


### PR DESCRIPTION
Stacked on #587 (Phase 2+3+3.1). Adds the next two phases of the browser web-clipper. Branched from `main` at the #587 merge.

## Phase 4 — Capture modes
Popup gains three ways to grab a page (no new permissions):
- **Article** — readable main content (default).
- **Selection** — only highlighted text (defuddle on the selected fragment).
- **Screenshot** — full-page, captured by background scroll + stitch (`captureVisibleTab` + `OffscreenCanvas`), decoded desktop-side into an inbox image attachment.

## Phase 5 — Trust + speed
- **Offline queue** — captures while Memry is closed persist in `browser.storage.local`, retry via `chrome.alarms` (~1 min), and a toolbar badge shows the pending count. Only new permission: `alarms`.
- **Keyboard command** — `Ctrl/Cmd+Shift+S` captures the active page in Article mode without the popup (no new permission; messages the declared content script).
- **Settings options page** — re-pair / unpair / rotate token / port override, plus one auth-guarded desktop route `POST /pair/revoke` (reuses `/capture` auth).
- **Add & open** — `InboxChannels.events.OPEN_ITEM` + `memry://open?item=<id>` deep-link brings Memry to front with the captured item focused; popup split button.

## Permissions / deps
Only new permission across both phases: `alarms`. No new `host_permissions`, no new dependencies. `commands` and `options_ui` are manifest keys, not permissions.

## Testing
- Extension: typecheck / lint / 58 unit tests / build all green; built manifest verified (`permissions=[storage,activeTab,alarms]`, `commands.capture-page`, `options_ui`).
- Desktop: `test:main` 18/18 (capture server + deeplink helper); `typecheck:node` + `typecheck:web` clean; `ipc:check` up to date.
- Docs: `docs:impact --strict` green (web-clipper section in `user-guide/inbox/capturing.md`); `docs:build` OK.
- **Pending: manual GUI QA** — load the unpacked extension against `pnpm dev` and run the queue / keyboard / settings / add-and-open / regression scenarios. Draft until that passes.

## Notes
Final whole-branch review fixed one concurrency bug: `flushQueue` now uses an in-flight guard so overlapping retry triggers can't double-ingest a queued capture.