### PR TITLE
feat(inbox): comfortable two-line list view with density toggle

### DIFF
--- a/apps/desktop/src/renderer/src/components/inbox/inbox-list.test.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox/inbox-list.test.tsx
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
-import { InboxListSection, InboxListItem, TypeIcon } from './inbox-list'
+import { InboxListSection, InboxListItem, TypeIcon, getInboxItemPreview } from './inbox-list'
 import type { InboxItemListItem, InboxItemType } from '@/types'
 
 vi.mock('@/components/ui/tooltip', () => ({
@@ -517,5 +517,29 @@ describe('InboxList - accessibility', () => {
 
     const listItem = screen.getByRole('listitem')
     expect(listItem).toHaveAttribute('tabindex', '0')
+  })
+})
+
+describe('getInboxItemPreview', () => {
+  it('returns markup-stripped content for a note', () => {
+    const item = createInboxItem('note', {
+      content: '# Title\n\nBody **bold** text <!-- memry:block-nesting-level=1 -->'
+    })
+    expect(getInboxItemPreview(item)).toBe('Title Body bold text')
+  })
+
+  it('prefers the excerpt for links', () => {
+    const item = createInboxItem('link', { excerpt: 'Link excerpt', content: 'fallback content' })
+    expect(getInboxItemPreview(item)).toBe('Link excerpt')
+  })
+
+  it('uses the transcription for voice items', () => {
+    const item = createInboxItem('voice', { transcription: 'Spoken words', content: null })
+    expect(getInboxItemPreview(item)).toBe('Spoken words')
+  })
+
+  it('returns null when there is no preview text', () => {
+    const item = createInboxItem('note', { content: null, excerpt: undefined })
+    expect(getInboxItemPreview(item)).toBeNull()
   })
 })

--- a/apps/desktop/src/renderer/src/components/inbox/inbox-list.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox/inbox-list.tsx
@@ -50,10 +50,35 @@ type InboxItem = InboxItemListItem
 // Context for selection and focus state
 // ============================================================================
 
+/** Strip light markdown/markup and collapse whitespace for a one-glance preview. */
+function normalizePreview(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  const text = raw
+    .replace(/<!--[\s\S]*?-->/g, ' ') // html comments (e.g. memry block markers)
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // links -> label
+    .replace(/[#>*_`~]+/g, ' ') // md heading/quote/emphasis markers
+    .replace(/\s+/g, ' ')
+    .trim()
+  return text.length > 0 ? text : null
+}
+
+/**
+ * Preview text for the comfortable (two-line) row: transcription for voice,
+ * excerpt for link/clip, else the captured content. Null when there's nothing
+ * worth showing — the row stays single-line in that case.
+ */
+export function getInboxItemPreview(item: InboxItem): string | null {
+  const raw =
+    item.type === 'voice' ? (item.transcription ?? item.content) : (item.excerpt ?? item.content)
+  return normalizePreview(raw)
+}
+
 interface InboxListContextValue {
   selectedIds: Set<string>
   focusedId: string | null
   isInBulkMode: boolean
+  density: DisplayDensity
   densityConfig: DensityConfig
   onSelect: (id: string, shiftKey: boolean) => void
   onFocus: (id: string) => void
@@ -198,7 +223,7 @@ const TranscriptionStatus = ({
               onRetry(item.id)
             }}
           >
-            <RotateCcw className="w-3 h-3 mr-1" />
+            <RotateCcw className="w-3 h-3 me-1" />
             {t('list.retryTranscription')}
           </Button>
         )}
@@ -292,7 +317,7 @@ export function InboxListSection({
 
   return (
     <InboxListContext.Provider
-      value={{ selectedIds, focusedId, isInBulkMode, densityConfig, onSelect, onFocus }}
+      value={{ selectedIds, focusedId, isInBulkMode, density, densityConfig, onSelect, onFocus }}
     >
       <section
         className={className}
@@ -302,7 +327,7 @@ export function InboxListSection({
           type="button"
           onClick={() => collapsible && setIsCollapsed(!isCollapsed)}
           className={cn(
-            'flex items-center gap-1.5 w-full text-left py-2 px-2',
+            'flex items-center gap-1.5 w-full text-start py-2 px-2',
             collapsible && 'cursor-pointer group'
           )}
           disabled={!collapsible}
@@ -393,7 +418,8 @@ export function InboxListItem({
   className
 }: InboxListItemProps) {
   const { t } = useT('inbox')
-  const { selectedIds, focusedId, isInBulkMode, densityConfig, onSelect, onFocus } = useInboxList()
+  const { selectedIds, focusedId, isInBulkMode, density, densityConfig, onSelect, onFocus } =
+    useInboxList()
   const isSelected = selectedIds.has(item.id)
   const isFocused = focusedId === item.id
 
@@ -419,6 +445,10 @@ export function InboxListItem({
     social: t('type.social'),
     reminder: t('type.reminder')
   }
+
+  // Comfortable density shows a second muted line of preview text (when present).
+  const previewText = getInboxItemPreview(item)
+  const showPreview = density === 'comfortable' && previewText !== null
 
   const handleClick = (): void => {
     onFocus(item.id)
@@ -517,95 +547,105 @@ export function InboxListItem({
           />
         </>
       ) : (
-        <>
-          {/* Title — single line, truncated */}
-          <span
-            className={cn(
-              'grow shrink min-w-0 truncate font-medium',
-              densityConfig.titleSize,
-              isReminderViewed
-                ? 'text-muted-foreground/60'
-                : item.snoozedUntil
-                  ? 'text-muted-foreground'
-                  : 'text-foreground/90'
-            )}
-          >
-            {displayTitle}
-          </span>
-
-          {/* Voice duration pill — hidden on hover when actions show */}
-          {item.type === 'voice' && item.duration != null && (
-            <div className={cn('shrink-0', !isInBulkMode && 'group-hover:opacity-0')}>
-              <Pill variant="bordered" color="amber">
-                {formatDuration(item.duration)}
-              </Pill>
-            </div>
-          )}
-
-          {/* PDF page count pill */}
-          {item.type === 'pdf' && item.pageCount != null && (
-            <Pill variant="bordered" color="red">
-              {t('list.pageCount', { count: item.pageCount })}
-            </Pill>
-          )}
-
-          {/* Snooze pill */}
-          {item.snoozedUntil && (
-            <Pill variant="filled" color="gray">
-              {t('list.snoozedUntilShort', {
-                date: new Date(item.snoozedUntil).toLocaleDateString('en-US', {
-                  month: 'short',
-                  day: 'numeric'
-                })
-              })}
-            </Pill>
-          )}
-
-          {/* Right slot: metadata swaps to actions on hover */}
-          <div className="relative shrink-0 flex items-center">
-            {/* Metadata — visible by default, hidden on hover */}
-            <div
-              className={cn('flex items-center gap-2', !isInBulkMode && 'group-hover:opacity-0')}
+        <div className="flex flex-col grow min-w-0 gap-0.5">
+          {/* Row 1: title, pills, and the metadata/actions slot */}
+          <div className="flex items-center gap-2 min-w-0">
+            {/* Title — single line, truncated */}
+            <span
+              className={cn(
+                'grow shrink min-w-0 truncate font-medium',
+                densityConfig.titleSize,
+                isReminderViewed
+                  ? 'text-muted-foreground/60'
+                  : item.snoozedUntil
+                    ? 'text-muted-foreground'
+                    : 'text-foreground/90'
+              )}
             >
-              {item.sourceUrl &&
-                (item.type === 'link' || item.type === 'social' || item.type === 'clip') && (
-                  <span
-                    className={cn('shrink-0', densityConfig.metaSize, 'text-muted-foreground/60')}
-                  >
-                    {extractDomain(item.sourceUrl)}
-                  </span>
-                )}
-              <span
-                className={cn(
-                  'shrink-0 w-9 text-right tabular-nums',
-                  densityConfig.metaSize,
-                  item.isStale ? 'text-amber-600 dark:text-amber-500' : 'text-muted-foreground/60'
-                )}
-              >
-                {formatCompactRelativeTime(
-                  item.createdAt instanceof Date ? item.createdAt : new Date(item.createdAt)
-                )}
-              </span>
-            </div>
+              {displayTitle}
+            </span>
 
-            {/* Actions — overlaid, visible on hover */}
-            {!isInBulkMode && (
-              <div
-                className={cn(
-                  'absolute inset-0 flex items-center justify-end',
-                  'opacity-0 group-hover:opacity-100'
-                )}
-              >
-                <QuickActions
-                  itemId={item.id}
-                  onArchive={onArchive}
-                  onSnooze={onSnooze}
-                  variant="row"
-                />
+            {/* Voice duration pill — hidden on hover when actions show */}
+            {item.type === 'voice' && item.duration != null && (
+              <div className={cn('shrink-0', !isInBulkMode && 'group-hover:opacity-0')}>
+                <Pill variant="bordered" color="amber">
+                  {formatDuration(item.duration)}
+                </Pill>
               </div>
             )}
+
+            {/* PDF page count pill */}
+            {item.type === 'pdf' && item.pageCount != null && (
+              <Pill variant="bordered" color="red">
+                {t('list.pageCount', { count: item.pageCount })}
+              </Pill>
+            )}
+
+            {/* Snooze pill */}
+            {item.snoozedUntil && (
+              <Pill variant="filled" color="gray">
+                {t('list.snoozedUntilShort', {
+                  date: new Date(item.snoozedUntil).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric'
+                  })
+                })}
+              </Pill>
+            )}
+
+            {/* Right slot: metadata swaps to actions on hover */}
+            <div className="relative shrink-0 flex items-center">
+              {/* Metadata — visible by default, hidden on hover */}
+              <div
+                className={cn('flex items-center gap-2', !isInBulkMode && 'group-hover:opacity-0')}
+              >
+                {item.sourceUrl &&
+                  (item.type === 'link' || item.type === 'social' || item.type === 'clip') && (
+                    <span
+                      className={cn('shrink-0', densityConfig.metaSize, 'text-muted-foreground/60')}
+                    >
+                      {extractDomain(item.sourceUrl)}
+                    </span>
+                  )}
+                <span
+                  className={cn(
+                    'shrink-0 w-9 text-end tabular-nums',
+                    densityConfig.metaSize,
+                    item.isStale ? 'text-amber-600 dark:text-amber-500' : 'text-muted-foreground/60'
+                  )}
+                >
+                  {formatCompactRelativeTime(
+                    item.createdAt instanceof Date ? item.createdAt : new Date(item.createdAt)
+                  )}
+                </span>
+              </div>
+
+              {/* Actions — overlaid, visible on hover */}
+              {!isInBulkMode && (
+                <div
+                  className={cn(
+                    'absolute inset-0 flex items-center justify-end',
+                    'opacity-0 group-hover:opacity-100'
+                  )}
+                >
+                  <QuickActions
+                    itemId={item.id}
+                    onArchive={onArchive}
+                    onSnooze={onSnooze}
+                    variant="row"
+                  />
+                </div>
+              )}
+            </div>
           </div>
-        </>
+
+          {/* Row 2: comfortable-only preview line */}
+          {showPreview && (
+            <span className="line-clamp-2 pe-1 text-[13px] leading-snug text-muted-foreground">
+              {previewText}
+            </span>
+          )}
+        </div>
       )}
     </div>
   )

--- a/apps/desktop/src/renderer/src/pages/inbox.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox.tsx
@@ -7,7 +7,9 @@ import {
   FilePdf,
   Image,
   Link2,
+  List,
   Mic,
+  Rows2,
   Scissors,
   Search,
   Share2,
@@ -24,6 +26,7 @@ import { CaptureInput } from '@/components/capture-input'
 import { Picker } from '@/components/ui/picker'
 import { useInboxNotifications } from '@/hooks/use-inbox-notifications'
 import { useInboxJobs, useInboxList } from '@/hooks/use-inbox'
+import { useDisplayDensity } from '@/hooks/use-display-density'
 import { useInboxRemindersPanel } from '@/hooks/use-inbox-reminders-panel'
 import { useActiveTab } from '@/contexts/tabs'
 import type { InboxItemType } from '@memry/contracts/inbox-api'
@@ -72,6 +75,7 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
   const archivedSearchRef = useRef<HTMLInputElement>(null)
   useInboxNotifications()
   const { items } = useInboxList()
+  const { density, toggleDensity, isComfortable } = useDisplayDensity()
   const { upcomingCount } = useInboxRemindersPanel()
   const { activeCount: activeJobCount, failedCount: failedJobCount } = useInboxJobs(
     items.map((item) => item.id)
@@ -386,6 +390,23 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
                     )}
                   </Picker.Content>
                 </Picker>
+
+                <button
+                  type="button"
+                  onClick={toggleDensity}
+                  title={
+                    isComfortable ? t('view.density.toCompact') : t('view.density.toComfortable')
+                  }
+                  aria-label={
+                    isComfortable ? t('view.density.toCompact') : t('view.density.toComfortable')
+                  }
+                  className={cn(
+                    'flex items-center justify-center shrink-0 rounded-[5px] py-1 px-2 border transition-colors',
+                    'border-border text-muted-foreground hover:bg-surface-active/50'
+                  )}
+                >
+                  {isComfortable ? <Rows2 className="size-3" /> : <List className="size-3" />}
+                </button>
               </>
             )}
           </PageToolbar>
@@ -413,6 +434,7 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
                 className={className}
                 selectedTypes={selectedTypes}
                 showSnoozedItems={showSnoozedItems}
+                density={density}
                 focusItemId={focusInboxItemId}
                 {...{ focusToken }}
               />

--- a/apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx
@@ -23,7 +23,7 @@ import type { InboxItemType } from '@memry/contracts/inbox-api'
 import { detectClusters, getClusterKey } from '@/lib/ai-clustering'
 import { cn } from '@/lib/utils'
 import { isInputFocused } from '@/hooks/use-keyboard-shortcuts'
-import { DENSITY_CONFIG } from '@/hooks/use-display-density'
+import { DENSITY_CONFIG, type DisplayDensity } from '@/hooks/use-display-density'
 import {
   useInboxList,
   useInboxItem,
@@ -44,6 +44,7 @@ export interface InboxListViewProps {
   className?: string
   selectedTypes: Set<InboxItemType>
   showSnoozedItems: boolean
+  density?: DisplayDensity
   focusItemId?: string | null
   focusToken?: number | null
 }
@@ -52,6 +53,7 @@ export function InboxListView({
   className,
   selectedTypes,
   showSnoozedItems,
+  density = 'comfortable',
   focusItemId = null,
   focusToken
 }: InboxListViewProps): React.JSX.Element {
@@ -60,8 +62,7 @@ export function InboxListView({
   const { openTab } = useTabs()
   const { enabled: aiEnabled } = useAISettingsContext()
 
-  const density = 'compact'
-  const densityConfig = DENSITY_CONFIG.compact
+  const densityConfig = DENSITY_CONFIG[density]
 
   // Data hooks
   const {

--- a/packages/i18n/src/locales/en/inbox.json
+++ b/packages/i18n/src/locales/en/inbox.json
@@ -17,6 +17,10 @@
       "showWithCount": "Show snoozed items ({count})",
       "hide": "Hide snoozed items"
     },
+    "density": {
+      "toComfortable": "Comfortable view",
+      "toCompact": "Compact view"
+    },
     "filter": {
       "button": "Filter",
       "byType": "Filter by type",


### PR DESCRIPTION
## What

Adds a non-compact (**comfortable**) list view to the inbox alongside the current compact list, plus a toolbar toggle to switch between them.

Comfortable rows are taller and show a **second muted line of preview text** per item, so you can scan content without opening each item:
- voice → transcription
- link / clip → excerpt
- everything else → captured content

Preview text is markup-stripped (markdown markers, image/link syntax, and memry block comments collapsed). The preview line only renders when there's text to show, so items without a body stay single-line.

## Why

The inbox was hardcoded to `compact`, but the app already ships a Comfortable/Compact density system (used in folder-view, and a documented signature in DESIGN.md). This reuses that system rather than adding a parallel "view" concept — minimal surface area, consistent with the rest of the app.

## How it works

- `inbox-list-view.tsx`: dropped the hardcoded `const density = 'compact'`; density is now a prop.
- `inbox.tsx`: toolbar toggle button (`Rows2` ↔ `List` icon) driven by the existing `useDisplayDensity()` hook; passes `density` to the list.
- `inbox-list.tsx`: exposed `density` on the list context; the row becomes a two-line column in comfortable mode. New pure `getInboxItemPreview()` helper.
- `en/inbox.json`: two toggle labels.

## Note on behavior

Density is the **shared app-wide preference** (`memry-display-density`). Toggling in the inbox also affects folder-view and vice-versa — one density across the app. Easy to split into an inbox-specific key if we'd rather.

## Testing

- Renderer tests: 43 pass, incl. 4 new `getInboxItemPreview` cases (note/link/voice/empty).
- `typecheck:web`: clean.
- ESLint: 0 errors on changed files.
- `i18n:check`: passed.

## Follow-ups before ready

- [ ] Manual GUI QA (toggle, two-line rendering across item types, RTL).
- [ ] Real docs page for inbox view density (pushed with `MEMRY_DOCS_IMPACT_SKIP=1`; no inbox docs page exists yet).