### PR TITLE
feat(folder-view): Linear-vibe redesign — List/Board/Gallery views + restyled table

### DIFF
--- a/apps/desktop/src/renderer/src/components/folder-view/folder-board-view.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-board-view.tsx
@@ -1,0 +1,193 @@
+/**
+ * Folder Board (Kanban) View
+ *
+ * Groups notes into columns by the folder's first `select` property (e.g. Status).
+ * When no select property exists, falls back to a single "All notes" column.
+ *
+ * ponytail: no drag-to-reorder yet — read-only board; wire dnd-kit when the
+ * write path (updating the group property on drop) is needed.
+ */
+
+import { useMemo } from 'react'
+import { FileText, Folder, Plus } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import type { NoteWithProperties } from '@memry/contracts/folder-view-api'
+import { FolderViewEmptyState } from './folder-view-empty-state'
+import { NoteTagPill, dotFor } from './note-card-pieces'
+
+interface AvailableProp {
+  name: string
+  type: string
+}
+
+export interface FolderBoardViewProps {
+  notes: NoteWithProperties[]
+  searchQuery?: string
+  tagColorMap: Map<string, string>
+  availableProperties: AvailableProp[]
+  onNoteOpen: (noteId: string) => void
+  onTagClick?: (tag: string) => void
+  onCreateNote?: () => void
+  onClearAll?: () => void
+  className?: string
+}
+
+const NO_VALUE = '—'
+
+export function FolderBoardView({
+  notes,
+  searchQuery,
+  tagColorMap,
+  availableProperties,
+  onNoteOpen,
+  onTagClick,
+  onCreateNote,
+  onClearAll,
+  className
+}: FolderBoardViewProps): React.JSX.Element {
+  const q = searchQuery?.trim().toLowerCase() ?? ''
+  const visible = useMemo(() => {
+    if (!q) return notes
+    return notes.filter(
+      (n) => n.title.toLowerCase().includes(q) || n.tags.some((t) => t.toLowerCase().includes(q))
+    )
+  }, [notes, q])
+
+  const groupProp = useMemo(
+    () => availableProperties.find((p) => p.type === 'select')?.name,
+    [availableProperties]
+  )
+
+  const columns = useMemo(() => {
+    if (!groupProp) return [{ key: '__all__', label: 'All notes', notes: visible }]
+    const map = new Map<string, NoteWithProperties[]>()
+    const order: string[] = []
+    for (const note of visible) {
+      const raw = note.properties?.[groupProp]
+      const key =
+        typeof raw === 'string' && raw !== ''
+          ? raw
+          : typeof raw === 'number'
+            ? String(raw)
+            : NO_VALUE
+      const bucket = map.get(key)
+      if (bucket) {
+        bucket.push(note)
+      } else {
+        map.set(key, [note])
+        order.push(key)
+      }
+    }
+    // Keep the "no value" column last.
+    order.sort((a, b) => (a === NO_VALUE ? 1 : 0) - (b === NO_VALUE ? 1 : 0))
+    return order.map((key) => ({
+      key,
+      label: key === NO_VALUE ? `No ${groupProp}` : key,
+      notes: map.get(key) ?? []
+    }))
+  }, [visible, groupProp])
+
+  if (visible.length === 0) {
+    return (
+      <FolderViewEmptyState
+        variant={q ? 'no-results' : 'empty'}
+        onCreateNote={onCreateNote}
+        onClearAll={onClearAll}
+        className={cn('h-full', className)}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={cn('flex h-full items-start gap-3.5 overflow-x-auto bg-muted/30 p-4', className)}
+    >
+      {columns.map((col, i) => (
+        <div key={col.key} className="flex w-[300px] shrink-0 flex-col">
+          <div className="flex items-center gap-2 px-1 pb-2.5 pt-0.5">
+            <span
+              className="size-2 shrink-0 rounded-full"
+              style={{ backgroundColor: dotFor(i) }}
+              aria-hidden="true"
+            />
+            <span className="text-xs font-semibold text-foreground">{col.label}</span>
+            <span className="text-[11px] tabular-nums text-muted-foreground/60">
+              {col.notes.length}
+            </span>
+            <div className="flex-1" />
+            <Plus className="size-3.5 text-muted-foreground/50" />
+          </div>
+          <div className="flex flex-col gap-2">
+            {col.notes.map((note) => (
+              <BoardCard
+                key={note.id}
+                note={note}
+                tagColorMap={tagColorMap}
+                onNoteOpen={onNoteOpen}
+                onTagClick={onTagClick}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function BoardCard({
+  note,
+  tagColorMap,
+  onNoteOpen,
+  onTagClick
+}: {
+  note: NoteWithProperties
+  tagColorMap: Map<string, string>
+  onNoteOpen: (noteId: string) => void
+  onTagClick?: (tag: string) => void
+}): React.JSX.Element {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onNoteOpen(note.id)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onNoteOpen(note.id)
+        }
+      }}
+      className="flex cursor-pointer flex-col gap-2 rounded-[10px] border border-border bg-card p-2.5 shadow-sm outline-none transition-shadow hover:shadow-md focus-visible:ring-2 focus-visible:ring-ring/40"
+    >
+      <div className="flex items-start gap-2">
+        {note.emoji ? (
+          <span className="text-sm leading-[18px]">{note.emoji}</span>
+        ) : (
+          <FileText className="mt-0.5 size-4 shrink-0 text-muted-foreground/70" />
+        )}
+        <span className="text-[13px] font-medium leading-[18px] text-foreground">
+          {note.title || 'Untitled'}
+        </span>
+      </div>
+      {note.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {note.tags.slice(0, 3).map((tag) => (
+            <NoteTagPill
+              key={tag}
+              tag={tag}
+              color={tagColorMap.get(tag.toLowerCase())}
+              onClick={onTagClick ? () => onTagClick(tag) : undefined}
+            />
+          ))}
+        </div>
+      )}
+      <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
+        <Folder className="size-3 shrink-0" />
+        <span className="truncate">{note.folder ? note.folder.replace(/^\//, '') : NO_VALUE}</span>
+        <div className="flex-1" />
+        <span className="tabular-nums">{`${note.wordCount.toLocaleString()}w`}</span>
+      </div>
+    </div>
+  )
+}
+
+export default FolderBoardView

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-gallery-view.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-gallery-view.tsx
@@ -1,0 +1,113 @@
+/**
+ * Folder Gallery (Grid) View
+ *
+ * Notes as cards with a tinted cover (theme-aware --card-* pastels), large emoji,
+ * title, tags, and folder + modified metadata.
+ *
+ * ponytail: no virtualization yet — fine for typical folders; add windowing if
+ * a folder routinely exceeds ~500 notes.
+ */
+
+import { useMemo } from 'react'
+import { Folder } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import type { NoteWithProperties } from '@memry/contracts/folder-view-api'
+import { FolderViewEmptyState } from './folder-view-empty-state'
+import { NoteTagPill, pastelFor, formatRelative } from './note-card-pieces'
+
+export interface FolderGalleryViewProps {
+  notes: NoteWithProperties[]
+  searchQuery?: string
+  tagColorMap: Map<string, string>
+  onNoteOpen: (noteId: string) => void
+  onTagClick?: (tag: string) => void
+  onCreateNote?: () => void
+  onClearAll?: () => void
+  className?: string
+}
+
+export function FolderGalleryView({
+  notes,
+  searchQuery,
+  tagColorMap,
+  onNoteOpen,
+  onTagClick,
+  onCreateNote,
+  onClearAll,
+  className
+}: FolderGalleryViewProps): React.JSX.Element {
+  const q = searchQuery?.trim().toLowerCase() ?? ''
+  const visible = useMemo(() => {
+    if (!q) return notes
+    return notes.filter(
+      (n) => n.title.toLowerCase().includes(q) || n.tags.some((t) => t.toLowerCase().includes(q))
+    )
+  }, [notes, q])
+
+  if (visible.length === 0) {
+    return (
+      <FolderViewEmptyState
+        variant={q ? 'no-results' : 'empty'}
+        onCreateNote={onCreateNote}
+        onClearAll={onClearAll}
+        className={cn('h-full', className)}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={cn('flex h-full flex-wrap content-start gap-4 overflow-auto p-[18px]', className)}
+    >
+      {visible.map((note) => (
+        <div
+          key={note.id}
+          role="button"
+          tabIndex={0}
+          onClick={() => onNoteOpen(note.id)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              onNoteOpen(note.id)
+            }
+          }}
+          className="flex w-[272px] cursor-pointer flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm outline-none transition-shadow hover:shadow-md focus-visible:ring-2 focus-visible:ring-ring/40"
+        >
+          <div
+            className={cn(
+              'flex h-[90px] items-center justify-center',
+              pastelFor(note.emoji || note.title || note.id)
+            )}
+          >
+            <span className="text-[34px] leading-none">{note.emoji || '📄'}</span>
+          </div>
+          <div className="flex flex-col gap-2 p-3">
+            <span className="line-clamp-2 text-[13px] font-semibold leading-[17px] text-foreground">
+              {note.title || 'Untitled'}
+            </span>
+            {note.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {note.tags.slice(0, 3).map((tag) => (
+                  <NoteTagPill
+                    key={tag}
+                    tag={tag}
+                    color={tagColorMap.get(tag.toLowerCase())}
+                    onClick={onTagClick ? () => onTagClick(tag) : undefined}
+                  />
+                ))}
+              </div>
+            )}
+            <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
+              <Folder className="size-3 shrink-0" />
+              <span className="truncate">{note.folder ? note.folder.replace(/^\//, '') : '—'}</span>
+              <div className="flex-1" />
+              <span className="tabular-nums">{formatRelative(note.modified)}</span>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default FolderGalleryView

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-list-view.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-list-view.tsx
@@ -1,0 +1,112 @@
+/**
+ * Folder List View
+ *
+ * Compact, title-centric single-line list of notes (Linear-vibe). A lighter
+ * alternative to the spreadsheet table: title + inline tags + trailing metadata.
+ *
+ * ponytail: no virtualization yet — fine for typical folders; add windowing if
+ * a folder routinely exceeds ~500 notes.
+ */
+
+import { useMemo } from 'react'
+import { FileText } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import type { NoteWithProperties } from '@memry/contracts/folder-view-api'
+import { FolderViewEmptyState } from './folder-view-empty-state'
+import { NoteTagPill, formatRelative } from './note-card-pieces'
+
+export interface FolderListViewProps {
+  notes: NoteWithProperties[]
+  searchQuery?: string
+  density?: 'comfortable' | 'compact'
+  tagColorMap: Map<string, string>
+  onNoteOpen: (noteId: string) => void
+  onTagClick?: (tag: string) => void
+  onCreateNote?: () => void
+  onClearAll?: () => void
+  className?: string
+}
+
+export function FolderListView({
+  notes,
+  searchQuery,
+  density = 'comfortable',
+  tagColorMap,
+  onNoteOpen,
+  onTagClick,
+  onCreateNote,
+  onClearAll,
+  className
+}: FolderListViewProps): React.JSX.Element {
+  const q = searchQuery?.trim().toLowerCase() ?? ''
+  const visible = useMemo(() => {
+    if (!q) return notes
+    return notes.filter(
+      (n) => n.title.toLowerCase().includes(q) || n.tags.some((t) => t.toLowerCase().includes(q))
+    )
+  }, [notes, q])
+
+  if (visible.length === 0) {
+    return (
+      <FolderViewEmptyState
+        variant={q ? 'no-results' : 'empty'}
+        onCreateNote={onCreateNote}
+        onClearAll={onClearAll}
+        className={cn('h-full', className)}
+      />
+    )
+  }
+
+  const rowH = density === 'compact' ? 'h-8' : 'h-10'
+
+  return (
+    <div className={cn('h-full overflow-auto py-1', className)} role="list">
+      {visible.map((note) => (
+        <div
+          key={note.id}
+          role="button"
+          tabIndex={0}
+          onClick={() => onNoteOpen(note.id)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              onNoteOpen(note.id)
+            }
+          }}
+          className={cn(
+            'group flex w-full cursor-pointer items-center gap-2.5 px-5 outline-none transition-colors hover:bg-muted/60 focus-visible:bg-muted/60',
+            rowH
+          )}
+        >
+          {note.emoji ? (
+            <span className="shrink-0 text-sm leading-none">{note.emoji}</span>
+          ) : (
+            <FileText className="size-[15px] shrink-0 text-muted-foreground/70" />
+          )}
+          <span className="shrink-0 truncate text-[13px] font-medium text-foreground/90">
+            {note.title || 'Untitled'}
+          </span>
+          <div className="flex shrink-0 items-center gap-1.5">
+            {note.tags.slice(0, 3).map((tag) => (
+              <NoteTagPill
+                key={tag}
+                tag={tag}
+                color={tagColorMap.get(tag.toLowerCase())}
+                onClick={onTagClick ? () => onTagClick(tag) : undefined}
+              />
+            ))}
+          </div>
+          <div className="flex-1" />
+          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70">
+            {`${note.wordCount.toLocaleString()}w`}
+          </span>
+          <span className="w-16 shrink-0 text-end text-[11px] tabular-nums text-muted-foreground/60">
+            {formatRelative(note.modified)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default FolderListView

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx
@@ -1042,7 +1042,7 @@ export function FolderTableView({
               top: 0,
               zIndex: 10
             }}
-            className="bg-background border-b"
+            className="bg-muted border-b border-border/60"
           >
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id} style={{ display: 'flex', width: '100%' }}>
@@ -1115,14 +1115,14 @@ export function FolderTableView({
                       transform: `translateY(${virtualRow.start}px)`
                     }}
                     className={cn(
-                      'border-b border-border/50',
+                      'border-b border-border/40',
                       'transition-colors',
                       'items-center',
                       'cursor-pointer',
                       // Hover styling (only when not selected)
                       !isSelected && 'hover:bg-muted/50',
-                      // Selected row styling - thin warm border
-                      isSelected && 'border-l-2',
+                      // Selected row styling - terracotta accent (tint)
+                      isSelected && 'bg-[var(--tint)]/[0.06] border-s-2 border-s-[var(--tint)]',
                       // Focused row styling (keyboard navigation cursor)
                       isFocused && 'ring-2x ring-inset',
                       // T121: Exit animation - simple opacity fade
@@ -1141,7 +1141,7 @@ export function FolderTableView({
                             // T099: Density-aware padding
                             density === 'compact' ? 'px-2 py-1' : 'px-3 py-2',
                             // T099: Column borders (not on last column)
-                            showColumnBorders && !isLastCell && 'border-r border-border/30'
+                            showColumnBorders && !isLastCell && 'border-e border-border/30'
                           )}
                           style={
                             isLastCell

--- a/apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx
@@ -1152,13 +1152,13 @@ export function GroupedTable({
                       paddingLeft: isInGroup ? '24px' : undefined
                     }}
                     className={cn(
-                      'border-b border-border/50',
+                      'border-b border-border/40',
                       'transition-colors',
                       'items-center',
                       'cursor-pointer',
                       !isSelected && 'hover:bg-muted/50',
-                      isSelected && 'border-l-2 border-amber-400 dark:border-amber-600',
-                      isFocused && 'ring-2 ring-amber-400/50 ring-inset dark:ring-amber-600/50',
+                      isSelected && 'bg-[var(--tint)]/[0.06] border-s-2 border-s-[var(--tint)]',
+                      isFocused && 'ring-2 ring-[var(--tint)]/40 ring-inset',
                       // T121: Exit animation - simple opacity fade
                       isExiting && 'opacity-0 transition-opacity duration-200'
                     )}
@@ -1175,7 +1175,7 @@ export function GroupedTable({
                           className={cn(
                             'flex-shrink-0 overflow-hidden',
                             density === 'compact' ? 'px-2 py-1' : 'px-3 py-2',
-                            showColumnBorders && !isLastCell && 'border-r border-border/30'
+                            showColumnBorders && !isLastCell && 'border-e border-border/30'
                           )}
                           style={
                             isLastCell
@@ -1318,7 +1318,7 @@ const GroupHeaderRow = memo(function GroupHeaderRow({
         </button>
 
         {/* Group property name and value */}
-        <span className="text-xs text-muted-foreground font-medium">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-muted-foreground">
           {capitalizeFirst(groupByProperty)}:
         </span>
         <span className="font-medium">{getGroupDisplayValue(groupValue)}</span>
@@ -1330,7 +1330,7 @@ const GroupHeaderRow = memo(function GroupHeaderRow({
 
         {/* Group summaries (if enabled) */}
         {groupSummaries && (
-          <div className="flex items-center gap-3 ml-4 text-xs text-muted-foreground">
+          <div className="flex items-center gap-3 ms-4 text-xs text-muted-foreground">
             {Object.entries(groupSummaries)
               .slice(0, 3)
               .map(([columnId, value]) => {

--- a/apps/desktop/src/renderer/src/components/folder-view/note-card-pieces.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/note-card-pieces.tsx
@@ -1,0 +1,83 @@
+/**
+ * Shared presentational pieces for the non-table folder views (list / board / gallery).
+ * Kept tiny and dependency-free so the three views render notes consistently.
+ */
+
+import { cn } from '@/lib/utils'
+
+const HEX6 = /^#([0-9a-f]{6})$/i
+
+/**
+ * A note tag rendered as a tinted pill. Uses the tag's custom color when it is a
+ * valid 6-digit hex, otherwise falls back to the neutral muted token.
+ */
+export function NoteTagPill({
+  tag,
+  color,
+  onClick
+}: {
+  tag: string
+  color?: string
+  onClick?: () => void
+}): React.JSX.Element {
+  const tinted = !!color && HEX6.test(color)
+  return (
+    <button
+      type="button"
+      onClick={
+        onClick
+          ? (e) => {
+              e.stopPropagation()
+              onClick()
+            }
+          : undefined
+      }
+      className={cn(
+        'inline-flex h-[18px] shrink-0 items-center rounded-full px-[7px] text-[10.5px] font-medium transition-colors',
+        !tinted && 'bg-muted text-muted-foreground hover:bg-muted/80'
+      )}
+      style={tinted ? { backgroundColor: `${color}24`, color } : undefined}
+    >
+      #{tag}
+    </button>
+  )
+}
+
+// Theme-aware pastel cover backgrounds (mapped from --card-* tokens in base.css).
+const PASTELS = [
+  'bg-card-sage',
+  'bg-card-lavender',
+  'bg-card-rose',
+  'bg-card-sand',
+  'bg-card-grey'
+] as const
+
+/** Deterministically pick a pastel cover for a card based on a stable seed. */
+export function pastelFor(seed: string): string {
+  let h = 0
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0
+  return PASTELS[h % PASTELS.length]
+}
+
+// Status-dot palette for board columns (terracotta accent shared with --tint).
+const DOTS = ['#9b9a97', '#2563eb', '#f97316', '#16a34a', '#7c3aed', '#0891b2'] as const
+
+/** Pick a board-column dot color by column index. */
+export function dotFor(index: number): string {
+  return DOTS[index % DOTS.length]
+}
+
+/** Compact relative timestamp ("2h ago" / "Jun 16") for card + row metadata. */
+export function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime()
+  if (Number.isNaN(t)) return ''
+  const diff = Date.now() - t
+  const m = Math.floor(diff / 60000)
+  if (m < 1) return 'now'
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  if (d < 7) return `${d}d ago`
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}

--- a/apps/desktop/src/renderer/src/components/folder-view/sortable-column-header.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/sortable-column-header.tsx
@@ -221,9 +221,9 @@ export function SortableColumnHeader({
     const arrow = sortDirection === 'asc' ? '▲' : '▼'
     const showIndex = totalSortedColumns > 1 && sortIndex !== undefined
     return (
-      <span className="ml-1 text-muted-foreground/70 whitespace-nowrap">
+      <span className="ms-1 text-muted-foreground/70 whitespace-nowrap">
         {arrow}
-        {showIndex && <sup className="text-[10px] ml-0.5">{sortIndex}</sup>}
+        {showIndex && <sup className="text-[10px] ms-0.5">{sortIndex}</sup>}
       </span>
     )
   }
@@ -235,17 +235,17 @@ export function SortableColumnHeader({
       className={cn(
         // T099: Density-aware padding
         density === 'compact' ? 'px-2 py-1' : 'px-3 py-2',
-        'text-left font-medium text-muted-foreground',
+        'text-start text-[11px] font-semibold uppercase tracking-[0.04em] text-muted-foreground/80',
         'select-none relative group',
         canSort && !isEditing && 'cursor-pointer hover:bg-muted/50',
         header.column.getIsResizing() && 'bg-muted/30',
         isHighlighted && 'bg-primary/10 text-primary',
         isDragging && 'opacity-50 z-50',
         // T099: Column borders (not on last column)
-        showColumnBorders && !isLastColumn && 'border-r border-border/30',
-        // Drop indicator - blue line on left side
+        showColumnBorders && !isLastColumn && 'border-e border-border/30',
+        // Drop indicator - accent line on the leading edge
         isOver &&
-          'before:absolute before:left-0 before:top-1 before:bottom-1 before:w-0.5 before:bg-primary before:rounded-full before:z-20'
+          'before:absolute before:start-0 before:top-1 before:bottom-1 before:w-0.5 before:bg-primary before:rounded-full before:z-20'
       )}
       onClick={handleSortClick}
     >
@@ -264,7 +264,7 @@ export function SortableColumnHeader({
             'flex-shrink-0 cursor-grab active:cursor-grabbing',
             'opacity-0 group-hover:opacity-100 transition-opacity',
             'text-muted-foreground/50 hover:text-muted-foreground',
-            '-ml-1 mr-0.5'
+            '-ms-1 me-0.5'
           )}
           aria-label={`Drag to reorder column: ${columnConfig.displayName ?? columnConfig.id}`}
           title={tPhaseF('phaseF.componentsFolderViewSortableColumnHeader.dragToReorderColumn')}
@@ -325,7 +325,7 @@ export function SortableColumnHeader({
         }}
         aria-label={tPhaseF('phaseF.componentsFolderViewSortableColumnHeader.resizeColumn')}
         className={cn(
-          'absolute right-0 top-0 h-full w-1 cursor-col-resize select-none touch-none',
+          'absolute end-0 top-0 h-full w-1 cursor-col-resize select-none touch-none',
           'opacity-0 group-hover:opacity-100 hover:bg-primary/50',
           header.column.getIsResizing() && 'opacity-100 bg-primary'
         )}

--- a/apps/desktop/src/renderer/src/components/folder-view/summary-row.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/summary-row.tsx
@@ -116,9 +116,9 @@ export function SummaryRow({
                 // Density-aware padding
                 density === 'compact' ? 'px-2 py-1' : 'px-3 py-2',
                 // Column borders (not on last column)
-                showColumnBorders && !isLast && 'border-r border-border/30',
+                showColumnBorders && !isLast && 'border-e border-border/30',
                 // Text styling
-                'text-sm font-medium text-muted-foreground',
+                'text-[11px] font-medium text-muted-foreground',
                 // Truncate overflow
                 'overflow-hidden'
               )}
@@ -164,18 +164,28 @@ function SummaryCell({ value, type, label }: SummaryCellProps): React.JSX.Elemen
   // For countBy, the value is already formatted with labels
   if (type === 'countBy') {
     return (
-      <div className="flex items-center gap-1.5 truncate" title={value}>
-        <span className="text-xs opacity-60">{symbol}</span>
-        <span className="truncate text-xs">{value}</span>
+      <div className="flex items-center gap-1.5 truncate text-[11px]" title={value}>
+        <span className="font-semibold text-muted-foreground/60">{symbol}</span>
+        <span className="truncate text-muted-foreground">{value}</span>
       </div>
     )
   }
 
   return (
-    <div className="flex items-center gap-1.5 truncate" title={`${label ?? type}: ${value}`}>
-      <span className="text-xs opacity-60">{symbol}</span>
-      {label && <span className="text-xs opacity-70">{label}:</span>}
-      <span className="truncate">{value}</span>
+    <div
+      className="flex items-center gap-1.5 truncate text-[11px]"
+      title={`${label ?? type}: ${value}`}
+    >
+      <span
+        className={cn(
+          'font-semibold',
+          type === 'sum' ? 'text-[var(--tint)]' : 'text-muted-foreground/60'
+        )}
+      >
+        {symbol}
+      </span>
+      {label && <span className="text-muted-foreground/70">{label}:</span>}
+      <span className="truncate font-semibold tabular-nums text-foreground">{value}</span>
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/pages/folder-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/folder-view.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useMemo, useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
-import { ArrowLeft, Folder, LayoutGrid, List, Plus, Settings2 } from '@/lib/icons'
+import { ArrowLeft, Columns3, Folder, LayoutGrid, List, Plus, Rows2, Settings2 } from '@/lib/icons'
 
 // ============================================================================
 // Debounce Hook
@@ -58,7 +58,11 @@ import { useSidebarDrillDown } from '@/contexts/sidebar-drill-down'
 import { FolderTableView } from '@/components/folder-view/folder-table-view'
 import { GroupedTable } from '@/components/folder-view/grouped-table'
 import { FolderViewToolbar } from '@/components/folder-view/folder-view-toolbar'
+import { FolderListView } from '@/components/folder-view/folder-list-view'
+import { FolderBoardView } from '@/components/folder-view/folder-board-view'
+import { FolderGalleryView } from '@/components/folder-view/folder-gallery-view'
 import { ViewSwitcher } from '@/components/folder-view/view-switcher'
+import { cn } from '@/lib/utils'
 import { MoveToFolderDialog } from '@/components/folder-view/move-to-folder-dialog'
 import { useFolderView } from '@/hooks/use-folder-view'
 import { useNoteMutations, useNoteTagsQuery } from '@/hooks/use-notes-query'
@@ -132,6 +136,15 @@ export function FolderViewPage({ folderPath }: FolderViewPageProps): React.JSX.E
 
   // Get first note for formula preview in editor
   const sampleNote = notes.length > 0 ? notes[0] : null
+
+  // Active view render mode (table / list / kanban / grid) — persisted via the view config.
+  const viewType = activeView?.type ?? 'table'
+  const handleViewTypeChange = useCallback(
+    (type: 'table' | 'list' | 'kanban' | 'grid') => {
+      void updateView({ type })
+    },
+    [updateView]
+  )
 
   // Delete confirmation dialog state
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
@@ -534,15 +547,15 @@ export function FolderViewPage({ folderPath }: FolderViewPageProps): React.JSX.E
         </span>
 
         {/* T098: New Note button */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
+        <button
+          type="button"
           onClick={() => void handleCreateNote()}
           title={tPhaseF('phaseF.pagesFolderView.createNewNote')}
+          className="flex h-8 items-center gap-1.5 rounded-md bg-[var(--tint)] px-3 text-[12.5px] font-semibold text-[var(--tint-foreground)] transition-colors hover:bg-[var(--tint-hover)]"
         >
-          <Plus className="h-4 w-4" />
-        </Button>
+          <Plus className="size-3.5" />
+          {tPhaseF('phaseF.pagesFolderView.createNewNote')}
+        </button>
 
         {/* Spacer */}
         <div className="flex-1" />
@@ -559,14 +572,36 @@ export function FolderViewPage({ folderPath }: FolderViewPageProps): React.JSX.E
           onDeleteView={deleteView}
         />
 
-        {/* View type toggle (future: table/grid/list) */}
-        <div className="flex items-center gap-1 border rounded-md p-0.5">
-          <Button variant="ghost" size="icon" className="h-7 w-7 bg-muted">
-            <List className="h-4 w-4" />
-          </Button>
-          <Button variant="ghost" size="icon" className="h-7 w-7" disabled>
-            <LayoutGrid className="h-4 w-4" />
-          </Button>
+        {/* View type switcher: Table / List / Board / Gallery */}
+        <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+          {(
+            [
+              { type: 'table', Icon: Rows2, label: 'Table' },
+              { type: 'list', Icon: List, label: 'List' },
+              { type: 'kanban', Icon: Columns3, label: 'Board' },
+              { type: 'grid', Icon: LayoutGrid, label: 'Gallery' }
+            ] as const
+          ).map(({ type, Icon, label }) => {
+            const active = viewType === type
+            return (
+              <button
+                key={type}
+                type="button"
+                title={label}
+                aria-pressed={active}
+                onClick={() => handleViewTypeChange(type)}
+                className={cn(
+                  'flex h-7 items-center gap-1.5 rounded-[5px] px-2 text-xs font-medium transition-colors',
+                  active
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                <Icon className="size-3.5" />
+                {active && <span>{label}</span>}
+              </button>
+            )
+          })}
         </div>
 
         {/* T099: View Settings dropdown */}
@@ -656,6 +691,41 @@ export function FolderViewPage({ folderPath }: FolderViewPageProps): React.JSX.E
             />
           ) : isLoading ? (
             <FolderViewSkeleton columns={activeView?.columns ?? DEFAULT_COLUMNS} />
+          ) : viewType === 'list' ? (
+            <FolderListView
+              notes={notes}
+              searchQuery={debouncedSearchQuery}
+              density={density}
+              tagColorMap={tagColorMap}
+              onNoteOpen={handleNoteOpen}
+              onTagClick={handleTagClick}
+              onCreateNote={() => void handleCreateNote()}
+              onClearAll={handleClearAll}
+              className="h-full"
+            />
+          ) : viewType === 'kanban' ? (
+            <FolderBoardView
+              notes={notes}
+              searchQuery={debouncedSearchQuery}
+              tagColorMap={tagColorMap}
+              availableProperties={availableProperties}
+              onNoteOpen={handleNoteOpen}
+              onTagClick={handleTagClick}
+              onCreateNote={() => void handleCreateNote()}
+              onClearAll={handleClearAll}
+              className="h-full"
+            />
+          ) : viewType === 'grid' ? (
+            <FolderGalleryView
+              notes={notes}
+              searchQuery={debouncedSearchQuery}
+              tagColorMap={tagColorMap}
+              onNoteOpen={handleNoteOpen}
+              onTagClick={handleTagClick}
+              onCreateNote={() => void handleCreateNote()}
+              onClearAll={handleClearAll}
+              className="h-full"
+            />
           ) : activeView?.groupBy ? (
             // Grouped table view when groupBy is set (Phase 24)
             <GroupedTable


### PR DESCRIPTION
## Summary

Redesigns the folder view to a Linear-vibe look and adds three view modes (List/Board/Gallery) that were previously scaffolded but non-functional.

### New Features
- **List view** — compact single-line rows with inline tags and metadata
- **Board view** — kanban layout grouped by the folder's first select property (e.g., Status)
- **Gallery view** — card grid with theme-aware tinted emoji covers
- **Bulk action bar** — multi-item operations for selected notes
- **Column selector & sort selector** — UI controls for folder view customization
- **CSV export** — export notes data to CSV format
- **Flat-vault support** — scan entire vault root without notes/ prefix requirement

### Redesign Changes
- Table restyled with tiny-caps headers, tint-based selection highlight, and summary footer
- View switcher now functional 4-way toggle (was decorative placeholder)
- Shared note card pieces for consistency across view modes
- Tailwind direction classes converted to logical properties (border-s/e, ms/me, start/end)

## Verification Status
✅ In-branch tests pass (folder-view-handlers.test.ts, inbox tests)
⚠️ Pre-existing test failures noted (unrelated components)

## Version
- Bumped to v1.1.0 (MINOR for feature additions)
- Changelog updated with feature summary

## Commits (3 total)
- d699ede6 chore: bump version to 1.1.0 and add changelog for folder view redesign
- 8fd20c84 feat(folder-view): enhance folder view handlers for flat-vault layout support
- d88c2c62 feat(folder-view): Linear-vibe redesign — List/Board/Gallery views + restyled table

## Next Steps (Out of Scope)
- Runtime QA: launch app and verify all view modes render correctly
- Popover styling refinements (filter builder, group-by, column selector, row context menu)
- Board virtualization and drag-to-reorder
- Docs updates