### PR TITLE
fix(agent): set Ollama context window via native /api to stop one-word replies (#591)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -137,6 +137,7 @@
     "metascraper-url": "^5.49.15",
     "mime-types": "^3.0.2",
     "nanoid": "^5.1.6",
+    "ollama-ai-provider-v2": "^3.6.0",
     "openai": "^6.15.0",
     "pako": "^2.1.0",
     "react": "^19.2.3",

--- a/apps/desktop/src/main/agent/backends/__tests__/local-openai-compatible-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/local-openai-compatible-backend.test.ts
@@ -4,12 +4,17 @@ const mocks = vi.hoisted(() => ({
   createOpenAI: vi.fn(() => ({
     chat: vi.fn((model: string) => ({ provider: 'openai-compatible', model }))
   })),
+  createOllama: vi.fn(() => vi.fn((model: string) => ({ provider: 'ollama', model }))),
   streamText: vi.fn(),
   stepCountIs: vi.fn((count: number) => ({ type: 'step-count', count }))
 }))
 
 vi.mock('@ai-sdk/openai', () => ({
   createOpenAI: mocks.createOpenAI
+}))
+
+vi.mock('ollama-ai-provider-v2', () => ({
+  createOllama: mocks.createOllama
 }))
 
 vi.mock('ai', () => ({
@@ -85,10 +90,9 @@ describe('LocalOpenAICompatibleBackend', () => {
     const events = []
     for await (const event of run.events) events.push(event)
 
-    expect(mocks.createOpenAI).toHaveBeenCalledWith({
-      baseURL: 'http://localhost:11434/v1',
-      apiKey: 'local'
-    })
+    expect(mocks.createOllama).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: 'http://localhost:11434/api' })
+    )
     expect(mocks.stepCountIs).toHaveBeenCalledWith(8)
     expect(mocks.streamText).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -392,6 +396,73 @@ describe('LocalOpenAICompatibleBackend', () => {
         tools: expect.anything()
       })
     )
+  })
+
+  it('ollama preset uses the native /api endpoint with num_ctx 8192', async () => {
+    mocks.streamText.mockReturnValueOnce({
+      fullStream: (async function* () {
+        yield { type: 'text-delta', text: 'ok' }
+      })()
+    })
+
+    const backend = new LocalOpenAICompatibleBackend({
+      getSettings: async () => ({
+        preset: 'ollama',
+        baseUrl: 'http://localhost:11434/v1',
+        model: 'gemma4',
+        apiKeyConfigured: false,
+        allowNonLoopback: false
+      }),
+      getApiKey: async () => null,
+      toolBridge: { execute: vi.fn() } as never,
+      fetch: createProbeFetch()
+    })
+
+    await backend.runTurn({
+      prompt: 'hi',
+      conversationId: 'c1',
+      windowId: 'window-1',
+      options: { backend: 'local_openai_compatible' }
+    })
+
+    expect(mocks.createOllama).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: 'http://localhost:11434/api' })
+    )
+    expect(mocks.createOpenAI).not.toHaveBeenCalled()
+    const streamArgs = mocks.streamText.mock.calls[0][0]
+    expect(streamArgs.providerOptions).toEqual({ ollama: { options: { num_ctx: 8192 } } })
+  })
+
+  it('non-ollama preset stays on the /v1 openai-compat path without num_ctx', async () => {
+    mocks.streamText.mockReturnValueOnce({
+      fullStream: (async function* () {
+        yield { type: 'text-delta', text: 'ok' }
+      })()
+    })
+
+    const backend = new LocalOpenAICompatibleBackend({
+      getSettings: async () => ({
+        preset: 'lm_studio',
+        baseUrl: 'http://localhost:1234/v1',
+        model: 'qwen2.5',
+        apiKeyConfigured: false,
+        allowNonLoopback: false
+      }),
+      getApiKey: async () => null,
+      toolBridge: { execute: vi.fn() } as never,
+      fetch: createProbeFetch()
+    })
+
+    await backend.runTurn({
+      prompt: 'hi',
+      conversationId: 'c1',
+      windowId: 'window-1',
+      options: { backend: 'local_openai_compatible' }
+    })
+
+    expect(mocks.createOpenAI).toHaveBeenCalled()
+    expect(mocks.createOllama).not.toHaveBeenCalled()
+    expect(mocks.streamText.mock.calls[0][0].providerOptions).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts
+++ b/apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts
@@ -1,4 +1,5 @@
 import { createOpenAI } from '@ai-sdk/openai'
+import { createOllama } from 'ollama-ai-provider-v2'
 import {
   type AgentBackendStatus,
   type AgentLocalProviderProbeResult,
@@ -11,6 +12,18 @@ import { AgentToolBridge, createAiSdkToolSet } from './tool-bridge'
 import type { AgentBackend, AgentBackendRunInput, BackendRunHandle } from './types'
 
 let nextLocalRunPid = -1
+
+// ponytail: fixed 8192-token window fixes #591. Ollama's default context is 4096
+// and OLLAMA_NUM_PARALLEL divides it across slots, so Memry's system prompt + tool
+// schemas overflow and the reply is cut to one token. Promote to a user setting only
+// if someone needs to tune it.
+const OLLAMA_NUM_CTX = 8192
+
+// Ollama's native API (the only endpoint that accepts num_ctx) lives at /api, while
+// the stored ollama preset baseUrl points at the /v1 OpenAI-compat path.
+function toOllamaApiBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/v1\/?$/, '') + '/api'
+}
 
 export class LocalOpenAICompatibleBackend implements AgentBackend {
   readonly id = 'local_openai_compatible' as const
@@ -63,10 +76,16 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
     const apiKey = await this.deps.getApiKey()
     const options = input.options.backend === this.id ? input.options : null
     const modelName = options?.model || settings.model
-    const model = createOpenAI({
-      baseURL: settings.baseUrl,
-      apiKey: apiKey || 'local'
-    }).chat(modelName)
+    const isOllama = settings.preset === 'ollama'
+    const model = isOllama
+      ? createOllama({
+          baseURL: toOllamaApiBaseUrl(settings.baseUrl),
+          ...(apiKey ? { headers: { Authorization: `Bearer ${apiKey}` } } : {})
+        })(modelName)
+      : createOpenAI({
+          baseURL: settings.baseUrl,
+          apiKey: apiKey || 'local'
+        }).chat(modelName)
     const controller = new AbortController()
     const toolsEnabled =
       allowTools &&
@@ -77,6 +96,9 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
       prompt: input.prompt,
       abortSignal: controller.signal,
       stopWhen: stepCountIs(8),
+      ...(isOllama
+        ? { providerOptions: { ollama: { options: { num_ctx: OLLAMA_NUM_CTX } } } }
+        : {}),
       ...(toolsEnabled
         ? {
             tools: createAiSdkToolSet(this.deps.toolBridge, {

--- a/apps/docs/src/user-guide/ai/provider-setup.md
+++ b/apps/docs/src/user-guide/ai/provider-setup.md
@@ -29,7 +29,7 @@ Best when you want privacy, no metering, and don't mind running an extra backgro
 
 ### Notes
 
-- Ollama exposes an OpenAI-compatible API at `/v1`, which memrynote uses.
+- memrynote talks to Ollama's native `/api/chat` endpoint and automatically sets `num_ctx: 8192` per request. You do not need to set `OLLAMA_CONTEXT_LENGTH` or `OLLAMA_NUM_PARALLEL` — the context window is managed for you.
 - No API key required for default local Ollama.
 - Token costs: zero, but RAM usage scales with model size.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
+      ollama-ai-provider-v2:
+        specifier: ^3.6.0
+        version: 3.6.0(ai@6.0.206(zod@4.3.6))(zod@4.3.6)
       openai:
         specifier: ^6.15.0
         version: 6.18.0(ws@8.20.1)(zod@4.3.6)
@@ -9863,6 +9866,13 @@ packages:
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  ollama-ai-provider-v2@3.6.0:
+    resolution: {integrity: sha512-1Om3FVJYhBwkAr5kQ+BX1s/tdVdtVdoFQWrX4PBQHDHPISyGt24CjhtggEjUYpy5ait0YeVfZwEpIYjgD8Ih7Q==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      ai: ^5.0.0 || ^6.0.0
+      zod: ^4.0.16
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -22258,6 +22268,13 @@ snapshots:
       ufo: 1.6.4
 
   ohash@2.0.11: {}
+
+  ollama-ai-provider-v2@3.6.0(ai@6.0.206(zod@4.3.6))(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.29(zod@4.3.6)
+      ai: 6.0.206(zod@4.3.6)
+      zod: 4.3.6
 
   on-exit-leak-free@2.1.2: {}
 


### PR DESCRIPTION
Closes #591.

## Problem
With the local provider set to Ollama, Agent Chat returned a single word for every reply, while `ollama run` answered fully.

## Root cause
Ollama's context window is one shared budget (input + output). Its default is 4096 tokens and `OLLAMA_NUM_PARALLEL` (auto, often 4) divides that across slots, leaving ~1024 effective tokens per request. Memry's large agent system prompt + tool schemas nearly fill that window, so the model emits one token and stops. `ollama run`'s tiny prompt never overflows, which is why it was irreproducible on lower-parallel machines.

Memry talked to Ollama over the OpenAI-compatible `/v1/chat/completions` endpoint, which cannot carry `num_ctx` (confirmed in Ollama's source: the request struct omits `num_ctx`/`keep_alive`/`extra_body`). So Memry never controlled the window.

## Fix
When the local provider preset is `ollama`, route the turn through Ollama's native `/api/chat` (via `ollama-ai-provider-v2`) and request `num_ctx: 8192`. The explicit value overrides the host's auto parallel-division, so replies are full on every machine with no user-side Ollama env vars. All other presets (LM Studio, llama.cpp, custom) keep the existing `/v1` path unchanged.

`num_ctx` is fixed at 8192 (no new setting) — enough for the agent prompt plus a full answer, conservative on memory.

## Testing
- New unit tests: ollama preset uses native `/api` with `num_ctx: 8192`; non-ollama preset stays on `/v1` with no `num_ctx`. Target test file 10/10.
- `typecheck:node` clean, ESLint clean, `docs:build` passes, docs gate covered.
- Pending: live Electron + Ollama QA (force the small window with `OLLAMA_NUM_PARALLEL=4 OLLAMA_CONTEXT_LENGTH=2048 ollama serve`, confirm full replies).

## Follow-up (non-blocking)
`toOllamaApiBaseUrl` strips a trailing `/v1` and appends `/api`; correct for the hardcoded preset default and bare host, but a hand-edited non-standard base URL (e.g. `.../api/v1`) would be mangled. Harden if custom Ollama base URLs become common.
