### PR TITLE
refactor: dedupe stdlib helpers (debounce, sleep, recursive walk)

### DIFF
--- a/apps/desktop/src/main/sync/retry.ts
+++ b/apps/desktop/src/main/sync/retry.ts
@@ -41,7 +41,7 @@ const DEFAULTS: RetryOptions = {
 const ONLINE_POLL_MS = 2000
 const MAX_OFFLINE_WAIT_MS = 5 * 60 * 1000
 
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
       reject(new DOMException('The operation was aborted.', 'AbortError'))

--- a/apps/desktop/src/main/sync/upload-queue.ts
+++ b/apps/desktop/src/main/sync/upload-queue.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '../lib/logger'
 import { NetworkError, RateLimitError } from './http-client'
+import { sleep } from './retry'
 import type { NetworkMonitor } from './network'
 import type { ProgressCallback, UploadResult } from './attachments'
 
@@ -87,7 +88,7 @@ export class UploadQueue {
         if (this.backoffUntil > now) {
           const waitMs = this.backoffUntil - now
           log.info('global backoff active', { waitMs })
-          await delay(waitMs)
+          await sleep(waitMs)
           continue
         }
 
@@ -128,8 +129,4 @@ export class UploadQueue {
       item.reject(err instanceof Error ? err : new Error(String(err)))
     }
   }
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/apps/desktop/src/renderer/src/components/inbox-detail/link-input.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/link-input.tsx
@@ -13,23 +13,7 @@ import { cn } from '@/lib/utils'
 import { NoteIconDisplay } from '@/lib/render-note-icon'
 import type { LinkedNote } from '@/types'
 
-// =============================================================================
-// Debounce Hook
-// =============================================================================
-
-function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value)
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value)
-    }, delay)
-
-    return () => clearTimeout(handler)
-  }, [value, delay])
-
-  return debouncedValue
-}
+import { useDebouncedValue } from '@/hooks/use-task-filters'
 
 // =============================================================================
 // LinkedNoteCard Component
@@ -150,7 +134,7 @@ export const LinkInput = ({
   const containerRef = useRef<HTMLDivElement>(null)
 
   // Debounced search query
-  const debouncedQuery = useDebounce(searchQuery, 200)
+  const debouncedQuery = useDebouncedValue(searchQuery, 200)
 
   // Fetch notes for search (by title only)
   const { data: searchResults = [], isLoading: isSearching } = useQuery({

--- a/apps/desktop/src/renderer/src/pages/folder-view.tsx
+++ b/apps/desktop/src/renderer/src/pages/folder-view.tsx
@@ -5,32 +5,10 @@
  * Supports multiple views, filtering, and sorting.
  */
 
-import { useMemo, useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
+import { useMemo, useState, useLayoutEffect, useCallback, useRef } from 'react'
 import { ArrowLeft, Columns3, Folder, LayoutGrid, List, Plus, Rows2, Settings2 } from '@/lib/icons'
 
-// ============================================================================
-// Debounce Hook
-// ============================================================================
-
-/**
- * Hook to debounce a value by a specified delay.
- * Used for search input to avoid excessive filtering while typing.
- */
-function useDebouncedValue<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value)
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedValue(value)
-    }, delay)
-
-    return () => {
-      clearTimeout(timer)
-    }
-  }, [value, delay])
-
-  return debouncedValue
-}
+import { useDebouncedValue } from '@/hooks/use-task-filters'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { FolderViewEmptyState } from '@/components/folder-view/folder-view-empty-state'

--- a/scripts/check-architecture-boundaries.js
+++ b/scripts/check-architecture-boundaries.js
@@ -68,18 +68,10 @@ function normalizeRepoPath(filePath) {
 }
 
 async function walk(dir) {
-  const entries = await fs.readdir(dir, { withFileTypes: true })
-  const files = await Promise.all(
-    entries.map(async (entry) => {
-      const entryPath = path.join(dir, entry.name)
-      if (entry.isDirectory()) {
-        return walk(entryPath)
-      }
-      return [entryPath]
-    })
-  )
-
-  return files.flat()
+  const entries = await fs.readdir(dir, { recursive: true, withFileTypes: true })
+  return entries
+    .filter((entry) => !entry.isDirectory())
+    .map((entry) => path.join(entry.parentPath, entry.name))
 }
 
 function isSourceFile(filePath) {

--- a/scripts/check-contract-boundaries.js
+++ b/scripts/check-contract-boundaries.js
@@ -20,18 +20,10 @@ const appRoots = [
 ]
 
 async function walk(dir) {
-  const entries = await fs.readdir(dir, { withFileTypes: true })
-  const files = await Promise.all(
-    entries.map(async (entry) => {
-      const entryPath = path.join(dir, entry.name)
-      if (entry.isDirectory()) {
-        return walk(entryPath)
-      }
-      return [entryPath]
-    })
-  )
-
-  return files.flat()
+  const entries = await fs.readdir(dir, { recursive: true, withFileTypes: true })
+  return entries
+    .filter((entry) => !entry.isDirectory())
+    .map((entry) => path.join(entry.parentPath, entry.name))
 }
 
 function isSourceFile(filePath) {


### PR DESCRIPTION
Tier 2 of the over-engineering audit — high-confidence stdlib/dedup swaps. Pure refactor, no behavior change.

## What changed
- **`useDebouncedValue` (3 → 1)** — dropped the two verbatim copies (`pages/folder-view.tsx`, `components/inbox-detail/link-input.tsx`, the latter named `useDebounce`) and imported the shared hook from `hooks/use-task-filters`.
- **`sleep` (2 → 1)** — exported the existing signal-aware `sleep` from `sync/retry.ts` and removed `upload-queue.ts`'s duplicate `delay()`. Behavior identical (`sleep(ms)` with no signal == the old `delay(ms)`).
- **`walk()` (2 → stdlib)** — replaced the hand-rolled recursive `readdir` + `Promise.all` in both boundary checkers with `fs.readdir(dir, { recursive: true, withFileTypes: true })`.

Net: **6 files, +15 / −72**.

## Verified green
- `pnpm --filter @memry/desktop typecheck` — exit 0
- `eslint` on all changed files — clean
- retry + upload-queue tests — 24/24
- link-input + folder-view + use-task-filters tests — 40/40
- `check:architecture` + `check:contracts` — pass (also re-run via typecheck pretask)

## Audit claims found WRONG / out of scope
- **`walk` was 2 copies, not 3** — `repair-package-links.js` uses a single-level `readdir`, not a recursive walk.
- **`sleep` "3×" was really 1** after OneNote's removal (Tier 1) — upload-queue's `delay` + retry's private `sleep`. The remaining inline `new Promise(r => setTimeout(r, ms))` one-liners are already the lazy form; hoisting a shared helper into each would add imports for no LOC win, so left alone.
- **CSV parsers (D) — skipped.** The three tokenizers are *not* near-identical: different CR handling (`csv-import` is CRLF-aware + handles lone-CR; the others just skip `\r`), different BOM placement, and different return shapes/exported names. Sharing them needs a new cross-package dependency edge between three currently-standalone packages — which Tier 3's importer-package merge would restructure anyway.
- **`utcNow()` — skipped.** ~20 importers, and it's mocked in 2 test files for deterministic timestamps. Inlining `new Date().toISOString()` would destroy that test clock-seam; it's justified indirection, not bloat.
- **`parseArgs` — skipped.** 11 hand-rolled arg loops across CI scripts, each with different positional/flag shapes; migrating is high-churn behavior-matching with real CI-break risk for no user value.
- **Keyboard hooks — skipped.** `use-keyboard-shortcuts-base` can't express the capture phase the search/command-palette shortcut needs, and modifier semantics diverge (save-filter fires on meta-OR-ctrl; the base hook is platform-exclusive). Routing global shortcuts through it risks user-visible regressions plus test rewrites for ~30 LOC.