### PR TITLE
feat(agent-mcp): expose Tier-1 app features via desktop allowlist

### DIFF
--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -166,8 +166,8 @@ export interface MainIpcInvokeHandlers {
   "notes:delete-version": (...args: [string]) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; }>>
   "notes:ensure-property-definition": (...args: [{ name: string; type: "status" | "select" | "multiselect"; }]) => Awaited<Promise<{ success: boolean; }>>
   "notes:exists": (...args: [string]) => Awaited<Promise<boolean>>
-  "notes:export-html": (...args: [{ noteId: string; includeMetadata?: boolean | undefined; pageSize?: "A4" | "Letter" | "Legal" | undefined; }]) => Awaited<Promise<{ success: false; error: string; path?: undefined; } | { success: true; path: string; error?: undefined; }> | { success: false; error: string }>
-  "notes:export-pdf": (...args: [{ noteId: string; includeMetadata?: boolean | undefined; pageSize?: "A4" | "Letter" | "Legal" | undefined; }]) => Awaited<Promise<{ success: false; error: string; path?: undefined; } | { success: true; path: string; error?: undefined; }> | { success: false; error: string }>
+  "notes:export-html": (...args: [{ noteId: string; includeMetadata?: boolean | undefined; pageSize?: "A4" | "Letter" | "Legal" | undefined; outputPath?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; path?: undefined; } | { success: true; path: string; error?: undefined; }> | { success: false; error: string }>
+  "notes:export-pdf": (...args: [{ noteId: string; includeMetadata?: boolean | undefined; pageSize?: "A4" | "Letter" | "Legal" | undefined; outputPath?: string | undefined; }]) => Awaited<Promise<{ success: false; error: string; path?: undefined; } | { success: true; path: string; error?: undefined; }> | { success: false; error: string }>
   "notes:get": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").Note | null>>
   "notes:get-all-positions": (...args: []) => Awaited<Promise<{ success: false; error: string; } | { success: boolean; positions: Record<string, number>; }>>
   "notes:get-by-path": (...args: [string]) => Awaited<Promise<import("../vault/notes-crud").Note | null>>

--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -164,7 +164,9 @@ const UpdatePropertyDefinitionSchema = z.object({
 const ExportNoteSchema = z.object({
   noteId: z.string().min(1),
   includeMetadata: z.boolean().default(true),
-  pageSize: z.enum(['A4', 'Letter', 'Legal']).default('A4')
+  pageSize: z.enum(['A4', 'Letter', 'Legal']).default('A4'),
+  // Headless export target — when provided, skip the save dialog (Agent MCP).
+  outputPath: z.string().min(1).optional()
 })
 
 /**
@@ -757,15 +759,19 @@ export function registerNotesHandlers(): void {
         return { success: false as const, error: t('error.noteNotFound') }
       }
 
-      const defaultFilename = `${sanitizeFilename(note.title)}.pdf`
-      const result = await dialog.showSaveDialog({
-        title: t('dialog.exportPdf.title'),
-        defaultPath: defaultFilename,
-        filters: [{ name: t('dialog.exportPdf.filterName'), extensions: ['pdf'] }]
-      })
+      let targetPath = input.outputPath
+      if (!targetPath) {
+        const defaultFilename = `${sanitizeFilename(note.title)}.pdf`
+        const result = await dialog.showSaveDialog({
+          title: t('dialog.exportPdf.title'),
+          defaultPath: defaultFilename,
+          filters: [{ name: t('dialog.exportPdf.filterName'), extensions: ['pdf'] }]
+        })
 
-      if (result.canceled || !result.filePath) {
-        return { success: false as const, error: t('dialog.exportCancelled') }
+        if (result.canceled || !result.filePath) {
+          return { success: false as const, error: t('dialog.exportCancelled') }
+        }
+        targetPath = result.filePath
       }
 
       const html = renderNoteAsHtml(
@@ -811,9 +817,9 @@ export function registerNotesHandlers(): void {
       })
 
       win.destroy()
-      await fs.writeFile(result.filePath, pdfData)
+      await fs.writeFile(targetPath, pdfData)
 
-      return { success: true as const, path: result.filePath }
+      return { success: true as const, path: targetPath }
     },
     'Failed to export PDF'
   )
@@ -832,15 +838,19 @@ export function registerNotesHandlers(): void {
         return { success: false as const, error: t('error.noteNotFound') }
       }
 
-      const defaultFilename = `${sanitizeFilename(note.title)}.html`
-      const result = await dialog.showSaveDialog({
-        title: t('dialog.exportHtml.title'),
-        defaultPath: defaultFilename,
-        filters: [{ name: t('dialog.exportHtml.filterName'), extensions: ['html', 'htm'] }]
-      })
+      let targetPath = input.outputPath
+      if (!targetPath) {
+        const defaultFilename = `${sanitizeFilename(note.title)}.html`
+        const result = await dialog.showSaveDialog({
+          title: t('dialog.exportHtml.title'),
+          defaultPath: defaultFilename,
+          filters: [{ name: t('dialog.exportHtml.filterName'), extensions: ['html', 'htm'] }]
+        })
 
-      if (result.canceled || !result.filePath) {
-        return { success: false as const, error: t('dialog.exportCancelled') }
+        if (result.canceled || !result.filePath) {
+          return { success: false as const, error: t('dialog.exportCancelled') }
+        }
+        targetPath = result.filePath
       }
 
       const html = renderNoteAsHtml(
@@ -856,9 +866,9 @@ export function registerNotesHandlers(): void {
         { includeMetadata: input.includeMetadata }
       )
 
-      await fs.writeFile(result.filePath, html, 'utf-8')
+      await fs.writeFile(targetPath, html, 'utf-8')
 
-      return { success: true as const, path: result.filePath }
+      return { success: true as const, path: targetPath }
     },
     'Failed to export HTML'
   )

--- a/packages/contracts/src/agent-mcp-channels.ts
+++ b/packages/contracts/src/agent-mcp-channels.ts
@@ -29,6 +29,7 @@ export const AgentMcpDesktopReadOperations = [
   'notes.getPositions',
   'notes.getAllPositions',
   'notes.getLocalOnlyCount',
+  'notes.getCalendarPropertyNames',
   'tasks.get',
   'tasks.list',
   'tasks.getSubtasks',
@@ -114,7 +115,13 @@ export const AgentMcpDesktopReadOperations = [
   'search.getReasons',
   'search.getAllTags',
   'graph.getData',
-  'graph.getLocal'
+  'graph.getLocal',
+  'homePages.list',
+  'homePages.get',
+  'vault.getAll',
+  'vault.getStatus',
+  'vault.getConfig',
+  'vault.listAccount'
 ] as const
 
 export const AgentMcpDesktopWriteOperations = [
@@ -143,6 +150,9 @@ export const AgentMcpDesktopWriteOperations = [
   'notes.reorder',
   'notes.importFiles',
   'notes.setLocalOnly',
+  'notes.setCalendarPropertyVisibility',
+  'notes.exportPdf',
+  'notes.exportHtml',
   'tasks.create',
   'tasks.update',
   'tasks.delete',
@@ -224,6 +234,7 @@ export const AgentMcpDesktopWriteOperations = [
   'tags.deleteTag',
   'tags.removeTagFromNote',
   'tags.mergeTag',
+  'tags.updateTagIcon',
   'folderView.setConfig',
   'folderView.setView',
   'folderView.deleteView',
@@ -257,7 +268,15 @@ export const AgentMcpDesktopWriteOperations = [
   'settings.setCalendarSettings',
   'search.rebuildIndex',
   'search.addReason',
-  'search.clearReasons'
+  'search.clearReasons',
+  'homePages.create',
+  'homePages.update',
+  'homePages.delete',
+  'homePages.reorder',
+  'vault.switch',
+  'vault.reindex',
+  'vault.updateConfig',
+  'vault.downloadRemote'
 ] as const
 
 export const AgentMcpDesktopOperations = [

--- a/packages/rpc/src/notes.ts
+++ b/packages/rpc/src/notes.ts
@@ -171,6 +171,9 @@ export interface ExportNoteInput {
   noteId: string
   includeMetadata?: boolean
   pageSize?: 'A4' | 'Letter' | 'Legal'
+  // When set, write directly to this path and skip the native save dialog
+  // (enables headless export, e.g. from the Agent MCP server).
+  outputPath?: string
 }
 
 export interface ExportNoteResponse {


### PR DESCRIPTION
## What

Exposes five existing app capabilities to the Agent MCP server. They were already implemented on `window.api` but unreachable by agents because the `vault_desktop_read` / `vault_desktop_write` pass-through is gated by the allowlist arrays in `packages/contracts/src/agent-mcp-channels.ts`. Adding the operation strings both permits the call and advertises it to the agent (the tool input schema is `z.enum(...allowlist)`), so no new dedicated tools are needed.

**19 operations added across 5 features:**

| Feature | Read | Write |
|---|---|---|
| Note-date on calendar | `notes.getCalendarPropertyNames` | `notes.setCalendarPropertyVisibility` |
| Note export | — | `notes.exportPdf`, `notes.exportHtml` |
| Tag icon | — | `tags.updateTagIcon` |
| Home pages / widgets | `homePages.list`, `homePages.get` | `homePages.create`, `homePages.update`, `homePages.delete`, `homePages.reorder` |
| Multi-vault | `vault.getAll`, `vault.getStatus`, `vault.getConfig`, `vault.listAccount` | `vault.switch`, `vault.reindex`, `vault.updateConfig`, `vault.downloadRemote` |

## Why the one code change (headless export)

`notes.exportPdf` / `exportHtml` popped a native `showSaveDialog` — unusable for a headless agent and liable to exceed the pass-through's 10s timeout. Added an optional `outputPath` to `ExportNoteInput`; when provided, export skips the dialog and writes directly. UI callers pass nothing, so existing behavior is unchanged.

## Scope / deferred

- **Importers** (`import.*`) deferred by request.
- **Tier 2** deferred: `calendar.refreshProvider`/`retryGoogleCalendarSourceSync`, settings AI/voice model actions, `locale.*`, read-only sync/account status.
- **Never exposing**: UI-only ops, secret writers, terminal-command install, OAuth connect/disconnect, crypto/sync internals.

## Verification

- `pnpm ipc:check` — invoke map up to date
- `pnpm --filter @memry/desktop typecheck:node` / `typecheck:web` — clean
- 62 tests (notes-handlers export, MCP schemas, desktop-api pass-through) — pass
- eslint on changed files — clean