### PR TITLE
feat(calendar): drag-and-drop event reschedule + resize

### DIFF
--- a/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
@@ -5,8 +5,10 @@ import { isToday, toLocalDateKey } from './date-utils'
 import { assignLanes } from './overlap-layout'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { formatHour } from '@/lib/time-format'
+import { cn } from '@/lib/utils'
 import type { CalendarProjectionItem } from '@/services/calendar-service'
 import { useTimeGridMarquee } from './use-time-grid-marquee'
+import { useEventDrag, isEventMovable, isEventResizable } from './use-event-drag'
 import { MarqueeSelectionOverlay } from './marquee-selection-overlay'
 import { CalendarQuickCreateDialog } from './calendar-quick-create-dialog'
 import { useScrollToCurrentTime } from './use-scroll-to-current-time'
@@ -31,6 +33,11 @@ interface CalendarDayViewProps {
   selectedItemId: string | null
   onSelectItem?: (item: CalendarProjectionItem, rect: AnchorRect) => void
   onDeleteItem?: (item: CalendarProjectionItem) => void
+  onMoveEvent?: (
+    item: CalendarProjectionItem,
+    startAt: string,
+    endAt: string
+  ) => void | Promise<void>
   onQuickSave?: (draft: CalendarEventDraft) => void | Promise<void>
 }
 
@@ -40,6 +47,7 @@ export function CalendarDayView({
   selectedItemId,
   onSelectItem,
   onDeleteItem,
+  onMoveEvent,
   onQuickSave
 }: CalendarDayViewProps): React.JSX.Element {
   const {
@@ -53,6 +61,18 @@ export function CalendarDayView({
     gridRef,
     dateForColumn
   })
+  const { drag, startMove, startResize, wasDragged } = useEventDrag({
+    gridRef,
+    dateForColumn,
+    onCommit: (item, startAt, endAt) => onMoveEvent?.(item, startAt, endAt)
+  })
+  const handleChipClick = useCallback(
+    (item: CalendarProjectionItem, rect: AnchorRect) => {
+      if (wasDragged()) return
+      onSelectItem?.(item, rect)
+    },
+    [onSelectItem, wasDragged]
+  )
   const today = isToday(anchorDate)
   useScrollToCurrentTime(scrollRef, today)
   const dayItems = items.filter((item) => toLocalDateKey(item.startAt) === anchorDate)
@@ -120,27 +140,61 @@ export function CalendarDayView({
               const pos = getEventPosition(item)
               const widthPct = 100 / laneCount
               const leftPct = lane * widthPct
+              const movable = isEventMovable(item)
+              const resizable = isEventResizable(item)
+              const isDraggingThis = drag?.projectionId === item.projectionId
               return (
                 <div
                   key={item.projectionId}
-                  className="absolute z-10 px-0.5 @xl:px-1"
+                  className={cn(
+                    'absolute z-10 px-0.5 @xl:px-1',
+                    movable && 'cursor-grab',
+                    isDraggingThis && 'opacity-40'
+                  )}
                   style={{
                     top: pos.top,
                     height: pos.height,
                     left: `${leftPct}%`,
                     width: `${widthPct}%`
                   }}
+                  onMouseDown={movable ? (e) => startMove(e, item, 0) : undefined}
                 >
                   <CalendarItemChip
                     item={item}
                     clockFormat={clockFormat}
                     isSelected={item.sourceType === 'event' && item.sourceId === selectedItemId}
-                    onClick={onSelectItem}
+                    onClick={handleChipClick}
                     onDeleteItem={onDeleteItem}
                   />
+                  {resizable && (
+                    <>
+                      <div
+                        className="absolute inset-x-0 top-0 h-1.5 cursor-ns-resize"
+                        onMouseDown={(e) => startResize(e, item, 0, 'start')}
+                      />
+                      <div
+                        className="absolute inset-x-0 bottom-0 h-1.5 cursor-ns-resize"
+                        onMouseDown={(e) => startResize(e, item, 0, 'end')}
+                      />
+                    </>
+                  )}
                 </div>
               )
             })}
+
+            {drag &&
+              (() => {
+                const draggedItem = items.find((it) => it.projectionId === drag.projectionId)
+                if (!draggedItem) return null
+                return (
+                  <div
+                    className="pointer-events-none absolute inset-x-0 z-30 px-0.5 @xl:px-1"
+                    style={{ top: drag.top, height: drag.height }}
+                  >
+                    <CalendarItemChip item={draggedItem} clockFormat={clockFormat} isSelected />
+                  </div>
+                )
+              })()}
 
             {today && (
               <div

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
@@ -69,6 +69,11 @@ interface CalendarShellProps {
   onToggleVisualType: (visualType: CalendarProjectionVisualType) => void
   onSelectItem: (item: CalendarProjectionItem, rect: AnchorRect) => void
   onDeleteItem?: (item: CalendarProjectionItem) => void
+  onMoveEvent?: (
+    item: CalendarProjectionItem,
+    startAt: string,
+    endAt: string
+  ) => void | Promise<void>
   onPopoverDismiss: () => void
   onPopoverDraftChange: (draft: CalendarEventDraft) => void
   onPopoverSave: () => void
@@ -110,6 +115,7 @@ export function CalendarShell({
   onToggleVisualType,
   onSelectItem,
   onDeleteItem,
+  onMoveEvent,
   onPopoverDismiss,
   onPopoverDraftChange,
   onPopoverSave,
@@ -272,10 +278,11 @@ export function CalendarShell({
             {t('state.loading-calendar')}
           </div>
         ) : view === 'day' ? (
-          <CalendarDayView {...chipViewProps} onQuickSave={onQuickSave} />
+          <CalendarDayView {...chipViewProps} onMoveEvent={onMoveEvent} onQuickSave={onQuickSave} />
         ) : view === 'week' ? (
           <CalendarWeekView
             {...chipViewProps}
+            onMoveEvent={onMoveEvent}
             todayRequestKey={todayRequestKey}
             onQuickSave={onQuickSave}
             onVisibleDayStartChange={(_, startDate) => onWeekVisibleRangeChange?.(startDate)}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
@@ -12,6 +12,7 @@ import { MarqueeSelectionOverlay } from './marquee-selection-overlay'
 import { CalendarQuickCreateDialog } from './calendar-quick-create-dialog'
 import { assignLanes } from './overlap-layout'
 import { useTimeGridMarquee } from './use-time-grid-marquee'
+import { useEventDrag, isEventMovable, isEventResizable } from './use-event-drag'
 import { useScrollToCurrentTime } from './use-scroll-to-current-time'
 import { useWeekInfiniteScroll } from './use-week-infinite-scroll'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
@@ -53,6 +54,11 @@ interface CalendarWeekViewProps {
   selectedItemId: string | null
   onSelectItem?: (item: CalendarProjectionItem, rect: AnchorRect) => void
   onDeleteItem?: (item: CalendarProjectionItem) => void
+  onMoveEvent?: (
+    item: CalendarProjectionItem,
+    startAt: string,
+    endAt: string
+  ) => void | Promise<void>
   onQuickSave?: (draft: CalendarEventDraft) => void | Promise<void>
   onVisibleDayStartChange?: (dayIndex: number, startDate: string) => void
   todayRequestKey?: number
@@ -64,6 +70,7 @@ export function CalendarWeekView({
   selectedItemId,
   onSelectItem,
   onDeleteItem,
+  onMoveEvent,
   onQuickSave,
   onVisibleDayStartChange,
   todayRequestKey
@@ -152,6 +159,34 @@ export function CalendarWeekView({
     columnCount: virtualizer.options.count,
     getColumnElement
   })
+
+  const columnIndexAtClientX = useCallback(
+    (clientX: number): number | null => {
+      const grid = gridRef.current
+      if (!grid) return null
+      const x = clientX - grid.getBoundingClientRect().left
+      for (const vi of virtualizer.getVirtualItems()) {
+        if (x >= vi.start && x < vi.start + vi.size) return vi.index
+      }
+      return null
+    },
+    [virtualizer]
+  )
+
+  const { drag, startMove, startResize, wasDragged } = useEventDrag({
+    gridRef,
+    dateForColumn,
+    columnIndexAtClientX,
+    onCommit: (item, startAt, endAt) => onMoveEvent?.(item, startAt, endAt)
+  })
+
+  const handleChipClick = useCallback(
+    (item: CalendarProjectionItem, rect: AnchorRect) => {
+      if (wasDragged()) return
+      onSelectItem?.(item, rect)
+    },
+    [onSelectItem, wasDragged]
+  )
 
   const weekContainsToday = useMemo(() => {
     for (let i = 0; i < 7; i++) {
@@ -360,16 +395,24 @@ export function CalendarWeekView({
                     const pos = getEventPosition(item)
                     const widthPct = 100 / laneCount
                     const leftPct = lane * widthPct
+                    const movable = isEventMovable(item)
+                    const resizable = isEventResizable(item)
+                    const isDraggingThis = drag?.projectionId === item.projectionId
                     return (
                       <div
                         key={item.projectionId}
-                        className="absolute z-10 px-0.5"
+                        className={cn(
+                          'absolute z-10 px-0.5',
+                          movable && 'cursor-grab',
+                          isDraggingThis && 'opacity-40'
+                        )}
                         style={{
                           top: pos.top,
                           height: pos.height,
                           left: `${leftPct}%`,
                           width: `${widthPct}%`
                         }}
+                        onMouseDown={movable ? (e) => startMove(e, item, vi.index) : undefined}
                       >
                         <CalendarItemChip
                           item={item}
@@ -377,9 +420,21 @@ export function CalendarWeekView({
                           isSelected={
                             item.sourceType === 'event' && item.sourceId === selectedItemId
                           }
-                          onClick={onSelectItem}
+                          onClick={handleChipClick}
                           onDeleteItem={onDeleteItem}
                         />
+                        {resizable && (
+                          <>
+                            <div
+                              className="absolute inset-x-0 top-0 h-1.5 cursor-ns-resize"
+                              onMouseDown={(e) => startResize(e, item, vi.index, 'start')}
+                            />
+                            <div
+                              className="absolute inset-x-0 bottom-0 h-1.5 cursor-ns-resize"
+                              onMouseDown={(e) => startResize(e, item, vi.index, 'end')}
+                            />
+                          </>
+                        )}
                       </div>
                     )
                   })}
@@ -429,6 +484,26 @@ export function CalendarWeekView({
                 </div>
               )
             })}
+
+            {drag &&
+              (() => {
+                const targetColumn = virtualItems.find((v) => v.index === drag.columnIndex)
+                const draggedItem = items.find((it) => it.projectionId === drag.projectionId)
+                if (!targetColumn || !draggedItem) return null
+                return (
+                  <div
+                    className="pointer-events-none absolute z-30 px-0.5"
+                    style={{
+                      left: targetColumn.start,
+                      width: targetColumn.size,
+                      top: drag.top,
+                      height: drag.height
+                    }}
+                  >
+                    <CalendarItemChip item={draggedItem} clockFormat={clockFormat} isSelected />
+                  </div>
+                )
+              })()}
           </div>
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/components/calendar/use-event-drag.test.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-event-drag.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { RefObject } from 'react'
+import {
+  snapMinutes,
+  clampStartWithinDay,
+  isoFromDayMinutes,
+  computeMovedTimes,
+  computeResizedTimes,
+  isEventMovable,
+  isEventResizable,
+  useEventDrag,
+  MINUTES_IN_DAY
+} from './use-event-drag'
+import type { CalendarProjectionItem } from '@/services/calendar-service'
+
+const SNAP = 15
+
+function makeEvent(overrides: Partial<CalendarProjectionItem> = {}): CalendarProjectionItem {
+  return {
+    projectionId: 'event:e1',
+    sourceType: 'event',
+    sourceId: 'e1',
+    title: 'Standup',
+    descriptionPreview: null,
+    startAt: '2026-04-14T09:00:00.000Z',
+    endAt: '2026-04-14T10:00:00.000Z',
+    isAllDay: false,
+    timezone: 'UTC',
+    visualType: 'event',
+    editability: { canMove: true, canResize: true, canEditText: true, canDelete: true },
+    source: { provider: null, isMemryManaged: true, calendarSourceId: null } as never,
+    binding: null,
+    snoozeOffsetMinutes: null,
+    ...overrides
+  } as CalendarProjectionItem
+}
+
+function minutesLocal(iso: string): number {
+  const d = new Date(iso)
+  return d.getHours() * 60 + d.getMinutes()
+}
+
+describe('snapMinutes', () => {
+  it('rounds to nearest snap increment', () => {
+    expect(snapMinutes(0, SNAP)).toBe(0)
+    expect(snapMinutes(7, SNAP)).toBe(0)
+    expect(snapMinutes(8, SNAP)).toBe(15)
+    expect(snapMinutes(98, SNAP)).toBe(105)
+  })
+})
+
+describe('clampStartWithinDay', () => {
+  it('keeps the event inside the day', () => {
+    expect(clampStartWithinDay(-30, 60)).toBe(0)
+    expect(clampStartWithinDay(1400, 60)).toBe(MINUTES_IN_DAY - 60) // 1380
+    expect(clampStartWithinDay(600, 60)).toBe(600)
+  })
+})
+
+describe('isoFromDayMinutes', () => {
+  it('round-trips a local time of day', () => {
+    expect(minutesLocal(isoFromDayMinutes('2026-04-14', 540))).toBe(540) // 09:00
+  })
+
+  it('rolls a full day (1440) into next-day midnight', () => {
+    const iso = isoFromDayMinutes('2026-04-14', MINUTES_IN_DAY)
+    const d = new Date(iso)
+    expect(d.getHours()).toBe(0)
+    expect(d.getDate()).toBe(15)
+  })
+})
+
+describe('computeMovedTimes', () => {
+  it('shifts start by snapped delta, preserving duration', () => {
+    // start 540 (09:00), 60min duration, +35min drag → snaps to +30 → 570 (09:30)
+    const r = computeMovedTimes(540, 60, 35, SNAP, '2026-04-14')
+    expect(r.startMin).toBe(570)
+    expect(r.endMin).toBe(630)
+  })
+
+  it('clamps so the event cannot spill past midnight', () => {
+    const r = computeMovedTimes(1380, 60, 120, SNAP, '2026-04-14') // would be 25:00
+    expect(r.startMin).toBe(MINUTES_IN_DAY - 60)
+    expect(r.endMin).toBe(MINUTES_IN_DAY)
+  })
+
+  it('moves to the target date for cross-day drags', () => {
+    const r = computeMovedTimes(540, 60, 0, SNAP, '2026-04-16')
+    expect(new Date(r.startAt).getDate()).toBe(16)
+    expect(minutesLocal(r.startAt)).toBe(540)
+  })
+})
+
+describe('computeResizedTimes', () => {
+  it('moves the start edge but never within 15min of the end', () => {
+    const r = computeResizedTimes(540, 600, 90, 'start', SNAP, '2026-04-14') // pushed past end
+    expect(r.startMin).toBe(600 - SNAP)
+    expect(r.endMin).toBe(600)
+  })
+
+  it('moves the end edge but never within 15min of the start', () => {
+    const r = computeResizedTimes(540, 600, -120, 'end', SNAP, '2026-04-14') // pulled past start
+    expect(r.endMin).toBe(540 + SNAP)
+    expect(r.startMin).toBe(540)
+  })
+
+  it('extends the end edge by snapped delta', () => {
+    const r = computeResizedTimes(540, 600, 40, 'end', SNAP, '2026-04-14')
+    expect(r.endMin).toBe(645) // 600 + snapped(40)=45
+  })
+})
+
+describe('eligibility guards', () => {
+  it('only native timed events are movable/resizable', () => {
+    expect(isEventMovable(makeEvent())).toBe(true)
+    expect(isEventResizable(makeEvent())).toBe(true)
+    expect(isEventMovable(makeEvent({ isAllDay: true }))).toBe(false)
+    expect(isEventMovable(makeEvent({ sourceType: 'task', visualType: 'task' }))).toBe(false)
+    expect(
+      isEventResizable(
+        makeEvent({
+          editability: { canMove: true, canResize: false, canEditText: true, canDelete: true }
+        })
+      )
+    ).toBe(false)
+  })
+})
+
+function mockGridRef(): RefObject<HTMLDivElement | null> {
+  const el = {
+    getBoundingClientRect: () => ({ top: 0, left: 0, width: 700, height: 1152 }) as DOMRect
+  } as unknown as HTMLDivElement
+  return { current: el }
+}
+
+describe('useEventDrag', () => {
+  it('ignores non-event chips and never commits', () => {
+    const onCommit = vi.fn()
+    const { result } = renderHook(() =>
+      useEventDrag({ gridRef: mockGridRef(), dateForColumn: () => '2026-04-14', onCommit })
+    )
+    act(() => {
+      result.current.startMove(
+        {
+          button: 0,
+          clientX: 10,
+          clientY: 10,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn()
+        } as never,
+        makeEvent({ sourceType: 'task', visualType: 'task' }),
+        0
+      )
+    })
+    expect(result.current.drag).toBeNull()
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('commits new times after a move drag and suppresses the trailing click', async () => {
+    const onCommit = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() =>
+      useEventDrag({ gridRef: mockGridRef(), dateForColumn: () => '2026-04-14', onCommit })
+    )
+    act(() => {
+      result.current.startMove(
+        {
+          button: 0,
+          clientX: 100,
+          clientY: 100,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn()
+        } as never,
+        makeEvent(),
+        0
+      )
+    })
+    // Drag down 48px = +60min, past the 4px threshold.
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 148 }))
+    })
+    expect(result.current.drag).not.toBeNull()
+    await act(async () => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+    expect(onCommit).toHaveBeenCalledTimes(1)
+    expect(result.current.wasDragged()).toBe(true)
+    // read-and-clear
+    expect(result.current.wasDragged()).toBe(false)
+  })
+
+  it('treats a click without movement as a plain click (no commit, no suppression)', () => {
+    const onCommit = vi.fn()
+    const { result } = renderHook(() =>
+      useEventDrag({ gridRef: mockGridRef(), dateForColumn: () => '2026-04-14', onCommit })
+    )
+    act(() => {
+      result.current.startMove(
+        {
+          button: 0,
+          clientX: 100,
+          clientY: 100,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn()
+        } as never,
+        makeEvent(),
+        0
+      )
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+    expect(onCommit).not.toHaveBeenCalled()
+    expect(result.current.wasDragged()).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/use-event-drag.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-event-drag.ts
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import { parseLocalDate, toLocalDateKey } from './date-utils'
+import type { CalendarProjectionItem } from '@/services/calendar-service'
+
+const HOUR_HEIGHT = 48
+const SNAP_MINUTES = 15
+const MOVE_THRESHOLD_PX = 4
+const DEFAULT_DURATION_MINUTES = 60
+export const MINUTES_IN_DAY = 1440
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(value, max))
+}
+
+export function snapMinutes(minutes: number, snap: number): number {
+  return Math.round(minutes / snap) * snap
+}
+
+/** Keep a moved event fully inside its day (no multi-day spill). */
+// ponytail: clamp within day; multi-day spill not supported.
+export function clampStartWithinDay(startMinutes: number, durationMinutes: number): number {
+  return clamp(startMinutes, 0, MINUTES_IN_DAY - durationMinutes)
+}
+
+export function isoFromDayMinutes(date: string, minutesFromMidnight: number): string {
+  const d = parseLocalDate(date)
+  d.setMinutes(d.getMinutes() + minutesFromMidnight)
+  return d.toISOString()
+}
+
+export interface DragTimes {
+  startMin: number
+  endMin: number
+  startAt: string
+  endAt: string
+}
+
+export function computeMovedTimes(
+  originalStartMin: number,
+  durationMin: number,
+  deltaMin: number,
+  snap: number,
+  targetDate: string
+): DragTimes {
+  const startMin = clampStartWithinDay(snapMinutes(originalStartMin + deltaMin, snap), durationMin)
+  const endMin = startMin + durationMin
+  return {
+    startMin,
+    endMin,
+    startAt: isoFromDayMinutes(targetDate, startMin),
+    endAt: isoFromDayMinutes(targetDate, endMin)
+  }
+}
+
+export function computeResizedTimes(
+  startMin: number,
+  endMin: number,
+  deltaMin: number,
+  edge: 'start' | 'end',
+  snap: number,
+  date: string
+): DragTimes {
+  let nextStart = startMin
+  let nextEnd = endMin
+  if (edge === 'start') {
+    nextStart = clamp(snapMinutes(startMin + deltaMin, snap), 0, endMin - snap)
+  } else {
+    nextEnd = clamp(snapMinutes(endMin + deltaMin, snap), startMin + snap, MINUTES_IN_DAY)
+  }
+  return {
+    startMin: nextStart,
+    endMin: nextEnd,
+    startAt: isoFromDayMinutes(date, nextStart),
+    endAt: isoFromDayMinutes(date, nextEnd)
+  }
+}
+
+/** Only native Memry events are draggable — tasks, reminders, notes, imports are not. */
+export function isEventMovable(item: CalendarProjectionItem): boolean {
+  return item.sourceType === 'event' && Boolean(item.editability?.canMove) && !item.isAllDay
+}
+
+export function isEventResizable(item: CalendarProjectionItem): boolean {
+  return isEventMovable(item) && Boolean(item.editability?.canResize)
+}
+
+function minutesOfDay(iso: string): number {
+  const d = new Date(iso)
+  return d.getHours() * 60 + d.getMinutes()
+}
+
+function durationMinutes(item: CalendarProjectionItem, snap: number): number {
+  const start = new Date(item.startAt).getTime()
+  const end = item.endAt ? new Date(item.endAt).getTime() : start + DEFAULT_DURATION_MINUTES * 60000
+  return Math.max((end - start) / 60000, snap)
+}
+
+export interface EventDragState {
+  projectionId: string
+  columnIndex: number
+  top: number
+  height: number
+}
+
+type DragMode = { kind: 'move' } | { kind: 'resize'; edge: 'start' | 'end' }
+
+interface UseEventDragOptions {
+  gridRef: RefObject<HTMLDivElement | null>
+  /** Resolve a column index to its local date (week: dateForDayIndex; day: () => anchorDate). */
+  dateForColumn: (columnIndex: number) => string
+  /** Week view: hit-test the column under the pointer for cross-day moves. Day view omits it. */
+  columnIndexAtClientX?: (clientX: number) => number | null
+  hourHeight?: number
+  snapMinutes?: number
+  onCommit: (item: CalendarProjectionItem, startAt: string, endAt: string) => void | Promise<void>
+}
+
+interface UseEventDragResult {
+  drag: EventDragState | null
+  startMove: (e: React.MouseEvent, item: CalendarProjectionItem, columnIndex: number) => void
+  startResize: (
+    e: React.MouseEvent,
+    item: CalendarProjectionItem,
+    columnIndex: number,
+    edge: 'start' | 'end'
+  ) => void
+  /** Read-and-clear: true if the last gesture moved, so the trailing click can be suppressed. */
+  wasDragged: () => boolean
+}
+
+export function useEventDrag({
+  gridRef,
+  dateForColumn,
+  columnIndexAtClientX,
+  hourHeight = HOUR_HEIGHT,
+  snapMinutes: snap = SNAP_MINUTES,
+  onCommit
+}: UseEventDragOptions): UseEventDragResult {
+  const [drag, setDrag] = useState<EventDragState | null>(null)
+  const [active, setActive] = useState(false)
+  const wasDraggedRef = useRef(false)
+
+  const dragState = useRef<{
+    mode: DragMode
+    item: CalendarProjectionItem
+    originColumnIndex: number
+    anchorX: number
+    anchorY: number
+    originStartMin: number
+    originEndMin: number
+    durationMin: number
+    originDate: string
+    hasMoved: boolean
+    last: DragTimes | null
+  } | null>(null)
+
+  const pxPerMinute = hourHeight / 60
+
+  const begin = useCallback(
+    (e: React.MouseEvent, item: CalendarProjectionItem, columnIndex: number, mode: DragMode) => {
+      if (e.button !== 0) return
+      e.preventDefault()
+      e.stopPropagation()
+      const startMin = minutesOfDay(item.startAt)
+      const duration = durationMinutes(item, snap)
+      dragState.current = {
+        mode,
+        item,
+        originColumnIndex: columnIndex,
+        anchorX: e.clientX,
+        anchorY: e.clientY,
+        originStartMin: startMin,
+        originEndMin: startMin + duration,
+        durationMin: duration,
+        originDate: toLocalDateKey(item.startAt),
+        hasMoved: false,
+        last: null
+      }
+      setActive(true)
+    },
+    [snap]
+  )
+
+  const startMove = useCallback(
+    (e: React.MouseEvent, item: CalendarProjectionItem, columnIndex: number) => {
+      if (!isEventMovable(item)) return
+      begin(e, item, columnIndex, { kind: 'move' })
+    },
+    [begin]
+  )
+
+  const startResize = useCallback(
+    (
+      e: React.MouseEvent,
+      item: CalendarProjectionItem,
+      columnIndex: number,
+      edge: 'start' | 'end'
+    ) => {
+      if (!isEventResizable(item)) return
+      begin(e, item, columnIndex, { kind: 'resize', edge })
+    },
+    [begin]
+  )
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      const state = dragState.current
+      if (!state) return
+      if (!state.hasMoved) {
+        const moved =
+          Math.abs(e.clientX - state.anchorX) > MOVE_THRESHOLD_PX ||
+          Math.abs(e.clientY - state.anchorY) > MOVE_THRESHOLD_PX
+        if (!moved) return
+        state.hasMoved = true
+        wasDraggedRef.current = true
+      }
+
+      const deltaMin = ((e.clientY - state.anchorY) / hourHeight) * 60
+
+      let times: DragTimes
+      let columnIndex: number
+      if (state.mode.kind === 'move') {
+        columnIndex = columnIndexAtClientX?.(e.clientX) ?? state.originColumnIndex
+        const targetDate = dateForColumn(columnIndex)
+        times = computeMovedTimes(
+          state.originStartMin,
+          state.durationMin,
+          deltaMin,
+          snap,
+          targetDate
+        )
+      } else {
+        columnIndex = state.originColumnIndex
+        times = computeResizedTimes(
+          state.originStartMin,
+          state.originEndMin,
+          deltaMin,
+          state.mode.edge,
+          snap,
+          state.originDate
+        )
+      }
+      state.last = times
+      setDrag({
+        projectionId: state.item.projectionId,
+        columnIndex,
+        top: times.startMin * pxPerMinute,
+        height: (times.endMin - times.startMin) * pxPerMinute
+      })
+    },
+    [columnIndexAtClientX, dateForColumn, hourHeight, pxPerMinute, snap]
+  )
+
+  const handleMouseUp = useCallback(() => {
+    const state = dragState.current
+    dragState.current = null
+    setActive(false)
+    if (!state || !state.hasMoved || !state.last) {
+      setDrag(null)
+      return
+    }
+    const { item, last } = state
+    const changed = last.startAt !== item.startAt || last.endAt !== (item.endAt ?? null)
+    if (!changed) {
+      setDrag(null)
+      return
+    }
+    Promise.resolve(onCommit(item, last.startAt, last.endAt)).finally(() => setDrag(null))
+  }, [onCommit])
+
+  useEffect(() => {
+    if (!active) return
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [active, handleMouseMove, handleMouseUp])
+
+  const wasDragged = useCallback(() => {
+    const value = wasDraggedRef.current
+    wasDraggedRef.current = false
+    return value
+  }, [])
+
+  return { drag, startMove, startResize, wasDragged }
+}

--- a/apps/desktop/src/renderer/src/hooks/use-undo.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-undo.ts
@@ -170,7 +170,6 @@ export const useUndoTracker = (): UseUndoTrackerReturn => {
   const undo = useCallback((): boolean => {
     const entry = popUndoEntry()
     if (!entry) {
-      toast.info(t('toast.nothingToUndo'))
       return false
     }
 
@@ -223,7 +222,7 @@ export const useUndoKeyboardShortcut = (): void => {
           return // Let native text undo work
         }
 
-        // Check if there's something to undo
+        // Check if there's something to undo. Nothing to undo → do nothing (no toast).
         const entry = getLastUndoEntry()
         if (entry) {
           e.preventDefault()
@@ -237,10 +236,6 @@ export const useUndoKeyboardShortcut = (): void => {
               toast.error(t('toast.undoFailed'))
             }
           }
-        } else {
-          // Still prevent default but show info
-          e.preventDefault()
-          toast.info(t('toast.nothingToUndo'), { duration: 2000 })
         }
       }
     }

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/calendar/date-utils'
 import { useCalendarRange } from '@/hooks/use-calendar-range'
 import { useDeleteCalendarEvent } from '@/hooks/use-calendar-mutations'
+import { useUndoTracker } from '@/hooks/use-undo'
 import {
   calendarService,
   promoteExternalCalendarEvent,
@@ -224,6 +225,7 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
   const [promoteError, setPromoteError] = useState<string | null>(null)
   const [pendingDelete, setPendingDelete] = useState<CalendarProjectionItem | null>(null)
   const deleteMutation = useDeleteCalendarEvent()
+  const { registerUndo } = useUndoTracker()
 
   const { openForDayView, closeForDayView, setDate: setDayPanelDate } = useDayPanel()
 
@@ -628,6 +630,42 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
   }
 
+  const commitEventTimes = async (id: string, startAt: string, endAt: string | null) => {
+    const result = await calendarService.updateEvent({
+      id,
+      startAt,
+      endAt,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+      isAllDay: false
+    })
+    if (!result.success) {
+      throw new Error(result.error ?? 'Could not update event.')
+    }
+    await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
+  }
+
+  const handleMoveEvent = async (item: CalendarProjectionItem, startAt: string, endAt: string) => {
+    const previousStartAt = item.startAt
+    const previousEndAt = item.endAt
+    try {
+      await commitEventTimes(item.sourceId, startAt, endAt)
+      // Register undo so Cmd+Z restores the previous time (handled globally in App.tsx).
+      registerUndo(getI18n().getFixedT(null, 'calendar')('undo.moveEvent'), () => {
+        void commitEventTimes(item.sourceId, previousStartAt, previousEndAt).catch((err) => {
+          log.error('Failed to undo calendar event move', {
+            eventId: item.sourceId,
+            error: extractErrorMessage(err, 'Could not update event.')
+          })
+        })
+      })
+    } catch (err) {
+      log.error('Failed to move calendar event', {
+        eventId: item.sourceId,
+        error: extractErrorMessage(err, 'Could not update event.')
+      })
+    }
+  }
+
   const selectedItemId =
     popoverState?.eventId ??
     taskPopoverState?.item.sourceId ??
@@ -705,6 +743,7 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
         }
         onSelectItem={(...args) => void handleSelectItem(...args)}
         onDeleteItem={handleDeleteItem}
+        onMoveEvent={handleMoveEvent}
         inboxSnoozePopoverState={inboxSnoozePopoverState}
         onInboxSnoozeOpenInInbox={handleInboxSnoozeOpenInInbox}
         onInboxSnoozeUnsnooze={handleInboxSnoozeUnsnooze}

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -52,12 +52,15 @@ The toggle is vault-wide per property name — enabling it for "Deadline" once s
 
 ## Drag to Reschedule
 
-Drag an event or task chip to a new slot:
+On the day and week timelines, drag an **event** to reschedule it:
 
-- **Day / week views** — drag vertically to change time, horizontally to change day
-- **Month view** — drag to a different date
+- Drag vertically to change the time.
+- In week view, drag across columns to move it to another day.
+- Drag the top or bottom edge to change the start or end time (resize).
 
-Recurring events ask whether to update **this occurrence** or the **series** (same UX as recurring tasks).
+Times snap to 15-minute steps. Only events are draggable — task, reminder, and note chips stay put. If the event is linked to a connected Google calendar, the new time syncs there too.
+
+Press **Cmd/Ctrl+Z** to undo a move or resize.
 
 ## External Calendar Integration
 

--- a/packages/i18n/src/locales/en/calendar.json
+++ b/packages/i18n/src/locales/en/calendar.json
@@ -5,6 +5,9 @@
     "month": "Month",
     "year": "Year"
   },
+  "undo": {
+    "moveEvent": "Move event"
+  },
   "toolbar": {
     "create-event": "Create event",
     "previous-period": "Previous period",


### PR DESCRIPTION
## Summary

Adds direct manipulation of calendar **events** on the day and week timelines:

- **Move** — drag an event vertically to change its time; in week view, drag across columns to move it to another day.
- **Resize** — drag the top or bottom edge to change start/end independently.
- **15-minute snapping** for both.
- **Events only** — task, reminder, note, and imported chips stay inert (`sourceType === 'event' && editability.canMove`).
- A live ghost preview follows the cursor; a plain click (no movement) still opens the edit popover.
- **Cmd/Ctrl+Z undoes** a move/resize, via the existing global undo stack.

Moves commit through the existing `updateEvent` path, so Google Calendar sync follows automatically (when connected + push enabled). No contract, IPC, DB, or main-process changes.

Also: stop showing the global **"Nothing to undo"** toast when the undo stack is empty (applies app-wide).

## Implementation

- New `use-event-drag.ts` — pure geometry helpers (`computeMovedTimes` / `computeResizedTimes`, day-bound clamp) + a mouse-gesture hook modeled on the existing time-grid marquee hook.
- Week + day views wire the gesture onto event chips with top/bottom resize handles, ghost overlay, and click suppression.
- `calendar.tsx` registers an undo on each move/resize that re-applies the previous times.

## Scope / follow-ups

- All-day strip drag, multi-day spill (clamped within the day), imported-event drag, and redo are intentionally out of scope.

## Test plan

- `use-event-drag` unit tests (geometry, eligibility guards, commit + click suppression): 14 passing.
- Calendar suites + `use-undo` tests green; `typecheck:web`, ESLint, and `i18n:check` clean; docs build passes.
- Manual QA: drag an event up/down (time changes, snaps, persists), drag to another day in week view, resize edges (min 15 min), confirm non-event chips don't drag, plain click still opens the popover, Cmd+Z reverts.