### PR TITLE
feat(updater): sidebar download/restart progress + install on shutdown

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1266,8 +1266,16 @@ app.on('before-quit', (event) => {
 
   // Set timeout to force exit if shutdown takes too long
   const shutdownTimeout = setTimeout(() => {
-    shutdownLog.error('timeout - forcing exit')
-    app.exit(1)
+    // If the user asked to install an update, still hand off to Squirrel/NSIS
+    // rather than app.exit() — a hard exit skips the install (and bypasses
+    // autoInstallOnAppQuit), so the update never applies and the app re-prompts.
+    if (isQuitAndInstallRequested()) {
+      shutdownLog.error('cleanup timed out; installing downloaded update anyway')
+      performQuitAndInstall()
+    } else {
+      shutdownLog.error('timeout - forcing exit')
+      app.exit(1)
+    }
   }, 5000) // 5 second timeout
 
   // Flush pending saves from all renderer windows before closing vault
@@ -1325,7 +1333,14 @@ app.on('before-quit', (event) => {
     .catch((error) => {
       shutdownLog.error('error during cleanup:', error)
       clearTimeout(shutdownTimeout)
-      app.exit(1)
+      // Same as the timeout path: a pending install must survive a failed
+      // cleanup, otherwise the hard exit drops the update and the loop returns.
+      if (isQuitAndInstallRequested()) {
+        shutdownLog.error('cleanup failed; installing downloaded update anyway')
+        performQuitAndInstall()
+      } else {
+        app.exit(1)
+      }
     })
 })
 

--- a/apps/desktop/src/main/lib/html-to-plain-text.test.ts
+++ b/apps/desktop/src/main/lib/html-to-plain-text.test.ts
@@ -26,8 +26,16 @@ describe('htmlToPlainText', () => {
     ).toBe('Fixed #529 and foo')
   })
 
-  it('collapses excess blank lines and trims', () => {
-    expect(htmlToPlainText('  <p>One</p>\n\n\n\n<p>Two</p>  ')).toBe('One\n\nTwo')
+  it('single-spaces blocks, keeping a blank line only before headings', () => {
+    expect(htmlToPlainText('  <p>One</p>\n\n\n\n<p>Two</p>  ')).toBe('One\nTwo')
+  })
+
+  it('single-spaces loose-list bullets and blanks only before section headings', () => {
+    const html =
+      '<h2>New Features</h2><ul><li><p>Feature one (#1)</p></li><li><p>Feature two (#2)</p></li></ul><h2>Bug Fixes</h2><ul><li><p>Bug one (#3)</p></li></ul>'
+    expect(htmlToPlainText(html)).toBe(
+      'New Features\n• Feature one (#1)\n• Feature two (#2)\n\nBug Fixes\n• Bug one (#3)'
+    )
   })
 
   it('passes plain text through unchanged', () => {

--- a/apps/desktop/src/main/lib/html-to-plain-text.ts
+++ b/apps/desktop/src/main/lib/html-to-plain-text.ts
@@ -24,13 +24,22 @@ function decodeEntities(text: string): string {
   })
 }
 
+// Marks where a heading starts so a blank line can be restored before it after
+// all other blank lines are collapsed. NUL never appears in feed HTML text.
+const HEADING_MARK = '\u0000'
+
 /**
  * Convert an HTML fragment (e.g. GitHub-rendered release notes from the
  * electron-updater atom feed) into readable plain text for the native update
  * dialog, which renders its `detail` field as plain text only.
+ *
+ * Bullets are single-spaced; a blank line is added only before section
+ * headings (New Features, Bug Fixes…), so the non-scrollable dialog stays
+ * compact instead of double-spacing every release-note item.
  */
 export function htmlToPlainText(input: string): string {
   const withBreaks = input
+    .replace(/<h[1-6][^>]*>/gi, HEADING_MARK)
     .replace(/<li[^>]*>/gi, '• ')
     .replace(/<\/(p|div|li|ul|ol|h[1-6]|blockquote|tr)>/gi, '\n')
     .replace(/<br\s*\/?>/gi, '\n')
@@ -39,6 +48,7 @@ export function htmlToPlainText(input: string): string {
 
   return decodeEntities(stripped)
     .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
+    .replace(/\n{2,}/g, '\n') // single-space everything (loose lists wrap each <li> in a <p>)
+    .replace(/\n*\u0000/g, '\n\n') // blank line only before section headings
     .trim()
 }

--- a/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
@@ -173,6 +173,10 @@ vi.mock('@/components/sidebar/sidebar-drill-down-container', () => ({
   SidebarDrillDownContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>
 }))
 
+vi.mock('@/components/sidebar/sidebar-update-button', () => ({
+  SidebarUpdateButton: () => null
+}))
+
 vi.mock('@/contexts/selected-folder-context', () => ({
   useSelectedFolder: () => ({ setSelectedFolder: mocks.setSelectedFolder })
 }))

--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -31,6 +31,7 @@ import { SidebarNav } from '@/components/sidebar/sidebar-nav'
 import { SidebarSection } from '@/components/sidebar-section'
 import { NotesTree, type NotesTreeActions } from '@/components/notes-tree'
 import { SidebarTagList } from '@/components/sidebar/sidebar-tag-list'
+import { SidebarUpdateButton } from '@/components/sidebar/sidebar-update-button'
 import { SidebarBookmarkList } from '@/components/sidebar/sidebar-bookmark-list'
 import { SidebarDrillDownContainer } from '@/components/sidebar/sidebar-drill-down-container'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -466,6 +467,7 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
         <SidebarDrillDownContainer>{mainContent}</SidebarDrillDownContainer>
       </SidebarContent>
       <SidebarFooter className="gap-0 p-2">
+        <SidebarUpdateButton />
         <div className="flex items-center gap-1">
           {authState.status === 'authenticated' ? (
             <div className="shrink-0 w-7 [&>button]:w-7 [&>button]:justify-center">

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-update-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-update-button.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
+
+import { SidebarUpdateButton } from './sidebar-update-button'
+
+const mocks = vi.hoisted(() => ({
+  downloadUpdate: vi.fn().mockResolvedValue(undefined),
+  quitAndInstall: vi.fn().mockResolvedValue(undefined),
+  state: {} as AppUpdateState
+}))
+
+vi.mock('@/hooks/use-app-updater', () => ({
+  useAppUpdater: () => ({
+    state: mocks.state,
+    isLoading: false,
+    error: null,
+    checkForUpdates: vi.fn(),
+    downloadUpdate: mocks.downloadUpdate,
+    quitAndInstall: mocks.quitAndInstall
+  })
+}))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      const leaf = key.split('.').at(-1) ?? key
+      return opts && 'percent' in opts ? `${leaf}-${opts.percent}` : leaf
+    }
+  })
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/lib/icons', () => ({
+  Download: () => <svg data-testid="icon-download" />,
+  RotateCw: () => <svg data-testid="icon-restart" />
+}))
+
+function makeState(patch: Partial<AppUpdateState>): AppUpdateState {
+  return {
+    currentVersion: '1.0.0',
+    status: 'idle',
+    updateSupported: true,
+    availableVersion: null,
+    releaseName: null,
+    releaseDate: null,
+    releaseNotes: null,
+    downloadProgressPercent: null,
+    lastCheckedAt: null,
+    error: null,
+    ...patch
+  }
+}
+
+describe('SidebarUpdateButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each(['idle', 'checking', 'up-to-date', 'unavailable', 'error'] as const)(
+    'renders nothing in %s state',
+    (status) => {
+      mocks.state = makeState({ status })
+      const { container } = render(<SidebarUpdateButton />)
+      expect(container).toBeEmptyDOMElement()
+    }
+  )
+
+  it('shows "Update" and downloads when available', () => {
+    mocks.state = makeState({ status: 'available', availableVersion: '1.1.0' })
+    render(<SidebarUpdateButton />)
+
+    const button = screen.getByRole('button', { name: 'updateAvailable' })
+    fireEvent.click(button)
+    expect(mocks.downloadUpdate).toHaveBeenCalledTimes(1)
+    expect(mocks.quitAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('shows live percent and disables the button while downloading', () => {
+    mocks.state = makeState({ status: 'downloading', downloadProgressPercent: 42 })
+    render(<SidebarUpdateButton />)
+
+    const button = screen.getByRole('button', { name: 'updateDownloadingPercent-42' })
+    expect(button).toBeDisabled()
+    fireEvent.click(button)
+    expect(mocks.downloadUpdate).not.toHaveBeenCalled()
+  })
+
+  it('shows "Restart" and installs when downloaded', () => {
+    mocks.state = makeState({ status: 'downloaded', downloadProgressPercent: 100 })
+    render(<SidebarUpdateButton />)
+
+    const button = screen.getByRole('button', { name: 'updateRestart' })
+    fireEvent.click(button)
+    expect(mocks.quitAndInstall).toHaveBeenCalledTimes(1)
+    expect(mocks.downloadUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-update-button.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-update-button.tsx
@@ -1,0 +1,85 @@
+import { useCallback } from 'react'
+import { Download, RotateCw } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { useT } from '@memry/i18n/renderer'
+import { useAppUpdater } from '@/hooks/use-app-updater'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('Component:SidebarUpdateButton')
+
+/**
+ * Accent button pinned above the sync/vault/settings row in the sidebar footer.
+ * Mirrors the update lifecycle from the native popup:
+ *   available  → "Update"  (click downloads)
+ *   downloading → "Downloading {percent}%" (live, with a progress fill)
+ *   downloaded → "Restart" (click quits + installs)
+ * Hidden in every other state (idle / checking / up-to-date / unsupported / error).
+ */
+export function SidebarUpdateButton() {
+  const { t } = useT('common')
+  const { state, downloadUpdate, quitAndInstall } = useAppUpdater()
+  const { status, downloadProgressPercent } = state
+
+  const handleClick = useCallback(() => {
+    if (status === 'available') {
+      void downloadUpdate().catch((err) => log.error('update download failed', err))
+    } else if (status === 'downloaded') {
+      void quitAndInstall().catch((err) => log.error('restart to install failed', err))
+    }
+  }, [status, downloadUpdate, quitAndInstall])
+
+  if (status !== 'available' && status !== 'downloading' && status !== 'downloaded') {
+    return null
+  }
+
+  const isDownloading = status === 'downloading'
+  const isDownloaded = status === 'downloaded'
+  const percent = Math.max(0, Math.min(100, downloadProgressPercent ?? 0))
+
+  const label = isDownloaded
+    ? t('phaseF.componentsAppSidebar.updateRestart')
+    : isDownloading
+      ? downloadProgressPercent == null
+        ? t('phaseF.componentsAppSidebar.updateDownloading')
+        : t('phaseF.componentsAppSidebar.updateDownloadingPercent', { percent })
+      : t('phaseF.componentsAppSidebar.updateAvailable')
+
+  const Icon = isDownloaded ? RotateCw : Download
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={isDownloading}
+          aria-label={label}
+          title={label}
+          className={cn(
+            'relative mb-1 flex h-8 w-full items-center justify-center gap-2 overflow-hidden rounded',
+            'bg-sidebar-terracotta text-white shadow-sm transition-colors',
+            'hover:bg-sidebar-terracotta/90 disabled:cursor-default',
+            // collapsed (icon-only) sidebar: shrink to a square, drop the label
+            'group-data-[collapsible=icon]:size-7 group-data-[collapsible=icon]:w-7 group-data-[collapsible=icon]:gap-0'
+          )}
+        >
+          {isDownloading && (
+            <span
+              aria-hidden="true"
+              className="absolute inset-y-0 start-0 bg-white/25 transition-[width] duration-300"
+              style={{ width: `${percent}%` }}
+            />
+          )}
+          <Icon className={cn('relative size-4 shrink-0', isDownloading && 'animate-pulse')} />
+          <span className="relative text-xs font-medium group-data-[collapsible=icon]:hidden">
+            {label}
+          </span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -214,7 +214,11 @@
       "new": "New",
       "newItemMenu": "Create new…",
       "syncDisabled": "Sync disabled",
-      "syncDisabled2": "Sync disabled"
+      "syncDisabled2": "Sync disabled",
+      "updateAvailable": "Update",
+      "updateDownloading": "Downloading…",
+      "updateDownloadingPercent": "Downloading {percent}%",
+      "updateRestart": "Restart"
     },
     "componentsDayPanelGlobalDayPanel": {
       "resizeDayPanel": "Resize Day Panel",


### PR DESCRIPTION
## What

Surfaces the app-update lifecycle in the **sidebar footer** (above sync/vault/settings) and hardens the install-on-restart path.

### Sidebar update button
New `sidebar-update-button.tsx`, pinned above the sync/vault/settings row. Drives off the existing `useAppUpdater()` live state (no new IPC/contract):

- `available` → **Update** (accent terracotta) → click downloads
- `downloading` → **Downloading {percent}%** — live, with a progress fill
- `downloaded` → **Restart** → click quits + installs
- hidden in every other state (so invisible in dev where updates are `unavailable`)

### Restart actually installs
`index.ts` shutdown: the 5s timeout and the cleanup `catch` both called `app.exit()` — a hard exit that **skips a requested install** and bypasses electron-updater's `autoInstallOnAppQuit` quit handler (it only auto-installs on the `quit` event with exitCode 0; `app.exit()` fires neither). When an install is requested, both paths now hand off to `performQuitAndInstall()` instead. Builds on #570 (graceful-quit handoff).

> Note: this closes a real, reachable hole (E2E logs show `timeout - forcing exit` firing under heavy teardown), but the root cause of the field report on v2026-06-20 is **not yet confirmed** — no real-app updater log was available locally. If a build reaches `installing downloaded update and relaunching` but still relaunches old, the remaining cause is native Squirrel.Mac (signing / `latest-mac.yml` feed), not app code.

## Verify
- typecheck:web ✅ · typecheck:node ✅ · i18n:check ✅ · eslint 0 ✅
- renderer 12/12 (8 new SidebarUpdateButton + 4 app-sidebar) ✅
- updater 6/6 ✅

## Notes
- First commit (`single-space release-note bullets`) was already in the working tree — kept as its own commit for honest history, not authored as part of this UI work.
- Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: change is a sidebar control + internal shutdown fix with no user-facing doc page.