### PR TITLE
feat(theme): default to white theme for new users

### DIFF
--- a/apps/desktop/src/main/ipc/settings-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.test.ts
@@ -546,7 +546,7 @@ describe('settings-handlers', () => {
     ;(settingsQueries.getSetting as Mock).mockReturnValueOnce('{bad json')
 
     const generalSettings = await invokeHandler(SettingsChannels.invoke.GET_GENERAL_SETTINGS)
-    expect(generalSettings).toEqual(expect.objectContaining({ theme: 'system' }))
+    expect(generalSettings).toEqual(expect.objectContaining({ theme: 'white' }))
     expect(settingsQueries.deleteSetting).toHaveBeenCalledWith({}, 'general')
 
     await invokeHandler(SettingsChannels.invoke.SET_EDITOR_SETTINGS, { width: 'wide' })

--- a/packages/app-core/src/settings.ts
+++ b/packages/app-core/src/settings.ts
@@ -59,7 +59,7 @@ const settingsKeys = {
 
 const settingsGroupDefaults: Record<SettingsGroupName, Record<string, unknown>> = {
   general: {
-    theme: 'system',
+    theme: 'white',
     fontSize: 'medium',
     fontFamily: 'system',
     accentColor: '#6366f1',

--- a/packages/contracts/src/settings-schemas.ts
+++ b/packages/contracts/src/settings-schemas.ts
@@ -31,7 +31,7 @@ export type GeneralSettings = z.infer<typeof GeneralSettingsSchema>
 export const DEFAULT_ACCENT_COLOR = '#f97316'
 
 export const GENERAL_SETTINGS_DEFAULTS: GeneralSettings = {
-  theme: 'system',
+  theme: 'white',
   fontSize: 'medium',
   fontFamily: 'system',
   accentColor: DEFAULT_ACCENT_COLOR,


### PR DESCRIPTION
## What

Flip the default theme from `system` to `white` for new users.

## Why

White is the intended out-of-box theme; new vaults were defaulting to `system` (follows OS light/dark).

## Changes

- `packages/contracts/src/settings-schemas.ts` — `GENERAL_SETTINGS_DEFAULTS.theme` → `white`
- `packages/app-core/src/settings.ts` — `settingsGroupDefaults.general.theme` → `white`
- `apps/desktop/src/main/ipc/settings-handlers.test.ts` — corrupted-settings recovery assertion → `white`

`white` is already a valid member of the theme enum/union everywhere, so the change is type-safe by construction. Existing users keep their saved theme; this only affects fresh installs / reset settings.

## Not touched (deliberate)

- The `?? 'system'` fallbacks in `startup-theme.ts` (preload + renderer) — error path when the settings API is unavailable, not the product default.
- Other `theme: 'system'` occurrences are test fixtures (arbitrary input), not defaults.

## Verification

Not run locally — fresh worktree, would need a full install + Electron native rebuild for a 3-literal swap. Change is type-checked by construction.