### PR TITLE
fix(import): sort import sources alphabetically in settings dropdown

### DIFF
--- a/apps/desktop/src/main/import/registry.test.ts
+++ b/apps/desktop/src/main/import/registry.test.ts
@@ -53,4 +53,12 @@ describe('importer registry', () => {
     expect(meta.find((m) => m.id === 'with-preview')?.supportsPreview).toBe(true)
     expect(meta[0].fileSpec).toEqual({ label: 'Fake', extensions: ['zip'], allowMultiple: false })
   })
+
+  it('sorts metadata alphabetically by name regardless of registration order', () => {
+    registerImporter({ ...fake, id: 'zebra', name: 'Zebra' })
+    registerImporter({ ...fake, id: 'apple', name: 'Apple' })
+    registerImporter({ ...fake, id: 'mango', name: 'Mango' })
+
+    expect(listImporterMeta().map((m) => m.name)).toEqual(['Apple', 'Mango', 'Zebra'])
+  })
 })

--- a/apps/desktop/src/main/import/registry.ts
+++ b/apps/desktop/src/main/import/registry.ts
@@ -18,15 +18,17 @@ export function listImporters(): Importer[] {
   return [...importers.values()]
 }
 
-/** Serializable importer metadata for the renderer's Settings catalog. */
+/** Serializable importer metadata for the renderer's Settings catalog, sorted by name. */
 export function listImporterMeta(): ImporterMeta[] {
-  return listImporters().map((i) => ({
-    id: i.id,
-    name: i.name,
-    descriptionKey: i.descriptionKey,
-    fileSpec: i.fileSpec,
-    supportsPreview: typeof i.preview === 'function'
-  }))
+  return listImporters()
+    .map((i) => ({
+      id: i.id,
+      name: i.name,
+      descriptionKey: i.descriptionKey,
+      fileSpec: i.fileSpec,
+      supportsPreview: typeof i.preview === 'function'
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
 }
 
 /** Test-only: clear the registry between cases. */


### PR DESCRIPTION
## What

Import sources in **Settings → Import** dropdown now list alphabetically by name instead of registration order.

Before: Notion, Todoist, TickTick, Markdown, HTML, Google Keep, Bear, Evernote, Roam, Apple Journal, CSV, Raindrop, Apple Notes.

After: Apple Journal, Apple Notes, Bear, CSV, Evernote, Google Keep, HTML, Markdown, Notion, Raindrop, Roam, TickTick, Todoist.

## How

Single chokepoint — sort in `listImporterMeta()` (`registry.ts`) by `name.localeCompare`. Renderer (`use-importers`) renders in returned order, so no UI change needed. Registration order in `register-builtins.ts` left untouched.

## Test

`registry.test.ts`: new case registers out of order, asserts alphabetical output. 6/6 main import-registry tests pass.