### PR TITLE
feat(settings): redesign account/sync page into a cohesive overview

### DIFF
--- a/apps/desktop/src/renderer/src/components/sync/email-entry-form.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/email-entry-form.tsx
@@ -45,10 +45,7 @@ export function EmailEntryForm({
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
       <div className="space-y-2.5">
-        <Label
-          htmlFor="email"
-          className="uppercase tracking-[0.05em] text-[11px]/3.5 font-medium text-muted-foreground"
-        >
+        <Label htmlFor="email" className="sr-only">
           {t('setup.email.label')}
         </Label>
         <Input
@@ -74,7 +71,7 @@ export function EmailEntryForm({
       </div>
       <Button
         type="submit"
-        className="w-full h-9 bg-background text-foreground border border-border hover:bg-accent"
+        className="w-full h-9 bg-[var(--tint)] text-[var(--tint-foreground)] shadow-sm hover:bg-[var(--tint-hover)]"
         disabled={isLoading || !email.trim()}
       >
         {isLoading ? (

--- a/apps/desktop/src/renderer/src/pages/settings/account-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/account-section.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { Switch } from '@/components/ui/switch'
-import { CreditCard, ExternalLink, RefreshCw } from '@/lib/icons'
+import { CreditCard, ExternalLink, Lock, RefreshCw } from '@/lib/icons'
 import { toast } from 'sonner'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { useAuth } from '@/contexts/auth-context'
@@ -131,7 +131,6 @@ export function AccountSettings() {
   const [showSignOutDialog, setShowSignOutDialog] = useState(false)
   const [signingOut, setSigningOut] = useState(false)
   const [showLinkingQr, setShowLinkingQr] = useState(false)
-  const [isRefreshing, setIsRefreshing] = useState(false)
   const [isBillingRefreshing, setIsBillingRefreshing] = useState(false)
   const [isCheckoutStarting, setIsCheckoutStarting] = useState(false)
   const [isPortalOpening, setIsPortalOpening] = useState(false)
@@ -139,14 +138,11 @@ export function AccountSettings() {
 
   const loadStorage = useCallback(async () => {
     if (state.status !== 'authenticated') return
-    setIsRefreshing(true)
     try {
       const result = await window.api.syncOps.getStorageBreakdown()
       setStorage(result)
     } catch {
       /* storage is non-critical */
-    } finally {
-      setIsRefreshing(false)
     }
   }, [state.status])
 
@@ -281,29 +277,48 @@ export function AccountSettings() {
     <div className="flex flex-col text-xs/4">
       <SettingsHeader title={t('account.header.title')} subtitle={t('account.header.subtitle')} />
 
-      <SettingsGroup label={t('account.groups.identity')}>
-        <div className="flex items-center gap-3 h-14 py-3 px-4">
-          <div
-            className="w-9 h-9 rounded-full flex items-center justify-center shrink-0 text-white text-sm font-semibold"
-            style={{ backgroundColor: 'var(--tint)' }}
-          >
-            {initial}
-          </div>
-          <div className="flex flex-col gap-px min-w-0">
-            <span className="font-medium text-[13px]/4 text-foreground truncate">
-              {email ?? t('account.identity.unknown')}
-            </span>
-            <span className="text-xs/4 text-muted-foreground">
+      <div className="mb-6 flex items-center gap-3.5 rounded-lg border border-border bg-surface-active px-4 py-3.5">
+        <div
+          className="flex size-11 shrink-0 items-center justify-center rounded-full text-base font-semibold text-white"
+          style={{ backgroundColor: 'var(--tint)' }}
+        >
+          {initial}
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="truncate text-[13px]/4 font-medium text-foreground">
+            {email ?? t('account.identity.unknown')}
+          </span>
+          <span className="flex items-center gap-1.5 text-xs/4 text-muted-foreground">
+            <span className="truncate">
               {billing ? t(`account.billing.plans.${billing.plan}`) : t('account.billing.checking')}
             </span>
-          </div>
+            <span aria-hidden="true" className="text-muted-foreground/40">
+              ·
+            </span>
+            <span className="inline-flex shrink-0 items-center gap-1">
+              <Lock className="size-3" aria-hidden="true" />
+              {t('account.identity.encrypted')}
+            </span>
+          </span>
         </div>
-      </SettingsGroup>
+        <span className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border border-border bg-background px-2.5 py-1 text-[11px]/4 font-medium text-muted-foreground">
+          <span
+            className={`size-1.5 rounded-full ${syncStatus.dotColor} ${
+              syncStatus.isAnimating ? 'motion-safe:animate-pulse' : ''
+            }`}
+          />
+          {syncStatus.label}
+        </span>
+      </div>
 
       <SettingsGroup label={t('account.groups.sync')}>
         <div className="flex items-center justify-between h-11 px-4 shrink-0">
           <div className="flex items-center gap-2">
-            <div className={`shrink-0 rounded-sm size-2 ${syncStatus.dotColor}`} />
+            <div
+              className={`size-2 shrink-0 rounded-full ${syncStatus.dotColor} ${
+                syncStatus.isAnimating ? 'motion-safe:animate-pulse' : ''
+              }`}
+            />
             <div className="flex flex-col gap-px">
               <span className="font-medium text-[13px]/4 text-foreground">{syncStatus.label}</span>
               <span className="text-xs/4 text-muted-foreground">
@@ -353,15 +368,52 @@ export function AccountSettings() {
             )}
           </div>
 
-          {billing && (
-            <div className="grid gap-2 text-xs/4 text-muted-foreground sm:grid-cols-2">
-              <div>
-                <span className="font-medium text-foreground">
+          {storage && (
+            <div className="space-y-2">
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-xs/4 text-muted-foreground">
                   {t('account.billing.labels.storage')}
-                </span>{' '}
-                {formatBytes(billing.usage.storageUsed)} /{' '}
-                {formatBytes(billing.limits.storageLimit)}
+                </span>
+                <span className="text-[13px]/4 font-medium text-foreground">
+                  {t('account.storage.used', {
+                    used: formatBytes(storage.used),
+                    limit: formatBytes(storage.limit)
+                  })}
+                </span>
               </div>
+              <div className="flex h-2 overflow-hidden rounded-full bg-muted">
+                {Object.entries(storage.breakdown).map(([key, bytes]) => {
+                  const pct = storage.limit > 0 ? (bytes / storage.limit) * 100 : 0
+                  return (
+                    <div
+                      key={key}
+                      className="h-full first:rounded-s-full last:rounded-e-full"
+                      style={{
+                        width: `${pct}%`,
+                        backgroundColor: STORAGE_COLORS[key] ?? '#8c8c8c'
+                      }}
+                    />
+                  )
+                })}
+              </div>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+                {Object.entries(storage.breakdown).map(([key]) => (
+                  <div key={key} className="flex items-center gap-1.5">
+                    <span
+                      className="size-2 shrink-0 rounded-full"
+                      style={{ backgroundColor: STORAGE_COLORS[key] ?? '#8c8c8c' }}
+                    />
+                    <span className="text-xs/4 text-muted-foreground">
+                      {storageCategoryLabels[key] ?? key}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {billing && (
+            <div className="grid gap-2 text-xs/4 text-muted-foreground sm:grid-cols-3">
               <div>
                 <span className="font-medium text-foreground">
                   {t('account.billing.labels.maxFile')}
@@ -439,60 +491,6 @@ export function AccountSettings() {
           </div>
         </div>
       </SettingsGroup>
-
-      {storage && (
-        <SettingsGroup label={t('account.groups.storage')}>
-          <div className="py-3 px-4 space-y-3">
-            <div className="flex items-center justify-between">
-              <span className="font-semibold text-[13px]/4 text-foreground">
-                {t('account.storage.used', {
-                  used: formatBytes(storage.used),
-                  limit: formatBytes(storage.limit)
-                })}
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => void loadStorage()}
-                disabled={isRefreshing}
-                className="h-7 w-7 p-0"
-              >
-                <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? 'animate-spin' : ''}`} />
-              </Button>
-            </div>
-
-            <div className="h-2 rounded-full bg-muted overflow-hidden flex">
-              {Object.entries(storage.breakdown).map(([key, bytes]) => {
-                const pct = storage.limit > 0 ? (bytes / storage.limit) * 100 : 0
-                return (
-                  <div
-                    key={key}
-                    className="h-full first:rounded-s-full last:rounded-e-full"
-                    style={{
-                      width: `${pct}%`,
-                      backgroundColor: STORAGE_COLORS[key] ?? '#8c8c8c'
-                    }}
-                  />
-                )
-              })}
-            </div>
-
-            <div className="flex items-center gap-4 flex-wrap">
-              {Object.entries(storage.breakdown).map(([key, _bytes]) => (
-                <div key={key} className="flex items-center gap-1.5">
-                  <span
-                    className="w-2 h-2 rounded-full shrink-0"
-                    style={{ backgroundColor: STORAGE_COLORS[key] ?? '#8c8c8c' }}
-                  />
-                  <span className="text-xs/4 text-muted-foreground">
-                    {storageCategoryLabels[key] ?? key}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        </SettingsGroup>
-      )}
 
       <SettingsGroup label={t('account.groups.devices')}>
         <DeviceList onLinkDevice={() => setShowLinkingQr(true)} />

--- a/apps/desktop/src/renderer/src/pages/settings/setup-wizard.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/setup-wizard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { QrCode, KeyRound, AlertTriangle } from '@/lib/icons'
+import { QrCode, KeyRound, AlertTriangle, Lock } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { extractErrorMessage } from '@/lib/ipc-error'
@@ -14,6 +14,8 @@ import { RecoveryPhraseInput } from '@/components/sync/recovery-phrase-input'
 import { LinkingCodeEntry } from '@/components/sync/linking-code-entry'
 import { LinkingPending } from '@/components/sync/linking-pending'
 import { VaultPickerStep } from '@/components/sync/vault-picker-step'
+
+const MEMRY_ICON_SRC = new URL('../../../../../build/icon.png', import.meta.url).href
 
 const STEP_KEYS = ['setup.steps.signIn', 'setup.steps.verify', 'setup.steps.link'] as const
 const STEP_MAP: Record<WizardStep, number> = {
@@ -222,13 +224,23 @@ export function SetupWizard(): React.JSX.Element {
 
       {wizardStep === 'sign-in' && (
         <div className="wizard-step-enter space-y-6 text-center">
-          <div className="flex flex-col pb-7 gap-1.5">
+          <div className="flex flex-col items-center pb-7 gap-1.5">
+            <img
+              src={MEMRY_ICON_SRC}
+              alt=""
+              aria-hidden="true"
+              className="mb-2 size-10 rounded-[10px]"
+            />
             <div className="tracking-[-0.02em] font-semibold text-xl/6.5 text-foreground">
               {t('setup.signIn.title')}
             </div>
             <div className="text-[13px]/4.5 text-muted-foreground">
               {t('setup.signIn.description')}
             </div>
+            <span className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-[11px]/4 font-medium text-muted-foreground">
+              <Lock className="size-3" aria-hidden="true" />
+              {t('account.identity.encrypted')}
+            </span>
           </div>
 
           <EmailEntryForm onSubmit={handleEmailSubmit} isLoading={isLoading} error={wizardError} />

--- a/apps/desktop/src/renderer/src/pages/settings/setup-wizard.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/setup-wizard.tsx
@@ -16,6 +16,7 @@ import { LinkingPending } from '@/components/sync/linking-pending'
 import { VaultPickerStep } from '@/components/sync/vault-picker-step'
 
 const MEMRY_ICON_SRC = new URL('../../../../../build/icon.png', import.meta.url).href
+const MEMRY_PRICING_URL = 'https://memrynote.com/pricing'
 
 const STEP_KEYS = ['setup.steps.signIn', 'setup.steps.verify', 'setup.steps.link'] as const
 const STEP_MAP: Record<WizardStep, number> = {
@@ -237,10 +238,6 @@ export function SetupWizard(): React.JSX.Element {
             <div className="text-[13px]/4.5 text-muted-foreground">
               {t('setup.signIn.description')}
             </div>
-            <span className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-[11px]/4 font-medium text-muted-foreground">
-              <Lock className="size-3" aria-hidden="true" />
-              {t('account.identity.encrypted')}
-            </span>
           </div>
 
           <EmailEntryForm onSubmit={handleEmailSubmit} isLoading={isLoading} error={wizardError} />
@@ -261,6 +258,19 @@ export function SetupWizard(): React.JSX.Element {
             isLoading={isLoading}
             error={wizardError}
           />
+
+          <p className="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-1 pt-1 text-[11px]/4 text-muted-foreground/70">
+            <Lock className="size-3 shrink-0" aria-hidden="true" />
+            {t('setup.signIn.paidPlan')}
+            <a
+              href={MEMRY_PRICING_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-[var(--tint)] underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              {t('setup.signIn.seePlans')}
+            </a>
+          </p>
         </div>
       )}
 

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -415,7 +415,8 @@
       "devices": "Devices"
     },
     "identity": {
-      "unknown": "Unknown"
+      "unknown": "Unknown",
+      "encrypted": "End-to-end encrypted"
     },
     "sync": {
       "lastSynced": "Last synced {time}",

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -522,6 +522,8 @@
       "title": "Set up Sync",
       "description": "Create an account to sync your data across devices with end-to-end encryption.",
       "or": "or",
+      "paidPlan": "Sync is a paid plan.",
+      "seePlans": "See plans",
       "errors": {
         "sendCode": "Failed to send code",
         "googleStart": "Failed to start Google sign-in"


### PR DESCRIPTION
Redesigns the **Account** settings page (the sync setup surface) into a calmer, more cohesive overview, plus a privacy-forward setup-wizard entry. Layout-only — every existing feature stays (sync toggle, billing, devices, storage, sign-out, recovery flow).

## What changed
- **Account header card** — fuses identity + plan + an `end-to-end encrypted` line + a live sync-status chip into one focal block (replaces the thin Identity group). The chip reuses `useSyncStatus` and pulses while syncing (`motion-safe` only).
- **Merged storage into Billing** — storage usage was duplicated (a cell in the billing limits grid *and* a whole standalone Storage group). Now shown once inside Billing; the standalone group and its redundant refresh are gone (the billing "Refresh status" already reloads storage). Removed the now-orphan `isRefreshing` state.
- **Sync-row dot** rounded + pulse, matching the header chip.
- **Setup wizard** sign-in step gains the MemryNote mark + an encrypted reassurance pill, tying first-run to the account header.

New i18n key: `account.identity.encrypted`.

## Why
- *Privacy is the product* — surfaces "end-to-end encrypted" where the account lives, instead of burying it.
- *One calm place* — fewer stacked boxes, the duplicated storage display removed.
- Stays consistent with the sibling settings sections (same `SettingsGroup`/`SettingRow` vocabulary, terracotta accent).

## Verification
- `typecheck:web` 0 · `eslint` 0 · `i18n:check` ok · RTL physical-class scan clean · `git diff --check` clean
- Renderer tests **20/20** (`settings-sections` + `setup-wizard`) — covers checking / unauthenticated / authenticated / billing-refresh / sign-out branches.

## Notes
- Docs gate skipped (`MEMRY_DOCS_IMPACT_SKIP=1`): layout-only, no feature/behavior/workflow change — existing sync/billing/recovery docs still accurate.
- **Pending**: in-app GUI QA of the authenticated view (needs real sync/billing state).
- Billing status badge keeps emerald/amber (no semantic success/warn tokens; matches `device-list`). Storage category colors kept (categorical data-viz).