### PR TITLE
feat(calendar): functional toolbar search that jumps to items

### DIFF
--- a/apps/desktop/src/renderer/src/components/calendar/calendar-light-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-light-surfaces.test.tsx
@@ -52,6 +52,12 @@ vi.mock('@/contexts/calendar-view-context', () => ({
   useCalendarView: () => calendarView
 }))
 
+// CalendarSearch self-fetches via react-query; stub it so this toolbar-action
+// test needs no QueryClient provider.
+vi.mock('./calendar-search', () => ({
+  CalendarSearch: () => <button type="button">search</button>
+}))
+
 vi.mock('@/hooks/use-calendar-preferences', () => ({
   useCalendarPreferences: () => calendarPreferences,
   resolveDayCellClickBehavior: (settings: Record<string, unknown>, isCalendarTabActive: boolean) =>
@@ -207,6 +213,7 @@ describe('calendar lightweight surfaces', () => {
         onNext={onNext}
         onToday={onToday}
         onCreateEvent={onCreateEvent}
+        onSearchJump={vi.fn()}
         extraActions={<button type="button">extra action</button>}
       />
     )

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-search-filter.test.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-search-filter.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import type { CalendarProjectionItem } from '@/services/calendar-service'
+import { filterCalendarItems } from './calendar-search-filter'
+
+function makeItem(overrides: Partial<CalendarProjectionItem>): CalendarProjectionItem {
+  return {
+    projectionId: overrides.projectionId ?? 'p',
+    sourceType: 'event',
+    sourceId: 's',
+    title: '',
+    descriptionPreview: null,
+    startAt: '2026-01-01T00:00:00.000Z',
+    endAt: null,
+    isAllDay: false,
+    timezone: 'UTC',
+    visualType: 'event',
+    editability: { canMove: true, canResize: true, canEditText: true, canDelete: true },
+    source: {
+      provider: null,
+      calendarSourceId: null,
+      title: null,
+      color: null,
+      kind: null,
+      isMemryManaged: true
+    },
+    binding: null,
+    snoozeOffsetMinutes: null,
+    ...overrides
+  }
+}
+
+const NOW = new Date('2026-06-01T00:00:00.000Z').getTime()
+
+describe('filterCalendarItems', () => {
+  it('returns nothing for a blank query', () => {
+    const items = [makeItem({ title: 'Standup' })]
+    expect(filterCalendarItems(items, '   ', NOW)).toEqual([])
+  })
+
+  it('matches title and description case-insensitively', () => {
+    const items = [
+      makeItem({ projectionId: 'a', title: 'Team STANDUP' }),
+      makeItem({ projectionId: 'b', title: 'Lunch', descriptionPreview: 'weekly standup notes' }),
+      makeItem({ projectionId: 'c', title: 'Gym' })
+    ]
+    const ids = filterCalendarItems(items, 'standup', NOW).map((i) => i.projectionId)
+    expect(ids).toEqual(['a', 'b'])
+  })
+
+  it('sorts matches by proximity to now', () => {
+    const items = [
+      makeItem({ projectionId: 'far', title: 'Trip', startAt: '2027-08-08T00:00:00.000Z' }),
+      makeItem({ projectionId: 'near', title: 'Trip', startAt: '2026-06-05T00:00:00.000Z' })
+    ]
+    expect(filterCalendarItems(items, 'trip', NOW).map((i) => i.projectionId)).toEqual([
+      'near',
+      'far'
+    ])
+  })
+
+  it('caps the result count', () => {
+    const items = Array.from({ length: 30 }, (_, n) =>
+      makeItem({ projectionId: `p${n}`, title: 'Repeat' })
+    )
+    expect(filterCalendarItems(items, 'repeat', NOW, 5)).toHaveLength(5)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-search-filter.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-search-filter.ts
@@ -1,0 +1,30 @@
+import type { CalendarProjectionItem } from '@/services/calendar-service'
+
+export const MAX_SEARCH_RESULTS = 20
+
+/**
+ * Filter the unified calendar projection by free text (title + description),
+ * sorted by temporal proximity to `nowMs` so the nearest matches surface first.
+ */
+export function filterCalendarItems(
+  items: CalendarProjectionItem[],
+  query: string,
+  nowMs: number,
+  limit = MAX_SEARCH_RESULTS
+): CalendarProjectionItem[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return []
+
+  return items
+    .filter((item) => {
+      const title = item.title?.toLowerCase() ?? ''
+      const desc = item.descriptionPreview?.toLowerCase() ?? ''
+      return title.includes(q) || desc.includes(q)
+    })
+    .sort(
+      (a, b) =>
+        Math.abs(new Date(a.startAt).getTime() - nowMs) -
+        Math.abs(new Date(b.startAt).getTime() - nowMs)
+    )
+    .slice(0, limit)
+}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-search.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-search.tsx
@@ -1,0 +1,162 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useT } from '@memry/i18n/renderer'
+import { Search, X } from '@/lib/icons'
+import { calendarService, type CalendarProjectionItem } from '@/services/calendar-service'
+import { calendarRangeKeys } from '@/hooks/use-calendar-range'
+import { VISUAL_TYPE_META } from './visual-type-meta'
+import { filterCalendarItems } from './calendar-search-filter'
+
+const SEARCH_WINDOW_YEARS_PAST = 2
+const SEARCH_WINDOW_YEARS_FUTURE = 3
+
+interface CalendarSearchProps {
+  onJump: (item: CalendarProjectionItem) => void
+}
+
+export function CalendarSearch({ onJump }: CalendarSearchProps): React.JSX.Element {
+  const { t, i18n } = useT('calendar')
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  // Captured when search opens so proximity sorting stays stable across renders.
+  const [nowMs, setNowMs] = useState(0)
+
+  // ponytail: search scans a fixed ±-year window of the same projection the
+  // calendar renders. Widen the window or add a dedicated calendar FTS index if
+  // events ever fall outside it.
+  const range = useMemo(() => {
+    const now = new Date()
+    return {
+      startAt: new Date(now.getFullYear() - SEARCH_WINDOW_YEARS_PAST, 0, 1).toISOString(),
+      endAt: new Date(now.getFullYear() + SEARCH_WINDOW_YEARS_FUTURE, 0, 1).toISOString(),
+      includeUnselectedSources: true
+    }
+  }, [])
+
+  const rangeQuery = useQuery({
+    queryKey: calendarRangeKeys.range(range),
+    queryFn: () => calendarService.getRange(range),
+    enabled: open
+  })
+
+  const results = useMemo(
+    () => filterCalendarItems(rangeQuery.data?.items ?? [], query, nowMs),
+    [rangeQuery.data, query, nowMs]
+  )
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(i18n.language, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+      }),
+    [i18n.language]
+  )
+
+  const timeFormatter = useMemo(
+    () => new Intl.DateTimeFormat(i18n.language, { hour: 'numeric', minute: '2-digit' }),
+    [i18n.language]
+  )
+
+  const close = (): void => {
+    setOpen(false)
+    setQuery('')
+  }
+
+  const jump = (item: CalendarProjectionItem): void => {
+    onJump(item)
+    close()
+  }
+
+  const formatWhen = (item: CalendarProjectionItem): string => {
+    const start = new Date(item.startAt)
+    if (item.isAllDay) return dateFormatter.format(start)
+    return `${dateFormatter.format(start)} · ${timeFormatter.format(start)}`
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setNowMs(Date.now())
+          setOpen(true)
+        }}
+        className="flex size-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground"
+        aria-label={t('search.open')}
+      >
+        <Search className="size-4" />
+      </button>
+    )
+  }
+
+  return (
+    <div className="relative">
+      <div className="flex h-9 items-center gap-1.5 rounded-full border border-border bg-background ps-3 pe-1.5">
+        <Search className="size-4 shrink-0 text-muted-foreground" />
+        <input
+          autoFocus
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              close()
+            } else if (event.key === 'Enter' && results[0]) {
+              // ponytail: Enter jumps to the top match; arrow-key row navigation
+              // can be added if users ask for it.
+              jump(results[0])
+            }
+          }}
+          placeholder={t('search.placeholder')}
+          aria-label={t('search.open')}
+          className="w-44 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+        />
+        <button
+          type="button"
+          onClick={close}
+          className="flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground"
+          aria-label={t('search.close')}
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+
+      {query.trim() && (
+        <div className="absolute end-0 top-full z-50 mt-2 max-h-80 w-80 overflow-y-auto rounded-xl border border-border bg-popover p-1 shadow-lg">
+          {results.length === 0 ? (
+            <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+              {rangeQuery.isLoading ? t('state.preparing') : t('search.no-results')}
+            </p>
+          ) : (
+            results.map((item) => (
+              <button
+                key={item.projectionId}
+                type="button"
+                onClick={() => jump(item)}
+                className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-start transition-colors hover:bg-accent"
+              >
+                <span
+                  aria-hidden="true"
+                  className="size-2.5 shrink-0 rounded-full ring-1 ring-border"
+                  style={{ backgroundColor: VISUAL_TYPE_META[item.visualType].dotColor }}
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm text-foreground">
+                    {item.title || t('time.new-event')}
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {formatWhen(item)}
+                  </span>
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CalendarSearch

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-shell.test.tsx
@@ -228,6 +228,7 @@ function createProps(overrides: Partial<React.ComponentProps<typeof CalendarShel
     onNext: vi.fn(),
     onToday: vi.fn(),
     onCreateEvent: vi.fn(),
+    onSearchJump: vi.fn(),
     onToggleMemryItems: vi.fn(),
     onToggleImportedCalendars: vi.fn(),
     onToggleImportedSource: vi.fn(),

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
@@ -63,6 +63,7 @@ interface CalendarShellProps {
   onToday: () => void
   todayRequestKey?: number
   onCreateEvent: (anchorRect: AnchorRect) => void
+  onSearchJump: (item: CalendarProjectionItem) => void
   onToggleMemryItems: () => void
   onToggleImportedCalendars: () => void
   onToggleImportedSource: (sourceId: string) => void
@@ -109,6 +110,7 @@ export function CalendarShell({
   onToday,
   todayRequestKey,
   onCreateEvent,
+  onSearchJump,
   onToggleMemryItems,
   onToggleImportedCalendars,
   onToggleImportedSource,
@@ -264,6 +266,7 @@ export function CalendarShell({
         onNext={onNext}
         onToday={onToday}
         onCreateEvent={onCreateEvent}
+        onSearchJump={onSearchJump}
         extraActions={
           <>
             {refreshButton}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-toolbar.tsx
@@ -1,7 +1,9 @@
 import { useT } from '@memry/i18n/renderer'
 import { Button } from '@/components/ui/button'
-import { ChevronLeft, ChevronRight, Plus, Search } from '@/lib/icons'
+import { ChevronLeft, ChevronRight, Plus } from '@/lib/icons'
+import type { CalendarProjectionItem } from '@/services/calendar-service'
 import { addLocalDays, getStartOfWeek, parseLocalDate } from './date-utils'
+import { CalendarSearch } from './calendar-search'
 import type { AnchorRect } from './types'
 
 export type CalendarWorkspaceView = 'day' | 'week' | 'month' | 'year'
@@ -23,6 +25,7 @@ interface CalendarToolbarProps {
   onNext: () => void
   onToday: () => void
   onCreateEvent: (anchorRect: AnchorRect) => void
+  onSearchJump: (item: CalendarProjectionItem) => void
   extraActions?: React.ReactNode
 }
 
@@ -70,10 +73,10 @@ export function CalendarToolbar({
   onNext,
   onToday,
   onCreateEvent,
+  onSearchJump,
   extraActions
 }: CalendarToolbarProps): React.JSX.Element {
   const { t, i18n } = useT('calendar')
-  const { t: tCommon } = useT('common')
   const anchorParsed = parseLocalDate(anchorDate)
   const monthName = new Intl.DateTimeFormat(i18n.language, { month: 'long' }).format(anchorParsed)
   const yearStr = String(anchorParsed.getFullYear())
@@ -117,13 +120,7 @@ export function CalendarToolbar({
 
         <div className="flex items-center gap-1.5">
           {extraActions}
-          <button
-            type="button"
-            className="flex size-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground"
-            aria-label={tCommon('action.search')}
-          >
-            <Search className="size-4" />
-          </button>
+          <CalendarSearch onJump={onSearchJump} />
         </div>
       </div>
 

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -490,6 +490,20 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     setPendingPromote({ item, anchorRect: rect })
   }
 
+  // Search jump: focus the item's day, then open its popover. The item is already
+  // in hand from search, so selection happens immediately without waiting for the
+  // range refetch (mirrors the Agent-Chat calendar focus flow).
+  const handleSearchJump = (item: CalendarProjectionItem) => {
+    setView('day')
+    setAnchorDate(toLocalDateString(new Date(item.startAt)))
+    void handleSelectItem(item, {
+      x: window.innerWidth / 2,
+      y: Math.max(120, window.innerHeight / 3),
+      width: 1,
+      height: 1
+    })
+  }
+
   const handleNoteOpen = (noteId: string, anchorId?: string | null) => {
     const tCalendar = getI18n().getFixedT(null, 'calendar')
     setNotePopoverState(null)
@@ -716,6 +730,7 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
         onPrevious={handlePrevious}
         onNext={handleNext}
         onToday={handleToday}
+        onSearchJump={handleSearchJump}
         todayRequestKey={todayRequestKey}
         onCreateEvent={(anchorRect) =>
           setPopoverState({

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -30,6 +30,15 @@ clickable target for opening or editing events.
 | Journal entries                             | A small badge / dot on dates with entries |
 | Notes with a calendar-enabled date property | All-day note chips on the property's date |
 
+## Search
+
+Click the search icon in the toolbar to reveal a search box. Type to filter everything
+the calendar shows — events, tasks, reminders, notes, and snoozed inbox items — by title
+or description, regardless of which date you're currently viewing. Matches appear in a
+dropdown, sorted by how close they are to today. Selecting a result jumps the calendar to
+that item's day and opens its detail popover. Press `Enter` to jump to the top match or
+`Escape` to close.
+
 ## Quick Create
 
 Click an empty time slot (day / week views) or a date cell (month) to create an event inline. The popover lets you set:

--- a/packages/i18n/src/locales/en/calendar.json
+++ b/packages/i18n/src/locales/en/calendar.json
@@ -16,6 +16,12 @@
     "next-month": "Next month",
     "today": "Today"
   },
+  "search": {
+    "open": "Search calendar",
+    "close": "Close search",
+    "placeholder": "Search events, tasks, reminders…",
+    "no-results": "No matches"
+  },
   "filter": {
     "filter-calendars": "Filter calendars",
     "sources": "Sources",


### PR DESCRIPTION
## Problem

The calendar toolbar's search icon was a dead button — clicking it did nothing.

## What this does

Wires the icon to a real search:

- Click the icon → an inline input appears in the toolbar.
- Type → a dropdown filters **everything the calendar shows** (events, tasks, reminders, notes, snoozed inbox items) by title/description, **across all dates** — not just the current view's range.
- Results are sorted by temporal proximity to today.
- Click a result (or press `Enter` on the top match) → the calendar jumps to that item's day and opens its detail popover. `Escape` closes.

## How

- New `calendar-search.tsx` self-fetches the unified projection (`calendarService.getRange`) over a fixed ±-year window, gated to fire only when search opens. Pure filter/sort extracted to `calendar-search-filter.ts` (unit-tested).
- Jump reuses the existing focus flow on the calendar page: `setView('day')` + `setAnchorDate` + `handleSelectItem` (the same path Agent-Chat calendar focus uses), so each item type opens the correct popover.

## Verification

- `typecheck:web` ✅
- renderer tests ✅ (new filter test 4/4 + touched calendar tests)
- `eslint` clean on changed files ✅
- `i18n:check` ✅ (one new `search.*` key group, en)
- docs gate ✅ + `docs:build` ✅

GUI QA pending.