### PR TITLE
feat(desktop): broad native menu bar (About, Insert, Format, and more)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -771,6 +771,11 @@ void app.whenReady().then(async () => {
 
   mainI18n = await bootI18n()
   setMainI18n(mainI18n)
+  app.setAboutPanelOptions({
+    applicationName: 'MemryNote',
+    applicationVersion: app.getVersion(),
+    copyright: `© ${new Date().getFullYear()} MemryNote`
+  })
   Menu.setApplicationMenu(buildAppMenu(mainI18n))
 
   // Initialize telemetry runtime before handlers so registerTelemetryHandlers

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -1,6 +1,9 @@
-import { app, BrowserWindow, Menu, type MenuItemConstructorOptions } from 'electron'
+import { app, BrowserWindow, dialog, Menu, shell, type MenuItemConstructorOptions } from 'electron'
+import { AppChannels } from '@memry/contracts/ipc-channels'
 import type { I18nInstance } from '@memry/i18n/main'
 import { sendAppNavigationDirection } from './app-navigation-command'
+
+const DOCS_URL = 'https://memrynote.com'
 
 interface EditableContextMenuParams {
   isEditable?: boolean
@@ -21,25 +24,65 @@ function sendNavigationToFocusedWindow(direction: 'back' | 'forward'): void {
   sendAppNavigationDirection(window.webContents, direction)
 }
 
+/** Send a menu command to the focused window's renderer (see use-menu-commands.ts). */
+function sendMenuCommand(command: string): void {
+  const window = BrowserWindow.getFocusedWindow()
+  if (!window || window.webContents.isDestroyed()) return
+
+  window.webContents.send(AppChannels.events.MENU_COMMAND, { command })
+}
+
 export function buildAppMenu(i18n: I18nInstance): Menu {
   const t = i18n.getFixedT(null, 'menu')
+  const isMac = process.platform === 'darwin'
+
+  // Bridge item: a click that dispatches a command to the renderer. No
+  // accelerator — the renderer/editor already owns the shortcuts, so adding one
+  // here would double-fire.
+  const cmd = (command: string, label: string): MenuItemConstructorOptions => ({
+    label,
+    click: () => sendMenuCommand(command)
+  })
+
+  const aboutItem: MenuItemConstructorOptions =
+    process.platform === 'win32'
+      ? {
+          label: t('help.about'),
+          click: () =>
+            void dialog.showMessageBox({
+              type: 'info',
+              title: t('help.about'),
+              message: app.name,
+              detail: `Version ${app.getVersion()}`
+            })
+        }
+      : { role: 'about' }
 
   const template: MenuItemConstructorOptions[] = [
-    ...(process.platform === 'darwin'
+    ...(isMac
       ? [
           {
             label: app.name,
-            submenu: [{ label: t('app.quit'), role: 'quit' as const }]
+            submenu: [
+              { role: 'about' as const },
+              { type: 'separator' as const },
+              cmd('app.preferences', t('app.preferences')),
+              { type: 'separator' as const },
+              { role: 'services' as const },
+              { type: 'separator' as const },
+              { role: 'hide' as const },
+              { role: 'hideOthers' as const },
+              { role: 'unhide' as const },
+              { type: 'separator' as const },
+              { label: t('app.quit'), role: 'quit' as const }
+            ]
           }
         ]
       : []),
     {
       label: t('file.label'),
       submenu: [
-        {
-          label: t('file.newNote'),
-          accelerator: 'CmdOrCtrl+N'
-        },
+        cmd('file.newNote', t('file.newNote')),
         {
           label: t('navigation.back'),
           accelerator: 'CmdOrCtrl+[',
@@ -54,8 +97,13 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
           acceleratorWorksWhenHidden: true,
           click: () => sendNavigationToFocusedWindow('forward')
         },
+        cmd('file.openQuickly', t('file.openQuickly')),
         { type: 'separator' },
-        { label: t('file.close'), role: 'close' }
+        cmd('file.exportPdf', t('file.exportPdf')),
+        { type: 'separator' },
+        cmd('file.closeTab', t('file.closeTab')),
+        { label: t('file.close'), role: 'close' },
+        ...(isMac ? [] : [{ type: 'separator' as const }, { role: 'quit' as const }])
       ]
     },
     {
@@ -67,8 +115,48 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
         { label: t('edit.cut'), role: 'cut' },
         { label: t('edit.copy'), role: 'copy' },
         { label: t('edit.paste'), role: 'paste' },
+        { role: 'pasteAndMatchStyle' },
+        { role: 'delete' },
+        { label: t('edit.selectAll'), role: 'selectAll', accelerator: 'CmdOrCtrl+A' },
         { type: 'separator' },
-        { label: t('edit.selectAll'), role: 'selectAll', accelerator: 'CmdOrCtrl+A' }
+        cmd('edit.find', t('edit.find')),
+        ...(isMac
+          ? [
+              { type: 'separator' as const },
+              {
+                label: t('edit.speech'),
+                submenu: [{ role: 'startSpeaking' as const }, { role: 'stopSpeaking' as const }]
+              }
+            ]
+          : [])
+      ]
+    },
+    {
+      label: t('insert.label'),
+      submenu: [
+        cmd('insert.codeBlock', t('insert.codeBlock')),
+        cmd('insert.table', t('insert.table')),
+        { type: 'separator' },
+        cmd('insert.bulletList', t('insert.bulletList')),
+        cmd('insert.numberedList', t('insert.numberedList')),
+        cmd('insert.taskList', t('insert.taskList')),
+        { type: 'separator' },
+        cmd('insert.attachment', t('insert.attachment'))
+      ]
+    },
+    {
+      label: t('format.label'),
+      submenu: [
+        cmd('format.heading1', t('format.heading1')),
+        cmd('format.heading2', t('format.heading2')),
+        cmd('format.heading3', t('format.heading3')),
+        cmd('format.body', t('format.body')),
+        { type: 'separator' },
+        cmd('format.bold', t('format.bold')),
+        cmd('format.italic', t('format.italic')),
+        cmd('format.code', t('format.code')),
+        cmd('format.highlight', t('format.highlight')),
+        cmd('format.strikethrough', t('format.strikethrough'))
       ]
     },
     {
@@ -77,7 +165,34 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
         { label: t('view.reload'), role: 'reload' },
         { label: t('view.toggleDevTools'), role: 'toggleDevTools' },
         { type: 'separator' },
-        { label: t('view.toggleFullscreen'), role: 'togglefullscreen' }
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { label: t('view.toggleFullscreen'), role: 'togglefullscreen' },
+        { type: 'separator' },
+        cmd('view.toggleSidebar', t('view.toggleSidebar')),
+        cmd('view.toggleDayPanel', t('view.toggleDayPanel')),
+        { type: 'separator' },
+        {
+          label: t('view.theme'),
+          submenu: [
+            cmd('view.theme.light', t('view.themeLight')),
+            cmd('view.theme.dark', t('view.themeDark')),
+            cmd('view.theme.white', t('view.themeWhite')),
+            cmd('view.theme.system', t('view.themeSystem'))
+          ]
+        }
+      ]
+    },
+    { role: 'windowMenu', label: t('window.label') },
+    {
+      role: 'help',
+      label: t('help.label'),
+      submenu: [
+        ...(isMac ? [] : [aboutItem, { type: 'separator' as const }]),
+        { label: t('help.documentation'), click: () => void shell.openExternal(DOCS_URL) },
+        cmd('view.shortcuts', t('help.shortcuts'))
       ]
     }
   ]

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -3,7 +3,7 @@ import type { GeneratedRpcApi } from '@memry/rpc'
 import type * as InboxRpc from '@memry/rpc/inbox'
 import type * as NotesRpc from '@memry/rpc/notes'
 import type * as TasksRpc from '@memry/rpc/tasks'
-import type { AppNavigationCommandEvent } from '@memry/contracts/ipc-channels'
+import type { AppNavigationCommandEvent, AppMenuCommandEvent } from '@memry/contracts/ipc-channels'
 import type { AgentMcpStatus } from '@memry/contracts/agent-mcp-channels'
 import type {
   AgentEvent,
@@ -1871,6 +1871,7 @@ interface API extends WindowAPI, GeneratedRpcApi {
   onUpdaterStateChanged: (callback: (state: AppUpdateState) => void) => () => void
   onImportProgress: (callback: (event: ImportProgressEvent) => void) => () => void
   onAppNavigationCommand: (callback: (command: AppNavigationCommandEvent) => void) => () => void
+  onMenuCommand: (callback: (event: AppMenuCommandEvent) => void) => () => void
   onLocaleChanged: (callback: (locale: Locale) => void) => () => void
   onMainInvoke: (callback: (payload: MainInvokePayload) => void | Promise<void>) => () => void
   respondToMainInvoke: (requestId: string, response: unknown) => void

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -3,7 +3,8 @@ import { electronAPI } from '@electron-toolkit/preload'
 import {
   AppChannels,
   LocaleChannels,
-  type AppNavigationCommandEvent
+  type AppNavigationCommandEvent,
+  type AppMenuCommandEvent
 } from '@memry/contracts/ipc-channels'
 import type { Locale, LocaleApi } from '@memry/contracts/locale-api'
 import { createLogger } from './lib/logger'
@@ -117,6 +118,8 @@ export const api = {
 
   onAppNavigationCommand: (callback: (command: AppNavigationCommandEvent) => void) =>
     subscribe<AppNavigationCommandEvent>(AppChannels.events.NAVIGATION_COMMAND, callback),
+  onMenuCommand: (callback: (event: AppMenuCommandEvent) => void) =>
+    subscribe<AppMenuCommandEvent>(AppChannels.events.MENU_COMMAND, callback),
   onLocaleChanged: (callback: (locale: Locale) => void) =>
     subscribe<Locale>(LocaleChannels.Changed, callback),
   onMainInvoke: (callback: (payload: MainInvokePayload) => void | Promise<void>) =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -49,6 +49,7 @@ import { SettingsModalProvider, useSettingsModal } from '@/contexts/settings-mod
 import { SettingsModal } from '@/components/settings-modal'
 import { useFolderViewEvents } from '@/hooks/use-folder-view-events'
 import { useFlushOnQuit } from '@/hooks/use-flush-on-quit'
+import { useMenuCommands } from '@/hooks/use-menu-commands'
 import { tasksService, queueTaskReorder } from '@/services/tasks-service'
 import { notesService } from '@/services/notes-service'
 import { VaultOnboarding } from '@/components/vault-onboarding'
@@ -218,6 +219,10 @@ const AppContent = (): React.JSX.Element => {
   const toggleShortcutsDialog = useCallback(() => setShowShortcutsDialog((prev) => !prev), [])
   useSearchShortcut(toggleSearch)
   useHintActivation()
+  useMenuCommands({
+    onNewNote: () => void handleNewNote(),
+    onOpenSearch: () => setSearchOpen(true)
+  })
 
   useEffect(() => {
     const openSearch = () => setSearchOpen(true)

--- a/apps/desktop/src/renderer/src/hooks/use-menu-commands.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-menu-commands.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react'
+import { useTheme } from 'next-themes'
+import { useTabs, useActiveTab } from '@/contexts/tabs'
+import { useSidebar } from '@/components/ui/sidebar'
+import { useDayPanel } from '@/contexts/day-panel-context'
+import { useSettingsModal } from '@/contexts/settings-modal-context'
+import { isEditorMenuCommand, runEditorMenuCommand } from '@/lib/menu-commands'
+
+interface MenuCommandHandlers {
+  onNewNote: () => void
+  onOpenSearch: () => void
+}
+
+/**
+ * Routes native menu-bar commands (sent from the main process over
+ * `app:menu-command`) to existing renderer actions. Editor commands fall
+ * through to the focused BlockNote editor.
+ */
+export function useMenuCommands({ onNewNote, onOpenSearch }: MenuCommandHandlers): void {
+  const { closeTab } = useTabs()
+  const activeTab = useActiveTab()
+  const { toggleSidebar } = useSidebar()
+  const { toggle: toggleDayPanel } = useDayPanel()
+  const { open: openSettings } = useSettingsModal()
+  const { setTheme } = useTheme()
+
+  const handlers: Record<string, () => void> = {
+    'file.newNote': onNewNote,
+    'file.openQuickly': onOpenSearch,
+    'file.closeTab': () => activeTab && closeTab(activeTab.id),
+    'file.exportPdf': () => window.dispatchEvent(new CustomEvent('memry:menu-export')),
+    'edit.find': () => window.dispatchEvent(new CustomEvent('memry:menu-find')),
+    'app.preferences': () => openSettings(),
+    'view.toggleSidebar': toggleSidebar,
+    'view.toggleDayPanel': toggleDayPanel,
+    'view.shortcuts': () => window.dispatchEvent(new CustomEvent('memry:open-shortcuts')),
+    'view.theme.light': () => setTheme('light'),
+    'view.theme.dark': () => setTheme('dark'),
+    'view.theme.white': () => setTheme('white'),
+    'view.theme.system': () => setTheme('system')
+  }
+
+  // Keep the latest handlers in a ref so the IPC subscription stays stable.
+  const handlersRef = useRef(handlers)
+  useEffect(() => {
+    handlersRef.current = handlers
+  })
+
+  useEffect(() => {
+    return window.api.onMenuCommand(({ command }) => {
+      const handler = handlersRef.current[command]
+      if (handler) {
+        handler()
+        return
+      }
+      if (isEditorMenuCommand(command)) runEditorMenuCommand(command)
+    })
+  }, [])
+}

--- a/apps/desktop/src/renderer/src/lib/menu-commands.test.ts
+++ b/apps/desktop/src/renderer/src/lib/menu-commands.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyEditorMenuCommand, isEditorMenuCommand } from './menu-commands'
+
+function makeEditor(block: unknown = {}) {
+  return {
+    toggleStyles: vi.fn(),
+    getTextCursorPosition: () => ({ block }),
+    updateBlock: vi.fn(),
+    insertBlocks: vi.fn()
+  }
+}
+
+describe('applyEditorMenuCommand', () => {
+  it('toggles inline styles without needing a block', () => {
+    const editor = makeEditor()
+    expect(applyEditorMenuCommand(editor, 'format.bold')).toBe(true)
+    expect(editor.toggleStyles).toHaveBeenCalledWith({ bold: true })
+  })
+
+  it('converts the current block for headings', () => {
+    const block = { id: 'b1' }
+    const editor = makeEditor(block)
+    expect(applyEditorMenuCommand(editor, 'format.heading1')).toBe(true)
+    expect(editor.updateBlock).toHaveBeenCalledWith(block, {
+      type: 'heading',
+      props: { level: 1 }
+    })
+  })
+
+  it('converts the current block to a bullet list', () => {
+    const block = { id: 'b2' }
+    const editor = makeEditor(block)
+    applyEditorMenuCommand(editor, 'insert.bulletList')
+    expect(editor.updateBlock).toHaveBeenCalledWith(block, { type: 'bulletListItem' })
+  })
+
+  it('inserts a fresh table block after the cursor', () => {
+    const block = { id: 'b3' }
+    const editor = makeEditor(block)
+    expect(applyEditorMenuCommand(editor, 'insert.table')).toBe(true)
+    const [blocks, ref, placement] = editor.insertBlocks.mock.calls[0]
+    expect((blocks[0] as { type: string }).type).toBe('table')
+    expect(ref).toBe(block)
+    expect(placement).toBe('after')
+  })
+
+  it('returns false when no block is focused for a block command', () => {
+    const editor = { ...makeEditor(), getTextCursorPosition: () => undefined }
+    expect(applyEditorMenuCommand(editor, 'format.heading1')).toBe(false)
+  })
+
+  it('returns false for unknown commands', () => {
+    const editor = makeEditor()
+    expect(applyEditorMenuCommand(editor, 'file.newNote')).toBe(false)
+  })
+
+  it('classifies editor vs app commands', () => {
+    expect(isEditorMenuCommand('format.heading1')).toBe(true)
+    expect(isEditorMenuCommand('insert.table')).toBe(true)
+    expect(isEditorMenuCommand('format.highlight')).toBe(true)
+    expect(isEditorMenuCommand('file.newNote')).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/menu-commands.ts
+++ b/apps/desktop/src/renderer/src/lib/menu-commands.ts
@@ -1,0 +1,89 @@
+/**
+ * Editor menu-command dispatch.
+ *
+ * Maps native menu-bar command ids (Insert/Format) onto the focused BlockNote
+ * editor using its stable block-type API — block-type names match the schema,
+ * unlike slash-menu titles which are localized.
+ */
+
+// ponytail: targets the last-mounted note editor (window.__memryEditor); add
+// per-pane focus tracking only if split-view users hit the wrong editor.
+interface EditorLike {
+  toggleStyles: (styles: Record<string, unknown>) => void
+  getTextCursorPosition: () => { block: unknown } | undefined
+  updateBlock: (ref: unknown, update: { type: string; props?: Record<string, unknown> }) => void
+  insertBlocks: (blocks: unknown[], ref: unknown, placement: 'after') => void
+}
+
+const STYLE_COMMANDS: Record<string, Record<string, unknown>> = {
+  'format.bold': { bold: true },
+  'format.italic': { italic: true },
+  'format.code': { code: true },
+  'format.strikethrough': { strike: true },
+  'format.highlight': { backgroundColor: 'yellow' }
+}
+
+/** Convert the current block to a new type. */
+const BLOCK_TYPE_COMMANDS: Record<string, { type: string; props?: Record<string, unknown> }> = {
+  'format.heading1': { type: 'heading', props: { level: 1 } },
+  'format.heading2': { type: 'heading', props: { level: 2 } },
+  'format.heading3': { type: 'heading', props: { level: 3 } },
+  'format.body': { type: 'paragraph' },
+  'insert.bulletList': { type: 'bulletListItem' },
+  'insert.numberedList': { type: 'numberedListItem' },
+  'insert.taskList': { type: 'checkListItem' },
+  'insert.codeBlock': { type: 'codeBlock' }
+}
+
+/** Insert a fresh block after the current one. */
+const INSERT_BLOCK_COMMANDS: Record<string, unknown> = {
+  'insert.table': {
+    type: 'table',
+    content: { type: 'tableContent', rows: [{ cells: ['', ''] }, { cells: ['', ''] }] }
+  },
+  'insert.attachment': { type: 'image' }
+}
+
+export function isEditorMenuCommand(command: string): boolean {
+  return (
+    command in STYLE_COMMANDS || command in BLOCK_TYPE_COMMANDS || command in INSERT_BLOCK_COMMANDS
+  )
+}
+
+/** Pure mapping — takes an editor-like object so it is testable without BlockNote. */
+export function applyEditorMenuCommand(editor: EditorLike, command: string): boolean {
+  const styles = STYLE_COMMANDS[command]
+  if (styles) {
+    editor.toggleStyles(styles)
+    return true
+  }
+
+  const block = editor.getTextCursorPosition()?.block
+  if (!block) return false
+
+  const conversion = BLOCK_TYPE_COMMANDS[command]
+  if (conversion) {
+    editor.updateBlock(block, conversion)
+    return true
+  }
+
+  const insert = INSERT_BLOCK_COMMANDS[command]
+  if (insert) {
+    editor.insertBlocks([insert], block, 'after')
+    return true
+  }
+
+  return false
+}
+
+export function runEditorMenuCommand(command: string): void {
+  const editor = (window as unknown as { __memryEditor?: EditorLike & { focus?: () => void } })
+    .__memryEditor
+  if (!editor) return
+  try {
+    editor.focus?.()
+    applyEditorMenuCommand(editor, command)
+  } catch {
+    // Editor not ready or block-shape drift — fail quietly rather than crash the menu.
+  }
+}

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -279,6 +279,19 @@ export function NotePage({ noteId }: NotePageProps) {
     isActiveNote
   )
 
+  // Native menu bar: Edit > Find and File > Export to PDF target the active note.
+  useEffect(() => {
+    if (!isActiveNote) return
+    const onFind = (): void => findInPage.open()
+    const onExport = (): void => setIsExportDialogOpen(true)
+    window.addEventListener('memry:menu-find', onFind)
+    window.addEventListener('memry:menu-export', onExport)
+    return () => {
+      window.removeEventListener('memry:menu-find', onFind)
+      window.removeEventListener('memry:menu-export', onExport)
+    }
+  }, [isActiveNote, findInPage])
+
   // Content tracking for change detection
   if (storedNoteIdForContent !== noteId) {
     setStoredNoteIdForContent(noteId)

--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -146,6 +146,7 @@ function unifiedSidebar() {
           items: [
             { text: 'Settings Reference', link: '/user-guide/settings' },
             { text: 'CLI Reference', link: '/user-guide/cli-reference' },
+            { text: 'Menu Bar', link: '/user-guide/menu-bar' },
             { text: 'Keyboard Shortcuts', link: '/user-guide/keyboard-shortcuts' }
           ]
         }

--- a/apps/docs/src/user-guide/menu-bar.md
+++ b/apps/docs/src/user-guide/menu-bar.md
@@ -1,0 +1,42 @@
+# Menu Bar
+
+memrynote has a native application menu bar — on macOS it sits in the system
+menu bar, and on Windows and Linux it appears at the top of the window. Most
+items mirror actions you can already reach from the sidebar, tabs, command
+palette, or the editor's slash menu.
+
+## Menus
+
+- **App menu** (macOS only, named “memrynote”) — About, Settings, Hide/Show,
+  and Quit.
+- **File** — New Note, Open Quickly (the command palette), Export to PDF, Close
+  Tab, and Close Window. On Windows and Linux this menu also contains Quit.
+- **Edit** — Undo / Redo, Cut / Copy / Paste (including Paste and Match Style),
+  Delete, Select All, and Find. On macOS the system adds Speech, Start
+  Dictation, and Emoji & Symbols.
+- **Insert** — add a Code Block, Table, Bullet / Numbered / Task List, or an
+  attachment to the note you're editing.
+- **Format** — Heading 1–3 or Body for the current block, plus Bold, Italics,
+  Code, Highlight, and Strikethrough for the selected text.
+- **View** — Reload, Developer Tools, zoom, full screen, Toggle Sidebar, Toggle
+  Day Panel, and a Theme submenu (Light, Dark, Paper, System).
+- **Window** — standard window controls (minimize, zoom, front).
+- **Help** — About, Documentation, and Keyboard Shortcuts.
+
+## About
+
+The **About** entry opens the operating system's native about panel on macOS
+and Linux, and a simple dialog showing the version on Windows.
+
+## Insert and Format act on the focused note
+
+The **Insert** and **Format** menus operate on the note editor that currently
+has focus. If no note is open, those items do nothing. They produce the same
+result as the editor's slash (`/`) menu and formatting toolbar.
+
+## Keyboard shortcuts
+
+Menu items intentionally do not display keyboard shortcuts. Shortcuts are owned
+by the app itself (and are remappable), so they keep working whether or not you
+use the menu. See [Keyboard Shortcuts](/user-guide/keyboard-shortcuts) for the
+full list.

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -18,9 +18,14 @@ export interface AppNavigationCommandEvent {
   direction: AppNavigationDirection
 }
 
+export interface AppMenuCommandEvent {
+  command: string
+}
+
 export const AppChannels = {
   events: {
-    NAVIGATION_COMMAND: 'app:navigation-command'
+    NAVIGATION_COMMAND: 'app:navigation-command',
+    MENU_COMMAND: 'app:menu-command'
   }
 } as const
 

--- a/packages/i18n/src/locales/en/menu.json
+++ b/packages/i18n/src/locales/en/menu.json
@@ -1,10 +1,14 @@
 {
   "app": {
-    "quit": "Quit"
+    "quit": "Quit",
+    "preferences": "Settings…"
   },
   "file": {
     "label": "File",
     "newNote": "New Note",
+    "openQuickly": "Open Quickly…",
+    "exportPdf": "Export to PDF…",
+    "closeTab": "Close Tab",
     "close": "Close Window"
   },
   "navigation": {
@@ -18,12 +22,51 @@
     "cut": "Cut",
     "copy": "Copy",
     "paste": "Paste",
-    "selectAll": "Select All"
+    "selectAll": "Select All",
+    "find": "Find",
+    "speech": "Speech"
+  },
+  "insert": {
+    "label": "Insert",
+    "codeBlock": "Code Block",
+    "table": "Table",
+    "bulletList": "Bullet List",
+    "numberedList": "Numbered List",
+    "taskList": "Task List",
+    "attachment": "Insert Attachment…"
+  },
+  "format": {
+    "label": "Format",
+    "heading1": "Heading 1",
+    "heading2": "Heading 2",
+    "heading3": "Heading 3",
+    "body": "Body",
+    "bold": "Bold",
+    "italic": "Italics",
+    "code": "Code",
+    "highlight": "Highlight",
+    "strikethrough": "Strikethrough"
   },
   "view": {
     "label": "View",
     "reload": "Reload",
     "toggleDevTools": "Toggle Developer Tools",
-    "toggleFullscreen": "Toggle Full Screen"
+    "toggleFullscreen": "Toggle Full Screen",
+    "toggleSidebar": "Toggle Sidebar",
+    "toggleDayPanel": "Toggle Day Panel",
+    "theme": "Theme",
+    "themeLight": "Light",
+    "themeDark": "Dark",
+    "themeWhite": "Paper",
+    "themeSystem": "System"
+  },
+  "window": {
+    "label": "Window"
+  },
+  "help": {
+    "label": "Help",
+    "documentation": "Documentation",
+    "shortcuts": "Keyboard Shortcuts",
+    "about": "About MemryNote"
   }
 }


### PR DESCRIPTION
## What

Replaces the minimal 3-menu app menu (App/File/Edit/View with only Quit + a few roles) with a full native menu bar modeled on a reference markdown app: **App · File · Edit · Insert · Format · View · Window · Help**, including a native **About** panel.

## How

- **One bridge.** New `app:menu-command` IPC event (main → focused renderer), mirroring the existing `app:navigation-command` pattern. `useMenuCommands` (mounted in `AppContent`) routes each command to an action that already exists — new note, command palette, close tab, settings, toggle sidebar/day-panel, theme, shortcuts. Find and Export to PDF dispatch window events that the active note listens for.
- **Editor commands.** Insert/Format items drive the focused BlockNote editor through its stable `updateBlock` / `insertBlocks` / `toggleStyles` API (schema type names like `bulletListItem`, `codeBlock`), not localized slash-menu titles.
- **About.** `app.setAboutPanelOptions(...)` → native panel on macOS/Linux, dialog fallback on Windows.
- **Gaps fixed.** Adds **Quit on Windows/Linux** (previously only in the macOS app menu) and wires the previously inert **New Note** item.

## Design notes

- Bridge items deliberately carry **no accelerators** — the renderer/editor already owns those shortcuts, so adding menu accelerators would double-fire. Menu items therefore don't display shortcut hints (single source of truth stays in the app).
- Editor commands target `window.__memryEditor` (the last-mounted note editor). Fine for single-pane; per-pane focus tracking is a future enhancement if split-view users hit the wrong editor.

## Deferred (net-new, intentionally out of scope)

New Window/multi-window · Replace · Math Block · Footnote · editor Folding · Open Recent submenu · Share · Heading 4–6.

## Verification

- `menu-commands` unit test (7 cases) ✅
- `typecheck:web` / `typecheck:node` ✅
- `ipc:check` ✅ (event channel; no invoke-map regen) · eslint clean · `i18n:check` ✅
- `docs:impact --strict` covered · `docs:build` ✅

**Not yet done:** runtime GUI QA (launching Electron to click each item). Table and Attachment insert shapes are try/catch-guarded but unverified against BlockNote 0.47 at runtime — verify those two when QA'ing.