### PR TITLE
Upgrade React Doctor Action to v2

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: millionco/react-doctor@v1
+      - uses: millionco/react-doctor@v2
         with:
           # On push to `main` React Doctor scans the whole repo as an advisory
           # health-score trend, so it must not fail the run (several findings,


### PR DESCRIPTION
Bumps the React Doctor GitHub Actions workflow to the action's latest major, `millionco/react-doctor@v2`.

Docs: https://www.react.doctor/ci