### PR TITLE
fix(tests): restore green test suites

### DIFF
--- a/apps/cli/src/run.test.ts
+++ b/apps/cli/src/run.test.ts
@@ -1956,7 +1956,7 @@ test('runs core commands against a vault and prints JSON output', async () => {
     theme?: string
     language?: string
   }
-  assert.equal(generalSettings.theme, 'system')
+  assert.equal(generalSettings.theme, 'white')
   assert.equal(generalSettings.language, 'tr')
 
   const updateGroupCode = await runCli(

--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -233,7 +233,9 @@ vi.mock('./vault/file-ops', () => ({
 }))
 
 vi.mock('./updater', () => ({
-  initializeUpdater: initializeUpdaterMock
+  initializeUpdater: initializeUpdaterMock,
+  isQuitAndInstallRequested: vi.fn(() => false),
+  performQuitAndInstall: vi.fn()
 }))
 
 vi.mock('./app-navigation-command', () => ({

--- a/apps/desktop/src/main/ipc/settings-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.test.ts
@@ -966,7 +966,7 @@ describe('settings-handlers', () => {
       )
 
       expect(result).toEqual({
-        theme: 'system',
+        theme: 'white',
         accentColor: GENERAL_SETTINGS_DEFAULTS.accentColor
       })
     })

--- a/apps/desktop/src/main/projections/projectors/embedding-projector.test.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.test.ts
@@ -52,6 +52,7 @@ vi.mock('electron', () => ({
 }))
 
 import { createEmbeddingProjector } from './embedding-projector'
+import { EMBEDDING_INPUT_VERSION } from '../../lib/embedding-input'
 
 describe('embedding projector', () => {
   beforeEach(() => {
@@ -81,6 +82,12 @@ describe('embedding projector', () => {
   it('reconcile removes embeddings for notes that no longer exist', async () => {
     const run = vi.fn()
     const prepare = vi.fn(() => ({ run }))
+
+    // Embedding input version already current → skip the migration rebuild and
+    // exercise only the stale-row reconcile delete.
+    getSetting.mockImplementation((_db: unknown, key: string) =>
+      key === 'ai.embeddingInputVersion' ? String(EMBEDDING_INPUT_VERSION) : 'true'
+    )
 
     getRawIndexDatabase.mockReturnValue({ prepare })
     getIndexDatabase.mockReturnValue({

--- a/apps/desktop/src/main/vault/settings-cache.test.ts
+++ b/apps/desktop/src/main/vault/settings-cache.test.ts
@@ -88,7 +88,7 @@ describe('populateSettingsCacheFromConfig', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const generalRaw = getSetting(testDb.db as any, 'general')
     const general = JSON.parse(generalRaw!)
-    expect(general.theme).toBe('system')
+    expect(general.theme).toBe(GENERAL_SETTINGS_DEFAULTS.theme)
     expect(general.accentColor).toBe(GENERAL_SETTINGS_DEFAULTS.accentColor)
   })
 
@@ -202,7 +202,7 @@ describe('migrateSettingsToConfig', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const generalRaw = getSetting(testDb.db as any, 'general')
     const general = JSON.parse(generalRaw!)
-    expect(general.theme).toBe('system')
+    expect(general.theme).toBe(GENERAL_SETTINGS_DEFAULTS.theme)
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
@@ -30,6 +30,10 @@ vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({ t: (key: string) => key.split('.').at(-1) ?? key })
 }))
 
+vi.mock('@/components/onboarding/use-first-run-tour', () => ({
+  useFirstRunTour: () => {}
+}))
+
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
@@ -175,6 +179,10 @@ vi.mock('@/components/sidebar/sidebar-drill-down-container', () => ({
 
 vi.mock('@/components/sidebar/sidebar-update-button', () => ({
   SidebarUpdateButton: () => null
+}))
+
+vi.mock('@/components/sidebar/sidebar-feedback-button', () => ({
+  SidebarFeedbackButton: () => null
 }))
 
 vi.mock('@/contexts/selected-folder-context', () => ({

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
@@ -34,7 +34,8 @@ const {
   mockUseActiveTab: vi.fn()
 }))
 
-vi.mock('@/hooks/use-calendar-range', () => ({
+vi.mock('@/hooks/use-calendar-range', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks/use-calendar-range')>()),
   useCalendarRange: mockUseCalendarRange
 }))
 

--- a/apps/desktop/src/renderer/src/components/cold-major-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/cold-major-components.test.tsx
@@ -723,7 +723,11 @@ describe('cold major renderer components', () => {
       expect.objectContaining({ value: '2026-05-10T00:00:00.000Z' })
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '' }))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'phaseF.componentsFolderViewFilterRow.removeFilter'
+      })
+    )
     expect(onRemove).toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.test.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-table-view.test.tsx
@@ -198,10 +198,12 @@ describe('FolderTableView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Work' }))
     expect(onFolderClick).toHaveBeenCalledWith('Work')
 
-    fireEvent.click(screen.getByRole('button', { name: /#work/ }))
+    fireEvent.click(screen.getByRole('option', { name: 'work' }))
     expect(onTagClick).toHaveBeenCalledWith('work')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Remove tag alpha' }))
+    const alphaTag = screen.getByRole('option', { name: 'alpha' })
+    fireEvent.mouseEnter(alphaTag)
+    fireEvent.click(screen.getByRole('button', { name: 'removeAria' }))
     expect(onTagRemove).toHaveBeenCalledWith('note-1', 'alpha')
 
     fireEvent.click(screen.getByRole('button', { name: 'Title' }))

--- a/apps/desktop/src/renderer/src/components/notes-tree-isolated.test.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree-isolated.test.tsx
@@ -288,6 +288,7 @@ const createActions = (overrides: Record<string, unknown> = {}) => ({
   handleSetFolderTemplate: vi.fn(),
   handleClearFolderTemplate: vi.fn(),
   setIconPickerFolderPath: vi.fn(),
+  setIconPickerNoteId: vi.fn(),
   handleRenameFolderClick: vi.fn(),
   handleDeleteFolderClick: vi.fn(),
   handleOpenFolderView: vi.fn(),
@@ -374,7 +375,7 @@ describe('NotesTree isolated coverage', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'set folder icon' })[0])
     fireEvent.click(screen.getAllByRole('button', { name: 'open icon picker' })[0])
     fireEvent.click(screen.getAllByRole('button', { name: 'close icon picker' })[0])
-    expect(mocks.actions.handleOpenFolderView).toHaveBeenCalledWith('Work')
+    expect(mocks.actions.handleOpenFolderView).toHaveBeenCalledWith('Work', 'star')
     expect(mocks.data.setFolderIcon).toHaveBeenCalledWith('Work', 'rocket')
     expect(mocks.actions.setIconPickerFolderPath).toHaveBeenCalledWith(null)
 

--- a/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/more-major-hooks.test.tsx
@@ -127,6 +127,10 @@ vi.mock('./use-is-item-active', () => ({
   useIsItemActive: () => mocks.activeItem
 }))
 
+vi.mock('@/contexts/settings-modal-context', () => ({
+  useSettingsModal: () => ({ open: vi.fn() })
+}))
+
 import { DENSITY_CONFIG, densityClasses, useDisplayDensity } from './use-display-density'
 import { useInboxNotifications } from './use-inbox-notifications'
 import { useMonthEntries } from './use-journal-month'

--- a/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
@@ -365,7 +365,8 @@ vi.mock('@/lib/logger', () => ({
 vi.mock('react-i18next', () => ({
   getI18n: () => ({
     getFixedT: () => (key: string) => key
-  })
+  }),
+  useTranslation: () => ({ t: (key: string) => key })
 }))
 
 function renderPage(): ReturnType<typeof render> {

--- a/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-quick-create.test.tsx
@@ -24,7 +24,8 @@ const {
   mockOpenTab: vi.fn()
 }))
 
-vi.mock('@/hooks/use-calendar-range', () => ({
+vi.mock('@/hooks/use-calendar-range', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks/use-calendar-range')>()),
   useCalendarRange: mockUseCalendarRange
 }))
 

--- a/apps/desktop/src/renderer/src/pages/calendar.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.test.tsx
@@ -10,6 +10,7 @@ import {
   type TabType
 } from '@/contexts/tabs'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
+import { SettingsModalProvider } from '@/contexts/settings-modal-context'
 import { SidebarNav } from '@/components/sidebar/sidebar-nav'
 import { NewTabMenu } from '@/components/tabs/new-tab-menu'
 import { TabContent } from '@/components/split-view/tab-content'
@@ -130,6 +131,7 @@ function SidebarCalendarHarness() {
           }
         ]}
         isActive={() => false}
+        isDisabled={() => false}
         onNavClick={() => () => openSidebarItem(CALENDAR_ITEM)}
         inboxCount={0}
         todayTasksCount={0}
@@ -178,11 +180,13 @@ describe('Calendar workspace navigation', () => {
     const user = userEvent.setup()
 
     renderWithProviders(
-      <SidebarProvider>
-        <TabProvider>
-          <SidebarCalendarHarness />
-        </TabProvider>
-      </SidebarProvider>
+      <SettingsModalProvider>
+        <SidebarProvider>
+          <TabProvider>
+            <SidebarCalendarHarness />
+          </TabProvider>
+        </SidebarProvider>
+      </SettingsModalProvider>
     )
 
     await user.click(screen.getByRole('button', { name: 'Split' }))

--- a/apps/desktop/src/renderer/src/pages/home.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/home.test.tsx
@@ -5,6 +5,11 @@ import HomePage from './home'
 // Stub the widgets barrel (Task 9 fills this)
 vi.mock('@/components/home/widgets', () => ({}))
 
+// HomePage reads openTab from the tabs context; no TabProvider in this test
+vi.mock('@/contexts/tabs', () => ({
+  useTabs: () => ({ openTab: vi.fn() })
+}))
+
 // Stub child components to avoid dnd-kit / WIDGET_REGISTRY / react-query deps
 vi.mock('@/components/home/home-header', () => ({
   HomeHeader: () => null

--- a/packages/app-core/src/memry-app.test.ts
+++ b/packages/app-core/src/memry-app.test.ts
@@ -643,7 +643,7 @@ test('opens a standalone vault and exposes core note, journal, task, inbox, and 
     toolbarMode: 'sticky'
   })
   assert.deepEqual(await app.settings.getGroup('general'), {
-    theme: 'system',
+    theme: 'white',
     fontSize: 'medium',
     fontFamily: 'system',
     accentColor: '#6366f1',

--- a/packages/contracts/src/bookmark-types.test.ts
+++ b/packages/contracts/src/bookmark-types.test.ts
@@ -11,6 +11,8 @@ describe('BookmarkItemTypes', () => {
       NOTE: 'note',
       JOURNAL: 'journal',
       TASK: 'task',
+      FOLDER: 'folder',
+      TAG: 'tag',
       IMAGE: 'image',
       PDF: 'pdf',
       AUDIO: 'audio',
@@ -25,6 +27,8 @@ describe('BookmarkItemTypes', () => {
       BookmarkItemTypes.NOTE,
       BookmarkItemTypes.JOURNAL,
       BookmarkItemTypes.TASK,
+      BookmarkItemTypes.FOLDER,
+      BookmarkItemTypes.TAG,
       BookmarkItemTypes.IMAGE,
       BookmarkItemTypes.PDF,
       BookmarkItemTypes.AUDIO,
@@ -32,7 +36,7 @@ describe('BookmarkItemTypes', () => {
       BookmarkItemTypes.CANVAS,
       BookmarkItemTypes.FILE
     ]
-    expect(values).toHaveLength(9)
+    expect(values).toHaveLength(11)
   })
 
   it('values are unique lowercase strings', () => {

--- a/packages/rpc/src/index.test.ts
+++ b/packages/rpc/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   defineDomain,
   defineEvent,
   defineMethod,
+  feedbackRpc,
   inboxRpc,
   notesRpc,
   rpcDomains,
@@ -12,7 +13,7 @@ import {
   telemetryRpc
 } from './index.ts'
 
-const DOMAINS_WITHOUT_EVENTS = new Set(['telemetry'])
+const DOMAINS_WITHOUT_EVENTS = new Set(['telemetry', 'feedback'])
 
 describe('@memry/rpc public surface', () => {
   it('re-exports the schema factories', () => {
@@ -28,19 +29,21 @@ describe('@memry/rpc public surface', () => {
     expect(settingsRpc.name).toBe('settings')
     expect(calendarRpc.name).toBe('calendar')
     expect(telemetryRpc.name).toBe('telemetry')
+    expect(feedbackRpc.name).toBe('feedback')
   })
 })
 
 describe('rpcDomains aggregate', () => {
-  it('contains exactly the six known domains in declaration order', () => {
-    expect(rpcDomains).toHaveLength(6)
+  it('contains exactly the seven known domains in declaration order', () => {
+    expect(rpcDomains).toHaveLength(7)
     expect(rpcDomains.map((d) => d.name)).toEqual([
       'notes',
       'tasks',
       'inbox',
       'settings',
       'calendar',
-      'telemetry'
+      'telemetry',
+      'feedback'
     ])
   })
 


### PR DESCRIPTION
## What

Repairs test drift across the suite so all tests pass again. Source had evolved on `main`; tests and mocks lagged. **All changes are test-side only — no app source was modified.** Categories: missing `vi.mock` exports, missing providers, drifted prop/callback signatures, and stale assertions.

## Verification

- Single-fork desktop (authoritative — suite SIGSEGVs under parallel workers, environmental):
  `pnpm exec vitest run --config config/vitest.config.ts --no-file-parallelism`
  → **10378 passed | 7 skipped | 0 failed**, exit 0, 0 unhandled errors.
- `@memry/app-core` 7/7, `@memry/cli` 5/5, `@memry/sync-server` 639/639, `@memry/contracts` and `@memry/rpc` exit 0.
- Prettier clean; `git diff --check` clean.

## Each failure → root cause → fix

**Pre-existing partial progress (theme default `white`, bookmark FOLDER/TAG types, feedback rpc domain):** `apps/cli/src/run.test.ts`, `apps/desktop/src/main/ipc/settings-handlers.test.ts`, `apps/desktop/src/main/vault/settings-cache.test.ts`, `packages/app-core/src/memry-app.test.ts`, `packages/contracts/src/bookmark-types.test.ts`, `packages/rpc/src/index.test.ts`.

**Desktop drift fixed in this session (36 failures + 4 unhandled errors):**

- `components/calendar/calendar-page.test.tsx` (15) + `pages/calendar-quick-create.test.tsx` (5): `calendar-search.tsx` / `use-calendar-mutations.ts` now import `calendarRangeKeys` from `@/hooks/use-calendar-range`, but the mock only exported `useCalendarRange`. Fix: spread `importOriginal()` into the mock factory so the real `calendarRangeKeys` key-builder is preserved.
- `pages/calendar-callbacks.test.tsx` (3): `use-undo.ts` now calls `useT('common')` → `useTranslation`. The `react-i18next` mock only exported `getI18n`. Fix: add `useTranslation: () => ({ t: (k) => k })`.
- `components/app-sidebar.test.tsx` (4): `AppSidebar` now calls `useFirstRunTour` (→ `useDayPanel`) and renders `SidebarFeedbackButton` (→ `useAppUpdater` → `window.api.updater`). Fix: mock `use-first-run-tour` to a no-op (onboarding is out of scope for this test) and mock `sidebar-feedback-button` to `() => null` (mirrors the existing `sidebar-update-button` mock).
- `pages/calendar.test.tsx` (1): `useSidebarNavigation` now calls `useSettingsModal`; `SidebarNav` gained a required `isDisabled` prop. Fix: wrap the harness in the real `SettingsModalProvider` and pass `isDisabled={() => false}`.
- `pages/home.test.tsx` (1): `HomePage` now reads `openTab` from `useTabs`; no `TabProvider` in this test. Fix: mock `@/contexts/tabs` with `useTabs: () => ({ openTab: vi.fn() })`.
- `hooks/more-major-hooks.test.tsx` (1): same `useSidebarNavigation` → `useSettingsModal` dependency. Fix: mock `@/contexts/settings-modal-context`.
- `main/index.phase2.test.ts` (2): shutdown paths now gate on `isQuitAndInstallRequested()` from `./updater`; the mock lacked it. Fix: add `isQuitAndInstallRequested: vi.fn(() => false)` and `performQuitAndInstall: vi.fn()` so the `app.exit(1)` branch runs.
- `main/projections/projectors/embedding-projector.test.ts` (1): `reconcile()` gained a version-migration rebuild step; the test's blanket `getSetting → 'true'` made the stored embedding version mismatch the current one, triggering an extra rebuild `DELETE` (second `run` call). Fix: key-aware `getSetting` returning the current `EMBEDDING_INPUT_VERSION` for the version key, so only the reconcile delete runs.
- `components/notes-tree-isolated.test.tsx` (1 assertion + 4 unhandled errors): `handleOpenFolderView` now receives `(path, icon)` — updated assertion to `('Work', 'star')`. The actions mock was missing `setIconPickerNoteId` (called by the note icon picker), surfacing as 4 unhandled `TypeError`s; added `setIconPickerNoteId: vi.fn()`.
- `components/folder-view/folder-table-view.test.tsx` (1): the tags cell was refactored onto the shared `TagChip` — clickable tag is now `role="option"` named `work` (no `#` prefix), and remove is hover-revealed (aria-label resolves to `removeAria` under the test's last-segment i18n mock). Updated the tag-click and tag-remove interactions accordingly.
- `components/cold-major-components.test.tsx` (1): `FilterRow`'s remove button gained an `aria-label` (`phaseF.componentsFolderViewFilterRow.removeFilter`); it is no longer nameless. Updated the query to its accessible name.

## Environmental notes

- The desktop vitest suite SIGSEGVs under parallel workers in this environment — unrelated to test logic. The single-fork command above is the authoritative check and is fully green (0 failed, 0 unhandled errors). No tests were skipped to achieve green; the 7 pre-existing skips are unchanged.
