### PR TITLE
feat(extension): popup theme toggle + brand-colored clipper UI

### DIFF
--- a/apps/extension/src/components/EditableTitle.tsx
+++ b/apps/extension/src/components/EditableTitle.tsx
@@ -19,7 +19,7 @@ export function EditableTitle({
         if (e.key === 'Enter') e.preventDefault()
       }}
       placeholder="Untitled"
-      className="w-full resize-none bg-transparent font-sans text-[19px] font-medium leading-snug tracking-[-0.01em] text-foreground outline-none [field-sizing:content] placeholder:font-normal placeholder:text-text-tertiary"
+      className="w-full resize-none bg-transparent font-sans text-[14px] font-semibold leading-snug tracking-[-0.01em] text-foreground outline-none [field-sizing:content] placeholder:font-normal placeholder:text-text-tertiary"
     />
   )
 }

--- a/apps/extension/src/components/PrimaryButton.tsx
+++ b/apps/extension/src/components/PrimaryButton.tsx
@@ -14,11 +14,11 @@ export function PrimaryButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-[13.5px] font-medium text-primary-foreground shadow-sm transition-[transform,background-color,opacity] duration-[130ms] ease-[var(--ease-out)] hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/25 active:scale-[0.985] disabled:opacity-50 disabled:active:scale-100"
+      className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand/85 px-4 py-2.5 text-[13.5px] font-medium text-white shadow-sm transition-[transform,background-color,opacity] duration-[130ms] ease-[var(--ease-out)] hover:bg-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 active:scale-[0.985] disabled:opacity-50 disabled:active:scale-100"
     >
       <span>{label}</span>
       {hint && (
-        <kbd className="rounded bg-primary-foreground/15 px-1.5 py-0.5 font-sans text-[10px] font-medium text-primary-foreground/80">
+        <kbd className="rounded bg-white/15 px-1.5 py-0.5 font-sans text-[10px] font-medium text-white/80">
           {hint}
         </kbd>
       )}

--- a/apps/extension/src/components/ThemeToggle.tsx
+++ b/apps/extension/src/components/ThemeToggle.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+
+type Theme = 'light' | 'dark'
+
+const STORAGE_KEY = 'memry-theme'
+
+function systemTheme(): Theme {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function storedTheme(): Theme {
+  const saved = localStorage.getItem(STORAGE_KEY)
+  return saved === 'light' || saved === 'dark' ? saved : systemTheme()
+}
+
+// Called once in main.tsx before render so a saved choice paints with no flash.
+export function applyStoredTheme(): void {
+  const saved = localStorage.getItem(STORAGE_KEY)
+  if (saved === 'light' || saved === 'dark') document.documentElement.dataset.theme = saved
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>(storedTheme)
+  const isDark = theme === 'dark'
+
+  const toggle = () => {
+    const next: Theme = isDark ? 'light' : 'dark'
+    setTheme(next)
+    document.documentElement.dataset.theme = next
+    localStorage.setItem(STORAGE_KEY, next)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      title={isDark ? 'Switch to light' : 'Switch to dark'}
+      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      className="-me-1 grid size-7 place-items-center rounded-md text-brand/70 transition-colors hover:bg-surface-active hover:text-brand"
+    >
+      {isDark ? (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          className="size-4"
+          aria-hidden
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path
+            d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
+            strokeLinecap="round"
+          />
+        </svg>
+      ) : (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          className="size-4"
+          aria-hidden
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" strokeLinejoin="round" />
+        </svg>
+      )}
+    </button>
+  )
+}

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -11,8 +11,8 @@ import { initialState, reducer, selectPhase } from '@/lib/popup-state'
 import { EditableTitle } from '@/components/EditableTitle'
 import { PropertyRows } from '@/components/PropertyRows'
 import { TagEditor } from '@/components/TagEditor'
-import { Excerpt } from '@/components/Excerpt'
 import { PrimaryButton } from '@/components/PrimaryButton'
+import { ThemeToggle } from '@/components/ThemeToggle'
 
 const isMac = navigator.platform.toLowerCase().includes('mac')
 const SUBMIT_HINT = isMac ? '⌘ ↵' : 'Ctrl ↵'
@@ -135,13 +135,16 @@ export default function App() {
             memrynote
           </span>
         </div>
-        {state.connection !== 'app-closed' && (
-          <div className="flex items-center gap-1.5" title={status.label}>
-            <span className={`size-1.5 rounded-full ${status.tone}`} aria-hidden />
-            <span className="text-[11px] font-medium text-text-tertiary">Inbox</span>
-            <span className="sr-only">{status.label}</span>
-          </div>
-        )}
+        <div className="flex items-center gap-2">
+          {state.connection !== 'app-closed' && (
+            <div className="flex items-center gap-1.5" title={status.label}>
+              <span className={`size-1.5 rounded-full ${status.tone}`} aria-hidden />
+              <span className="text-[11px] font-medium text-text-tertiary">Inbox</span>
+              <span className="sr-only">{status.label}</span>
+            </div>
+          )}
+          <ThemeToggle />
+        </div>
       </header>
 
       <main className="flex-1 overflow-y-auto">
@@ -222,8 +225,6 @@ export default function App() {
                     Couldn't read the article — saving the link and title.
                   </p>
                 )}
-
-                <Excerpt text={draft.excerpt} />
 
                 <TagEditor
                   tags={draft.tags ?? []}

--- a/apps/extension/src/entrypoints/popup/main.tsx
+++ b/apps/extension/src/entrypoints/popup/main.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { applyStoredTheme } from '@/components/ThemeToggle'
 import './tokens.css'
+
+applyStoredTheme()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/apps/extension/src/entrypoints/popup/tokens.css
+++ b/apps/extension/src/entrypoints/popup/tokens.css
@@ -40,8 +40,9 @@
   color-scheme: light;
 }
 
+/* System dark applies only when the user hasn't picked a theme manually. */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --bg: #181919;
     --surface: #202020;
     --surface-strong: #1d1e1e;
@@ -57,6 +58,24 @@
     --ready: #7b9e87;
     color-scheme: dark;
   }
+}
+
+/* Manual dark override (set via the header theme toggle). Light = :root default. */
+:root[data-theme='dark'] {
+  --bg: #181919;
+  --surface: #202020;
+  --surface-strong: #1d1e1e;
+  --surface-active: #2a2a2a;
+  --fg: #e9e7e2;
+  --text-secondary: #bcbab6;
+  --text-tertiary: #989590;
+  --border: #2c2c2c;
+  --primary: #e9e7e2;
+  --primary-hover: #ffffff;
+  --primary-foreground: #191919;
+  --brand: #ff7a36;
+  --ready: #7b9e87;
+  color-scheme: dark;
 }
 
 html,


### PR DESCRIPTION
## What

Popup (Web Clipper) UI polish:

- **Theme toggle** in the header (sun/moon). Persists to `localStorage`, applied before render so there's no flash. Defaults to the OS preference until the user picks a theme; `prefers-color-scheme` now only applies when no manual choice is set (`:root:not([data-theme])`).
- **Brand-colored buttons** — soft terracotta (`--brand` token) for the theme toggle and the *Send to memrynote* button instead of black/white.
- **Smaller capture title** — one clear step above body text, not a heading-sized block.
- **Removed the read-only excerpt** from the capture card.

## Scope

Extension popup only — 6 files. Pre-existing store-publishing prep (version bump, submit script, MemryNote rebrand, publish workflow) is intentionally **not** in this PR.

## Verify

- `npx tsc --noEmit` — clean.