### PR TITLE
fix(updater): break the auto-update restart/install loop

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -142,6 +142,7 @@ vi.mock('./ipc/settings-handlers', () => ({
 
 vi.mock('./vault', () => ({
   autoOpenLastVault: autoOpenLastVaultMock,
+  beginVaultShutdown: vi.fn(),
   closeVault: closeVaultMock,
   getStatus: getVaultStatusMock,
   onVaultStatusChanged: onVaultStatusChangedMock
@@ -1182,6 +1183,59 @@ describe('main index phase2 exports', () => {
     expect(disposeTelemetryRuntimeMock).toHaveBeenCalled()
     expect(stopSyncRuntimeMock).toHaveBeenCalled()
     expect(closeVaultMock).toHaveBeenCalled()
+  })
+
+  it('terminates via app.quit (not app.exit) after graceful shutdown so update-on-quit can run', async () => {
+    vi.useFakeTimers()
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+    const { app } = await import('electron')
+
+    const beforeQuitHandler = appOnMock.mock.calls.find(
+      ([event]) => event === 'before-quit'
+    )?.[1] as (event: { preventDefault: () => void }) => void
+    beforeQuitHandler({ preventDefault: vi.fn() })
+
+    const flushHandler = ipcMainOnMock.mock.calls.find(
+      ([event]) => event === 'app:flush-done'
+    )?.[1] as () => void
+    flushHandler()
+    for (let i = 0; i < 25; i++) {
+      await Promise.resolve()
+    }
+
+    expect(app.quit).toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
+  })
+
+  it('hands off to performQuitAndInstall when an update install was requested', async () => {
+    vi.useFakeTimers()
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+    const { app } = await import('electron')
+    const updater = await import('./updater')
+    vi.mocked(updater.isQuitAndInstallRequested).mockReturnValueOnce(true)
+
+    const beforeQuitHandler = appOnMock.mock.calls.find(
+      ([event]) => event === 'before-quit'
+    )?.[1] as (event: { preventDefault: () => void }) => void
+    beforeQuitHandler({ preventDefault: vi.fn() })
+
+    const flushHandler = ipcMainOnMock.mock.calls.find(
+      ([event]) => event === 'app:flush-done'
+    )?.[1] as () => void
+    flushHandler()
+    for (let i = 0; i < 25; i++) {
+      await Promise.resolve()
+    }
+
+    expect(updater.performQuitAndInstall).toHaveBeenCalled()
+    expect(app.quit).not.toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
   })
 
   it('creates close snapshots for open CRDT notes during graceful shutdown', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -27,6 +27,7 @@ import { registerAllHandlers } from './ipc'
 import { applyGlobalCaptureShortcut } from './ipc/settings-handlers'
 import {
   autoOpenLastVault,
+  beginVaultShutdown,
   closeVault,
   getStatus as getVaultStatus,
   onVaultStatusChanged
@@ -1270,6 +1271,11 @@ app.on('before-quit', (event) => {
 
   event.preventDefault()
 
+  // Stop broadcasting vault status to the renderer: the window is on its way
+  // out, and a closeVault() during cleanup would otherwise flip the UI to the
+  // vault picker (isOpen:false) right before the app quits/installs.
+  beginVaultShutdown()
+
   shutdownLog.info('starting graceful shutdown...')
 
   // Set timeout to force exit if shutdown takes too long
@@ -1335,7 +1341,12 @@ app.on('before-quit', (event) => {
         shutdownLog.info('installing downloaded update and relaunching')
         performQuitAndInstall()
       } else {
-        app.exit(0)
+        // Quit (not app.exit) so the `quit` event fires. app.exit() bypasses it,
+        // which silently disables electron-updater's autoInstallOnAppQuit — a
+        // downloaded-but-not-yet-installed update would never apply on a normal
+        // quit. The re-entrant before-quit returns early (isShuttingDown), so
+        // this completes the quit instead of re-running cleanup.
+        app.quit()
       }
     })
     .catch((error) => {

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -76,7 +76,17 @@ let currentStatus: VaultStatus = {
 }
 let agentHandle: AgentHandle | null = null
 let agentStartupPromise: Promise<void> | null = null
+let isShuttingDown = false
 const statusListeners = new Set<(status: VaultStatus) => void>()
+
+/**
+ * Mark the app as shutting down so vault status changes (e.g. closeVault during
+ * graceful shutdown) stop reaching the renderer. Prevents the UI flipping to the
+ * vault picker while the app is quitting/installing an update.
+ */
+export function beginVaultShutdown(): void {
+  isShuttingDown = true
+}
 
 export function onVaultStatusChanged(listener: (status: VaultStatus) => void): () => void {
   statusListeners.add(listener)
@@ -170,6 +180,7 @@ export function updateStatus(updates: Partial<VaultStatus>): void {
  */
 function emitStatusChanged(): void {
   statusListeners.forEach((listener) => listener(currentStatus))
+  if (isShuttingDown) return
   BrowserWindow.getAllWindows().forEach((win) => {
     win.webContents.send('vault:status-changed', currentStatus)
   })


### PR DESCRIPTION
## Problem

After downloading an update, clicking **Restart** did not relaunch the app. Instead the window flipped to the **vault picker**, the app stayed alive, and a second Restart click quit without installing. Reopening still offered the same update — an infinite loop, the app never updated.

## Root cause

The install was routed through the generic graceful-shutdown path, which had three compounding defects (PR #570 fixed the install handoff but not these):

1. **`app.exit(0)` on the normal-quit branch** skips the `quit` event, which silently disables electron-updater's `autoInstallOnAppQuit` (`BaseUpdater.addQuitHandler` hooks `app.onQuit`). A downloaded update could never install on a normal quit.
2. **`closeVault()` during shutdown** broadcast `isOpen:false` to the renderer, flipping the UI to the vault picker mid-restart (single window resizes to picker size).
3. The explicit `performQuitAndInstall()` path was kept, but combined with the above the app could end up alive on the picker with no way to recover in-session.

## Fix

- `apps/desktop/src/main/index.ts`: before-quit normal branch `app.exit(0)` → `app.quit()` so the `quit` event fires and a downloaded update installs on any normal quit. The re-entrant before-quit returns early on `isShuttingDown` (no `preventDefault`), so the quit still completes.
- `apps/desktop/src/main/vault/index.ts`: new `beginVaultShutdown()`; `emitStatusChanged()` stops the renderer `vault:status-changed` broadcast once shutdown begins, called at the start of before-quit → no more picker flip.
- Keep the explicit `performQuitAndInstall()` path for signed builds.

## Tests

- New main-process tests: terminates via `app.quit` (not `app.exit`); hands off to `performQuitAndInstall` when an install was requested.
- Full desktop main suite green (3286 pass / 0 fail) after `rebuild:node`; `typecheck:node` + eslint clean.

## Verification note

The final Squirrel.Mac bundle swap is `app.isPackaged`-only and can't be unit-tested. The logic above is verifiable locally (see testing recipe); a signed build is only needed to confirm the actual on-disk swap. A broken release can only be repaired by the next release (updater bootstrap), so this lands the correct behavior going forward.