### PR TITLE
chore: remove external product style references from comments and docs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -127,7 +127,7 @@ carried by beige paper (#f6f5f0), near-black ink (#1a1a1a), and editorial serifs
 not by decoration.
 
 The palette runs three theme bodies from one set of token names: **Warm** (default,
-beige paper), **White** (Notion-clean, cooler neutrals), and **Dark** (neutral
+beige paper), **White** (clean, cooler neutrals), and **Dark** (neutral
 charcoal #191919, muted warm text). Brand identity is carried by a single warm
 accent — **terracotta #ff671a** — used sparingly and deliberately. Inside the app,
 each user owns their own accent via a runtime `--tint` (default indigo #6366f1) for

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Memry is the opposite bet:
 - **Agent-native.** Bring your own model — Claude CLI, Codex CLI, local LLMs, or OpenAI-compatible endpoints. The agent gets read/write access to your vault through a localhost MCP server.
 - **One app, six surfaces.** Notes, tasks, projects, daily journal, calendar, inbox — instead of stitching seven tools together.
 
-Built for people who want Obsidian's local-first ethos, Notion's range, and an AI that actually knows what they're working on.
+Built for people who want a local-first, private home with room for everything they think about — and an AI that actually knows what they're working on.
 
 ## Features
 

--- a/apps/desktop/scripts/seed-data/notes.ts
+++ b/apps/desktop/scripts/seed-data/notes.ts
@@ -1298,7 +1298,7 @@ People who already journal but resent their tool. Bonus: programmers, researcher
 ## Anti-patterns
 
 - No paid ads. Not yet.
-- No "Notion alternative" framing. We are *not* Notion.
+- No "cheaper alternative" framing. We stand on our own.
 
 #projects/memry #gtm
 `

--- a/apps/desktop/src/main/database/queries/notes/journal-queries.ts
+++ b/apps/desktop/src/main/database/queries/notes/journal-queries.ts
@@ -9,7 +9,7 @@ import { getJournalConfig } from '@main/vault/journal-config'
 // Journal Entry Utilities
 //
 // A journal entry is a direct child of the configured journal folder whose
-// filename matches the configured Obsidian-style date format. Config comes from
+// filename matches the configured journal date format. Config comes from
 // the journal-config holder, kept in sync by the vault's getConfig().
 // ============================================================================
 

--- a/apps/desktop/src/main/import/_shared/html-to-markdown.ts
+++ b/apps/desktop/src/main/import/_shared/html-to-markdown.ts
@@ -1,7 +1,7 @@
 /**
  * Generic jsdom-based HTML → Markdown converter shared across importers.
  *
- * Extracted from the Notion importer's hand-rolled converter so HTML, Evernote,
+ * Extracted from an existing importer's hand-rolled converter so HTML, Evernote,
  * Apple Journal and OneNote can reuse one DOM walker. Source-specific behaviour
  * (wikilink resolution, attachment lookup, blocks to drop) is supplied through
  * {@link HtmlToMarkdownHooks}; with no hooks the converter emits portable
@@ -61,7 +61,7 @@ export function percentDecodeRef(ref: string): string {
   }
 }
 
-/** Strip leading `../` segments and percent-decode a local ref (Notion layout). */
+/** Strip leading `../` segments and percent-decode a local ref (export layout). */
 export function decodeRef(ref: string): string {
   return percentDecodeRef(ref.replace(/^(\.\.\/)+/, ''))
 }

--- a/apps/desktop/src/main/import/_shared/zip.ts
+++ b/apps/desktop/src/main/import/_shared/zip.ts
@@ -27,7 +27,7 @@ export function assertSafeEntryPath(entryPath: string): void {
 
 /**
  * Iterate every file entry across the given zip files, recursing into a nested
- * `.zip` only when it sits at the root of its parent archive (Notion exports
+ * `.zip` only when it sits at the root of its parent archive (some exports
  * wrap content in `Export-….zip → …-Part-N.zip`). Non-root zips are treated as
  * ordinary attachments and surfaced as entries.
  */

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -147,7 +147,7 @@ export function registerAllHandlers(deps?: IpcDeps): void {
   // Register Agent MCP settings/status handlers
   registerAgentMcpHandlers()
 
-  // Register generic import handlers (Notion + future importers)
+  // Register generic import handlers
   registerImportHandlers()
 
   // Register home page handlers

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -116,7 +116,7 @@
 }
 
 /* ===== PROSEMIRROR OVERRIDES ===== */
-/* ProseMirror disables ligatures by default — re-enable for Notion-like text density */
+/* ProseMirror disables ligatures by default — re-enable for denser text */
 :root .bn-editor .ProseMirror {
   font-variant-ligatures: normal;
   font-feature-settings: normal;
@@ -415,7 +415,7 @@
   pointer-events: auto;
 }
 
-/* Notion-style review canvas: the content column stays centered at its max
+/* Review canvas: the content column stays centered at its max
    width; when the rail is visible the whole content + gap + rail group is
    centered as a unit by shifting the column with an animated transform. */
 .review-canvas {
@@ -2407,7 +2407,7 @@ del.bn-inline-content {
   opacity: 0.8;
 }
 
-/* Link mention — Notion-style inline token: favicon + site name + title.
+/* Link mention — inline token: favicon + site name + title.
    The `.bn-shadcn .bn-editor a` prefix is required to beat BlockNote's
    `.bn-shadcn .bn-editor a { color: revert; text-decoration: revert }`,
    which otherwise paints the whole token browser-default blue/underlined. */
@@ -2458,7 +2458,7 @@ del.bn-inline-content {
   text-decoration-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
 }
 
-/* Date mention — Notion-style inline date/reminder token: dimmed `@` +
+/* Date mention — inline date/reminder token: dimmed `@` +
    relative label (Today/Tomorrow/…). A date-only pill (data-remind="none") is
    muted and label-only. When a reminder is set the pill turns blue and gains an
    alarm icon — blue + the alarm read as the reminder affordance (matches

--- a/apps/desktop/src/renderer/src/components/folder-view/index.ts
+++ b/apps/desktop/src/renderer/src/components/folder-view/index.ts
@@ -1,7 +1,7 @@
 /**
  * Folder View Components
  *
- * Obsidian Bases-like database view for folders.
+ * Database view for folders.
  * Displays notes in a table format with sortable columns and filters.
  */
 

--- a/apps/desktop/src/renderer/src/components/inbox-detail/inbox-content-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/inbox-detail/inbox-content-editor.tsx
@@ -39,7 +39,7 @@ interface InboxContentEditorProps {
  * InboxContentEditor - BlockNote-based rich text editor for inbox items
  *
  * Features:
- * - Block-based editing (Notion-style)
+ * - Block-based editing
  * - Slash commands for inserting blocks
  * - Formatting toolbar on text selection
  * - Auto-saves on content change

--- a/apps/desktop/src/renderer/src/components/note/content-area/callout-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/callout-block.tsx
@@ -185,7 +185,7 @@ export function getCalloutSlashMenuItem(
 }
 
 // ============================================================================
-// Callout Block Serialization (Obsidian-style: > [!type]\n> content)
+// Callout Block Serialization (> [!type]\n> content)
 // ============================================================================
 
 // Matches a callout block: starts with > [!type], followed by consecutive > lines

--- a/apps/desktop/src/renderer/src/components/note/content-area/critic-markup-offset-map.integration.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/critic-markup-offset-map.integration.test.ts
@@ -200,13 +200,13 @@ const INLINE_ATOM_FIXTURES: Array<{
     ]
   },
   {
-    annotated: '⟦1. ⟧HN post ⟦[[⟧Conference Talk⟦]]⟧ for version\n\n⟦2. ⟧second item ends Notion.',
+    annotated: '⟦1. ⟧HN post ⟦[[⟧Conference Talk⟦]]⟧ for version\n\n⟦2. ⟧second item ends here.',
     blocks: [
       {
         type: 'numberedListItem',
         content: ['HN post ', createWikiLinkInlineContent('Conference Talk', ''), ' for version']
       },
-      { type: 'numberedListItem', content: ['second item ends Notion.'] }
+      { type: 'numberedListItem', content: ['second item ends here.'] }
     ]
   },
   {

--- a/apps/desktop/src/renderer/src/components/note/content-area/date-mention-options.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/date-mention-options.ts
@@ -1,6 +1,6 @@
 import { type RemindOffset } from '@memry/shared/date-mention'
 
-// The Remind option list is dynamic on `hasTime` — matching Notion. With no
+// The Remind option list is dynamic on `hasTime`. With no
 // time, sub-hour offsets are meaningless and "at" reads as "On day of event".
 export function remindOptions(
   hasTime: boolean

--- a/apps/desktop/src/renderer/src/components/note/content-area/date-mention.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/date-mention.tsx
@@ -9,7 +9,7 @@ import {
 } from '@memry/shared/date-mention'
 import { formatTimeOfDay, type ClockFormat } from '@/lib/time-format'
 
-// Notion-style inline alarm icon (raw DOM render, so SVG markup rather than the
+// Inline alarm icon (raw DOM render, so SVG markup rather than the
 // React icon component). Only reminder pills show it; a date-only pill renders
 // label-only. Stroke uses currentColor → inherits the pill's blue.
 const ALARM_SVG =
@@ -39,7 +39,7 @@ function absoluteDate(d: Date): string {
   return `${d.getDate()} ${month}, ${d.getFullYear()}`
 }
 
-// Notion-style relative day. Future: Today / Tomorrow / This <Weekday> /
+// Relative day. Future: Today / Tomorrow / This <Weekday> /
 // Next <Weekday>. Past mirrors it: Yesterday / bare weekday earlier this week /
 // Last <Weekday>. Anything further out falls back to an absolute date.
 function formatRelativeDay(d: Date, now: Date, weekStartsOn: 0 | 1): string {

--- a/apps/desktop/src/renderer/src/components/note/note-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-layout.tsx
@@ -73,7 +73,7 @@ export function NoteLayout({
   })
 
   // Full width keeps the reserved grid column; otherwise the rail hangs off the
-  // centered content column and the group is shifted Notion-style.
+  // centered content column and the group is shifted as a unit.
   const showGridRail = hasSideRail && fullWidth
   const showCanvasRail = hasSideRail && !fullWidth && !railHidden
   const canvasStyle = showGridRail

--- a/apps/desktop/src/renderer/src/components/note/review/review-badge-layer.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-badge-layer.tsx
@@ -37,7 +37,7 @@ const PANEL_ANCHOR_GAP = 4
 const DRAFT_HIGHLIGHT_NAME = 'critic-comment-draft'
 
 /**
- * Notion-style fallback for narrow windows: when the review rail no longer
+ * Fallback for narrow windows: when the review rail no longer
  * fits, each block containing review marks gets an inline badge (icon +
  * count) at its logical end. Clicking the badge or the marked text opens a
  * flyout panel under the anchor listing the block's review cards.

--- a/apps/desktop/src/renderer/src/hooks/use-review-rail-shift.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-review-rail-shift.ts
@@ -22,7 +22,7 @@ interface ReviewRailShiftResult {
 }
 
 /**
- * Notion-style review rail shift: content stays centered at its max width and,
+ * Review rail shift: content stays centered at its max width and,
  * when the rail is visible, the whole content + gap + rail group is centered as
  * a unit by shifting the content column left with a transform. The shift clamps
  * so the content's inline-start edge keeps at least MIN_PAD, and the rail hides

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -569,7 +569,7 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
     fullWidth: isFullWidth
   })
   // Full width keeps the reserved grid column; otherwise the rail hangs off the
-  // centered content column and the group is shifted Notion-style.
+  // centered content column and the group is shifted as a unit.
   const showGridRail = hasReviewContent && isFullWidth
   const showCanvasRail = hasReviewContent && !isFullWidth && !railHidden
   const handleContentChange = useCallback((_newBlocks: Block[]) => {}, [])

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -11,7 +11,7 @@ Tailwind v4 `@theme inline` maps every CSS variable to a Tailwind utility class.
 | Theme | Selector | Character |
 |-------|----------|-----------|
 | Warm (default) | `:root` | Beige paper, warm greys, near-black text |
-| White | `.white` | Notion-inspired clean white, cooler neutrals |
+| White | `.white` | Clean white, cooler neutrals |
 | Dark | `.dark` | Neutral charcoal, muted warm text |
 
 User-customizable accent via `--tint` derived from `--user-accent-color` with `color-mix()`.

--- a/packages/contracts/src/vault-api.ts
+++ b/packages/contracts/src/vault-api.ts
@@ -51,7 +51,7 @@ export interface VaultConfig {
   /** Default folder for newly created notes; '' = vault root */
   defaultNoteFolder: string
   journalFolder: string
-  /** Obsidian-style date format for journal filenames (e.g. 'YYYY-MM-DD') */
+  /** Configurable date format for journal filenames (e.g. 'YYYY-MM-DD') */
   journalDateFormat: string
   attachmentsFolder: string
 }

--- a/packages/importers/src/apple-notes/convert-doc.ts
+++ b/packages/importers/src/apple-notes/convert-doc.ts
@@ -1,7 +1,7 @@
 /**
  * Convert a decoded Apple Notes document into Markdown.
  *
- * Ported in spirit from the Obsidian Apple Notes importer's NoteConverter, but
+ * Ported in spirit from the Three Planets Software Apple Notes importer's NoteConverter, but
  * scoped to v1: text formatting (headings, bold/italic, strikethrough, lists,
  * checkboxes, monospace, blockquote, links) plus inline image attachments.
  *

--- a/packages/importers/src/apple-notes/descriptor.ts
+++ b/packages/importers/src/apple-notes/descriptor.ts
@@ -1,7 +1,7 @@
 /**
  * protobufjs JSON descriptor for the Apple Notes note body.
  *
- * Ported from the Obsidian Apple Notes importer (MIT, Three Planets Software).
+ * Ported from the Three Planets Software Apple Notes importer (MIT).
  * Only the message graph reachable from `ciofecaforensics.Document` is kept,
  * which is everything required to decode a note body (Document → Note →
  * AttributeRun → ParagraphStyle/Font/Color/AttachmentInfo). The mergeable-data

--- a/packages/storage-vault/src/journal-format.ts
+++ b/packages/storage-vault/src/journal-format.ts
@@ -1,5 +1,5 @@
 /**
- * Obsidian-style journal filename date formats.
+ * Journal filename date formats.
  *
  * A journal (daily note) filename is derived from a date using a format string
  * built from these tokens:

--- a/packages/storage-vault/src/note-content-store.ts
+++ b/packages/storage-vault/src/note-content-store.ts
@@ -7,7 +7,7 @@ export interface VaultStoreLayout {
   rootPath: string
   notesFolder: string
   journalFolder: string
-  /** Obsidian-style date format for journal filenames; defaults to YYYY-MM-DD */
+  /** Configurable date format for journal filenames; defaults to YYYY-MM-DD */
   journalDateFormat?: string
 }
 


### PR DESCRIPTION
## What

Reworded code comments, two design-doc lines, and one seed note that described our own UI and features by analogy to external note-taking products. They now describe the behavior on its own terms. No functional change.

## Why

We don't want the codebase framing our features as clones of other products. Comparison-style comments ("X-style", "X-inspired", "matching X") get reworded to plain descriptions.

## Scope

- 17 files, 21 lines — comments, docs, and one seed string only. Zero logic change.
- Renderer comments (editor, date mention, review rail, folder view, callouts, base CSS), contracts, storage-vault, journal queries.
- Design docs and one seed-data GTM note.

## Kept intentionally

- Functional vault-exclusion paths and journal date-format presets — real interop behavior, not style references.
- The import package plus its integration registry and labels — importing from external products is a shipped feature.
- Landing and marketing content that references other products on purpose (positioning/SEO).

## Verify

- No remaining style-descriptor references in product code.
- `git diff --check` clean. Edits are comments/strings, so typecheck is unaffected.
