### PR TITLE
ci(release): auto-bump Homebrew cask on publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -790,3 +790,74 @@ jobs:
           console.log(`Published ${release.name}: ${release.url}`)
           console.log(`Assets: ${release.assets.length}`)
           NODE
+
+  update-homebrew-tap:
+    name: Bump Homebrew cask
+    needs:
+      - setup-release
+      - publish-release
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Generate and push cask
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with contents:write on memrynote/homebrew-tap; GITHUB_TOKEN cannot
+          # write to a different repo.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ needs.setup-release.outputs.tag }}
+          APP_VERSION: ${{ needs.setup-release.outputs.app_version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOMEBREW_TAP_TOKEN:-}" ]; then
+            echo "::error::Set HOMEBREW_TAP_TOKEN (PAT with contents:write on memrynote/homebrew-tap) to auto-bump the cask."
+            exit 1
+          fi
+
+          work="$RUNNER_TEMP/cask"
+          mkdir -p "$work"
+
+          # Names the cask url will resolve to; if electron-builder ever renames
+          # the DMG, gh release download fails loudly here instead of shipping a
+          # 404 cask.
+          arm_dmg="Memrynote-${APP_VERSION}-arm64.dmg"
+          x64_dmg="Memrynote-${APP_VERSION}-x64.dmg"
+
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern "$arm_dmg" --pattern "$x64_dmg" --dir "$work" --clobber
+
+          sha_arm="$(sha256sum "$work/$arm_dmg" | cut -d' ' -f1)"
+          sha_x64="$(sha256sum "$work/$x64_dmg" | cut -d' ' -f1)"
+
+          node scripts/generate-homebrew-cask.mjs \
+            --tag "$TAG" \
+            --app-version "$APP_VERSION" \
+            --sha-arm "$sha_arm" \
+            --sha-x64 "$sha_x64" \
+            > "$work/memry.rb"
+
+          git clone --depth 1 \
+            "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/memrynote/homebrew-tap.git" \
+            "$work/tap"
+          cp "$work/memry.rb" "$work/tap/Casks/memry.rb"
+
+          cd "$work/tap"
+          git config user.name "memry-release-bot"
+          git config user.email "release-bot@memrynote.com"
+          git add Casks/memry.rb
+          if git diff --staged --quiet; then
+            echo "Cask already up to date for ${TAG}."
+          else
+            git commit -m "chore: bump memry cask to ${TAG}"
+            git push
+          fi

--- a/scripts/generate-homebrew-cask.mjs
+++ b/scripts/generate-homebrew-cask.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// Renders the Homebrew cask for MemryNote from release inputs so publish-release
+// can push it to memrynote/homebrew-tap on every release (no manual brew edits).
+//
+// Usage:
+//   node scripts/generate-homebrew-cask.mjs \
+//     --tag v2026-07-01.2 --app-version 2026.701.2 --sha-arm <hex> --sha-x64 <hex>
+//   node scripts/generate-homebrew-cask.mjs --selfcheck
+import assert from 'node:assert/strict'
+
+export function renderCask({ tag, appVersion, shaArm, shaX64 }) {
+  for (const [field, value] of Object.entries({ tag, appVersion, shaArm, shaX64 })) {
+    if (!value) throw new Error(`Missing required field: ${field}`)
+  }
+  assert.match(shaArm, /^[0-9a-f]{64}$/, 'sha-arm must be a 64-char hex sha256')
+  assert.match(shaX64, /^[0-9a-f]{64}$/, 'sha-x64 must be a 64-char hex sha256')
+
+  // csv.first drives the /v<tag>/ download path; csv.second drives the DMG
+  // filename (Memrynote-<appVersion>-<arch>.dmg). Keep both interpolations so the
+  // cask stays a single source of truth even when hand-inspected.
+  const tagVersion = tag.replace(/^v/, '')
+
+  return `cask "memry" do
+  arch arm: "arm64", intel: "x64"
+
+  version "${tagVersion},${appVersion}"
+  sha256 arm:   "${shaArm}",
+         intel: "${shaX64}"
+
+  url "https://github.com/memrynote/memry/releases/download/v#{version.csv.first}/Memrynote-#{version.csv.second}-#{arch}.dmg",
+      verified: "github.com/memrynote/memry/"
+  name "Memrynote"
+  desc "Local-first notes, tasks, and projects"
+  homepage "https://memrynote.com/"
+
+  livecheck do
+    url :url
+    regex(%r{/v?(\\d{4}-\\d{2}-\\d{2}(?:\\.\\d+)?)/Memry(?:note)?[._-]?v?(\\d+(?:\\.\\d+)+)[._-]#{arch}\\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
+    end
+  end
+
+  depends_on macos: :monterey
+
+  app "Memry.app"
+
+  zap trash: [
+    "~/Library/Application Support/Memry",
+    "~/Library/Caches/com.memrynote.memry",
+    "~/Library/Logs/Memry",
+    "~/Library/Preferences/com.memrynote.memry.plist",
+    "~/Library/Saved Application State/com.memrynote.memry.savedState",
+  ]
+end
+`
+}
+
+function parseArgs(argv) {
+  const args = {}
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i]
+    if (!flag.startsWith('--')) continue
+    if (flag === '--selfcheck') {
+      args.selfcheck = true
+      continue
+    }
+    args[flag.slice(2)] = argv[++i]
+  }
+  return args
+}
+
+function selfcheck() {
+  const out = renderCask({
+    tag: 'v2026-07-01.2',
+    appVersion: '2026.701.2',
+    shaArm: 'a'.repeat(64),
+    shaX64: 'b'.repeat(64)
+  })
+  assert.match(out, /version "2026-07-01\.2,2026\.701\.2"/)
+  // The whole reason this exists: url must use the Memrynote- asset prefix.
+  assert.match(out, /Memrynote-#\{version\.csv\.second\}-#\{arch\}\.dmg/)
+  assert.ok(!/Memry-#\{version\.csv\.second\}/.test(out), 'url must not use stale Memry- prefix')
+  assert.match(out, /arm:\s+"a{64}"/)
+  assert.match(out, /intel:\s+"b{64}"/)
+  // Regex backslashes must survive templating (JS drops unknown escapes).
+  assert.match(out, /\\d\{4\}-\\d\{2\}-\\d\{2\}/)
+  assert.throws(() =>
+    renderCask({ tag: 'v1', appVersion: '', shaArm: 'a'.repeat(64), shaX64: 'b'.repeat(64) })
+  )
+  assert.throws(() =>
+    renderCask({ tag: 'v1', appVersion: '1', shaArm: 'nothex', shaX64: 'b'.repeat(64) })
+  )
+  console.log('selfcheck ok')
+}
+
+const args = parseArgs(process.argv.slice(2))
+if (args.selfcheck) {
+  selfcheck()
+} else {
+  process.stdout.write(
+    renderCask({
+      tag: args.tag,
+      appVersion: args['app-version'],
+      shaArm: args['sha-arm'],
+      shaX64: args['sha-x64']
+    })
+  )
+}


### PR DESCRIPTION
## Why

`brew install --cask memrynote/tap/memry` served a stale build (`2026-05-16`) because nothing bumped the tap cask after a release — the cask was hand-added once and never updated. On top of that the cask's `url` still hardcoded the old `Memry-` DMG prefix while releases now ship `Memrynote-` assets, so a naive version bump would 404.

## What

- **`scripts/generate-homebrew-cask.mjs`** — pure generator that renders the cask from `--tag`, `--app-version`, `--sha-arm`, `--sha-x64`. Fixes the `Memry-`→`Memrynote-` url prefix and pins version + both sha256. Includes `--selfcheck` (asserts the prefix fix and that regex backslashes survive JS templating).
- **`update-homebrew-tap` job** in `publish-release.yml` — after publish (skipped on dry-run): downloads both release DMGs, sha256s them, regenerates the cask, and pushes to `memrynote/homebrew-tap`. Every future release self-bumps; no manual brew edits.

The live cask was already bumped to `v2026-07-01.2` out-of-band so `brew install` returns latest today; this PR makes it automatic going forward.

## Required before it runs

Add repo secret **`HOMEBREW_TAP_TOKEN`** — a PAT with **Contents: Read and write** on `memrynote/homebrew-tap` (`GITHUB_TOKEN` cannot write to a different repo). Without it the job fails loudly but the release still publishes.

## Verification

- `node scripts/generate-homebrew-cask.mjs --selfcheck` → `selfcheck ok`
- Rendered cask's download URLs HEAD-checked against the live release → HTTP 200 (both arches)
- Workflow YAML parses; new job `update-homebrew-tap` present