### PR TITLE
Revert #654: restore working build to unblock macOS releases

### DIFF
--- a/apps/desktop/config/electron-builder.staged-local-mac.yml
+++ b/apps/desktop/config/electron-builder.staged-local-mac.yml
@@ -3,7 +3,20 @@ beforeBuild: ./scripts/before-build-external-node-modules.cjs
 npmRebuild: true
 dmg:
   size: 3g
-# node_modules is packed into app.asar by the base config (natives unpacked via
-# asarUnpack), not copied loose here — this is what cuts Squirrel's per-file
-# install verification from ~2min to seconds. app-config is inherited from
-# local-mac.yml's extraResources.
+extraResources:
+  - from: app-config
+    to: app-config
+  - from: node_modules
+    to: node_modules
+    filter:
+      - '**/*'
+      - '.pnpm'
+      - '.pnpm/**/*'
+      - '.modules.yaml'
+      - '!**/*.map'
+      - '!**/{coverage,doc,docs,example,examples,test,tests,__tests__}/**'
+      - '!**/re2/vendor/**'
+      - '!electron'
+      - '!electron/**/*'
+      - '!**/node_modules/electron'
+      - '!**/node_modules/electron/**/*'

--- a/apps/desktop/config/electron-builder.staged.yml
+++ b/apps/desktop/config/electron-builder.staged.yml
@@ -3,7 +3,28 @@ beforeBuild: ./scripts/before-build-external-node-modules.cjs
 npmRebuild: true
 dmg:
   size: 3g
-# node_modules is no longer copied loose as extraResources. The base config packs
-# it into app.asar (natives unpacked via asarUnpack) so macOS Squirrel verifies a
-# handful of sealed files at install time instead of ~40k loose ones. app-config
-# is inherited from the base config's extraResources (declared once there).
+# app-config is declared once in the base config (config/electron-builder.yml).
+# Re-declaring it here survives electron-builder's extends-merge as a DUPLICATE:
+# deepAssign concats the extraResources arrays and its `new Set()` dedup compares
+# object identity, so two distinct {from,to} objects both remain. electron-builder
+# then copies app-config to the same destination twice concurrently — POSIX
+# tolerates it, but Windows' file lock throws "EBUSY: resource busy or locked" and
+# kills the release. Only add the staged-specific node_modules here.
+extraResources:
+  - from: node_modules
+    to: node_modules
+    filter:
+      - '**/*'
+      - '.pnpm'
+      - '.pnpm/**/*'
+      - '.modules.yaml'
+      - '!**/*.map'
+      - '!**/*.a'
+      - '!**/*.o'
+      - '!**/{coverage,doc,docs,example,examples,test,tests,__tests__}/**'
+      - '!**/re2/vendor/**'
+      - '!**/build/Release/obj.target/**'
+      - '!electron'
+      - '!electron/**/*'
+      - '!**/node_modules/electron'
+      - '!**/node_modules/electron/**/*'

--- a/apps/desktop/config/electron-builder.yml
+++ b/apps/desktop/config/electron-builder.yml
@@ -23,32 +23,8 @@ files:
   - '!**/*.tsbuildinfo'
   - '!node_modules/**/*.map'
   - '!node_modules/**/{coverage,doc,docs,example,examples,test,tests,__tests__}/**'
-  # node_modules is now packed into app.asar; carry over the prune filters the
-  # loose-copy config used so build artifacts and unused vendor source stay out
-  # of the archive (smaller asar, fewer sealed files).
-  - '!node_modules/**/*.{a,o}'
-  - '!node_modules/**/re2/vendor/**'
-  - '!node_modules/**/build/Release/obj.target/**'
-  # Electron is a devDependency and must never be packed into the app; the
-  # production deploy tree should not contain it, but guard against leakage.
-  - '!node_modules/electron/**'
-  - '!node_modules/**/node_modules/electron/**'
 asarUnpack:
   - resources/**
-  # Native modules load their .node / .dylib by absolute path (dlopen /
-  # sqlite loadExtension), which cannot resolve inside the asar archive. Unpack
-  # each native package whole so its JS __dirname and its companion binary stay
-  # co-located under app.asar.unpacked (a bare '**/*.node' would leave dylibs
-  # like libvips / libonnxruntime / vec0.dylib stranded inside the archive).
-  - '**/*.node'
-  - '**/node_modules/@img/**'
-  - '**/node_modules/sharp/**'
-  - '**/node_modules/better-sqlite3/**'
-  - '**/node_modules/keytar/**'
-  - '**/node_modules/classic-level/**'
-  - '**/node_modules/onnxruntime-node/**'
-  - '**/node_modules/sqlite-vec*/**'
-  - '**/node_modules/re2/**'
 afterPack: scripts/prune-packaged-app.mjs
 extraResources:
   # ponytail: shipped as app-config (no .env token) so Defender's .env credential

--- a/apps/desktop/scripts/check-packaged-runtime-deps.js
+++ b/apps/desktop/scripts/check-packaged-runtime-deps.js
@@ -2,6 +2,7 @@
 
 const { spawnSync } = require('node:child_process')
 const fs = require('node:fs')
+const { createRequire } = require('node:module')
 const os = require('node:os')
 const path = require('node:path')
 const {
@@ -12,9 +13,6 @@ const {
 
 const appRoot = path.resolve(__dirname, '..')
 const productName = 'Memrynote'
-// Resolved from inside app.asar under Electron (Electron reads asar; plain Node
-// cannot). These are the modules the main process must be able to require at
-// runtime once node_modules is packed into the archive.
 const requiredModules = [
   '@tiptap/core',
   '@tiptap/pm/model',
@@ -28,14 +26,7 @@ const requiredModules = [
   'string_decoder/',
   'y-leveldb'
 ]
-// Native modules whose .node ABI/arch we verify against the target arch. Their
-// real binaries live on disk under app.asar.unpacked (asarUnpack), so plain Node
-// can lipo them even though the JS resolves inside the archive.
-const nativeArchCheckedBinaries = {
-  'better-sqlite3': 'better_sqlite3.node',
-  keytar: 'keytar.node',
-  'classic-level': 'classic_level.node'
-}
+const nativeArchCheckedModules = ['better-sqlite3', 'keytar']
 
 function getPackagedElectronExecutable(resourcesPath) {
   const contentsPath = path.dirname(resourcesPath)
@@ -92,33 +83,72 @@ function resolveResourcesCheck(inputPath) {
   ]
 }
 
-// Layout-agnostic recursive search: pnpm's deploy tree nests real files under
-// .pnpm/<pkg>@<ver>/node_modules/<pkg>/..., so hard-coding a package path is
-// fragile. Find every binary by name under the unpacked tree instead.
-function findFilesByName(rootDir, fileName) {
-  const results = []
-  const stack = [rootDir]
+function findPackageRoot(resolvedPath, packageName) {
+  let current = fs.statSync(resolvedPath).isDirectory() ? resolvedPath : path.dirname(resolvedPath)
+  const root = path.parse(current).root
 
-  while (stack.length > 0) {
-    const dir = stack.pop()
-    let entries
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true })
-    } catch {
-      continue
-    }
-
-    for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name)
-      if (entry.isDirectory()) {
-        stack.push(fullPath)
-      } else if (entry.isFile() && entry.name === fileName) {
-        results.push(fullPath)
+  while (current !== root) {
+    const packageJsonPath = path.join(current, 'package.json')
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+      if (packageJson.name === packageName) {
+        return current
       }
     }
+
+    current = path.dirname(current)
   }
 
-  return results
+  throw new Error(`Unable to locate ${packageName} package root from ${resolvedPath}`)
+}
+
+function assertPackagedPath(moduleName, resolvedPath, resourcesPath) {
+  const realResolvedPath = fs.realpathSync(resolvedPath)
+  const realResourcesPath = fs.realpathSync(resourcesPath)
+
+  if (!realResolvedPath.startsWith(`${realResourcesPath}${path.sep}`)) {
+    fail(`Packaged runtime module "${moduleName}" resolved outside the app: ${realResolvedPath}`)
+  }
+}
+
+function runElectronNativeSmoke(resourcesPath) {
+  const electronExecutable = getPackagedElectronExecutable(resourcesPath)
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-packaged-native-smoke-'))
+  const smokeScriptPath = path.join(tempDir, 'smoke.cjs')
+  const appMainPath = path.join(resourcesPath, 'app.asar', 'out', 'main', 'index.js')
+
+  fs.writeFileSync(
+    smokeScriptPath,
+    `
+const { createRequire } = require('node:module')
+
+const packagedRequire = createRequire(process.env.MEMRY_PACKAGED_MAIN)
+const Database = require(packagedRequire.resolve('better-sqlite3'))
+const database = new Database(':memory:')
+database.close()
+require(packagedRequire.resolve('keytar'))
+console.log(\`Electron native runtime ABI \${process.versions.modules}\`)
+`.trimStart()
+  )
+
+  try {
+    const result = spawnSync(electronExecutable, [smokeScriptPath], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ELECTRON_RUN_AS_NODE: '1',
+        MEMRY_PACKAGED_MAIN: appMainPath
+      }
+    })
+
+    if (result.status !== 0) {
+      const output = [result.stdout, result.stderr].filter(Boolean).join('\n').trim()
+      fail(`Packaged native modules do not load under Electron:\n${output}`)
+      return
+    }
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true })
+  }
 }
 
 function runLipoArchs(binaryPath) {
@@ -136,117 +166,85 @@ function runLipoArchs(binaryPath) {
   return result.stdout.trim().split(/\s+/).filter(Boolean)
 }
 
-// Resolve every required module and load every by-path native (their .node /
-// .dylib are dlopen'd by absolute path, which is the classic asar footgun) from
-// inside the archive, under Electron. Fails the gate if anything can't load.
-function runElectronRuntimeSmoke(resourcesPath) {
-  const electronExecutable = getPackagedElectronExecutable(resourcesPath)
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-packaged-runtime-smoke-'))
-  const smokeScriptPath = path.join(tempDir, 'smoke.cjs')
-  const appMainPath = path.join(resourcesPath, 'app.asar', 'out', 'main', 'index.js')
+function assertNativeModuleArch(moduleName, resolvedPath, expectedArch) {
+  const packageRoot = findPackageRoot(resolvedPath, moduleName)
+  const releaseDir = path.join(packageRoot, 'build', 'Release')
+  if (!fs.existsSync(releaseDir)) {
+    return
+  }
 
-  fs.writeFileSync(
-    smokeScriptPath,
-    `
-const { createRequire } = require('node:module')
-
-const packagedRequire = createRequire(process.env.MEMRY_PACKAGED_MAIN)
-
-for (const moduleName of ${JSON.stringify(requiredModules)}) {
-  packagedRequire.resolve(moduleName)
-}
-
-const Database = require(packagedRequire.resolve('better-sqlite3'))
-const database = new Database(':memory:')
-
-// vec0.dylib is loaded by absolute path via loadExtension — exercise it exactly
-// as src/main/database/client.ts does so an asar-stranded dylib fails the gate.
-const sqliteVec = require(packagedRequire.resolve('sqlite-vec'))
-sqliteVec.load(database)
-database.exec('CREATE VIRTUAL TABLE vec_smoke USING vec0(embedding float[4])')
-database.close()
-
-// keytar / onnxruntime-node / sharp each dlopen a native binary (and companion
-// dylib) by path; requiring them validates those paths resolve under unpacked.
-require(packagedRequire.resolve('keytar'))
-require(packagedRequire.resolve('classic-level'))
-require(packagedRequire.resolve('onnxruntime-node'))
-require(packagedRequire.resolve('sharp'))
-
-console.log('Packaged Electron runtime ABI ' + process.versions.modules)
-`.trimStart()
-  )
-
-  try {
-    const result = spawnSync(electronExecutable, [smokeScriptPath], {
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        ELECTRON_RUN_AS_NODE: '1',
-        MEMRY_PACKAGED_MAIN: appMainPath
-      }
-    })
-
-    if (result.status !== 0) {
-      const output = [result.stdout, result.stderr].filter(Boolean).join('\n').trim()
-      fail(`Packaged runtime modules do not load under Electron:\n${output}`)
-      return
+  for (const entry of fs.readdirSync(releaseDir)) {
+    if (!entry.endsWith('.node')) {
+      continue
     }
 
-    if (result.stdout) {
-      process.stdout.write(result.stdout)
+    const binaryPath = path.join(releaseDir, entry)
+    const archs = runLipoArchs(binaryPath)
+    if (archs.length > 0 && !archListIncludes(archs, expectedArch)) {
+      fail(
+        `Packaged native module "${moduleName}" has wrong architecture for ${expectedArch}: ${binaryPath} (${archs.join(', ')})`
+      )
     }
-  } finally {
-    fs.rmSync(tempDir, { force: true, recursive: true })
   }
 }
 
 function checkResources(resourcesPath, expectedArch) {
   const appAsarPath = path.join(resourcesPath, 'app.asar')
-  const unpackedNodeModulesPath = path.join(resourcesPath, 'app.asar.unpacked', 'node_modules')
+  const externalNodeModulesPath = path.join(resourcesPath, 'node_modules')
 
   if (!fs.existsSync(appAsarPath)) {
     fail(`Missing packaged app.asar: ${appAsarPath}`)
   }
 
-  // node_modules is packed into app.asar; only native packages are unpacked here.
-  if (!fs.existsSync(unpackedNodeModulesPath)) {
-    fail(`Missing unpacked native node_modules: ${unpackedNodeModulesPath}`)
+  if (!fs.existsSync(externalNodeModulesPath)) {
+    fail(`Missing external production node_modules: ${externalNodeModulesPath}`)
   }
 
   if (process.exitCode) {
     return
   }
 
-  // Native ABI/arch check needs the real .node on disk (unpacked).
-  for (const [moduleName, binaryName] of Object.entries(nativeArchCheckedBinaries)) {
-    const matches = findFilesByName(unpackedNodeModulesPath, binaryName)
-    if (matches.length === 0) {
-      fail(
-        `Missing unpacked native binary for "${moduleName}": ${binaryName} not found under ${unpackedNodeModulesPath}`
-      )
-      continue
-    }
+  const packagedRequire = createRequire(path.join(appAsarPath, 'out', 'main', 'index.js'))
+  const resolvedModules = new Map()
 
-    for (const binaryPath of matches) {
-      const archs = runLipoArchs(binaryPath)
-      if (archs.length > 0 && !archListIncludes(archs, expectedArch)) {
-        fail(
-          `Packaged native module "${moduleName}" has wrong architecture for ${expectedArch}: ${binaryPath} (${archs.join(', ')})`
-        )
-      }
+  for (const moduleName of requiredModules) {
+    try {
+      const resolvedPath = packagedRequire.resolve(moduleName)
+      resolvedModules.set(moduleName, resolvedPath)
+      assertPackagedPath(moduleName, resolvedPath, resourcesPath)
+    } catch (error) {
+      fail(`Cannot resolve packaged runtime module "${moduleName}": ${error.message}`)
     }
   }
 
   if (process.exitCode) {
     return
+  }
+
+  for (const moduleName of nativeArchCheckedModules) {
+    assertNativeModuleArch(moduleName, resolvedModules.get(moduleName), expectedArch)
+  }
+
+  if (process.exitCode) {
+    return
+  }
+
+  const betterSqliteRoot = findPackageRoot(resolvedModules.get('better-sqlite3'), 'better-sqlite3')
+  const betterSqliteBinary = path.join(betterSqliteRoot, 'build', 'Release', 'better_sqlite3.node')
+  if (!fs.existsSync(betterSqliteBinary)) {
+    fail(`Missing packaged better-sqlite3 binary: ${betterSqliteBinary}`)
+  }
+
+  const directElectronPath = path.join(externalNodeModulesPath, 'electron')
+  if (fs.existsSync(directElectronPath)) {
+    fail(`Packaged external node_modules should not include Electron: ${directElectronPath}`)
   }
 
   if (expectedArch === process.arch) {
-    runElectronRuntimeSmoke(resourcesPath)
+    runElectronNativeSmoke(resourcesPath)
   } else {
     console.log(
-      `Skipping Electron runtime smoke for ${resourcesPath}; expected arch ${expectedArch} differs from host ${process.arch}`
+      `Skipping Electron native smoke for ${resourcesPath}; expected arch ${expectedArch} differs from host ${process.arch}`
     )
   }
 


### PR DESCRIPTION
## Why

PR #654 (pack node_modules into app.asar) is merged to main and **blocks macOS releases** — the `2026.701.4` release failed at `check-packaged-runtime-deps.js`:

```
Missing unpacked native node_modules: .../app.asar.unpacked/node_modules
```

## Root cause (verified locally)

electron-builder's production-dependency **collector returns empty** for this repo:
- it detects `resolvedPackageManager=npm`, and
- the staged `package.json` carries `workspace:*` deps (`@memry/i18n`, …).

So **zero** node_modules get packed into `app.asar`. #654 removed the loose `extraResources` node_modules copy (the only mechanism delivering deps) on the assumption electron-builder would asar-pack them instead — it doesn't. Result: a dependency-less app on all three platforms (mac gate caught it; the broken build never published).

Flattening the tree with `pnpm --node-linker=hoisted` was tested locally and **does not help** — the collector, not the pnpm symlink layout, is the blocker.

## This PR

Reverts `3831d35a`, restoring the working loose-node_modules build. Releases unblocked.

The macOS update-install slowness (~2.5min, from Squirrel verifying ~40k loose files) is real but needs a different fix — electron-builder cannot asar-pack this dependency tree as-is. Follow-up options: prune the loose node_modules (safe, smaller win), or a dedicated spike on the electron-builder collector.