### PR TITLE
feat(landing): launch polish — account nav, minimal download page, changelog

### DIFF
--- a/apps/landing/src/components/account/CheckoutPanel.tsx
+++ b/apps/landing/src/components/account/CheckoutPanel.tsx
@@ -242,7 +242,7 @@ function OrderSummary({
 
       {status === 'success' && (
         <p role="status" className="mt-4 text-sm text-sage">
-          Payment complete. Return to Memry to finish activation.
+          Payment complete. Return to MemryNote to finish activation.
         </p>
       )}
       {status === 'canceled' && (
@@ -281,13 +281,13 @@ export function NoTokenNotice() {
       <span className="mx-auto flex h-11 w-11 items-center justify-center rounded-full bg-terracotta/10 text-terracotta">
         <Lock className="h-5 w-5" strokeWidth={2} />
       </span>
-      <h1 className="font-editorial mt-5 text-xl tracking-[-0.01em]">Open Memry to upgrade</h1>
+      <h1 className="font-editorial mt-5 text-xl tracking-[-0.01em]">Open MemryNote to upgrade</h1>
       <p className="mt-3 text-sm text-muted">
         Start checkout from <strong className="font-medium text-ink">Settings → Account</strong> in
-        the Memry desktop app so we can link the purchase to your account.
+        the MemryNote desktop app so we can link the purchase to your account.
       </p>
       <Button asChild className="mt-6 w-full">
-        <Link to="/download/desktop">Download Memry</Link>
+        <Link to="/download/desktop">Download MemryNote</Link>
       </Button>
     </div>
   )

--- a/apps/landing/src/components/layout/Footer.tsx
+++ b/apps/landing/src/components/layout/Footer.tsx
@@ -54,9 +54,10 @@ export function Footer() {
           <div className="col-span-2 md:col-span-2 pe-8">
             <Link
               to="/"
-              className="inline-block mb-6 group"
+              className="inline-flex items-center gap-2 mb-6 group"
               onClick={() => trackLandingEvent('landing_nav_click', 'footer:logo')}
             >
+              <img src="/favicon.svg" alt="" className="h-7 w-7" />
               <span className="font-serif text-3xl font-medium text-ink group-hover:text-terracotta transition-colors">
                 memrynote
               </span>

--- a/apps/landing/src/components/layout/Header.tsx
+++ b/apps/landing/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useLocation } from 'react-router-dom'
-import { Menu, X, ArrowUpRight, ChevronDown, type LucideIcon } from 'lucide-react'
+import { Menu, X, ChevronDown, type LucideIcon } from 'lucide-react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Button } from '@/components/ui/button'
@@ -17,6 +17,7 @@ import {
 import { cn } from '@/lib/utils'
 import { scrollToLandingTarget } from '@/lib/smooth-scroll'
 import { trackLandingEvent, type LandingEventName } from '@/lib/analytics'
+import { useAuth } from '@/contexts/auth-context'
 
 function isExternalHref(href: string) {
   return href.startsWith('http')
@@ -402,7 +403,12 @@ export function Header() {
   )
   const location = useLocation()
   const navigate = useNavigate()
+  const { isSignedIn } = useAuth()
   const showHeaderSurface = headerScrolled || mobileMenuOpen
+  // ponytail: signed out → /auth (sign-in/up); signed in → billing. Label stays "Account" either way.
+  const accountHref = isSignedIn ? '/account/billing' : '/auth'
+  const accountLabel = 'Account'
+  const accountTarget = isSignedIn ? 'nav:account' : 'nav:sign-in'
 
   const closeMobileMenu = () => {
     setMobileMenuOpen(false)
@@ -475,13 +481,12 @@ export function Header() {
           <div className="hidden md:flex items-center gap-3">
             <ThemeToggle />
             <GitHubStarWidget />
-            <Button variant="default" size="sm" className="rounded-full px-6" asChild>
+            <Button variant="ghost" size="sm" className="rounded-full px-4" asChild>
               <Link
-                to="/download/desktop"
-                onClick={() => trackLandingEvent('landing_download_click', 'nav:download')}
+                to={accountHref}
+                onClick={() => trackLandingEvent('landing_nav_click', accountTarget)}
               >
-                Download
-                <ArrowUpRight className="w-4 h-4" />
+                {accountLabel}
               </Link>
             </Button>
           </div>
@@ -538,17 +543,11 @@ export function Header() {
                     onNavigate={closeMobileMenu}
                   />
                 ))}
-                <Button variant="default" className="mt-1 h-10 w-full rounded-full" asChild>
-                  <Link
-                    to="/download/desktop"
-                    onClick={() => {
-                      trackLandingEvent('landing_download_click', 'mobile-nav:download')
-                      closeMobileMenu()
-                    }}
-                  >
-                    Download
-                  </Link>
-                </Button>
+                <MobileNavLink
+                  href={accountHref}
+                  label={accountLabel}
+                  onNavigate={closeMobileMenu}
+                />
               </div>
             </Container>
           </motion.div>

--- a/apps/landing/src/lib/constants.ts
+++ b/apps/landing/src/lib/constants.ts
@@ -321,20 +321,20 @@ export const ROADMAP_DATA = {
         'Local vault with Markdown notes, backlinks, and global search',
         'Inbox capture for text, URLs, images, and voice',
         'Tasks, projects, subtasks, recurring rules, and multiple views',
-        'Daily journal with templates and day context',
+        'Daily journal, calendar week view, and reminders',
         'End-to-end encrypted sync for notes and journals',
-        'Calendar week view, snoozed inbox items, and reminders',
-        'Voice memos with transcription and related items',
-        'Agent Chat mentions, per-turn permissions, and MemryNote CLI'
+        'Web clipper for Chrome, Firefox, and Edge',
+        'Importers for Obsidian, Notion, Roam, Bear, Evernote, and more',
+        'Agent Chat, voice memos with transcription, and MemryNote CLI'
       ]
     },
     {
       status: 'in-progress' as const,
       title: 'Building now',
-      caption: 'The next work is focused on better capture, migration, and agent reliability.',
+      caption: 'The next work is focused on wider clipping and agent reliability.',
       items: [
-        'Web clipper for pages, highlights, and snippets',
-        'Importers for Obsidian, Notion, Roam, and Markdown folders',
+        'Safari web clipper support',
+        'Browser store listings: Chrome Web Store, Firefox Add-ons, Edge',
         'Optional AI Agent polish: provider settings, streaming, approvals'
       ]
     },

--- a/apps/landing/src/lib/constants.ts
+++ b/apps/landing/src/lib/constants.ts
@@ -325,7 +325,7 @@ export const ROADMAP_DATA = {
         'End-to-end encrypted sync for notes and journals',
         'Calendar week view, snoozed inbox items, and reminders',
         'Voice memos with transcription and related items',
-        'Agent Chat mentions, per-turn permissions, and Memry CLI'
+        'Agent Chat mentions, per-turn permissions, and MemryNote CLI'
       ]
     },
     {

--- a/apps/landing/src/lib/paddle-checkout.ts
+++ b/apps/landing/src/lib/paddle-checkout.ts
@@ -88,7 +88,7 @@ export async function openPaddleCheckout(
 ) {
   const normalizedCheckoutToken = checkoutToken?.trim()
   if (!normalizedCheckoutToken) {
-    throw new Error('Open Memry and sign in from Account to start hosted sync.')
+    throw new Error('Open MemryNote and sign in from Account to start hosted sync.')
   }
 
   const response = await fetch('/api/paddle-checkout', {

--- a/apps/landing/src/lib/seo.test.ts
+++ b/apps/landing/src/lib/seo.test.ts
@@ -58,7 +58,7 @@ describe('landing SEO signals', () => {
     assert.equal(website['@context'], 'https://schema.org')
     assert.equal(website['@type'], 'WebSite')
     assert.equal(website.name, 'memrynote')
-    assert.deepEqual(website.alternateName, ['Memry Note', 'memrynote.com'])
+    assert.deepEqual(website.alternateName, ['MemryNote', 'memrynote.com'])
     assert.equal(website.url, 'https://memrynote.com/')
     assert.equal(website.potentialAction, undefined)
   })

--- a/apps/landing/src/lib/seo.ts
+++ b/apps/landing/src/lib/seo.ts
@@ -2,7 +2,7 @@ import { FAQ_ITEMS, FEATURES, GITHUB_URL, REDDIT_URL, TWITTER_DEV_URL } from './
 
 export const BASE_URL = 'https://memrynote.com'
 export const SITE_NAME = 'memrynote'
-export const ALTERNATE_SITE_NAMES = ['Memry Note', 'memrynote.com'] as const
+export const ALTERNATE_SITE_NAMES = ['MemryNote', 'memrynote.com'] as const
 // Brand handle (matches index.html). The founder's personal handle is TWITTER_DEV_URL in constants.
 export const TWITTER_HANDLE = '@memrynote'
 // Versioned by FILENAME, not a `?v=` query: Facebook and several scrapers ignore

--- a/apps/landing/src/pages/Auth.tsx
+++ b/apps/landing/src/pages/Auth.tsx
@@ -64,7 +64,7 @@ export function AuthPage() {
       <main className="py-24">
         <Container size="sm">
           <div className="mx-auto max-w-sm rounded-2xl border border-border bg-card p-8 shadow-card">
-            <h1 className="font-editorial text-xl tracking-[-0.01em]">Sign in to Memry</h1>
+            <h1 className="font-editorial text-xl tracking-[-0.01em]">Sign in to MemryNote</h1>
             {error ? <p className="mt-3 text-sm text-red-500">{error}</p> : null}
             {step === 'email' ? (
               <div className="mt-6 space-y-3">

--- a/apps/landing/src/pages/Auth.tsx
+++ b/apps/landing/src/pages/Auth.tsx
@@ -70,7 +70,6 @@ export function AuthPage() {
               <div className="mt-6 space-y-3">
                 <Input
                   type="email"
-                  placeholder="you@example.com"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                 />
@@ -96,7 +95,29 @@ export function AuthPage() {
               </div>
             )}
             <div className="my-5 text-center text-xs text-muted">or</div>
-            <Button variant="outline" className="w-full" onClick={continueWithGoogle}>
+            <Button
+              variant="outline"
+              className="inline-flex w-full items-center justify-center gap-2"
+              onClick={continueWithGoogle}
+            >
+              <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
+              </svg>
               Continue with Google
             </Button>
           </div>

--- a/apps/landing/src/pages/Changelog.tsx
+++ b/apps/landing/src/pages/Changelog.tsx
@@ -4,7 +4,9 @@ import {
   CalendarDays,
   FileText,
   GitBranch,
+  Globe,
   Lock,
+  Rocket,
   Search,
   type LucideIcon
 } from 'lucide-react'
@@ -24,6 +26,42 @@ interface ChangelogEntry {
 }
 
 const CHANGELOG_ENTRIES: ChangelogEntry[] = [
+  {
+    period: 'July 2026',
+    title: 'Public launch',
+    summary: 'memrynote opened its doors.',
+    icon: Rocket,
+    highlights: [
+      'Public downloads for macOS, Windows, and Linux',
+      'Signed builds with automatic updates',
+      'memrynote Sync plans and checkout',
+      'Homebrew cask install',
+      'Web clipper published to browser stores',
+      'Alternatives hub and comparison guides'
+    ]
+  },
+  {
+    period: 'June 2026',
+    title: 'Web clipper, importers, and a home that fits you',
+    summary: 'Getting your content in — and shaping the vault around you.',
+    icon: Globe,
+    highlights: [
+      'Web clipper for Chrome, Firefox, and Edge',
+      'One-click article extraction',
+      'Selection and full-page screenshot capture',
+      'Offline capture queue and keyboard shortcuts',
+      'Importers for Apple Notes, Bear, Evernote, and Notion',
+      'Google Keep, Todoist, TickTick, and Raindrop imports',
+      'Unified, pluggable import framework',
+      'Resizable home dashboard with widgets',
+      'Folder List, Board, and Gallery views',
+      'Calendar drag-to-reschedule and resize',
+      'Calendar toolbar search',
+      'Custom tag colors and per-tag icons',
+      'First-run interactive tour',
+      'Broad native menu bar'
+    ]
+  },
   {
     period: 'May 2026',
     title: 'Agent Chat, memrynote CLI, and voice workflows',

--- a/apps/landing/src/pages/DownloadDesktop.tsx
+++ b/apps/landing/src/pages/DownloadDesktop.tsx
@@ -1,24 +1,18 @@
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import {
-  Apple,
   ArrowRight,
   CheckCircle2,
-  Cpu,
   Download,
   FileText,
   FolderOpen,
   Github,
   HardDrive,
   Lock,
-  MonitorSmartphone,
-  Package,
   Search,
   Shield,
   Sparkles,
-  Terminal,
-  WifiOff,
-  type LucideIcon
+  WifiOff
 } from 'lucide-react'
 import { Container } from '@/components/layout/Container'
 import { FeatureHeroScreenshot } from '@/components/shared/FeatureHeroScreenshot'
@@ -35,7 +29,7 @@ import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from
 import { cn } from '@/lib/utils'
 import { trackLandingEvent } from '@/lib/analytics'
 import { DownloadButton } from '@/components/shared/DownloadCTA'
-import { downloadHref, useDetectedOS, type DetectedOS } from '@/lib/download'
+import { downloadHref, useDetectedOS, type DetectedOS, type DownloadPlatform } from '@/lib/download'
 
 const EASE_OUT_EXPO = [0.16, 1, 0.3, 1] as const
 
@@ -67,7 +61,6 @@ export function DownloadDesktopPage() {
         <WhyDesktop />
         <InAction />
         <WorksWithEverything />
-        <SystemRequirements />
         <InstallSteps />
         <ReleaseChannel />
         <DownloadFaq />
@@ -172,54 +165,70 @@ function DesktopNoteScreenshot() {
   )
 }
 
+interface PlatformDownload {
+  key: DownloadPlatform
+  label: string
+}
+
 interface PlatformInfo {
   id: 'mac' | 'windows' | 'linux'
   label: string
-  icon: LucideIcon
   versionTag: string
-  arches: string[]
-  formats: string[]
+  primary: PlatformDownload
+  secondary?: PlatformDownload
+}
+
+// Real brand marks (simple-icons), 24px viewBox, solid fill via currentColor.
+const PLATFORM_LOGO: Record<PlatformInfo['id'], string> = {
+  mac: 'M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701',
+  windows:
+    'M0,0H11.377V11.372H0ZM12.623,0H24V11.372H12.623ZM0,12.623H11.377V24H0Zm12.623,0H24V24H12.623',
+  linux:
+    'M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.132 1.884 1.071.771-.06 1.592-.536 2.257-1.306.631-.765 1.683-1.084 2.378-1.503.348-.199.629-.469.649-.853.023-.4-.2-.811-.714-1.376v-.097l-.003-.003c-.17-.2-.25-.535-.338-.926-.085-.401-.182-.786-.492-1.046h-.003c-.059-.054-.123-.067-.188-.135a.357.357 0 00-.19-.064c.431-1.278.264-2.55-.173-3.694-.533-1.41-1.465-2.638-2.175-3.483-.796-1.005-1.576-1.957-1.56-3.368.026-2.152.236-6.133-3.544-6.139zm.529 3.405h.013c.213 0 .396.062.584.198.19.135.33.332.438.533.105.259.158.459.166.724 0-.02.006-.04.006-.06v.105a.086.086 0 01-.004-.021l-.004-.024a1.807 1.807 0 01-.15.706.953.953 0 01-.213.335.71.71 0 00-.088-.042c-.104-.045-.198-.064-.284-.133a1.312 1.312 0 00-.22-.066c.05-.06.146-.133.183-.198.053-.128.082-.264.088-.402v-.02a1.21 1.21 0 00-.061-.4c-.045-.134-.101-.2-.183-.333-.084-.066-.167-.132-.267-.132h-.016c-.093 0-.176.03-.262.132a.8.8 0 00-.205.334 1.18 1.18 0 00-.09.4v.019c.002.089.008.179.02.267-.193-.067-.438-.135-.607-.202a1.635 1.635 0 01-.018-.2v-.02a1.772 1.772 0 01.15-.768c.082-.22.232-.406.43-.533a.985.985 0 01.594-.2zm-2.962.059h.036c.142 0 .27.048.399.135.146.129.264.288.344.465.09.199.14.4.153.667v.004c.007.134.006.2-.002.266v.08c-.03.007-.056.018-.083.024-.152.055-.274.135-.393.2.012-.09.013-.18.003-.267v-.015c-.012-.133-.04-.2-.082-.333a.613.613 0 00-.166-.267.248.248 0 00-.183-.064h-.021c-.071.006-.13.04-.186.132a.552.552 0 00-.12.27.944.944 0 00-.023.33v.015c.012.135.037.2.08.334.046.134.098.2.166.268.01.009.02.018.034.024-.07.057-.117.07-.176.136a.304.304 0 01-.131.068 2.62 2.62 0 01-.275-.402 1.772 1.772 0 01-.155-.667 1.759 1.759 0 01.08-.668 1.43 1.43 0 01.283-.535c.128-.133.26-.2.418-.2zm1.37 1.706c.332 0 .733.065 1.216.399.293.2.523.269 1.052.468h.003c.255.136.405.266.478.399v-.131a.571.571 0 01.016.47c-.123.31-.516.643-1.063.842v.002c-.268.135-.501.333-.775.465-.276.135-.588.292-1.012.267a1.139 1.139 0 01-.448-.067 3.566 3.566 0 01-.322-.198c-.195-.135-.363-.332-.612-.465v-.005h-.005c-.4-.246-.616-.512-.686-.71-.07-.268-.005-.47.193-.6.224-.135.38-.271.483-.336.104-.074.143-.102.176-.131h.002v-.003c.169-.202.436-.47.839-.601.139-.036.294-.065.466-.065zm2.8 2.142c.358 1.417 1.196 3.475 1.735 4.473.286.534.855 1.659 1.102 3.024.156-.005.33.018.513.064.646-1.671-.546-3.467-1.089-3.966-.22-.2-.232-.335-.123-.335.59.534 1.365 1.572 1.646 2.757.13.535.16 1.104.021 1.67.067.028.135.06.205.067 1.032.534 1.413.938 1.23 1.537v-.043c-.06-.003-.12 0-.18 0h-.016c.151-.467-.182-.825-1.065-1.224-.915-.4-1.646-.336-1.77.465-.008.043-.013.066-.018.135-.068.023-.139.053-.209.064-.43.268-.662.669-.793 1.187-.13.533-.17 1.156-.205 1.869v.003c-.02.334-.17.838-.319 1.35-1.5 1.072-3.58 1.538-5.348.334a2.645 2.645 0 00-.402-.533 1.45 1.45 0 00-.275-.333c.182 0 .338-.03.465-.067a.615.615 0 00.314-.334c.108-.267 0-.697-.345-1.163-.345-.467-.931-.995-1.788-1.521-.63-.4-.986-.87-1.15-1.396-.165-.534-.143-1.085-.015-1.645.245-1.07.873-2.11 1.274-2.763.107-.065.037.135-.408.974-.396.751-1.14 2.497-.122 3.854a8.123 8.123 0 01.647-2.876c.564-1.278 1.743-3.504 1.836-5.268.048.036.217.135.289.202.218.133.38.333.59.465.21.201.477.335.876.335.039.003.075.006.11.006.412 0 .73-.134.997-.268.29-.134.52-.334.74-.4h.005c.467-.135.835-.402 1.044-.7zm2.185 8.958c.037.6.343 1.245.882 1.377.588.134 1.434-.333 1.791-.765l.211-.01c.315-.007.577.01.847.268l.003.003c.208.199.305.53.391.876.085.4.154.78.409 1.066.486.527.645.906.636 1.14l.003-.007v.018l-.003-.012c-.015.262-.185.396-.498.595-.63.401-1.746.712-2.457 1.57-.618.737-1.37 1.14-2.036 1.191-.664.053-1.237-.2-1.574-.898l-.005-.003c-.21-.4-.12-1.025.056-1.69.176-.668.428-1.344.463-1.897.037-.714.076-1.335.195-1.814.12-.465.308-.797.641-.984l.045-.022zm-10.814.049h.01c.053 0 .105.005.157.014.376.055.706.333 1.023.752l.91 1.664.003.003c.243.533.754 1.064 1.189 1.637.434.598.77 1.131.729 1.57v.006c-.057.744-.48 1.148-1.125 1.294-.645.135-1.52.002-2.395-.464-.968-.536-2.118-.469-2.857-.602-.369-.066-.61-.2-.723-.4-.11-.2-.113-.602.123-1.23v-.004l.002-.003c.117-.334.03-.752-.027-1.118-.055-.401-.083-.71.043-.94.16-.334.396-.4.69-.533.294-.135.64-.202.915-.47h.002v-.002c.256-.268.445-.601.668-.838.19-.201.38-.336.663-.336zm7.159-9.074c-.435.201-.945.535-1.488.535-.542 0-.97-.267-1.28-.466-.154-.134-.28-.268-.373-.335-.164-.134-.144-.333-.074-.333.109.016.129.134.199.2.096.066.215.2.36.333.292.2.68.467 1.167.467.485 0 1.053-.267 1.398-.466.195-.135.445-.334.648-.467.156-.136.149-.267.279-.267.128.016.034.134-.147.332a8.097 8.097 0 01-.69.468zm-1.082-1.583V5.64c-.006-.02.013-.042.029-.05.074-.043.18-.027.26.004.063 0 .16.067.15.135-.006.049-.085.066-.135.066-.055 0-.092-.043-.141-.068-.052-.018-.146-.008-.163-.065zm-.551 0c-.02.058-.113.049-.166.066-.047.025-.086.068-.14.068-.05 0-.13-.02-.136-.068-.01-.066.088-.133.15-.133.08-.031.184-.047.259-.005.019.009.036.03.03.05v.02h.003z'
+}
+
+function PlatformLogo({ id, className }: { id: PlatformInfo['id']; className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden className={className}>
+      <path d={PLATFORM_LOGO[id]} />
+    </svg>
+  )
 }
 
 const PLATFORMS: PlatformInfo[] = [
   {
     id: 'mac',
     label: 'macOS',
-    icon: Apple,
     versionTag: 'macOS 11+',
-    arches: ['Apple Silicon', 'Intel'],
-    formats: ['.dmg', '.zip']
+    primary: { key: 'mac-arm64', label: 'Apple Silicon' },
+    secondary: { key: 'mac-x64', label: 'Intel' }
   },
   {
     id: 'windows',
     label: 'Windows',
-    icon: MonitorSmartphone,
     versionTag: 'Windows 10+',
-    arches: ['x64'],
-    formats: ['.exe', 'installer']
+    primary: { key: 'windows', label: '.exe' }
   },
   {
     id: 'linux',
     label: 'Linux',
-    icon: Terminal,
-    versionTag: 'Ubuntu 20.04+ / Fedora 36+',
-    arches: ['x64'],
-    formats: ['AppImage', '.deb', '.rpm']
+    versionTag: 'Ubuntu / Fedora',
+    primary: { key: 'linux', label: '.AppImage' },
+    secondary: { key: 'linux-deb', label: '.deb' }
   }
 ]
 
 function PlatformGrid({ detected }: { detected: DetectedOS }) {
   return (
     <section className="bg-paper-alt/55 py-24 md:py-28">
-      <Container>
+      <Container size="md">
         <motion.div {...fadeUp} className="mx-auto max-w-2xl text-center">
           <Eyebrow>Pick your platform</Eyebrow>
           <h2 className="mt-3 font-serif text-3xl font-normal leading-tight text-ink md:text-5xl">
             Three platforms. <span className="italic text-terracotta">One vault.</span>
           </h2>
           <p className="mt-5 text-lg leading-relaxed text-muted">
-            Signed builds for macOS, Windows, and Linux, with automatic updates. Pick your platform
-            below.
+            Signed builds with automatic updates. Pick yours.
           </p>
         </motion.div>
 
@@ -228,14 +237,14 @@ function PlatformGrid({ detected }: { detected: DetectedOS }) {
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true, margin: '-60px' }}
-          className="mt-14 grid gap-4 md:grid-cols-3"
+          className="mx-auto mt-14 grid max-w-xl gap-x-6 gap-y-12 sm:grid-cols-3"
         >
           {PLATFORMS.map((p) => (
-            <PlatformCard key={p.id} platform={p} highlighted={detected === p.id} />
+            <PlatformPick key={p.id} platform={p} highlighted={detected === p.id} />
           ))}
         </motion.div>
 
-        <p className="mt-8 text-center font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted/70">
+        <p className="mt-12 text-center font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted/70">
           Automatic updates keep you current. Source stays open on GitHub.
         </p>
       </Container>
@@ -243,97 +252,47 @@ function PlatformGrid({ detected }: { detected: DetectedOS }) {
   )
 }
 
-function PlatformCard({ platform, highlighted }: { platform: PlatformInfo; highlighted: boolean }) {
+function PlatformPick({ platform, highlighted }: { platform: PlatformInfo; highlighted: boolean }) {
+  const { primary, secondary } = platform
   return (
-    <motion.article
-      variants={fadeUpVariant}
-      className={cn(
-        'relative flex h-full flex-col overflow-hidden rounded-2xl border bg-card p-7 shadow-card transition-all',
-        highlighted
-          ? 'border-terracotta/40 shadow-[0_20px_60px_-30px_rgba(255,103,26,0.45)]'
-          : 'border-border/60'
-      )}
-    >
-      {highlighted && (
-        <span className="absolute end-5 top-5 inline-flex items-center gap-1 rounded-full bg-terracotta/12 px-2.5 py-0.5 font-mono-accent text-[10px] uppercase tracking-[0.18em] text-terracotta">
-          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-terracotta" />
-          Detected
-        </span>
-      )}
-      <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-paper-alt/80 text-ink">
-        <platform.icon className="h-6 w-6" strokeWidth={1.6} />
-      </span>
-      <h3 className="mt-5 font-serif text-2xl text-ink">{platform.label}</h3>
+    <motion.div variants={fadeUpVariant} className="flex flex-col items-center text-center">
+      <PlatformLogo
+        id={platform.id}
+        className={cn('h-9 w-9', highlighted ? 'text-terracotta' : 'text-ink')}
+      />
+      <h3 className="mt-4 flex items-center gap-2 font-serif text-xl text-ink">
+        {platform.label}
+        {highlighted && (
+          <span className="font-mono-accent text-[10px] uppercase tracking-[0.16em] text-terracotta">
+            Detected
+          </span>
+        )}
+      </h3>
       <p className="mt-1 font-mono-accent text-[11px] uppercase tracking-[0.16em] text-muted">
         {platform.versionTag}
       </p>
-
-      <div className="mt-6 space-y-2 text-[13px]">
-        <div className="flex items-center gap-2">
-          <Cpu className="h-3.5 w-3.5 text-muted" strokeWidth={2} />
-          <span className="text-muted">Arch:</span>
-          <span className="text-ink">{platform.arches.join(', ')}</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <Package className="h-3.5 w-3.5 text-muted" strokeWidth={2} />
-          <span className="text-muted">Formats:</span>
-          <span className="font-mono-accent text-ink">{platform.formats.join(' · ')}</span>
-        </div>
-      </div>
-
-      <div className="mt-auto space-y-2 pt-7">
-        <Button
-          size="lg"
-          variant={highlighted ? 'default' : 'outline'}
-          className={cn(
-            'w-full rounded-full',
-            highlighted
-              ? 'bg-terracotta text-white shadow-[0_16px_34px_-14px_rgba(255,103,26,0.7)]'
-              : 'border-ink/15 bg-paper-alt/40 text-ink'
-          )}
-          asChild
+      <a
+        href={downloadHref(primary.key)}
+        onClick={() =>
+          trackLandingEvent('landing_download_click', `download:${primary.key}:platform`)
+        }
+        className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-terracotta transition-colors hover:text-terracotta/80"
+      >
+        <Download className="h-4 w-4" strokeWidth={2} />
+        Download {primary.label}
+      </a>
+      {secondary && (
+        <a
+          href={downloadHref(secondary.key)}
+          onClick={() =>
+            trackLandingEvent('landing_download_click', `download:${secondary.key}:platform`)
+          }
+          className="mt-2 text-xs text-muted transition-colors hover:text-terracotta"
         >
-          <a
-            href={downloadHref(platform.id === 'mac' ? 'mac-arm64' : platform.id)}
-            onClick={() =>
-              trackLandingEvent(
-                'landing_download_click',
-                `download:${platform.id === 'mac' ? 'mac-arm64' : platform.id}:platform-card`
-              )
-            }
-          >
-            <Download className="h-4 w-4" />
-            {platform.id === 'mac'
-              ? 'Download for Apple Silicon'
-              : platform.id === 'windows'
-                ? 'Download .exe'
-                : 'Download .AppImage'}
-          </a>
-        </Button>
-        {platform.id === 'mac' && (
-          <a
-            href={downloadHref('mac-x64')}
-            onClick={() =>
-              trackLandingEvent('landing_download_click', 'download:mac-x64:platform-card')
-            }
-            className="block text-center font-mono-accent text-[11px] uppercase tracking-[0.16em] text-muted transition-colors hover:text-terracotta"
-          >
-            Download for Intel
-          </a>
-        )}
-        {platform.id === 'linux' && (
-          <a
-            href={downloadHref('linux-deb')}
-            onClick={() =>
-              trackLandingEvent('landing_download_click', 'download:linux-deb:platform-card')
-            }
-            className="block text-center font-mono-accent text-[11px] uppercase tracking-[0.16em] text-muted transition-colors hover:text-terracotta"
-          >
-            Download .deb
-          </a>
-        )}
-      </div>
-    </motion.article>
+          or {secondary.label}
+        </a>
+      )}
+    </motion.div>
   )
 }
 
@@ -508,90 +467,6 @@ function WorksWithEverything() {
               <p className="mt-2 text-sm leading-relaxed text-muted">{w.body}</p>
             </motion.article>
           ))}
-        </motion.div>
-      </Container>
-    </section>
-  )
-}
-
-const REQUIREMENTS: { platform: string; os: string; arch: string; ram: string; disk: string }[] = [
-  {
-    platform: 'macOS',
-    os: '11.0 Big Sur or later',
-    arch: 'Apple Silicon · Intel',
-    ram: '4 GB',
-    disk: '300 MB + vault'
-  },
-  {
-    platform: 'Windows',
-    os: 'Windows 10 (64-bit) or later',
-    arch: 'x64',
-    ram: '4 GB',
-    disk: '300 MB + vault'
-  },
-  {
-    platform: 'Linux',
-    os: 'Ubuntu 20.04 · Fedora 36 · Debian 11 or newer',
-    arch: 'x64',
-    ram: '4 GB',
-    disk: '300 MB + vault'
-  }
-]
-
-function SystemRequirements() {
-  return (
-    <section className="bg-paper-alt/55 py-24 md:py-28">
-      <Container size="md">
-        <motion.div {...fadeUp} className="mx-auto max-w-2xl text-center">
-          <Eyebrow>System requirements</Eyebrow>
-          <h2 className="mt-3 font-serif text-3xl font-normal leading-tight text-ink md:text-5xl">
-            Modest needs.
-          </h2>
-          <p className="mt-5 text-lg leading-relaxed text-muted">
-            memrynote runs on machines you already own. Built on Electron, sized like a small app.
-          </p>
-        </motion.div>
-
-        <motion.div
-          {...fadeUp}
-          transition={{ ...fadeUp.transition, delay: 0.1 }}
-          className="mt-12 overflow-x-auto rounded-2xl border border-border/55 bg-white/55 shadow-card"
-        >
-          <table className="w-full min-w-[720px]">
-            <thead>
-              <tr className="border-b border-border/60 bg-paper-alt/40">
-                <th className="px-6 py-4 text-start font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted">
-                  Platform
-                </th>
-                <th className="px-5 py-4 text-start font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted">
-                  Minimum OS
-                </th>
-                <th className="px-5 py-4 text-start font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted">
-                  Architecture
-                </th>
-                <th className="px-5 py-4 text-start font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted">
-                  RAM
-                </th>
-                <th className="px-5 py-4 text-start font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted">
-                  Disk
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {REQUIREMENTS.map((row) => (
-                <tr
-                  key={row.platform}
-                  className="border-b border-border/40 last:border-0 transition-colors hover:bg-paper-alt/40"
-                >
-                  <td className="px-6 py-4 text-sm font-medium text-ink">{row.platform}</td>
-                  <td className="px-5 py-4 text-sm text-ink/85">{row.os}</td>
-                  <td className="px-5 py-4 text-sm text-ink/85">{row.arch}</td>
-                  <td className="px-5 py-4 text-sm text-ink/85">{row.ram}</td>
-                  <td className="px-5 py-4 text-sm text-ink/85">{row.disk}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
         </motion.div>
       </Container>
     </section>

--- a/apps/landing/src/pages/Pricing.tsx
+++ b/apps/landing/src/pages/Pricing.tsx
@@ -142,18 +142,18 @@ function CheckoutNoticeBanner({ notice }: { notice: CheckoutNotice | null }) {
           ? 'Payment failed'
           : notice.type === 'canceled'
             ? 'Checkout canceled'
-            : 'Open Memry to continue'
+            : 'Open MemryNote to continue'
 
   const body =
     notice.type === 'success'
-      ? 'Memry will activate hosted sync after Paddle confirms the transaction.'
+      ? 'MemryNote will activate hosted sync after Paddle confirms the transaction.'
       : notice.type === 'pending'
-        ? 'Paddle is confirming the purchase. If Memry is open, refresh billing in Account.'
+        ? 'Paddle is confirming the purchase. If MemryNote is open, refresh billing in Account.'
         : notice.type === 'failed'
-          ? 'The payment was not completed. You can try again from Memry when ready.'
+          ? 'The payment was not completed. You can try again from MemryNote when ready.'
           : notice.type === 'canceled'
-            ? 'No charge was made. Start again from Memry when you are ready.'
-            : 'Memry desktop signs the checkout request so the purchase lands on your account.'
+            ? 'No charge was made. Start again from MemryNote when you are ready.'
+            : 'MemryNote desktop signs the checkout request so the purchase lands on your account.'
 
   const transactionId =
     notice.type === 'success' || notice.type === 'pending' ? notice.transactionId : null
@@ -184,7 +184,7 @@ function CheckoutNoticeBanner({ notice }: { notice: CheckoutNotice | null }) {
             >
               <a href={notice.type === 'desktop' ? notice.url : openMemryUrl}>
                 <ExternalLink className="h-3.5 w-3.5" aria-hidden />
-                Open Memry
+                Open MemryNote
               </a>
             </Button>
           )}

--- a/apps/landing/src/pages/Roadmap.tsx
+++ b/apps/landing/src/pages/Roadmap.tsx
@@ -76,7 +76,7 @@ const PLANNED_ITEMS: RoadmapItem[] = [
   },
   {
     title: 'Plugin API',
-    caption: 'Extend Memry with your own tools, integrations, and views.'
+    caption: 'Extend MemryNote with your own tools, integrations, and views.'
   },
   {
     title: 'Templates marketplace',
@@ -102,7 +102,7 @@ const LAUNCHED_GROUPS: LaunchedGroup[] = [
         title: 'Voice memos with transcription and related items',
         caption: 'Inline recorder, transcript previews, and audio-aware mention picker.'
       },
-      { title: 'Memry CLI' },
+      { title: 'MemryNote CLI' },
       { title: 'Landing demo refresh, founder story, and event analytics' }
     ]
   },

--- a/apps/landing/src/pages/Roadmap.tsx
+++ b/apps/landing/src/pages/Roadmap.tsx
@@ -31,12 +31,12 @@ interface LaunchedGroup {
 
 const ACTIVE_ITEMS: RoadmapItem[] = [
   {
-    title: 'Web clipper',
-    caption: 'Save pages, highlights, and snippets straight into your Inbox from any browser.'
+    title: 'Safari web clipper',
+    caption: 'Extend page, highlight, and snippet clipping to Safari alongside Chrome, Firefox, and Edge.'
   },
   {
-    title: 'Importers',
-    caption: 'Bring your knowledge base over from Obsidian, Notion, Roam, or any Markdown folder.'
+    title: 'Browser extension store listings',
+    caption: 'Publish the clipper to the Chrome Web Store, Firefox Add-ons, and Edge Add-ons.'
   },
   {
     title: 'Optional AI Agent public release polish',
@@ -89,6 +89,42 @@ const PLANNED_ITEMS: RoadmapItem[] = [
 ]
 
 const LAUNCHED_GROUPS: LaunchedGroup[] = [
+  {
+    period: 'July 2026',
+    items: [
+      {
+        title: 'Public launch',
+        caption:
+          'Direct downloads for macOS, Windows, and Linux, with purchases open and the waitlist retired.'
+      },
+      { title: 'Web clipper for Firefox and Edge' },
+      { title: 'Chrome Web Store publish pipeline' },
+      { title: 'Persistent Connect Google Calendar prompt' },
+      { title: 'Property-type icon doubles as a drag handle in properties' },
+      { title: 'Faster macOS auto-updates via app.asar repack' }
+    ]
+  },
+  {
+    period: 'June 2026',
+    items: [
+      {
+        title: 'Web clipper',
+        caption: 'Capture pages, highlights, and snippets straight into your Inbox from Chrome.'
+      },
+      {
+        title: 'Importers',
+        caption:
+          'Bring your vault over from Obsidian, Notion, Roam, Bear, Evernote, Apple Notes, Google Keep, Todoist, TickTick, Raindrop, and CSV.'
+      },
+      { title: 'Optional per-module toggles to turn features on or off' },
+      { title: 'First-run interactive onboarding tour' },
+      { title: 'Account and sync settings redesign' },
+      { title: 'Agent provider auto-save with inline connection checks' },
+      { title: 'Calendar drag-and-drop event reschedule and resize' },
+      { title: 'Broad native application menu bar' },
+      { title: 'Default white theme for new users' }
+    ]
+  },
   {
     period: 'May 2026',
     items: [


### PR DESCRIPTION
## Summary
Landing launch polish across the header, download page, changelog, and roadmap.

### Header
- Add an **Account** link (→ `/auth`, or `/account/billing` when signed in)
- Remove the orange **Download** CTA button (desktop + mobile); keep the Download dropdown

### Download page
- Remove the "System requirements" (*Modest needs.*) section
- Rebuild the platform picker into a minimal, card-free layout with **real Apple / Windows / Linux logos** (inline brand SVGs, no new dependency) — replaces the generic placeholder icons

### Changelog
- Add **June 2026** (features) and **July 2026** (public launch) entries, matching the existing monthly, features-only tone. All items grounded in June–July merges.

### Roadmap / Auth / Footer
- Roadmap: June/July milestones + refreshed launched items
- Auth: Google logo on "Continue with Google"
- Footer: brand logo mark

## Testing
- `tsc -b` (landing): **no errors**
- Whitespace + secret scan on staged diff: clean