### PR TITLE
fix(telemetry): diagnose validation 400s and stop retrying poison-pill batches

### DIFF
--- a/apps/desktop/src/main/telemetry/client.test.ts
+++ b/apps/desktop/src/main/telemetry/client.test.ts
@@ -174,6 +174,52 @@ describe('createTelemetryClient', () => {
     expect(client.getQueueDepth()).toBe(2)
   })
 
+  it('drops the batch on a 400 so a poison-pill event cannot wedge the queue', async () => {
+    // #given a server that permanently rejects the payload
+    const fetchMock = vi.fn(async () => new Response('bad', { status: 400 }))
+    const { deps } = createDeps({ fetch: fetchMock as unknown as TelemetryClientDeps['fetch'] })
+    const client = createTelemetryClient(deps)
+    client.track(buildEvent('11111111-1111-1111-1111-111111111111'))
+    client.track(buildEvent('22222222-2222-2222-2222-222222222222'))
+
+    // #when flushing
+    const result = await client.flush('manual')
+
+    // #then the rejected batch is dropped, not retried forever
+    expect(result.success).toBe(false)
+    expect(client.getQueueDepth()).toBe(0)
+  })
+
+  it('keeps the batch queued on a 429 rate-limit for a later retry', async () => {
+    // #given a transient rate-limit response
+    const fetchMock = vi.fn(async () => new Response('slow down', { status: 429 }))
+    const { deps } = createDeps({ fetch: fetchMock as unknown as TelemetryClientDeps['fetch'] })
+    const client = createTelemetryClient(deps)
+    client.track(buildEvent('11111111-1111-1111-1111-111111111111'))
+
+    // #when flushing
+    const result = await client.flush('manual')
+
+    // #then the batch stays queued because 429 is retryable
+    expect(result.success).toBe(false)
+    expect(client.getQueueDepth()).toBe(1)
+  })
+
+  it('keeps the batch queued on a 500 server error for a later retry', async () => {
+    // #given a transient server error
+    const fetchMock = vi.fn(async () => new Response('oops', { status: 500 }))
+    const { deps } = createDeps({ fetch: fetchMock as unknown as TelemetryClientDeps['fetch'] })
+    const client = createTelemetryClient(deps)
+    client.track(buildEvent('11111111-1111-1111-1111-111111111111'))
+
+    // #when flushing
+    const result = await client.flush('manual')
+
+    // #then the batch stays queued because 5xx is retryable
+    expect(result.success).toBe(false)
+    expect(client.getQueueDepth()).toBe(1)
+  })
+
   it('setEnabled(false) drops queued events and short-circuits future tracks', () => {
     // #given a client with queued events
     const { deps } = createDeps()

--- a/apps/desktop/src/main/telemetry/client.ts
+++ b/apps/desktop/src/main/telemetry/client.ts
@@ -122,7 +122,20 @@ export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClien
       })
 
       if (!response.ok) {
-        logger.warn('Telemetry batch rejected', { status: response.status, reason })
+        // A 4xx (except 429 rate limit) means the server permanently rejects this
+        // payload — e.g. a validation failure. Keeping it re-sends the same head-of-
+        // queue batch every flush, wedging the pipeline behind one bad event. Drop it.
+        // 5xx and 429 are transient, so leave those queued for a later retry.
+        const permanentlyRejected =
+          response.status >= 400 && response.status < 500 && response.status !== 429
+        if (permanentlyRejected) {
+          queue.splice(0, batchSize)
+        }
+        logger.warn('Telemetry batch rejected', {
+          status: response.status,
+          reason,
+          dropped: permanentlyRejected
+        })
         return {
           success: false,
           attempted: batchSize,

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -123,6 +123,18 @@ coherent across sign-in.
 - **Auth never blocks telemetry**: a missing or invalid bearer falls back to anonymous. Batches
   are never rejected for auth reasons.
 
+### Batch Validation & Retry
+
+Each `/telemetry/batch` payload is schema-validated on the sync server. A malformed batch is
+rejected with `400 VALIDATION_ERROR`. The server logs the failing field paths (Zod path + issue
+code only — never the field values, which may hold the raw identifiers the schema is designed to
+strip) so rejections are diagnosable without leaking data.
+
+The desktop client treats a permanent `4xx` (any `4xx` except `429`) as unrecoverable and drops
+that batch, so one malformed event cannot wedge the queue head and replay the same rejected batch
+on every flush. Transient failures — `5xx`, `429`, and network errors — leave the batch queued for
+a later retry.
+
 ### Autosave Event Throttling
 
 `note_updated` and `journal_updated` events fired by the autosave path are throttled to at most

--- a/apps/sync-server/src/routes/telemetry.test.ts
+++ b/apps/sync-server/src/routes/telemetry.test.ts
@@ -190,6 +190,27 @@ describe('POST /telemetry/batch', () => {
     expect(response.status).toBe(400)
   })
 
+  it('logs the failing field path (not its value) when the batch is invalid', async () => {
+    // #given an event whose action value trips the privacy dimension guard (contains a slash)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { env } = createEnv()
+    const request = new Request('http://localhost/telemetry/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...sampleBatch, events: [{ ...sampleEvent, action: 'opened/path' }] })
+    })
+
+    // #when posting
+    const response = await app.request(request, {}, env)
+
+    // #then it 400s and the log names the offending field but never leaks its value
+    expect(response.status).toBe(400)
+    const logged = warnSpy.mock.calls.map((call) => String(call[0])).join('\n')
+    expect(logged).toContain('events.0.action')
+    expect(logged).not.toContain('opened/path')
+    warnSpy.mockRestore()
+  })
+
   it('returns 400 for malformed JSON bodies', async () => {
     // #given an invalid JSON body
     const { env } = createEnv()

--- a/apps/sync-server/src/routes/telemetry.ts
+++ b/apps/sync-server/src/routes/telemetry.ts
@@ -3,10 +3,13 @@ import { Hono } from 'hono'
 import { TelemetryBatchSchema } from '@memry/contracts/telemetry-api'
 
 import { AppError, ErrorCodes } from '../lib/errors'
+import { createLogger } from '../lib/logger'
 import { verifyAccessToken } from '../lib/jwt-verify'
 import { createRateLimiter } from '../middleware/rate-limit'
 import { writeTelemetryBatch } from '../services/telemetry'
 import type { AppContext } from '../types'
+
+const logger = createLogger('Telemetry')
 
 export const telemetry = new Hono<AppContext>()
 
@@ -32,6 +35,14 @@ telemetry.post('/batch', async (c) => {
   const body = await c.req.json().catch(() => null)
   const parsed = TelemetryBatchSchema.safeParse(body)
   if (!parsed.success) {
+    // Surface which fields failed (path + zod code only — never the values, which
+    // may hold the raw identifiers the schema is designed to reject) so the 400 is
+    // diagnosable in logs instead of an opaque VALIDATION_ERROR.
+    logger.warn('Invalid telemetry payload', {
+      issues: parsed.error.issues
+        .slice(0, 10)
+        .map((issue) => `${issue.path.join('.') || '(root)'}:${issue.code}`)
+    })
     throw new AppError(ErrorCodes.VALIDATION_ERROR, 'Invalid telemetry payload', 400)
   }
 


### PR DESCRIPTION
## Problem

Production PostHog shows a steady stream of `server_error_seen` / `memry-sync-server:ErrorHandler:request_failed:VALIDATION_ERROR` on `POST /telemetry/batch` (HTTP 400), attributed to the synthetic `memry_sync_server_production` identity — so it looks like a mystery logged-out user.

Root cause: the desktop telemetry client posts a batch that fails `TelemetryBatchSchema` (most likely the `SafeDimensionValueSchema` privacy guard — a dimension/action value containing a slash, URL, email, UUID, or >64 chars). Two problems compound it:

1. **Undiagnosable** — the route throws a generic `VALIDATION_ERROR` and discards the Zod detail, so there's no way to tell *which* field failed.
2. **Self-perpetuating** — on a rejected batch the client logs a warning but never drops the events; it re-sends the same head-of-queue batch on every flush, so one malformed event wedges the queue and replays the 400 until it's trimmed at 500 events.

## Changes

- **Server** (`routes/telemetry.ts`): on validation failure, log the failing field paths — Zod `path` + issue `code` only, never the values (which may hold the raw identifiers the schema exists to strip). The 400 is now diagnosable from logs.
- **Client** (`main/telemetry/client.ts`): drop a batch on a permanent `4xx` (any `4xx` except `429`). One bad event can no longer block the queue. `5xx`, `429`, and network errors stay queued for retry, unchanged.
- **Docs** (`architecture/observability.md`): new "Batch Validation & Retry" subsection.

## Test plan

- `apps/sync-server` telemetry route tests — 14 pass, incl. new "logs the failing field path (not its value)".
- `apps/desktop` telemetry client tests — 17 pass, incl. new drop-on-400, keep-on-429, keep-on-500.
- `pnpm --filter @memry/sync-server typecheck` ✓ · `pnpm --filter @memry/desktop typecheck:node` ✓
- lint (changed files) ✓ · `pnpm docs:impact --base origin/main --strict` → covered ✓ · `pnpm docs:build` ✓

## Notes

Fix is internal reliability only — no API/schema/user-facing surface change. It stops the noise and, next time a real batch is rejected, the server log will name the exact offending field so we can fix the client emitter at the source.