### PR TITLE
feat(landing): route pricing CTAs to web checkout with auth gate

### DIFF
--- a/apps/landing/src/components/account/CheckoutPanel.tsx
+++ b/apps/landing/src/components/account/CheckoutPanel.tsx
@@ -26,11 +26,20 @@ function cadenceSuffix(label: 'Monthly' | 'Yearly' | 'One-time') {
 interface CheckoutPanelProps {
   token: string | null
   onTokenMissing?: ReactNode
+  initialPlan?: CheckoutPlanId
+  initialCadence?: PaddleCheckoutCadence
 }
 
-export function CheckoutPanel({ token, onTokenMissing }: CheckoutPanelProps) {
-  const [plan, setPlan] = useState<CheckoutPlanId>('pro')
-  const [cadence, setCadence] = useState<PaddleCheckoutCadence>('annual')
+export function CheckoutPanel({
+  token,
+  onTokenMissing,
+  initialPlan = 'pro',
+  initialCadence = 'annual'
+}: CheckoutPanelProps) {
+  const [plan, setPlan] = useState<CheckoutPlanId>(initialPlan)
+  const [cadence, setCadence] = useState<PaddleCheckoutCadence>(() =>
+    normalizeCadenceForPlan(initialPlan, initialCadence)
+  )
   const [status, setStatus] = useState<CheckoutStatus>('idle')
   const [error, setError] = useState<string | null>(null)
   const completedRef = useRef(false)

--- a/apps/landing/src/lib/account/next-path.test.ts
+++ b/apps/landing/src/lib/account/next-path.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { safeNextPath } from './next-path'
+
+describe('safeNextPath', () => {
+  it('keeps same-origin relative paths', () => {
+    assert.equal(
+      safeNextPath('/checkout?plan=pro&cadence=annual'),
+      '/checkout?plan=pro&cadence=annual'
+    )
+    assert.equal(safeNextPath('/account/billing'), '/account/billing')
+  })
+
+  it('falls back for empty or missing values', () => {
+    assert.equal(safeNextPath(null), '/account/profile')
+    assert.equal(safeNextPath(undefined), '/account/profile')
+    assert.equal(safeNextPath(''), '/account/profile')
+  })
+
+  it('rejects open-redirect attempts', () => {
+    assert.equal(safeNextPath('https://evil.com'), '/account/profile')
+    assert.equal(safeNextPath('//evil.com'), '/account/profile')
+    assert.equal(safeNextPath('/\\evil.com'), '/account/profile')
+    assert.equal(safeNextPath('javascript:alert(1)'), '/account/profile')
+  })
+
+  it('honors a custom fallback', () => {
+    assert.equal(safeNextPath(null, '/checkout'), '/checkout')
+  })
+})

--- a/apps/landing/src/lib/account/next-path.ts
+++ b/apps/landing/src/lib/account/next-path.ts
@@ -1,0 +1,15 @@
+// Carries the post-login destination across the Google OAuth round-trip (the
+// redirect leaves the SPA, so query state is lost — sessionStorage survives it).
+export const OAUTH_NEXT_STORAGE_KEY = 'memry:auth:next'
+
+// Post-login redirect target. Open-redirect guard: only same-origin relative
+// paths are allowed. Rejects absolute URLs and protocol-relative `//host` (and
+// the `/\host` variant some browsers normalize to protocol-relative).
+export function safeNextPath(
+  next: string | null | undefined,
+  fallback = '/account/profile'
+): string {
+  if (!next || !next.startsWith('/')) return fallback
+  if (next[1] === '/' || next[1] === '\\') return fallback
+  return next
+}

--- a/apps/landing/src/pages/Auth.tsx
+++ b/apps/landing/src/pages/Auth.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { PageHead } from '@/components/shared/PageHead'
@@ -7,9 +7,11 @@ import { Container } from '@/components/layout/Container'
 import { useAuth } from '@/contexts/auth-context'
 import { registerWebDevice } from '@/lib/account/auth-client'
 import { SYNC_SERVER_URL, WEB_OAUTH_REDIRECT_PATH } from '@/lib/account/config'
+import { OAUTH_NEXT_STORAGE_KEY, safeNextPath } from '@/lib/account/next-path'
 import { trackLandingEvent } from '@/lib/analytics'
 
-function continueWithGoogle() {
+function continueWithGoogle(next: string | null) {
+  sessionStorage.setItem(OAUTH_NEXT_STORAGE_KEY, next ?? '')
   const redirectUri = `${window.location.origin}${WEB_OAUTH_REDIRECT_PATH}`
   window.location.href = `${SYNC_SERVER_URL}/auth/oauth/google?redirect_uri=${encodeURIComponent(redirectUri)}`
 }
@@ -17,6 +19,9 @@ function continueWithGoogle() {
 export function AuthPage() {
   const { api, storage, refreshSignedIn } = useAuth()
   const navigate = useNavigate()
+  const [params] = useSearchParams()
+  const next = params.get('next')
+  const toCheckout = safeNextPath(next).startsWith('/checkout')
   const [email, setEmail] = useState('')
   const [code, setCode] = useState('')
   const [step, setStep] = useState<'email' | 'code'>('email')
@@ -50,7 +55,7 @@ export function AuthPage() {
       await registerWebDevice({ setupToken: res.setupToken, baseUrl: SYNC_SERVER_URL, storage })
       refreshSignedIn()
       trackLandingEvent('landing_account_signin', 'auth:otp')
-      navigate('/account/profile')
+      navigate(safeNextPath(next))
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Invalid code')
     } finally {
@@ -64,15 +69,18 @@ export function AuthPage() {
       <main className="py-24">
         <Container size="sm">
           <div className="mx-auto max-w-sm rounded-2xl border border-border bg-card p-8 shadow-card">
-            <h1 className="font-editorial text-xl tracking-[-0.01em]">Sign in to MemryNote</h1>
+            <h1 className="font-editorial text-xl tracking-[-0.01em]">
+              {toCheckout ? 'Sign in to continue' : 'Sign in to MemryNote'}
+            </h1>
+            {toCheckout ? (
+              <p className="mt-2 text-sm text-muted">
+                Log in first to choose your plan and check out.
+              </p>
+            ) : null}
             {error ? <p className="mt-3 text-sm text-red-500">{error}</p> : null}
             {step === 'email' ? (
               <div className="mt-6 space-y-3">
-                <Input
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                />
+                <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
                 <Button className="w-full" disabled={busy || !email} onClick={requestCode}>
                   {busy ? 'Sending…' : 'Email me a code'}
                 </Button>
@@ -98,7 +106,7 @@ export function AuthPage() {
             <Button
               variant="outline"
               className="inline-flex w-full items-center justify-center gap-2"
-              onClick={continueWithGoogle}
+              onClick={() => continueWithGoogle(next)}
             >
               <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
                 <path

--- a/apps/landing/src/pages/AuthCallback.tsx
+++ b/apps/landing/src/pages/AuthCallback.tsx
@@ -4,6 +4,7 @@ import { Container } from '@/components/layout/Container'
 import { useAuth } from '@/contexts/auth-context'
 import { registerWebDevice } from '@/lib/account/auth-client'
 import { SYNC_SERVER_URL } from '@/lib/account/config'
+import { OAUTH_NEXT_STORAGE_KEY, safeNextPath } from '@/lib/account/next-path'
 import { trackLandingEvent } from '@/lib/analytics'
 
 export function AuthCallbackPage() {
@@ -29,7 +30,9 @@ export function AuthCallbackPage() {
         await registerWebDevice({ setupToken: res.setupToken, baseUrl: SYNC_SERVER_URL, storage })
         refreshSignedIn()
         trackLandingEvent('landing_account_signin', 'auth:google')
-        navigate('/account/profile', { replace: true })
+        const stored = sessionStorage.getItem(OAUTH_NEXT_STORAGE_KEY)
+        sessionStorage.removeItem(OAUTH_NEXT_STORAGE_KEY)
+        navigate(safeNextPath(stored), { replace: true })
       } catch (e) {
         setCallbackError(e instanceof Error ? e.message : 'Sign-in failed')
       }

--- a/apps/landing/src/pages/Checkout.tsx
+++ b/apps/landing/src/pages/Checkout.tsx
@@ -1,24 +1,149 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { Navigate, useSearchParams } from 'react-router-dom'
 import { Container } from '@/components/layout/Container'
 import { PageHead } from '@/components/shared/PageHead'
+import { Button } from '@/components/ui/button'
 import { CheckoutPanel, NoTokenNotice } from '@/components/account/CheckoutPanel'
 import { parseCheckoutToken } from '@/lib/checkout-summary'
+import { useAuth } from '@/contexts/auth-context'
+import type { CheckoutPlanId } from '@/lib/constants'
+import type { PaddleCheckoutCadence } from '@/lib/paddle-checkout'
 
 const NO_TOKEN_NOTICE = <NoTokenNotice />
 
+function parsePlan(value: string | null): CheckoutPlanId | undefined {
+  return value === 'plus' || value === 'pro' || value === 'believer' ? value : undefined
+}
+
+function parseCadence(value: string | null): PaddleCheckoutCadence | undefined {
+  return value === 'monthly' || value === 'annual' || value === 'lifetime' ? value : undefined
+}
+
 export function CheckoutPage() {
-  const [token] = useState<string | null>(() =>
+  const { ready, isSignedIn, api } = useAuth()
+  const [params] = useSearchParams()
+  const initialPlan = parsePlan(params.get('plan'))
+  const initialCadence = parseCadence(params.get('cadence'))
+
+  // Desktop opens /checkout#token=<checkoutToken>. Web pricing has no hash token
+  // and mints one from the signed-in session instead.
+  const [hashToken] = useState<string | null>(() =>
     typeof window === 'undefined' ? null : parseCheckoutToken(window.location.hash)
   )
+  const [webToken, setWebToken] = useState<string | null>(null)
+  const [minting, setMinting] = useState(false)
+  const [mintError, setMintError] = useState<string | null>(null)
+
+  const mintToken = useCallback(async () => {
+    setMinting(true)
+    setMintError(null)
+    try {
+      const res = await api.authedJson<{ checkoutToken: string }>('/auth/checkout-token', {
+        method: 'POST'
+      })
+      setWebToken(res.checkoutToken)
+    } catch {
+      setMintError('Could not start checkout. Please try again.')
+    } finally {
+      setMinting(false)
+    }
+  }, [api])
+
+  useEffect(() => {
+    if (hashToken || !ready || !isSignedIn || webToken || minting || mintError) return
+    void mintToken()
+  }, [hashToken, ready, isSignedIn, webToken, minting, mintError, mintToken])
 
   return (
     <>
       <PageHead page="pricing" />
       <main className="overflow-hidden py-16 md:py-24">
         <Container size="sm">
-          <CheckoutPanel token={token} onTokenMissing={NO_TOKEN_NOTICE} />
+          <CheckoutContent
+            hashToken={hashToken}
+            ready={ready}
+            isSignedIn={isSignedIn}
+            search={params.toString()}
+            webToken={webToken}
+            mintError={mintError}
+            onRetry={mintToken}
+            initialPlan={initialPlan}
+            initialCadence={initialCadence}
+          />
         </Container>
       </main>
     </>
+  )
+}
+
+function CheckoutContent({
+  hashToken,
+  ready,
+  isSignedIn,
+  search,
+  webToken,
+  mintError,
+  onRetry,
+  initialPlan,
+  initialCadence
+}: {
+  hashToken: string | null
+  ready: boolean
+  isSignedIn: boolean
+  search: string
+  webToken: string | null
+  mintError: string | null
+  onRetry: () => void
+  initialPlan?: CheckoutPlanId
+  initialCadence?: PaddleCheckoutCadence
+}) {
+  // Desktop-minted token path (unchanged).
+  if (hashToken) {
+    return (
+      <CheckoutPanel
+        token={hashToken}
+        onTokenMissing={NO_TOKEN_NOTICE}
+        initialPlan={initialPlan}
+        initialCadence={initialCadence}
+      />
+    )
+  }
+
+  if (!ready) return null // avoid SSR/first-paint flash
+
+  if (!isSignedIn) {
+    const next = search ? `/checkout?${search}` : '/checkout'
+    return <Navigate to={`/auth?next=${encodeURIComponent(next)}`} replace />
+  }
+
+  if (mintError) {
+    return (
+      <CheckoutNotice>
+        <p className="text-sm text-terracotta">{mintError}</p>
+        <Button className="mt-4" onClick={onRetry}>
+          Try again
+        </Button>
+      </CheckoutNotice>
+    )
+  }
+
+  if (!webToken) {
+    return (
+      <CheckoutNotice>
+        <p className="text-sm text-muted">Preparing checkout…</p>
+      </CheckoutNotice>
+    )
+  }
+
+  return (
+    <CheckoutPanel token={webToken} initialPlan={initialPlan} initialCadence={initialCadence} />
+  )
+}
+
+function CheckoutNotice({ children }: { children: ReactNode }) {
+  return (
+    <div className="animate-fade-up mx-auto max-w-sm rounded-2xl border border-border bg-card p-8 text-center shadow-card">
+      {children}
+    </div>
   )
 }

--- a/apps/landing/src/pages/Pricing.tsx
+++ b/apps/landing/src/pages/Pricing.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { Check, ArrowRight, ShieldCheck, ExternalLink } from 'lucide-react'
 import { Container } from '@/components/layout/Container'
@@ -17,23 +17,17 @@ import {
   LIFECYCLE_STAGES,
   PRICING_FAQ_ITEMS,
   CHECKOUT_RELEASE_TIMING,
-  type CheckoutPlanId,
   type PlanComparisonValue,
   type SyncPlanTier,
   type LifecycleTone
 } from '@/lib/constants'
-import {
-  buildMemryBillingCompleteUrl,
-  buildMemryBillingStartUrl,
-  type PaddleCheckoutCadence
-} from '@/lib/paddle-checkout'
+import { buildMemryBillingCompleteUrl, type PaddleCheckoutCadence } from '@/lib/paddle-checkout'
 import { cn } from '@/lib/utils'
 import { BLUR_REVEAL_ANIMATE, BLUR_REVEAL_INITIAL, BLUR_REVEAL_TRANSITION } from '@/lib/motion'
 import { trackLandingEvent } from '@/lib/analytics'
 
 type Cadence = 'monthly' | 'annual'
 type CheckoutState = {
-  pendingKey: string | null
   error: string | null
   notice: CheckoutNotice | null
 }
@@ -42,7 +36,6 @@ type CheckoutNotice =
   | { type: 'pending'; transactionId: string | null }
   | { type: 'failed' }
   | { type: 'canceled' }
-  | { type: 'desktop'; url: string }
 
 const PURCHASES_ENABLED = true
 
@@ -56,37 +49,29 @@ const fadeUp = {
 const ASSURANCES = ['Cancel anytime', 'VAT handled by Paddle', 'Prices in USD']
 
 export function PricingPage() {
+  const navigate = useNavigate()
   const [cadence, setCadence] = useState<Cadence>('annual')
-  const [checkout, setCheckout] = useState<CheckoutState>(() => {
+  const [checkout] = useState<CheckoutState>(() => {
     if (typeof window === 'undefined') {
-      return { pendingKey: null, error: null, notice: null }
+      return { error: null, notice: null }
     }
     const params = new URLSearchParams(window.location.search)
     if (params.get('checkout') === 'success') {
       return {
-        pendingKey: null,
         error: null,
         notice: { type: 'success', transactionId: params.get('transactionId') }
       }
     }
-    return { pendingKey: null, error: null, notice: null }
+    return { error: null, notice: null }
   })
 
-  const handleCheckout = async (tier: SyncPlanTier) => {
+  const handleCheckout = (tier: SyncPlanTier) => {
     if (!PURCHASES_ENABLED || !tier.checkoutPlanId) return
 
     const checkoutCadence = getCheckoutCadence(tier, cadence)
-    const pendingKey = getCheckoutKey(tier.checkoutPlanId, checkoutCadence)
-    const desktopUrl = buildMemryBillingStartUrl(tier.checkoutPlanId, checkoutCadence)
-
     trackLandingEvent('landing_pricing_cta_click', pricingTarget(tier.id, checkoutCadence))
-    setCheckout({ pendingKey, error: null, notice: { type: 'desktop', url: desktopUrl } })
-    window.location.href = desktopUrl
-    window.setTimeout(() => {
-      setCheckout((current) =>
-        current.pendingKey === pendingKey ? { ...current, pendingKey: null } : current
-      )
-    }, 1000)
+    const params = new URLSearchParams({ plan: tier.checkoutPlanId, cadence: checkoutCadence })
+    navigate(`/checkout?${params.toString()}`)
   }
 
   return (
@@ -115,10 +100,6 @@ function getCheckoutCadence(tier: SyncPlanTier, cadence: Cadence): PaddleCheckou
   return tier.id === 'believer' ? 'lifetime' : cadence
 }
 
-function getCheckoutKey(planId: CheckoutPlanId, cadence: PaddleCheckoutCadence) {
-  return `${planId}:${cadence}`
-}
-
 function pricingTarget(tierId: string, cadence: string) {
   return `pricing:${tierId}:${cadence}`
 }
@@ -140,9 +121,7 @@ function CheckoutNoticeBanner({ notice }: { notice: CheckoutNotice | null }) {
         ? 'Activation pending'
         : notice.type === 'failed'
           ? 'Payment failed'
-          : notice.type === 'canceled'
-            ? 'Checkout canceled'
-            : 'Open MemryNote to continue'
+          : 'Checkout canceled'
 
   const body =
     notice.type === 'success'
@@ -151,9 +130,7 @@ function CheckoutNoticeBanner({ notice }: { notice: CheckoutNotice | null }) {
         ? 'Paddle is confirming the purchase. If MemryNote is open, refresh billing in Account.'
         : notice.type === 'failed'
           ? 'The payment was not completed. You can try again from MemryNote when ready.'
-          : notice.type === 'canceled'
-            ? 'No charge was made. Start again from MemryNote when you are ready.'
-            : 'MemryNote desktop signs the checkout request so the purchase lands on your account.'
+          : 'No charge was made. Start again from MemryNote when you are ready.'
 
   const transactionId =
     notice.type === 'success' || notice.type === 'pending' ? notice.transactionId : null
@@ -173,16 +150,14 @@ function CheckoutNoticeBanner({ notice }: { notice: CheckoutNotice | null }) {
             <p className="font-mono-accent text-[11px] uppercase tracking-[0.18em]">{title}</p>
             <p className="mt-1 text-ink/75">{body}</p>
           </div>
-          {(notice.type === 'success' ||
-            notice.type === 'pending' ||
-            notice.type === 'desktop') && (
+          {(notice.type === 'success' || notice.type === 'pending') && (
             <Button
               variant="outline"
               size="sm"
               className="shrink-0 rounded-sm border-ink/20 bg-transparent text-ink hover:bg-paper-alt"
               asChild
             >
-              <a href={notice.type === 'desktop' ? notice.url : openMemryUrl}>
+              <a href={openMemryUrl}>
                 <ExternalLink className="h-3.5 w-3.5" aria-hidden />
                 Open MemryNote
               </a>
@@ -318,17 +293,7 @@ function TierGrid({
                   tier.emphasis === 'founding' && 'xl:border-s-0'
                 )}
               >
-                <TierCard
-                  tier={tier}
-                  cadence={cadence}
-                  isPending={
-                    PURCHASES_ENABLED &&
-                    !!tier.checkoutPlanId &&
-                    checkout.pendingKey ===
-                      getCheckoutKey(tier.checkoutPlanId, getCheckoutCadence(tier, cadence))
-                  }
-                  onCheckout={() => onCheckout(tier)}
-                />
+                <TierCard tier={tier} cadence={cadence} onCheckout={() => onCheckout(tier)} />
               </div>
             ))}
           </div>
@@ -364,19 +329,16 @@ function TierGrid({
 function TierCard({
   tier,
   cadence,
-  isPending,
   onCheckout
 }: {
   tier: SyncPlanTier
   cadence: Cadence
-  isPending: boolean
   onCheckout: () => void
 }) {
   const isFounding = tier.emphasis === 'founding'
   const isRecommended = tier.emphasis === 'recommended'
   const isCheckoutEnabled = PURCHASES_ENABLED && !!tier.checkoutPlanId
   const isCheckoutUnavailable = !PURCHASES_ENABLED && !!tier.checkoutPlanId
-  const ctaLabel = isPending ? 'Opening checkout...' : tier.cta
 
   const ctaClass = isRecommended
     ? 'w-full rounded-sm bg-terracotta text-white hover:bg-terracotta-dark'
@@ -473,12 +435,11 @@ function TierCard({
           <Button
             variant={isRecommended ? 'default' : 'outline'}
             size="lg"
-            disabled={isPending}
             onClick={onCheckout}
-            aria-label={ctaLabel}
+            aria-label={tier.cta}
             className={ctaClass}
           >
-            {ctaLabel}
+            {tier.cta}
           </Button>
         )}
       </div>

--- a/scripts/check-staged-secrets.mjs
+++ b/scripts/check-staged-secrets.mjs
@@ -86,6 +86,15 @@ function isSourceCodeReferenceValue(filePath, value) {
 
   const normalized = normalizeValue(value)
 
+  // JSX expression container / object shorthand: `{ident}` wraps a code
+  // reference, not a secret literal. Unwrap one layer and re-check the inner
+  // expression. A quoted string inside stays flagged (isQuotedValue guard),
+  // and real secret formats are caught by tokenPatterns regardless.
+  const jsxInner = normalized.match(/^\{\s*(.+?)\s*\}$/)
+  if (jsxInner && !isQuotedValue(jsxInner[1])) {
+    return isSourceCodeReferenceValue(filePath, jsxInner[1])
+  }
+
   return (
     isTypeScriptTypeValue(normalized) ||
     /^[A-Za-z_$][\w$]*$/.test(normalized) ||

--- a/scripts/check-staged-secrets.test.mjs
+++ b/scripts/check-staged-secrets.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { scanTextForSecrets } from './check-staged-secrets.mjs'
+
+const rules = (text) => scanTextForSecrets('apps/example/Component.tsx', text).map((f) => f.rule)
+
+describe('check-staged-secrets JSX handling', () => {
+  it('ignores token-named JSX props whose value is a code reference', () => {
+    const jsx = [
+      '<CheckoutPanel',
+      '  token={webToken}',
+      '  onTokenMissing={NO_TOKEN_NOTICE}',
+      '/>'
+    ].join('\n')
+    assert.deepEqual(rules(jsx), [])
+  })
+
+  it('still flags a token-named prop assigned a quoted string literal', () => {
+    assert.deepEqual(rules('  token={"supersecretvalue123"}'), ['high-risk-secret-assignment'])
+  })
+})


### PR DESCRIPTION
## What

Pricing **Get Plus / Get Pro / Get Believer** buttons opened the desktop app via a `memry://billing/start` deep link. They now route into the existing web checkout, gated on web sign-in.

## Flow

```
Pricing "Get Pro"  →  /checkout?plan=pro&cadence=annual
  ├ #token= present (desktop)  → plan selector with that token (unchanged)
  ├ signed out                 → /auth?next=/checkout?…  ("Log in first to choose your plan")
  │                                 → sign in → back to /checkout, plan preselected
  └ signed in                  → POST /auth/checkout-token → plan selector → Paddle overlay
```

## Changes (`apps/landing`, no server changes — endpoints already existed)

- **`Pricing.tsx`** — CTA `navigate('/checkout?plan=…&cadence=…')` instead of the `memry://` redirect. Removed the now-dead desktop-redirect machinery (`pendingKey`, `'desktop'` notice variant, `getCheckoutKey`, `buildMemryBillingStartUrl` import, "Opening checkout…" state).
- **`Checkout.tsx`** — reads `plan`/`cadence` from the query, gates on `useAuth()`: signed-out → `<Navigate to="/auth?next=…">`; signed-in → mints a checkout token via `POST /auth/checkout-token`, then renders the plan selector → Paddle. Desktop `#token=` path preserved. Adds "Preparing checkout…" + a retry error state.
- **`CheckoutPanel.tsx`** — optional `initialPlan` / `initialCadence` props (default `pro` / `annual`).
- **`Auth.tsx` / `AuthCallback.tsx`** — honor `?next=`; OTP navigates there, Google carries it across the OAuth round-trip via `sessionStorage`; checkout intent swaps the heading to a "login first" hint.
- **`next-path.ts` (+ test)** — `safeNextPath()` open-redirect guard (same-origin relative paths only) + shared OAuth storage key.
- **`scripts/check-staged-secrets.mjs` (+ test)** — unwrap JSX expression containers (`{ident}`) in the code-reference allowlist so multiline token-named props aren't false positives; quoted literals inside JSX stay flagged; real secret formats still caught by `tokenPatterns`.

## Verify

- `pnpm --filter @memry/landing typecheck` ✓
- `pnpm --filter @memry/landing lint` ✓ (only pre-existing warning in untouched `auth-context.tsx`)
- `pnpm --filter @memry/landing test` ✓ (incl. new `safeNextPath` suite)
- `node --test scripts/check-staged-secrets.test.mjs` ✓