### PR TITLE
fix(sync-server): use Desktop OAuth client for desktop loopback sign-in

### DIFF
--- a/apps/sync-server/src/routes/auth.test.ts
+++ b/apps/sync-server/src/routes/auth.test.ts
@@ -785,6 +785,47 @@ describe('auth routes', () => {
       const json = (await res.json()) as { error: { code: string } }
       expect(json.error.code).toBe(ErrorCodes.VALIDATION_ERROR)
     })
+
+    it('should use the desktop client for loopback redirects when configured', async () => {
+      const envWithDesktop = {
+        ...env,
+        GOOGLE_DESKTOP_CLIENT_ID: 'mock-desktop-client-id',
+        GOOGLE_DESKTOP_CLIENT_SECRET: 'mock-desktop-client-secret'
+      }
+      const res = await app.request(
+        `/auth/oauth/google?redirect_uri=${encodeURIComponent('http://127.0.0.1:54321/callback')}`,
+        { method: 'GET' },
+        envWithDesktop
+      )
+
+      expect(res.status).toBe(302)
+      const location = res.headers.get('Location') ?? ''
+      expect(location).toContain('client_id=mock-desktop-client-id')
+      expect(location).not.toContain('client_id=mock-google-client-id')
+    })
+
+    it('should fall back to the web client for loopback redirects when desktop client is unset', async () => {
+      const res = await app.request(
+        `/auth/oauth/google?redirect_uri=${encodeURIComponent('http://127.0.0.1:54321/callback')}`,
+        { method: 'GET' },
+        env
+      )
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location') ?? '').toContain('client_id=mock-google-client-id')
+    })
+
+    it('should fall back to the web client for loopback when desktop secret is missing', async () => {
+      const envIdOnly = { ...env, GOOGLE_DESKTOP_CLIENT_ID: 'mock-desktop-client-id' }
+      const res = await app.request(
+        `/auth/oauth/google?redirect_uri=${encodeURIComponent('http://127.0.0.1:54321/callback')}`,
+        { method: 'GET' },
+        envIdOnly
+      )
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location') ?? '').toContain('client_id=mock-google-client-id')
+    })
   })
 
   // ==========================================================================
@@ -800,6 +841,38 @@ describe('auth routes', () => {
           json: () => Promise.resolve({ id_token: 'mock-id-token' })
         })
       )
+    })
+
+    it('should exchange the code with the desktop client for loopback redirects', async () => {
+      // #given a loopback redirect carried in the OAuth state
+      const fetchSpy = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id_token: 'mock-id-token' })
+      })
+      vi.stubGlobal('fetch', fetchSpy)
+      vi.mocked(jwtVerify).mockResolvedValueOnce({
+        payload: { type: 'oauth_state', redirect_uri: 'http://127.0.0.1:5000/callback' }
+      } as never)
+
+      const envWithDesktop = {
+        ...env,
+        GOOGLE_DESKTOP_CLIENT_ID: 'mock-desktop-client-id',
+        GOOGLE_DESKTOP_CLIENT_SECRET: 'mock-desktop-client-secret'
+      }
+
+      // #when
+      const res = await app.request(
+        '/auth/oauth/google/callback',
+        jsonPost('/auth/oauth/google/callback', { code: 'auth-code', state: 'valid-state' }),
+        envWithDesktop
+      )
+
+      // #then the token exchange uses the desktop credential, not the web one
+      expect(res.status).toBe(200)
+      const sentBody = (fetchSpy.mock.calls[0][1] as { body: URLSearchParams }).body
+      const params = new URLSearchParams(sentBody.toString())
+      expect(params.get('client_id')).toBe('mock-desktop-client-id')
+      expect(params.get('client_secret')).toBe('mock-desktop-client-secret')
     })
 
     it('should return 200 with setupToken and isNewUser on valid callback', async () => {

--- a/apps/sync-server/src/routes/auth.ts
+++ b/apps/sync-server/src/routes/auth.ts
@@ -58,7 +58,7 @@ import {
 } from '../services/entitlements'
 import { captureBusinessEvent, safeWaitUntil } from '../services/posthog'
 import { deleteUserData } from '../services/account-deletion'
-import type { AppContext } from '../types'
+import type { AppContext, Bindings } from '../types'
 
 const logger = createLogger('Auth')
 
@@ -185,6 +185,30 @@ export const verifyOAuthState = async (
   return { redirectUri: payload.redirect_uri as string | undefined }
 }
 
+const isLoopbackRedirect = (uri: string): boolean =>
+  /^http:\/\/127\.0\.0\.1(:\d+)?(\/.*)?$/.test(uri)
+
+// Google requires a "Desktop app" OAuth client for the 127.0.0.1 loopback the
+// desktop app uses, and a "Web application" client for the site's https
+// redirect. Same code path, different credential — pick by redirect type.
+// Falls back to the web client when the desktop client isn't configured.
+const resolveGoogleClient = (
+  env: Bindings,
+  redirectUri: string
+): { clientId: string; clientSecret: string } => {
+  if (
+    isLoopbackRedirect(redirectUri) &&
+    env.GOOGLE_DESKTOP_CLIENT_ID &&
+    env.GOOGLE_DESKTOP_CLIENT_SECRET
+  ) {
+    return {
+      clientId: env.GOOGLE_DESKTOP_CLIENT_ID,
+      clientSecret: env.GOOGLE_DESKTOP_CLIENT_SECRET
+    }
+  }
+  return { clientId: env.GOOGLE_CLIENT_ID, clientSecret: env.GOOGLE_CLIENT_SECRET }
+}
+
 export const auth = new Hono<AppContext>()
 
 // POST /otp/request
@@ -270,8 +294,7 @@ auth.get('/oauth/:provider', async (c) => {
   const clientRedirectUri = c.req.query('redirect_uri')
   const redirectUri = clientRedirectUri ?? c.env.GOOGLE_REDIRECT_URI
 
-  const isLoopback =
-    clientRedirectUri != null && /^http:\/\/127\.0\.0\.1(:\d+)?(\/.*)?$/.test(clientRedirectUri)
+  const isLoopback = clientRedirectUri != null && isLoopbackRedirect(clientRedirectUri)
   const isConfiguredWeb =
     clientRedirectUri != null && clientRedirectUri === c.env.WEB_OAUTH_REDIRECT_URI
 
@@ -284,9 +307,10 @@ auth.get('/oauth/:provider', async (c) => {
   }
 
   const state = await generateOAuthState(c.env.JWT_PRIVATE_KEY, redirectUri)
+  const { clientId } = resolveGoogleClient(c.env, redirectUri)
 
   const params = new URLSearchParams({
-    client_id: c.env.GOOGLE_CLIENT_ID,
+    client_id: clientId,
     redirect_uri: redirectUri,
     response_type: 'code',
     scope: 'openid email profile',
@@ -314,14 +338,15 @@ auth.post('/oauth/:provider/callback', async (c) => {
 
   const statePayload = await verifyOAuthState(state, c.env.JWT_PUBLIC_KEY)
   const redirectUri = statePayload.redirectUri ?? c.env.GOOGLE_REDIRECT_URI
+  const { clientId, clientSecret } = resolveGoogleClient(c.env, redirectUri)
 
   const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
       code,
-      client_id: c.env.GOOGLE_CLIENT_ID,
-      client_secret: c.env.GOOGLE_CLIENT_SECRET,
+      client_id: clientId,
+      client_secret: clientSecret,
       redirect_uri: redirectUri,
       grant_type: 'authorization_code'
     })
@@ -336,7 +361,7 @@ auth.post('/oauth/:provider/callback', async (c) => {
     throw new AppError(ErrorCodes.AUTH_INVALID_TOKEN, 'No ID token in response', 401)
   }
 
-  const claims = await validateGoogleIdToken(tokenData.id_token, c.env.GOOGLE_CLIENT_ID)
+  const claims = await validateGoogleIdToken(tokenData.id_token, clientId)
 
   const { user, isNewUser } = await getOrCreateUserByEmail(c.env.DB, claims.email, {
     authMethod: 'oauth',

--- a/apps/sync-server/src/types.ts
+++ b/apps/sync-server/src/types.ts
@@ -15,6 +15,8 @@ export type Bindings = {
   GOOGLE_CLIENT_ID: string
   GOOGLE_CLIENT_SECRET: string
   GOOGLE_REDIRECT_URI: string
+  GOOGLE_DESKTOP_CLIENT_ID?: string
+  GOOGLE_DESKTOP_CLIENT_SECRET?: string
   WEB_OAUTH_REDIRECT_URI?: string
   MIN_APP_VERSION: string
   RECOVERY_DUMMY_SECRET: string


### PR DESCRIPTION
## Problem

In the packaged desktop app, "Continue with Google" fails with **Error 400: `redirect_uri_mismatch`**.

The desktop sign-in uses a `http://127.0.0.1:<port>/callback` loopback redirect, but the sync-server authorized it with the **Web-application** `GOOGLE_CLIENT_ID`. Google only accepts a loopback redirect for a **Desktop-app** OAuth client, so the Web client rejects it. Dev worked because it talks to a Google client that accepts the loopback; production uses the Web client.

## Fix

The sync-server already knows whether a redirect is loopback (desktop) vs the configured web origin. It now selects the credential to match:

- **Loopback redirect** (`127.0.0.1`) → Desktop client (`GOOGLE_DESKTOP_CLIENT_ID` / `GOOGLE_DESKTOP_CLIENT_SECRET`)
- **Web-origin redirect** → Web client (`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`, unchanged)

Applied consistently across authorize, token exchange, and id_token audience validation. Requires **both** desktop id and secret to be set; otherwise it falls back to the Web client, so behavior is unchanged until the desktop secrets are configured. No desktop app rebuild needed — the fix is entirely server-side.

## Required before this takes effect (deploy config)

Set the Desktop OAuth client credentials as sync-server secrets (staging + prod):

```bash
# apps/sync-server
wrangler secret put GOOGLE_DESKTOP_CLIENT_ID     --env production
wrangler secret put GOOGLE_DESKTOP_CLIENT_SECRET --env production
# repeat with --env staging
```

Set secrets **before** deploying this code so there's no window where the code expects a secret that doesn't exist yet.

## Testing

- `apps/sync-server/src/routes/auth.test.ts`: added coverage for desktop-client selection on loopback, web fallback when desktop is unset, and web fallback when only the id is set. Token-exchange test asserts the desktop credential is used.
- Full run: `211 passed / 0 failed` for the auth route suite; sync-server typecheck clean. (`schema/d1.test.ts` fails locally on a pre-existing `better-sqlite3` NODE_MODULE_VERSION mismatch, unrelated to this change.)

## Docs

No docs update: this is an internal OAuth credential-selection fix with no user-facing behavior change, and the docs site does not document sync-server deployment secrets. `docs:impact` flags it only because it touches `apps/sync-server`.
