### PR TITLE
fix(observability): send real error source to PostHog without leaking note content

### DIFF
--- a/apps/desktop/src/main/telemetry/diagnostics.test.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.test.ts
@@ -21,14 +21,14 @@ describe('telemetry diagnostics', () => {
     trackMainEventMock.mockReset()
   })
 
-  it('emits sanitized main-process errors without raw messages', () => {
-    // #given an error containing private-looking text in the message
+  it('emits a stack for main-process errors but never the raw message', () => {
+    // #given an error whose message embeds a private note path
     const error = new TypeError('failed at /Users/kaan/private-note.md')
 
     // #when tracking the error
     trackMainError('main_process', 'unhandled_exception', error)
 
-    // #then only stable diagnostic metadata is sent
+    // #then stable metadata + a stack (code locations) are sent, never the message
     expect(trackMainEventMock).toHaveBeenCalledWith(
       'app_error_seen',
       expect.objectContaining({
@@ -37,10 +37,14 @@ describe('telemetry diagnostics', () => {
         objectType: 'exception',
         source: 'main_process',
         result: 'failed',
-        errorCode: 'TypeError'
+        errorCode: 'TypeError',
+        error: expect.objectContaining({ stack: expect.stringContaining('at ') })
       })
     )
-    expect(JSON.stringify(trackMainEventMock.mock.calls[0])).not.toContain('private-note')
+    const serialized = JSON.stringify(trackMainEventMock.mock.calls[0])
+    // message header is stripped; home paths in stack frames are scrubbed
+    expect(serialized).not.toContain('private-note')
+    expect(serialized).not.toContain('/Users/')
   })
 
   it('emits structured remote log breadcrumbs', () => {

--- a/apps/desktop/src/main/telemetry/diagnostics.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.ts
@@ -1,4 +1,5 @@
 import type { TelemetryResult } from '@memry/contracts/telemetry-api'
+import { buildErrorDetail } from '@memry/contracts/telemetry-api'
 
 import { trackMainEvent, type TrackMainEventOptions } from './track'
 
@@ -40,7 +41,8 @@ export const trackMainError = (source: string, action: string, error: unknown): 
     objectType: 'exception',
     source: toSafeToken(source, 'main_process'),
     result: 'failed',
-    errorCode: toErrorCode(error)
+    errorCode: toErrorCode(error),
+    error: buildErrorDetail(error)
   })
 }
 

--- a/apps/desktop/src/main/telemetry/track.ts
+++ b/apps/desktop/src/main/telemetry/track.ts
@@ -1,4 +1,5 @@
 import type {
+  TelemetryEvent,
   TelemetryEventName,
   TelemetryResult,
   TelemetrySurface
@@ -27,6 +28,7 @@ export interface TrackMainEventOptions {
     value?: number
   }
   dimensions?: Record<string, string>
+  error?: TelemetryEvent['error']
 }
 
 /**
@@ -48,7 +50,8 @@ export const trackMainEvent = (name: TelemetryEventName, options: TrackMainEvent
       result: options.result,
       errorCode: options.errorCode,
       metrics: options.metrics,
-      dimensions: options.dimensions
+      dimensions: options.dimensions,
+      error: options.error
     })
   } catch (error) {
     logger.warn('Failed to emit telemetry event', { name, error })

--- a/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.test.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.test.ts
@@ -15,14 +15,15 @@ describe('renderer telemetry diagnostics', () => {
     trackTelemetryMock.mockReset()
   })
 
-  it('emits sanitized renderer errors without raw messages', () => {
-    // #given an error with private-looking message text
+  it('emits a stack for renderer errors but never the raw message', () => {
+    // #given an error whose message embeds a private note path
     const error = new TypeError('failed at /Users/kaan/private-note.md')
 
     // #when tracking it
     trackRendererError('unhandled_rejection', error)
 
-    // #then only stable metadata leaves the renderer
+    // #then stable metadata + a stack (code locations) leave the renderer,
+    //   but the message text (which held the note path) never does
     expect(trackTelemetryMock).toHaveBeenCalledWith(
       'app_error_seen',
       expect.objectContaining({
@@ -31,10 +32,14 @@ describe('renderer telemetry diagnostics', () => {
         objectType: 'exception',
         source: 'renderer',
         result: 'failed',
-        errorCode: 'TypeError'
+        errorCode: 'TypeError',
+        error: expect.objectContaining({ stack: expect.stringContaining('at ') })
       })
     )
-    expect(JSON.stringify(trackTelemetryMock.mock.calls[0])).not.toContain('private-note')
+    const serialized = JSON.stringify(trackTelemetryMock.mock.calls[0])
+    // message header is stripped; home paths in stack frames are scrubbed
+    expect(serialized).not.toContain('private-note')
+    expect(serialized).not.toContain('/Users/')
   })
 
   it('emits structured renderer logs', () => {

--- a/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.ts
@@ -1,4 +1,5 @@
 import type { TelemetryResult } from '@memry/contracts/telemetry-api'
+import { buildErrorDetail } from '@memry/contracts/telemetry-api'
 
 import { trackTelemetry } from './telemetry'
 
@@ -33,14 +34,19 @@ const toErrorCode = (error: unknown): string => {
 const resultForLevel = (level: DiagnosticLevel): TelemetryResult =>
   level === 'error' || level === 'warn' ? 'failed' : 'success'
 
-export const trackRendererError = (action: string, error: unknown): void => {
+export const trackRendererError = (
+  action: string,
+  error: unknown,
+  componentStack?: string
+): void => {
   void trackTelemetry('app_error_seen', {
     surface: 'app',
     action: toSafeToken(action, 'error'),
     objectType: 'exception',
     source: 'renderer',
     result: 'failed',
-    errorCode: toErrorCode(error)
+    errorCode: toErrorCode(error),
+    error: buildErrorDetail(error, componentStack)
   })
 }
 

--- a/apps/desktop/src/renderer/src/lib/telemetry.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry.ts
@@ -44,6 +44,7 @@ export interface TrackTelemetryOptions {
   errorCode?: string
   metrics?: TelemetryEvent['metrics']
   dimensions?: Record<string, string>
+  error?: TelemetryEvent['error']
 }
 
 const generateEventId = (): string => {
@@ -80,7 +81,8 @@ export const trackTelemetry = async (
       result: options.result,
       errorCode: options.errorCode,
       dimensions: sanitizeDimensions(options.dimensions),
-      metrics: options.metrics
+      metrics: options.metrics,
+      error: options.error
     }
 
     await track(event)

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -53,9 +53,12 @@ Recognized surfaces (`TelemetrySurface` in `packages/contracts/telemetry-api`):
 - Identifiers (note IDs, task IDs, project IDs)
 - Search queries
 - Tag names
-- File paths
+- User file paths and note filenames
+- Exception messages (a desktop error message can embed a note title or content)
 
-The contract uses string-typed enums for surfaces and actions; arbitrary strings can't sneak through.
+The contract uses string-typed enums for surfaces and actions; arbitrary strings can't sneak
+through. The one exception is error diagnostics, which additionally ship a redacted **stack trace**
+of code locations (never the message) — see [Error Reporting](#error-reporting).
 
 ## Tracking Pattern
 
@@ -143,13 +146,26 @@ high-frequency editor flushes from inflating event counts.
 
 ## Error Reporting
 
-Desktop error reporting follows the same product telemetry setting. Captured errors include process
-area, component/source, action, phase, and stable error codes. They do not include note content,
-titles, file paths, search text, stack traces, or raw exception messages.
+Desktop error reporting follows the same product telemetry setting. Each captured error ships
+stable metadata — process area, component/source, action, phase, and the error's class name
+(`errorCode`) — plus a **redacted stack trace** and, for React boundaries, the component stack.
 
-Sync-server error reporting is server-side and uses only sanitized routing metadata: method,
-normalized path, route area, source, action, status code, error type, and error code. Dynamic path
-segments and query strings are removed before export.
+The free-form exception **message is never sent**: on the desktop it can embed a note title,
+filename, or content. The stack is reduced to code-location frames only — the leading
+`Name: message` header line is stripped — so a crash shows up as, for example, `TypeError` at
+`pushRecords (…/sync-engine.js:120)`: the source location, never the note. Frame file paths are
+app source/bundle locations (not user files); any home-directory prefix (`/Users/<name>`,
+`C:\Users\<name>`) is rewritten to `~`, and emails, UUIDs, JWTs, and bearer tokens are scrubbed
+from anything that ships.
+
+Sync-server error reporting is server-side. Because the sync server is end-to-end-blind (it only
+ever holds ciphertext), its own error strings are operational and are sent in full — redacted for
+stray identifiers — along with stack frames parsed from the real stack; this is what makes sync
+failures debuggable. Server errors are attributed to the signed-in `userId` (plus device and vault
+ids when present) so a failure can be traced to the account that hit it. Dynamic path segments and
+query strings are normalized away. Expected handled `4xx` responses (e.g. `SYNC_PAYMENT_REQUIRED`)
+are still counted as `server_error_seen` but do not open PostHog `$exception` issues, keeping Error
+Tracking focused on real failures.
 
 ## Server Configuration
 

--- a/apps/sync-server/src/lib/errors.test.ts
+++ b/apps/sync-server/src/lib/errors.test.ts
@@ -68,6 +68,7 @@ describe('sync-server error utilities', () => {
     )
     const context = {
       json,
+      get: () => undefined,
       env: {
         POSTHOG_API_KEY: 'phc_test_project',
         POSTHOG_HOST: 'https://us.i.posthog.com',
@@ -84,7 +85,7 @@ describe('sync-server error utilities', () => {
       }
     } as unknown as Parameters<typeof errorHandler>[1]
 
-    const response = errorHandler(new Error('private-note-title'), context)
+    const response = errorHandler(new Error('record decode failed'), context)
     await scheduled[0]
 
     expect(response.status).toBe(500)
@@ -101,10 +102,12 @@ describe('sync-server error utilities', () => {
       path: '/sync/records/push/:value',
       error_code: 'UNHANDLED_ERROR',
       status_code: 500,
-      handled: 0
+      handled: 0,
+      error_message: 'record decode failed'
     })
     const payloadText = JSON.stringify(body)
+    // Path identifiers stay scrubbed; the server's own (redacted) message is surfaced.
     expect(payloadText).not.toContain('550e8400-e29b-41d4-a716-446655440000')
-    expect(payloadText).not.toContain('private-note-title')
+    expect(payloadText).toContain('record decode failed')
   })
 })

--- a/apps/sync-server/src/lib/errors.ts
+++ b/apps/sync-server/src/lib/errors.ts
@@ -118,7 +118,10 @@ const scheduleServerErrorCapture = (
       action: 'request_failed',
       statusCode: metadata.statusCode,
       errorCode: metadata.errorCode,
-      handled: metadata.handled
+      handled: metadata.handled,
+      userId: c.get('userId'),
+      deviceId: c.get('deviceId'),
+      vaultId: c.get('vaultId')
     })
   )
 }

--- a/apps/sync-server/src/services/posthog.test.ts
+++ b/apps/sync-server/src/services/posthog.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { redactSensitive } from '@memry/contracts/telemetry-api'
+
 import {
   captureBusinessEvent,
   captureServerError,
   captureServerLog,
+  toPostHogExceptionEvent,
   waitUntilWithPostHog
 } from './posthog'
 
@@ -55,13 +58,15 @@ afterEach(() => {
 })
 
 describe('sync-server PostHog capture', () => {
-  it('captures sanitized server errors without raw messages, ids, or query strings', async () => {
+  it('captures server errors with a redacted message, scrubbing raw ids and query strings', async () => {
     // #given a configured PostHog project and an error with sensitive-looking details
     const fetchMock = vi.fn(
       async () => new Response(JSON.stringify({ status: 1 }), { status: 200 })
     )
     vi.stubGlobal('fetch', fetchMock)
-    const error = Object.assign(new Error(`private-note-title ${UUID}`), {
+    // Server-side error message (the sync server is E2E-blind — it only ever holds
+    // ciphertext, so its own error strings are operational, never note content).
+    const error = Object.assign(new Error(`record decode failed ${UUID}`), {
       name: 'QuotaFailure',
       code: 'STORAGE_QUOTA_EXCEEDED',
       statusCode: 507
@@ -119,14 +124,17 @@ describe('sync-server PostHog capture', () => {
       service_name: 'memry-sync-server',
       environment: 'development',
       $exception_type: 'QuotaFailure',
-      $exception_message: 'memry-sync-server:ErrorHandler:request_failed:STORAGE_QUOTA_EXCEEDED'
+      // The server's own message is surfaced (with structured PII redacted) instead
+      // of a synthetic diagnostic string, so the error is debuggable in Error Tracking.
+      $exception_message: 'record decode failed <uuid>'
     })
     expect(exceptionEvent?.properties.$exception_list).toEqual([
       expect.objectContaining({
         type: 'QuotaFailure',
-        value: 'memry-sync-server:ErrorHandler:request_failed:STORAGE_QUOTA_EXCEEDED'
+        value: 'record decode failed <uuid>'
       })
     ])
+    expect(body.batch[0].properties.error_message).toBe('record decode failed <uuid>')
     const logsBody = readPostHogLogsBody()
     expect(logsBody.resourceLogs[0].resource.attributes).toEqual(
       expect.arrayContaining([
@@ -142,9 +150,13 @@ describe('sync-server PostHog capture', () => {
     })
     const payloadText = JSON.stringify(body)
     const logsPayloadText = JSON.stringify(logsBody)
+    // Structured identifiers (raw UUID, path query token) are still scrubbed everywhere.
     expect(payloadText).not.toContain(UUID)
-    expect(payloadText).not.toContain('private-note-title')
     expect(payloadText).not.toContain('secret-token')
+    // The redacted server message text is intentionally present on the event/exception.
+    expect(payloadText).toContain('record decode failed')
+    expect(payloadText).toContain('<uuid>')
+    // Logs keep the synthetic diagnostic body — no raw message or identifiers leak there.
     expect(logsPayloadText).not.toContain(UUID)
     expect(logsPayloadText).not.toContain('private-note-title')
     expect(logsPayloadText).not.toContain('secret-token')
@@ -302,5 +314,94 @@ describe('sync-server PostHog capture', () => {
     })
     expect(JSON.stringify(body)).not.toContain(UUID)
     expect(JSON.stringify(body)).not.toContain('broadcast failed')
+  })
+})
+
+describe('sync-server error detail', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('redactSensitive scrubs emails, uuids, jwts, bearer tokens, and home paths', () => {
+    expect(redactSensitive('user kaan94karaca@gmail.com failed')).toBe('user <email> failed')
+    expect(redactSensitive('id 550e8400-e29b-41d4-a716-446655440000 missing')).toBe(
+      'id <uuid> missing'
+    )
+    expect(redactSensitive('token eyJhbGciOi.eyJzdWIi.SflKxwRJ end')).toBe('token <jwt> end')
+    expect(redactSensitive('Authorization: Bearer abc.def.ghi123')).toContain('Bearer <token>')
+    expect(redactSensitive('at fn (/Users/kaan/vault/note.md:1:1)')).toBe(
+      'at fn (~/vault/note.md:1:1)'
+    )
+  })
+
+  it('parses a real stack trace into $exception frames and keeps the real message', () => {
+    // #given an exception input carrying a real (redacted) V8 stack trace
+    const event = toPostHogExceptionEvent({
+      distinctId: 'user_1',
+      serviceName: 'memry-sync-server',
+      type: 'TypeError',
+      message: 'Cannot read properties of undefined (reading foo)',
+      source: 'sync',
+      action: 'push',
+      handled: false,
+      platform: 'node:javascript',
+      stack:
+        'TypeError: Cannot read properties of undefined (reading foo)\n' +
+        '    at pushRecords (~/apps/sync-server/src/routes/sync.ts:120:15)\n' +
+        '    at async handler (~/apps/sync-server/src/index.ts:88:5)',
+      properties: {}
+    })
+
+    // #then the real message is preserved and frames are parsed (not the synthetic stub)
+    expect(event.properties.$exception_message).toBe(
+      'Cannot read properties of undefined (reading foo)'
+    )
+    const list = event.properties.$exception_list as Array<{
+      value: string
+      stacktrace: { frames: Array<{ filename: string; function: string; lineno: number }> }
+    }>
+    const frames = list[0].stacktrace.frames
+    expect(frames).toHaveLength(2)
+    // V8 lists most-recent first; frames are reversed → deepest call is last
+    expect(frames[frames.length - 1]).toMatchObject({
+      function: 'pushRecords',
+      filename: '~/apps/sync-server/src/routes/sync.ts',
+      lineno: 120
+    })
+  })
+
+  it('attributes errors to the signed-in user and suppresses $exception for expected 4xx', async () => {
+    // #given a configured project and an expected paid-gate rejection for a signed-in user
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ status: 1 }), { status: 200 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when capturing a handled 402 with a userId
+    await captureServerError(env, {
+      error: new Error('Active sync subscription required'),
+      method: 'POST',
+      path: '/sync/records/push',
+      source: 'ErrorHandler',
+      action: 'request_failed',
+      statusCode: 402,
+      errorCode: 'SYNC_PAYMENT_REQUIRED',
+      handled: true,
+      userId: 'user_paid_1'
+    })
+
+    // #then only the counting event is emitted (no $exception noise) and it is user-attributed
+    const body = readPostHogBody()
+    expect(body.batch).toHaveLength(1)
+    expect(body.batch[0]).toMatchObject({
+      event: 'server_error_seen',
+      distinct_id: 'user_paid_1'
+    })
+    expect(body.batch[0].properties).toMatchObject({
+      error_code: 'SYNC_PAYMENT_REQUIRED',
+      status_code: 402,
+      user_id: 'user_paid_1'
+    })
+    expect(body.batch.find((e) => e.event === '$exception')).toBeUndefined()
   })
 })

--- a/apps/sync-server/src/services/posthog.ts
+++ b/apps/sync-server/src/services/posthog.ts
@@ -1,3 +1,5 @@
+import { redactSensitive } from '@memry/contracts/telemetry-api'
+
 import { createLogger } from '../lib/logger'
 import type { Bindings } from '../types'
 
@@ -94,6 +96,9 @@ export interface ServerErrorCaptureInput {
   statusCode?: number
   errorCode?: string
   handled: boolean
+  userId?: string
+  deviceId?: string
+  vaultId?: string
 }
 
 export interface ServerLogCaptureInput {
@@ -130,6 +135,8 @@ export interface PostHogExceptionInput {
   action: string
   handled: boolean
   platform: PostHogExceptionPlatform
+  /** Real (already redacted) stack trace; parsed into frames when present. */
+  stack?: string
   properties: Record<string, PostHogPropertyValue>
 }
 
@@ -308,11 +315,59 @@ export const toPostHogBatchPayload = (
   batch
 })
 
+const truncate = (value: string, max: number): string =>
+  value.length > max ? value.slice(0, max) : value
+
+const MAX_STACK_FRAMES = 40
+// Matches V8 stack lines: "    at fn (file:line:col)" or "    at file:line:col".
+const STACK_LINE_PATTERN = /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?\s*$/
+
+const parseStackFrames = (
+  stack: string,
+  platform: PostHogExceptionPlatform,
+  fallbackFilename: string
+): PostHogPropertyValue[] => {
+  const frames: PostHogPropertyValue[] = []
+  for (const line of stack.split('\n')) {
+    const match = STACK_LINE_PATTERN.exec(line)
+    if (!match) continue
+    const [, fn, file, lineno, colno] = match
+    frames.push({
+      platform,
+      filename: file ? truncate(file, 300) : fallbackFilename,
+      function: fn ? truncate(fn, 200) : '<anonymous>',
+      lineno: Number(lineno),
+      colno: Number(colno),
+      in_app: true
+    })
+    if (frames.length >= MAX_STACK_FRAMES) break
+  }
+  // V8 lists the most-recent call first; PostHog renders frames most-recent
+  // last, so reverse to match.
+  return frames.reverse()
+}
+
 export const toPostHogExceptionEvent = (input: PostHogExceptionInput): PostHogEventPayload => {
   const exceptionType = safeLabel(input.type, 'Error')
-  const exceptionMessage = safeLabel(input.message, 'memry_error')
+  const exceptionMessage = truncate(input.message, 500) || 'memry_error'
   const source = safeLabel(input.source, 'diagnostics')
   const action = safeLabel(input.action, 'error')
+
+  const parsedFrames = input.stack
+    ? parseStackFrames(input.stack, input.platform, input.serviceName)
+    : []
+  const frames: PostHogPropertyValue[] =
+    parsedFrames.length > 0
+      ? parsedFrames
+      : [
+          {
+            platform: input.platform,
+            filename: input.serviceName,
+            module: source,
+            function: action,
+            in_app: true
+          }
+        ]
 
   return {
     event: '$exception',
@@ -335,15 +390,7 @@ export const toPostHogExceptionEvent = (input: PostHogExceptionInput): PostHogEv
           },
           stacktrace: {
             type: 'raw',
-            frames: [
-              {
-                platform: input.platform,
-                filename: input.serviceName,
-                module: source,
-                function: action,
-                in_app: true
-              }
-            ]
+            frames
           }
         }
       ]
@@ -406,7 +453,20 @@ export const captureServerError = async (
 ): Promise<void> => {
   const path = normalizeServerPath(input.path)
   const timestamp = new Date().toISOString()
-  const distinctId = serverDistinctId(env)
+  // Attribute the error to the signed-in user when known so it is traceable to a
+  // real (paying) account; fall back to the synthetic server id for anon requests.
+  const distinctId = input.userId ?? serverDistinctId(env)
+  const status = input.statusCode ?? getStatusCode(input.error, 500)
+  const rawMessage =
+    input.error instanceof Error
+      ? input.error.message
+      : typeof input.error === 'string'
+        ? input.error
+        : undefined
+  const rawStack = input.error instanceof Error ? input.error.stack : undefined
+  const realMessage = rawMessage ? truncate(redactSensitive(rawMessage), 500) : undefined
+  const realStack = rawStack ? truncate(redactSensitive(rawStack), 4000) : undefined
+
   const properties: Record<string, PostHogPropertyValue> = {
     service_name: SERVER_SERVICE_NAME,
     environment: safeLabel(env.ENVIRONMENT, 'unknown'),
@@ -421,8 +481,12 @@ export const captureServerError = async (
       input.errorCode ?? getErrorCode(input.error, 'UNHANDLED_ERROR'),
       'UNHANDLED_ERROR'
     ),
-    status_code: input.statusCode ?? getStatusCode(input.error, 500),
-    handled: input.handled ? 1 : 0
+    status_code: status,
+    handled: input.handled ? 1 : 0,
+    ...(realMessage ? { error_message: realMessage } : {}),
+    ...(input.userId ? { user_id: input.userId } : {}),
+    ...(input.deviceId ? { device_id: input.deviceId } : {}),
+    ...(input.vaultId ? { vault_id: input.vaultId } : {})
   }
   const event: PostHogEventPayload = {
     event: 'server_error_seen',
@@ -430,18 +494,20 @@ export const captureServerError = async (
     timestamp,
     properties
   }
+  const diagnosticBody = toDiagnosticBody(
+    SERVER_SERVICE_NAME,
+    String(properties.source),
+    String(properties.action),
+    String(properties.error_code)
+  )
   const exceptionEvent = toPostHogExceptionEvent({
     distinctId,
     timestamp,
     serviceName: SERVER_SERVICE_NAME,
     environment: safeLabel(env.ENVIRONMENT, 'unknown'),
     type: String(properties.error_type),
-    message: toDiagnosticBody(
-      SERVER_SERVICE_NAME,
-      String(properties.source),
-      String(properties.action),
-      String(properties.error_code)
-    ),
+    message: realMessage ?? diagnosticBody,
+    stack: realStack,
     source: String(properties.source),
     action: String(properties.action),
     handled: input.handled,
@@ -454,12 +520,7 @@ export const captureServerError = async (
     distinctId,
     timestamp,
     level: 'error',
-    body: toDiagnosticBody(
-      SERVER_SERVICE_NAME,
-      String(properties.source),
-      String(properties.action),
-      String(properties.error_code)
-    ),
+    body: diagnosticBody,
     attributes: {
       event_name: event.event,
       method: String(properties.method),
@@ -474,10 +535,13 @@ export const captureServerError = async (
     }
   }
 
-  await Promise.all([
-    sendPostHogBatch(env, [event, exceptionEvent]),
-    sendPostHogLogs(env, [logRecord])
-  ])
+  // Expected client errors (handled 4xx such as SYNC_PAYMENT_REQUIRED /
+  // VALIDATION_ERROR) still count as server_error_seen but must NOT open
+  // $exception issues — that noise buries real unhandled failures in Error Tracking.
+  const reportException = status >= 500 || !input.handled
+  const batchEvents = reportException ? [event, exceptionEvent] : [event]
+
+  await Promise.all([sendPostHogBatch(env, batchEvents), sendPostHogLogs(env, [logRecord])])
 }
 
 export const captureServerLog = async (

--- a/apps/sync-server/src/services/telemetry.ts
+++ b/apps/sync-server/src/services/telemetry.ts
@@ -1,4 +1,5 @@
 import type { TelemetryBatch, TelemetryEvent } from '@memry/contracts/telemetry-api'
+import { redactSensitive } from '@memry/contracts/telemetry-api'
 
 import { AppError, ErrorCodes } from '../lib/errors'
 import type { Bindings } from '../types'
@@ -223,6 +224,15 @@ export const toPostHogEvent = (
   addNumberProperty(properties, 'value', metrics.value)
   addNumberProperty(properties, 'client_queue_depth', batch.clientQueueDepth)
 
+  // Desktop error detail: stack frames + component stack only (never a message —
+  // it could contain a note title/content). Re-redact defensively.
+  if (event.error?.stack) {
+    properties.error_stack = redactSensitive(event.error.stack)
+  }
+  if (event.error?.componentStack) {
+    properties.error_component_stack = redactSensitive(event.error.componentStack)
+  }
+
   return {
     event: event.name,
     distinct_id: overrideDistinctId ?? desktopDistinctId(batch, installHash, environment),
@@ -255,6 +265,10 @@ const getStringProperty = (
   return typeof value === 'string' ? value : undefined
 }
 
+// The full stack / component stack belong on the $exception, not on every log
+// line — keep them out of OTLP log attributes to avoid bloating log records.
+const HEAVY_LOG_KEYS = new Set(['error_stack', 'error_component_stack'])
+
 const toPrimitiveLogAttributes = (
   event: PostHogEventPayload
 ): Record<string, PostHogLogAttributeValue> => {
@@ -263,6 +277,7 @@ const toPrimitiveLogAttributes = (
   }
 
   for (const [key, value] of Object.entries(event.properties)) {
+    if (HEAVY_LOG_KEYS.has(key)) continue
     if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
       attributes[key] = value
     }
@@ -300,21 +315,36 @@ const toDesktopLogRecord = (event: PostHogEventPayload): PostHogLogRecordInput |
   }
 }
 
+// Desktop actions that originate from global crash handlers are genuinely
+// unhandled; everything else (React error boundaries, etc.) was caught.
+const UNHANDLED_DESKTOP_ACTIONS = new Set([
+  'window_error',
+  'unhandled_rejection',
+  'uncaught_exception',
+  'boot_failed',
+  'render_process_gone',
+  'child_process_gone'
+])
+
 const toDesktopExceptionEvent = (event: PostHogEventPayload): PostHogEventPayload | null => {
   if (event.event !== 'app_error_seen') return null
   const source = getStringProperty(event.properties, 'source') ?? 'desktop'
   const action = getStringProperty(event.properties, 'action') ?? 'error'
   const errorCode = getStringProperty(event.properties, 'error_code') ?? 'DesktopError'
+  const stack = getStringProperty(event.properties, 'error_stack')
   return toPostHogExceptionEvent({
     distinctId: event.distinct_id,
     timestamp: event.timestamp,
     serviceName: DESKTOP_SERVICE_NAME,
     environment: getStringProperty(event.properties, 'environment'),
     type: errorCode,
+    // Never the message — desktop crash messages can embed note content. The
+    // synthetic label + real stack frames give the code location instead.
     message: `${DESKTOP_SERVICE_NAME}:${source}:${action}:${errorCode}`,
+    stack,
     source,
     action,
-    handled: true,
+    handled: !UNHANDLED_DESKTOP_ACTIONS.has(action),
     platform: source === 'renderer' ? 'web:javascript' : 'node:javascript',
     properties: event.properties
   })

--- a/packages/contracts/src/telemetry-api.ts
+++ b/packages/contracts/src/telemetry-api.ts
@@ -98,6 +98,14 @@ export const TelemetryMetricsSchema = z.object({
   value: z.number().finite().optional()
 })
 
+export const TelemetryErrorDetailSchema = z.object({
+  // NOTE: there is intentionally NO free-form message field. On the desktop an
+  // error message can embed a note title, filename, or content, so we only ever
+  // ship the stack frames (code locations) and the React component stack.
+  stack: z.string().max(4000).optional(),
+  componentStack: z.string().max(2000).optional()
+})
+
 export const TelemetryEventSchema = z.object({
   id: z.string().uuid(),
   name: TelemetryEventNameSchema,
@@ -109,7 +117,8 @@ export const TelemetryEventSchema = z.object({
   result: TelemetryResultSchema.optional(),
   errorCode: SafeDimensionValueSchema.optional(),
   dimensions: TelemetryDimensionsSchema.optional(),
-  metrics: TelemetryMetricsSchema.optional()
+  metrics: TelemetryMetricsSchema.optional(),
+  error: TelemetryErrorDetailSchema.optional()
 })
 
 export const TelemetryBatchSchema = z.object({
@@ -136,5 +145,66 @@ export type TelemetryAuthState = z.infer<typeof TelemetryAuthStateSchema>
 export type TelemetrySyncState = z.infer<typeof TelemetrySyncStateSchema>
 export type TelemetryPlatform = z.infer<typeof TelemetryPlatformSchema>
 export type TelemetryMetrics = z.infer<typeof TelemetryMetricsSchema>
+export type TelemetryErrorDetail = z.infer<typeof TelemetryErrorDetailSchema>
 export type TelemetryEvent = z.infer<typeof TelemetryEventSchema>
 export type TelemetryBatch = z.infer<typeof TelemetryBatchSchema>
+
+/**
+ * Scrub obvious PII from an error message or stack trace before it leaves the
+ * device / reaches PostHog. Keeps the diagnostic shape (frames, class names,
+ * project-relative paths) while removing usernames, emails, ids, and tokens.
+ * Shared by desktop renderer, desktop main, and the sync-server mirror.
+ */
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}/g
+const BEARER_PATTERN = /Bearer\s+[A-Za-z0-9._~+/-]+=*/gi
+const EMAIL_PATTERN = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g
+const UUID_PATTERN = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi
+// /Users/<name>, /home/<name>, /root, C:\Users\<name> → ~ (drops the username, keeps the rest)
+const HOME_PATH_UNIX_PATTERN = /(?:\/Users\/|\/home\/|\/root\/)[^/\s:)'"]+/g
+const HOME_PATH_WIN_PATTERN = /[A-Za-z]:\\Users\\[^\\\s:)'"]+/gi
+
+export const redactSensitive = (input: string): string =>
+  input
+    .replace(JWT_PATTERN, '<jwt>')
+    .replace(BEARER_PATTERN, 'Bearer <token>')
+    .replace(EMAIL_PATTERN, '<email>')
+    .replace(UUID_PATTERN, '<uuid>')
+    .replace(HOME_PATH_UNIX_PATTERN, '~')
+    .replace(HOME_PATH_WIN_PATTERN, '~')
+
+const truncate = (value: string, max: number): string =>
+  value.length > max ? value.slice(0, max) : value
+
+// Keep only "    at <fn> (<file>:<line>:<col>)" frame lines. This deliberately
+// drops the leading "<ErrorName>: <message>" header (and any other prose) so a
+// free-form message — which on the desktop can embed a note title, filename, or
+// content — never rides along inside the stack. Frames are code locations only.
+const keepStackFrameLines = (stack: string): string =>
+  stack
+    .split('\n')
+    .filter((line) => /^\s*at\s/.test(line))
+    .join('\n')
+
+/**
+ * Build the redacted, length-capped error detail attached to `app_error_seen`
+ * desktop telemetry. Privacy: we NEVER send the error message (it can contain a
+ * note title/filename/content) — only the stack frames (code locations) and the
+ * React component stack, with home paths and stray identifiers scrubbed.
+ * Returns undefined when there is nothing useful to send.
+ */
+export const buildErrorDetail = (
+  error: unknown,
+  componentStack?: string
+): TelemetryErrorDetail | undefined => {
+  const detail: TelemetryErrorDetail = {}
+  const rawStack =
+    error instanceof Error && typeof error.stack === 'string' ? error.stack : undefined
+  if (rawStack) {
+    const frames = keepStackFrameLines(rawStack)
+    if (frames) detail.stack = truncate(redactSensitive(frames), 4000)
+  }
+  if (componentStack) {
+    detail.componentStack = truncate(redactSensitive(componentStack), 2000)
+  }
+  return detail.stack || detail.componentStack ? detail : undefined
+}


### PR DESCRIPTION
## Problem

PostHog Error Tracking showed opaque `TypeError` / `UNHANDLED_ERROR` issues with a synthetic message and a single fabricated stack frame — you couldn't tell *what* broke or *where*. Server errors were unattributable (synthetic `distinct_id`) and expected 4xx like `SYNC_PAYMENT_REQUIRED` buried the real, ongoing `UNHANDLED_ERROR`s (a 1,133-count spike on Jun 30 was completely undebuggable).

## What changed

Errors now carry their real **source** to PostHog, with a privacy model that never exposes note data.

**Desktop** (reaches users with the launch build)
- Sends a **redacted stack trace** (code-location frames) + React component stack — never the exception message (a desktop message can embed a note title, filename, or content). Home paths → `~`; emails / UUIDs / JWTs / bearer tokens scrubbed.
- The free-form message field is removed from the telemetry contract entirely (validation-enforced).

**Sync-server** (effective immediately on deploy)
- `$exception` now carries the real server message (the server is end-to-end-blind — only ciphertext — so its own error strings are operational, not note content) plus stack frames parsed from the real stack.
- Errors attributed to `userId` / `deviceId` / `vaultId` → traceable to the account that hit them.
- Expected handled `4xx` (e.g. `SYNC_PAYMENT_REQUIRED`, `VALIDATION_ERROR`) no longer open `$exception` issues; still counted as `server_error_seen`.

## Privacy

| Ships to PostHog | Never ships |
| --- | --- |
| Error class name, code stack frames (app source, home dir → `~`), React component names, sync-server operational messages | Desktop exception messages, note titles / filenames / content, user file paths, raw identifiers (emails, UUIDs, tokens) |

Docs updated: `apps/docs/src/architecture/observability.md`.

## Verification

- 647 sync-server + 48 desktop telemetry tests
- typecheck (sync-server + desktop web/node), `ipc:check`, docs gate, `docs:build` — all green

## Dashboards

Two live tiles already added to the **Memry Sync Server** PostHog dashboard: *Server Errors by Code* and *Server Errors by Status Code*.
