### PR TITLE
feat(desktop): sidebar & New-menu clicks land ready-to-act

### DIFF
--- a/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
@@ -292,11 +292,14 @@ describe('AppSidebar', () => {
     expect(mocks.setSelectedFolder).toHaveBeenCalledWith('Projects')
 
     fireEvent.click(screen.getByRole('button', { name: 'Inbox' }))
-    expect(mocks.openSidebarItem).toHaveBeenCalledWith({
-      type: 'inbox',
-      title: 'Inbox',
-      path: '/inbox'
-    })
+    expect(mocks.openSidebarItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'inbox',
+        title: 'Inbox',
+        path: '/inbox',
+        viewState: { focusCaptureAt: expect.any(Number) }
+      })
+    )
 
     fireEvent.click(screen.getByRole('button', { name: 'new' }))
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -45,6 +45,7 @@ import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
 import { useTabActions } from '@/contexts/tabs'
+import { newItemViewState } from '@/contexts/tabs/helpers'
 import { useSettingsModal } from '@/contexts/settings-modal-context'
 import { notesService } from '@/services/notes-service'
 import { useSidebarDrillDown } from '@/contexts/sidebar-drill-down'
@@ -224,11 +225,20 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
       graph: 'Graph'
     }
 
+    // Land the user ready-to-act: Inbox focuses capture, Tasks opens the default
+    // project + focuses quick-add. Calendar deliberately gets NO new-event popover
+    // from the sidebar — that only fires from the New menu and the new-tab +.
+    const pageToViewState: Partial<Record<AppPage, Record<string, unknown>>> = {
+      inbox: newItemViewState('inbox'),
+      tasks: newItemViewState('tasks')
+    }
+
     // Open as tab in active pane
     const item: SidebarItem = {
       type: pageToTabType[page],
       title: pageToTitle[page],
-      path: `/${page}`
+      path: `/${page}`,
+      viewState: pageToViewState[page]
     }
     openSidebarItem(item)
   }
@@ -461,11 +471,26 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
                     onJournal: () =>
                       openSidebarItem({ type: 'journal', title: 'Journal', path: '/journal' }),
                     onCalendar: () =>
-                      openSidebarItem({ type: 'calendar', title: 'Calendar', path: '/calendar' }),
+                      openSidebarItem({
+                        type: 'calendar',
+                        title: 'Calendar',
+                        path: '/calendar',
+                        viewState: newItemViewState('calendar')
+                      }),
                     onInbox: () =>
-                      openSidebarItem({ type: 'inbox', title: 'Inbox', path: '/inbox' }),
+                      openSidebarItem({
+                        type: 'inbox',
+                        title: 'Inbox',
+                        path: '/inbox',
+                        viewState: newItemViewState('inbox')
+                      }),
                     onTasks: () =>
-                      openSidebarItem({ type: 'tasks', title: 'Tasks', path: '/tasks' })
+                      openSidebarItem({
+                        type: 'tasks',
+                        title: 'Tasks',
+                        path: '/tasks',
+                        viewState: newItemViewState('tasks')
+                      })
                   }}
                 />
               </Picker.Content>

--- a/apps/desktop/src/renderer/src/components/capture-input.tsx
+++ b/apps/desktop/src/renderer/src/components/capture-input.tsx
@@ -65,6 +65,8 @@ interface CaptureInputProps {
   density?: DisplayDensity
   compact?: boolean
   className?: string
+  /** Bump to focus the capture field (changes each time to re-fire). */
+  focusSignal?: number
 }
 
 /**
@@ -106,7 +108,8 @@ export function CaptureInput({
   onCaptureError,
   density: _density = 'comfortable',
   compact = false,
-  className
+  className,
+  focusSignal
 }: CaptureInputProps): React.JSX.Element {
   const { t: tPhaseF } = useT('inbox')
   const [value, setValue] = useState('')
@@ -178,6 +181,12 @@ export function CaptureInput({
   }, [value])
 
   useEffect(() => clearRecorderDismissTimer, [clearRecorderDismissTimer])
+
+  // Focus on demand (e.g. clicking Inbox in the sidebar). The signal changes each
+  // time, so this re-fires even when the Inbox tab is already open.
+  useEffect(() => {
+    if (focusSignal) textareaRef.current?.focus()
+  }, [focusSignal])
 
   const handleSubmit = useCallback(
     async (force = false) => {

--- a/apps/desktop/src/renderer/src/components/tabs/new-tab-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/new-tab-menu.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, useEffect } from 'react'
 import { Plus } from '@/lib/icons'
 import { useTabs } from '@/contexts/tabs'
+import { newItemViewState } from '@/contexts/tabs/helpers'
 import { notesService } from '@/services/notes-service'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { createLogger } from '@/lib/logger'
@@ -99,6 +100,7 @@ export function NewTabMenu({ groupId }: NewTabMenuProps): React.JSX.Element {
         title: 'Tasks',
         icon: 'list-todo',
         path: '/tasks',
+        viewState: newItemViewState('tasks'),
         isPinned: false,
         isModified: false,
         isPreview: false,
@@ -115,6 +117,7 @@ export function NewTabMenu({ groupId }: NewTabMenuProps): React.JSX.Element {
         title: 'Calendar',
         icon: 'calendar',
         path: '/calendar',
+        viewState: newItemViewState('calendar'),
         isPinned: false,
         isModified: false,
         isPreview: false,
@@ -131,6 +134,7 @@ export function NewTabMenu({ groupId }: NewTabMenuProps): React.JSX.Element {
         title: 'Inbox',
         icon: 'inbox',
         path: '/inbox',
+        viewState: newItemViewState('inbox'),
         isPinned: false,
         isModified: false,
         isPreview: false,

--- a/apps/desktop/src/renderer/src/components/tasks/quick-add-input.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/quick-add-input.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useMemo } from 'react'
+import { useState, useRef, useCallback, useMemo, useEffect } from 'react'
 import { useT } from '@memry/i18n/renderer'
 import { Calendar, Folder, Flag } from '@/lib/icons'
 
@@ -132,6 +132,8 @@ interface QuickAddInputProps {
   className?: string
   compact?: boolean
   projectColor?: string
+  /** Bump to focus the input (changes each time to re-fire). */
+  focusSignal?: number
 }
 
 // ============================================================================
@@ -145,7 +147,8 @@ export const QuickAddInput = ({
   placeholder = 'Add a task...    !today  !!high  #project',
   className,
   compact = false,
-  projectColor = '#6B7280'
+  projectColor = '#6B7280',
+  focusSignal
 }: QuickAddInputProps): React.JSX.Element => {
   const { t: tPhaseF } = useT('tasks')
   const { t } = useT('tasks')
@@ -161,6 +164,12 @@ export const QuickAddInput = ({
       description: t('quickAdd.focusDescription')
     }
   ])
+
+  // Focus on demand (sidebar "Tasks" click, empty-state "Add task"). The signal
+  // changes each time, so this re-fires even when the Tasks tab is already open.
+  useEffect(() => {
+    if (focusSignal) inputRef.current?.focus()
+  }, [focusSignal])
 
   // Detect triggers for autocomplete - compute during render instead of useEffect
   const { showAutocomplete, autocompleteType, autocompleteQuery } = useMemo(() => {

--- a/apps/desktop/src/renderer/src/components/tasks/task-list.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-list.tsx
@@ -26,6 +26,8 @@ interface TaskListProps {
       projectId: string | null
     }
   ) => void
+  /** Focus the toolbar quick-add input (used by the empty-state Add task button). */
+  onFocusQuickAdd?: () => void
   className?: string
   // Selection props
   isSelectionMode?: boolean
@@ -59,6 +61,7 @@ export const TaskList = ({
   onTaskClick,
   onNoteClick,
   onQuickAdd,
+  onFocusQuickAdd,
   className,
   // Selection props
   isSelectionMode = false,
@@ -113,6 +116,7 @@ export const TaskList = ({
       onTaskClick={onTaskClick}
       onNoteClick={onNoteClick}
       onQuickAdd={onQuickAdd}
+      onFocusQuickAdd={onFocusQuickAdd}
       className={className}
       storageKey={selectedId}
       isSelectionMode={isSelectionMode}

--- a/apps/desktop/src/renderer/src/components/tasks/virtualized-all-tasks-view.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/virtualized-all-tasks-view.tsx
@@ -47,6 +47,8 @@ interface VirtualizedAllTasksViewProps {
       projectId: string | null
     }
   ) => void
+  /** Focus the toolbar quick-add input (empty-state Add task button). */
+  onFocusQuickAdd?: () => void
   className?: string
   isSelectionMode?: boolean
   selectedIds?: Set<string>
@@ -232,6 +234,7 @@ export const VirtualizedAllTasksView = ({
   onTaskClick,
   onNoteClick,
   onQuickAdd,
+  onFocusQuickAdd,
   className,
   isSelectionMode = false,
   selectedIds,
@@ -359,7 +362,10 @@ export const VirtualizedAllTasksView = ({
   if (isEmpty) {
     return (
       <div className={cn('flex-1 overflow-auto pt-4', className)}>
-        <TaskEmptyState variant="all" onAddTask={() => onQuickAdd('New Task')} />
+        <TaskEmptyState
+          variant="all"
+          onAddTask={onFocusQuickAdd ?? (() => onQuickAdd('New Task'))}
+        />
       </div>
     )
   }

--- a/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
@@ -211,6 +211,20 @@ export const createDefaultTab = (): Tab => ({
 /**
  * Create a tab from sidebar item
  */
+/**
+ * "New/create" intent delivered as tab viewState when opening Calendar / Inbox /
+ * Tasks from a create entry point (the New menu, the new-tab +). Calendar shows
+ * its new-event popover; Inbox focuses the capture field; Tasks opens the default
+ * project's All list with the quick-add focused. A fresh timestamp re-fires the
+ * intent on every click, even when the singleton tab already exists.
+ */
+export const newItemViewState = (type: 'calendar' | 'inbox' | 'tasks'): Record<string, unknown> => {
+  const at = Date.now()
+  if (type === 'calendar') return { createEventAt: at }
+  if (type === 'inbox') return { focusCaptureAt: at }
+  return { activeInternalTab: 'all', focusQuickAddAt: at }
+}
+
 export const createTabFromSidebarItem = (
   item: SidebarItem,
   isPreview: boolean = false
@@ -222,6 +236,7 @@ export const createTabFromSidebarItem = (
     emoji: item.emoji,
     path: item.path,
     entityId: item.entityId,
+    viewState: item.viewState,
     isPinned: false,
     isModified: false,
     isPreview,

--- a/apps/desktop/src/renderer/src/contexts/tabs/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/types.ts
@@ -337,4 +337,6 @@ export interface SidebarItem {
   count?: number
   /** Nested children items */
   children?: SidebarItem[]
+  /** Per-view intent delivered on open (e.g. focus input, show popover) */
+  viewState?: Record<string, unknown>
 }

--- a/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-sidebar-navigation.ts
@@ -172,6 +172,16 @@ export const useSidebarNavigation = () => {
       const existingTab = findExistingTabForItem(currentState, item)
 
       if (existingTab && !toTheSide) {
+        // Re-open singletons that carry per-view intent so the reducer merges
+        // the fresh viewState (nonce) into the existing tab and refocuses it.
+        // Passing the found groupId keeps the merge in the right split-view pane.
+        if (item.viewState) {
+          openTab(createTabFromSidebarItem(item, false), {
+            groupId: existingTab.groupId,
+            background: inBackground
+          })
+          return
+        }
         // Focus existing tab
         setActiveTab(existingTab.tab.id, existingTab.groupId)
         return

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -215,8 +215,13 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     typeof activeTab?.viewState?.focusDate === 'string' ? activeTab.viewState.focusDate : null
   const calendarFocusToken =
     typeof activeTab?.viewState?.focusedAt === 'number' ? activeTab.viewState.focusedAt : null
+  const calendarCreateEventToken =
+    typeof activeTab?.viewState?.createEventAt === 'number'
+      ? activeTab.viewState.createEventAt
+      : null
   const consumedCalendarNavigationRef = useRef<number | null>(null)
   const openedCalendarFocusRef = useRef<number | null>(null)
+  const consumedCreateEventRef = useRef<number | null>(null)
   const [isSaving, setIsSaving] = useState(false)
   const [pendingPromote, setPendingPromote] = useState<{
     item: CalendarProjectionItem
@@ -339,6 +344,26 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
     })
   }, [calendarFocusEventId, calendarFocusToken, filteredItems, rangeQuery.isLoading])
   /* eslint-enable react-you-might-not-need-an-effect/no-derived-state, react-you-might-not-need-an-effect/no-event-handler, react-you-might-not-need-an-effect/no-chain-state-updates */
+
+  // Sidebar "Calendar" click asks for the new-event popover (same as the toolbar +).
+  // The nonce re-fires this on every click, even when the tab is already open.
+  useEffect(() => {
+    if (calendarCreateEventToken === null) return
+    if (consumedCreateEventRef.current === calendarCreateEventToken) return
+
+    consumedCreateEventRef.current = calendarCreateEventToken
+    setPopoverState({
+      mode: 'create',
+      eventId: null,
+      draft: createDraftFromAnchor(anchorDate),
+      anchorRect: {
+        x: window.innerWidth / 2,
+        y: Math.max(120, window.innerHeight / 3),
+        width: 1,
+        height: 1
+      }
+    })
+  }, [anchorDate, calendarCreateEventToken])
 
   const handlePrevious = () => {
     setAnchorDate((current) => {

--- a/apps/desktop/src/renderer/src/pages/inbox.tsx
+++ b/apps/desktop/src/renderer/src/pages/inbox.tsx
@@ -87,6 +87,10 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
   }, [failedJobCount])
 
   const activeTab = useActiveTab()
+  const focusCaptureSignal =
+    typeof activeTab?.viewState?.focusCaptureAt === 'number'
+      ? activeTab.viewState.focusCaptureAt
+      : undefined
   const focusInboxItemId =
     typeof activeTab?.viewState?.focusInboxItemId === 'string'
       ? activeTab.viewState.focusInboxItemId
@@ -171,6 +175,15 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
     [closeArchivedSearch]
   )
 
+  // Sidebar "Inbox" click asks to capture: surface the capture bar (CaptureInput
+  // then focuses itself via focusSignal). Re-fires on every click via the nonce.
+  // Deferred setState matches the focus-item effect above and avoids a cascade render.
+  useEffect(() => {
+    if (!focusCaptureSignal) return
+    const timer = window.setTimeout(() => setCurrentView('inbox'), 0)
+    return () => window.clearTimeout(timer)
+  }, [focusCaptureSignal])
+
   return (
     <>
       <div className="flex h-full flex-col">
@@ -181,6 +194,7 @@ export function InboxPage({ className }: InboxPageProps): React.JSX.Element {
             <CaptureInput
               compact
               density="compact"
+              focusSignal={focusCaptureSignal}
               onCaptureSuccess={() => toast.success(t('view.itemCaptured'))}
               onCaptureError={(errorMsg) => toast.error(errorMsg)}
             />

--- a/apps/desktop/src/renderer/src/pages/tasks.tsx
+++ b/apps/desktop/src/renderer/src/pages/tasks.tsx
@@ -256,6 +256,18 @@ export const TasksPage = ({
     [updateTaskViewState]
   )
 
+  // Quick-add focus: viewState.focusQuickAddAt is the single source of truth, fed to
+  // QuickAddInput.focusSignal. Both the sidebar "Tasks" click and the empty-state
+  // "Add task" button stamp a fresh timestamp, so the input refocuses each time.
+  const focusQuickAddSignal =
+    typeof taskTabViewState.focusQuickAddAt === 'number'
+      ? taskTabViewState.focusQuickAddAt
+      : undefined
+  const focusQuickAdd = useCallback(
+    () => updateTaskViewState({ focusQuickAddAt: Date.now() }),
+    [updateTaskViewState]
+  )
+
   // Saved filters
   const {
     savedFilters,
@@ -903,6 +915,7 @@ export const TasksPage = ({
               onOpenModal={handleOpenAddTaskModal}
               projects={projects}
               projectColor={quickAddProjectColor}
+              focusSignal={focusQuickAddSignal}
             />
 
             {/* Filter Button */}
@@ -1065,6 +1078,7 @@ export const TasksPage = ({
                 onUpdateTask={handleUpdateTask}
                 onToggleSubtaskComplete={subtaskManagement.handleCompleteSubtask}
                 onQuickAdd={handleQuickAdd}
+                onFocusQuickAdd={focusQuickAdd}
                 onTaskClick={handleTaskClick}
                 onNoteClick={(...args) => void handleNoteClick(...args)}
                 selectedTaskId={detailTaskId}
@@ -1102,6 +1116,7 @@ export const TasksPage = ({
                   onUpdateTask={handleUpdateTask}
                   onToggleSubtaskComplete={subtaskManagement.handleCompleteSubtask}
                   onQuickAdd={handleQuickAdd}
+                  onFocusQuickAdd={focusQuickAdd}
                   onTaskClick={handleTaskClick}
                   onNoteClick={(...args) => void handleNoteClick(...args)}
                   selectedTaskId={detailTaskId}

--- a/apps/docs/src/guide/tour.md
+++ b/apps/docs/src/guide/tour.md
@@ -8,7 +8,9 @@ A 60-second lap through the parts of the app you'll use most.
 
 The left sidebar is your primary navigation.
 
-At the very top, the **New** button creates a note in one click. Click the chevron on its right to open the create menu — New Note, Journal, Calendar, Inbox, or Tasks — the same menu as the **+** on the tab bar.
+At the very top, the **New** button creates a note in one click. Click the chevron on its right to open the create menu — New Note, Journal, Calendar, Inbox, or Tasks — the same menu as the **+** on the tab bar. These create-menu entries open ready to act: **Calendar** pops the new-event popover, **Inbox** focuses the capture field, and **Tasks** opens your default project with the quick-add input focused.
+
+Opening the same views from the sidebar sections below focuses the input too (Inbox capture, Tasks quick-add), but the sidebar's **Calendar** just opens the calendar without the new-event popover — the popover is reserved for the create menu and the tab-bar **+**.
 
 Sections from top to bottom:
 


### PR DESCRIPTION
## What

Clicking **Calendar / Inbox / Tasks** from a create entry point now drops you straight into a ready-to-act state:

- **Calendar** → opens + shows the new-event popover (same as the toolbar **+**)
- **Inbox** → opens + focuses the capture field
- **Tasks** → opens your configured **default project** on the **All** list + focuses the quick-add input

This works from **every click** (not just first open) — the intent rides on the tab `viewState` with a fresh timestamp, which the existing `OPEN_TAB` reducer merges into the singleton tab and re-fires.

### Entry points → Calendar new-event popover

| Entry point | Calendar popover? |
|---|---|
| Left sidebar → Calendar | ❌ just opens |
| New ▾ create menu → Calendar | ✅ |
| Tab-bar **+** → Calendar | ✅ |

The sidebar keeps Inbox/Tasks focus, but the calendar popover is reserved for the explicit create entry points (New menu + tab-bar **+**) so viewing your calendar doesn't fire a popup every time.

### Bug fix

The empty-state **Add task** button used to silently create an off-view task on the Today tab (Today filters by due-date, so the new task vanished — "does nothing"). It now focuses the quick-add input. Landing Tasks on the **All** list also means created tasks are immediately visible.

## How

One shared helper `newItemViewState(type)` in `contexts/tabs/helpers.ts` is the single source of truth for the intent keys (`createEventAt` / `focusCaptureAt` / `activeInternalTab`+`focusQuickAddAt`), reused by all entry points so keys can't drift from what the pages read. Renderer-only; no new store, no new dependency.

## Verification

- `typecheck:web`, `eslint` on changed files — clean
- 96 renderer tests pass (tab reducer/helpers/context, sidebar, tab menus, calendar, inbox, tasks, capture-input, quick-add, virtualized-all-tasks-view)
- `docs:impact --strict` + `docs:build` — pass

Manual smoke (`pnpm dev:desktop`): open Calendar / Inbox / Tasks from the sidebar, the New ▾ menu, and the tab-bar **+**; confirm the calendar popover appears only from the last two, and Inbox/Tasks focus their inputs everywhere.