### PR TITLE
feat(tasks): bulk delete via folder-view-style multi-select

### DIFF
--- a/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-action-button.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-action-button.tsx
@@ -26,9 +26,9 @@ interface BulkActionButtonProps {
 // ============================================================================
 
 const variantStyles: Record<BulkActionVariant, string> = {
-  default: 'bg-background border-border hover:bg-accent text-foreground',
-  secondary: 'bg-background border-border hover:bg-accent text-muted-foreground',
-  danger: 'bg-background border-destructive/30 hover:bg-destructive/10 text-destructive'
+  default: 'text-foreground hover:bg-muted',
+  secondary: 'text-foreground hover:bg-muted',
+  danger: 'text-destructive hover:bg-destructive/10'
 }
 
 /**
@@ -65,8 +65,7 @@ export const BulkActionButton = ({
       onKeyDown={handleKeyDown}
       disabled={disabled}
       className={cn(
-        'flex items-center gap-1.5 rounded-sm border px-3 py-1.5 text-sm font-medium',
-        'transition-colors duration-150',
+        'flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] font-medium transition-colors',
         'focus-visible:outline-none',
         'disabled:cursor-not-allowed disabled:opacity-50',
         variantStyles[variant],
@@ -75,7 +74,7 @@ export const BulkActionButton = ({
       aria-label={label}
     >
       {icon}
-      <span className="hidden sm:inline">{label}</span>
+      {label}
     </button>
   )
 }

--- a/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-action-dropdown.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-action-dropdown.tsx
@@ -67,17 +67,15 @@ export const BulkActionDropdown = <T extends string | number = string>({
       <DropdownMenuTrigger
         disabled={disabled}
         className={cn(
-          'flex items-center gap-1.5 rounded-sm border px-3 py-1.5 text-sm font-medium',
-          'bg-background border-border hover:bg-accent text-foreground',
-          'transition-colors duration-150',
+          'flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] font-medium text-foreground transition-colors hover:bg-muted',
           'focus-visible:outline-none',
           'disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
       >
         {icon}
-        <span className="hidden sm:inline">{label}</span>
-        <ChevronDown className="size-3 ml-0.5" />
+        {label}
+        <ChevronDown className="size-3 ms-0.5" />
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align="start" className="min-w-[200px]">
@@ -102,7 +100,7 @@ export const BulkActionDropdown = <T extends string | number = string>({
             >
               {option.icon && (
                 <span
-                  className="mr-2 flex items-center"
+                  className="me-2 flex items-center"
                   style={option.color ? { color: option.color } : undefined}
                 >
                   {option.icon}

--- a/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-action-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-action-toolbar.tsx
@@ -1,7 +1,6 @@
 import { Check, Flag, Calendar, FolderOpen, Columns3, Archive, Trash2, X } from '@/lib/icons'
 
 import { cn } from '@/lib/utils'
-import { SelectionCheckbox } from './selection-checkbox'
 import { BulkActionButton } from './bulk-action-button'
 import { BulkActionDropdown, type BulkActionOption } from './bulk-action-dropdown'
 import { priorityConfig, type Priority } from '@/data/task-model'
@@ -15,12 +14,6 @@ import { useT } from '@memry/i18n/renderer'
 interface BulkActionToolbarProps {
   /** Number of selected tasks */
   selectedCount: number
-  /** Whether all visible tasks are selected */
-  allSelected: boolean
-  /** Whether some (but not all) visible tasks are selected */
-  someSelected: boolean
-  /** Toggle select all */
-  onToggleSelectAll: () => void
   /** Complete selected tasks */
   onComplete: () => void
   /** Change priority for selected tasks */
@@ -120,9 +113,6 @@ const dueDateOptions: BulkActionOption<string>[] = [
  */
 export const BulkActionToolbar = ({
   selectedCount,
-  allSelected,
-  someSelected,
-  onToggleSelectAll,
   onComplete,
   onChangePriority,
   onChangeDueDate,
@@ -157,114 +147,94 @@ export const BulkActionToolbar = ({
   return (
     <div
       className={cn(
-        'flex items-center gap-4 border-b border-primary/20 bg-primary/5 px-4 py-3',
+        'flex h-11 shrink-0 items-center gap-0.5 rounded-xl border border-border bg-popover ps-1.5 pe-2 text-xs shadow-lg',
+        'animate-in fade-in slide-in-from-bottom-2 duration-150',
         className
       )}
       role="toolbar"
       aria-label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.bulkActions')}
     >
-      {/* Select all checkbox + count */}
-      <div className="flex items-center gap-2">
-        <SelectionCheckbox
-          checked={allSelected}
-          indeterminate={someSelected}
-          onChange={onToggleSelectAll}
-          aria-label={allSelected ? 'Deselect all' : 'Select all'}
-        />
-        <span className="font-medium text-primary">
-          {selectedCount} {tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.selected')}
+      {/* Count pill */}
+      <div className="flex h-8 items-center gap-1.5 rounded-lg bg-[var(--tint)]/10 px-2.5">
+        <span className="font-bold tabular-nums text-[var(--tint)]">{selectedCount}</span>
+        <span className="font-medium text-[var(--tint)]">
+          {tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.selected')}
         </span>
       </div>
 
-      {/* Divider */}
-      <div className="h-6 w-px bg-primary/20" aria-hidden="true" />
+      <div className="mx-1 h-5 w-px shrink-0 bg-border" aria-hidden="true" />
 
-      {/* Action buttons */}
-      <div className="flex items-center gap-2">
-        {/* Complete */}
-        <BulkActionButton
-          icon={<Check className="size-4" />}
-          label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.complete')}
-          onClick={onComplete}
-        />
+      {/* Complete */}
+      <BulkActionButton
+        icon={<Check className="size-3.5 shrink-0" />}
+        label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.complete')}
+        onClick={onComplete}
+      />
 
-        {/* Priority dropdown */}
+      {/* Priority dropdown */}
+      <BulkActionDropdown
+        icon={<Flag className="size-3.5 shrink-0" />}
+        label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.priority')}
+        options={priorityOptions.filter((o) => !o.isSeparator || o.value !== 'none')}
+        onSelect={onChangePriority}
+        selectedCount={selectedCount}
+      />
+
+      {/* Due Date dropdown */}
+      <BulkActionDropdown
+        icon={<Calendar className="size-3.5 shrink-0" />}
+        label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.dueDate')}
+        options={dueDateOptions}
+        onSelect={onChangeDueDate}
+        selectedCount={selectedCount}
+      />
+
+      {/* Move to project dropdown */}
+      <BulkActionDropdown
+        icon={<FolderOpen className="size-3.5 shrink-0" />}
+        label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.moveTo')}
+        options={projectOptions}
+        onSelect={onMoveToProject}
+        selectedCount={selectedCount}
+      />
+
+      {/* Status dropdown (Kanban only) */}
+      {showStatusAction && statuses.length > 0 && onChangeStatus && (
         <BulkActionDropdown
-          icon={<Flag className="size-4" />}
-          label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.priority')}
-          options={priorityOptions.filter((o) => !o.isSeparator || o.value !== 'none')}
-          onSelect={onChangePriority}
+          icon={<Columns3 className="size-3.5 shrink-0" />}
+          label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.status')}
+          options={statusOptions}
+          onSelect={onChangeStatus}
           selectedCount={selectedCount}
         />
+      )}
 
-        {/* Due Date dropdown */}
-        <BulkActionDropdown
-          icon={<Calendar className="size-4" />}
-          label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.dueDate')}
-          options={dueDateOptions}
-          onSelect={onChangeDueDate}
-          selectedCount={selectedCount}
-        />
+      <div className="mx-1 h-5 w-px shrink-0 bg-border" aria-hidden="true" />
 
-        {/* Move to project dropdown */}
-        <BulkActionDropdown
-          icon={<FolderOpen className="size-4" />}
-          label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.moveTo')}
-          options={projectOptions}
-          onSelect={onMoveToProject}
-          selectedCount={selectedCount}
-        />
+      {/* Archive */}
+      <BulkActionButton
+        icon={<Archive className="size-3.5 shrink-0" />}
+        label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.archive')}
+        onClick={onArchive}
+        variant="secondary"
+      />
 
-        {/* Status dropdown (Kanban only) */}
-        {showStatusAction && statuses.length > 0 && onChangeStatus && (
-          <BulkActionDropdown
-            icon={<Columns3 className="size-4" />}
-            label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.status')}
-            options={statusOptions}
-            onSelect={onChangeStatus}
-            selectedCount={selectedCount}
-          />
-        )}
+      {/* Delete */}
+      <BulkActionButton
+        icon={<Trash2 className="size-3.5 shrink-0" />}
+        label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.delete')}
+        onClick={onDelete}
+        variant="danger"
+      />
 
-        {/* Divider */}
-        <div className="h-6 w-px bg-primary/20" aria-hidden="true" />
-
-        {/* Archive */}
-        <BulkActionButton
-          icon={<Archive className="size-4" />}
-          label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.archive')}
-          onClick={onArchive}
-          variant="secondary"
-        />
-
-        {/* Delete */}
-        <BulkActionButton
-          icon={<Trash2 className="size-4" />}
-          label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.delete')}
-          onClick={onDelete}
-          variant="danger"
-        />
-      </div>
-
-      {/* Spacer */}
-      <div className="flex-1" />
-
-      {/* Cancel button */}
+      {/* Clear selection */}
       <button
         type="button"
         onClick={onCancel}
-        className={cn(
-          'flex items-center gap-1 rounded-sm px-3 py-1.5 text-sm',
-          'text-muted-foreground hover:text-foreground hover:bg-accent',
-          'transition-colors duration-150',
-          'focus-visible:outline-none'
-        )}
         aria-label={tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.cancelSelection')}
+        className="flex size-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       >
-        <X className="size-4" />
-        <span className="hidden sm:inline">
-          {tPhaseF('phaseF.componentsTasksBulkActionsBulkActionToolbar.cancel')}
-        </span>
+        <X className="size-4" strokeWidth={2} />
       </button>
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/bulk-actions/bulk-actions.test.tsx
@@ -218,7 +218,6 @@ describe('bulk action components', () => {
 
   it('drives toolbar actions, active project filtering, and optional status actions', () => {
     const callbacks = {
-      onToggleSelectAll: vi.fn(),
       onComplete: vi.fn(),
       onChangePriority: vi.fn(),
       onChangeDueDate: vi.fn(),
@@ -232,8 +231,6 @@ describe('bulk action components', () => {
     render(
       <BulkActionToolbar
         selectedCount={2}
-        allSelected={false}
-        someSelected
         projects={projects}
         statuses={statuses}
         showStatusAction
@@ -242,13 +239,11 @@ describe('bulk action components', () => {
     )
 
     expect(screen.getByRole('toolbar', { name: 'Bulk actions' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Select all' }))
     fireEvent.click(screen.getByRole('button', { name: 'Complete' }))
     fireEvent.click(screen.getByRole('button', { name: 'Archive' }))
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     fireEvent.click(screen.getByRole('button', { name: 'Cancel selection' }))
 
-    expect(callbacks.onToggleSelectAll).toHaveBeenCalled()
     expect(callbacks.onComplete).toHaveBeenCalled()
     expect(callbacks.onArchive).toHaveBeenCalled()
     expect(callbacks.onDelete).toHaveBeenCalled()

--- a/apps/desktop/src/renderer/src/components/tasks/drag-drop/task-row.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/drag-drop/task-row.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 import { TaskRow } from './task-row'
 import { notesService } from '@/services/notes-service'
@@ -381,6 +381,61 @@ describe('TaskRow — Overlay Theme Styling', () => {
     expect(overlay.className).toContain('bg-card')
     expect(overlay.className).toContain('border-[#4C9EFF]')
     expect(overlay.className).not.toContain('bg-[#27272A]')
+  })
+})
+
+describe('TaskRow — Multi-select', () => {
+  it('renders a selection checkbox when onToggleSelect is provided, even outside selection mode', () => {
+    render(<TaskRow {...defaultProps} onToggleSelect={vi.fn()} />)
+
+    expect(screen.getByRole('checkbox', { name: 'Select Test Task' })).toBeInTheDocument()
+  })
+
+  it('does not render a selection checkbox without onToggleSelect', () => {
+    render(<TaskRow {...defaultProps} />)
+
+    expect(screen.queryByRole('checkbox', { name: /select/i })).not.toBeInTheDocument()
+  })
+
+  it('toggles selection when the checkbox is clicked without opening the row', async () => {
+    const user = userEvent.setup()
+    const onToggleSelect = vi.fn()
+    const onClick = vi.fn()
+    render(<TaskRow {...defaultProps} onClick={onClick} onToggleSelect={onToggleSelect} />)
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select Test Task' }))
+
+    expect(onToggleSelect).toHaveBeenCalledWith('task-1')
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('cmd/ctrl+click toggles selection instead of opening the row', () => {
+    const onToggleSelect = vi.fn()
+    const onClick = vi.fn()
+    render(<TaskRow {...defaultProps} onClick={onClick} onToggleSelect={onToggleSelect} />)
+
+    fireEvent.click(screen.getByLabelText(/^Task: Test Task/), { metaKey: true })
+
+    expect(onToggleSelect).toHaveBeenCalledWith('task-1')
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('shift+click starts a range selection even before selection mode', () => {
+    const onShiftSelect = vi.fn()
+    const onClick = vi.fn()
+    render(
+      <TaskRow
+        {...defaultProps}
+        onClick={onClick}
+        onToggleSelect={vi.fn()}
+        onShiftSelect={onShiftSelect}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText(/^Task: Test Task/), { shiftKey: true })
+
+    expect(onShiftSelect).toHaveBeenCalledWith('task-1')
+    expect(onClick).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/tasks/drag-drop/task-row.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/drag-drop/task-row.tsx
@@ -7,7 +7,7 @@ import { PriorityBars } from '@/components/tasks/task-icons'
 import { StatusIcon } from '@/components/tasks/status-icon'
 import { InlineStatusPopover } from '@/components/tasks/inline-status-popover'
 import { InlinePriorityPopover } from '@/components/tasks/inline-priority-popover'
-import { SelectionCheckbox } from '@/components/tasks/bulk-actions'
+import { SelectionCheckbox } from '@/components/folder-view/selection-checkbox'
 import { RepeatIndicator } from '@/components/tasks/repeat-indicator'
 import { TaskLinkedNoteIndicator } from '@/components/tasks/task-linked-note-indicator'
 import { InsertionIndicator } from './insertion-indicator'
@@ -163,7 +163,7 @@ const TaskRowComponent = ({
   const { type: statusType, color: statusColor } = resolveStatus(task, project.statuses)
 
   const handleRowClick = (e: React.MouseEvent): void => {
-    if (e.shiftKey && isSelectionMode && onShiftSelect) {
+    if (e.shiftKey && onShiftSelect) {
       e.preventDefault()
       onShiftSelect(task.id)
       return
@@ -220,7 +220,7 @@ const TaskRowComponent = ({
               '[box-shadow:rgba(0,0,0,0.5)_0px_8px_24px,rgba(76,158,255,0.15)_0px_2px_8px]'
             ]
           : [
-              'group relative flex items-center py-[7px] px-3 gap-3 transition-colors',
+              'group group/row relative flex items-center py-[7px] px-3 gap-3 transition-colors',
               'rounded-md hover:bg-accent/60',
               onClick && 'focus-visible:outline-none',
               dragHandleListeners && !isDragging && 'cursor-grab',
@@ -249,18 +249,18 @@ const TaskRowComponent = ({
       {!isOverlay && insertionIndicatorPosition && (
         <InsertionIndicator
           position={insertionIndicatorPosition}
-          className="left-3 right-3"
+          className="start-3 end-3"
           dataTestId="list-drop-indicator"
         />
       )}
 
-      {isSelectionMode && showSelection && (
-        <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
+      {!isOverlay && showSelection && (
+        <div className="flex shrink-0 items-center justify-center">
           <SelectionCheckbox
-            checked={isCheckedForSelection}
-            onChange={() => onToggleSelect?.(task.id)}
-            onClick={(e: React.MouseEvent) => e.stopPropagation()}
-            aria-label={`Select ${task.title}`}
+            state={isCheckedForSelection ? 'checked' : 'unchecked'}
+            onToggle={() => onToggleSelect?.(task.id)}
+            alwaysVisible={isSelectionMode}
+            label={`Select ${task.title}`}
           />
         </div>
       )}
@@ -324,7 +324,7 @@ const TaskRowComponent = ({
       {dueDateDisplay && (
         <div
           className={cn(
-            'text-[11px] shrink-0 text-right leading-3.5 whitespace-nowrap',
+            'text-[11px] shrink-0 text-end leading-3.5 whitespace-nowrap',
             'colorClass' in dueDateDisplay
               ? dueDateDisplay.colorClass
               : isOverlay

--- a/apps/desktop/src/renderer/src/components/tasks/parent-task-row.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/parent-task-row.tsx
@@ -5,7 +5,7 @@ import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { cn } from '@/lib/utils'
 import { hasSubtasks, type SubtaskProgress } from '@/lib/subtask-utils'
 import { formatDateShort, formatDueDate, formatTime } from '@/lib/task-utils'
-import { SelectionCheckbox } from '@/components/tasks/bulk-actions'
+import { SelectionCheckbox } from '@/components/folder-view/selection-checkbox'
 import { ExpandChevron } from '@/components/tasks/expand-chevron'
 import { InsertionIndicator } from '@/components/tasks/drag-drop/insertion-indicator'
 import type { SectionDragState } from '@/components/tasks/drag-drop/list-section-drag-state'
@@ -133,7 +133,7 @@ export const ParentTaskRow = ({
   const handleRowClick = (e: React.MouseEvent): void => {
     if ((e.target as HTMLElement).closest('[data-expand-button]')) return
 
-    if (e.shiftKey && isSelectionMode && onShiftSelect) {
+    if (e.shiftKey && onShiftSelect) {
       e.preventDefault()
       onShiftSelect(task.id)
       return
@@ -185,7 +185,7 @@ export const ParentTaskRow = ({
   })()
 
   return (
-    <div className={cn('group relative', className)}>
+    <div className={cn('group group/row relative', className)}>
       <div
         ref={rowRef}
         style={isOverlay && overlayWidth ? { width: `${overlayWidth}px` } : undefined}
@@ -234,18 +234,18 @@ export const ParentTaskRow = ({
         {!isOverlay && insertionIndicatorPosition && (
           <InsertionIndicator
             position={insertionIndicatorPosition}
-            className="left-3 right-3"
+            className="start-3 end-3"
             dataTestId="list-drop-indicator"
           />
         )}
 
-        {isSelectionMode && onToggleSelect && (
-          <div onClick={(e) => e.stopPropagation()}>
+        {!isOverlay && onToggleSelect && (
+          <div className="flex shrink-0 items-center justify-center">
             <SelectionCheckbox
-              checked={isCheckedForSelection}
-              onChange={() => onToggleSelect(task.id)}
-              onClick={(e: React.MouseEvent) => e.stopPropagation()}
-              aria-label={`Select ${task.title}`}
+              state={isCheckedForSelection ? 'checked' : 'unchecked'}
+              onToggle={() => onToggleSelect(task.id)}
+              alwaysVisible={isSelectionMode}
+              label={`Select ${task.title}`}
             />
           </div>
         )}
@@ -343,7 +343,7 @@ export const ParentTaskRow = ({
         {dueDateDisplay && (
           <div
             className={cn(
-              'text-[11px] shrink-0 text-right leading-3.5 whitespace-nowrap',
+              'text-[11px] shrink-0 text-end leading-3.5 whitespace-nowrap',
               'colorClass' in dueDateDisplay
                 ? dueDateDisplay.colorClass
                 : isOverlay

--- a/apps/desktop/src/renderer/src/pages/tasks.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/tasks.test.tsx
@@ -530,7 +530,6 @@ vi.mock('@/components/tasks/filters', () => ({
 
 vi.mock('@/components/tasks/bulk-actions', () => ({
   BulkActionToolbar: ({
-    onToggleSelectAll,
     onComplete,
     onChangePriority,
     onChangeDueDate,
@@ -541,7 +540,6 @@ vi.mock('@/components/tasks/bulk-actions', () => ({
     onCancel,
     statuses
   }: {
-    onToggleSelectAll: () => void
     onComplete: () => void
     onChangePriority: (priority: string) => void
     onChangeDueDate: (option: string) => void
@@ -554,9 +552,6 @@ vi.mock('@/components/tasks/bulk-actions', () => ({
   }) => (
     <div>
       <span data-testid="bulk-status-count">{statuses.length}</span>
-      <button type="button" onClick={onToggleSelectAll}>
-        Bulk toggle all
-      </button>
       <button type="button" onClick={onComplete}>
         Bulk complete
       </button>
@@ -1026,9 +1021,6 @@ describe('TasksPage', () => {
 
     fireEvent.keyDown(window, { key: 'Backspace', metaKey: true })
     await user.click(screen.getByRole('button', { name: 'Close bulk delete' }))
-
-    await user.click(screen.getByRole('button', { name: 'Bulk toggle all' }))
-    expect(mocks.toggleSelectAll).toHaveBeenCalled()
 
     await user.click(screen.getByRole('button', { name: 'Bulk priority' }))
     expect(mocks.bulkChangePriority).toHaveBeenCalledWith('urgent')

--- a/apps/desktop/src/renderer/src/pages/tasks.tsx
+++ b/apps/desktop/src/renderer/src/pages/tasks.tsx
@@ -362,14 +362,11 @@ export const TasksPage = ({
     selection,
     selectedCount,
     hasSelection,
-    allSelected,
-    someSelected,
     selectedTaskIds,
     toggleTask,
     selectRange,
     selectAll,
     deselectAll,
-    toggleSelectAll,
     enterSelectionMode,
     exitSelectionMode
   } = useTaskSelection(visibleTaskIds, {
@@ -879,7 +876,7 @@ export const TasksPage = ({
     <>
       <div className={cn('h-full flex overflow-hidden', className)}>
         {/* Main Content Area */}
-        <main className="flex-1 min-w-0 flex flex-col overflow-hidden">
+        <main className="relative flex-1 min-w-0 flex flex-col overflow-hidden">
           {/* Page Header — compact single-row toolbar */}
           <PageToolbar className="px-2 py-1 min-h-[38px] border-b-0">
             <TasksTabBar
@@ -1032,25 +1029,25 @@ export const TasksPage = ({
             />
           )}
 
-          {/* Bulk Action Toolbar - shown when tasks are selected */}
+          {/* Bulk Action Toolbar - floating bottom-center bar (folder-view style) */}
           {hasSelection && (
-            <BulkActionToolbar
-              selectedCount={selectedCount}
-              allSelected={allSelected}
-              someSelected={someSelected}
-              onToggleSelectAll={toggleSelectAll}
-              onComplete={(...args) => void bulkActions.bulkComplete(...args)}
-              onChangePriority={handleBulkChangePriority}
-              onChangeDueDate={handleBulkChangeDueDate}
-              onMoveToProject={handleBulkMoveToProject}
-              onChangeStatus={handleBulkChangeStatus}
-              onArchive={(...args) => void bulkActions.bulkArchive(...args)}
-              onDelete={() => setIsBulkDeleteDialogOpen(true)}
-              onCancel={deselectAll}
-              projects={projects}
-              statuses={currentProjectStatuses}
-              showStatusAction={false}
-            />
+            <div className="pointer-events-none absolute inset-x-0 bottom-6 z-20 flex justify-center px-4">
+              <BulkActionToolbar
+                className="pointer-events-auto"
+                selectedCount={selectedCount}
+                onComplete={(...args) => void bulkActions.bulkComplete(...args)}
+                onChangePriority={handleBulkChangePriority}
+                onChangeDueDate={handleBulkChangeDueDate}
+                onMoveToProject={handleBulkMoveToProject}
+                onChangeStatus={handleBulkChangeStatus}
+                onArchive={(...args) => void bulkActions.bulkArchive(...args)}
+                onDelete={() => setIsBulkDeleteDialogOpen(true)}
+                onCancel={deselectAll}
+                projects={projects}
+                statuses={currentProjectStatuses}
+                showStatusAction={false}
+              />
+            </div>
           )}
 
           {/* Content Body - Today Tab (flat listing of overdue + today tasks) */}

--- a/apps/docs/src/user-guide/tasks/bulk-actions.md
+++ b/apps/docs/src/user-guide/tasks/bulk-actions.md
@@ -6,14 +6,16 @@ Select many tasks and act on them in one step.
 
 ## Selecting Tasks
 
-| How | Result |
-| --- | --- |
-| Click a row checkbox | Toggle that row |
-| Shift-click | Range-select from previous |
-| <kbd>⌘</kbd>-click | Toggle without affecting others |
-| Drag-select (where supported) | Lasso-select rows |
+A checkbox sits at the start of each row. It fades in when you hover the row and stays visible once a selection is active.
 
-The bulk action bar appears at the top of the view with the selection count.
+| How                           | Result                             |
+| ----------------------------- | ---------------------------------- |
+| Click the row checkbox        | Toggle that row                    |
+| Shift-click a row             | Range-select from the previous one |
+| <kbd>⌘</kbd>-click a row      | Toggle without affecting others    |
+| Drag-select (where supported) | Lasso-select rows                  |
+
+The bulk action bar appears as a floating bar at the bottom of the view with the selection count.
 
 ## Available Actions
 


### PR DESCRIPTION
## Summary

Adds a discoverable **bulk delete** for tasks by surfacing the existing (but hard-to-reach) multi-select flow with the **same approach as folder view**.

The renderer→main→domain→sync bulk-delete pipeline already existed and is sync-correct (per-id tombstone + vector clock, undo snapshots). Only the front-end entry point was missing, so this change is **renderer-only** — no IPC / DB / sync work.

## What changed

- **Leading checkbox on task + parent rows** — hidden at rest, fades in on row hover, stays visible once a selection is active. Reuses the folder-view `SelectionCheckbox` and the global `--tint` tokens for exact visual parity.
- **Click model** — `⌘`/`Ctrl`-click toggles, `Shift`-click starts a range (now works even before selection mode). `⌘A` selects all, `Esc` clears.
- **Floating bulk bar** — moved to a bottom-center floating bar that mirrors folder view's `BulkActionBar` **verbatim**: same `--tint` count chip, `rounded-xl border bg-popover shadow-lg` shell, `bg-border` dividers, `BarButton` tokens (`h-8 rounded-lg px-2.5 text-[12.5px] hover:bg-muted`, destructive `hover:bg-destructive/10`), and an icon-only clear button. Kept the full task action set (Complete / Priority / Due / Move / Archive / Delete).
- Dropped the bar's select-all checkbox (folder view's bar has none; `⌘A` still selects all).
- Docs: updated `user-guide/tasks/bulk-actions.md` to reflect the hover checkbox and floating bar.

## Verification

- `typecheck:web` ✅
- `lint` (changed source files) ✅
- renderer tests ✅ — extended `task-row.test.tsx` with multi-select cases; updated `bulk-actions.test.tsx` + `tasks.test.tsx` for the removed select-all
- `i18n:check` ✅ (reused existing keys)
- `docs:impact --strict` ✅

## Not yet done

- Live Electron click-through (floating bar position, hover reveal, delete + undo) — pending manual QA.