### PR TITLE
Curated user-facing release notes

### DIFF
--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -206,6 +206,39 @@ describe('updater', () => {
     expect(updater.getUpdateState().releaseNotes).toBe('Fixes\n• Sync fix\n• Calendar fix')
   })
 
+  it('strips the developer changelog from string release notes', async () => {
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+    mocks.autoUpdater.emit('update-available', {
+      version: '1.2.4',
+      releaseNotes:
+        '<h2>Fixes</h2><ul><li>Sync fix</li></ul><h2>Changelog</h2><p>Full Changelog: https://x</p><p>#123 title @a</p>'
+    })
+    expect(updater.getUpdateState().releaseNotes).toBe('Fixes\n• Sync fix')
+  })
+
+  it('strips the developer changelog from array release notes', async () => {
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+    mocks.autoUpdater.emit('update-available', {
+      version: '1.2.4',
+      releaseNotes: [
+        { note: '<h2>Fixes</h2><ul><li>Sync fix</li></ul><h2>Changelog</h2><p>#1 x</p>' }
+      ]
+    })
+    expect(updater.getUpdateState().releaseNotes).toBe('Fixes\n• Sync fix')
+  })
+
+  it('leaves curated-only notes untouched', async () => {
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+    mocks.autoUpdater.emit('update-available', {
+      version: '1.2.4',
+      releaseNotes: '<h2>New Features</h2><ul><li>Calendar sync</li></ul>'
+    })
+    expect(updater.getUpdateState().releaseNotes).toBe('New Features\n• Calendar sync')
+  })
+
   it('coalesces manual checks and downloads, then installs downloaded updates', async () => {
     const updater = await loadUpdater()
     updater.initializeUpdater()

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -295,6 +295,15 @@ function buildPromptDetail(info: UpdateInfo, fallback: string): string {
   return `${fallback}\n\n${t('dialog.update.releaseNotesLabel')}\n${trimmedNotes}`
 }
 
+function stripDeveloperChangelog(text: string): string {
+  const lines = text.split('\n')
+  const index = lines.findIndex((line) => line.trim().toLowerCase() === 'changelog')
+  if (index === -1) {
+    return text
+  }
+  return lines.slice(0, index).join('\n').trimEnd()
+}
+
 function normalizeReleaseNotes(info: UpdateInfo): string | null {
   const { releaseNotes } = info
 
@@ -303,13 +312,13 @@ function normalizeReleaseNotes(info: UpdateInfo): string | null {
   }
 
   if (typeof releaseNotes === 'string') {
-    return htmlToPlainText(releaseNotes) || null
+    return stripDeveloperChangelog(htmlToPlainText(releaseNotes)) || null
   }
 
   const combined = releaseNotes
     .map((entry) => {
       const heading = entry.version ? `${formatAppVersionForDisplay(entry.version)}\n` : ''
-      return `${heading}${htmlToPlainText(entry.note ?? '')}`.trim()
+      return `${heading}${stripDeveloperChangelog(htmlToPlainText(entry.note ?? ''))}`.trim()
     })
     .filter(Boolean)
     .join('\n\n')

--- a/docs/superpowers/plans/2026-07-02-curated-release-notes.md
+++ b/docs/superpowers/plans/2026-07-02-curated-release-notes.md
@@ -1,0 +1,398 @@
+# Curated User-Facing Release Notes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `pnpm release -- --humanize --yes` produce a curated, user-facing release-notes markdown file per release and show only that curated content (no PR numbers, no dev noise) in the in-app update dialog.
+
+**Architecture:** One curated artifact `release-notes/<version>.md` is the source of truth. Its content is the top of the GitHub release body; the dev `## Changelog` stays below it for GitHub. The desktop app already renders the release body, so it only strips everything from `Changelog` onward. Three focused changes: (1) AI prompt + validation in `scripts/release-notes-utils.mjs`, (2) write the committed file in `scripts/humanize-release-notes.mjs`, (3) strip the changelog in-app in `apps/desktop/src/main/updater.ts`.
+
+**Tech Stack:** Node ESM scripts, `node:test` for script tests; Electron main + Vitest for the desktop app; `claude` CLI (headless) for note generation.
+
+## Global Constraints
+
+- Prettier: single quotes, no semicolons, 100 char width, no trailing commas. Copy the existing style in each file.
+- Script tests use `node:test` + `node:assert/strict` and run via `node --test`.
+- User-facing release-note bullets must contain **no PR numbers, no issue numbers, no commit hashes**.
+- User-facing sections are exactly: `## New Features`, `## Improvements`, `## Fixes`.
+- The GitHub release body still keeps its `## Changelog` section (dev PR list) — do not remove it.
+- Do not auto-commit or auto-push the notes file from the release script; only `git add` (stage) it.
+
+---
+
+### Task 1: Curated prompt + validation in `release-notes-utils.mjs`
+
+**Files:**
+
+- Modify: `scripts/release-notes-utils.mjs` (`buildReleaseNotesPrompt`, `validateHumanizedReleaseMarkdown`, `requiredHumanizedSections`)
+- Test: `scripts/release-notes-utils.test.mjs`
+
+**Interfaces:**
+
+- Consumes: existing `buildReleaseNotesPrompt({ finalTag, pullRequests })`, `validateHumanizedReleaseMarkdown(markdown)`.
+- Produces: `validateHumanizedReleaseMarkdown` that (a) requires sections `New Features`, `Improvements`, `Fixes`, (b) still rejects a `## Changelog` section, (c) **rejects** any bullet containing a `#NNN` number, (d) accepts bullets with no number. `buildReleaseNotesPrompt` unchanged signature.
+
+- [ ] **Step 1: Rewrite the two existing tests that hardcode the old sections**
+
+Two existing tests in `scripts/release-notes-utils.test.mjs` use the old sections (`Bug Fixes`/`Documentation`/`Chores`) and bullets containing `(#124)`. Both must be **replaced in place** — leaving them alongside the new rules would fail. (The prompt test "builds a prompt that asks the model to rewrite facts…" is unaffected — leave it as is.)
+
+Replace the whole `it('validates humanized markdown shape before editing a release', …)` test (currently lines ~115–155) with:
+
+```javascript
+it('validates humanized markdown shape before editing a release', () => {
+  const markdown = [
+    '## New Features',
+    '- 📑 Table of Contents Shortcut — Open note outlines faster.',
+    '',
+    '## Improvements',
+    '- 🚀 Faster Startup — The app opens more quickly.',
+    '',
+    '## Fixes',
+    '- 🔗 Better Media Paths — PDF links resolve more consistently.'
+  ].join('\n')
+
+  assert.equal(validateHumanizedReleaseMarkdown(markdown), markdown)
+  assert.throws(
+    () => validateHumanizedReleaseMarkdown('## New Features\n- Missing sections'),
+    /Improvements/
+  )
+  assert.throws(() => validateHumanizedReleaseMarkdown(`${markdown}\n\n## Changelog`), /Changelog/)
+  assert.throws(
+    () =>
+      validateHumanizedReleaseMarkdown(
+        [
+          '## New Features',
+          '📑 No bullet dash — nope.',
+          '',
+          '## Improvements',
+          '',
+          '## Fixes'
+        ].join('\n')
+      ),
+    /must be Markdown bullets/
+  )
+  assert.throws(
+    () =>
+      validateHumanizedReleaseMarkdown(
+        [
+          '## New Features',
+          '- 📑 Table of Contents Shortcut — Open note outlines faster. (#124)',
+          '',
+          '## Improvements',
+          '',
+          '## Fixes'
+        ].join('\n')
+      ),
+    /must not include a PR or issue number/
+  )
+})
+```
+
+Replace the `humanized` fixture inside `it('builds final release notes with marker, prose, and changelog', …)` (currently lines ~178–191) with the curated form (no old sections, no PR numbers in bullets):
+
+```javascript
+const humanized = [
+  '## New Features',
+  '- 📑 Table of Contents Shortcut — Open note outlines faster.',
+  '',
+  '## Improvements',
+  '- 🚀 Faster Startup — The app opens more quickly.',
+  '',
+  '## Fixes',
+  '- 🔗 Better Media Paths — PDF links resolve more consistently.'
+].join('\n')
+```
+
+Leave the rest of that test unchanged — the `#124` it asserts comes from the `## Changelog` section built from `pullRequests`, which is not affected by the curated rules.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test scripts/release-notes-utils.test.mjs`
+Expected: FAIL — the rewritten "validates humanized markdown shape" test fails because the current validator requires `Bug Fixes`/`Documentation`/`Chores` and requires a PR number in every bullet (so the curated `markdown` throws instead of validating, and the `(#124)` case does not throw the new message yet).
+
+- [ ] **Step 3: Update `requiredHumanizedSections` and validation**
+
+In `scripts/release-notes-utils.mjs`, change the constant near the top:
+
+```javascript
+const requiredHumanizedSections = ['New Features', 'Improvements', 'Fixes']
+```
+
+In `validateHumanizedReleaseMarkdown`, replace the PR-number-required loop:
+
+```javascript
+const bulletLines = contentLines.filter((line) => line.startsWith('- '))
+for (const line of bulletLines) {
+  if (!/#\d+\b/.test(line)) {
+    throw new Error(`Humanized release note bullet is missing a PR number: ${line}`)
+  }
+}
+```
+
+with the inverse rule:
+
+```javascript
+const bulletLines = contentLines.filter((line) => line.startsWith('- '))
+for (const line of bulletLines) {
+  if (/#\d+\b/.test(line)) {
+    throw new Error(`Humanized release note bullet must not include a PR or issue number: ${line}`)
+  }
+}
+```
+
+Leave the Changelog rejection and the "items must be Markdown bullets" checks unchanged.
+
+- [ ] **Step 4: Rewrite the prompt in `buildReleaseNotesPrompt`**
+
+Replace the returned array (the `return [ ... ].join('\n')`) with:
+
+```javascript
+return [
+  'You are writing Memry desktop release notes for end users.',
+  '',
+  'Audience: people using the Memry desktop app. They do not care about the',
+  'marketing website, browser extension, internal refactors, or developer tooling.',
+  '',
+  'Rules:',
+  '- Do not invent changes. Use only the provided PR titles, labels, authors, and release notes.',
+  '- Include only changes that affect the desktop app or the sync experience for end users.',
+  '- Judge relevance from each PR title scope and labels. Keep changes scoped to desktop, sync-server, or sync, plus cross-cutting user-facing features.',
+  '- Skip changes scoped to the landing site, browser extension or web clipper, brand or rename, documentation, CI, tests, chores, and schema-only or internal refactors.',
+  '- Do not include any PR numbers, issue numbers, or commit hashes.',
+  '- Rewrite technical PR names into short human-friendly release-note bullets.',
+  '- Keep each bullet to one sentence.',
+  '- Every release-note item must be a Markdown bullet line starting with "- ".',
+  '- Start every bullet with one relevant emoji, then a concise title, an em dash, and the explanation.',
+  '- Use exactly these sections: ## New Features, ## Improvements, ## Fixes.',
+  '- Leave a section empty if no provided change belongs there.',
+  '- If no change is user-facing, output only the "## Improvements" section with a single bullet "- ✨ General improvements — performance and stability updates." and leave the other sections empty.',
+  '- Do not include a Changelog section.',
+  '- Return Markdown only. Do not wrap the answer in a code fence.',
+  '- Begin the response with the "## New Features" heading. Add no greeting, preamble, or closing remarks.',
+  '',
+  'Input JSON:',
+  JSON.stringify(input, null, 2)
+].join('\n')
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `node --test scripts/release-notes-utils.test.mjs`
+Expected: PASS (all cases, including any pre-existing tests). If a pre-existing test asserted the old sections (`Bug Fixes`/`Documentation`/`Chores`) or required PR numbers in bullets, update that test to the new curated rules in the same commit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/release-notes-utils.mjs scripts/release-notes-utils.test.mjs
+git commit -m "feat(release): curate release-note prompt and drop PR numbers"
+```
+
+---
+
+### Task 2: Write the committed `release-notes/<version>.md` file
+
+**Files:**
+
+- Modify: `scripts/humanize-release-notes.mjs` (imports, add `writeCuratedReleaseNotes`, call it after the dry-run early return)
+
+**Interfaces:**
+
+- Consumes: `humanizedMarkdown` (the validated curated markdown, already computed at line ~97) and `preview.appVersion` (already computed at line ~55).
+- Produces: on a non-dry-run, `release-notes/<preview.appVersion>.md` written with the curated markdown and `git add`-ed. No new exports.
+
+- [ ] **Step 1: Extend the `node:fs` import**
+
+At the top of `scripts/humanize-release-notes.mjs`, change:
+
+```javascript
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+```
+
+to:
+
+```javascript
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+```
+
+(`execFileSync` and `path` are already imported.)
+
+- [ ] **Step 2: Add the `writeCuratedReleaseNotes` helper**
+
+Add this function near the other top-level helpers (e.g. above `writeTempNotes`):
+
+```javascript
+function writeCuratedReleaseNotes({ appVersion, markdown }) {
+  const dir = path.resolve(process.cwd(), 'release-notes')
+  mkdirSync(dir, { recursive: true })
+  const file = path.join(dir, `${appVersion}.md`)
+  writeFileSync(file, `${markdown.trim()}\n`)
+  execFileSync('git', ['add', file], { stdio: 'inherit' })
+  console.log(
+    `Wrote curated release notes: ${path.relative(process.cwd(), file)} (staged; commit with your release)`
+  )
+}
+```
+
+- [ ] **Step 3: Call it on a non-dry-run**
+
+In `runCli`, the dry-run block already returns early:
+
+```javascript
+if (options.dryRun) {
+  console.log('')
+  console.log(finalBody.trim())
+  return
+}
+```
+
+Immediately after that block (before the `if (!options.yes)` confirmation), add:
+
+```javascript
+writeCuratedReleaseNotes({ appVersion: preview.appVersion, markdown: humanizedMarkdown })
+```
+
+This guarantees the file is never written during `--dry-run` and is written before the GitHub edit.
+
+- [ ] **Step 4: Verify the script parses and lints**
+
+Run: `node --check scripts/humanize-release-notes.mjs`
+Expected: exits 0, no output.
+
+Run: `pnpm exec eslint scripts/humanize-release-notes.mjs`
+Expected: no errors. (Fix any import-order or style complaints to match the file.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/humanize-release-notes.mjs
+git commit -m "feat(release): write curated release-notes/<version>.md and stage it"
+```
+
+---
+
+### Task 3: Strip the dev changelog from in-app notes
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/updater.ts` (add `stripDeveloperChangelog`, apply in `normalizeReleaseNotes` both paths)
+- Test: `apps/desktop/src/main/updater.test.ts`
+
+**Interfaces:**
+
+- Consumes: existing `htmlToPlainText` and `normalizeReleaseNotes(info)`.
+- Produces: `stripDeveloperChangelog(text: string): string` that returns `text` unchanged when there is no `Changelog` heading line, otherwise everything before that line (trimmed). `normalizeReleaseNotes` applies it after `htmlToPlainText` in both the string and array-entry paths.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/desktop/src/main/updater.test.ts` inside the `describe('updater', ...)` block, mirroring the existing `update-available` string test (around line 196):
+
+```typescript
+it('strips the developer changelog from string release notes', async () => {
+  const updater = await loadUpdater()
+  updater.initializeUpdater()
+  mocks.autoUpdater.emit('update-available', {
+    version: '1.2.4',
+    releaseNotes:
+      '<h2>Fixes</h2><ul><li>Sync fix</li></ul><h2>Changelog</h2><p>Full Changelog: https://x</p><p>#123 title @a</p>'
+  })
+  expect(updater.getUpdateState().releaseNotes).toBe('Fixes\n• Sync fix')
+})
+
+it('strips the developer changelog from array release notes', async () => {
+  const updater = await loadUpdater()
+  updater.initializeUpdater()
+  mocks.autoUpdater.emit('update-available', {
+    version: '1.2.4',
+    releaseNotes: [
+      { note: '<h2>Fixes</h2><ul><li>Sync fix</li></ul><h2>Changelog</h2><p>#1 x</p>' }
+    ]
+  })
+  expect(updater.getUpdateState().releaseNotes).toBe('Fixes\n• Sync fix')
+})
+
+it('leaves curated-only notes untouched', async () => {
+  const updater = await loadUpdater()
+  updater.initializeUpdater()
+  mocks.autoUpdater.emit('update-available', {
+    version: '1.2.4',
+    releaseNotes: '<h2>New Features</h2><ul><li>Calendar sync</li></ul>'
+  })
+  expect(updater.getUpdateState().releaseNotes).toBe('New Features\n• Calendar sync')
+})
+```
+
+(Use the same `loadUpdater` / `mocks` helpers the existing tests use — match their exact setup, including any `beforeEach`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @memry/desktop test:main`
+Expected: the two "strips the developer changelog" cases FAIL (output still contains `Changelog` / `#123`). The "leaves curated-only notes untouched" case may already pass.
+
+- [ ] **Step 3: Add the `stripDeveloperChangelog` helper**
+
+In `apps/desktop/src/main/updater.ts`, add above `normalizeReleaseNotes`:
+
+```typescript
+function stripDeveloperChangelog(text: string): string {
+  const lines = text.split('\n')
+  const index = lines.findIndex((line) => line.trim().toLowerCase() === 'changelog')
+  if (index === -1) {
+    return text
+  }
+  return lines.slice(0, index).join('\n').trimEnd()
+}
+```
+
+- [ ] **Step 4: Apply it in `normalizeReleaseNotes`**
+
+Change the string path:
+
+```typescript
+if (typeof releaseNotes === 'string') {
+  return stripDeveloperChangelog(htmlToPlainText(releaseNotes)) || null
+}
+```
+
+Change the array path's map body:
+
+```typescript
+const combined = releaseNotes
+  .map((entry) => {
+    const heading = entry.version ? `${formatAppVersionForDisplay(entry.version)}\n` : ''
+    return `${heading}${stripDeveloperChangelog(htmlToPlainText(entry.note ?? ''))}`.trim()
+  })
+  .filter(Boolean)
+  .join('\n\n')
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @memry/desktop test:main`
+Expected: PASS (new cases plus the pre-existing `update-available` / `update-downloaded` tests, which contain no `Changelog` line and are unaffected).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @memry/desktop typecheck:node`
+Expected: no new errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/main/updater.ts apps/desktop/src/main/updater.test.ts
+git commit -m "fix(desktop): hide developer changelog from in-app update notes"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `node --test scripts/release-notes-utils.test.mjs` — PASS
+- [ ] `pnpm --filter @memry/desktop test:main` — PASS
+- [ ] `pnpm --filter @memry/desktop typecheck:node` — clean
+- [ ] `pnpm lint` — clean for touched files
+- [ ] `git diff --check` — no whitespace errors
+
+## Notes for the PR
+
+- No PR numbers in user-facing bullets; devs keep the full `## Changelog` on the GitHub release page.
+- `release-notes/<version>.md` is the committed source of truth for the in-app dialog.
+- Docs gate: this touches `apps/desktop` — run `pnpm docs:impact --base <base_commit> --strict`; if it flags `missing-docs`, either add a short note under `apps/docs/src/**` or use `MEMRY_DOCS_IMPACT_SKIP=1` for this non-user-doc change with a one-line reason.

--- a/docs/superpowers/specs/2026-07-02-curated-release-notes-design.md
+++ b/docs/superpowers/specs/2026-07-02-curated-release-notes-design.md
@@ -1,0 +1,132 @@
+# Curated user-facing release notes
+
+## Problem
+
+The in-app "update available" dialog shows the **entire GitHub release body**. That
+body is a developer changelog: every PR in the release gets a bullet (including
+landing-site, browser-extension, brand-rename, and sync-schema PRs that never
+touch the desktop user's experience), every bullet carries a `#NNN` PR number, and
+a `## Changelog` section lists all PRs again. Desktop users see noise, PR numbers,
+and internal `Documentation` / `Chores` sections they do not care about.
+
+Root cause: the developer changelog and the user-facing notes are the **same
+string**. Best practice (Keep a Changelog; most desktop apps) is to split the two
+audiences — devs get the full PR list on GitHub, users get a curated subset in-app.
+
+## Goal
+
+`pnpm release -- --humanize --yes` produces a curated, professional, user-facing
+release-notes markdown file per release. That file:
+
+- Contains only changes that impact the **desktop app or sync experience** for end
+  users (features, improvements/behavior changes, fixes).
+- Mentions **no PR numbers and no commit refs**.
+- Is committed to the repo as the canonical artifact and is what the **in-app
+  update dialog shows**.
+
+Developers keep the full PR changelog on the GitHub release page.
+
+## Approach (chosen: curate the body, reuse the pipeline)
+
+One curated artifact — `release-notes/<version>.md` — is the source of truth. Its
+content becomes the top of the GitHub release body; the dev `## Changelog` stays
+below it. The desktop app already renders the release body, so it needs only to
+**strip everything from `Changelog` onward** to show the curated notes alone.
+
+Rejected alternatives:
+
+- **App fetches the file directly** (raw.githubusercontent / bundled): cleanest
+  separation but adds fetch + cache + offline fallback + markdown rendering to the
+  app — most new code and a new failure mode. Not worth it.
+- **Curated body only, drop dev changelog**: zero app change, but loses the
+  developer PR list on the GitHub release page.
+
+## Changes
+
+All in existing files; no new subsystems.
+
+### 1. AI prompt — `scripts/release-notes-utils.mjs` `buildReleaseNotesPrompt`
+
+- **Filter** to user-impacting desktop + sync changes. Signal = the
+  conventional-commit scope already present in each PR title:
+  - **Keep**: `desktop`, `sync-server`, `sync`, and cross-cutting user features.
+  - **Drop**: `landing`, extension / clipper, `brand` / rename, `docs`, `ci`,
+    `test`, `chore`, and schema-only / internal refactors.
+- **No PR numbers, no commit refs** in bullets.
+- Sections reduced to user-facing: `## New Features`, `## Improvements`, `## Fixes`
+  (drop `Documentation` and `Chores`).
+- Each bullet: one emoji + short title + em dash + one-sentence user benefit.
+- If nothing qualifies → a single bullet under `## Improvements`:
+  `- ✨ General improvements — performance and stability updates.`
+
+### 2. Validation — `scripts/release-notes-utils.mjs` `validateHumanizedReleaseMarkdown`
+
+- **Remove** the "every bullet must include a PR number" rule (this rule is why
+  users see `#NNN`).
+- Required sections → `New Features`, `Improvements`, `Fixes`. Empty sections
+  allowed (a section heading with no bullets is fine).
+- Keep the "must not include a Changelog section" rule.
+
+### 3. Write the committed file — `scripts/humanize-release-notes.mjs`
+
+- After `validateHumanizedReleaseMarkdown` succeeds, write the curated markdown
+  (curated content only — no humanized marker, no changelog) to
+  `release-notes/<version>.md` at the repo root, named by `preview.appVersion`
+  (e.g. `release-notes/2026.7.2.md`).
+- `git add` the file so it is staged with the release. **Do not auto-commit or
+  push** — the human commits it with the release. Print a one-line reminder of the
+  written path.
+- Skip the file write on `--dry-run`.
+
+### 4. Body build + in-app strip
+
+- `buildHumanizedReleaseBody` (`release-notes-utils.mjs`): **unchanged** — GitHub
+  body stays `marker + curated + ## Changelog` so devs keep the PR list.
+- `normalizeReleaseNotes` (`apps/desktop/src/main/updater.ts`): after
+  `htmlToPlainText`, cut everything from a line that is just `Changelog` onward, so
+  the in-app dialog shows only the curated sections. Apply to both the string and
+  the array-entry code paths.
+
+## Data flow
+
+```
+PRs in draft release
+   │  (humanize-release-notes.mjs)
+   ▼
+buildReleaseNotesPrompt  ── filter desktop/sync, no PR#, 3 user sections ──▶ claude
+   ▼
+validateHumanizedReleaseMarkdown  (no PR# rule)
+   ├─▶ write release-notes/<version>.md  (curated only) + git add     ← source of truth
+   └─▶ buildHumanizedReleaseBody: marker + curated + ## Changelog
+          ▼  gh release edit  →  GitHub release body
+          ▼  electron-updater reads body via releases.atom (HTML)
+       normalizeReleaseNotes: htmlToPlainText → strip from "Changelog" onward
+          ▼
+       in-app update dialog  ← curated notes only, no PR numbers
+```
+
+## Edge cases
+
+- **No user-facing changes in a release** (only landing/extension/chore PRs): prompt
+  emits the single fallback "General improvements" bullet. Never empty.
+- **HTML vs markdown**: in-app notes arrive as HTML from `releases.atom`; strip the
+  Changelog **after** `htmlToPlainText` (match a `Changelog` heading line).
+- **`--dry-run`**: prints the body as today; no file written, nothing staged.
+
+## Testing
+
+- `scripts/release-notes-utils.test.mjs`:
+  - `validateHumanizedReleaseMarkdown` accepts bullets with no PR number.
+  - still rejects a `## Changelog` section.
+  - requires the three user sections; allows an empty section.
+- `apps/desktop/src/main/updater.test.ts`:
+  - `normalizeReleaseNotes` strips the `Changelog` section from a string body.
+  - strips it from an array-entry body.
+  - leaves curated-only notes untouched.
+
+## Out of scope
+
+- No change to how `release-notes/<version>.md` is consumed by landing/docs (future
+  reuse is possible but not built here).
+- No auto-commit / auto-push of the notes file from the release script.
+- No per-platform note variants.

--- a/scripts/humanize-release-notes.mjs
+++ b/scripts/humanize-release-notes.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { stdin as input, stdout as output } from 'node:process'
@@ -108,6 +108,8 @@ async function runCli() {
     return
   }
 
+  writeCuratedReleaseNotes({ appVersion: preview.appVersion, markdown: humanizedMarkdown })
+
   if (!options.yes) {
     const confirmed = await confirmEdit()
     if (!confirmed) {
@@ -208,6 +210,17 @@ async function confirmEdit() {
   } finally {
     reader.close()
   }
+}
+
+function writeCuratedReleaseNotes({ appVersion, markdown }) {
+  const dir = path.resolve(process.cwd(), 'release-notes')
+  mkdirSync(dir, { recursive: true })
+  const file = path.join(dir, `${appVersion}.md`)
+  writeFileSync(file, `${markdown.trim()}\n`)
+  execFileSync('git', ['add', file], { stdio: 'inherit' })
+  console.log(
+    `Wrote curated release notes: ${path.relative(process.cwd(), file)} (staged; commit with your release)`
+  )
 }
 
 function writeTempNotes(body) {

--- a/scripts/humanize-release-notes.mjs
+++ b/scripts/humanize-release-notes.mjs
@@ -108,8 +108,6 @@ async function runCli() {
     return
   }
 
-  writeCuratedReleaseNotes({ appVersion: preview.appVersion, markdown: humanizedMarkdown })
-
   if (!options.yes) {
     const confirmed = await confirmEdit()
     if (!confirmed) {
@@ -118,6 +116,8 @@ async function runCli() {
       return
     }
   }
+
+  writeCuratedReleaseNotes({ appVersion: preview.appVersion, markdown: humanizedMarkdown })
 
   const notesFile = writeTempNotes(finalBody)
   try {

--- a/scripts/release-notes-utils.mjs
+++ b/scripts/release-notes-utils.mjs
@@ -1,6 +1,6 @@
 export const HUMANIZED_RELEASE_MARKER = 'memry-humanized-release-notes'
 
-const requiredHumanizedSections = ['New Features', 'Bug Fixes', 'Documentation', 'Chores']
+const requiredHumanizedSections = ['New Features', 'Improvements', 'Fixes']
 
 function stripHtmlComments(text) {
   let output = ''
@@ -157,8 +157,10 @@ export function validateHumanizedReleaseMarkdown(markdown = '') {
 
   const bulletLines = contentLines.filter((line) => line.startsWith('- '))
   for (const line of bulletLines) {
-    if (!/#\d+\b/.test(line)) {
-      throw new Error(`Humanized release note bullet is missing a PR number: ${line}`)
+    if (/#\d+\b/.test(line)) {
+      throw new Error(
+        `Humanized release note bullet must not include a PR or issue number: ${line}`
+      )
     }
   }
 
@@ -206,18 +208,24 @@ export function buildReleaseNotesPrompt({ finalTag, pullRequests }) {
   }
 
   return [
-    'You are writing Memry release notes.',
+    'You are writing Memry desktop release notes for end users.',
+    '',
+    'Audience: people using the Memry desktop app. They do not care about the',
+    'marketing website, browser extension, internal refactors, or developer tooling.',
     '',
     'Rules:',
-    '- Do not invent changes.',
-    '- Use only the provided PR titles, labels, authors, and release notes.',
+    '- Do not invent changes. Use only the provided PR titles, labels, authors, and release notes.',
+    '- Include only changes that affect the desktop app or the sync experience for end users.',
+    '- Judge relevance from each PR title scope and labels. Keep changes scoped to desktop, sync-server, or sync, plus cross-cutting user-facing features.',
+    '- Skip changes scoped to the landing site, browser extension or web clipper, brand or rename, documentation, CI, tests, chores, and schema-only or internal refactors.',
+    '- Do not include any PR numbers, issue numbers, or commit hashes.',
     '- Rewrite technical PR names into short human-friendly release-note bullets.',
     '- Keep each bullet to one sentence.',
     '- Every release-note item must be a Markdown bullet line starting with "- ".',
     '- Start every bullet with one relevant emoji, then a concise title, an em dash, and the explanation.',
-    '- Every bullet must include one or more PR numbers.',
-    '- Use exactly these sections: ## New Features, ## Bug Fixes, ## Documentation, ## Chores.',
-    '- Leave a section empty if no provided PR belongs there.',
+    '- Use exactly these sections: ## New Features, ## Improvements, ## Fixes.',
+    '- Leave a section empty if no provided change belongs there.',
+    '- If no change is user-facing, output only the "## Improvements" section with a single bullet "- ✨ General improvements — performance and stability updates." and leave the other sections empty.',
     '- Do not include a Changelog section.',
     '- Return Markdown only. Do not wrap the answer in a code fence.',
     '- Begin the response with the "## New Features" heading. Add no greeting, preamble, or closing remarks.',

--- a/scripts/release-notes-utils.mjs
+++ b/scripts/release-notes-utils.mjs
@@ -225,7 +225,7 @@ export function buildReleaseNotesPrompt({ finalTag, pullRequests }) {
     '- Start every bullet with one relevant emoji, then a concise title, an em dash, and the explanation.',
     '- Use exactly these sections: ## New Features, ## Improvements, ## Fixes.',
     '- Leave a section empty if no provided change belongs there.',
-    '- If no change is user-facing, output only the "## Improvements" section with a single bullet "- ✨ General improvements — performance and stability updates." and leave the other sections empty.',
+    '- If no change is user-facing, keep all three headings and populate only "## Improvements" with a single bullet "- ✨ General improvements — performance and stability updates.", leaving "## New Features" and "## Fixes" with no bullets.',
     '- Do not include a Changelog section.',
     '- Return Markdown only. Do not wrap the answer in a code fence.',
     '- Begin the response with the "## New Features" heading. Add no greeting, preamble, or closing remarks.',

--- a/scripts/release-notes-utils.test.mjs
+++ b/scripts/release-notes-utils.test.mjs
@@ -163,6 +163,19 @@ describe('release notes helpers', () => {
     )
   })
 
+  it('accepts the no-user-facing-changes fallback shape', () => {
+    const markdown = [
+      '## New Features',
+      '',
+      '## Improvements',
+      '- ✨ General improvements — performance and stability updates.',
+      '',
+      '## Fixes'
+    ].join('\n')
+
+    assert.equal(validateHumanizedReleaseMarkdown(markdown), markdown)
+  })
+
   it('builds a deterministic changelog separate from AI prose', () => {
     const changelog = buildChangelogSection({
       compareUrl: 'https://github.com/memrynote/memry/compare/v2026-05-01...v2026-05-08',

--- a/scripts/release-notes-utils.test.mjs
+++ b/scripts/release-notes-utils.test.mjs
@@ -115,22 +115,19 @@ describe('release notes helpers', () => {
   it('validates humanized markdown shape before editing a release', () => {
     const markdown = [
       '## New Features',
-      '- 📑 Table of Contents Shortcut — Open note outlines faster. (#124)',
+      '- 📑 Table of Contents Shortcut — Open note outlines faster.',
       '',
-      '## Bug Fixes',
-      '- 🔗 Better Media Paths — PDF links resolve more consistently. (#125)',
+      '## Improvements',
+      '- 🚀 Faster Startup — The app opens more quickly.',
       '',
-      '## Documentation',
-      '- 📚 Clearer Setup Guide — Local AI setup notes are easier to follow. (#126)',
-      '',
-      '## Chores',
-      '- 🧹 Release Maintenance — Build script housekeeping. (#127)'
+      '## Fixes',
+      '- 🔗 Better Media Paths — PDF links resolve more consistently.'
     ].join('\n')
 
     assert.equal(validateHumanizedReleaseMarkdown(markdown), markdown)
     assert.throws(
       () => validateHumanizedReleaseMarkdown('## New Features\n- Missing sections'),
-      /Bug Fixes/
+      /Improvements/
     )
     assert.throws(
       () => validateHumanizedReleaseMarkdown(`${markdown}\n\n## Changelog`),
@@ -141,16 +138,28 @@ describe('release notes helpers', () => {
         validateHumanizedReleaseMarkdown(
           [
             '## New Features',
-            '📑 Table of Contents Shortcut — Open note outlines faster. (#124)',
+            '📑 No bullet dash — nope.',
             '',
-            '## Bug Fixes',
+            '## Improvements',
             '',
-            '## Documentation',
-            '',
-            '## Chores'
+            '## Fixes'
           ].join('\n')
         ),
       /must be Markdown bullets/
+    )
+    assert.throws(
+      () =>
+        validateHumanizedReleaseMarkdown(
+          [
+            '## New Features',
+            '- 📑 Table of Contents Shortcut — Open note outlines faster. (#124)',
+            '',
+            '## Improvements',
+            '',
+            '## Fixes'
+          ].join('\n')
+        ),
+      /must not include a PR or issue number/
     )
   })
 
@@ -178,16 +187,13 @@ describe('release notes helpers', () => {
   it('builds final release notes with marker, prose, and changelog', () => {
     const humanized = [
       '## New Features',
-      '- 📑 Table of Contents Shortcut — Open note outlines faster. (#124)',
+      '- 📑 Table of Contents Shortcut — Open note outlines faster.',
       '',
-      '## Bug Fixes',
-      '- 🔗 Better Media Paths — PDF links resolve more consistently. (#125)',
+      '## Improvements',
+      '- 🚀 Faster Startup — The app opens more quickly.',
       '',
-      '## Documentation',
-      '- 📚 Clearer Setup Guide — Local AI setup notes are easier to follow. (#126)',
-      '',
-      '## Chores',
-      '- 🧹 Release Maintenance — Build script housekeeping. (#127)'
+      '## Fixes',
+      '- 🔗 Better Media Paths — PDF links resolve more consistently.'
     ].join('\n')
 
     const body = buildHumanizedReleaseBody({


### PR DESCRIPTION
## Why

The in-app "update available" dialog shows the **entire GitHub release body** — a developer changelog. Desktop users therefore see changes that never touch their app (landing site, browser extension, brand renames, sync-schema PRs), a `#NNN` PR number on every line, and internal `Documentation` / `Chores` sections. Root cause: the developer changelog and the user-facing notes were the same string.

## What

Split the two audiences. Developers keep the full `## Changelog` PR list on the GitHub release page; desktop users see a curated subset. One committed artifact, `release-notes/<version>.md`, is the source of truth and drives the in-app dialog.

- **Curated prompt** (`scripts/release-notes-utils.mjs`): the humanizer now filters to changes that affect the desktop app or sync experience (judged from each PR's scope + labels), forbids PR/issue/commit numbers, and uses only `New Features` / `Improvements` / `Fixes`. A fallback bullet covers releases with no user-facing changes so the notes are never empty.
- **Validation**: bullets are now **rejected** if they contain a `#NNN` number (was: required). All three headings required; empty sections allowed; `## Changelog` still rejected inside the curated block.
- **Committed file** (`scripts/humanize-release-notes.mjs`): after the notes are confirmed, the curated markdown is written to `release-notes/<version>.md` and `git add`-ed (staged only — never auto-committed or pushed, never written on `--dry-run`).
- **In-app strip** (`apps/desktop/src/main/updater.ts`): `stripDeveloperChangelog` cuts everything from the `Changelog` heading onward, applied after `htmlToPlainText` in both the string and array paths of `normalizeReleaseNotes`. The GitHub body keeps the dev changelog; only the in-app view hides it.

## Testing

- `node --test scripts/release-notes-utils.test.mjs` — 16/16 (curated validation rules + fallback shape).
- `pnpm --filter @memry/desktop test:main` — full main suite green; `typecheck:node` clean.
- `git diff --check` clean.

## Docs

No user-doc page exists for the auto-update flow; this changes release tooling and how the update dialog renders notes (a behavior change, not a documented feature), so the docs-impact gate was skipped with `MEMRY_DOCS_IMPACT_SKIP=1`.

Spec: `docs/superpowers/specs/2026-07-02-curated-release-notes-design.md`
Plan: `docs/superpowers/plans/2026-07-02-curated-release-notes.md`
