### PR TITLE
fix(sync): stop mid-shutdown sync runtime + capture server restart

### DIFF
--- a/apps/desktop/src/main/app-shutdown.test.ts
+++ b/apps/desktop/src/main/app-shutdown.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest'
+
+async function load() {
+  vi.resetModules()
+  return import('./app-shutdown')
+}
+
+describe('app-shutdown latch', () => {
+  it('reports not shutting down by default', async () => {
+    const { isAppShuttingDown } = await load()
+    expect(isAppShuttingDown()).toBe(false)
+  })
+
+  it('latches to true after beginAppShutdown and stays latched', async () => {
+    const { beginAppShutdown, isAppShuttingDown } = await load()
+    expect(isAppShuttingDown()).toBe(false)
+    beginAppShutdown()
+    expect(isAppShuttingDown()).toBe(true)
+    beginAppShutdown()
+    expect(isAppShuttingDown()).toBe(true)
+  })
+})

--- a/apps/desktop/src/main/app-shutdown.ts
+++ b/apps/desktop/src/main/app-shutdown.ts
@@ -1,0 +1,25 @@
+// App-wide shutdown latch.
+//
+// Set once, at the very start of the app's graceful shutdown (before-quit). It
+// exists to stop long-running STARTUP work that is still in flight from
+// re-arming services the shutdown sequence has already torn down.
+//
+// Concretely: `autoOpenLastVault()` blocks on the vault's first `fullSync`
+// (which can be a slow re-pull) inside `startSyncRuntime()`. If the user clicks
+// Restart during that pull, before-quit stops the sync runtime + capture server,
+// and then — when the pull finally settles — the startup chain resumes and
+// restarts them mid-shutdown (observed: "Sync runtime started" logged after
+// "stopping sync runtime"). Gating the re-arm points on this latch prevents it.
+//
+// One-way for the process lifetime: the app never un-shuts-down. It is NOT tied
+// to `stopSyncRuntime()` (which also runs for vault switches / session teardown,
+// where sync SHOULD be able to start again) — only the app-quit path sets it.
+let shuttingDown = false
+
+export function beginAppShutdown(): void {
+  shuttingDown = true
+}
+
+export function isAppShuttingDown(): boolean {
+  return shuttingDown
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -64,6 +64,7 @@ import {
 } from './sync/certificate-pinning'
 import { getCrdtProvider } from './sync/crdt-provider'
 import { stopSyncRuntime } from './sync/runtime'
+import { beginAppShutdown, isAppShuttingDown } from './app-shutdown'
 import { getValidAccessToken } from './sync/token-manager'
 import { getNoteCacheById } from '@main/database/queries/notes'
 import { getIndexDatabase } from './database/client'
@@ -984,6 +985,13 @@ void app.whenReady().then(async () => {
   // The renderer subscribes to vault status events and updates automatically.
   void autoOpenLastVault()
     .then(async () => {
+      // autoOpenLastVault blocks on the vault's first fullSync; if the user quit
+      // during it, shutdown has already stopped these services — do not re-arm
+      // them here (that was the mid-shutdown capture-server/scheduler restart).
+      if (isAppShuttingDown()) {
+        mainLog.info('skipping post-vault-open startup: app is shutting down')
+        return
+      }
       try {
         checkDueItemsOnStartup()
         startSnoozeScheduler()
@@ -1275,6 +1283,11 @@ app.on('before-quit', (event) => {
   // out, and a closeVault() during cleanup would otherwise flip the UI to the
   // vault picker (isOpen:false) right before the app quits/installs.
   beginVaultShutdown()
+
+  // Latch app shutdown so in-flight startup work (a slow first fullSync inside
+  // autoOpenLastVault) can't re-arm the sync runtime / capture server after the
+  // cleanup below stops them. Must be set before the async cleanup chain yields.
+  beginAppShutdown()
 
   shutdownLog.info('starting graceful shutdown...')
 

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -639,6 +639,23 @@ describe('sync runtime', () => {
     await Promise.resolve()
   })
 
+  it('does not start or re-arm the sync runtime once app shutdown has begun', async () => {
+    const runtime = await loadRuntime()
+    // Shares the module instance the freshly-loaded runtime imports (resetModules
+    // ran in beforeEach, so this is the same latch startSyncRuntime checks).
+    const { beginAppShutdown } = await import('../app-shutdown')
+    beginAppShutdown()
+
+    await expect(runtime.startSyncRuntime()).resolves.toBeNull()
+
+    // Bailed before touching the session token, database, or engine — no
+    // mid-shutdown restart.
+    expect(runtimeMocks.retrieveToken).not.toHaveBeenCalled()
+    expect(runtimeMocks.getDatabase).not.toHaveBeenCalled()
+    expect(runtimeMocks.SyncEngine.instances).toHaveLength(0)
+    expect(runtime.getSyncEngine()).toBeNull()
+  })
+
   it('cleans up partial runtime when startup fails', async () => {
     runtimeMocks.engineStartError = new Error('start failed')
     const runtime = await loadRuntime()

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -5,6 +5,7 @@ import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
 import { createCrdtSyncAdapter, createSyncAdapterRegistry } from '@memry/sync-core'
 import { syncDevices } from '@memry/db-schema/schema/sync-devices'
 import { getDatabase, type DataDb } from '../database'
+import { isAppShuttingDown } from '../app-shutdown'
 import { createLogger } from '../lib/logger'
 import {
   getDevicePublicKey as deriveDevicePublicKey,
@@ -182,6 +183,11 @@ async function seedExistingCrdtDocs(
 }
 
 export async function startSyncRuntime(): Promise<SyncEngine | null> {
+  // Never spin up (or re-arm) the sync runtime once app shutdown has begun.
+  // In-flight startup work or a late IPC can otherwise restart it mid-shutdown,
+  // right after before-quit already stopped it. Return any existing engine so
+  // callers behave as if the runtime were already up.
+  if (isAppShuttingDown()) return runtime?.engine ?? null
   if (runtime) return runtime.engine
   if (startPromise) return startPromise
 


### PR DESCRIPTION
## Problem

Clicking **Restart** (or quitting) during a slow first `fullSync` re-pull restarted the sync runtime **and** capture server *mid-shutdown*.

`autoOpenLastVault()` blocks on the vault's initial `fullSync` inside `startSyncRuntime()` (`engine.start()` awaits it). If the user quits during that pull:

1. before-quit stops the sync runtime + capture server + schedulers,
2. the pull eventually settles → the startup chain resumes → it **re-arms** the capture server / schedulers, and the just-completing start logs `Sync runtime started` **after** `stopping sync runtime`.

Observed in `main.log` 2026-07-02 16:35 (`Sync runtime started` at 16:35:29.58 after `stopping sync runtime` at 16:35:24.68). This is follow-up #2 from `docs/auto-update-slow-restart-investigation.md`.

## Fix — one-way app-shutdown latch

New `src/main/app-shutdown.ts`: `beginAppShutdown()` / `isAppShuttingDown()`, set once at the top of the before-quit handler (synchronously, before the async cleanup chain yields).

- `startSyncRuntime()` returns early (existing engine or `null`) when the latch is set, so **no caller** — startup chain, IPC, billing, device registration, vault open — can restart the runtime during shutdown.
- The post-vault-open startup chain (`checkDueItemsOnStartup`, snooze/reminder schedulers, Google Calendar runner, capture server) returns early when shutting down, so the capture server and schedulers can't be re-armed.

The latch is **not** tied to `stopSyncRuntime()` (which also runs for vault switches / session teardown, where sync *should* be able to start again) — only the app-quit path sets it.

## Scope / follow-up

This kills the **restart** (the titled bug and the concrete damage). The separate flat ~5s cost from `stopSyncRuntime` awaiting the in-flight start's `fullSync` is still bounded by the existing before-quit watchdog; aborting the in-flight re-pull mid-`engine.start()` is a deeper engine change (each coordinator mints its own AbortController) tracked as a follow-up. The investigation doc's follow-up list is updated in #673.

## Test

- New `app-shutdown.test.ts` (latch contract).
- Regression test in `runtime.test.ts`: after `beginAppShutdown()`, `startSyncRuntime()` returns `null` and touches neither the session token, database, nor engine (14 tests green; existing start/stop tests still pass, proving normal boot is unaffected).
- `typecheck:node` + lint clean.
- Boot-tested the packaged main bundle — boots cleanly through vault open → sync IPC → capture server (latch off on a normal boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)