### PR TITLE
fix(test): add updater namespace to window.api DOM mock

### DIFF
--- a/apps/desktop/tests/setup-dom.ts
+++ b/apps/desktop/tests/setup-dom.ts
@@ -74,6 +74,25 @@ const createMockApi = () => ({
   // Native context menu bridge (main-process IPC in production)
   showContextMenu: vi.fn().mockResolvedValue(null),
 
+  // Auto-updater API (used by useAppUpdater on mount)
+  updater: {
+    getState: vi.fn().mockResolvedValue({
+      currentVersion: '0.0.0',
+      status: 'unavailable',
+      updateSupported: false,
+      availableVersion: null,
+      releaseName: null,
+      releaseDate: null,
+      releaseNotes: null,
+      downloadProgressPercent: null,
+      lastCheckedAt: null,
+      error: null
+    }),
+    checkForUpdates: vi.fn().mockResolvedValue({ status: 'up-to-date' }),
+    downloadUpdate: vi.fn().mockResolvedValue({ status: 'downloaded' }),
+    quitAndInstall: vi.fn().mockResolvedValue(undefined)
+  },
+
   // Vault API
   vault: {
     select: vi.fn().mockResolvedValue({ success: true, path: '/mock/vault' }),
@@ -510,7 +529,8 @@ const createMockApi = () => ({
   onReminderDismissed: vi.fn().mockReturnValue(() => {}),
   onReminderSnoozed: vi.fn().mockReturnValue(() => {}),
   onReminderClicked: vi.fn().mockReturnValue(() => {}),
-  onInboxOpenItem: vi.fn().mockReturnValue(() => {})
+  onInboxOpenItem: vi.fn().mockReturnValue(() => {}),
+  onUpdaterStateChanged: vi.fn().mockReturnValue(() => {})
 })
 
 if (typeof window === 'undefined') {


### PR DESCRIPTION
## Problem

`useAppUpdater()` runs on mount and calls `window.api.updater.getState()` and subscribes via `window.api.onUpdaterStateChanged()`. The shared renderer DOM mock (`apps/desktop/tests/setup-dom.ts`) had **neither**, so `window.api.updater` was `undefined` and the 5 `App.test.tsx` cases threw on render.

## Fix

Add to the `createMockApi()` mock:
- `updater` namespace: `getState` (resolves a valid `AppUpdateState`), `checkForUpdates`, `downloadUpdate`, `quitAndInstall`.
- top-level `onUpdaterStateChanged` (returns an unsubscribe fn), matching how the preload spreads `updaterEvents` at the root of `window.api`.

## Test

`App.test.tsx` — 5/5 pass (were failing). Independent of the auto-update PRs (#673/#674); this just unblocks the renderer suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)