### PR TITLE
fix(desktop): guarantee the main window becomes visible on Windows

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -886,6 +886,59 @@ describe('main index phase2 exports', () => {
     expect(preventDefault).toHaveBeenCalled()
   })
 
+  it('reveals the main window via fallback timeout when ready-to-show never fires', async () => {
+    vi.useFakeTimers()
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const createdWindow = browserWindows[0]
+    expect(createdWindow.show).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(10_000)
+    expect(createdWindow.show).toHaveBeenCalledTimes(1)
+  })
+
+  it('reveals the main window on fatal load failure but ignores ERR_ABORTED', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const createdWindow = browserWindows[0]
+    const didFailLoad = createdWindow.webContents.on.mock.calls.find(
+      ([event]) => event === 'did-fail-load'
+    )?.[1] as (event: unknown, code: number, description: string, url: string) => void
+
+    didFailLoad({}, -3, 'ERR_ABORTED', 'file:///renderer/index.html')
+    expect(createdWindow.show).not.toHaveBeenCalled()
+
+    didFailLoad({}, -6, 'ERR_FILE_NOT_FOUND', 'file:///renderer/index.html')
+    expect(createdWindow.show).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces a hidden existing window when a second instance launches', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const existing = browserWindows[0]
+    existing.isVisible.mockReturnValue(false)
+    existing.isMinimized.mockReturnValue(true)
+
+    const secondInstanceHandler = appOnMock.mock.calls.find(
+      ([event]) => event === 'second-instance'
+    )?.[1] as (event: unknown, commandLine: string[]) => void
+
+    secondInstanceHandler({}, ['--no-deep-link'])
+
+    expect(existing.show).toHaveBeenCalled()
+    expect(existing.restore).toHaveBeenCalled()
+    expect(existing.focus).toHaveBeenCalled()
+  })
+
   it('handles OAuth deep links for registered states', async () => {
     whenReadyMock.mockResolvedValue(undefined)
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -444,12 +444,46 @@ function createWindow(): void {
   })
   mainWindow.on('closed', unsubscribeVaultStatus)
 
+  // The window is created hidden (show:false) and normally revealed on
+  // 'ready-to-show'. On Windows a GPU/renderer crash before first paint can mean
+  // that event never fires, leaving the process alive with no visible window and
+  // no taskbar entry (unlike macOS, where the Dock still surfaces the app).
+  // Guarantee visibility with a one-shot reveal guarded by a load-failure handler
+  // and a fallback timeout, so a transient hiccup can't hide the app forever.
+  let mainWindowShown = false
+  const revealMainWindow = (reason: string): void => {
+    if (mainWindowShown || mainWindow.isDestroyed()) return
+    mainWindowShown = true
+    clearTimeout(fallbackShowTimer)
+    mainWindow.show()
+    trackLaunchPhase('window_shown', Date.now() - launchStartedAt)
+    mainLog.info(`main window shown (${reason})`)
+  }
+
+  const fallbackShowTimer = setTimeout(() => {
+    mainLog.warn('ready-to-show did not fire within 10s; revealing window as fallback')
+    revealMainWindow('fallback-timeout')
+  }, 10_000)
+  mainWindow.on('closed', () => clearTimeout(fallbackShowTimer))
+
   mainWindow.on('ready-to-show', () => {
     // Zoom out once (equivalent to Cmd+-)
     // mainWindow.webContents.setZoomLevel(-0.8)
-    mainWindow.show()
     trackLaunchPhase('window_ready_to_show', Date.now() - launchStartedAt)
+    revealMainWindow('ready-to-show')
   })
+
+  mainWindow.webContents.on(
+    'did-fail-load',
+    (_event, errorCode, errorDescription, validatedURL) => {
+      // ERR_ABORTED (-3) is benign (e.g. a superseded navigation); don't reveal on it.
+      if (errorCode === -3) return
+      mainLog.error(
+        `main window failed to load (${errorCode} ${errorDescription}) ${validatedURL}; revealing anyway`
+      )
+      revealMainWindow('did-fail-load')
+    }
+  )
 
   mainWindow.webContents.on('did-finish-load', () => {
     trackLaunchPhase('window_did_finish_load', Date.now() - launchStartedAt)
@@ -655,6 +689,16 @@ if (!headlessCliArgs && !allowMultiInstanceForDeviceTests) {
     app.quit()
   } else {
     app.on('second-instance', (_event, commandLine) => {
+      // A second launch (e.g. double-clicking the shortcut while the app is
+      // already running) must surface the existing window, not silently no-op.
+      // On Windows there is no Dock/'activate' fallback, so without this a hidden
+      // or minimized instance stays invisible and the app looks like it "won't open".
+      const existing = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+      if (existing) {
+        if (!existing.isVisible()) existing.show()
+        if (existing.isMinimized()) existing.restore()
+        existing.focus()
+      }
       const deepLinkUrl = commandLine.find((arg) => arg.startsWith('memry://'))
       if (deepLinkUrl) {
         handleDeepLink(deepLinkUrl)
@@ -723,8 +767,10 @@ void app.whenReady().then(async () => {
     }
   }
 
-  // Set app user model id for windows
-  electronApp.setAppUserModelId('com.electron')
+  // Set app user model id for windows. Must match the electron-builder appId
+  // (config/electron-builder.yml) so the taskbar button, pinned shortcut, and
+  // notifications all attribute to the same app identity.
+  electronApp.setAppUserModelId('com.memrynote.memry')
 
   // Register memry:// deep link protocol for OAuth callbacks (T041e)
   if (process.defaultApp && process.argv.length >= 2) {


### PR DESCRIPTION
## Problem

Reported on Windows: user downloads and opens the app, but **no window ever appears** while the process keeps running.

The main window is created hidden (`show: false`) and revealed only on `ready-to-show`. If the GPU/renderer process crashes before first paint, that event never fires, so the window stays hidden **forever** with no taskbar entry. This never manifested on macOS because the Dock still surfaces the running app and the `activate` event recreates the window — Windows has neither, so the same transient hiccup becomes a permanently invisible app.

## Changes (`apps/desktop/src/main/index.ts`)

- **Guaranteed reveal.** `ready-to-show` still reveals the window on the happy path, but a one-shot `revealMainWindow()` is now also driven by a **10s fallback timeout** and a **`did-fail-load`** handler (ignoring benign `ERR_ABORTED`/-3). A transient GPU/load hiccup can no longer hide the app forever. The reveal is idempotent and guards `isDestroyed()`; the timer is cleared on reveal and on `closed`.
- **`second-instance` surfaces the existing window.** A second launch (double-clicking the shortcut while already running) now shows/restores/focuses the existing window instead of silently no-op'ing. Windows has no Dock/`activate` fallback, so without this a hidden or minimized instance looks like "the app won't open."
- **Corrected `setAppUserModelId`.** Was the electron-vite template default `com.electron`; now matches the electron-builder `appId` `com.memrynote.memry`, fixing Windows taskbar identity, pinned-shortcut grouping, and notification attribution.

## Tests (`index.phase2.test.ts`)

Three regression tests: fallback timeout reveals when `ready-to-show` never fires; `did-fail-load` reveals on a fatal code but ignores `ERR_ABORTED`; `second-instance` surfaces a hidden existing window.

## Verify

- `pnpm --filter @memry/desktop typecheck:node` — clean
- eslint on changed files — 0 errors
- `vitest run src/main/index.phase2.test.ts` — 40/40 pass (3 new)

## Follow-up (not in this PR)

**Code-sign the Windows build.** The `win:` block in `config/electron-builder.yml` has no signing config, so downloads hit SmartScreen/Defender — a separate, infra-level cause of "opened it, nothing happened" that needs a cert secret, out of scope here.

## Note

Docs gate skipped (`MEMRY_DOCS_IMPACT_SKIP=1`): internal startup/window-lifecycle robustness with no user-facing feature or documented workflow. The heuristic flags any main-process file touch.