### PR TITLE
feat(tasks): seed Inbox with In Progress status by default

### DIFF
--- a/apps/desktop/src/main/database/defaults.test.ts
+++ b/apps/desktop/src/main/database/defaults.test.ts
@@ -33,7 +33,14 @@ describe('database defaults', () => {
       .where(eq(statuses.projectId, 'inbox'))
       .all()
 
-    expect(inboxStatuses).toHaveLength(2)
+    expect(inboxStatuses).toHaveLength(3)
+    expect(inboxStatuses.map((s) => s.name)).toEqual(['To Do', 'In Progress', 'Done'])
+
+    const inProgress = inboxStatuses.find((s) => s.id === 'inbox-in-progress')
+    expect(inProgress).toBeDefined()
+    expect(inProgress?.position).toBe(1)
+    expect(inProgress?.isDone).toBe(false)
+    expect(inProgress?.isDefault).toBe(false)
   })
 
   it('is idempotent', () => {
@@ -48,6 +55,6 @@ describe('database defaults', () => {
       .all()
 
     expect(inboxProjects).toHaveLength(1)
-    expect(inboxStatuses).toHaveLength(2)
+    expect(inboxStatuses).toHaveLength(3)
   })
 })

--- a/apps/desktop/src/main/database/defaults.ts
+++ b/apps/desktop/src/main/database/defaults.ts
@@ -46,11 +46,21 @@ export function ensureDefaultTaskProject(db: DataDb): void {
         createdAt: now
       },
       {
+        id: 'inbox-in-progress',
+        projectId: 'inbox',
+        name: 'In Progress',
+        color: '#F59E0B',
+        position: 1,
+        isDefault: false,
+        isDone: false,
+        createdAt: now
+      },
+      {
         id: 'inbox-done',
         projectId: 'inbox',
         name: 'Done',
         color: '#22c55e',
-        position: 1,
+        position: 2,
         isDefault: false,
         isDone: true,
         createdAt: now

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -29,6 +29,8 @@ Each project owns its own ordered list of statuses. A status has:
 
 Status types matter for cross-project views: "All Tasks → kanban grouped by status" maps `memrynote's status type`, not raw status names.
 
+The built-in **Inbox** project ships with `To Do / In Progress / Done` by default, so quick-captured tasks land in the same three lanes as any project you create.
+
 ### Editing Statuses
 
 Open the project header menu and choose **Edit statuses**. From there you can:

--- a/packages/app-core/src/database.ts
+++ b/packages/app-core/src/database.ts
@@ -133,11 +133,21 @@ function ensureDefaultTaskProject(db: DataDb): void {
         createdAt: now
       },
       {
+        id: 'inbox-in-progress',
+        projectId: 'inbox',
+        name: 'In Progress',
+        color: '#F59E0B',
+        position: 1,
+        isDefault: false,
+        isDone: false,
+        createdAt: now
+      },
+      {
         id: 'inbox-done',
         projectId: 'inbox',
         name: 'Done',
         color: '#22c55e',
-        position: 1,
+        position: 2,
         isDefault: false,
         isDone: true,
         createdAt: now


### PR DESCRIPTION
## What

The built-in **Inbox** task project was seeded with only two statuses — `To Do` and `Done`. This adds an **In Progress** lane by default, so the Inbox board/list matches every user-created project (which already gets `To Do / In Progress / Done`).

## Why

`in_progress` is already a first-class status type across the app, and `createDefaultStatuses` (`projects.ts`) gives new projects all three lanes. Only the Inbox seed lagged behind, leaving no place to park started-but-not-done tasks.

## Changes

- `apps/desktop/src/main/database/defaults.ts` — Inbox seed adds `In Progress` (id `inbox-in-progress`, position 1, `isDone: false`); `Done` moves to position 2.
- `packages/app-core/src/database.ts` — same seed for the CLI/app-core path.
- Color `#F59E0B` matches the existing `In Progress` in `createDefaultStatuses`.
- `defaults.test.ts` — updated to expect 3 statuses and assert the new lane's position/flags.
- `projects.md` — documents the Inbox default statuses.

## Scope note

The user-created-project seed in `app-core/src/tasks.ts` still creates only `To Do / Done` (separate from desktop's `createDefaultStatuses`, which has all three). Left untouched — out of scope for this Inbox-default change; flagging as a follow-up inconsistency.

Pre-production: no migration for existing vaults — the seed only runs for a fresh Inbox. Existing dev vaults keep their current statuses.

## Verification

- `vitest --project main src/main/database/defaults.test.ts` — 2 passed
- `typecheck:node` (desktop) + `typecheck` (app-core) — clean
- `docs:impact --base origin/main --strict` — covered
- `docs:build` — clean
