### PR TITLE
fix(tasks): seed In Progress in default Inbox + new projects

### DIFF
--- a/apps/desktop/src/main/database/defaults.test.ts
+++ b/apps/desktop/src/main/database/defaults.test.ts
@@ -33,7 +33,12 @@ describe('database defaults', () => {
       .where(eq(statuses.projectId, 'inbox'))
       .all()
 
-    expect(inboxStatuses).toHaveLength(2)
+    expect(inboxStatuses).toHaveLength(3)
+
+    const orderedNames = [...inboxStatuses]
+      .sort((a, b) => a.position - b.position)
+      .map((s) => s.name)
+    expect(orderedNames).toEqual(['To Do', 'In Progress', 'Done'])
   })
 
   it('is idempotent', () => {
@@ -48,6 +53,6 @@ describe('database defaults', () => {
       .all()
 
     expect(inboxProjects).toHaveLength(1)
-    expect(inboxStatuses).toHaveLength(2)
+    expect(inboxStatuses).toHaveLength(3)
   })
 })

--- a/apps/desktop/src/main/database/defaults.ts
+++ b/apps/desktop/src/main/database/defaults.ts
@@ -46,11 +46,21 @@ export function ensureDefaultTaskProject(db: DataDb): void {
         createdAt: now
       },
       {
+        id: 'inbox-in-progress',
+        projectId: 'inbox',
+        name: 'In Progress',
+        color: '#F59E0B',
+        position: 1,
+        isDefault: false,
+        isDone: false,
+        createdAt: now
+      },
+      {
         id: 'inbox-done',
         projectId: 'inbox',
         name: 'Done',
         color: '#22c55e',
-        position: 1,
+        position: 2,
         isDefault: false,
         isDone: true,
         createdAt: now

--- a/packages/app-core/src/database.ts
+++ b/packages/app-core/src/database.ts
@@ -133,11 +133,21 @@ function ensureDefaultTaskProject(db: DataDb): void {
         createdAt: now
       },
       {
+        id: 'inbox-in-progress',
+        projectId: 'inbox',
+        name: 'In Progress',
+        color: '#F59E0B',
+        position: 1,
+        isDefault: false,
+        isDone: false,
+        createdAt: now
+      },
+      {
         id: 'inbox-done',
         projectId: 'inbox',
         name: 'Done',
         color: '#22c55e',
-        position: 1,
+        position: 2,
         isDefault: false,
         isDone: true,
         createdAt: now

--- a/packages/app-core/src/memry-app.test.ts
+++ b/packages/app-core/src/memry-app.test.ts
@@ -320,6 +320,18 @@ test('opens a standalone vault and exposes core note, journal, task, inbox, and 
     name: 'Task Project',
     description: 'Task project description'
   })
+  assert.deepEqual(
+    (await app.tasks.projects.statuses('inbox'))
+      .sort((a, b) => a.position - b.position)
+      .map((status) => status.name),
+    ['To Do', 'In Progress', 'Done']
+  )
+  assert.deepEqual(
+    (await app.tasks.projects.statuses(taskProject.id))
+      .sort((a, b) => a.position - b.position)
+      .map((status) => status.name),
+    ['To Do', 'In Progress', 'Done']
+  )
   assert.equal(
     (await app.tasks.projects.update(taskProject.id, { name: 'Task Project Updated' })).name,
     'Task Project Updated'

--- a/packages/app-core/src/tasks.ts
+++ b/packages/app-core/src/tasks.ts
@@ -713,9 +713,19 @@ export function createTasksService(dataDb: DataDb): TasksService {
             {
               id: createId('status'),
               projectId: id,
+              name: 'In Progress',
+              color: '#F59E0B',
+              position: 1,
+              isDefault: false,
+              isDone: false,
+              createdAt: time
+            },
+            {
+              id: createId('status'),
+              projectId: id,
               name: 'Done',
               color: '#22c55e',
-              position: 1,
+              position: 2,
               isDefault: false,
               isDone: true,
               createdAt: time


### PR DESCRIPTION
## Problem

Task statuses are **per-project**, but the default seeds were inconsistent. The Inbox (where first-run capture lands) and the app-core project/inbox seeds only created **To Do + Done**, so "In Progress" was never assignable on default tasks — even though desktop-created projects (`createDefaultStatuses`) already seeded all three. A customer reported exactly this: *"there is a Status with In Progress, but I can't assign it — tasks only have To Do or Done."*

## Change

Align every seed path to **To Do → In Progress → Done**:

- `apps/desktop/src/main/database/defaults.ts` — desktop Inbox seed (the shipping default users hit)
- `packages/app-core/src/database.ts` — app-core/CLI Inbox seed
- `packages/app-core/src/tasks.ts` — app-core new-project create (mirrors desktop's already-3-status `createDefaultStatuses`)

In Progress uses the same swatch as the existing new-project default (`#F59E0B`, `isDone: false`, position 1); Done moves to position 2.

## Tests (TDD, red→green)

- `apps/desktop/src/main/database/defaults.test.ts` — Inbox now asserts length 3 + ordered `['To Do','In Progress','Done']`. Watched fail (got 2) → pass.
- `packages/app-core/src/memry-app.test.ts` — asserts both the Inbox and a newly created project seed all three statuses in order. Watched fail → pass.

`pnpm --filter @memry/desktop test:main` → 3294 pass. `pnpm --filter @memry/app-core test` → 7 pass.

## Note

Pre-production, so no migration: existing local vaults keep their old 2-status Inbox; only fresh vaults get In Progress. Flagging in case backfilling existing installs is wanted.