### PR TITLE
fix(editor): heal empty block ids that crash the editor

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -4,7 +4,8 @@ import {
   yDocToMarkdown,
   blocksToYFragment,
   markdownToYFragment,
-  yFragmentToBlocks
+  yFragmentToBlocks,
+  repairEmptyBlockIds
 } from './blocknote-converter'
 import * as Y from 'yjs'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
@@ -328,5 +329,88 @@ describe('blocknote-converter code block language', () => {
         ]
       })
     ])
+  })
+})
+
+describe('blocknote-converter block id integrity', () => {
+  const collectContainerIds = (fragment: Y.XmlFragment): (string | null)[] => {
+    const ids: (string | null)[] = []
+    const visit = (node: Y.XmlFragment | Y.XmlElement): void => {
+      for (const child of node.toArray()) {
+        const el = child as Y.XmlElement
+        if (typeof el.nodeName !== 'string') continue
+        if (el.nodeName === 'blockContainer') ids.push(el.getAttribute('id') ?? null)
+        visit(el)
+      }
+    }
+    visit(fragment)
+    return ids
+  }
+
+  it('never writes an empty block id for multi-blank-line gaps', async () => {
+    // #given markdown whose extra blank lines mint gap paragraphs
+    const doc = new Y.Doc()
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+
+    // #when
+    const ok = await markdownToYFragment('one\n\n\n\n\ntwo', fragment)
+
+    // #then every block container carries a real id (no '' or null)
+    expect(ok).toBe(true)
+    const ids = collectContainerIds(fragment)
+    expect(ids.length).toBeGreaterThan(0)
+    for (const id of ids) expect(id).toBeTruthy()
+  })
+
+  it('regenerates a falsy block id passed to blocksToYFragment', () => {
+    // #given a block handed in with an empty-string id
+    const doc = new Y.Doc()
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+
+    // #when
+    const ok = blocksToYFragment(
+      [{ id: '', type: 'paragraph', props: {}, content: [], children: [] } as unknown as never],
+      fragment
+    )
+
+    // #then the persisted container id is a real value, not ''
+    expect(ok).toBe(true)
+    const ids = collectContainerIds(fragment)
+    expect(ids).toHaveLength(1)
+    expect(ids[0]).toBeTruthy()
+  })
+
+  it('repairEmptyBlockIds stamps ids on containers missing one', () => {
+    // #given a fragment holding a block container with an empty id
+    const doc = new Y.Doc()
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    const container = new Y.XmlElement('blockContainer')
+    container.setAttribute('id', '')
+    container.insert(0, [new Y.XmlElement('paragraph')])
+    fragment.insert(0, [container])
+    expect(container.getAttribute('id')).toBe('')
+
+    // #when
+    const repaired = repairEmptyBlockIds(fragment)
+
+    // #then
+    expect(repaired).toBe(1)
+    expect(container.getAttribute('id')).toBeTruthy()
+  })
+
+  it('leaves already-valid block ids untouched', () => {
+    // #given a fragment whose container already has an id
+    const doc = new Y.Doc()
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    const container = new Y.XmlElement('blockContainer')
+    container.setAttribute('id', 'keep-me')
+    fragment.insert(0, [container])
+
+    // #when
+    const repaired = repairEmptyBlockIds(fragment)
+
+    // #then
+    expect(repaired).toBe(0)
+    expect(container.getAttribute('id')).toBe('keep-me')
   })
 })

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -8,6 +8,7 @@ import {
   createCodeBlockSpec
 } from '@blocknote/core'
 import { codeBlockOptions } from '@blocknote/code-block'
+import { randomUUID } from 'node:crypto'
 import type * as Y from 'yjs'
 import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import { parseCriticMarkup, writeCriticMarkupMarksToYDoc } from '@memry/shared'
@@ -111,15 +112,51 @@ export async function markdownToBlocks(markdown: string): Promise<Block[] | null
   }
 }
 
+// BlockNote's headless serializer regenerates a MISSING block id but writes an
+// explicit empty-string id as-is. An empty id then trips the renderer's block
+// resolver ("Block doesn't have id") and crashes the editor. Stamp a real id on
+// any block whose id is falsy before serializing.
+function ensureBlockIds(blocks: Block[]): void {
+  for (const block of blocks) {
+    if (!block.id) (block as { id: string }).id = randomUUID()
+    const children = block.children as Block[] | undefined
+    if (children?.length) ensureBlockIds(children)
+  }
+}
+
 export function blocksToYFragment(blocks: Block[], fragment: Y.XmlFragment): boolean {
   try {
     const editor = getEditor()
+    ensureBlockIds(blocks)
     editor.blocksToYXmlFragment(blocks, fragment)
     return true
   } catch (err) {
     log.error('Blocks-to-Yjs conversion failed', err)
     return false
   }
+}
+
+const BLOCK_CONTAINER_NODES = new Set(['blockContainer', 'columnList', 'column'])
+
+// Repair notes already persisted with empty-string block ids: walk the CRDT
+// fragment and stamp a fresh id on any block container missing one. Runs on
+// note open so previously-corrupted notes heal instead of showing "Editor
+// Error". Returns the number of blocks repaired.
+export function repairEmptyBlockIds(fragment: Y.XmlFragment): number {
+  let repaired = 0
+  const visit = (node: Y.XmlFragment | Y.XmlElement): void => {
+    for (const child of node.toArray()) {
+      const el = child as Y.XmlElement
+      if (typeof el.nodeName !== 'string' || typeof el.getAttribute !== 'function') continue
+      if (BLOCK_CONTAINER_NODES.has(el.nodeName) && !el.getAttribute('id')) {
+        el.setAttribute('id', randomUUID())
+        repaired++
+      }
+      visit(el)
+    }
+  }
+  visit(fragment)
+  return repaired
 }
 
 export async function markdownToYFragment(
@@ -165,7 +202,7 @@ function createEmptyParagraph(): Block {
     type: 'paragraph',
     content: [],
     children: [],
-    id: '',
+    id: randomUUID(),
     props: {}
   } as unknown as Block
 }

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -12,7 +12,7 @@ import { scheduleWriteback, flushPendingWritebacks, recordNetworkUpdate } from '
 import { toAbsolutePath } from '../vault/notes'
 import { safeRead } from '../vault/file-ops'
 import { parseNote } from '../vault/frontmatter'
-import { markdownToYFragment } from './blocknote-converter'
+import { markdownToYFragment, repairEmptyBlockIds } from './blocknote-converter'
 import { compactYDoc } from './crdt-compact-utils'
 import { isBinaryFileType } from '@memry/shared/file-types'
 import { CRITIC_MARKUP_MARKS_ARRAY } from '@memry/shared'
@@ -164,6 +164,16 @@ export class CrdtProvider {
         const update = Y.encodeStateAsUpdate(persisted)
         Y.applyUpdate(doc, update)
         persisted.destroy()
+        // Heal notes previously persisted with empty block ids, which crash the
+        // editor with "Block doesn't have id" on mount.
+        let repaired = 0
+        doc.transact(() => {
+          repaired = repairEmptyBlockIds(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+        }, ORIGIN_LOCAL)
+        if (repaired > 0) {
+          log.info('Repaired empty block ids in persisted note', { noteId, count: repaired })
+          await this.persistence.storeUpdate(noteId, Y.encodeStateAsUpdate(doc))
+        }
       } else {
         log.warn('CRDT persistence returned empty doc; continuing in-memory', { noteId })
       }


### PR DESCRIPTION
## Problem

A few notes showed **"Editor Error — The editor encountered an error"**, technical details starting with `Block doesn't have id at kt…`. Refresh didn't help.

Root cause: those notes had a block persisted with an **empty-string `id`** (`""`). BlockNote's `kt` resolver runs `if (!id) throw "Block doesn't have id"`, and `!"" === true`, so an empty id reads as missing and the editor crashes on mount. The error boundary then shows "Editor Error". The note text itself is fine — only the block's id attribute is empty.

## Why it happened

The markdown→CRDT converter mints one gap paragraph per **extra** blank line, and `createEmptyParagraph()` hard-coded `id: ''`. The headless serializer (`blocksToYXmlFragment`) regenerates a **missing** id into a real UUID, but writes an explicit empty string as-is. So any note with 2+ consecutive blank lines that re-hydrated from markdown — `seedFromMarkdown`, an external `.md` edit, or sync — persisted an empty-id block. Notes edited purely in the live editor keep real UUIDs, which is why only some notes broke, and why reload never fixed them (the empty id is in the persisted CRDT).

## Fix

- `createEmptyParagraph()` no longer seeds `id: ''` (uses `randomUUID()`).
- `blocksToYFragment` defensively stamps a UUID on any block whose id is falsy before serializing — closes the empty-string footgun at the write choke point.
- `repairEmptyBlockIds()` walks the CRDT fragment on note open and re-ids any empty/missing block container, so **already-corrupted notes self-heal** and re-persist (wired into `crdt-provider` load path).

## Tests

`blocknote-converter.test.ts` — new "block id integrity" suite:
- markdown with multi-blank-line gaps never yields an empty container id
- `blocksToYFragment` regenerates a falsy id
- `repairEmptyBlockIds` stamps missing ids and leaves valid ones untouched

## Reproduce

Externally edit a vault note's `.md` to have a double blank line between two lines of text, then reopen the note — before this change it throws "Editor Error".
