### PR TITLE
feat(desktop): scale editor text and tags with Appearance font size

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -115,6 +115,16 @@
   --bn-font-family: var(--font-sans);
 }
 
+/* ===== EDITOR FONT SIZE (Appearance → Font Size: S/M/L) ===== */
+/* BlockNote pins `.bn-default-styles` to a fixed 16px, so the app's font-size
+   setting — applied by useThemeSync as the root <html> font-size (14/16/18px) —
+   never reached editor body text. `1rem` re-ties the editor to that root value,
+   so S/M/L now scales note body text (and inline #tags, sized at 0.9em) too.
+   At Medium (16px) this is identical to the previous fixed 16px. */
+:root .bn-default-styles {
+  font-size: 1rem;
+}
+
 /* ===== PROSEMIRROR OVERRIDES ===== */
 /* ProseMirror disables ligatures by default — re-enable for denser text */
 :root .bn-editor .ProseMirror {

--- a/apps/desktop/src/renderer/src/components/note/tags-row/TagChip.tsx
+++ b/apps/desktop/src/renderer/src/components/note/tags-row/TagChip.tsx
@@ -31,7 +31,8 @@ export function TagChip({ tag, onRemove, onClick, isSelected, isFocused, disable
   const pillClasses = cn(
     '[font-synthesis:none] relative inline-flex items-center gap-1',
     'rounded-full px-2.5 py-1',
-    'text-[12px]/4 font-medium',
+    // text-xs (0.75rem) instead of fixed 12px so chips scale with Appearance → Font Size (S/M/L)
+    'text-xs font-medium',
     'shrink-0 select-none',
     'transition-colors transition-opacity duration-150',
     isClickable ? 'cursor-pointer hover:opacity-80' : 'cursor-default',
@@ -53,7 +54,7 @@ export function TagChip({ tag, onRemove, onClick, isSelected, isFocused, disable
   const content = (
     <>
       {tag.icon && (
-        <NoteIconDisplay value={tag.icon} className="size-3.5 shrink-0 text-[14px] leading-none" />
+        <NoteIconDisplay value={tag.icon} className="size-3.5 shrink-0 text-sm leading-none" />
       )}
       <span>{tag.name}</span>
       {isSelected && <Check className="h-3 w-3" />}

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -174,7 +174,7 @@ Eight presets — indigo, amber, emerald, red, violet, cyan, pink, orange — pl
 
 ### Typography
 
-- **Font Size** — Small / Medium / Large
+- **Font Size** — Small / Medium / Large. Scales the whole interface, including note editor text and tags.
 - **Font Family** — System, Sans-Serif, Serif, Monospace, Gelasio, Geist, Inter
 
 ---


### PR DESCRIPTION
## What
Appearance → Font Size (S/M/L) now scales BlockNote editor body text, inline #tags (0.9em), and tag-row chips. BlockNote pinned `.bn-default-styles` to a fixed 16px, so the setting never reached editor text; re-tying it to `1rem` (the root font-size `useThemeSync` already sets) makes it scale. Tag-row chips move from fixed `text-[12px]` to rem-based `text-xs`. Identical to today at Medium.

## Why
Customer report: tag text too small to read, and the font-size setting had no effect inside the note editor.