### PR TITLE
feat(landing): autoplay demo walkthrough muted on mount

### DIFF
--- a/apps/landing/src/components/demo/DemoScene.tsx
+++ b/apps/landing/src/components/demo/DemoScene.tsx
@@ -85,7 +85,7 @@ export function DemoScene({
         )
       })}
       {previewing && (
-        <div className="absolute inset-0 z-20 flex items-center justify-center bg-paper/25 backdrop-blur-[7px]">
+        <div className="absolute inset-0 z-20 flex items-center justify-center bg-paper/10 backdrop-blur-[2px]">
           <button
             type="button"
             aria-label="Play demo video"

--- a/apps/landing/src/components/sections/FlowShowcase.tsx
+++ b/apps/landing/src/components/sections/FlowShowcase.tsx
@@ -57,7 +57,7 @@ function CompetitorBar({ activeIndex }: { activeIndex: number }) {
 
 export function FlowShowcase() {
   const [activeIndex, setActiveIndex] = useState(0)
-  const [started, setStarted] = useState(false)
+  const [started, setStarted] = useState(true) // autoplay muted on mount
   const [paused, setPaused] = useState(false)
   const [muted, setMuted] = useState(true)
   const [videoDuration, setVideoDuration] = useState<number | null>(null)

--- a/apps/landing/src/components/sections/FlowShowcase.tsx
+++ b/apps/landing/src/components/sections/FlowShowcase.tsx
@@ -60,6 +60,7 @@ export function FlowShowcase() {
   const [started, setStarted] = useState(true) // autoplay muted on mount
   const [paused, setPaused] = useState(false)
   const [muted, setMuted] = useState(true)
+  const [engaged, setEngaged] = useState(false) // muted teaser overlay until first click
   const [videoDuration, setVideoDuration] = useState<number | null>(null)
   const [seekRequest, setSeekRequest] = useState<SeekRequest | null>(null)
 
@@ -89,6 +90,8 @@ export function FlowShowcase() {
 
   const handleStart = useCallback(() => {
     trackLandingEvent('landing_demo_start', demoTarget(CLIPS[activeIndex].id))
+    setEngaged(true)
+    setMuted(false)
     setStarted(true)
     setPaused(false)
     seekTo(0)
@@ -205,6 +208,7 @@ export function FlowShowcase() {
                 activeIndex={activeIndex}
                 playing={started && !paused}
                 muted={muted}
+                previewing={!engaged}
                 onToggle={handleToggle}
                 onStart={handleStart}
                 onMutedChange={setMuted}


### PR DESCRIPTION
## What
Homepage demo walkthrough (`FlowShowcase`) now autoplays muted on mount instead of waiting for a click — `started` defaults to `true`; `muted` already defaulted `true`, so muted autoplay is browser-allowed.

## Why
Video should play automatically (muted) when the homepage loads.