### PR TITLE
fix(landing): allow PostHog ingest host in CSP connect-src

### DIFF
--- a/apps/landing/src/lib/csp.test.ts
+++ b/apps/landing/src/lib/csp.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'node:test'
+
+// Regression guard for PR #588 CSP regression: the connect-src directive dropped
+// the PostHog ingest host (e.memrynote.com), so browsers blocked every pageview
+// and session-replay upload from the landing site for ~16 days. connect-src must
+// list every external host the browser talks to.
+const REQUIRED_CONNECT_SRC = [
+  'https://e.memrynote.com', // PostHog managed reverse proxy — VITE_POSTHOG_HOST
+  'https://sync.memrynote.com'
+]
+
+function getConnectSrc(): string {
+  const vercelPath = fileURLToPath(new URL('../../vercel.json', import.meta.url))
+  const config = JSON.parse(readFileSync(vercelPath, 'utf8'))
+  const csp = config.headers
+    .flatMap((entry: { headers: { key: string; value: string }[] }) => entry.headers)
+    .find((header: { key: string }) => header.key === 'Content-Security-Policy')?.value as string
+  return csp.split(';').find((directive) => directive.trim().startsWith('connect-src')) ?? ''
+}
+
+describe('landing CSP', () => {
+  it('allows every host the browser connects to', () => {
+    const connectSrc = getConnectSrc()
+    for (const host of REQUIRED_CONNECT_SRC) {
+      assert.ok(connectSrc.includes(host), `connect-src is missing ${host}`)
+    }
+  })
+})

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -21,7 +21,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://*.paddle.com; script-src 'self' 'unsafe-inline' https://*.paddle.com https://*.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' data: https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: https:; connect-src 'self' https://sync.memrynote.com https://*.posthog.com https://*.paddle.com; frame-src https://*.paddle.com"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://*.paddle.com; script-src 'self' 'unsafe-inline' https://*.paddle.com https://*.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' data: https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: https:; connect-src 'self' https://e.memrynote.com https://sync.memrynote.com https://*.posthog.com https://*.paddle.com; frame-src https://*.paddle.com"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },


### PR DESCRIPTION
## What

Landing analytics went dark: no PostHog visit metrics and no session replay since **2026-06-17** (~16 days).

## Root cause

PR #588 added a `Content-Security-Policy` header to `apps/landing/vercel.json`. Its `connect-src` allowed `https://*.posthog.com` but **not** the actual browser ingest host `https://e.memrynote.com` (the managed PostHog reverse proxy, `VITE_POSTHOG_HOST`). Every pageview and session-replay upload rides `connect-src`, so browsers CSP-blocked all of it. Desktop app was unaffected (no CSP).

Confirmed:
- Landing event counts fell from ~10-100/day to ~0 exactly on 2026-06-17.
- Live prod CSP header still omitted the host; deployed JS confirmed talking to `e.memrynote.com`.

## Fix

- Add `https://e.memrynote.com` to `connect-src`.
- Regression test (`src/lib/csp.test.ts`) asserts the CSP lists every host the browser connects to. Fails on the old CSP, passes on the fix.

## Deploy

Vercel redeploys on merge to `main`. Collection resumes as soon as the new CSP is live — no PostHog-side changes needed.