### PR TITLE
fix(desktop): hide macOS traffic-light controls on Windows/Linux

### DIFF
--- a/apps/desktop/src/renderer/src/components/traffic-lights.tsx
+++ b/apps/desktop/src/renderer/src/components/traffic-lights.tsx
@@ -25,13 +25,17 @@ export function TrafficLights({ className, compact = false }: TrafficLightsProps
   const { t: tPhaseF } = useT('common')
   const [isHovered, setIsHovered] = React.useState(false)
 
+  // Only macOS hides its native frame (titleBarStyle: 'hidden'). On Windows/Linux the
+  // native window buttons remain, so these mac-style controls would just duplicate them.
+  if (navigator.platform.toUpperCase().indexOf('MAC') < 0) return null
+
   const buttonSize = compact ? 'size-2.5' : 'size-3.5'
   const iconSize = compact ? 'size-2.5' : 'size-3.5'
 
   return (
     <div
       className={cn(
-        'flex items-center transition-all duration-200',
+        'no-drag flex items-center transition-all duration-200',
         compact ? 'gap-1.5' : 'gap-2',
         className
       )}

--- a/apps/desktop/src/renderer/src/components/vault-onboarding.tsx
+++ b/apps/desktop/src/renderer/src/components/vault-onboarding.tsx
@@ -92,9 +92,7 @@ export function VaultOnboarding(): React.JSX.Element {
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-background text-foreground antialiased font-sans">
       <div className="drag-region flex items-center h-9 px-3.5 shrink-0 bg-surface border-b border-border">
-        <div className="no-drag flex items-center">
-          <TrafficLights compact />
-        </div>
+        <TrafficLights compact />
       </div>
 
       <div className="flex w-full grow shrink basis-0 min-h-0 bg-background">

--- a/apps/desktop/src/renderer/src/components/window-controls.test.tsx
+++ b/apps/desktop/src/renderer/src/components/window-controls.test.tsx
@@ -79,9 +79,14 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn()
 })
 
+const setPlatform = (value: string): void => {
+  Object.defineProperty(window.navigator, 'platform', { value, configurable: true })
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   setTabs()
+  setPlatform('MacIntel') // TrafficLights only render on macOS
   const w = window as WindowWithApi
   originalApi = w.api
   w.api = windowApiMock
@@ -106,6 +111,16 @@ describe('WindowControls', () => {
     expect(screen.getByLabelText('Close window')).toBeInTheDocument()
     expect(screen.getByLabelText('Minimize window')).toBeInTheDocument()
     expect(screen.getByLabelText('Maximize window')).toBeInTheDocument()
+  })
+
+  it('hides traffic-light buttons on non-macOS (native frame provides them)', () => {
+    setPlatform('Win32')
+    renderWithSidebar(<WindowControls />)
+    expect(screen.queryByLabelText('Close window')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Minimize window')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Maximize window')).not.toBeInTheDocument()
+    // The rest of the bar (sidebar toggle) still renders.
+    expect(screen.getByRole('button', { name: /toggle sidebar/i })).toBeInTheDocument()
   })
 
   it('renders the sidebar toggle', () => {

--- a/apps/desktop/src/renderer/src/components/window-controls.tsx
+++ b/apps/desktop/src/renderer/src/components/window-controls.tsx
@@ -48,9 +48,7 @@ export function WindowControls({ className }: WindowControlsProps): React.JSX.El
 
   return (
     <div className={cn('drag-region flex items-center gap-2 shrink-0 h-9 ps-3 pe-2', className)}>
-      <div className="no-drag flex items-center">
-        <TrafficLights />
-      </div>
+      <TrafficLights />
 
       <div className="no-drag flex items-center gap-0.5 ms-1">
         <Tooltip>


### PR DESCRIPTION
## Problem
The Windows (and Linux) build showed macOS-style window chrome: the custom red/yellow/green close/minimize/maximize "traffic light" controls in the top-left. Only macOS hides its native frame (`titleBarStyle: 'hidden'` in `createWindow`), so on other platforms those controls were painted **on top of** the real native window buttons — duplicated, out of place.

## Fix
- `TrafficLights` now returns `null` unless the platform is macOS (render-time `navigator.platform` check, matching the existing idiom used across the keyboard hooks). Windows/Linux keep only their native frame buttons.
- Folded the `no-drag` wrapper into `TrafficLights` so a `null` return leaves zero DOM — no phantom flex gap in the window-controls bar or onboarding header on non-mac.

Single source of truth: both call sites (main window-controls bar + vault onboarding header) are covered by the one guard.

## Test
- `window-controls.test.tsx`: defaults the test platform to macOS (so existing render assertions hold) and adds a `Win32` case asserting the traffic-light buttons are hidden while the rest of the bar still renders.
- `pnpm --filter @memry/desktop test:renderer window-controls vault-onboarding` → 14 passed.

Renderer-only change; not observable from macOS at build time — verify visually on a Windows run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)