### PR TITLE
fix(desktop): stop invalid date property crashing the note tab

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.tsx
+++ b/apps/desktop/src/renderer/src/components/note/info-section/PropertyRow.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useMemo } from 'react'
+import { isValid } from 'date-fns'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import {
@@ -262,9 +263,13 @@ function PropertyValueRenderer({
   }
 
   if (property.type === 'date') {
+    // An unparseable stored value yields an Invalid Date (still truthy); pass null
+    // so the editor and calendar never receive one and read it as empty.
+    const rawDate = property.value ? new Date(property.value as string | number | Date) : null
+    const dateValue = rawDate && isValid(rawDate) ? rawDate : null
     return (
       <DateEditor
-        value={property.value ? new Date(property.value as string | number | Date) : null}
+        value={dateValue}
         onChange={(date) => onValueChange(date?.toISOString() ?? null)}
         defaultOpen={autoOpen}
       />

--- a/apps/desktop/src/renderer/src/lib/format-date.test.ts
+++ b/apps/desktop/src/renderer/src/lib/format-date.test.ts
@@ -11,6 +11,15 @@ describe('formatDate', () => {
     expect(formatDate(d, 'YYYY-MM-DD')).toBe('2026-07-02')
     expect(formatDate(d, 'DD.MM.YYYY')).toBe('02.07.2026')
   })
+
+  // Regression: an unparseable date property reaches the note tab as
+  // `new Date('...')` (Invalid Date). date-fns format() throws RangeError on it,
+  // which escaped into render and crashed the whole tab via the error boundary.
+  it('returns empty string instead of throwing on an invalid date', () => {
+    expect(() => formatDate(new Date('not a date'), 'DD.MM.YYYY')).not.toThrow()
+    expect(formatDate(new Date('not a date'), 'DD.MM.YYYY')).toBe('')
+    expect(formatDate(new Date(NaN))).toBe('')
+  })
 })
 
 describe('parseDateInput', () => {

--- a/apps/desktop/src/renderer/src/lib/format-date.ts
+++ b/apps/desktop/src/renderer/src/lib/format-date.ts
@@ -28,6 +28,10 @@ export function dateFnsPattern(f: DateFormat = current): string {
 }
 
 export function formatDate(date: Date, f: DateFormat = current): string {
+  // date-fns format() throws RangeError on an invalid Date. Unparseable date
+  // properties reach here as `new Date('...')` (Invalid Date), so guard instead
+  // of letting the throw escape into React render and blow up the whole tab.
+  if (!isValid(date)) return ''
   return format(date, PATTERNS[f])
 }
 


### PR DESCRIPTION
## Symptom

On Windows the app appeared to **crash immediately when clicking "+ New"** — the newly opened note tab blew up. PostHog error tracking shows the matching signal: a `RangeError` caught by `renderer:tab_error_boundary`, first/last seen 2026-07-03, single user, tiny window.

## Root cause

Opening a note renders its properties. For a `date`-typed property, `PropertyRow` built the editor value as:

```tsx
value={property.value ? new Date(property.value as string | number | Date) : null}
```

When the stored value can't be parsed, `new Date('...')` is an **Invalid Date** — still a truthy object, so the `property.value ?` guard passes it straight through. `DateEditor` then renders `formatDate(value)`, and `formatDate` calls **date-fns `format()`**, which throws `RangeError: Invalid time value` on an invalid date. That throw escaped into React render and propagated to the tab error boundary, tearing down the whole tab.

Confirmed locally:

```
format(new Date('x'), 'dd.MM.yyyy') → RangeError: Invalid time value
```

The date path is new (configurable date format / date-property picker), which is why this surfaced now.

## Fix

Two guards, root cause first:

1. **`format-date.ts` — `formatDate()` guards invalid dates** (returns `''`) instead of letting date-fns throw. This is the shared choke point every caller trusts, so it protects all of them at once.
2. **`PropertyRow.tsx`** treats an unparseable date value as empty (`null`), so `DateEditor` and the calendar never receive an Invalid Date in the first place.

## Test

`format-date.test.ts` gains a regression case asserting `formatDate` returns `''` and does not throw on an invalid date. It fails without the guard (date-fns throws) and passes with it.

## Verification

- `vitest run format-date.test.ts` → 4 passed
- `typecheck:web` clean on both changed files (only a pre-existing, unrelated `ai-elements/message.tsx` error remains)
- ESLint clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)