### PR TITLE
feat(tags): preserve tag case with case-insensitive identity

### DIFF
--- a/apps/desktop/src/main/database/drizzle-data/0034_tag_nocase.sql
+++ b/apps/desktop/src/main/database/drizzle-data/0034_tag_nocase.sql
@@ -1,0 +1,34 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_task_tags` (
+	`task_id` text NOT NULL,
+	`tag` text COLLATE NOCASE NOT NULL,
+	PRIMARY KEY(`task_id`, `tag`),
+	FOREIGN KEY (`task_id`) REFERENCES `tasks`(`id`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+INSERT OR IGNORE INTO `__new_task_tags`("task_id", "tag") SELECT "task_id", "tag" FROM `task_tags`;--> statement-breakpoint
+DROP TABLE `task_tags`;--> statement-breakpoint
+ALTER TABLE `__new_task_tags` RENAME TO `task_tags`;--> statement-breakpoint
+CREATE INDEX `idx_task_tags_tag` ON `task_tags` (`tag`);--> statement-breakpoint
+CREATE TABLE `__new_inbox_item_tags` (
+	`id` text PRIMARY KEY NOT NULL,
+	`item_id` text NOT NULL,
+	`tag` text COLLATE NOCASE NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`item_id`) REFERENCES `inbox_items`(`id`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+INSERT OR IGNORE INTO `__new_inbox_item_tags`("id", "item_id", "tag", "created_at") SELECT "id", "item_id", "tag", "created_at" FROM `inbox_item_tags`;--> statement-breakpoint
+DROP TABLE `inbox_item_tags`;--> statement-breakpoint
+ALTER TABLE `__new_inbox_item_tags` RENAME TO `inbox_item_tags`;--> statement-breakpoint
+CREATE INDEX `idx_inbox_tags_item` ON `inbox_item_tags` (`item_id`);--> statement-breakpoint
+CREATE INDEX `idx_inbox_tags_tag` ON `inbox_item_tags` (`tag`);--> statement-breakpoint
+CREATE TABLE `__new_tag_definitions` (
+	`name` text COLLATE NOCASE PRIMARY KEY NOT NULL,
+	`color` text NOT NULL,
+	`icon` text,
+	`clock` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);--> statement-breakpoint
+INSERT OR IGNORE INTO `__new_tag_definitions`("name", "color", "icon", "clock", "created_at") SELECT "name", "color", "icon", "clock", "created_at" FROM `tag_definitions`;--> statement-breakpoint
+DROP TABLE `tag_definitions`;--> statement-breakpoint
+ALTER TABLE `__new_tag_definitions` RENAME TO `tag_definitions`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/apps/desktop/src/main/database/drizzle-data/meta/_journal.json
+++ b/apps/desktop/src/main/database/drizzle-data/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1782518400000,
       "tag": "0033_tag_definition_icon",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1783206622572,
+      "tag": "0034_tag_nocase",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/src/main/database/drizzle-index/0019_bitter_zarda.sql
+++ b/apps/desktop/src/main/database/drizzle-index/0019_bitter_zarda.sql
@@ -1,0 +1,75 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_note_cache` (
+	`id` text PRIMARY KEY NOT NULL,
+	`path` text NOT NULL,
+	`title` text NOT NULL,
+	`file_type` text DEFAULT 'markdown' NOT NULL,
+	`mime_type` text,
+	`file_size` integer,
+	`attachment_id` text,
+	`emoji` text,
+	`local_only` integer DEFAULT false,
+	`content_hash` text,
+	`word_count` integer,
+	`character_count` integer,
+	`snippet` text,
+	`date` text,
+	`clock` text,
+	`synced_at` text,
+	`created_at` text NOT NULL,
+	`modified_at` text NOT NULL,
+	`indexed_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_note_cache`("id", "path", "title", "file_type", "mime_type", "file_size", "attachment_id", "emoji", "local_only", "content_hash", "word_count", "character_count", "snippet", "date", "clock", "synced_at", "created_at", "modified_at", "indexed_at") SELECT "id", "path", "title", "file_type", "mime_type", "file_size", "attachment_id", "emoji", "local_only", "content_hash", "word_count", "character_count", "snippet", "date", "clock", "synced_at", "created_at", "modified_at", "indexed_at" FROM `note_cache`;--> statement-breakpoint
+DROP TABLE `note_cache`;--> statement-breakpoint
+ALTER TABLE `__new_note_cache` RENAME TO `note_cache`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `note_cache_path_unique` ON `note_cache` (`path`);--> statement-breakpoint
+CREATE INDEX `idx_note_cache_path` ON `note_cache` (`path`);--> statement-breakpoint
+CREATE INDEX `idx_note_cache_modified` ON `note_cache` (`modified_at`);--> statement-breakpoint
+CREATE INDEX `idx_note_cache_date` ON `note_cache` (`date`);--> statement-breakpoint
+CREATE INDEX `idx_note_cache_file_type` ON `note_cache` (`file_type`);--> statement-breakpoint
+CREATE TABLE `__new_note_snapshots` (
+	`id` text PRIMARY KEY NOT NULL,
+	`note_id` text NOT NULL,
+	`content` text NOT NULL,
+	`title` text NOT NULL,
+	`word_count` integer DEFAULT 0 NOT NULL,
+	`content_hash` text NOT NULL,
+	`reason` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`note_id`) REFERENCES `note_cache`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_note_snapshots`("id", "note_id", "content", "title", "word_count", "content_hash", "reason", "created_at") SELECT "id", "note_id", "content", "title", "word_count", "content_hash", "reason", "created_at" FROM `note_snapshots`;--> statement-breakpoint
+DROP TABLE `note_snapshots`;--> statement-breakpoint
+ALTER TABLE `__new_note_snapshots` RENAME TO `note_snapshots`;--> statement-breakpoint
+CREATE INDEX `idx_note_snapshots_note_id` ON `note_snapshots` (`note_id`);--> statement-breakpoint
+CREATE INDEX `idx_note_snapshots_created` ON `note_snapshots` (`created_at`);--> statement-breakpoint
+CREATE TABLE `__new_note_tags` (
+	`note_id` text NOT NULL,
+	`tag` text COLLATE NOCASE NOT NULL,
+	`position` integer DEFAULT 0 NOT NULL,
+	`pinned_at` text,
+	PRIMARY KEY(`note_id`, `tag`),
+	FOREIGN KEY (`note_id`) REFERENCES `note_cache`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_note_tags`("note_id", "tag", "position", "pinned_at") SELECT "note_id", "tag", "position", "pinned_at" FROM `note_tags`;--> statement-breakpoint
+DROP TABLE `note_tags`;--> statement-breakpoint
+ALTER TABLE `__new_note_tags` RENAME TO `note_tags`;--> statement-breakpoint
+CREATE INDEX `idx_note_tags_tag` ON `note_tags` (`tag`);--> statement-breakpoint
+CREATE INDEX `idx_note_tags_pinned` ON `note_tags` (`pinned_at`);--> statement-breakpoint
+CREATE TABLE `__new_property_definitions` (
+	`name` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`options` text,
+	`default_value` text,
+	`color` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_property_definitions`("name", "type", "options", "default_value", "color", "created_at") SELECT "name", "type", "options", "default_value", "color", "created_at" FROM `property_definitions`;--> statement-breakpoint
+DROP TABLE `property_definitions`;--> statement-breakpoint
+ALTER TABLE `__new_property_definitions` RENAME TO `property_definitions`;

--- a/apps/desktop/src/main/database/drizzle-index/meta/0019_snapshot.json
+++ b/apps/desktop/src/main/database/drizzle-index/meta/0019_snapshot.json
@@ -1,0 +1,513 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "faed4048-7c56-4f13-a970-85e681dd5f6d",
+  "prevId": "91ff1d48-6ec6-4bc6-980d-6532ba51e18c",
+  "tables": {
+    "note_cache": {
+      "name": "note_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'markdown'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_only": {
+          "name": "local_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "character_count": {
+          "name": "character_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clock": {
+          "name": "clock",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "note_cache_path_unique": {
+          "name": "note_cache_path_unique",
+          "columns": ["path"],
+          "isUnique": true
+        },
+        "idx_note_cache_path": {
+          "name": "idx_note_cache_path",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "idx_note_cache_modified": {
+          "name": "idx_note_cache_modified",
+          "columns": ["modified_at"],
+          "isUnique": false
+        },
+        "idx_note_cache_date": {
+          "name": "idx_note_cache_date",
+          "columns": ["date"],
+          "isUnique": false
+        },
+        "idx_note_cache_file_type": {
+          "name": "idx_note_cache_file_type",
+          "columns": ["file_type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_links": {
+      "name": "note_links",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_note_links_target": {
+          "name": "idx_note_links_target",
+          "columns": ["target_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_links_source_id_note_cache_id_fk": {
+          "name": "note_links_source_id_note_cache_id_fk",
+          "tableFrom": "note_links",
+          "tableTo": "note_cache",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_links_source_id_target_title_pk": {
+          "columns": ["source_id", "target_title"],
+          "name": "note_links_source_id_target_title_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_properties": {
+      "name": "note_properties",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_note_properties_name": {
+          "name": "idx_note_properties_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "idx_note_properties_value": {
+          "name": "idx_note_properties_value",
+          "columns": ["value"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_properties_note_id_note_cache_id_fk": {
+          "name": "note_properties_note_id_note_cache_id_fk",
+          "tableFrom": "note_properties",
+          "tableTo": "note_cache",
+          "columnsFrom": ["note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_properties_note_id_name_pk": {
+          "columns": ["note_id", "name"],
+          "name": "note_properties_note_id_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_snapshots": {
+      "name": "note_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_note_snapshots_note_id": {
+          "name": "idx_note_snapshots_note_id",
+          "columns": ["note_id"],
+          "isUnique": false
+        },
+        "idx_note_snapshots_created": {
+          "name": "idx_note_snapshots_created",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_snapshots_note_id_note_cache_id_fk": {
+          "name": "note_snapshots_note_id_note_cache_id_fk",
+          "tableFrom": "note_snapshots",
+          "tableTo": "note_cache",
+          "columnsFrom": ["note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_tags": {
+      "name": "note_tags",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text COLLATE NOCASE",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_note_tags_tag": {
+          "name": "idx_note_tags_tag",
+          "columns": ["tag"],
+          "isUnique": false
+        },
+        "idx_note_tags_pinned": {
+          "name": "idx_note_tags_pinned",
+          "columns": ["pinned_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_tags_note_id_note_cache_id_fk": {
+          "name": "note_tags_note_id_note_cache_id_fk",
+          "tableFrom": "note_tags",
+          "tableTo": "note_cache",
+          "columnsFrom": ["note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_tags_note_id_tag_pk": {
+          "columns": ["note_id", "tag"],
+          "name": "note_tags_note_id_tag_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "property_definitions": {
+      "name": "property_definitions",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/desktop/src/main/database/drizzle-index/meta/_journal.json
+++ b/apps/desktop/src/main/database/drizzle-index/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1771961898409,
       "tag": "0018_secret_jackal",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1783206460942,
+      "tag": "0019_bitter_zarda",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/src/main/database/queries/notes/notes.test.ts
+++ b/apps/desktop/src/main/database/queries/notes/notes.test.ts
@@ -138,18 +138,32 @@ describe('notes cache queries', () => {
     expect(countNotes(db, 'projects')).toBe(2)
   })
 
-  it('manages note tags and tag listings', () => {
+  it('manages note tags and tag listings, preserving case', () => {
     createNote('note-11')
     setNoteTags(db, 'note-11', ['Work', 'Personal'])
 
-    expect(getNoteTags(db, 'note-11').sort()).toEqual(['personal', 'work'])
+    expect(getNoteTags(db, 'note-11').sort()).toEqual(['Personal', 'Work'])
     const tags = getAllTags(db)
     expect(tags).toEqual(
       expect.arrayContaining([
-        { tag: 'work', count: 1 },
-        { tag: 'personal', count: 1 }
+        { tag: 'Work', count: 1 },
+        { tag: 'Personal', count: 1 }
       ])
     )
+  })
+
+  it('treats tag identity case-insensitively', () => {
+    createNote('note-11a')
+    createNote('note-11b')
+    // Case variants on one note collapse to the first spelling
+    setNoteTags(db, 'note-11a', ['Work', 'work'])
+    expect(getNoteTags(db, 'note-11a')).toEqual(['Work'])
+
+    // Lookups match regardless of case, counts merge across notes
+    setNoteTags(db, 'note-11b', ['WORK'])
+    expect(findNotesByTag(db, 'work').length).toBe(2)
+    const tags = getAllTags(db)
+    expect(tags).toEqual(expect.arrayContaining([expect.objectContaining({ count: 2 })]))
   })
 
   it('finds notes by tags with pinned metadata', () => {

--- a/apps/desktop/src/main/database/queries/notes/tag-queries.ts
+++ b/apps/desktop/src/main/database/queries/notes/tag-queries.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, inArray, like, count, desc, sql } from 'drizzle-orm'
+import { eq, and, or, inArray, like, count, desc } from 'drizzle-orm'
 import {
   noteCache,
   noteTags,
@@ -14,10 +14,20 @@ import type { IndexDb } from '../../types'
 export function setNoteTags(db: IndexDb, noteId: string, tags: string[]): void {
   db.delete(noteTags).where(eq(noteTags.noteId, noteId)).run()
 
-  if (tags.length > 0) {
-    const tagRecords: NewNoteTag[] = tags.map((tag, index) => ({
+  // Case-preserving, case-insensitive dedupe (tag column is COLLATE NOCASE,
+  // so case variants would violate the (noteId, tag) primary key)
+  const byKey = new Map<string, string>()
+  for (const raw of tags) {
+    const tag = raw.trim()
+    if (!tag) continue
+    const key = tag.toLowerCase()
+    if (!byKey.has(key)) byKey.set(key, tag)
+  }
+
+  if (byKey.size > 0) {
+    const tagRecords: NewNoteTag[] = [...byKey.values()].map((tag, index) => ({
       noteId,
-      tag: tag.toLowerCase().trim(),
+      tag,
       position: index
     }))
     db.insert(noteTags).values(tagRecords).run()
@@ -219,25 +229,33 @@ export function unpinNoteFromTag(db: IndexDb, noteId: string, tag: string): void
 
 export function renameTag(db: IndexDb, oldName: string, newName: string): number {
   const normalizedOld = oldName.toLowerCase().trim()
-  const normalizedNew = newName.toLowerCase().trim()
+  const trimmedNew = newName.trim()
 
-  if (normalizedOld === normalizedNew) return 0
+  // Case-only renames are valid: they update the stored display case
+  if (oldName.trim() === trimmedNew) return 0
 
   const exactResult = db
     .update(noteTags)
-    .set({ tag: normalizedNew })
+    .set({ tag: trimmedNew })
     .where(eq(noteTags.tag, normalizedOld))
     .run()
 
-  const childResult = db
-    .update(noteTags)
-    .set({
-      tag: sql`replace(${noteTags.tag}, ${normalizedOld + '/'}, ${normalizedNew + '/'})`
-    })
+  // Rewrite children row-by-row: SQL replace() is case-sensitive, but stored
+  // prefixes may differ in case from the requested name
+  const childRows = db
+    .select({ noteId: noteTags.noteId, tag: noteTags.tag })
+    .from(noteTags)
     .where(like(noteTags.tag, `${normalizedOld}/%`))
-    .run()
+    .all()
 
-  return exactResult.changes + childResult.changes
+  for (const row of childRows) {
+    db.update(noteTags)
+      .set({ tag: trimmedNew + row.tag.slice(normalizedOld.length) })
+      .where(and(eq(noteTags.noteId, row.noteId), eq(noteTags.tag, row.tag)))
+      .run()
+  }
+
+  return exactResult.changes + childRows.length
 }
 
 export function deleteTag(db: IndexDb, tag: string, options: { cascade?: boolean } = {}): number {

--- a/apps/desktop/src/main/database/queries/tags.test.ts
+++ b/apps/desktop/src/main/database/queries/tags.test.ts
@@ -386,9 +386,9 @@ describe('mergeTagInNotes', () => {
     // #when: call with mixed-case args
     const result = mergeTagInNotes(indexDb, 'Work', 'Personal')
 
-    // #then: "work" row is renamed to "personal"
+    // #then: "work" row is renamed to "Personal" (target case preserved)
     expect(result.affected).toBe(1)
-    expect(readNoteTags(indexDb, 'n1')).toEqual(['personal'])
+    expect(readNoteTags(indexDb, 'n1')).toEqual(['Personal'])
   })
 
   it('returns correct noteIds for all affected rows', () => {
@@ -507,7 +507,7 @@ describe('mergeTagInTasks', () => {
 
     // #then
     expect(result.affected).toBe(1)
-    expect(readTaskTags(dataDb, 't1')).toEqual(['review'])
+    expect(readTaskTags(dataDb, 't1')).toEqual(['Review'])
   })
 
   it('returns correct taskIds for all affected rows', () => {

--- a/apps/desktop/src/main/database/queries/tags.ts
+++ b/apps/desktop/src/main/database/queries/tags.ts
@@ -13,22 +13,29 @@ export function getAllTagsWithCounts(indexDb: IndexDb, dataDb: DataDb): TagWithC
   const taskCounts = getAllTaskTags(dataDb)
   const definitions = getAllTagDefinitions(dataDb)
 
-  const colorMap = new Map(definitions.map((d) => [d.name, d.color]))
-  const iconMap = new Map(definitions.map((d) => [d.name, d.icon]))
+  // Identity is case-insensitive (lowercase key); display name keeps the
+  // first-seen casing from actual usage
+  const colorMap = new Map(definitions.map((d) => [d.name.toLowerCase(), d.color]))
+  const iconMap = new Map(definitions.map((d) => [d.name.toLowerCase(), d.icon]))
   const merged = new Map<string, TagWithCount>()
 
   for (const { tag, count } of noteCounts) {
-    const name = tag.toLowerCase().trim()
-    merged.set(name, { name, count, color: colorMap.get(name), icon: iconMap.get(name) })
-  }
-
-  for (const { tag, count } of taskCounts) {
-    const name = tag.toLowerCase().trim()
-    const existing = merged.get(name)
+    const key = tag.toLowerCase().trim()
+    const existing = merged.get(key)
     if (existing) {
       existing.count += count
     } else {
-      merged.set(name, { name, count, color: colorMap.get(name), icon: iconMap.get(name) })
+      merged.set(key, { name: tag.trim(), count, color: colorMap.get(key), icon: iconMap.get(key) })
+    }
+  }
+
+  for (const { tag, count } of taskCounts) {
+    const key = tag.toLowerCase().trim()
+    const existing = merged.get(key)
+    if (existing) {
+      existing.count += count
+    } else {
+      merged.set(key, { name: tag.trim(), count, color: colorMap.get(key), icon: iconMap.get(key) })
     }
   }
 
@@ -40,7 +47,7 @@ export function getAllTagsWithCounts(indexDb: IndexDb, dataDb: DataDb): TagWithC
   }
 
   for (const def of definitions) {
-    if (!merged.has(def.name)) {
+    if (!merged.has(def.name.toLowerCase())) {
       deleteTagDefinition(dataDb, def.name)
     }
   }
@@ -54,7 +61,8 @@ export function mergeTagInNotes(
   target: string
 ): { affected: number; noteIds: string[] } {
   const normalizedSource = source.toLowerCase().trim()
-  const normalizedTarget = target.toLowerCase().trim()
+  const trimmedTarget = target.trim()
+  const normalizedTarget = trimmedTarget.toLowerCase()
 
   if (normalizedSource === normalizedTarget) {
     return { affected: 0, noteIds: [] }
@@ -93,7 +101,7 @@ export function mergeTagInNotes(
   if (remainingNoteIds.length > 0) {
     indexDb
       .update(noteTags)
-      .set({ tag: normalizedTarget })
+      .set({ tag: trimmedTarget })
       .where(and(eq(noteTags.tag, normalizedSource), inArray(noteTags.noteId, remainingNoteIds)))
       .run()
   }
@@ -107,7 +115,8 @@ export function mergeTagInTasks(
   target: string
 ): { affected: number; taskIds: string[] } {
   const normalizedSource = source.toLowerCase().trim()
-  const normalizedTarget = target.toLowerCase().trim()
+  const trimmedTarget = target.trim()
+  const normalizedTarget = trimmedTarget.toLowerCase()
 
   if (normalizedSource === normalizedTarget) {
     return { affected: 0, taskIds: [] }
@@ -146,7 +155,7 @@ export function mergeTagInTasks(
   if (remainingTaskIds.length > 0) {
     dataDb
       .update(taskTags)
-      .set({ tag: normalizedTarget })
+      .set({ tag: trimmedTarget })
       .where(and(eq(taskTags.tag, normalizedSource), inArray(taskTags.taskId, remainingTaskIds)))
       .run()
   }

--- a/apps/desktop/src/main/database/queries/tasks.test.ts
+++ b/apps/desktop/src/main/database/queries/tasks.test.ts
@@ -382,13 +382,13 @@ describe('tasks queries', () => {
     const task = createTask('task-46')
     setTaskTags(db, task.id, ['Alpha', 'Beta'])
 
-    expect(getTaskTags(db, task.id).sort()).toEqual(['alpha', 'beta'])
+    expect(getTaskTags(db, task.id).sort()).toEqual(['Alpha', 'Beta'])
 
     const counts = getAllTaskTags(db)
     expect(counts).toEqual(
       expect.arrayContaining([
-        { tag: 'alpha', count: 1 },
-        { tag: 'beta', count: 1 }
+        { tag: 'Alpha', count: 1 },
+        { tag: 'Beta', count: 1 }
       ])
     )
   })

--- a/apps/desktop/src/main/database/queries/tasks.ts
+++ b/apps/desktop/src/main/database/queries/tasks.ts
@@ -584,11 +584,19 @@ export function setTaskTags(db: DataDb, taskId: string, tags: string[]): void {
   // Delete existing tags
   db.delete(taskTags).where(eq(taskTags.taskId, taskId)).run()
 
-  // Insert new tags
-  if (tags.length > 0) {
-    const tagRecords: NewTaskTag[] = tags.map((tag) => ({
+  // Insert new tags — case preserved, deduped case-insensitively
+  // (tag column is COLLATE NOCASE, case variants would violate the PK)
+  const byKey = new Map<string, string>()
+  for (const raw of tags) {
+    const tag = raw.trim()
+    if (!tag) continue
+    const key = tag.toLowerCase()
+    if (!byKey.has(key)) byKey.set(key, tag)
+  }
+  if (byKey.size > 0) {
+    const tagRecords: NewTaskTag[] = [...byKey.values()].map((tag) => ({
       taskId,
-      tag: tag.toLowerCase().trim()
+      tag
     }))
     db.insert(taskTags).values(tagRecords).run()
   }

--- a/apps/desktop/src/main/inbox/batch.test.ts
+++ b/apps/desktop/src/main/inbox/batch.test.ts
@@ -187,8 +187,8 @@ describe('inbox batch handlers', () => {
       handlers.handleBulkTag({ itemIds: ['item-1'], tags: [' Work ', '', 'Ideas'] })
     ).resolves.toEqual({ success: true, processedCount: 1, errors: [] })
     expect(db.inserts).toEqual([
-      { id: 'generated-id', itemId: 'item-1', tag: 'work' },
-      { id: 'generated-id', itemId: 'item-1', tag: 'ideas' }
+      { id: 'generated-id', itemId: 'item-1', tag: 'Work' },
+      { id: 'generated-id', itemId: 'item-1', tag: 'Ideas' }
     ])
     expect(emitInboxEvent).toHaveBeenCalledWith(expect.any(String), {
       id: 'item-1',

--- a/apps/desktop/src/main/inbox/batch.ts
+++ b/apps/desktop/src/main/inbox/batch.ts
@@ -123,7 +123,7 @@ export function createInboxBatchHandlers(deps: InboxBatchHandlerDeps): InboxBatc
         }
 
         for (const tag of tags) {
-          const normalizedTag = tag.trim().toLowerCase()
+          const normalizedTag = tag.trim()
           if (!normalizedTag) continue
 
           const existing = db

--- a/apps/desktop/src/main/ipc/tags-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/tags-handlers.test.ts
@@ -297,7 +297,7 @@ describe('tags-handlers', () => {
     expect(renameResult).toEqual({ success: true, affectedNotes: 1 })
     expect(fileMocks.toAbsolutePath).toHaveBeenCalledWith('notes/a.md')
     expect(fileMocks.readFile).toHaveBeenCalledWith('/vault/notes/a.md', 'utf-8')
-    expect(fileMocks.serializeNote).toHaveBeenCalledWith({ tags: ['new', 'keep'] }, 'Body')
+    expect(fileMocks.serializeNote).toHaveBeenCalledWith({ tags: ['New', 'keep'] }, 'Body')
     expect(fileMocks.atomicWrite).toHaveBeenCalledWith('/vault/notes/a.md', 'serialized note')
     expect(fileMocks.syncTaggedNote).toHaveBeenCalledWith('note-1')
     expect(fileMocks.syncTagDefinitionRename).toHaveBeenCalledWith(' old ', ' New ', {

--- a/apps/desktop/src/main/ipc/tags-handlers.ts
+++ b/apps/desktop/src/main/ipc/tags-handlers.ts
@@ -266,11 +266,11 @@ export function registerTagsHandlers(): void {
         syncTagDefinitionRename(input.oldName, input.newName, oldTagSnapshot)
 
         const normalizedOld = input.oldName.toLowerCase().trim()
-        const normalizedNew = input.newName.toLowerCase().trim()
+        const trimmedNew = input.newName.trim()
         await Promise.all(
           noteIds.map((noteId) =>
             updateNoteFrontmatterTag(indexDb, noteId, (tags) =>
-              tags.map((t) => (t.toLowerCase() === normalizedOld ? normalizedNew : t))
+              tags.map((t) => (t.toLowerCase() === normalizedOld ? trimmedNew : t))
             ).catch((err) => log.warn('Failed to update frontmatter for note', { noteId, err }))
           )
         )
@@ -413,14 +413,15 @@ export function registerTagsHandlers(): void {
         const dataDb = requireDatabase()
 
         const normalizedSource = input.source.toLowerCase().trim()
-        const normalizedTarget = input.target.toLowerCase().trim()
+        const trimmedTarget = input.target.trim()
+        const normalizedTarget = trimmedTarget.toLowerCase()
 
         if (normalizedSource === normalizedTarget) {
           return { success: false, error: 'Source and target tags are the same' }
         }
 
-        const noteResult = mergeTagInNotes(indexDb, normalizedSource, normalizedTarget)
-        const taskResult = mergeTagInTasks(dataDb, normalizedSource, normalizedTarget)
+        const noteResult = mergeTagInNotes(indexDb, input.source, input.target)
+        const taskResult = mergeTagInTasks(dataDb, input.source, input.target)
 
         const sourceSnapshot = dataDb
           .select()
@@ -438,7 +439,7 @@ export function registerTagsHandlers(): void {
             updateNoteFrontmatterTag(indexDb, noteId, (tags) => {
               const withoutSource = tags.filter((t) => t.toLowerCase() !== normalizedSource)
               const hasTarget = withoutSource.some((t) => t.toLowerCase() === normalizedTarget)
-              return hasTarget ? withoutSource : [...withoutSource, normalizedTarget]
+              return hasTarget ? withoutSource : [...withoutSource, trimmedTarget]
             }).catch((err) =>
               log.warn('Failed to update frontmatter for note during merge', { noteId, err })
             )

--- a/apps/desktop/src/main/sync/item-handlers/task-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/task-handler.ts
@@ -35,9 +35,17 @@ function queryNoteIds(db: DrizzleDb, taskId: string): string[] {
 
 function writeTags(db: DrizzleDb, taskId: string, tagList: string[]): void {
   db.delete(taskTags).where(eq(taskTags.taskId, taskId)).run()
-  if (tagList.length > 0) {
+  // Case preserved; dedupe case-insensitively (NOCASE PK on (taskId, tag))
+  const byKey = new Map<string, string>()
+  for (const raw of tagList) {
+    const tag = raw.trim()
+    if (!tag) continue
+    const key = tag.toLowerCase()
+    if (!byKey.has(key)) byKey.set(key, tag)
+  }
+  if (byKey.size > 0) {
     db.insert(taskTags)
-      .values(tagList.map((tag) => ({ taskId, tag: tag.toLowerCase().trim() })))
+      .values([...byKey.values()].map((tag) => ({ taskId, tag })))
       .run()
   }
 }

--- a/apps/desktop/src/main/vault/frontmatter.test.ts
+++ b/apps/desktop/src/main/vault/frontmatter.test.ts
@@ -137,14 +137,24 @@ describe('frontmatter utilities', () => {
     expect(links).toEqual(['Same Note', 'Other'])
   })
 
-  it('extractTags normalizes frontmatter tags', () => {
+  it('extractTags trims and preserves case', () => {
     const frontmatter: NoteFrontmatter = {
       id: 'abc123def456',
       created: FIXED_ISO,
       modified: FIXED_ISO,
       tags: [' Work ', 'PERSONAL', '']
     }
-    expect(extractTags(frontmatter)).toEqual(['work', 'personal'])
+    expect(extractTags(frontmatter)).toEqual(['Work', 'PERSONAL'])
+  })
+
+  it('extractTags deduplicates case-insensitively, first occurrence wins', () => {
+    const frontmatter: NoteFrontmatter = {
+      id: 'abc123def456',
+      created: FIXED_ISO,
+      modified: FIXED_ISO,
+      tags: ['Work', 'work', 'WORK', 'other']
+    }
+    expect(extractTags(frontmatter)).toEqual(['Work', 'other'])
   })
 
   it('calculateWordCount ignores code blocks and inline code', () => {
@@ -255,8 +265,12 @@ describe('extractInlineTagsFromMarkdown', () => {
     expect(extractInlineTagsFromMarkdown('#foo then #foo again')).toEqual(['foo'])
   })
 
-  it('normalizes to lowercase', () => {
-    expect(extractInlineTagsFromMarkdown('#Work #URGENT')).toEqual(['work', 'urgent'])
+  it('preserves case as typed', () => {
+    expect(extractInlineTagsFromMarkdown('#Work #URGENT')).toEqual(['Work', 'URGENT'])
+  })
+
+  it('deduplicates case variants, first occurrence wins', () => {
+    expect(extractInlineTagsFromMarkdown('#Work then #work again')).toEqual(['Work'])
   })
 
   it('skips tags inside fenced code blocks', () => {

--- a/apps/desktop/src/main/vault/frontmatter.ts
+++ b/apps/desktop/src/main/vault/frontmatter.ts
@@ -229,19 +229,25 @@ export function extractWikiLinks(content: string): string[] {
 }
 
 /**
- * Extract all tags from frontmatter, normalizing to lowercase.
+ * Extract all tags from frontmatter, preserving the case the user typed.
+ * Deduplicates case-insensitively (first occurrence wins).
  *
  * @param frontmatter - Parsed frontmatter
- * @returns Array of normalized tag strings
+ * @returns Array of trimmed tag strings
  */
 export function extractTags(frontmatter: NoteFrontmatter): string[] {
   if (!frontmatter.tags || !Array.isArray(frontmatter.tags)) {
     return []
   }
 
-  return frontmatter.tags
-    .map((tag) => String(tag).toLowerCase().trim())
-    .filter((tag) => tag.length > 0)
+  const byKey = new Map<string, string>()
+  for (const raw of frontmatter.tags) {
+    const tag = String(raw).trim()
+    if (!tag) continue
+    const key = tag.toLowerCase()
+    if (!byKey.has(key)) byKey.set(key, tag)
+  }
+  return [...byKey.values()]
 }
 
 /**
@@ -252,23 +258,24 @@ export function extractTags(frontmatter: NoteFrontmatter): string[] {
  * Mirrors the editor's HASH_TAG_PATTERN from hash-tag.tsx.
  *
  * @param content - Markdown body (post-frontmatter)
- * @returns Deduplicated, lowercase tag names
+ * @returns Deduplicated tag names (case preserved, case-insensitive dedupe)
  */
 export function extractInlineTagsFromMarkdown(content: string): string[] {
   const withoutCode = content.replace(/```[\s\S]*?```/g, '')
   const withoutInlineCode = withoutCode.replace(/`[^`]+`/g, '')
 
-  const tags = new Set<string>()
+  const byKey = new Map<string, string>()
   const pattern = /#([a-zA-Z][a-zA-Z0-9_-]*(?:\/[a-zA-Z0-9][a-zA-Z0-9_-]*)*)/g
   let match: RegExpExecArray | null
 
   while ((match = pattern.exec(withoutInlineCode)) !== null) {
     const precedingChar = match.index > 0 ? withoutInlineCode[match.index - 1] : ''
     if (precedingChar && !/\s/.test(precedingChar)) continue
-    tags.add(match[1].toLowerCase())
+    const key = match[1].toLowerCase()
+    if (!byKey.has(key)) byKey.set(key, match[1])
   }
 
-  return Array.from(tags)
+  return Array.from(byKey.values())
 }
 
 /**

--- a/apps/desktop/src/main/vault/note-sync.test.ts
+++ b/apps/desktop/src/main/vault/note-sync.test.ts
@@ -114,7 +114,7 @@ describe('extractNoteMetadata', () => {
       expect(extractNoteMetadata(input).tags).toEqual(['real'])
     })
 
-    it('normalizes all tags to lowercase', () => {
+    it('preserves tag case from both sources', () => {
       const input = buildInput({
         frontmatter: {
           id: 'abc123def456',
@@ -125,7 +125,7 @@ describe('extractNoteMetadata', () => {
         parsedContent: 'Also #URGENT'
       })
 
-      expect(extractNoteMetadata(input).tags).toEqual(['work', 'urgent'])
+      expect(extractNoteMetadata(input).tags).toEqual(['Work', 'URGENT'])
     })
 
     it('deduplicates case-insensitive matches across sources', () => {
@@ -139,7 +139,8 @@ describe('extractNoteMetadata', () => {
         parsedContent: 'Using #react in this note'
       })
 
-      expect(extractNoteMetadata(input).tags).toEqual(['react'])
+      // Frontmatter spelling wins over inline
+      expect(extractNoteMetadata(input).tags).toEqual(['React'])
     })
   })
 })

--- a/apps/desktop/src/main/vault/note-sync.ts
+++ b/apps/desktop/src/main/vault/note-sync.ts
@@ -81,7 +81,7 @@ export interface NoteSyncInput {
 export interface NoteMetadata {
   /** Note ID */
   id: string
-  /** Extracted tags (normalized to lowercase) */
+  /** Extracted tags (case preserved, deduplicated case-insensitively) */
   tags: string[]
   /** Custom properties from frontmatter */
   properties: Record<string, unknown>
@@ -137,7 +137,13 @@ export function extractNoteMetadata(input: NoteSyncInput): NoteMetadata {
 
   const frontmatterTags = extractTags(frontmatter)
   const inlineTags = extractInlineTagsFromMarkdown(parsedContent)
-  const tags = [...new Set([...frontmatterTags, ...inlineTags])]
+  // Case-insensitive merge; frontmatter spelling wins over inline
+  const tagsByKey = new Map<string, string>()
+  for (const tag of [...frontmatterTags, ...inlineTags]) {
+    const key = tag.toLowerCase()
+    if (!tagsByKey.has(key)) tagsByKey.set(key, tag)
+  }
+  const tags = [...tagsByKey.values()]
 
   const properties = extractProperties(frontmatter)
   const wikiLinks = extractWikiLinks(parsedContent)

--- a/apps/desktop/src/main/vault/watcher.test.ts
+++ b/apps/desktop/src/main/vault/watcher.test.ts
@@ -199,7 +199,7 @@ describe('vault watcher', () => {
       .all()
       .map((tag) => tag.tag)
       .sort()
-    expect(tags).toEqual(['alpha', 'beta'])
+    expect(tags).toEqual(['Alpha', 'Beta'])
 
     const links = indexDb.db
       .select()

--- a/apps/desktop/src/renderer/src/components/filing/tag-autocomplete.tsx
+++ b/apps/desktop/src/renderer/src/components/filing/tag-autocomplete.tsx
@@ -91,7 +91,10 @@ export const TagAutocomplete = ({
 
   // Saved color + icon per tag name, so suggestions and selected pills reflect
   // the user's chosen color/icon rather than a hashed default.
-  const metaByName = useMemo(() => new Map(tagDefs.map((d) => [d.name, d])), [tagDefs])
+  const metaByName = useMemo(
+    () => new Map(tagDefs.map((d) => [d.name.toLowerCase(), d])),
+    [tagDefs]
+  )
 
   const trimmedInput = inputValue.trim()
 
@@ -104,33 +107,38 @@ export const TagAutocomplete = ({
     }
   }, [trimmedInput])
 
+  const hasTagCi = useCallback(
+    (name: string) => tags.some((t) => t.toLowerCase() === name.toLowerCase()),
+    [tags]
+  )
+
   const availableAiTags = useMemo(
-    () => aiSuggestedTags.filter((t) => !tags.includes(t)),
-    [aiSuggestedTags, tags]
+    () => aiSuggestedTags.filter((t) => !hasTagCi(t)),
+    [aiSuggestedTags, hasTagCi]
   )
 
   const matchingTags = useMemo(() => {
     if (!trimmedInput) return []
     if (hierarchyContext) {
       return getChildTags(hierarchyContext.prefix, hierarchyContext.leafQuery || undefined).filter(
-        (t) => !tags.includes(t.name)
+        (t) => !hasTagCi(t.name)
       )
     }
-    return searchTags(trimmedInput).filter((t) => !tags.includes(t.name))
-  }, [trimmedInput, hierarchyContext, searchTags, getChildTags, tags])
+    return searchTags(trimmedInput).filter((t) => !hasTagCi(t.name))
+  }, [trimmedInput, hierarchyContext, searchTags, getChildTags, hasTagCi])
 
   const popularTags = useMemo(
-    () => getPopularTags(maxSuggestions).filter((t) => !tags.includes(t.name)),
-    [getPopularTags, maxSuggestions, tags]
+    () => getPopularTags(maxSuggestions).filter((t) => !hasTagCi(t.name)),
+    [getPopularTags, maxSuggestions, hasTagCi]
   )
 
   const exactMatchExists = useMemo(
     () =>
       trimmedInput
-        ? tags.includes(trimmedInput.toLowerCase()) ||
+        ? hasTagCi(trimmedInput) ||
           matchingTags.some((t) => t.name.toLowerCase() === trimmedInput.toLowerCase())
         : true,
-    [trimmedInput, tags, matchingTags]
+    [trimmedInput, hasTagCi, matchingTags]
   )
 
   // Build flat list for keyboard navigation
@@ -156,7 +164,7 @@ export const TagAutocomplete = ({
     }
 
     if (trimmedInput && !exactMatchExists) {
-      items.push({ type: 'create', value: trimmedInput.toLowerCase() })
+      items.push({ type: 'create', value: trimmedInput })
     }
 
     return items
@@ -187,9 +195,9 @@ export const TagAutocomplete = ({
 
   const addTag = useCallback(
     (tag: string): void => {
-      const normalized = tag.trim().toLowerCase()
-      if (normalized && !tags.includes(normalized)) {
-        onTagsChange([...tags, normalized])
+      const trimmed = tag.trim()
+      if (trimmed && !tags.some((t) => t.toLowerCase() === trimmed.toLowerCase())) {
+        onTagsChange([...tags, trimmed])
       }
       setInputValue('')
       setRequestedHighlightedIndex(0)
@@ -331,7 +339,7 @@ export const TagAutocomplete = ({
         {itemsToShow.map((tag, i) => {
           const idx = aiCount + i
           const colors = getTagColors(tag.color ?? '', tag.name)
-          const icon = metaByName.get(tag.name)?.icon
+          const icon = metaByName.get(tag.name.toLowerCase())?.icon
           return (
             <button
               key={tag.name}
@@ -410,7 +418,7 @@ export const TagAutocomplete = ({
           aria-label={tPhaseF('phaseF.componentsFilingTagAutocomplete.selectedTags')}
         >
           {tags.map((tag) => {
-            const def = metaByName.get(tag)
+            const def = metaByName.get(tag.toLowerCase())
             return <TagPill key={tag} tag={tag} color={def?.color} icon={def?.icon} />
           })}
           <input

--- a/apps/desktop/src/renderer/src/components/filing/tag-autocomplete.tsx
+++ b/apps/desktop/src/renderer/src/components/filing/tag-autocomplete.tsx
@@ -14,9 +14,11 @@ import { COLOR_NAMES, getTagColors } from '@/components/note/tags-row/tag-colors
 import { useT } from '@memry/i18n/renderer'
 
 function getColorForTag(tagName: string): string {
+  // Case-insensitive: #Work and #work fall back to the same color
+  const name = tagName.toLowerCase()
   let hash = 0
-  for (let i = 0; i < tagName.length; i++) {
-    hash = tagName.charCodeAt(i) + ((hash << 5) - hash)
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash)
   }
   return COLOR_NAMES[Math.abs(hash) % COLOR_NAMES.length]
 }
@@ -369,14 +371,13 @@ export const TagAutocomplete = ({
 
   const renderCreateFooter = (): React.JSX.Element | null => {
     if (!trimmedInput || exactMatchExists) return null
-    const normalized = trimmedInput.toLowerCase()
-    const colors = getTagColors(getColorForTag(normalized))
+    const colors = getTagColors(getColorForTag(trimmedInput))
     const idx = flatItems.length - 1
 
     return (
       <button
         type="button"
-        onClick={() => addTag(normalized)}
+        onClick={() => addTag(trimmedInput)}
         onMouseEnter={() => setRequestedHighlightedIndex(idx)}
         className={cn(
           'flex items-center w-full py-2 px-3 gap-1.5 border-t border-border/40 text-start transition-colors',
@@ -391,7 +392,7 @@ export const TagAutocomplete = ({
           className="inline-flex items-center rounded-md py-px px-1.5 text-[11px] leading-3.5"
           style={{ backgroundColor: `${colors.text}15`, color: colors.text }}
         >
-          {normalized}
+          {trimmedInput}
         </span>
       </button>
     )

--- a/apps/desktop/src/renderer/src/components/filing/tag-input.test.tsx
+++ b/apps/desktop/src/renderer/src/components/filing/tag-input.test.tsx
@@ -20,7 +20,7 @@ describe('TagInput', () => {
 
     const input = screen.getByLabelText('phaseF.componentsFilingTagInput.addTags2')
     fireEvent.change(input, { target: { value: 'Idea,' } })
-    expect(onTagsChange).toHaveBeenCalledWith(['work', 'idea'])
+    expect(onTagsChange).toHaveBeenCalledWith(['work', 'Idea'])
 
     onTagsChange.mockClear()
     fireEvent.change(input, { target: { value: 'work,' } })

--- a/apps/desktop/src/renderer/src/components/filing/tag-input.tsx
+++ b/apps/desktop/src/renderer/src/components/filing/tag-input.tsx
@@ -104,9 +104,9 @@ const TagInput = ({ tags, suggestedTags, onTagsChange }: TagInputProps): React.J
   const inputRef = useRef<HTMLInputElement>(null)
 
   const addTag = (tag: string): void => {
-    const normalizedTag = tag.trim().toLowerCase()
-    if (normalizedTag && !tags.includes(normalizedTag)) {
-      onTagsChange([...tags, normalizedTag])
+    const trimmedTag = tag.trim()
+    if (trimmedTag && !tags.some((t) => t.toLowerCase() === trimmedTag.toLowerCase())) {
+      onTagsChange([...tags, trimmedTag])
     }
     setInputValue('')
   }

--- a/apps/desktop/src/renderer/src/components/medium-gap-extra.test.tsx
+++ b/apps/desktop/src/renderer/src/components/medium-gap-extra.test.tsx
@@ -223,7 +223,7 @@ describe('medium gap renderer surfaces', () => {
   })
 
   it('matches hash tags and completes typed tags through the plugin append transaction', () => {
-    expect(matchHashTagBeforeCursor('Ship #memrynote-Launch ')).toBe('memrynote-launch')
+    expect(matchHashTagBeforeCursor('Ship #memrynote-Launch ')).toBe('memrynote-Launch')
     expect(matchHashTagBeforeCursor('Ship #broken/ ')).toBeNull()
 
     const plugin = createHashTagSpacePlugin((tag) => `color:${tag}`)

--- a/apps/desktop/src/renderer/src/components/note/content-area/hash-tag-inline-plugin.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hash-tag-inline-plugin.test.ts
@@ -51,8 +51,8 @@ describe('hash-tag-inline-plugin', () => {
       expect(matchHashTagImmediate('#abc')).toBeNull()
     })
 
-    it('normalizes to lowercase', () => {
-      expect(matchHashTagImmediate('#A')).toBe('a')
+    it('preserves case', () => {
+      expect(matchHashTagImmediate('#A')).toBe('A')
     })
   })
 
@@ -97,8 +97,8 @@ describe('hash-tag-inline-plugin', () => {
       expect(extendTagName('a', 'b')).toBe('ab')
     })
 
-    it('normalizes to lowercase', () => {
-      expect(extendTagName('hello', 'W')).toBe('hellow')
+    it('preserves case', () => {
+      expect(extendTagName('hello', 'W')).toBe('helloW')
     })
 
     it('appends digits', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hash-tag-inline-plugin.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hash-tag-inline-plugin.ts
@@ -11,7 +11,7 @@ const TRAILING_TAG_CHARS = /\ufffc([a-zA-Z0-9_\-/]+)$/
 
 export function matchHashTagImmediate(text: string): string | null {
   const match = text.match(HASH_TAG_IMMEDIATE)
-  return match ? match[2].toLowerCase() : null
+  return match ? match[2] : null
 }
 
 export function matchTrailingTagChars(text: string): { chars: string; offset: number } | null {
@@ -25,7 +25,7 @@ export function isTagChar(char: string): boolean {
 }
 
 export function extendTagName(currentTag: string, chars: string): string {
-  return (currentTag + chars).toLowerCase()
+  return currentTag + chars
 }
 
 export function shrinkTagName(currentTag: string): string | null {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hash-tag-space-plugin.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hash-tag-space-plugin.ts
@@ -6,7 +6,7 @@ const HASH_TAG_BEFORE_CURSOR = /(^|[\s\ufffc])#([a-zA-Z0-9][a-zA-Z0-9_\-/]*[a-zA
 
 export function matchHashTagBeforeCursor(text: string): string | null {
   const match = text.match(HASH_TAG_BEFORE_CURSOR)
-  return match ? match[2].toLowerCase() : null
+  return match ? match[2] : null
 }
 
 type GetTagColor = (tag: string) => string
@@ -31,7 +31,7 @@ export function createHashTagSpacePlugin(getTagColor: GetTagColor): Plugin {
       const match = textUpToCursor.match(HASH_TAG_BEFORE_CURSOR)
       if (!match) return null
 
-      const tag = match[2].toLowerCase()
+      const tag = match[2]
       const endPos = $from.start() + parentOffset
       const hashPos = endPos - tag.length - 2
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/hash-tag.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hash-tag.test.ts
@@ -21,9 +21,9 @@ describe('extractInlineTags', () => {
       expect(extractInlineTags(blocks)).toEqual(['typescript'])
     })
 
-    it('normalizes hashTag props to lowercase', () => {
+    it('preserves hashTag prop case', () => {
       const blocks = [textBlock([hashTagItem('TypeScript')])]
-      expect(extractInlineTags(blocks)).toEqual(['typescript'])
+      expect(extractInlineTags(blocks)).toEqual(['TypeScript'])
     })
 
     it('deduplicates across blocks', () => {
@@ -53,9 +53,9 @@ describe('extractInlineTags', () => {
       expect(extractInlineTags(blocks)).toEqual(['first'])
     })
 
-    it('normalizes text tags to lowercase', () => {
+    it('preserves text tag case', () => {
       const blocks = [textBlock([textItem('#URGENT')])]
-      expect(extractInlineTags(blocks)).toEqual(['urgent'])
+      expect(extractInlineTags(blocks)).toEqual(['URGENT'])
     })
 
     it('deduplicates text tags with hashTag nodes', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hash-tag.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hash-tag.test.tsx
@@ -55,13 +55,13 @@ describe('hash tag inline content', () => {
     expect(result.didChange).toBe(true)
     expect((result.blocks[0] as any).content).toEqual([
       'Start ',
-      { type: 'hashTag', props: { tag: 'work', color: 'blue', icon: '' } },
+      { type: 'hashTag', props: { tag: 'Work', color: 'blue', icon: '' } },
       ' and email#a'
     ])
     expect((result.blocks[1] as any).content).toBe('#work')
     expect((result.blocks[2] as any).content).toEqual([
       { type: 'text', text: 'Nested ', styles: { bold: true } },
-      { type: 'hashTag', props: { tag: 'personal', color: 'green', icon: '' } }
+      { type: 'hashTag', props: { tag: 'Personal', color: 'green', icon: '' } }
     ])
   })
 
@@ -101,6 +101,6 @@ describe('hash tag inline content', () => {
       { id: 'code', type: 'codeBlock', content: '#ignored' }
     ] as any)
 
-    expect(tags.sort()).toEqual(['nested', 'personal', 'work'])
+    expect(tags.sort()).toEqual(['Nested', 'Personal', 'Work'])
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/hash-tag.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hash-tag.tsx
@@ -162,7 +162,7 @@ function splitTextWithHashTags(
 
     const color = tagColorMap.get(normalizedTag) || ''
     const icon = tagIconMap?.get(normalizedTag) || ''
-    segments.push(createHashTagInlineContent(normalizedTag, color, icon))
+    segments.push(createHashTagInlineContent(tagName, color, icon))
 
     didChange = true
     lastIndex = match.index + full.length
@@ -305,8 +305,14 @@ export function normalizeHashTags(
 // =============================================================================
 
 export function extractInlineTags(blocks: Block[]): string[] {
-  const tags = new Set<string>()
+  // Case preserved; deduplicated case-insensitively (first occurrence wins)
+  const tagsByKey = new Map<string, string>()
   const tagPattern = new RegExp(HASH_TAG_PATTERN)
+
+  function addTag(tag: string): void {
+    const key = tag.toLowerCase()
+    if (!tagsByKey.has(key)) tagsByKey.set(key, tag)
+  }
 
   function extractFromText(text: string): void {
     tagPattern.lastIndex = 0
@@ -314,7 +320,7 @@ export function extractInlineTags(blocks: Block[]): string[] {
     while ((match = tagPattern.exec(text)) !== null) {
       const precedingChar = match.index > 0 ? text[match.index - 1] : ''
       if (precedingChar && !/\s/.test(precedingChar)) continue
-      tags.add(match[1].toLowerCase())
+      addTag(match[1])
     }
   }
 
@@ -324,7 +330,7 @@ export function extractInlineTags(blocks: Block[]): string[] {
     if (Array.isArray(block.content)) {
       for (const item of block.content as any[]) {
         if (item?.type === 'hashTag' && item.props?.tag) {
-          tags.add((item.props.tag as string).toLowerCase())
+          addTag(item.props.tag as string)
         } else if (item?.type === 'text' && item.text) {
           extractFromText(item.text as string)
         } else if (typeof item === 'string') {
@@ -342,5 +348,5 @@ export function extractInlineTags(blocks: Block[]): string[] {
   for (const block of blocks) {
     walkBlock(block)
   }
-  return Array.from(tags)
+  return Array.from(tagsByKey.values())
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.test.tsx
@@ -330,8 +330,8 @@ describe('useEditorSync', () => {
     act(() => {
       vi.advanceTimersByTime(100)
     })
-    expect(onInlineTagsChange).toHaveBeenCalledWith(['build', 'focus'])
-    expect(result.current.prevInlineTagsRef.current).toEqual(['build', 'focus'])
+    expect(onInlineTagsChange).toHaveBeenCalledWith(['Build', 'Focus'])
+    expect(result.current.prevInlineTagsRef.current).toEqual(['Build', 'Focus'])
   })
 
   it('skips markdown persistence for remote updates and Yjs-backed documents', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-tag-suggestions.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-tag-suggestions.ts
@@ -36,7 +36,8 @@ export function useTagSuggestions({
   const getTagColor = useCallback((tag: string): string => {
     // Fall back to a deterministic palette color derived from the tag name
     // (instead of a flat grey) when the tag has no explicit color yet.
-    return tagColorMapRef.current?.get(tag) || defaultTagColorName(tag)
+    // Maps are keyed by lowercase; tag identity is case-insensitive.
+    return tagColorMapRef.current?.get(tag.toLowerCase()) || defaultTagColorName(tag)
   }, [])
 
   // Register hashTag inline plugin on editor's tiptap instance
@@ -68,9 +69,10 @@ export function useTagSuggestions({
 
     state.doc.descendants((node: any, pos: number) => {
       if (node.type.name === 'hashTag') {
+        const tagKey = (node.attrs.tag as string).toLowerCase()
         const correctColor =
-          tagColorMap.get(node.attrs.tag as string) || defaultTagColorName(node.attrs.tag as string)
-        const correctIcon = tagIconMap?.get(node.attrs.tag as string) ?? ''
+          tagColorMap.get(tagKey) || defaultTagColorName(node.attrs.tag as string)
+        const correctIcon = tagIconMap?.get(tagKey) ?? ''
         if (node.attrs.color !== correctColor || (node.attrs.icon ?? '') !== correctIcon) {
           tr = tr.setNodeMarkup(pos, undefined, {
             ...node.attrs,
@@ -116,7 +118,7 @@ export function useTagSuggestions({
       const oldNode = tiptap.state.doc.nodeAt(nodePos)
       if (!oldNode || oldNode.type.name !== 'hashTag') return
 
-      const icon = tagIconMapRef.current?.get(tag) ?? ''
+      const icon = tagIconMapRef.current?.get(tag.toLowerCase()) ?? ''
       const newNode = hashTagNodeType.create({ tag, color, icon })
       const tr = tiptap.state.tr.replaceWith(nodePos, nodePos + oldNode.nodeSize, newNode)
       tiptap.view.dispatch(tr)

--- a/apps/desktop/src/renderer/src/components/note/tags-row/tag-colors.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/tags-row/tag-colors.test.ts
@@ -12,6 +12,11 @@ describe('defaultTagColorName', () => {
     expect(defaultTagColorName('research')).toBe(defaultTagColorName('research'))
   })
 
+  it('is case-insensitive — case variants of one tag share a color', () => {
+    expect(defaultTagColorName('Test')).toBe(defaultTagColorName('test'))
+    expect(defaultTagColorName('TEST')).toBe(defaultTagColorName('test'))
+  })
+
   it('always returns a real palette color name', () => {
     for (const name of ['research', 'tech/typescript', 'a', '', 'travel/japan']) {
       expect(COLOR_NAMES).toContain(defaultTagColorName(name))

--- a/apps/desktop/src/renderer/src/components/note/tags-row/tag-colors.ts
+++ b/apps/desktop/src/renderer/src/components/note/tags-row/tag-colors.ts
@@ -42,10 +42,13 @@ export const COLOR_ROWS = [
 // Deterministic palette color from a tag name: same tag → same color,
 // everywhere, with no stored color needed. Used as the default when a tag has
 // no explicit user-picked color (the alternative was a flat grey).
+// Hashes the lowercased name — tag identity is case-insensitive, so #Work and
+// #work must fall back to the same color.
 export function defaultTagColorName(tagName: string): string {
+  const name = tagName.toLowerCase()
   let hash = 0
-  for (let i = 0; i < tagName.length; i++) {
-    hash = (hash * 31 + tagName.charCodeAt(i)) | 0
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0
   }
   return COLOR_NAMES[Math.abs(hash) % COLOR_NAMES.length]
 }

--- a/apps/desktop/src/renderer/src/components/settings/tag-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/tag-manager.tsx
@@ -57,7 +57,7 @@ export function TagManager() {
   const editInputRef = useRef<HTMLInputElement>(null)
 
   const filteredTags = search.trim()
-    ? tags.filter((t) => t.name.includes(search.toLowerCase().trim()))
+    ? tags.filter((t) => t.name.toLowerCase().includes(search.toLowerCase().trim()))
     : tags
 
   const handleStartRename = useCallback((tagName: string) => {
@@ -67,7 +67,7 @@ export function TagManager() {
 
   const handleConfirmRename = useCallback(async () => {
     if (!editingTag || !editValue.trim()) return
-    const newName = editValue.trim().toLowerCase()
+    const newName = editValue.trim()
     if (newName === editingTag) {
       setEditingTag(null)
       return

--- a/apps/desktop/src/renderer/src/components/zero-leaf-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/components/zero-leaf-surfaces.test.tsx
@@ -162,7 +162,7 @@ describe('zero-covered leaf surfaces', () => {
   })
 
   it('matches hash-tag space completions and builds the plugin', () => {
-    expect(matchHashTagBeforeCursor('Plan #Work-2026 ')).toBe('work-2026')
+    expect(matchHashTagBeforeCursor('Plan #Work-2026 ')).toBe('Work-2026')
     expect(matchHashTagBeforeCursor('Plan #x ')).toBeNull()
     expect(matchHashTagBeforeCursor('Plan #bad. ')).toBeNull()
 

--- a/apps/desktop/src/renderer/src/hooks/use-all-tags.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-all-tags.test.tsx
@@ -64,20 +64,20 @@ describe('useAllTags', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.tags).toEqual([
-      { name: 'work', count: 7, color: '#111111', source: 'both' },
+      { name: 'Work', count: 7, color: '#111111', source: 'both' },
       { name: 'inbox', count: 6, source: 'inbox' },
       { name: 'work/dev', count: 5, source: 'inbox' },
       { name: 'work/design', count: 2, color: '#222222', source: 'notes' },
       { name: 'personal', count: 1, color: '#333333', source: 'notes' }
     ])
     expect(result.current.searchTags('work').map((tag) => tag.name)).toEqual([
-      'work',
+      'Work',
       'work/dev',
       'work/design'
     ])
-    expect(result.current.getPopularTags(2).map((tag) => tag.name)).toEqual(['work', 'inbox'])
+    expect(result.current.getPopularTags(2).map((tag) => tag.name)).toEqual(['Work', 'inbox'])
     expect(result.current.getRecentTags(3).map((tag) => tag.name)).toEqual([
-      'work',
+      'Work',
       'inbox',
       'work/dev'
     ])

--- a/apps/desktop/src/renderer/src/hooks/use-all-tags.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-all-tags.ts
@@ -90,12 +90,12 @@ export function useAllTags(): UseAllTagsResult {
   const combinedTags = useMemo((): TagWithMeta[] => {
     const tagMap = new Map<string, TagWithMeta>()
 
-    // Add notes tags
+    // Keyed by lowercase (case-insensitive identity); name keeps stored casing
     if (notesQuery.data) {
       for (const tag of notesQuery.data) {
-        const normalizedName = tag.tag.toLowerCase()
-        tagMap.set(normalizedName, {
-          name: normalizedName,
+        const key = tag.tag.toLowerCase()
+        tagMap.set(key, {
+          name: tag.tag,
           count: tag.count,
           color: tag.color,
           source: 'notes'
@@ -106,18 +106,18 @@ export function useAllTags(): UseAllTagsResult {
     // Add inbox tags (merge counts if tag exists)
     if (inboxQuery.data) {
       for (const tag of inboxQuery.data) {
-        const normalizedName = tag.tag.toLowerCase()
-        const existing = tagMap.get(normalizedName)
+        const key = tag.tag.toLowerCase()
+        const existing = tagMap.get(key)
         if (existing) {
           // Tag exists in both sources
-          tagMap.set(normalizedName, {
+          tagMap.set(key, {
             ...existing,
             count: existing.count + tag.count,
             source: 'both'
           })
         } else {
-          tagMap.set(normalizedName, {
-            name: normalizedName,
+          tagMap.set(key, {
+            name: tag.tag,
             count: tag.count,
             source: 'inbox'
           })
@@ -138,15 +138,17 @@ export function useAllTags(): UseAllTagsResult {
 
       const normalizedQuery = query.toLowerCase().trim()
 
-      // Filter tags that contain the query
-      const filtered = combinedTags.filter((tag) => tag.name.includes(normalizedQuery))
+      // Filter tags that contain the query (case-insensitive)
+      const filtered = combinedTags.filter((tag) =>
+        tag.name.toLowerCase().includes(normalizedQuery)
+      )
 
       // Sort: exact match first, then starts with, then contains
       return filtered.sort((a, b) => {
-        const aExact = a.name === normalizedQuery
-        const bExact = b.name === normalizedQuery
-        const aStartsWith = a.name.startsWith(normalizedQuery)
-        const bStartsWith = b.name.startsWith(normalizedQuery)
+        const aExact = a.name.toLowerCase() === normalizedQuery
+        const bExact = b.name.toLowerCase() === normalizedQuery
+        const aStartsWith = a.name.toLowerCase().startsWith(normalizedQuery)
+        const bStartsWith = b.name.toLowerCase().startsWith(normalizedQuery)
 
         if (aExact && !bExact) return -1
         if (!aExact && bExact) return 1
@@ -197,7 +199,7 @@ export function useAllTags(): UseAllTagsResult {
       const depth = normalizedPrefix.split('/').length
 
       const children = combinedTags.filter((tag) => {
-        if (!tag.name.startsWith(prefixWithSlash)) return false
+        if (!tag.name.toLowerCase().startsWith(prefixWithSlash)) return false
         const segments = tag.name.split('/')
         return segments.length === depth + 1
       })
@@ -207,7 +209,7 @@ export function useAllTags(): UseAllTagsResult {
       const normalizedLeaf = leafQuery.toLowerCase()
       return children.filter((tag) => {
         const leaf = tag.name.split('/').pop() ?? ''
-        return leaf.includes(normalizedLeaf)
+        return leaf.toLowerCase().includes(normalizedLeaf)
       })
     },
     [combinedTags]

--- a/apps/desktop/src/renderer/src/hooks/use-tags.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tags.ts
@@ -71,12 +71,12 @@ export function useTags() {
 
         return tags
           .filter((t) => {
-            if (!t.name.startsWith(prefixWithSlash)) return false
+            if (!t.name.toLowerCase().startsWith(prefixWithSlash)) return false
             const segments = t.name.split('/')
             if (segments.length !== prefixDepth + 1) return false
             if (!leafQuery) return true
             const leaf = segments[segments.length - 1]
-            return leaf.includes(leafQuery)
+            return leaf.toLowerCase().includes(leafQuery)
           })
           .sort((a, b) => b.count - a.count)
       }

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -390,8 +390,13 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
     for (const t of allAvailableTags) {
       map.set(t.tag.toLowerCase(), t.color)
     }
+    // Just-created tags aren't in allAvailableTags until reindex+refetch;
+    // without this the editor pill falls back to the hashed default color
+    for (const [key, color] of pendingTagColors) {
+      if (!map.has(key)) map.set(key, color)
+    }
     return map
-  }, [allAvailableTags])
+  }, [allAvailableTags, pendingTagColors])
 
   const tagIconMap = useMemo(() => {
     const map = new Map<string, string>()

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -384,10 +384,11 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
   // Tags & Properties
   const [pendingTagColors, setPendingTagColors] = useState(() => new Map<string, string>())
 
+  // Maps keyed by lowercase: tag identity is case-insensitive, display keeps user casing
   const tagColorMap = useMemo(() => {
     const map = new Map<string, string>()
     for (const t of allAvailableTags) {
-      map.set(t.tag, t.color)
+      map.set(t.tag.toLowerCase(), t.color)
     }
     return map
   }, [allAvailableTags])
@@ -395,7 +396,7 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
   const tagIconMap = useMemo(() => {
     const map = new Map<string, string>()
     for (const t of allAvailableTags) {
-      if (t.icon) map.set(t.tag, t.icon)
+      if (t.icon) map.set(t.tag.toLowerCase(), t.icon)
     }
     return map
   }, [allAvailableTags])
@@ -404,8 +405,9 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
     return (entry?.tags || []).map((tagName) => ({
       id: tagName,
       name: tagName,
-      color: tagColorMap.get(tagName) ?? pendingTagColors.get(tagName.toLowerCase()) ?? '',
-      icon: tagIconMap.get(tagName) ?? null
+      color:
+        tagColorMap.get(tagName.toLowerCase()) ?? pendingTagColors.get(tagName.toLowerCase()) ?? '',
+      icon: tagIconMap.get(tagName.toLowerCase()) ?? null
     }))
   }, [entry?.tags, tagColorMap, tagIconMap, pendingTagColors])
 

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -442,10 +442,11 @@ export function NotePage({ noteId }: NotePageProps) {
 
   const pendingTagColorsRef = useRef(new Map<string, string>())
 
+  // Maps keyed by lowercase: tag identity is case-insensitive, display keeps user casing
   const tagColorMap = useMemo(() => {
     const map = new Map<string, string>()
     for (const t of allAvailableTags) {
-      map.set(t.tag, t.color)
+      map.set(t.tag.toLowerCase(), t.color)
     }
     for (const key of pendingTagColorsRef.current.keys()) {
       if (map.has(key)) pendingTagColorsRef.current.delete(key)
@@ -456,7 +457,7 @@ export function NotePage({ noteId }: NotePageProps) {
   const tagIconMap = useMemo(() => {
     const map = new Map<string, string>()
     for (const t of allAvailableTags) {
-      if (t.icon) map.set(t.tag, t.icon)
+      if (t.icon) map.set(t.tag.toLowerCase(), t.icon)
     }
     return map
   }, [allAvailableTags])
@@ -465,8 +466,11 @@ export function NotePage({ noteId }: NotePageProps) {
     return (note?.tags || []).map((tagName) => ({
       id: tagName,
       name: tagName,
-      color: tagColorMap.get(tagName) ?? pendingTagColorsRef.current.get(tagName) ?? '',
-      icon: tagIconMap.get(tagName) ?? null
+      color:
+        tagColorMap.get(tagName.toLowerCase()) ??
+        pendingTagColorsRef.current.get(tagName.toLowerCase()) ??
+        '',
+      icon: tagIconMap.get(tagName.toLowerCase()) ?? null
     }))
   }, [note?.tags, tagColorMap, tagIconMap])
 

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -451,6 +451,11 @@ export function NotePage({ noteId }: NotePageProps) {
     for (const key of pendingTagColorsRef.current.keys()) {
       if (map.has(key)) pendingTagColorsRef.current.delete(key)
     }
+    // Just-created tags aren't in allAvailableTags until reindex+refetch;
+    // without this the editor pill falls back to the hashed default color
+    for (const [key, color] of pendingTagColorsRef.current) {
+      if (!map.has(key)) map.set(key, color)
+    }
     return map
   }, [allAvailableTags])
 

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -13,6 +13,7 @@ A row under the title shows the note's free-form labels.
 - Click the tag area to add a tag
 - Comma or space confirms
 - Tags are global — the same tag on two notes is the same tag
+- Tags keep the capitalization you type (`#Work` stays `#Work`), but identity is case-insensitive: `#Work` and `#work` are the same tag with one color and one combined count. This also applies to imported notes — an Obsidian vault's tag casing survives the import.
 
 Tags appear in the sidebar **Tags** section. Click any tag to drill into a list of notes that share it.
 

--- a/packages/app-core/src/inbox.ts
+++ b/packages/app-core/src/inbox.ts
@@ -238,7 +238,15 @@ function titleFromUrl(url: string): string {
 }
 
 function uniqueTags(tags: string[]): string[] {
-  return [...new Set(tags.map((tag) => tag.trim()).filter(Boolean))]
+  // Case-insensitive dedupe, first spelling wins
+  const byKey = new Map<string, string>()
+  for (const raw of tags) {
+    const tag = raw.trim()
+    if (!tag) continue
+    const key = tag.toLowerCase()
+    if (!byKey.has(key)) byKey.set(key, tag)
+  }
+  return [...byKey.values()]
 }
 
 function generateInboxNoteContent(item: InboxRecord): string {
@@ -742,7 +750,7 @@ export function createInboxService({
     },
 
     async bulkTag(ids, tags) {
-      const normalizedTags = uniqueTags(tags).map((tag) => tag.toLowerCase())
+      const normalizedTags = uniqueTags(tags)
       const errors: InboxBulkResponse['errors'] = []
       let processedCount = 0
       for (const id of ids) {

--- a/packages/db-schema/src/schema/inbox.ts
+++ b/packages/db-schema/src/schema/inbox.ts
@@ -9,6 +9,7 @@
 
 import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
+import { nocaseText } from './nocase.ts'
 import type { VectorClock } from '@memry/contracts/sync-api'
 
 // ============================================================================
@@ -251,7 +252,7 @@ export const inboxItemTags = sqliteTable(
       .references(() => inboxItems.id, { onDelete: 'cascade' }),
 
     /** Tag name */
-    tag: text('tag').notNull(),
+    tag: nocaseText('tag').notNull(),
 
     /** When the tag was added */
     createdAt: text('created_at')

--- a/packages/db-schema/src/schema/nocase.ts
+++ b/packages/db-schema/src/schema/nocase.ts
@@ -1,0 +1,11 @@
+import { customType } from 'drizzle-orm/sqlite-core'
+
+/**
+ * Case-insensitive text column (SQLite COLLATE NOCASE).
+ * Tag identity is case-insensitive; stored value preserves the case the user typed.
+ */
+export const nocaseText = customType<{ data: string }>({
+  dataType() {
+    return 'text COLLATE NOCASE'
+  }
+})

--- a/packages/db-schema/src/schema/notes-cache.ts
+++ b/packages/db-schema/src/schema/notes-cache.ts
@@ -1,5 +1,6 @@
 import { sqliteTable, text, integer, index, primaryKey } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
+import { nocaseText } from './nocase.ts'
 import type { FileType } from '@memry/shared/file-types'
 import type { VectorClock } from '@memry/contracts/sync-api'
 export { PropertyTypes, type PropertyType } from '@memry/contracts/property-types'
@@ -54,7 +55,7 @@ export const noteTags = sqliteTable(
     noteId: text('note_id')
       .notNull()
       .references(() => noteCache.id, { onDelete: 'cascade' }),
-    tag: text('tag').notNull(),
+    tag: nocaseText('tag').notNull(),
     position: integer('position').notNull().default(0),
     // When the note was pinned to this tag (null = not pinned)
     pinnedAt: text('pinned_at')

--- a/packages/db-schema/src/schema/tag-definitions.ts
+++ b/packages/db-schema/src/schema/tag-definitions.ts
@@ -1,8 +1,9 @@
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
+import { nocaseText } from './nocase.ts'
 
 export const tagDefinitions = sqliteTable('tag_definitions', {
-  name: text('name').primaryKey(),
+  name: nocaseText('name').primaryKey(),
   color: text('color').notNull(),
   icon: text('icon'),
   clock: text('clock', { mode: 'json' }),

--- a/packages/db-schema/src/schema/task-relations.ts
+++ b/packages/db-schema/src/schema/task-relations.ts
@@ -1,6 +1,7 @@
 import { sqliteTable, text, primaryKey, index } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
 import { tasks } from './tasks.ts'
+import { nocaseText } from './nocase.ts'
 
 export const taskNotes = sqliteTable(
   'task_notes',
@@ -22,7 +23,7 @@ export const taskTags = sqliteTable(
     taskId: text('task_id')
       .notNull()
       .references(() => tasks.id, { onDelete: 'cascade' }),
-    tag: text('tag').notNull()
+    tag: nocaseText('tag').notNull()
   },
   (table) => [
     primaryKey({ columns: [table.taskId, table.tag] }),

--- a/packages/importers/src/raindrop/map-rows.ts
+++ b/packages/importers/src/raindrop/map-rows.ts
@@ -3,12 +3,18 @@ import type { InboxItemPlan, RaindropImportPlan, RaindropRow, ImportWarning } fr
 const UNSORTED = 'unsorted'
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}T/
 
-/** Row tags + collection-as-tag; drops "Unsorted", lowercases, trims, dedupes. */
+/** Row tags + collection-as-tag; drops "Unsorted", trims, dedupes case-insensitively. */
 function resolveTags(row: RaindropRow): string[] {
-  const folder = row.folder.trim().toLowerCase()
-  const fromFolder = folder && folder !== UNSORTED ? [folder] : []
-  const all = [...row.tags, ...fromFolder].map((t) => t.trim().toLowerCase()).filter(Boolean)
-  return [...new Set(all)]
+  const folder = row.folder.trim()
+  const fromFolder = folder && folder.toLowerCase() !== UNSORTED ? [folder] : []
+  const byKey = new Map<string, string>()
+  for (const raw of [...row.tags, ...fromFolder]) {
+    const tag = raw.trim()
+    if (!tag) continue
+    const key = tag.toLowerCase()
+    if (!byKey.has(key)) byKey.set(key, tag)
+  }
+  return [...byKey.values()]
 }
 
 /** note + excerpt joined; null when both are empty. */


### PR DESCRIPTION
## Summary

Tags now keep the capitalization you type — `#Work` stays `#Work` — while identity stays case-insensitive: `#Work` and `#work` are the same tag with one color and one combined count (Obsidian-style). Previously every layer force-lowercased tags, including Obsidian imports.

## Changes

**Schema + migrations**
- New `nocaseText` custom type (`text COLLATE NOCASE`) on `note_tags.tag`, `task_tags.tag`, `inbox_item_tags.tag`, `tag_definitions.name`
- Index DB migration `0019` (generated), data DB migration `0034_tag_nocase.sql` (hand-written, matching existing data-DB migration convention). Data preserved; `INSERT OR IGNORE` collapses case-duplicate rows

**Main process**
- Frontmatter + inline `#tag` extraction preserve case, dedupe case-insensitively (first spelling wins) — this fixes the Obsidian import path
- `setNoteTags` / `setTaskTags` / sync task handler / inbox bulk-tag / app-core inbox / Raindrop importer stop lowercasing on write
- Rename/merge write the new name as typed, match case-insensitively; `renameTag` child rewrite is now per-row (SQL `replace()` is case-sensitive)
- Tag list aggregation keys by lowercase, display name keeps first-seen casing
- `tag_definitions` rows and sync item ids stay lowercase (stable identity keys)

**Renderer**
- Editor hash-tag plugins no longer lowercase while typing
- `normalizeHashTags` / `extractInlineTags` preserve case with case-insensitive dedupe
- Tag color/icon maps keyed by lowercase; all lookups lowercase the key, so case variants share one color
- Autocomplete, tag manager search, and duplicate checks compare case-insensitively

**Behavior notes**
- Notes previously saved in-app keep their lowercased frontmatter until re-edited or renamed (case-only renames now work in Tag Manager)
- Untouched Obsidian-vault files regain their original casing on reindex

## Documentation

- `apps/docs/src/user-guide/notes/properties-tags.md` documents the new behavior; `pnpm docs:impact --strict` and `pnpm docs:build` pass

## Test plan

- [x] Desktop main suite: 3335 passed (runs real migrations, so `0034` is exercised)
- [x] Desktop renderer suite: 5062 passed
- [x] app-core: 7 passed
- [x] `typecheck:node` + `typecheck:web` clean, ESLint 0 errors, Prettier clean
- [x] New regression tests: case-preserve + ci-dedupe in `frontmatter.test.ts`, ci identity in `notes.test.ts` (`Work`+`work` collapse; `findNotesByTag('work')` finds `WORK`)
- [ ] Manual smoke: type `#Work` in editor, import an Obsidian vault with mixed-case tags
