### PR TITLE
feat(notes): serialize bookmark/embed blocks as plain markdown links

### DIFF
--- a/apps/desktop/src/main/inbox/filing.test.ts
+++ b/apps/desktop/src/main/inbox/filing.test.ts
@@ -599,7 +599,7 @@ describe('Inbox Filing Operations', () => {
       )
     })
 
-    it('should embed YouTube links instead of rendering a mention link', async () => {
+    it('should file YouTube links as a bare URL line instead of a mention link', async () => {
       const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
       const itemId = seedInboxItem(testDb.db, {
         id: 'link-youtube',
@@ -611,7 +611,8 @@ describe('Inbox Filing Operations', () => {
       await fileToFolder(itemId, 'videos')
 
       const noteContent = mockCreateNote.mock.calls[0][0].content as string
-      expect(noteContent).toContain(`![embed](${url})`)
+      expect(noteContent.startsWith(`${url}\n\n`)).toBe(true)
+      expect(noteContent).not.toContain('![embed]')
       expect(noteContent).not.toContain('"mention"')
     })
 

--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -286,7 +286,9 @@ export function generateNoteContent(item: InboxItemRow): string {
       let content = ''
 
       if (isYouTube) {
-        content += `![embed](${url})\n\n`
+        // Bare URL on its own line — the editor upgrades it to an embed at
+        // parse time (docs/obs/03-bookmark-embed-plain-links.md).
+        content += `${url}\n\n`
       } else {
         const mentionText = title && title !== url ? `${domain} \u00B7 ${title}` : domain
         content += `[${mentionText}](${url} "mention")\n\n`

--- a/apps/desktop/src/renderer/src/components/note/content-area/bookmark-block-render.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/bookmark-block-render.tsx
@@ -20,11 +20,12 @@ export function BookmarkBlockRender({
 }) {
   const { url, domain, title, description, image, favicon, siteName } = block.props
 
-  // Markdown round-trip is lossy (URL only) — hydrate display-only metadata
-  // on mount when the block has no title. Never writes back to the block.
+  // Markdown persists only the link-text title — hydrate display-only metadata
+  // on mount when the card has none. Never writes back to the block; the
+  // persisted title always wins over fetched values.
   const [fetched, setFetched] = useState<UrlPreviewData | null>(null)
   useEffect(() => {
-    if (title || !url) return
+    if (!url || description || image || favicon) return
     let cancelled = false
     fetchLinkPreview(url)
       .then((data) => {
@@ -34,7 +35,7 @@ export function BookmarkBlockRender({
     return () => {
       cancelled = true
     }
-  }, [title, url])
+  }, [url, description, image, favicon])
 
   const displayTitle = title || fetched?.title || ''
   const displayDescription = description || fetched?.description || ''

--- a/apps/desktop/src/renderer/src/components/note/content-area/bookmark-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/bookmark-block.tsx
@@ -11,7 +11,8 @@ export const createBookmarkBlock = createReactBlockSpec(
       description: { default: '' },
       image: { default: '' },
       favicon: { default: '' },
-      siteName: { default: '' }
+      siteName: { default: '' },
+      sourceText: { default: '' }
     },
     content: 'none'
   },
@@ -20,8 +21,25 @@ export const createBookmarkBlock = createReactBlockSpec(
   }
 )
 
-export const BOOKMARK_BLOCK_REGEX = /!\[bookmark\]\(([^)]+)\)/g
+function escapeLinkText(text: string): string {
+  return text.replace(/\s*\n\s*/g, ' ').replace(/([[\]])/g, '\\$1')
+}
 
-export function serializeBookmark(url: string): string {
-  return `![bookmark](${url})`
+function urlHostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+// Plain markdown link; sourceText re-emits the originally parsed line verbatim
+// so foreign files stay byte-stable (docs/obs/03-bookmark-embed-plain-links.md).
+export function serializeBookmark(props: {
+  url: string
+  title?: string
+  sourceText?: string
+}): string {
+  if (props.sourceText) return props.sourceText
+  return `[${escapeLinkText(props.title || urlHostname(props.url))}](${props.url})`
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
@@ -81,7 +81,8 @@ describe('parseMarkdownPreservingBlanks', () => {
           type: 'youtubeEmbed',
           props: {
             videoId: 'dQw4w9WgXcQ',
-            videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+            videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            sourceText: ''
           }
         }),
         expect.objectContaining({
@@ -117,10 +118,167 @@ describe('parseMarkdownPreservingBlanks', () => {
       expect.arrayContaining([
         expect.objectContaining({
           type: 'bookmark',
-          props: { url: 'https://www.example.com/article', domain: 'example.com' }
+          props: {
+            url: 'https://www.example.com/article',
+            domain: 'example.com',
+            title: '',
+            sourceText: ''
+          }
         })
       ])
     )
+  })
+
+  it('upgrades standalone YouTube links (bare, autolink, titled) to embed blocks', async () => {
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) => [
+        {
+          type: 'paragraph',
+          props: {},
+          content: [{ type: 'text', text: markdown, styles: {} }],
+          children: []
+        }
+      ])
+    }
+
+    const blocks = await parseMarkdownPreservingBlanks(
+      editor,
+      [
+        'Intro',
+        '',
+        'https://youtu.be/dQw4w9WgXcQ',
+        '',
+        '<https://www.youtube.com/watch?v=dQw4w9WgXcQ>',
+        '',
+        '[Watch this](https://youtube.com/shorts/dQw4w9WgXcQ)'
+      ].join('\n')
+    )
+
+    expect(blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'youtubeEmbed',
+          props: {
+            videoId: 'dQw4w9WgXcQ',
+            videoUrl: 'https://youtu.be/dQw4w9WgXcQ',
+            sourceText: 'https://youtu.be/dQw4w9WgXcQ'
+          }
+        }),
+        expect.objectContaining({
+          type: 'youtubeEmbed',
+          props: expect.objectContaining({
+            videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            sourceText: '<https://www.youtube.com/watch?v=dQw4w9WgXcQ>'
+          })
+        }),
+        expect.objectContaining({
+          type: 'youtubeEmbed',
+          props: expect.objectContaining({
+            videoUrl: 'https://youtube.com/shorts/dQw4w9WgXcQ',
+            sourceText: '[Watch this](https://youtube.com/shorts/dQw4w9WgXcQ)'
+          })
+        })
+      ])
+    )
+  })
+
+  it('upgrades a standalone titled non-YouTube link to a bookmark card', async () => {
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) => [
+        {
+          type: 'paragraph',
+          props: {},
+          content: [{ type: 'text', text: markdown, styles: {} }],
+          children: []
+        }
+      ])
+    }
+
+    const blocks = await parseMarkdownPreservingBlanks(
+      editor,
+      ['Intro', '', '[My Article](https://www.example.com/article)', '', 'Outro'].join('\n')
+    )
+
+    expect(blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'bookmark',
+          props: {
+            url: 'https://www.example.com/article',
+            domain: 'example.com',
+            title: 'My Article',
+            sourceText: '[My Article](https://www.example.com/article)'
+          }
+        })
+      ])
+    )
+  })
+
+  it('leaves non-upgrade standalone and inline links as plain text', async () => {
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) => [
+        {
+          type: 'paragraph',
+          props: {},
+          content: [{ type: 'text', text: markdown, styles: {} }],
+          children: []
+        }
+      ])
+    }
+
+    const blocks = await parseMarkdownPreservingBlanks(
+      editor,
+      [
+        'https://example.com/bare-stays-plain',
+        '[https://example.com/a](https://example.com/a)',
+        'Check [My Article](https://example.com/a) inline',
+        'Some intro\n[My Article](https://example.com/a)',
+        '- [My Article](https://example.com/a)',
+        '![alt](https://example.com/img.png)',
+        '![[embedded-file.png]]'
+      ].join('\n\n')
+    )
+
+    const upgraded = (blocks as Array<{ type: string }>).filter(
+      (b) => b.type === 'bookmark' || b.type === 'youtubeEmbed'
+    )
+    expect(upgraded).toEqual([])
+  })
+
+  it('parses legacy markers without sourceText so the next save rewrites them', async () => {
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) => [
+        {
+          type: 'paragraph',
+          props: {},
+          content: [{ type: 'text', text: markdown, styles: {} }],
+          children: []
+        }
+      ])
+    }
+
+    const blocks = await parseMarkdownPreservingBlanks(
+      editor,
+      [
+        '![embed](https://youtu.be/dQw4w9WgXcQ)',
+        '',
+        '![bookmark](https://www.example.com/article)'
+      ].join('\n')
+    )
+
+    const upgraded = (blocks as Array<{ type: string }>).filter(
+      (b) => b.type === 'bookmark' || b.type === 'youtubeEmbed'
+    )
+    expect(upgraded).toEqual([
+      expect.objectContaining({
+        type: 'youtubeEmbed',
+        props: expect.objectContaining({ sourceText: '' })
+      }),
+      expect.objectContaining({
+        type: 'bookmark',
+        props: expect.objectContaining({ title: '', sourceText: '' })
+      })
+    ])
   })
 
   it('applies color markers to the first block of the following chunk', async () => {
@@ -306,12 +464,17 @@ describe('serializeBlocksPreservingBlanks', () => {
       },
       {
         type: 'youtubeEmbed',
-        props: { videoUrl: 'https://youtu.be/dQw4w9WgXcQ' },
+        props: { videoUrl: 'https://youtu.be/dQw4w9WgXcQ', sourceText: '' },
         children: []
       },
       {
         type: 'bookmark',
-        props: { url: 'https://example.com/article', domain: 'example.com' },
+        props: {
+          url: 'https://example.com/article',
+          domain: 'example.com',
+          title: '',
+          sourceText: ''
+        },
         children: []
       },
       {
@@ -330,10 +493,146 @@ describe('serializeBlocksPreservingBlanks', () => {
     expect(markdown).toContain('Intro')
     expect(markdown).toContain('- [ ] Parent task {task:parent-1}')
     expect(markdown).toContain('  - [x] Child task {task:child-1}')
-    expect(markdown).toContain('![embed](https://youtu.be/dQw4w9WgXcQ)')
-    expect(markdown).toContain('![bookmark](https://example.com/article)')
+    expect(markdown).toContain('https://youtu.be/dQw4w9WgXcQ')
+    expect(markdown).toContain('[example.com](https://example.com/article)')
+    expect(markdown).not.toContain('![embed]')
+    expect(markdown).not.toContain('![bookmark]')
     expect(markdown).toContain('> [!success]\n> Callout body')
     expect(markdown).toContain('Tail')
+  })
+
+  it('serializes bookmark and embed blocks as plain links, re-emitting sourceText verbatim', async () => {
+    const editor = {
+      blocksToMarkdownLossy: vi.fn(async (blocks: any[]) =>
+        blocks.map((block) => block.content?.[0]?.text ?? '').join('\n')
+      )
+    }
+
+    const markdown = await serializeBlocksPreservingBlanks(editor, [
+      {
+        type: 'bookmark',
+        props: {
+          url: 'https://example.com/a',
+          domain: 'example.com',
+          title: 'A [B] C',
+          sourceText: ''
+        },
+        children: []
+      },
+      {
+        type: 'bookmark',
+        props: {
+          url: 'https://example.com/b',
+          domain: 'example.com',
+          title: 'Fetched Later',
+          sourceText: '[Original  Spacing](https://example.com/b)'
+        },
+        children: []
+      },
+      {
+        type: 'youtubeEmbed',
+        props: {
+          videoId: 'dQw4w9WgXcQ',
+          videoUrl: 'https://youtu.be/dQw4w9WgXcQ',
+          sourceText: '<https://youtu.be/dQw4w9WgXcQ>'
+        },
+        children: []
+      }
+    ] as any[])
+
+    expect(markdown).toContain('[A \\[B\\] C](https://example.com/a)')
+    expect(markdown).toContain('[Original  Spacing](https://example.com/b)')
+    expect(markdown).toContain('<https://youtu.be/dQw4w9WgXcQ>')
+  })
+
+  it('round-trips standalone plain links byte-identically across two save cycles', async () => {
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) =>
+        markdown
+          .split(/\n\n+/)
+          .filter((chunk) => chunk.trim())
+          .map((chunk) => ({
+            type: 'paragraph',
+            props: {},
+            content: [{ type: 'text', text: chunk.trim(), styles: {} }],
+            children: []
+          }))
+      ),
+      blocksToMarkdownLossy: vi.fn(async (blocks: any[]) =>
+        blocks
+          .map((block) =>
+            Array.isArray(block.content)
+              ? block.content.map((content: any) => content.text ?? '').join('')
+              : ''
+          )
+          .filter(Boolean)
+          .join('\n\n')
+      )
+    }
+
+    const input = [
+      'Intro',
+      '',
+      '[My Article](https://www.example.com/article)',
+      '',
+      '<https://youtu.be/dQw4w9WgXcQ>',
+      '',
+      'https://example.com/plain-stays-plain'
+    ].join('\n')
+
+    const once = await serializeBlocksPreservingBlanks(
+      editor,
+      await parseMarkdownPreservingBlanks(editor, input)
+    )
+    expect(once).toBe(input)
+
+    const twice = await serializeBlocksPreservingBlanks(
+      editor,
+      await parseMarkdownPreservingBlanks(editor, once)
+    )
+    expect(twice).toBe(input)
+  })
+
+  it('rewrites legacy markers to canonical plain links on the next save', async () => {
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) =>
+        markdown
+          .split(/\n\n+/)
+          .filter((chunk) => chunk.trim())
+          .map((chunk) => ({
+            type: 'paragraph',
+            props: {},
+            content: [{ type: 'text', text: chunk.trim(), styles: {} }],
+            children: []
+          }))
+      ),
+      blocksToMarkdownLossy: vi.fn(async (blocks: any[]) =>
+        blocks
+          .map((block) =>
+            Array.isArray(block.content)
+              ? block.content.map((content: any) => content.text ?? '').join('')
+              : ''
+          )
+          .filter(Boolean)
+          .join('\n\n')
+      )
+    }
+
+    const input = [
+      '![embed](https://youtu.be/dQw4w9WgXcQ)',
+      '',
+      '![bookmark](https://www.example.com/article)'
+    ].join('\n')
+
+    const once = await serializeBlocksPreservingBlanks(
+      editor,
+      await parseMarkdownPreservingBlanks(editor, input)
+    )
+    expect(once).toBe(
+      ['https://youtu.be/dQw4w9WgXcQ', '', '[example.com](https://www.example.com/article)'].join(
+        '\n'
+      )
+    )
   })
 
   it('serializes colored blocks alone with a color marker line', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
@@ -159,12 +159,21 @@ export async function parseMarkdownPreservingBlanks(
             if (part.kind === 'embed') {
               blocks.push({
                 type: 'youtubeEmbed' as const,
-                props: { videoId: part.videoId, videoUrl: part.url }
+                props: {
+                  videoId: part.videoId,
+                  videoUrl: part.url,
+                  sourceText: part.sourceText ?? ''
+                }
               } as unknown as Block)
             } else if (part.kind === 'bookmark') {
               blocks.push({
                 type: 'bookmark' as const,
-                props: { url: part.url, domain: extractDomain(part.url) }
+                props: {
+                  url: part.url,
+                  domain: extractDomain(part.url),
+                  title: part.title ?? '',
+                  sourceText: part.sourceText ?? ''
+                }
               } as unknown as Block)
             } else if (part.kind === 'file') {
               blocks.push({
@@ -247,12 +256,11 @@ export async function serializeBlocksPreservingBlanks(
     } else if ((block.type as string) === 'youtubeEmbed') {
       await flushContent()
       flushGap()
-      const videoUrl = (block.props as any).videoUrl as string
-      segments.push({ type: 'content', text: serializeYoutubeEmbed(videoUrl) })
+      segments.push({ type: 'content', text: serializeYoutubeEmbed(block.props as any) })
     } else if ((block.type as string) === 'bookmark') {
       await flushContent()
       flushGap()
-      segments.push({ type: 'content', text: serializeBookmark((block.props as any).url) })
+      segments.push({ type: 'content', text: serializeBookmark(block.props as any) })
     } else if ((block.type as string) === 'file') {
       await flushContent()
       flushGap()
@@ -303,16 +311,75 @@ export async function serializeBlocksPreservingBlanks(
 
 type EmbedPart =
   | { kind: 'text'; text: string; colors?: BlockColors }
-  | { kind: 'embed'; url: string; videoId: string }
-  | { kind: 'bookmark'; url: string }
+  | { kind: 'embed'; url: string; videoId: string; sourceText?: string }
+  | { kind: 'bookmark'; url: string; title?: string; sourceText?: string }
   | { kind: 'file'; props: FileBlockProps }
 
+// Legacy Memry pseudo-image markers, parsed for one release so existing vault
+// files migrate: sourceText stays '' and the next save rewrites the marker to
+// the canonical plain link. Delete this branch next release (docs/obs/03).
 const EMBED_LINE_REGEX = /^!\[embed\]\(([^)]+)\)$/
 const BOOKMARK_LINE_REGEX = /^!\[bookmark\]\(([^)]+)\)$/
 const FILE_BLOCK_LINE_REGEX = /^<!-- file:\{[^}]+\} -->$/
 
+// Standalone plain-link forms considered for parse-time upgrade (docs/obs/03).
+// Anchored: inline links, list items, headings and quotes never match.
+const TITLED_LINK_LINE_REGEX = /^\[((?:\\.|[^\\[\]])+)\]\((https?:\/\/[^)\s]+)\)$/
+const AUTOLINK_LINE_REGEX = /^<(https?:\/\/[^>\s]+)>$/
+const BARE_URL_LINE_REGEX = /^https?:\/\/\S+$/
+
+function unescapeLinkText(text: string): string {
+  return text.replace(/\\([[\]])/g, '$1')
+}
+
+function matchStandaloneLink(line: string): EmbedPart | null {
+  let url: string | null = null
+  let title = ''
+  const titled = line.match(TITLED_LINK_LINE_REGEX)
+  if (titled) {
+    title = unescapeLinkText(titled[1])
+    url = titled[2]
+  } else {
+    const autolink = line.match(AUTOLINK_LINE_REGEX)
+    if (autolink) url = autolink[1]
+    else if (BARE_URL_LINE_REGEX.test(line)) url = line
+  }
+  if (!url) return null
+
+  const videoId = extractYouTubeVideoId(url)
+  if (videoId) return { kind: 'embed', url, videoId, sourceText: line }
+  // A titled standalone link is exactly what a bookmark card shows; bare URLs,
+  // autolinks and [url](url) stay plain links.
+  if (titled && title.trim() && title !== url) {
+    return { kind: 'bookmark', url, title, sourceText: line }
+  }
+  return null
+}
+
+// A link upgrades only when it is the sole content line of its blank-line-
+// delimited paragraph; color/file marker lines don't count as content.
+function findSoleContentLineIndexes(lines: string[]): Set<number> {
+  const sole = new Set<number>()
+  let paragraph: number[] = []
+  const flushParagraph = (): void => {
+    const contentLines = paragraph.filter((i) => {
+      const trimmed = lines[i].trim()
+      return !BLOCK_COLORS_LINE_REGEX.test(trimmed) && !FILE_BLOCK_LINE_REGEX.test(trimmed)
+    })
+    if (contentLines.length === 1) sole.add(contentLines[0])
+    paragraph = []
+  }
+  lines.forEach((line, i) => {
+    if (line.trim() === '') flushParagraph()
+    else paragraph.push(i)
+  })
+  flushParagraph()
+  return sole
+}
+
 function splitByEmbedMarkers(text: string): EmbedPart[] {
   const lines = text.split('\n')
+  const soleContentLines = findSoleContentLineIndexes(lines)
   const parts: EmbedPart[] = []
   let buffer: string[] = []
   let pendingColors: BlockColors | null = null
@@ -326,7 +393,8 @@ function splitByEmbedMarkers(text: string): EmbedPart[] {
     pendingColors = null
   }
 
-  for (const line of lines) {
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]
     const trimmedLine = line.trim()
     if (BLOCK_COLORS_LINE_REGEX.test(trimmedLine)) {
       const colors = parseBlockColorsMarker(trimmedLine)
@@ -362,6 +430,15 @@ function splitByEmbedMarkers(text: string): EmbedPart[] {
       flushBuffer()
       parts.push({ kind: 'bookmark', url: bookmarkMatch[1] })
       continue
+    }
+
+    if (soleContentLines.has(index)) {
+      const standalone = matchStandaloneLink(line)
+      if (standalone) {
+        flushBuffer()
+        parts.push(standalone)
+        continue
+      }
     }
     buffer.push(line)
   }

--- a/apps/desktop/src/renderer/src/components/note/content-area/youtube-embed-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/youtube-embed-block.tsx
@@ -34,7 +34,7 @@ function YouTubePlayer({ videoId, title }: { videoId: string; title?: string }) 
       />
       <div className="absolute inset-0 flex items-center justify-center bg-black/20 group-hover:bg-black/30 transition-colors">
         <div className="flex items-center justify-center size-14 rounded-full bg-red-600 group-hover:bg-red-500 transition-colors shadow-lg">
-          <Play className="size-6 text-white ml-0.5" />
+          <Play className="size-6 text-white ms-0.5" />
         </div>
       </div>
     </button>
@@ -81,7 +81,8 @@ export const createYoutubeEmbedBlock = createReactBlockSpec(
     type: 'youtubeEmbed' as const,
     propSchema: {
       videoId: { default: '' },
-      videoUrl: { default: '' }
+      videoUrl: { default: '' },
+      sourceText: { default: '' }
     },
     content: 'none'
   },
@@ -90,8 +91,8 @@ export const createYoutubeEmbedBlock = createReactBlockSpec(
   }
 )
 
-export const EMBED_BLOCK_REGEX = /!\[embed\]\(([^)]+)\)/g
-
-export function serializeYoutubeEmbed(videoUrl: string): string {
-  return `![embed](${videoUrl})`
+// Bare URL on its own line; sourceText re-emits the originally parsed line
+// verbatim (docs/obs/03-bookmark-embed-plain-links.md).
+export function serializeYoutubeEmbed(props: { videoUrl: string; sourceText?: string }): string {
+  return props.sourceText || props.videoUrl
 }

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -50,6 +50,17 @@ Common markdown shortcuts work inline:
 | `` `code` `` | `code`        |
 | ` ``` `      | Code block    |
 
+## Link Cards & YouTube Embeds
+
+Paste a URL and pick from the paste menu: keep it as a plain link, turn it into a **bookmark card** (title, description, preview image), or — for YouTube URLs — an **embedded player**.
+
+In the vault's `.md` file both stay ordinary markdown, so notes opened in other editors (e.g. Obsidian) show a normal link instead of app-specific syntax:
+
+- A bookmark card is saved as `[Title](https://example.com/article)` on its own line.
+- A YouTube embed is saved as the bare video URL on its own line.
+
+The upgrade also works in reverse when a note is opened: a titled link standing alone on its own line renders as a bookmark card, and a standalone YouTube URL (bare, `<autolink>`, or titled) renders as an embedded player. Links inside sentences, list items, headings, or quotes are never converted, and a standalone bare non-YouTube URL stays a plain link. Lines written outside memrynote are re-emitted byte-for-byte on save.
+
 ## Title
 
 The title is editable inline at the top of the editor. Renames are live — the title updates in tabs, the sidebar, search, and any inbound wiki links.


### PR DESCRIPTION
## What
Bookmark and YouTube embed blocks now serialize as plain markdown links — `[Title](url)` (hostname fallback) and the bare video URL — with parse-time upgrade of standalone links back to rich blocks; a `sourceText` prop re-emits foreign lines byte-for-byte, and legacy `![bookmark]`/`![embed]` markers keep parsing for one release and rewrite to plain links on the next save.

## Why
The pseudo-image markers render as broken images in Obsidian. Spec: `docs/obs/03-bookmark-embed-plain-links.md` (locked decision #4).