### PR TITLE
feat(vault): preserve foreign Obsidian syntax via rawMarkdown passthrough

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -35,6 +35,7 @@ import {
   restoreBlockNesting,
   splitMarkdownByBlockNestingMarkers
 } from '@memry/shared/block-nesting'
+import { splitForeignRawSegments } from '@memry/shared/foreign-syntax'
 import { createLogger } from '../lib/logger'
 
 const log = createLogger('BlockNoteConverter')
@@ -64,11 +65,30 @@ const createServerTaskBlock = createBlockSpec(
   }
 )
 
+// Headless twin of the renderer's rawMarkdown block (raw-markdown-block.tsx):
+// opaque container for foreign Obsidian syntax (docs/obs/06) whose `markdown`
+// prop re-emits verbatim. propSchema must stay identical to the renderer spec.
+const createServerRawMarkdownBlock = createBlockSpec(
+  {
+    type: 'rawMarkdown' as const,
+    propSchema: {
+      markdown: { default: '' }
+    },
+    content: 'none'
+  },
+  {
+    render: () => {
+      throw new Error('rawMarkdown server spec is serialization-only and must not be rendered')
+    }
+  }
+)
+
 const serverSchema = BlockNoteSchema.create({
   blockSpecs: {
     ...defaultBlockSpecs,
     codeBlock: createCodeBlockSpec(codeBlockOptions),
-    taskBlock: createServerTaskBlock()
+    taskBlock: createServerTaskBlock(),
+    rawMarkdown: createServerRawMarkdownBlock()
   }
 })
 
@@ -285,15 +305,29 @@ async function markdownToBlocksPreserving(
   editor: ServerBlockNoteEditor,
   markdown: string
 ): Promise<Block[]> {
-  const segments = splitMarkdownPreservingBlanks(separateBlockImages(markdown))
   const blocks: Block[] = []
 
-  for (const seg of segments) {
-    if (seg.type === 'content') {
-      blocks.push(...(await parseContentWithColorMarkers(editor, seg.text)))
-    } else {
-      for (let i = 0; i < seg.extraLines; i++) {
-        blocks.push(createEmptyParagraph())
+  for (const fseg of splitForeignRawSegments(markdown)) {
+    if (fseg.kind === 'raw') {
+      blocks.push({
+        type: 'rawMarkdown',
+        props: { markdown: fseg.text },
+        content: undefined,
+        children: [],
+        id: randomUUID()
+      } as unknown as Block)
+      continue
+    }
+
+    const segments = splitMarkdownPreservingBlanks(separateBlockImages(fseg.text))
+
+    for (const seg of segments) {
+      if (seg.type === 'content') {
+        blocks.push(...(await parseContentWithColorMarkers(editor, seg.text)))
+      } else {
+        for (let i = 0; i < seg.extraLines; i++) {
+          blocks.push(createEmptyParagraph())
+        }
       }
     }
   }
@@ -360,7 +394,15 @@ async function blocksToMarkdownPreserving(
   }
 
   for (const block of blocks) {
-    if ((block.type as string) === 'taskBlock') {
+    if ((block.type as string) === 'rawMarkdown') {
+      // Foreign Obsidian syntax (docs/obs/06) re-emits its source verbatim.
+      await flushContentGroup()
+      flushGap()
+      segments.push({
+        type: 'content',
+        text: (block.props as { markdown: string }).markdown
+      })
+    } else if ((block.type as string) === 'taskBlock') {
       // BlockNote can't serialize a taskBlock (it's content:'none'), so emit the
       // `- [ ] … {task:id}` line ourselves. Subtasks are kept on the immediately
       // following line (tight list) so a re-parse re-nests them under the parent.

--- a/apps/desktop/src/main/sync/foreign-syntax-roundtrip.test.ts
+++ b/apps/desktop/src/main/sync/foreign-syntax-roundtrip.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+import { CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
+import { FOREIGN_SYNTAX_FIXTURES } from '@memry/shared/foreign-syntax-fixtures'
+import { markdownToYFragment, yDocToMarkdown } from './blocknote-converter'
+
+// Main-pipeline twin of the renderer foreign-syntax matrix (docs/obs/06):
+// markdown → Y.Doc → markdown must be byte-identical for every fixture. This
+// is the CRDT writeback path, so a failure here mangles the vault file on the
+// next sync even if the renderer pipeline is clean.
+async function roundTrip(markdown: string): Promise<string> {
+  const doc = new Y.Doc()
+  const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+  const ok = await markdownToYFragment(markdown, fragment)
+  expect(ok).toBe(true)
+  return (await yDocToMarkdown(doc)) ?? ''
+}
+
+// Known list normalization: BlockNote's canonical output rewrites `-` bullets
+// to `*` and tight lists to loose (docs/obs/06 open question 1 — global list
+// style, not per-syntax). These rows flip to plain `it` when that lands.
+// tasks-emoji-linked-task passes here because normalizeTaskBlocks regenerates
+// the `- [ ] … {task:id}` line with a `-` marker.
+const KNOWN_LIST_MARKER_FAILURES = new Set(['block-id-on-bullet', 'tasks-emoji-plain-checkbox'])
+
+describe('foreign syntax round-trip (main CRDT pipeline)', () => {
+  for (const fixture of FOREIGN_SYNTAX_FIXTURES) {
+    const test = KNOWN_LIST_MARKER_FAILURES.has(fixture.name) ? it.fails : it
+    test(`round-trips ${fixture.name} verbatim`, async () => {
+      const once = await roundTrip(fixture.markdown)
+      expect(once).toBe(fixture.markdown)
+      const twice = await roundTrip(once)
+      expect(twice).toBe(once)
+    })
+  }
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/editor-schema.ts
@@ -10,6 +10,7 @@ import { createCalloutBlock } from './callout-block'
 import { createYoutubeEmbedBlock } from './youtube-embed-block'
 import { createBookmarkBlock } from './bookmark-block'
 import { createTaskBlock } from './task-block'
+import { createRawMarkdownBlock } from './raw-markdown-block'
 import { WikiLink } from './wiki-link'
 import { HashTag } from './hash-tag'
 import { LinkMention } from './link-mention'
@@ -23,7 +24,8 @@ export const editorSchema = BlockNoteSchema.create({
     callout: createCalloutBlock(),
     youtubeEmbed: createYoutubeEmbedBlock(),
     bookmark: createBookmarkBlock(),
-    taskBlock: createTaskBlock()
+    taskBlock: createTaskBlock(),
+    rawMarkdown: createRawMarkdownBlock()
   },
   inlineContentSpecs: {
     ...defaultInlineContentSpecs,

--- a/apps/desktop/src/renderer/src/components/note/content-area/foreign-syntax-roundtrip.integration.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/foreign-syntax-roundtrip.integration.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  BlockNoteEditor,
+  BlockNoteSchema,
+  defaultBlockSpecs,
+  createCodeBlockSpec
+} from '@blocknote/core'
+import { codeBlockOptions } from '@blocknote/code-block'
+import { FOREIGN_SYNTAX_FIXTURES } from '@memry/shared/foreign-syntax-fixtures'
+import { parseMarkdownPreservingBlanks, serializeBlocksPreservingBlanks } from './markdown-utils'
+
+// The callout renderer pulls in i18n; the render function is never invoked in
+// this headless round-trip, but the module-level hook import must not explode.
+vi.mock('@memry/i18n/renderer', () => ({ useT: () => ({ t: (key: string) => key }) }))
+
+const { createCalloutBlock } = await import('./callout-block')
+
+// Real-pipeline matrix (docs/obs/06): every fixture must survive
+// parse → serialize byte-identically (first-pass identity), which is stricter
+// than the idempotence-only CriticMarkup round-trip test. The schema mirrors
+// editor-schema.ts minus specs the round-trip never feeds to BlockNote
+// (file/youtubeEmbed/bookmark/taskBlock serialize without touching the editor;
+// file would drag react-pdf into jsdom).
+const matrixSchema = BlockNoteSchema.create({
+  blockSpecs: {
+    ...defaultBlockSpecs,
+    codeBlock: createCodeBlockSpec(codeBlockOptions),
+    callout: createCalloutBlock()
+  }
+})
+
+async function roundTrip(markdown: string): Promise<string> {
+  const editor = BlockNoteEditor.create({ schema: matrixSchema })
+  const blocks = await parseMarkdownPreservingBlanks(editor, markdown)
+  return serializeBlocksPreservingBlanks(editor, blocks)
+}
+
+// Known list normalization: BlockNote's canonical output rewrites `-` bullets
+// to `*` and tight lists to loose (docs/obs/06 open question 1 — global list
+// style, not per-syntax). Linked-task lines additionally regenerate from props
+// until spec 02 carries the raw line. These rows flip to plain `it` when that
+// work lands.
+const KNOWN_LIST_MARKER_FAILURES = new Set([
+  'block-id-on-bullet',
+  'tasks-emoji-plain-checkbox',
+  'tasks-emoji-linked-task'
+])
+
+describe('foreign syntax round-trip (renderer pipeline)', () => {
+  for (const fixture of FOREIGN_SYNTAX_FIXTURES) {
+    const test = KNOWN_LIST_MARKER_FAILURES.has(fixture.name) ? it.fails : it
+    test(`round-trips ${fixture.name} verbatim`, async () => {
+      const once = await roundTrip(fixture.markdown)
+      expect(once).toBe(fixture.markdown)
+      const twice = await roundTrip(once)
+      expect(twice).toBe(once)
+    })
+  }
+})

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
@@ -70,7 +70,10 @@ describe('parseMarkdownPreservingBlanks', () => {
         '![embed](https://www.youtube.com/watch?v=dQw4w9WgXcQ)',
         '![embed](https://example.com/not-youtube)',
         '',
-        '> [!warning] Heads up',
+        // Titleless Memry callout — the only form the app itself writes.
+        // Titled/folded/unknown callouts are raw-routed (docs/obs/06).
+        '> [!warning]',
+        '> Heads up',
         '> Body line'
       ].join('\n')
     )

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
@@ -19,6 +19,7 @@ import {
   restoreBlockNesting,
   splitMarkdownByBlockNestingMarkers
 } from '@memry/shared/block-nesting'
+import { splitForeignRawSegments } from '@memry/shared/foreign-syntax'
 import { splitMarkdownByCallouts, serializeCalloutBlock } from './callout-block'
 import { extractYouTubeVideoId } from '@/lib/youtube-utils'
 import { serializeYoutubeEmbed } from './youtube-embed-block'
@@ -138,55 +139,66 @@ export async function parseMarkdownPreservingBlanks(
   editor: any,
   markdown: string
 ): Promise<Block[]> {
-  const calloutSegments = splitMarkdownByCallouts(markdown)
   const blocks: Block[] = []
 
-  for (const cseg of calloutSegments) {
-    if (cseg.kind === 'callout') {
-      const parsed = await editor.tryParseMarkdownToBlocks(cseg.content)
-      const inlineContent = parsed[0]?.content ?? cseg.content
+  for (const fseg of splitForeignRawSegments(markdown)) {
+    if (fseg.kind === 'raw') {
       blocks.push({
-        type: 'callout' as const,
-        props: { type: cseg.type },
-        content: inlineContent
+        type: 'rawMarkdown' as const,
+        props: { markdown: fseg.text }
       } as unknown as Block)
-    } else {
-      const blankSegments = splitMarkdownPreservingBlanks(separateBlockImages(cseg.text))
-      for (const seg of blankSegments) {
-        if (seg.type === 'content') {
-          const embedParts = splitByEmbedMarkers(seg.text)
-          for (const part of embedParts) {
-            if (part.kind === 'embed') {
-              blocks.push({
-                type: 'youtubeEmbed' as const,
-                props: { videoId: part.videoId, videoUrl: part.url }
-              } as unknown as Block)
-            } else if (part.kind === 'bookmark') {
-              blocks.push({
-                type: 'bookmark' as const,
-                props: { url: part.url, domain: extractDomain(part.url) }
-              } as unknown as Block)
-            } else if (part.kind === 'file') {
-              blocks.push({
-                type: 'file' as const,
-                props: part.props
-              } as unknown as Block)
-            } else {
-              const parsed = await parseMarkdownChunkPreservingNesting(editor, part.text)
-              if (part.colors && parsed[0]) {
-                parsed[0].props = { ...parsed[0].props, ...part.colors }
+      continue
+    }
+
+    const calloutSegments = splitMarkdownByCallouts(fseg.text)
+
+    for (const cseg of calloutSegments) {
+      if (cseg.kind === 'callout') {
+        const parsed = await editor.tryParseMarkdownToBlocks(cseg.content)
+        const inlineContent = parsed[0]?.content ?? cseg.content
+        blocks.push({
+          type: 'callout' as const,
+          props: { type: cseg.type },
+          content: inlineContent
+        } as unknown as Block)
+      } else {
+        const blankSegments = splitMarkdownPreservingBlanks(separateBlockImages(cseg.text))
+        for (const seg of blankSegments) {
+          if (seg.type === 'content') {
+            const embedParts = splitByEmbedMarkers(seg.text)
+            for (const part of embedParts) {
+              if (part.kind === 'embed') {
+                blocks.push({
+                  type: 'youtubeEmbed' as const,
+                  props: { videoId: part.videoId, videoUrl: part.url }
+                } as unknown as Block)
+              } else if (part.kind === 'bookmark') {
+                blocks.push({
+                  type: 'bookmark' as const,
+                  props: { url: part.url, domain: extractDomain(part.url) }
+                } as unknown as Block)
+              } else if (part.kind === 'file') {
+                blocks.push({
+                  type: 'file' as const,
+                  props: part.props
+                } as unknown as Block)
+              } else {
+                const parsed = await parseMarkdownChunkPreservingNesting(editor, part.text)
+                if (part.colors && parsed[0]) {
+                  parsed[0].props = { ...parsed[0].props, ...part.colors }
+                }
+                blocks.push(...parsed)
               }
-              blocks.push(...parsed)
             }
-          }
-        } else {
-          for (let i = 0; i < seg.extraLines; i++) {
-            blocks.push({
-              type: 'paragraph',
-              content: [],
-              children: [],
-              props: {}
-            } as unknown as Block)
+          } else {
+            for (let i = 0; i < seg.extraLines; i++) {
+              blocks.push({
+                type: 'paragraph',
+                content: [],
+                children: [],
+                props: {}
+              } as unknown as Block)
+            }
           }
         }
       }
@@ -221,7 +233,12 @@ export async function serializeBlocksPreservingBlanks(
   }
 
   for (const block of blocks) {
-    if ((block.type as string) === 'taskBlock') {
+    if ((block.type as string) === 'rawMarkdown') {
+      // Foreign Obsidian syntax (docs/obs/06) re-emits its source verbatim.
+      await flushContent()
+      flushGap()
+      segments.push({ type: 'content', text: (block.props as { markdown: string }).markdown })
+    } else if ((block.type as string) === 'taskBlock') {
       await flushContent()
       flushGap()
       const props = block.props as {

--- a/apps/desktop/src/renderer/src/components/note/content-area/raw-markdown-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/raw-markdown-block.tsx
@@ -1,0 +1,26 @@
+import { createReactBlockSpec } from '@blocknote/react'
+
+// Opaque container for Obsidian syntax BlockNote cannot represent
+// (docs/obs/06): %%block comments%%, $$math$$, non-Memry callouts, custom
+// checkbox states, footnote definitions. `props.markdown` is re-emitted
+// verbatim on save; the block renders read-only (double-click-to-edit is a
+// later enhancement).
+export const createRawMarkdownBlock = createReactBlockSpec(
+  {
+    type: 'rawMarkdown' as const,
+    propSchema: {
+      markdown: { default: '' }
+    },
+    content: 'none'
+  },
+  {
+    render: (props) => (
+      <pre
+        className="my-1 overflow-x-auto rounded-md bg-muted/50 px-3 py-2 font-mono text-xs whitespace-pre-wrap text-muted-foreground"
+        contentEditable={false}
+      >
+        {props.block.props.markdown}
+      </pre>
+    )
+  }
+)

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -76,6 +76,12 @@ BlockNote uses Yjs natively. The renderer's BlockNote editor binds to the render
 Markdown cannot represent arbitrary nested BlockNote paragraphs. Note markdown export and CRDT writeback preserve those unsupported child blocks with hidden nesting markers, then restore them when a note reloads. Inbox note reload also reads BlockNote's saved `data-nesting-level` HTML metadata so captured note indentation round-trips through the editor.
 Marker parsing trims imported markdown with a linear scan so malformed or very large note bodies cannot trigger regex backtracking during reload.
 
+## Foreign Obsidian Syntax
+
+Obsidian block constructs that BlockNote cannot represent — `%%block comments%%`, `$$math$$` blocks, footnote definitions, custom checkbox states like `- [-]`, and callouts outside the four Memry types (or with titles, fold markers, nesting, or multi-paragraph bodies) — are split out before parsing and carried as opaque `rawMarkdown` blocks (`packages/shared/src/foreign-syntax.ts`). Both conversion pipelines (renderer `markdown-utils.ts` and main `blocknote-converter.ts`) re-emit the block's source verbatim on save, so an edited vault note never mangles syntax the editor doesn't understand. The block renders read-only in the editor.
+
+Inline Obsidian syntax (`%%…%%` comments, `==highlights==`, `$math$`, footnote references, `![[embeds]]`, wiki-link anchors, Dataview fields, template vars, block IDs) survives the parse→serialize round trip as plain text without special handling; the `foreign-syntax-roundtrip` test matrices in both pipelines guard this byte-for-byte.
+
 ## Files Worth Knowing
 
 ```

--- a/docs/obs/06-foreign-syntax-preservation.md
+++ b/docs/obs/06-foreign-syntax-preservation.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-07-05
 **Branch:** `obs-syntax-preservation`
-**Status:** Approved, pending implementation
+**Status:** Implemented (raw-segment passthrough only — the matrix proved the
+inline mask/restore layer unnecessary; see "Matrix results")
 
 ## Goal
 
@@ -117,6 +118,28 @@ inline mask/restore (Design §b); **raw** = raw-segment passthrough (Design §c)
 Related but out of this spec's per-syntax table: BlockNote's canonical style
 rewrites `-` bullets to `*` and tight lists to loose on the first save
 (**verified** via integration-test fixtures). See Open questions.
+
+## Matrix results (measured 2026-07-05)
+
+`foreign-syntax-roundtrip` fixtures through both real pipelines resolved every
+"unknown" above:
+
+- **Already verbatim (no fix needed; fixtures kept as regression guards):**
+  every inline row — `%%…%%` comments (even containing `[[links]]`),
+  `==highlight==`, `$math$`, `^[inline footnote]`, `[^1]` refs (when no
+  definition is present), all `![[…]]` embeds, wiki links with `#`/`#^`
+  anchors, `[note](My%20Note.md)`, all three Dataview forms, `{{templates}}`,
+  block IDs (eol and own-line), mermaid fences including the language.
+  remark escapes **nothing** here, so **design (b) mask/restore was dropped**
+  per the do-nothing-when-green rule.
+- **Broken at block level (fixed by (c) raw-segment passthrough):** `%%` block
+  comments, `$$` math blocks (backslash loss), footnote definitions (GFM
+  footnote nodes rewrite refs to `[1](#user-content-fn-1)`), custom checkbox
+  states, and all five callout shapes (remark also emits `\`-hard-breaks
+  inside blockquotes).
+- **Still failing, deferred (marked `it.fails`):** `-`→`*` + tight→loose list
+  normalization (`block-id-on-bullet`, `tasks-emoji-plain-checkbox`, and
+  renderer-side `tasks-emoji-linked-task`) — open question 1 / spec 02.
 
 ## Design
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,9 @@
     "./date-mention": "./src/date-mention.ts",
     "./block-nesting": "./src/block-nesting.ts",
     "./youtube": "./src/youtube.ts",
-    "./task-block": "./src/task-block.ts"
+    "./task-block": "./src/task-block.ts",
+    "./foreign-syntax": "./src/foreign-syntax.ts",
+    "./foreign-syntax-fixtures": "./src/foreign-syntax-fixtures.ts"
   },
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/shared/src/foreign-syntax-fixtures.ts
+++ b/packages/shared/src/foreign-syntax-fixtures.ts
@@ -1,0 +1,100 @@
+// Golden corpus for Obsidian foreign-syntax preservation (docs/obs/06).
+// One fixture per syntax-inventory row; both the renderer pipeline
+// (markdown-utils) and the main CRDT pipeline (blocknote-converter) matrix-test
+// every entry for first-pass identity (once === input) and idempotence
+// (twice === once). Do not "fix" a fixture to make a test pass — fixtures are
+// the spec; the pipelines must adapt.
+
+export interface ForeignSyntaxFixture {
+  name: string
+  markdown: string
+}
+
+export const FOREIGN_SYNTAX_FIXTURES: ForeignSyntaxFixture[] = [
+  { name: 'block-id-eol', markdown: 'Some text ^ab12cd' },
+  // Obsidian puts a block ID for quotes/tables on its own line after a blank line.
+  { name: 'block-id-own-line', markdown: '> quoted text\n\n^quote1' },
+  { name: 'block-id-on-bullet', markdown: '- item one ^ab12cd\n- item two' },
+  { name: 'comment-inline', markdown: 'Before %%draft [[Hidden Link]]%% after' },
+  { name: 'comment-block', markdown: '%%\n- raw notes\n- more notes\n%%' },
+  { name: 'highlight', markdown: 'This is ==important== text' },
+  { name: 'math-inline', markdown: 'Energy: $e=mc^2$ done' },
+  { name: 'math-block', markdown: '$$\n\\int_0^1 x^2 \\, dx = \\frac{1}{3}\n$$' },
+  { name: 'mermaid-fence', markdown: '```mermaid\ngraph TD;\n  A-->B;\n```' },
+  {
+    name: 'tasks-emoji-plain-checkbox',
+    markdown: '- [ ] Pay rent 📅 2026-07-05 🔁 every month ⏫'
+  },
+  {
+    name: 'tasks-emoji-linked-task',
+    markdown: '- [ ] Pay rent 📅 2026-07-05 ⏫ {task:t-42}'
+  },
+  { name: 'dataview-fullline', markdown: 'Rating:: 9' },
+  { name: 'dataview-bracketed', markdown: 'Loved it [rating:: 9] overall' },
+  { name: 'dataview-parenthesized', markdown: 'Loved it (rating:: 9) overall' },
+  {
+    name: 'checkbox-custom-states',
+    markdown: '- [-] cancelled task\n- [?] maybe task\n- [>] forwarded task'
+  },
+  { name: 'template-vars', markdown: 'Created {{date:YYYY-MM-DD}} for {{title}}' },
+  { name: 'footnote-inline', markdown: 'A claim^[see appendix] here' },
+  { name: 'footnote-ref', markdown: 'A claim[^1] here' },
+  { name: 'footnote-definition', markdown: 'A claim[^1] here\n\n[^1]: the supporting note' },
+  { name: 'embed-image-sized', markdown: '![[img.png|300x200]]' },
+  { name: 'embed-pdf-page', markdown: '![[doc.pdf#page=3]]' },
+  { name: 'embed-note-heading-inline', markdown: 'see ![[Note#Heading]] here' },
+  { name: 'wikilink-heading', markdown: 'see [[Note#Heading]] here' },
+  { name: 'wikilink-blockid', markdown: 'see [[Note#^ab12cd]] here' },
+  { name: 'mdlink-percent20', markdown: '[note](My%20Note.md)' },
+  { name: 'callout-unknown-type', markdown: '> [!faq] FAQ Title\n> Body line' },
+  { name: 'callout-fold-markers', markdown: '> [!note]- Folded title\n> Hidden body' },
+  { name: 'callout-custom-title', markdown: '> [!info] My title\n> Body line' },
+  {
+    name: 'callout-nested',
+    markdown: '> [!note]\n> outer body\n> > [!tip] inner\n> > nested body'
+  },
+  {
+    name: 'callout-multi-paragraph',
+    markdown: '> [!note]\n> First paragraph\n>\n> Second paragraph'
+  },
+  {
+    // Cross-pipeline sink: gaps, code fence, inline + block foreign syntax.
+    // Renderer-only Memry markers (![embed]/![bookmark]/file) are covered by
+    // their own unit tests per pipeline and stay out so the same bytes can be
+    // asserted through both pipelines.
+    name: 'kitchen-sink',
+    markdown: [
+      '# Trip notes',
+      '',
+      'Some text ^ab12cd',
+      '',
+      'Before %%draft [[Hidden Link]]%% after ==important== and $e=mc^2$.',
+      '',
+      '%%',
+      '- raw block notes',
+      '%%',
+      '',
+      '$$',
+      '\\int_0^1 x^2 \\, dx',
+      '$$',
+      '',
+      '> [!faq]- Custom FAQ title',
+      '> Folded body',
+      '',
+      '![[img.png|300x200]]',
+      '',
+      '- [-] cancelled item',
+      '',
+      '[^1]: the footnote',
+      '',
+      '```mermaid',
+      'graph TD;',
+      '  A-->B;',
+      '```',
+      '',
+      '',
+      '',
+      'After a big gap with {{title}} and [rating:: 9].'
+    ].join('\n')
+  }
+]

--- a/packages/shared/src/foreign-syntax.test.ts
+++ b/packages/shared/src/foreign-syntax.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { splitForeignRawSegments } from './foreign-syntax'
+
+const reassemble = (md: string): string =>
+  splitForeignRawSegments(md)
+    .map((s) => s.text)
+    .join('\n')
+
+describe('splitForeignRawSegments', () => {
+  it('claims %% block comments as raw', () => {
+    expect(splitForeignRawSegments('before\n%%\n- raw notes\n%%\nafter')).toEqual([
+      { kind: 'markdown', text: 'before' },
+      { kind: 'raw', text: '%%\n- raw notes\n%%' },
+      { kind: 'markdown', text: 'after' }
+    ])
+  })
+
+  it('leaves an unclosed %% delimiter as markdown', () => {
+    expect(splitForeignRawSegments('%%\nno closer')).toEqual([
+      { kind: 'markdown', text: '%%\nno closer' }
+    ])
+  })
+
+  it('claims $$ math blocks and single-line display math', () => {
+    expect(splitForeignRawSegments('$$\n\\int_0^1 x\n$$')).toEqual([
+      { kind: 'raw', text: '$$\n\\int_0^1 x\n$$' }
+    ])
+    expect(splitForeignRawSegments('$$e=mc^2$$')).toEqual([{ kind: 'raw', text: '$$e=mc^2$$' }])
+  })
+
+  it('never claims delimiters inside code fences', () => {
+    const md = '```\n%%\nnot a comment\n%%\n$$\n```'
+    expect(splitForeignRawSegments(md)).toEqual([{ kind: 'markdown', text: md }])
+  })
+
+  it('claims footnote definitions and custom checkbox states as raw lines', () => {
+    expect(splitForeignRawSegments('text\n[^1]: the note')).toEqual([
+      { kind: 'markdown', text: 'text' },
+      { kind: 'raw', text: '[^1]: the note' }
+    ])
+    // GFM states stay markdown; adjacent custom-state lines merge into ONE raw
+    // segment so their single-\n joins survive reassembly.
+    expect(splitForeignRawSegments('- [x] done\n- [-] cancelled\n- [?] maybe')).toEqual([
+      { kind: 'markdown', text: '- [x] done' },
+      { kind: 'raw', text: '- [-] cancelled\n- [?] maybe' }
+    ])
+  })
+
+  it('keeps lossless Memry callouts as markdown', () => {
+    const md = '> [!info]\n> Body line'
+    expect(splitForeignRawSegments(md)).toEqual([{ kind: 'markdown', text: md }])
+  })
+
+  it('claims callouts the Memry block cannot represent losslessly', () => {
+    const rawCallouts = [
+      '> [!faq] Title\n> Body', // unknown type
+      '> [!note]- Folded\n> Body', // fold marker
+      '> [!info] My title\n> Body', // custom title on a Memry type
+      '> [!note]\n> outer\n> > [!tip] inner', // nested
+      '> [!note]\n> First\n>\n> Second' // multi-paragraph
+    ]
+    for (const md of rawCallouts) {
+      expect(splitForeignRawSegments(md)).toEqual([{ kind: 'raw', text: md }])
+    }
+  })
+
+  it('reassembles the original bytes for line-adjacent segments', () => {
+    const md =
+      'intro\n\n%%\nblock\n%%\n\n$$\nx\n$$\n\n> [!faq] Q\n> A\n\n- [-] cancelled\n\ntail ^ab12cd'
+    expect(reassemble(md)).toBe(md)
+  })
+})

--- a/packages/shared/src/foreign-syntax.ts
+++ b/packages/shared/src/foreign-syntax.ts
@@ -1,0 +1,151 @@
+// Foreign-syntax raw-segment splitter (docs/obs/06).
+//
+// Obsidian block constructs that BlockNote/remark cannot represent are split
+// out BEFORE parsing and carried as opaque `rawMarkdown` blocks whose text is
+// re-emitted verbatim on serialize. Inline foreign syntax (%%…%%, ==…==, $…$,
+// [^1], ![[…]], {{…}}, ^blockid, dataview fields) is proven by the
+// foreign-syntax round-trip matrix to survive remark untouched, so it stays
+// plain text — no masking layer.
+//
+// ponytail: blank-line runs directly adjacent to a raw segment normalize to a
+// single blank line on save (same ceiling the Memry embed/file markers already
+// have); interior gaps inside markdown segments keep full fidelity via
+// empty-lines.ts.
+
+export type ForeignSegment = { kind: 'markdown'; text: string } | { kind: 'raw'; text: string }
+
+// Keep in sync with CALLOUT_TYPES in
+// apps/desktop/src/renderer/src/components/note/content-area/callout-block.tsx
+const MEMRY_CALLOUT_TYPES: readonly string[] = ['info', 'warning', 'error', 'success']
+
+const FENCE_LINE = /^ {0,3}(```|~~~)/
+const FOOTNOTE_DEF_LINE = /^\[\^[^\]\s]+\]:/
+// `- [x] …` GFM states (space/x/X) stay native checkboxes; anything else is an
+// Obsidian custom state the schema cannot represent.
+const CUSTOM_CHECKBOX_LINE = /^\s*[-*+] \[[^ xX\]]\] /
+const CALLOUT_START = /^> \[!(\w+)\](.*)$/
+
+// A callout the Memry callout block can represent losslessly: one of the four
+// Memry types, no fold marker or custom title, and a simple single-paragraph
+// body (no nested quotes/callouts, no `>` blank lines).
+function isLosslessMemryCallout(blockLines: string[]): boolean {
+  const match = blockLines[0].match(CALLOUT_START)
+  if (!match || !MEMRY_CALLOUT_TYPES.includes(match[1])) return false
+  if (match[2].trim() !== '') return false
+  return blockLines
+    .slice(1)
+    .every(
+      (line) =>
+        line.startsWith('> ') &&
+        line.slice(2).trim() !== '' &&
+        !line.startsWith('> >') &&
+        !line.startsWith('> [!')
+    )
+}
+
+/**
+ * Split markdown into segments the BlockNote pipeline may parse (`markdown`)
+ * and segments it must pass through verbatim (`raw`).
+ *
+ * Raw-claimed constructs: `%%` block comments, `$$` math blocks, footnote
+ * definition lines, custom-state checkbox lines, and callouts
+ * `isLosslessMemryCallout` rejects. Code-fence interiors are never claimed.
+ * Adjacent raw lines merge into one raw segment so their original single-`\n`
+ * joins survive reassembly.
+ */
+export function splitForeignRawSegments(markdown: string): ForeignSegment[] {
+  const lines = markdown.split('\n')
+  const segments: ForeignSegment[] = []
+  let mdLines: string[] = []
+  let rawLines: string[] = []
+
+  const flushMd = (): void => {
+    if (mdLines.length === 0) return
+    segments.push({ kind: 'markdown', text: mdLines.join('\n') })
+    mdLines = []
+  }
+  const flushRaw = (): void => {
+    if (rawLines.length === 0) return
+    segments.push({ kind: 'raw', text: rawLines.join('\n') })
+    rawLines = []
+  }
+  const pushMd = (line: string): void => {
+    flushRaw()
+    mdLines.push(line)
+  }
+  const pushRaw = (claimed: string[]): void => {
+    flushMd()
+    rawLines.push(...claimed)
+  }
+
+  let inFence = false
+  let fenceChar = ''
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]
+    const trimmed = line.trim()
+    const fenceMatch = line.match(FENCE_LINE)
+
+    if (inFence) {
+      if (fenceMatch && fenceMatch[1] === fenceChar) inFence = false
+      pushMd(line)
+      i++
+      continue
+    }
+    if (fenceMatch) {
+      inFence = true
+      fenceChar = fenceMatch[1]
+      pushMd(line)
+      i++
+      continue
+    }
+
+    // %% block comment / $$ math block: own-line delimiter through its closer.
+    // Unclosed delimiters fall through as plain markdown.
+    if (trimmed === '%%' || trimmed === '$$') {
+      let j = i + 1
+      while (j < lines.length && lines[j].trim() !== trimmed) j++
+      if (j < lines.length) {
+        pushRaw(lines.slice(i, j + 1))
+        i = j + 1
+        continue
+      }
+    }
+
+    // Single-line display math: $$…$$ on one line.
+    if (trimmed.startsWith('$$') && trimmed.endsWith('$$') && trimmed.length > 4) {
+      pushRaw([line])
+      i++
+      continue
+    }
+
+    // ponytail: single-line footnote definitions only; indented continuation
+    // lines re-parse as markdown (extend the claim if that ever bites).
+    if (FOOTNOTE_DEF_LINE.test(line) || CUSTOM_CHECKBOX_LINE.test(line)) {
+      pushRaw([line])
+      i++
+      continue
+    }
+
+    if (CALLOUT_START.test(line)) {
+      let j = i + 1
+      while (j < lines.length && (lines[j].startsWith('> ') || lines[j] === '>')) j++
+      const blockLines = lines.slice(i, j)
+      if (isLosslessMemryCallout(blockLines)) {
+        for (const calloutLine of blockLines) pushMd(calloutLine)
+      } else {
+        pushRaw(blockLines)
+      }
+      i = j
+      continue
+    }
+
+    pushMd(line)
+    i++
+  }
+
+  flushMd()
+  flushRaw()
+  return segments
+}


### PR DESCRIPTION
## What
Obsidian block syntax BlockNote cannot represent — `%%block comments%%`, `$$math$$`, footnote definitions, custom checkbox states, non-lossless callouts — is split out pre-parse (`splitForeignRawSegments` in `@memry/shared`) and carried as opaque `rawMarkdown` blocks that re-emit their source verbatim in both pipelines; a 31-fixture round-trip matrix (renderer + main CRDT) guards every syntax-inventory row byte-for-byte. The matrix proved all inline syntax already survives remark untouched, so spec 06's planned inline mask/restore layer was dropped.

## Why
Implements `docs/obs/06` — editing an Obsidian-vault note in MemryNote must not mangle syntax the editor doesn't understand (P2.9).