### PR TITLE
feat(vault): strip Obsidian-forbidden chars [ ] # ^ from filenames

### DIFF
--- a/apps/desktop/src/main/lib/export-utils.test.ts
+++ b/apps/desktop/src/main/lib/export-utils.test.ts
@@ -68,4 +68,10 @@ describe('export-utils', () => {
     expect(sanitizeFilename('  in<va>lid: file/name?.md  ')).toBe('invalid filename.md')
     expect(sanitizeFilename('a'.repeat(250))).toHaveLength(200)
   })
+
+  it('sanitizeFilename strips Obsidian-forbidden characters and falls back to untitled', () => {
+    expect(sanitizeFilename('Draft [v2] #1')).toBe('Draft v2 1')
+    expect(sanitizeFilename('a^b|c')).toBe('abc')
+    expect(sanitizeFilename('[#^]')).toBe('untitled')
+  })
 })

--- a/apps/desktop/src/main/lib/export-utils.ts
+++ b/apps/desktop/src/main/lib/export-utils.ts
@@ -408,9 +408,10 @@ export function renderNoteAsHtml(note: NoteExportData, options: RenderOptions = 
  */
 export function sanitizeFilename(filename: string): string {
   // Remove or replace characters that are invalid in filenames
-  return filename
-    .replace(/[<>:"/\\|?*]/g, '') // Remove invalid chars
+  const sanitized = filename
+    .replace(/[<>:"/\\|?*[\]#^]/g, '') // Remove platform + Obsidian-forbidden chars
     .replace(/\s+/g, ' ') // Normalize whitespace
     .trim()
     .slice(0, 200) // Limit length
+  return sanitized.length > 0 ? sanitized : 'untitled'
 }

--- a/apps/desktop/src/main/vault/file-ops.test.ts
+++ b/apps/desktop/src/main/vault/file-ops.test.ts
@@ -491,6 +491,12 @@ describe('sanitizeFilename', () => {
     expect(sanitizeFilename('My Note 2024')).toBe('My Note 2024')
     expect(sanitizeFilename('note-with_special.chars')).toBe('note-with_special.chars')
   })
+
+  it('T350: strips Obsidian-forbidden characters [ ] # ^', () => {
+    expect(sanitizeFilename('Draft [v2] #1')).toBe('Draft v2 1')
+    expect(sanitizeFilename('a^b|c')).toBe('abc')
+    expect(sanitizeFilename('[#^]')).toBe('untitled')
+  })
 })
 
 // ============================================================================

--- a/apps/desktop/src/main/vault/file-ops.ts
+++ b/apps/desktop/src/main/vault/file-ops.ts
@@ -291,7 +291,8 @@ export async function getFileStats(filePath: string): Promise<{
 
 /**
  * Sanitize a filename to be safe for the file system.
- * Removes or replaces invalid characters.
+ * Strips platform-invalid characters plus `[ ] # ^`, which Obsidian ≥1.8
+ * forbids in filenames (they break wikilink syntax).
  *
  * @param filename - Raw filename
  * @returns Sanitized filename
@@ -299,7 +300,7 @@ export async function getFileStats(filePath: string): Promise<{
 export function sanitizeFilename(filename: string): string {
   // Remove or replace invalid characters
   let sanitized = filename
-    .replace(/[<>:"/\\|?*]/g, '') // Remove invalid chars
+    .replace(/[<>:"/\\|?*[\]#^]/g, '') // Remove platform + Obsidian-forbidden chars
     .replace(/\s+/g, ' ') // Collapse whitespace
     .trim()
 

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -56,6 +56,10 @@ The title is editable inline at the top of the editor. Renames are live — the 
 
 If you leave the title empty, memrynote generates a fallback ("Untitled" or the first heading).
 
+Titles become filenames in your vault, so characters that are invalid in filenames or break
+Obsidian wiki links (`< > : " / \ | ? * [ ] # ^`) are stripped on save — a note titled
+`Draft [v2] #1` is saved as `Draft v2 1.md`. Existing files are never renamed retroactively.
+
 ## Drag-and-Drop Blocks
 
 Hover the gutter on the left to reveal the block handle. Drag a block to:


### PR DESCRIPTION
## What
Extend both filename sanitizers (vault file-ops + export defaults) to strip `[ ] # ^` alongside the platform-invalid set, add the missing `untitled` fallback to export-utils, and document the stripped set in the notes docs.

## Why
Obsidian ≥1.8 forbids `[ ] # ^` in filenames (they break wikilink syntax), so a note titled `Draft [v2] #1` produced a file Obsidian could never link to (spec `docs/obs/07-filename-sanitization.md`). Existing files are not renamed retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)