### PR TITLE
feat(vault): read Obsidian settings, keep .obsidian strictly read-only

### DIFF
--- a/apps/desktop/src/main/database/queries/notes/query-helpers.ts
+++ b/apps/desktop/src/main/database/queries/notes/query-helpers.ts
@@ -1,4 +1,5 @@
 import type { PropertyType } from '@memry/db-schema/schema/notes-cache'
+import { getObsidianPropertyType } from '@main/vault/obsidian-config'
 
 // ============================================================================
 // Activity Level
@@ -66,7 +67,9 @@ export function deserializeValue(value: string | null, type: PropertyType): unkn
 // Property Type Inference
 // ============================================================================
 
-export function inferPropertyType(value: unknown): PropertyType {
+export function inferPropertyType(name: string, value: unknown): PropertyType {
+  const obsidianType = getObsidianPropertyType(name)
+  if (obsidianType) return obsidianType
   if (typeof value === 'boolean') return 'checkbox'
   if (typeof value === 'number') return 'number'
   if (Array.isArray(value)) return 'text'

--- a/apps/desktop/src/main/vault/file-ops.test.ts
+++ b/apps/desktop/src/main/vault/file-ops.test.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import {
+  assertVaultWritePath,
   atomicWrite,
   safeRead,
   readRequired,
@@ -628,5 +629,51 @@ describe('generateUniquePathSync', () => {
 
     // #then
     expect(result).toBe(path.join(tempDir.path, 'note 3.md'))
+  })
+})
+
+// ============================================================================
+// Protected Path Guard (spec 08)
+// ============================================================================
+
+describe('assertVaultWritePath', () => {
+  let tempDir: TestDir
+
+  beforeEach(() => {
+    tempDir = createTempDir()
+  })
+
+  afterEach(() => {
+    tempDir.cleanup()
+  })
+
+  it('allows normal vault paths', () => {
+    expect(() => assertVaultWritePath(path.join(tempDir.path, 'notes', 'a.md'))).not.toThrow()
+  })
+
+  it('atomicWrite refuses paths inside .obsidian', async () => {
+    const target = path.join(tempDir.path, '.obsidian', 'app.json')
+
+    await expect(atomicWrite(target, '{}')).rejects.toMatchObject({
+      code: 'NOTE_INVALID_PATH'
+    })
+    expect(fs.existsSync(target)).toBe(false)
+  })
+
+  it('deleteFile refuses paths inside .trash', async () => {
+    const trashDir = path.join(tempDir.path, '.trash')
+    fs.mkdirSync(trashDir, { recursive: true })
+    const target = path.join(trashDir, 'note.md')
+    fs.writeFileSync(target, 'content')
+
+    await expect(deleteFile(target)).rejects.toMatchObject({
+      code: 'NOTE_INVALID_PATH'
+    })
+    expect(fs.readFileSync(target, 'utf-8')).toBe('content')
+  })
+
+  it('catches traversal into protected folders', () => {
+    const sneaky = path.join(tempDir.path, 'notes', '..', '.obsidian', 'app.json')
+    expect(() => assertVaultWritePath(sneaky)).toThrow(NoteError)
   })
 })

--- a/apps/desktop/src/main/vault/file-ops.ts
+++ b/apps/desktop/src/main/vault/file-ops.ts
@@ -13,6 +13,34 @@ import { NoteError, NoteErrorCode } from '../lib/errors'
 import { normalizeRelativePath } from '../lib/paths'
 
 // ============================================================================
+// Protected Paths
+// ============================================================================
+
+/**
+ * Folders Memry must never write into or delete from. `.obsidian/` is
+ * Obsidian-owned configuration and `.trash/` is Obsidian's trash — both are
+ * strictly read-only for Memry. No production path hits this today; it is
+ * pure regression insurance.
+ */
+const PROTECTED_VAULT_DIRS = new Set(['.obsidian', '.trash'])
+
+/**
+ * Throw if the resolved path is inside a protected vault folder.
+ *
+ * @param filePath - Absolute path about to be written or deleted
+ * @throws NoteError with INVALID_PATH if the path is protected
+ */
+export function assertVaultWritePath(filePath: string): void {
+  const segments = path.resolve(filePath).split(path.sep)
+  if (segments.some((segment) => PROTECTED_VAULT_DIRS.has(segment))) {
+    throw new NoteError(
+      `Refusing to write inside protected folder: ${filePath}`,
+      NoteErrorCode.INVALID_PATH
+    )
+  }
+}
+
+// ============================================================================
 // Atomic Write
 // ============================================================================
 
@@ -25,6 +53,8 @@ import { normalizeRelativePath } from '../lib/paths'
  * @throws NoteError if write fails
  */
 export async function atomicWrite(filePath: string, content: string): Promise<void> {
+  assertVaultWritePath(filePath)
+
   const dir = path.dirname(filePath)
   const tempPath = path.join(dir, `.${randomBytes(6).toString('hex')}.tmp`)
 
@@ -217,6 +247,8 @@ export async function listDirectories(dirPath: string, relativeTo?: string): Pro
  * @throws NoteError if delete fails
  */
 export async function deleteFile(filePath: string): Promise<void> {
+  assertVaultWritePath(filePath)
+
   try {
     await unlink(filePath)
   } catch (error) {

--- a/apps/desktop/src/main/vault/frontmatter.ts
+++ b/apps/desktop/src/main/vault/frontmatter.ts
@@ -262,6 +262,7 @@ export function generateContentHash(content: string): string {
 // ============================================================================
 
 import type { PropertyType } from '@memry/contracts/property-types'
+import { getObsidianPropertyType } from './obsidian-config'
 
 /**
  * Reserved frontmatter keys that are NOT properties — only the two keys with
@@ -325,11 +326,19 @@ function isURL(value: string): boolean {
  * T008: Used when syncing externally-edited properties that don't have
  * a pre-existing type definition.
  *
- * @param _name - Property name (unused, kept for API compatibility)
+ * Inference order: `.obsidian/types.json` by property name (loaded on vault
+ * open via the obsidian-config holder) → value-based inference.
+ *
+ * @param name - Property name, matched against Obsidian's types.json
  * @param value - Property value to infer type from
  * @returns Inferred property type
  */
-export function inferPropertyType(_name: string, value: unknown): PropertyType {
+export function inferPropertyType(name: string, value: unknown): PropertyType {
+  const obsidianType = getObsidianPropertyType(name)
+  if (obsidianType) {
+    return obsidianType
+  }
+
   // Boolean -> checkbox
   if (typeof value === 'boolean') {
     return 'checkbox'

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -29,6 +29,7 @@ import {
   getIndexDbPath
 } from './init'
 import { setJournalConfig } from './journal-config'
+import { loadObsidianPropertyTypes } from './obsidian-config'
 import {
   initDatabase,
   initIndexDatabase,
@@ -281,6 +282,10 @@ async function openVault(vaultPath: string): Promise<void> {
   // holder) resolve the real config.json instead of the closed-vault fallback —
   // otherwise the initial index uses default journal config + empty excludes.
   updateStatus({ isIndexing: true, indexProgress: 0, path: vaultPath })
+
+  // Load Obsidian property types (.obsidian/types.json) before indexing so
+  // property type inference sees them during the initial index.
+  loadObsidianPropertyTypes(vaultPath)
 
   try {
     if (indexHealth !== 'healthy') {
@@ -601,6 +606,7 @@ export async function reindex(): Promise<void> {
   updateStatus({ isIndexing: true, indexProgress: 0 })
 
   try {
+    loadObsidianPropertyTypes(currentStatus.path)
     await indexVault(currentStatus.path)
     updateStatus({ isIndexing: false, indexProgress: 100 })
   } catch (error) {

--- a/apps/desktop/src/main/vault/indexer.test.ts
+++ b/apps/desktop/src/main/vault/indexer.test.ts
@@ -461,4 +461,57 @@ Copied note`
       expect(after).toEqual(expect.objectContaining({ id: before?.id, path: relativePath }))
     })
   })
+
+  // ==========================================================================
+  // Spec 08: .obsidian / .canvas / .base / binary read-only safety
+  // ==========================================================================
+
+  describe('obsidian read-only safety', () => {
+    it('indexing and a note edit never rewrite .obsidian, .canvas, .base or binaries', async () => {
+      const obsidianDir = path.join(tempVault.path, '.obsidian')
+      fs.mkdirSync(obsidianDir, { recursive: true })
+
+      const protectedFiles: Record<string, string> = {
+        [path.join(obsidianDir, 'app.json')]: '{ "useMarkdownLinks": true }',
+        [path.join(obsidianDir, 'workspace.json')]: '{ "main": { "churn": 1 } }',
+        [path.join(tempVault.path, 'board.canvas')]: '{"nodes":[],"edges":[]}',
+        [path.join(tempVault.path, 'db.base')]: 'filters: {}'
+      }
+      for (const [filePath, content] of Object.entries(protectedFiles)) {
+        fs.writeFileSync(filePath, content)
+      }
+      const pngPath = path.join(tempVault.path, 'img.png')
+      const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3])
+      fs.writeFileSync(pngPath, pngBytes)
+
+      const allProtected = [...Object.keys(protectedFiles), pngPath]
+      const mtimesBefore = allProtected.map((p) => fs.statSync(p).mtimeMs)
+
+      const notePath = path.join(tempVault.notesDir, 'note.md')
+      fs.writeFileSync(notePath, '# Hello\n')
+
+      await indexer.indexVault(tempVault.path)
+
+      // Simulate a user note edit followed by reindex (update path)
+      fs.writeFileSync(notePath, '# Hello edited\n')
+      await indexer.indexVault(tempVault.path)
+
+      // Byte-identical, mtimes untouched
+      for (const [filePath, content] of Object.entries(protectedFiles)) {
+        expect(fs.readFileSync(filePath, 'utf-8')).toBe(content)
+      }
+      expect(fs.readFileSync(pngPath)).toEqual(pngBytes)
+      expect(allProtected.map((p) => fs.statSync(p).mtimeMs)).toEqual(mtimesBefore)
+
+      // Cache: no .obsidian paths, .canvas/.base never indexed, png metadata-only
+      const paths = testDb.db
+        .select()
+        .from(noteCache)
+        .all()
+        .map((row) => row.path)
+      expect(paths.some((p) => p.includes('.obsidian'))).toBe(false)
+      expect(paths.some((p) => p.endsWith('.canvas') || p.endsWith('.base'))).toBe(false)
+      expect(paths).toContain('img.png')
+    })
+  })
 })

--- a/apps/desktop/src/main/vault/init.test.ts
+++ b/apps/desktop/src/main/vault/init.test.ts
@@ -394,3 +394,83 @@ describe('countMarkdownFiles', () => {
     expect(() => countMarkdownFiles(tempDir.path)).not.toThrow()
   })
 })
+
+// ============================================================================
+// Obsidian Seeding (spec 08)
+// ============================================================================
+
+describe('initVault Obsidian seeding', () => {
+  let tempDir: TestDir
+
+  beforeEach(() => {
+    tempDir = createTempDir('init-obsidian-')
+  })
+
+  afterEach(() => {
+    tempDir.cleanup()
+  })
+
+  function writeDailyNotes(config: Record<string, unknown>): void {
+    const obsidianDir = path.join(tempDir.path, '.obsidian')
+    fs.mkdirSync(obsidianDir, { recursive: true })
+    fs.writeFileSync(path.join(obsidianDir, 'daily-notes.json'), JSON.stringify(config))
+  }
+
+  it('seeds journal folder and format from daily-notes.json on first init', () => {
+    writeDailyNotes({ folder: 'Daily Notes', format: 'DD-MM-YYYY' })
+
+    initVault(tempDir.path)
+
+    const config = readVaultConfig(tempDir.path)
+    expect(config.journalFolder).toBe('Daily Notes')
+    expect(config.journalDateFormat).toBe('DD-MM-YYYY')
+    // Seeded folder is created instead of the default one
+    expect(fs.existsSync(path.join(tempDir.path, 'Daily Notes'))).toBe(true)
+    expect(fs.existsSync(path.join(tempDir.path, 'journal'))).toBe(false)
+  })
+
+  it('keeps defaults when there is no .obsidian folder', () => {
+    initVault(tempDir.path)
+
+    const config = readVaultConfig(tempDir.path)
+    expect(config.journalFolder).toBe('journal')
+    expect(config.journalDateFormat).toBe('YYYY-MM-DD')
+    expect(fs.existsSync(path.join(tempDir.path, 'journal'))).toBe(true)
+  })
+
+  it('rejects a format that creates subfolders, keeps the seeded folder', () => {
+    writeDailyNotes({ folder: 'daily', format: 'YYYY/MM/DD' })
+
+    initVault(tempDir.path)
+
+    const config = readVaultConfig(tempDir.path)
+    expect(config.journalFolder).toBe('daily')
+    expect(config.journalDateFormat).toBe('YYYY-MM-DD')
+  })
+
+  it('rejects a format that does not round-trip', () => {
+    writeDailyNotes({ format: 'dddd, MMMM Do' })
+
+    initVault(tempDir.path)
+
+    expect(readVaultConfig(tempDir.path).journalDateFormat).toBe('YYYY-MM-DD')
+  })
+
+  it('rejects unsafe folders (absolute or parent-escaping)', () => {
+    writeDailyNotes({ folder: '../outside' })
+    initVault(tempDir.path)
+    expect(readVaultConfig(tempDir.path).journalFolder).toBe('journal')
+  })
+
+  it('never overwrites an existing config on a second init', () => {
+    initVault(tempDir.path)
+    writeVaultConfig(tempDir.path, { journalFolder: 'my-journal' })
+    writeDailyNotes({ folder: 'Daily Notes', format: 'DD-MM-YYYY' })
+
+    initVault(tempDir.path)
+
+    const config = readVaultConfig(tempDir.path)
+    expect(config.journalFolder).toBe('my-journal')
+    expect(config.journalDateFormat).toBe('YYYY-MM-DD')
+  })
+})

--- a/apps/desktop/src/main/vault/init.ts
+++ b/apps/desktop/src/main/vault/init.ts
@@ -1,10 +1,15 @@
 import fs from 'fs'
 import path from 'path'
+import { parseJournalDate, formatJournalFilename } from '@memry/storage-vault'
+import { createLogger } from '../lib/logger'
+import { readDailyNotesConfig } from './obsidian-config'
+
+const logger = createLogger('VaultInit')
 
 /**
- * Default vault folder structure
+ * Default vault folder structure (journal folder is added from config)
  */
-const VAULT_FOLDERS = ['journal', 'attachments', 'attachments/images', 'attachments/files']
+const VAULT_FOLDERS = ['attachments', 'attachments/images', 'attachments/files']
 
 /**
  * Hidden Memry folder name
@@ -83,9 +88,47 @@ export function hasWritePermission(dirPath: string): boolean {
 }
 
 /**
+ * True when an Obsidian daily-note format can serve as Memry's
+ * journalDateFormat: it must round-trip a date and stay a single filename
+ * (no '/' subfolders, which Memry's direct-child journal detection can't see).
+ */
+function isSeedableJournalFormat(format: string): boolean {
+  const stem = formatJournalFilename('2026-01-31', format)
+  return !stem.includes('/') && parseJournalDate(stem, format) === '2026-01-31'
+}
+
+/**
+ * Seed-once journal settings from `.obsidian/daily-notes.json`.
+ * Only consulted when `.memry/config.json` does not exist yet; afterwards
+ * Memry's own config is authoritative (no live re-sync by design).
+ */
+function obsidianJournalSeed(vaultPath: string): Partial<typeof DEFAULT_CONFIG> {
+  const dailyNotes = readDailyNotesConfig(vaultPath)
+  if (!dailyNotes) return {}
+
+  const seed: Partial<typeof DEFAULT_CONFIG> = {}
+  const folder = dailyNotes.folder?.replace(/\/+$/, '')
+  if (folder && !path.isAbsolute(folder) && !folder.split('/').includes('..')) {
+    seed.journalFolder = folder
+  }
+  if (dailyNotes.format) {
+    if (isSeedableJournalFormat(dailyNotes.format)) {
+      seed.journalDateFormat = dailyNotes.format
+    } else {
+      logger.warn(
+        `Ignoring Obsidian daily-note format "${dailyNotes.format}": not usable as a journal filename`
+      )
+    }
+  }
+  return seed
+}
+
+/**
  * Initialize a vault at the given path.
  * Creates .memry folder and default config if they don't exist.
- * Also creates default vault folders (notes, journal, attachments).
+ * Also creates default vault folders (journal, attachments).
+ * On first init of a vault with an .obsidian folder, journal settings are
+ * seeded from Obsidian's daily-notes config.
  */
 export function initVault(vaultPath: string): void {
   // Create .memry directory
@@ -94,8 +137,11 @@ export function initVault(vaultPath: string): void {
 
   // Create default config if it doesn't exist
   const configPath = getConfigPath(vaultPath)
+  const config = fs.existsSync(configPath)
+    ? readVaultConfig(vaultPath)
+    : { ...DEFAULT_CONFIG, ...obsidianJournalSeed(vaultPath) }
   try {
-    fs.writeFileSync(configPath, JSON.stringify(DEFAULT_CONFIG, null, 2), {
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), {
       encoding: 'utf-8',
       mode: 0o600,
       flag: 'wx'
@@ -107,7 +153,8 @@ export function initVault(vaultPath: string): void {
   }
 
   // Create default vault folders
-  for (const folder of VAULT_FOLDERS) {
+  for (const folder of [...VAULT_FOLDERS, config.journalFolder]) {
+    if (!folder) continue
     const folderPath = path.join(vaultPath, folder)
     fs.mkdirSync(folderPath, { recursive: true })
   }

--- a/apps/desktop/src/main/vault/obsidian-config.test.ts
+++ b/apps/desktop/src/main/vault/obsidian-config.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for obsidian-config.ts
+ * Read-only accessors for `.obsidian/` and the property-type holder.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import {
+  hasObsidianDir,
+  readDailyNotesConfig,
+  readAppConfig,
+  readPropertyTypes,
+  mapObsidianType,
+  loadObsidianPropertyTypes,
+  getObsidianPropertyType
+} from './obsidian-config'
+import { inferPropertyType } from './frontmatter'
+import { inferPropertyType as inferPropertyTypeDb } from '../database/queries/notes/query-helpers'
+
+let vaultPath: string
+
+function writeObsidianFile(file: string, content: string): void {
+  const dir = path.join(vaultPath, '.obsidian')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, file), content)
+}
+
+beforeEach(() => {
+  vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'obsidian-config-test-'))
+})
+
+afterEach(() => {
+  fs.rmSync(vaultPath, { recursive: true, force: true })
+  // Vault is gone → reload clears the process-wide holder
+  loadObsidianPropertyTypes(vaultPath)
+})
+
+describe('hasObsidianDir', () => {
+  it('returns false without .obsidian and true with it', () => {
+    expect(hasObsidianDir(vaultPath)).toBe(false)
+    fs.mkdirSync(path.join(vaultPath, '.obsidian'))
+    expect(hasObsidianDir(vaultPath)).toBe(true)
+  })
+
+  it('returns false when .obsidian is a file', () => {
+    fs.writeFileSync(path.join(vaultPath, '.obsidian'), 'not a dir')
+    expect(hasObsidianDir(vaultPath)).toBe(false)
+  })
+})
+
+describe('readDailyNotesConfig', () => {
+  it('reads folder, format and template', () => {
+    writeObsidianFile(
+      'daily-notes.json',
+      JSON.stringify({ folder: 'Daily Notes', format: 'YYYY-MM-DD', template: 'tpl.md' })
+    )
+    expect(readDailyNotesConfig(vaultPath)).toEqual({
+      folder: 'Daily Notes',
+      format: 'YYYY-MM-DD',
+      template: 'tpl.md'
+    })
+  })
+
+  it('returns null for missing folder, missing file and malformed JSON', () => {
+    expect(readDailyNotesConfig(vaultPath)).toBeNull()
+    fs.mkdirSync(path.join(vaultPath, '.obsidian'))
+    expect(readDailyNotesConfig(vaultPath)).toBeNull()
+    writeObsidianFile('daily-notes.json', '{ not json')
+    expect(readDailyNotesConfig(vaultPath)).toBeNull()
+  })
+
+  it('drops non-string values', () => {
+    writeObsidianFile('daily-notes.json', JSON.stringify({ folder: 42, format: 'YYYY-MM-DD' }))
+    expect(readDailyNotesConfig(vaultPath)).toEqual({ format: 'YYYY-MM-DD' })
+  })
+
+  it('never reads workspace.json', () => {
+    writeObsidianFile('workspace.json', JSON.stringify({ folder: 'from-workspace' }))
+    expect(readDailyNotesConfig(vaultPath)).toBeNull()
+    expect(readAppConfig(vaultPath)).toBeNull()
+    expect(readPropertyTypes(vaultPath)).toBeNull()
+  })
+})
+
+describe('readAppConfig', () => {
+  it('reads attachment and link preferences', () => {
+    writeObsidianFile(
+      'app.json',
+      JSON.stringify({
+        attachmentFolderPath: './assets',
+        newLinkFormat: 'relative',
+        useMarkdownLinks: true
+      })
+    )
+    expect(readAppConfig(vaultPath)).toEqual({
+      attachmentFolderPath: './assets',
+      newLinkFormat: 'relative',
+      useMarkdownLinks: true
+    })
+  })
+
+  it('drops invalid newLinkFormat values and returns null on malformed JSON', () => {
+    writeObsidianFile('app.json', JSON.stringify({ newLinkFormat: 'bogus' }))
+    expect(readAppConfig(vaultPath)).toEqual({})
+    writeObsidianFile('app.json', 'nope')
+    expect(readAppConfig(vaultPath)).toBeNull()
+  })
+})
+
+describe('readPropertyTypes', () => {
+  it('reads known types keyed by lowercased name, dropping unknown values', () => {
+    writeObsidianFile(
+      'types.json',
+      JSON.stringify({
+        types: {
+          Priority: 'number',
+          due: 'date',
+          done: 'checkbox',
+          people: 'multitext',
+          tags: 'tags',
+          weird: 'nonsense'
+        }
+      })
+    )
+    expect(readPropertyTypes(vaultPath)).toEqual({
+      priority: 'number',
+      due: 'date',
+      done: 'checkbox',
+      people: 'multitext',
+      tags: 'tags'
+    })
+  })
+
+  it('returns null when types key is missing or malformed', () => {
+    writeObsidianFile('types.json', JSON.stringify({ other: true }))
+    expect(readPropertyTypes(vaultPath)).toBeNull()
+    writeObsidianFile('types.json', JSON.stringify({ types: [1, 2] }))
+    expect(readPropertyTypes(vaultPath)).toBeNull()
+  })
+})
+
+describe('mapObsidianType', () => {
+  it('maps Obsidian types to Memry property types', () => {
+    expect(mapObsidianType('text')).toBe('text')
+    expect(mapObsidianType('number')).toBe('number')
+    expect(mapObsidianType('checkbox')).toBe('checkbox')
+    expect(mapObsidianType('date')).toBe('date')
+    expect(mapObsidianType('datetime')).toBe('date')
+    expect(mapObsidianType('multitext')).toBe('multiselect')
+    expect(mapObsidianType('tags')).toBeNull()
+  })
+})
+
+describe('property-type holder + inference order', () => {
+  beforeEach(() => {
+    writeObsidianFile(
+      'types.json',
+      JSON.stringify({ types: { priority: 'number', tags: 'tags', when: 'datetime' } })
+    )
+    loadObsidianPropertyTypes(vaultPath)
+  })
+
+  it('getObsidianPropertyType is name-based and case-insensitive', () => {
+    expect(getObsidianPropertyType('priority')).toBe('number')
+    expect(getObsidianPropertyType('Priority')).toBe('number')
+    expect(getObsidianPropertyType('when')).toBe('date')
+    expect(getObsidianPropertyType('tags')).toBeNull() // reserved, mapped to null
+    expect(getObsidianPropertyType('unlisted')).toBeNull()
+  })
+
+  it('types.json wins over value inference, value inference is the fallback', () => {
+    expect(inferPropertyType('priority', 'not a number')).toBe('number')
+    expect(inferPropertyType('unlisted', true)).toBe('checkbox')
+    expect(inferPropertyTypeDb('priority', 'not a number')).toBe('number')
+    expect(inferPropertyTypeDb('unlisted', 'https://example.com')).toBe('url')
+  })
+
+  it('reloading from a vault without .obsidian clears the holder', () => {
+    const emptyVault = fs.mkdtempSync(path.join(os.tmpdir(), 'obsidian-config-empty-'))
+    try {
+      loadObsidianPropertyTypes(emptyVault)
+      expect(getObsidianPropertyType('priority')).toBeNull()
+    } finally {
+      fs.rmSync(emptyVault, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/desktop/src/main/vault/obsidian-config.ts
+++ b/apps/desktop/src/main/vault/obsidian-config.ts
@@ -1,0 +1,146 @@
+/**
+ * Read-only accessors for a vault's `.obsidian/` configuration.
+ *
+ * Memry treats `.obsidian/` as strictly read-only: these helpers surface the
+ * user's Obsidian settings (daily notes, attachment/link preferences, property
+ * types) so Memry can behave consistently with them. Every reader is
+ * best-effort — a missing folder, missing file, or malformed JSON yields
+ * `null`, never a throw. `workspace.json` is intentionally never read (it
+ * churns constantly). No write API exists in this module by design.
+ *
+ * Only the default `.obsidian` folder name is supported; vaults using
+ * Obsidian's "Override config folder" setting simply get no seeding.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import type { PropertyType } from '@memry/contracts/property-types'
+import { createLogger } from '../lib/logger'
+
+const logger = createLogger('ObsidianConfig')
+
+export interface ObsidianDailyNotesConfig {
+  folder?: string // relative to vault root
+  format?: string // Moment tokens; may contain '/' → subfolders
+  template?: string // ignored in v1 — Memry has its own template system
+}
+
+export interface ObsidianAppConfig {
+  attachmentFolderPath?: string // '' | 'folder' | './' | './sub' (note-relative)
+  newLinkFormat?: 'shortest' | 'relative' | 'absolute'
+  useMarkdownLinks?: boolean
+}
+
+const OBSIDIAN_PROPERTY_TYPES = [
+  'text',
+  'multitext',
+  'number',
+  'checkbox',
+  'date',
+  'datetime',
+  'tags'
+] as const
+
+export type ObsidianPropertyType = (typeof OBSIDIAN_PROPERTY_TYPES)[number]
+
+function readObsidianJson(vaultPath: string, file: string): Record<string, unknown> | null {
+  const filePath = path.join(vaultPath, '.obsidian', file)
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+    return null
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      logger.debug(`Ignoring unreadable .obsidian/${file}:`, error)
+    }
+    return null
+  }
+}
+
+export function hasObsidianDir(vaultPath: string): boolean {
+  try {
+    return fs.statSync(path.join(vaultPath, '.obsidian')).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+export function readDailyNotesConfig(vaultPath: string): ObsidianDailyNotesConfig | null {
+  const raw = readObsidianJson(vaultPath, 'daily-notes.json')
+  if (!raw) return null
+  const config: ObsidianDailyNotesConfig = {}
+  if (typeof raw.folder === 'string') config.folder = raw.folder
+  if (typeof raw.format === 'string') config.format = raw.format
+  if (typeof raw.template === 'string') config.template = raw.template
+  return config
+}
+
+export function readAppConfig(vaultPath: string): ObsidianAppConfig | null {
+  const raw = readObsidianJson(vaultPath, 'app.json')
+  if (!raw) return null
+  const config: ObsidianAppConfig = {}
+  if (typeof raw.attachmentFolderPath === 'string') {
+    config.attachmentFolderPath = raw.attachmentFolderPath
+  }
+  if (
+    raw.newLinkFormat === 'shortest' ||
+    raw.newLinkFormat === 'relative' ||
+    raw.newLinkFormat === 'absolute'
+  ) {
+    config.newLinkFormat = raw.newLinkFormat
+  }
+  if (typeof raw.useMarkdownLinks === 'boolean') config.useMarkdownLinks = raw.useMarkdownLinks
+  return config
+}
+
+export function readPropertyTypes(vaultPath: string): Record<string, ObsidianPropertyType> | null {
+  const raw = readObsidianJson(vaultPath, 'types.json')
+  const types = raw?.types
+  if (!types || typeof types !== 'object' || Array.isArray(types)) return null
+  const result: Record<string, ObsidianPropertyType> = {}
+  for (const [name, value] of Object.entries(types)) {
+    if ((OBSIDIAN_PROPERTY_TYPES as readonly unknown[]).includes(value)) {
+      result[name.toLowerCase()] = value as ObsidianPropertyType
+    }
+  }
+  return result
+}
+
+const OBSIDIAN_TO_MEMRY: Record<ObsidianPropertyType, PropertyType | null> = {
+  text: 'text',
+  multitext: 'multiselect',
+  number: 'number',
+  checkbox: 'checkbox',
+  date: 'date',
+  datetime: 'date',
+  tags: null // reserved key — tag handling is owned by the tags pipeline, not properties
+}
+
+export function mapObsidianType(t: ObsidianPropertyType): PropertyType | null {
+  return OBSIDIAN_TO_MEMRY[t] ?? null
+}
+
+// ============================================================================
+// Property-type holder
+//
+// Same pattern as journal-config: inferPropertyType call sites don't have the
+// vault path in scope, so the mapped types.json content is held process-wide.
+// Loaded on vault open and refreshed on reindex.
+// ============================================================================
+
+let propertyTypesByName: Record<string, PropertyType> = {}
+
+export function loadObsidianPropertyTypes(vaultPath: string): void {
+  const next: Record<string, PropertyType> = {}
+  for (const [name, obsidianType] of Object.entries(readPropertyTypes(vaultPath) ?? {})) {
+    const mapped = mapObsidianType(obsidianType)
+    if (mapped) next[name] = mapped
+  }
+  propertyTypesByName = next
+}
+
+export function getObsidianPropertyType(name: string): PropertyType | null {
+  return propertyTypesByName[name.toLowerCase()] ?? null
+}

--- a/apps/docs/src/user-guide/journal/daily-entries.md
+++ b/apps/docs/src/user-guide/journal/daily-entries.md
@@ -62,6 +62,14 @@ You can wiki-link to other journal entries: `[[2026-05-07]]` resolves to that da
 
 Nothing. memrynote doesn't pad missing days with empty entries. Calendar heatmaps show genuine activity, not noise.
 
+## Obsidian Vaults
+
+If the folder you open is an Obsidian vault (it contains `.obsidian/`), memrynote reads the vault's Daily Notes settings on first open: the configured daily-note folder and date format become memrynote's journal folder and filename format, so both apps write the same daily files. This is a one-time seed — afterwards memrynote's own settings are authoritative, and reconfiguring one app never silently reconfigures the other. Date formats that place daily notes in subfolders (like `YYYY/MM/DD`) can't be adopted and fall back to `YYYY-MM-DD`.
+
+Property types defined in Obsidian (`.obsidian/types.json`) are respected too: a property marked there as a number, date, or checkbox keeps that type in memrynote even when a value alone is ambiguous.
+
+The `.obsidian/` and `.trash/` folders are strictly read-only — memrynote never writes, moves, or deletes anything inside them.
+
 ## Sync
 
 Journal entries sync as Yjs CRDTs (same as notes). Two devices writing on the same date during a flight merge cleanly when they reconnect.


### PR DESCRIPTION
## What
- `.obsidian/{daily-notes,app,types}.json` get best-effort read-only accessors (`workspace.json` never read); no write API exists
- First open of an Obsidian vault seeds journal folder/date format from Daily Notes settings (seed-once; formats must round-trip as a single filename)
- Property type inference consults `.obsidian/types.json` by name before value inference (holder loaded on vault open + reindex)
- `atomicWrite`/`deleteFile` now refuse any path inside `.obsidian/` or `.trash/` (regression insurance)

## Why
Spec 08 (`docs/obs/08-obsidian-settings-readonly.md`): behave consistently with the user's Obsidian config while guaranteeing Memry never mutates it. Stacked on #obs-frontmatter-diet (spec 01), same as #693.