### PR TITLE
feat(vault): frontmatter diet — stop writing Memry keys to vault files

### DIFF
--- a/apps/cli/src/run.test.ts
+++ b/apps/cli/src/run.test.ts
@@ -442,9 +442,10 @@ test('runs core commands against a vault and prints JSON output', async () => {
     }
   )
   assert.equal(versionCode, 0)
+  // Snapshot captured the pre-update file; files carry no title frontmatter
   assert.match(
     (JSON.parse(stdout.at(-1) ?? '{}') as { fileContent?: string }).fileContent ?? '',
-    /CLI Note/
+    /Created from CLI/
   )
 
   const attachmentSource = path.join(vaultPath, 'sample.txt')

--- a/apps/desktop/scripts/seed-data/journal.test.ts
+++ b/apps/desktop/scripts/seed-data/journal.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { seedDateOnly } from './date'
-import { JOURNAL_NOTES } from './journal'
+import { JOURNAL_METADATA, JOURNAL_NOTES } from './journal'
 
 describe('journal seed data', () => {
   it('has a generic journal entry for the day the seed command runs', () => {
@@ -12,8 +12,16 @@ describe('journal seed data', () => {
 
     const [entry] = todayEntries
     expect(entry.relativePath).toBe(`journal/${today}.md`)
-    expect(entry.frontmatter.title).toBe(today)
+    // User keys only — no Memry keys; title comes from the filename via metadata
+    expect(entry.frontmatter.id).toBeUndefined()
+    expect(entry.frontmatter.title).toBeUndefined()
+    expect(entry.frontmatter.mood).toBe(4)
     expect(entry.frontmatter.tags).toEqual(['daily', 'reflection'])
+    expect(entry.modified).toBeDefined()
+
+    const metadata = JOURNAL_METADATA.find((meta) => meta.journalDate === today)
+    expect(metadata?.title).toBe(today)
+    expect(metadata?.path).toBe(`journal/${today}.md`)
     expect(entry.body).toContain('A quiet day')
     expect(entry.body).toContain('## Schedule')
     expect(entry.body).toContain('## Tasks')

--- a/apps/desktop/scripts/seed-data/journal.ts
+++ b/apps/desktop/scripts/seed-data/journal.ts
@@ -273,15 +273,22 @@ const dateToModifiedISO = (date: string): string => {
 
 export const JOURNAL_NOTES: NoteFile[] = ENTRIES.map((entry) => ({
   relativePath: `journal/${entry.date}.md`,
+  // User keys only — no Memry keys; dates land on the file via mtime
   frontmatter: {
-    id: generateJournalId(entry.date),
-    title: entry.date,
-    created: dateToCreatedISO(entry.date),
-    modified: dateToModifiedISO(entry.date),
     date: entry.date,
-    journalDate: entry.date,
     mood: entry.mood,
-    tags: entry.tags
+    ...(entry.tags.length > 0 ? { tags: entry.tags } : {})
   },
-  body: entry.body
+  body: entry.body,
+  modified: dateToModifiedISO(entry.date)
+}))
+
+/** Canonical note_metadata rows so journal ids stay stable across indexing. */
+export const JOURNAL_METADATA = ENTRIES.map((entry) => ({
+  id: generateJournalId(entry.date),
+  path: `journal/${entry.date}.md`,
+  title: entry.date,
+  journalDate: entry.date,
+  createdAt: dateToCreatedISO(entry.date),
+  modifiedAt: dateToModifiedISO(entry.date)
 }))

--- a/apps/desktop/scripts/seed-data/notes.test.ts
+++ b/apps/desktop/scripts/seed-data/notes.test.ts
@@ -1,16 +1,26 @@
 import { describe, expect, it } from 'vitest'
 
-import { NOTES } from './notes'
+import { NOTES, NOTE_METADATA } from './notes'
 
 describe('notes seed data', () => {
   it('includes a consumer-facing Istanbul note that showcases note features', () => {
-    const istanbul = NOTES.find((note) => note.frontmatter.title === 'Istanbul')
+    const istanbul = NOTES.find((note) => note.relativePath === 'travel/Istanbul.md')
 
     expect(istanbul).toBeDefined()
-    expect(istanbul?.relativePath).toBe('travel/Istanbul.md')
+    // User keys only — no Memry keys in seed frontmatter
+    expect(istanbul?.frontmatter.id).toBeUndefined()
+    expect(istanbul?.frontmatter.title).toBeUndefined()
+    expect(istanbul?.frontmatter.created).toBeUndefined()
+    expect(istanbul?.frontmatter.modified).toBeUndefined()
     expect(istanbul?.frontmatter.tags).toEqual(['travel', 'istanbul', 'planning'])
     expect(istanbul?.frontmatter.location).toBe('Istanbul, Turkey')
     expect(istanbul?.frontmatter.status).toBe('planning')
+
+    // Identity + dates live in NOTE_METADATA (note_metadata seeding) and file mtime
+    const metadata = NOTE_METADATA.find((meta) => meta.path === 'travel/Istanbul.md')
+    expect(metadata?.title).toBe('Istanbul')
+    expect(metadata?.id).toBeTruthy()
+    expect(istanbul?.modified).toBe(metadata?.modifiedAt)
 
     const body = istanbul?.body ?? ''
 

--- a/apps/desktop/scripts/seed-data/notes.ts
+++ b/apps/desktop/scripts/seed-data/notes.ts
@@ -2169,21 +2169,27 @@ Pair with [[Kitchen Confidential]] for the *travel-as-eating* mindset.
   }
 ]
 
+/** Canonical note_metadata rows so note ids stay stable across indexing. */
+export const NOTE_METADATA = SPECS.map((spec) => ({
+  id: spec.id,
+  path: spec.relativePath,
+  title: spec.title,
+  emoji: spec.emoji ?? null,
+  createdAt: dayOffset(spec.daysAgoCreated),
+  modifiedAt: dayOffset(spec.daysAgoModified)
+}))
+
 export const NOTES: NoteFile[] = SPECS.map((spec) => {
-  const created = dayOffset(spec.daysAgoCreated)
   const modified = dayOffset(spec.daysAgoModified)
   return {
     relativePath: spec.relativePath,
+    // User keys only — no Memry keys in files; dates land on the file via mtime
     frontmatter: {
-      id: spec.id,
-      title: spec.title,
-      created,
-      modified,
-      tags: spec.tags,
+      ...(spec.tags.length > 0 ? { tags: spec.tags } : {}),
       ...(spec.aliases ? { aliases: spec.aliases } : {}),
-      ...(spec.emoji ? { emoji: spec.emoji } : {}),
       ...(spec.customProps ?? {})
     },
-    body: spec.body
+    body: spec.body,
+    modified
   }
 })

--- a/apps/desktop/scripts/seed-vault.ts
+++ b/apps/desktop/scripts/seed-vault.ts
@@ -20,6 +20,7 @@ import {
   insertFolderConfigs,
   insertInboxItems,
   insertProjects,
+  insertNoteMetadata,
   insertPropertyDefinitions,
   insertStatuses,
   insertTagDefinitions,
@@ -29,8 +30,8 @@ import {
   openDataDb
 } from './seed-vault/db-writer'
 
-import { FOLDER_CONFIGS, NOTES } from './seed-data/notes'
-import { JOURNAL_NOTES } from './seed-data/journal'
+import { FOLDER_CONFIGS, NOTES, NOTE_METADATA } from './seed-data/notes'
+import { JOURNAL_NOTES, JOURNAL_METADATA } from './seed-data/journal'
 import { PROJECTS, STATUSES, TASKS, TASK_NOTES, TASK_TAGS } from './seed-data/tasks'
 import { CALENDAR_EVENTS, CALENDAR_SOURCES } from './seed-data/calendar'
 import { FILING_HISTORY_ROWS, INBOX_ITEMS } from './seed-data/inbox'
@@ -149,6 +150,11 @@ function main(): void {
 
     const propCount = insertPropertyDefinitions(db, PROPERTY_DEFS)
     console.log(`  → property_definitions: ${propCount}`)
+
+    // Files carry no Memry ids — canonical rows keep seeded ids stable
+    // (task links reference NOTE_IDS) when the indexer adopts them by path
+    const noteMetaCount = insertNoteMetadata(db, [...NOTE_METADATA, ...JOURNAL_METADATA])
+    console.log(`  → note_metadata: ${noteMetaCount}`)
 
     const projectCount = insertProjects(db, PROJECTS)
     console.log(`  → projects: ${projectCount}`)

--- a/apps/desktop/scripts/seed-vault/db-writer.ts
+++ b/apps/desktop/scripts/seed-vault/db-writer.ts
@@ -52,6 +52,34 @@ export function insertTagDefinitions(db: DataDb, tags: SeedTagDefinition[]): num
   return tags.length
 }
 
+export interface SeedNoteMetadata {
+  id: string
+  path: string
+  title: string
+  emoji?: string | null
+  journalDate?: string | null
+  createdAt: string
+  modifiedAt: string
+}
+
+export function insertNoteMetadata(db: DataDb, notes: SeedNoteMetadata[]): number {
+  if (notes.length === 0) return 0
+  db.insert(schema.noteMetadata)
+    .values(
+      notes.map((n) => ({
+        id: n.id,
+        path: n.path,
+        title: n.title,
+        emoji: n.emoji ?? null,
+        journalDate: n.journalDate ?? null,
+        createdAt: n.createdAt,
+        modifiedAt: n.modifiedAt
+      }))
+    )
+    .run()
+  return notes.length
+}
+
 export interface SeedFolderConfig {
   path: string
   icon: string | null

--- a/apps/desktop/scripts/seed-vault/file-writer.ts
+++ b/apps/desktop/scripts/seed-vault/file-writer.ts
@@ -1,20 +1,25 @@
-import { writeFileSync, mkdirSync } from 'fs'
+import { writeFileSync, mkdirSync, utimesSync } from 'fs'
 import { dirname, resolve } from 'path'
 import matter from 'gray-matter'
 
 export interface NoteFile {
   /** Relative path inside the vault (e.g. "movies/Dune.md") */
   relativePath: string
-  /** Frontmatter object — id/title/created/modified must be set by the caller. */
+  /** User frontmatter keys only — no Memry keys (id/title/created/modified). */
   frontmatter: Record<string, unknown>
   /** Markdown body without YAML frontmatter. */
   body: string
+  /** ISO mtime to stamp on the file (dates come from fs stats, not frontmatter). */
+  modified?: string
 }
 
 function serialize(frontmatter: Record<string, unknown>, body: string): string {
   const cleanFrontmatter = Object.fromEntries(
     Object.entries(frontmatter).filter(([, v]) => v !== undefined)
   )
+  if (Object.keys(cleanFrontmatter).length === 0) {
+    return body.trim() + '\n'
+  }
   return matter.stringify(body.trim(), cleanFrontmatter).replace(/(?:\r?\n)+$/g, '') + '\n'
 }
 
@@ -22,6 +27,10 @@ function writeNoteFile(vaultRoot: string, file: NoteFile): void {
   const absolute = resolve(vaultRoot, file.relativePath)
   mkdirSync(dirname(absolute), { recursive: true })
   writeFileSync(absolute, serialize(file.frontmatter, file.body), 'utf8')
+  if (file.modified) {
+    const mtime = new Date(file.modified)
+    utimesSync(absolute, mtime, mtime)
+  }
 }
 
 export function writeNoteFiles(vaultRoot: string, files: NoteFile[]): number {

--- a/apps/desktop/src/main/database/queries/notes/index.ts
+++ b/apps/desktop/src/main/database/queries/notes/index.ts
@@ -6,7 +6,6 @@ export {
   getNoteCacheByPath,
   noteCacheExists,
   getLocalOnlyCount,
-  findDuplicateId,
   listNotesFromCache,
   countNotes,
   bulkInsertNotes,

--- a/apps/desktop/src/main/database/queries/notes/note-crud.ts
+++ b/apps/desktop/src/main/database/queries/notes/note-crud.ts
@@ -78,18 +78,6 @@ export function getLocalOnlyCount(db: IndexDb): number {
   return result?.count ?? 0
 }
 
-export function findDuplicateId(
-  db: IndexDb,
-  id: string,
-  excludePath: string
-): NoteCache | undefined {
-  return db
-    .select()
-    .from(noteCache)
-    .where(and(eq(noteCache.id, id), sql`${noteCache.path} != ${excludePath}`))
-    .get()
-}
-
 // ============================================================================
 // Note Listing
 // ============================================================================

--- a/apps/desktop/src/main/import/apple-notes/apple-notes-importer.test.ts
+++ b/apps/desktop/src/main/import/apple-notes/apple-notes-importer.test.ts
@@ -360,12 +360,12 @@ describe('appleNotesImporter (integration, synthetic NoteStore.sqlite)', () => {
     const ctx = importContext.createImportContext('an2', new AbortController().signal)
     await importer.appleNotesImporter.run({ sourcePaths: [dbPath] }, ctx)
 
-    const md = fs.readFileSync(
-      path.join(tempVault.notesDir, 'Apple Notes', 'Work', 'My Note.md'),
-      'utf8'
-    )
+    // Timestamps now live on the note record, not in the file.
+    const row = indexDb.sqlite
+      .prepare('SELECT created_at AS createdAt FROM note_cache WHERE path = ?')
+      .get('notes/Apple Notes/Work/My Note.md') as { createdAt: string } | undefined
     // created = 700000000 CoreTime → 2023 (see coreTimeToIso).
-    expect(md).toContain('2023-03-08')
+    expect(row?.createdAt).toContain('2023-03-08')
   })
 
   it('stops early when cancelled', async () => {

--- a/apps/desktop/src/main/import/csv/csv-importer.test.ts
+++ b/apps/desktop/src/main/import/csv/csv-importer.test.ts
@@ -92,11 +92,14 @@ describe('csvImporter (integration)', () => {
     const files = fs.readdirSync(csvDir)
     expect(files).toHaveLength(4)
 
-    // Check a note that has a comma in a quoted field
+    // Check a note that has a comma in a quoted field — the title now lives
+    // on the note record, not in the file's frontmatter
     const buyFile = files.find((f) => f.includes('Buy milk'))
     expect(buyFile).toBeTruthy()
-    const content = fs.readFileSync(path.join(csvDir, buyFile!), 'utf8')
-    expect(content).toContain('Buy milk, eggs')
+    const buyRow = indexDb.sqlite
+      .prepare('SELECT title FROM note_cache WHERE path = ?')
+      .get(`notes/CSV/${buyFile}`) as { title: string } | undefined
+    expect(buyRow?.title).toBe('Buy milk, eggs')
 
     // Check properties are saved (Tags column should appear as frontmatter property)
     const kickoffFile = files.find((f) => f.includes('Project kickoff'))

--- a/apps/desktop/src/main/import/evernote/evernote-importer.test.ts
+++ b/apps/desktop/src/main/import/evernote/evernote-importer.test.ts
@@ -117,11 +117,18 @@ describe('evernoteImporter (integration)', () => {
 
     const evernoteDir = path.join(tempVault.notesDir, 'Evernote', 'sample')
     const noteFiles = fs.readdirSync(evernoteDir)
-    const notePath = path.join(evernoteDir, noteFiles.find((f) => f.endsWith('.md'))!)
-    const content = fs.readFileSync(notePath, 'utf8')
+    const noteFile = noteFiles.find((f) => f.endsWith('.md'))!
 
-    // Frontmatter should have created/modified dates from the enex
-    expect(content).toContain('2023-10-15')
+    // Created/modified dates from the enex now live on the note record, not in the file
+    const row = indexDb.sqlite
+      .prepare(
+        'SELECT created_at AS createdAt, modified_at AS modifiedAt FROM note_cache WHERE path = ?'
+      )
+      .get(`notes/Evernote/sample/${noteFile}`) as
+      | { createdAt: string; modifiedAt: string }
+      | undefined
+    expect(row?.createdAt).toContain('2023-10-15')
+    expect(row?.modifiedAt).toContain('2023-10-16')
   })
 
   it('stops early when cancelled before processing', async () => {

--- a/apps/desktop/src/main/import/google-keep/google-keep-importer.test.ts
+++ b/apps/desktop/src/main/import/google-keep/google-keep-importer.test.ts
@@ -144,11 +144,12 @@ describe('googleKeepImporter (integration)', () => {
     const ctx = importContext.createImportContext('it5', new AbortController().signal)
     await importer.googleKeepImporter.run({ sourcePaths: [FIXTURE] }, ctx)
 
-    const keepDir = path.join(tempVault.notesDir, 'Google Keep')
-    const textFile = path.join(keepDir, 'My Text Note.md')
-    const content = fs.readFileSync(textFile, 'utf8')
+    // Timestamps now live on the note record, not in the file.
+    const row = indexDb.sqlite
+      .prepare('SELECT created_at AS createdAt FROM note_cache WHERE path = ?')
+      .get('notes/Google Keep/My Text Note.md') as { createdAt: string } | undefined
     // createdTimestampUsec: 1_609_459_200_000_000 → 2021-01-01
-    expect(content).toContain('2021-01-01')
+    expect(row?.createdAt).toContain('2021-01-01')
   })
 
   it('skips .html files — only 3 notes, not 4', async () => {

--- a/apps/desktop/src/main/import/markdown/markdown-importer.test.ts
+++ b/apps/desktop/src/main/import/markdown/markdown-importer.test.ts
@@ -131,9 +131,15 @@ describe('markdownImporter (integration)', () => {
     const ctx = importContext.createImportContext('it4', new AbortController().signal)
     await importer.markdownImporter.run({ sourcePaths: [FIXTURE_DIR] }, ctx)
 
-    // root-note.md has title: "Root Note" in frontmatter
+    // root-note.md has title: "Root Note" in frontmatter — the title now lives
+    // in the filename and the note cache, never in the file's frontmatter.
     const rootNote = path.join(tempVault.notesDir, 'Markdown', 'Root Note.md')
-    const content = fs.readFileSync(rootNote, 'utf8')
-    expect(content).toContain('Root Note')
+    expect(fs.existsSync(rootNote)).toBe(true)
+    expect(fs.readFileSync(rootNote, 'utf8')).not.toContain('title:')
+
+    const row = indexDb.sqlite
+      .prepare('SELECT title FROM note_cache WHERE path = ?')
+      .get('notes/Markdown/Root Note.md') as { title: string } | undefined
+    expect(row?.title).toBe('Root Note')
   })
 })

--- a/apps/desktop/src/main/import/notion/notion-importer.test.ts
+++ b/apps/desktop/src/main/import/notion/notion-importer.test.ts
@@ -105,11 +105,12 @@ describe('notionImporter (integration)', () => {
     const ctx = importContext.createImportContext('it2', new AbortController().signal)
     await importer.notionImporter.run({ sourcePaths: [FIXTURE] }, ctx)
 
-    const child = fs.readFileSync(
-      path.join(tempVault.notesDir, 'Notion', 'Parent Page', 'Child Page.md'),
-      'utf8'
-    )
-    expect(child).toContain('2024-03-05')
+    // Timestamps now live on the note record, not in the file.
+    const row = indexDb.sqlite
+      .prepare('SELECT created_at AS createdAt FROM note_cache WHERE path = ?')
+      .get('notes/Notion/Parent Page/Child Page.md') as { createdAt: string } | undefined
+    // Child Page was created March 5, 2024 in the export.
+    expect(row?.createdAt).toContain('2024-03-05')
   })
 
   it('stops early when cancelled', async () => {

--- a/apps/desktop/src/main/ipc/journal-handlers.ts
+++ b/apps/desktop/src/main/ipc/journal-handlers.ts
@@ -132,7 +132,10 @@ export function registerJournalHandlers(): void {
           path: journalPath,
           fileContent,
           frontmatter,
-          parsedContent: entry.content
+          parsedContent: entry.content,
+          title: entry.date,
+          createdAt: entry.createdAt,
+          modifiedAt: entry.modifiedAt
         },
         { isNew: !cached }
       )
@@ -184,7 +187,10 @@ export function registerJournalHandlers(): void {
             path: journalPath,
             fileContent,
             frontmatter,
-            parsedContent: entry.content
+            parsedContent: entry.content,
+            title: entry.date,
+            createdAt: entry.createdAt,
+            modifiedAt: entry.modifiedAt
           },
           { isNew: !cached }
         )
@@ -216,11 +222,8 @@ export function registerJournalHandlers(): void {
           // Create the current file content (before save) for snapshot
           // Include existing properties in snapshot frontmatter
           const snapshotFrontmatter: Parameters<typeof serializeJournalEntry>[0] = {
-            id: existing.id,
             date: existing.date,
-            created: existing.createdAt,
-            modified: existing.modifiedAt,
-            tags: existing.tags
+            ...(existing.tags.length > 0 ? { tags: existing.tags } : {})
           }
           if (existing.properties && Object.keys(existing.properties).length > 0) {
             snapshotFrontmatter.properties = existing.properties
@@ -255,7 +258,10 @@ export function registerJournalHandlers(): void {
           path: journalPath,
           fileContent,
           frontmatter,
-          parsedContent: entry.content
+          parsedContent: entry.content,
+          title: entry.date,
+          createdAt: entry.createdAt,
+          modifiedAt: entry.modifiedAt
         },
         { isNew: !cached }
       )

--- a/apps/desktop/src/main/ipc/properties-handlers.ts
+++ b/apps/desktop/src/main/ipc/properties-handlers.ts
@@ -193,7 +193,10 @@ async function updateJournalProperties(
       path: journalPath,
       fileContent,
       frontmatter,
-      parsedContent: entry.content
+      parsedContent: entry.content,
+      title: entry.date,
+      createdAt: entry.createdAt,
+      modifiedAt: entry.modifiedAt
     },
     { isNew: false }
   )

--- a/apps/desktop/src/main/notes/domain.test.ts
+++ b/apps/desktop/src/main/notes/domain.test.ts
@@ -5,7 +5,8 @@ vi.mock('../vault/notes', () => ({
   updateNote: vi.fn(),
   renameNote: vi.fn(),
   moveNote: vi.fn(),
-  deleteNote: vi.fn()
+  deleteNote: vi.fn(),
+  getNoteById: vi.fn()
 }))
 
 vi.mock('./runtime-effects', () => ({
@@ -59,8 +60,8 @@ describe('notes domain adapter', () => {
       id: 'note-1',
       title: 'Test Note'
     }
-    vi.mocked(noteVault.updateNote).mockResolvedValue(
-      note as Awaited<ReturnType<typeof noteVault.updateNote>>
+    vi.mocked(noteVault.getNoteById).mockResolvedValue(
+      note as Awaited<ReturnType<typeof noteVault.getNoteById>>
     )
 
     const result = await setNoteLocalOnlyCommand({
@@ -69,11 +70,10 @@ describe('notes domain adapter', () => {
     })
 
     expect(result).toBe(note)
-    expect(noteVault.updateNote).toHaveBeenCalledWith({
-      id: 'note-1',
-      frontmatter: { localOnly: true }
-    })
+    // localOnly is sidecar-only state — never written to file frontmatter
+    expect(noteVault.updateNote).not.toHaveBeenCalled()
     expect(runtimeEffects.setNoteLocalOnlyState).toHaveBeenCalledWith('note-1', true)
+    expect(noteVault.getNoteById).toHaveBeenCalledWith('note-1')
   })
 
   it('keeps note mutation sync orchestration out of IPC handlers', async () => {

--- a/apps/desktop/src/main/notes/domain.ts
+++ b/apps/desktop/src/main/notes/domain.ts
@@ -4,10 +4,12 @@ import {
   renameNote,
   moveNote,
   deleteNote,
+  getNoteById,
   type Note,
   type NoteCreateInput,
   type NoteUpdateInput
 } from '../vault/notes'
+import { NoteError, NoteErrorCode } from '../lib/errors'
 import {
   syncNoteCreate,
   syncNoteUpdate,
@@ -58,10 +60,11 @@ export async function setNoteLocalOnlyCommand(input: {
   id: string
   localOnly: boolean
 }): Promise<Note> {
-  const note = await updateNote({
-    id: input.id,
-    frontmatter: { localOnly: input.localOnly }
-  })
+  // localOnly is sidecar-only state — never written to the file
   setNoteLocalOnlyState(input.id, input.localOnly)
+  const note = await getNoteById(input.id)
+  if (!note) {
+    throw new NoteError(`Note not found: ${input.id}`, NoteErrorCode.NOT_FOUND, input.id)
+  }
   return note
 }

--- a/apps/desktop/src/main/notes/runtime-effects.ts
+++ b/apps/desktop/src/main/notes/runtime-effects.ts
@@ -1,5 +1,6 @@
 import { updateNoteMetadata } from '@memry/storage-data'
-import { getDatabase } from '../database'
+import { updateNoteCache } from '@main/database/queries/notes'
+import { getDatabase, getIndexDatabase } from '../database'
 import { attachmentEvents } from '../sync/attachment-events'
 import { getCrdtProvider } from '../sync/crdt-provider'
 import {
@@ -36,6 +37,8 @@ export function setNoteLocalOnlyState(noteId: string, localOnly: boolean): void 
     localOnly,
     syncPolicy: localOnly ? 'local-only' : 'sync'
   })
+  // localOnly is sidecar-only state — keep the index cache in step too
+  updateNoteCache(getIndexDatabase(), noteId, { localOnly })
 
   if (localOnly) {
     removePendingNoteSyncItems(noteId)

--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -5,6 +5,7 @@ import { JournalChannels, NotesChannels } from '@memry/contracts/ipc-channels'
 const mocks = vi.hoisted(() => ({
   yDocToMarkdown: vi.fn(),
   getNoteCacheById: vi.fn(),
+  getNoteCacheByPath: vi.fn(),
   atomicWrite: vi.fn(),
   safeRead: vi.fn(),
   fileExists: vi.fn(),
@@ -103,7 +104,8 @@ vi.mock('../database/client', () => ({
 }))
 
 vi.mock('@main/database/queries/notes', () => ({
-  getNoteCacheById: (...args: unknown[]) => mocks.getNoteCacheById(...args)
+  getNoteCacheById: (...args: unknown[]) => mocks.getNoteCacheById(...args),
+  getNoteCacheByPath: (...args: unknown[]) => mocks.getNoteCacheByPath(...args)
 }))
 
 vi.mock('@memry/app-core/reminders', () => ({
@@ -148,6 +150,7 @@ describe('crdt writeback', () => {
       path: 'notes/Existing.md',
       title: 'Existing'
     })
+    mocks.getNoteCacheByPath.mockReturnValue(undefined)
     mocks.safeRead.mockResolvedValue('---\ntitle: Existing\n---\nold markdown')
     mocks.parseNote.mockReturnValue({
       frontmatter: { id: 'note-1', title: 'Existing', tags: ['old'] },
@@ -308,15 +311,21 @@ describe('crdt writeback', () => {
   it('writes a collision file when a synced journal date already belongs to another id', async () => {
     mocks.getNoteCacheById.mockReturnValue(undefined)
     mocks.fileExists.mockResolvedValue(true)
-    mocks.safeRead.mockResolvedValue('---\nid: local-journal\n---\nlocal')
-    mocks.parseNote.mockReturnValue({
-      frontmatter: { id: 'local-journal' },
-      content: 'local'
+    // Collision detection keys on the note_cache row at the journal path,
+    // not on a frontmatter id (files no longer carry one)
+    mocks.getNoteCacheByPath.mockReturnValue({
+      id: 'local-journal',
+      path: 'journal/2026-01-03.md',
+      title: '2026-01-03'
     })
 
     scheduleWriteback('j2026-01-03', makeDoc('Collision'))
     await vi.advanceTimersByTimeAsync(500)
 
+    expect(mocks.getNoteCacheByPath).toHaveBeenCalledWith(
+      { kind: 'index-db' },
+      'journal/2026-01-03.md'
+    )
     expect(mocks.atomicWrite).toHaveBeenCalledWith(
       '/vault/journal/2026-01-03-j2026-01.md',
       expect.stringContaining('updated markdown')

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -22,7 +22,7 @@ import { getJournalPath } from '../vault/journal'
 import { syncNoteToCache, deleteNoteFromCache } from '../vault/note-sync'
 import { flushProjectionEvents } from '../projections'
 import { getIndexDatabase, getDatabase } from '../database/client'
-import { getNoteCacheById } from '@main/database/queries/notes'
+import { getNoteCacheById, getNoteCacheByPath } from '@main/database/queries/notes'
 import { createRemindersService } from '@memry/app-core/reminders'
 import { syncNoteDateReminders, clearNoteDateReminders } from '../notes/note-date-reminders'
 import { deleteFile } from '../vault/file-ops'
@@ -185,7 +185,7 @@ async function performWriteback(noteId: string, doc: Y.Doc): Promise<void> {
     await writebackJournal(noteId, doc, markdown, cached, indexDb)
   } else {
     if (cached) {
-      await writebackExisting(noteId, cached.path, doc, markdown, indexDb)
+      await writebackExisting(noteId, cached, doc, markdown, indexDb)
     } else {
       await writebackNewNote(noteId, doc, markdown, indexDb)
     }
@@ -199,11 +199,12 @@ async function performWriteback(noteId: string, doc: Y.Doc): Promise<void> {
 
 async function writebackExisting(
   noteId: string,
-  relativePath: string,
+  cached: NonNullable<ReturnType<typeof getNoteCacheById>>,
   doc: Y.Doc,
   markdown: string,
   indexDb: ReturnType<typeof getIndexDatabase>
 ): Promise<void> {
+  const relativePath = cached.path
   const absolutePath = toAbsolutePath(relativePath)
 
   const existingRaw = await safeRead(absolutePath)
@@ -212,14 +213,13 @@ async function writebackExisting(
   if (existingRaw) {
     const parsed = parseNote(existingRaw, absolutePath)
     existingFrontmatter = parsed.frontmatter
-    const title = existingFrontmatter?.title || 'Untitled'
     try {
       const snap = maybeCreateSignificantSnapshot(
         noteId,
         existingRaw,
         parsed.content,
         markdown,
-        title
+        cached.title
       )
       if (snap) log.info('Snapshot created during writeback', { noteId, snapshotId: snap.id })
     } catch (err) {
@@ -227,7 +227,7 @@ async function writebackExisting(
     }
   }
 
-  const mergedFrontmatter = mergeFrontmatter(noteId, existingFrontmatter, doc)
+  const mergedFrontmatter = mergeFrontmatter(existingFrontmatter, doc)
   const fileContent = serializeNote(mergedFrontmatter, markdown)
 
   ignoredWrites.set(absolutePath, Date.now())
@@ -240,7 +240,12 @@ async function writebackExisting(
       path: relativePath,
       fileContent,
       frontmatter: mergedFrontmatter,
-      parsedContent: markdown
+      parsedContent: markdown,
+      title: cached.title,
+      createdAt: cached.createdAt,
+      modifiedAt: utcNow(),
+      localOnly: cached.localOnly ?? false,
+      emoji: cached.emoji ?? null
     },
     { isNew: false }
   )
@@ -263,7 +268,7 @@ async function writebackNewNote(
   const absolutePath = generateNotePath(notesDir, title)
   const relativePath = toRelativePath(absolutePath)
 
-  const frontmatter = mergeFrontmatter(noteId, null, doc)
+  const frontmatter = mergeFrontmatter(null, doc)
   const fileContent = serializeNote(frontmatter, markdown)
 
   ignoredWrites.set(absolutePath, Date.now())
@@ -271,7 +276,16 @@ async function writebackNewNote(
 
   syncNoteToCache(
     indexDb,
-    { id: noteId, path: relativePath, fileContent, frontmatter, parsedContent: markdown },
+    {
+      id: noteId,
+      path: relativePath,
+      fileContent,
+      frontmatter,
+      parsedContent: markdown,
+      title,
+      createdAt: (meta.get('date') as string) || utcNow(),
+      modifiedAt: utcNow()
+    },
     { isNew: true }
   )
   void flushProjectionEvents()
@@ -301,21 +315,15 @@ async function writebackJournal(
     const existingRaw = await safeRead(absolutePath)
     const existing = existingRaw ? parseNote(existingRaw, absolutePath).frontmatter : null
 
-    if (existing && existing.id !== noteId) {
-      await handleJournalCollision(noteId, date, existing.id, doc, markdown, indexDb)
-      return
-    }
-
     if (existingRaw) {
       const parsed = parseNote(existingRaw, absolutePath)
-      const title = existing?.title || `Journal ${date}`
       try {
         const snap = maybeCreateSignificantSnapshot(
           noteId,
           existingRaw,
           parsed.content,
           markdown,
-          title
+          cached.title
         )
         if (snap)
           log.info('Journal snapshot created during writeback', { noteId, snapshotId: snap.id })
@@ -324,7 +332,7 @@ async function writebackJournal(
       }
     }
 
-    const mergedFrontmatter = mergeJournalFrontmatter(noteId, date, existing, doc)
+    const mergedFrontmatter = mergeJournalFrontmatter(date, existing, doc)
     const fileContent = serializeNote(mergedFrontmatter, markdown)
 
     ignoredWrites.set(absolutePath, Date.now())
@@ -337,7 +345,12 @@ async function writebackJournal(
         path: cached.path,
         fileContent,
         frontmatter: mergedFrontmatter,
-        parsedContent: markdown
+        parsedContent: markdown,
+        title: cached.title,
+        createdAt: cached.createdAt,
+        modifiedAt: utcNow(),
+        localOnly: cached.localOnly ?? false,
+        emoji: cached.emoji ?? null
       },
       { isNew: false }
     )
@@ -348,18 +361,17 @@ async function writebackJournal(
   }
 
   if (await fileExists(journalPath)) {
-    const raw = await safeRead(journalPath)
-    if (raw) {
-      const parsed = parseNote(raw, journalPath)
-      if (parsed.frontmatter.id !== noteId) {
-        await handleJournalCollision(noteId, date, parsed.frontmatter.id, doc, markdown, indexDb)
-        return
-      }
+    // File identity lives in the sidecar: a cache row at this path owned by a
+    // different (or unknown) note means the date file is already claimed
+    const rowAtPath = getNoteCacheByPath(indexDb, toRelativePath(journalPath))
+    if (rowAtPath?.id !== noteId) {
+      await handleJournalCollision(noteId, date, rowAtPath?.id ?? 'unknown', doc, markdown, indexDb)
+      return
     }
   }
 
   const relativePath = toRelativePath(journalPath)
-  const frontmatter = mergeJournalFrontmatter(noteId, date, null, doc)
+  const frontmatter = mergeJournalFrontmatter(date, null, doc)
   const fileContent = serializeNote(frontmatter, markdown)
 
   ignoredWrites.set(journalPath, Date.now())
@@ -367,7 +379,16 @@ async function writebackJournal(
 
   syncNoteToCache(
     indexDb,
-    { id: noteId, path: relativePath, fileContent, frontmatter, parsedContent: markdown },
+    {
+      id: noteId,
+      path: relativePath,
+      fileContent,
+      frontmatter,
+      parsedContent: markdown,
+      title: path.basename(journalPath, '.md'),
+      createdAt: utcNow(),
+      modifiedAt: utcNow()
+    },
     { isNew: true }
   )
   void flushProjectionEvents()
@@ -394,7 +415,7 @@ async function handleJournalCollision(
   const collisionPath = path.join(journalDir, collisionFilename)
   const relativePath = toRelativePath(collisionPath)
 
-  const frontmatter = mergeJournalFrontmatter(incomingId, date, null, doc)
+  const frontmatter = mergeJournalFrontmatter(date, null, doc)
   const fileContent = serializeNote(frontmatter, markdown)
 
   await ensureDirectory(journalDir)
@@ -403,7 +424,16 @@ async function handleJournalCollision(
 
   syncNoteToCache(
     indexDb,
-    { id: incomingId, path: relativePath, fileContent, frontmatter, parsedContent: markdown },
+    {
+      id: incomingId,
+      path: relativePath,
+      fileContent,
+      frontmatter,
+      parsedContent: markdown,
+      title: path.basename(collisionPath, '.md'),
+      createdAt: utcNow(),
+      modifiedAt: utcNow()
+    },
     { isNew: true }
   )
   void flushProjectionEvents()
@@ -456,61 +486,26 @@ export async function handleSyncDeletion(noteId: string): Promise<void> {
   log.info('Deleted from sync', { noteId })
 }
 
-function mergeFrontmatter(
-  noteId: string,
-  existing: NoteFrontmatter | null,
-  doc: Y.Doc
-): NoteFrontmatter {
-  const meta = doc.getMap('meta')
-  const yjsTitle = meta.get('title') as string | undefined
+/**
+ * Merge write-back frontmatter: user keys pass through verbatim, CRDT tags
+ * win when present. No Memry keys are ever injected.
+ */
+function mergeFrontmatter(existing: NoteFrontmatter | null, doc: Y.Doc): NoteFrontmatter {
   const yjsTags = getYjsTags(doc)
-
-  const indexDb = getIndexDatabase()
-  const cached = getNoteCacheById(indexDb, noteId)
-  const authorityTitle = cached?.title
-
-  if (!existing) {
-    return {
-      id: noteId,
-      title: authorityTitle || yjsTitle,
-      created: (meta.get('date') as string) || utcNow(),
-      modified: utcNow(),
-      tags: yjsTags.length > 0 ? yjsTags : undefined
-    }
-  }
-
-  return {
-    ...existing,
-    title: authorityTitle || existing.title || yjsTitle,
-    modified: utcNow(),
-    tags: yjsTags.length > 0 ? yjsTags : existing.tags
-  }
+  const merged: NoteFrontmatter = { ...(existing ?? {}) }
+  if (yjsTags.length > 0) merged.tags = yjsTags
+  return merged
 }
 
 function mergeJournalFrontmatter(
-  noteId: string,
   date: string,
   existing: NoteFrontmatter | null,
   doc: Y.Doc
 ): NoteFrontmatter {
   const yjsTags = getYjsTags(doc)
-
-  if (!existing) {
-    return {
-      id: noteId,
-      date,
-      created: utcNow(),
-      modified: utcNow(),
-      tags: yjsTags.length > 0 ? yjsTags : undefined
-    }
-  }
-
-  return {
-    ...existing,
-    date,
-    modified: utcNow(),
-    tags: yjsTags.length > 0 ? yjsTags : existing.tags
-  }
+  const merged: NoteFrontmatter = { ...(existing ?? {}), date }
+  if (yjsTags.length > 0) merged.tags = yjsTags
+  return merged
 }
 
 function getYjsTags(doc: Y.Doc): string[] {

--- a/apps/desktop/src/main/sync/item-handlers/journal-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/journal-handler.ts
@@ -77,7 +77,10 @@ class JournalHandler extends BaseItemHandler<JournalSyncPayload> {
               path: getJournalRelativePath(entry.date),
               fileContent,
               frontmatter,
-              parsedContent: entry.content
+              parsedContent: entry.content,
+              title: entry.date,
+              createdAt: entry.createdAt,
+              modifiedAt: data.modifiedAt ?? entry.modifiedAt
             },
             { isNew: false }
           )
@@ -118,7 +121,10 @@ class JournalHandler extends BaseItemHandler<JournalSyncPayload> {
             path: getJournalRelativePath(entry.date),
             fileContent,
             frontmatter,
-            parsedContent: entry.content
+            parsedContent: entry.content,
+            title: entry.date,
+            createdAt: entry.createdAt,
+            modifiedAt: entry.modifiedAt
           },
           { isNew: true }
         )

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.ts
@@ -209,7 +209,6 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
       })
 
       const resolvedEmoji = data.emoji ?? existing.emoji
-      const emojiChanged = data.emoji !== undefined && data.emoji !== existing.emoji
 
       const updateFields: Parameters<typeof updateNoteCache>[2] = {
         title: newTitle,
@@ -232,31 +231,37 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
         updateFields.path = newRelPath
 
         try {
-          const raw = fs.readFileSync(oldAbsPath, 'utf-8')
-          const parsed = parseNote(raw)
-          parsed.frontmatter.title = newTitle
-          if (tagsChanged && remoteTags) {
-            parsed.frontmatter.tags = remoteTags
-          }
-          if (propertiesPresent) {
-            if (Object.keys(remoteProperties).length > 0) {
-              parsed.frontmatter.properties = remoteProperties
-            } else {
-              delete parsed.frontmatter.properties
-            }
-          }
-          if (emojiChanged) {
-            parsed.frontmatter.emoji = resolvedEmoji
-          }
-          const updatedContent = serializeNote(parsed.frontmatter, parsed.content)
-
           markWritebackIgnored(newAbsPath)
           const dir = path.dirname(newAbsPath)
           fs.mkdirSync(dir, { recursive: true })
-          const tmpPath = newAbsPath + '.tmp'
-          fs.writeFileSync(tmpPath, updatedContent, 'utf-8')
-          fs.renameSync(tmpPath, newAbsPath)
-          fs.unlinkSync(oldAbsPath)
+
+          if ((tagsChanged && remoteTags) || propertiesPresent) {
+            // Content actually changed — rewrite user keys only
+            const raw = fs.readFileSync(oldAbsPath, 'utf-8')
+            const parsed = parseNote(raw)
+            if (tagsChanged && remoteTags) {
+              if (remoteTags.length > 0) {
+                parsed.frontmatter.tags = remoteTags
+              } else {
+                delete parsed.frontmatter.tags
+              }
+            }
+            if (propertiesPresent) {
+              if (Object.keys(remoteProperties).length > 0) {
+                parsed.frontmatter.properties = remoteProperties
+              } else {
+                delete parsed.frontmatter.properties
+              }
+            }
+            const updatedContent = serializeNote(parsed.frontmatter, parsed.content)
+            const tmpPath = newAbsPath + '.tmp'
+            fs.writeFileSync(tmpPath, updatedContent, 'utf-8')
+            fs.renameSync(tmpPath, newAbsPath)
+            fs.unlinkSync(oldAbsPath)
+          } else {
+            // Pure rename/move — file bytes untouched
+            fs.renameSync(oldAbsPath, newAbsPath)
+          }
           removeEmptyParents(path.dirname(oldAbsPath), notesDir).catch(() => {})
         } catch {
           log.warn('Could not read old note for rename/move', { itemId })
@@ -280,13 +285,18 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
             source: 'sync'
           })
         }
-      } else if ((tagsChanged && remoteTags) || propertiesPresent || emojiChanged) {
+      } else if ((tagsChanged && remoteTags) || propertiesPresent) {
+        // emoji is sidecar-only state — never a reason to rewrite the file
         const absPath = toAbsolutePath(existing.path)
         try {
           const raw = fs.readFileSync(absPath, 'utf-8')
           const parsed = parseNote(raw)
           if (tagsChanged && remoteTags) {
-            parsed.frontmatter.tags = remoteTags
+            if (remoteTags.length > 0) {
+              parsed.frontmatter.tags = remoteTags
+            } else {
+              delete parsed.frontmatter.tags
+            }
           }
           if (propertiesPresent) {
             if (Object.keys(remoteProperties).length > 0) {
@@ -294,9 +304,6 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
             } else {
               delete parsed.frontmatter.properties
             }
-          }
-          if (emojiChanged) {
-            parsed.frontmatter.emoji = resolvedEmoji
           }
           const updatedContent = serializeNote(parsed.frontmatter, parsed.content)
           markWritebackIgnored(absPath)
@@ -412,17 +419,13 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
 
     const content = data.content ?? ''
 
+    // User keys only — Memry state (id, title, dates, emoji) stays in the DBs
     const frontmatter: NoteFrontmatter = {
-      id: itemId,
-      title,
-      created: data.createdAt ?? now,
-      modified: data.modifiedAt ?? now,
-      tags: data.tags ?? [],
+      ...(data.tags?.length ? { tags: data.tags } : {}),
       ...(data.aliases?.length ? { aliases: data.aliases } : {}),
       ...(data.properties && Object.keys(data.properties).length > 0
         ? { properties: data.properties }
-        : {}),
-      ...(data.emoji ? { emoji: data.emoji } : {})
+        : {})
     }
 
     const fileContent = serializeNote(frontmatter, content)
@@ -435,7 +438,17 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
 
     syncNoteToCache(
       indexDb,
-      { id: itemId, path: relPath, fileContent, frontmatter, parsedContent: content },
+      {
+        id: itemId,
+        path: relPath,
+        fileContent,
+        frontmatter,
+        parsedContent: content,
+        title,
+        createdAt: data.createdAt ?? now,
+        modifiedAt: data.modifiedAt ?? now,
+        emoji: data.emoji ?? null
+      },
       { isNew: true }
     )
     void flushProjectionEvents()

--- a/apps/desktop/src/main/vault/frontmatter.test.ts
+++ b/apps/desktop/src/main/vault/frontmatter.test.ts
@@ -3,8 +3,6 @@ import matter from 'gray-matter'
 import {
   parseNote,
   serializeNote,
-  createFrontmatter,
-  ensureFrontmatter,
   validateNoteId,
   extractTitleFromPath,
   extractWikiLinks,
@@ -32,12 +30,10 @@ afterEach(() => {
 })
 
 describe('frontmatter parsing', () => {
-  it('parseNote extracts YAML frontmatter and normalizes fields', () => {
+  it('parseNote keeps user keys verbatim and normalizes tags/aliases', () => {
     const raw = `---
 id: abc123def456
 title: Sample Note
-created: 2026-01-01T00:00:00.000Z
-modified: 2026-01-02T00:00:00.000Z
 tags:
   - Work
   - Personal
@@ -49,82 +45,68 @@ Hello world
 
     const parsed = parseNote(raw)
     expect(parsed.hadFrontmatter).toBe(true)
-    expect(parsed.wasModified).toBe(true)
     expect(parsed.content).toBe('Hello world')
+    // Legacy Memry keys are plain user properties, never interpreted
     expect(parsed.frontmatter.id).toBe('abc123def456')
+    expect(parsed.frontmatter.title).toBe('Sample Note')
     expect(parsed.frontmatter.tags).toEqual(['Work', 'Personal'])
     expect(parsed.frontmatter.aliases).toEqual(['alias-one'])
+    // In-memory identity is fresh, not read from the file
+    expect(parsed.id).not.toBe('abc123def456')
+    expect(parsed.id).toMatch(/^[0-9a-z]{12}$/)
   })
 
-  it('parseNote handles content without frontmatter', () => {
+  it('parseNote generates in-memory defaults without touching frontmatter', () => {
     const raw = 'Just content'
     const parsed = parseNote(raw, 'notes/my-sample.md')
     expect(parsed.hadFrontmatter).toBe(false)
-    expect(parsed.wasModified).toBe(true)
-    expect(parsed.frontmatter.created).toBe(FIXED_ISO)
-    expect(parsed.frontmatter.modified).toBe(FIXED_ISO)
-    expect(parsed.frontmatter.title).toBe('My Sample')
-    expect(parsed.frontmatter.id).toMatch(/^[0-9a-z]{12}$/)
+    expect(parsed.frontmatter).toEqual({})
+    expect(parsed.id).toMatch(/^[0-9a-z]{12}$/)
+    expect(parsed.title).toBe('my-sample')
+    expect(parsed.created).toBe(FIXED_ISO)
+    expect(parsed.modified).toBe(FIXED_ISO)
     expect(parsed.content).toBe('Just content')
+  })
+
+  it('parseNote derives created/modified from fs stats when provided', () => {
+    const birthtime = new Date('2025-06-01T08:00:00.000Z')
+    const mtime = new Date('2025-06-02T09:30:00.000Z')
+    const parsed = parseNote('Body', 'notes/dated.md', { birthtime, mtime })
+    expect(parsed.created).toBe('2025-06-01T08:00:00.000Z')
+    expect(parsed.modified).toBe('2025-06-02T09:30:00.000Z')
   })
 })
 
 describe('frontmatter serialization', () => {
-  it('serializeNote updates modified and preserves trimmed content', () => {
+  it('serializeNote writes only the given keys and never bumps modified', () => {
     const frontmatter: NoteFrontmatter = {
-      id: 'abc123def456',
-      title: 'Serialized Note',
-      created: '2026-01-01T00:00:00.000Z',
-      modified: '2026-01-02T00:00:00.000Z'
+      tags: ['tag-one'],
+      rating: 5
     }
 
     const output = serializeNote(frontmatter, 'Body text\n')
     const parsed = matter(output)
 
-    expect(parsed.data.modified).toBe(FIXED_ISO)
-    expect(parsed.content).toBe('Body text')
+    expect(parsed.data).toEqual({ tags: ['tag-one'], rating: 5 })
+    expect(parsed.data.modified).toBeUndefined()
+    expect(parsed.content.trim()).toBe('Body text')
   })
 
-  it('createFrontmatter generates defaults for new notes', () => {
-    const frontmatter = createFrontmatter('New Note', ['tag-one'])
-    expect(frontmatter.title).toBe('New Note')
-    expect(frontmatter.tags).toEqual(['tag-one'])
-    expect(frontmatter.created).toBe(FIXED_ISO)
-    expect(frontmatter.modified).toBe(FIXED_ISO)
-    expect(validateNoteId(frontmatter.id)).toBe(true)
+  it('serializeNote returns bare content when no keys remain', () => {
+    expect(serializeNote({}, 'Body text\n')).toBe('Body text')
+    expect(serializeNote({ skipped: undefined }, 'Body text')).toBe('Body text')
   })
 })
 
 describe('frontmatter utilities', () => {
-  it('ensureFrontmatter adds missing frontmatter', () => {
-    const raw = 'Plain content'
-    const updated = ensureFrontmatter(raw, '/notes/new-note.md')
-    const parsed = matter(updated)
-
-    expect(parsed.content).toBe('Plain content')
-    expect(parsed.data.title).toBe('New Note')
-    expect(parsed.data.created).toBe(FIXED_ISO)
-    expect(parsed.data.modified).toBe(FIXED_ISO)
-    expect(parsed.data.id).toMatch(/^[0-9a-z]{12}$/)
-  })
-
-  it('ensureFrontmatter returns untouched content when complete', () => {
-    const raw = matter.stringify('Body', {
-      id: 'abc123def456',
-      title: 'Existing',
-      created: FIXED_ISO,
-      modified: FIXED_ISO
-    })
-    expect(ensureFrontmatter(raw, '/notes/existing.md')).toBe(raw)
-  })
-
   it('validateNoteId proxies the note id validator', () => {
     expect(validateNoteId('abc123def456')).toBe(true)
     expect(validateNoteId('invalid-id')).toBe(false)
   })
 
-  it('extractTitleFromPath converts filenames to titles', () => {
-    expect(extractTitleFromPath('/notes/my-note_file.md')).toBe('My Note File')
+  it('extractTitleFromPath returns the verbatim basename', () => {
+    expect(extractTitleFromPath('/notes/my-note_file.md')).toBe('my-note_file')
+    expect(extractTitleFromPath('notes/Meeting Notes.md')).toBe('Meeting Notes')
   })
 
   it('extractWikiLinks pulls link targets from content', () => {
@@ -189,10 +171,8 @@ describe('properties helpers', () => {
 
   it('extractProperties falls back to non-reserved keys', () => {
     const frontmatter: NoteFrontmatter = {
-      id: 'abc123def456',
-      created: FIXED_ISO,
-      modified: FIXED_ISO,
       tags: ['tag-one'],
+      aliases: ['other-name'],
       project: 'alpha',
       priority: 2
     }
@@ -200,29 +180,25 @@ describe('properties helpers', () => {
     expect(extractProperties(frontmatter)).toEqual({ project: 'alpha', priority: 2 })
   })
 
-  it('excludes emoji from extracted properties (regression: emoji leak on sync)', () => {
+  it('surfaces legacy Memry keys as plain user properties', () => {
+    // Only tags/aliases are reserved — id/title/created/modified/emoji/localOnly
+    // found in files are user properties, never interpreted
     const frontmatter: NoteFrontmatter = {
       id: 'abc123def456',
+      title: 'Old Memry Note',
       created: FIXED_ISO,
-      modified: FIXED_ISO,
-      emoji: '🎉'
+      emoji: '🎉',
+      localOnly: true,
+      tags: ['kept-out']
     }
 
-    expect(extractProperties(frontmatter)).toEqual({})
-  })
-
-  it('excludes emoji but keeps custom keys in fallback extraction', () => {
-    const frontmatter: NoteFrontmatter = {
+    expect(extractProperties(frontmatter)).toEqual({
       id: 'abc123def456',
+      title: 'Old Memry Note',
       created: FIXED_ISO,
-      modified: FIXED_ISO,
-      emoji: '📝',
-      customField: 'val'
-    }
-
-    const result = extractProperties(frontmatter)
-    expect(result).toEqual({ customField: 'val' })
-    expect(result).not.toHaveProperty('emoji')
+      emoji: '🎉',
+      localOnly: true
+    })
   })
 
   it('inferPropertyType detects common property types', () => {

--- a/apps/desktop/src/main/vault/frontmatter.ts
+++ b/apps/desktop/src/main/vault/frontmatter.ts
@@ -14,29 +14,42 @@ import { generateNoteId, isValidNoteId } from '../lib/id'
 // ============================================================================
 
 /**
- * Frontmatter fields stored in note YAML header.
+ * User frontmatter keys of a note. Every key is a plain user property;
+ * Memry only interprets `tags` and `aliases` (Obsidian-defined semantics).
+ * Legacy Memry keys (id, title, created, modified, emoji, localOnly) found in
+ * files are plain user properties too — never interpreted, never rewritten.
  */
 export interface NoteFrontmatter {
-  id: string
-  title?: string
-  created: string
-  modified: string
   tags?: string[]
   aliases?: string[]
-  localOnly?: boolean
   [key: string]: unknown // Allow custom properties
+}
+
+/**
+ * Filesystem stats used to derive in-memory created/modified defaults.
+ */
+export interface ParseNoteStats {
+  birthtime?: Date
+  mtime?: Date
 }
 
 /**
  * Result of parsing a markdown file with frontmatter.
  */
 export interface ParsedNote {
+  /** Raw user frontmatter keys, verbatim (tags/aliases normalized to arrays) */
   frontmatter: NoteFrontmatter
   content: string
   /** Whether frontmatter was present in the original file */
   hadFrontmatter: boolean
-  /** Whether any required fields were missing and auto-generated */
-  wasModified: boolean
+  /**
+   * In-memory defaults — never written back to the file. Callers that know
+   * the note from the sidecar DBs should prefer the cached values.
+   */
+  id: string
+  title: string
+  created: string
+  modified: string
 }
 
 // ============================================================================
@@ -45,81 +58,54 @@ export interface ParsedNote {
 
 /**
  * Parse a markdown file content into frontmatter and body.
- * Missing required fields (id, created, modified) are auto-generated.
+ * Identity and dates are in-memory defaults only: a fresh id, title from the
+ * filename, created/modified from fs stats when provided (else now).
  *
  * @param rawContent - Raw file content including frontmatter
  * @param filePath - Optional file path for extracting title from filename
- * @returns Parsed note with frontmatter and content
+ * @param stats - Optional fs stats for created/modified defaults
+ * @returns Parsed note with user frontmatter and in-memory defaults
  */
-export function parseNote(rawContent: string, filePath?: string): ParsedNote {
+export function parseNote(
+  rawContent: string,
+  filePath?: string,
+  stats?: ParseNoteStats
+): ParsedNote {
   const { data, content } = matter(rawContent)
   const hadFrontmatter = Object.keys(data).length > 0
   const now = new Date().toISOString()
-  let wasModified = false
 
-  // Ensure required fields exist
-  if (!data.id || typeof data.id !== 'string') {
-    data.id = generateNoteId()
-    wasModified = true
-  }
-
-  if (!data.created || typeof data.created !== 'string') {
-    data.created = now
-    wasModified = true
-  }
-
-  if (!data.modified || typeof data.modified !== 'string') {
-    data.modified = now
-    wasModified = true
-  }
-
-  // Extract title from filename if not in frontmatter
-  if (!data.title && filePath) {
-    data.title = extractTitleFromPath(filePath)
-  }
-
-  // Normalize tags to array
+  // Normalize tags to array (read-side only, never written back)
   if (data.tags && !Array.isArray(data.tags)) {
     data.tags = [String(data.tags)]
-    wasModified = true
   }
 
-  // Normalize aliases to array
+  // Normalize aliases to array (read-side only, never written back)
   if (data.aliases && !Array.isArray(data.aliases)) {
     data.aliases = [String(data.aliases)]
-    wasModified = true
-  }
-
-  // Normalize localOnly to boolean (YAML may parse as string)
-  if (data.localOnly !== undefined) {
-    if (typeof data.localOnly === 'string') {
-      data.localOnly = data.localOnly === 'true'
-      wasModified = true
-    } else if (typeof data.localOnly !== 'boolean') {
-      data.localOnly = Boolean(data.localOnly)
-      wasModified = true
-    }
   }
 
   return {
     frontmatter: data as NoteFrontmatter,
     content: content.trim(),
     hadFrontmatter,
-    wasModified
+    id: generateNoteId(),
+    title: filePath ? extractTitleFromPath(filePath) : 'Untitled',
+    created: stats?.birthtime?.toISOString() ?? now,
+    modified: stats?.mtime?.toISOString() ?? now
   }
 }
 
 /**
- * Extract a display title from a file path.
- * Removes extension and converts dashes/underscores to spaces.
+ * Extract a display title from a file path: the verbatim basename without
+ * the `.md` extension. The file path is the note's identity — the title
+ * round-trips to the filename exactly.
  *
  * @param filePath - File path (can be relative or absolute)
- * @returns Human-readable title
+ * @returns Verbatim basename without extension
  */
 export function extractTitleFromPath(filePath: string): string {
-  const basename = path.basename(filePath, '.md')
-  // Convert kebab-case and snake_case to Title Case
-  return basename.replace(/[-_]/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+  return path.basename(filePath, '.md')
 }
 
 // ============================================================================
@@ -132,72 +118,29 @@ function stripTrailingNewlines(value: string): string {
 
 /**
  * Serialize frontmatter and content back to markdown format.
+ * Writes exactly the keys given (minus `undefined` values); when no keys
+ * remain, returns the bare content with no YAML block at all.
  *
- * @param frontmatter - Frontmatter object
+ * @param frontmatter - User frontmatter keys
  * @param content - Markdown content (without frontmatter)
- * @returns Complete markdown file content with YAML frontmatter
+ * @returns Complete markdown file content
  */
 export function serializeNote(frontmatter: NoteFrontmatter, content: string): string {
-  const updatedFrontmatter = {
-    ...frontmatter,
-    modified: new Date().toISOString()
-  }
+  const clean = Object.fromEntries(Object.entries(frontmatter).filter(([, v]) => v !== undefined))
 
-  const clean = Object.fromEntries(
-    Object.entries(updatedFrontmatter).filter(([, v]) => v !== undefined)
-  )
+  // Explicit guard: no keys → no YAML block (don't rely on gray-matter's
+  // empty-object behavior)
+  if (Object.keys(clean).length === 0) {
+    return content.trim()
+  }
 
   const serialized = matter.stringify(content.trim(), clean)
   return stripTrailingNewlines(serialized)
 }
 
-/**
- * Create frontmatter for a new note.
- *
- * @param title - Note title
- * @param tags - Optional tags
- * @returns Fresh frontmatter object
- */
-export function createFrontmatter(
-  title: string,
-  tags?: string[],
-  options?: { created?: string; modified?: string }
-): NoteFrontmatter {
-  const now = new Date().toISOString()
-
-  return {
-    id: generateNoteId(),
-    title,
-    created: options?.created ?? now,
-    modified: options?.modified ?? now,
-    tags: tags ?? []
-  }
-}
-
 // ============================================================================
 // Validation & Utilities
 // ============================================================================
-
-/**
- * Ensure a markdown file has valid frontmatter.
- * If frontmatter is missing or incomplete, it will be added/completed.
- *
- * @param rawContent - Raw file content
- * @param filePath - File path for title extraction
- * @returns Updated file content with complete frontmatter
- */
-export function ensureFrontmatter(rawContent: string, filePath: string): string {
-  const parsed = parseNote(rawContent, filePath)
-
-  if (!parsed.hadFrontmatter || parsed.wasModified) {
-    // Re-serialize with complete frontmatter
-    const serialized = matter.stringify(parsed.content, parsed.frontmatter)
-    return stripTrailingNewlines(serialized)
-  }
-
-  // No changes needed
-  return rawContent
-}
 
 /**
  * Check if a note ID is valid and properly formatted.
@@ -321,18 +264,11 @@ export function generateContentHash(content: string): string {
 import type { PropertyType } from '@memry/contracts/property-types'
 
 /**
- * Reserved frontmatter keys that are NOT properties.
+ * Reserved frontmatter keys that are NOT properties — only the two keys with
+ * Obsidian-defined semantics that Memry reads. Legacy Memry keys (id, title,
+ * created, modified, emoji, localOnly) are plain user properties.
  */
-const RESERVED_FRONTMATTER_KEYS = new Set([
-  'id',
-  'title',
-  'created',
-  'modified',
-  'tags',
-  'aliases',
-  'emoji',
-  'localOnly'
-])
+const RESERVED_FRONTMATTER_KEYS = new Set(['tags', 'aliases'])
 
 /**
  * Extract custom properties from frontmatter.

--- a/apps/desktop/src/main/vault/indexer.test.ts
+++ b/apps/desktop/src/main/vault/indexer.test.ts
@@ -18,6 +18,7 @@ import {
 import { createTestDataDb, createTestIndexDb, type TestDatabaseResult } from '@tests/utils/test-db'
 import type { VaultConfig } from '@memry/contracts/vault-api'
 import { noteMetadata } from '@memry/db-schema/data-schema'
+import { noteCache, noteTags, noteLinks } from '@memry/db-schema/schema/notes-cache'
 import { createNoteDerivedStateProjector } from '../projections/projectors/note-derived-state-projector'
 import { startProjectionRuntime, stopProjectionRuntime } from '../projections'
 
@@ -255,40 +256,44 @@ describe('indexer', () => {
       // The indexer should detect this as a journal entry based on path
     })
 
-    it('T374: handles duplicate IDs (regenerates new ID)', async () => {
-      // Create first note with specific ID
-      createTestNote(tempVault, {
+    it('T374: indexes files with duplicate legacy ids as separate notes, never writing files', async () => {
+      // Legacy `id:` keys in files are plain user properties — internal ids
+      // live only in the sidecar DBs, so duplicate file ids cannot collide.
+      const note1Path = createTestNote(tempVault, {
         id: 'duplicate123',
         title: 'First Note',
         content: 'Original'
       })
+      const note1Content = fs.readFileSync(note1Path, 'utf-8')
 
       // Index first note
       await indexer.indexVault(tempVault.path)
 
-      // Create second note with same ID (simulating a copy)
+      // Create second note with the same legacy id (simulating a copy)
       const note2Dir = path.join(tempVault.notesDir, 'subfolder')
       fs.mkdirSync(note2Dir, { recursive: true })
       const note2Path = path.join(note2Dir, 'Second Note.md')
-      fs.writeFileSync(
-        note2Path,
-        `---
+      const note2Content = `---
 id: "duplicate123"
 title: "Second Note"
 ---
 
 Copied note`
-      )
+      fs.writeFileSync(note2Path, note2Content)
 
-      // Index again - should regenerate ID for the second note
       const result = await indexer.indexVault(tempVault.path)
 
-      expect(result.indexed).toBe(1) // Second note indexed with new ID
+      expect(result.indexed).toBe(1) // Second note indexed
       expect(result.skipped).toBe(1) // First note skipped
 
-      // Verify the second note's file was updated with new ID
-      const updatedContent = fs.readFileSync(note2Path, 'utf-8')
-      expect(updatedContent).not.toContain('id: "duplicate123"')
+      // The indexer never writes files — both keep their exact bytes
+      expect(fs.readFileSync(note1Path, 'utf-8')).toBe(note1Content)
+      expect(fs.readFileSync(note2Path, 'utf-8')).toBe(note2Content)
+
+      // Both files exist as distinct notes with their own internal ids
+      const rows = testDb.db.select().from(noteCache).all()
+      expect(rows).toHaveLength(2)
+      expect(rows[0].id).not.toBe(rows[1].id)
     })
   })
 
@@ -413,9 +418,8 @@ Copied note`
       expect(result.duration).toBeGreaterThanOrEqual(0)
     })
 
-    it('T376: preserves canonical note metadata across index rebuilds', async () => {
+    it('T376: preserves canonical note ids across index rebuilds via note_metadata byPath', async () => {
       const notePath = createTestNote(tempVault, {
-        id: 'persistent-note',
         title: 'Persistent Note',
         content: 'Canonical metadata should survive rebuilds'
       })
@@ -423,21 +427,38 @@ Copied note`
 
       await indexer.indexVault(tempVault.path)
 
+      // The internal id was generated at index time and recorded in note_metadata
       const before = dataDb.db
         .select()
         .from(noteMetadata)
-        .where(eq(noteMetadata.id, 'persistent-note'))
+        .where(eq(noteMetadata.path, relativePath))
         .get()
-      expect(before?.path).toBe(relativePath)
+      expect(before).toBeDefined()
 
-      await indexer.rebuildIndex(tempVault.path)
+      // Simulate the rebuild deleting index.db: wipe the index cache tables
+      vi.spyOn(database, 'runIndexMigrations').mockImplementation(() => {
+        testDb.db.delete(noteTags).run()
+        testDb.db.delete(noteLinks).run()
+        testDb.db.delete(noteCache).run()
+      })
+
+      const rebuild = await indexer.rebuildIndex(tempVault.path)
+      expect(rebuild.filesIndexed).toBe(1)
+
+      // The re-indexed file adopts its canonical id from note_metadata byPath
+      const cacheRow = testDb.db
+        .select()
+        .from(noteCache)
+        .where(eq(noteCache.path, relativePath))
+        .get()
+      expect(cacheRow?.id).toBe(before?.id)
 
       const after = dataDb.db
         .select()
         .from(noteMetadata)
-        .where(eq(noteMetadata.id, 'persistent-note'))
+        .where(eq(noteMetadata.path, relativePath))
         .get()
-      expect(after).toEqual(expect.objectContaining({ id: 'persistent-note', path: before?.path }))
+      expect(after).toEqual(expect.objectContaining({ id: before?.id, path: relativePath }))
     })
   })
 })

--- a/apps/desktop/src/main/vault/indexer.ts
+++ b/apps/desktop/src/main/vault/indexer.ts
@@ -21,19 +21,19 @@ import {
   getIndexDatabase,
   closeIndexDatabase
 } from '../database'
-import { parseNote, serializeNote } from './frontmatter'
-import { safeRead, atomicWrite } from './file-ops'
+import { parseNote } from './frontmatter'
+import { safeRead } from './file-ops'
 import { generateNoteId } from '../lib/id'
 import { normalizeRelativePath } from '../lib/paths'
 import { syncNoteToCache, syncFileToCache } from './note-sync'
 import { flushProjectionEvents } from '../projections'
 import {
   getNoteCacheByPath,
-  getNoteCacheById,
   countNotes,
   countJournalEntries,
   ensureTagDefinitions
 } from '@main/database/queries/notes'
+import { getNoteMetadataByPath } from '@memry/storage-data'
 import { isSupportedPath, getFileType, getMimeType, getExtension } from '@memry/shared/file-types'
 import { createLogger } from '../lib/logger'
 
@@ -158,38 +158,33 @@ async function indexMarkdownFile(
     return 'error'
   }
 
-  const parsed = parseNote(content, relativePath)
+  // Path unknown to the index cache (indexFile skips known paths). Prefer the
+  // canonical id from note_metadata (survives index rebuilds), else a fresh
+  // one. Dates from fs stats. The indexer never writes files.
+  const stats = await stat(absolutePath).catch(() => null)
+  const parsed = parseNote(content, relativePath, stats ?? undefined)
 
-  // Check if already in cache by ID (possible duplicate/copied file)
-  const existingById = getNoteCacheById(db, parsed.frontmatter.id)
-  if (existingById) {
-    // This is a copy of an existing note - regenerate ID
-    logger.debug(`Duplicate ID detected, regenerating for: ${relativePath}`)
-    const newId = generateNoteId()
-    parsed.frontmatter.id = newId
-    parsed.frontmatter.title = path.basename(relativePath, path.extname(relativePath))
-
-    // Write back to file with new ID
-    try {
-      const newContent = serializeNote(parsed.frontmatter, parsed.content)
-      await atomicWrite(absolutePath, newContent)
-      logger.debug(`Regenerated ID for ${relativePath}: ${existingById.id} → ${newId}`)
-    } catch (writeError) {
-      logger.error(`Failed to write new ID for ${relativePath}:`, writeError)
-      return 'error'
-    }
+  let canonicalId: string | undefined
+  try {
+    canonicalId = getNoteMetadataByPath(getDatabase(), relativePath)?.id
+  } catch {
+    // data DB not ready — fall back to a fresh id
   }
+  const noteId = canonicalId ?? parsed.id
 
   // Use syncNoteToCache for unified cache operations
   try {
     const result = syncNoteToCache(
       db,
       {
-        id: parsed.frontmatter.id,
+        id: noteId,
         path: relativePath,
         fileContent: content,
         frontmatter: parsed.frontmatter,
-        parsedContent: parsed.content
+        parsedContent: parsed.content,
+        title: parsed.title,
+        createdAt: parsed.created,
+        modifiedAt: parsed.modified
       },
       { isNew: true }
     )

--- a/apps/desktop/src/main/vault/journal.test.ts
+++ b/apps/desktop/src/main/vault/journal.test.ts
@@ -13,6 +13,7 @@ import {
   createJournalFrontmatter,
   readJournalEntry,
   writeJournalEntry,
+  writeJournalEntryWithContent,
   deleteJournalEntryFile,
   journalEntryExists,
   getJournalPath,
@@ -106,8 +107,9 @@ Today was a good day.`
     const parsed = parseJournalEntry(raw, '2026-01-15')
 
     expect(parsed.hadFrontmatter).toBe(true)
+    // Legacy Memry keys in the file are plain user properties, surfaced verbatim
     expect(parsed.frontmatter.id).toBe('j2026-01-15')
-    expect(parsed.frontmatter.date).toBe('2026-01-15')
+    expect(parsed.date).toBe('2026-01-15')
     expect(parsed.frontmatter.tags).toEqual(['reflection'])
     expect(parsed.content).toBe('Today was a good day.')
   })
@@ -118,10 +120,12 @@ Today was a good day.`
     const parsed = parseJournalEntry(raw, '2026-01-15')
 
     expect(parsed.hadFrontmatter).toBe(false)
-    expect(parsed.frontmatter.id).toBe('j2026-01-15')
-    expect(parsed.frontmatter.date).toBe('2026-01-15')
-    expect(parsed.frontmatter.created).toBe(FIXED_ISO)
-    expect(parsed.frontmatter.modified).toBe(FIXED_ISO)
+    // Generated fields are in-memory defaults, never injected into frontmatter
+    expect(parsed.frontmatter).toEqual({})
+    expect(parsed.id).toBe('j2026-01-15')
+    expect(parsed.date).toBe('2026-01-15')
+    expect(parsed.created).toBe(FIXED_ISO)
+    expect(parsed.modified).toBe(FIXED_ISO)
     expect(parsed.content).toBe('Just some content')
   })
 
@@ -146,7 +150,9 @@ Content`
 
     const parsed = parseJournalEntry(raw, '2026-01-15')
 
-    expect(parsed.frontmatter.id).toBe('j2026-01-15')
+    expect(parsed.id).toBe('j2026-01-15')
+    // ID is an in-memory default — never injected into frontmatter
+    expect(parsed.frontmatter.id).toBeUndefined()
   })
 })
 
@@ -164,22 +170,26 @@ describe('serializeJournalEntry', () => {
     vi.useRealTimers()
   })
 
-  it('T379: serializes frontmatter and content', () => {
+  it('T379: serializes only the given user keys and never bumps modified', () => {
     const frontmatter = {
-      id: 'j2026-01-15',
       date: '2026-01-15',
-      created: '2026-01-15T08:00:00.000Z',
-      modified: '2026-01-15T08:00:00.000Z',
       tags: ['daily']
     }
 
     const result = serializeJournalEntry(frontmatter, 'Journal content')
 
-    expect(result).toContain('j2026-01-15')
     expect(result).toContain('2026-01-15')
+    expect(result).toContain('daily')
     expect(result).toContain('Journal content')
-    // Modified should be updated to current time
-    expect(result).toContain(FIXED_ISO)
+    // No Memry-managed keys are injected and modified is never bumped
+    expect(result).not.toContain('id:')
+    expect(result).not.toContain('created:')
+    expect(result).not.toContain('modified:')
+    expect(result).not.toContain(FIXED_ISO)
+  })
+
+  it('T379: returns bare content when frontmatter has no keys', () => {
+    expect(serializeJournalEntry({}, 'Bare content')).toBe('Bare content')
   })
 
   it('T379: trims content', () => {
@@ -334,14 +344,11 @@ describe('createJournalFrontmatter', () => {
     vi.useRealTimers()
   })
 
-  it('T380: creates frontmatter with j-prefixed ID', () => {
+  it('T380: creates date-only frontmatter with no Memry-managed keys', () => {
     const frontmatter = createJournalFrontmatter('2026-01-15')
 
-    expect(frontmatter.id).toBe('j2026-01-15')
-    expect(frontmatter.date).toBe('2026-01-15')
-    expect(frontmatter.created).toBe(FIXED_ISO)
-    expect(frontmatter.modified).toBe(FIXED_ISO)
-    expect(frontmatter.tags).toEqual([])
+    // User keys only: no id/created/modified, no empty tags array
+    expect(frontmatter).toEqual({ date: '2026-01-15' })
   })
 
   it('T380: includes tags when provided', () => {
@@ -444,7 +451,7 @@ Today I worked on tests.`
       expect(entry.tags).toEqual(['updated'])
     })
 
-    it('T381: preserves created timestamp on update', async () => {
+    it('T381: preserves created timestamp from the provided existing entry', async () => {
       // Create initial entry
       const initial = await writeJournalEntry('2026-01-15', 'Initial')
       const createdAt = initial.createdAt
@@ -452,11 +459,13 @@ Today I worked on tests.`
       // Advance time
       vi.setSystemTime(new Date('2026-01-16T12:00:00.000Z'))
 
-      // Update
-      const updated = await writeJournalEntry('2026-01-15', 'Updated')
+      // Update — createdAt lives in the sidecar DBs, so callers pass the
+      // existing entry; the file itself carries no created/modified keys
+      const result = await writeJournalEntryWithContent('2026-01-15', 'Updated', undefined, initial)
 
-      expect(updated.createdAt).toBe(createdAt)
-      expect(updated.modifiedAt).not.toBe(createdAt)
+      expect(result.entry.createdAt).toBe(createdAt)
+      expect(result.entry.modifiedAt).not.toBe(createdAt)
+      expect(result.fileContent).not.toContain('created')
     })
   })
 

--- a/apps/desktop/src/main/vault/journal.ts
+++ b/apps/desktop/src/main/vault/journal.ts
@@ -27,13 +27,12 @@ import {
 // ============================================================================
 
 /**
- * Journal entry frontmatter fields.
+ * Journal entry frontmatter fields. Every key is a plain user property;
+ * Memry writes only `date` (and `tags`/`properties` on explicit edit).
+ * Legacy Memry keys (id, created, modified) are plain user properties.
  */
 export interface JournalFrontmatter {
-  id: string
-  date: string
-  created: string
-  modified: string
+  date?: string
   tags?: string[]
   [key: string]: unknown
 }
@@ -45,6 +44,11 @@ export interface ParsedJournalEntry {
   frontmatter: JournalFrontmatter
   content: string
   hadFrontmatter: boolean
+  /** In-memory defaults — never written back to the file */
+  id: string
+  date: string
+  created: string
+  modified: string
 }
 
 /**
@@ -116,24 +120,7 @@ export function parseJournalEntry(rawContent: string, date: string): ParsedJourn
   const hadFrontmatter = Object.keys(data).length > 0
   const now = new Date().toISOString()
 
-  // Ensure required fields exist
-  if (!data.id || typeof data.id !== 'string') {
-    data.id = generateJournalId(date)
-  }
-
-  if (!data.date || typeof data.date !== 'string') {
-    data.date = date
-  }
-
-  if (!data.created || typeof data.created !== 'string') {
-    data.created = now
-  }
-
-  if (!data.modified || typeof data.modified !== 'string') {
-    data.modified = now
-  }
-
-  // Normalize tags to array
+  // Normalize tags to array (read-side only, never written back)
   if (data.tags && !Array.isArray(data.tags)) {
     data.tags = [String(data.tags)]
   }
@@ -141,41 +128,42 @@ export function parseJournalEntry(rawContent: string, date: string): ParsedJourn
   return {
     frontmatter: data as JournalFrontmatter,
     content: content.trim(),
-    hadFrontmatter
+    hadFrontmatter,
+    id: generateJournalId(date),
+    date,
+    created: now,
+    modified: now
   }
 }
 
 /**
  * Serialize frontmatter and content to markdown format.
+ * Writes exactly the keys given; no keys → bare content, no YAML block.
+ *
  * @param frontmatter - Frontmatter object
  * @param content - Markdown content (without frontmatter)
- * @returns Complete markdown file content with YAML frontmatter
+ * @returns Complete markdown file content
  */
 export function serializeJournalEntry(frontmatter: JournalFrontmatter, content: string): string {
-  // Update modified timestamp
-  const updatedFrontmatter = {
-    ...frontmatter,
-    modified: new Date().toISOString()
+  const clean = Object.fromEntries(Object.entries(frontmatter).filter(([, v]) => v !== undefined))
+
+  if (Object.keys(clean).length === 0) {
+    return content.trim()
   }
 
-  return matter.stringify(content.trim(), updatedFrontmatter)
+  return matter.stringify(content.trim(), clean)
 }
 
 /**
- * Create frontmatter for a new journal entry.
+ * Create frontmatter for a new journal entry — user keys only.
  * @param date - Date in YYYY-MM-DD format
  * @param tags - Optional tags
  * @returns Fresh frontmatter object
  */
 export function createJournalFrontmatter(date: string, tags?: string[]): JournalFrontmatter {
-  const now = new Date().toISOString()
-
   return {
-    id: generateJournalId(date),
     date,
-    created: now,
-    modified: now,
-    tags: tags ?? []
+    ...(tags && tags.length > 0 ? { tags } : {})
   }
 }
 
@@ -249,14 +237,14 @@ export async function readJournalEntry(date: string): Promise<JournalEntry | nul
   const properties = extractJournalProperties(parsed.frontmatter)
 
   return {
-    id: parsed.frontmatter.id,
-    date: parsed.frontmatter.date,
+    id: parsed.id,
+    date: parsed.date,
     content: parsed.content,
     wordCount,
     characterCount,
     tags: parsed.frontmatter.tags ?? [],
-    createdAt: parsed.frontmatter.created,
-    modifiedAt: parsed.frontmatter.modified,
+    createdAt: parsed.created,
+    modifiedAt: parsed.modified,
     properties
   }
 }
@@ -291,13 +279,11 @@ export async function writeJournalEntryWithContent(
   let frontmatter: JournalFrontmatter
 
   if (existing) {
-    // Update existing entry - preserve created timestamp
-    frontmatter = {
-      id: existing.id,
-      date,
-      created: existing.createdAt,
-      modified: new Date().toISOString(),
-      tags: tags ?? existing.tags
+    // Update existing entry — user keys only
+    frontmatter = { date }
+    const mergedTags = tags ?? existing.tags
+    if (mergedTags.length > 0) {
+      frontmatter.tags = mergedTags
     }
 
     // Add properties if provided, or preserve existing properties
@@ -333,14 +319,14 @@ export async function writeJournalEntryWithContent(
   const writtenProperties = extractJournalProperties(parsed.frontmatter)
 
   const entry: JournalEntry = {
-    id: parsed.frontmatter.id,
-    date: parsed.frontmatter.date,
+    id: parsed.id,
+    date: parsed.date,
     content: parsed.content,
     wordCount,
     characterCount,
     tags: parsed.frontmatter.tags ?? [],
-    createdAt: parsed.frontmatter.created,
-    modifiedAt: parsed.frontmatter.modified,
+    createdAt: existing?.createdAt ?? parsed.created,
+    modifiedAt: parsed.modified,
     properties: writtenProperties
   }
 

--- a/apps/desktop/src/main/vault/note-sync.test.ts
+++ b/apps/desktop/src/main/vault/note-sync.test.ts
@@ -28,20 +28,21 @@ import type { NoteFrontmatter } from './frontmatter'
 const FIXED_ISO = '2026-01-15T12:00:00.000Z'
 
 function buildInput(overrides: Partial<NoteSyncInput> = {}): NoteSyncInput {
+  // Memry-written files carry user keys only — no id/created/modified
   const frontmatter: NoteFrontmatter = {
-    id: 'abc123def456',
-    created: FIXED_ISO,
-    modified: FIXED_ISO,
     tags: [],
     ...(overrides.frontmatter ?? {})
   }
 
   return {
-    id: frontmatter.id,
+    id: overrides.id ?? 'abc123def456',
     path: overrides.path ?? 'notes/test.md',
     fileContent: overrides.fileContent ?? '---\n---\n' + (overrides.parsedContent ?? ''),
     parsedContent: overrides.parsedContent ?? '',
-    frontmatter
+    frontmatter,
+    title: overrides.title ?? 'test',
+    createdAt: overrides.createdAt ?? FIXED_ISO,
+    modifiedAt: overrides.modifiedAt ?? FIXED_ISO
   }
 }
 
@@ -197,6 +198,7 @@ describe('syncNoteToCache — tagsOverride', () => {
 
     const input = buildInput({
       path: 'journal/2026-01-15.md',
+      title: '2026-01-15',
       parsedContent: 'Daily note'
     })
 

--- a/apps/desktop/src/main/vault/note-sync.ts
+++ b/apps/desktop/src/main/vault/note-sync.ts
@@ -63,16 +63,26 @@ function removeCanonicalMetadata(noteId: string): void {
  * Input for syncing a note to the cache.
  */
 export interface NoteSyncInput {
-  /** Unique note ID from frontmatter */
+  /** Internal note ID (sidecar-owned, never read from file frontmatter) */
   id: string
   /** Relative path from vault root */
   path: string
   /** Full file content including frontmatter */
   fileContent: string
-  /** Parsed frontmatter object */
+  /** Raw user frontmatter keys (used for tags/aliases/properties extraction) */
   frontmatter: NoteFrontmatter
   /** Markdown body content (without frontmatter) */
   parsedContent: string
+  /** Display title (verbatim basename) */
+  title: string
+  /** ISO created timestamp (sidecar/fs-sourced, never from frontmatter) */
+  createdAt: string
+  /** ISO modified timestamp (sidecar/fs-sourced, never from frontmatter) */
+  modifiedAt: string
+  /** Local-only privacy flag (sidecar-only state) */
+  localOnly?: boolean
+  /** Emoji icon (sidecar-only state) */
+  emoji?: string | null
 }
 
 /**
@@ -152,7 +162,7 @@ export function extractNoteMetadata(input: NoteSyncInput): NoteMetadata {
   const snippet = createSnippet(parsedContent)
   const contentHash = generateContentHash(fileContent)
   const date = extractDateFromPath(path)
-  const emoji = (frontmatter as { emoji?: string }).emoji ?? null
+  const emoji = input.emoji ?? null
 
   return {
     id,
@@ -181,13 +191,11 @@ export function syncNoteToCache(
   options: NoteSyncOptions
 ): NoteSyncResult {
   const { tagsOverride } = options
-  const { id, path, frontmatter, parsedContent } = input
+  const { id, path, parsedContent, title, createdAt, modifiedAt, localOnly } = input
   const metadata = extractNoteMetadata(input)
   const { properties, wikiLinks, wordCount, characterCount, snippet, contentHash, date, emoji } =
     metadata
   const tags = tagsOverride ?? metadata.tags
-
-  const title = frontmatter.title ?? path.split('/').pop()?.replace('.md', '') ?? 'Untitled'
 
   syncCanonicalMetadata(
     {
@@ -195,11 +203,11 @@ export function syncNoteToCache(
       path,
       title,
       emoji,
-      localOnly: frontmatter.localOnly ?? false,
+      localOnly: localOnly ?? false,
       journalDate: date,
       properties,
-      createdAt: frontmatter.created,
-      modifiedAt: frontmatter.modified
+      createdAt,
+      modifiedAt
     },
     properties
   )
@@ -210,15 +218,15 @@ export function syncNoteToCache(
     path,
     title,
     fileType: 'markdown',
-    localOnly: frontmatter.localOnly ?? false,
+    localOnly: localOnly ?? false,
     contentHash,
     wordCount,
     characterCount,
     snippet,
     date,
     emoji,
-    createdAt: frontmatter.created,
-    modifiedAt: frontmatter.modified,
+    createdAt,
+    modifiedAt,
     parsedContent,
     tags,
     properties,

--- a/apps/desktop/src/main/vault/notes-crud.ts
+++ b/apps/desktop/src/main/vault/notes-crud.ts
@@ -13,7 +13,6 @@ import { and, desc, eq } from 'drizzle-orm'
 import {
   parseNote,
   serializeNote,
-  createFrontmatter,
   extractInlineTagsFromMarkdown,
   type NoteFrontmatter
 } from './frontmatter'
@@ -33,7 +32,6 @@ import {
   getNoteTags,
   ensureTagDefinitions,
   getNotePropertiesAsRecord,
-  findDuplicateId,
   resolveNoteByTitle
 } from '@main/database/queries/notes'
 import { folderConfigs } from '@memry/db-schema/schema/folder-configs'
@@ -224,11 +222,14 @@ export async function createNote(input: NoteCreateInput): Promise<Note> {
 
   const mergedTags = [...new Set([...templateTags, ...(input.tags ?? [])])]
 
-  const frontmatter = createFrontmatter(input.title, mergedTags, {
-    created: input.created,
-    modified: input.modified
-  })
-  if (input.id) frontmatter.id = input.id
+  const noteId = input.id ?? generateNoteId()
+  const now = new Date().toISOString()
+  const created = input.created ?? now
+  const modified = input.modified ?? now
+
+  // User keys only — no Memry keys in the file; empty frontmatter → no YAML block
+  const frontmatter: NoteFrontmatter = {}
+  if (mergedTags.length > 0) frontmatter.tags = mergedTags
 
   const properties = { ...templateProperties, ...(input.properties ?? {}) }
   if (Object.keys(properties).length > 0) {
@@ -246,11 +247,14 @@ export async function createNote(input: NoteCreateInput): Promise<Note> {
   const syncResult = syncNoteToCache(
     db,
     {
-      id: frontmatter.id,
+      id: noteId,
       path: relativePath,
       fileContent,
       frontmatter,
-      parsedContent: content
+      parsedContent: content,
+      title: input.title,
+      createdAt: created,
+      modifiedAt: modified
     },
     { isNew: true }
   )
@@ -258,13 +262,13 @@ export async function createNote(input: NoteCreateInput): Promise<Note> {
   ensureTagDefinitions(dataDb, mergedTags)
 
   const note: Note = {
-    id: frontmatter.id,
+    id: noteId,
     path: relativePath,
     title: input.title,
     content,
     frontmatter,
-    created: new Date(frontmatter.created),
-    modified: new Date(frontmatter.modified),
+    created: new Date(created),
+    modified: new Date(modified),
     tags: mergedTags,
     aliases: frontmatter.aliases ?? [],
     wordCount: syncResult.wordCount,
@@ -314,51 +318,20 @@ export async function getNoteById(id: string): Promise<Note | null> {
   }
 
   const parsed = parseNote(fileContent, cached.path)
-  let responseTags = getNoteTags(db, id)
-  let responseProperties = getNotePropertiesAsRecord(db, id)
-  let responseWordCount = cached.wordCount ?? 0
-  let responseEmoji = cached.emoji ?? (parsed.frontmatter as { emoji?: string }).emoji ?? null
-
-  const duplicate = findDuplicateId(db, parsed.frontmatter.id, cached.path)
-  if (duplicate) {
-    const newId = generateNoteId()
-    parsed.frontmatter.id = newId
-    parsed.frontmatter.title = path.basename(cached.path, path.extname(cached.path))
-    const newContent = serializeNote(parsed.frontmatter, parsed.content)
-    await atomicWrite(absolutePath, newContent)
-    deleteNoteFromCache(db, id)
-    const syncResult = syncNoteToCache(
-      db,
-      {
-        id: newId,
-        path: cached.path,
-        fileContent: newContent,
-        frontmatter: parsed.frontmatter,
-        parsedContent: parsed.content
-      },
-      { isNew: true }
-    )
-
-    id = newId
-    responseTags = syncResult.tags
-    responseProperties = syncResult.properties
-    responseWordCount = syncResult.wordCount
-    responseEmoji = syncResult.emoji
-  }
 
   return {
     id,
     path: cached.path,
-    title: parsed.frontmatter.title ?? cached.title,
+    title: cached.title,
     content: parsed.content,
     frontmatter: parsed.frontmatter,
-    created: new Date(parsed.frontmatter.created),
-    modified: new Date(parsed.frontmatter.modified),
-    tags: responseTags,
+    created: new Date(cached.createdAt),
+    modified: new Date(cached.modifiedAt),
+    tags: getNoteTags(db, id),
     aliases: parsed.frontmatter.aliases ?? [],
-    wordCount: responseWordCount,
-    properties: responseProperties,
-    emoji: responseEmoji
+    wordCount: cached.wordCount ?? 0,
+    properties: getNotePropertiesAsRecord(db, id),
+    emoji: cached.emoji ?? null
   }
 }
 
@@ -427,28 +400,32 @@ export async function getNoteByPath(notePath: string): Promise<Note | null> {
     return null
   }
 
-  const parsed = parseNote(fileContent, notePath)
+  const stats = await fs.stat(absolutePath).catch(() => null)
+  const parsed = parseNote(fileContent, notePath, stats ?? undefined)
 
   const syncResult = syncNoteToCache(
     db,
     {
-      id: parsed.frontmatter.id,
+      id: parsed.id,
       path: notePath,
       fileContent,
       frontmatter: parsed.frontmatter,
-      parsedContent: parsed.content
+      parsedContent: parsed.content,
+      title: parsed.title,
+      createdAt: parsed.created,
+      modifiedAt: parsed.modified
     },
     { isNew: true }
   )
 
   return {
-    id: parsed.frontmatter.id,
+    id: parsed.id,
     path: notePath,
-    title: parsed.frontmatter.title ?? path.basename(notePath, '.md'),
+    title: parsed.title,
     content: parsed.content,
     frontmatter: parsed.frontmatter,
-    created: new Date(parsed.frontmatter.created),
-    modified: new Date(parsed.frontmatter.modified),
+    created: new Date(parsed.created),
+    modified: new Date(parsed.modified),
     tags: syncResult.tags,
     aliases: parsed.frontmatter.aliases ?? [],
     wordCount: syncResult.wordCount,
@@ -515,15 +492,16 @@ export async function updateNote(input: NoteUpdateInput): Promise<Note> {
     logger.info('updateNote: content unchanged, skipping snapshot', { noteId: input.id })
   }
 
-  const newFrontmatter: NoteFrontmatter & {
-    properties?: Record<string, unknown>
-    emoji?: string | null
-  } = {
+  // User keys only — Memry state (title, dates, emoji, localOnly) lives in the DBs
+  const newFrontmatter: NoteFrontmatter & { properties?: Record<string, unknown> } = {
     ...existing.frontmatter,
-    ...input.frontmatter,
-    title: newTitle,
-    tags: newTags,
-    modified: new Date().toISOString()
+    ...input.frontmatter
+  }
+
+  if (newTags.length > 0) {
+    newFrontmatter.tags = newTags
+  } else {
+    delete newFrontmatter.tags
   }
 
   if (Object.keys(newProperties).length > 0) {
@@ -532,13 +510,12 @@ export async function updateNote(input: NoteUpdateInput): Promise<Note> {
     delete newFrontmatter.properties
   }
 
-  if (newEmoji !== undefined) {
-    newFrontmatter.emoji = newEmoji
-  }
-
   const fileContent = serializeNote(newFrontmatter, newContent)
   const absolutePath = toAbsolutePath(existing.path)
   await atomicWrite(absolutePath, fileContent)
+
+  const cached = getNoteCacheById(db, input.id)
+  const newModified = new Date().toISOString()
 
   const syncResult = syncNoteToCache(
     db,
@@ -547,7 +524,12 @@ export async function updateNote(input: NoteUpdateInput): Promise<Note> {
       path: existing.path,
       fileContent,
       frontmatter: newFrontmatter,
-      parsedContent: newContent
+      parsedContent: newContent,
+      title: newTitle,
+      createdAt: cached?.createdAt ?? existing.created.toISOString(),
+      modifiedAt: newModified,
+      localOnly: cached?.localOnly ?? false,
+      emoji: newEmoji
     },
     { isNew: false, tagsOverride: newTags }
   )
@@ -566,7 +548,7 @@ export async function updateNote(input: NoteUpdateInput): Promise<Note> {
     content: newContent,
     frontmatter: newFrontmatter,
     created: existing.created,
-    modified: new Date(newFrontmatter.modified),
+    modified: new Date(newModified),
     tags: newTags,
     aliases: newFrontmatter.aliases ?? [],
     wordCount: syncResult.wordCount,

--- a/apps/desktop/src/main/vault/notes-rename.ts
+++ b/apps/desktop/src/main/vault/notes-rename.ts
@@ -1,22 +1,16 @@
 /**
- * Note rename and move operations — filesystem rename, frontmatter rewrite for
- * markdown, and cache resync. Pulled from notes.ts during the Phase 3.1 split
- * (.claude/plans/tech-debt-remediation.md).
+ * Note rename and move operations — pure filesystem rename plus cache resync;
+ * file bytes are never touched. Pulled from notes.ts during the Phase 3.1
+ * split (.claude/plans/tech-debt-remediation.md).
  *
  * @module vault/notes-rename
  */
 
 import path from 'path'
 import fs from 'fs/promises'
-import { serializeNote, type NoteFrontmatter } from './frontmatter'
+import { parseNote } from './frontmatter'
 import { syncNoteToCache, syncFileToCache } from './note-sync'
-import {
-  atomicWrite,
-  deleteFile,
-  ensureDirectory,
-  sanitizeFilename,
-  generateUniquePath
-} from './file-ops'
+import { ensureDirectory, sanitizeFilename, generateUniquePath, safeRead } from './file-ops'
 import { getNoteCacheById } from '@main/database/queries/notes'
 import { getDatabase, getIndexDatabase } from '../database'
 import { NoteError, NoteErrorCode } from '../lib/errors'
@@ -50,14 +44,11 @@ export async function renameNote(id: string, newTitle: string): Promise<Note> {
   const newRelativePath = toRelativePath(newPath)
 
   const now = new Date().toISOString()
-  const newFrontmatter: NoteFrontmatter = {
-    ...existing.frontmatter,
-    title: newTitle,
-    modified: now
-  }
+
+  // Pure filesystem rename — file bytes untouched; title/dates live in the DBs
+  await fs.rename(oldPath, newPath)
 
   if (isBinary) {
-    await fs.rename(oldPath, newPath)
     syncFileToCache(db, {
       id,
       path: newRelativePath,
@@ -74,17 +65,21 @@ export async function renameNote(id: string, newTitle: string): Promise<Note> {
       modifiedAt: now
     })
   } else {
-    const fileContent = serializeNote(newFrontmatter, existing.content)
-    await atomicWrite(newPath, fileContent)
-    await deleteFile(oldPath)
+    const fileContent = (await safeRead(newPath)) ?? ''
+    const parsed = parseNote(fileContent, newRelativePath)
     syncNoteToCache(
       db,
       {
         id,
         path: newRelativePath,
         fileContent,
-        frontmatter: newFrontmatter,
-        parsedContent: existing.content
+        frontmatter: parsed.frontmatter,
+        parsedContent: parsed.content,
+        title: newTitle,
+        createdAt: cached?.createdAt ?? existing.created.toISOString(),
+        modifiedAt: now,
+        localOnly: cached?.localOnly ?? false,
+        emoji: cached?.emoji ?? null
       },
       { isNew: false }
     )
@@ -94,7 +89,6 @@ export async function renameNote(id: string, newTitle: string): Promise<Note> {
     ...existing,
     path: newRelativePath,
     title: newTitle,
-    frontmatter: newFrontmatter,
     modified: new Date(now)
   }
 
@@ -134,13 +128,11 @@ export async function moveNote(id: string, newFolder: string): Promise<Note> {
   const newRelativePath = toRelativePath(newPath)
 
   const now = new Date().toISOString()
-  const newFrontmatter: NoteFrontmatter = {
-    ...existing.frontmatter,
-    modified: now
-  }
+
+  // Pure filesystem rename — file bytes untouched; dates live in the DBs
+  await fs.rename(oldPath, newPath)
 
   if (isBinary) {
-    await fs.rename(oldPath, newPath)
     syncFileToCache(db, {
       id,
       path: newRelativePath,
@@ -156,17 +148,21 @@ export async function moveNote(id: string, newFolder: string): Promise<Note> {
       modifiedAt: now
     })
   } else {
-    const fileContent = serializeNote(newFrontmatter, existing.content)
-    await atomicWrite(newPath, fileContent)
-    await deleteFile(oldPath)
+    const fileContent = (await safeRead(newPath)) ?? ''
+    const parsed = parseNote(fileContent, newRelativePath)
     syncNoteToCache(
       db,
       {
         id,
         path: newRelativePath,
         fileContent,
-        frontmatter: newFrontmatter,
-        parsedContent: existing.content
+        frontmatter: parsed.frontmatter,
+        parsedContent: parsed.content,
+        title: existing.title,
+        createdAt: cached?.createdAt ?? existing.created.toISOString(),
+        modifiedAt: now,
+        localOnly: cached?.localOnly ?? false,
+        emoji: cached?.emoji ?? null
       },
       { isNew: false }
     )
@@ -175,7 +171,6 @@ export async function moveNote(id: string, newFolder: string): Promise<Note> {
   const note: Note = {
     ...existing,
     path: newRelativePath,
-    frontmatter: newFrontmatter,
     modified: new Date(now)
   }
 

--- a/apps/desktop/src/main/vault/notes-versions.ts
+++ b/apps/desktop/src/main/vault/notes-versions.ts
@@ -187,17 +187,11 @@ export async function restoreVersion(snapshotId: string): Promise<Note> {
 
   const absolutePath = toAbsolutePath(cached.path)
   const currentFileContent = await fs.readFile(absolutePath, 'utf-8')
-  const currentParsed = parseNote(currentFileContent)
 
-  createSnapshot(
-    cached.id,
-    currentFileContent,
-    currentParsed.frontmatter.title ?? cached.title,
-    SnapshotReasons.SIGNIFICANT,
-    true
-  )
+  createSnapshot(cached.id, currentFileContent, cached.title, SnapshotReasons.SIGNIFICANT, true)
 
   const snapshotParsed = parseNote(snapshot.fileContent)
+  const now = new Date()
 
   await atomicWrite(absolutePath, snapshot.fileContent)
 
@@ -208,7 +202,12 @@ export async function restoreVersion(snapshotId: string): Promise<Note> {
       path: cached.path,
       fileContent: snapshot.fileContent,
       frontmatter: snapshotParsed.frontmatter,
-      parsedContent: snapshotParsed.content
+      parsedContent: snapshotParsed.content,
+      title: cached.title,
+      createdAt: cached.createdAt,
+      modifiedAt: now.toISOString(),
+      localOnly: cached.localOnly ?? false,
+      emoji: cached.emoji ?? null
     },
     { isNew: false }
   )
@@ -218,11 +217,11 @@ export async function restoreVersion(snapshotId: string): Promise<Note> {
   const restoredNote: Note = {
     id: cached.id,
     path: cached.path,
-    title: snapshotParsed.frontmatter.title ?? cached.title,
+    title: cached.title,
     content: snapshotParsed.content,
     frontmatter: snapshotParsed.frontmatter,
-    created: new Date(snapshotParsed.frontmatter.created),
-    modified: new Date(),
+    created: new Date(cached.createdAt),
+    modified: now,
     tags: syncResult.tags,
     aliases: snapshotParsed.frontmatter.aliases ?? [],
     wordCount: syncResult.wordCount,

--- a/apps/desktop/src/main/vault/notes.test.ts
+++ b/apps/desktop/src/main/vault/notes.test.ts
@@ -123,7 +123,7 @@ describe('notes operations', () => {
       expect(flushProjectionEventsSpy).not.toHaveBeenCalled()
     })
 
-    it('T361: creates file in correct location with frontmatter', async () => {
+    it('T361: creates file in correct location without Memry frontmatter keys', async () => {
       const result = await notes.createNote({
         title: 'My Test Note',
         content: 'This is test content.'
@@ -138,11 +138,14 @@ describe('notes operations', () => {
       const filePath = path.join(tempVault.notesDir, 'My Test Note.md')
       expect(fs.existsSync(filePath)).toBe(true)
 
-      // Verify frontmatter was written correctly
-      const { frontmatter, content } = readTestNote(filePath)
-      expect(frontmatter.id).toBe(result.id)
-      expect(frontmatter.title).toBe('My Test Note')
-      expect(content.trim()).toBe('This is test content.')
+      // No Memry keys in the file — empty frontmatter means no YAML block at all
+      const raw = fs.readFileSync(filePath, 'utf-8')
+      expect(raw).not.toContain('---')
+      expect(raw).not.toMatch(/^id:/m)
+      expect(raw).not.toMatch(/^title:/m)
+      expect(raw).not.toMatch(/^created:/m)
+      expect(raw).not.toMatch(/^modified:/m)
+      expect(raw.trim()).toBe('This is test content.')
     })
 
     it('T361: inserts note into cache', async () => {
@@ -316,26 +319,35 @@ describe('notes operations', () => {
       expect(secondGet).toBeNull()
     })
 
-    it('repairs duplicate frontmatter IDs found on disk', async () => {
-      const first = await notes.createNote({
+    it('writes no Memry keys to disk; rename leaves file bytes identical', async () => {
+      // Duplicate file ids can no longer exist — files carry no Memry identity.
+      const created = await notes.createNote({
         title: 'Duplicate A',
-        content: 'Original note.'
-      })
-      const second = await notes.createNote({
-        title: 'Duplicate B',
-        content: 'Copied note.'
+        content: 'Original note.',
+        tags: ['dup']
       })
 
-      const secondPath = path.join(tempVault.path, second.path)
-      const raw = fs.readFileSync(secondPath, 'utf-8')
-      fs.writeFileSync(secondPath, raw.replace(`id: ${second.id}`, `id: ${first.id}`))
+      const createdAbs = path.join(tempVault.path, created.path)
+      const rawBefore = fs.readFileSync(createdAbs, 'utf-8')
 
-      const repaired = await notes.getNoteById(second.id)
+      // User keys only (tags) — no id/title/created/modified lines
+      expect(rawBefore).toMatch(/^tags:/m)
+      expect(rawBefore).not.toMatch(/^id:/m)
+      expect(rawBefore).not.toMatch(/^title:/m)
+      expect(rawBefore).not.toMatch(/^created:/m)
+      expect(rawBefore).not.toMatch(/^modified:/m)
 
-      expect(repaired).not.toBeNull()
-      expect(repaired!.id).not.toBe(first.id)
-      expect(repaired!.id).not.toBe(second.id)
-      expect(repaired!.title).toBe('Duplicate B')
+      // Rename is a pure fs.rename — bytes identical apart from the path
+      const renamed = await notes.renameNote(created.id, 'Duplicate B')
+      expect(fs.existsSync(createdAbs)).toBe(false)
+      const rawAfter = fs.readFileSync(path.join(tempVault.path, renamed.path), 'utf-8')
+      expect(rawAfter).toBe(rawBefore)
+
+      // getNoteById returns identity/metadata from the cache row, not the file
+      const retrieved = await notes.getNoteById(created.id)
+      expect(retrieved).not.toBeNull()
+      expect(retrieved!.id).toBe(created.id)
+      expect(retrieved!.title).toBe('Duplicate B')
     })
   })
 
@@ -380,7 +392,12 @@ describe('notes operations', () => {
       const retrieved = await notes.getNoteByPath('notes/External.md')
 
       expect(retrieved).not.toBeNull()
-      expect(retrieved!.id).toBe('external-note-1')
+      // Legacy Memry keys in the file are plain user properties — the note
+      // gets a fresh internal id and its title from the filename
+      expect(retrieved!.id).not.toBe('external-note-1')
+      expect(retrieved!.id).toMatch(/^[a-z0-9]{12}$/)
+      expect(retrieved!.frontmatter.id).toBe('external-note-1')
+      expect(retrieved!.title).toBe('External')
       expect(retrieved!.tags).toContain('external')
     })
   })

--- a/apps/desktop/src/main/vault/rename-tracker.test.ts
+++ b/apps/desktop/src/main/vault/rename-tracker.test.ts
@@ -59,7 +59,7 @@ describe('rename-tracker', () => {
     vi.useFakeTimers()
     const onRealDelete = vi.fn().mockResolvedValue(undefined)
 
-    trackPendingDelete('note-1', 'notes/old.md', onRealDelete)
+    trackPendingDelete('note-1', 'hash-1', 'notes/old.md', onRealDelete)
 
     expect(hasPendingDeletes()).toBe(true)
     expect(getPendingDeleteCount()).toBe(1)
@@ -73,7 +73,7 @@ describe('rename-tracker', () => {
   // ==========================================================================
   // T597: checkForRename reports rename without mutating cache inline
   // ==========================================================================
-  it('returns the old path and leaves cache updates to the caller', async () => {
+  it('matches by content hash and leaves cache updates to the caller', async () => {
     const now = new Date().toISOString()
     indexDb.db
       .insert(noteCache)
@@ -89,17 +89,47 @@ describe('rename-tracker', () => {
       })
       .run()
 
-    trackPendingDelete('note-2', 'notes/old-name.md', vi.fn())
+    trackPendingDelete('note-2', 'hash', 'notes/old-name.md', vi.fn())
 
-    const oldPath = await checkForRename('note-2', 'notes/new-name.md')
+    const match = checkForRename('hash', 'notes/new-name.md')
 
-    expect(oldPath).toBe('notes/old-name.md')
+    expect(match).toEqual({ id: 'note-2', oldPath: 'notes/old-name.md' })
 
     const unchanged = indexDb.db.select().from(noteCache).where(eq(noteCache.id, 'note-2')).get()
 
     expect(unchanged?.path).toBe('notes/old-name.md')
     expect(unchanged?.title).toBe('old-name')
     expect(window.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('returns null when no pending delete matches the hash', () => {
+    trackPendingDelete('note-x', 'hash-x', 'notes/x.md', vi.fn())
+    expect(checkForRename('other-hash', 'notes/new.md')).toBeNull()
+    clearPendingDelete('note-x')
+  })
+
+  it('matches identical-hash collisions FIFO, oldest pending delete first', async () => {
+    vi.useFakeTimers()
+    const onRealDeleteA = vi.fn().mockResolvedValue(undefined)
+    const onRealDeleteB = vi.fn().mockResolvedValue(undefined)
+
+    trackPendingDelete('note-a', 'same-hash', 'notes/a.md', onRealDeleteA)
+    trackPendingDelete('note-b', 'same-hash', 'notes/b.md', onRealDeleteB)
+    expect(getPendingDeleteCount()).toBe(2)
+
+    expect(checkForRename('same-hash', 'notes/a-renamed.md')).toEqual({
+      id: 'note-a',
+      oldPath: 'notes/a.md'
+    })
+    expect(checkForRename('same-hash', 'notes/b-renamed.md')).toEqual({
+      id: 'note-b',
+      oldPath: 'notes/b.md'
+    })
+    expect(checkForRename('same-hash', 'notes/c.md')).toBeNull()
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(onRealDeleteA).not.toHaveBeenCalled()
+    expect(onRealDeleteB).not.toHaveBeenCalled()
   })
 
   it('emits rename event when the caller completes the rename', async () => {
@@ -125,8 +155,8 @@ describe('rename-tracker', () => {
     vi.useFakeTimers()
     const onRealDelete = vi.fn().mockResolvedValue(undefined)
 
-    trackPendingDelete('note-3', 'notes/old.md', onRealDelete)
-    trackPendingDelete('note-4', 'notes/old-2.md', onRealDelete)
+    trackPendingDelete('note-3', 'hash-3', 'notes/old.md', onRealDelete)
+    trackPendingDelete('note-4', 'hash-4', 'notes/old-2.md', onRealDelete)
 
     expect(getPendingDeleteCount()).toBe(2)
 

--- a/apps/desktop/src/main/vault/rename-tracker.ts
+++ b/apps/desktop/src/main/vault/rename-tracker.ts
@@ -1,9 +1,11 @@
 /**
- * Rename Tracker for UUID-based File Rename Detection
+ * Rename Tracker for content-hash-based File Rename Detection
  *
- * Detects file renames by matching UUIDs within a 500ms window.
- * chokidar emits 'unlink' then 'add' for renames - this module
- * tracks pending deletes and matches them with new files by UUID.
+ * Detects file renames by matching content hashes within a 500ms window.
+ * chokidar emits 'unlink' then 'add' for renames - this module tracks
+ * pending deletes (keyed by the cached content hash) and matches them with
+ * new files by hash. Files carry no Memry identity; the internal id lives
+ * in the sidecar DBs and is returned from the match.
  *
  * @module vault/rename-tracker
  */
@@ -31,8 +33,10 @@ const RENAME_WINDOW_MS = 500
 // ============================================================================
 
 interface PendingDelete {
-  /** Note UUID from frontmatter */
+  /** Internal note id (from the sidecar cache row) */
   id: string
+  /** Content hash of the deleted file (from the cache row) */
+  contentHash: string
   /** Old file path (relative to vault) */
   path: string
   /** Timestamp when delete was detected */
@@ -48,11 +52,12 @@ interface PendingDelete {
 // ============================================================================
 
 /**
- * Map of pending deletes keyed by UUID.
- * When a file is deleted, we store its UUID here and wait to see
- * if a new file with the same UUID appears (indicating a rename).
+ * Pending deletes keyed by content hash. When a file is deleted, we store
+ * its cached hash here and wait to see if a new file with the same content
+ * appears (indicating a rename). Identical-content collisions queue FIFO —
+ * the oldest pending delete matches first.
  */
-const pendingDeletes = new Map<string, PendingDelete>()
+const pendingDeletes = new Map<string, PendingDelete[]>()
 
 let onRenameSyncCallback: ((id: string) => void) | null = null
 
@@ -84,81 +89,101 @@ function emitNoteRenamed(event: NoteRenamedEvent): void {
 // Public API
 // ============================================================================
 
+function removePending(entry: PendingDelete): void {
+  const bucket = pendingDeletes.get(entry.contentHash)
+  if (!bucket) return
+  const index = bucket.indexOf(entry)
+  if (index !== -1) bucket.splice(index, 1)
+  if (bucket.length === 0) pendingDeletes.delete(entry.contentHash)
+}
+
 /**
  * Track a pending delete. Called when a file is deleted externally.
  * Waits for RENAME_WINDOW_MS to see if a matching 'add' event arrives.
  *
- * @param id - Note UUID from cache (before file was deleted)
+ * @param id - Internal note id from the cache row (before file was deleted)
+ * @param contentHash - Content hash from the cache row
  * @param relativePath - Relative path of the deleted file
  * @param onRealDelete - Callback to execute if this is a real delete
  */
 export function trackPendingDelete(
   id: string,
+  contentHash: string,
   relativePath: string,
   onRealDelete: () => Promise<void>
 ): void {
-  // Clear any existing pending for this ID (shouldn't happen, but be safe)
+  // Clear any existing pending for this id (shouldn't happen, but be safe)
   clearPendingDelete(id)
 
   logger.debug(`Tracking pending delete: ${id} at ${relativePath}`)
 
-  const timeout = setTimeout(() => {
-    // No matching 'add' event arrived - this is a real delete
-    const pending = pendingDeletes.get(id)
-    if (pending) {
-      logger.debug(`No rename detected for ${id}, processing as delete`)
-      pendingDeletes.delete(id)
-      void pending.onRealDelete()
-    }
-  }, RENAME_WINDOW_MS)
-
-  pendingDeletes.set(id, {
+  const entry: PendingDelete = {
     id,
+    contentHash,
     path: relativePath,
     timestamp: Date.now(),
-    timeout,
+    timeout: setTimeout(() => {
+      // No matching 'add' event arrived - this is a real delete
+      logger.debug(`No rename detected for ${id}, processing as delete`)
+      removePending(entry)
+      void entry.onRealDelete()
+    }, RENAME_WINDOW_MS),
     onRealDelete
-  })
+  }
+
+  const bucket = pendingDeletes.get(contentHash)
+  if (bucket) {
+    bucket.push(entry)
+  } else {
+    pendingDeletes.set(contentHash, [entry])
+  }
 }
 
 /**
  * Check if a newly added file matches a pending delete (indicating a rename).
- * If a match is found, the pending delete is cleared and the caller is
- * responsible for replaying the rename through projection-safe write paths.
+ * Identical-hash collisions match FIFO (oldest pending delete first). If a
+ * match is found, the pending delete is cleared and the caller is responsible
+ * for replaying the rename through projection-safe write paths.
  *
- * @param id - Note UUID from the newly added file's frontmatter
+ * @param contentHash - Content hash of the newly added file
  * @param newPath - Relative path of the new file
- * @returns The old path if this was a rename, null if it's a new file
+ * @returns The matched note id and old path if this was a rename, null if new
  */
-export function checkForRename(id: string, newPath: string): string | null {
-  const pending = pendingDeletes.get(id)
+export function checkForRename(
+  contentHash: string,
+  newPath: string
+): { id: string; oldPath: string } | null {
+  const bucket = pendingDeletes.get(contentHash)
 
-  if (!pending) {
-    // No pending delete with this UUID - it's a new file
+  if (!bucket || bucket.length === 0) {
+    // No pending delete with this content - it's a new file
     return null
   }
 
-  // Found a match! This is a rename.
+  // Found a match! This is a rename. FIFO: oldest pending delete wins.
+  const pending = bucket.shift() as PendingDelete
+  if (bucket.length === 0) pendingDeletes.delete(contentHash)
+
   logger.info(`Rename detected: ${pending.path} -> ${newPath}`)
-
-  // Clear the timeout and pending entry
   clearTimeout(pending.timeout)
-  pendingDeletes.delete(id)
 
-  return pending.path
+  return { id: pending.id, oldPath: pending.path }
 }
 
 /**
  * Clear a pending delete (e.g., when matched as a rename or on shutdown).
  *
- * @param id - Note UUID to clear
+ * @param id - Internal note id to clear
  */
 export function clearPendingDelete(id: string): void {
-  const pending = pendingDeletes.get(id)
-  if (pending) {
-    clearTimeout(pending.timeout)
-    pendingDeletes.delete(id)
-    logger.debug(`Cleared pending delete for ${id}`)
+  for (const bucket of pendingDeletes.values()) {
+    const entry = bucket.find((p) => p.id === id)
+    if (entry) {
+      clearTimeout(entry.timeout)
+      removePending(entry)
+      logger.debug(`Cleared pending delete for ${id}`)
+      return
+    }
   }
 }
 
@@ -166,9 +191,11 @@ export function clearPendingDelete(id: string): void {
  * Clear all pending deletes (e.g., on watcher shutdown).
  */
 export function clearAllPendingDeletes(): void {
-  for (const [id, pending] of pendingDeletes) {
-    clearTimeout(pending.timeout)
-    logger.debug(`Cleared pending delete for ${id} (shutdown)`)
+  for (const bucket of pendingDeletes.values()) {
+    for (const pending of bucket) {
+      clearTimeout(pending.timeout)
+      logger.debug(`Cleared pending delete for ${pending.id} (shutdown)`)
+    }
   }
   pendingDeletes.clear()
 }
@@ -184,7 +211,9 @@ export function hasPendingDeletes(): boolean {
  * Get the count of pending deletes.
  */
 export function getPendingDeleteCount(): number {
-  return pendingDeletes.size
+  let total = 0
+  for (const bucket of pendingDeletes.values()) total += bucket.length
+  return total
 }
 
 // ============================================================================
@@ -221,8 +250,12 @@ export function processRename(id: string, oldPath: string, newPath: string): voi
 }
 
 /**
- * Get a pending delete by ID (for testing/debugging).
+ * Get a pending delete by note id (for testing/debugging).
  */
 export function getPendingDelete(id: string): PendingDelete | undefined {
-  return pendingDeletes.get(id)
+  for (const bucket of pendingDeletes.values()) {
+    const entry = bucket.find((p) => p.id === id)
+    if (entry) return entry
+  }
+  return undefined
 }

--- a/apps/desktop/src/main/vault/watcher.test.ts
+++ b/apps/desktop/src/main/vault/watcher.test.ts
@@ -109,7 +109,6 @@ describe('vault watcher', () => {
   // ==========================================================================
   it('updates cache and emits UPDATED when a file changes', async () => {
     const notePath = createTestNote(vault, {
-      id: 'note-change',
       title: 'change-note',
       content: 'Old content',
       tags: ['alpha']
@@ -120,7 +119,14 @@ describe('vault watcher', () => {
 
     await watcher.handleFileAdd(notePath)
 
-    const initial = indexDb.db.select().from(noteCache).where(eq(noteCache.id, 'note-change')).get()
+    // Files carry no Memry identity — the watcher assigns a fresh internal id
+    const initial = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/change-note.md'))
+      .get()
+    expect(initial).toBeDefined()
+    const noteId = initial!.id
     const initialHash = initial?.contentHash
     const initialWordCount = initial?.wordCount ?? 0
 
@@ -133,7 +139,7 @@ describe('vault watcher', () => {
 
     await watcher.handleFileChange(notePath)
 
-    const updated = indexDb.db.select().from(noteCache).where(eq(noteCache.id, 'note-change')).get()
+    const updated = indexDb.db.select().from(noteCache).where(eq(noteCache.id, noteId)).get()
 
     expect(updated?.contentHash).not.toBe(initialHash)
     expect(updated?.wordCount).toBeGreaterThan(initialWordCount)
@@ -144,7 +150,7 @@ describe('vault watcher', () => {
         channel === NotesChannels.events.UPDATED &&
         typeof payload === 'object' &&
         payload !== null &&
-        (payload as { id?: string }).id === 'note-change'
+        (payload as { id?: string }).id === noteId
     )
     const hasCreatedEvent = sentCalls.some(
       ([channel, payload]) =>
@@ -153,7 +159,7 @@ describe('vault watcher', () => {
         payload !== null &&
         typeof (payload as { note?: { id?: string } }).note === 'object' &&
         (payload as { note?: { id?: string } }).note !== null &&
-        (payload as { note?: { id?: string } }).note?.id === 'note-change'
+        (payload as { note?: { id?: string } }).note?.id === noteId
     )
 
     expect(hasUpdatedEvent || hasCreatedEvent).toBe(true)
@@ -168,14 +174,12 @@ describe('vault watcher', () => {
     watcher.vaultPath = vault.path
 
     const targetPath = createTestNote(vault, {
-      id: 'target-note',
       title: 'Target Note',
       content: 'Target content'
     })
     await watcher.handleFileAdd(targetPath)
 
     const notePath = createTestNote(vault, {
-      id: 'note-add',
       title: 'source-note',
       content: 'See [[Target Note]]',
       tags: ['Alpha', 'Beta']
@@ -183,29 +187,27 @@ describe('vault watcher', () => {
 
     await watcher.handleFileAdd(notePath)
 
-    const cached = indexDb.db.select().from(noteCache).where(eq(noteCache.id, 'note-add')).get()
-    expect(cached?.path).toBe('notes/source-note.md')
-    const canonical = dataDb.db
+    // Fresh internal id assigned on add — resolve it via the path
+    const cached = indexDb.db
       .select()
-      .from(noteMetadata)
-      .where(eq(noteMetadata.id, 'note-add'))
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/source-note.md'))
       .get()
+    expect(cached).toBeDefined()
+    const noteId = cached!.id
+    const canonical = dataDb.db.select().from(noteMetadata).where(eq(noteMetadata.id, noteId)).get()
     expect(canonical?.path).toBe('notes/source-note.md')
 
     const tags = indexDb.db
       .select()
       .from(noteTags)
-      .where(eq(noteTags.noteId, 'note-add'))
+      .where(eq(noteTags.noteId, noteId))
       .all()
       .map((tag) => tag.tag)
       .sort()
     expect(tags).toEqual(['Alpha', 'Beta'])
 
-    const links = indexDb.db
-      .select()
-      .from(noteLinks)
-      .where(eq(noteLinks.sourceId, 'note-add'))
-      .all()
+    const links = indexDb.db.select().from(noteLinks).where(eq(noteLinks.sourceId, noteId)).all()
     if (links.length > 0) {
       expect(links).toEqual([expect.objectContaining({ targetTitle: 'Target Note' })])
     }
@@ -215,33 +217,33 @@ describe('vault watcher', () => {
     await watcher.handleFileDelete(notePath)
     await vi.advanceTimersByTimeAsync(500)
 
-    const deleted = indexDb.db.select().from(noteCache).where(eq(noteCache.id, 'note-add')).get()
+    const deleted = indexDb.db.select().from(noteCache).where(eq(noteCache.id, noteId)).get()
     expect(deleted).toBeUndefined()
     const deletedCanonical = dataDb.db
       .select()
       .from(noteMetadata)
-      .where(eq(noteMetadata.id, 'note-add'))
+      .where(eq(noteMetadata.id, noteId))
       .get()
     expect(deletedCanonical).toBeUndefined()
 
     const remainingTags = indexDb.db
       .select()
       .from(noteTags)
-      .where(eq(noteTags.noteId, 'note-add'))
+      .where(eq(noteTags.noteId, noteId))
       .all()
     expect(remainingTags).toEqual([])
 
     const remainingLinks = indexDb.db
       .select()
       .from(noteLinks)
-      .where(eq(noteLinks.sourceId, 'note-add'))
+      .where(eq(noteLinks.sourceId, noteId))
       .all()
     expect(remainingLinks).toEqual([])
 
     expect(window.webContents.send).toHaveBeenCalledWith(
       NotesChannels.events.DELETED,
       expect.objectContaining({
-        id: 'note-add',
+        id: noteId,
         path: 'notes/source-note.md',
         source: 'external'
       })
@@ -251,10 +253,9 @@ describe('vault watcher', () => {
   // ==========================================================================
   // T602: rename flow integration
   // ==========================================================================
-  it('processes rename flow via rename-tracker', async () => {
+  it('processes rename flow via rename-tracker (content-hash match)', async () => {
     vi.useFakeTimers()
     const oldPath = createTestNote(vault, {
-      id: 'note-rename',
       title: 'old-name',
       content: 'Old content'
     })
@@ -264,19 +265,25 @@ describe('vault watcher', () => {
 
     await watcher.handleFileAdd(oldPath)
 
+    const cachedBefore = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/old-name.md'))
+      .get()
+    expect(cachedBefore).toBeDefined()
+    const noteId = cachedBefore!.id
+
     window.webContents.send.mockClear()
 
-    const newPath = createTestNote(vault, {
-      id: 'note-rename',
-      title: 'new-name',
-      content: 'Old content'
-    })
+    // External rename: identical bytes at a new path — matched by content hash
+    const newPath = path.join(vault.notesDir, 'new-name.md')
+    fs.renameSync(oldPath, newPath)
 
     await watcher.handleFileDelete(oldPath)
     await watcher.handleFileAdd(newPath)
     await vi.advanceTimersByTimeAsync(500)
 
-    const updated = indexDb.db.select().from(noteCache).where(eq(noteCache.id, 'note-rename')).get()
+    const updated = indexDb.db.select().from(noteCache).where(eq(noteCache.id, noteId)).get()
 
     expect(updated?.path).toBe('notes/new-name.md')
     expect(updated?.title).toBe('new-name')
@@ -284,7 +291,7 @@ describe('vault watcher', () => {
     expect(window.webContents.send).toHaveBeenCalledWith(
       NotesChannels.events.RENAMED,
       expect.objectContaining({
-        id: 'note-rename',
+        id: noteId,
         oldPath: 'notes/old-name.md',
         newPath: 'notes/new-name.md',
         source: 'external'
@@ -332,7 +339,7 @@ describe('vault watcher', () => {
 
     expect(getWatcher().isWatching()).toBe(true)
 
-    trackPendingDelete('pending-note', 'notes/pending.md', vi.fn())
+    trackPendingDelete('pending-note', 'hash-pending', 'notes/pending.md', vi.fn())
     expect(hasPendingDeletes()).toBe(true)
 
     await stopWatcher()
@@ -513,12 +520,11 @@ describe('vault watcher', () => {
   })
 
   // ==========================================================================
-  // T604: Finder copy derives title from OS filename, not original
+  // T604: Finder copy is just a new note — fresh internal id, zero file writes
   // ==========================================================================
-  it('sets frontmatter title from OS filename when detecting a copy', async () => {
+  it('treats a copied file as a new note without writing to it', async () => {
     // #given — original note in the cache
     const originalPath = createTestNote(vault, {
-      id: 'original-id',
       title: 'my-note',
       content: 'Some content'
     })
@@ -528,7 +534,14 @@ describe('vault watcher', () => {
 
     await watcher.handleFileAdd(originalPath)
 
-    // #when — simulate Finder copy: identical frontmatter at "my-note copy.md"
+    const original = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, 'notes/my-note.md'))
+      .get()
+    expect(original).toBeDefined()
+
+    // #when — simulate Finder copy: identical bytes at "my-note copy.md"
     const copyFilename = 'my-note copy.md'
     const copyAbsPath = path.join(vault.notesDir, copyFilename)
     const originalContent = fs.readFileSync(originalPath, 'utf8')
@@ -536,11 +549,18 @@ describe('vault watcher', () => {
 
     await watcher.handleFileAdd(copyAbsPath)
 
-    // #then — copy gets new ID AND title derived from OS filename
-    const copyContent = fs.readFileSync(copyAbsPath, 'utf8')
-    const parsed = parseNote(copyContent, `notes/${copyFilename}`)
+    // #then — the watcher never writes files: both keep their exact bytes
+    expect(fs.readFileSync(copyAbsPath, 'utf8')).toBe(originalContent)
+    expect(fs.readFileSync(originalPath, 'utf8')).toBe(originalContent)
 
-    expect(parsed.frontmatter.id).not.toBe('original-id')
-    expect(parsed.frontmatter.title).toBe('my-note copy')
+    // The copy is a new note with a fresh internal id and filename-derived title
+    const copy = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.path, `notes/${copyFilename}`))
+      .get()
+    expect(copy).toBeDefined()
+    expect(copy!.id).not.toBe(original!.id)
+    expect(copy!.title).toBe('my-note copy')
   })
 })

--- a/apps/desktop/src/main/vault/watcher.ts
+++ b/apps/desktop/src/main/vault/watcher.ts
@@ -13,8 +13,8 @@ import chokidar from 'chokidar'
 import type { FSWatcher } from 'chokidar'
 import { BrowserWindow } from 'electron'
 import { getConfig } from './index'
-import { parseNote, serializeNote, generateContentHash, extractProperties } from './frontmatter'
-import { safeRead, atomicWrite } from './file-ops'
+import { parseNote, generateContentHash, extractProperties } from './frontmatter'
+import { safeRead } from './file-ops'
 import { generateNoteId } from '../lib/id'
 import { syncNoteToCache, syncFileToCache, deleteNoteFromCache } from './note-sync'
 import {
@@ -343,53 +343,33 @@ export class VaultWatcher {
       return
     }
 
-    const parsed = parseNote(content, relativePath)
+    const stats = await fs.stat(absolutePath).catch(() => null)
+    const parsed = parseNote(content, relativePath, stats ?? undefined)
 
-    // Check if this is a rename (UUID matches a pending delete)
-    const oldPath = checkForRename(parsed.frontmatter.id, relativePath)
-    if (oldPath !== null) {
-      await this.applyMarkdownRename(db, content, parsed, relativePath, oldPath)
+    // Check if this is a rename (content hash matches a pending delete);
+    // the internal id comes from the matched sidecar entry
+    const renameMatch = checkForRename(generateContentHash(content), relativePath)
+    if (renameMatch !== null) {
+      await this.applyMarkdownRename(db, content, parsed, relativePath, renameMatch)
       return
     }
 
-    // Check if a note with this ID exists at a different path
-    const existingById = getNoteCacheById(db, parsed.frontmatter.id)
-    if (existingById && existingById.path !== relativePath) {
-      const oldAbsPath = path.join(this.vaultPath!, existingById.path)
-      let oldFileExists = false
-      try {
-        await fs.access(oldAbsPath)
-        oldFileExists = true
-      } catch {
-        // old file gone
-      }
-
-      if (!oldFileExists) {
-        await this.applyMarkdownRename(db, content, parsed, relativePath, existingById.path)
-        return
-      }
-
-      // Old file still exists — genuine copy, regenerate ID + derive title from OS filename
-      const newId = generateNoteId()
-      parsed.frontmatter.id = newId
-      parsed.frontmatter.title = path.basename(relativePath, path.extname(relativePath))
-      try {
-        const newContent = serializeNote(parsed.frontmatter, parsed.content)
-        await atomicWrite(absolutePath, newContent)
-      } catch {
-        return
-      }
-    }
+    // Genuinely new external file: fresh internal id, fs-stat dates.
+    // No watcher path writes files.
+    const noteId = parsed.id
 
     // Sync to cache using NoteSyncService (handles tags, properties, FTS, links)
     const syncResult = syncNoteToCache(
       db,
       {
-        id: parsed.frontmatter.id,
+        id: noteId,
         path: relativePath,
         fileContent: content,
         frontmatter: parsed.frontmatter,
-        parsedContent: parsed.content
+        parsedContent: parsed.content,
+        title: parsed.title,
+        createdAt: parsed.created,
+        modifiedAt: parsed.modified
       },
       { isNew: true }
     )
@@ -403,28 +383,24 @@ export class VaultWatcher {
     }
 
     const noteListItem: NoteListItem = {
-      id: parsed.frontmatter.id,
+      id: noteId,
       path: relativePath,
-      title: parsed.frontmatter.title ?? path.basename(relativePath, '.md'),
-      created: new Date(parsed.frontmatter.created),
-      modified: new Date(parsed.frontmatter.modified),
+      title: parsed.title,
+      created: new Date(parsed.created),
+      modified: new Date(parsed.modified),
       tags,
       wordCount: syncResult.wordCount,
       snippet: syncResult.snippet,
-      localOnly: parsed.frontmatter.localOnly ?? false
+      localOnly: false
     }
 
     // Enqueue sync push so other devices learn about the new file
     if (isJournalPath(relativePath)) {
       const journalDate = extractJournalDate(relativePath)
-      enqueueJournalCreate(parsed.frontmatter.id, journalDate)
-      void initializeJournalCrdt(parsed.frontmatter.id, journalDate, tags)
+      enqueueJournalCreate(noteId, journalDate)
+      void initializeJournalCrdt(noteId, journalDate, tags)
     } else {
-      syncNoteCreate(
-        parsed.frontmatter.id,
-        parsed.frontmatter.title ?? path.basename(relativePath, '.md'),
-        tags
-      )
+      syncNoteCreate(noteId, parsed.title, tags)
     }
 
     // Emit event to renderer
@@ -445,8 +421,8 @@ export class VaultWatcher {
           tags,
           wordCount: syncResult.wordCount,
           characterCount: syncResult.characterCount,
-          modified: new Date(parsed.frontmatter.modified),
-          created: new Date(parsed.frontmatter.created)
+          modified: new Date(parsed.modified),
+          created: new Date(parsed.created)
         },
         source: 'external'
       })
@@ -458,16 +434,24 @@ export class VaultWatcher {
     fileContent: string,
     parsed: ReturnType<typeof parseNote>,
     relativePath: string,
-    oldPath: string
+    renameMatch: { id: string; oldPath: string }
   ): Promise<void> {
+    const { id, oldPath } = renameMatch
+    const cached = getNoteCacheById(db, id)
+
     const syncResult = syncNoteToCache(
       db,
       {
-        id: parsed.frontmatter.id,
+        id,
         path: relativePath,
         fileContent,
         frontmatter: parsed.frontmatter,
-        parsedContent: parsed.content
+        parsedContent: parsed.content,
+        title: parsed.title,
+        createdAt: cached?.createdAt ?? parsed.created,
+        modifiedAt: parsed.modified,
+        localOnly: cached?.localOnly ?? false,
+        emoji: cached?.emoji ?? null
       },
       { isNew: false }
     )
@@ -476,7 +460,7 @@ export class VaultWatcher {
       ensureTagDefinitions(getDatabase(), syncResult.tags)
     }
 
-    processRename(parsed.frontmatter.id, oldPath, relativePath)
+    processRename(id, oldPath, relativePath)
   }
 
   /**
@@ -590,7 +574,8 @@ export class VaultWatcher {
       return
     }
 
-    const parsed = parseNote(content, relativePath)
+    const stats = await fs.stat(absolutePath).catch(() => null)
+    const parsed = parseNote(content, relativePath, stats ?? undefined)
 
     const contentHash = generateContentHash(content)
 
@@ -605,7 +590,12 @@ export class VaultWatcher {
         path: relativePath,
         fileContent: content,
         frontmatter: parsed.frontmatter,
-        parsedContent: parsed.content
+        parsedContent: parsed.content,
+        title: cached.title,
+        createdAt: cached.createdAt,
+        modifiedAt: parsed.modified,
+        localOnly: cached.localOnly ?? false,
+        emoji: cached.emoji ?? null
       },
       { isNew: false }
     )
@@ -613,7 +603,7 @@ export class VaultWatcher {
 
     const tags = syncResult.tags
     const properties = extractProperties(parsed.frontmatter)
-    const title = parsed.frontmatter.title ?? path.basename(relativePath, '.md')
+    const title = cached.title
 
     if (tags.length > 0) {
       ensureTagDefinitions(getDatabase(), tags)
@@ -626,7 +616,7 @@ export class VaultWatcher {
         content: parsed.content,
         tags,
         properties,
-        modified: new Date(parsed.frontmatter.modified),
+        modified: new Date(parsed.modified),
         wordCount: syncResult.wordCount,
         snippet: syncResult.snippet
       },
@@ -646,8 +636,8 @@ export class VaultWatcher {
           tags,
           wordCount: syncResult.wordCount,
           characterCount: syncResult.characterCount,
-          modified: new Date(parsed.frontmatter.modified),
-          created: new Date(parsed.frontmatter.created)
+          modified: new Date(parsed.modified),
+          created: new Date(cached.createdAt)
         },
         source: 'external'
       })
@@ -719,8 +709,10 @@ export class VaultWatcher {
       const isJournal = isJournalPath(relativePath)
       const journalDate = isJournal ? extractJournalDate(relativePath) : null
 
-      // Track as pending delete - wait for potential rename (matching 'add' event)
-      trackPendingDelete(cached.id, relativePath, async () => {
+      // Track as pending delete - wait for potential rename (matching 'add'
+      // event with the same content hash). A missing hash never matches, so
+      // it degrades to a real delete after the window.
+      trackPendingDelete(cached.id, cached.contentHash ?? '', relativePath, async () => {
         // Enqueue sync delete BEFORE cache removal (enqueue reads cache for vector clock)
         if (isJournal && journalDate) {
           enqueueJournalDelete(cached.id, journalDate)

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -13,6 +13,25 @@ Splitting them buys three properties:
 2. **Cheap reset.** The index can be dropped and rebuilt without re-uploading anything to sync.
 3. **Performance.** Heavy read indexes and FTS triggers don't compete with the write path on the data DB.
 
+## Vault Markdown Files
+
+Vault `.md` files carry no MemryNote-managed frontmatter. The app reads only `tags` and
+`aliases` from a note's frontmatter; every other key is a plain user property. A note with
+no user keys has no YAML block at all.
+
+- **The file path is the note's identity.** The internal note id and created/modified dates
+  are stored in canonical `note_metadata` in the data DB, keyed by vault-relative path — never
+  written into the files. Legacy keys older versions wrote (`id`, `title`, `created`, `modified`)
+  are treated as plain user properties: never interpreted, never rewritten.
+- **The filename is the title.** The verbatim basename (without `.md`) round-trips to the note
+  title exactly.
+- **Rebuilds don't re-identify notes.** Indexing an unknown path adopts the canonical id from
+  `note_metadata` by path before minting a fresh one, so dropping and rebuilding the index DB
+  preserves note identity.
+- **External renames match by content hash.** The file watcher pairs a delete with a following add
+  inside a short window using the cached content hash (identical-content collisions match FIFO),
+  since files carry no embedded id to match on.
+
 ## Where the Files Live
 
 Inside the vault directory (chosen during [first run](/guide/first-run)):

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -86,3 +86,5 @@ Tags are zero-cost and discoverable. Properties are structured and great for fil
 ## Storage
 
 Tags and property values live in the data DB. Tag indexes and link graphs are mirrored into the index DB for fast lookups.
+
+In the vault's markdown files, a note's frontmatter contains only your own properties (plus `tags` and `aliases`). MemryNote keeps its internal bookkeeping — the note id and created/modified dates — in the local database and never writes its own keys into your files; a note with no properties has no frontmatter block at all.

--- a/packages/app-core/src/markdown.ts
+++ b/packages/app-core/src/markdown.ts
@@ -14,7 +14,12 @@ export function parseMarkdownNote(raw: string): ParsedMarkdownNote {
 }
 
 export function writeMarkdownNote(frontmatter: Record<string, unknown>, content: string): string {
-  return matter.stringify(content.trim(), frontmatter).trimEnd()
+  const clean = Object.fromEntries(Object.entries(frontmatter).filter(([, v]) => v !== undefined))
+  // No keys → no YAML block at all
+  if (Object.keys(clean).length === 0) {
+    return content.trim()
+  }
+  return matter.stringify(content.trim(), clean).trimEnd()
 }
 
 export function wordCount(content: string): number {

--- a/packages/app-core/src/memry-app.test.ts
+++ b/packages/app-core/src/memry-app.test.ts
@@ -140,7 +140,11 @@ test('opens a standalone vault and exposes core note, journal, task, inbox, and 
   assert.equal(snapshot?.noteId, note.id)
   await app.notes.update({ id: note.id, content: 'Changed content' })
   assert.equal((await app.versions.history(note.id))[0]?.id, snapshot?.id)
-  assert.match((await app.versions.get(snapshot?.id ?? ''))?.fileContent ?? '', /CLI Note/)
+  // Snapshot captured the pre-update file; files carry no title frontmatter
+  assert.match(
+    (await app.versions.get(snapshot?.id ?? ''))?.fileContent ?? '',
+    /Body from the command line/
+  )
   assert.equal(
     (await app.versions.restore(snapshot?.id ?? '')).content,
     'Body from the command line'

--- a/packages/app-core/src/note-files.ts
+++ b/packages/app-core/src/note-files.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { marked } from 'marked'
 import { saveCanonicalNote } from '@memry/domain-notes'
-import { getNoteMetadataById, getNoteMetadataByPath } from '@memry/storage-data'
+import { getNoteMetadataByPath } from '@memry/storage-data'
 import type { FileType } from '@memry/shared/file-types'
 import { createId } from './ids.ts'
 import type { DataDb } from './database.ts'
@@ -355,12 +355,10 @@ function indexImportedMarkdown(
   stats: { mtime: Date }
 ): void {
   const parsed = parseMarkdownNote(raw)
-  const id =
-    typeof parsed.frontmatter.id === 'string' && !getNoteMetadataById(dataDb, parsed.frontmatter.id)
-      ? parsed.frontmatter.id
-      : createId('note')
-  const title = String(parsed.frontmatter.title ?? path.basename(relativePath, '.md'))
-  const now = new Date().toISOString()
+  // Frontmatter keys are plain user properties — identity comes from the
+  // metadata DB, never from the file
+  const id = createId('note')
+  const title = path.basename(relativePath, '.md')
 
   saveCanonicalNote(dataDb, {
     id,
@@ -369,7 +367,7 @@ function indexImportedMarkdown(
     fileType: 'markdown',
     mimeType: 'text/markdown',
     properties: propertiesFromFrontmatter(parsed.frontmatter),
-    createdAt: typeof parsed.frontmatter.created === 'string' ? parsed.frontmatter.created : now,
+    createdAt: stats.mtime.toISOString(),
     modifiedAt: stats.mtime.toISOString()
   })
 }

--- a/packages/app-core/src/notes.ts
+++ b/packages/app-core/src/notes.ts
@@ -167,7 +167,7 @@ async function readNote(vaultPath: string, row: NoteMetadataRow): Promise<NoteRe
   return {
     id: row.id,
     path: row.path,
-    title: String(parsed.frontmatter.title ?? row.title),
+    title: row.title,
     content,
     tags: tagsFromFrontmatter(parsed.frontmatter),
     properties: propertiesFromFrontmatter(parsed.frontmatter),
@@ -251,12 +251,9 @@ export function createNotesService({
         notePath(config, input.title, input.folder)
       )
       const id = createId('note')
+      // User keys only — Memry identity/dates live in the metadata DB
       const frontmatter = {
-        id,
-        title: input.title,
-        created: now,
-        modified: now,
-        tags: input.tags ?? [],
+        ...(input.tags && input.tags.length > 0 ? { tags: input.tags } : {}),
         ...(input.properties && Object.keys(input.properties).length > 0
           ? { properties: input.properties }
           : {})
@@ -315,7 +312,7 @@ export function createNotesService({
       const raw = await fs.readFile(path.join(vaultPath, row.path), 'utf-8')
       const parsed = parseMarkdownNote(raw)
       const now = new Date().toISOString()
-      const nextTitle = input.title ?? String(parsed.frontmatter.title ?? row.title)
+      const nextTitle = input.title ?? row.title
       const nextProperties =
         input.properties !== undefined
           ? input.properties
@@ -323,13 +320,16 @@ export function createNotesService({
       const nextContent =
         input.content ??
         (input.append ? `${parsed.content}\n${input.append}`.trim() : parsed.content)
-      const nextFrontmatter = {
+      // User keys only — Memry identity/title/dates live in the metadata DB
+      const nextTags = input.tags ?? tagsFromFrontmatter(parsed.frontmatter)
+      const nextFrontmatter: Record<string, unknown> = {
         ...parsed.frontmatter,
-        id: row.id,
-        title: nextTitle,
-        modified: now,
-        tags: input.tags ?? tagsFromFrontmatter(parsed.frontmatter),
         ...(Object.keys(nextProperties).length > 0 ? { properties: nextProperties } : {})
+      }
+      if (nextTags.length > 0) {
+        nextFrontmatter.tags = nextTags
+      } else {
+        delete nextFrontmatter.tags
       }
       if (Object.keys(nextProperties).length === 0) delete nextFrontmatter.properties
       let nextPath = row.path
@@ -496,7 +496,7 @@ export function createNotesService({
       await fs.mkdir(path.dirname(path.join(vaultPath, relativePath)), { recursive: true })
       await fs.writeFile(
         path.join(vaultPath, relativePath),
-        writeMarkdownNote({ id, title: date, created: now, modified: now, tags: [] }, content),
+        writeMarkdownNote({}, content),
         'utf-8'
       )
       saveMetadata(dataDb, {

--- a/packages/app-core/src/versions.ts
+++ b/packages/app-core/src/versions.ts
@@ -165,7 +165,7 @@ export function createVersionsService({
 
       return notes.update({
         id: snapshot.noteId,
-        title: String(parsed.frontmatter.title ?? snapshot.title),
+        title: snapshot.title,
         content: parsed.content,
         tags,
         properties

--- a/packages/contracts/src/notes-api.ts
+++ b/packages/contracts/src/notes-api.ts
@@ -15,11 +15,12 @@ export { NotesChannels }
 // Types
 // ============================================================================
 
+/**
+ * Raw user frontmatter keys of a note. Every key is a plain user property;
+ * only `tags`/`aliases` carry Memry-read semantics. Identity, title, and
+ * dates are top-level `Note` fields sourced from the sidecar DBs.
+ */
 export interface NoteFrontmatter {
-  id: string
-  title?: string
-  created: string
-  modified: string
   tags?: string[]
   aliases?: string[]
   [key: string]: unknown

--- a/packages/rpc/src/notes.ts
+++ b/packages/rpc/src/notes.ts
@@ -13,10 +13,6 @@ import {
 } from './schema.ts'
 
 interface NoteFrontmatter {
-  id: string
-  title?: string
-  created: string
-  modified: string
   tags?: string[]
   aliases?: string[]
   [key: string]: unknown

--- a/packages/storage-data/src/note-metadata-repository.ts
+++ b/packages/storage-data/src/note-metadata-repository.ts
@@ -57,7 +57,8 @@ export function upsertNoteMetadata(db: NoteMetadataDb, metadata: NewNoteMetadata
         propertyDefinitionNames: metadata.propertyDefinitionNames,
         clock: metadata.clock,
         syncedAt: metadata.syncedAt,
-        createdAt: metadata.createdAt,
+        // createdAt intentionally omitted: preserve the original value on
+        // conflict (matches insertNoteCache in the index DB)
         modifiedAt: metadata.modifiedAt,
         storedAt: new Date().toISOString()
       }


### PR DESCRIPTION
## What
- Vault `.md` files carry no Memry-managed frontmatter: no `id`/`title`/`created`/`modified`/`emoji`/`localOnly`, no empty `tags: []`; empty frontmatter → no YAML block. Legacy keys in existing files are plain user properties.
- File path is the note's identity: internal id + dates live only in the `.memry` sidecar DBs; title = verbatim basename; in-app rename/move is a pure `fs.rename` (bytes untouched).
- External rename detection re-keyed from frontmatter UUID to content hash (FIFO on collisions); watcher/indexer never write files; index rebuilds keep ids via `note_metadata` by-path adoption.
- Journals get the same diet; seed vault emits clean files (dates via mtime, ids via seeded `note_metadata` rows).

## Why
First step of the Obsidian round-trip series (spec `docs/obs/01-frontmatter-diet.md`, approved): vault files should look like the user wrote them, exactly like Obsidian.

Known-unrelated: `importers/raindrop/map-rows.test.ts` fails on `main` too (tags case-preserving fallout).