### PR TITLE
fix(vault): correct over-broad filename sanitization from #694

### DIFF
--- a/apps/desktop/src/main/lib/export-utils.test.ts
+++ b/apps/desktop/src/main/lib/export-utils.test.ts
@@ -69,9 +69,10 @@ describe('export-utils', () => {
     expect(sanitizeFilename('a'.repeat(250))).toHaveLength(200)
   })
 
-  it('sanitizeFilename strips Obsidian-forbidden characters and falls back to untitled', () => {
-    expect(sanitizeFilename('Draft [v2] #1')).toBe('Draft v2 1')
-    expect(sanitizeFilename('a^b|c')).toBe('abc')
-    expect(sanitizeFilename('[#^]')).toBe('untitled')
+  it('sanitizeFilename does not strip Obsidian-only chars (export names are not wikilink targets)', () => {
+    // Brackets/hash/caret are legal in export defaults and Evernote folder names.
+    // Stripping them here caused `[..]` -> `..` traversal and notebook collapse.
+    expect(sanitizeFilename('Draft [v2] #1')).toBe('Draft [v2] #1')
+    expect(sanitizeFilename('[..]')).toBe('[..]')
   })
 })

--- a/apps/desktop/src/main/lib/export-utils.ts
+++ b/apps/desktop/src/main/lib/export-utils.ts
@@ -407,11 +407,14 @@ export function renderNoteAsHtml(note: NoteExportData, options: RenderOptions = 
  * Sanitize a filename for safe filesystem usage.
  */
 export function sanitizeFilename(filename: string): string {
-  // Remove or replace characters that are invalid in filenames
-  const sanitized = filename
-    .replace(/[<>:"/\\|?*[\]#^]/g, '') // Remove platform + Obsidian-forbidden chars
+  // Remove or replace characters that are invalid in filenames.
+  // Only the platform-forbidden set: these outputs (PDF/HTML export defaults,
+  // Evernote import folder names) are never Obsidian wikilink targets, so the
+  // `[ ] # ^` widening does not belong here (it caused `..` traversal, notebook
+  // collapse, and hidden-dotfile export names).
+  return filename
+    .replace(/[<>:"/\\|?*]/g, '') // Remove invalid chars
     .replace(/\s+/g, ' ') // Normalize whitespace
     .trim()
     .slice(0, 200) // Limit length
-  return sanitized.length > 0 ? sanitized : 'untitled'
 }

--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   safeRead: vi.fn(),
   fileExists: vi.fn(),
   generateNotePath: vi.fn(),
+  generateUniquePath: vi.fn(),
   ensureDirectory: vi.fn(),
   deleteFile: vi.fn(),
   parseNote: vi.fn(),
@@ -68,6 +69,7 @@ vi.mock('../vault/file-ops', () => ({
   safeRead: (...args: unknown[]) => mocks.safeRead(...args),
   fileExists: (...args: unknown[]) => mocks.fileExists(...args),
   generateNotePath: (...args: unknown[]) => mocks.generateNotePath(...args),
+  generateUniquePath: (...args: unknown[]) => mocks.generateUniquePath(...args),
   ensureDirectory: (...args: unknown[]) => mocks.ensureDirectory(...args),
   deleteFile: (...args: unknown[]) => mocks.deleteFile(...args)
 }))
@@ -163,6 +165,7 @@ describe('crdt writeback', () => {
     mocks.toRelativePath.mockImplementation((absolute: string) => absolute.replace('/vault/', ''))
     mocks.getNotesDir.mockReturnValue('/vault/notes')
     mocks.generateNotePath.mockReturnValue('/vault/notes/New.md')
+    mocks.generateUniquePath.mockImplementation((p: string) => Promise.resolve(p))
     mocks.getJournalPath.mockImplementation((date: string) => `/vault/journal/${date}.md`)
     mocks.fileExists.mockResolvedValue(false)
     mocks.atomicWrite.mockResolvedValue(undefined)

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -9,6 +9,7 @@ import {
   safeRead,
   fileExists,
   generateNotePath,
+  generateUniquePath,
   ensureDirectory
 } from '../vault/file-ops'
 import { parseNote, serializeNote, type NoteFrontmatter } from '../vault/frontmatter'
@@ -265,7 +266,10 @@ async function writebackNewNote(
   const title = (meta.get('title') as string) || 'Untitled'
 
   const notesDir = getNotesDir()
-  const absolutePath = generateNotePath(notesDir, title)
+  // Guard against filename collisions: distinct titles can sanitize to the same
+  // basename (e.g. `Report #1` and `Report 1`), which would otherwise overwrite
+  // an existing note's file and orphan an index row. Mirrors createNote.
+  const absolutePath = await generateUniquePath(generateNotePath(notesDir, title))
   const relativePath = toRelativePath(absolutePath)
 
   const frontmatter = mergeFrontmatter(null, doc)

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.test.ts
@@ -325,6 +325,49 @@ describe('noteHandler.applyUpsert — path collision', () => {
     })
   })
 
+  it('preserves a legacy bracketed basename on a folder-only move (no retroactive rename)', () => {
+    // #given — a legacy on-disk file whose basename predates the sanitizer widening
+    mockGetNoteMetadataById.mockReturnValue({
+      id: 'note-1',
+      title: 'Team [q3]',
+      path: path.join('notes', 'Old', 'Team [q3].md'),
+      emoji: null,
+      fileType: 'markdown',
+      mimeType: null,
+      fileSize: null,
+      attachmentId: null,
+      clock: { dev1: 1 },
+      createdAt: '2024-01-01T00:00:00.000Z',
+      modifiedAt: '2024-01-01T00:00:00.000Z'
+    })
+    vi.mocked(extractFolderFromPath).mockReturnValueOnce('Old')
+    fs.mkdirSync(path.join(NOTES_DIR, 'Old'), { recursive: true })
+    fs.writeFileSync(path.join(NOTES_DIR, 'Old', 'Team [q3].md'), '---\n---\nold content')
+
+    // #when — only the folder changes; the title is unchanged
+    const result = noteHandler.applyUpsert(
+      ctx,
+      'note-1',
+      makeNotePayload({ title: 'Team [q3]', folderPath: 'New', properties: {} }),
+      { dev1: 2 }
+    )
+
+    // #then — basename is preserved byte-for-byte, only the folder moves
+    expect(result).toBe('applied')
+    expect(updateNoteCache).toHaveBeenCalledWith(
+      {},
+      'note-1',
+      expect.objectContaining({ path: path.join('notes', 'New', 'Team [q3].md') })
+    )
+    expect(ctx.emit).toHaveBeenCalledWith(NotesChannels.events.MOVED, {
+      id: 'note-1',
+      oldPath: path.join('notes', 'Old', 'Team [q3].md'),
+      newPath: path.join('notes', 'New', 'Team [q3].md'),
+      source: 'sync'
+    })
+    expect(ctx.emit).not.toHaveBeenCalledWith(NotesChannels.events.RENAMED, expect.any(Object))
+  })
+
   it('returns conflict for concurrent markdown updates and tolerates frontmatter write failures', () => {
     mockGetNoteMetadataById.mockReturnValue({
       id: 'note-1',

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.ts
@@ -125,7 +125,12 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
             ? (getExtensionFromMimeType(existing.mimeType) ??
               getDefaultExtension(existing.fileType))
             : getDefaultExtension(existing.fileType)
-          const baseAbsPath = generateFilePath(notesDir, newTitle, ext, remoteFolder ?? undefined)
+          // Folder-only move (title unchanged): preserve the existing on-disk
+          // basename byte-for-byte instead of re-deriving it through the
+          // sanitizer, which would retroactively rename legacy files.
+          const baseAbsPath = titleChanged
+            ? generateFilePath(notesDir, newTitle, ext, remoteFolder ?? undefined)
+            : path.join(notesDir, remoteFolder ?? '', path.basename(existing.path))
           const newAbsPath = generateUniquePathSync(
             baseAbsPath,
             (p) => !!getNoteCacheByPath(indexDb, toRelativePath(p))
@@ -220,7 +225,12 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
 
       if (needsPathUpdate) {
         const notesDir = getNotesDir()
-        const baseAbsPath = generateNotePath(notesDir, newTitle, remoteFolder ?? undefined)
+        // Folder-only move (title unchanged): preserve the existing on-disk
+        // basename byte-for-byte instead of re-deriving it through the
+        // sanitizer, which would retroactively rename legacy files.
+        const baseAbsPath = titleChanged
+          ? generateNotePath(notesDir, newTitle, remoteFolder ?? undefined)
+          : path.join(notesDir, remoteFolder ?? '', path.basename(existing.path))
         const newAbsPath = generateUniquePathSync(
           baseAbsPath,
           (p) => !!getNoteCacheByPath(indexDb, toRelativePath(p))

--- a/apps/desktop/src/main/vault/file-ops.test.ts
+++ b/apps/desktop/src/main/vault/file-ops.test.ts
@@ -476,9 +476,10 @@ describe('sanitizeFilename', () => {
     expect(sanitizeFilename('???')).toBe('untitled')
   })
 
-  it('T350: strips only one leading dot', () => {
-    // Function removes one leading dot, leaving '..' which is not empty
-    expect(sanitizeFilename('...')).toBe('..')
+  it('T350: strips all leading dots and rejects bare dot names', () => {
+    // Loops the dot-strip so nothing collapses to a `.`/`..` fs reference.
+    expect(sanitizeFilename('...')).toBe('untitled')
+    expect(sanitizeFilename('..')).toBe('untitled')
     expect(sanitizeFilename('.hidden')).toBe('hidden')
   })
 
@@ -496,6 +497,13 @@ describe('sanitizeFilename', () => {
     expect(sanitizeFilename('Draft [v2] #1')).toBe('Draft v2 1')
     expect(sanitizeFilename('a^b|c')).toBe('abc')
     expect(sanitizeFilename('[#^]')).toBe('untitled')
+  })
+
+  it('T350: bracket-stripping never yields a dot-traversal or leading-space name', () => {
+    // Widened set can leave dots/spaces once brackets go; guard must clean up.
+    expect(sanitizeFilename('[...]')).toBe('untitled')
+    expect(sanitizeFilename('[..]')).toBe('untitled')
+    expect(sanitizeFilename('#. Report')).toBe('Report')
   })
 })
 

--- a/apps/desktop/src/main/vault/file-ops.ts
+++ b/apps/desktop/src/main/vault/file-ops.ts
@@ -304,12 +304,14 @@ export function sanitizeFilename(filename: string): string {
     .replace(/\s+/g, ' ') // Collapse whitespace
     .trim()
 
-  // Ensure it doesn't start with a dot (hidden file)
-  if (sanitized.startsWith('.')) {
-    sanitized = sanitized.slice(1)
+  // Strip every leading dot (hidden files) and re-trim any whitespace it
+  // exposes. Loop because stripping the widened char set can leave `..` or
+  // `. Report`; a single slice would keep a `..` traversal or a leading space.
+  while (sanitized.startsWith('.')) {
+    sanitized = sanitized.slice(1).trim()
   }
 
-  // Ensure it's not empty
+  // Ensure it's not empty (also catches bare `.` / `..`, which reduce to '')
   if (sanitized.length === 0) {
     sanitized = 'untitled'
   }


### PR DESCRIPTION
Follow-up to #694. That PR widened the sanitizer to strip `[ ] # ^` everywhere, which was too broad in a few spots. This narrows it and closes the resulting gaps.

## Fixes
- **export-utils**: reverts the `[ ] # ^` widening for export/import filenames (PDF/HTML export, Evernote notebook folders). Those are never Obsidian wikilink targets, and the widening caused `..` traversal, notebook-name collapse, and hidden dotfile export names. Back to the platform-forbidden set only.
- **sanitizeFilename**: loop-strip leading dots and re-trim, so stripping the widened set can't leave a `..` traversal or a leading-space name. Bare `.` / `..` now reduce to `untitled`.
- **crdt-writeback (new note)**: wrap the path in `generateUniquePath` — distinct titles that sanitize to the same basename no longer overwrite an existing note and orphan its index row. Mirrors `createNote`.
- **note-handler**: on a folder-only move (title unchanged), preserve the on-disk basename byte-for-byte instead of re-deriving it through the sanitizer, which would retroactively rename legacy files.

## Verify
- `crdt-writeback`, `file-ops`, `export-utils`, `note-handler` main-process tests: 88 pass
- `typecheck:node`: clean