### PR TITLE
test(desktop,sync-server): backfill coverage for untested gaps

### DIFF
--- a/apps/desktop/src/main/projections/bus.test.ts
+++ b/apps/desktop/src/main/projections/bus.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+
+import { ProjectionBus } from './bus'
+import type { ProjectionEvent } from './types'
+
+const ev = (id: string) => ({ type: 'note.updated', itemId: id }) as unknown as ProjectionEvent
+
+describe('ProjectionBus', () => {
+  it('dequeues in FIFO order and tracks size', () => {
+    // #given
+    const bus = new ProjectionBus()
+    expect(bus.size).toBe(0)
+
+    // #when
+    bus.enqueue(ev('a'))
+    bus.enqueue(ev('b'))
+
+    // #then
+    expect(bus.size).toBe(2)
+    expect(bus.dequeue()).toEqual(ev('a'))
+    expect(bus.dequeue()).toEqual(ev('b'))
+    expect(bus.size).toBe(0)
+  })
+
+  it('returns undefined when draining past empty', () => {
+    const bus = new ProjectionBus()
+    expect(bus.dequeue()).toBeUndefined()
+  })
+
+  it('clear() drops all pending events', () => {
+    // #given
+    const bus = new ProjectionBus()
+    bus.enqueue(ev('a'))
+    bus.enqueue(ev('b'))
+
+    // #when
+    bus.clear()
+
+    // #then
+    expect(bus.size).toBe(0)
+    expect(bus.dequeue()).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/settings/saved-filters-sync.test.ts
+++ b/apps/desktop/src/main/settings/saved-filters-sync.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  enqueueLocalSyncCreate: vi.fn(),
+  enqueueLocalSyncUpdate: vi.fn(),
+  enqueueLocalSyncDelete: vi.fn()
+}))
+
+vi.mock('../sync/local-mutations', () => ({
+  enqueueLocalSyncCreate: mocks.enqueueLocalSyncCreate,
+  enqueueLocalSyncUpdate: mocks.enqueueLocalSyncUpdate,
+  enqueueLocalSyncDelete: mocks.enqueueLocalSyncDelete
+}))
+
+import { syncFilterCreate, syncFilterUpdate, syncFilterDelete } from './saved-filters-sync'
+
+describe('saved-filters-sync', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('enqueues create/update under the "filter" sync item type', () => {
+    syncFilterCreate('filter-1')
+    syncFilterUpdate('filter-1')
+
+    expect(mocks.enqueueLocalSyncCreate).toHaveBeenCalledWith('filter', 'filter-1')
+    expect(mocks.enqueueLocalSyncUpdate).toHaveBeenCalledWith('filter', 'filter-1')
+  })
+
+  it('forwards the tombstone snapshot on delete', () => {
+    const snapshot = '{"id":"filter-1","clock":{"device":1}}'
+    syncFilterDelete('filter-1', snapshot)
+
+    expect(mocks.enqueueLocalSyncDelete).toHaveBeenCalledWith('filter', 'filter-1', snapshot)
+  })
+})

--- a/apps/desktop/src/preload/lib/ipc.test.ts
+++ b/apps/desktop/src/preload/lib/ipc.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  sendSync: vi.fn(),
+  send: vi.fn(),
+  on: vi.fn(),
+  removeListener: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: mocks.invoke,
+    sendSync: mocks.sendSync,
+    send: mocks.send,
+    on: mocks.on,
+    removeListener: mocks.removeListener
+  }
+}))
+
+import { invoke, invokeSync, send, subscribe } from './ipc'
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('preload ipc primitives', () => {
+  it('invoke forwards channel + args and returns the underlying promise', async () => {
+    mocks.invoke.mockResolvedValue('ok')
+    const result = await invoke('some:channel' as never, { a: 1 } as never)
+    expect(mocks.invoke).toHaveBeenCalledWith('some:channel', { a: 1 })
+    expect(result).toBe('ok')
+  })
+
+  it('invokeSync uses sendSync', () => {
+    mocks.sendSync.mockReturnValue(7)
+    expect(invokeSync('sync:channel')).toBe(7)
+    expect(mocks.sendSync).toHaveBeenCalledWith('sync:channel')
+  })
+
+  it('send forwards channel + args', () => {
+    send('evt:channel', 'x', 'y')
+    expect(mocks.send).toHaveBeenCalledWith('evt:channel', 'x', 'y')
+  })
+})
+
+describe('subscribe reference counting', () => {
+  // channelSubscriptions is module-level state, so give each test a fresh channel name.
+  it('registers a single ipcRenderer listener per channel and fans out to all callbacks', () => {
+    // #given two subscribers on the same channel
+    const a = vi.fn()
+    const b = vi.fn()
+    subscribe('chan-fanout', a)
+    subscribe('chan-fanout', b)
+
+    // #then only one underlying listener is attached
+    expect(mocks.on).toHaveBeenCalledTimes(1)
+    expect(mocks.on).toHaveBeenCalledWith('chan-fanout', expect.any(Function))
+
+    // #when the shared handler receives a payload
+    const handler = mocks.on.mock.calls[0][1] as (e: unknown, p: unknown) => void
+    handler({}, { hello: 'world' })
+
+    // #then both callbacks fire with the payload (not the event)
+    expect(a).toHaveBeenCalledWith({ hello: 'world' })
+    expect(b).toHaveBeenCalledWith({ hello: 'world' })
+  })
+
+  it('unsubscribing one callback keeps the listener alive for the rest', () => {
+    // #given
+    const a = vi.fn()
+    const b = vi.fn()
+    const offA = subscribe('chan-partial', a)
+    subscribe('chan-partial', b)
+    const handler = mocks.on.mock.calls[0][1] as (e: unknown, p: unknown) => void
+
+    // #when a unsubscribes
+    offA()
+    handler({}, 'ping')
+
+    // #then only b receives, listener not removed
+    expect(a).not.toHaveBeenCalled()
+    expect(b).toHaveBeenCalledWith('ping')
+    expect(mocks.removeListener).not.toHaveBeenCalled()
+  })
+
+  it('removes the underlying listener when the last callback unsubscribes', () => {
+    // #given
+    const off = subscribe('chan-last', vi.fn())
+    const handler = mocks.on.mock.calls[0][1]
+
+    // #when
+    off()
+
+    // #then
+    expect(mocks.removeListener).toHaveBeenCalledWith('chan-last', handler)
+
+    // and a fresh subscribe re-attaches (map entry was cleaned up)
+    subscribe('chan-last', vi.fn())
+    expect(mocks.on).toHaveBeenCalledTimes(2)
+  })
+
+  it('is idempotent — calling the unsubscribe twice is a no-op', () => {
+    const off = subscribe('chan-idem', vi.fn())
+    off()
+    off()
+    expect(mocks.removeListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/tests/e2e/saved-filters-events.e2e.ts
+++ b/apps/desktop/tests/e2e/saved-filters-events.e2e.ts
@@ -1,0 +1,75 @@
+import { test, expect } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+
+// CRUD for saved filters is covered by tasks-kanban.e2e. This covers the untested
+// half: the main->renderer IPC event fan-out (onSavedFilterCreated/Updated/Deleted)
+// that renderer subscribers rely on, exercised end-to-end through real electron.
+test.describe('Saved filter IPC events E2E', () => {
+  test('create/update/delete emit their events to renderer subscribers', async ({ page }) => {
+    await ready(page)
+
+    const filterName = `Events ${Date.now()}`
+
+    const result = await page.evaluate(async (name) => {
+      const api = window.api
+      const tick = () => new Promise((resolve) => setTimeout(resolve, 150))
+
+      const created: Array<{ savedFilter: { id: string; name: string } }> = []
+      const updated: Array<{ id: string; savedFilter: { name: string } }> = []
+      const deleted: Array<{ id: string }> = []
+
+      const offCreated = api.onSavedFilterCreated((e) => created.push(e as never))
+      const offUpdated = api.onSavedFilterUpdated((e) => updated.push(e as never))
+      const offDeleted = api.onSavedFilterDeleted((e) => deleted.push(e as never))
+
+      const createRes = await api.savedFilters.create({
+        name,
+        config: {
+          filters: {
+            search: '',
+            projectIds: [],
+            priorities: [],
+            dueDate: { type: 'any', customStart: null, customEnd: null },
+            statusIds: [],
+            completion: 'all',
+            repeatType: 'all',
+            hasTime: 'all'
+          },
+          sort: { field: 'priority', direction: 'desc' },
+          starred: false
+        }
+      })
+      if (!createRes.success || !createRes.savedFilter) {
+        throw new Error(createRes.error ?? 'create failed')
+      }
+      const id = createRes.savedFilter.id
+      await tick()
+
+      await api.savedFilters.update({ id, name: `${name} Updated` })
+      await tick()
+
+      await api.savedFilters.delete(id)
+      await tick()
+
+      offCreated()
+      offUpdated()
+      offDeleted()
+
+      return { id, created, updated, deleted }
+    }, filterName)
+
+    // created event carries the new filter
+    expect(result.created.map((e) => e.savedFilter.name)).toContain(filterName)
+
+    // updated event carries the id and new name
+    expect(result.updated).toContainEqual(
+      expect.objectContaining({
+        id: result.id,
+        savedFilter: expect.objectContaining({ name: `${filterName} Updated` })
+      })
+    )
+
+    // deleted event carries the id
+    expect(result.deleted).toContainEqual(expect.objectContaining({ id: result.id }))
+  })
+})

--- a/apps/sync-server/src/durable-objects/linking-session.test.ts
+++ b/apps/sync-server/src/durable-objects/linking-session.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest'
+
+import { LinkingSession } from './linking-session'
+
+// The mocked cloudflare:workers DurableObject ships a non-persisting storage stub
+// (get() always returns null, no deleteAll). Swap in a Map-backed storage so we can
+// exercise real create -> transition -> status round-trips.
+function makeStorage() {
+  const map = new Map<string, unknown>()
+  let alarm: number | null = null
+  return {
+    map,
+    get: async (key: string) => (map.has(key) ? map.get(key) : undefined),
+    put: async (key: string, value: unknown) => {
+      map.set(key, value)
+    },
+    getAlarm: async () => alarm,
+    setAlarm: async (scheduledTime: number) => {
+      alarm = scheduledTime
+    },
+    deleteAll: async () => {
+      map.clear()
+      alarm = null
+    }
+  }
+}
+
+function createDO() {
+  const doObj = new LinkingSession({} as DurableObjectState, {} as never)
+  const storage = makeStorage()
+  ;(doObj as unknown as { ctx: { storage: unknown } }).ctx.storage = storage
+  return { doObj, storage }
+}
+
+function req(path: string, body?: unknown): Request {
+  return new Request(`https://do.internal${path}`, {
+    method: body === undefined ? 'GET' : 'POST',
+    headers: body === undefined ? {} : { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body)
+  })
+}
+
+const nowSec = () => Math.floor(Date.now() / 1000)
+
+function createBody(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: 'sess-1',
+    userId: 'user-1',
+    initiatorDeviceId: 'device-1',
+    expiresAt: nowSec() + 1000,
+    ...overrides
+  }
+}
+
+describe('LinkingSession', () => {
+  describe('/create', () => {
+    it('stores pending meta and arms the expiry alarm', async () => {
+      // #given
+      const { doObj, storage } = createDO()
+      const expiresAt = nowSec() + 300
+
+      // #when
+      const res = await doObj.fetch(req('/create', createBody({ expiresAt })))
+
+      // #then
+      expect(await res.json()).toEqual({ ok: true })
+      expect(storage.map.get('meta')).toEqual({
+        sessionId: 'sess-1',
+        userId: 'user-1',
+        initiatorDeviceId: 'device-1',
+        status: 'pending',
+        expiresAt
+      })
+      expect(await storage.getAlarm()).toBe(expiresAt * 1000)
+    })
+  })
+
+  describe('transitions', () => {
+    it.each([
+      ['/scan', 'scanned'],
+      ['/approve', 'approved'],
+      ['/complete', 'completed']
+    ])('%s advances status to %s and echoes owner identity', async (path, expected) => {
+      // #given
+      const { doObj, storage } = createDO()
+      await doObj.fetch(req('/create', createBody()))
+
+      // #when
+      const res = await doObj.fetch(req(path, {}))
+
+      // #then
+      expect(await res.json()).toEqual({
+        ok: true,
+        userId: 'user-1',
+        initiatorDeviceId: 'device-1'
+      })
+      expect((storage.map.get('meta') as { status: string }).status).toBe(expected)
+    })
+
+    it('returns 404 when transitioning a session that was never created', async () => {
+      // #given
+      const { doObj } = createDO()
+
+      // #when
+      const res = await doObj.fetch(req('/approve', {}))
+
+      // #then
+      expect(res.status).toBe(404)
+      expect(await res.json()).toEqual({ error: 'Session not found in DO' })
+    })
+  })
+
+  describe('/status', () => {
+    it('reports expired when no session exists', async () => {
+      // #given
+      const { doObj } = createDO()
+
+      // #when
+      const res = await doObj.fetch(req('/status'))
+
+      // #then
+      expect(await res.json()).toEqual({ status: 'expired', expiresAt: null })
+    })
+
+    it('reports the live status while the session is unexpired', async () => {
+      // #given
+      const { doObj } = createDO()
+      const expiresAt = nowSec() + 1000
+      await doObj.fetch(req('/create', createBody({ expiresAt })))
+      await doObj.fetch(req('/scan', {}))
+
+      // #when
+      const res = await doObj.fetch(req('/status'))
+
+      // #then
+      expect(await res.json()).toEqual({ status: 'scanned', expiresAt })
+    })
+
+    it('reports expired once the deadline has passed even if meta remains', async () => {
+      // #given — meta persisted but expiry is in the past
+      const { doObj } = createDO()
+      const expiresAt = nowSec() - 5
+      await doObj.fetch(req('/create', createBody({ expiresAt })))
+
+      // #when
+      const res = await doObj.fetch(req('/status'))
+
+      // #then
+      expect(await res.json()).toEqual({ status: 'expired', expiresAt })
+    })
+  })
+
+  describe('alarm', () => {
+    it('wipes all session storage on expiry', async () => {
+      // #given
+      const { doObj, storage } = createDO()
+      await doObj.fetch(req('/create', createBody()))
+      expect(storage.map.size).toBe(1)
+
+      // #when
+      await doObj.alarm()
+
+      // #then
+      expect(storage.map.size).toBe(0)
+      expect(await storage.getAlarm()).toBeNull()
+    })
+  })
+
+  it('returns 404 for unknown paths', async () => {
+    // #given
+    const { doObj } = createDO()
+
+    // #when
+    const res = await doObj.fetch(req('/nope'))
+
+    // #then
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe('Not found')
+  })
+})


### PR DESCRIPTION
## What
Backfill tests for the genuinely-untested surfaces found auditing `apps/desktop` + `apps/sync-server` coverage:

- `linking-session` DO — device-linking state machine, expiry, alarm wipe (the one DO excluded from the 90% coverage gate)
- `ProjectionBus` FIFO queue
- `saved-filters-sync` — locks the `filter` sync item-type wiring
- preload `lib/ipc` — `subscribe` reference-counted listener teardown
- e2e: saved-filter IPC event fan-out (`create`/`update`/`delete`) — CRUD was covered, the events weren't

## Why
Both apps already enforce coverage gates; these five files were the real holes those gates didn't reach.