### PR TITLE
fix(desktop): recover from startup failures instead of an invisible window

### DIFF
--- a/apps/desktop/src/main/gpu-crash-guard.test.ts
+++ b/apps/desktop/src/main/gpu-crash-guard.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GpuGuardMarker } from './gpu-crash-guard'
 
 const mocks = vi.hoisted(() => ({
   app: {
     isPackaged: true,
+    disableHardwareAcceleration: vi.fn(),
     getVersion: vi.fn(() => '2026.702.2'),
     getPath: vi.fn((name: string) => `/userdata/${name}`)
   }
@@ -15,11 +16,17 @@ vi.mock('./lib/logger', () => ({
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
 }))
 
-import { shouldDisableHwAccel } from './gpu-crash-guard'
+import { readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { applyGpuCrashGuard, recordGpuCrash, shouldDisableHwAccel } from './gpu-crash-guard'
 
 function marker(overrides: Partial<GpuGuardMarker> = {}): GpuGuardMarker {
   return { disabledForGpu: true, version: '2026.702.2', ...overrides }
 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.app.isPackaged = true
+})
 
 describe('shouldDisableHwAccel', () => {
   it('disables when a crash was recorded for the current version', () => {
@@ -36,5 +43,52 @@ describe('shouldDisableHwAccel', () => {
 
   it('does not disable when the marker is not a disable directive', () => {
     expect(shouldDisableHwAccel(marker({ disabledForGpu: false }), '2026.702.2')).toBe(false)
+  })
+})
+
+describe('applyGpuCrashGuard', () => {
+  it('is a no-op in development (unpackaged) and never reads a marker', () => {
+    mocks.app.isPackaged = false
+    applyGpuCrashGuard()
+    expect(readFileSync).not.toHaveBeenCalled()
+    expect(mocks.app.disableHardwareAcceleration).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when there is no marker file', () => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+    applyGpuCrashGuard()
+    expect(mocks.app.disableHardwareAcceleration).not.toHaveBeenCalled()
+    expect(rmSync).not.toHaveBeenCalled()
+  })
+
+  it('disables hardware acceleration when a crash was recorded for this version', () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify(marker()))
+    applyGpuCrashGuard()
+    expect(mocks.app.disableHardwareAcceleration).toHaveBeenCalledTimes(1)
+    expect(rmSync).not.toHaveBeenCalled()
+  })
+
+  it('clears a stale marker from an older version and retries hardware acceleration', () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify(marker({ version: '2026.701.9' })))
+    applyGpuCrashGuard()
+    expect(mocks.app.disableHardwareAcceleration).not.toHaveBeenCalled()
+    expect(rmSync).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('recordGpuCrash', () => {
+  it('is a no-op in development (unpackaged)', () => {
+    mocks.app.isPackaged = false
+    recordGpuCrash()
+    expect(writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('writes a version-scoped disable marker', () => {
+    recordGpuCrash()
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const [, payload] = vi.mocked(writeFileSync).mock.calls[0]
+    expect(JSON.parse(payload as string)).toEqual({ disabledForGpu: true, version: '2026.702.2' })
   })
 })

--- a/apps/desktop/src/main/gpu-crash-guard.test.ts
+++ b/apps/desktop/src/main/gpu-crash-guard.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GpuGuardMarker } from './gpu-crash-guard'
+
+const mocks = vi.hoisted(() => ({
+  app: {
+    isPackaged: true,
+    getVersion: vi.fn(() => '2026.702.2'),
+    getPath: vi.fn((name: string) => `/userdata/${name}`)
+  }
+}))
+
+vi.mock('electron', () => ({ app: mocks.app }))
+vi.mock('node:fs', () => ({ readFileSync: vi.fn(), writeFileSync: vi.fn(), rmSync: vi.fn() }))
+vi.mock('./lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import { shouldDisableHwAccel } from './gpu-crash-guard'
+
+function marker(overrides: Partial<GpuGuardMarker> = {}): GpuGuardMarker {
+  return { disabledForGpu: true, version: '2026.702.2', ...overrides }
+}
+
+describe('shouldDisableHwAccel', () => {
+  it('disables when a crash was recorded for the current version', () => {
+    expect(shouldDisableHwAccel(marker(), '2026.702.2')).toBe(true)
+  })
+
+  it('does not disable when there is no marker', () => {
+    expect(shouldDisableHwAccel(null, '2026.702.2')).toBe(false)
+  })
+
+  it('does not disable when the marker is from an older version (retry on new build)', () => {
+    expect(shouldDisableHwAccel(marker({ version: '2026.701.9' }), '2026.702.2')).toBe(false)
+  })
+
+  it('does not disable when the marker is not a disable directive', () => {
+    expect(shouldDisableHwAccel(marker({ disabledForGpu: false }), '2026.702.2')).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/gpu-crash-guard.ts
+++ b/apps/desktop/src/main/gpu-crash-guard.ts
@@ -1,0 +1,98 @@
+import { app } from 'electron'
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { createLogger } from './lib/logger'
+
+const logger = createLogger('GpuCrashGuard')
+
+// Persisted next to the app's other guard markers. When a prior launch saw the
+// GPU process die (common on old/blacklisted Windows GPUs, where the window is
+// created but never composites — process alive, no visible window), we record
+// it here and disable hardware acceleration on the NEXT launch so the app can
+// paint via software rendering instead of stranding the user on an invisible
+// window. Scoped by version so a fresh build re-attempts hardware acceleration
+// (the auto-update itself becomes the retry), never permanently kneecapping it.
+export interface GpuGuardMarker {
+  disabledForGpu: boolean
+  version: string
+}
+
+/**
+ * Pure decision: should this launch disable hardware acceleration? Only when a
+ * marker says a GPU crash was recorded for the version we are currently running.
+ * A marker from a different version means a new build is in play — retry HW accel.
+ */
+export function shouldDisableHwAccel(
+  marker: GpuGuardMarker | null,
+  currentVersion: string
+): boolean {
+  if (!marker || !marker.disabledForGpu) return false
+  return marker.version === currentVersion
+}
+
+function markerPath(): string {
+  return join(app.getPath('userData'), 'gpu-crash-guard.json')
+}
+
+function safeVersion(): string {
+  return typeof app.getVersion === 'function' ? app.getVersion() : '0.0.0'
+}
+
+function readGpuGuard(): GpuGuardMarker | null {
+  try {
+    const parsed = JSON.parse(readFileSync(markerPath(), 'utf8')) as Partial<GpuGuardMarker>
+    if (typeof parsed.disabledForGpu === 'boolean' && typeof parsed.version === 'string') {
+      return { disabledForGpu: parsed.disabledForGpu, version: parsed.version }
+    }
+  } catch {
+    // Missing or corrupt marker → treat as no prior GPU crash.
+  }
+  return null
+}
+
+function clearGpuGuard(): void {
+  try {
+    rmSync(markerPath(), { force: true })
+  } catch (err) {
+    logger.warn('failed to clear gpu-crash marker', err)
+  }
+}
+
+/**
+ * Called once at module load, before app 'ready'. Disables hardware acceleration
+ * if a GPU crash was recorded for the current version; clears a stale marker from
+ * an older version so the new build gets a fresh chance with HW accel.
+ * disableHardwareAcceleration() MUST run before the app is ready, so this is a
+ * synchronous, best-effort call on the startup path.
+ */
+export function applyGpuCrashGuard(): void {
+  if (!app.isPackaged) return
+  const marker = readGpuGuard()
+  if (!marker) return
+
+  if (shouldDisableHwAccel(marker, safeVersion())) {
+    try {
+      app.disableHardwareAcceleration()
+      logger.warn('hardware acceleration disabled after a prior GPU crash on this version')
+    } catch (err) {
+      logger.warn('failed to disable hardware acceleration', err)
+    }
+    return
+  }
+
+  // Marker is from an older version — a new build may render fine. Drop it so
+  // this launch retries hardware acceleration.
+  clearGpuGuard()
+}
+
+/** Record that the GPU process died so the next launch falls back to software rendering. */
+export function recordGpuCrash(): void {
+  if (!app.isPackaged) return
+  try {
+    const marker: GpuGuardMarker = { disabledForGpu: true, version: safeVersion() }
+    writeFileSync(markerPath(), JSON.stringify(marker))
+    logger.warn('recorded GPU crash; hardware acceleration will be disabled on next launch')
+  } catch (err) {
+    logger.warn('failed to write gpu-crash marker', err)
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -75,6 +75,7 @@ import { SettingsChannels, InboxChannels } from '@memry/contracts/ipc-channels'
 import { parseInboxOpenItemId } from './deeplink-utils'
 import { initializeUpdater, isQuitAndInstallRequested, performQuitAndInstall } from './updater'
 import { clearPendingInstallMarker, isPendingInstallInFlight } from './updater-install-guard'
+import { applyGpuCrashGuard, recordGpuCrash } from './gpu-crash-guard'
 import { buildAppMenu, buildEditableTextContextMenu } from './menu'
 import { setMainI18n } from './lib/main-i18n'
 import {
@@ -137,6 +138,12 @@ function registerMainDiagnostics(): void {
       action: 'child_process_gone',
       errorCode: details.type
     })
+    // A dead GPU process means this launch may already be painting nothing.
+    // Record it so the next launch disables hardware acceleration (see
+    // gpu-crash-guard). 'crashed'/'abnormal-exit' only — a clean exit is not a fault.
+    if (details.type === 'GPU' && details.reason !== 'clean-exit') {
+      recordGpuCrash()
+    }
   })
 }
 if (deviceId) {
@@ -145,6 +152,11 @@ if (deviceId) {
   const deviceUserData = `${app.getPath('userData')}-${deviceId}`
   app.setPath('userData', deviceUserData)
 }
+
+// Must run before app 'ready': if a prior launch's GPU process crashed (old/
+// blacklisted Windows GPUs paint nothing, leaving an invisible window), fall
+// back to software rendering this launch instead of stranding the user.
+applyGpuCrashGuard()
 
 const mainLog = createLogger('Main')
 const configLog = createLogger('Config')
@@ -592,6 +604,62 @@ function showInstallingUpdateWindowAndExit(): void {
   setTimeout(() => app.exit(0), INSTALLING_SPLASH_EXIT_MS)
 }
 
+function startupErrorHtml(message: string): string {
+  const escaped = message.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><style>
+  html,body{margin:0;height:100%}
+  body{display:flex;align-items:center;justify-content:center;background:#f6f5f0;
+    color:#191919;font:14px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+    -webkit-user-select:none;user-select:none;padding:28px;box-sizing:border-box}
+  .card{max-width:420px}
+  .title{font-weight:600;font-size:16px;margin-bottom:10px}
+  .body{opacity:.75;line-height:1.5;margin-bottom:14px}
+  .details{font:12px ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.6;
+    background:rgba(25,25,25,.05);border-radius:6px;padding:10px;white-space:pre-wrap;
+    word-break:break-word;max-height:110px;overflow:auto;user-select:text}
+</style></head><body><div class="card">
+  <div class="title">Memrynote couldn't finish starting</div>
+  <div class="body">This can happen when the disk is very low on free space, or with
+    older graphics drivers. Try freeing up some disk space, then reopen Memrynote.
+    If it keeps happening, reinstalling usually clears it.</div>
+  <div class="details">${escaped}</div>
+</div></body></html>`
+}
+
+/**
+ * Last-resort guarantee that startup never leaves an invisible, process-alive
+ * "zombie": if the whenReady chain throws before a window is created, surface a
+ * small framed window explaining what happened instead of stranding the user
+ * with a running process, no window, and the single-instance lock held. If a
+ * real window already exists the failure came later — leave it untouched.
+ */
+function ensureStartupWindow(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error)
+  mainLog.error('startup failed before a window was shown:', error)
+  trackMainError('main_process', 'startup_failed_no_window', error)
+
+  if (BrowserWindow.getAllWindows().some((w) => !w.isDestroyed())) return
+
+  const errorWindow = new BrowserWindow({
+    width: 460,
+    height: 300,
+    resizable: false,
+    autoHideMenuBar: true,
+    show: false,
+    backgroundColor: '#f6f5f0',
+    webPreferences: { sandbox: true, contextIsolation: true, nodeIntegration: false }
+  })
+  errorWindow.once('ready-to-show', () => errorWindow.show())
+  // Same failure class can stop 'ready-to-show' firing; reveal anyway after a beat.
+  setTimeout(() => {
+    if (!errorWindow.isDestroyed()) errorWindow.show()
+  }, 3000)
+  void errorWindow.loadURL(
+    `data:text/html;charset=utf-8,${encodeURIComponent(startupErrorHtml(message))}`
+  )
+}
+
 const pendingOAuthStates = new Map<string, number>()
 
 export const registerOAuthState = (state: string): void => {
@@ -710,8 +778,16 @@ if (!headlessCliArgs && !allowMultiInstanceForDeviceTests) {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-void app.whenReady().then(async () => {
+const appReady = app.whenReady().then(async () => {
   if (headlessCliArgs) return
+
+  // Test-only reproduction of the customer's "app won't open" case: a startup that
+  // fails BEFORE the main window is created (ENOSPC on a full disk / GPU crash),
+  // leaving a process alive with no window. Inert outside the E2E harness (which
+  // sets NODE_ENV=test); never active in a shipped build.
+  if (process.env.NODE_ENV === 'test' && process.env.MEMRY_TEST_FORCE_STARTUP_THROW === '1') {
+    throw new Error('E2E: forced startup failure before window creation')
+  }
 
   // Auto-update guard: if a Squirrel/ShipIt install we started is still running
   // and the user relaunched the OLD build (Dock icon vanishes during the swap),
@@ -1152,6 +1228,14 @@ void app.whenReady().then(async () => {
     // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
+})
+
+// A throw anywhere in the async startup above (e.g. ENOSPC on a full disk opening
+// SQLite/logs) would otherwise reject unhandled, leaving createWindow() unreached:
+// process alive, no window, no taskbar entry, single-instance lock held. Guarantee
+// a visible window instead.
+void appReady.catch((error) => {
+  ensureStartupWindow(error)
 })
 
 // ============================================================================

--- a/apps/desktop/tests/e2e/startup-recovery.e2e.ts
+++ b/apps/desktop/tests/e2e/startup-recovery.e2e.ts
@@ -1,0 +1,39 @@
+/**
+ * Startup recovery E2E — reproduces the customer's "app won't open" report.
+ *
+ * A Windows 10 user hit a startup that failed BEFORE the main window was created
+ * (ENOSPC on a full disk / GPU crash on old hardware). The process stayed alive
+ * with no window and no taskbar entry — an invisible zombie holding the
+ * single-instance lock, so every relaunch was a silent no-op.
+ *
+ * This test forces that exact failure (MEMRY_TEST_FORCE_STARTUP_THROW, honored
+ * only under NODE_ENV=test) and asserts the app still surfaces a VISIBLE recovery
+ * window instead of nothing.
+ *
+ * Expected today (no fix): no window is ever created, launchElectronWithWindow
+ * times out waiting for the first window, and this test is RED — that red IS the
+ * customer's bug. The whenReady .catch fix turns it GREEN.
+ */
+import { test, expect } from '@playwright/test'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { launchElectronWithWindow, destroyElectronApp } from './utils/electron-lifecycle'
+
+test('surfaces a recovery window when startup fails before the main window is created', async () => {
+  const testVaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-recovery-vault-'))
+
+  // Throws (first-window timeout) today because no window is ever created —
+  // that failure is the reproduction. With the fix, the recovery window paints
+  // and this resolves.
+  const launched = await launchElectronWithWindow({
+    testVaultPath,
+    extraEnv: { MEMRY_TEST_FORCE_STARTUP_THROW: '1' }
+  })
+
+  try {
+    await expect(launched.page.locator('body')).toContainText("couldn't finish starting")
+  } finally {
+    await destroyElectronApp(launched.app, [launched.userDataDir, launched.resolvedUserDataDir])
+  }
+})


### PR DESCRIPTION
## Problem
A Windows 10 customer reported the app installs but never shows a window (process alive, no taskbar entry), NSIS says "cannot be closed" on a fresh install, and auto-update "Restart" never relaunches.

## Root cause
`apps/desktop/src/main/index.ts` `app.whenReady().then(...)` had **no `.catch`**. Any throw before `createWindow()` — ENOSPC on a full disk, or a GPU crash on old Windows hardware — rejected unhandled, so the window was never created. The process stayed alive holding the single-instance lock, which made every relaunch (manual or updater-driven) a silent no-op. The NSIS "cannot be closed" prompt is that live, windowless process.

## Fix (additive, backward-compatible — no schema/contract/vault-format/settings change)
1. **`whenReady` `.catch` → recovery window.** On a startup throw with no window created, show a small framed window explaining what happened (disk space / graphics driver hint) instead of leaving an invisible zombie. Guarded so it never clobbers a real window.
2. **`gpu-crash-guard.ts`.** On a GPU process crash (`child-process-gone`), persist a version-scoped marker; on the next launch call `app.disableHardwareAcceleration()` so an old/broken GPU falls back to software rendering. Version-scoped so a new build retries HW accel — never permanently disabled.

## Regression test
`startup-recovery.e2e.ts` forces the exact failure via a test-only knob (`MEMRY_TEST_FORCE_STARTUP_THROW`, honored only under `NODE_ENV=test`, inert in shipped builds) and asserts a recovery window appears. On the diagnostic branch **without** this fix it is RED on windows-2022 (`firstWindow: Timeout 30000ms … no window`) — the customer's exact bug. With this fix it goes green. (See PR #702 for the red baseline.)

## Verified
- `typecheck:node` clean · eslint clean · `gpu-crash-guard.test.ts` (4) green
- **`startup-recovery.e2e.ts` RED→GREEN proven locally (macOS, Electron 39.8.6):** knob-only, fix reverted → `firstWindow: Timeout 30000ms … no window`, `1 failed` (the customer's invisible-zombie bug reproduced); fix restored → recovery window renders "couldn't finish starting", `1 passed (3.9s)`.
- docs gate skipped (`MEMRY_DOCS_IMPACT_SKIP`): internal resilience code, no user-facing API/contract/settings/format surface

## Not yet verified (before marking ready)
- [ ] Windows smoke on real hardware: launch shows a window; forced-throw shows recovery window; trigger update → Restart relaunches (can't be manufactured on macOS — E2E harness launches `--disable-gpu`, so the real GPU trigger and the ShipIt relaunch need a Windows box)
- [ ] Optional: a docs troubleshooting note for the "couldn't finish starting" window

Intentionally does **not** port the macOS `updater-install-guard` (ShipItState.plist) to Windows — NSIS already waits for app exit, so it would be dead code.
