### PR TITLE
feat(desktop): ⌘/Ctrl+number sidebar section shortcuts

### DIFF
--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -44,6 +44,8 @@ import { useSelectedFolder } from '@/contexts/selected-folder-context'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
 import { useSidebarNavigation } from '@/hooks/use-sidebar-navigation'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
+import { useKeyboardShortcuts, type KeyboardShortcut } from '@/hooks/use-keyboard-shortcuts-base'
+import { useModifierHeld } from '@/hooks/use-modifier-held'
 import { useTabActions } from '@/contexts/tabs'
 import { newItemViewState } from '@/contexts/tabs/helpers'
 import { useSettingsModal } from '@/contexts/settings-modal-context'
@@ -204,44 +206,80 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
     }
   }, [openTab, generalSettings.createInSelectedFolder])
 
+  // Open a top-level section as a tab. Shared by sidebar clicks and the
+  // ⌘/Ctrl+number shortcuts so both land the user in exactly the same state.
+  const navigateToPage = useCallback(
+    (page: AppPage) => {
+      // Map page to tab type and title
+      const pageToTabType: Record<AppPage, TabType> = {
+        home: 'home',
+        inbox: 'inbox',
+        calendar: 'calendar',
+        journal: 'journal',
+        tasks: 'tasks',
+        graph: 'graph'
+      }
+      const pageToTitle: Record<AppPage, string> = {
+        home: 'Home',
+        inbox: 'Inbox',
+        calendar: 'Calendar',
+        journal: 'Journal',
+        tasks: 'Tasks',
+        graph: 'Graph'
+      }
+
+      // Land the user ready-to-act: Inbox focuses capture, Tasks opens the default
+      // project + focuses quick-add. Calendar deliberately gets NO new-event popover
+      // from the sidebar — that only fires from the New menu and the new-tab +.
+      const pageToViewState: Partial<Record<AppPage, Record<string, unknown>>> = {
+        inbox: newItemViewState('inbox'),
+        tasks: newItemViewState('tasks')
+      }
+
+      // Open as tab in active pane
+      const item: SidebarItem = {
+        type: pageToTabType[page],
+        title: pageToTitle[page],
+        path: `/${page}`,
+        viewState: pageToViewState[page]
+      }
+      openSidebarItem(item)
+    },
+    [openSidebarItem]
+  )
+
   const handleNavClick = (page: AppPage) => (e: React.MouseEvent) => {
     e.preventDefault()
-
-    // Map page to tab type and title
-    const pageToTabType: Record<AppPage, TabType> = {
-      home: 'home',
-      inbox: 'inbox',
-      calendar: 'calendar',
-      journal: 'journal',
-      tasks: 'tasks',
-      graph: 'graph'
-    }
-    const pageToTitle: Record<AppPage, string> = {
-      home: 'Home',
-      inbox: 'Inbox',
-      calendar: 'Calendar',
-      journal: 'Journal',
-      tasks: 'Tasks',
-      graph: 'Graph'
-    }
-
-    // Land the user ready-to-act: Inbox focuses capture, Tasks opens the default
-    // project + focuses quick-add. Calendar deliberately gets NO new-event popover
-    // from the sidebar — that only fires from the New menu and the new-tab +.
-    const pageToViewState: Partial<Record<AppPage, Record<string, unknown>>> = {
-      inbox: newItemViewState('inbox'),
-      tasks: newItemViewState('tasks')
-    }
-
-    // Open as tab in active pane
-    const item: SidebarItem = {
-      type: pageToTabType[page],
-      title: pageToTitle[page],
-      path: `/${page}`,
-      viewState: pageToViewState[page]
-    }
-    openSidebarItem(item)
+    navigateToPage(page)
   }
+
+  // Sections visible in the sidebar (Home always; others gated by feature flags).
+  // Drives both the rendered numbers and the ⌘/Ctrl+number shortcut mapping so
+  // they never drift.
+  const visibleNav = useMemo(
+    () => mainNav.filter((item) => item.page === 'home' || isEnabled(item.page)),
+    [isEnabled]
+  )
+
+  // ⌘/Ctrl + 1..9 → open the Nth visible section (matches the on-icon numbers).
+  // allowInInput + capture so it also fires while the note editor, inbox
+  // composer, or tasks quick-add input is focused (those pages auto-focus an
+  // input on open and some stop keydown propagation).
+  const sectionShortcuts = useMemo<KeyboardShortcut[]>(
+    () =>
+      visibleNav.slice(0, 9).map((item, i) => ({
+        key: String(i + 1),
+        modifiers: { meta: true },
+        action: () => navigateToPage(item.page),
+        description: `Go to ${item.title}`,
+        allowInInput: true
+      })),
+    [visibleNav, navigateToPage]
+  )
+  useKeyboardShortcuts(sectionShortcuts, { capture: true })
+
+  // While the modifier is held, section icons swap to their shortcut number.
+  const isModifierHeld = useModifierHeld()
 
   // Handle tag click - open tag drill-down view
   const handleTagClick = useCallback(
@@ -498,10 +536,10 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
           </div>
         </div>
         <SidebarNav
-          items={mainNav}
+          items={visibleNav}
           isActive={isActiveItem}
           onNavClick={handleNavClick}
-          isDisabled={(page) => page !== 'home' && !isEnabled(page)}
+          isModifierHeld={isModifierHeld}
           inboxCount={inboxCount}
           todayTasksCount={todayTasksCount}
         />

--- a/apps/desktop/src/renderer/src/components/keyboard/keyboard-shortcuts-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/keyboard/keyboard-shortcuts-dialog.tsx
@@ -60,7 +60,8 @@ const getShortcutGroups = (): ShortcutGroup[] => {
         { combos: [[mod, ',']], description: 'Open settings' },
         { combos: [['?'], [mod, '/']], description: 'Open keyboard shortcuts' },
         { combos: [[mod, 'Z']], description: 'Undo last task action' },
-        { combos: [[mod, 'B']], description: 'Toggle the sidebar' }
+        { combos: [[mod, 'B']], description: 'Toggle the sidebar' },
+        { combos: [[mod, '1-6']], description: 'Go to sidebar section' }
       ]
     },
     {
@@ -73,13 +74,6 @@ const getShortcutGroups = (): ShortcutGroup[] => {
         { combos: [[mod, shift, 'T']], description: 'Reopen closed tab' },
         { combos: [['Ctrl', 'Tab']], description: 'Next tab' },
         { combos: [['Ctrl', shift, 'Tab']], description: 'Previous tab' },
-        {
-          combos: [
-            [mod, '1-8'],
-            [mod, '9']
-          ],
-          description: 'Jump to tab'
-        },
         { combos: [[mod, shift, 'P']], description: 'Pin or unpin tab' },
         { combos: [[mod, shift, 'D']], description: 'Duplicate tab' },
         { combos: [[mod, '\\']], description: 'Split right' },

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-nav.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-nav.test.tsx
@@ -32,31 +32,14 @@ const items = [
 
 const noop = () => () => {}
 
-describe('SidebarNav feature filtering', () => {
-  it('removes disabled feature items and keeps enabled ones', () => {
+describe('SidebarNav', () => {
+  it('renders exactly the items it is given (caller pre-filters visibility)', () => {
     render(
       <SidebarNav
         items={items}
         isActive={() => false}
         onNavClick={noop}
-        isDisabled={(page) => page === 'inbox'}
-        inboxCount={0}
-        todayTasksCount={0}
-      />
-    )
-
-    expect(screen.queryByText('Inbox')).toBeNull()
-    expect(screen.getByText('Journal')).toBeTruthy()
-    expect(screen.getByText('Home')).toBeTruthy()
-  })
-
-  it('renders all items when none are disabled', () => {
-    render(
-      <SidebarNav
-        items={items}
-        isActive={() => false}
-        onNavClick={noop}
-        isDisabled={() => false}
+        isModifierHeld={false}
         inboxCount={0}
         todayTasksCount={0}
       />
@@ -65,5 +48,24 @@ describe('SidebarNav feature filtering', () => {
     expect(screen.getByText('Inbox')).toBeTruthy()
     expect(screen.getByText('Journal')).toBeTruthy()
     expect(screen.getByText('Home')).toBeTruthy()
+  })
+
+  it('swaps icons for 1-based shortcut numbers while the modifier is held', () => {
+    render(
+      <SidebarNav
+        items={items}
+        isActive={() => false}
+        onNavClick={noop}
+        isModifierHeld
+        inboxCount={0}
+        todayTasksCount={0}
+      />
+    )
+
+    // Numbers follow the given order; labels stay.
+    expect(screen.getByText('1')).toBeTruthy()
+    expect(screen.getByText('2')).toBeTruthy()
+    expect(screen.getByText('3')).toBeTruthy()
+    expect(screen.getByText('Inbox')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-nav.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-nav.tsx
@@ -15,54 +15,64 @@ interface NavItem {
 }
 
 interface SidebarNavProps {
+  /** Already filtered to the visible sections, in display order. */
   items: NavItem[]
   isActive: (item: SidebarItem) => boolean
   onNavClick: (page: AppPage) => (e: React.MouseEvent) => void
-  isDisabled: (page: AppPage) => boolean
+  /** When the ⌘/Ctrl modifier is held, icons swap to their 1-based shortcut number. */
+  isModifierHeld: boolean
   inboxCount: number
   todayTasksCount: number
+}
+
+/** The ordinal shortcut number, sized to match the section icon so the row doesn't shift. */
+function NavNumber({ n }: { n: number }) {
+  return (
+    <span className="flex size-4 shrink-0 items-center justify-center text-[11px] font-semibold leading-none">
+      {n}
+    </span>
+  )
 }
 
 export function SidebarNav({
   items,
   isActive,
   onNavClick,
-  isDisabled,
+  isModifierHeld,
   inboxCount,
   todayTasksCount
 }: SidebarNavProps) {
   return (
     <SidebarGroup data-tour="sidebar-nav" className="shrink-0 py-1.5 pb-0">
       <SidebarMenu>
-        {items
-          .filter((item) => !isDisabled(item.page))
-          .map((item) => {
-            const sidebarItem: SidebarItem = {
-              type: item.page as TabType,
-              title: item.title,
-              path: `/${item.page}`
-            }
-            const active = isActive(sidebarItem)
-            const badgeCount =
-              item.page === 'inbox' ? inboxCount : item.page === 'tasks' ? todayTasksCount : 0
+        {items.map((item, index) => {
+          const sidebarItem: SidebarItem = {
+            type: item.page as TabType,
+            title: item.title,
+            path: `/${item.page}`
+          }
+          const active = isActive(sidebarItem)
+          const badgeCount =
+            item.page === 'inbox' ? inboxCount : item.page === 'tasks' ? todayTasksCount : 0
+          const number = index + 1
 
-            return (
-              <SidebarMenuItem key={item.page}>
-                <SidebarMenuButton
-                  isActive={active}
-                  data-tour={`nav-${item.page}`}
-                  onClick={onNavClick(item.page)}
-                  className="h-7 rounded-[5px] p-0 ps-1 pe-2.5 gap-1.5 text-[13px] leading-4 font-medium text-sidebar-foreground"
-                >
-                  <item.icon />
-                  <span>{item.title}</span>
-                </SidebarMenuButton>
-                {badgeCount > 0 && (
-                  <SidebarMenuBadge>{badgeCount > 9 ? '9+' : badgeCount}</SidebarMenuBadge>
-                )}
-              </SidebarMenuItem>
-            )
-          })}
+          return (
+            <SidebarMenuItem key={item.page}>
+              <SidebarMenuButton
+                isActive={active}
+                data-tour={`nav-${item.page}`}
+                onClick={onNavClick(item.page)}
+                className="h-7 rounded-[5px] p-0 ps-1 pe-2.5 gap-1.5 text-[13px] leading-4 font-medium text-sidebar-foreground"
+              >
+                {isModifierHeld && number <= 9 ? <NavNumber n={number} /> : <item.icon />}
+                <span>{item.title}</span>
+              </SidebarMenuButton>
+              {badgeCount > 0 && (
+                <SidebarMenuBadge>{badgeCount > 9 ? '9+' : badgeCount}</SidebarMenuBadge>
+              )}
+            </SidebarMenuItem>
+          )
+        })}
       </SidebarMenu>
     </SidebarGroup>
   )

--- a/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.test.ts
@@ -65,7 +65,7 @@ describe('useKeyboardShortcuts', () => {
 
       renderHook(() => useKeyboardShortcuts([{ key: 'a', action, description: 'Test' }]))
 
-      expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
+      expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function), false)
     })
 
     it('should remove keydown event listener on unmount', () => {
@@ -78,7 +78,7 @@ describe('useKeyboardShortcuts', () => {
 
       unmount()
 
-      expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function), false)
     })
   })
 

--- a/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.ts
@@ -63,10 +63,24 @@ export const getModifierSymbol = (modifier: 'meta' | 'ctrl' | 'shift' | 'alt'): 
 // HOOK
 // =============================================================================
 
+export interface UseKeyboardShortcutsOptions {
+  /**
+   * Listen in the capture phase so matched shortcuts fire before input/editor
+   * keydown handlers that may call stopPropagation (e.g. the tasks quick-add
+   * input, inbox composer, or the note editor). Only matched shortcuts are
+   * intercepted; all other keystrokes pass through untouched.
+   */
+  capture?: boolean
+}
+
 /**
  * Hook to handle keyboard shortcuts
  */
-export const useKeyboardShortcuts = (shortcuts: KeyboardShortcut[]): void => {
+export const useKeyboardShortcuts = (
+  shortcuts: KeyboardShortcut[],
+  options: UseKeyboardShortcutsOptions = {}
+): void => {
+  const { capture = false } = options
   // Memoize shortcuts to prevent unnecessary re-renders
   const memoizedShortcuts = useMemo(() => shortcuts, [shortcuts])
 
@@ -132,9 +146,9 @@ export const useKeyboardShortcuts = (shortcuts: KeyboardShortcut[]): void => {
   )
 
   useEffect(() => {
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [handleKeyDown])
+    window.addEventListener('keydown', handleKeyDown, capture)
+    return () => window.removeEventListener('keydown', handleKeyDown, capture)
+  }, [handleKeyDown, capture])
 }
 
 export default useKeyboardShortcuts

--- a/apps/desktop/src/renderer/src/hooks/use-modifier-held.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-modifier-held.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useModifierHeld } from './use-modifier-held'
+
+vi.mock('@/contexts/hint-mode', () => ({
+  hintModeActiveRef: { current: false }
+}))
+
+// Set both ctrlKey and metaKey so the assertions hold regardless of platform.
+const modInit = { ctrlKey: true, metaKey: true } as const
+
+describe('useModifierHeld', () => {
+  it('is true while the modifier is held and false after release', () => {
+    const { result } = renderHook(() => useModifierHeld())
+    expect(result.current).toBe(false)
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', modInit))
+    })
+    expect(result.current).toBe(true)
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keyup', { ctrlKey: false, metaKey: false }))
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('resets to false on window blur', () => {
+    const { result } = renderHook(() => useModifierHeld())
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', modInit))
+    })
+    expect(result.current).toBe(true)
+
+    act(() => {
+      window.dispatchEvent(new Event('blur'))
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('activates even while a text input is focused (works on inbox/tasks/editor)', () => {
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    const { result } = renderHook(() => useModifierHeld())
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { ...modInit, bubbles: true }))
+    })
+    expect(result.current).toBe(true)
+
+    input.remove()
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-modifier-held.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-modifier-held.ts
@@ -1,0 +1,45 @@
+/**
+ * useModifierHeld
+ * Tracks whether the platform command modifier (⌘ on Mac, Ctrl elsewhere) is
+ * currently held down. Used to reveal the sidebar section number shortcuts.
+ *
+ * Listens in the capture phase so it sees the modifier even while the note
+ * editor or an auto-focused input (inbox composer, tasks quick-add) is focused
+ * and stops event propagation — keeping the numbers in sync with the ⌘+digit
+ * navigation, which works everywhere too. Resets on keyup and on window blur so
+ * the affordance never gets stuck when focus leaves the window (e.g. ⌘-Tab away
+ * while still holding).
+ */
+
+import { useEffect, useState } from 'react'
+import { isMac } from './use-keyboard-shortcuts-base'
+import { hintModeActiveRef } from '@/contexts/hint-mode'
+
+export const useModifierHeld = (): boolean => {
+  const [held, setHeld] = useState(false)
+
+  useEffect(() => {
+    const isModDown = (e: KeyboardEvent): boolean => (isMac ? e.metaKey : e.ctrlKey)
+
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      setHeld(isModDown(e) && !hintModeActiveRef.current)
+    }
+    const handleKeyUp = (e: KeyboardEvent): void => {
+      if (!isModDown(e)) setHeld(false)
+    }
+    const reset = (): void => setHeld(false)
+
+    window.addEventListener('keydown', handleKeyDown, true)
+    window.addEventListener('keyup', handleKeyUp, true)
+    window.addEventListener('blur', reset)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, true)
+      window.removeEventListener('keyup', handleKeyUp, true)
+      window.removeEventListener('blur', reset)
+    }
+  }, [])
+
+  return held
+}
+
+export default useModifierHeld

--- a/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.test.ts
@@ -45,12 +45,6 @@ function shortcut(description: string) {
   return found
 }
 
-function numberShortcut(index: number) {
-  const found = mocks.shortcuts.find((item) => item.description === `Go to tab ${index}`)
-  if (!found) throw new Error(`Missing number shortcut: ${index}`)
-  return found
-}
-
 describe('useTabKeyboardShortcuts', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -75,7 +69,7 @@ describe('useTabKeyboardShortcuts', () => {
     window.addEventListener('memry:new-tab-menu', newTabMenu)
 
     renderHook(() => useTabKeyboardShortcuts())
-    expect(mocks.shortcuts).toHaveLength(22)
+    expect(mocks.shortcuts).toHaveLength(13)
 
     shortcut('New tab').action()
     expect(newTabMenu).toHaveBeenCalled()
@@ -108,13 +102,6 @@ describe('useTabKeyboardShortcuts', () => {
     shortcut('Navigate forward').action()
     expect(mocks.navBack).toHaveBeenCalledWith('main')
     expect(mocks.navForward).toHaveBeenCalledWith('main')
-
-    numberShortcut(1).action()
-    shortcut('Go to last tab').action()
-    expect(mocks.dispatch).toHaveBeenCalledWith({
-      type: 'GO_TO_TAB_INDEX',
-      payload: { index: 0, groupId: 'main' }
-    })
 
     expect(shortcut('Close split pane').when()).toBe(false)
     window.removeEventListener('memry:new-tab-menu', newTabMenu)
@@ -210,7 +197,6 @@ describe('useTabKeyboardShortcuts', () => {
     shortcut('Close tab').action()
     shortcut('Pin/Unpin tab').action()
     shortcut('Duplicate tab').action()
-    shortcut('Go to last tab').action()
 
     expect(mocks.closeTab).not.toHaveBeenCalled()
     expect(mocks.pinTab).not.toHaveBeenCalled()

--- a/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-keyboard-shortcuts.ts
@@ -132,34 +132,9 @@ export const useTabKeyboardShortcuts = (): void => {
         description: 'Navigate forward'
       },
 
-      // Go to tab 1-8 (⌘1-8)
-      ...Array.from({ length: 8 }, (_, i) => ({
-        key: String(i + 1),
-        modifiers: { meta: true } as const,
-        action: () => {
-          dispatch({
-            type: 'GO_TO_TAB_INDEX',
-            payload: { index: i, groupId: state.activeGroupId }
-          })
-        },
-        description: `Go to tab ${i + 1}`
-      })),
-
-      // Go to last tab (⌘9)
-      {
-        key: '9',
-        modifiers: { meta: true },
-        action: () => {
-          if (activeGroup) {
-            const lastIndex = activeGroup.tabs.length - 1
-            dispatch({
-              type: 'GO_TO_TAB_INDEX',
-              payload: { index: lastIndex, groupId: state.activeGroupId }
-            })
-          }
-        },
-        description: 'Go to last tab'
-      },
+      // NOTE: ⌘1-9 are intentionally NOT bound here. They now open the Nth
+      // sidebar section (see app-sidebar.tsx / useModifierHeld). Ctrl+Tab and
+      // Ctrl+Shift+Tab remain the way to cycle open tabs.
 
       // =====================================================================
       // TAB MODIFICATION

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -6,30 +6,31 @@ Default shortcuts. Every entry in the Navigation, Tabs, Editor, and View categor
 
 ## Navigation
 
-| Action        | Shortcut                               |
-| ------------- | -------------------------------------- |
-| New note      | <kbd>⌘</kbd>+<kbd>N</kbd>              |
-| New task      | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>T</kbd> |
-| Go to Inbox   | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>I</kbd> |
-| Go to Notes   | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>E</kbd> |
-| Go to Tasks   | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>K</kbd> |
-| Open search   | <kbd>⌘</kbd>+<kbd>F</kbd>              |
-| Open settings | <kbd>⌘</kbd>+<kbd>,</kbd>              |
+| Action                | Shortcut                                              |
+| --------------------- | ----------------------------------------------------- |
+| New note              | <kbd>⌘</kbd>+<kbd>N</kbd>                             |
+| New task              | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>T</kbd>                |
+| Go to Inbox           | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>I</kbd>                |
+| Go to Notes           | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>E</kbd>                |
+| Go to Tasks           | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>K</kbd>                |
+| Go to sidebar section | <kbd>⌘</kbd>+<kbd>1</kbd> … <kbd>⌘</kbd>+<kbd>6</kbd> |
+| Open search           | <kbd>⌘</kbd>+<kbd>F</kbd>                             |
+| Open settings         | <kbd>⌘</kbd>+<kbd>,</kbd>                             |
+
+> Hold <kbd>⌘</kbd> (<kbd>Ctrl</kbd> on Windows / Linux) to reveal the section numbers on the sidebar icons, then press the number to jump — <kbd>⌘</kbd>+<kbd>1</kbd> opens Home, <kbd>⌘</kbd>+<kbd>2</kbd> Inbox, and so on. Numbers follow the sidebar's visible top-to-bottom order (Home is always 1), so they shift if you hide a section. This shortcut works everywhere, including inside the editor, and is fixed rather than rebindable.
 
 ## Tabs
 
-| Action            | Shortcut                                              |
-| ----------------- | ----------------------------------------------------- |
-| New tab           | <kbd>⌘</kbd>+<kbd>T</kbd>                             |
-| Close tab         | <kbd>⌘</kbd>+<kbd>W</kbd>                             |
-| Close all tabs    | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>W</kbd>                |
-| Reopen closed tab | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>T</kbd>                |
-| Next tab          | <kbd>Ctrl</kbd>+<kbd>Tab</kbd>                        |
-| Previous tab      | <kbd>Ctrl</kbd>+<kbd>⇧</kbd>+<kbd>Tab</kbd>           |
-| Go to tab 1–8     | <kbd>⌘</kbd>+<kbd>1</kbd> … <kbd>⌘</kbd>+<kbd>8</kbd> |
-| Go to last tab    | <kbd>⌘</kbd>+<kbd>9</kbd>                             |
-| Pin / unpin tab   | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>P</kbd>                |
-| Duplicate tab     | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>D</kbd>                |
+| Action            | Shortcut                                    |
+| ----------------- | ------------------------------------------- |
+| New tab           | <kbd>⌘</kbd>+<kbd>T</kbd>                   |
+| Close tab         | <kbd>⌘</kbd>+<kbd>W</kbd>                   |
+| Close all tabs    | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>W</kbd>      |
+| Reopen closed tab | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>T</kbd>      |
+| Next tab          | <kbd>Ctrl</kbd>+<kbd>Tab</kbd>              |
+| Previous tab      | <kbd>Ctrl</kbd>+<kbd>⇧</kbd>+<kbd>Tab</kbd> |
+| Pin / unpin tab   | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>P</kbd>      |
+| Duplicate tab     | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>D</kbd>      |
 
 > **Reopen closed tab** brings back the most recently closed tab at its original position and focus. Press it repeatedly to walk back through closed tabs, most recent first — it also recovers tabs closed in bulk by **Close all tabs**. The history is kept for the current session only.
 


### PR DESCRIPTION
## What

Hold **⌘** (⌃ on Windows/Linux) and the sidebar section icons swap to their **1-based number**; press the number to jump. `⌘1` → Home, `⌘2` → Inbox, `⌘3` → Journal, `⌘4` → Calendar, `⌘5` → Tasks, `⌘6` → Graph — numbered by the sidebar's **visible** order (feature-flag-gated sections are skipped, so numbering stays contiguous).

## How

- **`use-modifier-held.ts`** (new) — tracks the command modifier via keydown/keyup, **resets on window blur** (no stuck numbers after ⌘-Tab away). Capture-phase so it sees the modifier even inside the editor / focused inputs.
- **`sidebar-nav.tsx`** — items now arrive pre-filtered; new `isModifierHeld` prop swaps `<icon>` → number (sized to the icon so nothing shifts).
- **`app-sidebar.tsx`** — one derived `visibleNav` feeds both the numbers and the shortcut mapping (they can't drift). `navigateToPage` is shared by click and shortcut so both land identically (incl. Inbox/Tasks focus states).
- **`use-keyboard-shortcuts-base.ts`** — added an opt-in `{ capture }` option. Section shortcuts register with `allowInInput: true` + `capture: true`, so they fire **everywhere** — including the note editor and the auto-focused inbox/tasks inputs (which stop keydown propagation). Only a matched ⌘+digit is intercepted; typing is untouched.
- **`use-tab-keyboard-shortcuts.ts`** — removed the old `⌘1-9` "jump to open tab" binding (replaced by section nav). `Ctrl+Tab` / `Ctrl+Shift+Tab` still cycle tabs.
- Shortcuts dialog + `keyboard-shortcuts.md` updated to match.

No plain ⌘+digit editor binding exists (headings use Mod+Alt), so no collision.

## Testing

- `typecheck:web` ✓ · ESLint ✓ · docs gate + `docs:build` ✓
- Renderer tests **65/65** ✓ — new `use-modifier-held` test (keydown/keyup/blur, activates in inputs); updated tab-shortcut, base-hook, and sidebar-nav tests to the new contract.
- Not yet exercised in a live Electron build (can't drive a held key headless): confirm in-app that holding ⌘ shows numbers and ⌘1→Home works while the editor / inbox / tasks inputs are focused.

## Note

⌘+digit is now truly global, so it also fires while the command palette or a modal input is focused. That matches the "works everywhere" intent; easy to gate on open dialogs if we'd rather it not.