### PR TITLE
fix(desktop): survive a broken CRDT store instead of crashing note editing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -399,6 +399,14 @@ jobs:
           node apps/desktop/scripts/build-packaged-app.js --win --x64 --publish never
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      # 2026.705.1 shipped a classic-level binary whose napi calls failed at
+      # runtime — every CRDT persistence op crashed or hung, and nothing in the
+      # pipeline load-tested the Windows package. Verify native modules load
+      # and actually work under the packaged executable before staging assets.
+      - name: Check packaged runtime dependencies
+        shell: bash
+        run: node apps/desktop/scripts/check-packaged-runtime-deps.js apps/desktop/dist/win-unpacked
+
       - name: Stage Windows assets
         id: assets
         shell: pwsh

--- a/apps/desktop/config/electron-builder.yml
+++ b/apps/desktop/config/electron-builder.yml
@@ -42,6 +42,11 @@ nsis:
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
+  # Assisted installer: users with a full C: drive need to pick another
+  # install location. Auto-updates still install silently (/S), and existing
+  # one-click installs keep their current location on update.
+  oneClick: false
+  allowToChangeInstallationDirectory: true
 mac:
   artifactName: ${productName}-${version}-${arch}.${ext}
   entitlementsInherit: config/entitlements.mac.plist

--- a/apps/desktop/scripts/check-packaged-runtime-deps.js
+++ b/apps/desktop/scripts/check-packaged-runtime-deps.js
@@ -36,7 +36,10 @@ const nativeArchCheckedModules = ['better-sqlite3', 'keytar']
 
 function getPackagedElectronExecutable(resourcesPath) {
   const contentsPath = path.dirname(resourcesPath)
-  const executable = path.join(contentsPath, 'MacOS', productName)
+  const executable =
+    process.platform === 'win32'
+      ? path.join(contentsPath, `${productName}.exe`)
+      : path.join(contentsPath, 'MacOS', productName)
   if (!fs.existsSync(executable)) {
     throw new Error(`Missing packaged Electron executable: ${executable}`)
   }
@@ -76,6 +79,17 @@ function resolveResourcesCheck(inputPath) {
     return [
       {
         resourcesPath: absolutePath,
+        expectedArch: process.arch
+      }
+    ]
+  }
+
+  // Windows/Linux unpacked layout (e.g. dist/win-unpacked): resources/ sits
+  // next to the executable instead of inside a mac bundle.
+  if (fs.existsSync(path.join(absolutePath, 'resources'))) {
+    return [
+      {
+        resourcesPath: path.join(absolutePath, 'resources'),
         expectedArch: process.arch
       }
     ]
@@ -126,14 +140,46 @@ function runElectronNativeSmoke(resourcesPath) {
   fs.writeFileSync(
     smokeScriptPath,
     `
+const fs = require('node:fs')
 const { createRequire } = require('node:module')
+const os = require('node:os')
+const path = require('node:path')
 
 const packagedRequire = createRequire(process.env.MEMRY_PACKAGED_MAIN)
 const Database = require(packagedRequire.resolve('better-sqlite3'))
 const database = new Database(':memory:')
 database.close()
 require(packagedRequire.resolve('keytar'))
-console.log(\`Electron native runtime ABI \${process.versions.modules}\`)
+
+// classic-level backs the CRDT store (y-leveldb). A binary built for the
+// wrong ABI does not fail at require() — it fails at open() with
+// napi_create_reference errors thrown out-of-band, or hangs its callbacks
+// (shipped broken in 2026.705.1: first keystroke crashed the editor). Probe a
+// real open/put/get/close so a bad binary fails the build, not the user.
+const { ClassicLevel } = require(packagedRequire.resolve('classic-level'))
+const levelDbPath = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-classic-level-smoke-'))
+
+const timer = setTimeout(() => {
+  console.error('classic-level smoke timed out — native binding hangs under packaged Electron')
+  process.exit(1)
+}, 30000)
+
+;(async () => {
+  const db = new ClassicLevel(levelDbPath)
+  await db.open()
+  await db.put('probe', 'ok')
+  const value = await db.get('probe')
+  if (value !== 'ok') {
+    throw new Error(\`classic-level probe read mismatch: \${value}\`)
+  }
+  await db.close()
+  clearTimeout(timer)
+  fs.rmSync(levelDbPath, { force: true, recursive: true })
+  console.log(\`Electron native runtime ABI \${process.versions.modules}\`)
+})().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})
 `.trimStart()
   )
 

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -1,29 +1,45 @@
 import * as Y from 'yjs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({
-  sent: [] as Array<{ windowId: number; channel: string; payload: unknown }>,
-  windows: new Map<
-    number,
-    { isDestroyed: ReturnType<typeof vi.fn>; webContents: { send: ReturnType<typeof vi.fn> } }
-  >(),
-  getNoteCacheById: vi.fn(),
-  safeRead: vi.fn(),
-  parseNote: vi.fn(),
-  markdownToYFragment: vi.fn(),
-  repairEmptyBlockIds: vi.fn(() => 0),
-  compactYDoc: vi.fn(),
-  scheduleWriteback: vi.fn(),
-  flushPendingWritebacks: vi.fn(),
-  recordNetworkUpdate: vi.fn(),
-  persistenceInstances: [] as Array<{
-    getYDoc: ReturnType<typeof vi.fn>
-    clearDocument: ReturnType<typeof vi.fn>
-    destroy: ReturnType<typeof vi.fn>
-    storeUpdate: ReturnType<typeof vi.fn>
-    flushDocument: ReturnType<typeof vi.fn>
-  }>
-}))
+const mocks = vi.hoisted(() => {
+  // Simulates a broken classic-level native binding (napi_create_reference
+  // failures on ABI mismatch). 'reject' fails ops; 'hang' never settles.
+  const persistenceBehavior = { mode: 'ok' as 'ok' | 'reject' | 'hang' }
+  const persistenceOpFactory = async <T>(value: () => T): Promise<T> => {
+    if (persistenceBehavior.mode === 'reject') {
+      throw new Error('napi_create_reference(env, callback, 1, &callbackRef_) failed!')
+    }
+    if (persistenceBehavior.mode === 'hang') {
+      return new Promise<T>(() => {})
+    }
+    return value()
+  }
+  return {
+    persistenceBehavior,
+    persistenceOpFactory,
+    sent: [] as Array<{ windowId: number; channel: string; payload: unknown }>,
+    windows: new Map<
+      number,
+      { isDestroyed: ReturnType<typeof vi.fn>; webContents: { send: ReturnType<typeof vi.fn> } }
+    >(),
+    getNoteCacheById: vi.fn(),
+    safeRead: vi.fn(),
+    parseNote: vi.fn(),
+    markdownToYFragment: vi.fn(),
+    repairEmptyBlockIds: vi.fn(() => 0),
+    compactYDoc: vi.fn(),
+    scheduleWriteback: vi.fn(),
+    flushPendingWritebacks: vi.fn(),
+    recordNetworkUpdate: vi.fn(),
+    persistenceInstances: [] as Array<{
+      getYDoc: ReturnType<typeof vi.fn>
+      clearDocument: ReturnType<typeof vi.fn>
+      destroy: ReturnType<typeof vi.fn>
+      storeUpdate: ReturnType<typeof vi.fn>
+      flushDocument: ReturnType<typeof vi.fn>
+    }>
+  }
+})
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/memry-crdt-test' },
@@ -44,11 +60,13 @@ vi.mock('../lib/logger', () => ({
 
 vi.mock('y-leveldb', () => ({
   LeveldbPersistence: class {
-    getYDoc = vi.fn(async (noteId: string) => new Y.Doc({ guid: `${noteId}:persisted` }))
-    clearDocument = vi.fn(async () => {})
+    getYDoc = vi.fn((noteId: string) =>
+      mocks.persistenceOpFactory(() => new Y.Doc({ guid: `${noteId}:persisted` }))
+    )
+    clearDocument = vi.fn(() => mocks.persistenceOpFactory(() => undefined))
     destroy = vi.fn(async () => {})
-    storeUpdate = vi.fn(async () => {})
-    flushDocument = vi.fn(async () => {})
+    storeUpdate = vi.fn(() => mocks.persistenceOpFactory(() => undefined))
+    flushDocument = vi.fn(() => mocks.persistenceOpFactory(() => undefined))
 
     constructor() {
       mocks.persistenceInstances.push(this)
@@ -150,6 +168,7 @@ describe('CrdtProvider', () => {
     mocks.sent = []
     mocks.windows.clear()
     mocks.persistenceInstances.length = 0
+    mocks.persistenceBehavior.mode = 'ok'
     mocks.getNoteCacheById.mockReturnValue({
       id: 'note-1',
       path: 'notes/Note.md',
@@ -674,5 +693,97 @@ describe('CrdtProvider', () => {
     ;(provider as any).docs.get('closing-note').closing = false
     provider.applyIpcUpdate('closing-note', makeRemoteUpdate('local'), 99)
     expect(mocks.sent).toEqual([])
+  })
+})
+
+// Regression suite for the broken classic-level native binding shipped in
+// 2026.705.1 on Windows: napi_create_reference failures made every CRDT
+// persistence op throw or hang, crashing the editor on first keystroke and
+// making note content unloadable. The provider must survive a dead store.
+describe('CrdtProvider persistence resilience', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.sent = []
+    mocks.windows.clear()
+    mocks.persistenceInstances.length = 0
+    mocks.persistenceBehavior.mode = 'ok'
+    mocks.getNoteCacheById.mockReturnValue({
+      id: 'note-1',
+      path: 'notes/Note.md',
+      title: 'Note',
+      fileType: 'markdown'
+    })
+    mocks.safeRead.mockResolvedValue('# Note\n\nBody')
+    mocks.parseNote.mockReturnValue({ content: 'Body' })
+    mocks.markdownToYFragment.mockImplementation(
+      async (_content: string, fragment: Y.XmlFragment) => {
+        fragment.insert(0, [new Y.XmlText('Body')])
+        return true
+      }
+    )
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    resetCrdtProvider()
+  })
+
+  it('falls back to in-memory mode when the persistence probe rejects', async () => {
+    mocks.persistenceBehavior.mode = 'reject'
+    const provider = new CrdtProvider()
+
+    await expect(provider.init()).resolves.toBeUndefined()
+    expect(provider.isInitialized()).toBe(true)
+
+    // Docs still open and seed from the vault markdown file.
+    const doc = await provider.open('note-1')
+    expect(doc.getXmlFragment(CRDT_FRAGMENT_NAME).length).toBeGreaterThan(0)
+
+    // Typing must not throw even though the store is dead.
+    expect(() => provider.applyIpcUpdate('note-1', makeRemoteUpdate('typed'), 7)).not.toThrow()
+    await provider.close('note-1')
+  })
+
+  it('falls back to in-memory mode when the persistence probe hangs', async () => {
+    vi.useFakeTimers()
+    mocks.persistenceBehavior.mode = 'hang'
+    const provider = new CrdtProvider()
+
+    const init = provider.init()
+    await vi.advanceTimersByTimeAsync(20_000)
+    await expect(init).resolves.toBeUndefined()
+
+    expect(provider.isInitialized()).toBe(true)
+  })
+
+  it('does not retry a failed probe on subsequent init calls', async () => {
+    mocks.persistenceBehavior.mode = 'reject'
+    const provider = new CrdtProvider()
+
+    await provider.initPersistence()
+    await provider.initPersistence()
+    await provider.init()
+
+    expect(mocks.persistenceInstances).toHaveLength(1)
+  })
+
+  it('opens a doc from markdown when loading the persisted doc fails mid-session', async () => {
+    const provider = new CrdtProvider()
+    await provider.init()
+    expect(provider.isInitialized()).toBe(true)
+
+    mocks.persistenceBehavior.mode = 'reject'
+    const doc = await provider.open('note-1')
+    expect(doc.getXmlFragment(CRDT_FRAGMENT_NAME).length).toBeGreaterThan(0)
+    await provider.close('note-1')
+  })
+
+  it('reports uninitialized again after destroy', async () => {
+    const provider = new CrdtProvider()
+    await provider.init()
+    expect(provider.isInitialized()).toBe(true)
+
+    await provider.destroy()
+    expect(provider.isInitialized()).toBe(false)
   })
 })

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -30,6 +30,8 @@ const SIZE_CHECK_INTERVAL_MS = 60_000
 const ENCODED_SIZE_COMPACTION_THRESHOLD = 1024 * 1024
 const ACCUMULATED_BYTES_RECHECK_THRESHOLD = 512 * 1024
 const DEFAULT_INACTIVE_DOC_LIMIT = 32
+const PERSISTENCE_PROBE_KEY = '__memry_crdt_probe__'
+const PERSISTENCE_PROBE_TIMEOUT_MS = 15_000
 
 export type SnapshotPushFn = (noteId: string, state: Uint8Array) => Promise<void>
 
@@ -77,6 +79,8 @@ export class CrdtProvider {
   private docs = new Map<string, ActiveDoc>()
   private openLocks = new Map<string, Promise<Y.Doc>>()
   private persistence: CrdtPersistence | null = null
+  private persistenceReady = false
+  private persistenceInitPromise: Promise<void> | null = null
   private updateQueue: CrdtUpdateQueue | null = null
   private snapshotPushFn: SnapshotPushFn | null = null
   private readonly inactiveDocLimit: number
@@ -101,17 +105,44 @@ export class CrdtProvider {
   }
 
   async initPersistence(): Promise<void> {
-    if (this.persistence) {
+    // Never retry a settled init: a failed probe means the native binding is
+    // broken for this process — re-probing would just re-pay the timeout.
+    if (this.persistenceReady) {
       return
     }
 
+    if (!this.persistenceInitPromise) {
+      this.persistenceInitPromise = this.doInitPersistence().finally(() => {
+        this.persistenceInitPromise = null
+      })
+    }
+    return this.persistenceInitPromise
+  }
+
+  private async doInitPersistence(): Promise<void> {
     const storagePath = path.join(app.getPath('userData'), 'crdt-store')
-    this.persistence = new LeveldbPersistence(storagePath) as CrdtPersistence
-    log.debug('CrdtProvider persistence initialized', { storagePath })
+    try {
+      const persistence = new LeveldbPersistence(storagePath) as CrdtPersistence
+      await probePersistence(persistence)
+      this.persistence = persistence
+      log.debug('CrdtProvider persistence initialized', { storagePath })
+    } catch (err) {
+      // A broken classic-level native binding (e.g. napi_create_reference
+      // failures on ABI mismatch, as shipped in 2026.705.1 on Windows) throws
+      // out-of-band or hangs instead of rejecting. Degrade to in-memory:
+      // notes still load from vault markdown and write back to disk; only
+      // CRDT history persistence is lost.
+      log.error(
+        'CRDT persistence unavailable — continuing in-memory (notes still load from vault files)',
+        { storagePath, error: err }
+      )
+      this.persistence = null
+    }
+    this.persistenceReady = true
   }
 
   isInitialized(): boolean {
-    return this.persistence !== null
+    return this.persistenceReady
   }
 
   async open(noteId: string, windowId?: number, options?: { skipSeed?: boolean }): Promise<Y.Doc> {
@@ -159,23 +190,32 @@ export class CrdtProvider {
     this.initDocStructure(doc)
 
     if (this.persistence) {
-      const persisted = await this.persistence.getYDoc(noteId)
-      if (persisted) {
-        const update = Y.encodeStateAsUpdate(persisted)
-        Y.applyUpdate(doc, update)
-        persisted.destroy()
-        // Heal notes previously persisted with empty block ids, which crash the
-        // editor with "Block doesn't have id" on mount.
-        let repaired = 0
-        doc.transact(() => {
-          repaired = repairEmptyBlockIds(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
-        }, ORIGIN_LOCAL)
-        if (repaired > 0) {
-          log.info('Repaired empty block ids in persisted note', { noteId, count: repaired })
-          await this.persistence.storeUpdate(noteId, Y.encodeStateAsUpdate(doc))
+      try {
+        const persisted = await this.persistence.getYDoc(noteId)
+        if (persisted) {
+          const update = Y.encodeStateAsUpdate(persisted)
+          Y.applyUpdate(doc, update)
+          persisted.destroy()
+          // Heal notes previously persisted with empty block ids, which crash the
+          // editor with "Block doesn't have id" on mount.
+          let repaired = 0
+          doc.transact(() => {
+            repaired = repairEmptyBlockIds(doc.getXmlFragment(CRDT_FRAGMENT_NAME))
+          }, ORIGIN_LOCAL)
+          if (repaired > 0) {
+            log.info('Repaired empty block ids in persisted note', { noteId, count: repaired })
+            await this.persistence.storeUpdate(noteId, Y.encodeStateAsUpdate(doc))
+          }
+        } else {
+          log.warn('CRDT persistence returned empty doc; continuing in-memory', { noteId })
         }
-      } else {
-        log.warn('CRDT persistence returned empty doc; continuing in-memory', { noteId })
+      } catch (err) {
+        // A failing store must not block the note from opening — fall through
+        // to the markdown seed below so content stays visible.
+        log.error('Failed to load persisted CRDT doc; seeding from vault file', {
+          noteId,
+          error: err
+        })
       }
     }
 
@@ -248,7 +288,9 @@ export class CrdtProvider {
 
   async purge(noteId: string): Promise<void> {
     await this.close(noteId)
-    await this.persistence?.clearDocument(noteId)
+    await this.persistence?.clearDocument(noteId).catch((err) => {
+      log.warn('Failed to clear persisted CRDT doc during purge', { noteId, error: err })
+    })
   }
 
   getDoc(noteId: string): Y.Doc | undefined {
@@ -328,6 +370,7 @@ export class CrdtProvider {
       }
       this.persistence = null
     }
+    this.persistenceReady = false
 
     this.openLocks.clear()
     this.updateQueue = null
@@ -455,7 +498,9 @@ export class CrdtProvider {
 
     const ok = await markdownToYFragment(parsed.content, fragment)
     if (ok && this.persistence) {
-      await this.persistence.storeUpdate(noteId, Y.encodeStateAsUpdate(doc))
+      await this.persistence.storeUpdate(noteId, Y.encodeStateAsUpdate(doc)).catch((err) => {
+        log.error('Failed to persist markdown-seeded CRDT doc', { noteId, error: err })
+      })
     }
   }
 
@@ -519,10 +564,18 @@ export class CrdtProvider {
       for (const entry of batch) {
         if (this.docs.has(entry.id)) continue
         if (this.persistence) {
-          const existing = await this.persistence.getYDoc(entry.id)
-          const hasContent = Y.encodeStateAsUpdate(existing).length > 4
-          existing.destroy()
-          if (hasContent) continue
+          try {
+            const existing = await this.persistence.getYDoc(entry.id)
+            const hasContent = Y.encodeStateAsUpdate(existing).length > 4
+            existing.destroy()
+            if (hasContent) continue
+          } catch (err) {
+            log.warn('Failed to read persisted doc during seeding; skipping', {
+              noteId: entry.id,
+              error: err
+            })
+            continue
+          }
         }
 
         await this.initForNote(entry.id, { title: entry.title, date: entry.date }, entry.tags)
@@ -789,6 +842,54 @@ export class CrdtProvider {
     const diff = new Uint8Array(diffArr)
     Y.applyUpdate(entry.doc, diff, { source: 'ipc', windowId: -1 } satisfies IpcOrigin)
   }
+}
+
+/**
+ * Verify the CRDT store's native binding actually works before trusting it.
+ * A broken classic-level binding (ABI mismatch) doesn't reject cleanly — it
+ * throws out-of-band from an fs callback (surfacing as uncaughtException) or
+ * never invokes its callback at all (hanging the promise). Capture both so a
+ * bad binary degrades to in-memory mode instead of crashing note editing.
+ */
+async function probePersistence(persistence: CrdtPersistence): Promise<void> {
+  const probeDoc = new Y.Doc()
+  probeDoc.getMap('probe').set('ok', true)
+  const update = Y.encodeStateAsUpdate(probeDoc)
+  probeDoc.destroy()
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false
+    const settle = (fn: () => void): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      process.removeListener('uncaughtException', onUncaught)
+      fn()
+    }
+    const onUncaught = (err: Error): void => settle(() => reject(err))
+    const timer = setTimeout(
+      () =>
+        settle(() =>
+          reject(
+            new Error(`CRDT persistence probe timed out after ${PERSISTENCE_PROBE_TIMEOUT_MS}ms`)
+          )
+        ),
+      PERSISTENCE_PROBE_TIMEOUT_MS
+    )
+    process.prependListener('uncaughtException', onUncaught)
+
+    Promise.resolve()
+      .then(async () => {
+        await persistence.storeUpdate(PERSISTENCE_PROBE_KEY, update)
+        const loaded = await persistence.getYDoc(PERSISTENCE_PROBE_KEY)
+        loaded.destroy()
+        await persistence.clearDocument(PERSISTENCE_PROBE_KEY)
+      })
+      .then(
+        () => settle(resolve),
+        (err) => settle(() => reject(err instanceof Error ? err : new Error(String(err))))
+      )
+  })
 }
 
 function isIpcOrigin(origin: unknown): origin is IpcOrigin {

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -16,6 +16,18 @@ renderer  ──Yjs IPC provider──▶  main (Y.Doc)  ──y-leveldb──�
                                        └──network sync──▶  /sync/crdt/updates
 ```
 
+## Persistence Resilience
+
+The y-leveldb store is probed at startup (a write/read/clear round-trip with a
+timeout) before it is trusted. A broken `classic-level` native binding doesn't
+fail cleanly — it throws outside the promise chain or hangs its callbacks — so
+the probe captures both. If the probe fails, the provider degrades to
+**in-memory mode**: notes still load from vault markdown and write back to
+disk, and the editor keeps working; only CRDT history persistence across
+restarts is lost for that session. A mid-session load failure for a single doc
+falls back to seeding from the vault file instead of blocking the note from
+opening.
+
 ## Why the Main Process Owns Y.Docs
 
 - Single writer per document avoids merge complexity across renderer windows.

--- a/apps/docs/src/guide/install.md
+++ b/apps/docs/src/guide/install.md
@@ -4,7 +4,8 @@ Download the desktop app from **[memrynote.com/download/desktop](https://memryno
 The download page detects your platform and offers installers for:
 
 - **macOS** — Apple Silicon and Intel
-- **Windows**
+- **Windows** — the installer lets you choose the install location, so you can
+  install to a drive other than `C:`
 - **Linux** — AppImage and `.deb`
 
 On macOS you can also install with [Homebrew](https://brew.sh):


### PR DESCRIPTION
## Why

A beta user on Windows 10 running 2026.705.1 hit a crash loop: typing one character crashed the app, edited notes went invisible, and notes vanished from search. Her `main.log` shows the root cause — the `classic-level` native binding (which backs the y-leveldb CRDT store holding every note/journal Y.Doc) failed every napi call:

```
Unhandled Error: napi_create_reference(env, callback, 1, &callbackRef_) failed!
    at resources\node_modules\classic-level\index.js:55:17
```

Nothing in the pipeline load-tests the Windows package (the packaged runtime check only runs in the macOS job), so the broken binary shipped unverified.

## What

**Runtime resilience** (`crdt-provider.ts`)
- Probe the store at init: write/read/clear round-trip with a 15s timeout and out-of-band `uncaughtException` capture — a broken binding hangs or throws outside the promise chain instead of rejecting.
- On probe failure, degrade to in-memory mode: notes still load from vault markdown and write back to disk; the editor keeps working. Only CRDT history persistence is lost for that session.
- `isInitialized()` now reports init completion, not persistence health, so `crdt-handlers` IPC keeps serving the editor in degraded mode.
- Mid-session doc-load failure falls back to the markdown seed instead of rejecting the open (fixes invisible note content).
- Guards on `purge`, `seedFromMarkdown`, and `seedExistingDocs` persistence calls.

**Build guard** (`check-packaged-runtime-deps.js` + `publish-release.yml`)
- The Electron native smoke now open/put/get/closes a real `classic-level` DB — a wrong-ABI binary fails the build, not the user.
- The check now understands the `win-unpacked` layout and runs on the Windows release job after packaging.

**Installer** (`electron-builder.yml`)
- NSIS assisted installer with `allowToChangeInstallationDirectory` — the same user has a full C: drive and asked to install to D:. Auto-updates still install silently.

## Tests

- 5 new regression tests in `crdt-provider.test.ts` (probe reject, probe hang, no probe retry, mid-session load failure → markdown seed, destroy resets init state); mock simulates the exact napi failure mode.
- Full `src/main/sync/` + runtime-dependencies suites: 82 files / 839 tests green.
- `typecheck:node` clean, lint clean, `docs:impact --strict` + `docs:build` green.

## Notes

- Why the Windows binary was broken (prebuild selection vs rebuild on the runner) is still unconfirmed — the new Windows-job smoke will tell us on the next release build. Either way the app no longer dies from it.
- Follow-up candidates (not in this PR): user-visible degraded-mode banner; corrupt embedding-model redownload (`Protobuf parsing failed` in the same log).