### PR TITLE
fix(tasks): due date off-by-one in negative-offset timezones

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/task-block/task-block-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/task-block/task-block-utils.ts
@@ -4,6 +4,7 @@ import type {
   RepeatConfig as DisplayRepeatConfig
 } from '@/data/task-model'
 import type { Task as ServiceTask } from '@/services/tasks-service'
+import { parseDueDate } from '@/lib/task-utils'
 
 // Pure task-block markdown helpers live in @memry/shared so the main-process
 // CRDT seed/writeback can reuse the exact same logic. Re-exported here so the
@@ -50,7 +51,7 @@ export function serviceTaskToDisplayTask(task: ServiceTask, fallbackStatusId: st
     projectId: task.projectId,
     statusId: task.statusId ?? fallbackStatusId,
     priority: DB_PRIORITY_MAP[task.priority] ?? 'none',
-    dueDate: task.dueDate ? new Date(task.dueDate) : null,
+    dueDate: task.dueDate ? parseDueDate(task.dueDate) : null,
     dueTime: task.dueTime ?? null,
     isRepeating: task.repeatConfig !== null,
     repeatConfig,

--- a/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
+++ b/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import type { Project, ProjectWithStats, Status, Task } from '@memry/rpc/tasks'
-import { formatDateKey } from '@/lib/task-utils'
+import { formatDateKey, parseDueDate } from '@/lib/task-utils'
 import type { Task as UiTask, RepeatConfig as UiRepeatConfig } from '@/data/task-model'
 import type { Project as UiProject, Status as UiStatus, StatusType } from '@/data/tasks-data'
 import {
@@ -92,7 +92,7 @@ function dbTaskToUiTask(dbTask: Task): UiTask {
     projectId: dbTask.projectId,
     statusId: dbTask.statusId ?? '',
     priority: priorityMap[dbTask.priority as number] ?? 'none',
-    dueDate: dbTask.dueDate ? new Date(dbTask.dueDate) : null,
+    dueDate: dbTask.dueDate ? parseDueDate(dbTask.dueDate) : null,
     dueTime: dbTask.dueTime,
     isRepeating: !!dbTask.repeatConfig,
     repeatConfig: dbRepeatConfigToUiRepeatConfig(dbTask.repeatConfig),

--- a/apps/desktop/src/renderer/src/lib/task-utils/index.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/index.ts
@@ -19,7 +19,8 @@ export {
   isSameMonth,
   endOfDay,
   formatDateKey,
-  parseDateKey
+  parseDateKey,
+  parseDueDate
 } from './task-date-utils'
 
 export {

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-date-utils.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-date-utils.ts
@@ -131,3 +131,11 @@ export const parseDateKey = (key: string): Date => {
   const [year, month, day] = key.split('-').map(Number)
   return new Date(year, month - 1, day)
 }
+
+// Parse a stored task dueDate value into a local Date.
+// Date-only keys (yyyy-MM-dd) are parsed as local midnight; `new Date('yyyy-MM-dd')`
+// would parse them as UTC midnight and roll back a day in negative-offset zones.
+// Values that carry a time component fall back to native parsing.
+export const parseDueDate = (value: string): Date => {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? parseDateKey(value) : new Date(value)
+}

--- a/apps/desktop/src/renderer/src/lib/task-utils/task-utils.test.ts
+++ b/apps/desktop/src/renderer/src/lib/task-utils/task-utils.test.ts
@@ -61,6 +61,7 @@ import {
   // Calendar Helpers (T081)
   formatDateKey,
   parseDateKey,
+  parseDueDate,
   // Task Filtering - Basic (T082)
   filterBySearch,
   filterByProjects,
@@ -2203,6 +2204,29 @@ describe('Task Utils', () => {
         const date = parseDateKey('2028-02-29')
         expect(date.getMonth()).toBe(1)
         expect(date.getDate()).toBe(29)
+      })
+    })
+
+    describe('parseDueDate', () => {
+      it('should parse a date-only key to the same local calendar day (no UTC roll-back)', () => {
+        // Regression: `new Date('2026-07-10')` parses as UTC midnight and shows
+        // July 9 in negative-offset zones. parseDueDate must keep the same day.
+        const date = parseDueDate('2026-07-10')
+        expect(date.getFullYear()).toBe(2026)
+        expect(date.getMonth()).toBe(6)
+        expect(date.getDate()).toBe(10)
+      })
+
+      it('should roundtrip with formatDateKey on the same local day', () => {
+        const key = formatDateKey(new Date(2026, 6, 10))
+        const parsed = parseDueDate(key)
+        expect(formatDateKey(parsed)).toBe(key)
+        expect(parsed.getDate()).toBe(10)
+      })
+
+      it('should fall back to native parsing for values with a time component', () => {
+        const date = parseDueDate('2026-07-10T15:30:00.000Z')
+        expect(date.getTime()).toBe(new Date('2026-07-10T15:30:00.000Z').getTime())
       })
     })
   })


### PR DESCRIPTION
## What
Task due dates land on the correct day in every timezone. dueDate is stored as a local `YYYY-MM-DD` key but was read back with `new Date(str)`, which parses date-only strings as UTC midnight and rolls back a day in Americas timezones (July 10 shown as July 9).

## Why
New `parseDueDate` helper parses date-only keys as local midnight (datetime strings fall back to native for legacy compat), applied at both read sites. Write path was already correct, so existing stored dates need no migration.