### PR TITLE
fix(desktop): make Large font-size noticeably bigger (18px → 20px)

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -117,7 +117,7 @@
 
 /* ===== EDITOR FONT SIZE (Appearance → Font Size: S/M/L) ===== */
 /* BlockNote pins `.bn-default-styles` to a fixed 16px, so the app's font-size
-   setting — applied by useThemeSync as the root <html> font-size (14/16/18px) —
+   setting — applied by useThemeSync as the root <html> font-size (14/16/20px) —
    never reached editor body text. `1rem` re-ties the editor to that root value,
    so S/M/L now scales note body text (and inline #tags, sized at 0.9em) too.
    At Medium (16px) this is identical to the previous fixed 16px. */

--- a/apps/desktop/src/renderer/src/hooks/use-theme-sync.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-theme-sync.test.ts
@@ -64,7 +64,7 @@ describe('useThemeSync', () => {
 
     expect(setTheme).toHaveBeenCalledWith('light')
     expect(document.documentElement.style.getPropertyValue('--user-accent-color')).toBe('#123456')
-    expect(document.documentElement.style.fontSize).toBe('18px')
+    expect(document.documentElement.style.fontSize).toBe('20px')
     expect(document.documentElement.style.getPropertyValue('--font-sans')).toContain(
       'Crimson Pro Variable'
     )

--- a/apps/desktop/src/renderer/src/hooks/use-theme-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-theme-sync.ts
@@ -9,7 +9,7 @@ const log = createLogger('ThemeSync')
 const FONT_SIZE_MAP = {
   small: '14px',
   medium: '16px',
-  large: '18px'
+  large: '20px'
 } as const
 
 const FONT_FAMILY_MAP: Record<string, string> = {

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -181,7 +181,7 @@ Eight presets — indigo, amber, emerald, red, violet, cyan, pink, orange — pl
 
 ### Typography
 
-- **Font Size** — Small / Medium / Large. Scales the whole interface, including note editor text and tags.
+- **Font Size** — Small (14px) / Medium (16px) / Large (20px). Sets the base interface size; the whole app and note editor text scale with it.
 - **Font Family** — System, Sans-Serif, Serif, Monospace, Gelasio, Geist, Inter
 
 ---


### PR DESCRIPTION
## What
Widen the Appearance → Font Size `Large` step from 18px to 20px (Small 14 / Medium 16 unchanged).

## Why
The setting drives the root `<html>` font-size that the whole app and note editor text scale off. M→L was only 16→18px (+12.5%), so Large read as "nothing changed." 20px gives a clear +25% step; Medium stays 16px for backward compatibility.