### PR TITLE
fix(editor): persist inline text color through markdown save/reload

### DIFF
--- a/apps/desktop/src/main/sync/blocknote-converter.test.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.test.ts
@@ -451,6 +451,124 @@ describe('blocknote-converter list fidelity', () => {
   })
 })
 
+describe('blocknote-converter color fidelity', () => {
+  const roundTrip = async (md: string): Promise<string | null> => {
+    const doc = new Y.Doc()
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    await markdownToYFragment(md, fragment)
+    return yDocToMarkdown(doc)
+  }
+
+  const blocksToMd = async (blocks: NonNullable<Awaited<ReturnType<typeof markdownToBlocks>>>) => {
+    const doc = new Y.Doc()
+    const fragment = doc.getXmlFragment(CRDT_FRAGMENT_NAME)
+    blocksToYFragment(blocks, fragment)
+    return yDocToMarkdown(doc)
+  }
+
+  it('round-trips a heading with a block-level color marker', async () => {
+    // #given the drag-handle side-menu color path (block props)
+    const md = '<!-- colors:{"textColor":"red"} -->\n### Hello'
+
+    // #when
+    const blocks = await markdownToBlocks(md)
+    expect(blocks![0]).toMatchObject({
+      type: 'heading',
+      props: { level: 3, textColor: 'red' }
+    })
+    const out = await blocksToMd(blocks!)
+
+    // #then
+    expect(out).toBe(md)
+  })
+
+  it('serializes inline textColor styles on a heading as a span', async () => {
+    // #given the formatting-toolbar color path (inline styles)
+    const blocks = [
+      {
+        type: 'heading',
+        props: { level: 3 },
+        content: [
+          { type: 'text', text: 'He', styles: {} },
+          { type: 'text', text: 'llo', styles: { textColor: 'red' } },
+          { type: 'text', text: ' world', styles: {} }
+        ],
+        children: []
+      }
+    ] as unknown as NonNullable<Awaited<ReturnType<typeof markdownToBlocks>>>
+
+    // #when
+    const out = await blocksToMd(blocks)
+
+    // #then
+    expect(out).toBe('### He<span style="color:red">llo</span> world')
+  })
+
+  it('parses inline color spans back into styles', async () => {
+    // #given
+    const md = '### He<span style="color:red">llo</span> world'
+
+    // #when
+    const blocks = await markdownToBlocks(md)
+
+    // #then
+    expect(blocks![0].type).toBe('heading')
+    expect(blocks![0].content).toEqual([
+      expect.objectContaining({ text: 'He', styles: {} }),
+      expect.objectContaining({ text: 'llo', styles: { textColor: 'red' } }),
+      expect.objectContaining({ text: ' world', styles: {} })
+    ])
+  })
+
+  it('round-trips inline colors combined with bold and background color', async () => {
+    // #given
+    const md = 'a <span style="color:blue;background-color:yellow">**bold** plain</span> tail'
+
+    // #when
+    const out = await roundTrip(md)
+
+    // #then
+    expect(out).toBe(md)
+  })
+
+  it('round-trips inline color combined with italic despite intraword flanking', async () => {
+    // #given an italic run wrapped in a color span (token punctuation must keep
+    // the `*` delimiters left/right-flanking)
+    const md = 'a <span style="color:red">*em*</span> tail'
+
+    // #when
+    const out = await roundTrip(md)
+
+    // #then
+    expect(out).toBe(md)
+  })
+
+  it('leaves literal span text inside code fences untouched', async () => {
+    // #given
+    const md = '```html\n<span style="color:red">code</span>\n```'
+
+    // #when
+    const out = await roundTrip(md)
+
+    // #then
+    expect(out).toContain('<span style="color:red">code</span>')
+    expect(out).toContain('```html')
+  })
+
+  it('round-trips inline color on repeated saves without growing markup', async () => {
+    // #given
+    const md = 'He<span style="color:red">llo</span> world'
+
+    // #when — two consecutive round-trips (open, save, reopen, save)
+    const once = await roundTrip(md)
+    const twice = await roundTrip(once!)
+
+    // #then
+    expect(once).toBe(md)
+    expect(twice).toBe(md)
+  })
+})
+
 describe('blocknote-converter soft-break fidelity', () => {
   it('round-trips single-newline lines without adding blank lines or backslashes', async () => {
     // #given an Obsidian-style paragraph of soft-broken lines (single \n)

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -25,6 +25,12 @@ import {
   serializeBlockColorsMarker
 } from '@memry/shared/block-colors'
 import {
+  applyInlineColorTokens,
+  extractInlineColorRuns,
+  maskInlineColorSpans,
+  restoreInlineColorTokens
+} from '@memry/shared/inline-colors'
+import {
   splitMarkdownPreservingBlanks,
   assembleMarkdownWithBlanks,
   separateBlockImages,
@@ -212,12 +218,18 @@ const MARKDOWN_LIST_BLOCK_TYPES = new Set(['bulletListItem', 'numberedListItem',
 
 // Every blocks→markdown serialization funnels through here so list markers,
 // list tightness, and soft breaks stay byte-friendly against vault files.
-// See normalizeSerializedMarkdown.
+// See normalizeSerializedMarkdown. Inline text/background colors would be
+// dropped by blocksToMarkdownLossy, so colored runs are wrapped in tokens
+// first and re-emitted as `<span style="…">` after serialization.
 async function serializeBlocks(
   editor: ServerBlockNoteEditor,
   blocks: PartialBlock[]
 ): Promise<string> {
-  return normalizeSerializedMarkdown(await editor.blocksToMarkdownLossy(blocks))
+  const { blocks: wrapped, replacements } = extractInlineColorRuns(blocks as never[])
+  const md = normalizeSerializedMarkdown(
+    await editor.blocksToMarkdownLossy(wrapped as PartialBlock[])
+  )
+  return restoreInlineColorTokens(md, replacements)
 }
 
 function canSerializeChildNatively(parent: Block, child: Block): boolean {
@@ -296,7 +308,10 @@ async function markdownToBlocksPreserving(
   editor: ServerBlockNoteEditor,
   markdown: string
 ): Promise<Block[]> {
-  const segments = splitMarkdownPreservingBlanks(separateBlockImages(markdown))
+  // Inline color spans are masked into markdown-inert tokens before parsing
+  // (BlockNote strips raw spans), then re-applied as styles on the parsed runs.
+  const { text, spans } = maskInlineColorSpans(separateBlockImages(markdown))
+  const segments = splitMarkdownPreservingBlanks(text)
   const blocks: Block[] = []
 
   for (const seg of segments) {
@@ -309,7 +324,7 @@ async function markdownToBlocksPreserving(
     }
   }
 
-  return blocks
+  return applyInlineColorTokens(blocks as never[], spans) as Block[]
 }
 
 async function parseContentWithColorMarkers(

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.test.ts
@@ -170,6 +170,37 @@ describe('parseMarkdownPreservingBlanks', () => {
     ])
   })
 
+  it('applies inline color spans to parsed runs', async () => {
+    const editor = {
+      tryParseMarkdownToBlocks: vi.fn(async (markdown: string) =>
+        markdown
+          .split('\n')
+          .filter((line) => line.trim())
+          .map((line) => ({
+            type: 'paragraph',
+            props: {},
+            content: [{ type: 'text', text: line.trim(), styles: {} }],
+            children: []
+          }))
+      )
+    }
+
+    const blocks = await parseMarkdownPreservingBlanks(
+      editor,
+      'He<span style="color:red">llo</span> world'
+    )
+
+    expect(blocks).toEqual([
+      expect.objectContaining({
+        content: [
+          { type: 'text', text: 'He', styles: {} },
+          { type: 'text', text: 'llo', styles: { textColor: 'red' } },
+          { type: 'text', text: ' world', styles: {} }
+        ]
+      })
+    ])
+  })
+
   it('parses file block markers in place', async () => {
     const editor = {
       tryParseMarkdownToBlocks: vi.fn(async (markdown: string) => [
@@ -384,6 +415,36 @@ describe('serializeBlocksPreservingBlanks', () => {
     expect(markdown.lastIndexOf('<!-- colors:', tailIndex)).toBeLessThan(
       markdown.indexOf('Second colored')
     )
+  })
+
+  it('serializes inline textColor styles as span html', async () => {
+    const editor = {
+      blocksToMarkdownLossy: vi.fn(async (blocks: any[]) =>
+        blocks
+          .map((block) =>
+            Array.isArray(block.content)
+              ? block.content.map((content: any) => content.text ?? '').join('')
+              : ''
+          )
+          .filter(Boolean)
+          .join('\n')
+      )
+    }
+
+    const markdown = await serializeBlocksPreservingBlanks(editor, [
+      {
+        type: 'heading',
+        props: { level: 3 },
+        content: [
+          { type: 'text', text: 'He', styles: {} },
+          { type: 'text', text: 'llo', styles: { textColor: 'red' } },
+          { type: 'text', text: ' world', styles: {} }
+        ],
+        children: []
+      }
+    ] as any[])
+
+    expect(markdown).toBe('He<span style="color:red">llo</span> world')
   })
 
   it('serializes file blocks as markers without leaking rendered UI text', async () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
@@ -16,6 +16,12 @@ import {
   serializeBlockColorsMarker
 } from '@memry/shared/block-colors'
 import {
+  applyInlineColorTokens,
+  extractInlineColorRuns,
+  maskInlineColorSpans,
+  restoreInlineColorTokens
+} from '@memry/shared/inline-colors'
+import {
   createBlockNestingMarker,
   restoreBlockNesting,
   splitMarkdownByBlockNestingMarkers
@@ -80,9 +86,13 @@ async function parseMarkdownChunkPreservingNesting(
 // renderer save path matches the main/CRDT path (blocknote-converter.ts): `-`
 // bullets, tight lists, and single-newline paragraphs instead of remark's raw
 // `*` / loose / `\`-hard-break defaults. Without this the two serializers drift
-// and typed notes get rewritten to the loose remark style on disk.
+// and typed notes get rewritten to the loose remark style on disk. Inline
+// text/background colors would be dropped by blocksToMarkdownLossy, so colored
+// runs are wrapped in tokens first and re-emitted as `<span style="…">` after.
 async function serializeBlocks(editor: any, blocks: Block[]): Promise<string> {
-  return normalizeSerializedMarkdown(await editor.blocksToMarkdownLossy(blocks))
+  const { blocks: wrapped, replacements } = extractInlineColorRuns(blocks as never[])
+  const md = normalizeSerializedMarkdown(await editor.blocksToMarkdownLossy(wrapped))
+  return restoreInlineColorTokens(md, replacements)
 }
 
 async function serializeBlocksWithNestingMarkers(editor: any, blocks: Block[]): Promise<string> {
@@ -148,7 +158,10 @@ export async function parseMarkdownPreservingBlanks(
   editor: any,
   markdown: string
 ): Promise<Block[]> {
-  const calloutSegments = splitMarkdownByCallouts(markdown)
+  // Inline color spans are masked into markdown-inert tokens before parsing
+  // (BlockNote strips raw spans), then re-applied as styles on the parsed runs.
+  const { text: maskedMarkdown, spans } = maskInlineColorSpans(markdown)
+  const calloutSegments = splitMarkdownByCallouts(maskedMarkdown)
   const blocks: Block[] = []
 
   for (const cseg of calloutSegments) {
@@ -203,7 +216,7 @@ export async function parseMarkdownPreservingBlanks(
     }
   }
 
-  return blocks
+  return applyInlineColorTokens(blocks as never[], spans) as Block[]
 }
 
 export async function serializeBlocksPreservingBlanks(

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -78,6 +78,15 @@ Notes are plain `.md` files in the vault, and the write path is built around byt
 
 A golden round-trip test suite (`apps/desktop/src/main/vault/byte-preservation.golden.test.ts`) holds this contract against adversarial files (YAML comments/anchors, CRLF, BOM, missing final newline, Obsidian syntax).
 
+### Text colors in markdown
+
+Editor colors persist in two Obsidian-compatible forms:
+
+- **Block-level colors** (drag-handle menu) serialize as an HTML comment marker line before the block: `<!-- colors:{"textColor":"red"} -->` (`packages/shared/src/block-colors.ts`).
+- **Inline colors** (formatting toolbar on selected text) serialize as raw HTML spans — `<span style="color:red">…</span>` / `background-color` — which Obsidian renders natively (`packages/shared/src/inline-colors.ts`). Because BlockNote's markdown pipeline drops both literal spans and inline color styles, both serializers route colored runs through markdown-inert tokens: wrapped before `blocksToMarkdownLossy` and swapped for span HTML after; masked before `tryParseMarkdownToBlocks` and re-applied as styles after. Spans inside fenced or inline code are left untouched. Files without markers or spans parse unchanged, and older app versions reading span-bearing files keep the text and lose only the color.
+
+The pipeline is wired into both duplicated serializers: the renderer save path (`markdown-utils.ts`) and the main/CRDT path (`blocknote-converter.ts`).
+
 ## Concurrency
 
 better-sqlite3 is synchronous and single-process. The main process is the only writer. The renderer never touches SQLite directly — all reads and writes go through IPC.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,7 @@
     "./file-types": "./src/file-types.ts",
     "./empty-lines": "./src/empty-lines.ts",
     "./block-colors": "./src/block-colors.ts",
+    "./inline-colors": "./src/inline-colors.ts",
     "./date-mention": "./src/date-mention.ts",
     "./block-nesting": "./src/block-nesting.ts",
     "./youtube": "./src/youtube.ts",

--- a/packages/shared/src/inline-colors.test.ts
+++ b/packages/shared/src/inline-colors.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyInlineColorTokens,
+  extractInlineColorRuns,
+  maskInlineColorSpans,
+  restoreInlineColorTokens
+} from './inline-colors'
+
+describe('extractInlineColorRuns / restoreInlineColorTokens (serialize side)', () => {
+  it('wraps colored runs in token runs and restores them as span html', () => {
+    const blocks = [
+      {
+        type: 'heading',
+        props: { level: 3 },
+        content: [
+          { type: 'text', text: 'He', styles: {} },
+          { type: 'text', text: 'llo', styles: { textColor: 'red' } },
+          { type: 'text', text: ' world', styles: {} }
+        ],
+        children: []
+      }
+    ]
+
+    const { blocks: wrapped, replacements } = extractInlineColorRuns(blocks)
+
+    const content = (wrapped[0] as { content: Array<{ text: string; styles: object }> }).content
+    expect(content).toHaveLength(5)
+    expect(content[1].text).not.toBe('llo')
+    expect(content[2]).toEqual({ type: 'text', text: 'llo', styles: {} })
+
+    const markdown = `### ${content.map((c) => c.text).join('')}`
+    const restored = restoreInlineColorTokens(markdown, replacements)
+    expect(restored).toBe('### He<span style="color:red">llo</span> world')
+  })
+
+  it('keeps non-color styles on the wrapped run and emits both color decls', () => {
+    const blocks = [
+      {
+        type: 'paragraph',
+        props: {},
+        content: [
+          {
+            type: 'text',
+            text: 'x',
+            styles: { bold: true, textColor: 'blue', backgroundColor: 'yellow' }
+          }
+        ],
+        children: []
+      }
+    ]
+
+    const { blocks: wrapped, replacements } = extractInlineColorRuns(blocks)
+    const content = (wrapped[0] as { content: Array<{ text: string; styles: object }> }).content
+    expect(content[1].styles).toEqual({ bold: true })
+
+    const restored = restoreInlineColorTokens(content.map((c) => c.text).join(''), replacements)
+    expect(restored).toBe('<span style="color:blue;background-color:yellow">x</span>')
+  })
+
+  it('ignores default colors and leaves untouched blocks referentially intact', () => {
+    const blocks = [
+      {
+        type: 'paragraph',
+        props: {},
+        content: [{ type: 'text', text: 'plain', styles: { textColor: 'default' } }],
+        children: []
+      }
+    ]
+
+    const { blocks: wrapped, replacements } = extractInlineColorRuns(blocks)
+    expect(replacements.size).toBe(0)
+    expect(wrapped[0]).toBe(blocks[0])
+  })
+
+  it('wraps colored runs inside links and nested children', () => {
+    const blocks = [
+      {
+        type: 'paragraph',
+        props: {},
+        content: [
+          {
+            type: 'link',
+            href: 'https://example.com',
+            content: [{ type: 'text', text: 'link', styles: { textColor: 'green' } }]
+          }
+        ],
+        children: [
+          {
+            type: 'paragraph',
+            props: {},
+            content: [{ type: 'text', text: 'child', styles: { backgroundColor: 'pink' } }],
+            children: []
+          }
+        ]
+      }
+    ]
+
+    const { blocks: wrapped, replacements } = extractInlineColorRuns(blocks)
+    // two open tokens + the shared close token
+    expect(replacements.size).toBe(3)
+    const link = (wrapped[0] as { content: Array<{ content?: unknown[] }> }).content[0]
+    expect(link.content).toHaveLength(3)
+    const child = (wrapped[0] as { children: Array<{ content: unknown[] }> }).children[0]
+    expect(child.content).toHaveLength(3)
+  })
+})
+
+describe('maskInlineColorSpans / applyInlineColorTokens (parse side)', () => {
+  it('masks span tags into tokens and applies styles to parsed runs', () => {
+    const { text, spans } = maskInlineColorSpans('### He<span style="color:red">llo</span> world')
+    expect(text).not.toContain('<span')
+    expect(text).not.toContain('</span>')
+    expect(spans).toHaveLength(1)
+    expect(spans[0].styles).toEqual({ textColor: 'red' })
+
+    // simulate a parser that keeps the masked text verbatim in one run
+    const parsed = [
+      {
+        type: 'heading',
+        props: { level: 3 },
+        content: [{ type: 'text', text: text.replace(/^### /, ''), styles: {} }],
+        children: []
+      }
+    ]
+    const applied = applyInlineColorTokens(parsed, spans)
+    expect((applied[0] as { content: unknown[] }).content).toEqual([
+      { type: 'text', text: 'He', styles: {} },
+      { type: 'text', text: 'llo', styles: { textColor: 'red' } },
+      { type: 'text', text: ' world', styles: {} }
+    ])
+  })
+
+  it('parses combined color and background-color decls in any order', () => {
+    const { spans } = maskInlineColorSpans(
+      '<span style="background-color: yellow; color: blue">x</span>'
+    )
+    expect(spans[0].styles).toEqual({ textColor: 'blue', backgroundColor: 'yellow' })
+  })
+
+  it('merges span colors with styles the parser already produced', () => {
+    const { text, spans } = maskInlineColorSpans('<span style="color:red">**bold** plain</span>')
+    // simulate the parser splitting the bold run, tokens staying in the text runs
+    const openEnd = text.indexOf('**bold**')
+    const parsed = [
+      {
+        type: 'paragraph',
+        props: {},
+        content: [
+          { type: 'text', text: text.slice(0, openEnd), styles: {} },
+          { type: 'text', text: 'bold', styles: { bold: true } },
+          { type: 'text', text: text.slice(openEnd + '**bold**'.length), styles: {} }
+        ],
+        children: []
+      }
+    ]
+    const applied = applyInlineColorTokens(parsed, spans)
+    expect((applied[0] as { content: unknown[] }).content).toEqual([
+      { type: 'text', text: 'bold', styles: { bold: true, textColor: 'red' } },
+      { type: 'text', text: ' plain', styles: { textColor: 'red' } }
+    ])
+  })
+
+  it('leaves spans inside fenced code blocks and inline code untouched', () => {
+    const md = [
+      '```html',
+      '<span style="color:red">code</span>',
+      '```',
+      'inline `<span style="color:red">code</span>` tail'
+    ].join('\n')
+    const { text, spans } = maskInlineColorSpans(md)
+    expect(text).toBe(md)
+    expect(spans).toHaveLength(0)
+  })
+
+  it('does not mask spans with other attributes or non-color styles', () => {
+    const md = '<span class="x">a</span> <span style="font-weight:bold">b</span>'
+    const { text: masked } = maskInlineColorSpans(md)
+    expect(masked).toContain('<span class="x">')
+    expect(masked).toContain('<span style="font-weight:bold">')
+  })
+
+  it('leaves documents with only bare close tags unmasked', () => {
+    const { text, spans } = maskInlineColorSpans('plain </span> tail')
+    expect(text).toBe('plain </span> tail')
+    expect(spans).toHaveLength(0)
+  })
+
+  it('drops a stray close token once a real span was masked', () => {
+    const { text, spans } = maskInlineColorSpans(
+      '<span style="color:red">x</span> mid </span> tail'
+    )
+    const parsed = [
+      {
+        type: 'paragraph',
+        props: {},
+        content: [{ type: 'text', text, styles: {} }],
+        children: []
+      }
+    ]
+    const applied = applyInlineColorTokens(parsed, spans)
+    expect((applied[0] as { content: unknown[] }).content).toEqual([
+      { type: 'text', text: 'x', styles: { textColor: 'red' } },
+      { type: 'text', text: ' mid ', styles: {} },
+      { type: 'text', text: ' tail', styles: {} }
+    ])
+  })
+
+  it('restores tokens verbatim inside code blocks', () => {
+    // an indented code block slips past line-based fence tracking; the apply
+    // step must restore the original source instead of styling it
+    const { text, spans } = maskInlineColorSpans('    <span style="color:red">x</span>')
+    const parsed = [
+      {
+        type: 'codeBlock',
+        props: {},
+        content: [{ type: 'text', text: text.trim(), styles: {} }],
+        children: []
+      }
+    ]
+    const applied = applyInlineColorTokens(parsed, spans)
+    expect((applied[0] as { content: Array<{ text: string }> }).content[0].text).toBe(
+      '<span style="color:red">x</span>'
+    )
+  })
+})

--- a/packages/shared/src/inline-colors.ts
+++ b/packages/shared/src/inline-colors.ts
@@ -1,0 +1,381 @@
+/**
+ * Inline text color persistence.
+ *
+ * BlockNote's markdown pipeline drops inline `styles.textColor` /
+ * `styles.backgroundColor` in both directions, so colored selections are
+ * persisted as Obsidian-compatible raw HTML: `<span style="color:red">…</span>`.
+ *
+ * Markdown serializers escape literal `<span>` text inside runs, so both
+ * directions go through markdown-inert alphanumeric tokens instead:
+ * - serialize: colored runs are wrapped in token runs
+ *   (extractInlineColorRuns), serialized normally, then the tokens are
+ *   replaced with span tags (restoreInlineColorTokens).
+ * - parse: span tags are masked into tokens before the markdown parse
+ *   (maskInlineColorSpans), then the tokens are located in the parsed inline
+ *   runs and replaced by styles (applyInlineColorTokens).
+ *
+ * Tokens end (open) / start (close) with punctuation so emphasis markers next
+ * to them keep valid CommonMark flanking (`:*em*:` parses, `x*em*x` does not).
+ */
+
+export interface InlineColorStyles {
+  textColor?: string
+  backgroundColor?: string
+}
+
+interface StyledText {
+  type: string
+  text: string
+  styles: Record<string, unknown>
+}
+
+interface InlineNode {
+  type: string
+  text?: string
+  content?: InlineNode[]
+  styles?: Record<string, unknown>
+}
+
+interface BlockNode {
+  type?: string
+  content?: unknown
+  children?: BlockNode[]
+}
+
+interface TableContent {
+  type: 'tableContent'
+  rows: Array<{ cells: unknown[] }>
+}
+
+const openToken = (index: number): string => `MEMRYICO${index}:`
+const CLOSE_TOKEN = ':MEMRYICC;'
+const TOKEN_REGEX = /MEMRYICO(\d+):|:MEMRYICC;/g
+
+function pickColorStyles(styles: Record<string, unknown>): InlineColorStyles | null {
+  const colors: InlineColorStyles = {}
+  if (typeof styles.textColor === 'string' && styles.textColor !== 'default') {
+    colors.textColor = styles.textColor
+  }
+  if (typeof styles.backgroundColor === 'string' && styles.backgroundColor !== 'default') {
+    colors.backgroundColor = styles.backgroundColor
+  }
+  return colors.textColor || colors.backgroundColor ? colors : null
+}
+
+// Palette values are plain names; reject anything that could break out of the
+// style attribute or the decl list.
+function isSafeColorValue(value: string): boolean {
+  return value.length > 0 && !/[;"'<>]/.test(value)
+}
+
+function buildSpanOpen(colors: InlineColorStyles): string {
+  const decls: string[] = []
+  if (colors.textColor) decls.push(`color:${colors.textColor}`)
+  if (colors.backgroundColor) decls.push(`background-color:${colors.backgroundColor}`)
+  return `<span style="${decls.join(';')}">`
+}
+
+// ---------------------------------------------------------------------------
+// Serialize side
+// ---------------------------------------------------------------------------
+
+export function extractInlineColorRuns(blocks: BlockNode[]): {
+  blocks: BlockNode[]
+  replacements: Map<string, string>
+} {
+  const replacements = new Map<string, string>()
+  let index = 0
+
+  const wrapInline = (items: InlineNode[]): InlineNode[] => {
+    let changed = false
+    const out: InlineNode[] = []
+    // Consecutive runs with identical colors share one span so a parse that
+    // split e.g. `**bold** plain` into two runs re-serializes byte-identical.
+    let openColors: InlineColorStyles | null = null
+
+    const closeGroup = (): void => {
+      if (!openColors) return
+      out.push({ type: 'text', text: CLOSE_TOKEN, styles: {} })
+      openColors = null
+    }
+
+    for (const item of items) {
+      if (Array.isArray(item.content)) {
+        closeGroup()
+        const content = wrapInline(item.content)
+        if (content !== item.content) {
+          out.push({ ...item, content })
+          changed = true
+        } else {
+          out.push(item)
+        }
+        continue
+      }
+      const styles = item.styles
+      const colors =
+        typeof item.text === 'string' && item.text.length > 0 && styles
+          ? pickColorStyles(styles)
+          : null
+      if (
+        !colors ||
+        (colors.textColor && !isSafeColorValue(colors.textColor)) ||
+        (colors.backgroundColor && !isSafeColorValue(colors.backgroundColor))
+      ) {
+        closeGroup()
+        out.push(item)
+        continue
+      }
+      if (
+        !openColors ||
+        openColors.textColor !== colors.textColor ||
+        openColors.backgroundColor !== colors.backgroundColor
+      ) {
+        closeGroup()
+        const open = openToken(index++)
+        replacements.set(open, buildSpanOpen(colors))
+        replacements.set(CLOSE_TOKEN, '</span>')
+        out.push({ type: 'text', text: open, styles: {} })
+        openColors = colors
+      }
+      const {
+        textColor: _t,
+        backgroundColor: _b,
+        ...rest
+      } = styles as InlineColorStyles & Record<string, unknown>
+      out.push({ ...item, styles: rest })
+      changed = true
+    }
+    closeGroup()
+    return changed ? out : items
+  }
+
+  const wrapTable = (content: TableContent): TableContent | null => {
+    let changed = false
+    const rows = content.rows.map((row) => {
+      const cells = row.cells.map((cell) => {
+        if (!Array.isArray(cell)) return cell
+        const wrapped = wrapInline(cell as InlineNode[])
+        if (wrapped !== cell) changed = true
+        return wrapped
+      })
+      return { ...row, cells }
+    })
+    return changed ? { ...content, rows } : null
+  }
+
+  const wrapBlocks = (input: BlockNode[]): BlockNode[] => {
+    let changed = false
+    const out = input.map((block) => {
+      let next = block
+      if (Array.isArray(block.content)) {
+        const content = wrapInline(block.content as InlineNode[])
+        if (content !== block.content) next = { ...next, content }
+      } else if ((block.content as TableContent | undefined)?.type === 'tableContent') {
+        const table = wrapTable(block.content as TableContent)
+        if (table) next = { ...next, content: table }
+      }
+      if (Array.isArray(block.children) && block.children.length > 0) {
+        const children = wrapBlocks(block.children)
+        if (children !== block.children) next = { ...next, children }
+      }
+      if (next !== block) changed = true
+      return next
+    })
+    return changed ? out : input
+  }
+
+  return { blocks: wrapBlocks(blocks), replacements }
+}
+
+export function restoreInlineColorTokens(
+  markdown: string,
+  replacements: Map<string, string>
+): string {
+  if (replacements.size === 0) return markdown
+  let out = markdown
+  for (const [token, html] of replacements) {
+    out = out.split(token).join(html)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Parse side
+// ---------------------------------------------------------------------------
+
+export interface MaskedColorSpan {
+  styles: InlineColorStyles
+  source: string
+}
+
+const SPAN_OPEN_REGEX = /<span style="([^"]*)">/g
+const SPAN_CLOSE_REGEX = /<\/span>/g
+// Inline code spans: a backtick run, non-backtick content, matching run.
+const INLINE_CODE_REGEX = /(`+)[^`]*?\1/g
+
+function parseColorDecls(style: string): InlineColorStyles | null {
+  const colors: InlineColorStyles = {}
+  for (const decl of style.split(';')) {
+    if (!decl.trim()) continue
+    const colonIndex = decl.indexOf(':')
+    if (colonIndex === -1) return null
+    const prop = decl.slice(0, colonIndex).trim()
+    const value = decl.slice(colonIndex + 1).trim()
+    if (!isSafeColorValue(value)) return null
+    if (prop === 'color') colors.textColor = value
+    else if (prop === 'background-color') colors.backgroundColor = value
+    else return null
+  }
+  return colors.textColor || colors.backgroundColor ? colors : null
+}
+
+export function maskInlineColorSpans(markdown: string): {
+  text: string
+  spans: MaskedColorSpan[]
+} {
+  if (!markdown.includes('</span>')) return { text: markdown, spans: [] }
+
+  const spans: MaskedColorSpan[] = []
+
+  const maskSegment = (segment: string): string =>
+    segment
+      .replace(SPAN_OPEN_REGEX, (source, style: string) => {
+        const styles = parseColorDecls(style)
+        if (!styles) return source
+        spans.push({ styles, source })
+        return openToken(spans.length - 1)
+      })
+      .replace(SPAN_CLOSE_REGEX, CLOSE_TOKEN)
+
+  const maskLine = (line: string): string => {
+    // Skip inline code segments so literal span text inside backticks survives.
+    let out = ''
+    let last = 0
+    INLINE_CODE_REGEX.lastIndex = 0
+    for (const match of line.matchAll(INLINE_CODE_REGEX)) {
+      out += maskSegment(line.slice(last, match.index)) + match[0]
+      last = match.index + match[0].length
+    }
+    return out + maskSegment(line.slice(last))
+  }
+
+  let insideFence = false
+  let fenceMarker = ''
+  const lines = markdown.split('\n').map((line) => {
+    const fenceMatch = line.trimStart().match(/^(```+|~~~+)/)
+    if (fenceMatch) {
+      if (!insideFence) {
+        insideFence = true
+        fenceMarker = fenceMatch[1][0]
+      } else if (fenceMatch[1][0] === fenceMarker) {
+        insideFence = false
+      }
+      return line
+    }
+    return insideFence ? line : maskLine(line)
+  })
+
+  // Close tags only matter paired with a masked open; a document with no
+  // color-span opens keeps its original text (BlockNote drops bare spans the
+  // same way it always has).
+  if (spans.length === 0) return { text: markdown, spans: [] }
+
+  return { text: lines.join('\n'), spans }
+}
+
+function mergeActive(
+  styles: Record<string, unknown>,
+  active: InlineColorStyles[]
+): Record<string, unknown> {
+  if (active.length === 0) return styles
+  return Object.assign({}, styles, ...active)
+}
+
+function restoreTokensInText(text: string, spans: MaskedColorSpan[]): string {
+  return text.replace(TOKEN_REGEX, (match, openIndex: string | undefined) => {
+    if (openIndex === undefined) return '</span>'
+    return spans[Number(openIndex)]?.source ?? match
+  })
+}
+
+export function applyInlineColorTokens(blocks: BlockNode[], spans: MaskedColorSpan[]): BlockNode[] {
+  const applyInline = (items: InlineNode[], active: InlineColorStyles[]): InlineNode[] => {
+    const out: InlineNode[] = []
+    for (const item of items) {
+      if (Array.isArray(item.content)) {
+        out.push({ ...item, content: applyInline(item.content, active) })
+        continue
+      }
+      if (typeof item.text !== 'string') {
+        out.push(item)
+        continue
+      }
+      const run = item as unknown as StyledText
+      let last = 0
+      TOKEN_REGEX.lastIndex = 0
+      for (const match of run.text.matchAll(TOKEN_REGEX)) {
+        const plain = run.text.slice(last, match.index)
+        if (plain) {
+          out.push({ ...run, text: plain, styles: mergeActive(run.styles, active) })
+        }
+        last = match.index + match[0].length
+        const openIndex = match[1]
+        if (openIndex !== undefined) {
+          const span = spans[Number(openIndex)]
+          if (span) {
+            active.push(span.styles)
+          } else {
+            // No matching masked span: the text happened to look like a token.
+            out.push({ ...run, text: match[0], styles: mergeActive(run.styles, active) })
+          }
+        } else if (active.length > 0) {
+          active.pop()
+        }
+      }
+      const tail = run.text.slice(last)
+      if (tail) {
+        out.push({ ...run, text: tail, styles: mergeActive(run.styles, active) })
+      }
+    }
+    return out
+  }
+
+  const applyTable = (content: TableContent): TableContent => ({
+    ...content,
+    rows: content.rows.map((row) => ({
+      ...row,
+      cells: row.cells.map((cell) =>
+        Array.isArray(cell) ? applyInline(cell as InlineNode[], []) : cell
+      )
+    }))
+  })
+
+  const applyBlocks = (input: BlockNode[]): BlockNode[] =>
+    input.map((block) => {
+      let next = block
+      if (block.type === 'codeBlock') {
+        // Tokens that slipped into code content (e.g. indented code blocks the
+        // line-based fence tracking cannot see) are restored verbatim.
+        if (Array.isArray(block.content)) {
+          next = {
+            ...next,
+            content: (block.content as InlineNode[]).map((item) =>
+              typeof item.text === 'string'
+                ? { ...item, text: restoreTokensInText(item.text, spans) }
+                : item
+            )
+          }
+        }
+      } else if (Array.isArray(block.content)) {
+        next = { ...next, content: applyInline(block.content as InlineNode[], []) }
+      } else if ((block.content as TableContent | undefined)?.type === 'tableContent') {
+        next = { ...next, content: applyTable(block.content as TableContent) }
+      }
+      if (Array.isArray(block.children) && block.children.length > 0) {
+        next = { ...next, children: applyBlocks(block.children) }
+      }
+      return next
+    })
+
+  return spans.length === 0 ? blocks : applyBlocks(blocks)
+}


### PR DESCRIPTION
## Problem

Client report (2026-07-08, v2026-07-05 macOS): changing a Heading 3 color doesn't save — reopening the note shows the default color again.

Reproduced against the real `ServerBlockNoteEditor`:

- **Block-level colors** (drag-handle side menu) already round-trip via the `<!-- colors:… -->` marker, including on headings.
- **Inline colors** (formatting toolbar on selected text, `styles.textColor`/`styles.backgroundColor`) were **silently dropped** by `blocksToMarkdownLossy` in both duplicated serializers. This is the path the client hit. Yjs preserves the styles while the note is open, so the color only vanishes after the markdown write-back + reopen — exactly the reported symptom.

## Fix

New shared module `packages/shared/src/inline-colors.ts`, wired into both serializers (renderer `markdown-utils.ts` and main `blocknote-converter.ts`).

Inline colors persist as Obsidian-renderable raw HTML: `<span style="color:red">…</span>` (and `background-color`). Because remark escapes literal spans and BlockNote's parser strips them, both directions route through markdown-inert tokens:

- **serialize**: colored runs are wrapped in token runs → `blocksToMarkdownLossy` → tokens swapped for span HTML
- **parse**: spans masked into tokens → `tryParseMarkdownToBlocks` → styles re-applied onto the parsed runs

Details that mattered:

- Tokens carry punctuation edges so `*italic*` next to them keeps valid CommonMark flanking.
- Consecutive same-color runs share one span, so `**bold** plain` markup stays byte-stable across repeated saves.
- Masking skips fenced and inline code; tokens that leak into code blocks (e.g. indented code) are restored verbatim.
- Documents with only bare `</span>` stay unmasked, matching BlockNote's existing drop behavior for foreign spans.

## Backward compatibility

- Old files without spans parse unchanged (masking is a no-op).
- New files opened in older app versions: BlockNote strips the span tags but keeps the text (verified by probe) — only the color is lost, never content.
- No schema, IPC contract, or marker-format changes.

## Tests

- 12 unit tests for the shared token pipeline (`inline-colors.test.ts`)
- 7 real-engine round-trips in `blocknote-converter.test.ts`: heading block-level marker, inline color on headings, bold/italic/background combos, code fences, double-save stability
- 2 renderer serializer tests in `markdown-utils.test.ts`

`tsc` (shared/node/web), eslint, and docs gate (`docs:impact --strict`, `docs:build`) all green. Architecture doc updated (`apps/docs/src/architecture/local-storage.md`).