### PR TITLE
fix(tasks): preserve due date on description edit + BlockNote descriptions

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -42,6 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        # Full history so React Doctor can resolve the merge base and report
+        # only the issues a PR introduces, not every pre-existing finding.
+        with:
+          fetch-depth: 0
 
       - uses: millionco/react-doctor@v2
         with:

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -87,9 +87,12 @@
   caret-color: #f0efed;
 }
 
-/* Inbox detail drawer: editor inherits drawer surface bg, not page bg */
+/* Inbox detail + task description drawers: editor inherits the drawer surface
+   bg (var(--surface)), not the page bg — stays theme-correct in white/warm/dark. */
 .inbox-content-editor .bn-editor,
-.inbox-content-editor .bn-container {
+.inbox-content-editor .bn-container,
+.task-description-editor .bn-editor,
+.task-description-editor .bn-container {
   background-color: transparent !important;
 }
 

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -96,6 +96,14 @@
   background-color: transparent !important;
 }
 
+/* Task description editor: the app zeroes .bn-editor padding-inline globally, but
+   BlockNote renders its drag/plus side menu in a left gutter. Reserve that gutter
+   so the handles (and their menus) are not clipped by the drawer's overflow. */
+.task-description-editor .bn-editor {
+  padding-inline-start: 28px !important;
+  padding-inline-end: 4px !important;
+}
+
 /* Code block: always dark background regardless of theme (matches github-dark Shiki theme) */
 .bn-block-content[data-content-type='codeBlock'] {
   background-color: #24292e !important;

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-task-popover-meta.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-task-popover-meta.tsx
@@ -3,6 +3,7 @@ import { formatTaskDue } from '@/lib/format-task-due'
 import { TagChip, type Tag } from '@/components/note/tags-row'
 import { PriorityIcon } from '@/components/tasks/task-icons'
 import { priorityConfig, type Priority } from '@/data/task-model'
+import { TaskDescriptionPreview } from '@/components/tasks/task-description-preview'
 import { cn } from '@/lib/utils'
 
 export interface CalendarTaskPopoverMetaTask {
@@ -127,9 +128,11 @@ export function CalendarTaskPopoverMeta({
       )}
 
       {description && (
-        <p data-testid="description" className="text-muted-foreground line-clamp-3">
-          {description}
-        </p>
+        <TaskDescriptionPreview
+          data-testid="description"
+          markdown={description}
+          className="line-clamp-3"
+        />
       )}
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/tasks/add-task-modal.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/add-task-modal.test.tsx
@@ -9,6 +9,25 @@ import { AddTaskModal } from './add-task-modal'
 import type { Project, Status } from '@/data/tasks-data'
 import type { Task } from '@/data/task-model'
 
+// BlockNote can't mount in jsdom; stub the description editor with a textarea.
+vi.mock('./task-description-editor', () => ({
+  TaskDescriptionEditor: ({
+    initialContent,
+    onContentChange,
+    placeholder
+  }: {
+    initialContent: string | null
+    onContentChange?: (markdown: string) => void
+    placeholder?: string
+  }) => (
+    <textarea
+      placeholder={placeholder}
+      defaultValue={initialContent ?? ''}
+      onChange={(event) => onContentChange?.(event.target.value)}
+    />
+  )
+}))
+
 let i18nEn: I18nInstance
 let i18nTr: I18nInstance
 

--- a/apps/desktop/src/renderer/src/components/tasks/add-task-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/add-task-modal.tsx
@@ -11,6 +11,7 @@ import { DueDatePicker } from './due-date-picker'
 import { PrioritySelect } from './priority-select'
 import { RepeatPicker } from './repeat-picker'
 import { CustomRepeatDialog } from './custom-repeat-dialog'
+import { TaskDescriptionEditor } from './task-description-editor'
 import { cn } from '@/lib/utils'
 import { getDefaultTodoStatus } from '@/lib/task-utils'
 import { createDefaultTask, type Task, type Priority, type RepeatConfig } from '@/data/task-model'
@@ -104,8 +105,8 @@ function AddTaskModalSession({
     }
   }
 
-  const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
-    setFormData((prev) => ({ ...prev, description: e.target.value }))
+  const handleDescriptionChange = (markdown: string): void => {
+    setFormData((prev) => ({ ...prev, description: markdown }))
   }
 
   const handleProjectChange = (projectId: string): void => {
@@ -235,22 +236,16 @@ function AddTaskModalSession({
           </div>
 
           <div className="flex flex-col gap-2">
-            <label
-              htmlFor="task-description"
-              className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
-            >
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               {t('task.description')}
-            </label>
-            <textarea
-              id="task-description"
-              value={formData.description}
-              onChange={handleDescriptionChange}
+            </span>
+            <TaskDescriptionEditor
+              initialContent={formData.description}
+              onContentChange={handleDescriptionChange}
               placeholder={t('task.descriptionPlaceholder')}
-              rows={3}
+              ariaLabel={t('task.description')}
               className={cn(
-                'flex min-h-[80px] w-full rounded-sm border border-input bg-transparent px-3 py-2 text-sm shadow-sm',
-                'placeholder:text-muted-foreground focus-visible:outline-none',
-                'disabled:cursor-not-allowed disabled:opacity-50 resize-none'
+                'min-h-[80px] w-full rounded-sm border border-input bg-transparent px-3 py-2 text-sm shadow-sm'
               )}
             />
           </div>

--- a/apps/desktop/src/renderer/src/components/tasks/task-description-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-description-editor.tsx
@@ -1,0 +1,129 @@
+/**
+ * TaskDescriptionEditor
+ * BlockNote-based rich text editor for a task's description.
+ * Reads/writes a plain markdown string (no Yjs, no IPC) so the existing
+ * `description` text column and field-level sync are unchanged.
+ * Modeled on InboxContentEditor; links open externally like the note editor.
+ */
+
+import { memo, useCallback, useEffect, useRef } from 'react'
+import { useCreateBlockNote } from '@blocknote/react'
+import { BlockNoteView } from '@blocknote/shadcn'
+import { useTheme } from 'next-themes'
+
+import '@blocknote/shadcn/style.css'
+
+import { cn } from '@/lib/utils'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('Component:TaskDescriptionEditor')
+
+interface TaskDescriptionEditorProps {
+  /** Initial content (markdown). Loaded once on mount — remount via `key` to swap tasks. */
+  initialContent: string | null
+  /** Called with the serialized markdown when content changes. */
+  onContentChange?: (markdown: string) => void
+  /** Whether the editor is editable. */
+  editable?: boolean
+  /** Placeholder shown in the empty editor. */
+  placeholder?: string
+  /** Optional className for the wrapper. */
+  className?: string
+  /** Optional aria-label for the editor region. */
+  ariaLabel?: string
+}
+
+export const TaskDescriptionEditor = memo(function TaskDescriptionEditor({
+  initialContent,
+  onContentChange,
+  editable = true,
+  placeholder = 'Add a description…',
+  className,
+  ariaLabel
+}: TaskDescriptionEditorProps) {
+  const { resolvedTheme } = useTheme()
+  const editorTheme = resolvedTheme === 'dark' ? 'dark' : 'light'
+
+  const initialContentLoadedRef = useRef(false)
+  const isContentReadyRef = useRef(false)
+
+  const editor = useCreateBlockNote({
+    placeholders: {
+      default: placeholder,
+      heading: 'Heading',
+      bulletListItem: 'List item',
+      numberedListItem: 'List item',
+      checkListItem: 'To-do item'
+    }
+  })
+
+  // Parse and load initial markdown once.
+  useEffect(() => {
+    if (initialContentLoadedRef.current) return
+    initialContentLoadedRef.current = true
+
+    async function loadContent() {
+      if (typeof initialContent !== 'string' || !initialContent.trim()) {
+        isContentReadyRef.current = true
+        return
+      }
+      try {
+        // BlockNote's parse helper resolves asynchronously at runtime despite
+        // its synchronous type, so await a wrapped Promise.
+        const blocks = await Promise.resolve(editor.tryParseMarkdownToBlocks(initialContent))
+        if (blocks.length > 0) {
+          editor.replaceBlocks(editor.document, blocks)
+        }
+      } catch (error) {
+        log.error('Failed to parse task description markdown', error)
+      } finally {
+        isContentReadyRef.current = true
+      }
+    }
+    void loadContent()
+  }, [editor, initialContent])
+
+  const handleChange = useCallback(async () => {
+    if (!isContentReadyRef.current || !onContentChange) return
+    try {
+      const markdown = await Promise.resolve(editor.blocksToMarkdownLossy(editor.document))
+      // Normalize an empty doc to '' so clearing the field matches the old textarea.
+      onContentChange(markdown.trim() ? markdown : '')
+    } catch (error) {
+      log.error('Failed to serialize task description', error)
+    }
+  }, [editor, onContentChange])
+
+  // Open link clicks externally, like the note editor (window.open is routed
+  // to the OS browser by the main-process openExternal allowlist).
+  const handleContainerClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const link = (e.target as HTMLElement).closest('a')
+    const href = link?.getAttribute('href')
+    if (href && !href.startsWith('#')) {
+      e.preventDefault()
+      window.open(href, '_blank', 'noopener,noreferrer')
+    }
+  }, [])
+
+  return (
+    <section
+      className={cn(
+        'task-description-editor prose prose-sm dark:prose-invert max-w-none',
+        '[&_.bn-editor]:px-0 [&_.bn-editor]:py-0',
+        editable && 'cursor-text',
+        className
+      )}
+      aria-label={ariaLabel}
+      onClick={handleContainerClick}
+    >
+      <BlockNoteView
+        editor={editor}
+        editable={editable}
+        onChange={() => void handleChange()}
+        theme={editorTheme}
+      />
+    </section>
+  )
+})
+
+export default TaskDescriptionEditor

--- a/apps/desktop/src/renderer/src/components/tasks/task-description-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-description-editor.tsx
@@ -107,12 +107,7 @@ export const TaskDescriptionEditor = memo(function TaskDescriptionEditor({
 
   return (
     <section
-      className={cn(
-        'task-description-editor prose prose-sm dark:prose-invert max-w-none',
-        '[&_.bn-editor]:px-0 [&_.bn-editor]:py-0',
-        editable && 'cursor-text',
-        className
-      )}
+      className={cn('task-description-editor relative', editable && 'cursor-text', className)}
       aria-label={ariaLabel}
       onClick={handleContainerClick}
     >

--- a/apps/desktop/src/renderer/src/components/tasks/task-description-preview.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-description-preview.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TaskDescriptionPreview } from './task-description-preview'
+
+describe('TaskDescriptionPreview', () => {
+  it('renders plain text as-is', () => {
+    render(<TaskDescriptionPreview markdown="Just some plain text" />)
+    expect(screen.getByText('Just some plain text')).toBeInTheDocument()
+  })
+
+  it('renders bold markdown as a <strong> element, not raw asterisks', () => {
+    const { container } = render(<TaskDescriptionPreview markdown="an **important** note" />)
+    const strong = container.querySelector('strong')
+    expect(strong).not.toBeNull()
+    expect(strong?.textContent).toBe('important')
+    expect(container.textContent).not.toContain('**')
+  })
+
+  it('renders a markdown link as a clickable anchor and opens it externally', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+    render(<TaskDescriptionPreview markdown="see [the docs](https://memry.app)" />)
+
+    const link = screen.getByRole('link', { name: 'the docs' })
+    expect(link).toHaveAttribute('href', 'https://memry.app')
+
+    await userEvent.click(link)
+    expect(openSpy).toHaveBeenCalledWith('https://memry.app', '_blank', 'noopener,noreferrer')
+    openSpy.mockRestore()
+  })
+
+  it('flattens list markers into bulleted text lines', () => {
+    const { container } = render(<TaskDescriptionPreview markdown={'- first\n- second'} />)
+    expect(container.textContent).toContain('first')
+    expect(container.textContent).toContain('second')
+    expect(container.textContent).toContain('•')
+  })
+
+  it('applies the passed className and testid', () => {
+    render(
+      <TaskDescriptionPreview markdown="text" className="line-clamp-3" data-testid="description" />
+    )
+    expect(screen.getByTestId('description')).toHaveClass('line-clamp-3')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tasks/task-description-preview.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-description-preview.tsx
@@ -1,0 +1,154 @@
+/**
+ * TaskDescriptionPreview
+ * Read-only, formatted render of a task's markdown description for preview
+ * surfaces (e.g. the calendar task popover). Safe by construction: it walks
+ * marked's token stream and builds React elements — no HTML injection.
+ * Supports inline bold/italic/code/strikethrough and clickable links; block
+ * markers (headings, list bullets, quotes) are flattened to clean text lines.
+ */
+
+import type { ReactNode } from 'react'
+import { marked, type Token, type Tokens } from 'marked'
+
+import { cn } from '@/lib/utils'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('Component:TaskDescriptionPreview')
+
+function openLink(e: React.MouseEvent, href: string): void {
+  e.preventDefault()
+  e.stopPropagation()
+  window.open(href, '_blank', 'noopener,noreferrer')
+}
+
+function renderInline(tokens: Token[] | undefined, keyPrefix: string): ReactNode[] {
+  if (!tokens) return []
+  return tokens.map((token, i) => {
+    const key = `${keyPrefix}-${i}`
+    switch (token.type) {
+      case 'strong':
+        return <strong key={key}>{renderInline((token as Tokens.Strong).tokens, key)}</strong>
+      case 'em':
+        return <em key={key}>{renderInline((token as Tokens.Em).tokens, key)}</em>
+      case 'del':
+        return <del key={key}>{renderInline((token as Tokens.Del).tokens, key)}</del>
+      case 'codespan':
+        return (
+          <code key={key} className="rounded bg-muted px-1 py-0.5 text-[0.9em]">
+            {(token as Tokens.Codespan).text}
+          </code>
+        )
+      case 'br':
+        return <br key={key} />
+      case 'link': {
+        const link = token as Tokens.Link
+        return (
+          <a
+            key={key}
+            href={link.href}
+            onClick={(e) => openLink(e, link.href)}
+            className="text-primary underline underline-offset-2 hover:opacity-80"
+          >
+            {renderInline(link.tokens, key)}
+          </a>
+        )
+      }
+      case 'text': {
+        const t = token as Tokens.Text
+        return t.tokens && t.tokens.length > 0 ? (
+          <span key={key}>{renderInline(t.tokens, key)}</span>
+        ) : (
+          t.text
+        )
+      }
+      case 'escape':
+        return (token as Tokens.Escape).text
+      default:
+        return 'raw' in token ? token.raw : ''
+    }
+  })
+}
+
+function renderBlocks(tokens: Token[], keyPrefix: string): ReactNode[] {
+  const out: ReactNode[] = []
+  tokens.forEach((token, i) => {
+    const key = `${keyPrefix}-${i}`
+    switch (token.type) {
+      case 'heading':
+      case 'paragraph':
+        out.push(<span key={key}>{renderInline((token as Tokens.Paragraph).tokens, key)}</span>)
+        break
+      case 'text': {
+        const t = token as Tokens.Text
+        out.push(
+          <span key={key}>
+            {t.tokens && t.tokens.length > 0 ? renderInline(t.tokens, key) : t.text}
+          </span>
+        )
+        break
+      }
+      case 'blockquote':
+        out.push(...renderBlocks((token as Tokens.Blockquote).tokens, key))
+        break
+      case 'list':
+        ;(token as Tokens.List).items.forEach((item, j) => {
+          const itemKey = `${key}-${j}`
+          out.push(
+            <span key={itemKey}>
+              {'• '}
+              {renderInline(item.tokens, itemKey)}
+            </span>
+          )
+        })
+        break
+      case 'code':
+        out.push(
+          <code key={key} className="rounded bg-muted px-1 py-0.5 text-[0.9em]">
+            {(token as Tokens.Code).text}
+          </code>
+        )
+        break
+      case 'space':
+      case 'hr':
+        break
+      default:
+        if ('raw' in token && token.raw.trim()) {
+          out.push(<span key={key}>{token.raw}</span>)
+        }
+    }
+  })
+  return out
+}
+
+/** Render a markdown string as safe, formatted, inline-flow React nodes. */
+export function renderTaskDescriptionMarkdown(markdown: string): ReactNode[] {
+  try {
+    const tokens = marked.lexer(markdown)
+    const nodes = renderBlocks(tokens, 'md')
+    // Interleave a space between blocks so flattened lines don't run together.
+    return nodes.flatMap((node, i) => (i === 0 ? [node] : [' ', node]))
+  } catch (error) {
+    log.error('Failed to render task description markdown', error)
+    return [markdown]
+  }
+}
+
+interface TaskDescriptionPreviewProps {
+  markdown: string
+  className?: string
+  'data-testid'?: string
+}
+
+export function TaskDescriptionPreview({
+  markdown,
+  className,
+  'data-testid': testId
+}: TaskDescriptionPreviewProps): React.JSX.Element {
+  return (
+    <p data-testid={testId} className={cn('text-muted-foreground', className)}>
+      {renderTaskDescriptionMarkdown(markdown)}
+    </p>
+  )
+}
+
+export default TaskDescriptionPreview

--- a/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { I18nextProvider } from 'react-i18next'
 import type { i18n as I18nInstance } from 'i18next'
@@ -25,6 +25,25 @@ vi.mock('@/contexts/day-panel-context', () => ({
 
 vi.mock('@/components/tasks/task-reminder-button', () => ({
   TaskReminderButton: () => null
+}))
+
+// BlockNote can't mount in jsdom; stub the description editor with a textarea.
+vi.mock('@/components/tasks/task-description-editor', () => ({
+  TaskDescriptionEditor: ({
+    initialContent,
+    onContentChange,
+    placeholder
+  }: {
+    initialContent: string | null
+    onContentChange?: (markdown: string) => void
+    placeholder?: string
+  }) => (
+    <textarea
+      placeholder={placeholder}
+      defaultValue={initialContent ?? ''}
+      onChange={(event) => onContentChange?.(event.target.value)}
+    />
+  )
 }))
 
 let i18nEn: I18nInstance
@@ -233,9 +252,12 @@ describe('TaskDetailDrawer — editable properties', () => {
       const textarea = screen.getByPlaceholderText('Add a description…')
       await user.type(textarea, 'H')
 
-      expect(onUpdateTask).toHaveBeenCalledWith(
-        'task-1',
-        expect.objectContaining({ description: expect.any(String) })
+      // Persistence is debounced, so wait for the update to flush.
+      await waitFor(() =>
+        expect(onUpdateTask).toHaveBeenCalledWith(
+          'task-1',
+          expect.objectContaining({ description: expect.any(String) })
+        )
       )
     })
   })

--- a/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-detail-drawer.tsx
@@ -12,6 +12,7 @@ import { InteractiveStatusBadge } from '@/components/tasks/interactive-status-ba
 import { InteractivePriorityBadge } from '@/components/tasks/interactive-priority-badge'
 import { InteractiveDueDateBadge } from '@/components/tasks/interactive-due-date-badge'
 import { InteractiveProjectBadge } from '@/components/tasks/interactive-project-badge'
+import { TaskDescriptionEditor } from '@/components/tasks/task-description-editor'
 import { TaskReminderButton } from '@/components/tasks/task-reminder-button'
 import { StatusIcon } from '@/components/tasks/status-icon'
 import { FileAudio, FileImage, FilePdf, FileVideo, X, Plus, Trash } from '@/lib/icons'
@@ -269,6 +270,34 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
     [task, onUpdateTask]
   )
 
+  // Description is a BlockNote markdown editor; debounce persistence so we don't
+  // write to the DB (and bump the sync field clock) on every keystroke.
+  const pendingDescriptionRef = useRef<string | null>(null)
+  const descriptionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const flushDescription = useCallback(() => {
+    if (descriptionTimerRef.current) {
+      clearTimeout(descriptionTimerRef.current)
+      descriptionTimerRef.current = null
+    }
+    if (pendingDescriptionRef.current !== null && task) {
+      onUpdateTask?.(task.id, { description: pendingDescriptionRef.current })
+      pendingDescriptionRef.current = null
+    }
+  }, [task, onUpdateTask])
+
+  const handleDescriptionChange = useCallback(
+    (markdown: string) => {
+      pendingDescriptionRef.current = markdown
+      if (descriptionTimerRef.current) clearTimeout(descriptionTimerRef.current)
+      descriptionTimerRef.current = setTimeout(flushDescription, 500)
+    },
+    [flushDescription]
+  )
+
+  // Flush any pending description edit when the task changes or the drawer unmounts.
+  useEffect(() => flushDescription, [flushDescription])
+
   const handleRepeatChange = useCallback(
     (repeatConfig: RepeatConfig | null) => {
       if (!task) return
@@ -381,13 +410,13 @@ export const TaskDetailDrawer = memo(function TaskDetailDrawer({
             {/* ── Description ── */}
             <div className="flex flex-col py-4 px-5 gap-2 border-b border-border">
               <SectionLabel>{t('task.description')}</SectionLabel>
-              <textarea
-                value={task.description ?? ''}
-                onChange={(e) => onUpdateTask?.(task.id, { description: e.target.value })}
+              <TaskDescriptionEditor
+                key={task.id}
+                initialContent={task.description ?? ''}
+                onContentChange={handleDescriptionChange}
                 placeholder={t('task.descriptionPlaceholder')}
-                rows={3}
-                className="text-[13px] leading-5 text-text-secondary bg-transparent outline-none resize-none placeholder:text-text-tertiary"
-                aria-label={t('task.description')}
+                ariaLabel={t('task.description')}
+                className="text-[13px] leading-5 text-text-secondary"
               />
             </div>
 

--- a/apps/desktop/src/renderer/src/features/tasks/use-task-queries.test.tsx
+++ b/apps/desktop/src/renderer/src/features/tasks/use-task-queries.test.tsx
@@ -415,4 +415,84 @@ describe('useTaskWorkspaceMutations', () => {
     expect(mocks.log.error).toHaveBeenCalledWith('Failed to create task:', expect.any(Error))
     expect(mocks.log.error).toHaveBeenCalledWith('Failed to create project:', expect.any(Error))
   })
+
+  // Regression: editing a task's description (or any field that does not carry a
+  // dueDate) must NOT clear the due date. The renderer payload builder used to
+  // emit `dueDate: null` whenever the update lacked a dueDate, silently wiping it.
+  describe('updateTask preserves dueDate on partial updates', () => {
+    function lastUpdatePayload() {
+      const calls = vi.mocked(tasksService.update).mock.calls
+      return calls[calls.length - 1][0] as Record<string, unknown>
+    }
+
+    function renderMutations() {
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      queryClient.setQueryData(taskKeys.tasks(), [])
+      return renderHook(() => useTaskWorkspaceMutations(), {
+        wrapper: createWrapper(queryClient)
+      })
+    }
+
+    it('omits dueDate (does not null it) when updating only the description', async () => {
+      const { result } = renderMutations()
+
+      await act(async () => {
+        await result.current.updateTask('task-1', { description: 'a new description' })
+      })
+
+      const payload = lastUpdatePayload()
+      expect(payload).toMatchObject({ id: 'task-1', description: 'a new description' })
+      // undefined = Drizzle skips the column = existing due date preserved.
+      expect(payload.dueDate).toBeUndefined()
+    })
+
+    it('still clears dueDate when the update explicitly sets it to null', async () => {
+      const { result } = renderMutations()
+
+      await act(async () => {
+        await result.current.updateTask('task-1', { dueDate: null })
+      })
+
+      expect(lastUpdatePayload().dueDate).toBeNull()
+    })
+
+    it('formats and sends dueDate when the update provides a date', async () => {
+      const { result } = renderMutations()
+
+      await act(async () => {
+        await result.current.updateTask('task-1', {
+          dueDate: new Date('2026-05-10T12:00:00.000Z')
+        })
+      })
+
+      expect(lastUpdatePayload().dueDate).toBe('2026-05-10')
+    })
+
+    it('preserves dueDate when completing a task with other field edits', async () => {
+      const { result } = renderMutations()
+
+      await act(async () => {
+        await result.current.updateTask('task-1', {
+          completedAt: new Date('2026-05-11T00:00:00.000Z'),
+          description: 'done note'
+        })
+      })
+
+      // The "other updates" branch must also omit dueDate.
+      expect(lastUpdatePayload().dueDate).toBeUndefined()
+    })
+
+    it('preserves dueDate when archiving a task with other field edits', async () => {
+      const { result } = renderMutations()
+
+      await act(async () => {
+        await result.current.updateTask('task-1', {
+          archivedAt: new Date('2026-05-12T00:00:00.000Z'),
+          description: 'archive note'
+        })
+      })
+
+      expect(lastUpdatePayload().dueDate).toBeUndefined()
+    })
+  })
 })

--- a/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
+++ b/apps/desktop/src/renderer/src/features/tasks/use-task-queries.ts
@@ -357,7 +357,12 @@ export function useTaskWorkspaceMutations() {
               projectId: otherUpdates.projectId,
               statusId: otherUpdates.statusId ?? undefined,
               parentId: otherUpdates.parentId ?? undefined,
-              dueDate: otherUpdates.dueDate ? formatDateKey(otherUpdates.dueDate) : null,
+              dueDate:
+                'dueDate' in otherUpdates
+                  ? otherUpdates.dueDate
+                    ? formatDateKey(otherUpdates.dueDate)
+                    : null
+                  : undefined,
               dueTime: otherUpdates.dueTime ?? undefined,
               isRepeating: otherUpdates.isRepeating,
               repeatConfig: toServiceRepeatConfig(otherUpdates.repeatConfig),
@@ -391,7 +396,12 @@ export function useTaskWorkspaceMutations() {
               projectId: otherUpdates.projectId,
               statusId: otherUpdates.statusId ?? undefined,
               parentId: otherUpdates.parentId ?? undefined,
-              dueDate: otherUpdates.dueDate ? formatDateKey(otherUpdates.dueDate) : null,
+              dueDate:
+                'dueDate' in otherUpdates
+                  ? otherUpdates.dueDate
+                    ? formatDateKey(otherUpdates.dueDate)
+                    : null
+                  : undefined,
               dueTime: otherUpdates.dueTime ?? undefined,
               isRepeating: otherUpdates.isRepeating,
               repeatConfig: toServiceRepeatConfig(otherUpdates.repeatConfig),
@@ -412,7 +422,12 @@ export function useTaskWorkspaceMutations() {
           projectId: updates.projectId,
           statusId: updates.statusId ?? undefined,
           parentId: updates.parentId ?? undefined,
-          dueDate: updates.dueDate ? formatDateKey(updates.dueDate) : null,
+          dueDate:
+            'dueDate' in updates
+              ? updates.dueDate
+                ? formatDateKey(updates.dueDate)
+                : null
+              : undefined,
           dueTime: updates.dueTime ?? undefined,
           isRepeating: updates.isRepeating,
           repeatConfig: toServiceRepeatConfig(updates.repeatConfig),

--- a/apps/desktop/src/renderer/src/pages/tasks.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/tasks.test.tsx
@@ -111,6 +111,25 @@ vi.mock('sonner', () => ({
   }
 }))
 
+// BlockNote can't mount in jsdom; stub the task description editor.
+vi.mock('@/components/tasks/task-description-editor', () => ({
+  TaskDescriptionEditor: ({
+    initialContent,
+    onContentChange,
+    placeholder
+  }: {
+    initialContent: string | null
+    onContentChange?: (markdown: string) => void
+    placeholder?: string
+  }) => (
+    <textarea
+      placeholder={placeholder}
+      defaultValue={initialContent ?? ''}
+      onChange={(event) => onContentChange?.(event.target.value)}
+    />
+  )
+}))
+
 vi.mock('@/lib/logger', () => ({
   createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() })
 }))

--- a/apps/docs/src/user-guide/tasks/capturing.md
+++ b/apps/docs/src/user-guide/tasks/capturing.md
@@ -59,6 +59,10 @@ Subtasks inherit nothing automatically — give them their own due dates and pri
 
 Selecting a checklist item in a note offers a "Convert to task" action in the inline menu. The task is created with the note as a back-reference.
 
+## Rich Descriptions
+
+A task's description is a rich text editor, the same style as notes. In the task detail drawer (and the add-task dialog) you can use headings, lists, checkboxes, and inline formatting, and paste links that stay clickable. Type `/` for the block menu. Descriptions are stored as Markdown, so plain-text descriptions from earlier versions keep working unchanged.
+
 ## See Also
 
 - [List vs Kanban](/user-guide/tasks/list-vs-kanban) — view options


### PR DESCRIPTION
## What
- Fix: editing a task's description no longer clears its due date (renderer update payload emitted `dueDate: null` on any update lacking a dueDate).
- Feat: task description is now a BlockNote Markdown editor (detail drawer + add-task dialog) with headings, lists, checkboxes, and clickable links.
- Read-only description previews (calendar task popover) render Markdown safely.

## Why
Data-loss bug (due dates silently wiped, and the clear propagated over sync); descriptions were a plain textarea. Stored as a Markdown string in the existing column — no schema/sync/migration change.