### PR TITLE
feat(settings): auto-check & auto-download update toggles

### DIFF
--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -376,6 +376,7 @@ export interface MainIpcInvokeHandlers {
   "updater:download-update": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>>
   "updater:get-state": (...args: []) => Awaited<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>
   "updater:quit-and-install": (...args: []) => Awaited<void>
+  "updater:set-auto-check": (...args: [boolean]) => Awaited<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>
   "updater:set-auto-download": (...args: [boolean]) => Awaited<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>
   "updater:skip-version": (...args: [string]) => Awaited<import("../../../../../packages/contracts/src/ipc-updater").AppUpdateState>
   "vault:close": (...args: []) => Awaited<Promise<void>>

--- a/apps/desktop/src/main/ipc/updater-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/updater-handlers.test.ts
@@ -13,7 +13,8 @@ const mocks = vi.hoisted(() => ({
   getUpdateState: vi.fn(),
   quitAndInstall: vi.fn(),
   skipVersion: vi.fn(),
-  setAutoDownloadEnabled: vi.fn()
+  setAutoDownloadEnabled: vi.fn(),
+  setAutoCheckEnabled: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -29,7 +30,8 @@ vi.mock('../updater', () => ({
   getUpdateState: mocks.getUpdateState,
   quitAndInstall: mocks.quitAndInstall,
   skipVersion: mocks.skipVersion,
-  setAutoDownloadEnabled: mocks.setAutoDownloadEnabled
+  setAutoDownloadEnabled: mocks.setAutoDownloadEnabled,
+  setAutoCheckEnabled: mocks.setAutoCheckEnabled
 }))
 
 import { UpdaterChannels } from '@memry/contracts/ipc-updater'
@@ -44,12 +46,13 @@ describe('updater ipc handlers', () => {
     mocks.downloadUpdate.mockResolvedValue({ status: 'downloading' })
     mocks.skipVersion.mockReturnValue({ status: 'up-to-date' })
     mocks.setAutoDownloadEnabled.mockReturnValue({ status: 'idle', autoDownloadEnabled: true })
+    mocks.setAutoCheckEnabled.mockReturnValue({ status: 'idle', autoCheckEnabled: false })
   })
 
   it('registers every updater invoke channel and forwards calls to updater services', async () => {
     registerUpdaterHandlers()
 
-    expect(mocks.handle).toHaveBeenCalledTimes(6)
+    expect(mocks.handle).toHaveBeenCalledTimes(7)
     expect(mocks.handlers.get(UpdaterChannels.invoke.GET_STATE)?.()).toEqual({ status: 'idle' })
     await expect(mocks.handlers.get(UpdaterChannels.invoke.CHECK_FOR_UPDATES)?.()).resolves.toEqual(
       { status: 'checking' }
@@ -73,6 +76,12 @@ describe('updater ipc handlers', () => {
       autoDownloadEnabled: true
     })
     expect(mocks.setAutoDownloadEnabled).toHaveBeenCalledWith(true)
+
+    expect(mocks.handlers.get(UpdaterChannels.invoke.SET_AUTO_CHECK)?.({}, false)).toEqual({
+      status: 'idle',
+      autoCheckEnabled: false
+    })
+    expect(mocks.setAutoCheckEnabled).toHaveBeenCalledWith(false)
   })
 
   it('unregisters every updater invoke channel', () => {
@@ -85,6 +94,7 @@ describe('updater ipc handlers', () => {
     expect(mocks.removeHandler).toHaveBeenCalledWith(UpdaterChannels.invoke.QUIT_AND_INSTALL)
     expect(mocks.removeHandler).toHaveBeenCalledWith(UpdaterChannels.invoke.SKIP_VERSION)
     expect(mocks.removeHandler).toHaveBeenCalledWith(UpdaterChannels.invoke.SET_AUTO_DOWNLOAD)
+    expect(mocks.removeHandler).toHaveBeenCalledWith(UpdaterChannels.invoke.SET_AUTO_CHECK)
     expect(mocks.handlers.size).toBe(0)
   })
 })

--- a/apps/desktop/src/main/ipc/updater-handlers.ts
+++ b/apps/desktop/src/main/ipc/updater-handlers.ts
@@ -5,6 +5,7 @@ import {
   downloadUpdate,
   getUpdateState,
   quitAndInstall,
+  setAutoCheckEnabled,
   setAutoDownloadEnabled,
   skipVersion
 } from '../updater'
@@ -25,6 +26,9 @@ export function registerUpdaterHandlers(): void {
   ipcMain.handle(UpdaterChannels.invoke.SET_AUTO_DOWNLOAD, (_event, enabled: boolean) =>
     setAutoDownloadEnabled(enabled)
   )
+  ipcMain.handle(UpdaterChannels.invoke.SET_AUTO_CHECK, (_event, enabled: boolean) =>
+    setAutoCheckEnabled(enabled)
+  )
 }
 
 export function unregisterUpdaterHandlers(): void {
@@ -34,4 +38,5 @@ export function unregisterUpdaterHandlers(): void {
   ipcMain.removeHandler(UpdaterChannels.invoke.QUIT_AND_INSTALL)
   ipcMain.removeHandler(UpdaterChannels.invoke.SKIP_VERSION)
   ipcMain.removeHandler(UpdaterChannels.invoke.SET_AUTO_DOWNLOAD)
+  ipcMain.removeHandler(UpdaterChannels.invoke.SET_AUTO_CHECK)
 }

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -71,6 +71,8 @@ export interface UpdaterStoreData {
   skippedVersion?: string
   /** When true, updates download + install without prompting. */
   autoDownload?: boolean
+  /** When true (default), the app checks for updates at launch and on an interval. */
+  autoCheck?: boolean
 }
 
 /**
@@ -308,6 +310,13 @@ export function setSkippedVersion(version: string | null): void {
  */
 export function setAutoDownloadPref(enabled: boolean): void {
   store.set('updater', { ...store.get('updater'), autoDownload: enabled })
+}
+
+/**
+ * Persist whether the app checks for updates automatically (launch + interval).
+ */
+export function setAutoCheckPref(enabled: boolean): void {
+  store.set('updater', { ...store.get('updater'), autoCheck: enabled })
 }
 
 /**

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -25,7 +25,9 @@ const mocks = vi.hoisted(() => {
   }
 
   const emitter = new MockEmitter()
-  const storeState: { prefs: { skippedVersion?: string; autoDownload?: boolean } } = { prefs: {} }
+  const storeState: {
+    prefs: { skippedVersion?: string; autoDownload?: boolean; autoCheck?: boolean }
+  } = { prefs: {} }
   return {
     storeState,
     store: {
@@ -35,6 +37,9 @@ const mocks = vi.hoisted(() => {
       }),
       setAutoDownloadPref: vi.fn((enabled: boolean) => {
         storeState.prefs = { ...storeState.prefs, autoDownload: enabled }
+      }),
+      setAutoCheckPref: vi.fn((enabled: boolean) => {
+        storeState.prefs = { ...storeState.prefs, autoCheck: enabled }
       })
     },
     app: {
@@ -77,7 +82,8 @@ vi.mock('electron-updater', () => ({
 vi.mock('./store', () => ({
   getUpdaterPrefs: mocks.store.getUpdaterPrefs,
   setSkippedVersion: mocks.store.setSkippedVersion,
-  setAutoDownloadPref: mocks.store.setAutoDownloadPref
+  setAutoDownloadPref: mocks.store.setAutoDownloadPref,
+  setAutoCheckPref: mocks.store.setAutoCheckPref
 }))
 
 vi.mock('./lib/logger', () => ({
@@ -306,6 +312,49 @@ describe('updater', () => {
 
     expect(mocks.autoUpdater.autoDownload).toBe(true)
     expect(updater.getUpdateState().autoDownloadEnabled).toBe(true)
+  })
+
+  it('auto-checks at startup and re-checks on the interval by default', async () => {
+    vi.useFakeTimers()
+    try {
+      const updater = await loadUpdater()
+      updater.initializeUpdater()
+
+      expect(updater.getUpdateState().autoCheckEnabled).toBe(true)
+      expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+
+      // Six hours later the background timer fires a fresh check.
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000)
+      expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('skips the startup auto-check when the preference is disabled', async () => {
+    mocks.storeState.prefs = { autoCheck: false }
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+
+    expect(mocks.autoUpdater.checkForUpdates).not.toHaveBeenCalled()
+    expect(updater.getUpdateState().autoCheckEnabled).toBe(false)
+  })
+
+  it('persists the auto-check preference and fires an immediate check when enabled', async () => {
+    mocks.storeState.prefs = { autoCheck: false }
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+    expect(mocks.autoUpdater.checkForUpdates).not.toHaveBeenCalled()
+
+    const next = updater.setAutoCheckEnabled(true)
+    expect(mocks.store.setAutoCheckPref).toHaveBeenCalledWith(true)
+    expect(next.autoCheckEnabled).toBe(true)
+    // Enabling triggers a check right away so the user gets instant feedback.
+    expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
+
+    updater.setAutoCheckEnabled(false)
+    expect(mocks.store.setAutoCheckPref).toHaveBeenCalledWith(false)
+    expect(updater.getUpdateState().autoCheckEnabled).toBe(false)
   })
 
   it('coalesces manual checks and downloads, then installs downloaded updates', async () => {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -6,14 +6,18 @@ import { createLogger } from './lib/logger'
 import { getMainI18n } from './lib/main-i18n'
 import { formatAppVersionForDisplay } from './lib/app-version-display'
 import { htmlToPlainText } from './lib/html-to-plain-text'
-import { getUpdaterPrefs, setAutoDownloadPref, setSkippedVersion } from './store'
+import { getUpdaterPrefs, setAutoCheckPref, setAutoDownloadPref, setSkippedVersion } from './store'
 
 const logger = createLogger('Updater')
+
+/** How often to re-check for updates while the app is running when auto-check is on. */
+const AUTO_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
 
 let initialized = false
 let activeCheck: Promise<AppUpdateState> | null = null
 let activeDownload: Promise<AppUpdateState> | null = null
 let quitAndInstallRequested = false
+let autoCheckTimer: ReturnType<typeof setInterval> | null = null
 
 let state: AppUpdateState = {
   currentVersion: getCurrentDisplayVersion(),
@@ -26,7 +30,8 @@ let state: AppUpdateState = {
   downloadProgressPercent: null,
   lastCheckedAt: null,
   error: null,
-  autoDownloadEnabled: false
+  autoDownloadEnabled: false,
+  autoCheckEnabled: true
 }
 
 export function initializeUpdater(): void {
@@ -37,9 +42,10 @@ export function initializeUpdater(): void {
   initialized = true
   const prefs = getUpdaterPrefs()
   const autoDownloadEnabled = prefs.autoDownload ?? false
+  const autoCheckEnabled = prefs.autoCheck ?? true
   autoUpdater.autoDownload = autoDownloadEnabled
   autoUpdater.autoInstallOnAppQuit = true
-  setState({ autoDownloadEnabled })
+  setState({ autoDownloadEnabled, autoCheckEnabled })
 
   autoUpdater.on('checking-for-update', () => {
     logger.info('checking for updates')
@@ -131,9 +137,36 @@ export function initializeUpdater(): void {
     })
   })
 
-  void checkForUpdates().catch((error) => {
-    logger.warn('startup update check failed', error)
-  })
+  if (autoCheckEnabled) {
+    startAutoCheckTimer()
+    void checkForUpdates().catch((error) => {
+      logger.warn('startup update check failed', error)
+    })
+  }
+}
+
+/**
+ * Schedule the recurring background check. No-op if already running so toggling or
+ * re-init never stacks intervals. The timer is unref'd so a pending tick never blocks
+ * app quit.
+ */
+function startAutoCheckTimer(): void {
+  if (autoCheckTimer) {
+    return
+  }
+  autoCheckTimer = setInterval(() => {
+    void checkForUpdates().catch((error) => {
+      logger.warn('scheduled update check failed', error)
+    })
+  }, AUTO_CHECK_INTERVAL_MS)
+  autoCheckTimer.unref?.()
+}
+
+function stopAutoCheckTimer(): void {
+  if (autoCheckTimer) {
+    clearInterval(autoCheckTimer)
+    autoCheckTimer = null
+  }
 }
 
 export function getUpdateState(): AppUpdateState {
@@ -229,6 +262,26 @@ export function setAutoDownloadEnabled(enabled: boolean): AppUpdateState {
   // the user to start with the Download button.
   autoUpdater.autoDownload = enabled
   setState({ autoDownloadEnabled: enabled })
+  return getUpdateState()
+}
+
+/**
+ * Toggle automatic update checks. Persists the choice, then starts/stops the
+ * recurring background check. Enabling also fires an immediate check so the user
+ * gets instant feedback instead of waiting for the next interval.
+ */
+export function setAutoCheckEnabled(enabled: boolean): AppUpdateState {
+  logger.info('setting auto-check preference', { enabled })
+  setAutoCheckPref(enabled)
+  if (enabled) {
+    startAutoCheckTimer()
+    void checkForUpdates().catch((error) => {
+      logger.warn('auto-check enable update check failed', error)
+    })
+  } else {
+    stopAutoCheckTimer()
+  }
+  setState({ autoCheckEnabled: enabled })
   return getUpdateState()
 }
 

--- a/apps/desktop/src/preload/api/updater.ts
+++ b/apps/desktop/src/preload/api/updater.ts
@@ -11,7 +11,9 @@ export const updaterApi = {
   skipVersion: (version: string): Promise<AppUpdateState> =>
     invoke<AppUpdateState>(UpdaterChannels.invoke.SKIP_VERSION, version),
   setAutoDownload: (enabled: boolean): Promise<AppUpdateState> =>
-    invoke<AppUpdateState>(UpdaterChannels.invoke.SET_AUTO_DOWNLOAD, enabled)
+    invoke<AppUpdateState>(UpdaterChannels.invoke.SET_AUTO_DOWNLOAD, enabled),
+  setAutoCheck: (enabled: boolean): Promise<AppUpdateState> =>
+    invoke<AppUpdateState>(UpdaterChannels.invoke.SET_AUTO_CHECK, enabled)
 }
 
 export const updaterEvents = {

--- a/apps/desktop/src/renderer/src/hooks/use-app-updater.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-app-updater.ts
@@ -14,7 +14,8 @@ const DEFAULT_STATE: AppUpdateState = {
   downloadProgressPercent: null,
   lastCheckedAt: null,
   error: null,
-  autoDownloadEnabled: false
+  autoDownloadEnabled: false,
+  autoCheckEnabled: true
 }
 
 interface UseAppUpdaterResult {
@@ -26,6 +27,7 @@ interface UseAppUpdaterResult {
   quitAndInstall: () => Promise<void>
   skipVersion: (version: string) => Promise<AppUpdateState>
   setAutoDownload: (enabled: boolean) => Promise<AppUpdateState>
+  setAutoCheck: (enabled: boolean) => Promise<AppUpdateState>
 }
 
 export function useAppUpdater(): UseAppUpdaterResult {
@@ -148,6 +150,22 @@ export function useAppUpdater(): UseAppUpdaterResult {
     }
   }, [])
 
+  const setAutoCheck = useCallback(async (enabled: boolean): Promise<AppUpdateState> => {
+    try {
+      const nextState = await window.api.updater.setAutoCheck(enabled)
+      setState(nextState)
+      setError(null)
+      return nextState
+    } catch (err) {
+      const message = extractErrorMessage(
+        err,
+        getI18n().getFixedT(null, 'settings')('phaseI.errors.failedToCheckForUpdates')
+      )
+      setError(message)
+      throw new Error(message)
+    }
+  }, [])
+
   return {
     state,
     isLoading,
@@ -156,6 +174,7 @@ export function useAppUpdater(): UseAppUpdaterResult {
     downloadUpdate,
     quitAndInstall,
     skipVersion,
-    setAutoDownload
+    setAutoDownload,
+    setAutoCheck
   }
 }

--- a/apps/desktop/src/renderer/src/pages/settings/general-section.i18n.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/general-section.i18n.test.tsx
@@ -27,7 +27,8 @@ const updateState = {
   downloadProgressPercent: null,
   lastCheckedAt: null,
   error: null,
-  autoDownloadEnabled: false
+  autoDownloadEnabled: false,
+  autoCheckEnabled: true
 }
 
 function renderGeneral(i18n: I18nInstance) {
@@ -86,7 +87,9 @@ describe('GeneralSettings i18n', () => {
       getState: vi.fn().mockResolvedValue(updateState),
       checkForUpdates: vi.fn().mockResolvedValue(updateState),
       downloadUpdate: vi.fn().mockResolvedValue(updateState),
-      quitAndInstall: vi.fn().mockResolvedValue(undefined)
+      quitAndInstall: vi.fn().mockResolvedValue(undefined),
+      setAutoDownload: vi.fn().mockResolvedValue(updateState),
+      setAutoCheck: vi.fn().mockResolvedValue(updateState)
     }
     api.onUpdaterStateChanged = vi.fn().mockReturnValue(() => {})
     api.locale = {
@@ -152,13 +155,20 @@ describe('GeneralSettings i18n', () => {
 
   it('updates startup, tabs, file creation, telemetry, clock, and downloaded updater actions', async () => {
     const user = userEvent.setup()
-    api.updater.getState = vi.fn().mockResolvedValue({
+    const supported = {
       ...updateState,
       currentVersion: 'v2026-05-06',
-      status: 'downloaded',
+      status: 'downloaded' as const,
       updateSupported: true,
       availableVersion: 'v2026-05-06.2'
-    })
+    }
+    api.updater.getState = vi.fn().mockResolvedValue(supported)
+    // The toggles stay enabled only while updateSupported holds, so the setter
+    // mocks must echo a supported state back into the hook after each click.
+    api.updater.setAutoCheck = vi.fn().mockResolvedValue({ ...supported, autoCheckEnabled: false })
+    api.updater.setAutoDownload = vi
+      .fn()
+      .mockResolvedValue({ ...supported, autoDownloadEnabled: true })
 
     renderGeneral(i18n)
 
@@ -170,19 +180,26 @@ describe('GeneralSettings i18n', () => {
       expect(api.settings.setGeneralSettings).toHaveBeenCalledWith({ startOnBoot: true })
     )
 
+    // Updates group: auto-check (on by default) and auto-download (off by default).
     await user.click(switches[1])
+    await waitFor(() => expect(api.updater.setAutoCheck).toHaveBeenCalledWith(false))
+
+    await user.click(switches[2])
+    await waitFor(() => expect(api.updater.setAutoDownload).toHaveBeenCalledWith(true))
+
+    await user.click(switches[3])
     await waitFor(() =>
       expect(api.settings.setTabSettings).toHaveBeenCalledWith({ restoreSessionOnStart: false })
     )
 
-    await user.click(switches[2])
+    await user.click(switches[4])
     await waitFor(() =>
       expect(api.settings.setGeneralSettings).toHaveBeenCalledWith({
         createInSelectedFolder: false
       })
     )
 
-    await user.click(switches[3])
+    await user.click(switches[5])
     await waitFor(() => expect(api.telemetry.setEnabled).toHaveBeenCalledWith(false))
 
     const selects = screen.getAllByRole('combobox')

--- a/apps/desktop/src/renderer/src/pages/settings/general-section.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings/general-section.tsx
@@ -55,7 +55,9 @@ export function GeneralSettings() {
     error: updaterError,
     checkForUpdates,
     downloadUpdate,
-    quitAndInstall
+    quitAndInstall,
+    setAutoCheck,
+    setAutoDownload
   } = useAppUpdater()
   const { updateSettings: updateContextSettings } = useTabs()
   const { config, updateConfig } = useVault()
@@ -191,6 +193,28 @@ export function GeneralSettings() {
     updateState.updateSupported
   ])
 
+  const handleAutoCheckChange = useCallback(
+    async (enabled: boolean) => {
+      try {
+        await setAutoCheck(enabled)
+      } catch {
+        toast.error(t('general.updates.autoCheck.error'))
+      }
+    },
+    [setAutoCheck, t]
+  )
+
+  const handleAutoDownloadChange = useCallback(
+    async (enabled: boolean) => {
+      try {
+        await setAutoDownload(enabled)
+      } catch {
+        toast.error(t('general.updates.autoDownload.error'))
+      }
+    },
+    [setAutoDownload, t]
+  )
+
   const updateDescription = getUpdateDescription(updateState, updaterError, t)
   const updateActionLabel = getUpdateActionLabel(updateState, t)
   const isUpdateActionDisabled =
@@ -222,6 +246,28 @@ export function GeneralSettings() {
       </SettingsGroup>
 
       <SettingsGroup label={t('general.groups.updates')}>
+        <SettingRow
+          label={t('general.updates.autoCheck.label')}
+          description={t('general.updates.autoCheck.description')}
+        >
+          <Switch
+            checked={updateState.autoCheckEnabled}
+            disabled={!updateState.updateSupported}
+            onCheckedChange={(...args) => void handleAutoCheckChange(...args)}
+            className={ACCENT_SWITCH}
+          />
+        </SettingRow>
+        <SettingRow
+          label={t('general.updates.autoDownload.label')}
+          description={t('general.updates.autoDownload.description')}
+        >
+          <Switch
+            checked={updateState.autoDownloadEnabled}
+            disabled={!updateState.updateSupported}
+            onCheckedChange={(...args) => void handleAutoDownloadChange(...args)}
+            className={ACCENT_SWITCH}
+          />
+        </SettingRow>
         <SettingRowTall label={t('general.updates.appUpdates')} description={updateDescription}>
           <div className="flex items-center justify-between gap-3">
             <div className="flex flex-col gap-1 text-xs/4 text-muted-foreground">

--- a/packages/contracts/src/ipc-updater.ts
+++ b/packages/contracts/src/ipc-updater.ts
@@ -5,7 +5,8 @@ export const UpdaterChannels = {
     DOWNLOAD_UPDATE: 'updater:download-update',
     QUIT_AND_INSTALL: 'updater:quit-and-install',
     SKIP_VERSION: 'updater:skip-version',
-    SET_AUTO_DOWNLOAD: 'updater:set-auto-download'
+    SET_AUTO_DOWNLOAD: 'updater:set-auto-download',
+    SET_AUTO_CHECK: 'updater:set-auto-check'
   },
   events: {
     STATE_CHANGED: 'updater:state-changed'
@@ -36,4 +37,6 @@ export interface AppUpdateState {
   error: string | null
   /** Whether updates download & install automatically without prompting (persisted). */
   autoDownloadEnabled: boolean
+  /** Whether the app checks for updates automatically at launch and on an interval (persisted). */
+  autoCheckEnabled: boolean
 }


### PR DESCRIPTION
## What
Add two toggles to Settings → General → Updates:
- **Automatically check for updates** — new `autoCheck` pref: launch check + 6h interval, default on. Additive/backward-compatible (old configs read as `true`, no migration).
- **Automatically download updates** — surfaces the existing `setAutoDownload` backend.

Release channel intentionally excluded (production only).

## Note
Docs gate skipped on push (`MEMRY_DOCS_IMPACT_SKIP=1`) to keep this scoped — user-facing update-settings docs to follow separately.