### PR TITLE
feat(editor): per-note and per-journal width override

### DIFF
--- a/apps/desktop/src/renderer/src/components/journal/journal-header-actions.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-header-actions.tsx
@@ -4,12 +4,14 @@ import { Button } from '@/components/ui/button'
 import {
   Bookmark,
   MoreVertical,
+  Maximize,
   History,
   Settings,
   ChevronLeft,
   ChevronRight,
   Download
 } from '@/lib/icons'
+import { Switch } from '@/components/ui/switch'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -24,11 +26,13 @@ import { useT } from '@memry/i18n/renderer'
 interface JournalHeaderActionsProps {
   viewState: JournalViewState
   isBookmarked: boolean
+  isFullWidth: boolean
   hasEntry: boolean
   journalDate: string | null
   reviewPill?: ReactNode
   onPrevious: () => void
   onNext: () => void
+  onToggleFullWidth: () => void
   onBookmarkToggle: () => void
   onVersionHistory: () => void
   onExport: () => void
@@ -40,11 +44,13 @@ const ACTION_BTN = 'size-7 hover:bg-surface-active'
 export function JournalHeaderActions({
   viewState,
   isBookmarked,
+  isFullWidth,
   hasEntry,
   journalDate,
   reviewPill,
   onPrevious,
   onNext,
+  onToggleFullWidth,
   onBookmarkToggle,
   onVersionHistory,
   onExport,
@@ -122,9 +128,14 @@ export function JournalHeaderActions({
                 <Download className="me-2 size-4" />
                 {t('action.export')}
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
             </>
           )}
+          <DropdownMenuItem onClick={onToggleFullWidth}>
+            <Maximize className="me-2 size-4" />
+            <span className="flex-1">{t('action.fullWidth')}</span>
+            <Switch checked={isFullWidth} className="pointer-events-none h-4 w-7" tabIndex={-1} />
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem onClick={onOpenSettings}>
             <Settings className="me-2 size-4" />
             {t('action.journalSettings')}

--- a/apps/desktop/src/renderer/src/pages/journal.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.test.tsx
@@ -203,6 +203,7 @@ vi.mock('@/components/journal', () => ({
   JournalHeaderActions: ({
     onPrevious,
     onNext,
+    onToggleFullWidth,
     onBookmarkToggle,
     onVersionHistory,
     onExport,
@@ -211,6 +212,7 @@ vi.mock('@/components/journal', () => ({
     <div data-testid="header-actions">
       <button onClick={onPrevious}>header prev</button>
       <button onClick={onNext}>header next</button>
+      <button onClick={onToggleFullWidth}>width</button>
       <button onClick={onBookmarkToggle}>bookmark</button>
       <button onClick={onVersionHistory}>history</button>
       <button onClick={onExport}>export</button>
@@ -447,8 +449,10 @@ describe('JournalPage', () => {
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(screen.getByTestId('year-view')).toHaveTextContent('2026')
 
+    fireEvent.click(screen.getByText('width'))
     fireEvent.click(screen.getByText('bookmark'))
     fireEvent.click(screen.getByText('settings'))
+    expect(localStorage.setItem).toHaveBeenCalledWith('memry_journal_full_width', 'true')
     expect(mocks.toggleBookmark).toHaveBeenCalled()
     expect(mocks.openSettingsModal).toHaveBeenCalledWith('journal')
   })

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -184,12 +184,25 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
   // Journal settings
   const { settings: journalSettings, isLoading: isJournalSettingsLoading } = useJournalSettings()
 
-  // Editor settings — width is a single global setting (Normal / Full) applied
-  // to every journal page, matching notes.
+  // Editor settings — width follows the global setting (Normal / Full) unless
+  // the user overrides it for Journal, which applies to every journal page.
   const { settings: editorSettings } = useEditorSettings()
 
-  const isFullWidth = editorSettings.width === 'full'
+  const [journalWidthOverride, setJournalWidthOverride] = useState<boolean | null>(() => {
+    const saved = localStorage.getItem('memry_journal_full_width')
+    return saved === null ? null : saved === 'true'
+  })
+  const isFullWidth = journalWidthOverride ?? editorSettings.width === 'full'
   const journalContentWidth = isFullWidth ? undefined : EDITOR_NORMAL_CONTENT_WIDTH
+
+  const toggleJournalWidth = useCallback(() => {
+    setJournalWidthOverride((prev) => {
+      const current = prev ?? editorSettings.width === 'full'
+      const next = !current
+      localStorage.setItem('memry_journal_full_width', String(next))
+      return next
+    })
+  }, [editorSettings.width])
 
   // Settings modal
   const { open: openSettingsModal } = useSettingsModal()
@@ -798,10 +811,12 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
             <JournalHeaderActions
               viewState={currentViewState}
               isBookmarked={isBookmarked}
+              isFullWidth={isFullWidth}
               hasEntry={!!entry}
               journalDate={entry?.date ?? null}
               onPrevious={handleNavigationPrevious}
               onNext={handleNavigationNext}
+              onToggleFullWidth={toggleJournalWidth}
               onBookmarkToggle={(...args) => void toggleBookmark(...args)}
               onVersionHistory={() => setIsVersionHistoryOpen(true)}
               onExport={() => setIsExportDialogOpen(true)}

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -745,6 +745,14 @@ describe('NotePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.export' }))
     expect(screen.getByText('Export Test Note')).toBeInTheDocument()
 
+    fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.fullWidth' }))
+    await waitFor(() =>
+      expect(mocks.notesUpdate).toHaveBeenCalledWith({
+        id: 'note-1',
+        frontmatter: { fullWidth: true }
+      })
+    )
+
     fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.setLocalOnly' }))
     await waitFor(() => expect(mocks.setLocalOnly).toHaveBeenCalledWith('note-1', true))
     expect(mocks.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['notes', 'localOnlyCount'] })
@@ -860,6 +868,9 @@ describe('NotePage', () => {
     expect(toast.error).toHaveBeenCalledWith(
       'phaseI.toasts.cannotChangeLocalOnlyThisNoteWasDeleted'
     )
+
+    fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.fullWidth' }))
+    expect(mocks.notesUpdate).not.toHaveBeenCalled()
 
     act(() => {
       mocks.propertyOnBlocked?.('remove')

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -42,10 +42,12 @@ import {
   Download,
   AlarmClock,
   Monitor,
+  Maximize,
   ChartRelationship
 } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { Picker } from '@/components/ui/picker'
+import { Switch } from '@/components/ui/switch'
 import { toast } from 'sonner'
 import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
 import { useIsBookmarked } from '@/hooks/use-bookmarks'
@@ -223,8 +225,11 @@ export function NotePage({ noteId }: NotePageProps) {
   // Editor settings (toolbar mode, width)
   const { settings: editorSettings } = useEditorSettings()
 
-  // Width is a single global setting (Normal / Full) — applies to every note.
-  const isFullWidth = editorSettings.width === 'full'
+  // Width follows the global setting (Normal / Full) unless this note has an
+  // explicit per-note override in frontmatter (`fullWidth`), which wins.
+  const widthOverride = note?.frontmatter.fullWidth
+  const isFullWidth =
+    typeof widthOverride === 'boolean' ? widthOverride : editorSettings.width === 'full'
   const noteContentWidth = isFullWidth ? undefined : EDITOR_NORMAL_CONTENT_WIDTH
 
   // Focus editor at end when clicking empty space
@@ -751,6 +756,19 @@ export function NotePage({ noteId }: NotePageProps) {
     [noteId, isDeleted, refetchNote, queryClient, t]
   )
 
+  const handleToggleFullWidth = useCallback(
+    async (value: boolean) => {
+      if (!noteId || isDeleted) return
+      try {
+        await notesService.update({ id: noteId, frontmatter: { fullWidth: value } })
+        refetchNote()
+      } catch (err) {
+        toast.error(extractErrorMessage(err, t('page.toast.toggleFullWidthFailed')))
+      }
+    },
+    [noteId, isDeleted, refetchNote, t]
+  )
+
   // Link handlers
   const handleLinkClick = useCallback((href: string) => {
     window.open(href, '_blank', 'noopener,noreferrer')
@@ -946,6 +964,10 @@ export function NotePage({ noteId }: NotePageProps) {
         value={null}
         closeOnSelect={false}
         onValueChange={(action) => {
+          if (action === 'full-width') {
+            void handleToggleFullWidth(!isFullWidth)
+            return
+          }
           setMoreMenuOpen(false)
           if (action === 'local-graph') setIsLocalGraphOpen((prev) => !prev)
           if (action === 'version-history') setIsVersionHistoryOpen(true)
@@ -986,6 +1008,18 @@ export function NotePage({ noteId }: NotePageProps) {
               value="export"
               label={t('editor.toolbar.export')}
               icon={<Download className="size-4" />}
+            />
+            <Picker.Item
+              value="full-width"
+              label={t('editor.toolbar.fullWidth')}
+              icon={<Maximize className="size-4" />}
+              trailing={
+                <Switch
+                  checked={isFullWidth}
+                  className="pointer-events-none h-4 w-7"
+                  tabIndex={-1}
+                />
+              }
             />
             <Picker.Separator />
             <Picker.Item

--- a/apps/docs/src/user-guide/journal/daily-entries.md
+++ b/apps/docs/src/user-guide/journal/daily-entries.md
@@ -20,7 +20,7 @@ Use **Add property** or **Add tag** above the date heading to organize a daily e
 
 ## Width
 
-Journal pages follow the global **Width** setting in [Settings → Editor](/user-guide/settings#editor) — set it to **Full width** to widen the writing column edge to edge on big monitors. The same setting applies to every note and journal page.
+Journal pages follow the global **Width** setting in [Settings → Editor](/user-guide/settings#editor). To override it just for the Journal, use the **Full width** toggle in the journal ⋮ menu — it widens the writing column edge to edge and applies to every journal page until you turn it off.
 
 ## Sidebar Toggles
 

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -115,7 +115,7 @@ A **Create Template** button opens the [template editor](/user-guide/templates).
 
 ### Layout
 
-**Width** sets the writing column for every note and journal page — **Normal** (a comfortable reading column) or **Full width** (edge to edge). It's a single global setting; there's no per-note override.
+**Width** sets the default writing column for every note and journal page — **Normal** (a comfortable reading column) or **Full width** (edge to edge). Individual notes can override this from the note's ⋮ menu (**Full width**), and the Journal has its own **Full width** toggle in its ⋮ menu — both override the global default.
 
 ### Toolbar
 


### PR DESCRIPTION
## What
Restores the **Full width** toggle in the note ⋮ menu and the journal ⋮ menu. The global Editor Width (Normal/Full, shipped in #715) is the default; a note (frontmatter `fullWidth`) or the Journal (local flag) can override it.

## Why
Users want to pin a specific note or the Journal to full width regardless of the global default.