### PR TITLE
fix(desktop): restore main window size/position across close→reopen

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -27,6 +27,15 @@ const editableContextMenuPopupMock = vi.fn()
 const buildEditableTextContextMenuMock = vi.fn(() => ({ popup: editableContextMenuPopupMock }))
 const getCurrentVaultPathMock = vi.fn(() => null as string | null)
 const getStoredLocaleMock = vi.fn(() => null as string | null)
+type StoredWindowBoundsShape = {
+  width: number
+  height: number
+  x?: number
+  y?: number
+  isMaximized?: boolean
+}
+const getWindowBoundsMock = vi.fn((): StoredWindowBoundsShape | null => null)
+const setWindowBoundsMock = vi.fn()
 const getVaultStatusMock = vi.fn(() => ({ path: null as string | null }))
 const readPreferencesMock = vi.fn(() => ({ language: 'en' }))
 const initializeTelemetryRuntimeMock = vi.fn()
@@ -112,6 +121,8 @@ function createBrowserWindowMock() {
     isMaximized: vi.fn(() => false),
     getSize: vi.fn(() => [480, 82] as [number, number]),
     setSize: vi.fn(),
+    getBounds: vi.fn(() => ({ x: 0, y: 0, width: 480, height: 82 })),
+    getNormalBounds: vi.fn(() => ({ x: 0, y: 0, width: 480, height: 82 })),
     emitTestEvent: (event: string, ...args: unknown[]) => eventHandlers.get(event)?.(...args)
   }
   browserWindows.push(window)
@@ -150,7 +161,9 @@ vi.mock('./vault', () => ({
 
 vi.mock('./store', () => ({
   getCurrentVaultPath: getCurrentVaultPathMock,
-  getStoredLocale: getStoredLocaleMock
+  getStoredLocale: getStoredLocaleMock,
+  getWindowBounds: getWindowBoundsMock,
+  setWindowBounds: setWindowBoundsMock
 }))
 
 vi.mock('./vault/vault-preferences', () => ({
@@ -330,7 +343,8 @@ vi.mock('electron', () => ({
     readText: vi.fn(() => '')
   },
   screen: {
-    getPrimaryDisplay: vi.fn(() => ({ workAreaSize: { width: 1440, height: 900 } }))
+    getPrimaryDisplay: vi.fn(() => ({ workAreaSize: { width: 1440, height: 900 } })),
+    getAllDisplays: vi.fn(() => [{ workArea: { x: 0, y: 0, width: 1440, height: 900 } }])
   },
   session: {
     defaultSession: {
@@ -386,6 +400,7 @@ describe('main index phase2 exports', () => {
     applyGlobalCaptureShortcutMock.mockReturnValue({ registered: true })
     getCurrentVaultPathMock.mockReturnValue(null)
     getStoredLocaleMock.mockReturnValue(null)
+    getWindowBoundsMock.mockReturnValue(null)
     getVaultStatusMock.mockReturnValue({ path: null })
     readPreferencesMock.mockReturnValue({ language: 'en' })
     isPinningDisabledMock.mockReturnValue(true)
@@ -585,6 +600,66 @@ describe('main index phase2 exports', () => {
         height: 900,
         show: false
       })
+    )
+  })
+
+  it('restores the saved window size and position when a vault is open', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+    getCurrentVaultPathMock.mockReturnValue('/vault')
+    getWindowBoundsMock.mockReturnValue({
+      width: 1280,
+      height: 820,
+      x: 120,
+      y: 90,
+      isMaximized: false
+    })
+
+    await importMainModule()
+    await flushReadyWork()
+
+    expect(BrowserWindowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ width: 1280, height: 820, x: 120, y: 90, show: false })
+    )
+    expect(browserWindows[0].maximize).not.toHaveBeenCalled()
+  })
+
+  it('re-maximizes on launch when the window was left maximized', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+    getCurrentVaultPathMock.mockReturnValue('/vault')
+    getWindowBoundsMock.mockReturnValue({
+      width: 1280,
+      height: 820,
+      x: 120,
+      y: 90,
+      isMaximized: true
+    })
+
+    await importMainModule()
+    await flushReadyWork()
+
+    expect(browserWindows[0].maximize).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores saved bounds on dock reopen even when dev forces the vault picker', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+    // MEMRY_FORCE_VAULT_PICKER shrinks the *initial* size in dev, but on a dock
+    // reopen the vault is genuinely open — the saved geometry must still win.
+    process.env.MEMRY_FORCE_VAULT_PICKER = '1'
+    getCurrentVaultPathMock.mockReturnValue('/vault')
+    getVaultStatusMock.mockReturnValue({ isOpen: true, path: '/vault' } as never)
+    getWindowBoundsMock.mockReturnValue({
+      width: 1327,
+      height: 750,
+      x: 120,
+      y: 90,
+      isMaximized: false
+    })
+
+    await importMainModule()
+    await flushReadyWork()
+
+    expect(BrowserWindowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ width: 1327, height: 750, x: 120, y: 90, show: false })
     )
   })
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -33,7 +33,8 @@ import {
   onVaultStatusChanged
 } from './vault'
 import { readPreferences } from './vault/vault-preferences'
-import { getCurrentVaultPath, getStoredLocale } from './store'
+import { getCurrentVaultPath, getStoredLocale, getWindowBounds, setWindowBounds } from './store'
+import { resolveStartupBounds } from './window-bounds'
 import { startSnoozeScheduler, stopSnoozeScheduler, checkDueItemsOnStartup } from './inbox/snooze'
 import { stopVoiceModel } from './inbox/voice-model'
 import { stopImageProcessing } from './image-processing/bridge'
@@ -409,7 +410,7 @@ function getInitialMainWindowSize():
 
 function resizeWindowIfNeeded(
   window: BrowserWindow,
-  size: typeof DEFAULT_MAIN_WINDOW_SIZE | typeof VAULT_PICKER_WINDOW_SIZE
+  size: { width: number; height: number }
 ): void {
   if (window.isDestroyed()) return
 
@@ -422,13 +423,56 @@ function resizeWindowIfNeeded(
   window.setSize(size.width, size.height)
 }
 
+let persistWindowBoundsTimer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * Save the main window's geometry so the next launch / dock reopen restores it.
+ * Guarded to the real app window — the compact vault picker is never remembered.
+ * When maximized we store the *normal* (un-maximized) bounds plus the flag, so a
+ * later restore can place the window correctly and then re-maximize.
+ */
+function persistWindowBounds(window: BrowserWindow): void {
+  if (window.isDestroyed() || !getCurrentVaultPath()) return
+  const isMaximized = window.isMaximized()
+  const { width, height, x, y } = isMaximized ? window.getNormalBounds() : window.getBounds()
+  setWindowBounds({ width, height, x, y, isMaximized })
+}
+
+/** Debounced persist for the noisy resize/move event streams. */
+function scheduleWindowBoundsPersist(window: BrowserWindow): void {
+  if (persistWindowBoundsTimer) clearTimeout(persistWindowBoundsTimer)
+  persistWindowBoundsTimer = setTimeout(() => {
+    persistWindowBoundsTimer = null
+    persistWindowBounds(window)
+  }, 400)
+}
+
 function createWindow(): void {
   const initialSize = getInitialMainWindowSize()
 
+  // Restore the user's last size/position only for the real app window (the vault
+  // picker keeps its fixed compact size). "Real app window" means a vault is
+  // already open — e.g. a macOS dock reopen — or one is about to auto-open at
+  // startup (initialSize === DEFAULT). We check the live vault status too because
+  // the dev-only MEMRY_FORCE_VAULT_PICKER flag shrinks initialSize to the picker,
+  // which would otherwise skip restore for the whole dev workflow.
+  const willShowVault = getVaultStatus().isOpen || initialSize === DEFAULT_MAIN_WINDOW_SIZE
+
+  const startupBounds = willShowVault
+    ? resolveStartupBounds(
+        getWindowBounds(),
+        screen.getAllDisplays().map((display) => ({ workArea: display.workArea })),
+        DEFAULT_MAIN_WINDOW_SIZE
+      )
+    : { width: initialSize.width, height: initialSize.height, maximize: false }
+
   // Create the browser window.
   const mainWindow = new BrowserWindow({
-    width: initialSize.width,
-    height: initialSize.height,
+    width: startupBounds.width,
+    height: startupBounds.height,
+    ...(startupBounds.x !== undefined && startupBounds.y !== undefined
+      ? { x: startupBounds.x, y: startupBounds.y }
+      : {}),
     show: false,
     autoHideMenuBar: true,
     icon: join(__dirname, '../../build/icon.png'),
@@ -447,13 +491,41 @@ function createWindow(): void {
       webSecurity: true
     }
   })
+  if (startupBounds.maximize) mainWindow.maximize()
   trackLaunchPhase('window_created', Date.now() - launchStartedAt)
 
+  // Remember geometry as the user resizes/moves/maximizes it, and on close.
+  mainWindow.on('resize', () => scheduleWindowBoundsPersist(mainWindow))
+  mainWindow.on('move', () => scheduleWindowBoundsPersist(mainWindow))
+  mainWindow.on('maximize', () => persistWindowBounds(mainWindow))
+  mainWindow.on('unmaximize', () => persistWindowBounds(mainWindow))
+  mainWindow.on('close', () => {
+    if (persistWindowBoundsTimer) {
+      clearTimeout(persistWindowBoundsTimer)
+      persistWindowBoundsTimer = null
+    }
+    persistWindowBounds(mainWindow)
+  })
+
   const unsubscribeVaultStatus = onVaultStatusChanged((status) => {
-    resizeWindowIfNeeded(
-      mainWindow,
-      status.isOpen ? DEFAULT_MAIN_WINDOW_SIZE : VAULT_PICKER_WINDOW_SIZE
-    )
+    if (mainWindow.isDestroyed()) return
+    if (status.isOpen) {
+      // Grow from the compact picker to the app window, but never fight a window
+      // the user has already sized/moved/maximized (or that we just restored):
+      // only act on the genuine picker → main transition.
+      if (mainWindow.isMaximized()) return
+      const [width, height] = mainWindow.getSize()
+      const atPickerSize =
+        width === VAULT_PICKER_WINDOW_SIZE.width && height === VAULT_PICKER_WINDOW_SIZE.height
+      if (!atPickerSize) return
+      const saved = getWindowBounds()
+      resizeWindowIfNeeded(mainWindow, {
+        width: saved?.width ?? DEFAULT_MAIN_WINDOW_SIZE.width,
+        height: saved?.height ?? DEFAULT_MAIN_WINDOW_SIZE.height
+      })
+    } else {
+      resizeWindowIfNeeded(mainWindow, VAULT_PICKER_WINDOW_SIZE)
+    }
   })
   mainWindow.on('closed', unsubscribeVaultStatus)
 

--- a/apps/desktop/src/main/store.test.ts
+++ b/apps/desktop/src/main/store.test.ts
@@ -19,7 +19,9 @@ import {
   getDefaultVaultPath,
   setDefaultVaultPath,
   getStoredLocale,
-  setStoredLocale
+  setStoredLocale,
+  getWindowBounds,
+  setWindowBounds
 } from './store'
 
 describe('store', () => {
@@ -41,6 +43,21 @@ describe('store', () => {
     expect(getCurrentVaultPath()).toBeNull()
     expect(getVaults()).toEqual([])
     expect(getStoredLocale()).toBeNull()
+    expect(getWindowBounds()).toBeNull()
+  })
+
+  it('persists window bounds across reads', () => {
+    const bounds = { width: 1400, height: 920, x: 40, y: 30, isMaximized: false }
+    setWindowBounds(bounds)
+
+    expect(getWindowBounds()).toEqual(bounds)
+
+    const configPath = path.join(tempDir, 'memry-config.json')
+    const stored = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+      windowBounds: typeof bounds
+      currentVault: string | null
+    }
+    expect(stored.windowBounds).toEqual(bounds)
   })
 
   it('persists current vault path', () => {

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -63,6 +63,18 @@ export interface AgentStoreData {
 }
 
 /**
+ * Last known main-window geometry, restored on the next launch / dock reopen so
+ * the window comes back at the size and position the user left it.
+ */
+export interface StoredWindowBounds {
+  width: number
+  height: number
+  x?: number
+  y?: number
+  isMaximized?: boolean
+}
+
+/**
  * Auto-updater preferences that must survive restarts and be readable by the
  * main process before any renderer loads (so the startup update check honors them).
  */
@@ -93,6 +105,8 @@ interface StoreSchema {
   captureAllowedOrigins: string[]
   /** Auto-updater preferences */
   updater: UpdaterStoreData
+  /** Last known main-window geometry (null until the window is first sized) */
+  windowBounds: StoredWindowBounds | null
 }
 
 const CONFIG_FILE = 'memry-config.json'
@@ -104,7 +118,8 @@ const defaultData: StoreSchema = {
   sync: {},
   agent: {},
   captureAllowedOrigins: [],
-  updater: {}
+  updater: {},
+  windowBounds: null
 }
 
 /** In-memory cache — populated on first read, updated on every write. */
@@ -167,6 +182,20 @@ export const store = {
     const data = { ...getCache(), [key]: value }
     writeConfig(data)
   }
+}
+
+/**
+ * Get the last persisted main-window geometry, or null if none saved yet.
+ */
+export function getWindowBounds(): StoredWindowBounds | null {
+  return store.get('windowBounds')
+}
+
+/**
+ * Persist the main-window geometry for restore on the next launch / dock reopen.
+ */
+export function setWindowBounds(bounds: StoredWindowBounds): void {
+  store.set('windowBounds', bounds)
 }
 
 /**

--- a/apps/desktop/src/main/window-bounds.test.ts
+++ b/apps/desktop/src/main/window-bounds.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { resolveStartupBounds, type DisplayLike, type SavedWindowBounds } from './window-bounds'
+
+const FALLBACK = { width: 1550, height: 900 }
+
+// A single 1440x900 display whose work area starts at the origin.
+const PRIMARY: DisplayLike = { workArea: { x: 0, y: 0, width: 1440, height: 900 } }
+
+describe('resolveStartupBounds', () => {
+  it('returns the fallback size, centered, when there are no saved bounds', () => {
+    const result = resolveStartupBounds(null, [PRIMARY], FALLBACK)
+    expect(result).toEqual({ width: 1550, height: 900, maximize: false })
+    expect(result.x).toBeUndefined()
+    expect(result.y).toBeUndefined()
+  })
+
+  it('restores saved size and position that sit on a display', () => {
+    const saved: SavedWindowBounds = { width: 1200, height: 800, x: 100, y: 60 }
+    expect(resolveStartupBounds(saved, [PRIMARY], FALLBACK)).toEqual({
+      width: 1200,
+      height: 800,
+      x: 100,
+      y: 60,
+      maximize: false
+    })
+  })
+
+  it('drops an off-screen position but keeps the saved size', () => {
+    // x=5000 is far past the only 1440-wide display → not visible.
+    const saved: SavedWindowBounds = { width: 1200, height: 800, x: 5000, y: 60 }
+    const result = resolveStartupBounds(saved, [PRIMARY], FALLBACK)
+    expect(result.width).toBe(1200)
+    expect(result.height).toBe(800)
+    expect(result.x).toBeUndefined()
+    expect(result.y).toBeUndefined()
+    expect(result.maximize).toBe(false)
+  })
+
+  it('passes through the maximized flag while keeping the normal bounds', () => {
+    const saved: SavedWindowBounds = { width: 1200, height: 800, x: 100, y: 60, isMaximized: true }
+    expect(resolveStartupBounds(saved, [PRIMARY], FALLBACK)).toEqual({
+      width: 1200,
+      height: 800,
+      x: 100,
+      y: 60,
+      maximize: true
+    })
+  })
+
+  it('keeps the size when a position was never saved', () => {
+    const saved: SavedWindowBounds = { width: 1300, height: 850 }
+    const result = resolveStartupBounds(saved, [PRIMARY], FALLBACK)
+    expect(result.width).toBe(1300)
+    expect(result.height).toBe(850)
+    expect(result.x).toBeUndefined()
+    expect(result.y).toBeUndefined()
+  })
+
+  it('accepts a position on a secondary display to the right of the primary', () => {
+    const secondary: DisplayLike = { workArea: { x: 1440, y: 0, width: 1920, height: 1080 } }
+    const saved: SavedWindowBounds = { width: 1000, height: 700, x: 1600, y: 120 }
+    expect(resolveStartupBounds(saved, [PRIMARY, secondary], FALLBACK)).toMatchObject({
+      x: 1600,
+      y: 120
+    })
+  })
+
+  it('drops an absurdly small saved size in favour of the fallback', () => {
+    const saved: SavedWindowBounds = { width: 20, height: 10, x: 100, y: 60 }
+    const result = resolveStartupBounds(saved, [PRIMARY], FALLBACK)
+    expect(result.width).toBe(FALLBACK.width)
+    expect(result.height).toBe(FALLBACK.height)
+  })
+})

--- a/apps/desktop/src/main/window-bounds.ts
+++ b/apps/desktop/src/main/window-bounds.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure helpers for restoring the main window to its last size/position.
+ *
+ * Kept free of Electron imports so the on-screen validation logic can be unit
+ * tested without a display server. `index.ts` feeds it `screen.getAllDisplays()`
+ * and the persisted bounds from the store.
+ */
+
+export interface SavedWindowBounds {
+  width: number
+  height: number
+  x?: number
+  y?: number
+  isMaximized?: boolean
+}
+
+/** Shape of the parts of an Electron `Display` we depend on. */
+export interface DisplayLike {
+  workArea: { x: number; y: number; width: number; height: number }
+}
+
+export interface ResolvedBounds {
+  width: number
+  height: number
+  x?: number
+  y?: number
+  maximize: boolean
+}
+
+// Sizes below this are almost certainly corrupt/stale and would produce an
+// unusable window, so we fall back to the default size instead.
+const MIN_WIDTH = 400
+const MIN_HEIGHT = 300
+
+// A saved position is only reused if at least this much of the window would land
+// on a connected display's work area — otherwise the window would open off-screen
+// (e.g. a monitor that has since been unplugged).
+const MIN_VISIBLE_X = 100
+const MIN_VISIBLE_Y = 50
+
+function isPositionVisible(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  displays: DisplayLike[]
+): boolean {
+  return displays.some(({ workArea }) => {
+    const overlapX = Math.min(x + width, workArea.x + workArea.width) - Math.max(x, workArea.x)
+    const overlapY = Math.min(y + height, workArea.y + workArea.height) - Math.max(y, workArea.y)
+    return overlapX >= MIN_VISIBLE_X && overlapY >= MIN_VISIBLE_Y
+  })
+}
+
+/**
+ * Decide how to open the main window given the previously saved bounds.
+ *
+ * - No (or corrupt) saved bounds → the fallback size, centered by the OS.
+ * - A saved position is only reused when it remains visible on some display.
+ * - The maximized flag is passed through; the returned size is the *normal*
+ *   (un-maximized) size so a later `unmaximize()` restores it correctly.
+ */
+export function resolveStartupBounds(
+  saved: SavedWindowBounds | null,
+  displays: DisplayLike[],
+  fallback: { width: number; height: number }
+): ResolvedBounds {
+  const hasValidSize = saved != null && saved.width >= MIN_WIDTH && saved.height >= MIN_HEIGHT
+  if (!hasValidSize) {
+    return { width: fallback.width, height: fallback.height, maximize: false }
+  }
+
+  const result: ResolvedBounds = {
+    width: saved.width,
+    height: saved.height,
+    maximize: saved.isMaximized === true
+  }
+
+  if (
+    saved.x !== undefined &&
+    saved.y !== undefined &&
+    isPositionVisible(saved.x, saved.y, saved.width, saved.height, displays)
+  ) {
+    result.x = saved.x
+    result.y = saved.y
+  }
+
+  return result
+}


### PR DESCRIPTION
## What
Persist the main window's size, position, and maximized state, and restore it on launch and macOS dock reopen — instead of always recreating the window at a fixed default size. Saved position is validated against connected displays (drops an off-screen monitor). Restore is gated on live vault status so it also works under the dev `MEMRY_FORCE_VAULT_PICKER` flag.

## Why
Closing the window (red button, not quit) and reopening from the dock lost the user's last window geometry, reopening small.