### PR TITLE
fix(folders): preserve folder view settings when sync or template writes .folder.md

### DIFF
--- a/apps/desktop/src/main/ipc/notes-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.test.ts
@@ -127,6 +127,7 @@ import * as notesVault from '../vault/notes'
 import * as notesDomain from '../notes/domain'
 import * as attachmentsVault from '../vault/attachments'
 import * as foldersVault from '../vault/folders'
+import * as folderConfigEffects from '../notes/folder-config-effects'
 import * as noteQueries from '@main/database/queries/notes'
 import * as positionQueries from '@main/database/queries/note-positions'
 import * as storageData from '@memry/storage-data'
@@ -749,6 +750,55 @@ describe('notes-handlers', () => {
       })
 
       expect(result).toEqual({ success: true })
+    })
+
+    it('SET_FOLDER_CONFIG should preserve on-disk view config and absent icon', async () => {
+      const views = [{ name: 'All', type: 'table' }]
+      ;(foldersVault.readFolderConfig as Mock).mockResolvedValue({
+        icon: '📁',
+        views,
+        formulas: { total: 'wordCount * 2' },
+        properties: { status: { displayName: 'Status' } },
+        summaries: { wordCount: { type: 'sum' } }
+      })
+      ;(foldersVault.writeFolderConfig as Mock).mockResolvedValue(undefined)
+
+      const result = await invokeHandler(NotesChannels.invoke.SET_FOLDER_CONFIG, {
+        folderPath: 'projects',
+        config: { template: 'template2', inherit: true }
+      })
+
+      expect(result).toEqual({ success: true })
+      expect(foldersVault.writeFolderConfig).toHaveBeenCalledWith(
+        'projects',
+        expect.objectContaining({
+          template: 'template2',
+          icon: '📁',
+          views,
+          formulas: { total: 'wordCount * 2' },
+          properties: { status: { displayName: 'Status' } },
+          summaries: { wordCount: { type: 'sum' } }
+        })
+      )
+      expect(folderConfigEffects.syncFolderConfigSet).toHaveBeenCalledWith('projects', '📁')
+    })
+
+    it('SET_FOLDER_CONFIG should honor explicit icon null while preserving views', async () => {
+      const views = [{ name: 'All', type: 'table' }]
+      ;(foldersVault.readFolderConfig as Mock).mockResolvedValue({ icon: '📁', views })
+      ;(foldersVault.writeFolderConfig as Mock).mockResolvedValue(undefined)
+
+      const result = await invokeHandler(NotesChannels.invoke.SET_FOLDER_CONFIG, {
+        folderPath: 'projects',
+        config: { icon: null }
+      })
+
+      expect(result).toEqual({ success: true })
+      expect(foldersVault.writeFolderConfig).toHaveBeenCalledWith(
+        'projects',
+        expect.objectContaining({ icon: null, views })
+      )
+      expect(folderConfigEffects.syncFolderConfigSet).toHaveBeenCalledWith('projects', null)
     })
 
     it('GET_FOLDER_TEMPLATE should get resolved template', async () => {

--- a/apps/desktop/src/main/ipc/notes-handlers.ts
+++ b/apps/desktop/src/main/ipc/notes-handlers.ts
@@ -730,8 +730,21 @@ export function registerNotesHandlers(): void {
     NotesChannels.invoke.SET_FOLDER_CONFIG,
     SetFolderConfigSchema,
     async (input) => {
-      await writeFolderConfig(input.folderPath, input.config)
-      syncFolderConfigSet(input.folderPath, input.config.icon)
+      // FolderConfigSchema only carries icon/template/inherit, but .folder.md
+      // also stores view configuration (views/formulas/properties/summaries).
+      // Merge those back from disk so a template/icon write never wipes them.
+      // Icon is preserved when the key is absent; explicit null clears it.
+      const current = (await readFolderConfig(input.folderPath)) ?? {}
+      const icon = 'icon' in input.config ? (input.config.icon ?? null) : (current.icon ?? null)
+      await writeFolderConfig(input.folderPath, {
+        ...input.config,
+        icon,
+        views: current.views,
+        formulas: current.formulas,
+        properties: current.properties,
+        summaries: current.summaries
+      })
+      syncFolderConfigSet(input.folderPath, icon)
       return { success: true as const }
     },
     'Failed to set folder config'

--- a/apps/desktop/src/main/sync/item-handlers/folder-config-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/folder-config-handler.test.ts
@@ -49,6 +49,7 @@ describe('folderConfigHandler', () => {
     testDb = createTestDataDb()
     ctx = makeCtx(testDb)
     vi.clearAllMocks()
+    mockReadFolderConfig.mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -56,7 +57,7 @@ describe('folderConfigHandler', () => {
   })
 
   describe('applyUpsert', () => {
-    it('#given no existing row #when remote upsert arrives #then inserts DB row and writes .folder.md', () => {
+    it('#given no existing row #when remote upsert arrives #then inserts DB row and writes .folder.md', async () => {
       const data: FolderConfigSyncPayload = {
         icon: '🎉',
         createdAt: '2026-04-11T00:00:00.000Z',
@@ -77,11 +78,49 @@ describe('folderConfigHandler', () => {
       expect(row!.icon).toBe('🎉')
       expect(row!.clock).toEqual({ 'device-B': 1 })
 
-      expect(mockWriteFolderConfig).toHaveBeenCalledWith('projects/active', { icon: '🎉' })
+      await vi.waitFor(() => {
+        expect(mockWriteFolderConfig).toHaveBeenCalledWith('projects/active', { icon: '🎉' })
+      })
       expect(ctx.emit as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
         'notes:folder-config-updated',
         { path: 'projects/active' }
       )
+    })
+
+    it('#given .folder.md has views #when remote upsert arrives #then preserves views and updates icon only', async () => {
+      testDb.db
+        .insert(folderConfigs)
+        .values({
+          path: 'docs',
+          icon: '📄',
+          clock: { 'device-A': 1 },
+          createdAt: '2026-04-10T00:00:00.000Z',
+          modifiedAt: '2026-04-10T00:00:00.000Z'
+        })
+        .run()
+
+      const views = [{ name: 'All', type: 'table' as const, default: true }]
+      mockReadFolderConfig.mockResolvedValue({
+        icon: '📄',
+        template: 'tpl-1',
+        views,
+        formulas: { total: 'wordCount * 2' }
+      })
+
+      const data: FolderConfigSyncPayload = { icon: '📚' }
+      const clock: VectorClock = { 'device-A': 1, 'device-B': 2 }
+
+      const result = folderConfigHandler.applyUpsert(ctx, 'docs', data, clock)
+
+      expect(result).toBe('applied')
+      await vi.waitFor(() => {
+        expect(mockWriteFolderConfig).toHaveBeenCalledWith('docs', {
+          icon: '📚',
+          template: 'tpl-1',
+          views,
+          formulas: { total: 'wordCount * 2' }
+        })
+      })
     })
 
     it('#given existing row #when remote clock is newer #then updates DB row', () => {
@@ -161,7 +200,7 @@ describe('folderConfigHandler', () => {
   })
 
   describe('applyDelete', () => {
-    it('#given existing row #when delete arrives #then removes DB row and writes empty config', () => {
+    it('#given existing row #when delete arrives #then removes DB row and writes empty config', async () => {
       testDb.db
         .insert(folderConfigs)
         .values({
@@ -187,11 +226,39 @@ describe('folderConfigHandler', () => {
         .get()
       expect(row).toBeUndefined()
 
-      expect(mockWriteFolderConfig).toHaveBeenCalledWith('old-folder', { icon: null })
+      await vi.waitFor(() => {
+        expect(mockWriteFolderConfig).toHaveBeenCalledWith('old-folder', { icon: null })
+      })
       expect(ctx.emit as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
         'notes:folder-config-updated',
         { path: 'old-folder' }
       )
+    })
+
+    it('#given .folder.md has views #when delete arrives #then clears icon but preserves views', async () => {
+      testDb.db
+        .insert(folderConfigs)
+        .values({
+          path: 'old-folder',
+          icon: '📁',
+          clock: { 'device-A': 1 },
+          createdAt: '2026-04-10T00:00:00.000Z',
+          modifiedAt: '2026-04-10T00:00:00.000Z'
+        })
+        .run()
+
+      const views = [{ name: 'By status', type: 'table' as const }]
+      mockReadFolderConfig.mockResolvedValue({ icon: '📁', views })
+
+      const result = folderConfigHandler.applyDelete(ctx, 'old-folder', {
+        'device-A': 1,
+        'device-B': 2
+      })
+
+      expect(result).toBe('applied')
+      await vi.waitFor(() => {
+        expect(mockWriteFolderConfig).toHaveBeenCalledWith('old-folder', { icon: null, views })
+      })
     })
 
     it('#given no existing row #when delete arrives #then skips', () => {

--- a/apps/desktop/src/main/sync/item-handlers/folder-config-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/folder-config-handler.ts
@@ -12,9 +12,20 @@ import { increment } from '../vector-clock'
 import { createLogger } from '../../lib/logger'
 import { BaseItemHandler } from './base-handler'
 import type { ApplyContext, ApplyResult, DrizzleDb } from './types'
-import { writeFolderConfig } from '../../vault/folders'
+import { readFolderConfig, writeFolderConfig } from '../../vault/folders'
 
 const log = createLogger('FolderConfigHandler')
+
+/**
+ * The sync payload only carries the icon, but .folder.md also stores local-only
+ * view configuration (views/formulas/properties/summaries) and template settings.
+ * Merge the icon into the existing on-disk config so applying a remote folder
+ * config never wipes them.
+ */
+async function writeMergedFolderConfig(folderPath: string, icon: string | null): Promise<void> {
+  const current = (await readFolderConfig(folderPath)) ?? {}
+  await writeFolderConfig(folderPath, { ...current, icon })
+}
 
 class FolderConfigHandler extends BaseItemHandler<FolderConfigSyncPayload> {
   readonly type = 'folder_config' as const
@@ -50,7 +61,7 @@ class FolderConfigHandler extends BaseItemHandler<FolderConfigSyncPayload> {
           .where(eq(folderConfigs.path, itemId))
           .run()
 
-        void writeFolderConfig(itemId, { icon: data.icon ?? existing.icon })
+        void writeMergedFolderConfig(itemId, data.icon ?? existing.icon)
         ctx.emit(NotesChannels.events.FOLDER_CONFIG_UPDATED, { path: itemId })
         return resolution.action === 'merge' ? 'conflict' : 'applied'
       }
@@ -65,7 +76,7 @@ class FolderConfigHandler extends BaseItemHandler<FolderConfigSyncPayload> {
         })
         .run()
 
-      void writeFolderConfig(itemId, { icon: data.icon ?? null })
+      void writeMergedFolderConfig(itemId, data.icon ?? null)
       ctx.emit(NotesChannels.events.FOLDER_CONFIG_UPDATED, { path: itemId })
       return 'applied'
     })
@@ -84,7 +95,7 @@ class FolderConfigHandler extends BaseItemHandler<FolderConfigSyncPayload> {
     }
 
     ctx.db.delete(folderConfigs).where(eq(folderConfigs.path, itemId)).run()
-    void writeFolderConfig(itemId, { icon: null })
+    void writeMergedFolderConfig(itemId, null)
     ctx.emit(NotesChannels.events.FOLDER_CONFIG_UPDATED, { path: itemId })
     return 'applied'
   }

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.test.tsx
@@ -60,6 +60,7 @@ vi.mock('@/services/notes-service', () => ({
     getFolderTemplate: vi.fn(),
     renameFolder: vi.fn(),
     deleteFolder: vi.fn(),
+    getFolderConfig: vi.fn(),
     setFolderConfig: vi.fn(),
     reorder: vi.fn(),
     getAllPositions: vi.fn(),
@@ -301,10 +302,11 @@ describe('useNoteTreeActions', () => {
     expect(notesService.revealInFinder).toHaveBeenCalledWith('work-a')
   })
 
-  it('sets and clears folder templates with local display-name updates', async () => {
+  it('sets and clears folder templates preserving the existing folder config', async () => {
     const setFolderTemplateNames = vi.fn(
       (updater: (prev: Map<string, string>) => Map<string, string>) => updater(new Map())
     )
+    vi.mocked(notesService.getFolderConfig).mockResolvedValue({ icon: '📁', template: 'old-tpl' })
     const { result } = renderActions({ setFolderTemplateNames })
 
     act(() => result.current.handleSetFolderTemplate('Work'))
@@ -314,6 +316,7 @@ describe('useNoteTreeActions', () => {
       await result.current.handleFolderTemplateSelect('tpl-1')
     })
     expect(notesService.setFolderConfig).toHaveBeenCalledWith('Work', {
+      icon: '📁',
       template: 'tpl-1',
       inherit: true
     })
@@ -324,10 +327,9 @@ describe('useNoteTreeActions', () => {
     await act(async () => {
       await result.current.handleClearFolderTemplate('Work')
     })
-    expect(notesService.setFolderConfig).toHaveBeenCalledWith('Work', {
-      template: undefined,
-      inherit: true
-    })
+    const clearArg = vi.mocked(notesService.setFolderConfig).mock.lastCall?.[1]
+    expect(clearArg).toEqual({ icon: '📁', inherit: true })
+    expect(clearArg && 'template' in clearArg).toBe(false)
     expect(toast.success).toHaveBeenCalledWith('phaseI.toasts.defaultTemplateCleared')
   })
 

--- a/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-note-tree-actions.ts
@@ -525,7 +525,9 @@ export function useNoteTreeActions(deps: NoteTreeActionsDeps) {
     async (templateId: string | null) => {
       if (folderToConfigureTemplate && templateId) {
         try {
+          const existing = (await notesService.getFolderConfig(folderToConfigureTemplate)) ?? {}
           await notesService.setFolderConfig(folderToConfigureTemplate, {
+            ...existing,
             template: templateId,
             inherit: true
           })
@@ -554,10 +556,10 @@ export function useNoteTreeActions(deps: NoteTreeActionsDeps) {
   const handleClearFolderTemplate = useCallback(
     async (folderPath: string) => {
       try {
-        await notesService.setFolderConfig(folderPath, {
-          template: undefined,
-          inherit: true
-        })
+        const existing = (await notesService.getFolderConfig(folderPath)) ?? {}
+        const next = { ...existing, inherit: true }
+        delete next.template
+        await notesService.setFolderConfig(folderPath, next)
         deps.setFolderTemplateNames((prev) => {
           const next = new Map(prev)
           next.delete(folderPath)

--- a/apps/docs/src/user-guide/sync/how-sync-works.md
+++ b/apps/docs/src/user-guide/sync/how-sync-works.md
@@ -76,10 +76,12 @@ Resume sync to push and pull queued changes. Outgoing changes queue locally unti
 | Bookmarks and reminders                                        | ✓     |
 | Attachments (encrypted blobs)                                  | ✓     |
 | Agent chat conversations and terminal messages (paid accounts) | ✓     |
+| Folder icons                                                   | ✓     |
 
 ## What Does **Not** Get Synced
 
 - Open tabs, sidebar collapse, panel widths (UI state)
+- Folder view configuration (named views, columns, formulas, summaries) — per device; applying a synced folder icon or changing a folder template preserves it
 - Cached AI models and embedding vectors
 - Voice transcription model files
 - AI provider API keys


### PR DESCRIPTION
## What
- Folder-config sync apply (upsert/delete) now merges the icon into the existing `.folder.md` instead of overwriting it with an icon-only config
- `notes:set-folder-config` merges view keys (views/formulas/properties/summaries) back from disk and preserves the icon when absent (explicit `null` still clears)
- Folder template set/clear spreads the existing config so the icon survives

## Why
Folder view customizations live only in `.folder.md`; any pulled `folder_config` item (including fullSync re-deliveries at app launch) or a template change rewrote the file with a partial config, resetting folder views to defaults after restart (user report).