### PR TITLE
feat(editor): fluid note/journal chrome — floating material bar, springs, press feedback

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -294,6 +294,31 @@
   height: 16px !important;
 }
 
+/* Floating note chrome — translucent material over scrolling content.
+   Blur + tint are always on (invisible while nothing is beneath the bar);
+   the scroll edge (softened hairline + falloff) materializes via
+   [data-scrolled] only once content actually passes under it. */
+.note-chrome {
+  background: color-mix(in srgb, var(--background) 65%, transparent);
+  -webkit-backdrop-filter: blur(16px) saturate(180%);
+  backdrop-filter: blur(16px) saturate(180%);
+  transition: box-shadow 200ms var(--ease-out);
+}
+
+.note-chrome[data-scrolled] {
+  box-shadow:
+    0 1px 0 0 color-mix(in srgb, var(--border) 55%, transparent),
+    0 4px 16px -8px rgb(0 0 0 / 0.1);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .note-chrome {
+    background: var(--background);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
 /* Sticky toolbar mode - toolbar fixed at top of editor */
 .sticky-toolbar-enabled .bn-container {
   display: flex;
@@ -303,7 +328,8 @@
 .sticky-toolbar-enabled .bn-formatting-toolbar {
   order: -1;
   position: sticky !important;
-  top: 0 !important;
+  /* Stick below the floating note chrome (var set by NoteLayout, 0 elsewhere) */
+  top: var(--note-chrome-height, 0px) !important;
   z-index: 20;
   width: 100%;
   margin: 0 0 8px 0 !important;

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -308,14 +308,26 @@
   width: 100%;
   margin: 0 0 8px 0 !important;
   padding: 4px 0 8px 0 !important;
-  background: var(--background) !important;
+  background: color-mix(in srgb, var(--background) 72%, transparent) !important;
+  -webkit-backdrop-filter: blur(16px) saturate(180%);
+  backdrop-filter: blur(16px) saturate(180%);
   border: none !important;
-  border-bottom: 1px solid var(--border) !important;
   border-radius: 0 !important;
-  box-shadow: none !important;
+  /* Soft scroll-edge instead of a hard divider: softened hairline + short falloff */
+  box-shadow:
+    0 1px 0 0 color-mix(in srgb, var(--border) 60%, transparent),
+    0 1px 10px -4px rgb(0 0 0 / 0.08) !important;
   transform: none !important;
   opacity: 1 !important;
   pointer-events: auto !important;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .sticky-toolbar-enabled .bn-formatting-toolbar {
+    background: var(--background) !important;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
 }
 
 .sticky-toolbar-enabled .bn-formatting-toolbar > div {

--- a/apps/desktop/src/renderer/src/components/journal/journal-breadcrumb.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-breadcrumb.tsx
@@ -17,10 +17,10 @@ interface JournalBreadcrumbProps {
 }
 
 const CRUMB_CLASS =
-  'text-xs text-muted-foreground hover:bg-muted rounded-sm px-1 py-0.5 transition-colors cursor-pointer bg-transparent border-none'
+  'text-xs text-muted-foreground hover:bg-muted active:bg-muted/70 active:text-foreground rounded-sm px-1 py-0.5 transition-colors duration-150 cursor-pointer bg-transparent border-none'
 
 const BACK_BTN_CLASS =
-  'flex items-center justify-center shrink-0 text-muted-foreground hover:text-foreground transition-colors bg-transparent border-none cursor-pointer p-0'
+  'flex items-center justify-center shrink-0 text-muted-foreground hover:text-foreground transition-all duration-150 ease-out active:scale-90 bg-transparent border-none cursor-pointer p-0'
 
 export function JournalBreadcrumb({
   viewState,
@@ -76,7 +76,7 @@ export function JournalBreadcrumb({
         <span className="text-xs text-text-secondary px-0.5">/</span>
         <span className="text-xs text-foreground font-medium">{dateParts.day}</span>
         {isToday && (
-          <span className="ml-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-amber-700 dark:text-amber-400 bg-amber-500/10 rounded-full px-2 py-0.5 border border-amber-500/20">
+          <span className="ms-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-amber-700 dark:text-amber-400 bg-amber-500/10 rounded-full px-2 py-0.5 border border-amber-500/20">
             {t('date.relative.today')}
           </span>
         )}

--- a/apps/desktop/src/renderer/src/components/journal/journal-header-actions.tsx
+++ b/apps/desktop/src/renderer/src/components/journal/journal-header-actions.tsx
@@ -39,7 +39,8 @@ interface JournalHeaderActionsProps {
   onOpenSettings: () => void
 }
 
-const ACTION_BTN = 'size-7 hover:bg-surface-active'
+const ACTION_BTN =
+  'size-7 hover:bg-surface-active transition-all duration-150 ease-out active:scale-95 active:bg-surface-active/70 disabled:active:scale-100'
 
 export function JournalHeaderActions({
   viewState,

--- a/apps/desktop/src/renderer/src/components/note/note-breadcrumb.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-breadcrumb.tsx
@@ -30,7 +30,7 @@ function parseBreadcrumbSegments(notePath: string): BreadcrumbSegment[] {
 export const SIDEBAR_REVEAL_FOLDER_EVENT = 'sidebar:reveal-folder'
 
 const CRUMB_CLASS =
-  'text-xs text-muted-foreground hover:bg-muted rounded-sm px-1 py-0.5 transition-colors cursor-pointer bg-transparent border-none'
+  'text-xs text-muted-foreground hover:bg-muted active:bg-muted/70 active:text-foreground rounded-sm px-1 py-0.5 transition-colors duration-150 cursor-pointer bg-transparent border-none'
 
 export function NoteBreadcrumb({ notePath, noteTitle }: NoteBreadcrumbProps) {
   const { t } = useT('notes')
@@ -73,7 +73,7 @@ export function NoteBreadcrumb({ notePath, noteTitle }: NoteBreadcrumbProps) {
       <button
         type="button"
         onClick={handleBackClick}
-        className="flex items-center justify-center shrink-0 text-muted-foreground hover:text-foreground transition-colors bg-transparent border-none cursor-pointer p-0"
+        className="flex items-center justify-center shrink-0 text-muted-foreground hover:text-foreground transition-all duration-150 ease-out active:scale-90 bg-transparent border-none cursor-pointer p-0"
         aria-label={t('editor.breadcrumb.parentFolderAria')}
       >
         <ChevronLeft className="h-3.5 w-3.5" />

--- a/apps/desktop/src/renderer/src/components/note/note-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-layout.tsx
@@ -101,7 +101,7 @@ export function NoteLayout({
           <div
             data-note-layout-canvas
             className={cn(
-              'mx-auto w-full pt-6 pb-10 min-h-full transition-[max-width] duration-300 ease-in-out',
+              'mx-auto w-full pt-6 pb-10 min-h-full transition-[max-width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]',
               showGridRail
                 ? 'grid items-start gap-x-12 px-24 [grid-template-columns:minmax(0,var(--note-layout-content-track))_20rem] max-[920px]:max-w-[var(--note-layout-content-max)] max-[920px]:grid-cols-1 max-[920px]:px-8'
                 : 'px-24 flex flex-col'

--- a/apps/desktop/src/renderer/src/components/note/note-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-layout.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import {
+  useCallback,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type UIEvent
+} from 'react'
 import { cn } from '@/lib/utils'
 import { useActiveHeading } from '@/hooks/use-active-heading'
 import { useReviewRailShift } from '@/hooks/use-review-rail-shift'
@@ -65,6 +72,13 @@ export function NoteLayout({
   )
 
   const hasSideRail = sideRail !== undefined && sideRail !== null
+  const hasChrome = Boolean(breadcrumb || actions)
+  // Scroll-edge effect: the chrome's hairline/shadow materializes only once
+  // content is actually beneath it (state only flips at the 0 boundary).
+  const [isScrolled, setIsScrolled] = useState(false)
+  const handleScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
+    setIsScrolled(e.currentTarget.scrollTop > 0)
+  }, [])
   const resolvedContentWidth = contentWidth ?? '64rem'
   const { shiftStyle, railHidden, setContentEl } = useReviewRailShift(scrollEl, {
     railEnabled: hasSideRail,
@@ -89,19 +103,30 @@ export function NoteLayout({
       }
 
   return (
-    <div className={cn('h-full w-full overflow-hidden flex flex-col relative', className)}>
-      {(breadcrumb || actions) && (
-        <div className="flex items-center justify-between h-9 py-2 px-6 shrink-0 text-xs/4 [font-synthesis:none]">
+    <div
+      className={cn('h-full w-full overflow-hidden flex flex-col relative', className)}
+      style={{ '--note-chrome-height': hasChrome ? '2.25rem' : '0px' } as CSSProperties}
+    >
+      {hasChrome && (
+        <div
+          data-scrolled={isScrolled || undefined}
+          className="note-chrome absolute top-0 inset-x-0 z-30 flex items-center justify-between h-9 py-2 px-6 text-xs/4 [font-synthesis:none]"
+        >
           <div className="flex items-center">{breadcrumb}</div>
           <div className="flex items-center">{actions}</div>
         </div>
       )}
-      <div ref={setScrollRef} className="flex-1 overflow-y-auto overflow-x-visible">
+      <div
+        ref={setScrollRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto overflow-x-visible"
+      >
         <div ref={marqueeZoneRef} className="marquee-zone relative min-h-full w-full flex flex-col">
           <div
             data-note-layout-canvas
             className={cn(
-              'mx-auto w-full pt-6 pb-10 min-h-full transition-[max-width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]',
+              'mx-auto w-full pb-10 min-h-full transition-[max-width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]',
+              hasChrome ? 'pt-15' : 'pt-6',
               showGridRail
                 ? 'grid items-start gap-x-12 px-24 [grid-template-columns:minmax(0,var(--note-layout-content-track))_20rem] max-[920px]:max-w-[var(--note-layout-content-max)] max-[920px]:grid-cols-1 max-[920px]:px-8'
                 : 'px-24 flex flex-col'

--- a/apps/desktop/src/renderer/src/components/shared/outline-info-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/shared/outline-info-panel.tsx
@@ -199,13 +199,15 @@ export const OutlineInfoPanel = memo(function OutlineInfoPanel({
             'bg-background border border-border/10',
             'shadow-lg rounded-[10px]',
             'min-w-[240px] max-w-[300px]',
+            // Anchor the zoom to where the collapsed rail lives (top inline-end)
+            'origin-top-right rtl:origin-top-left',
             !isFadingOut && 'animate-in fade-in-0 zoom-in-95 duration-150'
           )}
           style={
             isFadingOut
               ? {
                   opacity: 0,
-                  transform: 'scale(0.98)',
+                  transform: 'scale(0.95)',
                   transition: `opacity ${FADE_DURATION}ms ease, transform ${FADE_DURATION}ms ease`
                 }
               : undefined

--- a/apps/desktop/src/renderer/src/pages/journal.tsx
+++ b/apps/desktop/src/renderer/src/pages/journal.tsx
@@ -12,9 +12,11 @@ import {
   useRef,
   useState,
   type CSSProperties,
-  type RefObject
+  type RefObject,
+  type UIEvent
 } from 'react'
 import { cn } from '@/lib/utils'
+import { motion, useReducedMotion } from 'motion/react'
 import { Loader2 } from '@/lib/icons'
 import {
   JournalMonthView,
@@ -334,6 +336,12 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
   const setJournalScrollRef = useCallback((el: HTMLDivElement | null) => {
     journalScrollRef.current = el
     setJournalScrollEl(el)
+  }, [])
+  const prefersReducedMotion = useReducedMotion()
+  // Scroll-edge effect for the floating chrome (state only flips at the 0 boundary)
+  const [isChromeScrolled, setIsChromeScrolled] = useState(false)
+  const handleChromeScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
+    setIsChromeScrolled(e.currentTarget.scrollTop > 0)
   }, [])
   const [marqueeZoneEl, setMarqueeZoneEl] = useState<HTMLDivElement | null>(null)
 
@@ -785,7 +793,10 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
     >
       <div className={cn('flex h-full w-full overflow-hidden bg-background', className)}>
         {/* Main Content Area */}
-        <main className={cn('flex-1 min-w-0 h-full relative flex flex-col')}>
+        <main
+          className={cn('flex-1 min-w-0 h-full relative flex flex-col')}
+          style={{ '--note-chrome-height': '2.25rem' } as CSSProperties}
+        >
           <FindBar
             isOpen={findInPage.isOpen}
             query={findInPage.query}
@@ -798,7 +809,10 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
             onClose={findInPage.close}
           />
 
-          <div className="flex items-center justify-between h-9 py-2 ps-6 pe-3 shrink-0 text-xs/4 [font-synthesis:none]">
+          <div
+            data-scrolled={isChromeScrolled || undefined}
+            className="note-chrome absolute top-0 inset-x-0 z-30 flex items-center justify-between h-9 py-2 ps-6 pe-3 text-xs/4 [font-synthesis:none]"
+          >
             <JournalBreadcrumb
               viewState={currentViewState}
               isToday={isToday}
@@ -824,19 +838,31 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
             />
           </div>
 
-          <div ref={setJournalScrollRef} className="flex-1 overflow-y-auto overflow-x-visible">
+          <div
+            ref={setJournalScrollRef}
+            onScroll={handleChromeScroll}
+            className="flex-1 overflow-y-auto overflow-x-visible"
+          >
             <div
               ref={setMarqueeZoneEl}
               className="marquee-zone relative min-h-full w-full flex flex-col"
             >
               <div
                 className={cn(
-                  'mx-auto w-full min-h-full flex flex-col pt-6 pb-10 lg:pb-16 transition-[max-width] duration-300 ease-in-out',
+                  'mx-auto w-full min-h-full flex flex-col pt-15 pb-10 lg:pb-16 transition-[max-width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]',
                   isFullWidth ? 'px-24 max-[920px]:px-8' : 'px-8 lg:px-12'
                 )}
                 style={{ maxWidth: isFullWidth ? '100%' : '64rem' }}
               >
-                <div className="flex flex-col flex-1 mx-auto w-full transition-[max-width] duration-300 ease-in-out">
+                {/* Content — materializes on day/view switch (crossfade only
+                    under reduced motion); critically damped spring, no overshoot */}
+                <motion.div
+                  key={`${currentViewState.type}-${selectedDate}`}
+                  initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ type: 'spring', bounce: 0, duration: 0.35 }}
+                  className="flex flex-col flex-1 mx-auto w-full transition-[max-width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]"
+                >
                   {entryError && (
                     <div className="mb-4 px-4 py-3 rounded-md bg-destructive/10 border border-destructive/20 text-destructive text-sm">
                       <span className="font-medium">{t('toast.errorPrefix')}</span> {entryError}
@@ -1024,7 +1050,7 @@ export function JournalPage({ className }: JournalPageProps): React.JSX.Element 
                       />
                     </div>
                   )}
-                </div>
+                </motion.div>
               </div>
             </div>
 

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -8,6 +8,7 @@ import { getI18n } from 'react-i18next'
 
 import { useState, useCallback, useEffect, useRef, useMemo, type RefObject } from 'react'
 import { cn } from '@/lib/utils'
+import { motion, useReducedMotion } from 'motion/react'
 import { useQueryClient } from '@tanstack/react-query'
 import { ExportDialog } from '@/components/note/export-dialog'
 import { VersionHistory } from '@/components/note/version-history'
@@ -129,6 +130,7 @@ export function NotePage({ noteId }: NotePageProps) {
   const activeTab = useActiveTab()
   const { openTag } = useSidebarDrillDown()
   const queryClient = useQueryClient()
+  const prefersReducedMotion = useReducedMotion()
 
   // Extract highlight info from tab viewState (from reminder navigation)
   const initialHighlight = useMemo(() => {
@@ -1063,8 +1065,13 @@ export function NotePage({ noteId }: NotePageProps) {
       breadcrumb={<NoteBreadcrumb notePath={note.path} noteTitle={note.title} />}
       stats={documentStats}
     >
-      {/* Note content */}
-      <div
+      {/* Note content — materializes on note switch (crossfade only under
+          reduced motion); critically damped spring, no overshoot */}
+      <motion.div
+        key={noteId}
+        initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ type: 'spring', bounce: 0, duration: 0.35 }}
         className="flex flex-col flex-1 mx-auto w-full transition-[max-width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]"
         style={{ maxWidth: noteContentWidth ?? '100%' }}
       >
@@ -1216,7 +1223,7 @@ export function NotePage({ noteId }: NotePageProps) {
             onTaskClick={handleLinkedTaskClick}
           />
         </div>
-      </div>
+      </motion.div>
 
       {/* Export Dialog */}
       <ExportDialog

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -928,7 +928,7 @@ export function NotePage({ noteId }: NotePageProps) {
           <Button
             variant="ghost"
             size="icon"
-            className="size-7 hover:bg-surface-active"
+            className="size-7 hover:bg-surface-active transition-all duration-150 ease-out active:scale-95 active:bg-surface-active/70 disabled:active:scale-100"
             disabled={isDeleted}
             title={
               hasActiveReminder ? t('editor.toolbar.reminderSet') : t('editor.toolbar.setReminder')
@@ -947,7 +947,7 @@ export function NotePage({ noteId }: NotePageProps) {
       <Button
         variant="ghost"
         size="icon"
-        className="size-7 hover:bg-surface-active"
+        className="size-7 hover:bg-surface-active transition-all duration-150 ease-out active:scale-95 active:bg-surface-active/70 disabled:active:scale-100"
         onClick={() => void toggleBookmark()}
         disabled={isDeleted}
         title={isBookmarked ? t('editor.toolbar.removeBookmark') : t('editor.toolbar.addBookmark')}
@@ -982,7 +982,7 @@ export function NotePage({ noteId }: NotePageProps) {
           <Button
             variant="ghost"
             size="icon"
-            className="size-7 hover:bg-surface-active"
+            className="size-7 hover:bg-surface-active transition-all duration-150 ease-out active:scale-95 active:bg-surface-active/70 disabled:active:scale-100"
             disabled={isDeleted}
           >
             <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
@@ -1065,7 +1065,7 @@ export function NotePage({ noteId }: NotePageProps) {
     >
       {/* Note content */}
       <div
-        className="flex flex-col flex-1 mx-auto w-full transition-[max-width] duration-300 ease-in-out"
+        className="flex flex-col flex-1 mx-auto w-full transition-[max-width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]"
         style={{ maxWidth: noteContentWidth ?? '100%' }}
       >
         {/* Title + Metadata zone — ghost affordance appears on hover */}


### PR DESCRIPTION
## What
- Note & journal top bars are now floating translucent chrome (`.note-chrome`): content scrolls beneath a blurred material bar; a soft scroll-edge hairline appears only once content is under it
- Note/journal content materializes on switch via a critically damped `motion/react` spring (crossfade under reduced motion)
- Instant press feedback (`active:scale`) on page action icons and breadcrumb buttons
- Sticky formatting toolbar becomes translucent material (with `prefers-reduced-transparency` fallback) and sticks below the chrome; outline panel zoom is anchored to its top-inline-end origin with a mirrored exit

## Why
Apply fluid-interface principles (instant response, real materials, anchored motion) to the two primary editing surfaces.

Docs gate skipped intentionally: purely visual/motion restyle — no settings, shortcuts, or workflows changed; docs sweep confirmed no documented behavior is invalidated.