### PR TITLE
feat(landing): apple-design pass — chrome materials, materialize motion, footer redesign

### DIFF
--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { useEffect } from 'react'
+import { MotionConfig } from 'framer-motion'
 import { HelmetProvider } from 'react-helmet-async'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
@@ -217,7 +218,11 @@ export default function App() {
     <HelmetProvider>
       <BrowserRouter>
         <AuthProvider>
-          <AppContent />
+          {/* reducedMotion="user": transform/layout animations degrade to crossfades
+              for prefers-reduced-motion users, across every motion.* on the site. */}
+          <MotionConfig reducedMotion="user">
+            <AppContent />
+          </MotionConfig>
           <Analytics />
           <SpeedInsights />
         </AuthProvider>

--- a/apps/landing/src/components/layout/Footer.tsx
+++ b/apps/landing/src/components/layout/Footer.tsx
@@ -4,6 +4,15 @@ import { Container } from './Container'
 import { FOOTER_LINKS, TWITTER_DEV_URL } from '@/lib/constants'
 import { trackLandingEvent } from '@/lib/analytics'
 
+const FOOTER_COLUMNS = [
+  { title: 'Product', links: FOOTER_LINKS.product },
+  { title: 'Compare', links: FOOTER_LINKS.compare },
+  { title: 'Resources', links: FOOTER_LINKS.resources },
+  { title: 'Connect', links: FOOTER_LINKS.social }
+] as const
+
+const TRUST_LINE = ['End-to-end encrypted', 'Open source', 'Local-first'] as const
+
 function footerHref(href: string, pathname: string): string {
   if (href.startsWith('#') && pathname !== '/') return '/' + href
   return href
@@ -16,7 +25,7 @@ function footerTarget(label: ReactNode) {
 }
 
 function FooterLink({ href, children }: { href: string; children: ReactNode }) {
-  const className = 'text-sm text-muted hover:text-terracotta transition-colors font-medium'
+  const className = 'text-sm font-medium text-muted transition-colors hover:text-terracotta'
 
   if (href.startsWith('http')) {
     return (
@@ -48,97 +57,58 @@ export function Footer() {
   const { pathname } = useLocation()
 
   return (
-    <footer className="border-t border-border bg-paper py-20">
+    <footer className="border-t border-border/60 py-20 md:py-24">
       <Container>
-        <div className="grid grid-cols-2 md:grid-cols-6 gap-10 mb-16">
-          <div className="col-span-2 md:col-span-2 pe-8">
+        <div className="mb-16 grid grid-cols-2 gap-x-8 gap-y-12 md:grid-cols-6 md:gap-10">
+          <div className="col-span-2 pe-8">
             <Link
               to="/"
-              className="inline-flex items-center gap-2 mb-6 group"
+              className="group inline-flex items-center gap-2"
               onClick={() => trackLandingEvent('landing_nav_click', 'footer:logo')}
             >
-              <img src="/favicon.svg" alt="" className="h-7 w-7" />
-              <span className="font-serif text-3xl font-medium text-ink group-hover:text-terracotta transition-colors">
+              <img src="/favicon.svg" alt="" className="h-6 w-6" />
+              <span className="font-geist text-2xl font-medium tracking-tight text-ink transition-colors group-hover:text-terracotta">
                 memrynote
               </span>
             </Link>
-            <p className="text-lg text-muted font-sans leading-relaxed max-w-sm">
+            <p className="mt-5 max-w-sm text-base leading-relaxed text-muted">
               Notes, tasks, and journal — finally in one place. Private, fast, and yours forever.
+            </p>
+            <p className="mt-6 font-mono-accent text-[10px] uppercase tracking-[0.18em] text-muted/60">
+              {TRUST_LINE.map((fact, i) => (
+                <span key={fact} className="inline-block">
+                  {fact}
+                  {i < TRUST_LINE.length - 1 && (
+                    <span aria-hidden className="mx-2.5 text-terracotta/60">
+                      ·
+                    </span>
+                  )}
+                </span>
+              ))}
             </p>
           </div>
 
-          <div>
-            <h4 className="font-serif text-lg text-ink mb-6">Product</h4>
-            <ul className="space-y-4">
-              {FOOTER_LINKS.product.map((link) => (
-                <li key={link.label}>
-                  <Link
-                    to={footerHref(link.href, pathname)}
-                    className="text-sm text-muted hover:text-terracotta transition-colors font-medium"
-                    onClick={() => trackLandingEvent('landing_nav_click', footerTarget(link.label))}
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div>
-            <h4 className="font-serif text-lg text-ink mb-6">Compare</h4>
-            <ul className="space-y-4">
-              {FOOTER_LINKS.compare.map((link) => (
-                <li key={link.label}>
-                  <Link
-                    to={footerHref(link.href, pathname)}
-                    className="text-sm text-muted hover:text-terracotta transition-colors font-medium"
-                    onClick={() => trackLandingEvent('landing_nav_click', footerTarget(link.label))}
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div>
-            <h4 className="font-serif text-lg text-ink mb-6">Resources</h4>
-            <ul className="space-y-4">
-              {FOOTER_LINKS.resources.map((link) => (
-                <li key={link.label}>
-                  <FooterLink href={link.href}>{link.label}</FooterLink>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div>
-            <h4 className="font-serif text-lg text-ink mb-6">Connect</h4>
-            <ul className="space-y-4">
-              {FOOTER_LINKS.social.map((link) => (
-                <li key={link.label}>
-                  <a
-                    href={link.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-muted hover:text-terracotta transition-colors font-medium"
-                    onClick={() =>
-                      trackLandingEvent('landing_external_click', footerTarget(link.label))
-                    }
-                  >
-                    {link.label}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
+          {FOOTER_COLUMNS.map((column) => (
+            <div key={column.title}>
+              <h4 className="mb-5 font-mono-accent text-[11px] uppercase tracking-[0.18em] text-muted/70">
+                {column.title}
+              </h4>
+              <ul className="space-y-3.5">
+                {column.links.map((link) => (
+                  <li key={link.label}>
+                    <FooterLink href={footerHref(link.href, pathname)}>{link.label}</FooterLink>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
 
-        <div className="pt-8 border-t border-border flex flex-col md:flex-row justify-between items-center gap-4">
-          <p className="text-sm text-muted/60 font-mono-accent">
+        <div className="flex flex-col items-center justify-between gap-4 border-t border-border/60 pt-8 md:flex-row">
+          <p className="font-mono-accent text-xs text-muted/60">
             © {currentYear} memrynote. All rights reserved.
           </p>
-          <p className="text-sm text-muted/60 font-mono-accent">
+          <p className="font-mono-accent text-xs text-muted/60">
             An indie project by{' '}
             <a
               href={TWITTER_DEV_URL}

--- a/apps/landing/src/components/layout/Header.tsx
+++ b/apps/landing/src/components/layout/Header.tsx
@@ -113,7 +113,7 @@ function GitHubStarWidget({
   return (
     <a
       className={cn(
-        'github-star-widget inline-flex items-center rounded-lg border border-border/70 bg-card/65 font-semibold text-ink shadow-[0_1px_0_rgba(255,255,255,0.7)] transition-colors hover:border-ink/15 hover:bg-card dark:border-white/10 dark:shadow-none',
+        'github-star-widget inline-flex items-center rounded-lg border border-border/70 bg-card/65 font-semibold text-ink shadow-[0_1px_0_rgba(255,255,255,0.7)] transition-[color,background-color,border-color,transform] duration-200 hover:border-ink/15 hover:bg-card active:scale-[0.97] active:duration-75 motion-reduce:active:scale-100 dark:border-white/10 dark:shadow-none',
         iconOnly
           ? 'h-10 w-10 justify-center rounded-full p-0'
           : compact
@@ -162,7 +162,7 @@ function DropdownTrigger({ label, icon: Icon }: { label: string; icon?: LucideIc
       {Icon ? <Icon className="h-3.5 w-3.5" aria-hidden /> : null}
       {label}
       <ChevronDown
-        className="h-3.5 w-3.5 transition-transform group-hover:rotate-180"
+        className="h-3.5 w-3.5 transition-transform group-hover:rotate-180 group-focus-within:rotate-180"
         aria-hidden
       />
     </button>
@@ -243,10 +243,12 @@ function DesktopDropdown({
   return (
     <div className="group relative">
       <DropdownTrigger label={label} icon={icon} />
-      <div className="invisible absolute left-1/2 top-full z-50 mt-3 -translate-x-1/2 opacity-0 transition-all duration-150 group-hover:visible group-hover:opacity-100">
+      {/* Materialize from the trigger: blur+scale+lift resolve together, anchored top.
+          focus-within keeps the menu reachable by keyboard, not just hover. */}
+      <div className="invisible absolute left-1/2 top-full z-50 mt-3 origin-top -translate-x-1/2 translate-y-1 scale-[0.97] opacity-0 blur-[6px] transition-all duration-200 [transition-timing-function:var(--ease-out-expo)] group-hover:visible group-hover:translate-y-0 group-hover:scale-100 group-hover:opacity-100 group-hover:blur-none group-focus-within:visible group-focus-within:translate-y-0 group-focus-within:scale-100 group-focus-within:opacity-100 group-focus-within:blur-none motion-reduce:translate-y-0 motion-reduce:scale-100 motion-reduce:blur-none motion-reduce:transition-[opacity,visibility]">
         <div
           className={cn(
-            'rounded-[22px] border border-white/70 bg-paper/95 p-3 shadow-[0_26px_80px_-28px_rgba(31,41,55,0.28),inset_0_1px_0_rgba(255,255,255,0.7)] backdrop-blur-xl dark:border-white/10 dark:bg-paper/90 dark:shadow-[0_26px_80px_-28px_rgba(0,0,0,0.7),inset_0_1px_0_rgba(255,255,255,0.04)]',
+            'material-chrome rounded-[22px] border border-white/70 p-3 shadow-[0_26px_80px_-28px_rgba(31,41,55,0.28),inset_0_1px_0_rgba(255,255,255,0.7)] dark:border-white/10 dark:shadow-[0_26px_80px_-28px_rgba(0,0,0,0.7),inset_0_1px_0_rgba(255,255,255,0.04)]',
             columns === 2 ? 'w-[574px]' : 'w-[320px]'
           )}
         >
@@ -456,7 +458,7 @@ export function Header() {
           className={cn(
             'mx-auto flex max-w-6xl items-center justify-between rounded-full border px-3 py-2 transition-all duration-300 sm:px-4',
             showHeaderSurface
-              ? 'border-border/60 bg-paper/85 shadow-sm backdrop-blur-xl'
+              ? 'material-chrome border-border/60 shadow-sm'
               : 'border-transparent bg-transparent'
           )}
         >
@@ -502,7 +504,7 @@ export function Header() {
             <GitHubStarWidget iconOnly className="h-9 w-9" />
             <button
               type="button"
-              className="rounded-full border border-border/70 bg-card/60 p-3 text-ink transition-colors hover:text-terracotta"
+              className="rounded-full border border-border/70 bg-card/60 p-3 text-ink transition-[color,transform] duration-200 hover:text-terracotta active:scale-95 active:duration-75 motion-reduce:active:scale-100"
               onClick={toggleMobileMenu}
               aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
             >
@@ -515,13 +517,14 @@ export function Header() {
       <AnimatePresence>
         {mobileMenuOpen && (
           <motion.div
-            initial={{ opacity: 0, y: -8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -8 }}
-            className="relative z-10 px-3 pt-3 md:hidden sm:px-6"
+            initial={{ opacity: 0, y: -8, scale: 0.98, filter: 'blur(8px)' }}
+            animate={{ opacity: 1, y: 0, scale: 1, filter: 'blur(0px)' }}
+            exit={{ opacity: 0, y: -8, scale: 0.98, filter: 'blur(8px)' }}
+            transition={{ type: 'spring', duration: 0.35, bounce: 0 }}
+            className="relative z-10 origin-top px-3 pt-3 md:hidden sm:px-6"
           >
             <Container size="full">
-              <div className="mx-auto flex max-h-[calc(100dvh-88px)] max-w-6xl flex-col gap-1.5 overflow-y-auto rounded-[20px] border border-white/70 bg-paper/92 p-2.5 shadow-[var(--shadow-float)] backdrop-blur-xl dark:border-white/10">
+              <div className="material-chrome mx-auto flex max-h-[calc(100dvh-88px)] max-w-6xl flex-col gap-1.5 overflow-y-auto rounded-[20px] border border-white/70 p-2.5 shadow-[var(--shadow-float)] dark:border-white/10">
                 {MOBILE_DROPDOWN_SECTIONS.map((section) => (
                   <MobileDropdownSection
                     key={section.key}

--- a/apps/landing/src/components/sections/Features.tsx
+++ b/apps/landing/src/components/sections/Features.tsx
@@ -144,7 +144,7 @@ export function Features() {
                   height={870}
                   decoding="async"
                   className="absolute inset-0 h-full w-full object-cover"
-                  initial={{ opacity: 0, scale: 1.02, filter: 'blur(12px)' }}
+                  initial={{ opacity: 0, scale: 1.02, filter: 'blur(8px)' }}
                   animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
                   exit={{ opacity: 0, transition: { duration: 0.3, ease: 'easeOut' } }}
                   transition={{ duration: 0.5, ease: EASE }}

--- a/apps/landing/src/components/sections/Features.tsx
+++ b/apps/landing/src/components/sections/Features.tsx
@@ -132,8 +132,10 @@ export function Features() {
           </div>
 
           <div className="overflow-hidden rounded-lg border border-border/70 bg-card shadow-card lg:sticky lg:top-28">
-            <div className="aspect-[1232/870]">
-              <AnimatePresence mode="wait">
+            {/* Materialize, don't just fade: incoming screenshot resolves from blur+scale
+                over the outgoing one — no mode="wait" blank frame between panels. */}
+            <div className="relative aspect-[1232/870]">
+              <AnimatePresence initial={false}>
                 <motion.img
                   key={`${activeFeature.id}-${theme}`}
                   src={screenshotSrc}
@@ -141,11 +143,11 @@ export function Features() {
                   width={1232}
                   height={870}
                   decoding="async"
-                  className="h-full w-full object-cover"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.25, ease: 'easeOut' }}
+                  className="absolute inset-0 h-full w-full object-cover"
+                  initial={{ opacity: 0, scale: 1.02, filter: 'blur(12px)' }}
+                  animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
+                  exit={{ opacity: 0, transition: { duration: 0.3, ease: 'easeOut' } }}
+                  transition={{ duration: 0.5, ease: EASE }}
                 />
               </AnimatePresence>
             </div>

--- a/apps/landing/src/components/sections/FinalCTA.tsx
+++ b/apps/landing/src/components/sections/FinalCTA.tsx
@@ -15,8 +15,8 @@ export function FinalCTA() {
 
       <Container size="sm">
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
+          initial={{ opacity: 0, y: 20, filter: 'blur(10px)' }}
+          whileInView={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
           viewport={{ once: true, margin: '-50px' }}
           transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
           className="relative text-center"

--- a/apps/landing/src/components/sections/SecurityShowcase.tsx
+++ b/apps/landing/src/components/sections/SecurityShowcase.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { motion, useInView } from 'framer-motion'
+import { motion, useInView, useReducedMotion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import { Container } from '@/components/layout/Container'
 
@@ -21,6 +21,7 @@ function useScramble(trigger: boolean, lineCount: number, charsPerLine: number) 
   const [lines, setLines] = useState<string[]>(() => Array.from({ length: lineCount }, () => ''))
   const [hovered, setHovered] = useState(false)
   const intervalRef = useRef<ReturnType<typeof setInterval>>(null)
+  const reduceMotion = useReducedMotion()
 
   useEffect(() => {
     if (!trigger) return
@@ -37,11 +38,13 @@ function useScramble(trigger: boolean, lineCount: number, charsPerLine: number) 
     }
 
     scramble()
+    // Reduced motion: one static cipher fill, no flicker loop.
+    if (reduceMotion) return
     intervalRef.current = setInterval(scramble, hovered ? FAST_INTERVAL : SLOW_INTERVAL)
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current)
     }
-  }, [trigger, lineCount, charsPerLine, hovered])
+  }, [trigger, lineCount, charsPerLine, hovered, reduceMotion])
 
   return { lines, setHovered }
 }
@@ -64,7 +67,9 @@ const PILLARS = [
 export function SecurityShowcase() {
   const ref = useRef<HTMLElement>(null)
   const isInView = useInView(ref, { once: true, amount: 0.3 })
-  const { lines: scrambled, setHovered } = useScramble(isInView, 4, 28)
+  // Live (not once): the cipher ticker pauses when the section scrolls away.
+  const scrambleActive = useInView(ref, { amount: 0.2 })
+  const { lines: scrambled, setHovered } = useScramble(scrambleActive, 4, 28)
 
   return (
     <section ref={ref} className="zone-dark py-24 md:py-32">

--- a/apps/landing/src/components/ui/button.tsx
+++ b/apps/landing/src/components/ui/button.tsx
@@ -4,12 +4,13 @@ import { forwardRef, type ButtonHTMLAttributes } from 'react'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  // Press feedback fires on :active (pointer-down) and lands fast — release eases back at 200ms.
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 active:scale-[0.97] active:duration-75 motion-reduce:active:scale-100',
   {
     variants: {
       variant: {
         default:
-          'bg-[var(--color-terracotta)] text-white shadow-sm hover:bg-[var(--color-terracotta-dark)] active:scale-[0.98]',
+          'bg-[var(--color-terracotta)] text-white shadow-sm hover:bg-[var(--color-terracotta-dark)]',
         secondary:
           'bg-[var(--color-paper-alt)] text-[var(--color-ink)] border border-[var(--color-border)] shadow-sm hover:bg-[var(--color-border)]',
         ghost: 'text-[var(--color-ink)] hover:bg-[var(--color-paper-alt)]',

--- a/apps/landing/src/index.css
+++ b/apps/landing/src/index.css
@@ -240,6 +240,30 @@ h6 {
   letter-spacing: -0.02em;
 }
 
+/* Translucent chrome — floating layers (nav pill, dropdowns, mobile menu).
+   Content scrolls under; degrades to solid paper for reduced-transparency/contrast. */
+.material-chrome {
+  background: color-mix(in srgb, var(--color-paper) 85%, transparent);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  backdrop-filter: blur(20px) saturate(140%);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .material-chrome {
+    background: var(--color-paper);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .material-chrome {
+    background: var(--color-paper);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
 ::selection {
   background-color: var(--color-terracotta);
   color: #fff;


### PR DESCRIPTION
## What

Design-quality pass over the landing homepage: translucent chrome materials, materialize motion, press feedback, reduced-motion compliance, and a footer redesign. Content, copy, and section order untouched.

## Changes

- **`.material-chrome` utility** (index.css): blur(20px)+saturate(140%) translucent chrome with `prefers-reduced-transparency` and `prefers-contrast` solid fallbacks. Used by the header pill, desktop dropdowns, and mobile menu.
- **`MotionConfig reducedMotion="user"`** (App.tsx): every framer-motion transform/layout animation degrades to a crossfade for reduced-motion users — site-wide, not per-component.
- **Header dropdowns**: materialize from the trigger origin (blur + scale + lift resolving together) and now open on keyboard `focus-within` — previously hover-only, so keyboard users could never open them.
- **Press feedback**: instant active-scale (75ms down, 200ms release) on the Button base (all variants), GitHub star widget, and mobile menu button.
- **Features screenshot swap**: blur+scale materialize crossfade over the outgoing image — removes the `mode="wait"` blank frame.
- **SecurityShowcase cipher ticker**: was running on an interval forever after first coming into view; now pauses when the section scrolls away. Reduced-motion users get a single static cipher fill instead of a flicker loop.
- **FinalCTA**: blur materialize on reveal.
- **Footer redesign**: eyebrow-style mono column labels (consistent with section eyebrows), header-consistent geist wordmark, trust line mirroring the hero, unified column renderer, calmer bottom bar. All analytics events preserved.

Deliberately untouched: Hero slogan/choreography, FlowShowcase demo machinery + analytics, FounderStory copy (tests assert literal strings).

## Verification

- `pnpm --filter @memry/landing lint` — clean (1 pre-existing warning in auth-context)
- `pnpm --filter @memry/landing test` — 50/50 pass
- `pnpm --filter @memry/landing build` — typecheck + vite build + 45 routes prerendered, green
- Live browser visual pass not yet done — Vercel preview on this PR is the place to eyeball it