### PR TITLE
feat(calendar): apple-design pass — floating chrome, spring view transitions, press feedback

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -319,6 +319,31 @@
   }
 }
 
+/* Floating page chrome — translucent material over scrolling content.
+   Blur + tint are always on (invisible while nothing is beneath the bar);
+   the scroll edge (softened hairline + falloff) materializes via
+   [data-scrolled] only once content actually passes under it. */
+.page-chrome {
+  background: color-mix(in srgb, var(--background) 65%, transparent);
+  -webkit-backdrop-filter: blur(16px) saturate(180%);
+  backdrop-filter: blur(16px) saturate(180%);
+  transition: box-shadow 200ms var(--ease-out);
+}
+
+.page-chrome[data-scrolled] {
+  box-shadow:
+    0 1px 0 0 color-mix(in srgb, var(--border) 55%, transparent),
+    0 4px 16px -8px rgb(0 0 0 / 0.1);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .page-chrome {
+    background: var(--background);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
 /* Sticky toolbar mode - toolbar fixed at top of editor */
 .sticky-toolbar-enabled .bn-container {
   display: flex;

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-day-view.tsx
@@ -109,7 +109,7 @@ export function CalendarDayView({
           </div>
         </div>
       )}
-      <div ref={scrollRef} className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+      <div ref={scrollRef} data-calendar-scroll className="min-h-0 min-w-0 flex-1 overflow-y-auto">
         <div
           className="relative flex [--grid-line-color:var(--border)]"
           style={{ height: HOUR_HEIGHT * 24 }}
@@ -201,7 +201,7 @@ export function CalendarDayView({
                 className="pointer-events-none absolute start-0 end-0 z-20 flex items-center"
                 style={{ top: currentTimeOffset }}
               >
-                <div className="size-2 rounded-full bg-tint" />
+                <div className="size-2 rounded-full bg-tint shadow-[0_0_6px] shadow-tint/60" />
                 <div className="h-0.5 flex-1 bg-tint" />
               </div>
             )}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-item-chip.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-item-chip.tsx
@@ -48,8 +48,10 @@ export function CalendarItemChip({
   const VisualIcon = VISUAL_TYPE_ICONS[item.visualType]
   const deletable = Boolean(onDeleteItem) && canDeleteEvent(item)
   const cls = cn(
-    'flex h-full w-full items-start justify-between gap-0.5 rounded-[6px] px-1 py-0.5 text-start transition-[filter] @xl:px-2 @xl:py-1',
-    (onClick || deletable) && 'cursor-pointer hover:brightness-100',
+    'flex h-full w-full items-start justify-between gap-0.5 rounded-[6px] px-1 py-0.5 text-start @xl:px-2 @xl:py-1',
+    'transition-[filter,transform] duration-100 ease-out',
+    (onClick || deletable) &&
+      'cursor-pointer hover:brightness-[1.06] active:scale-[0.98] active:brightness-[0.97]',
     // Fired note_date chips are kept but faded so the date isn't lost.
     item.isTriggered && 'opacity-60'
   )

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-shell.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
+import { motion, useReducedMotion } from 'motion/react'
 import { useT } from '@memry/i18n/renderer'
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -133,6 +135,59 @@ export function CalendarShell({
   const [isRefreshing, setIsRefreshing] = useState(false)
   const { t } = useT('calendar')
   const hasGoogleCalendars = importedSources.length > 0
+  const prefersReducedMotion = useReducedMotion()
+
+  // Scroll-edge state for the floating chrome: true once content is beneath it.
+  // Views own their scroll containers (marked data-calendar-scroll); capture-phase
+  // listening reaches them all without prop drilling.
+  const [isScrolled, setIsScrolled] = useState(false)
+  const handleScrollCapture = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const target = e.target
+    if (!(target instanceof HTMLElement) || !target.hasAttribute('data-calendar-scroll')) return
+    setIsScrolled(target.scrollTop > 0)
+  }, [])
+
+  // One key per rendered period: prev/next remounts the grid so it can slide in
+  // the direction of travel; a view switch materializes in place instead. Week is
+  // keyed on view only — its infinite scroller animates anchor changes itself.
+  const motionKey =
+    view === 'week'
+      ? 'week'
+      : view === 'day'
+        ? `day:${anchorDate}`
+        : view === 'month'
+          ? `month:${anchorDate.slice(0, 7)}`
+          : `year:${anchorDate.slice(0, 4)}`
+  const transitionRef = useRef<{
+    key: string
+    view: CalendarWorkspaceView
+    anchorDate: string
+    initial: { opacity: number; x?: number; y?: number } | null
+  }>({ key: motionKey, view, anchorDate, initial: null })
+  if (transitionRef.current.key !== motionKey) {
+    const sameView = transitionRef.current.view === view
+    const forward = anchorDate >= transitionRef.current.anchorDate
+    // New period/view mounts unscrolled — drop the chrome edge with it
+    setIsScrolled(false)
+    transitionRef.current = {
+      key: motionKey,
+      view,
+      anchorDate,
+      initial: prefersReducedMotion
+        ? { opacity: 0 }
+        : sameView
+          ? { opacity: 0, x: forward ? 20 : -20 }
+          : { opacity: 0, y: 8 }
+    }
+  } else if (
+    transitionRef.current.view !== view ||
+    transitionRef.current.anchorDate !== anchorDate
+  ) {
+    // Same key (week anchor changes): keep the baseline current without animating
+    transitionRef.current = { ...transitionRef.current, view, anchorDate }
+  }
+  const viewInitial =
+    transitionRef.current.initial ?? (prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8 })
 
   const handleRefreshGoogle = async (): Promise<void> => {
     if (isRefreshing) return
@@ -258,50 +313,72 @@ export function CalendarShell({
 
   return (
     <div
-      className="@container flex h-full min-h-0 flex-col bg-background"
+      className="@container relative flex h-full min-h-0 flex-col bg-background"
       data-testid="calendar-page"
+      onScrollCapture={handleScrollCapture}
     >
-      <CalendarToolbar
-        view={view}
-        anchorDate={anchorDate}
-        onViewChange={onViewChange}
-        onPrevious={onPrevious}
-        onNext={onNext}
-        onToday={onToday}
-        onCreateEvent={onCreateEvent}
-        onSearchJump={onSearchJump}
-        extraActions={
-          <>
-            {googleConnectAction}
-            {refreshButton}
-            {filterPopover}
-          </>
-        }
-      />
+      {/* Floating chrome — translucent material; the year grid scrolls beneath it */}
+      <div
+        data-scrolled={isScrolled || undefined}
+        className="page-chrome absolute inset-x-0 top-0 z-30"
+      >
+        <CalendarToolbar
+          view={view}
+          anchorDate={anchorDate}
+          onViewChange={onViewChange}
+          onPrevious={onPrevious}
+          onNext={onNext}
+          onToday={onToday}
+          onCreateEvent={onCreateEvent}
+          onSearchJump={onSearchJump}
+          extraActions={
+            <>
+              {googleConnectAction}
+              {refreshButton}
+              {filterPopover}
+            </>
+          }
+        />
+      </div>
 
-      <div className="min-h-0 flex-1">
+      {/* Year owns its offset inside the scroller so months pass under the chrome */}
+      <div className={cn('min-h-0 flex-1 overflow-x-clip', view !== 'year' && 'pt-12')}>
         {isLoading ? (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
             {t('state.loading-calendar')}
           </div>
-        ) : view === 'day' ? (
-          <CalendarDayView {...chipViewProps} onMoveEvent={onMoveEvent} onQuickSave={onQuickSave} />
-        ) : view === 'week' ? (
-          <CalendarWeekView
-            {...chipViewProps}
-            onMoveEvent={onMoveEvent}
-            todayRequestKey={todayRequestKey}
-            onQuickSave={onQuickSave}
-            onVisibleDayStartChange={(_, startDate) => onWeekVisibleRangeChange?.(startDate)}
-          />
-        ) : view === 'month' ? (
-          <CalendarMonthView {...chipViewProps} onQuickSave={onQuickSave} />
         ) : (
-          <CalendarYearView
-            {...viewProps}
-            onViewChange={onViewChange}
-            onAnchorChange={onAnchorChange}
-          />
+          <motion.div
+            key={motionKey}
+            initial={viewInitial}
+            animate={{ opacity: 1, x: 0, y: 0 }}
+            transition={{ type: 'spring', bounce: 0, duration: 0.35 }}
+            className="h-full"
+          >
+            {view === 'day' ? (
+              <CalendarDayView
+                {...chipViewProps}
+                onMoveEvent={onMoveEvent}
+                onQuickSave={onQuickSave}
+              />
+            ) : view === 'week' ? (
+              <CalendarWeekView
+                {...chipViewProps}
+                onMoveEvent={onMoveEvent}
+                todayRequestKey={todayRequestKey}
+                onQuickSave={onQuickSave}
+                onVisibleDayStartChange={(_, startDate) => onWeekVisibleRangeChange?.(startDate)}
+              />
+            ) : view === 'month' ? (
+              <CalendarMonthView {...chipViewProps} onQuickSave={onQuickSave} />
+            ) : (
+              <CalendarYearView
+                {...viewProps}
+                onViewChange={onViewChange}
+                onAnchorChange={onAnchorChange}
+              />
+            )}
+          </motion.div>
         )}
       </div>
 

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-toolbar.tsx
@@ -1,6 +1,9 @@
+import { useId } from 'react'
+import { LayoutGroup, motion, useReducedMotion } from 'motion/react'
 import { useT } from '@memry/i18n/renderer'
 import { Button } from '@/components/ui/button'
 import { ChevronLeft, ChevronRight, Plus } from '@/lib/icons'
+import { cn } from '@/lib/utils'
 import type { CalendarProjectionItem } from '@/services/calendar-service'
 import { parseLocalDate } from './date-utils'
 import { CalendarSearch } from './calendar-search'
@@ -41,13 +44,95 @@ export function CalendarToolbar({
   extraActions
 }: CalendarToolbarProps): React.JSX.Element {
   const { t, i18n } = useT('calendar')
+  const prefersReducedMotion = useReducedMotion()
+  const layoutGroupId = useId()
   const anchorParsed = parseLocalDate(anchorDate)
   const monthName = new Intl.DateTimeFormat(i18n.language, { month: 'long' }).format(anchorParsed)
   const yearStr = String(anchorParsed.getFullYear())
 
   return (
-    <div className="flex flex-col gap-2 bg-background px-3 py-2 @xl:gap-4 @xl:px-6 @xl:py-4">
-      <div className="flex items-center justify-between">
+    <div className="flex h-12 items-center gap-1.5 px-3 @xl:gap-2.5 @xl:px-6">
+      <h2 className="min-w-0 truncate text-base font-bold tracking-tight text-foreground @xl:text-lg">
+        {view === 'year' ? (
+          yearStr
+        ) : (
+          <>
+            {monthName} <span className="font-normal text-muted-foreground">{yearStr}</span>
+          </>
+        )}
+      </h2>
+
+      <div className="min-w-2 flex-1" />
+
+      {/* View switcher — the active pill springs between options instead of teleporting */}
+      <LayoutGroup id={layoutGroupId}>
+        <div className="flex shrink-0 items-center rounded-full bg-surface-active/80 p-0.5">
+          {VIEW_OPTIONS.map((option) => {
+            const isActive = view === option
+            return (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => onViewChange(option)}
+                className={cn(
+                  'relative rounded-full px-2.5 py-1 text-xs font-medium',
+                  'transition-colors duration-150 ease-out active:scale-[0.97] @xl:px-3',
+                  isActive ? 'text-tint-foreground' : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {isActive && (
+                  <motion.span
+                    layoutId="calendar-view-pill"
+                    aria-hidden="true"
+                    transition={
+                      prefersReducedMotion
+                        ? { duration: 0 }
+                        : { type: 'spring', bounce: 0, duration: 0.35 }
+                    }
+                    className="absolute inset-0 rounded-full bg-tint"
+                  />
+                )}
+                <span className="relative z-10">{t(VIEW_LABEL_KEYS[option])}</span>
+              </button>
+            )
+          })}
+        </div>
+      </LayoutGroup>
+
+      <div className="flex shrink-0 items-center rounded-full bg-surface-active/80">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="rounded-full text-muted-foreground transition-all duration-150 ease-out hover:bg-surface-active hover:text-foreground active:scale-95"
+          onClick={onPrevious}
+          aria-label={t('toolbar.previous-period')}
+        >
+          <ChevronLeft className="size-4" />
+        </Button>
+        <button
+          type="button"
+          onClick={onToday}
+          className="px-2 py-1 text-xs font-medium text-muted-foreground transition-all duration-150 ease-out hover:text-foreground active:scale-95 @xl:px-3 @xl:text-sm"
+        >
+          {t('toolbar.today')}
+        </button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="rounded-full text-muted-foreground transition-all duration-150 ease-out hover:bg-surface-active hover:text-foreground active:scale-95"
+          onClick={onNext}
+          aria-label={t('toolbar.next-period')}
+        >
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1 @xl:gap-1.5">
+        {extraActions}
+        <CalendarSearch onJump={onSearchJump} />
         <button
           type="button"
           onClick={(event) => {
@@ -59,76 +144,11 @@ export function CalendarToolbar({
               height: rect.height
             })
           }}
-          className="flex size-9 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors hover:border-muted-foreground hover:text-foreground"
+          className="flex size-8 shrink-0 items-center justify-center rounded-full bg-tint text-tint-foreground shadow-sm transition-all duration-150 ease-out hover:brightness-110 active:scale-95"
           aria-label={t('toolbar.create-event')}
         >
           <Plus className="size-4" />
         </button>
-
-        <div className="flex items-center rounded-full bg-surface-active/80 p-0.5">
-          {VIEW_OPTIONS.map((option) => (
-            <button
-              key={option}
-              type="button"
-              onClick={() => onViewChange(option)}
-              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                view === option
-                  ? 'bg-tint text-tint-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {t(VIEW_LABEL_KEYS[option])}
-            </button>
-          ))}
-        </div>
-
-        <div className="flex items-center gap-1.5">
-          {extraActions}
-          <CalendarSearch onJump={onSearchJump} />
-        </div>
-      </div>
-
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg tracking-tight @xl:text-2xl">
-          {view === 'year' ? (
-            <span className="font-bold text-foreground">{yearStr}</span>
-          ) : (
-            <>
-              <span className="font-bold text-foreground">{monthName}</span>{' '}
-              <span className="font-normal text-muted-foreground">{yearStr}</span>
-            </>
-          )}
-        </h2>
-
-        <div className="flex items-center rounded-full bg-surface-active/80">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            className="rounded-full text-muted-foreground hover:bg-surface-active hover:text-foreground"
-            onClick={onPrevious}
-            aria-label={t('toolbar.previous-period')}
-          >
-            <ChevronLeft className="size-4" />
-          </Button>
-          <button
-            type="button"
-            onClick={onToday}
-            className="px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-          >
-            {t('toolbar.today')}
-          </button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            className="rounded-full text-muted-foreground hover:bg-surface-active hover:text-foreground"
-            onClick={onNext}
-            aria-label={t('toolbar.next-period')}
-          >
-            <ChevronRight className="size-4" />
-          </Button>
-        </div>
       </div>
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-week-view.tsx
@@ -360,6 +360,7 @@ export function CalendarWeekView({
 
         <div
           ref={scrollContainerRef}
+          data-calendar-scroll
           className="scrollbar-none relative min-w-0 flex-1 overflow-auto"
           data-testid="calendar-week-scroll"
         >
@@ -444,7 +445,7 @@ export function CalendarWeekView({
                       className="pointer-events-none absolute start-0 end-0 z-20 flex items-center"
                       style={{ top: currentTimeOffset }}
                     >
-                      <div className="size-2 rounded-full bg-tint" />
+                      <div className="size-2 rounded-full bg-tint shadow-[0_0_6px] shadow-tint/60" />
                       <div className="h-0.5 flex-1 bg-tint" />
                     </div>
                   )}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-year-view.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-year-view.tsx
@@ -127,15 +127,17 @@ export function CalendarYearView({
         if (!open) setPopoverDay(null)
       }}
     >
+      {/* pt clears the floating chrome so months scroll beneath its material */}
       <section
-        className="h-full overflow-y-auto px-3 py-3 @lg:px-6 @lg:py-4 @3xl:px-8 @3xl:py-6"
+        data-calendar-scroll
+        className="h-full overflow-y-auto px-3 pb-3 pt-14 @lg:px-6 @lg:pb-4 @3xl:px-8 @3xl:pb-6"
         data-testid="calendar-view"
         data-view="year"
       >
         <div className="grid grid-cols-2 gap-4 @lg:grid-cols-3 @lg:gap-x-6 @lg:gap-y-6 @3xl:grid-cols-4 @3xl:gap-x-10 @3xl:gap-y-8">
           {months.map((month) => (
             <div key={month.monthAnchor}>
-              <h3 className="mb-2 text-sm font-semibold text-red-400">{month.label}</h3>
+              <h3 className="mb-2 text-sm font-semibold tracking-tight text-tint">{month.label}</h3>
 
               <div className="mb-1 grid grid-cols-7">
                 {dayHeaders.map((header, i) => (
@@ -168,7 +170,7 @@ export function CalendarYearView({
                       <span
                         className={cn(
                           'flex size-5 items-center justify-center rounded-full text-[10px] @lg:size-7 @lg:text-xs',
-                          today && 'bg-red-500/90 font-semibold text-white',
+                          today && 'bg-tint font-semibold text-tint-foreground',
                           !today && inMonth && 'text-foreground hover:bg-surface-active',
                           !today && !inMonth && 'text-muted-foreground'
                         )}
@@ -176,7 +178,7 @@ export function CalendarYearView({
                         {dayNum}
                       </span>
                       {hasEvents && !today && (
-                        <span className="absolute bottom-0 size-1 rounded-full bg-red-400" />
+                        <span className="absolute bottom-0 size-1 rounded-full bg-tint" />
                       )}
                     </button>
                   )


### PR DESCRIPTION
## What
- Toolbar collapses to a single-row floating translucent chrome (`.page-chrome`) with a scroll-edge shadow; view-switcher pill springs between day/week/month/year
- Views spring-materialize on switch and slide in the direction of travel on prev/next (week keeps its own smooth scroll, never remounts)
- Year grid scrolls beneath the chrome; red-400/500 hardcodes → tint tokens
- Event chips get instant press feedback; reduced-motion → crossfade, reduced-transparency → solid chrome

## Why
Calendar page pass of the apple-design series (inbox/note/home).

Docs gate skipped: purely visual, no behavior change.