### PR TITLE
feat(home): apple-design pass — floating chrome, spring motion, widget craft

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/board-empty-state.tsx
+++ b/apps/desktop/src/renderer/src/components/home/board-empty-state.tsx
@@ -1,3 +1,4 @@
+import { motion, useReducedMotion } from 'motion/react'
 import { Button } from '@/components/ui/button'
 import { Plus } from '@/lib/icons/icon-map'
 import { useT } from '@memry/i18n/renderer'
@@ -13,14 +14,18 @@ interface BoardEmptyStateProps {
  */
 export function BoardEmptyState({ onAddFirstWidget }: BoardEmptyStateProps): React.JSX.Element {
   const { t } = useT('common')
+  const reduceMotion = useReducedMotion()
   return (
-    <div
+    <motion.div
       data-testid="board-empty-state"
-      className="mx-auto flex max-w-sm flex-col items-center gap-3 px-6 py-16 text-center motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200"
+      className="mx-auto flex max-w-sm flex-col items-center gap-3 px-6 py-20 text-center"
+      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.97, filter: 'blur(6px)' }}
+      animate={reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1, filter: 'blur(0px)' }}
+      transition={{ type: 'spring', bounce: 0, duration: 0.5 }}
     >
       <div
         aria-hidden="true"
-        className="flex size-11 items-center justify-center rounded-full bg-muted text-muted-foreground"
+        className="flex size-12 items-center justify-center rounded-full bg-[color-mix(in_srgb,var(--tint)_12%,transparent)] text-[var(--tint)]"
       >
         <Plus className="size-5" />
       </div>
@@ -33,11 +38,11 @@ export function BoardEmptyState({ onAddFirstWidget }: BoardEmptyStateProps): Rea
         size="sm"
         data-testid="board-empty-cta"
         onClick={onAddFirstWidget}
-        className="mt-1"
+        className="mt-1 motion-safe:active:scale-[0.97]"
       >
         <Plus className="size-4" aria-hidden="true" />
         {t('home.empty.cta')}
       </Button>
-    </div>
+    </motion.div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/home/board-grid.tsx
+++ b/apps/desktop/src/renderer/src/components/home/board-grid.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { motion, useReducedMotion } from 'motion/react'
 import {
   Responsive,
   WidthProvider,
@@ -47,6 +48,7 @@ function unchanged(board: HomePage, next: Layout): boolean {
 
 export function BoardGrid({ board, onChange }: BoardGridProps): React.JSX.Element {
   const { t } = useT('common')
+  const reduceMotion = useReducedMotion()
 
   const layout: Layout = useMemo(
     () =>
@@ -90,41 +92,59 @@ export function BoardGrid({ board, onChange }: BoardGridProps): React.JSX.Elemen
       isBounded
       onLayoutChange={handleLayoutChange}
     >
-      {board.widgets.map((w) => {
+      {board.widgets.map((w, index) => {
         const def = WIDGET_REGISTRY[w.type]
         const size = sizeTier(w.w, w.h)
         // react-grid-layout clones this plain wrapper div (injecting position styles, drag handlers,
         // and appending the resize handle). Keeping it a vanilla element — rather than letting RGL
-        // clone WidgetFrame directly — is what makes drag/resize wiring reliable.
+        // clone WidgetFrame directly — is what makes drag/resize wiring reliable. The materialize
+        // animation therefore lives on an inner motion.div: RGL owns the wrapper's transform for
+        // positioning, so the two never fight over the same element.
         return (
           <div key={w.id} className="overflow-visible">
-            {def ? (
-              <WidgetFrame
-                widget={w}
-                size={size}
-                title={t(def.titleKey)}
-                icon={def.icon}
-                onRemove={() => onChange(removeWidget(board, w.id))}
-                ConfigEditor={def.ConfigEditor}
-                HeaderFilter={def.HeaderFilter}
-                HeaderCount={def.HeaderCount}
-                Footer={def.Footer}
-                onConfigChange={(cfg) => onChange(updateWidgetConfig(board, w.id, cfg))}
-                content={<def.Component config={w.config} size={size} />}
-              />
-            ) : (
-              <WidgetFrame
-                widget={w}
-                size={size}
-                title={t('home.widget.unknown')}
-                onRemove={() => onChange(removeWidget(board, w.id))}
-                content={
-                  <p data-testid="widget-unknown" className="text-sm text-muted-foreground">
-                    {t('home.widget.unknown')}
-                  </p>
-                }
-              />
-            )}
+            <motion.div
+              className="h-full w-full"
+              initial={
+                reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96, filter: 'blur(6px)' }
+              }
+              animate={
+                reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1, filter: 'blur(0px)' }
+              }
+              transition={{
+                type: 'spring',
+                bounce: 0,
+                duration: 0.45,
+                delay: Math.min(index * 0.04, 0.32)
+              }}
+            >
+              {def ? (
+                <WidgetFrame
+                  widget={w}
+                  size={size}
+                  title={t(def.titleKey)}
+                  icon={def.icon}
+                  onRemove={() => onChange(removeWidget(board, w.id))}
+                  ConfigEditor={def.ConfigEditor}
+                  HeaderFilter={def.HeaderFilter}
+                  HeaderCount={def.HeaderCount}
+                  Footer={def.Footer}
+                  onConfigChange={(cfg) => onChange(updateWidgetConfig(board, w.id, cfg))}
+                  content={<def.Component config={w.config} size={size} />}
+                />
+              ) : (
+                <WidgetFrame
+                  widget={w}
+                  size={size}
+                  title={t('home.widget.unknown')}
+                  onRemove={() => onChange(removeWidget(board, w.id))}
+                  content={
+                    <p data-testid="widget-unknown" className="text-sm text-muted-foreground">
+                      {t('home.widget.unknown')}
+                    </p>
+                  }
+                />
+              )}
+            </motion.div>
           </div>
         )
       })}

--- a/apps/desktop/src/renderer/src/components/home/home-grid.css
+++ b/apps/desktop/src/renderer/src/components/home/home-grid.css
@@ -1,10 +1,67 @@
 /* Overrides for react-grid-layout on the Home board. Loaded after the library's base styles. */
 
-/* Drag/resize placeholder under the moving widget. */
+/* Floating header chrome (mounted in home.tsx): sticky above the board, content scrolls under it.
+   backdrop-filter stays on permanently — at rest nothing sits underneath, so it's invisible; only
+   the background/edge fade in once content overlaps (data-scrolled). Toggling the filter itself
+   would pop, transitioning background-color doesn't. */
+.home-chrome {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  background: transparent;
+  -webkit-backdrop-filter: blur(20px) saturate(1.8);
+  backdrop-filter: blur(20px) saturate(1.8);
+  transition:
+    background-color 240ms ease,
+    box-shadow 240ms ease;
+}
+.home-chrome[data-scrolled='true'] {
+  background: color-mix(in srgb, var(--background) 75%, transparent);
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--border) 70%, transparent);
+}
+@media (prefers-reduced-transparency: reduce) {
+  .home-chrome {
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+  .home-chrome[data-scrolled='true'] {
+    background: var(--background);
+  }
+}
+
+/* Drag/resize placeholder under the moving widget. Radius matches the card (rounded-2xl). */
 .home-grid .react-grid-placeholder {
   background: var(--tint);
   opacity: 0.12;
-  border-radius: 0.75rem;
+  border-radius: 1rem;
+}
+
+/* Reflow: when other widgets make room they settle with a decelerating ease-out instead of RGL's
+   default. The dragging item itself must keep transition: none so it tracks the pointer 1:1. */
+.home-grid .react-grid-item.cssTransforms {
+  transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.home-grid .react-grid-item.react-draggable-dragging {
+  transition: none;
+  z-index: 20;
+}
+
+/* Pickup: lift the card (scale + deeper shadow) while dragged or resized. Applied to the inner
+   card, not the RGL item — the item's transform is position-owned by RGL. */
+.home-grid .react-grid-item [data-testid='widget'] {
+  transition:
+    transform 200ms cubic-bezier(0.2, 0, 0, 1),
+    box-shadow 200ms cubic-bezier(0.2, 0, 0, 1);
+}
+.home-grid .react-grid-item.react-draggable-dragging [data-testid='widget'] {
+  transform: scale(1.02);
+  box-shadow: 0 24px 48px -20px color-mix(in srgb, black 35%, transparent);
+}
+.home-grid .react-grid-item.react-draggable-dragging .widget-drag-handle {
+  cursor: grabbing;
+}
+.home-grid .react-grid-item.resizing [data-testid='widget'] {
+  box-shadow: 0 16px 40px -20px color-mix(in srgb, black 28%, transparent);
 }
 
 /* Resize grip: replace RGL's default corner arrow with a subtle always-on grip. */
@@ -27,10 +84,14 @@
   border-end-end-radius: 3px;
 }
 
-/* Respect reduced-motion: drop RGL's slide animation. */
+/* Respect reduced-motion: drop RGL's slide animation and the pickup lift. */
 @media (prefers-reduced-motion: reduce) {
   .home-grid .react-grid-item.cssTransforms,
-  .home-grid .react-grid-item {
+  .home-grid .react-grid-item,
+  .home-grid .react-grid-item [data-testid='widget'] {
     transition: none !important;
+  }
+  .home-grid .react-grid-item.react-draggable-dragging [data-testid='widget'] {
+    transform: none;
   }
 }

--- a/apps/desktop/src/renderer/src/components/home/home-header.tsx
+++ b/apps/desktop/src/renderer/src/components/home/home-header.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from 'react'
+import { motion, useReducedMotion } from 'motion/react'
 import { useT } from '@memry/i18n/renderer'
 import { useTaskWorkspaceData } from '@/features/tasks/use-task-queries'
 import { getTaskCounts } from '@/lib/task-utils/task-view-helpers'
@@ -53,6 +54,7 @@ export function HomeHeader({
   onAddWidget
 }: HomeHeaderProps): React.JSX.Element {
   const { t, i18n } = useT('common')
+  const reduceMotion = useReducedMotion()
 
   const { tasks, projects } = useTaskWorkspaceData({ enabled: true })
   const tasksDue = getTaskCounts(tasks, 'today', 'view', projects).dueToday
@@ -73,8 +75,13 @@ export function HomeHeader({
 
   return (
     <div className="flex items-end justify-between px-6 pt-7 pb-5.5 [font-synthesis:none] antialiased">
-      <div className="flex flex-col gap-2">
-        <h1 className="font-serif font-semibold tracking-[-0.01em] text-foreground text-[30px]/8">
+      <motion.div
+        className="flex flex-col gap-2"
+        initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 10, filter: 'blur(6px)' }}
+        animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0, filter: 'blur(0px)' }}
+        transition={{ type: 'spring', bounce: 0, duration: 0.55 }}
+      >
+        <h1 className="font-serif font-semibold tracking-[-0.022em] text-foreground text-[34px]/10">
           {greeting}
         </h1>
         <div className="flex items-center gap-2.5">
@@ -91,13 +98,13 @@ export function HomeHeader({
             </Fragment>
           ))}
         </div>
-      </div>
+      </motion.div>
       <div className="flex items-center gap-2">
         <DropdownMenu>
           <DropdownMenuTrigger
             data-testid="home-layout-switcher"
             aria-label={t('home.board.label')}
-            className="flex h-7.5 items-center gap-1.5 rounded-full border border-border bg-card px-2.75 text-text-secondary text-[12px]/4 transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
+            className="flex h-7.5 items-center gap-1.5 rounded-full border border-border bg-card px-2.75 text-text-secondary text-[12px]/4 transition-[background-color,transform] duration-100 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)] motion-safe:active:scale-[0.96]"
           >
             <span className="max-w-40 truncate font-medium">{activeName}</span>
             <ChevronDown className="size-3.5 shrink-0 opacity-70" aria-hidden="true" />
@@ -143,7 +150,7 @@ export function HomeHeader({
               data-testid="add-widget-trigger"
               aria-label={t('home.addWidget')}
               title={t('home.addWidget')}
-              className="flex size-7.5 items-center justify-center rounded-full border border-border bg-card text-text-secondary transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
+              className="flex size-7.5 items-center justify-center rounded-full border border-border bg-card text-text-secondary transition-[background-color,transform] duration-100 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)] motion-safe:active:scale-[0.96]"
             >
               <Plus className="size-4" aria-hidden="true" />
             </DropdownMenuTrigger>

--- a/apps/desktop/src/renderer/src/components/home/widget-frame.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widget-frame.tsx
@@ -31,7 +31,8 @@ interface WidgetFrameProps {
 // Rendered INSIDE the plain wrapper div that react-grid-layout clones (see board-grid). The card
 // fills that wrapper; the drag handle is the header, and RGL's resize handle is a sibling appended
 // to the wrapper (styled in home-grid.css). Keeping this a normal component — not RGL's cloned
-// child — is what keeps drag/resize reliably wired.
+// child — is what keeps drag/resize reliably wired. Pickup elevation (drag/resize lift) is driven
+// from home-grid.css off RGL's state classes on the wrapper.
 export function WidgetFrame({
   widget,
   size,
@@ -55,7 +56,8 @@ export function WidgetFrame({
       data-widget-size={size}
       data-widget-id={widget.id}
       className={cn(
-        'group/widget relative flex h-full w-full flex-col overflow-hidden rounded-xl border bg-card'
+        'group/widget relative flex h-full w-full flex-col overflow-hidden rounded-2xl border bg-card',
+        'shadow-[0_1px_2px_rgba(0,0,0,0.03),0_12px_32px_-24px_rgba(0,0,0,0.16)]'
       )}
     >
       {/* Header is the drag handle (react-grid-layout draggableHandle=".widget-drag-handle").
@@ -85,7 +87,7 @@ export function WidgetFrame({
               type="button"
               data-testid="widget-menu"
               aria-label={t('home.widget.menuAria')}
-              className="widget-no-drag inline-flex size-7 shrink-0 items-center justify-center rounded text-[var(--text-tertiary)] transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
+              className="widget-no-drag inline-flex size-7 shrink-0 items-center justify-center rounded text-[var(--text-tertiary)] transition-[background-color,transform] duration-100 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)] motion-safe:active:scale-90"
             >
               <MoreVertical className="size-4" aria-hidden="true" />
             </button>

--- a/apps/desktop/src/renderer/src/components/home/widgets/bookmarks-widget.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/bookmarks-widget.tsx
@@ -3,7 +3,8 @@ import { useBookmarks } from '@/hooks/use-bookmarks'
 import { useTabActions } from '@/contexts/tabs/context'
 import type { WidgetComponentProps } from '@/lib/home/widget-registry'
 import { Skeleton } from '@/components/ui/skeleton'
-import { CheckSquare, FileText, BookOpen } from '@/lib/icons/icon-map'
+import { CheckSquare, FileText, BookOpen, Bookmark } from '@/lib/icons/icon-map'
+import { WidgetRow, WidgetEmptyState } from './widget-list'
 import { useT } from '@memry/i18n/renderer'
 
 const ICON_BY_TYPE: Record<string, typeof FileText> = {
@@ -36,21 +37,21 @@ export function BookmarksWidget({ config, size }: WidgetComponentProps): React.J
     )
 
   if (bookmarks.length === 0)
-    return <div className="text-xs text-muted-foreground">{t('home.noBookmarksYet')}</div>
+    return <WidgetEmptyState icon={Bookmark} label={t('home.noBookmarksYet')} />
 
   return (
     <ul className="flex flex-col gap-0.5">
-      {bookmarks.slice(0, limit).map((b) => {
+      {bookmarks.slice(0, limit).map((b, index) => {
         const Icon = ICON_BY_TYPE[b.itemType] ?? FileText
         const typeLabel = b.itemType.charAt(0).toUpperCase() + b.itemType.slice(1)
         return (
-          <li key={b.id}>
+          <WidgetRow key={b.id} index={index}>
             <button
               type="button"
               data-testid="bookmark-item"
               data-item-id={b.itemId}
               data-item-type={b.itemType}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-start text-[13px] hover:bg-muted/60"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-start text-[13px] hover:bg-muted/60 active:bg-muted focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
               onClick={() =>
                 openTab(
                   b.itemType === 'task'
@@ -85,7 +86,7 @@ export function BookmarksWidget({ config, size }: WidgetComponentProps): React.J
                 {b.itemTitle ?? t('home.widget.untitled')}
               </span>
             </button>
-          </li>
+          </WidgetRow>
         )
       })}
     </ul>

--- a/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/calendar-widget.tsx
@@ -13,6 +13,8 @@ import {
 import type { WidgetComponentProps } from '@/lib/home/widget-registry'
 import { Skeleton } from '@/components/ui/skeleton'
 import { extractErrorMessage } from '@/lib/ipc-error'
+import { Calendar } from '@/lib/icons/icon-map'
+import { WidgetRow, WidgetEmptyState } from './widget-list'
 import { useT } from '@memry/i18n/renderer'
 
 export function CalendarWidget({ size }: WidgetComponentProps): React.JSX.Element {
@@ -47,8 +49,7 @@ export function CalendarWidget({ size }: WidgetComponentProps): React.JSX.Elemen
       </div>
     )
 
-  if (events.length === 0)
-    return <div className="text-xs text-muted-foreground">{t('home.noEventsYet')}</div>
+  if (events.length === 0) return <WidgetEmptyState icon={Calendar} label={t('home.noEventsYet')} />
 
   const limit = size === 'L' ? 12 : 6
   const visible = events.slice(0, limit)
@@ -79,8 +80,9 @@ export function CalendarWidget({ size }: WidgetComponentProps): React.JSX.Elemen
     const isNext = i === nextIndex
     const sub = subtitle(ev)
     rows.push(
-      <li
+      <WidgetRow
         key={ev.id}
+        index={i}
         data-testid="calendar-event"
         className={
           isNext
@@ -122,7 +124,7 @@ export function CalendarWidget({ size }: WidgetComponentProps): React.JSX.Elemen
             sub && <span className="truncate text-[11px] text-text-tertiary">{sub}</span>
           )}
         </span>
-      </li>
+      </WidgetRow>
     )
   })
   if (nowPos >= visible.length) rows.push(nowLine)

--- a/apps/desktop/src/renderer/src/components/home/widgets/inbox-widget.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/inbox-widget.tsx
@@ -3,13 +3,14 @@ import type { InboxListInput } from '@memry/rpc/inbox'
 import { useInboxList } from '@/hooks/use-inbox-queries'
 import { useArchiveInboxItem } from '@/hooks/use-inbox-mutations'
 import { useTabActions } from '@/contexts/tabs/context'
-import { Archive } from '@/lib/icons/icon-map'
+import { Archive, Inbox } from '@/lib/icons/icon-map'
 import { Skeleton } from '@/components/ui/skeleton'
 import { InboxTypeIcon } from '@/components/inbox/inbox-type-icon'
 import { formatTimeAgo } from '@/services/inbox-service'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import type { WidgetComponentProps } from '@/lib/home/widget-registry'
 import { inboxWidgetLimit } from '@/lib/home/inbox-widget-filter'
+import { WidgetRow, WidgetEmptyState } from './widget-list'
 import type { InboxItemType } from '@/types'
 import { useT } from '@memry/i18n/renderer'
 
@@ -58,18 +59,18 @@ export function InboxWidget({ config, size }: WidgetComponentProps): React.JSX.E
     )
 
   if (items.length === 0)
-    return <div className="text-xs text-muted-foreground">{tInbox('empty.noItemsYet')}</div>
+    return <WidgetEmptyState icon={Inbox} label={tInbox('empty.noItemsYet')} />
 
   return (
     <ul className="flex flex-col gap-0.5">
-      {items.slice(0, limit).map((item) => (
-        <li key={item.id} className="flex items-center gap-1">
+      {items.slice(0, limit).map((item, index) => (
+        <WidgetRow key={item.id} index={index} className="group/row flex items-center gap-1">
           <button
             type="button"
             data-testid="inbox-item"
             data-inbox-id={item.id}
             data-inbox-type={item.type}
-            className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1 text-start hover:bg-muted/60"
+            className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1 text-start hover:bg-muted/60 active:bg-muted focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
             onClick={() =>
               openTab({
                 type: 'inbox',
@@ -102,16 +103,17 @@ export function InboxWidget({ config, size }: WidgetComponentProps): React.JSX.E
               {formatTimeAgo(item.createdAt)}
             </span>
           </button>
+          {/* Quick action reveals on row hover/focus — keeps rows calm at rest, still keyboard-reachable. */}
           <button
             type="button"
             data-testid="inbox-archive"
             aria-label={tInbox('quickActions.archiveItem')}
-            className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            className="shrink-0 rounded-md p-1 text-muted-foreground opacity-0 transition-opacity duration-150 group-hover/row:opacity-100 group-focus-within/row:opacity-100 hover:bg-muted/60 hover:text-foreground focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)] motion-safe:active:scale-90"
             onClick={() => archive.mutate(item.id)}
           >
             <Archive className="size-3.5" />
           </button>
-        </li>
+        </WidgetRow>
       ))}
     </ul>
   )

--- a/apps/desktop/src/renderer/src/components/home/widgets/journal-widget.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/journal-widget.tsx
@@ -106,17 +106,18 @@ export function JournalWidget({ size }: WidgetComponentProps): React.JSX.Element
             type="button"
             onClick={() => openJournal(day.iso)}
             aria-label={day.iso}
-            className="flex flex-1 flex-col items-center gap-1.5 rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
+            className="group/day flex flex-1 flex-col items-center gap-1.5 rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
           >
             <span className="text-[10px] text-[var(--text-tertiary)]">{day.weekdayNarrow}</span>
+            {/* Press feedback on pointer-down (apple-design §1): the day circle dips, instantly. */}
             <span
-              className={
+              className={`transition-transform duration-100 motion-safe:group-active/day:scale-90 ${
                 day.isToday
                   ? 'flex size-8 items-center justify-center rounded-full bg-[var(--tint)] text-[12px] font-bold text-white'
                   : day.hasEntry
-                    ? 'flex size-8 items-center justify-center rounded-full bg-[var(--tint-light)] text-[12px] font-semibold text-[var(--tint)]'
-                    : 'flex size-8 items-center justify-center rounded-full border border-dashed text-[12px] text-[var(--text-tertiary)]'
-              }
+                    ? 'flex size-8 items-center justify-center rounded-full bg-[var(--tint-light)] text-[12px] font-semibold text-[var(--tint)] group-hover/day:bg-[var(--tint)]/20'
+                    : 'flex size-8 items-center justify-center rounded-full border border-dashed text-[12px] text-[var(--text-tertiary)] group-hover/day:border-solid group-hover/day:text-foreground/70'
+              }`}
             >
               {day.dayNum}
             </span>
@@ -141,7 +142,7 @@ export function JournalWidget({ size }: WidgetComponentProps): React.JSX.Element
               key={date}
               type="button"
               onClick={() => openJournal(date)}
-              className="flex flex-col gap-1 border-t py-2.5 text-start focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
+              className="-mx-2 flex flex-col gap-1 border-t px-2 py-2.5 text-start hover:bg-muted/40 active:bg-muted/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
             >
               <span className="flex items-center gap-1.5">
                 <span

--- a/apps/desktop/src/renderer/src/components/home/widgets/recently-edited-widget.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/recently-edited-widget.tsx
@@ -7,6 +7,7 @@ import { extractErrorMessage } from '@/lib/ipc-error'
 import { FileImage, FileText } from '@/lib/icons'
 import { formatRelative } from '@/components/folder-view/note-card-pieces'
 import { extractFolderFromPath } from '@/components/notes-tree-utils'
+import { WidgetRow, WidgetEmptyState } from './widget-list'
 import { useT } from '@memry/i18n/renderer'
 
 export function RecentlyEditedWidget({ size }: WidgetComponentProps): React.JSX.Element {
@@ -31,24 +32,23 @@ export function RecentlyEditedWidget({ size }: WidgetComponentProps): React.JSX.
       </div>
     )
 
-  if (notes.length === 0)
-    return <div className="text-xs text-muted-foreground">{t('home.noNotesYet')}</div>
+  if (notes.length === 0) return <WidgetEmptyState icon={FileText} label={t('home.noNotesYet')} />
 
   return (
     <ul className="flex flex-col gap-0.5">
-      {notes.slice(0, limit).map((n) => {
+      {notes.slice(0, limit).map((n, index) => {
         const folder = extractFolderFromPath(n.path)
         const time = n.modified ? formatRelative(n.modified.toISOString()) : ''
         const meta = folder
           ? t('home.widget.recentMetaWithFolder', { folder, time })
           : t('home.widget.recentMeta', { time })
         return (
-          <li key={n.id}>
+          <WidgetRow key={n.id} index={index}>
             <button
               type="button"
               data-testid="recent-note"
               data-note-id={n.id}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-start hover:bg-muted/60"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-start hover:bg-muted/60 active:bg-muted focus-visible:ring-1 focus-visible:ring-[var(--tint-ring)]"
               onClick={() =>
                 openTab({
                   type: 'note',
@@ -79,7 +79,7 @@ export function RecentlyEditedWidget({ size }: WidgetComponentProps): React.JSX.
                 </span>
               </span>
             </button>
-          </li>
+          </WidgetRow>
         )
       })}
     </ul>

--- a/apps/desktop/src/renderer/src/components/home/widgets/tasks-widget.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/tasks-widget.tsx
@@ -9,6 +9,8 @@ import { type Project } from '@/data/tasks-data'
 import type { WidgetComponentProps } from '@/lib/home/widget-registry'
 import { Skeleton } from '@/components/ui/skeleton'
 import { extractErrorMessage } from '@/lib/ipc-error'
+import { CheckSquare } from '@/lib/icons/icon-map'
+import { WidgetRow, WidgetEmptyState } from './widget-list'
 import { useT } from '@memry/i18n/renderer'
 
 export function TasksWidget({ config, size }: WidgetComponentProps): React.JSX.Element {
@@ -41,11 +43,11 @@ export function TasksWidget({ config, size }: WidgetComponentProps): React.JSX.E
     )
 
   if (filtered.length === 0)
-    return <div className="text-xs text-muted-foreground">{t('home.noTasksYet')}</div>
+    return <WidgetEmptyState icon={CheckSquare} label={t('home.noTasksYet')} />
 
   return (
     <ul className="flex flex-col gap-0.5">
-      {filtered.map((task) => {
+      {filtered.map((task, index) => {
         const project =
           projects.find((p) => p.id === task.projectId) ??
           ({
@@ -56,7 +58,7 @@ export function TasksWidget({ config, size }: WidgetComponentProps): React.JSX.E
           } as unknown as Project)
 
         return (
-          <li key={task.id} data-testid="task-item" data-task-id={task.id}>
+          <WidgetRow key={task.id} index={index} data-testid="task-item" data-task-id={task.id}>
             <TaskRow
               task={task}
               project={project}
@@ -83,7 +85,7 @@ export function TasksWidget({ config, size }: WidgetComponentProps): React.JSX.E
                 })
               }}
             />
-          </li>
+          </WidgetRow>
         )
       })}
     </ul>

--- a/apps/desktop/src/renderer/src/components/home/widgets/widget-list.tsx
+++ b/apps/desktop/src/renderer/src/components/home/widgets/widget-list.tsx
@@ -1,0 +1,56 @@
+import type { ComponentType, ReactNode } from 'react'
+import { motion, useReducedMotion } from 'motion/react'
+
+interface WidgetRowProps {
+  index: number
+  className?: string
+  children: ReactNode
+  'data-testid'?: string
+  'data-task-id'?: string
+}
+
+// Shared entrance for widget list rows: when data replaces the skeleton the rows rise in with a
+// short stagger instead of a hard cut. Critically damped — a list entrance carries no momentum,
+// so no overshoot. Collapses to a plain fade under reduced motion.
+export function WidgetRow({
+  index,
+  className,
+  children,
+  ...dataProps
+}: WidgetRowProps): React.JSX.Element {
+  const reduceMotion = useReducedMotion()
+  return (
+    <motion.li
+      className={className}
+      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 4 }}
+      animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+      transition={{
+        type: 'spring',
+        bounce: 0,
+        duration: 0.35,
+        delay: Math.min(index * 0.025, 0.2)
+      }}
+      {...dataProps}
+    >
+      {children}
+    </motion.li>
+  )
+}
+
+interface WidgetEmptyStateProps {
+  icon: ComponentType<{ className?: string }>
+  label: string
+}
+
+// Shared empty state: centered icon + label so an empty widget reads as a calm, deliberate
+// state instead of a stray line of text.
+export function WidgetEmptyState({ icon: Icon, label }: WidgetEmptyStateProps): React.JSX.Element {
+  return (
+    <div className="flex h-full min-h-20 flex-col items-center justify-center gap-1.5 py-3 text-center">
+      <span aria-hidden="true">
+        <Icon className="size-5 text-muted-foreground/40" />
+      </span>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/pages/home.tsx
+++ b/apps/desktop/src/renderer/src/pages/home.tsx
@@ -58,6 +58,9 @@ export default function HomePage(): React.JSX.Element {
   }, [openTab])
 
   const [galleryOpen, setGalleryOpen] = useState(false)
+  // The header floats over the board (.home-chrome, sticky); its material (blur + translucent
+  // background) only appears once content actually scrolls underneath it.
+  const [scrolled, setScrolled] = useState(false)
   const {
     boards,
     activeBoard,
@@ -106,39 +109,45 @@ export default function HomePage(): React.JSX.Element {
     setGalleryOpen(false)
   }
 
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    setScrolled(e.currentTarget.scrollTop > 4)
+  }
+
   return (
-    <div data-testid="home-page" className="flex h-full flex-col">
-      <HomeHeader
-        boards={localBoards}
-        activeBoardId={activeBoardId}
-        onSelectBoard={setActiveBoardId}
-        onCreateBoard={() => void createBoard(t('home.board.newName'))}
-        onDeleteBoard={(id) => void deleteBoard(id)}
-        showAddWidget={!isLoading && !!localActive}
-        galleryOpen={galleryOpen}
-        onGalleryOpenChange={setGalleryOpen}
-        onAddWidget={handleAddWidget}
-      />
+    <div data-testid="home-page" className="h-full overflow-auto" onScroll={handleScroll}>
+      <div className="home-chrome" data-scrolled={scrolled ? 'true' : 'false'}>
+        <HomeHeader
+          boards={localBoards}
+          activeBoardId={activeBoardId}
+          onSelectBoard={setActiveBoardId}
+          onCreateBoard={() => void createBoard(t('home.board.newName'))}
+          onDeleteBoard={(id) => void deleteBoard(id)}
+          showAddWidget={!isLoading && !!localActive}
+          galleryOpen={galleryOpen}
+          onGalleryOpenChange={setGalleryOpen}
+          onAddWidget={handleAddWidget}
+        />
+      </div>
       {isLoading && (
         <output
           data-testid="home-board-loading"
           aria-busy="true"
           aria-label={t('state.loading')}
-          className="min-h-0 flex-1 overflow-auto px-6 py-6"
+          className="block px-6 pt-6 pb-8"
         >
           <div
             className="grid auto-rows-[7rem] gap-3"
             style={{ gridTemplateColumns: 'repeat(4, minmax(0, 1fr))' }}
           >
-            <Skeleton className="col-span-2 row-span-2 h-full" />
-            <Skeleton className="col-span-2 row-span-2 h-full" />
-            <Skeleton className="col-span-1 h-full" />
-            <Skeleton className="col-span-1 h-full" />
+            <Skeleton className="col-span-2 row-span-2 h-full rounded-2xl" />
+            <Skeleton className="col-span-2 row-span-2 h-full rounded-2xl" />
+            <Skeleton className="col-span-1 h-full rounded-2xl" />
+            <Skeleton className="col-span-1 h-full rounded-2xl" />
           </div>
         </output>
       )}
       {!isLoading && localActive && (
-        <div className="min-h-0 flex-1 overflow-auto px-6 py-6">
+        <div className="px-6 pt-6 pb-8">
           <BoardGrid board={localActive} onChange={handleChange} />
           {localActive.widgets.length === 0 && (
             <BoardEmptyState onAddFirstWidget={handleAddFirstWidget} />


### PR DESCRIPTION
## What
- Home header becomes floating translucent chrome (sticky, backdrop-blur); board scrolls underneath, material appears only on overlap, with reduced-transparency fallback
- Widgets materialize with staggered critically-damped springs; drag/resize gets a physical pickup lift (scale + shadow) while the dragged item stays 1:1
- Widget bodies: shared WidgetRow (staggered row entrance) + WidgetEmptyState (icon + label); instant press states and tint focus rings on rows; inbox archive reveals on hover/focus
- Typography: greeting 34px/-0.022em; cards rounded-2xl with ambient shadow; reduced motion collapses all springs to fades

## Why
Home is the first screen — bringing it up to the apple-design interaction standard used on the note/journal and inbox passes.

Docs gate skipped (MEMRY_DOCS_IMPACT_SKIP=1): purely visual, no behavior/contract changes.