### PR TITLE
fix(calendar): notes off calendar by default + same-day note chip dedup

### DIFF
--- a/apps/desktop/src/main/calendar/projection.test.ts
+++ b/apps/desktop/src/main/calendar/projection.test.ts
@@ -602,6 +602,59 @@ describe('getCalendarRangeProjection', () => {
     expect(items.some((i) => i.projectionId === 'note-created:j1')).toBe(false)
   })
 
+  it('keeps only the property chip when a calendar-enabled date property lands on the creation day', () => {
+    indexDbResult.db.run(sql`
+      INSERT INTO note_cache (id, path, title, file_type, created_at, modified_at)
+      VALUES (${'n-both'}, ${'notes/plan.md'}, ${'Plan'}, ${'markdown'}, ${'2026-06-15T09:00:00.000Z'}, ${'2026-06-15T09:00:00.000Z'})
+    `)
+    indexDbResult.db.run(sql`
+      INSERT INTO note_properties (note_id, name, type, value)
+      VALUES (${'n-both'}, ${'Deadline'}, ${'date'}, ${'2026-06-15T09:00:00.000Z'})
+    `)
+
+    const { items } = getCalendarRangeProjection(
+      db as unknown as DataDb,
+      indexDb,
+      {
+        startAt: '2026-06-01T00:00:00.000Z',
+        endAt: '2026-07-01T00:00:00.000Z',
+        includeUnselectedSources: false
+      },
+      ['Deadline'],
+      true
+    )
+
+    const noteItems = items.filter((i) => i.sourceType === 'note')
+    expect(noteItems.map((i) => i.projectionId)).toEqual(['note:n-both:Deadline'])
+  })
+
+  it('keeps both chips when the date property falls on a different day than creation', () => {
+    indexDbResult.db.run(sql`
+      INSERT INTO note_cache (id, path, title, file_type, created_at, modified_at)
+      VALUES (${'n-later'}, ${'notes/launch.md'}, ${'Launch'}, ${'markdown'}, ${'2026-06-15T09:00:00.000Z'}, ${'2026-06-15T09:00:00.000Z'})
+    `)
+    indexDbResult.db.run(sql`
+      INSERT INTO note_properties (note_id, name, type, value)
+      VALUES (${'n-later'}, ${'Deadline'}, ${'date'}, ${'2026-06-20T09:00:00.000Z'})
+    `)
+
+    const { items } = getCalendarRangeProjection(
+      db as unknown as DataDb,
+      indexDb,
+      {
+        startAt: '2026-06-01T00:00:00.000Z',
+        endAt: '2026-07-01T00:00:00.000Z',
+        includeUnselectedSources: false
+      },
+      ['Deadline'],
+      true
+    )
+
+    const ids = items.filter((i) => i.sourceType === 'note').map((i) => i.projectionId)
+    expect(ids).toContain('note:n-later:Deadline')
+    expect(ids).toContain('note-created:n-later')
+  })
+
   it('omits created-date notes when showNotesByCreated is off', () => {
     indexDbResult.db.run(sql`
       INSERT INTO note_cache (id, path, title, file_type, created_at, modified_at)

--- a/apps/desktop/src/main/calendar/projection.ts
+++ b/apps/desktop/src/main/calendar/projection.ts
@@ -606,6 +606,19 @@ export function getCalendarRangeProjection(
   enabledNames: string[],
   showNotesByCreated = false
 ): CalendarRangeResponse {
+  const notePropertyItems = loadNoteDatePropertyItems(indexDb, enabledNames, input)
+
+  // A note whose calendar-enabled date property lands on its creation day would
+  // otherwise chip twice (once per source); keep only the property chip that day.
+  const notePropertyDays = new Set(
+    notePropertyItems.map((item) => `${item.sourceId}:${item.startAt}`)
+  )
+  const noteCreatedItems = showNotesByCreated
+    ? loadNotesByCreatedDate(indexDb, input).filter(
+        (item) => !notePropertyDays.has(`${item.sourceId}:${item.startAt}`)
+      )
+    : []
+
   const items = sortProjectionItems([
     ...loadMemryEvents(db, input),
     ...loadTaskItems(db, input),
@@ -613,8 +626,8 @@ export function getCalendarRangeProjection(
     ...loadNoteDateReminderItems(db, indexDb, input),
     ...loadInboxSnoozeItems(db, input),
     ...loadExternalEvents(db, input),
-    ...loadNoteDatePropertyItems(indexDb, enabledNames, input),
-    ...(showNotesByCreated ? loadNotesByCreatedDate(indexDb, input) : [])
+    ...notePropertyItems,
+    ...noteCreatedItems
   ])
 
   return { items }

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -62,7 +62,7 @@ The toggle is vault-wide per property name — enabling it for "Deadline" once s
 
 ## Show Notes on Calendar
 
-[Settings → Calendar](/user-guide/settings#calendar) has a **Show notes on calendar** toggle (on by default). While it's on, every note appears on the calendar as an all-day chip on the day it was created — no per-note setup. Turning it off removes them again. This is display-only: no date is written to the note.
+[Settings → Calendar](/user-guide/settings#calendar) has a **Show notes on calendar** toggle (off by default — new notes stay off the calendar until you opt in). While it's on, every note appears on the calendar as an all-day chip on the day it was created — no per-note setup. Turning it off removes them again. This is display-only: no date is written to the note. A note whose calendar-enabled date property falls on its creation day shows a single chip, not two.
 
 With notes on the calendar, the [Day Panel](/user-guide/day-panel) mini-calendar also shows a notes dot on days that have notes — alongside the event and journal-activity dots — and the day's list under the calendar includes those notes next to events.
 

--- a/packages/contracts/src/settings-schemas.ts
+++ b/packages/contracts/src/settings-schemas.ts
@@ -180,7 +180,9 @@ export const CALENDAR_SETTINGS_DEFAULTS: CalendarSettings = {
   dayCellClickBehavior: 'journal',
   calendarPageClickOverride: 'calendar',
   weekStartDay: 'monday',
-  showNotesOnCalendar: true
+  // Off by default: notes stay off the calendar until the user opts in (this
+  // global toggle, or a per-date-property calendar toggle on the note).
+  showNotesOnCalendar: false
 }
 
 // ============================================================================


### PR DESCRIPTION
## What
- `showNotesOnCalendar` now defaults to **false** — new notes stay off the calendar until the user opts in (global toggle or a per-date-property calendar toggle). Users who ever saved a calendar setting keep their stored value.
- Same-day dedup in the calendar projection: a note whose calendar-enabled date property lands on its creation day now shows one chip (the property chip), not two.

## Why
User feedback: a fresh note appeared twice on the Calendar, and notes shouldn't be there at all without opt-in.