### PR TITLE
fix(desktop): preflight the CRDT store in a disposable child process

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -70,6 +70,9 @@ export default defineConfig({
           index: resolve(appRoot, 'src/main/index.ts'),
           'embedding-worker': resolve(appRoot, 'src/main/lib/embedding-worker.ts'),
           'sync-worker': resolve(appRoot, 'src/main/sync/worker.ts'),
+          // utilityProcess child that exercises the classic-level native
+          // binding before main loads it (see crdt-preflight.ts)
+          'crdt-preflight-child': resolve(appRoot, 'src/main/sync/crdt-preflight-child.ts'),
           'image-processing-worker': resolve(appRoot, 'src/main/image-processing/worker.ts'),
           'voice-transcription-worker': resolve(
             appRoot,

--- a/apps/desktop/src/main/sync/crdt-preflight-child.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-child.ts
@@ -5,15 +5,17 @@
  * instructions, AV interference) can abort the process outright — no JS error,
  * no uncaughtException, nothing to catch. Observed in the wild on 2026.709.x:
  * the main process died silently seconds after launch, before the window ever
- * painted. So the binding is exercised HERE first; if this process dies, main
- * never loads the binding and degrades to in-memory mode instead of vanishing.
+ * painted. So the binding is exercised HERE first — on the REAL store
+ * directory, so corrupt on-disk state (torn LDB/MANIFEST from a past crash or
+ * full disk) dies here too, not just a binding that is broken outright. If
+ * this process dies, main never loads the binding; it quarantines the store
+ * and re-probes, or degrades to in-memory mode instead of vanishing.
  *
  * Keep this file free of project imports and `electron` — it must stay a
  * minimal, standalone bundle that only touches y-leveldb/yjs and node builtins.
  */
 import { LeveldbPersistence } from 'y-leveldb'
 import * as Y from 'yjs'
-import { rmSync } from 'fs'
 
 const PROBE_DOC = '__memry_preflight__'
 
@@ -29,6 +31,9 @@ async function main(): Promise<void> {
     throw new Error('crdt-preflight-child: missing probe directory argument')
   }
 
+  // This is the user's real store: round-trip a throwaway probe doc, clear it,
+  // and close cleanly (releasing the LevelDB LOCK for main). Never delete the
+  // directory — quarantine decisions belong to the provider in main.
   const persistence = new LeveldbPersistence(probeDir)
   const doc = new Y.Doc()
   doc.getMap('probe').set('ok', true)
@@ -40,7 +45,6 @@ async function main(): Promise<void> {
 
   await persistence.clearDocument(PROBE_DOC)
   await persistence.destroy()
-  rmSync(probeDir, { recursive: true, force: true })
 }
 
 main().then(

--- a/apps/desktop/src/main/sync/crdt-preflight-child.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-child.ts
@@ -1,0 +1,52 @@
+/**
+ * CRDT store preflight — runs in a disposable Electron utilityProcess.
+ *
+ * A broken classic-level native binding (wrong ABI, unsupported CPU
+ * instructions, AV interference) can abort the process outright — no JS error,
+ * no uncaughtException, nothing to catch. Observed in the wild on 2026.709.x:
+ * the main process died silently seconds after launch, before the window ever
+ * painted. So the binding is exercised HERE first; if this process dies, main
+ * never loads the binding and degrades to in-memory mode instead of vanishing.
+ *
+ * Keep this file free of project imports and `electron` — it must stay a
+ * minimal, standalone bundle that only touches y-leveldb/yjs and node builtins.
+ */
+import { LeveldbPersistence } from 'y-leveldb'
+import * as Y from 'yjs'
+import { rmSync } from 'fs'
+
+const PROBE_DOC = '__memry_preflight__'
+
+async function main(): Promise<void> {
+  // E2E reproduction of the field failure: a hard native-style abort. Honored
+  // only under the test harness (NODE_ENV=test); inert in shipped builds.
+  if (process.env.NODE_ENV === 'test' && process.env.MEMRY_TEST_CRDT_PREFLIGHT_CRASH === '1') {
+    process.abort()
+  }
+
+  const probeDir = process.argv[2]
+  if (!probeDir) {
+    throw new Error('crdt-preflight-child: missing probe directory argument')
+  }
+
+  const persistence = new LeveldbPersistence(probeDir)
+  const doc = new Y.Doc()
+  doc.getMap('probe').set('ok', true)
+  await persistence.storeUpdate(PROBE_DOC, Y.encodeStateAsUpdate(doc))
+  doc.destroy()
+
+  const loaded = await persistence.getYDoc(PROBE_DOC)
+  loaded.destroy()
+
+  await persistence.clearDocument(PROBE_DOC)
+  await persistence.destroy()
+  rmSync(probeDir, { recursive: true, force: true })
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error(err)
+    process.exit(1)
+  }
+)

--- a/apps/desktop/src/main/sync/crdt-preflight.test.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.test.ts
@@ -26,14 +26,15 @@ vi.mock('../lib/logger', () => ({
   })
 }))
 
-import { runCrdtPreflight, resetCrdtPreflightForTests } from './crdt-preflight'
+import { runCrdtPreflight } from './crdt-preflight'
+
+const STORE_DIR = '/tmp/memry-preflight-test/crdt-store'
 
 describe('runCrdtPreflight', () => {
   let child: MockChild
 
   beforeEach(() => {
     vi.clearAllMocks()
-    resetCrdtPreflightForTests()
     child = new MockChild()
     mockFork.mockReturnValue(child)
   })
@@ -42,19 +43,19 @@ describe('runCrdtPreflight', () => {
     vi.useRealTimers()
   })
 
-  it('passes when the child exits cleanly', async () => {
-    const pending = runCrdtPreflight()
+  it('passes when the child exits cleanly and probes the requested store dir', async () => {
+    const pending = runCrdtPreflight(STORE_DIR)
     child.emit('exit', 0)
 
     await expect(pending).resolves.toEqual({ ok: true })
     expect(mockFork).toHaveBeenCalledTimes(1)
     const [childPath, args] = mockFork.mock.calls[0] as [string, string[]]
     expect(childPath).toContain('crdt-preflight-child.js')
-    expect(args[0]).toContain('crdt-store-preflight')
+    expect(args[0]).toBe(STORE_DIR)
   })
 
   it('fails when the child dies with a non-zero code (native abort)', async () => {
-    const pending = runCrdtPreflight()
+    const pending = runCrdtPreflight(STORE_DIR)
     child.emit('exit', 134)
 
     const result = await pending
@@ -64,7 +65,7 @@ describe('runCrdtPreflight', () => {
 
   it('kills the child and fails when it hangs past the timeout', async () => {
     vi.useFakeTimers()
-    const pending = runCrdtPreflight()
+    const pending = runCrdtPreflight(STORE_DIR)
 
     await vi.advanceTimersByTimeAsync(11_000)
 
@@ -79,18 +80,20 @@ describe('runCrdtPreflight', () => {
       throw new Error('spawn failed')
     })
 
-    const result = await runCrdtPreflight()
+    const result = await runCrdtPreflight(STORE_DIR)
     expect(result.ok).toBe(false)
     expect(result.reason).toContain('spawn failed')
   })
 
-  it('runs the child once per process and caches the verdict', async () => {
-    const first = runCrdtPreflight()
-    child.emit('exit', 0)
+  it('forks a fresh child on every call so a quarantine retry re-probes', async () => {
+    const first = runCrdtPreflight(STORE_DIR)
+    child.emit('exit', 134)
     await first
 
-    const second = await runCrdtPreflight()
-    expect(second).toEqual({ ok: true })
-    expect(mockFork).toHaveBeenCalledTimes(1)
+    const second = runCrdtPreflight(STORE_DIR)
+    child.emit('exit', 0)
+
+    await expect(second).resolves.toEqual({ ok: true })
+    expect(mockFork).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/desktop/src/main/sync/crdt-preflight.test.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.test.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from 'events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockFork = vi.hoisted(() => vi.fn())
+
+class MockChild extends EventEmitter {
+  kill = vi.fn().mockReturnValue(true)
+  stdout = null
+  stderr = new EventEmitter()
+  pid = 4321
+}
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp/memry-preflight-test' },
+  utilityProcess: {
+    fork: (...args: unknown[]) => mockFork(...args)
+  }
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+import { runCrdtPreflight, resetCrdtPreflightForTests } from './crdt-preflight'
+
+describe('runCrdtPreflight', () => {
+  let child: MockChild
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetCrdtPreflightForTests()
+    child = new MockChild()
+    mockFork.mockReturnValue(child)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('passes when the child exits cleanly', async () => {
+    const pending = runCrdtPreflight()
+    child.emit('exit', 0)
+
+    await expect(pending).resolves.toEqual({ ok: true })
+    expect(mockFork).toHaveBeenCalledTimes(1)
+    const [childPath, args] = mockFork.mock.calls[0] as [string, string[]]
+    expect(childPath).toContain('crdt-preflight-child.js')
+    expect(args[0]).toContain('crdt-store-preflight')
+  })
+
+  it('fails when the child dies with a non-zero code (native abort)', async () => {
+    const pending = runCrdtPreflight()
+    child.emit('exit', 134)
+
+    const result = await pending
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('134')
+  })
+
+  it('kills the child and fails when it hangs past the timeout', async () => {
+    vi.useFakeTimers()
+    const pending = runCrdtPreflight()
+
+    await vi.advanceTimersByTimeAsync(11_000)
+
+    const result = await pending
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('timed out')
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('fails safely when the child cannot even be forked', async () => {
+    mockFork.mockImplementation(() => {
+      throw new Error('spawn failed')
+    })
+
+    const result = await runCrdtPreflight()
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('spawn failed')
+  })
+
+  it('runs the child once per process and caches the verdict', async () => {
+    const first = runCrdtPreflight()
+    child.emit('exit', 0)
+    await first
+
+    const second = await runCrdtPreflight()
+    expect(second).toEqual({ ok: true })
+    expect(mockFork).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-preflight.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.ts
@@ -1,0 +1,85 @@
+import path from 'path'
+import { app, utilityProcess } from 'electron'
+import { createLogger } from '../lib/logger'
+
+const log = createLogger('CrdtPreflight')
+
+const PREFLIGHT_TIMEOUT_MS = 10_000
+
+export interface CrdtPreflightResult {
+  ok: boolean
+  reason?: string
+}
+
+// One preflight per process: a broken binding stays broken, and a passed
+// preflight need not re-pay the child-spawn cost on re-init (sign-out/sign-in).
+let cached: Promise<CrdtPreflightResult> | null = null
+
+/**
+ * Verify the classic-level native binding survives real use — in a disposable
+ * utilityProcess, before the main process ever loads it. A binding that
+ * hard-aborts (no JS error, no uncaughtException) kills the child, not the
+ * app; main then runs the CRDT layer in-memory. See crdt-preflight-child.ts.
+ */
+export function runCrdtPreflight(): Promise<CrdtPreflightResult> {
+  if (!cached) {
+    cached = execPreflight().catch((err) => {
+      log.error('CRDT preflight failed to run', { error: err })
+      return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+    })
+  }
+  return cached
+}
+
+export function resetCrdtPreflightForTests(): void {
+  cached = null
+}
+
+async function execPreflight(): Promise<CrdtPreflightResult> {
+  const probeDir = path.join(app.getPath('userData'), 'crdt-store-preflight')
+  const childPath = path.join(__dirname, 'crdt-preflight-child.js')
+  const startedAt = Date.now()
+
+  return await new Promise<CrdtPreflightResult>((resolve) => {
+    let settled = false
+    let stderr = ''
+
+    const settle = (result: CrdtPreflightResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (result.ok) {
+        log.debug('CRDT preflight passed', { elapsedMs: Date.now() - startedAt })
+      } else {
+        log.error('CRDT store failed preflight — CRDT layer will run in-memory', {
+          reason: result.reason,
+          stderr: stderr.slice(0, 2000),
+          elapsedMs: Date.now() - startedAt
+        })
+      }
+      resolve(result)
+    }
+
+    const child = utilityProcess.fork(childPath, [probeDir], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      env: { ...process.env }
+    })
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill()
+      } catch {
+        // already gone
+      }
+      settle({ ok: false, reason: `timed out after ${PREFLIGHT_TIMEOUT_MS}ms` })
+    }, PREFLIGHT_TIMEOUT_MS)
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    child.once('exit', (code: number) => {
+      settle(code === 0 ? { ok: true } : { ok: false, reason: `child exited with code ${code}` })
+    })
+  })
+}

--- a/apps/desktop/src/main/sync/crdt-preflight.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { app, utilityProcess } from 'electron'
+import { utilityProcess } from 'electron'
 import { createLogger } from '../lib/logger'
 
 const log = createLogger('CrdtPreflight')
@@ -11,32 +11,25 @@ export interface CrdtPreflightResult {
   reason?: string
 }
 
-// One preflight per process: a broken binding stays broken, and a passed
-// preflight need not re-pay the child-spawn cost on re-init (sign-out/sign-in).
-let cached: Promise<CrdtPreflightResult> | null = null
-
 /**
  * Verify the classic-level native binding survives real use — in a disposable
- * utilityProcess, before the main process ever loads it. A binding that
- * hard-aborts (no JS error, no uncaughtException) kills the child, not the
- * app; main then runs the CRDT layer in-memory. See crdt-preflight-child.ts.
+ * utilityProcess, before the main process ever loads it. The child probes the
+ * REAL store directory, so both a binding that hard-aborts (no JS error, no
+ * uncaughtException) and a store whose on-disk state aborts the binding (torn
+ * LDB/MANIFEST from a past crash) kill the child, not the app.
+ *
+ * No verdict cache: the provider latches init (persistenceReady) so a verdict
+ * is only ever requested again after it quarantined the store — and that retry
+ * must genuinely re-probe. See crdt-preflight-child.ts and crdt-provider.ts.
  */
-export function runCrdtPreflight(): Promise<CrdtPreflightResult> {
-  if (!cached) {
-    cached = execPreflight().catch((err) => {
-      log.error('CRDT preflight failed to run', { error: err })
-      return { ok: false, reason: err instanceof Error ? err.message : String(err) }
-    })
-  }
-  return cached
+export function runCrdtPreflight(storeDir: string): Promise<CrdtPreflightResult> {
+  return execPreflight(storeDir).catch((err) => {
+    log.error('CRDT preflight failed to run', { error: err })
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  })
 }
 
-export function resetCrdtPreflightForTests(): void {
-  cached = null
-}
-
-async function execPreflight(): Promise<CrdtPreflightResult> {
-  const probeDir = path.join(app.getPath('userData'), 'crdt-store-preflight')
+async function execPreflight(storeDir: string): Promise<CrdtPreflightResult> {
   const childPath = path.join(__dirname, 'crdt-preflight-child.js')
   const startedAt = Date.now()
 
@@ -49,9 +42,10 @@ async function execPreflight(): Promise<CrdtPreflightResult> {
       settled = true
       clearTimeout(timer)
       if (result.ok) {
-        log.debug('CRDT preflight passed', { elapsedMs: Date.now() - startedAt })
+        log.debug('CRDT preflight passed', { storeDir, elapsedMs: Date.now() - startedAt })
       } else {
         log.error('CRDT store failed preflight — CRDT layer will run in-memory', {
+          storeDir,
           reason: result.reason,
           stderr: stderr.slice(0, 2000),
           elapsedMs: Date.now() - startedAt
@@ -60,7 +54,7 @@ async function execPreflight(): Promise<CrdtPreflightResult> {
       resolve(result)
     }
 
-    const child = utilityProcess.fork(childPath, [probeDir], {
+    const child = utilityProcess.fork(childPath, [storeDir], {
       stdio: ['ignore', 'ignore', 'pipe'],
       env: { ...process.env }
     })

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => {
   return {
     persistenceBehavior,
     persistenceOpFactory,
+    // Verdict of the disposable utilityProcess preflight (see crdt-preflight.ts)
+    preflightResult: { ok: true } as { ok: boolean; reason?: string },
     sent: [] as Array<{ windowId: number; channel: string; payload: unknown }>,
     windows: new Map<
       number,
@@ -56,6 +58,10 @@ vi.mock('../lib/logger', () => ({
     warn: vi.fn(),
     error: vi.fn()
   })
+}))
+
+vi.mock('./crdt-preflight', () => ({
+  runCrdtPreflight: vi.fn(async () => ({ ...mocks.preflightResult }))
 }))
 
 vi.mock('y-leveldb', () => ({
@@ -169,6 +175,7 @@ describe('CrdtProvider', () => {
     mocks.windows.clear()
     mocks.persistenceInstances.length = 0
     mocks.persistenceBehavior.mode = 'ok'
+    mocks.preflightResult = { ok: true }
     mocks.getNoteCacheById.mockReturnValue({
       id: 'note-1',
       path: 'notes/Note.md',
@@ -707,6 +714,7 @@ describe('CrdtProvider persistence resilience', () => {
     mocks.windows.clear()
     mocks.persistenceInstances.length = 0
     mocks.persistenceBehavior.mode = 'ok'
+    mocks.preflightResult = { ok: true }
     mocks.getNoteCacheById.mockReturnValue({
       id: 'note-1',
       path: 'notes/Note.md',
@@ -741,6 +749,21 @@ describe('CrdtProvider persistence resilience', () => {
 
     // Typing must not throw even though the store is dead.
     expect(() => provider.applyIpcUpdate('note-1', makeRemoteUpdate('typed'), 7)).not.toThrow()
+    await provider.close('note-1')
+  })
+
+  it('never loads the store binding when the preflight child dies', async () => {
+    mocks.preflightResult = { ok: false, reason: 'child exited with code 134' }
+    const provider = new CrdtProvider()
+
+    await expect(provider.init()).resolves.toBeUndefined()
+    expect(provider.isInitialized()).toBe(true)
+    // The whole point: LeveldbPersistence must never be constructed in main
+    // when the disposable child crashed exercising the native binding.
+    expect(mocks.persistenceInstances).toHaveLength(0)
+
+    const doc = await provider.open('note-1')
+    expect(doc.getXmlFragment(CRDT_FRAGMENT_NAME).length).toBeGreaterThan(0)
     await provider.close('note-1')
   })
 

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -1,4 +1,5 @@
 import * as Y from 'yjs'
+import * as fs from 'fs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => {
@@ -17,8 +18,12 @@ const mocks = vi.hoisted(() => {
   return {
     persistenceBehavior,
     persistenceOpFactory,
-    // Verdict of the disposable utilityProcess preflight (see crdt-preflight.ts)
+    // Verdict of the disposable utilityProcess preflight (see crdt-preflight.ts).
+    // preflightQueue serves per-call verdicts (quarantine retry = second call);
+    // when empty, preflightResult is the standing answer.
     preflightResult: { ok: true } as { ok: boolean; reason?: string },
+    preflightQueue: [] as Array<{ ok: boolean; reason?: string }>,
+    preflightCalls: [] as string[],
     sent: [] as Array<{ windowId: number; channel: string; payload: unknown }>,
     windows: new Map<
       number,
@@ -61,7 +66,11 @@ vi.mock('../lib/logger', () => ({
 }))
 
 vi.mock('./crdt-preflight', () => ({
-  runCrdtPreflight: vi.fn(async () => ({ ...mocks.preflightResult }))
+  runCrdtPreflight: vi.fn(async (storeDir: string) => {
+    mocks.preflightCalls.push(storeDir)
+    const queued = mocks.preflightQueue.shift()
+    return queued ? { ...queued } : { ...mocks.preflightResult }
+  })
 }))
 
 vi.mock('y-leveldb', () => ({
@@ -176,6 +185,8 @@ describe('CrdtProvider', () => {
     mocks.persistenceInstances.length = 0
     mocks.persistenceBehavior.mode = 'ok'
     mocks.preflightResult = { ok: true }
+    mocks.preflightQueue.length = 0
+    mocks.preflightCalls.length = 0
     mocks.getNoteCacheById.mockReturnValue({
       id: 'note-1',
       path: 'notes/Note.md',
@@ -715,6 +726,8 @@ describe('CrdtProvider persistence resilience', () => {
     mocks.persistenceInstances.length = 0
     mocks.persistenceBehavior.mode = 'ok'
     mocks.preflightResult = { ok: true }
+    mocks.preflightQueue.length = 0
+    mocks.preflightCalls.length = 0
     mocks.getNoteCacheById.mockReturnValue({
       id: 'note-1',
       path: 'notes/Note.md',
@@ -765,6 +778,75 @@ describe('CrdtProvider persistence resilience', () => {
     const doc = await provider.open('note-1')
     expect(doc.getXmlFragment(CRDT_FRAGMENT_NAME).length).toBeGreaterThan(0)
     await provider.close('note-1')
+  })
+
+  // The preflight child probes the REAL crdt-store dir, so it also dies on a
+  // store whose on-disk state (torn LDB/MANIFEST from a past crash or full
+  // disk) aborts the binding — not just on a binding that is broken outright.
+  // The two are told apart empirically: quarantine the store, re-probe fresh.
+  describe('store quarantine', () => {
+    const userDataDir = '/tmp/memry-crdt-test'
+    const storeDir = `${userDataDir}/crdt-store`
+
+    beforeEach(() => {
+      fs.rmSync(userDataDir, { recursive: true, force: true })
+    })
+
+    afterEach(() => {
+      fs.rmSync(userDataDir, { recursive: true, force: true })
+    })
+
+    it('quarantines a corrupt store and continues on a fresh one when the re-probe passes', async () => {
+      fs.mkdirSync(storeDir, { recursive: true })
+      fs.writeFileSync(`${storeDir}/MANIFEST-000001`, 'torn')
+      mocks.preflightQueue.push({ ok: false, reason: 'child exited with code 134' }, { ok: true })
+
+      const provider = new CrdtProvider()
+      await expect(provider.init()).resolves.toBeUndefined()
+
+      // Corrupt store moved aside (preserved, not deleted), fresh store adopted.
+      expect(mocks.preflightCalls).toEqual([storeDir, storeDir])
+      expect(fs.existsSync(storeDir)).toBe(false)
+      const quarantined = fs
+        .readdirSync(userDataDir)
+        .filter((f) => f.startsWith('crdt-store.broken-'))
+      expect(quarantined).toHaveLength(1)
+      expect(fs.existsSync(`${userDataDir}/${quarantined[0]}/MANIFEST-000001`)).toBe(true)
+      expect(mocks.persistenceInstances).toHaveLength(1)
+    })
+
+    it('restores the quarantined store when the re-probe also fails (broken binding)', async () => {
+      fs.mkdirSync(storeDir, { recursive: true })
+      fs.writeFileSync(`${storeDir}/MANIFEST-000001`, 'healthy-but-binding-broken')
+      mocks.preflightQueue.push(
+        { ok: false, reason: 'child exited with code 134' },
+        { ok: false, reason: 'child exited with code 134' }
+      )
+
+      const provider = new CrdtProvider()
+      await expect(provider.init()).resolves.toBeUndefined()
+
+      // Binding is the problem, not the data: put the store back so a future
+      // launch with a working binding finds the user's CRDT history intact.
+      expect(mocks.preflightCalls).toEqual([storeDir, storeDir])
+      expect(fs.existsSync(`${storeDir}/MANIFEST-000001`)).toBe(true)
+      expect(
+        fs.readdirSync(userDataDir).filter((f) => f.startsWith('crdt-store.broken-'))
+      ).toHaveLength(0)
+      expect(mocks.persistenceInstances).toHaveLength(0)
+      expect(provider.isInitialized()).toBe(true)
+    })
+
+    it('does not re-probe when no store exists to quarantine', async () => {
+      mocks.preflightQueue.push({ ok: false, reason: 'child exited with code 134' })
+
+      const provider = new CrdtProvider()
+      await expect(provider.init()).resolves.toBeUndefined()
+
+      expect(mocks.preflightCalls).toEqual([storeDir])
+      expect(mocks.persistenceInstances).toHaveLength(0)
+      expect(provider.isInitialized()).toBe(true)
+    })
   })
 
   it('falls back to in-memory mode when the persistence probe hangs', async () => {

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -1,6 +1,7 @@
 import * as Y from 'yjs'
 import { LeveldbPersistence } from 'y-leveldb'
 import path from 'path'
+import { existsSync, renameSync } from 'fs'
 import { app, BrowserWindow } from 'electron'
 import { CRDT_EVENTS, CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import { createLogger } from '../lib/logger'
@@ -126,9 +127,40 @@ export class CrdtProvider {
       // A binding that hard-aborts (unsupported CPU instructions, AV kills)
       // takes the whole process down with no catchable error — observed on
       // 2026.709.x: main died silently before the window painted. Exercise
-      // the binding in a disposable child first; only load it here if the
+      // the binding in a disposable child first — against the real store, so
+      // corrupt on-disk state aborts the child too. Only load it here if the
       // child survives.
-      const preflight = await runCrdtPreflight()
+      let preflight = await runCrdtPreflight(storagePath)
+      if (!preflight.ok && existsSync(storagePath)) {
+        // The abort may be the store's data (torn LDB/MANIFEST from a past
+        // crash or full disk), not the binding. Quarantine the store and give
+        // the binding one clean shot at a fresh directory: pass → the data was
+        // the problem, keep the quarantine and start fresh (vault markdown is
+        // the source of truth; only CRDT history moves aside). Fail → the
+        // binding is the problem, so restore the store for a future launch
+        // with a working binding and fall through to in-memory mode.
+        const quarantinePath = `${storagePath}.broken-${Date.now()}`
+        renameSync(storagePath, quarantinePath)
+        preflight = await runCrdtPreflight(storagePath)
+        if (preflight.ok) {
+          log.warn(
+            'CRDT store quarantined after failed preflight — continuing with a fresh store',
+            {
+              storagePath,
+              quarantinePath
+            }
+          )
+        } else {
+          try {
+            renameSync(quarantinePath, storagePath)
+          } catch (restoreErr) {
+            log.warn('Failed to restore quarantined CRDT store', {
+              quarantinePath,
+              error: restoreErr
+            })
+          }
+        }
+      }
       if (!preflight.ok) {
         throw new Error(`CRDT store preflight failed: ${preflight.reason ?? 'unknown'}`)
       }

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -9,6 +9,7 @@ import { getNoteCacheById } from '@main/database/queries/notes'
 import type { CrdtUpdateQueue } from './crdt-queue'
 import { MicrotaskBatchBroadcaster } from './microtask-batch-broadcaster'
 import { scheduleWriteback, flushPendingWritebacks, recordNetworkUpdate } from './crdt-writeback'
+import { runCrdtPreflight } from './crdt-preflight'
 import { toAbsolutePath } from '../vault/notes'
 import { safeRead } from '../vault/file-ops'
 import { parseNote } from '../vault/frontmatter'
@@ -122,6 +123,15 @@ export class CrdtProvider {
   private async doInitPersistence(): Promise<void> {
     const storagePath = path.join(app.getPath('userData'), 'crdt-store')
     try {
+      // A binding that hard-aborts (unsupported CPU instructions, AV kills)
+      // takes the whole process down with no catchable error — observed on
+      // 2026.709.x: main died silently before the window painted. Exercise
+      // the binding in a disposable child first; only load it here if the
+      // child survives.
+      const preflight = await runCrdtPreflight()
+      if (!preflight.ok) {
+        throw new Error(`CRDT store preflight failed: ${preflight.reason ?? 'unknown'}`)
+      }
       const persistence = new LeveldbPersistence(storagePath) as CrdtPersistence
       await probePersistence(persistence)
       this.persistence = persistence

--- a/apps/desktop/tests/e2e/crdt-preflight-crash.e2e.ts
+++ b/apps/desktop/tests/e2e/crdt-preflight-crash.e2e.ts
@@ -1,0 +1,44 @@
+/**
+ * CRDT preflight crash E2E — reproduces the customer's silent-death launch.
+ *
+ * A Windows 10 user on 2026.709.x had the main process die outright ~3s after
+ * launch, before the window painted: no JS error, no uncaughtException, no
+ * log line — the signature of a native abort in the classic-level binding.
+ * In-process guards cannot catch a process abort, so the binding is now
+ * exercised in a disposable utilityProcess first (crdt-preflight-child.ts).
+ *
+ * This test forces the child to die the same way (process.abort via
+ * MEMRY_TEST_CRDT_PREFLIGHT_CRASH, honored only under NODE_ENV=test) and
+ * asserts the app still launches a visible, working window — the CRDT layer
+ * quietly degrades to in-memory mode instead of taking the app down.
+ */
+import { test, expect } from '@playwright/test'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { launchElectronWithWindow, destroyElectronApp } from './utils/electron-lifecycle'
+
+test('opens a working window even when the CRDT preflight child crashes hard', async () => {
+  const testVaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-preflight-vault-'))
+
+  const launched = await launchElectronWithWindow({
+    testVaultPath,
+    extraEnv: { MEMRY_TEST_CRDT_PREFLIGHT_CRASH: '1' }
+  })
+
+  try {
+    // The window appearing at all is the core assertion — the customer's
+    // build never got this far. Then make sure it's the real app, not the
+    // startup-failure recovery page.
+    await expect(launched.page.locator('body')).toBeVisible()
+    await expect(launched.page.locator('body')).not.toContainText("couldn't finish starting")
+
+    // Guard against a vacuous pass: the preflight child must actually have
+    // died and been reported, or this test isn't exercising the crash path.
+    await expect
+      .poll(() => launched.mainLogs.join('\n'), { timeout: 15_000 })
+      .toContain('CRDT store failed preflight')
+  } finally {
+    await destroyElectronApp(launched.app, [launched.userDataDir, launched.resolvedUserDataDir])
+  }
+})

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -18,8 +18,12 @@ renderer  ──Yjs IPC provider──▶  main (Y.Doc)  ──y-leveldb──�
 
 ## Persistence Resilience
 
-The y-leveldb store is probed at startup (a write/read/clear round-trip with a
-timeout) before it is trusted. A broken `classic-level` native binding doesn't
+The classic-level native binding is first exercised in a **disposable
+utilityProcess** (`crdt-preflight-child.ts`): a binding that hard-aborts
+(unsupported CPU instructions, AV interference) kills that child, not the app,
+and the main process then never loads the binding at all. Only after the child
+survives is the y-leveldb store probed in-process (a write/read/clear
+round-trip with a timeout) before it is trusted. A broken `classic-level` native binding doesn't
 fail cleanly — it throws outside the promise chain or hangs its callbacks — so
 the probe captures both. If the probe fails, the provider degrades to
 **in-memory mode**: notes still load from vault markdown and write back to

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -19,11 +19,19 @@ renderer  ──Yjs IPC provider──▶  main (Y.Doc)  ──y-leveldb──�
 ## Persistence Resilience
 
 The classic-level native binding is first exercised in a **disposable
-utilityProcess** (`crdt-preflight-child.ts`): a binding that hard-aborts
-(unsupported CPU instructions, AV interference) kills that child, not the app,
-and the main process then never loads the binding at all. Only after the child
-survives is the y-leveldb store probed in-process (a write/read/clear
-round-trip with a timeout) before it is trusted. A broken `classic-level` native binding doesn't
+utilityProcess** (`crdt-preflight-child.ts`) against the **real store
+directory**: a binding that hard-aborts (unsupported CPU instructions, AV
+interference) — or a store whose on-disk state (torn LDB/MANIFEST from a past
+crash or full disk) aborts the binding — kills that child, not the app, and
+the main process then never loads the binding at all. When the preflight
+fails and a store exists, it is **quarantined** (renamed to
+`crdt-store.broken-<timestamp>`) and the preflight retried once against a
+fresh directory: a pass means the data was at fault, so the app continues
+with a fresh store; a second failure means the binding itself is broken, so
+the original store is restored for a future launch and the provider goes
+in-memory. Only after the child survives is the y-leveldb store probed
+in-process (a write/read/clear round-trip with a timeout) before it is
+trusted. A broken `classic-level` native binding doesn't
 fail cleanly — it throws outside the promise chain or hangs its callbacks — so
 the probe captures both. If the probe fails, the provider degrades to
 **in-memory mode**: notes still load from vault markdown and write back to


### PR DESCRIPTION
## Why

Follow-up to #709. The same Windows 10 beta user still cannot launch 2026.709.1/.2: her new `main.log` shows all 75 launch attempts complete `createWindow()` and kick off the update check, then the **main process dies silently ~3 seconds in** — no ready-to-show, no 10s reveal fallback (the timer never fires = the process is gone), no error, no updater response. Leftover "Suspended" `Memrynote.exe` entries in her Task Manager are the orphaned renderer/GPU children.

That signature is a **hard native abort** in the classic-level binding — the same component behind her #709 report, one failure mode deeper. `process.abort()` from native code bypasses every in-process guard: no promise rejection, no `uncaughtException`, nothing to catch. The #709 probe made the binding fire at startup instead of at first keystroke, which is why the crash moved earlier. Two machine-specific theories fit: an old-CPU illegal-instruction kill (disassembly of the shipped `classic-level@1.4.1` win32-x64 prebuild shows AVX/AVX2 and SSE4.2 use with cpuid dispatch sites), or a **corrupt on-disk store** (torn LDB/MANIFEST from the 2026.705.x crash-while-typing era — userData survives reinstall, matching "same failure on .1 and .2"). Event Viewer data has been requested from the user; this PR covers both.

## What

**Exercise the binding in a disposable `utilityProcess` — against the real store — before main ever loads it:**

- `crdt-preflight-child.ts` — standalone bundle (no project/electron imports): opens y-leveldb on the **real `crdt-store` dir**, write/read/clear round-trip on a probe doc, clean close (releases the LevelDB LOCK), exits 0. If the binding hard-aborts — because the binding is broken *or* because the store's on-disk state aborts it — this child dies, not the app.
- `crdt-preflight.ts` — forks the child, 10s timeout + kill. Any non-zero exit / hang / fork failure ⇒ `{ ok: false }`. No verdict cache: the provider latches init, and a quarantine retry must genuinely re-probe.
- `crdt-provider.doInitPersistence` — on a failed preflight with an existing store, **quarantine and re-probe once**: rename `crdt-store` → `crdt-store.broken-<ts>`, run the preflight again on a fresh dir. Pass ⇒ the data was at fault; continue with a fresh store (vault markdown is the source of truth; only CRDT history moves aside, preserved in the quarantine dir). Fail ⇒ the binding is at fault; restore the original store for a future launch with a working binding and throw into the existing #709 fallback: `LeveldbPersistence` is **never constructed in main**, the CRDT layer runs in-memory, notes still load from vault markdown and write back to disk.

**Fault-injection E2E** (`crdt-preflight-crash.e2e.ts`): `MEMRY_TEST_CRDT_PREFLIGHT_CRASH=1` (NODE_ENV=test only) makes the child `process.abort()` — the exact field failure. Asserts a visible, working window appears, it is not the startup-recovery page, and the main log actually reports `CRDT store failed preflight` (guards against a vacuous pass).

## Tests

- 5 unit tests for the preflight runner (clean exit + real-dir arg, non-zero exit, hang→kill, fork failure, fresh-child-per-call so a quarantine retry re-probes).
- 3 quarantine tests for the provider against a real temp filesystem: corrupt-store pass-on-retry (store quarantined + preserved, fresh store adopted), broken-binding double-fail (store restored, no `.broken-*` leftover, in-memory), no-store-no-retry. Plus the existing test proving `LeveldbPersistence` is never constructed when the child dies.
- Full `src/main/sync/` suite: **83 files / 862 tests green.**
- E2E: fault-injection spec green + `startup-recovery.e2e.ts` control green.
- `typecheck:node`, lint, `docs:impact --strict`, `docs:build` all green; `check-worker-bundles` green with the new bundle entry.

## Notes

- Healthy machines pay one child spawn (~hundreds of ms) once per process, off the startup critical path (init is fire-and-forget since #709).
- The child never deletes the store dir; quarantine decisions live in the provider in main.
- Root cause on the user's hardware still unconfirmed — Event Viewer faulting-module + CPU model requested. This PR makes the answer not matter for launchability, and self-heals the corrupt-store case.
