### PR TITLE
fix(sync): refresh token and retry once on 401 instead of failing the cycle

### DIFF
--- a/apps/desktop/config/vitest.config.ts
+++ b/apps/desktop/config/vitest.config.ts
@@ -116,6 +116,10 @@ export default defineConfig({
       // 2026-07-09: statements re-measured at 85.89 after #727; floor lowered 85.9 -> 85.8.
       // 2026-07-10: re-measured after #732 (85.86 / 73.69 / 85.59 / 87.93); branches
       //   73.7 -> 73.6, functions 85.6 -> 85.5.
+      // 2026-07-10: #734 sync 401 refresh-retry adds thin coordinator glue (per-request
+      //   auth wrappers) exercised only on the 401 path; measured functions 85.58, branches
+      //   73.68 — already within the floors above (new logic is unit-tested in
+      //   auth-retry/runtime/crdt-queue; only the coordinator glue is uncovered).
       thresholds: {
         statements: 85.8,
         branches: 73.6,

--- a/apps/desktop/src/main/sync/auth-retry.test.ts
+++ b/apps/desktop/src/main/sync/auth-retry.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import { SyncServerError } from './http-client'
+import { withAuthRetry } from './auth-retry'
+
+const unauthorized = (): SyncServerError => new SyncServerError('Token expired: "exp" claim', 401)
+
+const deps = (overrides?: {
+  refreshAccessToken?: () => Promise<boolean>
+  getAccessToken?: () => Promise<string | null>
+}): {
+  refreshAccessToken: ReturnType<typeof vi.fn>
+  getAccessToken: ReturnType<typeof vi.fn>
+} => ({
+  refreshAccessToken: vi.fn(overrides?.refreshAccessToken ?? (async () => true)),
+  getAccessToken: vi.fn(overrides?.getAccessToken ?? (async () => 'fresh-token'))
+})
+
+describe('withAuthRetry', () => {
+  it('returns the result without refreshing when the request succeeds', async () => {
+    const d = deps()
+    const fn = vi.fn(async (token: string) => `ok:${token}`)
+
+    await expect(withAuthRetry(fn, 'stale-token', d)).resolves.toBe('ok:stale-token')
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(d.refreshAccessToken).not.toHaveBeenCalled()
+  })
+
+  it('refreshes once on 401 and retries with the fresh token', async () => {
+    const d = deps()
+    const fn = vi
+      .fn<(token: string) => Promise<string>>()
+      .mockRejectedValueOnce(unauthorized())
+      .mockImplementation(async (token) => `ok:${token}`)
+    const onNewToken = vi.fn()
+
+    await expect(withAuthRetry(fn, 'stale-token', d, onNewToken)).resolves.toBe('ok:fresh-token')
+
+    expect(d.refreshAccessToken).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenNthCalledWith(1, 'stale-token')
+    expect(fn).toHaveBeenNthCalledWith(2, 'fresh-token')
+    expect(onNewToken).toHaveBeenCalledWith('fresh-token')
+  })
+
+  it('throws the original 401 when the refresh fails', async () => {
+    const original = unauthorized()
+    const d = deps({ refreshAccessToken: async () => false })
+    const fn = vi.fn<(token: string) => Promise<string>>().mockRejectedValue(original)
+
+    await expect(withAuthRetry(fn, 'stale-token', d)).rejects.toBe(original)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(d.getAccessToken).not.toHaveBeenCalled()
+  })
+
+  it('throws the original 401 when no fresh token is available after refresh', async () => {
+    const original = unauthorized()
+    const d = deps({ getAccessToken: async () => null })
+    const fn = vi.fn<(token: string) => Promise<string>>().mockRejectedValue(original)
+
+    await expect(withAuthRetry(fn, 'stale-token', d)).rejects.toBe(original)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not refresh on non-401 errors', async () => {
+    const d = deps()
+    const serverError = new SyncServerError('boom', 500)
+    const fn = vi.fn<(token: string) => Promise<string>>().mockRejectedValue(serverError)
+
+    await expect(withAuthRetry(fn, 'stale-token', d)).rejects.toBe(serverError)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(d.refreshAccessToken).not.toHaveBeenCalled()
+  })
+
+  it('gives up after a single retry when the fresh token is also rejected', async () => {
+    const d = deps()
+    const second = unauthorized()
+    const fn = vi
+      .fn<(token: string) => Promise<string>>()
+      .mockRejectedValueOnce(unauthorized())
+      .mockRejectedValueOnce(second)
+
+    await expect(withAuthRetry(fn, 'stale-token', d)).rejects.toBe(second)
+
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(d.refreshAccessToken).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/main/sync/auth-retry.test.ts
+++ b/apps/desktop/src/main/sync/auth-retry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { SyncServerError } from './http-client'
-import { withAuthRetry } from './auth-retry'
+import { engineAuthRetryDeps, withAuthRetry } from './auth-retry'
 
 const unauthorized = (): SyncServerError => new SyncServerError('Token expired: "exp" claim', 401)
 
@@ -74,6 +74,17 @@ describe('withAuthRetry', () => {
     expect(d.refreshAccessToken).not.toHaveBeenCalled()
   })
 
+  it('rethrows a non-SyncServerError without refreshing', async () => {
+    const d = deps()
+    const networkError = new Error('socket hang up')
+    const fn = vi.fn<(token: string) => Promise<string>>().mockRejectedValue(networkError)
+
+    await expect(withAuthRetry(fn, 'stale-token', d)).rejects.toBe(networkError)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(d.refreshAccessToken).not.toHaveBeenCalled()
+  })
+
   it('gives up after a single retry when the fresh token is also rejected', async () => {
     const d = deps()
     const second = unauthorized()
@@ -86,5 +97,26 @@ describe('withAuthRetry', () => {
 
     expect(fn).toHaveBeenCalledTimes(2)
     expect(d.refreshAccessToken).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('engineAuthRetryDeps', () => {
+  it('delegates to the provided refreshAccessToken and passes getAccessToken through', async () => {
+    const refreshAccessToken = vi.fn(async () => true)
+    const getAccessToken = vi.fn(async () => 'tok')
+
+    const adapted = engineAuthRetryDeps({ refreshAccessToken, getAccessToken })
+
+    await expect(adapted.refreshAccessToken()).resolves.toBe(true)
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1)
+    expect(adapted.getAccessToken).toBe(getAccessToken)
+  })
+
+  it('resolves false when no refreshAccessToken is wired', async () => {
+    const getAccessToken = vi.fn(async () => 'tok')
+
+    const adapted = engineAuthRetryDeps({ getAccessToken })
+
+    await expect(adapted.refreshAccessToken()).resolves.toBe(false)
   })
 })

--- a/apps/desktop/src/main/sync/auth-retry.ts
+++ b/apps/desktop/src/main/sync/auth-retry.ts
@@ -1,0 +1,48 @@
+import { SyncServerError } from './http-client'
+
+export interface AuthRetryDeps {
+  refreshAccessToken: () => Promise<boolean>
+  getAccessToken: () => Promise<string | null>
+}
+
+/**
+ * Runs a token-bearing sync request; on 401 refreshes the session and retries
+ * exactly once with the fresh token. Proactive refresh can't cover a token
+ * expiring between resolution and the request landing (long sync cycles,
+ * sleep/wake), so the server 401 itself is the refresh signal. If the refresh
+ * or the retry fails, the original 401 (or the retry's error) propagates —
+ * token-manager owns session-expired emission on terminal refresh failure.
+ */
+/** Adapts SyncEngineDeps (where refreshAccessToken is optional) to AuthRetryDeps. */
+export function engineAuthRetryDeps(deps: {
+  getAccessToken: () => Promise<string | null>
+  refreshAccessToken?: () => Promise<boolean>
+}): AuthRetryDeps {
+  return {
+    // No refresh fn wired → treat the session as unrefreshable so a 401 rethrows.
+    refreshAccessToken: () => deps.refreshAccessToken?.() ?? Promise.resolve(false),
+    getAccessToken: deps.getAccessToken
+  }
+}
+
+export async function withAuthRetry<T>(
+  fn: (token: string) => Promise<T>,
+  token: string,
+  deps: AuthRetryDeps,
+  onNewToken?: (token: string) => void
+): Promise<T> {
+  try {
+    return await fn(token)
+  } catch (err) {
+    if (!(err instanceof SyncServerError) || err.statusCode !== 401) throw err
+
+    const refreshed = await deps.refreshAccessToken()
+    if (!refreshed) throw err
+
+    const freshToken = await deps.getAccessToken()
+    if (!freshToken) throw err
+
+    onNewToken?.(freshToken)
+    return fn(freshToken)
+  }
+}

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -297,6 +297,19 @@ describe('CrdtProvider', () => {
     expect(await provider.pushSnapshotForNote('empty-note')).toBe(false)
   })
 
+  it('keeps the pending snapshot for retry when the snapshot push fails', async () => {
+    await provider.initForNote('note-1', { title: 'Snapshot' }, [])
+    provider.updateMeta('note-1', { title: 'Edited before push' })
+
+    pushSnapshot.mockRejectedValueOnce(new Error('401 exp claim'))
+    expect(await provider.pushSnapshotForNote('note-1')).toBe(false)
+
+    pushSnapshot.mockClear()
+    pushSnapshot.mockResolvedValue(undefined)
+    await expect(provider.pushAllSnapshots()).resolves.toBe(1)
+    expect(pushSnapshot).toHaveBeenCalledWith('note-1', expect.any(Uint8Array))
+  })
+
   it('seeds existing docs in batches, validates CRDT eligibility, purges, and destroys storage', async () => {
     const progress = vi.fn()
     const seeded = await provider.seedExistingDocs(

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -490,9 +490,12 @@ export class CrdtProvider {
     }
 
     const wasOpen = this.docs.has(noteId)
+    let entry: ActiveDoc | undefined
+    let clearedAccumulated = 0
+    let clearedPending = 0
     try {
       const doc = await this.open(noteId)
-      const entry = this.docs.get(noteId)
+      entry = this.docs.get(noteId)
       const state = Y.encodeStateAsUpdate(doc)
       if (state.length <= 4) {
         if (!wasOpen) await this.close(noteId)
@@ -501,6 +504,8 @@ export class CrdtProvider {
 
       // Reset accumulatedBytes BEFORE push so close() won't fire a duplicate push
       if (entry) {
+        clearedAccumulated = entry.accumulatedBytes
+        clearedPending = entry.pendingSnapshotBytes
         entry.accumulatedBytes = 0
         entry.pendingSnapshotBytes = 0
       }
@@ -511,6 +516,12 @@ export class CrdtProvider {
       return true
     } catch (err) {
       log.warn('pushSnapshotForNote failed', { noteId, error: err })
+      // Restore the pre-push counters (additive: updates may have landed
+      // mid-push) so pushAllSnapshots and close() still retry this note.
+      if (entry) {
+        entry.accumulatedBytes += clearedAccumulated
+        entry.pendingSnapshotBytes += clearedPending
+      }
       if (!wasOpen) await this.close(noteId)
       return false
     }

--- a/apps/desktop/src/main/sync/crdt-queue.test.ts
+++ b/apps/desktop/src/main/sync/crdt-queue.test.ts
@@ -78,6 +78,25 @@ describe('CrdtUpdateQueue', () => {
     queue.stop()
   })
 
+  it('re-buffers the flushed batch when the push fails with a 401', async () => {
+    const queue = new CrdtUpdateQueue()
+    const push = vi.fn(async () => {
+      throw new SyncServerError('Token expired: "exp" claim', 401)
+    })
+
+    queue.start(push)
+    queue.enqueue('note-a', new Uint8Array([1]))
+    queue.enqueue('note-a', new Uint8Array([2]))
+    vi.advanceTimersByTime(1000)
+
+    expect(push).toHaveBeenCalledTimes(1)
+    await flushPromises()
+    expect(queue.getPendingCount()).toBe(2)
+
+    queue.pause()
+    queue.stop()
+  })
+
   it('drops non-retryable client failures and flushes immediately at the max batch size', async () => {
     const queue = new CrdtUpdateQueue()
     const push = vi.fn(async () => {

--- a/apps/desktop/src/main/sync/crdt-queue.ts
+++ b/apps/desktop/src/main/sync/crdt-queue.ts
@@ -104,11 +104,14 @@ export class CrdtUpdateQueue {
         if (!this.paused) {
           log.error('Failed to push CRDT updates', { noteId, error: err })
         }
+        // 401 stays buffered: the push fn pauses the queue and a successful
+        // token refresh resumes it, so the batch retries instead of dropping.
         const nonRetryable =
           err instanceof SyncServerError &&
           err.statusCode >= 400 &&
           err.statusCode < 500 &&
-          err.statusCode !== 429
+          err.statusCode !== 429 &&
+          err.statusCode !== 401
         if (nonRetryable) return
 
         let existing = this.buffers.get(noteId)

--- a/apps/desktop/src/main/sync/engine/pull-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/pull-coordinator.ts
@@ -16,6 +16,7 @@ import { secureCleanup } from '../../crypto/index'
 import { decryptPullBatch } from '../sync-crypto-batch'
 import { getRemoteSyncAdapter } from '../item-handlers'
 import { withRetry } from '../retry'
+import { engineAuthRetryDeps, withAuthRetry } from '../auth-retry'
 import { postToServer, getFromServer, RateLimitError } from '../http-client'
 import { classifyError } from '../sync-errors'
 import { isBinaryFileType } from '@memry/shared/file-types'
@@ -213,7 +214,7 @@ export class PullCoordinator {
         changesResult = await prefetchedNext
         prefetchedNext = null
       } else {
-        changesResult = await this.fetchChangesPage(runState.accessJwt, cursor)
+        changesResult = await this.fetchChangesPage(runState, cursor)
       }
 
       const changes = changesResult.value
@@ -227,22 +228,30 @@ export class PullCoordinator {
       if (shouldStop) break
 
       if (hasMore && !this.ctx.abortController?.signal.aborted) {
-        prefetchedNext = this.fetchChangesPage(runState.accessJwt, cursor)
+        prefetchedNext = this.fetchChangesPage(runState, cursor)
         prefetchedNext.catch(() => {})
       }
     }
   }
 
   private async fetchChangesPage(
-    accessJwt: string,
+    runState: PullRunState,
     pageCursor: string | null | undefined
   ): ReturnType<typeof withRetry<RecordChangesResponse>> {
     return withRetry(
       () => {
         const cp = pageCursor ? `&cursor=${pageCursor}` : ''
-        return getFromServer<RecordChangesResponse>(
-          `/sync/changes?limit=${this.ctx.options.pullPageLimit}${cp}`,
-          accessJwt
+        return withAuthRetry(
+          (authToken) =>
+            getFromServer<RecordChangesResponse>(
+              `/sync/changes?limit=${this.ctx.options.pullPageLimit}${cp}`,
+              authToken
+            ),
+          runState.accessJwt,
+          engineAuthRetryDeps(this.ctx.deps),
+          (fresh) => {
+            runState.accessJwt = fresh
+          }
         )
       },
       {
@@ -261,14 +270,7 @@ export class PullCoordinator {
     )
     if (itemIds.length === 0) return false
 
-    const pageResult = await this.processPage(
-      itemIds,
-      runState.accessJwt,
-      runState.vaultKey,
-      runState.timer,
-      runState.processedIds,
-      runState.crdtNoteIds
-    )
+    const pageResult = await this.processPage(itemIds, runState)
     runState.pulledCount += pageResult.applied
     runState.totalConflictsResolved += pageResult.conflicts
     await this.applyCrdtBatch(runState)
@@ -430,14 +432,20 @@ export class PullCoordinator {
 
   private async processPage(
     itemIds: string[],
-    accessJwt: string,
-    vaultKey: Uint8Array,
-    timer: SyncTimer,
-    processedIds: Set<string>,
-    crdtNoteIds: string[]
+    runState: PullRunState
   ): Promise<{ applied: number; conflicts: number; allCryptoFailed: boolean }> {
+    const { vaultKey, timer, processedIds, crdtNoteIds } = runState
     const pullResult = await withRetry(
-      () => postToServer<{ items: RecordPullItemResponse[] }>('/sync/pull', { itemIds }, accessJwt),
+      () =>
+        withAuthRetry(
+          (authToken) =>
+            postToServer<{ items: RecordPullItemResponse[] }>('/sync/pull', { itemIds }, authToken),
+          runState.accessJwt,
+          engineAuthRetryDeps(this.ctx.deps),
+          (fresh) => {
+            runState.accessJwt = fresh
+          }
+        ),
       { signal: this.ctx.abortController!.signal, isOnline: () => this.ctx.deps.network.online }
     )
 
@@ -578,7 +586,7 @@ export class PullCoordinator {
       this.corruptTracker.clearExpired()
       const { recovered, permanentFailures } = await this.corruptTracker.refetch(
         allRefetchIds,
-        accessJwt,
+        runState.accessJwt,
         vaultKey
       )
 

--- a/apps/desktop/src/main/sync/engine/push-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.ts
@@ -6,6 +6,7 @@ import { secureCleanup } from '../../crypto/index'
 import { encryptPushBatch } from '../sync-crypto-batch'
 import { getHandler, getRemoteSyncAdapter } from '../item-handlers'
 import { withRetry } from '../retry'
+import { engineAuthRetryDeps, withAuthRetry } from '../auth-retry'
 import { postToServer, RateLimitError } from '../http-client'
 import { classifyError } from '../sync-errors'
 import { isBinaryFileType } from '@memry/shared/file-types'
@@ -77,7 +78,7 @@ export class PushCoordinator {
       this.ctx.abortController = new AbortController()
       const abortSignal = this.ctx.abortController.signal
 
-      const token = await this.ctx.deps.getAccessToken()
+      let token = await this.ctx.deps.getAccessToken()
       if (!token) {
         log.debug('Push aborted: no access token')
         return
@@ -162,10 +163,18 @@ export class PushCoordinator {
           timer.startPhase('network')
           const response = await withRetry(
             () =>
-              postToServer<PushResponse>(
-                '/sync/push',
-                { items: pushItems.map((p) => p.pushItem) },
-                token
+              withAuthRetry(
+                (authToken) =>
+                  postToServer<PushResponse>(
+                    '/sync/push',
+                    { items: pushItems.map((p) => p.pushItem) },
+                    authToken
+                  ),
+                token!,
+                engineAuthRetryDeps(this.ctx.deps),
+                (fresh) => {
+                  token = fresh
+                }
               ),
             {
               signal: abortSignal,

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -547,12 +547,30 @@ describe('sync runtime', () => {
     await runtime.startSyncRuntime()
     const queue = runtimeMocks.CrdtUpdateQueue.instances[0]
 
+    // Recoverable 401: refresh succeeds and the batch retries with the fresh token
     runtimeMocks.postToServer.mockRejectedValueOnce(new runtimeMocks.SyncServerError(401))
+    runtimeMocks.refreshAccessToken.mockResolvedValueOnce(true)
+    runtimeMocks.getValidAccessToken
+      .mockResolvedValueOnce('access-token')
+      .mockResolvedValueOnce('fresh-token')
+    await expect(queue.onBatch?.('note-1', [new Uint8Array([1])])).resolves.toBeUndefined()
+    expect(runtimeMocks.postToServer).toHaveBeenLastCalledWith(
+      '/sync/crdt/updates',
+      expect.objectContaining({ noteId: 'note-1' }),
+      'fresh-token'
+    )
+    expect(queue.pause).not.toHaveBeenCalled()
+    expect(runtimeMocks.emitSessionExpired).not.toHaveBeenCalled()
+
+    // Terminal 401: refresh fails — pause without a false session-expired toast
+    // (token-manager owns that emission on terminal refresh failure)
+    runtimeMocks.postToServer.mockRejectedValueOnce(new runtimeMocks.SyncServerError(401))
+    runtimeMocks.refreshAccessToken.mockResolvedValueOnce(false)
     await expect(queue.onBatch?.('note-1', [new Uint8Array([1])])).rejects.toThrow(
       'sync server error'
     )
     expect(queue.pause).toHaveBeenCalled()
-    expect(runtimeMocks.emitSessionExpired).toHaveBeenCalledTimes(1)
+    expect(runtimeMocks.emitSessionExpired).not.toHaveBeenCalled()
 
     runtimeMocks.postToServer.mockRejectedValueOnce(new runtimeMocks.SyncServerError(413))
     await expect(queue.onBatch?.('note-1', [new Uint8Array([1])])).rejects.toThrow(
@@ -606,7 +624,8 @@ describe('sync runtime', () => {
       'sync server error'
     )
     expect(queue.pause).toHaveBeenCalled()
-    expect(runtimeMocks.emitSessionExpired).toHaveBeenCalled()
+    expect(runtimeMocks.refreshAccessToken).toHaveBeenCalled()
+    expect(runtimeMocks.emitSessionExpired).not.toHaveBeenCalled()
 
     runtimeMocks.pushCrdtSnapshot.mockRejectedValueOnce(new runtimeMocks.SyncServerError(413))
     await expect(snapshotPush('note-quota', new Uint8Array([1]))).rejects.toThrow(

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -53,8 +53,8 @@ import { encryptCrdtUpdate } from './crdt-encrypt'
 import { postToServer, pushCrdtSnapshot, SyncServerError } from './http-client'
 import { EVENT_CHANNELS, type SyncStatusChangedEvent } from '@memry/contracts/ipc-events'
 import { withRetry } from './retry'
+import { withAuthRetry, type AuthRetryDeps } from './auth-retry'
 import {
-  emitSessionExpired,
   getValidAccessToken,
   refreshAccessToken,
   retrieveToken,
@@ -65,6 +65,11 @@ import { getOrCreateVaultUuid } from '../agent/storage/vault-id'
 import { store } from '../store'
 
 const log = createLogger('SyncRuntime')
+
+const crdtAuthRetryDeps: AuthRetryDeps = {
+  refreshAccessToken: () => refreshAccessToken(),
+  getAccessToken: () => getValidAccessToken()
+}
 
 interface SyncRuntimeState {
   queue: SyncQueueManager
@@ -354,7 +359,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
 
       const crdtQueue = new CrdtUpdateQueue()
       crdtQueue.start(async (noteId, updates) => {
-        const token = await getValidAccessToken()
+        let token = await getValidAccessToken()
         const vaultKey = await getOptionalRuntimeVaultKey(db, 'crdt update batch')
         const signingSecretKey = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)
         if (!token || !vaultKey || !signingSecretKey) {
@@ -381,7 +386,16 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
           }
 
           await withRetry(
-            () => postToServer('/sync/crdt/updates', { noteId, updates: b64Updates }, token),
+            () =>
+              withAuthRetry(
+                (authToken) =>
+                  postToServer('/sync/crdt/updates', { noteId, updates: b64Updates }, authToken),
+                token!,
+                crdtAuthRetryDeps,
+                (fresh) => {
+                  token = fresh
+                }
+              ),
             { maxRetries: 3, baseDelayMs: 2000 }
           )
 
@@ -395,8 +409,11 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
           }
         } catch (err) {
           if (err instanceof SyncServerError && err.statusCode === 401) {
+            // withAuthRetry already attempted a refresh. Pause so the
+            // re-buffered batch waits for the next successful refresh
+            // (setOnTokenRefreshed resumes the queue); token-manager owns the
+            // session-expired toast for terminal refresh failures.
             crdtQueue.pause()
-            emitSessionExpired()
           }
           if (err instanceof SyncServerError && err.statusCode === 413) {
             crdtQueue.pause()
@@ -410,7 +427,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       })
 
       const snapshotPushFn = async (noteId: string, state: Uint8Array): Promise<void> => {
-        const token = await getValidAccessToken()
+        let token = await getValidAccessToken()
         const vaultKey = await getOptionalRuntimeVaultKey(db, 'crdt snapshot push')
         const signingSecretKey = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY)
         if (!token || !vaultKey || !signingSecretKey) {
@@ -427,15 +444,28 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
 
         try {
           const encrypted = encryptCrdtUpdate(state, vaultKey, noteId, signingSecretKey)
-          await withRetry(() => pushCrdtSnapshot(noteId, encrypted, token), {
-            maxRetries: 3,
-            baseDelayMs: 2000
-          })
+          await withRetry(
+            () =>
+              withAuthRetry(
+                (authToken) => pushCrdtSnapshot(noteId, encrypted, authToken),
+                token!,
+                crdtAuthRetryDeps,
+                (fresh) => {
+                  token = fresh
+                }
+              ),
+            {
+              maxRetries: 3,
+              baseDelayMs: 2000
+            }
+          )
           log.debug('Pushed CRDT snapshot', { noteId, size: state.byteLength })
         } catch (err) {
           if (err instanceof SyncServerError && err.statusCode === 401) {
+            // withAuthRetry already attempted a refresh — see the update-batch
+            // handler above. The caller keeps pendingSnapshotBytes, so the
+            // snapshot re-pushes after the queue resumes.
             crdtQueue.pause()
-            emitSessionExpired()
           }
           if (err instanceof SyncServerError && err.statusCode === 413) {
             crdtQueue.pause()

--- a/apps/desktop/src/main/sync/vault-directory.test.ts
+++ b/apps/desktop/src/main/sync/vault-directory.test.ts
@@ -9,7 +9,7 @@ vi.mock('./http-client', () => ({
 }))
 
 vi.mock('./token-manager', () => ({
-  retrieveToken: vi.fn(async () => 'access-token')
+  getValidAccessToken: vi.fn(async () => 'access-token')
 }))
 
 vi.mock('../crypto', async (importOriginal) => ({
@@ -46,7 +46,7 @@ vi.mock('./vault-provisioning', () => ({
 }))
 
 import { getFromServer, postToServer } from './http-client'
-import { retrieveToken } from './token-manager'
+import { getValidAccessToken } from './token-manager'
 import {
   getAccountVaultsCache,
   getCurrentVaultPath,
@@ -136,7 +136,14 @@ describe('vault-directory', () => {
           vaultUuid: 'uuid-a'
         },
         // no uuid yet — must be skipped
-        { path: '/v/beta', name: 'Beta', noteCount: 0, taskCount: 0, lastOpened: '', isDefault: false }
+        {
+          path: '/v/beta',
+          name: 'Beta',
+          noteCount: 0,
+          taskCount: 0,
+          lastOpened: '',
+          isDefault: false
+        }
       ])
 
       await refreshVaultDirectory({ force: true })
@@ -205,7 +212,7 @@ describe('vault-directory', () => {
     })
 
     it('is a silent no-op without an access token', async () => {
-      vi.mocked(retrieveToken).mockResolvedValueOnce(null)
+      vi.mocked(getValidAccessToken).mockResolvedValueOnce(null)
 
       await refreshVaultDirectory({ force: true })
 
@@ -255,9 +262,9 @@ describe('vault-directory', () => {
 
   describe('suggestVaultFolder', () => {
     it('slugifies the name under the parent dir', () => {
-      expect(suggestVaultFolder({ vaultUuid: 'uuid-1234567890', name: 'My Vault!' }, '/parent')).toBe(
-        '/parent/my-vault'
-      )
+      expect(
+        suggestVaultFolder({ vaultUuid: 'uuid-1234567890', name: 'My Vault!' }, '/parent')
+      ).toBe('/parent/my-vault')
     })
 
     it('falls back to a uuid-based folder name without a name', () => {

--- a/apps/desktop/src/main/sync/vault-directory.ts
+++ b/apps/desktop/src/main/sync/vault-directory.ts
@@ -15,7 +15,7 @@ import {
   setAccountVaultsCache
 } from '../store'
 import { getFromServer, postToServer } from './http-client'
-import { retrieveToken } from './token-manager'
+import { getValidAccessToken } from './token-manager'
 import { decryptVaultName, encryptVaultName } from './vault-name-crypto'
 
 const log = createLogger('VaultDirectory')
@@ -55,7 +55,7 @@ async function getNameKey(): Promise<Uint8Array | null> {
 export async function refreshVaultDirectory(opts?: { force?: boolean }): Promise<void> {
   if (!opts?.force && Date.now() - lastRefreshAt < REFRESH_THROTTLE_MS) return
 
-  const token = await retrieveToken(KEYCHAIN_ENTRIES.ACCESS_TOKEN)
+  const token = await getValidAccessToken()
   if (!token) return
   const nameKey = await getNameKey()
   if (!nameKey) return

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -161,14 +161,14 @@ list.
 
 ## Error Modes
 
-| Failure            | Behavior                                                   |
-| ------------------ | ---------------------------------------------------------- |
-| Offline            | Outbox queues; retry with backoff                          |
-| Auth expired       | Refresh token; if rotation failed, prompt sign-in          |
-| Payment required   | Sync stays local-only until a paid plan is active          |
-| Quota exceeded     | Surfaces in [Settings → Vault](/user-guide/settings#vault) |
-| Server unavailable | Exponential backoff; status indicator turns yellow         |
-| Blob hash mismatch | Reject the item; log; alert health view                    |
+| Failure            | Behavior                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| Offline            | Outbox queues; retry with backoff                                                          |
+| Auth expired (401) | Refresh the access token and retry the request once; only a failed refresh prompts sign-in |
+| Payment required   | Sync stays local-only until a paid plan is active                                          |
+| Quota exceeded     | Surfaces in [Settings → Vault](/user-guide/settings#vault)                                 |
+| Server unavailable | Exponential backoff; status indicator turns yellow                                         |
+| Blob hash mismatch | Reject the item; log; alert health view                                                    |
 
 ## Encryption Stays End-to-End
 


### PR DESCRIPTION
## What
On a `401` mid sync cycle, refresh the access token and retry the request once instead of failing the cycle — killing the prod Loki "exp claim" 401 noise and the false "Session expired" toast.

- `withAuthRetry` wraps push / pull / CRDT fetches: 401 → `refreshAccessToken()` → retry once with the fresh token; `sync_error` telemetry only fires if the retry also fails.
- CRDT 401 no longer calls `emitSessionExpired()` — token-manager owns that on terminal refresh failure. The queue re-buffers the 401 batch and resumes after the next successful refresh.
- Restore `pendingSnapshotBytes` on a failed snapshot push so shutdown `pushAllSnapshots` still re-pushes the note (closes a bounded propagation gap).
- `vault-directory` resolves the token via `getValidAccessToken()`.

## Why
Coordinators resolved the token once per cycle and reused it; proactive refresh can't cover a token expiring mid-cycle (long syncs, sleep/wake). All client-local, no protocol change, backward-compat safe.