### PR TITLE
Seed a curated Home board + fix note icons lost on index rebuild

### DIFF
--- a/apps/desktop/scripts/seed-data/home.ts
+++ b/apps/desktop/scripts/seed-data/home.ts
@@ -1,0 +1,42 @@
+import type { SeedBookmark, SeedHomePage } from '../seed-vault/db-writer'
+import { NOTE_IDS } from './notes'
+
+// A curated default Home board so a freshly seeded vault opens on a full,
+// nicely arranged dashboard instead of the app's bare first-run auto-seed
+// (recently-edited + bookmarks only). The app only auto-seeds when zero boards
+// exist, so this row is left untouched once written.
+//
+// Coords are react-grid-layout units on the 8-column Home grid. Every widget
+// type here populates from existing seed data (tasks, calendar, inbox, journal,
+// notes, folders, bookmarks).
+export const HOME_PAGES: SeedHomePage[] = [
+  {
+    id: 'home-demo',
+    name: 'Home',
+    icon: '🏠',
+    position: 0,
+    widgets: [
+      // Hero row — today's tasks + agenda, taller than the rest.
+      { id: 'w-tasks', type: 'tasks', x: 0, y: 0, w: 4, h: 5, config: { dateRange: 'today' } },
+      { id: 'w-calendar', type: 'calendar', x: 4, y: 0, w: 4, h: 5 },
+      // Capture + reflect.
+      { id: 'w-inbox', type: 'inbox', x: 0, y: 5, w: 4, h: 4 },
+      { id: 'w-journal', type: 'journal', x: 4, y: 5, w: 4, h: 4 },
+      // Browse.
+      { id: 'w-recent', type: 'recently-edited', x: 0, y: 9, w: 4, h: 4 },
+      { id: 'w-folder', type: 'folder', x: 4, y: 9, w: 4, h: 4, config: { folderPath: 'books' } },
+      // Full-width footer.
+      { id: 'w-bookmarks', type: 'bookmarks', x: 0, y: 13, w: 8, h: 3 }
+    ]
+  }
+]
+
+// Favorite notes surfaced by the bookmarks widget. Note bookmarks resolve their
+// title via the index DB once the vault is indexed (ids adopted by file path —
+// the same mechanism task→note links rely on). itemType 'note' matches
+// BookmarkItemTypes.NOTE.
+export const HOME_BOOKMARKS: SeedBookmark[] = [
+  { id: 'bm-hail-mary', itemType: 'note', itemId: NOTE_IDS.bookProjectHailMary, position: 0 },
+  { id: 'bm-atomic-habits', itemType: 'note', itemId: NOTE_IDS.bookAtomicHabits, position: 1 },
+  { id: 'bm-dune', itemType: 'note', itemId: NOTE_IDS.bookDune, position: 2 }
+]

--- a/apps/desktop/scripts/seed-data/notes.ts
+++ b/apps/desktop/scripts/seed-data/notes.ts
@@ -86,7 +86,8 @@ export const NOTE_IDS = {
   travelMexicoCityArt: generateNoteId(),
   travelOsakaRamen: generateNoteId(),
   travelTokyoCafes: generateNoteId(),
-  travelAirportLounges: generateNoteId()
+  travelAirportLounges: generateNoteId(),
+  travelRomeWeekend: generateNoteId()
 } as const
 
 export const FOLDER_CONFIGS: Array<{ path: string; icon: string }> = [
@@ -2165,6 +2166,58 @@ Pair with [[Kitchen Confidential]] for the *travel-as-eating* mindset.
 - Most "premier" Priority Pass options. Fine, not great.
 
 #travel #logistics
+`
+  },
+  {
+    id: NOTE_IDS.travelRomeWeekend,
+    relativePath: 'travel/Weekend in Rome.md',
+    title: 'Weekend in Rome',
+    emoji: '🏛️',
+    tags: ['travel/europe', 'food', 'city-break', 'favorites'],
+    aliases: ['Rome trip', 'Rome city break'],
+    customProps: {
+      location: 'Rome, Italy',
+      startDate: '2026-09-18',
+      endDate: '2026-09-20',
+      status: 'planning'
+    },
+    daysAgoCreated: -2,
+    daysAgoModified: 0,
+    body: `Three slow days — old streets in the morning, long lunches, golden-hour walks. The trip where we finally don't over-plan.
+
+> [!tip] One neighborhood a day
+> Pick an anchor sight, then wander the rest on foot. Rome is best with frequent coffee stops.
+
+## Trip snapshot
+
+| Day | Morning | Afternoon | Evening |
+|----------|---------|-----------|---------|
+| Friday | Land, drop bags in Trastevere | Wander the lanes + first gelato | Dinner on a piazza |
+| Saturday | Colosseum & Forum (go early) | Pantheon → Trevi Fountain | Sunset from Gianicolo hill |
+| Sunday | Vatican Museums (book ahead) | Long lunch, slow espresso | Fly home |
+
+## Must-eat
+
+- **Cacio e pepe** — the whole reason we're here
+- Supplì from a street counter
+- A maritozzo for breakfast
+- Gelato, twice a day (rules don't apply on holiday)
+
+## Before we go
+
+- [x] Book Vatican tickets — skip-the-line
+- [x] Download an offline map of the center
+- [ ] Break in the comfortable shoes — see [[Packing List]]
+- [ ] Learn five words of Italian
+- [ ] Save the hotel address for offline
+
+## Links
+
+- Journal: [[2026-07-10]]
+- Packing: [[Packing List]]
+- Food notes: [[Food Diary]]
+
+#travel/europe #food #city-break
 `
   }
 ]

--- a/apps/desktop/scripts/seed-vault.ts
+++ b/apps/desktop/scripts/seed-vault.ts
@@ -14,10 +14,12 @@ import { homedir } from 'os'
 import { wipeVault } from './seed-vault/wipe'
 import { writeNoteFiles } from './seed-vault/file-writer'
 import {
+  insertBookmarks,
   insertCalendarEvents,
   insertCalendarSources,
   insertFilingHistory,
   insertFolderConfigs,
+  insertHomePages,
   insertInboxItems,
   insertProjects,
   insertNoteMetadata,
@@ -35,6 +37,7 @@ import { JOURNAL_NOTES, JOURNAL_METADATA } from './seed-data/journal'
 import { PROJECTS, STATUSES, TASKS, TASK_NOTES, TASK_TAGS } from './seed-data/tasks'
 import { CALENDAR_EVENTS, CALENDAR_SOURCES } from './seed-data/calendar'
 import { FILING_HISTORY_ROWS, INBOX_ITEMS } from './seed-data/inbox'
+import { HOME_BOOKMARKS, HOME_PAGES } from './seed-data/home'
 
 interface CliArgs {
   vaultPath: string
@@ -75,6 +78,9 @@ const TAG_PALETTE = [
   { name: 'travel/asia', color: '#f97316' },
   { name: 'travel/europe', color: '#0ea5e9' },
   { name: 'travel/japan', color: '#ef4444' },
+  { name: 'food', color: '#e11d48' },
+  { name: 'city-break', color: '#22c55e' },
+  { name: 'favorites', color: '#f59e0b' },
   { name: 'fitness', color: '#84cc16' },
   { name: 'reading', color: '#f59e0b' },
   { name: 'daily', color: '#6366f1' },
@@ -182,6 +188,12 @@ function main(): void {
 
     const filingCount = insertFilingHistory(db, FILING_HISTORY_ROWS)
     console.log(`  → filing_history: ${filingCount}`)
+
+    const bookmarkCount = insertBookmarks(db, HOME_BOOKMARKS)
+    console.log(`  → bookmarks: ${bookmarkCount}`)
+
+    const homePageCount = insertHomePages(db, HOME_PAGES)
+    console.log(`  → home_pages: ${homePageCount}`)
   } finally {
     close()
   }
@@ -195,7 +207,7 @@ function main(): void {
   console.log('')
   console.log('Done.')
   console.log(
-    `Seeded ${notesWritten} notes, ${journalsWritten} journal entries, ${TASKS.length} tasks, ${CALENDAR_EVENTS.length} events, ${INBOX_ITEMS.length} inbox items.`
+    `Seeded ${notesWritten} notes, ${journalsWritten} journal entries, ${TASKS.length} tasks, ${CALENDAR_EVENTS.length} events, ${INBOX_ITEMS.length} inbox items, ${HOME_PAGES.length} home board with ${HOME_PAGES[0].widgets.length} widgets.`
   )
   console.log(`Vault path: ${vaultPath}`)
   console.log('')

--- a/apps/desktop/scripts/seed-vault/db-writer.ts
+++ b/apps/desktop/scripts/seed-vault/db-writer.ts
@@ -456,3 +456,73 @@ export function insertFilingHistory(db: DataDb, history: SeedFilingHistory[]): n
   }
   return history.length
 }
+
+export interface SeedHomeWidget {
+  id: string
+  type: string
+  // react-grid-layout coords on the 8-column Home grid.
+  x: number
+  y: number
+  w: number
+  h: number
+  config?: Record<string, unknown>
+}
+
+export interface SeedHomePage {
+  id: string
+  name: string
+  icon?: string | null
+  position: number
+  widgets: SeedHomeWidget[]
+}
+
+export function insertHomePages(db: DataDb, pages: SeedHomePage[]): number {
+  if (pages.length === 0) return 0
+  db.insert(schema.homePages)
+    .values(
+      pages.map((p) => ({
+        id: p.id,
+        name: p.name,
+        icon: p.icon ?? null,
+        position: p.position,
+        // widgets column is JSON-encoded WidgetInstance[]; parsed by the IPC layer.
+        widgets: JSON.stringify(
+          p.widgets.map((w) => ({
+            id: w.id,
+            type: w.type,
+            x: w.x,
+            y: w.y,
+            w: w.w,
+            h: w.h,
+            config: w.config ?? {}
+          }))
+        )
+      }))
+    )
+    .run()
+  return pages.length
+}
+
+export interface SeedBookmark {
+  id: string
+  itemType: string
+  itemId: string
+  position: number
+  createdAt?: string
+}
+
+export function insertBookmarks(db: DataDb, rows: SeedBookmark[]): number {
+  if (rows.length === 0) return 0
+  db.insert(schema.bookmarks)
+    .values(
+      rows.map((b) => ({
+        id: b.id,
+        itemType: b.itemType,
+        itemId: b.itemId,
+        position: b.position,
+        ...(b.createdAt ? { createdAt: b.createdAt } : {})
+      }))
+    )
+    .run()
+  return rows.length
+}

--- a/apps/desktop/src/main/vault/indexer.test.ts
+++ b/apps/desktop/src/main/vault/indexer.test.ts
@@ -460,5 +460,52 @@ Copied note`
         .get()
       expect(after).toEqual(expect.objectContaining({ id: before?.id, path: relativePath }))
     })
+
+    it('T376: preserves note emoji across index rebuilds via note_metadata byPath', async () => {
+      // Emoji is DB-only sidecar state — never written to the vault file — so a
+      // cache rebuilt purely from files would lose the icon unless the indexer
+      // adopts emoji from note_metadata byPath (as it does for the canonical id).
+      const notePath = createTestNote(tempVault, {
+        title: 'Iconic Note',
+        content: 'Emoji lives in the sidecar DB, not the file'
+      })
+      const relativePath = path.relative(tempVault.path, notePath).replace(/\\/g, '/')
+
+      // First index records the canonical note_metadata row (emoji null — the
+      // file carries none). A seed / user-set icon then writes emoji DB-side.
+      await indexer.indexVault(tempVault.path)
+      dataDb.db
+        .update(noteMetadata)
+        .set({ emoji: '🪐' })
+        .where(eq(noteMetadata.path, relativePath))
+        .run()
+
+      // Simulate the rebuild deleting index.db: wipe the index cache tables
+      vi.spyOn(database, 'runIndexMigrations').mockImplementation(() => {
+        testDb.db.delete(noteTags).run()
+        testDb.db.delete(noteLinks).run()
+        testDb.db.delete(noteCache).run()
+      })
+
+      const rebuild = await indexer.rebuildIndex(tempVault.path)
+      expect(rebuild.filesIndexed).toBe(1)
+
+      // The re-indexed cache row adopts the emoji from note_metadata byPath, so
+      // the note keeps its icon instead of falling back to the default glyph.
+      const cacheRow = testDb.db
+        .select()
+        .from(noteCache)
+        .where(eq(noteCache.path, relativePath))
+        .get()
+      expect(cacheRow?.emoji).toBe('🪐')
+
+      // ...and the same pass must not clobber the emoji back to null data-side.
+      const after = dataDb.db
+        .select()
+        .from(noteMetadata)
+        .where(eq(noteMetadata.path, relativePath))
+        .get()
+      expect(after?.emoji).toBe('🪐')
+    })
   })
 })

--- a/apps/desktop/src/main/vault/indexer.ts
+++ b/apps/desktop/src/main/vault/indexer.ts
@@ -164,13 +164,13 @@ async function indexMarkdownFile(
   const stats = await stat(absolutePath).catch(() => null)
   const parsed = parseNote(content, relativePath, stats ?? undefined)
 
-  let canonicalId: string | undefined
+  let canonical: ReturnType<typeof getNoteMetadataByPath>
   try {
-    canonicalId = getNoteMetadataByPath(getDatabase(), relativePath)?.id
+    canonical = getNoteMetadataByPath(getDatabase(), relativePath)
   } catch {
     // data DB not ready — fall back to a fresh id
   }
-  const noteId = canonicalId ?? parsed.id
+  const noteId = canonical?.id ?? parsed.id
 
   // Use syncNoteToCache for unified cache operations
   try {
@@ -183,6 +183,11 @@ async function indexMarkdownFile(
         frontmatter: parsed.frontmatter,
         parsedContent: parsed.content,
         title: parsed.title,
+        // Emoji is DB-only sidecar state (never written to the file); adopt it
+        // from note_metadata by path so index rebuilds preserve the note icon,
+        // mirroring the canonical-id adoption above. Without this the cache row
+        // is written with emoji=null and the note falls back to the default icon.
+        emoji: canonical?.emoji,
         createdAt: parsed.created,
         modifiedAt: parsed.modified
       },


### PR DESCRIPTION
## What

Two related changes so a freshly **seeded** vault looks great on first open.

### 1. `fix(desktop)`: preserve note emoji across index rebuilds
The renderer reads a note's icon from `note_cache.emoji` (index DB). The indexer rebuilds `note_cache` from vault **files**, adopting only the canonical `id` from `note_metadata` by path — never the `emoji`. Emoji is DB-only sidecar state (deliberately not in the file, per the "frontmatter diet"), so a rebuild wrote `note_cache.emoji = null` → the note fell back to the default `FileText` icon. The same pass also **clobbered `note_metadata.emoji → null`** via the id-conflict upsert.

Fix: adopt `emoji` from `note_metadata` by path alongside the `id` (one spot in `indexMarkdownFile`). This restores note icons across index rebuilds **and** lets the seeded emoji surface. This is a real production bug, not just a seed issue — any full reindex was dropping user-set note icons.

### 2. `feat(desktop)`: seed a curated Home board + bookmarks
`pnpm seed` previously created **no** `home_pages` row, so the app auto-seeded a bare board (recently-edited + bookmarks). Now the seed writes:
- A **Home** board (🏠) with all 7 widget types in a 2-column magazine layout: tasks (today) + calendar hero, then inbox + journal, recently-edited + folder(`books`), bookmarks full-width footer.
- 3 note **bookmarks** (Project Hail Mary / Atomic Habits / Dune).
- Two travel notes (Weekend in Rome, Airport Lounges) + a few tags.

The app only auto-seeds a default board when `boards.length === 0`, so the seeded board wins and real installs are untouched.

## Verification
- New test `indexer.test.ts › preserves note emoji across index rebuilds`: **RED** without the fix (`expected null to be '🪐'`), **GREEN** with it.
- Full desktop main suite: **3446 passed**. `typecheck:node`: **0 errors**. `indexer.ts` lint-clean.
- `pnpm seed` runs clean: `home_pages: 1`, `bookmarks: 3`, all 3 bookmarks resolve to real notes; tasks-today widget has 5 due-today tasks (relative dates stay fresh on seed day).

## Docs
`docs:impact` flags `apps/desktop/{src,scripts}` paths as docs-relevant, but these changes are an **internal bugfix** (restoring intended icon persistence) and **dev-only seed tooling** — no user-facing surface to document. No `apps/docs/src` change included; flag me if the docs gate should be satisfied differently.

## Notes / follow-up
- The same adoption gap likely affects **`localOnly`** (also DB-only sidecar state, also not adopted on rebuild). Left out of this PR to keep it surgical + avoid sync-policy blast radius — worth a separate look.
