### PR TITLE
Windows: fix installer crash (electron-builder bump), memry-file paths, and cloud-lock write retries

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -417,7 +417,7 @@ jobs:
           New-Item -ItemType Directory -Path $assetDir | Out-Null
 
           Get-ChildItem apps/desktop/dist -File |
-            Where-Object { $_.Name -like '*.exe' -or $_.Name -like '*.blockmap' -or $_.Name -eq 'latest.yml' } |
+            Where-Object { $_.Name -like '*.exe' -or $_.Name -like '*-win.zip' -or $_.Name -like '*.blockmap' -or $_.Name -eq 'latest.yml' } |
             Copy-Item -Destination $assetDir
 
           Get-ChildItem $assetDir | Format-Table Name, Length
@@ -682,6 +682,7 @@ jobs:
           require_glob '*.zip' 'Missing macOS ZIP.'
           require_file 'latest-mac.yml' 'Missing latest-mac.yml.'
           require_glob '*.exe' 'Missing Windows installer.'
+          require_glob '*-win.zip' 'Missing Windows ZIP.'
           require_file 'latest.yml' 'Missing Windows latest.yml.'
           require_glob '*.AppImage' 'Missing Linux AppImage.'
           require_glob '*.deb' 'Missing Linux deb.'

--- a/apps/desktop/config/electron-builder.yml
+++ b/apps/desktop/config/electron-builder.yml
@@ -37,6 +37,10 @@ extraResources:
     to: app-config
 win:
   executableName: Memrynote
+  artifactName: ${productName}-${version}-win.${ext}
+  target:
+    - nsis
+    - zip
 nsis:
   artifactName: ${productName}-${version}-setup.${ext}
   shortcutName: ${productName}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -230,7 +230,7 @@
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
     "electron": "^39.8.6",
-    "electron-builder": "^26.0.12",
+    "electron-builder": "^26.15.6",
     "electron-store": "^11.0.2",
     "electron-updater": "^6.6.2",
     "electron-vite": "^5.0.0",

--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -286,7 +286,7 @@ vi.mock('./lib/logger', () => {
     error: vi.fn()
   }
   return {
-    log: { initialize: vi.fn() },
+    log: { initialize: vi.fn(), warn: vi.fn() },
     createLogger: vi.fn(() => scopedLogger),
     disableConsoleTransport: disableConsoleTransportMock,
     applyPackagedLogLevels: applyPackagedLogLevelsMock
@@ -323,7 +323,7 @@ vi.mock('electron', () => ({
     exit: vi.fn(),
     dock: { setIcon: vi.fn() }
   },
-  shell: { openExternal: vi.fn() },
+  shell: { openExternal: vi.fn(), openPath: vi.fn() },
   BrowserWindow: BrowserWindowMock,
   ipcMain: {
     on: ipcMainOnMock,
@@ -982,6 +982,50 @@ describe('main index phase2 exports', () => {
     const preventDefault = vi.fn()
     beforeInput({ preventDefault }, { key: 'BrowserBack' })
     expect(preventDefault).toHaveBeenCalled()
+  })
+
+  it('routes memry-file window opens to shell.openPath instead of openExternal', async () => {
+    whenReadyMock.mockResolvedValue(undefined)
+
+    await importMainModule()
+    await flushReadyWork()
+
+    const { shell } = await import('electron')
+    const createdWindow = browserWindows[0]
+    const openHandler = createdWindow.webContents.setWindowOpenHandler.mock
+      .calls[0][0] as (details: { url: string }) => { action: string }
+
+    getCurrentVaultPathMock.mockReturnValue('/mock/vault')
+
+    expect(openHandler({ url: 'memry-file://local/mock/vault/files/photo%201.png' })).toEqual({
+      action: 'deny'
+    })
+    expect(shell.openPath).toHaveBeenCalledWith('/mock/vault/files/photo 1.png')
+    expect(shell.openExternal).not.toHaveBeenCalled()
+
+    vi.mocked(shell.openPath).mockClear()
+    expect(openHandler({ url: 'memry-file://local/mock/elsewhere/secret.txt' })).toEqual({
+      action: 'deny'
+    })
+    expect(shell.openPath).not.toHaveBeenCalled()
+
+    expect(openHandler({ url: 'smb://host/share' })).toEqual({ action: 'deny' })
+    expect(shell.openPath).not.toHaveBeenCalled()
+    expect(shell.openExternal).not.toHaveBeenCalled()
+
+    expect(openHandler({ url: 'https://memrynote.com' })).toEqual({ action: 'deny' })
+    expect(shell.openExternal).toHaveBeenCalledWith('https://memrynote.com')
+    expect(shell.openPath).not.toHaveBeenCalled()
+  })
+
+  it('logs the app version and channel at startup', async () => {
+    await importMainModule()
+
+    const { createLogger } = await import('./lib/logger')
+    const scoped = vi.mocked(createLogger).mock.results[0]?.value as {
+      info: ReturnType<typeof vi.fn>
+    }
+    expect(scoped.info).toHaveBeenCalledWith('MemryNote 1.0.0 starting (dev)')
   })
 
   it('reveals the main window via fallback timeout when ready-to-show never fires', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -15,7 +15,7 @@ import {
   dialog
 } from 'electron'
 import { createHash } from 'node:crypto'
-import { join, resolve, normalize } from 'path'
+import { join, resolve, normalize, sep } from 'path'
 import { homedir } from 'node:os'
 import { existsSync, readdirSync, statSync, createReadStream } from 'node:fs'
 import { lookup as mimeLookup } from 'mime-types'
@@ -56,7 +56,7 @@ import {
   triggerGoogleCalendarSyncNow
 } from './calendar/google/sync-service'
 import { log, createLogger, disableConsoleTransport, applyPackagedLogLevels } from './lib/logger'
-import { isAllowedExternalUrl } from './lib/external-url'
+import { isAllowedExternalUrl, isPathInsideDirs, resolveMemryFilePath } from './lib/external-url'
 import { registerTestHooks } from './test-hooks'
 import {
   computeSpkiHashFromPem,
@@ -237,6 +237,8 @@ if (envResult.error) {
 if (app.isPackaged) {
   applyPackagedLogLevels()
 }
+
+mainLog.info(`MemryNote ${app.getVersion()} starting (${app.isPackaged ? 'packaged' : 'dev'})`)
 
 // Register custom protocol as privileged before app is ready
 // This enables streaming support for audio/video elements
@@ -585,6 +587,18 @@ function createWindow(): void {
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
+    const memryFilePath = resolveMemryFilePath(details.url)
+    if (memryFilePath) {
+      const allowedDirs = [app.getPath('userData'), getCurrentVaultPath(), getVaultStatus().path]
+        .filter((dir): dir is string => Boolean(dir))
+        .map((dir) => resolve(dir))
+      if (allowedDirs.some((dir) => memryFilePath.startsWith(dir + sep))) {
+        void shell.openPath(memryFilePath)
+      } else {
+        log.warn('Blocked memry-file open outside allowed directories', { path: memryFilePath })
+      }
+      return { action: 'deny' }
+    }
     if (isAllowedExternalUrl(details.url)) {
       void shell.openExternal(details.url)
     } else {
@@ -967,7 +981,7 @@ const appReady = app.whenReady().then(async () => {
       if (!allowedDirs.includes(resolvedVaultPath)) allowedDirs.push(resolvedVaultPath)
     }
 
-    const isAllowed = allowedDirs.some((dir) => filePath.startsWith(dir + '/') || filePath === dir)
+    const isAllowed = isPathInsideDirs(filePath, allowedDirs)
     if (!isAllowed) {
       mainLog.warn('memry-file: blocked path outside allowed directories', { filePath })
       return new Response(null, { status: 403, statusText: 'Forbidden' })

--- a/apps/desktop/src/main/lib/external-url.test.ts
+++ b/apps/desktop/src/main/lib/external-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isAllowedExternalUrl } from './external-url'
+import { isAllowedExternalUrl, isPathInsideDirs, resolveMemryFilePath } from './external-url'
 
 describe('isAllowedExternalUrl', () => {
   it('allows https, http, and mailto schemes', () => {
@@ -12,10 +12,84 @@ describe('isAllowedExternalUrl', () => {
     expect(isAllowedExternalUrl('file:///etc/passwd')).toBe(false)
     expect(isAllowedExternalUrl('smb://host/share')).toBe(false)
     expect(isAllowedExternalUrl('javascript:alert(1)')).toBe(false)
+    expect(isAllowedExternalUrl('memry-file://local/Users/kaan/vault/file.png')).toBe(false)
   })
 
   it('blocks empty and unparseable input', () => {
     expect(isAllowedExternalUrl('')).toBe(false)
     expect(isAllowedExternalUrl('not a url')).toBe(false)
+  })
+})
+
+describe('resolveMemryFilePath', () => {
+  it('resolves posix memry-file URLs to absolute paths', () => {
+    expect(resolveMemryFilePath('memry-file://local/Users/kaan/vault/file.png', 'darwin')).toBe(
+      '/Users/kaan/vault/file.png'
+    )
+  })
+
+  it('decodes percent-encoded characters', () => {
+    expect(
+      resolveMemryFilePath('memry-file://local/Users/kaan/vault/my%20file.pdf', 'darwin')
+    ).toBe('/Users/kaan/vault/my file.pdf')
+  })
+
+  it('resolves windows memry-file URLs to backslash paths', () => {
+    expect(
+      resolveMemryFilePath('memry-file://local/C:/Users/Leib.000/Koofr/0-WAITING/doc.pdf', 'win32')
+    ).toBe('C:\\Users\\Leib.000\\Koofr\\0-WAITING\\doc.pdf')
+  })
+
+  it('normalizes traversal segments before returning', () => {
+    expect(
+      resolveMemryFilePath('memry-file://local/Users/kaan/vault/../secret.txt', 'darwin')
+    ).toBe('/Users/kaan/secret.txt')
+  })
+
+  it('returns null for non memry-file URLs and malformed input', () => {
+    expect(resolveMemryFilePath('https://example.com', 'darwin')).toBeNull()
+    expect(resolveMemryFilePath('not a url', 'darwin')).toBeNull()
+    expect(resolveMemryFilePath('memry-file://local/%zz', 'darwin')).toBeNull()
+  })
+})
+
+describe('isPathInsideDirs', () => {
+  it('matches windows backslash paths inside an allowed directory', () => {
+    expect(
+      isPathInsideDirs(
+        'C:\\Users\\Leib.000\\Koofr\\0-WAITING\\100 Healthy Habits.pdf',
+        ['C:\\Users\\Leib.000\\Koofr\\0-WAITING'],
+        'win32'
+      )
+    ).toBe(true)
+  })
+
+  it('matches the directory itself', () => {
+    expect(isPathInsideDirs('/Users/kaan/vault', ['/Users/kaan/vault'], 'darwin')).toBe(true)
+  })
+
+  it('rejects prefix-sibling directories on both platforms', () => {
+    expect(
+      isPathInsideDirs(
+        'C:\\Users\\Leib.000\\Koofr\\0-WAITING-evil\\doc.pdf',
+        ['C:\\Users\\Leib.000\\Koofr\\0-WAITING'],
+        'win32'
+      )
+    ).toBe(false)
+    expect(
+      isPathInsideDirs('/Users/kaan/vault-evil/doc.pdf', ['/Users/kaan/vault'], 'darwin')
+    ).toBe(false)
+  })
+
+  it('matches posix paths inside an allowed directory', () => {
+    expect(isPathInsideDirs('/Users/kaan/vault/doc.pdf', ['/Users/kaan/vault'], 'darwin')).toBe(
+      true
+    )
+  })
+
+  it('rejects paths outside every allowed directory', () => {
+    expect(
+      isPathInsideDirs('C:\\Windows\\System32\\evil.dll', ['C:\\Users\\Leib.000\\Koofr'], 'win32')
+    ).toBe(false)
   })
 })

--- a/apps/desktop/src/main/lib/external-url.ts
+++ b/apps/desktop/src/main/lib/external-url.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+
 const EXTERNAL_URL_ALLOWED_SCHEMES = new Set(['https:', 'http:', 'mailto:'])
 
 /**
@@ -11,4 +13,47 @@ export function isAllowedExternalUrl(rawUrl: string): boolean {
   } catch {
     return false
   }
+}
+
+/**
+ * Resolves a memry-file://local/<absolute path> URL to its absolute filesystem
+ * path using the same decoding rules as the memry-file protocol handler.
+ * Returns null for anything that is not a valid memry-file URL.
+ */
+export function resolveMemryFilePath(
+  rawUrl: string,
+  platform: NodeJS.Platform = process.platform
+): string | null {
+  try {
+    const url = new URL(rawUrl)
+    if (url.protocol !== 'memry-file:') return null
+
+    let filePath = decodeURIComponent(url.pathname)
+    const pathModule = platform === 'win32' ? path.win32 : path.posix
+    if (platform === 'win32') {
+      if (filePath.startsWith('/')) filePath = filePath.slice(1)
+    } else if (!filePath.startsWith('/')) {
+      filePath = '/' + filePath
+    }
+
+    return pathModule.resolve(pathModule.normalize(filePath))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Whether an absolute path is one of the given directories or inside one,
+ * using the platform's separator so Windows backslash paths match correctly.
+ */
+export function isPathInsideDirs(
+  filePath: string,
+  dirs: string[],
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  const pathModule = platform === 'win32' ? path.win32 : path.posix
+  return dirs.some((dir) => {
+    const resolvedDir = pathModule.resolve(dir)
+    return filePath === resolvedDir || filePath.startsWith(resolvedDir + pathModule.sep)
+  })
 }

--- a/apps/desktop/src/main/sync/attachments.ts
+++ b/apps/desktop/src/main/sync/attachments.ts
@@ -7,7 +7,7 @@ import { net } from 'electron'
 
 import { createLogger } from '../lib/logger'
 import { secureDeleteFile } from '../lib/secure-fs'
-import { ensureDirectory } from '../vault/file-ops'
+import { ensureDirectory, withTransientFsRetry } from '../vault/file-ops'
 import { encrypt, decrypt, wrapFileKey, unwrapFileKey } from '../crypto/encryption'
 import { generateFileKey } from '../crypto/keys'
 import { secureCleanup } from '../crypto/index'
@@ -793,26 +793,33 @@ export class AttachmentSyncService {
 
   private async atomicWriteBinary(filePath: string, data: Buffer): Promise<void> {
     const dir = path.dirname(filePath)
-    const tempPath = path.join(dir, `.${randomBytes(6).toString('hex')}.tmp`)
 
     await ensureDirectory(dir)
 
-    let handle: Awaited<ReturnType<typeof open>> | null = null
     try {
-      handle = await open(tempPath, 'wx', 0o600)
-      await handle.writeFile(data)
-      await handle.close()
-      handle = null
-      await rename(tempPath, filePath)
+      await withTransientFsRetry(async () => {
+        const tempPath = path.join(dir, `.${randomBytes(6).toString('hex')}.tmp`)
+
+        let handle: Awaited<ReturnType<typeof open>> | null = null
+        try {
+          handle = await open(tempPath, 'wx', 0o600)
+          await handle.writeFile(data)
+          await handle.close()
+          handle = null
+          await rename(tempPath, filePath)
+        } catch (error) {
+          if (handle) {
+            await handle.close().catch(() => {})
+          }
+          try {
+            await secureDeleteFile(tempPath)
+          } catch {
+            // ignore cleanup errors
+          }
+          throw error
+        }
+      })
     } catch {
-      if (handle) {
-        await handle.close().catch(() => {})
-      }
-      try {
-        await secureDeleteFile(tempPath)
-      } catch {
-        // ignore cleanup errors
-      }
       throw new Error(`Failed to write attachment: ${filePath}`)
     }
   }

--- a/apps/desktop/src/main/vault/file-ops.test.ts
+++ b/apps/desktop/src/main/vault/file-ops.test.ts
@@ -3,10 +3,11 @@
  * Tests atomic file operations for safe reading and writing.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import { rename } from 'fs/promises'
 import {
   atomicWrite,
   safeRead,
@@ -24,6 +25,14 @@ import {
   generateUniquePathSync
 } from './file-ops'
 import { NoteError } from '../lib/errors'
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>()
+  return {
+    ...actual,
+    rename: vi.fn(actual.rename)
+  }
+})
 
 // ============================================================================
 // Test Helpers
@@ -111,6 +120,66 @@ describe('atomicWrite', () => {
     const files = fs.readdirSync(tempDir.path)
     const tempFiles = files.filter((f) => f.startsWith('.') && f.endsWith('.tmp'))
     expect(tempFiles).toHaveLength(0)
+  })
+})
+
+// ============================================================================
+// atomicWrite Transient Lock Retry Tests
+// ============================================================================
+
+describe('atomicWrite transient lock retry', () => {
+  let tempDir: TestDir
+  const renameMock = vi.mocked(rename)
+
+  function errnoError(code: string): NodeJS.ErrnoException {
+    const error = new Error(`${code}: resource busy`) as NodeJS.ErrnoException
+    error.code = code
+    return error
+  }
+
+  beforeEach(() => {
+    tempDir = createTempDir()
+    renameMock.mockClear()
+  })
+
+  afterEach(() => {
+    tempDir.cleanup()
+  })
+
+  it('retries rename on transient EBUSY and completes the write', async () => {
+    const filePath = path.join(tempDir.path, 'locked.txt')
+    renameMock.mockRejectedValueOnce(errnoError('EBUSY')).mockRejectedValueOnce(errnoError('EBUSY'))
+
+    await atomicWrite(filePath, 'content after retry')
+
+    expect(renameMock).toHaveBeenCalledTimes(3)
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe('content after retry')
+  })
+
+  it('propagates the error after exhausting retries on persistent EBUSY', async () => {
+    const filePath = path.join(tempDir.path, 'always-locked.txt')
+    renameMock
+      .mockRejectedValueOnce(errnoError('EBUSY'))
+      .mockRejectedValueOnce(errnoError('EBUSY'))
+      .mockRejectedValueOnce(errnoError('EBUSY'))
+      .mockRejectedValueOnce(errnoError('EBUSY'))
+
+    await expect(atomicWrite(filePath, 'never lands')).rejects.toThrow(NoteError)
+
+    expect(renameMock).toHaveBeenCalledTimes(4)
+    expect(fs.existsSync(filePath)).toBe(false)
+
+    const tempFiles = fs.readdirSync(tempDir.path).filter((f) => f.endsWith('.tmp'))
+    expect(tempFiles).toHaveLength(0)
+  })
+
+  it('does not retry non-retryable errors like ENOENT', async () => {
+    const filePath = path.join(tempDir.path, 'missing-dir.txt')
+    renameMock.mockRejectedValueOnce(errnoError('ENOENT'))
+
+    await expect(atomicWrite(filePath, 'content')).rejects.toThrow(NoteError)
+
+    expect(renameMock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/desktop/src/main/vault/file-ops.ts
+++ b/apps/desktop/src/main/vault/file-ops.ts
@@ -16,6 +16,30 @@ import { normalizeRelativePath } from '../lib/paths'
 // Atomic Write
 // ============================================================================
 
+const TRANSIENT_FS_ERROR_CODES = new Set(['EBUSY', 'EPERM', 'EACCES'])
+const TRANSIENT_FS_RETRY_DELAYS_MS = [50, 150, 450]
+
+/**
+ * Retry an fs operation that fails with a transient sharing violation
+ * (EBUSY/EPERM/EACCES) — on Windows, cloud-sync clients and antivirus
+ * scanners briefly lock vault files. Non-retryable errors propagate
+ * immediately; retryable ones are retried with backoff before the final
+ * attempt's error propagates.
+ */
+export async function withTransientFsRetry<T>(operation: () => Promise<T>): Promise<T> {
+  for (const delayMs of TRANSIENT_FS_RETRY_DELAYS_MS) {
+    try {
+      return await operation()
+    } catch (error) {
+      if (!isNodeError(error) || !TRANSIENT_FS_ERROR_CODES.has(error.code ?? '')) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+  return operation()
+}
+
 /**
  * Write content to a file atomically using temp-file-then-rename pattern.
  * Ensures file integrity even if the app crashes during write.
@@ -26,29 +50,38 @@ import { normalizeRelativePath } from '../lib/paths'
  */
 export async function atomicWrite(filePath: string, content: string): Promise<void> {
   const dir = path.dirname(filePath)
-  const tempPath = path.join(dir, `.${randomBytes(6).toString('hex')}.tmp`)
 
   try {
     // Ensure directory exists
     await ensureDirectory(dir)
 
-    // Write to the uniquely-named temp file exclusively (wx) with owner-only
-    // permissions, so a pre-existing symlink in a shared directory can't be
-    // followed and the temp contents can't be read by other users.
-    await writeFile(tempPath, content, { encoding: 'utf-8', mode: 0o600, flag: 'wx' })
+    // Each attempt uses a fresh temp file so a failed attempt can't collide
+    // with its own leftovers on retry.
+    await withTransientFsRetry(async () => {
+      const tempPath = path.join(dir, `.${randomBytes(6).toString('hex')}.tmp`)
 
-    // Atomic rename (overwrites existing file)
-    await rename(tempPath, filePath)
-  } catch {
-    // Clean up temp file on error
-    try {
-      if (existsSync(tempPath)) {
-        await unlink(tempPath)
+      try {
+        // Write to the uniquely-named temp file exclusively (wx) with owner-only
+        // permissions, so a pre-existing symlink in a shared directory can't be
+        // followed and the temp contents can't be read by other users.
+        await writeFile(tempPath, content, { encoding: 'utf-8', mode: 0o600, flag: 'wx' })
+
+        // Atomic rename (overwrites existing file)
+        await rename(tempPath, filePath)
+      } catch (error) {
+        // Clean up temp file on error
+        try {
+          if (existsSync(tempPath)) {
+            await unlink(tempPath)
+          }
+        } catch {
+          // Ignore cleanup errors
+        }
+
+        throw error
       }
-    } catch {
-      // Ignore cleanup errors
-    }
-
+    })
+  } catch {
     throw new NoteError(`Failed to write file: ${filePath}`, NoteErrorCode.WRITE_FAILED)
   }
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.test.tsx
@@ -138,7 +138,7 @@ describe('useWikiLinkSuggestions', () => {
     expect(editor.updateBlock).toHaveBeenCalledWith(currentBlock, {
       type: 'file',
       props: {
-        url: 'memry-file://local/Users/kaan/vault/notes/Voice memo.wav',
+        url: 'memry-file://local/Users/kaan/vault/notes/Voice%20memo.wav',
         name: 'Voice memo',
         size: 4096,
         mimeType: 'audio/wav'

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-wiki-link-suggestions.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef } from 'react'
 import { fuzzySearch } from '@/lib/fuzzy-search'
+import { toMemryFileUrl } from '@/lib/memry-file-url'
 import { notesService } from '@/services/notes-service'
 import { createWikiLinkInlineContent } from '../wiki-link'
 import { splitWikiLinkQuery } from '../wiki-link-utils'
@@ -17,13 +18,6 @@ type NoteSuggestion = {
   fileType?: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
   mimeType?: string | null
   fileSize?: number | null
-}
-
-function toMemryFileUrl(absolutePath: string): string {
-  const normalized = absolutePath.replace(/\\/g, '/')
-  return normalized.startsWith('/')
-    ? `memry-file://local${normalized}`
-    : `memry-file://local/${normalized}`
 }
 
 function blockHasContent(block: any): boolean {

--- a/apps/desktop/src/renderer/src/lib/memry-file-url.test.ts
+++ b/apps/desktop/src/renderer/src/lib/memry-file-url.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { toMemryFileUrl } from './memry-file-url'
+
+// Mirrors the main-process protocol handler (src/main/index.ts): it parses the
+// URL, decodes the pathname, and strips the leading slash for Windows drives.
+function decodeLikeProtocolHandler(url: string, platform: 'win32' | 'darwin'): string {
+  const parsed = new URL(url)
+  let filePath = decodeURIComponent(parsed.pathname)
+  if (platform === 'win32') {
+    if (filePath.startsWith('/')) filePath = filePath.slice(1)
+  } else if (!filePath.startsWith('/')) {
+    filePath = '/' + filePath
+  }
+  return filePath
+}
+
+describe('toMemryFileUrl', () => {
+  it('keeps the local host and leading slash for POSIX absolute paths', () => {
+    expect(toMemryFileUrl('/Users/kaan/vault/notes/file.pdf')).toBe(
+      'memry-file://local/Users/kaan/vault/notes/file.pdf'
+    )
+  })
+
+  it('adds the leading slash and forward slashes for Windows drive paths', () => {
+    expect(toMemryFileUrl('C:\\Users\\Leib.000\\Koofr\\0-WAITING\\attachments\\doc.pdf')).toBe(
+      'memry-file://local/C:/Users/Leib.000/Koofr/0-WAITING/attachments/doc.pdf'
+    )
+  })
+
+  it('percent-encodes spaces in filenames', () => {
+    expect(toMemryFileUrl('C:\\vault\\100 Healthy Habits.pdf')).toBe(
+      'memry-file://local/C:/vault/100%20Healthy%20Habits.pdf'
+    )
+  })
+
+  it('percent-encodes non-ASCII (Hebrew) filenames', () => {
+    expect(toMemryFileUrl('/vault/מסמך חשוב.pdf')).toBe(
+      'memry-file://local/vault/%D7%9E%D7%A1%D7%9E%D7%9A%20%D7%97%D7%A9%D7%95%D7%91.pdf'
+    )
+  })
+
+  it('keeps the drive letter in the URL path, not the host', () => {
+    const url = new URL(toMemryFileUrl('C:\\Users\\Leib.000\\file.pdf'))
+    expect(url.host).toBe('local')
+    expect(url.pathname).toBe('/C:/Users/Leib.000/file.pdf')
+  })
+
+  it('round-trips a Windows path with spaces through the protocol handler decode', () => {
+    const url = toMemryFileUrl('C:\\Users\\Leib.000\\Koofr\\0-WAITING\\100 Healthy Habits.pdf')
+    expect(decodeLikeProtocolHandler(url, 'win32')).toBe(
+      'C:/Users/Leib.000/Koofr/0-WAITING/100 Healthy Habits.pdf'
+    )
+  })
+
+  it('round-trips a POSIX Hebrew path through the protocol handler decode', () => {
+    const url = toMemryFileUrl('/Users/kaan/vault/מסמך חשוב.pdf')
+    expect(decodeLikeProtocolHandler(url, 'darwin')).toBe('/Users/kaan/vault/מסמך חשוב.pdf')
+  })
+
+  it('encodes URL-hostile characters so they survive the decode', () => {
+    const url = toMemryFileUrl('/vault/50% off #1 draft?.pdf')
+    expect(url).toBe('memry-file://local/vault/50%25%20off%20%231%20draft%3F.pdf')
+    expect(decodeLikeProtocolHandler(url, 'darwin')).toBe('/vault/50% off #1 draft?.pdf')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/memry-file-url.ts
+++ b/apps/desktop/src/renderer/src/lib/memry-file-url.ts
@@ -1,0 +1,19 @@
+/**
+ * Builds a memry-file:// URL from an absolute local file path.
+ *
+ * The main-process protocol handler expects `memry-file://local/<path>`: it
+ * decodes `url.pathname` with `decodeURIComponent` and, on Windows, strips the
+ * leading slash so `/C:/Users/...` resolves back to `C:/Users/...`. Backslashes
+ * are normalized to forward slashes, the leading slash is guaranteed (Windows
+ * drive paths have none), and each segment is percent-encoded so spaces and
+ * non-ASCII filenames survive the handler's decode.
+ */
+export function toMemryFileUrl(absolutePath: string): string {
+  const normalized = absolutePath.replace(/\\/g, '/')
+  const withLeadingSlash = normalized.startsWith('/') ? normalized : `/${normalized}`
+  const encoded = withLeadingSlash
+    .split('/')
+    .map((segment) => encodeURIComponent(segment).replace(/%3A/gi, ':'))
+    .join('/')
+  return `memry-file://local${encoded}`
+}

--- a/apps/desktop/src/renderer/src/pages/file.tsx
+++ b/apps/desktop/src/renderer/src/pages/file.tsx
@@ -9,6 +9,7 @@ import { getI18n } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
 import { Loader2, FileWarning, Download, ExternalLink } from '@/lib/icons'
 import { extractErrorMessage } from '@/lib/ipc-error'
+import { toMemryFileUrl } from '@/lib/memry-file-url'
 import { notesService } from '@/services/notes-service'
 import { PdfViewer, ImageViewer, AudioPlayer, VideoPlayer } from '@/components/viewers'
 import { Button } from '@/components/ui/button'
@@ -142,7 +143,7 @@ function FileInfoBar({ file }: { file: FileMetadata }) {
 function FileViewer({ file }: { file: FileMetadata }) {
   const { t: tPhaseF } = useT('notes')
   // Convert absolute path to memry-file:// protocol URL for secure local file access
-  const fileUrl = `memry-file://local${file.absolutePath}`
+  const fileUrl = toMemryFileUrl(file.absolutePath)
 
   switch (file.fileType) {
     case 'pdf':

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -78,6 +78,16 @@ Notes are plain `.md` files in the vault, and the write path is built around byt
 
 A golden round-trip test suite (`apps/desktop/src/main/vault/byte-preservation.golden.test.ts`) holds this contract against adversarial files (YAML comments/anchors, CRLF, BOM, missing final newline, Obsidian syntax).
 
+Atomic writes retry transient `EBUSY`/`EPERM`/`EACCES` failures with bounded backoff before surfacing an error — cloud-sync clients (Koofr, OneDrive, Dropbox) and antivirus scanners hold short-lived locks on vault files, especially on Windows.
+
+## Serving Vault Files to the Renderer (memry-file)
+
+Attachments and vault media reach the renderer through the custom `memry-file://local/<absolute path>` protocol, never `file://`.
+
+- URLs are built in the renderer by `toMemryFileUrl` (`src/renderer/src/lib/memry-file-url.ts`): backslashes normalized to slashes, a guaranteed leading slash before Windows drive letters (`memry-file://local/C:/...`), and per-segment percent-encoding so spaces and non-ASCII filenames round-trip. Building URLs by string concatenation is a Windows-fatal bug — the drive letter gets parsed as the URL host and the handler receives a relative path.
+- The main-process handler decodes the path and serves it only if it resolves inside an allowlist (the open vault and `userData`). Containment is checked with the platform separator (`isPathInsideDirs` in `src/main/lib/external-url.ts`); a plain `startsWith(dir + '/')` never matches Windows backslash paths.
+- `window.open` on a memry-file URL never opens a window or reaches `shell.openExternal`: the main process resolves the path with the same rules and, if it passes the directory check, opens the file in the OS default app via `shell.openPath`.
+
 ### Text colors in markdown
 
 Editor colors persist in two Obsidian-compatible forms:

--- a/apps/docs/src/guide/install.md
+++ b/apps/docs/src/guide/install.md
@@ -5,7 +5,10 @@ The download page detects your platform and offers installers for:
 
 - **macOS** — Apple Silicon and Intel
 - **Windows** — the installer lets you choose the install location, so you can
-  install to a drive other than `C:`
+  install to a drive other than `C:`. Each release also ships a
+  `MemryNote-<version>-win.zip` on the
+  [GitHub releases page](https://github.com/memrynote/memry/releases) — unzip and
+  run `Memrynote.exe` directly if the installer fails on your machine
 - **Linux** — AppImage and `.deb`
 
 On macOS you can also install with [Homebrew](https://brew.sh):

--- a/apps/landing/api/download.test.ts
+++ b/apps/landing/api/download.test.ts
@@ -6,6 +6,7 @@ import handler, { resolveAssetUrl } from './download.ts'
 const ASSETS = [
   { name: 'MemryNote-1.2.3-arm64.dmg', browser_download_url: 'https://example.com/arm64.dmg' },
   { name: 'MemryNote-1.2.3-x64.dmg', browser_download_url: 'https://example.com/x64.dmg' },
+  { name: 'MemryNote-1.2.3-win.zip', browser_download_url: 'https://example.com/win.zip' },
   { name: 'MemryNote-1.2.3-setup.exe', browser_download_url: 'https://example.com/setup.exe' },
   {
     name: 'MemryNote-1.2.3-x64.AppImage',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,8 +488,8 @@ importers:
         specifier: ^39.8.6
         version: 39.8.6
       electron-builder:
-        specifier: ^26.0.12
-        version: 26.7.0(electron-builder-squirrel-windows@26.7.0)
+        specifier: ^26.15.6
+        version: 26.15.6(electron-builder-squirrel-windows@26.15.6)
       electron-store:
         specifier: ^11.0.2
         version: 11.0.2
@@ -549,31 +549,31 @@ importers:
         version: 17.0.1
       metascraper:
         specifier: ^5.49.15
-        version: 5.49.21(@noble/hashes@1.8.0)
+        version: 5.49.21(@noble/hashes@2.2.0)
       metascraper-author:
         specifier: ^5.49.15
-        version: 5.49.21(@noble/hashes@1.8.0)
+        version: 5.49.21(@noble/hashes@2.2.0)
       metascraper-date:
         specifier: ^5.49.15
-        version: 5.49.21(@noble/hashes@1.8.0)
+        version: 5.49.21(@noble/hashes@2.2.0)
       metascraper-description:
         specifier: ^5.49.15
-        version: 5.49.21(@noble/hashes@1.8.0)
+        version: 5.49.21(@noble/hashes@2.2.0)
       metascraper-image:
         specifier: ^5.49.15
-        version: 5.49.21(@noble/hashes@1.8.0)
+        version: 5.49.21(@noble/hashes@2.2.0)
       metascraper-logo:
         specifier: ^5.49.15
-        version: 5.49.21(@noble/hashes@1.8.0)
+        version: 5.49.21(@noble/hashes@2.2.0)
       metascraper-publisher:
         specifier: ^5.49.15
-        version: 5.49.21(@noble/hashes@1.8.0)
+        version: 5.49.21(@noble/hashes@2.2.0)
       metascraper-title:
         specifier: ^5.49.15
-        version: 5.49.21(@noble/hashes@1.8.0)
+        version: 5.49.21(@noble/hashes@2.2.0)
       metascraper-url:
         specifier: ^5.49.15
-        version: 5.49.21(@noble/hashes@1.8.0)
+        version: 5.49.21(@noble/hashes@2.2.0)
       mime-types:
         specifier: ^3.0.2
         version: 3.0.2
@@ -935,7 +935,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.9(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.2.2)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.9(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.2.2)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@2.2.0))(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: ^4.0.0
         version: 4.71.0(@cloudflare/workers-types@4.20260305.1)
@@ -1206,12 +1206,9 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.0(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@2.2.0))(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
-
-  7zip-bin@5.2.0:
-    resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
 
   '@1natsu/wait-element@4.2.0':
     resolution: {integrity: sha512-Om0Q+WE9mNrpY4AwMTvkFiYHv8VM7TML3PvOqXy+w6kAjLjKhGYHYX+305+a6J8RVpds9s7IF2Z5aOPYwULFNw==}
@@ -1762,10 +1759,6 @@ packages:
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
-  '@develar/schema-utils@2.6.5':
-    resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
-    engines: {node: '>= 8.9.0'}
-
   '@devicefarmer/adbkit-logcat@2.1.3':
     resolution: {integrity: sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw==}
     engines: {node: '>= 4'}
@@ -1921,6 +1914,11 @@ packages:
 
   '@electron/rebuild@4.0.3':
     resolution: {integrity: sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+
+  '@electron/rebuild@4.2.0':
+    resolution: {integrity: sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -2683,9 +2681,17 @@ packages:
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@1.4.0':
+    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
+    engines: {node: '>= 16'}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodable/entities@2.2.0':
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
@@ -2871,6 +2877,20 @@ packages:
   '@paddle/paddle-node-sdk@3.8.0':
     resolution: {integrity: sha512-4RS6AhZisloYaT2jiFgx9hwm22qwLRUx4EgIVb1gS3bS96lhDBQWq8BC1/Zow2i3CuxMkehXQUc3qKSBS77ozA==}
     engines: {node: '>=20'}
+
+  '@peculiar/asn1-schema@2.8.0':
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+
+  '@peculiar/json-schema@1.1.12':
+    resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
+    engines: {node: '>=8.0.0'}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@peculiar/webcrypto@1.7.1':
+    resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
+    engines: {node: '>=14.18.0'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4593,9 +4613,6 @@ packages:
   '@types/pako@2.0.4':
     resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
 
-  '@types/plist@3.0.5':
-    resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
-
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -4627,9 +4644,6 @@ packages:
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
-
-  '@types/verror@1.10.11':
-    resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
@@ -5244,11 +5258,6 @@ packages:
       ajv:
         optional: true
 
-  ajv-keywords@3.5.2:
-    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
-    peerDependencies:
-      ajv: ^6.9.1
-
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -5296,15 +5305,12 @@ packages:
   anynum@1.0.0:
     resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
 
-  app-builder-bin@5.0.0-alpha.12:
-    resolution: {integrity: sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==}
-
-  app-builder-lib@26.7.0:
-    resolution: {integrity: sha512-/UgCD8VrO79Wv8aBNpjMfsS1pIUfIPURoRn0Ik6tMe5avdZF+vQgl/juJgipcMmH3YS0BD573lCdCHyoi84USg==}
+  app-builder-lib@26.15.6:
+    resolution: {integrity: sha512-lN6BliNJLnS2ruBdYd1j1rzd2yl4ZwKqyTtAwVznIkkadOR9cFvRz/tNQ6nd824AobnFZKhcdFrpIGDnr0PRSg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      dmg-builder: 26.7.0
-      electron-builder-squirrel-windows: 26.7.0
+      dmg-builder: 26.15.6
+      electron-builder-squirrel-windows: 26.15.6
 
   arg@4.1.0:
     resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
@@ -5362,9 +5368,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
-  assert-plus@1.0.0:
-    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
-    engines: {node: '>=0.8'}
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -5380,10 +5386,6 @@ packages:
 
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
-
-  astral-regex@2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
-    engines: {node: '>=8'}
 
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
@@ -5444,6 +5446,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   axios@1.16.1:
     resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
@@ -5582,8 +5587,13 @@ packages:
     resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
     engines: {node: '>=12.0.0'}
 
-  builder-util@26.4.1:
-    resolution: {integrity: sha512-FlgH43XZ50w3UtS1RVGDWOz8v9qMXPC7upMtKMtBEnYdt1OVoS61NYhKm/4x+cIaWqJTXua0+VVPI+fSPGXNIw==}
+  builder-util-runtime@9.7.0:
+    resolution: {integrity: sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==}
+    engines: {node: '>=12.0.0'}
+
+  builder-util@26.15.3:
+    resolution: {integrity: sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==}
+    engines: {node: '>=14.0.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -5596,6 +5606,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  bytestreamjs@2.0.1:
+    resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
+    engines: {node: '>=6.0.0'}
 
   c12@3.3.4:
     resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
@@ -5782,10 +5796,6 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
-  cli-truncate@2.1.0:
-    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
-    engines: {node: '>=8'}
-
   cli-truncate@5.2.0:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
@@ -5969,9 +5979,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  crc@3.8.0:
-    resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -6381,14 +6388,8 @@ packages:
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
 
-  dmg-builder@26.7.0:
-    resolution: {integrity: sha512-uOOBA3f+kW3o4KpSoMQ6SNpdXU7WtxlJRb9vCZgOvqhTz4b3GjcoWKstdisizNZLsylhTMv8TLHFPFW0Uxsj/g==}
-
-  dmg-license@1.0.11:
-    resolution: {integrity: sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==}
-    engines: {node: '>=8'}
-    os: [darwin]
-    hasBin: true
+  dmg-builder@26.15.6:
+    resolution: {integrity: sha512-nr5vQxEhM0REomp1qiHbc6V99yrfBZy+wUU56VXADfSOlLj8PdLqsHiRe7b+FbqKesiyv4ax+k1GVwGonYKuCg==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -6547,6 +6548,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -6570,11 +6574,11 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-builder-squirrel-windows@26.7.0:
-    resolution: {integrity: sha512-3EqkQK+q0kGshdPSKEPb2p5F75TENMKu6Fe5aTdeaPfdzFK4Yjp5L0d6S7K8iyvqIsGQ/ei4bnpyX9wt+kVCKQ==}
+  electron-builder-squirrel-windows@26.15.6:
+    resolution: {integrity: sha512-Vgw0bVXtTjZmD3O0Wl1gbo4eiI0Mqp7FQBsFgMR+wNwySiPJ08jadS0PZiSwP2cKCVaEclBHbKeBVTwil+SJfQ==}
 
-  electron-builder@26.7.0:
-    resolution: {integrity: sha512-LoXbCvSFxLesPneQ/fM7FB4OheIDA2tjqCdUkKlObV5ZKGhYgi5VHPHO/6UUOUodAlg7SrkPx7BZJPby+Vrtbg==}
+  electron-builder@26.15.6:
+    resolution: {integrity: sha512-jxlHRjqYrlTgLVo/aoACGpiki3QFYv8s4f2djsqaEbwTBZ9PcTBK03Tj/HMa65kiE0hdZxxbZdmVFo22eou2wA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -6582,8 +6586,8 @@ packages:
     resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
     engines: {node: '>= 14'}
 
-  electron-publish@26.6.0:
-    resolution: {integrity: sha512-LsyHMMqbvJ2vsOvuWJ19OezgF2ANdCiHpIucDHNiLhuI+/F3eW98ouzWSRmXXi82ZOPZXC07jnIravY4YYwCLQ==}
+  electron-publish@26.15.3:
+    resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
 
   electron-store@11.0.2:
     resolution: {integrity: sha512-4VkNRdN+BImL2KcCi41WvAYbh6zLX5AUTi4so68yPqiItjbgTjqpEnGAqasgnG+lB6GuAyUltKwVopp6Uv+gwQ==}
@@ -6946,10 +6950,6 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
-  extsprintf@1.4.1:
-    resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
-    engines: {'0': node >=0.6.0}
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -7138,6 +7138,10 @@ packages:
 
   fs-extra@11.1.1:
     resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.1:
+    resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
     engines: {node: '>=14.14'}
 
   fs-extra@11.3.5:
@@ -7586,11 +7590,6 @@ packages:
 
   i18next@23.16.8:
     resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
-
-  iconv-corefoundation@1.1.7:
-    resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
-    engines: {node: ^8.11.2 || >=10}
-    os: [darwin]
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -9139,9 +9138,6 @@ packages:
     resolution: {integrity: sha512-8QwIZqikRvDIkXS2S93LjzhsSPJuIbfaMETWH+Bx8oOT9Sa9UsUtBFQlc3gBNd1+QINjaTloitXr1W3dQLi9Iw==}
     engines: {node: '>=22.12.0'}
 
-  node-addon-api@1.7.2:
-    resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
-
   node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
 
@@ -9195,6 +9191,9 @@ packages:
     resolution: {integrity: sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
+
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
   node-notifier@10.0.1:
     resolution: {integrity: sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==}
@@ -9590,6 +9589,10 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
+  pkijs@3.4.0:
+    resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
+    engines: {node: '>=16.0.0'}
+
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
@@ -9865,6 +9868,13 @@ packages:
   pupa@3.3.0:
     resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
     engines: {node: '>=12.20'}
+
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
 
   qrcode.react@4.2.0:
     resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
@@ -10544,10 +10554,6 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
-  slice-ansi@3.0.0:
-    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
-    engines: {node: '>=8'}
 
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
@@ -11295,6 +11301,9 @@ packages:
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
+  unzipper@0.12.5:
+    resolution: {integrity: sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -11391,10 +11400,6 @@ packages:
     resolution: {integrity: sha512-/SabFfhZUp3uTqrCHzTZSPDFZU4cwKlCLF3McN9vrA5Gyk0ldvHruBqZNuFtW5Y3J8aSIiREzLxbmL3H8uTquw==}
     engines: {node: '>= 18'}
     hasBin: true
-
-  verror@1.10.1:
-    resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
-    engines: {node: '>=0.6.0'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -11665,6 +11670,9 @@ packages:
 
   web-vitals@0.2.4:
     resolution: {integrity: sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==}
+
+  webcrypto-core@1.9.2:
+    resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -12000,8 +12008,6 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-
-  7zip-bin@5.2.0: {}
 
   '@1natsu/wait-element@4.2.0':
     dependencies:
@@ -12817,11 +12823,6 @@ snapshots:
 
   '@date-fns/tz@1.4.1': {}
 
-  '@develar/schema-utils@2.6.5':
-    dependencies:
-      ajv: 6.14.0
-      ajv-keywords: 3.5.2(ajv@6.14.0)
-
   '@devicefarmer/adbkit-logcat@2.1.3': {}
 
   '@devicefarmer/adbkit-monkey@1.2.1': {}
@@ -13033,6 +13034,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@electron/rebuild@4.2.0':
+    dependencies:
+      '@malept/cross-spawn-promise': 2.0.0
+      debug: 4.4.3
+      node-abi: 4.26.0
+      node-api-version: 0.2.1
+      node-gyp: 12.2.0
+      read-binary-file-arch: 1.0.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@electron/universal@2.0.3':
     dependencies:
       '@electron/asar': 3.4.1
@@ -13218,6 +13230,10 @@ snapshots:
   '@exodus/bytes@1.12.0(@noble/hashes@1.8.0)':
     optionalDependencies:
       '@noble/hashes': 1.8.0
+
+  '@exodus/bytes@1.12.0(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -13566,7 +13582,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@metascraper/helpers@5.49.21(@noble/hashes@1.8.0)':
+  '@metascraper/helpers@5.49.21(@noble/hashes@2.2.0)':
     dependencies:
       audio-extensions: 0.0.0
       chrono-node: 2.9.0
@@ -13581,7 +13597,7 @@ snapshots:
       is-uri: 1.2.12
       iso-639-3: 2.2.0
       isostring: 0.0.1
-      jsdom: 27.4.0(@noble/hashes@1.8.0)
+      jsdom: 27.4.0(@noble/hashes@2.2.0)
       jsonrepair: 3.13.2
       lodash: 4.18.1
       memoize-one: 6.0.0
@@ -13753,7 +13769,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@noble/hashes@1.4.0': {}
+
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodable/entities@2.2.0': {}
 
@@ -13880,6 +13900,28 @@ snapshots:
   '@paddle/paddle-js@1.6.4': {}
 
   '@paddle/paddle-node-sdk@3.8.0': {}
+
+  '@peculiar/asn1-schema@2.8.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/json-schema@1.1.12':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/webcrypto@1.7.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/json-schema': 1.1.12
+      '@peculiar/utils': 2.0.3
+      tslib: 2.8.1
+      webcrypto-core: 1.9.2
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -15573,12 +15615,6 @@ snapshots:
 
   '@types/pako@2.0.4': {}
 
-  '@types/plist@3.0.5':
-    dependencies:
-      '@types/node': 25.2.2
-      xmlbuilder: 15.1.1
-    optional: true
-
   '@types/react-dom@19.2.3(@types/react@19.2.13)':
     dependencies:
       '@types/react': 19.2.13
@@ -15605,9 +15641,6 @@ snapshots:
   '@types/use-sync-external-store@1.5.0': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
-
-  '@types/verror@1.10.11':
-    optional: true
 
   '@types/web-bluetooth@0.0.21': {}
 
@@ -16299,7 +16332,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.0(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@2.2.0))(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
     optional: true
 
   '@vitest/ui@4.1.8(vitest@4.1.8)':
@@ -16554,10 +16587,6 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv-keywords@3.5.2(ajv@6.14.0):
-    dependencies:
-      ajv: 6.14.0
-
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -16615,32 +16644,33 @@ snapshots:
 
   anynum@1.0.0: {}
 
-  app-builder-bin@5.0.0-alpha.12: {}
-
-  app-builder-lib@26.7.0(dmg-builder@26.7.0)(electron-builder-squirrel-windows@26.7.0):
+  app-builder-lib@26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6):
     dependencies:
-      '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
       '@electron/get': 3.1.0
       '@electron/notarize': 2.5.0
       '@electron/osx-sign': 1.3.3
-      '@electron/rebuild': 4.0.3
+      '@electron/rebuild': 4.2.0
       '@electron/universal': 2.0.3
       '@malept/flatpak-bundler': 0.4.0
+      '@noble/hashes': 2.2.0
+      '@peculiar/webcrypto': 1.7.1
       '@types/fs-extra': 9.0.13
+      ajv: 8.18.0
+      asn1js: 3.0.10
       async-exit-hook: 2.0.1
-      builder-util: 26.4.1
-      builder-util-runtime: 9.5.1
+      builder-util: 26.15.3
+      builder-util-runtime: 9.7.0
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
       debug: 4.4.3
-      dmg-builder: 26.7.0(electron-builder-squirrel-windows@26.7.0)
+      dmg-builder: 26.15.6(electron-builder-squirrel-windows@26.15.6)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 26.7.0(dmg-builder@26.7.0)
-      electron-publish: 26.6.0
+      electron-builder-squirrel-windows: 26.15.6(dmg-builder@26.15.6)
+      electron-publish: 26.15.3
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
@@ -16649,6 +16679,7 @@ snapshots:
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
+      pkijs: 3.4.0
       plist: 3.1.0
       proper-lockfile: 4.1.2
       resedit: 1.7.2
@@ -16656,6 +16687,7 @@ snapshots:
       tar: 7.5.16
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
+      unzipper: 0.12.5
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -16739,8 +16771,11 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
-  assert-plus@1.0.0:
-    optional: true
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
 
   assertion-error@2.0.1: {}
 
@@ -16757,9 +16792,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
-
-  astral-regex@2.0.0:
-    optional: true
 
   async-exit-hook@2.0.1: {}
 
@@ -16808,6 +16840,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  aws4@1.13.2: {}
 
   axios@1.16.1:
     dependencies:
@@ -16968,12 +17002,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  builder-util@26.4.1:
+  builder-util-runtime@9.7.0:
     dependencies:
-      7zip-bin: 5.2.0
+      debug: 4.4.3
+      sax: 1.4.4
+    transitivePeerDependencies:
+      - supports-color
+
+  builder-util@26.15.3:
+    dependencies:
       '@types/debug': 4.1.12
-      app-builder-bin: 5.0.0-alpha.12
-      builder-util-runtime: 9.5.1
+      builder-util-runtime: 9.7.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -16996,6 +17035,8 @@ snapshots:
   bytes@3.1.0: {}
 
   bytes@3.1.2: {}
+
+  bytestreamjs@2.0.1: {}
 
   c12@3.3.4(magicast@0.5.2):
     dependencies:
@@ -17214,12 +17255,6 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
-  cli-truncate@2.1.0:
-    dependencies:
-      slice-ansi: 3.0.0
-      string-width: 4.2.3
-    optional: true
-
   cli-truncate@5.2.0:
     dependencies:
       slice-ansi: 8.0.0
@@ -17379,11 +17414,6 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
-
-  crc@3.8.0:
-    dependencies:
-      buffer: 5.7.1
-    optional: true
 
   crelt@1.0.6: {}
 
@@ -17820,30 +17850,15 @@ snapshots:
       minimatch: 3.1.5
       p-limit: 3.1.0
 
-  dmg-builder@26.7.0(electron-builder-squirrel-windows@26.7.0):
+  dmg-builder@26.15.6(electron-builder-squirrel-windows@26.15.6):
     dependencies:
-      app-builder-lib: 26.7.0(dmg-builder@26.7.0)(electron-builder-squirrel-windows@26.7.0)
-      builder-util: 26.4.1
+      app-builder-lib: 26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6)
+      builder-util: 26.15.3
       fs-extra: 10.1.0
-      iconv-lite: 0.6.3
       js-yaml: 4.2.0
-    optionalDependencies:
-      dmg-license: 1.0.11
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
-
-  dmg-license@1.0.11:
-    dependencies:
-      '@types/plist': 3.0.5
-      '@types/verror': 1.10.11
-      ajv: 6.14.0
-      crc: 3.8.0
-      iconv-corefoundation: 1.1.7
-      plist: 3.1.0
-      smart-buffer: 4.2.0
-      verror: 1.10.1
-    optional: true
 
   doctrine@2.1.0:
     dependencies:
@@ -17919,6 +17934,10 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexer2@0.1.4:
+    dependencies:
+      readable-stream: 2.3.8
+
   eastasianwidth@0.2.0: {}
 
   ecdsa-sig-formatter@1.0.11:
@@ -17950,23 +17969,23 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-builder-squirrel-windows@26.7.0(dmg-builder@26.7.0):
+  electron-builder-squirrel-windows@26.15.6(dmg-builder@26.15.6):
     dependencies:
-      app-builder-lib: 26.7.0(dmg-builder@26.7.0)(electron-builder-squirrel-windows@26.7.0)
-      builder-util: 26.4.1
+      app-builder-lib: 26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6)
+      builder-util: 26.15.3
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.7.0(electron-builder-squirrel-windows@26.7.0):
+  electron-builder@26.15.6(electron-builder-squirrel-windows@26.15.6):
     dependencies:
-      app-builder-lib: 26.7.0(dmg-builder@26.7.0)(electron-builder-squirrel-windows@26.7.0)
-      builder-util: 26.4.1
-      builder-util-runtime: 9.5.1
+      app-builder-lib: 26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6)
+      builder-util: 26.15.3
+      builder-util-runtime: 9.7.0
       chalk: 4.1.2
       ci-info: 4.4.0
-      dmg-builder: 26.7.0(electron-builder-squirrel-windows@26.7.0)
+      dmg-builder: 26.15.6(electron-builder-squirrel-windows@26.15.6)
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0
@@ -17977,11 +17996,12 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-publish@26.6.0:
+  electron-publish@26.15.3:
     dependencies:
       '@types/fs-extra': 9.0.13
-      builder-util: 26.4.1
-      builder-util-runtime: 9.5.1
+      aws4: 1.13.2
+      builder-util: 26.15.3
+      builder-util-runtime: 9.7.0
       chalk: 4.1.2
       form-data: 4.0.6
       fs-extra: 10.1.0
@@ -18533,9 +18553,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extsprintf@1.4.1:
-    optional: true
-
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -18719,6 +18736,12 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fs-extra@11.3.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
@@ -18889,7 +18912,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.4
+      semver: 7.8.4
       serialize-error: 7.0.1
 
   global-directory@4.0.1:
@@ -19221,6 +19244,12 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.12.0(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
@@ -19323,12 +19352,6 @@ snapshots:
   i18next@23.16.8:
     dependencies:
       '@babel/runtime': 7.29.7
-
-  iconv-corefoundation@1.1.7:
-    dependencies:
-      cli-truncate: 2.1.0
-      node-addon-api: 1.7.2
-    optional: true
 
   iconv-lite@0.4.24:
     dependencies:
@@ -19749,6 +19772,34 @@ snapshots:
       data-urls: 6.0.1
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsdom@27.4.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.7.8
+      '@exodus/bytes': 1.12.0(@noble/hashes@2.2.0)
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
@@ -20492,9 +20543,9 @@ snapshots:
       ts-dedent: 2.2.0
       uuid: 11.1.1
 
-  metascraper-author@5.49.21(@noble/hashes@1.8.0):
+  metascraper-author@5.49.21(@noble/hashes@2.2.0):
     dependencies:
-      '@metascraper/helpers': 5.49.21(@noble/hashes@1.8.0)
+      '@metascraper/helpers': 5.49.21(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
       - bufferutil
@@ -20502,9 +20553,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metascraper-date@5.49.21(@noble/hashes@1.8.0):
+  metascraper-date@5.49.21(@noble/hashes@2.2.0):
     dependencies:
-      '@metascraper/helpers': 5.49.21(@noble/hashes@1.8.0)
+      '@metascraper/helpers': 5.49.21(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
       - bufferutil
@@ -20512,9 +20563,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metascraper-description@5.49.21(@noble/hashes@1.8.0):
+  metascraper-description@5.49.21(@noble/hashes@2.2.0):
     dependencies:
-      '@metascraper/helpers': 5.49.21(@noble/hashes@1.8.0)
+      '@metascraper/helpers': 5.49.21(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
       - bufferutil
@@ -20522,9 +20573,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metascraper-image@5.49.21(@noble/hashes@1.8.0):
+  metascraper-image@5.49.21(@noble/hashes@2.2.0):
     dependencies:
-      '@metascraper/helpers': 5.49.21(@noble/hashes@1.8.0)
+      '@metascraper/helpers': 5.49.21(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
       - bufferutil
@@ -20532,9 +20583,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metascraper-logo@5.49.21(@noble/hashes@1.8.0):
+  metascraper-logo@5.49.21(@noble/hashes@2.2.0):
     dependencies:
-      '@metascraper/helpers': 5.49.21(@noble/hashes@1.8.0)
+      '@metascraper/helpers': 5.49.21(@noble/hashes@2.2.0)
       lodash: 4.18.1
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -20543,9 +20594,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metascraper-publisher@5.49.21(@noble/hashes@1.8.0):
+  metascraper-publisher@5.49.21(@noble/hashes@2.2.0):
     dependencies:
-      '@metascraper/helpers': 5.49.21(@noble/hashes@1.8.0)
+      '@metascraper/helpers': 5.49.21(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
       - bufferutil
@@ -20553,9 +20604,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metascraper-title@5.49.21(@noble/hashes@1.8.0):
+  metascraper-title@5.49.21(@noble/hashes@2.2.0):
     dependencies:
-      '@metascraper/helpers': 5.49.21(@noble/hashes@1.8.0)
+      '@metascraper/helpers': 5.49.21(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
       - bufferutil
@@ -20563,9 +20614,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metascraper-url@5.49.21(@noble/hashes@1.8.0):
+  metascraper-url@5.49.21(@noble/hashes@2.2.0):
     dependencies:
-      '@metascraper/helpers': 5.49.21(@noble/hashes@1.8.0)
+      '@metascraper/helpers': 5.49.21(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
       - bufferutil
@@ -20573,9 +20624,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metascraper@5.49.21(@noble/hashes@1.8.0):
+  metascraper@5.49.21(@noble/hashes@2.2.0):
     dependencies:
-      '@metascraper/helpers': 5.49.21(@noble/hashes@1.8.0)
+      '@metascraper/helpers': 5.49.21(@noble/hashes@2.2.0)
       cheerio: 1.1.2
       debug-logfmt: 1.4.7
       whoops: 5.0.7
@@ -21056,9 +21107,6 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  node-addon-api@1.7.2:
-    optional: true
-
   node-addon-api@4.3.0: {}
 
   node-api-version@0.2.1:
@@ -21120,6 +21168,8 @@ snapshots:
       which: 6.0.0
     transitivePeerDependencies:
       - supports-color
+
+  node-int64@0.4.0: {}
 
   node-notifier@10.0.1:
     dependencies:
@@ -21570,6 +21620,15 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  pkijs@3.4.0:
+    dependencies:
+      '@noble/hashes': 1.4.0
+      asn1js: 3.0.10
+      bytestreamjs: 2.0.1
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+
   platform@1.3.6: {}
 
   player.style@0.3.1(react@19.2.4):
@@ -21883,6 +21942,12 @@ snapshots:
   pupa@3.3.0:
     dependencies:
       escape-goat: 4.0.0
+
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
 
   qrcode.react@4.2.0(react@19.2.4):
     dependencies:
@@ -22824,7 +22889,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.4
 
   sirv@3.0.2:
     dependencies:
@@ -22833,13 +22898,6 @@ snapshots:
       totalist: 3.0.1
 
   sisteransi@1.0.5: {}
-
-  slice-ansi@3.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      astral-regex: 2.0.0
-      is-fullwidth-code-point: 3.0.0
-    optional: true
 
   slice-ansi@7.1.2:
     dependencies:
@@ -23641,6 +23699,14 @@ snapshots:
 
   until-async@3.0.2: {}
 
+  unzipper@0.12.5:
+    dependencies:
+      bluebird: 3.7.2
+      duplexer2: 0.1.4
+      fs-extra: 11.3.1
+      graceful-fs: 4.2.11
+      node-int64: 0.4.0
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -23761,13 +23827,6 @@ snapshots:
       - rollup
       - supports-color
       - typescript
-
-  verror@1.10.1:
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.4.1
-    optional: true
 
   vfile-location@5.0.3:
     dependencies:
@@ -23960,7 +24019,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.0(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.0(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@2.2.0))(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -23988,7 +24047,7 @@ snapshots:
       '@types/node': 25.2.2
       '@vitest/ui': 4.1.0(vitest@4.1.0)
       happy-dom: 20.8.9
-      jsdom: 27.4.0(@noble/hashes@1.8.0)
+      jsdom: 27.4.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -24025,7 +24084,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.9(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.2.2)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.9(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.2.2)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@2.2.0))(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(msw@2.12.9(@types/node@25.2.2)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -24052,7 +24111,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.2.2
       happy-dom: 20.8.9
-      jsdom: 27.4.0(@noble/hashes@1.8.0)
+      jsdom: 27.4.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -24119,6 +24178,14 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   web-vitals@0.2.4: {}
+
+  webcrypto-core@1.9.2:
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/json-schema': 1.1.12
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Why

A Windows user (Reddit r/MemryNote) hit three independent failures, all confirmed from his `main.log` + Event Viewer data:

1. **`MemryNote-*-setup.exe` crashes before showing any UI** — faulting module `System.dll` (NSIS plugin), `0xc0000005` at offset `0x1581`, 3× deterministic. Root cause is a buffer over-read in electron-builder 26.7.0's stock `multiUser.nsh` per-user **fresh-install** branch (`System::Call '*$2(&w${NSIS_MAX_STRLEN} .s)'` reading a small `SHGetKnownFolderPath` buffer), fixed upstream in 26.9.0+. It only fires when no HKCU `InstallLocation` exists — which is why updates worked for years but a clean install after uninstall dies instantly, and why his in-app update "got stuck" (the app quit cleanly; the silent NSIS run crashed after exit).
2. **Every PDF/image opened from Collections shows "server error" on Windows** — two stacked path bugs: renderer built `memry-file://local${absolutePath}`, so `C:` was parsed as the URL host and the handler resolved a relative path against the install dir; and the handler allowlist compared with `startsWith(dir + '/')`, which never matches Windows backslash paths, so even a well-formed URL was 403'd. His log shows the exact mangled path (`...\Programs\@memrydesktop\Users\Leib.000\Koofr\...`).
3. **Clicking an attachment link inside a note did nothing** — `memry-file:` fell into the `openExternal` scheme allowlist and was silently denied (8× in his log).

His vault also lives inside a Koofr cloud-sync folder, which holds transient locks on vault files.

## What

- **Bump electron-builder `^26.0.12` → `^26.15.6`** — the fixed template uses a bounded `lstrcpynW` copy. Verified by cross-building the actual Windows targets on macOS with the new version: real `MemryNote-*-setup.exe` (146 MB) + `MemryNote-*-win.zip` (191 MB) produced.
- **Publish a `MemryNote-<version>-win.zip`** alongside the setup exe (installer-free escape hatch for support). `latest.yml` still lists only the setup exe, so electron-updater behavior is unchanged; landing download API keeps resolving `-setup.exe` (fixture test with the zip listed first).
- **`toMemryFileUrl` renderer helper** (leading slash, backslash→slash, per-segment percent-encoding) replacing both string-concat build sites; round-trip tests for Windows drive paths, spaces, Hebrew filenames, and URL-hostile chars.
- **`isPathInsideDirs`** platform-separator containment used by the protocol handler and the window-open route; win32 behavior unit-tested (prefix-sibling dirs rejected).
- **memry-file window opens route to `shell.openPath`** after the same containment check, never `shell.openExternal`; unknown schemes still blocked, https still allowed (tests extended).
- **Atomic vault writes retry `EBUSY`/`EPERM`/`EACCES`** with bounded backoff (~3 attempts, <1s total) for cloud-sync/AV locks; tests cover transient-then-success, persistent failure, and immediate ENOENT propagation.
- **Startup log line with app version + channel** — his log's binary change was only detectable via an unrelated log-text diff.
- Docs: memry-file path rules + retry semantics in `architecture/local-storage.md`, zip fallback in `guide/install.md`.

## Proof

- Focused + full suites green locally: main 3487 / renderer 5096 / shared 2074 passed; lint 0 errors; typecheck 16/16 tasks; `docs:impact --strict` + `docs:build` green.
- New tests: `memry-file-url.test.ts` (8), `external-url.test.ts` (+10 incl. 5 win32 containment), `index.phase2.test.ts` (+2 wiring), `file-ops.test.ts` (retry matrix), `apps/landing/api/download.test.ts` (zip fixture).
- Local electron-builder 26.15.6 Windows build artifacts produced end-to-end (unsigned, version-unstamped — CI holds secrets/version).

## Notes

- The `-win.zip` won't exist until the next release runs `publish-release.yml`; the workflow's staging filter and verify step now require it.
- Not in scope: PR #729 (utilityProcess classic-level preflight) — this user's log independently re-confirms that failure pattern on Windows; #729 remains the fix for the silent pre-window aborts.