### PR TITLE
Release blocker: Linux AppImage fails under electron-builder 26.15 (executableName validation)

### DIFF
--- a/apps/desktop/config/electron-builder.yml
+++ b/apps/desktop/config/electron-builder.yml
@@ -61,6 +61,10 @@ mac:
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
   notarize: true
 linux:
+  # electron-builder >=26.13 rejects executable names with unsafe path chars;
+  # without an override Linux falls back to package.json name (@memry/desktop).
+  # userData is unaffected (derives from app.name, not the binary name).
+  executableName: memrynote
   target:
     - AppImage
     - deb


### PR DESCRIPTION
## Why

Release run 29096552456 (v2026.710.3): **Build Linux x64 fails** with

```
⨯ failed to build AppImage
error=executableName contains characters that cannot be safely used in file paths: @memrydesktop.
```

electron-builder ≥26.13 (we bumped to 26.15.6 in #736) validates `executableName` and rejects the fallback derived from the package.json name `@memry/desktop`. The old version accepted it silently. Windows already sets `win.executableName: Memrynote`; Linux had no override. Windows x64 and macOS jobs in the same run are green — this is the only blocker.

## What

One line: `linux.executableName: memrynote`.

- **userData is unaffected** — it derives from `app.name` (package.json `name`), never from the binary name. The known landmine (renaming app identity relocates user data) does not apply here.
- The binary inside the AppImage/.deb changes from the sanitized `@memrydesktop` to `memrynote`; the `.desktop` Exec entry is regenerated by electron-builder, so launchers keep working. Only hand-made shortcuts to the old binary path inside `/opt` would need re-pointing — unavoidable, since the old name is now rejected outright.

## Proof

- Local cross-build of the Linux AppImage with electron-builder 26.15.6 and this override (results being attached in a comment).
- Windows/mac targets untouched.

After merge: re-dispatch `publish-release.yml` — it checks out `main`, so the fix must land there first.