### PR TITLE
fix(vault): preserve fs errno when a note save fails

### DIFF
--- a/apps/desktop/src/main/lib/errors.test.ts
+++ b/apps/desktop/src/main/lib/errors.test.ts
@@ -36,6 +36,54 @@ describe('errors', () => {
     })
   })
 
+  it('NoteError preserves the originating error as cause', () => {
+    // #given a native fs failure carrying the errno we need for diagnosis
+    const cause = Object.assign(new Error('ENOSPC: no space left on device'), { code: 'ENOSPC' })
+
+    // #when it is wrapped in a NoteError
+    const err = new NoteError('note failure', NoteErrorCode.WRITE_FAILED, undefined, { cause })
+
+    // #then the original error survives the wrap
+    expect(err.cause).toBe(cause)
+  })
+
+  it('NoteError telemetry code carries the errno, never the file path', () => {
+    // #given an fs failure whose message embeds a private vault path
+    const cause = Object.assign(
+      new Error("EBUSY: resource busy, rename '/Users/kaan/OneDrive/vault/secret.md'"),
+      { code: 'EBUSY' }
+    )
+
+    // #when building the telemetry code
+    const err = new NoteError('write failed', NoteErrorCode.WRITE_FAILED, undefined, { cause })
+
+    // #then the errno is exposed and nothing path-derived leaks
+    expect(err.telemetryCode).toBe('NOTE_WRITE_FAILED:EBUSY')
+    expect(err.telemetryCode).not.toContain('secret.md')
+    expect(err.telemetryCode).not.toContain('/')
+  })
+
+  it('NoteError telemetry code falls back to the bare code without an errno', () => {
+    expect(new NoteError('missing', NoteErrorCode.NOT_FOUND).telemetryCode).toBe('NOTE_NOT_FOUND')
+    expect(
+      new NoteError('write failed', NoteErrorCode.WRITE_FAILED, undefined, {
+        cause: new Error('no errno here')
+      }).telemetryCode
+    ).toBe('NOTE_WRITE_FAILED')
+  })
+
+  it('NoteError telemetry code rejects a path-shaped errno', () => {
+    // #given a cause whose `code` is not an errno at all but a path
+    // (some libraries reuse `code`; it must never reach telemetry)
+    const cause = Object.assign(new Error('bad'), { code: '/Users/kaan/vault/secret.md' })
+
+    // #when building the telemetry code
+    const err = new NoteError('write failed', NoteErrorCode.WRITE_FAILED, undefined, { cause })
+
+    // #then the unrecognised value is dropped rather than forwarded
+    expect(err.telemetryCode).toBe('NOTE_WRITE_FAILED')
+  })
+
   it('DatabaseError stores message, code, and name for all codes', () => {
     Object.values(DatabaseErrorCode).forEach((code) => {
       const err = new DatabaseError('db failure', code)

--- a/apps/desktop/src/main/lib/errors.ts
+++ b/apps/desktop/src/main/lib/errors.ts
@@ -41,16 +41,43 @@ export const NoteErrorCode = {
 export type NoteErrorCode = (typeof NoteErrorCode)[keyof typeof NoteErrorCode]
 
 /**
+ * Matches a bare POSIX/libuv errno (EBUSY, ENOSPC, EPERM…). Deliberately a
+ * strict allowlist rather than a sanitizer: `code` on a rejected value is only
+ * conventionally an errno, and a path, URL or message must never reach
+ * telemetry. Anything that is not errno-shaped is dropped.
+ */
+const ERRNO_PATTERN = /^E[A-Z0-9]{1,31}$/
+
+const errnoOf = (cause: unknown): string | null => {
+  if (!(cause instanceof Error)) return null
+  const code = (cause as NodeJS.ErrnoException).code
+  return typeof code === 'string' && ERRNO_PATTERN.test(code) ? code : null
+}
+
+/**
  * Error for note-related operations.
  */
 export class NoteError extends Error {
   constructor(
     message: string,
     public code: NoteErrorCode,
-    public noteId?: string
+    public noteId?: string,
+    options?: { cause?: unknown }
   ) {
-    super(message)
+    super(message, options)
     this.name = 'NoteError'
+  }
+
+  /**
+   * Stable, privacy-safe identifier for telemetry: the note error code plus the
+   * originating errno when we have one (`NOTE_WRITE_FAILED:EBUSY`). Without it
+   * a failed save reports only the class name, which cannot distinguish a
+   * cloud-sync lock from a full disk. Never contains the file path — see
+   * `toSafeToken` in telemetry/diagnostics.ts for the transport-side rules.
+   */
+  get telemetryCode(): string {
+    const errno = errnoOf(this.cause)
+    return errno ? `${this.code}:${errno}` : this.code
   }
 }
 

--- a/apps/desktop/src/main/telemetry/diagnostics.test.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.test.ts
@@ -17,6 +17,7 @@ import {
   startActiveHeartbeat,
   stopActiveHeartbeat
 } from './diagnostics'
+import { NoteError, NoteErrorCode } from '../lib/errors'
 
 describe('telemetry diagnostics', () => {
   beforeEach(() => {
@@ -45,6 +46,34 @@ describe('telemetry diagnostics', () => {
     )
     const serialized = JSON.stringify(trackMainEventMock.mock.calls[0])
     // message header is stripped; home paths in stack frames are scrubbed
+    expect(serialized).not.toContain('private-note')
+    expect(serialized).not.toContain('/Users/')
+  })
+
+  it('reports a wrapped fs failure with its errno, never the file path', () => {
+    // #given a failed note save wrapping the real fs errno (the production
+    // case: errorCode was only ever "NoteError", so EBUSY vs ENOSPC was lost)
+    const cause = Object.assign(
+      new Error("EBUSY: resource busy, rename '/Users/kaan/private-note.md'"),
+      { code: 'EBUSY' }
+    )
+    const error = new NoteError(
+      'Failed to write file: /Users/kaan/private-note.md',
+      NoteErrorCode.WRITE_FAILED,
+      undefined,
+      { cause }
+    )
+
+    // #when the IPC layer reports it
+    trackMainError('ipc', 'note_update', error)
+
+    // #then the errno reaches telemetry
+    expect(trackMainEventMock).toHaveBeenCalledWith(
+      'app_error_seen',
+      expect.objectContaining({ errorCode: 'NOTE_WRITE_FAILED:EBUSY' })
+    )
+    // #and no path leaves the process
+    const serialized = JSON.stringify(trackMainEventMock.mock.calls[0])
     expect(serialized).not.toContain('private-note')
     expect(serialized).not.toContain('/Users/')
   })

--- a/apps/desktop/src/main/telemetry/diagnostics.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.ts
@@ -2,6 +2,7 @@ import type { TelemetryResult } from '@memry/contracts/telemetry-api'
 import { buildErrorDetail } from '@memry/contracts/telemetry-api'
 
 import { trackMainEvent, type TrackMainEventOptions } from './track'
+import { NoteError } from '../lib/errors'
 
 type DiagnosticLevel = 'debug' | 'info' | 'warn' | 'error'
 
@@ -21,6 +22,13 @@ const toSafeToken = (value: unknown, fallback: string): string => {
 }
 
 const toErrorCode = (error: unknown): string => {
+  // A NoteError's class name alone ("NoteError") cannot say why a save failed.
+  // Its telemetryCode adds the note error code and the originating errno
+  // (NOTE_WRITE_FAILED:EBUSY) and is built to be path-free by construction;
+  // toSafeToken still vets it before it leaves the process.
+  if (error instanceof NoteError) {
+    return toSafeToken(error.telemetryCode, 'NoteError')
+  }
   if (error instanceof Error && error.name) {
     return toSafeToken(error.name, 'Error')
   }

--- a/apps/desktop/src/main/vault/file-ops.test.ts
+++ b/apps/desktop/src/main/vault/file-ops.test.ts
@@ -24,7 +24,7 @@ import {
   generateUniquePath,
   generateUniquePathSync
 } from './file-ops'
-import { NoteError } from '../lib/errors'
+import { NoteError, NoteErrorCode } from '../lib/errors'
 
 vi.mock('fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs/promises')>()
@@ -33,6 +33,14 @@ vi.mock('fs/promises', async (importOriginal) => {
     rename: vi.fn(actual.rename)
   }
 })
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => loggerMock
+}))
 
 // ============================================================================
 // Test Helpers
@@ -137,9 +145,21 @@ describe('atomicWrite transient lock retry', () => {
     return error
   }
 
+  // Returns the NoteError atomicWrite rejected with, so tests can inspect the
+  // cause/telemetry code rather than only asserting that it threw.
+  async function atomicWriteError(filePath: string, content: string): Promise<NoteError> {
+    try {
+      await atomicWrite(filePath, content)
+    } catch (error) {
+      return error as NoteError
+    }
+    throw new Error('expected atomicWrite to reject')
+  }
+
   beforeEach(() => {
     tempDir = createTempDir()
     renameMock.mockClear()
+    loggerMock.warn.mockClear()
   })
 
   afterEach(() => {
@@ -156,6 +176,23 @@ describe('atomicWrite transient lock retry', () => {
     expect(fs.readFileSync(filePath, 'utf-8')).toBe('content after retry')
   })
 
+  it('logs each transient retry attempt with its errno, never the file path', async () => {
+    // #given a vault file that is briefly locked (OneDrive/antivirus on Windows)
+    const filePath = path.join(tempDir.path, 'logged.txt')
+    renameMock.mockRejectedValueOnce(errnoError('EBUSY'))
+
+    // #when the write succeeds on the retry
+    await atomicWrite(filePath, 'content')
+
+    // #then the local log explains the slow save: which errno, which attempt
+    expect(loggerMock.warn).toHaveBeenCalledTimes(1)
+    const logged = loggerMock.warn.mock.calls[0].join(' ')
+    expect(logged).toContain('EBUSY')
+    expect(logged).toContain('1')
+    // #and the log line is about the operation, not the private path
+    expect(logged).not.toContain(filePath)
+  })
+
   it('propagates the error after exhausting retries on persistent EBUSY', async () => {
     const filePath = path.join(tempDir.path, 'always-locked.txt')
     renameMock
@@ -164,13 +201,19 @@ describe('atomicWrite transient lock retry', () => {
       .mockRejectedValueOnce(errnoError('EBUSY'))
       .mockRejectedValueOnce(errnoError('EBUSY'))
 
-    await expect(atomicWrite(filePath, 'never lands')).rejects.toThrow(NoteError)
+    const error = await atomicWriteError(filePath, 'never lands')
 
+    expect(error).toBeInstanceOf(NoteError)
     expect(renameMock).toHaveBeenCalledTimes(4)
     expect(fs.existsSync(filePath)).toBe(false)
 
     const tempFiles = fs.readdirSync(tempDir.path).filter((f) => f.endsWith('.tmp'))
     expect(tempFiles).toHaveLength(0)
+
+    // #then the errno survives all four attempts — otherwise a lock is
+    // indistinguishable from a full disk in telemetry
+    expect((error.cause as NodeJS.ErrnoException).code).toBe('EBUSY')
+    expect(error.telemetryCode).toBe('NOTE_WRITE_FAILED:EBUSY')
   })
 
   it('does not retry non-retryable errors like ENOENT', async () => {
@@ -180,6 +223,40 @@ describe('atomicWrite transient lock retry', () => {
     await expect(atomicWrite(filePath, 'content')).rejects.toThrow(NoteError)
 
     expect(renameMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves a non-transient ENOSPC cause instead of swallowing it', async () => {
+    // #given a write that fails because the disk is full (not a lock)
+    const filePath = path.join(tempDir.path, 'full-disk.txt')
+    renameMock.mockRejectedValueOnce(errnoError('ENOSPC'))
+
+    // #when the note save fails
+    const error = await atomicWriteError(filePath, 'content')
+
+    // #then the errno reaches the caller, so "disk full" is distinguishable
+    // from "antivirus locked the file"
+    expect(error).toBeInstanceOf(NoteError)
+    expect(error.code).toBe(NoteErrorCode.WRITE_FAILED)
+    expect((error.cause as NodeJS.ErrnoException).code).toBe('ENOSPC')
+    // #and it fails fast rather than retrying an unrecoverable condition
+    expect(renameMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes a telemetry code with the errno and never the file path', async () => {
+    // #given a write failure on a path that is private user data
+    const filePath = path.join(tempDir.path, 'private-note.txt')
+    renameMock.mockRejectedValueOnce(errnoError('ENOSPC'))
+
+    // #when the resulting error is prepared for telemetry
+    const error = await atomicWriteError(filePath, 'content')
+
+    // #then the code identifies the failure precisely
+    expect(error.telemetryCode).toBe('NOTE_WRITE_FAILED:ENOSPC')
+    // #and carries nothing path-derived (privacy: paths must never be sent)
+    expect(error.telemetryCode).not.toContain(filePath)
+    expect(error.telemetryCode).not.toContain('private-note')
+    expect(error.telemetryCode).not.toContain(path.sep)
+    expect(error.telemetryCode).not.toContain(tempDir.path)
   })
 })
 
@@ -196,6 +273,24 @@ describe('safeRead', () => {
 
   afterEach(() => {
     tempDir.cleanup()
+  })
+
+  it('preserves the originating errno as cause when read fails', async () => {
+    // #given a path that exists but is not a readable file
+    let error: NoteError | undefined
+
+    // #when the read fails for a reason other than "missing"
+    try {
+      await safeRead(tempDir.path)
+    } catch (err) {
+      error = err as NoteError
+    }
+
+    // #then the errno survives for diagnosis, and the code names it
+    expect(error).toBeInstanceOf(NoteError)
+    expect(error?.code).toBe(NoteErrorCode.READ_FAILED)
+    expect((error?.cause as NodeJS.ErrnoException).code).toBeTruthy()
+    expect(error?.telemetryCode).toMatch(/^NOTE_READ_FAILED:[A-Z0-9]+$/)
   })
 
   it('T345: returns content for existing file', async () => {
@@ -412,6 +507,26 @@ describe('deleteFile', () => {
     await deleteFile(filePath)
 
     expect(fs.existsSync(filePath)).toBe(false)
+  })
+
+  it('preserves the originating errno as cause when delete fails', async () => {
+    // #given a path that exists but cannot be unlinked (it is a directory)
+    const dirPath = path.join(tempDir.path, 'a-directory')
+    fs.mkdirSync(dirPath)
+
+    // #when the delete fails
+    let error: NoteError | undefined
+    try {
+      await deleteFile(dirPath)
+    } catch (err) {
+      error = err as NoteError
+    }
+
+    // #then the errno survives for diagnosis, and the code names it
+    expect(error).toBeInstanceOf(NoteError)
+    expect(error?.code).toBe(NoteErrorCode.DELETE_FAILED)
+    expect((error?.cause as NodeJS.ErrnoException).code).toBeTruthy()
+    expect(error?.telemetryCode).toMatch(/^NOTE_DELETE_FAILED:[A-Z0-9]+$/)
   })
 
   it('T349: does not throw for non-existent file', async () => {

--- a/apps/desktop/src/main/vault/file-ops.ts
+++ b/apps/desktop/src/main/vault/file-ops.ts
@@ -11,6 +11,9 @@ import { randomBytes } from 'crypto'
 import path from 'path'
 import { NoteError, NoteErrorCode } from '../lib/errors'
 import { normalizeRelativePath } from '../lib/paths'
+import { createLogger } from '../lib/logger'
+
+const logger = createLogger('FileOps')
 
 // ============================================================================
 // Atomic Write
@@ -26,14 +29,24 @@ const TRANSIENT_FS_RETRY_DELAYS_MS = [50, 150, 450]
  * immediately; retryable ones are retried with backoff before the final
  * attempt's error propagates.
  */
-export async function withTransientFsRetry<T>(operation: () => Promise<T>): Promise<T> {
-  for (const delayMs of TRANSIENT_FS_RETRY_DELAYS_MS) {
+export async function withTransientFsRetry<T>(
+  operation: () => Promise<T>,
+  operationName = 'fs'
+): Promise<T> {
+  for (const [index, delayMs] of TRANSIENT_FS_RETRY_DELAYS_MS.entries()) {
     try {
       return await operation()
     } catch (error) {
       if (!isNodeError(error) || !TRANSIENT_FS_ERROR_CODES.has(error.code ?? '')) {
         throw error
       }
+      // Only the errno and attempt number — never the path, which is note-derived.
+      // This is the local-log counterpart to NoteError.telemetryCode: it explains
+      // a slow or failed save even when telemetry is off.
+      logger.warn(
+        `${operationName}: transient ${error.code} on attempt ${index + 1} of ` +
+          `${TRANSIENT_FS_RETRY_DELAYS_MS.length + 1}, retrying in ${delayMs}ms`
+      )
       await new Promise((resolve) => setTimeout(resolve, delayMs))
     }
   }
@@ -80,9 +93,19 @@ export async function atomicWrite(filePath: string, content: string): Promise<vo
 
         throw error
       }
-    })
-  } catch {
-    throw new NoteError(`Failed to write file: ${filePath}`, NoteErrorCode.WRITE_FAILED)
+    }, 'atomicWrite')
+  } catch (error) {
+    // Preserve the originating error: its errno is the only thing that tells a
+    // cloud-sync/antivirus lock (EBUSY) apart from a full disk (ENOSPC) or a
+    // read-only vault (EROFS) once the report reaches us.
+    throw new NoteError(
+      `Failed to write file: ${filePath}`,
+      NoteErrorCode.WRITE_FAILED,
+      undefined,
+      {
+        cause: error
+      }
+    )
   }
 }
 
@@ -120,7 +143,9 @@ export async function safeRead(filePath: string): Promise<string | null> {
       return null
     }
 
-    throw new NoteError(`Failed to read file: ${filePath}`, NoteErrorCode.READ_FAILED)
+    throw new NoteError(`Failed to read file: ${filePath}`, NoteErrorCode.READ_FAILED, undefined, {
+      cause: error
+    })
   }
 }
 
@@ -271,7 +296,12 @@ export async function deleteFile(filePath: string): Promise<void> {
       return // File already doesn't exist
     }
 
-    throw new NoteError(`Failed to delete file: ${filePath}`, NoteErrorCode.DELETE_FAILED)
+    throw new NoteError(
+      `Failed to delete file: ${filePath}`,
+      NoteErrorCode.DELETE_FAILED,
+      undefined,
+      { cause: error }
+    )
   }
 }
 

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -167,8 +167,10 @@ The marketing site (`apps/landing`) sends anonymous web events to the rate-limit
 ## Error Reporting
 
 Desktop error reporting follows the same product telemetry setting. Each captured error ships
-stable metadata — process area, component/source, action, phase, and the error's class name
-(`errorCode`) — plus a **redacted stack trace** and, for React boundaries, the component stack.
+stable metadata — process area, component/source, action, phase, and a stable error identifier
+(`errorCode`, the error's class name, or a more precise coded value where one exists — see
+[Vault File Errors](#vault-file-errors)) — plus a **redacted stack trace** and, for React
+boundaries, the component stack.
 
 The free-form exception **message is never sent**: on the desktop it can embed a note title,
 filename, or content. The stack is reduced to code-location frames only — the leading
@@ -177,6 +179,21 @@ filename, or content. The stack is reduced to code-location frames only — the 
 app source/bundle locations (not user files); any home-directory prefix (`/Users/<name>`,
 `C:\Users\<name>`) is rewritten to `~`, and emails, UUIDs, JWTs, and bearer tokens are scrubbed
 from anything that ships.
+
+### Vault File Errors
+
+A class name alone is often too coarse to act on: every failed note save reported `NoteError`,
+which cannot tell an antivirus or cloud-sync file lock apart from a full disk. `NoteError`
+therefore carries the originating fs error as its `cause`, and reports a composite `errorCode` of
+its note error code plus the errno — for example `NOTE_WRITE_FAILED:EBUSY` (locked) versus
+`NOTE_WRITE_FAILED:ENOSPC` (out of space). The errno is admitted by a strict allowlist
+(`/^E[A-Z0-9]+$/`), so **the vault file path is never part of the code** — paths are user data and
+stay out of telemetry, as above.
+
+Writes to a locked file are retried a bounded number of times before failing (see
+`withTransientFsRetry` in `main/vault/file-ops.ts`). Each retry is written to the local log with
+its errno and attempt number — again never the path — so a slow or failed save is explainable from
+a user's log file even when telemetry is switched off.
 
 Sync-server error reporting is server-side. Because the sync server is end-to-end-blind (it only
 ever holds ciphertext), its own error strings are operational: the redacted message and stack ship


### PR DESCRIPTION
## Production evidence

A real user's note save failed on Windows (win32, install `d7f63d79`, 2026.710.3) and we cannot find out why:

```
at atomicWrite (out/main/index.js:3932)
at async updateNote (out/main/index.js:7188)
at async updateNoteCommand (out/main/index.js:26230)
errorCode: "NoteError"
```

2 occurrences on 710.3 over 14 days. `errorCode: "NoteError"` is the entire signal — the class name. We cannot tell "antivirus/OneDrive locked the file" (`EBUSY`) from "disk full" (`ENOSPC`) or "read-only vault" (`EROFS`). The stack literally shows an `OneDrive - Kologik` install path, which makes a lock plausible — but nothing in the report can confirm it.

**Root cause (verified):** `main/vault/file-ops.ts` caught the fs error with a bare `catch {}` and threw a `NoteError` that could not carry a cause. The errno was destroyed at the throw site, before telemetry ever saw it. `NoteError` had no `cause` parameter, so there was nowhere to put it even if the catch had bound the error.

> **Scope note:** this path is a **local disk write**. It has nothing to do with Cloudflare or R2. The Cloudflare/R2 retry work is a sibling PR (`fix-crdt-blob-error-handling`) and is deliberately not touched here.

## The fix

1. **`main/lib/errors.ts`** — `NoteError` accepts an optional `cause` (4th arg, `{ cause }`) and exposes `telemetryCode`: the note error code plus the errno, e.g. `NOTE_WRITE_FAILED:EBUSY`.
2. **`main/vault/file-ops.ts`** — `atomicWrite`, `safeRead`, and `deleteFile` preserve the originating error as `cause` instead of swallowing it.
3. **`main/telemetry/diagnostics.ts`** — `toErrorCode` reports a `NoteError`'s `telemetryCode` rather than its class name, so the errno reaches Loki.
4. **Retry logging** — `withTransientFsRetry` logs each transient retry (errno + attempt number) via `createLogger('FileOps')`, so a user's local log explains a slow or failed save even with telemetry off.

### Privacy

The errno is admitted by a **strict allowlist** (`/^E[A-Z0-9]{1,31}$/`), not a sanitizer — a `code` that is a path, URL, or message is dropped rather than scrubbed. The file path is never part of the error code or any telemetry field; `toSafeToken` still vets the result. There is an explicit regression test asserting the path is absent.

## Retry hardening — what I did NOT change, and why

Kaan asked for retry hardening. I deliberately left the transient set (`EBUSY`/`EPERM`/`EACCES`) and the delays (`[50,150,450]`ms, 4 bounded attempts, ~650ms) **unchanged**:

- **We have no errno evidence yet.** That is the whole point of this PR. Widening the set (e.g. adding `EIO`) or inflating the delays now would be guessing at which failure we are fixing. This PR lands the instrumentation that produces the evidence; tuning follows the data.
- **`ENOENT` is deliberately not retried.** It is the normal signal for a legitimately missing path, and `ensureDirectory` runs *outside* the retry loop — so a vanished vault folder (unmounted drive, deleted directory) would spin uselessly through every attempt and then fail anyway, masking a distinct condition we want surfaced fast and named precisely.
- **Retries stay bounded** (4 attempts, ~650ms) so a note save can never hang the UI.

## Task/DB path (`SqliteError` at `updateTask`)

Audited — **not the same shape, no change made.** `updateTask` (`main/database/queries/tasks.ts:32`) is a bare Drizzle call with no try/catch, so nothing destroys the `SqliteError`; it reaches telemetry intact and reports as `SqliteError`. Making its `.code` (e.g. `SQLITE_BUSY`) visible is a telemetry-read change and belongs to the sibling `fix-telemetry-error-code-fidelity` PR, not here.

## Compat / migration

No DB, IPC contract, vault format, or settings change. **No migration required.**

- `NoteError`'s new `cause` is an **optional 4th parameter**; all 15 existing call sites are untouched and behave identically.
- `NoteError.code` keeps its exact `NoteErrorCode` union type and value — the composite string lives only in the additive `telemetryCode` getter, so any caller comparing `.code` is unaffected.
- Telemetry is additive: `errorCode` for note fs failures becomes more specific (`NoteError` → `NOTE_WRITE_FAILED:EBUSY`). Nothing else changes shape. Old clients keep sending `NoteError`; dashboards will see both during rollout.

## Verification actually run

| Check | Result |
| --- | --- |
| TDD red (`file-ops` + `errors` + `diagnostics`) | **11 tests failed first**, incl. `expected undefined to be Error: ENOSPC` (cause discarded) and telemetry `errorCode: "NoteError"` vs expected `NOTE_WRITE_FAILED:EBUSY` — the production bug reproduced |
| Same 3 files after fix | **80 passed** |
| `pnpm typecheck` | 16/16 tasks successful |
| `eslint` (changed source files) | 0 errors |
| `electron-vite build` + `check-worker-bundles.mjs` | **OK** — `file-ops.ts` now imports `electron-log`, and it is reachable from `src/main/sync/*`, so I ran the guard: `sync-worker.js` / `image-processing-worker.js` / `voice-transcription-worker.js` all OK. No worker chunk requires `electron` (this is the bundling landmine that once caused a silent prod sync outage) |
| `pnpm docs:impact --strict` + `pnpm docs:build` | pass |

## Not verified / risk

- **`pnpm test:main` full suite is not green in my worktree**: 31 files fail with `Error: Electron failed to install correctly`. I verified this is **environmental and pre-existing** by stashing my changes and reproducing the identical failure on a clean tree. None of my three files are in the failing set. I did not run the full suite green.
- **Not verified on real Windows.** The `EBUSY`/`ENOSPC` paths are exercised by injected errno mocks, not a real OneDrive/antivirus lock. The `safeRead`/`deleteFile` cause tests assert errno-shape rather than a specific errno, since it differs by platform.
- **The fix's real payoff is unproven until a user hits it again** — by design, this PR buys the diagnosis, not the cure. We won't know the actual errno until the next occurrence reports one.
- **Merge coordination:** the sibling `fix-telemetry-error-code-fidelity` PR also touches `toErrorCode` in `diagnostics.ts`. Expect a conflict there; resolution should keep the `NoteError → telemetryCode` branch, which composes with reading `.code` for other error classes. I own `lib/errors.ts`; that file is not touched by the sibling.
- **Mentioned, not changed** (out of brief scope): `ensureDirectory` runs outside the retry loop, so a transient `mkdir` lock is not retried; and `trackIpcError` in `main/ipc/validate.ts:18` throttles by `error.name`, so all `NoteError`s share one 60s throttle bucket regardless of errno — worth revisiting alongside the telemetry-fidelity PR.

---

# Context for reviewers

## Where this came from

This PR is one of 8 opened from a **2-day production error-log triage** (2026-07-13 → 07-15, Grafana `/d/memry-logs`, `env=production`, Loki on the VPS).

The whole window held only **161 log lines** — 90 desktop errors, 27 server errors, 44 server warns — across **13 distinct installs**. Cloudflare Analytics Engine gives the denominator: **18 active installs** in those 2 days, **30** over 5 days.

Two things made this triage possible at all, and both are recent:
- **#732** (merged 2026-07-10) fixed `detectBuildChannel` falling back to `process.env.NODE_ENV`, which is undefined in packaged Electron. Before it, every packaged install reported `build_channel="development"` **and** defaulted telemetry OFF. Every desktop line in this window now reads `build_channel=production` on `2026.710.3` — so we are finally seeing real users.
- **#733** (merged 2026-07-10) stopped clean utility-worker exits from firing error events, so what remains is signal.

Low line counts here mean **low telemetry volume, not low impact**. The headline finding of the whole triage — a 58-day, 100%-broken attachment upload — was exposed by exactly **2 log lines**.

## How these PRs were produced

Each production error class was root-caused by a dedicated investigation against the real code before any patch was written, then implemented TDD-first in an isolated worktree, then put through an **adversarial review** whose explicit brief was to find what is wrong rather than to approve.

That review stage earned its keep: **6 of 8 PRs came back `needs-work`**, several with defects that would have merged silently. Its findings are reproduced verbatim below — they are not cosmetic.

**The one question that matters most on every one of these PRs:** *would the new tests actually fail on the base branch?* The 58-day attachment outage survived because both the server suite (R2/D1 fully mocked, self-consistent fixtures like `total_size: 10` with raw bytes) and the desktop suite (`fetch` mocked wholesale) passed green while the seam between them was never exercised. A test that mocks the thing under test proves nothing. Some of these PRs repeated that exact mistake and the reviewer caught it.

## This PR: production evidence

`NoteError` → `atomicWrite` → `updateNote` → `updateNoteCommand`, win32, install `d7f63d79`, `2026.710.3`. A real user's **note save failed** — 2 occurrences over 14 days. Related: 5x `SqliteError` at `PreparedQuery.get` → `updateTask`.

The reason this is worth a PR despite 2 occurrences is not the frequency, it is that **we can never find out why it happened**. `file-ops.ts:84` is a bare `catch {}` that discards the original error and with it the errno (EBUSY? EPERM? ENOSPC? EROFS?). Combined with telemetry reporting the class name (`toErrorCode` returns `error.name`), a failed note save is permanently un-diagnosable — we cannot distinguish "antivirus locked the file" from "disk full".

Concrete lead: the production stack's install path is literally `~\OneDrive - Kologik\Desktop\memrynote\...` — the vault lives inside a OneDrive-synced folder, which makes the cloud-sync/AV file-lock hypothesis specific rather than theoretical.

## A clarification that shaped this PR

The original instruction paired this with "if Cloudflare is failing we need a retry mechanism". To be explicit: **this path is a local disk write and has nothing to do with Cloudflare.** The Cloudflare/R2 retry belongs to #744. Retry already existed here (`withTransientFsRetry`, EBUSY/EPERM/EACCES, 50/150/450ms) — the actual bug was the swallowed cause, not a missing retry.

## Adversarial review findings (verbatim)

> Reproduced exactly as returned. Findings cite file:line — verify them yourself rather than trusting either the author or the reviewer.

VERDICT: ship

## TESTS ARE REAL?
YES — verified independently, not taken on trust. The critical test (diagnostics.test.ts:53) mocks ONLY the sink (`trackMainEvent`), constructs a real `NoteError` with a real errno-bearing cause, and calls the real `trackMainError`/`toErrorCode`. It does not mock the thing under test. I confirmed each new test would have FAILED on origin/main by reading the old code: (1) old `NoteError` constructor is `super(message)` with no options param (errors.ts:52) → `err.cause` is undefined → the cause assertions fail; (2) no `telemetryCode` getter existed → `expect(...).toBe('NOTE_WRITE_FAILED:EBUSY')` gets undefined; (3) old `toErrorCode` returned `error.name` (diagnostics.ts:24) → emits literally 'NoteError', reproducing the exact Loki symptom the PR exists to fix; (4) old `atomicWrite` had a bare `catch {}` (file-ops.ts:84) discarding the errno; (5) no logger existed in the retry loop → warn called 0 times. The author's reported TDD failure messages match what the old code actually does — this is a genuine red-then-green, not a reconstruction. Test quality is good beyond the headline: safeRead/deleteFile tests use REAL fs (no mock on readFile/unlink) against real dirs, so they exercise actual libuv errnos; only `rename` and the logger are mocked, which are collaborators, not the unit under test. LIMITATION I must state honestly: I did NOT re-run the suite or typecheck myself — a clean checkout of the branch has no node_modules and the npx-resolved vitest was a different version, so installing was not worth the budget. My verification is by code-reading and end-to-end path tracing, which for this diff is conclusive. The author's 'full main suite not green (Electron install marker)' admission matches the known fresh-worktree gotcha and they reproduced it on a stashed clean tree — that is the right way to prove pre-existing, and none of the 3 changed files are in the failing set.

## BLOCKING


## NITS

- [1] SIGNIFICANT (strongest finding, follow-up not blocker): ipc/validate.ts:16 throttles telemetry by `error.name`, so ALL NoteErrors share one 'NoteError' key with a 60s window in a never-cleared module-level Map. An unrelated NOTE_NOT_FOUND at t=0 will suppress the NOTE_WRITE_FAILED:EBUSY at t=30s — precisely the event this PR exists to capture. The PR ships the composite code but leaves the throttle keyed on the coarse name, materially undercutting its own payoff. One-line fix: key on `error instanceof NoteError ? error.telemetryCode : error.name`. Not blocking because it is pre-existing behavior the PR does not regress, and a user retrying a failing save for minutes will eventually land an event — but this should land with the sibling fix-telemetry-error-code-fidelity PR, as the author suggests.

- [2] WINDOWS GAP, ironic given the target platform: libuv surfaces `code: 'UNKNOWN'` (errno -4094) for exactly the weird antivirus/OneDrive interference this PR is chasing. 'UNKNOWN' starts with U, fails ERRNO_PATTERN (errors.ts:49), and is silently dropped to a bare NOTE_WRITE_FAILED — you learn nothing from the case most likely to have caused the report. Consider allowlisting 'UNKNOWN' explicitly alongside the E-pattern.

- [3] errors.ts:51 `errnoOf` reads only the IMMEDIATE cause and does not walk the cause chain. Safe TODAY (I verified ensureDirectory at file-ops.ts:~178 and withTransientFsRetry both rethrow the RAW fs error, so atomicWrite's immediate cause always carries an errno), but fragile: if anyone later makes ensureDirectory throw a NoteError, telemetryCode silently degrades to bare NOTE_WRITE_FAILED with no test catching it. Degrades safely rather than leaking (NoteError.code starts with 'N', fails the pattern) — a fortunate accident worth making deliberate.

- [4] file-ops.ts:32 adds `operationName` for diagnosability but the OTHER caller, sync/attachments.ts:800, does not pass one — attachment write retries log as the useless 'fs: transient EBUSY...'. Free diagnosability left on the table in the exact code path (attachment writes) that is also lock-prone on Windows.

- [5] file-ops.test.ts retry-log test asserts `expect(logged).toContain('1')` — near-vacuous, since '1' also matches the '150ms' delay or 'of 1'. The neighboring EBUSY/path assertions carry the test; consider `toContain('attempt 1 of 4')`.

- [6] OPERATIONAL (not user-facing compat): the telemetry errorCode VALUE changes from 'NoteError' to 'NOTE_WRITE_FAILED:*'. During rollout the fleet is mixed — old clients keep emitting 'NoteError', new ones emit the composite. Any saved Grafana/AE query or alert filtering on errorCode = 'NoteError' silently stops matching updated clients. The docs update is honest and good but says nothing about existing dashboards; a prefix/OR match is needed. Worth a line in the PR body.

- [7] Backward compat is otherwise clean and I checked it specifically: no DB schema, no contracts, no IPC, no electron-store shape touched; the NoteError 4th param is optional so every existing call site compiles unchanged; this is main-process-only with nothing persisted. No migration needed. House rules pass: no Co-Authored-By in either commit, no agent/tool branding in branch or commits, createLogger not console.*, no renderer/Tailwind changes, no contracts change so ipc:generate/ipc:check are correctly not required.

- [8] Scope is tight — I looked for creep and found none. The `.entries()` change is required for the attempt index; the operationName param is required for the log line; the docs edit is mandatory because the change made the existing 'errorCode is the class name' sentence untrue. No drive-by refactors, no reformatting, no deleted pre-existing dead code. The author's decision to leave the retry set/delays untouched pending errno evidence is correct engineering, not laziness, and their disclosure that the payoff is unprovable until a user hits it again on a build carrying this change is accurate and appropriately humble.
