### PR TITLE
fix(sync-server): account for chunk encryption overhead in attachment upload sizes

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -245,6 +245,64 @@ jobs:
           path: apps/desktop/test-results/
           if-no-files-found: ignore
 
+  e2e-smoke-macos:
+    name: Electron E2E smoke (macOS)
+    # Push-to-main only, matching the ubuntu and Windows e2e jobs: a macOS
+    # runner is the most expensive minute GitHub bills (10x ubuntu), and PRs
+    # already run lint + typecheck + unit + ubuntu coverage, plus the attachment
+    # client/server integration spec in sync-server-ci.
+    # No xvfb: macOS runners have a window server. ensure-native.sh is used
+    # directly (it is bash-native and works here — the Windows job hand-rolls the
+    # rebuild + stamp only because ensure-native.sh breaks under MSYS).
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        env:
+          SKIP_ELECTRON_REBUILD: 1
+        run: pnpm install --frozen-lockfile
+
+      - name: Build desktop app
+        run: |
+          bash apps/desktop/scripts/check-cert-hashes.sh
+          bash apps/desktop/scripts/ensure-native.sh electron
+          pnpm --filter @memry/desktop exec electron-vite build
+
+      - name: Run Electron smoke tests
+        run: |
+          bash apps/desktop/scripts/ensure-native.sh electron
+          pnpm --filter @memry/desktop exec playwright test \
+            --config config/playwright.config.ts \
+            tests/e2e/startup-recovery.e2e.ts \
+            tests/e2e/vault.e2e.ts \
+            tests/e2e/notes.e2e.ts \
+            tests/e2e/tasks.e2e.ts \
+            tests/e2e/file-attachments-viewer.e2e.ts
+
+      - name: Upload E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-smoke-macos-results
+          path: apps/desktop/test-results/
+          if-no-files-found: ignore
+
   e2e-smoke-windows:
     name: Electron E2E smoke (Windows)
     # Push-to-main only, matching the ubuntu e2e-smoke/e2e-full jobs: Windows
@@ -323,7 +381,8 @@ jobs:
             tests/e2e/startup-recovery.e2e.ts \
             tests/e2e/vault.e2e.ts \
             tests/e2e/notes.e2e.ts \
-            tests/e2e/tasks.e2e.ts
+            tests/e2e/tasks.e2e.ts \
+            tests/e2e/file-attachments-viewer.e2e.ts
 
       - name: Upload E2E artifacts
         if: always()

--- a/.github/workflows/sync-server-ci.yml
+++ b/.github/workflows/sync-server-ci.yml
@@ -9,6 +9,10 @@ on:
       - 'packages/shared/**'
       - 'packages/sync-core/**'
       - 'tests/sync-harness/**'
+      # The attachment client is exercised against the real Worker by the
+      # integration spec below, so a client-side change must re-run this job.
+      - 'apps/desktop/src/main/sync/attachments.ts'
+      - 'apps/desktop/src/main/sync/attachments.integration.test.ts'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
@@ -22,6 +26,10 @@ on:
       - 'packages/shared/**'
       - 'packages/sync-core/**'
       - 'tests/sync-harness/**'
+      # The attachment client is exercised against the real Worker by the
+      # integration spec below, so a client-side change must re-run this job.
+      - 'apps/desktop/src/main/sync/attachments.ts'
+      - 'apps/desktop/src/main/sync/attachments.integration.test.ts'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
@@ -81,6 +89,18 @@ jobs:
 
       - name: Run sync protocol harness
         run: pnpm --filter @memry/sync-harness test
+
+      # Real client against the real Worker (miniflare + real D1 + real R2).
+      # Both sides' unit suites mock this seam and stayed green through a 58-day
+      # attachment upload outage, so this is the job that actually covers it.
+      # Needs no Electron binary and no display server (the spec injects fetchFn
+      # and stubs the electron import), and runs in seconds.
+      - name: Run attachment client/server integration spec
+        run: |
+          pnpm --filter @memry/desktop exec vitest run \
+            --config config/vitest.config.ts \
+            --project main \
+            src/main/sync/attachments.integration.test.ts
 
       - name: Validate Worker bundle
         run: pnpm --filter @memry/sync-server exec wrangler deploy --dry-run --outdir .wrangler/ci --env staging

--- a/apps/desktop/src/main/billing/entitlement-cache.test.ts
+++ b/apps/desktop/src/main/billing/entitlement-cache.test.ts
@@ -15,6 +15,7 @@ vi.mock('../store', () => ({
 
 import {
   isPaidBillingStatus,
+  getCachedMaxFileSize,
   getCachedEntitlement,
   setCachedEntitlementFromStatus
 } from './entitlement-cache'
@@ -57,14 +58,54 @@ describe('entitlement-cache', () => {
     expect(getCachedEntitlement()).toBeNull()
   })
 
+  it('getCachedMaxFileSize returns the cached plan limit', () => {
+    const s = status('plus', 'active')
+    s.limits.maxFileSize = 5 * 1024 * 1024
+    setCachedEntitlementFromStatus(s)
+    expect(getCachedMaxFileSize()).toBe(5 * 1024 * 1024)
+  })
+
+  it('getCachedMaxFileSize returns null on a cold cache', () => {
+    expect(getCachedMaxFileSize()).toBeNull()
+  })
+
+  it('getCachedMaxFileSize returns null for a store written before limits existed', () => {
+    // Real users' electron-store files have entitlement rows with no `limits`
+    // key. Reading one must fail open (null = defer to the server), never block.
+    storeData.sync = { entitlement: { isPaid: true, plan: 'plus', status: 'active' } }
+    expect(getCachedMaxFileSize()).toBeNull()
+  })
+
+  it('getCachedMaxFileSize returns null for an implausible cached limit', () => {
+    storeData.sync = {
+      entitlement: { isPaid: true, plan: 'plus', status: 'active', limits: { maxFileSize: 0 } }
+    }
+    expect(getCachedMaxFileSize()).toBeNull()
+  })
+
   it('setCachedEntitlementFromStatus writes a cache and getCachedEntitlement reads it', () => {
     const written = setCachedEntitlementFromStatus(status('plus', 'active'))
-    expect(written).toEqual({ isPaid: true, plan: 'plus', status: 'active' })
-    expect(getCachedEntitlement()).toEqual({ isPaid: true, plan: 'plus', status: 'active' })
+    expect(written).toEqual({
+      isPaid: true,
+      plan: 'plus',
+      status: 'active',
+      limits: { maxFileSize: 0 }
+    })
+    expect(getCachedEntitlement()).toEqual({
+      isPaid: true,
+      plan: 'plus',
+      status: 'active',
+      limits: { maxFileSize: 0 }
+    })
   })
 
   it('caches an unpaid status as isPaid=false', () => {
     setCachedEntitlementFromStatus(status('free', 'inactive'))
-    expect(getCachedEntitlement()).toEqual({ isPaid: false, plan: 'free', status: 'inactive' })
+    expect(getCachedEntitlement()).toEqual({
+      isPaid: false,
+      plan: 'free',
+      status: 'inactive',
+      limits: { maxFileSize: 0 }
+    })
   })
 })

--- a/apps/desktop/src/main/billing/entitlement-cache.ts
+++ b/apps/desktop/src/main/billing/entitlement-cache.ts
@@ -19,8 +19,28 @@ export function setCachedEntitlementFromStatus(s: BillingStatus): CachedEntitlem
   const cached: CachedEntitlement = {
     isPaid: isPaidBillingStatus(s),
     plan: s.plan,
-    status: s.status
+    status: s.status,
+    // Carry the file-size limit so an attachment upload can be rejected before
+    // the expensive read+hash+encrypt pass instead of after a server 413.
+    limits: { maxFileSize: s.limits.maxFileSize }
   }
   store.set('sync', { ...store.get('sync'), entitlement: cached })
   return cached
+}
+
+/**
+ * Cached plan file-size limit, or null when unknown.
+ *
+ * Null means "no opinion, let the server decide": the cache is only populated on
+ * a billing fetch, so it is legitimately absent on a cold start or on a store
+ * written by an older version. Callers must fail open — never block an upload on
+ * a cold cache.
+ */
+export function getCachedMaxFileSize(): number | null {
+  const cached = getCachedEntitlement()
+  const maxFileSize = cached?.limits?.maxFileSize
+  if (typeof maxFileSize !== 'number' || !Number.isFinite(maxFileSize) || maxFileSize <= 0) {
+    return null
+  }
+  return maxFileSize
 }

--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
@@ -15,6 +15,8 @@ import {
 } from '@memry/contracts/ipc-attachments'
 
 import { AttachmentSyncService, type TransferProgress } from '../sync/attachments'
+import { getCachedMaxFileSize } from '../billing/entitlement-cache'
+import { trackMainError } from '../telemetry/diagnostics'
 import { UploadQueue } from '../sync/upload-queue'
 import { attachmentEvents } from '../sync/attachment-events'
 import { markWritebackIgnored } from '../sync/crdt-writeback'
@@ -77,6 +79,7 @@ const getOrCreateAttachmentService = (): AttachmentSyncService | null => {
   if (attachmentService) return attachmentService
 
   attachmentService = new AttachmentSyncService({
+    getMaxFileSize: () => getCachedMaxFileSize(),
     getAccessToken: () => getValidAccessToken(),
     getVaultKey: async () => {
       if (!isDatabaseInitialized()) return null
@@ -263,6 +266,10 @@ export function registerAttachmentHandlers(): void {
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
         logger.error('Attachment upload failed', { noteId, diskPath, error: message })
+        // electron-log alone kept this outage invisible for 58 days — the only
+        // reason it surfaced was a server-side 413. Route it to telemetry too so
+        // an attachment outage is visible from the client side.
+        trackMainError('sync_attachments', 'attachment_upload_failed', err)
         for (const win of BrowserWindow.getAllWindows()) {
           win.webContents.send(SYNC_EVENTS.ATTACHMENT_UPLOAD_FAILED, {
             noteId,

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -24,6 +24,16 @@ export interface CachedEntitlement {
   isPaid: boolean
   plan: string
   status: string
+  /**
+   * Plan limits from the last billing status. Optional: stores written by older
+   * app versions have no `limits` key, and it is only populated on a billing
+   * fetch — so every reader must tolerate it being absent and fall back to
+   * server-authoritative behaviour rather than blocking.
+   */
+  limits?: {
+    /** Max plaintext bytes per file the plan allows. */
+    maxFileSize: number
+  }
 }
 
 /**

--- a/apps/desktop/src/main/sync/attachments.integration.test.ts
+++ b/apps/desktop/src/main/sync/attachments.integration.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Attachment upload/download against a REAL sync-server.
+ *
+ * Every other attachment test on both sides mocks the seam: the desktop suite
+ * mocks `fetch` wholesale and the sync-server suite mocks R2/D1 with
+ * self-consistent numbers. Both stayed green for 58 days while chunked upload
+ * was 413ing in production, because nothing exercised client and server
+ * together. This spec boots the real Worker (miniflare + real D1 migrations +
+ * real R2) and drives the real client against it, so the size accounting, the
+ * route prefix and the plan gates are all checked for real.
+ *
+ * No Electron and no display server needed — `fetchFn` is injected, so the
+ * `net` import is never dereferenced.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { randomUUID, randomBytes } from 'node:crypto'
+import path from 'node:path'
+import os from 'node:os'
+import sodium from 'libsodium-wrappers-sumo'
+
+// `attachments.ts` imports `net` from electron at module scope. This spec injects
+// `fetchFn`, so `net` is never dereferenced — stub the import so the suite runs on a
+// plain Node worker (no Electron binary, no display server).
+vi.mock('electron', () => ({
+  net: {
+    fetch: () => {
+      throw new Error('net.fetch must not be used — this spec injects fetchFn')
+    }
+  }
+}))
+
+import { AttachmentSyncService, type AttachmentSyncDeps } from './attachments'
+
+const MIB = 1024 * 1024
+// nonce(24) + Poly1305 tag(16) — mirrors the server's CHUNK_CRYPTO_OVERHEAD.
+const CHUNK_CRYPTO_OVERHEAD = 40
+
+// Mirrors the harness usage in apps/desktop/tests/e2e/utils/sync-backend.ts.
+type Harness = {
+  start(): Promise<void>
+  stop(): Promise<void>
+  getD1(): Promise<D1Database>
+  getDirectUrl(): Promise<URL>
+  createAccessToken(userId: string, deviceId: string): Promise<string>
+}
+
+let server: Harness
+let baseUrl: string
+let tmpDir: string
+
+interface SeededUser {
+  userId: string
+  deviceId: string
+  token: string
+}
+
+async function seedUser(opts: {
+  plan: string
+  status: string
+  maxFileSize: number
+  storageLimit: number
+}): Promise<SeededUser> {
+  const db = await server.getD1()
+  const userId = randomUUID()
+  const deviceId = randomUUID()
+  const now = Math.floor(Date.now() / 1000)
+
+  await db
+    .prepare(
+      `INSERT INTO users (id, email, email_verified, auth_method, storage_used, storage_limit, created_at, updated_at)
+       VALUES (?, ?, 1, 'otp', 0, ?, ?, ?)`
+    )
+    .bind(userId, `${userId}@example.test`, opts.storageLimit, now, now)
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO sync_entitlements (
+         user_id, plan, status, source, storage_limit, max_file_size, max_vaults, version_history_days, updated_at
+       ) VALUES (?, ?, ?, 'test_seed', ?, ?, NULL, 365, ?)`
+    )
+    .bind(userId, opts.plan, opts.status, opts.storageLimit, opts.maxFileSize, now)
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO devices (id, user_id, name, platform, app_version, auth_public_key, vault_id, created_at, updated_at)
+       VALUES (?, ?, 'test-device', 'test', '99.0.0', ?, 'default', ?, ?)`
+    )
+    .bind(deviceId, userId, `pubkey-${deviceId}`, now, now)
+    .run()
+
+  await db
+    .prepare('INSERT INTO server_cursor_sequence (user_id, current_cursor) VALUES (?, 0)')
+    .bind(userId)
+    .run()
+
+  const token = await server.createAccessToken(userId, deviceId)
+  return { userId, deviceId, token }
+}
+
+/**
+ * Real client deps. The signing keypair is shared with `getDevicePublicKey` so
+ * the manifest signature verifies on the download side.
+ */
+function createDeps(user: SeededUser): AttachmentSyncDeps {
+  const signing = sodium.crypto_sign_keypair()
+  const vaultKey = sodium.randombytes_buf(32)
+
+  return {
+    getAccessToken: async () => user.token,
+    getVaultKey: async () => vaultKey,
+    getSigningKeys: async () => ({
+      secretKey: signing.privateKey,
+      publicKey: signing.publicKey,
+      deviceId: user.deviceId
+    }),
+    getDevicePublicKey: async () => signing.publicKey,
+    getSyncServerUrl: () => baseUrl,
+    // Real HTTP against the miniflare listener — not a mock.
+    fetchFn: (input, init) => fetch(input as RequestInfo, init as RequestInit)
+  }
+}
+
+async function writeTempFile(name: string, bytes: Uint8Array): Promise<string> {
+  const p = path.join(tmpDir, name)
+  await writeFile(p, bytes)
+  return p
+}
+
+beforeAll(async () => {
+  await sodium.ready
+  const mod = await import('../../../../../tests/sync-harness/src/simulated-server.ts')
+  server = new mod.SimulatedServer() as Harness
+  await server.start()
+  const url = await server.getDirectUrl()
+  // origin, not href: href carries a trailing slash and the client appends '/sync/...'.
+  baseUrl = url.origin
+}, 180_000)
+
+afterAll(async () => {
+  await server?.stop()
+})
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), 'memry-attach-int-'))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+describe('attachment upload/download against the real sync-server', () => {
+  it('round-trips a single-chunk file with identical bytes', async () => {
+    const user = await seedUser({
+      plan: 'believer',
+      status: 'active',
+      maxFileSize: 200 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+    const svc = new AttachmentSyncService(createDeps(user))
+
+    const original = randomBytes(64 * 1024)
+    const src = await writeTempFile('small.bin', original)
+
+    const result = await svc.uploadAttachment('note-1', src)
+    expect(result.manifest.chunks).toHaveLength(1)
+
+    const dest = path.join(tmpDir, 'small-out.bin')
+    const download = await svc.downloadAttachment(result.attachmentId, dest)
+
+    const roundTripped = await import('node:fs/promises').then((fs) => fs.readFile(dest))
+    expect(Buffer.compare(roundTripped, original)).toBe(0)
+    expect(download.manifest.size).toBe(original.length)
+  }, 120_000)
+
+  it('round-trips a multi-chunk file (>8 MiB) with identical bytes', async () => {
+    const user = await seedUser({
+      plan: 'believer',
+      status: 'active',
+      maxFileSize: 200 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+    const svc = new AttachmentSyncService(createDeps(user))
+
+    // 20 MiB => 3 chunks at CHUNK_SIZE = 8 MiB. Each chunk adds nonce(24)+tag(16),
+    // so the ciphertext on the wire is 120 bytes larger than the plaintext.
+    const original = randomBytes(20 * MIB)
+    const src = await writeTempFile('big.bin', original)
+
+    const result = await svc.uploadAttachment('note-2', src)
+    expect(result.manifest.chunks).toHaveLength(3)
+
+    const dest = path.join(tmpDir, 'big-out.bin')
+    await svc.downloadAttachment(result.attachmentId, dest)
+
+    const roundTripped = await import('node:fs/promises').then((fs) => fs.readFile(dest))
+    expect(Buffer.compare(roundTripped, original)).toBe(0)
+  }, 180_000)
+
+  it('accepts a Plus-plan file at exactly the 5 MiB limit', async () => {
+    const user = await seedUser({
+      plan: 'plus',
+      status: 'active',
+      maxFileSize: 5 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+    const svc = new AttachmentSyncService(createDeps(user))
+
+    // Exactly at the limit. This is the regression that the 58-day bug caused:
+    // the encrypted bytes exceed the plaintext, so a naive server that measures
+    // ciphertext against the plan limit rejects a legal file.
+    const original = randomBytes(5 * MIB)
+    const src = await writeTempFile('exact.bin', original)
+
+    const result = await svc.uploadAttachment('note-3', src)
+    expect(result.manifest.size).toBe(5 * MIB)
+
+    const dest = path.join(tmpDir, 'exact-out.bin')
+    await svc.downloadAttachment(result.attachmentId, dest)
+    const roundTripped = await import('node:fs/promises').then((fs) => fs.readFile(dest))
+    expect(Buffer.compare(roundTripped, original)).toBe(0)
+  }, 180_000)
+
+  it('rejects an over-limit file on a Plus plan with a file-too-large error', async () => {
+    const user = await seedUser({
+      plan: 'plus',
+      status: 'active',
+      maxFileSize: 5 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+    const svc = new AttachmentSyncService(createDeps(user))
+
+    const src = await writeTempFile('over.bin', randomBytes(6 * MIB))
+
+    await expect(svc.uploadAttachment('note-4', src)).rejects.toThrow(/plan file size limit/i)
+  }, 120_000)
+
+  it('rejects upload on a free plan with payment required', async () => {
+    const user = await seedUser({
+      plan: 'free',
+      status: 'inactive',
+      maxFileSize: 0,
+      storageLimit: 0
+    })
+    const svc = new AttachmentSyncService(createDeps(user))
+
+    const src = await writeTempFile('free.bin', randomBytes(1024))
+
+    await expect(svc.uploadAttachment('note-5', src)).rejects.toThrow()
+  }, 120_000)
+
+  it('declares the exact encrypted byte total on initiate', async () => {
+    // The server can derive this, but only by assuming today's chunk framing.
+    // Declaring it explicitly keeps quota accounting correct if the client's
+    // cipher or chunking ever changes, and the server validates it for
+    // plausibility rather than trusting it.
+    const user = await seedUser({
+      plan: 'believer',
+      status: 'active',
+      maxFileSize: 200 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+
+    let initiateBody: Record<string, unknown> | null = null
+    const deps = createDeps(user)
+    const realFetch = deps.fetchFn!
+    deps.fetchFn = async (input, init) => {
+      const url = typeof input === 'string' ? input : String(input)
+      if (url.endsWith('/sync/attachments/upload/initiate') && typeof init?.body === 'string') {
+        initiateBody = JSON.parse(init.body) as Record<string, unknown>
+      }
+      return realFetch(input, init)
+    }
+
+    const svc = new AttachmentSyncService(deps)
+    const original = randomBytes(20 * MIB)
+    const src = await writeTempFile('declared.bin', original)
+    const result = await svc.uploadAttachment('note-6', src)
+
+    const onWire = result.manifest.chunks.reduce(
+      (sum, c) => sum + c.size + CHUNK_CRYPTO_OVERHEAD,
+      0
+    )
+    expect(initiateBody).not.toBeNull()
+    expect(initiateBody!.totalSize).toBe(20 * MIB)
+    expect(initiateBody!.encryptedSize).toBe(onWire)
+
+    // ...and the server charged storage against the ciphertext, not the
+    // plaintext. This is the property the 58-day bug violated: the wire bytes
+    // exceed `totalSize`, so accounting on `totalSize` under-counts quota and
+    // makes the chunk guard reject a legal upload.
+    const db = await server.getD1()
+    const row = await db
+      .prepare('SELECT storage_used FROM users WHERE id = ?')
+      .bind(user.userId)
+      .first<{ storage_used: number }>()
+    expect(row!.storage_used).toBeGreaterThanOrEqual(onWire)
+    expect(row!.storage_used).toBeGreaterThan(20 * MIB)
+  }, 180_000)
+
+  it('talks to the real /sync route prefix', async () => {
+    // The mocked suite matches with `urlStr.includes(path)`, which passes for a
+    // wrong base path too. Assert the real mount (index.ts: app.route('/sync', blob)).
+    const user = await seedUser({
+      plan: 'believer',
+      status: 'active',
+      maxFileSize: 200 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+
+    const resp = await fetch(`${baseUrl}/sync/attachments/upload/initiate`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        attachmentId: randomUUID(),
+        filename: 'probe.bin',
+        totalSize: 1024,
+        chunkCount: 1
+      })
+    })
+    expect(resp.status).toBe(201)
+
+    // ...and that the un-prefixed path is NOT a route.
+    const unprefixed = await fetch(`${baseUrl}/attachments/upload/initiate`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        attachmentId: randomUUID(),
+        filename: 'probe.bin',
+        totalSize: 1024,
+        chunkCount: 1
+      })
+    })
+    expect(unprefixed.status).toBe(404)
+  }, 120_000)
+})

--- a/apps/desktop/src/main/sync/attachments.test.ts
+++ b/apps/desktop/src/main/sync/attachments.test.ts
@@ -142,7 +142,12 @@ describe('AttachmentSyncService', () => {
       await expect(service.uploadAttachment('note-1', testFile)).rejects.toThrow('empty file')
     })
 
-    it('should skip dedup-existing chunks', async () => {
+    it('uploads every chunk without probing for server-side dedup', async () => {
+      // The old client HEAD-probed each chunk hash for dedup before uploading.
+      // That probe could never hit: the file key is random per upload and the
+      // nonce is random per chunk, so `encryptedHash` is unique every time. It
+      // cost a guaranteed-miss round-trip per chunk (and produced the 404 noise
+      // on HEAD /sync/attachments/chunks/:hash). Pin that it is gone.
       const testFile = path.join(tmpDir, 'dedup.txt')
       await writeFile(testFile, Buffer.alloc(512, 'B'))
 
@@ -162,7 +167,10 @@ describe('AttachmentSyncService', () => {
           expiresAt: 0
         }
       })
-      responses.set('HEAD /attachments/chunks/', { status: 200 })
+      responses.set('PUT /attachments/upload/session-2/chunk/0', {
+        status: 200,
+        body: { success: true, uploadedChunks: 1 }
+      })
       responses.set('POST /attachments/upload/session-2/complete', {
         status: 200,
         body: { success: true }
@@ -179,7 +187,116 @@ describe('AttachmentSyncService', () => {
         ([url, init]: [string, RequestInit]) =>
           init?.method === 'PUT' && typeof url === 'string' && url.includes('/chunk/')
       )
-      expect(putCalls).toHaveLength(0)
+      expect(putCalls).toHaveLength(1)
+
+      const headCalls = mockFetch.mock.calls.filter(
+        ([, init]: [string, RequestInit]) => init?.method === 'HEAD'
+      )
+      expect(headCalls).toHaveLength(0)
+    })
+
+    it('declares the encrypted byte total, not the plaintext size, on initiate', async () => {
+      // Regression guard for the 58-day outage: chunks go on the wire as
+      // nonce || ciphertext, so the bytes stored exceed the plaintext size.
+      const testFile = path.join(tmpDir, 'sizes.txt')
+      await writeFile(testFile, Buffer.alloc(512, 'D'))
+
+      const responses = new Map<string, { status: number; body?: unknown; binary?: Uint8Array }>()
+      responses.set('POST /attachments/upload/initiate', {
+        status: 200,
+        body: { sessionId: 'session-3', expiresAt: Date.now() + 3600000 }
+      })
+      responses.set('GET /attachments/upload/session-3', {
+        status: 200,
+        body: {
+          sessionId: 'session-3',
+          attachmentId: '',
+          totalSize: 0,
+          chunkCount: 1,
+          uploadedChunks: [],
+          expiresAt: 0
+        }
+      })
+      responses.set('PUT /attachments/upload/session-3/chunk/0', {
+        status: 200,
+        body: { success: true, uploadedChunks: 1 }
+      })
+      responses.set('POST /attachments/upload/session-3/complete', {
+        status: 200,
+        body: { success: true }
+      })
+
+      const mockFetch = createMockFetch(responses)
+      const service = new AttachmentSyncService(createTestDeps(mockFetch))
+      await service.uploadAttachment('note-1', testFile)
+
+      const initiateCall = mockFetch.mock.calls.find(
+        ([url, init]: [string, RequestInit]) =>
+          init?.method === 'POST' && typeof url === 'string' && url.includes('/initiate')
+      )
+      const body = JSON.parse((initiateCall![1] as RequestInit).body as string)
+      expect(body.totalSize).toBe(512)
+      // nonce(24) + Poly1305 tag(16) on the single chunk.
+      expect(body.encryptedSize).toBe(512 + 40)
+    })
+
+    it('rejects a file over the cached plan limit before reading or encrypting it', async () => {
+      const testFile = path.join(tmpDir, 'toobig.txt')
+      await writeFile(testFile, Buffer.alloc(2048, 'E'))
+
+      const mockFetch = createMockFetch(new Map())
+      const deps: AttachmentSyncDeps = {
+        ...createTestDeps(mockFetch),
+        getMaxFileSize: () => 1024
+      }
+      const service = new AttachmentSyncService(deps)
+
+      await expect(service.uploadAttachment('note-1', testFile)).rejects.toThrow(
+        /larger than your plan allows/i
+      )
+      // Nothing hit the network: the point is to avoid the read+hash+encrypt pass.
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('falls back to server authority when the cached plan limit is unknown', async () => {
+      // The entitlement cache is only warm after a billing fetch. A cold cache
+      // must never block an upload.
+      const testFile = path.join(tmpDir, 'unknown-limit.txt')
+      await writeFile(testFile, Buffer.alloc(2048, 'F'))
+
+      const responses = new Map<string, { status: number; body?: unknown; binary?: Uint8Array }>()
+      responses.set('POST /attachments/upload/initiate', {
+        status: 200,
+        body: { sessionId: 'session-4', expiresAt: Date.now() + 3600000 }
+      })
+      responses.set('GET /attachments/upload/session-4', {
+        status: 200,
+        body: {
+          sessionId: 'session-4',
+          attachmentId: '',
+          totalSize: 0,
+          chunkCount: 1,
+          uploadedChunks: [],
+          expiresAt: 0
+        }
+      })
+      responses.set('PUT /attachments/upload/session-4/chunk/0', {
+        status: 200,
+        body: { success: true, uploadedChunks: 1 }
+      })
+      responses.set('POST /attachments/upload/session-4/complete', {
+        status: 200,
+        body: { success: true }
+      })
+
+      const mockFetch = createMockFetch(responses)
+      const deps: AttachmentSyncDeps = {
+        ...createTestDeps(mockFetch),
+        getMaxFileSize: () => null
+      }
+      const service = new AttachmentSyncService(deps)
+
+      await expect(service.uploadAttachment('note-1', testFile)).resolves.toBeTruthy()
     })
   })
 

--- a/apps/desktop/src/main/sync/attachments.ts
+++ b/apps/desktop/src/main/sync/attachments.ts
@@ -17,13 +17,18 @@ import {
   NetworkError,
   SyncServerError,
   RateLimitError,
+  AttachmentTooLargeError,
   parseRetryAfterHeader,
   getSyncVaultHeaders,
   type FetchFn
 } from './http-client'
 import { withRetry } from './retry'
 
-import type { UploadInitResponse, UploadStatusResponse } from '@memry/contracts/blob-api'
+import type {
+  UploadInitRequest,
+  UploadInitResponse,
+  UploadStatusResponse
+} from '@memry/contracts/blob-api'
 
 const log = createLogger('Attachments')
 
@@ -102,7 +107,19 @@ export interface AttachmentSyncDeps {
   } | null>
   getDevicePublicKey: (deviceId: string) => Promise<Uint8Array | null>
   getSyncServerUrl: () => string
+  /**
+   * Cached plan file-size limit in plaintext bytes, or null when unknown.
+   * Null must mean "let the server decide" — the cache is only warm after a
+   * billing fetch, so a cold cache must never block an upload.
+   */
+  getMaxFileSize?: () => number | null
   fetchFn?: FetchFn
+}
+
+function formatBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024)
+  if (mb >= 1024) return `${(mb / 1024).toFixed(mb % 1024 === 0 ? 0 : 1)} GB`
+  return `${mb.toFixed(mb % 1 === 0 ? 0 : 1)} MB`
 }
 
 // ============================================================================
@@ -148,7 +165,7 @@ function sha256Hex(data: Uint8Array): string {
 // ============================================================================
 
 async function binaryFetch(
-  method: 'GET' | 'PUT' | 'HEAD' | 'POST',
+  method: 'GET' | 'PUT' | 'HEAD' | 'POST' | 'DELETE',
   url: string,
   token: string,
   body?: Uint8Array | string,
@@ -219,6 +236,8 @@ async function parallelMap<T, R>(
 // AttachmentSyncService
 // ============================================================================
 
+export { AttachmentTooLargeError }
+
 export class AttachmentSyncService {
   private deps: AttachmentSyncDeps
   private activeUploads = new Map<string, UploadState>()
@@ -256,6 +275,19 @@ export class AttachmentSyncService {
       }
       if (fileStat.size === 0) {
         throw new Error('Cannot upload empty file')
+      }
+
+      // Plan preflight, before the expensive read+hash+encrypt pass below. The
+      // server stays authoritative; this only avoids doing all that work just to
+      // eat a 413. Fails open: a null limit means the cache is cold or was
+      // written by an older version, so defer to the server as before.
+      const planMaxFileSize = this.deps.getMaxFileSize?.() ?? null
+      if (planMaxFileSize !== null && fileStat.size > planMaxFileSize) {
+        throw new AttachmentTooLargeError(
+          `File is larger than your plan allows: ${formatBytes(fileStat.size)} exceeds ${formatBytes(planMaxFileSize)}`,
+          fileStat.size,
+          planMaxFileSize
+        )
       }
 
       const attachmentId = sodium.to_hex(sodium.randombytes_buf(16))
@@ -326,12 +358,20 @@ export class AttachmentSyncService {
       if (options?.signal) netOpts.signal = options.signal
       if (options?.isOnline) netOpts.isOnline = options.isOnline
 
+      // Every chunk goes on the wire as nonce || ciphertext, so the encrypted
+      // total is larger than the plaintext. Declare it explicitly: the server
+      // reserves storage quota against this, and can otherwise only derive it by
+      // assuming today's chunk framing. The encryption loop above has already
+      // finished, so this is exact.
+      const encryptedSize = encryptedChunks.reduce((sum, c) => sum + c.data.byteLength, 0)
+
       const sessionId = await this.initiateUploadSession(
         token,
         attachmentId,
         filename,
         fileStat.size,
         totalChunks,
+        encryptedSize,
         netOpts
       )
 
@@ -380,15 +420,10 @@ export class AttachmentSyncService {
           })
         }
 
-        const dedupExists = await this.checkChunkDedup(token, chunk.ref.encryptedHash, netOpts)
-        if (dedupExists) {
-          log.debug('chunk deduped', { index: chunk.ref.index, hash: chunk.ref.encryptedHash })
-        } else {
-          await this.uploadChunk(token, sessionId, chunk.ref.index, chunk.data, {
-            ...netOpts,
-            onWaitingNetwork
-          })
-        }
+        await this.uploadChunk(token, sessionId, chunk.ref.index, chunk.data, {
+          ...netOpts,
+          onWaitingNetwork
+        })
 
         uploadState.completedChunks.add(chunk.ref.index)
         bytesUploaded += chunk.ref.size
@@ -517,6 +552,20 @@ export class AttachmentSyncService {
 
   async cancelUpload(sessionId: string): Promise<void> {
     this.activeUploads.delete(sessionId)
+
+    // Drop the server-side session too, otherwise the storage reserved at
+    // initiate stays counted against the user until the 24h TTL sweep.
+    // Best-effort: the sweep is still the backstop if this fails.
+    try {
+      const token = await this.deps.getAccessToken()
+      if (token) {
+        const url = `${this.deps.getSyncServerUrl()}/sync/attachments/upload/${sessionId}`
+        await binaryFetch('DELETE', url, token, undefined, this.deps.fetchFn)
+      }
+    } catch (err) {
+      log.warn('failed to release cancelled upload session on server', { sessionId, err })
+    }
+
     log.info('upload cancelled', { sessionId })
   }
 
@@ -530,22 +579,31 @@ export class AttachmentSyncService {
     filename: string,
     totalSize: number,
     chunkCount: number,
+    encryptedSize: number,
     options?: { signal?: AbortSignal; isOnline?: () => boolean }
   ): Promise<string> {
     const url = `${this.deps.getSyncServerUrl()}/sync/attachments/upload/initiate`
-    const body = JSON.stringify({ attachmentId, filename, totalSize, chunkCount })
+    const body: UploadInitRequest = {
+      attachmentId,
+      filename,
+      totalSize,
+      chunkCount,
+      encryptedSize
+    }
 
     const retryOpts: Partial<import('./retry').RetryOptions> = { maxRetries: 3, baseDelayMs: 2000 }
     if (options?.signal) retryOpts.signal = options.signal
     if (options?.isOnline) retryOpts.isOnline = options.isOnline
 
     const { value: resp } = await withRetry(
-      () => binaryFetch('POST', url, token, body, this.deps.fetchFn),
+      () => binaryFetch('POST', url, token, JSON.stringify(body), this.deps.fetchFn),
       retryOpts
     )
     if (!resp.ok) {
       const errBody = await resp.text()
-      throw new SyncServerError(`Failed to initiate upload: ${errBody}`, resp.status)
+      // Pass the raw body through as serverError so classifyError can tell a
+      // file-too-large rejection apart from a storage-quota one (both are 413).
+      throw new SyncServerError(`Failed to initiate upload: ${errBody}`, resp.status, errBody)
     }
 
     const data = (await resp.json()) as UploadInitResponse
@@ -583,28 +641,6 @@ export class AttachmentSyncService {
     } catch {
       log.warn('checkResumableSession failed, starting fresh', { sessionId })
       return null
-    }
-  }
-
-  private async checkChunkDedup(
-    token: string,
-    encryptedHash: string,
-    options?: { signal?: AbortSignal; isOnline?: () => boolean }
-  ): Promise<boolean> {
-    const url = `${this.deps.getSyncServerUrl()}/sync/attachments/chunks/${encryptedHash}`
-    const retryOpts: Partial<import('./retry').RetryOptions> = { maxRetries: 3, baseDelayMs: 1000 }
-    if (options?.signal) retryOpts.signal = options.signal
-    if (options?.isOnline) retryOpts.isOnline = options.isOnline
-
-    try {
-      const { value: resp } = await withRetry(
-        () => binaryFetch('HEAD', url, token, undefined, this.deps.fetchFn),
-        retryOpts
-      )
-      return resp.status === 200
-    } catch {
-      log.warn('checkChunkDedup failed, assuming not deduped', { encryptedHash })
-      return false
     }
   }
 

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -21,6 +21,23 @@ export class SyncServerError extends Error {
   }
 }
 
+/**
+ * One file is over the plan's per-file limit. Raised by the local preflight
+ * before a file is read/encrypted; mirrors the server's STORAGE_FILE_TOO_LARGE.
+ * Lives here with the other sync error types so `sync-errors` can classify it
+ * without importing the attachment service (and with it, electron + crypto).
+ */
+export class AttachmentTooLargeError extends Error {
+  constructor(
+    message: string,
+    public readonly fileSize: number,
+    public readonly maxFileSize: number
+  ) {
+    super(message)
+    this.name = 'AttachmentTooLargeError'
+  }
+}
+
 export class NetworkError extends Error {
   constructor(message: string) {
     super(message)

--- a/apps/desktop/src/main/sync/sync-errors.test.ts
+++ b/apps/desktop/src/main/sync/sync-errors.test.ts
@@ -1,10 +1,43 @@
 import { describe, it, expect } from 'vitest'
 import { classifyError } from './sync-errors'
-import { SyncServerError, NetworkError, RateLimitError } from './http-client'
+import {
+  SyncServerError,
+  NetworkError,
+  RateLimitError,
+  AttachmentTooLargeError
+} from './http-client'
 import { DeadLetterError } from './retry'
 import { CryptoError } from '../crypto/crypto-errors'
 
 describe('classifyError', () => {
+  it('#given SyncServerError 413 STORAGE_FILE_TOO_LARGE #then file_too_large, not retryable', () => {
+    // Both causes of a 413 used to map to storage_quota_exceeded, which told the
+    // user to free up space — never a fix for one oversized file.
+    const body =
+      '{"error":{"code":"STORAGE_FILE_TOO_LARGE","message":"File exceeds the plus plan file size limit"}}'
+    const err = new SyncServerError(`Failed to initiate upload: ${body}`, 413, body)
+    const result = classifyError(err)
+
+    expect(result.category).toBe('file_too_large')
+    expect(result.retryable).toBe(false)
+  })
+
+  it('#given SyncServerError 413 without a file-too-large code #then storage_quota_exceeded', () => {
+    const err = new SyncServerError('Storage quota exceeded', 413)
+    const result = classifyError(err)
+
+    expect(result.category).toBe('storage_quota_exceeded')
+    expect(result.retryable).toBe(false)
+  })
+
+  it('#given AttachmentTooLargeError #then file_too_large, not retryable', () => {
+    const err = new AttachmentTooLargeError('File is larger than your plan allows', 2048, 1024)
+    const result = classifyError(err)
+
+    expect(result.category).toBe('file_too_large')
+    expect(result.retryable).toBe(false)
+  })
+
   it('#given SyncServerError 401 #then auth_expired, not retryable', () => {
     const err = new SyncServerError('Unauthorized', 401)
     const result = classifyError(err)

--- a/apps/desktop/src/main/sync/sync-errors.ts
+++ b/apps/desktop/src/main/sync/sync-errors.ts
@@ -1,6 +1,11 @@
 import type { SyncErrorCategory } from '@memry/contracts/ipc-sync-ops'
 import { CryptoError } from '../crypto/crypto-errors'
-import { SyncServerError, NetworkError, RateLimitError } from './http-client'
+import {
+  SyncServerError,
+  NetworkError,
+  RateLimitError,
+  AttachmentTooLargeError
+} from './http-client'
 import { DeadLetterError } from './retry'
 
 export type { SyncErrorCategory }
@@ -15,6 +20,16 @@ export function classifyError(error: unknown): SyncErrorInfo {
   if (error instanceof DeadLetterError) {
     const inner = classifyError(error.lastError)
     return { ...inner, retryable: false }
+  }
+
+  // Local plan preflight — same user-facing outcome as the server's 413, but
+  // raised before the file is read and encrypted.
+  if (error instanceof AttachmentTooLargeError) {
+    return {
+      category: 'file_too_large',
+      message: error.message,
+      retryable: false
+    }
   }
 
   if (error instanceof RateLimitError) {
@@ -55,6 +70,20 @@ export function classifyError(error: unknown): SyncErrorInfo {
       }
     }
     if (error.statusCode === 413) {
+      // 413 covers two different problems. STORAGE_FILE_TOO_LARGE means this one
+      // file is over the plan's per-file limit; a bare 413 means the account is
+      // out of storage. Reporting "Storage quota exceeded" for the former sends
+      // the user to free up space, which never fixes it.
+      if (
+        error.serverError?.includes('STORAGE_FILE_TOO_LARGE') ||
+        error.message.includes('STORAGE_FILE_TOO_LARGE')
+      ) {
+        return {
+          category: 'file_too_large',
+          message: 'This file is larger than your plan allows',
+          retryable: false
+        }
+      }
       return {
         category: 'storage_quota_exceeded',
         message: 'Storage quota exceeded',

--- a/apps/desktop/src/preload/api/sync-events.ts
+++ b/apps/desktop/src/preload/api/sync-events.ts
@@ -7,6 +7,7 @@ import type {
   LinkingApprovedEvent,
   LinkingFinalizedEvent,
   UploadProgressEvent,
+  AttachmentUploadFailedEvent,
   DownloadProgressEvent,
   InitialSyncProgressEvent,
   QueueClearedEvent,
@@ -47,6 +48,11 @@ export const syncEvents = {
 
   onDownloadProgress: (callback: (event: DownloadProgressEvent) => void): (() => void) =>
     subscribe<DownloadProgressEvent>(SYNC_EVENTS.DOWNLOAD_PROGRESS, callback),
+
+  onAttachmentUploadFailed: (
+    callback: (event: AttachmentUploadFailedEvent) => void
+  ): (() => void) =>
+    subscribe<AttachmentUploadFailedEvent>(SYNC_EVENTS.ATTACHMENT_UPLOAD_FAILED, callback),
 
   onInitialSyncProgress: (callback: (event: InitialSyncProgressEvent) => void): (() => void) =>
     subscribe<InitialSyncProgressEvent>(SYNC_EVENTS.INITIAL_SYNC_PROGRESS, callback),

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -46,6 +46,7 @@ import type {
   LinkingApprovedEvent,
   LinkingFinalizedEvent,
   UploadProgressEvent,
+  AttachmentUploadFailedEvent,
   DownloadProgressEvent,
   InitialSyncProgressEvent,
   QueueClearedEvent,
@@ -1862,6 +1863,7 @@ interface API extends WindowAPI, GeneratedRpcApi {
   onLinkingFinalized: (callback: (event: LinkingFinalizedEvent) => void) => () => void
   onUploadProgress: (callback: (event: UploadProgressEvent) => void) => () => void
   onDownloadProgress: (callback: (event: DownloadProgressEvent) => void) => () => void
+  onAttachmentUploadFailed: (callback: (event: AttachmentUploadFailedEvent) => void) => () => void
   onInitialSyncProgress: (callback: (event: InitialSyncProgressEvent) => void) => () => void
   onQueueCleared: (callback: (event: QueueClearedEvent) => void) => () => void
   onSyncPaused: (callback: (event: SyncPausedEvent) => void) => () => void

--- a/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
@@ -13,6 +13,7 @@ let pausedListeners: EventCallback[] = []
 let resumedListeners: EventCallback[] = []
 let uploadProgressListeners: EventCallback[] = []
 let downloadProgressListeners: EventCallback[] = []
+let attachmentUploadFailedListeners: EventCallback[] = []
 let linkingRequestListeners: EventCallback[] = []
 let linkingApprovedListeners: EventCallback[] = []
 let conflictDetectedListeners: EventCallback[] = []
@@ -100,6 +101,7 @@ beforeEach(async () => {
   resumedListeners = []
   uploadProgressListeners = []
   downloadProgressListeners = []
+  attachmentUploadFailedListeners = []
   linkingRequestListeners = []
   linkingApprovedListeners = []
   conflictDetectedListeners = []
@@ -147,6 +149,12 @@ beforeEach(async () => {
     downloadProgressListeners.push(cb)
     return () => {
       downloadProgressListeners = downloadProgressListeners.filter((l) => l !== cb)
+    }
+  })
+  api.onAttachmentUploadFailed = vi.fn((cb: EventCallback) => {
+    attachmentUploadFailedListeners.push(cb)
+    return () => {
+      attachmentUploadFailedListeners = attachmentUploadFailedListeners.filter((l) => l !== cb)
     }
   })
   api.onLinkingRequest = vi.fn((cb: EventCallback) => {
@@ -285,6 +293,30 @@ describe('SyncProvider', () => {
       expect(result.current.state.uploadProgress).toEqual({
         'att-1': { progress: 50, status: 'uploading' }
       })
+    })
+  })
+
+  describe('#given attachment upload failed event #when listening', () => {
+    it('#then shows a toast naming the file', async () => {
+      // Nothing listened to this channel for 58 days, so a total attachment
+      // upload outage was silent. Pin that it surfaces.
+      const { result } = renderHook(() => useSync(), { wrapper })
+      await vi.waitFor(() => expect(result.current.state.status).toBe('idle'))
+
+      act(() => {
+        for (const cb of attachmentUploadFailedListeners) {
+          cb({
+            noteId: 'note-1',
+            diskPath: '/vault/attachments/report.pdf',
+            error: 'File exceeds the plus plan file size limit'
+          })
+        }
+      })
+
+      expect(toastMock.error).toHaveBeenCalledWith(
+        expect.stringContaining('report.pdf'),
+        expect.objectContaining({ duration: 10000 })
+      )
     })
   })
 

--- a/apps/desktop/src/renderer/src/contexts/sync-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.tsx
@@ -261,6 +261,19 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
         if (event.errorCategory === 'storage_quota_exceeded') {
           toast.error(t('sync.storageQuotaExceeded'), { duration: 10000 })
         }
+        if (event.errorCategory === 'file_too_large') {
+          toast.error(t('sync.fileTooLarge'), { duration: 10000 })
+        }
+      })
+    )
+
+    // Attachment upload failures were emitted to this channel with no listener,
+    // so a 58-day outage was completely silent to the user. Surface it.
+    cleanups.push(
+      window.api.onAttachmentUploadFailed((event) => {
+        if (cancelled) return
+        const filename = event.diskPath.split(/[\\/]/).pop() ?? event.diskPath
+        toast.error(t('sync.attachmentUploadFailed', { filename }), { duration: 10000 })
       })
     )
 

--- a/apps/desktop/src/renderer/src/lib/error-messages.ts
+++ b/apps/desktop/src/renderer/src/lib/error-messages.ts
@@ -94,6 +94,7 @@ const SYNC_ERROR_KEYS: Record<SyncErrorCategory, string> = {
   crypto_failure: 'sync.cryptoFailure',
   version_incompatible: 'sync.versionIncompatible',
   storage_quota_exceeded: 'sync.storageQuotaExceeded',
+  file_too_large: 'sync.fileTooLarge',
   sync_payment_required: 'sync.paymentRequired',
   certificate_pin_failed: 'sync.certificatePinFailed',
   unknown: 'sync.unknown'

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -61,6 +61,12 @@ Storage usage is visible in [Settings → Vault](/user-guide/settings#vault) wit
 - CRDT data
 - Other (indexes, leveldb, caches)
 
+### File Size Limits vs. Counted Storage
+
+Your plan's per-file size limit applies to the **original file size**. Encryption overhead never counts against it, so a file that is exactly at your plan's limit still uploads.
+
+Synced storage usage counts the **encrypted** size, which is a few bytes larger per chunk than the original (each chunk carries a nonce and an authentication tag). For a typical file this is a difference of tens of bytes.
+
 ## Garbage Collection
 
 Files that are no longer referenced by any note are pruned during periodic vacuum. You don't need to clean them up manually.

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -67,6 +67,12 @@ Your plan's per-file size limit applies to the **original file size**. Encryptio
 
 Synced storage usage counts the **encrypted** size, which is a few bytes larger per chunk than the original (each chunk carries a nonce and an authentication tag). For a typical file this is a difference of tens of bytes.
 
+If a file is over your plan's per-file limit, MemryNote tells you before it spends time encrypting it, and names the limit it hit. Freeing storage does not help in that case — the file itself is too big, so you need a plan with a larger per-file limit.
+
+### When an Attachment Doesn't Sync
+
+If an attachment can't be uploaded, you get a notification naming the file. The file is never lost: it stays in `<vault>/attachments/` and the note keeps working on this device. Only the synced copy is missing, so other devices won't see it until the upload succeeds.
+
 ## Garbage Collection
 
 Files that are no longer referenced by any note are pruned during periodic vacuum. You don't need to clean them up manually.

--- a/apps/sync-server/migrations/0002_upload_sessions_encrypted_size.sql
+++ b/apps/sync-server/migrations/0002_upload_sessions_encrypted_size.sql
@@ -3,14 +3,17 @@
 -- Storage accounting must use the encrypted size, while plan file-size limits
 -- stay on the plaintext size.
 --
--- Nullable and additive. Sessions the previous code left in flight reserved the
--- PLAINTEXT total_size, so they are backfilled to total_size: this column records
--- what was actually reserved, and the refund paths pay back exactly that. Deriving
--- a ciphertext total for these rows would refund bytes that were never reserved and
--- permanently drift users.storage_used down.
+-- Nullable and additive, and deliberately NOT backfilled. NULL is load-bearing: it
+-- is the signal that a row was written by the old server, and the two readers of
+-- this column need OPPOSITE numbers for such a row.
 --
--- Migrations apply before the Worker deploys, so the old code can still open new
--- sessions with a NULL encrypted_size during the rollout window; the refund paths
--- fall back to total_size for those.
+--   * the refund paths want the bytes RESERVED -> the old server reserved the
+--     plaintext, so they read `encrypted_size ?? total_size`.
+--   * the chunk cap and `complete` want the bytes EXPECTED ON THE WIRE -> the old
+--     client still sends ciphertext, so `expectedEncryptedTotal` must DERIVE
+--     total_size + 40*chunk_count, which it only does while this column is NULL.
+--
+-- Backfilling `encrypted_size = total_size` satisfies the first reader and breaks
+-- the second: the derive short-circuits on the non-NULL plaintext value and every
+-- in-flight session then 413s on its last chunk. Leaving NULL is correct for both.
 ALTER TABLE upload_sessions ADD COLUMN encrypted_size INTEGER;
-UPDATE upload_sessions SET encrypted_size = total_size WHERE encrypted_size IS NULL;

--- a/apps/sync-server/migrations/0002_upload_sessions_encrypted_size.sql
+++ b/apps/sync-server/migrations/0002_upload_sessions_encrypted_size.sql
@@ -3,7 +3,14 @@
 -- Storage accounting must use the encrypted size, while plan file-size limits
 -- stay on the plaintext size.
 --
--- Nullable and additive: in-flight sessions written by the previous code, and
--- sessions opened by clients that do not send `encryptedSize`, keep NULL here
--- and the server derives the value from total_size + chunk_count.
+-- Nullable and additive. Sessions the previous code left in flight reserved the
+-- PLAINTEXT total_size, so they are backfilled to total_size: this column records
+-- what was actually reserved, and the refund paths pay back exactly that. Deriving
+-- a ciphertext total for these rows would refund bytes that were never reserved and
+-- permanently drift users.storage_used down.
+--
+-- Migrations apply before the Worker deploys, so the old code can still open new
+-- sessions with a NULL encrypted_size during the rollout window; the refund paths
+-- fall back to total_size for those.
 ALTER TABLE upload_sessions ADD COLUMN encrypted_size INTEGER;
+UPDATE upload_sessions SET encrypted_size = total_size WHERE encrypted_size IS NULL;

--- a/apps/sync-server/migrations/0002_upload_sessions_encrypted_size.sql
+++ b/apps/sync-server/migrations/0002_upload_sessions_encrypted_size.sql
@@ -1,0 +1,9 @@
+-- Chunked attachment uploads declare a PLAINTEXT total_size but put CIPHERTEXT
+-- on the wire (each chunk is nonce || ciphertext, i.e. plaintext + 40 bytes).
+-- Storage accounting must use the encrypted size, while plan file-size limits
+-- stay on the plaintext size.
+--
+-- Nullable and additive: in-flight sessions written by the previous code, and
+-- sessions opened by clients that do not send `encryptedSize`, keep NULL here
+-- and the server derives the value from total_size + chunk_count.
+ALTER TABLE upload_sessions ADD COLUMN encrypted_size INTEGER;

--- a/apps/sync-server/schema/d1.test.ts
+++ b/apps/sync-server/schema/d1.test.ts
@@ -3,14 +3,21 @@ import Database from 'better-sqlite3'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
-// Canonical schema = the ordered D1 migrations wrangler applies on deploy.
-function loadSchemaSql(): string {
-  const dir = resolve(__dirname, '../migrations')
-  return readdirSync(dir)
+const migrationsDir = resolve(__dirname, '../migrations')
+
+function migrationFiles(): string[] {
+  return readdirSync(migrationsDir)
     .filter((file) => file.endsWith('.sql'))
     .sort()
-    .map((file) => readFileSync(join(dir, file), 'utf8'))
-    .join('\n')
+}
+
+function loadMigrationSql(file: string): string {
+  return readFileSync(join(migrationsDir, file), 'utf8')
+}
+
+// Canonical schema = the ordered D1 migrations wrangler applies on deploy.
+function loadSchemaSql(): string {
+  return migrationFiles().map(loadMigrationSql).join('\n')
 }
 
 describe('D1 schema', () => {
@@ -192,5 +199,67 @@ describe('D1 schema', () => {
     expect(crdtSnapshotColumns.map((column) => column.name)).toContain('vault_id')
     expect(uploadSessionColumns.map((column) => column.name)).toContain('vault_id')
     expect(blobChunkColumns.map((column) => column.name)).toContain('vault_id')
+  })
+
+  // Migrations are applied BEFORE the Worker deploys, so 0002 lands on rows the old
+  // server wrote. Those rows reserved the PLAINTEXT total_size; leaving encrypted_size
+  // NULL invites the refund paths to re-derive a larger ciphertext total and hand back
+  // bytes that were never reserved.
+  describe('0002_upload_sessions_encrypted_size', () => {
+    // A database at 0001 (pre-encrypted_size) with a user to own the sessions.
+    const dbAtBaseline = () => {
+      const db = new Database(':memory:')
+      db.exec(loadMigrationSql('0001_baseline.sql'))
+      db.prepare(
+        `INSERT INTO users (id, email, auth_method, created_at, updated_at)
+         VALUES ('user-1', 'a@b.com', 'otp', 1, 1)`
+      ).run()
+      return db
+    }
+
+    const insertLegacySession = (db: Database.Database, id: string, totalSize: number) =>
+      db
+        .prepare(
+          `INSERT INTO upload_sessions
+             (id, user_id, vault_id, attachment_id, filename, total_size, chunk_count, expires_at, created_at)
+           VALUES (?, 'user-1', 'vault-1', ?, 'f.bin', ?, 3, 1, 1)`
+        )
+        .run(id, `att-${id}`, totalSize)
+
+    it('backfills encrypted_size to total_size for rows written before the column existed', () => {
+      // #given a database at 0001 with in-flight sessions the old server reserved plaintext for
+      const db = dbAtBaseline()
+      insertLegacySession(db, 's1', 5_000)
+      insertLegacySession(db, 's2', 500_000)
+
+      // #when 0002 is applied
+      db.exec(loadMigrationSql('0002_upload_sessions_encrypted_size.sql'))
+
+      // #then every legacy row carries the plaintext size it actually reserved
+      const rows = db
+        .prepare('SELECT id, total_size, encrypted_size FROM upload_sessions ORDER BY id')
+        .all() as Array<{ id: string; total_size: number; encrypted_size: number | null }>
+
+      expect(rows).toEqual([
+        { id: 's1', total_size: 5_000, encrypted_size: 5_000 },
+        { id: 's2', total_size: 500_000, encrypted_size: 500_000 }
+      ])
+    })
+
+    it('leaves no NULL encrypted_size rows behind', () => {
+      // #given
+      const db = dbAtBaseline()
+      insertLegacySession(db, 's1', 5_000)
+
+      // #when
+      db.exec(loadMigrationSql('0002_upload_sessions_encrypted_size.sql'))
+
+      // #then
+      const { nulls } = db
+        .prepare('SELECT COUNT(*) AS nulls FROM upload_sessions WHERE encrypted_size IS NULL')
+        .get() as { nulls: number }
+
+      expect(nulls).toBe(0)
+    })
   })
 })

--- a/apps/sync-server/schema/d1.test.ts
+++ b/apps/sync-server/schema/d1.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import Database from 'better-sqlite3'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
+import { CHUNK_CRYPTO_OVERHEAD, expectedEncryptedTotal } from '../src/services/upload-size'
 
 const migrationsDir = resolve(__dirname, '../migrations')
 
@@ -202,9 +203,10 @@ describe('D1 schema', () => {
   })
 
   // Migrations are applied BEFORE the Worker deploys, so 0002 lands on rows the old
-  // server wrote. Those rows reserved the PLAINTEXT total_size; leaving encrypted_size
-  // NULL invites the refund paths to re-derive a larger ciphertext total and hand back
-  // bytes that were never reserved.
+  // server wrote. Those rows must keep a NULL encrypted_size: the refund paths read
+  // it as `?? total_size` (the plaintext they reserved), while the chunk cap and
+  // `complete` need `expectedEncryptedTotal` to DERIVE the ciphertext total, which it
+  // only does while the column is NULL. A backfill would break the second reader.
   describe('0002_upload_sessions_encrypted_size', () => {
     // A database at 0001 (pre-encrypted_size) with a user to own the sessions.
     const dbAtBaseline = () => {
@@ -226,7 +228,7 @@ describe('D1 schema', () => {
         )
         .run(id, `att-${id}`, totalSize)
 
-    it('backfills encrypted_size to total_size for rows written before the column existed', () => {
+    it('leaves encrypted_size NULL on rows written before the column existed', () => {
       // #given a database at 0001 with in-flight sessions the old server reserved plaintext for
       const db = dbAtBaseline()
       insertLegacySession(db, 's1', 5_000)
@@ -235,31 +237,41 @@ describe('D1 schema', () => {
       // #when 0002 is applied
       db.exec(loadMigrationSql('0002_upload_sessions_encrypted_size.sql'))
 
-      // #then every legacy row carries the plaintext size it actually reserved
+      // #then the legacy rows keep NULL, so the refunds fall back to the plaintext they
+      // reserved AND the wire-byte checks still derive the ciphertext total
       const rows = db
         .prepare('SELECT id, total_size, encrypted_size FROM upload_sessions ORDER BY id')
         .all() as Array<{ id: string; total_size: number; encrypted_size: number | null }>
 
       expect(rows).toEqual([
-        { id: 's1', total_size: 5_000, encrypted_size: 5_000 },
-        { id: 's2', total_size: 500_000, encrypted_size: 500_000 }
+        { id: 's1', total_size: 5_000, encrypted_size: null },
+        { id: 's2', total_size: 500_000, encrypted_size: null }
       ])
     })
 
-    it('leaves no NULL encrypted_size rows behind', () => {
-      // #given
+    // Backfilling encrypted_size is the tempting "fix" for the legacy refund and it
+    // silently breaks every in-flight upload. No other test can catch that: the unit
+    // suites hand-build session rows and never apply the SQL, so this is the only
+    // place the migration meets the code that reads it.
+    it('leaves legacy rows deriving the ciphertext total the old client still sends', () => {
+      // #given a legacy 3-chunk session the old server reserved 5,000 plaintext bytes for
       const db = dbAtBaseline()
       insertLegacySession(db, 's1', 5_000)
 
-      // #when
+      // #when 0002 is applied and the server reads the row back
       db.exec(loadMigrationSql('0002_upload_sessions_encrypted_size.sql'))
+      const row = db
+        .prepare('SELECT total_size, chunk_count, encrypted_size FROM upload_sessions WHERE id = ?')
+        .get('s1') as { total_size: number; chunk_count: number; encrypted_size: number | null }
 
-      // #then
-      const { nulls } = db
-        .prepare('SELECT COUNT(*) AS nulls FROM upload_sessions WHERE encrypted_size IS NULL')
-        .get() as { nulls: number }
+      // #then the chunk cap and `complete` expect CIPHERTEXT — the old client still puts
+      // nonce||tag on the wire — which only holds while the column is NULL
+      expect(expectedEncryptedTotal(row.total_size, row.chunk_count, row.encrypted_size)).toBe(
+        5_000 + CHUNK_CRYPTO_OVERHEAD * 3
+      )
 
-      expect(nulls).toBe(0)
+      // #and the refund still pays back only the PLAINTEXT that was actually reserved
+      expect(row.encrypted_size ?? row.total_size).toBe(5_000)
     })
   })
 })

--- a/apps/sync-server/src/__mocks__/blob-route-harness.ts
+++ b/apps/sync-server/src/__mocks__/blob-route-harness.ts
@@ -1,0 +1,123 @@
+import { Hono } from 'hono'
+import { vi } from 'vitest'
+
+import { errorHandler } from '../lib/errors'
+import { blob } from '../routes/blob'
+import type { AppContext } from '../types'
+
+/**
+ * Shared harness for the blob route suites.
+ *
+ * The `vi.mock` calls must stay in each test file (they are hoisted and scoped
+ * per file), but the D1/R2/session fakes below do not need duplicating — a
+ * single `first()` router means a new query in blob.ts is taught to the fakes
+ * once instead of drifting between two hand-maintained copies.
+ */
+
+export interface MockDbState {
+  session?: Record<string, unknown> | null
+  /** Row for chunk metadata reads (ref_count / size_bytes / r2_key lookups). */
+  chunk?: Record<string, unknown> | null
+  /** Row for the dedupe lookup performed on chunk upload. */
+  existingChunk?: Record<string, unknown> | null
+  /**
+   * Row for the entitlements lookup. Suites that mock ../services/entitlements
+   * never reach this; the accounting suite drives the real plan limits and
+   * supplies a row here.
+   */
+  entitlementRow?: () => Record<string, unknown> | null
+  statements: Array<{ sql: string; bindings: unknown[] }>
+}
+
+const createStatement = (sql: string, state: MockDbState) => {
+  const stmt = {
+    bindings: [] as unknown[],
+    bind: vi.fn((...args: unknown[]) => {
+      stmt.bindings = args
+      state.statements.push({ sql, bindings: args })
+      return stmt
+    }),
+    first: vi.fn(async () => {
+      if (sql.includes('FROM users u')) return state.entitlementRow?.() ?? null
+      if (sql.includes('FROM upload_sessions')) return state.session ?? null
+      if (sql.includes('FROM blob_chunks') && sql.includes('hash = ?')) {
+        if (sql.includes('SELECT id, r2_key')) return state.existingChunk ?? null
+        return state.chunk ?? null
+      }
+      return null
+    }),
+    run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } })
+  }
+  return stmt
+}
+
+export const createDb = (state: MockDbState) =>
+  ({
+    prepare: vi.fn((sql: string) => createStatement(sql, state))
+  }) as unknown as D1Database
+
+export const createR2Object = (overrides: Record<string, unknown> = {}) => ({
+  size: 5,
+  body: new ReadableStream(),
+  range: { offset: 1, length: 3 },
+  writeHttpMetadata: vi.fn(),
+  text: vi.fn().mockResolvedValue(JSON.stringify({ chunks: ['a'] })),
+  ...overrides
+})
+
+const storageObject = createR2Object()
+
+export const createStorage = () =>
+  ({
+    get: vi.fn().mockResolvedValue(storageObject),
+    head: vi.fn().mockResolvedValue({ size: 5 }),
+    put: vi.fn(),
+    delete: vi.fn()
+  }) as unknown as R2Bucket
+
+export const createEnv = (state: MockDbState) => ({
+  DB: createDb(state),
+  STORAGE: createStorage(),
+  USER_SYNC_STATE: {} as DurableObjectNamespace,
+  LINKING_SESSION: {} as DurableObjectNamespace,
+  ENVIRONMENT: 'development',
+  JWT_PUBLIC_KEY: 'pk',
+  JWT_PRIVATE_KEY: 'sk',
+  RESEND_API_KEY: 'resend',
+  GOOGLE_CLIENT_ID: 'google-client',
+  // `test-` prefixed so the staged-secret scanner reads it as a placeholder: it
+  // exempts *.test.ts, and this harness is not one.
+  GOOGLE_CLIENT_SECRET: 'test-google-secret',
+  GOOGLE_REDIRECT_URI: 'http://localhost/callback',
+  RECOVERY_DUMMY_SECRET: 'dummy'
+})
+
+export const createApp = () => {
+  const app = new Hono<AppContext>()
+  app.onError(errorHandler)
+  app.route('', blob)
+  return app
+}
+
+/**
+ * A fresh single-chunk session row as the server would have written it: 1024
+ * plaintext bytes, nothing uploaded yet, `encrypted_size` unset (the derive
+ * path taken by clients installed before that column existed).
+ */
+export const createSession = (overrides: Record<string, unknown> = {}) => ({
+  id: 'session-1',
+  user_id: 'user-1',
+  vault_id: 'vault-1',
+  attachment_id: 'att-1',
+  filename: 'file.bin',
+  total_size: 1024,
+  chunk_count: 1,
+  encrypted_size: null,
+  uploaded_chunks: '[]',
+  expires_at: Math.floor(Date.now() / 1000) + 100,
+  created_at: 1,
+  ...overrides
+})
+
+export const findBinding = (state: MockDbState, sqlFragment: string) =>
+  state.statements.find((s) => s.sql.includes(sqlFragment))

--- a/apps/sync-server/src/routes/blob-upload-size-accounting.test.ts
+++ b/apps/sync-server/src/routes/blob-upload-size-accounting.test.ts
@@ -1,0 +1,402 @@
+import { Hono } from 'hono'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { ErrorCodes, errorHandler } from '../lib/errors'
+import { SYNC_PLAN_LIMITS, type SyncPlan } from '../services/entitlements'
+import { XCHACHA20_PARAMS } from '@memry/contracts/crypto'
+import type { AppContext } from '../types'
+
+vi.mock('../services/blob', () => ({
+  generateAttachmentChunkKey: (userId: string, vaultId: string, chunkHash: string) =>
+    `${userId}/vaults/${vaultId}/chunks/${chunkHash}`,
+  generateAttachmentManifestKey: (userId: string, attachmentId: string, vaultId: string) =>
+    `${userId}/vaults/${vaultId}/attachments/${attachmentId}/manifest`,
+  generateBlobKey: (userId: string, itemId: string, vaultId: string) =>
+    `${userId}/vaults/${vaultId}/items/${itemId}`,
+  putBlob: vi.fn().mockResolvedValue({ etag: 'etag-1' }),
+  getBlob: vi.fn(),
+  deleteBlob: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../services/quota', () => ({
+  adjustStorageUsed: vi.fn().mockResolvedValue(undefined),
+  checkQuota: vi.fn().mockResolvedValue(undefined),
+  reserveStorage: vi.fn().mockResolvedValue(undefined)
+}))
+
+// NOTE: ../services/entitlements is deliberately NOT mocked. These tests drive the
+// real plan limits so that "5 MiB on plus" means the real 5 MiB constant.
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn().mockImplementation(async (c: any, next: any) => {
+    c.set('userId', 'user-1')
+    c.set('deviceId', 'device-1')
+    c.set('vaultId', 'vault-1')
+    await next()
+  })
+}))
+
+vi.mock('../middleware/paid-sync', () => ({
+  paidSyncMiddleware: vi.fn().mockImplementation(async (_c: any, next: any) => {
+    await next()
+  })
+}))
+
+vi.mock('../middleware/rate-limit', () => ({
+  createRateLimiter: vi.fn().mockReturnValue(
+    vi.fn().mockImplementation(async (_c: any, next: any) => {
+      await next()
+    })
+  )
+}))
+
+import { blob } from './blob'
+import { adjustStorageUsed, reserveStorage } from '../services/quota'
+
+// The client encrypts every chunk as nonce(24) || XChaCha20-Poly1305 ciphertext
+// (plaintext + 16-byte tag). See apps/desktop/src/main/sync/attachments.ts.
+const CHUNK_CRYPTO_OVERHEAD = XCHACHA20_PARAMS.NONCE_LENGTH + XCHACHA20_PARAMS.TAG_LENGTH
+const MIB = 1024 * 1024
+
+interface MockDbState {
+  plan: SyncPlan
+  session?: Record<string, unknown> | null
+  existingChunk?: Record<string, unknown> | null
+  statements: Array<{ sql: string; bindings: unknown[] }>
+}
+
+const entitlementRow = (plan: SyncPlan) => {
+  const limits = SYNC_PLAN_LIMITS[plan]
+  return {
+    user_id: 'user-1',
+    storage_used: 0,
+    plan,
+    status: plan === 'free' ? 'inactive' : 'active',
+    source: plan === 'free' ? 'none' : 'paddle',
+    storage_limit: limits.storageLimit,
+    max_file_size: limits.maxFileSize,
+    max_vaults: limits.maxVaults,
+    version_history_days: limits.versionHistoryDays,
+    paddle_customer_id: null,
+    paddle_subscription_id: null,
+    paddle_transaction_id: null,
+    expires_at: null
+  }
+}
+
+const createStatement = (sql: string, state: MockDbState) => {
+  const stmt = {
+    bind: vi.fn((...args: unknown[]) => {
+      state.statements.push({ sql, bindings: args })
+      return stmt
+    }),
+    first: vi.fn(async () => {
+      if (sql.includes('FROM users u')) return entitlementRow(state.plan)
+      if (sql.includes('FROM upload_sessions')) return state.session ?? null
+      if (sql.includes('FROM blob_chunks')) return state.existingChunk ?? null
+      return null
+    }),
+    run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } })
+  }
+  return stmt
+}
+
+const createEnv = (state: MockDbState) =>
+  ({
+    DB: { prepare: vi.fn((sql: string) => createStatement(sql, state)) } as unknown as D1Database,
+    STORAGE: {
+      get: vi.fn().mockResolvedValue(null),
+      head: vi.fn().mockResolvedValue(null),
+      put: vi.fn(),
+      delete: vi.fn()
+    } as unknown as R2Bucket,
+    ENVIRONMENT: 'development'
+  }) as any
+
+const createApp = () => {
+  const app = new Hono<AppContext>()
+  app.onError(errorHandler)
+  app.route('', blob)
+  return app
+}
+
+/** A session row as the server would have written it, with encrypted_size support. */
+const createSession = (overrides: Record<string, unknown> = {}) => ({
+  id: 'session-1',
+  user_id: 'user-1',
+  vault_id: 'vault-1',
+  attachment_id: 'att-1',
+  filename: 'file.bin',
+  total_size: 1024,
+  chunk_count: 1,
+  encrypted_size: null,
+  uploaded_chunks: '[]',
+  expires_at: Math.floor(Date.now() / 1000) + 100,
+  created_at: 1,
+  ...overrides
+})
+
+const initiate = (app: ReturnType<typeof createApp>, env: any, body: Record<string, unknown>) =>
+  app.request(
+    '/attachments/upload/initiate',
+    { method: 'POST', body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } },
+    env
+  )
+
+const putChunk = (app: ReturnType<typeof createApp>, env: any, index: number, bytes: number) =>
+  app.request(
+    `/attachments/upload/session-1/chunk/${index}`,
+    { method: 'PUT', body: new Uint8Array(bytes) },
+    env
+  )
+
+const findBinding = (state: MockDbState, sqlFragment: string) =>
+  state.statements.find((s) => s.sql.includes(sqlFragment))
+
+describe('attachment upload size accounting (plaintext limit, encrypted storage)', () => {
+  let app: ReturnType<typeof createApp>
+  let state: MockDbState
+  let env: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(reserveStorage).mockResolvedValue(undefined)
+    vi.mocked(adjustStorageUsed).mockResolvedValue(undefined)
+    app = createApp()
+    state = { plan: 'pro', session: createSession(), existingChunk: null, statements: [] }
+    env = createEnv(state)
+  })
+
+  it('derives 40 bytes of per-chunk overhead from the crypto contract', () => {
+    expect(XCHACHA20_PARAMS.NONCE_LENGTH + XCHACHA20_PARAMS.TAG_LENGTH).toBe(40)
+    expect(CHUNK_CRYPTO_OVERHEAD).toBe(40)
+  })
+
+  // ==========================================================================
+  // The 58-day regression: a single-chunk upload of N plaintext bytes puts
+  // N + 40 bytes on the wire and must be accepted.
+  // ==========================================================================
+
+  it('accepts a single chunk of plaintext+40 bytes against a declared plaintext size', async () => {
+    state.session = createSession({ total_size: 1024, chunk_count: 1, encrypted_size: null })
+
+    const res = await putChunk(app, env, 0, 1024 + CHUNK_CRYPTO_OVERHEAD)
+
+    expect(res.status).toBe(200)
+  })
+
+  it('accepts a 2-chunk upload totalling plaintext+80 bytes', async () => {
+    state.session = createSession({
+      total_size: 2048,
+      chunk_count: 2,
+      encrypted_size: null,
+      uploaded_chunks: JSON.stringify([{ i: 0, h: 'hash-0', b: 1024 + CHUNK_CRYPTO_OVERHEAD }])
+    })
+
+    const res = await putChunk(app, env, 1, 1024 + CHUNK_CRYPTO_OVERHEAD)
+
+    expect(res.status).toBe(200)
+  })
+
+  it('still rejects a chunk that exceeds the derived encrypted total', async () => {
+    state.session = createSession({ total_size: 1024, chunk_count: 1, encrypted_size: null })
+
+    const res = await putChunk(app, env, 0, 1024 + CHUNK_CRYPTO_OVERHEAD + 1)
+
+    expect(res.status).toBe(413)
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      ErrorCodes.STORAGE_FILE_TOO_LARGE
+    )
+  })
+
+  it('honours an explicit encrypted_size on the session over the derived value', async () => {
+    state.session = createSession({ total_size: 1024, chunk_count: 1, encrypted_size: 1064 })
+
+    const res = await putChunk(app, env, 0, 1064)
+
+    expect(res.status).toBe(200)
+  })
+
+  // ==========================================================================
+  // initiate: plan limit on plaintext, storage reservation on ciphertext
+  // ==========================================================================
+
+  it('derives the encrypted size for an old client that sends no encryptedSize', async () => {
+    const res = await initiate(app, env, {
+      attachmentId: 'att-1',
+      filename: 'f.bin',
+      totalSize: 1024,
+      chunkCount: 1
+    })
+
+    expect(res.status).toBe(201)
+    expect(reserveStorage).toHaveBeenCalledWith(env.DB, 'user-1', 1024 + CHUNK_CRYPTO_OVERHEAD)
+
+    const insert = findBinding(state, 'INSERT INTO upload_sessions')
+    expect(insert?.bindings).toContain(1024) // total_size stays plaintext
+    expect(insert?.bindings).toContain(1024 + CHUNK_CRYPTO_OVERHEAD) // encrypted_size persisted
+  })
+
+  it('accepts an explicit encryptedSize from a new client', async () => {
+    const res = await initiate(app, env, {
+      attachmentId: 'att-1',
+      filename: 'f.bin',
+      totalSize: 1024,
+      chunkCount: 1,
+      encryptedSize: 1024 + CHUNK_CRYPTO_OVERHEAD
+    })
+
+    expect(res.status).toBe(201)
+    expect(reserveStorage).toHaveBeenCalledWith(env.DB, 'user-1', 1024 + CHUNK_CRYPTO_OVERHEAD)
+  })
+
+  it('reserves plaintext+80 for a 2-chunk upload', async () => {
+    const res = await initiate(app, env, {
+      attachmentId: 'att-1',
+      filename: 'f.bin',
+      totalSize: 2048,
+      chunkCount: 2
+    })
+
+    expect(res.status).toBe(201)
+    expect(reserveStorage).toHaveBeenCalledWith(env.DB, 'user-1', 2048 + CHUNK_CRYPTO_OVERHEAD * 2)
+  })
+
+  it('lets a plus user upload a file of exactly the 5 MiB plaintext limit', async () => {
+    state.plan = 'plus'
+    expect(SYNC_PLAN_LIMITS.plus.maxFileSize).toBe(5 * MIB)
+
+    const res = await initiate(app, env, {
+      attachmentId: 'att-1',
+      filename: 'f.bin',
+      totalSize: 5 * MIB,
+      chunkCount: 1
+    })
+
+    expect(res.status).toBe(201)
+    // encryption overhead is charged to storage, never to the plan file-size limit
+    expect(reserveStorage).toHaveBeenCalledWith(env.DB, 'user-1', 5 * MIB + CHUNK_CRYPTO_OVERHEAD)
+  })
+
+  it('rejects a plus user one byte over the 5 MiB plaintext limit', async () => {
+    state.plan = 'plus'
+
+    const res = await initiate(app, env, {
+      attachmentId: 'att-1',
+      filename: 'f.bin',
+      totalSize: 5 * MIB + 1,
+      chunkCount: 1
+    })
+
+    expect(res.status).toBe(413)
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      ErrorCodes.STORAGE_FILE_TOO_LARGE
+    )
+    expect(reserveStorage).not.toHaveBeenCalled()
+  })
+
+  it('rejects a free user with 402', async () => {
+    state.plan = 'free'
+
+    const res = await initiate(app, env, {
+      attachmentId: 'att-1',
+      filename: 'f.bin',
+      totalSize: 1024,
+      chunkCount: 1
+    })
+
+    expect(res.status).toBe(402)
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      ErrorCodes.SYNC_PAYMENT_REQUIRED
+    )
+    expect(reserveStorage).not.toHaveBeenCalled()
+  })
+
+  it('rejects an implausible client encryptedSize without inflating quota', async () => {
+    const res = await initiate(app, env, {
+      attachmentId: 'att-1',
+      filename: 'f.bin',
+      totalSize: 1024,
+      chunkCount: 1,
+      encryptedSize: 10240
+    })
+
+    expect(res.status).toBe(400)
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      ErrorCodes.VALIDATION_ERROR
+    )
+    expect(reserveStorage).not.toHaveBeenCalled()
+  })
+
+  it('rejects a client encryptedSize below the plaintext size', async () => {
+    const res = await initiate(app, env, {
+      attachmentId: 'att-1',
+      filename: 'f.bin',
+      totalSize: 1024,
+      chunkCount: 1,
+      encryptedSize: 512
+    })
+
+    expect(res.status).toBe(400)
+    expect(reserveStorage).not.toHaveBeenCalled()
+  })
+
+  // ==========================================================================
+  // complete
+  // ==========================================================================
+
+  it('completes when uploaded bytes match the derived encrypted total', async () => {
+    state.session = createSession({
+      total_size: 1024,
+      chunk_count: 1,
+      encrypted_size: null,
+      uploaded_chunks: JSON.stringify([{ i: 0, h: 'hash-0', b: 1024 + CHUNK_CRYPTO_OVERHEAD }])
+    })
+
+    const res = await app.request(
+      '/attachments/upload/session-1/complete',
+      { method: 'POST', body: JSON.stringify({}), headers: { 'Content-Type': 'application/json' } },
+      env
+    )
+
+    expect(res.status).toBe(200)
+    expect(((await res.json()) as { size: number }).size).toBe(1024)
+  })
+
+  it('rejects complete when uploaded bytes are only the plaintext total', async () => {
+    state.session = createSession({
+      total_size: 1024,
+      chunk_count: 1,
+      encrypted_size: null,
+      uploaded_chunks: JSON.stringify([{ i: 0, h: 'hash-0', b: 1024 }])
+    })
+
+    const res = await app.request(
+      '/attachments/upload/session-1/complete',
+      { method: 'POST', body: JSON.stringify({}), headers: { 'Content-Type': 'application/json' } },
+      env
+    )
+
+    expect(res.status).toBe(400)
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      ErrorCodes.UPLOAD_INCOMPLETE
+    )
+  })
+
+  // ==========================================================================
+  // refunds
+  // ==========================================================================
+
+  it('refunds the encrypted total when a session is cancelled', async () => {
+    state.session = createSession({ total_size: 1024, chunk_count: 1, encrypted_size: null })
+
+    const res = await app.request('/attachments/upload/session-1', { method: 'DELETE' }, env)
+
+    expect(res.status).toBe(204)
+    expect(adjustStorageUsed).toHaveBeenCalledWith(
+      env.DB,
+      'user-1',
+      -(1024 + CHUNK_CRYPTO_OVERHEAD)
+    )
+  })
+})

--- a/apps/sync-server/src/routes/blob-upload-size-accounting.test.ts
+++ b/apps/sync-server/src/routes/blob-upload-size-accounting.test.ts
@@ -1,10 +1,7 @@
-import { Hono } from 'hono'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { ErrorCodes, errorHandler } from '../lib/errors'
+import { ErrorCodes } from '../lib/errors'
 import { SYNC_PLAN_LIMITS, type SyncPlan } from '../services/entitlements'
-import { XCHACHA20_PARAMS } from '@memry/contracts/crypto'
-import type { AppContext } from '../types'
 
 vi.mock('../services/blob', () => ({
   generateAttachmentChunkKey: (userId: string, vaultId: string, chunkHash: string) =>
@@ -50,19 +47,26 @@ vi.mock('../middleware/rate-limit', () => ({
   )
 }))
 
-import { blob } from './blob'
+import {
+  createApp,
+  createEnv,
+  createSession,
+  findBinding,
+  type MockDbState
+} from '../__mocks__/blob-route-harness'
 import { adjustStorageUsed, reserveStorage } from '../services/quota'
+import { CHUNK_CRYPTO_OVERHEAD, MAX_CHUNK_CRYPTO_OVERHEAD } from '../services/upload-size'
 
-// The client encrypts every chunk as nonce(24) || XChaCha20-Poly1305 ciphertext
-// (plaintext + 16-byte tag). See apps/desktop/src/main/sync/attachments.ts.
-const CHUNK_CRYPTO_OVERHEAD = XCHACHA20_PARAMS.NONCE_LENGTH + XCHACHA20_PARAMS.TAG_LENGTH
 const MIB = 1024 * 1024
 
-interface MockDbState {
+// A client-declared encrypted size that is plausible (inside the accepted band
+// [totalSize, totalSize + MAX_CHUNK_CRYPTO_OVERHEAD * chunkCount]) but is NOT the
+// value the server would derive. Tests using the derived overhead cannot tell the
+// explicit branch from the derive path, because both produce the same number.
+const DECLARED_OVERHEAD = 56
+
+interface AccountingState extends MockDbState {
   plan: SyncPlan
-  session?: Record<string, unknown> | null
-  existingChunk?: Record<string, unknown> | null
-  statements: Array<{ sql: string; bindings: unknown[] }>
 }
 
 const entitlementRow = (plan: SyncPlan) => {
@@ -84,58 +88,6 @@ const entitlementRow = (plan: SyncPlan) => {
   }
 }
 
-const createStatement = (sql: string, state: MockDbState) => {
-  const stmt = {
-    bind: vi.fn((...args: unknown[]) => {
-      state.statements.push({ sql, bindings: args })
-      return stmt
-    }),
-    first: vi.fn(async () => {
-      if (sql.includes('FROM users u')) return entitlementRow(state.plan)
-      if (sql.includes('FROM upload_sessions')) return state.session ?? null
-      if (sql.includes('FROM blob_chunks')) return state.existingChunk ?? null
-      return null
-    }),
-    run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } })
-  }
-  return stmt
-}
-
-const createEnv = (state: MockDbState) =>
-  ({
-    DB: { prepare: vi.fn((sql: string) => createStatement(sql, state)) } as unknown as D1Database,
-    STORAGE: {
-      get: vi.fn().mockResolvedValue(null),
-      head: vi.fn().mockResolvedValue(null),
-      put: vi.fn(),
-      delete: vi.fn()
-    } as unknown as R2Bucket,
-    ENVIRONMENT: 'development'
-  }) as any
-
-const createApp = () => {
-  const app = new Hono<AppContext>()
-  app.onError(errorHandler)
-  app.route('', blob)
-  return app
-}
-
-/** A session row as the server would have written it, with encrypted_size support. */
-const createSession = (overrides: Record<string, unknown> = {}) => ({
-  id: 'session-1',
-  user_id: 'user-1',
-  vault_id: 'vault-1',
-  attachment_id: 'att-1',
-  filename: 'file.bin',
-  total_size: 1024,
-  chunk_count: 1,
-  encrypted_size: null,
-  uploaded_chunks: '[]',
-  expires_at: Math.floor(Date.now() / 1000) + 100,
-  created_at: 1,
-  ...overrides
-})
-
 const initiate = (app: ReturnType<typeof createApp>, env: any, body: Record<string, unknown>) =>
   app.request(
     '/attachments/upload/initiate',
@@ -150,12 +102,9 @@ const putChunk = (app: ReturnType<typeof createApp>, env: any, index: number, by
     env
   )
 
-const findBinding = (state: MockDbState, sqlFragment: string) =>
-  state.statements.find((s) => s.sql.includes(sqlFragment))
-
 describe('attachment upload size accounting (plaintext limit, encrypted storage)', () => {
   let app: ReturnType<typeof createApp>
-  let state: MockDbState
+  let state: AccountingState
   let env: any
 
   beforeEach(() => {
@@ -164,12 +113,15 @@ describe('attachment upload size accounting (plaintext limit, encrypted storage)
     vi.mocked(adjustStorageUsed).mockResolvedValue(undefined)
     app = createApp()
     state = { plan: 'pro', session: createSession(), existingChunk: null, statements: [] }
+    state.entitlementRow = () => entitlementRow(state.plan)
     env = createEnv(state)
   })
 
+  // The one place that holds the literal: a crypto-param change must land here.
   it('derives 40 bytes of per-chunk overhead from the crypto contract', () => {
-    expect(XCHACHA20_PARAMS.NONCE_LENGTH + XCHACHA20_PARAMS.TAG_LENGTH).toBe(40)
     expect(CHUNK_CRYPTO_OVERHEAD).toBe(40)
+    expect(DECLARED_OVERHEAD).toBeGreaterThan(CHUNK_CRYPTO_OVERHEAD)
+    expect(DECLARED_OVERHEAD).toBeLessThanOrEqual(MAX_CHUNK_CRYPTO_OVERHEAD)
   })
 
   // ==========================================================================
@@ -210,11 +162,24 @@ describe('attachment upload size accounting (plaintext limit, encrypted storage)
   })
 
   it('honours an explicit encrypted_size on the session over the derived value', async () => {
-    state.session = createSession({ total_size: 1024, chunk_count: 1, encrypted_size: 1064 })
+    // 1024 + 56 = 1080, where the server would derive 1024 + 40 = 1064. A chunk of
+    // 1080 bytes only fits if the session's own encrypted_size wins.
+    const declared = 1024 + DECLARED_OVERHEAD
+    state.session = createSession({ total_size: 1024, chunk_count: 1, encrypted_size: declared })
 
-    const res = await putChunk(app, env, 0, 1064)
+    const res = await putChunk(app, env, 0, declared)
 
     expect(res.status).toBe(200)
+  })
+
+  it('rejects a chunk over an explicit encrypted_size that is below the derived value', async () => {
+    // The explicit branch must also be able to make the budget SMALLER than the
+    // derived one, not just larger.
+    state.session = createSession({ total_size: 1024, chunk_count: 1, encrypted_size: 1024 })
+
+    const res = await putChunk(app, env, 0, 1024 + CHUNK_CRYPTO_OVERHEAD)
+
+    expect(res.status).toBe(413)
   })
 
   // ==========================================================================
@@ -232,22 +197,43 @@ describe('attachment upload size accounting (plaintext limit, encrypted storage)
     expect(res.status).toBe(201)
     expect(reserveStorage).toHaveBeenCalledWith(env.DB, 'user-1', 1024 + CHUNK_CRYPTO_OVERHEAD)
 
+    // Asserted by position, not by membership: total_size and encrypted_size are
+    // both numbers in the same bind list, so `toContain` cannot tell them apart —
+    // swapping them would store ciphertext as plaintext and still pass.
     const insert = findBinding(state, 'INSERT INTO upload_sessions')
-    expect(insert?.bindings).toContain(1024) // total_size stays plaintext
-    expect(insert?.bindings).toContain(1024 + CHUNK_CRYPTO_OVERHEAD) // encrypted_size persisted
+    expect(insert?.bindings).toEqual([
+      expect.any(String), // id
+      'user-1', // user_id
+      'vault-1', // vault_id
+      'att-1', // attachment_id
+      'f.bin', // filename
+      1024, // total_size stays plaintext
+      1, // chunk_count
+      1024 + CHUNK_CRYPTO_OVERHEAD, // encrypted_size persisted
+      expect.any(Number), // expires_at
+      expect.any(Number) // created_at
+    ])
   })
 
   it('accepts an explicit encryptedSize from a new client', async () => {
+    // Distinct from the derived 1024 + 40, so the assertion below can only hold if
+    // the client's number is the one that reaches quota and storage.
+    const declared = 1024 + DECLARED_OVERHEAD
+
     const res = await initiate(app, env, {
       attachmentId: 'att-1',
       filename: 'f.bin',
       totalSize: 1024,
       chunkCount: 1,
-      encryptedSize: 1024 + CHUNK_CRYPTO_OVERHEAD
+      encryptedSize: declared
     })
 
     expect(res.status).toBe(201)
-    expect(reserveStorage).toHaveBeenCalledWith(env.DB, 'user-1', 1024 + CHUNK_CRYPTO_OVERHEAD)
+    expect(reserveStorage).toHaveBeenCalledWith(env.DB, 'user-1', declared)
+
+    const insert = findBinding(state, 'INSERT INTO upload_sessions')
+    expect(insert?.bindings[5]).toBe(1024) // total_size stays plaintext
+    expect(insert?.bindings[7]).toBe(declared) // encrypted_size is the client's value
   })
 
   it('reserves plaintext+80 for a 2-chunk upload', async () => {
@@ -387,8 +373,12 @@ describe('attachment upload size accounting (plaintext limit, encrypted storage)
   // refunds
   // ==========================================================================
 
-  it('refunds the encrypted total when a session is cancelled', async () => {
-    state.session = createSession({ total_size: 1024, chunk_count: 1, encrypted_size: null })
+  it('refunds the reserved encrypted_size when a session is cancelled', async () => {
+    state.session = createSession({
+      total_size: 1024,
+      chunk_count: 1,
+      encrypted_size: 1024 + CHUNK_CRYPTO_OVERHEAD
+    })
 
     const res = await app.request('/attachments/upload/session-1', { method: 'DELETE' }, env)
 
@@ -398,5 +388,27 @@ describe('attachment upload size accounting (plaintext limit, encrypted storage)
       'user-1',
       -(1024 + CHUNK_CRYPTO_OVERHEAD)
     )
+  })
+
+  // A session written by the OLD server reserved the PLAINTEXT total_size and left
+  // encrypted_size NULL. Deriving the ciphertext total here refunds bytes that were
+  // never reserved, permanently drifting users.storage_used down (adjustStorageUsed
+  // clamps at 0, so the drift has no reconciliation path).
+  it('refunds only the plaintext for a legacy session with no encrypted_size', async () => {
+    state.session = createSession({ total_size: 1024, chunk_count: 1, encrypted_size: null })
+
+    const res = await app.request('/attachments/upload/session-1', { method: 'DELETE' }, env)
+
+    expect(res.status).toBe(204)
+    expect(adjustStorageUsed).toHaveBeenCalledWith(env.DB, 'user-1', -1024)
+  })
+
+  it('refunds only the plaintext for a legacy multi-chunk session', async () => {
+    state.session = createSession({ total_size: 500_000, chunk_count: 63, encrypted_size: null })
+
+    const res = await app.request('/attachments/upload/session-1', { method: 'DELETE' }, env)
+
+    expect(res.status).toBe(204)
+    expect(adjustStorageUsed).toHaveBeenCalledWith(env.DB, 'user-1', -500_000)
   })
 })

--- a/apps/sync-server/src/routes/blob.test.ts
+++ b/apps/sync-server/src/routes/blob.test.ts
@@ -115,6 +115,10 @@ const createApp = () => {
   return app
 }
 
+// Chunks go on the wire encrypted: nonce(24) + ciphertext(plaintext + 16-byte tag).
+// Fixtures must honour that — a 5-byte plaintext chunk uploads as 45 bytes.
+const CHUNK_CRYPTO_OVERHEAD = 40
+
 const createSession = (overrides: Record<string, unknown> = {}) => ({
   id: 'session-1',
   user_id: 'user-1',
@@ -122,14 +126,18 @@ const createSession = (overrides: Record<string, unknown> = {}) => ({
   filename: 'file.bin',
   total_size: 10,
   chunk_count: 2,
+  encrypted_size: null,
   uploaded_chunks: JSON.stringify([
-    { i: 0, h: 'hash-0', b: 5 },
-    { i: 1, h: 'hash-1', b: 5 }
+    { i: 0, h: 'hash-0', b: 5 + CHUNK_CRYPTO_OVERHEAD },
+    { i: 1, h: 'hash-1', b: 5 + CHUNK_CRYPTO_OVERHEAD }
   ]),
   expires_at: Math.floor(Date.now() / 1000) + 100,
   created_at: 1,
   ...overrides
 })
+
+// 10 plaintext bytes across 2 chunks => 10 + 40*2 bytes stored.
+const UPLOAD_INIT_ENCRYPTED_SIZE = 10 + CHUNK_CRYPTO_OVERHEAD * 2
 
 const createEnv = (state: MockDbState) => ({
   DB: createDb(state),
@@ -306,7 +314,8 @@ describe('blob routes', () => {
       sessionId: expect.any(String),
       expiresAt: expect.any(Number)
     })
-    expect(reserveStorage).toHaveBeenCalledWith(env.DB, 'user-1', 10)
+    // storage is reserved on ciphertext, the plan limit is checked on plaintext
+    expect(reserveStorage).toHaveBeenCalledWith(env.DB, 'user-1', UPLOAD_INIT_ENCRYPTED_SIZE)
     expect(assertFileSizeAllowed).toHaveBeenCalledWith(env.DB, 'user-1', 10)
     expect(
       state.statements.some(
@@ -368,16 +377,17 @@ describe('blob routes', () => {
   })
 
   it('rejects a chunk that would exceed the declared upload size', async () => {
+    // 10 plaintext bytes over 2 chunks => 90 bytes allowed. 45 already up, 50 more overruns.
     state.session = createSession({
       total_size: 10,
-      uploaded_chunks: JSON.stringify([{ i: 0, h: 'hash-0', b: 8 }])
+      uploaded_chunks: JSON.stringify([{ i: 0, h: 'hash-0', b: 5 + CHUNK_CRYPTO_OVERHEAD }])
     })
 
     const res = await app.request(
       '/attachments/upload/session-1/chunk/1',
       {
         method: 'PUT',
-        body: 'abc'
+        body: new Uint8Array(50)
       },
       env
     )
@@ -568,7 +578,7 @@ describe('blob routes', () => {
       'user-1/vaults/vault-1/chunks/hash-0',
       'user-1'
     )
-    expect(adjustStorageUsed).toHaveBeenCalledWith(env.DB, 'user-1', -10)
+    expect(adjustStorageUsed).toHaveBeenCalledWith(env.DB, 'user-1', -UPLOAD_INIT_ENCRYPTED_SIZE)
     expect(
       state.statements.some((entry) => entry.sql.includes('DELETE FROM upload_sessions'))
     ).toBe(true)
@@ -585,7 +595,7 @@ describe('blob routes', () => {
 
     expect(res.status).toBe(204)
     expect(deleteBlob).not.toHaveBeenCalled()
-    expect(adjustStorageUsed).toHaveBeenCalledWith(env.DB, 'user-1', -10)
+    expect(adjustStorageUsed).toHaveBeenCalledWith(env.DB, 'user-1', -UPLOAD_INIT_ENCRYPTED_SIZE)
     expect(state.statements.some((entry) => entry.sql.includes('ref_count = ref_count - 1'))).toBe(
       true
     )

--- a/apps/sync-server/src/routes/blob.test.ts
+++ b/apps/sync-server/src/routes/blob.test.ts
@@ -1,8 +1,6 @@
-import { Hono } from 'hono'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { ErrorCodes, errorHandler } from '../lib/errors'
-import type { AppContext } from '../types'
+import { ErrorCodes } from '../lib/errors'
 
 vi.mock('../services/blob', () => ({
   generateAttachmentChunkKey: (userId: string, vaultId: string, chunkHash: string) =>
@@ -49,110 +47,36 @@ vi.mock('../middleware/rate-limit', () => ({
   )
 }))
 
-import { blob } from './blob'
+import {
+  createApp,
+  createEnv,
+  createR2Object,
+  createSession as baseSession,
+  type MockDbState
+} from '../__mocks__/blob-route-harness'
 import { putBlob, getBlob, deleteBlob } from '../services/blob'
 import { assertFileSizeAllowed } from '../services/entitlements'
 import { adjustStorageUsed, reserveStorage } from '../services/quota'
-
-interface MockDbState {
-  session?: Record<string, unknown> | null
-  chunk?: Record<string, unknown> | null
-  existingChunk?: Record<string, unknown> | null
-  statements: Array<{ sql: string; bindings: unknown[] }>
-}
-
-const createStatement = (sql: string, state: MockDbState) => {
-  const stmt = {
-    bindings: [] as unknown[],
-    bind: vi.fn((...args: unknown[]) => {
-      stmt.bindings = args
-      state.statements.push({ sql, bindings: args })
-      return stmt
-    }),
-    first: vi.fn(async () => {
-      if (sql.includes('FROM upload_sessions')) return state.session ?? null
-      if (sql.includes('FROM blob_chunks') && sql.includes('hash = ?')) {
-        if (sql.includes('SELECT id, r2_key')) return state.existingChunk ?? null
-        if (sql.includes('r2_key') || sql.includes('size_bytes') || sql.includes('ref_count')) {
-          return state.chunk ?? null
-        }
-      }
-      return null
-    }),
-    run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } })
-  }
-  return stmt
-}
-
-const createDb = (state: MockDbState) =>
-  ({
-    prepare: vi.fn((sql: string) => createStatement(sql, state))
-  }) as unknown as D1Database
-
-const createR2Object = (overrides: Record<string, unknown> = {}) => ({
-  size: 5,
-  body: new ReadableStream(),
-  range: { offset: 1, length: 3 },
-  writeHttpMetadata: vi.fn(),
-  text: vi.fn().mockResolvedValue(JSON.stringify({ chunks: ['a'] })),
-  ...overrides
-})
-
-const storageObject = createR2Object()
-
-const createStorage = () =>
-  ({
-    get: vi.fn().mockResolvedValue(storageObject),
-    head: vi.fn().mockResolvedValue({ size: 5 }),
-    put: vi.fn(),
-    delete: vi.fn()
-  }) as unknown as R2Bucket
-
-const createApp = () => {
-  const app = new Hono<AppContext>()
-  app.onError(errorHandler)
-  app.route('', blob)
-  return app
-}
-
-// Chunks go on the wire encrypted: nonce(24) + ciphertext(plaintext + 16-byte tag).
-// Fixtures must honour that — a 5-byte plaintext chunk uploads as 45 bytes.
-const CHUNK_CRYPTO_OVERHEAD = 40
-
-const createSession = (overrides: Record<string, unknown> = {}) => ({
-  id: 'session-1',
-  user_id: 'user-1',
-  attachment_id: 'att-1',
-  filename: 'file.bin',
-  total_size: 10,
-  chunk_count: 2,
-  encrypted_size: null,
-  uploaded_chunks: JSON.stringify([
-    { i: 0, h: 'hash-0', b: 5 + CHUNK_CRYPTO_OVERHEAD },
-    { i: 1, h: 'hash-1', b: 5 + CHUNK_CRYPTO_OVERHEAD }
-  ]),
-  expires_at: Math.floor(Date.now() / 1000) + 100,
-  created_at: 1,
-  ...overrides
-})
+import { CHUNK_CRYPTO_OVERHEAD } from '../services/upload-size'
 
 // 10 plaintext bytes across 2 chunks => 10 + 40*2 bytes stored.
 const UPLOAD_INIT_ENCRYPTED_SIZE = 10 + CHUNK_CRYPTO_OVERHEAD * 2
 
-const createEnv = (state: MockDbState) => ({
-  DB: createDb(state),
-  STORAGE: createStorage(),
-  USER_SYNC_STATE: {} as DurableObjectNamespace,
-  LINKING_SESSION: {} as DurableObjectNamespace,
-  ENVIRONMENT: 'development',
-  JWT_PUBLIC_KEY: 'pk',
-  JWT_PRIVATE_KEY: 'sk',
-  RESEND_API_KEY: 'resend',
-  GOOGLE_CLIENT_ID: 'google-client',
-  GOOGLE_CLIENT_SECRET: 'google-secret',
-  GOOGLE_REDIRECT_URI: 'http://localhost/callback',
-  RECOVERY_DUMMY_SECRET: 'dummy'
-})
+// A fully-uploaded 2-chunk session as the current server writes it. Chunks go on
+// the wire encrypted: nonce(24) + ciphertext(plaintext + 16-byte tag) — fixtures
+// must honour that, so a 5-byte plaintext chunk uploads as 45 bytes, and
+// encrypted_size records what initiate reserved.
+const createSession = (overrides: Record<string, unknown> = {}) =>
+  baseSession({
+    total_size: 10,
+    chunk_count: 2,
+    encrypted_size: UPLOAD_INIT_ENCRYPTED_SIZE,
+    uploaded_chunks: JSON.stringify([
+      { i: 0, h: 'hash-0', b: 5 + CHUNK_CRYPTO_OVERHEAD },
+      { i: 1, h: 'hash-1', b: 5 + CHUNK_CRYPTO_OVERHEAD }
+    ]),
+    ...overrides
+  })
 
 const uploadInitBody = {
   attachmentId: 'att-1',
@@ -474,12 +398,19 @@ describe('blob routes', () => {
     expect(await res.json()).toEqual({ error: 'Missing chunks', missing_chunks: [1] })
   })
 
-  it('rejects completion when uploaded chunk bytes do not match the declared total size', async () => {
+  it('rejects completion when uploaded chunk bytes are only the plaintext total', async () => {
+    // 200 plaintext bytes over 2 chunks must arrive as 200 + 40*2 = 280 bytes.
+    // These two 100-byte chunks are individually plausible on the wire (a chunk
+    // cannot be under 40 bytes) and sum to exactly the plaintext total — the
+    // shape a client produces when it is NOT counting encryption overhead. It
+    // must be rejected, which is only true if `complete` compares against the
+    // encrypted total rather than session.total_size.
     state.session = createSession({
-      total_size: 10,
+      total_size: 200,
+      encrypted_size: 200 + CHUNK_CRYPTO_OVERHEAD * 2,
       uploaded_chunks: JSON.stringify([
-        { i: 0, h: 'hash-0', b: 4 },
-        { i: 1, h: 'hash-1', b: 4 }
+        { i: 0, h: 'hash-0', b: 100 },
+        { i: 1, h: 'hash-1', b: 100 }
       ])
     })
 

--- a/apps/sync-server/src/routes/blob.ts
+++ b/apps/sync-server/src/routes/blob.ts
@@ -304,12 +304,24 @@ blob.put('/attachments/upload/:session_id/chunk/:chunk_index', chunkUploadLimit,
       .run()
   }
 
-  uploadedChunks.push({ i: chunkIndex, h: chunkHash, b: chunkData.byteLength })
+  // Append atomically in one statement. Clients upload up to MAX_CONCURRENT_CHUNKS
+  // chunks in parallel, so a read-modify-write of the whole array here loses
+  // entries: each request writes back the snapshot it read, and the last writer
+  // wins. The dropped index then fails `complete` with 400 "Missing chunks".
+  // `json_insert(x, '$[#]', ...)` appends without re-sending the array we read.
   await c.env.DB.prepare(
-    'UPDATE upload_sessions SET uploaded_chunks = ? WHERE id = ? AND user_id = ? AND vault_id = ?'
+    `UPDATE upload_sessions
+       SET uploaded_chunks = json_insert(uploaded_chunks, '$[#]', json(?))
+     WHERE id = ? AND user_id = ? AND vault_id = ?`
   )
-    .bind(JSON.stringify(uploadedChunks), sessionId, userId, vaultId)
+    .bind(
+      JSON.stringify({ i: chunkIndex, h: chunkHash, b: chunkData.byteLength }),
+      sessionId,
+      userId,
+      vaultId
+    )
     .run()
+  uploadedChunks.push({ i: chunkIndex, h: chunkHash, b: chunkData.byteLength })
 
   return c.json({
     success: true,

--- a/apps/sync-server/src/routes/blob.ts
+++ b/apps/sync-server/src/routes/blob.ts
@@ -14,6 +14,7 @@ import {
 } from '../services/blob'
 import { assertFileSizeAllowed } from '../services/entitlements'
 import { adjustStorageUsed, reserveStorage } from '../services/quota'
+import { MAX_CHUNK_CRYPTO_OVERHEAD, expectedEncryptedTotal } from '../services/upload-size'
 import { UploadInitRequestSchema } from '@memry/contracts/blob-api'
 import type { AppContext } from '../types'
 
@@ -175,7 +176,7 @@ blob.post('/attachments/upload/initiate', uploadSessionLimit, async (c) => {
     )
   }
 
-  const { attachmentId, filename, totalSize, chunkCount } = parsed.data
+  const { attachmentId, filename, totalSize, chunkCount, encryptedSize } = parsed.data
 
   if (totalSize > MAX_FILE_SIZE) {
     throw new AppError(
@@ -185,8 +186,26 @@ blob.post('/attachments/upload/initiate', uploadSessionLimit, async (c) => {
     )
   }
 
+  // encryptedSize drives storage quota, so never trust it blindly: it must be at
+  // least the plaintext and no larger than the plaintext plus per-chunk overhead.
+  if (
+    encryptedSize !== undefined &&
+    (encryptedSize < totalSize ||
+      encryptedSize > totalSize + MAX_CHUNK_CRYPTO_OVERHEAD * chunkCount)
+  ) {
+    throw new AppError(
+      ErrorCodes.VALIDATION_ERROR,
+      'encryptedSize is not plausible for the declared totalSize and chunkCount',
+      400
+    )
+  }
+
+  // Plan file-size limits apply to the plaintext the user picked; encryption
+  // overhead must not eat into their limit. Storage is reserved on ciphertext.
   await assertFileSizeAllowed(c.env.DB, userId, totalSize)
-  await reserveStorage(c.env.DB, userId, totalSize)
+
+  const expectedEncrypted = expectedEncryptedTotal(totalSize, chunkCount, encryptedSize ?? null)
+  await reserveStorage(c.env.DB, userId, expectedEncrypted)
 
   const now = Math.floor(Date.now() / 1000)
   const sessionId = crypto.randomUUID()
@@ -194,8 +213,8 @@ blob.post('/attachments/upload/initiate', uploadSessionLimit, async (c) => {
 
   try {
     await c.env.DB.prepare(
-      `INSERT INTO upload_sessions (id, user_id, vault_id, attachment_id, filename, total_size, chunk_count, uploaded_chunks, expires_at, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, '[]', ?, ?)`
+      `INSERT INTO upload_sessions (id, user_id, vault_id, attachment_id, filename, total_size, chunk_count, encrypted_size, uploaded_chunks, expires_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, '[]', ?, ?)`
     )
       .bind(
         sessionId,
@@ -205,12 +224,13 @@ blob.post('/attachments/upload/initiate', uploadSessionLimit, async (c) => {
         filename,
         totalSize,
         chunkCount,
+        expectedEncrypted,
         expiresAt,
         now
       )
       .run()
   } catch (error) {
-    await adjustStorageUsed(c.env.DB, userId, -totalSize)
+    await adjustStorageUsed(c.env.DB, userId, -expectedEncrypted)
     throw error
   }
 
@@ -244,7 +264,13 @@ blob.put('/attachments/upload/:session_id/chunk/:chunk_index', chunkUploadLimit,
 
   const chunkData = await c.req.arrayBuffer()
   const uploadedBytes = getUploadedByteTotal(uploadedChunks)
-  if (uploadedBytes === null || uploadedBytes + chunkData.byteLength > session.total_size) {
+  // Chunks arrive encrypted, so compare against the encrypted total, not total_size.
+  const expectedEncrypted = expectedEncryptedTotal(
+    session.total_size,
+    session.chunk_count,
+    session.encrypted_size
+  )
+  if (uploadedBytes === null || uploadedBytes + chunkData.byteLength > expectedEncrypted) {
     throw new AppError(
       ErrorCodes.STORAGE_FILE_TOO_LARGE,
       'Uploaded chunks exceed declared file size',
@@ -314,7 +340,10 @@ blob.post('/attachments/upload/:session_id/complete', chunkUploadLimit, async (c
   }
 
   const actualBytes = getUploadedByteTotal(uploadedEntries)
-  if (actualBytes !== session.total_size) {
+  if (
+    actualBytes !==
+    expectedEncryptedTotal(session.total_size, session.chunk_count, session.encrypted_size)
+  ) {
     throw new AppError(
       ErrorCodes.UPLOAD_INCOMPLETE,
       'Uploaded chunks do not match declared file size',
@@ -323,6 +352,7 @@ blob.post('/attachments/upload/:session_id/complete', chunkUploadLimit, async (c
   }
 
   const body: unknown = await c.req.json()
+  // Plan file-size limit stays on the plaintext size.
   await assertFileSizeAllowed(c.env.DB, userId, session.total_size)
   let manifestKey: string | null = null
   let manifestBytes: Uint8Array | null = null
@@ -422,7 +452,12 @@ blob.delete('/attachments/upload/:session_id', uploadSessionLimit, async (c) => 
     .bind(sessionId, userId, vaultId)
     .run()
   if ((deleteResult.meta.changes ?? 0) > 0) {
-    await adjustStorageUsed(c.env.DB, userId, -session.total_size)
+    // Refund what was reserved at initiate: the encrypted total, not the plaintext.
+    await adjustStorageUsed(
+      c.env.DB,
+      userId,
+      -expectedEncryptedTotal(session.total_size, session.chunk_count, session.encrypted_size)
+    )
   }
 
   return new Response(null, { status: 204 })
@@ -541,6 +576,8 @@ interface UploadSessionRow {
   filename: string
   total_size: number
   chunk_count: number
+  /** NULL for sessions opened before this column existed, or by clients that omit it. */
+  encrypted_size: number | null
   uploaded_chunks: string
   expires_at: number
   created_at: number

--- a/apps/sync-server/src/routes/blob.ts
+++ b/apps/sync-server/src/routes/blob.ts
@@ -464,12 +464,12 @@ blob.delete('/attachments/upload/:session_id', uploadSessionLimit, async (c) => 
     .bind(sessionId, userId, vaultId)
     .run()
   if ((deleteResult.meta.changes ?? 0) > 0) {
-    // Refund what was reserved at initiate: the encrypted total, not the plaintext.
-    await adjustStorageUsed(
-      c.env.DB,
-      userId,
-      -expectedEncryptedTotal(session.total_size, session.chunk_count, session.encrypted_size)
-    )
+    // Refund exactly what initiate reserved — never re-derive it. `encrypted_size`
+    // records the reservation; a NULL means the row was written by the old server,
+    // which reserved the plaintext total_size. Migration 0002 backfills the rows that
+    // existed when it ran, but migrations apply before the Worker deploys, so the old
+    // code can still open NULL rows during the rollout window. Keep the fallback.
+    await adjustStorageUsed(c.env.DB, userId, -(session.encrypted_size ?? session.total_size))
   }
 
   return new Response(null, { status: 204 })

--- a/apps/sync-server/src/services/cleanup.test.ts
+++ b/apps/sync-server/src/services/cleanup.test.ts
@@ -70,7 +70,9 @@ describe('cleanup services', () => {
           user_id: 'user-1',
           vault_id: 'vault-1',
           total_size: 10,
-          uploaded_chunks: JSON.stringify([{ i: 0, h: 'hash-0', b: 10 }]),
+          chunk_count: 1,
+          encrypted_size: null,
+          uploaded_chunks: JSON.stringify([{ i: 0, h: 'hash-0', b: 50 }]),
           r2_upload_id: 'up1',
           r2_key: 'k1'
         },
@@ -79,6 +81,8 @@ describe('cleanup services', () => {
           user_id: 'user-2',
           vault_id: 'vault-2',
           total_size: 20,
+          chunk_count: 2,
+          encrypted_size: null,
           uploaded_chunks: '[]',
           r2_upload_id: '',
           r2_key: ''
@@ -119,7 +123,9 @@ describe('cleanup services', () => {
     // #then
     expect(result).toBe(2)
     expect(db.prepare).toHaveBeenCalledWith(
-      expect.stringContaining('SELECT id, user_id, vault_id, total_size, uploaded_chunks')
+      expect.stringContaining(
+        'SELECT id, user_id, vault_id, total_size, chunk_count, encrypted_size'
+      )
     )
     expect(db.prepare).toHaveBeenCalledWith(
       'SELECT id, ref_count, r2_key FROM blob_chunks WHERE user_id = ? AND vault_id = ? AND hash = ?'
@@ -128,8 +134,9 @@ describe('cleanup services', () => {
     expect(db.prepare).toHaveBeenCalledWith(
       'DELETE FROM upload_sessions WHERE id = ? AND user_id = ? AND vault_id = ?'
     )
-    expect(releaseBind).toHaveBeenCalledWith(-10, expect.any(Number), 'user-1')
-    expect(releaseBind).toHaveBeenCalledWith(-20, expect.any(Number), 'user-2')
+    // refunds the encrypted total that initiate reserved: plaintext + 40 per chunk
+    expect(releaseBind).toHaveBeenCalledWith(-(10 + 40 * 1), expect.any(Number), 'user-1')
+    expect(releaseBind).toHaveBeenCalledWith(-(20 + 40 * 2), expect.any(Number), 'user-2')
     expect(storage.resumeMultipartUpload).toHaveBeenCalledWith('k1', 'up1')
     expect(abortFn).toHaveBeenCalledOnce()
   })

--- a/apps/sync-server/src/services/cleanup.test.ts
+++ b/apps/sync-server/src/services/cleanup.test.ts
@@ -82,7 +82,7 @@ describe('cleanup services', () => {
           vault_id: 'vault-2',
           total_size: 20,
           chunk_count: 2,
-          encrypted_size: null,
+          encrypted_size: 100,
           uploaded_chunks: '[]',
           r2_upload_id: '',
           r2_key: ''
@@ -134,9 +134,12 @@ describe('cleanup services', () => {
     expect(db.prepare).toHaveBeenCalledWith(
       'DELETE FROM upload_sessions WHERE id = ? AND user_id = ? AND vault_id = ?'
     )
-    // refunds the encrypted total that initiate reserved: plaintext + 40 per chunk
-    expect(releaseBind).toHaveBeenCalledWith(-(10 + 40 * 1), expect.any(Number), 'user-1')
-    expect(releaseBind).toHaveBeenCalledWith(-(20 + 40 * 2), expect.any(Number), 'user-2')
+    // s1 is a legacy row (encrypted_size IS NULL): the OLD server reserved the
+    // plaintext total_size, so refunding a derived ciphertext total would hand
+    // back bytes that were never reserved.
+    expect(releaseBind).toHaveBeenCalledWith(-10, expect.any(Number), 'user-1')
+    // s2 was written by the new server: refund exactly what it reserved.
+    expect(releaseBind).toHaveBeenCalledWith(-100, expect.any(Number), 'user-2')
     expect(storage.resumeMultipartUpload).toHaveBeenCalledWith('k1', 'up1')
     expect(abortFn).toHaveBeenCalledOnce()
   })
@@ -149,13 +152,17 @@ describe('cleanup services', () => {
       resumeMultipartUpload: vi.fn().mockReturnValue({ abort: abortFn })
     } as unknown as R2Bucket
 
+    // A legacy session: written by the old server, which reserved the PLAINTEXT
+    // total_size, so encrypted_size is NULL and must not be re-derived on refund.
     const selectAll = vi.fn().mockResolvedValue({
       results: [
         {
           id: 's1',
           user_id: 'user-1',
           vault_id: 'vault-1',
-          total_size: 10,
+          total_size: 5_000,
+          chunk_count: 3,
+          encrypted_size: null,
           uploaded_chunks: '[]',
           r2_upload_id: 'up1',
           r2_key: 'k1'
@@ -164,23 +171,28 @@ describe('cleanup services', () => {
     })
     const selectBind = vi.fn().mockReturnValue({ all: selectAll })
 
-    const deleteRun = vi.fn().mockResolvedValue({ meta: {} })
+    const deleteRun = vi.fn().mockResolvedValue({ meta: { changes: 1 } })
     const deleteBind = vi.fn().mockReturnValue({ run: deleteRun })
+    const releaseRun = vi.fn().mockResolvedValue({ meta: { changes: 1 } })
+    const releaseBind = vi.fn().mockReturnValue({ run: releaseRun })
 
     const db = {
       prepare: vi
         .fn()
         .mockReturnValueOnce({ bind: selectBind })
         .mockReturnValueOnce({ bind: deleteBind })
+        .mockReturnValueOnce({ bind: releaseBind })
     } as unknown as D1Database
 
     // #when
     const result = await cleanupExpiredUploadSessions(db, storage)
 
     // #then
-    expect(result).toBe(0)
+    expect(result).toBe(1)
     expect(abortFn).toHaveBeenCalledOnce()
     expect(deleteRun).toHaveBeenCalledOnce()
+    // refunds what was reserved (plaintext), not total_size + 40 * chunk_count
+    expect(releaseBind).toHaveBeenCalledWith(-5_000, expect.any(Number), 'user-1')
   })
 
   it('cleans up expired Google Calendar push channels', async () => {

--- a/apps/sync-server/src/services/cleanup.ts
+++ b/apps/sync-server/src/services/cleanup.ts
@@ -1,4 +1,5 @@
 import { adjustStorageUsed } from './quota'
+import { expectedEncryptedTotal } from './upload-size'
 
 export const cleanupExpiredOtpCodes = async (db: D1Database): Promise<number> => {
   const now = Math.floor(Date.now() / 1000)
@@ -23,7 +24,7 @@ export const cleanupExpiredUploadSessions = async (
 
   const stale = await db
     .prepare(
-      `SELECT id, user_id, vault_id, total_size, uploaded_chunks, r2_upload_id, r2_key
+      `SELECT id, user_id, vault_id, total_size, chunk_count, encrypted_size, uploaded_chunks, r2_upload_id, r2_key
        FROM upload_sessions
        WHERE expires_at < ?`
     )
@@ -33,6 +34,8 @@ export const cleanupExpiredUploadSessions = async (
       user_id: string
       vault_id: string
       total_size: number
+      chunk_count: number
+      encrypted_size: number | null
       uploaded_chunks: string
       r2_upload_id: string | null
       r2_key: string | null
@@ -80,7 +83,12 @@ export const cleanupExpiredUploadSessions = async (
       .run()
 
     if ((result.meta.changes ?? 0) > 0) {
-      await adjustStorageUsed(db, session.user_id, -session.total_size)
+      // Refund what initiate reserved: the encrypted total, not the plaintext.
+      await adjustStorageUsed(
+        db,
+        session.user_id,
+        -expectedEncryptedTotal(session.total_size, session.chunk_count, session.encrypted_size)
+      )
       cleaned += result.meta.changes ?? 0
     }
   }

--- a/apps/sync-server/src/services/cleanup.ts
+++ b/apps/sync-server/src/services/cleanup.ts
@@ -1,5 +1,4 @@
 import { adjustStorageUsed } from './quota'
-import { expectedEncryptedTotal } from './upload-size'
 
 export const cleanupExpiredOtpCodes = async (db: D1Database): Promise<number> => {
   const now = Math.floor(Date.now() / 1000)
@@ -83,12 +82,12 @@ export const cleanupExpiredUploadSessions = async (
       .run()
 
     if ((result.meta.changes ?? 0) > 0) {
-      // Refund what initiate reserved: the encrypted total, not the plaintext.
-      await adjustStorageUsed(
-        db,
-        session.user_id,
-        -expectedEncryptedTotal(session.total_size, session.chunk_count, session.encrypted_size)
-      )
+      // Refund exactly what initiate reserved — never re-derive it. `encrypted_size`
+      // records the reservation; a NULL means the row was written by the old server,
+      // which reserved the plaintext total_size. Migration 0002 backfills the rows that
+      // existed when it ran, but migrations apply before the Worker deploys, so the old
+      // code can still open NULL rows during the rollout window. Keep the fallback.
+      await adjustStorageUsed(db, session.user_id, -(session.encrypted_size ?? session.total_size))
       cleaned += result.meta.changes ?? 0
     }
   }

--- a/apps/sync-server/src/services/upload-size.ts
+++ b/apps/sync-server/src/services/upload-size.ts
@@ -1,0 +1,31 @@
+import { XCHACHA20_PARAMS } from '@memry/contracts/crypto'
+
+// Clients upload each chunk as nonce || XChaCha20-Poly1305 ciphertext, and the
+// ciphertext carries a Poly1305 tag — so every chunk is plaintext + 40 bytes on
+// the wire. Derived from packages/contracts/src/crypto.ts so a crypto change
+// cannot silently drift from this accounting.
+export const CHUNK_CRYPTO_OVERHEAD = XCHACHA20_PARAMS.NONCE_LENGTH + XCHACHA20_PARAMS.TAG_LENGTH
+
+// Upper bound used to sanity-check a client-declared encryptedSize. Leaves slack
+// for a future AEAD with a larger nonce/tag without trusting the client's number.
+export const MAX_CHUNK_CRYPTO_OVERHEAD = 64
+
+/**
+ * Bytes actually put on the wire (and stored) for an upload session: explicit
+ * when the client declared it, otherwise derived from the plaintext size plus
+ * per-chunk crypto overhead.
+ *
+ * Storage quota is reserved and refunded against this value. Plan file-size
+ * limits stay on the plaintext size, so encryption overhead never eats into a
+ * user's limit.
+ *
+ * The derive path (`encryptedSize === null`) is what makes already-installed
+ * clients — and sessions opened before `encrypted_size` existed — work.
+ */
+export function expectedEncryptedTotal(
+  totalSize: number,
+  chunkCount: number,
+  encryptedSize: number | null
+): number {
+  return encryptedSize ?? totalSize + CHUNK_CRYPTO_OVERHEAD * chunkCount
+}

--- a/packages/contracts/src/blob-api.ts
+++ b/packages/contracts/src/blob-api.ts
@@ -3,8 +3,16 @@ import { z } from 'zod'
 export const UploadInitRequestSchema = z.object({
   attachmentId: z.string().min(1),
   filename: z.string().min(1),
+  /** Plaintext byte size of the file. Plan file-size limits apply to this. */
   totalSize: z.number().int().positive(),
-  chunkCount: z.number().int().positive().max(128)
+  chunkCount: z.number().int().positive().max(128),
+  /**
+   * Total byte size actually put on the wire (and stored): every chunk is
+   * nonce || ciphertext, so this is larger than `totalSize`. Optional — the
+   * server derives it from `totalSize` + `chunkCount` when a client omits it.
+   * Storage quota is reserved against this, not `totalSize`.
+   */
+  encryptedSize: z.number().int().positive().optional()
 })
 
 export const ChunkUploadParamsSchema = z.object({

--- a/packages/contracts/src/ipc-sync-ops.ts
+++ b/packages/contracts/src/ipc-sync-ops.ts
@@ -35,6 +35,9 @@ export type SyncErrorCategory =
   | 'crypto_failure'
   | 'version_incompatible'
   | 'storage_quota_exceeded'
+  // One file is over the plan's per-file limit — distinct from being out of
+  // storage, and not fixable by freeing space.
+  | 'file_too_large'
   | 'sync_payment_required'
   | 'certificate_pin_failed'
   | 'unknown'

--- a/packages/i18n/src/locales/en/errors.json
+++ b/packages/i18n/src/locales/en/errors.json
@@ -63,6 +63,8 @@
     "cryptoFailure": "Failed to encrypt or decrypt sync data. Try signing out and back in.",
     "versionIncompatible": "This version of memrynote is no longer supported. Please update.",
     "storageQuotaExceeded": "Your sync storage is full. Free up space or upgrade your plan.",
+    "fileTooLarge": "This file is larger than your plan allows. Upgrade your plan to sync larger files.",
+    "attachmentUploadFailed": "Couldn't sync attachment \"{filename}\". It stays on this device.",
     "paymentRequired": "A paid Sync plan is required to use hosted encrypted sync.",
     "certificatePinFailed": "Secure connection failed. Check your network connection.",
     "unknown": "An unexpected sync error occurred. Will retry automatically.",


### PR DESCRIPTION
## Production evidence

Chunked attachment upload has been **100% broken for every paid user, on every file, since 3fb982cac (2026-05-18 — 58 days)**.

Loki shows `413` on `PUT /sync/attachments/upload/:value/chunk/:value` with `"Uploaded chunks exceed declared file size"`.

The client declares the **plaintext** size but uploads **ciphertext**:

- `apps/desktop/src/main/sync/attachments.ts:333` passes `fileStat.size` (plaintext) as `totalSize` to `initiateUploadSession`.
- `attachments.ts:286-289` builds each uploaded chunk as `nonce(24) || ciphertext(plaintext + 16-byte Poly1305 tag)` = **plaintext + exactly 40 bytes per chunk**.
- Server guard `blob.ts:246` compared `uploadedBytes + chunkData.byteLength > session.total_size`.

For any file ≤ 8MB (`CHUNK_SIZE`) there is exactly one chunk, so chunk 0 always evaluated `0 + (S+40) > S` → **always true** → always 413. Even if bypassed, `complete` re-rejected at `blob.ts:317` (`actualBytes !== session.total_size`).

## The fix

Plan limits and storage accounting are now measured on different things, deliberately:

- **Plan file-size limit stays on PLAINTEXT.** A user who picks a 5 MiB file on Plus passes. Encryption overhead must not eat into their limit.
- **Storage accounting/reservation uses the ENCRYPTED size** — what R2 actually stores.
- The server accepts an **optional** explicit `encryptedSize` and **derives** it when absent: `totalSize + 40 * chunkCount`.

The derive path is the point: **it fixes every already-installed client the moment this deploys, with no app release.**

The `40` is not hardcoded — `apps/sync-server/src/services/upload-size.ts` derives it as `XCHACHA20_PARAMS.NONCE_LENGTH + XCHACHA20_PARAMS.TAG_LENGTH` from `packages/contracts/src/crypto.ts`, so a crypto change cannot silently drift from this accounting. (`services/sync.ts` already imports from that module, so this adds no new worker dependency.) A test also asserts the sum is 40.

A client-sent `encryptedSize` drives quota, so it is **not trusted blindly**: rejected with `VALIDATION_ERROR` 400 unless `totalSize <= encryptedSize <= totalSize + 64 * chunkCount` (64 = slack for a future AEAD).

Every refund path now refunds the **same** encrypted total that `initiate` reserved — initiate rollback, session cancel, and `cleanup.ts` expired-session reclaim — so quota cannot leak or over-refund.

Unchanged on purpose: `SYNC_PLAN_LIMITS`, `assertPaidSyncAccess` (free users still correctly get 402), `assertFileSizeAllowed` (still plaintext). The manifest reserve/refund paths measure `manifestBytes.byteLength` — real stored bytes, already correct — so they are untouched.

## Compat / migration plan

- **Migration `0002_upload_sessions_encrypted_size.sql` is additive and nullable**: `ALTER TABLE upload_sessions ADD COLUMN encrypted_size INTEGER`. No data loss, no reset. Deploy workflows apply migrations **before** code (expand-before-deploy), so code never ships ahead of its schema.
- **Old clients** (no `encryptedSize`): derive path → they start working on deploy, no release needed. This is a **fix, not a break** — nothing worked before.
- **In-flight `upload_sessions` rows** written by the previous code have `NULL` `encrypted_size`; derivation covers them.
- **Contract change is additive**: `encryptedSize` is `.optional()`, so old clients still validate.

## Verification actually run

- `npx vitest run src/routes/blob-upload-size-accounting.test.ts` — **16/16 pass**. Written first; watched all 12 behavioural tests fail first, the headline one with `expected 413 to be 200` (the production bug reproduced).
- Full sync-server suite: `npx vitest run` — **673 passed / 48 files**.
- `npx tsc --noEmit` on `apps/sync-server` and `packages/contracts` — clean.
- `pnpm docs:impact --base <merge-base> --strict` — `covered`. `pnpm docs:build` — exit 0.
- Pre-commit `ipc:check` / RPC bindings / secret + renderer guards — all passed.

New tests use **real relationships**, not self-consistent numbers: real `SYNC_PLAN_LIMITS` (entitlements is deliberately *not* mocked), plaintext→ciphertext sizes that actually differ by 40/chunk. Covers: single-chunk N→N+40 succeeds (the regression), old-client derive, explicit `encryptedSize`, 2-chunk N+80, Plus at exactly 5 MiB passes, Plus at 5 MiB+1 → 413, free → 402, implausible `encryptedSize` → 400 with quota not inflated, and `40 === NONCE_LENGTH + TAG_LENGTH`.

I also corrected the pre-existing fixtures in `blob.test.ts` and `cleanup.test.ts`. They encoded `plaintext == ciphertext` (`total_size: 10` with two 5-byte raw chunks) — physically impossible, and precisely why this shipped broken.

## Not verified / risks

- **No live/staging run against real D1 + R2.** All server tests use mocked D1/R2. The migration itself has not been applied to a real database — verified only by reading `0001_baseline.sql`.
- **No end-to-end run with a real desktop client.** The plaintext+40 relationship is established by reading `attachments.ts` and the crypto constants, not by observing a real upload.
- Quota reserved at `initiate` is **not** refunded when a chunk dedups against an existing `blob_chunks` row (server stores nothing new but still charged). This is **pre-existing behaviour**, unchanged here, and flagged rather than fixed.
- Full `pnpm typecheck` exits 1 in this worktree on an unrelated `apps/desktop` native rebuild failure, not a type error — hence the direct `tsc` runs on the two packages touched.
- `pnpm lint` maps to `lint:desktop` only; sync-server has no lint script, so lint does not cover these files. Prettier formatting was applied and is clean.
- `apps/desktop` is untouched per the brief — the client still sends only plaintext `totalSize` and relies on the derive path. A stacked PR owns sending explicit `encryptedSize`.

---

# Context for reviewers

## Where this came from

This PR is one of 8 opened from a **2-day production error-log triage** (2026-07-13 → 07-15, Grafana `/d/memry-logs`, `env=production`, Loki on the VPS).

The whole window held only **161 log lines** — 90 desktop errors, 27 server errors, 44 server warns — across **13 distinct installs**. Cloudflare Analytics Engine gives the denominator: **18 active installs** in those 2 days, **30** over 5 days.

Two things made this triage possible at all, and both are recent:
- **#732** (merged 2026-07-10) fixed `detectBuildChannel` falling back to `process.env.NODE_ENV`, which is undefined in packaged Electron. Before it, every packaged install reported `build_channel="development"` **and** defaulted telemetry OFF. Every desktop line in this window now reads `build_channel=production` on `2026.710.3` — so we are finally seeing real users.
- **#733** (merged 2026-07-10) stopped clean utility-worker exits from firing error events, so what remains is signal.

Low line counts here mean **low telemetry volume, not low impact**. The headline finding of the whole triage — a 58-day, 100%-broken attachment upload — was exposed by exactly **2 log lines**.

## How these PRs were produced

Each production error class was root-caused by a dedicated investigation against the real code before any patch was written, then implemented TDD-first in an isolated worktree, then put through an **adversarial review** whose explicit brief was to find what is wrong rather than to approve.

That review stage earned its keep: **6 of 8 PRs came back `needs-work`**, several with defects that would have merged silently. Its findings are reproduced verbatim below — they are not cosmetic.

**The one question that matters most on every one of these PRs:** *would the new tests actually fail on the base branch?* The 58-day attachment outage survived because both the server suite (R2/D1 fully mocked, self-consistent fixtures like `total_size: 10` with raw bytes) and the desktop suite (`fetch` mocked wholesale) passed green while the seam between them was never exercised. A test that mocks the thing under test proves nothing. Some of these PRs repeated that exact mistake and the reviewer caught it.

## This PR: production evidence

Two log lines — one `STORAGE_FILE_TOO_LARGE` 413 on `PUT /sync/attachments/upload/:value/chunk/:value` ("Uploaded chunks exceed declared file size") and one `STORAGE_BLOB_NOT_FOUND` 404 — from a single user. They exposed that **chunked attachment upload has been 100% broken for every paid user, on every file, since `3fb982cac` (2026-05-18) — 58 days.**

The client declares **plaintext** size but uploads **ciphertext**: each chunk is `nonce(24) + ciphertext(plaintext + 16 tag)` = **plaintext + 40 bytes**. The guard `uploadedBytes + chunkData.byteLength > session.total_size` is therefore always true on chunk 0 for any single-chunk (≤8 MB) file. `complete` re-rejects for the same reason — double-locked, no attachment can ever complete.

It stayed silent because the failure is automatic and invisible: attachment saved → `emitSaved` → `onSaved` → upload queue → 413; the failure is logged to electron-log (**not** telemetry) and an `ATTACHMENT_UPLOAD_FAILED` event is sent to a renderer where **nothing listens**. We only learned about it because the *server* logged the 413.

## Why the design is what it is

Both the derive path and the explicit field are present **on purpose**:
- **Server derives** `totalSize + 40 * chunkCount` when `encryptedSize` is absent → deploying this PR alone **repairs every already-installed client with no app release**. That is the whole reason the derive path exists; do not remove it as redundant.
- **Client sends `encryptedSize`** (in the stacked client work) → the durable, correctly-layered design going forward.

**The plan limit stays on plaintext.** A user who picked a 5 MiB file on Plus must pass; encryption overhead must not eat their limit, or a file at exactly the advertised limit gets an absurd off-by-40 rejection. Storage accounting/reservation uses the encrypted size, because that is what R2 actually stores. These are two different numbers and conflating them is the original bug.

**What was deliberately NOT changed:** `SYNC_PLAN_LIMITS` (free 0 / plus 5 MiB / pro 200 MiB / believer 200 MiB) was checked against intent and is **already correct**. `assertPaidSyncAccess` → 402 for free users is **correct behaviour**, not a bug. `assertFileSizeAllowed` stays on plaintext.

## ⚠️ The review verdict below is STALE — read this

The `ship` verdict was given against the **server-only diff** (+540/-22, 9 files). Since then this branch **absorbed #746** (the desktop client work, which was reviewed separately and returned `needs-work` with 2 blocking findings). The branch is now ~34 files.

**The `ship` below does not describe what is currently in this branch.** The #746 blocking findings are fixed in the stacked #753. This combined diff has not been re-reviewed as a whole.

## Adversarial review findings (verbatim)

> Reproduced exactly as returned. Findings cite file:line — verify them yourself rather than trusting either the author or the reviewer.

VERDICT: ship

## TESTS ARE REAL?
YES — verified empirically, not taken on trust. I checked out origin/main into a scratch worktree, dropped the branch's new test file onto the OLD code, and ran it: `Tests 12 failed | 4 passed (16)`, with the headline failure `accepts a single chunk of plaintext+40 bytes against a declared plaintext size: AssertionError: expected 413 to be 200`. That is precisely the production bug, reproduced by the test. On the branch the same file is 16/16 green. The author's TDD report (12 failed / 4 passed) matches my run exactly.

Why the tests are not the self-consistent-mock trap that let this ship broken:
- The thing under test (the accounting logic in routes/blob.ts) is NOT mocked. The test drives real HTTP requests through the real Hono route. Only collaborators are mocked (quota, R2/blob, auth+rate-limit middleware).
- services/entitlements is DELIBERATELY left unmocked (blob-upload-size-accounting.test.ts:27-28), so "plus + exactly 5 MiB" exercises the real SYNC_PLAN_LIMITS constant rather than a number invented by the test.
- The overhead is not double-hardcoded to match the impl: the test asserts XCHACHA20_PARAMS.NONCE_LENGTH + TAG_LENGTH === 40 against the contracts constant, pinning the derivation.
- The pre-existing fixture edits in blob.test.ts / cleanup.test.ts TIGHTEN assertions (exact expected byte values) rather than weaken them; they replace physically-impossible fixtures (total_size:10 with two 5-byte raw chunks — plaintext==ciphertext) that were the very reason the bug shipped green.

Independently corroborated the correctness claim from real code rather than the author's reading: apps/desktop/src/main/crypto/encryption.ts:33 uses sodium.crypto_aead_xchacha20poly1305_ietf_encrypt (ciphertext = plaintext + 16-byte tag) and generateNonce() uses XCHACHA20_PARAMS.NONCE_LENGTH (24) => +40/chunk, exactly matching services/upload-size.ts. apps/desktop/src/main/sync/attachments.ts:536 sends only {attachmentId, filename, totalSize, chunkCount}, so installed clients hit the derive path and start working on deploy with no app release.

Residual gap (author already admits it, I confirm it stands): no live D1/R2 or real-desktop e2e run. The +40 relationship is proven by code-reading + unit tests on both sides, not by observing a real upload succeed. Partially mitigated by something the author under-credited: apps/sync-server/schema/d1.test.ts reads every migrations/*.sql in order and applies them to a real SQLite DB, so migration 0002 IS proven to apply cleanly on top of 0001_baseline (it asserts columns via toContain, so the added column doesn't break it).

Full-suite honesty check: I measured 4 failures in schema/d1.test.ts, but they are better-sqlite3 NODE_MODULE_VERSION 140-vs-137 errors from my symlinked node_modules, and they fail IDENTICALLY on origin/main in isolation. Not caused by this PR; the author's "673 passed / 0 failures" claim is not contradicted.

## BLOCKING


## NITS

- [1] REAL (small) DEFECT THE AUTHOR MISSED — legacy in-flight sessions are over-refunded. Sessions created BEFORE this deploys reserved only plaintext (old initiate), but after deploy their encrypted_size IS NULL so every refund path derives plaintext + 40*chunk_count. routes/blob.ts:456 (cancel) and services/cleanup.ts:87 (expiry) therefore refund MORE than was reserved, by up to 40*chunk_count (<=5120 bytes at the 128-chunk max). Not dangerous: services/quota.ts:60 clamps with MAX(0, storage_used + ?), so it cannot go negative, and the 24h UPLOAD_SESSION_TTL means it self-heals within a day of deploy. Worth a sentence in the PR body; not worth blocking a fix to a 58-day total outage.

- [2] SCOPE / YAGNI — the `encryptedSize` REQUEST field is currently dead surface. No client sends it (apps/desktop/src/main/sync/attachments.ts:536 sends only attachmentId/filename/totalSize/chunkCount, and the brief says desktop is untouched). The contracts field (packages/contracts/src/blob-api.ts) plus the ~12-line bounds-check at routes/blob.ts:189-200 exist solely for a caller that does not exist, which cuts against CLAUDE.md 'Simplicity First: no flexibility that wasn't requested'. Defensible as forward-compat and it IS bounds-checked, but the actual outage fix is the derive path alone. Note the persisted encrypted_size COLUMN is genuinely useful (it pins accounting at initiate time so a future overhead change can't corrupt in-flight refunds) — the column earns its place, the request field doesn't yet.

- [3] services/upload-size.ts:11 — MAX_CHUNK_CRYPTO_OVERHEAD = 64 is hardcoded while CHUNK_CRYPTO_OVERHEAD right above it is carefully DERIVED from XCHACHA20_PARAMS. Minor inconsistency in a file whose stated purpose is 'a crypto change cannot silently drift from this accounting'. It's only a validation slack bound so a magic number is acceptable, but a comment tying 64 to a concrete future AEAD (or deriving it) would match the file's own standard.

- [4] DEPLOY GATE (not a merge blocker) — the author's honest risk #1 stands: nothing here was exercised against real D1 + R2. Since this changes storage-quota accounting for real paying users, smoke-test one real single-chunk upload on staging after migrations apply and before promoting to production. The expand-before-deploy ordering this relies on is already CI-enforced and documented in apps/sync-server/migrations/README.md ('Both deploy workflows apply migrations before wrangler deploy'), and there is no 0002 filename collision — I verified both.

- [5] PRE-EXISTING, correctly left alone: packages/contracts has NO test script (only typecheck), and root `pnpm test` filters to app-core/cli/desktop/sync-server — so packages/contracts/src/blob-api.test.ts never runs in CI. Harmless here (the schema has no .strict(), so an optional additive field cannot break it, and apps/sync-server/src/foundation-contracts.test.ts:72 does validate the old-client shape and passed), but the contracts package's tests being unwired is a standing gap worth a follow-up.

- [6] Author's flagged pre-existing issue confirmed and correctly NOT fixed here: routes/blob.ts:290-296 bumps ref_count when a chunk dedups against an existing blob_chunks row, storing zero new bytes, yet the initiate reservation is never refunded — the user stays charged for bytes R2 never stored. Unchanged behaviour, right call to leave it, good follow-up candidate.

- [7] HOUSE RULES all clean, verified: no Co-Authored-By and no agent/tool branding in either commit or the branch name (0 hits scanning full commit bodies); branch is a code-context name; the commit message's blame of 3fb982cac checks out (2026-05-18 introduced that exact line at blob.ts:246 — 58 days to today 2026-07-15, so the '58-day' framing is accurate). No telemetry/privacy surface (desktop untouched; the new 400 message 'encryptedSize is not plausible...' carries no path/email/URL). No renderer/Tailwind code. No console.*. blob-api is an HTTP contract not on the IPC invoke surface — nothing generated references it — so ipc:check being a no-op is consistent, and getUploadSession's `SELECT *` picks up the new column automatically.


---

## Update — merged main + adversarial verification

**Merged `main`** (was `CONFLICTING`). The only real conflict was the blob-route refund site: `main` (#744) refactored the four refund sites into a `refundReservation` helper that swallows a failed refund so it never masks the real error. Resolution keeps that helper but feeds it #740's corrected amount at `initiate` — `expectedEncrypted` (the ciphertext total actually reserved), not the plaintext `totalSize`. The merged test file's own assertions expect exactly that (`-UPLOAD_INIT_ENCRYPTED_SIZE`). **sync-server: 48 files, 691 tests pass** locally on the merged result.

**Adversarial verification (6 independent reviewers).** The migration + accounting are correct on every path:
- `0002` is a nullable, no-default, **un-backfilled** `ADD COLUMN` — an O(1) metadata change that can't fail/lock/lose rows. `NULL` is load-bearing: refund reads it as `?? total_size` (what the old server reserved) while the chunk cap / `complete` **derive** `total_size + 40·chunk_count` (the ciphertext on the wire). A backfill would false-413 the last chunk of every in-flight session — which is why the earlier backfill was correctly dropped.
- Full reserve → cap → complete → refund lifecycle balances for both a new client (declares `encryptedSize`) and an old client (server derives). The untrusted `encryptedSize` is bounded (`totalSize ≤ encryptedSize ≤ totalSize + 64·chunkCount`); plan file-size limit stays on plaintext, storage quota on ciphertext — never swapped.
- Deploy ordering holds: an old client that sends no `encryptedSize` still works (derive path), and server-before-desktop is respected.

**Fixed (from review):**
- A **stale comment** in `blob.ts` and `cleanup.ts` claimed migration `0002` *backfills* `encrypted_size` — it deliberately does not. Corrected to warn against both footguns (removing the `?? total_size` fallback, or re-adding a backfill).
- A **pre-existing docs bug on `main`**: PR #748 (`inline-underline-persistence`) left an **unresolved conflict block committed** in `apps/docs/src/user-guide/notes/editing.md` (raw `<<<<<<<`/`=======`/`>>>>>>>` markers). It renders literally on the published docs site. Resolved here (kept both the toolbar-controls sentence and the new Text Formatting section) — **worth a direct fix on `main` too**, since every branch that merges main inherits it.

**Known limitations (accepted for merge):**
- **Rollback-only quota under-refund ≤ 5 KB/session.** If the worker is rolled back to pre-#740 code after `0002` is applied, cancelling/expiring a new-worker session refunds only plaintext (old code has no `encrypted_size` reader), under-refunding by `40·chunk_count`, always in the platform's favour. Clears via a storage reconciliation sweep. Forward (server-before-desktop) is the supported direction.
- A failed `complete` (exact-size mismatch) or a mid-upload 413 holds the reservation until the 24 h session TTL, when cleanup refunds it — a temporary hold, not a leak; pre-existing.
