### PR TITLE
fix(telemetry): name the crashed utility worker instead of the mojo interface

### DIFF
--- a/apps/desktop/src/main/lib/embeddings.test.ts
+++ b/apps/desktop/src/main/lib/embeddings.test.ts
@@ -8,6 +8,11 @@ const mockApp = vi.hoisted(() => ({
 }))
 const getAllWindows = vi.hoisted(() => vi.fn())
 const mockFork = vi.hoisted(() => vi.fn())
+const trackMainLogMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../telemetry/diagnostics', () => ({
+  trackMainLog: trackMainLogMock
+}))
 
 class MockUtilityProcess extends EventEmitter {
   postMessage = vi.fn()
@@ -47,6 +52,7 @@ vi.mock('@huggingface/transformers', () => {
   throw new Error('@huggingface/transformers should only load inside embedding-worker')
 })
 
+import { resetTelemetryThrottle } from '../telemetry/throttle'
 import {
   EMBEDDING_DIMENSION,
   generateEmbedding,
@@ -61,6 +67,8 @@ describe('embeddings', () => {
   beforeEach(() => {
     unloadModel()
     mockFork.mockReset()
+    trackMainLogMock.mockReset()
+    resetTelemetryThrottle()
     mockApp.getPath.mockImplementation((name: string) =>
       name === 'userData' ? '/mock/user-data' : `/mock/${name}`
     )
@@ -282,5 +290,123 @@ describe('embeddings', () => {
 
     await vi.advanceTimersByTimeAsync(30_000)
     expect(mockUtilityProcessInstance.postMessage).toHaveBeenLastCalledWith({ type: 'shutdown' })
+  })
+
+  // These exist to answer the open production question behind the
+  // `Utility:crashed:*` volume: does the worker die while TEARING DOWN (user
+  // impact ~zero, embedding already delivered) or while WORKING (user silently
+  // loses semantic-search indexing)? Nothing in telemetry can tell them apart today.
+  describe('worker exit telemetry', () => {
+    const startWorker = async (): Promise<{ requestId: string }> => {
+      const pending = generateEmbedding('content long enough for embeddings')
+      void pending.catch(() => {})
+      mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+      await vi.waitFor(() => {
+        expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+      })
+      const request = mockUtilityProcessInstance.postMessage.mock.calls[0]?.[0] as {
+        requestId: string
+      }
+      return { requestId: request.requestId }
+    }
+
+    it('reports idle_shutdown when the worker dies during its own teardown', async () => {
+      vi.useFakeTimers()
+      const { requestId } = await startWorker()
+
+      // #given the embedding was delivered, so nothing is in flight
+      mockUtilityProcessInstance.simulateMessage({
+        type: 'embed-result',
+        requestId,
+        embedding: Array.from(new Float32Array(EMBEDDING_DIMENSION))
+      })
+      await vi.waitFor(() => expect(getModelInfo().loaded).toBe(true))
+
+      // #when the 30s idle timer fires and the worker dies mid-teardown (SIGSEGV)
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenLastCalledWith({ type: 'shutdown' })
+      mockUtilityProcessInstance.emit('exit', 11)
+
+      // #then telemetry names the phase — this crash cost the user nothing
+      expect(trackMainLogMock).toHaveBeenCalledWith('error', {
+        scope: 'Embeddings',
+        action: 'worker_exit_idle_shutdown',
+        errorCode: 'EmbeddingWorkerExit',
+        metrics: { value: 11 }
+      })
+    })
+
+    it('reports in_flight when the worker dies with a request outstanding', async () => {
+      await startWorker()
+
+      // #when the worker dies while the embed request is still outstanding
+      mockUtilityProcessInstance.emit('exit', 11)
+
+      // #then telemetry says the user silently lost this embedding
+      expect(trackMainLogMock).toHaveBeenCalledWith('error', {
+        scope: 'Embeddings',
+        action: 'worker_exit_in_flight',
+        errorCode: 'EmbeddingWorkerExit',
+        metrics: { value: 11 }
+      })
+    })
+
+    it('stays silent for a clean idle shutdown', async () => {
+      vi.useFakeTimers()
+      const { requestId } = await startWorker()
+      mockUtilityProcessInstance.simulateMessage({
+        type: 'embed-result',
+        requestId,
+        embedding: Array.from(new Float32Array(EMBEDDING_DIMENSION))
+      })
+      await vi.waitFor(() => expect(getModelInfo().loaded).toBe(true))
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      // #when the worker exits(0) as designed — lifecycle, not a fault
+      mockUtilityProcessInstance.emit('exit', 0)
+
+      expect(trackMainLogMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('embedding failure visibility', () => {
+    it('reports failed embeddings so silent loss of indexing is measurable', async () => {
+      const embeddingPromise = generateEmbedding('content long enough for embeddings')
+
+      mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+      await vi.waitFor(() => {
+        expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+      })
+
+      // #when the worker dies outright, rejecting the in-flight request
+      mockUtilityProcessInstance.emit('exit', 11)
+      await expect(embeddingPromise).resolves.toBeNull()
+
+      // #then the failure reaches telemetry instead of only electron-log
+      expect(trackMainLogMock).toHaveBeenCalledWith('error', {
+        scope: 'Embeddings',
+        action: 'embed_failed',
+        errorCode: 'Error'
+      })
+    })
+
+    it('throttles repeated embed failures so a crash loop cannot flood the queue', async () => {
+      // #given a broken worker and several notes edited in quick succession
+      for (let i = 0; i < 3; i++) {
+        const embeddingPromise = generateEmbedding(`content long enough for embeddings ${i}`)
+        mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+        await vi.waitFor(() => {
+          expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalled()
+        })
+        mockUtilityProcessInstance.emit('exit', 11)
+        await expect(embeddingPromise).resolves.toBeNull()
+      }
+
+      // #then only the first embed_failed leaves the process
+      const embedFailures = trackMainLogMock.mock.calls.filter(
+        (call) => call[1]?.action === 'embed_failed'
+      )
+      expect(embedFailures).toHaveLength(1)
+    })
   })
 })

--- a/apps/desktop/src/main/lib/embeddings.test.ts
+++ b/apps/desktop/src/main/lib/embeddings.test.ts
@@ -16,7 +16,18 @@ vi.mock('../telemetry/diagnostics', () => ({
 
 class MockUtilityProcess extends EventEmitter {
   postMessage = vi.fn()
-  kill = vi.fn().mockReturnValue(true)
+  // Real utilityProcess.kill() ALWAYS causes an 'exit'; the old no-op stub hid
+  // every force-kill / reset exit path (where the phase-attribution bugs live).
+  // Arm killExitCode to model the OS delivering that 'exit' as a LATER macrotask,
+  // so it races the `shuttingDown` reset exactly as production does.
+  killExitCode: number | null = null
+  kill = vi.fn(() => {
+    if (this.killExitCode !== null) {
+      const code = this.killExitCode
+      setTimeout(() => this.emit('exit', code), 0)
+    }
+    return true
+  })
   stdout = null
   stderr = null
   pid = 1234
@@ -60,6 +71,7 @@ import {
   initEmbeddingModel,
   isModelLoaded,
   isModelLoading,
+  stopEmbeddingModel,
   unloadModel
 } from './embeddings'
 
@@ -365,6 +377,98 @@ describe('embeddings', () => {
       // #when the worker exits(0) as designed — lifecycle, not a fault
       mockUtilityProcessInstance.emit('exit', 0)
 
+      expect(trackMainLogMock).not.toHaveBeenCalled()
+    })
+
+    it('reports idle_shutdown when a wedged worker must be force-killed during teardown', async () => {
+      vi.useFakeTimers()
+      const { requestId } = await startWorker()
+      mockUtilityProcessInstance.simulateMessage({
+        type: 'embed-result',
+        requestId,
+        embedding: Array.from(new Float32Array(EMBEDDING_DIMENSION))
+      })
+      await vi.waitFor(() => expect(getModelInfo().loaded).toBe(true))
+
+      // #given the worker ignores the graceful shutdown and wedges — the exact
+      // onnxruntime-dispose failure mode this telemetry exists to catch
+      mockUtilityProcessInstance.killExitCode = 15 // SIGTERM
+
+      // #when the 30s idle timer fires -> stop() posts shutdown, but no clean exit
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenLastCalledWith({ type: 'shutdown' })
+      expect(mockUtilityProcessInstance.kill).not.toHaveBeenCalled()
+
+      // #and the 3s force-kill timeout fires; kill() delivers 'exit' as a later
+      // macrotask, AFTER the await continuation clears `shuttingDown`
+      await vi.advanceTimersByTimeAsync(3_000)
+      expect(mockUtilityProcessInstance.kill).toHaveBeenCalledOnce()
+
+      // #then the teardown death is named idle_shutdown, NOT the misleading `idle`
+      // ("died spontaneously doing nothing") the shuttingDown-reset race produced
+      expect(trackMainLogMock).toHaveBeenCalledWith('error', {
+        scope: 'Embeddings',
+        action: 'worker_exit_idle_shutdown',
+        errorCode: 'EmbeddingWorkerExit',
+        metrics: { value: 15 }
+      })
+      expect(trackMainLogMock).not.toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ action: 'worker_exit_idle' })
+      )
+    })
+
+    it('reports idle_shutdown when reset() force-kills the running worker', async () => {
+      vi.useFakeTimers()
+      await startWorker()
+
+      // #given a live worker that reset() will hard-kill to free memory
+      mockUtilityProcessInstance.killExitCode = 15
+
+      // #when unloadModel() force-kills it (no graceful shutdown message)
+      unloadModel()
+      await vi.advanceTimersByTimeAsync(0)
+
+      // #then its teardown death is idle_shutdown, not the racy `idle`
+      expect(trackMainLogMock).toHaveBeenCalledWith('error', {
+        scope: 'Embeddings',
+        action: 'worker_exit_idle_shutdown',
+        errorCode: 'EmbeddingWorkerExit',
+        metrics: { value: 15 }
+      })
+    })
+  })
+
+  describe('worker exit before ready', () => {
+    it('reports worker_exit_starting when the worker dies before it becomes ready', async () => {
+      const loadPromise = initEmbeddingModel()
+
+      // #when the worker crashes during bootstrap, before ever sending 'ready'
+      mockUtilityProcessInstance.emit('exit', 1)
+      await expect(loadPromise).resolves.toBe(false)
+
+      // #then the death is attributed to the startup phase
+      expect(trackMainLogMock).toHaveBeenCalledWith('error', {
+        scope: 'Embeddings',
+        action: 'worker_exit_starting',
+        errorCode: 'EmbeddingWorkerExit',
+        metrics: { value: 1 }
+      })
+    })
+
+    it('stays silent when shut down before the worker finishes starting', async () => {
+      const loadPromise = initEmbeddingModel()
+      expect(mockFork).toHaveBeenCalledOnce()
+
+      // #given the app quits while the worker is still bootstrapping (no 'ready')
+      const stopPromise = stopEmbeddingModel()
+
+      // #when that bootstrapping worker exits cleanly in response to the shutdown
+      mockUtilityProcessInstance.emit('exit', 0)
+      await stopPromise
+      await expect(loadPromise).resolves.toBe(false)
+
+      // #then a clean lifecycle exit is NOT reported as a worker_exit_starting fault
       expect(trackMainLogMock).not.toHaveBeenCalled()
     })
   })

--- a/apps/desktop/src/main/lib/embeddings.test.ts
+++ b/apps/desktop/src/main/lib/embeddings.test.ts
@@ -363,6 +363,30 @@ describe('embeddings', () => {
       })
     })
 
+    it('reports idle when the worker crashes spontaneously while sitting idle', async () => {
+      vi.useFakeTimers()
+      const { requestId } = await startWorker()
+      mockUtilityProcessInstance.simulateMessage({
+        type: 'embed-result',
+        requestId,
+        embedding: Array.from(new Float32Array(EMBEDDING_DIMENSION))
+      })
+      await vi.waitFor(() => expect(getModelInfo().loaded).toBe(true))
+
+      // #when the worker dies on its own AFTER delivering, but BEFORE the 30s idle
+      // timer fires — not tearing down, nothing in flight
+      mockUtilityProcessInstance.emit('exit', 11)
+
+      // #then it is the genuine `idle` bucket, distinct from idle_shutdown (this
+      // guards the force-kill latch from over-claiming idle_shutdown)
+      expect(trackMainLogMock).toHaveBeenCalledWith('error', {
+        scope: 'Embeddings',
+        action: 'worker_exit_idle',
+        errorCode: 'EmbeddingWorkerExit',
+        metrics: { value: 11 }
+      })
+    })
+
     it('stays silent for a clean idle shutdown', async () => {
       vi.useFakeTimers()
       const { requestId } = await startWorker()

--- a/apps/desktop/src/main/lib/embeddings.ts
+++ b/apps/desktop/src/main/lib/embeddings.ts
@@ -92,6 +92,12 @@ class EmbeddingModelBridge {
   private error: string | null = null
   private shuttingDown = false
   private idleShutdownTimer: ReturnType<typeof setTimeout> | null = null
+  // Latched when WE force-kill the worker (shutdown timeout / reset). The kill's
+  // 'exit' arrives as a later macrotask, after `shuttingDown` is already cleared,
+  // so the exit handler cannot recover the phase from `shuttingDown` alone —
+  // without this latch a wedged teardown is misreported as `idle` ("died doing
+  // nothing") instead of `idle_shutdown` ("died tearing down").
+  private pendingExitPhase: WorkerExitPhase | null = null
 
   get isLoaded(): boolean {
     return this.loaded
@@ -216,6 +222,11 @@ class EmbeddingModelBridge {
 
     await new Promise<void>((resolve) => {
       const timeout = setTimeout(() => {
+        // The worker ignored the graceful shutdown and wedged — this is the
+        // onnxruntime-dispose failure mode this telemetry exists to catch. Latch
+        // the phase before killing: the kill's 'exit' races (and loses to) the
+        // `shuttingDown = false` reset below.
+        this.pendingExitPhase = 'idle_shutdown'
         activeProcess.kill()
         resolve()
       }, SHUTDOWN_TIMEOUT_MS)
@@ -234,6 +245,11 @@ class EmbeddingModelBridge {
   reset(): void {
     this.shuttingDown = true
     this.clearIdleShutdown()
+    // Same force-kill race as stop(): latch the phase so the kill's async 'exit'
+    // is attributed to a deliberate teardown, not a spontaneous `idle` death.
+    if (this.process) {
+      this.pendingExitPhase = 'idle_shutdown'
+    }
     this.process?.kill()
     this.process = null
     this.readyPromise = null
@@ -264,6 +280,8 @@ class EmbeddingModelBridge {
     })
 
     this.process = child
+    // A fresh worker must never inherit a force-kill phase latched for a prior one.
+    this.pendingExitPhase = null
     child.stdout?.on('data', (chunk: Buffer | string) => {
       const output = chunk.toString().trim()
       if (output) {
@@ -314,7 +332,14 @@ class EmbeddingModelBridge {
 
       const onExitBeforeReady = (code: number): void => {
         cleanup()
-        this.trackWorkerExit('starting', code)
+        const forcedPhase = this.pendingExitPhase
+        this.pendingExitPhase = null
+        // A clean exit during shutdown is lifecycle, not a fault (mirrors the
+        // ready-state guard below). Without this, quitting the app mid-bootstrap
+        // emits a spurious error-level worker_exit_starting with exit code 0.
+        if (!(forcedPhase === null && this.shuttingDown && code === 0)) {
+          this.trackWorkerExit(forcedPhase ?? 'starting', code)
+        }
         const error = new Error(`Embedding utility exited unexpectedly (code ${code})`)
         this.failProcess(error)
         reject(error)
@@ -368,7 +393,14 @@ class EmbeddingModelBridge {
     })
 
     child.on('exit', (code: number) => {
-      if (this.shuttingDown && code === 0) {
+      const forcedPhase = this.pendingExitPhase
+      this.pendingExitPhase = null
+
+      // A clean, graceful shutdown (the worker exited 0 on its own after the
+      // shutdown message) is lifecycle, not a fault. A forced kill (forcedPhase
+      // set) is a teardown death worth measuring even though shuttingDown may
+      // already be cleared by the time its async 'exit' lands.
+      if (forcedPhase === null && this.shuttingDown && code === 0) {
         this.process = null
         this.readyPromise = null
         return
@@ -376,7 +408,7 @@ class EmbeddingModelBridge {
 
       // Phase must be read before failProcess(), which rejects and clears the
       // pending requests this classification depends on.
-      this.trackWorkerExit(this.currentPhase(), code)
+      this.trackWorkerExit(forcedPhase ?? this.currentPhase(), code)
       const error = new Error(`Embedding utility exited unexpectedly (code ${code})`)
       this.failProcess(error)
     })

--- a/apps/desktop/src/main/lib/embeddings.ts
+++ b/apps/desktop/src/main/lib/embeddings.ts
@@ -19,8 +19,18 @@ import type {
 } from './embedding-model-protocol'
 import { EMBEDDING_DIMENSION } from './embeddings-constants'
 import { createLogger } from './logger'
+import { trackMainLog } from '../telemetry/diagnostics'
+import { shouldEmitThrottled } from '../telemetry/throttle'
 
 const logger = createLogger('Embeddings')
+
+/**
+ * Where the worker was in its lifecycle when it died. This is the discriminator
+ * production is missing: an `idle_shutdown` death costs the user nothing (the
+ * embedding was already delivered), while `in_flight` means they silently lost
+ * semantic-search indexing for that note.
+ */
+type WorkerExitPhase = 'starting' | 'in_flight' | 'idle_shutdown' | 'idle'
 
 export interface ModelInfo {
   name: string
@@ -172,6 +182,17 @@ class EmbeddingModelBridge {
       this.loading = false
       this.error = error instanceof Error ? error.message : String(error)
       logger.error('Generation failed:', error)
+      // Until now this failure only ever reached electron-log, so a user
+      // silently losing semantic-search indexing was invisible to us. Throttled
+      // because a broken worker fails once per note edit; we need the yes/no,
+      // not the volume (worker_exit_* above carries the true cadence).
+      if (shouldEmitThrottled('embeddings:embed_failed')) {
+        trackMainLog('error', {
+          scope: 'Embeddings',
+          action: 'embed_failed',
+          errorCode: error instanceof Error && error.name ? error.name : 'UnknownError'
+        })
+      }
       return null
     }
   }
@@ -293,6 +314,7 @@ class EmbeddingModelBridge {
 
       const onExitBeforeReady = (code: number): void => {
         cleanup()
+        this.trackWorkerExit('starting', code)
         const error = new Error(`Embedding utility exited unexpectedly (code ${code})`)
         this.failProcess(error)
         reject(error)
@@ -352,8 +374,31 @@ class EmbeddingModelBridge {
         return
       }
 
+      // Phase must be read before failProcess(), which rejects and clears the
+      // pending requests this classification depends on.
+      this.trackWorkerExit(this.currentPhase(), code)
       const error = new Error(`Embedding utility exited unexpectedly (code ${code})`)
       this.failProcess(error)
+    })
+  }
+
+  private currentPhase(): WorkerExitPhase {
+    if (this.shuttingDown) return 'idle_shutdown'
+    if (this.pendingRequests.size > 0) return 'in_flight'
+    return 'idle'
+  }
+
+  /**
+   * Deliberately NOT throttled: the crash cadence (one install saw ~15/hour at
+   * 30s-2min intervals) is itself the diagnostic signal, and losing it would
+   * make the rate look lower than it is.
+   */
+  private trackWorkerExit(phase: WorkerExitPhase, code: number): void {
+    trackMainLog('error', {
+      scope: 'Embeddings',
+      action: `worker_exit_${phase}`,
+      errorCode: 'EmbeddingWorkerExit',
+      metrics: { value: code }
     })
   }
 

--- a/apps/desktop/src/main/telemetry/diagnostics.test.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.test.ts
@@ -115,28 +115,44 @@ describe('telemetry diagnostics', () => {
       expect(code).toBeNull()
     })
 
-    it('builds a composite type:reason:serviceName code for real faults', () => {
-      // #given a utility worker that actually crashed
+    it('names the crashed worker from details.name, not the constant mojo serviceName', () => {
+      // #given exactly what Electron sends in production: the fork's `serviceName`
+      // option lands in details.name, while details.serviceName is the mojo
+      // interface name — a constant, identical for all four of our forks.
       const code = childProcessGoneErrorCode({
         type: 'Utility',
         reason: 'crashed',
-        serviceName: 'Embeddings'
+        serviceName: 'node.mojom.NodeService',
+        name: 'Embeddings',
+        exitCode: 11
       })
 
-      // #then the code is diagnosable and passes the safe-token rules
+      // #then the code names the worker we can act on
       expect(code).toBe('Utility:crashed:Embeddings')
     })
 
-    it('handles processes without a serviceName', () => {
+    it('falls back to serviceName when name is absent', () => {
+      // #given a process Electron reports without a `name`
+      const code = childProcessGoneErrorCode({
+        type: 'Utility',
+        reason: 'crashed',
+        serviceName: 'Network Service'
+      })
+
+      // #then serviceName still identifies it rather than leaving the code empty
+      expect(code).toBe('Utility:crashed:Network_Service')
+    })
+
+    it('handles processes without a name or serviceName', () => {
       const code = childProcessGoneErrorCode({ type: 'GPU', reason: 'abnormal-exit' })
       expect(code).toBe('GPU:abnormal-exit:')
     })
 
-    it('sanitizes unsafe serviceName characters', () => {
+    it('sanitizes unsafe name characters', () => {
       const code = childProcessGoneErrorCode({
         type: 'Utility',
         reason: 'crashed',
-        serviceName: 'node service (v2)'
+        name: 'node service (v2)'
       })
       expect(code).toBe('Utility:crashed:node_service__v2_')
     })
@@ -144,12 +160,27 @@ describe('telemetry diagnostics', () => {
 
   describe('trackChildProcessGone', () => {
     it('emits no telemetry for a clean idle-worker exit', () => {
-      trackChildProcessGone({ type: 'Utility', reason: 'clean-exit', serviceName: 'Embeddings' })
+      trackChildProcessGone({
+        type: 'Utility',
+        reason: 'clean-exit',
+        serviceName: 'node.mojom.NodeService',
+        name: 'Embeddings',
+        exitCode: 0
+      })
       expect(trackMainEventMock).not.toHaveBeenCalled()
     })
 
-    it('emits an error log event with a composite code for a real fault', () => {
-      trackChildProcessGone({ type: 'Utility', reason: 'crashed', serviceName: 'Embeddings' })
+    it('names the worker and carries the exit signal for a real production crash', () => {
+      // #given the exact production payload behind `Utility:crashed:node.mojom.NodeService`
+      trackChildProcessGone({
+        type: 'Utility',
+        reason: 'crashed',
+        serviceName: 'node.mojom.NodeService',
+        name: 'Embeddings',
+        exitCode: 11
+      })
+
+      // #then Grafana can group by worker, and exitCode carries the signal (11 = SIGSEGV)
       expect(trackMainEventMock).toHaveBeenCalledWith('app_log_recorded', {
         surface: 'app',
         action: 'error',
@@ -157,7 +188,8 @@ describe('telemetry diagnostics', () => {
         source: 'Electron',
         result: 'failed',
         errorCode: 'Utility:crashed:Embeddings',
-        dimensions: { log_action: 'child_process_gone' }
+        dimensions: { log_action: 'child_process_gone' },
+        metrics: { value: 11 }
       })
     })
   })

--- a/apps/desktop/src/main/telemetry/diagnostics.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.ts
@@ -34,33 +34,44 @@ const toErrorCode = (error: unknown): string => {
 const resultForLevel = (level: DiagnosticLevel): TelemetryResult =>
   level === 'error' || level === 'warn' ? 'failed' : 'success'
 
+export interface ChildProcessGoneDetails {
+  type: string
+  reason: string
+  // The MOJO interface name. Constant by construction — every utilityProcess
+  // fork reports 'node.mojom.NodeService', so it cannot tell our workers apart.
+  serviceName?: string
+  // Where Electron actually routes the fork's `serviceName` OPTION, i.e. our
+  // 'Embeddings' / 'ImageProcessing' / 'VoiceTranscription' labels. A fork that
+  // passes no option (crdt-preflight) reports the default 'Node Utility Process'.
+  name?: string
+  // Platform exit status: on POSIX this carries the signal (11 SIGSEGV, 6 SIGABRT).
+  exitCode?: number
+}
+
 // Utility workers (embeddings, image-processing, voice-model) idle-shutdown
 // cleanly after ~30s; a clean exit is lifecycle, not a fault, so it must not
 // become an error event. Real faults get a composite code that stays inside
 // the safe-token rules (no '@', '://', '/', '\', ≤64 chars).
-export const childProcessGoneErrorCode = (details: {
-  type: string
-  reason: string
-  serviceName?: string
-}): string | null => {
+export const childProcessGoneErrorCode = (details: ChildProcessGoneDetails): string | null => {
   if (details.reason === 'clean-exit') return null
-  return toSafeToken(
-    `${details.type}:${details.reason}:${details.serviceName ?? ''}`,
-    'ChildProcessGone'
-  )
+  const worker = details.name ?? details.serviceName ?? ''
+  return toSafeToken(`${details.type}:${details.reason}:${worker}`, 'ChildProcessGone')
 }
 
 // Reports a `child-process-gone` fault as an error log event, or nothing at all
 // for a clean idle-worker exit. Kept here (not inline in index.ts) so the
 // skip decision is unit-tested rather than living in the untested bootstrap.
-export const trackChildProcessGone = (details: {
-  type: string
-  reason: string
-  serviceName?: string
-}): void => {
+export const trackChildProcessGone = (details: ChildProcessGoneDetails): void => {
   const errorCode = childProcessGoneErrorCode(details)
   if (!errorCode) return
-  trackMainLog('error', { scope: 'Electron', action: 'child_process_gone', errorCode })
+  // errorCode stays stable (no exit code baked in) so Grafana can count crashes
+  // per worker; the exit status rides along as a metric instead.
+  trackMainLog('error', {
+    scope: 'Electron',
+    action: 'child_process_gone',
+    errorCode,
+    metrics: typeof details.exitCode === 'number' ? { value: details.exitCode } : undefined
+  })
 }
 
 export const trackMainError = (source: string, action: string, error: unknown): void => {
@@ -81,7 +92,13 @@ export const trackMainLog = (
     scope: string
     action: string
     errorCode?: string
-    metrics?: { durationMs?: number; itemCount?: number; queueCount?: number; retryCount?: number }
+    metrics?: {
+      durationMs?: number
+      itemCount?: number
+      queueCount?: number
+      retryCount?: number
+      value?: number
+    }
   }
 ): void => {
   const eventOptions: TrackMainEventOptions = {

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -202,14 +202,31 @@ Loki adds the diagnostic detail (stacks, operational messages) that AE rows deli
 - **Desktop errors**: `/telemetry/batch` events carrying an `errorCode` or `error` detail are
   forwarded as `app="desktop"` lines containing the event name, error code, surface/action/source,
   app version, platform, the **redacted stack frames only** (the schema has no message field —
-  messages can embed note content; see Error Reporting above), and `log_action` — the operational
+  messages can embed note content; see Error Reporting above), `log_action` — the operational
   breadcrumb that keeps log-type error events (which carry no stack of their own) identifiable in
-  Grafana.
+  Grafana — and `exit_code`, the platform exit status for process-lifecycle events (empty string
+  when absent, since exit code `0` is itself meaningful). Labels stay low-cardinality
+  (`app`/`env`/`level`) — everything else lives inside the JSON line.
 - **Process lifecycle**: the main process reports a `child-process-gone` fault with a composite
-  `type:reason:serviceName` error code (e.g. `Utility:crashed:Embeddings`). A utility worker's
-  clean idle-shutdown (embeddings, image-processing, voice-model each exit after ~30s idle) is a
-  lifecycle event, not a fault, so a `clean-exit` reason is skipped entirely — only a real fault
-  produces an error event, mirroring the GPU crash guard.
+  `type:reason:name` error code (e.g. `Utility:crashed:Embeddings`). The worker label comes from
+  Electron's `details.name`, **not** `details.serviceName`: Electron routes a fork's `serviceName`
+  _option_ to `details.name`, while `details.serviceName` holds the Mojo interface name — a
+  constant (`node.mojom.NodeService`) that is identical for every utility fork and so cannot tell
+  our workers apart. A fork that passes no `serviceName` option reports the default
+  `Node Utility Process`. The exit status rides along in the line's `exit_code` field rather than
+  inside the error code, so crashes still group by worker in Grafana while the POSIX signal
+  (11 SIGSEGV, 6 SIGABRT) stays visible. A utility worker's clean idle-shutdown (embeddings,
+  image-processing, voice-model each exit after ~30s idle) is a lifecycle event, not a fault, so a
+  `clean-exit` reason is skipped entirely — only a real fault produces an error event, mirroring
+  the GPU crash guard. Note that `child_process_gone` is **not** throttled: the crash cadence is
+  itself a diagnostic signal.
+- **Embedding worker**: the embeddings bridge reports its own non-clean worker exits under
+  `source="Embeddings"` with a `worker_exit_<phase>` breadcrumb, where phase is `starting`,
+  `in_flight`, `idle_shutdown`, or `idle`. This is what separates a harmless teardown crash
+  (`idle_shutdown` — the embedding was already delivered) from real user impact (`in_flight` — the
+  user silently lost semantic-search indexing for that note). Embedding generation failures emit
+  `embed_failed`, throttled to one event per 5-minute window because a broken worker would
+  otherwise fail once per note edit.
 - **Desktop IPC envelopes**: every `{ success: false }` error envelope produced by the IPC layer
   (`withErrorHandler` / `withDb`) also emits an `app_error_seen` event, throttled in-memory to one
   event per error code per minute so an error loop can't flood the telemetry queue. The expected

--- a/apps/sync-server/src/services/loki.test.ts
+++ b/apps/sync-server/src/services/loki.test.ts
@@ -137,7 +137,8 @@ describe('desktopErrorEntry', () => {
       stack: 'at doThing (app://bundle.js:1:2)',
       component_stack: 'at NoteEditor',
       install_hash: 'hash123',
-      log_action: ''
+      log_action: '',
+      exit_code: ''
     })
     expect(Object.keys(result.line)).not.toContain('message')
   })
@@ -154,5 +155,26 @@ describe('desktopErrorEntry', () => {
     const result = desktopErrorEntry(batch, logEvent, 'hash123')
     expect(result.line.log_action).toBe('child_process_gone')
     expect(result.line.error_code).toBe('Utility:crashed:Embeddings')
+  })
+
+  it('carries the child-process exit code so the crash signal is visible in Grafana', () => {
+    // #given a utility crash reported with a POSIX signal status (11 = SIGSEGV)
+    const crashEvent: TelemetryEvent = {
+      ...event,
+      name: 'app_log_recorded',
+      action: 'error',
+      errorCode: 'Utility:crashed:Embeddings',
+      dimensions: { log_action: 'child_process_gone' },
+      metrics: { value: 11 },
+      error: undefined
+    }
+    const result = desktopErrorEntry(batch, crashEvent, 'hash123')
+    expect(result.line.exit_code).toBe(11)
+  })
+
+  it('leaves exit_code empty for events that carry no exit status', () => {
+    // #given exit code 0 is meaningful, so the empty case must not collapse to 0
+    const result = desktopErrorEntry(batch, event, 'hash123')
+    expect(result.line.exit_code).toBe('')
   })
 })

--- a/apps/sync-server/src/services/loki.ts
+++ b/apps/sync-server/src/services/loki.ts
@@ -68,6 +68,10 @@ export const desktopErrorEntry = (
     install_hash: installHash,
     // Log-type error events (app_log_recorded) have no stack; log_action is
     // what makes them identifiable in Grafana (e.g. child_process_gone).
-    log_action: event.dimensions?.log_action ?? ''
+    log_action: event.dimensions?.log_action ?? '',
+    // child_process_gone carries the platform exit status here (POSIX signal:
+    // 11 SIGSEGV, 6 SIGABRT). Kept out of error_code so crashes still group by
+    // worker. Empty string (not 0) when absent — exit code 0 is meaningful.
+    exit_code: event.metrics?.value ?? ''
   }
 })


### PR DESCRIPTION
## Update — adversarial review BLOCKINGs resolved

The `needs-work` review below has been addressed in this branch (TDD, each new test verified red on the pre-fix code):

- **[1] stop() force-kill phase race** — a wedged worker force-killed at the 3s shutdown timeout was misreported as `worker_exit_idle` ("died doing nothing") because `shuttingDown` was cleared in a microtask before the kill's async `exit`. Now the phase is **latched** (`pendingExitPhase`) before `kill()`, so the teardown death correctly reads `worker_exit_idle_shutdown`. Same latch applied to `reset()` (nit [3]).
- **[2] mock kill was a no-op** — `MockUtilityProcess.kill()` now delivers `exit` as a later macrotask (opt-in via `killExitCode`), so the force-kill / reset exit paths are actually exercised. New tests: force-kill teardown → `idle_shutdown`, reset force-kill → `idle_shutdown`.
- **[3] onExitBeforeReady clean-exit guard** — a clean exit (code 0) during shutdown of a still-bootstrapping worker no longer emits a spurious error-level `worker_exit_starting`. New tests cover both the clean-shutdown-silence and the genuine bootstrap-crash paths.
- **[4] false throttle claim** — corrected below; `shouldEmitThrottled` already had two production callers.

Verification: `test:main` green (embeddings + diagnostics targeted: 29 passed), and each blocking test confirmed **red on the pre-fix source, green after**.

---

## Production evidence

`Utility:crashed:node.mojom.NodeService` fired **66 times in 2 days** — our highest-volume error. 9 of 18 active installs (50%) hit it in 2 days; 19 of 30 (63%) on 2026.710.3 over 5 days. darwin + win32. Not once-per-start: one darwin install crashed ~15 times in an hour at 30s–2min intervals.

These are real crash-signal deaths, not lifecycle noise. All four `utilityProcess` forks shut down via `process.exit(0)` → Chromium reports `clean-exit`, already skipped. No normal-lifecycle path can produce `crashed`. (#733 assumed clean-exit noise and filtered it; the remaining volume is real.)

**We were throwing away the discriminator.** All four forks report `details.serviceName === 'node.mojom.NodeService'` — the Mojo interface name, constant by construction. Electron routes a fork's `serviceName` **option** to `details.name`, not `details.serviceName`. Verified in `electron@39.8.6/electron.d.ts`:

- `:20396` `exitCode` — "The exit code for the process (status from waitpid on POSIX)"
- `:20400` `serviceName?` — "The **non-localized** name of the process"
- `:20402` `name?` — "The name of the process"
- `:20722-20726` fork option — "Name of the process that will appear in `name` property … and `child-process-gone` event of `app`. Default is `Node Utility Process`."

`childProcessGoneErrorCode` read `details.serviceName` and never `details.name`. The discriminator was present on all 66 events and discarded, along with `exitCode` (which carries the signal).

The unit test passed only because the fixture was hand-made (`{ serviceName: 'Embeddings' }`). Production's `node.mojom.NodeService` proves the fixture wrong.

## The fix — make it visible, don't guess

We are blind, so this PR deliberately does **not** attempt the speculative onnxruntime fix. It makes the next 2 days of production data name the worker and settle teardown-vs-inference.

1. **`childProcessGoneErrorCode`** uses `details.name`, falling back to `serviceName`, then the existing `'ChildProcessGone'` literal so the code is never empty. Clean-exit skip and safe-token rules (no `@`, `://`, `/`, `\`, ≤64 chars) unchanged. This alone attributes **all four** workers — including crdt-preflight, which passes no option and will surface as the default `Node Utility Process`.
2. **`exitCode` → Loki line field `exit_code`** (`desktopErrorEntry`). Kept *out* of `error_code` so crashes still group by worker in Grafana rather than fragmenting per signal. Empty string (not `0`) when absent — exit code 0 is meaningful.
3. **Worker-phase telemetry** in the embeddings bridge: non-clean exits emit `worker_exit_<starting|in_flight|idle_shutdown|idle>` under `source="Embeddings"`. This is the teardown-vs-in-flight answer. Phase is read *before* `failProcess()`, which rejects and clears the pending requests the classification depends on. Not throttled — the cadence is the signal.
4. **Embedding failures reach telemetry.** `embed`'s catch previously did `logger.error` + `return null`, so Loki had **no `Embeddings` source at all** (confirmed across 14 days) and silent loss of semantic-search indexing was unmeasurable. Now emits `embed_failed`, throttled via the existing `shouldEmitThrottled` (5 min) because a broken worker fails once per note edit — we need the yes/no, not the volume.

Privacy model kept: desktop lines carry only codes/dimensions/metrics, never a message field.

### Design note — a constraint the plan didn't account for

`TelemetryDimensionsSchema` (`packages/contracts/src/telemetry-api.ts:85-89`) caps events at **one** dimension, and `log_action` already occupies that slot. So `worker_phase` could not be added as a second dimension without a contract change. Rather than relax a deliberate privacy/cardinality guard for a diagnostics PR, this works within the existing contract: phase rides in the existing `log_action` slot (`worker_exit_idle_shutdown`), exit code rides in `metrics.value` (already `z.number().finite().optional()`). **No contract change, no new event names, no schema migration.** Worth a look during review.

## Throttling finding (asked for explicitly)

**`child_process_gone` passes through no throttle at all.** `trackChildProcessGone` → `trackMainLog` → `trackMainEvent` → `runtime.track`; none throttle. `trackIpcError`'s 60s Map in `ipc/validate.ts` is keyed by `error.name` but is scoped to IPC envelope errors only and never sees this path. **So the 66 events are the true rate, not an understatement.**

Separately: `apps/desktop/src/main/telemetry/throttle.ts`'s `shouldEmitThrottled` **already has two production callers on `main`** — `notes-handlers.ts:279` (`note_updated:<id>`) and `journal-handlers.ts:276` (`journal_updated:<date>`). `embed_failed` is an **additional, consistent** use, not its first. (An earlier draft of this body claimed the helper had no production callers; that was wrong and is corrected here — see adversarial review BLOCKING [4].) Not deleting or refactoring anything pre-existing; flagging only.

## Compat / migration plan

**No migration required.** No DB schema, no sync protocol, no IPC contract, no vault format, no settings shape touched.

- **Contracts**: unchanged. `metrics.value` and the single `log_action` dimension already exist and already validate.
- **Server ← older desktops**: `exit_code` reads `event.metrics?.value ?? ''`. Older clients send no `metrics` on this event → `exit_code: ''`. Existing behavior preserved.
- **Server ← newer desktops**: `metrics: { value }` already passes `TelemetryBatchSchema` on the *current deployed* server, so ordering is not load-bearing here. Deploying the server first is still the safer default, and it only *adds* a line field.
- **Grafana**: `error_code` values change from `Utility:crashed:node.mojom.NodeService` to `Utility:crashed:<Worker>`. Intended — that is the fix — but any saved query pinned to the old literal will stop matching. Labels stay `app`/`env`/`level`; no new stream label, so no cardinality change.

## Verification actually run

| Check | Result |
|---|---|
| `pnpm --filter @memry/desktop test:main` | **343 files / 3499 passed, 1 skipped, 0 failed** |
| `apps/sync-server` `npx vitest run src/services/loki.test.ts src/routes/telemetry.test.ts` | **22 passed** |
| `pnpm typecheck` | **exit 0** |
| `pnpm lint` | **0 errors** (3 pre-existing `no-base-to-string` warnings in `frontmatter.ts` / `crdt-writeback.ts` — untouched files) |
| `pnpm docs:impact --base <merge-base> --strict` | **covered** |
| `pnpm docs:build` | **exit 0** |

### TDD — the failure observed first

The production-shaped test reproduces the Loki string verbatim before any fix:

```
FAIL src/main/telemetry/diagnostics.test.ts > childProcessGoneErrorCode >
  names the crashed worker from details.name, not the constant mojo serviceName
AssertionError: expected 'Utility:crashed:node.mojom.NodeService' to be 'Utility:crashed:Embeddings'

Expected: "Utility:crashed:Embeddings"
Received: "Utility:crashed:node.mojom.NodeService"
```

`Received` is exactly the string production has been emitting 66 times. The `trackChildProcessGone` test failed the same way plus a missing `metrics: { value: 11 }`; the Loki tests failed on the absent `exit_code`; the embeddings phase tests failed with `Number of calls: 0`. All then went green. The clean-exit skip tests stayed green throughout (the clean-shutdown guard passes vacuously pre-implementation and still passes after — that is its job).

The `diagnostics.test.ts` fixture is fixed to send what Electron actually sends (`serviceName: 'node.mojom.NodeService'` + `name: 'Embeddings'` + `exitCode`), so it can no longer pass while production is broken.

### Environment note

The worktree's Electron install was broken (`dist/Electron.app` present, `path.txt` empty → "Electron failed to install correctly"), failing 30 suites on import. **Proven pre-existing**: `git stash` + re-run reproduced the identical 11 failures on a clean tree. Repaired locally by writing `path.txt`; after that the full main suite is green. No repo files were changed for this — it is a local `node_modules` artifact.

## What I could NOT verify

- **No live Electron run.** Everything here is unit-level. The claim that Electron populates `details.name` with our fork's `serviceName` option is verified against `electron.d.ts` (the option doc is explicit) and against production data (all 66 events carry the constant Mojo name in `serviceName`), **but I did not observe a real `child-process-gone` payload at runtime.** If Electron were to leave `name` undefined on some platform, the code falls back to `serviceName` and we are no worse off than today — the fallback is the safety net for exactly this.
- **The hypothesis itself is untested.** This PR does not fix the crash and does not confirm the onnxruntime-teardown theory. It instruments it. Reassess when data lands.
- **Only embeddings got phase/failure telemetry.** image-processing and voice-model are covered by the attribution fix (item 1) but not by items 3–4. Deliberate: item 1 names the worker first; if the data points at voice or image-processing, add depth there rather than pre-building it blind. `image-processing` shells out via `execFile`, making it a weak suspect anyway.
- **Windows exit codes** may be large unsigned values (e.g. `0xC0000005`); they satisfy `z.number().finite()` and will pass through, but I have not seen a real win32 payload.

---

# Context for reviewers

## Where this came from

This PR is one of 8 opened from a **2-day production error-log triage** (2026-07-13 → 07-15, Grafana `/d/memry-logs`, `env=production`, Loki on the VPS).

The whole window held only **161 log lines** — 90 desktop errors, 27 server errors, 44 server warns — across **13 distinct installs**. Cloudflare Analytics Engine gives the denominator: **18 active installs** in those 2 days, **30** over 5 days.

Two things made this triage possible at all, and both are recent:
- **#732** (merged 2026-07-10) fixed `detectBuildChannel` falling back to `process.env.NODE_ENV`, which is undefined in packaged Electron. Before it, every packaged install reported `build_channel="development"` **and** defaulted telemetry OFF. Every desktop line in this window now reads `build_channel=production` on `2026.710.3` — so we are finally seeing real users.
- **#733** (merged 2026-07-10) stopped clean utility-worker exits from firing error events, so what remains is signal.

Low line counts here mean **low telemetry volume, not low impact**. The headline finding of the whole triage — a 58-day, 100%-broken attachment upload — was exposed by exactly **2 log lines**.

## How these PRs were produced

Each production error class was root-caused by a dedicated investigation against the real code before any patch was written, then implemented TDD-first in an isolated worktree, then put through an **adversarial review** whose explicit brief was to find what is wrong rather than to approve.

That review stage earned its keep: **6 of 8 PRs came back `needs-work`**, several with defects that would have merged silently. Its findings are reproduced verbatim below — they are not cosmetic.

**The one question that matters most on every one of these PRs:** *would the new tests actually fail on the base branch?* The 58-day attachment outage survived because both the server suite (R2/D1 fully mocked, self-consistent fixtures like `total_size: 10` with raw bytes) and the desktop suite (`fetch` mocked wholesale) passed green while the seam between them was never exercised. A test that mocks the thing under test proves nothing. Some of these PRs repeated that exact mistake and the reviewer caught it.

## This PR: production evidence

`Utility:crashed:node.mojom.NodeService` — **66 events in 2 days, our single highest-volume error.**

- **9 of 18 active installs (50%)** hit it in 2 days. On `2026.710.3` over 5 days: **19 of 30 active installs (63%)**.
- Cadence is **not** once-per-app-start: one darwin install crashed ~15 times in a single hour, at 30s–2min intervals, repeatedly across days. Both darwin and win32. Plus 1 linux `Utility:abnormal-exit`.

**These are real crash-signal deaths, not lifecycle noise.** All 4 `utilityProcess` forks shut down gracefully via `process.exit(0)` → `clean-exit` (already dropped at `diagnostics.ts:47`); the only raw `kill()` paths report `killed`. **No path in the normal lifecycle can produce `crashed`.** Note that #733 assumed clean-exit noise was the cause and filtered it — production says the remaining volume is real. Do not re-close this as noise.

**We threw away the discriminator.** All 4 forks report `details.serviceName === 'node.mojom.NodeService'` — the Mojo interface name, constant by construction. Electron routes the fork's `serviceName` **option** to `details.name`, not `details.serviceName` (`electron.d.ts:20400-20405` and the fork-option doc at `:20722-20726`). Our code read `serviceName` and never `name`. The discriminator was present on all 66 events and we discarded it. `details.exitCode` (which carries the signal) was dropped too. The unit test passed only because the fixture was hand-made (`{serviceName: 'Embeddings'}`) — production's constant Mojo name proves the fixture was the lie.

## Why this PR does NOT attempt the real fix

Leading hypothesis (medium confidence): the **embeddings** worker (onnxruntime via `@huggingface/transformers`) crashing during its 30s-idle `process.exit(0)` **teardown**. It fits — the 30s idle timer matches the cadence, AI is default-ON, and it is the only on-demand worker with a heavy in-process native addon (image-processing shells out via `execFile`). crdt-preflight is ruled out on volume (latched, max 2 forks per init), though the single linux `abnormal-exit` fits its `exit(1)` path exactly.

But **we cannot measure user impact, and that is itself the gap**: if the crash is at teardown (after the embedding was delivered) impact is ~zero and this is cosmetic; if it is during inference, users **silently lose semantic-search indexing**. We cannot tell, because embeddings failures never reach telemetry — `generateEmbedding`'s catch does `logger.error` and returns null, and Loki has **no `Embeddings` source across 14 days**.

So the deliberate decision was: **do not write a big fix blind.** Make it visible precisely and cheaply — name the worker, capture the exit code, and record whether the process died at idle-shutdown or with work in flight — so the next 2 days of production data settle teardown-vs-inference and the real fix can be aimed. That is the entire deliverable.

## Adversarial review findings (verbatim)

> Reproduced exactly as returned. Findings cite file:line — verify them yourself rather than trusting either the author or the reviewer.

VERDICT: needs-work

## TESTS ARE REAL?
YES for the headline fix — I convinced myself each new test fails on the old code, by tracing rather than trusting. (1) diagnostics.test.ts:131 — old code computes `${type}:${reason}:${serviceName ?? ''}` = 'Utility:crashed:node.mojom.NodeService' against an expected 'Utility:crashed:Embeddings'; deterministic fail. The trackChildProcessGone test also asserts `metrics: { value: 11 }`, which old code never passed. (2) loki.test.ts — `exit_code` did not exist on the line, so `result.line.exit_code` was undefined != 11; deterministic fail. (3) embeddings.test.ts — trackMainLog was called zero times on old code; deterministic fail. Critically, these are NOT self-consistent mocks: embeddings.test.ts mocks the telemetry SINK and the utilityProcess DEPENDENCY while driving the real exit-handler classification, and the diagnostics fixture is corroborated by two sources independent of the code (electron.d.ts:20396-20402 + the fork-option doc at :20722-20726, which I read myself, and the 66 production events showing the constant Mojo name). The OLD fixture was the lie, and production disproved it. THE GAP: MockUtilityProcess.kill() (embeddings.test.ts:19) never emits 'exit', so the suite cannot reach the force-kill or reset() paths where the phase misattribution lives. The tests are honest about what they cover but blind to exactly the code this PR adds most risk to. Also unverifiable by unit test and openly disclosed by the author: no live Electron run ever confirmed details.name is populated — mitigated by the `details.name ?? details.serviceName` fallback, which is no worse than today.

## BLOCKING

### [1]
embeddings.ts:217-231 — the shutdown force-kill path misattributes the phase, corrupting the exact bucket this PR exists to measure. In stop(), the 3s SHUTDOWN_TIMEOUT_MS timer calls activeProcess.kill() then resolve(); the await continuation sets `this.shuttingDown = false` (line 231) in a MICROTASK, while the killed process's 'exit' event arrives in a later MACROTASK. So by the time the line 370 handler runs, shuttingDown is already false and pendingRequests is empty -> currentPhase() returns 'idle', not 'idle_shutdown'. A worker that WEDGES during teardown (a very plausible onnxruntime-dispose failure mode — the actual hypothesis under investigation) gets force-killed and reported as `worker_exit_idle`, i.e. 'died spontaneously doing nothing'. That is the most misleading possible bucket for whoever reads this dashboard in 2 days. Fix: capture the phase before resolve(), or don't clear shuttingDown until after 'exit'.

### [2]
embeddings.test.ts:19 — `kill = vi.fn().mockReturnValue(true)` is a no-op stub that never emits 'exit', whereas the real utilityProcess.kill() always causes an 'exit' event. Every kill-driven exit path is therefore structurally untestable by this suite — which is precisely where both attribution bugs live. This is the same failure shape that let the headline bug survive 58 days: the mock cannot express the behavior that breaks. Add a test where kill() emits 'exit' and assert the phase is `idle_shutdown`, not `idle`.

### [3]
embeddings.ts:315-321 — `onExitBeforeReady` calls trackWorkerExit('starting', code) with NO clean-exit guard, unlike the carefully-guarded line 371 (`if (this.shuttingDown && code === 0)`). If stop() runs while the worker is still bootstrapping (app quit during the fork->'ready' window), the worker exits 0 cleanly and this emits an `error`-level `worker_exit_starting` with exit_code 0. This violates the invariant diagnostics.ts:57 exists to enforce — a clean exit is lifecycle, not a fault — and pollutes the very dashboard being built. The author's own summary claims 'non-clean worker exits emit worker_exit_*', which is not what this path does.

### [4]
PR body contains a false codebase claim (report 'THROTTLE FINDING' + risk item 7): 'telemetry/throttle.ts exported shouldEmitThrottled with NO production callers (dead outside its own test) — this PR is its first real use.' That is wrong. origin/main has two production callers: notes-handlers.ts:279 (`shouldEmitThrottled(`note_updated:${note.id}`)`) and journal-handlers.ts:276 (`shouldEmitThrottled(`journal_updated:${entry.date}`)`). No code consequence (reusing the helper is correct and consistent with existing usage), but the assertion was offered as a considered finding without being checked, and it misdirects the proposed follow-up PR. Correct the body before merge.

## NITS

- [1] loki.ts:75 — `exit_code: event.metrics?.value ?? ''` sources a Grafana field named `exit_code` from the GENERIC contract field `metrics.value` (telemetry-api.ts: `value: z.number().finite().optional()`). Today this is safe (I grepped: the only desktop writers of metrics.value are trackChildProcessGone and embeddings.ts:401, both genuine exit codes), but any future event that uses metrics.value for something else will silently have its number rendered as `exit_code`. Consider a dedicated `exitCode` metric or gating on `log_action`.

- [2] The design deviation is sound and I verified the constraint is real: TelemetryDimensionsSchema does cap at one dimension (`Object.keys(dimensions).length <= 1`) and log_action occupies it, so riding phase in log_action rather than relaxing a privacy/cardinality guard in a diagnostics PR is the right call. metrics.value is `finite()` with no `nonnegative()`, so the Windows 0xC0000005 concern (risk 5) is unfounded — large unsigned and negative codes both validate.

- [3] reset() (embeddings.ts:234-245) has the same synchronous shuttingDown=true->kill()->shuttingDown=false race as stop(), so a reset would report `worker_exit_idle`. Downgraded to a nit because unloadModel()/stopEmbeddingModel() have ZERO production callers (test-only), so it is unreachable today — but worth fixing alongside the stop() bug since it is the same 2-line change.

- [4] Privacy is clean: every new field is either a bounded number (exit codes) or passes toSafeToken (regex strips to [A-Za-z0-9_.:-], caps 64). 'Node Utility Process' -> 'Node_Utility_Process'. No message/path/email/URL added. embed_failed uses error.name only, then toSafeToken again in trackMainLog.

- [5] House rules pass: no Co-Authored-By, no agent/tool branding in branch/commit, no console.*, no renderer or Tailwind code touched, zero packages/contracts changes (so ipc:generate/ipc:check correctly not required). Scope is tight — all 7 files trace to the brief; the trackMainLog `value?: number` widening is necessary, not drive-by. Backward compat holds: server-side `value` already exists on main, so no server-first deploy ordering is required; old clients yield exit_code: ''. Grafana saved-query breakage is real but intended and disclosed.

