### PR TITLE
fix(desktop): guard three renderer/main crash paths

### DIFF
--- a/apps/desktop/src/main/sync/websocket.test.ts
+++ b/apps/desktop/src/main/sync/websocket.test.ts
@@ -270,6 +270,26 @@ describe('WebSocketManager', () => {
     })
   })
 
+  describe('#given a handshake in flight #when disconnect called', () => {
+    it('#then the deferred abort error does not throw out of the socket', async () => {
+      const manager = new WebSocketManager(createMockDeps())
+      await manager.connect()
+      const ws = lastWs()
+      // No simulateOpen(): the socket is still CONNECTING, so terminate() takes
+      // ws's abortHandshake path, which emits 'error' on the NEXT TICK — after
+      // cleanup() has already run. An EventEmitter with no 'error' listener
+      // rethrows the error, which surfaces as a main-process uncaughtException.
+      expect(ws.readyState).toBe(0)
+
+      manager.disconnect()
+
+      expect(ws.terminate).toHaveBeenCalled()
+      expect(() =>
+        ws.emit('error', new Error('WebSocket was closed before the connection was established'))
+      ).not.toThrow()
+    })
+  })
+
   describe('#given WebSocket error #when error occurs', () => {
     it('#then emits error event', async () => {
       const manager = new WebSocketManager(createMockDeps())

--- a/apps/desktop/src/main/sync/websocket.ts
+++ b/apps/desktop/src/main/sync/websocket.ts
@@ -214,6 +214,12 @@ export class WebSocketManager extends EventEmitter {
     this.stopPing()
     if (this.ws) {
       this.ws.removeAllListeners()
+      // terminate() on a CONNECTING socket aborts the in-flight handshake, which
+      // emits 'error' on the NEXT TICK (ws/lib/websocket.js abortHandshake). By
+      // then our listeners are gone, and an EventEmitter with no 'error' listener
+      // rethrows -> main-process uncaughtException. Reordering cannot help: the
+      // emit is deferred either way. This no-op listener must survive. Keep it.
+      this.ws.on('error', () => {})
       if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
         this.ws.terminate()
       }

--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
@@ -6,7 +6,11 @@ import type { GraphFilterState } from '@/hooks/use-graph-filters'
 const graphCanvasMocks = vi.hoisted(() => ({
   sigma: {
     setSetting: vi.fn(),
-    refresh: vi.fn()
+    refresh: vi.fn(),
+    // Sigma retains its graph reference even after kill(). The live instance is
+    // the one holding the graph the container was rendered with; a stale
+    // instance returns something else. Overridden per-test to model the race.
+    getGraph: (): unknown => graphCanvasMocks.sigmaContainerProps?.graph
   },
   sigmaContainerProps: null as null | Record<string, any>,
   layoutStart: vi.fn(),
@@ -203,6 +207,7 @@ describe('GraphCanvas', () => {
     vi.useFakeTimers()
     vi.clearAllMocks()
     graphCanvasMocks.sigmaContainerProps = null
+    graphCanvasMocks.sigma.getGraph = () => graphCanvasMocks.sigmaContainerProps?.graph
     graphCanvasMocks.createNote.mockResolvedValue({
       success: true,
       note: { id: 'created-note', title: 'Created from graph' }
@@ -295,6 +300,27 @@ describe('GraphCanvas', () => {
         isPreview: false
       })
     )
+  })
+
+  it('does not push settings into a sigma instance that does not own our graph', () => {
+    // SigmaContainer kills and recreates Sigma whenever the `graph` prop changes.
+    // React runs child effects before the container's create effect, so useSigma()
+    // can still hand SigmaSettingsSync the OLD, killed instance. kill() empties
+    // nodePrograms but keeps the graph, so pushing settings there schedules a
+    // render that throws on the next frame. Model that by having the instance
+    // report a graph that is not the one we rendered with.
+    graphCanvasMocks.sigma.getGraph = () => ({ stale: true })
+
+    render(
+      <GraphCanvas
+        data={data}
+        filterState={filters}
+        graphSettings={settings}
+        onFocusNode={vi.fn()}
+      />
+    )
+
+    expect(graphCanvasMocks.sigma.setSetting).not.toHaveBeenCalled()
   })
 
   it('syncs sigma settings and starts/stops forceatlas layout', () => {

--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
@@ -323,6 +323,36 @@ describe('GraphCanvas', () => {
     expect(graphCanvasMocks.sigma.setSetting).not.toHaveBeenCalled()
   })
 
+  it('re-applies settings once the committed instance owns our graph (recovery)', () => {
+    // Guard the recovery half of the fix: skipping the stale instance must not
+    // leave settings permanently unapplied. First render sees a foreign instance
+    // (guard bails, nothing pushed); once the container commits the instance that
+    // owns the rendered graph, a later settings change must re-run the effect and
+    // actually apply -- proving the guard skips the zombie without stranding
+    // settings on the live instance (a silent visual regression otherwise).
+    graphCanvasMocks.sigma.getGraph = () => ({ stale: true })
+    const { rerender } = render(
+      <GraphCanvas
+        data={data}
+        filterState={filters}
+        graphSettings={{ ...settings, showLabels: false }}
+        onFocusNode={vi.fn()}
+      />
+    )
+    expect(graphCanvasMocks.sigma.setSetting).not.toHaveBeenCalled()
+
+    graphCanvasMocks.sigma.getGraph = () => graphCanvasMocks.sigmaContainerProps?.graph
+    rerender(
+      <GraphCanvas
+        data={data}
+        filterState={filters}
+        graphSettings={{ ...settings, showLabels: true }}
+        onFocusNode={vi.fn()}
+      />
+    )
+    expect(graphCanvasMocks.sigma.setSetting).toHaveBeenCalledWith('labelRenderedSizeThreshold', 6)
+  })
+
   it('syncs sigma settings and starts/stops forceatlas layout', () => {
     const { rerender, unmount } = render(
       <GraphCanvas

--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx
@@ -239,6 +239,7 @@ export function GraphCanvas({
     <div className="relative h-full w-full">
       <SigmaContainer graph={graph} settings={initialSigmaSettings} className="h-full w-full">
         <SigmaSettingsSync
+          graph={graph}
           nodeReducer={nodeReducer}
           edgeReducer={edgeReducer}
           showLabels={graphSettings.showLabels}
@@ -417,11 +418,13 @@ function HoverFadeAnimator({
 }
 
 function SigmaSettingsSync({
+  graph,
   nodeReducer,
   edgeReducer,
   showLabels,
   labelColor
 }: {
+  graph: Graph
   nodeReducer: (node: string, attrs: Record<string, unknown>) => Partial<NodeDisplayData>
   edgeReducer: (edge: string, attrs: Record<string, unknown>) => Partial<EdgeDisplayData>
   showLabels: boolean
@@ -429,21 +432,33 @@ function SigmaSettingsSync({
 }): null {
   const sigma = useSigma()
 
+  // SigmaContainer kills and recreates Sigma whenever the `graph` prop changes.
+  // React runs child effects before the container's create effect, so useSigma()
+  // can still hand us the OLD, killed instance. kill() empties nodePrograms but
+  // keeps the graph reference, so any setSetting here schedules a refresh+render
+  // that throws on the next frame ("nodePrograms[circle] is undefined"). The live
+  // instance is the one holding the graph we rendered with; skip anything else.
+  // Once the container commits the new Sigma, these effects re-run and apply.
+
   useEffect(() => {
+    if (sigma.getGraph() !== graph) return
     sigma.setSetting('nodeReducer', nodeReducer)
-  }, [sigma, nodeReducer])
+  }, [sigma, graph, nodeReducer])
 
   useEffect(() => {
+    if (sigma.getGraph() !== graph) return
     sigma.setSetting('edgeReducer', edgeReducer)
-  }, [sigma, edgeReducer])
+  }, [sigma, graph, edgeReducer])
 
   useEffect(() => {
+    if (sigma.getGraph() !== graph) return
     sigma.setSetting('labelRenderedSizeThreshold', showLabels ? 6 : Infinity)
-  }, [sigma, showLabels])
+  }, [sigma, graph, showLabels])
 
   useEffect(() => {
+    if (sigma.getGraph() !== graph) return
     sigma.setSetting('labelColor', { color: labelColor })
-  }, [sigma, labelColor])
+  }, [sigma, graph, labelColor])
 
   return null
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/date-mention-popover.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/date-mention-popover.test.tsx
@@ -162,6 +162,27 @@ describe('DateMentionPopover', () => {
     expect(d.getMinutes()).toBe(30)
   })
 
+  it('ignores a cleared time input instead of crashing the handler', () => {
+    // Chromium's <input type="time"> reports value '' once a segment is cleared.
+    // ''.split(':').map(Number) is [0], so minutes arrive as undefined and
+    // new Date(y, mo, d, 0, undefined) is Invalid -> toISOString() throws.
+    // React rethrows out of the event handler rather than through fireEvent, so
+    // assert on the window 'error' event -- the same signal the renderer's
+    // telemetry listener reports in production.
+    const onWindowError = vi.fn()
+    window.addEventListener('error', onWindowError)
+    const { onChange } = renderPopover()
+
+    try {
+      fireEvent.change(screen.getByLabelText('Time'), { target: { value: '' } })
+    } finally {
+      window.removeEventListener('error', onWindowError)
+    }
+
+    expect(onWindowError).not.toHaveBeenCalled()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   it('selecting a calendar date preserves the existing time-of-day', () => {
     const { onChange } = renderPopover()
     fireEvent.click(screen.getByTestId('calendar'))

--- a/apps/desktop/src/renderer/src/components/note/content-area/date-mention-popover.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/date-mention-popover.test.tsx
@@ -183,6 +183,28 @@ describe('DateMentionPopover', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
+  it('ignores an out-of-range natural date instead of crashing on commit', () => {
+    // "in 99999999999 days" overflows Date to Invalid. tryParseDateInput read it
+    // back as { y: NaN, mo: NaN, d: NaN } -- a TRUTHY object, so commitDateText's
+    // `if (!parsed) return` did not stop it, and emitYMDHM's new Date(NaN).toISOString()
+    // threw the same RangeError this popover exists to prevent. React rethrows out
+    // of the handler, so assert on the window 'error' event (production's signal).
+    const onWindowError = vi.fn()
+    window.addEventListener('error', onWindowError)
+    const { onChange } = renderPopover()
+
+    try {
+      const input = screen.getByLabelText('Date')
+      fireEvent.change(input, { target: { value: 'in 99999999999 days' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+    } finally {
+      window.removeEventListener('error', onWindowError)
+    }
+
+    expect(onWindowError).not.toHaveBeenCalled()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   it('selecting a calendar date preserves the existing time-of-day', () => {
     const { onChange } = renderPopover()
     fireEvent.click(screen.getByTestId('calendar'))

--- a/apps/desktop/src/renderer/src/components/note/content-area/date-mention-popover.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/date-mention-popover.tsx
@@ -223,7 +223,10 @@ export function DateMentionPopover({
 
   function handleTimeChange(raw: string): void {
     const [h, mi] = raw.split(':').map(Number)
-    if (Number.isNaN(h) || Number.isNaN(mi)) return
+    // Chromium reports value '' when a segment is cleared; ''.split(':') is [''],
+    // so mi is undefined. Number.isNaN(undefined) is false (unlike isNaN), which
+    // would let an Invalid Date reach emitYMDHM's toISOString().
+    if (!Number.isFinite(h) || !Number.isFinite(mi)) return
     emitYMDHM(parts.y, parts.mo, parts.d, h, mi, true)
   }
 

--- a/apps/desktop/src/renderer/src/components/note/content-area/date-suggestions.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/date-suggestions.test.ts
@@ -43,6 +43,23 @@ describe('buildDateSuggestions', () => {
     const s = buildDateSuggestions('')
     expect(s?.dateLabel).toBe('Today')
   })
+
+  it('returns null (no crash) for an offset that overflows Date', () => {
+    // "in 99999999999 days" overflows Date to Invalid; before the parser fix it
+    // slipped through parsed.success === true, and new Date(...).toISOString()
+    // here threw a RangeError while the user was still typing in the mention menu.
+    expect(() => buildDateSuggestions('in 99999999999 days')).not.toThrow()
+    expect(buildDateSuggestions('in 99999999999 days')).toBeNull()
+  })
+
+  it('returns null for a far-future offset that overflows only after setHours', () => {
+    // "in 5000000 days" (~year 15715) has a VALID midnight, so a NaN-only parser
+    // guard admits it; buildDateSuggestions' base.setHours(9,0,0,0) then overflows a
+    // near-max date to Invalid and base.toISOString() throws. The 4-digit-year cap in
+    // the parser rejects it, so the mention menu offers nothing instead of crashing.
+    expect(() => buildDateSuggestions('in 5000000 days')).not.toThrow()
+    expect(buildDateSuggestions('in 5000000 days')).toBeNull()
+  })
 })
 
 // buildDateMentionEntry keeps the `@` menu alive through intermediate keystrokes:

--- a/apps/desktop/src/renderer/src/lib/natural-date-parser.test.ts
+++ b/apps/desktop/src/renderer/src/lib/natural-date-parser.test.ts
@@ -1237,3 +1237,45 @@ describe('Natural Date Parser', () => {
     })
   })
 })
+
+// The "in N days/weeks/months" branch takes an UNBOUNDED \d+ and never range-checks
+// it, so a huge N overflows Date past its ±8.64e15ms limit -> Invalid Date. Before
+// the fix, parseNaturalDate returned that Invalid Date as { success: true }, and the
+// contract violation only surfaced downstream as a RangeError when a caller reached
+// toISOString() (date-mention popover on Enter, date-suggestions while typing). The
+// parser must never report success with an unrepresentable date.
+describe('parseNaturalDate — out-of-range offsets', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 17, 12, 0, 0))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it.each(['in 99999999999 days', 'in 9999999999 weeks', 'in 999999999999 months'])(
+    'rejects %j instead of returning an Invalid Date as success',
+    (input) => {
+      const result = parseNaturalDate(input)
+      expect(result.success).toBe(false)
+    }
+  )
+
+  it('still accepts a small in-range offset', () => {
+    const result = parseNaturalDate('in 3 days')
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(Number.isNaN(result.result.date.getTime())).toBe(false)
+    }
+  })
+
+  it('rejects a far-future offset whose midnight is valid but overflows once a caller adds a time-of-day', () => {
+    // "in 5000000 days" is ~year 15715 — a REPRESENTABLE Date, so a NaN-only guard
+    // admits it. But callers add a time-of-day before serializing (date-suggestions
+    // setHours, popover new Date(y,mo,d,h,mi)); near Date's max that push overflows to
+    // Invalid and toISOString() throws RangeError. The parser caps accepted dates to a
+    // 4-digit year so no downstream time-of-day can overflow.
+    const result = parseNaturalDate('in 5000000 days')
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/natural-date-parser.ts
+++ b/apps/desktop/src/renderer/src/lib/natural-date-parser.ts
@@ -455,7 +455,15 @@ export const parseNaturalDate = (input: string): NaturalDateParseResult => {
   // RESULT
   // -------------------------------------------------------------------------
 
-  if (date) {
+  // The "in N days/weeks/months" branch accepts an unbounded N. A large N doesn't just
+  // overflow Date to Invalid (NaN) — even a still-representable far-future date (e.g.
+  // year 275760, a few hours below Date's ±8.64e15ms limit) overflows once a caller
+  // adds a time-of-day before serializing (date-suggestions' setHours, the popover's
+  // new Date(y, mo, d, h, mi)), throwing RangeError at toISOString(). Cap accepted
+  // dates to a 4-digit year — matching the numeric-date path — so no downstream
+  // time-of-day can overflow, and never report success with an unusable date.
+  const year = date ? date.getFullYear() : NaN
+  if (date && year >= 1 && year <= 9999) {
     return {
       success: true,
       result: {


### PR DESCRIPTION
Three independent, low-severity production crashes. None cause data loss and the app stays usable in every case — this is about correctness and cutting telemetry noise. Each fix is small, and each is pinned by a test that was **watched failing first**.

## 1. `RangeError: Invalid time value` in the date-mention time picker (1 occurrence, win32)

**Evidence.** Thrown from `emitYMDHM`'s `toISOString()`, reported by the passive `window` `error` listener in `telemetry-diagnostics.ts`.

**Root cause — the guard existed but never fired.** Chromium's `<input type="time">` reports `value === ''` when a segment is cleared. `''.split(':')` is `['']`, `.map(Number)` is `[0]`, so `h = 0` and **`mi = undefined`**. `Number.isNaN(undefined)` is `false` (unlike global `isNaN`), so the guard passed and `new Date(y, mo-1, d, 0, undefined)` → Invalid Date → `toISOString()` threw. Partial input like `'09:'` is harmless (`mi` is `0`), which is why only the empty-string case bites — but on that input it is deterministic, not a flake.

**Fix.** `if (!Number.isFinite(h) || !Number.isFinite(mi)) return` — `Number.isFinite(undefined)` is `false`.

**Not fixed, deliberately.** The brief floated an optional defence-in-depth `Number.isNaN(d.getTime())` guard inside `emitYMDHM` to also cover the `parseNaturalDate` path. I read `natural-date-parser.ts`: every path that sets `date` is range-guarded (`month >= 0 && month <= 11`, `day >= 1 && day <= 31`, ordinal `1..31`, year finite), so it cannot return `success: true` with an Invalid Date. With `handleTimeChange` fixed, no caller can hand `emitYMDHM` invalid input. That guard would be **dead code**, so I left it out.

## 2. Main-process `uncaughtException` from WebSocket cleanup (1 occurrence, darwin)

**Evidence.** `uncaughtException` routed to `trackMainError` (`main/index.ts`). The stack blames `terminate()`, which is **misleading** — I verified in `ws@8.21.0`:
- `terminate()` on a `CONNECTING` socket calls `abortHandshake(...)` and returns (`websocket.js:492-496`)
- `Error.captureStackTrace(err, abortHandshake)` (`:1106`) erases the real construction frame
- the emit is **deferred**: `process.nextTick(emitErrorAndClose, websocket, err)` (`:1121`) → `websocket.emit('error', err)` (`:1060`)

`cleanup()` calls `removeAllListeners()` then `terminate()`, so on the next tick the socket emits `'error'` with no listener attached, and Node's EventEmitter rethrows it.

**Impact is noise only.** Nothing throws *synchronously*, so `this.ws = null` still runs and `disconnect()` still emits `'disconnected'`. Reconnect timers/flags stay consistent; realtime sync is **not** wedged.

**Fix.** Reordering cannot work — the emit is on `nextTick` either way. The only correct fix is a surviving no-op `'error'` listener installed after `removeAllListeners()`. It carries a comment explaining why, so it is not deleted later as dead code. The other `terminate()` site (heartbeat) still has its listeners attached and routes correctly; left untouched.

## 3. Sigma graph zombie render (1 occurrence, linux)

**Root cause.** Not bad node data. `SigmaContainer` kills and recreates Sigma when the `graph` prop changes. React runs child effects before the container's create effect, so `useSigma()` can still return the **old, killed** instance — `kill()` empties `nodePrograms` but retains the graph, and `render()` has no killed-instance guard. `setSetting` → `scheduleRefresh` → `requestAnimationFrame(render)` → next frame `nodePrograms["circle"]` is undefined → throw.

**Impact.** The page does not break: the throw is inside a rAF callback (uncatchable by error boundaries anyway), and the new instance renders fine.

**Fix.** `SigmaSettingsSync` now takes `graph` and bails when `sigma.getGraph() !== graph`. Once the container commits the new instance the effects re-run and apply normally.

**Scope note.** The brief's snippet guarded only `nodeReducer`. My failing test showed `setSetting` was called **4 times** on the stale instance — every `setSetting` schedules a refresh, so `labelColor`/`labelRenderedSizeThreshold` revive the zombie identically. I guarded all four effects; the invariant is "never touch an instance we don't own."

**Related wart, not fixed (mentioned per brief):** `initialSigmaSettings` is `useMemo(..., [])`, so each new Sigma starts with the first render's stale `nodeReducer` closure until `SigmaSettingsSync` corrects it (possible one-frame visual artifact). The `getGraph()` guard is the smaller change; a ref-based reducer is the larger follow-up.

## Compat / migration

**None required.** No DB schema, IPC contract, sync protocol, vault format, or settings shape is touched. All three changes are guards inside existing renderer/main code paths, and all are backward compatible with data written by older app versions. No user-visible behavior changes: a cleared time input dropped the edit before and still drops it — minus the crash.

## Verification actually run

| Check | Result |
| --- | --- |
| `test:main` (full) | **3494 passed**, 1 skipped, 344 files |
| `test:renderer` (full) | **5098 passed**, 6 skipped, 446 files, exit 0 |
| `pnpm typecheck` | exit 0 |
| `pnpm lint` | exit 0 (3 pre-existing `no-base-to-string` warnings in `crdt-writeback.ts` / `frontmatter.ts`, untouched) |
| `git diff --check` | clean |

**TDD failures observed first (before any implementation):**
1. `RangeError: Invalid time value` at `date-mention-popover.tsx:202` → `handleTimeChange:227` → `onChange:264`
2. `AssertionError: expected [Function] to not throw an error but 'Error: WebSocket was closed before the connection was established' was thrown`
3. `AssertionError: expected "vi.fn()" to not be called at all, but actually been called 4 times`

**One test was a false positive and I rewrote it.** My first date-mention test used `expect(...).not.toThrow()` and **passed 13/13 while the RangeError still escaped** — React 19 rethrows out of the event handler rather than through `fireEvent`. Asserting `onChange` was not called is equally useless (true both before *and* after the fix). The test now asserts on the `window` `error` event — the same signal production telemetry reports — and genuinely fails without the fix.

## Not verified / risks

- **No live Electron run.** All three are verified by unit tests only; I did not reproduce any crash in a running app on win32/darwin/linux.
- **Fix 2's test does not exercise the real `nextTick` path.** The `ws` mock's `terminate()` does not model `abortHandshake`, and asserting on a real deferred `uncaughtException` under vitest is flaky. The test instead asserts the exact invariant that fails in production — emitting `'error'` on the socket after `cleanup()` must not throw — which is precisely the EventEmitter rethrow mechanism. The `nextTick` timing itself is verified by reading `ws@8.21.0` source (cited above), not by execution.
- **Fix 3's test models the race rather than reproducing it.** A true container-recreate race needs real Sigma + canvas, which is not feasible in jsdom. The test stubs `getGraph()` to report a foreign graph, which is the exact predicate the guard keys on — it does not prove React's child-first effect ordering, which is established from the react-sigma/React contract.
- **Docs gate is `missing-docs`.** `pnpm docs:impact --base <base> --strict` flags the three source files. I did **not** add docs: none of these change documented or user-facing behavior, and the gate only wants *some* file under `apps/docs/src` to change. Fabricating a docs edit to flip it green would violate "update only real docs". Flagging for your call. Note the pre-push hook does not actually run this gate (it ends at the branch-name guard) and no CI workflow references it.
- Local env fix, not part of the diff: this fresh worktree skipped Electron's postinstall (`path.txt` missing), which blocked main tests. Wrote the marker in `node_modules` only.

---

# Context for reviewers

## Where this came from

This PR is one of 8 opened from a **2-day production error-log triage** (2026-07-13 → 07-15, Grafana `/d/memry-logs`, `env=production`, Loki on the VPS).

The whole window held only **161 log lines** — 90 desktop errors, 27 server errors, 44 server warns — across **13 distinct installs**. Cloudflare Analytics Engine gives the denominator: **18 active installs** in those 2 days, **30** over 5 days.

Two things made this triage possible at all, and both are recent:
- **#732** (merged 2026-07-10) fixed `detectBuildChannel` falling back to `process.env.NODE_ENV`, which is undefined in packaged Electron. Before it, every packaged install reported `build_channel="development"` **and** defaulted telemetry OFF. Every desktop line in this window now reads `build_channel=production` on `2026.710.3` — so we are finally seeing real users.
- **#733** (merged 2026-07-10) stopped clean utility-worker exits from firing error events, so what remains is signal.

Low line counts here mean **low telemetry volume, not low impact**. The headline finding of the whole triage — a 58-day, 100%-broken attachment upload — was exposed by exactly **2 log lines**.

## How these PRs were produced

Each production error class was root-caused by a dedicated investigation against the real code before any patch was written, then implemented TDD-first in an isolated worktree, then put through an **adversarial review** whose explicit brief was to find what is wrong rather than to approve.

That review stage earned its keep: **6 of 8 PRs came back `needs-work`**, several with defects that would have merged silently. Its findings are reproduced verbatim below — they are not cosmetic.

**The one question that matters most on every one of these PRs:** *would the new tests actually fail on the base branch?* The 58-day attachment outage survived because both the server suite (R2/D1 fully mocked, self-consistent fixtures like `total_size: 10` with raw bytes) and the desktop suite (`fetch` mocked wholesale) passed green while the seam between them was never exercised. A test that mocks the thing under test proves nothing. Some of these PRs repeated that exact mistake and the reviewer caught it.

## This PR: production evidence

Three independent, small, verified renderer/main crashes. All are **low severity** — no data loss, app stays usable. This PR is about correctness and cutting telemetry noise, not user rescue.

1. **`RangeError: Invalid time value`** in the date-mention time picker (1 occurrence, win32). The guard **exists but is broken**: `''.split(':').map(Number)` → `[0]`, so `h = 0` and `mi = undefined`; `Number.isNaN(undefined)` is `false` (unlike global `isNaN`), so the guard passes and `new Date(y, mo-1, d, 0, undefined, …).toISOString()` throws. Chromium's `<input type="time">` emits `''` when a segment is cleared. Deterministic on that input, not a flake.
2. **Main-process `uncaughtException` from WebSocket cleanup** (1 occurrence, darwin). The stack is **misleading** — `terminate()` does not throw. `ws`'s `abortHandshake` calls `Error.captureStackTrace(err, abortHandshake)`, erasing itself, so the reported frame is the *construction* site. Real path: `cleanup()` calls `removeAllListeners()` then `terminate()` on a CONNECTING socket → `abortHandshake` defers `emit('error')` via `process.nextTick` → the listener is already stripped → EventEmitter throws it. **Reordering cannot fix this** (the emit is on nextTick either way); the fix is a surviving no-op `error` listener. Impact is noise only — nothing throws synchronously, so `this.ws = null` still runs and sync is **not** wedged.
3. **Sigma graph zombie render** (1 occurrence, linux). Not bad node data — `kill()` sets `nodePrograms = {}` but retains the graph, and `render()` has no killed-instance guard. A child effect (`SigmaSettingsSync`) calls `setSetting` on the killed instance before the container's create effect commits → rAF render → throw. The page does **not** break; the new instance renders fine.

## Adversarial review findings (verbatim)

> Reproduced exactly as returned. Findings cite file:line — verify them yourself rather than trusting either the author or the reviewer.

VERDICT: needs-work

## TESTS ARE REAL?
YES — all three would genuinely fail on the old code. I checked the load-bearing assumption behind each rather than trusting the mocks. (1) websocket.test.ts: MockWS `extends EventEmitter` (the REAL Node events module via vi.hoisted require), so `ws.emit('error', err)` with zero listeners genuinely throws — old cleanup() called removeAllListeners() and left none, so `expect(...).not.toThrow()` really fails pre-fix. Real, though it asserts only the invariant; terminate() is vi.fn() and never models abortHandshake, so the nextTick/emit timing is established by reading ws source, not executing it (author disclosed this). (2) date-mention-popover.test.tsx: the component under test is REAL (not mocked) and BASE_VALUE.hasTime=true so the Time input renders. The window 'error' assertion is sound because jsdom's dispatchEvent catches listener throws and calls reportException SYNCHRONOUSLY — which is both why the earlier `.not.toThrow()` was a false positive and why removing the listener in `finally` right after fireEvent is safe. The author's account of catching his own false positive is technically precise and matches jsdom internals; it reads as honest, not as cover. (3) graph-canvas.test.tsx: old code has no guard, so setSetting fires 4x on mount and `not.toHaveBeenCalled()` fails — real, but TAUTOLOGICAL: it mocks @react-sigma entirely and just restates the implementation. Crucially I validated the guard's predicate against the REAL libraries so the mock isn't self-confirming: @react-sigma/core@5.0.6 SigmaContainer passes the graph instance through by identity (`sigGraph = typeof graph === 'function' ? new graph() : graph`), sigma@3.0.3 getGraph() returns `this.graph`, and kill() empties nodePrograms but never clears this.graph — so `sigma.getGraph() !== graph` is a valid liveness test, not a mock artifact. BIGGEST TEST GAP (non-blocking): nothing covers the RECOVERY path. I confirmed by reading SigmaContainer that recovery works (context useMemo deps [sigma] -> new context -> children re-render -> `sigma` dep changes -> effects re-run and apply), but if someone dropped `sigma` from the effect deps, settings would be permanently lost and NO test would fail. That is the test worth adding.

## BLOCKING

### [1]
HEADLINE CRASH ONLY HALF-FIXED, on a justification that is verifiably FALSE. The author skipped the brief's emitYMDHM guard citing: 'Read natural-date-parser.ts: every path setting `date` is range-guarded ... parseNaturalDate cannot return success:true with an Invalid Date.' That is wrong. apps/desktop/src/renderer/src/lib/natural-date-parser.ts:293 matches /^in\s+(\d+)\s+(day|days|week|weeks|month|months)$/ — `\d+` is UNBOUNDED and `num = parseInt(...)` is never range-checked (unlike the month/day/ordinal branches the author looked at). addDays(today, 99999999999) -> setDate overflow -> Invalid Date; startOfDay() preserves NaN; natural-date-parser.ts:460-462 then returns `success: true, result: { date: <Invalid Date> }`. I verified this by executing the exact chain: 'in 99999999999 days', 'in 9999999999 weeks', 'in 999999999999 months' all produce RangeError: Invalid time value. The guard the author called 'dead code' is NOT dead — it is the code that catches this.

### [2]
LIVE PATH 1 — same crash, same line as the bug being fixed. date-mention-popover.tsx tryParseDateInput() natural path does `const dt = nat.result.date; return { y: dt.getFullYear(), mo: dt.getMonth()+1, d: dt.getDate() }` -> {y:NaN, mo:NaN, d:NaN}. That object is TRUTHY, so commitDateText's `if (!parsed) return` does not stop it -> emitYMDHM(NaN,NaN,NaN,...) -> `new Date(NaN,...).toISOString()` -> RangeError: Invalid time value. Reachable today: type 'in 99999999999 days' into the popover's date input and press Enter/blur. This is the exact same function and toISOString() line as the RangeError this PR exists to fix.

### [3]
LIVE PATH 2 — broader, and NOT covered by an emitYMDHM guard. date-suggestions.ts:41-55 buildDateSuggestions(): `const parsed = parseNaturalDate(query.trim() || 'today'); if (!parsed.success) return null; const base = new Date(parsed.result.date); base.setHours(9,0,0,0); dateISO: base.toISOString()` -> same RangeError, fired WHILE TYPING in the inline date-mention suggestion menu (a more prominent path than the popover). Because it consumes parseNaturalDate directly, guarding emitYMDHM alone does not close it. CORRECT FIX: repair the contract at the root in natural-date-parser.ts before line 460 — `if (!date || Number.isNaN(date.getTime())) return { success: false, ... }`. That closes both paths at once and makes the emitYMDHM guard genuine defence-in-depth rather than dead code. Add a test asserting parseNaturalDate('in 99999999999 days').success === false.

## NITS

- [1] graph-canvas.test.tsx: add the recovery test — swap getGraph() from a foreign graph back to the rendered graph, rerender, and assert setSetting IS then called. Without it the guard could silently become permanent (nodeReducer/edgeReducer/labelColor never applied = silent visual regression, arguably worse than the crash it replaces).

- [2] graph-canvas.tsx: initialSigmaSettings is useMemo(..., []) so each recreated Sigma is constructed with render #1's stale nodeReducer (closing over the OLD graph) and self-corrects only on the next commit — a real one-frame artifact the author flagged and left. Pre-existing and strictly better than a crash, but it is now the observable behavior; worth a follow-up.

- [3] date-mention-popover.test.tsx: `expect(onChange).not.toHaveBeenCalled()` is inert — it holds both pre- and post-fix (the throw happens before onChange). The author knows this and kept it anyway. Harmless as documentation, but only the window-'error' assertion is load-bearing; don't let the inert one create false confidence.

- [4] PRE-EXISTING REPO BUG worth surfacing to Kaan: .husky/pre-push is 37 lines and simply ENDS after computing `code_changed` / `has_changes` — it never invokes docs:impact, contradicting CLAUDE.md's description of it. Combined with zero workflow references (I grepped .github/workflows — none), the docs gate NEVER runs for anyone. The author's characterization was accurate (he said 'ends at the branch-name guard'; it actually ends a few lines later, but the substance — gate unenforced — is TRUE).

- [5] Docs gate: I independently confirmed the author's report. scripts/docs-impact.mjs docsRelevantPatterns matches ^apps/desktop/src/, and the 3 test files are excluded by /(?:\.test|\.spec)\./ — so the 3 source files yield status 'missing-docs'. I agree fabricating a docs edit would be wrong here (pure internal guards, no user-facing behavior change); MEMRY_DOCS_IMPACT_SKIP=1 with the stated reason is the CLAUDE.md-sanctioned route. Not blocking.

- [6] HONESTY: strong overall. Everything I could check independently was accurate — docs:impact status, the pre-push hook being a no-op, no workflow enforcement, the ws abortHandshake mechanism, and the sigma kill()/getGraph() behavior. Risks were disclosed rather than hidden (no live Electron run; fix 2's test doesn't exercise nextTick; fix 3's test models rather than reproduces the race). I could NOT verify the suite counts (3494 main / 5098 renderer) or lint/typecheck exit codes without running them; nothing contradicts them. The ONE material honesty failure is the natural-date-parser claim in the blocking finding — a specific, confident, false assertion about a file he says he read, used to justify skipping a defence the brief asked for.

- [7] Scope/compat/privacy/house-rules all clean: no DB, contracts, IPC, electron-store, sync-protocol or file-format changes (nothing for old clients to break on); no new telemetry or log lines (the `message`/`url` fields in websocket.ts are pre-existing electron-log, not telemetry, and not in this diff); no console.*; no new Tailwind classes; no Co-Authored-By; branch and commit body free of tool branding. Guarding all four SigmaSettingsSync effects is correctness, not scope creep — every setSetting() calls scheduleRefresh().
