### PR TITLE
fix(sync): stop transient CRDT storage failures surfacing as unhandled errors

### DIFF
--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -27,8 +27,10 @@ vi.mock('../../crypto/index', () => ({
   secureCleanup: (...args: unknown[]) => secureCleanupMock(...args)
 }))
 
+const withRetryMock = vi.fn(async (fn: () => Promise<unknown>) => ({ value: await fn() }))
+
 vi.mock('../retry', () => ({
-  withRetry: async <T>(fn: () => Promise<T>) => ({ value: await fn() })
+  withRetry: (fn: () => Promise<unknown>, options?: unknown) => withRetryMock(fn, options)
 }))
 
 vi.mock('../crdt-encrypt', () => ({
@@ -362,6 +364,95 @@ describe('CrdtSyncCoordinator', () => {
       '/sync/crdt/updates/batch',
       {
         notes: [{ noteId: 'note-1', since: 6 }],
+        limit: 100
+      },
+      'token-1'
+    )
+  })
+
+  const createBatchContext = (): {
+    ctx: SyncContext
+    open: ReturnType<typeof vi.fn>
+  } => {
+    const open = vi.fn().mockResolvedValue({})
+    const ctx = {
+      deps: {
+        crdtProvider: {
+          getDoc: vi.fn().mockReturnValue(undefined),
+          open,
+          closeIfInactive: vi.fn().mockResolvedValue(true),
+          applyRemoteUpdate: vi.fn(),
+          getStateVector: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3, 4])),
+          seedFromMarkdownPublic: vi.fn()
+        }
+      },
+      abortController: new AbortController()
+    } as unknown as SyncContext
+
+    return { ctx, open }
+  }
+
+  it('does not retry 429s inside the serial pull loop', async () => {
+    // #given a normal batch pass
+    const { ctx } = createBatchContext()
+    postToServerMock.mockResolvedValue({ notes: { 'note-1': { updates: [], hasMore: false } } })
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtBatch(['note-1'], 'token-1', new Uint8Array([4, 5, 6]))
+
+    // #then honouring Retry-After (up to 60s) x3 inside a serial loop stalls the
+    // whole pass on one note; the pass cadence is the retry instead.
+    expect(withRetryMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ retryOn429: false })
+    )
+  })
+
+  it('does not retry 429s when pulling a single note incrementally', async () => {
+    // #given
+    const { ctx } = createBatchContext()
+    getFromServerMock.mockResolvedValue({ updates: [], hasMore: false })
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtIncrementals('note-1', 'token-1', new Uint8Array([4, 5, 6]))
+
+    // #then
+    expect(withRetryMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ retryOn429: false })
+    )
+  })
+
+  it('keeps syncing the remaining notes when one note fails its snapshot baseline', async () => {
+    // #given note-2 dead-letters while fetching its snapshot baseline
+    const { ctx } = createBatchContext()
+    const deadLetter = new Error('Dead letter after 4 attempts: Server error (500)')
+    deadLetter.name = 'DeadLetterError'
+    fetchCrdtSnapshotMock
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(deadLetter)
+      .mockResolvedValueOnce(null)
+    postToServerMock.mockResolvedValue({
+      notes: {
+        'note-1': { updates: [], hasMore: false },
+        'note-3': { updates: [], hasMore: false }
+      }
+    })
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtBatch(['note-1', 'note-2', 'note-3'], 'token-1', new Uint8Array([4]))
+
+    // #then one bad note must not abandon every note after it in the pass
+    expect(postToServerMock).toHaveBeenCalledWith(
+      '/sync/crdt/updates/batch',
+      {
+        notes: [
+          { noteId: 'note-1', since: 0 },
+          { noteId: 'note-3', since: 0 }
+        ],
         limit: 100
       },
       'token-1'

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.test.ts
@@ -458,4 +458,63 @@ describe('CrdtSyncCoordinator', () => {
       'token-1'
     )
   })
+
+  it('does not seed a note whose snapshot baseline failed', async () => {
+    // #given note-2's baseline dead-letters; note-1 and note-3 succeed.
+    // note-2 was opened with { skipSeed: true } so its state vector is empty.
+    const seedFromMarkdownPublic = vi.fn()
+    const getStateVector = vi.fn((noteId: string) =>
+      noteId === 'note-2' ? new Uint8Array([]) : new Uint8Array([1, 2, 3, 4])
+    )
+    const ctx = {
+      deps: {
+        crdtProvider: {
+          getDoc: vi.fn().mockReturnValue(undefined),
+          open: vi.fn().mockResolvedValue({}),
+          closeIfInactive: vi.fn().mockResolvedValue(true),
+          applyRemoteUpdate: vi.fn(),
+          getStateVector,
+          seedFromMarkdownPublic
+        }
+      },
+      abortController: new AbortController()
+    } as unknown as SyncContext
+
+    const deadLetter = new Error('Dead letter after 4 attempts: Server error (500)')
+    deadLetter.name = 'DeadLetterError'
+    fetchCrdtSnapshotMock
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(deadLetter)
+      .mockResolvedValueOnce(null)
+    postToServerMock.mockResolvedValue({
+      notes: {
+        'note-1': { updates: [], hasMore: false },
+        'note-3': { updates: [], hasMore: false }
+      }
+    })
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtBatch(['note-1', 'note-2', 'note-3'], 'token-1', new Uint8Array([4]))
+
+    // #then seeding note-2 would persist local markdown into its open, empty doc;
+    // the next pass's real server snapshot would then merge as an independent
+    // insertion → duplicated note body. Only baselined notes may be seeded.
+    expect(seedFromMarkdownPublic).not.toHaveBeenCalledWith('note-2')
+  })
+
+  it('aborts the whole pass when a snapshot baseline is aborted mid-batch', async () => {
+    // #given note-1's baseline is aborted (shutdown/signal), not a transient failure
+    const { ctx } = createBatchContext()
+    const abort = new DOMException('The operation was aborted', 'AbortError')
+    fetchCrdtSnapshotMock.mockRejectedValueOnce(abort)
+    const coordinator = new CrdtSyncCoordinator(ctx, vi.fn())
+
+    // #when
+    await coordinator.applyCrdtBatch(['note-1', 'note-2'], 'token-1', new Uint8Array([4]))
+
+    // #then an abort must propagate, not be swallowed as a skipped note; the pass
+    // stops before pulling any updates.
+    expect(postToServerMock).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -275,7 +275,12 @@ export class CrdtSyncCoordinator {
         }
       }
 
-      for (const noteId of noteIds) {
+      // Seed only notes whose snapshot baseline succeeded. A note skipped at :205
+      // was opened with { skipSeed: true } and stays open with an empty state
+      // vector; seeding it here would persist local markdown, and the next pass's
+      // real server snapshot would then merge as an independent insertion →
+      // duplicated note body. Its baseline failed transiently; the next pass fetches it.
+      for (const noteId of sinceMap.keys()) {
         const postVector = crdtProvider.getStateVector(noteId)
         if (!postVector || postVector.length <= 2) {
           await crdtProvider.seedFromMarkdownPublic(noteId)

--- a/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts
@@ -118,7 +118,7 @@ export class CrdtSyncCoordinator {
               `/sync/crdt/updates?note_id=${encodeURIComponent(noteId)}&since=${since}&limit=100`,
               token
             ),
-          { maxRetries: 3, baseDelayMs: 2000, signal: effectiveSignal }
+          { maxRetries: 3, baseDelayMs: 2000, signal: effectiveSignal, retryOn429: false }
         ).then((r) => r.value)
 
         log.debug('applyCrdtIncrementals fetched', {
@@ -199,8 +199,18 @@ export class CrdtSyncCoordinator {
           continue
         }
 
-        const since = await this.applySnapshotBaseline(noteId, token, vaultKey, 'batch')
-        sinceMap.set(noteId, since)
+        try {
+          const since = await this.applySnapshotBaseline(noteId, token, vaultKey, 'batch')
+          sinceMap.set(noteId, since)
+        } catch (err) {
+          if (err instanceof DOMException && err.name === 'AbortError') throw err
+          // A single note's baseline failure must not abandon every note left in
+          // the pass. Skip it; the next pass retries it.
+          log.warn('Failed to apply CRDT snapshot baseline, skipping note in batch', {
+            noteId,
+            error: err instanceof Error ? err.message : String(err)
+          })
+        }
       }
 
       if (sinceMap.size === 0) return
@@ -219,7 +229,12 @@ export class CrdtSyncCoordinator {
               { notes, limit: 100 },
               token
             ),
-          { maxRetries: 3, baseDelayMs: 2000, signal: this.ctx.abortController.signal }
+          {
+            maxRetries: 3,
+            baseDelayMs: 2000,
+            signal: this.ctx.abortController.signal,
+            retryOn429: false
+          }
         ).then((r) => r.value)
 
         const signerIds = new Set<string>()

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -210,7 +210,10 @@ export async function fetchCrdtSnapshot(
         `/sync/crdt/snapshot/${encodeURIComponent(noteId)}`,
         token
       ),
-    { maxRetries: 3, baseDelayMs: 2000 }
+    // Snapshot baselines are fetched per note inside a serial loop, so honouring
+    // Retry-After here would stall every remaining note. The sync pass cadence
+    // is the retry.
+    { maxRetries: 3, baseDelayMs: 2000, retryOn429: false }
   )
 
   if (!result.snapshot || !result.signerDeviceId) return null

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -74,6 +74,34 @@ Notes flow through **both** sync paths:
 
 Snapshots are pushed **pre-batch** so other devices receive correct state before the sync notification reaches them.
 
+## Snapshot Failure Handling
+
+A snapshot is a **compaction optimization**, not the source of truth: the authoritative
+server-side state is the `crdt_updates` log. A failed snapshot is therefore recoverable,
+and the write path is ordered so it stays that way.
+
+- **R2 put before D1 upsert.** A failed put writes no metadata row, so there is never a
+  row pointing at an object that does not exist.
+- **Prune only after a successful store.** `pruneUpdatesBeforeSnapshot` runs only once
+  the snapshot is durable, so a failed snapshot never deletes the update log behind it.
+- **Transient puts are retried.** The R2 key is deterministic
+  (`<userId>/vaults/<vaultId>/crdt/<noteId>/snapshot`), so a retry overwrites the same
+  object and is idempotent. `putBlob` retries a transient failure twice with a short
+  bounded backoff; quota and permission rejections are terminal and are not retried.
+- **Failures are typed.** CRDT blob access goes through `putBlob`/`getBlob`, which
+  classify R2 failures into `AppError`s (`STORAGE_UPLOAD_FAILED`, and so on). A raw
+  storage error would otherwise reach the error handler as `UNHANDLED_ERROR` and make
+  a transient provider incident look like an application crash in telemetry.
+- **Quota refunds never mask the cause.** A reservation refund is itself a D1 write and
+  can fail during a D1 incident. The refund is isolated so the original error always
+  propagates; a failed refund is logged and leaves the reservation charged until it is
+  reconciled.
+
+The client mirrors this. CRDT pulls run in a **serial loop over notes**, so they do not
+retry `429`s inline — honouring `Retry-After` per note would stall the whole pass, and the
+sync cadence is the retry instead. A single note that fails its snapshot baseline is
+skipped and retried on the next pass rather than abandoning the remaining notes.
+
 ## Sign-Out / Sign-In Ordering
 
 A sign out → sign in cycle has a sharp ordering rule:

--- a/apps/sync-server/src/routes/blob.test.ts
+++ b/apps/sync-server/src/routes/blob.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { ErrorCodes, errorHandler } from '../lib/errors'
+import { AppError, ErrorCodes, errorHandler } from '../lib/errors'
 import type { AppContext } from '../types'
 
 vi.mock('../services/blob', () => ({
@@ -205,6 +205,29 @@ describe('blob routes', () => {
     expect(assertFileSizeAllowed).toHaveBeenCalledWith(env.DB, 'user-1', 2)
     expect(reserveStorage).not.toHaveBeenCalled()
     expect(adjustStorageUsed).toHaveBeenCalledWith(env.DB, 'user-1', -3)
+  })
+
+  it('surfaces the original storage error when the quota refund also fails', async () => {
+    // #given the reservation succeeds, the put fails with a typed error, and the
+    // refund D1 write ALSO fails — the compound outage the refund must survive.
+    vi.mocked(env.STORAGE.head).mockResolvedValueOnce(null)
+    vi.mocked(putBlob).mockRejectedValueOnce(
+      new AppError(ErrorCodes.STORAGE_UPLOAD_FAILED, 'Blob upload failed', 500)
+    )
+    vi.mocked(adjustStorageUsed).mockRejectedValueOnce(
+      new Error('D1_ERROR: Network connection lost.')
+    )
+
+    const res = await app.request('/blob/blob-1', { method: 'PUT', body: 'hello' }, env)
+
+    // #then the refund failure must not replace the real cause: the client sees
+    // the typed storage error, not an UNHANDLED_ERROR leaked from the refund.
+    expect(res.status).toBe(500)
+    expect(await res.json()).toMatchObject({
+      error: { code: ErrorCodes.STORAGE_UPLOAD_FAILED }
+    })
+    // the refund was still attempted (its failure is swallowed + logged)
+    expect(adjustStorageUsed).toHaveBeenCalledWith(env.DB, 'user-1', -5)
   })
 
   it('downloads a simple blob with content length headers', async () => {

--- a/apps/sync-server/src/routes/blob.ts
+++ b/apps/sync-server/src/routes/blob.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 
 import { AppError, ErrorCodes } from '../lib/errors'
+import { createLogger } from '../lib/logger'
 import { authMiddleware } from '../middleware/auth'
 import { paidSyncMiddleware } from '../middleware/paid-sync'
 import { createRateLimiter } from '../middleware/rate-limit'
@@ -16,6 +17,34 @@ import { assertFileSizeAllowed } from '../services/entitlements'
 import { adjustStorageUsed, reserveStorage } from '../services/quota'
 import { UploadInitRequestSchema } from '@memry/contracts/blob-api'
 import type { AppContext } from '../types'
+
+const logger = createLogger('BlobRoutes')
+
+/**
+ * Refunds a storage reservation after a failed write.
+ *
+ * The refund is itself a D1 write, so during a D1 outage it fails too. It must
+ * never replace the error that actually caused the write to fail: that turns a
+ * typed, handled error into an unhandled one and hides the real cause. A failed
+ * refund leaves the reservation charged to the user until reconciliation.
+ */
+const refundReservation = async (
+  db: D1Database,
+  userId: string,
+  reservedBytes: number,
+  context: Record<string, unknown>
+): Promise<void> => {
+  if (reservedBytes <= 0) return
+  try {
+    await adjustStorageUsed(db, userId, -reservedBytes)
+  } catch (refundError) {
+    logger.error('storage refund failed', {
+      ...context,
+      reservedBytes,
+      error: refundError instanceof Error ? refundError.message : String(refundError)
+    })
+  }
+}
 
 export const blob = new Hono<AppContext>()
 
@@ -75,9 +104,7 @@ blob.put('/blob/:blob_key', blobUploadLimit, async (c) => {
   try {
     result = await putBlob(c.env.STORAGE, key, body, userId)
   } catch (error) {
-    if (deltaBytes > 0) {
-      await adjustStorageUsed(c.env.DB, userId, -deltaBytes)
-    }
+    await refundReservation(c.env.DB, userId, deltaBytes, { operation: 'putBlob', userId, key })
     throw error
   }
 
@@ -210,7 +237,11 @@ blob.post('/attachments/upload/initiate', uploadSessionLimit, async (c) => {
       )
       .run()
   } catch (error) {
-    await adjustStorageUsed(c.env.DB, userId, -totalSize)
+    await refundReservation(c.env.DB, userId, totalSize, {
+      operation: 'uploadInitiate',
+      userId,
+      sessionId
+    })
     throw error
   }
 
@@ -345,9 +376,11 @@ blob.post('/attachments/upload/:session_id/complete', chunkUploadLimit, async (c
     try {
       await putBlob(c.env.STORAGE, manifestKey, manifestBytes.buffer as ArrayBuffer, userId)
     } catch (error) {
-      if (manifestDeltaBytes > 0) {
-        await adjustStorageUsed(c.env.DB, userId, -manifestDeltaBytes)
-      }
+      await refundReservation(c.env.DB, userId, manifestDeltaBytes, {
+        operation: 'uploadComplete',
+        userId,
+        key: manifestKey
+      })
       throw error
     }
   }
@@ -517,9 +550,11 @@ blob.put('/attachments/:attachment_id/manifest', blobUploadLimit, async (c) => {
   try {
     await putBlob(c.env.STORAGE, manifestKey, body, userId)
   } catch (error) {
-    if (deltaBytes > 0) {
-      await adjustStorageUsed(c.env.DB, userId, -deltaBytes)
-    }
+    await refundReservation(c.env.DB, userId, deltaBytes, {
+      operation: 'manifestPut',
+      userId,
+      key: manifestKey
+    })
     throw error
   }
   if (deltaBytes < 0) {

--- a/apps/sync-server/src/services/blob.test.ts
+++ b/apps/sync-server/src/services/blob.test.ts
@@ -225,6 +225,91 @@ describe('putBlob', () => {
 })
 
 // ============================================================================
+// Tests: putBlob transient-failure retry
+//
+// Production evidence: a ~5 minute burst of R2 put failures ("put: Please look
+// at https://www.cloudflarestatus.com for issues") surfaced as 500s. The key is
+// deterministic, so a put retry is idempotent.
+// ============================================================================
+
+const R2_TRANSIENT_MESSAGE = 'put: Please look at https://www.cloudflarestatus.com for issues'
+
+describe('putBlob retry on transient R2 failures', () => {
+  let storage: ReturnType<typeof createMockStorage>
+
+  beforeEach(() => {
+    storage = createMockStorage()
+  })
+
+  it('should retry a transient R2 put failure and succeed without surfacing an error', async () => {
+    // #given a put that fails once, then succeeds (the Cloudflare-incident shape)
+    storage.put
+      .mockRejectedValueOnce(new Error(R2_TRANSIENT_MESSAGE))
+      .mockResolvedValueOnce(createMockR2Object())
+
+    // #when
+    const result = await putBlob(
+      storage as unknown as R2Bucket,
+      'user-1/items/x',
+      new ArrayBuffer(10),
+      'user-1'
+    )
+
+    // #then the caller never sees the transient failure
+    expect(result).toBeDefined()
+    expect(storage.put).toHaveBeenCalledTimes(2)
+  })
+
+  it('should retry twice before giving up and surface a typed STORAGE_UPLOAD_FAILED', async () => {
+    // #given R2 is persistently failing
+    storage.put.mockRejectedValue(new Error(R2_TRANSIENT_MESSAGE))
+
+    // #when / #then
+    await expect(
+      putBlob(storage as unknown as R2Bucket, 'user-1/items/x', new ArrayBuffer(10), 'user-1')
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      code: ErrorCodes.STORAGE_UPLOAD_FAILED,
+      statusCode: 500
+    })
+    expect(storage.put).toHaveBeenCalledTimes(3)
+  })
+
+  it('should not retry quota failures', async () => {
+    // #given a terminal, non-transient failure
+    storage.put.mockRejectedValue(new Error('Storage quota exceeded for bucket'))
+
+    // #when / #then retrying a quota rejection only burns Worker budget
+    await expect(
+      putBlob(storage as unknown as R2Bucket, 'user-1/items/x', new ArrayBuffer(10), 'user-1')
+    ).rejects.toMatchObject({ code: ErrorCodes.STORAGE_QUOTA_EXCEEDED })
+    expect(storage.put).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not retry permission failures', async () => {
+    // #given
+    storage.put.mockRejectedValue(new Error('Access denied: forbidden'))
+
+    // #when / #then
+    await expect(
+      putBlob(storage as unknown as R2Bucket, 'user-1/items/x', new ArrayBuffer(10), 'user-1')
+    ).rejects.toMatchObject({ code: ErrorCodes.STORAGE_UNAUTHORIZED })
+    expect(storage.put).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not retry a stream body, which cannot be replayed after a failed attempt', async () => {
+    // #given a body that is consumed by the first attempt
+    storage.put.mockRejectedValue(new Error(R2_TRANSIENT_MESSAGE))
+
+    // #when / #then re-putting a consumed stream would upload a partial object
+    await expect(
+      putBlob(storage as unknown as R2Bucket, 'user-1/items/x', new ReadableStream(), 'user-1')
+    ).rejects.toMatchObject({ code: ErrorCodes.STORAGE_UPLOAD_FAILED })
+    expect(storage.put).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ============================================================================
 // Tests: getBlob
 // ============================================================================
 

--- a/apps/sync-server/src/services/blob.ts
+++ b/apps/sync-server/src/services/blob.ts
@@ -24,6 +24,26 @@ const assertKeyBelongsToUser = (key: string, userId: string): void => {
   }
 }
 
+// Blob keys are deterministic, so a put retry overwrites the same object and is
+// idempotent. Delays are kept short and bounded: the retries only wait on I/O
+// (they burn wall time, not the Worker CPU budget), but a request still has to
+// finish, so the worst case adds ~350ms rather than seconds.
+const PUT_RETRY_DELAYS_MS = [100, 250]
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+const classifyPutError = (err: unknown): AppError => {
+  if (err instanceof AppError) return err
+  const msg = err instanceof Error ? err.message : String(err)
+  if (/quota|limit|exceeded/i.test(msg)) {
+    return new AppError(ErrorCodes.STORAGE_QUOTA_EXCEEDED, `Storage quota exceeded: ${msg}`, 413)
+  }
+  if (/forbidden|permission|unauthorized|access denied/i.test(msg)) {
+    return new AppError(ErrorCodes.STORAGE_UNAUTHORIZED, `Storage permission error: ${msg}`, 403)
+  }
+  return new AppError(ErrorCodes.STORAGE_UPLOAD_FAILED, `Blob upload failed: ${msg}`, 500)
+}
+
 export const putBlob = async (
   storage: R2Bucket,
   key: string,
@@ -44,25 +64,29 @@ export const putBlob = async (
     }
   }
 
-  let result: R2Object
-  try {
-    const r2Result = await storage.put(key, data)
-    if (!r2Result) {
-      throw new AppError(ErrorCodes.STORAGE_UPLOAD_FAILED, 'R2 put returned null', 500)
+  // A stream body is consumed by the first attempt, so it cannot be replayed
+  // without risking a partial upload. Only buffered bodies are retried.
+  const canRetry = data instanceof ArrayBuffer
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const r2Result = await storage.put(key, data)
+      if (!r2Result) {
+        throw new AppError(ErrorCodes.STORAGE_UPLOAD_FAILED, 'R2 put returned null', 500)
+      }
+      return r2Result
+    } catch (err) {
+      const appError = classifyPutError(err)
+      const delayMs = PUT_RETRY_DELAYS_MS[attempt]
+      // Only transient failures are worth retrying; quota and permission
+      // rejections are terminal and would just burn budget.
+      const isTransient = appError.code === ErrorCodes.STORAGE_UPLOAD_FAILED
+      if (!canRetry || !isTransient || delayMs === undefined) {
+        throw appError
+      }
+      await sleep(delayMs)
     }
-    result = r2Result
-  } catch (err) {
-    if (err instanceof AppError) throw err
-    const msg = err instanceof Error ? err.message : String(err)
-    if (/quota|limit|exceeded/i.test(msg)) {
-      throw new AppError(ErrorCodes.STORAGE_QUOTA_EXCEEDED, `Storage quota exceeded: ${msg}`, 413)
-    }
-    if (/forbidden|permission|unauthorized|access denied/i.test(msg)) {
-      throw new AppError(ErrorCodes.STORAGE_UNAUTHORIZED, `Storage permission error: ${msg}`, 403)
-    }
-    throw new AppError(ErrorCodes.STORAGE_UPLOAD_FAILED, `Blob upload failed: ${msg}`, 500)
   }
-  return result
 }
 
 export const getBlob = async (

--- a/apps/sync-server/src/services/blob.ts
+++ b/apps/sync-server/src/services/blob.ts
@@ -65,8 +65,10 @@ export const putBlob = async (
   }
 
   // A stream body is consumed by the first attempt, so it cannot be replayed
-  // without risking a partial upload. Only buffered bodies are retried.
-  const canRetry = data instanceof ArrayBuffer
+  // without risking a partial upload. Retry any buffered body; only an
+  // unreplayable stream is excluded (a future non-ArrayBuffer buffered body
+  // such as a Uint8Array must not silently lose its retry).
+  const canRetry = !(data instanceof ReadableStream)
 
   for (let attempt = 0; ; attempt++) {
     try {

--- a/apps/sync-server/src/services/crdt.test.ts
+++ b/apps/sync-server/src/services/crdt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { AppError, ErrorCodes, errorHandler } from '../lib/errors'
 import {
   getBatchUpdates,
   getSnapshot,
@@ -244,7 +245,9 @@ function createMemoryBucket(): R2Bucket {
           ? new Uint8Array(value)
           : new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
       objects.set(key, bytes.slice())
-      return null as unknown as R2Object
+      // Real R2 resolves to an R2Object; returning null here would look like a
+      // failed upload to putBlob.
+      return { key, etag: `etag-${objects.size}` } as unknown as R2Object
     },
     async get(key: string) {
       const bytes = objects.get(key)
@@ -428,7 +431,7 @@ describe('CRDT storage accounting', () => {
         return null
       }
     })
-    const storage = { put: vi.fn().mockResolvedValue(undefined) } as unknown as R2Bucket
+    const storage = { put: vi.fn().mockResolvedValue({ etag: 'etag-1' }) } as unknown as R2Bucket
     const snapshot = new Uint8Array(10).buffer
 
     await storeSnapshot(db, storage, 'user-1', 'vault-1', 'note-1', 'device-1', snapshot)
@@ -453,5 +456,184 @@ describe('CRDT storage accounting', () => {
     const usageUpdate = statements.find((entry) => entry.sql.includes('UPDATE users'))
     expect(usageUpdate?.sql).toContain('MAX(0, storage_used + ?)')
     expect(usageUpdate?.bindings).toEqual([-8, expect.any(Number), 'user-1'])
+  })
+})
+
+// ============================================================================
+// Tests: CRDT failure handling
+//
+// Production evidence: a ~5 minute R2 incident produced 24x UNHANDLED_ERROR
+// 500s on POST /sync/crdt/snapshot, because the CRDT path called storage.put
+// directly instead of going through putBlob. Transient infra looked like an app
+// crash and polluted the unhandled-error signal.
+// ============================================================================
+
+const R2_TRANSIENT_MESSAGE = 'put: Please look at https://www.cloudflarestatus.com for issues'
+const D1_OUTAGE_MESSAGE = 'D1_ERROR: Network connection lost.'
+
+/**
+ * D1 fake whose storage-accounting writes can be made to fail independently,
+ * so we can model the "refund during a D1 outage" case.
+ */
+function createAccountingDatabase(options: { failRefund?: boolean; failInsert?: boolean }) {
+  const runSql: string[] = []
+
+  const db = {
+    prepare: vi.fn((sql: string) => {
+      const stmt = {
+        bind: vi.fn(() => stmt),
+        first: vi.fn(async () => {
+          if (sql.includes('INSERT INTO crdt_updates')) {
+            if (options.failInsert) throw new Error(D1_OUTAGE_MESSAGE)
+            return { sequence_num: 1 }
+          }
+          if (sql.includes('COALESCE(MAX(sequence_num)')) return { max_seq: 0 }
+          return null
+        }),
+        run: vi.fn(async () => {
+          runSql.push(sql)
+          // The refund is itself a D1 write; during an outage it fails too.
+          if (options.failRefund && sql.includes('MAX(0, storage_used + ?)')) {
+            throw new Error('D1_ERROR: internal error')
+          }
+          return { meta: { changes: 1 } }
+        })
+      }
+      return stmt
+    })
+  }
+
+  return { db: db as unknown as D1Database, runSql }
+}
+
+const createFailingBucket = (message: string): R2Bucket =>
+  ({ put: vi.fn().mockRejectedValue(new Error(message)) }) as unknown as R2Bucket
+
+describe('CRDT snapshot failure handling', () => {
+  it('retries a transient R2 put failure and still records the snapshot', async () => {
+    // #given R2 fails once then recovers, as in the Cloudflare incident
+    const db = createD1Database()
+    const put = vi
+      .fn()
+      .mockRejectedValueOnce(new Error(R2_TRANSIENT_MESSAGE))
+      .mockResolvedValueOnce({ etag: 'etag-1' })
+    const storage = {
+      put,
+      get: async () => ({ arrayBuffer: async () => bytes('snapshot-a') })
+    } as unknown as R2Bucket
+
+    // #when
+    const result = await storeSnapshot(
+      db,
+      storage,
+      'user-1',
+      'vault-1',
+      'note-1',
+      'device-a',
+      bytes('snapshot-a')
+    )
+
+    // #then the transient blip is absorbed and the D1 row is written
+    expect(put).toHaveBeenCalledTimes(2)
+    expect(result.sequenceNum).toBe(0)
+    expect(await getSnapshot(db, storage, 'user-1', 'vault-1', 'note-1')).not.toBeNull()
+  })
+
+  it('surfaces a typed STORAGE_UPLOAD_FAILED that the error handler reports as handled', async () => {
+    // #given R2 is persistently failing
+    const db = createD1Database()
+    const storage = createFailingBucket(R2_TRANSIENT_MESSAGE)
+
+    // #when
+    const error = await storeSnapshot(
+      db,
+      storage,
+      'user-1',
+      'vault-1',
+      'note-1',
+      'device-a',
+      bytes('snapshot-a')
+    ).catch((e: unknown) => e)
+
+    // #then a raw R2 Error would be logged as UNHANDLED_ERROR by the error handler
+    expect(error).toBeInstanceOf(AppError)
+    expect((error as AppError).code).toBe(ErrorCodes.STORAGE_UPLOAD_FAILED)
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const json = vi.fn(
+      (payload: unknown, init: unknown) =>
+        new Response(JSON.stringify(payload), init as ResponseInit)
+    )
+    const response = errorHandler(
+      error as Error,
+      { json } as unknown as Parameters<typeof errorHandler>[1]
+    )
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject({
+      error: { code: ErrorCodes.STORAGE_UPLOAD_FAILED }
+    })
+    expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('UNHANDLED_ERROR'))
+    consoleSpy.mockRestore()
+  })
+
+  it('writes no snapshot row when the R2 put fails, so nothing can be pruned', async () => {
+    // #given updates exist and the snapshot put fails
+    const db = createD1Database()
+    await storeUpdates(db, 'user-1', 'vault-1', 'note-1', 'device-a', [bytes('a1'), bytes('a2')])
+    const storage = createFailingBucket(R2_TRANSIENT_MESSAGE)
+
+    // #when
+    await expect(
+      storeSnapshot(db, storage, 'user-1', 'vault-1', 'note-1', 'device-a', bytes('snapshot-a'))
+    ).rejects.toThrow(AppError)
+
+    // #then no orphan row, and the authoritative update log is untouched
+    await expect(getSnapshot(db, storage, 'user-1', 'vault-1', 'note-1')).resolves.toBeNull()
+    await expect(pruneUpdatesBeforeSnapshot(db, 'user-1', 'vault-1', 'note-1')).resolves.toBe(0)
+    const remaining = await getUpdates(db, 'user-1', 'vault-1', 'note-1', 0, 10)
+    expect(remaining.updates).toHaveLength(2)
+  })
+
+  it('propagates the original put failure when the quota refund also fails', async () => {
+    // #given R2 is down AND D1 is down, so the refund write fails too
+    const { db } = createAccountingDatabase({ failRefund: true })
+    const storage = createFailingBucket(R2_TRANSIENT_MESSAGE)
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    // #when
+    const error = await storeSnapshot(
+      db,
+      storage,
+      'user-1',
+      'vault-1',
+      'note-1',
+      'device-a',
+      bytes('snapshot-a')
+    ).catch((e: unknown) => e)
+
+    // #then the refund failure must not replace the real cause
+    expect(error).toBeInstanceOf(AppError)
+    expect((error as AppError).code).toBe(ErrorCodes.STORAGE_UPLOAD_FAILED)
+    expect((error as Error).message).not.toContain('internal error')
+    // #and the leaked reservation is visible in the logs
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('storage refund failed'))
+    consoleSpy.mockRestore()
+  })
+
+  it('propagates the original update failure when the quota refund also fails', async () => {
+    // #given the insert fails and the refund write fails too
+    const { db } = createAccountingDatabase({ failInsert: true, failRefund: true })
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    // #when
+    const error = await storeUpdates(db, 'user-1', 'vault-1', 'note-1', 'device-a', [
+      bytes('a1')
+    ]).catch((e: unknown) => e)
+
+    // #then
+    expect((error as Error).message).toBe(D1_OUTAGE_MESSAGE)
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('storage refund failed'))
+    consoleSpy.mockRestore()
   })
 })

--- a/apps/sync-server/src/services/crdt.ts
+++ b/apps/sync-server/src/services/crdt.ts
@@ -1,5 +1,34 @@
-import { generateCrdtKey } from './blob'
+import { generateCrdtKey, getBlob, putBlob } from './blob'
 import { adjustStorageUsed, reserveStorage } from './quota'
+import { createLogger } from '../lib/logger'
+
+const logger = createLogger('CrdtService')
+
+/**
+ * Refunds a storage reservation after a failed write.
+ *
+ * The refund is itself a D1 write, so during a D1 outage it fails too. It must
+ * never replace the error that actually caused the write to fail: that turns a
+ * typed, handled error into an unhandled one and hides the real cause.
+ */
+const refundReservation = async (
+  db: D1Database,
+  userId: string,
+  reservedBytes: number,
+  context: { operation: string; vaultId: string; noteId: string }
+): Promise<void> => {
+  if (reservedBytes <= 0) return
+  try {
+    await adjustStorageUsed(db, userId, -reservedBytes)
+  } catch (refundError) {
+    // The reservation stays charged to the user until reconciliation.
+    logger.error('storage refund failed', {
+      ...context,
+      reservedBytes,
+      error: refundError instanceof Error ? refundError.message : String(refundError)
+    })
+  }
+}
 
 interface CrdtUpdate {
   id: string
@@ -95,9 +124,11 @@ export const storeUpdates = async (
       sequences.push(row!.sequence_num)
     }
   } catch (error) {
-    if (totalBytes > 0) {
-      await adjustStorageUsed(db, userId, -totalBytes)
-    }
+    await refundReservation(db, userId, totalBytes, {
+      operation: 'storeUpdates',
+      vaultId,
+      noteId
+    })
     throw error
   }
 
@@ -188,7 +219,11 @@ export const storeSnapshot = async (
   }
 
   try {
-    await storage.put(blobKey, snapshotData)
+    // Goes through putBlob so a transient R2 failure is retried and any
+    // remaining failure surfaces as a typed AppError rather than a raw R2
+    // Error the error handler can only log as UNHANDLED_ERROR. The put stays
+    // ahead of the D1 upsert so a failed put writes no orphan row.
+    await putBlob(storage, blobKey, snapshotData, userId)
 
     await db
       .prepare(
@@ -210,9 +245,11 @@ export const storeSnapshot = async (
       )
       .run()
   } catch (error) {
-    if (deltaBytes > 0) {
-      await adjustStorageUsed(db, userId, -deltaBytes)
-    }
+    await refundReservation(db, userId, deltaBytes, {
+      operation: 'storeSnapshot',
+      vaultId,
+      noteId
+    })
     throw error
   }
 
@@ -239,7 +276,9 @@ export const getSnapshot = async (
 
   if (!row) return null
 
-  const obj = await storage.get(row.blob_key)
+  // Legacy rows predate vault scoping but are still `${userId}/`-prefixed, so
+  // the ownership assertion inside getBlob holds for them too.
+  const obj = await getBlob(storage, row.blob_key, userId)
   if (!obj) return null
 
   const snapshotData = await obj.arrayBuffer()


### PR DESCRIPTION
## Update — adversarial-review findings addressed (2026-07-16)

The `needs-work` findings below were worked in this same PR (each fix TDD-first, watched failing on the pre-fix code):

**Fixed**

- **BLOCKING #1 — batch-seed data-integrity regression** (`crdt-sync-coordinator.ts`). The end-of-batch markdown seed loop iterated *all* `noteIds`, so a note whose snapshot baseline was skipped by fix #5 got seeded from local markdown into its open, empty doc — then the next pass's real server snapshot merged as an independent Yjs insertion → **duplicated note body**, triggered on exactly the transient incident this PR targets. The seed loop now iterates `sinceMap.keys()` (baselined notes only). Regression test added (empty state vector for the failed note; fails on the pre-fix loop).
- **NIT [6] / follow-up #4 — refund-masking left live on the item/attachment paths** (`routes/blob.ts`). All **four** unguarded `adjustStorageUsed`-in-`catch` sites (PUT `/blob`, upload `/initiate`, upload `/complete`, PUT manifest) now go through a guarded `refundReservation` helper, mirroring the one `services/crdt.ts` already uses, so a failing D1 refund can no longer replace the real error or mask it as `UNHANDLED_ERROR`, and the reservation is no longer silently leaked without a log. This eliminates the whole bug class, not just the CRDT instance. Route test added (put fails **and** refund throws → client still sees the typed `STORAGE_UPLOAD_FAILED`, not `INTERNAL_ERROR`; fails on the unguarded form).
- **NIT [1] — silent-degradation trap** (`blob.ts`). Retry gate inverted to `canRetry = !(data instanceof ReadableStream)` so a future buffered non-`ArrayBuffer` body keeps its retry instead of silently losing it. Behaviour-identical for every current caller (all pass `ArrayBuffer`).
- **NIT [4] — abort branch untested** (`crdt-sync-coordinator.ts`). Added a test proving an `AbortError` during a batch baseline propagates (aborts the pass) rather than being swallowed as a skipped note.

**Deferred, with rationale (each independently re-verified against the code)**

- **NIT [2] info-disclosure** — the new raw-R2-text echo is owner-only infrastructure text (no secrets; payloads are E2E-encrypted); a constant-message fix belongs in the shared classifier and would change item/attachment message behaviour beyond this triage's evidence. Follow-up.
- **NIT [3] retry blast radius** — retries are bounded (2× 100/250ms, transient-only), the body is already buffered in Worker memory, and a large upload is exactly the case that *wants* to survive a transient blip; a size gate adds signature churn for a rare-tail latency concern.
- **NIT [5] retryable-flag change** — already covered by `retry.test.ts:70-79` composed with `sync-errors.test.ts:24-30`; the flip to `retryable:true` is the intended semantics for the `retryOn429:false` callers.
- **NIT [7] real timers in `blob.test.ts`** — test-only (~450ms); the fake-timer choreography adds maintenance surface for little gain.

Follow-ups #1–#3 (batch snapshot-baseline endpoint, reservation reconcile path, D1-row-without-R2 prune edge) remain genuinely separate PRs.

**New follow-up (found by the pre-merge verification pass):** two more instances of the same refund-masking pattern live in `services/sync.ts` (`:385-390` and `:453-458`, the item-**push** path). Left out of this PR on purpose — it is a different code path with a different symptom (the outer catch at `:461-466` downgrades a `reason` code, it never becomes an `UNHANDLED_ERROR` 500) and has no evidence in this 2-day window. Same one-line fix (route both through a guarded refund) tracked separately.

**No new schema, contract, IPC, sync-protocol, vault-format, or migration change.** Behaviour-only; server and desktop remain deploy-order independent.

**Re-verification**

| Check | Result |
|---|---|
| `apps/sync-server` full vitest | **668 passed, 0 failed** |
| `pnpm --filter @memry/desktop test:main` | **3498 passed, 1 skipped** |
| `pnpm typecheck` (all packages) | **pass (16/16)** |
| `pnpm lint` (changed files) | **pass, 0 errors** |

---

## Production evidence

All 27 server 5xx in a 2-day Loki window came from one user, all on CRDT routes:

- **24x `UNHANDLED_ERROR` 500 on `POST /sync/crdt/snapshot`**, message `put: Please look at https://www.cloudflarestatus.com for issues` — a tight burst on 2026-07-14 14:57:41 → 15:02:23 (~5 min). A transient Cloudflare R2 incident.
- 2x `UNHANDLED_ERROR` 500 `GET /sync/crdt/updates` — `D1_ERROR: Network connection lost.`
- 1x `UNHANDLED_ERROR` 500 `GET /sync/crdt/snapshot/:value` — `D1_ERROR: internal error`

Separately, 25x `RATE_LIMITED` 429 from the same user in a **different** window (07-13 15:11–15:14).

**This was not a retry storm.** The 500s and 429s hit different rate-limit buckets (`crdt_push` vs `crdt_pull`) in different windows. Client backoff is sound and is left alone. **User impact was low**: snapshots are a compaction optimization, the authoritative state is the `crdt_updates` log, and `POST /updates` logged zero 500s.

The real defect is that transient infra **looked like an application crash** and polluted the unhandled-error signal.

## The fix

**Server**

1. **The CRDT path bypassed our own R2 wrapper.** `services/crdt.ts` called `storage.put` raw while `services/blob.ts` has `putBlob()` — the sanctioned wrapper that classifies R2 failures into typed `AppError`s. A raw R2 `Error` therefore propagated to `lib/errors.ts`, which can only log a non-`AppError` as `UNHANDLED_ERROR` + 500. CRDT snapshot reads/writes now go through `getBlob`/`putBlob`.
2. **Quota refund masked the real error and leaked the reservation.** The refund is itself a D1 write; during the D1 outage it failed too, its error *replaced* the real one, and the reserved bytes stayed charged to the user permanently. The refund is now isolated in its own try/catch so the original error always propagates, and a failed refund is logged.
3. **No retry on an idempotent put.** The R2 key is deterministic, so a put retry overwrites the same object. `putBlob` now retries transient failures **twice (100ms, 250ms)** — worst case ~350ms of added *wall* time (awaiting I/O, not Worker CPU budget). Quota/permission rejections are terminal and are not retried. **Stream bodies are never retried** — a consumed stream cannot be replayed without risking a partial upload (all current callers pass `ArrayBuffer`). Short bounded backoff would likely have absorbed all 24 errors invisibly.

**Desktop**

4. **429 was retried inside a serial loop.** No CRDT call site passed `retryOn429: false`, despite `lib/retry.ts` warning about exactly this. A 429'd baseline GET blocked the serial loop for `Retry-After` (up to 60s) x3 → up to ~3 min stalled on one note. Now passed at the three CRDT pull sites; the pass cadence is the retry.
5. **One bad note killed the whole pass.** The catch sat *outside* the per-note loop, so a `DeadLetterError` on note #37 of 500 abandoned every remaining note. The baseline failure is now handled inside the loop (abort still propagates).

Ordering was already safe (R2 put before D1 upsert; prune only after a successful store) and is unchanged.

## Compat / migration plan

**No schema, contract, or format change. No migration.** Behaviour-only.

- **Blob key format**: `getSnapshot` now goes through `getBlob`, which asserts the key is `${userId}/`-prefixed. Legacy pre-vault-scoping rows (`${userId}/crdt/${noteId}/snapshot`, changed in e8d9913b6) share that prefix, so the assertion holds for rows written by older versions.
- **Server/desktop independent**: the server change is strictly error-classification + retry; old clients see the same success responses, and a persistent failure changes only the error *code* (`STORAGE_UPLOAD_FAILED` instead of `INTERNAL_ERROR`) on an already-500 path. The desktop change is client-local. Deploy order does not matter.
- `putBlob` is shared with the item/attachment routes; the retry only adds attempts on failures that previously threw immediately, and the existing classification is preserved.

## Verification actually run

| Check | Result |
|---|---|
| `cd apps/sync-server && npx vitest run` (full suite) | **667 passed, 47 files** |
| `pnpm --filter @memry/desktop test:main` | **3496 passed, 1 skipped** |
| `pnpm typecheck` | **pass (exit 0)** |
| `pnpm lint` | **pass, 0 errors** (3 pre-existing warnings in untouched files) |
| `pnpm docs:impact --base <base> --strict` | **pass** |
| `pnpm docs:build` | **pass** |

TDD — every test was watched failing first, for the right reason:

- `expected Error: put: Please look at https://www.cl… to be an instance of AppError` → raw R2 error propagating (bug 1)
- `Expected: "D1_ERROR: Network connection lost." / Received: "D1_ERROR: internal error"` → the refund's own error masking the real cause (bug 2)
- `expected "vi.fn()" to be called 3 times, but got 1 times` → no retry (bug 3)
- `Number of calls: 0` on the batch pull → one note's `DeadLetterError` abandoned the entire pass (bug 5)

Tests cover the exact scenarios: transient put → retried → succeeds → no 500; persistent put → typed `STORAGE_UPLOAD_FAILED` fed through the real `errorHandler`, asserting it is **not** logged as `UNHANDLED_ERROR`; put fails **and** refund throws → original error still propagates and the refund failure is logged; failed snapshot → no D1 row, no prune, update log intact.

Two test fakes returned `null`/`undefined` from `put()`; real R2 resolves to an `R2Object`, and `putBlob` correctly treats null as a failed upload. Corrected them to match real R2.

## Not verified / risks

- **No live Cloudflare verification.** The R2/D1 failure modes are modelled from the Loki messages, not reproduced against real infra. The retry's effectiveness against a real incident is inferred, not measured.
- **Retry budget is a judgement call.** 2 retries / ~350ms worst case is deliberately conservative to protect the Worker budget. A longer incident than the backoff window still surfaces the (now typed) error.
- **A failed refund still leaks the reservation** — it is now logged instead of silently compounding, but there is no reconcile path. Follow-up below.
- The desktop main suite initially failed 31 files in this fresh worktree with `Error: Electron failed to install correctly` (known worktree postinstall skip). Repaired the local Electron install from the cached zip; the numbers above are from the repaired run.

## Follow-ups (deliberately not built here)

1. **Batch snapshot-baseline endpoint** mirroring `/updates/batch` — the real cure for the 429s. The per-note serial `GET /sync/crdt/snapshot/:noteId` fan-out shares the 300/60s `crdt_pull` budget with per-note `GET /updates`. That is an API design change and deserves its own PR.
2. **Reconcile path for leaked storage reservations** after a failed refund.
3. **Low probability, high severity**: if a D1 row ever survives without its R2 object, `getSnapshot` returns null gracefully — but `pruneUpdatesBeforeSnapshot` has by then deleted every update `<= sequence_num`, making the server-side body unrecoverable. The put-before-upsert ordering prevents the known path to this state; not addressed here.
4. **Same refund-masking pattern exists in `routes/blob.ts`** (:76, :518) for the item/attachment upload paths. Left alone to keep this diff scoped to the CRDT evidence.

---

# Context for reviewers

## Where this came from

This PR is one of 8 opened from a **2-day production error-log triage** (2026-07-13 → 07-15, Grafana `/d/memry-logs`, `env=production`, Loki on the VPS).

The whole window held only **161 log lines** — 90 desktop errors, 27 server errors, 44 server warns — across **13 distinct installs**. Cloudflare Analytics Engine gives the denominator: **18 active installs** in those 2 days, **30** over 5 days.

Two things made this triage possible at all, and both are recent:
- **#732** (merged 2026-07-10) fixed `detectBuildChannel` falling back to `process.env.NODE_ENV`, which is undefined in packaged Electron. Before it, every packaged install reported `build_channel="development"` **and** defaulted telemetry OFF. Every desktop line in this window now reads `build_channel=production` on `2026.710.3` — so we are finally seeing real users.
- **#733** (merged 2026-07-10) stopped clean utility-worker exits from firing error events, so what remains is signal.

Low line counts here mean **low telemetry volume, not low impact**. The headline finding of the whole triage — a 58-day, 100%-broken attachment upload — was exposed by exactly **2 log lines**.

## How these PRs were produced

Each production error class was root-caused by a dedicated investigation against the real code before any patch was written, then implemented TDD-first in an isolated worktree, then put through an **adversarial review** whose explicit brief was to find what is wrong rather than to approve.

That review stage earned its keep: **6 of 8 PRs came back `needs-work`**, several with defects that would have merged silently. Its findings are reproduced verbatim below — they are not cosmetic.

**The one question that matters most on every one of these PRs:** *would the new tests actually fail on the base branch?* The 58-day attachment outage survived because both the server suite (R2/D1 fully mocked, self-consistent fixtures like `total_size: 10` with raw bytes) and the desktop suite (`fetch` mocked wholesale) passed green while the seam between them was never exercised. A test that mocks the thing under test proves nothing. Some of these PRs repeated that exact mistake and the reviewer caught it.

## This PR: production evidence

All **27 server 5xx in 2 days came from one user**, all on CRDT routes:
- 24x `UNHANDLED_ERROR` 500 on `POST /sync/crdt/snapshot`, message `put: Please look at https://www.cloudflarestatus.com for issues` — a **tight burst**, 2026-07-14 14:57:41 → 15:02:23 (~5 min). A transient Cloudflare R2 incident.
- 2x `D1_ERROR: Network connection lost.`, 1x `D1_ERROR: internal error`.
- Separately 25x `RATE_LIMITED` 429 from the same user in a **different** window (07-13 15:11–15:14).

## What this is NOT — a hypothesis that was investigated and killed

The obvious read was a retry storm (500 → retry → 429 → retry). **It is not.** The 500s and 429s hit **different rate-limit buckets** (`crdt_push` vs `crdt_pull`) in **different time windows**, so the 500 path cannot produce those 429s. The client's backoff is **sound** — exponential with jitter, honours `Retry-After`. Do not "fix" the backoff. Likewise the R2-put-before-D1-upsert ordering is **already safe** (a failed put writes no orphan row) — do not "fix" the ordering.

User impact is genuinely **low**: snapshots are a compaction optimization; the authoritative state is the `crdt_updates` log and `POST /updates` logged **zero** 500s.

## Our actual bugs (what this PR is for)

1. **The CRDT path bypasses our own R2 wrapper.** `services/crdt.ts:191` calls `storage.put()` raw instead of `putBlob()` (`services/blob.ts:28-66`), which classifies R2 failures into typed `AppError`s. So a raw R2 error propagates all the way to `UNHANDLED_ERROR` 500 — **that is why transient Cloudflare infra looks like an app crash** and pollutes our unhandled-error signal.
2. **Quota refund in the catch masks the real error and leaks the reservation.** `adjustStorageUsed` is itself a D1 write; during a D1 outage it fails too, its error *replaces* the real one, and `throw error` never runs — so reserved bytes stay charged to the user permanently, compounding on every D1 blip.
3. **No retry on an idempotent put.** The R2 key is deterministic, so a retry is safe. 2–3 short retries would likely have absorbed all 24 errors invisibly.

## Deliberately out of scope

The real cure for the 429s is a **batch snapshot-baseline endpoint** mirroring `/updates/batch`, collapsing the per-note serial GET fan-out that shares the 300/60s `crdt_pull` budget. That is an API design change and deserves its own PR. Only the cheap client fixes are here (`retryOn429: false` at pull sites, moving the batch catch inside the loop).

**Also noted, not fixed:** if a D1 row ever survives without its R2 object, `getSnapshot` returns null gracefully **but** `pruneUpdatesBeforeSnapshot` has already deleted every update ≤ `sequence_num` → server-side body unrecoverable. Low probability, high severity.

## Adversarial review findings (verbatim)

> Reproduced exactly as returned. Findings cite file:line — verify them yourself rather than trusting either the author or the reviewer.

VERDICT: needs-work

## TESTS ARE REAL?
YES — verified empirically, not taken on trust. I checked out the branch in a scratch worktree, ran the touched suites (sync-server 37/37, desktop coordinator 10/10 — both claims reproduce), then reverted ONLY the source files (crdt.ts, blob.ts, crdt-sync-coordinator.ts, http-client.ts) while keeping the new tests. Result: 7/7 new server tests and 3/3 new desktop tests FAIL on old code, with exactly the assertion messages the author reported — including the key one, "expected 'D1_ERROR: internal error' to be 'D1_ERROR: Network connection lost.'", proving the refund's own error was literally replacing the real cause. The fakes are keyed to REAL SQL, not self-consistent fiction: createAccountingDatabase's `sql.includes('MAX(0, storage_used + ?)')` matches adjustStorageUsed (quota.ts:60) verbatim, and reserveStorage uses different SQL so the reservation genuinely succeeds before the refund fails — the test reaches the code path it claims to. crdt.test.ts's `bytes()` returns a real ArrayBuffer, so the retry assertions are not vacuous. The test-fake correction (put() returning an R2Object instead of null) moves the fake TOWARD real R2 behavior, which is the right direction.

CAVEAT, and it matters: the two `retryOn429` desktop tests (crdt-sync-coordinator.test.ts:391, :406) assert against a MOCKED withRetry. They prove the option is passed; they do NOT prove a 429 fails fast, because retry.ts's actual `(error.statusCode !== 429 || opts.retryOn429 === false)` never executes. These are wiring pins, not behavior tests. Mitigated by PRE-EXISTING real coverage at retry.test.ts:70-75 which drives a real RateLimitError through a real withRetry with retryOn429:false — so the composition is adequately covered, but only by accident of that test already existing.

The tests' real failure is one of OMISSION, and it hides a live regression: no test covers the note whose baseline FAILED reaching the end-of-batch seeding loop. createBatchContext hardcodes getStateVector to [1,2,3,4] (length>2), so the seed branch is never entered by any of the 3 new tests. I wrote a probe with getStateVector returning an empty vector for the failed note: it PASSES on origin/main and FAILS on the branch. See blocking finding #1.

## BLOCKING

### [1]
DATA INTEGRITY REGRESSION (verified empirically) — apps/desktop/src/main/sync/engine/crdt-sync-coordinator.ts:278. The end-of-batch markdown seeding loop iterates `for (const noteId of noteIds)` — ALL notes — including notes whose snapshot baseline just failed and were skipped by the NEW catch at :204. Those docs were opened with `{ skipSeed: true }` (:193), so their state vector is still empty → `postVector.length <= 2` → `seedFromMarkdownPublic(noteId)` fires, which seeds the Y.Doc from local markdown AND PERSISTS it (crdt-provider.ts:553-556, `persistence.storeUpdate`). The server DOES have that snapshot; we merely failed to fetch it. On the next successful pass the real snapshot is applied via applyRemoteUpdate and Yjs merges the two independent insertions → DUPLICATED NOTE BODY. Before this PR a baseline throw propagated out of the loop, so the seeding loop never ran for that pass — this is a NEW failure mode, introduced by fix #5, and it triggers on EXACTLY the transient-server incident this PR exists to fix. PROOF: probe test (getStateVector → empty for the failed note, fetchCrdtSnapshot → DeadLetterError for note-2) PASSES on origin/main, FAILS on the branch with `expected "vi.fn()" to not be called with arguments: [ 'note-2' ] / Number of calls: 1`. Two tells confirm this is real and not pre-existing: (a) the older `open()`-failure `continue` at :199 is safe only BY ACCIDENT — that note is not in `this.docs`, so seedFromMarkdownPublic returns early at crdt-provider.ts:561-563; the new skip path leaves the doc OPEN, which is precisely what makes it dangerous; (b) applyCrdtIncrementals (:160) keeps its identical seed fallback INSIDE the try, so a baseline throw skips the seed — the batch path is now inconsistent with the single-note path it is supposed to mirror. FIX: seed only notes that reached a successful baseline — iterate `sinceMap.keys()` instead of `noteIds`, or track a `failedBaseline` Set and exclude it. Add the probe as a regression test; the existing createBatchContext hardcodes getStateVector to [1,2,3,4] so no current test can catch this.

## NITS

- [1] SILENT-DEGRADATION TRAP — apps/sync-server/src/services/blob.ts:69: `const canRetry = data instanceof ArrayBuffer`. I traced all 6 production callers and they DO all pass real ArrayBuffers today (routes/blob.ts:76 `c.req.arrayBuffer()`, :270, :346 `manifestBytes.buffer as ArrayBuffer`, :518; services/sync.ts:384 `.slice().buffer`; services/crdt.ts:226 ← sync.ts:161 `decodeCrdtPayload` returns `bytes.slice().buffer as ArrayBuffer`), so the headline retry is NOT a no-op in prod. But the failure mode is silent: the param is typed `ArrayBuffer | ReadableStream`, and callers already use `as ArrayBuffer` casts (routes/blob.ts:346) that bypass the checker. A future caller passing a Uint8Array turns the retry off with zero test failures — the exact 'passes tests, broken in prod' shape the brief says survived 58 days. Invert the default: `const canRetry = !(data instanceof ReadableStream)` so the fallback is 'retry' rather than 'silently don't'.

- [2] INFO DISCLOSURE CHANGE — apps/sync-server/src/services/blob.ts:44 + lib/errors.ts formatErrorResponse. Routing the CRDT snapshot path through putBlob means the raw R2 error text is now echoed to the client: `Blob upload failed: ${msg}` goes into the 500 response body verbatim. Previously a raw R2 Error hit the non-AppError branch of errorHandler and got masked as a generic 'Internal server error'. Today's payload is harmless (a cloudflarestatus.com URL) but the message is arbitrary provider text. Prefer a constant client-facing message with the detail attached to the log/telemetry only. (Pre-existing pattern for other putBlob callers, so kind-consistent — but this PR newly extends it to the CRDT path.)

- [3] BLAST RADIUS — retry now applies to the 500MB item-upload path (routes/blob.ts:76, MAX_FILE_SIZE), not just the ≤5MB CRDT snapshots the incident evidence covers. A persistently failing 500MB put is now attempted 3x. The author disclosed this honestly. Consider gating the retry on a size threshold or making it opt-in per call site so the retry budget matches the evidence that justified it.

- [4] UNTESTED NEW BRANCH — crdt-sync-coordinator.ts:204, `if (err instanceof DOMException && err.name === 'AbortError') throw err`. No test covers it; all 3 new desktop tests use a plain `Error` with `name='DeadLetterError'`. Abort-propagation through the new catch is exactly the kind of thing that silently breaks (e.g. if an AbortError ever arrives as a plain Error rather than a DOMException, a shutdown would be swallowed and logged as a skipped note). Worth one test.

- [5] BEHAVIOR CHANGE WORTH NAMING — retryOn429:false means a 429 now surfaces as RateLimitError (classifyError → rate_limited, retryable:TRUE) instead of DeadLetterError(RateLimitError) (→ retryable:FALSE, sync-errors.ts:15-18). Arguably an improvement and consistent with the existing linking-service.ts:333 precedent, but it is a real change to the retryable flag that no test asserts.

- [6] KNOWN-BUG-LEFT-LIVE — routes/blob.ts:76-80 and :515-522 still contain the IDENTICAL refund-masking pattern this PR fixes in crdt.ts (unguarded `adjustStorageUsed` inside the catch, whose throw replaces the real error). The author disclosed this as follow-up #4 and scoping to the CRDT evidence is defensible — but be explicit that the same production failure mode remains live on the item and attachment-manifest upload paths, and that the next D1 incident will produce the same masked UNHANDLED_ERRORs there.

- [7] blob.test.ts retry tests use real timers — 'should retry twice before giving up' sleeps a real 350ms (100+250). Minor suite-time cost; vi.useFakeTimers() would remove it.

- [8] VERIFIED CLEAN (no action): no Co-Authored-By, no agent/tool branding in the two commits, branch name is code-context. createLogger used, not console.*. No packages/contracts changes → ipc:generate/ipc:check correctly not required. No new desktop telemetry fields, so no toSafeToken exposure — the new log.warn at :207 is electron-log, and refundReservation's logger.error is a server-side structured log, neither touches the captureServerError/toSafeToken path. Backward compat holds: legacy blob key `${userId}/crdt/${noteId}/snapshot` and current `${userId}/vaults/${vaultId}/...` both satisfy assertKeyBelongsToUser's `${userId}/` prefix check, so getSnapshot still reads legacy rows with no migration; old desktop clients classify the new typed 500 as retryable 'server_error' exactly as before (sync-errors.ts:68-72). Docs section matches the code.

