### PR TITLE
fix(attachments): declare encrypted upload size, surface failures, and test the client/server seam

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -245,6 +245,64 @@ jobs:
           path: apps/desktop/test-results/
           if-no-files-found: ignore
 
+  e2e-smoke-macos:
+    name: Electron E2E smoke (macOS)
+    # Push-to-main only, matching the ubuntu and Windows e2e jobs: a macOS
+    # runner is the most expensive minute GitHub bills (10x ubuntu), and PRs
+    # already run lint + typecheck + unit + ubuntu coverage, plus the attachment
+    # client/server integration spec in sync-server-ci.
+    # No xvfb: macOS runners have a window server. ensure-native.sh is used
+    # directly (it is bash-native and works here — the Windows job hand-rolls the
+    # rebuild + stamp only because ensure-native.sh breaks under MSYS).
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        env:
+          SKIP_ELECTRON_REBUILD: 1
+        run: pnpm install --frozen-lockfile
+
+      - name: Build desktop app
+        run: |
+          bash apps/desktop/scripts/check-cert-hashes.sh
+          bash apps/desktop/scripts/ensure-native.sh electron
+          pnpm --filter @memry/desktop exec electron-vite build
+
+      - name: Run Electron smoke tests
+        run: |
+          bash apps/desktop/scripts/ensure-native.sh electron
+          pnpm --filter @memry/desktop exec playwright test \
+            --config config/playwright.config.ts \
+            tests/e2e/startup-recovery.e2e.ts \
+            tests/e2e/vault.e2e.ts \
+            tests/e2e/notes.e2e.ts \
+            tests/e2e/tasks.e2e.ts \
+            tests/e2e/file-attachments-viewer.e2e.ts
+
+      - name: Upload E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-smoke-macos-results
+          path: apps/desktop/test-results/
+          if-no-files-found: ignore
+
   e2e-smoke-windows:
     name: Electron E2E smoke (Windows)
     # Push-to-main only, matching the ubuntu e2e-smoke/e2e-full jobs: Windows
@@ -323,7 +381,8 @@ jobs:
             tests/e2e/startup-recovery.e2e.ts \
             tests/e2e/vault.e2e.ts \
             tests/e2e/notes.e2e.ts \
-            tests/e2e/tasks.e2e.ts
+            tests/e2e/tasks.e2e.ts \
+            tests/e2e/file-attachments-viewer.e2e.ts
 
       - name: Upload E2E artifacts
         if: always()

--- a/.github/workflows/sync-server-ci.yml
+++ b/.github/workflows/sync-server-ci.yml
@@ -9,6 +9,10 @@ on:
       - 'packages/shared/**'
       - 'packages/sync-core/**'
       - 'tests/sync-harness/**'
+      # The attachment client is exercised against the real Worker by the
+      # integration spec below, so a client-side change must re-run this job.
+      - 'apps/desktop/src/main/sync/attachments.ts'
+      - 'apps/desktop/src/main/sync/attachments.integration.test.ts'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
@@ -22,6 +26,10 @@ on:
       - 'packages/shared/**'
       - 'packages/sync-core/**'
       - 'tests/sync-harness/**'
+      # The attachment client is exercised against the real Worker by the
+      # integration spec below, so a client-side change must re-run this job.
+      - 'apps/desktop/src/main/sync/attachments.ts'
+      - 'apps/desktop/src/main/sync/attachments.integration.test.ts'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
@@ -81,6 +89,18 @@ jobs:
 
       - name: Run sync protocol harness
         run: pnpm --filter @memry/sync-harness test
+
+      # Real client against the real Worker (miniflare + real D1 + real R2).
+      # Both sides' unit suites mock this seam and stayed green through a 58-day
+      # attachment upload outage, so this is the job that actually covers it.
+      # Needs no Electron binary and no display server (the spec injects fetchFn
+      # and stubs the electron import), and runs in seconds.
+      - name: Run attachment client/server integration spec
+        run: |
+          pnpm --filter @memry/desktop exec vitest run \
+            --config config/vitest.config.ts \
+            --project main \
+            src/main/sync/attachments.integration.test.ts
 
       - name: Validate Worker bundle
         run: pnpm --filter @memry/sync-server exec wrangler deploy --dry-run --outdir .wrangler/ci --env staging

--- a/apps/desktop/src/main/billing/entitlement-cache.test.ts
+++ b/apps/desktop/src/main/billing/entitlement-cache.test.ts
@@ -15,6 +15,7 @@ vi.mock('../store', () => ({
 
 import {
   isPaidBillingStatus,
+  getCachedMaxFileSize,
   getCachedEntitlement,
   setCachedEntitlementFromStatus
 } from './entitlement-cache'
@@ -57,14 +58,54 @@ describe('entitlement-cache', () => {
     expect(getCachedEntitlement()).toBeNull()
   })
 
+  it('getCachedMaxFileSize returns the cached plan limit', () => {
+    const s = status('plus', 'active')
+    s.limits.maxFileSize = 5 * 1024 * 1024
+    setCachedEntitlementFromStatus(s)
+    expect(getCachedMaxFileSize()).toBe(5 * 1024 * 1024)
+  })
+
+  it('getCachedMaxFileSize returns null on a cold cache', () => {
+    expect(getCachedMaxFileSize()).toBeNull()
+  })
+
+  it('getCachedMaxFileSize returns null for a store written before limits existed', () => {
+    // Real users' electron-store files have entitlement rows with no `limits`
+    // key. Reading one must fail open (null = defer to the server), never block.
+    storeData.sync = { entitlement: { isPaid: true, plan: 'plus', status: 'active' } }
+    expect(getCachedMaxFileSize()).toBeNull()
+  })
+
+  it('getCachedMaxFileSize returns null for an implausible cached limit', () => {
+    storeData.sync = {
+      entitlement: { isPaid: true, plan: 'plus', status: 'active', limits: { maxFileSize: 0 } }
+    }
+    expect(getCachedMaxFileSize()).toBeNull()
+  })
+
   it('setCachedEntitlementFromStatus writes a cache and getCachedEntitlement reads it', () => {
     const written = setCachedEntitlementFromStatus(status('plus', 'active'))
-    expect(written).toEqual({ isPaid: true, plan: 'plus', status: 'active' })
-    expect(getCachedEntitlement()).toEqual({ isPaid: true, plan: 'plus', status: 'active' })
+    expect(written).toEqual({
+      isPaid: true,
+      plan: 'plus',
+      status: 'active',
+      limits: { maxFileSize: 0 }
+    })
+    expect(getCachedEntitlement()).toEqual({
+      isPaid: true,
+      plan: 'plus',
+      status: 'active',
+      limits: { maxFileSize: 0 }
+    })
   })
 
   it('caches an unpaid status as isPaid=false', () => {
     setCachedEntitlementFromStatus(status('free', 'inactive'))
-    expect(getCachedEntitlement()).toEqual({ isPaid: false, plan: 'free', status: 'inactive' })
+    expect(getCachedEntitlement()).toEqual({
+      isPaid: false,
+      plan: 'free',
+      status: 'inactive',
+      limits: { maxFileSize: 0 }
+    })
   })
 })

--- a/apps/desktop/src/main/billing/entitlement-cache.ts
+++ b/apps/desktop/src/main/billing/entitlement-cache.ts
@@ -19,8 +19,28 @@ export function setCachedEntitlementFromStatus(s: BillingStatus): CachedEntitlem
   const cached: CachedEntitlement = {
     isPaid: isPaidBillingStatus(s),
     plan: s.plan,
-    status: s.status
+    status: s.status,
+    // Carry the file-size limit so an attachment upload can be rejected before
+    // the expensive read+hash+encrypt pass instead of after a server 413.
+    limits: { maxFileSize: s.limits.maxFileSize }
   }
   store.set('sync', { ...store.get('sync'), entitlement: cached })
   return cached
+}
+
+/**
+ * Cached plan file-size limit, or null when unknown.
+ *
+ * Null means "no opinion, let the server decide": the cache is only populated on
+ * a billing fetch, so it is legitimately absent on a cold start or on a store
+ * written by an older version. Callers must fail open — never block an upload on
+ * a cold cache.
+ */
+export function getCachedMaxFileSize(): number | null {
+  const cached = getCachedEntitlement()
+  const maxFileSize = cached?.limits?.maxFileSize
+  if (typeof maxFileSize !== 'number' || !Number.isFinite(maxFileSize) || maxFileSize <= 0) {
+    return null
+  }
+  return maxFileSize
 }

--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
@@ -15,6 +15,8 @@ import {
 } from '@memry/contracts/ipc-attachments'
 
 import { AttachmentSyncService, type TransferProgress } from '../sync/attachments'
+import { getCachedMaxFileSize } from '../billing/entitlement-cache'
+import { trackMainError } from '../telemetry/diagnostics'
 import { UploadQueue } from '../sync/upload-queue'
 import { attachmentEvents } from '../sync/attachment-events'
 import { markWritebackIgnored } from '../sync/crdt-writeback'
@@ -77,6 +79,7 @@ const getOrCreateAttachmentService = (): AttachmentSyncService | null => {
   if (attachmentService) return attachmentService
 
   attachmentService = new AttachmentSyncService({
+    getMaxFileSize: () => getCachedMaxFileSize(),
     getAccessToken: () => getValidAccessToken(),
     getVaultKey: async () => {
       if (!isDatabaseInitialized()) return null
@@ -263,6 +266,10 @@ export function registerAttachmentHandlers(): void {
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
         logger.error('Attachment upload failed', { noteId, diskPath, error: message })
+        // electron-log alone kept this outage invisible for 58 days — the only
+        // reason it surfaced was a server-side 413. Route it to telemetry too so
+        // an attachment outage is visible from the client side.
+        trackMainError('sync_attachments', 'attachment_upload_failed', err)
         for (const win of BrowserWindow.getAllWindows()) {
           win.webContents.send(SYNC_EVENTS.ATTACHMENT_UPLOAD_FAILED, {
             noteId,

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -24,6 +24,16 @@ export interface CachedEntitlement {
   isPaid: boolean
   plan: string
   status: string
+  /**
+   * Plan limits from the last billing status. Optional: stores written by older
+   * app versions have no `limits` key, and it is only populated on a billing
+   * fetch — so every reader must tolerate it being absent and fall back to
+   * server-authoritative behaviour rather than blocking.
+   */
+  limits?: {
+    /** Max plaintext bytes per file the plan allows. */
+    maxFileSize: number
+  }
 }
 
 /**

--- a/apps/desktop/src/main/sync/attachments.integration.test.ts
+++ b/apps/desktop/src/main/sync/attachments.integration.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Attachment upload/download against a REAL sync-server.
+ *
+ * Every other attachment test on both sides mocks the seam: the desktop suite
+ * mocks `fetch` wholesale and the sync-server suite mocks R2/D1 with
+ * self-consistent numbers. Both stayed green for 58 days while chunked upload
+ * was 413ing in production, because nothing exercised client and server
+ * together. This spec boots the real Worker (miniflare + real D1 migrations +
+ * real R2) and drives the real client against it, so the size accounting, the
+ * route prefix and the plan gates are all checked for real.
+ *
+ * No Electron and no display server needed — `fetchFn` is injected, so the
+ * `net` import is never dereferenced.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { randomUUID, randomBytes } from 'node:crypto'
+import path from 'node:path'
+import os from 'node:os'
+import sodium from 'libsodium-wrappers-sumo'
+
+// `attachments.ts` imports `net` from electron at module scope. This spec injects
+// `fetchFn`, so `net` is never dereferenced — stub the import so the suite runs on a
+// plain Node worker (no Electron binary, no display server).
+vi.mock('electron', () => ({
+  net: {
+    fetch: () => {
+      throw new Error('net.fetch must not be used — this spec injects fetchFn')
+    }
+  }
+}))
+
+import { AttachmentSyncService, type AttachmentSyncDeps } from './attachments'
+
+const MIB = 1024 * 1024
+// nonce(24) + Poly1305 tag(16) — mirrors the server's CHUNK_CRYPTO_OVERHEAD.
+const CHUNK_CRYPTO_OVERHEAD = 40
+
+// Mirrors the harness usage in apps/desktop/tests/e2e/utils/sync-backend.ts.
+type Harness = {
+  start(): Promise<void>
+  stop(): Promise<void>
+  getD1(): Promise<D1Database>
+  getDirectUrl(): Promise<URL>
+  createAccessToken(userId: string, deviceId: string): Promise<string>
+}
+
+let server: Harness
+let baseUrl: string
+let tmpDir: string
+
+interface SeededUser {
+  userId: string
+  deviceId: string
+  token: string
+}
+
+async function seedUser(opts: {
+  plan: string
+  status: string
+  maxFileSize: number
+  storageLimit: number
+}): Promise<SeededUser> {
+  const db = await server.getD1()
+  const userId = randomUUID()
+  const deviceId = randomUUID()
+  const now = Math.floor(Date.now() / 1000)
+
+  await db
+    .prepare(
+      `INSERT INTO users (id, email, email_verified, auth_method, storage_used, storage_limit, created_at, updated_at)
+       VALUES (?, ?, 1, 'otp', 0, ?, ?, ?)`
+    )
+    .bind(userId, `${userId}@example.test`, opts.storageLimit, now, now)
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO sync_entitlements (
+         user_id, plan, status, source, storage_limit, max_file_size, max_vaults, version_history_days, updated_at
+       ) VALUES (?, ?, ?, 'test_seed', ?, ?, NULL, 365, ?)`
+    )
+    .bind(userId, opts.plan, opts.status, opts.storageLimit, opts.maxFileSize, now)
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO devices (id, user_id, name, platform, app_version, auth_public_key, vault_id, created_at, updated_at)
+       VALUES (?, ?, 'test-device', 'test', '99.0.0', ?, 'default', ?, ?)`
+    )
+    .bind(deviceId, userId, `pubkey-${deviceId}`, now, now)
+    .run()
+
+  await db
+    .prepare('INSERT INTO server_cursor_sequence (user_id, current_cursor) VALUES (?, 0)')
+    .bind(userId)
+    .run()
+
+  const token = await server.createAccessToken(userId, deviceId)
+  return { userId, deviceId, token }
+}
+
+/**
+ * Real client deps. The signing keypair is shared with `getDevicePublicKey` so
+ * the manifest signature verifies on the download side.
+ */
+function createDeps(user: SeededUser): AttachmentSyncDeps {
+  const signing = sodium.crypto_sign_keypair()
+  const vaultKey = sodium.randombytes_buf(32)
+
+  return {
+    getAccessToken: async () => user.token,
+    getVaultKey: async () => vaultKey,
+    getSigningKeys: async () => ({
+      secretKey: signing.privateKey,
+      publicKey: signing.publicKey,
+      deviceId: user.deviceId
+    }),
+    getDevicePublicKey: async () => signing.publicKey,
+    getSyncServerUrl: () => baseUrl,
+    // Real HTTP against the miniflare listener — not a mock.
+    fetchFn: (input, init) => fetch(input as RequestInfo, init as RequestInit)
+  }
+}
+
+async function writeTempFile(name: string, bytes: Uint8Array): Promise<string> {
+  const p = path.join(tmpDir, name)
+  await writeFile(p, bytes)
+  return p
+}
+
+beforeAll(async () => {
+  await sodium.ready
+  const mod = await import('../../../../../tests/sync-harness/src/simulated-server.ts')
+  server = new mod.SimulatedServer() as Harness
+  await server.start()
+  const url = await server.getDirectUrl()
+  // origin, not href: href carries a trailing slash and the client appends '/sync/...'.
+  baseUrl = url.origin
+}, 180_000)
+
+afterAll(async () => {
+  await server?.stop()
+})
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), 'memry-attach-int-'))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+describe('attachment upload/download against the real sync-server', () => {
+  it('round-trips a single-chunk file with identical bytes', async () => {
+    const user = await seedUser({
+      plan: 'believer',
+      status: 'active',
+      maxFileSize: 200 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+    const svc = new AttachmentSyncService(createDeps(user))
+
+    const original = randomBytes(64 * 1024)
+    const src = await writeTempFile('small.bin', original)
+
+    const result = await svc.uploadAttachment('note-1', src)
+    expect(result.manifest.chunks).toHaveLength(1)
+
+    const dest = path.join(tmpDir, 'small-out.bin')
+    const download = await svc.downloadAttachment(result.attachmentId, dest)
+
+    const roundTripped = await import('node:fs/promises').then((fs) => fs.readFile(dest))
+    expect(Buffer.compare(roundTripped, original)).toBe(0)
+    expect(download.manifest.size).toBe(original.length)
+  }, 120_000)
+
+  it('round-trips a multi-chunk file (>8 MiB) with identical bytes', async () => {
+    const user = await seedUser({
+      plan: 'believer',
+      status: 'active',
+      maxFileSize: 200 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+    const svc = new AttachmentSyncService(createDeps(user))
+
+    // 20 MiB => 3 chunks at CHUNK_SIZE = 8 MiB. Each chunk adds nonce(24)+tag(16),
+    // so the ciphertext on the wire is 120 bytes larger than the plaintext.
+    const original = randomBytes(20 * MIB)
+    const src = await writeTempFile('big.bin', original)
+
+    const result = await svc.uploadAttachment('note-2', src)
+    expect(result.manifest.chunks).toHaveLength(3)
+
+    const dest = path.join(tmpDir, 'big-out.bin')
+    await svc.downloadAttachment(result.attachmentId, dest)
+
+    const roundTripped = await import('node:fs/promises').then((fs) => fs.readFile(dest))
+    expect(Buffer.compare(roundTripped, original)).toBe(0)
+  }, 180_000)
+
+  it('accepts a Plus-plan file at exactly the 5 MiB limit', async () => {
+    const user = await seedUser({
+      plan: 'plus',
+      status: 'active',
+      maxFileSize: 5 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+    const svc = new AttachmentSyncService(createDeps(user))
+
+    // Exactly at the limit. This is the regression that the 58-day bug caused:
+    // the encrypted bytes exceed the plaintext, so a naive server that measures
+    // ciphertext against the plan limit rejects a legal file.
+    const original = randomBytes(5 * MIB)
+    const src = await writeTempFile('exact.bin', original)
+
+    const result = await svc.uploadAttachment('note-3', src)
+    expect(result.manifest.size).toBe(5 * MIB)
+
+    const dest = path.join(tmpDir, 'exact-out.bin')
+    await svc.downloadAttachment(result.attachmentId, dest)
+    const roundTripped = await import('node:fs/promises').then((fs) => fs.readFile(dest))
+    expect(Buffer.compare(roundTripped, original)).toBe(0)
+  }, 180_000)
+
+  it('rejects an over-limit file on a Plus plan with a file-too-large error', async () => {
+    const user = await seedUser({
+      plan: 'plus',
+      status: 'active',
+      maxFileSize: 5 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+    const svc = new AttachmentSyncService(createDeps(user))
+
+    const src = await writeTempFile('over.bin', randomBytes(6 * MIB))
+
+    await expect(svc.uploadAttachment('note-4', src)).rejects.toThrow(/plan file size limit/i)
+  }, 120_000)
+
+  it('rejects upload on a free plan with payment required', async () => {
+    const user = await seedUser({
+      plan: 'free',
+      status: 'inactive',
+      maxFileSize: 0,
+      storageLimit: 0
+    })
+    const svc = new AttachmentSyncService(createDeps(user))
+
+    const src = await writeTempFile('free.bin', randomBytes(1024))
+
+    await expect(svc.uploadAttachment('note-5', src)).rejects.toThrow()
+  }, 120_000)
+
+  it('declares the exact encrypted byte total on initiate', async () => {
+    // The server can derive this, but only by assuming today's chunk framing.
+    // Declaring it explicitly keeps quota accounting correct if the client's
+    // cipher or chunking ever changes, and the server validates it for
+    // plausibility rather than trusting it.
+    const user = await seedUser({
+      plan: 'believer',
+      status: 'active',
+      maxFileSize: 200 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+
+    let initiateBody: Record<string, unknown> | null = null
+    const deps = createDeps(user)
+    const realFetch = deps.fetchFn!
+    deps.fetchFn = async (input, init) => {
+      const url = typeof input === 'string' ? input : String(input)
+      if (url.endsWith('/sync/attachments/upload/initiate') && typeof init?.body === 'string') {
+        initiateBody = JSON.parse(init.body) as Record<string, unknown>
+      }
+      return realFetch(input, init)
+    }
+
+    const svc = new AttachmentSyncService(deps)
+    const original = randomBytes(20 * MIB)
+    const src = await writeTempFile('declared.bin', original)
+    const result = await svc.uploadAttachment('note-6', src)
+
+    const onWire = result.manifest.chunks.reduce(
+      (sum, c) => sum + c.size + CHUNK_CRYPTO_OVERHEAD,
+      0
+    )
+    expect(initiateBody).not.toBeNull()
+    expect(initiateBody!.totalSize).toBe(20 * MIB)
+    expect(initiateBody!.encryptedSize).toBe(onWire)
+
+    // ...and the server charged storage against the ciphertext, not the
+    // plaintext. This is the property the 58-day bug violated: the wire bytes
+    // exceed `totalSize`, so accounting on `totalSize` under-counts quota and
+    // makes the chunk guard reject a legal upload.
+    const db = await server.getD1()
+    const row = await db
+      .prepare('SELECT storage_used FROM users WHERE id = ?')
+      .bind(user.userId)
+      .first<{ storage_used: number }>()
+    expect(row!.storage_used).toBeGreaterThanOrEqual(onWire)
+    expect(row!.storage_used).toBeGreaterThan(20 * MIB)
+  }, 180_000)
+
+  it('talks to the real /sync route prefix', async () => {
+    // The mocked suite matches with `urlStr.includes(path)`, which passes for a
+    // wrong base path too. Assert the real mount (index.ts: app.route('/sync', blob)).
+    const user = await seedUser({
+      plan: 'believer',
+      status: 'active',
+      maxFileSize: 200 * MIB,
+      storageLimit: 50 * 1024 * MIB
+    })
+
+    const resp = await fetch(`${baseUrl}/sync/attachments/upload/initiate`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        attachmentId: randomUUID(),
+        filename: 'probe.bin',
+        totalSize: 1024,
+        chunkCount: 1
+      })
+    })
+    expect(resp.status).toBe(201)
+
+    // ...and that the un-prefixed path is NOT a route.
+    const unprefixed = await fetch(`${baseUrl}/attachments/upload/initiate`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        attachmentId: randomUUID(),
+        filename: 'probe.bin',
+        totalSize: 1024,
+        chunkCount: 1
+      })
+    })
+    expect(unprefixed.status).toBe(404)
+  }, 120_000)
+})

--- a/apps/desktop/src/main/sync/attachments.test.ts
+++ b/apps/desktop/src/main/sync/attachments.test.ts
@@ -142,7 +142,12 @@ describe('AttachmentSyncService', () => {
       await expect(service.uploadAttachment('note-1', testFile)).rejects.toThrow('empty file')
     })
 
-    it('should skip dedup-existing chunks', async () => {
+    it('uploads every chunk without probing for server-side dedup', async () => {
+      // The old client HEAD-probed each chunk hash for dedup before uploading.
+      // That probe could never hit: the file key is random per upload and the
+      // nonce is random per chunk, so `encryptedHash` is unique every time. It
+      // cost a guaranteed-miss round-trip per chunk (and produced the 404 noise
+      // on HEAD /sync/attachments/chunks/:hash). Pin that it is gone.
       const testFile = path.join(tmpDir, 'dedup.txt')
       await writeFile(testFile, Buffer.alloc(512, 'B'))
 
@@ -162,7 +167,10 @@ describe('AttachmentSyncService', () => {
           expiresAt: 0
         }
       })
-      responses.set('HEAD /attachments/chunks/', { status: 200 })
+      responses.set('PUT /attachments/upload/session-2/chunk/0', {
+        status: 200,
+        body: { success: true, uploadedChunks: 1 }
+      })
       responses.set('POST /attachments/upload/session-2/complete', {
         status: 200,
         body: { success: true }
@@ -179,7 +187,116 @@ describe('AttachmentSyncService', () => {
         ([url, init]: [string, RequestInit]) =>
           init?.method === 'PUT' && typeof url === 'string' && url.includes('/chunk/')
       )
-      expect(putCalls).toHaveLength(0)
+      expect(putCalls).toHaveLength(1)
+
+      const headCalls = mockFetch.mock.calls.filter(
+        ([, init]: [string, RequestInit]) => init?.method === 'HEAD'
+      )
+      expect(headCalls).toHaveLength(0)
+    })
+
+    it('declares the encrypted byte total, not the plaintext size, on initiate', async () => {
+      // Regression guard for the 58-day outage: chunks go on the wire as
+      // nonce || ciphertext, so the bytes stored exceed the plaintext size.
+      const testFile = path.join(tmpDir, 'sizes.txt')
+      await writeFile(testFile, Buffer.alloc(512, 'D'))
+
+      const responses = new Map<string, { status: number; body?: unknown; binary?: Uint8Array }>()
+      responses.set('POST /attachments/upload/initiate', {
+        status: 200,
+        body: { sessionId: 'session-3', expiresAt: Date.now() + 3600000 }
+      })
+      responses.set('GET /attachments/upload/session-3', {
+        status: 200,
+        body: {
+          sessionId: 'session-3',
+          attachmentId: '',
+          totalSize: 0,
+          chunkCount: 1,
+          uploadedChunks: [],
+          expiresAt: 0
+        }
+      })
+      responses.set('PUT /attachments/upload/session-3/chunk/0', {
+        status: 200,
+        body: { success: true, uploadedChunks: 1 }
+      })
+      responses.set('POST /attachments/upload/session-3/complete', {
+        status: 200,
+        body: { success: true }
+      })
+
+      const mockFetch = createMockFetch(responses)
+      const service = new AttachmentSyncService(createTestDeps(mockFetch))
+      await service.uploadAttachment('note-1', testFile)
+
+      const initiateCall = mockFetch.mock.calls.find(
+        ([url, init]: [string, RequestInit]) =>
+          init?.method === 'POST' && typeof url === 'string' && url.includes('/initiate')
+      )
+      const body = JSON.parse((initiateCall![1] as RequestInit).body as string)
+      expect(body.totalSize).toBe(512)
+      // nonce(24) + Poly1305 tag(16) on the single chunk.
+      expect(body.encryptedSize).toBe(512 + 40)
+    })
+
+    it('rejects a file over the cached plan limit before reading or encrypting it', async () => {
+      const testFile = path.join(tmpDir, 'toobig.txt')
+      await writeFile(testFile, Buffer.alloc(2048, 'E'))
+
+      const mockFetch = createMockFetch(new Map())
+      const deps: AttachmentSyncDeps = {
+        ...createTestDeps(mockFetch),
+        getMaxFileSize: () => 1024
+      }
+      const service = new AttachmentSyncService(deps)
+
+      await expect(service.uploadAttachment('note-1', testFile)).rejects.toThrow(
+        /larger than your plan allows/i
+      )
+      // Nothing hit the network: the point is to avoid the read+hash+encrypt pass.
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('falls back to server authority when the cached plan limit is unknown', async () => {
+      // The entitlement cache is only warm after a billing fetch. A cold cache
+      // must never block an upload.
+      const testFile = path.join(tmpDir, 'unknown-limit.txt')
+      await writeFile(testFile, Buffer.alloc(2048, 'F'))
+
+      const responses = new Map<string, { status: number; body?: unknown; binary?: Uint8Array }>()
+      responses.set('POST /attachments/upload/initiate', {
+        status: 200,
+        body: { sessionId: 'session-4', expiresAt: Date.now() + 3600000 }
+      })
+      responses.set('GET /attachments/upload/session-4', {
+        status: 200,
+        body: {
+          sessionId: 'session-4',
+          attachmentId: '',
+          totalSize: 0,
+          chunkCount: 1,
+          uploadedChunks: [],
+          expiresAt: 0
+        }
+      })
+      responses.set('PUT /attachments/upload/session-4/chunk/0', {
+        status: 200,
+        body: { success: true, uploadedChunks: 1 }
+      })
+      responses.set('POST /attachments/upload/session-4/complete', {
+        status: 200,
+        body: { success: true }
+      })
+
+      const mockFetch = createMockFetch(responses)
+      const deps: AttachmentSyncDeps = {
+        ...createTestDeps(mockFetch),
+        getMaxFileSize: () => null
+      }
+      const service = new AttachmentSyncService(deps)
+
+      await expect(service.uploadAttachment('note-1', testFile)).resolves.toBeTruthy()
     })
   })
 

--- a/apps/desktop/src/main/sync/attachments.ts
+++ b/apps/desktop/src/main/sync/attachments.ts
@@ -17,13 +17,18 @@ import {
   NetworkError,
   SyncServerError,
   RateLimitError,
+  AttachmentTooLargeError,
   parseRetryAfterHeader,
   getSyncVaultHeaders,
   type FetchFn
 } from './http-client'
 import { withRetry } from './retry'
 
-import type { UploadInitResponse, UploadStatusResponse } from '@memry/contracts/blob-api'
+import type {
+  UploadInitRequest,
+  UploadInitResponse,
+  UploadStatusResponse
+} from '@memry/contracts/blob-api'
 
 const log = createLogger('Attachments')
 
@@ -102,7 +107,19 @@ export interface AttachmentSyncDeps {
   } | null>
   getDevicePublicKey: (deviceId: string) => Promise<Uint8Array | null>
   getSyncServerUrl: () => string
+  /**
+   * Cached plan file-size limit in plaintext bytes, or null when unknown.
+   * Null must mean "let the server decide" — the cache is only warm after a
+   * billing fetch, so a cold cache must never block an upload.
+   */
+  getMaxFileSize?: () => number | null
   fetchFn?: FetchFn
+}
+
+function formatBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024)
+  if (mb >= 1024) return `${(mb / 1024).toFixed(mb % 1024 === 0 ? 0 : 1)} GB`
+  return `${mb.toFixed(mb % 1 === 0 ? 0 : 1)} MB`
 }
 
 // ============================================================================
@@ -148,7 +165,7 @@ function sha256Hex(data: Uint8Array): string {
 // ============================================================================
 
 async function binaryFetch(
-  method: 'GET' | 'PUT' | 'HEAD' | 'POST',
+  method: 'GET' | 'PUT' | 'HEAD' | 'POST' | 'DELETE',
   url: string,
   token: string,
   body?: Uint8Array | string,
@@ -219,6 +236,8 @@ async function parallelMap<T, R>(
 // AttachmentSyncService
 // ============================================================================
 
+export { AttachmentTooLargeError }
+
 export class AttachmentSyncService {
   private deps: AttachmentSyncDeps
   private activeUploads = new Map<string, UploadState>()
@@ -256,6 +275,19 @@ export class AttachmentSyncService {
       }
       if (fileStat.size === 0) {
         throw new Error('Cannot upload empty file')
+      }
+
+      // Plan preflight, before the expensive read+hash+encrypt pass below. The
+      // server stays authoritative; this only avoids doing all that work just to
+      // eat a 413. Fails open: a null limit means the cache is cold or was
+      // written by an older version, so defer to the server as before.
+      const planMaxFileSize = this.deps.getMaxFileSize?.() ?? null
+      if (planMaxFileSize !== null && fileStat.size > planMaxFileSize) {
+        throw new AttachmentTooLargeError(
+          `File is larger than your plan allows: ${formatBytes(fileStat.size)} exceeds ${formatBytes(planMaxFileSize)}`,
+          fileStat.size,
+          planMaxFileSize
+        )
       }
 
       const attachmentId = sodium.to_hex(sodium.randombytes_buf(16))
@@ -326,12 +358,20 @@ export class AttachmentSyncService {
       if (options?.signal) netOpts.signal = options.signal
       if (options?.isOnline) netOpts.isOnline = options.isOnline
 
+      // Every chunk goes on the wire as nonce || ciphertext, so the encrypted
+      // total is larger than the plaintext. Declare it explicitly: the server
+      // reserves storage quota against this, and can otherwise only derive it by
+      // assuming today's chunk framing. The encryption loop above has already
+      // finished, so this is exact.
+      const encryptedSize = encryptedChunks.reduce((sum, c) => sum + c.data.byteLength, 0)
+
       const sessionId = await this.initiateUploadSession(
         token,
         attachmentId,
         filename,
         fileStat.size,
         totalChunks,
+        encryptedSize,
         netOpts
       )
 
@@ -380,15 +420,10 @@ export class AttachmentSyncService {
           })
         }
 
-        const dedupExists = await this.checkChunkDedup(token, chunk.ref.encryptedHash, netOpts)
-        if (dedupExists) {
-          log.debug('chunk deduped', { index: chunk.ref.index, hash: chunk.ref.encryptedHash })
-        } else {
-          await this.uploadChunk(token, sessionId, chunk.ref.index, chunk.data, {
-            ...netOpts,
-            onWaitingNetwork
-          })
-        }
+        await this.uploadChunk(token, sessionId, chunk.ref.index, chunk.data, {
+          ...netOpts,
+          onWaitingNetwork
+        })
 
         uploadState.completedChunks.add(chunk.ref.index)
         bytesUploaded += chunk.ref.size
@@ -517,6 +552,20 @@ export class AttachmentSyncService {
 
   async cancelUpload(sessionId: string): Promise<void> {
     this.activeUploads.delete(sessionId)
+
+    // Drop the server-side session too, otherwise the storage reserved at
+    // initiate stays counted against the user until the 24h TTL sweep.
+    // Best-effort: the sweep is still the backstop if this fails.
+    try {
+      const token = await this.deps.getAccessToken()
+      if (token) {
+        const url = `${this.deps.getSyncServerUrl()}/sync/attachments/upload/${sessionId}`
+        await binaryFetch('DELETE', url, token, undefined, this.deps.fetchFn)
+      }
+    } catch (err) {
+      log.warn('failed to release cancelled upload session on server', { sessionId, err })
+    }
+
     log.info('upload cancelled', { sessionId })
   }
 
@@ -530,22 +579,31 @@ export class AttachmentSyncService {
     filename: string,
     totalSize: number,
     chunkCount: number,
+    encryptedSize: number,
     options?: { signal?: AbortSignal; isOnline?: () => boolean }
   ): Promise<string> {
     const url = `${this.deps.getSyncServerUrl()}/sync/attachments/upload/initiate`
-    const body = JSON.stringify({ attachmentId, filename, totalSize, chunkCount })
+    const body: UploadInitRequest = {
+      attachmentId,
+      filename,
+      totalSize,
+      chunkCount,
+      encryptedSize
+    }
 
     const retryOpts: Partial<import('./retry').RetryOptions> = { maxRetries: 3, baseDelayMs: 2000 }
     if (options?.signal) retryOpts.signal = options.signal
     if (options?.isOnline) retryOpts.isOnline = options.isOnline
 
     const { value: resp } = await withRetry(
-      () => binaryFetch('POST', url, token, body, this.deps.fetchFn),
+      () => binaryFetch('POST', url, token, JSON.stringify(body), this.deps.fetchFn),
       retryOpts
     )
     if (!resp.ok) {
       const errBody = await resp.text()
-      throw new SyncServerError(`Failed to initiate upload: ${errBody}`, resp.status)
+      // Pass the raw body through as serverError so classifyError can tell a
+      // file-too-large rejection apart from a storage-quota one (both are 413).
+      throw new SyncServerError(`Failed to initiate upload: ${errBody}`, resp.status, errBody)
     }
 
     const data = (await resp.json()) as UploadInitResponse
@@ -583,28 +641,6 @@ export class AttachmentSyncService {
     } catch {
       log.warn('checkResumableSession failed, starting fresh', { sessionId })
       return null
-    }
-  }
-
-  private async checkChunkDedup(
-    token: string,
-    encryptedHash: string,
-    options?: { signal?: AbortSignal; isOnline?: () => boolean }
-  ): Promise<boolean> {
-    const url = `${this.deps.getSyncServerUrl()}/sync/attachments/chunks/${encryptedHash}`
-    const retryOpts: Partial<import('./retry').RetryOptions> = { maxRetries: 3, baseDelayMs: 1000 }
-    if (options?.signal) retryOpts.signal = options.signal
-    if (options?.isOnline) retryOpts.isOnline = options.isOnline
-
-    try {
-      const { value: resp } = await withRetry(
-        () => binaryFetch('HEAD', url, token, undefined, this.deps.fetchFn),
-        retryOpts
-      )
-      return resp.status === 200
-    } catch {
-      log.warn('checkChunkDedup failed, assuming not deduped', { encryptedHash })
-      return false
     }
   }
 

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -21,6 +21,23 @@ export class SyncServerError extends Error {
   }
 }
 
+/**
+ * One file is over the plan's per-file limit. Raised by the local preflight
+ * before a file is read/encrypted; mirrors the server's STORAGE_FILE_TOO_LARGE.
+ * Lives here with the other sync error types so `sync-errors` can classify it
+ * without importing the attachment service (and with it, electron + crypto).
+ */
+export class AttachmentTooLargeError extends Error {
+  constructor(
+    message: string,
+    public readonly fileSize: number,
+    public readonly maxFileSize: number
+  ) {
+    super(message)
+    this.name = 'AttachmentTooLargeError'
+  }
+}
+
 export class NetworkError extends Error {
   constructor(message: string) {
     super(message)

--- a/apps/desktop/src/main/sync/sync-errors.test.ts
+++ b/apps/desktop/src/main/sync/sync-errors.test.ts
@@ -1,10 +1,43 @@
 import { describe, it, expect } from 'vitest'
 import { classifyError } from './sync-errors'
-import { SyncServerError, NetworkError, RateLimitError } from './http-client'
+import {
+  SyncServerError,
+  NetworkError,
+  RateLimitError,
+  AttachmentTooLargeError
+} from './http-client'
 import { DeadLetterError } from './retry'
 import { CryptoError } from '../crypto/crypto-errors'
 
 describe('classifyError', () => {
+  it('#given SyncServerError 413 STORAGE_FILE_TOO_LARGE #then file_too_large, not retryable', () => {
+    // Both causes of a 413 used to map to storage_quota_exceeded, which told the
+    // user to free up space — never a fix for one oversized file.
+    const body =
+      '{"error":{"code":"STORAGE_FILE_TOO_LARGE","message":"File exceeds the plus plan file size limit"}}'
+    const err = new SyncServerError(`Failed to initiate upload: ${body}`, 413, body)
+    const result = classifyError(err)
+
+    expect(result.category).toBe('file_too_large')
+    expect(result.retryable).toBe(false)
+  })
+
+  it('#given SyncServerError 413 without a file-too-large code #then storage_quota_exceeded', () => {
+    const err = new SyncServerError('Storage quota exceeded', 413)
+    const result = classifyError(err)
+
+    expect(result.category).toBe('storage_quota_exceeded')
+    expect(result.retryable).toBe(false)
+  })
+
+  it('#given AttachmentTooLargeError #then file_too_large, not retryable', () => {
+    const err = new AttachmentTooLargeError('File is larger than your plan allows', 2048, 1024)
+    const result = classifyError(err)
+
+    expect(result.category).toBe('file_too_large')
+    expect(result.retryable).toBe(false)
+  })
+
   it('#given SyncServerError 401 #then auth_expired, not retryable', () => {
     const err = new SyncServerError('Unauthorized', 401)
     const result = classifyError(err)

--- a/apps/desktop/src/main/sync/sync-errors.ts
+++ b/apps/desktop/src/main/sync/sync-errors.ts
@@ -1,6 +1,11 @@
 import type { SyncErrorCategory } from '@memry/contracts/ipc-sync-ops'
 import { CryptoError } from '../crypto/crypto-errors'
-import { SyncServerError, NetworkError, RateLimitError } from './http-client'
+import {
+  SyncServerError,
+  NetworkError,
+  RateLimitError,
+  AttachmentTooLargeError
+} from './http-client'
 import { DeadLetterError } from './retry'
 
 export type { SyncErrorCategory }
@@ -15,6 +20,16 @@ export function classifyError(error: unknown): SyncErrorInfo {
   if (error instanceof DeadLetterError) {
     const inner = classifyError(error.lastError)
     return { ...inner, retryable: false }
+  }
+
+  // Local plan preflight — same user-facing outcome as the server's 413, but
+  // raised before the file is read and encrypted.
+  if (error instanceof AttachmentTooLargeError) {
+    return {
+      category: 'file_too_large',
+      message: error.message,
+      retryable: false
+    }
   }
 
   if (error instanceof RateLimitError) {
@@ -55,6 +70,20 @@ export function classifyError(error: unknown): SyncErrorInfo {
       }
     }
     if (error.statusCode === 413) {
+      // 413 covers two different problems. STORAGE_FILE_TOO_LARGE means this one
+      // file is over the plan's per-file limit; a bare 413 means the account is
+      // out of storage. Reporting "Storage quota exceeded" for the former sends
+      // the user to free up space, which never fixes it.
+      if (
+        error.serverError?.includes('STORAGE_FILE_TOO_LARGE') ||
+        error.message.includes('STORAGE_FILE_TOO_LARGE')
+      ) {
+        return {
+          category: 'file_too_large',
+          message: 'This file is larger than your plan allows',
+          retryable: false
+        }
+      }
       return {
         category: 'storage_quota_exceeded',
         message: 'Storage quota exceeded',

--- a/apps/desktop/src/preload/api/sync-events.ts
+++ b/apps/desktop/src/preload/api/sync-events.ts
@@ -7,6 +7,7 @@ import type {
   LinkingApprovedEvent,
   LinkingFinalizedEvent,
   UploadProgressEvent,
+  AttachmentUploadFailedEvent,
   DownloadProgressEvent,
   InitialSyncProgressEvent,
   QueueClearedEvent,
@@ -47,6 +48,11 @@ export const syncEvents = {
 
   onDownloadProgress: (callback: (event: DownloadProgressEvent) => void): (() => void) =>
     subscribe<DownloadProgressEvent>(SYNC_EVENTS.DOWNLOAD_PROGRESS, callback),
+
+  onAttachmentUploadFailed: (
+    callback: (event: AttachmentUploadFailedEvent) => void
+  ): (() => void) =>
+    subscribe<AttachmentUploadFailedEvent>(SYNC_EVENTS.ATTACHMENT_UPLOAD_FAILED, callback),
 
   onInitialSyncProgress: (callback: (event: InitialSyncProgressEvent) => void): (() => void) =>
     subscribe<InitialSyncProgressEvent>(SYNC_EVENTS.INITIAL_SYNC_PROGRESS, callback),

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -46,6 +46,7 @@ import type {
   LinkingApprovedEvent,
   LinkingFinalizedEvent,
   UploadProgressEvent,
+  AttachmentUploadFailedEvent,
   DownloadProgressEvent,
   InitialSyncProgressEvent,
   QueueClearedEvent,
@@ -1860,6 +1861,7 @@ interface API extends WindowAPI, GeneratedRpcApi {
   onLinkingFinalized: (callback: (event: LinkingFinalizedEvent) => void) => () => void
   onUploadProgress: (callback: (event: UploadProgressEvent) => void) => () => void
   onDownloadProgress: (callback: (event: DownloadProgressEvent) => void) => () => void
+  onAttachmentUploadFailed: (callback: (event: AttachmentUploadFailedEvent) => void) => () => void
   onInitialSyncProgress: (callback: (event: InitialSyncProgressEvent) => void) => () => void
   onQueueCleared: (callback: (event: QueueClearedEvent) => void) => () => void
   onSyncPaused: (callback: (event: SyncPausedEvent) => void) => () => void

--- a/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
@@ -13,6 +13,7 @@ let pausedListeners: EventCallback[] = []
 let resumedListeners: EventCallback[] = []
 let uploadProgressListeners: EventCallback[] = []
 let downloadProgressListeners: EventCallback[] = []
+let attachmentUploadFailedListeners: EventCallback[] = []
 let linkingRequestListeners: EventCallback[] = []
 let linkingApprovedListeners: EventCallback[] = []
 let conflictDetectedListeners: EventCallback[] = []
@@ -100,6 +101,7 @@ beforeEach(async () => {
   resumedListeners = []
   uploadProgressListeners = []
   downloadProgressListeners = []
+  attachmentUploadFailedListeners = []
   linkingRequestListeners = []
   linkingApprovedListeners = []
   conflictDetectedListeners = []
@@ -147,6 +149,12 @@ beforeEach(async () => {
     downloadProgressListeners.push(cb)
     return () => {
       downloadProgressListeners = downloadProgressListeners.filter((l) => l !== cb)
+    }
+  })
+  api.onAttachmentUploadFailed = vi.fn((cb: EventCallback) => {
+    attachmentUploadFailedListeners.push(cb)
+    return () => {
+      attachmentUploadFailedListeners = attachmentUploadFailedListeners.filter((l) => l !== cb)
     }
   })
   api.onLinkingRequest = vi.fn((cb: EventCallback) => {
@@ -285,6 +293,30 @@ describe('SyncProvider', () => {
       expect(result.current.state.uploadProgress).toEqual({
         'att-1': { progress: 50, status: 'uploading' }
       })
+    })
+  })
+
+  describe('#given attachment upload failed event #when listening', () => {
+    it('#then shows a toast naming the file', async () => {
+      // Nothing listened to this channel for 58 days, so a total attachment
+      // upload outage was silent. Pin that it surfaces.
+      const { result } = renderHook(() => useSync(), { wrapper })
+      await vi.waitFor(() => expect(result.current.state.status).toBe('idle'))
+
+      act(() => {
+        for (const cb of attachmentUploadFailedListeners) {
+          cb({
+            noteId: 'note-1',
+            diskPath: '/vault/attachments/report.pdf',
+            error: 'File exceeds the plus plan file size limit'
+          })
+        }
+      })
+
+      expect(toastMock.error).toHaveBeenCalledWith(
+        expect.stringContaining('report.pdf'),
+        expect.objectContaining({ duration: 10000 })
+      )
     })
   })
 

--- a/apps/desktop/src/renderer/src/contexts/sync-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.tsx
@@ -261,6 +261,19 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
         if (event.errorCategory === 'storage_quota_exceeded') {
           toast.error(t('sync.storageQuotaExceeded'), { duration: 10000 })
         }
+        if (event.errorCategory === 'file_too_large') {
+          toast.error(t('sync.fileTooLarge'), { duration: 10000 })
+        }
+      })
+    )
+
+    // Attachment upload failures were emitted to this channel with no listener,
+    // so a 58-day outage was completely silent to the user. Surface it.
+    cleanups.push(
+      window.api.onAttachmentUploadFailed((event) => {
+        if (cancelled) return
+        const filename = event.diskPath.split(/[\\/]/).pop() ?? event.diskPath
+        toast.error(t('sync.attachmentUploadFailed', { filename }), { duration: 10000 })
       })
     )
 

--- a/apps/desktop/src/renderer/src/lib/error-messages.ts
+++ b/apps/desktop/src/renderer/src/lib/error-messages.ts
@@ -94,6 +94,7 @@ const SYNC_ERROR_KEYS: Record<SyncErrorCategory, string> = {
   crypto_failure: 'sync.cryptoFailure',
   version_incompatible: 'sync.versionIncompatible',
   storage_quota_exceeded: 'sync.storageQuotaExceeded',
+  file_too_large: 'sync.fileTooLarge',
   sync_payment_required: 'sync.paymentRequired',
   certificate_pin_failed: 'sync.certificatePinFailed',
   unknown: 'sync.unknown'

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -67,6 +67,12 @@ Your plan's per-file size limit applies to the **original file size**. Encryptio
 
 Synced storage usage counts the **encrypted** size, which is a few bytes larger per chunk than the original (each chunk carries a nonce and an authentication tag). For a typical file this is a difference of tens of bytes.
 
+If a file is over your plan's per-file limit, MemryNote tells you before it spends time encrypting it, and names the limit it hit. Freeing storage does not help in that case — the file itself is too big, so you need a plan with a larger per-file limit.
+
+### When an Attachment Doesn't Sync
+
+If an attachment can't be uploaded, you get a notification naming the file. The file is never lost: it stays in `<vault>/attachments/` and the note keeps working on this device. Only the synced copy is missing, so other devices won't see it until the upload succeeds.
+
 ## Garbage Collection
 
 Files that are no longer referenced by any note are pruned during periodic vacuum. You don't need to clean them up manually.

--- a/apps/sync-server/src/routes/blob.ts
+++ b/apps/sync-server/src/routes/blob.ts
@@ -304,12 +304,24 @@ blob.put('/attachments/upload/:session_id/chunk/:chunk_index', chunkUploadLimit,
       .run()
   }
 
-  uploadedChunks.push({ i: chunkIndex, h: chunkHash, b: chunkData.byteLength })
+  // Append atomically in one statement. Clients upload up to MAX_CONCURRENT_CHUNKS
+  // chunks in parallel, so a read-modify-write of the whole array here loses
+  // entries: each request writes back the snapshot it read, and the last writer
+  // wins. The dropped index then fails `complete` with 400 "Missing chunks".
+  // `json_insert(x, '$[#]', ...)` appends without re-sending the array we read.
   await c.env.DB.prepare(
-    'UPDATE upload_sessions SET uploaded_chunks = ? WHERE id = ? AND user_id = ? AND vault_id = ?'
+    `UPDATE upload_sessions
+       SET uploaded_chunks = json_insert(uploaded_chunks, '$[#]', json(?))
+     WHERE id = ? AND user_id = ? AND vault_id = ?`
   )
-    .bind(JSON.stringify(uploadedChunks), sessionId, userId, vaultId)
+    .bind(
+      JSON.stringify({ i: chunkIndex, h: chunkHash, b: chunkData.byteLength }),
+      sessionId,
+      userId,
+      vaultId
+    )
     .run()
+  uploadedChunks.push({ i: chunkIndex, h: chunkHash, b: chunkData.byteLength })
 
   return c.json({
     success: true,

--- a/packages/contracts/src/ipc-sync-ops.ts
+++ b/packages/contracts/src/ipc-sync-ops.ts
@@ -35,6 +35,9 @@ export type SyncErrorCategory =
   | 'crypto_failure'
   | 'version_incompatible'
   | 'storage_quota_exceeded'
+  // One file is over the plan's per-file limit — distinct from being out of
+  // storage, and not fixable by freeing space.
+  | 'file_too_large'
   | 'sync_payment_required'
   | 'certificate_pin_failed'
   | 'unknown'

--- a/packages/i18n/src/locales/en/errors.json
+++ b/packages/i18n/src/locales/en/errors.json
@@ -63,6 +63,8 @@
     "cryptoFailure": "Failed to encrypt or decrypt sync data. Try signing out and back in.",
     "versionIncompatible": "This version of memrynote is no longer supported. Please update.",
     "storageQuotaExceeded": "Your sync storage is full. Free up space or upgrade your plan.",
+    "fileTooLarge": "This file is larger than your plan allows. Upgrade your plan to sync larger files.",
+    "attachmentUploadFailed": "Couldn't sync attachment \"{filename}\". It stays on this device.",
     "paymentRequired": "A paid Sync plan is required to use hosted encrypted sync.",
     "certificatePinFailed": "Secure connection failed. Check your network connection.",
     "unknown": "An unexpected sync error occurred. Will retry automatically.",


### PR DESCRIPTION
Stacked on `fix-attachment-upload-size-accounting` (base branch, not `main`). Review that one first.

## Production evidence

Chunked attachment upload has been 100% broken for 58 days. The client declared the **plaintext** size as `totalSize`, but every chunk goes on the wire as `nonce(24) || ciphertext(+16 tag)` — plaintext + 40 bytes per chunk. The server's chunk guard then rejected every upload:

```
413 {"error":{"code":"STORAGE_FILE_TOO_LARGE","message":"Uploaded chunks exceed declared file size"}}
```

It was **silent to users**. The failure was `logger.error` (electron-log, not telemetry) and an `ATTACHMENT_UPLOAD_FAILED` IPC event that **nothing in the renderer listened to**. We only found out because the *server* logged the 413.

## The fix

**Client**
- Declare the exact `encryptedSize` on initiate. `totalSize` stays plaintext (plan limits ride on it) and the manifest is untouched.
- Plan-aware preflight *before* the read+hash+encrypt pass. A Plus user picking a 100 MB file no longer encrypts every chunk just to eat a 413. **Fails open**: a cold/absent cached limit means "let the server decide" — an upload is never blocked on a cold cache.
- `CachedEntitlement` gains optional `limits.maxFileSize`, populated from the `BillingStatus` that was already fetched and thrown away.
- `STORAGE_FILE_TOO_LARGE` now maps to a distinct `file_too_large` category. Previously **both** causes of a 413 rendered as "Storage quota exceeded", which tells a user to free space — never a fix for one oversized file.
- `cancelUpload` now DELETEs the server session instead of pinning quota until the 24h TTL + 6h cron.
- **Removed the chunk dedup HEAD probe.** It can never hit: the file key is random per upload and the nonce is random per chunk, so `encryptedHash` is globally unique. It cost a guaranteed-miss round-trip per chunk and was the source of the production 404 noise on `HEAD /sync/attachments/chunks/:hash`. I verified the real route returns 404 unless the hash is in `blob_chunks`. The old test only passed because the mock asserted `HEAD -> 200`, which the real server cannot return.

**Surfacing** (the "silent for 58 days" fix)
- Renderer listens for `ATTACHMENT_UPLOAD_FAILED` and toasts, naming the file.
- Failure now goes to **telemetry** (`trackMainError`), not just electron-log, so a client-side attachment outage is visible in Loki.

**Server** — one change outside the original scope, flagged deliberately:
- `uploaded_chunks` was a read-modify-write of the whole JSON array. The client uploads up to 4 chunks concurrently, so requests clobber each other and lose an index — `complete` then fails `400 {"error":"Missing chunks","missing_chunks":[2]}`. Now an atomic single-statement `json_insert(uploaded_chunks, '$[#]', ...)`. **This is a second real production bug, found by the new spec.** I fixed it rather than shipping a knowingly-flaky test: the multi-chunk case failed 1-in-5 before, 8/8 after.

## Compat / migration

- **No DB migration.** `encrypted_size` already exists on the base branch.
- **Contract:** `encryptedSize` was already optional on the base branch; this client just starts sending it. Old clients that omit it keep working via the server's derive path. New client + old server: the extra field is ignored by the old Zod schema (non-strict), and the old server was 413ing anyway.
- **Store:** `limits` is additive and optional. Stores written by older versions have no `limits` key; `getCachedMaxFileSize()` returns `null` for missing/implausible values and callers fall back to today's 500 MiB behaviour. Explicitly tested.
- **`SyncErrorCategory`:** additive union member. Renderer and main ship together, so no cross-version exposure.

## Verification actually run

| Check | Result |
|---|---|
| **TDD red** (spec vs unfixed `origin/main`) | **3 failed / 3 passed** — reproduced the exact production 413 |
| New integration spec (this branch) | 7/7, **8/8 consecutive runs** (was 4/5 before the race fix) |
| `desktop --project main` (full) | **3510 passed**, 1 skipped, 345 files |
| `desktop --project renderer` (full) | **5097 passed**, 6 skipped, 446 files |
| `--project shared` / `--project preload` | 2074 passed / 17 passed |
| `pnpm test:sync-server` (full) | **673 passed**, 48 files |
| `pnpm --filter @memry/sync-harness test` | 32 passed |
| `pnpm typecheck` | 16/16 successful |
| `pnpm lint` | exit 0 |
| `pnpm ipc:generate && pnpm ipc:check` | up to date |
| `i18n:check` | passed |
| `docs:impact --strict` + `docs:build` | exit 0 |
| `git diff --check` | clean |

### The TDD failure I observed first

Run against `origin/main` (neither the server nor the client fix present):

```
FAIL  attachments.integration.test.ts > round-trips a single-chunk file with identical bytes
SyncServerError: Failed to upload chunk 0:
  {"error":{"code":"STORAGE_FILE_TOO_LARGE","message":"Uploaded chunks exceed declared file size"}}

FAIL  attachments.integration.test.ts > round-trips a multi-chunk file (>8 MiB) with identical bytes
SyncServerError: Failed to complete upload: {"error":"Missing chunks","missing_chunks":[2]}

FAIL  attachments.integration.test.ts > accepts a Plus-plan file at exactly the 5 MiB limit
SyncServerError: Failed to upload chunk 0: {"error":{"code":"STORAGE_FILE_TOO_LARGE",...}}

Tests  3 failed | 3 passed (6)
```

That is the production bug, reproduced. The two failure modes are distinct and both real: single-chunk hits the byte guard deterministically; multi-chunk races the guard and loses a chunk record instead.

Then, for the client change specifically (on this branch, server fix present):
```
AssertionError: expected undefined to be 20971640   // initiateBody.encryptedSize
```

## Tests

The reason this shipped broken: sync-server tests mock R2/D1 with self-consistent numbers, and `attachments.test.ts` mocks `fetch` wholesale. **Both sides passed their own tests. The seam was never tested.**

New `apps/desktop/src/main/sync/attachments.integration.test.ts` drives the **real client** against the **real Worker** on miniflare with **real D1 migrations** and **real R2**, via the existing `tests/sync-harness` — no new harness. Covers single-chunk, multi-chunk (>8 MiB), Plus at exactly 5 MiB (must pass), over-limit, free plan, the declared `encryptedSize`, and storage charged against ciphertext.

It also asserts the **real route prefix**: `app.route('/sync', blob)` means `/sync/attachments/...`, and the existing mock matches with `urlStr.includes(...)`, which passes for a wrong base path too. The spec asserts `/sync/...` is 201 and the un-prefixed path is 404.

No Electron, no Playwright, no display server — it stubs the `electron` import and injects `fetchFn`. Runs in ~3s.

## CI

- **`sync-server-ci.yml`**: runs the integration spec **on PRs**. That workflow already builds the harness worker and triggers on PR; I extended its path filters to include the desktop attachment client. **This is the one thing here that is PR-blocking**, and it's cheap (ubuntu, seconds).
- **`desktop-ci.yml`**: added `e2e-smoke-macos` mirroring `e2e-smoke-windows`, and added `file-attachments-viewer.e2e.ts` to the Windows + macOS smoke lists. macOS uses `ensure-native.sh` directly (bash-native; the Windows job hand-rolls the rebuild + `.native-build-target` stamp only because `ensure-native.sh` breaks under MSYS).

**Cost, honestly:** a macOS E2E job is the most expensive minute GitHub bills (~10x ubuntu, ~45 min budget). I kept it gated to push-to-main like the existing ubuntu/Windows E2E jobs, so it does **not** run on PRs and adds no PR latency.

## What I could NOT verify

- **The macOS E2E job has never run.** It's gated to push-to-main, so it won't run on this PR. Two specific unknowns: macOS keychain behaviour under Playwright (`keytar` hits the login keychain; the ubuntu job needs `gnome-keyring`, Windows uses Credential Manager, macOS is untested), and whether a window server is available without xvfb. **It may well need a fixup on first run on main.** I did not want to claim green on something I couldn't execute.
- `file-attachments-viewer.e2e.ts` covers the **local vault** path (`notes.uploadAttachment`), **not** the sync path. I added it to the OS matrix for cross-platform attachment file I/O coverage; it is *not* sync coverage. The sync path is covered by the integration spec.
- I did **not** write an Electron UI-level attachment *sync* E2E. It needs a real sync backend behind the packaged app, and I judged it too flaky/expensive for the value over the integration spec, which already covers the seam deterministically in seconds.
- No manual QA in a running app: no toast was seen with human eyes. The toast is covered by a renderer test asserting `toast.error` fires with the filename.
- `attachments.test.ts` / `sync-errors.test.ts` fail on a **fresh worktree** with "Electron failed to install correctly" — pre-existing (the known missing `path.txt` marker), reproduced on the clean base branch before my changes. I wrote the marker locally to run them; they pass.

## Pre-existing issues noticed, NOT changed

- The chunk byte guard (`uploadedBytes + chunkData.byteLength > expectedEncrypted`) is still a read-then-check across concurrent requests, so **quota accounting remains racy** under parallel chunk uploads. My `json_insert` fix addresses the lost *chunk record*, not the byte total. Worth a follow-up.
- The 409 "Chunk already uploaded" check is racy for the same reason.
