### PR TITLE
fix(folders): flush folder-view writes via the save registry

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-folder-view.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-folder-view.test.tsx
@@ -152,8 +152,13 @@ describe('useFolderView', () => {
     mocks.evaluateFilter.mockImplementation((note: { id: string }) => note.id === 'n1')
     mocks.propertiesSet.mockResolvedValue({ success: true })
     mocks.notesUpdate.mockResolvedValue({ success: true })
+    // Spreading `window` drops prototype methods, so bind the real jsdom event
+    // target back on: the hook registers a beforeunload listener to flush writes.
     vi.stubGlobal('window', {
       ...window,
+      addEventListener: window.addEventListener.bind(window),
+      removeEventListener: window.removeEventListener.bind(window),
+      dispatchEvent: window.dispatchEvent.bind(window),
       api: {
         ...(window as any).api,
         folderView: folderApi()
@@ -448,5 +453,56 @@ describe('useFolderView', () => {
 
     expect(toast.error).toHaveBeenCalledWith('phaseI.toasts.failedToUpdateProperty')
     expect(toast.error).toHaveBeenCalledWith('phaseI.toasts.failedToUpdateTags')
+  })
+
+  it('flushes a pending column write when the hook unmounts before the debounce fires', async () => {
+    const { result, unmount } = renderHook(() => useFolderView({ folderPath: 'Work' }), {
+      wrapper: makeWrapper()
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await result.current.updateColumns([{ id: 'status' }, { id: 'title' }])
+    })
+
+    // Still inside the debounce window: nothing written yet.
+    expect(window.api.folderView.setView).not.toHaveBeenCalled()
+
+    // User closes the tab / switches folder before the 300ms elapses.
+    unmount()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(window.api.folderView.setView).toHaveBeenCalledWith(
+      'Work',
+      expect.objectContaining({ columns: [{ id: 'status' }, { id: 'title' }] })
+    )
+  })
+
+  it('flushes a pending column write when the app quits (beforeunload)', async () => {
+    const { result } = renderHook(() => useFolderView({ folderPath: 'Work' }), {
+      wrapper: makeWrapper()
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await result.current.updateColumns([{ id: 'status' }, { id: 'title' }])
+    })
+
+    expect(window.api.folderView.setView).not.toHaveBeenCalled()
+
+    // Electron tears the renderer down on quit; the timer never fires.
+    await act(async () => {
+      window.dispatchEvent(new Event('beforeunload'))
+      await Promise.resolve()
+    })
+
+    expect(window.api.folderView.setView).toHaveBeenCalledWith(
+      'Work',
+      expect.objectContaining({ columns: [{ id: 'status' }, { id: 'title' }] })
+    )
   })
 })

--- a/apps/desktop/src/renderer/src/hooks/use-folder-view.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-folder-view.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type React from 'react'
 import { toast } from 'sonner'
+import { flushAllPendingSaves } from '@/lib/save-registry'
 import { useFolderView } from './use-folder-view'
 
 const mocks = vi.hoisted(() => ({
@@ -152,13 +153,8 @@ describe('useFolderView', () => {
     mocks.evaluateFilter.mockImplementation((note: { id: string }) => note.id === 'n1')
     mocks.propertiesSet.mockResolvedValue({ success: true })
     mocks.notesUpdate.mockResolvedValue({ success: true })
-    // Spreading `window` drops prototype methods, so bind the real jsdom event
-    // target back on: the hook registers a beforeunload listener to flush writes.
     vi.stubGlobal('window', {
       ...window,
-      addEventListener: window.addEventListener.bind(window),
-      removeEventListener: window.removeEventListener.bind(window),
-      dispatchEvent: window.dispatchEvent.bind(window),
       api: {
         ...(window as any).api,
         folderView: folderApi()
@@ -481,7 +477,7 @@ describe('useFolderView', () => {
     )
   })
 
-  it('flushes a pending column write when the app quits (beforeunload)', async () => {
+  it('flushes a pending column write through the save registry on app quit', async () => {
     const { result } = renderHook(() => useFolderView({ folderPath: 'Work' }), {
       wrapper: makeWrapper()
     })
@@ -494,9 +490,36 @@ describe('useFolderView', () => {
 
     expect(window.api.folderView.setView).not.toHaveBeenCalled()
 
-    // Electron tears the renderer down on quit; the timer never fires.
+    // Main drains the registry and awaits it BEFORE closeVault(); a beforeunload
+    // listener would instead run after the vault is closed and the write would fail.
     await act(async () => {
-      window.dispatchEvent(new Event('beforeunload'))
+      await flushAllPendingSaves()
+    })
+
+    expect(window.api.folderView.setView).toHaveBeenCalledWith(
+      'Work',
+      expect.objectContaining({ columns: [{ id: 'status' }, { id: 'title' }] })
+    )
+  })
+
+  it('flushes a pending column write when the user switches folders', async () => {
+    const { result, rerender } = renderHook(
+      ({ folderPath }: { folderPath: string }) => useFolderView({ folderPath }),
+      { wrapper: makeWrapper(), initialProps: { folderPath: 'Work' } }
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await result.current.updateColumns([{ id: 'status' }, { id: 'title' }])
+    })
+
+    expect(window.api.folderView.setView).not.toHaveBeenCalled()
+
+    // The page swaps folderPath without remounting, so the switch must still
+    // land Work's pending edit before Personal takes over the write slot.
+    rerender({ folderPath: 'Personal' })
+    await act(async () => {
       await Promise.resolve()
     })
 
@@ -504,5 +527,90 @@ describe('useFolderView', () => {
       'Work',
       expect.objectContaining({ columns: [{ id: 'status' }, { id: 'title' }] })
     )
+  })
+
+  it('serializes the view and rename writes so neither clobbers the other', async () => {
+    let releaseSetView: (() => void) | undefined
+    const setViewGate = new Promise<void>((resolve) => {
+      releaseSetView = resolve
+    })
+    ;(window.api.folderView.setView as any).mockImplementationOnce(async () => {
+      await setViewGate
+      return { success: true }
+    })
+
+    const { result, unmount } = renderHook(() => useFolderView({ folderPath: 'Work' }), {
+      wrapper: makeWrapper()
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await result.current.updateColumns([{ id: 'status' }, { id: 'title' }])
+      await result.current.renameView(0, 'Renamed')
+    })
+
+    unmount()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Both handlers read-modify-write the same .folder.md. The rename must not
+    // start until the view write has finished, or one silently erases the other.
+    expect(window.api.folderView.setConfig).not.toHaveBeenCalled()
+
+    await act(async () => {
+      releaseSetView?.()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(window.api.folderView.setConfig).toHaveBeenCalled())
+  })
+
+  it('keeps column edits and display-name edits in separate write slots', async () => {
+    const { result, unmount } = renderHook(() => useFolderView({ folderPath: 'Work' }), {
+      wrapper: makeWrapper()
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await result.current.updateColumns([{ id: 'status' }, { id: 'title' }])
+      await result.current.updateDisplayName('status', 'State')
+    })
+
+    unmount()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // A display-name edit must not evict the pending column edit.
+    expect(window.api.folderView.setView).toHaveBeenCalledWith(
+      'Work',
+      expect.objectContaining({ columns: [{ id: 'status' }, { id: 'title' }] })
+    )
+  })
+
+  it('reverts a display-name edit when the write fails', async () => {
+    // withErrorHandler RESOLVES {success:false} on throw; it does not reject.
+    ;(window.api.folderView.setView as any).mockResolvedValueOnce({
+      success: false,
+      error: 'No vault is currently open'
+    })
+
+    const { result } = renderHook(() => useFolderView({ folderPath: 'Work' }), {
+      wrapper: makeWrapper()
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await result.current.updateDisplayName('status', 'State')
+      vi.advanceTimersByTime(300)
+      await Promise.resolve()
+    })
+
+    // The failed setView must stop the sequence, not fall through to setConfig.
+    await waitFor(() => expect(window.api.folderView.setConfig).not.toHaveBeenCalled())
   })
 })

--- a/apps/desktop/src/renderer/src/hooks/use-folder-view.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-folder-view.ts
@@ -34,15 +34,19 @@ interface PendingWrite {
   run: (() => Promise<void>) | null
 }
 
-/** Run a pending write now, if one is waiting. */
-function flushWrite(ref: { current: PendingWrite }): void {
+/**
+ * Run a pending write now, if one is waiting. Returns the write's promise so
+ * callers can await it: the main-process handlers read-modify-write the same
+ * .folder.md with no lock, so concurrent flushes would clobber each other.
+ */
+function flushWrite(ref: { current: PendingWrite }): Promise<void> {
   if (ref.current.timer) {
     clearTimeout(ref.current.timer)
     ref.current.timer = null
   }
   const run = ref.current.run
   ref.current.run = null
-  void run?.()
+  return run ? run() : Promise.resolve()
 }
 
 /** Schedule a debounced write, replacing any write still pending on this slot. */
@@ -51,7 +55,7 @@ function scheduleWrite(ref: { current: PendingWrite }, run: () => Promise<void>)
     clearTimeout(ref.current.timer)
   }
   ref.current.run = run
-  ref.current.timer = setTimeout(() => flushWrite(ref), WRITE_DEBOUNCE_MS)
+  ref.current.timer = setTimeout(() => void flushWrite(ref), WRITE_DEBOUNCE_MS)
 }
 
 import { DEFAULT_COLUMNS, BUILT_IN_COLUMNS } from '@memry/contracts/folder-view-api'
@@ -61,6 +65,7 @@ import type {
   GroupByConfig
 } from '@memry/contracts/folder-view-api'
 import { evaluateFilter } from '@/lib/filter-evaluator'
+import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
 import { propertiesService } from '@/services/properties-service'
 import { notesService } from '@/services/notes-service'
 
@@ -270,7 +275,10 @@ export function useFolderView({
 
   // Debounced write for column/sort/filter updates
   const updateWriteRef = useRef<PendingWrite>({ timer: null, run: null })
-  // Debounced write for in-place renames (live, per-keystroke)
+  // Debounced write for column display-name edits. Kept separate from the update
+  // slot so a rename of a column header cannot evict a pending column edit.
+  const displayNameWriteRef = useRef<PendingWrite>({ timer: null, run: null })
+  // Debounced write for in-place view renames (live, per-keystroke)
   const renameWriteRef = useRef<PendingWrite>({ timer: null, run: null })
 
   // ============================================================================
@@ -736,12 +744,18 @@ export function useFolderView({
       })
 
       // Debounce the save
-      scheduleWrite(updateWriteRef, async () => {
+      scheduleWrite(displayNameWriteRef, async () => {
         try {
-          await window.api.folderView.setView(
+          // withErrorHandler resolves {success:false} on failure rather than
+          // rejecting, so an unchecked result would silently swallow the error.
+          const viewResult = await window.api.folderView.setView(
             folderPath,
             updatedView as unknown as Record<string, unknown>
           )
+
+          if (!viewResult.success) {
+            throw new Error(viewResult.error || 'Failed to save display name')
+          }
 
           const configResult = await window.api.folderView.getConfig(folderPath)
           const existingConfig = configResult.config
@@ -757,7 +771,11 @@ export function useFolderView({
             }
           }
 
-          await window.api.folderView.setConfig(folderPath, updatedConfig)
+          const saveResult = await window.api.folderView.setConfig(folderPath, updatedConfig)
+
+          if (!saveResult.success) {
+            throw new Error(saveResult.error || 'Failed to save display name')
+          }
         } catch (err) {
           log.error('Failed to save display name:', err)
           void queryClient.invalidateQueries({ queryKey: folderViewKeys.views(folderPath) })
@@ -1006,21 +1024,33 @@ export function useFolderView({
   // Effects
   // ============================================================================
 
-  // Flush pending writes on unmount (tab close, folder switch) and on app quit.
-  // Both tear the hook down before the debounce fires, so a scheduled-only write
-  // would never reach .folder.md and the view would revert on the next launch.
+  // Land pending writes before the hook stops owning this folder.
+  //
+  // Writes are sequential, not concurrent: each main handler read-modify-writes
+  // the same .folder.md without a lock, so firing them together loses one.
+  //
+  // Quit goes through the save registry, which main drains and awaits while the
+  // vault is still open. A beforeunload listener cannot work here: before-quit
+  // preventDefaults, so the window only closes after closeVault(), and the write
+  // would fail with "No vault is currently open".
+  //
+  // Keying on folderPath covers the folder switch too — the page swaps folderPath
+  // without remounting, so a mount-only effect would never flush the old folder.
   useEffect(() => {
-    const flushAll = (): void => {
-      flushWrite(updateWriteRef)
-      flushWrite(renameWriteRef)
+    const flushAll = async (): Promise<void> => {
+      await flushWrite(updateWriteRef)
+      await flushWrite(displayNameWriteRef)
+      await flushWrite(renameWriteRef)
     }
 
-    window.addEventListener('beforeunload', flushAll)
+    const registryKey = `folder-view:${folderPath}`
+    registerPendingSave(registryKey, flushAll)
+
     return () => {
-      window.removeEventListener('beforeunload', flushAll)
-      flushAll()
+      unregisterPendingSave(registryKey)
+      void flushAll()
     }
-  }, [])
+  }, [folderPath])
 
   // Note: Event listeners for cache sync are handled globally in useFolderViewEvents()
   // This ensures all folder-view tabs stay in sync even when unmounted

--- a/apps/desktop/src/renderer/src/hooks/use-folder-view.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-folder-view.ts
@@ -19,6 +19,41 @@ import { createLogger } from '@/lib/logger'
 import { toast } from 'sonner'
 
 const log = createLogger('Hook:FolderView')
+
+/** Delay before a view edit is written to .folder.md. */
+const WRITE_DEBOUNCE_MS = 300
+
+/**
+ * A disk write waiting out its debounce window. The write itself is held next
+ * to its timer so it can be flushed rather than dropped: clearing the timer
+ * alone discards the write while the optimistic cache still shows it as saved,
+ * which loses the edit on the next launch.
+ */
+interface PendingWrite {
+  timer: ReturnType<typeof setTimeout> | null
+  run: (() => Promise<void>) | null
+}
+
+/** Run a pending write now, if one is waiting. */
+function flushWrite(ref: { current: PendingWrite }): void {
+  if (ref.current.timer) {
+    clearTimeout(ref.current.timer)
+    ref.current.timer = null
+  }
+  const run = ref.current.run
+  ref.current.run = null
+  void run?.()
+}
+
+/** Schedule a debounced write, replacing any write still pending on this slot. */
+function scheduleWrite(ref: { current: PendingWrite }, run: () => Promise<void>): void {
+  if (ref.current.timer) {
+    clearTimeout(ref.current.timer)
+  }
+  ref.current.run = run
+  ref.current.timer = setTimeout(() => flushWrite(ref), WRITE_DEBOUNCE_MS)
+}
+
 import { DEFAULT_COLUMNS, BUILT_IN_COLUMNS } from '@memry/contracts/folder-view-api'
 import type {
   FilterExpression,
@@ -233,10 +268,10 @@ export function useFolderView({
   // Local state for user's current view selection
   const [activeViewIndex, setActiveViewIndex] = useState(0)
 
-  // Debounce timer for column updates
-  const updateTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  // Debounce timer for in-place renames (live, per-keystroke)
-  const renameTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  // Debounced write for column/sort/filter updates
+  const updateWriteRef = useRef<PendingWrite>({ timer: null, run: null })
+  // Debounced write for in-place renames (live, per-keystroke)
+  const renameWriteRef = useRef<PendingWrite>({ timer: null, run: null })
 
   // ============================================================================
   // Queries
@@ -427,28 +462,22 @@ export function useFolderView({
       })
 
       // Debounce the save to avoid too many writes
-      if (updateTimeoutRef.current) {
-        clearTimeout(updateTimeoutRef.current)
-      }
+      scheduleWrite(updateWriteRef, async () => {
+        try {
+          const result = await window.api.folderView.setView(
+            folderPath,
+            updatedView as unknown as Record<string, unknown>
+          )
 
-      updateTimeoutRef.current = setTimeout(() => {
-        void (async () => {
-          try {
-            const result = await window.api.folderView.setView(
-              folderPath,
-              updatedView as unknown as Record<string, unknown>
-            )
-
-            if (!result.success) {
-              throw new Error(result.error || 'Failed to save view')
-            }
-          } catch (err) {
-            log.error('updateView failed:', err)
-            // Revert on error
-            void queryClient.invalidateQueries({ queryKey: folderViewKeys.views(folderPath) })
+          if (!result.success) {
+            throw new Error(result.error || 'Failed to save view')
           }
-        })()
-      }, 300)
+        } catch (err) {
+          log.error('updateView failed:', err)
+          // Revert on error
+          void queryClient.invalidateQueries({ queryKey: folderViewKeys.views(folderPath) })
+        }
+      })
     },
     [activeView, activeViewIndex, folderPath, queryClient]
   )
@@ -542,26 +571,21 @@ export function useFolderView({
       )
 
       // Debounce the disk write to avoid thrashing on every keystroke
-      if (renameTimeoutRef.current) {
-        clearTimeout(renameTimeoutRef.current)
-      }
-      renameTimeoutRef.current = setTimeout(() => {
-        void (async () => {
-          try {
-            const result = await window.api.folderView.setConfig(folderPath, {
-              views: newViews
-            } as unknown as Record<string, unknown>)
+      scheduleWrite(renameWriteRef, async () => {
+        try {
+          const result = await window.api.folderView.setConfig(folderPath, {
+            views: newViews
+          } as unknown as Record<string, unknown>)
 
-            if (!result.success) {
-              throw new Error(result.error || 'Failed to rename view')
-            }
-          } catch (err) {
-            log.error('renameView failed:', err)
-            // Revert on error
-            void queryClient.invalidateQueries({ queryKey: folderViewKeys.views(folderPath) })
+          if (!result.success) {
+            throw new Error(result.error || 'Failed to rename view')
           }
-        })()
-      }, 300)
+        } catch (err) {
+          log.error('renameView failed:', err)
+          // Revert on error
+          void queryClient.invalidateQueries({ queryKey: folderViewKeys.views(folderPath) })
+        }
+      })
     },
     [views, folderPath, queryClient]
   )
@@ -712,39 +736,33 @@ export function useFolderView({
       })
 
       // Debounce the save
-      if (updateTimeoutRef.current) {
-        clearTimeout(updateTimeoutRef.current)
-      }
+      scheduleWrite(updateWriteRef, async () => {
+        try {
+          await window.api.folderView.setView(
+            folderPath,
+            updatedView as unknown as Record<string, unknown>
+          )
 
-      updateTimeoutRef.current = setTimeout(() => {
-        void (async () => {
-          try {
-            await window.api.folderView.setView(
-              folderPath,
-              updatedView as unknown as Record<string, unknown>
-            )
+          const configResult = await window.api.folderView.getConfig(folderPath)
+          const existingConfig = configResult.config
 
-            const configResult = await window.api.folderView.getConfig(folderPath)
-            const existingConfig = configResult.config
-
-            const updatedConfig = {
-              ...existingConfig,
-              properties: {
-                ...existingConfig.properties,
-                [columnId]: {
-                  ...(existingConfig.properties?.[columnId] || {}),
-                  displayName
-                }
+          const updatedConfig = {
+            ...existingConfig,
+            properties: {
+              ...existingConfig.properties,
+              [columnId]: {
+                ...(existingConfig.properties?.[columnId] || {}),
+                displayName
               }
             }
-
-            await window.api.folderView.setConfig(folderPath, updatedConfig)
-          } catch (err) {
-            log.error('Failed to save display name:', err)
-            void queryClient.invalidateQueries({ queryKey: folderViewKeys.views(folderPath) })
           }
-        })()
-      }, 300)
+
+          await window.api.folderView.setConfig(folderPath, updatedConfig)
+        } catch (err) {
+          log.error('Failed to save display name:', err)
+          void queryClient.invalidateQueries({ queryKey: folderViewKeys.views(folderPath) })
+        }
+      })
     },
     [activeView, activeViewIndex, folderPath, queryClient]
   )
@@ -988,12 +1006,19 @@ export function useFolderView({
   // Effects
   // ============================================================================
 
-  // Cleanup debounce timer
+  // Flush pending writes on unmount (tab close, folder switch) and on app quit.
+  // Both tear the hook down before the debounce fires, so a scheduled-only write
+  // would never reach .folder.md and the view would revert on the next launch.
   useEffect(() => {
+    const flushAll = (): void => {
+      flushWrite(updateWriteRef)
+      flushWrite(renameWriteRef)
+    }
+
+    window.addEventListener('beforeunload', flushAll)
     return () => {
-      if (updateTimeoutRef.current) {
-        clearTimeout(updateTimeoutRef.current)
-      }
+      window.removeEventListener('beforeunload', flushAll)
+      flushAll()
     }
   }, [])
 

--- a/apps/desktop/tests/e2e/folder-view.e2e.ts
+++ b/apps/desktop/tests/e2e/folder-view.e2e.ts
@@ -317,34 +317,42 @@ test.describe('Folder View', () => {
       return columns.map((col) => col.id)
     }
 
+    // openColumnSelector resolves true as soon as the Properties *button* is
+    // visible — it swallows the click and the panel wait — so prove the panel
+    // is actually open before touching it.
+    const openColumnPanel = async (): Promise<void> => {
+      await openColumnSelector(page)
+      await expect(page.getByPlaceholder('Search columns...')).toBeVisible()
+    }
+
     await openFolderView(page, PROJECT_FOLDER, PROJECT_FOLDER)
 
-    expect(await openColumnSelector(page), 'column selector should open').toBe(true)
+    await openColumnPanel()
     await toggleColumn(page, 'status')
     await page.keyboard.press('Escape').catch(() => {})
     await page.waitForTimeout(600)
 
     expect(readPersistedColumnIds('after add')).toContain('status')
 
-    // Reorder via drag handle, then assert disk order matches on-screen order.
+    // Reorder via drag handle. Unconditional: the Status column was just added,
+    // so its header and handle must exist — skipping here on a missing locator
+    // is how a broken reorder would slip through unnoticed.
     const statusHandle = page
       .locator('th:has-text("Status") [title="Drag to reorder column"]')
       .first()
     const titleHeader = page.locator('th:has-text("Title")').first()
-    if (
-      (await statusHandle.isVisible().catch(() => false)) &&
-      (await titleHeader.isVisible().catch(() => false))
-    ) {
-      await statusHandle.dragTo(titleHeader)
-      await page.waitForTimeout(600)
+    await expect(statusHandle).toBeVisible()
+    await expect(titleHeader).toBeVisible()
 
-      const persisted = readPersistedColumnIds('after reorder')
-      expect(persisted).toContain('status')
-      expect(persisted.indexOf('status')).toBeLessThan(persisted.indexOf('title'))
-    }
+    await statusHandle.dragTo(titleHeader)
+    await page.waitForTimeout(600)
+
+    const persisted = readPersistedColumnIds('after reorder')
+    expect(persisted).toContain('status')
+    expect(persisted.indexOf('status')).toBeLessThan(persisted.indexOf('title'))
 
     // Toggle column off to verify remove
-    expect(await openColumnSelector(page), 'column selector should reopen').toBe(true)
+    await openColumnPanel()
     await toggleColumn(page, 'status')
     await page.keyboard.press('Escape').catch(() => {})
     await page.waitForTimeout(600)

--- a/apps/desktop/tests/e2e/folder-view.e2e.ts
+++ b/apps/desktop/tests/e2e/folder-view.e2e.ts
@@ -305,25 +305,28 @@ test.describe('Folder View', () => {
     page,
     testVaultPath
   }) => {
+    // Reads the persisted column ids, asserting the view actually reached disk.
+    // Returning [] on a missing config would let every assertion below pass
+    // vacuously — which is exactly how a dropped write went unnoticed.
+    const readPersistedColumnIds = (label: string): string[] => {
+      const config = readFolderConfig(testVaultPath, PROJECT_FOLDER)
+      const views = (config?.views as Array<Record<string, unknown>>) ?? []
+      expect(views.length, `${label}: .folder.md should hold at least one view`).toBeGreaterThan(0)
+      const columns = (views[0]?.columns as Array<{ id: string }>) ?? []
+      expect(columns.length, `${label}: view should persist its columns`).toBeGreaterThan(0)
+      return columns.map((col) => col.id)
+    }
+
     await openFolderView(page, PROJECT_FOLDER, PROJECT_FOLDER)
 
-    if (await openColumnSelector(page)) {
-      await toggleColumn(page, 'status')
-      await page.keyboard.press('Escape').catch(() => {})
-    }
-
+    expect(await openColumnSelector(page), 'column selector should open').toBe(true)
+    await toggleColumn(page, 'status')
+    await page.keyboard.press('Escape').catch(() => {})
     await page.waitForTimeout(600)
 
-    const configAfterAdd = readFolderConfig(testVaultPath, PROJECT_FOLDER)
-    const viewsAfterAdd = (configAfterAdd?.views as Array<Record<string, unknown>>) ?? []
-    const columnsAfterAdd = (viewsAfterAdd[0]?.columns as Array<{ id: string }>) ?? []
+    expect(readPersistedColumnIds('after add')).toContain('status')
 
-    if (columnsAfterAdd.length > 0) {
-      const hasStatus = columnsAfterAdd.some((col) => col.id === 'status')
-      expect(hasStatus).toBe(true)
-    }
-
-    // Try a reorder via drag handle
+    // Reorder via drag handle, then assert disk order matches on-screen order.
     const statusHandle = page
       .locator('th:has-text("Status") [title="Drag to reorder column"]')
       .first()
@@ -332,27 +335,21 @@ test.describe('Folder View', () => {
       (await statusHandle.isVisible().catch(() => false)) &&
       (await titleHeader.isVisible().catch(() => false))
     ) {
-      await statusHandle.dragTo(titleHeader).catch(() => {})
+      await statusHandle.dragTo(titleHeader)
       await page.waitForTimeout(600)
+
+      const persisted = readPersistedColumnIds('after reorder')
+      expect(persisted).toContain('status')
+      expect(persisted.indexOf('status')).toBeLessThan(persisted.indexOf('title'))
     }
 
     // Toggle column off to verify remove
-    if (await openColumnSelector(page)) {
-      await toggleColumn(page, 'status')
-      await page.keyboard.press('Escape').catch(() => {})
-    }
-
+    expect(await openColumnSelector(page), 'column selector should reopen').toBe(true)
+    await toggleColumn(page, 'status')
+    await page.keyboard.press('Escape').catch(() => {})
     await page.waitForTimeout(600)
-    const configAfterRemove = readFolderConfig(testVaultPath, PROJECT_FOLDER)
-    const viewsAfterRemove = (configAfterRemove?.views as Array<Record<string, unknown>>) ?? []
-    const columnsAfterRemove = (viewsAfterRemove[0]?.columns as Array<{ id: string }>) ?? []
 
-    if (columnsAfterRemove.length > 0) {
-      const hasStatus = columnsAfterRemove.some((col) => col.id === 'status')
-      expect(hasStatus).toBe(false)
-    }
-
-    expect(true).toBe(true)
+    expect(readPersistedColumnIds('after remove')).not.toContain('status')
   })
 
   test('T127: should persist sorting configuration', async ({ page, testVaultPath }) => {

--- a/apps/docs/src/user-guide/folder-view.md
+++ b/apps/docs/src/user-guide/folder-view.md
@@ -25,6 +25,10 @@ You can show / hide columns including any custom property:
 
 Property columns let you sort and filter by typed values (numbers, dates, select).
 
+Your column choice and order are saved to the folder's `.folder.md` file, so they
+survive a restart. Saving is debounced, and pending changes are flushed when you
+leave the folder or quit, so the last edit you make is still written.
+
 ## Sorting
 
 Click any header to sort. Click again to reverse direction. <kbd>⇧</kbd>+click for **secondary sort** (sort by A then B).
@@ -53,11 +57,11 @@ Active filters show as chips you can dismiss.
 
 A density toggle in the toolbar:
 
-| Density | Row height |
-| --- | --- |
-| Compact | minimal padding |
-| Normal | comfortable |
-| Spacious | extra room |
+| Density  | Row height      |
+| -------- | --------------- |
+| Compact  | minimal padding |
+| Normal   | comfortable     |
+| Spacious | extra room      |
 
 Persisted per device.
 


### PR DESCRIPTION
## Why

A client reported folder columns reverting to defaults after restart on macOS. That report was a **stale build** — they run `v2026-07-08.2`, and #720 merged ~11h later and first shipped in `v2026-07-09` (`git merge-base --is-ancestor 74955b55a v2026-07-08.2` → false). **They just need to update.**

Investigating it surfaced a real, separate bug with the same symptom.

## The bug

Column, sort and filter edits persist only through a 300ms-debounced write. The unmount cleanup cleared the timer **without running the write**, and nothing else flushed it. Two things hid it: `updateView` resolves once the timer is *scheduled*, so callers saw success; and the optimistic cache kept showing the edit as saved until restart.

Distinct from #720, whose three `.folder.md` clobber paths remain fixed (`folders.test.ts` 18/18).

## What changed since the first push

The first attempt used a `beforeunload` listener. **It could not work.** `before-quit` calls `preventDefault()`, so the window only closes after the async chain has already run `closeVault()`:

```
before-quit → preventDefault()   ← window stays open, beforeunload does NOT fire
           → flushAllWindows()   ← drains the save registry
           → closeVault()        ← vault closed here
           → app.quit()          ← window closes now → beforeunload fires → too late
```

The listener fired against a closed vault; the write failed with `No vault is currently open`. Thanks to the review for catching it.

This version:

- **Registers with the save registry** (`lib/save-registry.ts`), which main drains via the `app:request-flush` handshake and **awaits before `closeVault()`** — while the vault is still open. `note.tsx` already uses this. `use-flush-on-quit` keeps a `beforeunload` backstop, so this hook needs none.
- **Keys the effect on `folderPath`.** `FolderViewPage` swaps `folderPath` during render rather than remounting (`folder-view.tsx:152`), so a mount-only effect never flushed on folder switch — edit A, click B within 300ms, A's write was replaced and lost.
- **Flushes sequentially.** Each handler read-modify-writes the same `.folder.md` with no lock, so concurrent flushes let one erase the other. The old cleanup avoided this only by accident, leaving the rename timer running.
- **Separate slot for display-name edits** — sharing one slot with `updateView` meant either could silently evict the other.
- **Checks `result.success` in `updateDisplayName`** — `withErrorHandler` resolves `{success:false}` rather than rejecting, so failures were swallowed and never reverted.

## Tests

Five new tests cover quit (through the **real** registry, not a mock), folder switch, write serialization, slot separation, and the failed-write revert.

Each was verified by **reverting its fix and confirming the test fails**:

| Mutation | Result |
|---|---|
| `[folderPath]` → `[]` | folder-switch fails — `Number of calls: 0` |
| remove `registerPendingSave` | quit fails — `Number of calls: 0` |
| sequential → concurrent flush | race fails — `setConfig` called while `setView` pending |
| share the write slot | slot test fails — column write evicted |
| drop `result.success` check | revert test fails |

The first push's tests passed while the fix was broken because they mocked `setView` → `{success:true}` and never modeled quit ordering. Hence mutation-testing this time.

**E2E T126:** dropped the `isVisible` guard around the reorder assertions, and now prove the column panel actually opened — `openColumnSelector` resolves `true` on the button alone, swallowing both the click and the panel wait, so it could not witness a failed open.

## Verification

- Renderer suite — **5102 pass, 0 fail**
- `pnpm typecheck` — 16/16 · `pnpm lint` — 0 errors (3 pre-existing warnings, untouched files)
- `docs:impact --strict` — covered · `docs:build` — clean

**Not verified:** the E2E suite was not run locally (needs an Electron build). The hardened T126 assertions are unproven until CI — and since I removed guards that previously swallowed failures, that is the likely place to see red first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)