### PR TITLE
fix(editor): show block type controls in the floating formatting toolbar

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -408,6 +408,27 @@
   gap: 6px;
 }
 
+.review-formatting-toolbar-block-type {
+  padding-bottom: 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+}
+
+/* BlockTypeSelect renders nothing when the current block has no entry in the
+   block type list, so collapse the row instead of leaving its gap behind. */
+.review-formatting-toolbar-block-type:empty {
+  display: none;
+}
+
+/* The shadcn select trigger ships `w-fit h-9`; match the compact popover. */
+.review-formatting-toolbar-block-type > button {
+  width: 100% !important;
+  height: 28px !important;
+  padding: 0 8px !important;
+  border-radius: 7px !important;
+  font-size: 12px !important;
+  color: inherit !important;
+}
+
 .review-formatting-toolbar-grid {
   display: grid;
   grid-template-columns: repeat(4, 28px);

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@blocknote/react', () => ({
   }: {
     formattingToolbar: (props: Record<string, unknown>) => React.ReactNode
   }) => <>{formattingToolbar({})}</>,
+  BlockTypeSelect: () => <button type="button">block type</button>,
   BasicTextStyleButton: ({ basicTextStyle }: { basicTextStyle: string }) => (
     <button type="button">{basicTextStyle}</button>
   ),
@@ -88,6 +89,17 @@ describe('ReviewFormattingToolbar', () => {
 
     expect(screen.getByText('bold')).toBeInTheDocument()
     expect(screen.getByText('Comment')).toBeInTheDocument()
+  })
+
+  // The floating toolbar is what every note gets by default (note.tsx always
+  // passes `review`, so BlockNote's stock toolbar never renders). Block type
+  // controls used to appear only in the sticky variant, which meant turning
+  // "Sticky Formatting Toolbar" off silently removed the only way to switch a
+  // block to a heading/list from the selection popup.
+  it('offers block type controls in the floating toolbar', () => {
+    render(<ReviewFormattingToolbar onAddComment={vi.fn()} />)
+
+    expect(screen.getByText('block type')).toBeInTheDocument()
   })
 
   it('captures selected text before clicking Comment collapses selection', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/review-formatting-toolbar.tsx
@@ -4,6 +4,7 @@ import type { EditorView } from '@tiptap/pm/view'
 import { useEffect, useRef, type MouseEvent, type PointerEvent } from 'react'
 import {
   BasicTextStyleButton,
+  BlockTypeSelect,
   ColorStyleButton,
   CreateLinkButton,
   FormattingToolbar,
@@ -69,6 +70,14 @@ export function ReviewFormattingToolbar({
   return (
     <FormattingToolbar {...toolbarProps}>
       <div className="review-formatting-toolbar-compact">
+        {/* Block type (paragraph/heading/list) is the sticky toolbar's first
+            item. Without it here, turning the sticky toolbar off left no way to
+            restyle a block from the selection popup. Renders null for blocks
+            outside the block type list (task blocks, callouts, files); the row
+            collapses via `:empty` so it costs no space then. */}
+        <div className="review-formatting-toolbar-block-type">
+          <BlockTypeSelect items={toolbarProps.blockTypeSelectItems} />
+        </div>
         <div className="review-formatting-toolbar-grid">
           <BasicTextStyleButton basicTextStyle="bold" />
           <BasicTextStyleButton basicTextStyle="italic" />

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -89,6 +89,8 @@ Toggle browser spellcheck in [Settings → Editor](/user-guide/settings#editor).
 
 The formatting toolbar can be sticky at the top or float above selections — choose in [Settings → Editor](/user-guide/settings#editor).
 
+Both modes offer the same formatting controls: the block type (paragraph, heading, list) plus inline styles, alignment, colour, indent, and links. The block type control is hidden for blocks that have no alternative type, such as tasks, callouts, and files.
+
 ## Comments
 
 Select text to open the floating toolbar. **Comment** creates an anchored review card in the right rail; selecting the text itself does not open the rail. The right rail aligns each card beside the marked text. Comment cards can be resolved or deleted.


### PR DESCRIPTION
## What

Add the block type control (paragraph / heading / list) to the floating selection toolbar, which previously offered only inline styles.

## Why

`note.tsx` always passes a `review` object, so `formattingToolbar={!stickyToolbar && !review}` is always false — BlockNote's stock floating toolbar (which carries `BlockTypeSelect`) never renders, and every note falls back to the compact review popup. That popup omitted block types, so changing a block to a heading or list worked only with **Settings → Editor → Sticky Formatting Toolbar** turned on.

Reported by a user. Verified in a live Electron run: selecting text in a paragraph and picking Heading 1 from the new dropdown converts the block.