### PR TITLE
fix(sync): never drop items behind the pull cursor

### DIFF
--- a/apps/desktop/src/main/sync/engine/corrupt-item-tracker.test.ts
+++ b/apps/desktop/src/main/sync/engine/corrupt-item-tracker.test.ts
@@ -142,5 +142,29 @@ describe('CorruptItemTracker', () => {
         expect(result).toEqual({ recovered: [], permanentFailures: [] })
       })
     })
+
+    describe('#given the whole /sync/pull response fails schema validation #when refetch called', () => {
+      afterEach(() => {
+        vi.restoreAllMocks()
+      })
+
+      it('#then does not mark items failed when the whole response is unparseable', async () => {
+        const tracker = createTracker()
+
+        const postServerMock = vi.fn().mockResolvedValue({
+          items: [{ id: 'a', type: 'not-a-real-type' }]
+        })
+        vi.spyOn(await import('../http-client'), 'postToServer').mockImplementation(postServerMock)
+
+        const result = await tracker.refetch(['a', 'b'], 'token', new Uint8Array(32))
+
+        expect(result.recovered).toEqual([])
+        // The batch failed, not the items: neither may be condemned.
+        expect(result.permanentFailures).toEqual([])
+        // And no item's retry counter may have been incremented.
+        expect(tracker.shouldRetry('a')).toBe(true)
+        expect(tracker.shouldRetry('b')).toBe(true)
+      })
+    })
   })
 })

--- a/apps/desktop/src/main/sync/engine/corrupt-item-tracker.ts
+++ b/apps/desktop/src/main/sync/engine/corrupt-item-tracker.ts
@@ -92,9 +92,13 @@ export class CorruptItemTracker {
 
       const parsed = RecordPullResponseSchema.safeParse(pullResult.value)
       if (!parsed.success) {
-        log.error('Re-fetch: invalid response', { error: parsed.error.message })
-        for (const id of eligible) this.markFailed(id)
-        return { recovered: [], permanentFailures: eligible }
+        // Batch-level failure: says nothing about any individual item. Do not
+        // penalise them toward permanent quarantine - leave them retryable.
+        log.error('Re-fetch: invalid response; leaving items retryable', {
+          error: parsed.error.message,
+          count: eligible.length
+        })
+        return { recovered: [], permanentFailures: [] }
       }
 
       const signerIds = new Set(parsed.data.items.map((i) => i.signerDeviceId))

--- a/apps/desktop/src/main/sync/engine/pull-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/pull-coordinator.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { decidePageAdvance } from './pull-coordinator'
+
+describe('decidePageAdvance', () => {
+  it('does not advance the cursor when the page failed to parse', () => {
+    expect(
+      decidePageAdvance({ applied: 0, conflicts: 0, allCryptoFailed: false, pageFailed: true })
+    ).toEqual({ advanceCursor: false, stop: true })
+  })
+
+  it('advances and continues on a normal page', () => {
+    expect(
+      decidePageAdvance({ applied: 5, conflicts: 0, allCryptoFailed: false, pageFailed: false })
+    ).toEqual({ advanceCursor: true, stop: false })
+  })
+
+  it('advances but stops when every item failed to decrypt', () => {
+    expect(
+      decidePageAdvance({ applied: 0, conflicts: 0, allCryptoFailed: true, pageFailed: false })
+    ).toEqual({ advanceCursor: true, stop: true })
+  })
+
+  it('advances on an applied-nothing page that did not fail', () => {
+    expect(
+      decidePageAdvance({ applied: 0, conflicts: 0, allCryptoFailed: false, pageFailed: false })
+    ).toEqual({ advanceCursor: true, stop: false })
+  })
+})

--- a/apps/desktop/src/main/sync/engine/pull-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/pull-coordinator.ts
@@ -58,6 +58,23 @@ const applyRank = (type: string): number => PULL_APPLY_ORDER[type] ?? 1
 export const sortByApplyOrder = <T extends { type: string }>(items: T[]): T[] =>
   [...items].sort((a, b) => applyRank(a.type) - applyRank(b.type))
 
+export type PageOutcome = {
+  applied: number
+  conflicts: number
+  allCryptoFailed: boolean
+  /** True only when the page could not be processed at all (e.g. unparseable
+   *  response). Distinct from "applied nothing": a failed page must never be
+   *  passed over, or its items are lost behind the cursor forever. */
+  pageFailed: boolean
+}
+
+export type PageDecision = { advanceCursor: boolean; stop: boolean }
+
+export function decidePageAdvance(outcome: PageOutcome): PageDecision {
+  if (outcome.pageFailed) return { advanceCursor: false, stop: true }
+  return { advanceCursor: true, stop: outcome.allCryptoFailed }
+}
+
 interface PullRunState {
   timer: SyncTimer
   startTime: number
@@ -218,14 +235,19 @@ export class PullCoordinator {
       }
 
       const changes = changesResult.value
-      const shouldStop = await this.pullChangesPage(changes, runState)
+      const decision = await this.pullChangesPage(changes, runState)
       this.emitInitialSyncProgress(changes, runState.pulledCount)
+
+      if (!decision.advanceCursor) {
+        log.error('Pull: page failed; leaving cursor in place for retry on next sync', { cursor })
+        break
+      }
 
       this.stateManager.setStateValue(SYNC_STATE_KEYS.LAST_CURSOR, String(changes.nextCursor))
       cursor = String(changes.nextCursor)
       hasMore = changes.hasMore
 
-      if (shouldStop) break
+      if (decision.stop) break
 
       if (hasMore && !this.ctx.abortController?.signal.aborted) {
         prefetchedNext = this.fetchChangesPage(runState, cursor)
@@ -264,18 +286,21 @@ export class PullCoordinator {
   private async pullChangesPage(
     changes: RecordChangesResponse,
     runState: PullRunState
-  ): Promise<boolean> {
+  ): Promise<PageDecision> {
     const itemIds = Array.from(
       new Set([...changes.items.map((item) => item.id), ...changes.deleted])
     )
-    if (itemIds.length === 0) return false
+    // An empty page is not a failure: advance past it.
+    if (itemIds.length === 0) return { advanceCursor: true, stop: false }
 
     const pageResult = await this.processPage(itemIds, runState)
+    if (pageResult.pageFailed) return decidePageAdvance(pageResult)
+
     runState.pulledCount += pageResult.applied
     runState.totalConflictsResolved += pageResult.conflicts
     await this.applyCrdtBatch(runState)
 
-    return pageResult.allCryptoFailed
+    return decidePageAdvance(pageResult)
   }
 
   private async applyCrdtBatch(runState: PullRunState): Promise<void> {
@@ -430,10 +455,7 @@ export class PullCoordinator {
     log.info('Pull: deferred apply retries processed', { retried: retries.length, applied, failed })
   }
 
-  private async processPage(
-    itemIds: string[],
-    runState: PullRunState
-  ): Promise<{ applied: number; conflicts: number; allCryptoFailed: boolean }> {
+  private async processPage(itemIds: string[], runState: PullRunState): Promise<PageOutcome> {
     const { vaultKey, timer, processedIds, crdtNoteIds } = runState
     const pullResult = await withRetry(
       () =>
@@ -451,8 +473,10 @@ export class PullCoordinator {
 
     const parsed = RecordPullResponseSchema.safeParse(pullResult.value)
     if (!parsed.success) {
-      log.error('Invalid pull response from server', { error: parsed.error.message })
-      return { applied: 0, conflicts: 0, allCryptoFailed: false }
+      log.error('Invalid pull response from server; halting page without advancing cursor', {
+        error: parsed.error.message
+      })
+      return { applied: 0, conflicts: 0, allCryptoFailed: false, pageFailed: true }
     }
 
     log.debug('Pull: response parsed', {
@@ -667,7 +691,7 @@ export class PullCoordinator {
       allCryptoFailed = true
     }
 
-    return { applied: pageApplied, conflicts: pageConflicts, allCryptoFailed }
+    return { applied: pageApplied, conflicts: pageConflicts, allCryptoFailed, pageFailed: false }
   }
 
   private handleConflict(dec: {

--- a/apps/desktop/src/main/sync/engine/pull-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/pull-coordinator.ts
@@ -239,6 +239,14 @@ export class PullCoordinator {
       this.emitInitialSyncProgress(changes, runState.pulledCount)
 
       if (!decision.advanceCursor) {
+        this.ctx.lastError =
+          'Pull page failed to parse — cursor held in place; will retry on next sync.'
+        this.ctx.lastErrorInfo = {
+          category: 'server_error',
+          message: this.ctx.lastError,
+          retryable: true
+        }
+        this.stateManager.setState('error')
         log.error('Pull: page failed; leaving cursor in place for retry on next sync', { cursor })
         break
       }

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -108,6 +108,24 @@ terminal status.
 
 `server_cursor_sequence` tracks per-device pull progress. Pull is incremental: fetch everything strictly after the cursor, advance, repeat.
 
+**Invariant: the cursor never advances past a page that failed to process.** A page whose
+response fails schema validation cannot be applied, so advancing past it would leave its
+items behind the cursor where they are never re-requested — silent, permanent loss on that
+device. The manifest-integrity re-pull does not rescue this: resetting the cursor re-fetches
+the same page, fails identically, and skips the same items again.
+
+Instead the pull halts with the cursor unmoved and retries the same page on the next run.
+The trade is deliberate: an unparseable item stalls that device's pull rather than silently
+dropping data. A stall is recoverable by shipping a client fix; dropped items are not.
+
+Because a stalled pull is indistinguishable from a healthy one from the outside, the halt
+sets sync state to `error` (the same signal the all-items-failed-to-decrypt circuit breaker
+uses). Known gap: the halted path still updates `lastSyncAt` and still reports a successful
+sync run to telemetry — the in-app state is correct, the Grafana signal is not.
+
+Failures of a *batch* are never attributed to individual *items*. A re-fetch whose whole
+response is unparseable leaves its items retryable rather than marking each one failed.
+
 ## Manifest Integrity
 
 Desktop periodically compares `/sync/manifest` with local syncable records. Notes and journals are


### PR DESCRIPTION
## Problem

Two paths in the sync layer treat a **batch-level** failure as an **item-level** outcome.

**1. `pull-coordinator.ts` — the data-loss bug.** `processPage` returned the same shape for
"response unparseable" and "applied nothing", so the loop advanced the cursor past items it
never applied. Up to `PULL_PAGE_LIMIT` (100) items then sit behind the cursor and are never
re-requested: permanent, silent loss on that device. Unrelated notes and tasks that merely
shared the page go with them.

The manifest-integrity re-pull does **not** rescue this. Resetting the cursor to 0 re-hits the
same page, fails identically, and skips the same items — forever.

**2. `corrupt-item-tracker.ts` — hygiene.** A failed `safeParse` of the re-fetch response
marked **every** eligible item failed. To be precise about the impact: `markFailed` does *not*
cause permanent quarantine (`shouldRetry` never reads `attempts`; only signature errors
quarantine). The real cost is a spurious 1-hour re-fetch cooldown and bogus `ITEM_CORRUPT`
events. Blaming items for a transport-level failure is still wrong.

Nothing triggers either today, because client and server share one item-type list. **Both
become reachable the moment a new sync item type exists.**

## Fix

- Explicit `pageFailed` signal plus a pure `decidePageAdvance` helper encoding the invariant:
  **never advance the cursor past a failed page.** Halt and retry the same cursor next sync.
- A halted pull sets sync state to `error`, mirroring the existing `allCryptoFailed` circuit
  breaker. Without this the trade is silent loss for *silent stall* — and a stall only counts
  as recoverable if someone knows to recover it.
- Batch-level parse failures no longer condemn individual items.

## The trade

This swaps *bounded, irrecoverable loss* for an *unbounded but recoverable stall*: a
permanently-unparseable item now wedges that device's cursor instead of being skipped past.
For an app whose product is the user's data, that is the right direction — the deterministic
parse failure is exactly why the old behavior could never self-heal.

**Known gap (pre-existing, shared with the crypto breaker, not introduced here):**
`finalizePullSuccess` still runs on the halted path, so `lastSyncAt` updates and telemetry
still reports `sync_run_completed: success`. In-app sync state is correct; the Grafana signal
is not. Worth a follow-up covering both breakers.

## Tests

- `decidePageAdvance` unit tests, including the regression guard that "applied nothing" stays
  distinguishable from "failed" — conflating those two is the bug.
- `corrupt-item-tracker` test proving an unparseable response leaves items retryable
  (verified to fail against the pre-fix code).
- `src/main/sync` suite: 878/878. `typecheck:node` clean. Full `pnpm lint`/`typecheck`/`test:desktop` green.

## Not covered

No test protects the *wiring* between `decidePageAdvance` and the loop — only the pure helper.
There is no DI harness for `PullCoordinator`, and building one dwarfs the fix. A future edit
moving the `break` after the cursor write would compile and pass everything.

## Note

This does **not** make it safe to add a new sync item type. It only protects clients released
after it; every client already in the field keeps the whole-batch behavior forever. A
server-side capability gate remains mandatory for that.