### PR TITLE
feat(sync): per-client sync-type negotiation

### DIFF
--- a/apps/desktop/src/main/sync/http-client.test.ts
+++ b/apps/desktop/src/main/sync/http-client.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
 
 const mockFetch = vi.fn()
 const mockDb = { name: 'db' }
@@ -125,6 +126,36 @@ describe('http-client', () => {
           })
         })
       )
+    })
+
+    it('declares the supported record sync types when token provided', async () => {
+      // #given
+      mockFetch.mockResolvedValue(createJsonResponse({ success: true }))
+
+      // #when
+      await syncFetch('GET', '/sync/changes', undefined, 'my-token-123')
+
+      // #then
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Memry-Sync-Types': RECORD_SYNC_ITEM_TYPES.join(',')
+          })
+        })
+      )
+    })
+
+    it('does not declare sync types on unauthenticated calls', async () => {
+      // #given
+      mockFetch.mockResolvedValue(createJsonResponse({ success: true }))
+
+      // #when
+      await syncFetch('GET', '/api/users')
+
+      // #then
+      const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>
+      expect(headers['X-Memry-Sync-Types']).toBeUndefined()
     })
 
     it('throws NetworkError on connection failure', async () => {

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -1,5 +1,11 @@
 import { net } from 'electron'
+import { RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
 import { withRetry } from './retry'
+
+// Declared to the server so it never sends this build an item type our
+// RecordPullResponseSchema would reject — one unknown type fails the whole-page
+// safeParse and silently drops the page.
+const SYNC_TYPES_HEADER_VALUE = RECORD_SYNC_ITEM_TYPES.join(',')
 
 function getSyncServerUrl(): string {
   const url = process.env.SYNC_SERVER_URL
@@ -87,6 +93,7 @@ export const syncFetch = async <T>(
 
   if (token) {
     headers['Authorization'] = `Bearer ${token}`
+    headers['X-Memry-Sync-Types'] = SYNC_TYPES_HEADER_VALUE
     Object.assign(headers, await getSyncVaultHeaders())
   }
 

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -75,6 +75,42 @@ Every domain object syncs as a `sync_item`. The server sees:
 
 The blob is the encrypted body. The server can reason about order, dedupe, and authorize writes — but the contents stay opaque.
 
+## Sync Type Negotiation
+
+Clients declare the record sync item types they understand via an `X-Memry-Sync-Types` header
+(comma-separated), sent on authenticated sync calls alongside the existing `X-Memry-Vault-Id`. The
+value is `RECORD_SYNC_ITEM_TYPES` joined with commas. The server (`/sync/changes`, `/sync/manifest`,
+`/sync/pull`) binds only the negotiated types into its `item_type IN (...)` SQL filter.
+
+| Header                      | Resolves to                                                                      |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| Absent                      | The frozen `LEGACY_RECORD_SYNC_ITEM_TYPES` list (15 types)                       |
+| Present, nothing recognized | An empty list — serves zero rows                                                 |
+| Present, some recognized    | The recognized subset, deduped and intersected with the server's supported types |
+
+No header means the client predates negotiation and never declared anything, so it gets exactly the
+frozen legacy list — the property that protects binaries already in users' hands. This list is never
+edited when a new sync item type is added; adding to it would hand that type to clients whose parsers
+reject it, which is exactly the bug this feature exists to prevent.
+
+A header that is present but names nothing recognized is a different situation and resolves
+differently: the client did negotiate, so it must never be handed types it didn't declare. Empty
+types short-circuit before any DB query, and `getChanges` returns the incoming cursor unchanged so
+nothing advances.
+
+Requested types are deduped and intersected with the server's supported set, bounding the
+bind-parameter count against D1's 95-parameter ceiling.
+
+**Why this exists:** the desktop client does not runtime-validate `/sync/changes`, does not filter
+item refs by type before pulling, and validates a pull page with a single whole-page `safeParse`. One
+unknown item type fails the entire page, the client drops it without throwing, and its cursor still
+advances past it — silently losing convergence for every note and task on that page, not just the
+unrecognized item. Published binaries cannot be patched, so the server is the only place this can be
+fixed.
+
+**Deploy order:** the sync-server change must reach production before any desktop build carrying a
+new item type.
+
 ## Vector Clocks (Doc-Level)
 
 Used by the server to order changes across devices. The server itself never inspects fields — it sees a single clock per document and uses it to pick the correct write on conflict.

--- a/apps/sync-server/src/lib/sync-types.test.ts
+++ b/apps/sync-server/src/lib/sync-types.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { LEGACY_RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+import { resolveSyncTypes, SYNC_TYPES_HEADER } from './sync-types'
+
+describe('resolveSyncTypes', () => {
+  const legacy = [...LEGACY_RECORD_SYNC_ITEM_TYPES]
+
+  it('exposes the header name', () => {
+    expect(SYNC_TYPES_HEADER).toBe('X-Memry-Sync-Types')
+  })
+
+  // THE regression that protects shipped binaries.
+  it('falls back to the frozen legacy list when the header is absent', () => {
+    expect(resolveSyncTypes(undefined)).toEqual(legacy)
+    expect(resolveSyncTypes(null)).toEqual(legacy)
+    expect(resolveSyncTypes('')).toEqual(legacy)
+  })
+
+  it('returns only the declared types when the header is present', () => {
+    expect(resolveSyncTypes('note,task')).toEqual(['note', 'task'])
+  })
+
+  it('tolerates whitespace and empty segments', () => {
+    expect(resolveSyncTypes(' note , task ,, ')).toEqual(['note', 'task'])
+  })
+
+  it('drops types the server does not support', () => {
+    expect(resolveSyncTypes('note,bogus,task')).toEqual(['note', 'task'])
+  })
+
+  it('falls back to legacy when nothing in the header is recognized', () => {
+    expect(resolveSyncTypes('bogus,nonsense')).toEqual(legacy)
+  })
+})

--- a/apps/sync-server/src/lib/sync-types.test.ts
+++ b/apps/sync-server/src/lib/sync-types.test.ts
@@ -28,7 +28,20 @@ describe('resolveSyncTypes', () => {
     expect(resolveSyncTypes('note,bogus,task')).toEqual(['note', 'task'])
   })
 
-  it('falls back to legacy when nothing in the header is recognized', () => {
-    expect(resolveSyncTypes('bogus,nonsense')).toEqual(legacy)
+  // A header IS present here — the client declared types, we just couldn't
+  // parse any of them. That must resolve to empty (serve nothing), never to
+  // the legacy list: falling back to legacy would hand a declaring client 15
+  // types it never asked for, which is the exact bug negotiation prevents.
+  it('resolves to empty when the header is present but nothing in it is recognized', () => {
+    expect(resolveSyncTypes('bogus,nonsense')).toEqual([])
+  })
+
+  it('dedupes repeated types while preserving first-seen order', () => {
+    expect(resolveSyncTypes('note,note,task')).toEqual(['note', 'task'])
+  })
+
+  it('bounds the resolved list length even under a long duplicate header', () => {
+    const result = resolveSyncTypes('note,'.repeat(100))
+    expect(result.length).toBeLessThanOrEqual(15)
   })
 })

--- a/apps/sync-server/src/lib/sync-types.ts
+++ b/apps/sync-server/src/lib/sync-types.ts
@@ -11,22 +11,36 @@ const SUPPORTED = new Set<string>(RECORD_SYNC_ITEM_TYPES)
 /**
  * Resolve the item types a client is willing to receive.
  *
- * No header means the client predates negotiation, so it gets exactly the
- * frozen legacy list — never the server's current type list, which may contain
- * types that binary would choke on.
+ * No header vs. an unrecognized header are different situations and must
+ * resolve differently:
  *
- * Unrecognized entries are dropped rather than trusted; an entirely
- * unrecognized header is treated as no header at all.
+ * - **No header at all** means the client predates negotiation entirely — it
+ *   never declared anything, so it gets exactly the frozen legacy list. This
+ *   is the property that protects binaries already in users' hands; never
+ *   change it.
+ * - **Header present but nothing in it recognized** means the client DID
+ *   negotiate — we just failed to parse any of what it declared (e.g. a
+ *   corrupted proxy, a future header format). Falling back to legacy here
+ *   would hand that client 15 types it never asked for, which is the exact
+ *   convergence-loss bug this feature exists to prevent. It must resolve to
+ *   an empty list instead, serving zero rows rather than guessing.
+ *
+ * Recognized entries are deduped (first-seen order preserved) because the
+ * header is unbounded client input: `note,note,note,...` must not multiply
+ * `types.length` past what the server actually supports. Since every
+ * surviving entry is already a member of `RECORD_SYNC_ITEM_TYPES`, deduping
+ * structurally bounds the result to that set's size — no separate cap needed.
  */
 export function resolveSyncTypes(header: string | undefined | null): RecordSyncItemType[] {
   if (!header) return [...LEGACY_RECORD_SYNC_ITEM_TYPES]
 
-  const negotiated = header
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry): entry is RecordSyncItemType => entry.length > 0 && SUPPORTED.has(entry))
+  const seen = new Set<RecordSyncItemType>()
+  for (const raw of header.split(',')) {
+    const entry = raw.trim()
+    if (entry.length > 0 && SUPPORTED.has(entry)) {
+      seen.add(entry as RecordSyncItemType)
+    }
+  }
 
-  if (negotiated.length === 0) return [...LEGACY_RECORD_SYNC_ITEM_TYPES]
-
-  return negotiated
+  return [...seen]
 }

--- a/apps/sync-server/src/lib/sync-types.ts
+++ b/apps/sync-server/src/lib/sync-types.ts
@@ -1,0 +1,32 @@
+import {
+  LEGACY_RECORD_SYNC_ITEM_TYPES,
+  RECORD_SYNC_ITEM_TYPES,
+  type RecordSyncItemType
+} from '@memry/contracts/sync-api'
+
+export const SYNC_TYPES_HEADER = 'X-Memry-Sync-Types'
+
+const SUPPORTED = new Set<string>(RECORD_SYNC_ITEM_TYPES)
+
+/**
+ * Resolve the item types a client is willing to receive.
+ *
+ * No header means the client predates negotiation, so it gets exactly the
+ * frozen legacy list — never the server's current type list, which may contain
+ * types that binary would choke on.
+ *
+ * Unrecognized entries are dropped rather than trusted; an entirely
+ * unrecognized header is treated as no header at all.
+ */
+export function resolveSyncTypes(header: string | undefined | null): RecordSyncItemType[] {
+  if (!header) return [...LEGACY_RECORD_SYNC_ITEM_TYPES]
+
+  const negotiated = header
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry): entry is RecordSyncItemType => entry.length > 0 && SUPPORTED.has(entry))
+
+  if (negotiated.length === 0) return [...LEGACY_RECORD_SYNC_ITEM_TYPES]
+
+  return negotiated
+}

--- a/apps/sync-server/src/middleware/sync-types.test.ts
+++ b/apps/sync-server/src/middleware/sync-types.test.ts
@@ -1,0 +1,35 @@
+import { Hono } from 'hono'
+import { describe, it, expect } from 'vitest'
+import { LEGACY_RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+import type { AppContext } from '../types'
+import { syncTypesMiddleware } from './sync-types'
+
+const createApp = () => {
+  const app = new Hono<AppContext>()
+  app.use('*', syncTypesMiddleware)
+  app.get('/probe', (c) => c.json({ syncTypes: c.get('syncTypes') }))
+  return app
+}
+
+describe('syncTypesMiddleware', () => {
+  it('sets the frozen legacy list when no header is sent', async () => {
+    // #when
+    const res = await createApp().request('/probe', { method: 'GET' })
+
+    // #then
+    const json = (await res.json()) as { syncTypes: string[] }
+    expect(json.syncTypes).toEqual([...LEGACY_RECORD_SYNC_ITEM_TYPES])
+  })
+
+  it('sets the declared types when the header is sent', async () => {
+    // #when
+    const res = await createApp().request('/probe', {
+      method: 'GET',
+      headers: { 'X-Memry-Sync-Types': 'note,task' }
+    })
+
+    // #then
+    const json = (await res.json()) as { syncTypes: string[] }
+    expect(json.syncTypes).toEqual(['note', 'task'])
+  })
+})

--- a/apps/sync-server/src/middleware/sync-types.ts
+++ b/apps/sync-server/src/middleware/sync-types.ts
@@ -1,0 +1,15 @@
+import type { MiddlewareHandler } from 'hono'
+
+import { resolveSyncTypes, SYNC_TYPES_HEADER } from '../lib/sync-types'
+import type { AppContext } from '../types'
+
+/**
+ * Resolve which item types this client can safely receive.
+ *
+ * Mirrors the X-Memry-Vault-Id pattern: read the header once here, and let
+ * handlers read the resolved value off the context.
+ */
+export const syncTypesMiddleware: MiddlewareHandler<AppContext> = async (c, next) => {
+  c.set('syncTypes', resolveSyncTypes(c.req.header(SYNC_TYPES_HEADER)))
+  await next()
+}

--- a/apps/sync-server/src/routes/sync.test.ts
+++ b/apps/sync-server/src/routes/sync.test.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { AppError, ErrorCodes, errorHandler } from '../lib/errors'
+import { LEGACY_RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
 import type { AppContext } from '../types'
 
 // ============================================================================
@@ -408,12 +409,14 @@ describe('sync routes', () => {
       expect(json).toEqual({ items: [], serverTime: 1000 })
     })
 
-    it('should pass userId to getManifest', async () => {
+    it('should pass userId and negotiated types to getManifest', async () => {
       // #when
       await app.request('/sync/manifest', { method: 'GET' }, env, executionCtx)
 
       // #then
-      expect(getManifest).toHaveBeenCalledWith(env.DB, 'user-1', 'vault-1')
+      expect(getManifest).toHaveBeenCalledWith(env.DB, 'user-1', 'vault-1', [
+        ...LEGACY_RECORD_SYNC_ITEM_TYPES
+      ])
     })
   })
 
@@ -437,7 +440,9 @@ describe('sync routes', () => {
       await app.request('/sync/changes?cursor=5&limit=10', { method: 'GET' }, env, executionCtx)
 
       // #then
-      expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 5, 10, 'vault-1')
+      expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 5, 10, 'vault-1', [
+        ...LEGACY_RECORD_SYNC_ITEM_TYPES
+      ])
     })
 
     it('should default cursor to 0 when omitted', async () => {
@@ -445,7 +450,9 @@ describe('sync routes', () => {
       await app.request('/sync/changes', { method: 'GET' }, env, executionCtx)
 
       // #then
-      expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 0, undefined, 'vault-1')
+      expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 0, undefined, 'vault-1', [
+        ...LEGACY_RECORD_SYNC_ITEM_TYPES
+      ])
     })
 
     it('should return 400 for non-numeric cursor', async () => {
@@ -901,7 +908,14 @@ describe('sync routes', () => {
       )
 
       // #then
-      expect(pullItems).toHaveBeenCalledWith(env.DB, env.STORAGE, 'user-1', [VALID_UUID], 'vault-1')
+      expect(pullItems).toHaveBeenCalledWith(
+        env.DB,
+        env.STORAGE,
+        'user-1',
+        [VALID_UUID],
+        'vault-1',
+        [...LEGACY_RECORD_SYNC_ITEM_TYPES]
+      )
     })
 
     it('should return 400 for empty itemIds', async () => {
@@ -1017,7 +1031,14 @@ describe('sync routes', () => {
       )
 
       expect(res.status).toBe(200)
-      expect(pullItems).toHaveBeenCalledWith(env.DB, env.STORAGE, 'user-1', [VALID_UUID], 'vault-1')
+      expect(pullItems).toHaveBeenCalledWith(
+        env.DB,
+        env.STORAGE,
+        'user-1',
+        [VALID_UUID],
+        'vault-1',
+        [...LEGACY_RECORD_SYNC_ITEM_TYPES]
+      )
     })
   })
 
@@ -1284,6 +1305,76 @@ describe('sync routes', () => {
         executionCtx
       )
       expect(res.status).toBe(400)
+    })
+  })
+
+  // ==========================================================================
+  // Sync-type negotiation
+  // ==========================================================================
+
+  describe('sync-type negotiation', () => {
+    // A client that predates negotiation sends no header. It must never be
+    // served a type its z.enum would reject — that drops a whole pull page.
+    it('serves the frozen legacy list to a header-less client', async () => {
+      // #when
+      await app.request('/sync/changes', { method: 'GET' }, env, executionCtx)
+
+      // #then
+      expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 0, undefined, 'vault-1', [
+        ...LEGACY_RECORD_SYNC_ITEM_TYPES
+      ])
+    })
+
+    it('narrows to the declared types when the header is sent', async () => {
+      // #when
+      await app.request(
+        '/sync/changes',
+        { method: 'GET', headers: { 'X-Memry-Sync-Types': 'note,task' } },
+        env,
+        executionCtx
+      )
+
+      // #then
+      expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 0, undefined, 'vault-1', [
+        'note',
+        'task'
+      ])
+    })
+
+    it('passes negotiated types to pullItems', async () => {
+      // #when
+      await app.request(
+        '/sync/pull',
+        {
+          ...jsonPost('/sync/pull', { itemIds: [VALID_UUID] }),
+          headers: { 'Content-Type': 'application/json', 'X-Memry-Sync-Types': 'note' }
+        },
+        env,
+        executionCtx
+      )
+
+      // #then
+      expect(pullItems).toHaveBeenCalledWith(
+        env.DB,
+        env.STORAGE,
+        'user-1',
+        [VALID_UUID],
+        'vault-1',
+        ['note']
+      )
+    })
+
+    it('applies negotiation on the /sync/records/* mount too', async () => {
+      // #when
+      await app.request(
+        '/sync/records/changes',
+        { method: 'GET', headers: { 'X-Memry-Sync-Types': 'note' } },
+        env,
+        executionCtx
+      )
+
+      // #then
+      expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 0, undefined, 'vault-1', ['note'])
     })
   })
 })

--- a/apps/sync-server/src/routes/sync.ts
+++ b/apps/sync-server/src/routes/sync.ts
@@ -8,6 +8,7 @@ import { AppError, ErrorCodes } from '../lib/errors'
 import { authMiddleware } from '../middleware/auth'
 import { paidSyncMiddleware } from '../middleware/paid-sync'
 import { createRateLimiter } from '../middleware/rate-limit'
+import { syncTypesMiddleware } from '../middleware/sync-types'
 import {
   getChanges,
   getItem,
@@ -103,6 +104,7 @@ const handleRegisterVault = async (c: Context<AppContext>): Promise<Response> =>
 sync.post('/vaults', vaultsRateLimit, handleRegisterVault)
 
 sync.use('*', paidSyncMiddleware)
+sync.use('*', syncTypesMiddleware)
 
 const MAX_UPDATE_BYTES = 5 * 1024 * 1024 // 5MB per individual update
 const BASE64_CHUNK_SIZE = 8192
@@ -247,7 +249,7 @@ const handleRecordStatus = async (c: Context<AppContext>): Promise<Response> => 
 const handleRecordManifest = async (c: Context<AppContext>): Promise<Response> => {
   const userId = c.get('userId')!
   const vaultId = c.get('vaultId')!
-  const manifest = await getManifest(c.env.DB, userId, vaultId)
+  const manifest = await getManifest(c.env.DB, userId, vaultId, c.get('syncTypes')!)
   return c.json(manifest)
 }
 
@@ -271,7 +273,7 @@ const handleRecordChanges = async (c: Context<AppContext>): Promise<Response> =>
     logQueryValidationFailure('record', endpoint, 'Invalid limit value')
   }
 
-  const changes = await getChanges(c.env.DB, userId, cursor, limit, vaultId)
+  const changes = await getChanges(c.env.DB, userId, cursor, limit, vaultId, c.get('syncTypes')!)
 
   if (changes.items.length > 0 || changes.deleted.length > 0) {
     await updateDeviceCursor(c.env.DB, deviceId, userId, changes.nextCursor, vaultId)
@@ -381,7 +383,14 @@ const handleRecordPull = async (c: Context<AppContext>): Promise<Response> => {
     label: 'pull request'
   })
 
-  const items = await pullItems(c.env.DB, c.env.STORAGE, userId, parsed.itemIds, vaultId)
+  const items = await pullItems(
+    c.env.DB,
+    c.env.STORAGE,
+    userId,
+    parsed.itemIds,
+    vaultId,
+    c.get('syncTypes')!
+  )
   logRecordQueryBatch({
     endpoint,
     operation: 'pull',

--- a/apps/sync-server/src/services/sync.test.ts
+++ b/apps/sync-server/src/services/sync.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import type { PushItemInput, VectorClock } from '@memry/contracts/sync-api'
+import { LEGACY_RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
 import { AppError, ErrorCodes } from '../lib/errors'
 
 vi.mock('./blob', () => ({
@@ -1916,5 +1917,79 @@ describe('processPushItem', () => {
       createValidPushItem()
     )
     expect(unknownResult).toEqual({ accepted: false, reason: 'INTERNAL_ERROR' })
+  })
+})
+
+// ============================================================================
+// Tests: sync-type negotiation
+// ============================================================================
+
+describe('sync-type negotiation', () => {
+  it('getChanges binds only the negotiated types', async () => {
+    // #given
+    const db = createMockDb()
+    const stmt = createMockStatement()
+    db.prepare.mockReturnValue(stmt)
+
+    // #when
+    await getChanges(db as unknown as D1Database, 'user-1', 0, 10, 'vault-1', ['note', 'task'])
+
+    // #then
+    expect(db.prepare.mock.calls[0][0]).toContain('item_type IN (?, ?)')
+    expect(stmt.bind).toHaveBeenCalledWith('user-1', 'vault-1', 0, 'note', 'task', 11)
+  })
+
+  it('getChanges defaults to the frozen legacy list when types are omitted', async () => {
+    // #given
+    const db = createMockDb()
+    const stmt = createMockStatement()
+    db.prepare.mockReturnValue(stmt)
+
+    // #when
+    await getChanges(db as unknown as D1Database, 'user-1', 0, 10, 'vault-1')
+
+    // #then
+    expect(stmt.bind).toHaveBeenCalledWith(
+      'user-1',
+      'vault-1',
+      0,
+      ...LEGACY_RECORD_SYNC_ITEM_TYPES,
+      11
+    )
+  })
+
+  it('getManifest binds only the negotiated types', async () => {
+    // #given
+    const db = createMockDb()
+    const stmt = createMockStatement()
+    db.prepare.mockReturnValue(stmt)
+
+    // #when
+    await getManifest(db as unknown as D1Database, 'user-1', 'vault-1', ['note'])
+
+    // #then
+    expect(db.prepare.mock.calls[0][0]).toContain('item_type IN (?)')
+    expect(stmt.bind).toHaveBeenCalledWith('user-1', 'vault-1', 'note')
+  })
+
+  it('pullItems binds only the negotiated types', async () => {
+    // #given
+    const db = createMockDb()
+    const stmt = createMockStatement()
+    db.prepare.mockReturnValue(stmt)
+
+    // #when
+    await pullItems(
+      db as unknown as D1Database,
+      {} as unknown as R2Bucket,
+      'user-1',
+      ['item-1'],
+      'vault-1',
+      ['note', 'task']
+    )
+
+    // #then
+    expect(db.prepare.mock.calls[0][0]).toContain('item_type IN (?, ?)')
+    expect(stmt.bind).toHaveBeenCalledWith('user-1', 'vault-1', 'note', 'task', 'item-1')
   })
 })

--- a/apps/sync-server/src/services/sync.test.ts
+++ b/apps/sync-server/src/services/sync.test.ts
@@ -1145,6 +1145,25 @@ describe('pullItems', () => {
     expect(result.map((item) => item.id)).toEqual(['item-10', 'item-90'])
   })
 
+  it('should size batches off the negotiated types.length, not RECORD_SYNC_ITEM_TYPES.length', async () => {
+    // #given — negotiate down to a single type so BATCH_SIZE = 95 - 2 - 1 = 92.
+    // 160 itemIds is chosen so the two possible implementations diverge: the
+    // correct code batches ceil(160 / 92) = 2 times (92 + 68). If BATCH_SIZE
+    // regressed to use RECORD_SYNC_ITEM_TYPES.length (15) instead of
+    // types.length, it would compute 95 - 2 - 15 = 78 and batch
+    // ceil(160 / 78) = 3 times (78 + 78 + 4) instead. 2 vs 3 prepare calls
+    // makes the regression observable.
+    const itemIds = Array.from({ length: 160 }, (_, index) => `item-${index}`)
+
+    // #when
+    await pullItems(db as unknown as D1Database, {} as R2Bucket, 'user-1', itemIds, 'default', [
+      'note'
+    ])
+
+    // #then
+    expect(db.prepare).toHaveBeenCalledTimes(2)
+  })
+
   it('should reject stored rows missing signer metadata', async () => {
     // #given
     const stmt = createMockStatement()

--- a/apps/sync-server/src/services/sync.test.ts
+++ b/apps/sync-server/src/services/sync.test.ts
@@ -2011,4 +2011,54 @@ describe('sync-type negotiation', () => {
     expect(db.prepare.mock.calls[0][0]).toContain('item_type IN (?, ?)')
     expect(stmt.bind).toHaveBeenCalledWith('user-1', 'vault-1', 'note', 'task', 'item-1')
   })
+
+  // Finding 1 makes an empty negotiated list a valid, reachable state (a
+  // header present but fully unrecognized). placeholdersFor([]) would emit
+  // `item_type IN ()`, a SQL syntax error — these three functions must
+  // short-circuit before ever touching the database.
+  describe('empty negotiated types short-circuit', () => {
+    it('getChanges returns an empty result without querying D1 and does not advance the cursor', async () => {
+      // #given
+      const db = createMockDb()
+
+      // #when
+      const result = await getChanges(db as unknown as D1Database, 'user-1', 42, 10, 'vault-1', [])
+
+      // #then
+      expect(result).toEqual({ items: [], deleted: [], hasMore: false, nextCursor: 42 })
+      expect(db.prepare).not.toHaveBeenCalled()
+    })
+
+    it('getManifest returns an empty result without querying D1', async () => {
+      // #given
+      const db = createMockDb()
+
+      // #when
+      const result = await getManifest(db as unknown as D1Database, 'user-1', 'vault-1', [])
+
+      // #then
+      expect(result.items).toEqual([])
+      expect(result.serverTime).toBeGreaterThan(0)
+      expect(db.prepare).not.toHaveBeenCalled()
+    })
+
+    it('pullItems returns an empty array without querying D1', async () => {
+      // #given
+      const db = createMockDb()
+
+      // #when
+      const result = await pullItems(
+        db as unknown as D1Database,
+        {} as R2Bucket,
+        'user-1',
+        ['item-1'],
+        'vault-1',
+        []
+      )
+
+      // #then
+      expect(result).toEqual([])
+      expect(db.prepare).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/apps/sync-server/src/services/sync.ts
+++ b/apps/sync-server/src/services/sync.ts
@@ -527,6 +527,10 @@ export const getManifest = async (
   vaultId = 'default',
   types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
 ): Promise<RecordSyncManifest> => {
+  if (types.length === 0) {
+    return { items: [], serverTime: Math.floor(Date.now() / 1000) }
+  }
+
   const rows = await db
     .prepare(
       `SELECT item_id, item_type, version, updated_at, size_bytes, state_vector
@@ -565,6 +569,10 @@ export const getChanges = async (
   vaultId = 'default',
   types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
 ): Promise<RecordChangesResponse> => {
+  if (types.length === 0) {
+    return { items: [], deleted: [], hasMore: false, nextCursor: cursor }
+  }
+
   const effectiveLimit = Math.min(limit ?? DEFAULT_CHANGES_LIMIT, MAX_CHANGES_LIMIT)
 
   const rows = await db
@@ -687,7 +695,7 @@ export const pullItems = async (
   vaultId = 'default',
   types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
 ): Promise<RecordPullItemResponse[]> => {
-  if (itemIds.length === 0) {
+  if (itemIds.length === 0 || types.length === 0) {
     return []
   }
 

--- a/apps/sync-server/src/services/sync.ts
+++ b/apps/sync-server/src/services/sync.ts
@@ -10,7 +10,11 @@ import type {
   RecordSyncItemType,
   RecordSyncManifest
 } from '@memry/contracts/sync-api'
-import { RECORD_CLOCK_REQUIRED_ITEM_TYPES, RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+import {
+  LEGACY_RECORD_SYNC_ITEM_TYPES,
+  RECORD_CLOCK_REQUIRED_ITEM_TYPES,
+  RECORD_SYNC_ITEM_TYPES
+} from '@memry/contracts/sync-api'
 import { encodeSignaturePayload } from '../lib/cbor'
 import { safeBase64Decode, verifyEd25519 } from '../lib/encoding'
 import { AppError, ErrorCodes } from '../lib/errors'
@@ -24,7 +28,9 @@ const DEFAULT_CHANGES_LIMIT = 100
 const MAX_CHANGES_LIMIT = 500
 const RECORD_SYNC_ITEM_TYPE_SET = new Set<RecordSyncItemType>(RECORD_SYNC_ITEM_TYPES)
 const RECORD_CLOCK_REQUIRED_TYPE_SET = new Set<RecordSyncItemType>(RECORD_CLOCK_REQUIRED_ITEM_TYPES)
-const RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS = RECORD_SYNC_ITEM_TYPES.map(() => '?').join(', ')
+
+const placeholdersFor = (types: readonly RecordSyncItemType[]): string =>
+  types.map(() => '?').join(', ')
 
 interface ExistingSyncItemRow {
   version: number
@@ -518,16 +524,17 @@ export const getSyncStatus = async (
 export const getManifest = async (
   db: D1Database,
   userId: string,
-  vaultId = 'default'
+  vaultId = 'default',
+  types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
 ): Promise<RecordSyncManifest> => {
   const rows = await db
     .prepare(
       `SELECT item_id, item_type, version, updated_at, size_bytes, state_vector
        FROM sync_items
-       WHERE user_id = ? AND vault_id = ? AND deleted_at IS NULL AND item_type IN (${RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS})
+       WHERE user_id = ? AND vault_id = ? AND deleted_at IS NULL AND item_type IN (${placeholdersFor(types)})
        ORDER BY server_cursor ASC`
     )
-    .bind(userId, vaultId, ...RECORD_SYNC_ITEM_TYPES)
+    .bind(userId, vaultId, ...types)
     .all<{
       item_id: string
       item_type: string
@@ -555,7 +562,8 @@ export const getChanges = async (
   userId: string,
   cursor: number,
   limit?: number,
-  vaultId = 'default'
+  vaultId = 'default',
+  types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
 ): Promise<RecordChangesResponse> => {
   const effectiveLimit = Math.min(limit ?? DEFAULT_CHANGES_LIMIT, MAX_CHANGES_LIMIT)
 
@@ -563,11 +571,11 @@ export const getChanges = async (
     .prepare(
       `SELECT item_id, item_type, version, updated_at, size_bytes, state_vector, server_cursor, deleted_at
        FROM sync_items
-       WHERE user_id = ? AND vault_id = ? AND server_cursor > ? AND item_type IN (${RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS})
+       WHERE user_id = ? AND vault_id = ? AND server_cursor > ? AND item_type IN (${placeholdersFor(types)})
        ORDER BY server_cursor ASC
        LIMIT ?`
     )
-    .bind(userId, vaultId, cursor, ...RECORD_SYNC_ITEM_TYPES, effectiveLimit + 1)
+    .bind(userId, vaultId, cursor, ...types, effectiveLimit + 1)
     .all<{
       item_id: string
       item_type: string
@@ -676,13 +684,15 @@ export const pullItems = async (
   storage: R2Bucket,
   userId: string,
   itemIds: string[],
-  vaultId = 'default'
+  vaultId = 'default',
+  types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
 ): Promise<RecordPullItemResponse[]> => {
   if (itemIds.length === 0) {
     return []
   }
 
-  const BATCH_SIZE = D1_MAX_BIND_PARAMS - 2 - RECORD_SYNC_ITEM_TYPES.length
+  // 95 D1 bind params, minus user_id + vault_id, minus one per negotiated type.
+  const BATCH_SIZE = D1_MAX_BIND_PARAMS - 2 - types.length
 
   const allDbRows: StoredSyncItemPullRow[] = []
 
@@ -694,11 +704,11 @@ export const pullItems = async (
         `SELECT item_id, item_type, blob_key, crypto_version, operation, signer_device_id, signature,
                 state_vector, clock, deleted_at, server_cursor
          FROM sync_items
-         WHERE user_id = ? AND vault_id = ? AND item_type IN (${RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS})
+         WHERE user_id = ? AND vault_id = ? AND item_type IN (${placeholdersFor(types)})
            AND item_id IN (${placeholders})
          ORDER BY server_cursor ASC`
       )
-      .bind(userId, vaultId, ...RECORD_SYNC_ITEM_TYPES, ...batch)
+      .bind(userId, vaultId, ...types, ...batch)
       .all<StoredSyncItemPullRow>()
     allDbRows.push(...(rows.results ?? []))
   }
@@ -737,7 +747,7 @@ export const getItem = async (
     .prepare(
       `SELECT item_id, item_type, version, blob_key, server_cursor
        FROM sync_items
-       WHERE user_id = ? AND vault_id = ? AND item_type IN (${RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS})
+       WHERE user_id = ? AND vault_id = ? AND item_type IN (${placeholdersFor(RECORD_SYNC_ITEM_TYPES)})
          AND item_id = ? AND deleted_at IS NULL`
     )
     .bind(userId, vaultId, ...RECORD_SYNC_ITEM_TYPES, itemId)

--- a/apps/sync-server/src/types.ts
+++ b/apps/sync-server/src/types.ts
@@ -41,5 +41,6 @@ export type AppContext = {
     sessionNonce?: string
     vaultId?: string
     syncEntitlement?: import('./services/entitlements').SyncEntitlement
+    syncTypes?: import('@memry/contracts/sync-api').RecordSyncItemType[]
   }
 }

--- a/docs/superpowers/plans/2026-07-16-sync-type-negotiation.md
+++ b/docs/superpowers/plans/2026-07-16-sync-type-negotiation.md
@@ -207,8 +207,22 @@ describe('resolveSyncTypes', () => {
     expect(resolveSyncTypes('note,bogus,task')).toEqual(['note', 'task'])
   })
 
-  it('falls back to legacy when nothing in the header is recognized', () => {
-    expect(resolveSyncTypes('bogus,nonsense')).toEqual(legacy)
+  // CORRECTED post-review (see 2026-07-15-template-sync-design.md): the original
+  // draft of this test expected a fully-unrecognized header to fall back to
+  // legacy. That was wrong and was inverted before ship — a header IS present
+  // here, so the client DID negotiate; we just couldn't parse any of it.
+  // Falling back to legacy would hand it 15 types it never declared, which is
+  // the exact bug negotiation exists to prevent. It must resolve to empty.
+  it('resolves to empty when the header is present but nothing in it is recognized', () => {
+    expect(resolveSyncTypes('bogus,nonsense')).toEqual([])
+  })
+
+  it('dedupes repeated types while preserving first-seen order', () => {
+    expect(resolveSyncTypes('note,note,task')).toEqual(['note', 'task'])
+  })
+
+  it('bounds the resolved list length even under a long duplicate header', () => {
+    expect(resolveSyncTypes('note,'.repeat(100)).length).toBeLessThanOrEqual(15)
   })
 })
 ```
@@ -236,31 +250,44 @@ const SUPPORTED = new Set<string>(RECORD_SYNC_ITEM_TYPES)
 /**
  * Resolve the item types a client is willing to receive.
  *
- * No header means the client predates negotiation, so it gets exactly the
- * frozen legacy list — never the server's current type list, which may contain
- * types that binary would choke on.
+ * No header vs. an unrecognized header are different situations and must
+ * resolve differently:
  *
- * Unrecognized entries are dropped rather than trusted; an entirely
- * unrecognized header is treated as no header at all.
+ * - **No header at all** means the client predates negotiation entirely — it
+ *   never declared anything, so it gets exactly the frozen legacy list. This
+ *   is the property that protects binaries already in users' hands; never
+ *   change it.
+ * - **Header present but nothing in it recognized** means the client DID
+ *   negotiate — we just failed to parse any of what it declared. Falling back
+ *   to legacy here would hand that client 15 types it never asked for, which
+ *   is the exact convergence-loss bug this feature exists to prevent. It must
+ *   resolve to an empty list instead, serving zero rows rather than guessing.
+ *
+ * Recognized entries are deduped (first-seen order preserved) because the
+ * header is unbounded client input: `note,note,note,...` must not multiply
+ * `types.length` past what the server actually supports. Since every
+ * surviving entry is already a member of `RECORD_SYNC_ITEM_TYPES`, deduping
+ * structurally bounds the result to that set's size — no separate cap needed.
  */
 export function resolveSyncTypes(header: string | undefined | null): RecordSyncItemType[] {
   if (!header) return [...LEGACY_RECORD_SYNC_ITEM_TYPES]
 
-  const negotiated = header
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry): entry is RecordSyncItemType => entry.length > 0 && SUPPORTED.has(entry))
+  const seen = new Set<RecordSyncItemType>()
+  for (const raw of header.split(',')) {
+    const entry = raw.trim()
+    if (entry.length > 0 && SUPPORTED.has(entry)) {
+      seen.add(entry as RecordSyncItemType)
+    }
+  }
 
-  if (negotiated.length === 0) return [...LEGACY_RECORD_SYNC_ITEM_TYPES]
-
-  return negotiated
+  return [...seen]
 }
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `pnpm --filter @memry/sync-server test -- sync-types`
-Expected: PASS (6 tests).
+Expected: PASS (9 tests).
 
 - [ ] **Step 5: Commit**
 
@@ -268,7 +295,10 @@ Expected: PASS (6 tests).
 git add apps/sync-server/src/lib/sync-types.ts apps/sync-server/src/lib/sync-types.test.ts
 git commit -m "feat(sync-server): resolve client sync types from request header
 
-Absent or fully-unrecognized header resolves to the frozen legacy list."
+No header falls back to the frozen legacy list (pre-negotiation client). A
+header present but fully unrecognized resolves to empty, not legacy — the
+client did negotiate, we just couldn't parse it, so serve nothing rather than
+hand it 15 undeclared types. Recognized entries are deduped."
 ```
 
 ---
@@ -289,6 +319,12 @@ Absent or fully-unrecognized header resolves to the frozen legacy list."
   - `pullItems(db: D1Database, storage: R2Bucket, userId: string, itemIds: string[], vaultId?: string, types?: readonly RecordSyncItemType[]): Promise<RecordPullItemResponse[]>`
 
 Each `types` parameter defaults to `LEGACY_RECORD_SYNC_ITEM_TYPES` — **not** `RECORD_SYNC_ITEM_TYPES`. A forgotten call site must fail closed (serving too little) rather than open (breaking old clients).
+
+**Empty `types` is now a valid, reachable state** (Task 2's `resolveSyncTypes` can return `[]` for a header present but fully unrecognized), and `placeholdersFor([])` would emit `item_type IN ()` — a SQL **syntax error**, not "matches nothing". All three functions must therefore short-circuit before touching the database when `types.length === 0`:
+
+- `getChanges` → `{ items: [], deleted: [], hasMore: false, nextCursor: cursor }` — return the **incoming** cursor unchanged, so the cursor never advances on an unparseable-header request.
+- `getManifest` → `{ items: [], serverTime: Math.floor(Date.now() / 1000) }`.
+- `pullItems` → `[]`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -365,13 +401,52 @@ describe('sync-type negotiation', () => {
     expect(db.prepare.mock.calls[0][0]).toContain('item_type IN (?, ?)')
     expect(stmt.bind).toHaveBeenCalledWith('user-1', 'vault-1', 'note', 'task', 'item-1')
   })
+
+  // Empty types is reachable (Task 2: a header present but fully
+  // unrecognized). item_type IN () is a SQL syntax error, so these three
+  // functions must short-circuit before ever calling db.prepare.
+  describe('empty negotiated types short-circuit', () => {
+    it('getChanges returns an empty result without querying D1 and does not advance the cursor', async () => {
+      const db = createMockDb()
+
+      const result = await getChanges(db as unknown as D1Database, 'user-1', 42, 10, 'vault-1', [])
+
+      expect(result).toEqual({ items: [], deleted: [], hasMore: false, nextCursor: 42 })
+      expect(db.prepare).not.toHaveBeenCalled()
+    })
+
+    it('getManifest returns an empty result without querying D1', async () => {
+      const db = createMockDb()
+
+      const result = await getManifest(db as unknown as D1Database, 'user-1', 'vault-1', [])
+
+      expect(result.items).toEqual([])
+      expect(db.prepare).not.toHaveBeenCalled()
+    })
+
+    it('pullItems returns an empty array without querying D1', async () => {
+      const db = createMockDb()
+
+      const result = await pullItems(
+        db as unknown as D1Database,
+        {} as R2Bucket,
+        'user-1',
+        ['item-1'],
+        'vault-1',
+        []
+      )
+
+      expect(result).toEqual([])
+      expect(db.prepare).not.toHaveBeenCalled()
+    })
+  })
 })
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `pnpm --filter @memry/sync-server test -- services/sync`
-Expected: FAIL — the extra argument is ignored, so `bind` still receives all 15 `RECORD_SYNC_ITEM_TYPES`.
+Expected: FAIL — the extra argument is ignored, so `bind` still receives all 15 `RECORD_SYNC_ITEM_TYPES`; the empty-types tests fail because `item_type IN ()` is sent to `db.prepare` instead of short-circuiting.
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -393,6 +468,10 @@ export const getManifest = async (
   vaultId = 'default',
   types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
 ): Promise<RecordSyncManifest> => {
+  if (types.length === 0) {
+    return { items: [], serverTime: Math.floor(Date.now() / 1000) }
+  }
+
   const rows = await db
     .prepare(
       `SELECT item_id, item_type, version, updated_at, size_bytes, state_vector
@@ -423,6 +502,10 @@ export const getChanges = async (
   vaultId = 'default',
   types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
 ): Promise<RecordChangesResponse> => {
+  if (types.length === 0) {
+    return { items: [], deleted: [], hasMore: false, nextCursor: cursor }
+  }
+
   const effectiveLimit = Math.min(limit ?? DEFAULT_CHANGES_LIMIT, MAX_CHANGES_LIMIT)
 
   const rows = await db
@@ -458,7 +541,7 @@ export const pullItems = async (
   vaultId = 'default',
   types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
 ): Promise<RecordPullItemResponse[]> => {
-  if (itemIds.length === 0) {
+  if (itemIds.length === 0 || types.length === 0) {
     return []
   }
 
@@ -500,7 +583,10 @@ git add apps/sync-server/src/services/sync.ts apps/sync-server/src/services/sync
 git commit -m "feat(sync-server): bind negotiated item types in changes/manifest/pull
 
 Types default to the frozen legacy list so a missed call site fails closed.
-pullItems BATCH_SIZE now derives from the negotiated list length."
+pullItems BATCH_SIZE now derives from the negotiated list length. All three
+functions short-circuit before SQL when types is empty (item_type IN () is a
+syntax error); getChanges returns the incoming cursor unchanged so the
+cursor never advances on that path."
 ```
 
 ---

--- a/docs/superpowers/plans/2026-07-16-sync-type-negotiation.md
+++ b/docs/superpowers/plans/2026-07-16-sync-type-negotiation.md
@@ -1,0 +1,954 @@
+# Plan A — Sync-Type Capability Negotiation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the sync server serve each client only the item types that client declares it understands, so adding any new sync item type can never break an already-shipped binary.
+
+**Architecture:** The client sends `X-Memry-Sync-Types: <comma-separated>` alongside the existing `X-Memry-Vault-Id` header. A Hono middleware resolves that header into a negotiated type list on the request context; `getChanges`, `getManifest` and `pullItems` bind that list into their existing `item_type IN (...)` SQL instead of the compile-time `RECORD_SYNC_ITEM_TYPES` constant. A request with no header resolves to a **frozen** legacy list, which is what protects binaries already in users' hands.
+
+**Tech Stack:** TypeScript, Hono, Cloudflare D1/R2 (sync-server), Electron main process (desktop client), Zod contracts, Vitest.
+
+## Global Constraints
+
+- **Live beta, real users on macOS/Windows/Linux. Backward compatibility is mandatory.** No DB resets. Old clients must keep working.
+- **Deploy order is a hard rule:** this server change goes to production BEFORE any desktop build carrying a new item type (Plan B). Staging auto-deploys on `main` push; prod is manual + approval via GitHub Actions.
+- **`LEGACY_RECORD_SYNC_ITEM_TYPES` is frozen forever.** It is never edited when a new sync type is added. That is the entire point of the constant.
+- No D1 migration is required — `sync_items.item_type` is a bare `TEXT NOT NULL` with no CHECK constraint.
+- Do not add `Co-Authored-By` to commit messages.
+- Logging: `createLogger('Scope')`, never raw `console.*`.
+
+## Background — why this exists
+
+`getChanges` already filters `item_type IN (...)` in SQL before `LIMIT`, binding the server's own compile-time `RECORD_SYNC_ITEM_TYPES`. The moment a server is deployed whose contracts include a new type, it serves refs of that type to **every** client, including binaries that predate it. On such a client:
+
+1. `/sync/changes` is fetched via `getFromServer<T>` → `syncFetch<T>` — a generic cast with **no runtime validation** — so the unknown ref is accepted.
+2. `pullChangesPage` maps every ref to an id with no type filter (`pull-coordinator.ts:268`).
+3. `RecordPullResponseSchema.safeParse` validates the **whole page**; the unknown type fails the old binary's `z.enum(RECORD_SYNC_ITEM_TYPES)`, so `processPage` returns `applied: 0` (`pull-coordinator.ts:453-456`) without throwing.
+4. `pullChanges` still persists `LAST_CURSOR` (`pull-coordinator.ts:1291`), so the page's notes and tasks are skipped **permanently**.
+
+Cursor mechanics need no change: because the type filter runs in SQL before `LIMIT`, excluded rows never enter a page and `nextCursor` steps over them for free.
+
+## File Structure
+
+| File                                                                | Responsibility                                                                             |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `packages/contracts/src/sync-api.ts` (modify)                       | Add the frozen `LEGACY_RECORD_SYNC_ITEM_TYPES` constant + `LegacyRecordSyncItemType` type. |
+| `packages/contracts/src/sync-api.test.ts` (modify)                  | Freeze-test the legacy list.                                                               |
+| `apps/sync-server/src/lib/sync-types.ts` (create)                   | `SYNC_TYPES_HEADER` + `resolveSyncTypes(header)` — pure, fully unit-testable.              |
+| `apps/sync-server/src/lib/sync-types.test.ts` (create)              | Unit tests for `resolveSyncTypes`.                                                         |
+| `apps/sync-server/src/types.ts` (modify)                            | `AppContext` Variables gain `syncTypes`.                                                   |
+| `apps/sync-server/src/middleware/sync-types.ts` (create)            | Middleware writing `syncTypes` onto the context.                                           |
+| `apps/sync-server/src/middleware/sync-types.test.ts` (create)       | Middleware tests.                                                                          |
+| `apps/sync-server/src/services/sync.ts` (modify)                    | `getChanges`/`getManifest`/`pullItems` take an explicit `types` argument.                  |
+| `apps/sync-server/src/services/sync.test.ts` (modify)               | Assert the negotiated list is what gets bound.                                             |
+| `apps/sync-server/src/routes/sync.ts` (modify)                      | Register middleware; pass `c.get('syncTypes')` into the three services.                    |
+| `apps/sync-server/src/routes/sync.test.ts` (modify)                 | Update call-arg assertions; add header-negotiation cases.                                  |
+| `apps/desktop/src/main/sync/http-client.ts` (modify)                | Send `X-Memry-Sync-Types`.                                                                 |
+| `apps/desktop/src/main/sync/http-client.test.ts` (create or modify) | Assert the header is sent.                                                                 |
+
+---
+
+### Task 1: Freeze the legacy item-type list in contracts
+
+**Files:**
+
+- Modify: `packages/contracts/src/sync-api.ts` (after the `CRDT_SYNC_ITEM_TYPES` declaration, ~line 79)
+- Test: `packages/contracts/src/sync-api.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `LEGACY_RECORD_SYNC_ITEM_TYPES: readonly RecordSyncItemType[]` and `type LegacyRecordSyncItemType`. Task 2 and Task 3 both import the constant.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/contracts/src/sync-api.test.ts`:
+
+```ts
+import { LEGACY_RECORD_SYNC_ITEM_TYPES, RECORD_SYNC_ITEM_TYPES } from './sync-api'
+
+describe('LEGACY_RECORD_SYNC_ITEM_TYPES', () => {
+  // This list is FROZEN. It describes what already-shipped binaries understand.
+  // If a new sync item type makes this test fail, the fix is NEVER to update this
+  // list — it is to leave it alone. See 2026-07-15-template-sync-design.md.
+  it('is exactly the 15 record types that shipped before type negotiation', () => {
+    expect(LEGACY_RECORD_SYNC_ITEM_TYPES).toEqual([
+      'note',
+      'task',
+      'project',
+      'settings',
+      'inbox',
+      'filter',
+      'journal',
+      'tag_definition',
+      'folder_config',
+      'calendar_event',
+      'calendar_source',
+      'calendar_binding',
+      'calendar_external_event',
+      'agent_conversation',
+      'agent_message'
+    ])
+  })
+
+  it('only contains types the server still supports', () => {
+    for (const type of LEGACY_RECORD_SYNC_ITEM_TYPES) {
+      expect(RECORD_SYNC_ITEM_TYPES).toContain(type)
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/contracts test -- sync-api`
+Expected: FAIL — `LEGACY_RECORD_SYNC_ITEM_TYPES` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/contracts/src/sync-api.ts`, immediately after the `CRDT_SYNC_ITEM_TYPES` declaration:
+
+```ts
+/**
+ * The record sync item types understood by every client shipped BEFORE
+ * per-request sync-type negotiation existed.
+ *
+ * FROZEN — never add to this list, not even when adding a new sync item type.
+ *
+ * A pre-negotiation binary sends no `X-Memry-Sync-Types` header, so the server
+ * serves it exactly these types. Without this, a newer item type reaches a
+ * binary whose `z.enum(RECORD_SYNC_ITEM_TYPES)` rejects it, which fails the
+ * whole-page `RecordPullResponseSchema.safeParse` and silently drops a page of
+ * notes and tasks while the device cursor advances past them.
+ */
+export const LEGACY_RECORD_SYNC_ITEM_TYPES = [
+  'note',
+  'task',
+  'project',
+  'settings',
+  'inbox',
+  'filter',
+  'journal',
+  'tag_definition',
+  'folder_config',
+  'calendar_event',
+  'calendar_source',
+  'calendar_binding',
+  'calendar_external_event',
+  'agent_conversation',
+  'agent_message'
+] as const
+
+export type LegacyRecordSyncItemType = (typeof LEGACY_RECORD_SYNC_ITEM_TYPES)[number]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/contracts test -- sync-api`
+Expected: PASS. Then `pnpm typecheck` — no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/contracts/src/sync-api.ts packages/contracts/src/sync-api.test.ts
+git commit -m "feat(contracts): freeze legacy record sync item type list
+
+Describes what pre-negotiation clients understand. Never edited when a new
+sync type is added; the server serves exactly this list to any client that
+sends no X-Memry-Sync-Types header."
+```
+
+---
+
+### Task 2: `resolveSyncTypes` header parser
+
+**Files:**
+
+- Create: `apps/sync-server/src/lib/sync-types.ts`
+- Test: `apps/sync-server/src/lib/sync-types.test.ts`
+
+**Interfaces:**
+
+- Consumes: `LEGACY_RECORD_SYNC_ITEM_TYPES`, `RECORD_SYNC_ITEM_TYPES`, `RecordSyncItemType` from `@memry/contracts/sync-api` (Task 1).
+- Produces: `SYNC_TYPES_HEADER: 'X-Memry-Sync-Types'` and `resolveSyncTypes(header: string | undefined | null): RecordSyncItemType[]`. Task 4 (middleware) is the only caller.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/sync-server/src/lib/sync-types.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { LEGACY_RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+import { resolveSyncTypes, SYNC_TYPES_HEADER } from './sync-types'
+
+describe('resolveSyncTypes', () => {
+  const legacy = [...LEGACY_RECORD_SYNC_ITEM_TYPES]
+
+  it('exposes the header name', () => {
+    expect(SYNC_TYPES_HEADER).toBe('X-Memry-Sync-Types')
+  })
+
+  // THE regression that protects shipped binaries.
+  it('falls back to the frozen legacy list when the header is absent', () => {
+    expect(resolveSyncTypes(undefined)).toEqual(legacy)
+    expect(resolveSyncTypes(null)).toEqual(legacy)
+    expect(resolveSyncTypes('')).toEqual(legacy)
+  })
+
+  it('returns only the declared types when the header is present', () => {
+    expect(resolveSyncTypes('note,task')).toEqual(['note', 'task'])
+  })
+
+  it('tolerates whitespace and empty segments', () => {
+    expect(resolveSyncTypes(' note , task ,, ')).toEqual(['note', 'task'])
+  })
+
+  it('drops types the server does not support', () => {
+    expect(resolveSyncTypes('note,bogus,task')).toEqual(['note', 'task'])
+  })
+
+  it('falls back to legacy when nothing in the header is recognized', () => {
+    expect(resolveSyncTypes('bogus,nonsense')).toEqual(legacy)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/sync-server test -- sync-types`
+Expected: FAIL — cannot resolve `./sync-types`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/sync-server/src/lib/sync-types.ts`:
+
+```ts
+import {
+  LEGACY_RECORD_SYNC_ITEM_TYPES,
+  RECORD_SYNC_ITEM_TYPES,
+  type RecordSyncItemType
+} from '@memry/contracts/sync-api'
+
+export const SYNC_TYPES_HEADER = 'X-Memry-Sync-Types'
+
+const SUPPORTED = new Set<string>(RECORD_SYNC_ITEM_TYPES)
+
+/**
+ * Resolve the item types a client is willing to receive.
+ *
+ * No header means the client predates negotiation, so it gets exactly the
+ * frozen legacy list — never the server's current type list, which may contain
+ * types that binary would choke on.
+ *
+ * Unrecognized entries are dropped rather than trusted; an entirely
+ * unrecognized header is treated as no header at all.
+ */
+export function resolveSyncTypes(header: string | undefined | null): RecordSyncItemType[] {
+  if (!header) return [...LEGACY_RECORD_SYNC_ITEM_TYPES]
+
+  const negotiated = header
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry): entry is RecordSyncItemType => entry.length > 0 && SUPPORTED.has(entry))
+
+  if (negotiated.length === 0) return [...LEGACY_RECORD_SYNC_ITEM_TYPES]
+
+  return negotiated
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/sync-server test -- sync-types`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/sync-server/src/lib/sync-types.ts apps/sync-server/src/lib/sync-types.test.ts
+git commit -m "feat(sync-server): resolve client sync types from request header
+
+Absent or fully-unrecognized header resolves to the frozen legacy list."
+```
+
+---
+
+### Task 3: Services take an explicit negotiated type list
+
+**Files:**
+
+- Modify: `apps/sync-server/src/services/sync.ts` — `getManifest` (~518-551), `getChanges` (~553-610), `pullItems` (~672-721)
+- Test: `apps/sync-server/src/services/sync.test.ts`
+
+**Interfaces:**
+
+- Consumes: `RecordSyncItemType` from contracts.
+- Produces — the exact signatures Task 5 calls:
+  - `getManifest(db: D1Database, userId: string, vaultId?: string, types?: readonly RecordSyncItemType[]): Promise<RecordSyncManifest>`
+  - `getChanges(db: D1Database, userId: string, cursor: number, limit?: number, vaultId?: string, types?: readonly RecordSyncItemType[]): Promise<RecordChangesResponse>`
+  - `pullItems(db: D1Database, storage: R2Bucket, userId: string, itemIds: string[], vaultId?: string, types?: readonly RecordSyncItemType[]): Promise<RecordPullItemResponse[]>`
+
+Each `types` parameter defaults to `LEGACY_RECORD_SYNC_ITEM_TYPES` — **not** `RECORD_SYNC_ITEM_TYPES`. A forgotten call site must fail closed (serving too little) rather than open (breaking old clients).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/sync-server/src/services/sync.test.ts`. The existing D1 fake is `createMockDb()` with a chainable `createMockStatement()`; reuse them.
+
+```ts
+import { LEGACY_RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+
+describe('sync-type negotiation', () => {
+  it('getChanges binds only the negotiated types', async () => {
+    // #given
+    const db = createMockDb()
+    const stmt = createMockStatement()
+    db.prepare.mockReturnValue(stmt)
+
+    // #when
+    await getChanges(db as unknown as D1Database, 'user-1', 0, 10, 'vault-1', ['note', 'task'])
+
+    // #then
+    expect(db.prepare.mock.calls[0][0]).toContain('item_type IN (?, ?)')
+    expect(stmt.bind).toHaveBeenCalledWith('user-1', 'vault-1', 0, 'note', 'task', 11)
+  })
+
+  it('getChanges defaults to the frozen legacy list when types are omitted', async () => {
+    // #given
+    const db = createMockDb()
+    const stmt = createMockStatement()
+    db.prepare.mockReturnValue(stmt)
+
+    // #when
+    await getChanges(db as unknown as D1Database, 'user-1', 0, 10, 'vault-1')
+
+    // #then
+    expect(stmt.bind).toHaveBeenCalledWith(
+      'user-1',
+      'vault-1',
+      0,
+      ...LEGACY_RECORD_SYNC_ITEM_TYPES,
+      11
+    )
+  })
+
+  it('getManifest binds only the negotiated types', async () => {
+    // #given
+    const db = createMockDb()
+    const stmt = createMockStatement()
+    db.prepare.mockReturnValue(stmt)
+
+    // #when
+    await getManifest(db as unknown as D1Database, 'user-1', 'vault-1', ['note'])
+
+    // #then
+    expect(db.prepare.mock.calls[0][0]).toContain('item_type IN (?)')
+    expect(stmt.bind).toHaveBeenCalledWith('user-1', 'vault-1', 'note')
+  })
+
+  it('pullItems binds only the negotiated types', async () => {
+    // #given
+    const db = createMockDb()
+    const stmt = createMockStatement()
+    db.prepare.mockReturnValue(stmt)
+
+    // #when
+    await pullItems(
+      db as unknown as D1Database,
+      {} as unknown as R2Bucket,
+      'user-1',
+      ['item-1'],
+      'vault-1',
+      ['note', 'task']
+    )
+
+    // #then
+    expect(db.prepare.mock.calls[0][0]).toContain('item_type IN (?, ?)')
+    expect(stmt.bind).toHaveBeenCalledWith('user-1', 'vault-1', 'note', 'task', 'item-1')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/sync-server test -- services/sync`
+Expected: FAIL — the extra argument is ignored, so `bind` still receives all 15 `RECORD_SYNC_ITEM_TYPES`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/sync-server/src/services/sync.ts`, add the import and a placeholder helper next to the existing constants (~line 22-27). **Delete** the now-unused module constant `RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS`:
+
+```ts
+import { LEGACY_RECORD_SYNC_ITEM_TYPES, type RecordSyncItemType } from '@memry/contracts/sync-api'
+
+const placeholdersFor = (types: readonly RecordSyncItemType[]): string =>
+  types.map(() => '?').join(', ')
+```
+
+`getManifest` — add the parameter and use it:
+
+```ts
+export const getManifest = async (
+  db: D1Database,
+  userId: string,
+  vaultId = 'default',
+  types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
+): Promise<RecordSyncManifest> => {
+  const rows = await db
+    .prepare(
+      `SELECT item_id, item_type, version, updated_at, size_bytes, state_vector
+       FROM sync_items
+       WHERE user_id = ? AND vault_id = ? AND deleted_at IS NULL AND item_type IN (${placeholdersFor(types)})
+       ORDER BY server_cursor ASC`
+    )
+    .bind(userId, vaultId, ...types)
+    .all<{
+      item_id: string
+      item_type: string
+      version: number
+      updated_at: number
+      size_bytes: number
+      state_vector: string | null
+    }>()
+  // ...rest of the function body is unchanged
+```
+
+`getChanges` — same treatment:
+
+```ts
+export const getChanges = async (
+  db: D1Database,
+  userId: string,
+  cursor: number,
+  limit?: number,
+  vaultId = 'default',
+  types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
+): Promise<RecordChangesResponse> => {
+  const effectiveLimit = Math.min(limit ?? DEFAULT_CHANGES_LIMIT, MAX_CHANGES_LIMIT)
+
+  const rows = await db
+    .prepare(
+      `SELECT item_id, item_type, version, updated_at, size_bytes, state_vector, server_cursor, deleted_at
+       FROM sync_items
+       WHERE user_id = ? AND vault_id = ? AND server_cursor > ? AND item_type IN (${placeholdersFor(types)})
+       ORDER BY server_cursor ASC
+       LIMIT ?`
+    )
+    .bind(userId, vaultId, cursor, ...types, effectiveLimit + 1)
+    .all<{
+      item_id: string
+      item_type: string
+      version: number
+      updated_at: number
+      size_bytes: number
+      state_vector: string | null
+      server_cursor: number
+      deleted_at: number | null
+    }>()
+  // ...rest of the function body is unchanged
+```
+
+`pullItems` — the parameter, and `BATCH_SIZE` must derive from `types.length`, not the module constant:
+
+```ts
+export const pullItems = async (
+  db: D1Database,
+  storage: R2Bucket,
+  userId: string,
+  itemIds: string[],
+  vaultId = 'default',
+  types: readonly RecordSyncItemType[] = LEGACY_RECORD_SYNC_ITEM_TYPES
+): Promise<RecordPullItemResponse[]> => {
+  if (itemIds.length === 0) {
+    return []
+  }
+
+  // 95 D1 bind params, minus user_id + vault_id, minus one per negotiated type.
+  const BATCH_SIZE = D1_MAX_BIND_PARAMS - 2 - types.length
+
+  const allDbRows: StoredSyncItemPullRow[] = []
+
+  for (let i = 0; i < itemIds.length; i += BATCH_SIZE) {
+    const batch = itemIds.slice(i, i + BATCH_SIZE)
+    const placeholders = batch.map(() => '?').join(', ')
+    const rows = await db
+      .prepare(
+        `SELECT item_id, item_type, blob_key, crypto_version, operation, signer_device_id, signature,
+                state_vector, clock, deleted_at, server_cursor
+         FROM sync_items
+         WHERE user_id = ? AND vault_id = ? AND item_type IN (${placeholdersFor(types)})
+           AND item_id IN (${placeholders})
+         ORDER BY server_cursor ASC`
+      )
+      .bind(userId, vaultId, ...types, ...batch)
+      .all<StoredSyncItemPullRow>()
+    allDbRows.push(...(rows.results ?? []))
+  }
+  // ...rest of the function body is unchanged
+```
+
+Leave `isSupportedRecordSyncItemType` and the JS-side `.filter(...)` alone — they narrow the TypeScript union; the SQL is what enforces negotiation.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/sync-server test -- services/sync`
+Expected: PASS. Then `pnpm --filter @memry/sync-server typecheck` — expect an error if `RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS` is still referenced anywhere; remove those references.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/sync-server/src/services/sync.ts apps/sync-server/src/services/sync.test.ts
+git commit -m "feat(sync-server): bind negotiated item types in changes/manifest/pull
+
+Types default to the frozen legacy list so a missed call site fails closed.
+pullItems BATCH_SIZE now derives from the negotiated list length."
+```
+
+---
+
+### Task 4: Sync-types middleware
+
+**Files:**
+
+- Create: `apps/sync-server/src/middleware/sync-types.ts`
+- Modify: `apps/sync-server/src/types.ts` (`AppContext` Variables)
+- Test: `apps/sync-server/src/middleware/sync-types.test.ts`
+
+**Interfaces:**
+
+- Consumes: `resolveSyncTypes`, `SYNC_TYPES_HEADER` (Task 2).
+- Produces: `syncTypesMiddleware: MiddlewareHandler<AppContext>`, and `c.get('syncTypes')` typed `RecordSyncItemType[]`. Task 5 reads it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/sync-server/src/middleware/sync-types.test.ts`:
+
+```ts
+import { Hono } from 'hono'
+import { describe, it, expect } from 'vitest'
+import { LEGACY_RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+import type { AppContext } from '../types'
+import { syncTypesMiddleware } from './sync-types'
+
+const createApp = () => {
+  const app = new Hono<AppContext>()
+  app.use('*', syncTypesMiddleware)
+  app.get('/probe', (c) => c.json({ syncTypes: c.get('syncTypes') }))
+  return app
+}
+
+describe('syncTypesMiddleware', () => {
+  it('sets the frozen legacy list when no header is sent', async () => {
+    // #when
+    const res = await createApp().request('/probe', { method: 'GET' })
+
+    // #then
+    const json = (await res.json()) as { syncTypes: string[] }
+    expect(json.syncTypes).toEqual([...LEGACY_RECORD_SYNC_ITEM_TYPES])
+  })
+
+  it('sets the declared types when the header is sent', async () => {
+    // #when
+    const res = await createApp().request('/probe', {
+      method: 'GET',
+      headers: { 'X-Memry-Sync-Types': 'note,task' }
+    })
+
+    // #then
+    const json = (await res.json()) as { syncTypes: string[] }
+    expect(json.syncTypes).toEqual(['note', 'task'])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/sync-server test -- middleware/sync-types`
+Expected: FAIL — cannot resolve `./sync-types`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/sync-server/src/middleware/sync-types.ts`:
+
+```ts
+import type { MiddlewareHandler } from 'hono'
+
+import { resolveSyncTypes, SYNC_TYPES_HEADER } from '../lib/sync-types'
+import type { AppContext } from '../types'
+
+/**
+ * Resolve which item types this client can safely receive.
+ *
+ * Mirrors the X-Memry-Vault-Id pattern: read the header once here, and let
+ * handlers read the resolved value off the context.
+ */
+export const syncTypesMiddleware: MiddlewareHandler<AppContext> = async (c, next) => {
+  c.set('syncTypes', resolveSyncTypes(c.req.header(SYNC_TYPES_HEADER)))
+  await next()
+}
+```
+
+In `apps/sync-server/src/types.ts`, add to the `AppContext` `Variables` block (alongside `vaultId`):
+
+```ts
+import type { RecordSyncItemType } from '@memry/contracts/sync-api'
+
+// ...inside AppContext['Variables']:
+  syncTypes: RecordSyncItemType[]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/sync-server test -- middleware/sync-types`
+Expected: PASS (2 tests). Then `pnpm --filter @memry/sync-server typecheck`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/sync-server/src/middleware/sync-types.ts apps/sync-server/src/middleware/sync-types.test.ts apps/sync-server/src/types.ts
+git commit -m "feat(sync-server): add sync-types middleware
+
+Resolves X-Memry-Sync-Types onto the request context, mirroring the
+X-Memry-Vault-Id pattern."
+```
+
+---
+
+### Task 5: Wire the middleware and services into the routes
+
+**Files:**
+
+- Modify: `apps/sync-server/src/routes/sync.ts` — register middleware after `sync.use('*', paidSyncMiddleware)` (~line 105); update `handleRecordManifest` (~247), `handleRecordChanges` (~254), `handleRecordPull` (~371)
+- Test: `apps/sync-server/src/routes/sync.test.ts`
+
+**Interfaces:**
+
+- Consumes: `syncTypesMiddleware` (Task 4); the service signatures from Task 3.
+- Produces: no new exports. Routes now pass `c.get('syncTypes')!` as the final argument to all three services.
+
+**Note:** every record route is registered **twice** — under `/sync/records/*` and `/sync/*` (`routes/sync.ts:409-425`). Registering the middleware with `sync.use('*', ...)` covers both, since `recordSync` is mounted onto `sync` via `sync.route('/records', recordSync)`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/sync-server/src/routes/sync.test.ts`, update the existing assertions and add negotiation cases. The existing tests assert 5-arg / 3-arg calls and **will fail** once the routes pass a 6th/4th argument — that is expected and correct.
+
+Replace the existing `'should pass userId to getManifest'` test:
+
+```ts
+it('should pass userId and negotiated types to getManifest', async () => {
+  // #when
+  await app.request('/sync/manifest', { method: 'GET' }, env, executionCtx)
+
+  // #then
+  expect(getManifest).toHaveBeenCalledWith(env.DB, 'user-1', 'vault-1', [
+    ...LEGACY_RECORD_SYNC_ITEM_TYPES
+  ])
+})
+```
+
+Replace `'should forward cursor and limit query params'` and `'should default cursor to 0 when omitted'`:
+
+```ts
+it('should forward cursor and limit query params', async () => {
+  // #when
+  await app.request('/sync/changes?cursor=5&limit=10', { method: 'GET' }, env, executionCtx)
+
+  // #then
+  expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 5, 10, 'vault-1', [
+    ...LEGACY_RECORD_SYNC_ITEM_TYPES
+  ])
+})
+
+it('should default cursor to 0 when omitted', async () => {
+  // #when
+  await app.request('/sync/changes', { method: 'GET' }, env, executionCtx)
+
+  // #then
+  expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 0, undefined, 'vault-1', [
+    ...LEGACY_RECORD_SYNC_ITEM_TYPES
+  ])
+})
+```
+
+Add a new `describe` block covering negotiation end-to-end through the routes:
+
+```ts
+// ==========================================================================
+// Sync-type negotiation
+// ==========================================================================
+
+describe('sync-type negotiation', () => {
+  // A client that predates negotiation sends no header. It must never be
+  // served a type its z.enum would reject — that drops a whole pull page.
+  it('serves the frozen legacy list to a header-less client', async () => {
+    // #when
+    await app.request('/sync/changes', { method: 'GET' }, env, executionCtx)
+
+    // #then
+    expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 0, undefined, 'vault-1', [
+      ...LEGACY_RECORD_SYNC_ITEM_TYPES
+    ])
+  })
+
+  it('narrows to the declared types when the header is sent', async () => {
+    // #when
+    await app.request(
+      '/sync/changes',
+      { method: 'GET', headers: { 'X-Memry-Sync-Types': 'note,task' } },
+      env,
+      executionCtx
+    )
+
+    // #then
+    expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 0, undefined, 'vault-1', [
+      'note',
+      'task'
+    ])
+  })
+
+  it('passes negotiated types to pullItems', async () => {
+    // #when
+    await app.request(
+      '/sync/pull',
+      {
+        ...jsonPost('/sync/pull', { itemIds: [VALID_UUID] }),
+        headers: { 'Content-Type': 'application/json', 'X-Memry-Sync-Types': 'note' }
+      },
+      env,
+      executionCtx
+    )
+
+    // #then
+    expect(pullItems).toHaveBeenCalledWith(env.DB, env.STORAGE, 'user-1', [VALID_UUID], 'vault-1', [
+      'note'
+    ])
+  })
+
+  it('applies negotiation on the /sync/records/* mount too', async () => {
+    // #when
+    await app.request(
+      '/sync/records/changes',
+      { method: 'GET', headers: { 'X-Memry-Sync-Types': 'note' } },
+      env,
+      executionCtx
+    )
+
+    // #then
+    expect(getChanges).toHaveBeenCalledWith(env.DB, 'user-1', 0, undefined, 'vault-1', ['note'])
+  })
+})
+```
+
+Add the import at the top of the test file, next to the other contract imports:
+
+```ts
+import { LEGACY_RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/sync-server test -- routes/sync`
+Expected: FAIL — services are still called without the types argument (`expected 6 arguments, received 5`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/sync-server/src/routes/sync.ts`, add the import:
+
+```ts
+import { syncTypesMiddleware } from '../middleware/sync-types'
+```
+
+Register it immediately after the existing `sync.use('*', paidSyncMiddleware)` (~line 105):
+
+```ts
+sync.use('*', paidSyncMiddleware)
+sync.use('*', syncTypesMiddleware)
+```
+
+`handleRecordManifest`:
+
+```ts
+const handleRecordManifest = async (c: Context<AppContext>): Promise<Response> => {
+  const userId = c.get('userId')!
+  const vaultId = c.get('vaultId')!
+  const manifest = await getManifest(c.env.DB, userId, vaultId, c.get('syncTypes')!)
+  return c.json(manifest)
+}
+```
+
+In `handleRecordChanges`, change only the `getChanges` call:
+
+```ts
+const changes = await getChanges(c.env.DB, userId, cursor, limit, vaultId, c.get('syncTypes')!)
+```
+
+In `handleRecordPull`, change only the `pullItems` call:
+
+```ts
+const items = await pullItems(
+  c.env.DB,
+  c.env.STORAGE,
+  userId,
+  parsed.itemIds,
+  vaultId,
+  c.get('syncTypes')!
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/sync-server test -- routes/sync`
+Expected: PASS. Then `pnpm --filter @memry/sync-server test && pnpm --filter @memry/sync-server typecheck` — all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/sync-server/src/routes/sync.ts apps/sync-server/src/routes/sync.test.ts
+git commit -m "feat(sync-server): serve each client only its negotiated sync types
+
+Header-less clients receive the frozen legacy list, so a new item type can
+never reach a binary that would reject it and drop a whole pull page."
+```
+
+---
+
+### Task 6: Client declares its supported types
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/sync/http-client.ts` — `syncFetch` header block (~68-133)
+- Test: `apps/desktop/src/main/sync/http-client.test.ts` (create if it does not exist)
+
+**Interfaces:**
+
+- Consumes: `RECORD_SYNC_ITEM_TYPES` from `@memry/contracts/sync-api`.
+- Produces: no new exports — `syncFetch` simply sends one more header.
+
+**Why inside `if (token)`:** `X-Memry-Vault-Id` is only attached for authenticated calls (`http-client.ts:172-175`). Sync-type negotiation is only meaningful on authenticated sync endpoints, so the new header belongs in the same block.
+
+- [ ] **Step 1: Write the failing test**
+
+Create (or extend) `apps/desktop/src/main/sync/http-client.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+
+vi.mock('electron', () => ({ net: { fetch: vi.fn() } }))
+
+vi.mock('../database', () => ({ getDatabase: vi.fn().mockReturnValue({}) }))
+vi.mock('../agent/storage/vault-id', () => ({
+  getOrCreateVaultUuid: vi.fn().mockReturnValue('vault-1')
+}))
+
+import { getFromServer } from './http-client'
+
+describe('syncFetch sync-type header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.SYNC_SERVER_URL = 'https://sync.example.com'
+  })
+
+  it('declares the supported record sync types on authenticated calls', async () => {
+    // #given
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+
+    // #when
+    await getFromServer('/sync/manifest', 'token-1', fetchFn)
+
+    // #then
+    const headers = fetchFn.mock.calls[0][1].headers as Record<string, string>
+    expect(headers['X-Memry-Sync-Types']).toBe(RECORD_SYNC_ITEM_TYPES.join(','))
+  })
+
+  it('does not declare sync types on unauthenticated calls', async () => {
+    // #given
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+
+    // #when
+    await getFromServer('/health', undefined, fetchFn)
+
+    // #then
+    const headers = fetchFn.mock.calls[0][1].headers as Record<string, string>
+    expect(headers['X-Memry-Sync-Types']).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main -- http-client`
+Expected: FAIL — `expected undefined to be 'note,task,...'`.
+If this errors with `ERR_DLOPEN_FAILED`, run `pnpm --filter @memry/desktop rebuild:node` first.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/desktop/src/main/sync/http-client.ts`, add the import and a module constant:
+
+```ts
+import { RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+
+// Declared to the server so it never sends this build an item type our
+// RecordPullResponseSchema would reject — one unknown type fails the whole-page
+// safeParse and silently drops the page.
+const SYNC_TYPES_HEADER_VALUE = RECORD_SYNC_ITEM_TYPES.join(',')
+```
+
+Then extend the authenticated header block inside `syncFetch`:
+
+```ts
+if (token) {
+  headers['Authorization'] = `Bearer ${token}`
+  headers['X-Memry-Sync-Types'] = SYNC_TYPES_HEADER_VALUE
+  Object.assign(headers, await getSyncVaultHeaders())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:main -- http-client`
+Expected: PASS (2 tests). Then `pnpm typecheck`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/sync/http-client.ts apps/desktop/src/main/sync/http-client.test.ts
+git commit -m "feat(sync): declare supported record sync types to the server
+
+Sent alongside X-Memry-Vault-Id on authenticated sync calls so the server
+can withhold item types this build cannot parse."
+```
+
+---
+
+## Verification (run before pushing)
+
+- [ ] `pnpm --filter @memry/contracts test` — legacy list frozen.
+- [ ] `pnpm --filter @memry/sync-server test && pnpm --filter @memry/sync-server typecheck` — negotiation green, no dangling `RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS`.
+- [ ] `pnpm --filter @memry/desktop test:main -- http-client` — header sent.
+- [ ] `pnpm typecheck`
+- [ ] `pnpm lint`
+- [ ] `pnpm check:contracts && pnpm check:architecture`
+- [ ] `pnpm docs:impact --base origin/main --strict` — sync-server + desktop sync changes are docs-relevant. If it reports `missing-docs`, update `apps/docs/src/**` or run `pnpm docs:ai-update --base origin/main`, then re-run and `pnpm docs:build`.
+
+**Manual two-profile check:** run `pnpm --filter @memry/desktop dev:a` and `dev:b` against one linked vault and confirm notes/tasks still converge. Negotiation is invisible when both clients declare the same list — this is a no-regression check, not a feature check.
+
+## Deploy
+
+1. Merge Plan A.
+2. Deploy sync-server to **staging** (automatic on `main` push); confirm sync still works.
+3. Deploy sync-server to **production** (manual + approval, GitHub Actions).
+4. Only then may Plan B's desktop build ship.
+
+## Follow-up
+
+Once this lands, correct `docs/superpowers/plans/2026-07-14-server-desktop-additive-d6-d8.md:1873`. It currently claims _"old clients simply never pull types they don't register"_ — false, and the reason this plan exists. Rewrite that backward-compat section to reference sync-type negotiation, and note that `home_page` / `bookmark` / `reminder` are safe to add only once this is deployed to production.

--- a/docs/superpowers/plans/2026-07-16-template-sync.md
+++ b/docs/superpowers/plans/2026-07-16-template-sync.md
@@ -1,0 +1,1980 @@
+# Plan B — Custom Template Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Also load the `adding-sync-item-type` skill before Task 1 — it encodes the full enum + registry + telemetry checklist and guards the non-exhaustive-switch typecheck failure.
+
+**Goal:** Make custom templates sync across devices, and migrate every existing user's template files into the synced store without losing one.
+
+**Architecture:** `template` becomes a record sync item type with whole-row LWW (`clock` only, no `fieldClocks`), copying `filter-handler.ts`. Custom templates move from `vault/.memry/templates/*.md` into a new `templates` table in the data DB; built-in templates stop being files entirely and become code constants served straight from `BUILT_IN_TEMPLATES`. A one-time, settings-guarded backfill imports each existing custom template file as a row with `clock = NULL`, which the existing `seedUnclocked` machinery then pushes.
+
+**Tech Stack:** TypeScript, Drizzle ORM + better-sqlite3 (data DB), Zod contracts, Electron main process, Vitest, Playwright (Electron E2E).
+
+## Global Constraints
+
+- **GATED ON PLAN A.** Do not ship a desktop build carrying the `template` type until `docs/superpowers/plans/2026-07-16-sync-type-negotiation.md` is **deployed to production**. Without it, an old client sharing a vault with an upgraded one drops entire pages of notes and tasks while its cursor advances past them.
+- **Live beta, real users on macOS/Windows/Linux. Backward compatibility is mandatory.** No DB resets.
+- **Data-DB migrations are HAND-WRITTEN.** Drizzle snapshots are broken past `0021`; `meta/` snapshots stop at `0021_snapshot.json`. Do NOT run `db:generate` for this table — write the SQL and the `_journal.json` entry by hand.
+- **Migration `when` must exceed `1783206622572`** (the current max in `_journal.json`), or drizzle silently skips it on every existing database. Enforced by `apps/desktop/src/main/database/migrate-journal.test.ts`.
+- **Built-in templates never sync.** They have fixed ids, are identical on every device, and are already immutable.
+- **Template ids are never regenerated during migration.** Preserve the id from file frontmatter.
+- Logging: `createLogger('Scope')`, never raw `console.*`. User-facing errors: `extractErrorMessage(err, fallback)`.
+- Do not add `Co-Authored-By` to commit messages.
+
+## File Structure
+
+| File                                                                      | Responsibility                                                         |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `packages/contracts/src/sync-api.ts` (modify)                             | `'template'` into four arrays.                                         |
+| `packages/contracts/src/sync-payloads.ts` (modify)                        | `TemplateSyncPayloadSchema` + inferred type.                           |
+| `packages/db-schema/src/schema/templates.ts` (create)                     | Drizzle `templates` table.                                             |
+| `packages/db-schema/src/data-schema.ts` + `schema/index.ts` (modify)      | Export it from **both** barrels.                                       |
+| `apps/desktop/src/main/database/drizzle-data/0035_templates.sql` (create) | Hand-written migration.                                                |
+| `apps/desktop/src/main/database/drizzle-data/meta/_journal.json` (modify) | Register migration 35.                                                 |
+| `apps/desktop/src/main/sync/item-handlers/template-handler.ts` (create)   | Record sync handler.                                                   |
+| `apps/desktop/src/main/sync/item-handlers/index.ts` (modify)              | Registry entry.                                                        |
+| `apps/desktop/src/main/sync/template-sync.ts` (create)                    | `RecordSyncController` service.                                        |
+| `apps/desktop/src/main/sync/offline-clock.ts` (modify)                    | `incrementTemplateClockOffline`.                                       |
+| `apps/desktop/src/main/sync/local-mutations.ts` (modify)                  | `template` registry block.                                             |
+| `apps/desktop/src/main/sync/runtime.ts` (modify)                          | init / reset / adapter registry.                                       |
+| `apps/desktop/src/main/sync/manifest-check.ts` (modify)                   | Include clocked templates.                                             |
+| `apps/sync-server/src/services/sync-telemetry.ts` (modify)                | `toSyncDomain` case (exhaustive switch — typecheck fails until added). |
+| `apps/desktop/src/main/vault/templates.ts` (rewrite)                      | DB-backed CRUD; built-ins as constants; enqueue on every mutation.     |
+| `apps/desktop/src/main/vault/templates-migration.ts` (create)             | One-time legacy file → row backfill.                                   |
+| `apps/desktop/src/main/vault/index.ts` (modify)                           | Invoke the backfill from `openVault()`.                                |
+| `apps/desktop/tests/e2e/fixtures/legacy-template-fixtures.ts` (create)    | Pre-launch vault seeding (new pattern — none exists today).            |
+| `apps/desktop/tests/e2e/templates-sync.e2e.ts` (create)                   | Dual-device E2E.                                                       |
+
+---
+
+### Task 1: Contracts — item type + sync payload
+
+**Files:**
+
+- Modify: `packages/contracts/src/sync-api.ts` (four arrays)
+- Modify: `packages/contracts/src/sync-payloads.ts`
+- Test: `packages/contracts/src/sync-payloads.test.ts`
+
+**Interfaces:**
+
+- Produces: `TemplateSyncPayloadSchema`, `type TemplateSyncPayload = { name?: string; description?: string | null; icon?: string | null; tags?: string[]; properties?: unknown; content?: string; clock?: VectorClock; createdAt?: string; modifiedAt?: string }`. Tasks 3, 4 and 6 consume it.
+
+**Four arrays, not one.** `'template'` goes into `SYNC_ITEM_TYPES`, `RECORD_SYNC_ITEM_TYPES`, `RECORD_CLOCK_REQUIRED_ITEM_TYPES` and `ENCRYPTABLE_ITEM_TYPES`. Omitting `ENCRYPTABLE_ITEM_TYPES` makes encryption refuse the type and sync silently drops it. Do **not** add it to `CRDT_SYNC_ITEM_TYPES`, and do **not** touch `LEGACY_RECORD_SYNC_ITEM_TYPES` (Plan A) — that list is frozen.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/contracts/src/sync-payloads.test.ts`:
+
+```ts
+import { TemplateSyncPayloadSchema } from './sync-payloads'
+import {
+  SYNC_ITEM_TYPES,
+  RECORD_SYNC_ITEM_TYPES,
+  RECORD_CLOCK_REQUIRED_ITEM_TYPES,
+  ENCRYPTABLE_ITEM_TYPES,
+  CRDT_SYNC_ITEM_TYPES,
+  LEGACY_RECORD_SYNC_ITEM_TYPES
+} from './sync-api'
+
+describe('template sync item type', () => {
+  it('is registered in all four required arrays', () => {
+    expect(SYNC_ITEM_TYPES).toContain('template')
+    expect(RECORD_SYNC_ITEM_TYPES).toContain('template')
+    expect(RECORD_CLOCK_REQUIRED_ITEM_TYPES).toContain('template')
+    // Omitting this one makes encryption refuse the type and sync drops it silently.
+    expect(ENCRYPTABLE_ITEM_TYPES).toContain('template')
+  })
+
+  it('is not a CRDT type and never leaks into the frozen legacy list', () => {
+    expect(CRDT_SYNC_ITEM_TYPES).not.toContain('template')
+    expect(LEGACY_RECORD_SYNC_ITEM_TYPES).not.toContain('template')
+  })
+})
+
+describe('TemplateSyncPayloadSchema', () => {
+  it('parses a full payload', () => {
+    const result = TemplateSyncPayloadSchema.safeParse({
+      name: 'Standup',
+      description: 'Daily standup',
+      icon: '✅',
+      tags: ['daily'],
+      properties: [{ name: 'date', type: 'date', value: null }],
+      content: '## Blockers',
+      clock: { 'device-a': 1 },
+      createdAt: '2026-07-16T00:00:00.000Z',
+      modifiedAt: '2026-07-16T00:00:00.000Z'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('parses an empty payload (every field optional)', () => {
+    expect(TemplateSyncPayloadSchema.safeParse({}).success).toBe(true)
+  })
+
+  it('accepts a null icon and null description', () => {
+    const result = TemplateSyncPayloadSchema.safeParse({ icon: null, description: null })
+    expect(result.success).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/contracts test -- sync-payloads`
+Expected: FAIL — `TemplateSyncPayloadSchema` is not exported; the array assertions fail.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/contracts/src/sync-api.ts`, add `'template'` as the last entry of `SYNC_ITEM_TYPES`, `RECORD_SYNC_ITEM_TYPES`, `RECORD_CLOCK_REQUIRED_ITEM_TYPES` and `ENCRYPTABLE_ITEM_TYPES`. For example:
+
+```ts
+export const SYNC_ITEM_TYPES = [
+  // ...existing entries unchanged...
+  'agent_conversation',
+  'agent_message',
+  'template'
+] as const
+```
+
+In `packages/contracts/src/sync-payloads.ts`, add next to `FilterSyncPayloadSchema`:
+
+```ts
+export const TemplateSyncPayloadSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().nullable().optional(),
+  icon: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+  properties: z.unknown().optional(),
+  content: z.string().optional(),
+  clock: VectorClockSchema.optional(),
+  createdAt: z.string().optional(),
+  modifiedAt: z.string().optional()
+})
+```
+
+And with the other `z.infer` exports at the bottom:
+
+```ts
+export type TemplateSyncPayload = z.infer<typeof TemplateSyncPayloadSchema>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/contracts test -- sync-payloads`
+Expected: PASS.
+Then `pnpm typecheck` — **expect a failure** in `apps/sync-server/src/services/sync-telemetry.ts`: the `toSyncDomain` switch is exhaustive over `SyncItemType` and has no `default`, so it now "lacks ending return statement". Task 9 fixes it. This failure is the checklist working.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/contracts/src/sync-api.ts packages/contracts/src/sync-payloads.ts packages/contracts/src/sync-payloads.test.ts
+git commit -m "feat(contracts): add template record sync item type
+
+Whole-row LWW; registered in all four arrays including ENCRYPTABLE_ITEM_TYPES.
+Left out of the frozen legacy list so pre-negotiation clients never see it."
+```
+
+---
+
+### Task 2: `templates` table + hand-written migration
+
+**Files:**
+
+- Create: `packages/db-schema/src/schema/templates.ts`
+- Modify: `packages/db-schema/src/data-schema.ts` and `packages/db-schema/src/schema/index.ts`
+- Create: `apps/desktop/src/main/database/drizzle-data/0035_templates.sql`
+- Modify: `apps/desktop/src/main/database/drizzle-data/meta/_journal.json`
+- Test: `apps/desktop/src/main/database/migrate-journal.test.ts` (already exists — it must stay green)
+
+**Interfaces:**
+
+- Produces: `templates` Drizzle table plus `type TemplateRow = typeof templates.$inferSelect` / `NewTemplateRow`. Columns: `id` (PK text), `name` (text notNull), `description` (text nullable), `icon` (text nullable), `tags` (json `string[]`, notNull, default `'[]'`), `properties` (json, notNull, default `'[]'`), `content` (text notNull, default `''`), `clock` (json `VectorClock`, nullable), `syncedAt` (text nullable), `createdAt` (text notNull), `modifiedAt` (text notNull). Tasks 3, 4, 5, 8, 10, 11 all import `templates`.
+
+**Both barrels.** `data-schema.ts` drives drizzle-kit generation; `schema/index.ts` is what consumers import from. A file missing from `data-schema.ts` gets a `DROP TABLE` emitted for it on the next generate.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/db-schema/src/schema/templates.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { templates } from './templates'
+import * as dataSchema from '../data-schema'
+import * as schemaIndex from './index'
+
+describe('templates schema', () => {
+  it('is exported from both barrels', () => {
+    // data-schema.ts drives drizzle-kit; schema/index.ts is what consumers import.
+    // Missing from data-schema.ts => drizzle-kit emits a DROP TABLE for it.
+    expect(dataSchema).toHaveProperty('templates')
+    expect(schemaIndex).toHaveProperty('templates')
+  })
+
+  it('carries the columns record sync needs', () => {
+    const columns = Object.keys(templates)
+    for (const column of [
+      'id',
+      'name',
+      'description',
+      'icon',
+      'tags',
+      'properties',
+      'content',
+      'clock',
+      'syncedAt',
+      'createdAt',
+      'modifiedAt'
+    ]) {
+      expect(columns).toContain(column)
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/db-schema test -- templates`
+Expected: FAIL — cannot resolve `./templates`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/db-schema/src/schema/templates.ts`:
+
+```ts
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { sql } from 'drizzle-orm'
+import type { VectorClock } from '@memry/contracts/sync-api'
+
+/**
+ * Custom note templates. Built-in templates are code constants (see
+ * BUILT_IN_TEMPLATES in main/vault/templates.ts) and never appear here.
+ */
+export const templates = sqliteTable('templates', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  description: text('description'),
+  icon: text('icon'),
+  tags: text('tags', { mode: 'json' }).$type<string[]>().notNull().default([]),
+  properties: text('properties', { mode: 'json' }).$type<unknown[]>().notNull().default([]),
+  content: text('content').notNull().default(''),
+  clock: text('clock', { mode: 'json' }).$type<VectorClock>(),
+  syncedAt: text('synced_at'),
+  createdAt: text('created_at')
+    .notNull()
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
+  modifiedAt: text('modified_at')
+    .notNull()
+    .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`)
+})
+
+export type TemplateRow = typeof templates.$inferSelect
+export type NewTemplateRow = typeof templates.$inferInsert
+```
+
+Add `export * from './schema/templates.ts'` to `packages/db-schema/src/data-schema.ts` and `export * from './templates.ts'` to `packages/db-schema/src/schema/index.ts`.
+
+Create `apps/desktop/src/main/database/drizzle-data/0035_templates.sql`:
+
+```sql
+CREATE TABLE `templates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`icon` text,
+	`tags` text DEFAULT '[]' NOT NULL,
+	`properties` text DEFAULT '[]' NOT NULL,
+	`content` text DEFAULT '' NOT NULL,
+	`clock` text,
+	`synced_at` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`modified_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+```
+
+Append to the `entries` array in `apps/desktop/src/main/database/drizzle-data/meta/_journal.json`, after the `0034_tag_nocase` entry:
+
+```json
+{
+  "idx": 35,
+  "version": "6",
+  "when": 1784246400000,
+  "tag": "0035_templates",
+  "breakpoints": true
+}
+```
+
+`when` must exceed `1783206622572` — `1784246400000` does. **Do not** create `meta/0035_snapshot.json`; hand-written migrations since 0022 have none. **Do not** run `db:generate`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/db-schema test -- templates` → PASS.
+Run: `pnpm --filter @memry/desktop test:main -- migrate-journal` → PASS (the `when` invariant holds).
+Run: `pnpm --filter @memry/desktop db:push` then `pnpm --filter @memry/desktop db:studio:data` and confirm the `templates` table exists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/db-schema/src/schema/templates.ts packages/db-schema/src/schema/templates.test.ts packages/db-schema/src/data-schema.ts packages/db-schema/src/schema/index.ts apps/desktop/src/main/database/drizzle-data/0035_templates.sql apps/desktop/src/main/database/drizzle-data/meta/_journal.json
+git commit -m "feat(db): add templates table
+
+Hand-written migration 0035; drizzle snapshots are broken past 0021 so
+db:generate is not used. Journal 'when' exceeds every prior entry, or
+drizzle skips the migration on existing databases."
+```
+
+---
+
+### Task 3: `template-handler.ts`
+
+**Files:**
+
+- Create: `apps/desktop/src/main/sync/item-handlers/template-handler.ts`
+- Modify: `apps/desktop/src/main/sync/item-handlers/index.ts`
+- Test: `apps/desktop/src/main/sync/item-handlers/template-handler.test.ts`
+
+**Interfaces:**
+
+- Consumes: `templates` (Task 2); `TemplateSyncPayloadSchema` / `TemplateSyncPayload` (Task 1); `TemplatesChannels` from `@memry/contracts/ipc-channels` (already exists and is already emitted by `vault/templates.ts`).
+- Produces: `export const templateHandler` — a `BaseItemHandler<TemplateSyncPayload>` with `type = 'template'`. Task 7 references it via `getRemoteSyncAdapter('template')`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/src/main/sync/item-handlers/template-handler.test.ts`, modelled on `tag-definition-handler.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { TemplatesChannels } from '@memry/contracts/ipc-channels'
+import { templates } from '@memry/db-schema/schema/templates'
+import { createTestDataDb, asSyncDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { SyncQueueManager } from '../queue'
+import { templateHandler } from './template-handler'
+import type { ApplyContext, DrizzleDb } from './types'
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+function makeCtx(testDb: TestDatabaseResult): ApplyContext {
+  return { db: testDb.db as unknown as DrizzleDb, emit: vi.fn() }
+}
+
+describe('templateHandler', () => {
+  let testDb: TestDatabaseResult
+  let ctx: ApplyContext
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    ctx = makeCtx(testDb)
+  })
+
+  afterEach(() => {
+    testDb.close()
+  })
+
+  it('inserts a remote template and emits CREATED', () => {
+    const result = templateHandler.applyUpsert(
+      ctx,
+      'tpl-1',
+      {
+        name: 'Standup',
+        icon: '✅',
+        tags: ['daily'],
+        properties: [],
+        content: '## Blockers',
+        createdAt: '2026-07-16T00:00:00.000Z'
+      },
+      { 'device-b': 1 }
+    )
+
+    expect(result).toBe('applied')
+    expect(testDb.db.select().from(templates).where(eq(templates.id, 'tpl-1')).get()).toMatchObject(
+      {
+        name: 'Standup',
+        icon: '✅',
+        content: '## Blockers',
+        clock: { 'device-b': 1 }
+      }
+    )
+    expect(ctx.emit).toHaveBeenCalledWith(TemplatesChannels.events.CREATED, { id: 'tpl-1' })
+  })
+
+  it('updates on newer clock, skips stale, reports concurrent as conflict', () => {
+    testDb.db
+      .insert(templates)
+      .values({
+        id: 'tpl-1',
+        name: 'Standup',
+        content: 'v1',
+        tags: [],
+        properties: [],
+        clock: { 'device-a': 1 },
+        createdAt: '2026-07-16T00:00:00.000Z',
+        modifiedAt: '2026-07-16T00:00:00.000Z'
+      })
+      .run()
+
+    expect(templateHandler.applyUpsert(ctx, 'tpl-1', { content: 'v2' }, { 'device-a': 2 })).toBe(
+      'applied'
+    )
+    expect(testDb.db.select().from(templates).where(eq(templates.id, 'tpl-1')).get()).toMatchObject(
+      {
+        content: 'v2'
+      }
+    )
+    expect(ctx.emit).toHaveBeenCalledWith(TemplatesChannels.events.UPDATED, { id: 'tpl-1' })
+
+    expect(templateHandler.applyUpsert(ctx, 'tpl-1', { content: 'stale' }, { 'device-a': 1 })).toBe(
+      'skipped'
+    )
+    expect(testDb.db.select().from(templates).where(eq(templates.id, 'tpl-1')).get()).toMatchObject(
+      {
+        content: 'v2'
+      }
+    )
+
+    expect(templateHandler.applyUpsert(ctx, 'tpl-1', { content: 'v3' }, { 'device-b': 1 })).toBe(
+      'conflict'
+    )
+    expect(testDb.db.select().from(templates).where(eq(templates.id, 'tpl-1')).get()).toMatchObject(
+      {
+        content: 'v3',
+        clock: { 'device-a': 2, 'device-b': 1 }
+      }
+    )
+  })
+
+  it('builds payloads, fetches local rows, deletes by clock, and seeds unclocked templates', () => {
+    testDb.db
+      .insert(templates)
+      .values([
+        {
+          id: 'synced',
+          name: 'Synced',
+          content: 'a',
+          tags: [],
+          properties: [],
+          clock: { 'device-a': 1 },
+          createdAt: '2026-07-16T00:00:00.000Z',
+          modifiedAt: '2026-07-16T00:00:00.000Z'
+        },
+        {
+          id: 'local-only',
+          name: 'Local Only',
+          content: 'b',
+          tags: [],
+          properties: [],
+          createdAt: '2026-07-16T00:00:00.000Z',
+          modifiedAt: '2026-07-16T00:00:00.000Z'
+        }
+      ])
+      .run()
+
+    expect(templateHandler.fetchLocal(testDb.db as unknown as DrizzleDb, 'synced')).toMatchObject({
+      name: 'Synced'
+    })
+    expect(templateHandler.fetchLocal(testDb.db as unknown as DrizzleDb, 'missing')).toBeUndefined()
+
+    expect(
+      JSON.parse(
+        templateHandler.buildPushPayload?.(
+          testDb.db as unknown as DrizzleDb,
+          'synced',
+          'device-a',
+          'update'
+        ) ?? '{}'
+      )
+    ).toMatchObject({ name: 'Synced', clock: { 'device-a': 1 } })
+    expect(
+      templateHandler.buildPushPayload?.(
+        testDb.db as unknown as DrizzleDb,
+        'missing',
+        'device-a',
+        'update'
+      )
+    ).toBeNull()
+
+    expect(templateHandler.applyDelete(ctx, 'missing')).toBe('skipped')
+    expect(templateHandler.applyDelete(ctx, 'synced', { 'device-b': 1 })).toBe('skipped')
+    expect(templateHandler.applyDelete(ctx, 'synced', { 'device-a': 2 })).toBe('applied')
+    expect(ctx.emit).toHaveBeenCalledWith(TemplatesChannels.events.DELETED, { id: 'synced' })
+
+    const queue = new SyncQueueManager(asSyncDb(testDb.db))
+    expect(
+      templateHandler.seedUnclocked(testDb.db as unknown as DrizzleDb, 'device-a', queue)
+    ).toBe(1)
+    const [queued] = queue.dequeue(1)
+    expect(queued).toMatchObject({ type: 'template', itemId: 'local-only', operation: 'create' })
+    expect(JSON.parse(queued.payload)).toMatchObject({ clock: { 'device-a': 1 } })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main -- template-handler`
+Expected: FAIL — cannot resolve `./template-handler`.
+On `ERR_DLOPEN_FAILED`, run `pnpm --filter @memry/desktop rebuild:node`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/desktop/src/main/sync/item-handlers/template-handler.ts`:
+
+```ts
+import { eq, isNull } from 'drizzle-orm'
+import { templates } from '@memry/db-schema/schema/templates'
+import { TemplateSyncPayloadSchema, type TemplateSyncPayload } from '@memry/contracts/sync-payloads'
+import { TemplatesChannels } from '@memry/contracts/ipc-channels'
+import type { VectorClock } from '@memry/contracts/sync-api'
+import { utcNow } from '@memry/shared/utc'
+import type { SyncQueueManager } from '../queue'
+import { increment } from '../vector-clock'
+import { createLogger } from '../../lib/logger'
+import { BaseItemHandler } from './base-handler'
+import type { ApplyContext, ApplyResult, DrizzleDb } from './types'
+
+const log = createLogger('TemplateHandler')
+
+class TemplateHandler extends BaseItemHandler<TemplateSyncPayload> {
+  readonly type = 'template' as const
+  readonly schema = TemplateSyncPayloadSchema
+
+  applyUpsert(
+    ctx: ApplyContext,
+    itemId: string,
+    data: TemplateSyncPayload,
+    clock: VectorClock
+  ): ApplyResult {
+    return ctx.db.transaction((tx): ApplyResult => {
+      const existing = tx.select().from(templates).where(eq(templates.id, itemId)).get()
+      const remoteClock = Object.keys(clock).length > 0 ? clock : (data.clock ?? {})
+      const now = utcNow()
+
+      if (existing) {
+        const resolution = this.resolveClock(existing.clock, remoteClock)
+        if (resolution.action === 'skip') {
+          log.info('Skipping remote template update, local is newer', { itemId })
+          return 'skipped'
+        }
+        if (resolution.action === 'merge') {
+          log.warn('Concurrent template edit, using last-write-wins', { itemId })
+        }
+
+        tx.update(templates)
+          .set({
+            name: data.name ?? existing.name,
+            description: data.description !== undefined ? data.description : existing.description,
+            icon: data.icon !== undefined ? data.icon : existing.icon,
+            tags: data.tags ?? existing.tags,
+            properties: (data.properties as unknown[]) ?? existing.properties,
+            content: data.content ?? existing.content,
+            clock: resolution.mergedClock,
+            syncedAt: now,
+            modifiedAt: data.modifiedAt ?? now
+          })
+          .where(eq(templates.id, itemId))
+          .run()
+
+        ctx.emit(TemplatesChannels.events.UPDATED, { id: itemId })
+        return resolution.action === 'merge' ? 'conflict' : 'applied'
+      }
+
+      tx.insert(templates)
+        .values({
+          id: itemId,
+          name: data.name ?? 'Untitled Template',
+          description: data.description ?? null,
+          icon: data.icon ?? null,
+          tags: data.tags ?? [],
+          properties: (data.properties as unknown[]) ?? [],
+          content: data.content ?? '',
+          clock: remoteClock,
+          syncedAt: now,
+          createdAt: data.createdAt ?? now,
+          modifiedAt: data.modifiedAt ?? now
+        })
+        .run()
+
+      ctx.emit(TemplatesChannels.events.CREATED, { id: itemId })
+      return 'applied'
+    })
+  }
+
+  applyDelete(ctx: ApplyContext, itemId: string, clock?: VectorClock): 'applied' | 'skipped' {
+    const existing = ctx.db.select().from(templates).where(eq(templates.id, itemId)).get()
+    if (!existing) return 'skipped'
+
+    if (clock && existing.clock) {
+      const resolution = this.resolveClock(existing.clock, clock)
+      if (resolution.action === 'skip' || resolution.action === 'merge') {
+        log.info('Skipping remote template delete, local has unseen changes', { itemId })
+        return 'skipped'
+      }
+    }
+
+    ctx.db.delete(templates).where(eq(templates.id, itemId)).run()
+    ctx.emit(TemplatesChannels.events.DELETED, { id: itemId })
+    return 'applied'
+  }
+
+  fetchLocal(db: DrizzleDb, itemId: string): Record<string, unknown> | undefined {
+    return db.select().from(templates).where(eq(templates.id, itemId)).get() as
+      | Record<string, unknown>
+      | undefined
+  }
+
+  buildPushPayload(
+    db: DrizzleDb,
+    itemId: string,
+    _deviceId: string,
+    _operation: string
+  ): string | null {
+    const template = db.select().from(templates).where(eq(templates.id, itemId)).get()
+    if (!template) return null
+    return JSON.stringify(template)
+  }
+
+  markPushSynced(db: DrizzleDb, itemId: string): void {
+    db.update(templates).set({ syncedAt: utcNow() }).where(eq(templates.id, itemId)).run()
+  }
+
+  seedUnclocked(db: DrizzleDb, deviceId: string, queue: SyncQueueManager): number {
+    const items = db.select().from(templates).where(isNull(templates.clock)).all()
+    for (const item of items) {
+      const clock = increment({}, deviceId)
+      db.update(templates).set({ clock }).where(eq(templates.id, item.id)).run()
+      queue.enqueue({
+        type: 'template',
+        itemId: item.id,
+        operation: 'create',
+        payload: JSON.stringify({ ...item, clock }),
+        priority: 0
+      })
+    }
+    return items.length
+  }
+}
+
+export const templateHandler = new TemplateHandler()
+```
+
+In `apps/desktop/src/main/sync/item-handlers/index.ts`, add the import alongside the others and register it in the `handlers` Map:
+
+```ts
+import { templateHandler } from './template-handler'
+
+// ...inside the Map literal, after ['agent_message', agentMessageHandler]:
+;['template', templateHandler]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:main -- template-handler`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/sync/item-handlers/template-handler.ts apps/desktop/src/main/sync/item-handlers/template-handler.test.ts apps/desktop/src/main/sync/item-handlers/index.ts
+git commit -m "feat(sync): add template record sync handler
+
+Whole-row LWW copied from filter-handler; seedUnclocked back-fills rows that
+predate sync."
+```
+
+---
+
+### Task 4: `template-sync.ts` service
+
+**Files:**
+
+- Create: `apps/desktop/src/main/sync/template-sync.ts`
+- Test: `apps/desktop/src/main/sync/template-sync.test.ts`
+
+**Interfaces:**
+
+- Consumes: `templates` (Task 2); `SyncQueueManager`.
+- Produces: `initTemplateSyncService(deps): TemplateSyncService`, `getTemplateSyncService(): TemplateSyncService | null`, `resetTemplateSyncService(): void`, and `class TemplateSyncService` with `enqueueCreate(id: string)`, `enqueueUpdate(id: string)`, `enqueueDelete(id: string, snapshotPayload: string)`. Tasks 6 and 7 consume all of these. `deps` is `{ queue: SyncQueueManager; db: DrizzleDb; getDeviceId: () => string | null }`.
+
+**Note:** this layer imports `incrementClock` / `withIncrementedClock` from `@memry/sync-core` — **not** `increment` from `./vector-clock`. The handler layer uses the latter. Two different helpers; mirror the layer you are in.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/src/main/sync/template-sync.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { templates } from '@memry/db-schema/schema/templates'
+import { createTestDataDb, asSyncDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { SyncQueueManager } from './queue'
+import {
+  initTemplateSyncService,
+  getTemplateSyncService,
+  resetTemplateSyncService
+} from './template-sync'
+
+describe('TemplateSyncService', () => {
+  let testDb: TestDatabaseResult
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    testDb.db
+      .insert(templates)
+      .values({
+        id: 'tpl-1',
+        name: 'Standup',
+        content: 'v1',
+        tags: [],
+        properties: [],
+        createdAt: '2026-07-16T00:00:00.000Z',
+        modifiedAt: '2026-07-16T00:00:00.000Z'
+      })
+      .run()
+  })
+
+  afterEach(() => {
+    resetTemplateSyncService()
+    testDb.close()
+  })
+
+  it('enqueues a create and bumps the row clock', () => {
+    const queue = new SyncQueueManager(asSyncDb(testDb.db))
+    const service = initTemplateSyncService({
+      queue,
+      db: testDb.db as never,
+      getDeviceId: () => 'device-a'
+    })
+
+    service.enqueueCreate('tpl-1')
+
+    const [queued] = queue.dequeue(1)
+    expect(queued).toMatchObject({ type: 'template', itemId: 'tpl-1', operation: 'create' })
+    expect(
+      testDb.db.select().from(templates).where(eq(templates.id, 'tpl-1')).get()?.clock
+    ).toEqual({ 'device-a': 1 })
+  })
+
+  it('exposes the singleton and clears it on reset', () => {
+    const queue = new SyncQueueManager(asSyncDb(testDb.db))
+    initTemplateSyncService({ queue, db: testDb.db as never, getDeviceId: () => 'device-a' })
+    expect(getTemplateSyncService()).not.toBeNull()
+
+    resetTemplateSyncService()
+    expect(getTemplateSyncService()).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main -- template-sync`
+Expected: FAIL — cannot resolve `./template-sync`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/desktop/src/main/sync/template-sync.ts` (copied from `filter-sync.ts`):
+
+```ts
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
+import { eq } from 'drizzle-orm'
+import type * as schema from '@memry/db-schema/data-schema'
+import { templates } from '@memry/db-schema/schema/templates'
+import type { VectorClock } from '@memry/contracts/sync-api'
+import { RecordSyncController, incrementClock, withIncrementedClock } from '@memry/sync-core'
+import type { SyncQueueManager } from './queue'
+
+type DrizzleDb = BetterSQLite3Database<typeof schema>
+
+interface TemplateSyncDeps {
+  queue: SyncQueueManager
+  db: DrizzleDb
+  getDeviceId: () => string | null
+}
+
+let instance: TemplateSyncService | null = null
+
+export function initTemplateSyncService(deps: TemplateSyncDeps): TemplateSyncService {
+  instance = new TemplateSyncService(deps)
+  return instance
+}
+
+export function getTemplateSyncService(): TemplateSyncService | null {
+  return instance
+}
+
+export function resetTemplateSyncService(): void {
+  instance = null
+}
+
+export class TemplateSyncService {
+  private controller: RecordSyncController<Record<string, unknown>, [], [string]>
+
+  constructor(deps: TemplateSyncDeps) {
+    this.controller = new RecordSyncController({
+      type: 'template',
+      queue: deps.queue,
+      getDeviceId: deps.getDeviceId,
+      load: (templateId) =>
+        deps.db.select().from(templates).where(eq(templates.id, templateId)).get() as
+          | Record<string, unknown>
+          | undefined,
+      applyLocalChange: ({ itemId, local, deviceId }) => {
+        const existingClock = (local.clock as VectorClock) ?? {}
+        const newClock = incrementClock(existingClock, deviceId)
+
+        deps.db.update(templates).set({ clock: newClock }).where(eq(templates.id, itemId)).run()
+
+        return { ...local, clock: newClock }
+      },
+      serialize: (local) => local,
+      buildDeletePayload: ({ extra, deviceId }) => withIncrementedClock(extra[0], deviceId)
+    })
+  }
+
+  enqueueCreate(templateId: string): void {
+    this.controller.enqueueCreate(templateId)
+  }
+
+  enqueueUpdate(templateId: string): void {
+    this.controller.enqueueUpdate(templateId)
+  }
+
+  enqueueDelete(templateId: string, snapshotPayload: string): void {
+    this.controller.enqueueDelete(templateId, snapshotPayload)
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:main -- template-sync`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/sync/template-sync.ts apps/desktop/src/main/sync/template-sync.test.ts
+git commit -m "feat(sync): add template sync service"
+```
+
+---
+
+### Task 5: Offline clock helper
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/sync/offline-clock.ts` (append after `incrementFilterClockOffline`, ~line 181)
+- Test: `apps/desktop/src/main/sync/offline-clock.test.ts` (extend if present, else create)
+
+**Interfaces:**
+
+- Produces: `incrementTemplateClockOffline(db: DataDb, templateId: string): void`. Task 6 is the only caller.
+
+**Why:** without it, edits made while the sync service is uninitialized (offline) never bump the clock, so they are lost on reconnect.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { templates } from '@memry/db-schema/schema/templates'
+import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { incrementTemplateClockOffline, OFFLINE_DEVICE_KEY } from './offline-clock'
+
+describe('incrementTemplateClockOffline', () => {
+  let testDb: TestDatabaseResult
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+  })
+
+  afterEach(() => {
+    testDb.close()
+  })
+
+  it('stamps the offline device key on the row clock', () => {
+    testDb.db
+      .insert(templates)
+      .values({
+        id: 'tpl-1',
+        name: 'Standup',
+        content: '',
+        tags: [],
+        properties: [],
+        createdAt: '2026-07-16T00:00:00.000Z',
+        modifiedAt: '2026-07-16T00:00:00.000Z'
+      })
+      .run()
+
+    incrementTemplateClockOffline(testDb.db as never, 'tpl-1')
+
+    expect(
+      testDb.db.select().from(templates).where(eq(templates.id, 'tpl-1')).get()?.clock
+    ).toEqual({ [OFFLINE_DEVICE_KEY]: 1 })
+  })
+
+  it('is a no-op for a missing template', () => {
+    expect(() => incrementTemplateClockOffline(testDb.db as never, 'nope')).not.toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main -- offline-clock`
+Expected: FAIL — `incrementTemplateClockOffline is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the import at the top of `offline-clock.ts`:
+
+```ts
+import { templates } from '@memry/db-schema/schema/templates'
+```
+
+Append the function (copied from `incrementFilterClockOffline`):
+
+```ts
+export function incrementTemplateClockOffline(db: DataDb, templateId: string): void {
+  try {
+    const template = db.select().from(templates).where(eq(templates.id, templateId)).get()
+    if (!template) return
+
+    const existingClock = (template.clock as VectorClock) ?? {}
+    const newClock = increment(existingClock, OFFLINE_DEVICE_KEY)
+
+    db.update(templates).set({ clock: newClock }).where(eq(templates.id, templateId)).run()
+
+    log.debug('Incremented offline template clock', { templateId })
+  } catch (err) {
+    log.warn('Failed to increment offline template clock', { templateId, error: err })
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:main -- offline-clock` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/sync/offline-clock.ts apps/desktop/src/main/sync/offline-clock.test.ts
+git commit -m "feat(sync): bump template clocks for offline edits"
+```
+
+---
+
+### Task 6: `local-mutations` registry entry
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/sync/local-mutations.ts`
+- Test: `apps/desktop/src/main/sync/local-mutations.test.ts`
+
+**Interfaces:**
+
+- Consumes: `getTemplateSyncService` (Task 4), `incrementTemplateClockOffline` (Task 5).
+- Produces: `enqueueLocalSyncCreate('template', id)` / `Update` / `Delete` now resolve to a real adapter. Task 10 calls these from the template CRUD.
+
+`type LocalSyncType = Exclude<SyncItemType, 'attachment'>` already includes `'template'` from Task 1, so without this entry `getLocal('template')` returns undefined and logs `'Missing local sync adapter'`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('resolves a local adapter for template', () => {
+  // Without a registry entry this logs 'Missing local sync adapter' and the
+  // mutation is silently dropped.
+  expect(localSyncRegistry.getLocal('template')).toBeDefined()
+})
+```
+
+Match the existing conventions in `local-mutations.test.ts` for exposing `localSyncRegistry`; if it is not exported, assert instead that `enqueueLocalSyncCreate('template', 'tpl-1')` reaches a mocked `getTemplateSyncService().enqueueCreate`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main -- local-mutations`
+Expected: FAIL — adapter undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the imports:
+
+```ts
+import { getTemplateSyncService } from './template-sync'
+import { incrementTemplateClockOffline } from './offline-clock'
+```
+
+Add this block to the `createSyncAdapterRegistry([...])` array (mirrors the `filter` block, offline fallback included):
+
+```ts
+  {
+    type: 'template',
+    kind: 'record',
+    local: {
+      enqueueCreate(itemId: string): void {
+        const service = getTemplateSyncService()
+        if (service) {
+          service.enqueueCreate(itemId)
+          return
+        }
+
+        incrementTemplateClockOffline(getDatabase(), itemId)
+      },
+      enqueueUpdate(itemId: string): void {
+        const service = getTemplateSyncService()
+        if (service) {
+          service.enqueueUpdate(itemId)
+          return
+        }
+
+        incrementTemplateClockOffline(getDatabase(), itemId)
+      },
+      enqueueDelete(itemId: string, snapshotPayload?: string): void {
+        if (!snapshotPayload) return
+        getTemplateSyncService()?.enqueueDelete(itemId, snapshotPayload)
+      }
+    }
+  },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:main -- local-mutations` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/sync/local-mutations.ts apps/desktop/src/main/sync/local-mutations.test.ts
+git commit -m "feat(sync): register template local mutation adapter"
+```
+
+---
+
+### Task 7: Runtime wiring
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/sync/runtime.ts` — import (~L25), `resetSyncServiceSingletons` (~L112-126), init (~L252), `createSyncAdapterRegistry` (~L288-358)
+- Test: `apps/desktop/src/main/sync/runtime-effects.test.ts` (extend, following existing conventions)
+
+**Interfaces:**
+
+- Consumes: `initTemplateSyncService` / `resetTemplateSyncService` (Task 4); `getRemoteSyncAdapter('template')` (Task 3).
+- Produces: a live `template` entry in the runtime adapter registry.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend the runtime allowlist/fan-out test to assert `template` is present in the adapter registry, matching how the existing test enumerates types.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main -- runtime-effects`
+Expected: FAIL — `template` missing from the registry.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Import, alongside the other record-sync service imports:
+
+```ts
+import { initTemplateSyncService, resetTemplateSyncService } from './template-sync'
+```
+
+Add to `resetSyncServiceSingletons()` before its closing brace:
+
+```ts
+resetTemplateSyncService()
+```
+
+Add the init next to the other services (after `calendarExternalEventSync`):
+
+```ts
+const templateSync = initTemplateSyncService({ queue, db: runtimeSyncDb, getDeviceId })
+```
+
+Add the registry entry before the `])` that closes `createSyncAdapterRegistry`:
+
+```ts
+          {
+            type: 'template',
+            kind: 'record',
+            local: templateSync,
+            remote: getRemoteSyncAdapter('template')
+          }
+```
+
+Mind the comma on the now-penultimate `calendar_external_event` entry.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:main -- runtime-effects` → PASS. Then `pnpm typecheck`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/sync/runtime.ts apps/desktop/src/main/sync/runtime-effects.test.ts
+git commit -m "feat(sync): wire template sync into runtime"
+```
+
+---
+
+### Task 8: Manifest check
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/sync/manifest-check.ts` — `getLocalSyncableItems` (~L140-143, after the `savedFilters` block)
+- Test: `apps/desktop/src/main/sync/manifest-check.test.ts` (extend)
+
+**Interfaces:**
+
+- Consumes: `templates` (Task 2).
+- Produces: clocked template rows now participate in manifest repair.
+
+Without this, a template that exists locally but is missing from the server manifest is never re-enqueued.
+
+- [ ] **Step 1: Write the failing test**
+
+Assert that a clocked template row is returned as a local syncable item (and an unclocked one is not), following the file's existing conventions.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main -- manifest-check`
+Expected: FAIL — template absent from local items.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the import:
+
+```ts
+import { templates } from '@memry/db-schema/schema/templates'
+```
+
+Add after the `savedFilters` block in `getLocalSyncableItems`:
+
+```ts
+const syncedTemplates = db.select().from(templates).where(isNotNull(templates.clock)).all()
+for (const t of syncedTemplates) {
+  addLocalItem({ id: t.id, type: 'template', payload: JSON.stringify(t) })
+}
+```
+
+`LocalSyncableItem.type` is `RecordSyncItemType`, which includes `'template'` from Task 1.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:main -- manifest-check` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/sync/manifest-check.ts apps/desktop/src/main/sync/manifest-check.test.ts
+git commit -m "feat(sync): include templates in manifest integrity check"
+```
+
+---
+
+### Task 9: Server telemetry domain
+
+**Files:**
+
+- Modify: `apps/sync-server/src/services/sync-telemetry.ts` — `SyncDomain` union (~L8-19), `toSyncDomain` (~L30-60)
+- Test: `apps/sync-server/src/services/sync-telemetry.test.ts`
+
+**Interfaces:**
+
+- Produces: `toSyncDomain('template') === 'templates'`.
+
+This is the **only** sync-server change Plan B needs — the server is otherwise type-agnostic (D1 metadata + opaque encrypted R2 blobs), and `sync_items.item_type` has no CHECK constraint, so no D1 migration. Note `getStorageBreakdown`'s switch (`services/storage.ts:47`) is `default`-terminated over `row.item_type: string`, so templates silently land in `other` with no typecheck error — that is acceptable and needs no edit.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('maps template to the templates domain', () => {
+  expect(toSyncDomain('template')).toBe('templates')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/sync-server test -- sync-telemetry`
+Expected: FAIL. And `pnpm --filter @memry/sync-server typecheck` fails with _"Function lacks ending return statement and return type does not include 'undefined'"_ — the switch is non-exhaustive over the widened `SyncItemType` (this has been failing since Task 1).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `'templates'` to the `SyncDomain` union, and the case to `toSyncDomain` before its closing brace:
+
+```ts
+    case 'template':
+      return 'templates'
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/sync-server test -- sync-telemetry` → PASS.
+Run: `pnpm --filter @memry/sync-server typecheck` → no errors; the switch is exhaustive again.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/sync-server/src/services/sync-telemetry.ts apps/sync-server/src/services/sync-telemetry.test.ts
+git commit -m "feat(sync-server): map template item type to templates domain"
+```
+
+---
+
+### Task 10: Move template CRUD into the DB
+
+**Files:**
+
+- Rewrite: `apps/desktop/src/main/vault/templates.ts`
+- Test: `apps/desktop/src/main/vault/templates.test.ts` (rewrite)
+
+**Interfaces:**
+
+- Consumes: `templates` (Task 2); `enqueueLocalSyncCreate/Update/Delete` (Task 6); `getDatabase` from `../database`.
+- Produces — the **public signatures must not change**, so `main/ipc/templates-handlers.ts` and the renderer stay untouched:
+  - `listTemplates(): Promise<TemplateListItem[]>`
+  - `getTemplate(id: string): Promise<Template | null>`
+  - `createTemplate(input: TemplateCreateInput): Promise<Template>`
+  - `updateTemplate(input: TemplateUpdateInput): Promise<Template>`
+  - `deleteTemplate(id: string): Promise<void>`
+  - `duplicateTemplate(id: string, newName: string): Promise<Template>`
+  - `applyTemplate(template: Template, title: string): { content: string; tags: string[]; properties: Record<string, unknown> }` — unchanged, pure.
+  - `BUILT_IN_TEMPLATES` — now **exported** so Task 11's migration can identify built-in ids.
+
+**Ordering — do NOT delete `parseTemplate` in this task.** Task 11 is what relocates it into `templates-migration.ts`. Removing it here would leave the tree unbuildable between the two commits. Leave `parseTemplate` (and its `matter` import and `TemplateFrontmatter` interface) exactly where they are; Task 11 deletes them from this file once the migration module owns them.
+
+**The critical rule:** every create/update/delete **must call** the `local-mutations` enqueue functions. Registering the adapter (Task 6) alone does nothing — a mutation that bypasses it writes to the DB, seeds once via `seedUnclocked`, and then never syncs again.
+
+**Behaviour changes to preserve:** `updateTemplate` and `deleteTemplate` still throw `VaultError` with `PERMISSION_DENIED` for built-ins. `listTemplates` still sorts built-ins first, then by name. `duplicateTemplate` of a built-in still produces a custom template.
+
+- [ ] **Step 1: Write the failing test**
+
+Rewrite `apps/desktop/src/main/vault/templates.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { templates as templatesTable } from '@memry/db-schema/schema/templates'
+import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+
+const enqueueCreate = vi.fn()
+const enqueueUpdate = vi.fn()
+const enqueueDelete = vi.fn()
+
+vi.mock('../sync/local-mutations', () => ({
+  enqueueLocalSyncCreate: (...args: unknown[]) => enqueueCreate(...args),
+  enqueueLocalSyncUpdate: (...args: unknown[]) => enqueueUpdate(...args),
+  enqueueLocalSyncDelete: (...args: unknown[]) => enqueueDelete(...args)
+}))
+
+let testDb: TestDatabaseResult
+vi.mock('../database', () => ({ getDatabase: () => testDb.db }))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import {
+  listTemplates,
+  getTemplate,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+  duplicateTemplate,
+  BUILT_IN_TEMPLATES
+} from './templates'
+
+describe('templates CRUD', () => {
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    testDb.close()
+  })
+
+  it('lists built-ins from code with no DB rows and no files', async () => {
+    const list = await listTemplates()
+    expect(list.length).toBe(BUILT_IN_TEMPLATES.length)
+    expect(list.every((t) => t.isBuiltIn)).toBe(true)
+    expect(testDb.db.select().from(templatesTable).all()).toEqual([])
+  })
+
+  it('serves a built-in by id without touching the DB', async () => {
+    const blank = await getTemplate('blank')
+    expect(blank).toMatchObject({ id: 'blank', isBuiltIn: true })
+  })
+
+  it('creates a custom template as a row and enqueues it for sync', async () => {
+    const created = await createTemplate({ name: 'Standup', content: '## Blockers' })
+
+    expect(created.isBuiltIn).toBe(false)
+    expect(
+      testDb.db.select().from(templatesTable).where(eq(templatesTable.id, created.id)).get()
+    ).toMatchObject({ name: 'Standup', content: '## Blockers' })
+    // Registry wiring alone does nothing — the mutation must enqueue.
+    expect(enqueueCreate).toHaveBeenCalledWith('template', created.id)
+  })
+
+  it('sorts built-ins first, then custom by name', async () => {
+    await createTemplate({ name: 'AAA Custom', content: '' })
+    const list = await listTemplates()
+    expect(list[0].isBuiltIn).toBe(true)
+    expect(list[list.length - 1]).toMatchObject({ name: 'AAA Custom', isBuiltIn: false })
+  })
+
+  it('updates a custom template and enqueues an update', async () => {
+    const created = await createTemplate({ name: 'Standup', content: 'v1' })
+    vi.clearAllMocks()
+
+    const updated = await updateTemplate({ id: created.id, content: 'v2' })
+
+    expect(updated.content).toBe('v2')
+    expect(enqueueUpdate).toHaveBeenCalledWith('template', created.id)
+  })
+
+  it('deletes a custom template and enqueues a delete with a snapshot payload', async () => {
+    const created = await createTemplate({ name: 'Standup', content: 'v1' })
+    vi.clearAllMocks()
+
+    await deleteTemplate(created.id)
+
+    expect(
+      testDb.db.select().from(templatesTable).where(eq(templatesTable.id, created.id)).get()
+    ).toBeUndefined()
+    expect(enqueueDelete).toHaveBeenCalledWith('template', created.id, expect.any(String))
+  })
+
+  it('refuses to modify or delete built-ins', async () => {
+    await expect(updateTemplate({ id: 'blank', content: 'x' })).rejects.toThrow()
+    await expect(deleteTemplate('blank')).rejects.toThrow()
+  })
+
+  it('duplicating a built-in produces a syncable custom template', async () => {
+    const copy = await duplicateTemplate('meeting-notes', 'My Meeting Notes')
+
+    expect(copy.isBuiltIn).toBe(false)
+    expect(copy.name).toBe('My Meeting Notes')
+    expect(enqueueCreate).toHaveBeenCalledWith('template', copy.id)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main -- vault/templates`
+Expected: FAIL — the current implementation reads and writes files.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Rewrite `apps/desktop/src/main/vault/templates.ts`:
+
+- **Keep** the `BUILT_IN_TEMPLATES` array exactly as-is, but `export` it and drop `createdAt`/`modifiedAt` synthesis into a helper (`toBuiltInTemplate(t)` stamping a fixed epoch — built-ins are immutable, so a stable timestamp avoids churn).
+- **Delete** `getTemplatesDir`, `ensureTemplatesDir`, `seedBuiltInTemplates`, `serializeTemplate`, `writeTemplate`, `getTemplatePath`, and the `fs`/`getMemryDir` imports. **Keep** `emitTemplateEvent` (the CRUD functions still broadcast through it, so `BrowserWindow` stays), and **keep** `parseTemplate` with its `TemplateFrontmatter` interface and the `path`/`matter` imports it needs — Task 11 relocates those and deletes them from here.
+- Row ↔ `Template` mapping:
+
+```ts
+function rowToTemplate(row: TemplateRow): Template {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? undefined,
+    icon: row.icon ?? null,
+    isBuiltIn: false,
+    tags: row.tags ?? [],
+    properties: (row.properties ?? []) as TemplateProperty[],
+    content: row.content,
+    createdAt: row.createdAt,
+    modifiedAt: row.modifiedAt
+  }
+}
+```
+
+- `listTemplates` returns built-ins mapped to `TemplateListItem` concatenated with rows, keeping the existing sort (built-ins first, then `name.localeCompare`).
+- `getTemplate(id)` checks `BUILT_IN_TEMPLATES` first, then the DB, else `null`.
+- `createTemplate` inserts a row with `generateNoteId()` and then calls `enqueueLocalSyncCreate('template', id)`.
+- `updateTemplate` throws `new VaultError('Cannot modify built-in templates', VaultErrorCode.PERMISSION_DENIED)` for built-in ids, throws `NOT_FOUND` when the row is absent, updates, then calls `enqueueLocalSyncUpdate('template', id)`.
+- `deleteTemplate` throws the same way for built-ins, **captures `JSON.stringify(row)` as the snapshot payload before deleting**, deletes, then calls `enqueueLocalSyncDelete('template', id, snapshot)`. The snapshot is required — `enqueueDelete` returns early without it and the tombstone never syncs.
+- `duplicateTemplate` stays a thin wrapper over `getTemplate` + `createTemplate`, so it inherits the enqueue.
+- Event emission stays on `TemplatesChannels.events.*`, now emitted from the CRUD functions via the existing window-broadcast helper.
+- `applyTemplate` is unchanged.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:main -- vault/templates` → PASS.
+Run: `pnpm ipc:generate && pnpm ipc:check` — the contract shape is unchanged, but regenerate anyway.
+Run: `pnpm --filter @memry/desktop test:main` → full main suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/vault/templates.ts apps/desktop/src/main/vault/templates.test.ts
+git commit -m "refactor(templates): move custom templates into the data DB
+
+Built-ins become code constants served without rows or files. Every mutation
+enqueues through local-mutations; registry wiring alone would seed once and
+then never sync. Public signatures unchanged, so IPC and renderer are untouched."
+```
+
+---
+
+### Task 11: One-time migration of existing template files
+
+**Files:**
+
+- Create: `apps/desktop/src/main/vault/templates-migration.ts`
+- Modify: `apps/desktop/src/main/vault/index.ts` — `openVault()` (~L233-262)
+- Test: `apps/desktop/src/main/vault/templates-migration.test.ts`
+
+**Interfaces:**
+
+- Consumes: `templates` (Task 2); `BUILT_IN_TEMPLATES` (Task 10); `getSetting`/`setSetting` from `../database/queries/settings`; `getMemryDir` from `./init`.
+- Produces: `migrateTemplateFilesToDb(db: DataDb, vaultPath: string): number` (returns the number imported), and `parseTemplate(content: string, filePath: string): Template` moved here from `templates.ts`.
+
+**Guard: `templates.importedFromFiles` settings key.** An existence check ("no rows yet") is wrong — a user who deletes all their templates would have them resurrected on next launch. This introduces a **new convention** (no settings-guarded one-time migration exists in the codebase today; `ensureDefaultTaskProject` uses an existence check and `migrateSettingsToConfig` infers state).
+
+**Old files are left on disk untouched** — zero-risk, and it doubles as the downgrade path.
+
+**`createDormantVault()`** (`sync/vault-provisioning.ts:30`) runs migrations without calling `openVault()`, so the backfill will not run there. That is correct: a dormant vault has no legacy template files.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/src/main/vault/templates-migration.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import matter from 'gray-matter'
+import { templates } from '@memry/db-schema/schema/templates'
+import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { getSetting } from '../database/queries/settings'
+import { migrateTemplateFilesToDb } from './templates-migration'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+let vaultPath: string
+let testDb: TestDatabaseResult
+
+function writeTemplateFile(id: string, frontmatter: Record<string, unknown>, body: string): void {
+  const dir = path.join(vaultPath, '.memry', 'templates')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, `${id}.md`), matter.stringify(body, frontmatter))
+}
+
+describe('migrateTemplateFilesToDb', () => {
+  beforeEach(() => {
+    vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-tpl-migration-'))
+    testDb = createTestDataDb()
+  })
+
+  afterEach(() => {
+    testDb.close()
+    fs.rmSync(vaultPath, { recursive: true, force: true })
+  })
+
+  it('imports a custom template preserving its frontmatter id', () => {
+    writeTemplateFile(
+      'abc123',
+      {
+        id: 'abc123',
+        name: 'My Standup',
+        isBuiltIn: false,
+        tags: ['daily'],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        modifiedAt: '2026-01-02T00:00:00.000Z'
+      },
+      '## Blockers'
+    )
+
+    expect(migrateTemplateFilesToDb(testDb.db as never, vaultPath)).toBe(1)
+
+    const rows = testDb.db.select().from(templates).all()
+    expect(rows).toHaveLength(1)
+    // The id MUST be preserved: a vault copied across devices must converge by
+    // LWW rather than duplicate.
+    expect(rows[0]).toMatchObject({
+      id: 'abc123',
+      name: 'My Standup',
+      content: '## Blockers',
+      tags: ['daily'],
+      createdAt: '2026-01-01T00:00:00.000Z'
+    })
+    // clock is NULL so seedUnclocked picks it up and pushes it.
+    expect(rows[0].clock).toBeNull()
+  })
+
+  it('skips built-in templates', () => {
+    writeTemplateFile('blank', { id: 'blank', name: 'Blank Note', isBuiltIn: true }, '')
+
+    expect(migrateTemplateFilesToDb(testDb.db as never, vaultPath)).toBe(0)
+    expect(testDb.db.select().from(templates).all()).toEqual([])
+  })
+
+  it('is idempotent and does not resurrect deleted templates', () => {
+    writeTemplateFile('abc123', { id: 'abc123', name: 'My Standup', isBuiltIn: false }, 'body')
+
+    expect(migrateTemplateFilesToDb(testDb.db as never, vaultPath)).toBe(1)
+    expect(getSetting(testDb.db as never, 'templates.importedFromFiles')).toBe('1')
+
+    // Simulate the user deleting the template after migration.
+    testDb.db.delete(templates).run()
+
+    expect(migrateTemplateFilesToDb(testDb.db as never, vaultPath)).toBe(0)
+    expect(testDb.db.select().from(templates).all()).toEqual([])
+  })
+
+  it('leaves the legacy files on disk as a downgrade path', () => {
+    writeTemplateFile('abc123', { id: 'abc123', name: 'My Standup', isBuiltIn: false }, 'body')
+
+    migrateTemplateFilesToDb(testDb.db as never, vaultPath)
+
+    expect(fs.existsSync(path.join(vaultPath, '.memry', 'templates', 'abc123.md'))).toBe(true)
+  })
+
+  it('falls back to the filename when frontmatter has no id', () => {
+    writeTemplateFile('legacy-name', { name: 'Legacy', isBuiltIn: false }, 'body')
+
+    expect(migrateTemplateFilesToDb(testDb.db as never, vaultPath)).toBe(1)
+    expect(testDb.db.select().from(templates).all()[0]).toMatchObject({ id: 'legacy-name' })
+  })
+
+  it('is a no-op when the templates directory does not exist', () => {
+    expect(migrateTemplateFilesToDb(testDb.db as never, vaultPath)).toBe(0)
+  })
+
+  it('skips unparseable files without aborting the migration', () => {
+    const dir = path.join(vaultPath, '.memry', 'templates')
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'broken.md'), '---\nname: [unclosed\n')
+    writeTemplateFile('good', { id: 'good', name: 'Good', isBuiltIn: false }, 'body')
+
+    expect(migrateTemplateFilesToDb(testDb.db as never, vaultPath)).toBe(1)
+    expect(testDb.db.select().from(templates).all()[0]).toMatchObject({ id: 'good' })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:main -- templates-migration`
+Expected: FAIL — cannot resolve `./templates-migration`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/desktop/src/main/vault/templates-migration.ts`:
+
+```ts
+import fs from 'fs'
+import path from 'path'
+import { existsSync } from 'fs'
+import matter from 'gray-matter'
+import { templates } from '@memry/db-schema/schema/templates'
+import type { Template, TemplateProperty } from '@memry/contracts/templates-api'
+import { getSetting, setSetting } from '../database/queries/settings'
+import type { DataDb } from '../database/types'
+import { createLogger } from '../lib/logger'
+import { getMemryDir } from './init'
+import { BUILT_IN_TEMPLATES } from './templates'
+
+const log = createLogger('TemplatesMigration')
+
+const MIGRATION_KEY = 'templates.importedFromFiles'
+const TEMPLATES_DIR = 'templates'
+
+const BUILT_IN_IDS = new Set(BUILT_IN_TEMPLATES.map((t) => t.id))
+
+interface TemplateFrontmatter {
+  id?: string
+  name?: string
+  description?: string
+  icon?: string | null
+  isBuiltIn?: boolean
+  tags?: string[]
+  properties?: TemplateProperty[]
+  createdAt?: string
+  modifiedAt?: string
+}
+
+/** Moved verbatim from vault/templates.ts — only the migration still needs it. */
+export function parseTemplate(content: string, filePath: string): Template {
+  const { data, content: body } = matter(content)
+  const frontmatter = data as TemplateFrontmatter
+  const id = frontmatter.id ?? path.basename(filePath, '.md')
+
+  return {
+    id,
+    name: frontmatter.name ?? id,
+    description: frontmatter.description,
+    icon: frontmatter.icon ?? null,
+    isBuiltIn: frontmatter.isBuiltIn === true,
+    tags: Array.isArray(frontmatter.tags) ? frontmatter.tags : [],
+    properties: Array.isArray(frontmatter.properties) ? frontmatter.properties : [],
+    content: body.trim(),
+    createdAt: frontmatter.createdAt ?? new Date().toISOString(),
+    modifiedAt: frontmatter.modifiedAt ?? new Date().toISOString()
+  }
+}
+
+/**
+ * One-time backfill of pre-sync template files into the data DB.
+ *
+ * Guarded by a settings key rather than an emptiness check: a user who deletes
+ * every template must not have them resurrected on the next launch.
+ *
+ * Rows are inserted with clock = NULL so seedUnclocked stamps a clock and
+ * pushes them. Ids come from frontmatter and are never regenerated, so a vault
+ * copied between devices converges by LWW instead of duplicating.
+ *
+ * Legacy files are deliberately left on disk: zero-risk, and an older build
+ * downgraded onto this vault still reads them.
+ */
+export function migrateTemplateFilesToDb(db: DataDb, vaultPath: string): number {
+  if (getSetting(db, MIGRATION_KEY) === '1') return 0
+
+  const dir = path.join(getMemryDir(vaultPath), TEMPLATES_DIR)
+  if (!existsSync(dir)) {
+    setSetting(db, MIGRATION_KEY, '1')
+    return 0
+  }
+
+  let imported = 0
+
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.endsWith('.md')) continue
+
+    const filePath = path.join(dir, file)
+    try {
+      const template = parseTemplate(fs.readFileSync(filePath, 'utf-8'), filePath)
+
+      if (template.isBuiltIn || BUILT_IN_IDS.has(template.id)) continue
+
+      db.insert(templates)
+        .values({
+          id: template.id,
+          name: template.name,
+          description: template.description ?? null,
+          icon: template.icon ?? null,
+          tags: template.tags,
+          properties: template.properties,
+          content: template.content,
+          clock: null,
+          createdAt: template.createdAt,
+          modifiedAt: template.modifiedAt
+        })
+        .onConflictDoNothing()
+        .run()
+
+      imported++
+    } catch (err) {
+      log.warn('Skipping unparseable template file during migration', { file, error: err })
+    }
+  }
+
+  setSetting(db, MIGRATION_KEY, '1')
+  log.info('Imported legacy template files', { imported })
+
+  return imported
+}
+```
+
+In `apps/desktop/src/main/vault/index.ts`, import it and call it inside `openVault()` right after `migrateSettingsToConfig(dataDb, vaultPath)`:
+
+```ts
+import { migrateTemplateFilesToDb } from './templates-migration'
+
+// ...inside openVault(), after migrateSettingsToConfig(dataDb, vaultPath):
+migrateTemplateFilesToDb(dataDb, vaultPath)
+```
+
+**Now complete the relocation Task 10 deferred.** `templates-migration.ts` owns `parseTemplate`, so delete `parseTemplate`, the `TemplateFrontmatter` interface, and the now-unused `matter` / `path` imports from `apps/desktop/src/main/vault/templates.ts`. Doing it here rather than in Task 10 is what keeps every commit buildable. Run `pnpm lint` — it flags any import this orphans.
+
+Guard against the import cycle: `templates-migration.ts` imports `BUILT_IN_TEMPLATES` from `./templates`, so `templates.ts` must **not** import anything from `templates-migration.ts`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:main -- templates-migration` → PASS (7 tests).
+Run: `pnpm --filter @memry/desktop test:main` → full main suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/vault/templates-migration.ts apps/desktop/src/main/vault/templates-migration.test.ts apps/desktop/src/main/vault/index.ts
+git commit -m "feat(templates): import existing template files into the data DB
+
+One-time, settings-guarded so deleted templates are never resurrected. Ids
+come from frontmatter and are never regenerated. Rows land with clock NULL so
+seedUnclocked pushes them. Legacy files stay on disk as the downgrade path."
+```
+
+---
+
+### Task 12: Dual-device E2E
+
+**Files:**
+
+- Create: `apps/desktop/tests/e2e/fixtures/legacy-template-fixtures.ts`
+- Create: `apps/desktop/tests/e2e/templates-sync.e2e.ts`
+
+**Interfaces:**
+
+- Consumes: `test`/`expect` from `./fixtures/sync-auth-fixtures` (`electronAppA`, `electronAppB`, `pageA`, `pageB`, `bootstrappedSyncPair`, `vaultPathA`, `vaultPathB`); `goOffline`/`goOnline`/`syncBothAndWait`/`waitForSyncOnline`/`waitForSyncOffline` from `./utils/network-control`.
+- Produces: a `test` export extending `sync-auth-fixtures` with a `seededLegacyTemplate` fixture.
+
+**Pre-launch vault seeding does not exist in this repo.** Every current E2E seeds _after_ launch and forces a reindex. The migration case needs the file present _before_ the app opens the vault, which means overriding `vaultPathA` (Playwright resolves it before `electronAppA`, which depends on it). Task 12 introduces that pattern.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/tests/e2e/fixtures/legacy-template-fixtures.ts`:
+
+```ts
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+import { test as base } from './sync-auth-fixtures'
+
+export const LEGACY_TEMPLATE_ID = 'legacy-tpl-1'
+export const LEGACY_TEMPLATE_NAME = 'Legacy Standup'
+export const LEGACY_TEMPLATE_BODY = '## Legacy Blockers'
+
+/**
+ * Writes a pre-sync template file into device A's vault BEFORE the app launches.
+ *
+ * vaultPathA is overridden rather than written from the test body because
+ * electronAppA depends on vaultPathA, so Playwright resolves this fixture first.
+ * Every other e2e seeds after launch and reindexes; the migration only runs on
+ * vault open, so it must be on disk beforehand.
+ */
+export const test = base.extend<{ seededLegacyTemplate: void }>({
+  vaultPathA: async ({ vaultPathA }, use) => {
+    const dir = path.join(vaultPathA, '.memry', 'templates')
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(
+      path.join(dir, `${LEGACY_TEMPLATE_ID}.md`),
+      matter.stringify(LEGACY_TEMPLATE_BODY, {
+        id: LEGACY_TEMPLATE_ID,
+        name: LEGACY_TEMPLATE_NAME,
+        isBuiltIn: false,
+        tags: ['daily'],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        modifiedAt: '2026-01-01T00:00:00.000Z'
+      })
+    )
+    await use(vaultPathA)
+  },
+
+  seededLegacyTemplate: async ({ vaultPathA }, use) => {
+    void vaultPathA
+    await use()
+  }
+})
+
+export { expect } from './sync-auth-fixtures'
+```
+
+Create `apps/desktop/tests/e2e/templates-sync.e2e.ts`:
+
+```ts
+import { test, expect } from './fixtures/sync-auth-fixtures'
+import {
+  test as legacyTest,
+  expect as legacyExpect,
+  LEGACY_TEMPLATE_ID,
+  LEGACY_TEMPLATE_NAME
+} from './fixtures/legacy-template-fixtures'
+import { goOffline, goOnline, syncBothAndWait, waitForSyncOnline } from './utils/network-control'
+import type { Page } from '@playwright/test'
+
+async function createTemplate(page: Page, name: string, content: string): Promise<string> {
+  return page.evaluate(
+    async ({ name, content }) => {
+      const result = await window.api.templates.create({ name, content })
+      if (!result.success || !result.template) throw new Error('template create failed')
+      return result.template.id
+    },
+    { name, content }
+  )
+}
+
+async function listTemplateNames(page: Page): Promise<string[]> {
+  return page.evaluate(async () => {
+    const result = await window.api.templates.list()
+    return result.templates.map((t) => t.name)
+  })
+}
+
+async function getTemplateContent(page: Page, id: string): Promise<string | null> {
+  return page.evaluate(async (templateId) => {
+    const template = await window.api.templates.get(templateId)
+    return template?.content ?? null
+  }, id)
+}
+
+test.describe('Custom template sync', () => {
+  test('T1: a template created on A appears on B', async ({
+    pageA,
+    pageB,
+    bootstrappedSyncPair
+  }) => {
+    void bootstrappedSyncPair
+    const name = `T1 Standup ${Date.now()}`
+
+    const id = await createTemplate(pageA, name, '## Blockers')
+    expect(await listTemplateNames(pageB)).not.toContain(name)
+
+    await syncBothAndWait(pageA, pageB)
+
+    expect(await listTemplateNames(pageB)).toContain(name)
+    expect(await getTemplateContent(pageB, id)).toBe('## Blockers')
+  })
+
+  test('T2: an edit on A propagates to B', async ({ pageA, pageB, bootstrappedSyncPair }) => {
+    void bootstrappedSyncPair
+    const name = `T2 Standup ${Date.now()}`
+
+    const id = await createTemplate(pageA, name, 'v1')
+    await syncBothAndWait(pageA, pageB)
+
+    await pageA.evaluate(async (templateId) => {
+      await window.api.templates.update({ id: templateId, content: 'v2' })
+    }, id)
+    await syncBothAndWait(pageA, pageB)
+
+    expect(await getTemplateContent(pageB, id)).toBe('v2')
+  })
+
+  test('T3: a delete on A tombstones on B', async ({ pageA, pageB, bootstrappedSyncPair }) => {
+    void bootstrappedSyncPair
+    const name = `T3 Standup ${Date.now()}`
+
+    const id = await createTemplate(pageA, name, 'v1')
+    await syncBothAndWait(pageA, pageB)
+    expect(await listTemplateNames(pageB)).toContain(name)
+
+    await pageA.evaluate(async (templateId) => {
+      await window.api.templates.delete(templateId)
+    }, id)
+    await syncBothAndWait(pageA, pageB)
+
+    expect(await listTemplateNames(pageB)).not.toContain(name)
+    expect(await getTemplateContent(pageB, id)).toBeNull()
+  })
+
+  test('T4: concurrent offline edits converge by LWW without looping', async ({
+    electronAppA,
+    electronAppB,
+    pageA,
+    pageB,
+    bootstrappedSyncPair
+  }) => {
+    void bootstrappedSyncPair
+    const name = `T4 Standup ${Date.now()}`
+
+    const id = await createTemplate(pageA, name, 'base')
+    await syncBothAndWait(pageA, pageB)
+
+    await goOffline(electronAppA, electronAppB)
+    await pageA.evaluate(async (t) => {
+      await window.api.templates.update({ id: t, content: 'from-A' })
+    }, id)
+    await pageB.evaluate(async (t) => {
+      await window.api.templates.update({ id: t, content: 'from-B' })
+    }, id)
+
+    await goOnline(electronAppA, electronAppB)
+    await Promise.all([waitForSyncOnline(pageA), waitForSyncOnline(pageB)])
+    await syncBothAndWait(pageA, pageB)
+
+    const contentA = await getTemplateContent(pageA, id)
+    const contentB = await getTemplateContent(pageB, id)
+    expect(contentA).toBe(contentB)
+    expect(['from-A', 'from-B']).toContain(contentA)
+  })
+
+  test('T6: built-ins exist on both devices and never duplicate', async ({
+    pageA,
+    pageB,
+    bootstrappedSyncPair
+  }) => {
+    void bootstrappedSyncPair
+    await syncBothAndWait(pageA, pageB)
+
+    for (const page of [pageA, pageB]) {
+      const names = await listTemplateNames(page)
+      const blanks = names.filter((n) => n === 'Blank Note')
+      expect(blanks).toHaveLength(1)
+    }
+  })
+})
+
+legacyTest.describe('Legacy template migration', () => {
+  legacyTest(
+    'T5: a pre-sync template file on A is migrated and reaches B',
+    async ({ pageA, pageB, bootstrappedSyncPair }) => {
+      void bootstrappedSyncPair
+
+      // A's vault had the file on disk before launch; openVault should have
+      // imported it with clock NULL, and seedUnclocked should have pushed it.
+      legacyExpect(await listTemplateNames(pageA)).toContain(LEGACY_TEMPLATE_NAME)
+
+      await syncBothAndWait(pageA, pageB)
+
+      legacyExpect(await listTemplateNames(pageB)).toContain(LEGACY_TEMPLATE_NAME)
+      legacyExpect(await getTemplateContent(pageB, LEGACY_TEMPLATE_ID)).toBe('## Legacy Blockers')
+    }
+  )
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:e2e -- templates-sync`
+Expected: FAIL — templates do not sync yet if Tasks 1-11 are incomplete; if they are complete, this should be the pass that proves the feature.
+Rebuild first if the app is stale: `pnpm --filter @memry/desktop exec electron-vite build`. On native load errors: `pnpm --filter @memry/desktop rebuild:electron`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+No implementation — Tasks 1-11 are the implementation. If a test fails here, fix the underlying task rather than weakening the test.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:e2e -- templates-sync`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/tests/e2e/fixtures/legacy-template-fixtures.ts apps/desktop/tests/e2e/templates-sync.e2e.ts
+git commit -m "test(e2e): dual-device custom template sync
+
+Covers create/edit/delete propagation, concurrent-offline LWW, built-in
+de-duplication, and legacy file migration reaching the second device. Adds the
+first pre-launch vault seeding fixture."
+```
+
+---
+
+## Verification (run before pushing)
+
+- [ ] `pnpm --filter @memry/contracts test` — four arrays + payload schema.
+- [ ] `pnpm --filter @memry/db-schema test` — table exported from both barrels.
+- [ ] `pnpm --filter @memry/desktop test:main -- migrate-journal` — the `when` invariant.
+- [ ] `pnpm --filter @memry/desktop test:main` — handler, service, offline clock, local mutations, runtime, manifest, CRUD, migration.
+- [ ] `pnpm --filter @memry/sync-server test && pnpm --filter @memry/sync-server typecheck` — exhaustive `toSyncDomain`.
+- [ ] `pnpm ipc:generate && pnpm ipc:check`
+- [ ] `pnpm typecheck` — catches any missed array or switch.
+- [ ] `pnpm lint` and `git diff --check`
+- [ ] `pnpm check:contracts && pnpm check:architecture`
+- [ ] `pnpm --filter @memry/desktop test:e2e -- templates-sync`
+- [ ] `pnpm docs:impact --base origin/main --strict`; if `missing-docs`, update `apps/docs/src/**` or run `pnpm docs:ai-update --base origin/main`, then re-run and `pnpm docs:build`.
+
+**Manual two-profile check:** `pnpm --filter @memry/desktop dev:a` + `dev:b` on one linked vault. Create a template on A → it appears on B. Edit on both concurrently → LWW resolves, no sync loop. Confirm built-ins are not duplicated on either device.
+
+**Manual upgrade check (the one that protects real users):** open a vault that already contains `.memry/templates/*.md` custom templates with a build from this branch. Confirm every custom template still appears in the UI, that the files remain on disk, and that the templates reach a second device after sync.
+
+## Release gate
+
+Do not ship a desktop build from this plan until **Plan A is deployed to production**. Verify the deployed server is serving the legacy list to header-less clients before releasing.

--- a/docs/superpowers/specs/2026-07-15-template-sync-design.md
+++ b/docs/superpowers/specs/2026-07-15-template-sync-design.md
@@ -46,13 +46,15 @@ Released binaries cannot be retroactively patched. **Only a server-side change p
 
 **Client:** `http-client.ts` sends `X-Memry-Sync-Types: note,task,…,template` on `/sync/changes`, `/sync/manifest`, and `/sync/pull`, mirroring the existing `X-Memry-Vault-Id` header pattern.
 
-**Server:** those three routes filter `item_type` to the negotiated list. **A missing header falls back to a frozen `LEGACY_SYNC_ITEM_TYPES` constant** — today's 16 types:
+**Server:** those three routes filter `item_type` to the negotiated list. **A missing header falls back to a frozen `LEGACY_RECORD_SYNC_ITEM_TYPES` constant** — the 15 record types that shipped before negotiation:
 
 ```
-note, task, project, settings, attachment, inbox, filter, journal,
+note, task, project, settings, inbox, filter, journal,
 tag_definition, folder_config, calendar_event, calendar_source,
 calendar_binding, calendar_external_event, agent_conversation, agent_message
 ```
+
+Fifteen, not sixteen: these are the _record_ sync endpoints, and `RECORD_SYNC_ITEM_TYPES` is `SYNC_ITEM_TYPES` minus `attachment`. The frozen list mirrors `RECORD_SYNC_ITEM_TYPES` as of today, which is what those endpoints bind.
 
 This constant is frozen forever. It is never edited when a new type is added; that is the whole point.
 

--- a/docs/superpowers/specs/2026-07-15-template-sync-design.md
+++ b/docs/superpowers/specs/2026-07-15-template-sync-design.md
@@ -58,6 +58,8 @@ Fifteen, not sixteen: these are the _record_ sync endpoints, and `RECORD_SYNC_IT
 
 This constant is frozen forever. It is never edited when a new type is added; that is the whole point.
 
+**Review correction (overrides this spec's original text):** the initial draft of this spec described an entirely-unrecognized header as being treated as no header at all — i.e. falling back to the same frozen legacy list. A code review caught that this is wrong and it was inverted before ship. **No header** and **a header present but fully unrecognized** are different client situations and must resolve differently: no header means the client never negotiated, so it gets the legacy list; a header present but unparseable means the client DID negotiate and we simply couldn't read what it declared, so it must resolve to an **empty** list (serve nothing) rather than being handed 15 types it never asked for. See the JSDoc on `resolveSyncTypes` in `apps/sync-server/src/lib/sync-types.ts` for the authoritative statement of this distinction.
+
 **Cursor correctness — resolved, no change needed.** An earlier draft of this spec claimed `nextCursor` had to be derived from the maximum _scanned_ `serverCursor` or old clients would stall on all-filtered pages. **That was wrong.** `getChanges` (`apps/sync-server/src/services/sync.ts:553-610`) already applies `item_type IN (...)` in SQL, **before** `LIMIT`:
 
 ```sql
@@ -119,7 +121,7 @@ Backward compatibility is mandatory — this is a live beta with real users on m
 
 **Migration tests:** imports custom templates from legacy files; idempotent across repeated runs; id preserved from frontmatter; built-ins skipped; missing `.memry/templates/` is a no-op.
 
-**Server tests:** `getChanges`/`getManifest`/`pullItems` bind only the negotiated types; a header-less request is served the frozen legacy list (the regression that protects shipped binaries); an unknown type in the header is dropped rather than bound; `pullItems`' `BATCH_SIZE` stays correct as the negotiated list length varies.
+**Server tests:** `getChanges`/`getManifest`/`pullItems` bind only the negotiated types; a header-less request is served the frozen legacy list (the regression that protects shipped binaries); a header present but fully unrecognized resolves to an empty list, not the legacy list; a header is deduped so repeated types cannot inflate `types.length`; the three service functions short-circuit before any SQL when the negotiated list is empty (`item_type IN ()` is a syntax error, not "matches nothing"), and `getChanges` must not advance the cursor when it does; `pullItems`' `BATCH_SIZE` stays correct as the negotiated list length varies.
 
 **E2E** (`templates-sync.e2e.ts`) on the existing dual-device harness — `fixtures/sync-auth-fixtures` (`electronAppA/B`, `pageA/pageB`, `bootstrappedSyncPair`) with `utils/network-control` (`goOffline`/`goOnline`/`syncBothAndWait`), modelled on `body-crdt-create-propagation.e2e.ts`:
 

--- a/docs/superpowers/specs/2026-07-15-template-sync-design.md
+++ b/docs/superpowers/specs/2026-07-15-template-sync-design.md
@@ -1,0 +1,140 @@
+# Custom Template Sync — Design
+
+**Date:** 2026-07-15
+**Branch:** `template-sync`
+**Status:** Approved, ready for planning
+
+## Problem
+
+Custom templates do not sync between devices. A template authored on one Mac is invisible on every other device.
+
+Templates live as markdown files in `vault/.memry/templates/*.md` (`apps/desktop/src/main/vault/templates.ts`). `.memry/` is excluded from the vault watcher (`vault/watcher.ts:177`), there is no `template` entry in `SYNC_ITEM_TYPES`, and there is no handler in `sync/item-handlers/`.
+
+This is already inconsistent rather than merely absent: `journal.defaultTemplate` is a settings key (`main/ipc/settings-handlers.ts:79`) and `settings` **is** a synced type. Setting a custom journal template on device A syncs a `defaultTemplate` id to device B that points at a template file which does not exist there — a dangling reference.
+
+## Blocker discovered during design: new sync types break already-shipped clients
+
+Adding a sync item type is a well-trodden ~14-file pattern. The hazard is what a new type does to binaries already in users' hands.
+
+Evidence chain:
+
+1. `/sync/changes` is fetched with `getFromServer<RecordChangesResponse>` (`sync/engine/pull-coordinator.ts:246`). `getFromServer<T>` → `syncFetch<T>` (`sync/http-client.ts:144`) is a **generic cast with no runtime validation** — an old client accepts a `template` ref without complaint.
+2. `pullChangesPage` maps **every** ref to an id with no type filter: `changes.items.map((item) => item.id)` (`pull-coordinator.ts:268`).
+3. `processPage` POSTs those ids to `/sync/pull`; the response contains the template item.
+4. `RecordPullResponseSchema.safeParse(pullResult.value)` (`pull-coordinator.ts:452`) validates the **entire page at once**. `template` is absent from an old binary's `z.enum(RECORD_SYNC_ITEM_TYPES)`, so the whole page fails and the method returns `applied: 0`.
+5. The server's `getChanges(c.env.DB, userId, cursor, limit, vaultId)` (`apps/sync-server/src/routes/sync.ts:274`) applies no type filter, and `updateDeviceCursor` advances the device cursor whenever changes are returned.
+
+**Consequence:** an old client sharing a vault with an upgraded client silently drops entire pages of notes and tasks, and its cursor advances past them. This is convergence loss, not a recoverable stall, and it lands on exactly the cohort this feature targets — multi-device users with custom templates.
+
+**This invalidates an assumption in the existing mobile plan.** `docs/superpowers/plans/2026-07-14-server-desktop-additive-d6-d8.md:1873` states: _"old clients simply never pull types they don't register."_ They do pull them. That claim underpins the `home_page` / `bookmark` / `reminder` types in the mobile program, so this fix is a shared prerequisite.
+
+Released binaries cannot be retroactively patched. **Only a server-side change protects them.**
+
+## Decisions
+
+| #   | Decision                                                        | Rationale                                                                                                                                                                                                                                          |
+| --- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Server-side sync-type filtering, negotiated per request         | The only mechanism that protects binaries already in the wild. Also unblocks the mobile program's three new types.                                                                                                                                 |
+| D2  | DB is the sole source of truth; built-ins become code constants | `.memry/` is app-private (it holds `data.db`, excluded from the watcher), so file storage was convenience, not philosophy. `BaseItemHandler.buildPushPayload` is synchronous, so file-backed truth would force `readFileSync` on the main process. |
+| D3  | Built-in templates never sync                                   | Fixed ids, identical on every device, already immutable (`updateTemplate`/`deleteTemplate` reject them). Syncing them would fight the seeder.                                                                                                      |
+| D4  | Whole-row LWW (`clock` only, no `fieldClocks`)                  | Templates are not concurrently field-edited. `fieldClocks` on a simple type is unneeded complexity.                                                                                                                                                |
+| D5  | Migration preserves the id from file frontmatter                | Ids must never be regenerated, so a vault copied across devices (Dropbox/iCloud) converges by LWW instead of duplicating.                                                                                                                          |
+
+## Architecture
+
+### Part 1 — Sync-type capability negotiation (prerequisite, server-first)
+
+**Client:** `http-client.ts` sends `X-Memry-Sync-Types: note,task,…,template` on `/sync/changes`, `/sync/manifest`, and `/sync/pull`, mirroring the existing `X-Memry-Vault-Id` header pattern.
+
+**Server:** those three routes filter `item_type` to the negotiated list. **A missing header falls back to a frozen `LEGACY_SYNC_ITEM_TYPES` constant** — today's 16 types:
+
+```
+note, task, project, settings, attachment, inbox, filter, journal,
+tag_definition, folder_config, calendar_event, calendar_source,
+calendar_binding, calendar_external_event, agent_conversation, agent_message
+```
+
+This constant is frozen forever. It is never edited when a new type is added; that is the whole point.
+
+**Cursor correctness (the sharp edge):** `nextCursor` must be derived from the maximum **scanned** `serverCursor`, not the maximum **returned** one. If a page consists entirely of filtered-out types, the old client receives an empty `items` array; `pullChangesPage` returns `false` and pull stops. If the cursor did not advance across the filtered rows, that client stalls permanently. Test this first.
+
+**Client-side hardening (defence in depth):** new clients also filter unknown types out of `changes.items` before building `itemIds`. This does not help already-shipped binaries — only D1 does — but it stops a future type from breaking this generation of clients if the header path ever regresses.
+
+**Deploy order (hard rule):** sync-server to production **before** any desktop build carrying the `template` type reaches users.
+
+### Part 2 — `template` as a record sync item type
+
+Follows `filter-handler.ts`, the simplest record type. Per the `adding-sync-item-type` skill:
+
+- `packages/contracts/src/sync-api.ts` — add `template` to **four** arrays: `SYNC_ITEM_TYPES`, `RECORD_SYNC_ITEM_TYPES`, `RECORD_CLOCK_REQUIRED_ITEM_TYPES`, `ENCRYPTABLE_ITEM_TYPES`. Omitting `ENCRYPTABLE_ITEM_TYPES` makes encryption refuse the type and sync silently drops it.
+- `packages/contracts/src/sync-payloads.ts` — `TemplateSyncPayloadSchema`: `name`, `description`, `icon`, `tags`, `properties`, `content`, `clock`, `createdAt`, `modifiedAt`.
+- `packages/db-schema/src/schema/templates.ts` — Drizzle table with `clock` JSON column. The data-DB migration is **hand-written** (Drizzle snapshots are broken past 0021).
+- `sync/item-handlers/template-handler.ts` + registry entry, `sync/template-sync.ts`, `offline-clock.ts`, `local-mutations.ts`, `runtime.ts`, `manifest-check.ts`, and the `sync-telemetry.ts` `toSyncDomain` case (its switch is exhaustive — typecheck fails until added).
+- `TemplatesChannels` already exists and is already emitted by `vault/templates.ts`; no new channel object needed.
+
+### Part 3 — Templates move into the DB
+
+- `BUILT_IN_TEMPLATES` stays a code constant, served directly by `listTemplates`/`getTemplate`. No rows, no files, never synced.
+- Custom templates become rows in `templates`.
+- `vault/templates.ts` CRUD is rewritten against the DB and **must call** the `local-mutations` `enqueueCreate/Update/Delete` on every mutation. Registering the adapter alone does nothing; mutations that bypass it seed once and then never sync again.
+- Deletes `ensureTemplatesDir`, `seedBuiltInTemplates`, `parseTemplate`/`serializeTemplate` and all template file I/O. `parseTemplate` moves into the migration module before deletion — the migration still needs it.
+- The IPC contract shape is unchanged, so the renderer is untouched. Run `pnpm ipc:generate && pnpm ipc:check` regardless.
+
+### Part 4 — Migration for existing users
+
+One-time, idempotent, guarded by a settings key, run on vault open:
+
+1. If `.memry/templates/` exists, read each `*.md` and parse it.
+2. Skip any with `isBuiltIn: true`.
+3. Insert each custom template as a row, **using the id from its frontmatter** (falling back to the filename basename, matching today's `parseTemplate`), with `clock = NULL`.
+4. `seedUnclocked` then increments the clock, enqueues a `create`, and pushes.
+5. **Old files are left on disk untouched** — zero-risk, and it doubles as the downgrade path.
+
+Convergence: two devices with independent template sets produce the union on both (ids are random per device, so no collisions). A vault copied between devices yields the same id on both; both push, and LWW converges.
+
+## Backward compatibility
+
+Backward compatibility is mandatory — this is a live beta with real users on macOS, Windows and Linux.
+
+- **Old clients:** send no `X-Memry-Sync-Types` header → server serves the frozen legacy list → they never see templates.
+- **Deploy order:** server to prod first, desktop release trails it.
+- **Downgrade:** an older build still finds `.memry/templates/*.md` on disk and reads its pre-migration templates. Degraded (no sync, no post-migration edits) but not broken, and no data is destroyed.
+- **No DB resets.** The `templates` table is additive and hand-written.
+
+## Testing
+
+**Handler unit tests** (`template-handler.test.ts`, modelled on `task-handler.test.ts`): insert; newer-clock update; older-clock skip; concurrent → `'conflict'`; delete; delete-skip; `seedUnclocked` enqueues; built-in never enqueued.
+
+**Migration tests:** imports custom templates from legacy files; idempotent across repeated runs; id preserved from frontmatter; built-ins skipped; missing `.memry/templates/` is a no-op.
+
+**Server tests:** filters by header; missing header → legacy list; **cursor advances past filtered-out rows** (the stall regression).
+
+**E2E** (`templates-sync.e2e.ts`) on the existing dual-device harness — `fixtures/sync-auth-fixtures` (`electronAppA/B`, `pageA/pageB`, `bootstrappedSyncPair`) with `utils/network-control` (`goOffline`/`goOnline`/`syncBothAndWait`), modelled on `body-crdt-create-propagation.e2e.ts`:
+
+1. Create custom template on A → appears on B.
+2. Edit on A → propagates to B.
+3. Delete on A → tombstoned on B.
+4. Both devices edit offline → LWW converges, no sync loop.
+5. Legacy `.memry/templates/*.md` pre-seeded on A → migrated and synced to B.
+6. Built-ins present and identical on both, never duplicated.
+
+## Risks
+
+| Risk                                       | Mitigation                                                                    |
+| ------------------------------------------ | ----------------------------------------------------------------------------- |
+| Cursor stalls on all-filtered pages        | Derive `nextCursor` from max scanned cursor; dedicated server test.           |
+| `ENCRYPTABLE_ITEM_TYPES` omitted           | Sync silently drops the type — explicit checklist item + handler test.        |
+| Mutations bypass `local-mutations` enqueue | Templates seed once then never sync — asserted in tests.                      |
+| Desktop ships before server                | Old clients break. Deploy order is a hard rule in both plans.                 |
+| Drizzle migration assumed automatic        | False. Hand-written SQL under `apps/desktop/src/main/database/drizzle-data/`. |
+
+## Plan split
+
+- **Plan A — sync-type capability negotiation.** Server-first, standalone, independently valuable: it is the root fix for `d6-d8.md:1873` and unblocks the mobile program's three new types.
+- **Plan B — template sync type + DB move + migration.** Gated on Plan A being deployed to production.
+
+Both target the next release. Plan A can merge and deploy independently.
+
+## Follow-up (out of scope)
+
+`docs/superpowers/plans/2026-07-14-server-desktop-additive-d6-d8.md:1873` should be corrected once Plan A lands, and its backward-compat section rewritten to reference the negotiation mechanism.

--- a/docs/superpowers/specs/2026-07-15-template-sync-design.md
+++ b/docs/superpowers/specs/2026-07-15-template-sync-design.md
@@ -70,7 +70,7 @@ Filtered-out rows therefore never enter the result set, and a page is always ful
 
 What this changes: the type-filtering machinery (`RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS` + the `item_type IN (...)` bind) **already exists**. The server filters against its own compile-time `RECORD_SYNC_ITEM_TYPES` — which is exactly the bug, since deploying a server whose contracts include `template` makes it serve template refs to every client. Plan A is therefore a narrow change: make that list per-request instead of compile-time constant.
 
-**Client-side hardening (defence in depth):** new clients also filter unknown types out of `changes.items` before building `itemIds`. This does not help already-shipped binaries — only D1 does — but it stops a future type from breaking this generation of clients if the header path ever regresses.
+**Client-side hardening — cut as YAGNI.** An earlier draft proposed that new clients also filter unknown types out of `changes.items` before building `itemIds`. Dropped: once the server serves only negotiated types, this protects nothing D1 does not already protect, and it cannot help already-shipped binaries either way. Not implemented in Plan A.
 
 **Deploy order (hard rule):** sync-server to production **before** any desktop build carrying the `template` type reaches users.
 

--- a/docs/superpowers/specs/2026-07-15-template-sync-design.md
+++ b/docs/superpowers/specs/2026-07-15-template-sync-design.md
@@ -56,7 +56,17 @@ calendar_binding, calendar_external_event, agent_conversation, agent_message
 
 This constant is frozen forever. It is never edited when a new type is added; that is the whole point.
 
-**Cursor correctness (the sharp edge):** `nextCursor` must be derived from the maximum **scanned** `serverCursor`, not the maximum **returned** one. If a page consists entirely of filtered-out types, the old client receives an empty `items` array; `pullChangesPage` returns `false` and pull stops. If the cursor did not advance across the filtered rows, that client stalls permanently. Test this first.
+**Cursor correctness — resolved, no change needed.** An earlier draft of this spec claimed `nextCursor` had to be derived from the maximum _scanned_ `serverCursor` or old clients would stall on all-filtered pages. **That was wrong.** `getChanges` (`apps/sync-server/src/services/sync.ts:553-610`) already applies `item_type IN (...)` in SQL, **before** `LIMIT`:
+
+```sql
+WHERE user_id = ? AND vault_id = ? AND server_cursor > ? AND item_type IN (${placeholders})
+ORDER BY server_cursor ASC
+LIMIT ?
+```
+
+Filtered-out rows therefore never enter the result set, and a page is always full of allowed rows up to the limit. `nextCursor = pageRows[pageRows.length - 1]?.server_cursor ?? cursor` steps over excluded rows for free and never rewinds. If every remaining row is a template, the page is simply empty, `hasMore` is false, and the client correctly stops — there is nothing to stall on. The existing cursor design is correct as-is.
+
+What this changes: the type-filtering machinery (`RECORD_SYNC_ITEM_TYPE_PLACEHOLDERS` + the `item_type IN (...)` bind) **already exists**. The server filters against its own compile-time `RECORD_SYNC_ITEM_TYPES` — which is exactly the bug, since deploying a server whose contracts include `template` makes it serve template refs to every client. Plan A is therefore a narrow change: make that list per-request instead of compile-time constant.
 
 **Client-side hardening (defence in depth):** new clients also filter unknown types out of `changes.items` before building `itemIds`. This does not help already-shipped binaries — only D1 does — but it stops a future type from breaking this generation of clients if the header path ever regresses.
 
@@ -107,7 +117,7 @@ Backward compatibility is mandatory — this is a live beta with real users on m
 
 **Migration tests:** imports custom templates from legacy files; idempotent across repeated runs; id preserved from frontmatter; built-ins skipped; missing `.memry/templates/` is a no-op.
 
-**Server tests:** filters by header; missing header → legacy list; **cursor advances past filtered-out rows** (the stall regression).
+**Server tests:** `getChanges`/`getManifest`/`pullItems` bind only the negotiated types; a header-less request is served the frozen legacy list (the regression that protects shipped binaries); an unknown type in the header is dropped rather than bound; `pullItems`' `BATCH_SIZE` stays correct as the negotiated list length varies.
 
 **E2E** (`templates-sync.e2e.ts`) on the existing dual-device harness — `fixtures/sync-auth-fixtures` (`electronAppA/B`, `pageA/pageB`, `bootstrappedSyncPair`) with `utils/network-control` (`goOffline`/`goOnline`/`syncBothAndWait`), modelled on `body-crdt-create-propagation.e2e.ts`:
 
@@ -120,13 +130,13 @@ Backward compatibility is mandatory — this is a live beta with real users on m
 
 ## Risks
 
-| Risk                                       | Mitigation                                                                    |
-| ------------------------------------------ | ----------------------------------------------------------------------------- |
-| Cursor stalls on all-filtered pages        | Derive `nextCursor` from max scanned cursor; dedicated server test.           |
-| `ENCRYPTABLE_ITEM_TYPES` omitted           | Sync silently drops the type — explicit checklist item + handler test.        |
-| Mutations bypass `local-mutations` enqueue | Templates seed once then never sync — asserted in tests.                      |
-| Desktop ships before server                | Old clients break. Deploy order is a hard rule in both plans.                 |
-| Drizzle migration assumed automatic        | False. Hand-written SQL under `apps/desktop/src/main/database/drizzle-data/`. |
+| Risk                                       | Mitigation                                                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Header-less request served new types       | The one regression that matters: absent header MUST resolve to the frozen legacy list. Dedicated server test. |
+| `ENCRYPTABLE_ITEM_TYPES` omitted           | Sync silently drops the type — explicit checklist item + handler test.                                        |
+| Mutations bypass `local-mutations` enqueue | Templates seed once then never sync — asserted in tests.                                                      |
+| Desktop ships before server                | Old clients break. Deploy order is a hard rule in both plans.                                                 |
+| Drizzle migration assumed automatic        | False. Hand-written SQL under `apps/desktop/src/main/database/drizzle-data/`.                                 |
 
 ## Plan split
 

--- a/packages/contracts/src/sync-api.test.ts
+++ b/packages/contracts/src/sync-api.test.ts
@@ -16,6 +16,7 @@ import {
   DeviceSyncStateSchema,
   EncryptedItemPayloadSchema,
   FieldClocksSchema,
+  LEGACY_RECORD_SYNC_ITEM_TYPES,
   OFFLINE_CLOCK_DEVICE_ID,
   PullItemResponseSchema,
   PullRequestSchema,
@@ -245,9 +246,7 @@ describe('SyncQueueItemSchema', () => {
   })
 
   it('rejects unknown operation', () => {
-    expect(
-      SyncQueueItemSchema.safeParse({ ...base, operation: 'patch' }).success
-    ).toBe(false)
+    expect(SyncQueueItemSchema.safeParse({ ...base, operation: 'patch' }).success).toBe(false)
   })
 
   it('rejects empty payload', () => {
@@ -311,9 +310,7 @@ describe('RecordPushItemSchema', () => {
   })
 
   it('accepts settings without clock (not clock-required)', () => {
-    const result = RecordPushItemSchema.safeParse(
-      validPushItem({ type: 'settings' })
-    )
+    const result = RecordPushItemSchema.safeParse(validPushItem({ type: 'settings' }))
     expect(result.success).toBe(true)
   })
 
@@ -710,9 +707,7 @@ describe('DeviceKeySchema / DeviceKeysResponseSchema', () => {
 
   it('accepts devices response', () => {
     const result = DeviceKeysResponseSchema.safeParse({
-      devices: [
-        { id: 'd1', name: 'A', platform: 'macos', signingPublicKey: 'pk', revokedAt: null }
-      ]
+      devices: [{ id: 'd1', name: 'A', platform: 'macos', signingPublicKey: 'pk', revokedAt: null }]
     })
     expect(result.success).toBe(true)
   })
@@ -720,9 +715,9 @@ describe('DeviceKeySchema / DeviceKeysResponseSchema', () => {
 
 describe('CursorPositionSchema', () => {
   it('accepts minimal cursor', () => {
-    expect(
-      CursorPositionSchema.safeParse({ cursor: 0, deviceId: 'd', updatedAt: 0 }).success
-    ).toBe(true)
+    expect(CursorPositionSchema.safeParse({ cursor: 0, deviceId: 'd', updatedAt: 0 }).success).toBe(
+      true
+    )
   })
 
   it('rejects negative cursor', () => {
@@ -753,6 +748,37 @@ describe('SignatureMetadataSchema', () => {
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0].path).toContain('algorithm')
+    }
+  })
+})
+
+describe('LEGACY_RECORD_SYNC_ITEM_TYPES', () => {
+  // This list is FROZEN. It describes what already-shipped binaries understand.
+  // If a new sync item type makes this test fail, the fix is NEVER to update this
+  // list — it is to leave it alone. See 2026-07-15-template-sync-design.md.
+  it('is exactly the 15 record types that shipped before type negotiation', () => {
+    expect(LEGACY_RECORD_SYNC_ITEM_TYPES).toEqual([
+      'note',
+      'task',
+      'project',
+      'settings',
+      'inbox',
+      'filter',
+      'journal',
+      'tag_definition',
+      'folder_config',
+      'calendar_event',
+      'calendar_source',
+      'calendar_binding',
+      'calendar_external_event',
+      'agent_conversation',
+      'agent_message'
+    ])
+  })
+
+  it('only contains types the server still supports', () => {
+    for (const type of LEGACY_RECORD_SYNC_ITEM_TYPES) {
+      expect(RECORD_SYNC_ITEM_TYPES).toContain(type)
     }
   })
 })

--- a/packages/contracts/src/sync-api.ts
+++ b/packages/contracts/src/sync-api.ts
@@ -60,6 +60,38 @@ export const RECORD_CLOCK_REQUIRED_ITEM_TYPES = [
 
 export const CRDT_SYNC_ITEM_TYPES = ['note'] as const
 
+/**
+ * The record sync item types understood by every client shipped BEFORE
+ * per-request sync-type negotiation existed.
+ *
+ * FROZEN — never add to this list, not even when adding a new sync item type.
+ *
+ * A pre-negotiation binary sends no `X-Memry-Sync-Types` header, so the server
+ * serves it exactly these types. Without this, a newer item type reaches a
+ * binary whose `z.enum(RECORD_SYNC_ITEM_TYPES)` rejects it, which fails the
+ * whole-page `RecordPullResponseSchema.safeParse` and silently drops a page of
+ * notes and tasks while the device cursor advances past them.
+ */
+export const LEGACY_RECORD_SYNC_ITEM_TYPES = [
+  'note',
+  'task',
+  'project',
+  'settings',
+  'inbox',
+  'filter',
+  'journal',
+  'tag_definition',
+  'folder_config',
+  'calendar_event',
+  'calendar_source',
+  'calendar_binding',
+  'calendar_external_event',
+  'agent_conversation',
+  'agent_message'
+] as const
+
+export type LegacyRecordSyncItemType = (typeof LEGACY_RECORD_SYNC_ITEM_TYPES)[number]
+
 export const SYNC_OPERATIONS = ['create', 'update', 'delete'] as const
 
 export const ENCRYPTABLE_ITEM_TYPES = [


### PR DESCRIPTION
## Why

Adding any new sync item type currently breaks clients **already installed on users' machines** — binaries we cannot patch.

The chain, all verified in code:

1. `/sync/changes` is fetched via `getFromServer<T>` → `syncFetch<T>`, a generic cast with **no runtime validation** — an unknown ref is accepted silently.
2. `pullChangesPage` maps **every** ref to an id with no type filter (`pull-coordinator.ts:268`).
3. `/sync/pull` returns those items and `RecordPullResponseSchema.safeParse` validates the **whole page at once**. One unknown `type` fails an older binary's `z.enum(RECORD_SYNC_ITEM_TYPES)`, so `processPage` returns `applied: 0` **without throwing** (`pull-coordinator.ts:453-456`).
4. `pullChanges` still persists `LAST_CURSOR` (`pull-coordinator.ts:1291`) — so that page's notes and tasks are skipped **permanently**.

Silent data-convergence loss, hitting multi-device users first. The server already filtered `item_type IN (...)` in SQL, but bound its **own compile-time** list — so a server deployed with a new type serves it to every client, old ones included. The server is the only place this can be fixed.

This also corrects a wrong assumption in `docs/superpowers/plans/2026-07-14-server-desktop-additive-d6-d8.md:1873`, which states *"old clients simply never pull types they don't register."* They do. That claim underpins the mobile program's three planned sync types, so this unblocks them too.

## What

Clients declare supported types via `X-Memry-Sync-Types` (mirroring `X-Memry-Vault-Id`); the server binds only those into its existing `item_type IN (...)` filter.

- **No header → frozen `LEGACY_RECORD_SYNC_ITEM_TYPES` (15 types).** This is the entire safety property: it protects binaries already in users' hands. The list is **frozen forever** and is never edited when a new type is added — a test enforces that.
- **Header present but nothing recognized → empty list**, serving zero rows. Deliberately *different* from "no header": a client that declared types must never be handed types it did not declare. Short-circuits before any DB call, and `getChanges` returns the incoming cursor unchanged so nothing advances.
- Requested types are deduped and intersected with the server's supported set, bounding bind params against D1's hard 95 ceiling.
- `types` defaults to the legacy list everywhere — fail-closed, so a missed call site serves too few types rather than breaking old clients.

No D1 migration: `sync_items.item_type` is bare `TEXT` with no CHECK constraint.

## Note on cursor mechanics

`getChanges` filters in SQL **before** `LIMIT`, so excluded rows never enter a page and `nextCursor` steps over them for free. A client that later declares a new type back-fills the rows it skipped. An earlier draft of the design claimed this needed changing — that was wrong, and reading the code disproved it. No cursor change was made.

## Deploy order (hard rule)

This must reach **production before** any desktop build carrying a new item type. Staging auto-deploys on merge; prod is manual + approval.

## Testing

- 679/679 sync-server tests; typecheck, lint, contracts, architecture all green.
- `http-client` 24/24 on the desktop side.
- The `BATCH_SIZE` test was verified to actually catch its regression: forcing the old constant turned it red (3 batches vs 2), reverting turned it green.

## Follow-ups (deliberately not in scope)

- `getItem` / `GET /items/:id` doesn't participate in negotiation. It has no caller in `apps/desktop` and returns a single object rather than a cursor page, so it cannot reproduce the page-drop bug. Probably worth deleting as dead code.
- `getSyncStatus` has no `types` param; nothing currently consumes `pendingItems`.
- `LEGACY_RECORD_SYNC_ITEM_TYPES` is `as const` without a runtime `Object.freeze`; the spread returns in `resolveSyncTypes` are what protect it.


## Relationship to #750 and #751

This is the **server-side capability gate** that issue #751 (journal at-rest encryption, parked) identified as mandatory and permanent. That issue's finding #1 already documented this failure mode; this branch re-verified it independently against current code and fixes it.

- **#751 proposed** keying the gate off "a device capability flag the new client registers itself," on the basis that the client sends no version header. This PR takes the simpler route: the client now sends one. Old clients not sending it is exactly what the frozen legacy fallback covers — no server-side device state needed. #751 also notes `/sync/manifest` must be filtered or the re-pull loop persists; it is filtered here.
- **#750 (`sync-pull-cursor-fix`) is the complementary client-side half** — it stops `LAST_CURSOR` advancing past a page that failed to parse, and surfaces the halt as a sync error instead of a "successful" sync. Its own conclusion was that it protects only clients released *after* it, and that the server gate is still required. The two compose: #750 protects future clients from unparseable pages generally; #754 stops the server ever sending an unparseable page to a client that didn't ask for it.
- **No file overlap** with #750 (`pull-coordinator.ts` vs `http-client.ts` + `apps/sync-server`), so they should merge independently.

Together they close the loop that gates the mobile program's three new sync types (`home_page` / `bookmark` / `reminder`).
