### PR TITLE
fix(agent): detect claude/codex CLIs in packaged builds via login-shell PATH

### DIFF
--- a/apps/desktop/src/main/agent/cli/__tests__/login-shell-path.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/login-shell-path.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  PATH_MARKER,
+  applyLoginShellPath,
+  mergePaths,
+  parseShellPath,
+  readLoginShellPath
+} from '../login-shell-path'
+
+describe('parseShellPath', () => {
+  it('extracts PATH from the marker line', () => {
+    const stdout = `${PATH_MARKER}/opt/homebrew/bin:/usr/bin:/bin\n`
+    expect(parseShellPath(stdout)).toBe('/opt/homebrew/bin:/usr/bin:/bin')
+  })
+
+  it('ignores rc noise printed before the marker', () => {
+    const stdout = [
+      'nvm: loaded',
+      'some rc banner',
+      `${PATH_MARKER}/Users/me/.local/bin:/usr/bin`
+    ].join('\n')
+    expect(parseShellPath(stdout)).toBe('/Users/me/.local/bin:/usr/bin')
+  })
+
+  it('trims trailing CR/whitespace', () => {
+    expect(parseShellPath(`${PATH_MARKER}/usr/bin:/bin  \r\n`)).toBe('/usr/bin:/bin')
+  })
+
+  it('returns null when the marker is absent', () => {
+    expect(parseShellPath('/usr/bin:/bin\n')).toBeNull()
+  })
+
+  it('returns null when nothing usable follows the marker', () => {
+    expect(parseShellPath(`${PATH_MARKER}\n`)).toBeNull()
+  })
+})
+
+describe('mergePaths', () => {
+  it('puts resolved dirs first, then current-only dirs, deduped', () => {
+    const merged = mergePaths('/usr/bin:/bin', '/opt/homebrew/bin:/usr/bin', ':')
+    expect(merged).toBe('/opt/homebrew/bin:/usr/bin:/bin')
+  })
+
+  it('drops exact duplicate entries', () => {
+    expect(mergePaths('/usr/bin:/usr/bin', '/usr/bin', ':')).toBe('/usr/bin')
+  })
+
+  it('returns resolved when current is empty', () => {
+    expect(mergePaths('', '/opt/homebrew/bin', ':')).toBe('/opt/homebrew/bin')
+  })
+
+  it('returns current when resolved is empty', () => {
+    expect(mergePaths('/usr/bin', '', ':')).toBe('/usr/bin')
+  })
+})
+
+describe('readLoginShellPath', () => {
+  const spawnOk = (path: string) =>
+    vi.fn().mockReturnValue({ status: 0, stdout: `${PATH_MARKER}${path}\n`, stderr: '' })
+
+  it('returns the login-shell PATH on a successful probe', () => {
+    const spawn = spawnOk('/opt/homebrew/bin:/usr/bin')
+    expect(readLoginShellPath(spawn as never)).toBe('/opt/homebrew/bin:/usr/bin')
+  })
+
+  it('invokes an interactive login shell', () => {
+    const spawn = spawnOk('/usr/bin')
+    readLoginShellPath(spawn as never)
+    const args = spawn.mock.calls[0][1] as string[]
+    expect(args[0]).toBe('-ilc')
+  })
+
+  it('returns null when the probe exits non-zero', () => {
+    const spawn = vi.fn().mockReturnValue({ status: 1, stdout: '', stderr: 'boom' })
+    expect(readLoginShellPath(spawn as never)).toBeNull()
+  })
+
+  it('returns null when the probe throws', () => {
+    const spawn = vi.fn().mockImplementation(() => {
+      throw new Error('spawn failed')
+    })
+    expect(readLoginShellPath(spawn as never)).toBeNull()
+  })
+})
+
+describe('applyLoginShellPath', () => {
+  it('augments env.PATH when packaged on a non-Windows platform', () => {
+    const env = { PATH: '/usr/bin:/bin' }
+    const applied = applyLoginShellPath({
+      packaged: true,
+      platform: 'darwin',
+      env,
+      resolve: () => '/opt/homebrew/bin:/usr/bin'
+    })
+    expect(applied).toBe(true)
+    expect(env.PATH).toBe('/opt/homebrew/bin:/usr/bin:/bin')
+  })
+
+  it('is a no-op when the app is not packaged (terminal already has full PATH)', () => {
+    const env = { PATH: '/usr/bin:/bin' }
+    const applied = applyLoginShellPath({
+      packaged: false,
+      platform: 'darwin',
+      env,
+      resolve: () => '/opt/homebrew/bin'
+    })
+    expect(applied).toBe(false)
+    expect(env.PATH).toBe('/usr/bin:/bin')
+  })
+
+  it('is a no-op on Windows (GUI apps inherit the system PATH)', () => {
+    const env = { PATH: 'C:\\Windows' }
+    const applied = applyLoginShellPath({
+      packaged: true,
+      platform: 'win32',
+      env,
+      resolve: () => 'C:\\tools'
+    })
+    expect(applied).toBe(false)
+    expect(env.PATH).toBe('C:\\Windows')
+  })
+
+  it('is a no-op when the login-shell PATH cannot be resolved', () => {
+    const env = { PATH: '/usr/bin:/bin' }
+    const applied = applyLoginShellPath({
+      packaged: true,
+      platform: 'darwin',
+      env,
+      resolve: () => null
+    })
+    expect(applied).toBe(false)
+    expect(env.PATH).toBe('/usr/bin:/bin')
+  })
+})

--- a/apps/desktop/src/main/agent/cli/login-shell-path.ts
+++ b/apps/desktop/src/main/agent/cli/login-shell-path.ts
@@ -1,0 +1,104 @@
+import { spawnSync } from 'node:child_process'
+import { delimiter } from 'node:path'
+
+/**
+ * Resolve the user's real login-shell PATH so packaged builds can find CLIs.
+ *
+ * A macOS/Linux app launched from Finder/Dock inherits only the minimal system
+ * PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), NOT the shell PATH where user-installed
+ * tools live (`~/.local/bin`, `/opt/homebrew/bin`, npm-global, volta, nvm...). So
+ * `which claude` / `which codex` fail and Agent Chat greys out those providers
+ * even though they're installed. Running the login shell recovers the same PATH
+ * the user sees in their terminal, so spawned probes and the CLIs' own `env node`
+ * shebangs resolve correctly. `pnpm dev` is launched from a terminal and already
+ * has the full PATH, so this is a packaged-only concern.
+ */
+
+/** Unique token prefixed to the printed PATH so we can extract it past rc noise. */
+export const PATH_MARKER = '__MEMRY_LOGIN_PATH__'
+
+type SpawnSync = typeof spawnSync
+
+/** Pull the PATH out of the shell probe's stdout. */
+export function parseShellPath(stdout: string, marker: string = PATH_MARKER): string | null {
+  const line = stdout
+    .split(/\r?\n/)
+    .reverse()
+    .find((candidate) => candidate.includes(marker))
+  if (line === undefined) {
+    return null
+  }
+  const value = line.slice(line.indexOf(marker) + marker.length).trim()
+  return value.length > 0 ? value : null
+}
+
+/** Merge two PATH strings, resolved entries first, deduped, order-preserving. */
+export function mergePaths(
+  current: string,
+  resolved: string,
+  separator: string = delimiter
+): string {
+  const seen = new Set<string>()
+  const merged: string[] = []
+  for (const entry of [...resolved.split(separator), ...current.split(separator)]) {
+    if (entry.length > 0 && !seen.has(entry)) {
+      seen.add(entry)
+      merged.push(entry)
+    }
+  }
+  return merged.join(separator)
+}
+
+/** Probe the login shell for its PATH; returns null on any failure. */
+export function readLoginShellPath(spawn: SpawnSync = spawnSync): string | null {
+  const shell = process.env.SHELL || '/bin/bash'
+  try {
+    // `-i` (interactive) so zsh's ~/.zshrc / bash's ~/.bashrc run — that's where
+    // PATH is usually set; `-l` (login) so profile files run too.
+    const result = spawn(shell, ['-ilc', `printf '%s\\n' "${PATH_MARKER}$PATH"`], {
+      encoding: 'utf8',
+      timeout: 3000
+    })
+    if (!result || result.status !== 0 || typeof result.stdout !== 'string') {
+      return null
+    }
+    return parseShellPath(result.stdout)
+  } catch {
+    return null
+  }
+}
+
+interface ApplyOptions {
+  resolve?: () => string | null
+  platform?: NodeJS.Platform
+  packaged?: boolean
+  env?: NodeJS.ProcessEnv
+}
+
+/**
+ * Augment `env.PATH` with the login-shell PATH. No-op unless the app is packaged
+ * on a non-Windows platform and the probe succeeds. Returns whether PATH changed.
+ */
+export function applyLoginShellPath({
+  resolve = readLoginShellPath,
+  platform = process.platform,
+  packaged = false,
+  env = process.env
+}: ApplyOptions = {}): boolean {
+  // Windows GUI apps already inherit the system PATH; dev is launched from a
+  // terminal with the full PATH, so only packaged macOS/Linux builds need this.
+  if (platform === 'win32' || !packaged) {
+    return false
+  }
+  const resolved = resolve()
+  if (!resolved) {
+    return false
+  }
+  const before = env.PATH ?? ''
+  const merged = mergePaths(before, resolved)
+  if (merged === before) {
+    return false
+  }
+  env.PATH = merged
+  return true
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -91,6 +91,7 @@ import { getHeadlessCliArgs, runHeadlessCli } from './cli/headless'
 import { reconcileBillingAndSync, startBillingCheckout } from './billing/paddle-billing'
 import { openPairingWindow } from './capture/pairing'
 import { startCaptureServer, stopCaptureServer } from './capture/server'
+import { applyLoginShellPath } from './agent/cli/login-shell-path'
 
 if (process.type === 'browser') {
   log.initialize()
@@ -165,6 +166,15 @@ const configLog = createLogger('Config')
 const quickCaptureLog = createLogger('QuickCapture')
 const shutdownLog = createLogger('Shutdown')
 const deepLinkLog = createLogger('DeepLink')
+
+// A Finder/Dock-launched packaged app inherits only the minimal system PATH, so
+// user-installed CLIs (claude/codex) are invisible to `which` and Agent Chat
+// greys out those providers. Recover the login-shell PATH before anything spawns
+// a probe or the CLIs themselves. No-op in dev (terminal already has full PATH).
+if (applyLoginShellPath({ packaged: app.isPackaged })) {
+  mainLog.info('Augmented PATH from login shell for packaged launch')
+}
+
 const headlessCliArgs = getHeadlessCliArgs(process.argv)
 
 let mainI18n: I18nInstance

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -33,7 +33,10 @@ edge while the chat content stays centered, and the tab name is the only convers
 that workspace view. Assistant responses render as full-width text in both the sidebar and popped-out
 tabs instead of bordered bubbles, with text aligned to the prompt input. For Claude CLI, memrynote checks
 that `claude` is available on `PATH`, that it reports version `2.1.0` or newer, and that the Agent
-disclosure has been accepted. For local models, configure a compatible server in
+disclosure has been accepted; the Codex CLI is detected the same way. On macOS and Linux, memrynote
+resolves your login shell's `PATH` at startup, so CLIs installed in shell-managed locations
+(`~/.local/bin`, Homebrew, nvm, volta) are still found when the app is launched from the Dock or
+Finder rather than from a terminal. For local models, configure a compatible server in
 [Settings -> AI Assistant -> Agent Permissions](/user-guide/settings#agent-permissions) first.
 If the global AI switch is off in [Settings -> AI](/user-guide/settings#ai), the Agent tab and Agent
 MCP current-note bridge are hidden and inactive.


### PR DESCRIPTION
## Problem

In a packaged (Finder/Dock-launched) MemryNote build, the **Claude** and **Codex** provider options in Agent Chat are greyed out even though both CLIs are installed. They work in `pnpm dev`.

## Root cause

Provider availability is a **live probe** — `which claude` / `which codex` + a `--version` check every time the panel mounts (`claude-binary.ts`, `codex-binary.ts`). Nothing about it is persisted, so config/userData state is not involved.

A GUI app launched from Finder/Dock inherits only the **minimal macOS system PATH** (`/usr/bin:/bin:/usr/sbin:/sbin`), not the shell PATH where user-installed CLIs live (`~/.local/bin`, Homebrew, npm-global, nvm, volta…). So `which claude` fails and the providers are marked unavailable. `pnpm dev` works only because the terminal hands Electron the full PATH.

Reproduced locally: with the minimal PATH, `which claude` and `which codex` both miss; the CLIs actually live in `~/.local/bin` and `~/.nvm/.../bin`.

## Fix

Resolve the user's **login-shell PATH** once at main-process startup (packaged, non-Windows only) and merge it into `process.env.PATH` before any probe or CLI spawn runs. All existing `spawnSync`/`spawn` call sites benefit, including the CLIs' own `env node` shebangs.

- New `src/main/agent/cli/login-shell-path.ts` — pure, dependency-injected, unit-tested (`parseShellPath`, `mergePaths`, `readLoginShellPath`, `applyLoginShellPath`).
- One-line wire-up in `index.ts` startup, gated on `app.isPackaged`.
- **No userData/config is touched** — production install state is unaffected. (This also confirms dev/e2e never corrupted the production install: their userData dirs are already isolated; the greyed-out dropdowns were always a PATH issue, not state pollution.)

## Verification

- 17 new unit tests + 39 existing agent-CLI tests green (56/56).
- `typecheck:node` clean, lint clean.
- End-to-end: reproduced the bug under the minimal Finder PATH, then confirmed the login-shell probe recovers both `~/.local/bin` (claude) and `~/.nvm/.../bin` (codex).
- Docs updated (`agent-mcp.md`); `docs:impact --strict` covered; `docs:build` passes.

## Interim workaround (before this merges)

Launch the current build from a terminal (`open /path/to/MemryNote.app`) so it inherits the full shell PATH.