### PR TITLE
fix(crypto): stabilize dev keychain master-key account across worktrees

### DIFF
--- a/apps/desktop/src/main/crypto/keychain-account.test.ts
+++ b/apps/desktop/src/main/crypto/keychain-account.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import type { KeychainEntry } from '@memry/contracts/crypto'
+
+import { normalizeDeviceSuffix, resolveKeychainAccount } from './keychain-account'
+
+const MASTER_KEY: KeychainEntry = { service: 'com.memry.test', account: 'master-key' }
+
+describe('normalizeDeviceSuffix', () => {
+  it('collapses a per-worktree plain-dev hash to a stable "dev"', () => {
+    expect(normalizeDeviceSuffix('dev-1a2b3c4d')).toBe('dev')
+    expect(normalizeDeviceSuffix('dev-deadbeef')).toBe('dev')
+  })
+
+  it('leaves explicit dev devices A/B/C untouched', () => {
+    expect(normalizeDeviceSuffix('A')).toBe('A')
+    expect(normalizeDeviceSuffix('B')).toBe('B')
+    expect(normalizeDeviceSuffix('C')).toBe('C')
+  })
+
+  it('leaves e2e device ids untouched', () => {
+    expect(normalizeDeviceSuffix('e2e-3f9c1a2b-A')).toBe('e2e-3f9c1a2b-A')
+  })
+
+  it('treats missing/empty as no suffix (production)', () => {
+    expect(normalizeDeviceSuffix(undefined)).toBeUndefined()
+    expect(normalizeDeviceSuffix('')).toBeUndefined()
+  })
+
+  it('does not collapse non-hex or wrong-length dev-* values', () => {
+    expect(normalizeDeviceSuffix('dev-XYZ')).toBe('dev-XYZ')
+    expect(normalizeDeviceSuffix('dev-1a2b')).toBe('dev-1a2b')
+    expect(normalizeDeviceSuffix('dev')).toBe('dev')
+  })
+})
+
+describe('resolveKeychainAccount', () => {
+  it('returns the bare account in production (no MEMRY_DEVICE)', () => {
+    expect(resolveKeychainAccount(MASTER_KEY, undefined)).toBe('master-key')
+  })
+
+  it('gives every plain-dev worktree the SAME account', () => {
+    const a = resolveKeychainAccount(MASTER_KEY, 'dev-1a2b3c4d')
+    const b = resolveKeychainAccount(MASTER_KEY, 'dev-99887766')
+    expect(a).toBe('master-key-dev')
+    expect(b).toBe('master-key-dev')
+    expect(a).toBe(b)
+  })
+
+  it('keeps explicit devices on their own account', () => {
+    expect(resolveKeychainAccount(MASTER_KEY, 'A')).toBe('master-key-A')
+  })
+})

--- a/apps/desktop/src/main/crypto/keychain-account.ts
+++ b/apps/desktop/src/main/crypto/keychain-account.ts
@@ -1,0 +1,32 @@
+import type { KeychainEntry } from '@memry/contracts/crypto'
+
+/**
+ * Plain `pnpm dev` sets `MEMRY_DEVICE` to `dev-<checkout-path-hash>` so each git
+ * worktree gets its own isolated userData dir (see `resolveDeviceId` in
+ * `main/index.ts`). The OS keychain, though, is machine-global, and the vault
+ * folder that stores the key verifier (`<vault>/.memry/data.db`) is shared across
+ * worktrees. Scoping the master-key account by the per-worktree hash therefore
+ * strands the key: opening the same dev vault from a second worktree looks under a
+ * different keychain account and fails with "verifier exists but master key is
+ * missing", which makes Agent Chat report its providers unavailable.
+ *
+ * Collapse the per-worktree dev hash to a stable `dev` suffix so every plain-dev
+ * worktree shares one master key. Production (`MEMRY_DEVICE` unset -> bare account)
+ * and explicit devices (`A`/`B`/`C`, `e2e-*`) are intentionally left untouched.
+ */
+const DEV_WORKTREE_DEVICE = /^dev-[0-9a-f]{8}$/
+
+export function normalizeDeviceSuffix(deviceSuffix: string | undefined): string | undefined {
+  if (deviceSuffix && DEV_WORKTREE_DEVICE.test(deviceSuffix)) {
+    return 'dev'
+  }
+  return deviceSuffix || undefined
+}
+
+export function resolveKeychainAccount(
+  entry: KeychainEntry,
+  deviceSuffix: string | undefined
+): string {
+  const normalized = normalizeDeviceSuffix(deviceSuffix)
+  return normalized ? `${entry.account}-${normalized}` : entry.account
+}

--- a/apps/desktop/src/main/crypto/keychain.ts
+++ b/apps/desktop/src/main/crypto/keychain.ts
@@ -3,9 +3,10 @@ import sodium from 'libsodium-wrappers-sumo'
 
 import type { KeychainEntry } from '@memry/contracts/crypto'
 
+import { resolveKeychainAccount } from './keychain-account'
+
 function resolveAccount(entry: KeychainEntry): string {
-  const deviceSuffix = process.env.MEMRY_DEVICE
-  return deviceSuffix ? `${entry.account}-${deviceSuffix}` : entry.account
+  return resolveKeychainAccount(entry, process.env.MEMRY_DEVICE)
 }
 
 // The OS keychain hangs under automated e2e (an adhoc-signed/headless build

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -36,6 +36,11 @@ First-device setup and recovery relinking rebind this local verifier immediately
 master key is saved, before sync activation. If the verifier cannot be checked at startup, the sync
 runtime stays offline instead of starting queues, CRDT seeding, or snapshot uploads with missing
 vault-key credentials.
+
+The keychain account is suffixed per device: production installs use the bare account, while
+explicit dev profiles (`A`/`B`/`C`) and e2e runs keep their own suffix. Plain `pnpm dev` scopes its
+profile by checkout-path hash, but all such worktrees share a single stable `dev` keychain suffix so
+that a dev vault opened from a second worktree still finds the master key that bound its verifier.
 When a local-only vault later signs up as the first sync device, device registration stores the
 account master key and rebinds this verifier before the sync runtime activates. That keeps notes
 created before sign-in on the same encrypted sync path instead of leaving the push queue without a


### PR DESCRIPTION
## Problem

Running `pnpm dev` from a **git worktree** makes Agent Chat show **Claude and Codex greyed out**. The main log shows:

```
[warn] (AgentBootstrap) Agent runtime unavailable: Vault key verifier exists but master key is missing
```

## Root cause

- Plain `pnpm dev` scopes `MEMRY_DEVICE` by a hash of the checkout path (`dev-<hash>`) to isolate userData per worktree (`resolveDeviceId` in `main/index.ts`).
- `resolveAccount` in `crypto/keychain.ts` inherited that suffix for the **OS keychain** too, so the master key was stored under a **per-worktree** account.
- But the **key verifier** lives in the **shared vault folder** (`<vault>/.memry/data.db`).
- So opening the same dev vault from a *second* worktree looks up a different keychain account → master key not found → `getOrInitializeLocalVaultKey` throws → bootstrap registers *unavailable* agent handlers → `getBackendStatuses` returns `available:false` → claude/codex disabled.

Production is **not** affected: packaged builds have `MEMRY_DEVICE` unset, so the keychain account is the stable bare account. This is purely a dev/worktree artifact.

## Fix

Collapse the per-worktree `dev-<hash>` to a stable `dev` keychain suffix so every plain-dev worktree shares one master key. Extracted the account logic into a keytar-free, unit-tested module.

- New `crypto/keychain-account.ts` — `normalizeDeviceSuffix` + `resolveKeychainAccount` (pure, 8 unit tests).
- `crypto/keychain.ts` `resolveAccount` now delegates to it.
- **Unchanged:** production (bare account), explicit devices `A`/`B`/`C`, and `e2e-*` ids.

## One-time dev migration

A dev vault previously bound under `dev-<hash>` will re-init a fresh master key under the stable `dev` account on first run after this lands (verifier rebind; agent chat history for that vault resets). **Dev data only — production installs are untouched.** To unstick an already-bound dev vault immediately:

```
sqlite3 "<vault>/.memry/data.db" "DELETE FROM settings WHERE key='vault.crypto.verifier.v1';"
```

## Verification

- 8 new unit tests + full crypto suite green (246 pass; the 1 non-passing is the real-OS-keychain E2E test, skipped in unit context).
- `typecheck:node` clean, lint clean.
- Docs updated (`architecture/cryptography.md`); `docs:impact --strict` covered; `docs:build` passes.

## Relationship to the PATH PR

Companion to #755 (packaged-build PATH detection). That PR fixes greyed providers in the **installed .app** (minimal Finder PATH); this one fixes greyed providers in **dev worktrees** (keychain account mismatch). Different subsystems, no file overlap.