### PR TITLE
feat(landing): motion polish for closing CTA and login

### DIFF
--- a/apps/landing/src/components/site/FinalCta.tsx
+++ b/apps/landing/src/components/site/FinalCta.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import { ArrowRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -10,8 +10,25 @@ import { HomeSection } from '@/components/site/primitives'
 
 const EASE = [0.16, 1, 0.3, 1] as const
 
-/** Terracotta sunrise — concentric arcs over a half-sun rising from the banner's bottom edge. */
+// Faint concentric rings, outer → inner. Each blooms in behind the rising sun.
+const SUN_ARCS = [
+  { d: 'M150 240a210 210 0 0 1 420 0', o: 0.12 },
+  { d: 'M203 240a157 157 0 0 1 314 0', o: 0.2 },
+  { d: 'M256 240a104 104 0 0 1 208 0', o: 0.3 }
+] as const
+
+/**
+ * Terracotta sunrise — concentric arcs over a half-sun that RISES from the banner's
+ * bottom edge as the closer scrolls into view: the sunrise metaphor the surrounding
+ * copy names, made literal at the one emotional beat of the page. Motion is
+ * transform/opacity only; the card's `overflow-hidden` clips the sun's start below the
+ * baseline. Framer-motion runs on rAF, so the global reduced-motion CSS does not touch
+ * it — `useReducedMotion()` renders every element settled instead.
+ */
 function SunArc() {
+  const reduce = useReducedMotion()
+  const viewport = { once: true, margin: '-80px' } as const
+
   return (
     <svg
       viewBox="0 0 720 240"
@@ -20,11 +37,28 @@ function SunArc() {
       aria-hidden
     >
       <g fill="none" stroke="#ff671a">
-        <path d="M150 240a210 210 0 0 1 420 0" strokeOpacity="0.12" strokeWidth="2" />
-        <path d="M203 240a157 157 0 0 1 314 0" strokeOpacity="0.2" strokeWidth="2" />
-        <path d="M256 240a104 104 0 0 1 208 0" strokeOpacity="0.3" strokeWidth="2" />
+        {SUN_ARCS.map((arc, i) => (
+          <motion.path
+            key={arc.d}
+            d={arc.d}
+            strokeOpacity={arc.o}
+            strokeWidth="2"
+            initial={reduce ? false : { opacity: 0, y: 12 }}
+            whileInView={reduce ? undefined : { opacity: 1, y: 0 }}
+            viewport={viewport}
+            transition={reduce ? undefined : { duration: 0.7, delay: 0.15 + i * 0.08, ease: EASE }}
+          />
+        ))}
       </g>
-      <path d="M308 240a52 52 0 0 1 104 0Z" fill="#ff671a" fillOpacity="0.85" />
+      <motion.path
+        d="M308 240a52 52 0 0 1 104 0Z"
+        fill="#ff671a"
+        fillOpacity="0.85"
+        initial={reduce ? false : { opacity: 0, y: 26 }}
+        whileInView={reduce ? undefined : { opacity: 1, y: 0 }}
+        viewport={viewport}
+        transition={reduce ? undefined : { duration: 0.9, delay: 0.28, ease: EASE }}
+      />
     </svg>
   )
 }

--- a/apps/landing/src/pages/Login.tsx
+++ b/apps/landing/src/pages/Login.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import { Button } from '@/components/ui/button'
@@ -8,6 +9,8 @@ import { registerWebDevice } from '@/lib/account/auth-client'
 import { SYNC_SERVER_URL, WEB_OAUTH_REDIRECT_PATH } from '@/lib/account/config'
 import { OAUTH_NEXT_STORAGE_KEY, safeNextPath } from '@/lib/account/next-path'
 import { trackLandingEvent } from '@/lib/analytics'
+
+const EASE = [0.16, 1, 0.3, 1] as const
 
 function continueWithGoogle(next: string | null) {
   sessionStorage.setItem(OAUTH_NEXT_STORAGE_KEY, next ?? '')
@@ -68,6 +71,7 @@ export function LoginPage() {
   const [step, setStep] = useState<'email' | 'code'>('email')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const reduce = useReducedMotion()
 
   async function requestCode() {
     setBusy(true)
@@ -138,62 +142,90 @@ export function LoginPage() {
                   : `We emailed a 6-digit code to ${email}.`}
             </p>
 
-            {error ? <p className="mt-4 text-center text-sm text-red-500">{error}</p> : null}
+            <AnimatePresence>
+              {error ? (
+                <motion.p
+                  key="login-error"
+                  className="mt-4 text-center text-sm text-red-500"
+                  initial={reduce ? { opacity: 0 } : { opacity: 0, y: -4 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={reduce ? { opacity: 0 } : { opacity: 0, y: -4 }}
+                  transition={{ duration: 0.18, ease: EASE }}
+                >
+                  {error}
+                </motion.p>
+              ) : null}
+            </AnimatePresence>
 
-            {step === 'email' ? (
-              <form
-                className="mt-8 space-y-3"
-                onSubmit={(e) => {
-                  e.preventDefault()
-                  void requestCode()
-                }}
-              >
-                <Input
-                  type="email"
-                  autoComplete="email"
-                  placeholder="Your email"
-                  aria-label="Email address"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                />
-                <Button type="submit" className="w-full" disabled={busy || !email}>
-                  {busy ? 'Sending…' : 'Continue'}
-                </Button>
-              </form>
-            ) : (
-              <form
-                className="mt-8 space-y-3"
-                onSubmit={(e) => {
-                  e.preventDefault()
-                  void verifyCode()
-                }}
-              >
-                <Input
-                  inputMode="numeric"
-                  autoComplete="one-time-code"
-                  maxLength={6}
-                  placeholder="123456"
-                  aria-label="6-digit code"
-                  className="text-center font-mono-accent tracking-[0.4em]"
-                  value={code}
-                  onChange={(e) => setCode(e.target.value)}
-                />
-                <Button type="submit" className="w-full" disabled={busy || code.length !== 6}>
-                  {busy ? 'Verifying…' : 'Verify & sign in'}
-                </Button>
-                <button
-                  type="button"
-                  className="mx-auto block text-xs text-muted underline underline-offset-2 transition-colors hover:text-ink"
-                  onClick={() => {
-                    setStep('email')
-                    setCode('')
-                    setError(null)
+            {/* Step swap slides forward: outgoing form exits left, incoming enters from the
+                right. mode="wait" keeps them from overlapping; initial={false} skips the entrance
+                on first mount, since the card already animates in via `.animate-fade-up`. */}
+            <AnimatePresence mode="wait" initial={false}>
+              {step === 'email' ? (
+                <motion.form
+                  key="email"
+                  className="mt-8 space-y-3"
+                  initial={reduce ? { opacity: 0 } : { opacity: 0, x: 8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={reduce ? { opacity: 0 } : { opacity: 0, x: -8 }}
+                  transition={{ duration: 0.2, ease: EASE }}
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    void requestCode()
                   }}
                 >
-                  Use a different email
-                </button>
-              </form>
-            )}
+                  <Input
+                    type="email"
+                    autoComplete="email"
+                    placeholder="Your email"
+                    aria-label="Email address"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                  />
+                  <Button type="submit" className="w-full" disabled={busy || !email}>
+                    {busy ? 'Sending…' : 'Continue'}
+                  </Button>
+                </motion.form>
+              ) : (
+                <motion.form
+                  key="code"
+                  className="mt-8 space-y-3"
+                  initial={reduce ? { opacity: 0 } : { opacity: 0, x: 8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={reduce ? { opacity: 0 } : { opacity: 0, x: -8 }}
+                  transition={{ duration: 0.2, ease: EASE }}
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    void verifyCode()
+                  }}
+                >
+                  <Input
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    maxLength={6}
+                    placeholder="123456"
+                    aria-label="6-digit code"
+                    className="text-center font-mono-accent tracking-[0.4em]"
+                    value={code}
+                    onChange={(e) => setCode(e.target.value)}
+                  />
+                  <Button type="submit" className="w-full" disabled={busy || code.length !== 6}>
+                    {busy ? 'Verifying…' : 'Verify & sign in'}
+                  </Button>
+                  <button
+                    type="button"
+                    className="mx-auto block text-xs text-muted underline underline-offset-2 transition-colors hover:text-ink"
+                    onClick={() => {
+                      setStep('email')
+                      setCode('')
+                      setError(null)
+                    }}
+                  >
+                    Use a different email
+                  </button>
+                </motion.form>
+              )}
+            </AnimatePresence>
 
             <div className="my-6 flex items-center gap-3 text-xs text-muted">
               <span className="h-px flex-1 bg-border" />


### PR DESCRIPTION
## What

Three small motion additions on the landing site, surfaced by an animation-opportunity sweep of `apps/landing/`. Each fills a genuinely *flat* seam — nothing existing was re-animated.

### 1. `FinalCta` — sunrise rise-in (delight)
The closing banner's `SunArc` half-sun now **rises** from the baseline as the card scrolls into view, with the concentric rings blooming in behind it. Makes the sunrise metaphor literal at the page's one emotional beat. One shared component → every page's closer benefits.

### 2. `Login` — error entrance (feedback)
The OTP error line entered/exited via `AnimatePresence` (fade + 4px drop, 180ms) instead of teleporting in on a failed request.

### 3. `Login` — step transition (spatial)
The email → code step swap slides forward through `AnimatePresence mode="wait"` (8px, 200ms) instead of a hard ternary swap.

## Constraints honored
- Reuses the site's single easing token `--ease-out-expo` = `cubic-bezier(0.16, 1, 0.3, 1)` — no new tokens.
- `transform` / `opacity` only. No `scale`/`filter` on SVG paths.
- Every animation gated on `useReducedMotion()` → renders settled when reduced motion is on (framer-motion runs on rAF, so the global reduced-motion CSS does not cover it).

## Verification
- `pnpm --filter @memry/landing typecheck` — clean
- `eslint` on both changed files — clean
- `pnpm --filter @memry/landing build` — clean, **45 routes prerendered** incl. `/login` + home (SSR renders the motion initial-state, same as existing `whileInView` sections)
- `git diff --check` — clean

## Still needs
In-browser **feel-check** (the sunrise beat + two crossfades can't be judged from code) and a reduced-motion pass. Draft until that lands.