### PR TITLE
feat(desktop): micro-motion polish for buttons, empty states, checkbox

### DIFF
--- a/apps/desktop/src/renderer/src/components/folder-view/folder-view-empty-state.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-view-empty-state.tsx
@@ -157,7 +157,10 @@ export function FolderViewEmptyState({
 
   return (
     <output
-      className={cn('flex flex-col items-center justify-center py-16 px-4 text-center', className)}
+      className={cn(
+        'flex flex-col items-center justify-center py-16 px-4 text-center fade-in-up',
+        className
+      )}
       aria-live="polite"
     >
       {/* Icon */}

--- a/apps/desktop/src/renderer/src/components/tasks/task-empty-state.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/task-empty-state.tsx
@@ -73,7 +73,12 @@ export const TaskEmptyState = ({
   const title = variant === 'project' && projectName ? `No tasks in ${projectName}` : config.title
 
   return (
-    <div className={cn('flex flex-col items-center justify-center py-16 text-center', className)}>
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center py-16 text-center fade-in-up',
+        className
+      )}
+    >
       {/* Icon */}
       <div className="mb-4 rounded-full bg-muted p-4">
         <Icon className="size-8 text-text-tertiary" aria-hidden="true" />

--- a/apps/desktop/src/renderer/src/components/tasks/today-empty-state.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/today-empty-state.tsx
@@ -27,7 +27,7 @@ export const TodayEmptyState = ({
   // If there are overdue tasks but nothing for today
   if (hasOverdue) {
     return (
-      <div className={cn('text-center py-12', className)}>
+      <div className={cn('text-center py-12 fade-in-up', className)}>
         <div className="mb-4 mx-auto w-12 h-12 rounded-full bg-muted flex items-center justify-center">
           <CalendarDays className="size-5 text-text-tertiary" aria-hidden="true" />
         </div>
@@ -50,7 +50,7 @@ export const TodayEmptyState = ({
 
   // Completely clear - calm, quiet satisfaction state
   return (
-    <div className={cn('text-center py-20', className)}>
+    <div className={cn('text-center py-20 fade-in-up', className)}>
       {/* Subtle checkmark icon */}
       <div className="mb-6 mx-auto w-16 h-16 rounded-full bg-task-complete/[0.08] flex items-center justify-center">
         <Check className="size-7 text-task-complete" aria-hidden="true" />

--- a/apps/desktop/src/renderer/src/components/tasks/upcoming-empty-state.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/upcoming-empty-state.tsx
@@ -27,7 +27,7 @@ export const UpcomingEmptyState = ({
   // If there are overdue tasks but nothing upcoming
   if (hasOverdue) {
     return (
-      <div className={cn('text-center py-12', className)}>
+      <div className={cn('text-center py-12 fade-in-up', className)}>
         <div className="mb-4 rounded-full bg-muted p-4 inline-block">
           <Calendar className="size-8 text-text-tertiary" aria-hidden="true" />
         </div>
@@ -50,7 +50,7 @@ export const UpcomingEmptyState = ({
 
   // Completely clear
   return (
-    <div className={cn('text-center py-16', className)}>
+    <div className={cn('text-center py-16 fade-in-up', className)}>
       {/* Icon */}
       <div className="mb-4 rounded-full bg-muted p-4 inline-block">
         <Calendar className="size-8 text-text-tertiary" aria-hidden="true" />

--- a/apps/desktop/src/renderer/src/components/ui/button-variants.ts
+++ b/apps/desktop/src/renderer/src/components/ui/button-variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority'
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition active:scale-[0.98] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/checkbox.tsx
@@ -16,7 +16,9 @@ const Checkbox = React.forwardRef<
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator className={cn('grid place-content-center text-current')}>
+    <CheckboxPrimitive.Indicator
+      className={cn('grid place-content-center text-current animate-in zoom-in-50 duration-100')}
+    >
       <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>


### PR DESCRIPTION
## What
- Button: press-scale feedback (`active:scale-[0.98]`) folded into the shared `Button` primitive
- Empty states: `fade-in-up` entrance on today / upcoming / task / folder-view empty states
- Checkbox: `zoom-in` the indicator on check

## Why
Three flat interaction seams from an animation sweep. Restraint-first: transform/opacity only, values pulled from existing tokens (`--ease-out`, `--duration-*`, `.fade-in-up`, tailwindcss-animate), reduced-motion-safe via the global guard at `base.css:1916`. Cosmetic only — no behavior/settings/feature surface.