### PR TITLE
feat(desktop): global design constraints — 2 weights, neutral palette, 8-12px radius

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -74,8 +74,8 @@
 :root .bn-editor,
 :root .bn-container {
   background-color: var(--background) !important;
-  color: #37352f !important;
-  caret-color: #37352f;
+  color: var(--foreground) !important;
+  caret-color: var(--foreground);
   padding-inline: 0px;
   -webkit-font-smoothing: auto !important;
 }
@@ -84,7 +84,7 @@
 .dark .bn-container {
   background-color: var(--background) !important;
   color: var(--text-bright) !important;
-  caret-color: #f0efed;
+  caret-color: var(--text-bright);
 }
 
 /* Inbox detail + task description drawers: editor inherits the drawer surface
@@ -186,7 +186,7 @@
 
 /* ===== HEADING TYPOGRAPHY ===== */
 :root .bn-block-content[data-content-type='heading'] {
-  font-weight: 600 !important;
+  font-weight: 500 !important;
   line-height: 1.3 !important;
   margin-top: 24px;
   padding: 1px 0 !important;
@@ -738,7 +738,7 @@
   color: var(--muted-foreground);
   font-size: 12px;
   line-height: 16px;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 /* Invisible positioning wrapper: the cards/composer inside carry their own
@@ -988,80 +988,81 @@
     --font-heading: 'Space Grotesk Variable', system-ui, sans-serif;
     --font-mono: 'JetBrains Mono Variable', 'SF Mono', 'Fira Code', monospace;
 
-    /* ===== BASE COLORS (Canvas) - "Warm Utility" Aesthetic ===== */
-    --background: #f6f5f0;
-
-    /* Warm Beige / "Paper" */
-    --foreground: #1a1a1a;
-    /* Primary Text - Near Black */
-    --surface: #efefe9;
-    /* Sidebar/Panels - Slightly darker warm grey */
-    --surface-active: #e4e4de;
-    /* Hover states */
+    /* ===== BASE COLORS (Canvas) - Tailwind neutral ramp ===== */
+    --background: oklch(98.5% 0 0);
+    /* neutral-50 */
+    --foreground: oklch(20.5% 0 0);
+    /* neutral-900 */
+    --surface: oklch(97% 0 0);
+    /* neutral-100 */
+    --surface-active: oklch(92.2% 0 0);
+    /* neutral-200 */
     --critic-review-card-hover-background: var(--surface-active);
     --critic-review-actions-background: var(--background);
 
-    /* ===== SEMANTIC PASTELS (Card Backgrounds) ===== */
-    --card-sage: #e6efe6;
-    /* Biology/Nature */
-    --card-rose: #efe6e6;
-    /* Economics/History */
-    --card-sand: #efebdd;
-    /* Cyber Security/General */
-    --card-lavender: #e6e0ef;
-    /* Machine Learning */
-    --card-grey: #e0e0e0;
-    /* Unknown/Sort */
+    /* ===== CATEGORY CARD BACKGROUNDS (neutralized) ===== */
+    --card-sage: oklch(97% 0 0);
+    --card-rose: oklch(97% 0 0);
+    --card-sand: oklch(97% 0 0);
+    --card-lavender: oklch(97% 0 0);
+    --card-grey: oklch(97% 0 0);
+    /* all neutral-100 */
 
     /* ===== TYPOGRAPHY COLORS ===== */
-    --text-primary: #1a1a1a;
-    /* Near Black - Title Headers */
-    --text-secondary: #4a4a4a;
-    /* Body text, sidebar items */
-    --text-tertiary: #8c8c8c;
-    /* Meta data, dates, unused icons */
-    --text-bright: #1a1a1a;
+    --text-primary: oklch(20.5% 0 0);
+    /* neutral-900 */
+    --text-secondary: oklch(43.9% 0 0);
+    /* neutral-600 */
+    --text-tertiary: oklch(55.6% 0 0);
+    /* neutral-500 */
+    --text-bright: oklch(14.5% 0 0);
+    /* neutral-950 */
 
-    /* ===== ACCENT COLORS (Category Dots) ===== */
-    --accent-cyan: #06b6d4;
-    --accent-purple: #8b5cf6;
-    --accent-green: #22c55e;
-    --accent-orange: #f97316;
+    /* ===== CATEGORY DOTS (neutralized) ===== */
+    --accent-cyan: oklch(55.6% 0 0);
+    --accent-purple: oklch(55.6% 0 0);
+    --accent-green: oklch(55.6% 0 0);
+    --accent-orange: oklch(55.6% 0 0);
+    /* all neutral-500 */
 
-    /* ===== UI SEMANTIC COLORS ===== */
-    --muted: #efefe9;
-    --muted-foreground: #4a4a4a;
-    --popover: #f6f5f0;
-    --popover-foreground: #1a1a1a;
-    --border: #e4e4de;
-    --input: #e4e4de;
+    /* ===== UI SEMANTIC COLORS (neutral ramp; destructive kept) ===== */
+    --muted: oklch(97% 0 0);
+    --muted-foreground: oklch(43.9% 0 0);
+    --popover: oklch(98.5% 0 0);
+    --popover-foreground: oklch(20.5% 0 0);
+    --border: oklch(92.2% 0 0);
+    --input: oklch(92.2% 0 0);
     --card: #ffffff;
-    --card-foreground: #1a1a1a;
-    --primary: #1a1a1a;
-    --primary-foreground: #f6f5f0;
-    --secondary: #efefe9;
-    --secondary-foreground: #1a1a1a;
-    --accent: #efefe9;
-    --accent-foreground: #1a1a1a;
+    --card-foreground: oklch(20.5% 0 0);
+    --primary: oklch(20.5% 0 0);
+    --primary-foreground: oklch(98.5% 0 0);
+    --secondary: oklch(97% 0 0);
+    --secondary-foreground: oklch(20.5% 0 0);
+    --accent: oklch(97% 0 0);
+    --accent-foreground: oklch(20.5% 0 0);
     --destructive: #dc2626;
     --destructive-foreground: #fafafa;
-    --ring: #8c8c8c;
+    --ring: oklch(70.8% 0 0);
 
-    /* ===== BORDER RADIUS (Squircle/Soft Rounding) ===== */
+    /* ===== BORDER RADIUS (Global: clamped 8–12px, no more no less) ===== */
     --radius: 0.5rem;
-    /* 8px - Default */
-    --radius-sm: 0.375rem;
-    /* 6px */
+    /* 8px - Default (also bare `rounded`) */
+    --radius-xs: 0.5rem;
+    /* 8px (floor) */
+    --radius-sm: 0.5rem;
+    /* 8px (floor) */
     --radius-md: 0.5rem;
     /* 8px - List Rows */
     --radius-lg: 0.75rem;
     /* 12px */
-    --radius-xl: 1rem;
-    /* 16px - Cards */
-    --radius-2xl: 1.25rem;
-    /* 20px */
+    --radius-xl: 0.75rem;
+    /* 12px (ceil) */
+    --radius-2xl: 0.75rem;
+    /* 12px (ceil) */
+    --radius-3xl: 0.75rem;
+    /* 12px (ceil) */
     --radius-full: 9999px;
-    /* Fully rounded - Tags/Badges */
+    /* Fully rounded - Tags/Badges/Avatars (exception) */
 
     /* ===== SHADOWS (Flat-first design) ===== */
     --shadow-card: 0 1px 2px 0 rgb(0 0 0 / 0.03), 0 1px 3px 0 rgb(0 0 0 / 0.05);
@@ -1072,26 +1073,26 @@
     --card-width: 280px;
     --card-height: 200px;
 
-    /* ===== GRAPH VIEW COLORS ===== */
-    --graph-node-note: #4a9e8e;
-    --graph-node-journal: #8b5cf6;
-    --graph-node-task: #d4944a;
-    --graph-node-project: #5a8a5a;
-    --graph-node-tag: #c2855a;
-    --graph-edge-default: #8c8c8c;
-    --graph-edge-wikilink: #8c8c8c;
-    --graph-edge-task-note: #c4a46a;
-    --graph-edge-project-task: #9a8abd;
-    --graph-edge-tag-cooccurrence: #a8a6a1;
-    --graph-ghost-node: #c4c2bc;
-    --graph-dimmed-node: #e4e4de;
-    --graph-edge-soft: #a8a6a0;
-    --graph-bg: #f6f5f0;
-    --graph-label-color: #1a1a1a;
+    /* ===== GRAPH VIEW COLORS (neutral mono-lightness ramp for legibility) ===== */
+    --graph-node-note: oklch(55.6% 0 0);
+    --graph-node-journal: oklch(43.9% 0 0);
+    --graph-node-task: oklch(70.8% 0 0);
+    --graph-node-project: oklch(37.1% 0 0);
+    --graph-node-tag: oklch(87% 0 0);
+    --graph-edge-default: oklch(70.8% 0 0);
+    --graph-edge-wikilink: oklch(70.8% 0 0);
+    --graph-edge-task-note: oklch(87% 0 0);
+    --graph-edge-project-task: oklch(70.8% 0 0);
+    --graph-edge-tag-cooccurrence: oklch(87% 0 0);
+    --graph-ghost-node: oklch(92.2% 0 0);
+    --graph-dimmed-node: oklch(92.2% 0 0);
+    --graph-edge-soft: oklch(87% 0 0);
+    --graph-bg: oklch(98.5% 0 0);
+    --graph-label-color: oklch(20.5% 0 0);
 
     /* ===== QUEUE LIST ===== */
-    --queue-bg: #eae8e1;
-    --queue-number-bg: #d4d1c5;
+    --queue-bg: oklch(97% 0 0);
+    --queue-number-bg: oklch(92.2% 0 0);
 
     /* ===== TASK COLORS ===== */
 
@@ -1154,76 +1155,76 @@
   }
 
   .white {
-    /* ===== BASE COLORS - White Mode ===== */
+    /* ===== BASE COLORS - White Mode (neutral; pure white canvas) ===== */
     --background: #ffffff;
-    --foreground: #37352f;
-    --surface: #f7f6f3;
-    --surface-active: #efedea;
+    --foreground: oklch(20.5% 0 0);
+    --surface: oklch(97% 0 0);
+    --surface-active: oklch(92.2% 0 0);
     --critic-review-card-hover-background: var(--surface-active);
     --critic-review-actions-background: var(--background);
 
-    /* ===== SEMANTIC PASTELS - White Mode ===== */
-    --card-sage: #dbeddb;
-    --card-rose: #ffe2dd;
-    --card-sand: #fdecc8;
-    --card-lavender: #e8deee;
-    --card-grey: #e3e2e0;
+    /* ===== CATEGORY CARD BACKGROUNDS - White Mode (neutralized) ===== */
+    --card-sage: oklch(97% 0 0);
+    --card-rose: oklch(97% 0 0);
+    --card-sand: oklch(97% 0 0);
+    --card-lavender: oklch(97% 0 0);
+    --card-grey: oklch(97% 0 0);
 
     /* ===== TYPOGRAPHY COLORS - White Mode ===== */
-    --text-primary: #37352f;
-    --text-secondary: #6b6966;
-    --text-tertiary: #9b9a97;
-    --text-bright: #37352f;
+    --text-primary: oklch(20.5% 0 0);
+    --text-secondary: oklch(43.9% 0 0);
+    --text-tertiary: oklch(55.6% 0 0);
+    --text-bright: oklch(14.5% 0 0);
 
-    /* ===== ACCENT COLORS ===== */
-    --accent-cyan: #0891b2;
-    --accent-purple: #7c3aed;
-    --accent-green: #16a34a;
-    --accent-orange: #ea580c;
+    /* ===== CATEGORY DOTS - White Mode (neutralized) ===== */
+    --accent-cyan: oklch(55.6% 0 0);
+    --accent-purple: oklch(55.6% 0 0);
+    --accent-green: oklch(55.6% 0 0);
+    --accent-orange: oklch(55.6% 0 0);
 
-    /* ===== UI SEMANTIC COLORS - White Mode ===== */
-    --muted: #f7f6f3;
-    --muted-foreground: #6b6966;
+    /* ===== UI SEMANTIC COLORS - White Mode (neutral ramp; destructive kept) ===== */
+    --muted: oklch(97% 0 0);
+    --muted-foreground: oklch(43.9% 0 0);
     --popover: #ffffff;
-    --popover-foreground: #37352f;
-    --border: #e3e2e0;
-    --input: #e3e2e0;
+    --popover-foreground: oklch(20.5% 0 0);
+    --border: oklch(92.2% 0 0);
+    --input: oklch(92.2% 0 0);
     --card: #ffffff;
-    --card-foreground: #37352f;
-    --primary: #37352f;
+    --card-foreground: oklch(20.5% 0 0);
+    --primary: oklch(20.5% 0 0);
     --primary-foreground: #ffffff;
-    --secondary: #f7f6f3;
-    --secondary-foreground: #37352f;
-    --accent: #f7f6f3;
-    --accent-foreground: #37352f;
+    --secondary: oklch(97% 0 0);
+    --secondary-foreground: oklch(20.5% 0 0);
+    --accent: oklch(97% 0 0);
+    --accent-foreground: oklch(20.5% 0 0);
     --destructive: #e03e3e;
     --destructive-foreground: #ffffff;
-    --ring: #9b9a97;
+    --ring: oklch(70.8% 0 0);
 
     /* ===== SHADOWS - White Mode (crisper than warm) ===== */
     --shadow-card: 0 1px 2px 0 rgb(0 0 0 / 0.04), 0 1px 3px 0 rgb(0 0 0 / 0.06);
     --shadow-card-hover: 0 4px 6px -1px rgb(0 0 0 / 0.08), 0 2px 4px -2px rgb(0 0 0 / 0.04);
 
-    /* ===== GRAPH VIEW COLORS - White Mode ===== */
-    --graph-node-note: #448c7c;
-    --graph-node-journal: #7c3aed;
-    --graph-node-task: #c87533;
-    --graph-node-project: #4a7a4a;
-    --graph-node-tag: #b07040;
-    --graph-edge-default: #9b9a97;
-    --graph-edge-wikilink: #9b9a97;
-    --graph-edge-task-note: #c4a46a;
-    --graph-edge-project-task: #9a8abd;
-    --graph-edge-tag-cooccurrence: #c4c2bc;
-    --graph-ghost-node: #d4d2cc;
-    --graph-dimmed-node: #e3e2e0;
-    --graph-edge-soft: #bfbdb6;
+    /* ===== GRAPH VIEW COLORS - White Mode (neutral mono-lightness ramp) ===== */
+    --graph-node-note: oklch(55.6% 0 0);
+    --graph-node-journal: oklch(43.9% 0 0);
+    --graph-node-task: oklch(70.8% 0 0);
+    --graph-node-project: oklch(37.1% 0 0);
+    --graph-node-tag: oklch(87% 0 0);
+    --graph-edge-default: oklch(70.8% 0 0);
+    --graph-edge-wikilink: oklch(70.8% 0 0);
+    --graph-edge-task-note: oklch(87% 0 0);
+    --graph-edge-project-task: oklch(70.8% 0 0);
+    --graph-edge-tag-cooccurrence: oklch(87% 0 0);
+    --graph-ghost-node: oklch(92.2% 0 0);
+    --graph-dimmed-node: oklch(92.2% 0 0);
+    --graph-edge-soft: oklch(87% 0 0);
     --graph-bg: #ffffff;
-    --graph-label-color: #37352f;
+    --graph-label-color: oklch(20.5% 0 0);
 
     /* ===== QUEUE LIST - White Mode ===== */
-    --queue-bg: #f7f6f3;
-    --queue-number-bg: #e3e2e0;
+    --queue-bg: oklch(97% 0 0);
+    --queue-number-bg: oklch(92.2% 0 0);
 
     /* ===== TASK COLORS - White Mode ===== */
 
@@ -1277,59 +1278,71 @@
     --font-heading: 'Space Grotesk Variable', system-ui, sans-serif;
     --font-mono: 'JetBrains Mono Variable', 'SF Mono', 'Fira Code', monospace;
 
-    /* ===== BASE COLORS - Dark Mode (Neutral Charcoal) ===== */
-    --background: #181919;
-    --foreground: #bcbab6;
-    --surface: #222222;
-    --surface-active: #2a2a2a;
-    --critic-review-card-hover-background: #202020;
-    --critic-review-actions-background: #191919;
+    /* ===== BASE COLORS - Dark Mode (Tailwind neutral ramp) ===== */
+    --background: oklch(14.5% 0 0);
+    /* neutral-950 */
+    --foreground: oklch(92.2% 0 0);
+    /* neutral-200 */
+    --surface: oklch(20.5% 0 0);
+    /* neutral-900 */
+    --surface-active: oklch(26.9% 0 0);
+    /* neutral-800 */
+    --critic-review-card-hover-background: oklch(20.5% 0 0);
+    --critic-review-actions-background: oklch(14.5% 0 0);
 
-    /* ===== SEMANTIC PASTELS - Dark Mode (Muted versions) ===== */
-    --card-sage: #1e261e;
-    --card-rose: #261e1e;
-    --card-sand: #26241e;
-    --card-lavender: #211e26;
-    --card-grey: #222222;
+    /* ===== CATEGORY CARD BACKGROUNDS - Dark Mode (neutralized) ===== */
+    --card-sage: oklch(20.5% 0 0);
+    --card-rose: oklch(20.5% 0 0);
+    --card-sand: oklch(20.5% 0 0);
+    --card-lavender: oklch(20.5% 0 0);
+    --card-grey: oklch(20.5% 0 0);
+    /* all neutral-900 */
 
     /* ===== TYPOGRAPHY COLORS - Dark Mode ===== */
-    --text-primary: #bcbab6;
-    --text-secondary: #bcbab6;
-    --text-tertiary: #ada9a3;
-    --text-bright: #dadada;
+    --text-primary: oklch(92.2% 0 0);
+    /* neutral-200 */
+    --text-secondary: oklch(87% 0 0);
+    /* neutral-300 */
+    --text-tertiary: oklch(70.8% 0 0);
+    /* neutral-400 */
+    --text-bright: oklch(97% 0 0);
+    /* neutral-100 */
 
-    /* ===== ACCENT COLORS (Same in dark mode) ===== */
-    --accent-cyan: #22d3ee;
-    --accent-purple: #a78bfa;
-    --accent-green: #4ade80;
-    --accent-orange: #fb923c;
+    /* ===== CATEGORY DOTS - Dark Mode (neutralized) ===== */
+    --accent-cyan: oklch(70.8% 0 0);
+    --accent-purple: oklch(70.8% 0 0);
+    --accent-green: oklch(70.8% 0 0);
+    --accent-orange: oklch(70.8% 0 0);
+    /* all neutral-400 */
 
-    /* ===== UI SEMANTIC COLORS - Dark Mode ===== */
-    --muted: #222222;
-    --muted-foreground: #ada9a3;
-    --popover: #1e1e1e;
-    --popover-foreground: #bcbab6;
-    --border: #2a2a2a;
-    --input: #333333;
-    --card: #222222;
-    --card-foreground: #bcbab6;
-    --primary: #e8e6e1;
-    --primary-foreground: #191919;
-    --secondary: #222222;
-    --secondary-foreground: #bcbab6;
-    --accent: #2a2a2a;
-    --accent-foreground: #bcbab6;
+    /* ===== UI SEMANTIC COLORS - Dark Mode (neutral ramp; destructive kept) ===== */
+    --muted: oklch(20.5% 0 0);
+    --muted-foreground: oklch(70.8% 0 0);
+    --popover: oklch(20.5% 0 0);
+    --popover-foreground: oklch(92.2% 0 0);
+    --border: oklch(26.9% 0 0);
+    --input: oklch(37.1% 0 0);
+    --card: oklch(20.5% 0 0);
+    --card-foreground: oklch(92.2% 0 0);
+    --primary: oklch(97% 0 0);
+    --primary-foreground: oklch(20.5% 0 0);
+    --secondary: oklch(20.5% 0 0);
+    --secondary-foreground: oklch(92.2% 0 0);
+    --accent: oklch(26.9% 0 0);
+    --accent-foreground: oklch(92.2% 0 0);
     --destructive: #dc2626;
     --destructive-foreground: #fafafa;
-    --ring: #6b6b6b;
+    --ring: oklch(43.9% 0 0);
 
-    /* ===== BORDER RADIUS (Same in dark mode) ===== */
+    /* ===== BORDER RADIUS (Global: clamped 8–12px, same in dark mode) ===== */
     --radius: 0.5rem;
-    --radius-sm: 0.375rem;
+    --radius-xs: 0.5rem;
+    --radius-sm: 0.5rem;
     --radius-md: 0.5rem;
     --radius-lg: 0.75rem;
-    --radius-xl: 1rem;
-    --radius-2xl: 1.25rem;
+    --radius-xl: 0.75rem;
+    --radius-2xl: 0.75rem;
+    --radius-3xl: 0.75rem;
     --radius-full: 9999px;
 
     /* ===== SHADOWS - Dark Mode ===== */
@@ -1341,26 +1354,26 @@
     --card-width: 280px;
     --card-height: 200px;
 
-    /* ===== GRAPH VIEW COLORS - Dark Mode ===== */
-    --graph-node-note: #5abfad;
-    --graph-node-journal: #a78bfa;
-    --graph-node-task: #e8a960;
-    --graph-node-project: #6aaa6a;
-    --graph-node-tag: #d4a070;
-    --graph-edge-default: #6b6966;
-    --graph-edge-wikilink: #6b6966;
-    --graph-edge-task-note: #b89a5a;
-    --graph-edge-project-task: #8a7aad;
-    --graph-edge-tag-cooccurrence: #5a5855;
-    --graph-ghost-node: #3a3840;
-    --graph-dimmed-node: #2a2830;
-    --graph-edge-soft: #6b6966;
-    --graph-bg: #0e0e10;
-    --graph-label-color: #bcbab6;
+    /* ===== GRAPH VIEW COLORS - Dark Mode (neutral mono-lightness ramp) ===== */
+    --graph-node-note: oklch(70.8% 0 0);
+    --graph-node-journal: oklch(55.6% 0 0);
+    --graph-node-task: oklch(87% 0 0);
+    --graph-node-project: oklch(43.9% 0 0);
+    --graph-node-tag: oklch(92.2% 0 0);
+    --graph-edge-default: oklch(43.9% 0 0);
+    --graph-edge-wikilink: oklch(43.9% 0 0);
+    --graph-edge-task-note: oklch(37.1% 0 0);
+    --graph-edge-project-task: oklch(43.9% 0 0);
+    --graph-edge-tag-cooccurrence: oklch(37.1% 0 0);
+    --graph-ghost-node: oklch(26.9% 0 0);
+    --graph-dimmed-node: oklch(26.9% 0 0);
+    --graph-edge-soft: oklch(37.1% 0 0);
+    --graph-bg: oklch(14.5% 0 0);
+    --graph-label-color: oklch(92.2% 0 0);
 
     /* ===== QUEUE LIST - Dark Mode ===== */
-    --queue-bg: #161618;
-    --queue-number-bg: #2a2a2e;
+    --queue-bg: oklch(14.5% 0 0);
+    --queue-number-bg: oklch(26.9% 0 0);
 
     /* ===== TASK COLORS - Dark Mode ===== */
 
@@ -1460,7 +1473,7 @@ div.react-sigma {
   h4,
   h5,
   h6 {
-    font-weight: 600;
+    font-weight: 500;
     line-height: 1.3;
     letter-spacing: -0.01em;
   }
@@ -2042,7 +2055,8 @@ del.bn-inline-content {
 :root,
 .white,
 .dark {
-  --default-user-accent-color: #f97316;
+  --default-user-accent-color: oklch(43.9% 0 0);
+  /* neutral-600 — out-of-box accent; users may still pick their own via --user-accent-color */
   --tint: var(--user-accent-color, var(--default-user-accent-color));
   --tint-foreground: #ffffff;
   --tint-hover: color-mix(in srgb, var(--tint) 85%, black);
@@ -2054,57 +2068,57 @@ del.bn-inline-content {
 }
 
 :root {
-  /* ===== SIDEBAR THEME - Warm Editorial Palette ===== */
-  --sidebar: #efefe9;
-  --sidebar-foreground: #8a857a;
-  --sidebar-primary: #1a1917;
-  --sidebar-primary-foreground: #edeae4;
+  /* ===== SIDEBAR THEME - Neutral (light) ===== */
+  --sidebar: oklch(97% 0 0);
+  --sidebar-foreground: oklch(55.6% 0 0);
+  --sidebar-primary: oklch(20.5% 0 0);
+  --sidebar-primary-foreground: oklch(98.5% 0 0);
   --sidebar-accent: rgba(0, 0, 0, 0.05);
   --sidebar-accent-foreground: var(--sidebar-foreground);
-  --sidebar-border: #d9d5ce;
+  --sidebar-border: oklch(92.2% 0 0);
   --sidebar-ring: var(--tint);
-  --sidebar-muted: #b5b0a6;
+  --sidebar-muted: oklch(70.8% 0 0);
   --sidebar-terracotta: var(--tint);
-  --sidebar-text-folder: #3d3a35;
-  --sidebar-text-child: #5c5850;
-  --sidebar-dot-inactive: #d9d5ce;
+  --sidebar-text-folder: oklch(37.1% 0 0);
+  --sidebar-text-child: oklch(43.9% 0 0);
+  --sidebar-dot-inactive: oklch(87% 0 0);
   --sidebar-surface: rgba(0, 0, 0, 0.04);
 }
 
 .white {
-  /* ===== SIDEBAR THEME - Clean White Palette ===== */
-  --sidebar: #f9f8f7;
-  --sidebar-foreground: #5f5e59;
-  --sidebar-primary: #37352f;
+  /* ===== SIDEBAR THEME - Neutral (white mode) ===== */
+  --sidebar: oklch(98.5% 0 0);
+  --sidebar-foreground: oklch(43.9% 0 0);
+  --sidebar-primary: oklch(20.5% 0 0);
   --sidebar-primary-foreground: #ffffff;
   --sidebar-accent: rgba(0, 0, 0, 0.04);
   --sidebar-accent-foreground: var(--sidebar-foreground);
-  --sidebar-border: #e9e9e7;
+  --sidebar-border: oklch(92.2% 0 0);
   --sidebar-ring: var(--tint);
-  --sidebar-muted: #b0afab;
+  --sidebar-muted: oklch(70.8% 0 0);
   --sidebar-terracotta: var(--tint);
-  --sidebar-text-folder: #37352f;
-  --sidebar-text-child: #6b6966;
-  --sidebar-dot-inactive: #e3e2e0;
+  --sidebar-text-folder: oklch(26.9% 0 0);
+  --sidebar-text-child: oklch(43.9% 0 0);
+  --sidebar-dot-inactive: oklch(92.2% 0 0);
   --sidebar-surface: rgba(0, 0, 0, 0.03);
 }
 
 .dark {
-  /* ===== SIDEBAR THEME - Neutral Charcoal ===== */
-  --sidebar: #1a1a1a;
-  --sidebar-foreground: #b5b3ae;
-  --sidebar-primary: #e8e5df;
-  --sidebar-primary-foreground: #202020;
-  --sidebar-accent: #2a2a2a;
+  /* ===== SIDEBAR THEME - Neutral (dark) ===== */
+  --sidebar: oklch(20.5% 0 0);
+  --sidebar-foreground: oklch(87% 0 0);
+  --sidebar-primary: oklch(97% 0 0);
+  --sidebar-primary-foreground: oklch(20.5% 0 0);
+  --sidebar-accent: oklch(26.9% 0 0);
   --sidebar-accent-foreground: var(--sidebar-primary);
-  --sidebar-border: #333333;
+  --sidebar-border: oklch(26.9% 0 0);
   --sidebar-ring: var(--tint);
-  --sidebar-muted: #6b6b6b;
+  --sidebar-muted: oklch(55.6% 0 0);
   --sidebar-terracotta: var(--tint);
-  --sidebar-text-folder: #c5c0b8;
-  --sidebar-text-child: #9a958d;
-  --sidebar-dot-inactive: #444444;
-  --sidebar-surface: #2a2a2a;
+  --sidebar-text-folder: oklch(87% 0 0);
+  --sidebar-text-child: oklch(70.8% 0 0);
+  --sidebar-dot-inactive: oklch(37.1% 0 0);
+  --sidebar-surface: oklch(26.9% 0 0);
 }
 
 @theme inline {
@@ -2213,12 +2227,25 @@ del.bn-inline-content {
   --color-sidebar-dot-inactive: var(--sidebar-dot-inactive);
   --color-sidebar-surface: var(--sidebar-surface);
 
-  /* ===== BORDER RADIUS ===== */
+  /* ===== FONT WEIGHTS (global: 2 weights only — 400 body, 500 headings/emphasis) ===== */
+  --font-weight-thin: 400;
+  --font-weight-extralight: 400;
+  --font-weight-light: 400;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 500;
+  --font-weight-bold: 500;
+  --font-weight-extrabold: 500;
+  --font-weight-black: 500;
+
+  /* ===== BORDER RADIUS (global: clamped 8–12px; full kept) ===== */
+  --radius-xs: var(--radius-xs);
   --radius-sm: var(--radius-sm);
   --radius-md: var(--radius-md);
   --radius-lg: var(--radius-lg);
   --radius-xl: var(--radius-xl);
   --radius-2xl: var(--radius-2xl);
+  --radius-3xl: var(--radius-3xl);
   --radius-full: var(--radius-full);
 
   /* ===== SHADOWS ===== */
@@ -2462,7 +2489,7 @@ del.bn-inline-content {
 /* Journal section label styling */
 .journal-section-label {
   font-size: 0.65rem;
-  font-weight: 600;
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.15em;
   color: var(--text-tertiary);

--- a/apps/desktop/src/renderer/src/components/onboarding/tour.css
+++ b/apps/desktop/src/renderer/src/components/onboarding/tour.css
@@ -9,7 +9,7 @@
 
 .driver-popover-title {
   font-size: 15px;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .driver-popover-description {

--- a/docs/superpowers/specs/2026-07-16-global-design-constraints-design.md
+++ b/docs/superpowers/specs/2026-07-16-global-design-constraints-design.md
@@ -1,0 +1,122 @@
+# Global design constraints — 2 weights · neutral palette · 8–12px radius
+
+## Goal
+
+Enforce three global design rules across the desktop Electron app:
+
+1. **Typography** — only 2 font weights: `400` (regular) for body, `500` (medium) for headings + emphasis.
+2. **Colors** — Tailwind `neutral` ramp as the foundation. Ignore the PRODUCT.md warm paper/ink/terracotta brand.
+3. **Radius** — every corner 8–12px, no more no less. `rounded-full` (avatars/pills/toggles) is the one exception.
+
+## Mechanism (why this is "global")
+
+Tailwind v4 utilities resolve to overridable `@theme` tokens. Confirmed in `apps/desktop/src/renderer/src/assets/base.css`:
+
+- `--radius-{sm,md,lg,xl,2xl,full}` mapped at `@theme inline` (base.css:2217) → every `rounded-*` utility reads these.
+- `--font-weight-*` (Tailwind default namespace) → every `font-*` utility reads these.
+- Color tokens (`--background`, `--foreground`, `--border`, …) defined per theme block and exposed via `@theme inline`.
+
+**So the change is a token remap only. Zero component/TSX files touched. Fully reversible via `git revert`.** All 1000+ existing `rounded-*` / `font-*` / color usages conform automatically.
+
+Scope = `base.css` (three theme blocks: `:root` warm-default, `.white`, `.dark`; three `--sidebar-*` sub-blocks; the `@theme inline` block) + 5 raw `font-weight:600` declarations.
+
+## Rule 1 — Typography (2 weights)
+
+Add to `@theme` (collapses the higher weights globally):
+
+```
+--font-weight-thin:       400
+--font-weight-extralight:  400
+--font-weight-light:       400   ← collapses 1 font-light use
+--font-weight-normal:      400   body
+--font-weight-medium:      500   headings + emphasis
+--font-weight-semibold:    500   ← was 600, 154 uses auto-collapse
+--font-weight-bold:        500   ← was 700, 19 uses auto-collapse
+--font-weight-extrabold:   500
+--font-weight-black:       500
+```
+
+Plus edit the 5 raw `font-weight: 600` lines in base.css (heading overrides at ~189, 741, 1463, 2465, and one more) → `500`. Result: only 400/500 render anywhere.
+
+## Rule 2 — Radius (8–12px, keep full)
+
+Remap in both `:root` and `.dark` radius blocks (`.white` inherits `:root`):
+
+```
+--radius-xs:  0.5rem  (8px)   ← was ~2px
+--radius-sm:  0.5rem  (8px)   ← was 6px
+--radius:     0.5rem  (8px)   (keep) — also covers bare `rounded`
+--radius-md:  0.5rem  (8px)   (keep)
+--radius-lg:  0.75rem (12px)  (keep)
+--radius-xl:  0.75rem (12px)  ← was 16px
+--radius-2xl: 0.75rem (12px)  ← was 20px
+--radius-3xl: 0.75rem (12px)  (guard, if referenced)
+--radius-full: 9999px         (keep ✓)
+```
+
+Add `--radius-xs` + `--radius-3xl` to the `@theme inline` map so the `rounded-xs` (13 uses) / `rounded-3xl` utilities pick them up. If any bare `rounded` utility falls outside the token (TW v4 default 4px), clamp via the `--radius` token above.
+
+## Rule 3 — Colors (Tailwind neutral)
+
+Tailwind v4 `neutral` ramp (oklch, pulled from tailwindcss.com/docs/colors via Context7):
+
+```
+50  oklch(98.5% 0 0)   300 oklch(87% 0 0)     700 oklch(37.1% 0 0)
+100 oklch(97% 0 0)     400 oklch(70.8% 0 0)   800 oklch(26.9% 0 0)
+200 oklch(92.2% 0 0)   500 oklch(55.6% 0 0)   900 oklch(20.5% 0 0)
+                       600 oklch(43.9% 0 0)   950 oklch(14.5% 0 0)
+```
+
+### Structural chrome → neutral
+
+| token                                   | `:root` / `.white` (light) | `.dark`             |
+| --------------------------------------- | -------------------------- | ------------------- |
+| background                              | 50 (`.white` = `#fff`)     | 950                 |
+| surface                                 | 100                        | 900                 |
+| surface-active                          | 200                        | 800                 |
+| foreground / text-primary               | 900                        | 200                 |
+| text-secondary                          | 600                        | 300                 |
+| text-tertiary / muted-foreground        | 500                        | 400                 |
+| text-bright                             | 950                        | 100                 |
+| muted                                   | 100                        | 900                 |
+| popover(+fg)                            | 50 / 900                   | 900 / 200           |
+| border                                  | 200                        | 800                 |
+| input                                   | 200                        | 700                 |
+| card(+fg)                               | `#fff` / 900               | 900 / 200           |
+| primary(+fg)                            | 900 / 50                   | 100 / 900           |
+| secondary(+fg)                          | 100 / 900                  | 900 / 200           |
+| accent(+fg)                             | 100 / 900                  | 800 / 200           |
+| ring                                    | 400                        | 600                 |
+| sidebar block (bg/fg/border/muted/etc.) | neutral equivalents        | neutral equivalents |
+| queue-bg / queue-number-bg              | 100 / 200                  | 900 / 800           |
+
+### Decorative brand color → neutral
+
+- **Category pastels** (`--card-sage/rose/sand/lavender/grey`) → uniform `neutral-100` (light) / `neutral-900` (dark). Category color affordance dropped (accepted).
+- **Accent dots** (`--accent-cyan/purple/green/orange`) → `neutral-500`.
+- **Graph node types** (`--graph-node-*`) → mono _lightness_ ramp so the graph stays legible without hue: note→500, journal→600, task→400, project→700, tag→300; edges→300/400, ghost/dimmed→200, bg→50/950, label→foreground.
+- **Default user accent** `--default-user-accent-color: #f97316` → `neutral-600`. The user-accent _feature_ stays — only the out-of-box default goes neutral. `--tint-foreground` stays `#fff` (AA on neutral-600).
+
+### KEEP colored (functional / status — untouched)
+
+- `--destructive` (+fg)
+- entire `--task-*` group: priority (urgent/high/medium/low/none), due (overdue/today/tomorrow/upcoming), complete, progress, star, repeat, token-date/project, checkbox-done
+- find-in-page highlight (`main.css` `::highlight(find-*)` ambers)
+
+## Verification
+
+- `pnpm --filter @memry/desktop typecheck` — no type impact (CSS only), but run.
+- `pnpm lint` — flat ESLint; CSS token edits are lint-neutral.
+- `git diff --check` — whitespace.
+- Visual: `pnpm dev` → toggle light / white / dark, check: headings look medium not bold; all corners 8–12px except circular avatars/pills; UI is gray with red/amber/blue task+error signals still colored.
+- No `pnpm i18n:check` / IPC / migration impact.
+
+## Backward compatibility (LIVE BETA)
+
+Purely visual token change. No DB schema, sync protocol, IPC contract, vault format, or settings-shape change → safe for every existing install. No migration. Reversible with one `git revert`.
+
+## Out of scope
+
+- `apps/landing` (separate brand surface — untouched).
+- Physical → logical component class rewrites (token remap makes them unnecessary).
+- Rewriting `font-semibold`/`rounded-xl` class names in TSX (token remap handles them; a codemod is a future cleanup, per Weights decision "token remap only").


### PR DESCRIPTION
## Summary

Enforces three global design constraints across the desktop app, entirely via **design-token remap** in `apps/desktop/src/renderer/src/assets/base.css` — **zero component/TSX files changed**, fully reversible.

| Rule | Mechanism | Result |
|---|---|---|
| **Two font weights** | `@theme` `--font-weight-*` tokens + 5 raw `600`→`500` | Only 400 (body) / 500 (headings + emphasis) render anywhere |
| **Radius 8–12px** | `--radius-*` remap across all theme scopes | xs/sm/md → 8px · lg/xl/2xl/3xl → 12px · `rounded-full` kept (avatars/pills/toggles) |
| **Neutral palette** | Tailwind `neutral` oklch ramp across `:root` / `.white` / `.dark` + sidebars + default accent | Structural chrome, category pastels, dots and graph nodes → neutral (graph uses a mono-lightness ramp for legibility). Functional signals kept colored: `--destructive`, all `--task-*` (priority / due / status), find-in-page highlight. |

Tailwind v4 utilities resolve to overridable `@theme` tokens, so redefining ~20 tokens conforms all 1000+ existing `rounded-*` / `font-*` / color usages with no per-component edits.

## Verification

- Renderer CSS compiles clean through the real Tailwind v4 pipeline.
- No `font-weight: 600/700/bold` remains anywhere.
- Radius tokens confirmed 8px floor / 12px ceil / full kept.
- 174 neutral `oklch` values; `--destructive` and `--task-*` tokens intact.
- Live visual smoke across light/white/dark: pending.

## Compatibility

Purely visual token change — no DB schema, sync protocol, IPC contract, vault format, or settings-shape change. Safe for every existing install. One revert fully undoes it.

Design record: `docs/superpowers/specs/2026-07-16-global-design-constraints-design.md`
