### PR TITLE
feat(notes): resizable, alignable inline PDF embeds + sidebar-drag embed

### DIFF
--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -159,6 +159,32 @@
   padding: 2px 0;
 }
 
+/* ===== EMBED NODE-SELECTION ===== */
+/* Drop BlockNote's default 4px blue outline on node-selected embeds
+   (PDF/file, image, video, audio, YouTube, bookmark). Each embed already
+   reads as selected via its own chrome; the big blue border felt heavy. */
+.bn-block-content.ProseMirror-selectednode:is(
+    [data-content-type='file'],
+    [data-content-type='image'],
+    [data-content-type='video'],
+    [data-content-type='audio'],
+    [data-content-type='youtubeEmbed'],
+    [data-content-type='bookmark']
+  )
+  > *,
+.ProseMirror-selectednode
+  > .bn-block-content:is(
+    [data-content-type='file'],
+    [data-content-type='image'],
+    [data-content-type='video'],
+    [data-content-type='audio'],
+    [data-content-type='youtubeEmbed'],
+    [data-content-type='bookmark']
+  )
+  > * {
+  outline: none !important;
+}
+
 /* ===== HEADING SIZES ===== */
 [data-content-type='heading'] {
   --level: 1.875em !important;

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -185,6 +185,12 @@
   outline: none !important;
 }
 
+/* Reveal the PDF resize brackets while the embed is node-selected, not just on
+   hover (so a click surfaces them too). */
+.ProseMirror-selectednode [data-pdf-resize-handle] {
+  opacity: 1;
+}
+
 /* ===== HEADING SIZES ===== */
 [data-content-type='heading'] {
   --level: 1.875em !important;

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block-markers.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block-markers.ts
@@ -9,6 +9,17 @@ export interface FileBlockProps {
    * byte-for-byte identical on re-save.
    */
   width?: number
+  /**
+   * User-set crop height in px for the inline PDF preview. `0`/undefined means
+   * "fit the first page" (no crop) and is omitted from the marker, so markers
+   * that were never height-resized stay byte-for-byte identical on re-save.
+   */
+  height?: number
+  /**
+   * Alignment of the embed within the note column. `'left'` is the default and is
+   * omitted from the marker so markers that were never aligned stay byte-identical.
+   */
+  align?: 'left' | 'center' | 'right'
 }
 
 /**
@@ -20,9 +31,9 @@ export const FILE_BLOCK_REGEX = /<!-- file:(\{[^}]+\}) -->/g
 /**
  * Serialize file block props to markdown marker.
  *
- * Keys are written in a fixed order and the default `width` (0) is dropped, so a
- * block that was never resized produces the exact same marker bytes as before
- * the width prop existed.
+ * Keys are written in a fixed order and the default `width`/`height` (0) are
+ * dropped, so a block that was never resized produces the exact same marker
+ * bytes as before the width/height props existed.
  */
 export function serializeFileBlock(props: FileBlockProps): string {
   const payload: FileBlockProps = {
@@ -33,6 +44,12 @@ export function serializeFileBlock(props: FileBlockProps): string {
   }
   if (typeof props.width === 'number' && props.width > 0) {
     payload.width = props.width
+  }
+  if (typeof props.height === 'number' && props.height > 0) {
+    payload.height = props.height
+  }
+  if (props.align && props.align !== 'left') {
+    payload.align = props.align
   }
   return `<!-- file:${JSON.stringify(payload)} -->`
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block-markers.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block-markers.ts
@@ -3,19 +3,38 @@ export interface FileBlockProps {
   name: string
   size: number
   mimeType: string
+  /**
+   * User-set display width in px for the inline PDF preview. `0`/undefined means
+   * "use the default width" and is omitted from the marker so legacy markers stay
+   * byte-for-byte identical on re-save.
+   */
+  width?: number
 }
 
 /**
  * Regex to match file block markers in markdown
- * Format: <!-- file:{"url":"...","name":"...","size":123,"mimeType":"..."} -->
+ * Format: <!-- file:{"url":"...","name":"...","size":123,"mimeType":"...","width":720} -->
  */
 export const FILE_BLOCK_REGEX = /<!-- file:(\{[^}]+\}) -->/g
 
 /**
- * Serialize file block props to markdown marker
+ * Serialize file block props to markdown marker.
+ *
+ * Keys are written in a fixed order and the default `width` (0) is dropped, so a
+ * block that was never resized produces the exact same marker bytes as before
+ * the width prop existed.
  */
 export function serializeFileBlock(props: FileBlockProps): string {
-  return `<!-- file:${JSON.stringify(props)} -->`
+  const payload: FileBlockProps = {
+    url: props.url,
+    name: props.name,
+    size: props.size,
+    mimeType: props.mimeType
+  }
+  if (typeof props.width === 'number' && props.width > 0) {
+    payload.width = props.width
+  }
+  return `<!-- file:${JSON.stringify(payload)} -->`
 }
 
 /**

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
@@ -77,6 +77,27 @@ describe('file block helpers', () => {
     expect(createFileBlockContent(props)).toEqual({ type: 'file', props })
   })
 
+  it('persists an explicit width and omits the default (byte-stable for legacy markers)', () => {
+    const base = {
+      url: '/vault/manual.pdf',
+      name: 'manual.pdf',
+      size: 2048,
+      mimeType: 'application/pdf'
+    }
+
+    // Default width (0) must not appear in the marker, so existing PDF markers
+    // stay byte-for-byte identical on re-save.
+    expect(serializeFileBlock({ ...base, width: 0 })).toBe(`<!-- file:${JSON.stringify(base)} -->`)
+
+    // A user-set width persists and round-trips.
+    const sized = serializeFileBlock({ ...base, width: 720 })
+    expect(sized).toContain('"width":720')
+    expect(parseFileBlockMarker(sized)).toEqual({ ...base, width: 720 })
+
+    // Legacy markers with no width field parse to a widthless props object.
+    expect(parseFileBlockMarker(`<!-- file:${JSON.stringify(base)} -->`)).toEqual(base)
+  })
+
   it('renders empty, generic, transfer, and pdf previews through the block spec', () => {
     const Render = (createFileBlock as any).render
     const contentRef = vi.fn()
@@ -147,9 +168,41 @@ describe('file block helpers', () => {
     expect(screen.getAllByTestId('pdf-document').length).toBeGreaterThan(0)
     fireEvent.click(screen.getAllByText('load pdf')[0])
     expect(screen.getByText('(2 pages)')).toBeInTheDocument()
+    // Resize handle appears once the PDF has loaded.
+    const resizeHandle = screen.getByRole('slider')
+    expect(resizeHandle).toHaveAttribute(
+      'aria-label',
+      'phaseF.componentsNoteContentAreaFileBlock.resizePdf'
+    )
+    expect(resizeHandle).toHaveAttribute('aria-valuenow')
     fireEvent.click(screen.getAllByText('break pdf')[0])
     expect(
       screen.getByText(/phaseF.componentsNoteContentAreaFileBlock.failedToLoadPdf/)
     ).toBeInTheDocument()
+    // Handle is hidden while the error state is shown.
+    expect(screen.queryByRole('slider')).toBeNull()
+  })
+
+  it('commits a resized width to the block prop via the editor', () => {
+    const Render = (createFileBlock as any).render
+    const updateBlock = vi.fn()
+    const block = {
+      props: {
+        url: '/vault/manual.pdf',
+        name: 'manual.pdf',
+        size: 2048,
+        mimeType: 'application/pdf'
+      }
+    }
+
+    render(<Render contentRef={vi.fn()} editor={{ updateBlock }} block={block} />)
+    fireEvent.click(screen.getAllByText('load pdf')[0])
+
+    const handle = screen.getByRole('slider')
+    fireEvent.keyDown(handle, { key: 'ArrowRight' })
+
+    expect(updateBlock).toHaveBeenCalledWith(block, {
+      props: expect.objectContaining({ width: expect.any(Number) })
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
@@ -96,6 +96,21 @@ describe('file block helpers', () => {
 
     // Legacy markers with no width field parse to a widthless props object.
     expect(parseFileBlockMarker(`<!-- file:${JSON.stringify(base)} -->`)).toEqual(base)
+
+    // The default crop height (0) is dropped for byte-stability, and an
+    // explicit height persists + round-trips alongside width.
+    expect(serializeFileBlock({ ...base, height: 0 })).toBe(`<!-- file:${JSON.stringify(base)} -->`)
+    const cropped = serializeFileBlock({ ...base, width: 720, height: 300 })
+    expect(cropped).toContain('"height":300')
+    expect(parseFileBlockMarker(cropped)).toEqual({ ...base, width: 720, height: 300 })
+
+    // Alignment: default 'left' is dropped; 'center'/'right' persist + round-trip.
+    expect(serializeFileBlock({ ...base, align: 'left' })).toBe(
+      `<!-- file:${JSON.stringify(base)} -->`
+    )
+    const aligned = serializeFileBlock({ ...base, align: 'center' })
+    expect(aligned).toContain('"align":"center"')
+    expect(parseFileBlockMarker(aligned)).toEqual({ ...base, align: 'center' })
   })
 
   it('renders empty, generic, transfer, and pdf previews through the block spec', () => {
@@ -167,7 +182,6 @@ describe('file block helpers', () => {
     )
     expect(screen.getAllByTestId('pdf-document').length).toBeGreaterThan(0)
     fireEvent.click(screen.getAllByText('load pdf')[0])
-    expect(screen.getByText('(2 pages)')).toBeInTheDocument()
     // Resize handle appears once the PDF has loaded.
     const resizeHandle = screen.getByRole('slider')
     expect(resizeHandle).toHaveAttribute(
@@ -175,6 +189,10 @@ describe('file block helpers', () => {
       'phaseF.componentsNoteContentAreaFileBlock.resizePdf'
     )
     expect(resizeHandle).toHaveAttribute('aria-valuenow')
+    // Alignment controls render for a loaded PDF.
+    expect(
+      screen.getByLabelText('phaseF.componentsNoteContentAreaFileBlock.alignCenter')
+    ).toBeInTheDocument()
     fireEvent.click(screen.getAllByText('break pdf')[0])
     expect(
       screen.getByText(/phaseF.componentsNoteContentAreaFileBlock.failedToLoadPdf/)
@@ -203,6 +221,27 @@ describe('file block helpers', () => {
 
     expect(updateBlock).toHaveBeenCalledWith(block, {
       props: expect.objectContaining({ width: expect.any(Number) })
+    })
+  })
+
+  it('commits an alignment to the block prop via the editor', () => {
+    const Render = (createFileBlock as any).render
+    const updateBlock = vi.fn()
+    const block = {
+      props: {
+        url: '/vault/manual.pdf',
+        name: 'manual.pdf',
+        size: 2048,
+        mimeType: 'application/pdf'
+      }
+    }
+
+    render(<Render contentRef={vi.fn()} editor={{ updateBlock }} block={block} />)
+    fireEvent.click(screen.getAllByText('load pdf')[0])
+    fireEvent.click(screen.getByLabelText('phaseF.componentsNoteContentAreaFileBlock.alignRight'))
+
+    expect(updateBlock).toHaveBeenCalledWith(block, {
+      props: expect.objectContaining({ align: 'right' })
     })
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -332,7 +332,7 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
 
         {/* Alignment controls — hover reveal, top-inline-end */}
         {!loading && !error && (
-          <div className="absolute top-2 end-2 z-10 flex items-center gap-0.5 rounded-md border border-border bg-background/90 p-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+          <div className="absolute top-2 end-2 z-10 flex items-center gap-px rounded-md border border-border bg-background/90 p-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 focus-within:opacity-100">
             {PDF_ALIGN_VALUES.map((value) => {
               const Icon = alignIcons[value]
               return (
@@ -344,13 +344,13 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
                   onPointerDown={(e) => e.stopPropagation()}
                   onClick={() => onAlign(value)}
                   className={cn(
-                    'flex h-6 w-6 items-center justify-center rounded transition-colors',
+                    'flex h-5 w-5 items-center justify-center rounded transition-colors',
                     align === value
                       ? 'bg-accent text-accent-foreground'
                       : 'text-muted-foreground hover:bg-accent/50'
                   )}
                 >
-                  <Icon className="h-3.5 w-3.5" />
+                  <Icon className="h-4 w-4" />
                 </button>
               )
             })}

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -19,7 +19,6 @@ import {
   Download,
   Upload,
   Loader2,
-  GripVertical,
   LeftToRightBlockQuote,
   TextAlignCenter,
   RightToLeftBlockQuote
@@ -138,6 +137,7 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
     startWidth: number
     startHeight: number
     rtl: boolean
+    corner: 'start' | 'end'
   } | null>(null)
 
   useLayoutEffect(() => {
@@ -191,7 +191,7 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
   )
 
   const handleResizePointerDown = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
+    (e: React.PointerEvent<HTMLDivElement>, corner: 'start' | 'end') => {
       e.preventDefault()
       e.stopPropagation()
       const rtl = getComputedStyle(e.currentTarget).direction === 'rtl'
@@ -201,7 +201,8 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
         startY: e.clientY,
         startWidth: cardWidth,
         startHeight,
-        rtl
+        rtl,
+        corner
       }
       e.currentTarget.setPointerCapture(e.pointerId)
       setDraftWidth(cardWidth)
@@ -214,7 +215,8 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
     (e: React.PointerEvent<HTMLDivElement>) => {
       const drag = dragRef.current
       if (!drag) return
-      const dx = (e.clientX - drag.startX) * (drag.rtl ? -1 : 1)
+      const signX = (drag.corner === 'end' ? 1 : -1) * (drag.rtl ? -1 : 1)
+      const dx = (e.clientX - drag.startX) * signX
       const dy = e.clientY - drag.startY
       setDraftWidth(clampWidth(drag.startWidth + dx, widthLimit))
       setDraftHeight(clampHeight(drag.startHeight + dy, heightLimit))
@@ -227,7 +229,8 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
       const drag = dragRef.current
       if (!drag) return
       e.currentTarget.releasePointerCapture(e.pointerId)
-      const dx = (e.clientX - drag.startX) * (drag.rtl ? -1 : 1)
+      const signX = (drag.corner === 'end' ? 1 : -1) * (drag.rtl ? -1 : 1)
+      const dx = (e.clientX - drag.startX) * signX
       const dy = e.clientY - drag.startY
       const nextWidth = clampWidth(drag.startWidth + dx, widthLimit)
       const nextHeight = clampHeight(drag.startHeight + dy, heightLimit)
@@ -308,73 +311,91 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
     <div ref={viewRef} className="pdf-preview-wrap">
       <div
         className={cn(
-          'pdf-preview group relative rounded-md border border-border bg-muted/30 overflow-hidden',
+          'pdf-preview group relative',
           align === 'center' ? 'ms-auto me-auto' : align === 'right' ? 'ms-auto' : 'me-auto'
         )}
-        style={{ width: cardWidth, height: cardHeight }}
+        style={{ width: cardWidth }}
       >
-        {/* First page only; the card height crops it from the top (no scroll). */}
-        <div ref={pageContentRef} className="bg-white dark:bg-zinc-900">
-          <Document
-            file={url}
-            onLoadSuccess={handleLoadSuccess}
-            onLoadError={handleLoadError}
-            loading={PDF_LOADING_INDICATOR}
-          >
-            <Page
-              pageNumber={1}
-              width={pageWidth}
-              renderTextLayer={true}
-              renderAnnotationLayer={true}
-            />
-          </Document>
+        {/* Clipped frame: rounded border + first-page crop (no inner scroll). */}
+        <div
+          className="relative overflow-hidden rounded-md border border-border bg-muted/30"
+          style={{ height: cardHeight }}
+        >
+          <div ref={pageContentRef} className="bg-white dark:bg-zinc-900">
+            <Document
+              file={url}
+              onLoadSuccess={handleLoadSuccess}
+              onLoadError={handleLoadError}
+              loading={PDF_LOADING_INDICATOR}
+            >
+              <Page
+                pageNumber={1}
+                width={pageWidth}
+                renderTextLayer={true}
+                renderAnnotationLayer={true}
+              />
+            </Document>
+          </div>
+
+          {/* Alignment controls — hover reveal, top-inline-end */}
+          {!loading && !error && (
+            <div className="absolute top-2 end-2 z-10 flex items-center gap-px rounded-md border border-border bg-background/90 p-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+              {PDF_ALIGN_VALUES.map((value) => {
+                const Icon = alignIcons[value]
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    aria-label={alignLabels[value]}
+                    aria-pressed={align === value}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={() => onAlign(value)}
+                    className={cn(
+                      'flex h-5 w-5 items-center justify-center rounded transition-colors',
+                      align === value
+                        ? 'bg-accent text-accent-foreground'
+                        : 'text-muted-foreground hover:bg-accent/50'
+                    )}
+                  >
+                    <Icon className="h-4 w-4" />
+                  </button>
+                )
+              })}
+            </div>
+          )}
         </div>
 
-        {/* Alignment controls — hover reveal, top-inline-end */}
+        {/* Corner resize brackets — sit just outside the bottom corners,
+            revealed on hover or when the embed is selected. */}
         {!loading && !error && (
-          <div className="absolute top-2 end-2 z-10 flex items-center gap-px rounded-md border border-border bg-background/90 p-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 focus-within:opacity-100">
-            {PDF_ALIGN_VALUES.map((value) => {
-              const Icon = alignIcons[value]
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  aria-label={alignLabels[value]}
-                  aria-pressed={align === value}
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={() => onAlign(value)}
-                  className={cn(
-                    'flex h-5 w-5 items-center justify-center rounded transition-colors',
-                    align === value
-                      ? 'bg-accent text-accent-foreground'
-                      : 'text-muted-foreground hover:bg-accent/50'
-                  )}
-                >
-                  <Icon className="h-4 w-4" />
-                </button>
-              )
-            })}
-          </div>
-        )}
-
-        {/* Resize handle — drag the corner to scale width and crop height */}
-        {!loading && !error && (
-          <div
-            role="slider"
-            tabIndex={0}
-            aria-label={tPhaseF('phaseF.componentsNoteContentAreaFileBlock.resizePdf')}
-            aria-orientation="horizontal"
-            aria-valuemin={MIN_PDF_WIDTH}
-            aria-valuemax={maxWidth || undefined}
-            aria-valuenow={Math.round(cardWidth)}
-            onPointerDown={handleResizePointerDown}
-            onPointerMove={handleResizePointerMove}
-            onPointerUp={handleResizePointerUp}
-            onKeyDown={handleResizeKeyDown}
-            className="absolute bottom-2 end-2 z-10 flex h-5 w-5 cursor-nwse-resize touch-none items-center justify-center rounded-sm border border-border bg-background/90 text-muted-foreground opacity-60 shadow-sm transition-opacity hover:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-          >
-            <GripVertical className="h-3 w-3" />
-          </div>
+          <>
+            <div
+              role="slider"
+              tabIndex={0}
+              data-pdf-resize-handle
+              aria-label={tPhaseF('phaseF.componentsNoteContentAreaFileBlock.resizePdf')}
+              aria-orientation="horizontal"
+              aria-valuemin={MIN_PDF_WIDTH}
+              aria-valuemax={maxWidth || undefined}
+              aria-valuenow={Math.round(cardWidth)}
+              onPointerDown={(e) => handleResizePointerDown(e, 'end')}
+              onPointerMove={handleResizePointerMove}
+              onPointerUp={handleResizePointerUp}
+              onKeyDown={handleResizeKeyDown}
+              className="absolute -bottom-1 -end-1 z-10 h-3.5 w-3.5 cursor-nwse-resize touch-none border-b-2 border-e-2 border-foreground/60 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+            />
+            <div
+              role="button"
+              tabIndex={0}
+              data-pdf-resize-handle
+              aria-label={tPhaseF('phaseF.componentsNoteContentAreaFileBlock.resizePdf')}
+              onPointerDown={(e) => handleResizePointerDown(e, 'start')}
+              onPointerMove={handleResizePointerMove}
+              onPointerUp={handleResizePointerUp}
+              onKeyDown={handleResizeKeyDown}
+              className="absolute -bottom-1 -start-1 z-10 h-3.5 w-3.5 cursor-nesw-resize touch-none border-b-2 border-s-2 border-foreground/60 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+            />
+          </>
         )}
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -6,7 +6,7 @@ import { getI18n } from 'react-i18next'
  * @module components/note/content-area/file-block
  */
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef, useLayoutEffect } from 'react'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { createReactBlockSpec } from '@blocknote/react'
 import { Document, Page, pdfjs } from 'react-pdf'
@@ -22,7 +22,8 @@ import {
   PanelLeftClose,
   PanelLeft,
   ChevronLeft,
-  ChevronRight
+  ChevronRight,
+  GripVertical
 } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -79,18 +80,107 @@ const PDF_LOADING_INDICATOR = (
 // PDF Preview Component with Collapsible Sidebar
 // ============================================================================
 
+// Resize bounds for the inline PDF preview.
+const MIN_PDF_WIDTH = 240
+// Release within this many px of the column edge snaps to full width.
+const PDF_SNAP_THRESHOLD = 24
+
+function clampWidth(value: number, max: number): number {
+  return Math.round(Math.min(Math.max(value, MIN_PDF_WIDTH), max))
+}
+
 interface PdfPreviewProps {
   url: string
   name: string
+  /** Stored display width in px; `0` uses the responsive default. */
+  width: number
+  /** Commit a new display width (px) to the block prop. `0` restores default. */
+  onResize: (width: number) => void
 }
 
-function PdfPreview({ url, name }: PdfPreviewProps) {
+function PdfPreview({ url, name, width, onResize }: PdfPreviewProps) {
   const { t: tPhaseF } = useT('notes')
   const [numPages, setNumPages] = useState<number>(0)
   const [currentPage, setCurrentPage] = useState(1)
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  // --- Resize state ---------------------------------------------------------
+  // The page-view column bounds the max width so a page never overflows or
+  // horizontally scrolls; measured live so a stored width wider than the
+  // current window clamps down (and restores when the window widens).
+  const viewRef = useRef<HTMLDivElement>(null)
+  const [maxWidth, setMaxWidth] = useState(0)
+  // Non-null only while dragging, for smooth feedback before the commit.
+  const [draftWidth, setDraftWidth] = useState<number | null>(null)
+  const dragRef = useRef<{ startX: number; startWidth: number; rtl: boolean } | null>(null)
+
+  useLayoutEffect(() => {
+    const el = viewRef.current
+    if (!el) return
+    const measure = () => setMaxWidth(el.clientWidth)
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  const defaultWidth = sidebarOpen ? 480 : 600
+  const storedWidth = width > 0 ? width : defaultWidth
+  const limit = maxWidth > 0 ? maxWidth : storedWidth
+  const renderWidth = Math.min(draftWidth ?? storedWidth, limit)
+
+  const handleResizePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const rtl = getComputedStyle(e.currentTarget).direction === 'rtl'
+      dragRef.current = { startX: e.clientX, startWidth: renderWidth, rtl }
+      e.currentTarget.setPointerCapture(e.pointerId)
+      setDraftWidth(renderWidth)
+    },
+    [renderWidth]
+  )
+
+  const handleResizePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current
+      if (!drag) return
+      const delta = (e.clientX - drag.startX) * (drag.rtl ? -1 : 1)
+      setDraftWidth(clampWidth(drag.startWidth + delta, limit))
+    },
+    [limit]
+  )
+
+  const handleResizePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current
+      if (!drag) return
+      e.currentTarget.releasePointerCapture(e.pointerId)
+      const delta = (e.clientX - drag.startX) * (drag.rtl ? -1 : 1)
+      const next = clampWidth(drag.startWidth + delta, limit)
+      dragRef.current = null
+      setDraftWidth(null)
+      onResize(next >= limit - PDF_SNAP_THRESHOLD ? limit : next)
+    },
+    [limit, onResize]
+  )
+
+  const handleResizeKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const step = e.shiftKey ? 50 : 20
+      if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        onResize(clampWidth(renderWidth + step, limit))
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
+        e.preventDefault()
+        onResize(clampWidth(renderWidth - step, limit))
+      }
+    },
+    [renderWidth, limit, onResize]
+  )
 
   const handleLoadSuccess = ({ numPages }: { numPages: number }) => {
     setNumPages(numPages)
@@ -216,21 +306,41 @@ function PdfPreview({ url, name }: PdfPreviewProps) {
         )}
 
         {/* Main PDF View */}
-        <div className="flex-1 min-w-0">
-          <div className="overflow-auto max-h-[400px] bg-white dark:bg-zinc-900">
-            <Document
-              file={url}
-              onLoadSuccess={handleLoadSuccess}
-              onLoadError={handleLoadError}
-              loading={PDF_LOADING_INDICATOR}
-            >
-              <Page
-                pageNumber={currentPage}
-                width={sidebarOpen ? 480 : 600}
-                renderTextLayer={true}
-                renderAnnotationLayer={true}
-              />
-            </Document>
+        <div ref={viewRef} className="flex-1 min-w-0">
+          <div className="group relative">
+            <div className="overflow-auto max-h-[80vh] bg-white dark:bg-zinc-900">
+              <Document
+                file={url}
+                onLoadSuccess={handleLoadSuccess}
+                onLoadError={handleLoadError}
+                loading={PDF_LOADING_INDICATOR}
+              >
+                <Page
+                  pageNumber={currentPage}
+                  width={renderWidth}
+                  renderTextLayer={true}
+                  renderAnnotationLayer={true}
+                />
+              </Document>
+            </div>
+            {!loading && !error && (
+              <div
+                role="slider"
+                tabIndex={0}
+                aria-label={tPhaseF('phaseF.componentsNoteContentAreaFileBlock.resizePdf')}
+                aria-orientation="horizontal"
+                aria-valuemin={MIN_PDF_WIDTH}
+                aria-valuemax={maxWidth || undefined}
+                aria-valuenow={Math.round(renderWidth)}
+                onPointerDown={handleResizePointerDown}
+                onPointerMove={handleResizePointerMove}
+                onPointerUp={handleResizePointerUp}
+                onKeyDown={handleResizeKeyDown}
+                className="absolute bottom-2 end-2 flex h-5 w-5 cursor-ew-resize touch-none items-center justify-center rounded-sm border border-border bg-background/90 text-muted-foreground opacity-0 shadow-sm transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              >
+                <GripVertical className="h-3 w-3" />
+              </div>
+            )}
           </div>
 
           {/* Page Navigation */}
@@ -417,17 +527,34 @@ function AudioPreview({ url, name }: FilePreviewProps) {
  * Shows inline PDF preview for PDFs, download card for other files.
  * Returns a factory function - call it when adding to schema: `file: createFileBlock()`
  */
+interface FileBlockEditor {
+  updateBlock: (block: unknown, update: { props: Record<string, unknown> }) => void
+}
+
 function FileBlockRender({
   block,
+  editor,
   contentRef
 }: {
-  block: { props: { url: string; name: string; size: number; mimeType: string } }
+  block: { props: { url: string; name: string; size: number; mimeType: string; width?: number } }
+  editor: unknown
   contentRef: React.Ref<HTMLDivElement>
 }) {
   const { t: tPhaseF } = useT('notes')
-  const { url, name, size, mimeType } = block.props
+  const { url, name, size, mimeType, width } = block.props
   const isPdf = mimeType === 'application/pdf'
   const isAudio = mimeType.startsWith('audio/')
+
+  // Persist the user-chosen PDF width to the block prop (round-trips to the
+  // vault marker via serializeFileBlock). Declared before the early return to
+  // keep hook order stable.
+  const handleResize = useCallback(
+    (nextWidth: number) => {
+      const fileEditor = editor as FileBlockEditor | undefined
+      fileEditor?.updateBlock(block, { props: { ...block.props, width: nextWidth } })
+    },
+    [editor, block]
+  )
 
   // Don't render if no URL
   if (!url) {
@@ -441,7 +568,7 @@ function FileBlockRender({
   return (
     <div ref={contentRef} className="file-block my-2" contentEditable={false}>
       {isPdf ? (
-        <PdfPreview url={url} name={name} />
+        <PdfPreview url={url} name={name} width={width ?? 0} onResize={handleResize} />
       ) : isAudio ? (
         <AudioPreview url={url} name={name} size={size} mimeType={mimeType} />
       ) : (
@@ -458,7 +585,8 @@ export const createFileBlock = createReactBlockSpec(
       url: { default: '' },
       name: { default: '' },
       size: { default: 0 },
-      mimeType: { default: '' }
+      mimeType: { default: '' },
+      width: { default: 0 }
     },
     content: 'none'
   },

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -20,9 +20,9 @@ import {
   Upload,
   Loader2,
   GripVertical,
-  AlignLeft,
-  AlignCenter,
-  AlignRight
+  LeftToRightBlockQuote,
+  TextAlignCenter,
+  RightToLeftBlockQuote
 } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -283,10 +283,10 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
     center: tPhaseF('phaseF.componentsNoteContentAreaFileBlock.alignCenter'),
     right: tPhaseF('phaseF.componentsNoteContentAreaFileBlock.alignRight')
   }
-  const alignIcons: Record<PdfAlign, typeof AlignLeft> = {
-    left: AlignLeft,
-    center: AlignCenter,
-    right: AlignRight
+  const alignIcons: Record<PdfAlign, typeof TextAlignCenter> = {
+    left: LeftToRightBlockQuote,
+    center: TextAlignCenter,
+    right: RightToLeftBlockQuote
   }
 
   if (error) {

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -19,14 +19,12 @@ import {
   Download,
   Upload,
   Loader2,
-  PanelLeftClose,
-  PanelLeft,
-  ChevronLeft,
-  ChevronRight,
-  GripVertical
+  GripVertical,
+  AlignLeft,
+  AlignCenter,
+  AlignRight
 } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
 import { useSync } from '@/contexts/sync-context'
 import { useT } from '@memry/i18n/renderer'
@@ -82,39 +80,65 @@ const PDF_LOADING_INDICATOR = (
 
 // Resize bounds for the inline PDF preview.
 const MIN_PDF_WIDTH = 240
-// Release within this many px of the column edge snaps to full width.
+const MIN_PDF_HEIGHT = 96
+// Release within this many px of the edge snaps to full width / full page.
 const PDF_SNAP_THRESHOLD = 24
+// Default card width; the embed resizes as a whole (card + page) like an image.
+const DEFAULT_PDF_CARD_WIDTH = 600
+// Card border (box-sizing: border-box) subtracted to get the page render width.
+const PDF_CARD_BORDER = 2
 
 function clampWidth(value: number, max: number): number {
   return Math.round(Math.min(Math.max(value, MIN_PDF_WIDTH), max))
 }
+
+function clampHeight(value: number, max: number): number {
+  return Math.round(Math.min(Math.max(value, MIN_PDF_HEIGHT), max))
+}
+
+type PdfAlign = 'left' | 'center' | 'right'
+
+const PDF_ALIGN_VALUES: readonly PdfAlign[] = ['left', 'center', 'right']
 
 interface PdfPreviewProps {
   url: string
   name: string
   /** Stored display width in px; `0` uses the responsive default. */
   width: number
-  /** Commit a new display width (px) to the block prop. `0` restores default. */
-  onResize: (width: number) => void
+  /** Stored crop height in px; `0` fits the first page (no crop). */
+  height: number
+  /** Alignment of the embed within the note column. */
+  align: PdfAlign
+  /** Commit a new display width + crop height (px) to the block props. */
+  onResize: (width: number, height: number) => void
+  /** Commit a new alignment to the block props. */
+  onAlign: (align: PdfAlign) => void
 }
 
-function PdfPreview({ url, name, width, onResize }: PdfPreviewProps) {
+function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfPreviewProps) {
   const { t: tPhaseF } = useT('notes')
-  const [numPages, setNumPages] = useState<number>(0)
-  const [currentPage, setCurrentPage] = useState(1)
-  const [sidebarOpen, setSidebarOpen] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   // --- Resize state ---------------------------------------------------------
-  // The page-view column bounds the max width so a page never overflows or
-  // horizontally scrolls; measured live so a stored width wider than the
-  // current window clamps down (and restores when the window widens).
+  // The column bounds the max width so the page never overflows horizontally;
+  // the first page's natural rendered height bounds the max crop. Both measured
+  // live so a stored size larger than the current layout clamps down.
   const viewRef = useRef<HTMLDivElement>(null)
   const [maxWidth, setMaxWidth] = useState(0)
+  // Natural (unclipped) height of the rendered first page; caps the crop.
+  const pageContentRef = useRef<HTMLDivElement>(null)
+  const [pageNaturalHeight, setPageNaturalHeight] = useState(0)
   // Non-null only while dragging, for smooth feedback before the commit.
   const [draftWidth, setDraftWidth] = useState<number | null>(null)
-  const dragRef = useRef<{ startX: number; startWidth: number; rtl: boolean } | null>(null)
+  const [draftHeight, setDraftHeight] = useState<number | null>(null)
+  const dragRef = useRef<{
+    startX: number
+    startY: number
+    startWidth: number
+    startHeight: number
+    rtl: boolean
+  } | null>(null)
 
   useLayoutEffect(() => {
     const el = viewRef.current
@@ -127,31 +151,75 @@ function PdfPreview({ url, name, width, onResize }: PdfPreviewProps) {
     return () => observer.disconnect()
   }, [])
 
-  const defaultWidth = sidebarOpen ? 480 : 600
-  const storedWidth = width > 0 ? width : defaultWidth
-  const limit = maxWidth > 0 ? maxWidth : storedWidth
-  const renderWidth = Math.min(draftWidth ?? storedWidth, limit)
+  useLayoutEffect(() => {
+    const el = pageContentRef.current
+    if (!el) return
+    const measure = () => setPageNaturalHeight(el.scrollHeight)
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  // Width scales the whole embed (card + page) like an image. Height is an
+  // independent crop: shrinking it clips the first page from the top so only
+  // the opening of the document shows — no inner scroll.
+  const columnWidth = maxWidth > 0 ? maxWidth : DEFAULT_PDF_CARD_WIDTH
+  const storedWidth = width > 0 ? width : columnWidth
+  const widthLimit = columnWidth
+  const cardWidth = Math.min(draftWidth ?? storedWidth, widthLimit)
+  const pageWidth = Math.max(140, cardWidth - PDF_CARD_BORDER)
+
+  const heightLimit = pageNaturalHeight > 0 ? pageNaturalHeight : Infinity
+  const draftCrop = draftHeight != null ? Math.min(draftHeight, heightLimit) : null
+  const storedCrop = height > 0 ? Math.min(height, heightLimit) : 0
+  // Effective crop height; `undefined` lets the card wrap the full first page.
+  const cardHeight = draftCrop ?? (storedCrop > 0 ? storedCrop : undefined)
+
+  // Snap width to the column edge and height to the full page before committing.
+  // Height "full" is the page's natural height, which changes with width, so it
+  // is stored as 0 ("fit page") rather than a px that would stop meaning "full".
+  const commitResize = useCallback(
+    (nextWidth: number, nextHeight: number) => {
+      const w = nextWidth >= widthLimit - PDF_SNAP_THRESHOLD ? widthLimit : nextWidth
+      const h =
+        heightLimit !== Infinity && nextHeight >= heightLimit - PDF_SNAP_THRESHOLD ? 0 : nextHeight
+      onResize(w, h)
+    },
+    [widthLimit, heightLimit, onResize]
+  )
 
   const handleResizePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       e.preventDefault()
       e.stopPropagation()
       const rtl = getComputedStyle(e.currentTarget).direction === 'rtl'
-      dragRef.current = { startX: e.clientX, startWidth: renderWidth, rtl }
+      const startHeight = cardHeight ?? (pageNaturalHeight || MIN_PDF_HEIGHT)
+      dragRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        startWidth: cardWidth,
+        startHeight,
+        rtl
+      }
       e.currentTarget.setPointerCapture(e.pointerId)
-      setDraftWidth(renderWidth)
+      setDraftWidth(cardWidth)
+      setDraftHeight(startHeight)
     },
-    [renderWidth]
+    [cardWidth, cardHeight, pageNaturalHeight]
   )
 
   const handleResizePointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       const drag = dragRef.current
       if (!drag) return
-      const delta = (e.clientX - drag.startX) * (drag.rtl ? -1 : 1)
-      setDraftWidth(clampWidth(drag.startWidth + delta, limit))
+      const dx = (e.clientX - drag.startX) * (drag.rtl ? -1 : 1)
+      const dy = e.clientY - drag.startY
+      setDraftWidth(clampWidth(drag.startWidth + dx, widthLimit))
+      setDraftHeight(clampHeight(drag.startHeight + dy, heightLimit))
     },
-    [limit]
+    [widthLimit, heightLimit]
   )
 
   const handleResizePointerUp = useCallback(
@@ -159,31 +227,44 @@ function PdfPreview({ url, name, width, onResize }: PdfPreviewProps) {
       const drag = dragRef.current
       if (!drag) return
       e.currentTarget.releasePointerCapture(e.pointerId)
-      const delta = (e.clientX - drag.startX) * (drag.rtl ? -1 : 1)
-      const next = clampWidth(drag.startWidth + delta, limit)
+      const dx = (e.clientX - drag.startX) * (drag.rtl ? -1 : 1)
+      const dy = e.clientY - drag.startY
+      const nextWidth = clampWidth(drag.startWidth + dx, widthLimit)
+      const nextHeight = clampHeight(drag.startHeight + dy, heightLimit)
       dragRef.current = null
       setDraftWidth(null)
-      onResize(next >= limit - PDF_SNAP_THRESHOLD ? limit : next)
+      setDraftHeight(null)
+      commitResize(nextWidth, nextHeight)
     },
-    [limit, onResize]
+    [widthLimit, heightLimit, commitResize]
   )
 
+  // Keyboard commits precise values (no edge snap — snapping is a drag-release
+  // feel only). Left/Right change width; Up/Down change the crop height, and
+  // growing height past the full page stores 0 so it stays "fit page".
   const handleResizeKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       const step = e.shiftKey ? 50 : 20
-      if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
+      const cropBase = cardHeight ?? pageNaturalHeight
+      if (e.key === 'ArrowRight') {
         e.preventDefault()
-        onResize(clampWidth(renderWidth + step, limit))
-      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
+        onResize(clampWidth(cardWidth + step, widthLimit), height)
+      } else if (e.key === 'ArrowLeft') {
         e.preventDefault()
-        onResize(clampWidth(renderWidth - step, limit))
+        onResize(clampWidth(cardWidth - step, widthLimit), height)
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        const raw = cropBase + step
+        onResize(width, raw >= heightLimit ? 0 : clampHeight(raw, heightLimit))
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        onResize(width, clampHeight(cropBase - step, heightLimit))
       }
     },
-    [renderWidth, limit, onResize]
+    [cardWidth, cardHeight, width, height, widthLimit, heightLimit, pageNaturalHeight, onResize]
   )
 
-  const handleLoadSuccess = ({ numPages }: { numPages: number }) => {
-    setNumPages(numPages)
+  const handleLoadSuccess = () => {
     setLoading(false)
   }
 
@@ -197,22 +278,16 @@ function PdfPreview({ url, name, width, onResize }: PdfPreviewProps) {
     setLoading(false)
   }
 
-  const goToPage = useCallback(
-    (page: number) => {
-      if (page >= 1 && page <= numPages) {
-        setCurrentPage(page)
-      }
-    },
-    [numPages]
-  )
-
-  const goToPrevPage = useCallback(() => {
-    goToPage(currentPage - 1)
-  }, [currentPage, goToPage])
-
-  const goToNextPage = useCallback(() => {
-    goToPage(currentPage + 1)
-  }, [currentPage, goToPage])
+  const alignLabels: Record<PdfAlign, string> = {
+    left: tPhaseF('phaseF.componentsNoteContentAreaFileBlock.alignLeft'),
+    center: tPhaseF('phaseF.componentsNoteContentAreaFileBlock.alignCenter'),
+    right: tPhaseF('phaseF.componentsNoteContentAreaFileBlock.alignRight')
+  }
+  const alignIcons: Record<PdfAlign, typeof AlignLeft> = {
+    left: AlignLeft,
+    center: AlignCenter,
+    right: AlignRight
+  }
 
   if (error) {
     return (
@@ -230,146 +305,77 @@ function PdfPreview({ url, name, width, onResize }: PdfPreviewProps) {
   }
 
   return (
-    <div className="pdf-preview rounded-md border border-border bg-muted/30 overflow-hidden">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border bg-muted/50">
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <FileText className="h-4 w-4 text-red-500" />
-          <span className="font-medium truncate max-w-[200px]">{name}</span>
-          {!loading && numPages > 0 && (
-            <span className="text-xs text-muted-foreground/70">
-              ({numPages} {numPages === 1 ? 'page' : 'pages'})
-            </span>
-          )}
+    <div ref={viewRef} className="pdf-preview-wrap">
+      <div
+        className={cn(
+          'pdf-preview group relative rounded-md border border-border bg-muted/30 overflow-hidden',
+          align === 'center' ? 'ms-auto me-auto' : align === 'right' ? 'ms-auto' : 'me-auto'
+        )}
+        style={{ width: cardWidth, height: cardHeight }}
+      >
+        {/* First page only; the card height crops it from the top (no scroll). */}
+        <div ref={pageContentRef} className="bg-white dark:bg-zinc-900">
+          <Document
+            file={url}
+            onLoadSuccess={handleLoadSuccess}
+            onLoadError={handleLoadError}
+            loading={PDF_LOADING_INDICATOR}
+          >
+            <Page
+              pageNumber={1}
+              width={pageWidth}
+              renderTextLayer={true}
+              renderAnnotationLayer={true}
+            />
+          </Document>
         </div>
-        <div className="flex items-center gap-1">
-          {numPages > 1 && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setSidebarOpen(!sidebarOpen)}
-              className="h-7 w-7 p-0"
-              title={sidebarOpen ? 'Hide pages' : 'Show pages'}
-            >
-              {sidebarOpen ? (
-                <PanelLeftClose className="h-4 w-4" />
-              ) : (
-                <PanelLeft className="h-4 w-4" />
-              )}
-            </Button>
-          )}
-          <Button variant="ghost" size="sm" asChild className="h-7 text-xs">
-            <a href={url} download={name}>
-              <Download className="me-1 h-3 w-3" />
 
-              {tPhaseF('phaseF.componentsNoteContentAreaFileBlock.download')}
-            </a>
-          </Button>
-        </div>
-      </div>
-
-      {/* PDF Content */}
-      <div className="flex">
-        {/* Sidebar with page thumbnails */}
-        {sidebarOpen && numPages > 1 && (
-          <div className="w-[120px] border-e border-border bg-muted/30 flex-shrink-0">
-            <ScrollArea className="h-[400px]">
-              <div className="p-2 space-y-2">
-                <Document file={url}>
-                  {Array.from({ length: numPages }, (_, i) => (
-                    <button
-                      key={i + 1}
-                      type="button"
-                      onClick={() => goToPage(i + 1)}
-                      className={cn(
-                        'w-full rounded border-2 overflow-hidden transition-all hover:border-primary/50',
-                        currentPage === i + 1
-                          ? 'border-primary ring-1 ring-primary/20'
-                          : 'border-transparent'
-                      )}
-                    >
-                      <Page
-                        pageNumber={i + 1}
-                        width={100}
-                        renderTextLayer={false}
-                        renderAnnotationLayer={false}
-                      />
-                      <div className="text-[10px] text-center py-1 bg-background/80 text-muted-foreground">
-                        {i + 1}
-                      </div>
-                    </button>
-                  ))}
-                </Document>
-              </div>
-            </ScrollArea>
+        {/* Alignment controls — hover reveal, top-inline-end */}
+        {!loading && !error && (
+          <div className="absolute top-2 end-2 z-10 flex items-center gap-0.5 rounded-md border border-border bg-background/90 p-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+            {PDF_ALIGN_VALUES.map((value) => {
+              const Icon = alignIcons[value]
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  aria-label={alignLabels[value]}
+                  aria-pressed={align === value}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={() => onAlign(value)}
+                  className={cn(
+                    'flex h-6 w-6 items-center justify-center rounded transition-colors',
+                    align === value
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:bg-accent/50'
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                </button>
+              )
+            })}
           </div>
         )}
 
-        {/* Main PDF View */}
-        <div ref={viewRef} className="flex-1 min-w-0">
-          <div className="group relative">
-            <div className="overflow-auto max-h-[80vh] bg-white dark:bg-zinc-900">
-              <Document
-                file={url}
-                onLoadSuccess={handleLoadSuccess}
-                onLoadError={handleLoadError}
-                loading={PDF_LOADING_INDICATOR}
-              >
-                <Page
-                  pageNumber={currentPage}
-                  width={renderWidth}
-                  renderTextLayer={true}
-                  renderAnnotationLayer={true}
-                />
-              </Document>
-            </div>
-            {!loading && !error && (
-              <div
-                role="slider"
-                tabIndex={0}
-                aria-label={tPhaseF('phaseF.componentsNoteContentAreaFileBlock.resizePdf')}
-                aria-orientation="horizontal"
-                aria-valuemin={MIN_PDF_WIDTH}
-                aria-valuemax={maxWidth || undefined}
-                aria-valuenow={Math.round(renderWidth)}
-                onPointerDown={handleResizePointerDown}
-                onPointerMove={handleResizePointerMove}
-                onPointerUp={handleResizePointerUp}
-                onKeyDown={handleResizeKeyDown}
-                className="absolute bottom-2 end-2 flex h-5 w-5 cursor-ew-resize touch-none items-center justify-center rounded-sm border border-border bg-background/90 text-muted-foreground opacity-60 shadow-sm transition-opacity hover:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-              >
-                <GripVertical className="h-3 w-3" />
-              </div>
-            )}
+        {/* Resize handle — drag the corner to scale width and crop height */}
+        {!loading && !error && (
+          <div
+            role="slider"
+            tabIndex={0}
+            aria-label={tPhaseF('phaseF.componentsNoteContentAreaFileBlock.resizePdf')}
+            aria-orientation="horizontal"
+            aria-valuemin={MIN_PDF_WIDTH}
+            aria-valuemax={maxWidth || undefined}
+            aria-valuenow={Math.round(cardWidth)}
+            onPointerDown={handleResizePointerDown}
+            onPointerMove={handleResizePointerMove}
+            onPointerUp={handleResizePointerUp}
+            onKeyDown={handleResizeKeyDown}
+            className="absolute bottom-2 end-2 z-10 flex h-5 w-5 cursor-nwse-resize touch-none items-center justify-center rounded-sm border border-border bg-background/90 text-muted-foreground opacity-60 shadow-sm transition-opacity hover:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            <GripVertical className="h-3 w-3" />
           </div>
-
-          {/* Page Navigation */}
-          {numPages > 1 && (
-            <div className="flex items-center justify-center gap-2 py-2 border-t border-border bg-muted/30">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={goToPrevPage}
-                disabled={currentPage <= 1}
-                className="h-7 w-7 p-0"
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </Button>
-              <span className="text-xs text-muted-foreground min-w-[60px] text-center">
-                {currentPage} / {numPages}
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={goToNextPage}
-                disabled={currentPage >= numPages}
-                className="h-7 w-7 p-0"
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-          )}
-        </div>
+        )}
       </div>
     </div>
   )
@@ -536,22 +542,42 @@ function FileBlockRender({
   editor,
   contentRef
 }: {
-  block: { props: { url: string; name: string; size: number; mimeType: string; width?: number } }
+  block: {
+    props: {
+      url: string
+      name: string
+      size: number
+      mimeType: string
+      width?: number
+      height?: number
+      align?: 'left' | 'center' | 'right'
+    }
+  }
   editor: unknown
   contentRef: React.Ref<HTMLDivElement>
 }) {
   const { t: tPhaseF } = useT('notes')
-  const { url, name, size, mimeType, width } = block.props
+  const { url, name, size, mimeType, width, height, align } = block.props
   const isPdf = mimeType === 'application/pdf'
   const isAudio = mimeType.startsWith('audio/')
 
-  // Persist the user-chosen PDF width to the block prop (round-trips to the
-  // vault marker via serializeFileBlock). Declared before the early return to
-  // keep hook order stable.
+  // Persist the user-chosen PDF width + crop height to the block props
+  // (round-trips to the vault marker via serializeFileBlock). Declared before
+  // the early return to keep hook order stable.
   const handleResize = useCallback(
-    (nextWidth: number) => {
+    (nextWidth: number, nextHeight: number) => {
       const fileEditor = editor as FileBlockEditor | undefined
-      fileEditor?.updateBlock(block, { props: { ...block.props, width: nextWidth } })
+      fileEditor?.updateBlock(block, {
+        props: { ...block.props, width: nextWidth, height: nextHeight }
+      })
+    },
+    [editor, block]
+  )
+
+  const handleAlign = useCallback(
+    (nextAlign: 'left' | 'center' | 'right') => {
+      const fileEditor = editor as FileBlockEditor | undefined
+      fileEditor?.updateBlock(block, { props: { ...block.props, align: nextAlign } })
     },
     [editor, block]
   )
@@ -568,7 +594,15 @@ function FileBlockRender({
   return (
     <div ref={contentRef} className="file-block my-2" contentEditable={false}>
       {isPdf ? (
-        <PdfPreview url={url} name={name} width={width ?? 0} onResize={handleResize} />
+        <PdfPreview
+          url={url}
+          name={name}
+          width={width ?? 0}
+          height={height ?? 0}
+          align={align ?? 'left'}
+          onResize={handleResize}
+          onAlign={handleAlign}
+        />
       ) : isAudio ? (
         <AudioPreview url={url} name={name} size={size} mimeType={mimeType} />
       ) : (
@@ -586,7 +620,9 @@ export const createFileBlock = createReactBlockSpec(
       name: { default: '' },
       size: { default: 0 },
       mimeType: { default: '' },
-      width: { default: 0 }
+      width: { default: 0 },
+      height: { default: 0 },
+      align: { default: 'left' as const, values: ['left', 'center', 'right'] as const }
     },
     content: 'none'
   },

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -99,6 +99,12 @@ type PdfAlign = 'left' | 'center' | 'right'
 
 const PDF_ALIGN_VALUES: readonly PdfAlign[] = ['left', 'center', 'right']
 
+const PDF_ALIGN_ICONS: Record<PdfAlign, typeof TextAlignCenter> = {
+  left: LeftToRightBlockQuote,
+  center: TextAlignCenter,
+  right: RightToLeftBlockQuote
+}
+
 interface PdfPreviewProps {
   url: string
   name: string
@@ -286,12 +292,6 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
     center: tPhaseF('phaseF.componentsNoteContentAreaFileBlock.alignCenter'),
     right: tPhaseF('phaseF.componentsNoteContentAreaFileBlock.alignRight')
   }
-  const alignIcons: Record<PdfAlign, typeof TextAlignCenter> = {
-    left: LeftToRightBlockQuote,
-    center: TextAlignCenter,
-    right: RightToLeftBlockQuote
-  }
-
   if (error) {
     return (
       <div className="pdf-preview-error rounded-md border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950">
@@ -341,7 +341,7 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
           {!loading && !error && (
             <div className="absolute top-2 end-2 z-10 flex items-center gap-px rounded-md border border-border bg-background/90 p-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 focus-within:opacity-100">
               {PDF_ALIGN_VALUES.map((value) => {
-                const Icon = alignIcons[value]
+                const Icon = PDF_ALIGN_ICONS[value]
                 return (
                   <button
                     key={value}

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -336,7 +336,7 @@ function PdfPreview({ url, name, width, onResize }: PdfPreviewProps) {
                 onPointerMove={handleResizePointerMove}
                 onPointerUp={handleResizePointerUp}
                 onKeyDown={handleResizeKeyDown}
-                className="absolute bottom-2 end-2 flex h-5 w-5 cursor-ew-resize touch-none items-center justify-center rounded-sm border border-border bg-background/90 text-muted-foreground opacity-0 shadow-sm transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                className="absolute bottom-2 end-2 flex h-5 w-5 cursor-ew-resize touch-none items-center justify-center rounded-sm border border-border bg-background/90 text-muted-foreground opacity-60 shadow-sm transition-opacity hover:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
               >
                 <GripVertical className="h-3 w-3" />
               </div>

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-drag-drop.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-drag-drop.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
 import { findDropTarget, type DropTarget } from '../drop-target-utils'
+import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
 
 interface EditorDragDropParams {
   containerRef: React.RefObject<HTMLDivElement | null>
@@ -59,8 +60,13 @@ export function useEditorDragDrop({ containerRef }: EditorDragDropParams): Edito
   const handleDragOver = useCallback(
     (e: React.DragEvent) => {
       e.stopPropagation()
-      if (!e.dataTransfer.types.includes('Files')) return
+      const types = e.dataTransfer.types
+      const isFileDrag = types.includes('Files')
+      const isInternalItem = types.includes(MEMRY_NOTE_DRAG_MIME)
+      // Both an OS file drop and a file-type sidebar item can be embedded.
+      if (!isFileDrag && !isInternalItem) return
       e.preventDefault()
+      if (isInternalItem && !isFileDrag) e.dataTransfer.dropEffect = 'copy'
       setIsDragging(true)
       const target = findDropTarget(e.clientY, containerRef)
       setDropTarget(target)

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.test.ts
@@ -4,12 +4,13 @@ import { isImageFile, useEditorFileUpload } from './use-editor-file-upload'
 
 const mocks = vi.hoisted(() => ({
   uploadAttachment: vi.fn(),
+  getFile: vi.fn(),
   warn: vi.fn(),
   error: vi.fn()
 }))
 
 vi.mock('@/services/notes-service', () => ({
-  notesService: { uploadAttachment: mocks.uploadAttachment }
+  notesService: { uploadAttachment: mocks.uploadAttachment, getFile: mocks.getFile }
 }))
 
 vi.mock('@/lib/logger', () => ({
@@ -182,6 +183,99 @@ describe('useEditorFileUpload', () => {
       stopPropagation: vi.fn()
     } as unknown as React.DragEvent)
 
+    expect(readOnly.editor.insertBlocks).not.toHaveBeenCalled()
+  })
+
+  // A file-type item dragged out of the left sidebar carries our custom mime
+  // (the note id). It is embedded by its own vault path — never re-uploaded.
+  const internalDrop = (id: string) =>
+    ({
+      getData: (mime: string) => (mime === 'application/x-memry-note' ? id : '')
+    }) as unknown as DataTransfer
+
+  it('embeds a dropped sidebar PDF by path without copying to attachments', async () => {
+    mocks.getFile.mockResolvedValue({
+      absolutePath: '/vault/notes/report.pdf',
+      fileType: 'pdf',
+      title: 'report',
+      fileSize: 1234,
+      mimeType: 'application/pdf'
+    })
+    const { result, editor, params } = setup({
+      dropTarget: { blockId: 'target-block', position: 'after' }
+    })
+
+    await act(async () => {
+      await result.current.handleInternalItemDrop(internalDrop('file-id'))
+    })
+
+    expect(mocks.getFile).toHaveBeenCalledWith('file-id')
+    expect(mocks.uploadAttachment).not.toHaveBeenCalled()
+    expect(params.onDragReset).toHaveBeenCalled()
+    expect(editor.insertBlocks).toHaveBeenCalledWith(
+      [
+        {
+          type: 'file',
+          props: {
+            url: 'memry-file://local/vault/notes/report.pdf',
+            name: 'report',
+            size: 1234,
+            mimeType: 'application/pdf'
+          }
+        }
+      ],
+      'target-block',
+      'after'
+    )
+  })
+
+  it('embeds a dropped sidebar image as an image block at the cursor', async () => {
+    mocks.getFile.mockResolvedValue({
+      absolutePath: '/vault/notes/pic.png',
+      fileType: 'image',
+      title: 'pic',
+      fileSize: 50,
+      mimeType: 'image/png'
+    })
+    const { result, editor } = setup()
+
+    await act(async () => {
+      await result.current.handleInternalItemDrop(internalDrop('img-id'))
+    })
+
+    expect(editor.insertBlocks).toHaveBeenCalledWith(
+      [
+        {
+          type: 'image',
+          props: {
+            url: 'memry-file://local/vault/notes/pic.png',
+            caption: 'pic',
+            previewWidth: 600
+          }
+        }
+      ],
+      'cursor-block',
+      'after'
+    )
+  })
+
+  it('ignores an internal drop without the item mime and read-only drops', async () => {
+    const { result, editor } = setup()
+    await result.current.handleInternalItemDrop({ getData: () => '' } as unknown as DataTransfer)
+    expect(mocks.getFile).not.toHaveBeenCalled()
+    expect(editor.insertBlocks).not.toHaveBeenCalled()
+
+    mocks.getFile.mockResolvedValue({
+      absolutePath: '/vault/notes/report.pdf',
+      fileType: 'pdf',
+      title: 'report',
+      fileSize: 1,
+      mimeType: 'application/pdf'
+    })
+    const readOnly = setup({ editable: false })
+    await act(async () => {
+      await readOnly.result.current.handleInternalItemDrop(internalDrop('file-id'))
+    })
     expect(readOnly.editor.insertBlocks).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-file-upload.ts
@@ -5,6 +5,8 @@ import { notesService } from '@/services/notes-service'
 import { createFileBlockContent } from '../file-block'
 import type { DropTarget } from '../drop-target-utils'
 import { createLogger } from '@/lib/logger'
+import { toMemryFileUrl } from '@/lib/memry-file-url'
+import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
 
 const log = createLogger('Hook:EditorFileUpload')
 
@@ -34,6 +36,7 @@ interface EditorFileUploadParams {
 interface EditorFileUploadResult {
   uploadFile: (file: File) => Promise<string>
   handleNonImageDrop: (e: React.DragEvent) => Promise<boolean>
+  handleInternalItemDrop: (dataTransfer: DataTransfer) => Promise<void>
 }
 
 export function useEditorFileUpload({
@@ -144,13 +147,69 @@ export function useEditorFileUpload({
     [noteId, editable, editor, dropTarget, onDragReset]
   )
 
+  // Embed a file-type item dragged out of the left sidebar. Unlike an OS file
+  // drop, the bytes already live in the vault, so we reference the item by its
+  // own path (memry-file:// URL) instead of copying into attachments/.
+  const handleInternalItemDrop = useCallback(
+    async (dataTransfer: DataTransfer): Promise<void> => {
+      const itemId = dataTransfer.getData(MEMRY_NOTE_DRAG_MIME)
+      if (!itemId) return
+
+      const insertTarget = dropTarget
+      onDragReset()
+
+      if (!editable) return
+
+      let referenceBlockId: string
+      let placement: 'before' | 'after' = 'after'
+      if (insertTarget) {
+        referenceBlockId = insertTarget.blockId
+        placement = insertTarget.position
+      } else {
+        referenceBlockId = editor.getTextCursorPosition().block.id
+      }
+
+      try {
+        const file = await notesService.getFile(itemId)
+        if (!file?.absolutePath) {
+          log.warn('Cannot embed dropped item: no file path', itemId)
+          return
+        }
+
+        const url = toMemryFileUrl(file.absolutePath)
+        const name = file.title || 'file'
+        const mimeType = file.mimeType || ''
+
+        if (file.fileType === 'image' || mimeType.startsWith('image/')) {
+          editor.insertBlocks(
+            [{ type: 'image', props: { url, caption: name, previewWidth: 600 } }],
+            referenceBlockId,
+            placement
+          )
+        } else {
+          editor.insertBlocks(
+            [createFileBlockContent({ url, name, size: file.fileSize ?? 0, mimeType })],
+            referenceBlockId,
+            placement
+          )
+        }
+      } catch (error) {
+        log.error('Failed to embed dropped item', itemId, error)
+      }
+    },
+    [editable, editor, dropTarget, onDragReset]
+  )
+
   // Capture-phase drop handler to intercept before BlockNote
   useEffect(() => {
     const container = containerRef.current
     if (!container) return
 
     const captureDropHandler = (e: DragEvent): void => {
-      const files = Array.from(e.dataTransfer?.files || [])
+      const dataTransfer = e.dataTransfer
+      if (!dataTransfer) return
+
+      const files = Array.from(dataTransfer.files || [])
       const hasNonImageFiles = files.some((f) => !isImageFile(f))
 
       if (hasNonImageFiles) {
@@ -159,11 +218,19 @@ export function useEditorFileUpload({
 
         void handleNonImageDrop({
           ...e,
-          dataTransfer: e.dataTransfer,
+          dataTransfer,
           preventDefault: () => e.preventDefault(),
           stopPropagation: () => e.stopPropagation(),
           currentTarget: container
         } as unknown as React.DragEvent)
+        return
+      }
+
+      // Internal file-type sidebar item (no OS files on the drag).
+      if (files.length === 0 && dataTransfer.types.includes(MEMRY_NOTE_DRAG_MIME)) {
+        e.preventDefault()
+        e.stopPropagation()
+        void handleInternalItemDrop(dataTransfer)
       }
     }
 
@@ -172,7 +239,7 @@ export function useEditorFileUpload({
     return () => {
       container.removeEventListener('drop', captureDropHandler, { capture: true })
     }
-  }, [handleNonImageDrop, containerRef])
+  }, [handleNonImageDrop, handleInternalItemDrop, containerRef])
 
-  return { uploadFile, handleNonImageDrop }
+  return { uploadFile, handleNonImageDrop, handleInternalItemDrop }
 }

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -31,6 +31,7 @@ import {
   Smile
 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
 import { useTabActions } from '@/contexts/tabs'
 import type { NoteListItem } from '@/hooks/use-notes-query'
 import {
@@ -921,11 +922,20 @@ export function VirtualizedNotesTree({
     (e: React.DragEvent, itemId: string) => {
       if (isDragDisabled) return
 
-      e.dataTransfer.effectAllowed = 'move'
+      e.dataTransfer.effectAllowed = 'copyMove'
       e.dataTransfer.setData('text/plain', itemId)
+      // Tag file-type items (pdf/image/audio/etc.) so the note editor can embed
+      // them by their own vault path on drop, instead of ignoring the drag.
+      if (!isFolder(itemId)) {
+        const note = noteMap.get(itemId)
+        const fileType = (note?.fileType ?? 'markdown') as FileType
+        if (fileType !== 'markdown') {
+          e.dataTransfer.setData(MEMRY_NOTE_DRAG_MIME, itemId)
+        }
+      }
       setDragState((prev) => ({ ...prev, draggedId: itemId }))
     },
-    [isDragDisabled]
+    [isDragDisabled, noteMap]
   )
 
   const handleDragEnd = useCallback(() => {

--- a/apps/desktop/src/renderer/src/lib/drag-mime.ts
+++ b/apps/desktop/src/renderer/src/lib/drag-mime.ts
@@ -1,0 +1,10 @@
+/**
+ * Custom drag data type used when a file-type item is dragged out of the left
+ * sidebar (`VirtualizedNotesTree`) so the note editor can distinguish it from a
+ * plain text drag or an OS file drop and embed the item by its own vault path
+ * (no copy into `attachments/`).
+ *
+ * The payload is the item's note id; the editor resolves it to an absolute path
+ * via `window.api.notes.getFile(id)`.
+ */
+export const MEMRY_NOTE_DRAG_MIME = 'application/x-memry-note'

--- a/apps/desktop/src/renderer/src/lib/icons/icon-map.ts
+++ b/apps/desktop/src/renderer/src/lib/icons/icon-map.ts
@@ -2,8 +2,8 @@ import {
   // Direct matches
   AlertCircleIcon,
   AlignLeftIcon,
-  AlignCenter as AlignCenterIcon,
-  AlignRightIcon,
+  RightToLeftBlockQuoteIcon,
+  TextAlignCenterIcon,
   AiWebBrowsingIcon,
   Archive03Icon,
   ArchiveIcon,
@@ -459,8 +459,9 @@ export const GripVertical = createIcon(DragDropVerticalIcon)
 export const PanelLeft = createIcon(PanelLeftIcon)
 export const PanelRight = createIcon(PanelRightIcon)
 export const AlignLeft = createIcon(AlignLeftIcon)
-export const AlignCenter = createIcon(AlignCenterIcon)
-export const AlignRight = createIcon(AlignRightIcon)
+export const LeftToRightBlockQuote = createIcon(LeftToRightBlockQuoteIcon)
+export const RightToLeftBlockQuote = createIcon(RightToLeftBlockQuoteIcon)
+export const TextAlignCenter = createIcon(TextAlignCenterIcon)
 
 // ── Status & Indicators ─────────────────────────────
 export const Check = createIcon(Tick01Icon)

--- a/apps/desktop/src/renderer/src/lib/icons/icon-map.ts
+++ b/apps/desktop/src/renderer/src/lib/icons/icon-map.ts
@@ -2,6 +2,8 @@ import {
   // Direct matches
   AlertCircleIcon,
   AlignLeftIcon,
+  AlignCenter as AlignCenterIcon,
+  AlignRightIcon,
   AiWebBrowsingIcon,
   Archive03Icon,
   ArchiveIcon,
@@ -457,6 +459,8 @@ export const GripVertical = createIcon(DragDropVerticalIcon)
 export const PanelLeft = createIcon(PanelLeftIcon)
 export const PanelRight = createIcon(PanelRightIcon)
 export const AlignLeft = createIcon(AlignLeftIcon)
+export const AlignCenter = createIcon(AlignCenterIcon)
+export const AlignRight = createIcon(AlignRightIcon)
 
 // ── Status & Indicators ─────────────────────────────
 export const Check = createIcon(Tick01Icon)

--- a/apps/desktop/tests/e2e/pdf-embed-resize.e2e.ts
+++ b/apps/desktop/tests/e2e/pdf-embed-resize.e2e.ts
@@ -152,7 +152,7 @@ test.describe('PDF embed via sidebar drag + resize', () => {
 
     await dropSidebarItem(page, pdfId)
 
-    // The inline PDF preview renders in the editor (header shows before pdfjs load).
+    // The inline PDF preview card renders in the editor (visible before pdfjs load).
     await expect(page.locator('.pdf-preview')).toBeVisible({ timeout: 10_000 })
 
     // Crucially: the bytes were NOT copied into attachments/ — the embed references
@@ -202,6 +202,30 @@ test.describe('PDF embed via sidebar drag + resize', () => {
       .poll(async () => /<!-- file:\{[^}]*"width":\d+/.test(await noteMarkdown(page, targetId)), {
         timeout: 20_000
       })
+      .toBe(true)
+  })
+
+  test('aligns the embed and persists the alignment', async ({ page }) => {
+    await ready(page)
+
+    const pdfId = await importPdf(page)
+    const targetId = await seedNote(page, uniqueLabel('Align Target'), 'drop here')
+    await openNoteInEditor(page, targetId, 'Align Target')
+    await dropSidebarItem(page, pdfId)
+
+    await expect(page.locator('.pdf-preview')).toBeVisible({ timeout: 10_000 })
+    // Scroll the embed clear of the sticky note header before clicking.
+    await page.locator('.pdf-preview').scrollIntoViewIfNeeded()
+
+    // Click the center-align control (hover-revealed, still clickable at rest).
+    await page.getByRole('button', { name: 'Align center' }).click()
+
+    // The alignment round-trips to the persisted note markdown.
+    await expect
+      .poll(
+        async () => /<!-- file:\{[^}]*"align":"center"/.test(await noteMarkdown(page, targetId)),
+        { timeout: 20_000 }
+      )
       .toBe(true)
   })
 })

--- a/apps/desktop/tests/e2e/pdf-embed-resize.e2e.ts
+++ b/apps/desktop/tests/e2e/pdf-embed-resize.e2e.ts
@@ -1,0 +1,199 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import { ready, uniqueLabel } from './utils/desktop-test-helpers'
+import { SELECTORS, seedNote } from './utils/electron-helpers'
+
+// Keep in sync with src/renderer/src/lib/drag-mime.ts. Duplicated as a literal
+// so the test asserts the exact wire contract the sidebar and editor share.
+const MEMRY_NOTE_DRAG_MIME = 'application/x-memry-note'
+
+/**
+ * Build a valid single-page PDF with a byte-correct xref table so pdfjs (react-pdf)
+ * loads it and the inline preview reaches its non-loading state (which is when the
+ * resize handle renders). A blank page is enough — we only need a successful load.
+ */
+function makeMinimalPdf(): Buffer {
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 400] /Resources << >> >>'
+  ]
+  let body = '%PDF-1.4\n'
+  const offsets: number[] = []
+  objects.forEach((obj, i) => {
+    offsets.push(Buffer.byteLength(body, 'latin1'))
+    body += `${i + 1} 0 obj\n${obj}\nendobj\n`
+  })
+  const xrefStart = Buffer.byteLength(body, 'latin1')
+  const size = objects.length + 1
+  let xref = `xref\n0 ${size}\n0000000000 65535 f \n`
+  for (const off of offsets) {
+    xref += `${String(off).padStart(10, '0')} 00000 n \n`
+  }
+  const trailer = `trailer\n<< /Size ${size} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF\n`
+  return Buffer.from(body + xref + trailer, 'latin1')
+}
+
+/** Import a PDF into the vault (becomes a file-type sidebar item) and return its id. */
+async function importPdf(page: Page): Promise<string> {
+  const importDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-e2e-pdf-'))
+  const pdfName = `e2e-embed-${Date.now()}.pdf`
+  fs.writeFileSync(path.join(importDir, pdfName), makeMinimalPdf())
+
+  const pdfId = await page.evaluate(
+    async (src) => {
+      const imported = await window.api.notes.importFiles([src], '')
+      if (!imported.success) throw new Error(imported.errors?.join('\n') || 'pdf import failed')
+      const list = await window.api.notes.list({ limit: 200 })
+      return list.notes.find((n) => n.fileType === 'pdf')?.id ?? null
+    },
+    path.join(importDir, pdfName)
+  )
+
+  expect(pdfId).toBeTruthy()
+  return pdfId as string
+}
+
+/** Open a seeded markdown note in the editor deterministically via restored tab state. */
+async function openNoteInEditor(page: Page, noteId: string, title: string): Promise<void> {
+  await page.addInitScript(
+    ({ id, t }) => {
+      localStorage.setItem(
+        'memry_tab_state',
+        JSON.stringify({
+          version: 2,
+          tabGroups: {
+            g1: {
+              id: 'g1',
+              activeTabId: 'note-tab',
+              tabs: [
+                {
+                  id: 'note-tab',
+                  type: 'note',
+                  title: t,
+                  icon: 'file',
+                  path: `/notes/${id}`,
+                  entityId: id,
+                  isPinned: false
+                }
+              ]
+            }
+          },
+          layout: { type: 'leaf', tabGroupId: 'g1' },
+          activeGroupId: 'g1',
+          settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' },
+          savedAt: Date.now()
+        })
+      )
+    },
+    { id: noteId, t: title }
+  )
+  await page.reload()
+  await page.waitForLoadState('domcontentloaded')
+  await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 15_000 })
+}
+
+/** Simulate a file-type sidebar item being dropped onto the note editor. */
+async function dropSidebarItem(page: Page, itemId: string): Promise<void> {
+  const editor = page.locator(SELECTORS.noteEditor).first()
+  await editor.click() // place a text cursor so the block has an insertion anchor
+  await page.evaluate(
+    ({ mime, id, sel }) => {
+      const el = document.querySelector(sel)
+      if (!el) throw new Error('editor element not found')
+      const dt = new DataTransfer()
+      dt.setData(mime, id)
+      el.dispatchEvent(
+        new DragEvent('dragover', { dataTransfer: dt, bubbles: true, cancelable: true })
+      )
+      el.dispatchEvent(new DragEvent('drop', { dataTransfer: dt, bubbles: true, cancelable: true }))
+    },
+    { mime: MEMRY_NOTE_DRAG_MIME, id: itemId, sel: SELECTORS.noteEditor }
+  )
+}
+
+test.describe('PDF embed via sidebar drag + resize', () => {
+  test('drops a sidebar PDF as an embed by path, not as an attachment copy', async ({
+    page,
+    testVaultPath
+  }) => {
+    await ready(page)
+
+    const pdfId = await importPdf(page)
+    const targetId = await seedNote(page, uniqueLabel('Embed Target'), 'drop here')
+    await openNoteInEditor(page, targetId, 'Embed Target')
+
+    await dropSidebarItem(page, pdfId)
+
+    // The inline PDF preview renders in the editor (header shows before pdfjs load).
+    await expect(page.locator('.pdf-preview')).toBeVisible({ timeout: 10_000 })
+
+    // Crucially: the bytes were NOT copied into attachments/ — the embed references
+    // the sidebar item's own vault path.
+    const targetAttachmentsDir = path.join(testVaultPath, 'attachments', targetId)
+    expect(fs.existsSync(targetAttachmentsDir)).toBe(false)
+
+    // The persisted marker points at the imported PDF path (notes/…), not attachments/.
+    await expect
+      .poll(
+        () => {
+          const notesDir = path.join(testVaultPath, 'notes')
+          return fs
+            .readdirSync(notesDir)
+            .filter((f) => f.endsWith('.md'))
+            .some((f) => {
+              const txt = fs.readFileSync(path.join(notesDir, f), 'utf8')
+              const match = txt.match(/<!-- file:(\{[^}]+\}) -->/)
+              return !!match && match[1].includes('.pdf') && !match[1].includes('attachments')
+            })
+        },
+        { timeout: 15_000 }
+      )
+      .toBe(true)
+  })
+
+  test('shows a resize handle and persists the new width', async ({ page, testVaultPath }) => {
+    await ready(page)
+
+    const pdfId = await importPdf(page)
+    const targetId = await seedNote(page, uniqueLabel('Resize Target'), 'drop here')
+    await openNoteInEditor(page, targetId, 'Resize Target')
+    await dropSidebarItem(page, pdfId)
+
+    // Resize indicator exists once the PDF has loaded.
+    const slider = page.getByRole('slider')
+    await expect(slider).toBeVisible({ timeout: 20_000 })
+
+    const before = Number(await slider.getAttribute('aria-valuenow'))
+    expect(before).toBeGreaterThan(0)
+
+    // Shrink via the keyboard (deterministic regardless of column width).
+    await slider.focus()
+    await page.keyboard.press('ArrowLeft')
+    await page.keyboard.press('ArrowLeft')
+    await page.keyboard.press('ArrowLeft')
+
+    await expect
+      .poll(async () => Number(await page.getByRole('slider').getAttribute('aria-valuenow')))
+      .toBeLessThan(before)
+
+    // The width round-trips to the vault marker.
+    await expect
+      .poll(
+        () => {
+          const notesDir = path.join(testVaultPath, 'notes')
+          return fs
+            .readdirSync(notesDir)
+            .filter((f) => f.endsWith('.md'))
+            .some((f) =>
+              /<!-- file:\{[^}]*"width":\d+/.test(fs.readFileSync(path.join(notesDir, f), 'utf8'))
+            )
+        },
+        { timeout: 15_000 }
+      )
+      .toBe(true)
+  })
+})

--- a/apps/desktop/tests/e2e/pdf-embed-resize.e2e.ts
+++ b/apps/desktop/tests/e2e/pdf-embed-resize.e2e.ts
@@ -41,19 +41,34 @@ function makeMinimalPdf(): Buffer {
 async function importPdf(page: Page): Promise<string> {
   const importDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-e2e-pdf-'))
   const pdfName = `e2e-embed-${Date.now()}.pdf`
+  const pdfTitle = path.basename(pdfName, '.pdf')
   fs.writeFileSync(path.join(importDir, pdfName), makeMinimalPdf())
 
-  const pdfId = await page.evaluate(
-    async (src) => {
-      const imported = await window.api.notes.importFiles([src], '')
-      if (!imported.success) throw new Error(imported.errors?.join('\n') || 'pdf import failed')
-      const list = await window.api.notes.list({ limit: 200 })
-      return list.notes.find((n) => n.fileType === 'pdf')?.id ?? null
-    },
+  const imported = await page.evaluate(
+    async (src) => window.api.notes.importFiles([src], ''),
     path.join(importDir, pdfName)
   )
+  expect(imported.success).toBe(true)
 
-  expect(pdfId).toBeTruthy()
+  // Imported file notes surface in the list only after indexing — poll by
+  // filename/title rather than assuming a fileType value.
+  let pdfId: string | null = null
+  await expect
+    .poll(
+      async () => {
+        pdfId = await page.evaluate(
+          async ({ name, title }) => {
+            const list = await window.api.notes.list({ limit: 200 })
+            return list.notes.find((n) => n.path === name || n.title === title)?.id ?? null
+          },
+          { name: pdfName, title: pdfTitle }
+        )
+        return pdfId
+      },
+      { timeout: 20_000 }
+    )
+    .not.toBeNull()
+
   return pdfId as string
 }
 
@@ -115,6 +130,15 @@ async function dropSidebarItem(page: Page, itemId: string): Promise<void> {
   )
 }
 
+/** Read a note's saved markdown through the app data layer (survives autosave debounce). */
+async function noteMarkdown(page: Page, id: string): Promise<string> {
+  return page.evaluate(async (noteId) => {
+    const res = (await window.api.notes.get(noteId)) as Record<string, unknown>
+    const note = (res?.note ?? res) as Record<string, unknown> | undefined
+    return String(note?.content ?? note?.contentMarkdown ?? '')
+  }, id)
+}
+
 test.describe('PDF embed via sidebar drag + resize', () => {
   test('drops a sidebar PDF as an embed by path, not as an attachment copy', async ({
     page,
@@ -136,26 +160,19 @@ test.describe('PDF embed via sidebar drag + resize', () => {
     const targetAttachmentsDir = path.join(testVaultPath, 'attachments', targetId)
     expect(fs.existsSync(targetAttachmentsDir)).toBe(false)
 
-    // The persisted marker points at the imported PDF path (notes/…), not attachments/.
+    // The persisted marker points at the imported PDF path, not attachments/.
     await expect
       .poll(
-        () => {
-          const notesDir = path.join(testVaultPath, 'notes')
-          return fs
-            .readdirSync(notesDir)
-            .filter((f) => f.endsWith('.md'))
-            .some((f) => {
-              const txt = fs.readFileSync(path.join(notesDir, f), 'utf8')
-              const match = txt.match(/<!-- file:(\{[^}]+\}) -->/)
-              return !!match && match[1].includes('.pdf') && !match[1].includes('attachments')
-            })
+        async () => {
+          const match = (await noteMarkdown(page, targetId)).match(/<!-- file:(\{[^}]+\}) -->/)
+          return !!match && match[1].includes('.pdf') && !match[1].includes('attachments')
         },
-        { timeout: 15_000 }
+        { timeout: 20_000 }
       )
       .toBe(true)
   })
 
-  test('shows a resize handle and persists the new width', async ({ page, testVaultPath }) => {
+  test('shows a resize handle and persists the new width', async ({ page }) => {
     await ready(page)
 
     const pdfId = await importPdf(page)
@@ -180,20 +197,11 @@ test.describe('PDF embed via sidebar drag + resize', () => {
       .poll(async () => Number(await page.getByRole('slider').getAttribute('aria-valuenow')))
       .toBeLessThan(before)
 
-    // The width round-trips to the vault marker.
+    // The width round-trips to the persisted note markdown.
     await expect
-      .poll(
-        () => {
-          const notesDir = path.join(testVaultPath, 'notes')
-          return fs
-            .readdirSync(notesDir)
-            .filter((f) => f.endsWith('.md'))
-            .some((f) =>
-              /<!-- file:\{[^}]*"width":\d+/.test(fs.readFileSync(path.join(notesDir, f), 'utf8'))
-            )
-        },
-        { timeout: 15_000 }
-      )
+      .poll(async () => /<!-- file:\{[^}]*"width":\d+/.test(await noteMarkdown(page, targetId)), {
+        timeout: 20_000
+      })
       .toBe(true)
   })
 })

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -7,12 +7,11 @@ controls, and other file types appear as download blocks.
 
 ## Adding Files
 
-Two ways:
+Three ways:
 
-- **Drag and drop** — drop a file from your OS file manager onto the editor at the position you want it
-- **Slash menu** — `/file` inserts a File block; click to pick a file
-
-Files are **copied** into the vault attachments directory (`<vault>/attachments/`), so the original on your filesystem can be moved or deleted without breaking the note.
+- **Drag from your OS file manager** — drop a file onto the editor at the position you want it. The file is **copied** into the vault attachments directory (`<vault>/attachments/`), so the original on your filesystem can be moved or deleted without breaking the note.
+- **Drag from the sidebar** — drag a file item (PDF, image, audio, …) from the left sidebar onto a note. This **embeds it by reference** using the item's own vault path, so no second copy is made.
+- **Slash menu** — `/file` inserts a File block; click to pick a file.
 
 ## File Block
 
@@ -26,13 +25,14 @@ Each attachment renders as a block with:
 
 ## PDF Inline Preview
 
-PDFs render in an embedded scrollable viewer right in the editor. Useful for reading PDF source material while taking notes.
+PDFs render inline as a clean first-page preview — no viewer chrome — so a note reads as a document with its source embedded. Open the file page (double-click the sidebar item) for the full multi-page viewer with zoom and find-in-page.
 
-The preview honors:
+Hover the preview, or click to select it, to reveal its controls:
 
-- Zoom (browser zoom or per-block scale)
-- Find-in-page (the embedded viewer's find, not memrynote's)
-- Multi-page scrolling
+- **Resize** — drag either bottom corner. Width scales the whole embed like an image; dragging upward shortens it, cropping the first page from the top so only the opening shows (no inner scroll).
+- **Align** — the top-right toolbar aligns the embed **left**, **center**, or **right** within the note column.
+
+Size, crop, and alignment are **saved with the note** and restored when you reopen it.
 
 ## Audio Attachments
 

--- a/docs/superpowers/specs/2026-07-16-resizable-pdf-embed-design.md
+++ b/docs/superpowers/specs/2026-07-16-resizable-pdf-embed-design.md
@@ -1,0 +1,130 @@
+# Resizable inline PDF embeds
+
+**Date:** 2026-07-16
+**Status:** Approved design → implementation
+**Scope:** Desktop app, note editor. PDF-in-note embeds only.
+
+## Problem
+
+PDFs embedded in a note render at a hardcoded width (`480px` when the page
+sidebar is open, `600px` otherwise) with a fixed `max-h-[400px]` scroll box.
+There is no way to make a PDF bigger or smaller. Landscape and portrait PDFs
+both get the same fixed width, so neither reads well. Users want to adjust the
+display size per embedded PDF.
+
+## Non-goals
+
+- The full-page standalone `PdfViewer` (`components/viewers/pdf-viewer.tsx`)
+  already has its own zoom; it is untouched.
+- Images are BlockNote's default `image` block with its own native resize
+  handle; out of scope.
+- Non-PDF file cards (the generic attachment card in the same `file` block)
+  keep their current fixed layout.
+- Keyboard arrow-nudge resize — deferred (nice-to-have, not in this pass).
+
+## Model
+
+Drag = **width**, aspect-locked. `react-pdf`'s `<Page width={n}>` derives the
+rendered height from the PDF page's native aspect ratio, so a single `width`
+value handles both orientations correctly:
+
+- Landscape (e.g. 16:9) at width 600 → short and wide.
+- Portrait (e.g. A4) at width 600 → tall and narrow.
+
+No independent height (would distort or crop the page). No zoom/scale state.
+
+## Design
+
+### 1. Data & persistence
+
+- Add `width: { default: 0 }` to the `file` block `propSchema` in
+  `renderer/src/components/note/content-area/file-block.tsx` and to the
+  `FileBlockProps` interface in `file-block-markers.ts`.
+- `0` is the sentinel for "no explicit width → use the default". This keeps
+  every existing PDF marker (which has no `width` field) rendering exactly as
+  before — **backward-compatible, no migration needed**.
+- Persistence is free: the block already serializes its whole props object to a
+  `<!-- file:{...} -->` HTML-comment marker via `serializeFileBlock`, and parses
+  it back via `parseFileBlockMarker` (`file-block-markers.ts`). A numeric
+  `width` field round-trips automatically and is safe with the existing
+  `FILE_BLOCK_REGEX` (`/<!-- file:(\{[^}]+\}) --/g`) because the value has no
+  nested braces.
+- Keep the main-side duplicate in `main/import/_shared/attachment-markdown.ts`
+  (`serializeFileBlockMarker`, `FileBlockProps` shape) in sync. Importers keep
+  omitting `width`, so imported PDFs get the default — no behavior change there.
+- The main-side sync/CRDT converter (`main/sync/blocknote-converter.ts`) does
+  not handle `file` blocks, so no change is needed there; the vault round-trip
+  runs entirely through the renderer serializer.
+
+### 2. Rendering
+
+In `PdfPreview` (`file-block.tsx`):
+
+- Resolve the effective page width: `props.width || (sidebarOpen ? 480 : 600)`.
+- Clamp the rendered width to the editor column width via a container ref /
+  `ResizeObserver` (or `max-width: 100%` on the wrapper) so a stored width wider
+  than the current window never overflows horizontally.
+- Relax the `max-h-[400px]` cap on the page scroll container so an enlarged page
+  grows vertically instead of scrolling inside a fixed box. (Very tall portrait
+  pages still get a sane upper bound / natural page flow — see edge cases.)
+- Pass the resolved width to `<Page width={...} />`. Thumbnail sidebar width and
+  its `480 vs 600` split are preserved as the _default_ only.
+
+### 3. Interaction — the drag handle
+
+- A bottom-right corner handle overlaid on the PDF page, revealed on hover or
+  when the block is selected.
+- Pointer-drag adjusts **width** (aspect-locked; height auto-follows).
+- Uses **pointer capture** (`setPointerCapture`) and `stopPropagation` /
+  `preventDefault` so dragging never starts a text selection, moves the
+  BlockNote block, or bubbles into the editor.
+- During drag: track width in **local component state** for smooth 60fps
+  feedback. **Commit once on pointer-up** by writing the final width to the
+  block prop (`editor.updateBlock` / the block's prop-update path) — avoids
+  spamming CRDT/IPC on every pointer move.
+- Clamp: `min ≈ 240px` → `max = editor column width`. Gentle snap to full
+  column width when released within a small threshold of the edge.
+- Rendered **only when `isPdf`** (`mimeType === 'application/pdf'`).
+
+### 4. Accessibility & motion
+
+- The handle is focusable, has a visible focus ring and an `aria-label`
+  (e.g. "Resize PDF").
+- Hover reveal is instant / respects `prefers-reduced-motion` (no motion
+  requirement; if any transition is added it is gated by the existing global
+  reduced-motion guard).
+- Cursor: `nwse-resize` (or `ew-resize`) while over the handle.
+
+## Edge cases
+
+- **Window narrower than stored width:** render clamps to column width; the
+  stored prop value is unchanged (restores when the window widens).
+- **Sidebar open:** the page width is derived from the resolved width; sidebar
+  remains laid out beside/over it as today. Default falls back to `480` when
+  open, `600` when closed.
+- **Very tall portrait page:** width is bounded by column width, so height is
+  bounded by `columnWidth × aspectRatio`; acceptable. No separate height cap
+  needed once width is clamped.
+- **Multi-page nav / thumbnails:** unaffected; width applies to the currently
+  displayed page.
+- **Old markers without `width`:** `props.width` is `0` → default path → byte
+  identical output until the user resizes.
+
+## Verification
+
+- Unit: serialize → parse round-trip for a `file` block with a numeric `width`
+  (asserts the marker JSON carries `width` and parses back). Assert a marker
+  _without_ `width` parses to `width: 0` (default) and re-serializes byte for
+  byte unchanged when width stays default.
+- Manual (live Electron in the worktree): embed a landscape PDF and a portrait
+  PDF, drag the handle, confirm each scales aspect-correctly; reload the note
+  and confirm the size persisted; inspect the vault `.md` and confirm the
+  `width` field is present in the marker.
+
+## Rollout / compat
+
+- Purely additive prop with a safe default. No DB schema change, no sync
+  contract change, no vault format break. Existing installs open older notes
+  unchanged; newly-resized PDFs write a `width` field older app versions will
+  simply ignore (unknown JSON key → dropped on their parse, falls back to
+  default). Forward/backward tolerant.

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -504,7 +504,10 @@
       "download": "Download",
       "download2": "Download",
       "noFileAttached": "No file attached",
-      "resizePdf": "Resize PDF"
+      "resizePdf": "Resize PDF",
+      "alignLeft": "Align left",
+      "alignCenter": "Align center",
+      "alignRight": "Align right"
     },
     "componentsNoteContentAreaTaskBlockTaskBlockRenderer": {
       "openInTaskPanel": "Open in task panel",

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -503,7 +503,8 @@
       "failedToLoadPdf": "Failed to load PDF: ",
       "download": "Download",
       "download2": "Download",
-      "noFileAttached": "No file attached"
+      "noFileAttached": "No file attached",
+      "resizePdf": "Resize PDF"
     },
     "componentsNoteContentAreaTaskBlockTaskBlockRenderer": {
       "openInTaskPanel": "Open in task panel",


### PR DESCRIPTION
## What
- Inline PDF embeds now render as a chromeless first-page preview; drag either bottom corner to resize — width scales the whole embed like an image, dragging up crops the first page from the top (no inner scroll).
- Hover toolbar aligns the embed left/center/right within the note column. Size, crop, and alignment persist in the file marker and restore on reopen.
- Dragging a file item (PDF/image/audio) from the left sidebar embeds it by its own vault path — no copy into `attachments/`.
- Fix: react-pdf's text layer no longer intercepts clicks/drags on the embed controls (z-index).