### PR TITLE
feat(desktop): retire keytar → safeStorage secret storage (dual-read migration)

### DIFF
--- a/apps/desktop/src/main/agent/backends/local-provider-keychain.ts
+++ b/apps/desktop/src/main/agent/backends/local-provider-keychain.ts
@@ -1,4 +1,4 @@
-import keytar from 'keytar'
+import { deleteSecret, getSecret, setSecret } from '../../secrets/secret-storage'
 
 const SERVICE = 'memry.agent.local-provider'
 const ACCOUNT_BASE = 'api-key'
@@ -9,7 +9,7 @@ function account(): string {
 }
 
 export async function getLocalProviderApiKey(): Promise<string | null> {
-  return keytar.getPassword(SERVICE, account())
+  return getSecret(SERVICE, account())
 }
 
 export async function hasLocalProviderApiKey(): Promise<boolean> {
@@ -18,8 +18,8 @@ export async function hasLocalProviderApiKey(): Promise<boolean> {
 
 export async function setLocalProviderApiKey(value: string | null): Promise<void> {
   if (!value) {
-    await keytar.deletePassword(SERVICE, account())
+    await deleteSecret(SERVICE, account())
     return
   }
-  await keytar.setPassword(SERVICE, account(), value)
+  await setSecret(SERVICE, account(), value)
 }

--- a/apps/desktop/src/main/calendar/google/keychain.ts
+++ b/apps/desktop/src/main/calendar/google/keychain.ts
@@ -1,4 +1,4 @@
-import keytar from 'keytar'
+import { deleteSecret, getSecret, setSecret } from '../../secrets/secret-storage'
 
 const SERVICE = 'com.memry.calendar.google'
 
@@ -24,11 +24,11 @@ async function setPassword(
 
   try {
     if (!value || value.trim().length === 0) {
-      await keytar.deletePassword(SERVICE, account)
+      await deleteSecret(SERVICE, account)
       return
     }
 
-    await keytar.setPassword(SERVICE, account, value.trim())
+    await setSecret(SERVICE, account, value.trim())
   } catch (error) {
     throw new Error(
       `Failed to store Google Calendar credential (${account}): ${error instanceof Error ? error.message : 'unknown error'}`
@@ -40,7 +40,7 @@ async function getPassword(accountId: string, kind: GoogleTokenKind): Promise<st
   const account = getAccountKey(accountId, kind)
 
   try {
-    return await keytar.getPassword(SERVICE, account)
+    return await getSecret(SERVICE, account)
   } catch (error) {
     throw new Error(
       `Failed to read Google Calendar credential (${account}): ${error instanceof Error ? error.message : 'unknown error'}`
@@ -52,7 +52,7 @@ async function deletePassword(accountId: string, kind: GoogleTokenKind): Promise
   const account = getAccountKey(accountId, kind)
 
   try {
-    await keytar.deletePassword(SERVICE, account)
+    await deleteSecret(SERVICE, account)
   } catch (error) {
     throw new Error(
       `Failed to delete Google Calendar credential (${account}): ${error instanceof Error ? error.message : 'unknown error'}`

--- a/apps/desktop/src/main/capture/pairing.ts
+++ b/apps/desktop/src/main/capture/pairing.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto'
-import keytar from 'keytar'
+import { deleteSecret, getSecret, setSecret } from '../secrets/secret-storage'
 import { store } from '../store'
 import { isExtensionOrigin } from './auth'
 
@@ -23,9 +23,9 @@ export async function getCaptureToken(): Promise<string> {
   if (cachedToken) return cachedToken
   if (inFlightRead) return inFlightRead
   inFlightRead = (async () => {
-    const existing = await keytar.getPassword(SERVICE, ACCOUNT)
+    const existing = await getSecret(SERVICE, ACCOUNT)
     const token = existing ?? generateToken()
-    if (!existing) await keytar.setPassword(SERVICE, ACCOUNT, token)
+    if (!existing) await setSecret(SERVICE, ACCOUNT, token)
     cachedToken = token
     return token
   })()
@@ -38,7 +38,7 @@ export async function getCaptureToken(): Promise<string> {
 
 export async function rotateCaptureToken(): Promise<string> {
   const token = generateToken()
-  await keytar.setPassword(SERVICE, ACCOUNT, token)
+  await setSecret(SERVICE, ACCOUNT, token)
   cachedToken = token
   store.set(ALLOWLIST_KEY, [])
   claimWindowUntil = 0
@@ -46,7 +46,7 @@ export async function rotateCaptureToken(): Promise<string> {
 }
 
 export async function unpairCapture(): Promise<void> {
-  await keytar.deletePassword(SERVICE, ACCOUNT)
+  await deleteSecret(SERVICE, ACCOUNT)
   cachedToken = null
   store.set(ALLOWLIST_KEY, [])
   claimWindowUntil = 0

--- a/apps/desktop/src/main/crypto/keychain.ts
+++ b/apps/desktop/src/main/crypto/keychain.ts
@@ -1,12 +1,36 @@
 import keytar from 'keytar'
 import sodium from 'libsodium-wrappers-sumo'
 
+import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
 import type { KeychainEntry } from '@memry/contracts/crypto'
 
-import { resolveKeychainAccount } from './keychain-account'
+import {
+  deleteSecret,
+  finalizeKeytarMigration,
+  getSecret,
+  setSecret
+} from '../secrets/secret-storage'
+import { normalizeDeviceSuffix, resolveKeychainAccount } from './keychain-account'
 
 function resolveAccount(entry: KeychainEntry): string {
   return resolveKeychainAccount(entry, process.env.MEMRY_DEVICE)
+}
+
+// Plain-dev worktrees share one master key through the machine-global OS
+// keychain (the per-worktree dev hash collapses to a stable `dev` account, see
+// keychain-account.ts) while userData — and therefore the safeStorage store
+// file — stays per-worktree. Migrating out of keytar there would strand the
+// shared key for every other worktree, so plain `pnpm dev` keeps keytar
+// authoritative. Production (no MEMRY_DEVICE) and explicit devices migrate.
+function usesSharedDevKeychain(): boolean {
+  return normalizeDeviceSuffix(process.env.MEMRY_DEVICE) === 'dev'
+}
+
+function isMasterKeyEntry(entry: KeychainEntry): boolean {
+  return (
+    entry.service === KEYCHAIN_ENTRIES.MASTER_KEY.service &&
+    entry.account === KEYCHAIN_ENTRIES.MASTER_KEY.account
+  )
 }
 
 // The OS keychain hangs under automated e2e (an adhoc-signed/headless build
@@ -14,7 +38,9 @@ function resolveAccount(entry: KeychainEntry): string {
 // daemon), which would leave the agent runtime stuck starting forever. Under
 // NODE_ENV=test only, bound each keychain call so a hang degrades to the
 // not-found path instead of blocking. In unit tests keytar is mocked and
-// resolves instantly, so the timeout never fires there.
+// resolves instantly, so the timeout never fires there. The bound wraps the
+// whole dual-read (safeStorage store first, keytar fallback), so the keytar
+// fallback path stays covered.
 const KEYCHAIN_TEST_TIMEOUT_MS = 400
 const isTestEnv = process.env.NODE_ENV === 'test'
 
@@ -31,15 +57,20 @@ async function withTestTimeout<T>(op: Promise<T>, fallback: T): Promise<T> {
   }
 }
 
-// Accepted risk: keytar stores strings, so keys are base64-encoded in OS keychain memory.
-// The base64 copy is an inherent JS/keytar limitation — no way to securely zero a JS string.
-// Mitigated by: OS keychain encryption at rest, short-lived Uint8Array on retrieval.
+// Accepted risk: secrets are stored as strings, so keys are base64-encoded in
+// memory during store/retrieve. The base64 copy is an inherent JS limitation —
+// no way to securely zero a JS string. Mitigated by: encryption at rest
+// (safeStorage or OS keychain), short-lived Uint8Array on retrieval.
 export const storeKey = async (entry: KeychainEntry, key: Uint8Array): Promise<void> => {
   await sodium.ready
   const encoded = sodium.to_base64(key, sodium.base64_variants.ORIGINAL)
   const account = resolveAccount(entry)
   try {
-    await withTestTimeout(keytar.setPassword(entry.service, account, encoded), undefined)
+    if (usesSharedDevKeychain()) {
+      await withTestTimeout(keytar.setPassword(entry.service, account, encoded), undefined)
+    } else {
+      await withTestTimeout(setSecret(entry.service, account, encoded), undefined)
+    }
   } catch (err) {
     throw new Error(
       `Failed to store key in keychain (${account}): ${err instanceof Error ? err.message : 'unknown error'}`
@@ -52,7 +83,17 @@ export const retrieveKey = async (entry: KeychainEntry): Promise<Uint8Array | nu
   const account = resolveAccount(entry)
   let encoded: string | null
   try {
-    encoded = await withTestTimeout(keytar.getPassword(entry.service, account), null)
+    if (usesSharedDevKeychain()) {
+      encoded = await withTestTimeout(keytar.getPassword(entry.service, account), null)
+    } else {
+      // The master key's OS keychain copy is only dropped after the retrieved
+      // key has been confirmed against the vault verifier — see
+      // confirmMasterKeyMigrated and crypto/vault-key-state.ts.
+      encoded = await withTestTimeout(
+        getSecret(entry.service, account, { deferKeytarDelete: isMasterKeyEntry(entry) }),
+        null
+      )
+    }
   } catch (err) {
     throw new Error(
       `Failed to retrieve key from keychain (${account}): ${err instanceof Error ? err.message : 'unknown error'}`
@@ -69,10 +110,28 @@ export const retrieveKey = async (entry: KeychainEntry): Promise<Uint8Array | nu
 export const deleteKey = async (entry: KeychainEntry): Promise<void> => {
   const account = resolveAccount(entry)
   try {
-    await keytar.deletePassword(entry.service, account)
+    if (usesSharedDevKeychain()) {
+      await keytar.deletePassword(entry.service, account)
+    } else {
+      await deleteSecret(entry.service, account)
+    }
   } catch (err) {
     throw new Error(
       `Failed to delete key from keychain (${account}): ${err instanceof Error ? err.message : 'unknown error'}`
     )
   }
+}
+
+/**
+ * Finish the master key's deferred safeStorage migration. Called once the
+ * retrieved key has been confirmed against the vault verifier; only then is
+ * the OS keychain copy deleted (and only while it is byte-identical to the
+ * safeStorage copy). Idempotent, crash-resumable, never throws.
+ */
+export const confirmMasterKeyMigrated = async (): Promise<void> => {
+  if (usesSharedDevKeychain()) return
+  await finalizeKeytarMigration(
+    KEYCHAIN_ENTRIES.MASTER_KEY.service,
+    resolveAccount(KEYCHAIN_ENTRIES.MASTER_KEY)
+  )
 }

--- a/apps/desktop/src/main/crypto/vault-key-state.ts
+++ b/apps/desktop/src/main/crypto/vault-key-state.ts
@@ -5,7 +5,7 @@ import * as schema from '@memry/db-schema/data-schema'
 import { KEYCHAIN_ENTRIES, KEY_DERIVATION_CONTEXTS } from '@memry/contracts/crypto'
 
 import type { DataDb } from '../database/types'
-import { retrieveKey, storeKey } from './keychain'
+import { confirmMasterKeyMigrated, retrieveKey, storeKey } from './keychain'
 import { deriveKey } from './keys'
 import { lockKeyMaterial } from './memory-lock'
 import { secureCleanup } from './primitives'
@@ -85,6 +85,9 @@ export async function getOrInitializeLocalVaultKey(
     try {
       bindOrVerifyVaultKey(db, vaultId, vaultKey, expectedVerifier)
       keepVaultKey = true
+      // The master key just passed the vault verifier check — safe to finish
+      // its safeStorage migration by dropping the OS keychain copy.
+      await confirmMasterKeyMigrated()
       return vaultKey
     } finally {
       if (!keepVaultKey) secureCleanup(vaultKey)

--- a/apps/desktop/src/main/inbox/voice-transcription-keychain.ts
+++ b/apps/desktop/src/main/inbox/voice-transcription-keychain.ts
@@ -1,4 +1,4 @@
-import keytar from 'keytar'
+import { deleteSecret, getSecret, setSecret } from '../secrets/secret-storage'
 
 const SERVICE = 'memry.voice-transcription'
 const OPENAI_ACCOUNT = 'openai'
@@ -10,7 +10,7 @@ function resolveAccount(account: string): string {
 
 export async function getVoiceTranscriptionOpenAIApiKey(): Promise<string | null> {
   try {
-    return await keytar.getPassword(SERVICE, resolveAccount(OPENAI_ACCOUNT))
+    return await getSecret(SERVICE, resolveAccount(OPENAI_ACCOUNT))
   } catch (error) {
     throw new Error(
       `Failed to read voice transcription API key: ${error instanceof Error ? error.message : 'unknown error'}`
@@ -29,11 +29,11 @@ export async function setVoiceTranscriptionOpenAIApiKey(apiKey: string): Promise
   try {
     const account = resolveAccount(OPENAI_ACCOUNT)
     if (trimmed.length === 0) {
-      await keytar.deletePassword(SERVICE, account)
+      await deleteSecret(SERVICE, account)
       return
     }
 
-    await keytar.setPassword(SERVICE, account, trimmed)
+    await setSecret(SERVICE, account, trimmed)
   } catch (error) {
     throw new Error(
       `Failed to store voice transcription API key: ${error instanceof Error ? error.message : 'unknown error'}`

--- a/apps/desktop/src/main/secrets/secret-storage-callsites.test.ts
+++ b/apps/desktop/src/main/secrets/secret-storage-callsites.test.ts
@@ -1,0 +1,382 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import Database from 'better-sqlite3'
+import sodium from 'libsodium-wrappers-sumo'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as schema from '@memry/db-schema/data-schema'
+import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+
+const harness = vi.hoisted(() => {
+  const keytarStore = new Map<string, string>()
+  return {
+    appReady: true,
+    encryptionAvailable: true,
+    userDataDir: '',
+    keytarStore,
+    keytarGet: vi.fn(async (s: string, a: string) => keytarStore.get(`${s}:${a}`) ?? null),
+    keytarSet: vi.fn(async (s: string, a: string, v: string) => {
+      keytarStore.set(`${s}:${a}`, v)
+    }),
+    keytarDelete: vi.fn(async (s: string, a: string) => keytarStore.delete(`${s}:${a}`))
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    isReady: () => harness.appReady,
+    getPath: () => harness.userDataDir
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => harness.encryptionAvailable,
+    getSelectedStorageBackend: () => 'keychain_access',
+    encryptString: (value: string) => Buffer.from(`enc:${value}`, 'utf-8'),
+    decryptString: (buf: Buffer) => {
+      const raw = buf.toString('utf-8')
+      if (!raw.startsWith('enc:')) throw new Error('safeStorage decrypt failed')
+      return raw.slice(4)
+    }
+  }
+}))
+
+vi.mock('keytar', () => ({
+  default: {
+    getPassword: harness.keytarGet,
+    setPassword: harness.keytarSet,
+    deletePassword: harness.keytarDelete
+  }
+}))
+
+vi.mock('../store', () => ({
+  store: {
+    get: () => undefined,
+    set: () => undefined
+  }
+}))
+
+import { resetSecretStorageForTests, SECRET_STORE_FILENAME } from './secret-storage'
+import { confirmMasterKeyMigrated, deleteKey, retrieveKey, storeKey } from '../crypto/keychain'
+import { getGoogleCalendarTokens, storeGoogleCalendarTokens } from '../calendar/google/keychain'
+import {
+  getVoiceTranscriptionOpenAIApiKey,
+  setVoiceTranscriptionOpenAIApiKey
+} from '../inbox/voice-transcription-keychain'
+import {
+  getLocalProviderApiKey,
+  setLocalProviderApiKey
+} from '../agent/backends/local-provider-keychain'
+import { getOrInitializeLocalVaultKey } from '../crypto/vault-key-state'
+
+const MASTER = KEYCHAIN_ENTRIES.MASTER_KEY
+const SIGNING = KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY
+
+const toB64 = (bytes: Uint8Array): string =>
+  sodium.to_base64(bytes, sodium.base64_variants.ORIGINAL)
+
+const cipherFor = (value: string): string => Buffer.from(`enc:${value}`, 'utf-8').toString('base64')
+
+const readStoreJson = (): { entries: Record<string, Record<string, string>> } =>
+  JSON.parse(fs.readFileSync(path.join(harness.userDataDir, SECRET_STORE_FILENAME), 'utf-8'))
+
+const storeFileExists = (): boolean =>
+  fs.existsSync(path.join(harness.userDataDir, SECRET_STORE_FILENAME))
+
+function freshDb() {
+  const sqlite = new Database(':memory:')
+  sqlite.exec(`
+    CREATE TABLE settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      modified_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    );
+
+    CREATE TABLE agent_conversations (
+      id TEXT PRIMARY KEY,
+      vault_id TEXT NOT NULL,
+      title_ciphertext TEXT NOT NULL,
+      backend TEXT NOT NULL,
+      backend_model TEXT,
+      trust_list TEXT NOT NULL DEFAULT '[]',
+      pinned INTEGER NOT NULL DEFAULT 0,
+      vector_clock TEXT NOT NULL,
+      field_clocks TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER,
+      last_synced_at INTEGER
+    );
+
+    CREATE TABLE agent_messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content_ciphertext TEXT NOT NULL,
+      attachments_ciphertext TEXT NOT NULL,
+      tool_call_id TEXT,
+      status TEXT NOT NULL,
+      vector_clock TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER
+    );
+  `)
+  return drizzle(sqlite, { schema })
+}
+
+describe('secret-storage call sites — account string preservation and migration', () => {
+  beforeAll(async () => {
+    await sodium.ready
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSecretStorageForTests()
+    harness.appReady = true
+    harness.encryptionAvailable = true
+    harness.keytarStore.clear()
+    harness.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-secret-callsites-'))
+    delete process.env.MEMRY_DEVICE
+  })
+
+  afterEach(() => {
+    delete process.env.MEMRY_DEVICE
+    fs.rmSync(harness.userDataDir, { recursive: true, force: true })
+  })
+
+  // --------------------------------------------------------------------------
+  // crypto/keychain — vault master key and sync keys
+  // --------------------------------------------------------------------------
+
+  describe('crypto/keychain', () => {
+    it('stores keys under the exact device-suffixed account (MEMRY_DEVICE=A)', async () => {
+      process.env.MEMRY_DEVICE = 'A'
+      const key = new Uint8Array([1, 2, 3, 4])
+
+      await storeKey(MASTER, key)
+
+      expect(readStoreJson().entries['com.memry.sync']['master-key-A']).toBe(cipherFor(toB64(key)))
+      expect(harness.keytarSet).not.toHaveBeenCalled()
+      await expect(retrieveKey(MASTER)).resolves.toEqual(key)
+    })
+
+    it('migrates a non-master key from keytar immediately after verification', async () => {
+      const key = new Uint8Array([9, 8, 7])
+      harness.keytarStore.set(`${SIGNING.service}:${SIGNING.account}`, toB64(key))
+
+      await expect(retrieveKey(SIGNING)).resolves.toEqual(key)
+
+      expect(readStoreJson().entries[SIGNING.service][SIGNING.account]).toBe(cipherFor(toB64(key)))
+      expect(harness.keytarDelete).toHaveBeenCalledWith(SIGNING.service, SIGNING.account)
+    })
+
+    it('defers the master key keytar delete until confirmMasterKeyMigrated', async () => {
+      const key = new Uint8Array([5, 5, 5, 5])
+      harness.keytarStore.set(`${MASTER.service}:${MASTER.account}`, toB64(key))
+
+      await expect(retrieveKey(MASTER)).resolves.toEqual(key)
+
+      expect(readStoreJson().entries[MASTER.service][MASTER.account]).toBe(cipherFor(toB64(key)))
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+      expect(harness.keytarStore.get(`${MASTER.service}:${MASTER.account}`)).toBe(toB64(key))
+
+      await confirmMasterKeyMigrated()
+
+      expect(harness.keytarDelete).toHaveBeenCalledWith(MASTER.service, MASTER.account)
+      expect(harness.keytarStore.has(`${MASTER.service}:${MASTER.account}`)).toBe(false)
+    })
+
+    it('keeps keytar authoritative for plain-dev worktrees (shared dev keychain)', async () => {
+      process.env.MEMRY_DEVICE = 'dev-0123abcd'
+      const key = new Uint8Array([7, 7, 7])
+
+      await storeKey(MASTER, key)
+
+      expect(harness.keytarSet).toHaveBeenCalledWith('com.memry.sync', 'master-key-dev', toB64(key))
+      expect(storeFileExists()).toBe(false)
+
+      await expect(retrieveKey(MASTER)).resolves.toEqual(key)
+      await confirmMasterKeyMigrated()
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+
+      await deleteKey(MASTER)
+      expect(harness.keytarDelete).toHaveBeenCalledWith('com.memry.sync', 'master-key-dev')
+    })
+
+    it('completes the master key migration only after the vault verifier accepts the key', async () => {
+      const db = freshDb()
+      const masterKey = sodium.randombytes_buf(32)
+      harness.keytarStore.set(`${MASTER.service}:${MASTER.account}`, toB64(masterKey))
+
+      const vaultKey = await getOrInitializeLocalVaultKey(db, 'vault-1')
+
+      expect(vaultKey).toHaveLength(32)
+      // Migration persisted the key and, because the verifier check passed,
+      // the OS keychain copy is gone.
+      expect(readStoreJson().entries[MASTER.service][MASTER.account]).toBe(
+        cipherFor(toB64(masterKey))
+      )
+      expect(harness.keytarStore.has(`${MASTER.service}:${MASTER.account}`)).toBe(false)
+    })
+
+    it('keeps the keytar master key when the vault verifier rejects it', async () => {
+      const db = freshDb()
+      const boundKey = sodium.randombytes_buf(32)
+      const otherKey = sodium.randombytes_buf(32)
+
+      // Bind the vault to one key, then present a different one from keytar.
+      harness.keytarStore.set(`${MASTER.service}:${MASTER.account}`, toB64(boundKey))
+      await getOrInitializeLocalVaultKey(db, 'vault-1')
+
+      resetSecretStorageForTests()
+      harness.keytarStore.set(`${MASTER.service}:${MASTER.account}`, toB64(otherKey))
+      fs.rmSync(path.join(harness.userDataDir, SECRET_STORE_FILENAME), { force: true })
+      harness.keytarDelete.mockClear()
+
+      await expect(getOrInitializeLocalVaultKey(db, 'vault-1')).rejects.toThrow(
+        'Current master key does not match this vault'
+      )
+
+      // Verification failed — the OS keychain copy must survive.
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+      expect(harness.keytarStore.get(`${MASTER.service}:${MASTER.account}`)).toBe(toB64(otherKey))
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Google Calendar tokens
+  // --------------------------------------------------------------------------
+
+  describe('calendar/google/keychain', () => {
+    it('preserves the per-account per-kind per-device account strings', async () => {
+      process.env.MEMRY_DEVICE = 'A'
+
+      await storeGoogleCalendarTokens({
+        accountId: 'alice@example.com',
+        accessToken: 'alice-access',
+        refreshToken: 'alice-refresh'
+      })
+
+      const entries = readStoreJson().entries['com.memry.calendar.google']
+      expect(entries['access-token-alice@example.com-A']).toBe(cipherFor('alice-access'))
+      expect(entries['refresh-token-alice@example.com-A']).toBe(cipherFor('alice-refresh'))
+      expect(harness.keytarSet).not.toHaveBeenCalled()
+    })
+
+    it('migrates legacy keytar tokens read under the identical account strings', async () => {
+      harness.keytarStore.set(
+        'com.memry.calendar.google:access-token-bob@example.com',
+        'bob-access'
+      )
+      harness.keytarStore.set(
+        'com.memry.calendar.google:refresh-token-bob@example.com',
+        'bob-refresh'
+      )
+
+      await expect(getGoogleCalendarTokens('bob@example.com')).resolves.toEqual({
+        accessToken: 'bob-access',
+        refreshToken: 'bob-refresh'
+      })
+
+      const entries = readStoreJson().entries['com.memry.calendar.google']
+      expect(entries['access-token-bob@example.com']).toBe(cipherFor('bob-access'))
+      expect(entries['refresh-token-bob@example.com']).toBe(cipherFor('bob-refresh'))
+      expect(harness.keytarDelete).toHaveBeenCalledWith(
+        'com.memry.calendar.google',
+        'access-token-bob@example.com'
+      )
+      expect(harness.keytarDelete).toHaveBeenCalledWith(
+        'com.memry.calendar.google',
+        'refresh-token-bob@example.com'
+      )
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Voice transcription API key
+  // --------------------------------------------------------------------------
+
+  describe('inbox/voice-transcription-keychain', () => {
+    it('preserves the device-suffixed account string', async () => {
+      process.env.MEMRY_DEVICE = 'A'
+
+      await setVoiceTranscriptionOpenAIApiKey('sk-voice')
+
+      expect(readStoreJson().entries['memry.voice-transcription']['openai-A']).toBe(
+        cipherFor('sk-voice')
+      )
+    })
+
+    it('migrates the legacy keytar key on read', async () => {
+      harness.keytarStore.set('memry.voice-transcription:openai', 'sk-legacy')
+
+      await expect(getVoiceTranscriptionOpenAIApiKey()).resolves.toBe('sk-legacy')
+
+      expect(readStoreJson().entries['memry.voice-transcription']['openai']).toBe(
+        cipherFor('sk-legacy')
+      )
+      expect(harness.keytarDelete).toHaveBeenCalledWith('memry.voice-transcription', 'openai')
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Agent local provider API key
+  // --------------------------------------------------------------------------
+
+  describe('agent/backends/local-provider-keychain', () => {
+    it('preserves the colon-separated device account string', async () => {
+      process.env.MEMRY_DEVICE = ' A '
+
+      await setLocalProviderApiKey('sk-local')
+
+      expect(readStoreJson().entries['memry.agent.local-provider']['api-key:A']).toBe(
+        cipherFor('sk-local')
+      )
+    })
+
+    it('migrates the legacy keytar key on read', async () => {
+      harness.keytarStore.set('memry.agent.local-provider:api-key', 'sk-legacy')
+
+      await expect(getLocalProviderApiKey()).resolves.toBe('sk-legacy')
+
+      expect(readStoreJson().entries['memry.agent.local-provider']['api-key']).toBe(
+        cipherFor('sk-legacy')
+      )
+      expect(harness.keytarDelete).toHaveBeenCalledWith('memry.agent.local-provider', 'api-key')
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Capture pairing token
+  // --------------------------------------------------------------------------
+
+  describe('capture/pairing', () => {
+    it('keeps the unsuffixed pairing-token account even when MEMRY_DEVICE is set', async () => {
+      process.env.MEMRY_DEVICE = 'A'
+      vi.resetModules()
+      const { getCaptureToken } = await import('../capture/pairing')
+
+      const token = await getCaptureToken()
+
+      expect(token).toHaveLength(64)
+      expect(readStoreJson().entries['com.memry.capture']['pairing-token']).toBe(cipherFor(token))
+      expect(harness.keytarSet).not.toHaveBeenCalled()
+    })
+
+    it('migrates a legacy keytar pairing token on read', async () => {
+      vi.resetModules()
+      const legacyToken = 'a'.repeat(64)
+      harness.keytarStore.set('com.memry.capture:pairing-token', legacyToken)
+      const { getCaptureToken } = await import('../capture/pairing')
+
+      await expect(getCaptureToken()).resolves.toBe(legacyToken)
+
+      expect(readStoreJson().entries['com.memry.capture']['pairing-token']).toBe(
+        cipherFor(legacyToken)
+      )
+      expect(harness.keytarDelete).toHaveBeenCalledWith('com.memry.capture', 'pairing-token')
+    })
+  })
+})

--- a/apps/desktop/src/main/secrets/secret-storage.test.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.test.ts
@@ -1,0 +1,452 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const harness = vi.hoisted(() => {
+  const keytarStore = new Map<string, string>()
+  return {
+    appReady: true,
+    encryptionAvailable: true,
+    backend: 'keychain_access',
+    userDataDir: '',
+    // encryptString prefixes the plaintext; decryptString requires decryptPrefix.
+    // Diverging the two simulates a broken safeStorage round-trip.
+    encryptPrefix: 'enc:',
+    decryptPrefix: 'enc:',
+    keytarStore,
+    keytarGet: vi.fn(async (s: string, a: string) => keytarStore.get(`${s}:${a}`) ?? null),
+    keytarSet: vi.fn(async (s: string, a: string, v: string) => {
+      keytarStore.set(`${s}:${a}`, v)
+    }),
+    keytarDelete: vi.fn(async (s: string, a: string) => keytarStore.delete(`${s}:${a}`))
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    isReady: () => harness.appReady,
+    getPath: (name: string) => {
+      if (name !== 'userData') throw new Error(`unexpected getPath(${name})`)
+      return harness.userDataDir
+    }
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => harness.encryptionAvailable,
+    getSelectedStorageBackend: () => harness.backend,
+    encryptString: (value: string) => Buffer.from(`${harness.encryptPrefix}${value}`, 'utf-8'),
+    decryptString: (buf: Buffer) => {
+      const raw = buf.toString('utf-8')
+      if (!raw.startsWith(harness.decryptPrefix)) throw new Error('safeStorage decrypt failed')
+      return raw.slice(harness.decryptPrefix.length)
+    }
+  }
+}))
+
+vi.mock('keytar', () => ({
+  default: {
+    getPassword: harness.keytarGet,
+    setPassword: harness.keytarSet,
+    deletePassword: harness.keytarDelete
+  }
+}))
+
+import {
+  SECRET_STORE_FILENAME,
+  deleteSecret,
+  finalizeKeytarMigration,
+  getSecret,
+  isSafeStorageAvailable,
+  resetSecretStorageForTests,
+  setSecret
+} from './secret-storage'
+
+const SERVICE = 'com.memry.test-service'
+const ACCOUNT = 'test-account'
+
+const originalPlatform = process.platform
+const setPlatform = (platform: string): void => {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+const storeFilePath = (): string => path.join(harness.userDataDir, SECRET_STORE_FILENAME)
+
+const readStoreJson = (): { version: number; entries: Record<string, Record<string, string>> } =>
+  JSON.parse(fs.readFileSync(storeFilePath(), 'utf-8'))
+
+const cipherFor = (value: string): string => Buffer.from(`enc:${value}`, 'utf-8').toString('base64')
+
+const seedStoreFile = (service: string, account: string, value: string): void => {
+  fs.mkdirSync(harness.userDataDir, { recursive: true })
+  fs.writeFileSync(
+    storeFilePath(),
+    JSON.stringify({ version: 1, entries: { [service]: { [account]: cipherFor(value) } } }),
+    'utf-8'
+  )
+}
+
+describe('secret-storage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSecretStorageForTests()
+    harness.appReady = true
+    harness.encryptionAvailable = true
+    harness.backend = 'keychain_access'
+    harness.encryptPrefix = 'enc:'
+    harness.decryptPrefix = 'enc:'
+    harness.keytarStore.clear()
+    harness.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-secret-storage-'))
+  })
+
+  afterEach(() => {
+    setPlatform(originalPlatform)
+    fs.rmSync(harness.userDataDir, { recursive: true, force: true })
+  })
+
+  // --------------------------------------------------------------------------
+  // Availability gating
+  // --------------------------------------------------------------------------
+
+  describe('isSafeStorageAvailable', () => {
+    it('is false before app ready even when encryption is available', () => {
+      harness.appReady = false
+      expect(isSafeStorageAvailable()).toBe(false)
+    })
+
+    it('is false when safeStorage reports encryption unavailable', () => {
+      harness.encryptionAvailable = false
+      expect(isSafeStorageAvailable()).toBe(false)
+    })
+
+    it('refuses the plaintext basic_text backend on Linux', () => {
+      setPlatform('linux')
+      harness.backend = 'basic_text'
+      expect(isSafeStorageAvailable()).toBe(false)
+    })
+
+    it('accepts a real keyring backend on Linux', () => {
+      setPlatform('linux')
+      harness.backend = 'gnome_libsecret'
+      expect(isSafeStorageAvailable()).toBe(true)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Dual-read + migrate-on-read
+  // --------------------------------------------------------------------------
+
+  describe('getSecret migration', () => {
+    it('migrates a keytar secret: encrypt, persist, verify, then delete from keytar', async () => {
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+
+      const value = await getSecret(SERVICE, ACCOUNT)
+
+      expect(value).toBe('legacy-value')
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('legacy-value'))
+      expect(harness.keytarDelete).toHaveBeenCalledWith(SERVICE, ACCOUNT)
+      expect(harness.keytarStore.has(`${SERVICE}:${ACCOUNT}`)).toBe(false)
+    })
+
+    it('does not migrate when encryption is unavailable but keytar reads still work', async () => {
+      harness.encryptionAvailable = false
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+
+      const value = await getSecret(SERVICE, ACCOUNT)
+
+      expect(value).toBe('legacy-value')
+      expect(fs.existsSync(storeFilePath())).toBe(false)
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+    })
+
+    it('does not migrate on the Linux basic_text backend; keytar stays authoritative', async () => {
+      setPlatform('linux')
+      harness.backend = 'basic_text'
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+
+      const value = await getSecret(SERVICE, ACCOUNT)
+
+      expect(value).toBe('legacy-value')
+      expect(fs.existsSync(storeFilePath())).toBe(false)
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+    })
+
+    it('keeps keytar authoritative and persists nothing when round-trip verification fails', async () => {
+      harness.encryptPrefix = 'garbled:' // decrypt of persisted bytes will fail
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+
+      const value = await getSecret(SERVICE, ACCOUNT)
+
+      expect(value).toBe('legacy-value')
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+      expect(harness.keytarStore.get(`${SERVICE}:${ACCOUNT}`)).toBe('legacy-value')
+      if (fs.existsSync(storeFilePath())) {
+        expect(readStoreJson().entries[SERVICE]?.[ACCOUNT]).toBeUndefined()
+      }
+    })
+
+    it('reads safeStorage first when both copies exist (dual-read order)', async () => {
+      await setSecret(SERVICE, ACCOUNT, 'store-value')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'keytar-value')
+
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('store-value')
+    })
+
+    it('falls back to keytar with the identical account string when the store has no entry', async () => {
+      harness.encryptionAvailable = false
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+
+      await getSecret(SERVICE, ACCOUNT)
+
+      expect(harness.keytarGet).toHaveBeenCalledWith(SERVICE, ACCOUNT)
+    })
+
+    it('is idempotent: repeat reads return the same value and delete from keytar only once', async () => {
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('legacy-value')
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('legacy-value')
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('legacy-value')
+
+      await vi.waitFor(() => {
+        expect(harness.keytarDelete).toHaveBeenCalledTimes(1)
+      })
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('legacy-value'))
+    })
+
+    it('resumes after a crash between persist and keytar delete without corruption', async () => {
+      // Simulates: previous run persisted + verified the ciphertext, crashed
+      // before keytar.deletePassword. Both copies exist and are identical.
+      seedStoreFile(SERVICE, ACCOUNT, 'legacy-value')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+
+      const value = await getSecret(SERVICE, ACCOUNT)
+
+      expect(value).toBe('legacy-value')
+      await vi.waitFor(() => {
+        expect(harness.keytarDelete).toHaveBeenCalledWith(SERVICE, ACCOUNT)
+      })
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('legacy-value'))
+    })
+
+    it('never deletes a keytar copy that differs from the safeStorage copy', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'store-value')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'different-value')
+
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('store-value')
+
+      await vi.waitFor(() => {
+        expect(harness.keytarGet).toHaveBeenCalledWith(SERVICE, ACCOUNT)
+      })
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+      expect(harness.keytarStore.get(`${SERVICE}:${ACCOUNT}`)).toBe('different-value')
+    })
+
+    it('self-heals an unreadable stored ciphertext from the keytar fallback', async () => {
+      fs.mkdirSync(harness.userDataDir, { recursive: true })
+      fs.writeFileSync(
+        storeFilePath(),
+        JSON.stringify({ version: 1, entries: { [SERVICE]: { [ACCOUNT]: 'not-decryptable' } } }),
+        'utf-8'
+      )
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+
+      const value = await getSecret(SERVICE, ACCOUNT)
+
+      expect(value).toBe('legacy-value')
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('legacy-value'))
+    })
+
+    it('moves an unparseable store file aside and still serves the keytar fallback', async () => {
+      fs.mkdirSync(harness.userDataDir, { recursive: true })
+      fs.writeFileSync(storeFilePath(), 'not json {{{', 'utf-8')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+
+      const value = await getSecret(SERVICE, ACCOUNT)
+
+      expect(value).toBe('legacy-value')
+      const corruptBackups = fs
+        .readdirSync(harness.userDataDir)
+        .filter((name) => name.includes('.corrupt-'))
+      expect(corruptBackups).toHaveLength(1)
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('legacy-value'))
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Deferred migration (vault master key)
+  // --------------------------------------------------------------------------
+
+  describe('deferred keytar delete', () => {
+    it('persists the migrated secret but keeps the keytar copy until finalize', async () => {
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'master-key-material')
+
+      const value = await getSecret(SERVICE, ACCOUNT, { deferKeytarDelete: true })
+
+      expect(value).toBe('master-key-material')
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('master-key-material'))
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+      expect(harness.keytarStore.get(`${SERVICE}:${ACCOUNT}`)).toBe('master-key-material')
+
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+
+      expect(harness.keytarDelete).toHaveBeenCalledWith(SERVICE, ACCOUNT)
+      expect(harness.keytarStore.has(`${SERVICE}:${ACCOUNT}`)).toBe(false)
+    })
+
+    it('skips the lazy cleanup on store hits while deletion is deferred', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'master-key-material')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'master-key-material')
+
+      await getSecret(SERVICE, ACCOUNT, { deferKeytarDelete: true })
+      await new Promise((resolve) => setImmediate(resolve))
+
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+    })
+
+    it('finalize refuses to delete a keytar copy that differs from the stored secret', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'store-value')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'different-value')
+
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+    })
+
+    it('finalize is idempotent and a no-op without a stored secret', async () => {
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+    })
+
+    it('finalize is a no-op when safeStorage is unavailable', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'store-value')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'store-value')
+      harness.encryptionAvailable = false
+
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Writes
+  // --------------------------------------------------------------------------
+
+  describe('setSecret', () => {
+    it('writes encrypted to the store, not keytar, and drops any stale keytar copy', async () => {
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'stale-value')
+
+      await setSecret(SERVICE, ACCOUNT, 'new-value')
+
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('new-value'))
+      expect(harness.keytarSet).not.toHaveBeenCalled()
+      expect(harness.keytarStore.has(`${SERVICE}:${ACCOUNT}`)).toBe(false)
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('new-value')
+    })
+
+    it('writes to keytar when encryption is unavailable', async () => {
+      harness.encryptionAvailable = false
+
+      await setSecret(SERVICE, ACCOUNT, 'value')
+
+      expect(harness.keytarSet).toHaveBeenCalledWith(SERVICE, ACCOUNT, 'value')
+      expect(fs.existsSync(storeFilePath())).toBe(false)
+    })
+
+    it('falls back to keytar when the encrypted value fails round-trip verification', async () => {
+      harness.encryptPrefix = 'garbled:'
+
+      await setSecret(SERVICE, ACCOUNT, 'value')
+
+      expect(harness.keytarSet).toHaveBeenCalledWith(SERVICE, ACCOUNT, 'value')
+    })
+
+    it('falls back to keytar when the store file cannot be persisted', async () => {
+      // Point userData at a regular file so mkdir/write of the store fails.
+      const blocker = path.join(harness.userDataDir, 'blocker')
+      fs.writeFileSync(blocker, 'x', 'utf-8')
+      harness.userDataDir = blocker
+
+      await setSecret(SERVICE, ACCOUNT, 'value')
+
+      expect(harness.keytarSet).toHaveBeenCalledWith(SERVICE, ACCOUNT, 'value')
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Atomic writes
+  // --------------------------------------------------------------------------
+
+  describe('atomic store writes', () => {
+    it('writes through a temp file and renames it over the store', async () => {
+      const writeSpy = vi.spyOn(fs, 'writeFileSync')
+      const renameSpy = vi.spyOn(fs, 'renameSync')
+
+      await setSecret(SERVICE, ACCOUNT, 'value')
+
+      const tmpWrite = writeSpy.mock.calls.find(
+        ([target]) => typeof target === 'string' && target.endsWith('.tmp')
+      )
+      expect(tmpWrite).toBeDefined()
+      const tmpPath = tmpWrite![0] as string
+      expect(tmpPath).not.toBe(storeFilePath())
+      expect(path.dirname(tmpPath)).toBe(path.dirname(storeFilePath()))
+      expect(renameSpy).toHaveBeenCalledWith(tmpPath, storeFilePath())
+
+      writeSpy.mockRestore()
+      renameSpy.mockRestore()
+    })
+
+    it('leaves the existing store intact when a write crashes mid-rename', async () => {
+      await setSecret(SERVICE, 'existing-account', 'existing-value')
+
+      const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementationOnce(() => {
+        throw new Error('simulated crash during rename')
+      })
+
+      await setSecret(SERVICE, ACCOUNT, 'new-value')
+
+      renameSpy.mockRestore()
+
+      // Prior content survived untouched, the failed write fell back to keytar,
+      // and no temp files linger.
+      expect(readStoreJson().entries[SERVICE]['existing-account']).toBe(cipherFor('existing-value'))
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBeUndefined()
+      expect(harness.keytarSet).toHaveBeenCalledWith(SERVICE, ACCOUNT, 'new-value')
+      const leftoverTmp = fs
+        .readdirSync(harness.userDataDir)
+        .filter((name) => name.endsWith('.tmp'))
+      expect(leftoverTmp).toHaveLength(0)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Deletes
+  // --------------------------------------------------------------------------
+
+  describe('deleteSecret', () => {
+    it('removes the secret from both the store and keytar', async () => {
+      await setSecret(SERVICE, ACCOUNT, 'value')
+      await setSecret(SERVICE, 'other-account', 'other-value')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'value')
+
+      await deleteSecret(SERVICE, ACCOUNT)
+
+      expect(harness.keytarDelete).toHaveBeenCalledWith(SERVICE, ACCOUNT)
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBeUndefined()
+      expect(readStoreJson().entries[SERVICE]['other-account']).toBe(cipherFor('other-value'))
+    })
+
+    it('still deletes from keytar when the app is not ready', async () => {
+      harness.appReady = false
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'value')
+
+      await deleteSecret(SERVICE, ACCOUNT)
+
+      expect(harness.keytarDelete).toHaveBeenCalledWith(SERVICE, ACCOUNT)
+      expect(harness.keytarStore.has(`${SERVICE}:${ACCOUNT}`)).toBe(false)
+    })
+  })
+})

--- a/apps/desktop/src/main/secrets/secret-storage.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.ts
@@ -1,0 +1,423 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { app, safeStorage } from 'electron'
+import keytar from 'keytar'
+
+import { createLogger } from '../lib/logger'
+
+const logger = createLogger('SecretStorage')
+
+export const SECRET_STORE_FILENAME = 'secure-secrets.json'
+
+const STORE_VERSION = 1
+
+interface SecretStoreFile {
+  version: number
+  /** service -> account -> base64-encoded safeStorage ciphertext */
+  entries: Record<string, Record<string, string>>
+}
+
+export interface GetSecretOptions {
+  /**
+   * Keep the OS-keychain copy even after a verified safeStorage migration.
+   * The vault master key uses this: its keytar copy is only deleted once the
+   * caller has confirmed the retrieved key actually unlocks the vault
+   * (see finalizeKeytarMigration and crypto/vault-key-state.ts).
+   */
+  deferKeytarDelete?: boolean
+}
+
+// Lazy keytar cleanup (crash-resume: ciphertext persisted but the keytar
+// delete never ran) is attempted at most once per secret per process run.
+const keytarCleanupAttempted = new Set<string>()
+
+let loggedPlaintextBackend = false
+
+const cleanupKey = (service: string, account: string): string => `${service}\u0000${account}`
+
+/** Test-only: reset per-run module state between test cases. */
+export function resetSecretStorageForTests(): void {
+  keytarCleanupAttempted.clear()
+  loggedPlaintextBackend = false
+}
+
+// ---------------------------------------------------------------------------
+// Electron access. Every touch of `app` / `safeStorage` stays inside
+// try/catch: unit tests mock 'electron' with partial shapes (accessing a
+// missing export throws), and plain-node imports resolve both to undefined.
+// ---------------------------------------------------------------------------
+
+function isAppReady(): boolean {
+  try {
+    return Boolean(app && typeof app.isReady === 'function' && app.isReady())
+  } catch {
+    return false
+  }
+}
+
+export function isSafeStorageAvailable(): boolean {
+  // isEncryptionAvailable must only be evaluated after app 'ready' — before
+  // then its result is meaningless (always false on Linux, undefined
+  // behaviour elsewhere), so pre-ready callers stay on the keytar path.
+  if (!isAppReady()) return false
+  try {
+    if (typeof safeStorage?.isEncryptionAvailable !== 'function') return false
+    if (!safeStorage.isEncryptionAvailable()) return false
+    if (process.platform === 'linux') {
+      const backend =
+        typeof safeStorage.getSelectedStorageBackend === 'function'
+          ? safeStorage.getSelectedStorageBackend()
+          : 'unknown'
+      if (backend === 'basic_text') {
+        // Plaintext backend: migrating would silently downgrade security vs
+        // the OS keyring keytar uses. Refuse; keytar stays authoritative.
+        if (!loggedPlaintextBackend) {
+          loggedPlaintextBackend = true
+          logger.warn(
+            'safeStorage uses the plaintext basic_text backend; refusing migration, secrets stay in the OS keychain'
+          )
+        }
+        return false
+      }
+    }
+    return true
+  } catch (err) {
+    logger.warn('safeStorage availability check failed; using OS keychain', { error: err })
+    return false
+  }
+}
+
+function resolveStoreFilePath(): string | null {
+  if (!isAppReady()) return null
+  try {
+    return path.join(app.getPath('userData'), SECRET_STORE_FILENAME)
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Store file I/O
+// ---------------------------------------------------------------------------
+
+function emptyStore(): SecretStoreFile {
+  return { version: STORE_VERSION, entries: {} }
+}
+
+function readStoreFile(filePath: string): SecretStoreFile {
+  let raw: string
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8')
+  } catch {
+    return emptyStore()
+  }
+  try {
+    const parsed = JSON.parse(raw) as SecretStoreFile
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      parsed.entries &&
+      typeof parsed.entries === 'object'
+    ) {
+      return { version: STORE_VERSION, entries: parsed.entries }
+    }
+  } catch (err) {
+    // Preserve the bytes for forensics instead of clobbering them on the next
+    // write; any secret still in the OS keychain remains readable via fallback.
+    try {
+      fs.renameSync(filePath, `${filePath}.corrupt-${Date.now()}`)
+    } catch {
+      /* best effort */
+    }
+    logger.error('Secret store file unparseable; moved aside, starting empty', { error: err })
+  }
+  return emptyStore()
+}
+
+function writeStoreFile(filePath: string, store: SecretStoreFile): void {
+  // Atomic: full write to a temp file in the same directory, then rename over
+  // the target, so a crash mid-write can never truncate the live store.
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(store, null, 2), 'utf-8')
+    fs.renameSync(tmpPath, filePath)
+  } catch (err) {
+    try {
+      fs.rmSync(tmpPath, { force: true })
+    } catch {
+      /* best effort */
+    }
+    throw err
+  }
+}
+
+function readCiphertext(filePath: string, service: string, account: string): string | null {
+  const value = readStoreFile(filePath).entries[service]?.[account]
+  return typeof value === 'string' ? value : null
+}
+
+function persistCiphertext(
+  filePath: string,
+  service: string,
+  account: string,
+  ciphertext: string
+): void {
+  const store = readStoreFile(filePath)
+  store.entries[service] = { ...store.entries[service], [account]: ciphertext }
+  writeStoreFile(filePath, store)
+}
+
+function removeCiphertext(filePath: string, service: string, account: string): void {
+  const store = readStoreFile(filePath)
+  const serviceSecrets = store.entries[service]
+  if (!serviceSecrets || !(account in serviceSecrets)) return
+  delete serviceSecrets[account]
+  if (Object.keys(serviceSecrets).length === 0) delete store.entries[service]
+  writeStoreFile(filePath, store)
+}
+
+// ---------------------------------------------------------------------------
+// Encryption
+// ---------------------------------------------------------------------------
+
+function encryptValue(value: string): string | null {
+  try {
+    return safeStorage.encryptString(value).toString('base64')
+  } catch (err) {
+    logger.error('safeStorage encryption failed', { error: err })
+    return null
+  }
+}
+
+function decryptValue(ciphertext: string): string | null {
+  try {
+    return safeStorage.decryptString(Buffer.from(ciphertext, 'base64'))
+  } catch (err) {
+    logger.warn('safeStorage decryption failed', { error: err })
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API — keytar-shaped (service + account), dual-read with lazy
+// migrate-on-read. keytar stays a read-only fallback for at least one release.
+// ---------------------------------------------------------------------------
+
+export async function getSecret(
+  service: string,
+  account: string,
+  options?: GetSecretOptions
+): Promise<string | null> {
+  const filePath = isSafeStorageAvailable() ? resolveStoreFilePath() : null
+
+  if (filePath) {
+    const ciphertext = readCiphertext(filePath, service, account)
+    if (ciphertext !== null) {
+      const value = decryptValue(ciphertext)
+      if (value !== null) {
+        if (!options?.deferKeytarDelete) {
+          // Crash-resume: a previous run may have persisted the ciphertext but
+          // died before deleting the keytar copy. Fire-and-forget so a hung OS
+          // keychain (headless e2e) can never block the read itself.
+          void cleanupLegacyKeytarCopy(service, account, value)
+        }
+        return value
+      }
+      logger.warn('Stored secret ciphertext unreadable; falling back to OS keychain', {
+        service,
+        account
+      })
+    }
+  }
+
+  const legacy = await keytar.getPassword(service, account)
+  if (legacy === null || filePath === null) return legacy
+
+  await migrateLegacySecret(filePath, service, account, legacy, options?.deferKeytarDelete === true)
+  return legacy
+}
+
+export async function setSecret(service: string, account: string, value: string): Promise<void> {
+  const filePath = isSafeStorageAvailable() ? resolveStoreFilePath() : null
+
+  if (filePath) {
+    try {
+      const ciphertext = encryptValue(value)
+      if (ciphertext === null || decryptValue(ciphertext) !== value) {
+        throw new Error('safeStorage round-trip verification failed')
+      }
+      persistCiphertext(filePath, service, account, ciphertext)
+      const persisted = readCiphertext(filePath, service, account)
+      if (persisted === null || decryptValue(persisted) !== value) {
+        throw new Error('persisted secret failed read-back verification')
+      }
+      // The safeStorage copy is now authoritative; drop any stale OS keychain
+      // copy so the read fallback can never resurrect an outdated secret.
+      try {
+        await keytar.deletePassword(service, account)
+      } catch (err) {
+        logger.warn('Could not remove stale OS keychain copy after write', {
+          error: err,
+          service,
+          account
+        })
+      }
+      return
+    } catch (err) {
+      logger.error('safeStorage write failed; falling back to OS keychain', {
+        error: err,
+        service,
+        account
+      })
+      try {
+        removeCiphertext(filePath, service, account)
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+
+  await keytar.setPassword(service, account, value)
+}
+
+export async function deleteSecret(service: string, account: string): Promise<void> {
+  // Keytar first: it was the pre-migration source of truth and its errors are
+  // what call sites historically surfaced.
+  await keytar.deletePassword(service, account)
+  // Store removal only needs the userData path, not encryption availability.
+  const filePath = resolveStoreFilePath()
+  if (filePath) removeCiphertext(filePath, service, account)
+}
+
+/**
+ * Complete a deferred migration: delete the OS keychain copy of a secret whose
+ * safeStorage copy has been externally confirmed (e.g. the vault master key
+ * after it passed the vault verifier check). Idempotent and crash-resumable —
+ * the keytar copy is only deleted while it is byte-identical to the decrypted
+ * safeStorage copy.
+ */
+export async function finalizeKeytarMigration(service: string, account: string): Promise<void> {
+  if (!isSafeStorageAvailable()) return
+  const filePath = resolveStoreFilePath()
+  if (!filePath) return
+  try {
+    const ciphertext = readCiphertext(filePath, service, account)
+    if (ciphertext === null) return
+    const value = decryptValue(ciphertext)
+    if (value === null) return
+    const legacy = await keytar.getPassword(service, account)
+    if (legacy !== null && legacy === value) {
+      await keytar.deletePassword(service, account)
+      logger.info('Removed confirmed migrated secret from OS keychain', { service, account })
+    }
+  } catch (err) {
+    logger.warn('Deferred OS keychain cleanup failed (will retry next run)', {
+      error: err,
+      service,
+      account
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Migration internals
+// ---------------------------------------------------------------------------
+
+async function migrateLegacySecret(
+  filePath: string,
+  service: string,
+  account: string,
+  value: string,
+  deferKeytarDelete: boolean
+): Promise<void> {
+  try {
+    const ciphertext = encryptValue(value)
+    if (ciphertext === null || decryptValue(ciphertext) !== value) {
+      logger.error(
+        'safeStorage round-trip failed during migration; OS keychain stays authoritative',
+        {
+          service,
+          account
+        }
+      )
+      return
+    }
+    persistCiphertext(filePath, service, account, ciphertext)
+
+    // Verify what actually hit the disk decrypts byte-identical to the source
+    // before the keytar copy is ever touched.
+    const persisted = readCiphertext(filePath, service, account)
+    const roundTrip = persisted === null ? null : decryptValue(persisted)
+    if (roundTrip !== value) {
+      logger.error('Persisted secret failed verification; OS keychain stays authoritative', {
+        service,
+        account
+      })
+      // Do not leave bad ciphertext shadowing the good keytar copy.
+      try {
+        removeCiphertext(filePath, service, account)
+      } catch {
+        /* best effort */
+      }
+      return
+    }
+  } catch (err) {
+    logger.error('Secret migration failed; OS keychain stays authoritative', {
+      error: err,
+      service,
+      account
+    })
+    try {
+      removeCiphertext(filePath, service, account)
+    } catch {
+      /* best effort */
+    }
+    return
+  }
+
+  if (deferKeytarDelete) {
+    logger.info('Migrated secret to safeStorage; OS keychain copy kept until confirmation', {
+      service,
+      account
+    })
+    return
+  }
+
+  try {
+    await keytar.deletePassword(service, account)
+    logger.info('Migrated secret from OS keychain to safeStorage', { service, account })
+  } catch (err) {
+    // The safeStorage copy is verified; a lingering keytar copy is harmless
+    // and gets retried by the lazy cleanup on the next run.
+    logger.warn('Could not delete migrated secret from OS keychain (will retry next run)', {
+      error: err,
+      service,
+      account
+    })
+  }
+}
+
+async function cleanupLegacyKeytarCopy(
+  service: string,
+  account: string,
+  expected: string
+): Promise<void> {
+  const key = cleanupKey(service, account)
+  if (keytarCleanupAttempted.has(key)) return
+  keytarCleanupAttempted.add(key)
+  try {
+    const legacy = await keytar.getPassword(service, account)
+    if (legacy !== null && legacy === expected) {
+      await keytar.deletePassword(service, account)
+      logger.info('Removed migrated secret from OS keychain', { service, account })
+    }
+  } catch (err) {
+    logger.warn('Legacy OS keychain cleanup failed (will retry next run)', {
+      error: err,
+      service,
+      account
+    })
+  }
+}

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -46,6 +46,28 @@ account master key and rebinds this verifier before the sync runtime activates. 
 created before sign-in on the same encrypted sync path instead of leaving the push queue without a
 usable vault key.
 
+## Secret Storage
+
+Secrets (vault master key, sync keys, Google Calendar tokens, voice transcription and local agent
+provider API keys, and the capture pairing token) are stored as Electron `safeStorage` ciphertext in
+an atomically written `secure-secrets.json` under the app's user-data directory, keyed by the same
+service and account strings the OS keychain used. The retired `keytar` module stays installed as a
+read-only fallback: every read tries the safeStorage store first and falls back to the OS keychain
+under the identical account.
+
+A legacy secret migrates lazily on first read: encrypt, persist, decrypt round-trip verify
+byte-identical against the source, and only then delete the OS keychain copy. Any verification
+failure keeps the OS keychain authoritative. The vault master key goes one step further — its OS
+keychain copy is only deleted after the retrieved key has passed the vault verifier check. Migration
+is idempotent and crash-resumable: a crash between persist and delete is cleaned up on a later run,
+and only while both copies still match.
+
+Writes gate on `safeStorage.isEncryptionAvailable()` evaluated after app `ready`. On Linux, the
+plaintext `basic_text` backend refuses migration entirely so secrets are never silently downgraded
+out of the OS keyring. Plain `pnpm dev` worktrees also stay on the OS keychain: they share one `dev`
+master key machine-globally while user data is per-worktree, so migrating would strand the shared
+key for other worktrees.
+
 ## Nonces
 
 All XChaCha20 operations use 24-byte random nonces from `sodium.randombytes_buf(24)` via a dedicated nonce utility (T029b). Nonces are stored alongside ciphertext.


### PR DESCRIPTION
## What

Retires the unmaintained `keytar` native module as the primary secret store. All five secret call sites (vault master key + sync keys, Google Calendar tokens, voice transcription API key, local agent provider API key, capture pairing token) now store secrets as Electron `safeStorage` ciphertext in an atomically written `secure-secrets.json` under userData, keyed by the exact account strings the OS keychain used.

Closes #766

## Why

`keytar` is archived/unmaintained and is a native-module liability on every Electron/ABI bump. `safeStorage` ships with Electron, needs no native rebuild, and uses the same OS-level protection (Keychain on macOS, DPAPI on Windows, keyring-backed encryption on Linux).

## Migration safety design

This is a live-beta production app — a botched migration means permanent vault-key loss. The design is defensive throughout:

- **Dual-read at all 5 sites**: safeStorage store first, then `keytar.getPassword` fallback with the **identical** account string. Every existing account-suffix scheme is preserved (MEMRY_DEVICE per device, Google per-accountId + token kind, voice, pairing-token unsuffixed).
- **Verify-before-delete**: per-key migrate-on-read does encrypt → persist (atomic temp-write + rename) → decrypt round-trip verify byte-identical against the source → only then `keytar.deletePassword`. Any verification failure keeps keytar authoritative, removes the bad ciphertext, and logs.
- **Master key gets an extra gate**: its keytar delete is deferred until the retrieved key has passed the vault verifier check (`confirmMasterKeyMigrated` runs in `getOrInitializeLocalVaultKey` after `bindOrVerifyVaultKey` succeeds).
- **Availability gating**: every write gates on `safeStorage.isEncryptionAvailable()` evaluated only after app `ready`. On Linux, the plaintext `basic_text` backend refuses migration entirely (logged) — no silent security downgrade.
- **Idempotent + crash-resumable**: a crash between persist and keytar-delete leaves both copies identical; the next run serves the safeStorage copy and lazily deletes the keytar copy only while the two still match (fire-and-forget so a hung OS keychain can never block reads).
- **Atomic store file**: temp file + rename in the same directory; a corrupt store file is moved aside (`.corrupt-<ts>`) instead of clobbered, with the keytar fallback still serving reads.
- **Plain-dev worktrees keep keytar authoritative**: they share one `dev` master key machine-globally while userData is per-worktree; migrating would strand the shared key for other worktrees (would regress #758).
- **keytar stays** as a dependency, electron-rebuild target, and read-only fallback in this PR. Removal is staged behind a later release gated on field telemetry. The e2e keychain-hang test timeout now bounds the whole dual-read, so the keytar fallback path stays covered.

## Test plan

42 new unit tests (`src/main/secrets/`), all with electron + keytar fully mocked (never touching the real OS keychain):

- happy-path migration per entry type (master key, signing key, Google access/refresh, voice, local provider, pairing)
- decrypt-verify failure → keytar stays authoritative, no delete, no bad ciphertext left shadowing
- `isEncryptionAvailable() === false` → no migration, keytar reads/writes still work
- Linux `basic_text` backend → refusal
- dual-read fallback order (store wins over keytar)
- idempotent re-run (keytar deleted exactly once)
- crash-resume (store + keytar both present → clean lazy delete; mismatched copies → never deleted)
- master-key deferral: keytar copy kept until `confirmMasterKeyMigrated`; vault-verifier reject → keytar copy survives
- account-string suffix preservation for all 5 sites (including `dev-<hash>` → `dev` normalization and the unsuffixed pairing token)
- atomic write behavior (temp + rename; crash mid-rename leaves prior content intact, no temp litter)

Full desktop suite: 11010 passed. `pnpm lint`, `pnpm typecheck`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm docs:build` all green. No contracts/preload changes, so no IPC regeneration needed.

## Rollout note

Merge should wait until #765 (Electron 43 upgrade) is confirmed stable in the field — this change deliberately rides on the post-upgrade safeStorage behavior and should not compound risk in the same release window.
