### PR TITLE
feat(desktop): remove delivered notifications on dismiss/snooze + dock badge

### DIFF
--- a/apps/desktop/src/main/lib/reminders.test.ts
+++ b/apps/desktop/src/main/lib/reminders.test.ts
@@ -48,6 +48,12 @@ const loggerMock = {
   error: vi.fn(),
   debug: vi.fn()
 }
+const setBadgeCountMock = vi.fn()
+
+const realPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!
+const setPlatform = (value: string): void => {
+  Object.defineProperty(process, 'platform', { value, configurable: true })
+}
 
 type MockNotificationOptions = {
   id?: string
@@ -59,6 +65,8 @@ type MockNotificationOptions = {
 
 class MockNotification {
   static isSupported = vi.fn(() => true)
+  // Electron 42+ API; set to undefined in tests to simulate older Electron.
+  static remove: ReturnType<typeof vi.fn> | undefined = vi.fn()
   options: MockNotificationOptions
   handlers: Record<string, (...args: unknown[]) => void> = {}
   show = vi.fn()
@@ -149,6 +157,8 @@ describe('reminders service', () => {
     notificationInstances.length = 0
     MockNotification.isSupported.mockReset()
     MockNotification.isSupported.mockReturnValue(true)
+    MockNotification.remove = vi.fn()
+    setBadgeCountMock.mockReset()
     reminderCounter = 0
     emitCalendarProjectionChanged.mockClear()
     scheduleGoogleCalendarSourceSync.mockClear()
@@ -163,6 +173,9 @@ describe('reminders service', () => {
 
     vi.resetModules()
     vi.doMock('electron', () => ({
+      app: {
+        setBadgeCount: setBadgeCountMock
+      },
       BrowserWindow: {
         getAllWindows: vi.fn()
       },
@@ -221,6 +234,7 @@ describe('reminders service', () => {
     remindersService.stopReminderScheduler()
     cleanupTestDatabase(dataDb)
     cleanupTestDatabase(indexDb)
+    Object.defineProperty(process, 'platform', realPlatformDescriptor)
     vi.clearAllMocks()
   })
 
@@ -543,6 +557,159 @@ describe('reminders service', () => {
     expect(scheduleGoogleCalendarSourceSync).toHaveBeenCalledWith({
       sourceType: 'reminder',
       sourceId: 'rem-b2'
+    })
+  })
+
+  describe('delivered notification cleanup (Electron 42+, macOS)', () => {
+    it('removes the delivered notification banner on dismiss', () => {
+      setPlatform('darwin')
+      seedReminder({ id: 'rem-nc1', status: reminderStatus.TRIGGERED })
+
+      const result = remindersService.dismissReminder('rem-nc1')
+
+      expect(result?.status).toBe(reminderStatus.DISMISSED)
+      expect(MockNotification.remove).toHaveBeenCalledWith('rem-nc1')
+    })
+
+    it('removes the delivered notification banner on snooze', () => {
+      setPlatform('darwin')
+      seedReminder({ id: 'rem-nc2', status: reminderStatus.TRIGGERED })
+
+      const snoozeUntil = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+      const result = remindersService.snoozeReminder({ id: 'rem-nc2', snoozeUntil })
+
+      expect(result?.status).toBe(reminderStatus.SNOOZED)
+      expect(MockNotification.remove).toHaveBeenCalledWith('rem-nc2')
+    })
+
+    it('does not touch delivered notifications on non-darwin platforms', () => {
+      setPlatform('win32')
+      seedReminder({ id: 'rem-nc3', status: reminderStatus.TRIGGERED })
+      seedReminder({ id: 'rem-nc4', status: reminderStatus.TRIGGERED })
+
+      remindersService.dismissReminder('rem-nc3')
+      remindersService.snoozeReminder({
+        id: 'rem-nc4',
+        snoozeUntil: new Date(Date.now() + 60 * 60 * 1000).toISOString()
+      })
+
+      expect(MockNotification.remove).not.toHaveBeenCalled()
+    })
+
+    it('is a silent no-op when Notification.remove is unavailable (Electron <42)', () => {
+      setPlatform('darwin')
+      MockNotification.remove = undefined
+      seedReminder({ id: 'rem-nc5', status: reminderStatus.TRIGGERED })
+
+      const result = remindersService.dismissReminder('rem-nc5')
+
+      expect(result?.status).toBe(reminderStatus.DISMISSED)
+    })
+
+    it('logs and keeps dismissing when Notification.remove throws', () => {
+      setPlatform('darwin')
+      const removeError = new Error('notification center unavailable')
+      MockNotification.remove?.mockImplementation(() => {
+        throw removeError
+      })
+      seedReminder({ id: 'rem-nc6', status: reminderStatus.TRIGGERED })
+
+      const result = remindersService.dismissReminder('rem-nc6')
+
+      expect(result?.status).toBe(reminderStatus.DISMISSED)
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        'Failed to remove delivered notification for reminder rem-nc6:',
+        removeError
+      )
+    })
+  })
+
+  describe('dock badge count', () => {
+    it('sets the badge from the pending count when the scheduler starts', () => {
+      const future = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+      seedReminder({ id: 'rem-bg1', remindAt: future, status: reminderStatus.PENDING })
+      seedReminder({
+        id: 'rem-bg2',
+        remindAt: future,
+        status: reminderStatus.SNOOZED,
+        snoozedUntil: future
+      })
+
+      remindersService.startReminderScheduler()
+      remindersService.stopReminderScheduler()
+
+      expect(setBadgeCountMock).toHaveBeenLastCalledWith(2)
+    })
+
+    it('drops the badge count when a due reminder fires', () => {
+      seedReminder({
+        id: 'rem-bg3',
+        remindAt: '2000-01-01T00:00:00.000Z',
+        status: reminderStatus.PENDING
+      })
+      seedReminder({
+        id: 'rem-bg4',
+        remindAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        status: reminderStatus.PENDING
+      })
+
+      remindersService.startReminderScheduler()
+      remindersService.stopReminderScheduler()
+
+      expect(setBadgeCountMock).toHaveBeenLastCalledWith(1)
+    })
+
+    it('clears the badge when the last pending reminder is dismissed', () => {
+      seedReminder({ id: 'rem-bg5', status: reminderStatus.PENDING })
+
+      remindersService.dismissReminder('rem-bg5')
+
+      expect(setBadgeCountMock).toHaveBeenLastCalledWith(0)
+    })
+
+    it('counts a snoozed reminder back into the badge', () => {
+      seedReminder({ id: 'rem-bg6', status: reminderStatus.TRIGGERED })
+
+      remindersService.snoozeReminder({
+        id: 'rem-bg6',
+        snoozeUntil: new Date(Date.now() + 60 * 60 * 1000).toISOString()
+      })
+
+      expect(setBadgeCountMock).toHaveBeenLastCalledWith(1)
+    })
+
+    it('updates the badge on create and delete', () => {
+      const created = remindersService.createReminder({
+        targetType: 'note',
+        targetId: 'note-1',
+        remindAt: new Date(Date.now() + 60 * 60 * 1000).toISOString()
+      })
+      expect(setBadgeCountMock).toHaveBeenLastCalledWith(1)
+
+      remindersService.deleteReminder(created.id)
+      expect(setBadgeCountMock).toHaveBeenLastCalledWith(0)
+    })
+
+    it('updates the badge after bulk dismiss', () => {
+      seedReminder({ id: 'rem-bg7', status: reminderStatus.PENDING })
+      seedReminder({ id: 'rem-bg8', status: reminderStatus.PENDING })
+
+      remindersService.bulkDismissReminders(['rem-bg7', 'rem-bg8'])
+
+      expect(setBadgeCountMock).toHaveBeenLastCalledWith(0)
+    })
+
+    it('swallows and logs badge failures without breaking the reminder flow', () => {
+      const badgeError = new Error('badge unsupported')
+      setBadgeCountMock.mockImplementation(() => {
+        throw badgeError
+      })
+      seedReminder({ id: 'rem-bg9', status: reminderStatus.PENDING })
+
+      const result = remindersService.dismissReminder('rem-bg9')
+
+      expect(result?.status).toBe(reminderStatus.DISMISSED)
+      expect(loggerMock.warn).toHaveBeenCalledWith('Failed to update app badge count:', badgeError)
     })
   })
 

--- a/apps/desktop/src/main/lib/reminders.ts
+++ b/apps/desktop/src/main/lib/reminders.ts
@@ -7,7 +7,7 @@
  * @module main/lib/reminders
  */
 
-import { BrowserWindow, Notification } from 'electron'
+import { app, BrowserWindow, Notification } from 'electron'
 import { getDatabase, getIndexDatabase } from '../database'
 import type { IndexDb } from '../database/types'
 import { getNoteCacheById } from '../database/queries/notes'
@@ -300,6 +300,36 @@ function showDesktopNotification(reminder: ReminderWithTarget): void {
   }
 }
 
+/**
+ * Remove a delivered notification banner for a reminder from Notification
+ * Center. `Notification.remove` is Electron 42+ and only implemented on
+ * macOS — everywhere else this is a silent no-op.
+ * @param reminderId - Stable reminder id used as the notification id
+ */
+function removeDeliveredNotification(reminderId: string): void {
+  if (process.platform !== 'darwin') return
+  if (typeof Notification.remove !== 'function') return
+
+  try {
+    Notification.remove(reminderId)
+  } catch (error) {
+    logger.warn(`Failed to remove delivered notification for reminder ${reminderId}:`, error)
+  }
+}
+
+/**
+ * Reflect the pending reminder count on the dock/taskbar badge
+ * (macOS dock + Unity launcher; a no-op false return on Windows).
+ * A badge failure must never break the reminder flow.
+ */
+function updateAppBadge(): void {
+  try {
+    app.setBadgeCount(countPendingReminders())
+  } catch (error) {
+    logger.warn('Failed to update app badge count:', error)
+  }
+}
+
 // ============================================================================
 // CRUD Operations
 // ============================================================================
@@ -347,6 +377,7 @@ export function createReminder(input: CreateReminderInput): Reminder {
   const result = toReminder(reminder)
   emitEvent(ReminderChannels.events.CREATED, { reminder: result })
   syncReminderCalendarState(id)
+  updateAppBadge()
 
   logger.info(`Created reminder ${id} for ${input.targetType}:${input.targetId}`)
   return result
@@ -395,6 +426,7 @@ export function updateReminder(input: UpdateReminderInput): Reminder | null {
   const result = toReminder(reminder)
   emitEvent(ReminderChannels.events.UPDATED, { reminder: result })
   syncReminderCalendarState(input.id)
+  updateAppBadge()
 
   logger.info(`Updated reminder ${input.id}`)
   return result
@@ -421,6 +453,7 @@ export function deleteReminder(id: string): boolean {
     targetId: reminder.targetId
   })
   syncReminderCalendarState(id)
+  updateAppBadge()
 
   logger.info(`Deleted reminder ${id}`)
   return true
@@ -599,6 +632,8 @@ export function dismissReminder(id: string): Reminder | null {
   const result = toReminder(reminder)
   emitEvent(ReminderChannels.events.DISMISSED, { reminder: result })
   syncReminderCalendarState(id)
+  removeDeliveredNotification(id)
+  updateAppBadge()
 
   logger.info(`Dismissed reminder ${id}`)
   return result
@@ -635,6 +670,8 @@ export function snoozeReminder(input: SnoozeReminderInput): Reminder | null {
   const result = toReminder(reminder)
   emitEvent(ReminderChannels.events.SNOOZED, { reminder: result })
   syncReminderCalendarState(input.id)
+  removeDeliveredNotification(input.id)
+  updateAppBadge()
 
   logger.info(`Snoozed reminder ${input.id} until ${input.snoozeUntil}`)
   return result
@@ -668,6 +705,8 @@ export function bulkDismissReminders(reminderIds: string[]): number {
     }
   }
 
+  updateAppBadge()
+
   logger.info(`Bulk dismissed ${dismissedCount} reminders`)
   return dismissedCount
 }
@@ -686,6 +725,9 @@ function processDueReminders(): void {
     const dueReminders = getDueReminders()
 
     if (dueReminders.length === 0) {
+      // Reminders can also mutate outside this module (e.g. note date pills),
+      // so refresh the badge on every tick to self-heal a stale count.
+      updateAppBadge()
       return
     }
 
@@ -722,6 +764,9 @@ function processDueReminders(): void {
 
     emitEvent(ReminderChannels.events.DUE, event)
     logger.debug(`Emitted due event for ${dueReminders.length} reminders`)
+
+    // Fired reminders left the pending/snoozed set — reflect that on the badge.
+    updateAppBadge()
   } catch (error) {
     logger.error('Error processing due reminders:', error)
   }
@@ -739,6 +784,10 @@ export function startReminderScheduler(): void {
 
   // Process any reminders that became due while app was closed
   processDueReminders()
+
+  // Seed the dock/taskbar badge on startup (processDueReminders skips it
+  // when the vault is not open yet).
+  updateAppBadge()
 
   // Set up interval to check for due reminders
   schedulerInterval = setInterval(processDueReminders, SCHEDULER_INTERVAL_MS)

--- a/apps/docs/src/user-guide/snooze-reminders.md
+++ b/apps/docs/src/user-guide/snooze-reminders.md
@@ -58,6 +58,12 @@ memrynote shows a toast with:
 - Title and snippet
 - Action buttons (snooze 5 min, snooze 10 min, custom snooze, open, dismiss)
 
+A system notification is shown as well. On macOS, dismissing or snoozing the reminder also removes its delivered banner from Notification Center, so handled reminders don't pile up there.
+
+### Dock & Taskbar Badge
+
+The app icon shows a badge with the number of pending reminders (scheduled or snoozed). The badge updates as reminders fire, get created, snoozed, or dismissed, and clears when nothing is pending. Numeric badges appear on the macOS Dock and Linux Unity launcher; Windows does not support numeric taskbar badges.
+
 ### Reminder Badge
 
 Items with upcoming reminders show a small bell badge in the sidebar / tab bar / inbox row. Hover for the time.
@@ -73,7 +79,7 @@ Each row shows the source type icon and title; clicking it opens the source — 
 
 ### App Closed When Reminder Fires?
 
-The toast appears when memrynote next opens. Reminders aren't OS-level notifications (yet — see [Roadmap](/roadmap)).
+The reminder fires the next time memrynote opens: the toast and system notification appear, and the reminder lands in the inbox.
 
 ## Snooze vs Reminder
 


### PR DESCRIPTION
## What

Retires the unmaintained `keytar` native module as the primary secret store. All five secret call sites (vault master key + sync keys, Google Calendar tokens, voice transcription API key, local agent provider API key, capture pairing token) now store secrets as Electron `safeStorage` ciphertext in an atomically written `secure-secrets.json` under userData, keyed by the exact account strings the OS keychain used.

Closes #766

## Why

`keytar` is archived/unmaintained and is a native-module liability on every Electron/ABI bump. `safeStorage` ships with Electron, needs no native rebuild, and uses the same OS-level protection (Keychain on macOS, DPAPI on Windows, keyring-backed encryption on Linux).

## Migration safety design

This is a live-beta production app — a botched migration means permanent vault-key loss. The design is defensive throughout:

- **Dual-read at all 5 sites**: safeStorage store first, then `keytar.getPassword` fallback with the **identical** account string. Every existing account-suffix scheme is preserved (MEMRY_DEVICE per device, Google per-accountId + token kind, voice, pairing-token unsuffixed).
- **Verify-before-delete**: per-key migrate-on-read does encrypt → persist (atomic temp-write + rename) → decrypt round-trip verify byte-identical against the source → only then `keytar.deletePassword`. Any verification failure keeps keytar authoritative, removes the bad ciphertext, and logs.
- **Master key gets an extra gate**: its keytar delete is deferred until the retrieved key has passed the vault verifier check (`confirmMasterKeyMigrated` runs in `getOrInitializeLocalVaultKey` after `bindOrVerifyVaultKey` succeeds).
- **Availability gating**: every write gates on `safeStorage.isEncryptionAvailable()` evaluated only after app `ready`. On Linux, the plaintext `basic_text` backend refuses migration entirely (logged) — no silent security downgrade.
- **Idempotent + crash-resumable**: a crash between persist and keytar-delete leaves both copies identical; the next run serves the safeStorage copy and lazily deletes the keytar copy only while the two still match (fire-and-forget so a hung OS keychain can never block reads).
- **Atomic store file**: temp file + rename in the same directory; a corrupt store file is moved aside (`.corrupt-<ts>`) instead of clobbered, with the keytar fallback still serving reads.
- **Plain-dev worktrees keep keytar authoritative**: they share one `dev` master key machine-globally while userData is per-worktree; migrating would strand the shared key for other worktrees (would regress #758).
- **keytar stays** as a dependency, electron-rebuild target, and read-only fallback in this PR. Removal is staged behind a later release gated on field telemetry. The e2e keychain-hang test timeout now bounds the whole dual-read, so the keytar fallback path stays covered.

## Test plan

42 new unit tests (`src/main/secrets/`), all with electron + keytar fully mocked (never touching the real OS keychain):

- happy-path migration per entry type (master key, signing key, Google access/refresh, voice, local provider, pairing)
- decrypt-verify failure → keytar stays authoritative, no delete, no bad ciphertext left shadowing
- `isEncryptionAvailable() === false` → no migration, keytar reads/writes still work
- Linux `basic_text` backend → refusal
- dual-read fallback order (store wins over keytar)
- idempotent re-run (keytar deleted exactly once)
- crash-resume (store + keytar both present → clean lazy delete; mismatched copies → never deleted)
- master-key deferral: keytar copy kept until `confirmMasterKeyMigrated`; vault-verifier reject → keytar copy survives
- account-string suffix preservation for all 5 sites (including `dev-<hash>` → `dev` normalization and the unsuffixed pairing token)
- atomic write behavior (temp + rename; crash mid-rename leaves prior content intact, no temp litter)

Full desktop suite: 11010 passed. `pnpm lint`, `pnpm typecheck`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm docs:build` all green. No contracts/preload changes, so no IPC regeneration needed.

## Rollout note

Merge should wait until #765 (Electron 43 upgrade) is confirmed stable in the field — this change deliberately rides on the post-upgrade safeStorage behavior and should not compound risk in the same release window.
