### PR TITLE
feat(desktop): deny-by-default renderer permission handlers

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -71,6 +71,8 @@ const protocolRegisterSchemesMock = vi.fn()
 const ipcMainOnMock = vi.fn()
 const ipcMainHandleMock = vi.fn()
 const setCertificateVerifyProcMock = vi.fn()
+const setPermissionRequestHandlerMock = vi.fn()
+const setPermissionCheckHandlerMock = vi.fn()
 const globalShortcutRegisterMock = vi.fn(() => true)
 const globalShortcutUnregisterAllMock = vi.fn()
 const menuSetApplicationMenuMock = vi.fn()
@@ -354,6 +356,8 @@ vi.mock('electron', () => ({
         onHeadersReceived: webRequestOnHeadersReceivedMock
       },
       setCertificateVerifyProc: setCertificateVerifyProcMock,
+      setPermissionRequestHandler: setPermissionRequestHandlerMock,
+      setPermissionCheckHandler: setPermissionCheckHandlerMock,
       extensions: {
         loadExtension: vi.fn(async () => ({ name: 'React DevTools' }))
       }
@@ -593,6 +597,8 @@ describe('main index phase2 exports', () => {
     expect(applyPackagedLogLevelsMock).not.toHaveBeenCalled()
     expect(protocolHandleMock).toHaveBeenCalledWith('memry-file', expect.any(Function))
     expect(webRequestOnHeadersReceivedMock).toHaveBeenCalledWith(expect.any(Function))
+    expect(setPermissionRequestHandlerMock).toHaveBeenCalledWith(expect.any(Function))
+    expect(setPermissionCheckHandlerMock).toHaveBeenCalledWith(expect.any(Function))
     expect(initPersistenceMock).toHaveBeenCalled()
     expect(applyGlobalCaptureShortcutMock).toHaveBeenCalled()
     expect(BrowserWindowMock).toHaveBeenCalledWith(

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -35,6 +35,7 @@ import {
 import { readPreferences } from './vault/vault-preferences'
 import { getCurrentVaultPath, getStoredLocale, getWindowBounds, setWindowBounds } from './store'
 import { resolveStartupBounds } from './window-bounds'
+import { configureSessionPermissions } from './session-permissions'
 import { startSnoozeScheduler, stopSnoozeScheduler, checkDueItemsOnStartup } from './inbox/snooze'
 import { stopVoiceModel } from './inbox/voice-model'
 import { stopImageProcessing } from './image-processing/bridge'
@@ -1278,9 +1279,10 @@ const appReady = app.whenReady().then(async () => {
   }
   registerQuickCaptureTestHooks()
 
-  // Configure CSP and cert pinning before the window loads
+  // Configure CSP, cert pinning, and permission handlers before the window loads
   configureCsp()
   configureCertificatePinning()
+  configureSessionPermissions()
 
   if (process.platform === 'darwin' && !app.isPackaged) {
     const iconPath = join(__dirname, '../../build/icon.png')

--- a/apps/desktop/src/main/session-permissions.test.ts
+++ b/apps/desktop/src/main/session-permissions.test.ts
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  is: { dev: false },
+  defaultSession: {
+    setPermissionRequestHandler: vi.fn(),
+    setPermissionCheckHandler: vi.fn()
+  }
+}))
+
+vi.mock('electron', () => ({ session: { defaultSession: mocks.defaultSession } }))
+vi.mock('@electron-toolkit/utils', () => ({ is: mocks.is }))
+vi.mock('./lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import {
+  configureSessionPermissions,
+  isPermissionAllowed,
+  isTrustedAppOrigin,
+  type PermissionPolicyOptions
+} from './session-permissions'
+
+const prod: PermissionPolicyOptions = { allowDevServerOrigins: false }
+const dev: PermissionPolicyOptions = { allowDevServerOrigins: true }
+
+const FILE_ORIGIN = 'file:///'
+const DEV_ORIGIN = 'http://localhost:5173'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.is.dev = false
+})
+
+describe('isTrustedAppOrigin', () => {
+  it('trusts the packaged renderer file:// origin', () => {
+    expect(isTrustedAppOrigin('file:///', prod)).toBe(true)
+    expect(isTrustedAppOrigin('file:///Users/x/app/renderer/index.html', prod)).toBe(true)
+  })
+
+  it('trusts the memry-file:// vault asset scheme', () => {
+    expect(isTrustedAppOrigin('memry-file://local', prod)).toBe(true)
+  })
+
+  it('trusts localhost dev-server origins only when dev origins are enabled', () => {
+    expect(isTrustedAppOrigin('http://localhost:5173', dev)).toBe(true)
+    expect(isTrustedAppOrigin('http://127.0.0.1:5173', dev)).toBe(true)
+    expect(isTrustedAppOrigin('http://localhost:5173', prod)).toBe(false)
+    expect(isTrustedAppOrigin('http://127.0.0.1:5173', prod)).toBe(false)
+  })
+
+  it('rejects external and lookalike origins even in dev', () => {
+    expect(isTrustedAppOrigin('https://www.youtube-nocookie.com', dev)).toBe(false)
+    expect(isTrustedAppOrigin('https://evil.example', dev)).toBe(false)
+    expect(isTrustedAppOrigin('http://localhost.evil.example', dev)).toBe(false)
+    expect(isTrustedAppOrigin('https://localhost:5173', prod)).toBe(false)
+  })
+
+  it('rejects opaque, empty, and malformed origins', () => {
+    expect(isTrustedAppOrigin('null', prod)).toBe(false)
+    expect(isTrustedAppOrigin('', prod)).toBe(false)
+    expect(isTrustedAppOrigin(undefined, prod)).toBe(false)
+    expect(isTrustedAppOrigin('not a url', prod)).toBe(false)
+    expect(isTrustedAppOrigin('data:text/html,hi', prod)).toBe(false)
+  })
+})
+
+describe('isPermissionAllowed', () => {
+  it('allows microphone-only media from the app origin', () => {
+    expect(isPermissionAllowed('media', FILE_ORIGIN, { mediaTypes: ['audio'] }, prod)).toBe(true)
+    expect(isPermissionAllowed('media', DEV_ORIGIN, { mediaTypes: ['audio'] }, dev)).toBe(true)
+  })
+
+  it('allows media checks without explicit media types from the app origin', () => {
+    expect(isPermissionAllowed('media', FILE_ORIGIN, {}, prod)).toBe(true)
+  })
+
+  it('denies media whenever video or unknown capture is requested', () => {
+    expect(isPermissionAllowed('media', FILE_ORIGIN, { mediaTypes: ['video'] }, prod)).toBe(false)
+    expect(
+      isPermissionAllowed('media', FILE_ORIGIN, { mediaTypes: ['audio', 'video'] }, prod)
+    ).toBe(false)
+    expect(isPermissionAllowed('media', FILE_ORIGIN, { mediaTypes: ['unknown'] }, prod)).toBe(false)
+  })
+
+  it('allows clipboard and notification permissions from the app origin', () => {
+    expect(isPermissionAllowed('clipboard-sanitized-write', FILE_ORIGIN, {}, prod)).toBe(true)
+    expect(isPermissionAllowed('clipboard-read', FILE_ORIGIN, {}, prod)).toBe(true)
+    expect(isPermissionAllowed('notifications', FILE_ORIGIN, {}, prod)).toBe(true)
+  })
+
+  it('denies allowlisted permissions from untrusted origins', () => {
+    for (const permission of [
+      'media',
+      'clipboard-sanitized-write',
+      'clipboard-read',
+      'notifications'
+    ]) {
+      expect(
+        isPermissionAllowed(
+          permission,
+          'https://www.youtube-nocookie.com',
+          { mediaTypes: ['audio'] },
+          prod
+        )
+      ).toBe(false)
+      expect(isPermissionAllowed(permission, 'https://evil.example', {}, dev)).toBe(false)
+      expect(isPermissionAllowed(permission, undefined, {}, prod)).toBe(false)
+    }
+  })
+
+  it('denies every permission outside the allowlist even from the app origin', () => {
+    const denied = [
+      'geolocation',
+      'fullscreen',
+      'display-capture',
+      'pointerLock',
+      'keyboardLock',
+      'idle-detection',
+      'midi',
+      'midiSysex',
+      'hid',
+      'serial',
+      'usb',
+      'bluetooth',
+      'mediaKeySystem',
+      'openExternal',
+      'speaker-selection',
+      'storage-access',
+      'top-level-storage-access',
+      'window-management',
+      'deprecated-sync-clipboard-read',
+      'fileSystem',
+      'unknown'
+    ]
+    for (const permission of denied) {
+      expect(isPermissionAllowed(permission, FILE_ORIGIN, {}, prod)).toBe(false)
+      expect(isPermissionAllowed(permission, DEV_ORIGIN, {}, dev)).toBe(false)
+    }
+  })
+})
+
+type RequestHandler = (
+  webContents: { getURL: () => string },
+  permission: string,
+  callback: (granted: boolean) => void,
+  details: Record<string, unknown>
+) => void
+
+type CheckHandler = (
+  webContents: null,
+  permission: string,
+  requestingOrigin: string,
+  details: Record<string, unknown>
+) => boolean
+
+function wireHandlers(): { request: RequestHandler; check: CheckHandler } {
+  configureSessionPermissions()
+  const request = mocks.defaultSession.setPermissionRequestHandler.mock
+    .calls[0]?.[0] as unknown as RequestHandler
+  const check = mocks.defaultSession.setPermissionCheckHandler.mock
+    .calls[0]?.[0] as unknown as CheckHandler
+  return { request, check }
+}
+
+describe('configureSessionPermissions', () => {
+  it('registers both a request handler and a check handler on the default session', () => {
+    configureSessionPermissions()
+    expect(mocks.defaultSession.setPermissionRequestHandler).toHaveBeenCalledTimes(1)
+    expect(mocks.defaultSession.setPermissionCheckHandler).toHaveBeenCalledTimes(1)
+    expect(mocks.defaultSession.setPermissionRequestHandler.mock.calls[0]?.[0]).toBeTypeOf(
+      'function'
+    )
+    expect(mocks.defaultSession.setPermissionCheckHandler.mock.calls[0]?.[0]).toBeTypeOf('function')
+  })
+
+  it('grants the voice recorder microphone request from the packaged app', () => {
+    const { request } = wireHandlers()
+    const callback = vi.fn()
+    request({ getURL: () => FILE_ORIGIN }, 'media', callback, {
+      isMainFrame: true,
+      requestingUrl: 'file:///renderer/index.html',
+      mediaTypes: ['audio']
+    })
+    expect(callback).toHaveBeenCalledWith(true)
+  })
+
+  it('denies a video capture request even from the app origin', () => {
+    const { request } = wireHandlers()
+    const callback = vi.fn()
+    request({ getURL: () => FILE_ORIGIN }, 'media', callback, {
+      isMainFrame: true,
+      requestingUrl: 'file:///renderer/index.html',
+      mediaTypes: ['audio', 'video']
+    })
+    expect(callback).toHaveBeenCalledWith(false)
+  })
+
+  it('denies non-allowlisted permission requests', () => {
+    const { request } = wireHandlers()
+    const callback = vi.fn()
+    request({ getURL: () => FILE_ORIGIN }, 'geolocation', callback, {
+      isMainFrame: true,
+      requestingUrl: 'file:///renderer/index.html'
+    })
+    expect(callback).toHaveBeenCalledWith(false)
+  })
+
+  it('denies allowlisted permissions requested by an embedded external frame', () => {
+    const { request } = wireHandlers()
+    const callback = vi.fn()
+    request({ getURL: () => FILE_ORIGIN }, 'notifications', callback, {
+      isMainFrame: false,
+      requestingUrl: 'https://www.youtube-nocookie.com/embed/x'
+    })
+    expect(callback).toHaveBeenCalledWith(false)
+  })
+
+  it('falls back to the webContents URL when requestingUrl is empty', () => {
+    const { request } = wireHandlers()
+    const callback = vi.fn()
+    request({ getURL: () => 'file:///renderer/index.html' }, 'notifications', callback, {
+      isMainFrame: true,
+      requestingUrl: ''
+    })
+    expect(callback).toHaveBeenCalledWith(true)
+  })
+
+  it('answers permission checks consistently with permission requests', () => {
+    const { request, check } = wireHandlers()
+    const grid: Array<{ permission: string; origin: string; mediaType?: string }> = [
+      { permission: 'media', origin: FILE_ORIGIN, mediaType: 'audio' },
+      { permission: 'media', origin: FILE_ORIGIN, mediaType: 'video' },
+      { permission: 'media', origin: 'https://evil.example', mediaType: 'audio' },
+      { permission: 'notifications', origin: FILE_ORIGIN },
+      { permission: 'notifications', origin: 'https://evil.example' },
+      { permission: 'clipboard-read', origin: FILE_ORIGIN },
+      { permission: 'clipboard-sanitized-write', origin: FILE_ORIGIN },
+      { permission: 'geolocation', origin: FILE_ORIGIN },
+      { permission: 'fullscreen', origin: FILE_ORIGIN },
+      { permission: 'openExternal', origin: FILE_ORIGIN }
+    ]
+    for (const { permission, origin, mediaType } of grid) {
+      const callback = vi.fn()
+      request(
+        { getURL: () => origin },
+        permission,
+        callback,
+        mediaType === undefined
+          ? { isMainFrame: true, requestingUrl: origin }
+          : { isMainFrame: true, requestingUrl: origin, mediaTypes: [mediaType] }
+      )
+      const requested = callback.mock.calls[0]?.[0] as boolean
+      const checked = check(
+        null,
+        permission,
+        origin,
+        mediaType === undefined ? { isMainFrame: true } : { isMainFrame: true, mediaType }
+      )
+      expect(checked, `${permission} from ${origin}`).toBe(requested)
+    }
+  })
+
+  it('grants Notification.permission checks from the app origin so inbox notifications keep working', () => {
+    const { check } = wireHandlers()
+    expect(check(null, 'notifications', FILE_ORIGIN, { isMainFrame: true })).toBe(true)
+  })
+
+  it('denies unknown-media permission checks', () => {
+    const { check } = wireHandlers()
+    expect(check(null, 'media', FILE_ORIGIN, { isMainFrame: true, mediaType: 'unknown' })).toBe(
+      false
+    )
+  })
+
+  it('trusts dev-server origins only when running in dev mode', () => {
+    mocks.is.dev = true
+    const { check } = wireHandlers()
+    expect(check(null, 'notifications', DEV_ORIGIN, { isMainFrame: true })).toBe(true)
+
+    vi.clearAllMocks()
+    mocks.is.dev = false
+    const { check: prodCheck } = wireHandlers()
+    expect(prodCheck(null, 'notifications', DEV_ORIGIN, { isMainFrame: true })).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/session-permissions.ts
+++ b/apps/desktop/src/main/session-permissions.ts
@@ -1,0 +1,118 @@
+import { session, type Session } from 'electron'
+import { is } from '@electron-toolkit/utils'
+import { createLogger } from './lib/logger'
+
+const permissionLog = createLogger('SessionPermissions')
+
+/**
+ * Renderer permissions the app actually uses. Everything else is denied:
+ * - `media`: voice recorder microphone capture (audio only — video is never requested)
+ * - `clipboard-read`: quick capture reads the clipboard to prefill a capture
+ * - `clipboard-sanitized-write`: copy actions across the app (navigator.clipboard.writeText)
+ * - `notifications`: inbox review notifications via the HTML5 Notification API
+ */
+const ALLOWED_PERMISSIONS: ReadonlySet<string> = new Set([
+  'media',
+  'clipboard-read',
+  'clipboard-sanitized-write',
+  'notifications'
+])
+
+export interface PermissionPolicyOptions {
+  /**
+   * Trust http://localhost / http://127.0.0.1 origins (Vite dev server).
+   * Must be false in packaged builds.
+   */
+  allowDevServerOrigins: boolean
+}
+
+export interface PermissionDecisionDetails {
+  /** Media types attached to a `media` permission request or check. */
+  mediaTypes?: readonly string[]
+}
+
+/**
+ * Whether a permission request comes from the app's own pages: the packaged
+ * renderer loads via file://, vault assets via the memry-file:// scheme, and
+ * the dev renderer from a localhost Vite server. Everything else (embedded
+ * iframes such as YouTube, arbitrary web content) is untrusted.
+ */
+export function isTrustedAppOrigin(
+  requestingOrigin: string | undefined,
+  options: PermissionPolicyOptions
+): boolean {
+  if (!requestingOrigin) return false
+
+  let parsed: URL
+  try {
+    parsed = new URL(requestingOrigin)
+  } catch {
+    return false
+  }
+
+  if (parsed.protocol === 'file:' || parsed.protocol === 'memry-file:') return true
+
+  if (
+    options.allowDevServerOrigins &&
+    parsed.protocol === 'http:' &&
+    (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1')
+  ) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Pure deny-by-default permission decision shared by the request handler and
+ * the check handler so both always agree.
+ */
+export function isPermissionAllowed(
+  permission: string,
+  requestingOrigin: string | undefined,
+  details: PermissionDecisionDetails,
+  options: PermissionPolicyOptions
+): boolean {
+  if (!ALLOWED_PERMISSIONS.has(permission)) return false
+  if (!isTrustedAppOrigin(requestingOrigin, options)) return false
+
+  if (permission === 'media') {
+    // The voice recorder captures audio only; any video (or unknown) capture
+    // request is denied. Checks without an explicit media type (e.g. device
+    // enumeration) are allowed since the origin is already trusted.
+    const mediaTypes = details.mediaTypes ?? []
+    return mediaTypes.every((type) => type === 'audio')
+  }
+
+  return true
+}
+
+/**
+ * Registers deny-by-default permission handlers on the session the app's
+ * windows use. Without these, Electron auto-grants every renderer permission
+ * request (camera, geolocation, midi, ...).
+ */
+export function configureSessionPermissions(targetSession: Session = session.defaultSession): void {
+  const options: PermissionPolicyOptions = { allowDevServerOrigins: is.dev }
+
+  targetSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
+    const requestingOrigin = details.requestingUrl || webContents.getURL()
+    const mediaTypes = 'mediaTypes' in details ? details.mediaTypes : undefined
+    const allowed = isPermissionAllowed(permission, requestingOrigin, { mediaTypes }, options)
+    if (!allowed) {
+      permissionLog.warn('Denied renderer permission request', { permission, requestingOrigin })
+    }
+    callback(allowed)
+  })
+
+  targetSession.setPermissionCheckHandler((_webContents, permission, requestingOrigin, details) => {
+    const mediaTypes = details.mediaType === undefined ? undefined : [details.mediaType]
+    const allowed = isPermissionAllowed(permission, requestingOrigin, { mediaTypes }, options)
+    if (!allowed) {
+      permissionLog.debug('Denied renderer permission check', { permission, requestingOrigin })
+    }
+    return allowed
+  })
+
+  permissionLog.info('Deny-by-default session permission handlers configured')
+}

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -62,6 +62,17 @@ allowed through the Electron verifier instead of being compared against an unrel
 pins. Development builds keep pinning disabled so local sync servers and test certificates remain
 usable.
 
+## Renderer Permission Policy
+
+The desktop app registers deny-by-default permission handlers on the Electron session at startup,
+covering both permission requests and permission checks. Grants are limited to the app's own pages
+(packaged `file://` pages, the `memry-file://` asset scheme, and the localhost dev server in
+development builds) and to the permissions the app actually uses: microphone capture for the voice
+recorder (audio only — video capture is always denied), clipboard read for quick capture, sanitized
+clipboard writes for copy actions, and HTML5 notifications for inbox reviews. Every other
+permission (geolocation, camera, MIDI, fullscreen, and so on) and every request from embedded
+external content such as YouTube iframes is denied.
+
 ## Tombstone Signing
 
 The `deleted_at` field is included in the Ed25519-signed payload metadata. A hostile server cannot forge a deletion because it would lack the signing key.


### PR DESCRIPTION
## What

Registers deny-by-default `setPermissionRequestHandler` and `setPermissionCheckHandler` on `session.defaultSession` at app ready, next to the existing CSP / cert-pinning session setup. Today the app registers no permission handler, so Electron auto-grants every renderer permission request (camera, geolocation, midi, hid, ...).

The decision logic lives in a pure, deterministic function (`isPermissionAllowed(permission, requestingOrigin, details, options)`) in `apps/desktop/src/main/session-permissions.ts`; the Electron wiring is a thin adapter around it, so the request handler and the check handler always agree.

## Allowlist (derived from actual renderer usage)

| Permission | Evidence | Scope |
| --- | --- | --- |
| `media` | `voice-recorder.tsx:181` — `navigator.mediaDevices.getUserMedia({ audio: ... })`; no video capture anywhere in the renderer | audio only — any request containing `video` (or `unknown`) media types is denied |
| `clipboard-read` | `quick-capture.tsx:155` — `navigator.clipboard.read()` to prefill a capture | trusted app origins only |
| `clipboard-sanitized-write` | 12 renderer files call `navigator.clipboard.writeText` (copy buttons, recovery phrase display, context menus, ...) | trusted app origins only |
| `notifications` | `use-inbox-notifications.ts` — `Notification.requestPermission()` + `new Notification(...)`; the hook gates on `Notification.permission === 'granted'`, which flows through the check handler | trusted app origins only |

Everything else — `geolocation`, `fullscreen`, `display-capture`, `pointerLock`, `midi`/`midiSysex`, `hid`, `serial`, `usb`, `bluetooth`, `mediaKeySystem`, `openExternal`, `idle-detection`, `window-management`, `fileSystem`, `unknown`, ... — is denied.

`fullscreen` was audited and intentionally left out: the renderer has no `requestFullscreen` call, no `allowfullscreen` iframe attribute (the YouTube embeds' `allow` list is `autoplay; encrypted-media`, so their fullscreen button is already disabled by permissions policy), and no `<video>` element.

## Trusted origins

- `file:` — packaged renderer pages (`loadFile(.../renderer/index.html)`)
- `memry-file:` — the app's privileged vault-asset scheme
- `http://localhost` / `http://127.0.0.1` — only when `is.dev` (Vite dev server via `ELECTRON_RENDERER_URL`); denied in packaged builds

External or opaque origins (`youtube-nocookie.com` embed iframes, `data:` splash/error windows, malformed or `null` origins) are denied even for allowlisted permission names.

All app windows (main, quick capture, splash/error) use `session.defaultSession` — no custom partition exists in the codebase — so registering on the default session covers every window.

## Test plan

- `session-permissions.test.ts` (21 tests, written red-first): exhaustive pure-policy coverage — allowed permission x trusted origin, allowed permission x untrusted origin, every non-allowlisted permission denied, media-with-video denied, unknown media denied, malformed/opaque origins denied, dev-origin gating, and a request-handler/check-handler consistency grid
- `index.phase2.test.ts`: the ready-time wiring test now asserts both handlers are registered on the default session
- `pnpm lint`, `pnpm typecheck`, full `pnpm test:desktop`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build` all green

Part of #768
