### PR TITLE
feat(desktop): safeStorage async encryption API

### DIFF
--- a/apps/desktop/src/main/secrets/secret-storage.test.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const harness = vi.hoisted(() => {
   const keytarStore = new Map<string, string>()
-  return {
+  const self = {
     appReady: true,
     encryptionAvailable: true,
     backend: 'keychain_access',
@@ -15,13 +15,37 @@ const harness = vi.hoisted(() => {
     // Diverging the two simulates a broken safeStorage round-trip.
     encryptPrefix: 'enc:',
     decryptPrefix: 'enc:',
+    // Async safeStorage API (Electron 43 os_crypt_async). Present and available
+    // by default so the whole suite exercises the async path; individual tests
+    // flip these to cover the sync fallback. Sync and async mocks share the
+    // exact same ciphertext encoding — mirroring Electron, where both APIs
+    // produce and accept identical bytes.
+    asyncApiPresent: true,
+    asyncAvailable: true,
+    shouldReEncrypt: false,
     keytarStore,
     keytarGet: vi.fn(async (s: string, a: string) => keytarStore.get(`${s}:${a}`) ?? null),
     keytarSet: vi.fn(async (s: string, a: string, v: string) => {
       keytarStore.set(`${s}:${a}`, v)
     }),
-    keytarDelete: vi.fn(async (s: string, a: string) => keytarStore.delete(`${s}:${a}`))
+    keytarDelete: vi.fn(async (s: string, a: string) => keytarStore.delete(`${s}:${a}`)),
+    decode(buf: Buffer): string {
+      const raw = buf.toString('utf-8')
+      if (!raw.startsWith(self.decryptPrefix)) throw new Error('safeStorage decrypt failed')
+      return raw.slice(self.decryptPrefix.length)
+    },
+    syncEncrypt: vi.fn((value: string) => Buffer.from(`${self.encryptPrefix}${value}`, 'utf-8')),
+    syncDecrypt: vi.fn((buf: Buffer) => self.decode(buf)),
+    isAsyncEncryptionAvailable: vi.fn(async () => self.asyncAvailable),
+    asyncEncrypt: vi.fn(async (value: string) =>
+      Buffer.from(`${self.encryptPrefix}${value}`, 'utf-8')
+    ),
+    asyncDecrypt: vi.fn(async (buf: Buffer) => ({
+      shouldReEncrypt: self.shouldReEncrypt,
+      result: self.decode(buf)
+    }))
   }
+  return self
 })
 
 vi.mock('electron', () => ({
@@ -35,11 +59,18 @@ vi.mock('electron', () => ({
   safeStorage: {
     isEncryptionAvailable: () => harness.encryptionAvailable,
     getSelectedStorageBackend: () => harness.backend,
-    encryptString: (value: string) => Buffer.from(`${harness.encryptPrefix}${value}`, 'utf-8'),
-    decryptString: (buf: Buffer) => {
-      const raw = buf.toString('utf-8')
-      if (!raw.startsWith(harness.decryptPrefix)) throw new Error('safeStorage decrypt failed')
-      return raw.slice(harness.decryptPrefix.length)
+    encryptString: harness.syncEncrypt,
+    decryptString: harness.syncDecrypt,
+    // Getter-based so tests can simulate an Electron without the async API
+    // surface (typeof checks in the implementation see undefined).
+    get isAsyncEncryptionAvailable() {
+      return harness.asyncApiPresent ? harness.isAsyncEncryptionAvailable : undefined
+    },
+    get encryptStringAsync() {
+      return harness.asyncApiPresent ? harness.asyncEncrypt : undefined
+    },
+    get decryptStringAsync() {
+      return harness.asyncApiPresent ? harness.asyncDecrypt : undefined
     }
   }
 }))
@@ -95,6 +126,9 @@ describe('secret-storage', () => {
     harness.backend = 'keychain_access'
     harness.encryptPrefix = 'enc:'
     harness.decryptPrefix = 'enc:'
+    harness.asyncApiPresent = true
+    harness.asyncAvailable = true
+    harness.shouldReEncrypt = false
     harness.keytarStore.clear()
     harness.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-secret-storage-'))
   })
@@ -447,6 +481,153 @@ describe('secret-storage', () => {
 
       expect(harness.keytarDelete).toHaveBeenCalledWith(SERVICE, ACCOUNT)
       expect(harness.keytarStore.has(`${SERVICE}:${ACCOUNT}`)).toBe(false)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Async safeStorage API (Electron 43 os_crypt_async)
+  // --------------------------------------------------------------------------
+
+  describe('async safeStorage API', () => {
+    it('uses the async API for writes and reads; the sync API is never called', async () => {
+      await setSecret(SERVICE, ACCOUNT, 'value')
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('value')
+
+      expect(harness.asyncEncrypt).toHaveBeenCalledWith('value')
+      expect(harness.asyncDecrypt).toHaveBeenCalled()
+      expect(harness.syncEncrypt).not.toHaveBeenCalled()
+      expect(harness.syncDecrypt).not.toHaveBeenCalled()
+      // Ciphertext on disk is byte-identical to what the sync API would write.
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('value'))
+    })
+
+    it('falls back to the sync API when isAsyncEncryptionAvailable resolves false', async () => {
+      harness.asyncAvailable = false
+
+      await setSecret(SERVICE, ACCOUNT, 'value')
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('value')
+
+      expect(harness.syncEncrypt).toHaveBeenCalledWith('value')
+      expect(harness.syncDecrypt).toHaveBeenCalled()
+      expect(harness.asyncEncrypt).not.toHaveBeenCalled()
+      expect(harness.asyncDecrypt).not.toHaveBeenCalled()
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('value'))
+    })
+
+    it('falls back to the sync API when the async surface is absent', async () => {
+      harness.asyncApiPresent = false
+
+      await setSecret(SERVICE, ACCOUNT, 'value')
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('value')
+
+      expect(harness.syncEncrypt).toHaveBeenCalledWith('value')
+      expect(harness.syncDecrypt).toHaveBeenCalled()
+      expect(harness.isAsyncEncryptionAvailable).not.toHaveBeenCalled()
+      expect(harness.asyncEncrypt).not.toHaveBeenCalled()
+      expect(harness.asyncDecrypt).not.toHaveBeenCalled()
+    })
+
+    it('accepts sync-era ciphertext unchanged on the async read path', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'legacy-value')
+      const bytesBefore = fs.readFileSync(storeFilePath(), 'utf-8')
+
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('legacy-value')
+
+      // The async decryptor received the stored bytes verbatim — no
+      // re-encoding or transformation between the two API generations.
+      const received = harness.asyncDecrypt.mock.calls[0][0]
+      expect(received.equals(Buffer.from(cipherFor('legacy-value'), 'base64'))).toBe(true)
+      expect(fs.readFileSync(storeFilePath(), 'utf-8')).toBe(bytesBefore)
+      expect(harness.syncDecrypt).not.toHaveBeenCalled()
+    })
+
+    it('async-written ciphertext is readable by the sync path on a later run', async () => {
+      await setSecret(SERVICE, ACCOUNT, 'value')
+      expect(harness.asyncEncrypt).toHaveBeenCalledWith('value')
+      const bytesBefore = fs.readFileSync(storeFilePath(), 'utf-8')
+
+      // Simulate the next app run on an Electron without async encryption.
+      resetSecretStorageForTests()
+      harness.asyncAvailable = false
+      harness.asyncDecrypt.mockClear()
+      harness.syncDecrypt.mockClear()
+
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('value')
+
+      expect(harness.syncDecrypt).toHaveBeenCalled()
+      expect(harness.asyncDecrypt).not.toHaveBeenCalled()
+      expect(fs.readFileSync(storeFilePath(), 'utf-8')).toBe(bytesBefore)
+    })
+
+    it('ignores shouldReEncrypt: the read returns the value and never rewrites the store', async () => {
+      harness.shouldReEncrypt = true
+      seedStoreFile(SERVICE, ACCOUNT, 'value')
+      const bytesBefore = fs.readFileSync(storeFilePath(), 'utf-8')
+
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('value')
+
+      expect(harness.asyncEncrypt).not.toHaveBeenCalled()
+      expect(fs.readFileSync(storeFilePath(), 'utf-8')).toBe(bytesBefore)
+    })
+
+    it('keeps encryption-unavailable gating unchanged: the async API is never touched', async () => {
+      harness.encryptionAvailable = false
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('legacy-value')
+      await setSecret(SERVICE, ACCOUNT, 'new-value')
+
+      expect(harness.keytarSet).toHaveBeenCalledWith(SERVICE, ACCOUNT, 'new-value')
+      expect(fs.existsSync(storeFilePath())).toBe(false)
+      expect(harness.isAsyncEncryptionAvailable).not.toHaveBeenCalled()
+      expect(harness.asyncEncrypt).not.toHaveBeenCalled()
+      expect(harness.asyncDecrypt).not.toHaveBeenCalled()
+    })
+
+    it('an async encryption rejection falls back to keytar exactly like a sync throw', async () => {
+      harness.asyncEncrypt.mockRejectedValueOnce(new Error('os_crypt_async failure'))
+
+      await setSecret(SERVICE, ACCOUNT, 'value')
+
+      expect(harness.keytarSet).toHaveBeenCalledWith(SERVICE, ACCOUNT, 'value')
+      if (fs.existsSync(storeFilePath())) {
+        expect(readStoreJson().entries[SERVICE]?.[ACCOUNT]).toBeUndefined()
+      }
+    })
+
+    it('an async decryption rejection falls back to the OS keychain copy', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'store-value')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+      harness.asyncDecrypt.mockRejectedValueOnce(new Error('os_crypt_async failure'))
+
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('legacy-value')
+    })
+
+    it('a failed availability probe falls back to the sync API', async () => {
+      harness.isAsyncEncryptionAvailable.mockRejectedValueOnce(new Error('probe failure'))
+
+      await setSecret(SERVICE, ACCOUNT, 'value')
+
+      expect(harness.syncEncrypt).toHaveBeenCalledWith('value')
+      expect(harness.asyncEncrypt).not.toHaveBeenCalled()
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('value')
+    })
+
+    it('probes async availability exactly once across concurrent startup reads', async () => {
+      seedStoreFile(SERVICE, 'account-a', 'value-a')
+      const store = readStoreJson()
+      store.entries[SERVICE]['account-b'] = cipherFor('value-b')
+      store.entries[SERVICE]['account-c'] = cipherFor('value-c')
+      fs.writeFileSync(storeFilePath(), JSON.stringify(store), 'utf-8')
+
+      const [a, b, c] = await Promise.all([
+        getSecret(SERVICE, 'account-a'),
+        getSecret(SERVICE, 'account-b'),
+        getSecret(SERVICE, 'account-c')
+      ])
+
+      expect([a, b, c]).toEqual(['value-a', 'value-b', 'value-c'])
+      expect(harness.isAsyncEncryptionAvailable).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/apps/desktop/src/main/secrets/secret-storage.test.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.test.ts
@@ -84,6 +84,7 @@ vi.mock('keytar', () => ({
 }))
 
 import {
+  ASYNC_PROBE_TIMEOUT_MS,
   SECRET_STORE_FILENAME,
   deleteSecret,
   finalizeKeytarMigration,
@@ -410,6 +411,64 @@ describe('secret-storage', () => {
   })
 
   // --------------------------------------------------------------------------
+  // Concurrent writes — the encrypt/persist/verify critical sections contain
+  // await points, so racing writers must be serialized per secret.
+  // --------------------------------------------------------------------------
+
+  describe('concurrent writes', () => {
+    it('a setSecret racing migrate-on-read never loses the newly written value', async () => {
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+      let releaseEncrypt!: () => void
+      const gate = new Promise<void>((resolve) => {
+        releaseEncrypt = resolve
+      })
+      // Hold the migration's encrypt so a concurrent setSecret can race it.
+      harness.asyncEncrypt.mockImplementationOnce(async (value: string) => {
+        await gate
+        return Buffer.from(`enc:${value}`, 'utf-8')
+      })
+
+      const read = getSecret(SERVICE, ACCOUNT)
+      await vi.waitFor(() => {
+        expect(harness.asyncEncrypt).toHaveBeenCalledTimes(1)
+      })
+      const write = setSecret(SERVICE, ACCOUNT, 'new-value')
+      // Let the write progress as far as it can before the migration resumes.
+      await new Promise((resolve) => setImmediate(resolve))
+      releaseEncrypt()
+      await expect(read).resolves.toBe('legacy-value')
+      await write
+
+      // The write is the freshest value: it must win, exist exactly once, and
+      // never be rolled back by the migration's read-back verification.
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('new-value'))
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('new-value')
+    })
+
+    it('migration skips when a setSecret landed while the keytar read was in flight', async () => {
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+      let releaseKeytar!: () => void
+      const gate = new Promise<void>((resolve) => {
+        releaseKeytar = resolve
+      })
+      harness.keytarGet.mockImplementationOnce(async () => {
+        await gate
+        return 'legacy-value'
+      })
+
+      const read = getSecret(SERVICE, ACCOUNT)
+      await setSecret(SERVICE, ACCOUNT, 'new-value')
+      releaseKeytar()
+      // The racing read returns what keytar held at read time…
+      await expect(read).resolves.toBe('legacy-value')
+
+      // …but its migration must not clobber the fresher store entry.
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('new-value'))
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('new-value')
+    })
+  })
+
+  // --------------------------------------------------------------------------
   // Atomic writes
   // --------------------------------------------------------------------------
 
@@ -584,8 +643,22 @@ describe('secret-storage', () => {
       expect(harness.asyncDecrypt).not.toHaveBeenCalled()
     })
 
-    it('an async encryption rejection falls back to keytar exactly like a sync throw', async () => {
+    it('an async encryption rejection retries the sync API and still writes the store', async () => {
       harness.asyncEncrypt.mockRejectedValueOnce(new Error('os_crypt_async failure'))
+
+      await setSecret(SERVICE, ACCOUNT, 'value')
+
+      expect(harness.syncEncrypt).toHaveBeenCalledWith('value')
+      expect(harness.keytarSet).not.toHaveBeenCalled()
+      expect(readStoreJson().entries[SERVICE][ACCOUNT]).toBe(cipherFor('value'))
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('value')
+    })
+
+    it('falls back to keytar only when both encryptors fail', async () => {
+      harness.asyncEncrypt.mockRejectedValueOnce(new Error('os_crypt_async failure'))
+      harness.syncEncrypt.mockImplementationOnce(() => {
+        throw new Error('sync encrypt failure')
+      })
 
       await setSecret(SERVICE, ACCOUNT, 'value')
 
@@ -595,12 +668,46 @@ describe('secret-storage', () => {
       }
     })
 
-    it('an async decryption rejection falls back to the OS keychain copy', async () => {
+    it('an async decryption rejection retries the sync API before any keychain fallback', async () => {
+      // The async encryptor can report available yet fail per-call (e.g. a
+      // poisoned key provider) while the sync OSCrypt path still works; the
+      // ciphertext is byte-compatible, so the sync retry must recover it.
       seedStoreFile(SERVICE, ACCOUNT, 'store-value')
       harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
       harness.asyncDecrypt.mockRejectedValueOnce(new Error('os_crypt_async failure'))
 
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('store-value')
+      expect(harness.syncDecrypt).toHaveBeenCalled()
+    })
+
+    it('falls back to the OS keychain copy only when both decryptors fail', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'store-value')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'legacy-value')
+      harness.asyncDecrypt.mockRejectedValueOnce(new Error('os_crypt_async failure'))
+      harness.syncDecrypt.mockImplementationOnce(() => {
+        throw new Error('sync decrypt failure')
+      })
+
       await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBe('legacy-value')
+    })
+
+    it('a hung availability probe times out to the sync API instead of blocking reads', async () => {
+      vi.useFakeTimers()
+      try {
+        harness.isAsyncEncryptionAvailable.mockImplementationOnce(
+          () => new Promise<boolean>(() => {})
+        )
+        seedStoreFile(SERVICE, ACCOUNT, 'value')
+
+        const read = getSecret(SERVICE, ACCOUNT)
+        await vi.advanceTimersByTimeAsync(ASYNC_PROBE_TIMEOUT_MS + 1)
+
+        await expect(read).resolves.toBe('value')
+        expect(harness.syncDecrypt).toHaveBeenCalled()
+        expect(harness.asyncDecrypt).not.toHaveBeenCalled()
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('a failed availability probe falls back to the sync API', async () => {

--- a/apps/desktop/src/main/secrets/secret-storage.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.ts
@@ -43,11 +43,44 @@ let asyncEncryptionProbe: Promise<boolean> | null = null
 
 const cleanupKey = (service: string, account: string): string => `${service}\u0000${account}`
 
+// The probe triggers lazy os_crypt_async initialization, which on Linux does
+// DBus round-trips to the keyring (and can hang on a wedged daemon) — bound it
+// so a degraded keyring costs at most this latency, never availability: on
+// timeout the run permanently degrades to the byte-compatible sync API.
+export const ASYNC_PROBE_TIMEOUT_MS = 5000
+
+// Store writes verify what they persisted before touching the keytar copy,
+// and the async encrypt/decrypt awaits sit inside that critical section. Racing
+// writers to the same secret must therefore be serialized, or one writer's
+// read-back verification can observe — and roll back — another writer's fresh,
+// already-acknowledged value.
+const secretWriteLocks = new Map<string, Promise<void>>()
+
+function withSecretWriteLock<T>(
+  service: string,
+  account: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const key = cleanupKey(service, account)
+  const previous = secretWriteLocks.get(key) ?? Promise.resolve()
+  const run = previous.then(fn)
+  const tail = run.then(
+    () => undefined,
+    () => undefined
+  )
+  secretWriteLocks.set(key, tail)
+  void tail.then(() => {
+    if (secretWriteLocks.get(key) === tail) secretWriteLocks.delete(key)
+  })
+  return run
+}
+
 /** Test-only: reset per-run module state between test cases. */
 export function resetSecretStorageForTests(): void {
   keytarCleanupAttempted.clear()
   loggedPlaintextBackend = false
   asyncEncryptionProbe = null
+  secretWriteLocks.clear()
 }
 
 // ---------------------------------------------------------------------------
@@ -193,6 +226,14 @@ function removeCiphertext(filePath: string, service: string, account: string): v
 // The async safeStorage API (os_crypt_async, Electron 43+) produces and
 // accepts ciphertext byte-identical to the sync API, so switching between the
 // two is purely behavioral: no store-format change, no re-encryption pass.
+// LOAD-BEARING Electron behavior: byte-compatibility exists only because
+// Electron requests its async encryptor with
+// os_crypt_async::Encryptor::Option::kEncryptSyncCompat
+// (shell/browser/api/electron_api_safe_storage.cc), which pins async
+// encryption to the sync-OSCrypt-compatible key provider. If a future Electron
+// drops that option (e.g. adopts app-bound encryption on Windows),
+// async-written ciphertext stops being readable by the sync path — re-verify
+// this on every Electron major bump before trusting the fallbacks below.
 // The sync calls below are the deprecation-candidate fallback — removing them
 // later is a matter of deleting the two `safeStorage.encryptString` /
 // `safeStorage.decryptString` branches and this availability probe.
@@ -208,7 +249,19 @@ function isAsyncSafeStorageAvailable(): Promise<boolean> {
         ) {
           return false
         }
-        return await safeStorage.isAsyncEncryptionAvailable()
+        // Bounded: the first call lazily initializes os_crypt_async, and a
+        // wedged OS keyring can otherwise stall this promise (and with it the
+        // first secret read — vault unlock) indefinitely.
+        return await Promise.race([
+          safeStorage.isAsyncEncryptionAvailable(),
+          new Promise<boolean>((resolve) => {
+            const timer = setTimeout(() => {
+              logger.warn('safeStorage async availability probe timed out; using sync API')
+              resolve(false)
+            }, ASYNC_PROBE_TIMEOUT_MS)
+            timer.unref?.()
+          })
+        ])
       } catch (err) {
         logger.warn('safeStorage async availability probe failed; using sync API', { error: err })
         return false
@@ -220,10 +273,19 @@ function isAsyncSafeStorageAvailable(): Promise<boolean> {
 
 async function encryptValue(value: string): Promise<string | null> {
   try {
-    const encrypted = (await isAsyncSafeStorageAvailable())
-      ? await safeStorage.encryptStringAsync(value)
-      : safeStorage.encryptString(value)
-    return encrypted.toString('base64')
+    if (await isAsyncSafeStorageAvailable()) {
+      try {
+        return (await safeStorage.encryptStringAsync(value)).toString('base64')
+      } catch (err) {
+        // os_crypt_async can report available yet fail per-call (its key
+        // provider is a separate implementation from sync OSCrypt and can be
+        // poisoned for a whole run, e.g. Linux keyring races at startup).
+        // Ciphertext is byte-compatible across the two APIs, so retry sync
+        // before giving up.
+        logger.warn('Async safeStorage encryption failed; retrying sync API', { error: err })
+      }
+    }
+    return safeStorage.encryptString(value).toString('base64')
   } catch (err) {
     logger.error('safeStorage encryption failed', { error: err })
     return null
@@ -234,11 +296,19 @@ async function decryptValue(ciphertext: string): Promise<string | null> {
   try {
     const encrypted = Buffer.from(ciphertext, 'base64')
     if (await isAsyncSafeStorageAvailable()) {
-      // shouldReEncrypt is deliberately ignored: honoring it would rewrite
-      // ciphertext on read, and this store's write path already re-encrypts
-      // every secret on setSecret. Reads must stay side-effect-free on disk.
-      const { result } = await safeStorage.decryptStringAsync(encrypted)
-      return result
+      try {
+        // shouldReEncrypt is deliberately ignored: honoring it would rewrite
+        // ciphertext on read, and this store's write path already re-encrypts
+        // every secret on setSecret. Reads must stay side-effect-free on disk.
+        const { result } = await safeStorage.decryptStringAsync(encrypted)
+        return result
+      } catch (err) {
+        // A failed async decrypt does not mean the ciphertext is bad: the
+        // async key provider can be unavailable while sync OSCrypt still
+        // holds a working key for the same bytes. Never skip the sync retry —
+        // for the vault master key a false null here means vault lockout.
+        logger.warn('Async safeStorage decryption failed; retrying sync API', { error: err })
+      }
     }
     return safeStorage.decryptString(encrypted)
   } catch (err) {
@@ -287,6 +357,10 @@ export async function getSecret(
 }
 
 export async function setSecret(service: string, account: string, value: string): Promise<void> {
+  return withSecretWriteLock(service, account, () => setSecretLocked(service, account, value))
+}
+
+async function setSecretLocked(service: string, account: string, value: string): Promise<void> {
   const filePath = isSafeStorageAvailable() ? resolveStoreFilePath() : null
 
   if (filePath) {
@@ -296,8 +370,10 @@ export async function setSecret(service: string, account: string, value: string)
         throw new Error('safeStorage round-trip verification failed')
       }
       persistCiphertext(filePath, service, account, ciphertext)
-      const persisted = readCiphertext(filePath, service, account)
-      if (persisted === null || (await decryptValue(persisted)) !== value) {
+      // Verify the exact ciphertext written — never decrypt-and-compare
+      // whatever is currently on disk, so this can only ever judge (and roll
+      // back) this writer's own bytes.
+      if (readCiphertext(filePath, service, account) !== ciphertext) {
         throw new Error('persisted secret failed read-back verification')
       }
       // The safeStorage copy is now authoritative; drop any stale OS keychain
@@ -379,6 +455,26 @@ async function migrateLegacySecret(
   value: string,
   deferKeytarDelete: boolean
 ): Promise<void> {
+  return withSecretWriteLock(service, account, () =>
+    migrateLegacySecretLocked(filePath, service, account, value, deferKeytarDelete)
+  )
+}
+
+async function migrateLegacySecretLocked(
+  filePath: string,
+  service: string,
+  account: string,
+  value: string,
+  deferKeytarDelete: boolean
+): Promise<void> {
+  // A concurrent setSecret (or another migration) may have established a
+  // store entry while this read's keytar fetch or lock wait was in flight.
+  // A readable entry is fresher than the keytar value captured earlier —
+  // never clobber it, and never touch the keytar copy on this path either.
+  // An unreadable entry is the self-heal case: proceed and overwrite it.
+  const existing = readCiphertext(filePath, service, account)
+  if (existing !== null && (await decryptValue(existing)) !== null) return
+
   try {
     const ciphertext = await encryptValue(value)
     if (ciphertext === null || (await decryptValue(ciphertext)) !== value) {
@@ -393,11 +489,10 @@ async function migrateLegacySecret(
     }
     persistCiphertext(filePath, service, account, ciphertext)
 
-    // Verify what actually hit the disk decrypts byte-identical to the source
-    // before the keytar copy is ever touched.
-    const persisted = readCiphertext(filePath, service, account)
-    const roundTrip = persisted === null ? null : await decryptValue(persisted)
-    if (roundTrip !== value) {
+    // Verify the exact ciphertext written actually hit the disk before the
+    // keytar copy is ever touched. String equality (not decrypt-and-compare)
+    // so this can only ever judge — and roll back — this migration's own bytes.
+    if (readCiphertext(filePath, service, account) !== ciphertext) {
       logger.error('Persisted secret failed verification; OS keychain stays authoritative', {
         service,
         account

--- a/apps/desktop/src/main/secrets/secret-storage.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.ts
@@ -34,12 +34,20 @@ const keytarCleanupAttempted = new Set<string>()
 
 let loggedPlaintextBackend = false
 
+// Shared probe for the async safeStorage API (os_crypt_async). Electron
+// lazily initializes the async encryptor on the first call to
+// isAsyncEncryptionAvailable / encryptStringAsync / decryptStringAsync, so
+// concurrent startup reads must all await one probe instead of each
+// triggering initialization.
+let asyncEncryptionProbe: Promise<boolean> | null = null
+
 const cleanupKey = (service: string, account: string): string => `${service}\u0000${account}`
 
 /** Test-only: reset per-run module state between test cases. */
 export function resetSecretStorageForTests(): void {
   keytarCleanupAttempted.clear()
   loggedPlaintextBackend = false
+  asyncEncryptionProbe = null
 }
 
 // ---------------------------------------------------------------------------
@@ -182,18 +190,57 @@ function removeCiphertext(filePath: string, service: string, account: string): v
 // Encryption
 // ---------------------------------------------------------------------------
 
-function encryptValue(value: string): string | null {
+// The async safeStorage API (os_crypt_async, Electron 43+) produces and
+// accepts ciphertext byte-identical to the sync API, so switching between the
+// two is purely behavioral: no store-format change, no re-encryption pass.
+// The sync calls below are the deprecation-candidate fallback — removing them
+// later is a matter of deleting the two `safeStorage.encryptString` /
+// `safeStorage.decryptString` branches and this availability probe.
+
+function isAsyncSafeStorageAvailable(): Promise<boolean> {
+  if (asyncEncryptionProbe === null) {
+    asyncEncryptionProbe = (async () => {
+      try {
+        if (
+          typeof safeStorage?.isAsyncEncryptionAvailable !== 'function' ||
+          typeof safeStorage.encryptStringAsync !== 'function' ||
+          typeof safeStorage.decryptStringAsync !== 'function'
+        ) {
+          return false
+        }
+        return await safeStorage.isAsyncEncryptionAvailable()
+      } catch (err) {
+        logger.warn('safeStorage async availability probe failed; using sync API', { error: err })
+        return false
+      }
+    })()
+  }
+  return asyncEncryptionProbe
+}
+
+async function encryptValue(value: string): Promise<string | null> {
   try {
-    return safeStorage.encryptString(value).toString('base64')
+    const encrypted = (await isAsyncSafeStorageAvailable())
+      ? await safeStorage.encryptStringAsync(value)
+      : safeStorage.encryptString(value)
+    return encrypted.toString('base64')
   } catch (err) {
     logger.error('safeStorage encryption failed', { error: err })
     return null
   }
 }
 
-function decryptValue(ciphertext: string): string | null {
+async function decryptValue(ciphertext: string): Promise<string | null> {
   try {
-    return safeStorage.decryptString(Buffer.from(ciphertext, 'base64'))
+    const encrypted = Buffer.from(ciphertext, 'base64')
+    if (await isAsyncSafeStorageAvailable()) {
+      // shouldReEncrypt is deliberately ignored: honoring it would rewrite
+      // ciphertext on read, and this store's write path already re-encrypts
+      // every secret on setSecret. Reads must stay side-effect-free on disk.
+      const { result } = await safeStorage.decryptStringAsync(encrypted)
+      return result
+    }
+    return safeStorage.decryptString(encrypted)
   } catch (err) {
     logger.warn('safeStorage decryption failed', { error: err })
     return null
@@ -215,7 +262,7 @@ export async function getSecret(
   if (filePath) {
     const ciphertext = readCiphertext(filePath, service, account)
     if (ciphertext !== null) {
-      const value = decryptValue(ciphertext)
+      const value = await decryptValue(ciphertext)
       if (value !== null) {
         if (!options?.deferKeytarDelete) {
           // Crash-resume: a previous run may have persisted the ciphertext but
@@ -244,13 +291,13 @@ export async function setSecret(service: string, account: string, value: string)
 
   if (filePath) {
     try {
-      const ciphertext = encryptValue(value)
-      if (ciphertext === null || decryptValue(ciphertext) !== value) {
+      const ciphertext = await encryptValue(value)
+      if (ciphertext === null || (await decryptValue(ciphertext)) !== value) {
         throw new Error('safeStorage round-trip verification failed')
       }
       persistCiphertext(filePath, service, account, ciphertext)
       const persisted = readCiphertext(filePath, service, account)
-      if (persisted === null || decryptValue(persisted) !== value) {
+      if (persisted === null || (await decryptValue(persisted)) !== value) {
         throw new Error('persisted secret failed read-back verification')
       }
       // The safeStorage copy is now authoritative; drop any stale OS keychain
@@ -305,7 +352,7 @@ export async function finalizeKeytarMigration(service: string, account: string):
   try {
     const ciphertext = readCiphertext(filePath, service, account)
     if (ciphertext === null) return
-    const value = decryptValue(ciphertext)
+    const value = await decryptValue(ciphertext)
     if (value === null) return
     const legacy = await keytar.getPassword(service, account)
     if (legacy !== null && legacy === value) {
@@ -333,8 +380,8 @@ async function migrateLegacySecret(
   deferKeytarDelete: boolean
 ): Promise<void> {
   try {
-    const ciphertext = encryptValue(value)
-    if (ciphertext === null || decryptValue(ciphertext) !== value) {
+    const ciphertext = await encryptValue(value)
+    if (ciphertext === null || (await decryptValue(ciphertext)) !== value) {
       logger.error(
         'safeStorage round-trip failed during migration; OS keychain stays authoritative',
         {
@@ -349,7 +396,7 @@ async function migrateLegacySecret(
     // Verify what actually hit the disk decrypts byte-identical to the source
     // before the keytar copy is ever touched.
     const persisted = readCiphertext(filePath, service, account)
-    const roundTrip = persisted === null ? null : decryptValue(persisted)
+    const roundTrip = persisted === null ? null : await decryptValue(persisted)
     if (roundTrip !== value) {
       logger.error('Persisted secret failed verification; OS keychain stays authoritative', {
         service,

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -68,6 +68,14 @@ out of the OS keyring. Plain `pnpm dev` worktrees also stay on the OS keychain: 
 master key machine-globally while user data is per-worktree, so migrating would strand the shared
 key for other worktrees.
 
+Encryption and decryption prefer Electron's asynchronous safeStorage API
+(`encryptStringAsync`/`decryptStringAsync`), gated on a single cached `isAsyncEncryptionAvailable()`
+probe so concurrent startup reads share one lazy encryptor initialization. Ciphertext is
+byte-identical between the sync and async APIs, so no store-format change or second migration is
+involved; when the async surface is unavailable the store falls back to the synchronous calls, and
+reads never rewrite stored ciphertext (`shouldReEncrypt` is ignored — every write re-encrypts
+anyway).
+
 ## Nonces
 
 All XChaCha20 operations use 24-byte random nonces from `sodium.randombytes_buf(24)` via a dedicated nonce utility (T029b). Nonces are stored alongside ciphertext.


### PR DESCRIPTION
# ⚠️ BLOCKED — stacked on #772

**Do not merge until #772 (keytar → safeStorage migration) lands AND is stable in the field.** This PR is based on `keytar-safestorage-migration`; retarget the base to `main` once #772 merges.

Closes #767

## What

Swaps the safeStorage secret store's encrypt/decrypt calls to Electron 43's asynchronous safeStorage API (`os_crypt_async`): `encryptStringAsync`, `decryptStringAsync`, gated on `isAsyncEncryptionAvailable()`. When the async surface is unavailable (or absent, e.g. an older Electron shape), the store falls back to the existing synchronous calls.

## Design notes

- **Identical ciphertext → no migration.** The sync and async APIs produce and accept byte-identical ciphertext, so this change is behavioral-only: no store-format change, no second migration, no re-encryption pass. Bytes written by the sync path are read unchanged by the async path and vice versa (asserted at the mock seam in tests; the real guarantee is Electron passing `kEncryptSyncCompat` when requesting its async encryptor — now documented as load-bearing in `secret-storage.ts` and to be re-verified on Electron major bumps).
- **Single cached availability probe.** `isAsyncEncryptionAvailable()` lazily initializes the async encryptor, so all concurrent startup reads await one shared probe promise — no double-init race.
- **`shouldReEncrypt` is deliberately ignored.** Honoring it would rewrite ciphertext on read; reads stay side-effect-free on disk, and every `setSecret` re-encrypts anyway.
- **Sync fallback is isolated.** The synchronous calls appear only in the two `encryptValue`/`decryptValue` branches plus the probe's typeof guard — removing the deprecated sync API later is one small edit.
- **Keytar read-fallback path untouched.** The #772 dual-read/migrate-on-read/verify-before-delete machinery is semantically unchanged (its verify step now compares the exact ciphertext written, see below).
- **`isEncryptionAvailable()` gating semantics unchanged.** The async API is only ever consulted after the existing availability gate passes; when encryption is unavailable, the async surface is never touched.

## Hardening (post-review)

Adversarial review surfaced that making encrypt/decrypt async inserted await points into the previously-synchronous persist → read-back-verify critical sections, plus two async-provider failure modes. Fixed:

- **Per-secret write serialization.** `setSecret` and migrate-on-read now run their store critical sections under an in-process per-`service:account` lock. Without it, a racing writer's read-back verification could observe — and roll back via `removeCiphertext` — another writer's fresh, already-acknowledged ciphertext (worst case: store entry and keytar copy both deleted, secret lost).
- **Verify exactly what was written.** Read-back verification compares the persisted ciphertext string against the bytes this writer produced, never decrypt-and-compare of whatever is currently on disk — it can only ever judge (and roll back) its own write.
- **Migration never clobbers a fresher write.** If a readable store entry appeared while the migration's keytar read or lock wait was in flight, migration skips (unreadable entries still self-heal from the keytar copy).
- **Sync retry on async call failure.** `os_crypt_async` can report available yet fail per-call (its key provider is a separate implementation from sync OSCrypt and can be poisoned for a whole run, e.g. Linux keyring races at startup). Since ciphertext is byte-compatible, a rejected `encryptStringAsync`/`decryptStringAsync` now retries the sync API before any fallback — without this, a false decrypt-null on the vault master key (whose keytar copy is deleted post-migration) would mean vault lockout for the entire run.
- **Bounded availability probe.** The first probe triggers lazy os_crypt_async init (DBus round-trips on Linux); a wedged keyring daemon could previously stall the first secret read — vault unlock — indefinitely. The probe now times out after 5s and permanently degrades the run to the sync path: latency cost only, never availability.

## Test plan

17 new unit tests in `src/main/secrets/secret-storage.test.ts` (the existing 42-test suite from #772 now also runs entirely through the async path via the default mock state):

- async available → async API used for both writes and reads, sync API never called
- `isAsyncEncryptionAvailable()` resolves false → sync fallback, async encrypt/decrypt never called
- async surface absent (typeof guard) → sync fallback, probe never called
- sync-era ciphertext accepted verbatim by the async read path (exact-bytes assertion, store file unchanged)
- async-written ciphertext readable by the sync path on a simulated later run (no re-encoding)
- `shouldReEncrypt: true` → value returned, store never rewritten
- encryption-unavailable gating unchanged → keytar path, async API untouched
- async encryption rejection → sync retry succeeds, store still written, keytar untouched
- both encryptors fail → keytar fallback, no bad ciphertext left in the store
- async decryption rejection → sync retry recovers the store value before any keychain fallback
- both decryptors fail → OS keychain copy served
- hung availability probe → 5s timeout, read completes via the sync path (fake timers)
- failed availability probe → sync fallback for the process run
- concurrent startup reads → availability probed exactly once, all values correct
- `setSecret` racing migrate-on-read → the written value wins, is never rolled back, and reads return it
- `setSecret` landing during migration's in-flight keytar read → migration skips, store keeps the fresh value

`pnpm lint`, `pnpm typecheck`, `pnpm --filter @memry/desktop test:main` (3672 passed), `pnpm docs:impact --base origin/main --strict` all green.
