### PR TITLE
fix(desktop): editor undo/redo from Ctrl+Z on Windows/Linux and the Edit menu

### DIFF
--- a/apps/desktop/src/main/menu.test.ts
+++ b/apps/desktop/src/main/menu.test.ts
@@ -15,9 +15,27 @@ vi.mock('electron', () => ({
 
 import { buildAppMenu, buildEditableTextContextMenu } from './menu'
 
+interface TemplateItem {
+  label?: string
+  role?: string
+  accelerator?: string
+  registerAccelerator?: boolean
+  id?: string
+  click?: () => void
+  submenu?: TemplateItem[]
+}
+
+/** Find an item by label in the most recently built template. */
+function findMenuItem(label: string): TemplateItem | undefined {
+  const template = buildFromTemplate.mock.calls.at(-1)?.[0] as TemplateItem[]
+  return template.flatMap((item) => item.submenu ?? []).find((item) => item.label === label)
+}
+
 describe('buildAppMenu', () => {
   beforeEach(() => {
     buildFromTemplate.mockClear()
+    vi.mocked(BrowserWindow.getFocusedWindow).mockReset().mockReturnValue(null)
+    vi.mocked(BrowserWindow.getAllWindows).mockReset().mockReturnValue([])
   })
 
   it('labels every current native menu item from menu.json', async () => {
@@ -110,12 +128,14 @@ describe('buildAppMenu', () => {
     // role's registered accelerator also swallowed Ctrl+Z before the renderer
     // ever saw it, so undo was dead in the editor entirely.
     expect(undoItem).toMatchObject({
+      id: 'edit.undo',
       accelerator: 'CmdOrCtrl+Z',
       registerAccelerator: false
     })
     expect(undoItem?.role).toBeUndefined()
     expect(redoItem).toMatchObject({
-      accelerator: 'CmdOrCtrl+Shift+Z',
+      id: 'edit.redo',
+      accelerator: process.platform === 'win32' ? 'Control+Y' : 'CmdOrCtrl+Shift+Z',
       registerAccelerator: false
     })
     expect(redoItem?.role).toBeUndefined()
@@ -126,28 +146,46 @@ describe('buildAppMenu', () => {
     expect(send).toHaveBeenCalledWith(AppChannels.events.MENU_COMMAND, { command: 'edit.redo' })
   })
 
-  it('falls back to a live window when no window reports focus', async () => {
+  it('falls back to the sole visible window when no window reports focus', async () => {
     const i18n = await createMainI18n({ locale: 'en' })
     const send = vi.fn()
-    vi.mocked(BrowserWindow.getFocusedWindow).mockReturnValue(null)
+    const makeWindow = (visible: boolean, sendFn = vi.fn()) =>
+      ({
+        isVisible: () => visible,
+        webContents: { isDestroyed: () => false, send: sendFn }
+      }) as unknown as Electron.BrowserWindow
+    // Hidden helper windows (PDF export, unopened quick capture) never qualify.
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
-      { webContents: { isDestroyed: () => true, send: vi.fn() } },
-      { webContents: { isDestroyed: () => false, send } }
-    ] as unknown as Electron.BrowserWindow[])
+      makeWindow(false),
+      makeWindow(true, send)
+    ])
 
     buildAppMenu(i18n)
 
-    const template = buildFromTemplate.mock.calls[0][0] as Array<{
-      submenu?: Array<{ label?: string; click?: () => void }>
-    }>
-    const undoItem = template
-      .flatMap((item) => item.submenu ?? [])
-      .find((item) => item.label === 'Undo')
+    const undoItem = findMenuItem('Undo')
 
     // Menu items are clickable while no window has focus (macOS app menu,
     // Linux focus-follows-mouse); the command must not be dropped.
     undoItem?.click?.()
     expect(send).toHaveBeenCalledWith(AppChannels.events.MENU_COMMAND, { command: 'edit.undo' })
+  })
+
+  it('drops the command when several visible windows could be the target', async () => {
+    const i18n = await createMainI18n({ locale: 'en' })
+    const sendA = vi.fn()
+    const sendB = vi.fn()
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+      { isVisible: () => true, webContents: { isDestroyed: () => false, send: sendA } },
+      { isVisible: () => true, webContents: { isDestroyed: () => false, send: sendB } }
+    ] as unknown as Electron.BrowserWindow[])
+
+    buildAppMenu(i18n)
+
+    // Ambiguous target: guessing could undo/close a tab in a window the user
+    // isn't looking at, so the command is dropped like before the fallback.
+    findMenuItem('Undo')?.click?.()
+    expect(sendA).not.toHaveBeenCalled()
+    expect(sendB).not.toHaveBeenCalled()
   })
 
   it('registers native text editing roles and accelerators', async () => {

--- a/apps/desktop/src/main/menu.test.ts
+++ b/apps/desktop/src/main/menu.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BrowserWindow } from 'electron'
+import { AppChannels } from '@memry/contracts/ipc-channels'
 import { createMainI18n } from '@memry/i18n/main'
 
 const { buildFromTemplate } = vi.hoisted(() => ({
@@ -79,6 +81,49 @@ describe('buildAppMenu', () => {
         })
       ])
     )
+  })
+
+  it('routes Edit undo/redo through the renderer instead of native roles', async () => {
+    const i18n = await createMainI18n({ locale: 'en' })
+    const send = vi.fn()
+    vi.mocked(BrowserWindow.getFocusedWindow).mockReturnValue({
+      webContents: { isDestroyed: () => false, send }
+    } as unknown as Electron.BrowserWindow)
+
+    buildAppMenu(i18n)
+
+    const template = buildFromTemplate.mock.calls[0][0] as Array<{
+      submenu?: Array<{
+        label?: string
+        role?: string
+        accelerator?: string
+        registerAccelerator?: boolean
+        click?: () => void
+      }>
+    }>
+    const items = template.flatMap((item) => item.submenu ?? [])
+    const undoItem = items.find((item) => item.label === 'Undo')
+    const redoItem = items.find((item) => item.label === 'Redo')
+
+    // Regression: role 'undo'/'redo' drives Chromium's native undo stack, which
+    // is empty in the BlockNote editor (Yjs owns history). On Windows/Linux the
+    // role's registered accelerator also swallowed Ctrl+Z before the renderer
+    // ever saw it, so undo was dead in the editor entirely.
+    expect(undoItem).toMatchObject({
+      accelerator: 'CmdOrCtrl+Z',
+      registerAccelerator: false
+    })
+    expect(undoItem?.role).toBeUndefined()
+    expect(redoItem).toMatchObject({
+      accelerator: 'CmdOrCtrl+Shift+Z',
+      registerAccelerator: false
+    })
+    expect(redoItem?.role).toBeUndefined()
+
+    undoItem?.click?.()
+    expect(send).toHaveBeenCalledWith(AppChannels.events.MENU_COMMAND, { command: 'edit.undo' })
+    redoItem?.click?.()
+    expect(send).toHaveBeenCalledWith(AppChannels.events.MENU_COMMAND, { command: 'edit.redo' })
   })
 
   it('registers native text editing roles and accelerators', async () => {

--- a/apps/desktop/src/main/menu.test.ts
+++ b/apps/desktop/src/main/menu.test.ts
@@ -9,7 +9,7 @@ const { buildFromTemplate } = vi.hoisted(() => ({
 
 vi.mock('electron', () => ({
   app: { name: 'MemryNote' },
-  BrowserWindow: { getFocusedWindow: vi.fn() },
+  BrowserWindow: { getFocusedWindow: vi.fn(), getAllWindows: vi.fn(() => []) },
   Menu: { buildFromTemplate }
 }))
 
@@ -124,6 +124,30 @@ describe('buildAppMenu', () => {
     expect(send).toHaveBeenCalledWith(AppChannels.events.MENU_COMMAND, { command: 'edit.undo' })
     redoItem?.click?.()
     expect(send).toHaveBeenCalledWith(AppChannels.events.MENU_COMMAND, { command: 'edit.redo' })
+  })
+
+  it('falls back to a live window when no window reports focus', async () => {
+    const i18n = await createMainI18n({ locale: 'en' })
+    const send = vi.fn()
+    vi.mocked(BrowserWindow.getFocusedWindow).mockReturnValue(null)
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+      { webContents: { isDestroyed: () => true, send: vi.fn() } },
+      { webContents: { isDestroyed: () => false, send } }
+    ] as unknown as Electron.BrowserWindow[])
+
+    buildAppMenu(i18n)
+
+    const template = buildFromTemplate.mock.calls[0][0] as Array<{
+      submenu?: Array<{ label?: string; click?: () => void }>
+    }>
+    const undoItem = template
+      .flatMap((item) => item.submenu ?? [])
+      .find((item) => item.label === 'Undo')
+
+    // Menu items are clickable while no window has focus (macOS app menu,
+    // Linux focus-follows-mouse); the command must not be dropped.
+    undoItem?.click?.()
+    expect(send).toHaveBeenCalledWith(AppChannels.events.MENU_COMMAND, { command: 'edit.undo' })
   })
 
   it('registers native text editing roles and accelerators', async () => {

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -112,8 +112,24 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
     {
       label: t('edit.label'),
       submenu: [
-        { label: t('edit.undo'), role: 'undo' },
-        { label: t('edit.redo'), role: 'redo' },
+        // Not role 'undo'/'redo': the role drives Chromium's native undo stack,
+        // which is empty in the BlockNote editor (Yjs owns history), and on
+        // Windows/Linux the role's registered accelerator swallows Ctrl+Z in the
+        // main process before the editor keymap ever sees it. registerAccelerator
+        // false keeps the shortcut visible in the menu while letting the keydown
+        // reach the renderer; click covers the menu-bar path.
+        {
+          label: t('edit.undo'),
+          accelerator: 'CmdOrCtrl+Z',
+          registerAccelerator: false,
+          click: () => sendMenuCommand('edit.undo')
+        },
+        {
+          label: t('edit.redo'),
+          accelerator: 'CmdOrCtrl+Shift+Z',
+          registerAccelerator: false,
+          click: () => sendMenuCommand('edit.redo')
+        },
         { type: 'separator' },
         { label: t('edit.cut'), role: 'cut' },
         { label: t('edit.copy'), role: 'copy' },

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -26,7 +26,12 @@ function sendNavigationToFocusedWindow(direction: 'back' | 'forward'): void {
 
 /** Send a menu command to the focused window's renderer (see use-menu-commands.ts). */
 function sendMenuCommand(command: string): void {
-  const window = BrowserWindow.getFocusedWindow()
+  // Menu items stay clickable while no window reports focus (macOS app menu
+  // without a focused window, Linux focus-follows-mouse) — fall back to the
+  // first live window instead of silently dropping the command.
+  const window =
+    BrowserWindow.getFocusedWindow() ??
+    BrowserWindow.getAllWindows().find((candidate) => !candidate.webContents.isDestroyed())
   if (!window || window.webContents.isDestroyed()) return
 
   window.webContents.send(AppChannels.events.MENU_COMMAND, { command })

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -17,22 +17,34 @@ interface EditableContextMenuParams {
   }
 }
 
+/**
+ * Menu items stay clickable while no window reports focus (macOS app menu
+ * without a focused window, Linux focus-follows-mouse). Fall back to the app
+ * window only when it is unambiguous: exactly one visible live window.
+ * Hidden helper windows (PDF export, unopened quick capture) never qualify,
+ * and with several visible windows we drop the command rather than guess.
+ */
+function resolveMenuTargetWindow(): BrowserWindow | null {
+  const focused = BrowserWindow.getFocusedWindow()
+  if (focused && !focused.webContents.isDestroyed()) return focused
+
+  const visible = BrowserWindow.getAllWindows().filter(
+    (candidate) => candidate.isVisible() && !candidate.webContents.isDestroyed()
+  )
+  return visible.length === 1 ? visible[0] : null
+}
+
 function sendNavigationToFocusedWindow(direction: 'back' | 'forward'): void {
-  const window = BrowserWindow.getFocusedWindow()
-  if (!window || window.webContents.isDestroyed()) return
+  const window = resolveMenuTargetWindow()
+  if (!window) return
 
   sendAppNavigationDirection(window.webContents, direction)
 }
 
-/** Send a menu command to the focused window's renderer (see use-menu-commands.ts). */
+/** Send a menu command to the target window's renderer (see use-menu-commands.ts). */
 function sendMenuCommand(command: string): void {
-  // Menu items stay clickable while no window reports focus (macOS app menu
-  // without a focused window, Linux focus-follows-mouse) — fall back to the
-  // first live window instead of silently dropping the command.
-  const window =
-    BrowserWindow.getFocusedWindow() ??
-    BrowserWindow.getAllWindows().find((candidate) => !candidate.webContents.isDestroyed())
-  if (!window || window.webContents.isDestroyed()) return
+  const window = resolveMenuTargetWindow()
+  if (!window) return
 
   window.webContents.send(AppChannels.events.MENU_COMMAND, { command })
 }
@@ -41,11 +53,18 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
   const t = i18n.getFixedT(null, 'menu')
   const isMac = process.platform === 'darwin'
 
-  // Bridge item: a click that dispatches a command to the renderer. No
-  // accelerator — the renderer/editor already owns the shortcuts, so adding one
-  // here would double-fire.
-  const cmd = (command: string, label: string): MenuItemConstructorOptions => ({
+  // Bridge item: a click that dispatches a command to the renderer. When an
+  // accelerator is given it is display-only (registerAccelerator: false) — the
+  // renderer/editor owns the shortcut, so registering it here would swallow the
+  // keydown in the main process on Windows/Linux before the editor sees it.
+  const cmd = (
+    command: string,
+    label: string,
+    accelerator?: string
+  ): MenuItemConstructorOptions => ({
+    id: command,
     label,
+    ...(accelerator ? { accelerator, registerAccelerator: false } : {}),
     click: () => sendMenuCommand(command)
   })
 
@@ -120,21 +139,15 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
         // Not role 'undo'/'redo': the role drives Chromium's native undo stack,
         // which is empty in the BlockNote editor (Yjs owns history), and on
         // Windows/Linux the role's registered accelerator swallows Ctrl+Z in the
-        // main process before the editor keymap ever sees it. registerAccelerator
-        // false keeps the shortcut visible in the menu while letting the keydown
-        // reach the renderer; click covers the menu-bar path.
-        {
-          label: t('edit.undo'),
-          accelerator: 'CmdOrCtrl+Z',
-          registerAccelerator: false,
-          click: () => sendMenuCommand('edit.undo')
-        },
-        {
-          label: t('edit.redo'),
-          accelerator: 'CmdOrCtrl+Shift+Z',
-          registerAccelerator: false,
-          click: () => sendMenuCommand('edit.redo')
-        },
+        // main process before the editor keymap ever sees it. The cmd() bridge
+        // shows the shortcut without registering it. Windows redo follows the
+        // platform's Ctrl+Y convention like the role did.
+        cmd('edit.undo', t('edit.undo'), 'CmdOrCtrl+Z'),
+        cmd(
+          'edit.redo',
+          t('edit.redo'),
+          process.platform === 'win32' ? 'Control+Y' : 'CmdOrCtrl+Shift+Z'
+        ),
         { type: 'separator' },
         { label: t('edit.cut'), role: 'cut' },
         { label: t('edit.copy'), role: 'copy' },

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-note-setup.test.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-note-setup.test.ts
@@ -37,6 +37,7 @@ function createEditor(options?: { registerCreatesExtension?: boolean }) {
     }),
     focus: vi.fn(),
     setTextCursorPosition: vi.fn(),
+    isEditable: true,
     document: [] as Array<{ id: string }>
   }
 
@@ -121,6 +122,44 @@ describe('useBlockNoteSetup', () => {
 
     expect((window as unknown as { __memryEditor?: unknown }).__memryEditor).toBeUndefined()
     expect(editor.registerExtension).not.toHaveBeenCalled()
+  })
+
+  it('does not expose read-only editors as the menu-command target', () => {
+    const { editor } = createEditor()
+    editor.isEditable = false
+
+    const { unmount } = renderHook(() =>
+      useBlockNoteSetup({
+        editor,
+        aiPort: null,
+        editorContainerRef
+      })
+    )
+
+    expect((window as unknown as { __memryEditor?: unknown }).__memryEditor).toBeUndefined()
+    unmount()
+  })
+
+  it('keeps another live editor registered when a later mount unmounts', () => {
+    const { editor: noteEditor } = createEditor()
+    ;(window as unknown as { __memryEditor?: unknown }).__memryEditor = noteEditor
+
+    const { editor: previewEditor } = createEditor()
+    const { unmount } = renderHook(() =>
+      useBlockNoteSetup({
+        editor: previewEditor,
+        aiPort: null,
+        editorContainerRef
+      })
+    )
+    expect((window as unknown as { __memryEditor?: unknown }).__memryEditor).toBe(previewEditor)
+
+    // Re-register the note editor (its own effect would do this on focus/remount
+    // in the app); the preview's later cleanup must not clobber it.
+    ;(window as unknown as { __memryEditor?: unknown }).__memryEditor = noteEditor
+    unmount()
+
+    expect((window as unknown as { __memryEditor?: unknown }).__memryEditor).toBe(noteEditor)
   })
 
   it('syncs spellcheck and focus-at-end behavior into the editor DOM', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-note-setup.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-block-note-setup.ts
@@ -76,13 +76,19 @@ export function useBlockNoteSetup({
     }
   }, [aiPort, editor])
 
-  // E2E test instrumentation: expose the active editor on window so Playwright
-  // tests can drive the editor via its API (avoiding typing-race conditions
-  // with auto-promote handlers). Only the currently mounted editor is exposed.
+  // Expose the active editor on window. Production path for the Edit-menu
+  // undo/redo and Insert/Format commands (lib/menu-commands.ts), and E2E
+  // instrumentation. Read-only instances (template preview) must not claim the
+  // global, and cleanup only clears its own registration so unmounting a later
+  // preview/split pane doesn't deregister a still-live editor.
   useEffect(() => {
-    ;(window as unknown as { __memryEditor?: unknown }).__memryEditor = editor
+    if (!editor.isEditable) return
+    const host = window as unknown as { __memryEditor?: unknown }
+    host.__memryEditor = editor
     return () => {
-      delete (window as unknown as { __memryEditor?: unknown }).__memryEditor
+      if (host.__memryEditor === editor) {
+        delete host.__memryEditor
+      }
     }
   }, [editor])
 

--- a/apps/desktop/src/renderer/src/hooks/use-menu-commands.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-menu-commands.ts
@@ -4,7 +4,11 @@ import { useTabs, useActiveTab } from '@/contexts/tabs'
 import { useSidebar } from '@/components/ui/sidebar'
 import { useDayPanel } from '@/contexts/day-panel-context'
 import { useSettingsModal } from '@/contexts/settings-modal-context'
-import { isEditorMenuCommand, runEditorMenuCommand } from '@/lib/menu-commands'
+import {
+  isEditorMenuCommand,
+  runEditorMenuCommand,
+  runHistoryMenuCommand
+} from '@/lib/menu-commands'
 
 interface MenuCommandHandlers {
   onNewNote: () => void
@@ -29,6 +33,8 @@ export function useMenuCommands({ onNewNote, onOpenSearch }: MenuCommandHandlers
     'file.openQuickly': onOpenSearch,
     'file.closeTab': () => activeTab && closeTab(activeTab.id),
     'file.exportPdf': () => window.dispatchEvent(new CustomEvent('memry:menu-export')),
+    'edit.undo': () => runHistoryMenuCommand('undo'),
+    'edit.redo': () => runHistoryMenuCommand('redo'),
     'edit.find': () => window.dispatchEvent(new CustomEvent('memry:menu-find')),
     'app.preferences': () => openSettings(),
     'view.toggleSidebar': toggleSidebar,

--- a/apps/desktop/src/renderer/src/lib/menu-commands.test.ts
+++ b/apps/desktop/src/renderer/src/lib/menu-commands.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
-import { applyEditorMenuCommand, isEditorMenuCommand } from './menu-commands'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { applyEditorMenuCommand, isEditorMenuCommand, runHistoryMenuCommand } from './menu-commands'
 
 function makeEditor(block: unknown = {}) {
   return {
@@ -59,5 +59,64 @@ describe('applyEditorMenuCommand', () => {
     expect(isEditorMenuCommand('insert.table')).toBe(true)
     expect(isEditorMenuCommand('format.highlight')).toBe(true)
     expect(isEditorMenuCommand('file.newNote')).toBe(false)
+  })
+})
+
+describe('runHistoryMenuCommand', () => {
+  afterEach(() => {
+    delete (window as unknown as { __memryEditor?: unknown }).__memryEditor
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('routes undo/redo to the BlockNote editor history', () => {
+    const editor = { undo: vi.fn(), redo: vi.fn() }
+    ;(window as unknown as { __memryEditor?: unknown }).__memryEditor = editor
+
+    runHistoryMenuCommand('undo')
+    expect(editor.undo).toHaveBeenCalledTimes(1)
+
+    runHistoryMenuCommand('redo')
+    expect(editor.redo).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps native undo for focused input fields', () => {
+    const editor = { undo: vi.fn(), redo: vi.fn() }
+    ;(window as unknown as { __memryEditor?: unknown }).__memryEditor = editor
+    const execCommand = vi.fn()
+    document.execCommand = execCommand
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+
+    runHistoryMenuCommand('undo')
+    expect(execCommand).toHaveBeenCalledWith('undo')
+    expect(editor.undo).not.toHaveBeenCalled()
+  })
+
+  it('keeps native undo for focused textareas', () => {
+    const execCommand = vi.fn()
+    document.execCommand = execCommand
+
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    textarea.focus()
+
+    runHistoryMenuCommand('redo')
+    expect(execCommand).toHaveBeenCalledWith('redo')
+  })
+
+  it('does nothing without an editor', () => {
+    expect(() => runHistoryMenuCommand('undo')).not.toThrow()
+  })
+
+  it('swallows editor errors instead of crashing the menu', () => {
+    ;(window as unknown as { __memryEditor?: unknown }).__memryEditor = {
+      undo: () => {
+        throw new Error('not ready')
+      }
+    }
+    expect(() => runHistoryMenuCommand('undo')).not.toThrow()
   })
 })

--- a/apps/desktop/src/renderer/src/lib/menu-commands.test.ts
+++ b/apps/desktop/src/renderer/src/lib/menu-commands.test.ts
@@ -63,15 +63,30 @@ describe('applyEditorMenuCommand', () => {
 })
 
 describe('runHistoryMenuCommand', () => {
+  const originalExecCommand = document.execCommand
+
+  function makeHistoryEditor() {
+    const domElement = document.createElement('div')
+    const inner = document.createElement('span')
+    inner.tabIndex = 0
+    domElement.appendChild(inner)
+    document.body.appendChild(domElement)
+
+    const editor = { undo: vi.fn(), redo: vi.fn(), domElement }
+    ;(window as unknown as { __memryEditor?: unknown }).__memryEditor = editor
+    return { editor, focusInside: () => inner.focus() }
+  }
+
   afterEach(() => {
     delete (window as unknown as { __memryEditor?: unknown }).__memryEditor
     document.body.innerHTML = ''
+    document.execCommand = originalExecCommand
     vi.restoreAllMocks()
   })
 
-  it('routes undo/redo to the BlockNote editor history', () => {
-    const editor = { undo: vi.fn(), redo: vi.fn() }
-    ;(window as unknown as { __memryEditor?: unknown }).__memryEditor = editor
+  it('routes undo/redo to the editor history while focus is inside it', () => {
+    const { editor, focusInside } = makeHistoryEditor()
+    focusInside()
 
     runHistoryMenuCommand('undo')
     expect(editor.undo).toHaveBeenCalledTimes(1)
@@ -80,9 +95,35 @@ describe('runHistoryMenuCommand', () => {
     expect(editor.redo).toHaveBeenCalledTimes(1)
   })
 
+  it('does not touch the editor history when focus is outside it', () => {
+    const { editor } = makeHistoryEditor()
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+    outside.focus()
+
+    runHistoryMenuCommand('undo')
+    expect(editor.undo).not.toHaveBeenCalled()
+  })
+
+  it('routes other contenteditable surfaces to the native command', () => {
+    const { editor } = makeHistoryEditor()
+    const execCommand = vi.fn()
+    document.execCommand = execCommand
+
+    const composer = document.createElement('div')
+    composer.contentEditable = 'true'
+    composer.tabIndex = 0
+    document.body.appendChild(composer)
+    composer.focus()
+    Object.defineProperty(composer, 'isContentEditable', { value: true })
+
+    runHistoryMenuCommand('undo')
+    expect(execCommand).toHaveBeenCalledWith('undo')
+    expect(editor.undo).not.toHaveBeenCalled()
+  })
+
   it('keeps native undo for focused input fields', () => {
-    const editor = { undo: vi.fn(), redo: vi.fn() }
-    ;(window as unknown as { __memryEditor?: unknown }).__memryEditor = editor
+    const { editor } = makeHistoryEditor()
     const execCommand = vi.fn()
     document.execCommand = execCommand
 
@@ -112,11 +153,12 @@ describe('runHistoryMenuCommand', () => {
   })
 
   it('swallows editor errors instead of crashing the menu', () => {
-    ;(window as unknown as { __memryEditor?: unknown }).__memryEditor = {
-      undo: () => {
-        throw new Error('not ready')
-      }
-    }
+    const { editor, focusInside } = makeHistoryEditor()
+    editor.undo.mockImplementation(() => {
+      throw new Error('not ready')
+    })
+    focusInside()
+
     expect(() => runHistoryMenuCommand('undo')).not.toThrow()
   })
 })

--- a/apps/desktop/src/renderer/src/lib/menu-commands.ts
+++ b/apps/desktop/src/renderer/src/lib/menu-commands.ts
@@ -87,3 +87,27 @@ export function runEditorMenuCommand(command: string): void {
     // Editor not ready or block-shape drift — fail quietly rather than crash the menu.
   }
 }
+
+/**
+ * Menu-bar Undo/Redo. Native inputs keep the browser's own edit history;
+ * everything else routes to the BlockNote editor's (Yjs) undo stack — the
+ * native menu role can't reach it (see main/menu.ts).
+ */
+export function runHistoryMenuCommand(action: 'undo' | 'redo'): void {
+  const active = document.activeElement
+  if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+    document.execCommand(action)
+    return
+  }
+
+  const editor = (
+    window as unknown as { __memryEditor?: { undo?: () => boolean; redo?: () => boolean } }
+  ).__memryEditor
+  if (!editor) return
+  try {
+    if (action === 'undo') editor.undo?.()
+    else editor.redo?.()
+  } catch {
+    // Editor not ready — fail quietly rather than crash the menu.
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/menu-commands.ts
+++ b/apps/desktop/src/renderer/src/lib/menu-commands.ts
@@ -15,6 +15,19 @@ interface EditorLike {
   insertBlocks: (blocks: unknown[], ref: unknown, placement: 'after') => void
 }
 
+/** Shape of the BlockNote editor exposed on window by use-block-note-setup.ts. */
+interface MemryEditorGlobal extends EditorLike {
+  undo: () => boolean
+  redo: () => boolean
+  focus?: () => void
+  domElement?: HTMLElement
+}
+
+/** Single accessor for the editor global set by use-block-note-setup.ts. */
+function getMemryEditor(): MemryEditorGlobal | undefined {
+  return (window as unknown as { __memryEditor?: MemryEditorGlobal }).__memryEditor
+}
+
 const STYLE_COMMANDS: Record<string, Record<string, unknown>> = {
   'format.bold': { bold: true },
   'format.italic': { italic: true },
@@ -77,8 +90,7 @@ export function applyEditorMenuCommand(editor: EditorLike, command: string): boo
 }
 
 export function runEditorMenuCommand(command: string): void {
-  const editor = (window as unknown as { __memryEditor?: EditorLike & { focus?: () => void } })
-    .__memryEditor
+  const editor = getMemryEditor()
   if (!editor) return
   try {
     editor.focus?.()
@@ -89,9 +101,12 @@ export function runEditorMenuCommand(command: string): void {
 }
 
 /**
- * Menu-bar Undo/Redo. Native inputs keep the browser's own edit history;
- * everything else routes to the BlockNote editor's (Yjs) undo stack — the
- * native menu role can't reach it (see main/menu.ts).
+ * Menu-bar Undo/Redo. Native inputs keep the browser's own edit history; the
+ * note editor's (Yjs) undo stack is used only while focus is inside it — the
+ * native menu role can't reach it (see main/menu.ts). Other editable surfaces
+ * (task description, agent composer) own their history, so they get the native
+ * command, and non-editable focus is a no-op rather than an invisible edit to
+ * a background document.
  */
 export function runHistoryMenuCommand(action: 'undo' | 'redo'): void {
   const active = document.activeElement
@@ -100,14 +115,18 @@ export function runHistoryMenuCommand(action: 'undo' | 'redo'): void {
     return
   }
 
-  const editor = (
-    window as unknown as { __memryEditor?: { undo?: () => boolean; redo?: () => boolean } }
-  ).__memryEditor
-  if (!editor) return
-  try {
-    if (action === 'undo') editor.undo?.()
-    else editor.redo?.()
-  } catch {
-    // Editor not ready — fail quietly rather than crash the menu.
+  const editor = getMemryEditor()
+  if (editor?.domElement && active && editor.domElement.contains(active)) {
+    try {
+      if (action === 'undo') editor.undo()
+      else editor.redo()
+    } catch {
+      // Editor not ready — fail quietly rather than crash the menu.
+    }
+    return
+  }
+
+  if (active instanceof HTMLElement && active.isContentEditable) {
+    document.execCommand(action)
   }
 }

--- a/apps/desktop/tests/e2e/editor-undo.e2e.ts
+++ b/apps/desktop/tests/e2e/editor-undo.e2e.ts
@@ -69,7 +69,7 @@ test.describe('Editor undo history', () => {
     await page.keyboard.type(typedLine)
     await expectNoteEditorBody(page, `${body}\n\n${typedLine}`)
 
-    await clickApplicationMenuItem(electronApp, 'Undo')
+    await clickApplicationMenuItem(electronApp, 'edit.undo')
     await expectNoteEditorBody(page, body)
   })
 
@@ -90,19 +90,18 @@ test.describe('Editor undo history', () => {
 
 async function clickApplicationMenuItem(
   electronApp: ElectronApplication,
-  label: string
+  itemId: string
 ): Promise<void> {
-  await electronApp.evaluate(({ Menu, BrowserWindow }, itemLabel) => {
+  await electronApp.evaluate(({ Menu, BrowserWindow }, id) => {
     // The renderer dispatch targets the focused window; make sure there is one.
     BrowserWindow.getAllWindows()[0]?.focus()
     const menu = Menu.getApplicationMenu()
     if (!menu) throw new Error('No application menu')
-    const flatten = (items: Electron.MenuItem[]): Electron.MenuItem[] =>
-      items.flatMap((item) => [item, ...(item.submenu ? flatten(item.submenu.items) : [])])
-    const item = flatten(menu.items).find((candidate) => candidate.label === itemLabel)
-    if (!item) throw new Error(`Application menu item "${itemLabel}" not found`)
+    // Lookup by command id, not display label — labels are localized.
+    const item = menu.getMenuItemById(id)
+    if (!item) throw new Error(`Application menu item "${id}" not found`)
     item.click()
-  }, label)
+  }, itemId)
 }
 
 async function seedNote(page: Page, title: string, content: string): Promise<NoteHandle> {

--- a/apps/desktop/tests/e2e/editor-undo.e2e.ts
+++ b/apps/desktop/tests/e2e/editor-undo.e2e.ts
@@ -56,11 +56,13 @@ test.describe('Editor undo history', () => {
     // which is empty in the BlockNote editor — the menu item silently did
     // nothing on every platform, and its registered accelerator swallowed
     // Ctrl+Z on Windows/Linux. Drives the real menu item, not the keyboard.
+    // Runs on the journal surface (same ContentArea editor) because it opens
+    // without the note-tab helper.
     const body = `Menu undo seed ${Date.now()}`
     const typedLine = 'typed before menu undo'
-    const note = await seedNote(page, `Menu Undo Note ${Date.now()}`, body)
+    await seedCurrentJournalEntry(page, body)
 
-    await openNoteByHandle(page, note)
+    await navigateTo(page, 'journal')
     await expectNoteEditorBody(page, body)
 
     await focusEditorEnd(page)

--- a/apps/desktop/tests/e2e/editor-undo.e2e.ts
+++ b/apps/desktop/tests/e2e/editor-undo.e2e.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
 import { test, expect } from './fixtures'
 import {
   navigateTo,
@@ -51,6 +51,26 @@ test.describe('Editor undo history', () => {
     await expectNoteEditorBody(page, body)
   })
 
+  test('Edit menu Undo reverts a local edit', async ({ electronApp, page }) => {
+    // Regression: Edit→Undo used role 'undo' (Chromium's native undo stack),
+    // which is empty in the BlockNote editor — the menu item silently did
+    // nothing on every platform, and its registered accelerator swallowed
+    // Ctrl+Z on Windows/Linux. Drives the real menu item, not the keyboard.
+    const body = `Menu undo seed ${Date.now()}`
+    const typedLine = 'typed before menu undo'
+    const note = await seedNote(page, `Menu Undo Note ${Date.now()}`, body)
+
+    await openNoteByHandle(page, note)
+    await expectNoteEditorBody(page, body)
+
+    await focusEditorEnd(page)
+    await page.keyboard.type(typedLine)
+    await expectNoteEditorBody(page, `${body}\n\n${typedLine}`)
+
+    await clickApplicationMenuItem(electronApp, 'Undo')
+    await expectNoteEditorBody(page, body)
+  })
+
   test('journal first-open undo preserves the seeded entry', async ({ page }) => {
     const body = `Journal undo seed ${Date.now()}\n\nStill here after undo`
     await seedCurrentJournalEntry(page, body)
@@ -65,6 +85,23 @@ test.describe('Editor undo history', () => {
     await expect.poll(() => currentJournalEntryContent(page)).toBe(body)
   })
 })
+
+async function clickApplicationMenuItem(
+  electronApp: ElectronApplication,
+  label: string
+): Promise<void> {
+  await electronApp.evaluate(({ Menu, BrowserWindow }, itemLabel) => {
+    // The renderer dispatch targets the focused window; make sure there is one.
+    BrowserWindow.getAllWindows()[0]?.focus()
+    const menu = Menu.getApplicationMenu()
+    if (!menu) throw new Error('No application menu')
+    const flatten = (items: Electron.MenuItem[]): Electron.MenuItem[] =>
+      items.flatMap((item) => [item, ...(item.submenu ? flatten(item.submenu.items) : [])])
+    const item = flatten(menu.items).find((candidate) => candidate.label === itemLabel)
+    if (!item) throw new Error(`Application menu item "${itemLabel}" not found`)
+    item.click()
+  }, label)
+}
 
 async function seedNote(page: Page, title: string, content: string): Promise<NoteHandle> {
   return page.evaluate(

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -54,15 +54,17 @@ A chord indicator briefly flashes when the prefix is active.
 
 ## Editor
 
-| Action              | Shortcut                  |
-| ------------------- | ------------------------- |
-| Save (manual flush) | <kbd>⌘</kbd>+<kbd>S</kbd> |
-| Bold                | <kbd>⌘</kbd>+<kbd>B</kbd> |
-| Italic              | <kbd>⌘</kbd>+<kbd>I</kbd> |
-| Underline           | <kbd>⌘</kbd>+<kbd>U</kbd> |
-| Insert wiki link    | Type `[[`                 |
-| Open block menu     | Type `/`                  |
-| Find in page        | <kbd>⌘</kbd>+<kbd>F</kbd> |
+| Action              | Shortcut                               |
+| ------------------- | -------------------------------------- |
+| Undo                | <kbd>⌘</kbd>+<kbd>Z</kbd>              |
+| Redo                | <kbd>⇧</kbd>+<kbd>⌘</kbd>+<kbd>Z</kbd> |
+| Save (manual flush) | <kbd>⌘</kbd>+<kbd>S</kbd>              |
+| Bold                | <kbd>⌘</kbd>+<kbd>B</kbd>              |
+| Italic              | <kbd>⌘</kbd>+<kbd>I</kbd>              |
+| Underline           | <kbd>⌘</kbd>+<kbd>U</kbd>              |
+| Insert wiki link    | Type `[[`                              |
+| Open block menu     | Type `/`                               |
+| Find in page        | <kbd>⌘</kbd>+<kbd>F</kbd>              |
 
 ## View
 


### PR DESCRIPTION
## Problem

Customer report: undo does not work in the note editor on Fedora Linux — neither Ctrl+Z nor Edit→Undo. On macOS ⌘Z works, but Edit→Undo does nothing there either. Other editors (Anytype, Capacities) handle it fine.

## Root cause

The Edit menu used `role: 'undo'` / `role: 'redo'`:

1. On Windows/Linux, a role item's default `CmdOrCtrl+Z` accelerator is registered as a system accelerator and consumed in the main process **before the renderer ever sees the keydown**, so BlockNote's `Mod-z` keymap (→ Yjs UndoManager) never runs. The role's action is `webContents.undo()` — Chromium's native undo stack, which is empty because ProseMirror/Yjs owns all editing. Net: Ctrl+Z swallowed and replaced with a no-op. macOS is unaffected because the page gets first crack at menu key equivalents.
2. A role item ignores `click`, so the menu item itself was a native no-op on **every** platform.

Cut/copy/paste/select-all survived because their native equivalents genuinely work on contenteditable; undo is the only Edit role with no native backing.

## Fix

- Undo/Redo are now `cmd()` bridge items: the shortcut is displayed but **not registered** (`registerAccelerator: false`), so the keydown reaches the editor keymap on Windows/Linux; the click dispatches `edit.undo`/`edit.redo` to the renderer. Windows shows the platform `Ctrl+Y` redo accelerator.
- Renderer `runHistoryMenuCommand`: native inputs → `execCommand`; the note editor's Yjs history only while focus is inside it; other editable surfaces get the native command; non-editable focus is a no-op (no invisible edits to background documents).
- `sendMenuCommand` no longer silently drops commands when no window reports focus (macOS app menu, Linux focus-follows-mouse): shared resolver falls back to the **sole visible** window; hidden helper windows (PDF export, quick capture) never qualify, and an ambiguous multi-window state drops the command as before.
- `__memryEditor` registration skips read-only editors (template preview) and cleanup only clears its own registration.

## Verification

- 31 unit tests across menu template, dispatch, fallback, containment, and editor-global lifecycle (all new behaviors covered).
- New e2e drives the real application-menu item (`Menu.getMenuItemById('edit.undo').click()`) — synthetic CDP keystrokes bypass the accelerator table, so keyboard e2e structurally cannot catch this bug class. Local e2e runs were blocked by pre-existing infra flakes on a loaded machine (note-tab open event drop — tracked separately); CI should exercise it on clean runners.
- Typecheck, lint, docs gate green. Docs updated with editor Undo/Redo shortcuts.

## Notes

- Right-click context-menu Undo/Redo (still role-based) is handled in a separate follow-up branch; reconcile when landing both.
- Real-hardware Fedora verification recommended with the next build (mechanism confirmed against Electron's documented accelerator behavior).