### PR TITLE
feat(note): file actions in note-view menu (delete, move, rename, reveal, copy path, find)

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/note-title/NoteTitle.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-title/NoteTitle.tsx
@@ -1,3 +1,4 @@
+import type { RefObject } from 'react'
 import { cn } from '@/lib/utils'
 import { NoteIconDisplay } from '@/lib/render-note-icon'
 import { TitleInput } from './TitleInput'
@@ -10,6 +11,8 @@ export interface NoteTitleProps {
   onTitleChange: (title: string) => void
   autoFocus?: boolean
   disabled?: boolean
+  /** Optional external ref to the title textarea (e.g. to focus from the menu) */
+  inputRef?: RefObject<HTMLTextAreaElement | null>
 }
 
 export function NoteTitle({
@@ -18,7 +21,8 @@ export function NoteTitle({
   placeholder,
   onTitleChange,
   autoFocus = false,
-  disabled = false
+  disabled = false,
+  inputRef
 }: NoteTitleProps) {
   const { t } = useT('notes')
 
@@ -37,6 +41,7 @@ export function NoteTitle({
           onChange={onTitleChange}
           autoFocus={autoFocus}
           disabled={disabled}
+          inputRef={inputRef}
         />
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/note/note-title/TitleInput.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-title/TitleInput.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, useState, KeyboardEvent } from 'react'
+import { useRef, useEffect, useCallback, useState, KeyboardEvent, type RefObject } from 'react'
 import { cn } from '@/lib/utils'
 import { useT } from '@memry/i18n/renderer'
 
@@ -8,6 +8,8 @@ interface TitleInputProps {
   onChange: (value: string) => void
   autoFocus?: boolean
   disabled?: boolean
+  /** Optional external ref to the underlying textarea (e.g. to focus from a menu) */
+  inputRef?: RefObject<HTMLTextAreaElement | null>
 }
 
 export function TitleInput({
@@ -15,12 +17,22 @@ export function TitleInput({
   placeholder,
   onChange,
   autoFocus = false,
-  disabled = false
+  disabled = false,
+  inputRef
 }: TitleInputProps) {
   const { t } = useT('notes')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [draftValue, setDraftValue] = useState<string | null>(null)
   const displayValue = draftValue ?? value
+
+  // Merge the internal auto-resize ref with an optional external ref.
+  const setTextareaRef = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      textareaRef.current = node
+      if (inputRef) inputRef.current = node
+    },
+    [inputRef]
+  )
 
   // Auto-resize textarea
   const adjustHeight = useCallback(() => {
@@ -75,7 +87,7 @@ export function TitleInput({
 
   return (
     <textarea
-      ref={textareaRef}
+      ref={setTextareaRef}
       value={displayValue}
       onChange={handleChange}
       onKeyDown={handleKeyDown}

--- a/apps/desktop/src/renderer/src/components/note/note-title/note-title.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/note-title/note-title.test.tsx
@@ -141,3 +141,22 @@ describe('NoteTitle - accessibility', () => {
     expect(screen.getByRole('textbox', { name: /note title/i })).toBeInTheDocument()
   })
 })
+
+describe('NoteTitle - external inputRef (rename from menu)', () => {
+  it('forwards an external ref to the underlying textarea so it can be focused', () => {
+    const inputRef = { current: null as HTMLTextAreaElement | null }
+    renderWithI18n(
+      <NoteTitle emoji={null} title="Focus Me" onTitleChange={vi.fn()} inputRef={inputRef} />
+    )
+
+    const textarea = screen.getByRole('textbox', { name: /note title/i })
+    expect(inputRef.current).toBe(textarea)
+
+    // The "Rename" menu item focuses + selects via this ref
+    inputRef.current?.focus()
+    inputRef.current?.select()
+    expect(textarea).toHaveFocus()
+    expect(inputRef.current?.selectionStart).toBe(0)
+    expect(inputRef.current?.selectionEnd).toBe('Focus Me'.length)
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -1024,5 +1024,52 @@ describe('NotePage', () => {
       expect(mocks.closeTab).not.toHaveBeenCalled()
       expect(toast.error).toHaveBeenCalledWith('nope')
     })
+
+    it('surfaces an error toast when copy path fails', async () => {
+      const writeText = vi.fn().mockRejectedValue(new Error('clipboard blocked'))
+      Object.assign(navigator, { clipboard: { writeText } })
+
+      renderWithProviders(<NotePage noteId="note-1" />)
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.copyPath' }))
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('clipboard blocked'))
+    })
+
+    it('surfaces an error toast when reveal in Finder fails', async () => {
+      mocks.revealInFinder.mockRejectedValueOnce(new Error('reveal failed'))
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.revealInFinder' }))
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('reveal failed'))
+    })
+
+    it('surfaces an error toast when open in default app fails', async () => {
+      mocks.openExternal.mockRejectedValueOnce(new Error('open failed'))
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.openInDefaultApp' }))
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('open failed'))
+    })
+
+    it('surfaces an error toast when the move op reports failure', async () => {
+      mocks.moveNote.mockResolvedValueOnce({ success: false, error: 'move blocked' })
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.moveToFolder' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm move' }))
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('move blocked'))
+    })
+
+    it('surfaces an error toast when delete throws', async () => {
+      mocks.deleteNote.mockRejectedValueOnce(new Error('delete crashed'))
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.delete' }))
+      fireEvent.click(screen.getByRole('button', { name: 'page.deleteConfirm.confirm' }))
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('delete crashed'))
+      expect(mocks.closeTab).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -16,9 +16,14 @@ const mocks = vi.hoisted(() => ({
   createNote: vi.fn(),
   updateNote: vi.fn(),
   renameNote: vi.fn(),
+  deleteNote: vi.fn(),
+  moveNote: vi.fn(),
   openTab: vi.fn(),
+  closeTab: vi.fn(),
   setTabDeleted: vi.fn(),
   updateTabTitleByEntityId: vi.fn(),
+  revealInFinder: vi.fn(),
+  openExternal: vi.fn(),
   openTag: vi.fn(),
   invalidateQueries: vi.fn(),
   handleAddProperty: vi.fn(),
@@ -53,6 +58,7 @@ const mocks = vi.hoisted(() => ({
     matchCount: 2,
     currentIndex: 1,
     inputRef: { current: null },
+    open: vi.fn(),
     setQuery: vi.fn(),
     next: vi.fn(),
     prev: vi.fn(),
@@ -99,7 +105,9 @@ vi.mock('@/hooks/use-notes-query', () => ({
   useNoteMutations: () => ({
     createNote: { mutateAsync: mocks.createNote },
     updateNote: { mutateAsync: mocks.updateNote },
-    renameNote: { mutateAsync: mocks.renameNote }
+    renameNote: { mutateAsync: mocks.renameNote },
+    deleteNote: { mutateAsync: mocks.deleteNote },
+    moveNote: { mutateAsync: mocks.moveNote }
   }),
   useNoteLinksQuery: () => ({
     incoming: [
@@ -157,7 +165,9 @@ vi.mock('@/hooks/use-tasks-linked-to-note', () => ({
 vi.mock('@/services/notes-service', () => ({
   notesService: {
     setLocalOnly: mocks.setLocalOnly,
-    update: mocks.notesUpdate
+    update: mocks.notesUpdate,
+    revealInFinder: mocks.revealInFinder,
+    openExternal: mocks.openExternal
   },
   onNoteDeleted: (handler: (event: { id: string }) => void) => {
     mocks.deletedHandler = handler
@@ -185,10 +195,12 @@ vi.mock('@/lib/wikilink-resolver', () => ({
 vi.mock('@/contexts/tabs', () => ({
   useTabs: () => ({
     openTab: mocks.openTab,
+    closeTab: mocks.closeTab,
     setTabDeleted: mocks.setTabDeleted,
     updateTabTitleByEntityId: mocks.updateTabTitleByEntityId
   }),
   useActiveTab: () => ({
+    id: '/notes/note-1',
     entityId: 'note-1',
     viewState: { highlightText: 'Important', highlightStart: 1, highlightEnd: 10 }
   })
@@ -495,6 +507,48 @@ vi.mock('@/components/ui/switch', () => ({
   Switch: () => <span data-testid="switch" />
 }))
 
+vi.mock('@/components/folder-view/move-to-folder-dialog', () => ({
+  MoveToFolderDialog: ({
+    open,
+    noteIds,
+    currentFolder,
+    onMove
+  }: {
+    open: boolean
+    noteIds: string[]
+    currentFolder?: string
+    onMove: (folder: string) => void
+  }) =>
+    open ? (
+      <div data-testid="move-dialog">
+        <span>{`move:${noteIds.join(',')}:${currentFolder ?? ''}`}</span>
+        <button type="button" onClick={() => onMove('Work')}>
+          Confirm move
+        </button>
+      </div>
+    ) : null
+}))
+
+vi.mock('@/components/ui/alert-dialog', () => ({
+  AlertDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="delete-dialog">{children}</div> : null,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  AlertDialogCancel: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  AlertDialogAction: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  )
+}))
+
 vi.mock('@/components/note/export-dialog', () => ({
   ExportDialog: ({ open, noteTitle }: { open: boolean; noteTitle: string }) =>
     open ? <div>Export {noteTitle}</div> : null
@@ -578,6 +632,10 @@ describe('NotePage', () => {
     mocks.noteState.error = null
     mocks.updateNote.mockResolvedValue({ success: true })
     mocks.renameNote.mockResolvedValue({ success: true })
+    mocks.deleteNote.mockResolvedValue({ success: true })
+    mocks.moveNote.mockResolvedValue({ success: true })
+    mocks.revealInFinder.mockResolvedValue(undefined)
+    mocks.openExternal.mockResolvedValue(undefined)
     mocks.createNote.mockResolvedValue({
       success: true,
       note: { id: 'created-note', title: 'New Note' }
@@ -876,5 +934,95 @@ describe('NotePage', () => {
       mocks.propertyOnBlocked?.('remove')
     })
     expect(toast.error).toHaveBeenCalledWith('Cannot delete property - this note was deleted')
+  })
+
+  describe('note-view menu file actions', () => {
+    it('opens find in page from the menu', () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.find' }))
+      expect(mocks.findInPage.open).toHaveBeenCalled()
+    })
+
+    it('copies the vault-relative path to the clipboard', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.assign(navigator, { clipboard: { writeText } })
+
+      renderWithProviders(<NotePage noteId="note-1" />)
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.copyPath' }))
+
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith('notes/Test Note.md'))
+      expect(toast.success).toHaveBeenCalledWith('page.toast.pathCopied')
+    })
+
+    it('reveals the note in the OS file manager', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.revealInFinder' }))
+      await waitFor(() => expect(mocks.revealInFinder).toHaveBeenCalledWith('note-1'))
+    })
+
+    it('opens the note in the default app', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.openInDefaultApp' }))
+      await waitFor(() => expect(mocks.openExternal).toHaveBeenCalledWith('note-1'))
+    })
+
+    it('dispatches a reveal-in-sidebar event', () => {
+      const listener = vi.fn()
+      window.addEventListener('reveal-in-sidebar', listener)
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.revealInSidebar' }))
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      const event = listener.mock.calls[0][0] as CustomEvent
+      expect(event.detail).toEqual({ path: '/notes/note-1', entityId: 'note-1' })
+      window.removeEventListener('reveal-in-sidebar', listener)
+    })
+
+    it('moves the note to a folder via the dialog', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      // Dialog is closed until the menu item is chosen
+      expect(screen.queryByTestId('move-dialog')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.moveToFolder' }))
+      const dialog = screen.getByTestId('move-dialog')
+      // current folder is derived from the note path
+      expect(dialog).toHaveTextContent('move:note-1:notes')
+
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm move' }))
+      await waitFor(() =>
+        expect(mocks.moveNote).toHaveBeenCalledWith({ id: 'note-1', newFolder: 'Work' })
+      )
+      expect(toast.success).toHaveBeenCalledWith('page.toast.moved')
+    })
+
+    it('deletes the note after confirmation and closes its tab', async () => {
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      // Confirmation not shown until the delete item is chosen
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.delete' }))
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument()
+      // Nothing deleted just by opening the dialog
+      expect(mocks.deleteNote).not.toHaveBeenCalled()
+
+      fireEvent.click(screen.getByRole('button', { name: 'page.deleteConfirm.confirm' }))
+      await waitFor(() => expect(mocks.deleteNote).toHaveBeenCalledWith('note-1'))
+      expect(mocks.closeTab).toHaveBeenCalledWith('/notes/note-1')
+    })
+
+    it('does not delete when the delete op reports failure', async () => {
+      mocks.deleteNote.mockResolvedValueOnce({ success: false, error: 'nope' })
+      renderWithProviders(<NotePage noteId="note-1" />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'editor.toolbar.delete' }))
+      fireEvent.click(screen.getByRole('button', { name: 'page.deleteConfirm.confirm' }))
+
+      await waitFor(() => expect(mocks.deleteNote).toHaveBeenCalledWith('note-1'))
+      expect(mocks.closeTab).not.toHaveBeenCalled()
+      expect(toast.error).toHaveBeenCalledWith('nope')
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -1439,7 +1439,7 @@ export function NotePage({ noteId }: NotePageProps) {
       <MoveToFolderDialog
         open={isMoveDialogOpen}
         onOpenChange={setIsMoveDialogOpen}
-        noteIds={noteId ? [noteId] : []}
+        noteIds={[noteId]}
         currentFolder={
           note.path.includes('/') ? note.path.slice(0, note.path.lastIndexOf('/')) : ''
         }

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -46,11 +46,30 @@ import {
   Monitor,
   Maximize,
   ChartRelationship,
-  PenLine
+  PenLine,
+  Pencil,
+  Search,
+  FolderInput,
+  Copy,
+  FolderOpen,
+  PanelLeft,
+  ExternalLink,
+  Trash2
 } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { Picker } from '@/components/ui/picker'
 import { Switch } from '@/components/ui/switch'
+import { MoveToFolderDialog } from '@/components/folder-view/move-to-folder-dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
 import { toast } from 'sonner'
 import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
 import { useIsBookmarked } from '@/hooks/use-bookmarks'
@@ -124,11 +143,11 @@ export function NotePage({ noteId }: NotePageProps) {
   const { t } = useT('notes')
   // TanStack Query hooks for data fetching with caching
   const { note, isLoading, error: noteError, refetch: refetchNote } = useNote(noteId ?? null)
-  const { createNote, updateNote, renameNote } = useNoteMutations()
+  const { createNote, updateNote, renameNote, deleteNote, moveNote } = useNoteMutations()
   const { incoming: rawBacklinks, isLoading: backlinksLoading } = useNoteLinksQuery(noteId ?? null)
   const { tasks: linkedTasks, isLoading: linkedTasksLoading } = useTasksLinkedToNote(noteId ?? null)
   const { tags: allAvailableTags } = useNoteTagsQuery()
-  const { openTab, setTabDeleted, updateTabTitleByEntityId } = useTabs()
+  const { openTab, setTabDeleted, updateTabTitleByEntityId, closeTab } = useTabs()
   const activeTab = useActiveTab()
   const { openTag } = useSidebarDrillDown()
   const queryClient = useQueryClient()
@@ -171,6 +190,11 @@ export function NotePage({ noteId }: NotePageProps) {
   const [isVersionHistoryOpen, setIsVersionHistoryOpen] = useState(false)
   const [isLocalGraphOpen, setIsLocalGraphOpen] = useState(false)
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
+  const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false)
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  // External ref to the inline title textarea so the "Rename" menu item can focus it
+  const titleInputRef = useRef<HTMLTextAreaElement | null>(null)
   const [externalUpdateCount, setExternalUpdateCount] = useState(0)
   const [eventContentOverride, setEventContentOverride] = useState<{
     noteId: string
@@ -774,6 +798,97 @@ export function NotePage({ noteId }: NotePageProps) {
     [noteId, isDeleted, refetchNote, t]
   )
 
+  // ── Note-view menu file actions ───────────────────────────────────────────
+
+  // Rename: focus + select the inline title textarea (no dialog).
+  // Deferred so the menu's focus-restore-on-close does not steal focus back.
+  const handleRename = useCallback(() => {
+    requestAnimationFrame(() => {
+      const el = titleInputRef.current
+      if (!el) return
+      el.focus()
+      el.select()
+    })
+  }, [])
+
+  // Copy the vault-relative path (Obsidian parity; no IPC, OS-agnostic)
+  const handleCopyPath = useCallback(async () => {
+    if (!note) return
+    try {
+      await navigator.clipboard.writeText(note.path)
+      toast.success(t('page.toast.pathCopied'))
+    } catch (err) {
+      toast.error(extractErrorMessage(err, t('page.toast.copyPathFailed')))
+    }
+  }, [note, t])
+
+  // Reveal in the OS file manager (Finder / Explorer / file manager)
+  const handleRevealInFinder = useCallback(async () => {
+    if (!noteId) return
+    try {
+      await notesService.revealInFinder(noteId)
+    } catch (err) {
+      toast.error(extractErrorMessage(err, t('page.toast.revealFailed')))
+    }
+  }, [noteId, t])
+
+  // Reveal in the app sidebar / navigation tree
+  const handleRevealInSidebar = useCallback(() => {
+    if (!noteId) return
+    window.dispatchEvent(
+      new CustomEvent('reveal-in-sidebar', {
+        detail: { path: `/notes/${noteId}`, entityId: noteId }
+      })
+    )
+  }, [noteId])
+
+  // Open in the OS default app for the file type
+  const handleOpenExternal = useCallback(async () => {
+    if (!noteId) return
+    try {
+      await notesService.openExternal(noteId)
+    } catch (err) {
+      toast.error(extractErrorMessage(err, t('page.toast.openExternalFailed')))
+    }
+  }, [noteId, t])
+
+  // Move to another folder (via the shared dialog)
+  const handleMoveToFolder = useCallback(
+    async (targetFolder: string) => {
+      if (!noteId) return
+      try {
+        const result = await moveNote.mutateAsync({ id: noteId, newFolder: targetFolder })
+        if (result.success) {
+          toast.success(t('page.toast.moved'))
+        } else {
+          toast.error(result.error ?? t('page.toast.moveFailed'))
+        }
+      } catch (err) {
+        toast.error(extractErrorMessage(err, t('page.toast.moveFailed')))
+      }
+    },
+    [noteId, moveNote, t]
+  )
+
+  // Delete the current note, then close its tab
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!noteId || isDeleting) return
+    setIsDeleting(true)
+    try {
+      const result = await deleteNote.mutateAsync(noteId)
+      if (result.success) {
+        setIsDeleteConfirmOpen(false)
+        closeTab(activeTab?.id ?? `/notes/${noteId}`)
+      } else {
+        toast.error(result.error ?? t('page.toast.deleteFailed'))
+      }
+    } catch (err) {
+      toast.error(extractErrorMessage(err, t('page.toast.deleteFailed')))
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [noteId, isDeleting, deleteNote, closeTab, activeTab?.id, t])
+
   // Link handlers
   const handleLinkClick = useCallback((href: string) => {
     window.open(href, '_blank', 'noopener,noreferrer')
@@ -975,9 +1090,17 @@ export function NotePage({ noteId }: NotePageProps) {
           }
           setMoreMenuOpen(false)
           if (action === 'local-graph') setIsLocalGraphOpen((prev) => !prev)
+          if (action === 'find') findInPage.open()
           if (action === 'version-history') setIsVersionHistoryOpen(true)
           if (action === 'export') setIsExportDialogOpen(true)
           if (action === 'apply-template') setIsApplyTemplateOpen(true)
+          if (action === 'rename') handleRename()
+          if (action === 'move-to-folder') setIsMoveDialogOpen(true)
+          if (action === 'copy-path') void handleCopyPath()
+          if (action === 'reveal-in-finder') void handleRevealInFinder()
+          if (action === 'reveal-in-sidebar') handleRevealInSidebar()
+          if (action === 'open-external') void handleOpenExternal()
+          if (action === 'delete') setIsDeleteConfirmOpen(true)
           if (action === 'local-only')
             void handleToggleLocalOnly(!(note.frontmatter.localOnly ?? false))
         }}
@@ -990,6 +1113,8 @@ export function NotePage({ noteId }: NotePageProps) {
             size="icon"
             className="size-7 hover:bg-surface-active transition-all duration-150 ease-out active:scale-95 active:bg-surface-active/70 disabled:active:scale-100"
             disabled={isDeleted}
+            data-testid="note-more-menu"
+            aria-label={t('editor.toolbar.moreActions')}
           >
             <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
           </Button>
@@ -1004,6 +1129,11 @@ export function NotePage({ noteId }: NotePageProps) {
                   : t('editor.toolbar.showLocalGraph')
               }
               icon={<ChartRelationship className="size-4" />}
+            />
+            <Picker.Item
+              value="find"
+              label={t('editor.toolbar.find')}
+              icon={<Search className="size-4" />}
             />
             <Picker.Item
               value="version-history"
@@ -1034,6 +1164,38 @@ export function NotePage({ noteId }: NotePageProps) {
             />
             <Picker.Separator />
             <Picker.Item
+              value="rename"
+              label={t('editor.toolbar.rename')}
+              icon={<Pencil className="size-4" />}
+            />
+            <Picker.Item
+              value="move-to-folder"
+              label={t('editor.toolbar.moveToFolder')}
+              icon={<FolderInput className="size-4" />}
+            />
+            <Picker.Item
+              value="copy-path"
+              label={t('editor.toolbar.copyPath')}
+              icon={<Copy className="size-4" />}
+            />
+            <Picker.Separator />
+            <Picker.Item
+              value="reveal-in-finder"
+              label={t('editor.toolbar.revealInFinder')}
+              icon={<FolderOpen className="size-4" />}
+            />
+            <Picker.Item
+              value="reveal-in-sidebar"
+              label={t('editor.toolbar.revealInSidebar')}
+              icon={<PanelLeft className="size-4" />}
+            />
+            <Picker.Item
+              value="open-external"
+              label={t('editor.toolbar.openInDefaultApp')}
+              icon={<ExternalLink className="size-4" />}
+            />
+            <Picker.Separator />
+            <Picker.Item
               value="local-only"
               label={
                 note.frontmatter.localOnly
@@ -1041,6 +1203,13 @@ export function NotePage({ noteId }: NotePageProps) {
                   : t('editor.toolbar.setLocalOnly')
               }
               icon={<Monitor className="size-4" />}
+            />
+            <Picker.Separator />
+            <Picker.Item
+              value="delete"
+              label={t('editor.toolbar.delete')}
+              icon={<Trash2 className="size-4" />}
+              destructive
             />
           </Picker.List>
         </Picker.Content>
@@ -1091,6 +1260,7 @@ export function NotePage({ noteId }: NotePageProps) {
             title={note.title}
             onTitleChange={(...args) => void handleTitleChange(...args)}
             placeholder={t('editor.title.untitled')}
+            inputRef={titleInputRef}
           />
 
           {/* Tags: visible when tags exist */}
@@ -1264,6 +1434,48 @@ export function NotePage({ noteId }: NotePageProps) {
           refetchNote()
         }}
       />
+
+      {/* Move to Folder Dialog */}
+      <MoveToFolderDialog
+        open={isMoveDialogOpen}
+        onOpenChange={setIsMoveDialogOpen}
+        noteIds={noteId ? [noteId] : []}
+        currentFolder={
+          note.path.includes('/') ? note.path.slice(0, note.path.lastIndexOf('/')) : ''
+        }
+        noteTitle={note.title}
+        onMove={(targetFolder) => void handleMoveToFolder(targetFolder)}
+      />
+
+      {/* Delete confirmation */}
+      <AlertDialog
+        open={isDeleteConfirmOpen}
+        onOpenChange={(open) => !open && setIsDeleteConfirmOpen(false)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('page.deleteConfirm.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('page.deleteConfirm.description', { title: note.title })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>
+              {t('page.deleteConfirm.cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                void handleDeleteConfirm()
+              }}
+              disabled={isDeleting}
+              className="bg-red-500 hover:bg-red-600"
+            >
+              {isDeleting ? t('page.deleteConfirm.deleting') : t('page.deleteConfirm.confirm')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </NoteLayout>
   )
 }

--- a/apps/desktop/tests/e2e/note-menu-actions.e2e.ts
+++ b/apps/desktop/tests/e2e/note-menu-actions.e2e.ts
@@ -1,0 +1,133 @@
+/**
+ * Note-view menu file actions E2E
+ *
+ * Covers the file actions added to the note-view "more" menu:
+ * Find, Rename, Move to folder, Copy path, Reveal in Finder,
+ * Reveal in navigation, Open in default app, Delete note.
+ *
+ * Side-effecting OS items (Reveal in Finder / Open in default app) are only
+ * asserted present + enabled — they are never clicked, so no Finder/Explorer
+ * window is spawned on the CI machine. All handlers are cross-platform Electron
+ * shell APIs (showItemInFolder / openPath), verified at the unit level.
+ */
+
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+import {
+  waitForAppReady,
+  waitForVaultReady,
+  seedNote,
+  waitForToast,
+  SELECTORS
+} from './utils/electron-helpers'
+import { openNoteByHandle } from './utils/note-sync-helpers'
+
+const MENU_ITEMS = [
+  'Find…',
+  'Rename…',
+  'Move to folder…',
+  'Copy path',
+  'Reveal in Finder',
+  'Reveal in navigation',
+  'Open in default app',
+  'Delete note'
+]
+
+test.describe('Note-view menu file actions', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+  })
+
+  async function seedAndOpen(page: Page, title: string): Promise<string> {
+    const id = await seedNote(page, title, 'Body for menu actions')
+    await openNoteByHandle(page, { id, title })
+    await expect(page.locator(SELECTORS.noteTitle).first()).toHaveValue(title)
+    return id
+  }
+
+  async function openMoreMenu(page: Page): Promise<void> {
+    await page.locator('[data-testid="note-more-menu"]').first().click()
+  }
+
+  test('shows all file actions in the menu', async ({ page }) => {
+    await seedAndOpen(page, `Menu Items ${Date.now()}`)
+    await openMoreMenu(page)
+
+    for (const label of MENU_ITEMS) {
+      await expect(page.getByRole('option', { name: label })).toBeVisible()
+    }
+  })
+
+  test('Find opens the find bar', async ({ page }) => {
+    await seedAndOpen(page, `Find From Menu ${Date.now()}`)
+    await openMoreMenu(page)
+    await page.getByRole('option', { name: 'Find…' }).click()
+
+    await expect(page.getByRole('textbox', { name: 'Find, replace, ask...' })).toBeVisible()
+  })
+
+  test('Copy path copies the vault-relative path', async ({ page }) => {
+    await seedAndOpen(page, `Copy Path ${Date.now()}`)
+    await openMoreMenu(page)
+    await page.getByRole('option', { name: 'Copy path' }).click()
+
+    await waitForToast(page, 'Path copied')
+  })
+
+  test('Rename focuses the title', async ({ page }) => {
+    await seedAndOpen(page, `Rename From Menu ${Date.now()}`)
+    await openMoreMenu(page)
+    await page.getByRole('option', { name: 'Rename…' }).click()
+
+    await expect(page.locator(SELECTORS.noteTitle).first()).toBeFocused()
+  })
+
+  test('Move to folder opens the move dialog', async ({ page }) => {
+    await seedAndOpen(page, `Move From Menu ${Date.now()}`)
+    await openMoreMenu(page)
+    await page.getByRole('option', { name: 'Move to folder…' }).click()
+
+    await expect(page.getByRole('dialog')).toBeVisible()
+    // Close without moving — the move itself is covered at the unit level.
+    await page.keyboard.press('Escape')
+  })
+
+  test('Reveal/Open OS items are present and enabled (not clicked)', async ({ page }) => {
+    await seedAndOpen(page, `OS Items ${Date.now()}`)
+    await openMoreMenu(page)
+
+    for (const label of ['Reveal in Finder', 'Reveal in navigation', 'Open in default app']) {
+      const item = page.getByRole('option', { name: label })
+      await expect(item).toBeVisible()
+      await expect(item).toBeEnabled()
+    }
+  })
+
+  test('Delete removes the note after confirmation and closes its tab', async ({ page }) => {
+    const title = `Delete From Menu ${Date.now()}`
+    const id = await seedAndOpen(page, title)
+
+    await openMoreMenu(page)
+    await page.getByRole('option', { name: 'Delete note' }).click()
+
+    // Confirmation dialog
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'Delete', exact: true }).click()
+
+    // Note is gone from the default list, and its tab is closed
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async (noteId) => {
+            const { notes } = await window.api.notes.list({})
+            return notes.some((n: { id: string }) => n.id === noteId)
+          }, id),
+        { timeout: 10000 }
+      )
+      .toBe(false)
+
+    await expect(page.locator(`${SELECTORS.noteTitle}`).filter({ hasText: title })).toHaveCount(0)
+  })
+})

--- a/apps/desktop/tests/e2e/note-menu-actions.e2e.ts
+++ b/apps/desktop/tests/e2e/note-menu-actions.e2e.ts
@@ -13,14 +13,7 @@
 
 import type { Page } from '@playwright/test'
 import { test, expect } from './fixtures'
-import {
-  waitForAppReady,
-  waitForVaultReady,
-  seedNote,
-  waitForToast,
-  SELECTORS
-} from './utils/electron-helpers'
-import { openNoteByHandle } from './utils/note-sync-helpers'
+import { waitForAppReady, waitForVaultReady, seedNote, SELECTORS } from './utils/electron-helpers'
 
 const MENU_ITEMS = [
   'Find…',
@@ -39,9 +32,46 @@ test.describe('Note-view menu file actions', () => {
     await waitForVaultReady(page)
   })
 
+  // Seed a note, then restore a session with it as the active tab and reload —
+  // the robust open pattern used by pdf-embed-resize.e2e.ts (no tab-strip race).
   async function seedAndOpen(page: Page, title: string): Promise<string> {
     const id = await seedNote(page, title, 'Body for menu actions')
-    await openNoteByHandle(page, { id, title })
+    await page.addInitScript(
+      ({ noteId, t }) => {
+        localStorage.setItem(
+          'memry_tab_state',
+          JSON.stringify({
+            version: 2,
+            tabGroups: {
+              g1: {
+                id: 'g1',
+                activeTabId: 'note-tab',
+                tabs: [
+                  {
+                    id: 'note-tab',
+                    type: 'note',
+                    title: t,
+                    icon: 'file',
+                    path: `/notes/${noteId}`,
+                    entityId: noteId,
+                    isPinned: false
+                  }
+                ]
+              }
+            },
+            layout: { type: 'leaf', tabGroupId: 'g1' },
+            activeGroupId: 'g1',
+            settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' },
+            savedAt: Date.now()
+          })
+        )
+      },
+      { noteId: id, t: title }
+    )
+    await page.reload()
+    await waitForAppReady(page)
+    await waitForVaultReady(page)
+    await page.locator(SELECTORS.noteEditor).first().waitFor({ state: 'visible', timeout: 20_000 })
     await expect(page.locator(SELECTORS.noteTitle).first()).toHaveValue(title)
     return id
   }
@@ -72,7 +102,8 @@ test.describe('Note-view menu file actions', () => {
     await openMoreMenu(page)
     await page.getByRole('option', { name: 'Copy path' }).click()
 
-    await waitForToast(page, 'Path copied')
+    // Success toast confirms the copy (sonner renders nested nodes, so match first)
+    await expect(page.getByText('Path copied').first()).toBeVisible({ timeout: 5_000 })
   })
 
   test('Rename focuses the title', async ({ page }) => {

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -60,6 +60,32 @@ Titles become filenames in your vault, so characters that are invalid in filenam
 Obsidian wiki links (`< > : " / \ | ? * [ ] # ^`) are stripped on save — a note titled
 `Draft [v2] #1` is saved as `Draft v2 1.md`. Existing files are never renamed retroactively.
 
+## Note Menu
+
+The **⋯ button** in the top-right of a note (the _More actions_ menu) collects note-wide and file actions, so you can act on the note you are viewing without going back to the list.
+
+**View & tools**
+
+- **Local graph** — show or hide the note's local link graph
+- **Find…** — open in-note search (also <kbd>⌘</kbd>+<kbd>F</kbd>)
+- **Version history** — browse and restore past versions
+- **Export** — export the note to PDF or HTML
+- **Apply template** — insert a template into the note
+- **Full width** — toggle the wide editor layout
+
+**File actions**
+
+- **Rename…** — moves focus to the title so you can rename in place
+- **Move to folder…** — move the note into another folder
+- **Copy path** — copy the note's vault-relative path
+- **Reveal in Finder** — show the `.md` file in your operating system's file manager (Finder on macOS, File Explorer on Windows, your file manager on Linux)
+- **Reveal in navigation** — highlight the note in the sidebar
+- **Open in default app** — open the `.md` file in your system's default editor
+
+**Local only** keeps the note on this device (never synced).
+
+**Delete note** moves the note to the trash after a confirmation, then closes its tab. This does the same thing as deleting from the note list — you no longer need to close the note first.
+
 ## Drag-and-Drop Blocks
 
 Hover the gutter on the left to reveal the block handle. Drag a block to:

--- a/docs/superpowers/specs/2026-07-17-note-view-menu-actions-design.md
+++ b/docs/superpowers/specs/2026-07-17-note-view-menu-actions-design.md
@@ -1,0 +1,122 @@
+# Note-view menu actions — design
+
+**Date:** 2026-07-17
+**Status:** Approved (design), implementing.
+
+## Problem
+
+To delete a note you're viewing, you must close its tab first, then delete it
+from the note list. The note-view "more" menu (`Picker` in
+`apps/desktop/src/renderer/src/pages/note.tsx`) exposes view/tools actions
+(Local Graph, Version History, Export, Apply Template, Full Width, Local Only)
+but no file actions. Bring the file actions the sidebar/list context menu already
+offers into the note-view menu.
+
+## Scope
+
+Add **8 items** to the note-view `Picker`. All wire to existing IPC/hooks — no
+backend, no contract change, no migration. **Replace is deferred** (Find is a
+read-only CSS-highlight engine; Replace needs a BlockNote/ProseMirror mutation
+engine — separate spec).
+
+| Item                 | Icon (hugeicon)        | Mechanism                                                   |
+| -------------------- | ---------------------- | ----------------------------------------------------------- |
+| Find…                | `Search`               | `findInPage.open()` (hook already in note.tsx)              |
+| Rename…              | `PenLine`              | focus + select inline title textarea via ref                |
+| Move to folder…      | `FolderInput`          | `MoveToFolderDialog` + `moveNote.mutateAsync`               |
+| Copy path            | `Copy`                 | `navigator.clipboard.writeText(note.path)` (vault-relative) |
+| Reveal in Finder     | `FolderOpen`           | `notesService.revealInFinder(id)`                           |
+| Reveal in navigation | `PanelLeft`            | `reveal-in-sidebar` CustomEvent                             |
+| Open in default app  | `ExternalLink`         | `notesService.openExternal(id)`                             |
+| Delete note          | `Trash2` (destructive) | confirm → `deleteNote.mutateAsync` → `closeTab`             |
+
+## Menu layout
+
+```
+Local Graph                 (existing)
+Find…                    ◆
+Version History             (existing)
+Export                      (existing)
+Apply Template              (existing)
+Full Width         [toggle] (existing)
+──────────
+Rename…                  ◆
+Move to folder…          ◆
+Copy path                ◆
+──────────
+Reveal in Finder         ◆
+Reveal in navigation     ◆
+Open in default app      ◆
+──────────
+Local Only         [toggle] (existing)
+──────────
+Delete note              ◆   (destructive, bottom)
+```
+
+## Key mechanics
+
+- **`Picker.Item`** already supports `icon`, `destructive`, `shortcut`,
+  `Picker.Separator`. New items are added to `Picker.List` and dispatched via the
+  existing `onValueChange` switch. `closeOnSelect={false}` stays; each action
+  calls `setMoreMenuOpen(false)` (dialogs/toggles already do).
+- **Delete**: `Picker.Item destructive` → opens an `AlertDialog` confirm (mirrors
+  `unsaved-changes-dialog.tsx`) → on confirm `deleteNote.mutateAsync(noteId)` →
+  `closeTab(activeTab.id)` (groupId defaults to active group). Matches
+  `use-tree-delete.ts` (delete → closeTab) and Obsidian's close-on-delete.
+- **Rename**: note title is an always-mounted inline `<textarea>`
+  (`TitleInput.tsx`). Thread an optional `inputRef` prop note.tsx → `NoteTitle` →
+  `TitleInput` (callback ref merges with the internal auto-resize ref). Rename
+  action = `ref.focus()` + `ref.select()`. No new dialog.
+- **Move**: mount the existing `MoveToFolderDialog`; `onMove(folder)` →
+  `moveNote.mutateAsync({ id, newFolder: folder })`. `currentFolder` derived from
+  `note.path` (dirname).
+- **Copy path**: copies vault-relative `note.path` (Obsidian parity, no IPC).
+- **Reveal in navigation**: dispatch `reveal-in-sidebar` CustomEvent
+  (`{ detail: { path: '/notes/'+id, entityId: id } }`), same as row-context-menu.
+
+## Cross-platform (macOS / Linux / Windows)
+
+- `revealInFinder` → `shell.showItemInFolder`; `openExternal` → `shell.openPath`.
+  Both are cross-platform Electron APIs (already used by the list context menu).
+- Copy path uses `note.path` (vault-relative, stored with `/`); no OS path
+  concat, no drive-letter pitfalls.
+- Find, Rename, Move, Reveal-in-nav, Delete are pure renderer/IPC — OS-agnostic.
+- Label "Reveal in Finder" reuses the app's existing string on all platforms
+  (matches current sidebar menu convention).
+
+## Guardrails
+
+- All items respect the existing `disabled={isDeleted}` gate on the menu trigger.
+- i18n: new `editor.toolbar.*` + `page.deleteConfirm.*` + `page.toast.*` keys under
+  the `notes` namespace (English gate; other locales warn-only per repo policy).
+- RTL: logical Tailwind (Picker.Item handles); no physical `ml/mr/left/right`.
+- Reduced-motion: no new animation introduced.
+
+## Testing
+
+- **Unit (renderer, vitest + jsdom)** — extend `note.test.tsx` / new
+  `note-menu-actions.test.tsx`:
+  - each item renders with its hugeicon and label
+  - Find → `findInPage.open` invoked
+  - Copy path → `clipboard.writeText(note.path)`
+  - Reveal in Finder / Open in default app → `notesService.revealInFinder` /
+    `openExternal` called with note id (mocked — no real OS launch)
+  - Reveal in navigation → `reveal-in-sidebar` event dispatched
+  - Rename → title textarea focused
+  - Move → dialog opens; `onMove` → `moveNote` called
+  - Delete → confirm opens; confirm → `deleteNote` called + `closeTab` invoked;
+    cancel → nothing deleted
+- **E2E (Playwright/Electron)** — new `note-menu-actions.e2e.ts`, side-effect-free
+  items only (never actually spawn Finder/Explorer on CI):
+  - open menu → all 8 items visible
+  - Find → find bar opens
+  - Copy path → clipboard holds vault-relative path
+  - Rename → title focused, editable
+  - Delete → confirm dialog → confirm → tab closes, note gone from list
+  - Reveal-in-Finder / Open-in-default-app: assert present + enabled only (IPC
+    stub / no click that launches the OS shell)
+
+## Out of scope
+
+Replace, Split view, Merge, Open-in-new-window, Bookmark (already present),
+Version History / Export / PDF (already present).

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -16,9 +16,23 @@
       "willSync": "Note will sync to cloud",
       "renameFailed": "Failed to rename note",
       "toggleLocalOnlyFailed": "Failed to toggle local only",
-      "toggleFullWidthFailed": "Failed to toggle full width"
+      "toggleFullWidthFailed": "Failed to toggle full width",
+      "pathCopied": "Path copied",
+      "copyPathFailed": "Failed to copy path",
+      "revealFailed": "Failed to reveal note",
+      "openExternalFailed": "Failed to open note",
+      "moved": "Note moved",
+      "moveFailed": "Failed to move note",
+      "deleteFailed": "Failed to delete note"
     },
-    "deleteDialogTitle": "{count, plural, one {Delete Note} other {Delete # Notes}}"
+    "deleteDialogTitle": "{count, plural, one {Delete Note} other {Delete # Notes}}",
+    "deleteConfirm": {
+      "title": "Delete note",
+      "description": "Are you sure you want to delete \"{title}\"? This action cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete",
+      "deleting": "Deleting..."
+    }
   },
   "tree": {
     "aria": {
@@ -80,12 +94,21 @@
       "addBookmark": "Add bookmark",
       "hideLocalGraph": "Hide local graph",
       "showLocalGraph": "Show local graph",
+      "moreActions": "More actions",
+      "find": "Find…",
       "versionHistory": "Version history",
       "export": "Export",
       "applyTemplate": "Apply Template",
       "fullWidth": "Full width",
+      "rename": "Rename…",
+      "moveToFolder": "Move to folder…",
+      "copyPath": "Copy path",
+      "revealInFinder": "Reveal in Finder",
+      "revealInSidebar": "Reveal in navigation",
+      "openInDefaultApp": "Open in default app",
       "disableLocalOnly": "Disable local only",
-      "setLocalOnly": "Set local only"
+      "setLocalOnly": "Set local only",
+      "delete": "Delete note"
     },
     "breadcrumb": {
       "locationAria": "Note location",


### PR DESCRIPTION
## Why

To delete a note you're viewing, you had to close its tab first, then delete it from the note list. The note-view **⋯ menu** exposed view/tools actions (Version History, Export, Full width…) but no file actions.

This brings the file actions the sidebar/list context menu already offers into the note-view menu.

## What

Adds **8 items** to the note-view `Picker` (`pages/note.tsx`), each with a hugeicon:

| Item | Icon | Wired to |
|---|---|---|
| Find… | `Search` | `findInPage.open()` (existing hook) |
| Rename… | `Pencil` | focus + select the inline title textarea |
| Move to folder… | `FolderInput` | existing `MoveToFolderDialog` + `moveNote` |
| Copy path | `Copy` | `note.path` (vault-relative) |
| Reveal in Finder | `FolderOpen` | `notesService.revealInFinder` |
| Reveal in navigation | `PanelLeft` | `reveal-in-sidebar` event |
| Open in default app | `ExternalLink` | `notesService.openExternal` |
| Delete note | `Trash2` (destructive) | confirm → `deleteNote` → close tab |

**Delete** opens a confirmation, deletes, then closes the note's tab (matches the sidebar delete flow and Obsidian's close-on-delete).

No backend, contract, or migration changes — everything wires to existing IPC/hooks already used by the list context menu.

## Cross-platform (macOS / Linux / Windows)

- Reveal / Open use `shell.showItemInFolder` / `shell.openPath` — cross-platform Electron APIs already shipping in the sidebar menu.
- Copy path uses the vault-relative `note.path` (stored with `/`) — no OS path concat, no drive-letter pitfalls.
- Find, Rename, Move, Reveal-in-nav, Delete are pure renderer/IPC.

## Tests

- **Unit** (`note.test.tsx`): each action's wiring — Find opens, Copy path → clipboard, Reveal/Open → IPC (mocked, no OS launch), reveal-in-sidebar event, Move → dialog → `moveNote`, Delete → confirm → `deleteNote` + `closeTab`, and delete-failure path.
- **Unit** (`note-title.test.tsx`): the new `inputRef` forwards to the title textarea (rename focus mechanism).
- **E2E** (`note-menu-actions.e2e.ts`, 7 tests, all green): menu shows all items; Find opens the bar; Copy path toast; Rename focuses the title; Move opens the dialog; Delete confirms → removes note → closes tab. Reveal/Open OS items are asserted present + enabled but never clicked (no Finder/Explorer spawned on CI).

## Out of scope

Replace (Find is a read-only highlighter; a real find-and-replace engine is a separate spec), Split view, Merge, Open-in-new-window.

Spec: `docs/superpowers/specs/2026-07-17-note-view-menu-actions-design.md`
