### PR TITLE
fix(desktop): feature-flag writes during initial fetch no longer clobbered by stale read

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-feature-flags.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-feature-flags.test.ts
@@ -51,4 +51,59 @@ describe('useFeatureFlags', () => {
     act(() => settingsChangedListener?.({ key: 'features', value: { graph: false } }))
     expect(result.current.isEnabled('graph')).toBe(false)
   })
+
+  it('settings:changed during the initial fetch wins over the stale fetch result', async () => {
+    let resolveGet!: (value: unknown) => void
+    const settingsMock = window.api.settings as Record<string, unknown>
+    settingsMock.getFeaturesSettings = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useFeatureFlags())
+    act(() => settingsChangedListener?.({ key: 'features', value: { graph: false } }))
+    await act(async () => {
+      // stale snapshot read before the write: still has graph: true
+      resolveGet({
+        home: true,
+        inbox: false,
+        journal: true,
+        tasks: true,
+        calendar: true,
+        graph: true
+      })
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isEnabled('graph')).toBe(false)
+  })
+
+  it('setFlag during the initial fetch wins over the stale fetch result', async () => {
+    let resolveGet!: (value: unknown) => void
+    const settingsMock = window.api.settings as Record<string, unknown>
+    settingsMock.getFeaturesSettings = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useFeatureFlags())
+    await act(async () => {
+      await result.current.setFlag('tasks', false)
+    })
+    await act(async () => {
+      resolveGet({
+        home: true,
+        inbox: false,
+        journal: true,
+        tasks: true,
+        calendar: true,
+        graph: true
+      })
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isEnabled('tasks')).toBe(false)
+  })
 })

--- a/apps/desktop/src/renderer/src/hooks/use-feature-flags.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-feature-flags.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import {
   FEATURES_SETTINGS_DEFAULTS,
@@ -18,13 +18,16 @@ export function useFeatureFlags(): UseFeatureFlagsReturn {
   const [flags, setFlags] = useState<FeaturesSettings>(FEATURES_SETTINGS_DEFAULTS)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Writes that land while the initial fetch is in flight; the fetch result is a
+  // snapshot read before those writes, so they must win over it.
+  const overridesRef = useRef<Partial<FeaturesSettings>>({})
 
   useEffect(() => {
     let mounted = true
     const load = async (): Promise<void> => {
       try {
         const result = await window.api.settings.getFeaturesSettings()
-        if (mounted) setFlags(result)
+        if (mounted) setFlags({ ...result, ...overridesRef.current })
       } catch (err) {
         if (mounted) setError(extractErrorMessage(err))
       } finally {
@@ -40,7 +43,9 @@ export function useFeatureFlags(): UseFeatureFlagsReturn {
   useEffect(() => {
     const unsubscribe = window.api.onSettingsChanged((event) => {
       if (event.key === 'features') {
-        setFlags((prev) => ({ ...prev, ...(event.value as Partial<FeaturesSettings>) }))
+        const value = event.value as Partial<FeaturesSettings>
+        overridesRef.current = { ...overridesRef.current, ...value }
+        setFlags((prev) => ({ ...prev, ...value }))
       }
     })
     return unsubscribe
@@ -51,6 +56,7 @@ export function useFeatureFlags(): UseFeatureFlagsReturn {
     try {
       const result = await window.api.settings.setFeaturesSettings(updates)
       if (result.success) {
+        overridesRef.current = { ...overridesRef.current, ...updates }
         setFlags((prev) => ({ ...prev, ...updates }))
         return true
       }


### PR DESCRIPTION
## Problem

`useFeatureFlags` dispatches `getFeaturesSettings()` on mount and unconditionally `setFlags(result)` when it resolves. Any write landing while that GET is in flight — a `settings:changed` event for the `features` key, or the hook's own `setFlag` optimistic update — merges into state first, then gets clobbered by the stale snapshot (read before the write). The flag flips on and silently reverts.

Observed in Playwright e2e: first-run-tour dismissal remounts the sidebar, and a flag write races the remounted hook's fetch. Affects every feature-flag toggle (home/inbox/journal/tasks/calendar/graph), not just new flags.

## Fix

Keep `overridesRef` accumulating writes from both paths (`settings:changed` handler and `setFlag`'s success branch) and apply the initial fetch as `setFlags({ ...result, ...overridesRef.current })`, so anything written during the flight wins over the snapshot.

## Tests

Two new unit tests in `use-feature-flags.test.ts` with a deferred GET mock:
- `settings:changed` during the initial fetch wins over the stale fetch result
- `setFlag` during the initial fetch wins over the stale fetch result

Both failed before the fix (flag reverted to the stale value) and pass after. Full file 5/5 green; `typecheck:web` and ESLint clean. Docs gate: `docs:ai-update` verdict — internal race fix, no documentable surface, no docs edits needed.