### PR TITLE
fix(desktop): open vault before projection reconcile so the app initializes

### DIFF
--- a/apps/desktop/src/main/projections/projectors/embedding-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.ts
@@ -94,13 +94,10 @@ export function createEmbeddingProjector(getVaultPath: () => string | null): Pro
       return { success: false, computed: 0, skipped: 0, error: 'No vault is open' }
     }
 
-    if (!isModelLoaded()) {
-      const loaded = await initEmbeddingModel()
-      if (!loaded) {
-        return { success: false, computed: 0, skipped: 0, error: 'Failed to load embedding model' }
-      }
-    }
-
+    // Query the work list BEFORE loading the model. initEmbeddingModel() loads a
+    // heavy native model (seconds), so an empty/markdown-less vault must not pay
+    // that cost just to find nothing to embed — which is exactly the fresh-vault
+    // case on every app open until the first note exists (and every E2E launch).
     const indexDb = getIndexDatabase()
     const rawDb = getRawIndexDatabase()
     const notes = indexDb.all<{
@@ -113,6 +110,19 @@ export function createEmbeddingProjector(getVaultPath: () => string | null): Pro
       FROM note_cache
       WHERE COALESCE(file_type, 'markdown') = 'markdown'
     `)
+
+    if (notes.length === 0) {
+      rawDb.prepare('DELETE FROM vec_notes').run()
+      emitProgress(0, 0, 'complete')
+      return { success: true, computed: 0, skipped: 0 }
+    }
+
+    if (!isModelLoaded()) {
+      const loaded = await initEmbeddingModel()
+      if (!loaded) {
+        return { success: false, computed: 0, skipped: 0, error: 'Failed to load embedding model' }
+      }
+    }
 
     rawDb.prepare('DELETE FROM vec_notes').run()
     emitProgress(0, notes.length, 'embedding')

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -327,8 +327,6 @@ async function openVault(vaultPath: string): Promise<void> {
 
   updateStatus({ isIndexing: false, indexProgress: 100 })
 
-  await reconcileProjections()
-
   // Start file watcher for external changes
   await startWatcher(vaultPath)
 
@@ -336,10 +334,21 @@ async function openVault(vaultPath: string): Promise<void> {
   // the engine's first fullSync, and on a freshly provisioned (downloaded or
   // linked) vault that pull writes notes/journals to disk via the current vault
   // path — which throws "No vault is currently open" if the status isn't set yet.
+  //
+  // Vault-open must NOT wait on reconcileProjections(): the renderer only needs
+  // the index (built above) to render, but the embedding projector's reconcile
+  // loads the embedding model / backfills vectors, which takes ~18s on the first
+  // open after an embedding-version change — and on every fresh vault, since the
+  // stored version starts null. Blocking here stranded the app on the vault
+  // picker for that whole time. Reconcile in the background after opening.
   updateStatus({
     isOpen: true,
     path: vaultPath,
     error: null
+  })
+
+  void reconcileProjections().catch((error) => {
+    logger.error('Background projection reconcile failed:', error)
   })
 
   // Register the agent IPC handlers before the sync runtime starts: agent chat

--- a/apps/desktop/tests/e2e/utils/electron-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/electron-helpers.ts
@@ -127,24 +127,26 @@ export async function waitForAppReady(page: Page, timeout = 30000): Promise<void
 }
 
 /**
- * Wait for vault to be fully indexed and ready
+ * Wait for the vault to be open and ready.
+ *
+ * The vault opens asynchronously in the main process (autoOpenLastVault →
+ * openVault → indexVault) and the renderer only leaves the VaultOnboarding
+ * screen once vault status flips to isOpen: true. That can take tens of seconds
+ * under CPU load. Poll the authoritative main-process status via IPC rather than
+ * guessing from DOM selectors — the old sidebar probe swallowed its own timeout
+ * and returned while the app was still on the onboarding screen, so tests
+ * proceeded against a closed vault and then failed downstream (e.g. a note-open
+ * event dispatched into a renderer with no listener mounted yet).
  */
-export async function waitForVaultReady(page: Page, timeout = 15000): Promise<void> {
-  // Try multiple selectors to detect when app is ready
-  // The app may show sidebar, or may still be on onboarding
-  try {
-    // Wait for either sidebar or main content area to be visible
-    await page.locator('[data-testid="sidebar"], aside, [class*="sidebar"], nav').first().waitFor({
-      state: 'visible',
-      timeout
-    })
-  } catch {
-    // If sidebar not found, just wait for DOM to stabilize
-    await page.waitForTimeout(2000)
-  }
-
-  // Wait for initial indexing to complete
-  await page.waitForTimeout(1000)
+export async function waitForVaultReady(page: Page, timeout = 45000): Promise<void> {
+  await page.waitForFunction(
+    async () => {
+      const status = await window.api.vault.getStatus()
+      return status?.isOpen === true
+    },
+    undefined,
+    { timeout, polling: 250 }
+  )
 
   await dismissFirstRunOnboarding(page)
 }

--- a/apps/desktop/tests/e2e/utils/note-sync-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/note-sync-helpers.ts
@@ -89,12 +89,25 @@ async function openNoteInUi(page: Page, note: NoteHandle): Promise<void> {
     .poll(() => findNoteHandle(page, note.id, note.title), { timeout: NOTE_LIST_POLL_TIMEOUT_MS })
     .not.toBeNull()
 
-  await page.evaluate((detail) => {
-    window.dispatchEvent(new CustomEvent('memry:test-open-note', { detail }))
-  }, note)
-
+  // findNoteHandle succeeds via pure IPC, so the note can exist before the
+  // renderer has mounted the 'memry:test-open-note' listener: that listener
+  // lives in AppContent, which only mounts once the vault is open. A CustomEvent
+  // has no queue, so a single dispatch that lands before the listener mounts (or
+  // is clobbered by a late RESTORE_SESSION) is lost silently and the tab never
+  // opens. Re-dispatch until the tab renders. OPEN_TAB dedupes by entityId, so
+  // repeated dispatches are safe — they just focus the already-open tab.
   const tab = page.locator(SELECTORS.tab).filter({ hasText: note.title }).first()
-  await expect(tab).toBeVisible({ timeout: NOTE_OPEN_TIMEOUT_MS })
+  await expect
+    .poll(
+      async () => {
+        await page.evaluate((detail) => {
+          window.dispatchEvent(new CustomEvent('memry:test-open-note', { detail }))
+        }, note)
+        return tab.isVisible().catch(() => false)
+      },
+      { timeout: NOTE_OPEN_TIMEOUT_MS, intervals: [500, 1_000, 2_000] }
+    )
+    .toBe(true)
   await tab.click()
 
   const titleInput = page.locator(SELECTORS.noteTitle).first()


### PR DESCRIPTION
## What
- `vault/index.ts`: set vault status `isOpen` right after the file watcher starts, then run `reconcileProjections()` in the background. The UI only needs the index (already built by `indexVault`), not reconciliation.
- `embedding-projector.ts`: query the note list before loading the embedding model; skip the model load entirely when there is nothing to embed.
- e2e helpers: `waitForVaultReady` polls authoritative vault status instead of a lenient sidebar probe; `openNoteInUi` re-dispatches the open event until the tab appears.

## Why
`openVault()` awaited `reconcileProjections()` before flipping `isOpen`, and the embedding projector loaded a native model (~18s) even on empty vaults (it loaded the model before checking for notes). Every fresh vault — and every E2E launch — stranded the renderer on the vault picker for that time. Verified: editor-undo x4 repeat (12 runs) green; note tests 27-49s -> 13-15s.