### PR TITLE
Spatial canvas M2 — item cards, capture-first, redirect (local-only)

### DIFF
--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
+import { CANVAS_ITEM_DRAG_MIME, canvasDragPayload } from '@/pages/canvas/canvas-cards'
 import { useTabActions } from '@/contexts/tabs'
 import type { NoteListItem } from '@/hooks/use-notes-query'
 import {
@@ -932,6 +933,9 @@ export function VirtualizedNotesTree({
         if (fileType !== 'markdown') {
           e.dataTransfer.setData(MEMRY_NOTE_DRAG_MIME, itemId)
         }
+        // Every non-folder item is a note entity — tag it so the spatial canvas
+        // can create a referencing card on drop (markdown notes set no other MIME).
+        e.dataTransfer.setData(CANVAS_ITEM_DRAG_MIME, canvasDragPayload('note', itemId))
       }
       setDragState((prev) => ({ ...prev, draggedId: itemId }))
     },

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.test.tsx
@@ -1,0 +1,220 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useRef } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CanvasCardLayer } from './canvas-card-overlay'
+import { CANVAS_ITEM_DRAG_MIME, type CardElement } from './canvas-cards'
+import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
+
+// Stub the Excalidraw runtime imports so the overlay mounts in jsdom without
+// pulling the real (canvas-dependent) library.
+vi.mock('@excalidraw/excalidraw', () => ({
+  convertToExcalidrawElements: (skeletons: unknown[]) =>
+    skeletons.map((s, i) => ({ ...(s as object), id: `new-${i}` })),
+  viewportCoordsToSceneCoords: ({ clientX, clientY }: { clientX: number; clientY: number }) => ({
+    x: clientX,
+    y: clientY
+  }),
+  CaptureUpdateAction: { IMMEDIATELY: 'immediately' }
+}))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key.split('.').at(-1) ?? key })
+}))
+vi.mock('react-i18next', () => ({ getI18n: () => ({ getFixedT: () => (k: string) => k }) }))
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
+
+const mocks = vi.hoisted(() => ({
+  openTab: vi.fn(),
+  notesCreate: vi.fn(),
+  entities: new Map<string, unknown>()
+}))
+
+vi.mock('@/contexts/tabs', () => ({ useTabActions: () => ({ openTab: mocks.openTab }) }))
+vi.mock('@/services/notes-service', () => ({
+  notesService: { create: (input: unknown) => mocks.notesCreate(input) }
+}))
+vi.mock('./use-canvas-entities', async () => {
+  const actual =
+    await vi.importActual<typeof import('./use-canvas-entities')>('./use-canvas-entities')
+  return { entityKey: actual.entityKey, useCanvasEntities: () => mocks.entities }
+})
+// Keep the card lightweight; its own test covers rendering.
+vi.mock('./canvas-card', () => ({
+  CanvasCard: ({
+    cardRef,
+    onRedirect
+  }: {
+    cardRef: { elementId: string; entityType: string; entityId: string }
+    onRedirect: (c: unknown) => void
+  }) => (
+    <button data-testid={`card-${cardRef.elementId}`} onClick={() => onRedirect(cardRef)}>
+      {cardRef.entityId}
+    </button>
+  )
+}))
+
+function cardEl(id: string, entityId: string, x = 0, y = 0): CardElement {
+  return {
+    id,
+    type: 'rectangle',
+    x,
+    y,
+    width: 260,
+    height: 168,
+    angle: 0,
+    customData: { entityType: 'note', entityId }
+  }
+}
+
+function makeApi(elements: CardElement[]): {
+  api: ExcalidrawImperativeAPI
+  fire: () => void
+  updateScene: ReturnType<typeof vi.fn>
+} {
+  let onChangeCb: (() => void) | null = null
+  const updateScene = vi.fn()
+  const api = {
+    getSceneElements: () => elements,
+    getSceneElementsIncludingDeleted: () => elements,
+    getAppState: () => ({
+      scrollX: 0,
+      scrollY: 0,
+      zoom: { value: 1 },
+      offsetLeft: 0,
+      offsetTop: 0
+    }),
+    getFiles: () => ({}),
+    updateScene,
+    refresh: vi.fn(),
+    onChange: (cb: () => void) => {
+      onChangeCb = cb
+      return () => {}
+    }
+  } as unknown as ExcalidrawImperativeAPI
+  return { api, fire: () => onChangeCb?.(), updateScene }
+}
+
+function Harness({
+  api,
+  onSceneMutated = vi.fn()
+}: {
+  api: ExcalidrawImperativeAPI
+  onSceneMutated?: () => void
+}) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  return (
+    <div ref={wrapperRef} data-testid="wrapper">
+      <CanvasCardLayer
+        excalidrawAPI={api}
+        wrapperRef={wrapperRef}
+        onSceneMutated={onSceneMutated}
+      />
+    </div>
+  )
+}
+
+describe('CanvasCardLayer', () => {
+  beforeEach(() => {
+    mocks.openTab.mockReset()
+    mocks.notesCreate.mockReset()
+    mocks.entities = new Map()
+  })
+
+  it('renders a card for each visible card element', async () => {
+    const { api } = makeApi([cardEl('e1', 'n1'), cardEl('e2', 'n2')])
+    render(<Harness api={api} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('card-e1')).toBeInTheDocument()
+      expect(screen.getByTestId('card-e2')).toBeInTheDocument()
+    })
+  })
+
+  it('creates a referencing card element on a canvas-item drop', async () => {
+    const { api, updateScene } = makeApi([])
+    const onSceneMutated = vi.fn()
+    render(<Harness api={api} onSceneMutated={onSceneMutated} />)
+
+    const wrapper = screen.getByTestId('wrapper')
+    const drop = new Event('drop', { bubbles: true, cancelable: true })
+    Object.defineProperty(drop, 'dataTransfer', {
+      value: {
+        types: [CANVAS_ITEM_DRAG_MIME],
+        getData: (t: string) =>
+          t === CANVAS_ITEM_DRAG_MIME
+            ? JSON.stringify({ entityType: 'note', entityId: 'dropped' })
+            : ''
+      }
+    })
+    Object.defineProperty(drop, 'clientX', { value: 120 })
+    Object.defineProperty(drop, 'clientY', { value: 80 })
+    wrapper.dispatchEvent(drop)
+
+    await waitFor(() => expect(updateScene).toHaveBeenCalled())
+    const passed = updateScene.mock.calls[0][0]
+    expect(passed.captureUpdate).toBe('immediately')
+    expect(
+      passed.elements.some(
+        (e: { customData?: { entityId?: string } }) => e.customData?.entityId === 'dropped'
+      )
+    ).toBe(true)
+    expect(onSceneMutated).toHaveBeenCalled()
+  })
+
+  it('ignores drops without the canvas MIME', async () => {
+    const { api, updateScene } = makeApi([])
+    render(<Harness api={api} />)
+    const wrapper = screen.getByTestId('wrapper')
+    const drop = new Event('drop', { bubbles: true, cancelable: true })
+    Object.defineProperty(drop, 'dataTransfer', {
+      value: { types: ['text/plain'], getData: () => '' }
+    })
+    wrapper.dispatchEvent(drop)
+    // No card created.
+    expect(updateScene).not.toHaveBeenCalled()
+  })
+
+  it('opens a tab when a card requests redirect', async () => {
+    mocks.entities = new Map([['note:n1', { status: 'ready', kind: 'note', title: 'Note One' }]])
+    const { api } = makeApi([cardEl('e1', 'n1')])
+    render(<Harness api={api} />)
+    fireEvent.click(await screen.findByTestId('card-e1'))
+    expect(mocks.openTab).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'note', entityId: 'n1', title: 'Note One' })
+    )
+  })
+
+  it('capture-first: creates a note then a card element', async () => {
+    mocks.notesCreate.mockResolvedValue({ success: true, note: { id: 'captured' } })
+    const { api, updateScene } = makeApi([])
+    render(<Harness api={api} />)
+
+    fireEvent.click(screen.getByTestId('canvas-new-note'))
+    await waitFor(() => expect(mocks.notesCreate).toHaveBeenCalled())
+    await waitFor(() => expect(updateScene).toHaveBeenCalled())
+    const passed = updateScene.mock.calls[0][0]
+    expect(
+      passed.elements.some(
+        (e: { customData?: { entityId?: string } }) => e.customData?.entityId === 'captured'
+      )
+    ).toBe(true)
+  })
+
+  it('redirects on a dblclick that hits a card', async () => {
+    mocks.entities = new Map([['note:n1', { status: 'ready', kind: 'note', title: 'Hit' }]])
+    const { api, fire } = makeApi([cardEl('e1', 'n1', 100, 100)])
+    render(<Harness api={api} />)
+    fire()
+    const wrapper = screen.getByTestId('wrapper')
+    const dbl = new MouseEvent('dblclick', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 150,
+      clientY: 150
+    })
+    wrapper.dispatchEvent(dbl)
+    await waitFor(() =>
+      expect(mocks.openTab).toHaveBeenCalledWith(expect.objectContaining({ entityId: 'n1' }))
+    )
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
@@ -1,0 +1,343 @@
+/**
+ * CanvasCardLayer — the DOM overlay that renders read-only preview cards over
+ * the Excalidraw scene and owns all card behavior (drop-to-create, capture a
+ * new note, ↗ redirect, dblclick redirect).
+ *
+ * Perf model (M2): the layer transform is applied IMPERATIVELY on every
+ * onChange (zero setState during pan); only a change in the set OR geometry of
+ * visible cards triggers a React render, and only cards inside a padded
+ * viewport are mounted (virtualization with hysteresis).
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  convertToExcalidrawElements,
+  viewportCoordsToSceneCoords,
+  CaptureUpdateAction
+} from '@excalidraw/excalidraw'
+import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
+import { toast } from 'sonner'
+import { getI18n } from 'react-i18next'
+import { Plus } from '@/lib/icons'
+import { useTabActions } from '@/contexts/tabs'
+import { notesService } from '@/services/notes-service'
+import { createLogger } from '@/lib/logger'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { useT } from '@memry/i18n/renderer'
+import { CanvasCard } from './canvas-card'
+import { useCanvasEntities, entityKey } from './use-canvas-entities'
+import {
+  computeVisibleCardIds,
+  getCardRefs,
+  makeCardSkeleton,
+  overlayTransform,
+  readCanvasDragItem,
+  sameMembership,
+  viewportSceneRect,
+  CANVAS_ITEM_DRAG_MIME,
+  type CanvasAppStateView,
+  type CanvasCardRef,
+  type CardElement
+} from './canvas-cards'
+import { buildRedirectTab } from './canvas-redirect'
+
+const log = createLogger('SpatialCanvas')
+
+const ENTER_PADDING = 200
+const EXIT_PADDING = 500
+
+interface CanvasCardLayerProps {
+  excalidrawAPI: ExcalidrawImperativeAPI
+  /** Wrapper element hosting the canvas — capture-phase drop/dblclick attach here. */
+  wrapperRef: React.RefObject<HTMLDivElement | null>
+  /** Notifies the scene persister after a card is created. */
+  onSceneMutated: () => void
+}
+
+export const CanvasCardLayer = ({
+  excalidrawAPI,
+  wrapperRef,
+  onSceneMutated
+}: CanvasCardLayerProps): React.JSX.Element => {
+  const { t } = useT('common')
+  const { openTab } = useTabActions()
+  const layerRef = useRef<HTMLDivElement>(null)
+  const clipRef = useRef<HTMLDivElement>(null)
+
+  const [visibleRefs, setVisibleRefs] = useState<CanvasCardRef[]>([])
+  const visibleIdsRef = useRef<Set<string>>(new Set())
+  const signatureRef = useRef('')
+
+  const entities = useCanvasEntities(visibleRefs)
+  // Keep entity state reachable from imperative handlers (dblclick redirect).
+  const entitiesRef = useRef(entities)
+  useEffect(() => {
+    entitiesRef.current = entities
+  }, [entities])
+
+  const readScene = useCallback((): {
+    cards: CanvasCardRef[]
+    appState: CanvasAppStateView & { offsetLeft: number; offsetTop: number }
+  } => {
+    const elements = excalidrawAPI.getSceneElements() as unknown as CardElement[]
+    const appState = excalidrawAPI.getAppState() as unknown as CanvasAppStateView & {
+      offsetLeft: number
+      offsetTop: number
+    }
+    return { cards: getCardRefs(elements), appState }
+  }, [excalidrawAPI])
+
+  const recompute = useCallback(() => {
+    const { cards, appState } = readScene()
+    const clip = clipRef.current
+    const layer = layerRef.current
+    if (!clip || !layer) {
+      return
+    }
+    // Transform is imperative: no React render during pan/zoom.
+    layer.style.transform = overlayTransform(appState)
+    clip.dataset.scrollX = String(appState.scrollX)
+    clip.dataset.scrollY = String(appState.scrollY)
+    clip.dataset.zoom = String(appState.zoom.value)
+
+    const rect = viewportSceneRect(appState, {
+      width: clip.clientWidth,
+      height: clip.clientHeight
+    })
+    const nextIds = computeVisibleCardIds(cards, rect, {
+      enterPadding: ENTER_PADDING,
+      exitPadding: EXIT_PADDING,
+      previousVisible: visibleIdsRef.current
+    })
+    const visible = cards.filter((card) => nextIds.has(card.elementId))
+    // Re-render on membership OR geometry change (a moved card), never on pan.
+    const signature = visible
+      .map(
+        (c) =>
+          `${c.elementId}:${Math.round(c.x)}:${Math.round(c.y)}:${Math.round(c.width)}:${Math.round(c.height)}:${c.angle.toFixed(3)}`
+      )
+      .join('|')
+    const membershipChanged = !sameMembership(nextIds, visibleIdsRef.current)
+    visibleIdsRef.current = nextIds
+    if (membershipChanged || signature !== signatureRef.current) {
+      signatureRef.current = signature
+      setVisibleRefs(visible)
+    }
+  }, [readScene])
+
+  useEffect(() => {
+    recompute()
+    const unsubscribe = excalidrawAPI.onChange(() => recompute())
+    return unsubscribe
+  }, [excalidrawAPI, recompute])
+
+  // Container resize changes the viewport → recompute membership + let
+  // Excalidraw recalc its canvas offsets so coordinate math stays correct.
+  useEffect(() => {
+    const clip = clipRef.current
+    if (!clip || typeof ResizeObserver === 'undefined') {
+      return
+    }
+    const observer = new ResizeObserver(() => {
+      excalidrawAPI.refresh()
+      recompute()
+    })
+    observer.observe(clip)
+    return () => observer.disconnect()
+  }, [excalidrawAPI, recompute])
+
+  const redirect = useCallback(
+    (card: CanvasCardRef): void => {
+      const state = entitiesRef.current.get(entityKey(card.entityType, card.entityId))
+      const tab = buildRedirectTab({
+        entityType: card.entityType,
+        entityId: card.entityId,
+        title: state?.status === 'ready' && state.kind === 'note' ? state.title : '',
+        startAt:
+          state?.status === 'ready' && state.kind === 'calendar_event' ? state.startAt : null,
+        now: Date.now()
+      })
+      if (tab) {
+        openTab(tab)
+      }
+    },
+    [openTab]
+  )
+
+  const createCardElement = useCallback(
+    (
+      entityType: CanvasCardRef['entityType'],
+      entityId: string,
+      centerX: number,
+      centerY: number
+    ): void => {
+      const skeleton = makeCardSkeleton({ entityType, entityId, centerX, centerY })
+      const created = convertToExcalidrawElements([skeleton] as unknown as Parameters<
+        typeof convertToExcalidrawElements
+      >[0])
+      const existing = excalidrawAPI.getSceneElementsIncludingDeleted()
+      excalidrawAPI.updateScene({
+        elements: [...existing, ...created],
+        captureUpdate: CaptureUpdateAction.IMMEDIATELY
+      })
+      onSceneMutated()
+      recompute()
+    },
+    [excalidrawAPI, onSceneMutated, recompute]
+  )
+
+  // Capture-phase drop/dragover/dblclick on the wrapper so they run before
+  // Excalidraw's own handlers (mirrors the note editor's capture listeners).
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    if (!wrapper) {
+      return
+    }
+
+    const onDragOver = (e: DragEvent): void => {
+      if (e.dataTransfer?.types.includes(CANVAS_ITEM_DRAG_MIME)) {
+        e.preventDefault()
+        e.stopPropagation()
+        e.dataTransfer.dropEffect = 'copy'
+      }
+    }
+
+    const onDrop = (e: DragEvent): void => {
+      if (!e.dataTransfer) {
+        return
+      }
+      const item = readCanvasDragItem((type) => e.dataTransfer!.getData(type))
+      if (!item) {
+        return
+      }
+      e.preventDefault()
+      e.stopPropagation()
+      const appState = excalidrawAPI.getAppState()
+      const scene = viewportCoordsToSceneCoords(
+        { clientX: e.clientX, clientY: e.clientY },
+        appState
+      )
+      createCardElement(item.entityType, item.entityId, scene.x, scene.y)
+    }
+
+    const onDblClick = (e: MouseEvent): void => {
+      const appState = excalidrawAPI.getAppState()
+      const scene = viewportCoordsToSceneCoords(
+        { clientX: e.clientX, clientY: e.clientY },
+        appState
+      )
+      const cards = getCardRefs(excalidrawAPI.getSceneElements() as unknown as CardElement[])
+      // Reverse z-order: last element is topmost.
+      for (let i = cards.length - 1; i >= 0; i--) {
+        const card = cards[i]
+        if (
+          scene.x >= card.x &&
+          scene.x <= card.x + card.width &&
+          scene.y >= card.y &&
+          scene.y <= card.y + card.height
+        ) {
+          e.preventDefault()
+          e.stopPropagation()
+          redirect(card)
+          return
+        }
+      }
+    }
+
+    wrapper.addEventListener('dragover', onDragOver, { capture: true })
+    wrapper.addEventListener('drop', onDrop, { capture: true })
+    wrapper.addEventListener('dblclick', onDblClick, { capture: true })
+    return () => {
+      wrapper.removeEventListener('dragover', onDragOver, { capture: true })
+      wrapper.removeEventListener('drop', onDrop, { capture: true })
+      wrapper.removeEventListener('dblclick', onDblClick, { capture: true })
+    }
+  }, [wrapperRef, excalidrawAPI, createCardElement, redirect])
+
+  const handleCreateNote = useCallback(async () => {
+    try {
+      const result = await notesService.create({ title: 'Untitled Note', content: '' })
+      if (!result.success || !result.note) {
+        throw new Error(result.error ?? 'note create failed')
+      }
+      const { appState } = readScene()
+      const rect = viewportSceneRect(appState, {
+        width: clipRef.current?.clientWidth ?? 0,
+        height: clipRef.current?.clientHeight ?? 0
+      })
+      createCardElement(
+        'note',
+        result.note.id,
+        (rect.minX + rect.maxX) / 2,
+        (rect.minY + rect.maxY) / 2
+      )
+    } catch (err) {
+      log.error('Failed to create canvas note', err)
+      toast.error(
+        extractErrorMessage(
+          err,
+          getI18n().getFixedT(null, 'common')('canvas.card.createNoteFailed')
+        )
+      )
+    }
+  }, [readScene, createCardElement])
+
+  const cards = useMemo(
+    () =>
+      visibleRefs.map((card) => (
+        <div
+          key={card.elementId}
+          className="absolute"
+          style={{
+            left: card.x,
+            top: card.y,
+            width: card.width,
+            height: card.height,
+            transform: card.angle ? `rotate(${card.angle}rad)` : undefined,
+            transformOrigin: 'center'
+          }}
+        >
+          <CanvasCard
+            cardRef={card}
+            state={entities.get(entityKey(card.entityType, card.entityId))}
+            onRedirect={redirect}
+          />
+        </div>
+      )),
+    [visibleRefs, entities, redirect]
+  )
+
+  return (
+    <>
+      {/* z-[3] lifts the overlay above Excalidraw's interactive canvas
+          (--zIndex-interactiveCanvas: 2) so card previews cover their
+          rectangles and the ↗ buttons are clickable. .excalidraw has no
+          z-index, so its canvases share this stacking context. The layer is
+          pointer-events:none, so pan/draw still pass through to the canvas;
+          Excalidraw's toolbar/panels (z-index 4+) stay above the overlay. */}
+      <div ref={clipRef} className="pointer-events-none absolute inset-0 z-[3] overflow-hidden">
+        {/* Positioned at the scene origin (0,0) with transform-origin 0 0 —
+            coordinate space, RTL-invariant, so inline (not logical classes). */}
+        <div
+          ref={layerRef}
+          data-canvas-overlay=""
+          className="absolute will-change-transform"
+          style={{ left: 0, top: 0, transformOrigin: '0 0' }}
+        >
+          {cards}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => void handleCreateNote()}
+        data-testid="canvas-new-note"
+        // Horizontally centered (symmetric in RTL) via inline left/translate.
+        style={{ left: '50%', transform: 'translateX(-50%)' }}
+        className="pointer-events-auto absolute bottom-4 z-10 flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium text-text-secondary shadow-sm transition-colors hover:bg-muted hover:text-foreground"
+      >
+        <Plus className="size-3.5" aria-hidden="true" />
+        {t('canvas.card.newNote')}
+      </button>
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { CanvasCard } from './canvas-card'
+import type { CanvasCardRef } from './canvas-cards'
+import type { CanvasEntityState } from './use-canvas-entities'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key.split('.').at(-1) ?? key })
+}))
+
+// Render the note body as its raw text so the card test doesn't depend on the
+// marked token walker's internals (covered by its own tests).
+vi.mock('@/components/tasks/task-description-preview', () => ({
+  renderTaskDescriptionMarkdown: (md: string) => [md]
+}))
+
+function ref(overrides: Partial<CanvasCardRef> = {}): CanvasCardRef {
+  return {
+    elementId: 'e1',
+    entityType: 'note',
+    entityId: 'n1',
+    x: 0,
+    y: 0,
+    width: 260,
+    height: 168,
+    angle: 0,
+    ...overrides
+  }
+}
+
+describe('CanvasCard', () => {
+  it('renders a note preview with title, body, and stamps entity attributes', () => {
+    const state: CanvasEntityState = {
+      status: 'ready',
+      kind: 'note',
+      title: 'My Note',
+      emoji: null,
+      body: 'the body text'
+    }
+    render(<CanvasCard cardRef={ref()} state={state} onRedirect={vi.fn()} />)
+
+    expect(screen.getByText('My Note')).toBeInTheDocument()
+    expect(screen.getByText('the body text')).toBeInTheDocument()
+    const root = document.querySelector('[data-canvas-card-id="e1"]')
+    expect(root?.getAttribute('data-canvas-card-entity')).toBe('note:n1')
+    expect(root?.getAttribute('data-canvas-card-state')).toBe('ready')
+  })
+
+  it('renders a completed task with a strike-through title and due date', () => {
+    const state: CanvasEntityState = {
+      status: 'ready',
+      kind: 'task',
+      title: 'Do it',
+      completed: true,
+      dueDate: '2026-07-20'
+    }
+    render(
+      <CanvasCard
+        cardRef={ref({ entityType: 'task', entityId: 't1' })}
+        state={state}
+        onRedirect={vi.fn()}
+      />
+    )
+    const title = screen.getByText('Do it')
+    expect(title.className).toContain('line-through')
+    // due date rendered (locale-formatted; assert the day number is present)
+    expect(screen.getByText(/20|Jul/)).toBeInTheDocument()
+  })
+
+  it('renders a calendar event with its time', () => {
+    const state: CanvasEntityState = {
+      status: 'ready',
+      kind: 'calendar_event',
+      title: 'Standup',
+      startAt: '2026-07-20T09:30:00.000Z',
+      endAt: null,
+      isAllDay: false
+    }
+    render(
+      <CanvasCard
+        cardRef={ref({ entityType: 'calendar_event', entityId: 'ev1' })}
+        state={state}
+        onRedirect={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Standup')).toBeInTheDocument()
+  })
+
+  it('renders a dangling state for deleted entities', () => {
+    render(<CanvasCard cardRef={ref()} state={{ status: 'dangling' }} onRedirect={vi.fn()} />)
+    expect(screen.getByText('deleted')).toBeInTheDocument()
+    expect(document.querySelector('[data-canvas-card-state="dangling"]')).not.toBeNull()
+  })
+
+  it('renders a loading state when the entity is not yet resolved', () => {
+    render(<CanvasCard cardRef={ref()} state={undefined} onRedirect={vi.fn()} />)
+    expect(screen.getByText('loading')).toBeInTheDocument()
+    expect(document.querySelector('[data-canvas-card-state="loading"]')).not.toBeNull()
+  })
+
+  it('fires onRedirect (and stops propagation) when the ↗ button is clicked', () => {
+    const onRedirect = vi.fn()
+    const cardRef = ref()
+    render(
+      <CanvasCard
+        cardRef={cardRef}
+        state={{ status: 'ready', kind: 'note', title: 'X', emoji: null, body: '' }}
+        onRedirect={onRedirect}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'open' }))
+    expect(onRedirect).toHaveBeenCalledWith(cardRef)
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card.tsx
@@ -1,0 +1,139 @@
+/**
+ * CanvasCard — read-only preview rendered over one card rectangle.
+ *
+ * The card body is pointer-events:none so canvas pan/draw/select passes through
+ * to the underlying Excalidraw rectangle (which owns geometry, resize, and
+ * arrow-binding). Only the ↗ redirect button is interactive. Idle previews are
+ * static markdown-rendered React (no editor mounted) per the M2 perf strategy.
+ */
+
+import React from 'react'
+import { ArrowUpRight, CheckCircle, Circle, CalendarClock, AlertTriangle } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { NoteIconDisplay } from '@/lib/render-note-icon'
+import { renderTaskDescriptionMarkdown } from '@/components/tasks/task-description-preview'
+import { useT } from '@memry/i18n/renderer'
+import type { CanvasCardRef } from './canvas-cards'
+import type { CanvasEntityState } from './use-canvas-entities'
+
+interface CanvasCardProps {
+  cardRef: CanvasCardRef
+  state: CanvasEntityState | undefined
+  onRedirect: (cardRef: CanvasCardRef) => void
+}
+
+function formatDueDate(dueDate: string | null): string | null {
+  if (!dueDate) return null
+  const parsed = new Date(`${dueDate}T00:00:00`)
+  if (Number.isNaN(parsed.getTime())) return dueDate
+  return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+function formatEventTime(startAt: string, isAllDay: boolean, allDayLabel: string): string {
+  const parsed = new Date(startAt)
+  if (Number.isNaN(parsed.getTime())) return startAt
+  const date = parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  if (isAllDay) return `${date} · ${allDayLabel}`
+  const time = parsed.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+  return `${date} · ${time}`
+}
+
+const CanvasCardInner = ({ cardRef, state, onRedirect }: CanvasCardProps): React.JSX.Element => {
+  const { t } = useT('common')
+
+  const handleRedirect = (e: React.MouseEvent): void => {
+    e.preventDefault()
+    e.stopPropagation()
+    onRedirect(cardRef)
+  }
+
+  const dangling = state?.status === 'dangling'
+
+  return (
+    <div
+      className={cn(
+        'group/card pointer-events-none relative flex h-full w-full flex-col overflow-hidden rounded-md border bg-white text-start shadow-sm dark:bg-zinc-900',
+        dangling ? 'border-dashed border-destructive/50' : 'border-border'
+      )}
+      data-canvas-card-id={cardRef.elementId}
+      data-canvas-card-entity={`${cardRef.entityType}:${cardRef.entityId}`}
+      data-canvas-card-state={state?.status ?? 'loading'}
+    >
+      {/* Redirect button — the one interactive region on an idle card. */}
+      <button
+        type="button"
+        onClick={handleRedirect}
+        onPointerDown={(e) => e.stopPropagation()}
+        className="pointer-events-auto absolute end-1.5 top-1.5 z-10 flex size-6 items-center justify-center rounded-md bg-background/70 text-text-secondary opacity-0 shadow-sm transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover/card:opacity-100"
+        aria-label={t('canvas.card.open')}
+      >
+        <ArrowUpRight className="size-3.5" aria-hidden="true" />
+      </button>
+
+      {dangling ? (
+        <div className="flex h-full flex-col items-center justify-center gap-1.5 p-3 text-center">
+          <AlertTriangle className="size-4 text-destructive/70" aria-hidden="true" />
+          <span className="text-xs text-text-tertiary">{t('canvas.card.deleted')}</span>
+        </div>
+      ) : state?.status === 'ready' && state.kind === 'note' ? (
+        <div className="flex h-full flex-col gap-1.5 p-3">
+          <div className="flex items-center gap-1.5">
+            {state.emoji ? (
+              <NoteIconDisplay
+                value={state.emoji}
+                className="flex size-4 shrink-0 items-center justify-center text-sm"
+              />
+            ) : null}
+            <h3 className="truncate text-[13px] font-semibold text-foreground">
+              {state.title || t('canvas.card.untitled')}
+            </h3>
+          </div>
+          <div className="min-h-0 flex-1 overflow-hidden text-[11px] leading-snug text-text-secondary">
+            <p className="line-clamp-6 whitespace-pre-wrap break-words">
+              {renderTaskDescriptionMarkdown(state.body)}
+            </p>
+          </div>
+        </div>
+      ) : state?.status === 'ready' && state.kind === 'task' ? (
+        <div className="flex h-full flex-col justify-center gap-1.5 p-3">
+          <div className="flex items-start gap-1.5">
+            {state.completed ? (
+              <CheckCircle className="mt-0.5 size-3.5 shrink-0 text-primary" aria-hidden="true" />
+            ) : (
+              <Circle className="mt-0.5 size-3.5 shrink-0 text-text-tertiary" aria-hidden="true" />
+            )}
+            <span
+              className={cn(
+                'text-[13px] font-medium',
+                state.completed ? 'text-text-tertiary line-through' : 'text-foreground'
+              )}
+            >
+              {state.title || t('canvas.card.untitled')}
+            </span>
+          </div>
+          {formatDueDate(state.dueDate) ? (
+            <span className="ms-5 text-[11px] text-text-tertiary">
+              {formatDueDate(state.dueDate)}
+            </span>
+          ) : null}
+        </div>
+      ) : state?.status === 'ready' && state.kind === 'calendar_event' ? (
+        <div className="flex h-full flex-col justify-center gap-1 p-3">
+          <span className="text-[13px] font-medium text-foreground">
+            {state.title || t('canvas.card.untitled')}
+          </span>
+          <span className="flex items-center gap-1 text-[11px] text-text-tertiary">
+            <CalendarClock className="size-3" aria-hidden="true" />
+            {formatEventTime(state.startAt, state.isAllDay, t('canvas.card.allDay'))}
+          </span>
+        </div>
+      ) : (
+        <div className="flex h-full items-center justify-center p-3">
+          <span className="text-xs text-text-tertiary">{t('canvas.card.loading')}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const CanvasCard = React.memo(CanvasCardInner)

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-cards.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-cards.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getCardRef,
+  getCardRefs,
+  extractEntityRefs,
+  overlayTransform,
+  viewportSceneRect,
+  computeVisibleCardIds,
+  sameMembership,
+  makeCardSkeleton,
+  readCanvasDragItem,
+  canvasDragPayload,
+  CANVAS_ITEM_DRAG_MIME,
+  type CardElement
+} from './canvas-cards'
+
+function rect(overrides: Partial<CardElement> = {}): CardElement {
+  return {
+    id: 'e1',
+    type: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    angle: 0,
+    customData: { entityType: 'note', entityId: 'n1' },
+    ...overrides
+  }
+}
+
+describe('getCardRef', () => {
+  it('resolves a rectangle with valid card customData', () => {
+    expect(getCardRef(rect())).toMatchObject({
+      elementId: 'e1',
+      entityType: 'note',
+      entityId: 'n1'
+    })
+  })
+
+  it('rejects non-rectangles, deleted, and missing/invalid customData', () => {
+    expect(getCardRef(rect({ type: 'freedraw' }))).toBeNull()
+    expect(getCardRef(rect({ isDeleted: true }))).toBeNull()
+    expect(getCardRef(rect({ customData: null }))).toBeNull()
+    expect(getCardRef(rect({ customData: { entityType: 'note' } }))).toBeNull()
+    expect(getCardRef(rect({ customData: { entityType: 'bogus', entityId: 'x' } }))).toBeNull()
+    expect(getCardRef(rect({ customData: { entityType: 'note', entityId: '' } }))).toBeNull()
+  })
+})
+
+describe('getCardRefs / extractEntityRefs', () => {
+  it('collects only live cards and dedupes entity refs', () => {
+    const elements: CardElement[] = [
+      rect({ id: 'a', customData: { entityType: 'note', entityId: 'n1' } }),
+      rect({ id: 'b', customData: { entityType: 'note', entityId: 'n1' } }), // dup entity
+      rect({ id: 'c', customData: { entityType: 'task', entityId: 't1' } }),
+      rect({ id: 'd', type: 'freedraw' }), // not a card
+      rect({ id: 'e', isDeleted: true, customData: { entityType: 'note', entityId: 'n9' } })
+    ]
+    expect(getCardRefs(elements).map((c) => c.elementId)).toEqual(['a', 'b', 'c'])
+    expect(extractEntityRefs(elements)).toEqual([
+      { entityType: 'note', entityId: 'n1' },
+      { entityType: 'task', entityId: 't1' }
+    ])
+  })
+})
+
+describe('overlayTransform', () => {
+  it('matches Excalidraw scene→viewport mapping (translate by scroll*zoom, scale by zoom)', () => {
+    expect(overlayTransform({ scrollX: 10, scrollY: -20, zoom: { value: 2 } })).toBe(
+      'translate(20px, -40px) scale(2)'
+    )
+  })
+})
+
+describe('viewportSceneRect', () => {
+  it('converts the pixel viewport into scene coordinates', () => {
+    const r = viewportSceneRect(
+      { scrollX: 100, scrollY: 50, zoom: { value: 2 } },
+      { width: 800, height: 600 }
+    )
+    expect(r).toEqual({ minX: -100, minY: -50, maxX: 800 / 2 - 100, maxY: 600 / 2 - 50 })
+  })
+})
+
+describe('computeVisibleCardIds (hysteresis)', () => {
+  const cards = getCardRefs([
+    rect({ id: 'in', x: 0, y: 0 }),
+    rect({ id: 'edge', x: 1100, y: 0 }),
+    rect({ id: 'far', x: 5000, y: 5000 })
+  ])
+  const viewport = { minX: 0, minY: 0, maxX: 800, maxY: 600 }
+
+  it('includes cards within enterPadding when not previously visible', () => {
+    const visible = computeVisibleCardIds(cards, viewport, {
+      enterPadding: 200,
+      exitPadding: 500,
+      previousVisible: new Set()
+    })
+    expect(visible.has('in')).toBe(true)
+    expect(visible.has('edge')).toBe(false) // left edge 1100 > 800 + 200 enter
+    expect(visible.has('far')).toBe(false)
+  })
+
+  it('keeps a previously-visible edge card until it exits the wider exit band', () => {
+    const visible = computeVisibleCardIds(cards, viewport, {
+      enterPadding: 200,
+      exitPadding: 500,
+      previousVisible: new Set(['edge'])
+    })
+    expect(visible.has('edge')).toBe(true) // 1100 <= 800 + 500 exit
+  })
+})
+
+describe('sameMembership', () => {
+  it('compares set membership', () => {
+    expect(sameMembership(new Set(['a', 'b']), new Set(['b', 'a']))).toBe(true)
+    expect(sameMembership(new Set(['a']), new Set(['a', 'b']))).toBe(false)
+    expect(sameMembership(new Set(['a']), new Set(['b']))).toBe(false)
+  })
+})
+
+describe('makeCardSkeleton', () => {
+  it('centers a clean rectangle on the drop point and carries customData', () => {
+    const skeleton = makeCardSkeleton({
+      entityType: 'note',
+      entityId: 'n1',
+      centerX: 100,
+      centerY: 100
+    })
+    expect(skeleton.type).toBe('rectangle')
+    expect(skeleton.roughness).toBe(0)
+    expect(skeleton.customData).toEqual({ entityType: 'note', entityId: 'n1' })
+    // centered: x = center - width/2
+    expect(skeleton.x).toBe(100 - skeleton.width / 2)
+    expect(skeleton.y).toBe(100 - skeleton.height / 2)
+  })
+})
+
+describe('readCanvasDragItem / canvasDragPayload', () => {
+  it('round-trips a valid payload', () => {
+    const payload = canvasDragPayload('task', 't1')
+    const getData = (type: string): string => (type === CANVAS_ITEM_DRAG_MIME ? payload : '')
+    expect(readCanvasDragItem(getData)).toEqual({ entityType: 'task', entityId: 't1' })
+  })
+
+  it('returns null for missing MIME, bad JSON, or invalid content', () => {
+    expect(readCanvasDragItem(() => '')).toBeNull()
+    expect(readCanvasDragItem(() => 'not json')).toBeNull()
+    expect(readCanvasDragItem(() => JSON.stringify({ entityType: 'x', entityId: 'y' }))).toBeNull()
+    expect(readCanvasDragItem(() => JSON.stringify({ entityType: 'note' }))).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-cards.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-cards.ts
@@ -1,0 +1,275 @@
+/**
+ * Pure geometry + data helpers for spatial-canvas item cards.
+ *
+ * A card is an Excalidraw `rectangle` carrying
+ * `customData: { entityType, entityId }`. The scene stays the source of truth
+ * for geometry; a DOM overlay (canvas-card-overlay.tsx) renders a read-only
+ * preview over each visible card rectangle. Everything here is
+ * Excalidraw-runtime-free (types only) so it unit-tests without the library.
+ */
+
+import {
+  CANVAS_ENTITY_TYPES,
+  type CanvasEntityRef,
+  type CanvasEntityType
+} from '@memry/contracts/canvas-api'
+
+/** The custom drag MIME a card drop consumes ({ entityType, entityId } JSON). */
+export const CANVAS_ITEM_DRAG_MIME = 'application/x-memry-canvas-item'
+
+/** Default card rectangle size in scene units. */
+export const CARD_DEFAULT_WIDTH = 260
+export const CARD_DEFAULT_HEIGHT = 168
+
+/** Minimal element shape the card logic reads (subset of ExcalidrawElement). */
+export interface CardElement {
+  id: string
+  type: string
+  x: number
+  y: number
+  width: number
+  height: number
+  angle: number
+  isDeleted?: boolean
+  customData?: Record<string, unknown> | null
+}
+
+/** Minimal appState shape the overlay reads. */
+export interface CanvasAppStateView {
+  scrollX: number
+  scrollY: number
+  zoom: { value: number }
+}
+
+/** A card resolved from a scene element: its element id + the entity it refs. */
+export interface CanvasCardRef extends CanvasEntityRef {
+  elementId: string
+  x: number
+  y: number
+  width: number
+  height: number
+  angle: number
+}
+
+function isEntityType(value: unknown): value is CanvasEntityType {
+  return typeof value === 'string' && (CANVAS_ENTITY_TYPES as readonly string[]).includes(value)
+}
+
+/**
+ * Reads the card data off a rectangle element, or null when the element is not
+ * a live card (wrong type, deleted, or missing/invalid customData).
+ */
+export function getCardRef(element: CardElement): CanvasCardRef | null {
+  if (element.type !== 'rectangle' || element.isDeleted) {
+    return null
+  }
+  const data = element.customData
+  if (!data) {
+    return null
+  }
+  const entityType = data.entityType
+  const entityId = data.entityId
+  if (!isEntityType(entityType) || typeof entityId !== 'string' || entityId.length === 0) {
+    return null
+  }
+  return {
+    elementId: element.id,
+    entityType,
+    entityId,
+    x: element.x,
+    y: element.y,
+    width: element.width,
+    height: element.height,
+    angle: element.angle ?? 0
+  }
+}
+
+/** All live card refs in a scene, in z-order (elements array order). */
+export function getCardRefs(elements: readonly CardElement[]): CanvasCardRef[] {
+  const cards: CanvasCardRef[] = []
+  for (const element of elements) {
+    const card = getCardRef(element)
+    if (card) {
+      cards.push(card)
+    }
+  }
+  return cards
+}
+
+/**
+ * Advisory entity refs for persistence, deduped by (entityType, entityId).
+ * The store rewrites canvas_entity_refs from this on every save.
+ */
+export function extractEntityRefs(elements: readonly CardElement[]): CanvasEntityRef[] {
+  const seen = new Set<string>()
+  const refs: CanvasEntityRef[] = []
+  for (const card of getCardRefs(elements)) {
+    const key = `${card.entityType}:${card.entityId}`
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    refs.push({ entityType: card.entityType, entityId: card.entityId })
+  }
+  return refs
+}
+
+/**
+ * CSS transform for the overlay layer so its children, positioned in scene
+ * units, land exactly over the canvas. Mirrors Excalidraw's
+ * sceneCoordsToViewportCoords: viewportX = (sceneX + scrollX) * zoom.
+ * Applied with transform-origin: 0 0.
+ */
+export function overlayTransform(appState: CanvasAppStateView): string {
+  const z = appState.zoom.value
+  return `translate(${appState.scrollX * z}px, ${appState.scrollY * z}px) scale(${z})`
+}
+
+export interface SceneRect {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+/** The visible viewport expressed in scene coordinates. */
+export function viewportSceneRect(
+  appState: CanvasAppStateView,
+  container: { width: number; height: number }
+): SceneRect {
+  const z = appState.zoom.value || 1
+  return {
+    minX: -appState.scrollX,
+    minY: -appState.scrollY,
+    maxX: container.width / z - appState.scrollX,
+    maxY: container.height / z - appState.scrollY
+  }
+}
+
+function intersects(card: CanvasCardRef, rect: SceneRect, padding: number): boolean {
+  return (
+    card.x <= rect.maxX + padding &&
+    card.x + card.width >= rect.minX - padding &&
+    card.y <= rect.maxY + padding &&
+    card.y + card.height >= rect.minY - padding
+  )
+}
+
+export interface VisibilityOptions {
+  /** Scene-unit padding for a card to ENTER the visible set. */
+  enterPadding: number
+  /** Larger scene-unit padding for a visible card to STAY visible (hysteresis). */
+  exitPadding: number
+  /** Element ids currently mounted, so membership only flips at the thresholds. */
+  previousVisible: ReadonlySet<string>
+}
+
+/**
+ * Viewport-membership with hysteresis: a card enters when it intersects the
+ * viewport + enterPadding and only leaves once it exits viewport + exitPadding.
+ * The wider exit band stops cards near the edge from mounting/unmounting on
+ * every sub-pixel pan.
+ */
+export function computeVisibleCardIds(
+  cards: readonly CanvasCardRef[],
+  rect: SceneRect,
+  options: VisibilityOptions
+): Set<string> {
+  const visible = new Set<string>()
+  for (const card of cards) {
+    const wasVisible = options.previousVisible.has(card.elementId)
+    const padding = wasVisible ? options.exitPadding : options.enterPadding
+    if (intersects(card, rect, padding)) {
+      visible.add(card.elementId)
+    }
+  }
+  return visible
+}
+
+/** Two id sets are equal (same membership). */
+export function sameMembership(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) {
+    return false
+  }
+  for (const id of a) {
+    if (!b.has(id)) {
+      return false
+    }
+  }
+  return true
+}
+
+/** Rectangle-skeleton input for convertToExcalidrawElements (card creation). */
+export interface CardSkeleton {
+  type: 'rectangle'
+  x: number
+  y: number
+  width: number
+  height: number
+  strokeColor: string
+  backgroundColor: string
+  fillStyle: string
+  strokeWidth: number
+  roughness: number
+  roundness: { type: number }
+  customData: { entityType: CanvasEntityType; entityId: string }
+}
+
+/**
+ * A clean (roughness 0) rectangle skeleton for a card, centered on (x, y).
+ * Pass to convertToExcalidrawElements. The overlay draws the real preview;
+ * this rectangle provides geometry, selection, resize, and arrow-binding.
+ */
+export function makeCardSkeleton(input: {
+  entityType: CanvasEntityType
+  entityId: string
+  /** Scene coordinate to center the card on (e.g. the drop point). */
+  centerX: number
+  centerY: number
+  width?: number
+  height?: number
+}): CardSkeleton {
+  const width = input.width ?? CARD_DEFAULT_WIDTH
+  const height = input.height ?? CARD_DEFAULT_HEIGHT
+  return {
+    type: 'rectangle',
+    x: input.centerX - width / 2,
+    y: input.centerY - height / 2,
+    width,
+    height,
+    strokeColor: '#ced4da',
+    backgroundColor: 'transparent',
+    fillStyle: 'solid',
+    strokeWidth: 1,
+    roughness: 0,
+    roundness: { type: 3 },
+    customData: { entityType: input.entityType, entityId: input.entityId }
+  }
+}
+
+/**
+ * Parses the canvas drag payload from a DataTransfer-like getData function.
+ * Returns null when the drag is not a canvas item (no MIME / bad JSON).
+ */
+export function readCanvasDragItem(
+  getData: (type: string) => string
+): { entityType: CanvasEntityType; entityId: string } | null {
+  const raw = getData(CANVAS_ITEM_DRAG_MIME)
+  if (!raw) {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(raw) as { entityType?: unknown; entityId?: unknown }
+    if (isEntityType(parsed.entityType) && typeof parsed.entityId === 'string' && parsed.entityId) {
+      return { entityType: parsed.entityType, entityId: parsed.entityId }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+/** Serializes a canvas drag payload for dataTransfer.setData. */
+export function canvasDragPayload(entityType: CanvasEntityType, entityId: string): string {
+  return JSON.stringify({ entityType, entityId })
+}

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
@@ -6,7 +6,7 @@
  * public/excalidraw-asset-path.js) because the CSP blocks Excalidraw's CDN.
  */
 
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Excalidraw, serializeAsJSON, languages, defaultLang } from '@excalidraw/excalidraw'
 import type {
   ExcalidrawImperativeAPI,
@@ -21,6 +21,8 @@ import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
 import { createLogger } from '@/lib/logger'
 import { createScenePersister } from './canvas-persistence'
 import { pickExcalidrawLangCode } from './excalidraw-lang'
+import { CanvasCardLayer } from './canvas-card-overlay'
+import { extractEntityRefs, type CardElement } from './canvas-cards'
 
 const log = createLogger('SpatialCanvas')
 
@@ -39,6 +41,8 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
   const { t } = useT('common')
   const { resolvedTheme } = useTheme()
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const [api, setApi] = useState<ExcalidrawImperativeAPI | null>(null)
 
   const initialData = useMemo(() => {
     if (!initialScene) {
@@ -83,7 +87,10 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
         }
       },
       save: async (scene) => {
-        await canvasService.update({ id: canvasId, scene })
+        // Advisory entity refs are derived from the same scene, so the dedupe
+        // key (scene string) still governs whether a save runs.
+        const elements = (apiRef.current?.getSceneElements() ?? []) as unknown as CardElement[]
+        await canvasService.update({ id: canvasId, scene, entityRefs: extractEntityRefs(elements) })
       },
       debounceMs: SCENE_SAVE_DEBOUNCE_MS,
       lastSavedScene: initialScene,
@@ -119,10 +126,11 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
   }
 
   return (
-    <div className="h-full w-full" data-canvas-editor={canvasId}>
+    <div ref={wrapperRef} className="relative h-full w-full" data-canvas-editor={canvasId}>
       <Excalidraw
-        excalidrawAPI={(api) => {
-          apiRef.current = api
+        excalidrawAPI={(instance) => {
+          apiRef.current = instance
+          setApi(instance)
         }}
         initialData={initialData}
         onChange={() => persisterRef.current?.notifyChange()}
@@ -131,6 +139,13 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
         theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
         langCode={langCode}
       />
+      {api ? (
+        <CanvasCardLayer
+          excalidrawAPI={api}
+          wrapperRef={wrapperRef}
+          onSceneMutated={() => persisterRef.current?.notifyChange()}
+        />
+      ) : null}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-redirect.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-redirect.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { buildRedirectTab } from './canvas-redirect'
+
+describe('buildRedirectTab', () => {
+  it('opens a note tab keyed by entityId', () => {
+    const tab = buildRedirectTab({
+      entityType: 'note',
+      entityId: 'n1',
+      title: 'My note',
+      now: 1000
+    })
+    expect(tab).toMatchObject({
+      type: 'note',
+      title: 'My note',
+      entityId: 'n1',
+      path: '/note/n1'
+    })
+  })
+
+  it('falls back to a default note title when empty', () => {
+    expect(buildRedirectTab({ entityType: 'note', entityId: 'n1', title: '', now: 1 })?.title).toBe(
+      'Note'
+    )
+  })
+
+  it('opens Tasks with an openTaskId viewState', () => {
+    const tab = buildRedirectTab({ entityType: 'task', entityId: 't1', title: '', now: 1 })
+    expect(tab).toMatchObject({ type: 'tasks', viewState: { openTaskId: 't1' } })
+  })
+
+  it('opens Calendar focused on the event day with a fresh token', () => {
+    const tab = buildRedirectTab({
+      entityType: 'calendar_event',
+      entityId: 'ev1',
+      title: '',
+      startAt: '2026-07-20T14:30:00.000Z',
+      now: 9999
+    })
+    expect(tab).toMatchObject({
+      type: 'calendar',
+      viewState: {
+        focusCalendarEventId: 'ev1',
+        focusDate: '2026-07-20',
+        focusedAt: 9999
+      }
+    })
+  })
+
+  it('returns null for a calendar event without a start date', () => {
+    expect(
+      buildRedirectTab({ entityType: 'calendar_event', entityId: 'ev1', title: '', now: 1 })
+    ).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-redirect.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-redirect.ts
@@ -1,0 +1,74 @@
+/**
+ * Builds the openTab argument that opens a card's entity "as if clicked in its
+ * home view", reusing the proven viewState deep-links from
+ * agent-chat/messages/memry-links.tsx (note → note tab, task → Tasks + drawer,
+ * event → Calendar focus). Pure so it unit-tests without the tab context.
+ */
+
+import type { Tab } from '@/contexts/tabs/types'
+import type { CanvasEntityType } from '@memry/contracts/canvas-api'
+
+export type RedirectTab = Omit<Tab, 'id' | 'openedAt' | 'lastAccessedAt'>
+
+const base = {
+  isPinned: false,
+  isModified: false,
+  isPreview: false,
+  isDeleted: false
+} as const
+
+export interface RedirectInput {
+  entityType: CanvasEntityType
+  entityId: string
+  /** Card title for the note tab label. */
+  title: string
+  /** Event start ISO — required to focus the right calendar day. */
+  startAt?: string | null
+  /** Monotonic token so a repeat redirect to the same entity re-fires focus. */
+  now: number
+}
+
+/**
+ * Returns the tab descriptor to pass to openTab, or null when the input is
+ * insufficient (e.g. a calendar event with no start date to focus).
+ */
+export function buildRedirectTab(input: RedirectInput): RedirectTab | null {
+  switch (input.entityType) {
+    case 'note':
+      return {
+        ...base,
+        type: 'note',
+        title: input.title || 'Note',
+        icon: 'file-text',
+        path: `/note/${input.entityId}`,
+        entityId: input.entityId
+      }
+    case 'task':
+      return {
+        ...base,
+        type: 'tasks',
+        title: 'Tasks',
+        icon: 'list-checks',
+        path: '/tasks',
+        viewState: { openTaskId: input.entityId }
+      }
+    case 'calendar_event': {
+      if (!input.startAt) {
+        return null
+      }
+      const focusDate = input.startAt.slice(0, 10)
+      return {
+        ...base,
+        type: 'calendar',
+        title: 'Calendar',
+        icon: 'calendar',
+        path: '/calendar',
+        viewState: {
+          focusCalendarEventId: input.entityId,
+          focusDate,
+          focusedAt: input.now
+        }
+      }
+    }
+  }
+}

--- a/apps/desktop/src/renderer/src/pages/canvas/use-canvas-entities.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/use-canvas-entities.test.ts
@@ -1,0 +1,190 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useCanvasEntities, entityKey } from './use-canvas-entities'
+import type { CanvasCardRef } from './canvas-cards'
+import type { CanvasEntityType } from '@memry/contracts/canvas-api'
+
+const mocks = vi.hoisted(() => ({
+  notesGet: vi.fn(),
+  tasksGet: vi.fn(),
+  calGet: vi.fn(),
+  cb: {
+    noteUpdated: null as ((e: { id: string }) => void) | null,
+    noteRenamed: null as ((e: { id: string }) => void) | null,
+    noteDeleted: null as ((e: { id: string }) => void) | null,
+    taskUpdated: null as ((e: { id: string }) => void) | null,
+    taskCompleted: null as ((e: { id: string }) => void) | null,
+    taskDeleted: null as ((e: { id: string }) => void) | null,
+    calChanged: null as ((e: { entityType: string; id: string }) => void) | null
+  }
+}))
+
+vi.mock('@/services/notes-service', () => ({
+  notesService: { get: (id: string) => mocks.notesGet(id) },
+  onNoteUpdated: (cb: (e: { id: string }) => void) => {
+    mocks.cb.noteUpdated = cb
+    return () => {}
+  },
+  onNoteRenamed: (cb: (e: { id: string }) => void) => {
+    mocks.cb.noteRenamed = cb
+    return () => {}
+  },
+  onNoteDeleted: (cb: (e: { id: string }) => void) => {
+    mocks.cb.noteDeleted = cb
+    return () => {}
+  }
+}))
+
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: { get: (id: string) => mocks.tasksGet(id) },
+  onTaskUpdated: (cb: (e: { id: string }) => void) => {
+    mocks.cb.taskUpdated = cb
+    return () => {}
+  },
+  onTaskCompleted: (cb: (e: { id: string }) => void) => {
+    mocks.cb.taskCompleted = cb
+    return () => {}
+  },
+  onTaskDeleted: (cb: (e: { id: string }) => void) => {
+    mocks.cb.taskDeleted = cb
+    return () => {}
+  }
+}))
+
+vi.mock('@/services/calendar-service', () => ({
+  calendarService: { getEvent: (id: string) => mocks.calGet(id) },
+  onCalendarChanged: (cb: (e: { entityType: string; id: string }) => void) => {
+    mocks.cb.calChanged = cb
+    return () => {}
+  }
+}))
+
+function ref(entityType: CanvasEntityType, entityId: string): CanvasCardRef {
+  return {
+    elementId: `${entityType}-${entityId}`,
+    entityType,
+    entityId,
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    angle: 0
+  }
+}
+
+describe('useCanvasEntities', () => {
+  beforeEach(() => {
+    mocks.notesGet.mockReset()
+    mocks.tasksGet.mockReset()
+    mocks.calGet.mockReset()
+  })
+
+  it('loads note, task, and event entities into a keyed map', async () => {
+    mocks.notesGet.mockResolvedValue({ title: 'Note A', emoji: '📄', content: 'body' })
+    mocks.tasksGet.mockResolvedValue({
+      title: 'Task A',
+      completedAt: null,
+      dueDate: '2026-07-20',
+      archivedAt: null
+    })
+    mocks.calGet.mockResolvedValue({
+      title: 'Event A',
+      startAt: '2026-07-20T10:00:00Z',
+      endAt: null,
+      isAllDay: false,
+      archivedAt: null
+    })
+
+    const refs = [ref('note', 'n1'), ref('task', 't1'), ref('calendar_event', 'ev1')]
+    const { result } = renderHook(() => useCanvasEntities(refs))
+
+    await waitFor(() => {
+      expect(result.current.get(entityKey('note', 'n1'))).toMatchObject({
+        status: 'ready',
+        kind: 'note',
+        title: 'Note A'
+      })
+      expect(result.current.get(entityKey('task', 't1'))).toMatchObject({
+        kind: 'task',
+        completed: false,
+        dueDate: '2026-07-20'
+      })
+      expect(result.current.get(entityKey('calendar_event', 'ev1'))).toMatchObject({
+        kind: 'calendar_event',
+        title: 'Event A'
+      })
+    })
+  })
+
+  it('marks missing or archived entities as dangling', async () => {
+    mocks.notesGet.mockResolvedValue(null)
+    mocks.tasksGet.mockResolvedValue({
+      title: 'x',
+      completedAt: null,
+      dueDate: null,
+      archivedAt: '2026-01-01'
+    })
+
+    const { result } = renderHook(() => useCanvasEntities([ref('note', 'n1'), ref('task', 't1')]))
+    await waitFor(() => {
+      expect(result.current.get(entityKey('note', 'n1'))).toEqual({ status: 'dangling' })
+      expect(result.current.get(entityKey('task', 't1'))).toEqual({ status: 'dangling' })
+    })
+  })
+
+  it('refetches a held entity when its update event fires', async () => {
+    mocks.notesGet.mockResolvedValue({ title: 'Before', emoji: null, content: '' })
+    const { result } = renderHook(() => useCanvasEntities([ref('note', 'n1')]))
+    await waitFor(() => {
+      expect(result.current.get(entityKey('note', 'n1'))).toMatchObject({ title: 'Before' })
+    })
+
+    mocks.notesGet.mockResolvedValue({ title: 'After', emoji: null, content: '' })
+    act(() => mocks.cb.noteUpdated?.({ id: 'n1' }))
+    await waitFor(() => {
+      expect(result.current.get(entityKey('note', 'n1'))).toMatchObject({ title: 'After' })
+    })
+    // Two fetches: initial + event.
+    expect(mocks.notesGet).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores events for entities it does not hold', async () => {
+    mocks.notesGet.mockResolvedValue({ title: 'A', emoji: null, content: '' })
+    renderHook(() => useCanvasEntities([ref('note', 'n1')]))
+    await waitFor(() => expect(mocks.notesGet).toHaveBeenCalledTimes(1))
+
+    act(() => mocks.cb.noteUpdated?.({ id: 'other' }))
+    // No extra fetch for an unheld entity.
+    expect(mocks.notesGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('flips to dangling on a delete event', async () => {
+    mocks.tasksGet.mockResolvedValue({
+      title: 'A',
+      completedAt: null,
+      dueDate: null,
+      archivedAt: null
+    })
+    const { result } = renderHook(() => useCanvasEntities([ref('task', 't1')]))
+    await waitFor(() =>
+      expect(result.current.get(entityKey('task', 't1'))).toMatchObject({ kind: 'task' })
+    )
+
+    act(() => mocks.cb.taskDeleted?.({ id: 't1' }))
+    await waitFor(() =>
+      expect(result.current.get(entityKey('task', 't1'))).toEqual({ status: 'dangling' })
+    )
+  })
+
+  it('prunes entities whose cards scroll out of view', async () => {
+    mocks.notesGet.mockResolvedValue({ title: 'A', emoji: null, content: '' })
+    const { result, rerender } = renderHook(({ refs }) => useCanvasEntities(refs), {
+      initialProps: { refs: [ref('note', 'n1')] }
+    })
+    await waitFor(() => expect(result.current.has(entityKey('note', 'n1'))).toBe(true))
+
+    rerender({ refs: [] })
+    await waitFor(() => expect(result.current.has(entityKey('note', 'n1'))).toBe(false))
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/canvas/use-canvas-entities.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/use-canvas-entities.ts
@@ -1,0 +1,241 @@
+/**
+ * Resolves the entities referenced by visible canvas cards into a live
+ * title/status/dangling map.
+ *
+ * Fetch-on-visible with a small cache (C2): only the entities whose cards are
+ * currently on screen are loaded, and each is loaded once. Live one-way IPC
+ * events keep the cached state fresh — a note/task edited in its own tab
+ * updates its card here with no polling. `get(id) === null` (or an archived
+ * task/event) is the dangling signal.
+ */
+
+import { useEffect, useMemo, useReducer, useRef } from 'react'
+import { notesService, onNoteUpdated, onNoteDeleted, onNoteRenamed } from '@/services/notes-service'
+import {
+  tasksService,
+  onTaskUpdated,
+  onTaskDeleted,
+  onTaskCompleted
+} from '@/services/tasks-service'
+import { calendarService, onCalendarChanged } from '@/services/calendar-service'
+import { createLogger } from '@/lib/logger'
+import type { CanvasCardRef } from './canvas-cards'
+import type { CanvasEntityType } from '@memry/contracts/canvas-api'
+
+const log = createLogger('SpatialCanvas')
+
+export type CanvasEntityState =
+  | { status: 'loading' }
+  | { status: 'dangling' }
+  | { status: 'ready'; kind: 'note'; title: string; emoji: string | null; body: string }
+  | { status: 'ready'; kind: 'task'; title: string; completed: boolean; dueDate: string | null }
+  | {
+      status: 'ready'
+      kind: 'calendar_event'
+      title: string
+      startAt: string
+      endAt: string | null
+      isAllDay: boolean
+    }
+
+export function entityKey(entityType: CanvasEntityType, entityId: string): string {
+  return `${entityType}:${entityId}`
+}
+
+type EntityMap = ReadonlyMap<string, CanvasEntityState>
+
+type Action =
+  | { type: 'set'; key: string; state: CanvasEntityState }
+  | { type: 'prune'; keep: ReadonlySet<string> }
+
+function reducer(state: EntityMap, action: Action): EntityMap {
+  switch (action.type) {
+    case 'set': {
+      const existing = state.get(action.key)
+      if (existing && shallowEqual(existing, action.state)) {
+        return state
+      }
+      const next = new Map(state)
+      next.set(action.key, action.state)
+      return next
+    }
+    case 'prune': {
+      let changed = false
+      const next = new Map(state)
+      for (const key of state.keys()) {
+        if (!action.keep.has(key)) {
+          next.delete(key)
+          changed = true
+        }
+      }
+      return changed ? next : state
+    }
+  }
+}
+
+function shallowEqual(a: CanvasEntityState, b: CanvasEntityState): boolean {
+  const ak = Object.keys(a) as (keyof CanvasEntityState)[]
+  const bk = Object.keys(b)
+  if (ak.length !== bk.length) {
+    return false
+  }
+  return ak.every(
+    (key) => (a as Record<string, unknown>)[key] === (b as Record<string, unknown>)[key]
+  )
+}
+
+async function loadEntity(
+  entityType: CanvasEntityType,
+  entityId: string
+): Promise<CanvasEntityState> {
+  if (entityType === 'note') {
+    const note = await notesService.get(entityId)
+    if (!note) {
+      return { status: 'dangling' }
+    }
+    return {
+      status: 'ready',
+      kind: 'note',
+      title: note.title,
+      emoji: note.emoji ?? null,
+      body: note.content
+    }
+  }
+  if (entityType === 'task') {
+    const task = await tasksService.get(entityId)
+    if (!task || task.archivedAt) {
+      return { status: 'dangling' }
+    }
+    return {
+      status: 'ready',
+      kind: 'task',
+      title: task.title,
+      completed: task.completedAt !== null,
+      dueDate: task.dueDate
+    }
+  }
+  const event = await calendarService.getEvent(entityId)
+  if (!event || event.archivedAt) {
+    return { status: 'dangling' }
+  }
+  return {
+    status: 'ready',
+    kind: 'calendar_event',
+    title: event.title,
+    startAt: event.startAt,
+    endAt: event.endAt,
+    isAllDay: event.isAllDay
+  }
+}
+
+export function useCanvasEntities(visibleRefs: readonly CanvasCardRef[]): EntityMap {
+  const [entities, dispatch] = useReducer(
+    reducer,
+    undefined,
+    () => new Map<string, CanvasEntityState>()
+  )
+
+  // Distinct (type, id) pairs currently visible, and a stable signature for the
+  // effect. The effect keys off the signature only (not the map identity) so a
+  // `loading` dispatch re-render doesn't re-run it and cancel in-flight loads.
+  const wanted = useMemo(() => {
+    const map = new Map<string, { entityType: CanvasEntityType; entityId: string }>()
+    for (const ref of visibleRefs) {
+      map.set(entityKey(ref.entityType, ref.entityId), {
+        entityType: ref.entityType,
+        entityId: ref.entityId
+      })
+    }
+    return map
+  }, [visibleRefs])
+  const wantedSignature = useMemo(() => Array.from(wanted.keys()).sort().join('|'), [wanted])
+  const wantedRef = useRef(wanted)
+  // Declared before the load effect so it runs first and the load effect reads
+  // the fresh map (effects fire in declaration order).
+  useEffect(() => {
+    wantedRef.current = wanted
+  }, [wanted])
+
+  // Everything currently loaded/loading, so events can target only live cards.
+  const loadedRef = useRef<Set<string>>(new Set())
+  // Cancellation is per-hook, not per-effect: an effect re-run for a changed
+  // visible set must not cancel a still-wanted load (dispatch is gated on the
+  // key still being in loadedRef, which prune removes).
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    const current = wantedRef.current
+    const keep = new Set(current.keys())
+    dispatch({ type: 'prune', keep })
+    for (const key of loadedRef.current) {
+      if (!keep.has(key)) {
+        loadedRef.current.delete(key)
+      }
+    }
+
+    for (const [key, ref] of current) {
+      if (loadedRef.current.has(key)) {
+        continue
+      }
+      loadedRef.current.add(key)
+      dispatch({ type: 'set', key, state: { status: 'loading' } })
+      void loadEntity(ref.entityType, ref.entityId)
+        .then((state) => {
+          if (mountedRef.current && loadedRef.current.has(key)) {
+            dispatch({ type: 'set', key, state })
+          }
+        })
+        .catch((err: unknown) => {
+          if (mountedRef.current && loadedRef.current.has(key)) {
+            log.error('Failed to load canvas card entity', err)
+            dispatch({ type: 'set', key, state: { status: 'dangling' } })
+          }
+        })
+    }
+  }, [wantedSignature])
+
+  // Live updates. Refetch (or apply payload) only for entities we hold.
+  useEffect(() => {
+    const has = (key: string): boolean => loadedRef.current.has(key)
+    const refresh = (entityType: CanvasEntityType, entityId: string): void => {
+      const key = entityKey(entityType, entityId)
+      if (!has(key)) {
+        return
+      }
+      void loadEntity(entityType, entityId)
+        .then((state) => dispatch({ type: 'set', key, state }))
+        .catch(() => dispatch({ type: 'set', key, state: { status: 'dangling' } }))
+    }
+
+    const unsubscribes = [
+      onNoteUpdated((event) => refresh('note', event.id)),
+      onNoteRenamed((event) => refresh('note', event.id)),
+      onNoteDeleted((event) => {
+        const key = entityKey('note', event.id)
+        if (has(key)) dispatch({ type: 'set', key, state: { status: 'dangling' } })
+      }),
+      onTaskUpdated((event) => refresh('task', event.id)),
+      onTaskCompleted((event) => refresh('task', event.id)),
+      onTaskDeleted((event) => {
+        const key = entityKey('task', event.id)
+        if (has(key)) dispatch({ type: 'set', key, state: { status: 'dangling' } })
+      }),
+      onCalendarChanged((event) => {
+        if (event.entityType === 'calendar_event') {
+          refresh('calendar_event', event.id)
+        }
+      })
+    ]
+    return () => {
+      unsubscribes.forEach((unsubscribe) => unsubscribe())
+    }
+  }, [])
+
+  return entities
+}

--- a/apps/desktop/tests/e2e/canvas-cards.e2e.ts
+++ b/apps/desktop/tests/e2e/canvas-cards.e2e.ts
@@ -1,0 +1,208 @@
+// @ts-nocheck - E2E tests in development, follow notes.e2e.ts convention
+/**
+ * Spatial canvas M2 — item cards (rectangle + read-only overlay preview).
+ *
+ * Cards reference real entities by id (no content copied). The drop is driven
+ * by a synthetic DragEvent carrying the canvas MIME (Playwright's native DnD
+ * doesn't populate a capture-phase dataTransfer reliably); everything else
+ * uses window.api. Persistence + no-copy are asserted via the scene JSON from
+ * window.api.canvas.get, per the design spec (§18 B4).
+ */
+import { test, expect, type Page } from './fixtures'
+import { ready } from './utils/desktop-test-helpers'
+
+/**
+ * A cold first launch opens the vault slowly (embedding-model init can take
+ * ~30s), which exceeds waitForVaultReady's internal 15s fallback — so wait for
+ * the sidebar to actually appear before ready() runs its onboarding dismissal.
+ */
+async function openVault(page: Page): Promise<void> {
+  await page
+    .locator('aside, [data-testid="sidebar"], [class*="sidebar"], nav')
+    .first()
+    .waitFor({ state: 'visible', timeout: 90_000 })
+  await ready(page)
+}
+
+async function setSpatialCanvasFlag(page: Page, enabled: boolean): Promise<void> {
+  const result = await page.evaluate(
+    async (value) => window.api.settings.setFeaturesSettings({ spatialCanvas: value }),
+    enabled
+  )
+  if (!result?.success) throw new Error(result?.error ?? 'setFeaturesSettings failed')
+  await page.reload()
+  await openVault(page)
+}
+
+async function createCanvasFromSidebar(page: Page): Promise<string> {
+  const header = page.getByRole('button', { name: /Canvases section/ })
+  await expect(header).toBeVisible()
+  await header.hover()
+  await page.getByRole('button', { name: 'New canvas' }).click()
+  await expect(page.locator('[data-canvas-editor]')).toBeVisible({ timeout: 20000 })
+  await expect(page.locator('.excalidraw').first()).toBeVisible({ timeout: 20000 })
+  const list = await page.evaluate(async () => window.api.canvas.list())
+  return list.canvases[0].id
+}
+
+async function seedNote(page: Page, title: string, content: string): Promise<string> {
+  const res = await page.evaluate(
+    async ({ t, c }) => window.api.notes.create({ title: t, content: c }),
+    { t: title, c: content }
+  )
+  if (!res?.note?.id) throw new Error(`seedNote failed for ${title}`)
+  return res.note.id
+}
+
+/** Dispatch a canvas-item drop at a client point (defaults to canvas center). */
+async function dropNote(page: Page, noteId: string, dx = 0, dy = 0): Promise<void> {
+  await page.evaluate(
+    ({ id, ddx, ddy }) => {
+      const wrapper = document.querySelector('[data-canvas-editor]') as HTMLElement
+      const r = wrapper.getBoundingClientRect()
+      const dt = new DataTransfer()
+      dt.setData(
+        'application/x-memry-canvas-item',
+        JSON.stringify({ entityType: 'note', entityId: id })
+      )
+      const ev = new DragEvent('drop', {
+        bubbles: true,
+        cancelable: true,
+        clientX: r.left + r.width / 2 + ddx,
+        clientY: r.top + r.height / 2 + ddy
+      })
+      Object.defineProperty(ev, 'dataTransfer', { value: dt })
+      wrapper.dispatchEvent(ev)
+    },
+    { id: noteId, ddx: dx, ddy: dy }
+  )
+}
+
+async function sceneOf(page: Page, canvasId: string) {
+  return page.evaluate(async (id) => {
+    const c = await window.api.canvas.get(id)
+    return { scene: c?.scene ?? '', parsed: c?.scene ? JSON.parse(c.scene) : { elements: [] } }
+  }, canvasId)
+}
+
+function cardRects(parsed): Array<{ customData?: { entityId?: string } }> {
+  return (parsed.elements ?? []).filter(
+    (e) => e.type === 'rectangle' && !e.isDeleted && e.customData?.entityId
+  )
+}
+
+test.describe('Spatial canvas — item cards (M2)', () => {
+  test.describe.configure({ timeout: 240_000 })
+
+  test('drop a note → referencing card (no content copied) + ↗ opens the note tab', async ({
+    page
+  }) => {
+    await openVault(page)
+    await setSpatialCanvasFlag(page, true)
+    const canvasId = await createCanvasFromSidebar(page)
+
+    const marker = `BODYMARKER_${Date.now()}`
+    const title = `Alpha ${Date.now()}`
+    const noteId = await seedNote(page, title, `secret ${marker} body`)
+
+    await dropNote(page, noteId)
+
+    const card = page.locator(`[data-canvas-card-entity="note:${noteId}"]`)
+    await expect(card).toBeVisible({ timeout: 20000 })
+    await expect(card).toContainText(title, { timeout: 20000 })
+
+    // Referencing, not copying: the scene holds a rectangle with the note id in
+    // customData but never the note body.
+    await expect
+      .poll(async () => cardRects((await sceneOf(page, canvasId)).parsed).length, {
+        timeout: 15000
+      })
+      .toBeGreaterThan(0)
+    const { scene, parsed } = await sceneOf(page, canvasId)
+    expect(cardRects(parsed).some((r) => r.customData?.entityId === noteId)).toBe(true)
+    expect(scene).not.toContain(marker)
+
+    // ↗ redirect opens the note in its own tab.
+    await card.getByRole('button', { name: 'Open in tab' }).click()
+    await expect(page.getByRole('tab', { name: title })).toBeVisible({ timeout: 20000 })
+  })
+
+  test('card reflects a title edit made elsewhere, then goes dangling on delete', async ({
+    page
+  }) => {
+    await openVault(page)
+    await setSpatialCanvasFlag(page, true)
+    await createCanvasFromSidebar(page)
+
+    const title = `Beta ${Date.now()}`
+    const noteId = await seedNote(page, title, 'body')
+    await dropNote(page, noteId)
+
+    const card = page.locator(`[data-canvas-card-entity="note:${noteId}"]`)
+    await expect(card).toContainText(title, { timeout: 20000 })
+
+    const renamed = `Renamed ${Date.now()}`
+    await page.evaluate(async ({ id, t }) => window.api.notes.rename(id, t), {
+      id: noteId,
+      t: renamed
+    })
+    await expect(card).toContainText(renamed, { timeout: 20000 })
+
+    await page.evaluate(async (id) => window.api.notes.delete(id), noteId)
+    await expect(card).toHaveAttribute('data-canvas-card-state', 'dangling', { timeout: 20000 })
+  })
+
+  test('capture-first: the New note button creates a note card on the canvas', async ({ page }) => {
+    await openVault(page)
+    await setSpatialCanvasFlag(page, true)
+    const canvasId = await createCanvasFromSidebar(page)
+
+    await page.getByTestId('canvas-new-note').click()
+
+    await expect(page.locator('[data-canvas-card-id]')).toHaveCount(1, { timeout: 20000 })
+    await expect
+      .poll(async () => cardRects((await sceneOf(page, canvasId)).parsed).length, {
+        timeout: 15000
+      })
+      .toBe(1)
+  })
+
+  test('overlay stays synced on pan and virtualizes off-screen cards', async ({ page }) => {
+    await openVault(page)
+    await setSpatialCanvasFlag(page, true)
+    const canvasId = await createCanvasFromSidebar(page)
+
+    const noteId = await seedNote(page, `Grid ${Date.now()}`, 'body')
+    // Spread cards far apart so most fall outside the padded viewport.
+    for (let i = 0; i < 8; i++) {
+      await dropNote(page, noteId, (i - 4) * 900, 0)
+    }
+    await expect
+      .poll(async () => cardRects((await sceneOf(page, canvasId)).parsed).length, {
+        timeout: 15000
+      })
+      .toBe(8)
+
+    // Virtualization: fewer cards are mounted than exist in the scene.
+    const mounted = await page.locator('[data-canvas-card-id]').count()
+    expect(mounted).toBeGreaterThan(0)
+    expect(mounted).toBeLessThan(8)
+
+    // Pan updates the overlay's scroll stamp (imperative transform sync).
+    const before = await page
+      .locator('[data-canvas-overlay]')
+      .evaluate((el) => el.parentElement?.getAttribute('data-scroll-x'))
+    const box = await page.locator('[data-canvas-editor]').boundingBox()
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.wheel(600, 0)
+    await expect
+      .poll(
+        async () =>
+          page
+            .locator('[data-canvas-overlay]')
+            .evaluate((el) => el.parentElement?.getAttribute('data-scroll-x')),
+        { timeout: 10000 }
+      )
+      .not.toBe(before)
+  })
+})

--- a/apps/desktop/tests/e2e/canvas-surface.e2e.ts
+++ b/apps/desktop/tests/e2e/canvas-surface.e2e.ts
@@ -11,6 +11,19 @@ import { test, expect, type Page } from './fixtures'
 import { ready } from './utils/desktop-test-helpers'
 
 /**
+ * A cold first launch opens the vault slowly (embedding-model init can take
+ * ~30s), exceeding waitForVaultReady's internal 15s fallback — wait for the
+ * sidebar to appear before ready() runs its onboarding dismissal.
+ */
+async function openVault(page: Page): Promise<void> {
+  await page
+    .locator('aside, [data-testid="sidebar"], [class*="sidebar"], nav')
+    .first()
+    .waitFor({ state: 'visible', timeout: 90_000 })
+  await ready(page)
+}
+
+/**
  * Persists the flag, then reloads so every useFeatureFlags mount reads the
  * new value on its initial fetch. The live settings:changed path is racy on
  * a cold boot (a fetch dispatched before the write can resolve after the
@@ -25,7 +38,7 @@ async function setSpatialCanvasFlag(page: Page, enabled: boolean): Promise<void>
     throw new Error(result?.error ?? 'setFeaturesSettings failed')
   }
   await page.reload()
-  await ready(page)
+  await openVault(page)
 }
 
 /** Parsed scene JSON for a canvas id, or null when the canvas is missing. */
@@ -65,7 +78,7 @@ test.describe('Spatial canvas — surface (M1)', () => {
   test('flag off shows no sidebar section; enabled: create, draw, reload persists ink', async ({
     page
   }) => {
-    await ready(page)
+    await openVault(page)
 
     // Flag off (default): zero user-visible change.
     await expect(page.getByRole('button', { name: /Canvases section/ })).toHaveCount(0)
@@ -101,7 +114,7 @@ test.describe('Spatial canvas — surface (M1)', () => {
 
     // Reload: flag + scene persist, the restored tab mounts the editor again.
     await page.reload()
-    await ready(page)
+    await openVault(page)
 
     const after = liveElements(await getCanvasScene(page, canvasId))
     expect(after.filter((element) => element.type === 'freedraw').length).toBe(freedrawCount)
@@ -109,7 +122,7 @@ test.describe('Spatial canvas — surface (M1)', () => {
   })
 
   test('restored canvas tab shows a placeholder when the flag is off', async ({ page }) => {
-    await ready(page)
+    await openVault(page)
     await setSpatialCanvasFlag(page, true)
     await createCanvasFromSidebar(page)
 

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -231,7 +231,16 @@
     "notFound": "This canvas could not be found",
     "corruptScene": "This canvas could not be read. Editing is disabled to avoid losing data.",
     "disabledTitle": "Canvas is not enabled",
-    "disabledBody": "This tab belongs to a feature that is not enabled on this device."
+    "disabledBody": "This tab belongs to a feature that is not enabled on this device.",
+    "card": {
+      "open": "Open in tab",
+      "deleted": "Item deleted",
+      "loading": "Loading…",
+      "untitled": "Untitled",
+      "allDay": "All day",
+      "newNote": "New note",
+      "createNoteFailed": "Could not create note"
+    }
   },
   "phaseF": {
     "componentsAppSidebar": {


### PR DESCRIPTION
Third of three stacked PRs. **Stacked on #781 (M1).** Local-only — still behind the hidden \`spatialCanvas\` flag (default OFF).

## Scope (M2)
Hybrid card model: an Excalidraw \`rectangle\` carries \`customData {entityType, entityId}\` for geometry/selection/arrow-binding; a DOM overlay renders a read-only preview over each visible card. **No entity content is copied** — cards reference notes/tasks/events by id only.

- Pure geometry/data core (entity-ref extraction, overlay transform, viewport membership with hysteresis, card skeleton, drag payload).
- Fetch-on-visible entity cache with live title/status via note/task/calendar events; \`get() === null\` (or archived) = dangling.
- Card preview: A4-style note body (safe marked token-walker), task/event status chips, dangling + loading states, ↗ redirect button.
- Overlay controller: imperative transform on every \`onChange\` (zero setState during pan), viewport virtualization, capture-phase drop/dblclick, capture-first "New note" button.
- Deep-link redirects reuse the proven \`memry-links\` viewState (note tab, Tasks drawer, Calendar focus).
- Sidebar note drag tags \`application/x-memry-canvas-item\` so a note can be dropped onto a canvas.

## Bug fixed
The ↗ button was unclickable — \`.excalidraw\` has no \`z-index\`, so its interactive canvas (\`z-2\`) sat above the overlay in the same stacking context. Fixed with \`z-[3]\` on the overlay clip layer (would have affected real users, not just tests).

## Verification
typecheck · lint · ipc:check · i18n:check · full suite (11,041 tests) · coverage ratchet (85.92 / 73.88 / 85.59 / 87.97) · canvas e2e 4/4 all green. E2E runs in CI mode (\`--disable-gpu\`, retries) — local non-CI Electron flakes under load.

## Out of scope (by design)
Task/event drag **onto** the canvas (they use dnd-kit, not dataTransfer) — those cards still render + redirect. In-place editing is M6.

_Base retargets up the stack automatically as M0/M1 merge._