### PR TITLE
fix(crypto): stop safeStorage false-absent from orphaning the vault master key

### DIFF
--- a/apps/desktop/src/main/ipc/sync-core-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/sync-core-handlers.test.ts
@@ -618,6 +618,32 @@ describe('sync IPC handlers', () => {
       expect(mockTeardownSession).toHaveBeenCalledWith('integrity')
     })
 
+    it('does NOT tear down local state when the master key read throws transiently', async () => {
+      // Regression: a transient keychain read failure (safeStorage not ready,
+      // a mid-flight keytar→safeStorage migration, an OS keychain lock) must
+      // never be misread as "key absent" and trigger a destructive re-auth that
+      // rebinds key material the vault no longer matches.
+      mockIsDatabaseInitialized.mockReturnValue(true)
+      mockSelectGet.mockReturnValue({ id: 'dev-1', signingPublicKey: 'base64-encoded' })
+      mockRetrieveKey.mockRejectedValueOnce(new Error('Failed to retrieve key from keychain'))
+
+      await checkSyncIntegrity()
+
+      expect(mockTeardownSession).not.toHaveBeenCalled()
+    })
+
+    it('does NOT tear down local state when the signing key read throws transiently', async () => {
+      mockIsDatabaseInitialized.mockReturnValue(true)
+      mockSelectGet.mockReturnValue({ id: 'dev-1', signingPublicKey: 'base64-encoded' })
+      mockRetrieveKey
+        .mockResolvedValueOnce(new Uint8Array(32).fill(1))
+        .mockRejectedValueOnce(new Error('Failed to retrieve key from keychain'))
+
+      await checkSyncIntegrity()
+
+      expect(mockTeardownSession).not.toHaveBeenCalled()
+    })
+
     it('leaves matching signing keys alone and swallows integrity errors', async () => {
       mockIsDatabaseInitialized.mockReturnValue(true)
       mockSelectGet.mockReturnValue({ id: 'dev-1', signingPublicKey: 'base64-encoded' })

--- a/apps/desktop/src/main/ipc/sync-core-handlers.ts
+++ b/apps/desktop/src/main/ipc/sync-core-handlers.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron'
 import sodium from 'libsodium-wrappers-sumo'
 
 import { syncDevices } from '@memry/db-schema/schema/sync-devices'
-import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
+import { KEYCHAIN_ENTRIES, type KeychainEntry } from '@memry/contracts/crypto'
 import { SYNC_CHANNELS } from '@memry/contracts/ipc-sync'
 import {
   GetHistorySchema,
@@ -59,6 +59,35 @@ const parseSyncHistoryDetails = (details: string): unknown => {
 // Startup Integrity Check
 // ============================================================================
 
+// A keychain read has two very different failure modes and they must not be
+// conflated: `retrieveKey` RETURNS null only when the read succeeded and the
+// key is genuinely absent, but THROWS when the read itself failed transiently
+// (safeStorage not yet ready, a mid-flight keytar→safeStorage migration, an
+// OS keychain prompt/lock). Treating a transient throw as "key absent" makes
+// the integrity check below tear down local sync state and force a re-auth
+// that rebinds key material — which then no longer matches the vault, so every
+// synced item fails to decrypt and fails signature verification. Only a
+// confirmed null is allowed to trigger destructive cleanup.
+async function readKeyForIntegrity(
+  entry: KeychainEntry,
+  deviceId: string
+): Promise<{ transientError: true } | { transientError: false; key: Uint8Array | null }> {
+  try {
+    return { transientError: false, key: await retrieveKey(entry) }
+  } catch (err) {
+    logger.warn(
+      'Skipping sync integrity check — keychain read failed transiently. ' +
+        'NOT cleaning up local state (avoids a destructive re-auth on an uncertain read).',
+      {
+        deviceId,
+        service: entry.service,
+        error: err instanceof Error ? err.message : String(err)
+      }
+    )
+    return { transientError: true }
+  }
+}
+
 export async function checkSyncIntegrity(): Promise<void> {
   if (!isDatabaseInitialized()) {
     logger.debug('Skipping sync integrity check — no vault open')
@@ -74,8 +103,9 @@ export async function checkSyncIntegrity(): Promise<void> {
 
     if (!currentDevice) return
 
-    const masterKey = await retrieveKey(KEYCHAIN_ENTRIES.MASTER_KEY).catch(() => null)
-    if (!masterKey) {
+    const masterKeyRead = await readKeyForIntegrity(KEYCHAIN_ENTRIES.MASTER_KEY, currentDevice.id)
+    if (masterKeyRead.transientError) return
+    if (!masterKeyRead.key) {
       logger.error(
         'Detected orphaned device registration — master key missing from keychain. ' +
           'Cleaning up local state. User will need to re-authenticate.',
@@ -85,7 +115,12 @@ export async function checkSyncIntegrity(): Promise<void> {
       return
     }
 
-    const signingKey = await retrieveKey(KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY).catch(() => null)
+    const signingKeyRead = await readKeyForIntegrity(
+      KEYCHAIN_ENTRIES.DEVICE_SIGNING_KEY,
+      currentDevice.id
+    )
+    if (signingKeyRead.transientError) return
+    const signingKey = signingKeyRead.key
     if (!signingKey) {
       logger.error(
         'Signing key missing from keychain but device registered. ' +

--- a/apps/desktop/src/main/secrets/secret-storage.test.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.test.ts
@@ -277,6 +277,46 @@ describe('secret-storage', () => {
   // Deferred migration (vault master key)
   // --------------------------------------------------------------------------
 
+  // --------------------------------------------------------------------------
+  // False-absent protection (#772 vault-orphaning guard)
+  // --------------------------------------------------------------------------
+
+  describe('false-absent protection', () => {
+    it('throws instead of reporting absent when the secret exists in the store but safeStorage is unavailable this run', async () => {
+      // A migrated secret lives only in safeStorage (keytar copy already
+      // dropped). On a run where safeStorage cannot be read, returning null
+      // would be a false absence — the master-key path would regenerate a key
+      // and orphan the vault. Must fail loud instead.
+      await setSecret(SERVICE, ACCOUNT, 'store-value')
+      harness.keytarStore.clear()
+      harness.encryptionAvailable = false
+
+      await expect(getSecret(SERVICE, ACCOUNT)).rejects.toThrow(/could not be read this run/)
+    })
+
+    it('throws when the stored ciphertext is undecryptable and no keytar copy remains', async () => {
+      fs.mkdirSync(harness.userDataDir, { recursive: true })
+      fs.writeFileSync(
+        storeFilePath(),
+        JSON.stringify({ version: 1, entries: { [SERVICE]: { [ACCOUNT]: 'not-decryptable' } } }),
+        'utf-8'
+      )
+      harness.keytarStore.clear()
+
+      await expect(getSecret(SERVICE, ACCOUNT)).rejects.toThrow(/could not be read this run/)
+    })
+
+    it('still returns null for a genuinely fresh secret (nothing in store or keytar)', async () => {
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBeNull()
+    })
+
+    it('returns null (true absence) when the store is readable and the entry is simply not there', async () => {
+      seedStoreFile(SERVICE, 'other-account', 'other-value')
+
+      await expect(getSecret(SERVICE, ACCOUNT)).resolves.toBeNull()
+    })
+  })
+
   describe('deferred keytar delete', () => {
     it('persists the migrated secret but keeps the keytar copy until finalize', async () => {
       harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'master-key-material')

--- a/apps/desktop/src/main/secrets/secret-storage.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.ts
@@ -210,7 +210,8 @@ export async function getSecret(
   account: string,
   options?: GetSecretOptions
 ): Promise<string | null> {
-  const filePath = isSafeStorageAvailable() ? resolveStoreFilePath() : null
+  const storePath = resolveStoreFilePath()
+  const filePath = isSafeStorageAvailable() ? storePath : null
 
   if (filePath) {
     const ciphertext = readCiphertext(filePath, service, account)
@@ -233,10 +234,36 @@ export async function getSecret(
   }
 
   const legacy = await keytar.getPassword(service, account)
-  if (legacy === null || filePath === null) return legacy
+  if (legacy !== null) {
+    if (filePath !== null) {
+      await migrateLegacySecret(
+        filePath,
+        service,
+        account,
+        legacy,
+        options?.deferKeytarDelete === true
+      )
+    }
+    return legacy
+  }
 
-  await migrateLegacySecret(filePath, service, account, legacy, options?.deferKeytarDelete === true)
-  return legacy
+  // keytar is empty. Before reporting the secret as ABSENT, make sure it isn't
+  // merely UNREADABLE this run: if a safeStorage entry for it still exists on
+  // disk but we couldn't read a value above (safeStorage unavailable this run,
+  // or the stored ciphertext was undecryptable), `null` means "can't read", not
+  // "not there". A false absence is dangerous — destructive callers act on it:
+  // vault-key-state.ts regenerates the vault master key and sync-core-handlers.ts
+  // tears down local sync state, both of which permanently orphan the vault from
+  // its encrypted data. This is the failure mode behind the #772 keytar→
+  // safeStorage regression. Fail loud so the caller retries on a healthy run.
+  if (storePath !== null && readCiphertext(storePath, service, account) !== null) {
+    throw new Error(
+      `Secret ${service}/${account} exists in the secret store but could not be read this run; ` +
+        'refusing to report it as absent'
+    )
+  }
+
+  return null
 }
 
 export async function setSecret(service: string, account: string, value: string): Promise<void> {


### PR DESCRIPTION
## SEV — production vault lockout (MemryNote 2026.717.x)

Regression from #772 (keytar → safeStorage secret storage). Symptoms: remote-vault download shows *"All items failed with crypto errors — possible vault key mismatch"*, the sidebar shows a sync error, sync reports "completed" but the downloaded vault is **empty**; a repeating *"A sync item failed signature verification and will be retried"* toast.

### Root cause
`secret-storage.ts getSecret()` reads safeStorage first and drops the keytar copies after migrating. When a persisted secret is **transiently unreadable** (safeStorage unavailable that run, or the stored ciphertext won't decrypt), `getSecret()` returned `null` — a **false "absent"**. Destructive callers act on that:

- `getOrInitializeLocalVaultKey()` **regenerates a new random master key**,
- `checkSyncIntegrity()` **tears down local sync state**,

and `bindLocalVaultToMasterKey()` then rebinds the verifier to the wrong key so it "passes" while the real items (encrypted under the original master key) fail to decrypt. Confirmed in production logs: a successful `Pull page … applied: 2` immediately before the #772 migration ran, then `Current master key does not match this vault` and all-items crypto failures. Core item crypto (encryption, key derivation, CBOR order) is unchanged, so this is a secret-storage-layer regression only.

### Fix
- **`getSecret`**: if a secret still exists in the on-disk store but could not be read this run, **throw** ("could not be read this run") instead of reporting a false absence. A genuinely fresh secret (no store entry, no keytar copy) still returns `null`. This makes `retrieveKey(MASTER_KEY)` fail loud so the master key can never be regenerated on an uncertain read.
- **`checkSyncIntegrity`**: a thrown (transient) key read now skips the check with **no teardown**; only a confirmed-null triggers cleanup.

### Safety / compat
- Server data is unaffected (still correctly encrypted); this only restores correct local key handling.
- Genuinely-fresh installs and Linux basic_text (keytar-authoritative) paths are preserved.

### Tests
- `secret-storage.test.ts` +4 (false-absent protection), `sync-core-handlers.test.ts` +2.
- 60/60 main tests green; typecheck:node + eslint + `git diff --check` clean.
- Both fixes **mutation-proven** (reverting the guard makes the new tests fail).

### Follow-up (separate)
- Recovery routine for installs already orphaned by the broken release (detect mismatch → re-derive master key from recovery phrase + server salt, validate against server verifier, rebind). The crypto backend (`recoverMasterKeyFromPhrase` / `validateKeyVerifier`) already exists; #508 removed the recovery-phrase entry UI, which needs re-exposing.