### PR TITLE
feat(sync): recover an orphaned vault via the recovery phrase

### DIFF
--- a/apps/desktop/src/main/crypto/vault-key-error.test.ts
+++ b/apps/desktop/src/main/crypto/vault-key-error.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyVaultKeyError, vaultRecoveryReason } from './vault-key-error'
+
+describe('classifyVaultKeyError', () => {
+  it('flags a master-key/vault mismatch as recovery-needed', () => {
+    expect(classifyVaultKeyError(new Error('Current master key does not match this vault'))).toBe(
+      'recovery-needed'
+    )
+  })
+
+  it('flags a missing master key with an existing verifier as recovery-needed', () => {
+    expect(
+      classifyVaultKeyError(new Error('Vault key verifier exists but master key is missing'))
+    ).toBe('recovery-needed')
+  })
+
+  it('flags a transiently unreadable secret as transient, NOT recovery-needed', () => {
+    // secret-storage.ts throws this when a persisted secret can't be read this
+    // run — retrying is correct; prompting recovery would be wrong.
+    expect(
+      classifyVaultKeyError(
+        new Error(
+          'Secret com.memry.sync/master-key exists in the secret store but could not be read this run; refusing to report it as absent'
+        )
+      )
+    ).toBe('transient')
+  })
+
+  it('treats unrelated errors as other', () => {
+    expect(classifyVaultKeyError(new Error('network down'))).toBe('other')
+    expect(classifyVaultKeyError('not an error object')).toBe('other')
+  })
+
+  it('maps the reason for the renderer event', () => {
+    expect(vaultRecoveryReason(new Error('Current master key does not match this vault'))).toBe(
+      'vault-key-mismatch'
+    )
+    expect(
+      vaultRecoveryReason(new Error('Vault key verifier exists but master key is missing'))
+    ).toBe('master-key-missing')
+  })
+})

--- a/apps/desktop/src/main/crypto/vault-key-error.ts
+++ b/apps/desktop/src/main/crypto/vault-key-error.ts
@@ -1,0 +1,42 @@
+import type { VaultRecoveryNeededEvent } from '@memry/contracts/ipc-events'
+
+/**
+ * Classifies a vault-key verification failure so the sync runtime can react
+ * correctly:
+ *
+ * - `recovery-needed`: the device holds a master key that cannot decrypt this
+ *   vault, or the master key is gone while a verifier still exists. The user
+ *   must re-derive the correct master key (recovery phrase / re-link). Surface a
+ *   recovery prompt.
+ * - `transient`: a secret could not be read this run (safeStorage unavailable,
+ *   or an undecryptable ciphertext). Do NOT prompt recovery — the read may
+ *   succeed on the next healthy run. See secrets/secret-storage.ts getSecret.
+ * - `other`: anything else; treat as a generic sync failure.
+ *
+ * Matches on the thrown Error messages from crypto/vault-key-state.ts and
+ * secrets/secret-storage.ts. Kept as a pure string classifier so it can be unit
+ * tested without the keychain, database, or native modules.
+ */
+export type VaultKeyErrorKind = 'recovery-needed' | 'transient' | 'other'
+
+export function classifyVaultKeyError(error: unknown): VaultKeyErrorKind {
+  const message = error instanceof Error ? error.message : String(error)
+
+  if (message.includes('could not be read this run')) {
+    return 'transient'
+  }
+
+  if (
+    message.includes('does not match this vault') ||
+    message.includes('verifier exists but master key is missing')
+  ) {
+    return 'recovery-needed'
+  }
+
+  return 'other'
+}
+
+export function vaultRecoveryReason(error: unknown): VaultRecoveryNeededEvent['reason'] {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes('master key is missing') ? 'master-key-missing' : 'vault-key-mismatch'
+}

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -51,7 +51,12 @@ import { CrdtUpdateQueue } from './crdt-queue'
 import { recoverDirtyItems } from './dirty-recovery'
 import { encryptCrdtUpdate } from './crdt-encrypt'
 import { postToServer, pushCrdtSnapshot, SyncServerError } from './http-client'
-import { EVENT_CHANNELS, type SyncStatusChangedEvent } from '@memry/contracts/ipc-events'
+import {
+  EVENT_CHANNELS,
+  type SyncStatusChangedEvent,
+  type VaultRecoveryNeededEvent
+} from '@memry/contracts/ipc-events'
+import { classifyVaultKeyError, vaultRecoveryReason } from '../crypto/vault-key-error'
 import { withRetry } from './retry'
 import { withAuthRetry, type AuthRetryDeps } from './auth-retry'
 import {
@@ -82,6 +87,12 @@ interface SyncRuntimeState {
 
 function getVerifiedVaultKey(db: DataDb): Promise<Uint8Array> {
   return getOrInitializeLocalVaultKey(db, getOrCreateVaultUuid(db))
+}
+
+function emitVaultRecoveryNeeded(event: VaultRecoveryNeededEvent): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(EVENT_CHANNELS.VAULT_RECOVERY_NEEDED, event)
+  }
 }
 
 function emitSyncStatus(event: SyncStatusChangedEvent): void {
@@ -226,6 +237,13 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         vaultKeyFailureLogged = false
       } catch (error) {
         log.error('Sync runtime unavailable: vault key verification failed', error)
+        // A persistent mismatch (wrong or missing master key) can't be retried
+        // away — prompt the user to recover the correct key instead of leaving
+        // them at a generic "sync unavailable" error. A transient unreadable
+        // secret is NOT surfaced here; it retries on the next healthy run.
+        if (classifyVaultKeyError(error) === 'recovery-needed') {
+          emitVaultRecoveryNeeded({ reason: vaultRecoveryReason(error) })
+        }
         return null
       } finally {
         if (startupVaultKey) secureCleanup(startupVaultKey)

--- a/apps/desktop/src/preload/api/preload-api.test.ts
+++ b/apps/desktop/src/preload/api/preload-api.test.ts
@@ -1015,6 +1015,10 @@ describe('preload api wrappers', () => {
       () => syncEvents.onCertificatePinFailed(callback),
       SYNC_EVENTS.CERTIFICATE_PIN_FAILED
     )
+    expectSubscribe(
+      () => syncEvents.onVaultRecoveryNeeded(callback),
+      SYNC_EVENTS.VAULT_RECOVERY_NEEDED
+    )
     expectSubscribe(() => onCrdtStateChanged(callback), SYNC_EVENTS.STATE_CHANGED)
     expectSubscribe(
       () => updaterEvents.onUpdaterStateChanged(callback),

--- a/apps/desktop/src/preload/api/sync-events.ts
+++ b/apps/desktop/src/preload/api/sync-events.ts
@@ -20,7 +20,8 @@ import type {
   ClockSkewWarningEvent,
   DeviceRevokedEvent,
   SecurityWarningEvent,
-  CertificatePinFailedEvent
+  CertificatePinFailedEvent,
+  VaultRecoveryNeededEvent
 } from '@memry/contracts/ipc-sync'
 import { subscribe } from '../lib/ipc'
 
@@ -88,5 +89,8 @@ export const syncEvents = {
     subscribe<SecurityWarningEvent>(SYNC_EVENTS.SECURITY_WARNING, callback),
 
   onCertificatePinFailed: (callback: (event: CertificatePinFailedEvent) => void): (() => void) =>
-    subscribe<CertificatePinFailedEvent>(SYNC_EVENTS.CERTIFICATE_PIN_FAILED, callback)
+    subscribe<CertificatePinFailedEvent>(SYNC_EVENTS.CERTIFICATE_PIN_FAILED, callback),
+
+  onVaultRecoveryNeeded: (callback: (event: VaultRecoveryNeededEvent) => void): (() => void) =>
+    subscribe<VaultRecoveryNeededEvent>(SYNC_EVENTS.VAULT_RECOVERY_NEEDED, callback)
 }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -59,7 +59,8 @@ import type {
   ClockSkewWarningEvent,
   DeviceRevokedEvent,
   SecurityWarningEvent,
-  CertificatePinFailedEvent
+  CertificatePinFailedEvent,
+  VaultRecoveryNeededEvent
 } from '../shared/contracts/ipc-sync'
 import type { CrdtOpenDocResult, CrdtSyncStep1Result } from '@memry/contracts/ipc-crdt'
 
@@ -1879,6 +1880,7 @@ interface API extends WindowAPI, GeneratedRpcApi {
   onClockSkewWarning: (callback: (event: ClockSkewWarningEvent) => void) => () => void
   onSecurityWarning: (callback: (event: SecurityWarningEvent) => void) => () => void
   onCertificatePinFailed: (callback: (event: CertificatePinFailedEvent) => void) => () => void
+  onVaultRecoveryNeeded: (callback: (event: VaultRecoveryNeededEvent) => void) => () => void
   onUpdaterStateChanged: (callback: (state: AppUpdateState) => void) => () => void
   onImportProgress: (callback: (event: ImportProgressEvent) => void) => () => void
   onAppNavigationCommand: (callback: (command: AppNavigationCommandEvent) => void) => () => void

--- a/apps/desktop/src/renderer/src/components/sync/vault-recovery-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/vault-recovery-dialog.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  linkViaRecovery: vi.fn()
+}))
+
+vi.mock('@/contexts/auth-context', () => ({
+  useAuth: () => ({ linkViaRecovery: hoisted.linkViaRecovery })
+}))
+
+// Stub RecoveryPhraseInput so the test can drive submit/back/error deterministically
+// without reproducing its 24-word validation UI.
+vi.mock('./recovery-phrase-input', () => ({
+  RecoveryPhraseInput: ({
+    onSubmit,
+    isLoading,
+    error,
+    onBack
+  }: {
+    onSubmit: (phrase: string) => void
+    isLoading: boolean
+    error: string | null
+    onBack: () => void
+  }) => (
+    <div>
+      <button onClick={() => onSubmit('valid recovery phrase')}>submit-phrase</button>
+      <button onClick={onBack}>back</button>
+      {isLoading && <span>loading</span>}
+      {error && <span data-testid="phrase-error">{error}</span>}
+    </div>
+  )
+}))
+
+import { VaultRecoveryDialog } from './vault-recovery-dialog'
+
+const openInput = (): void => {
+  fireEvent.click(screen.getByRole('button', { name: 'Enter recovery phrase' }))
+}
+
+describe('VaultRecoveryDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when closed', () => {
+    render(
+      <VaultRecoveryDialog
+        open={false}
+        onRecovered={vi.fn()}
+        onDismiss={vi.fn()}
+        onSignOut={vi.fn()}
+      />
+    )
+    expect(screen.queryByText(/open your vault/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the intro and dismisses via Later', () => {
+    const onDismiss = vi.fn()
+    render(
+      <VaultRecoveryDialog open onRecovered={vi.fn()} onDismiss={onDismiss} onSignOut={vi.fn()} />
+    )
+    expect(screen.getByText(/open your vault/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Later' }))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('recovers: submitting the phrase calls linkViaRecovery, then onRecovered on success', async () => {
+    hoisted.linkViaRecovery.mockResolvedValueOnce({ deviceId: 'dev-1' })
+    const onRecovered = vi.fn()
+    render(
+      <VaultRecoveryDialog open onRecovered={onRecovered} onDismiss={vi.fn()} onSignOut={vi.fn()} />
+    )
+
+    openInput()
+    fireEvent.click(screen.getByRole('button', { name: 'submit-phrase' }))
+
+    await waitFor(() =>
+      expect(hoisted.linkViaRecovery).toHaveBeenCalledWith('valid recovery phrase')
+    )
+    await waitFor(() => expect(onRecovered).toHaveBeenCalledTimes(1))
+  })
+
+  it('offers re-auth when the setup token has expired', async () => {
+    hoisted.linkViaRecovery.mockRejectedValueOnce(
+      new Error('Session expired. Please sign in again.')
+    )
+    const onSignOut = vi.fn()
+    const onRecovered = vi.fn()
+    render(
+      <VaultRecoveryDialog
+        open
+        onRecovered={onRecovered}
+        onDismiss={vi.fn()}
+        onSignOut={onSignOut}
+      />
+    )
+
+    openInput()
+    fireEvent.click(screen.getByRole('button', { name: 'submit-phrase' }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('phrase-error')).toHaveTextContent(/session expired/i)
+    )
+    expect(onRecovered).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in again' }))
+    expect(onSignOut).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces a wrong-phrase error without recovering or offering re-auth', async () => {
+    hoisted.linkViaRecovery.mockRejectedValueOnce(
+      new Error('Recovery phrase does not match. Please try again.')
+    )
+    const onRecovered = vi.fn()
+    render(
+      <VaultRecoveryDialog open onRecovered={onRecovered} onDismiss={vi.fn()} onSignOut={vi.fn()} />
+    )
+
+    openInput()
+    fireEvent.click(screen.getByRole('button', { name: 'submit-phrase' }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('phrase-error')).toHaveTextContent(/does not match/i)
+    )
+    expect(onRecovered).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: 'Sign in again' })).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/sync/vault-recovery-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/vault-recovery-dialog.tsx
@@ -1,0 +1,126 @@
+import { useState, useCallback } from 'react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { AlertTriangle } from '@/lib/icons'
+import { useAuth } from '@/contexts/auth-context'
+import { RecoveryPhraseInput } from './recovery-phrase-input'
+
+interface VaultRecoveryDialogProps {
+  open: boolean
+  onRecovered: () => void
+  onDismiss: () => void
+  onSignOut: () => void
+}
+
+/**
+ * Shown when the sync runtime detects that this device holds key material that
+ * cannot decrypt the vault (VAULT_RECOVERY_NEEDED). Drives the existing
+ * recovery-phrase flow (auth linkViaRecovery -> LINK_VIA_RECOVERY) to re-derive
+ * the correct master key from the recovery phrase, validated against the server
+ * verifier. If the setup token has expired, linkViaRecovery reports it and the
+ * user is offered a re-authentication path.
+ */
+export function VaultRecoveryDialog({
+  open,
+  onRecovered,
+  onDismiss,
+  onSignOut
+}: VaultRecoveryDialogProps): React.JSX.Element {
+  const { linkViaRecovery } = useAuth()
+  const [phase, setPhase] = useState<'intro' | 'input'>('intro')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [sessionExpired, setSessionExpired] = useState(false)
+
+  const handleSubmit = useCallback(
+    async (phrase: string) => {
+      setIsLoading(true)
+      setError(null)
+      setSessionExpired(false)
+      try {
+        await linkViaRecovery(phrase)
+        onRecovered()
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        if (/sign in again|session expired/i.test(message)) {
+          setSessionExpired(true)
+        }
+        setError(message)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [linkViaRecovery, onRecovered]
+  )
+
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent className="sm:max-w-md">
+        {phase === 'intro' ? (
+          <>
+            <AlertDialogHeader>
+              <div className="flex items-center gap-3 mb-1">
+                <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-amber-500/10 dark:bg-amber-400/10">
+                  <AlertTriangle
+                    className="w-5 h-5 text-amber-600 dark:text-amber-400"
+                    aria-hidden="true"
+                  />
+                </div>
+                <AlertDialogTitle className="font-display text-xl tracking-tight">
+                  {'This device can’t open your vault'}
+                </AlertDialogTitle>
+              </div>
+              <AlertDialogDescription className="font-serif text-[15px] leading-relaxed">
+                {
+                  'The key on this device no longer matches your vault, so its items can’t be decrypted. Your data is safe on the server. Enter your recovery phrase to restore the correct key, or sign in again on a device that still has it.'
+                }
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter className="gap-2 sm:gap-0">
+              <Button variant="outline" onClick={onDismiss}>
+                {'Later'}
+              </Button>
+              <Button
+                onClick={() => {
+                  setError(null)
+                  setSessionExpired(false)
+                  setPhase('input')
+                }}
+              >
+                {'Enter recovery phrase'}
+              </Button>
+            </AlertDialogFooter>
+          </>
+        ) : (
+          <>
+            <AlertDialogHeader>
+              <AlertDialogTitle className="font-display text-xl tracking-tight">
+                {'Restore your vault key'}
+              </AlertDialogTitle>
+            </AlertDialogHeader>
+            <RecoveryPhraseInput
+              onSubmit={(phrase) => void handleSubmit(phrase)}
+              isLoading={isLoading}
+              error={error}
+              onBack={() => setPhase('intro')}
+            />
+            {sessionExpired && (
+              <AlertDialogFooter>
+                <Button variant="outline" onClick={onSignOut}>
+                  {'Sign in again'}
+                </Button>
+              </AlertDialogFooter>
+            )}
+          </>
+        )}
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
@@ -25,6 +25,7 @@ let sessionExpiredListeners: VoidCallback[] = []
 let deviceRevokedListeners: EventCallback[] = []
 let securityWarningListeners: EventCallback[] = []
 let certificatePinFailedListeners: VoidCallback[] = []
+let vaultRecoveryNeededListeners: EventCallback[] = []
 let i18n: I18nInstance
 
 const toastMock = vi.hoisted(() => ({
@@ -113,6 +114,7 @@ beforeEach(async () => {
   deviceRevokedListeners = []
   securityWarningListeners = []
   certificatePinFailedListeners = []
+  vaultRecoveryNeededListeners = []
   logoutMock.mockClear()
   vi.mocked(useAuth).mockReturnValue({
     state: { status: 'authenticated' },
@@ -221,6 +223,12 @@ beforeEach(async () => {
     certificatePinFailedListeners.push(cb)
     return () => {
       certificatePinFailedListeners = certificatePinFailedListeners.filter((l) => l !== cb)
+    }
+  })
+  api.onVaultRecoveryNeeded = vi.fn((cb: EventCallback) => {
+    vaultRecoveryNeededListeners.push(cb)
+    return () => {
+      vaultRecoveryNeededListeners = vaultRecoveryNeededListeners.filter((l) => l !== cb)
     }
   })
 })

--- a/apps/desktop/src/renderer/src/contexts/sync-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.tsx
@@ -13,7 +13,12 @@ import { toast } from 'sonner'
 import { useAuth } from './auth-context'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { DeviceRevokedDialog } from '@/components/sync/device-revoked-dialog'
-import type { InitialSyncPhase, LinkingRequestEvent } from '@memry/contracts/ipc-events'
+import { VaultRecoveryDialog } from '@/components/sync/vault-recovery-dialog'
+import type {
+  InitialSyncPhase,
+  LinkingRequestEvent,
+  VaultRecoveryNeededEvent
+} from '@memry/contracts/ipc-events'
 import { useT } from '@memry/i18n/renderer'
 
 type SyncStatus = 'idle' | 'syncing' | 'paused' | 'error' | 'offline' | 'unknown'
@@ -188,6 +193,8 @@ interface SyncContextValue {
   linkingRequest: LinkingRequestEvent | null
   clearLinkingRequest: () => void
   dismissDeviceRevoked: () => void
+  vaultRecovery: VaultRecoveryNeededEvent | null
+  clearVaultRecovery: () => void
 }
 
 const SyncContext = createContext<SyncContextValue | null>(null)
@@ -210,6 +217,7 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
   const { t: tSettings } = useT('settings')
   const [state, dispatch] = useReducer(syncReducer, initialState)
   const [linkingRequest, setLinkingRequest] = useState<LinkingRequestEvent | null>(null)
+  const [vaultRecovery, setVaultRecovery] = useState<VaultRecoveryNeededEvent | null>(null)
   const sessionExpiredRef = useRef(state.sessionExpired)
   useEffect(() => {
     sessionExpiredRef.current = state.sessionExpired
@@ -414,6 +422,13 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
       })
     )
 
+    cleanups.push(
+      window.api.onVaultRecoveryNeeded((event) => {
+        if (cancelled) return
+        setVaultRecovery(event)
+      })
+    )
+
     return () => {
       cancelled = true
       for (const cleanup of cleanups) cleanup()
@@ -466,6 +481,10 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
     dispatch({ type: 'RESET' })
   }, [])
 
+  const clearVaultRecovery = useCallback(() => {
+    setVaultRecovery(null)
+  }, [])
+
   const value = useMemo<SyncContextValue>(
     () => ({
       state,
@@ -475,7 +494,9 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
       clearError,
       linkingRequest,
       clearLinkingRequest,
-      dismissDeviceRevoked
+      dismissDeviceRevoked,
+      vaultRecovery,
+      clearVaultRecovery
     }),
     [
       state,
@@ -485,7 +506,9 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
       clearError,
       linkingRequest,
       clearLinkingRequest,
-      dismissDeviceRevoked
+      dismissDeviceRevoked,
+      vaultRecovery,
+      clearVaultRecovery
     ]
   )
 
@@ -497,6 +520,12 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
     void logout()
   }, [logout])
 
+  const handleVaultRecovered = useCallback(() => {
+    setVaultRecovery(null)
+    toast.success(t('sync.vaultRecovered'), { duration: 6000 })
+    void window.api.syncOps.triggerSync().catch(() => {})
+  }, [t])
+
   return (
     <SyncContext.Provider value={value}>
       {children}
@@ -504,6 +533,12 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
         open={state.deviceRevoked !== null}
         unsyncedCount={state.deviceRevoked?.unsyncedCount ?? 0}
         onExport={handleDeviceRevokedExport}
+        onSignOut={handleDeviceRevokedSignOut}
+      />
+      <VaultRecoveryDialog
+        open={vaultRecovery !== null}
+        onRecovered={handleVaultRecovered}
+        onDismiss={clearVaultRecovery}
         onSignOut={handleDeviceRevokedSignOut}
       />
     </SyncContext.Provider>

--- a/packages/contracts/src/ipc-events.ts
+++ b/packages/contracts/src/ipc-events.ts
@@ -29,7 +29,8 @@ export const EVENT_CHANNELS = {
   ITEM_RECOVERED: 'sync:item-recovered',
   ITEM_CORRUPT: 'sync:item-corrupt',
   SECURITY_WARNING: 'sync:security-warning',
-  CERTIFICATE_PIN_FAILED: 'sync:certificate-pin-failed'
+  CERTIFICATE_PIN_FAILED: 'sync:certificate-pin-failed',
+  VAULT_RECOVERY_NEEDED: 'sync:vault-recovery-needed'
 } as const
 
 // ============================================================================
@@ -191,4 +192,16 @@ export interface CertificatePinFailedEvent {
   hostname: string
   actualHash: string
   expectedHashes: string[]
+}
+
+/**
+ * The local device holds key material that cannot decrypt this vault — its
+ * master key no longer matches (`vault-key-mismatch`), or the master key is gone
+ * while a verifier still exists (`master-key-missing`). The renderer surfaces a
+ * recovery prompt (re-derive the master key from the recovery phrase) rather
+ * than a generic sync error. Only emitted for a persistent mismatch, never for
+ * a transient unreadable-secret failure (which just retries).
+ */
+export interface VaultRecoveryNeededEvent {
+  reason: 'vault-key-mismatch' | 'master-key-missing'
 }

--- a/packages/i18n/src/locales/en/errors.json
+++ b/packages/i18n/src/locales/en/errors.json
@@ -76,6 +76,7 @@
     "settingsNotInitialized": "Settings sync not initialized",
     "securityQuarantinePermanent": "A sync item could not be verified and has been quarantined for security.",
     "securityQuarantineRetry": "A sync item failed signature verification and will be retried.",
-    "certificatePinPaused": "Secure connection to sync server could not be verified. Syncing has been paused for your protection."
+    "certificatePinPaused": "Secure connection to sync server could not be verified. Syncing has been paused for your protection.",
+    "vaultRecovered": "Vault key restored. Syncing will resume."
   }
 }


### PR DESCRIPTION
## Follow-up to #784 — heal installs already orphaned by the #772 regression

#784 stops NEW breakage. This lets a device whose local master key no longer matches the vault recover, instead of sitting at a generic "sync unavailable" error.

### Flow
- **Detect** (main): when `getVerifiedVaultKey` fails at sync-runtime start, `classifyVaultKeyError` distinguishes a **persistent mismatch** (`does not match this vault` / `verifier exists but master key is missing` → recovery-needed) from a **transient** unreadable-secret failure (`could not be read this run` → retry, never prompt). On a persistent mismatch, emit `VAULT_RECOVERY_NEEDED`.
- **Prompt** (renderer): `VaultRecoveryDialog` (mounted in `SyncProvider`) shows a recovery prompt and drives the **existing** recovery-phrase flow — `auth.linkViaRecovery` → `LINK_VIA_RECOVERY`, which re-derives the master key from the recovery phrase + server `kdfSalt` (`recoverMasterKeyFromPhrase`) and validates it against the server verifier (`validateKeyVerifier`) before rebinding. On success, sync resumes.
- **Re-auth fallback**: if the setup token has expired, `linkViaRecovery` reports it and the dialog offers "Sign in again".

### Why it's safe / recoverable
Server ciphertext is untouched. The master key is deterministically re-derivable from the recovery phrase + server salt, so the correct key can always be restored (given the phrase). Reuses the intact `RecoveryPhraseInput` component; #508 only removed the settings recovery-key dialog, not this flow.

### Tests / checks
- `vault-key-error.test.ts` (classifier, 5 cases: mismatch/missing → recovery-needed, `could not be read this run` → transient, else other).
- `preload-api.test.ts` +1 (subscription coverage for the new event).
- typecheck web + node, ipc:check, i18n:check, eslint all green.

### Notes
- Dialog copy is inline English (consistent with `DeviceRevokedDialog`); can be moved to i18n keys if desired.
- Manual recovery works today without this PR: sign out → sign in → recover with recovery phrase. This just makes it discoverable from the orphaned state.