### PR TITLE
fix(vercel): deploy landing/docs only on main when their files change

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,8 +1,9 @@
 {
+  "installCommand": "SKIP_ELECTRON_REBUILD=1 pnpm install --frozen-lockfile",
+  "ignoreCommand": "if [ \"$VERCEL_ENV\" != \"production\" ]; then exit 0; fi; git diff --quiet HEAD^ HEAD -- .",
   "git": {
     "deploymentEnabled": {
-      "main": true,
-      "*": false
+      "main": true
     }
   },
   "trailingSlash": false,

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,10 @@
 {
   "cleanUrls": true,
+  "installCommand": "SKIP_ELECTRON_REBUILD=1 pnpm install --frozen-lockfile",
+  "ignoreCommand": "if [ \"$VERCEL_ENV\" != \"production\" ]; then exit 0; fi; git diff --quiet HEAD^ HEAD -- apps/docs vercel.json",
   "git": {
     "deploymentEnabled": {
-      "main": true,
-      "*": false
+      "main": true
     }
   },
   "redirects": [


### PR DESCRIPTION
## What
- `ignoreCommand` on landing + docs: skip preview (PR) deploys, and skip production deploys when that app's own files are unchanged.
- `installCommand` with `SKIP_ELECTRON_REBUILD=1`: stop the workspace install failing on desktop's better-sqlite3 electron-rebuild.
- Drop the `"*"` `deploymentEnabled` key — it is a literal branch name, not a wildcard, so it never disabled PR previews.

## Why
Every merge to main redeployed landing/docs for unrelated desktop/sync changes, PR branches deployed failing previews, and every deploy since the Electron 43 bump (#765) errored on `pnpm install`.