### PR TITLE
fix(sync-server): include item_type in R2 blob keys to stop cross-type payload clobbering

### DIFF
--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -81,6 +81,17 @@ Every domain object syncs as a `sync_item`. The server sees:
 
 The blob is the encrypted body. The server can reason about order, dedupe, and authorize writes — but the contents stay opaque.
 
+### Blob key layout
+
+Item ids are human-readable and may repeat across types: the default project id is `inbox`, a
+`tag_definition` id is the lowercased tag name, and a `folder_config` id is the folder path. R2 keys
+for sync-item payloads therefore include the item type — new pushes write to
+`<user>/vaults/<vault>/items-v2/<type>/<id>`, so a project and a tag both named `inbox` own separate
+objects. Rows written before this layout keep their legacy untyped `items/<id>` key; every read path
+resolves the `blob_key` stored on the row rather than re-deriving it, so old rows continue to work
+without a migration. (The old layout let same-id items of different types overwrite one shared
+object, which permanently broke the losing row's signature.)
+
 ## Sync Type Negotiation
 
 Clients declare the record sync item types they understand via an `X-Memry-Sync-Types` header

--- a/apps/sync-server/src/services/blob.test.ts
+++ b/apps/sync-server/src/services/blob.test.ts
@@ -4,6 +4,7 @@ import { AppError, ErrorCodes } from '../lib/errors'
 
 import {
   generateBlobKey,
+  generateItemBlobKey,
   generateCrdtKey,
   generateAttachmentManifestKey,
   generateAttachmentChunkKey,
@@ -45,6 +46,28 @@ describe('generateBlobKey', () => {
     expect(generateBlobKey('user-1', 'item-1', 'vault-1')).toBe(
       'user-1/vaults/vault-1/items/item-1'
     )
+  })
+})
+
+describe('generateItemBlobKey', () => {
+  it('should create type-scoped item key', () => {
+    expect(generateItemBlobKey('user-1', 'task', 'item-1', 'vault-1')).toBe(
+      'user-1/vaults/vault-1/items-v2/task/item-1'
+    )
+  })
+
+  it('should give distinct keys to same-id items of different types', () => {
+    const projectKey = generateItemBlobKey('user-1', 'project', 'inbox', 'vault-1')
+    const tagKey = generateItemBlobKey('user-1', 'tag_definition', 'inbox', 'vault-1')
+    expect(projectKey).not.toBe(tagKey)
+  })
+
+  it('should never collide with the legacy untyped namespace, even for slash-containing ids', () => {
+    // folder_config ids are folder paths and may contain slashes; a legacy key
+    // like items/task/x must not equal a typed key for task 'x'.
+    const legacyNestedFolder = generateBlobKey('user-1', 'task/x', 'vault-1')
+    const typedTask = generateItemBlobKey('user-1', 'task', 'x', 'vault-1')
+    expect(legacyNestedFolder).not.toBe(typedTask)
   })
 })
 

--- a/apps/sync-server/src/services/blob.ts
+++ b/apps/sync-server/src/services/blob.ts
@@ -3,6 +3,23 @@ import { AppError, ErrorCodes } from '../lib/errors'
 export const generateBlobKey = (userId: string, itemId: string, vaultId = 'default'): string =>
   `${userId}/vaults/${vaultId}/items/${itemId}`
 
+// Sync-item payload keys must include the item type: item ids are human-readable
+// and collide across types by design (default project id 'inbox', tag_definition
+// id = lowercased tag name, folder_config id = folder path), so an untyped key
+// makes a project and a tag named 'inbox' overwrite ONE R2 object while D1 keeps
+// two rows — the losing row's signature can never verify again and its payload
+// is silently destroyed. The 'items-v2' segment keeps the typed namespace fully
+// disjoint from legacy untyped keys (folder_config ids may contain slashes, so
+// nesting types under 'items/' could still collide with an old key). Reads are
+// unaffected: every consumer reads the per-row stored blob_key, never re-derives
+// it, so legacy rows keep resolving to their old untyped objects.
+export const generateItemBlobKey = (
+  userId: string,
+  itemType: string,
+  itemId: string,
+  vaultId = 'default'
+): string => `${userId}/vaults/${vaultId}/items-v2/${itemType}/${itemId}`
+
 export const generateCrdtKey = (userId: string, noteId: string, vaultId = 'default'): string =>
   `${userId}/vaults/${vaultId}/crdt/${noteId}/snapshot`
 

--- a/apps/sync-server/src/services/sync.test.ts
+++ b/apps/sync-server/src/services/sync.test.ts
@@ -4,8 +4,8 @@ import type { PushItemInput, VectorClock } from '@memry/contracts/sync-api'
 import { LEGACY_RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
 import { AppError, ErrorCodes } from '../lib/errors'
 
-vi.mock('./blob', () => ({
-  generateBlobKey: vi.fn().mockReturnValue('user-1/vaults/default/items/item-1'),
+vi.mock('./blob', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./blob')>()),
   putBlob: vi.fn().mockResolvedValue({ etag: 'etag-1' }),
   getBlob: vi.fn()
 }))
@@ -56,7 +56,7 @@ import {
   processPushItem
 } from './sync'
 import { getDevice } from './device'
-import { getBlob } from './blob'
+import { getBlob, putBlob } from './blob'
 import { reserveStorage, checkQuota } from './quota'
 import { getNextCursor } from './cursor'
 
@@ -1752,6 +1752,47 @@ describe('processPushItem', () => {
     expect(upsertStmt.bind).toHaveBeenCalled()
     const bindArgs = upsertStmt.bind.mock.calls[0]
     expect(bindArgs[16]).toBe(123456)
+  })
+
+  it('should write the payload to a type-scoped blob key so same-id items of different types never clobber each other', async () => {
+    // Regression for the cross-type R2 collision: a project and a tag_definition
+    // both named 'inbox' used to share ONE untyped blob key, so the later push
+    // silently destroyed the other type's ciphertext and its signature could
+    // never verify again.
+    const runPush = async (type: PushItemInput['type']) => {
+      const selectStmt = createMockStatement()
+      selectStmt.first.mockResolvedValue(null)
+      const upsertStmt = createMockStatement()
+      const updateStmt = createMockStatement()
+      const db = createMockDb()
+      db.prepare
+        .mockReturnValueOnce(selectStmt)
+        .mockReturnValueOnce(upsertStmt)
+        .mockReturnValueOnce(updateStmt)
+      const storage = {
+        put: vi.fn().mockResolvedValue({ etag: 'etag-1' })
+      } as unknown as R2Bucket
+      const result = await processPushItem(
+        db as unknown as D1Database,
+        storage,
+        'user-1',
+        'device-1',
+        createValidPushItem({ id: 'inbox', type, clock: { 'device-1': 1 } }),
+        'vault-1'
+      )
+      expect(result.accepted).toBe(true)
+      const putKey = vi.mocked(putBlob).mock.lastCall?.[1] as string
+      const boundBlobKey = upsertStmt.bind.mock.calls[0][5] as string
+      expect(boundBlobKey).toBe(putKey)
+      return putKey
+    }
+
+    const projectKey = await runPush('project')
+    const tagKey = await runPush('tag_definition')
+
+    expect(projectKey).toBe('user-1/vaults/vault-1/items-v2/project/inbox')
+    expect(tagKey).toBe('user-1/vaults/vault-1/items-v2/tag_definition/inbox')
+    expect(projectKey).not.toBe(tagKey)
   })
 
   it('should batch sync item upsert and storage usage update atomically', async () => {

--- a/apps/sync-server/src/services/sync.ts
+++ b/apps/sync-server/src/services/sync.ts
@@ -18,7 +18,7 @@ import {
 import { encodeSignaturePayload } from '../lib/cbor'
 import { safeBase64Decode, verifyEd25519 } from '../lib/encoding'
 import { AppError, ErrorCodes } from '../lib/errors'
-import { generateBlobKey, getBlob, putBlob } from './blob'
+import { generateItemBlobKey, getBlob, putBlob } from './blob'
 import { getNextCursor } from './cursor'
 import { getDevice } from './device'
 import { adjustStorageUsed, checkQuota, reserveStorage } from './quota'
@@ -385,7 +385,7 @@ export const processPushItem = async (
       reservedBytes = sizeDelta
     }
 
-    const blobKey = generateBlobKey(userId, item.id, vaultId)
+    const blobKey = generateItemBlobKey(userId, item.type, item.id, vaultId)
     try {
       await putBlob(storage, blobKey, payloadBytes.slice().buffer, userId)
     } catch (error) {


### PR DESCRIPTION
## What
New sync pushes write payloads to a type-scoped `items-v2/<type>/<id>` R2 key; reads keep resolving the per-row stored `blob_key`, so legacy rows work unchanged with no migration.

## Why
Item ids repeat across types by design (project `inbox` vs tag `inbox`, folder_config path vs tag name), and the untyped key made colliding pairs overwrite one shared R2 object — the losing row's ciphertext was silently destroyed and its signature could never verify again (prod sync incident 2026-07-18; 6 collision groups across 2 accounts confirmed in prod D1).