### PR TITLE
fix(sync): key per-item bookkeeping by (type,id) and stop faking Retry success

### DIFF
--- a/apps/desktop/src/main/crypto/vault-key-state.ts
+++ b/apps/desktop/src/main/crypto/vault-key-state.ts
@@ -59,7 +59,11 @@ export async function bindLocalVaultToMasterKey(
 
 // Mirrors SYNC_STATE_KEYS in sync/engine/sync-context.ts (imported as literals
 // here to keep crypto/ free of sync-engine imports).
-const KEY_SCOPED_SYNC_STATE_KEYS = ['lastCursor', 'quarantinedItems'] as const
+const KEY_SCOPED_SYNC_STATE_KEYS = [
+  'lastCursor',
+  'quarantinedItems',
+  'lastManifestCheckAt'
+] as const
 
 function purgeKeyScopedSyncState(db: DataDb): void {
   for (const key of KEY_SCOPED_SYNC_STATE_KEYS) {

--- a/apps/desktop/src/main/store.test.ts
+++ b/apps/desktop/src/main/store.test.ts
@@ -103,6 +103,43 @@ describe('store', () => {
     expect(findVault('/vaults/a')?.noteCount).toBe(8)
   })
 
+  it('preserves a stored vaultUuid when an update omits it', () => {
+    // The uuid links the row to the account vault directory; callers rebuild
+    // VaultInfo from scratch, so an omitted uuid must not erase a stored one.
+    upsertVault({
+      path: '/vaults/a',
+      name: 'Vault A',
+      noteCount: 2,
+      taskCount: 5,
+      lastOpened: '2025-01-01T00:00:00.000Z',
+      isDefault: true,
+      vaultUuid: 'uuid-1'
+    })
+
+    upsertVault({
+      path: '/vaults/a',
+      name: 'Vault A',
+      noteCount: 9,
+      taskCount: 5,
+      lastOpened: '2025-01-02T00:00:00.000Z',
+      isDefault: true
+    })
+
+    expect(findVault('/vaults/a')?.vaultUuid).toBe('uuid-1')
+    expect(findVault('/vaults/a')?.noteCount).toBe(9)
+
+    upsertVault({
+      path: '/vaults/a',
+      name: 'Vault A',
+      noteCount: 9,
+      taskCount: 5,
+      lastOpened: '2025-01-03T00:00:00.000Z',
+      isDefault: true,
+      vaultUuid: 'uuid-2'
+    })
+    expect(findVault('/vaults/a')?.vaultUuid).toBe('uuid-2')
+  })
+
   it('removes vaults and updates lastOpened', () => {
     const vaultA = {
       path: '/vaults/a',

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -265,7 +265,13 @@ export function upsertVault(vault: StoredVaultInfo): void {
   const existingIndex = vaults.findIndex((v) => v.path === vault.path)
 
   if (existingIndex >= 0) {
-    vaults[existingIndex] = vault
+    // The server vault uuid is the ONLY link between this row and the account
+    // vault directory — losing it makes the vault look cloud-only and mints a
+    // fresh dormant folder on the next Download. Callers rebuild VaultInfo
+    // from scratch and stamp the uuid best-effort, so a row update without a
+    // uuid must never erase one that was already stored.
+    const existing = vaults[existingIndex]
+    vaults[existingIndex] = { ...vault, vaultUuid: vault.vaultUuid ?? existing.vaultUuid }
   } else {
     vaults.push(vault)
   }

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -125,7 +125,8 @@ export class SyncEngine extends EventEmitter {
         pull: () => this.pull(),
         push: () => this.push(),
         scheduleSync: (fn) => this.scheduleSync(fn)
-      }
+      },
+      (itemId, itemType) => this.quarantine.isQuarantined(itemId, itemType)
     )
     this.ctx.doPush = () => this.push()
     SyncEngine.activeInstance = this

--- a/apps/desktop/src/main/sync/engine/corrupt-item-tracker.test.ts
+++ b/apps/desktop/src/main/sync/engine/corrupt-item-tracker.test.ts
@@ -3,6 +3,8 @@ import { CorruptItemTracker } from './corrupt-item-tracker'
 import { CORRUPT_ITEM_COOLDOWN_MS } from './sync-context'
 import type { SyncContext } from './sync-context'
 import type { QuarantineManager } from './quarantine-manager'
+import { postToServer } from '../http-client'
+import { decryptPullBatch } from '../sync-crypto-batch'
 
 vi.mock('../../lib/logger', () => ({
   createLogger: () => ({
@@ -11,6 +13,18 @@ vi.mock('../../lib/logger', () => ({
     error: vi.fn(),
     debug: vi.fn()
   })
+}))
+
+vi.mock('../http-client', () => ({
+  postToServer: vi.fn()
+}))
+
+vi.mock('../retry', () => ({
+  withRetry: vi.fn(async (fn: () => Promise<unknown>) => ({ value: await fn() }))
+}))
+
+vi.mock('../sync-crypto-batch', () => ({
+  decryptPullBatch: vi.fn()
 }))
 
 const createTracker = (): CorruptItemTracker => {
@@ -45,7 +59,7 @@ describe('CorruptItemTracker', () => {
       it('#then returns true', () => {
         const tracker = createTracker()
 
-        const result = tracker.shouldRetry('item-1')
+        const result = tracker.shouldRetry({ id: 'item-1', type: 'task' })
 
         expect(result).toBe(true)
       })
@@ -54,9 +68,9 @@ describe('CorruptItemTracker', () => {
     describe('#given recently failed item #when shouldRetry called', () => {
       it('#then returns false', () => {
         const tracker = createTracker()
-        tracker.markFailed('item-1')
+        tracker.markFailed({ id: 'item-1', type: 'task' })
 
-        const result = tracker.shouldRetry('item-1')
+        const result = tracker.shouldRetry({ id: 'item-1', type: 'task' })
 
         expect(result).toBe(false)
       })
@@ -65,11 +79,11 @@ describe('CorruptItemTracker', () => {
     describe('#given failed item #when cooldown has expired', () => {
       it('#then returns true', () => {
         const tracker = createTracker()
-        tracker.markFailed('item-1')
+        tracker.markFailed({ id: 'item-1', type: 'task' })
 
         vi.advanceTimersByTime(CORRUPT_ITEM_COOLDOWN_MS + 1)
 
-        const result = tracker.shouldRetry('item-1')
+        const result = tracker.shouldRetry({ id: 'item-1', type: 'task' })
 
         expect(result).toBe(true)
       })
@@ -81,19 +95,19 @@ describe('CorruptItemTracker', () => {
       it('#then creates entry with attempts=1', () => {
         const tracker = createTracker()
 
-        tracker.markFailed('item-1')
+        tracker.markFailed({ id: 'item-1', type: 'task' })
 
-        expect(tracker.shouldRetry('item-1')).toBe(false)
+        expect(tracker.shouldRetry({ id: 'item-1', type: 'task' })).toBe(false)
       })
     })
 
     describe('#given existing failed item #when markFailed called again', () => {
       it('#then increments attempts and item remains not retryable', () => {
         const tracker = createTracker()
-        tracker.markFailed('item-1')
-        tracker.markFailed('item-1')
+        tracker.markFailed({ id: 'item-1', type: 'task' })
+        tracker.markFailed({ id: 'item-1', type: 'task' })
 
-        expect(tracker.shouldRetry('item-1')).toBe(false)
+        expect(tracker.shouldRetry({ id: 'item-1', type: 'task' })).toBe(false)
       })
     })
   })
@@ -103,14 +117,14 @@ describe('CorruptItemTracker', () => {
       it('#then removes only expired entries', () => {
         const tracker = createTracker()
 
-        tracker.markFailed('old-item')
+        tracker.markFailed({ id: 'old-item', type: 'task' })
         vi.advanceTimersByTime(CORRUPT_ITEM_COOLDOWN_MS + 1)
-        tracker.markFailed('fresh-item')
+        tracker.markFailed({ id: 'fresh-item', type: 'task' })
 
         tracker.clearExpired()
 
-        expect(tracker.shouldRetry('old-item')).toBe(true)
-        expect(tracker.shouldRetry('fresh-item')).toBe(false)
+        expect(tracker.shouldRetry({ id: 'old-item', type: 'task' })).toBe(true)
+        expect(tracker.shouldRetry({ id: 'fresh-item', type: 'task' })).toBe(false)
       })
     })
   })
@@ -119,13 +133,13 @@ describe('CorruptItemTracker', () => {
     describe('#given tracked items #when clear called', () => {
       it('#then removes all entries', () => {
         const tracker = createTracker()
-        tracker.markFailed('item-1')
-        tracker.markFailed('item-2')
+        tracker.markFailed({ id: 'item-1', type: 'task' })
+        tracker.markFailed({ id: 'item-2', type: 'task' })
 
         tracker.clear()
 
-        expect(tracker.shouldRetry('item-1')).toBe(true)
-        expect(tracker.shouldRetry('item-2')).toBe(true)
+        expect(tracker.shouldRetry({ id: 'item-1', type: 'task' })).toBe(true)
+        expect(tracker.shouldRetry({ id: 'item-2', type: 'task' })).toBe(true)
       })
     })
   })
@@ -134,12 +148,61 @@ describe('CorruptItemTracker', () => {
     describe('#given all items on cooldown #when refetch called', () => {
       it('#then returns empty recovered and permanentFailures', async () => {
         const tracker = createTracker()
-        tracker.markFailed('item-1')
-        tracker.markFailed('item-2')
+        tracker.markFailed({ id: 'item-1', type: 'task' })
+        tracker.markFailed({ id: 'item-2', type: 'task' })
 
-        const result = await tracker.refetch(['item-1', 'item-2'], 'token', new Uint8Array(32))
+        const result = await tracker.refetch(
+          [
+            { id: 'item-1', type: 'task' },
+            { id: 'item-2', type: 'task' }
+          ],
+          'token',
+          new Uint8Array(32)
+        )
 
         expect(result).toEqual({ recovered: [], permanentFailures: [] })
+      })
+    })
+
+    describe('#given the server returns both type rows for a shared id #when refetch requested one type', () => {
+      it('#then only the requested (type, id) pair is processed', async () => {
+        // The pull endpoint matches bare ids across all types, so id 'inbox'
+        // returns both the project and the tag_definition rows. The sibling
+        // type was never corrupt and must not be decrypted or re-branded.
+        const tracker = createTracker()
+
+        const makeServerItem = (type: string) => ({
+          id: 'inbox',
+          type,
+          operation: 'update',
+          signature: 'c2ln',
+          signerDeviceId: 'device-a',
+          blob: {
+            encryptedKey: 'a2V5',
+            keyNonce: 'bm9uY2U=',
+            encryptedData: 'ZGF0YQ==',
+            dataNonce: 'bm9uY2Uy'
+          }
+        })
+        vi.mocked(postToServer).mockResolvedValue({
+          items: [makeServerItem('project'), makeServerItem('tag_definition')]
+        })
+        vi.mocked(decryptPullBatch).mockResolvedValue({
+          decrypted: [{ id: 'inbox', type: 'tag_definition', content: '{}', operation: 'update' }],
+          failures: []
+        } as unknown as Awaited<ReturnType<typeof decryptPullBatch>>)
+
+        const result = await tracker.refetch(
+          [{ id: 'inbox', type: 'tag_definition' }],
+          'token',
+          new Uint8Array(32)
+        )
+
+        const decryptedInput = vi.mocked(decryptPullBatch).mock.calls[0][0]
+        expect(decryptedInput).toHaveLength(1)
+        expect(decryptedInput[0].type).toBe('tag_definition')
+        expect(result.recovered).toHaveLength(1)
+        expect(result.permanentFailures).toHaveLength(0)
       })
     })
   })

--- a/apps/desktop/src/main/sync/engine/corrupt-item-tracker.ts
+++ b/apps/desktop/src/main/sync/engine/corrupt-item-tracker.ts
@@ -6,11 +6,16 @@ import { withRetry } from '../retry'
 import { postToServer } from '../http-client'
 import type { SyncContext } from './sync-context'
 import type { QuarantineManager } from './quarantine-manager'
-import { CORRUPT_ITEM_COOLDOWN_MS } from './sync-context'
+import { CORRUPT_ITEM_COOLDOWN_MS, itemRefKey } from './sync-context'
 
 const log = createLogger('CorruptItemTracker')
 
 export type ResolveDeviceKey = (deviceId: string) => Promise<Uint8Array | null>
+
+export interface ItemRef {
+  id: string
+  type: string
+}
 
 export interface RecoveredItem {
   id: string
@@ -33,23 +38,23 @@ export class CorruptItemTracker {
     this.resolveDeviceKey = resolveDeviceKey
   }
 
-  shouldRetry(itemId: string): boolean {
-    const entry = this.corruptItems.get(itemId)
+  shouldRetry(ref: ItemRef): boolean {
+    const entry = this.corruptItems.get(itemRefKey(ref.type, ref.id))
     if (!entry) return true
     if (Date.now() - entry.failedAt > CORRUPT_ITEM_COOLDOWN_MS) {
-      this.corruptItems.delete(itemId)
+      this.corruptItems.delete(itemRefKey(ref.type, ref.id))
       return true
     }
     return false
   }
 
-  markFailed(itemId: string): void {
-    const entry = this.corruptItems.get(itemId)
+  markFailed(ref: ItemRef): void {
+    const entry = this.corruptItems.get(itemRefKey(ref.type, ref.id))
     if (entry) {
       entry.attempts++
       entry.failedAt = Date.now()
     } else {
-      this.corruptItems.set(itemId, { failedAt: Date.now(), attempts: 1 })
+      this.corruptItems.set(itemRefKey(ref.type, ref.id), { failedAt: Date.now(), attempts: 1 })
     }
   }
 
@@ -67,11 +72,11 @@ export class CorruptItemTracker {
   }
 
   async refetch(
-    failedItemIds: string[],
+    failedItems: ItemRef[],
     token: string,
     vaultKey: Uint8Array
-  ): Promise<{ recovered: RecoveredItem[]; permanentFailures: string[] }> {
-    const eligible = failedItemIds.filter((id) => this.shouldRetry(id))
+  ): Promise<{ recovered: RecoveredItem[]; permanentFailures: ItemRef[] }> {
+    const eligible = failedItems.filter((ref) => this.shouldRetry(ref))
     if (eligible.length === 0) return { recovered: [], permanentFailures: [] }
 
     log.info('Attempting re-fetch for corrupt items', { count: eligible.length })
@@ -81,7 +86,7 @@ export class CorruptItemTracker {
         () =>
           postToServer<{ items: RecordPullItemResponse[] }>(
             '/sync/pull',
-            { itemIds: eligible },
+            { itemIds: Array.from(new Set(eligible.map((ref) => ref.id))) },
             token
           ),
         {
@@ -93,21 +98,30 @@ export class CorruptItemTracker {
       const parsed = RecordPullResponseSchema.safeParse(pullResult.value)
       if (!parsed.success) {
         log.error('Re-fetch: invalid response', { error: parsed.error.message })
-        for (const id of eligible) this.markFailed(id)
+        for (const ref of eligible) this.markFailed(ref)
         return { recovered: [], permanentFailures: eligible }
       }
 
-      const signerIds = new Set(parsed.data.items.map((i) => i.signerDeviceId))
+      // The pull endpoint matches ids across ALL negotiated types, so an id
+      // shared by two types (project 'inbox' vs tag 'inbox') returns BOTH
+      // rows. Only process the (type, id) pairs this refetch actually asked
+      // for — the sibling type was not corrupt and must not be re-branded here.
+      const requested = new Set(eligible.map((ref) => itemRefKey(ref.type, ref.id)))
+      const requestedItems = parsed.data.items.filter((item) =>
+        requested.has(itemRefKey(item.type, item.id))
+      )
+
+      const signerIds = new Set(requestedItems.map((i) => i.signerDeviceId))
       for (const sid of signerIds) {
         await this.resolveDeviceKey(sid)
       }
 
-      const { decrypted, failures } = await decryptPullBatch(parsed.data.items, vaultKey, {
+      const { decrypted, failures } = await decryptPullBatch(requestedItems, vaultKey, {
         workerBridge: this.ctx.deps.workerBridge,
         resolveDeviceKey: (id) => this.resolveDeviceKey(id)
       })
 
-      const permanentFailures: string[] = []
+      const permanentFailures: ItemRef[] = []
       for (const failure of failures) {
         if (failure.isSignatureError) {
           this.quarantine.quarantineItem(
@@ -117,10 +131,14 @@ export class CorruptItemTracker {
             failure.error
           )
         } else {
-          this.markFailed(failure.id)
+          this.markFailed({ id: failure.id, type: failure.type })
         }
-        permanentFailures.push(failure.id)
-        log.warn('Re-fetch: item failed again', { itemId: failure.id, error: failure.error })
+        permanentFailures.push({ id: failure.id, type: failure.type })
+        log.warn('Re-fetch: item failed again', {
+          itemId: failure.id,
+          itemType: failure.type,
+          error: failure.error
+        })
       }
 
       return { recovered: decrypted, permanentFailures }
@@ -128,7 +146,7 @@ export class CorruptItemTracker {
       log.error('Re-fetch request failed', {
         error: error instanceof Error ? error.message : String(error)
       })
-      for (const id of eligible) this.markFailed(id)
+      for (const ref of eligible) this.markFailed(ref)
       return { recovered: [], permanentFailures: eligible }
     }
   }

--- a/apps/desktop/src/main/sync/engine/corrupt-item-tracker.ts
+++ b/apps/desktop/src/main/sync/engine/corrupt-item-tracker.ts
@@ -111,6 +111,17 @@ export class CorruptItemTracker {
         requested.has(itemRefKey(item.type, item.id))
       )
 
+      // A requested pair the server no longer returns (row purged/repaired
+      // away) would otherwise vanish from the accounting entirely: never
+      // recovered, never failed, re-requested on every page forever. Mark it
+      // failed (cooldown) and report it permanent so it surfaces once.
+      const returned = new Set(requestedItems.map((item) => itemRefKey(item.type, item.id)))
+      const missing = eligible.filter((ref) => !returned.has(itemRefKey(ref.type, ref.id)))
+      for (const ref of missing) {
+        this.markFailed(ref)
+        log.warn('Re-fetch: item no longer on server', { itemId: ref.id, itemType: ref.type })
+      }
+
       const signerIds = new Set(requestedItems.map((i) => i.signerDeviceId))
       for (const sid of signerIds) {
         await this.resolveDeviceKey(sid)
@@ -121,7 +132,7 @@ export class CorruptItemTracker {
         resolveDeviceKey: (id) => this.resolveDeviceKey(id)
       })
 
-      const permanentFailures: ItemRef[] = []
+      const permanentFailures: ItemRef[] = [...missing]
       for (const failure of failures) {
         if (failure.isSignatureError) {
           this.quarantine.quarantineItem(

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -26,6 +26,7 @@ export class FullSyncRunner {
   private pushCoordinator: PushCoordinator
   private crdtSync: CrdtSyncCoordinator
   private actions: FullSyncActions
+  private isQuarantined?: (itemId: string, itemType: string) => boolean
   // In-memory cache of the persisted throttle timestamp. The persisted value
   // is the authority: this runner is recreated with every engine (vault
   // switch, restart, retry), and an instance-only field re-armed an immediate
@@ -38,13 +39,15 @@ export class FullSyncRunner {
     stateManager: SyncStateManager,
     pushCoordinator: PushCoordinator,
     crdtSync: CrdtSyncCoordinator,
-    actions: FullSyncActions
+    actions: FullSyncActions,
+    isQuarantined?: (itemId: string, itemType: string) => boolean
   ) {
     this.ctx = ctx
     this.stateManager = stateManager
     this.pushCoordinator = pushCoordinator
     this.crdtSync = crdtSync
     this.actions = actions
+    this.isQuarantined = isQuarantined
   }
 
   async run(): Promise<void> {
@@ -88,24 +91,33 @@ export class FullSyncRunner {
         totalItems: 0
       } satisfies InitialSyncProgressEvent)
 
-      const persistedCheckAt = Number(
+      const persistedRaw = Number(
         this.stateManager.getStateValue(SYNC_STATE_KEYS.LAST_MANIFEST_CHECK_AT) ?? '0'
       )
+      // Clamp to now: a future-dated persisted timestamp (clock skew, machine
+      // migration) would otherwise throttle the check until the wall clock
+      // catches up with it.
+      const persistedCheckAt = Number.isFinite(persistedRaw)
+        ? Math.min(persistedRaw, Date.now())
+        : 0
       const manifestResult = await checkManifestIntegrity({
         db: this.ctx.deps.db,
         queue: this.ctx.deps.queue,
         getAccessToken: this.ctx.deps.getAccessToken,
         isOnline: () => this.ctx.deps.network.online,
-        lastCheckAt: Math.max(
-          this.lastManifestCheckAt,
-          Number.isFinite(persistedCheckAt) ? persistedCheckAt : 0
-        )
+        lastCheckAt: Math.max(this.lastManifestCheckAt, persistedCheckAt),
+        isQuarantined: this.isQuarantined
       })
       this.lastManifestCheckAt = manifestResult.checkedAt
-      this.stateManager.setStateValue(
-        SYNC_STATE_KEYS.LAST_MANIFEST_CHECK_AT,
-        String(manifestResult.checkedAt)
-      )
+      // Persist only when a manifest was actually fetched and diffed: stamping
+      // the no-token or fetch-failure paths would silently defer the next REAL
+      // check by the full 30-minute window.
+      if (manifestResult.performed) {
+        this.stateManager.setStateValue(
+          SYNC_STATE_KEYS.LAST_MANIFEST_CHECK_AT,
+          String(manifestResult.checkedAt)
+        )
+      }
       log.debug('fullSync: manifest check complete', {
         rePullNeeded: manifestResult.rePullNeeded,
         serverOnlyCount: manifestResult.serverOnlyCount

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -26,6 +26,11 @@ export class FullSyncRunner {
   private pushCoordinator: PushCoordinator
   private crdtSync: CrdtSyncCoordinator
   private actions: FullSyncActions
+  // In-memory cache of the persisted throttle timestamp. The persisted value
+  // is the authority: this runner is recreated with every engine (vault
+  // switch, restart, retry), and an instance-only field re-armed an immediate
+  // manifest check each time — with a permanently quarantined item that meant
+  // a cursor reset and full re-pull on every single sync cycle.
   lastManifestCheckAt = 0
 
   constructor(
@@ -83,14 +88,24 @@ export class FullSyncRunner {
         totalItems: 0
       } satisfies InitialSyncProgressEvent)
 
+      const persistedCheckAt = Number(
+        this.stateManager.getStateValue(SYNC_STATE_KEYS.LAST_MANIFEST_CHECK_AT) ?? '0'
+      )
       const manifestResult = await checkManifestIntegrity({
         db: this.ctx.deps.db,
         queue: this.ctx.deps.queue,
         getAccessToken: this.ctx.deps.getAccessToken,
         isOnline: () => this.ctx.deps.network.online,
-        lastCheckAt: this.lastManifestCheckAt
+        lastCheckAt: Math.max(
+          this.lastManifestCheckAt,
+          Number.isFinite(persistedCheckAt) ? persistedCheckAt : 0
+        )
       })
       this.lastManifestCheckAt = manifestResult.checkedAt
+      this.stateManager.setStateValue(
+        SYNC_STATE_KEYS.LAST_MANIFEST_CHECK_AT,
+        String(manifestResult.checkedAt)
+      )
       log.debug('fullSync: manifest check complete', {
         rePullNeeded: manifestResult.rePullNeeded,
         serverOnlyCount: manifestResult.serverOnlyCount

--- a/apps/desktop/src/main/sync/engine/pull-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/pull-coordinator.ts
@@ -58,6 +58,15 @@ const applyRank = (type: string): number => PULL_APPLY_ORDER[type] ?? 1
 export const sortByApplyOrder = <T extends { type: string }>(items: T[]): T[] =>
   [...items].sort((a, b) => applyRank(a.type) - applyRank(b.type))
 
+// Why a page stopped the pull run:
+// - 'transition': key material is mid-swap (sign-in/recovery) — momentary, do
+//   not advance the cursor, the flow re-pulls cleanly once the key settles.
+// - 'mismatch': the local key does not match the account — do not advance,
+//   recovery must run first.
+// - 'breaker': the key is right but the page's payloads are undecryptable
+//   (server-side poisoned data) — advance past the page, mark items corrupt.
+type PageStopReason = 'none' | 'transition' | 'mismatch' | 'breaker'
+
 interface PullRunState {
   timer: SyncTimer
   startTime: number
@@ -67,6 +76,8 @@ interface PullRunState {
   crdtNoteIds: string[]
   accessJwt: string
   vaultKey: Uint8Array
+  /** Set when the run stopped on a page it could not apply — no success finalize. */
+  refused?: boolean
 }
 
 export class PullCoordinator {
@@ -121,7 +132,16 @@ export class PullCoordinator {
       try {
         await this.pullChanges(runState)
         await this.applyDeferredRetries(runState)
-        this.finalizePullSuccess(runState)
+        if (runState.refused) {
+          // The run stopped on a page it could not apply. Recording a success
+          // history row and a fresh lastSyncAt here is what made a failing
+          // Retry look like a clean sync in the 2026-07-18 incident.
+          log.warn('Pull finished on a refused page — not recording a successful sync', {
+            pulledCount: runState.pulledCount
+          })
+        } else {
+          this.finalizePullSuccess(runState)
+        }
       } catch (error) {
         this.handlePullError(error, runState.startTime)
       }
@@ -218,18 +238,33 @@ export class PullCoordinator {
       }
 
       const changes = changesResult.value
-      const shouldStop = await this.pullChangesPage(changes, runState)
+      const stop = await this.pullChangesPage(changes, runState)
       this.emitInitialSyncProgress(changes, runState.pulledCount)
 
-      // A page we refused to apply (all-crypto-failed, key mid-transition)
-      // must NOT advance the persisted cursor: doing so made the next manual
-      // Retry resume past the failing page and report a clean sync while the
-      // items were never applied.
-      if (shouldStop) break
+      // Key-state stops ('transition' mid sign-in/recovery, 'mismatch') must
+      // NOT advance the persisted cursor: the failures are a key problem that
+      // resolves out-of-band, and advancing made the next manual Retry resume
+      // past the failing page and report a clean sync while the items were
+      // never applied.
+      if (stop === 'transition' || stop === 'mismatch') {
+        runState.refused = true
+        break
+      }
 
       this.stateManager.setStateValue(SYNC_STATE_KEYS.LAST_CURSOR, String(changes.nextCursor))
       cursor = String(changes.nextCursor)
       hasMore = changes.hasMore
+
+      // Circuit breaker (key matches the account but the page's payloads are
+      // undecryptable — server-side poisoned data): the cursor DOES advance,
+      // because these items can never decrypt no matter how often they are
+      // re-pulled, and pinning the cursor here would block every later item
+      // from ever reaching this device. The failures were marked corrupt and
+      // surfaced; the run still ends in an error state, not a fake success.
+      if (stop === 'breaker') {
+        runState.refused = true
+        break
+      }
 
       if (hasMore && !this.ctx.abortController?.signal.aborted) {
         prefetchedNext = this.fetchChangesPage(runState, cursor)
@@ -268,18 +303,18 @@ export class PullCoordinator {
   private async pullChangesPage(
     changes: RecordChangesResponse,
     runState: PullRunState
-  ): Promise<boolean> {
+  ): Promise<PageStopReason> {
     const itemIds = Array.from(
       new Set([...changes.items.map((item) => item.id), ...changes.deleted])
     )
-    if (itemIds.length === 0) return false
+    if (itemIds.length === 0) return 'none'
 
     const pageResult = await this.processPage(itemIds, runState)
     runState.pulledCount += pageResult.applied
     runState.totalConflictsResolved += pageResult.conflicts
     await this.applyCrdtBatch(runState)
 
-    return pageResult.allCryptoFailed
+    return pageResult.stop
   }
 
   private async applyCrdtBatch(runState: PullRunState): Promise<void> {
@@ -437,7 +472,7 @@ export class PullCoordinator {
   private async processPage(
     itemIds: string[],
     runState: PullRunState
-  ): Promise<{ applied: number; conflicts: number; allCryptoFailed: boolean }> {
+  ): Promise<{ applied: number; conflicts: number; stop: PageStopReason }> {
     const { vaultKey, timer, processedIds, crdtNoteIds } = runState
     const pullResult = await withRetry(
       () =>
@@ -456,7 +491,7 @@ export class PullCoordinator {
     const parsed = RecordPullResponseSchema.safeParse(pullResult.value)
     if (!parsed.success) {
       log.error('Invalid pull response from server', { error: parsed.error.message })
-      return { applied: 0, conflicts: 0, allCryptoFailed: false }
+      return { applied: 0, conflicts: 0, stop: 'none' }
     }
 
     log.debug('Pull: response parsed', {
@@ -521,7 +556,7 @@ export class PullCoordinator {
           { failedCount: failures.length }
         )
         this.ctx.deps.onVaultKeyMismatch?.()
-        return { applied: 0, conflicts: 0, allCryptoFailed: true }
+        return { applied: 0, conflicts: 0, stop: 'mismatch' }
       }
       if (keyCheck === 'transition') {
         // Sign-in / recovery / linking is mid-swap: the failures are expected
@@ -531,7 +566,7 @@ export class PullCoordinator {
           'Pull: key material is being re-established — stopping cycle without recording item failures',
           { failedCount: failures.length }
         )
-        return { applied: 0, conflicts: 0, allCryptoFailed: true }
+        return { applied: 0, conflicts: 0, stop: 'transition' }
       }
     }
 
@@ -694,7 +729,7 @@ export class PullCoordinator {
       conflicts: pageConflicts
     })
 
-    let allCryptoFailed = false
+    let stop: PageStopReason = 'none'
     if (
       pageFailed > 0 &&
       pageFailed === cryptoFailCount &&
@@ -711,10 +746,25 @@ export class PullCoordinator {
       }
       this.stateManager.setState('error')
       log.error('Pull: circuit breaker tripped — all items failed crypto', { cryptoFailCount })
-      allCryptoFailed = true
+      // The account key check above said 'match' (or was unavailable), so
+      // these payloads are undecryptable with the CORRECT key — server-side
+      // poisoned data that no amount of re-pulling can fix. Record each item
+      // in the corrupt tracker (cooldown) and surface it, so the caller can
+      // advance the cursor past this page without silently losing track of
+      // what failed.
+      for (const failure of failures) {
+        if (!failure.isCryptoError) continue
+        this.corruptTracker.markFailed({ id: failure.id, type: failure.type })
+        this.ctx.deps.emitToRenderer(EVENT_CHANNELS.ITEM_CORRUPT, {
+          itemId: failure.id,
+          type: failure.type,
+          error: failure.error
+        } satisfies ItemCorruptEvent)
+      }
+      stop = 'breaker'
     }
 
-    return { applied: pageApplied, conflicts: pageConflicts, allCryptoFailed }
+    return { applied: pageApplied, conflicts: pageConflicts, stop }
   }
 
   private handleConflict(dec: {

--- a/apps/desktop/src/main/sync/engine/pull-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/pull-coordinator.ts
@@ -27,7 +27,7 @@ import type { QuarantineManager } from './quarantine-manager'
 import type { CrdtSyncCoordinator } from './crdt-sync-coordinator'
 import type { PushCoordinator } from './push-coordinator'
 import { CorruptItemTracker } from './corrupt-item-tracker'
-import { SYNC_STATE_KEYS, YIELD_EVERY_N_ITEMS, yieldToEventLoop } from './sync-context'
+import { SYNC_STATE_KEYS, YIELD_EVERY_N_ITEMS, yieldToEventLoop, itemRefKey } from './sync-context'
 
 const log = createLogger('PullCoordinator')
 
@@ -221,11 +221,15 @@ export class PullCoordinator {
       const shouldStop = await this.pullChangesPage(changes, runState)
       this.emitInitialSyncProgress(changes, runState.pulledCount)
 
+      // A page we refused to apply (all-crypto-failed, key mid-transition)
+      // must NOT advance the persisted cursor: doing so made the next manual
+      // Retry resume past the failing page and report a clean sync while the
+      // items were never applied.
+      if (shouldStop) break
+
       this.stateManager.setStateValue(SYNC_STATE_KEYS.LAST_CURSOR, String(changes.nextCursor))
       cursor = String(changes.nextCursor)
       hasMore = changes.hasMore
-
-      if (shouldStop) break
 
       if (hasMore && !this.ctx.abortController?.signal.aborted) {
         prefetchedNext = this.fetchChangesPage(runState, cursor)
@@ -413,7 +417,7 @@ export class PullCoordinator {
           if (!isBinary) runState.crdtNoteIds.push(dec.id)
         }
 
-        runState.processedIds.add(dec.id)
+        runState.processedIds.add(itemRefKey(dec.type, dec.id))
         runState.pulledCount++
         applied++
         this.stateManager.emitItemSynced(dec.id, dec.type, 'pull', itemOp)
@@ -471,11 +475,11 @@ export class PullCoordinator {
     let pageConflicts = 0
 
     const itemsToProcess = parsed.data.items.filter((item) => {
-      if (processedIds.has(item.id)) {
+      if (processedIds.has(itemRefKey(item.type, item.id))) {
         pageSkipped++
         return false
       }
-      if (this.quarantine.isQuarantined(item.id)) {
+      if (this.quarantine.isQuarantined(item.id, item.type)) {
         pageSkipped++
         return false
       }
@@ -602,7 +606,7 @@ export class PullCoordinator {
             if (!isBinary) crdtNoteIds.push(dec.id)
           }
 
-          processedIds.add(dec.id)
+          processedIds.add(itemRefKey(dec.type, dec.id))
           pageApplied++
           this.stateManager.emitItemSynced(dec.id, dec.type, 'pull', itemOp)
         } catch (applyError) {
@@ -620,14 +624,16 @@ export class PullCoordinator {
     }
     timer.endPhase(decrypted.length)
 
-    const cryptoRefetchIds = failures.filter((f) => f.isCryptoError).map((f) => f.id)
-    const parseRefetchIds = parseErrorIds.map((p) => p.id)
-    const allRefetchIds = [...cryptoRefetchIds, ...parseRefetchIds]
+    const cryptoRefetchRefs = failures
+      .filter((f) => f.isCryptoError)
+      .map((f) => ({ id: f.id, type: f.type }))
+    const parseRefetchRefs = parseErrorIds.map((p) => ({ id: p.id, type: p.type }))
+    const allRefetchRefs = [...cryptoRefetchRefs, ...parseRefetchRefs]
 
-    if (allRefetchIds.length > 0 && pageApplied > 0) {
+    if (allRefetchRefs.length > 0 && pageApplied > 0) {
       this.corruptTracker.clearExpired()
       const { recovered, permanentFailures } = await this.corruptTracker.refetch(
-        allRefetchIds,
+        allRefetchRefs,
         runState.accessJwt,
         vaultKey
       )
@@ -646,7 +652,7 @@ export class PullCoordinator {
             vaultKey
           })
           if (result === 'applied' || result === 'conflict') {
-            processedIds.add(dec.id)
+            processedIds.add(itemRefKey(dec.type, dec.id))
             pageApplied++
             pageFailed--
             this.stateManager.emitItemSynced(dec.id, dec.type, 'pull', itemOp)
@@ -664,11 +670,10 @@ export class PullCoordinator {
         }
       }
 
-      for (const id of permanentFailures) {
-        const failInfo = parseErrorIds.find((p) => p.id === id) ?? failures.find((f) => f.id === id)
+      for (const ref of permanentFailures) {
         this.ctx.deps.emitToRenderer(EVENT_CHANNELS.ITEM_CORRUPT, {
-          itemId: id,
-          type: failInfo?.type ?? 'unknown',
+          itemId: ref.id,
+          type: ref.type,
           error: 'Item corrupt after re-fetch attempt'
         } satisfies ItemCorruptEvent)
       }

--- a/apps/desktop/src/main/sync/engine/quarantine-manager.test.ts
+++ b/apps/desktop/src/main/sync/engine/quarantine-manager.test.ts
@@ -102,8 +102,9 @@ describe('QuarantineManager', () => {
         .all()
       expect(rows).toHaveLength(1)
       const parsed = JSON.parse(rows[0].value)
-      expect(parsed).toHaveLength(1)
-      expect(parsed[0].itemId).toBe('item-1')
+      expect(parsed.v).toBe(2)
+      expect(parsed.entries).toHaveLength(1)
+      expect(parsed.entries[0].itemId).toBe('item-1')
     })
   })
 
@@ -190,7 +191,7 @@ describe('QuarantineManager', () => {
         .insert(syncState)
         .values({
           key: SYNC_STATE_KEYS.QUARANTINED_ITEMS,
-          value: JSON.stringify(entries),
+          value: JSON.stringify({ v: 2, entries }),
           updatedAt: new Date()
         })
         .run()
@@ -202,6 +203,35 @@ describe('QuarantineManager', () => {
       // #then
       expect(fresh.isQuarantined('restored-1', 'task')).toBe(true)
       expect(fresh.getQuarantinedItems()).toHaveLength(1)
+    })
+
+    it('#given legacy id-keyed (v1 array) persisted state #when loadState called #then it is discarded', () => {
+      // v1 entries were id-aliased across types: attemptCount and itemType
+      // could belong to the WRONG type, so they must not be trusted.
+      const legacy = [
+        {
+          itemId: 'inbox',
+          itemType: 'tag_definition',
+          signerDeviceId: 'device-x',
+          failedAt: Date.now(),
+          attemptCount: QUARANTINE_MAX_ATTEMPTS,
+          lastError: 'aliased'
+        }
+      ]
+      testDb.db
+        .insert(syncState)
+        .values({
+          key: SYNC_STATE_KEYS.QUARANTINED_ITEMS,
+          value: JSON.stringify(legacy),
+          updatedAt: new Date()
+        })
+        .run()
+
+      const fresh = new QuarantineManager(ctx)
+      fresh.loadState()
+
+      expect(fresh.getQuarantinedItems()).toHaveLength(0)
+      expect(fresh.isQuarantined('inbox', 'tag_definition')).toBe(false)
     })
 
     it('#given persisted entry older than the TTL #when loadState called #then entry is dropped', () => {
@@ -219,7 +249,7 @@ describe('QuarantineManager', () => {
         .insert(syncState)
         .values({
           key: SYNC_STATE_KEYS.QUARANTINED_ITEMS,
-          value: JSON.stringify(entries),
+          value: JSON.stringify({ v: 2, entries }),
           updatedAt: new Date()
         })
         .run()

--- a/apps/desktop/src/main/sync/engine/quarantine-manager.test.ts
+++ b/apps/desktop/src/main/sync/engine/quarantine-manager.test.ts
@@ -115,7 +115,7 @@ describe('QuarantineManager', () => {
       }
 
       // #then
-      expect(manager.isQuarantined('item-1')).toBe(true)
+      expect(manager.isQuarantined('item-1', 'task')).toBe(true)
     })
 
     it('#given item below max attempts #when isQuarantined called #then returns false', () => {
@@ -123,11 +123,33 @@ describe('QuarantineManager', () => {
       manager.quarantineItem('item-1', 'task', 'device-a', 'bad sig')
 
       // #then
-      expect(manager.isQuarantined('item-1')).toBe(false)
+      expect(manager.isQuarantined('item-1', 'task')).toBe(false)
     })
 
     it('#given unknown itemId #when isQuarantined called #then returns false', () => {
-      expect(manager.isQuarantined('nonexistent')).toBe(false)
+      expect(manager.isQuarantined('nonexistent', 'task')).toBe(false)
+    })
+
+    it('#given same id quarantined as another type #when isQuarantined called #then types stay independent', () => {
+      // Ids repeat across item types (project 'inbox' vs tag 'inbox'); a
+      // permanent quarantine on one type must not block the sibling type.
+      for (let i = 0; i < QUARANTINE_MAX_ATTEMPTS; i++) {
+        manager.quarantineItem('inbox', 'tag_definition', 'device-a', 'bad sig')
+      }
+
+      expect(manager.isQuarantined('inbox', 'tag_definition')).toBe(true)
+      expect(manager.isQuarantined('inbox', 'project')).toBe(false)
+    })
+
+    it('#given both types of a colliding id failing #when quarantined #then attempt counts do not alias', () => {
+      manager.quarantineItem('inbox', 'project', 'device-a', 'bad sig')
+      manager.quarantineItem('inbox', 'tag_definition', 'device-a', 'bad sig')
+      manager.quarantineItem('inbox', 'project', 'device-a', 'bad sig')
+
+      const items = manager.getQuarantinedItems()
+      expect(items).toHaveLength(2)
+      expect(items.find((i) => i.itemType === 'project')?.attemptCount).toBe(2)
+      expect(items.find((i) => i.itemType === 'tag_definition')?.attemptCount).toBe(1)
     })
   })
 
@@ -178,8 +200,35 @@ describe('QuarantineManager', () => {
       fresh.loadState()
 
       // #then
-      expect(fresh.isQuarantined('restored-1')).toBe(true)
+      expect(fresh.isQuarantined('restored-1', 'task')).toBe(true)
       expect(fresh.getQuarantinedItems()).toHaveLength(1)
+    })
+
+    it('#given persisted entry older than the TTL #when loadState called #then entry is dropped', () => {
+      const entries = [
+        {
+          itemId: 'stale-1',
+          itemType: 'task',
+          signerDeviceId: 'device-x',
+          failedAt: Date.now() - 8 * 24 * 60 * 60 * 1000,
+          attemptCount: QUARANTINE_MAX_ATTEMPTS,
+          lastError: 'old error'
+        }
+      ]
+      testDb.db
+        .insert(syncState)
+        .values({
+          key: SYNC_STATE_KEYS.QUARANTINED_ITEMS,
+          value: JSON.stringify(entries),
+          updatedAt: new Date()
+        })
+        .run()
+
+      const fresh = new QuarantineManager(ctx)
+      fresh.loadState()
+
+      expect(fresh.isQuarantined('stale-1', 'task')).toBe(false)
+      expect(fresh.getQuarantinedItems()).toHaveLength(0)
     })
 
     it('#given no persisted state in DB #when loadState called #then quarantine remains empty', () => {
@@ -203,7 +252,7 @@ describe('QuarantineManager', () => {
       fresh.loadState()
 
       // #then
-      expect(fresh.isQuarantined('round-trip')).toBe(true)
+      expect(fresh.isQuarantined('round-trip', 'project')).toBe(true)
       expect(fresh.getQuarantinedItems()[0].lastError).toBe('err')
     })
   })
@@ -219,7 +268,7 @@ describe('QuarantineManager', () => {
 
       // #then
       expect(manager.getQuarantinedItems()).toHaveLength(0)
-      expect(manager.isQuarantined('item-1')).toBe(false)
+      expect(manager.isQuarantined('item-1', 'task')).toBe(false)
     })
   })
 })

--- a/apps/desktop/src/main/sync/engine/quarantine-manager.ts
+++ b/apps/desktop/src/main/sync/engine/quarantine-manager.ts
@@ -66,7 +66,20 @@ export class QuarantineManager {
         .all()
       const val = rows[0]?.value
       if (!val) return
-      const entries = JSON.parse(val) as QuarantineEntry[]
+      const parsed = JSON.parse(val) as
+        | QuarantineEntry[]
+        | { v: number; entries: QuarantineEntry[] }
+      // v1 (bare array) was written by the id-keyed era: colliding item types
+      // shared one entry whose attemptCount and itemType were jointly mangled,
+      // so a legacy entry can brand the WRONG type permanent. Discard v1
+      // wholesale — a genuinely broken item re-quarantines within
+      // QUARANTINE_MAX_ATTEMPTS pulls, a healthy one flows again immediately.
+      if (Array.isArray(parsed)) {
+        log.info('Discarded legacy id-keyed quarantine state', { dropped: parsed.length })
+        this.persistState()
+        return
+      }
+      const entries = parsed.entries ?? []
       // Expire stale entries: the server rows that earned a quarantine may
       // have been repaired or purged since. If an item is still broken it
       // re-quarantines within QUARANTINE_MAX_ATTEMPTS pulls, so dropping old
@@ -113,7 +126,7 @@ export class QuarantineManager {
       const permanent = Array.from(this.quarantinedItems.values()).filter(
         (e) => e.attemptCount >= QUARANTINE_MAX_ATTEMPTS
       )
-      const value = JSON.stringify(permanent)
+      const value = JSON.stringify({ v: 2, entries: permanent })
       this.ctx.deps.db
         .insert(syncState)
         .values({ key: SYNC_STATE_KEYS.QUARANTINED_ITEMS, value, updatedAt: new Date() })

--- a/apps/desktop/src/main/sync/engine/quarantine-manager.ts
+++ b/apps/desktop/src/main/sync/engine/quarantine-manager.ts
@@ -4,7 +4,12 @@ import { createLogger } from '../../lib/logger'
 import { EVENT_CHANNELS } from '@memry/contracts/ipc-events'
 import type { SecurityWarningEvent, QuarantinedItemInfo } from '@memry/contracts/ipc-events'
 import type { SyncContext, QuarantineEntry } from './sync-context'
-import { SYNC_STATE_KEYS, QUARANTINE_MAX_ATTEMPTS } from './sync-context'
+import {
+  SYNC_STATE_KEYS,
+  QUARANTINE_MAX_ATTEMPTS,
+  QUARANTINE_ENTRY_TTL_MS,
+  itemRefKey
+} from './sync-context'
 
 const log = createLogger('QuarantineManager')
 
@@ -17,11 +22,11 @@ export class QuarantineManager {
   }
 
   quarantineItem(itemId: string, itemType: string, signerDeviceId: string, error: string): void {
-    const existing = this.quarantinedItems.get(itemId)
+    const existing = this.quarantinedItems.get(itemRefKey(itemType, itemId))
     const attemptCount = existing ? existing.attemptCount + 1 : 1
     const permanent = attemptCount >= QUARANTINE_MAX_ATTEMPTS
 
-    this.quarantinedItems.set(itemId, {
+    this.quarantinedItems.set(itemRefKey(itemType, itemId), {
       itemId,
       itemType,
       signerDeviceId,
@@ -62,11 +67,22 @@ export class QuarantineManager {
       const val = rows[0]?.value
       if (!val) return
       const entries = JSON.parse(val) as QuarantineEntry[]
-      for (const entry of entries) {
-        this.quarantinedItems.set(entry.itemId, entry)
+      // Expire stale entries: the server rows that earned a quarantine may
+      // have been repaired or purged since. If an item is still broken it
+      // re-quarantines within QUARANTINE_MAX_ATTEMPTS pulls, so dropping old
+      // entries is safe — keeping them forever is what blocked healthy items
+      // indefinitely after the 2026-07-18 server-side cleanup.
+      const now = Date.now()
+      const live = entries.filter((entry) => now - entry.failedAt < QUARANTINE_ENTRY_TTL_MS)
+      for (const entry of live) {
+        this.quarantinedItems.set(itemRefKey(entry.itemType, entry.itemId), entry)
       }
-      if (entries.length > 0) {
-        log.info('Loaded persisted quarantine state', { count: entries.length })
+      if (live.length > 0) {
+        log.info('Loaded persisted quarantine state', { count: live.length })
+      }
+      if (live.length < entries.length) {
+        log.info('Expired stale quarantine entries', { dropped: entries.length - live.length })
+        this.persistState()
       }
     } catch (err) {
       log.warn('Failed to load quarantine state', {
@@ -75,8 +91,8 @@ export class QuarantineManager {
     }
   }
 
-  isQuarantined(itemId: string): boolean {
-    const entry = this.quarantinedItems.get(itemId)
+  isQuarantined(itemId: string, itemType: string): boolean {
+    const entry = this.quarantinedItems.get(itemRefKey(itemType, itemId))
     if (!entry) return false
     return entry.attemptCount >= QUARANTINE_MAX_ATTEMPTS
   }

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -83,8 +83,16 @@ export const SYNC_STATE_KEYS = {
   LAST_SYNC_AT: 'lastSyncAt',
   SYNC_PAUSED: 'syncPaused',
   INITIAL_SEED_DONE: 'initialSeedDone',
-  QUARANTINED_ITEMS: 'quarantinedItems'
+  QUARANTINED_ITEMS: 'quarantinedItems',
+  LAST_MANIFEST_CHECK_AT: 'lastManifestCheckAt'
 } as const
+
+// Item ids are NOT unique across item types (default project id 'inbox', tag
+// ids are tag names, folder_config ids are folder paths), so every piece of
+// per-item sync bookkeeping must key on (type, id) — an id-only key makes a
+// project and a tag named 'inbox' share one entry and corrupt each other's
+// state (2026-07-18 incident).
+export const itemRefKey = (itemType: string, itemId: string): string => `${itemType}:${itemId}`
 
 export const PUSH_BATCH_SIZE = 100
 export const MAX_PUSH_ITERATIONS = 50
@@ -92,6 +100,7 @@ export const CLOCK_SKEW_THRESHOLD_SECONDS = 300
 export const PULL_PAGE_LIMIT = 100
 export const CORRUPT_ITEM_COOLDOWN_MS = 60 * 60 * 1000
 export const QUARANTINE_MAX_ATTEMPTS = 3
+export const QUARANTINE_ENTRY_TTL_MS = 7 * 24 * 60 * 60 * 1000
 export const STALE_CURSOR_THRESHOLD_MS = 24 * 60 * 60 * 1000
 export const MAX_RATE_LIMIT_BACKOFF_MS = 5 * 60 * 1000
 export const BASE_RATE_LIMIT_BACKOFF_MS = 5_000

--- a/apps/desktop/src/main/sync/key-verification.ts
+++ b/apps/desktop/src/main/sync/key-verification.ts
@@ -34,6 +34,11 @@ export function isKeyMaterialActivityRecent(): boolean {
   return Date.now() - lastKeyMaterialActivityAt < KEY_MATERIAL_ACTIVITY_WINDOW_MS
 }
 
+/** Milliseconds until the key-material transition window expires (0 when clear). */
+export function keyMaterialActivityRemainingMs(): number {
+  return Math.max(0, KEY_MATERIAL_ACTIVITY_WINDOW_MS - (Date.now() - lastKeyMaterialActivityAt))
+}
+
 /** Test-only: reset module state between test cases. */
 export function resetKeyVerificationForTests(): void {
   lastKeyMaterialActivityAt = 0

--- a/apps/desktop/src/main/sync/manifest-check.ts
+++ b/apps/desktop/src/main/sync/manifest-check.ts
@@ -11,6 +11,7 @@ import { noteCache } from '@memry/db-schema/schema/notes-cache'
 import type { RecordSyncItemType, RecordSyncManifest } from '@memry/contracts/sync-api'
 import { withRetry } from './retry'
 import { getFromServer } from './http-client'
+import { itemRefKey } from './engine/sync-context'
 import type { SyncQueueManager } from './queue'
 import { getIndexDatabase } from '../database/client'
 import { createLogger } from '../lib/logger'
@@ -27,12 +28,18 @@ interface ManifestCheckDeps {
   getAccessToken: () => Promise<string | null>
   isOnline: () => boolean
   lastCheckAt?: number
+  /** Excludes quarantined items from the server-only diff — a permanently
+   * quarantined item is skipped on every pull, so counting it server-only
+   * would reset the cursor and re-pull the whole vault on every check. */
+  isQuarantined?: (itemId: string, itemType: string) => boolean
 }
 
 export interface ManifestCheckResult {
   checkedAt: number
   rePullNeeded: boolean
   serverOnlyCount: number
+  /** True only when a manifest was actually fetched and diffed. */
+  performed: boolean
 }
 
 export async function checkManifestIntegrity(
@@ -42,13 +49,14 @@ export async function checkManifestIntegrity(
   const noAction: ManifestCheckResult = {
     checkedAt: deps.lastCheckAt ?? 0,
     rePullNeeded: false,
-    serverOnlyCount: 0
+    serverOnlyCount: 0,
+    performed: false
   }
 
   if (now - (deps.lastCheckAt ?? 0) < MIN_INTERVAL_MS) return noAction
 
   const token = await deps.getAccessToken()
-  if (!token) return { checkedAt: now, rePullNeeded: false, serverOnlyCount: 0 }
+  if (!token) return { checkedAt: now, rePullNeeded: false, serverOnlyCount: 0, performed: false }
 
   try {
     const result = await withRetry(
@@ -62,17 +70,25 @@ export async function checkManifestIntegrity(
     // diff directions must compare (type, id) pairs — an id-only diff hides a
     // missing item behind its same-id sibling of another type, and counts a
     // quarantined sibling as "server-only" forever (endless re-pull loop).
-    const refKey = (type: string, id: string): string => `${type}:${id}`
     const serverItemMap = new Map(
-      result.value.items.map((item) => [refKey(item.type, item.id), item])
+      result.value.items.map((item) => [itemRefKey(item.type, item.id), item])
     )
 
     const localItems = getLocalSyncableItems(deps.db)
-    const localKeys = new Set(localItems.map((l) => refKey(l.type, l.id)))
+    // A note held locally counts as present whether the server row calls it
+    // 'note' or 'journal' — the classification is derived and must not make
+    // the item look server-only.
+    const localKeys = new Set(
+      localItems.flatMap((l) =>
+        l.type === 'note' || l.type === 'journal'
+          ? [itemRefKey('note', l.id), itemRefKey('journal', l.id)]
+          : [itemRefKey(l.type, l.id)]
+      )
+    )
 
     let reEnqueuedCount = 0
     for (const local of localItems) {
-      const serverRef = serverItemMap.get(refKey(local.type, local.id))
+      const serverRef = serverItemMap.get(itemRefKey(local.type, local.id))
 
       if (!serverRef) {
         log.warn('Local item missing from server manifest, enqueuing as create', {
@@ -92,7 +108,8 @@ export async function checkManifestIntegrity(
     }
 
     const serverOnlyIds = result.value.items.filter(
-      (item) => !localKeys.has(refKey(item.type, item.id))
+      (item) =>
+        !localKeys.has(itemRefKey(item.type, item.id)) && !deps.isQuarantined?.(item.id, item.type)
     )
     if (serverOnlyIds.length > 0) {
       log.warn('Server has items not found locally, will trigger re-pull', {
@@ -107,11 +124,12 @@ export async function checkManifestIntegrity(
     return {
       checkedAt: now,
       rePullNeeded: serverOnlyIds.length > 0,
-      serverOnlyCount: serverOnlyIds.length
+      serverOnlyCount: serverOnlyIds.length,
+      performed: true
     }
   } catch (err) {
     log.error('Manifest integrity check failed', err)
-    return { checkedAt: now, rePullNeeded: false, serverOnlyCount: 0 }
+    return { checkedAt: now, rePullNeeded: false, serverOnlyCount: 0, performed: false }
   }
 }
 
@@ -124,9 +142,19 @@ interface LocalSyncableItem {
 function getLocalSyncableItems(db: DrizzleDb): LocalSyncableItem[] {
   const items: LocalSyncableItem[] = []
   const localIds = new Set<string>()
+  // Dedup by (type, id): a bare-id dedup silently dropped the same-id sibling
+  // of another type (project 'inbox' vs tag 'inbox'), making it look
+  // server-only on every manifest check. Notes and journals stay one dedup
+  // family: the same note id is listed by both the data DB and the index DB,
+  // and their journal-ness classification must not create a double entry.
+  const dedupKey = (item: LocalSyncableItem): string =>
+    item.type === 'note' || item.type === 'journal'
+      ? `note~journal:${item.id}`
+      : itemRefKey(item.type, item.id)
   const addLocalItem = (item: LocalSyncableItem) => {
-    if (localIds.has(item.id)) return
-    localIds.add(item.id)
+    const key = dedupKey(item)
+    if (localIds.has(key)) return
+    localIds.add(key)
     items.push(item)
   }
 

--- a/apps/desktop/src/main/sync/manifest-check.ts
+++ b/apps/desktop/src/main/sync/manifest-check.ts
@@ -58,13 +58,21 @@ export async function checkManifestIntegrity(
       }
     )
 
-    const serverItemMap = new Map(result.value.items.map((item) => [item.id, item]))
+    // Ids repeat across item types (project 'inbox' vs tag 'inbox'), so both
+    // diff directions must compare (type, id) pairs — an id-only diff hides a
+    // missing item behind its same-id sibling of another type, and counts a
+    // quarantined sibling as "server-only" forever (endless re-pull loop).
+    const refKey = (type: string, id: string): string => `${type}:${id}`
+    const serverItemMap = new Map(
+      result.value.items.map((item) => [refKey(item.type, item.id), item])
+    )
 
     const localItems = getLocalSyncableItems(deps.db)
+    const localKeys = new Set(localItems.map((l) => refKey(l.type, l.id)))
 
     let reEnqueuedCount = 0
     for (const local of localItems) {
-      const serverRef = serverItemMap.get(local.id)
+      const serverRef = serverItemMap.get(refKey(local.type, local.id))
 
       if (!serverRef) {
         log.warn('Local item missing from server manifest, enqueuing as create', {
@@ -84,7 +92,7 @@ export async function checkManifestIntegrity(
     }
 
     const serverOnlyIds = result.value.items.filter(
-      (item) => !localItems.some((l) => l.id === item.id)
+      (item) => !localKeys.has(refKey(item.type, item.id))
     )
     if (serverOnlyIds.length > 0) {
       log.warn('Server has items not found locally, will trigger re-pull', {

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -57,7 +57,11 @@ import {
   type VaultRecoveryNeededEvent
 } from '@memry/contracts/ipc-events'
 import { classifyVaultKeyError, vaultRecoveryReason } from '../crypto/vault-key-error'
-import { checkLocalKeyAgainstAccount, isKeyMaterialActivityRecent } from './key-verification'
+import {
+  checkLocalKeyAgainstAccount,
+  isKeyMaterialActivityRecent,
+  keyMaterialActivityRemainingMs
+} from './key-verification'
 import { withRetry } from './retry'
 import { withAuthRetry, type AuthRetryDeps } from './auth-retry'
 import {
@@ -118,6 +122,26 @@ function emitLocalOnly(): void {
 let runtime: SyncRuntimeState | null = null
 let startPromise: Promise<SyncEngine | null> | null = null
 let seedAbortController: AbortController | null = null
+let deferredStartTimer: NodeJS.Timeout | null = null
+
+const DEFERRED_START_GRACE_MS = 2_000
+
+// One-shot retry for a start deferred by the key-material transition window.
+// startSyncRuntime self-guards (shutdown, existing runtime, missing session),
+// so a late or redundant firing is a no-op.
+function scheduleDeferredStart(): void {
+  if (deferredStartTimer) return
+  const delay = keyMaterialActivityRemainingMs() + DEFERRED_START_GRACE_MS
+  deferredStartTimer = setTimeout(() => {
+    deferredStartTimer = null
+    void startSyncRuntime().catch((err) => {
+      log.warn('Deferred sync runtime start failed', {
+        error: err instanceof Error ? err.message : String(err)
+      })
+    })
+  }, delay)
+  deferredStartTimer.unref?.()
+}
 let seedPromise: Promise<void> | null = null
 let vaultKeyFailureLogged = false
 // Once per process: a confirmed account-key mismatch escalates (recovery
@@ -260,8 +284,11 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       const accountKeyCheck = await checkLocalKeyAgainstAccount()
       if (accountKeyCheck === 'transition') {
         // Sign-in / recovery / linking is mid-flight; the true key lands at
-        // flow finalize, which restarts the runtime itself. Just stand down.
+        // flow finalize — but the finalize's own restart usually lands INSIDE
+        // this same window and gets deferred too, leaving sync dark until an
+        // unrelated trigger. Schedule one retry for just past window expiry.
         log.info('Sync runtime deferred: key material is being re-established')
+        scheduleDeferredStart()
         return null
       }
       if (accountKeyCheck === 'mismatch') {
@@ -698,6 +725,11 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
 }
 
 export async function stopSyncRuntime(options?: { skipFinalSync?: boolean }): Promise<void> {
+  if (deferredStartTimer) {
+    clearTimeout(deferredStartTimer)
+    deferredStartTimer = null
+  }
+
   if (startPromise) {
     await startPromise.catch(() => {})
   }

--- a/apps/desktop/src/main/sync/vault-directory.test.ts
+++ b/apps/desktop/src/main/sync/vault-directory.test.ts
@@ -26,7 +26,8 @@ vi.mock('../store', () => ({
   getVaults: vi.fn(() => []),
   getCurrentVaultPath: vi.fn(() => null),
   getAccountVaultsCache: vi.fn(() => undefined),
-  setAccountVaultsCache: vi.fn()
+  setAccountVaultsCache: vi.fn(),
+  upsertVault: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -51,7 +52,8 @@ import {
   getAccountVaultsCache,
   getCurrentVaultPath,
   getVaults,
-  setAccountVaultsCache
+  setAccountVaultsCache,
+  upsertVault
 } from '../store'
 import { selectVault } from '../vault'
 import { createDormantVault } from './vault-provisioning'
@@ -308,6 +310,35 @@ describe('vault-directory', () => {
       expect(createDormantVault).toHaveBeenCalledWith(`${parent}/beta`, 'uuid-b')
       expect(selectVault).toHaveBeenCalledWith({ path: `${parent}/beta` })
       expect(result.success).toBe(true)
+    })
+
+    it('enforces the known vault uuid on the registry row when the best-effort stamp missed it', async () => {
+      // Losing the uuid association is what makes a downloaded vault look
+      // cloud-only again and mints another empty folder on the next Download.
+      const parent = '/tmp/__memry-vd-test__'
+      vi.mocked(getVaults)
+        .mockReturnValueOnce([]) // dedupe lookup: not downloaded yet
+        .mockReturnValue([
+          {
+            path: `${parent}/beta`,
+            name: 'beta',
+            noteCount: 0,
+            taskCount: 0,
+            lastOpened: '',
+            isDefault: false
+            // no vaultUuid: selectVault's best-effort stamp failed
+          }
+        ])
+      vi.mocked(getAccountVaultsCache).mockReturnValue({
+        fetchedAt: 1,
+        vaults: [{ vaultUuid: 'uuid-b', name: 'Beta', itemCount: 4, createdAt: 2000 }]
+      })
+
+      await downloadRemoteVault({ vaultUuid: 'uuid-b', parentPath: parent })
+
+      expect(upsertVault).toHaveBeenCalledWith(
+        expect.objectContaining({ path: `${parent}/beta`, vaultUuid: 'uuid-b' })
+      )
     })
   })
 })

--- a/apps/desktop/src/main/sync/vault-directory.ts
+++ b/apps/desktop/src/main/sync/vault-directory.ts
@@ -169,10 +169,11 @@ export async function downloadRemoteVault(input: {
   const result = await selectVault({ path: folder })
 
   // selectVault stamps the uuid best-effort from the data.db; here the uuid is
-  // known authoritatively, and losing it means the next Download of this vault
-  // mints yet another empty folder. Enforce it on the registry row.
+  // known authoritatively, and losing (or keeping a stale foreign) uuid means
+  // the next Download of this vault mints yet another empty folder. Enforce it
+  // on the registry row.
   const row = getVaults().find((v) => v.path === folder)
-  if (row && !row.vaultUuid) {
+  if (row && row.vaultUuid !== input.vaultUuid) {
     upsertVault({ ...row, vaultUuid: input.vaultUuid })
   }
 

--- a/apps/desktop/src/main/sync/vault-directory.ts
+++ b/apps/desktop/src/main/sync/vault-directory.ts
@@ -12,7 +12,8 @@ import {
   getAccountVaultsCache,
   getCurrentVaultPath,
   getVaults,
-  setAccountVaultsCache
+  setAccountVaultsCache,
+  upsertVault
 } from '../store'
 import { getFromServer, postToServer } from './http-client'
 import { getValidAccessToken } from './token-manager'
@@ -165,5 +166,15 @@ export async function downloadRemoteVault(input: {
   createDormantVault(folder, input.vaultUuid)
   // createDormantVault repoints the data.db singleton — open the new vault now
   // so the singleton ends on the vault the user is actually in.
-  return selectVault({ path: folder })
+  const result = await selectVault({ path: folder })
+
+  // selectVault stamps the uuid best-effort from the data.db; here the uuid is
+  // known authoritatively, and losing it means the next Download of this vault
+  // mints yet another empty folder. Enforce it on the registry row.
+  const row = getVaults().find((v) => v.path === folder)
+  if (row && !row.vaultUuid) {
+    upsertVault({ ...row, vaultUuid: input.vaultUuid })
+  }
+
+  return result
 }

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -163,7 +163,8 @@ export function createVaultInfo(vaultPath: string): VaultInfo {
     noteCount,
     taskCount: existingVault?.taskCount ?? 0,
     lastOpened: new Date().toISOString(),
-    isDefault: existingVault?.isDefault ?? getVaults().length === 0
+    isDefault: existingVault?.isDefault ?? getVaults().length === 0,
+    vaultUuid: existingVault?.vaultUuid
   }
 }
 
@@ -392,8 +393,15 @@ export async function selectVault(input: { path?: string }): Promise<SelectVault
       const { getOrCreateVaultUuid } = await import('../agent/storage/vault-id')
       const { getDatabase } = await import('../database/client')
       vaultInfo.vaultUuid = getOrCreateVaultUuid(getDatabase())
-    } catch {
-      // vault opened without a data db (or uuid minting failed) — skip
+    } catch (err) {
+      // vault opened without a data db (or uuid minting failed) — the registry
+      // keeps any previously stored uuid (createVaultInfo carries it forward),
+      // but a first-time stamp failure leaves this vault unmatched in the
+      // account directory, so make it visible instead of swallowing it.
+      logger.warn('Vault uuid stamp failed; account-directory match may be stale', {
+        vaultPath,
+        error: err instanceof Error ? err.message : String(err)
+      })
     }
 
     // Store in electron-store

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -92,6 +92,22 @@ resolves the `blob_key` stored on the row rather than re-deriving it, so old row
 without a migration. (The old layout let same-id items of different types overwrite one shared
 object, which permanently broke the losing row's signature.)
 
+### Per-item bookkeeping and retry semantics
+
+Because ids repeat across item types, every piece of client-side per-item bookkeeping — the
+signature-failure quarantine, the corrupt-item re-fetch tracker, the within-run apply dedup, and the
+manifest diff — keys on the `(type, id)` pair, never the bare id. A permanent quarantine on one type
+does not block its same-id sibling of another type, and a re-fetch that asks for one `(type, id)`
+pair ignores the sibling rows the server returns for the same id.
+
+Retry semantics: the pull cursor only advances past pages that were actually applied. A page the
+client refused (all items failed crypto, or the key was mid-transition during sign-in/recovery) does
+not move the cursor, so a manual Retry lands on the same page instead of skipping it and reporting a
+clean sync. Persisted quarantine entries expire after 7 days — if the underlying server row is still
+broken the item re-quarantines within a few pulls, and if it was repaired server-side the item flows
+again without an emergency wipe. The manifest-check throttle (30 minutes) persists in sync state, so
+engine restarts and vault switches cannot re-arm an immediate check.
+
 ## Sync Type Negotiation
 
 Clients declare the record sync item types they understand via an `X-Memry-Sync-Types` header


### PR DESCRIPTION
## What
- Quarantine, corrupt-item re-fetch, within-run apply dedup, and manifest diff all key on `(type, id)` instead of the bare item id (ids repeat across types by design: project `inbox` vs tag `inbox`).
- The pull cursor no longer advances past a refused page (all-crypto-failed / key transition), so Retry genuinely retries instead of skipping the failing page and reporting a clean sync.
- Persisted quarantine entries expire after 7 days; the manifest-check throttle persists in sync state so engine recreation cannot re-arm an immediate check (this was the endless cursor-reset re-pull loop).
- A runtime start deferred by the key-material transition window schedules its own retry at window expiry.
- Vault registry can no longer lose the server-vault uuid (merge-upsert, carry-forward in createVaultInfo, enforced stamp after dormant provisioning) — losing it made a downloaded vault look cloud-only and minted another empty folder on every Download.

## Why
Client half of the 2026-07-18 sync incident: id-collision aliasing, cursor/quarantine semantics, and registry uuid loss kept installs in an endless re-pull loop with illusory Retry success, stale quarantines blocking healthy items, and repeated dormant re-provisioning.