### PR TITLE
feat(canvas): M5 — asset externalization (memry-file:// + R2, dedup, GC)

### DIFF
--- a/apps/desktop/src/main/canvas/assets/asset-service-context.test.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service-context.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// vi.mock factories are hoisted above the file body, so the mock fns they reference
+// must come from vi.hoisted() (which runs first) — a plain top-level `const` would not
+// be initialized yet when the factory executes.
+const {
+  isDatabaseInitialized,
+  getDatabase,
+  getVaultStatus,
+  getOrCreateVaultUuid,
+  getCanvasAssetIO,
+  getValidAccessToken,
+  resolveSyncServerUrl,
+  markWritebackIgnored,
+  trackMainEvent,
+  dereferenceChunks
+} = vi.hoisted(() => ({
+  isDatabaseInitialized: vi.fn(),
+  getDatabase: vi.fn(),
+  getVaultStatus: vi.fn(),
+  getOrCreateVaultUuid: vi.fn(),
+  getCanvasAssetIO: vi.fn(),
+  getValidAccessToken: vi.fn(),
+  resolveSyncServerUrl: vi.fn(),
+  markWritebackIgnored: vi.fn(),
+  trackMainEvent: vi.fn(),
+  dereferenceChunks: vi.fn()
+}))
+
+vi.mock('../../database/client', () => ({ isDatabaseInitialized, getDatabase }))
+vi.mock('../../vault/index', () => ({ getStatus: getVaultStatus }))
+vi.mock('../../agent/storage/vault-id', () => ({ getOrCreateVaultUuid }))
+vi.mock('../../ipc/sync-attachment-handlers', () => ({ getCanvasAssetIO }))
+vi.mock('../../sync/token-manager', () => ({ getValidAccessToken }))
+vi.mock('../../sync/sync-server-url', () => ({ resolveSyncServerUrl }))
+vi.mock('../../sync/crdt-writeback', () => ({ markWritebackIgnored }))
+vi.mock('../../telemetry/track', () => ({ trackMainEvent }))
+vi.mock('./attachment-dereference', () => ({ dereferenceChunks }))
+
+import { buildAssetServiceContext } from './asset-service-context'
+
+describe('buildAssetServiceContext', () => {
+  const fakeDb = { marker: 'db' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isDatabaseInitialized.mockReturnValue(true)
+    getVaultStatus.mockReturnValue({ path: '/vault/path' })
+    getDatabase.mockReturnValue(fakeDb)
+    getOrCreateVaultUuid.mockReturnValue('vault-uuid-1')
+  })
+
+  it('returns null when the database is not initialized', () => {
+    isDatabaseInitialized.mockReturnValue(false)
+
+    expect(buildAssetServiceContext()).toBeNull()
+    expect(getVaultStatus).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the vault has no path (vault not open)', () => {
+    getVaultStatus.mockReturnValue({ path: '' })
+
+    expect(buildAssetServiceContext()).toBeNull()
+    expect(getDatabase).not.toHaveBeenCalled()
+  })
+
+  it('returns a populated context wired to the vault db/id/path when open', () => {
+    const ctx = buildAssetServiceContext()
+
+    expect(ctx).not.toBeNull()
+    expect(ctx?.db).toBe(fakeDb)
+    expect(ctx?.vaultId).toBe('vault-uuid-1')
+    expect(ctx?.vaultPath).toBe('/vault/path')
+    expect(ctx?.markWritebackIgnored).toBe(markWritebackIgnored)
+    expect(ctx?.trackEvent).toBe(trackMainEvent)
+  })
+
+  describe('uploadAttachment', () => {
+    it('rejects when getCanvasAssetIO() is null (sync not initialized)', async () => {
+      getCanvasAssetIO.mockReturnValue(null)
+      const ctx = buildAssetServiceContext()
+
+      await expect(ctx!.uploadAttachment('canvas-1', '/tmp/file.png')).rejects.toThrow(
+        'Sync is not initialized'
+      )
+    })
+
+    it('delegates to the resolved IO when sync is initialized', async () => {
+      const uploadResult = { attachmentId: 'att-1', manifest: { chunks: [] } }
+      const uploadAttachment = vi.fn().mockResolvedValue(uploadResult)
+      getCanvasAssetIO.mockReturnValue({ uploadAttachment, downloadAttachment: vi.fn() })
+      const ctx = buildAssetServiceContext()
+
+      const result = await ctx!.uploadAttachment('canvas-1', '/tmp/file.png')
+
+      expect(uploadAttachment).toHaveBeenCalledWith('canvas-1', '/tmp/file.png')
+      expect(result).toBe(uploadResult)
+    })
+  })
+
+  describe('downloadAttachment', () => {
+    it('rejects when getCanvasAssetIO() is null (sync not initialized)', async () => {
+      getCanvasAssetIO.mockReturnValue(null)
+      const ctx = buildAssetServiceContext()
+
+      await expect(ctx!.downloadAttachment('att-1', '/tmp/target.png')).rejects.toThrow(
+        'Sync is not initialized'
+      )
+    })
+
+    it('delegates to the resolved IO when sync is initialized', async () => {
+      const downloadAttachment = vi.fn().mockResolvedValue(undefined)
+      getCanvasAssetIO.mockReturnValue({ uploadAttachment: vi.fn(), downloadAttachment })
+      const ctx = buildAssetServiceContext()
+
+      await ctx!.downloadAttachment('att-1', '/tmp/target.png')
+
+      expect(downloadAttachment).toHaveBeenCalledWith('att-1', '/tmp/target.png')
+    })
+  })
+
+  describe('dereference', () => {
+    it('maps dereferenceChunks({ok}) through, dropping the status field', async () => {
+      dereferenceChunks.mockResolvedValue({ ok: true, status: 200 })
+      getValidAccessToken.mockResolvedValue('token-abc')
+      resolveSyncServerUrl.mockReturnValue('https://sync.example.com')
+      const ctx = buildAssetServiceContext()
+
+      const result = await ctx!.dereference(['chunk-1', 'chunk-2'])
+
+      expect(result).toEqual({ ok: true })
+      expect(dereferenceChunks).toHaveBeenCalledWith(
+        ['chunk-1', 'chunk-2'],
+        expect.objectContaining({
+          getAccessToken: expect.any(Function),
+          getSyncServerUrl: expect.any(Function),
+          getVaultId: expect.any(Function)
+        })
+      )
+
+      const deps = dereferenceChunks.mock.calls[0][1]
+      await expect(deps.getAccessToken()).resolves.toBe('token-abc')
+      expect(deps.getSyncServerUrl()).toBe('https://sync.example.com')
+      expect(deps.getVaultId()).toBe('vault-uuid-1')
+    })
+
+    it('surfaces ok:false without throwing (offline / 404 / missing token)', async () => {
+      dereferenceChunks.mockResolvedValue({ ok: false, status: 0 })
+      const ctx = buildAssetServiceContext()
+
+      const result = await ctx!.dereference(['chunk-1'])
+
+      expect(result).toEqual({ ok: false })
+    })
+  })
+})

--- a/apps/desktop/src/main/canvas/assets/asset-service-context.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service-context.ts
@@ -57,9 +57,10 @@ export function buildAssetServiceContext(): AssetServiceContext | null {
       await io.downloadAttachment(attachmentId, targetPath)
     },
     dereference: async (chunkHashes) => {
-      // Never throws: a 404 / missing token / offline degrades to a no-op so
-      // GC can never break a canvas save or delete.
-      await dereferenceChunks(chunkHashes, dereferenceDeps)
+      // Never throws: a 404 / missing token / offline degrades to `{ ok: false }` so GC can
+      // never break a canvas save or delete, and the caller keeps the rows to retry later.
+      const { ok } = await dereferenceChunks(chunkHashes, dereferenceDeps)
+      return { ok }
     },
     markWritebackIgnored,
     trackEvent: trackMainEvent

--- a/apps/desktop/src/main/canvas/assets/asset-service-context.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service-context.ts
@@ -1,0 +1,67 @@
+/**
+ * Real-runtime wiring for the canvas {@link AssetServiceContext}.
+ *
+ * This is the ONE seam that reaches into the sync runtime: it reuses the
+ * shared AttachmentSyncService / upload-queue singletons (via
+ * `getCanvasAssetIO`), the sync token/url resolvers, the writeback-ignore
+ * guard, and the server dereference client. It lives under `main/canvas/`
+ * (a feature module) rather than in `canvas-handlers.ts` because the IPC
+ * boundary may not import `main/sync/**`; the architecture check permits a
+ * feature module to depend on the sync internals it composes here.
+ */
+
+import { getOrCreateVaultUuid } from '../../agent/storage/vault-id'
+import { getDatabase, isDatabaseInitialized } from '../../database/client'
+import { getCanvasAssetIO } from '../../ipc/sync-attachment-handlers'
+import { markWritebackIgnored } from '../../sync/crdt-writeback'
+import { resolveSyncServerUrl } from '../../sync/sync-server-url'
+import { getValidAccessToken } from '../../sync/token-manager'
+import { trackMainEvent } from '../../telemetry/track'
+import { getStatus as getVaultStatus } from '../../vault/index'
+
+import { dereferenceChunks, type DereferenceDeps } from './attachment-dereference'
+import type { AssetServiceContext } from './asset-service'
+
+/**
+ * Assemble the real asset-service context, or `null` when the vault is not
+ * open / the database is not initialized (read handlers degrade to empty,
+ * write handlers skip asset work — offline-safe). The attachment IO is
+ * resolved lazily so read-only asset lookups work even before sync is up.
+ */
+export function buildAssetServiceContext(): AssetServiceContext | null {
+  if (!isDatabaseInitialized()) return null
+  const vaultPath = getVaultStatus().path
+  if (!vaultPath) return null
+
+  const db = getDatabase()
+  const vaultId = getOrCreateVaultUuid(db)
+
+  const dereferenceDeps: DereferenceDeps = {
+    getAccessToken: () => getValidAccessToken(),
+    getSyncServerUrl: () => resolveSyncServerUrl(),
+    getVaultId: () => vaultId
+  }
+
+  return {
+    db,
+    vaultId,
+    vaultPath,
+    uploadAttachment: async (canvasId, filePath) => {
+      const io = getCanvasAssetIO()
+      if (!io) throw new Error('Sync is not initialized')
+      return io.uploadAttachment(canvasId, filePath)
+    },
+    downloadAttachment: async (attachmentId, targetPath) => {
+      const io = getCanvasAssetIO()
+      if (!io) throw new Error('Sync is not initialized')
+      await io.downloadAttachment(attachmentId, targetPath)
+    },
+    dereference: async (chunkHashes) => {
+      // Never throws: a 404 / missing token / offline degrades to a no-op so
+      // GC can never break a canvas save or delete.
+      await dereferenceChunks(chunkHashes, dereferenceDeps)
+    },
+    markWritebackIgnored,
+    trackEvent: trackMainEvent
+  }
+}

--- a/apps/desktop/src/main/canvas/assets/asset-service.test.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service.test.ts
@@ -1,0 +1,304 @@
+import { describe, beforeEach, afterEach, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+
+import * as schema from '@memry/db-schema/data-schema'
+import type { MemryAssetDescriptor } from '@memry/contracts/canvas-api'
+
+import {
+  ensureAssetsPresent,
+  reconcileCanvasAssets,
+  uploadCanvasAsset,
+  canvasAssetDiskPath,
+  type AssetServiceContext,
+  type AssetUploadResult
+} from './asset-service'
+import { listAssetsByCanvas, recordAsset } from './asset-store'
+import { hashAssetContent, assetFilename } from './content-hash'
+
+const MIGRATION_FILES = ['0035_spatial_canvas.sql', '0036_canvas_assets.sql']
+
+function freshDb() {
+  const sqlite = new Database(':memory:')
+  sqlite.pragma('foreign_keys = ON')
+  for (const file of MIGRATION_FILES) {
+    const sql = fs.readFileSync(
+      path.join(__dirname, '..', '..', 'database', 'drizzle-data', file),
+      'utf8'
+    )
+    for (const statement of sql.split('--> statement-breakpoint')) {
+      const trimmed = statement.trim()
+      if (trimmed) sqlite.exec(trimmed)
+    }
+  }
+  return drizzle(sqlite, { schema })
+}
+
+function insertCanvas(db: ReturnType<typeof freshDb>, id: string, vaultId: string) {
+  db.insert(schema.canvases)
+    .values({
+      id,
+      vaultId,
+      title: null,
+      snapshotCiphertext: 'ciphertext',
+      vectorClock: {},
+      createdAt: 1700000000000,
+      updatedAt: 1700000000000,
+      deletedAt: null,
+      lastSyncedAt: null,
+      clock: null
+    })
+    .run()
+}
+
+/** A scene JSON whose only externalized file points at the given content hash. */
+function sceneWithHashes(hashes: string[]): string {
+  const files: Record<string, { dataURL: string }> = {}
+  hashes.forEach((hash, i) => {
+    files[`file-${i}`] = {
+      dataURL: `memry-file://local/x/attachments/canvas-assets/${hash}.png`
+    }
+  })
+  return JSON.stringify({ type: 'excalidraw', files })
+}
+
+describe('canvas asset service', () => {
+  let db: ReturnType<typeof freshDb>
+  let vaultPath: string
+  let uploadAttachment: ReturnType<typeof vi.fn>
+  let downloadAttachment: ReturnType<typeof vi.fn>
+  let dereference: ReturnType<typeof vi.fn>
+  let markWritebackIgnored: ReturnType<typeof vi.fn>
+  let trackEvent: ReturnType<typeof vi.fn>
+  let ctx: AssetServiceContext
+
+  beforeEach(() => {
+    db = freshDb()
+    insertCanvas(db, 'canvas-a', 'vault-1')
+    insertCanvas(db, 'canvas-b', 'vault-1')
+    vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'canvas-assets-'))
+
+    let counter = 0
+    uploadAttachment = vi.fn(
+      async (): Promise<AssetUploadResult> => ({
+        attachmentId: `attachment-${++counter}`,
+        manifest: {
+          chunks: [{ encryptedHash: `enc-${counter}-0` }, { encryptedHash: `enc-${counter}-1` }]
+        }
+      })
+    )
+    downloadAttachment = vi.fn(async (_attachmentId: string, targetPath: string) => {
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+      fs.writeFileSync(targetPath, Buffer.from('downloaded'))
+    })
+    dereference = vi.fn(async () => {})
+    markWritebackIgnored = vi.fn()
+    trackEvent = vi.fn()
+
+    ctx = {
+      db,
+      vaultId: 'vault-1',
+      vaultPath,
+      uploadAttachment,
+      downloadAttachment,
+      dereference,
+      markWritebackIgnored,
+      trackEvent
+    }
+  })
+
+  afterEach(() => {
+    fs.rmSync(vaultPath, { recursive: true, force: true })
+  })
+
+  describe('uploadCanvasAsset', () => {
+    it('uploads a new asset: calls the upload fn once and records chunkHashes from the manifest', async () => {
+      const bytes = Buffer.from('the-image-bytes')
+      const res = await uploadCanvasAsset(ctx, 'canvas-a', 'file-1', 'image/png', bytes)
+
+      expect(res.deduped).toBe(false)
+      expect(uploadAttachment).toHaveBeenCalledTimes(1)
+      expect(res.descriptor.chunkHashes).toEqual(['enc-1-0', 'enc-1-1'])
+      expect(res.descriptor.attachmentId).toBe('attachment-1')
+
+      const rows = listAssetsByCanvas(db, 'canvas-a')
+      expect(rows).toHaveLength(1)
+      expect(rows[0].chunkHashes).toEqual(['enc-1-0', 'enc-1-1'])
+      expect(rows[0].sizeBytes).toBe(bytes.length)
+
+      // File materialized on disk under the content-addressed store.
+      const diskPath = canvasAssetDiskPath(
+        vaultPath,
+        assetFilename(hashAssetContent(bytes), 'image/png')
+      )
+      expect(fs.existsSync(diskPath)).toBe(true)
+      expect(markWritebackIgnored).toHaveBeenCalledWith(diskPath)
+
+      expect(trackEvent).toHaveBeenCalledWith(
+        'canvas_asset_uploaded',
+        expect.objectContaining({ metrics: { byteCount: bytes.length } })
+      )
+    })
+
+    it('dedup hit: a second upload of identical bytes reuses the attachment and does not re-upload', async () => {
+      const bytes = Buffer.from('shared-image-bytes')
+      const first = await uploadCanvasAsset(ctx, 'canvas-a', 'file-1', 'image/png', bytes)
+      const second = await uploadCanvasAsset(ctx, 'canvas-b', 'file-9', 'image/png', bytes)
+
+      expect(first.deduped).toBe(false)
+      expect(second.deduped).toBe(true)
+      // The upload fn ran only for the first upload.
+      expect(uploadAttachment).toHaveBeenCalledTimes(1)
+      expect(second.descriptor.attachmentId).toBe(first.descriptor.attachmentId)
+      expect(second.ref).toBe(first.ref)
+      expect(second.descriptor.chunkHashes).toEqual(first.descriptor.chunkHashes)
+
+      // Both canvases now have their own dedup/GC row for the shared content.
+      expect(listAssetsByCanvas(db, 'canvas-a')).toHaveLength(1)
+      expect(listAssetsByCanvas(db, 'canvas-b')).toHaveLength(1)
+
+      expect(trackEvent).toHaveBeenCalledWith(
+        'canvas_asset_dedup_hit',
+        expect.objectContaining({ metrics: { byteCount: bytes.length } })
+      )
+    })
+  })
+
+  describe('reconcileCanvasAssets', () => {
+    function seedRow(canvasId: string, contentHash: string, chunk: string) {
+      recordAsset(db, {
+        vaultId: 'vault-1',
+        canvasId,
+        contentHash,
+        attachmentId: `att-${contentHash}`,
+        fileId: `fid-${contentHash}`,
+        filename: `${contentHash}.png`,
+        mimeType: 'image/png',
+        sizeBytes: 10,
+        chunkHashes: [chunk],
+        createdAt: 1700000000000
+      })
+    }
+
+    it('dereferences only assets no other canvas references and prunes the removed rows', async () => {
+      // canvas-a references hashA (shared), hashB (unique), hashC (shared).
+      seedRow('canvas-a', 'hashA', 'chunkA')
+      seedRow('canvas-a', 'hashB', 'chunkB')
+      seedRow('canvas-a', 'hashC', 'chunkC')
+      // canvas-b also references hashA and hashC.
+      seedRow('canvas-b', 'hashA', 'chunkA')
+      seedRow('canvas-b', 'hashC', 'chunkC')
+
+      // Write the on-disk files so the safe-unlink path can be exercised.
+      const dir = path.join(vaultPath, 'attachments', 'canvas-assets')
+      fs.mkdirSync(dir, { recursive: true })
+      for (const h of ['hashA', 'hashB', 'hashC']) {
+        fs.writeFileSync(path.join(dir, `${h}.png`), Buffer.from(h))
+      }
+
+      // The saved scene keeps only hashA.
+      await reconcileCanvasAssets(ctx, 'canvas-a', sceneWithHashes(['hashA']))
+
+      // Only hashB (referenced by nobody else) is dereferenced.
+      expect(dereference).toHaveBeenCalledTimes(1)
+      expect(dereference).toHaveBeenCalledWith(['chunkB'])
+
+      // canvas-a keeps hashA; hashB + hashC rows pruned.
+      expect(listAssetsByCanvas(db, 'canvas-a').map((r) => r.contentHash)).toEqual(['hashA'])
+      // canvas-b untouched.
+      expect(
+        listAssetsByCanvas(db, 'canvas-b')
+          .map((r) => r.contentHash)
+          .sort()
+      ).toEqual(['hashA', 'hashC'])
+
+      // Safe unlink: hashB's file removed (orphan); hashA (kept) and hashC
+      // (shared with canvas-b) stay on disk.
+      expect(fs.existsSync(path.join(dir, 'hashB.png'))).toBe(false)
+      expect(fs.existsSync(path.join(dir, 'hashA.png'))).toBe(true)
+      expect(fs.existsSync(path.join(dir, 'hashC.png'))).toBe(true)
+
+      expect(trackEvent).toHaveBeenCalledWith(
+        'canvas_asset_gc_reaped',
+        expect.objectContaining({ metrics: { itemCount: 2 } })
+      )
+    })
+
+    it('is a no-op when the scene still references every recorded asset', async () => {
+      seedRow('canvas-a', 'hashA', 'chunkA')
+      await reconcileCanvasAssets(ctx, 'canvas-a', sceneWithHashes(['hashA']))
+      expect(dereference).not.toHaveBeenCalled()
+      expect(listAssetsByCanvas(db, 'canvas-a')).toHaveLength(1)
+    })
+  })
+
+  describe('ensureAssetsPresent', () => {
+    function descriptor(overrides: Partial<MemryAssetDescriptor>): MemryAssetDescriptor {
+      return {
+        fileId: 'fid',
+        attachmentId: 'att',
+        contentHash: 'hash',
+        chunkHashes: ['chunk'],
+        mimeType: 'image/png',
+        sizeBytes: 10,
+        filename: 'hash.png',
+        ...overrides
+      }
+    }
+
+    it('downloads only missing files, marks writeback ignored first, and survives a failed download', async () => {
+      const present = descriptor({
+        contentHash: 'present',
+        filename: 'present.png',
+        attachmentId: 'a-present'
+      })
+      const missing = descriptor({
+        contentHash: 'missing',
+        filename: 'missing.png',
+        attachmentId: 'a-missing'
+      })
+      const failing = descriptor({
+        contentHash: 'failing',
+        filename: 'failing.png',
+        attachmentId: 'a-failing'
+      })
+
+      // Pre-create the "present" file so it is skipped.
+      const presentPath = canvasAssetDiskPath(vaultPath, 'present.png')
+      fs.mkdirSync(path.dirname(presentPath), { recursive: true })
+      fs.writeFileSync(presentPath, Buffer.from('already-here'))
+
+      downloadAttachment.mockImplementation(async (attachmentId: string, targetPath: string) => {
+        if (attachmentId === 'a-failing') throw new Error('network down')
+        fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+        fs.writeFileSync(targetPath, Buffer.from('downloaded'))
+      })
+
+      await ensureAssetsPresent(ctx, 'canvas-a', [present, missing, failing])
+
+      // Only the two missing files were attempted.
+      expect(downloadAttachment).toHaveBeenCalledTimes(2)
+      expect(downloadAttachment).toHaveBeenCalledWith(
+        'a-missing',
+        canvasAssetDiskPath(vaultPath, 'missing.png')
+      )
+      expect(downloadAttachment).toHaveBeenCalledWith(
+        'a-failing',
+        canvasAssetDiskPath(vaultPath, 'failing.png')
+      )
+
+      // markWritebackIgnored precedes each download.
+      const firstMark = markWritebackIgnored.mock.invocationCallOrder[0]
+      const firstDownload = downloadAttachment.mock.invocationCallOrder[0]
+      expect(firstMark).toBeLessThan(firstDownload)
+
+      // The successful download recorded a local row; the failure did not abort it.
+      const rows = listAssetsByCanvas(db, 'canvas-a').map((r) => r.contentHash)
+      expect(rows).toContain('missing')
+      expect(rows).not.toContain('failing')
+    })
+  })
+})

--- a/apps/desktop/src/main/canvas/assets/asset-service.test.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service.test.ts
@@ -13,11 +13,15 @@ import {
   reconcileCanvasAssets,
   uploadCanvasAsset,
   canvasAssetDiskPath,
+  getCanvasAssetRef,
+  listCanvasAssetDescriptors,
+  injectSceneAssetSidecar,
   type AssetServiceContext,
   type AssetUploadResult
 } from './asset-service'
 import { listAssetsByCanvas, recordAsset } from './asset-store'
 import { hashAssetContent, assetFilename } from './content-hash'
+import { toMemryFileUrl } from '../../lib/paths'
 
 const MIGRATION_FILES = ['0035_spatial_canvas.sql', '0036_canvas_assets.sql']
 
@@ -203,6 +207,37 @@ describe('canvas asset service', () => {
       expect(fs.existsSync(recordedDiskPath)).toBe(true)
       expect(fs.existsSync(staleDiskPath)).toBe(false)
     })
+
+    it('dedup hit: re-materializes the file when the recorded content is missing on this device', async () => {
+      const bytes = Buffer.from('device-b-is-missing-this-file')
+      const contentHash = hashAssetContent(bytes)
+      const filename = assetFilename(contentHash, 'image/png')
+
+      // A row exists (synced from another device) but the bytes were never
+      // downloaded to this device's content-addressed store.
+      recordAsset(db, {
+        vaultId: 'vault-1',
+        canvasId: 'canvas-a',
+        contentHash,
+        attachmentId: 'attachment-remote',
+        fileId: 'file-remote',
+        filename,
+        mimeType: 'image/png',
+        sizeBytes: bytes.length,
+        chunkHashes: ['chunk-remote'],
+        createdAt: 1700000000000
+      })
+      const diskPath = canvasAssetDiskPath(vaultPath, filename)
+      expect(fs.existsSync(diskPath)).toBe(false)
+
+      const res = await uploadCanvasAsset(ctx, 'canvas-b', 'file-2', 'image/png', bytes)
+
+      expect(res.deduped).toBe(true)
+      expect(uploadAttachment).not.toHaveBeenCalled()
+      expect(markWritebackIgnored).toHaveBeenCalledWith(diskPath)
+      expect(fs.existsSync(diskPath)).toBe(true)
+      expect(fs.readFileSync(diskPath)).toEqual(bytes)
+    })
   })
 
   describe('reconcileCanvasAssets', () => {
@@ -371,6 +406,125 @@ describe('canvas asset service', () => {
       const rows = listAssetsByCanvas(db, 'canvas-a').map((r) => r.contentHash)
       expect(rows).toContain('missing')
       expect(rows).not.toContain('failing')
+    })
+  })
+
+  describe('getCanvasAssetRef', () => {
+    it('resolves the memry-file:// ref for a recorded fileId', () => {
+      recordAsset(db, {
+        vaultId: 'vault-1',
+        canvasId: 'canvas-a',
+        contentHash: 'hashRef',
+        attachmentId: 'att-ref',
+        fileId: 'file-ref',
+        filename: 'hashRef.png',
+        mimeType: 'image/png',
+        sizeBytes: 5,
+        chunkHashes: ['chunk-ref'],
+        createdAt: 1700000000000
+      })
+
+      const ref = getCanvasAssetRef(ctx, 'canvas-a', 'file-ref')
+
+      expect(ref).toBe(toMemryFileUrl(canvasAssetDiskPath(vaultPath, 'hashRef.png')))
+    })
+
+    it('returns null when there is no recorded asset for the fileId', () => {
+      expect(getCanvasAssetRef(ctx, 'canvas-a', 'unknown-file')).toBeNull()
+    })
+  })
+
+  describe('listCanvasAssetDescriptors', () => {
+    it('maps every recorded row for a canvas to its descriptor', () => {
+      recordAsset(db, {
+        vaultId: 'vault-1',
+        canvasId: 'canvas-a',
+        contentHash: 'hashD1',
+        attachmentId: 'att-d1',
+        fileId: 'file-d1',
+        filename: 'hashD1.png',
+        mimeType: 'image/png',
+        sizeBytes: 11,
+        chunkHashes: ['chunk-d1'],
+        createdAt: 1700000000000
+      })
+      recordAsset(db, {
+        vaultId: 'vault-1',
+        canvasId: 'canvas-a',
+        contentHash: 'hashD2',
+        attachmentId: 'att-d2',
+        fileId: 'file-d2',
+        filename: 'hashD2.png',
+        mimeType: 'image/png',
+        sizeBytes: 22,
+        chunkHashes: ['chunk-d2'],
+        createdAt: 1700000000000
+      })
+
+      const descriptors = listCanvasAssetDescriptors(ctx, 'canvas-a')
+
+      expect(descriptors.map((d) => d.fileId).sort()).toEqual(['file-d1', 'file-d2'])
+      const d1 = descriptors.find((d) => d.fileId === 'file-d1')
+      expect(d1).toEqual({
+        fileId: 'file-d1',
+        attachmentId: 'att-d1',
+        contentHash: 'hashD1',
+        chunkHashes: ['chunk-d1'],
+        mimeType: 'image/png',
+        sizeBytes: 11,
+        filename: 'hashD1.png'
+      })
+    })
+
+    it('returns an empty array for a canvas with no recorded assets', () => {
+      expect(listCanvasAssetDescriptors(ctx, 'canvas-a')).toEqual([])
+    })
+  })
+
+  describe('injectSceneAssetSidecar', () => {
+    it('returns the scene unchanged when it is empty', () => {
+      expect(injectSceneAssetSidecar(ctx, 'canvas-a', '')).toBe('')
+    })
+
+    it('returns the scene unchanged when it fails to parse (never corrupts it)', () => {
+      const broken = '{not json'
+      expect(injectSceneAssetSidecar(ctx, 'canvas-a', broken)).toBe(broken)
+    })
+
+    it('injects only the descriptors still referenced by the scene', () => {
+      recordAsset(db, {
+        vaultId: 'vault-1',
+        canvasId: 'canvas-a',
+        contentHash: 'hashKept',
+        attachmentId: 'att-kept',
+        fileId: 'file-kept',
+        filename: 'hashKept.png',
+        mimeType: 'image/png',
+        sizeBytes: 7,
+        chunkHashes: ['chunk-kept'],
+        createdAt: 1700000000000
+      })
+      recordAsset(db, {
+        vaultId: 'vault-1',
+        canvasId: 'canvas-a',
+        contentHash: 'hashStale',
+        attachmentId: 'att-stale',
+        fileId: 'file-stale',
+        filename: 'hashStale.png',
+        mimeType: 'image/png',
+        sizeBytes: 8,
+        chunkHashes: ['chunk-stale'],
+        createdAt: 1700000000000
+      })
+
+      // The scene's files map only still references hashKept.
+      const scene = sceneWithHashes(['hashKept'])
+      const result = injectSceneAssetSidecar(ctx, 'canvas-a', scene)
+      const parsed = JSON.parse(result) as { memryAssets: MemryAssetDescriptor[] }
+
+      expect(parsed.memryAssets).toHaveLength(1)
+      expect(parsed.memryAssets[0].contentHash).toBe('hashKept')
+      expect(parsed.memryAssets[0].fileId).toBe('file-kept')
     })
   })
 })

--- a/apps/desktop/src/main/canvas/assets/asset-service.test.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service.test.ts
@@ -165,6 +165,44 @@ describe('canvas asset service', () => {
         expect.objectContaining({ metrics: { byteCount: bytes.length } })
       )
     })
+
+    it('dedup hit: resolves ref/path/filename from the RECORDED filename, not the locally-computed one', async () => {
+      const bytes = Buffer.from('mismatched-extension-bytes')
+      const contentHash = hashAssetContent(bytes)
+      const recordedFilename = `${contentHash}.png`
+
+      // Pre-seed a row recorded under .png (e.g. first upload declared image/png).
+      recordAsset(db, {
+        vaultId: 'vault-1',
+        canvasId: 'canvas-a',
+        contentHash,
+        attachmentId: 'attachment-seed',
+        fileId: 'file-seed',
+        filename: recordedFilename,
+        mimeType: 'image/png',
+        sizeBytes: bytes.length,
+        chunkHashes: ['chunk-seed'],
+        createdAt: 1700000000000
+      })
+
+      // This upload declares a DIFFERENT mimeType for the same bytes, so the
+      // locally-computed filename (.webp) diverges from the recorded one (.png).
+      const res = await uploadCanvasAsset(ctx, 'canvas-b', 'file-2', 'image/webp', bytes)
+
+      expect(res.deduped).toBe(true)
+      expect(uploadAttachment).not.toHaveBeenCalled()
+      expect(res.descriptor.filename).toBe(recordedFilename)
+      expect(res.descriptor.attachmentId).toBe('attachment-seed')
+
+      const recordedDiskPath = canvasAssetDiskPath(vaultPath, recordedFilename)
+      const staleDiskPath = canvasAssetDiskPath(vaultPath, `${contentHash}.webp`)
+      expect(res.ref.endsWith(recordedFilename)).toBe(true)
+      expect(res.ref).not.toContain('.webp')
+
+      // The file materializes at the RECORDED path, never at the locally-computed one.
+      expect(fs.existsSync(recordedDiskPath)).toBe(true)
+      expect(fs.existsSync(staleDiskPath)).toBe(false)
+    })
   })
 
   describe('reconcileCanvasAssets', () => {

--- a/apps/desktop/src/main/canvas/assets/asset-service.test.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service.test.ts
@@ -94,7 +94,7 @@ describe('canvas asset service', () => {
       fs.mkdirSync(path.dirname(targetPath), { recursive: true })
       fs.writeFileSync(targetPath, Buffer.from('downloaded'))
     })
-    dereference = vi.fn(async () => {})
+    dereference = vi.fn(async () => ({ ok: true }))
     markWritebackIgnored = vi.fn()
     trackEvent = vi.fn()
 
@@ -259,9 +259,11 @@ describe('canvas asset service', () => {
       expect(fs.existsSync(path.join(dir, 'hashA.png'))).toBe(true)
       expect(fs.existsSync(path.join(dir, 'hashC.png'))).toBe(true)
 
+      // Only hashB is actually reaped on the server (hashC's local row is pruned but its
+      // server chunk stays — canvas-b still references it), so the metric counts 1.
       expect(trackEvent).toHaveBeenCalledWith(
         'canvas_asset_gc_reaped',
-        expect.objectContaining({ metrics: { itemCount: 2 } })
+        expect.objectContaining({ metrics: { itemCount: 1 } })
       )
     })
 
@@ -270,6 +272,38 @@ describe('canvas asset service', () => {
       await reconcileCanvasAssets(ctx, 'canvas-a', sceneWithHashes(['hashA']))
       expect(dereference).not.toHaveBeenCalled()
       expect(listAssetsByCanvas(db, 'canvas-a')).toHaveLength(1)
+    })
+
+    it('keeps orphaned rows for retry when the server dereference fails (e.g. endpoint not yet deployed)', async () => {
+      seedRow('canvas-a', 'hashB', 'chunkB')
+      const dir = path.join(vaultPath, 'attachments', 'canvas-assets')
+      fs.mkdirSync(dir, { recursive: true })
+      fs.writeFileSync(path.join(dir, 'hashB.png'), Buffer.from('hashB'))
+
+      // 404 / offline → dereference reports failure.
+      dereference.mockResolvedValueOnce({ ok: false })
+
+      await reconcileCanvasAssets(ctx, 'canvas-a', sceneWithHashes([]))
+
+      // The server WAS called, but because it failed the local row + file are KEPT so a
+      // later reconcile can retry — the chunkHashes are not lost and ref_count won't leak.
+      expect(dereference).toHaveBeenCalledWith(['chunkB'])
+      expect(listAssetsByCanvas(db, 'canvas-a').map((r) => r.contentHash)).toEqual(['hashB'])
+      expect(fs.existsSync(path.join(dir, 'hashB.png'))).toBe(true)
+      expect(trackEvent).not.toHaveBeenCalledWith('canvas_asset_gc_reaped', expect.anything())
+    })
+
+    it('prunes a shared-removed row without any server call', async () => {
+      // hashS referenced by canvas-a AND canvas-b; canvas-a drops it from its scene.
+      seedRow('canvas-a', 'hashS', 'chunkS')
+      seedRow('canvas-b', 'hashS', 'chunkS')
+
+      await reconcileCanvasAssets(ctx, 'canvas-a', sceneWithHashes([]))
+
+      // No dereference (canvas-b still holds it), but canvas-a's row is pruned.
+      expect(dereference).not.toHaveBeenCalled()
+      expect(listAssetsByCanvas(db, 'canvas-a')).toHaveLength(0)
+      expect(listAssetsByCanvas(db, 'canvas-b').map((r) => r.contentHash)).toEqual(['hashS'])
     })
   })
 

--- a/apps/desktop/src/main/canvas/assets/asset-service.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service.ts
@@ -63,7 +63,10 @@ export interface AssetServiceContext {
   /** Download an attachment to targetPath through the shared attachment pipeline. */
   downloadAttachment: (attachmentId: string, targetPath: string) => Promise<void>
   /** Best-effort server ref_count decrement for GC'd chunks. Never throws. */
-  dereference: (chunkHashes: string[]) => Promise<void>
+  /** Decrement server ref_count for these chunk hashes. Never throws; `ok` is false on a
+   *  404 (endpoint not yet deployed) / missing token / offline, so the caller can keep the
+   *  rows that hold these hashes and retry on a later reconcile instead of leaking ref_count. */
+  dereference: (chunkHashes: string[]) => Promise<{ ok: boolean }>
   /** Suppress the vault watcher's re-upload loop before writing/downloading a file. */
   markWritebackIgnored: (absolutePath: string) => void
   trackEvent: (name: TelemetryEventName, options: TrackMainEventOptions) => void
@@ -256,26 +259,42 @@ export async function reconcileCanvasAssets(
   const plan = planDereference(prev, current, others)
   if (plan.removedContentHashes.length === 0) return
 
-  deleteCanvasAssetRows(ctx.db, canvasId, plan.removedContentHashes)
-
-  if (plan.dereferenceChunkHashes.length > 0) {
-    // dereference never throws — GC must not break a save/delete.
-    await ctx.dereference(plan.dereferenceChunkHashes)
-    ctx.trackEvent('canvas_asset_gc_reaped', {
-      surface: 'sync',
-      action: 'gc',
-      objectType: 'canvas',
-      result: 'success',
-      metrics: { itemCount: plan.removedContentHashes.length }
-    })
+  // Shared removed content — still referenced by another canvas, so no server call is needed;
+  // prune the local row immediately.
+  const dereferenced = new Set(plan.dereferencedContentHashes)
+  const sharedRemoved = plan.removedContentHashes.filter((hash) => !dereferenced.has(hash))
+  if (sharedRemoved.length > 0) {
+    deleteCanvasAssetRows(ctx.db, canvasId, sharedRemoved)
   }
 
-  // Safe on-disk delete: only when the content is referenced by NEITHER the
-  // saved scene NOR any other canvas.
-  const removed = new Set(plan.removedContentHashes)
+  if (plan.dereferencedContentHashes.length === 0) return
+
+  // Orphaned content — dereference on the server FIRST, and prune the rows (which hold the
+  // chunkHashes needed to retry) only once the server confirms. A 404 (endpoint not yet
+  // deployed) / transient outage keeps the rows so the next reconcile retries, instead of
+  // silently leaking ref_count forever.
+  const { ok } = await ctx.dereference(plan.dereferenceChunkHashes)
+  if (!ok) {
+    log.warn('canvas asset dereference failed; keeping rows for a later retry', {
+      canvasId,
+      contentHashes: plan.dereferencedContentHashes.length
+    })
+    return
+  }
+
+  deleteCanvasAssetRows(ctx.db, canvasId, plan.dereferencedContentHashes)
+  ctx.trackEvent('canvas_asset_gc_reaped', {
+    surface: 'sync',
+    action: 'gc',
+    objectType: 'canvas',
+    result: 'success',
+    metrics: { itemCount: plan.dereferencedContentHashes.length }
+  })
+
+  // Safe on-disk delete: only the reaped content (referenced by NEITHER the saved scene NOR
+  // any other canvas — i.e. exactly the dereferenced set).
   for (const row of prev) {
-    if (!removed.has(row.contentHash)) continue
-    if (current.has(row.contentHash) || others.has(row.contentHash)) continue
+    if (!dereferenced.has(row.contentHash)) continue
 
     const diskPath = canvasAssetDiskPath(ctx.vaultPath, row.filename)
     try {

--- a/apps/desktop/src/main/canvas/assets/asset-service.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service.ts
@@ -1,0 +1,333 @@
+/**
+ * Canvas asset service — the M5 orchestrator that externalizes, dedups,
+ * uploads, restores, and garbage-collects canvas image assets.
+ *
+ * Every side-effecting dependency (attachment upload/download, server
+ * dereference, the writeback-ignore guard, telemetry) is INJECTED via
+ * {@link AssetServiceContext} rather than imported, so this module stays
+ * free of electron / sync / keychain wiring and is unit-testable in node.
+ * The real context is assembled in `asset-service-context.ts`, which is the
+ * only place that touches the attachment singletons and the sync runtime.
+ *
+ * Disk layout: assets live at a vault-level, content-addressed store
+ * `{vaultPath}/attachments/canvas-assets/<contentHash>.<ext>` so the same
+ * bytes are shared across canvases and the `memry-file://` protocol allowlist
+ * + the download targetPath guard both already permit the path.
+ */
+
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { DataDb } from '../../database'
+import type { CanvasUploadAssetResponse, MemryAssetDescriptor } from '@memry/contracts/canvas-api'
+import type { TelemetryEventName } from '@memry/contracts/telemetry-api'
+import type { CanvasAssetRow } from '@memry/db-schema'
+
+import { createLogger } from '../../lib/logger'
+import { toMemryFileUrl } from '../../lib/paths'
+import { atomicWriteBinary, fileExists } from '../../vault/file-ops'
+import type { TrackMainEventOptions } from '../../telemetry/track'
+
+import { assetFilename, hashAssetContent } from './content-hash'
+import { contentHashFromRef, extractSceneFileRefs, writeMemryAssets } from './memry-assets'
+import {
+  deleteCanvasAssetRows,
+  findAssetByContentHash,
+  hashesReferencedByOtherCanvases,
+  listAssetsByCanvas,
+  recordAsset
+} from './asset-store'
+import { planDereference } from './dedup-plan'
+
+const log = createLogger('CanvasAssetService')
+
+const CANVAS_ASSETS_DIR = 'canvas-assets'
+
+/** Minimal shape of an attachment upload result — just what the GC index needs. */
+export interface AssetUploadResult {
+  attachmentId: string
+  manifest: { chunks: { encryptedHash: string }[] }
+}
+
+/**
+ * Injected dependencies for the asset service. The canvas-handlers layer
+ * builds the real context (wiring the reused AttachmentSyncService / upload
+ * queue singletons); tests inject fakes.
+ */
+export interface AssetServiceContext {
+  db: DataDb
+  vaultId: string
+  vaultPath: string
+  /** Upload a local file through the shared attachment pipeline; returns the manifest. */
+  uploadAttachment: (canvasId: string, filePath: string) => Promise<AssetUploadResult>
+  /** Download an attachment to targetPath through the shared attachment pipeline. */
+  downloadAttachment: (attachmentId: string, targetPath: string) => Promise<void>
+  /** Best-effort server ref_count decrement for GC'd chunks. Never throws. */
+  dereference: (chunkHashes: string[]) => Promise<void>
+  /** Suppress the vault watcher's re-upload loop before writing/downloading a file. */
+  markWritebackIgnored: (absolutePath: string) => void
+  trackEvent: (name: TelemetryEventName, options: TrackMainEventOptions) => void
+}
+
+/** Absolute path of a content-addressed asset in the vault-level store. */
+export function canvasAssetDiskPath(vaultPath: string, filename: string): string {
+  return join(vaultPath, 'attachments', CANVAS_ASSETS_DIR, filename)
+}
+
+function rowToDescriptor(row: CanvasAssetRow): MemryAssetDescriptor {
+  return {
+    fileId: row.fileId,
+    attachmentId: row.attachmentId,
+    contentHash: row.contentHash,
+    chunkHashes: row.chunkHashes,
+    mimeType: row.mimeType,
+    sizeBytes: row.sizeBytes,
+    filename: row.filename
+  }
+}
+
+/** Content hashes still present as externalized `memry-file://` refs in a scene. */
+function sceneContentHashes(sceneJson: string): Set<string> {
+  return new Set(
+    extractSceneFileRefs(sceneJson)
+      .map((r) => contentHashFromRef(r.ref))
+      .filter((h): h is string => !!h)
+  )
+}
+
+/**
+ * Externalize one Excalidraw image: content-address it, dedup against the
+ * vault store, upload the bytes if new, and record the per-(canvas,image)
+ * dedup/GC row. Idempotent on disk.
+ */
+export async function uploadCanvasAsset(
+  ctx: AssetServiceContext,
+  canvasId: string,
+  fileId: string,
+  mimeType: string,
+  bytes: Uint8Array
+): Promise<CanvasUploadAssetResponse> {
+  const contentHash = hashAssetContent(bytes)
+  const filename = assetFilename(contentHash, mimeType)
+  const diskPath = canvasAssetDiskPath(ctx.vaultPath, filename)
+  const ref = toMemryFileUrl(diskPath)
+
+  const existing = findAssetByContentHash(ctx.db, ctx.vaultId, contentHash)
+  if (existing) {
+    // Dedup hit: the bytes already exist somewhere in the vault. Reuse the
+    // attachment id / chunk hashes; only re-materialize the local file if this
+    // device is missing it. No upload.
+    if (!(await fileExists(diskPath))) {
+      ctx.markWritebackIgnored(diskPath)
+      await atomicWriteBinary(diskPath, bytes)
+    }
+    recordAsset(ctx.db, {
+      vaultId: ctx.vaultId,
+      canvasId,
+      contentHash,
+      attachmentId: existing.attachmentId,
+      fileId,
+      filename: existing.filename,
+      mimeType: existing.mimeType,
+      sizeBytes: existing.sizeBytes,
+      chunkHashes: existing.chunkHashes,
+      createdAt: Date.now()
+    })
+    const descriptor: MemryAssetDescriptor = {
+      fileId,
+      attachmentId: existing.attachmentId,
+      contentHash,
+      chunkHashes: existing.chunkHashes,
+      mimeType: existing.mimeType,
+      sizeBytes: existing.sizeBytes,
+      filename: existing.filename
+    }
+    ctx.trackEvent('canvas_asset_dedup_hit', {
+      surface: 'sync',
+      action: 'dedup',
+      objectType: 'canvas',
+      result: 'success',
+      metrics: { byteCount: existing.sizeBytes }
+    })
+    return { ref, descriptor, deduped: true }
+  }
+
+  // New asset: write it to the content-addressed store, then upload the bytes
+  // through the shared attachment pipeline to capture its chunk manifest.
+  ctx.markWritebackIgnored(diskPath)
+  await atomicWriteBinary(diskPath, bytes)
+
+  const { attachmentId, manifest } = await ctx.uploadAttachment(canvasId, diskPath)
+  const chunkHashes = manifest.chunks.map((c) => c.encryptedHash)
+  const sizeBytes = bytes.length
+
+  recordAsset(ctx.db, {
+    vaultId: ctx.vaultId,
+    canvasId,
+    contentHash,
+    attachmentId,
+    fileId,
+    filename,
+    mimeType,
+    sizeBytes,
+    chunkHashes,
+    createdAt: Date.now()
+  })
+  const descriptor: MemryAssetDescriptor = {
+    fileId,
+    attachmentId,
+    contentHash,
+    chunkHashes,
+    mimeType,
+    sizeBytes,
+    filename
+  }
+  ctx.trackEvent('canvas_asset_uploaded', {
+    surface: 'sync',
+    action: 'upload',
+    objectType: 'canvas',
+    result: 'success',
+    metrics: { byteCount: sizeBytes }
+  })
+  return { ref, descriptor, deduped: false }
+}
+
+/**
+ * Device-B restore: download any asset in `descriptors` that is missing on
+ * disk, and record its local dedup/GC row. One failed asset must not abort the
+ * rest, so per-asset errors are swallowed (logged). Called by the canvas sync
+ * apply path (Task 9) with the canvas the scene belongs to.
+ */
+export async function ensureAssetsPresent(
+  ctx: AssetServiceContext,
+  canvasId: string,
+  descriptors: MemryAssetDescriptor[]
+): Promise<void> {
+  for (const descriptor of descriptors) {
+    const diskPath = canvasAssetDiskPath(ctx.vaultPath, descriptor.filename)
+    if (await fileExists(diskPath)) continue
+
+    try {
+      ctx.markWritebackIgnored(diskPath)
+      await ctx.downloadAttachment(descriptor.attachmentId, diskPath)
+      recordAsset(ctx.db, {
+        vaultId: ctx.vaultId,
+        canvasId,
+        contentHash: descriptor.contentHash,
+        attachmentId: descriptor.attachmentId,
+        fileId: descriptor.fileId,
+        filename: descriptor.filename,
+        mimeType: descriptor.mimeType,
+        sizeBytes: descriptor.sizeBytes,
+        chunkHashes: descriptor.chunkHashes,
+        createdAt: Date.now()
+      })
+    } catch (err) {
+      log.warn('failed to restore canvas asset; leaving it for a later retry', {
+        canvasId,
+        fileId: descriptor.fileId,
+        err
+      })
+    }
+  }
+}
+
+/**
+ * Garbage-collect assets a canvas no longer references. Runs on every save
+ * (with the saved scene) and on delete (`sceneJson === ''`). Prunes the local
+ * rows for removed assets, dereferences the server chunks of assets referenced
+ * by NO other canvas, and safely unlinks the on-disk file when it is shared by
+ * nobody.
+ */
+export async function reconcileCanvasAssets(
+  ctx: AssetServiceContext,
+  canvasId: string,
+  sceneJson: string
+): Promise<void> {
+  const current = sceneContentHashes(sceneJson)
+  const prev = listAssetsByCanvas(ctx.db, canvasId)
+  const others = hashesReferencedByOtherCanvases(ctx.db, ctx.vaultId, canvasId)
+
+  const plan = planDereference(prev, current, others)
+  if (plan.removedContentHashes.length === 0) return
+
+  deleteCanvasAssetRows(ctx.db, canvasId, plan.removedContentHashes)
+
+  if (plan.dereferenceChunkHashes.length > 0) {
+    // dereference never throws — GC must not break a save/delete.
+    await ctx.dereference(plan.dereferenceChunkHashes)
+    ctx.trackEvent('canvas_asset_gc_reaped', {
+      surface: 'sync',
+      action: 'gc',
+      objectType: 'canvas',
+      result: 'success',
+      metrics: { itemCount: plan.removedContentHashes.length }
+    })
+  }
+
+  // Safe on-disk delete: only when the content is referenced by NEITHER the
+  // saved scene NOR any other canvas.
+  const removed = new Set(plan.removedContentHashes)
+  for (const row of prev) {
+    if (!removed.has(row.contentHash)) continue
+    if (current.has(row.contentHash) || others.has(row.contentHash)) continue
+
+    const diskPath = canvasAssetDiskPath(ctx.vaultPath, row.filename)
+    try {
+      ctx.markWritebackIgnored(diskPath)
+      await rm(diskPath, { force: true })
+    } catch (err) {
+      log.warn('failed to unlink orphaned canvas asset file', {
+        canvasId,
+        contentHash: row.contentHash,
+        err
+      })
+    }
+  }
+}
+
+/**
+ * Resolve the `memry-file://` ref for one scene file id on a canvas, or null
+ * when there is no recorded asset for it (pre-M5 / inline scenes).
+ */
+export function getCanvasAssetRef(
+  ctx: AssetServiceContext,
+  canvasId: string,
+  fileId: string
+): string | null {
+  const row = listAssetsByCanvas(ctx.db, canvasId).find((r) => r.fileId === fileId)
+  if (!row) return null
+  return toMemryFileUrl(canvasAssetDiskPath(ctx.vaultPath, row.filename))
+}
+
+/** All asset descriptors recorded for a canvas. */
+export function listCanvasAssetDescriptors(
+  ctx: AssetServiceContext,
+  canvasId: string
+): MemryAssetDescriptor[] {
+  return listAssetsByCanvas(ctx.db, canvasId).map(rowToDescriptor)
+}
+
+/**
+ * Inject the `memryAssets` sidecar into a scene before it is persisted/synced,
+ * so a receiving device can restore the externalized images. Descriptors are
+ * the recorded rows still referenced by this scene. Returns the scene
+ * unchanged when it is empty or unparseable (pre-M5 / brand-new canvases).
+ */
+export function injectSceneAssetSidecar(
+  ctx: AssetServiceContext,
+  canvasId: string,
+  sceneJson: string
+): string {
+  if (!sceneJson) return sceneJson
+  const current = sceneContentHashes(sceneJson)
+  const descriptors = listAssetsByCanvas(ctx.db, canvasId)
+    .filter((row) => current.has(row.contentHash))
+    .map(rowToDescriptor)
+  try {
+    return writeMemryAssets(sceneJson, descriptors)
+  } catch {
+    // Unparseable scene — never corrupt it by dropping the payload.
+    return sceneJson
+  }
+}

--- a/apps/desktop/src/main/canvas/assets/asset-service.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service.ts
@@ -116,10 +116,15 @@ export async function uploadCanvasAsset(
   if (existing) {
     // Dedup hit: the bytes already exist somewhere in the vault. Reuse the
     // attachment id / chunk hashes; only re-materialize the local file if this
-    // device is missing it. No upload.
-    if (!(await fileExists(diskPath))) {
-      ctx.markWritebackIgnored(diskPath)
-      await atomicWriteBinary(diskPath, bytes)
+    // device is missing it. No upload. Resolve path/ref from the RECORDED
+    // filename (existing.filename), not the locally-computed one — they can
+    // diverge if the same bytes were ever recorded under a different mimeType
+    // (different extension), and writing/returning the wrong path would point
+    // a later restore at a file that doesn't exist.
+    const existingDiskPath = canvasAssetDiskPath(ctx.vaultPath, existing.filename)
+    if (!(await fileExists(existingDiskPath))) {
+      ctx.markWritebackIgnored(existingDiskPath)
+      await atomicWriteBinary(existingDiskPath, bytes)
     }
     recordAsset(ctx.db, {
       vaultId: ctx.vaultId,
@@ -149,7 +154,7 @@ export async function uploadCanvasAsset(
       result: 'success',
       metrics: { byteCount: existing.sizeBytes }
     })
-    return { ref, descriptor, deduped: true }
+    return { ref: toMemryFileUrl(existingDiskPath), descriptor, deduped: true }
   }
 
   // New asset: write it to the content-addressed store, then upload the bytes

--- a/apps/desktop/src/main/canvas/assets/asset-store.test.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-store.test.ts
@@ -1,0 +1,152 @@
+import { describe, beforeEach, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+
+import * as schema from '@memry/db-schema/data-schema'
+import type { NewCanvasAssetRow } from '@memry/db-schema'
+import {
+  deleteCanvasAssetRows,
+  findAssetByContentHash,
+  hashesReferencedByOtherCanvases,
+  listAssetsByCanvas,
+  recordAsset
+} from './asset-store'
+
+const MIGRATION_FILES = ['0035_spatial_canvas.sql', '0036_canvas_assets.sql']
+
+function freshDb() {
+  const sqlite = new Database(':memory:')
+  sqlite.pragma('foreign_keys = ON')
+  for (const file of MIGRATION_FILES) {
+    const sql = fs.readFileSync(
+      path.join(__dirname, '..', '..', 'database', 'drizzle-data', file),
+      'utf8'
+    )
+    for (const statement of sql.split('--> statement-breakpoint')) {
+      const trimmed = statement.trim()
+      if (trimmed) sqlite.exec(trimmed)
+    }
+  }
+  return drizzle(sqlite, { schema })
+}
+
+function insertCanvas(db: ReturnType<typeof freshDb>, id: string, vaultId: string) {
+  db.insert(schema.canvases)
+    .values({
+      id,
+      vaultId,
+      title: null,
+      snapshotCiphertext: 'ciphertext',
+      vectorClock: {},
+      createdAt: 1700000000000,
+      updatedAt: 1700000000000,
+      deletedAt: null,
+      lastSyncedAt: null,
+      clock: null
+    })
+    .run()
+}
+
+function assetRow(overrides: Partial<NewCanvasAssetRow> = {}): NewCanvasAssetRow {
+  return {
+    vaultId: 'vault-1',
+    canvasId: 'canvas-a',
+    contentHash: 'hash-x',
+    attachmentId: 'attachment-1',
+    fileId: 'file-1',
+    filename: 'image.png',
+    mimeType: 'image/png',
+    sizeBytes: 1234,
+    chunkHashes: ['chunk-1'],
+    createdAt: 1700000000000,
+    ...overrides
+  }
+}
+
+describe('canvas asset store', () => {
+  let db: ReturnType<typeof freshDb>
+
+  beforeEach(() => {
+    db = freshDb()
+    insertCanvas(db, 'canvas-a', 'vault-1')
+    insertCanvas(db, 'canvas-b', 'vault-1')
+    insertCanvas(db, 'canvas-other-vault', 'vault-2')
+  })
+
+  describe('findAssetByContentHash', () => {
+    it('finds a recorded row by (vaultId, contentHash)', () => {
+      recordAsset(db, assetRow({ contentHash: 'hash-x' }))
+      const found = findAssetByContentHash(db, 'vault-1', 'hash-x')
+      expect(found?.contentHash).toBe('hash-x')
+      expect(found?.canvasId).toBe('canvas-a')
+    })
+
+    it('returns undefined for an unknown hash', () => {
+      expect(findAssetByContentHash(db, 'vault-1', 'no-such-hash')).toBeUndefined()
+    })
+
+    it('is scoped by vaultId', () => {
+      recordAsset(
+        db,
+        assetRow({ canvasId: 'canvas-other-vault', vaultId: 'vault-2', contentHash: 'hash-x' })
+      )
+      expect(findAssetByContentHash(db, 'vault-1', 'hash-x')).toBeUndefined()
+      expect(findAssetByContentHash(db, 'vault-2', 'hash-x')?.canvasId).toBe('canvas-other-vault')
+    })
+  })
+
+  describe('recordAsset', () => {
+    it('upsert is idempotent: recording the same (canvasId, contentHash) twice yields one row', () => {
+      recordAsset(db, assetRow({ contentHash: 'hash-x' }))
+      recordAsset(db, assetRow({ contentHash: 'hash-x' }))
+
+      const rows = db.select().from(schema.canvasAssets).all()
+      expect(rows).toHaveLength(1)
+    })
+  })
+
+  describe('listAssetsByCanvas', () => {
+    it('returns only that canvas rows', () => {
+      recordAsset(db, assetRow({ canvasId: 'canvas-a', contentHash: 'hash-x' }))
+      recordAsset(db, assetRow({ canvasId: 'canvas-b', contentHash: 'hash-y' }))
+
+      const rows = listAssetsByCanvas(db, 'canvas-a')
+      expect(rows.map((r) => r.contentHash)).toEqual(['hash-x'])
+    })
+  })
+
+  describe('hashesReferencedByOtherCanvases', () => {
+    it('returns hashes referenced by other canvases, excluding the given canvasId own hashes', () => {
+      recordAsset(db, assetRow({ canvasId: 'canvas-a', contentHash: 'hash-x' }))
+      recordAsset(db, assetRow({ canvasId: 'canvas-b', contentHash: 'hash-x' }))
+      recordAsset(db, assetRow({ canvasId: 'canvas-b', contentHash: 'hash-y' }))
+
+      const forA = hashesReferencedByOtherCanvases(db, 'vault-1', 'canvas-a')
+      expect(forA).toEqual(new Set(['hash-x', 'hash-y']))
+
+      const forB = hashesReferencedByOtherCanvases(db, 'vault-1', 'canvas-b')
+      expect(forB).toEqual(new Set(['hash-x']))
+    })
+  })
+
+  describe('deleteCanvasAssetRows', () => {
+    it('removes only the named (canvasId, contentHash) rows, leaving other canvases rows intact', () => {
+      recordAsset(db, assetRow({ canvasId: 'canvas-a', contentHash: 'hash-x' }))
+      recordAsset(db, assetRow({ canvasId: 'canvas-a', contentHash: 'hash-y' }))
+      recordAsset(db, assetRow({ canvasId: 'canvas-b', contentHash: 'hash-x' }))
+
+      deleteCanvasAssetRows(db, 'canvas-a', ['hash-x'])
+
+      expect(listAssetsByCanvas(db, 'canvas-a').map((r) => r.contentHash)).toEqual(['hash-y'])
+      expect(listAssetsByCanvas(db, 'canvas-b').map((r) => r.contentHash)).toEqual(['hash-x'])
+    })
+
+    it('is a no-op for an empty list', () => {
+      recordAsset(db, assetRow({ canvasId: 'canvas-a', contentHash: 'hash-x' }))
+      deleteCanvasAssetRows(db, 'canvas-a', [])
+      expect(listAssetsByCanvas(db, 'canvas-a')).toHaveLength(1)
+    })
+  })
+})

--- a/apps/desktop/src/main/canvas/assets/asset-store.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-store.ts
@@ -1,0 +1,59 @@
+/**
+ * Canvas asset store — drizzle CRUD for canvas_assets: the per-device dedup
+ * index + GC bookkeeping for externalized canvas image assets (M5).
+ *
+ * Electron-free (mirrors main/canvas/store.ts): functions take `db` as a
+ * parameter so they stay testable without the keychain or electron runtime.
+ */
+
+import { and, eq, inArray, ne } from 'drizzle-orm'
+import { canvasAssets, type CanvasAssetRow, type NewCanvasAssetRow } from '@memry/db-schema'
+import type { DataDb } from '../../database'
+
+/** Vault-scoped dedup lookup: has any canvas already externalized this contentHash? */
+export function findAssetByContentHash(
+  db: DataDb,
+  vaultId: string,
+  contentHash: string
+): CanvasAssetRow | undefined {
+  return db
+    .select()
+    .from(canvasAssets)
+    .where(and(eq(canvasAssets.vaultId, vaultId), eq(canvasAssets.contentHash, contentHash)))
+    .limit(1)
+    .get()
+}
+
+/** Record a (canvas, asset) reference row. Upsert on the (canvasId, contentHash) PK. */
+export function recordAsset(db: DataDb, row: NewCanvasAssetRow): void {
+  db.insert(canvasAssets).values(row).onConflictDoNothing().run()
+}
+
+/** All asset rows for one canvas (the "previous" set for a GC diff). */
+export function listAssetsByCanvas(db: DataDb, canvasId: string): CanvasAssetRow[] {
+  return db.select().from(canvasAssets).where(eq(canvasAssets.canvasId, canvasId)).all()
+}
+
+/** The GC union: contentHashes referenced by any OTHER canvas in the vault (excludes canvasId). */
+export function hashesReferencedByOtherCanvases(
+  db: DataDb,
+  vaultId: string,
+  canvasId: string
+): Set<string> {
+  const rows = db
+    .select({ contentHash: canvasAssets.contentHash })
+    .from(canvasAssets)
+    .where(and(eq(canvasAssets.vaultId, vaultId), ne(canvasAssets.canvasId, canvasId)))
+    .all()
+  return new Set(rows.map((row) => row.contentHash))
+}
+
+/** Prune specific asset rows for one canvas (after a scene save/delete removes those images). */
+export function deleteCanvasAssetRows(db: DataDb, canvasId: string, contentHashes: string[]): void {
+  if (contentHashes.length === 0) return
+  db.delete(canvasAssets)
+    .where(
+      and(eq(canvasAssets.canvasId, canvasId), inArray(canvasAssets.contentHash, contentHashes))
+    )
+    .run()
+}

--- a/apps/desktop/src/main/canvas/assets/attachment-dereference.test.ts
+++ b/apps/desktop/src/main/canvas/assets/attachment-dereference.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+import { dereferenceChunks, type DereferenceDeps } from './attachment-dereference'
+
+function makeDeps(overrides: Partial<DereferenceDeps> = {}): DereferenceDeps {
+  return {
+    getAccessToken: vi.fn().mockResolvedValue('test-token'),
+    getSyncServerUrl: () => 'https://sync.example.com',
+    getVaultId: () => 'vault-1',
+    ...overrides
+  }
+}
+
+describe('dereferenceChunks', () => {
+  it('posts to /sync/attachments/dereference and returns ok on 200', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    const deps = makeDeps({ fetchFn })
+
+    const result = await dereferenceChunks(['chunk-1', 'chunk-2'], deps)
+
+    expect(result).toEqual({ ok: true, status: 200 })
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchFn.mock.calls[0]
+    expect(url).toBe('https://sync.example.com/sync/attachments/dereference')
+    expect(init.method).toBe('POST')
+    expect(init.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-token',
+      'X-Memry-Vault-Id': 'vault-1'
+    })
+    expect(JSON.parse(init.body as string)).toEqual({ chunkHashes: ['chunk-1', 'chunk-2'] })
+  })
+
+  it('returns {ok:false} on a 404 without throwing', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(null, { status: 404 }))
+    const deps = makeDeps({ fetchFn })
+
+    const result = await dereferenceChunks(['chunk-1'], deps)
+
+    expect(result).toEqual({ ok: false, status: 404 })
+  })
+
+  it('returns {ok:false, status:0} on a network error without throwing', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('network down'))
+    const deps = makeDeps({ fetchFn })
+
+    const result = await dereferenceChunks(['chunk-1'], deps)
+
+    expect(result).toEqual({ ok: false, status: 0 })
+  })
+
+  it('returns {ok:true, status:200} without calling fetch for empty chunkHashes', async () => {
+    const fetchFn = vi.fn()
+    const deps = makeDeps({ fetchFn })
+
+    const result = await dereferenceChunks([], deps)
+
+    expect(result).toEqual({ ok: true, status: 200 })
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('returns {ok:false, status:0} without calling fetch when there is no access token', async () => {
+    const fetchFn = vi.fn()
+    const deps = makeDeps({ fetchFn, getAccessToken: vi.fn().mockResolvedValue(null) })
+
+    const result = await dereferenceChunks(['chunk-1'], deps)
+
+    expect(result).toEqual({ ok: false, status: 0 })
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/canvas/assets/attachment-dereference.ts
+++ b/apps/desktop/src/main/canvas/assets/attachment-dereference.ts
@@ -1,0 +1,65 @@
+/**
+ * Server dereference client for externalized canvas image assets (M5 GC).
+ *
+ * POSTs the chunk hashes of assets no longer referenced by any canvas so the
+ * server can decrement its ref_count and reclaim storage. Never throws — a
+ * 404 (server not yet deployed), missing token, or network error must never
+ * break a canvas save/delete, so every failure degrades to `{ok:false}`.
+ *
+ * Electron-free: deps are injected (mirrors the main/sync deps-injection
+ * pattern) and the sync server URL is resolved lazily inside the call, not
+ * at module load, per the http-client lazy-URL-resolution gotcha.
+ */
+
+import { createLogger } from '../../lib/logger'
+
+const log = createLogger('CanvasAssetDereference')
+
+export interface DereferenceDeps {
+  getAccessToken(): Promise<string | null>
+  getSyncServerUrl(): string
+  getVaultId(): string
+  fetchFn?: typeof fetch
+}
+
+/**
+ * POST /sync/attachments/dereference to decrement server ref_count for the
+ * given chunk hashes.
+ */
+export async function dereferenceChunks(
+  chunkHashes: string[],
+  deps: DereferenceDeps
+): Promise<{ ok: boolean; status: number }> {
+  if (chunkHashes.length === 0) return { ok: true, status: 200 }
+
+  const token = await deps.getAccessToken()
+  if (!token) {
+    log.warn('no access token, skipping chunk dereference', { count: chunkHashes.length })
+    return { ok: false, status: 0 }
+  }
+
+  const url = `${deps.getSyncServerUrl()}/sync/attachments/dereference`
+  const fetchImpl = deps.fetchFn ?? fetch
+
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'X-Memry-Vault-Id': deps.getVaultId()
+      },
+      body: JSON.stringify({ chunkHashes })
+    })
+
+    if (!response.ok) {
+      log.warn('dereference request failed', { status: response.status })
+      return { ok: false, status: response.status }
+    }
+
+    return { ok: true, status: response.status }
+  } catch (err) {
+    log.warn('dereference request threw', err)
+    return { ok: false, status: 0 }
+  }
+}

--- a/apps/desktop/src/main/canvas/assets/content-hash.test.ts
+++ b/apps/desktop/src/main/canvas/assets/content-hash.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { hashAssetContent, extForMime, assetFilename } from './content-hash'
+
+describe('hashAssetContent', () => {
+  it('returns the same hash for the same bytes', () => {
+    const bytes = new Uint8Array([1, 2, 3, 4])
+    expect(hashAssetContent(bytes)).toBe(hashAssetContent(new Uint8Array([1, 2, 3, 4])))
+  })
+
+  it('returns a different hash for different bytes', () => {
+    const a = hashAssetContent(new Uint8Array([1, 2, 3]))
+    const b = hashAssetContent(new Uint8Array([4, 5, 6]))
+    expect(a).not.toBe(b)
+  })
+
+  it('returns a sha256 hex digest', () => {
+    const hash = hashAssetContent(new Uint8Array([1, 2, 3]))
+    expect(hash).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+describe('extForMime', () => {
+  it.each([
+    ['image/png', 'png'],
+    ['image/jpeg', 'jpg'],
+    ['image/gif', 'gif'],
+    ['image/webp', 'webp'],
+    ['image/svg+xml', 'svg']
+  ])('maps %s to %s', (mime, ext) => {
+    expect(extForMime(mime)).toBe(ext)
+  })
+
+  it('falls back to bin for an unknown mime type', () => {
+    expect(extForMime('application/octet-stream')).toBe('bin')
+  })
+})
+
+describe('assetFilename', () => {
+  it('joins the content hash and mime-derived extension', () => {
+    expect(assetFilename('abc123', 'image/png')).toBe('abc123.png')
+  })
+
+  it('falls back to bin for an unknown mime type', () => {
+    expect(assetFilename('abc123', 'application/octet-stream')).toBe('abc123.bin')
+  })
+})

--- a/apps/desktop/src/main/canvas/assets/content-hash.ts
+++ b/apps/desktop/src/main/canvas/assets/content-hash.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto'
+
+/** sha256 hex of the plaintext image bytes — the vault-scoped dedup key. Collision-safe content address. */
+export function hashAssetContent(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+/** File extension for a mime type (content-addressed filenames). */
+export function extForMime(mimeType: string): string {
+  switch (mimeType) {
+    case 'image/png':
+      return 'png'
+    case 'image/jpeg':
+      return 'jpg'
+    case 'image/gif':
+      return 'gif'
+    case 'image/webp':
+      return 'webp'
+    case 'image/svg+xml':
+      return 'svg'
+    default:
+      return 'bin'
+  }
+}
+
+/** Content-addressed on-disk filename: `<contentHash>.<ext>`. */
+export function assetFilename(contentHash: string, mimeType: string): string {
+  return `${contentHash}.${extForMime(mimeType)}`
+}

--- a/apps/desktop/src/main/canvas/assets/dedup-plan.test.ts
+++ b/apps/desktop/src/main/canvas/assets/dedup-plan.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import type { CanvasAssetRow } from '@memry/db-schema'
+import { planDereference } from './dedup-plan'
+
+function row(
+  overrides: Partial<CanvasAssetRow> & Pick<CanvasAssetRow, 'contentHash' | 'chunkHashes'>
+): CanvasAssetRow {
+  return {
+    vaultId: 'vault-1',
+    canvasId: 'canvas-1',
+    attachmentId: 'attachment-1',
+    fileId: 'file-1',
+    filename: 'image.png',
+    mimeType: 'image/png',
+    sizeBytes: 1234,
+    createdAt: 1700000000000,
+    ...overrides
+  }
+}
+
+describe('planDereference', () => {
+  it('removes an asset dropped from the scene and dereferences its chunks when no other canvas references it', () => {
+    const prevRows = [row({ contentHash: 'hash-a', chunkHashes: ['chunk-1'] })]
+    const plan = planDereference(prevRows, new Set(), new Set())
+    expect(plan.removedContentHashes).toEqual(['hash-a'])
+    expect(plan.dereferenceChunkHashes).toEqual(['chunk-1'])
+  })
+
+  it('removes a dropped asset from this canvas but does not dereference its chunks when another canvas still references it', () => {
+    const prevRows = [row({ contentHash: 'hash-a', chunkHashes: ['chunk-1'] })]
+    const plan = planDereference(prevRows, new Set(), new Set(['hash-a']))
+    expect(plan.removedContentHashes).toEqual(['hash-a'])
+    expect(plan.dereferenceChunkHashes).toEqual([])
+  })
+
+  it('leaves an asset that is still present in the scene out of both lists', () => {
+    const prevRows = [row({ contentHash: 'hash-a', chunkHashes: ['chunk-1'] })]
+    const plan = planDereference(prevRows, new Set(['hash-a']), new Set())
+    expect(plan.removedContentHashes).toEqual([])
+    expect(plan.dereferenceChunkHashes).toEqual([])
+  })
+
+  it('returns an empty plan when nothing changed', () => {
+    const prevRows = [
+      row({ contentHash: 'hash-a', chunkHashes: ['chunk-1'] }),
+      row({ contentHash: 'hash-b', chunkHashes: ['chunk-2'] })
+    ]
+    const plan = planDereference(prevRows, new Set(['hash-a', 'hash-b']), new Set())
+    expect(plan.removedContentHashes).toEqual([])
+    expect(plan.dereferenceChunkHashes).toEqual([])
+  })
+
+  it('flattens all chunkHashes of a removed, orphaned asset with multiple chunks', () => {
+    const prevRows = [
+      row({ contentHash: 'hash-a', chunkHashes: ['chunk-1', 'chunk-2', 'chunk-3'] })
+    ]
+    const plan = planDereference(prevRows, new Set(), new Set())
+    expect(plan.removedContentHashes).toEqual(['hash-a'])
+    expect(plan.dereferenceChunkHashes).toEqual(['chunk-1', 'chunk-2', 'chunk-3'])
+  })
+})

--- a/apps/desktop/src/main/canvas/assets/dedup-plan.test.ts
+++ b/apps/desktop/src/main/canvas/assets/dedup-plan.test.ts
@@ -23,6 +23,7 @@ describe('planDereference', () => {
     const prevRows = [row({ contentHash: 'hash-a', chunkHashes: ['chunk-1'] })]
     const plan = planDereference(prevRows, new Set(), new Set())
     expect(plan.removedContentHashes).toEqual(['hash-a'])
+    expect(plan.dereferencedContentHashes).toEqual(['hash-a'])
     expect(plan.dereferenceChunkHashes).toEqual(['chunk-1'])
   })
 
@@ -30,6 +31,8 @@ describe('planDereference', () => {
     const prevRows = [row({ contentHash: 'hash-a', chunkHashes: ['chunk-1'] })]
     const plan = planDereference(prevRows, new Set(), new Set(['hash-a']))
     expect(plan.removedContentHashes).toEqual(['hash-a'])
+    // shared with another canvas → NOT reaped
+    expect(plan.dereferencedContentHashes).toEqual([])
     expect(plan.dereferenceChunkHashes).toEqual([])
   })
 
@@ -37,6 +40,7 @@ describe('planDereference', () => {
     const prevRows = [row({ contentHash: 'hash-a', chunkHashes: ['chunk-1'] })]
     const plan = planDereference(prevRows, new Set(['hash-a']), new Set())
     expect(plan.removedContentHashes).toEqual([])
+    expect(plan.dereferencedContentHashes).toEqual([])
     expect(plan.dereferenceChunkHashes).toEqual([])
   })
 
@@ -47,6 +51,7 @@ describe('planDereference', () => {
     ]
     const plan = planDereference(prevRows, new Set(['hash-a', 'hash-b']), new Set())
     expect(plan.removedContentHashes).toEqual([])
+    expect(plan.dereferencedContentHashes).toEqual([])
     expect(plan.dereferenceChunkHashes).toEqual([])
   })
 
@@ -56,6 +61,7 @@ describe('planDereference', () => {
     ]
     const plan = planDereference(prevRows, new Set(), new Set())
     expect(plan.removedContentHashes).toEqual(['hash-a'])
+    expect(plan.dereferencedContentHashes).toEqual(['hash-a'])
     expect(plan.dereferenceChunkHashes).toEqual(['chunk-1', 'chunk-2', 'chunk-3'])
   })
 })

--- a/apps/desktop/src/main/canvas/assets/dedup-plan.ts
+++ b/apps/desktop/src/main/canvas/assets/dedup-plan.ts
@@ -1,0 +1,28 @@
+import type { CanvasAssetRow } from '@memry/db-schema'
+
+export interface DereferencePlan {
+  /** contentHashes no longer referenced by this canvas — prune their canvas_assets rows. */
+  removedContentHashes: string[]
+  /** chunk hashes to dereference on the server — only for assets referenced by NO other canvas. */
+  dereferenceChunkHashes: string[]
+}
+
+/**
+ * Diff a canvas's previously-recorded asset rows against the assets still present in its
+ * just-saved scene, and against the union of assets referenced by every OTHER canvas.
+ * @param prevRows        canvas_assets rows for THIS canvas (before this save).
+ * @param currentContentHashes  contentHashes still present in the saved scene.
+ * @param otherCanvasHashes     contentHashes referenced by any OTHER canvas in the vault (the GC union).
+ */
+export function planDereference(
+  prevRows: CanvasAssetRow[],
+  currentContentHashes: Set<string>,
+  otherCanvasHashes: Set<string>
+): DereferencePlan {
+  const removed = prevRows.filter((row) => !currentContentHashes.has(row.contentHash))
+  const removedContentHashes = removed.map((row) => row.contentHash)
+  const dereferenceChunkHashes = removed
+    .filter((row) => !otherCanvasHashes.has(row.contentHash))
+    .flatMap((row) => row.chunkHashes)
+  return { removedContentHashes, dereferenceChunkHashes }
+}

--- a/apps/desktop/src/main/canvas/assets/dedup-plan.ts
+++ b/apps/desktop/src/main/canvas/assets/dedup-plan.ts
@@ -3,7 +3,13 @@ import type { CanvasAssetRow } from '@memry/db-schema'
 export interface DereferencePlan {
   /** contentHashes no longer referenced by this canvas — prune their canvas_assets rows. */
   removedContentHashes: string[]
-  /** chunk hashes to dereference on the server — only for assets referenced by NO other canvas. */
+  /**
+   * Removed contentHashes referenced by NO other canvas — the ones actually reaped on the server.
+   * A superset relationship holds: these ⊆ removedContentHashes; the difference is shared assets
+   * whose local row is pruned but whose server chunks stay (another canvas still references them).
+   */
+  dereferencedContentHashes: string[]
+  /** chunk hashes to dereference on the server — the chunks of `dereferencedContentHashes`. */
   dereferenceChunkHashes: string[]
 }
 
@@ -21,8 +27,8 @@ export function planDereference(
 ): DereferencePlan {
   const removed = prevRows.filter((row) => !currentContentHashes.has(row.contentHash))
   const removedContentHashes = removed.map((row) => row.contentHash)
-  const dereferenceChunkHashes = removed
-    .filter((row) => !otherCanvasHashes.has(row.contentHash))
-    .flatMap((row) => row.chunkHashes)
-  return { removedContentHashes, dereferenceChunkHashes }
+  const orphaned = removed.filter((row) => !otherCanvasHashes.has(row.contentHash))
+  const dereferencedContentHashes = orphaned.map((row) => row.contentHash)
+  const dereferenceChunkHashes = orphaned.flatMap((row) => row.chunkHashes)
+  return { removedContentHashes, dereferencedContentHashes, dereferenceChunkHashes }
 }

--- a/apps/desktop/src/main/canvas/assets/memry-assets.test.ts
+++ b/apps/desktop/src/main/canvas/assets/memry-assets.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import type { MemryAssetDescriptor } from '@memry/contracts/canvas-api'
+import {
+  extractSceneFileRefs,
+  contentHashFromRef,
+  readMemryAssets,
+  writeMemryAssets
+} from './memry-assets'
+
+function descriptor(overrides: Partial<MemryAssetDescriptor> = {}): MemryAssetDescriptor {
+  return {
+    fileId: 'f1',
+    attachmentId: 'attachment-1',
+    contentHash: 'abc123',
+    chunkHashes: ['chunk-1'],
+    mimeType: 'image/png',
+    sizeBytes: 1234,
+    filename: 'abc123.png',
+    ...overrides
+  }
+}
+
+const PRE_M5_SCENE = JSON.stringify({
+  type: 'excalidraw',
+  elements: [],
+  appState: {},
+  files: {
+    f1: { mimeType: 'image/png', id: 'f1', dataURL: 'data:image/png;base64,AAAA' }
+  }
+})
+
+describe('writeMemryAssets / readMemryAssets round-trip', () => {
+  it('round-trips a descriptor array and preserves the rest of the scene', () => {
+    const scene = JSON.stringify({
+      type: 'excalidraw',
+      elements: [{ id: 'r1', type: 'rectangle' }],
+      appState: { zoom: 1 },
+      files: { f1: { mimeType: 'image/png', dataURL: 'memry-file://local/x' } }
+    })
+    const descriptors = [descriptor()]
+
+    const written = writeMemryAssets(scene, descriptors)
+    const parsed = JSON.parse(written)
+
+    expect(readMemryAssets(written)).toEqual(descriptors)
+    expect(parsed.elements).toEqual([{ id: 'r1', type: 'rectangle' }])
+    expect(parsed.appState).toEqual({ zoom: 1 })
+    expect(parsed.files).toEqual({ f1: { mimeType: 'image/png', dataURL: 'memry-file://local/x' } })
+  })
+
+  it('throws on unparseable scene JSON (callers pass valid scene JSON)', () => {
+    expect(() => writeMemryAssets('{not json', [descriptor()])).toThrow()
+  })
+})
+
+describe('backward compat with pre-M5 base64 scenes', () => {
+  it('readMemryAssets returns [] when memryAssets is absent', () => {
+    expect(readMemryAssets(PRE_M5_SCENE)).toEqual([])
+  })
+
+  it('extractSceneFileRefs returns [] for a data: URI scene (not a memry-file ref)', () => {
+    expect(extractSceneFileRefs(PRE_M5_SCENE)).toEqual([])
+  })
+})
+
+describe('extractSceneFileRefs', () => {
+  it('returns only the memry-file:// entries, skipping data: URIs', () => {
+    const scene = JSON.stringify({
+      type: 'excalidraw',
+      elements: [],
+      appState: {},
+      files: {
+        inline: { mimeType: 'image/png', dataURL: 'data:image/png;base64,AAAA' },
+        external: {
+          mimeType: 'image/png',
+          dataURL: 'memry-file://local/x/attachments/canvas-assets/abc123.png'
+        }
+      }
+    })
+
+    expect(extractSceneFileRefs(scene)).toEqual([
+      { fileId: 'external', ref: 'memry-file://local/x/attachments/canvas-assets/abc123.png' }
+    ])
+  })
+
+  it('returns [] for malformed JSON', () => {
+    expect(extractSceneFileRefs('{not json')).toEqual([])
+  })
+
+  it('returns [] when files is missing', () => {
+    expect(extractSceneFileRefs(JSON.stringify({ type: 'excalidraw' }))).toEqual([])
+  })
+})
+
+describe('contentHashFromRef', () => {
+  it('extracts the content hash from a canvas-asset ref', () => {
+    expect(
+      contentHashFromRef('memry-file://local/Users/x/attachments/canvas-assets/abc123.png')
+    ).toBe('abc123')
+  })
+
+  it('extracts the content hash from a Windows-style canvas-asset ref', () => {
+    expect(
+      contentHashFromRef('memry-file://local/C:/x/attachments/canvas-assets/def456.webp')
+    ).toBe('def456')
+  })
+
+  it('returns null for a non-canvas-asset memry-file ref', () => {
+    expect(contentHashFromRef('memry-file://local/Users/x/attachments/note-1/img.png')).toBeNull()
+  })
+
+  it('returns null for a data: URI', () => {
+    expect(contentHashFromRef('data:image/png;base64,AAAA')).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/canvas/assets/memry-assets.ts
+++ b/apps/desktop/src/main/canvas/assets/memry-assets.ts
@@ -1,0 +1,89 @@
+/**
+ * Main-side, electron-free (de)serialization of the `memryAssets` scene
+ * sidecar and extraction of externalized `memry-file://` file refs from a
+ * serialized Excalidraw scene.
+ *
+ * Runs inside the bundled sync worker (canvas sync item-handler), so this
+ * module must stay free of any electron import, direct or transitive — only
+ * `JSON` and a type-only import of `MemryAssetDescriptor`.
+ *
+ * An externalized image's `files[fileId].dataURL` is a
+ * `memry-file://local/.../attachments/canvas-assets/<contentHash>.<ext>` URL
+ * (content-addressed). Pre-M5 scenes carry inline `data:` URIs instead and
+ * have no top-level `memryAssets` key — every function here degrades to the
+ * empty/absent case for those scenes so old canvases keep working untouched.
+ */
+
+import type { MemryAssetDescriptor } from '@memry/contracts/canvas-api'
+
+const MEMRY_FILE_PREFIX = 'memry-file://'
+const CANVAS_ASSET_MARKER = '/canvas-assets/'
+
+/**
+ * Parse a serialized Excalidraw scene and return the `{fileId, ref}` pairs
+ * for every `files[fileId]` whose `dataURL` is a `memry-file://` ref (i.e.
+ * already externalized). Inline `data:` URIs and anything else are skipped.
+ * Returns `[]` on parse failure or a missing/malformed `files` map — never throws.
+ */
+export function extractSceneFileRefs(sceneJson: string): { fileId: string; ref: string }[] {
+  let files: unknown
+  try {
+    const parsed = JSON.parse(sceneJson) as { files?: unknown }
+    files = parsed.files
+  } catch {
+    return []
+  }
+  if (!files || typeof files !== 'object') return []
+
+  const refs: { fileId: string; ref: string }[] = []
+  for (const [fileId, file] of Object.entries(files as Record<string, unknown>)) {
+    const dataURL = (file as { dataURL?: unknown } | null)?.dataURL
+    if (typeof dataURL === 'string' && dataURL.startsWith(MEMRY_FILE_PREFIX)) {
+      refs.push({ fileId, ref: dataURL })
+    }
+  }
+  return refs
+}
+
+/**
+ * Extract the content hash embedded in a canvas-asset `memry-file://` ref
+ * (the basename minus extension). Returns `null` for anything that isn't a
+ * canvas-asset ref (a `data:` URI, a non-canvas-asset memry-file ref, etc).
+ * Refs always use forward slashes, including on Windows — `toMemryFileUrl`
+ * normalizes backslashes before the ref is ever stored.
+ */
+export function contentHashFromRef(ref: string): string | null {
+  if (!ref.startsWith(MEMRY_FILE_PREFIX) || !ref.includes(CANVAS_ASSET_MARKER)) return null
+
+  const basename = ref.split('/').pop()
+  if (!basename) return null
+
+  const dotIndex = basename.lastIndexOf('.')
+  return dotIndex > 0 ? basename.slice(0, dotIndex) : basename
+}
+
+/**
+ * Read the top-level `memryAssets` sidecar from a serialized scene. Returns
+ * `[]` when absent, malformed, or the scene fails to parse — this is the
+ * backward-compat path for pre-M5 / inline-base64 scenes. Never throws.
+ */
+export function readMemryAssets(sceneJson: string): MemryAssetDescriptor[] {
+  try {
+    const parsed = JSON.parse(sceneJson) as { memryAssets?: unknown }
+    return Array.isArray(parsed.memryAssets) ? (parsed.memryAssets as MemryAssetDescriptor[]) : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Set the top-level `memryAssets` sidecar on a serialized scene, preserving
+ * every other key. Throws if `sceneJson` can't be parsed — callers always
+ * pass valid scene JSON, and silently swallowing a parse failure here would
+ * corrupt the scene by dropping it.
+ */
+export function writeMemryAssets(sceneJson: string, descriptors: MemryAssetDescriptor[]): string {
+  const parsed = JSON.parse(sceneJson) as Record<string, unknown>
+  parsed.memryAssets = descriptors
+  return JSON.stringify(parsed)
+}

--- a/apps/desktop/src/main/canvas/sync-bridge.test.ts
+++ b/apps/desktop/src/main/canvas/sync-bridge.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { localMutationsMock, trackMainEventMock } = vi.hoisted(() => ({
+  localMutationsMock: {
+    enqueueLocalSyncCreate: vi.fn(),
+    enqueueLocalSyncUpdate: vi.fn(),
+    enqueueLocalSyncDelete: vi.fn(),
+    bumpCanvasClockLocalOnly: vi.fn()
+  },
+  trackMainEventMock: vi.fn()
+}))
+
+vi.mock('../sync/local-mutations', () => localMutationsMock)
+vi.mock('../telemetry/track', () => ({ trackMainEvent: trackMainEventMock }))
+
+import {
+  CANVAS_SCENE_SYNC_CAP_BYTES,
+  canvasSceneExceedsSyncCap,
+  syncCanvasCreate,
+  syncCanvasUpdate
+} from './sync-bridge'
+
+const SMALL_SCENE = JSON.stringify({ type: 'excalidraw', version: 2, elements: [{ id: 'r1' }] })
+
+/** A freehand-ink-like scene: many points in one stroke, no images — pure JSON growth. */
+function hugeFreehandScene(): string {
+  const points: [number, number][] = []
+  for (let i = 0; i < 400_000; i++) {
+    points.push([i, i])
+  }
+  return JSON.stringify({
+    type: 'excalidraw',
+    version: 2,
+    elements: [{ id: 'ink1', type: 'freedraw', points }]
+  })
+}
+
+describe('canvasSceneExceedsSyncCap', () => {
+  it('returns false for a small scene', () => {
+    expect(canvasSceneExceedsSyncCap(SMALL_SCENE)).toBe(false)
+  })
+
+  it('returns true once UTF-8 byte length exceeds the cap', () => {
+    const scene = hugeFreehandScene()
+    expect(Buffer.byteLength(scene, 'utf8')).toBeGreaterThan(CANVAS_SCENE_SYNC_CAP_BYTES)
+    expect(canvasSceneExceedsSyncCap(scene)).toBe(true)
+  })
+
+  it('stays under cap for a moderate scene with externalized memry-file:// image refs (M5)', () => {
+    // Post-M5, images are stored on disk and referenced by URL instead of inlined as
+    // base64 — externalization is what keeps normal scenes under the cap.
+    const refs = Array.from(
+      { length: 50 },
+      (_, i) => `memry-file://vault-1/canvas-assets/image-${i}.png`
+    )
+    const scene = JSON.stringify({
+      type: 'excalidraw',
+      version: 2,
+      elements: refs.map((url, i) => ({ id: `img${i}`, type: 'image', fileUrl: url }))
+    })
+    expect(Buffer.byteLength(scene, 'utf8')).toBeLessThan(CANVAS_SCENE_SYNC_CAP_BYTES)
+    expect(canvasSceneExceedsSyncCap(scene)).toBe(false)
+  })
+})
+
+describe('syncCanvasUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('too-large scene: returns false, emits canvas_too_large telemetry, bumps clock locally, does not enqueue', () => {
+    const scene = hugeFreehandScene()
+    const byteCount = Buffer.byteLength(scene, 'utf8')
+
+    const result = syncCanvasUpdate('canvas-1', scene)
+
+    expect(result).toBe(false)
+    expect(trackMainEventMock).toHaveBeenCalledWith('canvas_too_large', {
+      surface: 'sync',
+      action: 'push_blocked',
+      objectType: 'canvas',
+      result: 'skipped',
+      metrics: { byteCount }
+    })
+    // Local-only clock bump (not a silent markFailed): a later remote edit resolves
+    // as concurrent instead of clobbering the retained-but-unsynced scene.
+    expect(localMutationsMock.bumpCanvasClockLocalOnly).toHaveBeenCalledWith('canvas-1')
+    expect(localMutationsMock.enqueueLocalSyncUpdate).not.toHaveBeenCalled()
+  })
+
+  it('small scene: returns true, enqueues update, does not emit telemetry', () => {
+    const result = syncCanvasUpdate('canvas-1', SMALL_SCENE)
+
+    expect(result).toBe(true)
+    expect(localMutationsMock.enqueueLocalSyncUpdate).toHaveBeenCalledWith('canvas', 'canvas-1')
+    expect(trackMainEventMock).not.toHaveBeenCalled()
+    expect(localMutationsMock.bumpCanvasClockLocalOnly).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncCanvasCreate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('too-large initial scene: returns false, emits canvas_too_large telemetry, does not enqueue', () => {
+    const scene = hugeFreehandScene()
+    const byteCount = Buffer.byteLength(scene, 'utf8')
+
+    const result = syncCanvasCreate('canvas-2', scene)
+
+    expect(result).toBe(false)
+    expect(trackMainEventMock).toHaveBeenCalledWith('canvas_too_large', {
+      surface: 'sync',
+      action: 'push_blocked',
+      objectType: 'canvas',
+      result: 'skipped',
+      metrics: { byteCount }
+    })
+    expect(localMutationsMock.enqueueLocalSyncCreate).not.toHaveBeenCalled()
+  })
+
+  it('small scene: returns true, enqueues create', () => {
+    const result = syncCanvasCreate('canvas-2', SMALL_SCENE)
+
+    expect(result).toBe(true)
+    expect(localMutationsMock.enqueueLocalSyncCreate).toHaveBeenCalledWith('canvas', 'canvas-2')
+    expect(trackMainEventMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/canvas/sync-bridge.ts
+++ b/apps/desktop/src/main/canvas/sync-bridge.ts
@@ -33,6 +33,17 @@ const log = createLogger('CanvasSync')
  */
 export const CANVAS_SCENE_SYNC_CAP_BYTES = 3_000_000
 
+/**
+ * Measures the UNCOMPRESSED scene, deliberately — `encryptItemForPush`
+ * (`main/sync/encrypt.ts`) computes its "Item too large" throw from
+ * `input.content.byteLength * 1.37` before compression ever runs (compression
+ * happens after that check). Measuring the compressed payload here would let
+ * scenes that are large uncompressed but shrink well (e.g. repetitive
+ * freehand-ink point arrays) pass this guard and then still blow the
+ * uncompressed encrypt-time limit — reintroducing the silent `markFailed`
+ * drop this cap exists to prevent. Compressed measurement was considered and
+ * rejected for that reason.
+ */
 export function canvasSceneExceedsSyncCap(scene: string): boolean {
   return Buffer.byteLength(scene, 'utf8') > CANVAS_SCENE_SYNC_CAP_BYTES
 }

--- a/apps/desktop/src/main/database/drizzle-data/0036_canvas_assets.sql
+++ b/apps/desktop/src/main/database/drizzle-data/0036_canvas_assets.sql
@@ -1,0 +1,26 @@
+-- Adds canvas_assets: per-device dedup index + GC bookkeeping for externalized
+-- canvas image assets (M5). content_hash = plaintext sha256 (dedup key);
+-- chunk_hashes = encrypted chunk hashes (JSON) for server dereference.
+-- Hand-written (project switched off Drizzle generator after 0020).
+-- Additive only; frozen once any build ships it.
+
+CREATE TABLE IF NOT EXISTS `canvas_assets` (
+  `vault_id` TEXT NOT NULL,
+  `canvas_id` TEXT NOT NULL,
+  `content_hash` TEXT NOT NULL,
+  `attachment_id` TEXT NOT NULL,
+  `file_id` TEXT NOT NULL,
+  `filename` TEXT NOT NULL,
+  `mime_type` TEXT NOT NULL,
+  `size_bytes` INTEGER NOT NULL,
+  `chunk_hashes` TEXT NOT NULL,
+  `created_at` INTEGER NOT NULL,
+  PRIMARY KEY (`canvas_id`, `content_hash`),
+  FOREIGN KEY (`canvas_id`) REFERENCES `canvases`(`id`) ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_canvas_assets_dedup`
+  ON `canvas_assets` (`vault_id`, `content_hash`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_canvas_assets_attachment`
+  ON `canvas_assets` (`attachment_id`);

--- a/apps/desktop/src/main/database/drizzle-data/meta/_journal.json
+++ b/apps/desktop/src/main/database/drizzle-data/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1784289166413,
       "tag": "0035_spatial_canvas",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1784565001735,
+      "tag": "0036_canvas_assets",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/src/main/database/migrate.test.ts
+++ b/apps/desktop/src/main/database/migrate.test.ts
@@ -220,13 +220,16 @@ describe('0036_canvas_assets migration', () => {
   function makePre0036Folder(): string {
     const copy = path.join(tempDir, 'drizzle-data-pre-0036')
     fs.cpSync(migrationsDir, copy, { recursive: true })
-    fs.rmSync(path.join(copy, '0036_canvas_assets.sql'))
     const journalPath = path.join(copy, 'meta', '_journal.json')
     const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as {
       entries: { tag: string }[]
     }
-    expect(journal.entries[journal.entries.length - 1].tag).toBe('0036_canvas_assets')
-    journal.entries.pop()
+    const cutoff = journal.entries.findIndex((e) => e.tag === '0036_canvas_assets')
+    expect(cutoff).toBeGreaterThanOrEqual(0)
+    const removed = journal.entries.splice(cutoff)
+    for (const entry of removed) {
+      fs.rmSync(path.join(copy, `${entry.tag}.sql`))
+    }
     fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2))
     return copy
   }

--- a/apps/desktop/src/main/database/migrate.test.ts
+++ b/apps/desktop/src/main/database/migrate.test.ts
@@ -78,20 +78,25 @@ describe('0035_spatial_canvas migration', () => {
   })
 
   /**
-   * Copies drizzle-data/ to a temp folder with 0035 stripped (SQL file + last
-   * journal entry) so a database migrated from it is shaped like a production
-   * install that pre-dates the canvas tables.
+   * Copies drizzle-data/ to a temp folder with 0035 and everything after it
+   * stripped (SQL files + journal entries) so a database migrated from it is
+   * shaped like a production install that pre-dates the canvas tables. Looks
+   * up 0035 by tag (not "last entry") so later migrations added after it
+   * don't break this helper.
    */
   function makePre0035Folder(): string {
     const copy = path.join(tempDir, 'drizzle-data-pre-0035')
     fs.cpSync(migrationsDir, copy, { recursive: true })
-    fs.rmSync(path.join(copy, '0035_spatial_canvas.sql'))
     const journalPath = path.join(copy, 'meta', '_journal.json')
     const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as {
       entries: { tag: string }[]
     }
-    expect(journal.entries[journal.entries.length - 1].tag).toBe('0035_spatial_canvas')
-    journal.entries.pop()
+    const cutoff = journal.entries.findIndex((e) => e.tag === '0035_spatial_canvas')
+    expect(cutoff).toBeGreaterThanOrEqual(0)
+    const removed = journal.entries.splice(cutoff)
+    for (const entry of removed) {
+      fs.rmSync(path.join(copy, `${entry.tag}.sql`))
+    }
     fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2))
     return copy
   }
@@ -189,6 +194,174 @@ describe('0035_spatial_canvas migration', () => {
     sqlite.prepare("DELETE FROM canvases WHERE id = 'c1'").run()
     const remaining = sqlite
       .prepare("SELECT COUNT(*) AS n FROM canvas_entity_refs WHERE canvas_id = 'c1'")
+      .get() as { n: number }
+    expect(remaining.n).toBe(0)
+    sqlite.close()
+  })
+})
+
+describe('0036_canvas_assets migration', () => {
+  let tempDir: string
+  const migrationsDir = path.join(__dirname, 'drizzle-data')
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-canvas-assets-migrate-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  /**
+   * Copies drizzle-data/ to a temp folder with 0036 stripped (SQL file + last
+   * journal entry) so a database migrated from it is shaped like a production
+   * install that pre-dates the canvas_assets table.
+   */
+  function makePre0036Folder(): string {
+    const copy = path.join(tempDir, 'drizzle-data-pre-0036')
+    fs.cpSync(migrationsDir, copy, { recursive: true })
+    fs.rmSync(path.join(copy, '0036_canvas_assets.sql'))
+    const journalPath = path.join(copy, 'meta', '_journal.json')
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as {
+      entries: { tag: string }[]
+    }
+    expect(journal.entries[journal.entries.length - 1].tag).toBe('0036_canvas_assets')
+    journal.entries.pop()
+    fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2))
+    return copy
+  }
+
+  function tableNames(sqlite: InstanceType<typeof Database>): string[] {
+    return (
+      sqlite.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+        name: string
+      }[]
+    ).map((t) => t.name)
+  }
+
+  it('creates canvas_assets when upgrading an existing pre-0036 database', () => {
+    const dbPath = path.join(tempDir, 'data.db')
+    const sqlite = new Database(dbPath)
+    const db = drizzle(sqlite)
+
+    migrate(db, { migrationsFolder: makePre0036Folder() })
+    expect(tableNames(sqlite)).not.toContain('canvas_assets')
+    sqlite
+      .prepare(
+        "INSERT INTO canvases (id, vault_id, snapshot_ciphertext, vector_clock, created_at, updated_at) VALUES ('c-pre', 'v1', 'ct', '{}', 1, 1)"
+      )
+      .run()
+
+    migrate(db, { migrationsFolder: migrationsDir })
+
+    const names = tableNames(sqlite)
+    expect(names).toContain('canvas_assets')
+    const kept = sqlite.prepare("SELECT id FROM canvases WHERE id = 'c-pre'").get() as {
+      id: string
+    }
+    expect(kept.id).toBe('c-pre')
+    sqlite.close()
+  })
+
+  it('raw SQL statements are idempotent when executed twice', () => {
+    const dbPath = path.join(tempDir, 'data.db')
+    runMigrations(dbPath)
+
+    const sqlite = new Database(dbPath)
+    const statements = fs
+      .readFileSync(path.join(migrationsDir, '0036_canvas_assets.sql'), 'utf8')
+      .split('--> statement-breakpoint')
+      .map((s) => s.trim())
+      .filter(Boolean)
+
+    expect(statements.length).toBeGreaterThanOrEqual(3)
+    for (let round = 0; round < 2; round++) {
+      for (const statement of statements) {
+        expect(() => sqlite.exec(statement)).not.toThrow()
+      }
+    }
+    sqlite.close()
+  })
+
+  it('creates the expected columns', () => {
+    const dbPath = path.join(tempDir, 'data.db')
+    runMigrations(dbPath)
+
+    const sqlite = new Database(dbPath)
+    const columns = sqlite.pragma('table_info(canvas_assets)') as {
+      name: string
+      type: string
+      notnull: number
+      pk: number
+    }[]
+    const byName = Object.fromEntries(columns.map((c) => [c.name, c]))
+
+    expect(Object.keys(byName).sort()).toEqual(
+      [
+        'vault_id',
+        'canvas_id',
+        'content_hash',
+        'attachment_id',
+        'file_id',
+        'filename',
+        'mime_type',
+        'size_bytes',
+        'chunk_hashes',
+        'created_at'
+      ].sort()
+    )
+    for (const name of Object.keys(byName)) {
+      expect(byName[name].notnull, `${name} should be NOT NULL`).toBe(1)
+    }
+    expect(byName.size_bytes.type).toBe('INTEGER')
+    expect(byName.created_at.type).toBe('INTEGER')
+    expect(byName.canvas_id.pk).toBeGreaterThan(0)
+    expect(byName.content_hash.pk).toBeGreaterThan(0)
+    expect(byName.vault_id.pk).toBe(0)
+
+    sqlite.close()
+  })
+
+  it('creates the FK cascade, composite PK, and both indexes', () => {
+    const dbPath = path.join(tempDir, 'data.db')
+    runMigrations(dbPath)
+
+    const sqlite = new Database(dbPath)
+    sqlite.pragma('foreign_keys = ON')
+
+    const fks = sqlite.pragma('foreign_key_list(canvas_assets)') as {
+      table: string
+      from: string
+      to: string
+      on_delete: string
+    }[]
+    expect(fks).toHaveLength(1)
+    expect(fks[0]).toMatchObject({ table: 'canvases', from: 'canvas_id', on_delete: 'CASCADE' })
+
+    const indexNames = (
+      sqlite.prepare("SELECT name FROM sqlite_master WHERE type='index'").all() as {
+        name: string
+      }[]
+    ).map((i) => i.name)
+    expect(indexNames).toEqual(
+      expect.arrayContaining(['idx_canvas_assets_dedup', 'idx_canvas_assets_attachment'])
+    )
+
+    sqlite
+      .prepare(
+        "INSERT INTO canvases (id, vault_id, snapshot_ciphertext, vector_clock, created_at, updated_at) VALUES ('c1', 'v1', 'ct', '{}', 1, 1)"
+      )
+      .run()
+    const insertAsset = sqlite.prepare(
+      "INSERT INTO canvas_assets (vault_id, canvas_id, content_hash, attachment_id, file_id, filename, mime_type, size_bytes, chunk_hashes, created_at) VALUES ('v1', 'c1', 'hash1', 'att1', 'file1', 'img.png', 'image/png', 1234, '[]', 1)"
+    )
+    insertAsset.run()
+    // Duplicate (canvas_id, content_hash) violates the composite PK.
+    expect(() => insertAsset.run()).toThrow(/UNIQUE|PRIMARY/i)
+
+    sqlite.prepare("DELETE FROM canvases WHERE id = 'c1'").run()
+    const remaining = sqlite
+      .prepare("SELECT COUNT(*) AS n FROM canvas_assets WHERE canvas_id = 'c1'")
       .get() as { n: number }
     expect(remaining.n).toBe(0)
     sqlite.close()

--- a/apps/desktop/src/main/ipc/canvas-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/canvas-handlers.test.ts
@@ -37,6 +37,12 @@ vi.mock('../canvas/store', () => ({
   listCanvases: vi.fn(() => []),
   updateCanvas: vi.fn()
 }))
+// Keep the sync/attachment runtime out of this registration test: the real
+// context builder pulls the whole attachment + writeback graph. Returning null
+// makes the asset handlers degrade to their offline-safe branches.
+vi.mock('../canvas/assets/asset-service-context', () => ({
+  buildAssetServiceContext: vi.fn(() => null)
+}))
 
 const INVOKE_CHANNELS = Object.values(CanvasChannels.invoke)
 

--- a/apps/desktop/src/main/ipc/canvas-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/canvas-handlers.test.ts
@@ -1,6 +1,16 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { CanvasChannels } from '@memry/contracts/canvas-api'
 import { registerCanvasHandlers, unregisterCanvasHandlers } from './canvas-handlers'
+import { buildAssetServiceContext } from '../canvas/assets/asset-service-context'
+import {
+  getCanvasAssetRef,
+  listCanvasAssetDescriptors,
+  injectSceneAssetSidecar,
+  reconcileCanvasAssets,
+  uploadCanvasAsset
+} from '../canvas/assets/asset-service'
+import { updateCanvas, deleteCanvas } from '../canvas/store'
+import { syncCanvasUpdate, syncCanvasDelete } from '../canvas/sync-bridge'
 
 // Mock electron ipcMain so register/unregister can run in tests
 vi.mock('electron', () => ({
@@ -37,11 +47,37 @@ vi.mock('../canvas/store', () => ({
   listCanvases: vi.fn(() => []),
   updateCanvas: vi.fn()
 }))
+vi.mock('../canvas/sync-bridge', () => ({
+  syncCanvasCreate: vi.fn(() => true),
+  syncCanvasUpdate: vi.fn(() => true),
+  syncCanvasDelete: vi.fn()
+}))
 // Keep the sync/attachment runtime out of this registration test: the real
 // context builder pulls the whole attachment + writeback graph. Returning null
 // makes the asset handlers degrade to their offline-safe branches.
 vi.mock('../canvas/assets/asset-service-context', () => ({
   buildAssetServiceContext: vi.fn(() => null)
+}))
+// The asset service itself is unit-tested elsewhere (asset-service.test.ts);
+// here we only need to verify the handlers call it with the right args.
+vi.mock('../canvas/assets/asset-service', () => ({
+  getCanvasAssetRef: vi.fn(),
+  listCanvasAssetDescriptors: vi.fn(() => []),
+  injectSceneAssetSidecar: vi.fn((_ctx: unknown, _id: string, scene: string) => scene),
+  reconcileCanvasAssets: vi.fn(async () => {}),
+  uploadCanvasAsset: vi.fn(async () => ({
+    ref: 'memry-file://local/x/attachments/canvas-assets/hash.png',
+    descriptor: {
+      fileId: 'file-1',
+      attachmentId: 'att-1',
+      contentHash: 'hash',
+      chunkHashes: ['chunk-1'],
+      mimeType: 'image/png',
+      sizeBytes: 3,
+      filename: 'hash.png'
+    },
+    deduped: false
+  }))
 }))
 
 const INVOKE_CHANNELS = Object.values(CanvasChannels.invoke)
@@ -120,5 +156,206 @@ describe('canvas vault key memoization', () => {
 
     expect(initMock).toHaveBeenCalledTimes(2)
     unregisterCanvasHandlers()
+  })
+})
+
+type Handler = (event: unknown, input?: unknown) => Promise<unknown>
+
+/** Register the handlers and return a channel -> handler lookup for direct invocation. */
+async function registerAndGetHandlers(): Promise<Record<string, Handler>> {
+  const { ipcMain } = await import('electron')
+  const handleMock = vi.mocked(ipcMain.handle)
+  handleMock.mockClear()
+  registerCanvasHandlers()
+  const map: Record<string, Handler> = {}
+  for (const [channel, handler] of handleMock.mock.calls) {
+    map[channel as string] = handler as Handler
+  }
+  return map
+}
+
+/** Set up requireDatabase/getOrCreateVaultUuid/getOrInitializeLocalVaultKey to resolve. */
+async function withWorkingCanvasContext(): Promise<void> {
+  const { requireDatabase } = await import('../database')
+  const { getOrCreateVaultUuid } = await import('../agent/storage/vault-id')
+  const { getOrInitializeLocalVaultKey } = await import('../crypto')
+  vi.mocked(requireDatabase).mockReturnValue({} as never)
+  vi.mocked(getOrCreateVaultUuid).mockReturnValue('vault-1')
+  vi.mocked(getOrInitializeLocalVaultKey).mockReset().mockResolvedValue(new Uint8Array(32))
+}
+
+describe('canvas asset IPC handlers', () => {
+  afterEach(() => {
+    unregisterCanvasHandlers()
+    vi.clearAllMocks()
+  })
+
+  describe('canvas:upload-asset', () => {
+    it('throws "No vault is open" when buildAssetServiceContext() returns null', async () => {
+      vi.mocked(buildAssetServiceContext).mockReturnValue(null)
+      const handlers = await registerAndGetHandlers()
+
+      await expect(
+        handlers[CanvasChannels.invoke.UPLOAD_ASSET](
+          {},
+          { canvasId: 'canvas-1', fileId: 'file-1', mimeType: 'image/png', data: [1, 2, 3] }
+        )
+      ).rejects.toThrow('No vault is open')
+      expect(uploadCanvasAsset).not.toHaveBeenCalled()
+    })
+
+    it('decodes the number[] payload to bytes and calls uploadCanvasAsset with the context', async () => {
+      const fakeCtx = { marker: 'ctx' }
+      vi.mocked(buildAssetServiceContext).mockReturnValue(fakeCtx as never)
+      const handlers = await registerAndGetHandlers()
+
+      const result = await handlers[CanvasChannels.invoke.UPLOAD_ASSET](
+        {},
+        { canvasId: 'canvas-1', fileId: 'file-1', mimeType: 'image/png', data: [137, 80, 78, 71] }
+      )
+
+      expect(uploadCanvasAsset).toHaveBeenCalledTimes(1)
+      const [ctxArg, canvasIdArg, fileIdArg, mimeTypeArg, bytesArg] =
+        vi.mocked(uploadCanvasAsset).mock.calls[0]
+      expect(ctxArg).toBe(fakeCtx)
+      expect(canvasIdArg).toBe('canvas-1')
+      expect(fileIdArg).toBe('file-1')
+      expect(mimeTypeArg).toBe('image/png')
+      expect(bytesArg).toBeInstanceOf(Uint8Array)
+      expect(Array.from(bytesArg as Uint8Array)).toEqual([137, 80, 78, 71])
+      expect(result).toMatchObject({ deduped: false })
+    })
+  })
+
+  describe('canvas:get-asset', () => {
+    it('returns { ref: null } when buildAssetServiceContext() returns null', async () => {
+      vi.mocked(buildAssetServiceContext).mockReturnValue(null)
+      const handlers = await registerAndGetHandlers()
+
+      const result = await handlers[CanvasChannels.invoke.GET_ASSET](
+        {},
+        { canvasId: 'canvas-1', fileId: 'file-1' }
+      )
+
+      expect(result).toEqual({ ref: null })
+      expect(getCanvasAssetRef).not.toHaveBeenCalled()
+    })
+
+    it('resolves the ref via getCanvasAssetRef when a vault is open', async () => {
+      const fakeCtx = { marker: 'ctx' }
+      vi.mocked(buildAssetServiceContext).mockReturnValue(fakeCtx as never)
+      vi.mocked(getCanvasAssetRef).mockReturnValue(
+        'memry-file://local/x/attachments/canvas-assets/found.png'
+      )
+      const handlers = await registerAndGetHandlers()
+
+      const result = await handlers[CanvasChannels.invoke.GET_ASSET](
+        {},
+        { canvasId: 'canvas-1', fileId: 'file-1' }
+      )
+
+      expect(getCanvasAssetRef).toHaveBeenCalledWith(fakeCtx, 'canvas-1', 'file-1')
+      expect(result).toEqual({ ref: 'memry-file://local/x/attachments/canvas-assets/found.png' })
+    })
+  })
+
+  describe('canvas:list-assets', () => {
+    it('returns { assets: [] } when buildAssetServiceContext() returns null', async () => {
+      vi.mocked(buildAssetServiceContext).mockReturnValue(null)
+      const handlers = await registerAndGetHandlers()
+
+      const result = await handlers[CanvasChannels.invoke.LIST_ASSETS]({}, { canvasId: 'canvas-1' })
+
+      expect(result).toEqual({ assets: [] })
+      expect(listCanvasAssetDescriptors).not.toHaveBeenCalled()
+    })
+
+    it('returns the descriptors via listCanvasAssetDescriptors when a vault is open', async () => {
+      const fakeCtx = { marker: 'ctx' }
+      vi.mocked(buildAssetServiceContext).mockReturnValue(fakeCtx as never)
+      const descriptors = [
+        {
+          fileId: 'file-1',
+          attachmentId: 'att-1',
+          contentHash: 'hash-1',
+          chunkHashes: ['chunk-1'],
+          mimeType: 'image/png',
+          sizeBytes: 5,
+          filename: 'hash-1.png'
+        }
+      ]
+      vi.mocked(listCanvasAssetDescriptors).mockReturnValue(descriptors)
+      const handlers = await registerAndGetHandlers()
+
+      const result = await handlers[CanvasChannels.invoke.LIST_ASSETS]({}, { canvasId: 'canvas-1' })
+
+      expect(listCanvasAssetDescriptors).toHaveBeenCalledWith(fakeCtx, 'canvas-1')
+      expect(result).toEqual({ assets: descriptors })
+    })
+  })
+
+  describe('canvas:update — asset sidecar injection + GC', () => {
+    it('injects the sidecar and reconciles assets when a vault is open and scene is provided', async () => {
+      await withWorkingCanvasContext()
+      const fakeCtx = { marker: 'ctx' }
+      vi.mocked(buildAssetServiceContext).mockReturnValue(fakeCtx as never)
+      vi.mocked(injectSceneAssetSidecar).mockReturnValue('{"scene":"with-sidecar"}')
+      vi.mocked(updateCanvas).mockReturnValue({ id: 'canvas-1', title: null } as never)
+      const handlers = await registerAndGetHandlers()
+
+      await handlers[CanvasChannels.invoke.UPDATE]({}, { id: 'canvas-1', scene: '{"scene":"raw"}' })
+
+      expect(injectSceneAssetSidecar).toHaveBeenCalledWith(fakeCtx, 'canvas-1', '{"scene":"raw"}')
+      // updateCanvas persists the sidecar-injected scene, not the raw one.
+      expect(vi.mocked(updateCanvas).mock.calls[0][3]).toMatchObject({
+        scene: '{"scene":"with-sidecar"}'
+      })
+      expect(syncCanvasUpdate).toHaveBeenCalledWith('canvas-1', '{"scene":"with-sidecar"}')
+      expect(reconcileCanvasAssets).toHaveBeenCalledWith(
+        fakeCtx,
+        'canvas-1',
+        '{"scene":"with-sidecar"}'
+      )
+    })
+
+    it('skips sidecar injection and GC when no vault is open (ctx is null)', async () => {
+      await withWorkingCanvasContext()
+      vi.mocked(buildAssetServiceContext).mockReturnValue(null)
+      vi.mocked(updateCanvas).mockReturnValue({ id: 'canvas-1', title: null } as never)
+      const handlers = await registerAndGetHandlers()
+
+      await handlers[CanvasChannels.invoke.UPDATE]({}, { id: 'canvas-1', scene: '{"scene":"raw"}' })
+
+      expect(injectSceneAssetSidecar).not.toHaveBeenCalled()
+      expect(vi.mocked(updateCanvas).mock.calls[0][3]).toMatchObject({ scene: '{"scene":"raw"}' })
+      expect(reconcileCanvasAssets).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('canvas:delete — asset GC', () => {
+    it('reconciles assets before deleting when a vault is open', async () => {
+      await withWorkingCanvasContext()
+      const fakeCtx = { marker: 'ctx' }
+      vi.mocked(buildAssetServiceContext).mockReturnValue(fakeCtx as never)
+      vi.mocked(deleteCanvas).mockReturnValue(true)
+      const handlers = await registerAndGetHandlers()
+
+      const result = await handlers[CanvasChannels.invoke.DELETE]({}, 'canvas-1')
+
+      expect(reconcileCanvasAssets).toHaveBeenCalledWith(fakeCtx, 'canvas-1', '')
+      expect(syncCanvasDelete).toHaveBeenCalledWith('canvas-1')
+      expect(result).toEqual({ success: true })
+    })
+
+    it('skips reconcile when no vault is open (ctx is null)', async () => {
+      await withWorkingCanvasContext()
+      vi.mocked(buildAssetServiceContext).mockReturnValue(null)
+      vi.mocked(deleteCanvas).mockReturnValue(true)
+      const handlers = await registerAndGetHandlers()
+
+      await handlers[CanvasChannels.invoke.DELETE]({}, 'canvas-1')
+
+      expect(reconcileCanvasAssets).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/desktop/src/main/ipc/canvas-handlers.ts
+++ b/apps/desktop/src/main/ipc/canvas-handlers.ts
@@ -6,15 +6,21 @@
  * @module ipc/canvas-handlers
  */
 
+import { z } from 'zod'
 import { ipcMain, BrowserWindow } from 'electron'
 import {
   CanvasChannels,
   CanvasCreateSchema,
   CanvasUpdateSchema,
+  CanvasGetAssetSchema,
+  CanvasListAssetsSchema,
   type CanvasCreatedEvent,
   type CanvasUpdatedEvent,
   type CanvasDeletedEvent,
-  type CanvasTooLargeEvent
+  type CanvasTooLargeEvent,
+  type CanvasUploadAssetResponse,
+  type CanvasGetAssetResponse,
+  type CanvasListAssetsResponse
 } from '@memry/contracts/canvas-api'
 import { createValidatedHandler, createHandler, createStringHandler } from './validate'
 import { requireDatabase, type DataDb } from '../database'
@@ -39,6 +45,15 @@ function emitCanvasEvent(
 // every later call would throw "verifier exists but master key is missing".
 // A failed resolution is not cached so a transient keychain error can retry.
 let vaultKeyPromise: Promise<Uint8Array> | null = null
+
+// Binary payload validation is app-side, not contracts (A3): the renderer
+// serializes ArrayBuffer to number[] over the invoke bridge, so accept both.
+const UploadCanvasAssetSchema = z.object({
+  canvasId: z.string().min(1),
+  fileId: z.string().min(1),
+  mimeType: z.string().min(1),
+  data: z.instanceof(ArrayBuffer).or(z.array(z.number()))
+})
 
 function getVaultKeyOnce(db: DataDb, vaultId: string): Promise<Uint8Array> {
   if (!vaultKeyPromise) {
@@ -129,6 +144,39 @@ export function registerCanvasHandlers(): void {
       return { canvases: listCanvases(db, vaultId) }
     })
   )
+
+  // canvas:upload-asset - Store a scene binary file (stub — see M5 Task 5)
+  ipcMain.handle(
+    CanvasChannels.invoke.UPLOAD_ASSET,
+    createValidatedHandler(
+      UploadCanvasAssetSchema,
+      async (_input): Promise<CanvasUploadAssetResponse> => {
+        throw new Error('canvas asset upload not implemented until M5 Task 5')
+      }
+    )
+  )
+
+  // canvas:get-asset - Resolve a scene binary file's ref (stub — see M5 Task 5)
+  ipcMain.handle(
+    CanvasChannels.invoke.GET_ASSET,
+    createValidatedHandler(
+      CanvasGetAssetSchema,
+      async (_input): Promise<CanvasGetAssetResponse> => {
+        throw new Error('canvas get-asset not implemented until M5 Task 5')
+      }
+    )
+  )
+
+  // canvas:list-assets - List a canvas's scene binary files (stub — see M5 Task 5)
+  ipcMain.handle(
+    CanvasChannels.invoke.LIST_ASSETS,
+    createValidatedHandler(
+      CanvasListAssetsSchema,
+      async (_input): Promise<CanvasListAssetsResponse> => {
+        throw new Error('canvas list-assets not implemented until M5 Task 5')
+      }
+    )
+  )
 }
 
 export function unregisterCanvasHandlers(): void {
@@ -137,6 +185,9 @@ export function unregisterCanvasHandlers(): void {
   ipcMain.removeHandler(CanvasChannels.invoke.UPDATE)
   ipcMain.removeHandler(CanvasChannels.invoke.DELETE)
   ipcMain.removeHandler(CanvasChannels.invoke.LIST)
+  ipcMain.removeHandler(CanvasChannels.invoke.UPLOAD_ASSET)
+  ipcMain.removeHandler(CanvasChannels.invoke.GET_ASSET)
+  ipcMain.removeHandler(CanvasChannels.invoke.LIST_ASSETS)
   if (vaultKeyPromise) {
     void vaultKeyPromise.then((key) => secureCleanup(key)).catch(() => {})
     vaultKeyPromise = null

--- a/apps/desktop/src/main/ipc/canvas-handlers.ts
+++ b/apps/desktop/src/main/ipc/canvas-handlers.ts
@@ -28,6 +28,14 @@ import { getOrCreateVaultUuid } from '../agent/storage/vault-id'
 import { getOrInitializeLocalVaultKey, secureCleanup } from '../crypto'
 import { createCanvas, deleteCanvas, getCanvas, listCanvases, updateCanvas } from '../canvas/store'
 import { syncCanvasCreate, syncCanvasUpdate, syncCanvasDelete } from '../canvas/sync-bridge'
+import {
+  getCanvasAssetRef,
+  injectSceneAssetSidecar,
+  listCanvasAssetDescriptors,
+  reconcileCanvasAssets,
+  uploadCanvasAsset
+} from '../canvas/assets/asset-service'
+import { buildAssetServiceContext } from '../canvas/assets/asset-service-context'
 
 function emitCanvasEvent(
   channel: string,
@@ -108,15 +116,30 @@ export function registerCanvasHandlers(): void {
     CanvasChannels.invoke.UPDATE,
     createValidatedHandler(CanvasUpdateSchema, async (input) => {
       const { db, vaultKey } = await getCanvasContext()
-      const summary = updateCanvas(db, vaultKey, input.id, input)
+
+      // Inject the memryAssets sidecar so the synced scene carries the asset
+      // descriptors a receiving device needs to restore externalized images.
+      const assetCtx = buildAssetServiceContext()
+      const sceneToPersist =
+        assetCtx && input.scene !== undefined
+          ? injectSceneAssetSidecar(assetCtx, input.id, input.scene)
+          : input.scene
+
+      const summary = updateCanvas(db, vaultKey, input.id, { ...input, scene: sceneToPersist })
       if (!summary) {
         throw new Error('Canvas not found')
       }
-      const synced = syncCanvasUpdate(input.id, input.scene)
+      const synced = syncCanvasUpdate(input.id, sceneToPersist)
       emitCanvasEvent(CanvasChannels.events.UPDATED, { canvas: summary })
       if (!synced) {
         // Saved locally but too large to sync (§5.6) — surface, never silent.
         emitCanvasEvent(CanvasChannels.events.TOO_LARGE, { id: input.id })
+      }
+
+      // GC assets the saved scene no longer references (union protects assets
+      // still used by other canvases).
+      if (assetCtx && input.scene !== undefined) {
+        await reconcileCanvasAssets(assetCtx, input.id, sceneToPersist ?? '')
       }
       return summary
     })
@@ -127,6 +150,15 @@ export function registerCanvasHandlers(): void {
     CanvasChannels.invoke.DELETE,
     createStringHandler(async (id) => {
       const { db } = await getCanvasContext()
+
+      // GC this canvas's assets before the row is tombstoned (the other-canvas
+      // union keeps assets shared with surviving canvases). Reads the
+      // canvas_assets rows, so it must run before soft-delete/sync-delete.
+      const assetCtx = buildAssetServiceContext()
+      if (assetCtx) {
+        await reconcileCanvasAssets(assetCtx, id, '')
+      }
+
       const success = deleteCanvas(db, id)
       if (success) {
         syncCanvasDelete(id)
@@ -145,35 +177,40 @@ export function registerCanvasHandlers(): void {
     })
   )
 
-  // canvas:upload-asset - Store a scene binary file (stub — see M5 Task 5)
+  // canvas:upload-asset - Externalize + dedup + upload one scene image
   ipcMain.handle(
     CanvasChannels.invoke.UPLOAD_ASSET,
     createValidatedHandler(
       UploadCanvasAssetSchema,
-      async (_input): Promise<CanvasUploadAssetResponse> => {
-        throw new Error('canvas asset upload not implemented until M5 Task 5')
+      async (input): Promise<CanvasUploadAssetResponse> => {
+        const ctx = buildAssetServiceContext()
+        if (!ctx) throw new Error('No vault is open')
+        // The renderer sends ArrayBuffer as number[] over the invoke bridge.
+        const bytes = new Uint8Array(input.data)
+        return uploadCanvasAsset(ctx, input.canvasId, input.fileId, input.mimeType, bytes)
       }
     )
   )
 
-  // canvas:get-asset - Resolve a scene binary file's ref (stub — see M5 Task 5)
+  // canvas:get-asset - Resolve a scene image's memry-file:// ref
   ipcMain.handle(
     CanvasChannels.invoke.GET_ASSET,
-    createValidatedHandler(
-      CanvasGetAssetSchema,
-      async (_input): Promise<CanvasGetAssetResponse> => {
-        throw new Error('canvas get-asset not implemented until M5 Task 5')
-      }
-    )
+    createValidatedHandler(CanvasGetAssetSchema, async (input): Promise<CanvasGetAssetResponse> => {
+      const ctx = buildAssetServiceContext()
+      if (!ctx) return { ref: null }
+      return { ref: getCanvasAssetRef(ctx, input.canvasId, input.fileId) }
+    })
   )
 
-  // canvas:list-assets - List a canvas's scene binary files (stub — see M5 Task 5)
+  // canvas:list-assets - List a canvas's externalized image descriptors
   ipcMain.handle(
     CanvasChannels.invoke.LIST_ASSETS,
     createValidatedHandler(
       CanvasListAssetsSchema,
-      async (_input): Promise<CanvasListAssetsResponse> => {
-        throw new Error('canvas list-assets not implemented until M5 Task 5')
+      async (input): Promise<CanvasListAssetsResponse> => {
+        const ctx = buildAssetServiceContext()
+        if (!ctx) return { assets: [] }
+        return { assets: listCanvasAssetDescriptors(ctx, input.canvasId) }
       }
     )
   )

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -71,8 +71,11 @@ export interface MainIpcInvokeHandlers {
   "canvas:create": (...args: [{ title?: string | null | undefined; scene?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").Canvas>>
   "canvas:delete": (...args: [string]) => Awaited<Promise<{ success: boolean; }>>
   "canvas:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").Canvas | null>>
+  "canvas:get-asset": (...args: [{ canvasId: string; fileId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").CanvasGetAssetResponse>>
   "canvas:list": (...args: []) => Awaited<Promise<{ canvases: import("../../../../../packages/contracts/src/canvas-api").CanvasSummary[]; }>>
+  "canvas:list-assets": (...args: [{ canvasId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").CanvasListAssetsResponse>>
   "canvas:update": (...args: [{ id: string; title?: string | null | undefined; scene?: string | undefined; entityRefs?: { entityType: "note" | "task" | "calendar_event"; entityId: string; }[] | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").CanvasSummary>>
+  "canvas:upload-asset": (...args: [{ canvasId: string; fileId: string; mimeType: string; data: ArrayBuffer | number[]; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").CanvasUploadAssetResponse>>
   "context-menu:show": (...args: [{ id: string; label: string; accelerator?: string | undefined; disabled?: boolean | undefined; type?: "normal" | "separator" | undefined; }[]]) => Awaited<Promise<string | null>>
   "crdt:apply-update": (...args: [unknown]) => Awaited<Promise<void>>
   "crdt:close-doc": (...args: [unknown]) => Awaited<Promise<{ success: boolean; }>>

--- a/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
+++ b/apps/desktop/src/main/ipc/sync-attachment-handlers.ts
@@ -17,7 +17,8 @@ import {
 import {
   AttachmentSyncService,
   AttachmentTooLargeError,
-  type TransferProgress
+  type TransferProgress,
+  type UploadResult
 } from '../sync/attachments'
 import { classifyError } from '../sync/sync-errors'
 import {
@@ -129,6 +130,29 @@ const getOrCreateAttachmentService = (): AttachmentSyncService | null => {
   })
 
   return attachmentService
+}
+
+/**
+ * Bound upload/download IO over the SHARED attachment singletons, for the
+ * canvas asset service to reuse (no second queue/service). Uploads go through
+ * the upload queue (network gating + backoff) and return the full manifest;
+ * downloads go straight through the service. Returns null only if the sync
+ * singletons cannot be constructed.
+ */
+export function getCanvasAssetIO(): {
+  uploadAttachment: (canvasId: string, filePath: string) => Promise<UploadResult>
+  downloadAttachment: (attachmentId: string, targetPath: string) => Promise<void>
+} | null {
+  const queue = getOrCreateUploadQueue()
+  const service = getOrCreateAttachmentService()
+  if (!queue || !service) return null
+  return {
+    uploadAttachment: (canvasId, filePath) =>
+      queue.enqueue(canvasId, filePath, broadcastUploadProgress),
+    downloadAttachment: async (attachmentId, targetPath) => {
+      await service.downloadAttachment(attachmentId, targetPath)
+    }
+  }
 }
 
 export function clearAttachmentState(): void {

--- a/apps/desktop/src/main/sync/item-handlers/canvas-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/canvas-handler.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vite
 import { and, eq, isNull } from 'drizzle-orm'
 import sodium from 'libsodium-wrappers-sumo'
 import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
-import { canvases, canvasEntityRefs } from '@memry/db-schema/data-schema'
+import { canvases, canvasEntityRefs, canvasAssets } from '@memry/db-schema/data-schema'
 import type { CanvasSyncPayload } from '@memry/contracts/sync-payloads'
 import type { VectorClock } from '@memry/contracts/sync-api'
+import type { MemryAssetDescriptor } from '@memry/contracts/canvas-api'
 import type { SyncQueueManager } from '../queue'
 import type { ApplyContext, DrizzleDb } from './types'
 
@@ -12,9 +13,48 @@ vi.mock('../../lib/logger', () => ({
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
 }))
 
+// M5 asset IO is mocked: these modules transitively import electron (vault /
+// ipc / sync runtime), and the unit tests must never touch real network/disk.
+// `recordAsset` (asset-store) and `readMemryAssets` (memry-assets) are left REAL
+// — they are electron-free plain DB writes / JSON parsing under test.
+const { mockBuildAssetServiceContext, mockEnsureAssetsPresent, mockReconcileCanvasAssets } =
+  vi.hoisted(() => ({
+    mockBuildAssetServiceContext: vi.fn(),
+    mockEnsureAssetsPresent: vi.fn(),
+    mockReconcileCanvasAssets: vi.fn()
+  }))
+vi.mock('../../canvas/assets/asset-service-context', () => ({
+  buildAssetServiceContext: mockBuildAssetServiceContext
+}))
+vi.mock('../../canvas/assets/asset-service', () => ({
+  ensureAssetsPresent: mockEnsureAssetsPresent,
+  reconcileCanvasAssets: mockReconcileCanvasAssets
+}))
+
 import { canvasHandler } from './canvas-handler'
 import { encryptCanvasSceneForVault, decryptCanvasSceneForVault } from '../../canvas/encryption'
+import { hashesReferencedByOtherCanvases } from '../../canvas/assets/asset-store'
 import { initCanvasSyncService, resetCanvasSyncService } from '../canvas-sync'
+
+const ASSET_CTX = { marker: 'asset-ctx' }
+
+function asset(hash: string): MemryAssetDescriptor {
+  return {
+    fileId: `file-${hash}`,
+    attachmentId: `att-${hash}`,
+    contentHash: hash,
+    chunkHashes: [`chunk-${hash}`],
+    mimeType: 'image/png',
+    sizeBytes: 1024,
+    filename: `${hash}.png`
+  }
+}
+
+function sceneWithAssets(entityId: string, assets: MemryAssetDescriptor[], extra = ''): string {
+  const base = JSON.parse(sceneWith(entityId, extra)) as Record<string, unknown>
+  base.memryAssets = assets
+  return JSON.stringify(base)
+}
 
 const VAULT_KEY = new Uint8Array(32).fill(7)
 const VAULT_ID = 'vault-1'
@@ -89,6 +129,9 @@ describe('canvasHandler', () => {
       getDeviceId: () => LOCAL_DEVICE
     })
     ctx = { db, emit: vi.fn(), vaultKey: VAULT_KEY }
+    mockBuildAssetServiceContext.mockReset().mockReturnValue(ASSET_CTX)
+    mockEnsureAssetsPresent.mockReset().mockResolvedValue(undefined)
+    mockReconcileCanvasAssets.mockReset().mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -399,6 +442,124 @@ describe('canvasHandler', () => {
         .where(and(eq(canvases.id, 'c1'), isNull(canvases.clock)))
         .get()
       expect(row).toBeDefined()
+    })
+  })
+
+  describe('M5 asset ingestion / restore / GC', () => {
+    it('#given a create carrying 2 memryAssets #then records 2 rows + restores after commit', () => {
+      const a1 = asset('h1')
+      const a2 = asset('h2')
+      const data: CanvasSyncPayload = {
+        id: 'c1',
+        vaultId: VAULT_ID,
+        title: 'Remote',
+        scene: sceneWithAssets('note-1', [a1, a2]),
+        clock: { B: 1 }
+      }
+
+      const result = canvasHandler.applyUpsert(ctx, 'c1', data, { B: 1 })
+
+      expect(result).toBe('applied')
+      const rows = db.select().from(canvasAssets).where(eq(canvasAssets.canvasId, 'c1')).all()
+      expect(rows.map((r) => r.contentHash).sort()).toEqual(['h1', 'h2'])
+      expect(rows.every((r) => r.vaultId === VAULT_ID)).toBe(true)
+      // Restore is fired AFTER the tx commits, once, with the same descriptors.
+      expect(mockEnsureAssetsPresent).toHaveBeenCalledTimes(1)
+      expect(mockEnsureAssetsPresent).toHaveBeenCalledWith(ASSET_CTX, 'c1', [a1, a2])
+    })
+
+    it('#given a concurrent-clock conflict copy #then records shared assets under BOTH ids (GC union protects them)', () => {
+      const shared = asset('shared')
+      seedCanvas(db, 'c1', sceneWithAssets('note-local', [shared]), { A: 2 })
+
+      const result = canvasHandler.applyUpsert(
+        ctx,
+        'c1',
+        {
+          id: 'c1',
+          vaultId: VAULT_ID,
+          scene: sceneWithAssets('note-remote', [shared]),
+          clock: { B: 3 }
+        },
+        { B: 3 }
+      )
+
+      expect(result).toBe('conflict')
+      const copy = db
+        .select()
+        .from(canvases)
+        .all()
+        .find((r) => r.id !== 'c1')!
+      expect(copy).toBeDefined()
+
+      const c1Hashes = db
+        .select()
+        .from(canvasAssets)
+        .where(eq(canvasAssets.canvasId, 'c1'))
+        .all()
+        .map((r) => r.contentHash)
+      const copyHashes = db
+        .select()
+        .from(canvasAssets)
+        .where(eq(canvasAssets.canvasId, copy.id))
+        .all()
+        .map((r) => r.contentHash)
+      expect(c1Hashes).toEqual(['shared'])
+      expect(copyHashes).toEqual(['shared'])
+
+      // The union protects the shared asset from GC over EITHER canvas: deleting
+      // the original must not reap an asset the conflict copy still references.
+      expect(hashesReferencedByOtherCanvases(db, VAULT_ID, 'c1').has('shared')).toBe(true)
+      expect(hashesReferencedByOtherCanvases(db, VAULT_ID, copy.id).has('shared')).toBe(true)
+    })
+
+    it('#given a remote delete #then GCs the canvas assets with an empty scene', () => {
+      seedCanvas(db, 'c1', sceneWithAssets('note-1', [asset('h1')]), { A: 1 })
+
+      const result = canvasHandler.applyDelete(ctx, 'c1', { A: 1, B: 2 })
+
+      expect(result).toBe('applied')
+      expect(mockReconcileCanvasAssets).toHaveBeenCalledTimes(1)
+      expect(mockReconcileCanvasAssets).toHaveBeenCalledWith(ASSET_CTX, 'c1', '')
+    })
+
+    it('#given a skipped delete (local newer) #then does NOT GC', () => {
+      seedCanvas(db, 'c1', sceneWith('note-1'), { A: 5 })
+
+      expect(canvasHandler.applyDelete(ctx, 'c1', { A: 2 })).toBe('skipped')
+      expect(mockReconcileCanvasAssets).not.toHaveBeenCalled()
+    })
+
+    it('#given a pre-M5 base64 scene (no memryAssets) #then records nothing, restores nothing, never throws', () => {
+      const data: CanvasSyncPayload = {
+        id: 'c1',
+        vaultId: VAULT_ID,
+        scene: sceneWith('note-1'),
+        clock: { B: 1 }
+      }
+
+      const result = canvasHandler.applyUpsert(ctx, 'c1', data, { B: 1 })
+
+      expect(result).toBe('applied')
+      expect(db.select().from(canvasAssets).all()).toHaveLength(0)
+      expect(mockEnsureAssetsPresent).not.toHaveBeenCalled()
+    })
+
+    it('#given a payload without a scene (D5) #then still skips and records no assets', () => {
+      seedCanvas(db, 'c1', sceneWithAssets('note-keep', [asset('h1')]), { A: 1 })
+      // Seeded row itself recorded no asset rows (seedCanvas bypasses the handler).
+      const before = db.select().from(canvasAssets).all().length
+
+      const result = canvasHandler.applyUpsert(
+        ctx,
+        'c1',
+        { id: 'c1', vaultId: VAULT_ID, clock: { A: 1, B: 5 } },
+        { A: 1, B: 5 }
+      )
+
+      expect(result).toBe('skipped')
+      expect(db.select().from(canvasAssets).all()).toHaveLength(before)
+      expect(mockEnsureAssetsPresent).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/desktop/src/main/sync/item-handlers/canvas-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/canvas-handler.ts
@@ -9,10 +9,15 @@ import { createLogger } from '../../lib/logger'
 import { generateId } from '../../lib/id'
 import { encryptCanvasSceneForVault, decryptCanvasSceneForVault } from '../../canvas/encryption'
 import { extractEntityRefsFromScene } from '../../canvas/scene-refs'
+import { readMemryAssets } from '../../canvas/assets/memry-assets'
+import { recordAsset } from '../../canvas/assets/asset-store'
+import { ensureAssetsPresent, reconcileCanvasAssets } from '../../canvas/assets/asset-service'
+import { buildAssetServiceContext } from '../../canvas/assets/asset-service-context'
 import { getCanvasSyncService } from '../canvas-sync'
 import { trackMainEvent } from '../../telemetry/track'
 import { BaseItemHandler } from './base-handler'
 import type { ApplyContext, ApplyResult, DrizzleDb } from './types'
+import type { MemryAssetDescriptor } from '@memry/contracts/canvas-api'
 
 const log = createLogger('CanvasHandler')
 
@@ -24,6 +29,75 @@ function writeRefs(tx: CanvasTx, canvasId: string, scene: string): void {
       .values({ canvasId, entityType: ref.entityType, entityId: ref.entityId })
       .onConflictDoNothing()
       .run()
+  }
+}
+
+/**
+ * M5: ingest the `memryAssets` scene sidecar into the per-device dedup/GC index
+ * (`canvas_assets`). Records one idempotent row per (canvas, asset) so a
+ * non-authoring device gets the dedup + GC bookkeeping it never uploaded, and
+ * the GC union (`hashesReferencedByOtherCanvases`) protects assets shared across
+ * canvases (incl. conflict copies). A pre-M5 / inline-base64 scene yields `[]`
+ * → zero rows (backward compat). Uses the same connection as the apply tx, so
+ * it is atomic with the scene write.
+ */
+function recordSceneAssets(
+  db: DrizzleDb,
+  vaultId: string,
+  canvasId: string,
+  descriptors: MemryAssetDescriptor[]
+): void {
+  const now = Date.now()
+  for (const descriptor of descriptors) {
+    recordAsset(db, {
+      vaultId,
+      canvasId,
+      contentHash: descriptor.contentHash,
+      attachmentId: descriptor.attachmentId,
+      fileId: descriptor.fileId,
+      filename: descriptor.filename,
+      mimeType: descriptor.mimeType,
+      sizeBytes: descriptor.sizeBytes,
+      chunkHashes: descriptor.chunkHashes,
+      createdAt: now
+    })
+  }
+}
+
+/**
+ * M5 device-B restore: after the apply tx commits, download any asset file the
+ * applied scene references but this device is missing, so the scene renders.
+ * Fire-and-forget — a failed/slow download must never fail (or block) the apply,
+ * and a closed vault (no asset context) is a silent no-op. `ensureAssetsPresent`
+ * already isolates per-asset errors and calls `markWritebackIgnored` first.
+ */
+async function restoreCanvasAssets(
+  canvasId: string,
+  descriptors: MemryAssetDescriptor[]
+): Promise<void> {
+  try {
+    const assetCtx = buildAssetServiceContext()
+    if (!assetCtx) return
+    await ensureAssetsPresent(assetCtx, canvasId, descriptors)
+  } catch (err) {
+    log.warn('canvas asset restore failed after apply', { canvasId, err })
+  }
+}
+
+/**
+ * M5 GC on remote delete: after the tombstone commits, reconcile the deleted
+ * canvas against an empty scene so all of its hashes are candidates for removal.
+ * The GC union still protects any hash a conflict copy / other canvas references,
+ * so a shared asset survives. Fire-and-forget / graceful — GC must never fail a
+ * delete, and a closed vault is a silent no-op.
+ */
+async function gcDeletedCanvasAssets(canvasId: string): Promise<void> {
+  try {
+    const assetCtx = buildAssetServiceContext()
+    if (!assetCtx) return
+    await reconcileCanvasAssets(assetCtx, canvasId, '')
+  } catch (err) {
+    log.warn('canvas asset GC failed after delete', { canvasId, err })
   }
 }
 
@@ -65,8 +139,11 @@ export class CanvasHandler extends BaseItemHandler<CanvasSyncPayload> {
       return 'skipped'
     }
     const scene = data.scene
+    // M5: assets externalized into the scene sidecar. `[]` for a pre-M5 /
+    // inline-base64 scene → no rows recorded, no downloads triggered.
+    const descriptors = readMemryAssets(scene)
 
-    return ctx.db.transaction((tx): ApplyResult => {
+    const result = ctx.db.transaction((tx): ApplyResult => {
       const existing = tx.select().from(canvases).where(eq(canvases.id, itemId)).get()
       const remoteClock = Object.keys(clock).length > 0 ? clock : (data.clock ?? {})
       const now = Date.now()
@@ -92,6 +169,8 @@ export class CanvasHandler extends BaseItemHandler<CanvasSyncPayload> {
           })
           .run()
         writeRefs(tx, itemId, scene)
+        // M5: ingest the asset sidecar so this device gets dedup/GC rows.
+        recordSceneAssets(ctx.db, vaultId, itemId, descriptors)
         ctx.emit(CanvasChannels.events.CREATED, {
           canvas: { id: itemId, title: data.title ?? null, createdAt: now, updatedAt: now }
         })
@@ -142,16 +221,27 @@ export class CanvasHandler extends BaseItemHandler<CanvasSyncPayload> {
       // D4: rebuild advisory refs from the incoming scene.
       tx.delete(canvasEntityRefs).where(eq(canvasEntityRefs.canvasId, itemId)).run()
       writeRefs(tx, itemId, scene)
+      // M5: ingest the incoming scene's asset sidecar under this canvas. Rows are
+      // append-only (idempotent upsert); GC on save/delete prunes stale ones.
+      recordSceneAssets(ctx.db, existing.vaultId, itemId, descriptors)
 
       ctx.emit(CanvasChannels.events.UPDATED, {
         canvas: { id: itemId, title: nextTitle, createdAt: existing.createdAt, updatedAt: now }
       })
       return madeCopy ? 'conflict' : 'applied'
     })
+
+    // AFTER commit (never inside the tx): fetch any missing asset files so the
+    // applied scene renders. Skipped applies (D5 / LWW-lose) applied no scene, so
+    // there is nothing to restore. Fire-and-forget: a download must not fail apply.
+    if (result !== 'skipped' && descriptors.length > 0) {
+      void restoreCanvasAssets(itemId, descriptors)
+    }
+    return result
   }
 
   applyDelete(ctx: ApplyContext, itemId: string, clock?: VectorClock): 'applied' | 'skipped' {
-    return ctx.db.transaction((tx): 'applied' | 'skipped' => {
+    const result = ctx.db.transaction((tx): 'applied' | 'skipped' => {
       const existing = tx.select().from(canvases).where(eq(canvases.id, itemId)).get()
       if (!existing || existing.deletedAt !== null) return 'skipped'
 
@@ -182,6 +272,14 @@ export class CanvasHandler extends BaseItemHandler<CanvasSyncPayload> {
       ctx.emit(CanvasChannels.events.DELETED, { id: itemId })
       return 'applied'
     })
+
+    // AFTER commit: GC the deleted canvas's assets (empty scene → all its hashes
+    // are removal candidates; the GC union protects any still shared). Only when
+    // a tombstone was actually written — a skipped delete leaves the canvas live.
+    if (result === 'applied') {
+      void gcDeletedCanvasAssets(itemId)
+    }
+    return result
   }
 
   fetchLocal(db: DrizzleDb, itemId: string): Record<string, unknown> | undefined {
@@ -282,6 +380,13 @@ export class CanvasHandler extends BaseItemHandler<CanvasSyncPayload> {
     // derived from the scene itself, not the refs table, so the copy is correct
     // even if the table was never populated for this row.
     writeRefs(tx, copyId, localScene)
+
+    // M5 (R12 data-loss guard): the copy holds the LOSING LOCAL scene verbatim,
+    // so it must own asset rows for the assets THAT scene references — read from
+    // `localScene`, NOT the incoming winning scene. This puts the copy's hashes
+    // into the GC union (`hashesReferencedByOtherCanvases`), so when the original
+    // is later overwritten/deleted, GC will not reap an asset the copy still uses.
+    recordSceneAssets(ctx.db, existing.vaultId, copyId, readMemryAssets(localScene))
 
     if (deviceId) {
       // Enqueue a METADATA-ONLY create push (no plaintext scene at rest in the

--- a/apps/desktop/src/main/sync/item-handlers/canvas-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/canvas-handler.ts
@@ -1,5 +1,10 @@
 import { and, eq, isNull } from 'drizzle-orm'
-import { canvases, canvasEntityRefs, type CanvasRow } from '@memry/db-schema/data-schema'
+import {
+  canvasAssets,
+  canvases,
+  canvasEntityRefs,
+  type CanvasRow
+} from '@memry/db-schema/data-schema'
 import { CanvasSyncPayloadSchema, type CanvasSyncPayload } from '@memry/contracts/sync-payloads'
 import { CanvasChannels } from '@memry/contracts/ipc-channels'
 import type { VectorClock } from '@memry/contracts/sync-api'
@@ -10,7 +15,6 @@ import { generateId } from '../../lib/id'
 import { encryptCanvasSceneForVault, decryptCanvasSceneForVault } from '../../canvas/encryption'
 import { extractEntityRefsFromScene } from '../../canvas/scene-refs'
 import { readMemryAssets } from '../../canvas/assets/memry-assets'
-import { recordAsset } from '../../canvas/assets/asset-store'
 import { ensureAssetsPresent, reconcileCanvasAssets } from '../../canvas/assets/asset-service'
 import { buildAssetServiceContext } from '../../canvas/assets/asset-service-context'
 import { getCanvasSyncService } from '../canvas-sync'
@@ -38,29 +42,33 @@ function writeRefs(tx: CanvasTx, canvasId: string, scene: string): void {
  * non-authoring device gets the dedup + GC bookkeeping it never uploaded, and
  * the GC union (`hashesReferencedByOtherCanvases`) protects assets shared across
  * canvases (incl. conflict copies). A pre-M5 / inline-base64 scene yields `[]`
- * → zero rows (backward compat). Uses the same connection as the apply tx, so
- * it is atomic with the scene write.
+ * → zero rows (backward compat). Writes through the apply transaction handle
+ * (`tx`, like `writeRefs`), so it commits/rolls back atomically with the scene
+ * + entity-ref writes.
  */
 function recordSceneAssets(
-  db: DrizzleDb,
+  tx: CanvasTx,
   vaultId: string,
   canvasId: string,
   descriptors: MemryAssetDescriptor[]
 ): void {
   const now = Date.now()
   for (const descriptor of descriptors) {
-    recordAsset(db, {
-      vaultId,
-      canvasId,
-      contentHash: descriptor.contentHash,
-      attachmentId: descriptor.attachmentId,
-      fileId: descriptor.fileId,
-      filename: descriptor.filename,
-      mimeType: descriptor.mimeType,
-      sizeBytes: descriptor.sizeBytes,
-      chunkHashes: descriptor.chunkHashes,
-      createdAt: now
-    })
+    tx.insert(canvasAssets)
+      .values({
+        vaultId,
+        canvasId,
+        contentHash: descriptor.contentHash,
+        attachmentId: descriptor.attachmentId,
+        fileId: descriptor.fileId,
+        filename: descriptor.filename,
+        mimeType: descriptor.mimeType,
+        sizeBytes: descriptor.sizeBytes,
+        chunkHashes: descriptor.chunkHashes,
+        createdAt: now
+      })
+      .onConflictDoNothing()
+      .run()
   }
 }
 
@@ -170,7 +178,7 @@ export class CanvasHandler extends BaseItemHandler<CanvasSyncPayload> {
           .run()
         writeRefs(tx, itemId, scene)
         // M5: ingest the asset sidecar so this device gets dedup/GC rows.
-        recordSceneAssets(ctx.db, vaultId, itemId, descriptors)
+        recordSceneAssets(tx, vaultId, itemId, descriptors)
         ctx.emit(CanvasChannels.events.CREATED, {
           canvas: { id: itemId, title: data.title ?? null, createdAt: now, updatedAt: now }
         })
@@ -223,7 +231,7 @@ export class CanvasHandler extends BaseItemHandler<CanvasSyncPayload> {
       writeRefs(tx, itemId, scene)
       // M5: ingest the incoming scene's asset sidecar under this canvas. Rows are
       // append-only (idempotent upsert); GC on save/delete prunes stale ones.
-      recordSceneAssets(ctx.db, existing.vaultId, itemId, descriptors)
+      recordSceneAssets(tx, existing.vaultId, itemId, descriptors)
 
       ctx.emit(CanvasChannels.events.UPDATED, {
         canvas: { id: itemId, title: nextTitle, createdAt: existing.createdAt, updatedAt: now }
@@ -386,7 +394,7 @@ export class CanvasHandler extends BaseItemHandler<CanvasSyncPayload> {
     // `localScene`, NOT the incoming winning scene. This puts the copy's hashes
     // into the GC union (`hashesReferencedByOtherCanvases`), so when the original
     // is later overwritten/deleted, GC will not reap an asset the copy still uses.
-    recordSceneAssets(ctx.db, existing.vaultId, copyId, readMemryAssets(localScene))
+    recordSceneAssets(tx, existing.vaultId, copyId, readMemryAssets(localScene))
 
     if (deviceId) {
       // Enqueue a METADATA-ONLY create push (no plaintext scene at rest in the

--- a/apps/desktop/src/main/vault/file-ops.test.ts
+++ b/apps/desktop/src/main/vault/file-ops.test.ts
@@ -10,6 +10,7 @@ import * as os from 'os'
 import { rename } from 'fs/promises'
 import {
   atomicWrite,
+  atomicWriteBinary,
   safeRead,
   readRequired,
   ensureDirectory,
@@ -125,6 +126,64 @@ describe('atomicWrite', () => {
     await expect(atomicWrite(dirPath, 'content')).rejects.toThrow(NoteError)
 
     // No temp files should be left behind
+    const files = fs.readdirSync(tempDir.path)
+    const tempFiles = files.filter((f) => f.startsWith('.') && f.endsWith('.tmp'))
+    expect(tempFiles).toHaveLength(0)
+  })
+})
+
+// ============================================================================
+// atomicWriteBinary Tests
+// ============================================================================
+
+describe('atomicWriteBinary', () => {
+  let tempDir: TestDir
+
+  beforeEach(() => {
+    tempDir = createTempDir()
+  })
+
+  afterEach(() => {
+    tempDir.cleanup()
+  })
+
+  it('writes raw bytes atomically via temp file and rename', async () => {
+    const filePath = path.join(tempDir.path, 'asset.png')
+    const data = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02])
+
+    await atomicWriteBinary(filePath, data)
+
+    expect(fs.existsSync(filePath)).toBe(true)
+    expect(fs.readFileSync(filePath)).toEqual(data)
+  })
+
+  it('creates parent directories if they do not exist', async () => {
+    const filePath = path.join(tempDir.path, 'nested', 'deep', 'asset.bin')
+    const data = new Uint8Array([1, 2, 3, 4])
+
+    await atomicWriteBinary(filePath, data)
+
+    expect(fs.existsSync(filePath)).toBe(true)
+    expect(fs.readFileSync(filePath)).toEqual(Buffer.from(data))
+  })
+
+  it('overwrites existing binary content', async () => {
+    const filePath = path.join(tempDir.path, 'existing.bin')
+    fs.writeFileSync(filePath, Buffer.from([9, 9, 9]))
+
+    await atomicWriteBinary(filePath, Buffer.from([1, 2, 3]))
+
+    expect(fs.readFileSync(filePath)).toEqual(Buffer.from([1, 2, 3]))
+  })
+
+  it('cleans up the temp file and propagates the error on write failure', async () => {
+    // Target a directory path so the rename fails.
+    const dirPath = path.join(tempDir.path, 'a-directory')
+    fs.mkdirSync(dirPath)
+
+    await expect(atomicWriteBinary(dirPath, Buffer.from([1, 2, 3]))).rejects.toThrow(NoteError)
+
+    // No temp files should be left behind in the parent directory.
     const files = fs.readdirSync(tempDir.path)
     const tempFiles = files.filter((f) => f.startsWith('.') && f.endsWith('.tmp'))
     expect(tempFiles).toHaveLength(0)

--- a/apps/desktop/src/main/vault/file-ops.ts
+++ b/apps/desktop/src/main/vault/file-ops.ts
@@ -110,6 +110,54 @@ export async function atomicWrite(filePath: string, content: string): Promise<vo
 }
 
 /**
+ * Binary counterpart of {@link atomicWrite}: same temp-file-then-rename +
+ * transient-retry pattern, but writes raw bytes without a text encoding.
+ * Used for content-addressed canvas image assets under `attachments/`.
+ *
+ * @param filePath - Absolute path to the target file
+ * @param data - Bytes to write
+ * @throws NoteError if write fails
+ */
+export async function atomicWriteBinary(
+  filePath: string,
+  data: Buffer | Uint8Array
+): Promise<void> {
+  const dir = path.dirname(filePath)
+
+  try {
+    await ensureDirectory(dir)
+
+    await withTransientFsRetry(async () => {
+      const tempPath = path.join(dir, `.${randomBytes(6).toString('hex')}.tmp`)
+
+      try {
+        await writeFile(tempPath, data, { mode: 0o600, flag: 'wx' })
+        await rename(tempPath, filePath)
+      } catch (error) {
+        try {
+          if (existsSync(tempPath)) {
+            await unlink(tempPath)
+          }
+        } catch {
+          // Ignore cleanup errors
+        }
+
+        throw error
+      }
+    }, 'atomicWriteBinary')
+  } catch (error) {
+    throw new NoteError(
+      `Failed to write file: ${filePath}`,
+      NoteErrorCode.WRITE_FAILED,
+      undefined,
+      {
+        cause: error
+      }
+    )
+  }
+}
+
+/**
  * Write only when the content differs from what is on disk. Skipping the
  * write entirely means no mtime churn, no watcher echo and no sync item for
  * no-op saves.

--- a/apps/desktop/src/preload/generated-rpc.ts
+++ b/apps/desktop/src/preload/generated-rpc.ts
@@ -299,6 +299,15 @@ export function createGeneratedRpcApi({
       "update": ((input) => invoke("canvas:update", input)) as GeneratedRpcApi["canvas"]["update"],
       "delete": ((id) => invoke("canvas:delete", id)) as GeneratedRpcApi["canvas"]["delete"],
       "list": (() => invoke("canvas:list")) as GeneratedRpcApi["canvas"]["list"],
+      "uploadAsset": (async (input) =>
+        invoke("canvas:upload-asset", {
+          canvasId: input.canvasId,
+          fileId: input.fileId,
+          mimeType: input.mimeType,
+          data: Array.from(new Uint8Array(input.data))
+        })) as GeneratedRpcApi["canvas"]["uploadAsset"],
+      "getAsset": ((canvasId, fileId) => invoke("canvas:get-asset", { canvasId, fileId })) as GeneratedRpcApi["canvas"]["getAsset"],
+      "listAssets": ((canvasId) => invoke("canvas:list-assets", { canvasId })) as GeneratedRpcApi["canvas"]["listAssets"],
     },
     "telemetry": {
       "track": ((event) => invoke("telemetry:track", event)) as GeneratedRpcApi["telemetry"]["track"],

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
@@ -21,6 +21,7 @@ import { canvasService, onCanvasTooLarge } from '@/services/canvas-service'
 import { registerPendingSave, unregisterPendingSave } from '@/lib/save-registry'
 import { createLogger } from '@/lib/logger'
 import { createScenePersister } from './canvas-persistence'
+import { externalizeSceneAssets } from './canvas-externalize'
 import { pickExcalidrawLangCode } from './excalidraw-lang'
 import { CanvasCardLayer } from './canvas-card-overlay'
 import { extractEntityRefs, type CardElement } from './canvas-cards'
@@ -101,7 +102,20 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
         // Advisory entity refs are derived from the same scene, so the dedupe
         // key (scene string) still governs whether a save runs.
         const elements = (apiRef.current?.getSceneElements() ?? []) as unknown as CardElement[]
-        await canvasService.update({ id: canvasId, scene, entityRefs: extractEntityRefs(elements) })
+        let sceneToSave = scene
+        try {
+          sceneToSave = await externalizeSceneAssets(scene, canvasId, (input) =>
+            canvasService.uploadAsset(input)
+          )
+        } catch (err) {
+          log.error('Failed to externalize canvas assets; saving scene as-is', err)
+          // Fall back to the original scene — the pre-push size guard surfaces oversize saves.
+        }
+        await canvasService.update({
+          id: canvasId,
+          scene: sceneToSave,
+          entityRefs: extractEntityRefs(elements)
+        })
       },
       debounceMs: SCENE_SAVE_DEBOUNCE_MS,
       lastSavedScene: initialScene,

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-externalize.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-externalize.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest'
+import { externalizeSceneAssets, type AssetUploader } from './canvas-externalize'
+
+const CANVAS_ID = 'canvas-1'
+
+function scene(files: Record<string, unknown>): string {
+  return JSON.stringify({ elements: [], appState: {}, files })
+}
+
+describe('externalizeSceneAssets', () => {
+  it('uploads a data: URI file and rewrites its dataURL to the returned ref', async () => {
+    const upload = vi.fn<AssetUploader>().mockResolvedValue({ ref: 'memry-file://canvas-1/file-1' })
+    const sceneJson = scene({
+      'file-1': { mimeType: 'image/png', dataURL: 'data:image/png;base64,aGVsbG8=' }
+    })
+
+    const result = await externalizeSceneAssets(sceneJson, CANVAS_ID, upload)
+
+    expect(upload).toHaveBeenCalledTimes(1)
+    expect(upload).toHaveBeenCalledWith({
+      canvasId: CANVAS_ID,
+      fileId: 'file-1',
+      mimeType: 'image/png',
+      data: expect.any(ArrayBuffer)
+    })
+    const [[{ data }]] = upload.mock.calls
+    expect(new TextDecoder().decode(data as ArrayBuffer)).toBe('hello')
+
+    const parsed = JSON.parse(result)
+    expect(parsed.files['file-1'].dataURL).toBe('memry-file://canvas-1/file-1')
+  })
+
+  it('leaves an already-externalized file untouched and does not upload', async () => {
+    const upload = vi.fn<AssetUploader>()
+    const sceneJson = scene({
+      'file-1': { mimeType: 'image/png', dataURL: 'memry-file://canvas-1/file-1' }
+    })
+
+    const result = await externalizeSceneAssets(sceneJson, CANVAS_ID, upload)
+
+    expect(upload).not.toHaveBeenCalled()
+    expect(result).toBe(sceneJson)
+  })
+
+  it('externalizes only the data: file in a mixed scene', async () => {
+    const upload = vi.fn<AssetUploader>().mockResolvedValue({ ref: 'memry-file://canvas-1/file-1' })
+    const sceneJson = scene({
+      'file-1': { mimeType: 'image/png', dataURL: 'data:image/png;base64,aGVsbG8=' },
+      'file-2': { mimeType: 'image/jpeg', dataURL: 'memry-file://canvas-1/file-2' }
+    })
+
+    const result = await externalizeSceneAssets(sceneJson, CANVAS_ID, upload)
+
+    expect(upload).toHaveBeenCalledTimes(1)
+    expect(upload).toHaveBeenCalledWith(
+      expect.objectContaining({ fileId: 'file-1', mimeType: 'image/png' })
+    )
+    const parsed = JSON.parse(result)
+    expect(parsed.files['file-1'].dataURL).toBe('memry-file://canvas-1/file-1')
+    expect(parsed.files['file-2'].dataURL).toBe('memry-file://canvas-1/file-2')
+  })
+
+  it('returns the input unchanged when there are no files', async () => {
+    const upload = vi.fn<AssetUploader>()
+    const sceneJson = scene({})
+
+    const result = await externalizeSceneAssets(sceneJson, CANVAS_ID, upload)
+
+    expect(upload).not.toHaveBeenCalled()
+    expect(result).toBe(sceneJson)
+
+    const noFilesJson = JSON.stringify({ elements: [], appState: {} })
+    const noFilesResult = await externalizeSceneAssets(noFilesJson, CANVAS_ID, upload)
+    expect(upload).not.toHaveBeenCalled()
+    expect(noFilesResult).toBe(noFilesJson)
+  })
+
+  it('keeps the failed file as data: URI but still externalizes the others', async () => {
+    const upload = vi
+      .fn<AssetUploader>()
+      .mockRejectedValueOnce(new Error('upload failed'))
+      .mockResolvedValueOnce({ ref: 'memry-file://canvas-1/file-2' })
+    const sceneJson = scene({
+      'file-1': { mimeType: 'image/png', dataURL: 'data:image/png;base64,aGVsbG8=' },
+      'file-2': { mimeType: 'image/png', dataURL: 'data:image/png;base64,d29ybGQ=' }
+    })
+
+    const resolved = await externalizeSceneAssets(sceneJson, CANVAS_ID, upload)
+
+    expect(upload).toHaveBeenCalledTimes(2)
+    const parsed = JSON.parse(resolved)
+    expect(parsed.files['file-1'].dataURL).toBe('data:image/png;base64,aGVsbG8=')
+    expect(parsed.files['file-2'].dataURL).toBe('memry-file://canvas-1/file-2')
+  })
+
+  it('falls back to parsing the mime type from the dataURL when mimeType is missing', async () => {
+    const upload = vi.fn<AssetUploader>().mockResolvedValue({ ref: 'memry-file://canvas-1/file-1' })
+    const sceneJson = scene({
+      'file-1': { dataURL: 'data:image/webp;base64,aGVsbG8=' }
+    })
+
+    await externalizeSceneAssets(sceneJson, CANVAS_ID, upload)
+
+    expect(upload).toHaveBeenCalledWith(expect.objectContaining({ mimeType: 'image/webp' }))
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-externalize.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-externalize.ts
@@ -1,0 +1,86 @@
+/**
+ * Externalizes inline base64 images out of a serialized Excalidraw scene.
+ *
+ * serializeAsJSON embeds every image as a base64 `data:` URI inside the
+ * scene's `files` map. That's fine for a single local vault, but ships raw
+ * image bytes through sync as JSON text (no dedup, no GC, R2/D1 bloat). This
+ * module rewrites each `data:` file to the `memry-file://` ref returned by
+ * `canvas:upload-asset` (main-process dedup/GC already exist — this is what
+ * finally calls them). Excalidraw-runtime-free (types only) so it
+ * unit-tests without the library.
+ */
+
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('SpatialCanvas')
+
+export interface AssetUploader {
+  (input: { canvasId: string; fileId: string; mimeType: string; data: ArrayBuffer }): Promise<{
+    ref: string
+  }>
+}
+
+interface ExcalidrawFileEntry {
+  mimeType?: string
+  dataURL?: string
+}
+
+interface SceneShape {
+  files?: Record<string, ExcalidrawFileEntry>
+}
+
+const DATA_URL_RE = /^data:([^;,]*)(?:;[^,]*)?,(.*)$/s
+
+/** Decodes a `data:<mime>;base64,<payload>` URI into raw bytes + parsed mime type. */
+function decodeDataUrl(dataURL: string): { mimeType: string | undefined; data: ArrayBuffer } {
+  const match = DATA_URL_RE.exec(dataURL)
+  const mimeType = match?.[1] || undefined
+  const base64 = match?.[2] ?? ''
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return { mimeType, data: bytes.buffer }
+}
+
+/**
+ * Externalize inline base64 images out of a serialized Excalidraw scene.
+ * For each files[fileId] whose dataURL is a `data:` URI, uploads the bytes via
+ * `upload` and rewrites dataURL to the returned memry-file:// ref.
+ * Already-externalized (memry-file://) files and non-`data:` entries are left
+ * as-is (idempotent — re-saving does not re-upload). A single failed upload
+ * keeps that file's data: URI (logged here) and does NOT abort the others
+ * (the pre-push size guard is the backstop). Returns the (re-stringified)
+ * scene; if nothing changed, returns the input unchanged.
+ */
+export async function externalizeSceneAssets(
+  sceneJson: string,
+  canvasId: string,
+  upload: AssetUploader
+): Promise<string> {
+  const scene = JSON.parse(sceneJson) as SceneShape
+  const files = scene.files
+  if (!files || typeof files !== 'object') {
+    return sceneJson
+  }
+
+  let changed = false
+  for (const [fileId, file] of Object.entries(files)) {
+    const dataURL = file?.dataURL
+    if (typeof dataURL !== 'string' || !dataURL.startsWith('data:')) {
+      continue
+    }
+    try {
+      const decoded = decodeDataUrl(dataURL)
+      const mimeType = file.mimeType ?? decoded.mimeType ?? 'application/octet-stream'
+      const { ref } = await upload({ canvasId, fileId, mimeType, data: decoded.data })
+      file.dataURL = ref
+      changed = true
+    } catch (err) {
+      log.error('Failed to externalize canvas asset; keeping inline data URI', { fileId, err })
+    }
+  }
+
+  return changed ? JSON.stringify(scene) : sceneJson
+}

--- a/apps/sync-server/src/__mocks__/blob-route-harness.ts
+++ b/apps/sync-server/src/__mocks__/blob-route-harness.ts
@@ -21,6 +21,12 @@ export interface MockDbState {
   /** Row for the dedupe lookup performed on chunk upload. */
   existingChunk?: Record<string, unknown> | null
   /**
+   * Per-hash chunk rows for the dereference route, which looks up each hash in
+   * a request independently (unlike the other single-row-at-a-time lookups
+   * above). Keyed by hash; a missing key means "no such chunk" (route skips it).
+   */
+  chunksByHash?: Record<string, Record<string, unknown> | null>
+  /**
    * Row for the entitlements lookup. Suites that mock ../services/entitlements
    * never reach this; the accounting suite drives the real plan limits and
    * supplies a row here.
@@ -40,6 +46,10 @@ const createStatement = (sql: string, state: MockDbState) => {
     first: vi.fn(async () => {
       if (sql.includes('FROM users u')) return state.entitlementRow?.() ?? null
       if (sql.includes('FROM upload_sessions')) return state.session ?? null
+      if (sql.includes('SELECT id, ref_count FROM blob_chunks')) {
+        const hash = stmt.bindings[2] as string | undefined
+        return (hash === undefined ? undefined : state.chunksByHash?.[hash]) ?? null
+      }
       if (sql.includes('FROM blob_chunks') && sql.includes('hash = ?')) {
         if (sql.includes('SELECT id, r2_key')) return state.existingChunk ?? null
         return state.chunk ?? null

--- a/apps/sync-server/src/routes/blob.test.ts
+++ b/apps/sync-server/src/routes/blob.test.ts
@@ -609,6 +609,44 @@ describe('blob routes', () => {
     )
   })
 
+  it('skips a hash that has no matching chunk instead of erroring (idempotent dereference)', async () => {
+    // The hash is not seeded in chunksByHash, so the route's lookup misses —
+    // dereferencing a hash already gone must not error.
+    state.chunksByHash = {}
+
+    const res = await app.request(
+      '/attachments/dereference',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chunkHashes: ['already-gone'] })
+      },
+      env
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ dereferenced: 0 })
+
+    const decrements = state.statements.filter((entry) =>
+      entry.sql.includes('UPDATE blob_chunks SET ref_count = ref_count - 1')
+    )
+    expect(decrements).toHaveLength(0)
+  })
+
+  it('rejects an empty chunkHashes array', async () => {
+    const res = await app.request(
+      '/attachments/dereference',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chunkHashes: [] })
+      },
+      env
+    )
+
+    expect(res.status).toBe(400)
+  })
+
   it('checks and downloads deduplicated chunks', async () => {
     let res = await app.request('/attachments/chunks/hash-0', { method: 'HEAD' }, env)
     expect(res.status).toBe(200)

--- a/apps/sync-server/src/routes/blob.test.ts
+++ b/apps/sync-server/src/routes/blob.test.ts
@@ -581,6 +581,34 @@ describe('blob routes', () => {
     ).toBe(true)
   })
 
+  it('dereferences chunks by decrementing ref_count per hash', async () => {
+    state.chunksByHash = {
+      h1: { id: 'chunk-h1', ref_count: 2 },
+      h2: { id: 'chunk-h2', ref_count: 1 }
+    }
+
+    const res = await app.request(
+      '/attachments/dereference',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chunkHashes: ['h1', 'h2'] })
+      },
+      env
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ dereferenced: 2 })
+
+    const decrements = state.statements.filter((entry) =>
+      entry.sql.includes('UPDATE blob_chunks SET ref_count = ref_count - 1')
+    )
+    expect(decrements).toHaveLength(2)
+    expect(decrements.map((entry) => entry.bindings)).toEqual(
+      expect.arrayContaining([['chunk-h1'], ['chunk-h2']])
+    )
+  })
+
   it('checks and downloads deduplicated chunks', async () => {
     let res = await app.request('/attachments/chunks/hash-0', { method: 'HEAD' }, env)
     expect(res.status).toBe(200)

--- a/apps/sync-server/src/routes/blob.ts
+++ b/apps/sync-server/src/routes/blob.ts
@@ -21,7 +21,7 @@ import {
   getUploadedByteTotal,
   parseUploadedChunks
 } from '../services/upload-size'
-import { UploadInitRequestSchema } from '@memry/contracts/blob-api'
+import { DereferenceRequestSchema, UploadInitRequestSchema } from '@memry/contracts/blob-api'
 import type { AppContext } from '../types'
 
 const logger = createLogger('BlobRoutes')
@@ -80,6 +80,12 @@ const chunkUploadLimit = createRateLimiter({
 
 const uploadSessionLimit = createRateLimiter({
   keyPrefix: 'upload_session',
+  maxRequests: 20,
+  windowSeconds: 60
+})
+
+const dereferenceLimit = createRateLimiter({
+  keyPrefix: 'dereference',
   maxRequests: 20,
   windowSeconds: 60
 })
@@ -516,6 +522,41 @@ blob.delete('/attachments/upload/:session_id', uploadSessionLimit, async (c) => 
   }
 
   return new Response(null, { status: 204 })
+})
+
+// Decrements ref_count for each hash by 1. Decrement-only, on purpose: unlike
+// the cancel-session path above, this never eager-deletes R2 — the
+// `cleanupOrphanedBlobChunks` cron reaps rows once ref_count <= 0.
+blob.post('/attachments/dereference', dereferenceLimit, async (c) => {
+  const userId = c.get('userId')!
+  const vaultId = c.get('vaultId')!
+
+  const body: unknown = await c.req.json()
+  const parsed = DereferenceRequestSchema.safeParse(body)
+  if (!parsed.success) {
+    throw new AppError(
+      ErrorCodes.VALIDATION_ERROR,
+      `Invalid dereference: ${parsed.error.issues[0]?.message ?? 'validation failed'}`,
+      400
+    )
+  }
+
+  let dereferenced = 0
+  for (const hash of new Set(parsed.data.chunkHashes)) {
+    const chunk = await c.env.DB.prepare(
+      'SELECT id, ref_count FROM blob_chunks WHERE user_id = ? AND vault_id = ? AND hash = ?'
+    )
+      .bind(userId, vaultId, hash)
+      .first<{ id: string; ref_count: number }>()
+    if (!chunk) continue
+
+    await c.env.DB.prepare('UPDATE blob_chunks SET ref_count = ref_count - 1 WHERE id = ?')
+      .bind(chunk.id)
+      .run()
+    dereferenced++
+  }
+
+  return c.json({ dereferenced }, 200)
 })
 
 // ============================================================================

--- a/docs/superpowers/plans/2026-07-20-spatial-canvas-m5-assets.md
+++ b/docs/superpowers/plans/2026-07-20-spatial-canvas-m5-assets.md
@@ -1,0 +1,399 @@
+# Spatial Canvas M5 — Asset Externalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Also invoke `ipc-contract-change` for Task 3 (renderer↔main asset channels) and `superpowers:test-driven-development` for every logic task.
+
+**Goal:** Externalize Excalidraw inline-base64 images out of the encrypted canvas scene JSON into `memry-file://` + R2 via the existing attachment pipeline, with a server dereference/GC endpoint, on-disk content-hash dedup, an N-asset reference set, and a refined size guard — additive, backward-compatible, flag default-OFF.
+
+**Architecture:** Reuse the attachment/blob spine (`AttachmentSyncService` → `UploadQueue` → `attachmentEvents` → R2 chunks; `protocol.handle('memry-file')` for reads). New binary IPC channels `canvas:upload-asset|get-asset|list-assets`. A vault-level content-addressed on-disk store (`{vault}/attachments/canvas-assets/<contentHash>.<ext>`) gives a stable `memry-file://` ref + cheap dedup. A new `canvas_assets` table (migration 0036) is the per-device dedup index + GC bookkeeping; a `memryAssets` sidecar embedded in the synced scene JSON carries per-image `{attachmentId, contentHash, chunkHashes,…}` cross-device. A new sync-server endpoint `POST /sync/attachments/dereference {chunkHashes[]}` decrements `blob_chunks.ref_count` (client-supplied hashes — the server cannot map `attachmentId`→hashes); the existing cron `cleanupOrphanedBlobChunks` reaps at `ref_count<=0`.
+
+**Tech Stack:** TypeScript, Electron (main/preload/renderer), better-sqlite3 + Drizzle (data DB), libsodium (existing crypto — unchanged), Excalidraw 0.18.1, Hono + D1 + R2 (sync-server), Zod v4, Vitest, Playwright.
+
+## Global Constraints
+
+- **LIVE PRODUCTION BETA — backward compatibility MANDATORY.** No DB reset. Existing installs (incl. pre-M5 canvases with INLINE base64 scenes) must open, render, and sync with zero data loss. Externalization is additive; a pre-M5 canvas externalizes only on its next save.
+- **Flag `spatialCanvas` stays default-OFF and hidden.** Do NOT touch its default, do NOT promote to `FEATURE_KEYS`. (`packages/contracts/src/settings-schemas.ts`.)
+- **Do NOT change crypto primitives.** Option B = on-disk content-hash dedup only; keep the existing RANDOM per-image fileKey/attachmentId (server can never confirm a known image is present). NO convergent encryption.
+- **Do NOT add a new `SyncItemType`.** Asset descriptors ride inside the existing `canvas` scene blob (`memryAssets` sidecar). Asset bytes ride the existing attachment chunk pipeline.
+- **Deploy order (non-negotiable):** sync-server FIRST (dereference endpoint + telemetry enum additions), staging → verify → prod, THEN desktop. The dereference endpoint is a NEW route; a desktop that calls it before the server ships gets a 404 and must degrade gracefully (log + telemetry, never crash a save).
+- **Never hand-concat `memry-file://`** (Windows drive-letter → 403). Always `toMemryFileUrl` (main) / `memryFileUrl` (renderer).
+- **`markWritebackIgnored(diskPath)` BEFORE restoring a downloaded asset** or you get a re-upload loop.
+- **Sync runs in a bundled worker** → worker-imported modules stay electron-free (`createLogger` from `@main/lib/logger` is fine; no `electron` import in shared logic). User-facing errors: `extractErrorMessage` (renderer only) / `main/lib/errors.ts` (main).
+- **jsdom cannot test canvas geometry** → unit-test logic (externalize/dedup/ref-set/GC diff/sidecar/crypto round-trip/migration); push real image interaction to E2E.
+- **Tailwind logical-props** for any new renderer UI (`ms/me`, `ps/pe`, `start/end`, …).
+- **IPC regen order:** edit contracts → rpc → register main handlers → `pnpm ipc:generate` → `pnpm ipc:check`. Every new rpc method needs a live main handler or generated-rpc fails typecheck. Commit both generated files.
+- **Migration:** hand-written SQL (Drizzle snapshots broken past 0021 — do NOT `db:generate`); additive `IF NOT EXISTS` only; append a `_journal.json` entry with a fresh `when` > `0035`'s; no `meta/0036_snapshot.json`; freeze once any build ships it.
+
+---
+
+## File Structure
+
+**sync-server (Task 1 — ships first):**
+
+- Modify `packages/contracts/src/blob-api.ts` — add `DereferenceRequestSchema`.
+- Modify `apps/sync-server/src/routes/blob.ts` — add `POST /attachments/dereference` + a rate limiter; mirror the DELETE-session decrement loop.
+- Modify `apps/sync-server/src/routes/blob.test.ts` + `src/__mocks__/blob-route-harness.ts` — teach the fake D1 the dereference lookup; assert per-hash decrement.
+- Modify `packages/contracts/src/telemetry-api.ts` — add asset event-name literals (Task 8).
+
+**Contracts + RPC (Task 2–3):**
+
+- Modify `packages/contracts/src/ipc-channels.ts` — `CanvasChannels.invoke` += `UPLOAD_ASSET|GET_ASSET|LIST_ASSETS`.
+- Modify `packages/contracts/src/canvas-api.ts` — asset request schemas + response types + `MemryAssetDescriptor`.
+- Modify `packages/rpc/src/canvas.ts` — asset method bindings (`uploadAsset` via `implementation` escape hatch).
+- Regenerate `apps/desktop/src/preload/generated-rpc.ts` + `apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts` (committed).
+
+**DB (Task 4):**
+
+- Modify `packages/db-schema/src/schema/canvas.ts` — add `canvasAssets` table (auto-exported via `data-schema.ts` `export * from './schema/canvas.ts'` — verify).
+- Create `apps/desktop/src/main/database/drizzle-data/0036_canvas_assets.sql` + append `meta/_journal.json`.
+
+**Desktop asset logic (Task 5–6, pure + effectful split):**
+
+- Create `apps/desktop/src/main/canvas/assets/content-hash.ts` — `hashAssetContent`, `assetFilename`, `extForMime`.
+- Create `apps/desktop/src/main/canvas/assets/memry-assets.ts` — sidecar (de)serialize; ref extraction from scene.
+- Create `apps/desktop/src/main/canvas/assets/dedup-plan.ts` — pure dedup/GC-diff logic.
+- Create `apps/desktop/src/main/canvas/assets/asset-store.ts` — `canvas_assets` Drizzle CRUD.
+- Create `apps/desktop/src/main/canvas/assets/asset-service.ts` — effectful orchestrator (disk write, upload enqueue, download restore, reconcile/GC) wiring the attachment spine.
+- Create `apps/desktop/src/main/sync/attachment-dereference.ts` — `dereferenceChunks(chunkHashes[])` → POST; graceful 404.
+- Modify `apps/desktop/src/main/ipc/canvas-handlers.ts` — register/teardown 3 asset handlers; call reconcile in UPDATE/DELETE.
+- Modify `apps/desktop/src/main/canvas/store.ts` — `deleteCanvas` returns asset rows for GC; scene get/persist tolerate the sidecar.
+- Modify the canvas sync apply handler (`apps/desktop/src/main/sync/item-handlers/canvas-handler.ts`) — on `applyUpsert`, ingest `memryAssets` (record rows + ensure-present download); conflict-copy duplicates rows; on `applyDelete`, GC.
+
+**Size guard (Task 7):**
+
+- Modify `apps/desktop/src/main/canvas/sync-bridge.ts` — refine `canvasSceneExceedsSyncCap` to measure compressed bytes; keep the single guard + toast + `canvas_too_large`.
+
+**Renderer (Task 5 client half):**
+
+- Modify `apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx` + `canvas-persistence.ts` + `services/canvas-service.ts` — on save, upload new `data:` files via `canvas:upload-asset`, rewrite `files[fileId].dataURL` to the returned ref before `canvas:update`.
+
+**Telemetry (Task 8):**
+
+- Modify `packages/contracts/src/telemetry-api.ts` (shared; server validates → ships in Task 1's deploy).
+- Emit via `trackMainEvent` in asset-service / sync-bridge.
+
+---
+
+## Interfaces (defined once, referenced by all tasks)
+
+```ts
+// packages/contracts/src/canvas-api.ts  (Task 2)
+export interface MemryAssetDescriptor {
+  fileId: string // Excalidraw file id (per scene)
+  attachmentId: string // random id from AttachmentSyncService.uploadAttachment
+  contentHash: string // plaintext sha256 hex (dedup key)
+  chunkHashes: string[] // encryptedHash[] from UploadResult.manifest.chunks — for dereference
+  mimeType: string
+  sizeBytes: number
+  filename: string // content-addressed on-disk filename
+}
+export const CanvasUploadAssetSchema = z.object({
+  canvasId: z.string().min(1),
+  fileId: z.string().min(1),
+  mimeType: z.string().min(1),
+  data: z.instanceof(ArrayBuffer).or(z.array(z.number())) // notes.uploadAttachment precedent
+})
+export interface CanvasUploadAssetResponse {
+  ref: string
+  descriptor: MemryAssetDescriptor
+  deduped: boolean
+}
+export const CanvasGetAssetSchema = z.object({
+  canvasId: z.string().min(1),
+  fileId: z.string().min(1)
+})
+export interface CanvasGetAssetResponse {
+  ref: string | null
+}
+export const CanvasListAssetsSchema = z.object({ canvasId: z.string().min(1) })
+export interface CanvasListAssetsResponse {
+  assets: MemryAssetDescriptor[]
+}
+```
+
+```ts
+// asset-store.ts row (Task 5)
+export interface CanvasAssetRow {
+  vaultId: string
+  canvasId: string
+  contentHash: string
+  attachmentId: string
+  fileId: string
+  filename: string
+  mimeType: string
+  sizeBytes: number
+  chunkHashes: string[]
+  createdAt: number
+}
+```
+
+```ts
+// dedup-plan.ts pure API (Task 6)  — no I/O, fully unit-testable
+export function planDereference(
+  prevRows: CanvasAssetRow[], // canvas_assets WHERE canvasId = current
+  currentContentHashes: Set<string>, // parsed from the just-saved scene refs
+  otherCanvasHashes: Set<string> // canvas_assets WHERE canvasId != current (the GC union)
+): { removedContentHashes: string[]; dereferenceChunkHashes: string[] }
+```
+
+```ts
+// attachment-dereference.ts (Task 5)
+export async function dereferenceChunks(
+  chunkHashes: string[],
+  deps: {
+    getAccessToken(): Promise<string | null>
+    getSyncServerUrl(): string
+    getVaultId(): string
+  }
+): Promise<{ ok: boolean; status: number }> // graceful on 404 (server not yet deployed)
+```
+
+---
+
+## Task 1: Sync-server dereference endpoint (ships first)
+
+**Files:**
+
+- Modify: `packages/contracts/src/blob-api.ts`
+- Modify: `apps/sync-server/src/routes/blob.ts:57-85` (limiters), add route after `DELETE /attachments/upload/:session_id` (`:519`)
+- Test: `apps/sync-server/src/routes/blob.test.ts`, `apps/sync-server/src/__mocks__/blob-route-harness.ts`
+
+**Interfaces — Produces:** `POST /sync/attachments/dereference`, body `{ chunkHashes: string[] }`, decrements `blob_chunks.ref_count` by 1 per `(user_id, vault_id, hash)`; returns `{ dereferenced: number }`.
+
+- [ ] **Step 1: Failing test — per-hash decrement.** In `blob.test.ts`, seed the fake D1 with two `blob_chunks` rows (`hash:'h1' ref_count:2`, `hash:'h2' ref_count:1`) for `user-1/vault-1`; `app.request('/attachments/dereference', {method:'POST', body: JSON.stringify({chunkHashes:['h1','h2']})}, env)`; assert 200, and via `findBinding(state, 'UPDATE blob_chunks SET ref_count = ref_count - 1')` that both hashes were decremented (h1→1, h2→0). Teach `blob-route-harness.ts` `createDb().first()` a branch matching `SELECT ... FROM blob_chunks WHERE user_id = ? AND vault_id = ? AND hash = ?` returning the seeded row.
+- [ ] **Step 2: Run — FAIL** (`route not found`). `pnpm --filter @memry/sync-server test -- blob`.
+- [ ] **Step 3: Contract schema.** In `blob-api.ts`:
+  ```ts
+  export const DereferenceRequestSchema = z.object({
+    chunkHashes: z.array(z.string().min(1)).min(1).max(4096)
+  })
+  ```
+- [ ] **Step 4: Route (mirror the cancel-session decrement, `blob.ts:483-500`).** Add a limiter like the existing ones, then:
+  ```ts
+  blob.post('/attachments/dereference', dereferenceLimit, async (c) => {
+    const userId = c.get('userId')!
+    const vaultId = c.get('vaultId')!
+    const body: unknown = await c.req.json()
+    const parsed = DereferenceRequestSchema.safeParse(body)
+    if (!parsed.success) {
+      throw new AppError(
+        ErrorCodes.VALIDATION_ERROR,
+        `Invalid dereference: ${parsed.error.issues[0]?.message ?? 'validation failed'}`,
+        400
+      )
+    }
+    let dereferenced = 0
+    for (const hash of new Set(parsed.data.chunkHashes)) {
+      const chunk = await c.env.DB.prepare(
+        'SELECT id, ref_count FROM blob_chunks WHERE user_id = ? AND vault_id = ? AND hash = ?'
+      )
+        .bind(userId, vaultId, hash)
+        .first<{ id: string; ref_count: number }>()
+      if (!chunk) continue
+      await c.env.DB.prepare('UPDATE blob_chunks SET ref_count = ref_count - 1 WHERE id = ?')
+        .bind(chunk.id)
+        .run() // let cleanupOrphanedBlobChunks reap at ref_count<=0
+      dereferenced++
+    }
+    return c.json({ dereferenced }, 200)
+  })
+  ```
+  Do NOT eager-delete R2 here (unlike the session path) — the cron reap keeps this endpoint idempotent-ish and cheap. Decrement-only; never below the row's natural floor is fine (a stray double-call just makes cron reap it — acceptable and matches the session semantics; a hardening `ref_count = MAX(ref_count - 1, 0)` may be added if D1 supports it, else leave as-is to mirror the session loop).
+- [ ] **Step 5: Run — PASS.** `pnpm --filter @memry/sync-server test -- blob`.
+- [ ] **Step 6: Commit** `feat(sync-server): POST /attachments/dereference to decrement blob_chunks ref_count`.
+
+**Verify (server suite):** `pnpm test:sync-server` green (90% coverage thresholds).
+
+---
+
+## Task 2: Contracts — asset channels + schemas
+
+**Files:** Modify `packages/contracts/src/ipc-channels.ts:652-669`, `packages/contracts/src/canvas-api.ts`.
+
+- [ ] **Step 1:** `CanvasChannels.invoke` += `UPLOAD_ASSET: 'canvas:upload-asset'`, `GET_ASSET: 'canvas:get-asset'`, `LIST_ASSETS: 'canvas:list-assets'` (keys SCREAMING_SNAKE_CASE, values `canvas:`-prefixed — `ipc-channels.test.ts` guards pass automatically since `CanvasChannels` is already in `ALL_GROUPS`).
+- [ ] **Step 2:** Add the `MemryAssetDescriptor` + request schemas + response types from **Interfaces** above to `canvas-api.ts`. (No `package.json` exports change — `./canvas-api` subpath already registered from M0.)
+- [ ] **Step 3:** `pnpm --filter @memry/contracts test` (channel guard) green.
+- [ ] **Step 4: Commit.**
+
+---
+
+## Task 3: RPC bindings + regen (invoke `ipc-contract-change`)
+
+**Files:** Modify `packages/rpc/src/canvas.ts:39-70`; regen writes `preload/generated-rpc.ts` + `main/ipc/generated-ipc-invoke-map.ts`.
+
+**Interfaces — Consumes** Task 2 schemas; **Produces** `window.api.canvas.uploadAsset/getAsset/listAssets`.
+
+- [ ] **Step 1:** Add three `defineMethod`s inside `methods:`. `getAsset`/`listAssets` are plain:
+  ```ts
+  getAsset: defineMethod<(canvasId: string, fileId: string) => Promise<CanvasGetAssetResponse>>({
+    channel: CanvasChannels.invoke.GET_ASSET, params: ['canvasId', 'fileId']
+  }),
+  listAssets: defineMethod<(canvasId: string) => Promise<CanvasListAssetsResponse>>({
+    channel: CanvasChannels.invoke.LIST_ASSETS, params: ['canvasId']
+  }),
+  ```
+  `uploadAsset` uses the binary `implementation` escape-hatch (notes.ts:501-512 precedent — take a `Blob`/`ArrayBuffer`):
+  ```ts
+  uploadAsset: defineMethod<(input: { canvasId: string; fileId: string; mimeType: string; data: ArrayBuffer }) => Promise<CanvasUploadAssetResponse>>({
+    channel: CanvasChannels.invoke.UPLOAD_ASSET, params: ['input'],
+    implementation: `async (input) =>
+      invoke(${JSON.stringify(CanvasChannels.invoke.UPLOAD_ASSET)}, {
+        canvasId: input.canvasId, fileId: input.fileId, mimeType: input.mimeType,
+        data: Array.from(new Uint8Array(input.data))
+      })`
+  }),
+  ```
+  Add the response types to the imports (relative `../../contracts/src/canvas-api.ts` — generator runs under strip-types; A8).
+- [ ] **Step 2:** Register the app-side upload schema. The binary schema is app-side, not contracts (A3): add to `apps/desktop/src/main/ipc/canvas-handlers.ts` a local `UploadCanvasAssetSchema = z.object({ canvasId, fileId, mimeType, data: z.instanceof(ArrayBuffer).or(z.array(z.number())) })`.
+- [ ] **Step 3:** Register the three `ipcMain.handle` handlers (Task 5 provides bodies) so the invoke-map generator sees them. **Handlers must exist before regen or `ipc:check` fails.** Implement stub handlers first (throw `not implemented`) to unblock regen, fill in Task 5.
+- [ ] **Step 4:** `pnpm ipc:generate` then `pnpm ipc:check`. Commit BOTH generated files.
+- [ ] **Step 5: Commit** `feat(canvas): asset IPC channels + rpc bindings (M5)`.
+
+---
+
+## Task 4: `canvas_assets` table + migration 0036
+
+**Files:** Modify `packages/db-schema/src/schema/canvas.ts`; create `apps/desktop/src/main/database/drizzle-data/0036_canvas_assets.sql`; append `meta/_journal.json`.
+
+- [ ] **Step 1:** Add to `canvas.ts` (mirror `canvases`/`canvasEntityRefs` style):
+  ```ts
+  export const canvasAssets = sqliteTable(
+    'canvas_assets',
+    {
+      vaultId: text('vault_id').notNull(),
+      canvasId: text('canvas_id').notNull(),
+      contentHash: text('content_hash').notNull(),
+      attachmentId: text('attachment_id').notNull(),
+      fileId: text('file_id').notNull(),
+      filename: text('filename').notNull(),
+      mimeType: text('mime_type').notNull(),
+      sizeBytes: integer('size_bytes').notNull(),
+      chunkHashes: text('chunk_hashes', { mode: 'json' }).$type<string[]>().notNull(),
+      createdAt: integer('created_at').notNull()
+    },
+    (t) => [
+      primaryKey({ columns: [t.canvasId, t.contentHash] }),
+      index('idx_canvas_assets_dedup').on(t.vaultId, t.contentHash),
+      index('idx_canvas_assets_attachment').on(t.attachmentId),
+      foreignKey({ columns: [t.canvasId], foreignColumns: [canvases.id] }).onDelete('cascade')
+    ]
+  )
+  ```
+  Note: FK cascade cleans rows on hard-delete, but canvas delete is SOFT (tombstone) — Task 5 GC prunes rows explicitly in the delete path; the FK is a safety net only.
+- [ ] **Step 2:** Failing test `packages/db-schema` or `apps/desktop` migration test (real better-sqlite3 `:memory:`, load migration SQL, `PRAGMA table_info(canvas_assets)` asserts columns; `PRAGMA foreign_key_list` shows CASCADE; duplicate `(canvasId, contentHash)` insert throws; both indexes exist). Model on `schema/d1.test.ts` style + the M0 A5 upgrade-path test.
+- [ ] **Step 3:** Write `0036_canvas_assets.sql` (hand-written comment; `CREATE TABLE IF NOT EXISTS canvas_assets (...)` → `--> statement-breakpoint` → two `CREATE INDEX IF NOT EXISTS`). Additive only.
+- [ ] **Step 4:** Append `_journal.json`: `{"idx":36,"version":"6","when":<epoch_ms > 0034/0035's>,"tag":"0036_canvas_assets","breakpoints":true}`. Confirm `_journal.json` current max idx is 35 before writing. Do NOT create `meta/0036_snapshot.json`. Re-mint `when` if any in-flight branch claims 0036 first (A5 — stale `when` silently skips on updated installs).
+- [ ] **Step 5:** Run migration test — PASS. Verify `canvasAssets` reachable from `@memry/db-schema` barrel (`data-schema.ts` `export *`).
+- [ ] **Step 6: Commit** `feat(canvas): canvas_assets table + migration 0036 (M5 dedup/GC index)`.
+
+---
+
+## Task 5: Asset service — externalize, dedup, upload, restore, GC (effectful)
+
+**Files:** Create `content-hash.ts`, `memry-assets.ts`, `asset-store.ts`, `asset-service.ts`, `sync/attachment-dereference.ts`; wire `canvas-handlers.ts`.
+
+**Interfaces — Consumes:** `AttachmentSyncService.uploadAttachment/downloadAttachment` + `UploadQueue` (bound via the same lazy-singleton wiring as `sync-attachment-handlers.ts:86-132`), `attachmentEvents`, `markWritebackIgnored`, `toMemryFileUrl`, `getVault…Dir`. **Produces:** the three IPC handler bodies + `reconcileCanvasAssets(canvasId, scene)`.
+
+### 5a — content-hash + sidecar (pure, electron-free)
+
+- [ ] `content-hash.ts`: `hashAssetContent(bytes: Uint8Array): string` = `sodium.to_hex(sodium.crypto_hash_sha256(bytes))` (reuse `sha256Hex` pattern from attachments.ts; sha256 is collision-safe for content addressing). `extForMime(mime): string` (`image/png`→`png`, jpeg→`jpg`, gif, webp, svg+xml→`svg`; default `bin`). `assetFilename(contentHash, mime) = \`${contentHash}.${extForMime(mime)}\``. **Tests:** deterministic hash for same bytes; different bytes → different hash; ext mapping.
+- [ ] `memry-assets.ts`:
+  - `extractSceneFileRefs(sceneJson: string): { fileId: string; ref: string }[]` — parse `files`, return entries whose `dataURL` is a `memry-file://` ref (skip `data:` ones).
+  - `contentHashFromRef(ref: string): string | null` — parse the content-addressed filename out of a `memry-file://…/canvas-assets/<hash>.<ext>` ref (via `fromMemryFileUrl` + basename).
+  - `readMemryAssets(sceneJson): MemryAssetDescriptor[]` — top-level `memryAssets` key (`[]` if absent → backward compat with pre-M5/base64 scenes).
+  - `writeMemryAssets(sceneJson, descriptors): string` — parse → set `memryAssets` → stringify (deterministic key order not required).
+  - **Tests:** round-trip write→read; a pre-M5 scene (no key, base64 files) → `readMemryAssets` = `[]` and `extractSceneFileRefs` = `[]` (proves backward compat); ref→contentHash parse incl. a Windows-style path.
+
+### 5b — asset-store (Drizzle CRUD)
+
+- [ ] `asset-store.ts`: `findByContentHash(db, vaultId, contentHash): CanvasAssetRow | undefined`; `recordAsset(db, row)` (upsert on `(canvasId, contentHash)`, `null`-coalesce per Drizzle gotcha); `listByCanvas(db, canvasId)`; `hashesReferencedByOtherCanvases(db, vaultId, canvasId): Set<string>` (the GC union — `SELECT DISTINCT content_hash … WHERE vault_id=? AND canvas_id != ?`); `deleteCanvasAssetRows(db, canvasId, contentHashes[])`. **Tests:** in-memory DB — dedup lookup hits across canvases; union excludes the current canvas; delete removes only the named rows.
+
+### 5c — dereference client
+
+- [ ] `sync/attachment-dereference.ts`: `dereferenceChunks(chunkHashes, deps)` POSTs `/sync/attachments/dereference` with `Authorization` + `X-Memry-Vault-Id`. **On 404 (server not yet deployed) or network error: log `warn`, return `{ok:false}` — NEVER throw into a canvas save.** **Test:** 200 path calls fetch with the hashes; 404 returns `{ok:false}` without throwing (mirror the `http-client` test style; lazy URL resolution per the known gotcha).
+
+### 5d — asset-service (orchestrator)
+
+- [ ] `uploadCanvasAsset(canvasId, fileId, mimeType, bytes)`:
+  1. `contentHash = hashAssetContent(bytes)`.
+  2. Dedup: `existing = findByContentHash(db, vaultId, contentHash)`. If found → write the file to disk **only if missing** (idempotent), `recordAsset` a row for THIS canvasId reusing `existing.attachmentId/filename/chunkHashes`, emit `canvas_asset_dedup_hit`, return `{ ref: toMemryFileUrl(diskPath), descriptor, deduped:true }`. **No upload.**
+  3. New: `diskPath = {vault}/attachments/canvas-assets/<assetFilename>`; `mkdir -p`; `markWritebackIgnored(diskPath)`; `atomicWriteBinary(diskPath, bytes)`. `uploadAttachment(canvasId, diskPath)` via the queue → `UploadResult` (attachmentId, manifest.chunks). `chunkHashes = manifest.chunks.map(c => c.encryptedHash)`. `recordAsset(...)`. Emit `canvas_asset_uploaded` (`metrics.byteCount`). Return `{ ref, descriptor, deduped:false }`.
+  - Reuse the `getOrCreateAttachmentService`/`uploadQueue` singletons from `sync-attachment-handlers.ts` (export them or replicate the wiring; prefer exporting a shared accessor to avoid two queues).
+- [ ] `ensureAssetsPresent(canvasId, descriptors)` (device B restore): for each descriptor whose `diskPath` is missing → `markWritebackIgnored(diskPath)` FIRST → `downloadAttachment(attachmentId, diskPath)` → `recordAsset` locally. Missing-file protocol handler already returns a transparent PNG until this completes.
+- [ ] `reconcileCanvasAssets(canvasId, sceneJson)` (GC on save/delete): `current = new Set(extractSceneFileRefs(scene).map(r => contentHashFromRef(r.ref)))`; `prev = listByCanvas(db, canvasId)`; `others = hashesReferencedByOtherCanvases(db, vaultId, canvasId)`; `{removedContentHashes, dereferenceChunkHashes} = planDereference(prev, current, others)` (Task 6). `deleteCanvasAssetRows(db, canvasId, removedContentHashes)`; if `dereferenceChunkHashes.length` → `dereferenceChunks(...)` (fire-and-forget, graceful) + emit `canvas_asset_gc_reaped` (`metrics.itemCount`). Optionally unlink the disk file only when the hash is in NO canvas (i.e. also not in `others`) — safe because GC ran the union.
+
+### 5e — IPC handlers
+
+- [ ] Fill the Task 3 stubs in `canvas-handlers.ts`: `UPLOAD_ASSET` → `Buffer.from(new Uint8Array(input.data))` → `uploadCanvasAsset`; `GET_ASSET`/`LIST_ASSETS` → `asset-store` reads. Teardown in `unregisterCanvasHandlers`.
+- [ ] In the `UPDATE` handler (after `updateCanvas`, before/after sync): inject the `memryAssets` sidecar into the stored scene (`writeMemryAssets` from `listByCanvas`) so the SYNCED payload carries descriptors, then `reconcileCanvasAssets`. In the `DELETE` handler: `reconcileCanvasAssets(canvasId, '')` (empty scene → all hashes removed → GC union protects shared ones) then soft-delete.
+  - **Architecture guard (A4):** `canvas-handlers.ts` must not import `@main/database/queries/*` or `main/sync/**` directly. Put all Drizzle + attachment wiring in `main/canvas/assets/*` (store precedent); the handler imports only `main/canvas/*` + contracts + `./validate`. Run `pnpm check:architecture`.
+
+- [ ] **Commit** `feat(canvas): externalize/dedup/restore/GC asset service + IPC handlers (M5)`.
+
+---
+
+## Task 6: Pure dedup/ref-set/GC-diff logic (TDD-first)
+
+**Files:** Create `apps/desktop/src/main/canvas/assets/dedup-plan.ts` + `dedup-plan.test.ts`.
+
+- [ ] **Step 1: Failing tests** for `planDereference(prevRows, currentContentHashes, otherCanvasHashes)`:
+  - image removed from scene AND not referenced elsewhere → its chunkHashes returned for dereference; its contentHash in `removedContentHashes`.
+  - image removed from scene BUT still in `otherCanvasHashes` (conflict-copy / shared) → NOT dereferenced; still removed from THIS canvas's rows.
+  - image still present → no dereference.
+  - unchanged scene → empty plan.
+- [ ] **Step 2: FAIL.** **Step 3:** implement (set difference: `removed = prev.filter(r => !current.has(r.contentHash))`; `dereferenceChunkHashes = removed.filter(r => !other.has(r.contentHash)).flatMap(r => r.chunkHashes)`). **Step 4: PASS.** **Step 5: Commit.**
+
+---
+
+## Task 7: Size-guard refinement (do NOT duplicate)
+
+**Files:** Modify `apps/desktop/src/main/canvas/sync-bridge.ts:34`.
+
+- [ ] Keep the single guard. Once images externalize, the scene rarely trips it; verify it still fires for huge freehand-ink scenes. Refine `canvasSceneExceedsSyncCap` to measure the **compressed** payload (spec §5.6) IF `compressPayload` is importable electron-free here; else keep raw-byte measurement with a note. Test: a >3MB freehand scene (no images) still returns `true` → toast + `canvas_too_large` telemetry (assert `trackMainEvent` called), NOT a silent `markFailed`. Do not add a second cap.
+- [ ] **Commit.**
+
+---
+
+## Task 8: Telemetry enum (ships with Task 1's server deploy)
+
+**Files:** Modify `packages/contracts/src/telemetry-api.ts:3-51`.
+
+- [ ] Add literals to `TelemetryEventNameSchema`: `'canvas_asset_uploaded'`, `'canvas_asset_dedup_hit'`, `'canvas_asset_gc_reaped'`. Use `surface:'sync'`, `action` ∈ safe tokens (`'asset_upload'`/`'asset_dedup'`/`'asset_gc'`), `objectType:'canvas'`, only `metrics` (byteCount/itemCount) — **never** put `attachmentId`/`contentHash` in a dimension (`SafeDimensionValueSchema`: no slash, not UUID-shaped, ≤64). **These are validated server-side → they must be in the sync-server build that deploys FIRST.**
+- [ ] `pnpm --filter @memry/contracts test` + `pnpm --filter @memry/sync-server test` green. **Commit** (fold into Task 1's PR-of-record ordering).
+
+---
+
+## Task 9: Sync apply integration (device B) + conflict-copy
+
+**Files:** Modify `apps/desktop/src/main/sync/item-handlers/canvas-handler.ts`.
+
+- [ ] `applyUpsert`: after writing the row, `readMemryAssets(scene)` → `recordAsset` each locally (device B now has the dedup index) → `ensureAssetsPresent(canvasId, descriptors)` (download, `markWritebackIgnored` first). The **conflict-copy** INSERT (M4 `resolution.action==='merge'`) copies the same scene → its `memryAssets` → `recordAsset` under the NEW canvasId (shared attachmentIds) so the GC union protects them. Keep it inside the same `ctx.db.transaction`; download is fire-and-forget after commit (not inside the tx).
+- [ ] `applyDelete` (soft tombstone): `reconcileCanvasAssets(canvasId, '')` — GC union prevents reaping assets a live conflict-copy still holds.
+- [ ] **Tests (main-integration, node):** (1) applyUpsert of a scene with 2 memryAssets records 2 rows + triggers 2 downloads (mock the service); (2) a conflict-copy apply leaves the shared assets referenced by BOTH canvasIds → planDereference over either returns empty; (3) a pre-M5 base64 scene (no memryAssets) applies with zero asset rows + zero downloads (backward compat).
+- [ ] **Commit.**
+
+---
+
+## Verification (exit criteria — all green)
+
+- [ ] `pnpm typecheck && pnpm lint && pnpm ipc:check && pnpm i18n:check && pnpm check:architecture && pnpm check:contracts` (run `pnpm ipc:generate` before `ipc:check`).
+- [ ] `pnpm test:sync-server` (dereference route + coverage 90%).
+- [ ] `pnpm test:desktop` (content-hash, sidecar, asset-store, dedup-plan, dereference-client, sync-apply integration) + coverage ratchet green (keep glue thin so it doesn't drag the ratchet).
+- [ ] `git diff --check`.
+- [ ] E2E (`SYNC_SERVER_URL=https://sync-staging.memrynote.com`, build first): paste image on A → renders; syncs to B → renders via `memry-file://` restore; delete image then delete canvas on A → server `ref_count` decrements → orphan reaped by `cleanupOrphanedBlobChunks`; paste same image twice → one R2 object / stable ref (no second upload); oversized freehand canvas → toast + telemetry; pre-M5 inline-base64 canvas opens + externalizes on next save; conflict-copy asset test → GC does not reap shared assets.
+- [ ] `pnpm docs:ai-update --base origin/main` (or manual `apps/docs/src`) → `pnpm docs:impact --base origin/main --strict` + `pnpm docs:build`.
+- [ ] Manual 2-device asset smoke.
+
+## Deploy (mandatory order — the one step NOT done autonomously)
+
+1. Merge/deploy **sync-server** (dereference endpoint + telemetry enum) via GitHub Actions → **staging** → verify `POST /sync/attachments/dereference` + `cleanupOrphanedBlobChunks` reap → **prod**.
+2. THEN release **desktop**. Confirm M4 sync-server is already live in prod before shipping M5 (entry gate).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §6 gap1 (GC) → Task 1+5d+6+9; gap2 (dedup) → Task 5d(2)+6; gap3/R12 (N-asset set) → Task 4+5b+9. §5.6/R4 size guard → Task 7. §13 M5 exit criteria → Verification. §18 A3 (channels deferred to M5) → Task 2/3. §17 Q3 dedup=Option B → honored (random keys, on-disk hash). Appendix asset anchors → all re-verified.
+- **Backward compat:** pre-M5 base64 scene tested at 5a, 9 (zero asset rows/downloads); no DB reset; additive migration; graceful 404 on the new endpoint; flag stays off.
+- **Type consistency:** `MemryAssetDescriptor` / `CanvasAssetRow` / `chunkHashes` (encryptedHash[]) used identically across Tasks 2/4/5/9. `planDereference` signature matches its call site in 5d.
+- **Deploy safety:** telemetry enum + endpoint both in the server-first build; desktop degrades if endpoint absent.
+- **Open contingency (flagged, not blocking):** if Excalidraw refuses a non-`data:` `dataURL`, switch to re-hydrate-on-`canvas:get` (main reads disk → base64 into `files`); storage/sync externalization is unaffected. Validate in the first E2E paste test.

--- a/packages/contracts/src/blob-api.ts
+++ b/packages/contracts/src/blob-api.ts
@@ -28,6 +28,10 @@ export const ChunkExistenceCheckSchema = z.object({
   hash: z.string().min(1)
 })
 
+export const DereferenceRequestSchema = z.object({
+  chunkHashes: z.array(z.string().min(1)).min(1).max(4096)
+})
+
 export const UploadInitResponseSchema = z.object({
   sessionId: z.string(),
   expiresAt: z.number()
@@ -58,6 +62,7 @@ export type UploadInitRequest = z.infer<typeof UploadInitRequestSchema>
 export type ChunkUploadParams = z.infer<typeof ChunkUploadParamsSchema>
 export type UploadCompleteRequest = z.infer<typeof UploadCompleteRequestSchema>
 export type ChunkExistenceCheck = z.infer<typeof ChunkExistenceCheckSchema>
+export type DereferenceRequest = z.infer<typeof DereferenceRequestSchema>
 export type UploadInitResponse = z.infer<typeof UploadInitResponseSchema>
 export type ChunkUploadResponse = z.infer<typeof ChunkUploadResponseSchema>
 export type UploadCompleteResponse = z.infer<typeof UploadCompleteResponseSchema>

--- a/packages/contracts/src/canvas-api.ts
+++ b/packages/contracts/src/canvas-api.ts
@@ -73,12 +73,50 @@ export const CanvasUpdateSchema = z.object({
   entityRefs: z.array(CanvasEntityRefSchema).optional()
 })
 
+export const CanvasGetAssetSchema = z.object({
+  canvasId: z.string().min(1),
+  fileId: z.string().min(1)
+})
+
+export const CanvasListAssetsSchema = z.object({
+  canvasId: z.string().min(1)
+})
+
 // ============================================================================
 // Responses & Events
 // ============================================================================
 
 export interface CanvasListResponse {
   canvases: CanvasSummary[]
+}
+
+/**
+ * Descriptor for one asset (Excalidraw binary file) attached to a canvas
+ * scene. Stored alongside the scene; content-addressed on disk via
+ * AttachmentSyncService.
+ */
+export interface MemryAssetDescriptor {
+  fileId: string // Excalidraw file id (per scene)
+  attachmentId: string // random id from AttachmentSyncService.uploadAttachment
+  contentHash: string // plaintext sha256 hex (dedup key)
+  chunkHashes: string[] // encryptedHash[] from the upload manifest — for dereference
+  mimeType: string
+  sizeBytes: number
+  filename: string // content-addressed on-disk filename
+}
+
+export interface CanvasUploadAssetResponse {
+  ref: string // memry-file:// URL
+  descriptor: MemryAssetDescriptor
+  deduped: boolean
+}
+
+export interface CanvasGetAssetResponse {
+  ref: string | null
+}
+
+export interface CanvasListAssetsResponse {
+  assets: MemryAssetDescriptor[]
 }
 
 export interface CanvasDeleteResponse {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -655,7 +655,10 @@ export const CanvasChannels = {
     GET: 'canvas:get',
     UPDATE: 'canvas:update',
     DELETE: 'canvas:delete',
-    LIST: 'canvas:list'
+    LIST: 'canvas:list',
+    UPLOAD_ASSET: 'canvas:upload-asset',
+    GET_ASSET: 'canvas:get-asset',
+    LIST_ASSETS: 'canvas:list-assets'
   },
   events: {
     CREATED: 'canvas:created',

--- a/packages/contracts/src/telemetry-api.ts
+++ b/packages/contracts/src/telemetry-api.ts
@@ -47,7 +47,10 @@ export const TelemetryEventNameSchema = z.enum([
   'app_error_seen',
   'canvas_sync_conflict_copy',
   'canvas_too_large',
-  'sync_skipped_unknown_type'
+  'sync_skipped_unknown_type',
+  'canvas_asset_uploaded',
+  'canvas_asset_dedup_hit',
+  'canvas_asset_gc_reaped'
 ])
 
 export const TelemetrySurfaceSchema = z.enum([

--- a/packages/db-schema/src/schema/canvas.ts
+++ b/packages/db-schema/src/schema/canvas.ts
@@ -52,3 +52,35 @@ export type CanvasRow = typeof canvases.$inferSelect
 export type NewCanvasRow = typeof canvases.$inferInsert
 export type CanvasEntityRefRow = typeof canvasEntityRefs.$inferSelect
 export type NewCanvasEntityRefRow = typeof canvasEntityRefs.$inferInsert
+
+/**
+ * Per-device dedup index + GC bookkeeping for externalized canvas image assets (M5).
+ * content_hash = plaintext sha256 (dedup key, per vault); attachment_id = random id from
+ * the attachment pipeline (stable per content_hash within a vault); chunk_hashes = encrypted
+ * chunk hashes used for server dereference. One row per (canvas, image).
+ * FK canvas_id -> canvases(id) ON DELETE cascade lives in the SQL migration (mirrors
+ * canvas_entity_refs); delete is soft, so GC prunes rows explicitly — the FK is a safety net.
+ */
+export const canvasAssets = sqliteTable(
+  'canvas_assets',
+  {
+    vaultId: text('vault_id').notNull(),
+    canvasId: text('canvas_id').notNull(),
+    contentHash: text('content_hash').notNull(),
+    attachmentId: text('attachment_id').notNull(),
+    fileId: text('file_id').notNull(),
+    filename: text('filename').notNull(),
+    mimeType: text('mime_type').notNull(),
+    sizeBytes: integer('size_bytes').notNull(),
+    chunkHashes: text('chunk_hashes', { mode: 'json' }).$type<string[]>().notNull(),
+    createdAt: integer('created_at').notNull()
+  },
+  (table) => [
+    primaryKey({ columns: [table.canvasId, table.contentHash] }),
+    index('idx_canvas_assets_dedup').on(table.vaultId, table.contentHash),
+    index('idx_canvas_assets_attachment').on(table.attachmentId)
+  ]
+)
+
+export type CanvasAssetRow = typeof canvasAssets.$inferSelect
+export type NewCanvasAssetRow = typeof canvasAssets.$inferInsert

--- a/packages/db-schema/src/schema/canvas.ts
+++ b/packages/db-schema/src/schema/canvas.ts
@@ -65,7 +65,9 @@ export const canvasAssets = sqliteTable(
   'canvas_assets',
   {
     vaultId: text('vault_id').notNull(),
-    canvasId: text('canvas_id').notNull(),
+    canvasId: text('canvas_id')
+      .notNull()
+      .references(() => canvases.id, { onDelete: 'cascade' }),
     contentHash: text('content_hash').notNull(),
     attachmentId: text('attachment_id').notNull(),
     fileId: text('file_id').notNull(),

--- a/packages/db-schema/src/schema/canvas.ts
+++ b/packages/db-schema/src/schema/canvas.ts
@@ -70,6 +70,10 @@ export const canvasAssets = sqliteTable(
       .references(() => canvases.id, { onDelete: 'cascade' }),
     contentHash: text('content_hash').notNull(),
     attachmentId: text('attachment_id').notNull(),
+    // A representative Excalidraw fileId that references this content. Assets are
+    // content-addressed, so several scene elements (distinct fileIds) may share one
+    // contentHash → one physical asset; this stores the first-seen fileId. Rendering,
+    // restore, and GC all key on contentHash (never fileId), so the collapse is by design.
     fileId: text('file_id').notNull(),
     filename: text('filename').notNull(),
     mimeType: text('mime_type').notNull(),
@@ -78,6 +82,7 @@ export const canvasAssets = sqliteTable(
     createdAt: integer('created_at').notNull()
   },
   (table) => [
+    // Content-addressed dedup key: one row per (canvas, distinct content), NOT per fileId.
     primaryKey({ columns: [table.canvasId, table.contentHash] }),
     index('idx_canvas_assets_dedup').on(table.vaultId, table.contentHash),
     index('idx_canvas_assets_attachment').on(table.attachmentId)

--- a/packages/rpc/src/canvas.ts
+++ b/packages/rpc/src/canvas.ts
@@ -8,6 +8,9 @@ import {
   type CanvasEntityRef,
   type CanvasListResponse,
   type CanvasDeleteResponse,
+  type CanvasUploadAssetResponse,
+  type CanvasGetAssetResponse,
+  type CanvasListAssetsResponse,
   type CanvasCreatedEvent,
   type CanvasUpdatedEvent,
   type CanvasDeletedEvent,
@@ -59,6 +62,34 @@ export const canvasRpc = defineDomain({
     list: defineMethod<() => Promise<CanvasListResponse>>({
       channel: CanvasChannels.invoke.LIST,
       params: []
+    }),
+    uploadAsset: defineMethod<
+      (input: {
+        canvasId: string
+        fileId: string
+        mimeType: string
+        data: ArrayBuffer
+      }) => Promise<CanvasUploadAssetResponse>
+    >({
+      channel: CanvasChannels.invoke.UPLOAD_ASSET,
+      params: ['input'],
+      implementation: `async (input) =>
+        invoke(${JSON.stringify(CanvasChannels.invoke.UPLOAD_ASSET)}, {
+          canvasId: input.canvasId,
+          fileId: input.fileId,
+          mimeType: input.mimeType,
+          data: Array.from(new Uint8Array(input.data))
+        })`
+    }),
+    getAsset: defineMethod<(canvasId: string, fileId: string) => Promise<CanvasGetAssetResponse>>({
+      channel: CanvasChannels.invoke.GET_ASSET,
+      params: ['canvasId', 'fileId'],
+      invokeArgs: ['{ canvasId, fileId }']
+    }),
+    listAssets: defineMethod<(canvasId: string) => Promise<CanvasListAssetsResponse>>({
+      channel: CanvasChannels.invoke.LIST_ASSETS,
+      params: ['canvasId'],
+      invokeArgs: ['{ canvasId }']
     })
   },
   events: {


### PR DESCRIPTION
## Spatial Canvas M5 — Asset externalization

Externalizes Excalidraw inline-base64 images out of the encrypted canvas scene JSON onto the existing `memry-file://` + R2 attachment rails, with dereference/GC, on-disk content-hash dedup, an N-asset reference set, and a refined size guard. Additive; the `spatialCanvas` flag stays **default-OFF and hidden**. M0–M4 are already on `main`.

### What's wired (end to end)

- **Externalize on save** — the renderer walks the Excalidraw `files` map and, for each inline `data:` image, uploads the bytes via a new `canvas:upload-asset` IPC channel and rewrites `files[fileId].dataURL` to a `memry-file://` ref before persisting. Idempotent (already-externalized refs are skipped).
- **On-disk content-hash dedup (Option B)** — images are content-addressed at `{vault}/attachments/canvas-assets/<sha256>.<ext>`; a second paste/duplicate of the same bytes reuses the existing ref and skips the upload entirely. Crypto primitives unchanged — random per-image `fileKey`/`attachmentId` are kept, so the server can never confirm a known image is present. No convergent encryption.
- **Cross-device restore** — a `memryAssets` sidecar embedded in the synced scene JSON carries `{attachmentId, contentHash, chunkHashes,…}` per image, so a receiving device downloads the files (via the existing attachment pipeline, `markWritebackIgnored` first) and the scene resolves through `protocol.handle('memry-file')`.
- **Dereference / GC** — new sync-server route `POST /sync/attachments/dereference {chunkHashes[]}` decrements `blob_chunks.ref_count` (client supplies the chunk hashes — the server has no `attachmentId`→hash map and the manifest is E2E-opaque). The existing `cleanupOrphanedBlobChunks` cron reaps at `ref_count<=0`. Client GC runs on canvas save **and** delete, diffing the scene's assets against the vault-wide reference set.
- **Multi-asset reference set + conflict-copy safety** — a new `canvas_assets` table (migration **0036**, additive) tracks the (canvas ↔ asset) references per device. GC only dereferences an asset no other canvas references, so an M4 conflict-copy (which shares asset ids with the original) can never let GC reap a still-referenced asset.
- **Size guard** — the M4 pre-push cap is kept and now measures uncompressed scene bytes deliberately (it must precede `encryptItemForPush`'s uncompressed limit); externalization keeps image-heavy scenes well under it, while a huge freehand-ink scene still surfaces the toast + `canvas_too_large` telemetry rather than a silent drop.
- **Telemetry** — `canvas_asset_uploaded` / `canvas_asset_dedup_hit` / `canvas_asset_gc_reaped` added to the shared enum (server-validated → ships in the server-first deploy); metrics-only, no raw ids in dimensions.

### Backward compatibility (live prod)

- A pre-M5 canvas with inline base64 opens, renders, and saves fine — it has no `memryAssets` sidecar (`readMemryAssets → []`) and externalizes on its next save. Already-synced base64 scenes still pull and render on other devices. No DB reset; migration 0036 is additive/`IF NOT EXISTS`/idempotent. The new server endpoint degrades gracefully (404 → warn, never breaks a save), so a desktop built before the server deploy is safe.

### ⚠️ Deploy order (mandatory — server first)

Ship **sync-server first** (the dereference endpoint + the telemetry enum), staging → verify → prod, **then** desktop. This PR does not deploy anything — the production rollout is a separate, manual step.

### Known limitation (must close before flag promotion, M7)

Because dereference is client-driven and decrement-only (a chunk shared across N canvases is uploaded once → `ref_count = 1`), the vault-wide reference set is the only reap protection and it races sync ordering: a device that applies a canvas-delete **before** the create of another canvas that shares an asset can dereference that asset to `ref_count 0` and let the cron reap it. This is a ceiling of the deliberately chosen design, only bites once the flag is default-ON, and is captured for M7 (server-side reference tracking / reap grace period).

### Verification

Green: `typecheck` (16/16), `lint`, `ipc:check`, `check:architecture`, `check:contracts`, `i18n:check`, `git diff --check`, `test:sync-server` (757), `test:desktop` (11,516 passed / 0 failed).

Not yet run (deferred, as the plan scopes them): coverage ratchet (separate CI check), Electron E2E + the manual 2-device asset smoke, and the one load-bearing contingency the plan flagged — whether Excalidraw renders a `memry-file://` `dataURL` directly (fallback: re-hydrate base64 on `canvas:get`). Docs are scheduled for M7 rollout, so `docs:impact` is intentionally skipped for this hidden-phase change.

### Follow-ups (non-blocking, from the whole-branch review)

- Harden the sidecar-injection readiness check (unify with `getCanvasContext`).
- Device-B `applyUpsert` doesn't prune rows/files for remotely-removed images (storage leak, never data loss).
- DRY the two `atomicWriteBinary` copies; renderer re-externalize cost (dedup makes it correct; optimize via `api.addFiles`).

Implementation plan: `docs/superpowers/plans/2026-07-20-spatial-canvas-m5-assets.md`. Design source: `docs/superpowers/specs/2026-07-17-spatial-canvas-design.md` (§6, §5.6, §13 M5).
