### PR TITLE
fix(devex): un-gate contracts vitest suite from root test pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typecheck:landing": "pnpm --filter @memry/landing typecheck",
     "typecheck:sync-server": "pnpm --filter @memry/sync-server typecheck",
     "typecheck:emails": "pnpm --filter @memry/marketing-emails typecheck",
-    "test": "pnpm repair:links && node scripts/run-turbo.js run test --filter=@memry/app-core --filter=@memry/cli --filter=@memry/desktop --filter=@memry/sync-server",
+    "test": "pnpm repair:links && node scripts/run-turbo.js run test --filter=@memry/contracts --filter=@memry/app-core --filter=@memry/cli --filter=@memry/desktop --filter=@memry/sync-server",
     "test:cli": "pnpm --filter @memry/app-core test && pnpm --filter @memry/cli test",
     "test:release": "node --test scripts/release-utils.test.mjs scripts/release-notes-utils.test.mjs scripts/reddit-release-utils.test.mjs scripts/pre-push-policy.test.mjs scripts/package-scripts.test.mjs apps/desktop/scripts/build-packaged-app-utils.test.cjs apps/desktop/scripts/check-packaged-runtime-deps-utils.test.cjs",
     "test:desktop": "pnpm --filter @memry/desktop test",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -59,6 +59,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
+    "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Contracts (47 vitest files, ~1520 tests incl. sync-payloads) had no `test` script, so the suite was skipped by `pnpm test` and CI despite always passing when run directly.

## Changes

- `packages/contracts/package.json`: add `test: vitest run`
- root `package.json`: add `--filter=@memry/contracts` to root `test` script

vitest is hoisted at `node_modules/.bin/vitest` — no new devDep. All 1523 tests pass.

## Non-obvious turbo behavior

The `test` task has `dependsOn: ["^test"]` and app-core depends on @memry/contracts, so adding the leaf script alone auto-gates contracts via the dependency graph (turbo resolves `cmd="vitest run"` even without an explicit root filter). The root `--filter` is explicit first-class targeting, matching the `typecheck` convention.

## Testing

- `pnpm --filter @memry/contracts test` → 47 passed, 1523 tests passed
- Root pipeline now includes contracts#test

Ready for review and merge.