### PR TITLE
feat(updater): short-interval polling, silent opt-in download, read-only release-notes tab

### DIFF
--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -262,6 +262,76 @@ describe('updater', () => {
     expect(updater.getUpdateState().releaseNotes).toBe('New Features\n• Calendar sync')
   })
 
+  it('keeps the full release-notes html (changelog + PR links) for the release-notes tab', async () => {
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+    const html =
+      '<h2>Fixes</h2><ul><li>Sync fix</li></ul><h2>Changelog</h2>' +
+      '<p>Full Changelog: https://x</p>' +
+      '<p><a href="https://github.com/memrynote/memry/pull/123">#123</a> title @a</p>'
+    mocks.autoUpdater.emit('update-available', { version: '1.2.4', releaseNotes: html })
+    await flushAsyncWork()
+
+    const state = updater.getUpdateState()
+    // The modal text stays stripped to the curated bullets…
+    expect(state.releaseNotes).toBe('Fixes\n• Sync fix')
+    // …but the release-notes tab keeps the entire body, including the clickable PR link.
+    expect(state.releaseNotesHtml).toBe(html)
+    expect(state.releaseNotesHtml).toContain('pull/123')
+  })
+
+  it('combines array release notes into html for the tab', async () => {
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+    mocks.autoUpdater.emit('update-available', {
+      version: '1.2.4',
+      releaseNotes: [
+        { version: '1.2.4', note: '<ul><li>A</li></ul>' },
+        { note: '<ul><li>B</li></ul>' }
+      ]
+    })
+    await flushAsyncWork()
+
+    const html = updater.getUpdateState().releaseNotesHtml
+    expect(html).toContain('<li>A</li>')
+    expect(html).toContain('<li>B</li>')
+    expect(html).toContain('v1.2.4')
+  })
+
+  it('clears release-notes html when no update is available or the version is skipped', async () => {
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+    mocks.autoUpdater.emit('update-available', { version: '1.2.4', releaseNotes: '<p>notes</p>' })
+    expect(updater.getUpdateState().releaseNotesHtml).toBe('<p>notes</p>')
+
+    updater.skipVersion('v1.2.4')
+    expect(updater.getUpdateState().releaseNotesHtml).toBeNull()
+
+    mocks.autoUpdater.emit('update-not-available')
+    expect(updater.getUpdateState().releaseNotesHtml).toBeNull()
+  })
+
+  it('starts the download immediately when auto-download is enabled while an update already waits', async () => {
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+    mocks.autoUpdater.emit('update-available', { version: '1.2.4', releaseNotes: 'notes' })
+    expect(updater.getUpdateState().status).toBe('available')
+    expect(mocks.autoUpdater.downloadUpdate).not.toHaveBeenCalled()
+
+    updater.setAutoDownloadEnabled(true)
+    await flushAsyncWork()
+    expect(mocks.autoUpdater.downloadUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not start a download when auto-download is enabled with no update available', async () => {
+    const updater = await loadUpdater()
+    updater.initializeUpdater()
+
+    updater.setAutoDownloadEnabled(true)
+    await flushAsyncWork()
+    expect(mocks.autoUpdater.downloadUpdate).not.toHaveBeenCalled()
+  })
+
   it('skips a version: clears the current prompt and suppresses it on re-check', async () => {
     const updater = await loadUpdater()
     updater.initializeUpdater()
@@ -314,7 +384,7 @@ describe('updater', () => {
     expect(updater.getUpdateState().autoDownloadEnabled).toBe(true)
   })
 
-  it('auto-checks at startup and re-checks on the interval by default', async () => {
+  it('auto-checks at startup and re-checks on a short (~10 min) interval by default', async () => {
     vi.useFakeTimers()
     try {
       const updater = await loadUpdater()
@@ -323,9 +393,12 @@ describe('updater', () => {
       expect(updater.getUpdateState().autoCheckEnabled).toBe(true)
       expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
 
-      // Six hours later the background timer fires a fresh check.
-      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000)
+      // A short interval keeps freshly published releases picked up quickly while
+      // the app is open (previously 6h — too slow to surface an update in-session).
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000)
       expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000)
+      expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(3)
     } finally {
       vi.useRealTimers()
     }

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -10,8 +10,14 @@ import { getUpdaterPrefs, setAutoCheckPref, setAutoDownloadPref, setSkippedVersi
 
 const logger = createLogger('Updater')
 
-/** How often to re-check for updates while the app is running when auto-check is on. */
-const AUTO_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+/**
+ * How often to re-check for updates while the app is running when auto-check is on.
+ * Short by design (10 min) so a release published while the app is open is picked up
+ * within one interval — either silently downloaded (auto-download on) or surfaced via
+ * the in-app prompt. The timer is unref'd and packaged-only, so it never blocks quit
+ * and never polls in dev.
+ */
+const AUTO_CHECK_INTERVAL_MS = 10 * 60 * 1000
 
 let initialized = false
 let activeCheck: Promise<AppUpdateState> | null = null
@@ -27,6 +33,7 @@ let state: AppUpdateState = {
   releaseName: null,
   releaseDate: null,
   releaseNotes: null,
+  releaseNotesHtml: null,
   downloadProgressPercent: null,
   lastCheckedAt: null,
   error: null,
@@ -70,6 +77,7 @@ export function initializeUpdater(): void {
         releaseName: null,
         releaseDate: null,
         releaseNotes: null,
+        releaseNotesHtml: null,
         downloadProgressPercent: null,
         error: null
       })
@@ -83,6 +91,7 @@ export function initializeUpdater(): void {
       releaseName: info.releaseName ?? null,
       releaseDate: info.releaseDate ?? null,
       releaseNotes: normalizeReleaseNotes(info),
+      releaseNotesHtml: rawReleaseNotesHtml(info),
       downloadProgressPercent: null,
       error: null
     })
@@ -99,6 +108,7 @@ export function initializeUpdater(): void {
       releaseName: null,
       releaseDate: null,
       releaseNotes: null,
+      releaseNotesHtml: null,
       downloadProgressPercent: null,
       error: null
     })
@@ -120,6 +130,7 @@ export function initializeUpdater(): void {
       releaseName: info.releaseName ?? null,
       releaseDate: info.releaseDate ?? null,
       releaseNotes: normalizeReleaseNotes(info),
+      releaseNotesHtml: rawReleaseNotesHtml(info),
       downloadProgressPercent: 100,
       error: null
     })
@@ -243,6 +254,7 @@ export function skipVersion(version: string): AppUpdateState {
     releaseName: null,
     releaseDate: null,
     releaseNotes: null,
+    releaseNotesHtml: null,
     downloadProgressPercent: null,
     error: null
   })
@@ -257,11 +269,16 @@ export function skipVersion(version: string): AppUpdateState {
 export function setAutoDownloadEnabled(enabled: boolean): AppUpdateState {
   logger.info('setting auto-download preference', { enabled })
   setAutoDownloadPref(enabled)
-  // Applies to future checks ("in the future"): electron-updater reads autoDownload
-  // when the next update-available fires. The currently-available update is left for
-  // the user to start with the Download button.
+  // electron-updater reads autoDownload only when the NEXT update-available fires.
   autoUpdater.autoDownload = enabled
   setState({ autoDownloadEnabled: enabled })
+  // Close the gap where an update is already waiting: opting in should not leave that
+  // update stuck behind the manual Download button, so start its download now.
+  if (enabled && state.status === 'available') {
+    void downloadUpdate().catch((error) => {
+      logger.warn('auto-download on-enable download failed', error)
+    })
+  }
   return getUpdateState()
 }
 
@@ -356,6 +373,35 @@ function stripDeveloperChangelog(text: string): string {
     return text
   }
   return lines.slice(0, index).join('\n').trimEnd()
+}
+
+/**
+ * The full release-notes body kept verbatim (HTML from the update feed) for the
+ * read-only "release notes" tab. Unlike normalizeReleaseNotes, this does NOT convert
+ * to plain text or strip the developer changelog, so the tab keeps the clickable PR
+ * references / Full Changelog link. For array feeds each entry is prefixed with its
+ * version heading.
+ */
+function rawReleaseNotesHtml(info: UpdateInfo): string | null {
+  const { releaseNotes } = info
+
+  if (!releaseNotes) {
+    return null
+  }
+
+  if (typeof releaseNotes === 'string') {
+    return releaseNotes.trim() || null
+  }
+
+  const combined = releaseNotes
+    .map((entry) => {
+      const heading = entry.version ? `<h3>${formatAppVersionForDisplay(entry.version)}</h3>\n` : ''
+      return `${heading}${entry.note ?? ''}`.trim()
+    })
+    .filter(Boolean)
+    .join('\n')
+
+  return combined || null
 }
 
 function normalizeReleaseNotes(info: UpdateInfo): string | null {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -57,6 +57,7 @@ import { IncidentReportProvider } from '@/components/diagnostics/incident-report
 import { VaultOnboarding } from '@/components/vault-onboarding'
 import { UpdatingScreen } from '@/components/updating-screen'
 import { UpdatePromptDialog } from '@/components/updater/update-prompt-dialog'
+import { UpdateReleaseNotesTabOpener } from '@/components/updater/update-release-notes-tab-opener'
 import { useAppUpdater } from '@/hooks/use-app-updater'
 import { useThemeSync } from '@/hooks/use-theme-sync'
 import { useWeekStartSync } from '@/hooks/use-week-start-sync'
@@ -526,6 +527,9 @@ function App(): React.JSX.Element {
                                 <SidebarInset className="flex flex-col overflow-hidden">
                                   <AppContent />
                                 </SidebarInset>
+                                {/* Opens the ephemeral read-only release-notes tab as part
+                                    of the update flow. Lives inside TabProvider for openTab(). */}
+                                <UpdateReleaseNotesTabOpener />
                               </SidebarDrillDownProvider>
                               <TaskDragOverlay projects={projectsWithCounts} />
                               {/* Last child so paint order puts the chrome overlay above the

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -58,6 +58,7 @@ import { VaultOnboarding } from '@/components/vault-onboarding'
 import { UpdatingScreen } from '@/components/updating-screen'
 import { UpdatePromptDialog } from '@/components/updater/update-prompt-dialog'
 import { UpdateReleaseNotesTabOpener } from '@/components/updater/update-release-notes-tab-opener'
+import { ReleaseNotesDevTrigger } from '@/components/updater/release-notes-dev-trigger'
 import { useAppUpdater } from '@/hooks/use-app-updater'
 import { useThemeSync } from '@/hooks/use-theme-sync'
 import { useWeekStartSync } from '@/hooks/use-week-start-sync'
@@ -530,6 +531,9 @@ function App(): React.JSX.Element {
                                 {/* Opens the ephemeral read-only release-notes tab as part
                                     of the update flow. Lives inside TabProvider for openTab(). */}
                                 <UpdateReleaseNotesTabOpener />
+                                {/* Dev-only: window.openReleaseNotesDemo() to preview the tab
+                                    with dummy data (updater never fires in dev). */}
+                                {import.meta.env.DEV && <ReleaseNotesDevTrigger />}
                               </SidebarDrillDownProvider>
                               <TaskDragOverlay projects={projectsWithCounts} />
                               {/* Last child so paint order puts the chrome overlay above the

--- a/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
+++ b/apps/desktop/src/renderer/src/components/split-view/tab-content.tsx
@@ -57,6 +57,9 @@ const LazyAgentConversationTab = React.lazy(async () => ({
 const LazyCanvasPage = React.lazy(async () => ({
   default: (await import('@/pages/canvas')).CanvasPage
 }))
+const LazyVirtualNotePage = React.lazy(async () => ({
+  default: (await import('@/pages/virtual-note')).VirtualNotePage
+}))
 const LazyHomePage = React.lazy(() => import('@/pages/home'))
 
 interface TabContentProps {
@@ -193,6 +196,15 @@ export const TabContent = ({ tab, groupId, className }: TabContentProps): React.
 
       case 'canvas':
         return <LazyCanvasPage canvasId={tab.entityId} />
+
+      case 'virtual-note':
+        return (
+          <LazyVirtualNotePage
+            title={tab.title}
+            content={stringifyUnknown(tab.viewState?.content)}
+            contentType={tab.viewState?.contentType === 'markdown' ? 'markdown' : 'html'}
+          />
+        )
 
       case 'collection':
         return (

--- a/apps/desktop/src/renderer/src/components/tabs/tab-icon.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-icon.tsx
@@ -94,7 +94,8 @@ const TYPE_TO_ICON: Record<TabType, string> = {
   templates: 'layout-template',
   graph: 'graph',
   'agent-chat': 'bot',
-  canvas: 'pen-tool'
+  canvas: 'pen-tool',
+  'virtual-note': 'file-text'
 }
 
 /**

--- a/apps/desktop/src/renderer/src/components/updater/release-notes-dev-trigger.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/release-notes-dev-trigger.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from 'react'
+import { useTabs } from '@/contexts/tabs'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('Dev:ReleaseNotesTrigger')
+
+/**
+ * Dummy release-notes body shaped like the real GitHub update feed: curated emoji
+ * bullets under section headings + a Changelog section whose `#NNN` references and
+ * "Full Changelog" URL are clickable <a> links (this is exactly what the tab keeps
+ * that the modal strips).
+ */
+const DEMO_RELEASE_NOTES_HTML = `
+<h2>New Features</h2>
+<ul>
+  <li>📥 Daily inbox review reminder — a gentle nudge each day to clear your inbox.</li>
+  <li>📄 Inline PDF embeds — drop PDFs into a note and resize, align, or drag them in.</li>
+  <li>📅 Drag tasks onto the calendar — schedule a task by dragging it onto a day.</li>
+</ul>
+<h2>Improvements</h2>
+<ul>
+  <li>🌑 Darker dark theme — deeper backgrounds and clearer surfaces.</li>
+  <li>🔄 Smarter sync negotiation — clients agree on sync types per connection.</li>
+</ul>
+<h2>Fixes</h2>
+<ul>
+  <li>⌨️ Delete-key crash — fixed forward-delete at the end of a document.</li>
+  <li>〽️ Underline persistence — underlined text now survives save + reload.</li>
+</ul>
+<h2>Changelog</h2>
+<p>Full Changelog: <a href="https://github.com/memrynote/memry/compare/2026.719.2...2026.999.9">2026.719.2...2026.999.9</a></p>
+<p><a href="https://github.com/memrynote/memry/pull/818">#818</a> feat(updater): short-interval polling, silent opt-in download, read-only release-notes tab @kaan</p>
+<p><a href="https://github.com/memrynote/memry/pull/811">#811</a> feat(canvas): M4 — E2E-encrypted cross-device sync @kaan</p>
+<p><a href="https://github.com/memrynote/memry/pull/785">#785</a> feat(canvas): spatial canvas (Excalidraw) M0–M3 @kaan</p>
+`.trim()
+
+/**
+ * Dev-only: exposes `window.openReleaseNotesDemo([version])` so the read-only
+ * release-notes tab can be inspected with dummy data without a packaged updater run
+ * (the updater is `app.isPackaged`-gated and never fires in dev). Mounted only under
+ * `import.meta.env.DEV`, so it is stripped from production builds and never registers
+ * the helper there.
+ */
+export function ReleaseNotesDevTrigger(): null {
+  const { openTab } = useTabs()
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return
+
+    const open = (version = '2026.999.9'): void => {
+      openTab({
+        type: 'virtual-note',
+        title: `MemryNote ${version}`,
+        icon: 'file-text',
+        path: `/virtual/release-notes/${version}`,
+        isPinned: false,
+        isModified: false,
+        isPreview: false,
+        isDeleted: false,
+        viewState: { content: DEMO_RELEASE_NOTES_HTML, contentType: 'html' }
+      })
+    }
+
+    const win = window as unknown as { openReleaseNotesDemo?: (version?: string) => void }
+    win.openReleaseNotesDemo = open
+    log.info('dev helper ready — run openReleaseNotesDemo() in the console to open the tab')
+
+    return () => {
+      delete win.openReleaseNotesDemo
+    }
+  }, [openTab])
+
+  return null
+}

--- a/apps/desktop/src/renderer/src/components/updater/release-notes-tab.test.ts
+++ b/apps/desktop/src/renderer/src/components/updater/release-notes-tab.test.ts
@@ -22,11 +22,11 @@ function makeState(overrides: Partial<AppUpdateState> = {}): AppUpdateState {
 }
 
 describe('planReleaseNotesTab', () => {
-  it('plans a tab titled "memry note <version>" with the full html body when an update is available', () => {
+  it('plans a tab titled "MemryNote <version>" with the full html body when an update is available', () => {
     const plan = planReleaseNotesTab(makeState(), null)
     expect(plan).toEqual({
       version: '2026.708.1',
-      title: 'memry note 2026.708.1',
+      title: 'MemryNote 2026.708.1',
       content: '<h2>New Features</h2><ul><li>A</li></ul>',
       contentType: 'html'
     })

--- a/apps/desktop/src/renderer/src/components/updater/release-notes-tab.test.ts
+++ b/apps/desktop/src/renderer/src/components/updater/release-notes-tab.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
+import { planReleaseNotesTab } from './release-notes-tab'
+
+function makeState(overrides: Partial<AppUpdateState> = {}): AppUpdateState {
+  return {
+    currentVersion: '2026.700.1',
+    status: 'available',
+    updateSupported: true,
+    availableVersion: '2026.708.1',
+    releaseName: null,
+    releaseDate: null,
+    releaseNotes: 'New Features\n• A',
+    releaseNotesHtml: '<h2>New Features</h2><ul><li>A</li></ul>',
+    downloadProgressPercent: null,
+    lastCheckedAt: null,
+    error: null,
+    autoDownloadEnabled: false,
+    autoCheckEnabled: true,
+    ...overrides
+  }
+}
+
+describe('planReleaseNotesTab', () => {
+  it('plans a tab titled "memry note <version>" with the full html body when an update is available', () => {
+    const plan = planReleaseNotesTab(makeState(), null)
+    expect(plan).toEqual({
+      version: '2026.708.1',
+      title: 'memry note 2026.708.1',
+      content: '<h2>New Features</h2><ul><li>A</li></ul>',
+      contentType: 'html'
+    })
+  })
+
+  it('also plans while an opted-in update is silently downloading or downloaded', () => {
+    expect(planReleaseNotesTab(makeState({ status: 'downloading' }), null)?.version).toBe(
+      '2026.708.1'
+    )
+    expect(planReleaseNotesTab(makeState({ status: 'downloaded' }), null)?.version).toBe(
+      '2026.708.1'
+    )
+  })
+
+  it('falls back to the plain-text notes as markdown when no html body is present', () => {
+    const plan = planReleaseNotesTab(makeState({ releaseNotesHtml: null }), null)
+    expect(plan).toMatchObject({ content: 'New Features\n• A', contentType: 'markdown' })
+  })
+
+  it('does not re-open the same version it already surfaced', () => {
+    expect(planReleaseNotesTab(makeState(), '2026.708.1')).toBeNull()
+  })
+
+  it('returns null for non-surfacing statuses', () => {
+    for (const status of ['idle', 'checking', 'up-to-date', 'error', 'installing'] as const) {
+      expect(planReleaseNotesTab(makeState({ status }), null)).toBeNull()
+    }
+  })
+
+  it('returns null when updates are unsupported, no version, or no content', () => {
+    expect(planReleaseNotesTab(makeState({ updateSupported: false }), null)).toBeNull()
+    expect(planReleaseNotesTab(makeState({ availableVersion: null }), null)).toBeNull()
+    expect(
+      planReleaseNotesTab(makeState({ releaseNotes: null, releaseNotesHtml: null }), null)
+    ).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/updater/release-notes-tab.ts
+++ b/apps/desktop/src/renderer/src/components/updater/release-notes-tab.ts
@@ -1,0 +1,59 @@
+import type { AppUpdateState, UpdaterStatus } from '@memry/contracts/ipc-updater'
+
+/** Statuses for which a real update has surfaced and its notes are worth showing. */
+const SURFACING_STATUSES: ReadonlySet<UpdaterStatus> = new Set<UpdaterStatus>([
+  'available',
+  'downloading',
+  'downloaded'
+])
+
+export interface ReleaseNotesTabPlan {
+  /** Display version this tab is for (used for dedup + a unique tab path). */
+  version: string
+  /** Tab title, e.g. "memry note 2026.708.1". */
+  title: string
+  /** Release-notes body to render read-only. */
+  content: string
+  /** How `content` should be parsed by the note renderer. */
+  contentType: 'html' | 'markdown'
+}
+
+/**
+ * Decide whether the update flow should open a read-only "release notes" tab, and
+ * with what content. Pure so it can be unit-tested and reused by the opener effect.
+ *
+ * Fires once per surfaced version (the caller tracks `surfacedVersion`), covering
+ * both the prompt path and the silent auto-download path. Prefers the full HTML body
+ * (keeps clickable PR references); falls back to the stripped plain-text notes.
+ */
+export function planReleaseNotesTab(
+  state: AppUpdateState,
+  surfacedVersion: string | null
+): ReleaseNotesTabPlan | null {
+  if (!state.updateSupported) return null
+
+  const version = state.availableVersion
+  if (!version) return null
+  if (!SURFACING_STATUSES.has(state.status)) return null
+  if (version === surfacedVersion) return null
+
+  if (state.releaseNotesHtml) {
+    return {
+      version,
+      title: `memry note ${version}`,
+      content: state.releaseNotesHtml,
+      contentType: 'html'
+    }
+  }
+
+  if (state.releaseNotes) {
+    return {
+      version,
+      title: `memry note ${version}`,
+      content: state.releaseNotes,
+      contentType: 'markdown'
+    }
+  }
+
+  return null
+}

--- a/apps/desktop/src/renderer/src/components/updater/release-notes-tab.ts
+++ b/apps/desktop/src/renderer/src/components/updater/release-notes-tab.ts
@@ -10,7 +10,7 @@ const SURFACING_STATUSES: ReadonlySet<UpdaterStatus> = new Set<UpdaterStatus>([
 export interface ReleaseNotesTabPlan {
   /** Display version this tab is for (used for dedup + a unique tab path). */
   version: string
-  /** Tab title, e.g. "memry note 2026.708.1". */
+  /** Tab title, e.g. "MemryNote 2026.708.1". */
   title: string
   /** Release-notes body to render read-only. */
   content: string
@@ -40,7 +40,7 @@ export function planReleaseNotesTab(
   if (state.releaseNotesHtml) {
     return {
       version,
-      title: `memry note ${version}`,
+      title: `MemryNote ${version}`,
       content: state.releaseNotesHtml,
       contentType: 'html'
     }
@@ -49,7 +49,7 @@ export function planReleaseNotesTab(
   if (state.releaseNotes) {
     return {
       version,
-      title: `memry note ${version}`,
+      title: `MemryNote ${version}`,
       content: state.releaseNotes,
       contentType: 'markdown'
     }

--- a/apps/desktop/src/renderer/src/components/updater/update-prompt-dialog.test.ts
+++ b/apps/desktop/src/renderer/src/components/updater/update-prompt-dialog.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import type { AppUpdateState, UpdaterStatus } from '@memry/contracts/ipc-updater'
+import { shouldShowUpdatePrompt } from './update-prompt-dialog'
+
+function state(overrides: Partial<AppUpdateState> = {}): AppUpdateState {
+  return {
+    currentVersion: '2026.700.1',
+    status: 'available',
+    updateSupported: true,
+    availableVersion: '2026.708.1',
+    releaseName: null,
+    releaseDate: null,
+    releaseNotes: 'notes',
+    releaseNotesHtml: '<p>notes</p>',
+    downloadProgressPercent: null,
+    lastCheckedAt: null,
+    error: null,
+    autoDownloadEnabled: false,
+    autoCheckEnabled: true,
+    ...overrides
+  }
+}
+
+describe('shouldShowUpdatePrompt', () => {
+  it('shows the available prompt when auto-download is off', () => {
+    expect(shouldShowUpdatePrompt(state({ status: 'available' }), null)).toBe(true)
+  })
+
+  it('shows the downloaded prompt when auto-download is off', () => {
+    expect(shouldShowUpdatePrompt(state({ status: 'downloaded' }), null)).toBe(true)
+  })
+
+  it('stays silent for BOTH phases when auto-download is on (no popup)', () => {
+    expect(
+      shouldShowUpdatePrompt(state({ status: 'available', autoDownloadEnabled: true }), null)
+    ).toBe(false)
+    expect(
+      shouldShowUpdatePrompt(state({ status: 'downloaded', autoDownloadEnabled: true }), null)
+    ).toBe(false)
+  })
+
+  it('hides a phase the user dismissed', () => {
+    expect(shouldShowUpdatePrompt(state({ status: 'available' }), 'available')).toBe(false)
+  })
+
+  it('never shows when updates are unsupported or there is nothing to prompt', () => {
+    expect(shouldShowUpdatePrompt(state({ updateSupported: false }), null)).toBe(false)
+    for (const status of [
+      'idle',
+      'checking',
+      'downloading',
+      'up-to-date',
+      'error'
+    ] as UpdaterStatus[]) {
+      expect(shouldShowUpdatePrompt(state({ status }), null)).toBe(false)
+    }
+  })
+})

--- a/apps/desktop/src/renderer/src/components/updater/update-prompt-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-prompt-dialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import type { UpdaterStatus } from '@memry/contracts/ipc-updater'
+import type { AppUpdateState, UpdaterStatus } from '@memry/contracts/ipc-updater'
 import { useT } from '@memry/i18n/renderer'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -10,6 +10,25 @@ import { createLogger } from '@/lib/logger'
 import memryLogo from '@/assets/icon-logo.png'
 
 const log = createLogger('Component:UpdatePromptDialog')
+
+/**
+ * Whether the in-app update prompt should surface. With auto-download on, BOTH the
+ * "available" and "downloaded" phases stay silent — the update downloads and installs
+ * on the next quit without any popup — so a silent background update never flashes a
+ * prompt when a new release is found on the short-interval poll.
+ */
+export function shouldShowUpdatePrompt(
+  state: AppUpdateState,
+  dismissedStatus: UpdaterStatus | null
+): boolean {
+  const isPromptable = state.status === 'available' || state.status === 'downloaded'
+  return (
+    state.updateSupported &&
+    isPromptable &&
+    state.status !== dismissedStatus &&
+    !state.autoDownloadEnabled
+  )
+}
 
 /**
  * In-app replacement for the native "update available" / "restart to install"
@@ -33,13 +52,7 @@ export function UpdatePromptDialog(): React.JSX.Element | null {
   const isAvailable = state.status === 'available'
   const isDownloaded = state.status === 'downloaded'
 
-  const shouldShow =
-    state.updateSupported &&
-    (isAvailable || isDownloaded) &&
-    state.status !== dismissedStatus &&
-    // With auto-update on, don't nag: the download/install happens automatically
-    // and installs on the next quit (autoInstallOnAppQuit).
-    !(isDownloaded && state.autoDownloadEnabled)
+  const shouldShow = shouldShowUpdatePrompt(state, dismissedStatus)
 
   const dismiss = useCallback(() => {
     setDismissedStatus(state.status)

--- a/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-opener.test.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-opener.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import type { AppUpdateState } from '@memry/contracts/ipc-updater'
+
+const mocks = vi.hoisted(() => ({
+  state: {} as AppUpdateState,
+  openTab: vi.fn()
+}))
+
+vi.mock('@/hooks/use-app-updater', () => ({
+  useAppUpdater: () => ({ state: mocks.state })
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabs: () => ({ openTab: mocks.openTab })
+}))
+
+import { UpdateReleaseNotesTabOpener } from './update-release-notes-tab-opener'
+
+function available(version: string): AppUpdateState {
+  return {
+    currentVersion: '2026.700.1',
+    status: 'available',
+    updateSupported: true,
+    availableVersion: version,
+    releaseName: null,
+    releaseDate: null,
+    releaseNotes: 'notes',
+    releaseNotesHtml: `<p>${version}</p>`,
+    downloadProgressPercent: null,
+    lastCheckedAt: null,
+    error: null,
+    autoDownloadEnabled: false,
+    autoCheckEnabled: true
+  }
+}
+
+describe('UpdateReleaseNotesTabOpener', () => {
+  beforeEach(() => {
+    mocks.openTab.mockReset()
+  })
+
+  it('opens a read-only release-notes tab once when an update surfaces', () => {
+    mocks.state = available('2026.708.1')
+    render(<UpdateReleaseNotesTabOpener />)
+
+    expect(mocks.openTab).toHaveBeenCalledTimes(1)
+    const tab = mocks.openTab.mock.calls[0][0]
+    expect(tab).toMatchObject({
+      type: 'virtual-note',
+      title: 'memry note 2026.708.1',
+      path: '/virtual/release-notes/2026.708.1',
+      isPreview: false,
+      viewState: { content: '<p>2026.708.1</p>', contentType: 'html' }
+    })
+  })
+
+  it('does not re-open the same version on a re-render', () => {
+    mocks.state = available('2026.708.1')
+    const { rerender } = render(<UpdateReleaseNotesTabOpener />)
+    expect(mocks.openTab).toHaveBeenCalledTimes(1)
+
+    mocks.state = { ...available('2026.708.1'), status: 'downloading' }
+    rerender(<UpdateReleaseNotesTabOpener />)
+    expect(mocks.openTab).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens again for a newer version', () => {
+    mocks.state = available('2026.708.1')
+    const { rerender } = render(<UpdateReleaseNotesTabOpener />)
+    mocks.state = available('2026.709.1')
+    rerender(<UpdateReleaseNotesTabOpener />)
+    expect(mocks.openTab).toHaveBeenCalledTimes(2)
+  })
+
+  it('stays quiet when there is no update to surface', () => {
+    mocks.state = { ...available('2026.708.1'), status: 'up-to-date', availableVersion: null }
+    render(<UpdateReleaseNotesTabOpener />)
+    expect(mocks.openTab).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-opener.test.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-opener.test.tsx
@@ -48,7 +48,7 @@ describe('UpdateReleaseNotesTabOpener', () => {
     const tab = mocks.openTab.mock.calls[0][0]
     expect(tab).toMatchObject({
       type: 'virtual-note',
-      title: 'memry note 2026.708.1',
+      title: 'MemryNote 2026.708.1',
       path: '/virtual/release-notes/2026.708.1',
       isPreview: false,
       viewState: { content: '<p>2026.708.1</p>', contentType: 'html' }

--- a/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-opener.tsx
+++ b/apps/desktop/src/renderer/src/components/updater/update-release-notes-tab-opener.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react'
+import { useAppUpdater } from '@/hooks/use-app-updater'
+import { useTabs } from '@/contexts/tabs'
+import { planReleaseNotesTab } from './release-notes-tab'
+
+/**
+ * Part of the update flow: when a new release surfaces — whether the prompt is shown
+ * or a silent auto-download begins — open a read-only "release notes" tab rendering
+ * the humanized notes (with clickable PR links). The tab is ephemeral (never written
+ * to the vault, never synced, excluded from tab persistence); closing removes it, and
+ * Cmd/Ctrl+Shift+T reopens it from the in-memory closed-tab stack.
+ *
+ * Opens once per surfaced version so short-interval polling never re-opens it.
+ * Renders nothing; must live inside TabProvider.
+ */
+export function UpdateReleaseNotesTabOpener(): null {
+  const { state } = useAppUpdater()
+  const { openTab } = useTabs()
+  const surfacedVersionRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const plan = planReleaseNotesTab(state, surfacedVersionRef.current)
+    if (!plan) return
+
+    surfacedVersionRef.current = plan.version
+    openTab({
+      type: 'virtual-note',
+      title: plan.title,
+      icon: 'file-text',
+      // Unique per version so distinct release-notes tabs never collapse into one
+      // another via the no-entityId open/reopen dedup.
+      path: `/virtual/release-notes/${plan.version}`,
+      isPinned: false,
+      isModified: false,
+      isPreview: false,
+      isDeleted: false,
+      viewState: { content: plan.content, contentType: plan.contentType }
+    })
+  }, [state, openTab])
+
+  return null
+}

--- a/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/helpers.ts
@@ -135,7 +135,8 @@ const TAB_ICONS: Record<TabType, string> = {
   templates: 'layout-template',
   graph: 'graph',
   'agent-chat': 'bot',
-  canvas: 'pen-tool'
+  canvas: 'pen-tool',
+  'virtual-note': 'file-text'
 }
 
 /**

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.test.ts
@@ -66,7 +66,7 @@ describe('serializeTabState', () => {
     const note = makeTab({ title: 'Real note' })
     const releaseNotes = makeTab({
       type: 'virtual-note',
-      title: 'memry note 2026.708.1',
+      title: 'MemryNote 2026.708.1',
       entityId: undefined,
       path: '/virtual/release-notes/2026.708.1',
       viewState: { content: '<h2>Fixes</h2>', contentType: 'html' }

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.test.ts
@@ -57,7 +57,8 @@ const makeState = (tabs: Tab[]): TabSystemState => {
     tabGroups: { g1: group },
     layout: { type: 'leaf', tabGroupId: 'g1' },
     activeGroupId: 'g1',
-    settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' }
+    settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' },
+    recentlyClosed: []
   }
 }
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.test.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { isRestorableTabType } from './serialization'
+import { isRestorableTabType, serializeTabState } from './serialization'
 import type { FeaturesSettings } from '@memry/contracts/settings-schemas'
+import type { Tab, TabGroup, TabSystemState } from '../types'
+import { generateId } from '../helpers'
 
 const flags: FeaturesSettings = {
   home: false,
@@ -23,5 +25,57 @@ describe('isRestorableTabType', () => {
   })
   it('keeps non-feature tabs (notes)', () => {
     expect(isRestorableTabType('note', flags)).toBe(true)
+  })
+})
+
+const makeTab = (overrides: Partial<Tab> = {}): Tab => ({
+  id: generateId(),
+  type: 'note',
+  title: 'Test Note',
+  icon: 'file-text',
+  path: '/note/test',
+  entityId: `entity-${generateId()}`,
+  isPinned: false,
+  isModified: false,
+  isPreview: false,
+  isDeleted: false,
+  openedAt: Date.now(),
+  lastAccessedAt: Date.now(),
+  ...overrides
+})
+
+const makeState = (tabs: Tab[]): TabSystemState => {
+  const group: TabGroup = {
+    id: 'g1',
+    tabs,
+    activeTabId: tabs[0]?.id ?? null,
+    isActive: true,
+    back: [],
+    forward: []
+  }
+  return {
+    tabGroups: { g1: group },
+    layout: { type: 'leaf', tabGroupId: 'g1' },
+    activeGroupId: 'g1',
+    settings: { restoreSessionOnStart: true, tabCloseButton: 'hover' }
+  }
+}
+
+describe('serializeTabState', () => {
+  it('never persists ephemeral virtual-note tabs (release notes) so they die with the session', () => {
+    const note = makeTab({ title: 'Real note' })
+    const releaseNotes = makeTab({
+      type: 'virtual-note',
+      title: 'memry note 2026.708.1',
+      entityId: undefined,
+      path: '/virtual/release-notes/2026.708.1',
+      viewState: { content: '<h2>Fixes</h2>', contentType: 'html' }
+    })
+
+    const persisted = serializeTabState(makeState([note, releaseNotes]))
+    const persistedTabs = persisted.tabGroups.g1?.tabs ?? []
+
+    expect(persistedTabs.map((tab) => tab.type)).toEqual(['note'])
+    expect(persistedTabs.some((tab) => tab.type === 'virtual-note')).toBe(false)
   })
 })

--- a/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/persistence/serialization.ts
@@ -39,9 +39,10 @@ export const serializeTabState = (state: TabSystemState): PersistedTabState => {
   const tabGroups: Record<string, PersistedTabGroup> = {}
 
   for (const [groupId, group] of Object.entries(state.tabGroups)) {
-    // Filter out preview tabs - they shouldn't persist
+    // Filter out preview tabs (transient) and virtual notes (ephemeral, in-memory
+    // only — e.g. release notes) so neither survives a restart.
     const persistedTabs: PersistedTab[] = group.tabs
-      .filter((tab) => !tab.isPreview)
+      .filter((tab) => !tab.isPreview && tab.type !== 'virtual-note')
       .map((tab) => ({
         id: tab.id,
         type: tab.type,

--- a/apps/desktop/src/renderer/src/contexts/tabs/types.ts
+++ b/apps/desktop/src/renderer/src/contexts/tabs/types.ts
@@ -30,6 +30,7 @@ export type TabType =
   | 'graph' // Knowledge graph visualization
   | 'agent-chat' // Agent conversation
   | 'canvas' // Spatial canvas (Excalidraw) — entity-based, one tab per canvas
+  | 'virtual-note' // Ephemeral, read-only in-memory note (e.g. release notes) — never persisted or synced
 
 /**
  * Singleton tab types - only one instance allowed

--- a/apps/desktop/src/renderer/src/hooks/use-app-updater.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-app-updater.ts
@@ -11,6 +11,7 @@ const DEFAULT_STATE: AppUpdateState = {
   releaseName: null,
   releaseDate: null,
   releaseNotes: null,
+  releaseNotesHtml: null,
   downloadProgressPercent: null,
   lastCheckedAt: null,
   error: null,

--- a/apps/desktop/src/renderer/src/pages/virtual-note.tsx
+++ b/apps/desktop/src/renderer/src/pages/virtual-note.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 import { ContentArea } from '@/components/note/content-area'
 
 interface VirtualNotePageProps {
-  /** Tab title, rendered as the note heading (e.g. "memry note 2026.708.1"). */
+  /** Tab title, rendered as the note heading (e.g. "MemryNote 2026.708.1"). */
   title: string
   /** Release-notes body to render read-only. */
   content: string

--- a/apps/desktop/src/renderer/src/pages/virtual-note.tsx
+++ b/apps/desktop/src/renderer/src/pages/virtual-note.tsx
@@ -1,0 +1,37 @@
+import { useCallback } from 'react'
+import { ContentArea } from '@/components/note/content-area'
+
+interface VirtualNotePageProps {
+  /** Tab title, rendered as the note heading (e.g. "memry note 2026.708.1"). */
+  title: string
+  /** Release-notes body to render read-only. */
+  content: string
+  /** How `content` should be parsed by the note renderer. */
+  contentType: 'html' | 'markdown'
+}
+
+/**
+ * Read-only, in-memory note page for the ephemeral "release notes" tab. Not backed by
+ * a vault note: it renders provided markdown/HTML directly (with clickable PR links)
+ * and is never editable, persisted, or synced.
+ */
+export function VirtualNotePage({ title, content, contentType }: VirtualNotePageProps) {
+  // External links (e.g. PR references) open in the user's browser, matching notes.
+  const handleLinkClick = useCallback((href: string) => {
+    window.open(href, '_blank', 'noopener,noreferrer')
+  }, [])
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-8 py-10">
+      <h1 className="mb-6 text-2xl font-semibold text-foreground">{title}</h1>
+      <ContentArea
+        initialContent={content}
+        contentType={contentType}
+        editable={false}
+        onLinkClick={handleLinkClick}
+      />
+    </div>
+  )
+}
+
+export default VirtualNotePage

--- a/packages/contracts/src/ipc-updater.ts
+++ b/packages/contracts/src/ipc-updater.ts
@@ -32,6 +32,13 @@ export interface AppUpdateState {
   releaseName: string | null
   releaseDate: string | null
   releaseNotes: string | null
+  /**
+   * The full, unstripped release-notes body (HTML from the update feed) used by the
+   * in-app read-only "release notes" tab. Unlike `releaseNotes` (plain text with the
+   * developer changelog stripped for the modal), this keeps the changelog + clickable
+   * PR references so the tab can link through to each PR.
+   */
+  releaseNotesHtml: string | null
   downloadProgressPercent: number | null
   lastCheckedAt: number | null
   error: string | null


### PR DESCRIPTION
Closes #817.

Three related improvements to the desktop auto-update flow, plus one latent-popup fix.

## 1. Short-interval background polling
- `AUTO_CHECK_INTERVAL_MS` 6h → **10 min**, so a release published while the app is open is picked up in-session. Timer stays `unref`'d and packaged-only (`app.isPackaged`); startup check + skip-version handling unchanged.

## 2. Silent background download when opted in
- Closes the known gap: enabling auto-download **while an update is already `available`** now starts the download immediately instead of leaving it behind the manual Download button (`setAutoDownloadEnabled` → `downloadUpdate()`).
- Update prompt now stays silent for **both** the `available` and `downloaded` phases when auto-download is on (previously only `downloaded`), so a silent background update never flashes a popup. Extracted as a pure, tested `shouldShowUpdatePrompt`.

## 3. Read-only "release notes" tab (ephemeral, non-vault)
- New `virtual-note` tab type: renders provided in-memory content instead of resolving a real vault note.
- Content = the **full** release-notes body (kept with clickable PR references / changelog links), carried to the renderer via a new `AppUpdateState.releaseNotesHtml` field. The existing modal keeps its stripped plain-text notes.
- Rendered read-only by reusing `ContentArea` (`contentType="html"`, `editable={false}`, `onLinkClick` → external browser); BlockNote's HTML import handles parsing/sanitization, so **no new dependency**.
- Title `memry note <version>`, no tags/properties. **Never written to the vault, never synced**, and excluded from tab persistence — closing removes it, `Cmd/Ctrl+Shift+T` reopens it from the in-memory closed-tab stack.
- Opens once per surfaced version (covers both the prompt and the silent-download paths) via a small opener mounted inside `TabProvider`.

## Decisions (issue's open questions)
- Interval: **10 min** (gentler on GitHub rate limits, still fast).
- Tab source: **full HTML `info.releaseNotes`** — the only runtime source with PR links (`release-notes/<ver>.md` isn't bundled).
- "Don't ask again" == the existing `autoDownload` toggle (no new flag).
- Tab opens in the **foreground** (rare — once per version per session).

## Verification
- `tsc` web + node: 0 errors · `ipc:check`: up to date · lint: clean
- Vitest: 128 passing across touched suites (updater 21, tabs, updater components 15), written test-first (RED → GREEN)
- `docs:impact --base origin/main --strict`: no docs-relevant changes

## Not covered
- Runtime E2E of the download/install path — the updater is `app.isPackaged`-gated, so it can't run in dev. Recommend a packaged smoke before release: publish a test release, confirm silent download (opted-in) vs prompt (opted-out) and that the read-only release-notes tab opens with clickable PR links.