### PR TITLE
fix(updater): stop embeddings utility process on quit (#805)

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -412,6 +412,15 @@ async function flushReadyWork() {
   await Promise.resolve()
 }
 
+// Drain microtasks until `predicate` holds (bounded by a safety cap), instead of
+// looping a hard-coded number of ticks that's coupled to the shutdown chain
+// length and breaks whenever an async step is added/removed.
+async function flushUntil(predicate: () => boolean, maxTicks = 100): Promise<void> {
+  for (let i = 0; i < maxTicks && !predicate(); i++) {
+    await Promise.resolve()
+  }
+}
+
 describe('main index phase2 exports', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -1612,9 +1621,7 @@ describe('main index phase2 exports', () => {
       ([event]) => event === 'app:flush-done'
     )?.[1] as () => void
     flushHandler()
-    for (let i = 0; i < 40; i++) {
-      await Promise.resolve()
-    }
+    await flushUntil(() => vi.mocked(app.exit).mock.calls.length > 0)
 
     expect(app.exit).toHaveBeenCalledWith(1)
   })

--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -49,6 +49,7 @@ const getCrdtProviderMock = vi.fn(() => ({
   getDoc: getProviderDocMock
 }))
 const stopSyncRuntimeMock = vi.fn(async () => undefined)
+const stopEmbeddingModelMock = vi.fn(async () => undefined)
 const startGoogleCalendarSyncRunnerMock = vi.fn(async () => undefined)
 const stopGoogleCalendarSyncRunnerMock = vi.fn()
 const triggerGoogleCalendarSyncNowMock = vi.fn()
@@ -204,6 +205,13 @@ vi.mock('./inbox/review-scheduler', () => ({
 
 vi.mock('./inbox/voice-model', () => ({
   stopVoiceModel: vi.fn(async () => undefined)
+}))
+
+// Keep the real module (other importers use initEmbeddingModel/getModelInfo/etc.);
+// spy only stopEmbeddingModel to assert the embeddings utilityProcess is stopped on quit (#805).
+vi.mock('./lib/embeddings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./lib/embeddings')>()),
+  stopEmbeddingModel: stopEmbeddingModelMock
 }))
 
 vi.mock('./telemetry/runtime', () => ({
@@ -1445,6 +1453,9 @@ describe('main index phase2 exports', () => {
 
     expect(preventDefault).toHaveBeenCalled()
     expect(disposeTelemetryRuntimeMock).toHaveBeenCalled()
+    // Embeddings utilityProcess must be stopped on quit or it lingers as a
+    // Memrynote.exe and blocks the Windows NSIS update install (#805).
+    expect(stopEmbeddingModelMock).toHaveBeenCalled()
     expect(stopSyncRuntimeMock).toHaveBeenCalled()
     expect(closeVaultMock).toHaveBeenCalled()
   })
@@ -1601,7 +1612,7 @@ describe('main index phase2 exports', () => {
       ([event]) => event === 'app:flush-done'
     )?.[1] as () => void
     flushHandler()
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < 40; i++) {
       await Promise.resolve()
     }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -39,6 +39,7 @@ import { configureSessionPermissions } from './session-permissions'
 import { startSnoozeScheduler, stopSnoozeScheduler, checkDueItemsOnStartup } from './inbox/snooze'
 import { stopVoiceModel } from './inbox/voice-model'
 import { stopImageProcessing } from './image-processing/bridge'
+import { stopEmbeddingModel } from './lib/embeddings'
 import { startReminderScheduler, stopReminderScheduler } from './lib/reminders'
 import { startInboxReviewScheduler, stopInboxReviewScheduler } from './inbox/review-scheduler'
 import { disposeTelemetryRuntime, initializeTelemetryRuntime } from './telemetry/runtime'
@@ -1690,6 +1691,14 @@ app.on('before-quit', (event) => {
     .then(() => {
       shutdownLog.info('stopping image processing utility...')
       return stopImageProcessing()
+    })
+    .then(() => {
+      // Terminate the embeddings utilityProcess explicitly. On Windows it runs
+      // as the app binary (Memrynote.exe); if left to its 30s idle self-exit it
+      // can outlive the NSIS CHECK_APP_RUNNING window and block the update
+      // install ("MemryNote cannot be closed", #805).
+      shutdownLog.info('stopping embeddings utility...')
+      return stopEmbeddingModel()
     })
     .then(async () => {
       shutdownLog.info('stopping active heartbeat...')


### PR DESCRIPTION
## Summary

Fixes #805 — Windows in-app updates refused to install with "MemryNote cannot be closed," even when no window was open (reported on Win10 v2026.718.3; part of #795).

The `before-quit` shutdown chain (`apps/desktop/src/main/index.ts`) stopped the capture server, voice model, image processing, sync runtime and vault — but never terminated the **embeddings** `utilityProcess`. That worker only self-exits after a 30s idle timer, and on Windows `utilityProcess.fork` runs as the app binary (`Memrynote.exe`). At "Restart to install," the lingering `Memrynote.exe` could outlive the NSIS `CHECK_APP_RUNNING` retry window, so the installer refused the update and the user had to uninstall to update.

The fix awaits `stopEmbeddingModel()` immediately after `stopImageProcessing()`, so every `utilityProcess` child is stopped before `performQuitAndInstall()` hands off to the installer. `stopEmbeddingModel()` already existed (idempotent, graceful shutdown message + 3s force-kill fallback) — it simply had no production caller. This mirrors the already-wired `stopVoiceModel` / `stopImageProcessing` steps exactly.

Scope is the primary fix only. The issue also floated a defensive Windows process-kill guard mirroring the darwin `updater-install-guard`, but that guard is currently dormant — `writePendingInstallMarker()` has zero production callers, so it never fires even on macOS. Mirroring dead code would add risk without benefit; noted for a possible separate follow-up.

## Release note
none

## Test plan

- `pnpm --filter @memry/desktop test:main` — full main suite green (3993 passed, 1 skipped), including a new regression test asserting the embeddings worker is stopped during graceful `before-quit` cleanup (added to `index.phase2.test.ts`).
- The regression test was verified red before the wiring and green after (TDD).
- `pnpm --filter @memry/desktop typecheck:node` — clean.
- `eslint` on `index.ts` — clean. `git diff --check` — clean.
- **Not verifiable on macOS:** the end-to-end Windows installer path (update installs without the "cannot be closed" prompt; no `Memrynote.exe` lingers in Task Manager after quit) needs a packaged Windows build — please confirm via CI or a manual Windows smoke.