### PR TITLE
fix(vault): defer embeddings out of the index pass so vault-open never hangs (#803)

### DIFF
--- a/apps/desktop/src/main/ipc/settings-handlers.inbox.test.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.inbox.test.ts
@@ -57,7 +57,8 @@ vi.mock('../lib/embeddings', () => ({
   initEmbeddingModel: vi.fn(),
   getModelInfo: vi.fn(),
   isModelLoaded: vi.fn(),
-  isModelLoading: vi.fn()
+  isModelLoading: vi.fn(),
+  resetEmbeddingModelFailure: vi.fn()
 }))
 
 vi.mock('../projections', () => ({

--- a/apps/desktop/src/main/ipc/settings-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.test.ts
@@ -88,7 +88,8 @@ vi.mock('../lib/embeddings', () => ({
   initEmbeddingModel: vi.fn(),
   getModelInfo: vi.fn(),
   isModelLoaded: vi.fn(),
-  isModelLoading: vi.fn()
+  isModelLoading: vi.fn(),
+  resetEmbeddingModelFailure: vi.fn()
 }))
 
 vi.mock('../telemetry/track', () => ({

--- a/apps/desktop/src/main/ipc/settings-handlers.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.ts
@@ -41,7 +41,13 @@ import { createLogger } from '../lib/logger'
 import { getDatabase } from '../database'
 import { getSetting, setSetting, deleteSetting } from '../settings/settings-store'
 import { withErrorHandler } from './validate'
-import { initEmbeddingModel, getModelInfo, isModelLoaded, isModelLoading } from '../lib/embeddings'
+import {
+  initEmbeddingModel,
+  getModelInfo,
+  isModelLoaded,
+  isModelLoading,
+  resetEmbeddingModelFailure
+} from '../lib/embeddings'
 import { rebuildProjections } from '../projections'
 import { writePreferences, PORTABLE_GENERAL_FIELDS } from '../vault/vault-preferences'
 import { getCurrentVaultPath, getDefaultVaultPath, getVaults, setDefaultVaultPath } from '../store'
@@ -477,6 +483,11 @@ export function registerSettingsHandlers(): void {
 
       if (settings.enabled !== undefined) {
         setSetting(db, SETTINGS_KEYS.AI_ENABLED, settings.enabled ? 'true' : 'false')
+        // Re-enabling AI is an explicit retry: clear the model-load circuit
+        // breaker so a previously failed/stalled load is attempted again (#803).
+        if (settings.enabled) {
+          resetEmbeddingModelFailure()
+        }
       }
 
       // Emit settings changed event
@@ -657,6 +668,8 @@ export function registerSettingsHandlers(): void {
         return { success: false, error: 'Model is already loading' }
       }
 
+      // Manual load is an explicit retry — clear the circuit breaker first (#803).
+      resetEmbeddingModelFailure()
       const success = await initEmbeddingModel()
       if (success) {
         return { success: true }
@@ -671,6 +684,8 @@ export function registerSettingsHandlers(): void {
   ipcMain.handle(
     SettingsChannels.invoke.REINDEX_EMBEDDINGS,
     withErrorHandler(async () => {
+      // Reindex is an explicit retry — clear the circuit breaker first (#803).
+      resetEmbeddingModelFailure()
       const result = await rebuildProjections(['embedding'])
       return result.embedding as {
         success: boolean

--- a/apps/desktop/src/main/lib/embeddings.test.ts
+++ b/apps/desktop/src/main/lib/embeddings.test.ts
@@ -71,6 +71,7 @@ import {
   initEmbeddingModel,
   isModelLoaded,
   isModelLoading,
+  resetEmbeddingModelFailure,
   stopEmbeddingModel,
   unloadModel
 } from './embeddings'
@@ -169,6 +170,38 @@ describe('embeddings', () => {
 
     await expect(loadPromise).resolves.toBe(false)
     expect(getModelInfo().error).toBe('load failed')
+  })
+
+  it('short-circuits repeat load attempts after a failure until reset', async () => {
+    // First load fails.
+    const first = initEmbeddingModel()
+    mockUtilityProcessInstance.simulateMessage({ type: 'ready' })
+    await vi.waitFor(() => {
+      expect(mockUtilityProcessInstance.postMessage).toHaveBeenCalledTimes(1)
+    })
+    const worker = mockUtilityProcessInstance
+    const req = worker.postMessage.mock.calls[0]?.[0] as { requestId: string }
+    worker.simulateMessage({ type: 'error', requestId: req.requestId, error: 'load failed' })
+    await expect(first).resolves.toBe(false)
+    expect(mockFork).toHaveBeenCalledOnce()
+
+    // Circuit breaker latched: the next attempt returns false without forking a
+    // fresh worker or sending another load-model request — this is the per-note
+    // re-download loop that made vault-open hang (#803).
+    await expect(initEmbeddingModel()).resolves.toBe(false)
+    expect(mockFork).toHaveBeenCalledOnce()
+    expect(worker.postMessage).toHaveBeenCalledTimes(1)
+
+    // Reset re-enables loading; the next attempt issues a fresh load-model request.
+    resetEmbeddingModelFailure()
+    const third = initEmbeddingModel()
+    await vi.waitFor(() => {
+      expect(worker.postMessage).toHaveBeenCalledTimes(2)
+    })
+    const req3 = worker.postMessage.mock.calls[1]?.[0] as { requestId: string }
+    worker.simulateMessage({ type: 'load-model-result', requestId: req3.requestId })
+    await expect(third).resolves.toBe(true)
+    expect(isModelLoaded()).toBe(true)
   })
 
   it('tracks loading state and unloads the model', async () => {

--- a/apps/desktop/src/main/lib/embeddings.ts
+++ b/apps/desktop/src/main/lib/embeddings.ts
@@ -90,6 +90,12 @@ class EmbeddingModelBridge {
   private requestCounter = 0
   private loaded = false
   private loading = false
+  // Circuit breaker: latched when a model load fails (download stall, worker
+  // crash, timeout). While set, loadModel() short-circuits instead of re-forking
+  // the worker and re-attempting the ~23MB download per note — the loop that made
+  // vault-open hang indefinitely (#803). Cleared on a successful load, on reset(),
+  // and when AI is re-enabled (resetEmbeddingModelFailure).
+  private loadFailed = false
   private error: string | null = null
   private shuttingDown = false
   private idleShutdownTimer: ReturnType<typeof setTimeout> | null = null
@@ -119,6 +125,13 @@ class EmbeddingModelBridge {
   }
 
   async loadModel(): Promise<boolean> {
+    // A previous load already failed this session — do not re-fork the worker or
+    // re-attempt the download. Recover via resetEmbeddingModelFailure() (AI
+    // re-enable), unloadModel(), or app restart.
+    if (this.loadFailed) {
+      return false
+    }
+
     try {
       this.loading = !this.loaded
       await this.start()
@@ -131,22 +144,26 @@ class EmbeddingModelBridge {
       if (response.type === 'error') {
         this.error = response.error
         this.loading = false
+        this.loadFailed = true
         return false
       }
 
       if (response.type !== 'load-model-result') {
         this.error = `Unexpected response type: ${response.type}`
         this.loading = false
+        this.loadFailed = true
         return false
       }
 
       this.loaded = true
       this.loading = false
+      this.loadFailed = false
       this.error = null
       return true
     } catch (error) {
       this.loading = false
       this.error = error instanceof Error ? error.message : String(error)
+      this.loadFailed = true
       return false
     }
   }
@@ -257,8 +274,13 @@ class EmbeddingModelBridge {
     this.rejectAll(new Error('Embedding utility reset'))
     this.loaded = false
     this.loading = false
+    this.loadFailed = false
     this.error = null
     this.shuttingDown = false
+  }
+
+  clearLoadFailure(): void {
+    this.loadFailed = false
   }
 
   private async start(): Promise<void> {
@@ -601,4 +623,12 @@ export function unloadModel(): void {
 
 export async function stopEmbeddingModel(): Promise<void> {
   await bridge.stop()
+}
+
+/**
+ * Clear the model-load circuit breaker so the next embedding attempt retries a
+ * fresh load. Call when the user re-enables AI after a failed/stalled load (#803).
+ */
+export function resetEmbeddingModelFailure(): void {
+  bridge.clearLoadFailure()
 }

--- a/apps/desktop/src/main/projections/projectors/embedding-projector.test.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.test.ts
@@ -162,6 +162,52 @@ describe('embedding projector', () => {
     expect(readFile).toHaveBeenCalledWith('/vault/notes/two.md', 'utf-8')
   })
 
+  it('retains deferred ids when the model fails to load, then embeds them on a later reconcile', async () => {
+    const run = vi.fn()
+    // note-1 already has a (stale) vector, so it is only in the work list because
+    // it was deferred — the missing-vector filter alone would not re-catch it.
+    const prepare = vi.fn(() => ({ run, all: () => [{ note_id: 'note-1' }] }))
+    getRawIndexDatabase.mockReturnValue({ prepare })
+    getIndexDatabase.mockReturnValue({
+      all: vi.fn(() => [{ id: 'note-1', path: 'notes/one.md', title: 'One' }])
+    })
+    getSetting.mockImplementation((_db: unknown, key: string) =>
+      key === 'ai.embeddingInputVersion' ? String(EMBEDDING_INPUT_VERSION) : 'true'
+    )
+    readFile.mockResolvedValue('raw markdown')
+    parseNote.mockReturnValue({ content: 'parsed markdown long enough' })
+
+    let indexing = true
+    const projector = createEmbeddingProjector(
+      () => '/vault',
+      () => indexing
+    )
+
+    // Defer note-1 during indexing.
+    await projector.project({
+      type: 'note.upserted',
+      note: {
+        kind: 'markdown',
+        noteId: 'note-1',
+        title: 'One',
+        parsedContent: 'body one long enough'
+      }
+    } as never)
+    indexing = false
+
+    // First reconcile: the model won't load → the deferred id must be kept, not embedded.
+    isModelLoaded.mockReturnValue(false)
+    initEmbeddingModel.mockResolvedValueOnce(false)
+    await projector.reconcile()
+    expect(generateEmbedding).not.toHaveBeenCalled()
+
+    // Second reconcile: the model loads → the retained deferred id is embedded even
+    // though it still has a stale vector row.
+    initEmbeddingModel.mockResolvedValue(true)
+    await projector.reconcile()
+    expect(generateEmbedding).toHaveBeenCalledTimes(1)
+  })
+
   it('handles note events by storing, deleting, or skipping embeddings', async () => {
     const run = vi.fn()
     const prepare = vi.fn(() => ({ run }))

--- a/apps/desktop/src/main/projections/projectors/embedding-projector.test.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.test.ts
@@ -83,7 +83,9 @@ describe('embedding projector', () => {
 
   it('reconcile removes embeddings for notes that no longer exist', async () => {
     const run = vi.fn()
-    const prepare = vi.fn(() => ({ run }))
+    // note-1 already has a vector, so the backfill finds no work and only the
+    // orphan-prune DELETE runs.
+    const prepare = vi.fn(() => ({ run, all: () => [{ note_id: 'note-1' }] }))
 
     // Embedding input version already current → skip the migration rebuild and
     // exercise only the stale-row reconcile delete.
@@ -102,6 +104,62 @@ describe('embedding projector', () => {
 
     expect(prepare).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM vec_notes'))
     expect(run).toHaveBeenCalledTimes(1)
+    // note-1 already embedded → no re-embed
+    expect(generateEmbedding).not.toHaveBeenCalled()
+  })
+
+  it('defers embedding while indexing and backfills the deferred notes on reconcile', async () => {
+    const run = vi.fn()
+    const prepare = vi.fn(() => ({ run, all: () => [] as Array<{ note_id: string }> }))
+    getRawIndexDatabase.mockReturnValue({ prepare })
+    getIndexDatabase.mockReturnValue({
+      all: vi.fn(() => [
+        { id: 'note-1', path: 'notes/one.md', title: 'One' },
+        { id: 'note-2', path: 'notes/two.md', title: 'Two' }
+      ])
+    })
+    getSetting.mockImplementation((_db: unknown, key: string) =>
+      key === 'ai.embeddingInputVersion' ? String(EMBEDDING_INPUT_VERSION) : 'true'
+    )
+    readFile.mockResolvedValue('raw markdown')
+    parseNote.mockReturnValue({ content: 'parsed markdown long enough' })
+
+    let indexing = true
+    const projector = createEmbeddingProjector(
+      () => '/vault',
+      () => indexing
+    )
+
+    // While indexing, project() must NOT load the model or embed inline.
+    await projector.project({
+      type: 'note.upserted',
+      note: {
+        kind: 'markdown',
+        noteId: 'note-1',
+        title: 'One',
+        parsedContent: 'body one long enough'
+      }
+    } as never)
+    await projector.project({
+      type: 'note.upserted',
+      note: {
+        kind: 'markdown',
+        noteId: 'note-2',
+        title: 'Two',
+        parsedContent: 'body two long enough'
+      }
+    } as never)
+
+    expect(generateEmbedding).not.toHaveBeenCalled()
+    expect(initEmbeddingModel).not.toHaveBeenCalled()
+
+    // After indexing, the backgrounded reconcile embeds the deferred notes.
+    indexing = false
+    await projector.reconcile()
+
+    expect(generateEmbedding).toHaveBeenCalledTimes(2)
+    expect(readFile).toHaveBeenCalledWith('/vault/notes/one.md', 'utf-8')
+    expect(readFile).toHaveBeenCalledWith('/vault/notes/two.md', 'utf-8')
   })
 
   it('handles note events by storing, deleting, or skipping embeddings', async () => {

--- a/apps/desktop/src/main/projections/projectors/embedding-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.ts
@@ -78,7 +78,50 @@ async function updateEmbedding(noteId: string, content: string): Promise<boolean
   return true
 }
 
-export function createEmbeddingProjector(getVaultPath: () => string | null): ProjectionProjector {
+export function createEmbeddingProjector(
+  getVaultPath: () => string | null,
+  isIndexing: () => boolean = () => false
+): ProjectionProjector {
+  // Note ids whose embedding was deferred because it arrived during the initial
+  // index pass (see project()). Instance-scoped so it starts empty per open; the
+  // backgrounded reconcile drains it after the vault is open (#803).
+  const pendingEmbedding = new Set<string>()
+
+  // Embed a list of markdown notes from disk. Shared by the full rebuild and the
+  // reconcile backfill; assumes the model is already loaded and vaultPath is set.
+  const embedNotes = async (
+    vaultPath: string,
+    notes: Array<{ id: string; path: string; title: string | null }>
+  ): Promise<{ computed: number; skipped: number }> => {
+    let computed = 0
+    let skipped = 0
+
+    for (let i = 0; i < notes.length; i++) {
+      const note = notes[i]
+      try {
+        const absolutePath = path.join(vaultPath, note.path)
+        const raw = await fs.readFile(absolutePath, 'utf-8')
+        const parsed = parseNote(raw, note.path)
+
+        const input = buildEmbeddingInput({ title: note.title, content: parsed.content })
+        if (!(await updateEmbedding(note.id, input))) {
+          skipped++
+        } else {
+          computed++
+        }
+      } catch (error) {
+        skipped++
+        logger.warn('Failed to rebuild note embedding', { noteId: note.id, error })
+      }
+
+      if ((i + 1) % 5 === 0 || i === notes.length - 1) {
+        emitProgress(i + 1, notes.length, 'embedding')
+      }
+    }
+
+    return { computed, skipped }
+  }
+
   const runRebuild = async (): Promise<{
     success: boolean
     computed: number
@@ -127,31 +170,7 @@ export function createEmbeddingProjector(getVaultPath: () => string | null): Pro
     rawDb.prepare('DELETE FROM vec_notes').run()
     emitProgress(0, notes.length, 'embedding')
 
-    let computed = 0
-    let skipped = 0
-
-    for (let i = 0; i < notes.length; i++) {
-      const note = notes[i]
-      try {
-        const absolutePath = path.join(vaultPath, note.path)
-        const raw = await fs.readFile(absolutePath, 'utf-8')
-        const parsed = parseNote(raw, note.path)
-
-        const input = buildEmbeddingInput({ title: note.title, content: parsed.content })
-        if (!(await updateEmbedding(note.id, input))) {
-          skipped++
-        } else {
-          computed++
-        }
-      } catch (error) {
-        skipped++
-        logger.warn('Failed to rebuild note embedding', { noteId: note.id, error })
-      }
-
-      if ((i + 1) % 5 === 0 || i === notes.length - 1) {
-        emitProgress(i + 1, notes.length, 'embedding')
-      }
-    }
+    const { computed, skipped } = await embedNotes(vaultPath, notes)
 
     emitProgress(notes.length, notes.length, 'complete')
     return { success: true, computed, skipped }
@@ -167,6 +186,7 @@ export function createEmbeddingProjector(getVaultPath: () => string | null): Pro
     async project(event: ProjectionEvent): Promise<void> {
       if (event.type === 'note.deleted') {
         deleteNoteEmbedding(event.noteId)
+        pendingEmbedding.delete(event.noteId)
         return
       }
 
@@ -178,6 +198,17 @@ export function createEmbeddingProjector(getVaultPath: () => string | null): Pro
 
       if (note.kind !== 'markdown') {
         deleteNoteEmbedding(note.noteId)
+        pendingEmbedding.delete(note.noteId)
+        return
+      }
+
+      // During the initial index pass, embedding is deferred: indexVault awaits
+      // this projector per file (before the vault is marked open), and loading the
+      // ~23MB model + running CPU inference here is what stranded vault-open for
+      // minutes. Record the id and let the backgrounded reconcile embed it after
+      // isOpen. Only fires while isIndexing; live edits still embed inline. (#803)
+      if (isIndexing()) {
+        pendingEmbedding.add(note.noteId)
         return
       }
 
@@ -213,6 +244,7 @@ export function createEmbeddingProjector(getVaultPath: () => string | null): Pro
       const rawDb = getRawIndexDatabase()
       const indexDb = getIndexDatabase()
 
+      // Prune vectors for notes that no longer exist.
       rawDb
         .prepare(
           `
@@ -226,13 +258,54 @@ export function createEmbeddingProjector(getVaultPath: () => string | null): Pro
         )
         .run()
 
-      const existingNoteIds = indexDb.all<{ id: string }>(sql`
-        SELECT id
+      const markdownNotes = indexDb.all<{
+        id: string
+        path: string
+        title: string | null
+      }>(sql`
+        SELECT id, path, title
         FROM note_cache
         WHERE COALESCE(file_type, 'markdown') = 'markdown'
       `)
 
-      emitProgress(existingNoteIds.length, existingNoteIds.length, 'complete')
+      const vaultPath = getVaultPath()
+      if (!isAIEnabled() || !vaultPath) {
+        pendingEmbedding.clear()
+        emitProgress(markdownNotes.length, markdownNotes.length, 'complete')
+        return
+      }
+
+      // Backfill: embed markdown notes with no vector yet (freshly imported notes
+      // whose inline embedding was deferred during indexing) plus any deferred /
+      // edited notes tracked this session. Runs in the background after isOpen, so
+      // a slow or failed model load never blocks vault-open (#803). Loading the
+      // model is bounded to when there is actually work to do.
+      const embeddedIds = new Set(
+        (rawDb.prepare('SELECT note_id FROM vec_notes').all() as Array<{ note_id: string }>).map(
+          (row) => row.note_id
+        )
+      )
+      const workList = markdownNotes.filter(
+        (note) => !embeddedIds.has(note.id) || pendingEmbedding.has(note.id)
+      )
+      pendingEmbedding.clear()
+
+      if (workList.length === 0) {
+        emitProgress(markdownNotes.length, markdownNotes.length, 'complete')
+        return
+      }
+
+      if (!isModelLoaded()) {
+        const loaded = await initEmbeddingModel()
+        if (!loaded) {
+          emitProgress(markdownNotes.length, markdownNotes.length, 'complete')
+          return
+        }
+      }
+
+      emitProgress(0, workList.length, 'embedding')
+      await embedNotes(vaultPath, workList)
+      emitProgress(workList.length, workList.length, 'complete')
     }
   }
 }

--- a/apps/desktop/src/main/projections/projectors/embedding-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/embedding-projector.ts
@@ -270,7 +270,8 @@ export function createEmbeddingProjector(
 
       const vaultPath = getVaultPath()
       if (!isAIEnabled() || !vaultPath) {
-        pendingEmbedding.clear()
+        // Deferred ids are left intact — nothing was embedded, so a later
+        // reconcile (or a full rebuild once AI is enabled) can still pick them up.
         emitProgress(markdownNotes.length, markdownNotes.length, 'complete')
         return
       }
@@ -288,9 +289,9 @@ export function createEmbeddingProjector(
       const workList = markdownNotes.filter(
         (note) => !embeddedIds.has(note.id) || pendingEmbedding.has(note.id)
       )
-      pendingEmbedding.clear()
 
       if (workList.length === 0) {
+        pendingEmbedding.clear()
         emitProgress(markdownNotes.length, markdownNotes.length, 'complete')
         return
       }
@@ -298,6 +299,9 @@ export function createEmbeddingProjector(
       if (!isModelLoaded()) {
         const loaded = await initEmbeddingModel()
         if (!loaded) {
+          // Keep the deferred ids: dropping them here would let an edited note
+          // (which still has a stale vector, so the missing-vector filter above
+          // won't re-catch it) keep that stale embedding after a failed load.
           emitProgress(markdownNotes.length, markdownNotes.length, 'complete')
           return
         }
@@ -305,6 +309,7 @@ export function createEmbeddingProjector(
 
       emitProgress(0, workList.length, 'embedding')
       await embedNotes(vaultPath, workList)
+      pendingEmbedding.clear()
       emitProgress(workList.length, workList.length, 'complete')
     }
   }

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -274,7 +274,10 @@ async function openVault(vaultPath: string): Promise<void> {
   startProjectionRuntime([
     createNoteDerivedStateProjector(() => vaultPath),
     createSearchProjector(() => vaultPath),
-    createEmbeddingProjector(() => vaultPath),
+    createEmbeddingProjector(
+      () => vaultPath,
+      () => currentStatus.isIndexing
+    ),
     createInboxStatsProjector()
   ])
 
@@ -336,12 +339,13 @@ async function openVault(vaultPath: string): Promise<void> {
   // linked) vault that pull writes notes/journals to disk via the current vault
   // path — which throws "No vault is currently open" if the status isn't set yet.
   //
-  // Vault-open must NOT wait on reconcileProjections(): the renderer only needs
-  // the index (built above) to render, but the embedding projector's reconcile
-  // loads the embedding model / backfills vectors, which takes ~18s on the first
-  // open after an embedding-version change — and on every fresh vault, since the
-  // stored version starts null. Blocking here stranded the app on the vault
-  // picker for that whole time. Reconcile in the background after opening.
+  // Vault-open must NOT wait on embeddings: the renderer only needs the index
+  // (built above) to render. Embedding is deferred out of the indexing pass —
+  // the embedding projector no-ops while isIndexing and records the note ids —
+  // so the ~23MB model load + per-note CPU inference never runs on the blocking
+  // path (this stranded imported vaults on the picker for minutes; #803). The
+  // backgrounded reconcileProjections() below embeds those deferred/missing
+  // notes after isOpen; a slow or failed model load can no longer block open.
   updateStatus({
     isOpen: true,
     path: vaultPath,

--- a/apps/docs/src/user-guide/ai/embeddings-search.md
+++ b/apps/docs/src/user-guide/ai/embeddings-search.md
@@ -35,10 +35,14 @@ The status line shows:
 
 You can **Unload** the model from settings to free memory; reload as needed.
 
-memrynote does not load the embedding model just because a vault opens. Semantic surfaces such as
-search, inbox linked-note suggestions, related notes, and reindexing start the local model on first
-use. The model runs in a separate utility process and shuts down after an idle period so regular note
-reading does not keep the embedding runtime resident forever.
+Opening a vault never blocks on embeddings. When a vault has notes that still need embedding — for
+example the first open after importing a vault — memrynote embeds them in the **background** after the
+vault is already open, so a large vault (or a slow or failed model download) can never hold up opening.
+
+Beyond that, the model is loaded lazily: semantic surfaces such as search, inbox linked-note
+suggestions, related notes, and reindexing start the local model on first use. The model runs in a
+separate utility process and shuts down after an idle period, so regular note reading does not keep the
+embedding runtime resident forever.
 
 ## Model Size
 


### PR DESCRIPTION
Fixes #803.

## Problem

Opening a freshly imported Obsidian vault could hang indefinitely (>5 min). `openVault` awaited `indexVault()` **before** marking the vault open, and each markdown file's `note.upserted` ran the embedding projector **inline** — loading the ~23MB model (5-minute request timeout) plus per-note CPU inference, all on the blocking path. On a failed or stalled load, `isModelLoaded()` stayed false, so every subsequent note re-forked the worker and re-attempted the download, making the hang effectively permanent. (Dotfolders like `.git`/`.github` were already excluded and were **not** the cause.)

This extends the earlier fix that backgrounded `reconcileProjections()`; that covered the *reconcile* path, while the per-note `project()` path inside `indexVault` remained a separate, still-inline blocker.

## Fix

Three coordinated changes — additive, no schema/migration, backward-compatible:

1. **Defer during indexing.** `createEmbeddingProjector` now takes an `isIndexing` accessor (`vault/index.ts` passes `() => currentStatus.isIndexing`). While indexing, `project()` records markdown note ids in an instance-scoped `pendingEmbedding` set instead of loading the model. Live edits still embed inline. The vault opens at index speed.

2. **Backfill in the background reconcile.** The steady-state `reconcile()` branch previously only pruned orphaned vectors; it now also embeds notes with no vector yet plus any deferred/edited ids (shared `embedNotes` helper, model loaded only when there is work). Runs after `isOpen` via the already-backgrounded `reconcileProjections()`, so embeddings are produced just after open instead of before it — nothing loses its embedding.

3. **Circuit breaker.** `EmbeddingModelBridge.loadFailed` short-circuits repeat loads after a failure (no re-fork / re-download), cleared on success, on `reset()`, and via the new `resetEmbeddingModelFailure()` wired into the AI re-enable / load-model / reindex retry paths. The 5-minute timeout is kept deliberately so slow-but-valid first downloads still complete — the breaker plus backgrounding remove the user-facing harm.

## Acceptance

A freshly imported vault (any size, AI on) opens promptly; embeddings continue in the background, and a failed or stalled model load can no longer block or freeze the open.

## Verification

- `test:main` — 3991 passing, including new projector coverage (defer-then-backfill) and embeddings coverage (breaker short-circuits, then reset re-enables).
- `typecheck:node`, ESLint, `docs:impact --strict`, and `docs:build` all clean.

## Reviewer notes

- The `embeddings-search.md` doc paragraph on model lifecycle was updated to state that opening never blocks on embeddings.
- Adding the `resetEmbeddingModelFailure` export required listing it in the two `settings-handlers` test `vi.mock('../lib/embeddings')` factories.
- The related updater "cannot be closed" issue (#805), which shares the embeddings-worker-lifecycle root, is intentionally out of scope here (tracked separately).