### PR TITLE
fix(comments): keep review flyout open when editing a comment

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/review/review-badge-layer.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-badge-layer.test.tsx
@@ -251,6 +251,30 @@ describe('ReviewBadgeLayer', () => {
     expect(document.querySelector('.critic-review-flyout')).toBeNull()
   })
 
+  it('does not dismiss the flyout when a pointerdown target detaches mid-dispatch', async () => {
+    renderLayer(createReview())
+    await findBadges()
+
+    const span = editorContainer.querySelector('[data-critic-mark-id="comment-1"]') as HTMLElement
+    fireEvent.click(span)
+
+    const flyout = document.querySelector<HTMLElement>('.critic-review-flyout') as HTMLElement
+    expect(flyout).not.toBeNull()
+    const pencil = within(flyout).getByLabelText('comments.edit')
+
+    // In the app the pencil's onPointerDown flips the card into edit mode, which
+    // React flushes synchronously, unmounting the pencil before this pointerdown
+    // reaches the document-level dismiss listener. RTL's act() batching hides that
+    // timing, so we recreate the same condition explicitly: detach the target mid
+    // dispatch, then let the event keep bubbling to the dismiss handler. Without
+    // the isConnected guard, target.closest('.critic-review-flyout') misses on the
+    // detached node and the flyout is wrongly dismissed.
+    pencil.addEventListener('pointerdown', () => pencil.remove())
+    fireEvent.pointerDown(pencil)
+
+    expect(document.querySelector('.critic-review-flyout')).not.toBeNull()
+  })
+
   it('hosts the comment composer in a flyout under the drafted selection', async () => {
     const review = createReview({
       activeDraft: { text: 'selected text' },

--- a/apps/desktop/src/renderer/src/components/note/review/review-badge-layer.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-badge-layer.tsx
@@ -172,6 +172,11 @@ export function ReviewBadgeLayer({
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as HTMLElement | null
       if (target) {
+        // A synchronous re-render (the pencil switching a card into edit mode)
+        // can detach event.target before this document-level listener runs. A
+        // detached node was inside the flyout, so don't treat it as an outside
+        // press — otherwise editing a comment would dismiss the flyout.
+        if (!target.isConnected) return
         if (target.closest('.critic-review-flyout')) return
         if (target.closest('.critic-review-badge')) return
         const span = target.closest('[data-critic-mark-id]')


### PR DESCRIPTION
## Problem

Reported by Aurelie Kabore (Windows 10, v2026.718.3). Part of #795.

In the **narrow-window flyout** review surface, clicking the pen to edit a comment *closes* the flyout; you then have to reopen the badge, and it shows the card already in edit mode. The wide-window **rail** surface is fine.

## Root cause

The pencil fires on `onPointerDown` and synchronously flips the card into edit mode. Because `pointerdown` is a React *discrete* event, React flushes that state update immediately, swapping the card's read-view for the composer and **unmounting the pencil node mid-dispatch**. The same native `pointerdown` keeps bubbling to the flyout's document-level dismiss listener, whose `event.target` is now the *detached* pencil. `target.closest('.critic-review-flyout')` returns `null` for a detached node, every guard misses, and `setPanel(null)` closes the flyout. `editingMarkId` is separate state that survives, so reopening the badge shows edit mode.

The rail has no document-level dismiss listener, so it was never affected.

## Fix

Guard the dismiss handler against detached targets — a node removed during the same dispatch was inside the flyout, so it is not an outside press:

```tsx
if (!target.isConnected) return
```

`isConnected` over `composedPath()` (both viable): one-line, reads clearly, and behaves reliably under jsdom for the regression test. No change to the review card or the rail.

## Test

Added a regression test to `review-badge-layer.test.tsx`.

Note: RTL's `fireEvent` wraps dispatch in `act()`, which **batches** React's re-render, so a naïve `fireEvent.pointerDown` on the pencil passes even with the bug present (false confidence). The test instead recreates the real condition deterministically — detaches the target mid-dispatch, then lets the event bubble to the dismiss handler. Verified via mutation: it **fails** when the guard is neutralized (`expected null not to be null` = flyout dismissed) and **passes** with it.

## Verification

- Flyout + rail test files: 36 pass, 0 fail
- `typecheck:web` clean · ESLint clean (no new issues) · docs gate: no docs needed

## Acceptance (#796)

- [x] Pen on an open comment in the narrow-window flyout switches to inline edit without closing the flyout
- [x] Rail behavior unchanged
- [x] Regression test added for the flyout path

Closes #796