### PR TITLE
fix(comments): keep just-added comment through stale resync during save debounce

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/review/review-ui.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-ui.test.tsx
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { act, fireEvent, render, renderHook, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { serializeCriticMarkup } from '@memry/shared'
 import { ReviewRail } from './review-rail'
 import {
   useCriticMarkupReview,
@@ -802,6 +803,47 @@ describe('review UI', () => {
     })
 
     expect(undoEvent.defaultPrevented).toBe(true)
+    expect(result.current.marks).toHaveLength(0)
+  })
+
+  it('keeps a locally-added comment when a stale resync lands before save (issue #797)', () => {
+    const { result, rerender } = renderHook(
+      ({ markdown }: { markdown: string }) =>
+        useCriticMarkupReview({ markdown, onMarkdownChange: vi.fn() }),
+      { initialProps: { markdown: 'comment target' } }
+    )
+
+    act(() => {
+      result.current.openCommentComposer({ text: 'comment target', isEmpty: false })
+    })
+    act(() => {
+      result.current.submitComment({ body: 'Needs work', mentions: [], attachments: [] })
+    })
+    expect(result.current.marks).toHaveLength(1)
+    const commentId = result.current.marks[0].id
+
+    // A refetch/sync delivers still-stale content (lacking the just-added comment)
+    // during note.tsx's 1s save debounce. The comment must not be clobbered.
+    act(() => {
+      rerender({ markdown: 'comment target edited' })
+    })
+    expect(result.current.marks).toHaveLength(1)
+    expect(result.current.marks[0].id).toBe(commentId)
+    expect(result.current.marks[0]).toMatchObject({ kind: 'comment', body: 'Needs work' })
+
+    // Once the save round-trips (incoming markdown now reflects the comment),
+    // pending clears and normal external resync resumes.
+    const persisted = serializeCriticMarkup(result.current.plainMarkdown, result.current.marks)
+    act(() => {
+      rerender({ markdown: persisted })
+    })
+    expect(result.current.marks).toHaveLength(1)
+
+    // Guard is scoped to the pending window: a later genuinely-external change
+    // is no longer suppressed.
+    act(() => {
+      rerender({ markdown: 'totally different external content' })
+    })
     expect(result.current.marks).toHaveLength(0)
   })
 })

--- a/apps/desktop/src/renderer/src/components/note/review/use-critic-markup-review.ts
+++ b/apps/desktop/src/renderer/src/components/note/review/use-critic-markup-review.ts
@@ -89,6 +89,7 @@ export function useCriticMarkupReview({
   onMarkdownChange
 }: UseCriticMarkupReviewParams): CriticMarkupReviewController {
   const parsed = useMemo(() => parseCriticMarkup(markdown), [markdown])
+  const parsedMarkIds = useMemo(() => new Set(parsed.marks.map((mark) => mark.id)), [parsed.marks])
   const [plainMarkdown, setPlainMarkdown] = useState(parsed.plainText)
   const [marks, setMarks] = useState<CriticMarkupMark[]>(parsed.marks)
   const [activeDraft, setActiveDraft] = useState<CommentDraft | null>(null)
@@ -101,15 +102,34 @@ export function useCriticMarkupReview({
   const editorRef = useRef<BlockNoteHost | null>(null)
   const emittedMarkdownsRef = useRef<string[]>([])
   const undoStackRef = useRef<ReviewUndoEntry[]>([])
+  // Ids of marks added locally but not yet confirmed persisted. Guards the resync
+  // below from dropping a just-added comment when a refetch/sync delivers stale
+  // note content during note.tsx's save debounce window (issue #797).
+  const pendingMarkIdsRef = useRef<Set<string>>(new Set())
 
   useEffect(() => {
     const currentSerialized = serializeCriticMarkup(plainMarkdownRef.current, marksRef.current)
     // No-op resync: the incoming markdown matches what the current marks
     // serialize to. Keep the in-memory marks — re-parsing would drop fields the
     // markup cannot carry (mark createdAt, stable mark ids).
-    if (markdown === currentSerialized) return
+    if (markdown === currentSerialized) {
+      pendingMarkIdsRef.current.clear()
+      return
+    }
     if (emittedMarkdownsRef.current.includes(markdown)) {
       return
+    }
+
+    // Don't clobber locally-added comments that haven't persisted yet. If the
+    // incoming markdown is missing any pending mark id, it predates our unsaved
+    // change (a stale refetch/sync) — keep local state until the save round-trips.
+    if (pendingMarkIdsRef.current.size > 0) {
+      const hasUnpersisted = Array.from(pendingMarkIdsRef.current).some(
+        (id) => !parsedMarkIds.has(id)
+      )
+      if (hasUnpersisted) return
+      // All pending marks are present in the incoming markdown → confirmed persisted.
+      pendingMarkIdsRef.current.clear()
     }
 
     undoStackRef.current = []
@@ -121,7 +141,7 @@ export function useCriticMarkupReview({
     setHoveredMarkId(null)
     setMarkPositions({})
     /* eslint-enable react-hooks/set-state-in-effect, react-you-might-not-need-an-effect/no-pass-data-to-parent, react-you-might-not-need-an-effect/no-derived-state, react-you-might-not-need-an-effect/no-adjust-state-on-prop-change */
-  }, [markdown, parsed.plainText, parsed.marks])
+  }, [markdown, parsed.plainText, parsed.marks, parsedMarkIds])
 
   const persist = useCallback(
     (nextPlainMarkdown: string, nextMarks: CriticMarkupMark[]) => {
@@ -131,6 +151,14 @@ export function useCriticMarkupReview({
       setPlainMarkdown(nextPlainMarkdown)
       setMarks(nextMarks)
       rememberEmittedMarkdown(emittedMarkdownsRef.current, serialized)
+      // Drop pending ids for marks that no longer exist locally (undo/delete of a
+      // still-unsaved mark), so a wedged pending set can't suppress future resyncs.
+      if (pendingMarkIdsRef.current.size > 0) {
+        const nextIds = new Set(nextMarks.map((mark) => mark.id))
+        for (const id of pendingMarkIdsRef.current) {
+          if (!nextIds.has(id)) pendingMarkIdsRef.current.delete(id)
+        }
+      }
       onMarkdownChange(serialized)
     },
     [onMarkdownChange]
@@ -254,6 +282,7 @@ export function useCriticMarkupReview({
       )
       activeDraftRef.current = null
       setActiveDraft(null)
+      pendingMarkIdsRef.current.add(id)
       persist(plainMarkdownRef.current, nextMarks)
     },
     [persist]


### PR DESCRIPTION
Fixes #797 (part of #795).

## Problem

Adding a comment, then navigating away and back, the comment briefly disappears and then reappears on its own.

**Root cause:** a new comment is added to the review controller's in-memory `marks` and emitted as serialized critic-markup, but `note.tsx` persists that content only after a **1000ms debounce**. The review hook's resync effect re-parses `marks` from the incoming `markdown` prop (`= note.content` / `eventContentOverride`) whenever it changes and isn't a no-op or a recently-emitted string. If a TanStack Query refetch or a sync update lands during the debounce window — before the save round-trips — it delivers **stale** note content (predating the comment). The resync re-parses that stale markdown and clobbers the just-added comment. Once the debounced save persists, a later resync restores it.

The two existing resync guards only cover (a) incoming == currently-serialized state and (b) incoming ∈ the last-12 emitted strings. Neither covers genuinely stale content that predates a local, not-yet-persisted comment.

## Fix

Track ids of locally-added, not-yet-persisted marks (the issue's suggested "pending mark ids" direction). Self-contained in the review hook — no `note.tsx`, prop, or IPC changes.

- `submitComment` registers the new mark id as pending.
- The resync effect keeps local marks when the incoming markdown is **missing any pending id** (it predates our unsaved change); it clears pending once all ids appear (save round-tripped) or local state already matches the incoming markdown, then resumes normal external resync.
- `persist` prunes pending ids for marks removed locally (undo/delete), so the set can't wedge and permanently suppress resyncs.
- The incoming mark-id `Set` is memoized during render (not computed in the effect) to keep the effect lint-clean.

When nothing is pending the guard is skipped entirely, so there is **zero behavior change** for typing, journals, and normal external sync.

## Testing

- New regression test in `review-ui.test.tsx`: add a comment, rerender with stale markdown lacking it → the comment survives (this fails on `main`), then confirm resync resumes after the save round-trips and stays scoped to the pending window.
- `review-ui.test.tsx` — 23/23 pass.
- `pnpm --filter @memry/desktop typecheck:web` — clean.
- `eslint` on both changed files — 0 problems.

## Reviewer notes

- **Scope:** protects comment **adds** (the reported symptom + acceptance criterion). Edit-clobber (a stale resync overwriting an edited comment body while the mark id still matches) is out of scope for this fix — id-based detection can't distinguish it; possible follow-up.
- **Docs:** none — internal race-condition fix, no user-facing surface/behavior change. `docs:impact` flags the hook path as docs-relevant but there is no comment-behavior documentation to update.
- **Backward compat:** no schema, sync-protocol, IPC, or file-format changes.
