### PR TITLE
feat(projects): Project Hub Phase 4 — Files section + drag-to-link

### DIFF
--- a/apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { DndContext } from '@dnd-kit/core'
+import { SortableContext } from '@dnd-kit/sortable'
+import { SortableProjectItem } from './sortable-project-item'
+import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
+import { SidebarProvider } from '@/components/ui/sidebar'
+import type { Project } from '@/data/tasks-data'
+
+const mocks = vi.hoisted(() => ({
+  getFile: vi.fn(),
+  linkProjectItem: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn()
+}))
+
+vi.mock('sonner', () => ({ toast: { success: mocks.toastSuccess, error: mocks.toastError } }))
+vi.mock('@/services/notes-service', () => ({ notesService: { getFile: mocks.getFile } }))
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: { linkProjectItem: mocks.linkProjectItem }
+}))
+
+const project = { id: 'p1', name: 'Launch', color: '#f00', taskCount: 0 } as unknown as Project
+
+const renderItem = () =>
+  render(
+    <SidebarProvider>
+      <DndContext>
+        <SortableContext items={['p1']}>
+          <ul>
+            <SortableProjectItem
+              project={project}
+              isActive={false}
+              onClick={vi.fn()}
+              onEdit={vi.fn()}
+              onArchive={vi.fn()}
+              onDelete={vi.fn()}
+            />
+          </ul>
+        </SortableContext>
+      </DndContext>
+    </SidebarProvider>
+  )
+
+const noteDataTransfer = (id: string) => ({
+  types: [MEMRY_NOTE_DRAG_MIME],
+  getData: (type: string) => (type === MEMRY_NOTE_DRAG_MIME ? id : ''),
+  dropEffect: 'none'
+})
+
+describe('SortableProjectItem drop-to-link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.linkProjectItem.mockResolvedValue({ success: true })
+  })
+
+  it('#then links a dropped markdown note as a note', async () => {
+    mocks.getFile.mockResolvedValue(null)
+    renderItem()
+
+    fireEvent.drop(screen.getByText('Launch').closest('li')!, {
+      dataTransfer: noteDataTransfer('n1')
+    })
+
+    await waitFor(() =>
+      expect(mocks.linkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'note',
+        itemId: 'n1'
+      })
+    )
+    expect(mocks.toastSuccess).toHaveBeenCalled()
+  })
+
+  it('#then links a dropped file as a file', async () => {
+    mocks.getFile.mockResolvedValue({ id: 'f1' })
+    renderItem()
+
+    fireEvent.drop(screen.getByText('Launch').closest('li')!, {
+      dataTransfer: noteDataTransfer('f1')
+    })
+
+    await waitFor(() =>
+      expect(mocks.linkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'file',
+        itemId: 'f1'
+      })
+    )
+  })
+})

--- a/apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.tsx
@@ -1,6 +1,8 @@
+import { useCallback, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { useDroppable } from '@dnd-kit/core'
 import { CSS } from '@dnd-kit/utilities'
+import { toast } from 'sonner'
 import { Settings } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import {
@@ -11,6 +13,11 @@ import {
   useSidebar
 } from '@/components/ui/sidebar'
 import { useOptionalDragContext } from '@/contexts/drag-context'
+import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { linkSidebarItemToProject } from '@/lib/link-sidebar-item-to-project'
+import { notesService } from '@/services/notes-service'
+import { tasksService } from '@/services/tasks-service'
 import type { Project } from '@/data/tasks-data'
 import { useT } from '@memry/i18n/renderer'
 
@@ -37,6 +44,7 @@ export const SortableProjectItem = ({
   onDelete: _onDelete
 }: SortableProjectItemProps): React.JSX.Element => {
   const { t: tPhaseF } = useT('notes')
+  const { t: tTasks } = useT('tasks')
   const { isMobile: _isMobile } = useSidebar()
 
   const dragContext = useOptionalDragContext()
@@ -76,16 +84,54 @@ export const SortableProjectItem = ({
   // Show as drop zone when a task is being dragged (not a project)
   const showAsDropZone = dragState.isDragging && !isSortableDragging
 
+  // Native HTML5 drop target for sidebar notes/files dragged from the notes tree
+  const [isNoteDragOver, setIsNoteDragOver] = useState(false)
+
+  const handleNoteDragOver = useCallback((e: React.DragEvent): void => {
+    if (!e.dataTransfer.types.includes(MEMRY_NOTE_DRAG_MIME)) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'copy'
+    setIsNoteDragOver(true)
+  }, [])
+
+  const handleNoteDragLeave = useCallback((): void => {
+    setIsNoteDragOver(false)
+  }, [])
+
+  const handleNoteDrop = useCallback(
+    (e: React.DragEvent): void => {
+      if (!e.dataTransfer.types.includes(MEMRY_NOTE_DRAG_MIME)) return
+      e.preventDefault()
+      setIsNoteDragOver(false)
+      void (async () => {
+        try {
+          const linked = await linkSidebarItemToProject(e.dataTransfer, project.id, {
+            getFile: (id) => notesService.getFile(id),
+            link: (input) => tasksService.linkProjectItem(input)
+          })
+          if (linked) toast.success(tTasks('addToProject.toastSuccess', { name: project.name }))
+        } catch (error) {
+          toast.error(extractErrorMessage(error, tTasks('addToProject.toastError')))
+        }
+      })()
+    },
+    [project.id, project.name, tTasks]
+  )
+
   return (
     <SidebarMenuItem
       ref={setRefs}
       style={style}
+      onDragOver={handleNoteDragOver}
+      onDragLeave={handleNoteDragLeave}
+      onDrop={handleNoteDrop}
       className={cn(
         'group/project relative transition-all duration-150',
         isSortableDragging && 'opacity-50 z-50',
         // Drop zone visual feedback
         showAsDropZone && 'border border-dotted border-muted-foreground/40 rounded-md',
-        isOver && 'bg-primary/10 ring-2 ring-primary rounded-md shadow-sm'
+        isOver && 'bg-primary/10 ring-2 ring-primary rounded-md shadow-sm',
+        isNoteDragOver && 'bg-primary/10 ring-2 ring-primary rounded-md shadow-sm'
       )}
       {...attributes}
       {...listeners}

--- a/apps/desktop/src/renderer/src/components/tasks/projects/add-file-to-project-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/add-file-to-project-dialog.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AddFileToProjectDialog } from './add-file-to-project-dialog'
+
+const mocks = vi.hoisted(() => ({
+  listProjects: vi.fn(),
+  linkProjectItem: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn()
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() })
+}))
+vi.mock('sonner', () => ({
+  toast: { success: mocks.toastSuccess, error: mocks.toastError }
+}))
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: { listProjects: mocks.listProjects, linkProjectItem: mocks.linkProjectItem }
+}))
+
+describe('AddFileToProjectDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.listProjects.mockResolvedValue({
+      projects: [{ id: 'p1', name: 'Launch', color: '#f00', archivedAt: null }]
+    })
+    mocks.linkProjectItem.mockResolvedValue({ success: true })
+  })
+
+  it('#then links the file to the chosen project as itemType file', async () => {
+    render(<AddFileToProjectDialog open onOpenChange={vi.fn()} fileId="f1" />)
+
+    await userEvent.click(await screen.findByText('Launch'))
+
+    await waitFor(() =>
+      expect(mocks.linkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'file',
+        itemId: 'f1'
+      })
+    )
+    expect(mocks.toastSuccess).toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tasks/projects/add-file-to-project-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/add-file-to-project-dialog.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { cn } from '@/lib/utils'
+import { tasksService, type ProjectWithStats } from '@/services/tasks-service'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { createLogger } from '@/lib/logger'
+import { useT } from '@memry/i18n/renderer'
+
+const log = createLogger('AddToProject')
+
+interface AddFileToProjectDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  fileId: string
+}
+
+/**
+ * File info bar → "Add to project": lists active projects and links the file
+ * to the chosen one via `PROJECT_LINK_ITEM` (itemType 'file').
+ */
+export const AddFileToProjectDialog = ({
+  open,
+  onOpenChange,
+  fileId
+}: AddFileToProjectDialogProps): React.JSX.Element => {
+  const { t } = useT('tasks')
+  const [projects, setProjects] = useState<ProjectWithStats[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setIsLoading(true)
+    tasksService
+      .listProjects()
+      .then((res) => setProjects(res.projects.filter((project) => project.archivedAt == null)))
+      .catch((error) => log.error('Failed to list projects', extractErrorMessage(error)))
+      .finally(() => setIsLoading(false))
+  }, [open])
+
+  const handleSelect = async (project: ProjectWithStats): Promise<void> => {
+    try {
+      const result = await tasksService.linkProjectItem({
+        projectId: project.id,
+        itemType: 'file',
+        itemId: fileId
+      })
+      if (!result.success) throw new Error(result.error)
+      toast.success(t('addToProject.toastSuccess', { name: project.name }))
+      onOpenChange(false)
+    } catch (error) {
+      toast.error(extractErrorMessage(error, t('addToProject.toastError')))
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{t('addToProject.dialogTitle')}</DialogTitle>
+        </DialogHeader>
+        <ScrollArea className="max-h-[300px] -mx-2">
+          <div className="space-y-1 px-2">
+            {isLoading ? (
+              <div className="flex items-center justify-center h-20 text-sm text-muted-foreground">
+                {t('addToProject.loading')}
+              </div>
+            ) : projects.length === 0 ? (
+              <div className="flex items-center justify-center h-20 text-sm text-muted-foreground">
+                {t('addToProject.noProjects')}
+              </div>
+            ) : (
+              projects.map((project) => (
+                <button
+                  key={project.id}
+                  type="button"
+                  onClick={() => void handleSelect(project)}
+                  className={cn(
+                    'flex w-full items-center gap-2 rounded-md p-2 text-start transition-colors',
+                    'hover:bg-muted/50'
+                  )}
+                >
+                  <span
+                    className="size-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: project.color }}
+                    aria-hidden="true"
+                  />
+                  <span className="truncate text-sm">{project.name}</span>
+                </button>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default AddFileToProjectDialog

--- a/apps/desktop/src/renderer/src/components/tasks/projects/project-files-section.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/project-files-section.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ProjectFilesSection } from './project-files-section'
+
+const mocks = vi.hoisted(() => ({
+  listProjectLinks: vi.fn(),
+  unlinkProjectItem: vi.fn(),
+  getFile: vi.fn()
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() })
+}))
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: {
+    listProjectLinks: mocks.listProjectLinks,
+    unlinkProjectItem: mocks.unlinkProjectItem
+  }
+}))
+vi.mock('@/services/notes-service', () => ({
+  notesService: { getFile: mocks.getFile }
+}))
+
+const fileLink = (id: string) => ({
+  id: `link-${id}`,
+  projectId: 'p1',
+  itemType: 'file',
+  itemId: id,
+  position: 0,
+  createdAt: ''
+})
+
+describe('ProjectFilesSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.unlinkProjectItem.mockResolvedValue({ success: true })
+  })
+
+  it('#then lists only file-typed links, resolved by getFile', async () => {
+    mocks.listProjectLinks.mockResolvedValue([
+      fileLink('f1'),
+      { id: 'link-n', projectId: 'p1', itemType: 'note', itemId: 'n1', position: 0, createdAt: '' }
+    ])
+    mocks.getFile.mockImplementation(async (id: string) =>
+      id === 'f1' ? { id: 'f1', title: 'Budget.pdf', fileType: 'pdf' } : null
+    )
+
+    render(<ProjectFilesSection projectId="p1" />)
+
+    expect(await screen.findByText('Budget.pdf')).toBeInTheDocument()
+    // The note-typed link is never resolved as a file.
+    expect(mocks.getFile).toHaveBeenCalledTimes(1)
+    expect(mocks.getFile).toHaveBeenCalledWith('f1')
+  })
+
+  it('#then skips orphaned file links whose getFile returns null', async () => {
+    mocks.listProjectLinks.mockResolvedValue([fileLink('f1'), fileLink('gone')])
+    mocks.getFile.mockImplementation(async (id: string) =>
+      id === 'f1' ? { id: 'f1', title: 'Slide.png', fileType: 'image' } : null
+    )
+
+    render(<ProjectFilesSection projectId="p1" />)
+
+    expect(await screen.findByText('Slide.png')).toBeInTheDocument()
+    expect(screen.queryByText('gone')).not.toBeInTheDocument()
+  })
+
+  it('#then renders nothing when there are no file links', async () => {
+    mocks.listProjectLinks.mockResolvedValue([])
+    const { container } = render(<ProjectFilesSection projectId="p1" />)
+    await waitFor(() => expect(mocks.listProjectLinks).toHaveBeenCalled())
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('#then unlinks a file on remove click', async () => {
+    mocks.listProjectLinks.mockResolvedValue([fileLink('f1')])
+    mocks.getFile.mockResolvedValue({ id: 'f1', title: 'Budget.pdf', fileType: 'pdf' })
+
+    render(<ProjectFilesSection projectId="p1" />)
+    await screen.findByText('Budget.pdf')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove from project' }))
+
+    await waitFor(() =>
+      expect(mocks.unlinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'file',
+        itemId: 'f1'
+      })
+    )
+    expect(screen.queryByText('Budget.pdf')).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tasks/projects/project-files-section.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/project-files-section.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from 'react'
+import { File, FileText, Image, Music, Video, Loader2, X } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { tasksService } from '@/services/tasks-service'
+import { notesService } from '@/services/notes-service'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { createLogger } from '@/lib/logger'
+import { useT } from '@memry/i18n/renderer'
+
+const log = createLogger('ProjectFiles')
+
+type FileKind = 'pdf' | 'image' | 'audio' | 'video'
+
+interface LinkedFile {
+  itemId: string
+  title: string
+  fileType: FileKind
+}
+
+const FILE_ICONS = {
+  pdf: FileText,
+  image: Image,
+  audio: Music,
+  video: Video
+} as const
+
+interface ProjectFilesSectionProps {
+  projectId: string
+  onFileClick?: (fileId: string) => void
+  className?: string
+}
+
+/**
+ * Project Home "Files" section — lists the files (notes with a non-markdown
+ * fileType) linked to a project via `project_links` and lets the user unlink
+ * one. Files are resolved through `notesService.getFile`, which returns null
+ * for a deleted file or a markdown note, so orphaned links are skipped.
+ */
+export const ProjectFilesSection = ({
+  projectId,
+  onFileClick,
+  className
+}: ProjectFilesSectionProps): React.JSX.Element | null => {
+  const { t } = useT('tasks')
+  const [files, setFiles] = useState<LinkedFile[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  const loadFiles = useCallback(async (): Promise<void> => {
+    setIsLoading(true)
+    try {
+      const links = await tasksService.listProjectLinks(projectId)
+      const fileLinks = links.filter((link) => link.itemType === 'file')
+      const resolved = await Promise.all(
+        fileLinks.map(async (link) => {
+          // Defensive: getFile returns null for a deleted file (orphaned link)
+          // or a markdown id; skip either. Cleanup of orphaned links is owned
+          // by a concurrent effort.
+          const file = await notesService.getFile(link.itemId)
+          if (!file) return null
+          return { itemId: link.itemId, title: file.title, fileType: file.fileType }
+        })
+      )
+      setFiles(resolved.filter((file): file is LinkedFile => file !== null))
+    } catch (error) {
+      log.error(
+        'Failed to load project files',
+        extractErrorMessage(error, t('projectFiles.loadError'))
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }, [projectId, t])
+
+  useEffect(() => {
+    void loadFiles()
+  }, [loadFiles])
+
+  const handleRemove = useCallback(
+    async (itemId: string): Promise<void> => {
+      try {
+        await tasksService.unlinkProjectItem({ projectId, itemType: 'file', itemId })
+        setFiles((prev) => prev.filter((file) => file.itemId !== itemId))
+      } catch (error) {
+        log.error(
+          'Failed to remove file from project',
+          extractErrorMessage(error, t('projectFiles.removeError'))
+        )
+      }
+    },
+    [projectId, t]
+  )
+
+  if (!isLoading && files.length === 0) return null
+
+  return (
+    <section className={cn('px-4 py-3 border-t border-border', className)}>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {t('projectFiles.title')}
+      </h3>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          {t('projectFiles.loading')}
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {files.map((file) => {
+            const Icon = FILE_ICONS[file.fileType] ?? File
+            return (
+              <div
+                key={file.itemId}
+                className="group relative flex items-center gap-2 rounded-md border border-border p-2 hover:bg-surface-hover"
+              >
+                <button
+                  type="button"
+                  className="flex min-w-0 flex-1 items-center gap-2 text-start"
+                  onClick={() => onFileClick?.(file.itemId)}
+                >
+                  <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  <span className="truncate text-sm">{file.title}</span>
+                </button>
+                <button
+                  type="button"
+                  aria-label={t('projectFiles.removeFromProject')}
+                  onClick={() => void handleRemove(file.itemId)}
+                  className="shrink-0 rounded-sm p-1 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+                >
+                  <X className="size-3.5" aria-hidden="true" />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default ProjectFilesSection

--- a/apps/desktop/src/renderer/src/components/tasks/projects/project-stats-row.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/project-stats-row.test.tsx
@@ -4,10 +4,20 @@ import { ProjectStatsRow } from './project-stats-row'
 
 describe('ProjectStatsRow', () => {
   it('#then renders counts and derived progress', () => {
-    render(<ProjectStatsRow taskCount={4} noteCount={2} eventCount={1} progressPct={50} />)
+    render(
+      <ProjectStatsRow taskCount={4} noteCount={2} eventCount={1} fileCount={3} progressPct={50} />
+    )
     expect(screen.getByText('4')).toBeInTheDocument()
     expect(screen.getByText('2')).toBeInTheDocument()
     expect(screen.getByText('1')).toBeInTheDocument()
     expect(screen.getByText('50%')).toBeInTheDocument()
+  })
+
+  it('#then renders the files tile', () => {
+    render(
+      <ProjectStatsRow taskCount={1} noteCount={2} eventCount={3} fileCount={4} progressPct={50} />
+    )
+    expect(screen.getByText('Files')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/src/components/tasks/projects/project-stats-row.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/projects/project-stats-row.tsx
@@ -5,6 +5,7 @@ interface ProjectStatsRowProps {
   taskCount: number
   noteCount: number
   eventCount: number
+  fileCount: number
   progressPct: number
   className?: string
 }
@@ -13,6 +14,7 @@ export const ProjectStatsRow = ({
   taskCount,
   noteCount,
   eventCount,
+  fileCount,
   progressPct,
   className
 }: ProjectStatsRowProps): React.JSX.Element => {
@@ -21,10 +23,11 @@ export const ProjectStatsRow = ({
     { label: t('projectHome.stats.tasks'), value: String(taskCount) },
     { label: t('projectHome.stats.notes'), value: String(noteCount) },
     { label: t('projectHome.stats.events'), value: String(eventCount) },
+    { label: t('projectHome.stats.files'), value: String(fileCount) },
     { label: t('projectHome.stats.progress'), value: `${progressPct}%` }
   ]
   return (
-    <div className={cn('grid grid-cols-4 gap-3 px-4 py-3', className)}>
+    <div className={cn('grid grid-cols-5 gap-3 px-4 py-3', className)}>
       {tiles.map((tile) => (
         <div
           key={tile.label}

--- a/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx
@@ -925,21 +925,18 @@ export function VirtualizedNotesTree({
 
       e.dataTransfer.effectAllowed = 'copyMove'
       e.dataTransfer.setData('text/plain', itemId)
-      // Tag file-type items (pdf/image/audio/etc.) so the note editor can embed
-      // them by their own vault path on drop, instead of ignoring the drag.
       if (!isFolder(itemId)) {
-        const note = noteMap.get(itemId)
-        const fileType = (note?.fileType ?? 'markdown') as FileType
-        if (fileType !== 'markdown') {
-          e.dataTransfer.setData(MEMRY_NOTE_DRAG_MIME, itemId)
-        }
+        // Tag every note/file item so drop targets (note editor embed, sidebar
+        // project link) can resolve it by id. getFile(id) later discriminates
+        // a file (non-markdown, embeddable) from a plain note (returns null).
+        e.dataTransfer.setData(MEMRY_NOTE_DRAG_MIME, itemId)
         // Every non-folder item is a note entity — tag it so the spatial canvas
         // can create a referencing card on drop (markdown notes set no other MIME).
         e.dataTransfer.setData(CANVAS_ITEM_DRAG_MIME, canvasDragPayload('note', itemId))
       }
       setDragState((prev) => ({ ...prev, draggedId: itemId }))
     },
-    [isDragDisabled, noteMap]
+    [isDragDisabled]
   )
 
   const handleDragEnd = useCallback(() => {

--- a/apps/desktop/src/renderer/src/lib/drag-mime.ts
+++ b/apps/desktop/src/renderer/src/lib/drag-mime.ts
@@ -1,10 +1,11 @@
 /**
- * Custom drag data type used when a file-type item is dragged out of the left
- * sidebar (`VirtualizedNotesTree`) so the note editor can distinguish it from a
- * plain text drag or an OS file drop and embed the item by its own vault path
- * (no copy into `attachments/`).
+ * Custom drag data type set when any note or file item is dragged out of the
+ * left sidebar (`VirtualizedNotesTree`). The payload is the item's note id.
  *
- * The payload is the item's note id; the editor resolves it to an absolute path
- * via `window.api.notes.getFile(id)`.
+ * Consumers:
+ * - the note editor embeds a *file* item by its own vault path
+ *   (`window.api.notes.getFile(id)`; a markdown note resolves to null → no-op);
+ * - a sidebar project drop links the item to the project (file vs note is
+ *   resolved via `getFile`).
  */
 export const MEMRY_NOTE_DRAG_MIME = 'application/x-memry-note'

--- a/apps/desktop/src/renderer/src/lib/link-sidebar-item-to-project.test.ts
+++ b/apps/desktop/src/renderer/src/lib/link-sidebar-item-to-project.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import { linkSidebarItemToProject } from './link-sidebar-item-to-project'
+import { MEMRY_NOTE_DRAG_MIME } from './drag-mime'
+
+const dt = (mime: string | null, id: string): Pick<DataTransfer, 'getData' | 'types'> => ({
+  types: mime ? [mime] : [],
+  getData: (type: string) => (type === mime ? id : '')
+})
+
+describe('linkSidebarItemToProject', () => {
+  it('#then links a markdown note as itemType note', async () => {
+    const getFile = vi.fn().mockResolvedValue(null)
+    const link = vi.fn().mockResolvedValue({ success: true })
+
+    const result = await linkSidebarItemToProject(dt(MEMRY_NOTE_DRAG_MIME, 'n1'), 'p1', {
+      getFile,
+      link
+    })
+
+    expect(link).toHaveBeenCalledWith({ projectId: 'p1', itemType: 'note', itemId: 'n1' })
+    expect(result).toEqual({ itemType: 'note', itemId: 'n1' })
+  })
+
+  it('#then links a file (getFile non-null) as itemType file', async () => {
+    const getFile = vi.fn().mockResolvedValue({ id: 'f1' })
+    const link = vi.fn().mockResolvedValue({ success: true })
+
+    const result = await linkSidebarItemToProject(dt(MEMRY_NOTE_DRAG_MIME, 'f1'), 'p1', {
+      getFile,
+      link
+    })
+
+    expect(link).toHaveBeenCalledWith({ projectId: 'p1', itemType: 'file', itemId: 'f1' })
+    expect(result).toEqual({ itemType: 'file', itemId: 'f1' })
+  })
+
+  it('#then no-ops when the drag carries no note MIME', async () => {
+    const getFile = vi.fn()
+    const link = vi.fn()
+
+    const result = await linkSidebarItemToProject(dt(null, ''), 'p1', { getFile, link })
+
+    expect(result).toBeNull()
+    expect(getFile).not.toHaveBeenCalled()
+    expect(link).not.toHaveBeenCalled()
+  })
+
+  it('#then throws when link fails', async () => {
+    const getFile = vi.fn().mockResolvedValue(null)
+    const link = vi.fn().mockResolvedValue({ success: false, error: 'boom' })
+
+    await expect(
+      linkSidebarItemToProject(dt(MEMRY_NOTE_DRAG_MIME, 'n1'), 'p1', { getFile, link })
+    ).rejects.toThrow('boom')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/link-sidebar-item-to-project.ts
+++ b/apps/desktop/src/renderer/src/lib/link-sidebar-item-to-project.ts
@@ -1,0 +1,34 @@
+import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
+import type { ProjectItemType } from '@/services/tasks-service'
+
+interface LinkSidebarItemDeps {
+  getFile: (id: string) => Promise<{ id: string } | null>
+  link: (input: {
+    projectId: string
+    itemType: ProjectItemType
+    itemId: string
+  }) => Promise<{ success: boolean; error?: string }>
+}
+
+/**
+ * Links a sidebar item (dragged from the notes tree via MEMRY_NOTE_DRAG_MIME)
+ * to a project. Files are notes with a non-markdown fileType, so
+ * `getFile(id)` returns non-null exactly for files — the file/note
+ * discriminator. Returns null when the drag carried no linkable item (so the
+ * caller can skip the toast); throws when the link call reports failure.
+ */
+export async function linkSidebarItemToProject(
+  dataTransfer: Pick<DataTransfer, 'getData' | 'types'>,
+  projectId: string,
+  deps: LinkSidebarItemDeps
+): Promise<{ itemType: ProjectItemType; itemId: string } | null> {
+  if (!dataTransfer.types.includes(MEMRY_NOTE_DRAG_MIME)) return null
+  const itemId = dataTransfer.getData(MEMRY_NOTE_DRAG_MIME)
+  if (!itemId) return null
+
+  const file = await deps.getFile(itemId)
+  const itemType: ProjectItemType = file ? 'file' : 'note'
+  const result = await deps.link({ projectId, itemType, itemId })
+  if (!result.success) throw new Error(result.error)
+  return { itemType, itemId }
+}

--- a/apps/desktop/src/renderer/src/pages/file.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/file.test.tsx
@@ -25,6 +25,17 @@ vi.mock('@/services/notes-service', () => ({
   }
 }))
 
+vi.mock('@/components/tasks/projects/item-project-chips', () => ({
+  ItemProjectChips: ({ itemType, itemId }: { itemType: string; itemId: string }) => (
+    <div data-testid="chips" data-item-type={itemType} data-item-id={itemId} />
+  )
+}))
+
+vi.mock('@/components/tasks/projects/add-file-to-project-dialog', () => ({
+  AddFileToProjectDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="add-file-dialog" /> : null
+}))
+
 vi.mock('@/components/viewers', () => ({
   PdfViewer: ({ src }: { src: string }) => <div data-testid="pdf-viewer">{src}</div>,
   ImageViewer: ({ src, alt }: { src: string; alt: string }) => (
@@ -167,5 +178,23 @@ describe('FilePage', () => {
     expect(
       await screen.findByText('File not found. It may have been deleted or moved.')
     ).toBeInTheDocument()
+  })
+
+  it('renders file project chips with itemType file', async () => {
+    renderWithProviders(<FilePage fileId="file-1" />)
+
+    const chips = await screen.findByTestId('chips')
+    expect(chips).toHaveAttribute('data-item-type', 'file')
+    expect(chips).toHaveAttribute('data-item-id', 'file-1')
+  })
+
+  it('opens the add-to-project dialog from the info-bar button', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<FilePage fileId="file-1" />)
+
+    expect(await screen.findByText('File title')).toBeInTheDocument()
+    await user.click(screen.getByTitle('addToProject.menuLabel'))
+
+    expect(screen.getByTestId('add-file-dialog')).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/src/pages/file.tsx
+++ b/apps/desktop/src/renderer/src/pages/file.tsx
@@ -6,8 +6,9 @@ import { getI18n } from 'react-i18next'
  * Loads file metadata via IPC and renders the file using the absolute path.
  */
 
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Loader2, FileWarning, Download, ExternalLink } from '@/lib/icons'
+import { Loader2, FileWarning, Download, ExternalLink, FolderPlus } from '@/lib/icons'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { toMemryFileUrl } from '@/lib/memry-file-url'
 import { notesService } from '@/services/notes-service'
@@ -16,6 +17,8 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import type { FileMetadata } from '@memry/rpc/notes'
 import { useT } from '@memry/i18n/renderer'
+import { ItemProjectChips } from '@/components/tasks/projects/item-project-chips'
+import { AddFileToProjectDialog } from '@/components/tasks/projects/add-file-to-project-dialog'
 
 // ============================================================================
 // Types
@@ -97,40 +100,56 @@ function FileLoadingState() {
 // File Info Bar Component
 // ============================================================================
 
-function FileInfoBar({ file }: { file: FileMetadata }) {
+function FileInfoBar({ file, onAddToProject }: { file: FileMetadata; onAddToProject: () => void }) {
   const { t: tPhaseF } = useT('notes')
+  const { t: tTasks } = useT('tasks')
   return (
-    <div className="flex items-center justify-between gap-2 px-2 sm:px-4 py-2 border-b border-border bg-muted/30 flex-shrink-0">
-      <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
-        <h1 className="font-medium truncate flex-1 min-w-0">{file.title}</h1>
-        <span className="text-xs text-muted-foreground uppercase flex-shrink-0 hidden sm:inline">
-          {file.fileType}
-        </span>
-        <span className="text-xs text-muted-foreground flex-shrink-0 hidden md:inline">
-          {formatFileSize(file.fileSize)}
-        </span>
+    <div className="flex flex-col gap-1 border-b border-border bg-muted/30 flex-shrink-0">
+      <div className="flex items-center justify-between gap-2 px-2 sm:px-4 py-2">
+        <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
+          <h1 className="font-medium truncate flex-1 min-w-0">{file.title}</h1>
+          <span className="text-xs text-muted-foreground uppercase flex-shrink-0 hidden sm:inline">
+            {file.fileType}
+          </span>
+          <span className="text-xs text-muted-foreground flex-shrink-0 hidden md:inline">
+            {formatFileSize(file.fileSize)}
+          </span>
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onAddToProject}
+            className="h-8 w-8 p-0 sm:w-auto sm:px-3"
+            title={tTasks('addToProject.menuLabel')}
+          >
+            <FolderPlus className="h-4 w-4 sm:me-1" />
+            <span className="hidden sm:inline">{tTasks('addToProject.menuLabel')}</span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void window.api.notes.openExternal(file.id)}
+            className="h-8 w-8 p-0 sm:w-auto sm:px-3"
+            title={tPhaseF('phaseF.pagesFile.openInDefaultApp')}
+          >
+            <ExternalLink className="h-4 w-4 sm:me-1" />
+            <span className="hidden sm:inline">{tPhaseF('phaseF.pagesFile.open')}</span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void window.api.notes.revealInFinder(file.id)}
+            className="h-8 w-8 p-0 sm:w-auto sm:px-3"
+            title={tPhaseF('phaseF.pagesFile.revealInFinder')}
+          >
+            <Download className="h-4 w-4 sm:me-1" />
+            <span className="hidden sm:inline">{tPhaseF('phaseF.pagesFile.reveal')}</span>
+          </Button>
+        </div>
       </div>
-      <div className="flex items-center gap-1 flex-shrink-0">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => void window.api.notes.openExternal(file.id)}
-          className="h-8 w-8 p-0 sm:w-auto sm:px-3"
-          title={tPhaseF('phaseF.pagesFile.openInDefaultApp')}
-        >
-          <ExternalLink className="h-4 w-4 sm:me-1" />
-          <span className="hidden sm:inline">{tPhaseF('phaseF.pagesFile.open')}</span>
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => void window.api.notes.revealInFinder(file.id)}
-          className="h-8 w-8 p-0 sm:w-auto sm:px-3"
-          title={tPhaseF('phaseF.pagesFile.revealInFinder')}
-        >
-          <Download className="h-4 w-4 sm:me-1" />
-          <span className="hidden sm:inline">{tPhaseF('phaseF.pagesFile.reveal')}</span>
-        </Button>
+      <div className="px-2 sm:px-4 pb-2">
+        <ItemProjectChips itemType="file" itemId={file.id} />
       </div>
     </div>
   )
@@ -184,6 +203,8 @@ function FileViewer({ file }: { file: FileMetadata }) {
 // ============================================================================
 
 export function FilePage({ fileId }: FilePageProps) {
+  const [addToProjectOpen, setAddToProjectOpen] = useState(false)
+
   // Query for file metadata
   const {
     data: file,
@@ -232,8 +253,13 @@ export function FilePage({ fileId }: FilePageProps) {
 
   return (
     <div className={cn('flex h-full flex-col min-h-0')}>
-      <FileInfoBar file={file} />
+      <FileInfoBar file={file} onAddToProject={() => setAddToProjectOpen(true)} />
       <FileViewer file={file} />
+      <AddFileToProjectDialog
+        open={addToProjectOpen}
+        onOpenChange={setAddToProjectOpen}
+        fileId={file.id}
+      />
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/pages/file.tsx
+++ b/apps/desktop/src/renderer/src/pages/file.tsx
@@ -148,9 +148,7 @@ function FileInfoBar({ file, onAddToProject }: { file: FileMetadata; onAddToProj
           </Button>
         </div>
       </div>
-      <div className="px-2 sm:px-4 pb-2">
-        <ItemProjectChips itemType="file" itemId={file.id} />
-      </div>
+      <ItemProjectChips itemType="file" itemId={file.id} className="px-2 sm:px-4 pb-2" />
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/pages/project-home.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/project-home.test.tsx
@@ -205,4 +205,15 @@ describe('ProjectHomePage', () => {
     )
     expect(mocks.getProject).toHaveBeenCalledTimes(2)
   })
+
+  it('#then renders linked files in the Files section', async () => {
+    mocks.listProjectLinks.mockResolvedValue([
+      { id: 'l-f', projectId: 'p1', itemType: 'file', itemId: 'f1', position: 0, createdAt: '' }
+    ])
+    mocks.notesGetFile.mockResolvedValue({ id: 'f1', title: 'Budget.pdf', fileType: 'pdf' })
+
+    render(<ProjectHomePage projectId="p1" />)
+
+    expect(await screen.findByText('Budget.pdf')).toBeInTheDocument()
+  })
 })

--- a/apps/desktop/src/renderer/src/pages/project-home.tsx
+++ b/apps/desktop/src/renderer/src/pages/project-home.tsx
@@ -4,6 +4,7 @@ import { FolderKanban } from '@/lib/icons'
 import { getIconByName } from '@/components/icon-picker'
 import { TaskList } from '@/components/tasks/task-list'
 import { ProjectNotesSection } from '@/components/tasks/projects/project-notes-section'
+import { ProjectFilesSection } from '@/components/tasks/projects/project-files-section'
 import { ProjectEventsSection } from '@/components/tasks/projects/project-events-section'
 import { ProjectOverviewNote } from '@/components/tasks/projects/project-overview-note'
 import { ProjectStatsRow } from '@/components/tasks/projects/project-stats-row'
@@ -132,6 +133,7 @@ export const ProjectHomePage = ({
     () => links.filter((link) => link.itemType === 'calendar_event').length,
     [links]
   )
+  const fileCount = useMemo(() => links.filter((link) => link.itemType === 'file').length, [links])
 
   const handleNoteClick = useCallback(
     async (noteId: string) => {
@@ -232,6 +234,7 @@ export const ProjectHomePage = ({
         taskCount={projectTasks.length}
         noteCount={noteCount}
         eventCount={eventCount}
+        fileCount={fileCount}
         progressPct={progressPct}
       />
 
@@ -254,6 +257,8 @@ export const ProjectHomePage = ({
       <ProjectEventsSection projectId={project.id} onEventClick={handleEventClick} />
 
       <ProjectNotesSection projectId={project.id} onNoteClick={handleNoteClick} />
+
+      <ProjectFilesSection projectId={project.id} onFileClick={handleNoteClick} />
     </div>
   )
 }

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -68,6 +68,7 @@ At the top, a stats row summarizes the project:
 - **Tasks** — total tasks in the project
 - **Notes** — linked notes
 - **Events** — linked calendar events
+- **Files** — linked files
 - **Progress** — share of the project's tasks that are complete (derived live from the done ratio; there is nothing to configure)
 
 Below the stats, Project Home stacks these sections:
@@ -76,8 +77,7 @@ Below the stats, Project Home stacks these sections:
 - **Tasks** — the project's task list (the same list and quick-add you already know)
 - **Notes** — the notes linked to this project
 - **Calendar** — the calendar events linked to this project
-
-(A **Files** section is planned for a later release.)
+- **Files** — the files linked to this project (PDFs, images, audio, video)
 
 ### Overview note
 
@@ -88,15 +88,17 @@ A project can point at a real note that renders inline at the top of Project Hom
 
 The overview is a pointer to a note, so it never shows up twice — it does not also appear in the Notes section.
 
-### Linking notes and events
+### Linking notes, events, and files
 
-Notes and events join a project as **links** (many-to-many): the same note can belong to more than one project.
+Notes, events, and files join a project as **links** (many-to-many): the same note or file can belong to more than one project.
 
-- **Add a note** — from a note's **⋯** menu choose **Add to project**, or drag a note onto a project
+- **Add a note** — from a note's **⋯** menu choose **Add to project**, or drag the note onto a project in the sidebar
+- **Add a file** — open the file and choose **Add to project** from its toolbar, or drag the file onto a project in the sidebar
 - **Add an event** — right-click a calendar event and choose **Add to project**
-- Linked items appear in Project Home's **Notes** / **Calendar** sections; use each row's remove control to unlink (this only unlinks — it never deletes the note or event)
+- Dragging any note or file from the sidebar onto a project links it in one step — memrynote tells notes and files apart automatically, so the same drag works for either
+- Linked items appear in Project Home's **Notes** / **Calendar** / **Files** sections; use each row's remove control to unlink (this only unlinks — it never deletes the note, event, or file)
 
-Wherever a note or event lives, small **project chips** under its title show which projects it belongs to — click a chip to jump to that Project Home.
+Wherever a note, event, or file lives, small **project chips** under its title show which projects it belongs to — click a chip to jump to that Project Home.
 
 ## Deleting a Project
 
@@ -108,7 +110,7 @@ Deleting asks you to choose what to do with the tasks:
 
 Each path is reversible via undo within the 10-second window.
 
-Linked **notes, events, and files are never deleted** with a project — only the project's tasks and its links are removed. Your notes and events stay in your vault and simply lose the project link, so a project is safe to delete without losing the material collected under it.
+Linked **notes, events, and files are never deleted** with a project — only the project's tasks and its links are removed. Your notes, events, and files stay in your vault and simply lose the project link, so a project is safe to delete without losing the material collected under it.
 
 ## Sync
 

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -98,7 +98,7 @@ Notes, events, and files join a project as **links** (many-to-many): the same no
 - Dragging any note or file from the sidebar onto a project links it in one step — memrynote tells notes and files apart automatically, so the same drag works for either
 - Linked items appear in Project Home's **Notes** / **Calendar** / **Files** sections; use each row's remove control to unlink (this only unlinks — it never deletes the note, event, or file)
 
-Wherever a note, event, or file lives, small **project chips** under its title show which projects it belongs to — click a chip to jump to that Project Home.
+Wherever a note, event, or file lives, small **project chips** under its title show which projects it belongs to. On notes and events, click a chip to jump to that Project Home.
 
 ## Deleting a Project
 

--- a/docs/superpowers/plans/2026-07-22-project-hub-phase4-files.md
+++ b/docs/superpowers/plans/2026-07-22-project-hub-phase4-files.md
@@ -1,0 +1,1371 @@
+# Project Hub — Phase 4 (Files) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the **Files** section to Project Home, let a user link a file to a project, and let a user drag a sidebar note/file onto a project to link it — closing out the Projects all-in-one hub (spec §9 Phase 4).
+
+**Architecture:** A "file" in MemryNote is a note whose `fileType ∈ {pdf,image,audio,video}` (markdown = a regular note); there is no separate file/attachment table. Its stable id is the **note id**, resolved via `notesService.getFile(id) → FileMetadata | null` (returns `null` for markdown). The `project_links` table, the link/unlink/list IPC + RPC, and the sync payload are all **already generic over `item_type`** (contract enums already include `'file'`, `queries/projects.ts` types `itemType` as `string`, and the project sync payload selects _all_ links for a project). So Phase 4 is **renderer-only**: mirror the existing `ProjectNotesSection`/`AddNoteToProjectDialog` patterns for files, and add a native-HTML5 drop target on the sidebar project item. **No migration, no new `SyncItemType`, no contract/RPC/main-process change.**
+
+**Tech Stack:** React 19 + TypeScript, Vitest + Testing Library (jsdom), Tailwind (logical props), `@memry/i18n`, dnd-kit (sidebar sortable) + native HTML5 DnD (sidebar note drag), `electron-log` logger, `sonner` toasts.
+
+## Global Constraints
+
+- **PRODUCTION, backward-compat MANDATORY:** additive only, no DB reset. Phase 4 adds **no** migration, **no** new `SyncItemType`, **no** contract/RPC change — file links ride the existing `project_links` + project sync payload. If a migration ever seems needed, STOP.
+- **Deleting a project keeps notes/events/files** (only `project_links` + tasks cascade) — unchanged from Phase 1; nothing in this plan alters delete semantics.
+- **Do NOT touch** the note-deletion / orphan-link-cleanup path (`main/notes/domain.ts`, `notes/runtime-effects.ts`, `cleanupProjectLinksForDeletedNote`). Only **defensively skip** null-target links in new read-only sections.
+- `listForItem` consumers must guard `Array.isArray(result)` (served via `withDb`, may return an error envelope).
+- New renderer code uses **logical Tailwind props only** (`ms/me/ps/pe/start/end`, `text-start/end`, `border-s/e`, `rounded-s/e`).
+- Logging via `createLogger('Scope')`; user-facing errors via `extractErrorMessage(err, fallback)`.
+- i18n: add English keys to `packages/i18n/src/locales/en/tasks.json`; `pnpm i18n:check` gates English only.
+- Files are notes → resolve via `notesService.getFile(id)`; a `null` result means the link is orphaned (file deleted) OR the id is a markdown note — skip it in the Files section.
+- Tests: renderer via `pnpm --filter @memry/desktop test:renderer` (runs the FULL suite; there is no file filter). Native context menus / `Picker` do NOT open in jsdom — unit-test rendered components + extracted pure logic, not menu-open flows.
+
+---
+
+## File Structure
+
+**New files:**
+
+- `apps/desktop/src/renderer/src/components/tasks/projects/project-files-section.tsx` — Project Home "Files" section (mirror of `project-notes-section.tsx`).
+- `apps/desktop/src/renderer/src/components/tasks/projects/project-files-section.test.tsx`
+- `apps/desktop/src/renderer/src/components/tasks/projects/add-file-to-project-dialog.tsx` — "Add to project" dialog for a file (mirror of `add-note-to-project-dialog.tsx`).
+- `apps/desktop/src/renderer/src/components/tasks/projects/add-file-to-project-dialog.test.tsx`
+- `apps/desktop/src/renderer/src/lib/link-sidebar-item-to-project.ts` — pure helper: read the dragged note id from a `DataTransfer`, resolve file-vs-note, link it. (Extracted so the drop logic is testable without dnd-kit context.)
+- `apps/desktop/src/renderer/src/lib/link-sidebar-item-to-project.test.ts`
+
+**Modified files:**
+
+- `apps/desktop/src/renderer/src/pages/project-home.tsx` — mount `<ProjectFilesSection>` at the `FILES_SECTION_SLOT`; compute `fileCount`; pass it to `ProjectStatsRow`.
+- `apps/desktop/src/renderer/src/components/tasks/projects/project-stats-row.tsx` — add a required `fileCount` prop + a 5th "Files" tile (`grid-cols-5`).
+- `apps/desktop/src/renderer/src/components/tasks/projects/project-stats-row.test.tsx` — cover the new tile.
+- `apps/desktop/src/renderer/src/pages/project-home.test.tsx` — new test: a file link renders in the Files section.
+- `apps/desktop/src/renderer/src/pages/file.tsx` — "Add to project" button in the info bar + `ItemProjectChips` + dialog wiring.
+- `apps/desktop/src/renderer/src/pages/file.test.tsx` — (create if absent) cover the new button/chips.
+- `apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx` — set `MEMRY_NOTE_DRAG_MIME` for **all** non-folder items (not just files).
+- `apps/desktop/src/renderer/src/lib/drag-mime.ts` — update the doc comment to reflect notes + files.
+- `apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.tsx` — native `onDragOver`/`onDragLeave`/`onDrop` to link a dragged sidebar item.
+- `apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.test.tsx` — (create) cover the drop-to-link wiring.
+- `packages/i18n/src/locales/en/tasks.json` — `projectFiles.*` + `projectHome.stats.files`.
+- `apps/docs/src/user-guide/projects.md` — extend "Project Home" with Files.
+
+**Reference (read, do not modify) — the patterns being mirrored:**
+
+- `project-notes-section.tsx` — the section shape (filter links by `itemType`, resolve each item, skip nulls, unlink control, `return null` when empty).
+- `project-events-section.tsx` — same shape with async resolution + per-item icon.
+- `add-note-to-project-dialog.tsx` / `add-event-to-project-dialog.tsx` — the "Add to project" dialog.
+- `item-project-chips.tsx` — membership chips (`Array.isArray` guard).
+- `pages/project-home.tsx` — where sections mount; the `onProjectUpdated` refresh wiring.
+
+---
+
+## Task 1: Project Files section
+
+Mirrors `ProjectNotesSection` for `itemType === 'file'`, resolving each link via `notesService.getFile` and skipping orphaned/markdown links.
+
+**Files:**
+
+- Create: `apps/desktop/src/renderer/src/components/tasks/projects/project-files-section.tsx`
+- Test: `apps/desktop/src/renderer/src/components/tasks/projects/project-files-section.test.tsx`
+- Modify: `packages/i18n/src/locales/en/tasks.json`
+
+**Interfaces:**
+
+- Consumes: `tasksService.listProjectLinks(projectId) → Promise<ProjectLink[]>` where `ProjectLink = { id; projectId; itemType: string; itemId: string; position: number; createdAt: string }`; `tasksService.unlinkProjectItem({ projectId, itemType, itemId }) → Promise<{ success: boolean; error?: string }>`; `notesService.getFile(id) → Promise<FileMetadata | null>` where `FileMetadata` has `{ id: string; title: string; fileType: 'pdf'|'image'|'audio'|'video' }`.
+- Produces: `export const ProjectFilesSection: (props: { projectId: string; onFileClick?: (fileId: string) => void; className?: string }) => React.JSX.Element | null`.
+
+- [ ] **Step 1: Add i18n keys**
+
+In `packages/i18n/src/locales/en/tasks.json`, add a `projectFiles` block as a sibling of the existing `projectNotes` block (keep the file valid JSON — add a comma after the preceding block):
+
+```json
+  "projectFiles": {
+    "title": "Files",
+    "loading": "Loading files…",
+    "loadError": "Failed to load project files",
+    "removeFromProject": "Remove from project",
+    "removeError": "Failed to remove file from project"
+  },
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `project-files-section.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ProjectFilesSection } from './project-files-section'
+
+const mocks = vi.hoisted(() => ({
+  listProjectLinks: vi.fn(),
+  unlinkProjectItem: vi.fn(),
+  getFile: vi.fn()
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() })
+}))
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: {
+    listProjectLinks: mocks.listProjectLinks,
+    unlinkProjectItem: mocks.unlinkProjectItem
+  }
+}))
+vi.mock('@/services/notes-service', () => ({
+  notesService: { getFile: mocks.getFile }
+}))
+
+const fileLink = (id: string) => ({
+  id: `link-${id}`,
+  projectId: 'p1',
+  itemType: 'file',
+  itemId: id,
+  position: 0,
+  createdAt: ''
+})
+
+describe('ProjectFilesSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.unlinkProjectItem.mockResolvedValue({ success: true })
+  })
+
+  it('#then lists only file-typed links, resolved by getFile', async () => {
+    mocks.listProjectLinks.mockResolvedValue([
+      fileLink('f1'),
+      { id: 'link-n', projectId: 'p1', itemType: 'note', itemId: 'n1', position: 0, createdAt: '' }
+    ])
+    mocks.getFile.mockImplementation(async (id: string) =>
+      id === 'f1' ? { id: 'f1', title: 'Budget.pdf', fileType: 'pdf' } : null
+    )
+
+    render(<ProjectFilesSection projectId="p1" />)
+
+    expect(await screen.findByText('Budget.pdf')).toBeInTheDocument()
+    // The note-typed link is never resolved as a file.
+    expect(mocks.getFile).toHaveBeenCalledTimes(1)
+    expect(mocks.getFile).toHaveBeenCalledWith('f1')
+  })
+
+  it('#then skips orphaned file links whose getFile returns null', async () => {
+    mocks.listProjectLinks.mockResolvedValue([fileLink('f1'), fileLink('gone')])
+    mocks.getFile.mockImplementation(async (id: string) =>
+      id === 'f1' ? { id: 'f1', title: 'Slide.png', fileType: 'image' } : null
+    )
+
+    render(<ProjectFilesSection projectId="p1" />)
+
+    expect(await screen.findByText('Slide.png')).toBeInTheDocument()
+    expect(screen.queryByText('gone')).not.toBeInTheDocument()
+  })
+
+  it('#then renders nothing when there are no file links', async () => {
+    mocks.listProjectLinks.mockResolvedValue([])
+    const { container } = render(<ProjectFilesSection projectId="p1" />)
+    await waitFor(() => expect(mocks.listProjectLinks).toHaveBeenCalled())
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('#then unlinks a file on remove click', async () => {
+    mocks.listProjectLinks.mockResolvedValue([fileLink('f1')])
+    mocks.getFile.mockResolvedValue({ id: 'f1', title: 'Budget.pdf', fileType: 'pdf' })
+
+    render(<ProjectFilesSection projectId="p1" />)
+    await screen.findByText('Budget.pdf')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove from project' }))
+
+    await waitFor(() =>
+      expect(mocks.unlinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'file',
+        itemId: 'f1'
+      })
+    )
+    expect(screen.queryByText('Budget.pdf')).not.toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- project-files-section`
+Expected: FAIL — `Cannot find module './project-files-section'`.
+
+- [ ] **Step 4: Write the component**
+
+Create `project-files-section.tsx` (mirror `project-notes-section.tsx`; per-`fileType` icon; `notesService.getFile` resolution; skip nulls):
+
+```tsx
+import { useCallback, useEffect, useState } from 'react'
+import { File, FileText, Image, Music, Video, Loader2, X } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { tasksService } from '@/services/tasks-service'
+import { notesService } from '@/services/notes-service'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { createLogger } from '@/lib/logger'
+import { useT } from '@memry/i18n/renderer'
+
+const log = createLogger('ProjectFiles')
+
+type FileKind = 'pdf' | 'image' | 'audio' | 'video'
+
+interface LinkedFile {
+  itemId: string
+  title: string
+  fileType: FileKind
+}
+
+const FILE_ICONS = {
+  pdf: FileText,
+  image: Image,
+  audio: Music,
+  video: Video
+} as const
+
+interface ProjectFilesSectionProps {
+  projectId: string
+  onFileClick?: (fileId: string) => void
+  className?: string
+}
+
+/**
+ * Project Home "Files" section — lists the files (notes with a non-markdown
+ * fileType) linked to a project via `project_links` and lets the user unlink
+ * one. Files are resolved through `notesService.getFile`, which returns null
+ * for a deleted file or a markdown note, so orphaned links are skipped.
+ */
+export const ProjectFilesSection = ({
+  projectId,
+  onFileClick,
+  className
+}: ProjectFilesSectionProps): React.JSX.Element | null => {
+  const { t } = useT('tasks')
+  const [files, setFiles] = useState<LinkedFile[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  const loadFiles = useCallback(async (): Promise<void> => {
+    setIsLoading(true)
+    try {
+      const links = await tasksService.listProjectLinks(projectId)
+      const fileLinks = links.filter((link) => link.itemType === 'file')
+      const resolved = await Promise.all(
+        fileLinks.map(async (link) => {
+          // Defensive: getFile returns null for a deleted file (orphaned link)
+          // or a markdown id; skip either. Cleanup of orphaned links is owned
+          // by a concurrent effort.
+          const file = await notesService.getFile(link.itemId)
+          if (!file) return null
+          return { itemId: link.itemId, title: file.title, fileType: file.fileType }
+        })
+      )
+      setFiles(resolved.filter((file): file is LinkedFile => file !== null))
+    } catch (error) {
+      log.error(
+        'Failed to load project files',
+        extractErrorMessage(error, t('projectFiles.loadError'))
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }, [projectId, t])
+
+  useEffect(() => {
+    void loadFiles()
+  }, [loadFiles])
+
+  const handleRemove = useCallback(
+    async (itemId: string): Promise<void> => {
+      try {
+        await tasksService.unlinkProjectItem({ projectId, itemType: 'file', itemId })
+        setFiles((prev) => prev.filter((file) => file.itemId !== itemId))
+      } catch (error) {
+        log.error(
+          'Failed to remove file from project',
+          extractErrorMessage(error, t('projectFiles.removeError'))
+        )
+      }
+    },
+    [projectId, t]
+  )
+
+  if (!isLoading && files.length === 0) return null
+
+  return (
+    <section className={cn('px-4 py-3 border-t border-border', className)}>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {t('projectFiles.title')}
+      </h3>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          {t('projectFiles.loading')}
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {files.map((file) => {
+            const Icon = FILE_ICONS[file.fileType] ?? File
+            return (
+              <div
+                key={file.itemId}
+                className="group relative flex items-center gap-2 rounded-md border border-border p-2 hover:bg-surface-hover"
+              >
+                <button
+                  type="button"
+                  className="flex min-w-0 flex-1 items-center gap-2 text-start"
+                  onClick={() => onFileClick?.(file.itemId)}
+                >
+                  <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  <span className="truncate text-sm">{file.title}</span>
+                </button>
+                <button
+                  type="button"
+                  aria-label={t('projectFiles.removeFromProject')}
+                  onClick={() => void handleRemove(file.itemId)}
+                  className="shrink-0 rounded-sm p-1 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+                >
+                  <X className="size-3.5" aria-hidden="true" />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default ProjectFilesSection
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- project-files-section`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: i18n gate**
+
+Run: `pnpm --filter @memry/desktop i18n:check`
+Expected: PASS (English keys present).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/tasks/projects/project-files-section.tsx \
+        apps/desktop/src/renderer/src/components/tasks/projects/project-files-section.test.tsx \
+        packages/i18n/src/locales/en/tasks.json
+git commit -m "feat(projects): add Project Home Files section"
+```
+
+---
+
+## Task 2: Mount Files section + Files stat tile
+
+Mounts `ProjectFilesSection` on Project Home below the Events section and adds a Files count to the stats row.
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/components/tasks/projects/project-stats-row.tsx`
+- Modify: `apps/desktop/src/renderer/src/components/tasks/projects/project-stats-row.test.tsx`
+- Modify: `apps/desktop/src/renderer/src/pages/project-home.tsx`
+- Modify: `apps/desktop/src/renderer/src/pages/project-home.test.tsx`
+- Modify: `packages/i18n/src/locales/en/tasks.json`
+
+**Interfaces:**
+
+- Consumes: `ProjectFilesSection` (Task 1); `ProjectLink.itemType`.
+- Produces: `ProjectStatsRow` now requires `fileCount: number`.
+
+- [ ] **Step 1: Add the stats i18n key**
+
+In `packages/i18n/src/locales/en/tasks.json`, add `"files": "Files"` to the existing `projectHome.stats` object (which currently has `tasks`/`notes`/`events`/`progress`).
+
+- [ ] **Step 2: Update the stats-row test (failing)**
+
+In `project-stats-row.test.tsx`, add `fileCount` to the rendered props and assert the Files tile. (Read the existing test first; add a case mirroring the notes/events assertions, and add `fileCount={4}` to any existing render call so the required prop is satisfied.) Example new case:
+
+```tsx
+it('#then renders the files tile', () => {
+  render(
+    <ProjectStatsRow taskCount={1} noteCount={2} eventCount={3} fileCount={4} progressPct={50} />
+  )
+  expect(screen.getByText('Files')).toBeInTheDocument()
+  expect(screen.getByText('4')).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- project-stats-row`
+Expected: FAIL — type error / missing `fileCount`.
+
+- [ ] **Step 4: Add the prop + tile**
+
+In `project-stats-row.tsx`: add `fileCount: number` to `ProjectStatsRowProps`, destructure it, add a Files tile between Events and Progress, and widen the grid to 5 columns:
+
+```tsx
+interface ProjectStatsRowProps {
+  taskCount: number
+  noteCount: number
+  eventCount: number
+  fileCount: number
+  progressPct: number
+  className?: string
+}
+
+export const ProjectStatsRow = ({
+  taskCount,
+  noteCount,
+  eventCount,
+  fileCount,
+  progressPct,
+  className
+}: ProjectStatsRowProps): React.JSX.Element => {
+  const { t } = useT('tasks')
+  const tiles = [
+    { label: t('projectHome.stats.tasks'), value: String(taskCount) },
+    { label: t('projectHome.stats.notes'), value: String(noteCount) },
+    { label: t('projectHome.stats.events'), value: String(eventCount) },
+    { label: t('projectHome.stats.files'), value: String(fileCount) },
+    { label: t('projectHome.stats.progress'), value: `${progressPct}%` }
+  ]
+  return (
+    <div className={cn('grid grid-cols-5 gap-3 px-4 py-3', className)}>
+      {tiles.map((tile) => (
+        <div
+          key={tile.label}
+          className="rounded-lg border border-border bg-surface p-3 text-center"
+        >
+          <div className="text-lg font-semibold text-foreground">{tile.value}</div>
+          <div className="mt-0.5 text-xs uppercase tracking-wide text-muted-foreground">
+            {tile.label}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Wire Project Home**
+
+In `project-home.tsx`:
+
+1. Add the import next to the other section imports:
+
+```tsx
+import { ProjectFilesSection } from '@/components/tasks/projects/project-files-section'
+```
+
+2. Add a `fileCount` memo next to `noteCount`/`eventCount`:
+
+```tsx
+const fileCount = useMemo(() => links.filter((link) => link.itemType === 'file').length, [links])
+```
+
+3. Pass it to `<ProjectStatsRow>`:
+
+```tsx
+<ProjectStatsRow
+  taskCount={projectTasks.length}
+  noteCount={noteCount}
+  eventCount={eventCount}
+  fileCount={fileCount}
+  progressPct={progressPct}
+/>
+```
+
+4. Mount the section below `<ProjectNotesSection>` (the `FILES_SECTION_SLOT`). `handleNoteClick` already routes any vault item id via `openRelatedVaultItem`, so reuse it for files:
+
+```tsx
+;<ProjectNotesSection projectId={project.id} onNoteClick={handleNoteClick} />
+
+{
+  /* FILES_SECTION_SLOT */
+}
+;<ProjectFilesSection projectId={project.id} onFileClick={handleNoteClick} />
+```
+
+- [ ] **Step 6: Add the Project Home files test**
+
+In `project-home.test.tsx`, add a test that a file link renders. `notesGetFile` is already mocked; make `listProjectLinks` return a file link and `getFile` resolve it:
+
+```tsx
+it('#then renders linked files in the Files section', async () => {
+  mocks.listProjectLinks.mockResolvedValue([
+    { id: 'l-f', projectId: 'p1', itemType: 'file', itemId: 'f1', position: 0, createdAt: '' }
+  ])
+  mocks.notesGetFile.mockResolvedValue({ id: 'f1', title: 'Budget.pdf', fileType: 'pdf' })
+
+  render(<ProjectHomePage projectId="p1" />)
+
+  expect(await screen.findByText('Budget.pdf')).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- project-stats-row project-home`
+Expected: PASS (stats-row + project-home suites, including the new cases).
+
+- [ ] **Step 8: i18n gate + commit**
+
+```bash
+pnpm --filter @memry/desktop i18n:check
+git add apps/desktop/src/renderer/src/pages/project-home.tsx \
+        apps/desktop/src/renderer/src/pages/project-home.test.tsx \
+        apps/desktop/src/renderer/src/components/tasks/projects/project-stats-row.tsx \
+        apps/desktop/src/renderer/src/components/tasks/projects/project-stats-row.test.tsx \
+        packages/i18n/src/locales/en/tasks.json
+git commit -m "feat(projects): mount Files section and Files stat on Project Home"
+```
+
+---
+
+## Task 3: "Add file to project" dialog
+
+Mirrors `AddNoteToProjectDialog` with `itemType: 'file'`. Reuses the existing `addToProject.*` i18n copy.
+
+**Files:**
+
+- Create: `apps/desktop/src/renderer/src/components/tasks/projects/add-file-to-project-dialog.tsx`
+- Test: `apps/desktop/src/renderer/src/components/tasks/projects/add-file-to-project-dialog.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `tasksService.listProjects() → Promise<{ projects: ProjectWithStats[] }>`; `tasksService.linkProjectItem({ projectId, itemType, itemId }) → Promise<{ success: boolean; error?: string }>`.
+- Produces: `export const AddFileToProjectDialog: (props: { open: boolean; onOpenChange: (open: boolean) => void; fileId: string }) => React.JSX.Element`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `add-file-to-project-dialog.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AddFileToProjectDialog } from './add-file-to-project-dialog'
+
+const mocks = vi.hoisted(() => ({
+  listProjects: vi.fn(),
+  linkProjectItem: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn()
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() })
+}))
+vi.mock('sonner', () => ({
+  toast: { success: mocks.toastSuccess, error: mocks.toastError }
+}))
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: { listProjects: mocks.listProjects, linkProjectItem: mocks.linkProjectItem }
+}))
+
+describe('AddFileToProjectDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.listProjects.mockResolvedValue({
+      projects: [{ id: 'p1', name: 'Launch', color: '#f00', archivedAt: null }]
+    })
+    mocks.linkProjectItem.mockResolvedValue({ success: true })
+  })
+
+  it('#then links the file to the chosen project as itemType file', async () => {
+    render(<AddFileToProjectDialog open onOpenChange={vi.fn()} fileId="f1" />)
+
+    await userEvent.click(await screen.findByText('Launch'))
+
+    await waitFor(() =>
+      expect(mocks.linkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'file',
+        itemId: 'f1'
+      })
+    )
+    expect(mocks.toastSuccess).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- add-file-to-project-dialog`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the dialog**
+
+Create `add-file-to-project-dialog.tsx` — copy `add-note-to-project-dialog.tsx` verbatim, then change: the interface name → `AddFileToProjectDialogProps`, the prop `noteId` → `fileId`, the component name → `AddFileToProjectDialog`, the doc comment → "File info bar → 'Add to project'", and the link call to:
+
+```tsx
+const result = await tasksService.linkProjectItem({
+  projectId: project.id,
+  itemType: 'file',
+  itemId: fileId
+})
+```
+
+Full file:
+
+```tsx
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { cn } from '@/lib/utils'
+import { tasksService, type ProjectWithStats } from '@/services/tasks-service'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { createLogger } from '@/lib/logger'
+import { useT } from '@memry/i18n/renderer'
+
+const log = createLogger('AddToProject')
+
+interface AddFileToProjectDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  fileId: string
+}
+
+/**
+ * File info bar → "Add to project": lists active projects and links the file
+ * to the chosen one via `PROJECT_LINK_ITEM` (itemType 'file').
+ */
+export const AddFileToProjectDialog = ({
+  open,
+  onOpenChange,
+  fileId
+}: AddFileToProjectDialogProps): React.JSX.Element => {
+  const { t } = useT('tasks')
+  const [projects, setProjects] = useState<ProjectWithStats[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setIsLoading(true)
+    tasksService
+      .listProjects()
+      .then((res) => setProjects(res.projects.filter((project) => project.archivedAt == null)))
+      .catch((error) => log.error('Failed to list projects', extractErrorMessage(error)))
+      .finally(() => setIsLoading(false))
+  }, [open])
+
+  const handleSelect = async (project: ProjectWithStats): Promise<void> => {
+    try {
+      const result = await tasksService.linkProjectItem({
+        projectId: project.id,
+        itemType: 'file',
+        itemId: fileId
+      })
+      if (!result.success) throw new Error(result.error)
+      toast.success(t('addToProject.toastSuccess', { name: project.name }))
+      onOpenChange(false)
+    } catch (error) {
+      toast.error(extractErrorMessage(error, t('addToProject.toastError')))
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{t('addToProject.dialogTitle')}</DialogTitle>
+        </DialogHeader>
+        <ScrollArea className="max-h-[300px] -mx-2">
+          <div className="space-y-1 px-2">
+            {isLoading ? (
+              <div className="flex items-center justify-center h-20 text-sm text-muted-foreground">
+                {t('addToProject.loading')}
+              </div>
+            ) : projects.length === 0 ? (
+              <div className="flex items-center justify-center h-20 text-sm text-muted-foreground">
+                {t('addToProject.noProjects')}
+              </div>
+            ) : (
+              projects.map((project) => (
+                <button
+                  key={project.id}
+                  type="button"
+                  onClick={() => void handleSelect(project)}
+                  className={cn(
+                    'flex w-full items-center gap-2 rounded-md p-2 text-start transition-colors',
+                    'hover:bg-muted/50'
+                  )}
+                >
+                  <span
+                    className="size-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: project.color }}
+                    aria-hidden="true"
+                  />
+                  <span className="truncate text-sm">{project.name}</span>
+                </button>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default AddFileToProjectDialog
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- add-file-to-project-dialog`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/tasks/projects/add-file-to-project-dialog.tsx \
+        apps/desktop/src/renderer/src/components/tasks/projects/add-file-to-project-dialog.test.tsx
+git commit -m "feat(projects): add AddFileToProjectDialog"
+```
+
+---
+
+## Task 4: FilePage "Add to project" entry point + chips
+
+Adds an "Add to project" button to the `FilePage` info bar (mirroring the note ⋯ menu entry) and shows the file's project-membership chips.
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/pages/file.tsx`
+- Test: `apps/desktop/src/renderer/src/pages/file.test.tsx` (create if absent)
+
+**Interfaces:**
+
+- Consumes: `AddFileToProjectDialog` (Task 3); `ItemProjectChips` (`{ itemType: 'file'; itemId: string; onProjectClick? }`); `useTabActions().openTab`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend `file.test.tsx`. Mock `notesService.getFile` to resolve a file, mock `ItemProjectChips` + `AddFileToProjectDialog` to simple markers, and assert the button opens the dialog:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { FilePage } from './file'
+
+const mocks = vi.hoisted(() => ({ getFile: vi.fn(), openTab: vi.fn() }))
+
+vi.mock('@/services/notes-service', () => ({ notesService: { getFile: mocks.getFile } }))
+vi.mock('@/contexts/tabs', () => ({ useTabActions: () => ({ openTab: mocks.openTab }) }))
+vi.mock('@/components/tasks/projects/item-project-chips', () => ({
+  ItemProjectChips: ({ itemType, itemId }: { itemType: string; itemId: string }) => (
+    <div data-testid="chips" data-item-type={itemType} data-item-id={itemId} />
+  )
+}))
+vi.mock('@/components/tasks/projects/add-file-to-project-dialog', () => ({
+  AddFileToProjectDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="add-file-dialog" /> : null
+}))
+
+const renderPage = (fileId: string) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <FilePage fileId={fileId} />
+    </QueryClientProvider>
+  )
+}
+
+describe('FilePage add-to-project', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getFile.mockResolvedValue({
+      id: 'f1',
+      title: 'Budget.pdf',
+      absolutePath: '/v/Budget.pdf',
+      fileType: 'pdf',
+      mimeType: 'application/pdf',
+      fileSize: 10,
+      created: new Date(),
+      modified: new Date()
+    })
+  })
+
+  it('#then renders file chips with itemType file', async () => {
+    renderPage('f1')
+    const chips = await screen.findByTestId('chips')
+    expect(chips).toHaveAttribute('data-item-type', 'file')
+    expect(chips).toHaveAttribute('data-item-id', 'f1')
+  })
+
+  it('#then opens the add-to-project dialog from the info-bar button', async () => {
+    renderPage('f1')
+    await userEvent.click(await screen.findByRole('button', { name: 'Add to project' }))
+    expect(screen.getByTestId('add-file-dialog')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- pages/file`
+Expected: FAIL — no "Add to project" button / no chips.
+
+- [ ] **Step 3: Implement the entry point**
+
+In `file.tsx`:
+
+1. Add imports:
+
+```tsx
+import { useState } from 'react'
+import { Loader2, FileWarning, Download, ExternalLink, FolderPlus } from '@/lib/icons'
+import { useTabActions } from '@/contexts/tabs'
+import { ItemProjectChips } from '@/components/tasks/projects/item-project-chips'
+import { AddFileToProjectDialog } from '@/components/tasks/projects/add-file-to-project-dialog'
+```
+
+(Keep the existing `@/lib/icons` import — just add `FolderPlus`. Merge the `useState` into the existing React import.)
+
+2. Change `FileInfoBar` to accept an `onAddToProject` callback and render the button + chips. Add a `tTasks` hook for the tasks-namespace label:
+
+```tsx
+function FileInfoBar({ file, onAddToProject }: { file: FileMetadata; onAddToProject: () => void }) {
+  const { t: tPhaseF } = useT('notes')
+  const { t: tTasks } = useT('tasks')
+  return (
+    <div className="flex flex-col gap-1 border-b border-border bg-muted/30 flex-shrink-0">
+      <div className="flex items-center justify-between gap-2 px-2 sm:px-4 py-2">
+        <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
+          <h1 className="font-medium truncate flex-1 min-w-0">{file.title}</h1>
+          <span className="text-xs text-muted-foreground uppercase flex-shrink-0 hidden sm:inline">
+            {file.fileType}
+          </span>
+          <span className="text-xs text-muted-foreground flex-shrink-0 hidden md:inline">
+            {formatFileSize(file.fileSize)}
+          </span>
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onAddToProject}
+            className="h-8 w-8 p-0 sm:w-auto sm:px-3"
+            title={tTasks('addToProject.menuLabel')}
+          >
+            <FolderPlus className="h-4 w-4 sm:me-1" />
+            <span className="hidden sm:inline">{tTasks('addToProject.menuLabel')}</span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void window.api.notes.openExternal(file.id)}
+            className="h-8 w-8 p-0 sm:w-auto sm:px-3"
+            title={tPhaseF('phaseF.pagesFile.openInDefaultApp')}
+          >
+            <ExternalLink className="h-4 w-4 sm:me-1" />
+            <span className="hidden sm:inline">{tPhaseF('phaseF.pagesFile.open')}</span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void window.api.notes.revealInFinder(file.id)}
+            className="h-8 w-8 p-0 sm:w-auto sm:px-3"
+            title={tPhaseF('phaseF.pagesFile.revealInFinder')}
+          >
+            <Download className="h-4 w-4 sm:me-1" />
+            <span className="hidden sm:inline">{tPhaseF('phaseF.pagesFile.reveal')}</span>
+          </Button>
+        </div>
+      </div>
+      <div className="px-2 sm:px-4 pb-2">
+        <ItemProjectChips itemType="file" itemId={file.id} />
+      </div>
+    </div>
+  )
+}
+```
+
+Note: `ItemProjectChips` returns `null` when the file has no projects, so the chip strip collapses cleanly.
+
+3. In `FilePage`, add dialog state + wire the button, and pass an `onProjectClick` from chips to open the project (optional — chips already render). Update the success return:
+
+```tsx
+export function FilePage({ fileId }: FilePageProps) {
+  const [addToProjectOpen, setAddToProjectOpen] = useState(false)
+  // ...existing useQuery + guards unchanged...
+
+  return (
+    <div className={cn('flex h-full flex-col min-h-0')}>
+      <FileInfoBar file={file} onAddToProject={() => setAddToProjectOpen(true)} />
+      <FileViewer file={file} />
+      <AddFileToProjectDialog
+        open={addToProjectOpen}
+        onOpenChange={setAddToProjectOpen}
+        fileId={file.id}
+      />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- pages/file`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/pages/file.tsx \
+        apps/desktop/src/renderer/src/pages/file.test.tsx
+git commit -m "feat(projects): add 'Add to project' + membership chips to FilePage"
+```
+
+---
+
+## Task 5: Sidebar drag-note/file-onto-project → link
+
+Widens `MEMRY_NOTE_DRAG_MIME` to cover markdown notes (not just files), then adds a native HTML5 drop target on the sidebar project item that links the dragged item (resolving file vs note).
+
+**Files:**
+
+- Create: `apps/desktop/src/renderer/src/lib/link-sidebar-item-to-project.ts`
+- Test: `apps/desktop/src/renderer/src/lib/link-sidebar-item-to-project.test.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/drag-mime.ts` (doc comment only)
+- Modify: `apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx` (drag source)
+- Modify: `apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.tsx`
+- Test: `apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.test.tsx` (create)
+
+**Interfaces:**
+
+- Consumes: `MEMRY_NOTE_DRAG_MIME`; `notesService.getFile(id) → Promise<{ id } | null>`; `tasksService.linkProjectItem(input) → Promise<{ success: boolean; error?: string }>`.
+- Produces: `export async function linkSidebarItemToProject(dataTransfer: Pick<DataTransfer,'getData'|'types'>, projectId: string, deps: { getFile; link }): Promise<{ itemType: 'note'|'file'; itemId: string } | null>`.
+
+- [ ] **Step 1: Write the failing helper test**
+
+Create `link-sidebar-item-to-project.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { linkSidebarItemToProject } from './link-sidebar-item-to-project'
+import { MEMRY_NOTE_DRAG_MIME } from './drag-mime'
+
+const dt = (mime: string | null, id: string): Pick<DataTransfer, 'getData' | 'types'> => ({
+  types: mime ? [mime] : [],
+  getData: (type: string) => (type === mime ? id : '')
+})
+
+describe('linkSidebarItemToProject', () => {
+  it('#then links a markdown note as itemType note', async () => {
+    const getFile = vi.fn().mockResolvedValue(null)
+    const link = vi.fn().mockResolvedValue({ success: true })
+
+    const result = await linkSidebarItemToProject(dt(MEMRY_NOTE_DRAG_MIME, 'n1'), 'p1', {
+      getFile,
+      link
+    })
+
+    expect(link).toHaveBeenCalledWith({ projectId: 'p1', itemType: 'note', itemId: 'n1' })
+    expect(result).toEqual({ itemType: 'note', itemId: 'n1' })
+  })
+
+  it('#then links a file (getFile non-null) as itemType file', async () => {
+    const getFile = vi.fn().mockResolvedValue({ id: 'f1' })
+    const link = vi.fn().mockResolvedValue({ success: true })
+
+    const result = await linkSidebarItemToProject(dt(MEMRY_NOTE_DRAG_MIME, 'f1'), 'p1', {
+      getFile,
+      link
+    })
+
+    expect(link).toHaveBeenCalledWith({ projectId: 'p1', itemType: 'file', itemId: 'f1' })
+    expect(result).toEqual({ itemType: 'file', itemId: 'f1' })
+  })
+
+  it('#then no-ops when the drag carries no note MIME', async () => {
+    const getFile = vi.fn()
+    const link = vi.fn()
+
+    const result = await linkSidebarItemToProject(dt(null, ''), 'p1', { getFile, link })
+
+    expect(result).toBeNull()
+    expect(getFile).not.toHaveBeenCalled()
+    expect(link).not.toHaveBeenCalled()
+  })
+
+  it('#then throws when link fails', async () => {
+    const getFile = vi.fn().mockResolvedValue(null)
+    const link = vi.fn().mockResolvedValue({ success: false, error: 'boom' })
+
+    await expect(
+      linkSidebarItemToProject(dt(MEMRY_NOTE_DRAG_MIME, 'n1'), 'p1', { getFile, link })
+    ).rejects.toThrow('boom')
+  })
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- link-sidebar-item-to-project`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the helper**
+
+Create `link-sidebar-item-to-project.ts`:
+
+```ts
+import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
+import type { ProjectItemType } from '@/services/tasks-service'
+
+interface LinkSidebarItemDeps {
+  getFile: (id: string) => Promise<{ id: string } | null>
+  link: (input: {
+    projectId: string
+    itemType: ProjectItemType
+    itemId: string
+  }) => Promise<{ success: boolean; error?: string }>
+}
+
+/**
+ * Links a sidebar item (dragged from the notes tree via MEMRY_NOTE_DRAG_MIME)
+ * to a project. Files are notes with a non-markdown fileType, so
+ * `getFile(id)` returns non-null exactly for files — the file/note
+ * discriminator. Returns null when the drag carried no linkable item (so the
+ * caller can skip the toast); throws when the link call reports failure.
+ */
+export async function linkSidebarItemToProject(
+  dataTransfer: Pick<DataTransfer, 'getData' | 'types'>,
+  projectId: string,
+  deps: LinkSidebarItemDeps
+): Promise<{ itemType: ProjectItemType; itemId: string } | null> {
+  if (!dataTransfer.types.includes(MEMRY_NOTE_DRAG_MIME)) return null
+  const itemId = dataTransfer.getData(MEMRY_NOTE_DRAG_MIME)
+  if (!itemId) return null
+
+  const file = await deps.getFile(itemId)
+  const itemType: ProjectItemType = file ? 'file' : 'note'
+  const result = await deps.link({ projectId, itemType, itemId })
+  if (!result.success) throw new Error(result.error)
+  return { itemType, itemId }
+}
+```
+
+Note: `ProjectItemType` is `'note' | 'calendar_event' | 'file'` and is already exported from `@/services/tasks-service`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- link-sidebar-item-to-project`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Widen the drag source**
+
+In `virtualized-notes-tree.tsx` `handleDragStart` (currently ~line 928-935), move the `MEMRY_NOTE_DRAG_MIME` `setData` OUT of the `fileType !== 'markdown'` guard so **every** non-folder item carries it. Result:
+
+```tsx
+if (!isFolder(itemId)) {
+  // Tag every note/file item so drop targets (note editor embed, sidebar
+  // project link) can resolve it by id. getFile(id) later discriminates
+  // a file (non-markdown, embeddable) from a plain note (returns null).
+  e.dataTransfer.setData(MEMRY_NOTE_DRAG_MIME, itemId)
+  // Every non-folder item is a note entity — tag it so the spatial canvas
+  // can create a referencing card on drop (markdown notes set no other MIME).
+  e.dataTransfer.setData(CANVAS_ITEM_DRAG_MIME, canvasDragPayload('note', itemId))
+}
+```
+
+(The `noteMap`/`fileType` lookup for this block is no longer needed; remove those two now-orphaned lines but keep the rest of `handleDragStart` and its dependency array intact.)
+
+- [ ] **Step 6: Update the drag-mime doc**
+
+In `drag-mime.ts`, update the comment so it no longer claims "file-type item only":
+
+```ts
+/**
+ * Custom drag data type set when any note or file item is dragged out of the
+ * left sidebar (`VirtualizedNotesTree`). The payload is the item's note id.
+ *
+ * Consumers:
+ * - the note editor embeds a *file* item by its own vault path
+ *   (`window.api.notes.getFile(id)`; a markdown note resolves to null → no-op);
+ * - a sidebar project drop links the item to the project (file vs note is
+ *   resolved via `getFile`).
+ */
+export const MEMRY_NOTE_DRAG_MIME = 'application/x-memry-note'
+```
+
+- [ ] **Step 7: Write the failing project-item drop test**
+
+Create `sortable-project-item.test.tsx`. Wrap in `DndContext` (dnd-kit hooks require it) and fire a native `drop` with a stub `dataTransfer`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { DndContext } from '@dnd-kit/core'
+import { SortableContext } from '@dnd-kit/sortable'
+import { SortableProjectItem } from './sortable-project-item'
+import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
+import type { Project } from '@/data/tasks-data'
+
+const mocks = vi.hoisted(() => ({
+  getFile: vi.fn(),
+  linkProjectItem: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn()
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() })
+}))
+vi.mock('sonner', () => ({ toast: { success: mocks.toastSuccess, error: mocks.toastError } }))
+vi.mock('@/services/notes-service', () => ({ notesService: { getFile: mocks.getFile } }))
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: { linkProjectItem: mocks.linkProjectItem }
+}))
+
+const project = { id: 'p1', name: 'Launch', color: '#f00', taskCount: 0 } as unknown as Project
+
+const renderItem = () =>
+  render(
+    <DndContext>
+      <SortableContext items={['p1']}>
+        <ul>
+          <SortableProjectItem
+            project={project}
+            isActive={false}
+            onClick={vi.fn()}
+            onEdit={vi.fn()}
+            onArchive={vi.fn()}
+            onDelete={vi.fn()}
+          />
+        </ul>
+      </SortableContext>
+    </DndContext>
+  )
+
+const noteDataTransfer = (id: string) => ({
+  types: [MEMRY_NOTE_DRAG_MIME],
+  getData: (type: string) => (type === MEMRY_NOTE_DRAG_MIME ? id : ''),
+  dropEffect: 'none'
+})
+
+describe('SortableProjectItem drop-to-link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.linkProjectItem.mockResolvedValue({ success: true })
+  })
+
+  it('#then links a dropped markdown note as a note', async () => {
+    mocks.getFile.mockResolvedValue(null)
+    renderItem()
+
+    fireEvent.drop(screen.getByText('Launch').closest('li')!, {
+      dataTransfer: noteDataTransfer('n1')
+    })
+
+    await waitFor(() =>
+      expect(mocks.linkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'note',
+        itemId: 'n1'
+      })
+    )
+    expect(mocks.toastSuccess).toHaveBeenCalled()
+  })
+
+  it('#then links a dropped file as a file', async () => {
+    mocks.getFile.mockResolvedValue({ id: 'f1' })
+    renderItem()
+
+    fireEvent.drop(screen.getByText('Launch').closest('li')!, {
+      dataTransfer: noteDataTransfer('f1')
+    })
+
+    await waitFor(() =>
+      expect(mocks.linkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'file',
+        itemId: 'f1'
+      })
+    )
+  })
+})
+```
+
+- [ ] **Step 8: Run it to verify it fails**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- sortable-project-item`
+Expected: FAIL — no drop handler wired (`linkProjectItem` never called).
+
+- [ ] **Step 9: Wire the native drop target**
+
+In `sortable-project-item.tsx`:
+
+1. Add imports:
+
+```tsx
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+import { MEMRY_NOTE_DRAG_MIME } from '@/lib/drag-mime'
+import { linkSidebarItemToProject } from '@/lib/link-sidebar-item-to-project'
+import { notesService } from '@/services/notes-service'
+import { tasksService } from '@/services/tasks-service'
+import { extractErrorMessage } from '@/lib/ipc-error'
+```
+
+Add a tasks-namespace translation hook next to the existing `useT('notes')`:
+
+```tsx
+const { t: tTasks } = useT('tasks')
+```
+
+2. Add drop state + handlers inside the component:
+
+```tsx
+const [isNoteDragOver, setIsNoteDragOver] = useState(false)
+
+const handleNoteDragOver = useCallback((e: React.DragEvent): void => {
+  if (!e.dataTransfer.types.includes(MEMRY_NOTE_DRAG_MIME)) return
+  e.preventDefault()
+  e.dataTransfer.dropEffect = 'copy'
+  setIsNoteDragOver(true)
+}, [])
+
+const handleNoteDragLeave = useCallback((): void => {
+  setIsNoteDragOver(false)
+}, [])
+
+const handleNoteDrop = useCallback(
+  (e: React.DragEvent): void => {
+    if (!e.dataTransfer.types.includes(MEMRY_NOTE_DRAG_MIME)) return
+    e.preventDefault()
+    setIsNoteDragOver(false)
+    void (async () => {
+      try {
+        const linked = await linkSidebarItemToProject(e.dataTransfer, project.id, {
+          getFile: (id) => notesService.getFile(id),
+          link: (input) => tasksService.linkProjectItem(input)
+        })
+        if (linked) toast.success(tTasks('addToProject.toastSuccess', { name: project.name }))
+      } catch (error) {
+        toast.error(extractErrorMessage(error, tTasks('addToProject.toastError')))
+      }
+    })()
+  },
+  [project.id, project.name, tTasks]
+)
+```
+
+3. Attach the handlers + affordance to the `<SidebarMenuItem>`. Add to its `className` a `isNoteDragOver && 'bg-primary/10 ring-2 ring-primary rounded-md'` clause (alongside the existing `isOver` clause), and add the event props:
+
+```tsx
+    <SidebarMenuItem
+      ref={setRefs}
+      style={style}
+      onDragOver={handleNoteDragOver}
+      onDragLeave={handleNoteDragLeave}
+      onDrop={handleNoteDrop}
+      className={cn(
+        'group/project relative transition-all duration-150',
+        isSortableDragging && 'opacity-50 z-50',
+        showAsDropZone && 'border border-dotted border-muted-foreground/40 rounded-md',
+        isOver && 'bg-primary/10 ring-2 ring-primary rounded-md shadow-sm',
+        isNoteDragOver && 'bg-primary/10 ring-2 ring-primary rounded-md shadow-sm'
+      )}
+      {...attributes}
+      {...listeners}
+    >
+```
+
+Note: dnd-kit's `{...listeners}` are pointer-based (PointerSensor), so they do not conflict with native HTML5 drag events; the two DnD systems coexist.
+
+- [ ] **Step 10: Run tests to verify they pass**
+
+Run: `pnpm --filter @memry/desktop test:renderer -- sortable-project-item link-sidebar-item-to-project`
+Expected: PASS.
+
+- [ ] **Step 11: Guard against regressions in the drag source + editor**
+
+Run the notes-tree and editor drop suites to confirm widening the MIME didn't break embed-on-drop:
+
+Run: `pnpm --filter @memry/desktop test:renderer -- virtualized-notes-tree use-editor-file-upload`
+Expected: PASS (or "no tests found" for a pattern with no suite — that is acceptable, not a failure).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/lib/link-sidebar-item-to-project.ts \
+        apps/desktop/src/renderer/src/lib/link-sidebar-item-to-project.test.ts \
+        apps/desktop/src/renderer/src/lib/drag-mime.ts \
+        apps/desktop/src/renderer/src/components/virtualized-notes-tree.tsx \
+        apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.tsx \
+        apps/desktop/src/renderer/src/components/sidebar/sortable-project-item.test.tsx
+git commit -m "feat(projects): link a sidebar note/file to a project by drag-and-drop"
+```
+
+---
+
+## Task 6: Documentation
+
+Extends the user guide's "Project Home" section with Files, satisfying the docs gate.
+
+**Files:**
+
+- Modify: `apps/docs/src/user-guide/projects.md`
+
+- [ ] **Step 1: Extend the Project Home docs**
+
+Read `apps/docs/src/user-guide/projects.md`. In the "Project Home" section (which already documents Overview, Tasks, Notes, Events), add a **Files** subsection describing: linked files appear in the Files section; add one via a file's **Add to project** button, or by **dragging a note or file from the sidebar onto a project**; removing a file from a project (the X control) unlinks it but keeps the file in your vault; deleting the project keeps all linked files.
+
+Match the surrounding heading level, tone, and formatting. If `pnpm docs:ai-update` is available and preferred, run it instead; otherwise write the prose manually.
+
+- [ ] **Step 2: Docs gate**
+
+Run (BASE = the branch this stack was cut from — `project-hub-calendar-overview` unless #819/#812 have since merged to `main`):
+
+```bash
+pnpm docs:impact --base origin/project-hub-calendar-overview --strict
+pnpm docs:build
+```
+
+Expected: PASS (no `missing-docs`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/docs/src/user-guide/projects.md
+git commit -m "docs(projects): document the Project Home Files section"
+```
+
+---
+
+## Final verification (run before opening the PR)
+
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm --filter @memry/desktop test:main` (unchanged, but confirm still green — backend untouched)
+- [ ] `pnpm --filter @memry/desktop test:renderer`
+- [ ] `pnpm ipc:check` (expected: no change — no contract edits — but verify)
+- [ ] `pnpm --filter @memry/desktop i18n:check`
+- [ ] `pnpm check:architecture`
+- [ ] `git diff --check`
+- [ ] `pnpm docs:impact --base origin/project-hub-calendar-overview --strict` + `pnpm docs:build`
+- [ ] Real-app smoke (`pnpm dev`): (1) open a file → **Add to project** → it appears in that project's Files section; (2) drag a sidebar note onto a project → it links (Notes section); drag a file onto a project → it links (Files section); (3) delete the project → the files/notes still exist in the vault.
+
+---
+
+## Self-Review
+
+**Spec coverage (spec §9 Phase 4 = "Files section + sidebar drag-to-project"):**
+
+- Files section on Project Home → Tasks 1–2 (component + mount + stat + `FILES_SECTION_SLOT`). ✓
+- Link a file to a project (`item_type='file'`, reuse `PROJECT_LINK_ITEM`) → Task 3 (dialog) + Task 4 (FilePage entry point). ✓
+- Sidebar drag-note-onto-project via `MEMRY_NOTE_DRAG_MIME` → Task 5 (widen MIME + native drop, links note or file). ✓
+- Backward compat / no migration / no new sync type → guaranteed by design (renderer-only; backend already generic); asserted by leaving `test:main` untouched + `ipc:check` unchanged. ✓
+- Deleting a project keeps files → unchanged Phase 1 behavior; smoke-verified. ✓
+- Orphaned links skipped defensively → Task 1 (`getFile` null → skip), tested. ✓
+
+**Design decision recorded:** The "drag a note onto a project" ask crosses two DnD systems — the sidebar note drag is native HTML5, the project item is a dnd-kit droppable (for tasks). Chosen approach: widen the note-named `MEMRY_NOTE_DRAG_MIME` to all non-folder items (matches the spec's named mechanism and the constant's own name) + add a native drop handler to the project item; the drop resolves file-vs-note via `getFile`. This is editor-safe because `getFileById` returns `null` for markdown (`notes-crud.ts:353`), so the editor's existing embed-on-drop no-ops for a markdown id (and it also removes today's latent raw-uuid insertion when a note is dragged into an editor).
+
+**Placeholder scan:** none — every code step contains complete code.
+
+**Type consistency:** `linkSidebarItemToProject` signature is identical in the interface block, the helper impl, and the component call site; `ProjectItemType` (`'note'|'calendar_event'|'file'`) is the shared type; `fileCount` prop name is consistent across `ProjectStatsRow`, its test, and the `project-home.tsx` caller; `ProjectFilesSection` prop names (`projectId`, `onFileClick`) match between the component, its test, and the mount site.

--- a/packages/i18n/src/locales/en/tasks.json
+++ b/packages/i18n/src/locales/en/tasks.json
@@ -680,7 +680,13 @@
     "toastError": "Failed to add to project"
   },
   "projectHome": {
-    "stats": { "tasks": "Tasks", "notes": "Notes", "events": "Events", "progress": "Progress" },
+    "stats": {
+      "tasks": "Tasks",
+      "notes": "Notes",
+      "events": "Events",
+      "files": "Files",
+      "progress": "Progress"
+    },
     "emptyTitle": "No project selected",
     "emptyBody": "Pick a project from the sidebar to open its home.",
     "loadError": "Could not load project details",

--- a/packages/i18n/src/locales/en/tasks.json
+++ b/packages/i18n/src/locales/en/tasks.json
@@ -657,6 +657,13 @@
     "removeFromProject": "Remove from project",
     "removeError": "Failed to remove note from project"
   },
+  "projectFiles": {
+    "title": "Files",
+    "loading": "Loading files…",
+    "loadError": "Failed to load project files",
+    "removeFromProject": "Remove from project",
+    "removeError": "Failed to remove file from project"
+  },
   "projectEvents": {
     "title": "Events",
     "loading": "Loading events…",


### PR DESCRIPTION
## Project Hub — Phase 4 (Files)

Closes out the "Projects all-in-one hub" (spec §9 Phase 4): files can now live under a project, alongside notes, tasks, and events.

> **Stacked on `project-hub-calendar-overview` (#819)** — this PR's base is that branch (which carries Phase 1–3), because #819 and #812 are not yet merged to `main`. Retarget to `main` once the stack lands.

### Key finding: this is renderer-only
A "file" in MemryNote is a note with a non-markdown `fileType` (pdf/image/audio/video) — there is **no separate file/attachment table**. Its stable id is the note id, resolved via `notesService.getFile(id) → FileMetadata | null` (null for a markdown note or a deleted file). The link infrastructure — `project_links`, the link/unlink/list IPC+RPC, and the project sync payload — was already generic over `item_type` (the contract enum already includes `'file'`; the payload selects *all* links for a project). So Phase 4 needed **no migration, no new `SyncItemType`, and no contract/RPC/main-process change** — file links ride the existing project payload exactly like note/event links. `ipc:check` confirms zero contract drift.

### What shipped
- **Files section on Project Home** — mirrors the Notes/Events sections for `item_type='file'`, resolving each file via `getFile` and defensively skipping orphaned links (deleted files / markdown ids). Adds a **Files** stat tile.
- **Link a file to a project** — an **Add to project** button + project-membership chips on the file page, backed by a new `AddFileToProjectDialog` (mirrors the note/event dialogs).
- **Drag a sidebar note or file onto a project** — widened `MEMRY_NOTE_DRAG_MIME` to all non-folder sidebar items and added a native HTML5 drop target on the sidebar project item. A pure, unit-tested helper resolves file-vs-note (`getFile` non-null ⇒ `file`, else `note`). The two drag systems (dnd-kit pointer sensors for task-drag/reorder; native HTML5 for note/file→project) don't conflict. The widen is editor-safe (the editor embed-on-drop no-ops when `getFile` returns null for markdown) and incidentally fixes a latent bug where dragging a markdown note into an editor inserted its raw uuid.
- **Docs** — extended the Project Home user guide with Files.

### Backward compatibility
Additive/renderer-only. No DB reset, no schema/sync/contract change. Deleting a project drops its links + tasks but keeps notes, events, and **files** (files live in the notes tables; only the links cascade).

### Deferred (fast-follow — acceptable per final review)
- File-page project chips show membership but don't navigate on click (note/event chips do). Follow-up: wire `onProjectClick`, or drop the "open project" aria-label while non-interactive.
- Dragging a *markdown* note over an editor now shows the embeddable affordance even though the drop safely no-ops.
- Minor drop-target ring flicker on `dragleave` over child elements.

### Verification (all green)
`pnpm lint` · `pnpm typecheck` · `test:main` · `test:renderer` (full suites) · `pnpm ipc:check` (zero drift) · `i18n:check` · `check:architecture` · `git diff --check` · docs gate (`docs:impact --strict` + `docs:build`). New/changed tests: Files section (orphan-skip + unlink), stats tile, project-home mount, add-file dialog, the drag helper (note/file/no-op/failure), and the native drop handler. Built via TDD with per-task review + a final whole-branch review.
