### PR TITLE
fix(comments): unclip @-mention picker and open it from the "@" button

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-prompt-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-prompt-editor.test.tsx
@@ -81,6 +81,30 @@ describe('AgentPromptEditor', () => {
     expect(onMentionQueryChange).toHaveBeenLastCalledWith('')
   })
 
+  it('opens the mention query from the "@" trigger even after a word', async () => {
+    const { ref, onMentionQueryChange } = renderPromptEditor()
+
+    await typePrompt('hello')
+    act(() => {
+      ref.current?.insertMentionTrigger()
+    })
+
+    // A leading space is prepended so the mention regex matches after a word.
+    expect(ref.current?.getValue()).toEqual({ text: 'hello @', attachments: [] })
+    expect(onMentionQueryChange).toHaveBeenLastCalledWith('')
+  })
+
+  it('inserts a bare "@" from the trigger at the start of an empty editor', () => {
+    const { ref, onMentionQueryChange } = renderPromptEditor()
+
+    act(() => {
+      ref.current?.insertMentionTrigger()
+    })
+
+    expect(ref.current?.getValue()).toEqual({ text: '@', attachments: [] })
+    expect(onMentionQueryChange).toHaveBeenLastCalledWith('')
+  })
+
   it('serializes non-standard mention kinds and dedupes repeated attachments', async () => {
     const { ref, onMentionQueryChange } = renderPromptEditor()
 

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/ref-picker.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/ref-picker.test.tsx
@@ -12,6 +12,7 @@ function renderRefPicker(overrides: Partial<ComponentProps<typeof RefPicker>> = 
   const props: ComponentProps<typeof RefPicker> = {
     query: 'star',
     selectedIndex: 0,
+    anchorRef: { current: document.createElement('div') },
     onItemsChange: vi.fn(),
     onPick: vi.fn(),
     onSelectedIndexChange: vi.fn(),
@@ -55,6 +56,16 @@ describe('RefPicker', () => {
 
     expect(props.onSelectedIndexChange).toHaveBeenLastCalledWith(-1)
     expect(props.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the list in a body-level fixed portal so overflow cannot clip it', async () => {
+    renderRefPicker()
+
+    const listbox = await screen.findByRole('listbox')
+    // Portalled directly under document.body, not nested in the render container.
+    expect(listbox.parentElement).toBe(document.body)
+    expect(listbox.getAttribute('data-ref-picker')).toBe('')
+    expect(listbox.style.position).toBe('fixed')
   })
 
   it('selects, hovers, and picks icon-backed search and calendar results', async () => {

--- a/apps/desktop/src/renderer/src/agent-chat/agent-prompt-editor.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-prompt-editor.tsx
@@ -43,6 +43,12 @@ export interface AgentPromptEditorHandle {
   focus: () => void
   getValue: () => AgentPromptValue
   insertText: (text: string) => void
+  /**
+   * Insert an `@` that is guaranteed to open the mention picker: prepends a
+   * space when the caret sits right after a non-whitespace character, so the
+   * `findMentionQuery` regex (which requires start-or-whitespace) still matches.
+   */
+  insertMentionTrigger: () => void
   insertMention: (attachment: MentionAttachment) => void
   seed: (parts: AgentPromptSeedPart[]) => void
 }
@@ -431,6 +437,24 @@ export const AgentPromptEditor = forwardRef<AgentPromptEditorHandle, AgentPrompt
           if (!editor || !text) return
 
           editor.chain().focus().insertContent(text).run()
+
+          const mentionQuery = findMentionQuery(editor)
+          activeMentionRef.current = mentionQuery
+          onMentionQueryChangeRef.current(mentionQuery?.query ?? null)
+          onValueChangeRef.current(readEditorValue(editor))
+        },
+        insertMentionTrigger: () => {
+          if (!editor) return
+
+          const { $from } = editor.state.selection
+          const textBefore = $from.parent.textBetween(0, $from.parentOffset, '\n', '￼')
+          const needsSpace = textBefore.length > 0 && !/\s$/.test(textBefore)
+
+          editor
+            .chain()
+            .focus()
+            .insertContent(needsSpace ? ' @' : '@')
+            .run()
 
           const mentionQuery = findMentionQuery(editor)
           activeMentionRef.current = mentionQuery

--- a/apps/desktop/src/renderer/src/agent-chat/composer.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/composer.tsx
@@ -198,6 +198,7 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
   const agent = useAgentOptional()
   const activeTab = useActiveTab()
   const promptEditorRef = useRef<AgentPromptEditorHandle>(null)
+  const composerBoxRef = useRef<HTMLDivElement>(null)
   const [promptValue, setPromptValue] = useState<AgentPromptValue>({
     text: '',
     attachments: []
@@ -519,13 +520,17 @@ export function Composer({ conversationId, sourceWindowId }: ComposerProps): Rea
         <RefPicker
           query={pickerQuery}
           selectedIndex={selectedPickerIndex}
+          anchorRef={composerBoxRef}
           onItemsChange={setPickerItems}
           onPick={pickMention}
           onSelectedIndexChange={setSelectedPickerIndex}
           onClose={closePicker}
         />
       )}
-      <div className="flex min-h-[120px] cursor-text flex-col rounded-2xl border border-border bg-card shadow-lg">
+      <div
+        ref={composerBoxRef}
+        className="flex min-h-[120px] cursor-text flex-col rounded-2xl border border-border bg-card shadow-lg"
+      >
         <div
           className="relative max-h-[258px] flex-1 overflow-y-auto"
           onPointerDown={(event) => {

--- a/apps/desktop/src/renderer/src/agent-chat/ref-picker.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/ref-picker.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useLayoutEffect, useState, type CSSProperties, type RefObject } from 'react'
+import { createPortal } from 'react-dom'
 
 import type { CalendarEventRecord } from '@memry/contracts/calendar-api'
 import type { AttachmentInput } from '@memry/contracts/ipc-agent'
@@ -11,11 +12,21 @@ import { cn } from '@/lib/utils'
 interface RefPickerProps {
   query: string
   selectedIndex: number
+  /**
+   * Element the picker anchors to. The list renders in a `document.body` portal
+   * with `position: fixed` so an `overflow` ancestor (e.g. the review flyout)
+   * cannot clip it.
+   */
+  anchorRef: RefObject<HTMLElement | null>
   onItemsChange: (items: MentionAttachment[]) => void
   onPick: (attachment: MentionAttachment) => void
   onSelectedIndexChange: (index: number) => void
   onClose: () => void
 }
+
+const PICKER_GAP = 8
+const PICKER_MARGIN = 8
+const PICKER_MAX_HEIGHT = 256
 
 interface RefPickerResult {
   kind: AttachmentInput['kind']
@@ -114,6 +125,7 @@ function toMentionAttachment(result: RefPickerResult): MentionAttachment {
 export function RefPicker({
   query,
   selectedIndex,
+  anchorRef,
   onItemsChange,
   onPick,
   onSelectedIndexChange,
@@ -122,6 +134,10 @@ export function RefPicker({
   const { t } = useT('common')
   const [results, setResults] = useState<RefPickerResult[]>([])
   const [prevQuery, setPrevQuery] = useState(query)
+  const [portalStyle, setPortalStyle] = useState<CSSProperties>({
+    position: 'fixed',
+    visibility: 'hidden'
+  })
 
   // Clear stale results synchronously at render when the query changes, so
   // keyboard selection never targets a previous query's refs while async
@@ -152,11 +168,49 @@ export function RefPicker({
     }
   }, [onItemsChange, onSelectedIndexChange, query])
 
-  return (
+  // Anchor the portal to the composer and keep it aligned while the surrounding
+  // container scrolls or the window resizes. Prefers the side with more room so
+  // the list never opens off-screen.
+  useLayoutEffect(() => {
+    const anchor = anchorRef.current
+    if (!anchor) return
+
+    const reposition = (): void => {
+      const rect = anchor.getBoundingClientRect()
+      const viewportHeight = window.innerHeight
+      const spaceBelow = viewportHeight - rect.bottom
+      const spaceAbove = rect.top
+      const openBelow = spaceBelow >= spaceAbove
+      const available = (openBelow ? spaceBelow : spaceAbove) - PICKER_GAP - PICKER_MARGIN
+      const maxHeight = Math.max(96, Math.min(PICKER_MAX_HEIGHT, available))
+
+      setPortalStyle({
+        position: 'fixed',
+        left: rect.left,
+        width: rect.width,
+        maxHeight,
+        ...(openBelow
+          ? { top: rect.bottom + PICKER_GAP }
+          : { bottom: viewportHeight - rect.top + PICKER_GAP })
+      })
+    }
+
+    reposition()
+    window.addEventListener('scroll', reposition, true)
+    window.addEventListener('resize', reposition)
+    return () => {
+      window.removeEventListener('scroll', reposition, true)
+      window.removeEventListener('resize', reposition)
+    }
+  }, [anchorRef])
+
+  return createPortal(
     <div
       role="listbox"
       tabIndex={-1}
-      className="absolute inset-x-2 bottom-full z-50 mb-2 max-h-64 overflow-y-auto rounded-md border border-sidebar-border bg-popover p-1 text-popover-foreground shadow-md"
+      data-ref-picker=""
+      style={portalStyle}
+      className="z-50 overflow-y-auto rounded-md border border-sidebar-border bg-popover p-1 text-popover-foreground shadow-md"
       onKeyDown={(event) => {
         if (event.key === 'Escape') onClose()
       }}
@@ -186,6 +240,7 @@ export function RefPicker({
           </button>
         )
       })}
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/apps/desktop/src/renderer/src/components/note/review/comment-composer.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/comment-composer.tsx
@@ -180,7 +180,11 @@ export function CommentComposer({
     const ownerWindow = ownerDocument.defaultView ?? window
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as Node | null
-      if (!target || composer.contains(target)) return
+      if (!target) return
+      // The mention picker renders in a body-level portal, so its options sit
+      // outside the composer subtree; treat clicks inside it as inside.
+      if (target instanceof Element && target.closest('[data-ref-picker]')) return
+      if (composer.contains(target)) return
       cancelIfEmpty()
     }
 
@@ -203,6 +207,7 @@ export function CommentComposer({
         <RefPicker
           query={mentionQuery}
           selectedIndex={selectedMentionIndex}
+          anchorRef={composerRef}
           onItemsChange={setMentionItems}
           onPick={insertMention}
           onSelectedIndexChange={setSelectedMentionIndex}
@@ -256,7 +261,7 @@ export function CommentComposer({
             aria-label={t('comments.mentionAria')}
             onClick={() => {
               editorRef.current?.focus()
-              editorRef.current?.insertText('@')
+              editorRef.current?.insertMentionTrigger()
             }}
           >
             <AtSign className="size-3.5" aria-hidden="true" />

--- a/apps/desktop/src/renderer/src/components/note/review/review-badge-layer.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-badge-layer.tsx
@@ -174,6 +174,8 @@ export function ReviewBadgeLayer({
       if (target) {
         if (target.closest('.critic-review-flyout')) return
         if (target.closest('.critic-review-badge')) return
+        // The mention picker portals to document.body, outside the flyout.
+        if (target.closest('[data-ref-picker]')) return
         const span = target.closest('[data-critic-mark-id]')
         if (span && containerRef.current?.contains(span)) return
       }

--- a/apps/desktop/src/renderer/src/components/note/review/review-ui.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-ui.test.tsx
@@ -267,6 +267,54 @@ describe('review UI', () => {
     })
   })
 
+  it('opens the mention picker from the "@" button even after typing a word', async () => {
+    const user = userEvent.setup()
+    const searchQuery = vi.fn().mockResolvedValue({
+      groups: [
+        {
+          type: 'note',
+          totalInGroup: 1,
+          results: [
+            {
+              id: 'note-42',
+              type: 'note',
+              title: 'Planning note',
+              snippet: '',
+              score: 1,
+              normalizedScore: 1,
+              matchType: 'title',
+              modifiedAt: '2026-05-10T00:00:00.000Z',
+              metadata: { type: 'note', path: '/Planning note', tags: [], emoji: '📝' }
+            }
+          ]
+        }
+      ],
+      totalCount: 1,
+      queryTimeMs: 0
+    })
+    vi.mocked(window.api.search.query).mockImplementation(searchQuery)
+    Object.assign(window.api, {
+      calendar: {
+        ...((window.api as unknown as { calendar?: Record<string, unknown> }).calendar ?? {}),
+        listEvents: vi.fn().mockResolvedValue({ events: [] })
+      }
+    })
+
+    const review = createReview({ activeDraft: { text: 'draft target' } })
+    render(<ReviewRail review={review} />)
+
+    // Type a word first: previously the "@" button inserted a bare "@" after a
+    // word, which the mention regex ignored, so no picker opened.
+    await user.type(screen.getByLabelText('comments.commentPlaceholder'), 'hello')
+    await user.click(screen.getByRole('button', { name: 'comments.mentionAria' }))
+
+    const listbox = await screen.findByRole('listbox')
+    // Portalled to document.body so the review flyout's overflow cannot clip it.
+    expect(listbox.getAttribute('data-ref-picker')).toBe('')
+    expect(listbox.parentElement).toBe(document.body)
+    expect(await within(listbox).findByText('Planning note')).toBeInTheDocument()
+  })
+
   it('edits a comment card inline and saves through updateComment', async () => {
     const user = userEvent.setup()
     const review = createReview({


### PR DESCRIPTION
Fixes #798 (reported by Aurelie Kabore, Windows 10 v2026.718.3; part of #795).

## Problem

Typing `@` or clicking the `@` icon in a note/journal comment showed **no** usable suggestion list, so linking a note felt broken. Two real defects (the "link is inert until save" part is by-design and out of scope):

1. **Picker clipped.** `RefPicker` rendered as a plain `absolute … bottom-full` child of the composer, so in the narrow-window badge-layer flyout it was clipped by `.critic-review-flyout { overflow-y:auto; max-height:420px }` and opened off the top. The user never saw options — yet the picker seeds `selectedIndex = 0`, so typing an exact name + Enter still produced the blue pill, which is why it "sort of" worked.
2. **"@" button dead.** The button inserted a bare `@`, but the mention detector only fires when `@` is at block start or preceded by whitespace. Clicking it after a word inserted a literal `@` and opened nothing.

## Fix

- **Portal the picker.** `RefPicker` now renders in a `document.body` portal with `position:fixed`, anchored via a new required `anchorRef` prop, so an `overflow` ancestor can no longer clip it. Placement picks the side (above/below) with more room and re-tracks on scroll/resize. `RefPicker` is shared, so this is applied to **both** the comment composer and Agent Chat.
- **Fix the "@" button.** New editor handle `insertMentionTrigger()` prepends a space when the caret sits after a non-whitespace char, so the mention query always fires; the button calls it instead of inserting a bare `@`.
- **Guard outside-press.** A portalled option lives in `document.body`, outside the composer/flyout subtree, so a click on it would otherwise trip the dismiss/cancel and lose the pick (worst in comment edit mode, where it calls `onCancel`). Both the comment composer's pointerdown handler and the badge-layer flyout dismiss handler now ignore targets inside `[data-ref-picker]`. Agent Chat needs no guard (it opens/closes purely via the mention-query callback).

## Scope / compatibility

Renderer-only. No DB, IPC, contract, or sync changes. `anchorRef` is a new required prop on an internal component; both call sites are updated in this change.

## Tests

- `agent-prompt-editor.test.tsx` — `insertMentionTrigger()` opens the query after a word and from an empty editor.
- `ref-picker.test.tsx` — the list renders in a body-level `position:fixed` portal (`data-ref-picker`).
- `review-ui.test.tsx` — end-to-end: type a word → click the `@` button → the picker opens with a note option.

## Verification

- Renderer vitest: ref-picker + editor (10), review-ui (23), agent-chat (116), review-badge-layer (13) — all green, incl. 4 new tests
- `typecheck:web` clean · `eslint` 0 errors · `docs:impact` = no docs needed

jsdom can't verify actual clipping, so a manual `pnpm dev` pass (narrow/badge-layer flyout **and** rail, plus Agent Chat `@` mentions) is still worth doing before marking ready.