### PR TITLE
fix(inbox): open filed binaries in the file viewer + preserve tags (#800)

### DIFF
--- a/apps/desktop/src/main/database/queries/search.ts
+++ b/apps/desktop/src/main/database/queries/search.ts
@@ -44,6 +44,7 @@ interface FtsNoteRow {
   path: string
   date: string | null
   emoji: string | null
+  fileType: NoteResultMetadata['fileType']
   wordCount: number | null
   modifiedAt: string
   rank: number
@@ -92,6 +93,7 @@ function searchNotes(indexDb: IndexDb, ftsQuery: string, limit: number): SearchR
       nc.path,
       nc.date,
       nc.emoji,
+      nc.file_type as fileType,
       nc.word_count as wordCount,
       nc.modified_at as modifiedAt,
       bm25(fts_notes, 0.0, 2.0, 1.0, 1.0) as rank,
@@ -110,6 +112,7 @@ function searchNotes(indexDb: IndexDb, ftsQuery: string, limit: number): SearchR
       path: row.path,
       tags: [],
       emoji: row.emoji,
+      fileType: row.fileType ?? undefined,
       wordCount: row.wordCount
     }
     return {
@@ -281,13 +284,21 @@ interface TitleRow {
 function getNoteTitles(
   indexDb: IndexDb
 ): Array<TitleRow & { type: ContentType; metadata: NoteResultMetadata }> {
-  const rows = indexDb.all<TitleRow & { path: string; emoji: string | null }>(
-    sql`SELECT id, title, path, emoji, modified_at as modifiedAt FROM note_cache WHERE date IS NULL`
+  const rows = indexDb.all<
+    TitleRow & { path: string; emoji: string | null; fileType: NoteResultMetadata['fileType'] }
+  >(
+    sql`SELECT id, title, path, emoji, file_type as fileType, modified_at as modifiedAt FROM note_cache WHERE date IS NULL`
   )
   return rows.map((r) => ({
     ...r,
     type: 'note' as ContentType,
-    metadata: { type: 'note' as const, path: r.path, tags: [], emoji: r.emoji }
+    metadata: {
+      type: 'note' as const,
+      path: r.path,
+      tags: [],
+      emoji: r.emoji,
+      fileType: r.fileType ?? undefined
+    }
   }))
 }
 

--- a/apps/desktop/src/main/inbox/filing.test.ts
+++ b/apps/desktop/src/main/inbox/filing.test.ts
@@ -359,6 +359,26 @@ describe('Inbox Filing Operations', () => {
       expect(mockSetNoteTags).toHaveBeenCalledWith({}, 'file-note-id', ['Photos', 'Image', 'inbox'])
     })
 
+    it('still files the binary when tag persistence fails (best-effort) (#800)', async () => {
+      // The file is already moved before tags are persisted; a tag-write failure
+      // must not abort filing and orphan the inbox item.
+      mockIndexBinaryFile.mockRejectedValueOnce(new Error('index db unavailable'))
+      const itemId = seedInboxItem(testDb.db, {
+        id: 'image-tagfail',
+        type: 'image',
+        title: 'Screenshot'
+      })
+      updateInboxItem(itemId, { attachmentPath: 'attachments/inbox/image-tagfail/screenshot.png' })
+
+      const result = await fileToFolder(itemId, 'projects', ['Image'])
+
+      expect(result).toEqual({ success: true, filedTo: 'notes/projects/screenshot.png' })
+      expect(mockSend).toHaveBeenCalledWith(
+        'inbox:filed',
+        expect.objectContaining({ id: itemId, filedAction: 'folder' })
+      )
+    })
+
     it('should fall back to copy and unlink when binary rename crosses devices', async () => {
       mockRename.mockRejectedValueOnce(Object.assign(new Error('cross-device'), { code: 'EXDEV' }))
       const itemId = seedInboxItem(testDb.db, {

--- a/apps/desktop/src/main/inbox/filing.test.ts
+++ b/apps/desktop/src/main/inbox/filing.test.ts
@@ -14,7 +14,19 @@ import { eq } from 'drizzle-orm'
 // Mock the database module
 vi.mock('../database', () => ({
   getDatabase: vi.fn(),
-  requireDatabase: vi.fn()
+  requireDatabase: vi.fn(),
+  getIndexDatabase: vi.fn()
+}))
+
+const mockIndexBinaryFile = vi.fn()
+const mockSetNoteTags = vi.fn()
+
+vi.mock('../vault/indexer', () => ({
+  indexBinaryFile: (...args: unknown[]) => mockIndexBinaryFile(...args)
+}))
+
+vi.mock('../database/queries/notes', () => ({
+  setNoteTags: (...args: unknown[]) => mockSetNoteTags(...args)
 }))
 
 const mockSend = vi.fn()
@@ -96,7 +108,7 @@ vi.mock('../lib/reminders', () => ({
   createReminder: (...args: unknown[]) => mockCreateReminder(...args)
 }))
 
-import { getDatabase, requireDatabase } from '../database'
+import { getDatabase, requireDatabase, getIndexDatabase } from '../database'
 import { getStatus } from '../vault/index'
 import {
   fileToFolder,
@@ -150,6 +162,10 @@ describe('Inbox Filing Operations', () => {
     testDb = createTestDatabase()
     vi.mocked(getDatabase).mockReturnValue(testDb.db)
     vi.mocked(requireDatabase).mockReturnValue(testDb.db)
+    vi.mocked(getIndexDatabase).mockReturnValue({} as never)
+
+    mockIndexBinaryFile.mockReset().mockResolvedValue('file-note-id')
+    mockSetNoteTags.mockReset()
 
     mockCreateNote.mockReset()
     mockGetNoteById.mockReset()
@@ -318,6 +334,29 @@ describe('Inbox Filing Operations', () => {
         'inbox:filed',
         expect.objectContaining({ id: itemId, filedAction: 'folder' })
       )
+    })
+
+    it('preserves assigned + existing tags when filing a binary (#800)', async () => {
+      const itemId = seedInboxItem(testDb.db, {
+        id: 'image-tags',
+        type: 'image',
+        title: 'Screenshot'
+      })
+      seedInboxItemTags(testDb.db, itemId, ['Photos'])
+      updateInboxItem(itemId, { attachmentPath: 'attachments/inbox/image-tags/screenshot.png' })
+
+      const result = await fileToFolder(itemId, 'projects', ['Image'])
+
+      expect(result).toEqual({ success: true, filedTo: 'notes/projects/screenshot.png' })
+      // Binary is eagerly indexed as an image to obtain its note id...
+      expect(mockIndexBinaryFile).toHaveBeenCalledWith(
+        {},
+        'notes/projects/screenshot.png',
+        '/mock-vault/notes/projects/screenshot.png',
+        'image'
+      )
+      // ...and the merged tags (existing + assigned + 'inbox') are written to note_tags.
+      expect(mockSetNoteTags).toHaveBeenCalledWith({}, 'file-note-id', ['Photos', 'Image', 'inbox'])
     })
 
     it('should fall back to copy and unlink when binary rename crosses devices', async () => {

--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -12,8 +12,11 @@ import path from 'path'
 import { rename, copyFile, unlink } from 'fs/promises'
 import { existsSync } from 'fs'
 import { createLogger } from '../lib/logger'
-import { getDatabase, requireDatabase } from '../database'
+import { getDatabase, requireDatabase, getIndexDatabase } from '../database'
 import { createNote, getNoteById, updateNote, createFolder, getFolders } from '../vault/notes'
+import { setNoteTags } from '../database/queries/notes'
+import { indexBinaryFile } from '../vault/indexer'
+import { getFileType } from '@memry/shared/file-types'
 import { getStatus, getConfig } from '../vault/index'
 import { inboxItems, inboxItemTags, filingHistory } from '@memry/db-schema/schema/inbox'
 import { generateId } from '../lib/id'
@@ -168,6 +171,29 @@ function getInboxItem(db: ReturnType<typeof getDatabase>, itemId: string): Inbox
 function getItemTags(db: ReturnType<typeof getDatabase>, itemId: string): string[] {
   const tags = db.select().from(inboxItemTags).where(eq(inboxItemTags.itemId, itemId)).all()
   return tags.map((t) => t.tag)
+}
+
+/**
+ * Persist tags onto a filed binary (image/PDF/audio/video).
+ *
+ * Binaries have no frontmatter, so tags can't ride along in file content the way
+ * markdown notes do. Instead we eagerly index the moved file to obtain its
+ * `note_cache` id (idempotent — the filesystem watcher reuses the same id by
+ * path and never touches `note_tags`) and write the tags to the index DB.
+ * No-op for unsupported/markdown extensions. See #800.
+ */
+async function persistBinaryTags(
+  relativePath: string,
+  absolutePath: string,
+  tags: string[]
+): Promise<void> {
+  if (tags.length === 0) return
+  const fileType = getFileType(path.extname(absolutePath))
+  if (!fileType || fileType === 'markdown') return
+
+  const indexDb = getIndexDatabase()
+  const noteId = await indexBinaryFile(indexDb, relativePath, absolutePath, fileType)
+  setNoteTags(indexDb, noteId, tags)
 }
 
 /**
@@ -474,7 +500,11 @@ function recordFilingHistory(
  * @param itemId - Inbox item ID
  * @param folderPath - Target folder path (relative to vault, empty string for root)
  */
-async function fileBinaryToFolder(itemId: string, folderPath: string): Promise<FileResponse> {
+async function fileBinaryToFolder(
+  itemId: string,
+  folderPath: string,
+  tags: string[] = []
+): Promise<FileResponse> {
   try {
     const db = requireDatabase()
 
@@ -493,6 +523,10 @@ async function fileBinaryToFolder(itemId: string, folderPath: string): Promise<F
     if (!item.attachmentPath) {
       return { success: false, filedTo: null, error: 'No attachment found for this item' }
     }
+
+    // Merge tags (existing inbox tags + new, deduplicated) — same shape as the
+    // markdown path so binaries keep their assigned tags after filing.
+    const mergedTags = [...new Set([...getItemTags(db, itemId), ...tags, 'inbox'])]
 
     // Ensure destination folder exists
     await ensureFolderExists(folderPath)
@@ -529,11 +563,14 @@ async function fileBinaryToFolder(itemId: string, folderPath: string): Promise<F
     // Calculate relative path from vault root for storage
     const relativePath = normalizeRelativePath(path.relative(vaultPath, finalPath))
 
+    // Persist the assigned tags onto the filed file (index DB / note_tags)
+    await persistBinaryTags(relativePath, finalPath, mergedTags)
+
     // Mark inbox item as filed
     markItemAsFiled(itemId, relativePath, 'folder')
 
-    // Record filing history (no content for binary files)
-    recordFilingHistory(item.type, null, relativePath, 'folder', [])
+    // Record filing history
+    recordFilingHistory(item.type, null, relativePath, 'folder', mergedTags)
 
     log.info(`Filed binary item to: ${relativePath}`)
 
@@ -578,9 +615,9 @@ export async function fileToFolder(
       return { success: false, filedTo: null, error: 'Item has already been filed' }
     }
 
-    // Binary types: move file directly (no markdown wrapper, no tags)
+    // Binary types: move file directly (no markdown wrapper), preserving tags
     if (isBinaryType(item.type)) {
-      return fileBinaryToFolder(itemId, folderPath)
+      return fileBinaryToFolder(itemId, folderPath, tags)
     }
 
     // Text + link types: create markdown note
@@ -920,6 +957,7 @@ async function linkBinaryToNotes(
   itemId: string,
   item: InboxItemRow,
   noteIds: string[],
+  tags: string[] = [],
   folderPath?: string
 ): Promise<{ success: boolean; error?: string; linkedCount?: number }> {
   try {
@@ -927,6 +965,11 @@ async function linkBinaryToNotes(
     if (!item.attachmentPath) {
       return { success: false, error: 'No attachment found for this item' }
     }
+
+    // Merge tags (existing inbox tags + new, deduplicated) — mirror the
+    // markdown link path so linked binaries keep their assigned tags. See #800.
+    const db = requireDatabase()
+    const mergedTags = [...new Set([...getItemTags(db, itemId), ...tags, 'inbox'])]
 
     // Validate all target notes exist first
     const targetNotes: Array<{ id: string; content: string; path: string }> = []
@@ -1017,11 +1060,14 @@ async function linkBinaryToNotes(
     // Calculate relative path for storage
     const relativePath = normalizeRelativePath(path.relative(vaultPath, finalPath))
 
+    // Persist the assigned tags onto the filed file (index DB / note_tags)
+    await persistBinaryTags(relativePath, finalPath, mergedTags)
+
     // Mark inbox item as filed
     markItemAsFiled(itemId, relativePath, 'linked')
 
-    // Record filing history (no content for binary files)
-    recordFilingHistory(item.type, null, relativePath, 'linked', [])
+    // Record filing history
+    recordFilingHistory(item.type, null, relativePath, 'linked', mergedTags)
 
     log.info(`Linked binary item to ${targetNotes.length} note(s): ${relativePath}`)
 
@@ -1070,7 +1116,7 @@ export async function linkToNotes(
 
     // Binary types: move file and add wiki-links to target notes
     if (isBinaryType(item.type)) {
-      return linkBinaryToNotes(itemId, item, noteIds, folderPath)
+      return linkBinaryToNotes(itemId, item, noteIds, tags, folderPath)
     }
 
     // Text types: create markdown note and add wiki-links (existing logic)

--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -191,9 +191,20 @@ async function persistBinaryTags(
   const fileType = getFileType(path.extname(absolutePath))
   if (!fileType || fileType === 'markdown') return
 
-  const indexDb = getIndexDatabase()
-  const noteId = await indexBinaryFile(indexDb, relativePath, absolutePath, fileType)
-  setNoteTags(indexDb, noteId, tags)
+  // Best-effort: the caller has already moved the file and deleted the inbox
+  // attachment folder, so a failure here (e.g. index DB unavailable) must not
+  // abort filing and leave the inbox item pointing at a now-missing attachment.
+  // Log and continue. See #800.
+  try {
+    const indexDb = getIndexDatabase()
+    const noteId = await indexBinaryFile(indexDb, relativePath, absolutePath, fileType)
+    setNoteTags(indexDb, noteId, tags)
+  } catch (error) {
+    log.warn(
+      'Failed to persist tags for filed binary (continuing):',
+      error instanceof Error ? error.message : String(error)
+    )
+  }
 }
 
 /**

--- a/apps/desktop/src/main/vault/indexer.ts
+++ b/apps/desktop/src/main/vault/indexer.ts
@@ -207,6 +207,48 @@ async function indexMarkdownFile(
 }
 
 /**
+ * Index a single non-markdown file (PDF/image/audio/video) into the cache and
+ * return its `note_cache` id.
+ *
+ * Idempotent: `syncFileToCache` resolves the id by path, so calling this before
+ * the filesystem watcher indexes the same file (e.g. eagerly during inbox
+ * filing) reuses one id and never touches `note_tags`. See #800.
+ */
+export async function indexBinaryFile(
+  db: ReturnType<typeof getIndexDatabase>,
+  relativePath: string,
+  absolutePath: string,
+  fileType: 'pdf' | 'image' | 'audio' | 'video'
+): Promise<string> {
+  // Get file stats for metadata
+  const stats = await stat(absolutePath)
+
+  // Generate a new ID for this file (reused if the path is already cached)
+  const id = generateNoteId()
+
+  // Get MIME type
+  const ext = getExtension(absolutePath)
+  const mimeType = getMimeType(ext)
+
+  // Derive title from filename (without extension)
+  const title = path.basename(absolutePath, path.extname(absolutePath))
+
+  const result = syncFileToCache(db, {
+    id,
+    path: relativePath,
+    title,
+    fileType,
+    mimeType,
+    fileSize: stats.size,
+    createdAt: stats.birthtime,
+    modifiedAt: stats.mtime
+  })
+  await flushProjectionEvents()
+
+  return result.id
+}
+
+/**
  * Index a non-markdown file (PDF, images, audio, video).
  */
 async function indexNonMarkdownFile(
@@ -217,39 +259,7 @@ async function indexNonMarkdownFile(
   db: ReturnType<typeof getIndexDatabase>
 ): Promise<'indexed' | 'error'> {
   try {
-    // Get file stats for metadata
-    const stats = await stat(absolutePath)
-
-    // Generate a new ID for this file
-    const id = generateNoteId()
-
-    // Get MIME type
-    const ext = getExtension(absolutePath)
-    const mimeType = getMimeType(ext)
-
-    // Derive title from filename (without extension)
-    const title = path.basename(absolutePath, path.extname(absolutePath))
-
-    // Sync to cache
-    logger.debug(`Syncing file to cache:`, {
-      id,
-      path: relativePath,
-      title,
-      fileType,
-      mimeType
-    })
-    syncFileToCache(db, {
-      id,
-      path: relativePath,
-      title,
-      fileType,
-      mimeType,
-      fileSize: stats.size,
-      createdAt: stats.birthtime,
-      modifiedAt: stats.mtime
-    })
-    await flushProjectionEvents()
-
+    await indexBinaryFile(db, relativePath, absolutePath, fileType)
     logger.debug(`Successfully indexed: ${relativePath} (${fileType})`)
     return 'indexed'
   } catch (error) {

--- a/apps/desktop/src/renderer/src/components/search/command-palette.tsx
+++ b/apps/desktop/src/renderer/src/components/search/command-palette.tsx
@@ -7,6 +7,7 @@ import type {
   DateRange,
   SearchReason
 } from '@memry/contracts/search-api'
+import { getTabIconForFileType } from '@memry/shared/file-types'
 import { useTabs } from '@/contexts/tabs'
 import { useSearch } from '@/hooks/use-search'
 import { searchService } from '@/services/search-service'
@@ -147,12 +148,17 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps): Rea
         objectType: item.type
       })
       switch (item.type) {
-        case 'note':
+        case 'note': {
+          // A "note" search result can actually be a filed binary (image/PDF/…).
+          // Open those via the file viewer with the correct icon, never the
+          // markdown editor (which would render raw bytes / freeze). See #800.
+          const fileType = item.metadata?.type === 'note' ? item.metadata.fileType : undefined
+          const isMarkdown = !fileType || fileType === 'markdown'
           openTab({
-            type: 'note',
+            type: isMarkdown ? 'note' : 'file',
             title: item.title,
-            icon: 'file-text',
-            path: `/note/${item.id}`,
+            icon: isMarkdown ? 'file-text' : getTabIconForFileType(fileType),
+            path: isMarkdown ? `/note/${item.id}` : `/file/${item.id}`,
             entityId: item.id,
             isPinned: false,
             isModified: false,
@@ -160,6 +166,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps): Rea
             isDeleted: false
           })
           break
+        }
         case 'journal': {
           const date = item.metadata?.type === 'journal' ? item.metadata.date : item.id
           openTab({

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -229,8 +229,8 @@ export function NotePage({ noteId }: NotePageProps) {
           return
         }
         setFileProbe({ id: noteId, status: 'file' })
-        openTab({
-          type: 'file',
+        const fileTab = {
+          type: 'file' as const,
           title: file.title,
           icon: getTabIconForFileType(file.fileType),
           path: `/file/${noteId}`,
@@ -239,8 +239,20 @@ export function NotePage({ noteId }: NotePageProps) {
           isModified: false,
           isPreview: false,
           isDeleted: false
-        })
-        if (activeTab?.id) closeTab(activeTab.id)
+        }
+        // Convert THIS tab in place. openTab dedups by entityId, so a plain
+        // openTab would just re-focus the existing note tab without changing its
+        // type/icon — replaceActive swaps the active tab for the file viewer.
+        // Guard on the active tab being this note (replaceActive replaces the
+        // group's active tab, so an unguarded call in a split/background pane
+        // would clobber an unrelated tab) and skip pinned tabs (replaceActive
+        // no-ops on them); the render gate already prevents the editor from
+        // mounting on the binary in those rare fallthrough cases.
+        if (activeTab?.entityId === noteId && !activeTab.isPinned) {
+          openTab(fileTab, { replaceActive: true })
+        } else {
+          openTab(fileTab)
+        }
       })
       .catch(() => {
         if (!cancelled) setFileProbe({ id: noteId, status: 'note' })
@@ -248,7 +260,7 @@ export function NotePage({ noteId }: NotePageProps) {
     return () => {
       cancelled = true
     }
-  }, [noteId, openTab, closeTab, activeTab?.id])
+  }, [noteId, openTab, activeTab?.entityId, activeTab?.isPinned])
 
   const handlePropertyBlocked = useCallback((action: PropertySectionAction) => {
     const messages: Record<PropertySectionAction, string> = {

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -84,6 +84,7 @@ import { useFindInPage } from '@/hooks/use-find-in-page'
 import { ReviewBadgeLayer, ReviewRail, useCriticMarkupReview } from '@/components/note/review'
 
 import { useT } from '@memry/i18n/renderer'
+import { getTabIconForFileType } from '@memry/shared/file-types'
 
 const log = createLogger('Page:Note')
 
@@ -201,6 +202,53 @@ export function NotePage({ noteId }: NotePageProps) {
     content: string
   } | null>(null)
   const [storedNoteIdForContent, setStoredNoteIdForContent] = useState(noteId)
+
+  // #800 belt-and-suspenders: a filed binary (image/PDF/…) mis-opened as a note
+  // tab must never mount the markdown editor — raw bytes render as junk tag
+  // pills and a multi-MB blob freezes the app. Probe getFile (null for real
+  // markdown notes); if this id is actually a file, redirect the tab to the
+  // in-app viewer. Render nothing until the probe resolves so the editor never
+  // mounts on a binary. Runs concurrently with the note load, so it adds no
+  // perceptible latency for normal notes. The result is keyed by id so a stale
+  // result for a previous note reads as 'pending' during render (no reset in
+  // the effect).
+  const [fileProbe, setFileProbe] = useState<{ id: string | null; status: 'note' | 'file' }>({
+    id: null,
+    status: 'note'
+  })
+  const fileProbeStatus = fileProbe.id === noteId ? fileProbe.status : 'pending'
+  useEffect(() => {
+    if (!noteId) return
+    let cancelled = false
+    void notesService
+      .getFile(noteId)
+      .then((file) => {
+        if (cancelled) return
+        if (!file) {
+          setFileProbe({ id: noteId, status: 'note' })
+          return
+        }
+        setFileProbe({ id: noteId, status: 'file' })
+        openTab({
+          type: 'file',
+          title: file.title,
+          icon: getTabIconForFileType(file.fileType),
+          path: `/file/${noteId}`,
+          entityId: noteId,
+          isPinned: false,
+          isModified: false,
+          isPreview: false,
+          isDeleted: false
+        })
+        if (activeTab?.id) closeTab(activeTab.id)
+      })
+      .catch(() => {
+        if (!cancelled) setFileProbe({ id: noteId, status: 'note' })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [noteId, openTab, closeTab, activeTab?.id])
 
   const handlePropertyBlocked = useCallback((action: PropertySectionAction) => {
     const messages: Record<PropertySectionAction, string> = {
@@ -1025,6 +1073,13 @@ export function NotePage({ noteId }: NotePageProps) {
   // No note ID - show empty state
   if (!noteId) {
     return <NoteEmptyState />
+  }
+
+  // #800: don't mount the markdown editor until we've confirmed this id is not a
+  // filed binary. 'pending' = probe in flight; 'file' = redirecting to the file
+  // viewer. Either way render nothing so a binary never reaches the editor.
+  if (fileProbeStatus !== 'note') {
+    return null
   }
 
   // Error

--- a/packages/contracts/src/search-api.ts
+++ b/packages/contracts/src/search-api.ts
@@ -34,6 +34,12 @@ export interface NoteResultMetadata {
   tags: string[]
   emoji?: string | null
   wordCount?: number | null
+  /**
+   * Underlying file type. Absent/`'markdown'` = a real note; a binary value
+   * (image/pdf/audio/video) means this "note" result is actually a filed file
+   * and must be opened via the file viewer, not the markdown editor. See #800.
+   */
+  fileType?: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
 }
 
 export interface JournalResultMetadata {


### PR DESCRIPTION
Closes #800.

## Problem
Filing an image/PDF via the inbox **File** button, then opening it from Cmd/Ctrl+K or Home, rendered the raw bytes in the markdown editor: garbage title, colorful byte-runs as "tag" pills, a freeze on multi-MB blobs, and a note icon in the tab (while Collections showed the image icon). The tag assigned in the inbox was also dropped.

Two independent root causes:
- **Open path.** Search had no `fileType` concept — the fuzzy `getNoteTitles` fallback returned binary `note_cache` rows as `type:'note'`, and the command palette hardcoded `type:'note'` / `file-text` / `/note/:id`. `getNoteById` then read the file as utf-8 and handed the bytes to BlockNote.
- **Filing.** `fileBinaryToFolder` never forwarded tags and recorded an empty tag set; binaries have no frontmatter so nothing persisted them.

## Changes
**Open path**
- `NoteResultMetadata` now carries an optional `fileType`; `searchNotes` and the fuzzy `getNoteTitles` fallback select `file_type`.
- The command palette opens a binary "note" result as a **file tab** with the correct icon (`getTabIconForFileType`) — same branch the tree/related-item openers already use.
- Belt-and-suspenders: `NotePage` probes `getFile` and, for any binary still routed to a note tab (e.g. recent-search "reasons"), redirects to the in-app file viewer and never mounts the editor on raw bytes. The probe runs concurrently with the note load and is keyed by id, so normal notes see no added latency. `getNoteById` is intentionally left unchanged (it's shared by rename/move/canvas/tasks).

**Tags**
- Binary filing (both file-to-folder and link-to-notes) merges existing inbox tags + assigned tags + `inbox`, eagerly indexes the moved file to obtain its `note_cache` id, and writes the tags to `note_tags`.
- Extracted a shared `indexBinaryFile()` helper (the bulk indexer now delegates to it). The eager index is idempotent — `syncFileToCache` resolves the id by path and never touches `note_tags`, so the filesystem watcher's later re-sync reuses the same id and leaves tags intact.

## Backward compatibility
Additive optional contract field (old search payloads still parse); no schema/migration change — `note_tags` and `note_cache.file_type` already exist and already store binaries.

## Notes for reviewers
- `FilePage` doesn't render a tags row today, so tags are now persisted/discoverable (tag search, graph, collections) but not shown in the viewer — surfacing them there is out of scope.
- Binary filing now also tags the file `inbox`, matching the markdown filing path.

## Tests
- `filing.test.ts`: new — filing an image with a tag persists existing + assigned + `inbox` to `note_tags` and eagerly indexes as `image`.
- Full desktop **main** suite: 3994 passed / 1 skipped. Node + web + contracts typecheck, `ipc:check`, and eslint on changed files all clean.
- Manual (dev app) still recommended: file an image/PDF with a tag, open from ⌘K and Home → in-app viewer, correct tab icon, responsive, deletable, tag present.