### PR TITLE
fix(extension): request Firefox host permission before first clip

### DIFF
--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -281,6 +281,12 @@ export default defineBackground(() => {
       setTimeout(() => void restoreQueueBadge(), 2000)
       return
     }
+    // On Firefox MV3 the loopback host permission is opt-in and can only be
+    // requested from a user-gesture page — the popup — so this background
+    // shortcut cannot prompt for it. Until it is granted, the loopback fetch
+    // fails and captureOrQueue queues the capture (the badge shows the count)
+    // rather than losing it; the queue flushes once the user grants access by
+    // saving from the popup once.
     const res = await captureOrQueue(extracted.capture)
     if (res.ok) {
       await browser.action.setBadgeText({ text: '✓' })

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -122,6 +122,9 @@ export default function App() {
       .sendMessage({ type: 'CAPTURE', capture: state.draft })
       .catch(() => ({ ok: false, error: 'network' }))
     dispatch({ type: 'SAVE_DONE', result })
+    // Mirror onAdd: if the server came up between the timeout and this CAPTURE,
+    // flash "Sent" and close. Offline-queued / error stay open.
+    if (result.ok) setTimeout(() => window.close(), 600)
   }
 
   // One button. Firefox MV3 makes the loopback host permission opt-in, so

--- a/apps/extension/src/entrypoints/popup/App.tsx
+++ b/apps/extension/src/entrypoints/popup/App.tsx
@@ -8,6 +8,7 @@ import type {
   StatusResponse
 } from '@/lib/messages'
 import { initialState, reducer, selectPhase } from '@/lib/popup-state'
+import { ensureHostPermission } from '@/lib/capture-permissions'
 import { EditableTitle } from '@/components/EditableTitle'
 import { PropertyRows } from '@/components/PropertyRows'
 import { TagEditor } from '@/components/TagEditor'
@@ -62,6 +63,16 @@ export default function App() {
 
   const setDraft = (draft: ArticleCapture) => dispatch({ type: 'EDIT', draft })
 
+  // Probe the desktop app again. The mount probe may have run while the Firefox
+  // host permission was still blocked and cached a stale 'app-closed'.
+  const fetchStatus = async (): Promise<StatusResponse> => {
+    try {
+      return (await browser.runtime.sendMessage({ type: 'GET_STATUS' })) as StatusResponse
+    } catch {
+      return { connection: 'app-closed', port: null }
+    }
+  }
+
   const onAdd = async (
     connectionOverride?: ConnectionState
   ): Promise<CaptureResponse | undefined> => {
@@ -92,14 +103,44 @@ export default function App() {
     const up: { ok: boolean } = await browser.runtime
       .sendMessage({ type: 'WAIT_FOR_SERVER' })
       .catch(() => ({ ok: false }))
-    dispatch({ type: 'LAUNCH_DONE', ok: up.ok })
-    if (!up.ok) return
-    dispatch({ type: 'STATUS', connection: 'needs-pairing', port: null })
-    await onAdd('needs-pairing')
+    if (up.ok) {
+      dispatch({ type: 'LAUNCH_DONE', ok: true })
+      const status = await fetchStatus()
+      dispatch({ type: 'STATUS', connection: status.connection, port: status.port })
+      await onAdd(status.connection === 'app-closed' ? 'needs-pairing' : status.connection)
+      return
+    }
+    // The server never came up in time. Don't drop the draft — hand it to the
+    // background, which queues it for the retry alarm (the badge shows the
+    // count) instead of losing it when the popup closes.
+    if (!state.draft) {
+      dispatch({ type: 'LAUNCH_DONE', ok: false })
+      return
+    }
+    dispatch({ type: 'SAVE_START' })
+    const result: CaptureResponse = await browser.runtime
+      .sendMessage({ type: 'CAPTURE', capture: state.draft })
+      .catch(() => ({ ok: false, error: 'network' }))
+    dispatch({ type: 'SAVE_DONE', result })
   }
 
-  // One button: launch MemryNote first if it's closed, otherwise just send.
-  const onSend = () => (state.connection === 'app-closed' ? onLaunchAndAdd() : onAdd())
+  // One button. Firefox MV3 makes the loopback host permission opt-in, so
+  // request it on this click (a user gesture) before any 127.0.0.1 fetch —
+  // a no-op on Chrome/Edge where it's granted at install. Then re-probe: the
+  // mount probe may have been blocked by the missing permission.
+  const onSend = async () => {
+    if (!(await ensureHostPermission())) {
+      dispatch({ type: 'SAVE_DONE', result: { ok: false, error: 'permission-denied' } })
+      return
+    }
+    const status = await fetchStatus()
+    dispatch({ type: 'STATUS', connection: status.connection, port: status.port })
+    if (status.connection === 'app-closed') {
+      await onLaunchAndAdd()
+    } else {
+      await onAdd(status.connection)
+    }
+  }
 
   // ⌘↵ / Ctrl↵ saves when the card is ready. Ref keeps the handler fresh
   // without re-subscribing the listener on every render.

--- a/apps/extension/src/lib/capture-permissions.test.ts
+++ b/apps/extension/src/lib/capture-permissions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ensureHostPermission, LOOPBACK_ORIGIN } from './capture-permissions'
+
+const origins = { origins: [LOOPBACK_ORIGIN] }
+
+describe('ensureHostPermission', () => {
+  it('returns true without prompting when the host is already granted', async () => {
+    const request = vi.fn()
+    const ok = await ensureHostPermission({
+      contains: vi.fn().mockResolvedValue(true),
+      request
+    })
+    expect(ok).toBe(true)
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('requests the host when missing and returns the grant (approved)', async () => {
+    const request = vi.fn().mockResolvedValue(true)
+    const ok = await ensureHostPermission({
+      contains: vi.fn().mockResolvedValue(false),
+      request
+    })
+    expect(ok).toBe(true)
+    expect(request).toHaveBeenCalledWith(origins)
+  })
+
+  it('returns false when the user denies the request', async () => {
+    const ok = await ensureHostPermission({
+      contains: vi.fn().mockResolvedValue(false),
+      request: vi.fn().mockResolvedValue(false)
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('falls back to true when the permissions API throws', async () => {
+    const ok = await ensureHostPermission({
+      contains: vi.fn().mockRejectedValue(new Error('no api')),
+      request: vi.fn()
+    })
+    expect(ok).toBe(true)
+  })
+})

--- a/apps/extension/src/lib/capture-permissions.ts
+++ b/apps/extension/src/lib/capture-permissions.ts
@@ -1,0 +1,26 @@
+// Firefox MV3 treats manifest host_permissions as opt-in: they are NOT granted
+// at install, so every 127.0.0.1 loopback fetch is blocked until the user
+// approves. Chrome/Edge grant the declared host at install, so contains() is
+// already true there and no prompt is shown.
+export const LOOPBACK_ORIGIN = 'http://127.0.0.1/*'
+
+interface PermissionsApi {
+  contains(perms: { origins: string[] }): Promise<boolean>
+  request(perms: { origins: string[] }): Promise<boolean>
+}
+
+// Ensure the loopback host permission before any 127.0.0.1 fetch. Must be called
+// from a user gesture (a click) so Firefox allows the request prompt. Returns
+// true when the permission is held (already granted, or just approved), false
+// when the user denies it. If the permissions API is unavailable the capture is
+// not blocked — the manifest still declares the host.
+export async function ensureHostPermission(
+  permissions: PermissionsApi = browser.permissions
+): Promise<boolean> {
+  try {
+    if (await permissions.contains({ origins: [LOOPBACK_ORIGIN] })) return true
+    return await permissions.request({ origins: [LOOPBACK_ORIGIN] })
+  } catch {
+    return true
+  }
+}

--- a/apps/extension/src/lib/popup-state.test.ts
+++ b/apps/extension/src/lib/popup-state.test.ts
@@ -120,6 +120,10 @@ describe('mapError', () => {
     expect(mapError('payload-too-large')).toContain('too large')
     expect(mapError('whatever')).toContain('reach Memry')
   })
+
+  test('a denied host permission asks the user to allow 127.0.0.1', () => {
+    expect(mapError('permission-denied')).toBe('Allow access to 127.0.0.1, then save again.')
+  })
 })
 
 describe('offline queue state', () => {

--- a/apps/extension/src/lib/popup-state.ts
+++ b/apps/extension/src/lib/popup-state.ts
@@ -61,6 +61,8 @@ export function mapError(code: string): string {
       return 'This page is too large to capture.'
     case 'pair-timeout':
       return 'Pairing timed out. Try again.'
+    case 'permission-denied':
+      return 'Allow access to 127.0.0.1, then save again.'
     default:
       return "Couldn't reach Memry. Try again."
   }


### PR DESCRIPTION
## Problem

Reported on Firefox/Zen by a beta tester (part of #795): install the clipper, open a page, clip → the browser asks for permission, they approve, **but nothing is saved**. The second clip works and does not re-ask.

**Root cause.** On Firefox MV3, manifest `host_permissions` are opt-in — granted *after* install, not at install time. The clipper declares `host_permissions: ['http://127.0.0.1/*']` but never called `browser.permissions.request()` anywhere, so the loopback fetch to the desktop app is blocked on the first capture. The failure is swallowed and indistinguishable from "app closed":

- `probeServer`/`postCapture` collapse every fetch throw to `null`/`'network'`.
- The popup probes connection status once on mount and caches a stale `'app-closed'` (the desktop app is actually running).
- The launch path returned before the draft ever reached the background, so it was dropped rather than queued.

Chrome/Edge are unaffected — they grant the declared host at install, so the permission is already held.

## Fix

- **`lib/capture-permissions.ts` (new)** — `ensureHostPermission()` checks `permissions.contains()` and, if missing, calls `permissions.request()` for `http://127.0.0.1/*`. It takes the permissions API as an injectable argument, mirroring the existing `fetchFn = fetch` pattern in `capture-client.ts`, so it is unit-tested. Returns `true` when held/granted, `false` on denial, and does not block capture if the API is unavailable.
- **`popup/App.tsx`** — request the permission on the user's click (a user gesture, required by Firefox) before any loopback fetch, then re-probe so a stale `'app-closed'` is refreshed and the capture routes on fresh status. On the launch path, hand the draft to the background queue instead of dropping it when the server doesn't come up in time.
- **`popup-state.ts`** — map a denied permission to actionable copy ("Allow access to 127.0.0.1, then save again.").

No manifest change: the origin is already declared, and Firefox MV3 makes declared `host_permissions` runtime-requestable.

## Verification

- `pnpm --filter @memry/extension test` → 61/61 (4 new `capture-permissions` tests + a `permission-denied` mapError test + existing suite)
- `pnpm --filter @memry/extension typecheck` → clean
- `pnpm --filter @memry/extension lint` → clean

## Reviewer notes

- **Manual Firefox/Zen QA is the real acceptance and is still pending**: fresh profile with the desktop app running → open a page → Send → approve the 127.0.0.1 prompt → capture lands (or queues + flushes); re-clip → no re-prompt. Plus a Chrome regression pass.
- Known Firefox nuance: on some versions the browserAction popup may close when the permission doorhanger appears, aborting the awaited continuation. The grant still persists, so it degrades to a deterministic reopen-and-save (the draft re-extracts on reopen) — a strict improvement over today's implicit-grant race, and the common case (popup stays open) captures on the first click.
- Out of scope (noted, unchanged): `waitForServer` probes default ports only, ignoring the `memry:capture-port` override — unrelated to this bug.

Closes #804