### PR TITLE
fix(icon-picker): keep note/folder emoji picker on-screen via Radix Popover

### DIFF
--- a/apps/desktop/src/renderer/src/components/folder-view/folder-emoji-chip.test.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-emoji-chip.test.tsx
@@ -14,6 +14,31 @@ vi.mock('@/components/note/note-title/EmojiPicker', () => ({
     ) : null
 }))
 
+// The real Radix Popover does not open on click in jsdom. Stub the wrapper so the
+// trigger click flips `onOpenChange(true)` and the content renders only when open.
+vi.mock('@/components/ui/popover', async () => {
+  const React = await import('react')
+  return {
+    Popover: ({ open, onOpenChange, children }: any) =>
+      React.createElement(
+        React.Fragment,
+        null,
+        React.Children.map(children, (child: any) =>
+          React.isValidElement(child) ? React.cloneElement(child, { open, onOpenChange }) : child
+        )
+      ),
+    PopoverTrigger: ({ children, onOpenChange }: any) =>
+      React.cloneElement(children, {
+        onClick: (e: any) => {
+          children.props.onClick?.(e)
+          onOpenChange?.(true)
+        }
+      }),
+    PopoverContent: ({ children, open }: any) =>
+      open ? React.createElement('div', null, children) : null
+  }
+})
+
 describe('FolderEmojiChip', () => {
   it('renders folder icon button when no custom icon', () => {
     const onIconChange = vi.fn()

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-emoji-chip.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-emoji-chip.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useState } from 'react'
-import { createPortal } from 'react-dom'
 import { Folder } from '@/lib/icons'
 import { NoteIconDisplay } from '@/lib/render-note-icon'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { useT } from '@memry/i18n/renderer'
 
 const LazyEmojiPicker = lazy(async () => ({
@@ -22,14 +22,6 @@ interface FolderEmojiChipProps {
 export function FolderEmojiChip({ icon, onIconChange }: FolderEmojiChipProps): React.JSX.Element {
   const { t } = useT('common')
   const [open, setOpen] = useState(false)
-  const [pos, setPos] = useState<{ top: number; left: number } | null>(null)
-
-  const handleClick = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation()
-    const rect = e.currentTarget.getBoundingClientRect()
-    setPos({ top: rect.bottom + 6, left: rect.left })
-    setOpen((v) => !v)
-  }, [])
 
   const handleSelect = useCallback(
     (value: string) => {
@@ -45,36 +37,38 @@ export function FolderEmojiChip({ icon, onIconChange }: FolderEmojiChipProps): R
   }, [onIconChange])
 
   return (
-    <>
-      <button
-        type="button"
-        onClick={handleClick}
-        aria-label={t('phaseF.componentsFolderIconButton.setFolderIcon')}
-        className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-[9px] border bg-muted transition-colors hover:bg-accent"
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          onClick={(e) => e.stopPropagation()}
+          aria-label={t('phaseF.componentsFolderIconButton.setFolderIcon')}
+          className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-[9px] border bg-muted transition-colors hover:bg-accent"
+        >
+          {icon ? (
+            <NoteIconDisplay value={icon} className="text-[17px] leading-none" />
+          ) : (
+            <Folder className="h-4 w-4 text-muted-foreground" />
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="w-auto border-0 bg-transparent p-0 shadow-none"
+        onClick={(e) => e.stopPropagation()}
       >
-        {icon ? (
-          <NoteIconDisplay value={icon} className="text-[17px] leading-none" />
-        ) : (
-          <Folder className="h-4 w-4 text-muted-foreground" />
-        )}
-      </button>
-
-      {open &&
-        pos &&
-        createPortal(
-          <div className="fixed z-[100]" style={{ top: pos.top, left: pos.left }}>
-            <Suspense fallback={null}>
-              <LazyEmojiPicker
-                isOpen
-                onClose={() => setOpen(false)}
-                onSelect={handleSelect}
-                onRemove={handleRemove}
-                hasEmoji={!!icon}
-              />
-            </Suspense>
-          </div>,
-          document.body
-        )}
-    </>
+        <Suspense fallback={null}>
+          <LazyEmojiPicker
+            isOpen
+            embedded
+            onClose={() => setOpen(false)}
+            onSelect={handleSelect}
+            onRemove={handleRemove}
+            hasEmoji={!!icon}
+          />
+        </Suspense>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/apps/desktop/src/renderer/src/components/folder-view/folder-emoji-chip.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/folder-emoji-chip.tsx
@@ -43,7 +43,7 @@ export function FolderEmojiChip({ icon, onIconChange }: FolderEmojiChipProps): R
           type="button"
           onClick={(e) => e.stopPropagation()}
           aria-label={t('phaseF.componentsFolderIconButton.setFolderIcon')}
-          className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-[9px] border bg-muted transition-colors hover:bg-accent"
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px] border bg-muted transition-colors hover:bg-accent"
         >
           {icon ? (
             <NoteIconDisplay value={icon} className="text-[17px] leading-none" />

--- a/apps/desktop/src/renderer/src/components/icon-picker-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/icon-picker-button.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { IconPickerButton } from './icon-picker-button'
+
+// Mock the lazy EmojiPicker with a minimal stub exposing Select/Remove/Close.
+vi.mock('@/components/note/note-title/EmojiPicker', () => ({
+  EmojiPicker: ({ onSelect, onRemove, onClose, isOpen }: any) =>
+    isOpen ? (
+      <div data-testid="emoji-picker">
+        <button onClick={() => onSelect('🎯')}>Select 🎯</button>
+        <button onClick={onRemove}>Remove</button>
+        <button onClick={onClose}>Close</button>
+      </div>
+    ) : null
+}))
+
+// The real Radix Popover does not open on click in jsdom. Stub the wrapper so the
+// trigger click flips `onOpenChange(true)` and the content renders only when open.
+vi.mock('@/components/ui/popover', async () => {
+  const React = await import('react')
+  return {
+    Popover: ({ open, onOpenChange, children }: any) =>
+      React.createElement(
+        React.Fragment,
+        null,
+        React.Children.map(children, (child: any) =>
+          React.isValidElement(child) ? React.cloneElement(child, { open, onOpenChange }) : child
+        )
+      ),
+    PopoverTrigger: ({ children, onOpenChange }: any) =>
+      React.cloneElement(children, {
+        onClick: (e: any) => {
+          children.props.onClick?.(e)
+          onOpenChange?.(true)
+        }
+      }),
+    PopoverContent: ({ children, open }: any) =>
+      open ? React.createElement('div', null, children) : null
+  }
+})
+
+describe('IconPickerButton', () => {
+  it('renders the trigger button with the given ariaLabel and glyph', () => {
+    render(
+      <IconPickerButton hasIcon={false} onIconChange={vi.fn()} ariaLabel="Set icon">
+        <span>📝</span>
+      </IconPickerButton>
+    )
+
+    const btn = screen.getByRole('button', { name: 'Set icon' })
+    expect(btn).toBeDefined()
+    expect(screen.getByText('📝')).toBeDefined()
+  })
+
+  it('renders the leading element before the trigger', () => {
+    render(
+      <IconPickerButton
+        hasIcon={false}
+        onIconChange={vi.fn()}
+        ariaLabel="Set icon"
+        leading={<span data-testid="chevron" />}
+      >
+        <span>📝</span>
+      </IconPickerButton>
+    )
+
+    expect(screen.getByTestId('chevron')).toBeDefined()
+  })
+
+  it('opens the picker on trigger click when uncontrolled', async () => {
+    render(
+      <IconPickerButton hasIcon={false} onIconChange={vi.fn()} ariaLabel="Set icon">
+        <span>📝</span>
+      </IconPickerButton>
+    )
+
+    expect(screen.queryByTestId('emoji-picker')).toBeFalsy()
+    fireEvent.click(screen.getByRole('button', { name: 'Set icon' }))
+    expect(await screen.findByTestId('emoji-picker')).toBeDefined()
+  })
+
+  it('calls onIconChange with the picked value', () => {
+    const onIconChange = vi.fn()
+    render(
+      <IconPickerButton hasIcon={false} onIconChange={onIconChange} ariaLabel="Set icon">
+        <span>📝</span>
+      </IconPickerButton>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set icon' }))
+    fireEvent.click(screen.getByText('Select 🎯'))
+
+    expect(onIconChange).toHaveBeenCalledWith('🎯')
+  })
+
+  it('calls onIconChange with null when removed', () => {
+    const onIconChange = vi.fn()
+    render(
+      <IconPickerButton hasIcon onIconChange={onIconChange} ariaLabel="Set icon">
+        <span>⭐</span>
+      </IconPickerButton>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set icon' }))
+    fireEvent.click(screen.getByText('Remove'))
+
+    expect(onIconChange).toHaveBeenCalledWith(null)
+  })
+
+  it('honours the controlled pickerOpen prop', () => {
+    const { rerender } = render(
+      <IconPickerButton
+        hasIcon={false}
+        onIconChange={vi.fn()}
+        ariaLabel="Set icon"
+        pickerOpen={false}
+        onPickerOpenChange={vi.fn()}
+      >
+        <span>📝</span>
+      </IconPickerButton>
+    )
+    expect(screen.queryByTestId('emoji-picker')).toBeFalsy()
+
+    rerender(
+      <IconPickerButton
+        hasIcon={false}
+        onIconChange={vi.fn()}
+        ariaLabel="Set icon"
+        pickerOpen
+        onPickerOpenChange={vi.fn()}
+      >
+        <span>📝</span>
+      </IconPickerButton>
+    )
+    expect(screen.getByTestId('emoji-picker')).toBeDefined()
+  })
+
+  it('fires onPickerOpenChange(true) when the trigger is clicked (controlled)', () => {
+    const onPickerOpenChange = vi.fn()
+    render(
+      <IconPickerButton
+        hasIcon={false}
+        onIconChange={vi.fn()}
+        ariaLabel="Set icon"
+        pickerOpen={false}
+        onPickerOpenChange={onPickerOpenChange}
+      >
+        <span>📝</span>
+      </IconPickerButton>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set icon' }))
+    expect(onPickerOpenChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/icon-picker-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/icon-picker-button.test.tsx
@@ -79,7 +79,7 @@ describe('IconPickerButton', () => {
     expect(await screen.findByTestId('emoji-picker')).toBeDefined()
   })
 
-  it('calls onIconChange with the picked value', () => {
+  it('calls onIconChange with the picked value', async () => {
     const onIconChange = vi.fn()
     render(
       <IconPickerButton hasIcon={false} onIconChange={onIconChange} ariaLabel="Set icon">
@@ -88,12 +88,13 @@ describe('IconPickerButton', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Set icon' }))
-    fireEvent.click(screen.getByText('Select 🎯'))
+    // EmojiPicker is React.lazy — await it before interacting to avoid order-dependence.
+    fireEvent.click(await screen.findByText('Select 🎯'))
 
     expect(onIconChange).toHaveBeenCalledWith('🎯')
   })
 
-  it('calls onIconChange with null when removed', () => {
+  it('calls onIconChange with null when removed', async () => {
     const onIconChange = vi.fn()
     render(
       <IconPickerButton hasIcon onIconChange={onIconChange} ariaLabel="Set icon">
@@ -102,12 +103,12 @@ describe('IconPickerButton', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Set icon' }))
-    fireEvent.click(screen.getByText('Remove'))
+    fireEvent.click(await screen.findByText('Remove'))
 
     expect(onIconChange).toHaveBeenCalledWith(null)
   })
 
-  it('honours the controlled pickerOpen prop', () => {
+  it('honours the controlled pickerOpen prop', async () => {
     const { rerender } = render(
       <IconPickerButton
         hasIcon={false}
@@ -132,7 +133,39 @@ describe('IconPickerButton', () => {
         <span>📝</span>
       </IconPickerButton>
     )
-    expect(screen.getByTestId('emoji-picker')).toBeDefined()
+    expect(await screen.findByTestId('emoji-picker')).toBeDefined()
+  })
+
+  it('closes the picker when the picker requests close (uncontrolled)', async () => {
+    render(
+      <IconPickerButton hasIcon={false} onIconChange={vi.fn()} ariaLabel="Set icon">
+        <span>📝</span>
+      </IconPickerButton>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set icon' }))
+    fireEvent.click(await screen.findByText('Close'))
+
+    expect(screen.queryByTestId('emoji-picker')).toBeFalsy()
+  })
+
+  it('notifies onPickerOpenChange(false) when the picker requests close (controlled)', async () => {
+    const onPickerOpenChange = vi.fn()
+    render(
+      <IconPickerButton
+        hasIcon={false}
+        onIconChange={vi.fn()}
+        ariaLabel="Set icon"
+        pickerOpen
+        onPickerOpenChange={onPickerOpenChange}
+      >
+        <span>📝</span>
+      </IconPickerButton>
+    )
+
+    fireEvent.click(await screen.findByText('Close'))
+
+    expect(onPickerOpenChange).toHaveBeenCalledWith(false)
   })
 
   it('fires onPickerOpenChange(true) when the trigger is clicked (controlled)', () => {

--- a/apps/desktop/src/renderer/src/components/icon-picker-button.tsx
+++ b/apps/desktop/src/renderer/src/components/icon-picker-button.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 
 const LazyEmojiPicker = lazy(async () => ({
   default: (await import('@/components/note/note-title/EmojiPicker')).EmojiPicker
@@ -34,7 +34,6 @@ export function IconPickerButton({
   onPickerOpenChange
 }: IconPickerButtonProps) {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
-  const [portalPosition, setPortalPosition] = useState<{ top: number; left: number } | null>(null)
 
   const isControlled = pickerOpen !== undefined
   const isPickerOpen = isControlled ? pickerOpen : uncontrolledOpen
@@ -48,32 +47,6 @@ export function IconPickerButton({
       }
     },
     [isControlled, onPickerOpenChange]
-  )
-
-  const updatePortalPosition = useCallback((button: HTMLButtonElement) => {
-    const rect = button.getBoundingClientRect()
-    setPortalPosition({ top: rect.bottom + 4, left: rect.left })
-  }, [])
-
-  const handleButtonRef = useCallback(
-    (button: HTMLButtonElement | null) => {
-      if (button) {
-        updatePortalPosition(button)
-      } else {
-        setPortalPosition(null)
-      }
-    },
-    [updatePortalPosition]
-  )
-
-  const handleIconClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.stopPropagation()
-      e.preventDefault()
-      updatePortalPosition(e.currentTarget)
-      setPickerOpen(!isPickerOpen)
-    },
-    [updatePortalPosition, setPickerOpen, isPickerOpen]
   )
 
   const handleSelect = useCallback(
@@ -97,35 +70,35 @@ export function IconPickerButton({
     <div className="shrink-0 flex items-center gap-0.5">
       {leading}
 
-      <button
-        ref={handleButtonRef}
-        type="button"
-        onClick={handleIconClick}
-        className="flex h-5 w-5 items-center justify-center rounded"
-        aria-label={ariaLabel}
-      >
-        {children}
-      </button>
-
-      {isPickerOpen &&
-        portalPosition &&
-        createPortal(
-          <div
-            className="fixed z-[100]"
-            style={{ top: portalPosition.top, left: portalPosition.left }}
+      <Popover open={isPickerOpen} onOpenChange={setPickerOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            onClick={(e) => e.stopPropagation()}
+            className="flex h-5 w-5 items-center justify-center rounded"
+            aria-label={ariaLabel}
           >
-            <Suspense fallback={null}>
-              <LazyEmojiPicker
-                isOpen
-                onClose={handleClose}
-                onSelect={handleSelect}
-                onRemove={handleRemove}
-                hasEmoji={hasIcon}
-              />
-            </Suspense>
-          </div>,
-          document.body
-        )}
+            {children}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          sideOffset={4}
+          className="w-auto border-0 bg-transparent p-0 shadow-none"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Suspense fallback={null}>
+            <LazyEmojiPicker
+              isOpen
+              embedded
+              onClose={handleClose}
+              onSelect={handleSelect}
+              onRemove={handleRemove}
+              hasEmoji={hasIcon}
+            />
+          </Suspense>
+        </PopoverContent>
+      </Popover>
     </div>
   )
 }


### PR DESCRIPTION
Fixes #801 (part of epic #795).

## Problem
The sidebar note/folder icon picker was frequently clipped below the fold, pinned to the sidebar's left edge, or vanished while scrolling. `IconPickerButton` portaled the emoji/icon picker to `document.body` with a one-shot `getBoundingClientRect()` position and **zero viewport-collision handling**:
- No clamp against `window.innerHeight/innerWidth`, no flip-up → a ~350×435px panel pinned below a lower row overflows the viewport ("never fully visible") and anchors to the sidebar's left edge ("far left").
- No scroll/resize reposition; in the virtualized tree the ref callback ran `setPortalPosition(null)` on row recycle and the render guard then unmounted the panel ("hides even more").

## Fix
Replace the manual portal with a Radix `Popover` hosting `<EmojiPicker embedded>`, mirroring the already-proven `settings/tag-icon-chip.tsx` pattern. Radix (Floating UI) handles flip/shift collision avoidance and reposition-on-scroll for free, and deletes all the fragile positioning state.

- `icon-picker-button.tsx` — core rewrite. **Public API unchanged** (`children`/`hasIcon`/`onIconChange`/`ariaLabel`/`leading`/`pickerOpen`/`onPickerOpenChange`), so all three callers (notes-tree, virtualized-notes-tree, folder-icon-button) are untouched. The `leading` chevron stays outside the Popover; non-`modal` since the sidebar isn't inside a Dialog.
- `folder-view/folder-emoji-chip.tsx` — the folder-view header chip had the identical manual-portal defect; migrated the same way for consistency.

## Tests
- `icon-picker-button.test.tsx` — **new** (previously zero coverage): trigger/aria, controlled + uncontrolled open, select/remove/close wiring.
- `folder-emoji-chip.test.tsx` — added a stateful `@/components/ui/popover` stub (the real Radix Popover does not open on click in jsdom).

## Verification
- Full renderer suite: **5374 passed, 0 failed**, 6 skipped (481 files)
- `typecheck:web`: 0 errors · eslint on changed sources: clean · `git diff --check`: clean

## Reviewer notes
- Pure positioning fix — no documented user-facing workflow changes, and no docs page references the icon/emoji picker (docs gate skipped as intentionally non-docs).
- Manual smoke suggested: long scrolled tree → click an icon near the viewport bottom (should flip up, fully visible); scroll with the picker open; confirm the folder chevron still expands and clicking the icon doesn't select the row.