### PR TITLE
fix(comments): open image/PDF attachments in-app instead of trapping the app

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -15,7 +15,7 @@ import {
   dialog
 } from 'electron'
 import { createHash } from 'node:crypto'
-import { join, resolve, normalize, sep } from 'path'
+import { join, resolve, normalize } from 'path'
 import { homedir } from 'node:os'
 import { existsSync, readdirSync, statSync, createReadStream } from 'node:fs'
 import { lookup as mimeLookup } from 'mime-types'
@@ -179,6 +179,25 @@ const shutdownLog = createLogger('Shutdown')
 const deepLinkLog = createLogger('DeepLink')
 const navGuardLog = createLogger('NavigationGuard')
 
+// Hand a memry-file:// URL to the OS default app after allowlist-checking the
+// resolved path against userData + vault dirs. Shared by the frame-navigation
+// guard (main-frame memry-file: nav, which would otherwise trap the app) and the
+// window-open handler, so the allowlist has a single source of truth. Returns
+// true when the URL was a memry-file URL (and thus handled here).
+function openMemryFileInOs(rawUrl: string): boolean {
+  const memryFilePath = resolveMemryFilePath(rawUrl)
+  if (!memryFilePath) return false
+  const allowedDirs = [app.getPath('userData'), getCurrentVaultPath(), getVaultStatus().path]
+    .filter((dir): dir is string => Boolean(dir))
+    .map((dir) => resolve(dir))
+  if (isPathInsideDirs(memryFilePath, allowedDirs)) {
+    void shell.openPath(memryFilePath)
+  } else {
+    log.warn('Blocked memry-file open outside allowed directories', { path: memryFilePath })
+  }
+  return true
+}
+
 // Frame-level navigation guard for every window's webContents: pins main-frame
 // navigation to the local app origin and re-routes external links through
 // shell.openExternal. Complements (does not replace) the per-window
@@ -194,6 +213,8 @@ app.on('web-contents-created', (_event, contents) => {
     details.preventDefault()
     if (decision === 'open-external' && isAllowedExternalUrl(details.url)) {
       void shell.openExternal(details.url)
+    } else if (decision === 'open-file') {
+      openMemryFileInOs(details.url)
     } else {
       navGuardLog.warn('Blocked frame navigation', {
         url: details.url.slice(0, 256),
@@ -638,16 +659,7 @@ function createWindow(): void {
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
-    const memryFilePath = resolveMemryFilePath(details.url)
-    if (memryFilePath) {
-      const allowedDirs = [app.getPath('userData'), getCurrentVaultPath(), getVaultStatus().path]
-        .filter((dir): dir is string => Boolean(dir))
-        .map((dir) => resolve(dir))
-      if (allowedDirs.some((dir) => memryFilePath.startsWith(dir + sep))) {
-        void shell.openPath(memryFilePath)
-      } else {
-        log.warn('Blocked memry-file open outside allowed directories', { path: memryFilePath })
-      }
+    if (openMemryFileInOs(details.url)) {
       return { action: 'deny' }
     }
     if (isAllowedExternalUrl(details.url)) {

--- a/apps/desktop/src/main/lib/frame-navigation.test.ts
+++ b/apps/desktop/src/main/lib/frame-navigation.test.ts
@@ -71,10 +71,16 @@ describe('decideFrameNavigation', () => {
   })
 
   describe('memry-file custom scheme', () => {
-    it('allows memry-file URLs (protocol handler enforces its own path allowlist)', () => {
+    it('hands a main-frame memry-file navigation to the OS instead of navigating (would trap the app)', () => {
       expect(decideFrameNavigation('memry-file://local/Users/kaan/vault/file.pdf', prodMain)).toBe(
-        'allow'
+        'open-file'
       )
+      expect(decideFrameNavigation('memry-file://local/Users/kaan/vault/image.png', devMain)).toBe(
+        'open-file'
+      )
+    })
+
+    it('still allows memry-file in subframes (protocol handler enforces its own path allowlist)', () => {
       expect(decideFrameNavigation('memry-file://local/Users/kaan/vault/file.pdf', prodSub)).toBe(
         'allow'
       )

--- a/apps/desktop/src/main/lib/frame-navigation.ts
+++ b/apps/desktop/src/main/lib/frame-navigation.ts
@@ -1,6 +1,6 @@
 import { isAllowedExternalUrl } from './external-url'
 
-export type FrameNavigationDecision = 'allow' | 'deny' | 'open-external'
+export type FrameNavigationDecision = 'allow' | 'deny' | 'open-external' | 'open-file'
 
 export interface FrameNavigationContext {
   /** Whether the navigation targets the window's top-level frame. */
@@ -51,9 +51,13 @@ export function decideFrameNavigation(
   const target = parseUrl(rawUrl)
   if (!target) return 'deny'
 
-  // App-controlled local scheme; the memry-file protocol handler enforces its
-  // own directory allowlist (userData + vault) on every request.
-  if (target.protocol === 'memry-file:') return 'allow'
+  // App-controlled local scheme. Inline resource loads (<img>/<audio>/<video>,
+  // react-pdf fetch) never fire will-frame-navigate, so a memry-file event here
+  // is a real navigation. On the main frame that would replace the SPA document
+  // with the protocol handler's raw file bytes and trap the app (no in-app back
+  // path) — hand the file to the OS instead. Subframes may still load it in-place
+  // (the protocol handler enforces its own userData+vault directory allowlist).
+  if (target.protocol === 'memry-file:') return isMainFrame ? 'open-file' : 'allow'
 
   if (!isMainFrame) {
     // Frames initialize as about:blank / about:srcdoc before real content.

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -651,7 +651,8 @@
   pointer-events: none;
 }
 
-.critic-review-content a {
+.critic-review-content a,
+.critic-review-content button {
   pointer-events: auto;
 }
 

--- a/apps/desktop/src/renderer/src/assets/base.css
+++ b/apps/desktop/src/renderer/src/assets/base.css
@@ -683,7 +683,8 @@
 
 .critic-review-attachments {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 6px;
   margin-top: 8px;
 }

--- a/apps/desktop/src/renderer/src/components/note/review/comment-attachments.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/comment-attachments.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CriticMarkupCommentAttachmentRef, CriticMarkupMark } from '@memry/shared'
+import { CommentAttachments, classifyCommentAttachment } from './comment-attachments'
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key, i18n: { language: 'en' } })
+}))
+
+// The real viewers pull in react-pdf / canvas machinery; this component's job is
+// only to route the right attachment to the right viewer, so stub them. The PDF
+// viewer is lazy-loaded in the component, so its stub resolves asynchronously.
+vi.mock('@/components/viewers/image-viewer', () => ({
+  ImageViewer: ({ src }: { src: string }) => <div data-testid="image-viewer" data-src={src} />
+}))
+vi.mock('@/components/viewers/pdf-viewer', () => ({
+  PdfViewer: ({ src }: { src: string }) => <div data-testid="pdf-viewer" data-src={src} />
+}))
+
+function att(
+  overrides: Partial<CriticMarkupCommentAttachmentRef> & { name: string }
+): CriticMarkupCommentAttachmentRef {
+  const path = overrides.path ?? `memry-file://local/vault/attachments/n1/${overrides.name}`
+  return { id: overrides.id ?? path, name: overrides.name, path, ...overrides }
+}
+
+function markWith(attachments: CriticMarkupCommentAttachmentRef[]): CriticMarkupMark {
+  return {
+    id: 'm1',
+    kind: 'comment',
+    visibleText: '',
+    start: 0,
+    end: 0,
+    attachments
+  }
+}
+
+describe('classifyCommentAttachment', () => {
+  it('trusts an explicit image type over the extension', () => {
+    expect(classifyCommentAttachment(att({ name: 'blob.bin', type: 'image' }))).toBe('image')
+  })
+
+  it('classifies images by mimeType', () => {
+    expect(classifyCommentAttachment(att({ name: 'blob', mimeType: 'image/png' }))).toBe('image')
+  })
+
+  it('falls back to the filename extension when mimeType and type are missing', () => {
+    expect(classifyCommentAttachment(att({ name: 'holiday.JPEG' }))).toBe('image')
+    expect(classifyCommentAttachment(att({ name: 'diagram.svg' }))).toBe('image')
+  })
+
+  it('classifies pdf by mimeType and by extension', () => {
+    expect(classifyCommentAttachment(att({ name: 'blob', mimeType: 'application/pdf' }))).toBe(
+      'pdf'
+    )
+    expect(classifyCommentAttachment(att({ name: 'report.PDF' }))).toBe('pdf')
+  })
+
+  it('classifies everything else as a plain file', () => {
+    expect(classifyCommentAttachment(att({ name: 'notes.docx' }))).toBe('file')
+    expect(classifyCommentAttachment(att({ name: 'README' }))).toBe('file')
+  })
+})
+
+describe('CommentAttachments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when there are no attachments', () => {
+    const { container } = render(<CommentAttachments mark={markWith([])} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders an image attachment as an <img> thumbnail — never a navigable anchor', () => {
+    const path = 'memry-file://local/vault/attachments/n1/pic.png'
+    const { container } = render(
+      <CommentAttachments mark={markWith([att({ name: 'pic.png', path })])} />
+    )
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('src')).toBe(path)
+    // The trap this fixes was a bare <a href="memry-file://…">; there must be none.
+    expect(container.querySelector('a')).toBeNull()
+  })
+
+  it('renders pdf and other files as buttons, never navigable memry-file anchors', () => {
+    const { container } = render(
+      <CommentAttachments
+        mark={markWith([att({ name: 'report.pdf' }), att({ name: 'notes.docx' })])}
+      />
+    )
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.querySelectorAll('button')).toHaveLength(2)
+  })
+
+  it('opens the in-app ImageViewer with the attachment path when an image is clicked', () => {
+    const path = 'memry-file://local/vault/attachments/n1/pic.png'
+    render(<CommentAttachments mark={markWith([att({ name: 'pic.png', path })])} />)
+    expect(screen.queryByTestId('image-viewer')).toBeNull()
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByTestId('image-viewer').getAttribute('data-src')).toBe(path)
+  })
+
+  it('opens the in-app PdfViewer when a pdf is clicked (not a black frame / external app)', async () => {
+    const path = 'memry-file://local/vault/attachments/n1/report.pdf'
+    render(<CommentAttachments mark={markWith([att({ name: 'report.pdf', path })])} />)
+    fireEvent.click(screen.getByRole('button'))
+    // PdfViewer is lazy-loaded, so it resolves asynchronously.
+    const viewer = await screen.findByTestId('pdf-viewer')
+    expect(viewer.getAttribute('data-src')).toBe(path)
+  })
+
+  it('hands a non-viewable file to the OS via window.open — no in-app viewer, no trap', () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+    const path = 'memry-file://local/vault/attachments/n1/notes.docx'
+    render(<CommentAttachments mark={markWith([att({ name: 'notes.docx', path })])} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(openSpy).toHaveBeenCalledWith(path, '_blank', 'noopener,noreferrer')
+    expect(screen.queryByTestId('image-viewer')).toBeNull()
+    expect(screen.queryByTestId('pdf-viewer')).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/note/review/comment-attachments.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/comment-attachments.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CriticMarkupCommentAttachmentRef, CriticMarkupMark } from '@memry/shared'
 import { formatBytes } from '@/lib/format'
 import { CommentAttachments, classifyCommentAttachment } from './comment-attachments'
@@ -66,6 +66,11 @@ describe('classifyCommentAttachment', () => {
 describe('CommentAttachments', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    // Restore spies (e.g. window.open) so a mock never leaks into a later test.
+    vi.restoreAllMocks()
   })
 
   it('renders nothing when there are no attachments', () => {

--- a/apps/desktop/src/renderer/src/components/note/review/comment-attachments.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/comment-attachments.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CriticMarkupCommentAttachmentRef, CriticMarkupMark } from '@memry/shared'
+import { formatBytes } from '@/lib/format'
 import { CommentAttachments, classifyCommentAttachment } from './comment-attachments'
 
 vi.mock('@memry/i18n/renderer', () => ({
@@ -91,6 +92,12 @@ describe('CommentAttachments', () => {
     )
     expect(container.querySelector('a')).toBeNull()
     expect(container.querySelectorAll('button')).toHaveLength(2)
+  })
+
+  it('shows the filename and formatted size on a file attachment', () => {
+    render(<CommentAttachments mark={markWith([att({ name: 'sample.pdf', size: 18841 })])} />)
+    expect(screen.getByText('sample.pdf')).toBeTruthy()
+    expect(screen.getByText(formatBytes(18841))).toBeTruthy()
   })
 
   it('opens the in-app ImageViewer with the attachment path when an image is clicked', () => {

--- a/apps/desktop/src/renderer/src/components/note/review/comment-attachments.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/comment-attachments.tsx
@@ -1,7 +1,8 @@
 import { lazy, Suspense, useState } from 'react'
-import { FileText, Paperclip } from '@/lib/icons'
+import { File, FileText } from '@/lib/icons'
 import { ImageViewer } from '@/components/viewers/image-viewer'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { formatBytes } from '@/lib/format'
 import { useT } from '@memry/i18n/renderer'
 import type { CriticMarkupCommentAttachmentRef, CriticMarkupMark } from '@memry/shared'
 
@@ -80,7 +81,7 @@ export function CommentAttachments({ mark }: { mark: CriticMarkupMark }): React.
           <button
             key={attachment.id}
             type="button"
-            className="inline-flex max-w-full items-center gap-1 rounded-full bg-muted px-2 py-1 text-xs text-muted-foreground hover:bg-muted/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="inline-flex max-w-xs items-center gap-2.5 rounded-md border border-border bg-muted/30 px-2.5 py-2 text-start transition-colors hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             aria-label={t('comments.openAttachmentAria', { name: attachment.name })}
             onClick={() => {
               if (kind === 'pdf') {
@@ -91,11 +92,20 @@ export function CommentAttachments({ mark }: { mark: CriticMarkupMark }): React.
             }}
           >
             {kind === 'pdf' ? (
-              <FileText className="size-3 shrink-0" aria-hidden="true" />
+              <FileText className="size-5 shrink-0 text-red-500" aria-hidden="true" />
             ) : (
-              <Paperclip className="size-3 shrink-0" aria-hidden="true" />
+              <File className="size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
             )}
-            <span className="truncate">{attachment.name}</span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-xs font-medium text-foreground">
+                {attachment.name}
+              </span>
+              {typeof attachment.size === 'number' && attachment.size > 0 && (
+                <span className="block text-[11px] leading-tight text-muted-foreground">
+                  {formatBytes(attachment.size)}
+                </span>
+              )}
+            </span>
           </button>
         )
       })}

--- a/apps/desktop/src/renderer/src/components/note/review/comment-attachments.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/comment-attachments.tsx
@@ -1,0 +1,122 @@
+import { lazy, Suspense, useState } from 'react'
+import { FileText, Paperclip } from '@/lib/icons'
+import { ImageViewer } from '@/components/viewers/image-viewer'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { useT } from '@memry/i18n/renderer'
+import type { CriticMarkupCommentAttachmentRef, CriticMarkupMark } from '@memry/shared'
+
+// react-pdf is heavy and hard-crashes at module load outside a real DOM
+// (pdf.js needs DOMMatrix), so lazy-load it — it only mounts when a PDF is
+// opened, and it keeps review-card's static import graph clean for jsdom tests.
+const PdfViewer = lazy(() =>
+  import('@/components/viewers/pdf-viewer').then((m) => ({ default: m.PdfViewer }))
+)
+
+export type CommentAttachmentKind = 'image' | 'pdf' | 'file'
+
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'avif'])
+
+function fileExtension(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot === -1 ? '' : name.slice(dot + 1).toLowerCase()
+}
+
+/**
+ * Classify a comment attachment for display. `mimeType`/`type` are optional on
+ * older/normalized attachments, so fall back to the filename extension.
+ */
+export function classifyCommentAttachment(
+  attachment: CriticMarkupCommentAttachmentRef
+): CommentAttachmentKind {
+  const ext = fileExtension(attachment.name)
+  if (
+    attachment.type === 'image' ||
+    attachment.mimeType?.startsWith('image/') ||
+    IMAGE_EXTENSIONS.has(ext)
+  ) {
+    return 'image'
+  }
+  if (attachment.mimeType === 'application/pdf' || ext === 'pdf') return 'pdf'
+  return 'file'
+}
+
+/**
+ * Renders a comment's attachments. Images show inline thumbnails; clicking an
+ * image or PDF opens the in-app viewer (Esc / click-outside / X to close). Other
+ * files open in the OS default app. Never a bare `<a href="memry-file://…">`,
+ * which would drive a main-frame navigation and trap the app (issue #799).
+ */
+export function CommentAttachments({ mark }: { mark: CriticMarkupMark }): React.JSX.Element | null {
+  const { t } = useT('notes')
+  const [active, setActive] = useState<CriticMarkupCommentAttachmentRef | null>(null)
+
+  if (!mark.attachments?.length) return null
+
+  return (
+    <div className="critic-review-attachments">
+      {mark.attachments.map((attachment) => {
+        const kind = classifyCommentAttachment(attachment)
+
+        if (kind === 'image') {
+          return (
+            <button
+              key={attachment.id}
+              type="button"
+              className="inline-flex max-w-full overflow-hidden rounded-md border border-border bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label={t('comments.openImageAria', { name: attachment.name })}
+              onClick={() => setActive(attachment)}
+            >
+              <img
+                src={attachment.path}
+                alt={attachment.name}
+                loading="lazy"
+                className="max-h-32 max-w-full object-cover"
+              />
+            </button>
+          )
+        }
+
+        return (
+          <button
+            key={attachment.id}
+            type="button"
+            className="inline-flex max-w-full items-center gap-1 rounded-full bg-muted px-2 py-1 text-xs text-muted-foreground hover:bg-muted/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={t('comments.openAttachmentAria', { name: attachment.name })}
+            onClick={() => {
+              if (kind === 'pdf') {
+                setActive(attachment)
+              } else {
+                window.open(attachment.path, '_blank', 'noopener,noreferrer')
+              }
+            }}
+          >
+            {kind === 'pdf' ? (
+              <FileText className="size-3 shrink-0" aria-hidden="true" />
+            ) : (
+              <Paperclip className="size-3 shrink-0" aria-hidden="true" />
+            )}
+            <span className="truncate">{attachment.name}</span>
+          </button>
+        )
+      })}
+
+      <Dialog open={active !== null} onOpenChange={(open) => !open && setActive(null)}>
+        {active && (
+          <DialogContent
+            aria-describedby={undefined}
+            className="flex h-[88vh] w-full max-w-[92vw] flex-col gap-0 p-0"
+          >
+            <DialogTitle className="sr-only">{active.name}</DialogTitle>
+            {classifyCommentAttachment(active) === 'image' ? (
+              <ImageViewer src={active.path} alt={active.name} className="min-h-0 flex-1" />
+            ) : (
+              <Suspense fallback={null}>
+                <PdfViewer src={active.path} className="min-h-0 flex-1" />
+              </Suspense>
+            )}
+          </DialogContent>
+        )}
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/note/review/review-card.tsx
+++ b/apps/desktop/src/renderer/src/components/note/review/review-card.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties, MouseEvent } from 'react'
 import { MentionIcon, mentionColorForKind } from '@/agent-chat/mention-icons'
 import { useMemryLinkNavigation } from '@/agent-chat/messages/memry-links'
-import { Check, Paperclip, Pencil, Trash } from '@/lib/icons'
+import { Check, Pencil, Trash } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useGeneralSettings } from '@/hooks/use-general-settings'
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils'
 import type { CriticMarkupReviewController } from './use-critic-markup-review'
 import { useT } from '@memry/i18n/renderer'
 import type { CriticMarkupCommentMentionRef, CriticMarkupMark } from '@memry/shared'
+import { CommentAttachments } from './comment-attachments'
 import { iconForMention, splitCommentBody } from './comment-body'
 import { CommentComposer } from './comment-composer'
 import { syncInlineHoverClass } from './inline-hover'
@@ -227,24 +228,6 @@ function CommentMentionLink({
       <MentionIcon icon={iconForMention(mention)} className="size-3 text-current" />
       <span className="truncate">@{mention.label}</span>
     </a>
-  )
-}
-
-function CommentAttachments({ mark }: { mark: CriticMarkupMark }): React.JSX.Element | null {
-  if (!mark.attachments?.length) return null
-  return (
-    <div className="critic-review-attachments">
-      {mark.attachments.map((attachment) => (
-        <a
-          key={attachment.id}
-          href={attachment.path}
-          className="inline-flex max-w-full items-center gap-1 rounded-full bg-muted px-2 py-1 text-xs text-muted-foreground"
-        >
-          <Paperclip className="size-3 shrink-0" aria-hidden="true" />
-          <span className="truncate">{attachment.name}</span>
-        </a>
-      ))}
-    </div>
   )
 }
 

--- a/apps/docs/src/user-guide/notes/editing.md
+++ b/apps/docs/src/user-guide/notes/editing.md
@@ -137,6 +137,8 @@ Formatting applied in MemryNote round-trips. Underline written any other way —
 
 Select text to open the floating toolbar. **Comment** creates an anchored review card in the right rail; selecting the text itself does not open the rail. The right rail aligns each card beside the marked text. Comment cards can be resolved or deleted.
 
+Comments can carry file attachments. Image attachments show an inline thumbnail; clicking an image or PDF opens it in the in-app viewer (close with Esc, a click outside, or the ✕). Other file types open in your operating system's default app.
+
 ## What Notes Are Made Of
 
 Under the hood, every note is a Yjs CRDT (`Y.Doc`). Markdown is a derived export, not the canonical form — this is what lets edits from two devices merge cleanly. See [CRDT & Notes Sync](/architecture/crdt) for details.

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -224,6 +224,8 @@
     "attachAria": "Attach file",
     "mentionAria": "Mention a person, page or date",
     "sendAria": "Send comment",
+    "openImageAria": "Open image {name}",
+    "openAttachmentAria": "Open attachment {name}",
     "kind": {
       "comment": "Comment",
       "addition": "Addition",


### PR DESCRIPTION
Fixes #799 (part of #795).

## Problem

Clicking a comment's image or PDF attachment trapped the app. `CommentAttachments` rendered each attachment as a bare `<a href="memry-file://…">`, so clicking drove a **main-frame** navigation. `decideFrameNavigation` allowed `memry-file:` on the top frame, so Chromium replaced the React app with the protocol handler's raw bytes:

- **Image** → a raw image document with no app chrome; Esc / click-outside did nothing (the app had unmounted), so only a restart recovered.
- **PDF** → a blank/black frame (Electron has no inline PDF plugin) while the OS PDF app opened.

## Fix

**1. Comment attachment rendering** (`comment-attachments.tsx`, new)
- Images render an inline `<img>` thumbnail.
- Clicking an image or PDF opens the existing in-app `ImageViewer` / `PdfViewer` inside a `Dialog` — closes with Esc, click-outside, or the ✕.
- Other file types (docx, txt, …) open in the OS default app via `window.open` → `setWindowOpenHandler` → `shell.openPath`.
- No navigable `memry-file://` anchors anywhere.
- `PdfViewer` is `React.lazy`-loaded — `react-pdf`/pdf.js crashes at module load outside a real DOM (`DOMMatrix is not defined`), and this keeps `review-card`'s static import graph clean for jsdom tests (also defers a heavy dep until a PDF is actually opened).

**2. Defense-in-depth navigation hardening** (`frame-navigation.ts`, `index.ts`)
- A main-frame `memry-file:` navigation now resolves to a new `'open-file'` decision (subframes still `'allow'`), routed through a shared `openMemryFileInOs` helper that is also reused by `setWindowOpenHandler`. Any future bare `memry-file://` anchor opens in the OS instead of trapping the app.

## Acceptance

- ✅ Comment image shows a thumbnail; clicking opens an in-app viewer that closes with Esc / click-outside.
- ✅ Comment PDF opens in the in-app `PdfViewer` (not a black frame / external app).

## Notes for reviewers

- **Backward compatible**: no DB / contract / IPC / vault-format / settings change. The attachment classifier tolerates older attachments with missing `mimeType`/`type` via a filename-extension fallback.
- Comment attachments have no `fileId` (they live in a per-note `attachments/<noteId>/` folder, not the indexed vault-files table), so the tab-based file-page opener does not apply — the viewers are reused directly in a `Dialog`.

## Verification

- `frame-navigation` 25 ✓ · `comment-attachments` 11 ✓ · full review dir 46 ✓ · main lib 195 ✓
- `typecheck` (web + node) ✓ · IPC/contract/architecture checks ✓ · `eslint` 0 errors · `i18n:check` ✓ · `docs:impact --strict` covered · `docs:build` ✓

Manual smoke pending on a packaged/dev run: comment with an image, a PDF, and a `.txt`.
