### PR TITLE
fix(tasks): migrate project icon picker to shared emoji/icon picker (#802)

### DIFF
--- a/apps/desktop/src/renderer/src/components/tasks/drag-drop/move-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/drag-drop/move-menu.tsx
@@ -22,7 +22,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
-import { getIconByName } from '@/components/icon-picker'
+import { ProjectIcon } from '@/components/tasks/project-icon'
 import { addDays, startOfDay } from '@/lib/task-utils'
 import type { Project, Status } from '@/data/tasks-data'
 import type { Task } from '@/data/task-model'
@@ -171,7 +171,7 @@ export const MoveMenu = ({
           <>
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
-                <FolderOpen className="size-4 mr-2" />
+                <FolderOpen className="size-4 me-2" />
 
                 {tPhaseF('phaseF.componentsTasksDragDropMoveMenu.moveToProject')}
               </DropdownMenuSubTrigger>
@@ -179,7 +179,6 @@ export const MoveMenu = ({
                 {projects
                   .filter((p) => !p.isArchived)
                   .map((project) => {
-                    const IconComponent = getIconByName(project.icon)
                     const isCurrent = project.id === task.projectId
 
                     return (
@@ -188,17 +187,20 @@ export const MoveMenu = ({
                         onClick={() => handleProjectChange(project.id)}
                         disabled={isCurrent}
                       >
-                        {IconComponent ? (
-                          <IconComponent className="size-4 mr-2" style={{ color: project.color }} />
-                        ) : (
-                          <span
-                            className="size-3 rounded-full mr-2"
-                            style={{ backgroundColor: project.color }}
-                          />
-                        )}
+                        <ProjectIcon
+                          icon={project.icon}
+                          className="size-4 me-2"
+                          color={project.color}
+                          fallback={
+                            <span
+                              className="size-3 rounded-full me-2"
+                              style={{ backgroundColor: project.color }}
+                            />
+                          }
+                        />
                         {project.name}
                         {isCurrent && (
-                          <span className="ml-auto text-muted-foreground text-xs">
+                          <span className="ms-auto text-muted-foreground text-xs">
                             {tPhaseF('phaseF.componentsTasksDragDropMoveMenu.current')}
                           </span>
                         )}
@@ -218,7 +220,7 @@ export const MoveMenu = ({
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <span
-                  className="size-3 rounded-full mr-2"
+                  className="size-3 rounded-full me-2"
                   style={{
                     backgroundColor: statuses.find((s) => s.id === task.statusId)?.color || '#888'
                   }}
@@ -237,12 +239,12 @@ export const MoveMenu = ({
                       disabled={isCurrent}
                     >
                       <span
-                        className="size-3 rounded-full mr-2"
+                        className="size-3 rounded-full me-2"
                         style={{ backgroundColor: status.color }}
                       />
                       {status.name}
                       {isCurrent && (
-                        <span className="ml-auto text-muted-foreground text-xs">
+                        <span className="ms-auto text-muted-foreground text-xs">
                           {tPhaseF('phaseF.componentsTasksDragDropMoveMenu.current2')}
                         </span>
                       )}
@@ -267,33 +269,33 @@ export const MoveMenu = ({
 
             {onMoveUp && (
               <DropdownMenuItem onClick={() => handleReorder('up')}>
-                <ArrowUp className="size-4 mr-2" />
+                <ArrowUp className="size-4 me-2" />
                 Move up
-                <span className="ml-auto text-xs text-muted-foreground">Alt+↑</span>
+                <span className="ms-auto text-xs text-muted-foreground">Alt+↑</span>
               </DropdownMenuItem>
             )}
 
             {onMoveDown && (
               <DropdownMenuItem onClick={() => handleReorder('down')}>
-                <ArrowDown className="size-4 mr-2" />
+                <ArrowDown className="size-4 me-2" />
                 Move down
-                <span className="ml-auto text-xs text-muted-foreground">Alt+↓</span>
+                <span className="ms-auto text-xs text-muted-foreground">Alt+↓</span>
               </DropdownMenuItem>
             )}
 
             {onMoveToTop && (
               <DropdownMenuItem onClick={() => handleReorder('top')}>
-                <ChevronsUp className="size-4 mr-2" />
+                <ChevronsUp className="size-4 me-2" />
                 Move to top
-                <span className="ml-auto text-xs text-muted-foreground">Alt+Shift+↑</span>
+                <span className="ms-auto text-xs text-muted-foreground">Alt+Shift+↑</span>
               </DropdownMenuItem>
             )}
 
             {onMoveToBottom && (
               <DropdownMenuItem onClick={() => handleReorder('bottom')}>
-                <ChevronsDown className="size-4 mr-2" />
+                <ChevronsDown className="size-4 me-2" />
                 Move to bottom
-                <span className="ml-auto text-xs text-muted-foreground">Alt+Shift+↓</span>
+                <span className="ms-auto text-xs text-muted-foreground">Alt+Shift+↓</span>
               </DropdownMenuItem>
             )}
           </>

--- a/apps/desktop/src/renderer/src/components/tasks/drag-drop/sidebar-drop-zones.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/drag-drop/sidebar-drop-zones.tsx
@@ -1,10 +1,9 @@
-import { createElement } from 'react'
 import { useDroppable } from '@dnd-kit/core'
 import { Trash2, Archive, Settings } from '@/lib/icons'
 
 import { cn } from '@/lib/utils'
 import { useDragContext } from '@/contexts/drag-context'
-import { getIconByName } from '@/components/icon-picker'
+import { ProjectIcon } from '@/components/tasks/project-icon'
 import type { Project } from '@/data/tasks-data'
 import { useT } from '@memry/i18n/renderer'
 
@@ -60,9 +59,6 @@ export const DroppableProjectItem = ({
   // Only show as drop zone when dragging
   const showAsDropZone = dragState.isDragging
 
-  // Get the icon component
-  const IconComponent = getIconByName(project.icon)
-
   const handleClick = (): void => {
     onClick()
   }
@@ -99,29 +95,28 @@ export const DroppableProjectItem = ({
       className={cn(
         'group flex w-full items-center gap-2 rounded-sm px-3 py-2 text-sm transition-all duration-150',
         'hover:bg-accent/50 focus-visible:outline-none',
-        isSelected && 'bg-accent border-l-3 border-l-primary font-medium',
+        isSelected && 'bg-accent border-s-3 border-s-primary font-medium',
         // Drop zone styling
         showAsDropZone && 'border border-dotted border-muted-foreground/40',
         isOver && 'bg-primary/10 ring-2 ring-primary shadow-sm'
       )}
     >
       {/* Project Icon or Color Dot */}
-      {IconComponent ? (
-        createElement(IconComponent, {
-          className: 'size-4 shrink-0',
-          style: { color: project.color },
-          'aria-hidden': 'true'
-        })
-      ) : (
-        <span
-          className="size-3 shrink-0 rounded-full"
-          style={{ backgroundColor: project.color }}
-          aria-hidden="true"
-        />
-      )}
+      <ProjectIcon
+        icon={project.icon}
+        className="size-4 shrink-0"
+        color={project.color}
+        fallback={
+          <span
+            className="size-3 shrink-0 rounded-full"
+            style={{ backgroundColor: project.color }}
+            aria-hidden="true"
+          />
+        }
+      />
 
       {/* Project Name */}
-      <span className="flex-1 truncate text-left text-text-secondary">{project.name}</span>
+      <span className="flex-1 truncate text-start text-text-secondary">{project.name}</span>
 
       {/* Drop indicator */}
       {isOver && (

--- a/apps/desktop/src/renderer/src/components/tasks/project-icon.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project-icon.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ProjectIcon } from './project-icon'
+
+// Legacy lucide resolver: only PascalCase names in the curated map resolve.
+vi.mock('@/components/icon-picker', () => ({
+  getIconByName: (name: string) =>
+    name === 'Folder' || name === 'Star'
+      ? (props: { className?: string; style?: React.CSSProperties }) => (
+          <span data-testid="lucide" className={props.className} style={props.style}>
+            {name}
+          </span>
+        )
+      : undefined
+}))
+
+// The shared renderer: icon: values → huge icon, else raw text in a span.
+vi.mock('@/lib/render-note-icon', () => ({
+  NoteIconDisplay: ({ value, className }: { value: string; className?: string }) => (
+    <span data-testid="note-icon" data-value={value} className={className}>
+      {value}
+    </span>
+  )
+}))
+
+const DOT = <span data-testid="fallback">dot</span>
+
+describe('ProjectIcon', () => {
+  it('renders a legacy bare lucide name as the lucide glyph, tinted', () => {
+    render(<ProjectIcon icon="Folder" className="size-4" color="#11aa55" fallback={DOT} />)
+
+    const glyph = screen.getByTestId('lucide')
+    expect(glyph).toHaveTextContent('Folder')
+    expect(glyph).toHaveStyle({ color: '#11aa55' })
+    expect(screen.queryByTestId('note-icon')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('fallback')).not.toBeInTheDocument()
+  })
+
+  it('renders a new "icon:Name" value through NoteIconDisplay', () => {
+    render(<ProjectIcon icon="icon:StarIcon" className="size-6" fallback={DOT} />)
+
+    expect(screen.getByTestId('note-icon')).toHaveAttribute('data-value', 'icon:StarIcon')
+    expect(screen.queryByTestId('lucide')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('fallback')).not.toBeInTheDocument()
+  })
+
+  it('renders a raw emoji through NoteIconDisplay', () => {
+    render(<ProjectIcon icon="📚" fallback={DOT} />)
+
+    expect(screen.getByTestId('note-icon')).toHaveAttribute('data-value', '📚')
+    expect(screen.queryByTestId('fallback')).not.toBeInTheDocument()
+  })
+
+  it('renders the fallback for null', () => {
+    render(<ProjectIcon icon={null} fallback={DOT} />)
+
+    expect(screen.getByTestId('fallback')).toBeInTheDocument()
+    expect(screen.queryByTestId('note-icon')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('lucide')).not.toBeInTheDocument()
+  })
+
+  it('renders the fallback for an unresolved ASCII name (e.g. lowercase "folder")', () => {
+    render(<ProjectIcon icon="folder" fallback={DOT} />)
+
+    // Not an icon: value, not in the lucide map, and ASCII → not an emoji glyph.
+    expect(screen.getByTestId('fallback')).toBeInTheDocument()
+    expect(screen.queryByTestId('note-icon')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('lucide')).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/tasks/project-icon.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project-icon.test.tsx
@@ -37,18 +37,23 @@ describe('ProjectIcon', () => {
     expect(screen.queryByTestId('fallback')).not.toBeInTheDocument()
   })
 
-  it('renders a new "icon:Name" value through NoteIconDisplay', () => {
+  it('renders a new "icon:Name" value through NoteIconDisplay, marked decorative', () => {
     render(<ProjectIcon icon="icon:StarIcon" className="size-6" fallback={DOT} />)
 
-    expect(screen.getByTestId('note-icon')).toHaveAttribute('data-value', 'icon:StarIcon')
+    const icon = screen.getByTestId('note-icon')
+    expect(icon).toHaveAttribute('data-value', 'icon:StarIcon')
+    // Decorative: the project name is the accessible label, so the glyph is hidden.
+    expect(icon.closest('[aria-hidden="true"]')).toBeInTheDocument()
     expect(screen.queryByTestId('lucide')).not.toBeInTheDocument()
     expect(screen.queryByTestId('fallback')).not.toBeInTheDocument()
   })
 
-  it('renders a raw emoji through NoteIconDisplay', () => {
+  it('renders a raw emoji through NoteIconDisplay, marked decorative', () => {
     render(<ProjectIcon icon="📚" fallback={DOT} />)
 
-    expect(screen.getByTestId('note-icon')).toHaveAttribute('data-value', '📚')
+    const icon = screen.getByTestId('note-icon')
+    expect(icon).toHaveAttribute('data-value', '📚')
+    expect(icon.closest('[aria-hidden="true"]')).toBeInTheDocument()
     expect(screen.queryByTestId('fallback')).not.toBeInTheDocument()
   })
 

--- a/apps/desktop/src/renderer/src/components/tasks/project-icon.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project-icon.tsx
@@ -1,0 +1,73 @@
+import { createElement } from 'react'
+
+import { getIconByName } from '@/components/icon-picker'
+import { isIconValue } from '@/components/note/note-title/emoji-icon-utils'
+import { NoteIconDisplay } from '@/lib/render-note-icon'
+
+interface ProjectIconProps {
+  /**
+   * A project's stored icon. May be a new shared-picker value (a raw emoji like
+   * "📚" or an "icon:<HugeIconsName>" value), a legacy bare lucide name written
+   * by older app versions (e.g. "Folder", "Star"), or null.
+   */
+  icon: string | null | undefined
+  className?: string
+  /** Hex tint applied to lucide + HugeIcons glyphs. Raw emoji is never tinted. */
+  color?: string
+  /** Rendered when `icon` is empty or an unrecognized bare name. */
+  fallback: React.ReactNode
+}
+
+/** True when the string carries any non-ASCII code point (i.e. is an emoji glyph). */
+function containsNonAscii(value: string): boolean {
+  for (const ch of value) {
+    if ((ch.codePointAt(0) ?? 0) > 0x7f) return true
+  }
+  return false
+}
+
+/**
+ * Renders a project's icon across the shared emoji/icon picker migration.
+ *
+ * Projects now store the same values as notes/tags/folders (raw emoji or
+ * "icon:<HugeIconsName>"), but existing installs and older app versions keep
+ * writing bare lucide names. This shim resolves all shapes so a mixed-version
+ * fleet renders correctly, degrading unknown values to the caller's fallback.
+ */
+export function ProjectIcon({
+  icon,
+  className,
+  color,
+  fallback
+}: ProjectIconProps): React.JSX.Element {
+  if (icon) {
+    // New HugeIcons value ("icon:Name") — tint via a wrapper (icons inherit currentColor).
+    if (isIconValue(icon)) {
+      return (
+        <span className="inline-flex" style={color ? { color } : undefined}>
+          <NoteIconDisplay value={icon} className={className} />
+        </span>
+      )
+    }
+
+    // Legacy bare lucide name ("Folder", "Star", …) — preserves the prior look.
+    const LegacyIcon = getIconByName(icon)
+    if (LegacyIcon) {
+      return createElement(LegacyIcon, {
+        className,
+        style: color ? { color } : undefined,
+        'aria-hidden': 'true'
+      })
+    }
+
+    // New raw emoji ("📚") — rendered as a glyph, never tinted.
+    if (containsNonAscii(icon)) {
+      return <NoteIconDisplay value={icon} className={className} />
+    }
+  }
+
+  // null / lowercase 'folder' / unknown ASCII name → caller's fallback (color dot or 📁).
+  return <>{fallback}</>
+}
+
+export default ProjectIcon

--- a/apps/desktop/src/renderer/src/components/tasks/project-icon.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project-icon.tsx
@@ -41,10 +41,13 @@ export function ProjectIcon({
   fallback
 }: ProjectIconProps): React.JSX.Element {
   if (icon) {
-    // New HugeIcons value ("icon:Name") — tint via a wrapper (icons inherit currentColor).
-    if (isIconValue(icon)) {
+    // New shared-picker values: a HugeIcons "icon:Name" or a raw emoji glyph.
+    // Wrap in an aria-hidden `display:contents` span — the project name is the
+    // accessible label, so the glyph is decorative, and `contents` adds no layout
+    // box (color still inherits, tinting the HugeIcon; emoji ignore it).
+    if (isIconValue(icon) || containsNonAscii(icon)) {
       return (
-        <span className="inline-flex" style={color ? { color } : undefined}>
+        <span className="contents" style={color ? { color } : undefined} aria-hidden="true">
           <NoteIconDisplay value={icon} className={className} />
         </span>
       )
@@ -58,11 +61,6 @@ export function ProjectIcon({
         style: color ? { color } : undefined,
         'aria-hidden': 'true'
       })
-    }
-
-    // New raw emoji ("📚") — rendered as a glyph, never tinted.
-    if (containsNonAscii(icon)) {
-      return <NoteIconDisplay value={icon} className={className} />
     }
   }
 

--- a/apps/desktop/src/renderer/src/components/tasks/project-modal.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project-modal.test.tsx
@@ -62,30 +62,41 @@ vi.mock('@/components/ui/alert-dialog', () => ({
   )
 }))
 
-vi.mock('@/components/icon-picker', () => ({
-  getIconByName: (name: string) =>
-    name === 'MissingIcon' ? null : (props: { className?: string }) => <span {...props}>icon</span>,
-  IconPicker: ({
-    isOpen,
-    onClose,
+// The icon lives inside a Radix Popover in real code; passthrough mocks keep the
+// flow deterministic (Radix Popover open/focus is unreliable under jsdom).
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+// The shared emoji/icon picker. "pick Star" emits an icon: value; Remove clears it.
+vi.mock('@/components/note/note-title/EmojiPicker', () => ({
+  EmojiPicker: ({
     onSelect,
-    currentIcon
+    onRemove,
+    hasEmoji
   }: {
-    isOpen: boolean
-    onClose: () => void
-    onSelect: (iconName: string) => void
-    currentIcon: string
-  }) =>
-    isOpen ? (
-      <div role="listbox" aria-label={`icons-${currentIcon}`}>
-        <button type="button" onClick={() => onSelect('Star')}>
-          icon Star
+    onSelect: (value: string) => void
+    onRemove: () => void
+    hasEmoji: boolean
+  }) => (
+    <div role="listbox" aria-label="icon-picker">
+      <button type="button" onClick={() => onSelect('icon:StarIcon')}>
+        pick Star
+      </button>
+      {hasEmoji && (
+        <button type="button" onClick={onRemove}>
+          remove icon
         </button>
-        <button type="button" onClick={onClose}>
-          close icons
-        </button>
-      </div>
-    ) : null
+      )}
+    </div>
+  )
+}))
+
+vi.mock('@/components/tasks/project-icon', () => ({
+  ProjectIcon: ({ icon, fallback }: { icon: string | null; fallback: React.ReactNode }) =>
+    icon ? <span data-testid="project-icon">{icon}</span> : <>{fallback}</>
 }))
 
 vi.mock('@/components/tasks/color-picker', () => ({
@@ -140,7 +151,7 @@ function makeProject(overrides: Partial<Project> = {}): Project {
 }
 
 describe('ProjectModal', () => {
-  it('creates a project with edited fields, icon, color, and statuses', () => {
+  it('creates a project with edited fields, icon, color, and statuses', async () => {
     const onSave = vi.fn()
     const onClose = vi.fn()
 
@@ -150,8 +161,8 @@ describe('ProjectModal', () => {
     fireEvent.change(screen.getByPlaceholderText('briefDescriptionOfThisProject'), {
       target: { value: 'Ship checklist' }
     })
-    fireEvent.click(screen.getByRole('button', { name: 'selectIcon' }))
-    fireEvent.click(screen.getByRole('button', { name: 'icon Star' }))
+    // The picker is lazy-loaded; findBy flushes the Suspense boundary.
+    fireEvent.click(await screen.findByRole('button', { name: 'pick Star' }))
     fireEvent.click(screen.getByRole('button', { name: 'pick blue' }))
     fireEvent.click(screen.getByRole('button', { name: 'valid statuses' }))
 
@@ -161,7 +172,7 @@ describe('ProjectModal', () => {
       expect.objectContaining({
         name: 'Launch',
         description: 'Ship checklist',
-        icon: 'Star',
+        icon: 'icon:StarIcon',
         color: '#00f',
         statuses: validStatuses,
         isDefault: false,
@@ -173,7 +184,7 @@ describe('ProjectModal', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('edits, deletes, validates statuses, and confirms discarding changes', () => {
+  it('edits, deletes, validates statuses, and confirms discarding changes', async () => {
     const onSave = vi.fn()
     const onClose = vi.fn()
     const onDelete = vi.fn()
@@ -188,6 +199,8 @@ describe('ProjectModal', () => {
       />
     )
 
+    // Flush the lazy-loaded icon picker's Suspense boundary before sync assertions.
+    await screen.findByRole('button', { name: 'pick Star' })
     expect(screen.getByText('Edit Project')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'deleteProject' }))
     expect(onDelete).toHaveBeenCalledWith('project-1')
@@ -214,7 +227,7 @@ describe('ProjectModal', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('hides delete for default projects and closes clean forms immediately', () => {
+  it('hides delete for default projects and closes clean forms immediately', async () => {
     const onClose = vi.fn()
     render(
       <ProjectModal
@@ -226,6 +239,8 @@ describe('ProjectModal', () => {
       />
     )
 
+    // Flush the lazy-loaded icon picker's Suspense boundary before sync assertions.
+    await screen.findByRole('button', { name: 'pick Star' })
     expect(screen.queryByRole('button', { name: 'deleteProject' })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
     expect(onClose).toHaveBeenCalled()

--- a/apps/desktop/src/renderer/src/components/tasks/project-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project-modal.tsx
@@ -1,4 +1,4 @@
-import { createElement, useState, useCallback, useMemo } from 'react'
+import { lazy, Suspense, useState, useCallback, useMemo } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -21,7 +21,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle
 } from '@/components/ui/alert-dialog'
-import { IconPicker, getIconByName } from '@/components/icon-picker'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { ProjectIcon } from '@/components/tasks/project-icon'
 import { ColorPicker } from '@/components/tasks/color-picker'
 import { StatusEditor } from '@/components/tasks/status-editor'
 import { cn } from '@/lib/utils'
@@ -34,6 +35,14 @@ import {
   validateProject,
   type ProjectValidationErrors
 } from '@/data/tasks-data'
+
+const LazyEmojiPicker = lazy(async () => ({
+  default: (await import('@/components/note/note-title/EmojiPicker')).EmojiPicker
+}))
+
+// Mirrors createDefaultProject().icon: used to detect a custom icon (show Remove)
+// and to reset the icon when the user removes it.
+const DEFAULT_ICON = 'Folder'
 
 // ============================================================================
 // TYPES
@@ -119,16 +128,6 @@ const getProjectDialogKey = (isOpen: boolean, project?: Project | null): string 
   })
 }
 
-const ProjectIconPreview = ({ iconName }: { iconName: string }): React.JSX.Element => {
-  const Icon = getIconByName(iconName)
-
-  if (!Icon) {
-    return <span className="text-2xl">📁</span>
-  }
-
-  return createElement(Icon, { className: 'size-6 text-text-secondary' })
-}
-
 // ============================================================================
 // PROJECT MODAL COMPONENT
 // ============================================================================
@@ -148,9 +147,8 @@ const ProjectModalDialog = ({
   // Form state
   const [formData, setFormData] = useState<FormData>(() => initialFormData)
 
-  // Icon picker state
-  const [isIconPickerOpen, setIsIconPickerOpen] = useState(false)
-  const [iconPickerPosition, setIconPickerPosition] = useState({ x: 0, y: 0 })
+  // Icon picker state (a modal Popover hosting the shared emoji/icon picker)
+  const [iconPickerOpen, setIconPickerOpen] = useState(false)
 
   // Unsaved changes dialog
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false)
@@ -233,14 +231,12 @@ const ProjectModalDialog = ({
     setFormData((prev) => ({ ...prev, color }))
   }
 
-  const handleIconClick = (e: React.MouseEvent<HTMLButtonElement>): void => {
-    const rect = e.currentTarget.getBoundingClientRect()
-    setIconPickerPosition({ x: rect.left, y: rect.bottom + 8 })
-    setIsIconPickerOpen(true)
+  const handleIconSelect = (icon: string): void => {
+    setFormData((prev) => ({ ...prev, icon }))
   }
 
-  const handleIconSelect = (iconName: string): void => {
-    setFormData((prev) => ({ ...prev, icon: iconName || 'Folder' }))
+  const handleIconRemove = (): void => {
+    setFormData((prev) => ({ ...prev, icon: DEFAULT_ICON }))
   }
 
   const handleStatusesChange = (statuses: Status[]): void => {
@@ -249,15 +245,7 @@ const ProjectModalDialog = ({
 
   return (
     <>
-      {/* Drop modal behavior only while the icon picker is open. The picker is a
-          floating layer rendered outside DialogContent; a modal dialog's focus trap
-          would yank focus back from its search box and its pointer-events lock would
-          disable it. Staying modal otherwise keeps the normal open/dismiss flow intact. */}
-      <Dialog
-        modal={!isIconPickerOpen}
-        open={isOpen}
-        onOpenChange={(open) => !open && handleClose()}
-      >
+      <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
         <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
           <DialogHeader>
             <DialogTitle>{isEditMode ? 'Edit Project' : 'Create Project'}</DialogTitle>
@@ -275,19 +263,45 @@ const ProjectModalDialog = ({
                 {tPhaseF('phaseF.componentsTasksProjectModal.iconName')}
               </label>
               <div className="flex items-center gap-3">
-                {/* Icon Button */}
-                <button
-                  type="button"
-                  onClick={handleIconClick}
-                  className={cn(
-                    'flex size-12 shrink-0 items-center justify-center rounded-sm border-2 border-dashed',
-                    'transition-colors hover:border-primary hover:bg-accent/50',
-                    'focus-visible:outline-none'
-                  )}
-                  aria-label={tPhaseF('phaseF.componentsTasksProjectModal.selectIcon')}
-                >
-                  <ProjectIconPreview iconName={formData.icon} />
-                </button>
+                {/* Icon Button — hosts the shared emoji/icon picker in a modal Popover.
+                    A modal Popover is a branch of the Dialog's dismissable layer, so it
+                    owns anchoring, focus, and dismissal while the Dialog stays modal —
+                    no modal toggling, no flicker, and the first click reliably registers. */}
+                <Popover open={iconPickerOpen} onOpenChange={setIconPickerOpen} modal>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      className={cn(
+                        'flex size-12 shrink-0 items-center justify-center rounded-sm border-2 border-dashed',
+                        'transition-colors hover:border-primary hover:bg-accent/50',
+                        'focus-visible:outline-none'
+                      )}
+                      aria-label={tPhaseF('phaseF.componentsTasksProjectModal.selectIcon')}
+                    >
+                      <ProjectIcon
+                        icon={formData.icon}
+                        className="size-6 text-text-secondary"
+                        fallback={<span className="text-2xl">📁</span>}
+                      />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    align="start"
+                    sideOffset={8}
+                    className="w-auto border-0 bg-transparent p-0 shadow-none"
+                  >
+                    <Suspense fallback={null}>
+                      <LazyEmojiPicker
+                        isOpen
+                        embedded
+                        hasEmoji={formData.icon !== DEFAULT_ICON}
+                        onClose={() => setIconPickerOpen(false)}
+                        onSelect={handleIconSelect}
+                        onRemove={handleIconRemove}
+                      />
+                    </Suspense>
+                  </PopoverContent>
+                </Popover>
 
                 {/* Name Input */}
                 <div className="flex-1">
@@ -389,15 +403,6 @@ const ProjectModalDialog = ({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
-      {/* Icon Picker */}
-      <IconPicker
-        isOpen={isIconPickerOpen}
-        onClose={() => setIsIconPickerOpen(false)}
-        onSelect={handleIconSelect}
-        position={iconPickerPosition}
-        currentIcon={formData.icon}
-      />
 
       {/* Unsaved Changes Confirmation */}
       <AlertDialog open={showUnsavedDialog} onOpenChange={setShowUnsavedDialog}>

--- a/apps/desktop/src/renderer/src/components/tasks/project-picker.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project-picker.tsx
@@ -1,6 +1,6 @@
-import { createElement, useMemo } from 'react'
+import { useMemo } from 'react'
 import { FolderKanban } from '@/lib/icons'
-import { getIconByName } from '@/components/icon-picker'
+import { ProjectIcon } from '@/components/tasks/project-icon'
 import { cn } from '@/lib/utils'
 import { Picker, usePickerContext, usePickerSearch } from '@/components/ui/picker'
 import { ProjectCreateFooter, useProjectQuickCreate } from './use-project-quick-create'
@@ -39,25 +39,20 @@ export interface ProjectPickerProps {
   className?: string
 }
 
-const ProjectIndicator = ({ project }: { project: Project }): React.JSX.Element => {
-  const IconComponent = getIconByName(project.icon)
-
-  if (IconComponent) {
-    return createElement(IconComponent, {
-      className: 'size-4 shrink-0',
-      style: { color: project.color },
-      'aria-hidden': 'true'
-    })
-  }
-
-  return (
-    <span
-      className="size-3 shrink-0 rounded-full"
-      style={{ backgroundColor: project.color }}
-      aria-hidden="true"
-    />
-  )
-}
+const ProjectIndicator = ({ project }: { project: Project }): React.JSX.Element => (
+  <ProjectIcon
+    icon={project.icon}
+    className="size-4 shrink-0"
+    color={project.color}
+    fallback={
+      <span
+        className="size-3 shrink-0 rounded-full"
+        style={{ backgroundColor: project.color }}
+        aria-hidden="true"
+      />
+    }
+  />
+)
 
 interface ProjectPickerListProps {
   projects: Project[]

--- a/apps/docs/src/user-guide/projects.md
+++ b/apps/docs/src/user-guide/projects.md
@@ -14,7 +14,7 @@ The **+** affordance in the sidebar Projects section opens a creation dialog:
 
 - **Name** — display title
 - **Color** — accent for the sidebar entry and project header
-- **Icon** — emoji or icon set choice
+- **Icon** — click the icon button to open the shared emoji/icon picker (the same one used for notes, folders, and tags) and choose an emoji or icon
 - **Initial statuses** — memrynote pre-fills `Todo / In Progress / Done`; you can edit before creating
 
 You can also create a project without leaving the task you're working on. Every project dropdown — the **Add Task** dialog, the **task detail** drawer, the project picker in the **Projects** tab, and the project-scope dropdown above the task list — ends with a **Create project** entry. Choosing it opens the same creation dialog, and the new project is selected once you save.


### PR DESCRIPTION
## Problem

Fixes #802 (part of epic #795). Opening the **project icon picker** flickered the entire UI, and the **second click canceled** — users could not set a project icon.

**Root cause:** `project-modal.tsx` toggled the Radix `Dialog`'s `modal` prop (`<Dialog modal={!isIconPickerOpen}>`) while a `position:fixed` lucide `IconPicker` rendered as a sibling **outside** `DialogContent`. Flipping `modal` true→false tore down the overlay + `RemoveScroll` scroll-lock + focus-trap (the flicker) and reflowed the measured anchor rect, so the next click landed "outside" → `onClose` (couldn't set an icon).

## Fix

Migrate project icons to the **shared EmojiPicker-in-Popover (`embedded`) pattern** already used by tags (`tag-icon-chip.tsx`) and folders. A **modal Popover** is a branch of the Dialog's dismissable layer, so it owns anchoring, focus, and dismissal while the Dialog stays modal — no `modal` toggling, no flicker, reliable first-click select. Project icons now match notes/tags/folders (emoji + HugeIcons).

### Backward compatibility (mandatory, render-time)

Existing projects store bare lucide names (`"Folder"`, `"Star"`), and older app versions keep writing them (the `icon` column is a field-level LWW-synced value). `NoteIconDisplay` has no lucide compat — fed `"Folder"` it prints the literal word. So a new render-time shim, `components/tasks/project-icon.tsx` (`ProjectIcon`), resolves all shapes:

- `icon:<HugeIconsName>` → `NoteIconDisplay` (tinted)
- legacy bare lucide name → lucide glyph (tinted, unchanged look)
- raw emoji → glyph
- null / unknown → caller's fallback (color dot, or 📁 in the modal)

`ProjectIcon` is wired into every project-icon render site: the modal, project picker, "Move to project" menu, and sidebar drop zones.

**No DB / contract / sync / migration change** — `projects.icon` was already a nullable string, and the new values (emoji, `icon:Name`) are still strings. Old clients gracefully degrade unknown values to their existing color-dot fallback.

## Out of scope (untouched)

- kibo-ui tree + `icon-picker.tsx` — these are note-tree node icons, a separate lucide system that keeps working.
- `graph.ts` passes the icon string into a node `emoji` field — new emoji values are, if anything, more correct there.

## Testing

- New `project-icon.test.tsx` pins the shim across all four value shapes (legacy lucide, `icon:Name`, emoji, fallback).
- `project-modal.test.tsx` updated to the new picker path (Popover + EmojiPicker), asserting the new `icon:StarIcon` value.
- Full renderer suite green: **5372 passing** (6 pre-existing skips).
- `typecheck:web` clean · eslint 0 errors · `i18n:check` pass · `docs:impact --strict` covered · `docs:build` clean.
- Physical Tailwind classes in the two edited drag-drop files were converted to logical (RTL-safe) equivalents to satisfy the renderer guard.

## Reviewer notes

- The no-flicker / first-click behavior is inherently runtime Radix; it rests on the already-shipped `tag-icon-chip` modal-Popover pattern. A quick manual smoke (create/edit a project → open the icon picker) is worthwhile.
- Noticed but left out of scope: `use-task-queries.ts` maps a null DB icon to lowercase `'folder'` (unresolvable) → color-dot fallback. A one-char `'Folder'` fix would render a folder glyph instead; happy to fold in if wanted.