### PR TITLE
feat(menu): F1 opens online docs; fix Help→Documentation URL

### DIFF
--- a/apps/desktop/src/main/menu.test.ts
+++ b/apps/desktop/src/main/menu.test.ts
@@ -3,14 +3,16 @@ import { BrowserWindow } from 'electron'
 import { AppChannels } from '@memry/contracts/ipc-channels'
 import { createMainI18n } from '@memry/i18n/main'
 
-const { buildFromTemplate } = vi.hoisted(() => ({
-  buildFromTemplate: vi.fn((template: unknown) => ({ template }))
+const { buildFromTemplate, openExternal } = vi.hoisted(() => ({
+  buildFromTemplate: vi.fn((template: unknown) => ({ template })),
+  openExternal: vi.fn()
 }))
 
 vi.mock('electron', () => ({
   app: { name: 'MemryNote' },
   BrowserWindow: { getFocusedWindow: vi.fn(), getAllWindows: vi.fn(() => []) },
-  Menu: { buildFromTemplate }
+  Menu: { buildFromTemplate },
+  shell: { openExternal }
 }))
 
 import { buildAppMenu, buildEditableTextContextMenu } from './menu'
@@ -34,6 +36,7 @@ function findMenuItem(label: string): TemplateItem | undefined {
 describe('buildAppMenu', () => {
   beforeEach(() => {
     buildFromTemplate.mockClear()
+    openExternal.mockClear()
     vi.mocked(BrowserWindow.getFocusedWindow).mockReset().mockReturnValue(null)
     vi.mocked(BrowserWindow.getAllWindows).mockReset().mockReturnValue([])
   })
@@ -99,6 +102,20 @@ describe('buildAppMenu', () => {
         })
       ])
     )
+  })
+
+  it('opens the online docs from Help → Documentation via F1', async () => {
+    const i18n = await createMainI18n({ locale: 'en' })
+
+    buildAppMenu(i18n)
+
+    const docs = findMenuItem('Documentation')
+    // The action lives in the main process (shell.openExternal), so unlike the
+    // renderer-owned cmd() items this accelerator registers and fires F1 directly.
+    expect(docs).toMatchObject({ accelerator: 'F1' })
+
+    docs?.click?.()
+    expect(openExternal).toHaveBeenCalledWith('https://docs.memrynote.com')
   })
 
   it('routes Edit undo/redo through the renderer instead of native roles', async () => {

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -3,7 +3,7 @@ import { AppChannels } from '@memry/contracts/ipc-channels'
 import type { I18nInstance } from '@memry/i18n/main'
 import { sendAppNavigationDirection } from './app-navigation-command'
 
-const DOCS_URL = 'https://memrynote.com'
+const DOCS_URL = 'https://docs.memrynote.com'
 
 interface EditableContextMenuParams {
   isEditable?: boolean
@@ -228,7 +228,15 @@ export function buildAppMenu(i18n: I18nInstance): Menu {
       label: t('help.label'),
       submenu: [
         ...(isMac ? [] : [aboutItem, { type: 'separator' as const }]),
-        { label: t('help.documentation'), click: () => void shell.openExternal(DOCS_URL) },
+        // F1 registers as a real accelerator (default registerAccelerator: true):
+        // the action lives here in the main process, so unlike the renderer-owned
+        // cmd() items there is no editor keydown to swallow. Opening the docs is
+        // always safe, and the menu now surfaces F1 for discoverability.
+        {
+          label: t('help.documentation'),
+          accelerator: 'F1',
+          click: () => void shell.openExternal(DOCS_URL)
+        },
         cmd('view.shortcuts', t('help.shortcuts'))
       ]
     }

--- a/apps/docs/src/user-guide/keyboard-shortcuts.md
+++ b/apps/docs/src/user-guide/keyboard-shortcuts.md
@@ -77,6 +77,17 @@ The same shortcut reference opens from the question-mark button in the sidebar f
 It groups shortcuts into General, Tabs & Splits, Inbox, Journal, Notes / Editor, Tasks,
 and Settings sections so you can scan by workflow.
 
+## Help
+
+| Action                    | Shortcut      |
+| ------------------------- | ------------- |
+| Open documentation online | <kbd>F1</kbd> |
+
+<kbd>F1</kbd> opens [docs.memrynote.com](https://docs.memrynote.com) in your browser —
+the same page you reach from **Help → Documentation** in the menu bar. It works
+everywhere, including inside the editor. This is a fixed menu shortcut and isn't
+rebindable.
+
 ## Inbox
 
 When the inbox or a card has focus:

--- a/apps/docs/src/user-guide/menu-bar.md
+++ b/apps/docs/src/user-guide/menu-bar.md
@@ -21,7 +21,7 @@ palette, or the editor's slash menu.
 - **View** — Reload, Developer Tools, zoom, full screen, Toggle Sidebar, Toggle
   Day Panel, and a Theme submenu (Light, Dark, Paper, System).
 - **Window** — standard window controls (minimize, zoom, front).
-- **Help** — About, Documentation, and Keyboard Shortcuts.
+- **Help** — About, Documentation (<kbd>F1</kbd>), and Keyboard Shortcuts.
 
 ## About
 
@@ -36,7 +36,9 @@ result as the editor's slash (`/`) menu and formatting toolbar.
 
 ## Keyboard shortcuts
 
-Menu items intentionally do not display keyboard shortcuts. Shortcuts are owned
-by the app itself (and are remappable), so they keep working whether or not you
-use the menu. See [Keyboard Shortcuts](/user-guide/keyboard-shortcuts) for the
-full list.
+Menu items intentionally do not display keyboard shortcuts, with one exception:
+**Help → Documentation** shows <kbd>F1</kbd>, the fixed shortcut for opening the
+online docs at [docs.memrynote.com](https://docs.memrynote.com). Every other
+shortcut is owned by the app itself (and is remappable), so it keeps working
+whether or not you use the menu. See
+[Keyboard Shortcuts](/user-guide/keyboard-shortcuts) for the full list.


### PR DESCRIPTION
## Summary

Two changes to make the online docs discoverable from the desktop app:

- **F1 opens the docs.** Added `accelerator: 'F1'` to the **Help → Documentation** menu item. It registers as a real menu accelerator (not the display-only `cmd()` bridge) because the action lives in the main process (`shell.openExternal`) — there is no renderer/editor keydown to swallow. F1 now works app-wide, including inside the editor, and the shortcut renders next to the menu item for discoverability.
- **Fixed the docs URL.** `DOCS_URL` pointed at the marketing site (`memrynote.com`); it now points at **`docs.memrynote.com`**, matching the onboarding link.

Docs pages (`keyboard-shortcuts.md`, `menu-bar.md`) updated to reflect the new F1 shortcut and the one menu item that now displays a shortcut.

### Note for reviewers
On macOS with "Use F1, F2 as standard function keys" disabled, bare F1 is brightness — users press **fn+F1**. The in-app shortcuts dialog (`?` / `⌘/`) is unaffected. Happy to add a `⌘⇧/` mac-convention alias if wanted.

## Release note

Press F1 (or Help → Documentation) to open the online documentation.

## Test plan

- `vitest run src/main/menu.test.ts` — 9 pass (new test asserts F1 accelerator + `docs.memrynote.com` on click)
- `pnpm --filter @memry/desktop typecheck:node` — clean
- `eslint` on changed files — clean
- `pnpm docs:impact --base <base> --strict` — pass
- `pnpm docs:build` — pass