### PR TITLE
fix(tasks): refresh tag sidebar live when a task tag changes

### DIFF
--- a/apps/desktop/src/main/sync/item-handlers/task-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/task-handler.test.ts
@@ -459,3 +459,117 @@ describe('taskHandler applyUpsert with tags/linkedNoteIds', () => {
     expect(getTagsForTask('task-omit-1')).toEqual(['keep-me'])
   })
 })
+
+describe('taskHandler broadcasts notes:tags-changed on synced tag changes', () => {
+  let testDb: TestDatabaseResult
+  let ctx: ApplyContext
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    ctx = makeCtx(testDb)
+    testDb.db.insert(projects).values(TEST_PROJECT).run()
+    testDb.db.insert(statuses).values(TEST_STATUSES).run()
+  })
+
+  afterEach(() => {
+    testDb.close()
+  })
+
+  it('emits on INSERT when the remote task carries tags', () => {
+    taskHandler.applyUpsert(ctx, 'sync-insert-1', makeTaskPayload({ tags: ['synced'] }), {
+      'device-B': 1
+    })
+    expect(ctx.emit).toHaveBeenCalledWith('notes:tags-changed', {})
+  })
+
+  it('does not emit on INSERT when the remote task has no tags field', () => {
+    taskHandler.applyUpsert(ctx, 'sync-insert-2', makeTaskPayload({}), { 'device-B': 1 })
+    expect(ctx.emit).not.toHaveBeenCalledWith('notes:tags-changed', {})
+  })
+
+  it('emits on APPLY (remote wins) when the payload carries tags', () => {
+    testDb.db
+      .insert(tasks)
+      .values({
+        id: 'sync-apply-1',
+        projectId: 'proj-1',
+        statusId: 'status-todo',
+        title: 'Task',
+        priority: 0,
+        position: 0,
+        clock: { 'device-A': 1 }
+      })
+      .run()
+
+    taskHandler.applyUpsert(ctx, 'sync-apply-1', makeTaskPayload({ tags: ['remote'] }), {
+      'device-A': 5
+    })
+    expect(ctx.emit).toHaveBeenCalledWith('notes:tags-changed', {})
+  })
+
+  it('emits on MERGE (concurrent edits) when the payload carries tags', () => {
+    const localFC = initAllFieldClocks({ 'device-A': 1 }, TASK_SYNCABLE_FIELDS)
+    testDb.db
+      .insert(tasks)
+      .values({
+        id: 'sync-merge-1',
+        projectId: 'proj-1',
+        statusId: 'status-todo',
+        title: 'Task',
+        priority: 0,
+        position: 0,
+        clock: { 'device-A': 2 },
+        fieldClocks: localFC
+      })
+      .run()
+
+    const remoteFC = initAllFieldClocks({ 'device-B': 1 }, TASK_SYNCABLE_FIELDS)
+    taskHandler.applyUpsert(
+      ctx,
+      'sync-merge-1',
+      makeTaskPayload({ tags: ['remote'], fieldClocks: remoteFC }),
+      { 'device-B': 2 }
+    )
+    expect(ctx.emit).toHaveBeenCalledWith('notes:tags-changed', {})
+  })
+
+  it('emits on DELETE when the deleted task had tags', () => {
+    testDb.db
+      .insert(tasks)
+      .values({
+        id: 'sync-del-1',
+        projectId: 'proj-1',
+        statusId: 'status-todo',
+        title: 'Task',
+        priority: 0,
+        position: 0,
+        clock: { 'device-A': 1 }
+      })
+      .run()
+    testDb.db
+      .insert(taskTags)
+      .values([{ taskId: 'sync-del-1', tag: 'gone' }])
+      .run()
+
+    taskHandler.applyDelete(ctx, 'sync-del-1')
+    expect(ctx.emit).toHaveBeenCalledWith('notes:tags-changed', {})
+  })
+
+  it('does not emit on DELETE when the deleted task had no tags', () => {
+    testDb.db
+      .insert(tasks)
+      .values({
+        id: 'sync-del-2',
+        projectId: 'proj-1',
+        statusId: 'status-todo',
+        title: 'Task',
+        priority: 0,
+        position: 0,
+        clock: { 'device-A': 1 }
+      })
+      .run()
+
+    taskHandler.applyDelete(ctx, 'sync-del-2')
+    expect(ctx.emit).not.toHaveBeenCalledWith('notes:tags-changed', {})
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/task-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/task-handler.ts
@@ -133,6 +133,7 @@ class TaskHandler extends BaseItemHandler<TaskSyncPayload> {
 
           const updated = tx.select().from(tasks).where(eq(tasks.id, itemId)).get()
           ctx.emit(TasksChannels.events.UPDATED, { id: itemId, task: updated, changes: {} })
+          if (data.tags) ctx.emit('notes:tags-changed', {})
           publishProjectionEvent({ type: 'task.upserted', taskId: itemId })
           return result.hadConflicts ? 'conflict' : 'applied'
         }
@@ -169,6 +170,7 @@ class TaskHandler extends BaseItemHandler<TaskSyncPayload> {
 
         const updated = tx.select().from(tasks).where(eq(tasks.id, itemId)).get()
         ctx.emit(TasksChannels.events.UPDATED, { id: itemId, task: updated, changes: {} })
+        if (data.tags) ctx.emit('notes:tags-changed', {})
         publishProjectionEvent({ type: 'task.upserted', taskId: itemId })
         return 'applied'
       }
@@ -206,6 +208,7 @@ class TaskHandler extends BaseItemHandler<TaskSyncPayload> {
 
       const inserted = tx.select().from(tasks).where(eq(tasks.id, itemId)).get()
       ctx.emit(TasksChannels.events.CREATED, { task: inserted })
+      if (data.tags) ctx.emit('notes:tags-changed', {})
       publishProjectionEvent({ type: 'task.upserted', taskId: itemId })
       return 'applied'
     })
@@ -223,8 +226,11 @@ class TaskHandler extends BaseItemHandler<TaskSyncPayload> {
       }
     }
 
+    const hadTags = queryTags(ctx.db, itemId).length > 0
+
     ctx.db.delete(tasks).where(eq(tasks.id, itemId)).run()
     ctx.emit(TasksChannels.events.DELETED, { id: itemId })
+    if (hadTags) ctx.emit('notes:tags-changed', {})
     publishProjectionEvent({ type: 'task.deleted', taskId: itemId })
     return 'applied'
   }

--- a/apps/desktop/src/main/tasks/publisher.test.ts
+++ b/apps/desktop/src/main/tasks/publisher.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tasks publisher tests
+ *
+ * Regression: creating/updating a task's tags must broadcast `notes:tags-changed`
+ * so the tag list (tasks filter sidebar) refreshes without an app restart.
+ *
+ * @module tasks/publisher.test
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Task } from '@memry/domain-tasks'
+
+const mockSend = vi.fn()
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [{ webContents: { send: mockSend } }])
+  }
+}))
+
+vi.mock('./runtime-effects', () => ({
+  syncTaskCreate: vi.fn(),
+  syncTaskUpdate: vi.fn(),
+  syncTaskDelete: vi.fn(),
+  syncProjectCreate: vi.fn(),
+  syncProjectUpdate: vi.fn(),
+  syncProjectDelete: vi.fn()
+}))
+
+vi.mock('../telemetry/track', () => ({
+  trackMainEvent: vi.fn()
+}))
+
+import { createTasksPublisher } from './publisher'
+
+const TAGS_CHANGED = 'notes:tags-changed'
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    projectId: 'proj-1',
+    statusId: null,
+    parentId: null,
+    title: 'Task',
+    description: null,
+    priority: 0,
+    position: 0,
+    dueDate: null,
+    dueTime: null,
+    startDate: null,
+    repeatConfig: null,
+    repeatFrom: null,
+    sourceNoteId: null,
+    completedAt: null,
+    archivedAt: null,
+    createdAt: '2026-07-22T00:00:00.000Z',
+    modifiedAt: '2026-07-22T00:00:00.000Z',
+    tags: [],
+    linkedNoteIds: [],
+    ...overrides
+  } as Task
+}
+
+describe('createTasksPublisher tags-changed broadcast', () => {
+  beforeEach(() => {
+    mockSend.mockClear()
+  })
+
+  it('broadcasts notes:tags-changed when a created task has tags', () => {
+    const publisher = createTasksPublisher()
+    publisher.taskCreated({ task: makeTask({ tags: ['urgent'] }) })
+    expect(mockSend).toHaveBeenCalledWith(TAGS_CHANGED, {})
+  })
+
+  it('does not broadcast notes:tags-changed when a created task has no tags', () => {
+    const publisher = createTasksPublisher()
+    publisher.taskCreated({ task: makeTask({ tags: [] }) })
+    expect(mockSend).not.toHaveBeenCalledWith(TAGS_CHANGED, {})
+  })
+
+  it('broadcasts notes:tags-changed when an update changes tags', () => {
+    const publisher = createTasksPublisher()
+    publisher.taskUpdated({
+      id: 'task-1',
+      task: makeTask({ tags: ['new'] }),
+      changes: { tags: ['new'] },
+      changedFields: ['tags']
+    })
+    expect(mockSend).toHaveBeenCalledWith(TAGS_CHANGED, {})
+  })
+
+  it('does not broadcast notes:tags-changed when an update does not touch tags', () => {
+    const publisher = createTasksPublisher()
+    publisher.taskUpdated({
+      id: 'task-1',
+      task: makeTask({ title: 'Renamed' }),
+      changes: { title: 'Renamed' },
+      changedFields: ['title']
+    })
+    expect(mockSend).not.toHaveBeenCalledWith(TAGS_CHANGED, {})
+  })
+
+  it('broadcasts notes:tags-changed when a deleted task had tags', () => {
+    const publisher = createTasksPublisher()
+    publisher.taskDeleted({ id: 'task-1', snapshot: makeTask({ tags: ['urgent'] }) })
+    expect(mockSend).toHaveBeenCalledWith(TAGS_CHANGED, {})
+  })
+
+  it('does not broadcast notes:tags-changed when a deleted task had no tags', () => {
+    const publisher = createTasksPublisher()
+    publisher.taskDeleted({ id: 'task-1', snapshot: makeTask({ tags: [] }) })
+    expect(mockSend).not.toHaveBeenCalledWith(TAGS_CHANGED, {})
+  })
+})

--- a/apps/desktop/src/main/tasks/publisher.ts
+++ b/apps/desktop/src/main/tasks/publisher.ts
@@ -18,10 +18,18 @@ function emitTaskEvent(channel: string, data: unknown): void {
   })
 }
 
+// Task tags share the global tag list (see getTagsWithCounts). The tag hooks
+// (useTags / useAllTags / useNoteTagsQuery) only refetch on `notes:tags-changed`,
+// so a task tag mutation must broadcast it or the list stays stale until restart.
+function emitTagsChanged(): void {
+  emitTaskEvent('notes:tags-changed', {})
+}
+
 export function createTasksPublisher(): TasksDomainPublisher {
   return {
     taskCreated: ({ task }) => {
       emitTaskEvent(TasksChannels.events.CREATED, { task })
+      if (task.tags && task.tags.length > 0) emitTagsChanged()
       syncTaskCreate(task.id)
       trackMainEvent('task_created', {
         surface: 'tasks',
@@ -32,11 +40,13 @@ export function createTasksPublisher(): TasksDomainPublisher {
     },
     taskUpdated: ({ id, task, changes, changedFields }) => {
       emitTaskEvent(TasksChannels.events.UPDATED, { id, task, changes })
+      if (changedFields.includes('tags')) emitTagsChanged()
       syncTaskUpdate(id, changedFields)
     },
     taskDeleted: ({ id, snapshot }) => {
       syncTaskDelete(id, snapshot)
       emitTaskEvent(TasksChannels.events.DELETED, { id })
+      if (snapshot?.tags && snapshot.tags.length > 0) emitTagsChanged()
     },
     taskCompleted: ({ id, task }) => {
       emitTaskEvent(TasksChannels.events.COMPLETED, { id, task })


### PR DESCRIPTION
## What
Broadcast `notes:tags-changed` on task tag mutations so the tasks tag sidebar/filter updates immediately instead of only after an app restart — in both the local publisher and the cross-device sync task handler.

## Why
Task tags persist immediately and `getTagsWithCounts` reads them live, but the renderer tag hooks (`useTags`/`useAllTags`/`useNoteTagsQuery`) only refetch on `notes:tags-changed`, which neither path emitted.

No schema, contract, or IPC-channel change; the event and its listeners already exist. Covered by 12 new tests.