### PR TITLE
fix(release): inject GOOGLE_CALENDAR_CLIENT_SECRET in all publish build jobs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -189,6 +189,7 @@ jobs:
       - name: Create runtime environment
         env:
           GOOGLE_CALENDAR_CLIENT_ID: ${{ secrets.GOOGLE_CALENDAR_CLIENT_ID }}
+          GOOGLE_CALENDAR_CLIENT_SECRET: ${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}
           SYNC_SERVER_URL: ${{ secrets.SYNC_SERVER_URL }}
         run: |
           set -euo pipefail
@@ -200,9 +201,14 @@ jobs:
             echo "::error::Set GOOGLE_CALENDAR_CLIENT_ID as a repository secret before publishing."
             exit 1
           fi
+          if [ -z "${GOOGLE_CALENDAR_CLIENT_SECRET:-}" ]; then
+            echo "::error::Set GOOGLE_CALENDAR_CLIENT_SECRET as a repository secret before publishing."
+            exit 1
+          fi
           {
             printf 'SYNC_SERVER_URL=%s\n' "$SYNC_SERVER_URL"
             printf 'GOOGLE_CALENDAR_CLIENT_ID=%s\n' "$GOOGLE_CALENDAR_CLIENT_ID"
+            printf 'GOOGLE_CALENDAR_CLIENT_SECRET=%s\n' "$GOOGLE_CALENDAR_CLIENT_SECRET"
           } > apps/desktop/.env.production
 
       - name: Build signed macOS artifacts
@@ -365,6 +371,7 @@ jobs:
       - name: Create runtime environment
         env:
           GOOGLE_CALENDAR_CLIENT_ID: ${{ secrets.GOOGLE_CALENDAR_CLIENT_ID }}
+          GOOGLE_CALENDAR_CLIENT_SECRET: ${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}
           SYNC_SERVER_URL: ${{ secrets.SYNC_SERVER_URL }}
         shell: bash
         run: |
@@ -377,9 +384,14 @@ jobs:
             echo "::error::Set GOOGLE_CALENDAR_CLIENT_ID as a repository secret before publishing"
             exit 1
           fi
+          if [ -z "${GOOGLE_CALENDAR_CLIENT_SECRET:-}" ]; then
+            echo "::error::Set GOOGLE_CALENDAR_CLIENT_SECRET as a repository secret before publishing"
+            exit 1
+          fi
           {
             printf 'SYNC_SERVER_URL=%s\n' "$SYNC_SERVER_URL"
             printf 'GOOGLE_CALENDAR_CLIENT_ID=%s\n' "$GOOGLE_CALENDAR_CLIENT_ID"
+            printf 'GOOGLE_CALENDAR_CLIENT_SECRET=%s\n' "$GOOGLE_CALENDAR_CLIENT_SECRET"
           } > apps/desktop/.env.production
 
       # The runtime env is staged + shipped as resources/app-config, a filename
@@ -511,6 +523,7 @@ jobs:
       - name: Create runtime environment
         env:
           GOOGLE_CALENDAR_CLIENT_ID: ${{ secrets.GOOGLE_CALENDAR_CLIENT_ID }}
+          GOOGLE_CALENDAR_CLIENT_SECRET: ${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}
           SYNC_SERVER_URL: ${{ secrets.SYNC_SERVER_URL }}
         run: |
           set -euo pipefail
@@ -522,9 +535,14 @@ jobs:
             echo "::error::Set GOOGLE_CALENDAR_CLIENT_ID as a repository secret before publishing."
             exit 1
           fi
+          if [ -z "${GOOGLE_CALENDAR_CLIENT_SECRET:-}" ]; then
+            echo "::error::Set GOOGLE_CALENDAR_CLIENT_SECRET as a repository secret before publishing."
+            exit 1
+          fi
           {
             printf 'SYNC_SERVER_URL=%s\n' "$SYNC_SERVER_URL"
             printf 'GOOGLE_CALENDAR_CLIENT_ID=%s\n' "$GOOGLE_CALENDAR_CLIENT_ID"
+            printf 'GOOGLE_CALENDAR_CLIENT_SECRET=%s\n' "$GOOGLE_CALENDAR_CLIENT_SECRET"
           } > apps/desktop/.env.production
 
       - name: Build Linux artifacts


### PR DESCRIPTION
## Problem

Production desktop builds cannot connect Google Calendar. Token exchange returns `400 invalid_request: client_secret is missing` (confirmed in prod Loki, scope `Calendar:GoogleOAuth`, `hasClientSecret:false`).

`publish-release.yml` injects only `GOOGLE_CALENDAR_CLIENT_ID` into `apps/desktop/.env.production` in the three build jobs. `apps/desktop/src/main/calendar/google/oauth.ts` reads `process.env.GOOGLE_CALENDAR_CLIENT_SECRET` and only sends `client_secret` when present — so every packaged build omits it and Google rejects the exchange.

## Fix

Mirror the existing `GOOGLE_CALENDAR_CLIENT_ID` injection for `GOOGLE_CALENDAR_CLIENT_SECRET` in all three build jobs (macOS, Windows, Linux):

- `env` reference to `secrets.GOOGLE_CALENDAR_CLIENT_SECRET`
- fail-fast guard that errors the build when the secret is unset
- `printf` line into `apps/desktop/.env.production`

Workflow-only change; no app code touched.

## ⚠️ Action required before merge

**Add `GOOGLE_CALENDAR_CLIENT_SECRET` to the GitHub repo secrets** (Settings → Secrets and variables → Actions) with the OAuth client secret value. Until it exists, the guard added here will intentionally fail any release build.

## Verification

- `js-yaml` parse of the workflow: OK
- 12 references across the file = 3 jobs × (env ref + guard test + guard message + printf)
- `publish-release.yml` is the only workflow referencing `GOOGLE_CALENDAR_CLIENT_ID`, so no other workflow needs the same fix