### PR TITLE
fix(updater): log the phase, code and message behind update failures (#842)

### DIFF
--- a/apps/desktop/src/main/telemetry/log-ship.test.ts
+++ b/apps/desktop/src/main/telemetry/log-ship.test.ts
@@ -87,6 +87,24 @@ describe('parseRecord', () => {
     const p = parseRecord({ level: 'error', data: [new Error('')] })
     expect(p.message).toBe('Error')
   })
+
+  it('keeps the error message as a field when a label already claimed the message', () => {
+    // logger.error('updater error', err) shipped `{"errorName":"Error"}` and nothing
+    // else — the label won the message slot and the Error's own message was dropped,
+    // leaving prod failures undiagnosable (#842).
+    const p = parseRecord({ level: 'error', data: ['updater error', new Error('kaboom')] })
+    expect(p.message).toBe('updater error')
+    expect(p.fields.errorName).toBe('Error')
+    expect(p.fields.errorMessage).toBe('kaboom')
+  })
+
+  it('does not overwrite an explicit errorMessage field', () => {
+    const p = parseRecord({
+      level: 'error',
+      data: ['updater error', { errorMessage: 'curated' }, new Error('raw')]
+    })
+    expect(p.fields.errorMessage).toBe('curated')
+  })
 })
 
 describe('installLogShip', () => {

--- a/apps/desktop/src/main/telemetry/log-ship.ts
+++ b/apps/desktop/src/main/telemetry/log-ship.ts
@@ -55,6 +55,11 @@ export const parseRecord = (
       if (!message)
         message = typeof arg.message === 'string' && arg.message ? arg.message : arg.name
       fields.errorName = arg.name
+      // A leading label (logger.error('updater error', err)) claims the message slot,
+      // which used to leave the Error itself reduced to `{"errorName":"Error"}` —
+      // no message, nothing to diagnose (#842). Keep it as a field instead.
+      if (typeof arg.message === 'string' && arg.message && !('errorMessage' in fields))
+        fields.errorMessage = arg.message
     } else if (arg && typeof arg === 'object') Object.assign(fields, arg)
     else if (!message) message = String(arg)
   }

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -57,6 +57,14 @@ const mocks = vi.hoisted(() => {
     dialog: {
       showMessageBox: vi.fn()
     },
+    // Stable across createLogger() calls so tests can assert on the enriched
+    // updater-failure payloads (issue #842).
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn()
+    },
     autoUpdater: Object.assign(emitter, {
       autoDownload: true,
       autoInstallOnAppQuit: false,
@@ -87,12 +95,7 @@ vi.mock('./store', () => ({
 }))
 
 vi.mock('./lib/logger', () => ({
-  createLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn()
-  })
+  createLogger: () => mocks.logger
 }))
 
 vi.mock('./lib/main-i18n', () => ({
@@ -466,6 +469,126 @@ describe('updater', () => {
     expect(mocks.app.quit).toHaveBeenCalledTimes(1)
     expect(updater.isQuitAndInstallRequested()).toBe(true)
     expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled()
+  })
+
+  // Issue #842: prod updater failures shipped as `{"errorName":"Error"}` and nothing
+  // else, because the log-ship transport keeps only the first string argument as the
+  // message and drops the Error's own message. Every updater failure now carries an
+  // explicit fields object so the payload is diagnosable in Loki.
+  describe('error payload enrichment (#842)', () => {
+    it('extracts message, code, http status and url from an electron-updater error', async () => {
+      const updater = await loadUpdater()
+      const error = Object.assign(
+        new Error('Cannot download "https://x.test/latest.yml", status 404'),
+        {
+          name: 'HttpError',
+          code: 'ERR_UPDATER_LATEST_VERSION_NOT_FOUND',
+          statusCode: 404,
+          url: 'https://x.test/latest.yml'
+        }
+      )
+
+      expect(updater.describeUpdaterError(error, 'download')).toMatchObject({
+        phase: 'download',
+        errorName: 'HttpError',
+        errorMessage: 'Cannot download "https://x.test/latest.yml", status 404',
+        errorCode: 'ERR_UPDATER_LATEST_VERSION_NOT_FOUND',
+        httpStatus: 404,
+        url: 'https://x.test/latest.yml'
+      })
+      expect(updater.describeUpdaterError(error, 'download').errorStack).toContain(
+        'updater.test.ts'
+      )
+    })
+
+    it('keeps a non-Error rejection diagnosable', async () => {
+      const updater = await loadUpdater()
+
+      expect(updater.describeUpdaterError('boom', 'startup-check')).toEqual({
+        phase: 'startup-check',
+        errorName: 'NonError',
+        errorMessage: 'boom'
+      })
+    })
+
+    it('reports the errno and cause of a network failure', async () => {
+      const updater = await loadUpdater()
+      const error = Object.assign(new Error('request failed'), {
+        code: 'ENOTFOUND',
+        cause: Object.assign(new Error('getaddrinfo ENOTFOUND github.com'), { code: 'ENOTFOUND' })
+      })
+
+      expect(updater.describeUpdaterError(error, 'scheduled-check')).toMatchObject({
+        phase: 'scheduled-check',
+        errorCode: 'ENOTFOUND',
+        errorCause: 'Error: getaddrinfo ENOTFOUND github.com (ENOTFOUND)'
+      })
+    })
+
+    it('logs the updater error event with the phase inferred from the current status', async () => {
+      const updater = await loadUpdater()
+      updater.initializeUpdater()
+
+      mocks.autoUpdater.emit('checking-for-update')
+      const checkError = Object.assign(new Error('network failed'), { code: 'ECONNRESET' })
+      mocks.autoUpdater.emit('error', checkError)
+
+      expect(mocks.logger.error).toHaveBeenCalledWith(
+        'updater error',
+        checkError,
+        expect.objectContaining({
+          phase: 'check',
+          errorName: 'Error',
+          errorMessage: 'network failed',
+          errorCode: 'ECONNRESET'
+        })
+      )
+    })
+
+    it('logs a download-phase updater error while a download is in flight', async () => {
+      const updater = await loadUpdater()
+      updater.initializeUpdater()
+
+      void updater.downloadUpdate()
+      mocks.autoUpdater.emit('error', new Error('disk full'))
+
+      expect(mocks.logger.error).toHaveBeenCalledWith(
+        'updater error',
+        expect.any(Error),
+        expect.objectContaining({ phase: 'download', errorMessage: 'disk full' })
+      )
+    })
+
+    it('enriches startup and scheduled check failures', async () => {
+      vi.useFakeTimers()
+      try {
+        mocks.autoUpdater.checkForUpdates.mockRejectedValue(
+          Object.assign(new Error('feed unreachable'), { code: 'ERR_UPDATER_INVALID_RELEASE_FEED' })
+        )
+        const updater = await loadUpdater()
+        updater.initializeUpdater()
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(mocks.logger.warn).toHaveBeenCalledWith(
+          'startup update check failed',
+          expect.any(Error),
+          expect.objectContaining({
+            phase: 'startup-check',
+            errorMessage: 'feed unreachable',
+            errorCode: 'ERR_UPDATER_INVALID_RELEASE_FEED'
+          })
+        )
+
+        await vi.advanceTimersByTimeAsync(10 * 60 * 1000)
+        expect(mocks.logger.warn).toHaveBeenCalledWith(
+          'scheduled update check failed',
+          expect.any(Error),
+          expect.objectContaining({ phase: 'scheduled-check', errorMessage: 'feed unreachable' })
+        )
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   it('installs the downloaded update only after graceful shutdown completes', async () => {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -19,6 +19,116 @@ const logger = createLogger('Updater')
  */
 const AUTO_CHECK_INTERVAL_MS = 10 * 60 * 1000
 
+/**
+ * Where in the update lifecycle a failure happened. Shipped verbatim as the `phase`
+ * field (see VERBATIM_FIELD_KEYS in contracts/redact) so a Loki line says whether the
+ * startup check, the background check, the download, or the install is what broke.
+ */
+export type UpdaterErrorPhase =
+  | 'startup-check'
+  | 'scheduled-check'
+  | 'auto-check-enable'
+  | 'auto-download-enable'
+  | 'check'
+  | 'download'
+  | 'downloaded'
+  | 'install'
+  | 'idle'
+
+const ERROR_TEXT_CAP = 300
+const ERROR_STACK_FRAMES = 4
+
+const truncate = (value: string, limit: number): string =>
+  value.length > limit ? `${value.slice(0, limit)}…` : value
+
+/** electron-updater / node errno codes are strings; HTTP-ish libs sometimes use numbers. */
+const codeOf = (error: object): string | undefined => {
+  const { code } = error as { code?: unknown }
+  if (typeof code === 'string' && code) return code
+  if (typeof code === 'number' && Number.isFinite(code)) return String(code)
+  return undefined
+}
+
+const describeCause = (cause: unknown): string | undefined => {
+  if (cause instanceof Error) {
+    const code = codeOf(cause)
+    return truncate(`${cause.name}: ${cause.message}${code ? ` (${code})` : ''}`, ERROR_TEXT_CAP)
+  }
+  return typeof cause === 'string' && cause ? truncate(cause, ERROR_TEXT_CAP) : undefined
+}
+
+/**
+ * Stack frames only — the `Name: message` header is already carried by errorName /
+ * errorMessage, and the shipped field value is capped at 500 chars upstream.
+ */
+const describeStack = (stack: unknown): string | undefined => {
+  if (typeof stack !== 'string') return undefined
+  const frames = stack
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('at '))
+    .slice(0, ERROR_STACK_FRAMES)
+  return frames.length > 0 ? truncate(frames.join(' | '), 400) : undefined
+}
+
+/**
+ * Flatten an updater failure into log fields. Without this, `logger.error('updater
+ * error', error)` shipped `{"errorName":"Error"}` and nothing else: the log-ship
+ * transport keeps the first string argument as the message and never reads the
+ * Error's own message/code (see telemetry/log-ship.ts parseRecord). Field names are
+ * chosen against the redaction allowlist — `phase`/`errorCode` pass verbatim, `url`
+ * is path-redacted (query string stripped), the rest are text-redacted and capped.
+ */
+export function describeUpdaterError(
+  error: unknown,
+  phase: UpdaterErrorPhase
+): Record<string, unknown> {
+  if (!(error instanceof Error)) {
+    return {
+      phase,
+      errorName: 'NonError',
+      errorMessage: truncate(String(error), ERROR_TEXT_CAP)
+    }
+  }
+
+  const source = error as Error & { statusCode?: unknown; url?: unknown; cause?: unknown }
+  const status = typeof source.statusCode === 'number' ? source.statusCode : undefined
+  const url = typeof source.url === 'string' && source.url ? source.url : undefined
+  const code = codeOf(source)
+  const cause = describeCause(source.cause)
+  const stack = describeStack(source.stack)
+
+  return {
+    phase,
+    errorName: error.name,
+    errorMessage: truncate(error.message, ERROR_TEXT_CAP),
+    ...(code ? { errorCode: code } : {}),
+    ...(status !== undefined ? { httpStatus: status } : {}),
+    ...(url ? { url } : {}),
+    ...(cause ? { errorCause: cause } : {}),
+    ...(stack ? { errorStack: stack } : {})
+  }
+}
+
+/**
+ * electron-updater's `error` event carries no phase of its own, so derive it from the
+ * status the updater was in when it fired.
+ */
+function currentErrorPhase(): UpdaterErrorPhase {
+  switch (state.status) {
+    case 'checking':
+      return 'check'
+    case 'downloading':
+      return 'download'
+    case 'downloaded':
+      return 'downloaded'
+    case 'installing':
+      return 'install'
+    default:
+      return 'idle'
+  }
+}
+
 let initialized = false
 let activeCheck: Promise<AppUpdateState> | null = null
 let activeDownload: Promise<AppUpdateState> | null = null
@@ -141,7 +251,7 @@ export function initializeUpdater(): void {
   autoUpdater.on('error', (error) => {
     const message =
       error instanceof Error ? error.message : getMainI18n().t('system:error.updateFailed')
-    logger.error('updater error', error)
+    logger.error('updater error', error, describeUpdaterError(error, currentErrorPhase()))
     setState({
       status: 'error',
       error: message
@@ -151,7 +261,11 @@ export function initializeUpdater(): void {
   if (autoCheckEnabled) {
     startAutoCheckTimer()
     void checkForUpdates().catch((error) => {
-      logger.warn('startup update check failed', error)
+      logger.warn(
+        'startup update check failed',
+        error,
+        describeUpdaterError(error, 'startup-check')
+      )
     })
   }
 }
@@ -167,7 +281,11 @@ function startAutoCheckTimer(): void {
   }
   autoCheckTimer = setInterval(() => {
     void checkForUpdates().catch((error) => {
-      logger.warn('scheduled update check failed', error)
+      logger.warn(
+        'scheduled update check failed',
+        error,
+        describeUpdaterError(error, 'scheduled-check')
+      )
     })
   }, AUTO_CHECK_INTERVAL_MS)
   autoCheckTimer.unref?.()
@@ -276,7 +394,11 @@ export function setAutoDownloadEnabled(enabled: boolean): AppUpdateState {
   // update stuck behind the manual Download button, so start its download now.
   if (enabled && state.status === 'available') {
     void downloadUpdate().catch((error) => {
-      logger.warn('auto-download on-enable download failed', error)
+      logger.warn(
+        'auto-download on-enable download failed',
+        error,
+        describeUpdaterError(error, 'auto-download-enable')
+      )
     })
   }
   return getUpdateState()
@@ -293,7 +415,11 @@ export function setAutoCheckEnabled(enabled: boolean): AppUpdateState {
   if (enabled) {
     startAutoCheckTimer()
     void checkForUpdates().catch((error) => {
-      logger.warn('auto-check enable update check failed', error)
+      logger.warn(
+        'auto-check enable update check failed',
+        error,
+        describeUpdaterError(error, 'auto-check-enable')
+      )
     })
   } else {
     stopAutoCheckTimer()

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -268,7 +268,11 @@ Loki adds the diagnostic detail (stacks, operational messages) that AE rows deli
   30s, drop-4xx-except-429) to `POST /telemetry/logs`, gated on the telemetry toggle
   (`getTelemetryRuntime().getSettings().enabled`) and disabled outright in dev builds. Repeated
   identical `level|scope|message` lines within a 3s window are throttled into one line with a
-  `repeatCount` field. Worker processes (embeddings, image processing, voice transcription)
+  `repeatCount` field. A record's arguments are flattened by `parseRecord`: the first string wins
+  the `message` slot, plain objects merge into the fields, and an `Error` contributes `errorName`
+  plus `errorMessage`. That last part matters — `logger.error('updater error', err)` used to ship
+  `{"errorName":"Error"}` and nothing else, because the label had already claimed the message slot
+  and the Error's own message was dropped. Worker processes (embeddings, image processing, voice transcription)
   forward their own `warn`/`error` records to main over `process.parentPort`
   (`apps/desktop/src/main/lib/log-forward.ts`, electron-free) for the same redaction + ship pass,
   tagged `origin: 'worker'` and `workerName`. The server re-runs `redactLogLine` in mask mode (no
@@ -298,6 +302,15 @@ Loki adds the diagnostic detail (stacks, operational messages) that AE rows deli
 reason, phase, mode, status, kind, result`, plus numeric metric keys like
   `durationMs`/`itemCount`) ships verbatim; most other field values run through the same redaction as
   the message.
+- **Updater failures**: every failure in `apps/desktop/src/main/updater.ts` logs a
+  `describeUpdaterError()` field bag alongside the raw error, so a silent auto-update failure is
+  diagnosable from Loki alone: `phase` (`startup-check`, `scheduled-check`, `auto-check-enable`,
+  `auto-download-enable`, or — for electron-updater's own `error` event, which carries no phase —
+  one of `check` / `download` / `downloaded` / `install` inferred from the status at the time),
+  plus `errorName`, `errorMessage`, `errorCode`, `httpStatus`, `url`, `errorCause` and the top
+  stack frames as `errorStack`. The field names are chosen against the redaction allowlist above:
+  `phase` and `errorCode` ship verbatim, `url` is path-redacted (query string stripped), the rest
+  are text-redacted and capped.
 - **Process lifecycle**: the main process reports a `child-process-gone` fault with a composite
   `type:reason:name` error code (e.g. `Utility:crashed:Embeddings`). The worker label comes from
   Electron's `details.name`, **not** `details.serviceName`: Electron routes a fork's `serviceName`


### PR DESCRIPTION
Closes #842.

## Problem

Prod updater failures shipped as `{"errorName":"Error"}` and nothing else — six events across four installs in three days, none diagnosable.

Root cause is in the log-ship transport: `parseRecord` gives the `message` slot to the first string argument, so `logger.error('updater error', err)` kept the label and dropped the Error's own message. This silently affected **every** scope, not just the updater.

## Change

- **`describeUpdaterError(error, phase)`** in `updater.ts` flattens a failure into log fields: `phase`, `errorName`, `errorMessage`, `errorCode`, `httpStatus`, `url`, `errorCause`, and the top 4 stack frames as `errorStack`. Field names are picked against the redaction allowlist — `phase`/`errorCode` ship verbatim, `url` is path-redacted (query stripped), the rest are text-redacted and capped.
- **Every updater failure site** now passes it: the `autoUpdater` `error` event (phase inferred from the status at the time — `check` / `download` / `downloaded` / `install`), the startup and scheduled checks, and the auto-check / auto-download enable paths. The raw `Error` is still passed too, so the on-disk log keeps the full stack.
- **`parseRecord`** keeps an `Error`'s message as an `errorMessage` field when a leading label already claimed the message slot. This is the root-cause fix and enriches every other scope for free; it's the one part of this PR that reaches beyond the updater, so it's easy to split out if you'd rather land it separately.

## Verification

- `updater.test.ts` +6 tests, `log-ship.test.ts` +2 tests.
- Mutation-checked: breaking the phase inference (`currentErrorPhase()` → hardcoded `'idle'`) fails the download-phase test.
- Full desktop `main` project: 4020 pass, 0 fail. `typecheck:node` clean, eslint clean.
- `docs:impact --strict` covered, `docs:build` clean.

## Follow-up

Per the issue: re-triage Loki once this ships and real payloads accumulate, then open a targeted fix issue if a pattern emerges.

Part of #836.