### PR TITLE
fix(telemetry): harden error normalization; recover window_error class + location

### DIFF
--- a/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.test.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.test.ts
@@ -88,6 +88,39 @@ describe('renderer telemetry diagnostics', () => {
     expect(serialized).not.toContain('boom')
   })
 
+  it('captures the error class and source location of a window error with no error object', () => {
+    // #given a window error that arrived without `event.error` — previously
+    // reported as StringError with an empty stack and nothing to triage
+    registerRendererDiagnostics()
+
+    // #when the window reports it
+    window.dispatchEvent(
+      Object.assign(new Event('error'), {
+        error: null,
+        message: 'Uncaught TypeError: n.focus is not a function',
+        filename: 'file:///Users/kaan/Memry.app/out/renderer/assets/index-VP6Jd1Vs.js',
+        lineno: 121718,
+        colno: 22
+      })
+    )
+
+    // #then the class name and the code location both reach telemetry
+    expect(trackTelemetryMock).toHaveBeenCalledWith(
+      'app_error_seen',
+      expect.objectContaining({
+        action: 'window_error',
+        errorCode: 'TypeError',
+        error: expect.objectContaining({
+          stack: expect.stringContaining('index-VP6Jd1Vs.js:121718:22')
+        })
+      })
+    )
+    // #and neither the message text nor the username ships
+    const serialized = JSON.stringify(trackTelemetryMock.mock.calls[0])
+    expect(serialized).not.toContain('focus')
+    expect(serialized).not.toContain('/Users/kaan')
+  })
+
   it('emits structured renderer logs', () => {
     // #given a warning breadcrumb
     trackRendererLog('warn', 'boot_failed', 'RendererBoot')

--- a/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.ts
@@ -2,6 +2,7 @@ import type { TelemetryResult } from '@memry/contracts/telemetry-api'
 import {
   buildErrorDetail,
   normalizeRejectionReason,
+  normalizeWindowError,
   toErrorCode,
   toSafeToken
 } from '@memry/contracts/telemetry-api'
@@ -56,7 +57,20 @@ export const trackRendererReady = (durationMs: number): void => {
 
 export const registerRendererDiagnostics = (): void => {
   window.addEventListener('error', (event) => {
-    trackRendererError('window_error', event.error ?? event.message)
+    // `event.error` is absent for cross-origin scripts and some Chromium failure
+    // paths; passing the bare message string on landed in telemetry as
+    // `StringError` with no stack. Normalize so a class name and the source
+    // location always survive.
+    trackRendererError(
+      'window_error',
+      normalizeWindowError({
+        error: event.error,
+        message: event.message,
+        filename: event.filename,
+        lineno: event.lineno,
+        colno: event.colno
+      })
+    )
   })
 
   window.addEventListener('unhandledrejection', (event) => {

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -189,7 +189,23 @@ landed in Loki as an unactionable bare `Error` with an empty stack. Reasons are 
 reporting: a real `Error` passes through, a cross-realm error's own frames are adopted, and
 anything else gets a stack synthesized at the handler plus a code naming the reason's type
 (`Rejection_string`, `Rejection_Object`, `Rejection_undefined`). The reason's message or value is
-never copied — only its shape.
+never copied — only its shape. A reason that crossed a structured-clone or IPC boundary keeps its
+`.name` but loses both its stack and its constructor; that name is preferred over the constructor
+name, so it reports `Rejection_TypeError` rather than collapsing to `Rejection_Error`. When the
+code is a `Rejection_*` name the stack is the handler's own frames, not the fault's — the code is
+the actionable part.
+
+A **window error** does not always carry an `error` object: cross-origin scripts and some Chromium
+failure paths report only a message and a source location, which previously landed as `StringError`
+with an empty stack and nothing to triage. The error class is recovered from the message's leading
+token (`Uncaught TypeError: …` → `TypeError`, subject to the same enum-token rule) and the
+`filename`/`lineno`/`colno` are rebuilt into a stack frame, so the code location survives the same
+frame filter and redaction as a real stack. The message text itself is still never shipped.
+
+Because a rejection reason or `event.error` can be **any** value — including a `Proxy` whose traps
+throw or an object with throwing getters — every property read in this path (including `instanceof`,
+which can trap `getPrototypeOf`) is individually guarded. A hostile value can no longer throw out of
+the diagnostics handler and destroy the report being built.
 
 The free-form exception **message is never sent**: on the desktop it can embed a note title,
 filename, or content. The stack is reduced to code-location frames only — the leading

--- a/packages/contracts/src/telemetry-api.test.ts
+++ b/packages/contracts/src/telemetry-api.test.ts
@@ -7,6 +7,7 @@ import {
   TelemetryEventSchema,
   buildErrorDetail,
   normalizeRejectionReason,
+  normalizeWindowError,
   toErrorCode
 } from './telemetry-api'
 
@@ -775,5 +776,141 @@ describe('normalizeRejectionReason', () => {
       expect(code).not.toContain('\\')
       expect(code.length).toBeLessThanOrEqual(64)
     }
+  })
+
+  it('names the reason by its own error name when it has no usable stack', () => {
+    // #given an error-shaped reason that crossed a structured-clone / IPC boundary:
+    // the name survives, the stack does not, and the constructor is plain Object
+    const cloned = { name: 'TypeError', message: 'x is not a function' }
+
+    // #then the useful name is kept instead of collapsing to Rejection_Object
+    expect(normalizeRejectionReason(cloned).name).toBe('Rejection_TypeError')
+  })
+
+  it('survives a reason whose property access throws', () => {
+    // #given a reason with hostile getters on every property the handler reads
+    const hostile = {
+      get name() {
+        throw new Error('hostile name')
+      },
+      get stack() {
+        throw new Error('hostile stack')
+      },
+      get constructor() {
+        throw new Error('hostile constructor')
+      }
+    }
+
+    // #then normalizing does not throw out of the rejection handler
+    expect(() => normalizeRejectionReason(hostile)).not.toThrow()
+    expect(normalizeRejectionReason(hostile)).toBeInstanceOf(Error)
+    expect(() => toErrorCode(hostile)).not.toThrow()
+    expect(() => buildErrorDetail(hostile)).not.toThrow()
+  })
+
+  it('survives a Proxy reason that traps instanceof and every read', () => {
+    // #given a reason that throws from `get`, `has` and `getPrototypeOf` — so even
+    // `reason instanceof Error` throws before any property is touched
+    const hostile = new Proxy(
+      {},
+      {
+        get: () => {
+          throw new Error('hostile get')
+        },
+        has: () => {
+          throw new Error('hostile has')
+        },
+        getPrototypeOf: () => {
+          throw new Error('hostile prototype')
+        }
+      }
+    )
+
+    // #then the handler still produces a safe, code-carrying Error
+    expect(() => normalizeRejectionReason(hostile)).not.toThrow()
+    expect(toErrorCode(normalizeRejectionReason(hostile))).toBe('Rejection_object')
+    expect(() => toErrorCode(hostile)).not.toThrow()
+    expect(() => buildErrorDetail(hostile)).not.toThrow()
+  })
+
+  it('survives a null-prototype reason that has no constructor at all', () => {
+    // #given a reason built with Object.create(null)
+    const bare = Object.create(null) as Record<string, unknown>
+    bare.detail = 'nope'
+
+    // #then the type is still described rather than crashing the handler
+    expect(normalizeRejectionReason(bare).name).toBe('Rejection_object')
+  })
+})
+
+describe('normalizeWindowError', () => {
+  it('passes through a real error that already has stack frames', () => {
+    // #given a window error carrying the original Error object
+    const error = new Error('boom')
+
+    // #then it is used as-is (its own stack is the actionable one)
+    expect(normalizeWindowError({ error, message: 'Uncaught Error: boom' })).toBe(error)
+  })
+
+  it('recovers the error class and source location when the error object is missing', () => {
+    // #given a window error with no `error` — the case that reached telemetry as
+    // StringError with an empty stack and nothing to triage
+    const normalized = normalizeWindowError({
+      error: null,
+      message: 'Uncaught TypeError: n.focus is not a function',
+      filename: 'file:///Users/kaan/Memry.app/out/renderer/assets/index-VP6Jd1Vs.js',
+      lineno: 121718,
+      colno: 22
+    })
+
+    // #then the class name and the code location both survive
+    expect(normalized.name).toBe('TypeError')
+    const detail = buildErrorDetail(normalized)
+    expect(detail?.stack).toContain('at ')
+    expect(detail?.stack).toContain('index-VP6Jd1Vs.js:121718:22')
+    // #and neither the message text nor the username rides along
+    expect(JSON.stringify(detail)).not.toContain('focus')
+    expect(JSON.stringify(detail)).not.toContain('/Users/kaan')
+  })
+
+  it('keeps a generic code when the message names no error class', () => {
+    // #given the opaque cross-origin case: "Script error." and no location
+    const normalized = normalizeWindowError({ error: null, message: 'Script error.' })
+
+    // #then a stable, non-leaking code is reported
+    expect(toErrorCode(normalized)).toBe('WindowError')
+    expect(normalized.message).toBe('')
+  })
+
+  it('does not adopt a message-derived name that is not an enum-ish token', () => {
+    // #given a message whose leading token is really a path
+    const normalized = normalizeWindowError({
+      error: null,
+      message: '/Users/kaan/secret.md: failed to load'
+    })
+
+    // #then the path-shaped token is rejected outright
+    expect(normalized.name).toBe('WindowError')
+    expect(toErrorCode(normalized)).not.toContain('secret')
+    expect(toErrorCode(normalized)).not.toContain('/')
+  })
+
+  it('survives a hostile error value on the event', () => {
+    // #given `event.error` is a Proxy that throws on every read
+    const hostile = new Proxy(
+      {},
+      {
+        get: () => {
+          throw new Error('hostile get')
+        },
+        getPrototypeOf: () => {
+          throw new Error('hostile prototype')
+        }
+      }
+    )
+
+    // #then the window error handler still reports something
+    expect(() => normalizeWindowError({ error: hostile, message: 'boom' })).not.toThrow()
+    expect(normalizeWindowError({ error: hostile, message: 'boom' })).toBeInstanceOf(Error)
   })
 })

--- a/packages/contracts/src/telemetry-api.ts
+++ b/packages/contracts/src/telemetry-api.ts
@@ -227,6 +227,23 @@ const keepStackFrameLines = (stack: string): string =>
 
 const SAFE_TOKEN = /^(?!.*@)(?!.*:\/\/)(?!.*[/\\]).{1,64}$/
 
+// A rejection reason or `event.error` can be ANY value: a Proxy whose traps
+// throw, an object with throwing getters, a revoked Proxy. Every read below
+// happens inside a diagnostics handler, so a throw there destroys the very
+// report we are building — the original error is then lost for good.
+const safeRead = <T>(read: () => T, fallback: T): T => {
+  try {
+    return read()
+  } catch {
+    return fallback
+  }
+}
+
+// Read one property at a time: a single hostile getter must not cost us the
+// other properties, so each read gets its own guard.
+const readProp = (value: unknown, key: string): unknown =>
+  safeRead(() => (value as Record<string, unknown> | null | undefined)?.[key], undefined)
+
 /**
  * Coerce a value into a token safe to ship as telemetry metadata: known charset,
  * ≤64 chars, no '@', '://', '/' or '\'. Falls back when the value cannot be made
@@ -256,11 +273,11 @@ const MAX_CAUSE_DEPTH = 4
 
 const typedErrorCode = (error: unknown, depth = 0): string | undefined => {
   if (!error || typeof error !== 'object' || depth > MAX_CAUSE_DEPTH) return undefined
-  const candidate = error as {
-    telemetryCode?: unknown
-    code?: unknown
-    cause?: unknown
-    errors?: unknown
+  const candidate = {
+    telemetryCode: readProp(error, 'telemetryCode'),
+    code: readProp(error, 'code'),
+    cause: readProp(error, 'cause'),
+    errors: readProp(error, 'errors')
   }
   // A richer app-assigned code wins over the bare `.code`, so a note failure
   // keeps its originating errno (NoteError.telemetryCode = NOTE_WRITE_FAILED:EBUSY)
@@ -298,27 +315,52 @@ const typedErrorCode = (error: unknown, depth = 0): string | undefined => {
 export const toErrorCode = (error: unknown): string => {
   const typed = typedErrorCode(error)
   if (typed) return typed
-  if (error instanceof Error && error.name) {
-    return toSafeToken(error.name, 'Error')
+  const name = readProp(error, 'name')
+  if (isError(error) && typeof name === 'string' && name) {
+    return toSafeToken(name, 'Error')
   }
-  if (error && typeof error === 'object' && error.constructor?.name) {
-    return toSafeToken(error.constructor.name, 'UnknownError')
+  const ctor = constructorName(error)
+  if (error && typeof error === 'object' && ctor) {
+    return toSafeToken(ctor, 'UnknownError')
   }
   if (typeof error === 'string') return 'StringError'
   return 'UnknownError'
 }
 
-const hasStackFrames = (value: unknown): value is { stack: string } => {
-  const stack = (value as { stack?: unknown } | null | undefined)?.stack
-  return typeof stack === 'string' && /^\s*at\s/m.test(stack)
+// `instanceof` itself can throw: a Proxy may trap `getPrototypeOf`, and an
+// object may define a throwing `Symbol.hasInstance`.
+const isError = (value: unknown): value is Error => safeRead(() => value instanceof Error, false)
+
+const constructorName = (value: unknown): string | undefined => {
+  const name = readProp(readProp(value, 'constructor'), 'name')
+  return typeof name === 'string' && name ? name : undefined
+}
+
+// The value's own `.stack`, but only when it holds real "    at …" frames.
+const ownStackFrames = (value: unknown): string | undefined => {
+  const stack = readProp(value, 'stack')
+  return typeof stack === 'string' && /^\s*at\s/m.test(stack) ? stack : undefined
+}
+
+// A value's own `.name`, adopted only when it is already an enum-ish token. A
+// path/email/prose name is rejected outright (not character-substituted, which
+// would still leak its structure).
+const enumishName = (value: unknown): string | undefined => {
+  const name = readProp(value, 'name')
+  return typeof name === 'string' && TYPED_ERROR_CODE.test(name) ? name : undefined
 }
 
 const rejectionTypeName = (reason: unknown): string => {
   if (reason === null) return 'Rejection_null'
   if (reason === undefined) return 'Rejection_undefined'
   if (typeof reason !== 'object') return `Rejection_${typeof reason}`
-  const ctor = (reason as { constructor?: { name?: unknown } }).constructor?.name
-  return typeof ctor === 'string' && ctor ? `Rejection_${ctor}` : 'Rejection_object'
+  // An error that crossed a structured-clone / IPC boundary keeps its `.name`
+  // ('TypeError') but loses both its stack and its constructor, so it would
+  // otherwise collapse to the unactionable Rejection_Object / Rejection_Error.
+  const own = enumishName(reason)
+  if (own) return `Rejection_${own}`
+  const ctor = constructorName(reason)
+  return ctor ? `Rejection_${ctor}` : 'Rejection_object'
 }
 
 /**
@@ -333,20 +375,70 @@ const rejectionTypeName = (reason: unknown): string => {
  * copied — only its shape. buildErrorDetail still strips the stack header.
  */
 export const normalizeRejectionReason = (reason: unknown): Error => {
-  if (reason instanceof Error && hasStackFrames(reason)) return reason
+  const frames = ownStackFrames(reason)
+  if (isError(reason) && frames) return reason
 
   const normalized = new Error()
   normalized.name = toSafeToken(rejectionTypeName(reason), 'Rejection_unknown')
-  if (hasStackFrames(reason)) {
-    normalized.stack = reason.stack
-    const name = (reason as { name?: unknown }).name
-    // Adopt the reason's own name only when it is already an enum-ish token; a
-    // path/email/prose name is rejected (not character-substituted, which would
-    // still leak its structure) and the synthesized Rejection_* name is kept.
-    if (typeof name === 'string' && TYPED_ERROR_CODE.test(name)) {
-      normalized.name = name
-    }
+  if (frames) {
+    normalized.stack = frames
+    // Adopt the reason's own name only when it is already an enum-ish token.
+    const own = enumishName(reason)
+    if (own) normalized.name = own
   }
+  // Otherwise the stack stays the one captured here, i.e. this handler's own
+  // frames. That is deliberate — there is nothing better to report — and the
+  // Rejection_* name is what marks the stack as synthetic during triage.
+  return normalized
+}
+
+export interface WindowErrorReport {
+  error?: unknown
+  message?: unknown
+  filename?: unknown
+  lineno?: unknown
+  colno?: unknown
+}
+
+// "Uncaught TypeError: x is not a function" → TypeError. Only the leading
+// <Something>Error token is read; everything after it is prose that can embed a
+// note title or path, and is never touched.
+const MESSAGE_ERROR_CLASS =
+  /^(?:Uncaught\s+(?:\(in promise\)\s+)?)?([A-Za-z][A-Za-z0-9_$]{0,55}Error)\b/
+
+const MAX_SOURCE_FILENAME = 300
+
+// "    at window_error (file:///…/index-VP6Jd1Vs.js:121718:22)" — the browser's
+// filename/lineno/colno rebuilt as a stack frame, so it survives the same frame
+// filter and redaction as a real stack. A code location, never message text.
+const sourceFrame = (report: WindowErrorReport): string | undefined => {
+  const filename = typeof report.filename === 'string' ? report.filename.trim() : ''
+  if (!filename) return undefined
+  const line = Number.isFinite(report.lineno) ? (report.lineno as number) : 0
+  const column = Number.isFinite(report.colno) ? (report.colno as number) : 0
+  return `    at window_error (${filename.slice(0, MAX_SOURCE_FILENAME)}:${line}:${column})`
+}
+
+/**
+ * Normalize a window `error` event into an Error that carries a code and a
+ * location. `event.error` is absent for cross-origin scripts and for some
+ * Chromium failure paths, and passing the bare `event.message` string on landed
+ * in telemetry as `StringError` with no stack — nothing to triage at all.
+ *
+ * Privacy: the message is only pattern-matched for its leading error class; its
+ * text is never copied. The filename rides along as a stack frame, so it goes
+ * through the same redaction as any other frame.
+ */
+export const normalizeWindowError = (report: WindowErrorReport): Error => {
+  const frames = ownStackFrames(report.error)
+  if (isError(report.error) && frames) return report.error
+
+  const normalized = new Error()
+  const messageClass =
+    typeof report.message === 'string' ? MESSAGE_ERROR_CLASS.exec(report.message)?.[1] : undefined
+  normalized.name = toSafeToken(enumishName(report.error) ?? messageClass, 'WindowError')
+  const stack = frames ?? sourceFrame(report)
+  if (stack) normalized.stack = stack
   return normalized
 }
 
@@ -362,8 +454,8 @@ export const buildErrorDetail = (
   componentStack?: string
 ): TelemetryErrorDetail | undefined => {
   const detail: TelemetryErrorDetail = {}
-  const rawStack =
-    error instanceof Error && typeof error.stack === 'string' ? error.stack : undefined
+  const stack = readProp(error, 'stack')
+  const rawStack = isError(error) && typeof stack === 'string' ? stack : undefined
   if (rawStack) {
     const frames = keepStackFrameLines(rawStack)
     if (frames) detail.stack = truncate(redactSensitive(frames), 4000)


### PR DESCRIPTION
Closes #845.

## Correction to the issue's diagnosis

`normalizeRejectionReason` was **not** throwing in the reported prod events. `at normalizeRejectionReason (…)` is the top frame of the `new Error()` it *synthesizes* when the reason has no usable frames — the code path working as designed, just producing a stack made entirely of our own frames. A real throw inside the `unhandledrejection` listener could not have produced `error_code=Rejection_Error` / `action=unhandled_rejection` at all; it would have surfaced as a `TypeError` on `window_error`.

That said, the throw hazard the issue points at is real and now has a failing-test-first fix: a reason with hostile getters (or a `Proxy` trapping `getPrototypeOf`) *did* throw out of the handler. Confirmed RED before the fix.

## What changed

**1. Every read in the diagnostics path is individually guarded** (`packages/contracts/src/telemetry-api.ts`)

A rejection reason or `event.error` can be any value. `instanceof` itself can throw (a `Proxy` may trap `getPrototypeOf`, an object may define a throwing `Symbol.hasInstance`), and so can any getter. Reads are one-per-property so a single hostile getter does not cost us the others. `toErrorCode`, `typedErrorCode` and `buildErrorDetail` are hardened too — they are called directly on raw errors elsewhere.

**2. `Rejection_Error` now resolves to the real class where one survived**

An error that crossed a structured-clone / IPC boundary keeps its `.name` but loses both its stack and its constructor, so it collapsed to `Rejection_Error` / `Rejection_Object`. The reason's own enum-ish `.name` is now preferred over the constructor name → `Rejection_TypeError`. Still gated by the existing enum-token rule, so a path/email/prose name is rejected outright.

**3. `window_error` StringError blind spot**

`event.error` is absent for cross-origin scripts and some Chromium paths; the bare `event.message` string landed as `StringError` with an empty stack. New `normalizeWindowError`:
- recovers the error class from the message's leading token (`Uncaught TypeError: …` → `TypeError`), same enum-token gate;
- rebuilds `filename`/`lineno`/`colno` as a stack frame (`    at window_error (…/index-VP6Jd1Vs.js:121718:22)`), so the code location goes through the *same* frame filter and redaction as a real stack.

## Privacy

The issue asked to carry `message` into the payload. I did not — `TelemetryErrorDetailSchema` intentionally has no free-form message field because a desktop error message can embed a note title, filename, or content. The message is only *pattern-matched* for its leading error-class token; its text is never copied. The filename ships as a stack frame, so home paths are rewritten to `~` like any other frame. Tests assert the message text and the username do not appear in the serialized event.

## Known limitation (not fixed here)

When a rejection reason has no frames of its own, the stack shipped is still this handler's own frames — there is nothing better to report. The `Rejection_*` code is what marks it as synthetic. Dropping that stack entirely would be more honest but changes a shipped telemetry field, so I left it; say the word and it's a one-line follow-up.

## Verification

- `packages/contracts` telemetry-api: 59 pass (9 new tests, all watched RED first — throwing getters, `Proxy` traps, null-prototype objects, structured-clone shape, hostile `event.error`)
- desktop renderer diagnostics: 6 pass
- desktop main + renderer telemetry: 120 / 29 pass
- `pnpm test:sync-server`: 763 pass
- `pnpm typecheck` clean · `pnpm lint` 0 errors (11 pre-existing warnings, untouched files)
- `pnpm check:contracts`, `pnpm check:architecture` pass
- `pnpm docs:impact --base origin/main --strict` covered · `pnpm docs:build` clean
