### PR TITLE
feat(startup): log a single launch phase timeline per launch (#843)

### DIFF
--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -1126,6 +1126,17 @@ describe('main index phase2 exports', () => {
 
     vi.advanceTimersByTime(10_000)
     expect(createdWindow.show).toHaveBeenCalledTimes(1)
+
+    // The reveal reports one structured timeline so the slow phase is
+    // attributable from the logs alone (#843).
+    const { createLogger } = await import('./lib/logger')
+    const scoped = vi.mocked(createLogger).mock.results[0]?.value as {
+      warn: ReturnType<typeof vi.fn>
+    }
+    const timeline = scoped.warn.mock.calls.find(([message]) => message === 'launch timeline')
+    expect(timeline?.[1]).toMatchObject({ reason: 'fallback-timeout', fallback: true })
+    expect(timeline?.[1]).toHaveProperty('windowCreatedMs')
+    expect(timeline?.[1]).toHaveProperty('shownMs')
   })
 
   it('reveals the main window on fatal load failure but ignores ERR_ABORTED', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -47,13 +47,13 @@ import { getTelemetryAuthState, getTelemetrySyncState } from './telemetry/state'
 import { getLogShip, installLogShip } from './telemetry/log-ship'
 import {
   trackChildProcessGone,
-  trackLaunchPhase,
   trackMainError,
   trackMainLog,
   trackMainUnhandledRejection,
   startActiveHeartbeat,
   stopActiveHeartbeat
 } from './telemetry/diagnostics'
+import { recordLaunchPhase, reportLaunchTimeline } from './launch-timeline'
 import { trackMainEvent } from './telemetry/track'
 import {
   startGoogleCalendarSyncRunner,
@@ -118,7 +118,6 @@ function resolveDeviceId(): string | undefined {
 }
 
 const deviceId = resolveDeviceId()
-const launchStartedAt = Date.now()
 
 let mainDiagnosticsRegistered = false
 
@@ -573,7 +572,7 @@ function createWindow(): void {
     }
   })
   if (startupBounds.maximize) mainWindow.maximize()
-  trackLaunchPhase('window_created', Date.now() - launchStartedAt)
+  recordLaunchPhase('window_created')
 
   // Remember geometry as the user resizes/moves/maximizes it, and on close.
   mainWindow.on('resize', () => scheduleWindowBoundsPersist(mainWindow))
@@ -622,8 +621,11 @@ function createWindow(): void {
     mainWindowShown = true
     clearTimeout(fallbackShowTimer)
     mainWindow.show()
-    trackLaunchPhase('window_shown', Date.now() - launchStartedAt)
+    recordLaunchPhase('window_shown')
     mainLog.info(`main window shown (${reason})`)
+    // Reveal is the moment the user stops staring at nothing, so it is where
+    // the launch timeline is complete enough to attribute a slow start (#843).
+    reportLaunchTimeline(reason)
   }
 
   const fallbackShowTimer = setTimeout(() => {
@@ -635,7 +637,7 @@ function createWindow(): void {
   mainWindow.on('ready-to-show', () => {
     // Zoom out once (equivalent to Cmd+-)
     // mainWindow.webContents.setZoomLevel(-0.8)
-    trackLaunchPhase('window_ready_to_show', Date.now() - launchStartedAt)
+    recordLaunchPhase('window_ready_to_show')
     revealMainWindow('ready-to-show')
   })
 
@@ -652,7 +654,7 @@ function createWindow(): void {
   )
 
   mainWindow.webContents.on('did-finish-load', () => {
-    trackLaunchPhase('window_did_finish_load', Date.now() - launchStartedAt)
+    recordLaunchPhase('window_did_finish_load')
   })
 
   mainWindow.on('focus', () => {
@@ -1155,7 +1157,7 @@ const appReady = app.whenReady().then(async () => {
     })
   })
 
-  trackLaunchPhase('app_ready', Date.now() - launchStartedAt)
+  recordLaunchPhase('app_ready')
 
   registerAllHandlers({ i18n: mainI18n, rebuildMenu })
 
@@ -1336,6 +1338,21 @@ const appReady = app.whenReady().then(async () => {
 
   // Open the last vault and start schedulers concurrently with renderer load.
   // The renderer subscribes to vault status events and updates automatically.
+  //
+  // Vault open runs on the main process (migrations, indexing), so it is the
+  // prime suspect when the window reveal misses its deadline. Time it up to
+  // isOpen — not to the promise, which also waits on the first full sync. Only
+  // when there is a vault to restore: a launch onto the picker has no such
+  // phase, and stamping one would report it as forever-pending.
+  if (getCurrentVaultPath()) {
+    recordLaunchPhase('vault_open_start')
+    let unsubscribeLaunchVaultStatus: (() => void) | null = onVaultStatusChanged((status) => {
+      if (!status.isOpen) return
+      recordLaunchPhase('vault_open_ready')
+      unsubscribeLaunchVaultStatus?.()
+      unsubscribeLaunchVaultStatus = null
+    })
+  }
   void autoOpenLastVault()
     .then(async () => {
       // autoOpenLastVault blocks on the vault's first fullSync; if the user quit

--- a/apps/desktop/src/main/launch-timeline.test.ts
+++ b/apps/desktop/src/main/launch-timeline.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const scopedLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+}
+const trackLaunchPhaseMock = vi.fn()
+
+vi.mock('./lib/logger', () => ({
+  createLogger: vi.fn(() => scopedLogger)
+}))
+
+vi.mock('./telemetry/diagnostics', () => ({
+  trackLaunchPhase: trackLaunchPhaseMock
+}))
+
+const LAUNCH_AT = new Date('2026-07-22T10:00:00.000Z').getTime()
+
+// The module stamps process start at import time, so every test gets a fresh
+// copy with the clock parked at LAUNCH_AT.
+async function importTimeline(): Promise<typeof import('./launch-timeline')> {
+  vi.resetModules()
+  vi.setSystemTime(LAUNCH_AT)
+  return import('./launch-timeline')
+}
+
+describe('launch timeline', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    scopedLogger.info.mockClear()
+    scopedLogger.warn.mockClear()
+    trackLaunchPhaseMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reports every phase offset in a single line on a healthy launch', async () => {
+    const { recordLaunchPhase, reportLaunchTimeline } = await importTimeline()
+
+    vi.setSystemTime(LAUNCH_AT + 300)
+    recordLaunchPhase('app_ready')
+    vi.setSystemTime(LAUNCH_AT + 420)
+    recordLaunchPhase('window_created')
+    vi.setSystemTime(LAUNCH_AT + 430)
+    recordLaunchPhase('vault_open_start')
+    vi.setSystemTime(LAUNCH_AT + 900)
+    recordLaunchPhase('vault_open_ready')
+    vi.setSystemTime(LAUNCH_AT + 1100)
+    recordLaunchPhase('window_did_finish_load')
+    vi.setSystemTime(LAUNCH_AT + 1200)
+    recordLaunchPhase('window_ready_to_show')
+    recordLaunchPhase('window_shown')
+
+    reportLaunchTimeline('ready-to-show')
+
+    expect(scopedLogger.warn).not.toHaveBeenCalled()
+    expect(scopedLogger.info).toHaveBeenCalledTimes(1)
+    expect(scopedLogger.info).toHaveBeenCalledWith('launch timeline', {
+      reason: 'ready-to-show',
+      appReadyMs: 300,
+      windowCreatedMs: 420,
+      vaultOpenStartMs: 430,
+      vaultOpenReadyMs: 900,
+      rendererLoadedMs: 1100,
+      readyToShowMs: 1200,
+      shownMs: 1200,
+      fallback: false,
+      vaultOpenPending: false
+    })
+  })
+
+  it('warns with the fallback flag and the unfinished vault open when the deadline is missed', async () => {
+    const { recordLaunchPhase, reportLaunchTimeline } = await importTimeline()
+
+    vi.setSystemTime(LAUNCH_AT + 250)
+    recordLaunchPhase('app_ready')
+    recordLaunchPhase('window_created')
+    recordLaunchPhase('vault_open_start')
+    vi.setSystemTime(LAUNCH_AT + 10_250)
+    recordLaunchPhase('window_shown')
+
+    reportLaunchTimeline('fallback-timeout')
+
+    expect(scopedLogger.info).not.toHaveBeenCalled()
+    expect(scopedLogger.warn).toHaveBeenCalledWith('launch timeline', {
+      reason: 'fallback-timeout',
+      appReadyMs: 250,
+      windowCreatedMs: 250,
+      vaultOpenStartMs: 250,
+      shownMs: 10_250,
+      fallback: true,
+      vaultOpenPending: true
+    })
+  })
+
+  it('warns on a slow launch even when ready-to-show did fire', async () => {
+    const { recordLaunchPhase, reportLaunchTimeline } = await importTimeline()
+
+    vi.setSystemTime(LAUNCH_AT + 6_000)
+    recordLaunchPhase('window_ready_to_show')
+    recordLaunchPhase('window_shown')
+
+    reportLaunchTimeline('ready-to-show')
+
+    expect(scopedLogger.info).not.toHaveBeenCalled()
+    expect(scopedLogger.warn).toHaveBeenCalledTimes(1)
+    expect(scopedLogger.warn.mock.calls[0][1]).toMatchObject({
+      reason: 'ready-to-show',
+      fallback: false,
+      shownMs: 6_000
+    })
+  })
+
+  it('emits the timeline only once per launch', async () => {
+    const { recordLaunchPhase, reportLaunchTimeline } = await importTimeline()
+
+    recordLaunchPhase('window_shown')
+    reportLaunchTimeline('ready-to-show')
+    reportLaunchTimeline('did-fail-load')
+
+    expect(scopedLogger.info).toHaveBeenCalledTimes(1)
+    expect(scopedLogger.warn).not.toHaveBeenCalled()
+  })
+
+  it('keeps the first stamp for a repeated phase but still tracks every occurrence', async () => {
+    const { recordLaunchPhase, reportLaunchTimeline } = await importTimeline()
+
+    vi.setSystemTime(LAUNCH_AT + 500)
+    recordLaunchPhase('window_created')
+    vi.setSystemTime(LAUNCH_AT + 9_000)
+    recordLaunchPhase('window_created')
+    recordLaunchPhase('window_shown')
+
+    reportLaunchTimeline('ready-to-show')
+
+    expect(scopedLogger.warn.mock.calls[0][1]).toMatchObject({ windowCreatedMs: 500 })
+    expect(trackLaunchPhaseMock).toHaveBeenCalledWith('window_created', 500)
+    expect(trackLaunchPhaseMock).toHaveBeenCalledWith('window_created', 9_000)
+  })
+})

--- a/apps/desktop/src/main/launch-timeline.ts
+++ b/apps/desktop/src/main/launch-timeline.ts
@@ -1,0 +1,76 @@
+// One-per-launch startup phase timeline. Prod installs hit the 10s
+// 'ready-to-show' fallback (#843) and the logs only said the deadline was
+// missed, never which phase ate the time. Each phase stamps its offset from
+// process start here; the reveal emits them as a single structured line so a
+// slow launch is attributable from one log record.
+import { createLogger } from './lib/logger'
+import { trackLaunchPhase } from './telemetry/diagnostics'
+
+const launchStartedAt = Date.now()
+const startupLog = createLogger('Startup')
+
+// Only warn/error records reach the diagnostic log sink, so a healthy launch
+// stays local-only and pathological ones ship for triage.
+const SLOW_LAUNCH_MS = 5_000
+
+export type LaunchPhase =
+  | 'app_ready'
+  | 'window_created'
+  | 'vault_open_start'
+  | 'vault_open_ready'
+  | 'window_did_finish_load'
+  | 'window_ready_to_show'
+  | 'window_shown'
+
+// Field names are the summary line's schema; the numeric ones are allowlisted
+// in the shared redaction module so they ship as numbers, not scrubbed text.
+const PHASE_FIELDS: Array<[LaunchPhase, string]> = [
+  ['app_ready', 'appReadyMs'],
+  ['window_created', 'windowCreatedMs'],
+  ['vault_open_start', 'vaultOpenStartMs'],
+  ['vault_open_ready', 'vaultOpenReadyMs'],
+  ['window_did_finish_load', 'rendererLoadedMs'],
+  ['window_ready_to_show', 'readyToShowMs'],
+  ['window_shown', 'shownMs']
+]
+
+const marks = new Map<LaunchPhase, number>()
+let reported = false
+
+/**
+ * Stamp a launch phase and forward it as the per-phase telemetry event.
+ * A phase can repeat (a macOS dock reopen re-creates the window, a reload
+ * re-fires did-finish-load); the timeline only ever describes the first one.
+ */
+export const recordLaunchPhase = (phase: LaunchPhase): void => {
+  const elapsedMs = Math.max(0, Date.now() - launchStartedAt)
+  if (!marks.has(phase)) marks.set(phase, elapsedMs)
+  trackLaunchPhase(phase, elapsedMs)
+}
+
+/**
+ * Emit the timeline once, at the moment the window is revealed — the point the
+ * user stops staring at nothing. `reason` names what revealed it, so a
+ * fallback reveal and a normal one are one field apart in the log sink.
+ */
+export const reportLaunchTimeline = (reason: string): void => {
+  if (reported) return
+  reported = true
+
+  const fields: Record<string, number | string | boolean> = { reason }
+  for (const [phase, field] of PHASE_FIELDS) {
+    const at = marks.get(phase)
+    if (at !== undefined) fields[field] = at
+  }
+
+  fields.fallback = reason === 'fallback-timeout'
+  // Vault open runs concurrently with renderer load. Still running at reveal
+  // makes it the prime suspect for a blocked main process, so say so instead
+  // of leaving the reader to infer it from a missing field.
+  fields.vaultOpenPending = marks.has('vault_open_start') && !marks.has('vault_open_ready')
+
+  const shownMs = marks.get('window_shown') ?? 0
+  const slow = fields.fallback === true || shownMs >= SLOW_LAUNCH_MS
+  if (slow) startupLog.warn('launch timeline', fields)
+  else startupLog.info('launch timeline', fields)
+}

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -30,6 +30,32 @@ log.error('pull failed', err)
 | Windows  | `%USERPROFILE%/AppData/Roaming/memrynote/logs/` |
 | Linux    | `~/.config/memrynote/logs/`                     |
 
+### Launch Phase Timeline
+
+`src/main/launch-timeline.ts` stamps each startup milestone's offset (ms) from process start and
+emits them as **one** structured line, `launch timeline`, when the main window is revealed. Phases
+are recorded with `recordLaunchPhase(phase)`, which also forwards each one as the per-phase
+`app_launch_phase_completed` telemetry event.
+
+| Field                                   | Meaning                                                    |
+| --------------------------------------- | ---------------------------------------------------------- |
+| `appReadyMs`                            | Electron `app.whenReady()` startup work finished           |
+| `windowCreatedMs`                       | main `BrowserWindow` constructed                           |
+| `vaultOpenStartMs` / `vaultOpenReadyMs` | vault restore started / reached `isOpen`                   |
+| `rendererLoadedMs`                      | renderer `did-finish-load`                                 |
+| `readyToShowMs`                         | first `ready-to-show` (absent when it never fired)         |
+| `shownMs`                               | window actually revealed                                   |
+| `reason`                                | `ready-to-show`, `fallback-timeout`, or `did-fail-load`    |
+| `fallback`                              | `true` when the 10s reveal fallback fired                  |
+| `vaultOpenPending`                      | vault open was still running at reveal — the prime suspect |
+
+Vault-open timing stops at `isOpen`, not at the `autoOpenLastVault()` promise, which also waits on
+the first full sync. A launch onto the vault picker records no vault phase at all.
+
+The line is logged at `warn` when the reveal came from the fallback or took ≥5s — only `warn`/
+`error` records reach the diagnostic log sink — and at `info` otherwise, so healthy launches stay
+local instead of flooding the sink.
+
 ## Telemetry
 
 Telemetry is enabled by default in production builds and off by default in development builds.
@@ -280,8 +306,8 @@ Loki adds the diagnostic detail (stacks, operational messages) that AE rows deli
   re-redaction pass has no salt, so it masks them to a fixed `<id>` instead. A fixed field allowlist
   (`level, scope, action, errorCode, appVersion, buildChannel, platform, arch, origin, workerName,
 reason, phase, mode, status, kind, result`, plus numeric metric keys like
-  `durationMs`/`itemCount`) ships verbatim; most other field values run through the same redaction as
-  the message.
+  `durationMs`/`itemCount` and the [launch timeline](#launch-phase-timeline) phase offsets) ships
+  verbatim; most other field values run through the same redaction as the message.
 - **Process lifecycle**: the main process reports a `child-process-gone` fault with a composite
   `type:reason:name` error code (e.g. `Utility:crashed:Embeddings`). The worker label comes from
   Electron's `details.name`, **not** `details.serviceName`: Electron routes a fork's `serviceName`

--- a/packages/contracts/src/redact.test.ts
+++ b/packages/contracts/src/redact.test.ts
@@ -120,6 +120,38 @@ describe('redactLogLine — allowlist + per-key strategy', () => {
     )
     expect(fields).toMatchObject({ droppedCount: 12, durationMs: 40 })
   })
+  it('passes launch timeline phase offsets through as numbers', () => {
+    const { fields } = redactLogLine(
+      {
+        message: 'launch timeline',
+        fields: {
+          reason: 'fallback-timeout',
+          appReadyMs: 300,
+          windowCreatedMs: 420,
+          vaultOpenStartMs: 430,
+          vaultOpenReadyMs: 9800,
+          rendererLoadedMs: 1100,
+          readyToShowMs: 10_100,
+          shownMs: 10_150,
+          fallback: true,
+          vaultOpenPending: false
+        }
+      },
+      opts
+    )
+    expect(fields).toMatchObject({
+      reason: 'fallback-timeout',
+      appReadyMs: 300,
+      windowCreatedMs: 420,
+      vaultOpenStartMs: 430,
+      vaultOpenReadyMs: 9800,
+      rendererLoadedMs: 1100,
+      readyToShowMs: 10_100,
+      shownMs: 10_150,
+      fallback: true,
+      vaultOpenPending: false
+    })
+  })
   it('hashes id keys even when not uuid-shaped', () => {
     const { fields } = redactLogLine(
       { message: 'x', fields: { noteId: 'abc123', signerDeviceId: 'dev-xyz' } },

--- a/packages/contracts/src/redact.ts
+++ b/packages/contracts/src/redact.ts
@@ -128,7 +128,15 @@ export const NUMERIC_FIELD_KEYS = [
   'pageCount',
   'attempt',
   'size',
-  'exitCode'
+  'exitCode',
+  // Startup phase offsets from the launch timeline (main/launch-timeline.ts).
+  'appReadyMs',
+  'windowCreatedMs',
+  'vaultOpenStartMs',
+  'vaultOpenReadyMs',
+  'rendererLoadedMs',
+  'readyToShowMs',
+  'shownMs'
 ] as const
 export const ID_FIELD_KEYS = [
   'noteId',


### PR DESCRIPTION
Closes #843.

## Why

Prod installs hit the 10s `ready-to-show` fallback (×6 / 4 installs, linux + win32, v2026.719.2) and the only log line said the deadline was missed — never which phase ate the time. Instrumentation-first: this makes the next triage round attributable.

## What

`apps/desktop/src/main/launch-timeline.ts` stamps each startup milestone's offset from process start and emits them as **one** structured line, `launch timeline`, when the window is revealed:

| Field | Meaning |
| --- | --- |
| `appReadyMs` | `app.whenReady()` startup work finished |
| `windowCreatedMs` | main `BrowserWindow` constructed |
| `vaultOpenStartMs` / `vaultOpenReadyMs` | vault restore started / reached `isOpen` |
| `rendererLoadedMs` | renderer `did-finish-load` |
| `readyToShowMs` | first `ready-to-show` (absent when it never fired) |
| `shownMs` | window actually revealed |
| `reason` | `ready-to-show`, `fallback-timeout`, or `did-fail-load` |
| `fallback` | `true` when the 10s fallback fired |
| `vaultOpenPending` | vault open still running at reveal — the prime suspect |

Notes on the choices:

- **Vault timing stops at `isOpen`**, not at the `autoOpenLastVault()` promise, which also waits on the first full sync. `isOpen` is the main-process work (migrations, indexing) that can actually block the reveal. A launch onto the picker records no vault phase at all, so it can't report a forever-pending open.
- **`warn` when the reveal came from the fallback or took ≥5s, `info` otherwise.** Only `warn`/`error` reach the diagnostic log sink, so pathological launches ship and healthy ones stay local.
- `recordLaunchPhase()` still forwards every phase to the existing `app_launch_phase_completed` telemetry event — those dashboards are unchanged, and the existing "did not fire within 10s" warn line stays put.
- The seven `*Ms` fields are allowlisted as numerics in shared redaction, otherwise they'd ship as scrubbed text instead of numbers.

## Verification

- `vitest --project main` — 4017 pass, 0 fail (5 new launch-timeline tests + fallback-reveal wiring assertion in `index.phase2.test.ts`)
- `@memry/contracts` — 1524 pass, 0 fail (new redaction passthrough test)
- `typecheck` (desktop node + web, contracts), `lint` (0 errors), `ipc:check`, contract + architecture boundary checks
- `docs:impact --base origin/main --strict` → covered; `docs:build` clean

## Follow-up

Re-triage prod logs once a release carrying this is out — the slow phase names the real issue. Note #821 (embeddings off the vault-open blocking path) is merged but unreleased and is one of the candidate causes; if it lands in the same release, `vaultOpenReadyMs` should show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)