### PR TITLE
fix(auth): stop refresh storm on a dead refresh token

### DIFF
--- a/apps/desktop/src/main/sync/token-manager.test.ts
+++ b/apps/desktop/src/main/sync/token-manager.test.ts
@@ -267,6 +267,132 @@ describe('token-manager', () => {
     })
   })
 
+  describe('refresh-token rejection latch', () => {
+    /** Access token permanently expired + refresh token the server always rejects. */
+    function givenDeadRefreshToken(): { win: { webContents: { send: ReturnType<typeof vi.fn> } } } {
+      const expiredToken = encodeToken({ exp: nowSeconds() - 100 })
+      mockRetrieveKey.mockImplementation((entry) => {
+        if (entry.account === 'access-token') {
+          return Promise.resolve(new TextEncoder().encode(expiredToken))
+        }
+        if (entry.account === 'refresh-token') {
+          return Promise.resolve(new TextEncoder().encode('dead-refresh-tok'))
+        }
+        return Promise.resolve(null)
+      })
+      mockDecodeJwt.mockReturnValue({ exp: nowSeconds() - 100 })
+      const win = { webContents: { send: vi.fn() } }
+      mockGetAllWindows.mockReturnValue([win])
+      return { win }
+    }
+
+    async function rejectWith401(): Promise<void> {
+      const { SyncServerError } = await import('./http-client')
+      mockPostToServer.mockRejectedValue(new SyncServerError('Invalid refresh token', 401))
+    }
+
+    it('does not re-hit /auth/refresh while the backoff window is open', async () => {
+      // #given a dead refresh token and many callers demanding a token
+      givenDeadRefreshToken()
+      await rejectWith401()
+
+      // #when
+      await getValidAccessToken()
+      await getValidAccessToken()
+      await getValidAccessToken()
+
+      // #then only the first attempt reached the network
+      expect(mockPostToServer).toHaveBeenCalledTimes(1)
+    })
+
+    it('goes terminal after 3 rejections and never calls the server again', async () => {
+      // #given
+      const { win } = givenDeadRefreshToken()
+      await rejectWith401()
+
+      // #when three rejections, each after its backoff window elapses
+      await getValidAccessToken()
+      await vi.advanceTimersByTimeAsync(61_000)
+      await getValidAccessToken()
+      await vi.advanceTimersByTimeAsync(301_000)
+      await getValidAccessToken()
+
+      // #then
+      expect(mockPostToServer).toHaveBeenCalledTimes(3)
+      expect(win.webContents.send).toHaveBeenCalledWith('auth:session-expired', {
+        reason: 'refresh_rejected'
+      })
+
+      // #and the latch is permanent — no further requests, ever
+      await vi.advanceTimersByTimeAsync(60 * 60_000)
+      await getValidAccessToken()
+      await getValidAccessToken()
+      expect(mockPostToServer).toHaveBeenCalledTimes(3)
+    })
+
+    it('does not schedule a fallback retry after a rejection', async () => {
+      // #given a live session whose refresh token is then rejected
+      givenDeadRefreshToken()
+      await rejectWith401()
+      scheduleTokenRefresh(900)
+
+      // #when the scheduled refresh fires and is rejected
+      await vi.advanceTimersByTimeAsync(631_000)
+
+      // #then the fallback-retry timer must not add another attempt
+      expect(mockPostToServer).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(900_000)
+      expect(mockPostToServer).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears the latch when a new session is established', async () => {
+      // #given a session that went terminal
+      givenDeadRefreshToken()
+      await rejectWith401()
+      await getValidAccessToken()
+      await vi.advanceTimersByTimeAsync(61_000)
+      await getValidAccessToken()
+      await vi.advanceTimersByTimeAsync(301_000)
+      await getValidAccessToken()
+      expect(mockPostToServer).toHaveBeenCalledTimes(3)
+
+      // #when the user signs in again (sign-in schedules the next refresh)
+      scheduleTokenRefresh(900)
+      mockPostToServer.mockResolvedValue({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresIn: 900
+      })
+
+      // #then refresh works again
+      await refreshAccessToken()
+      expect(mockPostToServer).toHaveBeenCalledTimes(4)
+    })
+
+    it('resets the rejection count after a successful refresh', async () => {
+      // #given one rejection
+      givenDeadRefreshToken()
+      await rejectWith401()
+      await refreshAccessToken()
+
+      // #when the next attempt succeeds
+      await vi.advanceTimersByTimeAsync(61_000)
+      mockPostToServer.mockResolvedValue({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresIn: 900
+      })
+      await refreshAccessToken()
+
+      // #then a later rejection starts from a clean slate (short backoff, not terminal)
+      await rejectWith401()
+      await refreshAccessToken()
+      await vi.advanceTimersByTimeAsync(61_000)
+      await refreshAccessToken()
+      expect(mockPostToServer).toHaveBeenCalledTimes(4)
+    })
+  })
+
   describe('scheduleTokenRefresh / cancelTokenRefresh', () => {
     it('schedules a refresh that fires within the jitter window', async () => {
       // #given

--- a/apps/desktop/src/main/sync/token-manager.ts
+++ b/apps/desktop/src/main/sync/token-manager.ts
@@ -2,6 +2,7 @@ import { BrowserWindow } from 'electron'
 import { decodeJwt } from 'jose'
 
 import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
+import type { SessionExpiredReason } from '@memry/contracts/ipc-events'
 import { SYNC_EVENTS } from '@memry/contracts/ipc-sync'
 import { RefreshTokenResponseSchema } from '@memry/contracts/auth-api'
 import { storeKey, retrieveKey } from '../crypto'
@@ -16,11 +17,30 @@ const REFRESH_BACKOFF_BASE_MS = 1000
 const FALLBACK_RETRY_THRESHOLD_S = 60
 const EXPIRY_SAFETY_MARGIN_SECONDS = 60
 
+/**
+ * A 401 on /auth/refresh means the refresh token itself is dead, so retrying
+ * cannot succeed — but `getValidAccessToken()` has ~15 demand-driven callers
+ * (sync passes, WS reconnects, CRDT pushes, attachments, calendar, billing),
+ * and every one of them re-entered the refresh path once the access token was
+ * permanently expired. That produced a server-side storm (prod: 58 requests in
+ * 47 minutes from one install) while the app sat in a zombie signed-in state.
+ *
+ * So a rejection latches: the window blocks all refresh traffic without
+ * touching the network, and after this many rejections the latch is permanent
+ * and the user is prompted to sign in again. The spacing exists only so a
+ * transient server-side 401 has room to recover before we declare the session
+ * dead — a truly dead token costs 3 requests instead of 58.
+ */
+const REFRESH_REJECT_TERMINAL_ATTEMPTS = 3
+const REFRESH_REJECT_BACKOFF_MS = [60_000, 300_000]
+
 let refreshTimer: ReturnType<typeof setTimeout> | null = null
 let activeRefreshPromise: Promise<boolean> | null = null
 let fallbackRetryScheduled = false
 let tokenIssuedAt = 0
 let onTokenRefreshedCallback: (() => void) | null = null
+let refreshRejections = 0
+let refreshBlockedUntil = 0
 
 export function setOnTokenRefreshed(cb: () => void): void {
   onTokenRefreshedCallback = cb
@@ -62,6 +82,11 @@ export function isTokenExpired(token: string): boolean {
 export const scheduleTokenRefresh = (expiresInSeconds: number): void => {
   cancelTokenRefresh()
   fallbackRetryScheduled = false
+  // Every path that establishes a usable session lands here (sign-in, device
+  // registration, successful refresh), so this is where a latched-dead session
+  // is released — without it, signing in again would leave sync permanently
+  // blocked by the previous session's latch.
+  clearRefreshRejections()
   tokenIssuedAt = Date.now()
   const jitter = 0.5 + Math.random() * 0.2
   const refreshAtMs = Math.floor(expiresInSeconds * jitter) * 1000
@@ -77,14 +102,54 @@ export const cancelTokenRefresh = (): void => {
   }
 }
 
-export const emitSessionExpired = (): void => {
+export const emitSessionExpired = (reason: SessionExpiredReason = 'token_expired'): void => {
   cancelTokenRefresh()
   const windows = BrowserWindow.getAllWindows()
   for (const win of windows) {
-    win.webContents.send(SYNC_EVENTS.SESSION_EXPIRED, {
-      reason: 'token_expired'
-    })
+    win.webContents.send(SYNC_EVENTS.SESSION_EXPIRED, { reason })
   }
+}
+
+const clearRefreshRejections = (): void => {
+  refreshRejections = 0
+  refreshBlockedUntil = 0
+}
+
+const isRefreshBlocked = (): boolean => Date.now() < refreshBlockedUntil
+
+/**
+ * The server rejected the refresh token. Never retried inline — the caller
+ * returns immediately and the latch keeps every other caller off the network
+ * until the backoff window elapses (or forever, once terminal).
+ */
+const handleRefreshRejected = (error: SyncServerError): void => {
+  refreshRejections += 1
+  cancelTokenRefresh()
+
+  if (refreshRejections >= REFRESH_REJECT_TERMINAL_ATTEMPTS) {
+    refreshBlockedUntil = Number.POSITIVE_INFINITY
+    log.error('Refresh token rejected — session is dead, re-authentication required', {
+      attempts: refreshRejections,
+      statusCode: error.statusCode,
+      serverError: error.serverError
+    })
+    emitSessionExpired('refresh_rejected')
+    return
+  }
+
+  const backoffMs =
+    REFRESH_REJECT_BACKOFF_MS[refreshRejections - 1] ?? REFRESH_REJECT_BACKOFF_MS.at(-1)!
+  refreshBlockedUntil = Date.now() + backoffMs
+  log.warn('Refresh token rejected by server', {
+    attempt: refreshRejections,
+    of: REFRESH_REJECT_TERMINAL_ATTEMPTS,
+    retryInSeconds: Math.floor(backoffMs / 1000),
+    statusCode: error.statusCode,
+    serverError: error.serverError
+  })
+  // Keep the pre-existing advisory signal on the way to terminal, so the user
+  // isn't left with a silently stalled sync for the whole backoff span.
+  emitSessionExpired('token_expired')
 }
 
 const doRefreshAccessToken = async (): Promise<boolean> => {
@@ -107,7 +172,16 @@ const doRefreshAccessToken = async (): Promise<boolean> => {
       onTokenRefreshedCallback?.()
       return true
     } catch (error: unknown) {
-      if (error instanceof SyncServerError && error.statusCode === 401) break
+      if (error instanceof SyncServerError && error.statusCode === 401) {
+        handleRefreshRejected(error)
+        return false
+      }
+
+      log.warn('Token refresh attempt failed', {
+        attempt: attempt + 1,
+        of: REFRESH_MAX_RETRIES,
+        error: error instanceof Error ? error.message : String(error)
+      })
 
       if (attempt < REFRESH_MAX_RETRIES - 1) {
         const backoff = REFRESH_BACKOFF_BASE_MS * Math.pow(2, attempt)
@@ -135,6 +209,13 @@ const doRefreshAccessToken = async (): Promise<boolean> => {
 }
 
 export const refreshAccessToken = async (): Promise<boolean> => {
+  if (isRefreshBlocked()) {
+    log.debug('Refresh suppressed: refresh token was rejected', {
+      rejections: refreshRejections,
+      terminal: refreshBlockedUntil === Number.POSITIVE_INFINITY
+    })
+    return false
+  }
   if (activeRefreshPromise) return activeRefreshPromise
 
   activeRefreshPromise = doRefreshAccessToken()
@@ -164,4 +245,5 @@ export function resetTokenManagerState(): void {
   fallbackRetryScheduled = false
   tokenIssuedAt = 0
   onTokenRefreshedCallback = null
+  clearRefreshRejections()
 }

--- a/apps/desktop/src/renderer/src/components/sync/session-expired-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/session-expired-dialog.tsx
@@ -1,0 +1,57 @@
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { AlertTriangle } from '@/lib/icons'
+
+interface SessionExpiredDialogProps {
+  open: boolean
+  onSignOut: () => void
+}
+
+/**
+ * Shown when the server rejected this device's refresh token outright, so no
+ * amount of retrying can revive the session. Without this the app sits in a
+ * zombie signed-in state: the UI looks connected while sync is dead.
+ *
+ * Signing out is deliberately the user's click — the session is dead on the
+ * server either way, but clearing local key material is not something to do
+ * behind their back on the strength of an HTTP status.
+ */
+export function SessionExpiredDialog({
+  open,
+  onSignOut
+}: SessionExpiredDialogProps): React.JSX.Element {
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent className="sm:max-w-md">
+        <AlertDialogHeader>
+          <div className="flex items-center gap-3 mb-1">
+            <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-amber-500/10 dark:bg-amber-400/10">
+              <AlertTriangle
+                className="w-5 h-5 text-amber-600 dark:text-amber-400"
+                aria-hidden="true"
+              />
+            </div>
+            <AlertDialogTitle className="font-display text-xl tracking-tight">
+              {'Your session has ended'}
+            </AlertDialogTitle>
+          </div>
+          <AlertDialogDescription className="font-serif text-[15px] leading-relaxed">
+            {
+              'This device has been signed out of your account, so syncing has stopped. Your notes on this device are untouched. Sign in again to resume syncing.'
+            }
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <Button onClick={onSignOut}>{'Sign in again'}</Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.test.tsx
@@ -21,7 +21,7 @@ let itemSyncedListeners: EventCallback[] = []
 let initialSyncProgressListeners: EventCallback[] = []
 let queueClearedListeners: VoidCallback[] = []
 let clockSkewWarningListeners: VoidCallback[] = []
-let sessionExpiredListeners: VoidCallback[] = []
+let sessionExpiredListeners: EventCallback[] = []
 let deviceRevokedListeners: EventCallback[] = []
 let securityWarningListeners: EventCallback[] = []
 let certificatePinFailedListeners: VoidCallback[] = []
@@ -455,7 +455,7 @@ describe('SyncProvider', () => {
       await vi.waitFor(() => expect(sessionExpiredListeners.length).toBeGreaterThan(0))
 
       act(() => {
-        for (const cb of sessionExpiredListeners) cb()
+        for (const cb of sessionExpiredListeners) cb({ reason: 'token_expired' })
       })
       expect(toastMock.error).toHaveBeenCalledWith(
         'Your session has expired. Sign in again to continue syncing.',
@@ -467,6 +467,21 @@ describe('SyncProvider', () => {
       })
       await vi.waitFor(() =>
         expect(result.current.state.error).toBe('This device has been removed from your account.')
+      )
+    })
+
+    it('#then prompts for re-auth instead of a toast when the refresh token is rejected', async () => {
+      renderHook(() => useSync(), { wrapper })
+      await vi.waitFor(() => expect(sessionExpiredListeners.length).toBeGreaterThan(0))
+
+      act(() => {
+        for (const cb of sessionExpiredListeners) cb({ reason: 'refresh_rejected' })
+      })
+
+      await screen.findByText('Your session has ended')
+      expect(toastMock.error).not.toHaveBeenCalledWith(
+        'Your session has expired. Sign in again to continue syncing.',
+        { duration: 8000 }
       )
     })
 

--- a/apps/desktop/src/renderer/src/contexts/sync-context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/sync-context.tsx
@@ -14,6 +14,7 @@ import { useAuth } from './auth-context'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { DeviceRevokedDialog } from '@/components/sync/device-revoked-dialog'
 import { VaultRecoveryDialog } from '@/components/sync/vault-recovery-dialog'
+import { SessionExpiredDialog } from '@/components/sync/session-expired-dialog'
 import type {
   InitialSyncPhase,
   LinkingRequestEvent,
@@ -218,6 +219,7 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
   const [state, dispatch] = useReducer(syncReducer, initialState)
   const [linkingRequest, setLinkingRequest] = useState<LinkingRequestEvent | null>(null)
   const [vaultRecovery, setVaultRecovery] = useState<VaultRecoveryNeededEvent | null>(null)
+  const [reauthRequired, setReauthRequired] = useState(false)
   const sessionExpiredRef = useRef(state.sessionExpired)
   useEffect(() => {
     sessionExpiredRef.current = state.sessionExpired
@@ -331,9 +333,13 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
     )
 
     cleanups.push(
-      window.api.onSessionExpired(() => {
+      window.api.onSessionExpired((event) => {
         if (cancelled) return
-        if (!sessionExpiredRef.current) {
+        // A rejected refresh token can never recover — the toast is too easy to
+        // miss for a session that is over, so escalate to a blocking prompt.
+        if (event.reason === 'refresh_rejected') {
+          setReauthRequired(true)
+        } else if (!sessionExpiredRef.current) {
           toast.error(t('sync.authExpired'), { duration: 8000 })
         }
         dispatch({ type: 'SESSION_EXPIRED', error: t('sync.authExpired') })
@@ -541,6 +547,7 @@ export function SyncProvider({ children }: SyncProviderProps): React.JSX.Element
         onDismiss={clearVaultRecovery}
         onSignOut={handleDeviceRevokedSignOut}
       />
+      <SessionExpiredDialog open={reauthRequired} onSignOut={handleDeviceRevokedSignOut} />
     </SyncContext.Provider>
   )
 }

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -244,11 +244,28 @@ phrase can restore the correct key. See
 | ------------------ | ------------------------------------------------------------------------------------------ |
 | Offline            | Outbox queues; retry with backoff                                                          |
 | Auth expired (401) | Refresh the access token and retry the request once; only a failed refresh prompts sign-in |
+| Refresh rejected   | Stop refreshing entirely (see below); prompt the user to sign in again                     |
 | Payment required   | Sync stays local-only until a paid plan is active                                          |
 | Quota exceeded     | Surfaces in [Settings → Vault](/user-guide/settings#vault)                                 |
 | Server unavailable | Exponential backoff; status indicator turns yellow                                         |
 | Blob hash mismatch | Reject the item; log; alert health view                                                    |
 | Vault-key mismatch | Stop pulling without branding items; prompt recovery; sign out to restore the correct key  |
+
+### Rejected Refresh Tokens
+
+A 401 on `/auth/refresh` means the refresh token itself is dead, so no retry can succeed. Because
+every part of the app asks for a valid access token on demand — sync passes, websocket reconnects,
+CRDT pushes, attachment transfers, calendar sync, billing checks — an unlatched failure would let
+each of them re-enter the refresh path forever.
+
+A rejection therefore latches. The first two rejections open a backoff window (1 minute, then 5)
+during which no refresh request reaches the network at all; that spacing exists only so a transient
+server-side 401 can recover before the session is written off. The third rejection is terminal: the
+client stops refreshing for good and prompts the user to sign in again.
+
+Signing out remains an explicit user action. The session is already dead on the server, but local
+key material is never cleared on the strength of an HTTP status alone. Signing in again clears the
+latch and sync resumes.
 
 ## Encryption Stays End-to-End
 

--- a/packages/contracts/src/ipc-events.ts
+++ b/packages/contracts/src/ipc-events.ts
@@ -107,7 +107,16 @@ export interface SyncResumedEvent {
   pendingCount: number
 }
 
-export type SessionExpiredReason = 'token_expired' | 'device_revoked' | 'server_error'
+/**
+ * 'refresh_rejected' — the server rejected the refresh token itself (401
+ * AUTH_INVALID_TOKEN). Unlike 'token_expired' this can never resolve on its
+ * own: the client stops refreshing entirely and the user must sign in again.
+ */
+export type SessionExpiredReason =
+  | 'token_expired'
+  | 'device_revoked'
+  | 'server_error'
+  | 'refresh_rejected'
 
 export interface SessionExpiredEvent {
   reason: SessionExpiredReason

--- a/scripts/check-staged-secrets.mjs
+++ b/scripts/check-staged-secrets.mjs
@@ -112,6 +112,8 @@ function isCodeDeclarationValue(filePath, value) {
   const normalized = normalizeValue(value)
 
   return (
+    // numeric literals (`tokenIssuedAt = 0`) carry no secret material
+    /^-?\d+(?:\.\d+)?$/.test(normalized) ||
     normalized.startsWith('() =>') ||
     /^[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$/i.test(normalized) ||
     isSourceCodeReferenceValue(filePath, value)

--- a/scripts/check-staged-secrets.test.mjs
+++ b/scripts/check-staged-secrets.test.mjs
@@ -21,6 +21,16 @@ describe('check-staged-secrets JSX handling', () => {
   })
 })
 
+describe('check-staged-secrets numeric values', () => {
+  it('ignores a token-named variable reset to a number', () => {
+    assert.deepEqual(rules('  tokenIssuedAt = 0'), [])
+  })
+
+  it('still flags a token-named prop assigned a long quoted number-like string', () => {
+    assert.deepEqual(rules('  token={"01234567890123456789"}'), ['high-risk-secret-assignment'])
+  })
+})
+
 describe('check-staged-secrets constructor values', () => {
   it('ignores a secret-named key assigned a constructor call over a code reference', () => {
     assert.deepEqual(rules('  signingSecretKey: new Uint8Array(signingSecretKey),'), [])


### PR DESCRIPTION
Fixes #839.

## Root cause

A 401 on `POST /auth/refresh` was already terminal *within a single refresh call* — `doRefreshAccessToken` broke out of its retry loop and called `emitSessionExpired()`. But `emitSessionExpired()` is purely advisory: it cancels the scheduled timer and sends an IPC event. Nothing latched.

`getValidAccessToken()` has ~15 demand-driven callers — sync passes, websocket reconnects, CRDT pushes, attachment transfers, calendar push, billing, canvas assets, device handlers. Once the access token was permanently expired, every one of them re-entered the refresh path on its own schedule. That is the storm: 58 requests in 47 minutes from one install (~1 per 49s, matching sync-poll cadence), with the app sitting in a zombie signed-in state and the desktop logging nothing.

## Fix

**Latch** (`token-manager.ts`) — a rejection records itself and blocks the refresh path:

- rejections 1 and 2 open a backoff window (60s, then 300s) during which `refreshAccessToken()` returns `false` without touching the network;
- rejection 3 is terminal — the latch is permanent for the process and `session-expired` is emitted with a new `refresh_rejected` reason;
- the spacing exists only so a transient server-side 401 can recover before the session is written off. A truly dead token now costs 3 requests instead of 58;
- the fallback-retry timer is no longer scheduled after a rejection (it was another storm contributor);
- `scheduleTokenRefresh()` clears the latch, so signing in again resumes sync. `resetTokenManagerState()` clears it too.

**Logging** — the desktop was silent on this path. Now: `warn` per rejection (attempt count, status, server error code, next retry), `error` at terminal, and `warn` on non-401 refresh failures, which were also unlogged.

**Re-auth prompt** — new `SessionExpiredDialog`, opened only on `refresh_rejected`. The pre-existing advisory toast still fires on the way to terminal, so there is no silent gap.

Signing out stays the user's click: the session is already dead server-side, but local key material is not cleared on the strength of an HTTP status. The button routes into the existing `logout()` teardown.

## Backward compatibility

`SessionExpiredReason` gains a member — additive, and the renderer previously ignored `reason` entirely. No protocol, schema, or server change.

## Incidental

The staged-secret scanner reads whole staged files, so it flagged the pre-existing `tokenIssuedAt = 0` line and blocked any commit touching `token-manager.ts`. Numeric literals are now recognised as code, with a test.

## Verification

- `pnpm test:desktop` — green (exit 0)
- `token-manager.test.ts` — 23 passed, including 5 new tests that reproduce the storm (red before the fix)
- `sync-context.test.tsx` — 19 passed, including a new test for the dialog path
- `packages/contracts` `ipc-events.test.ts` — 20 passed
- `scripts/check-staged-secrets.test.mjs` — 6 passed
- `pnpm typecheck` — 16/16 · `pnpm lint` — 0 errors · `pnpm ipc:check` — up to date
- `pnpm docs:impact --base origin/main --strict` and `pnpm docs:build` — green

Not verified end-to-end against a live dead refresh token; the behaviour is covered by unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)