### PR TITLE
fix(sync): renew WS token in place instead of expiry-driven reconnect churn

### DIFF
--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -619,6 +619,9 @@ export class SyncEngine extends EventEmitter {
       }
       case 'heartbeat':
         break
+      case 'auth_ok':
+        log.debug('WS auth refreshed', { exp: message.payload?.exp })
+        break
       case 'error':
         if (message.payload?.code === 'AUTH_DEVICE_REVOKED') {
           this.handleDeviceRevoked()

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -52,6 +52,7 @@ const runtimeMocks = vi.hoisted(() => {
   class WebSocketManager {
     static instances: WebSocketManager[] = []
     disconnect = vi.fn()
+    refreshAuth = vi.fn(async () => undefined)
     constructor(public options: unknown) {
       WebSocketManager.instances.push(this)
     }
@@ -541,6 +542,9 @@ describe('sync runtime', () => {
     const onTokenRefreshed = runtimeMocks.setOnTokenRefreshed.mock.calls[0][0] as () => void
     onTokenRefreshed()
     expect(queue.resume).toHaveBeenCalledTimes(2)
+    // Fresh token is handed to the live socket so the server extends it in place
+    // rather than dropping it with WS_TOKEN_EXPIRED.
+    expect(runtimeMocks.WebSocketManager.instances[0].refreshAuth).toHaveBeenCalledTimes(1)
 
     await runtime.stopSyncRuntime()
     expect(runtimeMocks.crdtProvider.pushAllSnapshots).toHaveBeenCalledTimes(1)

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -586,17 +586,20 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
           crdtQueue.pause()
         }
       })
-      setOnTokenRefreshed(() => {
-        if (network.online) {
-          crdtQueue.resume()
-        }
-      })
-
       const ws = new WebSocketManager({
         getAccessToken: () => getValidAccessToken(),
         getAppVersion: () => app.getVersion(),
         isOnline: () => network.online,
         serverUrl: resolveSyncServerUrl()
+      })
+
+      setOnTokenRefreshed(() => {
+        if (network.online) {
+          crdtQueue.resume()
+        }
+        // Hand the fresh token to the live socket so the server extends it in
+        // place instead of dropping it with WS_TOKEN_EXPIRED at expiry.
+        void ws.refreshAuth()
       })
 
       const engine = new SyncEngine({

--- a/apps/desktop/src/main/sync/websocket.test.ts
+++ b/apps/desktop/src/main/sync/websocket.test.ts
@@ -171,6 +171,59 @@ describe('WebSocketManager', () => {
     })
   })
 
+  describe('#given connected WebSocket #when refreshAuth is called', () => {
+    it('#then sends the fresh access token over the live socket', async () => {
+      const deps = createMockDeps()
+      const manager = new WebSocketManager(deps)
+      await manager.connect()
+      lastWs().simulateOpen()
+
+      vi.mocked(deps.getAccessToken).mockResolvedValue('renewed-token')
+      await manager.refreshAuth()
+
+      expect(lastWs().send).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'auth', payload: { token: 'renewed-token' } })
+      )
+    })
+
+    it('#then accepts the server auth_ok ack without an error', async () => {
+      const manager = new WebSocketManager(createMockDeps())
+      const messageSpy = vi.fn()
+      const errorSpy = vi.fn()
+      manager.on('message', messageSpy)
+      manager.on('error', errorSpy)
+
+      await manager.connect()
+      lastWs().simulateOpen()
+      lastWs().simulateMessage({ type: 'auth_ok', payload: { exp: 123 } })
+
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(messageSpy).toHaveBeenCalledWith({ type: 'auth_ok', payload: { exp: 123 } })
+    })
+
+    it('#then does nothing when the socket is not open', async () => {
+      const deps = createMockDeps()
+      const manager = new WebSocketManager(deps)
+      await manager.connect()
+
+      await manager.refreshAuth()
+
+      expect(lastWs().send).not.toHaveBeenCalled()
+    })
+
+    it('#then does nothing when no token is available', async () => {
+      const deps = createMockDeps()
+      const manager = new WebSocketManager(deps)
+      await manager.connect()
+      lastWs().simulateOpen()
+
+      vi.mocked(deps.getAccessToken).mockResolvedValue(null)
+      await manager.refreshAuth()
+
+      expect(lastWs().send).not.toHaveBeenCalled()
+    })
+  })
+
   describe('#given connected WebSocket #when heartbeat timeout fires', () => {
     it('#then terminates connection after 31s', async () => {
       const manager = new WebSocketManager(createMockDeps())

--- a/apps/desktop/src/main/sync/websocket.ts
+++ b/apps/desktop/src/main/sync/websocket.ts
@@ -22,6 +22,7 @@ const WebSocketMessageSchema = z.object({
     'crdt_updated',
     'calendar_changes_available',
     'heartbeat',
+    'auth_ok',
     'error',
     'linking_request',
     'linking_approved'
@@ -199,6 +200,29 @@ export class WebSocketManager extends EventEmitter {
       }
       this.emit('error', err)
     })
+  }
+
+  /**
+   * Push the current access token over the live socket so the server can extend
+   * the connection's expiry in place. Called when token-manager refreshes, which
+   * happens well before expiry — without it the server drops the socket with
+   * WS_TOKEN_EXPIRED and we pay a full reconnect every token lifetime.
+   * Best-effort: on failure the socket still expires and reconnects as before.
+   */
+  async refreshAuth(): Promise<void> {
+    if (!this._connected || this.ws?.readyState !== WebSocket.OPEN) return
+
+    try {
+      const token = await this.deps.getAccessToken()
+      if (!token) return
+      if (this.ws?.readyState !== WebSocket.OPEN) return
+      this.ws.send(JSON.stringify({ type: 'auth', payload: { token } }))
+      log.debug('Sent WebSocket auth refresh')
+    } catch (err) {
+      log.warn('WebSocket auth refresh failed', {
+        message: err instanceof Error ? err.message : String(err)
+      })
+    }
   }
 
   disconnect(): void {

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -229,6 +229,25 @@ list.
 | `POST /devices/*`         | mixed     | Linking, listing, revoking                                                     |
 | `POST /keys/*`            | mixed     | Key sealing during link, rotation                                              |
 
+## Realtime Socket Auth
+
+The change-notification WebSocket (`/sync/ws`) authenticates once at handshake with a Bearer access
+token. The server pins that token's expiry to the connection and sweeps every 60s, closing any
+socket whose token has expired (`WS_TOKEN_EXPIRED`, close code 4003).
+
+Because access tokens are short-lived, the client renews the connection **in place** rather than
+riding each token to expiry. Whenever the token manager refreshes — the same cycle that serves HTTP
+requests, and always well before expiry — the client sends the fresh token over the open socket:
+
+| Direction       | Message                                 | Meaning                                       |
+| --------------- | --------------------------------------- | --------------------------------------------- |
+| client → server | `{ type: 'auth', payload: { token } }`  | Renew this connection with a fresh token      |
+| server → client | `{ type: 'auth_ok', payload: { exp } }` | Accepted; the connection now expires at `exp` |
+
+The server verifies the token and requires it to belong to the same device before extending the
+expiry. Renewal is best-effort: a rejected or unanswered `auth` leaves the original expiry in place,
+so the socket closes at expiry and the client reconnects with a fresh token as it otherwise would.
+
 ## Vault-Key Verification
 
 Before syncing — and whenever an entire pull page fails to decrypt — the client verifies its local
@@ -240,15 +259,16 @@ phrase can restore the correct key. See
 
 ## Error Modes
 
-| Failure            | Behavior                                                                                   |
-| ------------------ | ------------------------------------------------------------------------------------------ |
-| Offline            | Outbox queues; retry with backoff                                                          |
-| Auth expired (401) | Refresh the access token and retry the request once; only a failed refresh prompts sign-in |
-| Payment required   | Sync stays local-only until a paid plan is active                                          |
-| Quota exceeded     | Surfaces in [Settings → Vault](/user-guide/settings#vault)                                 |
-| Server unavailable | Exponential backoff; status indicator turns yellow                                         |
-| Blob hash mismatch | Reject the item; log; alert health view                                                    |
-| Vault-key mismatch | Stop pulling without branding items; prompt recovery; sign out to restore the correct key  |
+| Failure             | Behavior                                                                                   |
+| ------------------- | ------------------------------------------------------------------------------------------ |
+| Offline             | Outbox queues; retry with backoff                                                          |
+| Auth expired (401)  | Refresh the access token and retry the request once; only a failed refresh prompts sign-in |
+| Payment required    | Sync stays local-only until a paid plan is active                                          |
+| Quota exceeded      | Surfaces in [Settings → Vault](/user-guide/settings#vault)                                 |
+| Socket token expiry | In-place renewal over the open socket; a rejected renewal falls back to close + reconnect  |
+| Server unavailable  | Exponential backoff; status indicator turns yellow                                         |
+| Blob hash mismatch  | Reject the item; log; alert health view                                                    |
+| Vault-key mismatch  | Stop pulling without branding items; prompt recovery; sign out to restore the correct key  |
 
 ## Encryption Stays End-to-End
 

--- a/apps/sync-server/src/durable-objects/user-sync-state.test.ts
+++ b/apps/sync-server/src/durable-objects/user-sync-state.test.ts
@@ -67,6 +67,9 @@ function broadcastRequest(excludeDeviceId: string, cursor: number, vaultId?: str
 describe('UserSyncState', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // mockReset (not clearAllMocks) drops leftover *Once queues so a test that
+    // stops short of consuming one cannot leak claims into the next test.
+    hoisted.verifyAccessTokenMock.mockReset()
     hoisted.verifyAccessTokenMock.mockResolvedValue({
       userId: 'user-1',
       deviceId: 'device-1',
@@ -284,7 +287,7 @@ describe('UserSyncState', () => {
 
       // #when - send 101 messages (limit is 100)
       for (let i = 0; i <= 100; i++) {
-        doObj.webSocketMessage(ws)
+        await doObj.webSocketMessage(ws, '{}')
       }
 
       // #then
@@ -294,6 +297,97 @@ describe('UserSyncState', () => {
 
       const errorMsg = mockWs.sentMessages.find((m) => m.includes(ErrorCodes.WS_RATE_LIMITED))
       expect(errorMsg).toBeDefined()
+    })
+  })
+
+  describe('webSocketMessage (auth refresh)', () => {
+    async function connectExpiring(doObj: UserSyncState, exp: number) {
+      hoisted.verifyAccessTokenMock.mockResolvedValueOnce({
+        userId: 'user-1',
+        deviceId: 'device-1',
+        exp
+      })
+      await doObj.fetch(connectRequest())
+      const sockets = getCtx(doObj).getWebSockets('device:device-1')
+      return sockets[0] as unknown as MockWebSocket
+    }
+
+    function authMessage(token = 'fresh-token'): string {
+      return JSON.stringify({ type: 'auth', payload: { token } })
+    }
+
+    it('extends tokenExp so the alarm no longer closes the socket', async () => {
+      // #given a socket whose original token has already expired
+      const doObj = createDO()
+      const ws = await connectExpiring(doObj, Math.floor(Date.now() / 1000) - 60)
+
+      // #when the client re-authenticates with a fresh token
+      const freshExp = Math.floor(Date.now() / 1000) + 900
+      hoisted.verifyAccessTokenMock.mockResolvedValueOnce({
+        userId: 'user-1',
+        deviceId: 'device-1',
+        exp: freshExp
+      })
+      await doObj.webSocketMessage(ws as unknown as WebSocket, authMessage())
+      await doObj.alarm()
+
+      // #then the socket survives and is acked
+      expect(ws.closeCalled).toBe(false)
+      expect(ws.sentMessages).toContainEqual(
+        JSON.stringify({ type: 'auth_ok', payload: { exp: freshExp } })
+      )
+      expect((ws.deserializeAttachment() as { tokenExp: number }).tokenExp).toBe(freshExp)
+    })
+
+    it('rejects an invalid token without closing the socket', async () => {
+      // #given
+      const doObj = createDO()
+      const originalExp = Math.floor(Date.now() / 1000) + 900
+      const ws = await connectExpiring(doObj, originalExp)
+
+      // #when
+      hoisted.verifyAccessTokenMock.mockRejectedValueOnce(new Error('invalid'))
+      await doObj.webSocketMessage(ws as unknown as WebSocket, authMessage('bad-token'))
+
+      // #then the existing (still valid) token keeps the socket alive
+      expect(ws.closeCalled).toBe(false)
+      expect((ws.deserializeAttachment() as { tokenExp: number }).tokenExp).toBe(originalExp)
+      expect(ws.sentMessages.find((m) => m.includes(ErrorCodes.AUTH_INVALID_TOKEN))).toBeDefined()
+    })
+
+    it('rejects a token issued for a different device', async () => {
+      // #given
+      const doObj = createDO()
+      const originalExp = Math.floor(Date.now() / 1000) + 900
+      const ws = await connectExpiring(doObj, originalExp)
+
+      // #when
+      hoisted.verifyAccessTokenMock.mockResolvedValueOnce({
+        userId: 'user-1',
+        deviceId: 'device-2',
+        exp: Math.floor(Date.now() / 1000) + 9000
+      })
+      await doObj.webSocketMessage(ws as unknown as WebSocket, authMessage())
+
+      // #then
+      expect((ws.deserializeAttachment() as { tokenExp: number }).tokenExp).toBe(originalExp)
+      expect(ws.sentMessages.find((m) => m.includes(ErrorCodes.AUTH_INVALID_TOKEN))).toBeDefined()
+    })
+
+    it('ignores non-JSON and non-auth messages', async () => {
+      // #given
+      const doObj = createDO()
+      const originalExp = Math.floor(Date.now() / 1000) + 900
+      const ws = await connectExpiring(doObj, originalExp)
+
+      // #when
+      await doObj.webSocketMessage(ws as unknown as WebSocket, 'not json')
+      await doObj.webSocketMessage(ws as unknown as WebSocket, JSON.stringify({ type: 'noop' }))
+
+      // #then
+      expect(ws.sentMessages).toHaveLength(0)
+      expect((ws.deserializeAttachment() as { tokenExp: number }).tokenExp).toBe(originalExp)
+      expect(hoisted.verifyAccessTokenMock).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -581,7 +675,7 @@ describe('UserSyncState', () => {
       }
 
       // #when
-      doObj.webSocketMessage(brokenWs as never)
+      doObj.webSocketMessage(brokenWs as never, '{}')
 
       // #then
       expect(fetchMock).toHaveBeenCalledTimes(1)

--- a/apps/sync-server/src/durable-objects/user-sync-state.ts
+++ b/apps/sync-server/src/durable-objects/user-sync-state.ts
@@ -25,6 +25,25 @@ const CLOSE_CODE_DEVICE_REVOKED = 4004
 const CLOSE_CODE_RATE_LIMITED = 4008
 const CLOSE_CODE_VERSION_INCOMPATIBLE = 4009
 
+function parseClientMessage(
+  message: string | ArrayBuffer
+): { type: string; payload?: unknown } | null {
+  if (typeof message !== 'string') return null
+  try {
+    const parsed: unknown = JSON.parse(message)
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as { type?: unknown }).type === 'string'
+    ) {
+      return parsed as { type: string; payload?: unknown }
+    }
+  } catch {
+    // Not JSON — nothing to handle
+  }
+  return null
+}
+
 export function isVersionBelow(version: string, minimum: string): boolean {
   const parse = (v: string) => v.split('.').map(Number)
   const [aMaj, aMin = 0, aPat = 0] = parse(version)
@@ -250,7 +269,7 @@ export class UserSyncState extends DurableObject<Bindings> {
     ])
   }
 
-  webSocketMessage(ws: WebSocket): void {
+  webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void | Promise<void> {
     try {
       const attachment = ws.deserializeAttachment() as WsAttachment | null
       if (!attachment) {
@@ -278,10 +297,62 @@ export class UserSyncState extends DurableObject<Bindings> {
           })
         )
         ws.close(CLOSE_CODE_RATE_LIMITED, 'Rate limit exceeded')
+        return
+      }
+
+      const parsed = parseClientMessage(message)
+      if (parsed?.type === 'auth') {
+        const token = (parsed.payload as { token?: unknown } | undefined)?.token
+        return this.handleAuthRefresh(ws, attachment, token).catch((error) =>
+          this.captureError('ws_auth_refresh', error)
+        )
       }
     } catch (error) {
       void this.captureError('ws_message', error)
     }
+  }
+
+  /**
+   * In-place token renewal: the client pushes a freshly refreshed access token
+   * over the live socket so the alarm's expiry sweep never has to drop it.
+   * Rejection is non-fatal — the socket keeps its existing tokenExp and the
+   * alarm closes it at the original expiry, which is the pre-renewal behaviour.
+   */
+  private async handleAuthRefresh(
+    ws: WebSocket,
+    attachment: WsAttachment,
+    token: unknown
+  ): Promise<void> {
+    const reject = (message: string): void => {
+      ws.send(
+        JSON.stringify({
+          type: 'error',
+          payload: { code: ErrorCodes.AUTH_INVALID_TOKEN, message }
+        })
+      )
+    }
+
+    if (typeof token !== 'string' || token.length === 0) {
+      reject('Missing token')
+      return
+    }
+
+    let claims: { userId: string; deviceId: string; exp: number }
+    try {
+      claims = await verifyAccessToken(token, this.env.JWT_PUBLIC_KEY)
+    } catch {
+      reject('Invalid token')
+      return
+    }
+
+    if (claims.deviceId !== attachment.deviceId) {
+      reject('Token does not match connection')
+      return
+    }
+
+    attachment.tokenExp = claims.exp
+    ws.serializeAttachment(attachment)
+    ws.send(JSON.stringify({ type: 'auth_ok', payload: { exp: claims.exp } }))
   }
 
   webSocketClose(ws: WebSocket, code: number, reason: string): void {


### PR DESCRIPTION
## Summary

Closes #841.

`WS_TOKEN_EXPIRED` ×67 over Jul 19–22 for just 2 installs — the sync WebSocket rode each access token to expiry and reconnected.

**The root cause isn't a missing client-side refresh.** The client already renews proactively: `scheduleTokenRefresh` fires at 50–70% of the 900s lifetime. But that only fed HTTP. The Durable Object copies `claims.exp` into the socket's `WsAttachment.tokenExp` at `/connect` and **never updates it**, so its 60s `alarm()` sweep closed every socket one token lifetime after connect regardless of how fresh the client's token was.

The issue offered two directions — proactive reconnect, or in-place renewal. Reconnect would have kept the drop (latency blip + wasted handshake), so this does the renewal:

- **Server** (`user-sync-state.ts`): `webSocketMessage` now reads the message it previously ignored — it existed only for rate limiting, since `setWebSocketAutoResponse('ping','pong')` means client pings never reach it. On `{type:'auth', payload:{token}}` it verifies the token, requires it to belong to the same device, bumps `tokenExp`, and acks `{type:'auth_ok', payload:{exp}}`. A rejected renewal sends `AUTH_INVALID_TOKEN` and **does not close** — the socket keeps its original expiry, i.e. exactly today's behavior.
- **Client** (`websocket.ts`): `WebSocketManager.refreshAuth()` pushes the fresh token over the open socket, wired into the existing `setOnTokenRefreshed` hook in `runtime.ts` so WS and HTTP share one renewal cycle. `auth_ok` added to the inbound schema plus an engine `case` so it doesn't log as an unknown type.

### Compatibility

Neither side is deploy-order dependent. An old server ignores the `auth` message (its `webSocketMessage` only rate-limits) → the socket still expires → the client reconnects, unchanged. An old client never sends `auth`, so it never receives `auth_ok`. Server-first is still the safer order.

### Reviewer notes

- The one behavior change on the existing rate-limit path is an added `return` after the close, so a rate-limited message isn't also processed as `auth`.
- `user-sync-state.test.ts` used `vi.clearAllMocks()`, which does not drain `mockResolvedValueOnce` queues — an unconsumed one leaks claims into the next test and cascades bogus failures. Added `mockReset()` in `beforeEach`.

## Release note
none

## Test plan

- `npx vitest run` (sync-server) — 767/767 across 52 files, incl. 4 new auth-refresh cases: expiry extended so the alarm no longer closes the socket, invalid token rejected without closing, cross-device token rejected, non-JSON/non-auth ignored
- `npx vitest run --project main src/main/sync/` (desktop) — 960/960 across 88 files, incl. 4 new `refreshAuth` cases and the runtime wiring assertion
- `npx tsc --noEmit` (sync-server) and `typecheck:node` (desktop) — clean
- `eslint` on all changed desktop files — clean
- `pnpm docs:impact --base origin/main --strict` — covered (new "Realtime Socket Auth" section in `apps/docs/src/architecture/sync-protocol.md`); `pnpm docs:build` green

Not verified end-to-end against a live server — the renewal path is exercised by unit tests on both sides, not by a real 15-minute socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)