### PR TITLE
fix(crdt): stop blaming the store when the preflight child never starts

### DIFF
--- a/apps/desktop/scripts/check-worker-bundles.mjs
+++ b/apps/desktop/scripts/check-worker-bundles.mjs
@@ -18,6 +18,9 @@ import { fileURLToPath } from 'node:url'
 const outMain = resolve(dirname(fileURLToPath(import.meta.url)), '../out/main')
 
 const WORKER_ENTRIES = [
+  // Not a worker_thread, but it runs under ELECTRON_RUN_AS_NODE as a fallback
+  // (see crdt-preflight.ts), where `electron` does not exist either.
+  'crdt-preflight-child.js',
   'sync-worker.js',
   'image-processing-worker.js',
   'voice-transcription-worker.js',

--- a/apps/desktop/src/main/sync/crdt-preflight-child.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-child.ts
@@ -1,5 +1,5 @@
 /**
- * CRDT store preflight — runs in a disposable Electron utilityProcess.
+ * CRDT store preflight — runs in a disposable child process.
  *
  * A broken classic-level native binding (wrong ABI, unsupported CPU
  * instructions, AV interference) can abort the process outright — no JS error,
@@ -11,17 +11,35 @@
  * this process dies, main never loads the binding; it quarantines the store
  * and re-probes, or degrades to in-memory mode instead of vanishing.
  *
- * Keep this file free of project imports and `electron` — it must stay a
- * minimal, standalone bundle that only touches y-leveldb/yjs and node builtins.
+ * The stage markers matter as much as the exit code: a child that dies before
+ * `started` never ran at all (its runtime failed to boot), which is no verdict
+ * on the store. See crdt-preflight-protocol.ts.
+ *
+ * Keep this file free of project imports (bar the protocol constants) and
+ * `electron` — it must stay a minimal, standalone bundle that only touches
+ * y-leveldb/yjs and node builtins, and it runs under `ELECTRON_RUN_AS_NODE`
+ * too, where `electron` does not exist.
  */
-import { LeveldbPersistence } from 'y-leveldb'
+import { writeSync } from 'fs'
+import { createRequire } from 'module'
 import * as Y from 'yjs'
+import { PREFLIGHT_MARK_BINDING_LOADED, PREFLIGHT_MARK_STARTED } from './crdt-preflight-protocol'
 
 const PROBE_DOC = '__memry_preflight__'
 
+function mark(marker: string): void {
+  // writeSync, not process.stderr.write: stderr is a pipe here, so Node's
+  // stream write is async and a native abort microseconds later would eat the
+  // marker — which is the exact moment the parent needs it.
+  writeSync(2, `${marker}\n`)
+}
+
 async function main(): Promise<void> {
-  // E2E reproduction of the field failure: a hard native-style abort. Honored
-  // only under the test harness (NODE_ENV=test); inert in shipped builds.
+  mark(PREFLIGHT_MARK_STARTED)
+
+  // E2E reproduction of the field failure: a hard native-style abort while the
+  // binding loads. Honored only under the test harness (NODE_ENV=test); inert
+  // in shipped builds.
   if (process.env.NODE_ENV === 'test' && process.env.MEMRY_TEST_CRDT_PREFLIGHT_CRASH === '1') {
     process.abort()
   }
@@ -30,6 +48,16 @@ async function main(): Promise<void> {
   if (!probeDir) {
     throw new Error('crdt-preflight-child: missing probe directory argument')
   }
+
+  // Loaded lazily so the `started` marker is out before the native binding is
+  // touched: a binding that aborts on load is then distinguishable from a
+  // child runtime that never started. `require`, not `import()` — y-leveldb is
+  // an external dep resolved relative to this bundle, and CJS require is what
+  // works from inside the packaged app.
+  const { LeveldbPersistence } = createRequire(__filename)(
+    'y-leveldb'
+  ) as typeof import('y-leveldb')
+  mark(PREFLIGHT_MARK_BINDING_LOADED)
 
   // This is the user's real store: round-trip a throwaway probe doc, clear it,
   // and close cleanly (releasing the LevelDB LOCK for main). Never delete the

--- a/apps/desktop/src/main/sync/crdt-preflight-protocol.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-protocol.ts
@@ -1,0 +1,32 @@
+/**
+ * Wire protocol between the CRDT preflight parent and its disposable child.
+ *
+ * The child reports progress by writing marker lines to stderr — the only
+ * channel that exists in BOTH transports the parent uses (an Electron
+ * utilityProcess fork and a plain `ELECTRON_RUN_AS_NODE` spawn), and one that
+ * survives a hard native abort mid-probe because it is unbuffered.
+ *
+ * Keep this file import-free: it is bundled into the standalone preflight
+ * child, which must not reach `electron` or any project module graph.
+ */
+
+/** Written before anything heavier than node builtins is touched. */
+export const PREFLIGHT_MARK_STARTED = '@@memry-preflight:started@@'
+
+/** Written once the classic-level native binding has loaded. */
+export const PREFLIGHT_MARK_BINDING_LOADED = '@@memry-preflight:binding-loaded@@'
+
+/**
+ * How far the child got before it died — the parent reads this off the markers
+ * and it decides whether the store is a suspect at all:
+ *
+ * - `bootstrap` — the child never reached JS. Its runtime failed to start
+ *   (observed on Windows: exit `0xFFFF7003` during Chromium/crashpad init).
+ *   Says nothing about the binding or the store.
+ * - `binding` — the child ran, the native binding failed to load. The store
+ *   was never opened, so it cannot be at fault.
+ * - `store` — the binding loaded and the probe died using it. Either the
+ *   on-disk state or the binding-in-use is bad; only this stage is worth
+ *   quarantining for.
+ */
+export type CrdtPreflightStage = 'bootstrap' | 'binding' | 'store'

--- a/apps/desktop/src/main/sync/crdt-preflight.test.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.test.ts
@@ -1,13 +1,20 @@
 import { EventEmitter } from 'events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PREFLIGHT_MARK_BINDING_LOADED, PREFLIGHT_MARK_STARTED } from './crdt-preflight-protocol'
 
 const mockFork = vi.hoisted(() => vi.fn())
+const mockSpawn = vi.hoisted(() => vi.fn())
 
 class MockChild extends EventEmitter {
   kill = vi.fn().mockReturnValue(true)
   stdout = null
   stderr = new EventEmitter()
   pid = 4321
+
+  /** Emit a child stderr line, as the real child does for its stage markers. */
+  say(line: string): void {
+    this.stderr.emit('data', Buffer.from(`${line}\n`))
+  }
 }
 
 vi.mock('electron', () => ({
@@ -15,6 +22,10 @@ vi.mock('electron', () => ({
   utilityProcess: {
     fork: (...args: unknown[]) => mockFork(...args)
   }
+}))
+
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args)
 }))
 
 vi.mock('../lib/logger', () => ({
@@ -32,11 +43,14 @@ const STORE_DIR = '/tmp/memry-preflight-test/crdt-store'
 
 describe('runCrdtPreflight', () => {
   let child: MockChild
+  let nodeChild: MockChild
 
   beforeEach(() => {
     vi.clearAllMocks()
     child = new MockChild()
+    nodeChild = new MockChild()
     mockFork.mockReturnValue(child)
+    mockSpawn.mockReturnValue(nodeChild)
   })
 
   afterEach(() => {
@@ -52,10 +66,13 @@ describe('runCrdtPreflight', () => {
     const [childPath, args] = mockFork.mock.calls[0] as [string, string[]]
     expect(childPath).toContain('crdt-preflight-child.js')
     expect(args[0]).toBe(STORE_DIR)
+    expect(mockSpawn).not.toHaveBeenCalled()
   })
 
   it('fails when the child dies with a non-zero code (native abort)', async () => {
     const pending = runCrdtPreflight(STORE_DIR)
+    child.say(PREFLIGHT_MARK_STARTED)
+    child.say(PREFLIGHT_MARK_BINDING_LOADED)
     child.emit('exit', 134)
 
     const result = await pending
@@ -66,6 +83,8 @@ describe('runCrdtPreflight', () => {
   it('kills the child and fails when it hangs past the timeout', async () => {
     vi.useFakeTimers()
     const pending = runCrdtPreflight(STORE_DIR)
+    child.say(PREFLIGHT_MARK_STARTED)
+    child.say(PREFLIGHT_MARK_BINDING_LOADED)
 
     await vi.advanceTimersByTimeAsync(11_000)
 
@@ -75,18 +94,23 @@ describe('runCrdtPreflight', () => {
     expect(child.kill).toHaveBeenCalled()
   })
 
-  it('fails safely when the child cannot even be forked', async () => {
+  it('fails safely when neither child can even be forked', async () => {
     mockFork.mockImplementation(() => {
+      throw new Error('utility fork failed')
+    })
+    mockSpawn.mockImplementation(() => {
       throw new Error('spawn failed')
     })
 
     const result = await runCrdtPreflight(STORE_DIR)
-    expect(result.ok).toBe(false)
+    expect(result).toMatchObject({ ok: false, stage: 'bootstrap' })
     expect(result.reason).toContain('spawn failed')
   })
 
   it('forks a fresh child on every call so a quarantine retry re-probes', async () => {
     const first = runCrdtPreflight(STORE_DIR)
+    child.say(PREFLIGHT_MARK_STARTED)
+    child.say(PREFLIGHT_MARK_BINDING_LOADED)
     child.emit('exit', 134)
     await first
 
@@ -95,5 +119,85 @@ describe('runCrdtPreflight', () => {
 
     await expect(second).resolves.toEqual({ ok: true })
     expect(mockFork).toHaveBeenCalledTimes(2)
+  })
+
+  // The child reports how far it got on stderr, because the exit code alone
+  // cannot tell "the store aborted the binding" from "this machine cannot
+  // start a utility process at all" (Windows 0xFFFF7003, crashpad init).
+  describe('failure staging', () => {
+    it('reports stage "store" when the binding loaded before the child died', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.say(PREFLIGHT_MARK_STARTED)
+      child.say(PREFLIGHT_MARK_BINDING_LOADED)
+      child.emit('exit', 134)
+
+      await expect(pending).resolves.toMatchObject({ ok: false, stage: 'store' })
+    })
+
+    it('reports stage "binding" when the child started but never loaded the binding', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.say(PREFLIGHT_MARK_STARTED)
+      child.emit('exit', 1)
+
+      await expect(pending).resolves.toMatchObject({ ok: false, stage: 'binding' })
+      // A child that never opened the store is no verdict on the store, so
+      // there is nothing for the plain-node retry to disambiguate.
+      expect(mockSpawn).not.toHaveBeenCalled()
+    })
+
+    it('renders the Windows exit code in hex so it is recognizable in logs', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.say(PREFLIGHT_MARK_STARTED)
+      child.emit('exit', -36861)
+
+      const result = await pending
+      expect(result.reason).toContain('0xFFFF7003')
+    })
+  })
+
+  // Production: on 9 Windows installs the utility child died in Chromium's
+  // crashpad init (exit 0xFFFF7003) before any of our JS ran, so the store was
+  // blamed and CRDT persistence stayed off for good. Retry the same probe with
+  // no Chromium at all before giving up.
+  describe('plain-node fallback when the utility child never starts', () => {
+    it('retries under ELECTRON_RUN_AS_NODE and passes when that child survives', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.emit('exit', -36861)
+      await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(1))
+      nodeChild.emit('exit', 0)
+
+      await expect(pending).resolves.toEqual({ ok: true })
+      const [execPath, args, options] = mockSpawn.mock.calls[0] as [
+        string,
+        string[],
+        { env: Record<string, string> }
+      ]
+      expect(execPath).toBe(process.execPath)
+      expect(args[0]).toContain('crdt-preflight-child.js')
+      expect(args[1]).toBe(STORE_DIR)
+      expect(options.env.ELECTRON_RUN_AS_NODE).toBe('1')
+    })
+
+    it('keeps stage "bootstrap" when the fallback child cannot start either', async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.emit('exit', -36861)
+      await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(1))
+      nodeChild.emit('exit', -36861)
+
+      // Stage bootstrap is what keeps the provider from quarantining a store
+      // that was never even opened.
+      await expect(pending).resolves.toMatchObject({ ok: false, stage: 'bootstrap' })
+    })
+
+    it("reports the fallback child's own stage when it does reach the store", async () => {
+      const pending = runCrdtPreflight(STORE_DIR)
+      child.emit('exit', -36861)
+      await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(1))
+      nodeChild.say(PREFLIGHT_MARK_STARTED)
+      nodeChild.say(PREFLIGHT_MARK_BINDING_LOADED)
+      nodeChild.emit('exit', 134)
+
+      await expect(pending).resolves.toMatchObject({ ok: false, stage: 'store' })
+    })
   })
 })

--- a/apps/desktop/src/main/sync/crdt-preflight.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight.ts
@@ -1,67 +1,139 @@
+import { spawn } from 'child_process'
+import os from 'os'
 import path from 'path'
 import { utilityProcess } from 'electron'
 import { createLogger } from '../lib/logger'
+import {
+  PREFLIGHT_MARK_BINDING_LOADED,
+  PREFLIGHT_MARK_STARTED,
+  type CrdtPreflightStage
+} from './crdt-preflight-protocol'
 
 const log = createLogger('CrdtPreflight')
 
 const PREFLIGHT_TIMEOUT_MS = 10_000
+// The interesting part of a native abort is the first crash banner; keep
+// enough of it to identify the failing subsystem in log aggregation.
+const STDERR_CAPTURE_CHARS = 4096
+
+export type { CrdtPreflightStage }
 
 export interface CrdtPreflightResult {
   ok: boolean
   reason?: string
+  /** How far the child got before failing. Only meaningful when `ok` is false. */
+  stage?: CrdtPreflightStage
+}
+
+type Transport = 'utility' | 'node'
+
+/** The bits of UtilityProcess and ChildProcess this module actually uses. */
+interface ProbeChild {
+  stderr: { on(event: 'data', listener: (chunk: Buffer) => void): unknown } | null
+  kill(): unknown
+  once(event: 'exit', listener: (code: number | null) => void): unknown
+  on(event: 'error', listener: (error: Error) => void): unknown
 }
 
 /**
  * Verify the classic-level native binding survives real use — in a disposable
- * utilityProcess, before the main process ever loads it. The child probes the
+ * child process, before the main process ever loads it. The child probes the
  * REAL store directory, so both a binding that hard-aborts (no JS error, no
  * uncaughtException) and a store whose on-disk state aborts the binding (torn
  * LDB/MANIFEST from a past crash) kill the child, not the app.
+ *
+ * Two transports, because the utilityProcess itself can be the thing that
+ * fails: on a set of Windows installs it dies during Chromium/crashpad init
+ * (exit `0xFFFF7003`) before any of our JS runs, which used to read as "the
+ * store is bad" and left those machines in-memory forever. When the child
+ * never reaches its `started` marker, the same probe is retried as a plain
+ * node child (`ELECTRON_RUN_AS_NODE`), which boots no Chromium and no crash
+ * handler — same process isolation, none of the Chromium startup surface.
  *
  * No verdict cache: the provider latches init (persistenceReady) so a verdict
  * is only ever requested again after it quarantined the store — and that retry
  * must genuinely re-probe. See crdt-preflight-child.ts and crdt-provider.ts.
  */
-export function runCrdtPreflight(storeDir: string): Promise<CrdtPreflightResult> {
-  return execPreflight(storeDir).catch((err) => {
+export async function runCrdtPreflight(storeDir: string): Promise<CrdtPreflightResult> {
+  return await probeWithFallback(storeDir).catch((err) => {
     log.error('CRDT preflight failed to run', { error: err })
-    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+    return {
+      ok: false,
+      stage: 'bootstrap' as const,
+      reason: err instanceof Error ? err.message : String(err)
+    }
   })
 }
 
-async function execPreflight(storeDir: string): Promise<CrdtPreflightResult> {
-  const childPath = path.join(__dirname, 'crdt-preflight-child.js')
+async function probeWithFallback(storeDir: string): Promise<CrdtPreflightResult> {
   const startedAt = Date.now()
+  let result = await execPreflight(storeDir, 'utility')
+
+  if (!result.ok && result.stage === 'bootstrap') {
+    log.warn('CRDT preflight child never started — retrying without Chromium', {
+      reason: result.reason,
+      platform: process.platform,
+      osRelease: os.release()
+    })
+    result = await execPreflight(storeDir, 'node')
+  }
+
+  if (result.ok) {
+    log.debug('CRDT preflight passed', { storeDir, elapsedMs: Date.now() - startedAt })
+  } else {
+    log.error('CRDT store failed preflight — CRDT layer will run in-memory', {
+      storeDir,
+      reason: result.reason,
+      stage: result.stage,
+      platform: process.platform,
+      osRelease: os.release(),
+      elapsedMs: Date.now() - startedAt
+    })
+  }
+  return result
+}
+
+async function execPreflight(storeDir: string, transport: Transport): Promise<CrdtPreflightResult> {
+  const childPath = path.join(__dirname, 'crdt-preflight-child.js')
 
   return await new Promise<CrdtPreflightResult>((resolve) => {
     let settled = false
     let stderr = ''
 
+    const stageFromMarkers = (): CrdtPreflightStage => {
+      if (stderr.includes(PREFLIGHT_MARK_BINDING_LOADED)) return 'store'
+      if (stderr.includes(PREFLIGHT_MARK_STARTED)) return 'binding'
+      return 'bootstrap'
+    }
+
     const settle = (result: CrdtPreflightResult): void => {
       if (settled) return
       settled = true
       clearTimeout(timer)
-      if (result.ok) {
-        log.debug('CRDT preflight passed', { storeDir, elapsedMs: Date.now() - startedAt })
-      } else {
-        log.error('CRDT store failed preflight — CRDT layer will run in-memory', {
+      if (!result.ok) {
+        log.warn('CRDT preflight child failed', {
+          transport,
           storeDir,
           reason: result.reason,
-          stderr: stderr.slice(0, 2000),
-          elapsedMs: Date.now() - startedAt
+          stage: result.stage,
+          stderr: stderr.slice(0, STDERR_CAPTURE_CHARS)
         })
       }
       resolve(result)
     }
 
-    const child = utilityProcess.fork(childPath, [storeDir], {
-      // Label the fork so a native abort here surfaces as 'CrdtPreflight' in
-      // `ps` and child-process-gone telemetry instead of an anonymous
-      // 'Node Utility Process' (the long-lived workers already set this).
-      serviceName: 'CrdtPreflight',
-      stdio: ['ignore', 'ignore', 'pipe'],
-      env: { ...process.env }
-    })
+    let child: ProbeChild
+    try {
+      child = fork(childPath, storeDir, transport)
+    } catch (err) {
+      // Never reached JS, so the store is not a suspect.
+      resolve({
+        ok: false,
+        stage: 'bootstrap',
+        reason: err instanceof Error ? err.message : String(err)
+      })
+      return
+    }
 
     const timer = setTimeout(() => {
       try {
@@ -69,15 +141,55 @@ async function execPreflight(storeDir: string): Promise<CrdtPreflightResult> {
       } catch {
         // already gone
       }
-      settle({ ok: false, reason: `timed out after ${PREFLIGHT_TIMEOUT_MS}ms` })
+      settle({
+        ok: false,
+        stage: stageFromMarkers(),
+        reason: `timed out after ${PREFLIGHT_TIMEOUT_MS}ms`
+      })
     }, PREFLIGHT_TIMEOUT_MS)
 
     child.stderr?.on('data', (chunk: Buffer) => {
       stderr += chunk.toString()
     })
 
-    child.once('exit', (code: number) => {
-      settle(code === 0 ? { ok: true } : { ok: false, reason: `child exited with code ${code}` })
+    child.on('error', (err: Error) => {
+      settle({ ok: false, stage: stageFromMarkers(), reason: err.message })
+    })
+
+    child.once('exit', (code: number | null) => {
+      if (code === 0) {
+        settle({ ok: true })
+        return
+      }
+      // Log the code in hex too: Windows reports these as huge unsigned
+      // values (0xFFFF7003 = 4294930435) that are meaningless in decimal.
+      const hex = typeof code === 'number' ? ` (0x${(code >>> 0).toString(16).toUpperCase()})` : ''
+      settle({
+        ok: false,
+        stage: stageFromMarkers(),
+        reason: `child exited with code ${code}${hex}`
+      })
     })
   })
+}
+
+function fork(childPath: string, storeDir: string, transport: Transport): ProbeChild {
+  if (transport === 'node') {
+    // Same binary, no Chromium: ELECTRON_RUN_AS_NODE boots plain node, so the
+    // crashpad/sandbox startup path that kills the utility child is not run.
+    return spawn(process.execPath, [childPath, storeDir], {
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+      stdio: ['ignore', 'ignore', 'pipe'],
+      windowsHide: true
+    }) as unknown as ProbeChild
+  }
+
+  return utilityProcess.fork(childPath, [storeDir], {
+    // Label the fork so a native abort here surfaces as 'CrdtPreflight' in
+    // `ps` and child-process-gone telemetry instead of an anonymous
+    // 'Node Utility Process' (the long-lived workers already set this).
+    serviceName: 'CrdtPreflight',
+    stdio: ['ignore', 'ignore', 'pipe'],
+    env: { ...process.env }
+  }) as unknown as ProbeChild
 }

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -1,5 +1,7 @@
 import * as Y from 'yjs'
 import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CrdtPreflightStage } from './crdt-preflight-protocol'
@@ -45,6 +47,9 @@ const mocks = vi.hoisted(() => {
   return {
     persistenceBehavior,
     persistenceOpFactory,
+    // Per-run temp dir, assigned once the real fs is importable (below). A
+    // fixed name in a world-writable dir is a symlink-swap target.
+    userDataDir: '',
     // Verdict of the disposable utilityProcess preflight (see crdt-preflight.ts).
     // preflightQueue serves per-call verdicts (quarantine retry = second call);
     // when empty, preflightResult is the standing answer.
@@ -76,7 +81,7 @@ const mocks = vi.hoisted(() => {
 })
 
 vi.mock('electron', () => ({
-  app: { getPath: () => '/tmp/memry-crdt-test' },
+  app: { getPath: () => mocks.userDataDir },
   BrowserWindow: {
     fromId: (id: number) => mocks.windows.get(id) ?? null,
     getAllWindows: () => Array.from(mocks.windows.values())
@@ -182,6 +187,8 @@ vi.mock('./microtask-batch-broadcaster', () => ({
 
 import { CRDT_EVENTS, CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import { CrdtProvider, getCrdtProvider, resetCrdtProvider } from './crdt-provider'
+
+mocks.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-crdt-'))
 
 const createWindow = (id: number, destroyed = false) => {
   const win = {
@@ -827,7 +834,7 @@ describe('CrdtProvider persistence resilience', () => {
   // disk) aborts the binding — not just on a binding that is broken outright.
   // The two are told apart empirically: quarantine the store, re-probe fresh.
   describe('store quarantine', () => {
-    const userDataDir = '/tmp/memry-crdt-test'
+    const userDataDir = mocks.userDataDir
     const storeDir = `${userDataDir}/crdt-store`
 
     beforeEach(() => {

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -2,6 +2,33 @@ import * as Y from 'yjs'
 import * as fs from 'fs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { CrdtPreflightStage } from './crdt-preflight-protocol'
+
+type PreflightVerdict = {
+  ok: boolean
+  reason?: string
+  stage?: CrdtPreflightStage
+  /** Side effect the real child would have had on disk before dying. */
+  onCall?: () => void
+}
+
+// Lets a single test make `renameSync` fail the way Windows does (EPERM on a
+// locked store dir) without disturbing the real fs everything else here uses.
+const fsHooks = vi.hoisted(() => ({
+  renameSync: null as null | ((from: string, to: string) => void),
+  realRenameSync: (from: string, to: string): void => {
+    throw new Error(`fs mock not installed (${from} -> ${to})`)
+  }
+}))
+
+vi.mock('fs', async (importActual) => {
+  const actual = await importActual<typeof import('fs')>()
+  fsHooks.realRenameSync = actual.renameSync
+  const renameSync = (from: string, to: string): void =>
+    (fsHooks.renameSync ?? actual.renameSync)(from, to)
+  return { ...actual, default: { ...actual, renameSync }, renameSync }
+})
+
 const mocks = vi.hoisted(() => {
   // Simulates a broken classic-level native binding (napi_create_reference
   // failures on ABI mismatch). 'reject' fails ops; 'hang' never settles.
@@ -21,8 +48,8 @@ const mocks = vi.hoisted(() => {
     // Verdict of the disposable utilityProcess preflight (see crdt-preflight.ts).
     // preflightQueue serves per-call verdicts (quarantine retry = second call);
     // when empty, preflightResult is the standing answer.
-    preflightResult: { ok: true } as { ok: boolean; reason?: string },
-    preflightQueue: [] as Array<{ ok: boolean; reason?: string }>,
+    preflightResult: { ok: true } as PreflightVerdict,
+    preflightQueue: [] as PreflightVerdict[],
     preflightCalls: [] as string[],
     sent: [] as Array<{ windowId: number; channel: string; payload: unknown }>,
     windows: new Map<
@@ -69,7 +96,9 @@ vi.mock('./crdt-preflight', () => ({
   runCrdtPreflight: vi.fn(async (storeDir: string) => {
     mocks.preflightCalls.push(storeDir)
     const queued = mocks.preflightQueue.shift()
-    return queued ? { ...queued } : { ...mocks.preflightResult }
+    const { onCall, ...verdict } = queued ?? mocks.preflightResult
+    onCall?.()
+    return verdict
   })
 }))
 
@@ -779,7 +808,7 @@ describe('CrdtProvider persistence resilience', () => {
   })
 
   it('never loads the store binding when the preflight child dies', async () => {
-    mocks.preflightResult = { ok: false, reason: 'child exited with code 134' }
+    mocks.preflightResult = { ok: false, reason: 'child exited with code 134', stage: 'store' }
     const provider = new CrdtProvider()
 
     await expect(provider.init()).resolves.toBeUndefined()
@@ -812,7 +841,10 @@ describe('CrdtProvider persistence resilience', () => {
     it('quarantines a corrupt store and continues on a fresh one when the re-probe passes', async () => {
       fs.mkdirSync(storeDir, { recursive: true })
       fs.writeFileSync(`${storeDir}/MANIFEST-000001`, 'torn')
-      mocks.preflightQueue.push({ ok: false, reason: 'child exited with code 134' }, { ok: true })
+      mocks.preflightQueue.push(
+        { ok: false, reason: 'child exited with code 134', stage: 'store' },
+        { ok: true }
+      )
 
       const provider = new CrdtProvider()
       await expect(provider.init()).resolves.toBeUndefined()
@@ -832,8 +864,8 @@ describe('CrdtProvider persistence resilience', () => {
       fs.mkdirSync(storeDir, { recursive: true })
       fs.writeFileSync(`${storeDir}/MANIFEST-000001`, 'healthy-but-binding-broken')
       mocks.preflightQueue.push(
-        { ok: false, reason: 'child exited with code 134' },
-        { ok: false, reason: 'child exited with code 134' }
+        { ok: false, reason: 'child exited with code 134', stage: 'store' },
+        { ok: false, reason: 'child exited with code 134', stage: 'store' }
       )
 
       const provider = new CrdtProvider()
@@ -850,8 +882,119 @@ describe('CrdtProvider persistence resilience', () => {
       expect(provider.isInitialized()).toBe(true)
     })
 
+    // Production (9 Windows installs, v717.2 → v719.2): the preflight child
+    // died in Chromium/crashpad init (0xFFFF7003) before it ever opened the
+    // store, and the store got quarantined for it — every launch, with the
+    // restore then failing EPERM. A child that never reached the store cannot
+    // be evidence against it.
+    it('does not quarantine when the child never started', async () => {
+      fs.mkdirSync(storeDir, { recursive: true })
+      fs.writeFileSync(`${storeDir}/MANIFEST-000001`, 'healthy')
+      mocks.preflightQueue.push({
+        ok: false,
+        reason: 'child exited with code -36861 (0xFFFF7003)',
+        stage: 'bootstrap'
+      })
+
+      const provider = new CrdtProvider()
+      await expect(provider.init()).resolves.toBeUndefined()
+
+      expect(mocks.preflightCalls).toEqual([storeDir])
+      expect(fs.existsSync(`${storeDir}/MANIFEST-000001`)).toBe(true)
+      expect(
+        fs.readdirSync(userDataDir).filter((f) => f.startsWith('crdt-store.broken-'))
+      ).toHaveLength(0)
+      expect(mocks.persistenceInstances).toHaveLength(0)
+      expect(provider.isInitialized()).toBe(true)
+    })
+
+    it('does not quarantine when the child died loading the binding', async () => {
+      fs.mkdirSync(storeDir, { recursive: true })
+      fs.writeFileSync(`${storeDir}/MANIFEST-000001`, 'healthy')
+      mocks.preflightQueue.push({
+        ok: false,
+        reason: 'child exited with code 1',
+        stage: 'binding'
+      })
+
+      const provider = new CrdtProvider()
+      await expect(provider.init()).resolves.toBeUndefined()
+
+      expect(mocks.preflightCalls).toEqual([storeDir])
+      expect(fs.existsSync(`${storeDir}/MANIFEST-000001`)).toBe(true)
+      expect(
+        fs.readdirSync(userDataDir).filter((f) => f.startsWith('crdt-store.broken-'))
+      ).toHaveLength(0)
+    })
+
+    // The failed re-probe leaves a partial fresh store behind; renaming the
+    // quarantine back onto an existing directory is EPERM on Windows, which is
+    // how installs ended up with their history stranded in `.broken-*`.
+    it('restores the quarantined store over a partial fresh store', async () => {
+      fs.mkdirSync(storeDir, { recursive: true })
+      fs.writeFileSync(`${storeDir}/MANIFEST-000001`, 'healthy-but-binding-broken')
+      mocks.preflightQueue.push(
+        { ok: false, reason: 'child exited with code 134', stage: 'store' },
+        {
+          ok: false,
+          reason: 'child exited with code 134',
+          stage: 'store',
+          // The re-probe child created the fresh dir before dying.
+          onCall: () => fs.mkdirSync(`${storeDir}/LOCK`, { recursive: true })
+        }
+      )
+
+      const provider = new CrdtProvider()
+      await expect(provider.init()).resolves.toBeUndefined()
+
+      expect(fs.readFileSync(`${storeDir}/MANIFEST-000001`, 'utf8')).toBe(
+        'healthy-but-binding-broken'
+      )
+      expect(
+        fs.readdirSync(userDataDir).filter((f) => f.startsWith('crdt-store.broken-'))
+      ).toHaveLength(0)
+    })
+
+    it('restores by copy when the rename keeps failing', async () => {
+      fs.mkdirSync(storeDir, { recursive: true })
+      fs.writeFileSync(`${storeDir}/MANIFEST-000001`, 'healthy-but-binding-broken')
+      mocks.preflightQueue.push(
+        { ok: false, reason: 'child exited with code 134', stage: 'store' },
+        { ok: false, reason: 'child exited with code 134', stage: 'store' }
+      )
+
+      // Windows: AV or the just-exited child still holds the directory, so
+      // every rename after the quarantine fails.
+      let quarantined = false
+      fsHooks.renameSync = (from, to) => {
+        if (!quarantined) {
+          quarantined = true
+          fsHooks.realRenameSync(from, to)
+          return
+        }
+        const err = new Error('EPERM: operation not permitted, rename') as NodeJS.ErrnoException
+        err.code = 'EPERM'
+        throw err
+      }
+
+      try {
+        const provider = new CrdtProvider()
+        await expect(provider.init()).resolves.toBeUndefined()
+      } finally {
+        fsHooks.renameSync = null
+      }
+
+      // History is back where the next launch will look for it, not stranded.
+      expect(fs.readFileSync(`${storeDir}/MANIFEST-000001`, 'utf8')).toBe(
+        'healthy-but-binding-broken'
+      )
+      expect(
+        fs.readdirSync(userDataDir).filter((f) => f.startsWith('crdt-store.broken-'))
+      ).toHaveLength(0)
+    })
+
     it('does not re-probe when no store exists to quarantine', async () => {
-      mocks.preflightQueue.push({ ok: false, reason: 'child exited with code 134' })
+      mocks.preflightQueue.push({ ok: false, reason: 'child exited with code 134', stage: 'store' })
 
       const provider = new CrdtProvider()
       await expect(provider.init()).resolves.toBeUndefined()

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -1,7 +1,7 @@
 import * as Y from 'yjs'
 import { LeveldbPersistence } from 'y-leveldb'
 import path from 'path'
-import { existsSync, renameSync } from 'fs'
+import { existsSync, rmSync } from 'fs'
 import { app, BrowserWindow } from 'electron'
 import { CRDT_EVENTS, CRDT_FRAGMENT_NAME } from '@memry/contracts/ipc-crdt'
 import { createLogger } from '../lib/logger'
@@ -11,6 +11,7 @@ import type { CrdtUpdateQueue } from './crdt-queue'
 import { MicrotaskBatchBroadcaster } from './microtask-batch-broadcaster'
 import { scheduleWriteback, flushPendingWritebacks, recordNetworkUpdate } from './crdt-writeback'
 import { runCrdtPreflight } from './crdt-preflight'
+import { moveStoreDir } from './crdt-store-move'
 import { toAbsolutePath } from '../vault/notes'
 import { safeRead } from '../vault/file-ops'
 import { parseNote } from '../vault/frontmatter'
@@ -131,7 +132,12 @@ export class CrdtProvider {
       // corrupt on-disk state aborts the child too. Only load it here if the
       // child survives.
       let preflight = await runCrdtPreflight(storagePath)
-      if (!preflight.ok && existsSync(storagePath)) {
+      // Only a child that actually opened the store can implicate it. A child
+      // that never started (Windows: utility process dies in Chromium/crashpad
+      // init) or that died loading the binding never touched the data, and
+      // quarantining on that verdict only churned the store dir every launch —
+      // with the restore then failing EPERM under AV. See crdt-preflight.ts.
+      if (!preflight.ok && preflight.stage === 'store' && existsSync(storagePath)) {
         // The abort may be the store's data (torn LDB/MANIFEST from a past
         // crash or full disk), not the binding. Quarantine the store and give
         // the binding one clean shot at a fresh directory: pass → the data was
@@ -140,24 +146,35 @@ export class CrdtProvider {
         // binding is the problem, so restore the store for a future launch
         // with a working binding and fall through to in-memory mode.
         const quarantinePath = `${storagePath}.broken-${Date.now()}`
-        renameSync(storagePath, quarantinePath)
-        preflight = await runCrdtPreflight(storagePath)
-        if (preflight.ok) {
-          log.warn(
-            'CRDT store quarantined after failed preflight — continuing with a fresh store',
-            {
-              storagePath,
-              quarantinePath
-            }
-          )
+        const quarantined = await moveStoreDir(storagePath, quarantinePath)
+        if (!quarantined) {
+          log.warn('Could not quarantine the CRDT store — leaving it in place', { storagePath })
         } else {
-          try {
-            renameSync(quarantinePath, storagePath)
-          } catch (restoreErr) {
-            log.warn('Failed to restore quarantined CRDT store', {
-              quarantinePath,
-              error: restoreErr
-            })
+          preflight = await runCrdtPreflight(storagePath)
+          if (preflight.ok) {
+            log.warn(
+              'CRDT store quarantined after failed preflight — continuing with a fresh store',
+              {
+                storagePath,
+                quarantinePath
+              }
+            )
+          } else {
+            // The failed re-probe can leave a partial fresh store behind, and
+            // on Windows renaming onto an existing directory fails EPERM —
+            // exactly what production logs show. That directory holds nothing
+            // (the probe never completed), so clear it before restoring.
+            try {
+              rmSync(storagePath, { recursive: true, force: true })
+            } catch (err) {
+              log.warn('Could not clear the fresh CRDT store before restoring', {
+                storagePath,
+                error: err
+              })
+            }
+            if (!(await moveStoreDir(quarantinePath, storagePath))) {
+              log.warn('Failed to restore quarantined CRDT store', { quarantinePath, storagePath })
+            }
           }
         }
       }
@@ -445,7 +462,6 @@ export class CrdtProvider {
     await this.destroy()
     const storagePath = path.join(app.getPath('userData'), 'crdt-store')
     try {
-      const { rmSync } = await import('fs')
       rmSync(storagePath, { recursive: true, force: true })
       log.info('CRDT storage wiped', { storagePath })
     } catch (err) {

--- a/apps/desktop/src/main/sync/crdt-store-move.ts
+++ b/apps/desktop/src/main/sync/crdt-store-move.ts
@@ -16,17 +16,17 @@ const MOVE_RETRY_DELAYS_MS = [50, 150, 400]
  * at all; the caller decides what that means.
  */
 export async function moveStoreDir(from: string, to: string): Promise<boolean> {
+  // One attempt, then one per backoff delay.
   for (let attempt = 0; attempt <= MOVE_RETRY_DELAYS_MS.length; attempt++) {
     try {
       renameSync(from, to)
       return true
     } catch (err) {
-      const delay = MOVE_RETRY_DELAYS_MS[attempt]
-      if (delay === undefined) {
+      if (attempt === MOVE_RETRY_DELAYS_MS.length) {
         log.warn('Renaming the CRDT store failed — falling back to copy', { from, to, error: err })
         break
       }
-      await new Promise((resolve) => setTimeout(resolve, delay))
+      await new Promise((resolve) => setTimeout(resolve, MOVE_RETRY_DELAYS_MS[attempt]))
     }
   }
 

--- a/apps/desktop/src/main/sync/crdt-store-move.ts
+++ b/apps/desktop/src/main/sync/crdt-store-move.ts
@@ -1,0 +1,47 @@
+import { cpSync, renameSync, rmSync } from 'fs'
+import { createLogger } from '../lib/logger'
+
+const log = createLogger('CrdtStoreMove')
+
+const MOVE_RETRY_DELAYS_MS = [50, 150, 400]
+
+/**
+ * Move a CRDT store directory, tolerating a locked source.
+ *
+ * On Windows the store dir is regularly still held for a moment after the
+ * preflight child exits — by AV scanning the LDB files, by the vault watcher,
+ * or by the dying child itself — and `rename` fails EPERM. Retry with backoff,
+ * then fall back to copy+delete so the user's CRDT history is never stranded
+ * in a `.broken-*` dir. Returns false only if the directory could not be moved
+ * at all; the caller decides what that means.
+ */
+export async function moveStoreDir(from: string, to: string): Promise<boolean> {
+  for (let attempt = 0; attempt <= MOVE_RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      renameSync(from, to)
+      return true
+    } catch (err) {
+      const delay = MOVE_RETRY_DELAYS_MS[attempt]
+      if (delay === undefined) {
+        log.warn('Renaming the CRDT store failed — falling back to copy', { from, to, error: err })
+        break
+      }
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+  }
+
+  try {
+    cpSync(from, to, { recursive: true })
+    rmSync(from, { recursive: true, force: true })
+    return true
+  } catch (err) {
+    log.warn('Copying the CRDT store failed', { from, to, error: err })
+    // Leave the source as the single copy rather than two half-moved ones.
+    try {
+      rmSync(to, { recursive: true, force: true })
+    } catch {
+      // best effort
+    }
+    return false
+  }
+}

--- a/apps/docs/src/architecture/crdt.md
+++ b/apps/docs/src/architecture/crdt.md
@@ -23,13 +23,30 @@ utilityProcess** (`crdt-preflight-child.ts`) against the **real store
 directory**: a binding that hard-aborts (unsupported CPU instructions, AV
 interference) — or a store whose on-disk state (torn LDB/MANIFEST from a past
 crash or full disk) aborts the binding — kills that child, not the app, and
-the main process then never loads the binding at all. When the preflight
-fails and a store exists, it is **quarantined** (renamed to
+the main process then never loads the binding at all.
+
+The child reports how far it got by writing **stage markers** to stderr
+(`crdt-preflight-protocol.ts`), because the exit code alone cannot tell a bad
+store from a machine that cannot start a child at all:
+
+- `bootstrap` — the child never reached JS. Observed on Windows, where the
+  utility process dies in Chromium/crashpad init with exit `0xFFFF7003`. The
+  same probe is then retried as a plain node child
+  (`ELECTRON_RUN_AS_NODE`), which starts no Chromium and no crash handler.
+- `binding` — the child ran but the native binding failed to load. The store
+  was never opened.
+- `store` — the binding loaded and the probe died using it.
+
+Only a `store` verdict implicates the store. When it fails and a store
+exists, the store is **quarantined** (renamed to
 `crdt-store.broken-<timestamp>`) and the preflight retried once against a
 fresh directory: a pass means the data was at fault, so the app continues
 with a fresh store; a second failure means the binding itself is broken, so
 the original store is restored for a future launch and the provider goes
-in-memory. Only after the child survives is the y-leveldb store probed
+in-memory. Restoring first clears the partial fresh store the failed re-probe
+left behind (renaming onto an existing directory is `EPERM` on Windows), and
+falls back to retries and then copy+delete if the directory is still locked.
+Only after the child survives is the y-leveldb store probed
 in-process (a write/read/clear round-trip with a timeout) before it is
 trusted. A broken `classic-level` native binding doesn't
 fail cleanly — it throws outside the promise chain or hangs its callbacks — so


### PR DESCRIPTION
Fixes #838.

## What was happening

On 9 Windows installs (v717.2 → v719.2) the CRDT preflight utilityProcess died during Chromium/crashpad init with exit `-36861` / `0xFFFF7003` — **before any of our JS ran**. The parent only saw a non-zero exit, so it read that as "the store is bad":

1. quarantine `crdt-store` → `crdt-store.broken-<ts>`
2. re-probe a fresh dir → dies the same way (it's the environment, not the data)
3. restore → `EPERM` on rename, history stranded in `.broken-*`
4. CRDT persistence off for that install, every launch

## The fix

**Stage markers.** The child writes `started` / `binding-loaded` to stderr (`writeSync(2, …)`, so a native abort microseconds later can't eat them), giving the parent three verdicts:

| stage | meaning | store implicated? |
|---|---|---|
| `bootstrap` | child never reached JS (crashpad, spawn failure) | no |
| `binding` | ran, native binding failed to load — store never opened | no |
| `store` | binding loaded, probe died using it | **yes** |

Only `store` quarantines. That alone stops the churn and the EPERM restores.

**Plain-node retry.** A `bootstrap` verdict re-runs the same probe via `spawn(process.execPath, …, { ELECTRON_RUN_AS_NODE: '1' })` — same process isolation, no Chromium and no crash handler. Affected installs get real CRDT persistence back instead of in-memory mode. Verified against the actual built bundle:

```
$ ELECTRON_RUN_AS_NODE=1 npx electron out/main/crdt-preflight-child.js /tmp/preflight-probe
@@memry-preflight:started@@
@@memry-preflight:binding-loaded@@
exit=0   # real LevelDB store created
```

**Restore path.** The failed re-probe leaves a partial fresh store behind, and renaming onto an existing directory is `EPERM` on Windows — likely the literal cause of the logged failures. Restore now clears that dir first, then retries with backoff, then falls back to copy+delete (`crdt-store-move.ts`).

**Diagnostics** (issue asked for these): exit code rendered in hex, 4KB of child stderr, `platform` + `os.release()` on the failure line, and the stage itself.

## Notes

- `y-leveldb` is loaded lazily via `createRequire` — not `import()` — so the marker lands before the binding is touched while keeping the CJS resolution that works from inside the packaged app.
- `crdt-preflight-child.js` added to `check-worker-bundles.mjs`: it now runs without `electron` available.
- No schema, contract, or protocol change. Older installs are unaffected — this only changes how a failed probe is interpreted.
- Not done (issue item 3): the "sync persistence degraded" user-facing notice after N in-memory sessions. Left out deliberately; happy to add separately.

## Verification

- `crdt-preflight.test.ts` — 11 tests incl. stage classification, hex exit code, node fallback (passes / stays `bootstrap` / reports its own stage)
- `crdt-provider.test.ts` — 38 tests incl. no-quarantine on `bootstrap`/`binding`, restore over a partial fresh store, restore-by-copy when rename keeps failing (mutation-checked: breaking the copy fallback fails the test)
- `src/main/sync` suite: 966 passed
- E2E `crdt-preflight-crash` (hard abort in the real utilityProcess): passed; `sidebar-window-controls`, `startup-recovery`: passed
- typecheck, eslint, prettier, `check:architecture`, `ipc:check`, `docs:impact --strict`, `docs:build`: green
- `body-crdt-create-propagation` fails identically on a clean tree (needs sync-server infra) — pre-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)