### PR TITLE
fix(indexer): tolerate broken YAML frontmatter, log errno for unreadable files (#844)

### DIFF
--- a/apps/desktop/src/main/vault/frontmatter.test.ts
+++ b/apps/desktop/src/main/vault/frontmatter.test.ts
@@ -3,6 +3,7 @@ import matter from 'gray-matter'
 import {
   parseNote,
   serializeNote,
+  serializeParsedNote,
   validateNoteId,
   extractTitleFromPath,
   extractWikiLinks,
@@ -78,6 +79,42 @@ Hello world
     const parsed = parseNote('Body', 'notes/dated.md', { birthtime, mtime })
     expect(parsed.created).toBe('2025-06-01T08:00:00.000Z')
     expect(parsed.modified).toBe('2025-06-02T09:30:00.000Z')
+  })
+
+  it('parseNote reports no frontmatter error for parseable YAML', () => {
+    const parsed = parseNote('---\ntitle: Fine\n---\n\nBody\n')
+    expect(parsed.frontmatterError).toBeNull()
+  })
+
+  it('parseNote tolerates malformed YAML: body kept, metadata dropped', () => {
+    const raw = `---
+title: "unterminated
+tags: [work, personal
+---
+
+Body survives
+`
+    const parsed = parseNote(raw, 'notes/Broken.md')
+
+    expect(parsed.frontmatterError).toBeTruthy()
+    expect(parsed.frontmatter).toEqual({})
+    expect(parsed.hadFrontmatter).toBe(false)
+    expect(parsed.content).toBe('\nBody survives\n')
+    // Title still falls back to the filename, dates to the in-memory defaults
+    expect(parsed.title).toBe('Broken')
+  })
+
+  it('parseNote keeps the malformed block verbatim for byte-preserving writeback', () => {
+    const raw = `---
+title: "unterminated
+---
+
+Body survives
+`
+    const parsed = parseNote(raw, 'notes/Broken.md')
+
+    expect(parsed.rawFrontmatterBlock).toBe('---\ntitle: "unterminated\n---\n')
+    expect(serializeParsedNote(parsed, parsed.content, { frontmatterEdited: false })).toBe(raw)
   })
 })
 

--- a/apps/desktop/src/main/vault/frontmatter.ts
+++ b/apps/desktop/src/main/vault/frontmatter.ts
@@ -54,6 +54,12 @@ export interface ParsedNote {
    * `---` line and its EOL, or null when the file had no frontmatter.
    */
   rawFrontmatterBlock: string | null
+  /**
+   * YAML parse failure message when the frontmatter block could not be read,
+   * else null. On failure `frontmatter` is empty and the body is still parsed —
+   * the note stays usable and indexable instead of failing whole.
+   */
+  frontmatterError: string | null
   eol: Eol
   hadTrailingNewline: boolean
   /**
@@ -86,9 +92,21 @@ export function parseNote(
   stats?: ParseNoteStats
 ): ParsedNote {
   const { block, body } = splitFrontmatterBlock(rawContent)
-  // The `{}` options bypass gray-matter's content-keyed cache, which would
-  // otherwise leak `data` mutations into later parses of identical content.
-  const data = block ? (matter(block, {}).data as Record<string, unknown>) : {}
+  // Foreign vaults hold arbitrary YAML; a block we cannot parse must not cost
+  // the note its body (it would vanish from search, graph and backlinks — #844).
+  // The raw block is kept verbatim, so writeback preserves the broken bytes
+  // unless the user actually edits frontmatter.
+  let data: Record<string, unknown> = {}
+  let frontmatterError: string | null = null
+  if (block) {
+    try {
+      // The `{}` options bypass gray-matter's content-keyed cache, which would
+      // otherwise leak `data` mutations into later parses of identical content.
+      data = matter(block, {}).data as Record<string, unknown>
+    } catch (error) {
+      frontmatterError = error instanceof Error ? error.message : String(error)
+    }
+  }
   const hadFrontmatter = Object.keys(data).length > 0
   const now = new Date().toISOString()
 
@@ -107,6 +125,7 @@ export function parseNote(
     content: body,
     hadFrontmatter,
     rawFrontmatterBlock: block,
+    frontmatterError,
     eol: rawContent.includes('\r\n') ? '\r\n' : '\n',
     hadTrailingNewline: /\r?\n$/.test(rawContent),
     id: generateNoteId(),

--- a/apps/desktop/src/main/vault/indexer.test.ts
+++ b/apps/desktop/src/main/vault/indexer.test.ts
@@ -49,6 +49,31 @@ vi.mock('../inbox/suggestions', () => ({
   updateNoteEmbedding: vi.fn(() => Promise.resolve())
 }))
 
+// Paths whose reads fail with a chosen errno — lets the unreadable-file path be
+// exercised deterministically without relying on filesystem permissions.
+const { unreadablePaths, loggerMock } = vi.hoisted(() => ({
+  unreadablePaths: new Map<string, string>(),
+  loggerMock: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>()
+  return {
+    ...actual,
+    readFile: vi.fn((filePath: Parameters<typeof actual.readFile>[0], ...rest: unknown[]) => {
+      const code = unreadablePaths.get(String(filePath))
+      if (code) {
+        return Promise.reject(Object.assign(new Error(`${code}: mocked`), { code }))
+      }
+      return (actual.readFile as (...args: unknown[]) => Promise<unknown>)(filePath, ...rest)
+    })
+  }
+})
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => loggerMock
+}))
+
 // ============================================================================
 // Test Suite
 // ============================================================================
@@ -66,6 +91,8 @@ describe('indexer', () => {
   beforeEach(async () => {
     // Clear progress tracking
     progressCalls.length = 0
+    unreadablePaths.clear()
+    for (const fn of Object.values(loggerMock)) fn.mockClear()
 
     // Create fresh test fixtures
     tempVault = createTestVault('indexer-test')
@@ -294,6 +321,59 @@ Copied note`
       const rows = testDb.db.select().from(noteCache).all()
       expect(rows).toHaveLength(2)
       expect(rows[0].id).not.toBe(rows[1].id)
+    })
+
+    it('#844: indexes a note whose frontmatter is malformed YAML', async () => {
+      const notePath = path.join(tempVault.notesDir, 'Broken Frontmatter.md')
+      const raw = `---
+title: "unterminated
+tags: [work, personal
+---
+
+Body of a note with broken frontmatter
+`
+      fs.mkdirSync(tempVault.notesDir, { recursive: true })
+      fs.writeFileSync(notePath, raw)
+
+      const result = await indexer.indexVault(tempVault.path)
+
+      expect(result.indexed).toBe(1)
+      expect(result.errors).toBe(0)
+
+      // Searchable: the body is cached, the title falls back to the filename
+      const rows = testDb.db.select().from(noteCache).all()
+      expect(rows).toHaveLength(1)
+      expect(rows[0].title).toBe('Broken Frontmatter')
+      expect(rows[0].snippet).toContain('Body of a note with broken frontmatter')
+
+      // The indexer never writes files — broken bytes stay untouched
+      expect(fs.readFileSync(notePath, 'utf-8')).toBe(raw)
+    })
+
+    it('#844: indexes an empty note file instead of counting it as an error', async () => {
+      fs.mkdirSync(tempVault.notesDir, { recursive: true })
+      fs.writeFileSync(path.join(tempVault.notesDir, 'Empty.md'), '')
+
+      const result = await indexer.indexVault(tempVault.path)
+
+      expect(result.indexed).toBe(1)
+      expect(result.errors).toBe(0)
+    })
+
+    it('#844: logs the errno when a note file cannot be read', async () => {
+      const notePath = createTestNote(tempVault, { title: 'Locked', content: 'Secret' })
+      unreadablePaths.set(notePath, 'EACCES')
+
+      const result = await indexer.indexVault(tempVault.path)
+
+      expect(result.indexed).toBe(0)
+      expect(result.errors).toBe(1)
+
+      const warned = loggerMock.warn.mock.calls.find((call) =>
+        String(call[0]).includes('Could not read file')
+      )
+      expect(warned).toBeDefined()
+      expect(JSON.stringify(warned)).toContain('EACCES')
     })
   })
 

--- a/apps/desktop/src/main/vault/indexer.ts
+++ b/apps/desktop/src/main/vault/indexer.ts
@@ -9,7 +9,7 @@
  */
 
 import path from 'path'
-import { readdir, stat } from 'fs/promises'
+import { readdir, readFile, stat } from 'fs/promises'
 import { existsSync, unlinkSync } from 'fs'
 import { getConfig, emitIndexProgress } from './index'
 import { getIndexDbPath } from './init'
@@ -22,7 +22,6 @@ import {
   closeIndexDatabase
 } from '../database'
 import { parseNote } from './frontmatter'
-import { safeRead } from './file-ops'
 import { generateNoteId } from '../lib/id'
 import { normalizeRelativePath } from '../lib/paths'
 import { syncNoteToCache, syncFileToCache } from './note-sync'
@@ -151,10 +150,15 @@ async function indexMarkdownFile(
   absolutePath: string,
   db: ReturnType<typeof getIndexDatabase>
 ): Promise<'indexed' | 'error'> {
-  // Read and parse the file
-  const content = await safeRead(absolutePath)
-  if (!content) {
-    logger.warn(`Could not read file: ${relativePath}`)
+  // Read the file directly (not via safeRead) so the errno survives into the
+  // log — ENOENT (vanished mid-scan), EACCES (permissions) and ELOOP (broken
+  // symlink) all present as "could not read" otherwise (#844).
+  let content: string
+  try {
+    content = await readFile(absolutePath, 'utf-8')
+  } catch (error) {
+    const code = error instanceof Error && 'code' in error ? String(error.code) : 'UNKNOWN'
+    logger.warn(`Could not read file: ${relativePath} (${code})`)
     return 'error'
   }
 
@@ -163,6 +167,10 @@ async function indexMarkdownFile(
   // one. Dates from fs stats. The indexer never writes files.
   const stats = await stat(absolutePath).catch(() => null)
   const parsed = parseNote(content, relativePath, stats ?? undefined)
+  if (parsed.frontmatterError) {
+    // Body is indexed without metadata rather than dropping the note.
+    logger.warn(`Unparseable frontmatter, indexing body only: ${relativePath}`)
+  }
 
   let canonical: ReturnType<typeof getNoteMetadataByPath>
   try {

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -100,3 +100,5 @@ Tags and property values live in the data DB. Tag indexes and link graphs are mi
 In the vault's markdown files, a note's frontmatter contains only your own properties (plus `tags` and `aliases`). MemryNote keeps its internal bookkeeping — the note id and created/modified dates — in the local database and never writes its own keys into your files; a note with no properties has no frontmatter block at all.
 
 Frontmatter in your `.md` files is treated as yours: memrynote re-emits the original block byte-for-byte (comments, key order, and quoting included) unless you actually edit a property, tag, or alias in the app. Saving a note without changing anything writes nothing to disk at all.
+
+If a note's frontmatter isn't valid YAML — an unterminated quote, an unclosed list — the note is still indexed. Its text stays searchable and its links still show up in the graph; only its properties, tags, and aliases are unavailable until the YAML is fixed. The broken block is left on disk untouched, so you can repair it in memrynote or any other editor.


### PR DESCRIPTION
## Summary

Closes #844. Prod logs (Jul 19–22, 5 installs across darwin/linux/win32) showed notes silently dropping out of search, graph, and backlinks with no user-facing signal.

Two causes:

**1. A `YAMLException` aborted indexing for the whole file.** Foreign Obsidian vaults hold arbitrary YAML, so a block we can't parse must not cost the note its body. `parseNote` now catches the parse failure, returns empty frontmatter with the body intact, and reports the reason via a new `frontmatterError: string | null` field on `ParsedNote`. The indexer logs it once per affected note.

Byte preservation is unaffected: `rawFrontmatterBlock` still holds the original bytes, so `serializeParsedNote(..., { frontmatterEdited: false })` re-emits the broken block verbatim — covered by a test. `frontmatterEdited` is only true when the caller actually changed a tag/property/alias, in which case the block is legitimately re-stringified.

**2. `Could not read file` carried no reason.** The indexer read through `safeRead`, which collapses ENOENT to `null` and wraps everything else in a `NoteError`, so the logs couldn't distinguish a file that vanished mid-scan from a permissions problem or a broken symlink. The indexer now reads directly and logs the errno: `Could not read file: <path> (EACCES)`.

### Side effect worth reviewing

The old `if (!content)` check also treated a 0-byte note as an error, so empty notes were never cached. They now index. Locked in with a test.

### Not included

- Issue item 3 ("consider surfacing a per-vault files-skipped count in diagnostics") — the indexer already logs `X indexed, Y skipped, Z errors` at info level when errors occur. Say the word if you want it surfaced in Settings.
- `journal.ts` `parseJournalEntry` has the same untolerant `matter()` call. The indexer doesn't use it (journal files go through `parseNote`), so it's out of scope here — worth a follow-up.

## Release note

Notes with malformed YAML frontmatter are no longer skipped by the indexer — their text stays searchable and their links still appear in the graph, with only properties and tags unavailable until the YAML is fixed. Empty notes now index too.

## Test plan

- `vitest --project main src/main/vault/indexer.test.ts src/main/vault/frontmatter.test.ts` — 64 passed, 5 new tests (malformed frontmatter indexes body only; malformed block round-trips byte-for-byte; errno reaches the log; empty file indexes; `frontmatterError` null on valid YAML)
- Mutation-checked the errno test — dropping `(${code})` from the log line fails it
- `vitest --project main src/main/vault src/main/sync` — 1358 passed
- `tsc --noEmit -p tsconfig.node.json` clean; `eslint` clean on changed files
- `docs:impact --base origin/main --strict` covered; `vitepress build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)