### PR TITLE
fix(sync): tombstone cascade-deleted tasks, repair FK orphans on pull (#837)

### DIFF
--- a/apps/desktop/src/main/sync/engine/orphan-repair.test.ts
+++ b/apps/desktop/src/main/sync/engine/orphan-repair.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { repairOrphans, type OrphanRef } from './orphan-repair'
+import type { SyncContext } from './sync-context'
+import type { CorruptItemTracker } from './corrupt-item-tracker'
+
+const fetchLocal = vi.fn()
+
+vi.mock('../item-handlers', () => ({
+  getHandler: (type: string) => (type === 'project' ? { fetchLocal } : undefined)
+}))
+
+function makeOrphan(overrides: Partial<OrphanRef> = {}): OrphanRef {
+  return {
+    item: {
+      id: 'task-1',
+      type: 'task',
+      content: '{"title":"Orphan"}',
+      clock: { 'device-A': 1 },
+      operation: 'update'
+    } as OrphanRef['item'],
+    parentType: 'project',
+    parentId: 'proj-gone',
+    ...overrides
+  }
+}
+
+function makeCtx(): SyncContext {
+  return {
+    applier: { apply: vi.fn() },
+    requestPush: vi.fn(),
+    deps: {
+      db: {},
+      queue: { enqueue: vi.fn() }
+    }
+  } as unknown as SyncContext
+}
+
+function makeTracker(recovered: unknown[] = []): CorruptItemTracker {
+  return {
+    clearExpired: vi.fn(),
+    refetch: vi.fn(async () => ({ recovered, permanentFailures: [] }))
+  } as unknown as CorruptItemTracker
+}
+
+const VAULT_KEY = new Uint8Array(32)
+
+describe('repairOrphans (#837)', () => {
+  beforeEach(() => {
+    fetchLocal.mockReset()
+  })
+
+  it('does nothing when there are no orphans', async () => {
+    const ctx = makeCtx()
+    const tracker = makeTracker()
+
+    const result = await repairOrphans({
+      orphans: [],
+      ctx,
+      corruptTracker: tracker,
+      accessJwt: 'jwt',
+      vaultKey: VAULT_KEY,
+      applyItem: vi.fn()
+    })
+
+    expect(result).toEqual({ repaired: 0, tombstoned: 0 })
+    expect(tracker.refetch).not.toHaveBeenCalled()
+  })
+
+  // The server still has the parent — it just sat outside this run's cursor
+  // window. Applying it and retrying the child is the whole repair; nothing
+  // should be deleted.
+  it('applies a refetched parent and re-applies the child', async () => {
+    const ctx = makeCtx()
+    const tracker = makeTracker([
+      {
+        id: 'proj-gone',
+        type: 'project',
+        content: '{"name":"Recovered"}',
+        clock: {},
+        operation: 'update'
+      }
+    ])
+    fetchLocal.mockReturnValue({ id: 'proj-gone' })
+    const applyItem = vi.fn()
+
+    const result = await repairOrphans({
+      orphans: [makeOrphan()],
+      ctx,
+      corruptTracker: tracker,
+      accessJwt: 'jwt',
+      vaultKey: VAULT_KEY,
+      applyItem
+    })
+
+    expect(result).toEqual({ repaired: 1, tombstoned: 0 })
+    expect(ctx.applier.apply).toHaveBeenCalledWith(
+      expect.objectContaining({ itemId: 'proj-gone', type: 'project' })
+    )
+    expect(applyItem).toHaveBeenCalledTimes(1)
+    expect(ctx.deps.queue.enqueue).not.toHaveBeenCalled()
+  })
+
+  // The parent is gone locally AND the server does not return it, so the child
+  // can never be written. Tombstoning it is what the cascade should have pushed
+  // in the first place, and it ends the re-pull loop on every device.
+  it('tombstones the child when the parent is gone server-side', async () => {
+    const ctx = makeCtx()
+    const tracker = makeTracker([])
+    fetchLocal.mockReturnValue(undefined)
+
+    const result = await repairOrphans({
+      orphans: [makeOrphan()],
+      ctx,
+      corruptTracker: tracker,
+      accessJwt: 'jwt',
+      vaultKey: VAULT_KEY,
+      applyItem: vi.fn()
+    })
+
+    expect(result).toEqual({ repaired: 0, tombstoned: 1 })
+    expect(ctx.deps.queue.enqueue).toHaveBeenCalledWith({
+      type: 'task',
+      itemId: 'task-1',
+      operation: 'delete',
+      payload: '{"title":"Orphan"}',
+      priority: 0
+    })
+    expect(ctx.requestPush).toHaveBeenCalled()
+  })
+
+  it('refetches each distinct parent once for many orphans', async () => {
+    const ctx = makeCtx()
+    const tracker = makeTracker([])
+    fetchLocal.mockReturnValue(undefined)
+
+    await repairOrphans({
+      orphans: [
+        makeOrphan({ item: { ...makeOrphan().item, id: 'task-1' } }),
+        makeOrphan({ item: { ...makeOrphan().item, id: 'task-2' } }),
+        makeOrphan({ item: { ...makeOrphan().item, id: 'task-3' } })
+      ],
+      ctx,
+      corruptTracker: tracker,
+      accessJwt: 'jwt',
+      vaultKey: VAULT_KEY,
+      applyItem: vi.fn()
+    })
+
+    expect(tracker.refetch).toHaveBeenCalledWith(
+      [{ id: 'proj-gone', type: 'project' }],
+      'jwt',
+      VAULT_KEY
+    )
+    expect(ctx.deps.queue.enqueue).toHaveBeenCalledTimes(3)
+  })
+
+  // A child that fails again after its parent was restored must not be deleted
+  // — the failure is something other than the missing parent.
+  it('does not tombstone when the re-apply throws but the parent exists', async () => {
+    const ctx = makeCtx()
+    const tracker = makeTracker([])
+    fetchLocal.mockReturnValue({ id: 'proj-gone' })
+
+    const result = await repairOrphans({
+      orphans: [makeOrphan()],
+      ctx,
+      corruptTracker: tracker,
+      accessJwt: 'jwt',
+      vaultKey: VAULT_KEY,
+      applyItem: vi.fn(() => {
+        throw new Error('still broken')
+      })
+    })
+
+    expect(result).toEqual({ repaired: 0, tombstoned: 0 })
+    expect(ctx.deps.queue.enqueue).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/sync/engine/orphan-repair.ts
+++ b/apps/desktop/src/main/sync/engine/orphan-repair.ts
@@ -1,0 +1,134 @@
+import type { SyncItemType } from '@memry/contracts/sync-api'
+import { createLogger } from '../../lib/logger'
+import { decryptPullBatch } from '../sync-crypto-batch'
+import { getHandler } from '../item-handlers'
+import type { SyncContext } from './sync-context'
+import type { CorruptItemTracker } from './corrupt-item-tracker'
+import { itemRefKey } from './sync-context'
+
+const log = createLogger('OrphanRepair')
+
+type DecryptedPullItem = Awaited<ReturnType<typeof decryptPullBatch>>['decrypted'][number]
+
+export interface OrphanRef {
+  item: DecryptedPullItem
+  parentType: string
+  parentId: string
+}
+
+export interface OrphanRepairParams {
+  orphans: OrphanRef[]
+  ctx: SyncContext
+  corruptTracker: CorruptItemTracker
+  accessJwt: string
+  vaultKey: Uint8Array
+  /** Applies the item and does the run bookkeeping; throws if it still fails. */
+  applyItem: (item: DecryptedPullItem) => void
+}
+
+function parentExistsLocally(ctx: SyncContext, parentType: string, parentId: string): boolean {
+  const handler = getHandler(parentType as SyncItemType)
+  if (!handler) return false
+  try {
+    return handler.fetchLocal(ctx.deps.db, parentId) !== undefined
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve items left unwritable by a missing FK parent.
+ *
+ * A cascade delete is invisible to sync: deleting a project removes its tasks
+ * locally via SQLite `ON DELETE cascade`, but only the project is tombstoned on
+ * the server. The child rows stay alive up there forever, so every device
+ * re-pulls them, fails the FK insert, skips them, sees them as server-only in
+ * the next manifest check, and re-pulls again — an endless loop (#837).
+ *
+ * The parent is re-fetched by id, which is authoritative in a way the pull
+ * cursor window is not:
+ * - server still has it → apply the parent, then the child lands normally.
+ * - server no longer has it → the parent is gone everywhere, so the child is a
+ *   confirmed orphan. Tombstone it, which is what the cascade should have
+ *   pushed in the first place, and the loop ends on every device.
+ */
+export async function repairOrphans(
+  params: OrphanRepairParams
+): Promise<{ repaired: number; tombstoned: number }> {
+  const { orphans, ctx, corruptTracker, accessJwt, vaultKey, applyItem } = params
+  if (orphans.length === 0) return { repaired: 0, tombstoned: 0 }
+
+  const parentRefs = Array.from(
+    new Map(orphans.map((o) => [itemRefKey(o.parentType, o.parentId), o])).values()
+  ).map((o) => ({ id: o.parentId, type: o.parentType }))
+
+  log.info('Repairing items with a missing FK parent', {
+    orphanCount: orphans.length,
+    parentCount: parentRefs.length
+  })
+
+  corruptTracker.clearExpired()
+  const { recovered } = await corruptTracker.refetch(parentRefs, accessJwt, vaultKey)
+
+  for (const parent of recovered) {
+    try {
+      ctx.applier.apply({
+        itemId: parent.id,
+        type: parent.type as Parameters<typeof ctx.applier.apply>[0]['type'],
+        operation: parent.deletedAt ? 'delete' : (parent.operation as 'create' | 'update'),
+        content: new TextEncoder().encode(parent.content),
+        clock: parent.clock,
+        deletedAt: parent.deletedAt,
+        vaultKey
+      })
+    } catch (err) {
+      log.warn('Failed to apply refetched FK parent', {
+        itemId: parent.id,
+        type: parent.type,
+        error: err instanceof Error ? err.message : String(err)
+      })
+    }
+  }
+
+  let repaired = 0
+  let tombstoned = 0
+
+  for (const orphan of orphans) {
+    if (parentExistsLocally(ctx, orphan.parentType, orphan.parentId)) {
+      try {
+        applyItem(orphan.item)
+        repaired++
+      } catch (err) {
+        log.warn('Orphan still failed after its parent was restored', {
+          itemId: orphan.item.id,
+          type: orphan.item.type,
+          error: err instanceof Error ? err.message : String(err)
+        })
+      }
+      continue
+    }
+
+    // Parent confirmed absent locally AND not returned by the server. The child
+    // can never be written, so stop the re-pull loop at its source by
+    // tombstoning it server-side for every device.
+    ctx.deps.queue.enqueue({
+      type: orphan.item.type as SyncItemType,
+      itemId: orphan.item.id,
+      operation: 'delete',
+      payload: orphan.item.content,
+      priority: 0
+    })
+    tombstoned++
+    log.warn('FK parent gone server-side — tombstoning orphaned item', {
+      itemId: orphan.item.id,
+      type: orphan.item.type,
+      parentType: orphan.parentType,
+      parentId: orphan.parentId
+    })
+  }
+
+  log.info('Orphan repair complete', { repaired, tombstoned })
+  if (tombstoned > 0) ctx.requestPush()
+
+  return { repaired, tombstoned }
+}

--- a/apps/desktop/src/main/sync/engine/pull-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/pull-coordinator.ts
@@ -15,6 +15,7 @@ import { RecordPullResponseSchema } from '@memry/contracts/sync-api'
 import { secureCleanup } from '../../crypto/index'
 import { decryptPullBatch } from '../sync-crypto-batch'
 import { getRemoteSyncAdapter } from '../item-handlers'
+import { MissingSyncParentError } from '../item-handlers/types'
 import { withRetry } from '../retry'
 import { engineAuthRetryDeps, withAuthRetry } from '../auth-retry'
 import { postToServer, getFromServer, RateLimitError } from '../http-client'
@@ -27,6 +28,7 @@ import type { QuarantineManager } from './quarantine-manager'
 import type { CrdtSyncCoordinator } from './crdt-sync-coordinator'
 import type { PushCoordinator } from './push-coordinator'
 import { CorruptItemTracker } from './corrupt-item-tracker'
+import { repairOrphans, type OrphanRef } from './orphan-repair'
 import { SYNC_STATE_KEYS, YIELD_EVERY_N_ITEMS, yieldToEventLoop, itemRefKey } from './sync-context'
 
 const log = createLogger('PullCoordinator')
@@ -90,6 +92,8 @@ export class PullCoordinator {
   private deviceKeyCache = new Map<string, Uint8Array | null>()
   /** Items whose apply threw (e.g. FK parent not pulled yet) — retried once after all pages land */
   private pendingApplyRetries: DecryptedPullItem[] = []
+  /** Items still missing an FK parent after the deferred retry — repaired at end of run (#837) */
+  private orphanedItems: OrphanRef[] = []
 
   constructor(
     ctx: SyncContext,
@@ -129,9 +133,11 @@ export class PullCoordinator {
         pullStartedAt
       )
       this.pendingApplyRetries = []
+      this.orphanedItems = []
       try {
         await this.pullChanges(runState)
         await this.applyDeferredRetries(runState)
+        await this.repairOrphanedItems(runState)
         if (runState.refused) {
           // The run stopped on a page it could not apply. Recording a success
           // history row and a fresh lastSyncAt here is what made a failing
@@ -458,6 +464,24 @@ export class PullCoordinator {
         this.stateManager.emitItemSynced(dec.id, dec.type, 'pull', itemOp)
       } catch (retryError) {
         failed++
+        if (retryError instanceof MissingSyncParentError) {
+          // Not a dead end: the parent may simply sit outside this run's cursor
+          // window, or be gone everywhere. repairOrphanedItems() tells them
+          // apart instead of dropping the item until some future remote update
+          // (which, for a cascade-deleted project, never comes) — #837.
+          this.orphanedItems.push({
+            item: dec,
+            parentType: retryError.parentType,
+            parentId: retryError.parentId
+          })
+          log.warn('Pull: deferred retry still missing FK parent — queued for repair', {
+            itemId: dec.id,
+            type: dec.type,
+            parentType: retryError.parentType,
+            parentId: retryError.parentId
+          })
+          continue
+        }
         log.error('Pull: deferred retry failed — item skipped until next remote update', {
           itemId: dec.id,
           type: dec.type,
@@ -467,6 +491,36 @@ export class PullCoordinator {
     }
 
     log.info('Pull: deferred apply retries processed', { retried: retries.length, applied, failed })
+  }
+
+  /** See `repairOrphans` — resolves items left unwritable by a missing FK parent (#837). */
+  private async repairOrphanedItems(runState: PullRunState): Promise<void> {
+    const orphans = this.orphanedItems
+    this.orphanedItems = []
+    await repairOrphans({
+      orphans,
+      ctx: this.ctx,
+      corruptTracker: this.corruptTracker,
+      accessJwt: runState.accessJwt,
+      vaultKey: runState.vaultKey,
+      applyItem: (item) => this.applyOrphan(item, runState)
+    })
+  }
+
+  private applyOrphan(dec: DecryptedPullItem, runState: PullRunState): void {
+    const itemOp = dec.deletedAt ? 'delete' : (dec.operation as 'create' | 'update')
+    this.ctx.applier.apply({
+      itemId: dec.id,
+      type: dec.type as Parameters<typeof this.ctx.applier.apply>[0]['type'],
+      operation: itemOp,
+      content: new TextEncoder().encode(dec.content),
+      clock: dec.clock,
+      deletedAt: dec.deletedAt,
+      vaultKey: runState.vaultKey
+    })
+    runState.processedIds.add(itemRefKey(dec.type, dec.id))
+    runState.pulledCount++
+    this.stateManager.emitItemSynced(dec.id, dec.type, 'pull', itemOp)
   }
 
   private async processPage(
@@ -652,7 +706,10 @@ export class PullCoordinator {
           log.error('Pull: failed to apply decrypted item — deferring for retry', {
             itemId: dec.id,
             type: dec.type,
-            error: applyError instanceof Error ? applyError.message : String(applyError)
+            error: applyError instanceof Error ? applyError.message : String(applyError),
+            ...(applyError instanceof MissingSyncParentError
+              ? { parentType: applyError.parentType, parentId: applyError.parentId }
+              : {})
           })
           this.pendingApplyRetries.push(dec)
           pageFailed++

--- a/apps/desktop/src/main/sync/item-handlers/task-handler-fk.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/task-handler-fk.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { projects } from '@memry/db-schema/schema/projects'
+import { statuses } from '@memry/db-schema/schema/statuses'
+import { tasks } from '@memry/db-schema/schema/tasks'
+import { taskHandler } from './task-handler'
+import { MissingSyncParentError } from './types'
+import type { ApplyContext } from './types'
+import {
+  TEST_PROJECT,
+  TEST_STATUSES,
+  makeCtx,
+  makeTaskPayload
+} from '@tests/utils/fixtures/sync-item-handlers'
+
+// #837: a pulled task whose FK parent is gone used to raise SQLite's anonymous
+// `FOREIGN KEY constraint failed`, which named neither the constraint nor the
+// missing id — so the pull coordinator could only defer, then drop the item.
+describe('taskHandler missing FK parents (#837)', () => {
+  let testDb: TestDatabaseResult
+  let ctx: ApplyContext
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    ctx = makeCtx(testDb)
+    testDb.db.insert(projects).values(TEST_PROJECT).run()
+    testDb.db.insert(statuses).values(TEST_STATUSES).run()
+  })
+
+  afterEach(() => {
+    testDb.close()
+  })
+
+  it('names the missing project instead of throwing a bare FK error on insert', () => {
+    try {
+      taskHandler.applyUpsert(ctx, 'orphan-1', makeTaskPayload({ projectId: 'deleted-project' }), {
+        'device-B': 1
+      })
+      expect.unreachable('expected a MissingSyncParentError')
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingSyncParentError)
+      const parent = err as MissingSyncParentError
+      expect(parent.parentType).toBe('project')
+      expect(parent.parentId).toBe('deleted-project')
+      expect(parent.childId).toBe('orphan-1')
+    }
+  })
+
+  it('names the missing project when updating an existing task', () => {
+    taskHandler.applyUpsert(ctx, 'task-1', makeTaskPayload({}), { 'device-B': 1 })
+
+    expect(() =>
+      taskHandler.applyUpsert(ctx, 'task-1', makeTaskPayload({ projectId: 'deleted-project' }), {
+        'device-B': 2
+      })
+    ).toThrow(MissingSyncParentError)
+  })
+
+  // status_id is FK-bound ON DELETE SET NULL, so null is the schema's own
+  // answer for a dangling status — a project update that reconciles statuses
+  // away must not make every later task pull unwritable.
+  it('clears a dangling statusId instead of failing the apply', () => {
+    const result = taskHandler.applyUpsert(
+      ctx,
+      'task-2',
+      makeTaskPayload({ statusId: 'deleted-status' }),
+      { 'device-B': 1 }
+    )
+
+    expect(result).toBe('applied')
+    const row = testDb.db.select().from(tasks).where(eq(tasks.id, 'task-2')).get()
+    expect(row?.statusId).toBeNull()
+  })
+
+  it('keeps a statusId that still resolves', () => {
+    taskHandler.applyUpsert(ctx, 'task-3', makeTaskPayload({ statusId: TEST_STATUSES[0].id }), {
+      'device-B': 1
+    })
+
+    const row = testDb.db.select().from(tasks).where(eq(tasks.id, 'task-3')).get()
+    expect(row?.statusId).toBe(TEST_STATUSES[0].id)
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/task-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/task-handler.ts
@@ -1,5 +1,7 @@
 import { eq, isNull } from 'drizzle-orm'
 import { tasks } from '@memry/db-schema/schema/tasks'
+import { projects } from '@memry/db-schema/schema/projects'
+import { statuses } from '@memry/db-schema/schema/statuses'
 import { taskTags, taskNotes } from '@memry/db-schema/schema/task-relations'
 import { TaskSyncPayloadSchema, type TaskSyncPayload } from '@memry/contracts/sync-payloads'
 import { TasksChannels } from '@memry/contracts/ipc-channels'
@@ -10,10 +12,50 @@ import { increment } from '../vector-clock'
 import { mergeTaskFields, initAllFieldClocks, TASK_SYNCABLE_FIELDS } from '../field-merge'
 import { createLogger } from '../../lib/logger'
 import { BaseItemHandler } from './base-handler'
+import { MissingSyncParentError } from './types'
 import type { ApplyContext, ApplyResult, DrizzleDb } from './types'
 import { publishProjectionEvent } from '../../projections'
 
 const log = createLogger('TaskHandler')
+
+/**
+ * `tasks.project_id` is NOT NULL and FK-bound, so an absent project makes the
+ * row unwritable. Surface it as a typed error naming the missing id instead of
+ * SQLite's anonymous `FOREIGN KEY constraint failed` (#837).
+ */
+function requireProject(tx: DrizzleDb, taskId: string, projectId: string): void {
+  const parent = tx
+    .select({ id: projects.id })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .get()
+  if (!parent) throw new MissingSyncParentError('task', taskId, 'project', projectId)
+}
+
+/**
+ * `tasks.status_id` is FK-bound with ON DELETE SET NULL, so null IS the
+ * schema's own answer for a status that no longer exists (a project update can
+ * reconcile statuses away underneath a task that still references one). Drop
+ * the dangling reference rather than failing the whole apply.
+ */
+function resolveStatusId(
+  tx: DrizzleDb,
+  taskId: string,
+  statusId: string | null | undefined
+): string | null {
+  if (!statusId) return null
+  const parent = tx
+    .select({ id: statuses.id })
+    .from(statuses)
+    .where(eq(statuses.id, statusId))
+    .get()
+  if (parent) return statusId
+  log.warn('Task references a status that no longer exists — clearing statusId', {
+    itemId: taskId,
+    statusId
+  })
+  return null
+}
 
 function queryTags(db: DrizzleDb, taskId: string): string[] {
   return db
@@ -109,6 +151,16 @@ class TaskHandler extends BaseItemHandler<TaskSyncPayload> {
             }
           })
 
+          const mergedTx = tx as unknown as DrizzleDb
+          // Same "unchanged means omitted" rule as the plain-apply branch below.
+          const mergedProjectId = result.merged.projectId as string | undefined
+          if (mergedProjectId) requireProject(mergedTx, itemId, mergedProjectId)
+          result.merged.statusId = resolveStatusId(
+            mergedTx,
+            itemId,
+            result.merged.statusId as string | null
+          )
+
           tx.update(tasks)
             .set({
               ...result.merged,
@@ -140,12 +192,18 @@ class TaskHandler extends BaseItemHandler<TaskSyncPayload> {
 
         const appliedFC = remoteFieldClocks ?? initAllFieldClocks(remoteClock, TASK_SYNCABLE_FIELDS)
 
+        // An absent projectId means "unchanged" — drizzle omits the column, so
+        // the existing (already valid) parent stays. Only a supplied one needs
+        // checking.
+        if (data.projectId) requireProject(tx as unknown as DrizzleDb, itemId, data.projectId)
+        const appliedStatusId = resolveStatusId(tx as unknown as DrizzleDb, itemId, data.statusId)
+
         tx.update(tasks)
           .set({
             title: data.title,
             description: data.description ?? null,
             projectId: data.projectId,
-            statusId: data.statusId ?? null,
+            statusId: appliedStatusId,
             parentId: data.parentId ?? null,
             priority: data.priority ?? 0,
             position: data.position ?? 0,
@@ -177,12 +235,15 @@ class TaskHandler extends BaseItemHandler<TaskSyncPayload> {
 
       const insertedFC = remoteFieldClocks ?? initAllFieldClocks(remoteClock, TASK_SYNCABLE_FIELDS)
 
+      requireProject(tx as unknown as DrizzleDb, itemId, data.projectId!)
+      const insertedStatusId = resolveStatusId(tx as unknown as DrizzleDb, itemId, data.statusId)
+
       tx.insert(tasks)
         .values({
           id: itemId,
           title: data.title ?? 'Untitled',
           projectId: data.projectId!,
-          statusId: data.statusId ?? null,
+          statusId: insertedStatusId,
           parentId: data.parentId ?? null,
           description: data.description ?? null,
           priority: data.priority ?? 0,

--- a/apps/desktop/src/main/sync/item-handlers/types.ts
+++ b/apps/desktop/src/main/sync/item-handlers/types.ts
@@ -32,6 +32,25 @@ export interface SyncItemHandler<T = unknown> {
   markPushSynced?(db: DrizzleDb, itemId: string): void
 }
 
+/**
+ * A pulled item references an FK parent that does not exist locally. Thrown
+ * instead of letting SQLite raise a bare `FOREIGN KEY constraint failed`, which
+ * names neither the constraint nor the missing id — the pull coordinator needs
+ * both to decide between "parent hasn't landed yet" and "parent is gone
+ * everywhere, tombstone the child" (#837).
+ */
+export class MissingSyncParentError extends Error {
+  constructor(
+    readonly childType: string,
+    readonly childId: string,
+    readonly parentType: string,
+    readonly parentId: string
+  ) {
+    super(`${childType} ${childId} references missing ${parentType} ${parentId}`)
+    this.name = 'MissingSyncParentError'
+  }
+}
+
 export interface ClockResolution {
   action: 'skip' | 'apply' | 'merge'
   mergedClock: VectorClock

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -108,6 +108,33 @@ broken the item re-quarantines within a few pulls, and if it was repaired server
 again without an emergency wipe. The manifest-check throttle (30 minutes) persists in sync state, so
 engine restarts and vault switches cannot re-arm an immediate check.
 
+### Foreign-key parents and orphan repair
+
+Some rows carry foreign keys — a task references its project and its status — and the data DB
+enforces them. Server cursor order is last-update order, not dependency order, so pulled items are
+sorted so FK parents apply before their children, and anything that still fails is retried once after
+every page has landed.
+
+That covers a parent that simply arrived late. It does not cover a parent that is **gone**, which is
+what a cascade delete produces: deleting a project removes its tasks locally through SQLite
+`ON DELETE cascade`, and a cascade is invisible to sync unless each child is tombstoned explicitly.
+Project deletion therefore pushes a tombstone for every task it cascades away, including completed
+and archived ones. Without that, the child rows stay alive on the server, every device re-pulls them,
+the FK insert fails, the item is skipped, the next manifest check still sees it server-only, and the
+cycle repeats forever.
+
+For installs already holding such orphans, the end of a pull run repairs them. The missing parent is
+re-fetched **by id**, which is authoritative in a way the cursor window is not:
+
+- the server still returns the parent → apply it, then the child lands normally.
+- the server no longer returns it → the parent is gone everywhere, so the child is a confirmed
+  orphan and is tombstoned. That is what the cascade should have pushed originally, and it ends the
+  re-pull loop on every device.
+
+Deletion is gated on that second condition alone; a child whose re-apply fails for any other reason
+is left untouched and retried on the next cycle. A dangling `status_id` is not an orphan at all — the
+FK is `ON DELETE SET NULL`, so the reference is simply cleared rather than failing the apply.
+
 ## Sync Type Negotiation
 
 Clients declare the record sync item types they understand via an `X-Memry-Sync-Types` header

--- a/packages/domain-tasks/src/commands-delete-project.test.ts
+++ b/packages/domain-tasks/src/commands-delete-project.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createTasksCommands } from './commands.ts'
+import {
+  createCommandRepository,
+  createListItem,
+  createProjectWithStatuses,
+  createPublisher
+} from './test-fixtures.ts'
+
+function buildDeps(overrides: Parameters<typeof createCommandRepository>[0] = {}) {
+  let seq = 0
+  const generateId = vi.fn(() => `gen-${++seq}`)
+  const repository = createCommandRepository(overrides)
+  const publisher = createPublisher()
+  return { repository, publisher, generateId }
+}
+
+// #837: deleting a project cascades its tasks away locally via SQLite
+// ON DELETE cascade, but a cascade is invisible to sync. Without an explicit
+// tombstone per task the server keeps them alive forever, and every device then
+// re-pulls a task whose project_id no longer resolves — FOREIGN KEY constraint
+// failed, item skipped, manifest still sees it server-only, re-pull, forever.
+describe('createTasksCommands — deleteProject', () => {
+  it('tombstones every cascade-deleted task so the server does not keep orphans', async () => {
+    const cascaded = [
+      createListItem({ id: 'task-1', projectId: 'proj-1' }),
+      createListItem({ id: 'task-2', projectId: 'proj-1' })
+    ]
+    const deps = buildDeps({
+      getProject: vi.fn(() => createProjectWithStatuses({ id: 'proj-1' })),
+      listTasks: vi.fn(() => cascaded)
+    })
+    const commands = createTasksCommands(deps)
+
+    const result = await commands.deleteProject('proj-1')
+
+    expect(result.success).toBe(true)
+    expect(deps.publisher.projectDeleted).toHaveBeenCalledTimes(1)
+    expect(deps.publisher.taskDeleted).toHaveBeenCalledTimes(2)
+    expect(deps.publisher.taskDeleted).toHaveBeenCalledWith({
+      id: 'task-1',
+      snapshot: cascaded[0]
+    })
+    expect(deps.publisher.taskDeleted).toHaveBeenCalledWith({
+      id: 'task-2',
+      snapshot: cascaded[1]
+    })
+  })
+
+  // Completed and archived tasks are cascaded by SQLite just the same, so they
+  // must be listed too — otherwise they are exactly the rows left stranded.
+  it('collects completed and archived tasks before the cascade runs', async () => {
+    const listTasks = vi.fn(() => [])
+    const deps = buildDeps({
+      getProject: vi.fn(() => createProjectWithStatuses({ id: 'proj-1' })),
+      listTasks
+    })
+    const commands = createTasksCommands(deps)
+
+    await commands.deleteProject('proj-1')
+
+    expect(listTasks).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      includeCompleted: true,
+      includeArchived: true
+    })
+    expect(listTasks.mock.invocationCallOrder[0]).toBeLessThan(
+      (deps.repository.deleteProject as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]
+    )
+  })
+
+  it('publishes nothing extra when the project has no tasks', async () => {
+    const deps = buildDeps({
+      getProject: vi.fn(() => createProjectWithStatuses({ id: 'proj-1' })),
+      listTasks: vi.fn(() => [])
+    })
+    const commands = createTasksCommands(deps)
+
+    await commands.deleteProject('proj-1')
+
+    expect(deps.publisher.taskDeleted).not.toHaveBeenCalled()
+  })
+})

--- a/packages/domain-tasks/src/commands.ts
+++ b/packages/domain-tasks/src/commands.ts
@@ -91,7 +91,12 @@ export interface StatusUpdateInput {
 }
 
 export interface TasksCommandRepository extends TasksQueryRepository {
-  createTask(task: Omit<Task, 'tags' | 'linkedNoteIds' | 'hasSubtasks' | 'subtaskCount' | 'completedSubtaskCount'>): Task
+  createTask(
+    task: Omit<
+      Task,
+      'tags' | 'linkedNoteIds' | 'hasSubtasks' | 'subtaskCount' | 'completedSubtaskCount'
+    >
+  ): Task
   updateTask(
     id: string,
     updates: Partial<
@@ -256,7 +261,8 @@ export function createTasksCommands({
   return {
     async createTask(input: TaskCreateInput) {
       const id = generateId()
-      const position = input.position ?? repository.getNextTaskPosition(input.projectId, input.parentId)
+      const position =
+        input.position ?? repository.getNextTaskPosition(input.projectId, input.parentId)
 
       const createdTask = repository.createTask({
         id,
@@ -636,8 +642,21 @@ export function createTasksCommands({
 
     async deleteProject(id: string) {
       const snapshot = repository.getProject(id)
+      // SQLite cascades this project's tasks away locally, but a cascade is
+      // invisible to sync: without an explicit tombstone per task the server
+      // keeps them alive forever, and every device then re-pulls a task whose
+      // project_id no longer resolves — FOREIGN KEY constraint failed on every
+      // cycle, item skipped, manifest still sees it server-only, re-pull (#837).
+      const cascadedTasks = repository.listTasks({
+        projectId: id,
+        includeCompleted: true,
+        includeArchived: true
+      })
       repository.deleteProject(id)
       await publisher.projectDeleted({ id, snapshot })
+      for (const task of cascadedTasks) {
+        await publisher.taskDeleted({ id: task.id, snapshot: task })
+      }
       return { success: true }
     },
 


### PR DESCRIPTION
## Summary

Closes #837. Sync pull permanently dropped tasks on `FOREIGN KEY constraint failed`, and manifest-check then re-pulled the same items forever. A real user was affected for the whole 3-day Loki window (Linux install, plus one darwin).

**Root cause: cascade deletes are invisible to sync.** `deleteProject` relies on SQLite `ON DELETE cascade` to remove its tasks locally, but the publisher only pushes a *project* delete. The child task rows are never tombstoned, so they live on the server forever. Every device — including the one that did the delete — then sees them as server-only in manifest-check, re-pulls, fails `tasks.project_id → projects(id)`, defers, skips, and loops.

`sortByApplyOrder` (project rank 0 before task rank 2) and the end-of-run deferred retry already existed. Neither can help here: the parent is not coming.

Second orphan source, same class: `reconcileStatuses` deletes statuses out from under `tasks.status_id`.

### Changes

**Stop new orphans at the source**
- `domain-tasks/commands.ts` `deleteProject` lists the project's tasks (including completed and archived — SQLite cascades those just the same) *before* the delete, then publishes `taskDeleted` for each so the cascade is tombstoned server-side.

**Name the missing parent**
- New `MissingSyncParentError(childType, childId, parentType, parentId)`. SQLite's bare `FOREIGN KEY constraint failed` names neither the constraint nor the id, which is exactly the gap the issue flagged in the production logs. Pull failure logs now carry `parentType` and `parentId`.
- `task-handler` guards both FK parents across all three write paths (merge / plain update / insert). A missing project throws the typed error; a dangling `status_id` is nulled, since the FK is already `ON DELETE SET NULL` and null is the schema's own answer. An absent `projectId` still means "unchanged" and is left alone.

**Heal installs already stuck in the loop**
- New `engine/orphan-repair.ts`. Re-fetches the missing parent **by id**, which is authoritative in a way the pull cursor window is not:
  - server still returns the parent → apply it, then the child lands normally.
  - server no longer returns it → the parent is gone everywhere → the child is a confirmed orphan and gets tombstoned. That is what the cascade should have pushed in the first place, and it ends the loop on every device.
- Deletion is gated on that second condition alone. A child whose re-apply fails for any other reason is left untouched and retried next cycle.

## Release note

Fixed tasks created or edited on another device failing to appear, with sync repeatedly re-downloading the same items, after a project had been deleted.

## Test plan

- `apps/desktop` main sync suite — **PASS (965), FAIL (0)**
- `packages/domain-tasks` — **PASS (88), FAIL (0)**
- New regression coverage: `task-handler-fk.test.ts` (4), `orphan-repair.test.ts` (5), `commands-delete-project.test.ts` (3)
- Pre-fix repro confirmed the FK throw on **both** parents before any code was changed
- `pnpm typecheck` 16/16 · `eslint` 0 errors · `check:architecture` · `check:contracts` · `ipc:check` · `docs:impact --strict` covered · `docs:build`

## Reviewer notes

- **Tombstoning is a one-way write to server-side user data.** The guard is deliberately narrow: local absence alone is never enough — the server must also decline to return the parent. Worth a second pair of eyes on that condition.
- `orphan-repair` lives in its own module because `pull-coordinator.ts` hit the 800-line `max-lines` cap. That matches the existing `corrupt-item-tracker` / `quarantine-manager` split.
- No schema, contract, or protocol change. Nothing here requires a server deploy first, and older clients are unaffected — they just keep not tombstoning cascades.
- **Not covered:** the issue's third symptom, `app_error_seen error_code=SQLITE_CONSTRAINT_FOREIGNKEY action=Failed_to_update_task` (darwin + win32), is the *local* `tasks:update` IPC path, not the sync applier — likely a renderer holding a stale `statusId` after an incoming sync reconciled statuses away. Should get its own issue.