### PR TITLE
fix(logging): drop CertPin/CryptoMemLock/embeddings noise from the warn stream

### DIFF
--- a/apps/desktop/src/main/crypto/memory-lock.test.ts
+++ b/apps/desktop/src/main/crypto/memory-lock.test.ts
@@ -1,6 +1,17 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import sodium from 'libsodium-wrappers-sumo'
 import { lockKeyMaterial, unlockKeyMaterial } from './memory-lock'
+
+const mockLog = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => mockLog
+}))
 
 beforeAll(async () => {
   await sodium.ready
@@ -53,6 +64,29 @@ describe('unlockKeyMaterial', () => {
       const unlocked = unlockKeyMaterial(buffer)
       expect(locked).toBe(false)
       expect(unlocked).toBe(false)
+    })
+  })
+})
+
+describe('unavailable-API log level', () => {
+  describe('#given a WASM build with no mlock/munlock #when key material is locked', () => {
+    it('#then the notice stays at debug and never reaches the warn stream', async () => {
+      // #given — fresh module so the once-guards start clean
+      vi.resetModules()
+      mockLog.debug.mockClear()
+      mockLog.warn.mockClear()
+      mockLog.error.mockClear()
+      const fresh = await import('./memory-lock')
+      const buffer = sodium.randombytes_buf(32)
+
+      // #when
+      fresh.lockKeyMaterial(buffer)
+      fresh.unlockKeyMaterial(buffer)
+
+      // #then — expected steady state, not a fault (#846)
+      expect(mockLog.debug).toHaveBeenCalledTimes(2)
+      expect(mockLog.warn).not.toHaveBeenCalled()
+      expect(mockLog.error).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/desktop/src/main/crypto/memory-lock.ts
+++ b/apps/desktop/src/main/crypto/memory-lock.ts
@@ -7,6 +7,9 @@ type SodiumLockApi = Record<string, unknown> & {
   sodium_munlock?: (buf: Uint8Array) => void
 }
 
+// The WASM build never exposes mlock/munlock, so "unavailable" is the expected
+// steady state, not a fault — it stays at debug so it never reaches the remote
+// warn stream (#846). Real mlock/munlock *failures* below remain at warn.
 let warnedMissingMlock = false
 let warnedMissingMunlock = false
 
@@ -24,7 +27,7 @@ export function lockKeyMaterial(buffer: Uint8Array): boolean {
   if (!mlock) {
     if (!warnedMissingMlock) {
       warnedMissingMlock = true
-      log.warn(
+      log.debug(
         'sodium_mlock unavailable in WASM build. Key material will not be pinned to RAM. ' +
           'This is expected in Electron/Node.js — OS-level FDE provides equivalent swap protection.'
       )
@@ -48,7 +51,7 @@ export function unlockKeyMaterial(buffer: Uint8Array): boolean {
   if (!munlock) {
     if (!warnedMissingMunlock) {
       warnedMissingMunlock = true
-      log.warn('sodium_munlock unavailable in WASM build. Cleanup will continue without munlock.')
+      log.debug('sodium_munlock unavailable in WASM build. Cleanup will continue without munlock.')
     }
     return false
   }

--- a/apps/desktop/src/main/lib/embeddings.test.ts
+++ b/apps/desktop/src/main/lib/embeddings.test.ts
@@ -69,6 +69,7 @@ import {
   generateEmbedding,
   getModelInfo,
   initEmbeddingModel,
+  isInformationalWorkerStderr,
   isModelLoaded,
   isModelLoading,
   resetEmbeddingModelFailure,
@@ -568,6 +569,33 @@ describe('embeddings', () => {
         (call) => call[1]?.action === 'embed_failed'
       )
       expect(embedFailures).toHaveLength(1)
+    })
+  })
+
+  describe('worker stderr classification', () => {
+    it('treats the transformers.js content-length note as informational', () => {
+      expect(
+        isInformationalWorkerStderr(
+          'Unable to determine content-length from response headers, will expand buffer when needed.'
+        )
+      ).toBe(true)
+    })
+
+    it('treats a real worker failure as an error', () => {
+      expect(isInformationalWorkerStderr('Error: ENOSPC: no space left on device')).toBe(false)
+    })
+
+    it('keeps a chunk at error when a real failure is interleaved with benign notes', () => {
+      const chunk = [
+        'Unable to determine content-length from response headers, will expand buffer when needed.',
+        'Error: ENOSPC: no space left on device'
+      ].join('\n')
+
+      expect(isInformationalWorkerStderr(chunk)).toBe(false)
+    })
+
+    it('does not classify an empty chunk as informational', () => {
+      expect(isInformationalWorkerStderr('   \n  ')).toBe(false)
     })
   })
 })

--- a/apps/desktop/src/main/lib/embeddings.ts
+++ b/apps/desktop/src/main/lib/embeddings.ts
@@ -71,6 +71,28 @@ type PendingRequest = {
 }
 
 /**
+ * Progress notes transformers.js writes to the worker's stderr during a model
+ * download. They are informational, not failures, but logging the whole stream
+ * at error put them in the production error feed (#846).
+ */
+const INFORMATIONAL_WORKER_STDERR = [
+  /Unable to determine content-length from response headers/i
+] as const
+
+/**
+ * True only when every line in the chunk is a known-benign note, so a real
+ * error interleaved with progress output still surfaces at error level.
+ */
+export function isInformationalWorkerStderr(output: string): boolean {
+  const lines = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+  if (lines.length === 0) return false
+  return lines.every((line) => INFORMATIONAL_WORKER_STDERR.some((pattern) => pattern.test(line)))
+}
+
+/**
  * Emit model loading progress to all renderer windows
  */
 function emitProgress(phase: EmbeddingProgressPhase, progress: number, status: string): void {
@@ -313,9 +335,12 @@ class EmbeddingModelBridge {
     })
     child.stderr?.on('data', (chunk: Buffer | string) => {
       const output = chunk.toString().trim()
-      if (output) {
-        logger.error(`Embedding utility stderr: ${output}`)
+      if (!output) return
+      if (isInformationalWorkerStderr(output)) {
+        logger.debug(`Embedding utility stderr: ${output}`)
+        return
       }
+      logger.error(`Embedding utility stderr: ${output}`)
     })
 
     this.readyPromise = new Promise<void>((resolve, reject) => {

--- a/apps/desktop/src/main/sync/certificate-pinning.test.ts
+++ b/apps/desktop/src/main/sync/certificate-pinning.test.ts
@@ -288,10 +288,11 @@ describe('certificate-pinning', () => {
   })
 
   describe('placeholder pins fallback logging', () => {
-    it('#given packaged mode with placeholders #then warns once and never logs an error', async () => {
+    it('#given packaged mode with placeholders #then logs debug once and never warns or errors', async () => {
       // #given — fresh module so the once-guard starts clean
       vi.resetModules()
       mockApp.isPackaged = true
+      mockLog.debug.mockClear()
       mockLog.warn.mockClear()
       mockLog.error.mockClear()
       const fresh = await import('./certificate-pinning')
@@ -301,8 +302,10 @@ describe('certificate-pinning', () => {
       fresh.createPinnedAgent()
       fresh.warnPinningUnconfiguredOnce()
 
-      // #then — TLS-only fallback is deliberate: one warn, no CRITICAL noise
-      expect(mockLog.warn).toHaveBeenCalledTimes(1)
+      // #then — TLS-only fallback is deliberate: one debug line, nothing in the
+      // remote warn/error stream (which is floored at warn) — see #846
+      expect(mockLog.debug).toHaveBeenCalledTimes(1)
+      expect(mockLog.warn).not.toHaveBeenCalled()
       expect(mockLog.error).not.toHaveBeenCalled()
     })
   })

--- a/apps/desktop/src/main/sync/certificate-pinning.ts
+++ b/apps/desktop/src/main/sync/certificate-pinning.ts
@@ -25,14 +25,15 @@ export class CertificatePinningError extends Error {
 }
 
 // Placeholder pins mean pinning was never activated for this host; TLS-only
-// is the deliberate fallback, not a runtime failure. Warn once per process
-// instead of logging CRITICAL errors on every boot.
+// is the deliberate fallback, not a runtime failure. Log once per process at
+// debug: at warn this fired on every startup and was the single largest group
+// in the production log stream (#846), with nothing actionable for the user.
 let warnedPinningUnconfigured = false
 
 export function warnPinningUnconfiguredOnce(): void {
   if (warnedPinningUnconfigured) return
   warnedPinningUnconfigured = true
-  log.warn(
+  log.debug(
     'Certificate pinning not configured — using standard TLS. Run `pnpm cert:extract -- <hostname>` and update certificate-pins.ts to enable pinning.'
   )
 }

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -22,6 +22,23 @@ log.error('pull failed', err)
 - Important launch, renderer, and main-process errors are mirrored as telemetry events when
   product telemetry is enabled.
 
+### Choosing a Level
+
+The redacted diagnostic log stream is floored at `warn` (see
+[Error Logs in Grafana (Loki)](#error-logs-in-grafana-loki)), so `warn` and `error` are the levels
+an operator actually triages. Reserve them for conditions someone can act on, and log expected
+steady states at `debug`:
+
+- Certificate pinning falling back to standard TLS when no pins are configured
+  (`main/sync/certificate-pinning.ts`) — a deliberate fallback, not a failure.
+- `sodium_mlock` / `sodium_munlock` being absent in the WASM libsodium build
+  (`main/crypto/memory-lock.ts`) — the expected state in Electron. An mlock/munlock call that
+  is present but _fails_ still logs at `warn`.
+- Progress notes the embedding worker writes to stderr, such as transformers.js reporting an
+  unknown content-length during a model download (`main/lib/embeddings.ts`). A stderr chunk is
+  only downgraded when every line in it matches a known-benign pattern, so a real failure
+  interleaved with progress output still reaches `error`.
+
 ### Log Locations
 
 | Platform | Path                                            |


### PR DESCRIPTION
## Summary

Closes #846.

Three benign warning groups made up roughly 20% of production log lines (622 lines, Jul 19–22) and drowned real signal — actual bugs like the task FK loop sit at comparable volume.

The lever: `main/telemetry/log-ship.ts` clamps its level floor to `>= warn` — the configured level can only *raise* the bar, never lower it. So moving a line to `debug` removes it from the remote diagnostic stream entirely, and packaged file logs are already `info`. Nothing is lost in dev, where the floor is `debug`.

- **CertPin** (`main/sync/certificate-pinning.ts`) — `warnPinningUnconfiguredOnce` logs at `debug`. Placeholder pins mean pinning was never activated for the host; TLS-only is the deliberate fallback, not a runtime fault. 57 lines / 23 installs, every startup.
- **CryptoMemLock** (`main/crypto/memory-lock.ts`) — both "`sodium_mlock`/`sodium_munlock` unavailable in WASM build" notices log at `debug`. The message already said "This is expected in Electron/Node.js". Real `mlock`/`munlock` *failures* (the `catch` branches) stay at `warn`.
- **Embeddings** (`main/lib/embeddings.ts`) — new exported `isInformationalWorkerStderr()` routes transformers.js download progress notes to `debug`.

## Reviewer notes

- `isInformationalWorkerStderr` returns true only when **every** non-empty line in the chunk matches a known-benign pattern, so a real failure interleaved with progress output still reaches `error`.
- The stderr handler still logs the chunk as one record rather than splitting per line — splitting would shred a real stack trace into N separate error lines.
- The once-per-process guards in both `certificate-pinning.ts` and `memory-lock.ts` are unchanged; only the level moved.
- No behavior outside logging changes: no control flow, no return values, no contracts.

## Release note

none

## Test plan

- `pnpm --filter @memry/desktop test:main` → 4017 passed, 1 skipped, 0 failed
- `pnpm --filter @memry/desktop typecheck:node` → clean
- eslint + prettier clean on changed files
- `pnpm docs:impact --base origin/main --strict` → `covered`

Tests added:
- `memory-lock.test.ts` — mocks the logger; asserts the unavailable-API path emits 2 `debug` lines and never touches `warn`/`error`.
- `certificate-pinning.test.ts` — existing placeholder-fallback test now asserts one `debug`, zero `warn`, zero `error`.
- `embeddings.test.ts` — 4 cases for the stderr predicate: the benign content-length note, a real `ENOSPC` failure, a chunk mixing both (must stay `error`), and a whitespace-only chunk.

Docs: new "Choosing a Level" section in `apps/docs/src/architecture/observability.md` recording the warn-floor rule, so the next expected-state notice does not land at `warn` again.
