### PR TITLE
fix(e2e): purge the keychain items each e2e run mints

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -89,6 +89,11 @@ jobs:
       - name: Test macOS update-manifest validator
         run: node --test scripts/validate-mac-update-manifest.test.mjs
 
+      # Guards the account matcher that decides which keychain items the purge
+      # deletes. Pure functions only, so it runs on any platform.
+      - name: Test e2e keychain cleanup tooling
+        run: node --test apps/desktop/scripts/purge-e2e-keychain.test.mjs
+
   unit:
     name: Unit & integration tests
     runs-on: ubuntu-latest

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -85,6 +85,8 @@
     "test:component": "pnpm exec vitest run --config config/vitest.config.ts tests/component",
     "pretest:e2e": "pnpm repair:links && bash scripts/ensure-native.sh electron",
     "test:e2e": "playwright test --config config/playwright.config.ts",
+    "test:keychain-tools": "node --test scripts/purge-e2e-keychain.test.mjs",
+    "keychain:purge-e2e": "node scripts/purge-e2e-keychain.mjs",
     "rpc:generate": "node --experimental-strip-types --experimental-transform-types scripts/generate-rpc-bindings.ts",
     "rpc:check": "node --experimental-strip-types --experimental-transform-types scripts/generate-rpc-bindings.ts --check",
     "ipc:generate": "pnpm rpc:generate && node scripts/generate-ipc-invoke-map.js",

--- a/apps/desktop/scripts/purge-e2e-keychain.mjs
+++ b/apps/desktop/scripts/purge-e2e-keychain.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * One-shot purge of the macOS keychain backlog left by E2E runs.
+ *
+ * Every `pnpm test:e2e` launch sets `MEMRY_DEVICE=e2e-<uuid>-A|B`, which suffixes
+ * every KEYCHAIN_ENTRIES account (see main/crypto/keychain-account.ts). Until the
+ * harness learned to clean up after itself (tests/e2e/utils/keychain-cleanup.ts)
+ * those items were never deleted, so a machine that has run the suite for a while
+ * accumulates thousands of `com.memry.sync` rows. This reclaims them.
+ *
+ * Dry-run by default. Pass `--apply` to actually delete.
+ *
+ *   node scripts/purge-e2e-keychain.mjs
+ *   node scripts/purge-e2e-keychain.mjs --apply
+ */
+
+import { spawnSync } from 'node:child_process'
+
+const SYNC_SERVICE = 'com.memry.sync'
+
+/**
+ * Accounts that must NEVER be deleted: production (bare), the shared plain-dev
+ * account, and the explicit local dev devices. Belt-and-braces — none of these
+ * contain `-e2e-`, so the matcher already rejects them, but an exact denylist
+ * means a future matcher bug still cannot nuke a developer's real master key.
+ */
+const PROTECTED_ACCOUNTS = new Set([
+  'master-key',
+  'master-key-dev',
+  'master-key-A',
+  'master-key-B',
+  'master-key-C',
+  'device-signing-key',
+  'device-signing-key-dev',
+  'device-signing-key-A',
+  'device-signing-key-B',
+  'device-signing-key-C',
+  'access-token',
+  'refresh-token',
+  'setup-token',
+  'pairing-token'
+])
+
+/** `master-key-e2e-<uuid>-A`, `setup-token-e2e-vault-deletion-<uuid>`, ... */
+const E2E_SYNC_ACCOUNT = /^[a-z-]+-e2e-[A-Za-z0-9@._-]+$/
+
+/** Electron safeStorage: service is `<app.name> Safe Storage`, app.name is `memry-<MEMRY_DEVICE>`. */
+const E2E_SAFE_STORAGE_SERVICE = /^memry-e2e-[A-Za-z0-9-]+ Safe Storage$/
+
+export function isPurgeableE2eEntry(entry) {
+  const { service, account } = entry
+  if (!service || !account) return false
+  if (PROTECTED_ACCOUNTS.has(account)) return false
+
+  if (service === SYNC_SERVICE) {
+    return account.includes('-e2e-') && E2E_SYNC_ACCOUNT.test(account)
+  }
+  return E2E_SAFE_STORAGE_SERVICE.test(service)
+}
+
+/**
+ * Parse `security dump-keychain` output into {service, account} pairs.
+ * Attribute values are quoted blobs, optionally preceded by a hex dump for
+ * non-ASCII values, or the literal `<NULL>`.
+ */
+export function parseKeychainDump(text) {
+  const attr = /^\s*"(acct|svce)"<blob>=(?:0x[0-9A-Fa-f]+\s+)?(?:"((?:[^"\\]|\\.)*)"|<NULL>)\s*$/
+  const entries = []
+  let current = {}
+
+  const flush = () => {
+    if (current.acct !== undefined || current.svce !== undefined) {
+      entries.push({ service: current.svce, account: current.acct })
+    }
+    current = {}
+  }
+
+  for (const line of text.split('\n')) {
+    if (line.startsWith('keychain:')) {
+      flush()
+      continue
+    }
+    const match = attr.exec(line)
+    if (match) current[match[1]] = match[2]
+  }
+  flush()
+
+  return entries
+}
+
+function dumpKeychain() {
+  const result = spawnSync('security', ['dump-keychain'], {
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024
+  })
+  if (result.error) throw result.error
+  return result.stdout ?? ''
+}
+
+function deleteGenericPassword(service, account) {
+  return spawnSync('security', ['delete-generic-password', '-s', service, '-a', account], {
+    stdio: 'ignore',
+    timeout: 10_000
+  }).status
+}
+
+function main() {
+  if (process.platform !== 'darwin') {
+    console.log('Not macOS — nothing to do (no `security` keychain).')
+    return
+  }
+
+  const apply = process.argv.includes('--apply')
+  const all = parseKeychainDump(dumpKeychain())
+  const targets = all.filter(isPurgeableE2eEntry)
+
+  const memryBefore = all.filter((e) => e.service === SYNC_SERVICE).length
+  console.log(`Scanned ${all.length} keychain items.`)
+  console.log(`  ${SYNC_SERVICE} items:        ${memryBefore}`)
+  console.log(`  e2e items to purge:          ${targets.length}`)
+  console.log(`  kept (dev/prod/unrelated):   ${all.length - targets.length}`)
+
+  const sample = targets.slice(0, 5)
+  if (sample.length) {
+    console.log('\nSample targets:')
+    for (const t of sample) console.log(`  ${t.service}  ${t.account}`)
+    if (targets.length > sample.length)
+      console.log(`  ... and ${targets.length - sample.length} more`)
+  }
+
+  if (!apply) {
+    console.log('\nDry run. Re-run with --apply to delete.')
+    return
+  }
+
+  let deleted = 0
+  let failed = 0
+  for (const { service, account } of targets) {
+    if (PROTECTED_ACCOUNTS.has(account)) {
+      throw new Error(`Refusing to delete protected account: ${account}`)
+    }
+    // `security` removes one item per call; duplicates need a loop.
+    let status = deleteGenericPassword(service, account)
+    if (status === 0) {
+      deleted++
+      while (deleteGenericPassword(service, account) === 0) deleted++
+    } else {
+      failed++
+    }
+  }
+
+  const after = parseKeychainDump(dumpKeychain())
+  console.log(`\nDeleted ${deleted} items (${failed} could not be deleted).`)
+  console.log(
+    `  ${SYNC_SERVICE} items:        ${memryBefore} -> ${after.filter((e) => e.service === SYNC_SERVICE).length}`
+  )
+  console.log(`  remaining e2e items:         ${after.filter(isPurgeableE2eEntry).length}`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/apps/desktop/scripts/purge-e2e-keychain.test.mjs
+++ b/apps/desktop/scripts/purge-e2e-keychain.test.mjs
@@ -1,0 +1,112 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { isPurgeableE2eEntry, parseKeychainDump } from './purge-e2e-keychain.mjs'
+
+const SYNC = 'com.memry.sync'
+
+test('matches every e2e-suffixed com.memry.sync account', () => {
+  const uuid = 'acc474be-3e59-4621-a8ea-fba2ddd008cc'
+  for (const entry of [
+    'master-key',
+    'device-signing-key',
+    'access-token',
+    'refresh-token',
+    'setup-token'
+  ]) {
+    for (const device of [`e2e-${uuid}-A`, `e2e-${uuid}-B`, `e2e-vault-deletion-${uuid}`]) {
+      assert.equal(
+        isPurgeableE2eEntry({ service: SYNC, account: `${entry}-${device}` }),
+        true,
+        `${entry}-${device} should be purgeable`
+      )
+    }
+  }
+})
+
+test('never matches production or local dev accounts', () => {
+  const protectedAccounts = [
+    'master-key',
+    'master-key-dev',
+    'master-key-A',
+    'master-key-B',
+    'master-key-C',
+    'master-key-dev-6f23ea9b',
+    'device-signing-key-A',
+    'device-signing-key-dev-d9cfd05c',
+    'access-token-B',
+    'refresh-token-dev-d9cfd05c',
+    'setup-token-C',
+    'pairing-token',
+    'access-token-kaan94karaca@gmail.com-dev-d9cfd05c'
+  ]
+  for (const account of protectedAccounts) {
+    assert.equal(
+      isPurgeableE2eEntry({ service: SYNC, account }),
+      false,
+      `${account} must never be purged`
+    )
+  }
+})
+
+test('ignores services outside memry', () => {
+  assert.equal(
+    isPurgeableE2eEntry({ service: 'com.apple.foo', account: 'master-key-e2e-x' }),
+    false
+  )
+  assert.equal(isPurgeableE2eEntry({ service: 'AirPort', account: 'e2e-network' }), false)
+  assert.equal(isPurgeableE2eEntry({ service: SYNC, account: undefined }), false)
+  assert.equal(isPurgeableE2eEntry({ service: undefined, account: 'master-key-e2e-x' }), false)
+})
+
+test('matches e2e safeStorage services but not dev ones', () => {
+  const account = 'memry-e2e-6c29af05-f76e-4a84-a0fe-37567745f447-A Key'
+  assert.equal(
+    isPurgeableE2eEntry({
+      service: 'memry-e2e-6c29af05-f76e-4a84-a0fe-37567745f447-A Safe Storage',
+      account
+    }),
+    true
+  )
+  assert.equal(
+    isPurgeableE2eEntry({ service: 'memry-A Safe Storage', account: 'memry-A Key' }),
+    false
+  )
+  assert.equal(
+    isPurgeableE2eEntry({
+      service: '@memry/desktop Safe Storage',
+      account: '@memry/desktop Key'
+    }),
+    false
+  )
+})
+
+test('parses security dump-keychain output', () => {
+  const dump = [
+    'keychain: "/Users/x/Library/Keychains/login.keychain-db"',
+    'version: 512',
+    'class: "genp"',
+    'attributes:',
+    '    "acct"<blob>="master-key-e2e-1234-A"',
+    '    "svce"<blob>="com.memry.sync"',
+    'keychain: "/Users/x/Library/Keychains/login.keychain-db"',
+    'attributes:',
+    '    "acct"<blob>=0x6D6173746572  "master-key"',
+    '    "svce"<blob>="com.memry.sync"',
+    'keychain: "/Users/x/Library/Keychains/login.keychain-db"',
+    'attributes:',
+    '    "acct"<blob>=<NULL>',
+    '    "svce"<blob>="com.apple.kerberos.kdc"',
+    ''
+  ].join('\n')
+
+  const entries = parseKeychainDump(dump)
+  assert.deepEqual(entries, [
+    { service: 'com.memry.sync', account: 'master-key-e2e-1234-A' },
+    { service: 'com.memry.sync', account: 'master-key' },
+    { service: 'com.apple.kerberos.kdc', account: undefined }
+  ])
+  assert.deepEqual(entries.filter(isPurgeableE2eEntry), [
+    { service: 'com.memry.sync', account: 'master-key-e2e-1234-A' }
+  ])
+})

--- a/apps/desktop/tests/e2e/fixtures.ts
+++ b/apps/desktop/tests/e2e/fixtures.ts
@@ -11,7 +11,7 @@ import * as os from 'os'
 import * as path from 'path'
 
 import {
-  destroyElectronApp,
+  destroyLaunchedElectron,
   launchElectronWithWindow,
   LaunchedElectron
 } from './utils/electron-lifecycle'
@@ -40,11 +40,7 @@ export const test = base.extend<{
 
     await use(launched.app)
 
-    const dirs = [launched.userDataDir]
-    if (launched.resolvedUserDataDir !== launched.userDataDir) {
-      dirs.push(launched.resolvedUserDataDir)
-    }
-    await destroyElectronApp(launched.app, dirs)
+    await destroyLaunchedElectron(launched)
   },
 
   page: async ({ electronApp }, use) => {

--- a/apps/desktop/tests/e2e/fixtures/sync-fixtures.ts
+++ b/apps/desktop/tests/e2e/fixtures/sync-fixtures.ts
@@ -10,7 +10,7 @@ import * as os from 'os'
 import * as path from 'path'
 import { waitForAppReady } from '../utils/electron-helpers'
 import {
-  destroyElectronApp,
+  destroyLaunchedElectron,
   launchElectronWithWindow,
   LaunchedElectron
 } from '../utils/electron-lifecycle'
@@ -83,11 +83,7 @@ export const test = base.extend<{
     })
     ;(launched.app as unknown as { __launched?: LaunchedElectron }).__launched = launched
     await use(launched.app)
-    const dirs = [launched.userDataDir]
-    if (launched.resolvedUserDataDir !== launched.userDataDir) {
-      dirs.push(launched.resolvedUserDataDir)
-    }
-    await destroyElectronApp(launched.app, dirs)
+    await destroyLaunchedElectron(launched)
   },
 
   electronAppB: async ({ deviceIdB, vaultPathB, syncServerUrl }, use) => {
@@ -98,11 +94,7 @@ export const test = base.extend<{
     })
     ;(launched.app as unknown as { __launched?: LaunchedElectron }).__launched = launched
     await use(launched.app)
-    const dirs = [launched.userDataDir]
-    if (launched.resolvedUserDataDir !== launched.userDataDir) {
-      dirs.push(launched.resolvedUserDataDir)
-    }
-    await destroyElectronApp(launched.app, dirs)
+    await destroyLaunchedElectron(launched)
   },
 
   pageA: async ({ electronAppA, vaultPathA }, use) => {

--- a/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
+++ b/apps/desktop/tests/e2e/utils/electron-lifecycle.ts
@@ -9,6 +9,8 @@
  *    always unblocks it
  *  - best-effort cleanup of both the requested user-data-dir and the
  *    Electron-resolved one (they can differ on macOS)
+ *  - best-effort purge of the OS keychain items the run's `MEMRY_DEVICE`
+ *    minted, which outlive the userData dir (see keychain-cleanup.ts)
  */
 
 import { _electron as electron, ElectronApplication, Page } from '@playwright/test'
@@ -17,6 +19,7 @@ import { createRequire } from 'node:module'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
+import { purgeKeychainForDevice } from './keychain-cleanup'
 
 const MAIN_ENTRY = path.join(__dirname, '../../../out/main/index.js')
 const ELECTRON_INSTALLER = path.join(__dirname, '../../../scripts/install-electron-binary.cjs')
@@ -40,6 +43,7 @@ export interface LaunchedElectron {
   resolvedUserDataDir: string
   mainLogs: string[]
   logDir: string
+  deviceId?: string
 }
 
 function getElectronExecutablePath(): string {
@@ -99,7 +103,25 @@ function getElectronPlatformPath(): string {
   }
 }
 
-export async function destroyElectronApp(app: ElectronApplication, dirs: string[]): Promise<void> {
+/**
+ * Tear down a launch: stop the app, remove both user-data dirs, and purge the
+ * keychain items its `MEMRY_DEVICE` minted. Prefer this over `destroyElectronApp`
+ * — it derives everything from `launched`, so a new fixture cannot forget the
+ * keychain purge and silently start leaking again.
+ */
+export async function destroyLaunchedElectron(launched: LaunchedElectron): Promise<void> {
+  const dirs = [launched.userDataDir]
+  if (launched.resolvedUserDataDir !== launched.userDataDir) {
+    dirs.push(launched.resolvedUserDataDir)
+  }
+  await destroyElectronApp(launched.app, dirs, launched.deviceId)
+}
+
+export async function destroyElectronApp(
+  app: ElectronApplication,
+  dirs: string[],
+  deviceId?: string
+): Promise<void> {
   const child = app.process()
   const graceful = app.close().catch(() => {})
   const timedOut = await Promise.race([
@@ -122,6 +144,7 @@ export async function destroyElectronApp(app: ElectronApplication, dirs: string[
       // best-effort cleanup
     }
   }
+  purgeKeychainForDevice(deviceId)
 }
 
 /**
@@ -208,9 +231,17 @@ async function launchOnce(opts: LaunchOptions): Promise<LaunchedElectron> {
     } catch {
       // fall back to requested dir
     }
-    return { app, page, userDataDir, resolvedUserDataDir, mainLogs, logDir }
+    return {
+      app,
+      page,
+      userDataDir,
+      resolvedUserDataDir,
+      mainLogs,
+      logDir,
+      deviceId: opts.deviceId
+    }
   } catch (err) {
-    await destroyElectronApp(app, [userDataDir])
+    await destroyElectronApp(app, [userDataDir], opts.deviceId)
     const tail = mainLogs.slice(-40).join('').slice(-4000)
     const baseMsg = err instanceof Error ? err.message : String(err)
     throw new Error(`${baseMsg}\n--- main process output ---\n${tail}\n--- end ---`)

--- a/apps/desktop/tests/e2e/utils/keychain-cleanup.ts
+++ b/apps/desktop/tests/e2e/utils/keychain-cleanup.ts
@@ -1,0 +1,65 @@
+/**
+ * Keychain teardown for E2E runs.
+ *
+ * Every launch sets `MEMRY_DEVICE=e2e-<uuid>-A|B` (see electron-lifecycle), and
+ * `resolveKeychainAccount` suffixes every KEYCHAIN_ENTRIES account with it. The
+ * OS keychain is machine-global and outlives the throwaway userData dir, so
+ * without this the suite mints ~5 permanent keychain items per app launch and
+ * never reclaims them (a local machine had 1315 leaked `com.memry.sync` rows).
+ *
+ * macOS only: `security(1)` is the zero-dependency way to reach the login
+ * keychain from the Playwright process. keytar is built for the Electron ABI in
+ * this workspace, so requiring it from Node would hit ERR_DLOPEN_FAILED. Linux
+ * CI runs headless with no libsecret daemon, so nothing is persisted there.
+ */
+
+import { spawnSync } from 'child_process'
+import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
+
+/**
+ * Only ever purge accounts minted by an E2E launch. Guards against a stray
+ * `deviceId` of `A`/`B`/`C`/`dev` (real local dev vaults) or `undefined`
+ * (production's bare `master-key`) wiping a real developer's keys.
+ */
+export const E2E_DEVICE_ID = /^e2e-[A-Za-z0-9-]+$/
+
+export function isE2eDeviceId(deviceId: string | undefined): deviceId is string {
+  return !!deviceId && E2E_DEVICE_ID.test(deviceId)
+}
+
+export function keychainAccountsForDevice(
+  deviceId: string
+): { service: string; account: string }[] {
+  return Object.values(KEYCHAIN_ENTRIES).map((entry) => ({
+    service: entry.service,
+    account: `${entry.account}-${deviceId}`
+  }))
+}
+
+function deleteGenericPassword(service: string, account: string): boolean {
+  const result = spawnSync('security', ['delete-generic-password', '-s', service, '-a', account], {
+    stdio: 'ignore',
+    timeout: 10_000
+  })
+  return result.status === 0
+}
+
+/**
+ * Delete every keychain item this run created. Best-effort: a missing item exits
+ * non-zero (44) and is not an error, and no failure here may fail a test.
+ */
+export function purgeKeychainForDevice(deviceId: string | undefined): void {
+  if (process.platform !== 'darwin') return
+  if (!isE2eDeviceId(deviceId)) return
+
+  try {
+    for (const { service, account } of keychainAccountsForDevice(deviceId)) {
+      deleteGenericPassword(service, account)
+    }
+    // Electron's safeStorage keeps its own item under `<app.name> Safe Storage`,
+    // and app.name is `memry-<MEMRY_DEVICE>`, so it leaks per run too.
+    deleteGenericPassword(`memry-${deviceId} Safe Storage`, `memry-${deviceId} Key`)
+  } catch {
+    // best-effort cleanup — never fail teardown over the keychain
+  }
+}

--- a/apps/desktop/tests/e2e/vault-deletion.e2e.ts
+++ b/apps/desktop/tests/e2e/vault-deletion.e2e.ts
@@ -16,7 +16,7 @@ import * as path from 'path'
 import { test as base, expect, type ElectronApplication, type Page } from '@playwright/test'
 import { waitForAppReady, waitForVaultReady } from './utils/electron-helpers'
 import {
-  destroyElectronApp,
+  destroyLaunchedElectron,
   launchElectronWithWindow,
   type LaunchedElectron
 } from './utils/electron-lifecycle'
@@ -82,11 +82,7 @@ const test = base.extend<{
     })
     ;(launched.app as unknown as { __launched?: LaunchedElectron }).__launched = launched
     await use(launched.app)
-    const dirs = [launched.userDataDir]
-    if (launched.resolvedUserDataDir !== launched.userDataDir) {
-      dirs.push(launched.resolvedUserDataDir)
-    }
-    await destroyElectronApp(launched.app, dirs)
+    await destroyLaunchedElectron(launched)
   },
 
   // Signs the single launched instance into the shared test account so

--- a/apps/docs/src/contribute/testing.md
+++ b/apps/docs/src/contribute/testing.md
@@ -74,6 +74,25 @@ Main-push Desktop CI runs the full Electron E2E suite across 16 Playwright shard
 the default 60s test timeout and 20s assertion timeout, while CI raises those to 180s and 60s, with
 helper-specific headroom for sync replication and Agent/MCP startup on slower Linux runners.
 
+### E2E Keychain Cleanup (macOS)
+
+Sync E2E launches set `MEMRY_DEVICE=e2e-<uuid>-A|B`, and every keychain account is suffixed with
+that device id. The OS keychain is machine-global and outlives the throwaway user-data dir, so each
+launch mints permanent `com.memry.sync` items. Teardown now deletes them:
+`tests/e2e/utils/keychain-cleanup.ts` purges the run's accounts, and fixtures call
+`destroyLaunchedElectron(launched)` — prefer it over `destroyElectronApp`, since it derives the dirs
+and device id from the launch so a new fixture cannot forget the purge. The purge only ever fires
+for device ids matching `/^e2e-[A-Za-z0-9-]+$/`, so local `A`/`B`/`C`/`dev` vaults and production's
+bare `master-key` are never touched. macOS only — keytar is built for the Electron ABI here, so
+teardown shells out to `security(1)` instead.
+
+To reclaim a backlog from runs that predate this cleanup:
+
+```bash
+pnpm --filter @memry/desktop keychain:purge-e2e            # dry run, prints counts
+pnpm --filter @memry/desktop keychain:purge-e2e -- --apply # delete
+```
+
 ### E2E Test Hooks
 
 Desktop E2E helpers live behind `globalThis.__memryTestHooks` and only register when


### PR DESCRIPTION
## Summary

Every e2e launch sets `MEMRY_DEVICE=e2e-<uuid>-A|B`, which suffixes both the `KEYCHAIN_ENTRIES` accounts (via `resolveKeychainAccount`) and Electron's `safeStorage` service (via `app.name`). The OS keychain is machine-global and outlives the throwaway userData dir, so every app launch minted permanent keychain items that were never reclaimed. One local machine had accumulated **1330** leaked items.

Two parts:

**Teardown.** New `tests/e2e/utils/keychain-cleanup.ts` deletes every `KEYCHAIN_ENTRIES` account for the run's device suffix, plus the `memry-<device> Safe Storage` item. `LaunchedElectron` now carries `deviceId`, and a new `destroyLaunchedElectron(launched)` derives dirs + device id from the launch so a future fixture cannot forget the purge and silently start leaking again. All four call sites converted (`fixtures.ts`, `sync-fixtures.ts` ×2, `vault-deletion.e2e.ts`). This also fixes the `launchOnce` failure path, which leaked a full set of entries on every first-window timeout.

**Backlog.** `scripts/purge-e2e-keychain.mjs` reclaims what already leaked. Dry-run by default, `--apply` to delete.

```bash
pnpm --filter @memry/desktop keychain:purge-e2e            # dry run
pnpm --filter @memry/desktop keychain:purge-e2e -- --apply
```

### Safety

Deleting keychain entries is destructive and unrecoverable, so the matching is deliberately narrow and double-guarded:

- Teardown fires only for device ids matching `/^e2e-[A-Za-z0-9-]+$/`. `A`/`B`/`C`/`dev`, a worktree `dev-<hash>`, and `undefined` (production's bare `master-key`) are hard no-ops.
- The purge script requires `-e2e-` in the account under `com.memry.sync` (or an `memry-e2e-* Safe Storage` service), and re-asserts an explicit `PROTECTED_ACCOUNTS` denylist immediately before each delete, so a future matcher bug still cannot touch `master-key`, `master-key-dev`, or `master-key-A/B/C`.

macOS only. keytar is built for the Electron ABI in this workspace, so requiring it from Node would hit `ERR_DLOPEN_FAILED`; teardown shells out to `security(1)` instead. Linux CI has no libsecret daemon, so nothing persists there and both paths no-op.

## Release note
none

## Test plan

**End-to-end A/B on a real Playwright run.** Same test (`vault-deletion.e2e.ts`, 3 launches), same machine, back to back, counting `memry-e2e-* Key` safeStorage items:

| e2e files | before | after |
|---|---|---|
| `origin/main` | 28 | **31** (+1 per launch) |
| this branch | 31 | **31** (no leak) |

Other verification:

- `node --test scripts/purge-e2e-keychain.test.mjs` — 5/5 pass, including an explicit "never matches production or local dev accounts" case over real account names taken from an affected machine.
- Direct exercise of `purgeKeychainForDevice`: minted 6/6 entries for a synthetic `e2e-verify-<uuid>-A`, purged → 0 remaining; `master-key-A`, `master-key-B`, `master-key-dev` untouched; all 8 device-id guard cases correct.
- Backlog purge on the affected machine: `com.memry.sync` **1332 → 17**, and the 17 survivors are exactly the real accounts (`master-key-A/B`, `master-key-dev`, two `master-key-dev-<hash>`, `setup-token-A/B/C`, the `*-dev-d9cfd05c` set). Zero contain `e2e`. A later run reclaimed 31 leftover safeStorage items with `com.memry.sync` untouched at 17.
- No regression in the sync e2e suite: `dual-device-isolation` and `vault-deletion` pass; `manual-sync-smoke` and `body-crdt-create-propagation` fail identically on untouched `origin/main` (see below).
- `tsc --noEmit` clean on the changed files. `pnpm docs:impact --base origin/main --strict` → covered; `pnpm docs:build` passes.

## Reviewer notes

- **Counting `com.memry.sync` alone hides the leak.** The `KEYCHAIN_ENTRIES` accounts are only minted when sync bootstrap fully succeeds; the `memry-<device> Safe Storage` item is minted on *every* launch. A before/after that greps only `com.memry.sync` will show no movement and look like a false negative — count `memry-e2e-* Key` too.
- **Pre-existing, unrelated failure:** `manual-sync-smoke` and `body-crdt-create-propagation` fail with `errors:sync.engineNotInitialized` on this machine, identically on `origin/main`. The local test sync-server logs "Missing secret binding" ~280 times per run, which is the likely cause. Not touched by this PR and not documented in `docs/eng/e2e-residual-failures.md`.
- `tests/e2e/**` and `scripts/**` are eslint-ignored and in no tsconfig, so neither new file is gated by `pnpm lint` / `pnpm typecheck` in CI. `test:keychain-tools` follows the existing `test:i18n-tools` precedent, which also isn't CI-wired — happy to add both to a workflow if you want the gate.
- The original leak estimate of 665 undercounted it: `access-token-e2e-*`, `device-signing-key-e2e-*`, and the safeStorage items weren't in the grep that found it.