### PR TITLE
fix(husky): resolve @{u} with --verify so the pre-push origin/main fallback is reachable

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -10,10 +10,13 @@ case "$current_branch" in
     ;;
 esac
 
-base_ref=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
+# --verify --quiet resolves to an object or exits non-zero with no output. Do not use
+# --symbolic-full-name here: with no upstream some git versions echo the literal '@{u}'
+# and exit 0, which makes the origin/main fallback below unreachable.
+upstream_commit=$(git rev-parse --verify --quiet '@{u}' 2>/dev/null || true)
 
-if [ -n "$base_ref" ]; then
-  base_commit=$(git merge-base HEAD "$base_ref")
+if [ -n "$upstream_commit" ]; then
+  base_commit=$(git merge-base HEAD "$upstream_commit")
 elif git rev-parse --verify origin/main >/dev/null 2>&1; then
   base_commit=$(git merge-base HEAD origin/main)
 else


### PR DESCRIPTION
## Summary

Fixes #875 — `.husky/pre-push` failed with exit 128 on every new branch's first push, forcing `--no-verify`.

`git rev-parse --abbrev-ref --symbolic-full-name '@{u}'` is **version-dependent** when the branch has no upstream. On some gits it echoes the literal string `@{u}` and exits **0**, so `|| true` never fired, the `-n` guard passed, and `git merge-base HEAD '@{u}'` died under `set -eu`. The `origin/main` fallback directly below was unreachable in exactly the case it was written for.

```diff
-base_ref=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
-if [ -n "$base_ref" ]; then
-  base_commit=$(git merge-base HEAD "$base_ref")
+upstream_commit=$(git rev-parse --verify --quiet '@{u}' 2>/dev/null || true)
+if [ -n "$upstream_commit" ]; then
+  base_commit=$(git merge-base HEAD "$upstream_commit")
```

`--verify --quiet` resolves to a real object or exits non-zero with **no output**, so it cannot echo a literal. This was preferred over a `[ "$base_ref" = '@{u}' ]` string-compare because it eliminates the whole class rather than one symptom.

One correction to the issue's diagnosis: the literal-echo is not universal. On git 2.50.1 (Apple Git-155) `@{u}` errors cleanly with exit 128 and empty stdout — the hook still broke, just via `merge-base` rather than the literal. So the local git could not be trusted to reproduce the report.

## Release note
none

## Test plan

`sh -n .husky/pre-push` passes. Behaviour verified in a scratch repo, using a fake `git` shim on `PATH` that echoes `@{u}` and exits 0 to reproduce the reporter's git rather than relying on the local one:

| Case | Old hook | New hook |
| --- | --- | --- |
| No upstream, real git | fatal, exit 128 | exit 0 |
| No upstream, literal-echo git | fatal, exit 128 | exit 0 |
| Real upstream present | — | exit 0, base resolves to upstream (not `origin/main`) |

Mutation-tested: the old hook fails both broken cases under the same harness, so the check is not vacuous. The upstream case asserts `merge-base` differs from `origin/main`, confirming the upstream path is genuinely taken.

Real-world confirmation: this branch had no upstream when pushed, and the hook ran clean.

## Note for the reviewer — separate pre-existing issue, deliberately not fixed here

The issue's impact section says pushing with `--no-verify` "skips the docs gate the hook exists to enforce". **That gate is already gone.** Commit c2e46b2c7 ("chore: UI component updates and refactoring", #611, 2026-06-26) deleted the entire 35-line `pnpm docs:impact --base "$base_commit" --strict` block — including the `MEMRY_DOCS_IMPACT_SKIP` escape hatch and the `MEMRY_DOCS_AI_AUTO` opt-in updater — as apparent collateral in a UI refactor. The hook now computes `base_commit`, checks the `code_changed` regex, and exits 0.

`CLAUDE.md` still documents that gate as live, so code and docs currently disagree. `scripts/pre-push-policy.test.mjs` asserts the gate exists and fails 2 of 3 tests today, but nothing invokes it — the root `test` script only runs turbo across the five workspace packages — which is why the deletion went unnoticed for four weeks.

Restoring the gate versus updating the docs is a scope call, so it is left out of this PR and tracked separately.
