### PR TITLE
fix(build): stop failing builds on unactivated certificate pins (#876)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -43,7 +43,7 @@
     "clean:c": "rm -rf \"$HOME/Library/Application Support/memry-C\"",
     "clean:devices": "pnpm clean:a && pnpm clean:b && pnpm clean:c",
     "build": "cross-env MEMRY_ENV=production pnpm typecheck && cross-env MEMRY_ENV=production electron-vite build && node scripts/check-worker-bundles.mjs",
-    "build:release": "pnpm repair:links && cross-env MEMRY_ENV=production electron-vite build && node scripts/check-worker-bundles.mjs",
+    "build:release": "pnpm repair:links && bash scripts/check-cert-hashes.sh && cross-env MEMRY_ENV=production electron-vite build && node scripts/check-worker-bundles.mjs",
     "postinstall": "[ \"$SKIP_ELECTRON_REBUILD\" = '1' ] || pnpm exec electron-rebuild -o better-sqlite3,classic-level,keytar",
     "rebuild:node": "bash scripts/ensure-native.sh node",
     "rebuild:electron": "bash scripts/ensure-native.sh electron",

--- a/apps/desktop/scripts/check-cert-hashes.sh
+++ b/apps/desktop/scripts/check-cert-hashes.sh
@@ -4,10 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-if [ "${CI:-}" = "true" ]; then
-  echo "CI detected — skipping certificate hash check (not a production build)"
-  exit 0
-fi
-
+# No CI escape hatch: placeholder pins now warn instead of failing, so the check
+# is safe to run everywhere and is only useful where releases are actually built.
 node --experimental-strip-types --experimental-transform-types \
   "$APP_ROOT/scripts/check-cert-hashes.ts"

--- a/apps/desktop/scripts/check-cert-hashes.ts
+++ b/apps/desktop/scripts/check-cert-hashes.ts
@@ -1,21 +1,22 @@
 import {
+  checkCertificatePinConfig,
   getConfiguredPinnedCertificateHashes,
-  getConfiguredSyncCertHostname,
-  hasPlaceholderHashes
+  getConfiguredSyncCertHostname
 } from '../src/main/sync/certificate-pins.ts'
 
 const hostname = getConfiguredSyncCertHostname(process.env.SYNC_SERVER_URL)
 const pins = getConfiguredPinnedCertificateHashes(process.env.SYNC_SERVER_URL)
+const strict = process.env.MEMRY_CERT_PINS_STRICT === '1'
 
-if (pins.length === 0) {
-  console.error(`ERROR: No certificate pins configured for sync host ${hostname}`)
+const result = checkCertificatePinConfig({ hostname, pins, strict })
+
+if (result.level === 'error') {
+  console.error(`ERROR: ${result.message}`)
   process.exit(1)
 }
 
-if (hasPlaceholderHashes(pins)) {
-  console.error(`ERROR: Placeholder certificate hashes found for sync host ${hostname}`)
-  console.error("Run 'pnpm cert:extract -- <hostname>' and update the matching host entry.")
-  process.exit(1)
+if (result.level === 'warn') {
+  console.warn(`WARNING: ${result.message}`)
+} else {
+  console.log(result.message)
 }
-
-console.log(`Certificate hashes OK for ${hostname} — no placeholders found`)

--- a/apps/desktop/src/main/sync/certificate-pins.test.ts
+++ b/apps/desktop/src/main/sync/certificate-pins.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from 'vitest'
 
 import {
   DEFAULT_SYNC_CERT_HOSTNAME,
+  checkCertificatePinConfig,
   getConfiguredSyncCertHostname,
   getPinnedCertificateHashesForHostname,
   getConfiguredPinnedCertificateHashes
 } from './certificate-pins'
+
+const REAL_PIN = 'sha256/LUkXdP3NZ4aBKbFriRvHtAP2pzTAO9sMqzOnl24KZV4='
+const PLACEHOLDER_PIN = 'sha256/PLACEHOLDER_PRIMARY_CERT_HASH_BASE64'
 
 describe('certificate-pins', () => {
   it('uses the default hostname when no sync server url is configured', () => {
@@ -32,5 +36,61 @@ describe('certificate-pins', () => {
 
   it('returns an empty pin set for unknown hosts', () => {
     expect(getPinnedCertificateHashesForHostname('example.com')).toEqual([])
+  })
+})
+
+describe('checkCertificatePinConfig', () => {
+  it('accepts a host whose pins are real SPKI hashes', () => {
+    const result = checkCertificatePinConfig({
+      hostname: 'sync-staging.memrynote.com',
+      pins: [REAL_PIN]
+    })
+
+    expect(result.level).toBe('ok')
+  })
+
+  it('warns instead of failing when a host still has placeholder pins', () => {
+    const result = checkCertificatePinConfig({
+      hostname: DEFAULT_SYNC_CERT_HOSTNAME,
+      pins: [PLACEHOLDER_PIN]
+    })
+
+    expect(result.level).toBe('warn')
+    expect(result.message).toContain(DEFAULT_SYNC_CERT_HOSTNAME)
+  })
+
+  it('fails on placeholder pins in strict mode', () => {
+    const result = checkCertificatePinConfig({
+      hostname: DEFAULT_SYNC_CERT_HOSTNAME,
+      pins: [PLACEHOLDER_PIN],
+      strict: true
+    })
+
+    expect(result.level).toBe('error')
+  })
+
+  it('fails when the host has no pin entry at all', () => {
+    const result = checkCertificatePinConfig({ hostname: 'example.com', pins: [] })
+
+    expect(result.level).toBe('error')
+    expect(result.message).toContain('example.com')
+  })
+
+  it('fails on a malformed pin even outside strict mode', () => {
+    const result = checkCertificatePinConfig({
+      hostname: 'sync-staging.memrynote.com',
+      pins: ['sha256/not-a-real-hash']
+    })
+
+    expect(result.level).toBe('error')
+  })
+
+  it('fails when a pin is missing the sha256 prefix', () => {
+    const result = checkCertificatePinConfig({
+      hostname: 'sync-staging.memrynote.com',
+      pins: [REAL_PIN.replace('sha256/', '')]
+    })
+
+    expect(result.level).toBe('error')
   })
 })

--- a/apps/desktop/src/main/sync/certificate-pins.ts
+++ b/apps/desktop/src/main/sync/certificate-pins.ts
@@ -8,6 +8,8 @@ export const PINNED_CERTIFICATE_HASHES_BY_HOST: Record<string, readonly string[]
   'sync-staging.memrynote.com': ['sha256/LUkXdP3NZ4aBKbFriRvHtAP2pzTAO9sMqzOnl24KZV4=']
 }
 
+const SPKI_PIN_PATTERN = /^sha256\/[A-Za-z0-9+/]{43}=$/
+
 function normalizeHostname(hostname: string): string {
   return hostname.trim().toLowerCase().replace(/\.+$/, '')
 }
@@ -39,4 +41,57 @@ export function getConfiguredPinnedCertificateHashes(
   syncServerUrl = process.env.SYNC_SERVER_URL
 ): readonly string[] {
   return getPinnedCertificateHashesForHostname(getConfiguredSyncCertHostname(syncServerUrl))
+}
+
+export interface CertificatePinConfigResult {
+  level: 'ok' | 'warn' | 'error'
+  message: string
+}
+
+/**
+ * Build-time audit of a host's pin entry. Placeholder pins are a supported
+ * state — the runtime falls back to standard TLS for them (see
+ * `createPinnedAgent`) — so they warn rather than fail. Only genuinely broken
+ * config fails: a host with no entry, or a pin that is not an SPKI hash and so
+ * could never match a real certificate. `strict` is for release builds of a
+ * host whose pinning has actually been activated.
+ */
+export function checkCertificatePinConfig({
+  hostname,
+  pins,
+  strict = false
+}: {
+  hostname: string
+  pins: readonly string[]
+  strict?: boolean
+}): CertificatePinConfigResult {
+  if (pins.length === 0) {
+    return {
+      level: 'error',
+      message: `No certificate pins configured for sync host ${hostname}. Add an entry to certificate-pins.ts.`
+    }
+  }
+
+  const malformed = pins.filter((pin) => !SPKI_PIN_PATTERN.test(pin) && !/PLACEHOLDER/i.test(pin))
+  if (malformed.length > 0) {
+    return {
+      level: 'error',
+      message: `Malformed certificate pin(s) for sync host ${hostname}: ${malformed.join(', ')}. Expected sha256/<base64 SPKI hash>.`
+    }
+  }
+
+  if (hasPlaceholderHashes(pins)) {
+    const remedy = `Run 'pnpm cert:extract -- ${hostname}' and update the matching host entry in certificate-pins.ts.`
+    return strict
+      ? {
+          level: 'error',
+          message: `Certificate pinning is required for sync host ${hostname} (MEMRY_CERT_PINS_STRICT=1) but the host still has placeholder pins. ${remedy}`
+        }
+      : {
+          level: 'warn',
+          message: `Certificate pinning is not activated for sync host ${hostname} — this build uses standard TLS. ${remedy}`
+        }
+  }
+
+  return { level: 'ok', message: `Certificate pins OK for ${hostname} (${pins.length} pinned)` }
 }

--- a/apps/docs/src/architecture/cryptography.md
+++ b/apps/docs/src/architecture/cryptography.md
@@ -107,6 +107,27 @@ allowed through the Electron verifier instead of being compared against an unrel
 pins. Development builds keep pinning disabled so local sync servers and test certificates remain
 usable.
 
+### Pin activation state
+
+A host entry in `certificate-pins.ts` may hold placeholder hashes, which means pinning has not been
+activated for that host yet. This is a supported state, not a broken one: the runtime falls back to
+standard TLS verification for placeholder pins rather than failing the connection.
+
+`pnpm cert:check` (also run by `prebuild` and `build:release`) audits the configured host and
+reflects the same rule:
+
+| Host pin state                                     | Result                               |
+| -------------------------------------------------- | ------------------------------------ |
+| Real SPKI hashes                                   | passes                               |
+| Placeholder hashes                                 | warns — build proceeds with TLS only |
+| Placeholder hashes with `MEMRY_CERT_PINS_STRICT=1` | fails                                |
+| No entry for the host, or a malformed pin          | fails                                |
+
+To activate pinning for a host, run `pnpm cert:extract -- <hostname>`, replace that host's
+placeholders with the emitted hashes (keep a backup pin for rotation), and set
+`MEMRY_CERT_PINS_STRICT=1` in the release build so the host can never silently regress to
+unpinned.
+
 ## Renderer Permission Policy
 
 The desktop app registers deny-by-default permission handlers on the Electron session at startup,


### PR DESCRIPTION
Fixes #876.

## Summary

`prebuild` ran `check-cert-hashes.sh`, which treated placeholder cert pins as a fatal error. Production's host entry ships placeholders, so **every first build from a fresh checkout failed** — `pnpm build`, `pnpm dev`, and e2e via `BUILD_BEFORE_TEST=1`.

The check contradicted the runtime, and guarded nothing:

- `createPinnedAgent` treats placeholder pins as *"pinning was never activated for this host; TLS-only is the deliberate fallback, not a runtime failure"* (`certificate-pinning.ts:27`, from #846). The build script called that same state fatal.
- It never guarded a release artifact: the script exited 0 on `CI=true`, and the release workflow runs `build:release` — a different script name, so npm's `prebuild` hook never fires for it. The only thing it ever blocked was a developer's machine.
- `c3fe4252b` had already punched the CI hole for this exact class of failure.

This aligns the check with the runtime:

| Host pin state | Result |
| --- | --- |
| Real SPKI hashes | passes |
| Placeholder hashes | **warns** — build proceeds with TLS only |
| Placeholder hashes with `MEMRY_CERT_PINS_STRICT=1` | fails |
| No entry for the host, or a malformed pin | fails |

- Hard failure is reserved for genuinely broken config: a host with no pin entry, or a pin that is not an SPKI hash and so could never match a real certificate.
- `MEMRY_CERT_PINS_STRICT=1` restores fail-closed, for release builds of a host whose pinning has actually been activated.
- Dropped the `CI=true` escape hatch — the check is now safe to run everywhere, and skipping it in CI hid it exactly where releases are built. The three `desktop-ci.yml` steps that call it were previously no-ops and now genuinely validate config.
- Added the check to `build:release`, which previously skipped it entirely.

The decision is extracted into `checkCertificatePinConfig()` so it is unit tested rather than only exercised by the build.

**No production behavior change.** Prod remains TLS-only until real pins land.

## Reviewer notes

Worth stating explicitly, since the docs read otherwise: **production sync is not certificate-pinned today.** `sync.memrynote.com` ships `PLACEHOLDER_*`, so released clients use plain TLS; only `sync-staging.memrynote.com` has a real pin. `docs/ARCHITECTURE.md` lists "TLS + certificate pinning" under transport security, which overstates the current state.

Deliberately out of scope: extracting real pins for `sync.memrynote.com`. That flips prod from TLS-only to hard pinning for real users, and a Cloudflare cert rotation against a stale committed pin would brick sync in already-released clients. It needs a backup pin plus a rotation plan first. When that happens, flipping `MEMRY_CERT_PINS_STRICT=1` in the release workflow is the one-line switch that makes the gate real.

## Release note
none

## Test plan

- `pnpm build` — succeeds from a fresh checkout (the reported symptom; includes `typecheck`)
- Check script exit codes: default `0` + warning · staging `0` · `MEMRY_CERT_PINS_STRICT=1` `1` · unknown host `1` · `CI=true` now runs instead of skipping
- `pnpm --filter @memry/desktop test:main` — 380 files / 4074 tests pass, incl. 6 new `checkCertificatePinConfig` tests (each watched fail first)
- `pnpm docs:impact --base origin/main --strict` — covered · `pnpm docs:build` — clean
- `git diff --check` — clean