### PR TITLE
fix(projections): give each projector its own queue (#877)

### DIFF
--- a/apps/desktop/src/main/projections/runtime.test.ts
+++ b/apps/desktop/src/main/projections/runtime.test.ts
@@ -89,7 +89,7 @@ describe('projection runtime', () => {
     )
   })
 
-  it('drains events in publish order and projector order', async () => {
+  it('drains each projector in publish order', async () => {
     const calls: string[] = []
     const first = createProjector('first', {
       project: vi.fn(async (event: ProjectionEvent) => {
@@ -107,12 +107,69 @@ describe('projection runtime', () => {
     runtime.publish({ type: 'inbox.deleted', itemId: 'item-1' })
     await runtime.flush()
 
-    expect(calls).toEqual([
+    expect(calls.filter((call) => call.startsWith('first:'))).toEqual([
       'first:note.upserted:note-1',
+      'first:inbox.deleted:item-1'
+    ])
+    expect(calls.filter((call) => call.startsWith('second:'))).toEqual([
       'second:note.upserted:note-1',
-      'first:inbox.deleted:item-1',
       'second:inbox.deleted:item-1'
     ])
+  })
+
+  /**
+   * Regression (#877): the embedding projector awaits a multi-second model load
+   * inside project(). With one shared queue that stalled every other projector,
+   * so note_cache kept a renamed note's old path and every read of it returned
+   * null — the whole renderer saw a live note as deleted.
+   */
+  it('does not let a slow projector stall the other projectors', async () => {
+    let releaseSlow: () => void = () => {}
+    const slowGate = new Promise<void>((resolve) => {
+      releaseSlow = resolve
+    })
+    const slow = createProjector('slow', { project: vi.fn(async () => slowGate) })
+    const fastCalls: string[] = []
+    const fast = createProjector('fast', {
+      project: vi.fn(async (event: ProjectionEvent) => {
+        fastCalls.push(eventEntityId(event))
+      })
+    })
+    const runtime = createProjectionRuntime({ projectors: [slow, fast] })
+
+    runtime.publish(noteEvent)
+    runtime.publish({ type: 'inbox.deleted', itemId: 'item-1' })
+
+    // Let every already-schedulable task run, without releasing the slow projector.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fastCalls).toEqual(['note-1', 'item-1'])
+
+    releaseSlow()
+    await runtime.flush()
+    expect(slow.project).toHaveBeenCalledTimes(2)
+  })
+
+  it('flush waits for every projector, including a slow one', async () => {
+    const done: string[] = []
+    const slow = createProjector('slow', {
+      project: vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        done.push('slow')
+      })
+    })
+    const fast = createProjector('fast', {
+      project: vi.fn(async () => {
+        done.push('fast')
+      })
+    })
+    const runtime = createProjectionRuntime({ projectors: [slow, fast] })
+
+    runtime.publish(noteEvent)
+    await runtime.flush()
+
+    expect(done).toEqual(['fast', 'slow'])
+    expect(runtime.getPendingCount()).toBe(0)
   })
 
   it('dispatches rebuild and reconcile to selected projectors', async () => {

--- a/apps/desktop/src/main/projections/runtime.ts
+++ b/apps/desktop/src/main/projections/runtime.ts
@@ -28,69 +28,112 @@ function selectProjectors(
   return projectors.filter((projector) => wanted.has(projector.name))
 }
 
+/**
+ * One independent queue per projector.
+ *
+ * Projectors used to share a single queue that awaited each of them in turn, so
+ * one slow projector blocked every other projector's writes head-of-line. The
+ * embedding projector awaits a multi-second model load inside project(), which
+ * left note_cache holding a renamed note's old path for seconds — long enough
+ * for every read of that note to resolve a file that no longer exists and come
+ * back null, i.e. a live note looking deleted to the renderer (#877).
+ *
+ * Each lane still drains its own events in publish order; only the ordering
+ * *between* projectors is relaxed, and no projector reads another's output
+ * during project() (they all work from the event payload).
+ */
+interface ProjectorLane {
+  projector: ProjectionProjector
+  bus: ProjectionBus
+  isScheduled: boolean
+  activeDrain: Promise<void> | null
+}
+
 export function createProjectionRuntime(options: ProjectionRuntimeOptions): ProjectionRuntime {
-  const bus = new ProjectionBus()
   const logger = options.logger
   const scheduleDrain = options.scheduleDrain ?? ((task: () => void) => queueMicrotask(task))
 
   let isStopped = false
-  let isScheduled = false
-  let activeDrain: Promise<void> | null = null
 
-  const runEvent = async (event: ProjectionEvent): Promise<void> => {
-    for (const projector of options.projectors) {
-      if (!projector.handles(event)) {
-        continue
-      }
+  const lanes: ProjectorLane[] = options.projectors.map((projector) => ({
+    projector,
+    bus: new ProjectionBus(),
+    isScheduled: false,
+    activeDrain: null
+  }))
 
-      try {
-        await projector.project(event)
-      } catch (error) {
-        logger?.error?.('Projection projector failed', {
-          projector: projector.name,
-          event,
-          error
-        })
-      }
+  const runEvent = async (lane: ProjectorLane, event: ProjectionEvent): Promise<void> => {
+    if (!lane.projector.handles(event)) {
+      return
+    }
+
+    try {
+      await lane.projector.project(event)
+    } catch (error) {
+      logger?.error?.('Projection projector failed', {
+        projector: lane.projector.name,
+        event,
+        error
+      })
     }
   }
 
-  const drain = async (): Promise<void> => {
-    if (activeDrain) {
-      return activeDrain
+  const drainLane = (lane: ProjectorLane): Promise<void> => {
+    if (lane.activeDrain) {
+      return lane.activeDrain
     }
 
-    activeDrain = (async () => {
+    // The handle is created and stored before the loop starts: an already-empty
+    // lane finishes its body synchronously, and assigning the promise afterwards
+    // would overwrite the null the `finally` already wrote, leaving the lane
+    // permanently "draining" (and drain()'s wait loop spinning).
+    let settle: () => void = () => {}
+    const handle = new Promise<void>((resolve) => {
+      settle = resolve
+    })
+    lane.activeDrain = handle
+
+    void (async () => {
       try {
-        while (!isStopped && bus.size > 0) {
-          const event = bus.dequeue()
+        while (!isStopped && lane.bus.size > 0) {
+          const event = lane.bus.dequeue()
           if (!event) {
             break
           }
 
-          await runEvent(event)
+          await runEvent(lane, event)
         }
       } finally {
-        isScheduled = false
-        activeDrain = null
+        lane.isScheduled = false
+        lane.activeDrain = null
+        settle()
 
-        if (!isStopped && bus.size > 0) {
-          schedule()
+        if (!isStopped && lane.bus.size > 0) {
+          schedule(lane)
         }
       }
     })()
 
-    return activeDrain
+    return handle
   }
 
-  const schedule = (): void => {
-    if (isStopped || isScheduled) {
+  const drain = async (): Promise<void> => {
+    // Lanes advance independently, so a lane can still be busy (or have been
+    // refilled) when a faster one settles. Loop until every lane is idle — or
+    // until the runtime stops, since a stopped lane never drains its backlog.
+    while (!isStopped && lanes.some((lane) => lane.bus.size > 0 || lane.activeDrain)) {
+      await Promise.all(lanes.map((lane) => drainLane(lane)))
+    }
+  }
+
+  const schedule = (lane: ProjectorLane): void => {
+    if (isStopped || lane.isScheduled) {
       return
     }
 
-    isScheduled = true
+    lane.isScheduled = true
     scheduleDrain(() => {
-      void drain()
+      void drainLane(lane)
     })
   }
 
@@ -101,8 +144,10 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
         return
       }
 
-      bus.enqueue(event)
-      schedule()
+      for (const lane of lanes) {
+        lane.bus.enqueue(event)
+        schedule(lane)
+      }
     },
 
     async flush() {
@@ -136,12 +181,14 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
       }
 
       isStopped = true
-      isScheduled = false
-      bus.clear()
+      for (const lane of lanes) {
+        lane.isScheduled = false
+        lane.bus.clear()
+      }
     },
 
     getPendingCount() {
-      return bus.size
+      return lanes.reduce((total, lane) => total + lane.bus.size, 0)
     }
   }
 }

--- a/apps/docs/src/architecture/local-storage.md
+++ b/apps/docs/src/architecture/local-storage.md
@@ -32,6 +32,28 @@ no user keys has no YAML block at all.
   inside a short window using the cached content hash (identical-content collisions match FIFO),
   since files carry no embedded id to match on.
 
+## Derived State Projections
+
+Index-DB state is not written inline by the code that changes a note. Write paths persist
+canonical data (the file plus `note_metadata` in the data DB) synchronously, then publish a
+projection event; projectors apply it to the index DB — `note_cache` and the link/tag tables,
+the FTS tables, and the embedding vectors.
+
+**Every projector has its own queue.** Each one still receives events in publish order, but a
+slow projector only delays itself. This matters because the embedding projector awaits a
+multi-second model load inside `project()`: on a single shared queue that stalled every other
+projector head-of-line, which left `note_cache` holding a renamed note's _old_ path long enough
+for reads of that note to resolve a file that no longer existed and come back `null` — a live
+note appearing deleted throughout the renderer.
+
+Two consequences worth knowing:
+
+- **Ordering between projectors is not guaranteed.** A projector must work from the event
+  payload, never from another projector's output.
+- **Index reads are eventually consistent.** They settle a microtask after the canonical write,
+  not synchronously with it. Callers needing the index to reflect a write immediately must
+  `await flushProjectionEvents()`, which drains every lane.
+
 ## Where the Files Live
 
 Inside the vault directory (chosen during [first run](/guide/first-run)):


### PR DESCRIPTION
## Summary

Fixes #877 — the canvas-cards e2e test *"card reflects a title edit made elsewhere, then goes dangling on delete"*, which failed deterministically on `main`.

The canvas card was innocent. It refetched on `notes:renamed` correctly; the main process genuinely answered `null`.

**Root cause.** `note_cache.path` is written *only* by the `note-derived-state` projector — asynchronously. `renameNote` moves the file and writes canonical `note_metadata` **synchronously**, then emits `notes:renamed` immediately. The projection runtime drained **one shared queue and awaited every projector per event**, so the slowest projector blocked all others head-of-line. `embedding-projector.project()` awaits `initEmbeddingModel()` (~2.4s) inline, and a note created seconds earlier was still sitting in it.

So after a rename `note_cache` kept the **old** path while the file was at the new one → `getNoteById` → `safeRead` ENOENT → **`notes:get` returned `null` for ~2.3s after every rename**. A live note looked deleted to the entire renderer, not just to canvas. The card latched `dangling` and never recovered, because no further event fires.

Same staleness, second symptom: the watcher's `add` for the new path missed `note_cache`, treated the renamed file as brand new, and logged `SqliteError: UNIQUE constraint failed: note_metadata.path`.

**Fix.** One queue per projector. Each lane still drains its own events in publish order; only ordering *between* projectors is relaxed — and no projector reads another's output during `project()` (they all work from the event payload). `flush` / `stop` / `getPendingCount` now span all lanes.

### Reviewer notes

- **Relaxed guarantee:** cross-projector ordering is no longer guaranteed. Verified none of the four projectors depends on it. Documented in `apps/docs/src/architecture/local-storage.md` alongside the eventual-consistency note for index reads.
- **Subtle bit worth a look** (`drainLane`): the drain handle is created and stored *before* the loop body starts. An already-empty lane completes its body synchronously, so assigning the promise afterwards would overwrite the `null` the `finally` already wrote and leave the lane permanently "draining" — which turns `drain()`'s wait loop into a 99% CPU microtask spin. That starves the event loop hard enough that vitest's `--testTimeout` can never fire, so the symptom is a hung run with no output. Comment in place.
- Memory: each event is now queued once per projector instead of once globally (×4). Negligible at these volumes, and `handles()` is still evaluated at drain time so its semantics are unchanged.

## Release note

Fixed a bug where renaming a note could briefly make it unreadable — showing it as deleted in canvas cards and other views — while background indexing was busy.

## Test plan

Evidence gathered with a throwaway diagnostic spec that polled `window.api.notes.get(id)` every 100ms after the rename and read `main.log` from inside the test.

Before:

```
dt=1     get: NULL   cardState: dangling   <- rename had already returned success
dt=2240  get: NULL   cardState: dangling
dt=2345  get: "Renamed ... | Renamed ....md"   <- recovers exactly when "Embedding model ready" logs
main.log: getNoteById: file missing on disk ... { path: 'Beta 1784750419438.md' }   <- the OLD path
main.log: Watcher Error: SqliteError: UNIQUE constraint failed: note_metadata.path
```

After: `get` resolves the renamed note at **dt=1ms**, card stays `ready`, **0** UNIQUE constraint errors.

| Check | Result |
| --- | --- |
| `runtime.test.ts` (2 new regression tests) | fail before the fix, 9 pass after |
| `vitest --project main` (projections, vault, notes, notes-handlers) | 547 passed |
| `playwright canvas-cards.e2e.ts` (full file) | **5 passed** — was 1 deterministic failure |
| `pnpm typecheck` / `pnpm lint` | clean |
| `pnpm docs:impact --strict` / `pnpm docs:build` | covered / clean |

## Not in this PR

`use-canvas-entities` still latches `dangling` permanently on any `null`. That is correct now that `null` means genuinely deleted, but there is no recovery path if a read ever hiccups again — worth a follow-up if we want belt-and-braces.