### PR TITLE
fix(canvas): give the Add card picker a backdrop scrim (#872)

### DIFF
--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-dialog.test.tsx
@@ -63,6 +63,15 @@ describe('CanvasAddCardDialog', () => {
     mocks.sources = { results: [], projections: [], loading: false }
   })
 
+  it('dims the canvas behind it with a backdrop scrim', () => {
+    setup()
+    // cmdk puts `className` on the Command root, so the scrim can only come
+    // from `overlayClassName` landing on Radix's [cmdk-overlay]. See #872.
+    const overlay = document.querySelector('[cmdk-overlay]')
+    expect(overlay).not.toBeNull()
+    expect(overlay?.className).toContain('bg-black/50')
+  })
+
   it('offers create-new-note when the query is empty', () => {
     const props = setup()
     fireEvent.click(screen.getByTestId('canvas-add-create-note'))

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-dialog.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-dialog.tsx
@@ -119,6 +119,10 @@ export function CanvasAddCardDialog({
       value={value}
       onValueChange={setValue}
       label={t('canvas.card.addCard')}
+      // `className` lands on the cmdk root, not on the Radix parts — the scrim
+      // has to go through `overlayClassName` to dim the canvas behind. Matches
+      // the command palette's bg-black/50. See #872.
+      overlayClassName="fixed inset-0 z-50 bg-black/50"
       className="fixed start-1/2 top-24 z-50 w-[32rem] max-w-[90vw] -translate-x-1/2 overflow-hidden rounded-xl border border-border bg-card shadow-lg rtl:translate-x-1/2"
     >
       <Command.Input

--- a/apps/docs/src/user-guide/canvas/cards-and-links.md
+++ b/apps/docs/src/user-guide/canvas/cards-and-links.md
@@ -9,7 +9,8 @@ canvas. The canvas stores the reference, never a copy of your content.
 - **Click "Add card"** at the bottom of the canvas to search your notes, tasks
   and events, or to create a new note without leaving the board. "Create
   note …" is always the first option, and typing a title carries it into the
-  new note.
+  new note. The picker opens over a dimmed canvas; press <kbd>Esc</kbd> or
+  click outside it to go back to the board.
 
 Task and calendar-event cards are added through **Add card**. Dragging works
 for notes from the sidebar; the Tasks and Calendar pages have no drag-in, so


### PR DESCRIPTION
## Summary

Fixes #872 — the canvas **Add card** picker rendered without a dimmed backdrop, so the canvas behind it stayed at full contrast and the dialog read as floating rather than modal.

Root cause: cmdk 1.1.1's `Command.Dialog` spreads `className` onto the cmdk **root** (inside `Dialog.Content`) and routes the Radix parts through separate `overlayClassName` / `contentClassName` props — confirmed in the shipped bundle:

```js
React.createElement(Dialog.Overlay, { "cmdk-overlay": "", className: overlayClassName })
```

So the overlay was rendering with an empty `className` and nothing was styling it. The dialog was already functionally modal via Radix; this was purely visual.

The fix routes the scrim through `overlayClassName` with the same `bg-black/50` the command palette uses. Positioning and DOM structure are untouched — Radix renders Overlay before Content, so the panel still paints above it.

Also on this branch:

- A red-first renderer test asserting `[cmdk-overlay]` carries the scrim class.
- One clause in `apps/docs/src/user-guide/canvas/cards-and-links.md` (the docs gate flagged the file): the picker opens over a dimmed canvas, Esc or outside-click dismisses. Both are existing Radix defaults, not new behavior.

## Release note

The canvas "Add card" picker now dims the canvas behind it, matching the search palette.

## Test plan

- `vitest --project renderer canvas-add-card-dialog.test.tsx` → **PASS 12 / FAIL 0** (new test failed first with `expected '' to contain 'bg-black/50'`)
- `pnpm --filter @memry/desktop typecheck:web` → clean
- `eslint` on both touched files → only pre-existing `set-state-in-effect` warnings on the untouched effects (lines 49–53, 65–68)
- `prettier --check` → clean
- `pnpm docs:impact --base origin/main --strict` → `covered`
- `pnpm docs:build` → complete

Not manually verified in the running app — the change is one Tailwind class on the Radix overlay, covered by the DOM assertion.
