### PR TITLE
refactor(canvas): single entityKey derivation (#873)

### DIFF
--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-dialog.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-dialog.tsx
@@ -10,16 +10,16 @@ import { Plus } from '@/lib/icons'
 import { useT } from '@memry/i18n/renderer'
 import type { CanvasEntityType } from '@memry/contracts/canvas-api'
 import {
-  candidateKey,
   candidatesFromProjections,
   candidatesFromSearch,
   groupCandidates,
   markOnCanvas,
   type AddCardCandidate
 } from './canvas-add-card'
+import { entityKey } from './canvas-cards'
 import { useCanvasAddSearch } from './use-canvas-add-search'
 
-/** cmdk value for the pinned create row; never collides with a candidateKey. */
+/** cmdk value for the pinned create row; never collides with an entityKey. */
 const CREATE_VALUE = '__create_note__'
 
 export interface CanvasAddCardDialogProps {
@@ -64,7 +64,7 @@ export function CanvasAddCardDialog({
   // existing item; the create row is one arrow-up away.
   useEffect(() => {
     const first = groups.note[0] ?? groups.task[0] ?? groups.calendar_event[0]
-    setValue(first ? candidateKey(first.entityType, first.entityId) : CREATE_VALUE)
+    setValue(first ? entityKey(first.entityType, first.entityId) : CREATE_VALUE)
   }, [groups])
 
   const select = (candidate: AddCardCandidate): void => {
@@ -83,7 +83,7 @@ export function CanvasAddCardDialog({
     return (
       <Command.Group heading={heading}>
         {items.map((candidate) => {
-          const key = candidateKey(candidate.entityType, candidate.entityId)
+          const key = entityKey(candidate.entityType, candidate.entityId)
           return (
             <Command.Item
               key={key}

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import type { SearchResultItem } from '@memry/contracts/search-api'
 import type { CalendarProjectionItem } from '@memry/contracts/calendar-api'
 import {
-  candidateKey,
   candidatesFromProjections,
   candidatesFromSearch,
   eventRange,
@@ -11,6 +10,7 @@ import {
   onCanvasKeys,
   revealScroll
 } from './canvas-add-card'
+import { entityKey } from './canvas-cards'
 
 function noteHit(id: string, title: string, fileType?: string): SearchResultItem {
   return {
@@ -177,7 +177,7 @@ describe('candidatesFromProjections', () => {
 describe('markOnCanvas + groupCandidates', () => {
   it('flags entities already carded and groups by type', () => {
     const keys = onCanvasKeys([{ entityType: 'task', entityId: 't1' }])
-    expect(keys.has(candidateKey('task', 't1'))).toBe(true)
+    expect(keys.has(entityKey('task', 't1'))).toBe(true)
 
     const marked = markOnCanvas(
       candidatesFromSearch([noteHit('n1', 'Alpha'), taskHit('t1', 'Ship it')]),

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card.ts
@@ -8,7 +8,7 @@
 import type { CanvasEntityType } from '@memry/contracts/canvas-api'
 import type { CalendarProjectionItem } from '@memry/contracts/calendar-api'
 import type { SearchResultItem } from '@memry/contracts/search-api'
-import { formatEventTime } from './canvas-cards'
+import { entityKey, formatEventTime } from './canvas-cards'
 
 /** How far either side of today the picker looks for events. */
 export const EVENT_RANGE_DAYS = 90
@@ -27,11 +27,6 @@ export interface AddCardGroups {
   note: AddCardCandidate[]
   task: AddCardCandidate[]
   calendar_event: AddCardCandidate[]
-}
-
-/** Stable identity for a candidate, matching extractEntityRefs' key shape. */
-export function candidateKey(entityType: CanvasEntityType, entityId: string): string {
-  return `${entityType}:${entityId}`
 }
 
 /**
@@ -116,7 +111,7 @@ export function candidatesFromProjections(
 export function onCanvasKeys(
   cards: readonly { entityType: CanvasEntityType; entityId: string }[]
 ): Set<string> {
-  return new Set(cards.map((card) => candidateKey(card.entityType, card.entityId)))
+  return new Set(cards.map((card) => entityKey(card.entityType, card.entityId)))
 }
 
 export function markOnCanvas(
@@ -125,7 +120,7 @@ export function markOnCanvas(
 ): AddCardCandidate[] {
   return candidates.map((candidate) => ({
     ...candidate,
-    onCanvas: keys.has(candidateKey(candidate.entityType, candidate.entityId))
+    onCanvas: keys.has(entityKey(candidate.entityType, candidate.entityId))
   }))
 }
 

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-cards.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-cards.ts
@@ -97,6 +97,16 @@ export function getCardRefs(elements: readonly CardElement[]): CanvasCardRef[] {
 }
 
 /**
+ * The one derivation of an entity's string identity. Everything that keys a
+ * Map/Set by (entityType, entityId) — ref dedup, the resolved-entity map, the
+ * picker's "already on canvas" check — goes through here so the shapes cannot
+ * drift apart.
+ */
+export function entityKey(entityType: CanvasEntityType, entityId: string): string {
+  return `${entityType}:${entityId}`
+}
+
+/**
  * Advisory entity refs for persistence, deduped by (entityType, entityId).
  * The store rewrites canvas_entity_refs from this on every save.
  */
@@ -104,7 +114,7 @@ export function extractEntityRefs(elements: readonly CardElement[]): CanvasEntit
   const seen = new Set<string>()
   const refs: CanvasEntityRef[] = []
   for (const card of getCardRefs(elements)) {
-    const key = `${card.entityType}:${card.entityId}`
+    const key = entityKey(card.entityType, card.entityId)
     if (seen.has(key)) {
       continue
     }

--- a/apps/desktop/src/renderer/src/pages/canvas/use-canvas-entities.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/use-canvas-entities.ts
@@ -19,7 +19,7 @@ import {
 } from '@/services/tasks-service'
 import { calendarService, onCalendarChanged } from '@/services/calendar-service'
 import { createLogger } from '@/lib/logger'
-import type { CanvasCardRef } from './canvas-cards'
+import { entityKey, type CanvasCardRef } from './canvas-cards'
 import type { CanvasEntityType } from '@memry/contracts/canvas-api'
 
 const log = createLogger('SpatialCanvas')
@@ -38,9 +38,7 @@ export type CanvasEntityState =
       isAllDay: boolean
     }
 
-export function entityKey(entityType: CanvasEntityType, entityId: string): string {
-  return `${entityType}:${entityId}`
-}
+export { entityKey }
 
 type EntityMap = ReadonlyMap<string, CanvasEntityState>
 


### PR DESCRIPTION
## Summary

Closes #873 (epic #878, follow-up from #868).

`"<entityType>:<entityId>"` was derived independently in three places — inline in `extractEntityRefs`, as `entityKey` in `use-canvas-entities.ts`, and as `candidateKey` in `canvas-add-card.ts`. `candidateKey`'s docblock documented the coupling rather than removing it: if one ever drifted, the picker's "already on canvas" check would silently stop matching and duplicate cards would appear for entities already placed.

Now there is one exported `entityKey` and everything routes through it.

**Where it lives:** `canvas-cards.ts`, not `use-canvas-entities.ts` as the issue suggested. `canvas-add-card.ts` is deliberately React- and service-free (its docblock commits to this so the merge/dedup/scroll logic unit-tests without either library) — importing from the hook module would pull React plus the notes/tasks/calendar services into it. `canvas-cards.ts` is the pure module both already depend on.

`use-canvas-entities.ts` re-exports `entityKey`, so existing imports and `canvas-card-overlay.test.tsx`'s partial mock (`actual.entityKey`) keep working untouched. `candidateKey` is deleted; the dialog and its test import `entityKey` instead.

**Deliberately left alone:**
- `src/main/canvas/scene-refs.ts` — same key shape, but across the renderer/main process boundary; its docblock already explains why that duplication exists.
- `data-canvas-card-entity` in `canvas-card.tsx` / `canvas-card-active.tsx` — a DOM contract hardcoded literally in ~20 E2E locators, not an internal Map key. Routing it through `entityKey` would couple a test selector contract to an internal helper without removing any drift.

No behavior change: the produced string is byte-identical, so nothing persisted, rendered, or selected on moves.

## Release note
none

## Test plan

- `pnpm --filter @memry/desktop typecheck:web` — clean
- `pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/pages/canvas` — 152 passed, 0 failed
- `pnpm exec eslint <5 changed files>` — 0 errors (7 pre-existing `react-hooks` warnings in the dialog, on lines this PR does not touch)

Note: `pnpm docs:impact --base origin/main --strict` reports `missing-docs`, as it does for any `apps/desktop` change. Nothing user-facing moved here, so there is no real doc to update.
