### PR TITLE
fix(canvas): filter note file types inside quick search so the Add card cap counts placeable rows

### DIFF
--- a/apps/desktop/src/main/database/queries/search.test.ts
+++ b/apps/desktop/src/main/database/queries/search.test.ts
@@ -39,6 +39,34 @@ function createDbMock() {
   }
 }
 
+/** Flattens a drizzle SQL object into its literal text and bound params. */
+function sqlParts(query: unknown): { text: string; params: unknown[] } {
+  const chunks = (query as { queryChunks?: unknown[] }).queryChunks ?? []
+  let text = ''
+  const params: unknown[] = []
+  const walk = (chunk: unknown): void => {
+    // Bound values ride in the chunk list as bare primitives; only StringChunk
+    // (a `value: string[]`) and nested SQL carry literal text.
+    if (chunk === null || typeof chunk !== 'object') {
+      params.push(chunk)
+      return
+    }
+    const value = (chunk as { value?: unknown }).value
+    if (Array.isArray(value) && value.every((part) => typeof part === 'string')) {
+      text += value.join('')
+      return
+    }
+    const nested = (chunk as { queryChunks?: unknown[] }).queryChunks
+    if (nested) {
+      nested.forEach(walk)
+      return
+    }
+    params.push(value ?? chunk)
+  }
+  chunks.forEach(walk)
+  return { text, params }
+}
+
 function query(overrides: Partial<SearchQuery> = {}): SearchQuery {
   return {
     text: 'budget',
@@ -277,6 +305,45 @@ describe('cross-type search queries', () => {
     expect(fuzzySearchTitlesMock).toHaveBeenCalledTimes(2)
   })
 
+  it('filters note file types inside the FTS query so the cap counts eligible rows', () => {
+    indexDb.allQueue.push(noteRows(5))
+
+    searchAll(indexDb, dataDb, query({ types: ['note'], noteFileTypes: ['markdown'] }))
+
+    const fts = sqlParts(indexDb.all.mock.calls[0][0])
+    expect(fts.text).toContain("COALESCE(nc.file_type, 'markdown') IN (")
+    expect(fts.params).toContain('markdown')
+    // The eligibility test must sit above LIMIT, not after it.
+    expect(fts.text.indexOf('COALESCE')).toBeLessThan(fts.text.indexOf('LIMIT'))
+  })
+
+  it('filters fuzzy fallback candidates by note file type too', () => {
+    indexDb.allQueue.push(noteRows(1), [])
+
+    searchAll(indexDb, dataDb, query({ types: ['note'], noteFileTypes: ['markdown'] }))
+
+    const titles = sqlParts(indexDb.all.mock.calls[1][0])
+    expect(titles.text).toContain("COALESCE(nc.file_type, 'markdown') IN (")
+    expect(titles.params).toContain('markdown')
+  })
+
+  it('forwards quick-search note file types into the note query', () => {
+    indexDb.allQueue.push(noteRows(5), journalRows(5))
+    dataDb.allQueue.push(taskRows(5), inboxRows(5))
+
+    quickSearch(indexDb, dataDb, { text: 'invoice', noteFileTypes: ['markdown'] })
+
+    expect(sqlParts(indexDb.all.mock.calls[0][0]).params).toContain('markdown')
+  })
+
+  it('leaves note results unfiltered when no file types are requested', () => {
+    indexDb.allQueue.push(noteRows(5))
+
+    searchAll(indexDb, dataDb, query({ types: ['note'] }))
+
+    expect(sqlParts(indexDb.all.mock.calls[0][0]).text).not.toContain('COALESCE')
+  })
+
   it('continues after per-type FTS failures and keeps exact results if fuzzy fallback fails', () => {
     indexDb.allQueue.push(new Error('fts notes failed'))
     dataDb.allQueue.push(taskRows(1), new Error('title load failed'))
@@ -301,7 +368,7 @@ describe('cross-type search queries', () => {
     indexDb.allQueue.push(noteRows(3), journalRows(3))
     dataDb.allQueue.push(taskRows(3), inboxRows(3))
 
-    const quick = quickSearch(indexDb, dataDb, 'budget')
+    const quick = quickSearch(indexDb, dataDb, { text: 'budget' })
 
     expect(quick.results).toHaveLength(12)
     expect(quick.results[0].id).toBe('note-1')

--- a/apps/desktop/src/main/database/queries/search.ts
+++ b/apps/desktop/src/main/database/queries/search.ts
@@ -12,6 +12,8 @@ import { sql } from 'drizzle-orm'
 import type { DataDb, IndexDb } from '../types'
 import type {
   ContentType,
+  NoteFileType,
+  QuickSearchInput,
   SearchResultItem,
   SearchResultGroup,
   SearchResponse,
@@ -83,7 +85,27 @@ interface FtsInboxRow {
 // Per-type FTS queries
 // ============================================================================
 
-function searchNotes(indexDb: IndexDb, ftsQuery: string, limit: number): SearchResultItem[] {
+/**
+ * `file_type` is NULL for rows written before filed binaries existed, and those
+ * are always markdown — so the eligibility test has to coalesce, not compare.
+ * Returns an always-true fragment when the caller wants every file type.
+ */
+function noteFileTypeFilter(noteFileTypes: NoteFileType[] | undefined) {
+  if (!noteFileTypes || noteFileTypes.length === 0) {
+    return sql`1 = 1`
+  }
+  return sql`COALESCE(nc.file_type, 'markdown') IN (${sql.join(
+    noteFileTypes.map((fileType) => sql`${fileType}`),
+    sql`, `
+  )})`
+}
+
+function searchNotes(
+  indexDb: IndexDb,
+  ftsQuery: string,
+  limit: number,
+  noteFileTypes?: NoteFileType[]
+): SearchResultItem[] {
   if (!ftsQuery) return []
 
   const rows = indexDb.all<FtsNoteRow>(sql`
@@ -102,6 +124,7 @@ function searchNotes(indexDb: IndexDb, ftsQuery: string, limit: number): SearchR
     JOIN note_cache nc ON nc.id = fts_notes.id
     WHERE fts_notes MATCH ${ftsQuery}
       AND nc.date IS NULL
+      AND ${noteFileTypeFilter(noteFileTypes)}
     ORDER BY rank
     LIMIT ${limit}
   `)
@@ -282,12 +305,16 @@ interface TitleRow {
 }
 
 function getNoteTitles(
-  indexDb: IndexDb
+  indexDb: IndexDb,
+  noteFileTypes?: NoteFileType[]
 ): Array<TitleRow & { type: ContentType; metadata: NoteResultMetadata }> {
   const rows = indexDb.all<
     TitleRow & { path: string; emoji: string | null; fileType: NoteResultMetadata['fileType'] }
   >(
-    sql`SELECT id, title, path, emoji, file_type as fileType, modified_at as modifiedAt FROM note_cache WHERE date IS NULL`
+    sql`SELECT id, title, path, emoji, file_type as fileType, modified_at as modifiedAt
+        FROM note_cache nc
+        WHERE date IS NULL
+          AND ${noteFileTypeFilter(noteFileTypes)}`
   )
   return rows.map((r) => ({
     ...r,
@@ -454,10 +481,15 @@ function applyPostFilters(
   return filtered
 }
 
-function loadFuzzyCandidates(indexDb: IndexDb, dataDb: DataDb, type: ContentType) {
+function loadFuzzyCandidates(
+  indexDb: IndexDb,
+  dataDb: DataDb,
+  type: ContentType,
+  noteFileTypes?: NoteFileType[]
+) {
   switch (type) {
     case 'note':
-      return getNoteTitles(indexDb)
+      return getNoteTitles(indexDb, noteFileTypes)
     case 'journal':
       return getJournalTitles(indexDb)
     case 'task':
@@ -496,7 +528,7 @@ export function searchAll(indexDb: IndexDb, dataDb: DataDb, query: SearchQuery):
     try {
       switch (type) {
         case 'note':
-          results = searchNotes(indexDb, ftsQuery, fetchLimit)
+          results = searchNotes(indexDb, ftsQuery, fetchLimit, query.noteFileTypes)
           break
         case 'journal':
           results = searchJournals(indexDb, ftsQuery, fetchLimit)
@@ -523,7 +555,7 @@ export function searchAll(indexDb: IndexDb, dataDb: DataDb, query: SearchQuery):
 
     if (normalized.length < FUZZY_FALLBACK_THRESHOLD) {
       try {
-        const candidates = loadFuzzyCandidates(indexDb, dataDb, type)
+        const candidates = loadFuzzyCandidates(indexDb, dataDb, type, query.noteFileTypes)
         const existingIds = new Set(normalized.map((r) => r.id))
         const fuzzyResults = fuzzySearchTitles(candidates, query.text, query.limit).filter(
           (r) => !existingIds.has(r.id)
@@ -551,17 +583,22 @@ export function searchAll(indexDb: IndexDb, dataDb: DataDb, query: SearchQuery):
   return { groups, totalCount, queryTimeMs }
 }
 
-export function quickSearch(indexDb: IndexDb, dataDb: DataDb, text: string): QuickSearchResponse {
+export function quickSearch(
+  indexDb: IndexDb,
+  dataDb: DataDb,
+  input: QuickSearchInput
+): QuickSearchResponse {
   const startTime = performance.now()
   const query: SearchQuery = {
-    text,
+    text: input.text,
     types: [],
     tags: [],
     dateRange: null,
     projectId: null,
     folderPath: null,
     limit: 5,
-    offset: 0
+    offset: 0,
+    noteFileTypes: input.noteFileTypes
   }
 
   const response = searchAll(indexDb, dataDb, query)

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -245,8 +245,8 @@ export interface MainIpcInvokeHandlers {
   "search:get-all-tags": (...args: []) => Awaited<Promise<string[]>>
   "search:get-reasons": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchReason[]>>
   "search:get-stats": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchStats>>
-  "search:query": (...args: [{ text: string; types?: ("inbox" | "note" | "task" | "journal")[] | undefined; tags?: string[] | undefined; dateRange?: { from: string; to: string; } | null | undefined; projectId?: string | null | undefined; folderPath?: string | null | undefined; limit?: number | undefined; offset?: number | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchResponse>>
-  "search:quick": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").QuickSearchResponse>>
+  "search:query": (...args: [{ text: string; types?: ("inbox" | "note" | "task" | "journal")[] | undefined; tags?: string[] | undefined; dateRange?: { from: string; to: string; } | null | undefined; projectId?: string | null | undefined; folderPath?: string | null | undefined; limit?: number | undefined; offset?: number | undefined; noteFileTypes?: ("markdown" | "pdf" | "image" | "audio" | "video")[] | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").SearchResponse>>
+  "search:quick": (...args: [{ text: string; noteFileTypes?: ("markdown" | "pdf" | "image" | "audio" | "video")[] | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/search-api").QuickSearchResponse>>
   "search:rebuild-index": (...args: []) => Awaited<Promise<{ notes: number; tasks: number; inbox: number; durationMs: number; started: true; error?: undefined; } | { started: false; error: string; }>>
   "settings:downloadVoiceModel": (...args: []) => Awaited<Promise<{ success: boolean; error?: undefined; } | { success: boolean; error: string; }>>
   "settings:get": (...args: [string]) => Awaited<string | null>

--- a/apps/desktop/src/main/ipc/search-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/search-handlers.test.ts
@@ -229,8 +229,15 @@ describe('search-handlers: reasons', () => {
         queryTimeMs: 5
       })
 
-      await invokeHandler(SearchChannels.invoke.QUICK, 'budget')
+      await invokeHandler(SearchChannels.invoke.QUICK, {
+        text: 'budget',
+        noteFileTypes: ['markdown']
+      })
 
+      expect(searchQueriesMock.quickSearch.mock.calls[0][2]).toEqual({
+        text: 'budget',
+        noteFileTypes: ['markdown']
+      })
       expect(trackMainEventMock).toHaveBeenCalledWith(
         'search_performed',
         expect.objectContaining({
@@ -259,10 +266,12 @@ describe('search-handlers: reasons', () => {
       searchQueriesMock.quickSearch.mockImplementationOnce(() => {
         throw new Error('quick failed')
       })
-      await expect(invokeHandler(SearchChannels.invoke.QUICK, 'budget')).resolves.toEqual({
-        results: [],
-        queryTimeMs: 0
-      })
+      await expect(invokeHandler(SearchChannels.invoke.QUICK, { text: 'budget' })).resolves.toEqual(
+        {
+          results: [],
+          queryTimeMs: 0
+        }
+      )
       expect(trackMainEventMock).toHaveBeenCalledWith(
         'search_performed',
         expect.objectContaining({ result: 'failed' })

--- a/apps/desktop/src/main/ipc/search-handlers.ts
+++ b/apps/desktop/src/main/ipc/search-handlers.ts
@@ -1,9 +1,13 @@
 import { ipcMain } from 'electron'
 import { SearchChannels } from '@memry/contracts/ipc-channels'
-import { SearchQuerySchema, AddReasonSchema } from '@memry/contracts/search-api'
+import {
+  SearchQuerySchema,
+  AddReasonSchema,
+  QuickSearchInputSchema
+} from '@memry/contracts/search-api'
 import type { SearchReason } from '@memry/contracts/search-api'
 import { createLogger } from '../lib/logger'
-import { createValidatedHandler, createHandler, createStringHandler } from './validate'
+import { createValidatedHandler, createHandler } from './validate'
 import { getDatabase, getIndexDatabase } from '../database'
 import { generateId } from '../lib/id'
 import { searchQueries } from '../search/store'
@@ -56,11 +60,11 @@ export function registerSearchHandlers(): void {
 
   ipcMain.handle(
     SearchChannels.invoke.QUICK,
-    createStringHandler(async (text) => {
+    createValidatedHandler(QuickSearchInputSchema, async (input) => {
       try {
         const indexDb = getIndexDatabase()
         const dataDb = getDatabase()
-        const result = searchQueries.quickSearch(indexDb, dataDb, text)
+        const result = searchQueries.quickSearch(indexDb, dataDb, input)
         const totalCount = result.results?.length ?? 0
         trackMainEvent('search_performed', {
           surface: 'search',

--- a/apps/desktop/src/preload/api/preload-api.test.ts
+++ b/apps/desktop/src/preload/api/preload-api.test.ts
@@ -514,7 +514,14 @@ describe('preload api wrappers', () => {
     await expectInvoke(() => searchApi.query({ text: 'memo' }), SearchChannels.invoke.QUERY, {
       text: 'memo'
     })
-    await expectInvoke(() => searchApi.quick('memo'), SearchChannels.invoke.QUICK, 'memo')
+    await expectInvoke(() => searchApi.quick('memo'), SearchChannels.invoke.QUICK, {
+      text: 'memo',
+      noteFileTypes: undefined
+    })
+    await expectInvoke(() => searchApi.quick('memo', ['markdown']), SearchChannels.invoke.QUICK, {
+      text: 'memo',
+      noteFileTypes: ['markdown']
+    })
     await expectInvoke(() => searchApi.getStats(), SearchChannels.invoke.GET_STATS)
     await expectInvoke(() => searchApi.rebuildIndex(), SearchChannels.invoke.REBUILD_INDEX)
     await expectInvoke(() => searchApi.getReasons(), SearchChannels.invoke.GET_REASONS)

--- a/apps/desktop/src/preload/api/search.ts
+++ b/apps/desktop/src/preload/api/search.ts
@@ -10,6 +10,8 @@ export const graphApi = {
 
 type SearchItemType = 'note' | 'journal' | 'task' | 'inbox'
 
+type SearchNoteFileType = 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
+
 export const searchApi = {
   query: (params: {
     text: string
@@ -20,8 +22,11 @@ export const searchApi = {
     folderPath?: string | null
     limit?: number
     offset?: number
+    noteFileTypes?: SearchNoteFileType[]
   }) => invoke(SearchChannels.invoke.QUERY, params),
-  quick: (text: string) => invoke(SearchChannels.invoke.QUICK, text),
+  /** `noteFileTypes` narrows note hits before the per-type cap applies (#874). */
+  quick: (text: string, noteFileTypes?: SearchNoteFileType[]) =>
+    invoke(SearchChannels.invoke.QUICK, { text, noteFileTypes }),
   getStats: () => invoke(SearchChannels.invoke.GET_STATS),
   rebuildIndex: () => invoke(SearchChannels.invoke.REBUILD_INDEX),
   getReasons: () => invoke(SearchChannels.invoke.GET_REASONS),

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -815,6 +815,7 @@ export type InboxClientAPI = InboxRpc.InboxClientAPI
 
 // Search types
 import type {
+  NoteFileType,
   SearchResponse,
   QuickSearchResponse,
   SearchStats,
@@ -832,8 +833,9 @@ export interface SearchClientAPI {
     folderPath?: string | null
     limit?: number
     offset?: number
+    noteFileTypes?: NoteFileType[]
   }): Promise<SearchResponse>
-  quick(text: string): Promise<QuickSearchResponse>
+  quick(text: string, noteFileTypes?: NoteFileType[]): Promise<QuickSearchResponse>
   getStats(): Promise<SearchStats>
   rebuildIndex(): Promise<{ started: true }>
   getReasons(): Promise<SearchReason[]>

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card.ts
@@ -44,7 +44,8 @@ export function candidatesFromSearch(results: readonly SearchResultItem[]): AddC
     if (result.metadata.type === 'note') {
       // A "note" hit can be a filed binary (pdf/image/audio/video — see #800).
       // Canvas note cards render markdown previews and open the markdown
-      // editor, so a binary is not placeable.
+      // editor, so a binary is not placeable. The picker's quick-search call
+      // already asks for markdown only (#874); this is the backstop.
       if ((result.metadata.fileType ?? 'markdown') !== 'markdown') {
         continue
       }

--- a/apps/desktop/src/renderer/src/pages/canvas/use-canvas-add-search.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/use-canvas-add-search.test.ts
@@ -7,7 +7,9 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/services/search-service', () => ({
-  searchService: { quick: (text: string) => mocks.quick(text) }
+  searchService: {
+    quick: (text: string, noteFileTypes?: string[]) => mocks.quick(text, noteFileTypes)
+  }
 }))
 vi.mock('@/services/calendar-service', () => ({
   calendarService: { getRange: (input: unknown) => mocks.getRange(input) }
@@ -50,7 +52,7 @@ describe('useCanvasAddSearch', () => {
   it('returns search results once the query resolves', async () => {
     const { result } = renderHook(() => useCanvasAddSearch(true, 'alpha'))
     await waitFor(() => expect(result.current.results).toEqual([{ id: 'n1' }]))
-    expect(mocks.quick).toHaveBeenCalledWith('alpha')
+    expect(mocks.quick).toHaveBeenCalledWith('alpha', ['markdown'])
     expect(result.current.loading).toBe(false)
   })
 
@@ -61,7 +63,7 @@ describe('useCanvasAddSearch', () => {
     rerender({ q: 'al' })
     rerender({ q: 'alp' })
     await waitFor(() => expect(mocks.quick).toHaveBeenCalledTimes(1))
-    expect(mocks.quick).toHaveBeenCalledWith('alp')
+    expect(mocks.quick).toHaveBeenCalledWith('alp', ['markdown'])
   })
 
   it('falls back to empty results when search rejects', async () => {

--- a/apps/desktop/src/renderer/src/pages/canvas/use-canvas-add-search.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/use-canvas-add-search.ts
@@ -8,7 +8,7 @@
 
 import { useEffect, useState } from 'react'
 import type { CalendarProjectionItem } from '@memry/contracts/calendar-api'
-import type { SearchResultItem } from '@memry/contracts/search-api'
+import type { NoteFileType, SearchResultItem } from '@memry/contracts/search-api'
 import { calendarService } from '@/services/calendar-service'
 import { searchService } from '@/services/search-service'
 import { createLogger } from '@/lib/logger'
@@ -24,6 +24,12 @@ const log = createLogger('SpatialCanvas')
 // results commit in the same tick as the query change and the highlight
 // would flicker to the create row on every keystroke.
 const SEARCH_DEBOUNCE_MS = 150
+
+// A filed binary is a "note" hit the picker can never place (see #800), and
+// quick-search caps results at 5 per type. Asking for markdown only makes the
+// cap count placeable rows, so matching PDFs can no longer eat every note slot
+// and leave the Notes group empty (#874).
+const NOTE_FILE_TYPES: NoteFileType[] = ['markdown']
 
 export interface CanvasAddSources {
   results: SearchResultItem[]
@@ -77,7 +83,7 @@ export function useCanvasAddSearch(open: boolean, query: string): CanvasAddSourc
     const timer = setTimeout(() => {
       void (async () => {
         try {
-          const response = await searchService.quick(query)
+          const response = await searchService.quick(query, NOTE_FILE_TYPES)
           if (!cancelled) {
             setResults(response.results)
           }

--- a/apps/desktop/src/renderer/src/services/search-service.test.ts
+++ b/apps/desktop/src/renderer/src/services/search-service.test.ts
@@ -31,7 +31,10 @@ describe('searchService', () => {
     expect(api.search.query).toHaveBeenCalledWith({ query: 'roadmap' })
 
     await searchService.quick('road')
-    expect(api.search.quick).toHaveBeenCalledWith('road')
+    expect(api.search.quick).toHaveBeenCalledWith('road', undefined)
+
+    await searchService.quick('road', ['markdown'])
+    expect(api.search.quick).toHaveBeenCalledWith('road', ['markdown'])
 
     await searchService.getStats()
     expect(api.search.getStats).toHaveBeenCalled()

--- a/apps/desktop/src/renderer/src/services/search-service.ts
+++ b/apps/desktop/src/renderer/src/services/search-service.ts
@@ -1,4 +1,5 @@
 import type {
+  NoteFileType,
   SearchQueryInput,
   SearchResponse,
   QuickSearchResponse,
@@ -13,8 +14,8 @@ export const searchService = {
     return window.api.search.query(params)
   },
 
-  quick(text: string): Promise<QuickSearchResponse> {
-    return window.api.search.quick(text)
+  quick(text: string, noteFileTypes?: NoteFileType[]): Promise<QuickSearchResponse> {
+    return window.api.search.quick(text, noteFileTypes)
   },
 
   getStats(): Promise<SearchStats> {

--- a/apps/docs/src/user-guide/canvas/cards-and-links.md
+++ b/apps/docs/src/user-guide/canvas/cards-and-links.md
@@ -15,6 +15,11 @@ Task and calendar-event cards are added through **Add card**. Dragging works
 for notes from the sidebar; the Tasks and Calendar pages have no drag-in, so
 tasks and events always go through the picker.
 
+Files you have filed into your vault — PDFs, images, audio and video — do not
+appear in the picker. A note card renders a markdown preview, so those open in
+the file viewer instead. They never take up room in the search results, so a
+matching note is always shown even when many filed files share its name.
+
 If you pick something that is already on the board, Memry scrolls to the card
 you already have instead of adding a duplicate — look for the **On canvas**
 badge in the results.

--- a/packages/contracts/src/search-api.ts
+++ b/packages/contracts/src/search-api.ts
@@ -24,6 +24,12 @@ export type MatchType = 'exact' | 'prefix' | 'fuzzy'
 
 export type DatePreset = 'today' | 'this-week' | 'this-month' | 'custom'
 
+/**
+ * Underlying file behind a "note" row. Absent in older index rows, which are
+ * always markdown.
+ */
+export type NoteFileType = 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
+
 // ============================================================================
 // Search Result Metadata (per-type)
 // ============================================================================
@@ -39,7 +45,7 @@ export interface NoteResultMetadata {
    * (image/pdf/audio/video) means this "note" result is actually a filed file
    * and must be opened via the file viewer, not the markdown editor. See #800.
    */
-  fileType?: 'markdown' | 'pdf' | 'image' | 'audio' | 'video'
+  fileType?: NoteFileType
 }
 
 export interface JournalResultMetadata {
@@ -110,6 +116,13 @@ export interface SearchQuery {
   folderPath: string | null
   limit: number
   offset: number
+  /**
+   * Restricts note hits to these file types. Applied inside the FTS query so
+   * `limit` counts eligible rows only — filtering after the cap would let
+   * matching binaries starve the markdown notes out of the results (#874).
+   * Omitted = every file type.
+   */
+  noteFileTypes?: NoteFileType[]
 }
 
 // ============================================================================
@@ -179,6 +192,8 @@ export interface IndexRebuildProgress {
 
 export const ContentTypeEnum = z.enum(['note', 'journal', 'task', 'inbox'])
 
+export const NoteFileTypeEnum = z.enum(['markdown', 'pdf', 'image', 'audio', 'video'])
+
 export const DateRangeSchema = z.object({
   from: z.string(),
   to: z.string()
@@ -192,10 +207,18 @@ export const SearchQuerySchema = z.object({
   projectId: z.string().nullable().default(null),
   folderPath: z.string().nullable().default(null),
   limit: z.number().min(1).max(100).default(10),
-  offset: z.number().min(0).default(0)
+  offset: z.number().min(0).default(0),
+  noteFileTypes: z.array(NoteFileTypeEnum).min(1).optional()
 })
 
 export type SearchQueryInput = z.infer<typeof SearchQuerySchema>
+
+export const QuickSearchInputSchema = z.object({
+  text: z.string(),
+  noteFileTypes: z.array(NoteFileTypeEnum).min(1).optional()
+})
+
+export type QuickSearchInput = z.infer<typeof QuickSearchInputSchema>
 
 export const AddReasonSchema = z.object({
   itemId: z.string().min(1),


### PR DESCRIPTION
## Summary

Fixes #874. The canvas "Add card" picker could render an empty **Notes** group even when a markdown note matched.

`quickSearch` caps results at 5 per content type, and the picker dropped filed binaries client-side (a note card renders a markdown preview and cannot show a PDF — see #800). The cap ran **before** the filter, so 5 matching PDFs consumed the whole note budget and every one was then filtered out.

The eligibility test now lives in the query, so `LIMIT` counts only rows the caller can place:

- `SearchQuery` gains an optional `noteFileTypes`, applied as `COALESCE(nc.file_type, 'markdown') IN (...)`. The coalesce matters: `file_type` is `NULL` for index rows written before filed binaries existed, and those are always markdown.
- Applied in **both** `searchNotes` (FTS) and `getNoteTitles` (fuzzy-title fallback) — the fallback fires when FTS returns fewer than 3 hits and would otherwise pull binaries straight back in.
- `search:quick` payload changes from a bare string to `{ text, noteFileTypes? }`. Preload keeps the ergonomic `quick(text, noteFileTypes?)` signature; invoke map regenerated.
- The picker asks for `['markdown']`. The client-side filter in `candidatesFromSearch` stays as a backstop.

Global search is unchanged — omitting `noteFileTypes` keeps every file type.

Considered raising the note limit and filtering after, but that only moves the threshold: a user with 20 matching PDFs hits the same empty group.

### Reviewer notes

- `search:quick` is renderer↔main only and the two ship together, so the payload change needs no version tolerance. No schema, sync, or file-format surface is touched.
- Test helper `sqlParts` in `search.test.ts` flattens a drizzle `SQL` object. Worth knowing: bound values sit in `queryChunks` as **bare primitives**; only `StringChunk` (`value: string[]`) and nested `SQL` carry literal text.

## Release note

The canvas "Add card" picker no longer hides matching notes when filed PDFs, images, or other files share the search term.

## Test plan

- New coverage: predicate lands above `LIMIT`, fuzzy candidates filtered the same way, quick search forwards the file-type list, unfiltered path stays unfiltered; handler test asserts pass-through.
- `pnpm exec vitest --project main` 4078 passed · `--project renderer` 5508 passed · `--project shared` 2201 passed. Run per project deliberately: a single combined `vitest run` SIGSEGVs at the end of the suite with zero test failures (known parallel flake).
- `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm ipc:generate` + `pnpm ipc:check`, `pnpm check:architecture`, `pnpm check:contracts`, `pnpm docs:impact --base origin/main --strict`, `pnpm docs:build` — all green.
- Not manually exercised in the running app.
