### PR TITLE
fix(canvas): tile added cards instead of stacking them on the viewport centre (#871)

### DIFF
--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.test.tsx
@@ -271,6 +271,30 @@ describe('CanvasCardLayer', () => {
     ).toBe(true)
   })
 
+  it('offsets a placed card off one already sitting at the viewport centre (#871)', async () => {
+    mocks.notesCreate.mockResolvedValue({ success: true, note: { id: 'captured' } })
+    // jsdom reports a 0-size clip, so the viewport centre is (0, 0) — this card
+    // covers it, and the new card must not be dropped on top of it.
+    const occupied = cardEl('e1', 'n1', -130, -84)
+    const { api, updateScene } = makeApi([occupied])
+    render(<Harness api={api} />)
+
+    fireEvent.click(screen.getByTestId('canvas-add-card'))
+    fireEvent.click(screen.getByTestId('stub-create-note'))
+    await waitFor(() => expect(updateScene).toHaveBeenCalled())
+
+    const created = updateScene.mock.calls[0][0].elements.find(
+      (e: { customData?: { entityId?: string } }) => e.customData?.entityId === 'captured'
+    )
+    expect(created).toBeDefined()
+    expect(
+      created.x >= occupied.x + occupied.width ||
+        created.x + created.width <= occupied.x ||
+        created.y >= occupied.y + occupied.height ||
+        created.y + created.height <= occupied.y
+    ).toBe(true)
+  })
+
   it('reveals an existing card (searching the whole scene, not just visible cards) without adding a new element', async () => {
     mocks.entities = new Map([
       ['note:n1', { status: 'ready', kind: 'note', title: 'One' }],

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
@@ -30,6 +30,7 @@ import { hitTestCard, shouldDeactivateForTool, nextActive, withActivePinned } fr
 import { useCanvasEntities, entityKey } from './use-canvas-entities'
 import {
   computeVisibleCardIds,
+  findFreeCardCenter,
   getCardRefs,
   makeCardSkeleton,
   overlayTransform,
@@ -366,17 +367,15 @@ export const CanvasCardLayer = ({
 
   const placeCard = useCallback(
     (entityType: CanvasCardRef['entityType'], entityId: string) => {
-      const { appState } = readScene()
+      const { cards, appState } = readScene()
       const rect = viewportSceneRect(appState, {
         width: clipRef.current?.clientWidth ?? 0,
         height: clipRef.current?.clientHeight ?? 0
       })
-      createCardElement(
-        entityType,
-        entityId,
-        (rect.minX + rect.maxX) / 2,
-        (rect.minY + rect.maxY) / 2
-      )
+      // Free cell, not the raw centre: repeated picks would otherwise pile up
+      // on one point and have to be dragged apart (#871).
+      const { x, y } = findFreeCardCenter(cards, rect)
+      createCardElement(entityType, entityId, x, y)
     },
     [readScene, createCardElement]
   )

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-cards.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-cards.test.ts
@@ -8,10 +8,14 @@ import {
   computeVisibleCardIds,
   sameMembership,
   makeCardSkeleton,
+  findFreeCardCenter,
   readCanvasDragItem,
   canvasDragPayload,
   CANVAS_ITEM_DRAG_MIME,
-  type CardElement
+  CARD_DEFAULT_WIDTH,
+  CARD_DEFAULT_HEIGHT,
+  type CardElement,
+  type CanvasCardRef
 } from './canvas-cards'
 
 function rect(overrides: Partial<CardElement> = {}): CardElement {
@@ -148,6 +152,61 @@ describe('makeCardSkeleton', () => {
     })
     expect(skeleton.backgroundColor).not.toBe('transparent')
     expect(skeleton.fillStyle).toBe('solid')
+  })
+})
+
+describe('findFreeCardCenter', () => {
+  const viewport = { minX: 0, minY: 0, maxX: 1600, maxY: 1000 }
+  const center = { x: 800, y: 500 }
+
+  function cardAt(id: string, centerX: number, centerY: number): CanvasCardRef {
+    return {
+      elementId: id,
+      entityType: 'note',
+      entityId: id,
+      x: centerX - CARD_DEFAULT_WIDTH / 2,
+      y: centerY - CARD_DEFAULT_HEIGHT / 2,
+      width: CARD_DEFAULT_WIDTH,
+      height: CARD_DEFAULT_HEIGHT,
+      angle: 0
+    }
+  }
+
+  function overlaps(a: CanvasCardRef, b: CanvasCardRef): boolean {
+    return (
+      a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height
+    )
+  }
+
+  it('uses the viewport centre when nothing is there', () => {
+    expect(findFreeCardCenter([], viewport)).toEqual(center)
+  })
+
+  it('steps off a card already occupying the centre', () => {
+    const placed = findFreeCardCenter([cardAt('a', center.x, center.y)], viewport)
+    expect(placed).not.toEqual(center)
+    expect(overlaps(cardAt('new', placed.x, placed.y), cardAt('a', center.x, center.y))).toBe(false)
+  })
+
+  it('never stacks across repeated placements (the #871 pile)', () => {
+    // Each pick sees the cards the previous picks added — exactly how the
+    // overlay re-reads the scene between picks.
+    const cards: CanvasCardRef[] = []
+    for (let i = 0; i < 9; i++) {
+      const { x, y } = findFreeCardCenter(cards, viewport)
+      cards.push(cardAt(`c${i}`, x, y))
+    }
+    for (let i = 0; i < cards.length; i++) {
+      for (let j = i + 1; j < cards.length; j++) {
+        expect(overlaps(cards[i], cards[j])).toBe(false)
+      }
+    }
+  })
+
+  it('places the first offset card beside the centre, not far from it', () => {
+    const placed = findFreeCardCenter([cardAt('a', center.x, center.y)], viewport)
+    expect(Math.abs(placed.x - center.x)).toBeLessThanOrEqual(CARD_DEFAULT_WIDTH * 2)
+    expect(Math.abs(placed.y - center.y)).toBeLessThanOrEqual(CARD_DEFAULT_HEIGHT * 2)
   })
 })
 

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-cards.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-cards.ts
@@ -252,6 +252,83 @@ export function makeCardSkeleton(input: {
   }
 }
 
+/** Scene-unit gap left between auto-placed cards. */
+export const CARD_PLACEMENT_GAP = 24
+/** How far the placement spiral searches before falling back to the centre. */
+const MAX_PLACEMENT_RINGS = 8
+
+function rectsOverlap(
+  a: { x: number; y: number; width: number; height: number },
+  b: { x: number; y: number; width: number; height: number }
+): boolean {
+  return a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height
+}
+
+/**
+ * Grid offsets forming one square ring at radius `ring`, ordered clockwise from
+ * due east so the next card lands beside its predecessor rather than diagonally
+ * above it.
+ */
+function ringCells(ring: number): [number, number][] {
+  if (ring === 0) {
+    return [[0, 0]]
+  }
+  const cells: [number, number][] = []
+  for (let dy = -ring; dy <= ring; dy++) {
+    for (let dx = -ring; dx <= ring; dx++) {
+      if (Math.max(Math.abs(dx), Math.abs(dy)) === ring) {
+        cells.push([dx, dy])
+      }
+    }
+  }
+  const clockwise = ([dx, dy]: [number, number]): number => {
+    const angle = Math.atan2(dy, dx)
+    return angle < 0 ? angle + 2 * Math.PI : angle
+  }
+  return cells.sort((a, b) => clockwise(a) - clockwise(b))
+}
+
+/**
+ * Where to centre a newly added card: the viewport centre, or — when a card is
+ * already there — the first free cell of a card-sized grid spiralling out from
+ * it. Without this, adding several cards in a row stacks them exactly on top of
+ * each other and the user has to drag the pile apart to find them (#871).
+ *
+ * Occupancy is read from the live scene, so consecutive picks tile outwards
+ * without the caller tracking any placement state.
+ */
+export function findFreeCardCenter(
+  cards: readonly CanvasCardRef[],
+  rect: SceneRect,
+  size: { width: number; height: number } = {
+    width: CARD_DEFAULT_WIDTH,
+    height: CARD_DEFAULT_HEIGHT
+  }
+): { x: number; y: number } {
+  const centerX = (rect.minX + rect.maxX) / 2
+  const centerY = (rect.minY + rect.maxY) / 2
+  const stepX = size.width + CARD_PLACEMENT_GAP
+  const stepY = size.height + CARD_PLACEMENT_GAP
+  for (let ring = 0; ring <= MAX_PLACEMENT_RINGS; ring++) {
+    for (const [dx, dy] of ringCells(ring)) {
+      const x = centerX + dx * stepX
+      const y = centerY + dy * stepY
+      const candidate = {
+        x: x - size.width / 2,
+        y: y - size.height / 2,
+        width: size.width,
+        height: size.height
+      }
+      if (!cards.some((card) => rectsOverlap(candidate, card))) {
+        return { x, y }
+      }
+    }
+  }
+  // Everything within reach is taken — stack on the centre rather than fling
+  // the card somewhere the user would have to hunt for it.
+  return { x: centerX, y: centerY }
+}
+
 /**
  * Parses the canvas drag payload from a DataTransfer-like getData function.
  * Returns null when the drag is not a canvas item (no MIME / bad JSON).

--- a/apps/docs/src/user-guide/canvas/cards-and-links.md
+++ b/apps/docs/src/user-guide/canvas/cards-and-links.md
@@ -19,6 +19,11 @@ If you pick something that is already on the board, Memry scrolls to the card
 you already have instead of adding a duplicate — look for the **On canvas**
 badge in the results.
 
+A card added from the picker lands in the middle of your view, or in the
+nearest free spot beside it when something is already there. Add three tasks
+and an event in a row and they tile out from the centre instead of piling up on
+one point.
+
 Cards show a live preview: a note's title and the start of its body, a task's
 title and status, an event's title and time. Rename or complete the item
 anywhere in the app and the card updates.


### PR DESCRIPTION
## Summary

`placeCard` always centred a new card on the viewport midpoint, so picking several entities in a row from **Add card** buried them in one pile — the user had to drag each card off the stack to discover the others. Pre-existing behaviour for the old one-click "New note" button; the picker makes "add three tasks and an event" the normal flow, so it started to matter (found in the final review of #868).

- New pure helper `findFreeCardCenter(cards, rect, size?)` in `canvas-cards.ts`: spirals out from the viewport centre over a card-sized grid (`CARD_PLACEMENT_GAP = 24`, 8 rings max), skipping cells that overlap a live card. Falls back to the centre when everything in reach is taken, rather than flinging the card somewhere the user has to hunt for.
- `placeCard` feeds it `readScene().cards`, so occupancy comes from the live scene — consecutive picks tile outwards with no placement state in React.
- Ring cells are ordered clockwise from due east, so the second card lands beside its predecessor instead of diagonally above it.

Closes #871.

## Release note

Cards added from the canvas "Add card" picker now tile out from the centre of your view instead of stacking on one point.

## Test plan

Written test-first (RED: 5 failures, incl. an overlay test asserting the new card overlapped one already at the centre).

- `canvas-cards.test.ts` — centre when free, steps off an occupied centre, 9 successive placements are mutually non-overlapping (the #871 pile), first offset stays near the centre
- `canvas-card-overlay.test.tsx` — placing over a card at the viewport centre produces a non-overlapping element (wiring, not just the helper)
- `pnpm test:desktop` — 11814 passed, 7 skipped, 0 failed
- `pnpm typecheck` — 16/16 tasks
- `pnpm lint` — 0 errors (19 pre-existing warnings, none in touched files)
- `pnpm docs:impact --base origin/main --strict` — covered; `pnpm docs:build` — ok

Not run: E2E.