### PR TITLE
ci(vercel): deploy landing and docs from main only, via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,54 @@
+name: Deploy docs (production)
+
+# Automatic Git deployments are turned off for this project
+# ("git": { "deploymentEnabled": false } in the root vercel.json), so every push
+# no longer mints a Vercel deployment record. Production deploys happen here
+# instead, only when main moves and only when docs files changed.
+#
+# memry-docs has its Vercel Root Directory set to the repository root, so it
+# reads the root /vercel.json. apps/docs/vercel.json is vestigial and is never
+# read by Vercel — do not move this project's config there.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/docs/**'
+      - 'vercel.json'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-docs-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy memry-docs to production
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      # memry-docs. Not a secret: the project id is visible in the Vercel
+      # dashboard URL and is inert without VERCEL_TOKEN.
+      VERCEL_PROJECT_ID: prj_nve19PogMusECtpcMbvYKizqXm8m
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      # Vercel runs the build remotely, so the root vercel.json still supplies
+      # installCommand (SKIP_ELECTRON_REBUILD=1) and ignoreCommand.
+      - name: Deploy to production
+        run: |
+          npx --yes vercel@latest deploy --prod --yes \
+            --token "$VERCEL_TOKEN" > deployment-url.txt
+          echo "Deployed: $(cat deployment-url.txt)" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -1,0 +1,52 @@
+name: Deploy landing (production)
+
+# Automatic Git deployments are turned off for this project
+# ("git": { "deploymentEnabled": false } in apps/landing/vercel.json), so every
+# push no longer mints a Vercel deployment record. Production deploys happen
+# here instead, only when main moves and only when landing files changed.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/landing/**'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-landing-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy memrynote-landing to production
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      # memrynote-landing. Not a secret: the project id is visible in the Vercel
+      # dashboard URL and is inert without VERCEL_TOKEN.
+      VERCEL_PROJECT_ID: prj_Wr8cz8Dd2HBQaXM6ZCGjTDr5uOlO
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      # Run from the repository root, never from apps/landing: the project's
+      # Root Directory setting is applied by Vercel during the build, so the CLI
+      # has to upload the whole repo for the workspace install to resolve.
+      # Vercel runs the build remotely, so apps/landing/vercel.json still
+      # supplies installCommand (SKIP_ELECTRON_REBUILD=1) and ignoreCommand.
+      - name: Deploy to production
+        run: |
+          npx --yes vercel@latest deploy --prod --yes \
+            --token "$VERCEL_TOKEN" > deployment-url.txt
+          echo "Deployed: $(cat deployment-url.txt)" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,10 +1,8 @@
 {
   "installCommand": "SKIP_ELECTRON_REBUILD=1 pnpm install --frozen-lockfile",
-  "ignoreCommand": "if [ \"$VERCEL_ENV\" != \"production\" ]; then exit 0; fi; git diff --quiet HEAD^ HEAD -- .",
+  "ignoreCommand": "if [ \"$VERCEL_ENV\" != \"production\" ]; then exit 0; fi; git diff --quiet HEAD^ HEAD -- . || exit 1; exit 0",
   "git": {
-    "deploymentEnabled": {
-      "main": true
-    }
+    "deploymentEnabled": false
   },
   "trailingSlash": false,
   "redirects": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,9 @@
 {
   "cleanUrls": true,
   "installCommand": "SKIP_ELECTRON_REBUILD=1 pnpm install --frozen-lockfile",
-  "ignoreCommand": "if [ \"$VERCEL_ENV\" != \"production\" ]; then exit 0; fi; git diff --quiet HEAD^ HEAD -- apps/docs vercel.json",
+  "ignoreCommand": "if [ \"$VERCEL_ENV\" != \"production\" ]; then exit 0; fi; git diff --quiet HEAD^ HEAD -- apps/docs vercel.json || exit 1; exit 0",
   "git": {
-    "deploymentEnabled": {
-      "main": true
-    }
+    "deploymentEnabled": false
   },
   "redirects": [
     {


### PR DESCRIPTION
## Problem

Every push to every branch created two Vercel deployment records — `memrynote-landing` and `memry-docs`. The `ignoreCommand` added in #788 cancelled the builds in ~8s, but the *deployment record* was still created. Records post GitHub status checks and count against the Hobby-plan daily deployment quota. The quota ran out and produced a red `Vercel – memry-docs` check with `upgradeToPro=build-rate-limit`.

Root cause: `"git": { "deploymentEnabled": { "main": true } }` restricted nothing. Per the [Git Configuration docs](https://vercel.com/docs/project-configuration/git-configuration), unspecified branches **default to `true`** — the object only ever turns branches *off*.

## Change

**1. Stop all automatic Git deployments.** `"git": { "deploymentEnabled": false }` in both files Vercel actually reads:

| Project | Vercel Root Directory | Config file it reads |
| --- | --- | --- |
| `memrynote-landing` | `apps/landing` | `apps/landing/vercel.json` |
| `memry-docs` | repo root | root `/vercel.json` |

`apps/docs/vercel.json` is vestigial and is **not** read by Vercel — deliberately untouched.

**2. Two path-filtered production deploy workflows** replace the lost automatic main deploy:

- `.github/workflows/deploy-landing.yml` — `push` to `main` on `apps/landing/**`
- `.github/workflows/deploy-docs.yml` — `push` to `main` on `apps/docs/**` and `vercel.json`

Separate files rather than one workflow with two jobs, because GitHub's `paths` filter is per-workflow, not per-job — this avoids pulling in a third-party paths-filter action. A desktop- or sync-only merge triggers neither. Both also expose `workflow_dispatch` for a manual redeploy.

## Why `vercel deploy --prod` and not a Deploy Hook

A Deploy Hook is one `curl`, so it looked like the simpler option. Rejected on evidence:

- The [Deploy Hooks docs](https://vercel.com/docs/deploy-hooks) state: *"Deploy Hooks will not be triggered if you have the `github.enabled = false` configuration present in your `vercel.json` file."* `github.enabled` is documented as the **deprecated predecessor of `git.deploymentEnabled`**. Whether Vercel treats `deploymentEnabled: false` as suppressing hooks is not documented either way — and that is precisely the premise this PR depends on. Not verifiable without merging and watching it fail.
- `vercel deploy --prod` has no such interaction: it is a CLI/API-initiated deployment that uploads source directly. `git.deploymentEnabled` governs only *automatic* deployments triggered by Git — the docs section is literally titled "Turning off all automatic deployments".
- A hook returns `{"job": {"state": "PENDING"}}` and nothing else, so a failed build is invisible to the Actions run. `vercel deploy` blocks, exits non-zero on failure, and prints the deployment URL to the step summary.

Both workflows run the CLI **from the repository root**, never from `apps/landing`. Vercel applies the project's Root Directory setting during the build, so the CLI must upload the whole repo — otherwise the workspace `pnpm install` in `apps/landing` has no root lockfile to resolve against.

`SKIP_ELECTRON_REBUILD=1` is preserved: these are remote builds, so Vercel still reads `installCommand` from each `vercel.json`. Nothing installs on the runner.

## ignoreCommand kept, with one hardening

Kept as a second line of defence (dashboard redeploys, or if automatic Git deploys are ever re-enabled), but both lines now normalise their exit code:

```diff
-git diff --quiet HEAD^ HEAD -- <paths>
+git diff --quiet HEAD^ HEAD -- <paths> || exit 1; exit 0
```

`ignoreCommand` documents only two outcomes: exit `0` skips the build, exit `1` continues it. A CLI-initiated deployment has no git history in the build container, so `git diff` there exits `128` — outside the documented contract, with undefined behaviour. The `|| exit 1` makes the failure mode fail *open* (build proceeds) and guarantees only 0 or 1.

Verified all four paths by executing the exact strings under `sh -c`:

| Case | Exit | Meaning |
| --- | --- | --- |
| `VERCEL_ENV=preview` | 0 | skip |
| production, no change in watched paths | 0 | skip |
| production, watched path changed | 1 | build |
| production, no git history (CLI deploy) | 1 | build — not 128 |

## Manual step for Kaan — add these repository secrets

Settings → Secrets and variables → Actions → **New repository secret**:

| Secret | Where to get it |
| --- | --- |
| `VERCEL_TOKEN` | Vercel → Account Settings → Tokens → Create Token. Scope it to the `kaan94karaca-5848s-projects` team. |
| `VERCEL_ORG_ID` | Vercel → Team Settings → General → Team ID (starts `team_`). |

Repository secrets, not environment secrets — the workflows deliberately declare no `environment:`, so a required-reviewer gate can't stall an auto-deploy on merge.

The two project IDs are inline in the workflows rather than secrets: they are visible in the Vercel dashboard URL and are inert without `VERCEL_TOKEN`. Keeping them in the file makes it reviewable which workflow targets which project.

**Until both secrets exist, the deploy workflows fail and neither site updates on merge.** Add them before merging.

## Verification

- `git diff --check` clean
- Both `vercel.json` files parse as JSON; both workflows parse as YAML (`yaml` package) with the expected `on.push.paths`
- Pre-push `pnpm docs:impact --strict` passed; `MEMRY_DOCS_IMPACT_SKIP` was **not** used
- This PR touches `vercel.json` and `apps/landing/vercel.json`, so merging it exercises both new workflows immediately — a self-verifying first run

## Not verified

- No live deployment was run: that needs the secrets above, and a Vercel-authenticated session was not available here.
- The two project IDs and Root Directory settings come from the dashboard as reported; they could not be re-read from the Vercel API without auth. Worth a glance before merge.
- A lockfile-only change (`pnpm-lock.yaml`) that affects a site's dependencies will not deploy until the next change under that site's paths. Deliberate — the alternative re-couples both sites to every dependency bump — and `workflow_dispatch` covers the rare case.
