### PR TITLE
fix(canvas): persist the Excalidraw shape library in the vault and unblock file import

### DIFF
--- a/apps/desktop/src/main/canvas/encryption.ts
+++ b/apps/desktop/src/main/canvas/encryption.ts
@@ -12,18 +12,22 @@ export interface CanvasEnvelope {
 
 const BASE64 = sodium.base64_variants.ORIGINAL
 const PURPOSE_AD = `memry/${CANVAS_AT_REST_VERSION}/canvas_snapshot`
+/**
+ * Distinct AD from the scene purpose so a library-item ciphertext can never be
+ * swapped into a canvases row (or vice versa) and still authenticate.
+ */
+const LIBRARY_ITEM_PURPOSE_AD = `memry/${CANVAS_AT_REST_VERSION}/canvas_library_item`
 
 function purposeAd(): Uint8Array {
   return new TextEncoder().encode(PURPOSE_AD)
 }
 
-/**
- * Encrypts a serialized Excalidraw scene under the vault key for at-rest
- * storage in canvases.snapshot_ciphertext. Mirrors the agent-chat at-rest
- * envelope (main/agent/storage/encryption.ts) with a canvas-specific purpose.
- */
-export function encryptCanvasSceneForVault(scene: string, vaultKey: Uint8Array): string {
-  const result = encrypt(new TextEncoder().encode(scene), vaultKey, purposeAd())
+function libraryItemPurposeAd(): Uint8Array {
+  return new TextEncoder().encode(LIBRARY_ITEM_PURPOSE_AD)
+}
+
+function seal(plaintext: string, vaultKey: Uint8Array, ad: Uint8Array): string {
+  const result = encrypt(new TextEncoder().encode(plaintext), vaultKey, ad)
   const envelope: CanvasEnvelope = {
     version: CANVAS_AT_REST_VERSION,
     nonce: sodium.to_base64(result.nonce, BASE64),
@@ -32,11 +36,8 @@ export function encryptCanvasSceneForVault(scene: string, vaultKey: Uint8Array):
   return JSON.stringify(envelope)
 }
 
-export function decryptCanvasSceneForVault(
-  snapshotCiphertext: string,
-  vaultKey: Uint8Array
-): string {
-  const envelope = JSON.parse(snapshotCiphertext) as CanvasEnvelope
+function open(serializedEnvelope: string, vaultKey: Uint8Array, ad: Uint8Array): string {
+  const envelope = JSON.parse(serializedEnvelope) as CanvasEnvelope
   if (envelope.version !== CANVAS_AT_REST_VERSION) {
     throw new Error(`Unsupported canvas envelope version: ${envelope.version}`)
   }
@@ -45,7 +46,38 @@ export function decryptCanvasSceneForVault(
     sodium.from_base64(envelope.ciphertext, BASE64),
     sodium.from_base64(envelope.nonce, BASE64),
     vaultKey,
-    purposeAd()
+    ad
   )
   return new TextDecoder().decode(plaintext)
+}
+
+/**
+ * Encrypts one serialized Excalidraw LibraryItem for storage in
+ * canvas_library_items.item_ciphertext.
+ */
+export function encryptCanvasLibraryItemForVault(item: string, vaultKey: Uint8Array): string {
+  return seal(item, vaultKey, libraryItemPurposeAd())
+}
+
+export function decryptCanvasLibraryItemForVault(
+  itemCiphertext: string,
+  vaultKey: Uint8Array
+): string {
+  return open(itemCiphertext, vaultKey, libraryItemPurposeAd())
+}
+
+/**
+ * Encrypts a serialized Excalidraw scene under the vault key for at-rest
+ * storage in canvases.snapshot_ciphertext. Mirrors the agent-chat at-rest
+ * envelope (main/agent/storage/encryption.ts) with a canvas-specific purpose.
+ */
+export function encryptCanvasSceneForVault(scene: string, vaultKey: Uint8Array): string {
+  return seal(scene, vaultKey, purposeAd())
+}
+
+export function decryptCanvasSceneForVault(
+  snapshotCiphertext: string,
+  vaultKey: Uint8Array
+): string {
+  return open(snapshotCiphertext, vaultKey, purposeAd())
 }

--- a/apps/desktop/src/main/canvas/library-diff.test.ts
+++ b/apps/desktop/src/main/canvas/library-diff.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { diffLibraryItems, serializeLibraryItem, type StoredLibraryItem } from './library-diff'
+import type { CanvasLibraryItem } from '@memry/contracts/canvas-api'
+
+function item(id: string, extra: Record<string, unknown> = {}): CanvasLibraryItem {
+  return { id, status: 'unpublished', created: 1, elements: [], ...extra } as CanvasLibraryItem
+}
+
+function stored(...items: CanvasLibraryItem[]): StoredLibraryItem[] {
+  return items.map((it) => ({ id: it.id, json: serializeLibraryItem(it) }))
+}
+
+describe('diffLibraryItems', () => {
+  it('inserts items the vault has never seen', () => {
+    const diff = diffLibraryItems([], [item('a'), item('b')])
+
+    expect(diff.inserts.map((i) => i.id)).toEqual(['a', 'b'])
+    expect(diff.updates).toEqual([])
+    expect(diff.deletes).toEqual([])
+  })
+
+  it('is a no-op when the payload matches storage', () => {
+    const items = [item('a'), item('b')]
+
+    const diff = diffLibraryItems(stored(...items), items)
+
+    expect(diff).toEqual({ inserts: [], updates: [], deletes: [] })
+  })
+
+  it('updates an item whose contents changed', () => {
+    const diff = diffLibraryItems(stored(item('a')), [item('a', { name: 'Renamed' })])
+
+    expect(diff.updates.map((i) => i.id)).toEqual(['a'])
+    expect(diff.inserts).toEqual([])
+    expect(diff.deletes).toEqual([])
+  })
+
+  it('deletes live rows the payload omits', () => {
+    const diff = diffLibraryItems(stored(item('a'), item('b')), [item('a')])
+
+    expect(diff.deletes).toEqual(['b'])
+    expect(diff.inserts).toEqual([])
+    expect(diff.updates).toEqual([])
+  })
+
+  it('tombstones everything when the payload is empty (reset library)', () => {
+    const diff = diffLibraryItems(stored(item('a'), item('b')), [])
+
+    expect(diff.deletes).toEqual(['a', 'b'])
+  })
+
+  it('keeps the first occurrence when the payload repeats an id', () => {
+    // Importing a library that overlaps one already installed can hand back the
+    // same id twice; writing both would make the second clobber the first.
+    const diff = diffLibraryItems([], [item('a', { name: 'First' }), item('a', { name: 'Second' })])
+
+    expect(diff.inserts).toHaveLength(1)
+    expect(diff.inserts[0].json).toContain('First')
+  })
+
+  it('does not re-delete an id that the payload also re-adds', () => {
+    const diff = diffLibraryItems(stored(item('a')), [item('a'), item('b')])
+
+    expect(diff.deletes).toEqual([])
+    expect(diff.inserts.map((i) => i.id)).toEqual(['b'])
+  })
+})

--- a/apps/desktop/src/main/canvas/library-diff.ts
+++ b/apps/desktop/src/main/canvas/library-diff.ts
@@ -1,0 +1,71 @@
+/**
+ * Blob-to-rows reconciliation for the canvas library.
+ *
+ * Excalidraw's LibraryPersistenceAdapter always hands us the FULL item list on
+ * save, while storage is one row per item (so a future sync type gets per-item
+ * LWW and real tombstones). This module is the seam between those two shapes,
+ * kept pure — no drizzle, no encryption — so every branch is testable without a
+ * database or the keychain.
+ *
+ * Safety note: because "absent from the payload" means delete, callers must
+ * pass the payload Excalidraw actually produced. Excalidraw calls
+ * `adapter.load({ source: 'save' })` before each save precisely so items that
+ * arrived in storage mid-session are merged in first; skipping that would let a
+ * stale in-memory list tombstone rows it never knew about.
+ */
+
+import type { CanvasLibraryItem } from '@memry/contracts/canvas-api'
+
+/** A stored item reduced to what reconciliation needs. */
+export interface StoredLibraryItem {
+  id: string
+  /** Decrypted LibraryItem JSON exactly as it was written. */
+  json: string
+}
+
+export interface LibraryDiff {
+  inserts: { id: string; json: string }[]
+  updates: { id: string; json: string }[]
+  /** Ids of live rows the payload no longer contains — soft-deleted, never dropped. */
+  deletes: string[]
+}
+
+/**
+ * Serializes a library item for storage and comparison. Both sides of a
+ * comparison go through this, so a key-order difference can only produce a
+ * redundant write, never a missed one.
+ */
+export function serializeLibraryItem(item: CanvasLibraryItem): string {
+  return JSON.stringify(item)
+}
+
+export function diffLibraryItems(
+  stored: readonly StoredLibraryItem[],
+  incoming: readonly CanvasLibraryItem[]
+): LibraryDiff {
+  const storedById = new Map(stored.map((row) => [row.id, row.json]))
+  const diff: LibraryDiff = { inserts: [], updates: [], deletes: [] }
+  const seen = new Set<string>()
+
+  for (const item of incoming) {
+    // Excalidraw can hand back the same id twice (importing a library that
+    // overlaps one already installed). First occurrence wins; writing both
+    // would make the second overwrite the first in the same transaction.
+    if (seen.has(item.id)) continue
+    seen.add(item.id)
+
+    const json = serializeLibraryItem(item)
+    const existing = storedById.get(item.id)
+    if (existing === undefined) {
+      diff.inserts.push({ id: item.id, json })
+    } else if (existing !== json) {
+      diff.updates.push({ id: item.id, json })
+    }
+  }
+
+  for (const row of stored) {
+    if (!seen.has(row.id)) diff.deletes.push(row.id)
+  }
+
+  return diff
+}

--- a/apps/desktop/src/main/canvas/library-store.test.ts
+++ b/apps/desktop/src/main/canvas/library-store.test.ts
@@ -1,0 +1,134 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { eq } from 'drizzle-orm'
+import sodium from 'libsodium-wrappers-sumo'
+
+import * as schema from '@memry/db-schema/data-schema'
+import type { CanvasLibraryItem } from '@memry/contracts/canvas-api'
+import { listCanvasLibraryItems, saveCanvasLibraryItems } from './library-store'
+import { decryptCanvasLibraryItemForVault, decryptCanvasSceneForVault } from './encryption'
+
+const MIGRATION_SQL = fs.readFileSync(
+  path.join(__dirname, '..', 'database', 'drizzle-data', '0038_canvas_library_items.sql'),
+  'utf8'
+)
+
+function freshDb() {
+  const sqlite = new Database(':memory:')
+  for (const statement of MIGRATION_SQL.split('--> statement-breakpoint')) {
+    const trimmed = statement.trim()
+    if (trimmed) sqlite.exec(trimmed)
+  }
+  return drizzle(sqlite, { schema })
+}
+
+function item(id: string, extra: Record<string, unknown> = {}): CanvasLibraryItem {
+  return {
+    id,
+    status: 'unpublished',
+    created: 1,
+    elements: [{ type: 'rectangle', id: `${id}-el` }],
+    ...extra
+  } as CanvasLibraryItem
+}
+
+const VAULT = 'vault-1'
+
+describe('canvas library store', () => {
+  let vaultKey: Uint8Array
+  let db: ReturnType<typeof freshDb>
+
+  beforeAll(async () => {
+    await sodium.ready
+    vaultKey = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
+  })
+
+  beforeEach(() => {
+    db = freshDb()
+  })
+
+  it('stores items encrypted and reads them back verbatim', () => {
+    const changed = saveCanvasLibraryItems(db, vaultKey, VAULT, [item('a'), item('b')])
+
+    expect(changed).toBe(2)
+
+    const raw = db.select().from(schema.canvasLibraryItems).all()
+    expect(raw).toHaveLength(2)
+    expect(raw[0].itemCiphertext).not.toContain('rectangle')
+    expect(JSON.parse(decryptCanvasLibraryItemForVault(raw[0].itemCiphertext, vaultKey))).toEqual(
+      item('a')
+    )
+
+    expect(listCanvasLibraryItems(db, vaultKey, VAULT)).toEqual([item('a'), item('b')])
+  })
+
+  it('preserves fields it does not know about', () => {
+    // An Excalidraw upgrade that adds a LibraryItem field must round-trip, or
+    // saving would quietly strip data the panel depends on.
+    saveCanvasLibraryItems(db, vaultKey, VAULT, [item('a', { futureField: { nested: true } })])
+
+    expect(listCanvasLibraryItems(db, vaultKey, VAULT)[0]).toMatchObject({
+      futureField: { nested: true }
+    })
+  })
+
+  it('is idempotent when the same list is saved twice', () => {
+    const items = [item('a'), item('b')]
+    saveCanvasLibraryItems(db, vaultKey, VAULT, items)
+
+    expect(saveCanvasLibraryItems(db, vaultKey, VAULT, items)).toBe(0)
+  })
+
+  it('soft-deletes items dropped from the list', () => {
+    saveCanvasLibraryItems(db, vaultKey, VAULT, [item('a'), item('b')])
+    saveCanvasLibraryItems(db, vaultKey, VAULT, [item('a')])
+
+    expect(listCanvasLibraryItems(db, vaultKey, VAULT).map((i) => i.id)).toEqual(['a'])
+
+    // The row survives as a tombstone — a hard delete would let the item come
+    // back from another device once this table syncs.
+    const rows = db.select().from(schema.canvasLibraryItems).all()
+    expect(rows).toHaveLength(2)
+    expect(rows.find((r) => r.id === 'b')?.deletedAt).toBeTypeOf('number')
+  })
+
+  it('revives a tombstoned item when the user re-adds it', () => {
+    saveCanvasLibraryItems(db, vaultKey, VAULT, [item('a')])
+    saveCanvasLibraryItems(db, vaultKey, VAULT, [])
+    saveCanvasLibraryItems(db, vaultKey, VAULT, [item('a', { name: 'Back' })])
+
+    const live = listCanvasLibraryItems(db, vaultKey, VAULT)
+    expect(live).toHaveLength(1)
+    expect(live[0]).toMatchObject({ id: 'a', name: 'Back' })
+  })
+
+  it('scopes the library to its vault', () => {
+    saveCanvasLibraryItems(db, vaultKey, VAULT, [item('a')])
+    saveCanvasLibraryItems(db, vaultKey, 'vault-2', [item('b')])
+
+    expect(listCanvasLibraryItems(db, vaultKey, VAULT).map((i) => i.id)).toEqual(['a'])
+    expect(listCanvasLibraryItems(db, vaultKey, 'vault-2').map((i) => i.id)).toEqual(['b'])
+  })
+
+  it('skips an unreadable row instead of losing the whole library', () => {
+    saveCanvasLibraryItems(db, vaultKey, VAULT, [item('a'), item('b')])
+    db.update(schema.canvasLibraryItems)
+      .set({ itemCiphertext: 'not-an-envelope' })
+      .where(eq(schema.canvasLibraryItems.id, 'a'))
+      .run()
+
+    expect(listCanvasLibraryItems(db, vaultKey, VAULT).map((i) => i.id)).toEqual(['b'])
+  })
+
+  it('does not decrypt under the scene purpose', () => {
+    // Distinct associated data means a library ciphertext cannot be swapped
+    // into a canvases row and still authenticate.
+    saveCanvasLibraryItems(db, vaultKey, VAULT, [item('a')])
+    const raw = db.select().from(schema.canvasLibraryItems).all()[0]
+
+    expect(() => decryptCanvasSceneForVault(raw.itemCiphertext, vaultKey)).toThrow()
+  })
+})

--- a/apps/desktop/src/main/canvas/library-store.ts
+++ b/apps/desktop/src/main/canvas/library-store.ts
@@ -1,0 +1,132 @@
+/**
+ * Canvas library store — drizzle CRUD for canvas_library_items.
+ *
+ * Mirrors main/canvas/store.ts: lives outside main/ipc so the ipc layer never
+ * imports queries directly (architecture boundary), and takes the vault key as
+ * a parameter so it stays testable without the keychain.
+ *
+ * The library is vault-global, not per canvas — Excalidraw keeps one shared
+ * collection, and the editor remounts per canvas id.
+ */
+
+import { and, asc, eq, isNull } from 'drizzle-orm'
+import { canvasLibraryItems } from '@memry/db-schema/data-schema'
+import type { CanvasLibraryItem } from '@memry/contracts/canvas-api'
+import type { DataDb } from '../database'
+import { createLogger } from '../lib/logger'
+import { decryptCanvasLibraryItemForVault, encryptCanvasLibraryItemForVault } from './encryption'
+import { diffLibraryItems, type StoredLibraryItem } from './library-diff'
+
+const log = createLogger('CanvasLibraryStore')
+
+/**
+ * Reads the live library rows as decrypted JSON strings.
+ *
+ * A row that fails to decrypt or parse is skipped rather than thrown: one bad
+ * row (wrong vault key, truncated write) must not cost the user their entire
+ * shapes panel. The skipped row stays on disk untouched.
+ */
+function loadStoredItems(db: DataDb, vaultKey: Uint8Array, vaultId: string): StoredLibraryItem[] {
+  const rows = db
+    .select({ id: canvasLibraryItems.id, itemCiphertext: canvasLibraryItems.itemCiphertext })
+    .from(canvasLibraryItems)
+    .where(and(eq(canvasLibraryItems.vaultId, vaultId), isNull(canvasLibraryItems.deletedAt)))
+    .orderBy(asc(canvasLibraryItems.createdAt))
+    .all()
+
+  const items: StoredLibraryItem[] = []
+  for (const row of rows) {
+    try {
+      items.push({
+        id: row.id,
+        json: decryptCanvasLibraryItemForVault(row.itemCiphertext, vaultKey)
+      })
+    } catch (err) {
+      log.error('Skipping unreadable canvas library item', { id: row.id, err })
+    }
+  }
+  return items
+}
+
+/** All library items for the vault, in insertion order. */
+export function listCanvasLibraryItems(
+  db: DataDb,
+  vaultKey: Uint8Array,
+  vaultId: string
+): CanvasLibraryItem[] {
+  const items: CanvasLibraryItem[] = []
+  for (const stored of loadStoredItems(db, vaultKey, vaultId)) {
+    try {
+      items.push(JSON.parse(stored.json) as CanvasLibraryItem)
+    } catch (err) {
+      log.error('Skipping unparseable canvas library item', { id: stored.id, err })
+    }
+  }
+  return items
+}
+
+/**
+ * Reconciles the vault's library rows against the full item list Excalidraw
+ * saved. Returns the number of rows written; 0 means nothing changed, which is
+ * the common case since Excalidraw saves on every library mutation including
+ * ones that only reorder in memory.
+ */
+export function saveCanvasLibraryItems(
+  db: DataDb,
+  vaultKey: Uint8Array,
+  vaultId: string,
+  incoming: readonly CanvasLibraryItem[]
+): number {
+  return db.transaction((tx) => {
+    const diff = diffLibraryItems(loadStoredItems(tx as DataDb, vaultKey, vaultId), incoming)
+    const now = Date.now()
+
+    for (const item of diff.inserts) {
+      tx.insert(canvasLibraryItems)
+        .values({
+          id: item.id,
+          vaultId,
+          itemCiphertext: encryptCanvasLibraryItemForVault(item.json, vaultKey),
+          vectorClock: {},
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+          lastSyncedAt: null,
+          clock: null
+        })
+        // A tombstoned row keeps the id, so re-adding an item the user
+        // previously deleted collides on the primary key; revive it instead of
+        // failing the whole save.
+        .onConflictDoUpdate({
+          target: canvasLibraryItems.id,
+          set: {
+            itemCiphertext: encryptCanvasLibraryItemForVault(item.json, vaultKey),
+            updatedAt: now,
+            deletedAt: null
+          }
+        })
+        .run()
+    }
+
+    for (const item of diff.updates) {
+      tx.update(canvasLibraryItems)
+        .set({
+          itemCiphertext: encryptCanvasLibraryItemForVault(item.json, vaultKey),
+          updatedAt: now
+        })
+        .where(eq(canvasLibraryItems.id, item.id))
+        .run()
+    }
+
+    for (const id of diff.deletes) {
+      // Soft delete: a hard delete would let the item resurrect from another
+      // device once this table syncs.
+      tx.update(canvasLibraryItems)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(eq(canvasLibraryItems.id, id))
+        .run()
+    }
+
+    return diff.inserts.length + diff.updates.length + diff.deletes.length
+  })
+}

--- a/apps/desktop/src/main/database/drizzle-data/0038_canvas_library_items.sql
+++ b/apps/desktop/src/main/database/drizzle-data/0038_canvas_library_items.sql
@@ -1,0 +1,19 @@
+-- Adds canvas_library_items: the Excalidraw library (shapes panel), one
+-- encrypted row per LibraryItem, vault-global rather than per canvas.
+-- Hand-written (project switched off Drizzle generator after 0020).
+-- Additive only; frozen once any build ships it.
+
+CREATE TABLE IF NOT EXISTS `canvas_library_items` (
+  `id` TEXT PRIMARY KEY NOT NULL,
+  `vault_id` TEXT NOT NULL,
+  `item_ciphertext` TEXT NOT NULL,
+  `vector_clock` TEXT NOT NULL,
+  `created_at` INTEGER NOT NULL,
+  `updated_at` INTEGER NOT NULL,
+  `deleted_at` INTEGER,
+  `last_synced_at` INTEGER,
+  `clock` TEXT
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `canvas_library_items_by_vault`
+  ON `canvas_library_items` (`vault_id`, `updated_at`);

--- a/apps/desktop/src/main/database/drizzle-data/meta/_journal.json
+++ b/apps/desktop/src/main/database/drizzle-data/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1784721218000,
       "tag": "0037_project_links",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1784811299000,
+      "tag": "0038_canvas_library_items",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/src/main/ipc/canvas-handlers.ts
+++ b/apps/desktop/src/main/ipc/canvas-handlers.ts
@@ -14,6 +14,9 @@ import {
   CanvasUpdateSchema,
   CanvasGetAssetSchema,
   CanvasListAssetsSchema,
+  CanvasLibrarySaveSchema,
+  type CanvasLibraryListResponse,
+  type CanvasLibrarySaveResponse,
   type CanvasCreatedEvent,
   type CanvasUpdatedEvent,
   type CanvasDeletedEvent,
@@ -27,6 +30,7 @@ import { requireDatabase, type DataDb } from '../database'
 import { getOrCreateVaultUuid } from '../agent/storage/vault-id'
 import { getOrInitializeLocalVaultKey, secureCleanup } from '../crypto'
 import { createCanvas, deleteCanvas, getCanvas, listCanvases, updateCanvas } from '../canvas/store'
+import { listCanvasLibraryItems, saveCanvasLibraryItems } from '../canvas/library-store'
 import { syncCanvasCreate, syncCanvasUpdate, syncCanvasDelete } from '../canvas/sync-bridge'
 import {
   getCanvasAssetRef,
@@ -233,6 +237,29 @@ export function registerCanvasHandlers(): void {
       }
     )
   )
+
+  // canvas:library-list - The vault's Excalidraw library (shapes panel)
+  ipcMain.handle(
+    CanvasChannels.invoke.LIBRARY_LIST,
+    createHandler(async (): Promise<CanvasLibraryListResponse> => {
+      const { db, vaultId, vaultKey } = await getCanvasContext()
+      return { libraryItems: listCanvasLibraryItems(db, vaultKey, vaultId) }
+    })
+  )
+
+  // canvas:library-save - Reconcile the vault rows against Excalidraw's full
+  // item list. Excalidraw's persistence adapter has no per-item callbacks, so
+  // "absent from this payload" is how a delete reaches us.
+  ipcMain.handle(
+    CanvasChannels.invoke.LIBRARY_SAVE,
+    createValidatedHandler(
+      CanvasLibrarySaveSchema,
+      async (input): Promise<CanvasLibrarySaveResponse> => {
+        const { db, vaultId, vaultKey } = await getCanvasContext()
+        return { changed: saveCanvasLibraryItems(db, vaultKey, vaultId, input.libraryItems) }
+      }
+    )
+  )
 }
 
 export function unregisterCanvasHandlers(): void {
@@ -244,6 +271,8 @@ export function unregisterCanvasHandlers(): void {
   ipcMain.removeHandler(CanvasChannels.invoke.UPLOAD_ASSET)
   ipcMain.removeHandler(CanvasChannels.invoke.GET_ASSET)
   ipcMain.removeHandler(CanvasChannels.invoke.LIST_ASSETS)
+  ipcMain.removeHandler(CanvasChannels.invoke.LIBRARY_LIST)
+  ipcMain.removeHandler(CanvasChannels.invoke.LIBRARY_SAVE)
   if (vaultKeyPromise) {
     void vaultKeyPromise.then((key) => secureCleanup(key)).catch(() => {})
     vaultKeyPromise = null

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -73,6 +73,8 @@ export interface MainIpcInvokeHandlers {
   "canvas:delete": (...args: [string]) => Awaited<Promise<{ success: boolean; }>>
   "canvas:get": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").Canvas | null>>
   "canvas:get-asset": (...args: [{ canvasId: string; fileId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").CanvasGetAssetResponse>>
+  "canvas:library-list": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").CanvasLibraryListResponse>>
+  "canvas:library-save": (...args: [{ libraryItems: { [x: string]: unknown; id: string; }[]; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").CanvasLibrarySaveResponse>>
   "canvas:list": (...args: []) => Awaited<Promise<{ canvases: import("../../../../../packages/contracts/src/canvas-api").CanvasSummary[]; }>>
   "canvas:list-assets": (...args: [{ canvasId: string; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").CanvasListAssetsResponse>>
   "canvas:update": (...args: [{ id: string; title?: string | null | undefined; scene?: string | undefined; entityRefs?: { entityType: "note" | "task" | "calendar_event"; entityId: string; }[] | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/canvas-api").CanvasSummary>>

--- a/apps/desktop/src/main/session-permissions.test.ts
+++ b/apps/desktop/src/main/session-permissions.test.ts
@@ -89,12 +89,20 @@ describe('isPermissionAllowed', () => {
     expect(isPermissionAllowed('notifications', FILE_ORIGIN, {}, prod)).toBe(true)
   })
 
+  it('allows fileSystem from the app origin so the canvas library can import files', () => {
+    // Excalidraw's library panel reads .excalidrawlib through the File System
+    // Access API; denying this let the picker open and then failed the read.
+    expect(isPermissionAllowed('fileSystem', FILE_ORIGIN, {}, prod)).toBe(true)
+    expect(isPermissionAllowed('fileSystem', DEV_ORIGIN, {}, dev)).toBe(true)
+  })
+
   it('denies allowlisted permissions from untrusted origins', () => {
     for (const permission of [
       'media',
       'clipboard-sanitized-write',
       'clipboard-read',
-      'notifications'
+      'notifications',
+      'fileSystem'
     ]) {
       expect(
         isPermissionAllowed(
@@ -130,7 +138,6 @@ describe('isPermissionAllowed', () => {
       'top-level-storage-access',
       'window-management',
       'deprecated-sync-clipboard-read',
-      'fileSystem',
       'unknown'
     ]
     for (const permission of denied) {

--- a/apps/desktop/src/main/session-permissions.ts
+++ b/apps/desktop/src/main/session-permissions.ts
@@ -10,12 +10,19 @@ const permissionLog = createLogger('SessionPermissions')
  * - `clipboard-read`: quick capture reads the clipboard to prefill a capture
  * - `clipboard-sanitized-write`: copy actions across the app (navigator.clipboard.writeText)
  * - `notifications`: inbox review notifications via the HTML5 Notification API
+ * - `fileSystem`: the canvas library panel imports/exports `.excalidrawlib`
+ *   files through the File System Access API (Excalidraw uses
+ *   browser-fs-access). Denying it let the OS picker open and then failed the
+ *   subsequent `handle.getFile()` read, surfacing as "Couldn't load library".
+ *   Every access is still driven by a picker the user opens themselves, and
+ *   `isTrustedAppOrigin` keeps it away from embedded web content.
  */
 const ALLOWED_PERMISSIONS: ReadonlySet<string> = new Set([
   'media',
   'clipboard-read',
   'clipboard-sanitized-write',
-  'notifications'
+  'notifications',
+  'fileSystem'
 ])
 
 export interface PermissionPolicyOptions {

--- a/apps/desktop/src/preload/generated-rpc.ts
+++ b/apps/desktop/src/preload/generated-rpc.ts
@@ -314,6 +314,8 @@ export function createGeneratedRpcApi({
         })) as GeneratedRpcApi["canvas"]["uploadAsset"],
       "getAsset": ((canvasId, fileId) => invoke("canvas:get-asset", { canvasId, fileId })) as GeneratedRpcApi["canvas"]["getAsset"],
       "listAssets": ((canvasId) => invoke("canvas:list-assets", { canvasId })) as GeneratedRpcApi["canvas"]["listAssets"],
+      "libraryList": (() => invoke("canvas:library-list")) as GeneratedRpcApi["canvas"]["libraryList"],
+      "librarySave": ((libraryItems) => invoke("canvas:library-save", { libraryItems })) as GeneratedRpcApi["canvas"]["librarySave"],
     },
     "telemetry": {
       "track": ((event) => invoke("telemetry:track", event)) as GeneratedRpcApi["telemetry"]["track"],

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.tsx
@@ -7,7 +7,13 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Excalidraw, serializeAsJSON, languages, defaultLang } from '@excalidraw/excalidraw'
+import {
+  Excalidraw,
+  serializeAsJSON,
+  languages,
+  defaultLang,
+  useHandleLibrary
+} from '@excalidraw/excalidraw'
 import type {
   ExcalidrawImperativeAPI,
   ExcalidrawInitialDataState
@@ -24,6 +30,7 @@ import { createScenePersister } from './canvas-persistence'
 import { externalizeSceneAssets } from './canvas-externalize'
 import { pickExcalidrawLangCode } from './excalidraw-lang'
 import { CanvasCardLayer } from './canvas-card-overlay'
+import { createVaultLibraryAdapter } from './canvas-library-adapter'
 import { extractEntityRefs, type CardElement } from './canvas-cards'
 
 const log = createLogger('SpatialCanvas')
@@ -156,6 +163,30 @@ export const CanvasEditor = ({ canvasId, initialScene }: CanvasEditorProps): Rea
       persisterRef.current = null
     }
   }, [canvasId, initialScene, corrupt])
+
+  // The library is vault-global, not per canvas: Excalidraw keeps one shared
+  // collection, and this editor remounts per canvas id, so anything held in
+  // component state would be lost on the next tab switch. The adapter is
+  // rebuilt per mount but reads from the vault, so that remount is harmless.
+  const libraryAdapter = useMemo(
+    () =>
+      createVaultLibraryAdapter({
+        list: () => canvasService.libraryList(),
+        save: (libraryItems) => canvasService.librarySave(libraryItems),
+        onError: (err, operation) => {
+          log.error(`Failed to ${operation} canvas library`, err)
+          if (operation === 'save') {
+            // A failed load leaves the panel as-is and retries on the next
+            // save; a failed save means the user's import is not on disk, so
+            // only that one is worth interrupting them for.
+            toast.error(t('canvas.libraryStoreFailed'))
+          }
+        }
+      }),
+    [t]
+  )
+
+  useHandleLibrary({ excalidrawAPI: api, adapter: libraryAdapter })
 
   // Excalidraw's own toolbar/menu i18n comes from its bundled translations via
   // langCode — independent of Memry's i18n and i18n:check; we do not translate

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-library-adapter.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-library-adapter.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createVaultLibraryAdapter } from './canvas-library-adapter'
+import type { CanvasLibraryItem } from '@memry/contracts/canvas-api'
+
+function item(id: string): CanvasLibraryItem {
+  return { id, status: 'unpublished', created: 1, elements: [] } as CanvasLibraryItem
+}
+
+function makeAdapter(overrides: Partial<Parameters<typeof createVaultLibraryAdapter>[0]> = {}) {
+  const deps = {
+    list: vi.fn().mockResolvedValue({ libraryItems: [item('a')] }),
+    save: vi.fn().mockResolvedValue({ changed: 1 }),
+    onError: vi.fn(),
+    ...overrides
+  }
+  return { adapter: createVaultLibraryAdapter(deps), deps }
+}
+
+describe('createVaultLibraryAdapter', () => {
+  it('loads the vault library', async () => {
+    const { adapter } = makeAdapter()
+
+    await expect(adapter.load({ source: 'load' })).resolves.toEqual({ libraryItems: [item('a')] })
+  })
+
+  it('returns null rather than an empty library when loading fails', async () => {
+    // null means "nothing stored", which leaves Excalidraw's in-memory library
+    // untouched. Returning { libraryItems: [] } would read as "the vault is
+    // empty" and the next save would tombstone every row.
+    const { adapter, deps } = makeAdapter({
+      list: vi.fn().mockRejectedValue(new Error('ipc down'))
+    })
+
+    await expect(adapter.load({ source: 'save' })).resolves.toBeNull()
+    expect(deps.onError).toHaveBeenCalledWith(expect.any(Error), 'load')
+  })
+
+  it('saves the full item list', async () => {
+    const { adapter, deps } = makeAdapter()
+
+    await adapter.save({ libraryItems: [item('a'), item('b')] as never })
+
+    expect(deps.save).toHaveBeenCalledWith([item('a'), item('b')])
+  })
+
+  it('reports a failed save instead of swallowing it', async () => {
+    const { adapter, deps } = makeAdapter({
+      save: vi.fn().mockRejectedValue(new Error('disk full'))
+    })
+
+    await expect(adapter.save({ libraryItems: [item('a')] as never })).resolves.toBeUndefined()
+    expect(deps.onError).toHaveBeenCalledWith(expect.any(Error), 'save')
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-library-adapter.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-library-adapter.ts
@@ -1,0 +1,57 @@
+/**
+ * Vault-backed persistence for Excalidraw's library (the shapes panel).
+ *
+ * Without an adapter the library lives only in the component's memory, and the
+ * editor remounts per canvas id — so an imported `.excalidrawlib` survives
+ * until the first tab switch and then vanishes. This routes load/save to the
+ * canvas library IPC surface, which stores one encrypted row per item.
+ *
+ * Dependency-injected (no `window.api` import) so the adapter is testable
+ * without the preload bridge or the Excalidraw runtime.
+ */
+
+import type { LibraryPersistenceAdapter } from '@excalidraw/excalidraw/data/library'
+import type { LibraryItems } from '@excalidraw/excalidraw/types'
+import type { CanvasLibraryItem } from '@memry/contracts/canvas-api'
+
+export interface VaultLibraryAdapterDeps {
+  list: () => Promise<{ libraryItems: CanvasLibraryItem[] }>
+  save: (libraryItems: CanvasLibraryItem[]) => Promise<unknown>
+  /** Surfaces a failure to the user; a silently dropped save loses their import. */
+  onError: (err: unknown, operation: 'load' | 'save') => void
+}
+
+export function createVaultLibraryAdapter(
+  deps: VaultLibraryAdapterDeps
+): LibraryPersistenceAdapter {
+  return {
+    async load() {
+      try {
+        const { libraryItems } = await deps.list()
+        // The vault stores library items as opaque JSON — only `id` is ours to
+        // interpret — so this cast is the one place the loose stored shape is
+        // reasserted as Excalidraw's. Anything narrower would strip fields a
+        // future Excalidraw version adds.
+        return { libraryItems: libraryItems as unknown as LibraryItems }
+      } catch (err) {
+        // Returning null means "no stored library" rather than "empty
+        // library". Excalidraw then leaves what's in memory alone, so a
+        // transient IPC failure can't cascade into wiping the panel — and,
+        // because Excalidraw calls load() again before each save, it can't
+        // cascade into tombstoning every row either.
+        deps.onError(err, 'load')
+        return null
+      }
+    },
+
+    async save(libraryData) {
+      try {
+        // The array is readonly on Excalidraw's side; the IPC bridge structured-
+        // clones it anyway, so copy rather than cast.
+        await deps.save([...libraryData.libraryItems] as CanvasLibraryItem[])
+      } catch (err) {
+        deps.onError(err, 'save')
+      }
+    }
+  }
+}

--- a/apps/docs/src/user-guide/canvas/overview.md
+++ b/apps/docs/src/user-guide/canvas/overview.md
@@ -36,13 +36,31 @@ register. Test it on your own device before relying on it.
 The drawing toolbar is provided by the underlying canvas engine and follows its
 own language list, which does not always match memrynote's interface language.
 
+## Shape library
+
+The library is the panel of reusable shapes you can drag onto any board. Open it
+with <kbd>0</kbd> or the library button in the toolbar.
+
+To install a shape kit, download an `.excalidrawlib` file — for example from
+[libraries.excalidraw.com](https://libraries.excalidraw.com) — and add it either
+way:
+
+- **Drag the file** onto the canvas.
+- **Open the library panel**, click the **⋯** menu, and choose **Open**.
+
+Your library is stored in your vault, encrypted, and is shared by every canvas
+rather than belonging to one board — so a kit you install stays available when
+you switch boards or restart. Removing an item from the panel removes it for
+good.
+
 ## Saving
 
 Canvases save into your vault automatically as you draw — there is nothing to
 save by hand. Pressing **Cmd/Ctrl+S** simply confirms this with a short
 "changes are saved" notice; it never opens a file dialog. Canvases are not
-files on disk, so the drawing engine's own open/save/export-to-file actions
-are hidden.
+files on disk, so the drawing engine's own open/save/export-to-file actions for
+_boards_ are hidden. The library's own file actions stay available, since a
+shape kit is a file you bring in from elsewhere.
 
 ## Next steps
 

--- a/apps/docs/src/user-guide/canvas/sync-and-limits.md
+++ b/apps/docs/src/user-guide/canvas/sync-and-limits.md
@@ -25,6 +25,14 @@ Images pasted or dropped onto a canvas are stored as attachments rather than
 inside the board itself, so boards stay small and an identical image used twice
 is stored once. Deleting the image, or the canvas, releases the stored copy.
 
+## The shape library
+
+Your shape library is stored in your vault encrypted, alongside your boards, and
+is shared by every canvas. It does not yet sync between devices: a kit you
+install on one computer stays on that computer, and you install it again on the
+next one. Installing different kits on two devices is safe — neither replaces
+the other.
+
 ## Size limit
 
 A canvas has a maximum synced size (the raw drawing data, not counting
@@ -46,3 +54,6 @@ canvases is the usual fix.
   differ from memrynote's interface language.
 - Canvas is opt-in per device — enabling it on one device does not enable it on
   another.
+- The shape library is stored per vault but does not sync between devices yet.
+- Publishing a shape kit to the public Excalidraw library from inside memrynote
+  is not supported; the panel's **Publish** action does not work here.

--- a/packages/contracts/src/canvas-api.ts
+++ b/packages/contracts/src/canvas-api.ts
@@ -73,6 +73,27 @@ export const CanvasUpdateSchema = z.object({
   entityRefs: z.array(CanvasEntityRefSchema).optional()
 })
 
+/**
+ * One Excalidraw LibraryItem. Only `id` is ours to reason about — it is the
+ * per-item storage key and the reconciliation key across devices. Everything
+ * else (elements, name, status, created) is stored verbatim and never
+ * interpreted, so an Excalidraw upgrade that adds fields round-trips intact;
+ * hence `looseObject` rather than a closed shape that would strip them.
+ */
+export const CanvasLibraryItemSchema = z.looseObject({
+  id: z.string().min(1)
+})
+export type CanvasLibraryItem = z.infer<typeof CanvasLibraryItemSchema>
+
+/**
+ * The whole library as Excalidraw hands it to us. Excalidraw's persistence
+ * adapter is blob-shaped (it always saves the full list); main diffs this
+ * against the stored rows, so an item missing here is a delete.
+ */
+export const CanvasLibrarySaveSchema = z.object({
+  libraryItems: z.array(CanvasLibraryItemSchema)
+})
+
 export const CanvasGetAssetSchema = z.object({
   canvasId: z.string().min(1),
   fileId: z.string().min(1)
@@ -121,6 +142,15 @@ export interface CanvasListAssetsResponse {
 
 export interface CanvasDeleteResponse {
   success: boolean
+}
+
+export interface CanvasLibraryListResponse {
+  libraryItems: CanvasLibraryItem[]
+}
+
+export interface CanvasLibrarySaveResponse {
+  /** Rows written (inserted + updated + tombstoned) — 0 means the save was a no-op. */
+  changed: number
 }
 
 export interface CanvasCreatedEvent {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -665,7 +665,10 @@ export const CanvasChannels = {
     LIST: 'canvas:list',
     UPLOAD_ASSET: 'canvas:upload-asset',
     GET_ASSET: 'canvas:get-asset',
-    LIST_ASSETS: 'canvas:list-assets'
+    LIST_ASSETS: 'canvas:list-assets',
+    /** Excalidraw library (shapes panel) — vault-global, not per canvas. */
+    LIBRARY_LIST: 'canvas:library-list',
+    LIBRARY_SAVE: 'canvas:library-save'
   },
   events: {
     CREATED: 'canvas:created',

--- a/packages/db-schema/src/schema/canvas.ts
+++ b/packages/db-schema/src/schema/canvas.ts
@@ -28,6 +28,42 @@ export const canvases = sqliteTable(
 )
 
 /**
+ * Excalidraw library items (the shapes panel), one row per LibraryItem.
+ *
+ * Vault-global, NOT per canvas — Excalidraw's library is a single collection
+ * shared by every scene, and the editor remounts per canvas id, so anything
+ * scoped to a canvas would vanish on the next tab switch.
+ *
+ * Row-per-item (rather than one blob) so a future sync type gets per-item LWW
+ * and real delete tombstones for free: two devices importing different kits
+ * both keep theirs. The sync columns are present from the first migration so
+ * enabling sync stays additive.
+ */
+export const canvasLibraryItems = sqliteTable(
+  'canvas_library_items',
+  {
+    // The Excalidraw LibraryItem id — stable across devices, which is what
+    // makes per-item reconciliation possible without a mapping table.
+    id: text('id').primaryKey(),
+    vaultId: text('vault_id').notNull(),
+    // Vault-key-encrypted LibraryItem JSON (elements, name, status, created).
+    itemCiphertext: text('item_ciphertext').notNull(),
+    vectorClock: text('vector_clock', { mode: 'json' }).$type<VectorClock>().notNull(),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+    // Soft-delete: removing an item from the panel must stay visible to sync,
+    // otherwise the item resurrects from another device on the next pull.
+    deletedAt: integer('deleted_at'),
+    lastSyncedAt: integer('last_synced_at'),
+    clock: text('clock', { mode: 'json' }).$type<VectorClock>()
+  },
+  (table) => [index('canvas_library_items_by_vault').on(table.vaultId, table.updatedAt)]
+)
+
+export type CanvasLibraryItemRow = typeof canvasLibraryItems.$inferSelect
+export type NewCanvasLibraryItemRow = typeof canvasLibraryItems.$inferInsert
+
+/**
  * Advisory index of which entities a canvas references. NOT authoritative —
  * the geometry/refs source of truth is the encrypted scene snapshot. Rows are
  * rewritten from the scene on every save/apply; consumers must LEFT JOIN and

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -232,6 +232,7 @@
     "corruptScene": "This canvas could not be read. Editing is disabled to avoid losing data.",
     "tooLargeToSync": "This canvas is too large to sync. It's saved on this device but won't reach your other devices until it's smaller.",
     "savedToVault": "All changes are saved to your vault automatically",
+    "libraryStoreFailed": "Could not save your shape library. Recent changes to it may be lost.",
     "disabledTitle": "Canvas is not enabled",
     "disabledBody": "This tab belongs to a feature that is not enabled on this device.",
     "card": {

--- a/packages/rpc/src/canvas.ts
+++ b/packages/rpc/src/canvas.ts
@@ -4,6 +4,9 @@ import {
   CanvasCreateSchema,
   CanvasUpdateSchema,
   type Canvas,
+  type CanvasLibraryItem,
+  type CanvasLibraryListResponse,
+  type CanvasLibrarySaveResponse,
   type CanvasSummary,
   type CanvasEntityRef,
   type CanvasListResponse,
@@ -33,6 +36,9 @@ export type {
   CanvasEntityRef,
   CanvasListResponse,
   CanvasDeleteResponse,
+  CanvasLibraryItem,
+  CanvasLibraryListResponse,
+  CanvasLibrarySaveResponse,
   CanvasCreatedEvent,
   CanvasUpdatedEvent,
   CanvasDeletedEvent,
@@ -90,6 +96,17 @@ export const canvasRpc = defineDomain({
       channel: CanvasChannels.invoke.LIST_ASSETS,
       params: ['canvasId'],
       invokeArgs: ['{ canvasId }']
+    }),
+    libraryList: defineMethod<() => Promise<CanvasLibraryListResponse>>({
+      channel: CanvasChannels.invoke.LIBRARY_LIST,
+      params: []
+    }),
+    librarySave: defineMethod<
+      (libraryItems: CanvasLibraryItem[]) => Promise<CanvasLibrarySaveResponse>
+    >({
+      channel: CanvasChannels.invoke.LIBRARY_SAVE,
+      params: ['libraryItems'],
+      invokeArgs: ['{ libraryItems }']
     })
   },
   events: {


### PR DESCRIPTION
## What

- Allow the `fileSystem` permission for trusted app origins, so the library panel's **Open** action can read a `.excalidrawlib` — the OS picker opened and then failed the `handle.getFile()` read, surfacing as Excalidraw's generic "Couldn't load library".
- Add `canvas_library_items` (migration `0038`), one encrypted row per LibraryItem, vault-global rather than per canvas, wired through `useHandleLibrary`.
- Reconcile Excalidraw's blob-shaped adapter against row-shaped storage in a pure `library-diff` module.
- Document the library, its vault storage, and its limits.

## Why

Two independent faults. Fixing only the permission would have looked correct and still lost the user's kit: no persistence adapter was wired, so the library lived in component memory while the editor remounts per canvas id.

Sync is deliberately not included — the shape is settled (one sync item per library item, for per-item LWW and real tombstones) and the sync columns already ship in `0038` so it stays additive, but `apps/sync-server/src/lib/sync-types.ts` derives its supported set from `RECORD_SYNC_ITEM_TYPES`, so the server has to deploy before a client can push the new type.