### PR TITLE
feat(canvas): render add-card results the way the app renders its entities

### DIFF
--- a/apps/desktop/src/main/database/queries/search.ts
+++ b/apps/desktop/src/main/database/queries/search.ts
@@ -48,6 +48,7 @@ interface FtsNoteRow {
   emoji: string | null
   fileType: NoteResultMetadata['fileType']
   wordCount: number | null
+  createdAt: string
   modifiedAt: string
   rank: number
   snippet: string
@@ -64,6 +65,7 @@ interface FtsTaskRow {
   dueDate: string | null
   priority: number
   completedAt: string | null
+  createdAt: string
   modifiedAt: string
   rank: number
   snippet: string
@@ -117,6 +119,7 @@ function searchNotes(
       nc.emoji,
       nc.file_type as fileType,
       nc.word_count as wordCount,
+      nc.created_at as createdAt,
       nc.modified_at as modifiedAt,
       bm25(fts_notes, 0.0, 2.0, 1.0, 1.0) as rank,
       snippet(fts_notes, 2, '<mark>', '</mark>', '...', 20) as snippet
@@ -136,7 +139,8 @@ function searchNotes(
       tags: [],
       emoji: row.emoji,
       fileType: row.fileType ?? undefined,
-      wordCount: row.wordCount
+      wordCount: row.wordCount,
+      createdAt: row.createdAt
     }
     return {
       id: row.id,
@@ -163,6 +167,7 @@ function searchJournals(indexDb: IndexDb, ftsQuery: string, limit: number): Sear
       nc.date,
       nc.emoji,
       nc.word_count as wordCount,
+      nc.created_at as createdAt,
       nc.modified_at as modifiedAt,
       bm25(fts_notes, 0.0, 2.0, 1.0, 1.0) as rank,
       snippet(fts_notes, 2, '<mark>', '</mark>', '...', 20) as snippet
@@ -211,6 +216,7 @@ function searchTasks(dataDb: DataDb, ftsQuery: string, limit: number): SearchRes
       t.due_date as dueDate,
       t.priority,
       t.completed_at as completedAt,
+      t.created_at as createdAt,
       t.modified_at as modifiedAt,
       bm25(fts_tasks, 0.0, 2.0, 1.0, 1.0) as rank,
       snippet(fts_tasks, 1, '<mark>', '</mark>', '...', 20) as snippet
@@ -233,7 +239,8 @@ function searchTasks(dataDb: DataDb, ftsQuery: string, limit: number): SearchRes
       statusName: row.statusName,
       dueDate: row.dueDate,
       priority: row.priority,
-      completedAt: row.completedAt
+      completedAt: row.completedAt,
+      createdAt: row.createdAt
     }
     return {
       id: row.id,
@@ -309,9 +316,15 @@ function getNoteTitles(
   noteFileTypes?: NoteFileType[]
 ): Array<TitleRow & { type: ContentType; metadata: NoteResultMetadata }> {
   const rows = indexDb.all<
-    TitleRow & { path: string; emoji: string | null; fileType: NoteResultMetadata['fileType'] }
+    TitleRow & {
+      path: string
+      emoji: string | null
+      fileType: NoteResultMetadata['fileType']
+      createdAt: string
+    }
   >(
-    sql`SELECT id, title, path, emoji, file_type as fileType, modified_at as modifiedAt
+    sql`SELECT id, title, path, emoji, file_type as fileType,
+          created_at as createdAt, modified_at as modifiedAt
         FROM note_cache nc
         WHERE date IS NULL
           AND ${noteFileTypeFilter(noteFileTypes)}`
@@ -324,7 +337,8 @@ function getNoteTitles(
       path: r.path,
       tags: [],
       emoji: r.emoji,
-      fileType: r.fileType ?? undefined
+      fileType: r.fileType ?? undefined,
+      createdAt: r.createdAt
     }
   }))
 }
@@ -355,9 +369,10 @@ function getTaskTitles(
       dueDate: string | null
       priority: number
       completedAt: string | null
+      createdAt: string
     }
   >(sql`
-    SELECT t.id, t.title, t.modified_at as modifiedAt,
+    SELECT t.id, t.title, t.created_at as createdAt, t.modified_at as modifiedAt,
       t.project_id as projectId, p.name as projectName, p.color as projectColor,
       t.status_id as statusId, s.name as statusName,
       t.due_date as dueDate, t.priority, t.completed_at as completedAt
@@ -377,7 +392,8 @@ function getTaskTitles(
       statusName: r.statusName,
       dueDate: r.dueDate,
       priority: r.priority,
-      completedAt: r.completedAt
+      completedAt: r.completedAt,
+      createdAt: r.createdAt
     }
   }))
 }

--- a/apps/desktop/src/renderer/src/components/note/content-area/task-block/task-block-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/task-block/task-block-utils.ts
@@ -17,7 +17,7 @@ export {
 } from '@memry/shared/task-block'
 export type { TaskBlockProps } from '@memry/shared/task-block'
 
-const DB_PRIORITY_MAP: Record<number, Priority> = {
+export const DB_PRIORITY_MAP: Record<number, Priority> = {
   0: 'none',
   1: 'low',
   2: 'medium',

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-dialog.test.tsx
@@ -20,8 +20,11 @@ const mocks = vi.hoisted(() => ({
 // render regardless of its own deps, masking whether the highlight effect's
 // dependency array is actually correct.
 vi.mock('@memry/i18n/renderer', () => {
-  const t = (key: string, vars?: Record<string, unknown>) =>
-    vars?.query ? `${key.split('.').at(-1)}:${String(vars.query)}` : (key.split('.').at(-1) ?? key)
+  const t = (key: string, vars?: Record<string, unknown>) => {
+    const last = key.split('.').at(-1) ?? key
+    const filled = vars?.query ?? vars?.date
+    return filled === undefined ? last : `${last}:${String(filled)}`
+  }
   const useTResult = { t }
   return {
     useT: () => useTResult
@@ -88,6 +91,95 @@ describe('CanvasAddCardDialog', () => {
     await waitFor(() => expect(screen.getByText('Alpha')).toBeInTheDocument())
     expect(screen.getByText('Ship it')).toBeInTheDocument()
     expect(screen.getByText('Standup')).toBeInTheDocument()
+  })
+
+  describe('row rendering', () => {
+    // The picker is a placement surface: a row has to say "note" / "task" /
+    // "event" on sight, the way the sidebar and the task list already do.
+    async function renderQuery(sources: typeof mocks.sources, anchor: string) {
+      mocks.sources = sources
+      setup()
+      fireEvent.change(screen.getByTestId('canvas-add-input'), { target: { value: 'a' } })
+      await waitFor(() => expect(screen.getByText(anchor)).toBeInTheDocument())
+    }
+
+    it("shows a note's own icon, its path and when it was created", async () => {
+      // #given — a note carrying an emoji icon
+      await renderQuery(
+        {
+          results: [
+            {
+              id: 'n1',
+              type: 'note',
+              title: 'Alpha',
+              metadata: {
+                type: 'note',
+                path: 'n/Alpha.md',
+                tags: [],
+                emoji: '📌',
+                createdAt: '2026-06-01T00:00:00.000Z'
+              }
+            }
+          ],
+          events: [],
+          loading: false
+        },
+        'Alpha'
+      )
+
+      // #then — the note's identity, not a bare title/subtitle pair
+      expect(screen.getByText('📌')).toBeInTheDocument()
+      expect(screen.getByText('n/Alpha.md')).toBeInTheDocument()
+      expect(screen.getByText(/addCreatedAt:/)).toBeInTheDocument()
+    })
+
+    it("shows a task's project, status, priority and due date", async () => {
+      // #given — a task with every property the task list would show
+      await renderQuery(
+        {
+          results: [
+            {
+              id: 't1',
+              type: 'task',
+              title: 'Ship it',
+              metadata: {
+                type: 'task',
+                projectName: 'Inbox',
+                projectColor: '#ff671a',
+                statusId: 's1',
+                statusName: 'In progress',
+                dueDate: '2026-08-01',
+                priority: 4,
+                completedAt: null,
+                createdAt: '2026-06-01T00:00:00.000Z'
+              }
+            }
+          ],
+          events: [],
+          loading: false
+        },
+        'Ship it'
+      )
+
+      // #then — the same vocabulary the task list uses, priority label included
+      expect(screen.getByText('Inbox')).toBeInTheDocument()
+      expect(screen.getByText('In progress')).toBeInTheDocument()
+      expect(screen.getByText('Urgent')).toBeInTheDocument()
+      // Aug 1, not Jul 31 — the date-only due date must not shift westward.
+      expect(screen.getByText(/Aug/)).toBeInTheDocument()
+    })
+
+    it('shows an event as a time, never as a raw ISO string', async () => {
+      // #given — a timed calendar event
+      await renderQuery(
+        { results: [], events: [eventItem('e1', 'Standup')], loading: false },
+        'Standup'
+      )
+
+      // #then — humanized, like the calendar card renders it
+      expect(screen.queryByText('2026-07-22T09:00:00.000Z')).not.toBeInTheDocument()
+      expect(screen.getByText(/Jul/)).toBeInTheDocument()
+    })
   })
 
   it('picks a fresh entity', async () => {

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-dialog.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-dialog.tsx
@@ -16,6 +16,7 @@ import {
   markOnCanvas,
   type AddCardCandidate
 } from './canvas-add-card'
+import { CanvasAddCardRow } from './canvas-add-card-row'
 import { entityKey } from './canvas-cards'
 import { useCanvasAddSearch } from './use-canvas-add-search'
 
@@ -53,12 +54,9 @@ export function CanvasAddCardDialog({
   }, [open])
 
   const groups = useMemo(() => {
-    const merged = [
-      ...candidatesFromSearch(results),
-      ...candidatesFromEvents(events, t('canvas.card.allDay'))
-    ]
+    const merged = [...candidatesFromSearch(results), ...candidatesFromEvents(events)]
     return groupCandidates(markOnCanvas(merged, onCanvasKeys))
-  }, [results, events, onCanvasKeys, t])
+  }, [results, events, onCanvasKeys])
 
   // A blank query always highlights the create row — the hook clears `events`
   // in its own effect, so for one frame after the user clears the input the
@@ -98,17 +96,14 @@ export function CanvasAddCardDialog({
               value={key}
               data-testid={`canvas-add-item-${key}`}
               onSelect={() => select(candidate)}
-              className="flex cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-2 text-sm data-[selected=true]:bg-muted"
+              className="flex cursor-pointer items-start gap-2.5 rounded-md px-2 py-2 text-sm data-[selected=true]:bg-muted"
             >
-              <span className="flex min-w-0 flex-col">
-                <span className="truncate">{candidate.title}</span>
-                <span className="truncate text-xs text-text-tertiary">{candidate.subtitle}</span>
-              </span>
-              {candidate.onCanvas ? (
-                <span className="shrink-0 rounded-full border border-border px-1.5 py-0.5 text-[10px] text-text-tertiary">
-                  {t('canvas.card.addOnCanvas')}
-                </span>
-              ) : null}
+              <CanvasAddCardRow
+                candidate={candidate}
+                createdLabel={(date) => t('canvas.card.addCreatedAt', { date })}
+                allDayLabel={t('canvas.card.allDay')}
+                onCanvasLabel={t('canvas.card.addOnCanvas')}
+              />
             </Command.Item>
           )
         })}

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-row.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card-row.tsx
@@ -1,0 +1,153 @@
+/**
+ * One result row in the canvas "Add card" picker.
+ *
+ * The picker is a placement surface, so a row has to answer "which entity is
+ * this?" at a glance. It borrows the vocabulary the user already learned
+ * elsewhere: the note's own icon as the sidebar shows it, the task's
+ * check/circle plus priority and due date as the task list shows them, and the
+ * event's clock as the calendar card shows it (canvas-card-summary.tsx).
+ */
+
+import React from 'react'
+import { CalendarClock, CheckCircle, Circle, FileText } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { NoteIconDisplay } from '@/lib/render-note-icon'
+import { priorityConfig } from '@/data/task-model'
+import { DB_PRIORITY_MAP } from '@/components/note/content-area/task-block/task-block-utils'
+import { formatEventTime } from './canvas-cards'
+import { formatDueDate, formatShortDate, type AddCardCandidate } from './canvas-add-card'
+
+/** A metadata chip: never wider than its content, never wrapping mid-word. */
+function Meta({
+  children,
+  style
+}: {
+  children: React.ReactNode
+  style?: React.CSSProperties
+}): React.JSX.Element {
+  return (
+    <span className="flex shrink-0 items-center gap-1 whitespace-nowrap" style={style}>
+      {children}
+    </span>
+  )
+}
+
+function RowIcon({ candidate }: { candidate: AddCardCandidate }): React.JSX.Element {
+  const { detail } = candidate
+
+  if (detail.type === 'note') {
+    return detail.emoji ? (
+      <NoteIconDisplay
+        value={detail.emoji}
+        className="flex size-4 shrink-0 items-center justify-center text-sm"
+      />
+    ) : (
+      <FileText className="size-4 shrink-0 text-text-tertiary" aria-hidden="true" />
+    )
+  }
+
+  if (detail.type === 'task') {
+    return detail.completed ? (
+      <CheckCircle className="size-4 shrink-0 text-primary" aria-hidden="true" />
+    ) : (
+      <Circle className="size-4 shrink-0 text-text-tertiary" aria-hidden="true" />
+    )
+  }
+
+  return <CalendarClock className="size-4 shrink-0 text-text-tertiary" aria-hidden="true" />
+}
+
+function RowMeta({
+  candidate,
+  createdLabel,
+  allDayLabel
+}: {
+  candidate: AddCardCandidate
+  createdLabel: (date: string) => string
+  allDayLabel: string
+}): React.JSX.Element | null {
+  const { detail } = candidate
+
+  if (detail.type === 'note') {
+    const created = formatShortDate(detail.createdAt)
+    return (
+      <div className="flex items-center gap-2 text-xs text-text-tertiary">
+        <span className="truncate">{detail.path}</span>
+        {created ? <Meta>{createdLabel(created)}</Meta> : null}
+      </div>
+    )
+  }
+
+  if (detail.type === 'task') {
+    const priority = DB_PRIORITY_MAP[detail.priority] ?? 'none'
+    const due = formatDueDate(detail.dueDate)
+    const created = formatShortDate(detail.createdAt)
+    return (
+      <div className="flex items-center gap-2 text-xs text-text-tertiary">
+        <Meta>
+          <span
+            className="inline-block size-2 rounded-full"
+            style={{ backgroundColor: detail.projectColor }}
+            aria-hidden="true"
+          />
+          <span className="max-w-32 truncate">{detail.projectName}</span>
+        </Meta>
+        {detail.statusName ? <Meta>{detail.statusName}</Meta> : null}
+        {priority !== 'none' ? (
+          <Meta style={{ color: priorityConfig[priority].color ?? undefined }}>
+            {priorityConfig[priority].label}
+          </Meta>
+        ) : null}
+        {due ? <Meta>{due}</Meta> : null}
+        {created ? <Meta>{createdLabel(created)}</Meta> : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-xs text-text-tertiary">
+      <Meta>{formatEventTime(detail.startAt, detail.isAllDay, allDayLabel)}</Meta>
+    </div>
+  )
+}
+
+export interface CanvasAddCardRowProps {
+  candidate: AddCardCandidate
+  /** Renders "Created {date}" — passed in so this file stays i18n-hook-free. */
+  createdLabel: (date: string) => string
+  allDayLabel: string
+  onCanvasLabel: string
+}
+
+export function CanvasAddCardRow({
+  candidate,
+  createdLabel,
+  allDayLabel,
+  onCanvasLabel
+}: CanvasAddCardRowProps): React.JSX.Element {
+  const isCompletedTask = candidate.detail.type === 'task' && candidate.detail.completed
+
+  return (
+    <>
+      <span className="mt-0.5 flex shrink-0 items-start">
+        <RowIcon candidate={candidate} />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span
+          className={cn(
+            'truncate text-sm font-medium',
+            isCompletedTask ? 'text-text-tertiary line-through' : 'text-foreground'
+          )}
+        >
+          {candidate.title}
+        </span>
+        <RowMeta candidate={candidate} createdLabel={createdLabel} allDayLabel={allDayLabel} />
+      </span>
+      {candidate.onCanvas ? (
+        <span className="mt-0.5 shrink-0 rounded-full border border-border px-1.5 py-0.5 text-[10px] text-text-tertiary">
+          {onCanvasLabel}
+        </span>
+      ) : null}
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card.test.ts
@@ -4,6 +4,8 @@ import type { CalendarEventSearchItem } from '@memry/contracts/calendar-api'
 import {
   candidatesFromEvents,
   candidatesFromSearch,
+  formatDueDate,
+  formatShortDate,
   groupCandidates,
   markOnCanvas,
   onCanvasKeys,
@@ -25,6 +27,7 @@ function noteHit(id: string, title: string, fileType?: string): SearchResultItem
       type: 'note',
       path: `notes/${title}.md`,
       tags: [],
+      createdAt: '2026-06-01T00:00:00.000Z',
       ...(fileType ? { fileType } : {})
     }
   } as SearchResultItem
@@ -49,7 +52,8 @@ function taskHit(id: string, title: string): SearchResultItem {
       statusName: null,
       dueDate: null,
       priority: 0,
-      completedAt: null
+      completedAt: null,
+      createdAt: '2026-06-01T00:00:00.000Z'
     }
   } as SearchResultItem
 }
@@ -62,11 +66,65 @@ describe('candidatesFromSearch', () => {
         entityType: 'note',
         entityId: 'n1',
         title: 'Alpha',
-        subtitle: 'notes/Alpha.md',
+        detail: {
+          type: 'note',
+          emoji: null,
+          path: 'notes/Alpha.md',
+          createdAt: '2026-06-01T00:00:00.000Z'
+        },
         onCanvas: false
       },
-      { entityType: 'task', entityId: 't1', title: 'Ship it', subtitle: 'Inbox', onCanvas: false }
+      {
+        entityType: 'task',
+        entityId: 't1',
+        title: 'Ship it',
+        detail: {
+          type: 'task',
+          projectName: 'Inbox',
+          projectColor: '#fff',
+          statusName: null,
+          priority: 0,
+          dueDate: null,
+          completed: false,
+          createdAt: '2026-06-01T00:00:00.000Z'
+        },
+        onCanvas: false
+      }
     ])
+  })
+
+  it('carries the fields a row renders: icon, status and dates', () => {
+    // #given — a note with its own icon and a completed, prioritised task
+    const note = noteHit('n1', 'Alpha')
+    ;(note.metadata as { emoji?: string | null }).emoji = '📌'
+    const task = taskHit('t1', 'Ship it')
+    Object.assign(task.metadata, {
+      statusName: 'In progress',
+      priority: 4,
+      dueDate: '2026-08-01',
+      completedAt: '2026-07-20T00:00:00.000Z'
+    })
+
+    // #when — they become candidates
+    const [noteCandidate, taskCandidate] = candidatesFromSearch([note, task])
+
+    // #then — nothing the row needs was flattened away
+    expect(noteCandidate.detail).toMatchObject({ emoji: '📌' })
+    expect(taskCandidate.detail).toMatchObject({
+      statusName: 'In progress',
+      priority: 4,
+      dueDate: '2026-08-01',
+      completed: true
+    })
+  })
+
+  it('treats a missing createdAt from an older main process as absent, not a crash', () => {
+    // #given — a note hit predating the createdAt field
+    const note = noteHit('n1', 'Alpha')
+    delete (note.metadata as { createdAt?: string | null }).createdAt
+
+    // #when / #then — the candidate still builds, with a null date
+    expect(candidatesFromSearch([note])[0].detail).toMatchObject({ createdAt: null })
   })
 
   it('drops filed binaries masquerading as notes (#800)', () => {
@@ -149,7 +207,7 @@ describe('candidatesFromEvents (#869)', () => {
     ]
 
     // #when — we map them to candidates
-    const out = candidatesFromEvents(items, 'All day')
+    const out = candidatesFromEvents(items)
 
     // #then — nothing is dropped or reordered client-side
     expect(out.map((c) => c.entityId)).toEqual(['e1', 'e2'])
@@ -157,31 +215,52 @@ describe('candidatesFromEvents (#869)', () => {
     expect(out.every((c) => c.onCanvas === false)).toBe(true)
   })
 
-  it('formats the subtitle with formatEventTime instead of a raw ISO string', () => {
-    // #given — a timed event
-    const out = candidatesFromEvents(
-      [eventItem('e1', 'Standup', '2026-07-02T09:00:00.000Z')],
-      'All day'
-    )
+  it('carries the raw start so the row can format it, all-day flag included', () => {
+    // #given — one timed and one all-day event
+    const out = candidatesFromEvents([
+      eventItem('e1', 'Standup', '2026-07-02T09:00:00.000Z'),
+      eventItem('e2', 'Offsite', '2026-07-02T00:00:00.000Z', true)
+    ])
 
-    // #then — the subtitle is humanized
-    expect(out[0].subtitle).not.toBe('2026-07-02T09:00:00.000Z')
-    expect(out[0].subtitle.length).toBeGreaterThan(0)
-  })
-
-  it('uses the all-day label for all-day events', () => {
-    // #given — an all-day event
-    const out = candidatesFromEvents(
-      [eventItem('e1', 'Offsite', '2026-07-02T00:00:00.000Z', true)],
-      'All day'
-    )
-
-    // #then — the label appears in the subtitle
-    expect(out[0].subtitle).toContain('All day')
+    // #then — formatting is the row's job now, not the candidate's
+    expect(out[0].detail).toEqual({
+      type: 'calendar_event',
+      startAt: '2026-07-02T09:00:00.000Z',
+      isAllDay: false
+    })
+    expect(out[1].detail).toMatchObject({ isAllDay: true })
   })
 
   it('returns an empty list for no items', () => {
     // #given / #when / #then — no events in, no candidates out
-    expect(candidatesFromEvents([], 'All day')).toEqual([])
+    expect(candidatesFromEvents([])).toEqual([])
+  })
+})
+
+describe('date formatting', () => {
+  it('omits the year for the current year and includes it otherwise', () => {
+    // #given — a fixed "now" in 2026
+    const now = new Date('2026-07-23T12:00:00.000Z')
+
+    // #when / #then — same-year dates stay short, older ones carry the year
+    expect(formatShortDate('2026-07-02T09:00:00.000Z', now)).not.toContain('2026')
+    expect(formatShortDate('2024-07-02T09:00:00.000Z', now)).toContain('2024')
+  })
+
+  it('keeps a date-only due date on its own day regardless of timezone', () => {
+    // #given — a due date that `new Date()` would parse as the previous day
+    // west of Greenwich (see the parseDueDate off-by-one)
+    const formatted = formatDueDate('2026-07-10', new Date('2026-07-23T12:00:00.000Z'))
+
+    // #then — the 10th, not the 9th
+    expect(formatted).toContain('10')
+  })
+
+  it('returns null for missing or unparseable values', () => {
+    // #given / #when / #then — nothing to show beats "Invalid Date"
+    expect(formatShortDate(null)).toBeNull()
+    expect(formatShortDate(undefined)).toBeNull()
+    expect(formatShortDate('not-a-date')).toBeNull()
+    expect(formatDueDate(null)).toBeNull()
   })
 })

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-add-card.ts
@@ -8,14 +8,40 @@
 import type { CanvasEntityType } from '@memry/contracts/canvas-api'
 import type { CalendarEventSearchItem } from '@memry/contracts/calendar-api'
 import type { SearchResultItem } from '@memry/contracts/search-api'
-import { entityKey, formatEventTime } from './canvas-cards'
+import { parseDueDate } from '@/lib/task-utils'
+import { entityKey } from './canvas-cards'
+
+/**
+ * Everything a picker row needs to render its entity the way the rest of the
+ * app renders it. Carried raw (not pre-formatted into one subtitle string) so
+ * the row can show an icon, a status and a date as separate affordances.
+ */
+export type AddCardDetail =
+  | {
+      type: 'note'
+      /** Emoji or hugeicon token from the note itself; null falls back to the type icon. */
+      emoji: string | null
+      path: string
+      createdAt: string | null
+    }
+  | {
+      type: 'task'
+      projectName: string
+      projectColor: string
+      statusName: string | null
+      /** 0–4, as stored. The row maps it to the shared priorityConfig. */
+      priority: number
+      dueDate: string | null
+      completed: boolean
+      createdAt: string | null
+    }
+  | { type: 'calendar_event'; startAt: string; isAllDay: boolean }
 
 export interface AddCardCandidate {
   entityType: CanvasEntityType
   entityId: string
   title: string
-  /** Secondary line: note path, project name, or event start. */
-  subtitle: string
+  detail: AddCardDetail
   /** True when this entity already has a card on the open canvas. */
   onCanvas: boolean
 }
@@ -45,7 +71,12 @@ export function candidatesFromSearch(results: readonly SearchResultItem[]): AddC
         entityType: 'note',
         entityId: result.id,
         title: result.title,
-        subtitle: result.metadata.path,
+        detail: {
+          type: 'note',
+          emoji: result.metadata.emoji ?? null,
+          path: result.metadata.path,
+          createdAt: result.metadata.createdAt ?? null
+        },
         onCanvas: false
       })
     } else if (result.metadata.type === 'task') {
@@ -53,7 +84,16 @@ export function candidatesFromSearch(results: readonly SearchResultItem[]): AddC
         entityType: 'task',
         entityId: result.id,
         title: result.title,
-        subtitle: result.metadata.projectName,
+        detail: {
+          type: 'task',
+          projectName: result.metadata.projectName,
+          projectColor: result.metadata.projectColor,
+          statusName: result.metadata.statusName,
+          priority: result.metadata.priority,
+          dueDate: result.metadata.dueDate,
+          completed: result.metadata.completedAt !== null,
+          createdAt: result.metadata.createdAt ?? null
+        },
         onCanvas: false
       })
     }
@@ -109,14 +149,43 @@ export function revealScroll(
  * pure mapping — no client-side filter, no occurrence dedup (one row per event).
  */
 export function candidatesFromEvents(
-  items: readonly CalendarEventSearchItem[],
-  allDayLabel: string
+  items: readonly CalendarEventSearchItem[]
 ): AddCardCandidate[] {
   return items.map((item) => ({
     entityType: 'calendar_event' as const,
     entityId: item.id,
     title: item.title,
-    subtitle: formatEventTime(item.startAt, item.isAllDay, allDayLabel),
+    detail: { type: 'calendar_event' as const, startAt: item.startAt, isAllDay: item.isAllDay },
     onCanvas: false
   }))
+}
+
+/**
+ * "Jul 2" for dates in the current year, "Jul 2, 2024" otherwise — an undated
+ * "Jul 2" three years old reads as recent, which is exactly backwards.
+ */
+function formatDate(parsed: Date, now: Date): string | null {
+  if (Number.isNaN(parsed.getTime())) return null
+  return parsed.toLocaleDateString(
+    undefined,
+    parsed.getFullYear() === now.getFullYear()
+      ? { month: 'short', day: 'numeric' }
+      : { month: 'short', day: 'numeric', year: 'numeric' }
+  )
+}
+
+/** Creation timestamps, which arrive as full datetimes. */
+export function formatShortDate(
+  value: string | null | undefined,
+  now: Date = new Date()
+): string | null {
+  return value ? formatDate(new Date(value), now) : null
+}
+
+/**
+ * Due dates are date-only strings; `new Date('2026-07-10')` parses as UTC and
+ * renders as the 9th west of Greenwich, so they go through parseDueDate.
+ */
+export function formatDueDate(value: string | null, now: Date = new Date()): string | null {
+  return value ? formatDate(parseDueDate(value), now) : null
 }

--- a/apps/docs/src/user-guide/canvas/cards-and-links.md
+++ b/apps/docs/src/user-guide/canvas/cards-and-links.md
@@ -21,6 +21,15 @@ appear in the picker. A note card renders a markdown preview, so those open in
 the file viewer instead. They never take up room in the search results, so a
 matching note is always shown even when many filed files share its name.
 
+Results are grouped into Notes, Tasks and Events, and each row is labelled the
+way the rest of the app labels it, so you can tell at a glance what you are
+about to place:
+
+- **Notes** show the note's own icon, its folder path and when it was created.
+- **Tasks** show a checkmark when they are done, plus their project, status,
+  priority and due date.
+- **Events** show a clock and the event's date and time.
+
 If you pick something that is already on the board, Memry scrolls to the card
 you already have instead of adding a duplicate — look for the **On canvas**
 badge in the results.

--- a/packages/contracts/src/search-api.ts
+++ b/packages/contracts/src/search-api.ts
@@ -40,6 +40,8 @@ export interface NoteResultMetadata {
   tags: string[]
   emoji?: string | null
   wordCount?: number | null
+  /** Index-row creation time. Absent in responses from older main processes. */
+  createdAt?: string | null
   /**
    * Underlying file type. Absent/`'markdown'` = a real note; a binary value
    * (image/pdf/audio/video) means this "note" result is actually a filed file
@@ -66,6 +68,8 @@ export interface TaskResultMetadata {
   dueDate: string | null
   priority: number
   completedAt: string | null
+  /** Task row creation time. Absent in responses from older main processes. */
+  createdAt?: string | null
 }
 
 export interface InboxResultMetadata {

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -250,7 +250,8 @@
       "addGroupNotes": "Notes",
       "addGroupTasks": "Tasks",
       "addGroupEvents": "Events",
-      "addOnCanvas": "On canvas"
+      "addOnCanvas": "On canvas",
+      "addCreatedAt": "Created {date}"
     }
   },
   "phaseF": {


### PR DESCRIPTION
## What

- Add-card picker rows now carry per-type detail: the note's own icon, path and creation date; the task's check/circle, project, status, priority and due date; the event's clock and time.
- `AddCardCandidate` drops its pre-flattened `subtitle` for a typed `detail` union.
- Search metadata gains an optional `createdAt` for notes and tasks — additive, so responses from an older main process still parse. Both `note_cache` and `tasks` already stored the column; the FTS **and** fuzzy-fallback queries now select it.

## Why

Every hit rendered as a title plus one grey subtitle, so a note, a task and an event were indistinguishable — you could not tell from the row which kind of thing you were about to place on the canvas.