### PR TITLE
test(canvas): stub useHandleLibrary in the CanvasEditor Excalidraw mock

### DIFF
--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-editor.test.tsx
@@ -63,7 +63,10 @@ vi.mock('@excalidraw/excalidraw', () => ({
   },
   serializeAsJSON: (elements: unknown[]) => JSON.stringify({ elements }),
   languages: [],
-  defaultLang: { code: 'en' }
+  defaultLang: { code: 'en' },
+  // Library persistence is covered by the adapter's own tests; here it only
+  // needs to exist so the hook call does not blow up the component.
+  useHandleLibrary: () => {}
 }))
 vi.mock('@excalidraw/excalidraw/index.css', () => ({}))
 vi.mock('next-themes', () => ({ useTheme: () => ({ resolvedTheme: 'light' }) }))


### PR DESCRIPTION
## Summary

Fixes red `main` on Desktop CI → **Unit & integration tests**.

`ba7180426` (#891) added `useHandleLibrary` to `canvas-editor.tsx`, but `canvas-editor.test.tsx` mocks `@excalidraw/excalidraw` with an explicit factory that only exported `Excalidraw`, `serializeAsJSON`, `languages`, and `defaultLang`. All four `CanvasEditor persistence safety` tests failed with:

```
[vitest] No "useHandleLibrary" export is defined on the "@excalidraw/excalidraw" mock.
```

Adds a no-op `useHandleLibrary` stub to that factory.

Why a no-op is the right stub: `useHandleLibrary` is the only consumer of `libraryAdapter`, so the adapter is constructed by `useMemo` but never invoked — nothing reaches IPC under jsdom. Library persistence behavior remains covered by `canvas-library-adapter.test.ts`.

This also unblocks #892, which touches neither file.

## Release note
none

## Test plan

```
cd apps/desktop && npx vitest run --config config/vitest.config.ts --project renderer src/renderer/src/pages/canvas/canvas-editor.test.tsx
```

`PASS (4) FAIL (0)` — was 0/4 before the change.