### PR TITLE
feat(canvas): drag notes, tasks and events onto a canvas

### DIFF
--- a/apps/desktop/src/renderer/src/components/calendar/draggable-task-chip.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/draggable-task-chip.test.tsx
@@ -25,7 +25,7 @@ vi.mock('@dnd-kit/core', () => ({
 
 interface DraggableConfig {
   id: string
-  data: { type: string; sourceType: string; taskId: string }
+  data: Record<string, unknown>
 }
 
 function lastDraggableConfig(): DraggableConfig {
@@ -81,10 +81,49 @@ describe('DraggableTaskChip', () => {
     })
   })
 
-  it('does not wrap an event chip', () => {
+  it('does not wrap an event chip as a task drag', () => {
     renderChip(makeItem({ sourceType: 'event', sourceId: 'event-1', visualType: 'event' }))
 
+    // Rescheduling an event by dragging it is not a thing; the event chip is
+    // draggable only so it can be dropped on a canvas.
     expect(screen.queryByTestId('draggable-task-chip')).toBeNull()
+    expect(screen.getByTestId('draggable-canvas-chip')).toBeInTheDocument()
+  })
+
+  it('registers an event chip as a canvas-entity drag drag-context will ignore', () => {
+    renderChip(makeItem({ sourceType: 'event', sourceId: 'event-1', visualType: 'event' }))
+
+    const config = lastDraggableConfig()
+    expect(config.data).toEqual({
+      type: 'canvas-entity',
+      entityType: 'calendar_event',
+      entityId: 'event-1'
+    })
+  })
+
+  it('namespaces the event draggable id so it cannot collide with a task id', () => {
+    // drag-context resolves multi-select by matching active.id against the task
+    // list; a bare event id could collide with a task id and drag the wrong rows.
+    renderChip(makeItem({ sourceType: 'event', sourceId: 'event-1', visualType: 'event' }))
+
+    const config = lastDraggableConfig()
+    expect(config.id).toBe('canvas-event:event-1')
+  })
+
+  it('uses the event source id, not the projection id, for the entity', () => {
+    // A recurring event projects one item per occurrence; the card must
+    // reference the event, not the occurrence.
+    renderChip(
+      makeItem({
+        projectionId: 'event:event-1:2026-07-15',
+        sourceType: 'event',
+        sourceId: 'event-1',
+        visualType: 'event'
+      })
+    )
+
+    const config = lastDraggableConfig()
+    expect((config.data as unknown as { entityId: string }).entityId).toBe('event-1')
   })
 
   it('does not wrap a task chip that cannot move', () => {

--- a/apps/desktop/src/renderer/src/components/calendar/draggable-task-chip.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/draggable-task-chip.tsx
@@ -1,4 +1,5 @@
 import { useDraggable } from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
 import { CalendarItemChip } from './calendar-item-chip'
 import { cn } from '@/lib/utils'
 import type { AnchorRect } from './types'
@@ -12,7 +13,10 @@ interface DraggableTaskChipProps {
   onAddToProject?: (eventId: string) => void
 }
 
-/** Task chips are date-draggable via dnd-kit; every other chip renders untouched. */
+/**
+ * Task chips are date-draggable via dnd-kit; event chips are draggable only so
+ * they can be dropped on a spatial canvas. Every other chip renders untouched.
+ */
 export function DraggableTaskChip({
   item,
   isSelected,
@@ -22,9 +26,21 @@ export function DraggableTaskChip({
 }: DraggableTaskChipProps): React.JSX.Element {
   const isDraggableTask = item.sourceType === 'task' && Boolean(item.editability?.canMove)
 
-  if (!isDraggableTask) {
+  if (isDraggableTask) {
     return (
-      <CalendarItemChip
+      <DraggableTaskChipInner
+        item={item}
+        isSelected={isSelected}
+        onClick={onClick}
+        onDeleteItem={onDeleteItem}
+        onAddToProject={onAddToProject}
+      />
+    )
+  }
+
+  if (item.sourceType === 'event') {
+    return (
+      <DraggableCanvasChipInner
         item={item}
         isSelected={isSelected}
         onClick={onClick}
@@ -35,13 +51,62 @@ export function DraggableTaskChip({
   }
 
   return (
-    <DraggableTaskChipInner
+    <CalendarItemChip
       item={item}
       isSelected={isSelected}
       onClick={onClick}
       onDeleteItem={onDeleteItem}
       onAddToProject={onAddToProject}
     />
+  )
+}
+
+/**
+ * An event chip that can be dragged onto a spatial canvas to create a card.
+ *
+ * The drag type is deliberately NOT one of drag-context's task types, so the
+ * task drag machinery (multi-select, drag overlay, reschedule-on-drop) ignores
+ * it entirely; the canvas resolves it in canvas-drop-entity.ts. Since there is
+ * no DragOverlay for it, the chip itself takes the drag translation so
+ * something follows the cursor.
+ */
+function DraggableCanvasChipInner({
+  item,
+  isSelected,
+  onClick,
+  onDeleteItem,
+  onAddToProject
+}: DraggableTaskChipProps): React.JSX.Element {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    // Namespaced: drag-context matches active.id against the task list, and a
+    // bare event id could collide with a task id there. The entity id travels
+    // in `data`, never parsed back out of this id.
+    id: `canvas-event:${item.sourceId}`,
+    data: {
+      type: 'canvas-entity',
+      entityType: 'calendar_event',
+      entityId: item.sourceId
+    }
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid="draggable-canvas-chip"
+      data-event-id={item.sourceId}
+      className={cn('touch-none', isDragging && 'relative z-50 opacity-80')}
+      style={{ transform: CSS.Translate.toString(transform) }}
+      {...attributes}
+      {...listeners}
+    >
+      <CalendarItemChip
+        item={item}
+        isSelected={isSelected}
+        onClick={onClick}
+        onDeleteItem={onDeleteItem}
+        onAddToProject={onAddToProject}
+      />
+    </div>
   )
 }
 

--- a/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.test.tsx
+++ b/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.test.tsx
@@ -12,6 +12,7 @@ import {
   TreeView,
   useTree
 } from './index'
+import { CANVAS_ITEM_DRAG_MIME } from '@/pages/canvas/canvas-cards'
 
 vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({ t: (key: string) => key.split('.').at(-1) ?? key })
@@ -296,5 +297,58 @@ describe('TreeProvider and tree primitives', () => {
     expect(() => render(<TreeNodeTrigger>orphan</TreeNodeTrigger>)).toThrow(
       'Tree components must be used within a TreeProvider'
     )
+  })
+})
+
+describe('canvas drag payload', () => {
+  function renderNode(canvasNoteId?: string) {
+    render(
+      <TreeProvider persistKey="tree-canvas-test" draggable>
+        <TreeView>
+          <TreeNode nodeId="note-1" canvasNoteId={canvasNoteId}>
+            <TreeNodeTrigger>
+              <span>Note One</span>
+            </TreeNodeTrigger>
+          </TreeNode>
+        </TreeView>
+      </TreeProvider>
+    )
+    return screen.getByText('Note One').closest('[draggable]') as HTMLElement
+  }
+
+  it('tags a note so the spatial canvas can card it on drop', () => {
+    const node = renderNode('note-1')
+    const transfer = dataTransfer()
+
+    fireEvent.dragStart(node, { dataTransfer: transfer })
+
+    expect(transfer.setData).toHaveBeenCalledWith(
+      CANVAS_ITEM_DRAG_MIME,
+      JSON.stringify({ entityType: 'note', entityId: 'note-1' })
+    )
+    // Chromium refuses a drop whose dropEffect is not permitted by
+    // effectAllowed, and the canvas asks for 'copy'. Leaving this at the
+    // tree's own 'move' silently kills the drop with no visible error.
+    expect(transfer.effectAllowed).toBe('copyMove')
+  })
+
+  it('still carries the tree payload its own reordering needs', () => {
+    const node = renderNode('note-1')
+    const transfer = dataTransfer()
+
+    fireEvent.dragStart(node, { dataTransfer: transfer })
+
+    expect(transfer.setData).toHaveBeenCalledWith('application/x-memry-tree-node', 'note-1')
+  })
+
+  it('leaves a node with no canvas entity untouched', () => {
+    const node = renderNode(undefined)
+    const transfer = dataTransfer()
+
+    fireEvent.dragStart(node, { dataTransfer: transfer })
+
+    expect(transfer.setData).toHaveBeenCalledTimes(1)
+    expect(transfer.setData).toHaveBeenCalledWith('application/x-memry-tree-node', 'note-1')
+    expect(transfer.effectAllowed).toBe('move')
   })
 })

--- a/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.tsx
+++ b/apps/desktop/src/renderer/src/components/kibo-ui/tree/index.tsx
@@ -23,6 +23,7 @@ import {
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
 import { IconPicker, getIconByName } from '@/components/icon-picker'
+import { CANVAS_ITEM_DRAG_MIME, canvasDragPayload } from '@/pages/canvas/canvas-cards'
 import { useT } from '@memry/i18n/renderer'
 
 type NodeInfo = {
@@ -112,6 +113,7 @@ type TreeNodeContextType = {
   hideLines: boolean
   customIcon?: string
   inheritedIcon?: string
+  canvasNoteId?: string
   setCustomIcon: (iconName: string | undefined) => void
 }
 
@@ -501,6 +503,12 @@ export type TreeNodeProps = HTMLAttributes<HTMLDivElement> & {
   customIcon?: string
   inheritedIcon?: string
   hasChildren?: boolean
+  /**
+   * The note this row stands for, when it is one. Opt-in: a node that sets it
+   * also carries the spatial-canvas drag payload, so dropping the row on a
+   * canvas creates a referencing card. Folders leave it unset.
+   */
+  canvasNoteId?: string
 }
 
 export const TreeNode = ({
@@ -516,6 +524,7 @@ export const TreeNode = ({
   customIcon: initialCustomIcon,
   inheritedIcon: initialInheritedIcon,
   hasChildren = false,
+  canvasNoteId,
   ...props
 }: TreeNodeProps) => {
   const generatedId = useId()
@@ -556,6 +565,7 @@ export const TreeNode = ({
     hideLines: hideLinesProp,
     customIcon,
     inheritedIcon,
+    canvasNoteId,
     setCustomIcon
   }
 
@@ -605,7 +615,8 @@ export const TreeNodeTrigger = ({
     setNodeIcon,
     getEffectiveIcon
   } = useTree()
-  const { nodeId, level, hasChildren, parentId, customIcon, acceptsDropInside } = useTreeNode()
+  const { nodeId, level, hasChildren, parentId, customIcon, acceptsDropInside, canvasNoteId } =
+    useTreeNode()
   const isSelected = selectedIds.includes(nodeId)
   const triggerRef = useRef<HTMLDivElement>(null)
 
@@ -707,11 +718,19 @@ export const TreeNodeTrigger = ({
     (e: React.DragEvent) => {
       if (!draggable) return
 
-      e.dataTransfer.effectAllowed = 'move'
+      e.dataTransfer.effectAllowed = canvasNoteId ? 'copyMove' : 'move'
       e.dataTransfer.setData('application/x-memry-tree-node', nodeId)
+      if (canvasNoteId) {
+        // Mirrors VirtualizedNotesTree, which the sidebar swaps to once the
+        // vault passes the virtualization threshold. Without this the same
+        // drag onto a canvas does nothing on a small vault. 'copyMove' above
+        // matters just as much: the canvas asks for dropEffect 'copy', and
+        // Chromium silently refuses a drop that effectAllowed does not permit.
+        e.dataTransfer.setData(CANVAS_ITEM_DRAG_MIME, canvasDragPayload('note', canvasNoteId))
+      }
       setDragState({ draggedId: nodeId })
     },
-    [draggable, nodeId, setDragState]
+    [draggable, nodeId, canvasNoteId, setDragState]
   )
 
   const handleDragEnd = useCallback(() => {

--- a/apps/desktop/src/renderer/src/components/notes-tree.tsx
+++ b/apps/desktop/src/renderer/src/components/notes-tree.tsx
@@ -275,7 +275,14 @@ export const NotesTree = forwardRef<NotesTreeActions, NotesTreeProps>(function N
     const isPartOfSelection = isSelected && selectedIds.length > 1
 
     return (
-      <TreeNode key={note.id} nodeId={note.id} level={level} isLast={isLast} hideLines={hideLines}>
+      <TreeNode
+        key={note.id}
+        nodeId={note.id}
+        level={level}
+        isLast={isLast}
+        hideLines={hideLines}
+        canvasNoteId={note.id}
+      >
         <TreeNodeTrigger
           contextMenuContent={
             <>

--- a/apps/desktop/src/renderer/src/hooks/use-drag-handlers.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-drag-handlers.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react'
 import type { DragEndEvent } from '@dnd-kit/core'
 
 import { useDragHandlers } from './use-drag-handlers'
+import { CANVAS_DROP_DATA } from '@/pages/canvas/canvas-drop-entity'
 import type { DragState } from '@/contexts/drag-context'
 import type { Priority, Task } from '@/data/task-model'
 import type { Project, Status, StatusType } from '@/data/tasks-data'
@@ -111,6 +112,40 @@ describe('useDragHandlers', () => {
       result.current.handleDragStart({} as never, createDragState())
       result.current.handleDragOver({} as never, createDragState())
       result.current.undo()
+    })
+
+    expect(onUpdateTask).not.toHaveBeenCalled()
+    expect(onDeleteTask).not.toHaveBeenCalled()
+    expect(onReorder).not.toHaveBeenCalled()
+    expect(result.current.canUndo).toBe(false)
+  })
+
+  it('leaves a task untouched when it is dropped on a spatial canvas', () => {
+    // A canvas drop only creates a referencing card (canvas-card-overlay owns
+    // that through useDndMonitor). The task itself must not be rescheduled,
+    // reordered, moved between projects, or trashed on the way past.
+    const onUpdateTask = vi.fn()
+    const onDeleteTask = vi.fn()
+    const onReorder = vi.fn()
+
+    const { result } = renderHook(() =>
+      useDragHandlers({
+        tasks: [createTask()],
+        projects: [createProject()],
+        onUpdateTask,
+        onDeleteTask,
+        onReorder
+      })
+    )
+
+    act(() => {
+      result.current.handleDragEnd(
+        createDragEvent({
+          active: { id: 'task-1', data: { current: { type: 'task', task: createTask() } } },
+          over: { id: 'canvas-drop-1', data: { current: CANVAS_DROP_DATA } }
+        }),
+        createDragState({ overType: null, overId: 'canvas-drop-1', overSectionId: null })
+      )
     })
 
     expect(onUpdateTask).not.toHaveBeenCalled()

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useRef } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -17,6 +17,37 @@ vi.mock('@excalidraw/excalidraw', () => ({
     y: clientY
   }),
   CaptureUpdateAction: { IMMEDIATELY: 'immediately' }
+}))
+
+// dnd-kit's monitor throws outside a DndContext, and a real DndContext gives
+// no way to synthesize a drag in jsdom. Capturing the listeners instead lets
+// the suite drive the overlay's own drop handler directly — the mapping it
+// feeds on is unit-tested in canvas-drop-entity.test.ts.
+const dnd = vi.hoisted(() => ({
+  listeners: {} as {
+    onDragStart?: (event: unknown) => void
+    onDragEnd?: (event: unknown) => void
+    onDragCancel?: () => void
+  },
+  isOver: false,
+  droppableId: null as string | null,
+  droppableData: null as unknown,
+  dragContext: null as { dragState: { draggedTasks: { id: string }[] } } | null
+}))
+
+vi.mock('@/contexts/drag-context', () => ({
+  useOptionalDragContext: () => dnd.dragContext
+}))
+
+vi.mock('@dnd-kit/core', () => ({
+  useDndMonitor: (listeners: typeof dnd.listeners) => {
+    dnd.listeners = listeners
+  },
+  useDroppable: ({ id, data }: { id: string; data: unknown }) => {
+    dnd.droppableId = id
+    dnd.droppableData = data
+    return { setNodeRef: () => {}, isOver: dnd.isOver }
+  }
 }))
 
 vi.mock('@memry/i18n/renderer', () => ({
@@ -443,5 +474,181 @@ describe('CanvasCardLayer', () => {
         expect(screen.getByTestId('card-e1')).toHaveAttribute('data-canvas-card-locked', 'true')
       )
     })
+  })
+})
+
+describe('CanvasCardLayer — dnd-kit drops', () => {
+  beforeEach(() => {
+    mocks.entities = new Map()
+    mocks.lockReason = null
+    dnd.listeners = {}
+    dnd.isOver = false
+    dnd.droppableId = null
+    dnd.droppableData = null
+    dnd.dragContext = null
+  })
+
+  /** A dnd-kit drag-end landing on the canvas droppable at (clientX, clientY). */
+  function dropEvent(
+    data: Record<string, unknown>,
+    activeId: string,
+    at: { clientX: number; clientY: number } | null = { clientX: 120, clientY: 80 },
+    overId: string | null = dnd.droppableId
+  ): unknown {
+    return {
+      active: { id: activeId, data: { current: data } },
+      over: overId === null ? null : { id: overId },
+      activatorEvent: at ?? {},
+      delta: { x: 0, y: 0 }
+    }
+  }
+
+  function entityIds(passed: { elements: { customData?: { entityId?: string } }[] }): string[] {
+    return passed.elements.map((e) => e.customData?.entityId).filter(Boolean) as string[]
+  }
+
+  it('registers a droppable that task drop handlers can tell apart', () => {
+    const { api } = makeApi([])
+    render(<Harness api={api} />)
+    expect(dnd.droppableId).toBeTruthy()
+    // use-drag-handlers switches on over.data.current.type; 'canvas' must not
+    // collide with a task drop target or the task would also be rescheduled.
+    expect(dnd.droppableData).toEqual({ type: 'canvas' })
+  })
+
+  it('cards a task dropped from a task list at the drop point', async () => {
+    const { api, updateScene } = makeApi([])
+    const onSceneMutated = vi.fn()
+    render(<Harness api={api} onSceneMutated={onSceneMutated} />)
+
+    act(() => {
+      dnd.listeners.onDragEnd?.(dropEvent({ type: 'task', task: { id: 't1' } }, 't1'))
+    })
+
+    await waitFor(() => expect(updateScene).toHaveBeenCalled())
+    const passed = updateScene.mock.calls[0][0]
+    expect(entityIds(passed)).toEqual(['t1'])
+    const card = passed.elements[0]
+    expect(card.customData).toEqual({ entityType: 'task', entityId: 't1' })
+    // makeApi's viewport is 1:1 at the origin, so scene == client coords, and
+    // the skeleton is centred on the drop point.
+    expect(card.x + card.width / 2).toBe(120)
+    expect(card.y + card.height / 2).toBe(80)
+    expect(onSceneMutated).toHaveBeenCalled()
+  })
+
+  it('cards a calendar event dragged from a calendar view', async () => {
+    const { api, updateScene } = makeApi([])
+    render(<Harness api={api} />)
+
+    act(() => {
+      dnd.listeners.onDragEnd?.(
+        dropEvent(
+          { type: 'canvas-entity', entityType: 'calendar_event', entityId: 'ev1' },
+          'canvas-event:ev1'
+        )
+      )
+    })
+
+    await waitFor(() => expect(updateScene).toHaveBeenCalled())
+    expect(updateScene.mock.calls[0][0].elements[0].customData).toEqual({
+      entityType: 'calendar_event',
+      entityId: 'ev1'
+    })
+  })
+
+  it('ignores a drop that landed on another droppable', () => {
+    const { api, updateScene } = makeApi([])
+    render(<Harness api={api} />)
+
+    act(() => {
+      dnd.listeners.onDragEnd?.(
+        dropEvent(
+          { type: 'task', task: { id: 't1' } },
+          't1',
+          { clientX: 1, clientY: 1 },
+          'some-list'
+        )
+      )
+      dnd.listeners.onDragEnd?.(
+        dropEvent({ type: 'task', task: { id: 't1' } }, 't1', { clientX: 1, clientY: 1 }, null)
+      )
+    })
+
+    expect(updateScene).not.toHaveBeenCalled()
+  })
+
+  it('ignores a drag the canvas cannot place', () => {
+    const { api, updateScene } = makeApi([])
+    render(<Harness api={api} />)
+
+    act(() => {
+      dnd.listeners.onDragEnd?.(dropEvent({ type: 'column', columnId: 'c1' }, 'c1'))
+    })
+
+    expect(updateScene).not.toHaveBeenCalled()
+  })
+
+  it('places one card per task of a multi-select drop, without stacking them', async () => {
+    dnd.dragContext = {
+      dragState: { draggedTasks: [{ id: 't1' }, { id: 't2' }, { id: 't3' }] }
+    }
+    const { api, updateScene } = makeApi([])
+    render(<Harness api={api} />)
+
+    act(() => {
+      dnd.listeners.onDragEnd?.(dropEvent({ type: 'task', task: { id: 't1' } }, 't1'))
+    })
+
+    await waitFor(() => expect(updateScene).toHaveBeenCalled())
+    const passed = updateScene.mock.calls[0][0]
+    expect(entityIds(passed)).toEqual(['t1', 't2', 't3'])
+    const centers = passed.elements.map(
+      (e: { x: number; y: number; width: number; height: number }) =>
+        `${e.x + e.width / 2},${e.y + e.height / 2}`
+    )
+    expect(new Set(centers).size).toBe(3)
+  })
+
+  it('still places a card when the drag carries no pointer (keyboard sensor)', async () => {
+    const { api, updateScene } = makeApi([])
+    render(<Harness api={api} />)
+
+    act(() => {
+      dnd.listeners.onDragEnd?.(dropEvent({ type: 'task', task: { id: 't1' } }, 't1', null))
+    })
+
+    await waitFor(() => expect(updateScene).toHaveBeenCalled())
+    expect(entityIds(updateScene.mock.calls[0][0])).toEqual(['t1'])
+  })
+
+  it('shows the drop ring only while a placeable drag is over the canvas', async () => {
+    dnd.isOver = true
+    const { api } = makeApi([])
+    const { rerender } = render(<Harness api={api} />)
+    expect(screen.queryByTestId('canvas-drop-ring')).toBeNull()
+
+    act(() => {
+      dnd.listeners.onDragStart?.({ active: { id: 't1', data: { current: { type: 'task' } } } })
+    })
+    await waitFor(() => expect(screen.getByTestId('canvas-drop-ring')).toBeInTheDocument())
+
+    act(() => {
+      dnd.listeners.onDragCancel?.()
+    })
+    rerender(<Harness api={api} />)
+    await waitFor(() => expect(screen.queryByTestId('canvas-drop-ring')).toBeNull())
+  })
+
+  it('does not show the drop ring for a drag the canvas cannot place', async () => {
+    dnd.isOver = true
+    const { api } = makeApi([])
+    render(<Harness api={api} />)
+
+    act(() => {
+      dnd.listeners.onDragStart?.({ active: { id: 'c1', data: { current: { type: 'column' } } } })
+    })
+
+    await waitFor(() => expect(screen.queryByTestId('canvas-drop-ring')).toBeNull())
   })
 })

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-card-overlay.tsx
@@ -9,17 +9,20 @@
  * viewport are mounted (virtualization with hysteresis).
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import {
   convertToExcalidrawElements,
   viewportCoordsToSceneCoords,
   CaptureUpdateAction
 } from '@excalidraw/excalidraw'
 import type { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types'
+import { useDndMonitor, useDroppable } from '@dnd-kit/core'
+import type { CanvasEntityRef } from '@memry/contracts/canvas-api'
 import { toast } from 'sonner'
 import { getI18n } from 'react-i18next'
 import { Plus } from '@/lib/icons'
 import { useTabActions } from '@/contexts/tabs'
+import { useOptionalDragContext } from '@/contexts/drag-context'
 import { notesService } from '@/services/notes-service'
 import { createLogger } from '@/lib/logger'
 import { extractErrorMessage } from '@/lib/ipc-error'
@@ -32,6 +35,8 @@ import {
   computeVisibleCardIds,
   findFreeCardCenter,
   getCardRefs,
+  CARD_DEFAULT_HEIGHT,
+  CARD_DEFAULT_WIDTH,
   makeCardSkeleton,
   overlayTransform,
   readCanvasDragItem,
@@ -42,6 +47,12 @@ import {
   type CanvasCardRef,
   type CardElement
 } from './canvas-cards'
+import {
+  CANVAS_DROP_DATA,
+  entitiesFromDrag,
+  entityFromDndData,
+  pointerFromDragEnd
+} from './canvas-drop-entity'
 import { buildRedirectTab } from './canvas-redirect'
 import { noteCardClaims } from './canvas-note-lock'
 import { useNoteEditLock, lockReasonForCard } from './use-note-edit-lock'
@@ -52,6 +63,9 @@ const log = createLogger('SpatialCanvas')
 
 const ENTER_PADDING = 200
 const EXIT_PADDING = 500
+
+/** Stable empty default so the drop handler's deps do not change every render. */
+const EMPTY_DRAGGED_TASKS: readonly { id: string }[] = []
 
 interface CanvasCardLayerProps {
   excalidrawAPI: ExcalidrawImperativeAPI
@@ -218,18 +232,51 @@ export const CanvasCardLayer = ({
     [openTab]
   )
 
-  const createCardElement = useCallback(
-    (
-      entityType: CanvasCardRef['entityType'],
-      entityId: string,
-      centerX: number,
-      centerY: number
-    ): void => {
-      const skeleton = makeCardSkeleton({ entityType, entityId, centerX, centerY })
-      const created = convertToExcalidrawElements([skeleton] as unknown as Parameters<
-        typeof convertToExcalidrawElements
-      >[0])
+  /**
+   * Cards for one or more entities in a single scene update. The first lands
+   * exactly on (centerX, centerY) — the user picked that point by dropping
+   * there — and each further card spirals out to the nearest free cell so a
+   * multi-select drop tiles instead of stacking into one unreadable pile.
+   */
+  const createCardElements = useCallback(
+    (refs: readonly CanvasEntityRef[], centerX: number, centerY: number): void => {
+      if (refs.length === 0) {
+        return
+      }
       const existing = excalidrawAPI.getSceneElementsIncludingDeleted()
+      // Occupancy grows as we place, so cards in the same drop avoid each other
+      // and not just the cards that were already on the scene.
+      const occupied = getCardRefs(existing as unknown as CardElement[])
+      const skeletons = refs.map((ref, index) => {
+        const center =
+          index === 0
+            ? { x: centerX, y: centerY }
+            : findFreeCardCenter(occupied, {
+                minX: centerX,
+                maxX: centerX,
+                minY: centerY,
+                maxY: centerY
+              })
+        occupied.push({
+          elementId: '',
+          entityType: ref.entityType,
+          entityId: ref.entityId,
+          x: center.x - CARD_DEFAULT_WIDTH / 2,
+          y: center.y - CARD_DEFAULT_HEIGHT / 2,
+          width: CARD_DEFAULT_WIDTH,
+          height: CARD_DEFAULT_HEIGHT,
+          angle: 0
+        })
+        return makeCardSkeleton({
+          entityType: ref.entityType,
+          entityId: ref.entityId,
+          centerX: center.x,
+          centerY: center.y
+        })
+      })
+      const created = convertToExcalidrawElements(
+        skeletons as unknown as Parameters<typeof convertToExcalidrawElements>[0]
+      )
       excalidrawAPI.updateScene({
         elements: [...existing, ...created],
         captureUpdate: CaptureUpdateAction.IMMEDIATELY
@@ -239,6 +286,76 @@ export const CanvasCardLayer = ({
     },
     [excalidrawAPI, onSceneMutated, recompute]
   )
+
+  const createCardElement = useCallback(
+    (
+      entityType: CanvasCardRef['entityType'],
+      entityId: string,
+      centerX: number,
+      centerY: number
+    ): void => {
+      createCardElements([{ entityType, entityId }], centerX, centerY)
+    },
+    [createCardElements]
+  )
+
+  // The dnd-kit drop target, alongside the capture-phase HTML5 one below.
+  // Task rows and calendar chips spread their dnd-kit listeners on the row
+  // root, so they cannot also carry a native `draggable` without two drag
+  // systems racing on one pointerdown — they arrive through dnd-kit instead.
+  // useId keys the target to this mounted layer, so two canvases open in a
+  // split view are two independent drop targets with no central registry.
+  const dropId = useId()
+  const { setNodeRef: setDropRef, isOver } = useDroppable({ id: dropId, data: CANVAS_DROP_DATA })
+  useEffect(() => {
+    setDropRef(wrapperRef.current)
+    return () => setDropRef(null)
+  }, [setDropRef, wrapperRef])
+
+  // Optional: the canvas renders inside DragProvider in the app, but must not
+  // require it (tests mount the layer alone). Without it, a multi-select drop
+  // degrades to placing the one dragged row.
+  const dragContext = useOptionalDragContext()
+  const draggedTasks = dragContext?.dragState.draggedTasks ?? EMPTY_DRAGGED_TASKS
+  const [dragPlaceable, setDragPlaceable] = useState(false)
+
+  useDndMonitor({
+    onDragStart: (event) => {
+      setDragPlaceable(
+        entityFromDndData(event.active.data.current, String(event.active.id)) !== null
+      )
+    },
+    onDragCancel: () => setDragPlaceable(false),
+    onDragEnd: (event) => {
+      setDragPlaceable(false)
+      if (event.over?.id !== dropId) {
+        return
+      }
+      const refs = entitiesFromDrag(
+        event.active.data.current,
+        String(event.active.id),
+        draggedTasks
+      )
+      if (refs.length === 0) {
+        return
+      }
+      const pointer = pointerFromDragEnd(event.activatorEvent, event.delta)
+      if (!pointer) {
+        // Keyboard sensor: there is no pointer to drop on, so fall back to the
+        // automatic placement the Add-card picker uses.
+        const { cards, appState } = readScene()
+        const rect = viewportSceneRect(appState, {
+          width: clipRef.current?.clientWidth ?? 0,
+          height: clipRef.current?.clientHeight ?? 0
+        })
+        const { x, y } = findFreeCardCenter(cards, rect)
+        createCardElements(refs, x, y)
+        return
+      }
+      const scene = viewportCoordsToSceneCoords(pointer, excalidrawAPI.getAppState())
+      createCardElements(refs, scene.x, scene.y)
+    }
+  })
 
   // Capture-phase drop/dragover/dblclick on the wrapper so they run before
   // Excalidraw's own handlers (mirrors the note editor's capture listeners).
@@ -479,6 +596,15 @@ export const CanvasCardLayer = ({
 
   return (
     <>
+      {/* Drop affordance: only while a canvas-placeable drag is over this
+          canvas, so hovering it with a task being reordered stays silent. */}
+      {isOver && dragPlaceable ? (
+        <div
+          data-testid="canvas-drop-ring"
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-2 z-[4] rounded-lg border-2 border-dashed border-sidebar-terracotta/60"
+        />
+      ) : null}
       {/* z-[3] lifts the overlay above Excalidraw's interactive canvas
           (--zIndex-interactiveCanvas: 2) so card previews cover their
           rectangles and the ↗ buttons are clickable. .excalidraw has no

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-drop-entity.test.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-drop-entity.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CANVAS_DROP_DATA,
+  entityFromDndData,
+  entitiesFromDrag,
+  pointerFromDragEnd
+} from './canvas-drop-entity'
+
+describe('CANVAS_DROP_DATA', () => {
+  it('marks the droppable as a canvas so task drag handlers can ignore it', () => {
+    expect(CANVAS_DROP_DATA).toEqual({ type: 'canvas' })
+  })
+})
+
+describe('entityFromDndData', () => {
+  it('maps a list/kanban task row', () => {
+    expect(entityFromDndData({ type: 'task', task: { id: 't1' } }, 't1')).toEqual({
+      entityType: 'task',
+      entityId: 't1'
+    })
+  })
+
+  it('falls back to the draggable id when the task payload has no task object', () => {
+    expect(entityFromDndData({ type: 'task' }, 't2')).toEqual({
+      entityType: 'task',
+      entityId: 't2'
+    })
+  })
+
+  it('maps a calendar task chip through taskId', () => {
+    expect(entityFromDndData({ type: 'calendar-task', taskId: 't3' }, 't3')).toEqual({
+      entityType: 'task',
+      entityId: 't3'
+    })
+  })
+
+  it('maps a subtask row', () => {
+    expect(entityFromDndData({ type: 'subtask', subtask: { id: 's1' } }, 's1')).toEqual({
+      entityType: 'task',
+      entityId: 's1'
+    })
+  })
+
+  it('maps an explicit canvas-entity payload', () => {
+    expect(
+      entityFromDndData(
+        { type: 'canvas-entity', entityType: 'calendar_event', entityId: 'e1' },
+        'canvas-event:e1'
+      )
+    ).toEqual({ entityType: 'calendar_event', entityId: 'e1' })
+  })
+
+  it('never trusts the draggable id for a canvas-entity payload', () => {
+    // The namespaced draggable id is not the entity id — a missing entityId
+    // must fail closed rather than create a card pointing at "canvas-event:e1".
+    expect(
+      entityFromDndData({ type: 'canvas-entity', entityType: 'note' }, 'canvas-event:e1')
+    ).toBe(null)
+  })
+
+  it('rejects an unknown entityType', () => {
+    expect(
+      entityFromDndData({ type: 'canvas-entity', entityType: 'inbox_item', entityId: 'i1' }, 'x')
+    ).toBe(null)
+  })
+
+  it('rejects drags that are not canvas-placeable', () => {
+    expect(entityFromDndData({ type: 'column' }, 'c1')).toBe(null)
+    expect(entityFromDndData({ type: 'tab' }, 'tab1')).toBe(null)
+    expect(entityFromDndData(undefined, 'p1')).toBe(null)
+    // A sidebar project reorder carries no type at all (App.tsx relies on that).
+    expect(entityFromDndData({}, 'proj1')).toBe(null)
+  })
+
+  it('rejects a task drag with no usable id', () => {
+    expect(entityFromDndData({ type: 'task' }, '')).toBe(null)
+    expect(entityFromDndData({ type: 'calendar-task' }, '')).toBe(null)
+  })
+})
+
+describe('entitiesFromDrag', () => {
+  const task = (id: string): { id: string } => ({ id })
+
+  it('expands a multi-select task drag into one ref per task', () => {
+    const refs = entitiesFromDrag({ type: 'task', task: task('t1') }, 't1', [
+      task('t1'),
+      task('t2'),
+      task('t3')
+    ])
+    expect(refs).toEqual([
+      { entityType: 'task', entityId: 't1' },
+      { entityType: 'task', entityId: 't2' },
+      { entityType: 'task', entityId: 't3' }
+    ])
+  })
+
+  it('ignores the selection when the dragged row is not part of it', () => {
+    // Dragging an unselected row must move only that row — mirrors dnd-kit's
+    // own multi-drag rule in drag-context.
+    const refs = entitiesFromDrag({ type: 'task', task: task('t9') }, 't9', [
+      task('t1'),
+      task('t2')
+    ])
+    expect(refs).toEqual([{ entityType: 'task', entityId: 't9' }])
+  })
+
+  it('returns a single ref for a single-item drag', () => {
+    expect(entitiesFromDrag({ type: 'task', task: task('t1') }, 't1', [task('t1')])).toEqual([
+      { entityType: 'task', entityId: 't1' }
+    ])
+    expect(entitiesFromDrag({ type: 'task', task: task('t1') }, 't1', [])).toEqual([
+      { entityType: 'task', entityId: 't1' }
+    ])
+  })
+
+  it('does not multi-expand a calendar event drag', () => {
+    const refs = entitiesFromDrag(
+      { type: 'canvas-entity', entityType: 'calendar_event', entityId: 'e1' },
+      'canvas-event:e1',
+      [task('t1'), task('t2')]
+    )
+    expect(refs).toEqual([{ entityType: 'calendar_event', entityId: 'e1' }])
+  })
+
+  it('returns nothing for a drag the canvas cannot place', () => {
+    expect(entitiesFromDrag({ type: 'column' }, 'c1', [])).toEqual([])
+    expect(entitiesFromDrag(undefined, 'x', [])).toEqual([])
+  })
+
+  it('drops selected ids that no longer resolve to a task', () => {
+    const refs = entitiesFromDrag({ type: 'task', task: task('t1') }, 't1', [
+      task('t1'),
+      { id: '' } as { id: string }
+    ])
+    expect(refs).toEqual([{ entityType: 'task', entityId: 't1' }])
+  })
+})
+
+describe('pointerFromDragEnd', () => {
+  it('adds the drag delta to the pointerdown coordinate', () => {
+    const activator = { clientX: 100, clientY: 200 } as PointerEvent
+    expect(pointerFromDragEnd(activator, { x: 30, y: -40 })).toEqual({
+      clientX: 130,
+      clientY: 160
+    })
+  })
+
+  it('returns the activator coordinate when there is no delta', () => {
+    const activator = { clientX: 10, clientY: 20 } as PointerEvent
+    expect(pointerFromDragEnd(activator, null)).toEqual({ clientX: 10, clientY: 20 })
+  })
+
+  it('returns null for an activator with no coordinates (keyboard sensor)', () => {
+    expect(pointerFromDragEnd({} as Event, { x: 1, y: 1 })).toBe(null)
+    expect(pointerFromDragEnd(null, { x: 1, y: 1 })).toBe(null)
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-drop-entity.ts
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-drop-entity.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure mapping helpers for dropping an existing item onto a canvas via dnd-kit.
+ *
+ * The canvas already accepts a native HTML5 drag from the sidebar note tree
+ * (see CANVAS_ITEM_DRAG_MIME in canvas-cards.ts). Task rows and calendar chips
+ * cannot use that path: their dnd-kit listeners sit on the row root, so a
+ * native `draggable` on the same element would put two drag systems on one
+ * pointerdown. They come in through dnd-kit instead, and this module turns a
+ * dnd-kit drag payload into the canvas entity refs a drop should card.
+ *
+ * React- and Excalidraw-free (types only), mirroring canvas-cards.ts, so the
+ * mapping unit-tests without either library.
+ */
+
+import {
+  CANVAS_ENTITY_TYPES,
+  type CanvasEntityRef,
+  type CanvasEntityType
+} from '@memry/contracts/canvas-api'
+
+/**
+ * The `data` a canvas droppable registers. `use-drag-handlers` switches on
+ * `over.data.current.type`, so this value must stay outside the set of task
+ * drop-target types — a task dropped on a canvas must become a card without
+ * also being rescheduled or moved between sections.
+ */
+export const CANVAS_DROP_DATA = { type: 'canvas' } as const
+
+/** dnd-kit drag types that carry a task, across list, kanban, calendar and subtask rows. */
+const TASK_DRAG_TYPES = new Set(['task', 'calendar-task', 'subtask'])
+
+/** The drag type calendar event chips register — the canvas is their only target. */
+const CANVAS_ENTITY_DRAG_TYPE = 'canvas-entity'
+
+/** Minimal shape of anything the selection can hand back as a dragged task. */
+export interface DraggedTaskLike {
+  id: string
+}
+
+type DndData = Record<string, unknown> | undefined | null
+
+function isEntityType(value: unknown): value is CanvasEntityType {
+  return typeof value === 'string' && (CANVAS_ENTITY_TYPES as readonly string[]).includes(value)
+}
+
+function readId(value: unknown): string | null {
+  if (typeof value === 'string' && value.length > 0) {
+    return value
+  }
+  if (value && typeof value === 'object') {
+    const id = (value as { id?: unknown }).id
+    if (typeof id === 'string' && id.length > 0) {
+      return id
+    }
+  }
+  return null
+}
+
+/**
+ * The entity a single dnd-kit drag refers to, or null when the drag is not
+ * something a canvas can place (a column, a tab, a sidebar project reorder).
+ *
+ * `activeId` is the draggable id and is only a fallback for task drags, where
+ * it IS the task id. A canvas-entity drag namespaces its draggable id
+ * (`canvas-event:<id>`), so its entity id must come from the payload alone.
+ */
+export function entityFromDndData(data: DndData, activeId: string): CanvasEntityRef | null {
+  const type = data?.type
+  if (typeof type !== 'string') {
+    return null
+  }
+
+  if (TASK_DRAG_TYPES.has(type)) {
+    const entityId =
+      readId(data?.task) ?? readId(data?.subtask) ?? readId(data?.taskId) ?? readId(activeId)
+    return entityId ? { entityType: 'task', entityId } : null
+  }
+
+  if (type === CANVAS_ENTITY_DRAG_TYPE) {
+    const entityType = data?.entityType
+    const entityId = readId(data?.entityId)
+    if (isEntityType(entityType) && entityId) {
+      return { entityType, entityId }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Every entity a drop should card. A task drag that is part of the current
+ * multi-selection expands to one ref per selected task — dragging three
+ * selected rows onto a canvas places three cards. Dragging an unselected row
+ * places only that row, mirroring drag-context's own multi-drag rule.
+ */
+export function entitiesFromDrag(
+  data: DndData,
+  activeId: string,
+  draggedTasks: readonly DraggedTaskLike[]
+): CanvasEntityRef[] {
+  const single = entityFromDndData(data, activeId)
+  if (!single) {
+    return []
+  }
+
+  const isMultiTaskDrag =
+    single.entityType === 'task' &&
+    draggedTasks.length > 1 &&
+    draggedTasks.some((task) => task.id === single.entityId)
+  if (!isMultiTaskDrag) {
+    return [single]
+  }
+
+  const refs: CanvasEntityRef[] = []
+  for (const task of draggedTasks) {
+    if (task.id) {
+      refs.push({ entityType: 'task', entityId: task.id })
+    }
+  }
+  return refs
+}
+
+/**
+ * Where the pointer was when the drag ended. dnd-kit reports no drop
+ * coordinate, only the activating pointer event and the distance dragged since
+ * — their sum is the drop point. Null for a drag with no pointer at all
+ * (keyboard sensor), where the caller falls back to automatic placement.
+ */
+export function pointerFromDragEnd(
+  activatorEvent: Event | null | undefined,
+  delta: { x: number; y: number } | null | undefined
+): { clientX: number; clientY: number } | null {
+  const source = activatorEvent as { clientX?: unknown; clientY?: unknown } | null | undefined
+  if (typeof source?.clientX !== 'number' || typeof source?.clientY !== 'number') {
+    return null
+  }
+  return {
+    clientX: source.clientX + (delta?.x ?? 0),
+    clientY: source.clientY + (delta?.y ?? 0)
+  }
+}

--- a/apps/docs/src/user-guide/canvas/cards-and-links.md
+++ b/apps/docs/src/user-guide/canvas/cards-and-links.md
@@ -5,16 +5,36 @@ canvas. The canvas stores the reference, never a copy of your content.
 
 ## Adding cards
 
-- **Drag a note** from the sidebar onto the canvas.
+- **Drag the item onto the canvas.** Notes from the sidebar, tasks from any
+  task list, and events from the Calendar all drop straight onto the board and
+  become a card where you let go. A dashed outline shows the canvas is ready to
+  take the drop.
 - **Click "Add card"** at the bottom of the canvas to search your notes, tasks
   and events, or to create a new note without leaving the board. "Create
   note …" is always the first option, and typing a title carries it into the
   new note. The picker opens over a dimmed canvas; press <kbd>Esc</kbd> or
   click outside it to go back to the board.
 
-Task and calendar-event cards are added through **Add card**. Dragging works
-for notes from the sidebar; the Tasks and Calendar pages have no drag-in, so
-tasks and events always go through the picker.
+Searching is never required. If you can see the item — in the sidebar, in the
+other half of a split view, on the Calendar — you can drag it over.
+
+### Dragging items in
+
+Tasks drag from anywhere they are listed: the Tasks page, a board column, a
+project, and Today. Select several tasks first and the whole selection drops
+together, tiled side by side rather than stacked on one point.
+
+Calendar events drag from the day, week and month views. Dragging an event onto
+a canvas never changes its date — it only places a card.
+
+Inbox items cannot be dragged onto a canvas. File one first: the note or task
+it becomes can then be dragged over like any other item.
+
+Dropping something that already has a card gives you a second card for it. Both
+stay live and both update together — useful when the same note belongs to two
+clusters on the board. The **Add card** picker behaves differently: pick
+something that is already on the board and it scrolls to the card you have
+instead, marked with an **On canvas** badge.
 
 Files you have filed into your vault — PDFs, images, audio and video — do not
 appear in the picker. A note card renders a markdown preview, so those open in
@@ -30,14 +50,16 @@ about to place:
   priority and due date.
 - **Events** show a clock and the event's date and time.
 
-If you pick something that is already on the board, Memry scrolls to the card
-you already have instead of adding a duplicate — look for the **On canvas**
-badge in the results.
-
 A card added from the picker lands in the middle of your view, or in the
 nearest free spot beside it when something is already there. Add three tasks
 and an event in a row and they tile out from the centre instead of piling up on
 one point.
+
+## Removing cards
+
+Select a card and press <kbd>Backspace</kbd> to take it off the board. Only the
+card goes — the note, task or event itself is untouched and stays wherever it
+lives.
 
 Cards show a live preview: a note's title and the start of its body, a task's
 title and status, an event's title and time. Rename or complete the item

--- a/docs/superpowers/specs/2026-07-23-canvas-drag-drop-items-design.md
+++ b/docs/superpowers/specs/2026-07-23-canvas-drag-drop-items-design.md
@@ -1,0 +1,168 @@
+# Canvas drag & drop: place items without the Add-card picker
+
+Date: 2026-07-23
+Status: approved, ready for implementation
+Branch: `canvas-drag-drop-items`
+
+## Problem
+
+Putting an item on a spatial canvas today means opening the Add-card picker and
+searching for it. Search is the _only_ path for tasks and calendar events. That
+is backwards when the item is already on screen — in the sidebar tree, in a
+task list in the other split pane, or on the calendar.
+
+Sidebar notes are the exception: they already drag onto a canvas. The gap is
+every other entity kind.
+
+Goal: any canvas-placeable item that is visible anywhere in the app can be
+dragged onto an open canvas and becomes a card at the drop point. The picker
+stays, but stops being mandatory.
+
+## Scope
+
+| Source surface                          | Today                               | After                                   |
+| --------------------------------------- | ----------------------------------- | --------------------------------------- |
+| Sidebar note tree                       | native HTML5 drag → card (works)    | unchanged                               |
+| Task row (list, kanban, today, project) | dnd-kit draggable, no canvas target | drops onto canvas; **no source change** |
+| Calendar event chip (day/week/month)    | not draggable                       | `useDraggable` added                    |
+| Calendar task chip                      | dnd-kit (reschedule)                | also drops onto canvas                  |
+| Inbox item                              | —                                   | **out of scope**                        |
+
+### Why inbox is out of scope
+
+`CANVAS_ENTITY_TYPES` is `['note', 'task', 'calendar_event']`
+(`packages/contracts/src/canvas-api.ts`). Adding `inbox_item` would touch the
+contract enum, `canvas_entity_refs`, the card renderer (voice / clip / pdf /
+reminder previews each differ), the entity resolver, the redirect-tab builder,
+and would need older app versions to tolerate a card type they cannot render —
+a sync/back-compat problem for a live beta. Inbox items are also transient:
+filing one already produces a note or a task, which _are_ placeable. Deferred
+as its own piece of work.
+
+### Removal
+
+Deleting a card is already Excalidraw's own delete (select + Backspace);
+`extractEntityRefs` rewrites `canvas_entity_refs` on the next save. No new work.
+
+## Approach
+
+Two drag mechanisms exist in the app and both stay:
+
+- **Native HTML5 DnD** — the note tree writes `CANVAS_ITEM_DRAG_MIME`
+  (`application/x-memry-canvas-item`); the canvas already consumes it in a
+  capture-phase `drop` listener.
+- **dnd-kit** — `DragProvider`'s `DndContext` is mounted at the app root
+  (`App.tsx`), so _every_ pane, including a canvas in a split view, is inside
+  one drag context. Task rows spread dnd-kit listeners on the row root
+  (`components/tasks/drag-drop/task-row.tsx`), so a native `draggable` on the
+  same element would make two drag systems race on one pointerdown.
+
+Therefore the canvas becomes a **dnd-kit droppable** in addition to its
+existing HTML5 drop target. Task rows need no change at all; calendar event
+chips gain a `useDraggable`.
+
+The canvas listens for its own drops with `useDndMonitor` rather than routing
+through `App.tsx`'s `handleDragEnd`. `App.tsx` stays untouched, and a canvas in
+each split pane registers its own droppable id — no central registry of which
+pane holds which canvas.
+
+`DragProvider` ignores any drag whose `data.type` is not
+`task` / `calendar-task` / `subtask` (`contexts/drag-context.tsx`), so the new
+`canvas-entity` drag type cannot disturb task drag state, multi-select, or the
+drag overlay.
+
+### Duplicates
+
+A drop always creates a card, including for an entity that already has one.
+Multiple cards for one entity are legal — the same note can appear in two
+clusters — and `extractEntityRefs` already dedupes the persisted refs.
+
+Known inconsistency, accepted: the Add-card picker still marks and blocks
+entities that are already on the canvas (`onCanvas`). Drag and picker will
+disagree. Relaxing the picker is a separate decision.
+
+## Components
+
+### 1. `pages/canvas/canvas-drop-entity.ts` (new, pure)
+
+React- and Excalidraw-free, mirroring `canvas-cards.ts` so it unit-tests
+without either library.
+
+- `CANVAS_DROP_DATA` — the `data` object the canvas droppable registers,
+  `{ type: 'canvas' }`.
+- `entityFromDndData(data): CanvasEntityRef | null` — maps a dnd-kit
+  `active.data.current` to a canvas entity:
+  - `type: 'task' | 'calendar-task' | 'subtask'` → `{ entityType: 'task', entityId }`,
+    reading the id from `task.id` / `taskId` / the draggable id passed in.
+  - `type: 'canvas-entity'` → `{ entityType, entityId }` read from the payload,
+    validated against `CANVAS_ENTITY_TYPES`.
+  - anything else → `null`.
+- `entitiesFromDrag(activeData, activeId, draggedTasks): CanvasEntityRef[]` —
+  expands a multi-select task drag (dnd-kit's `dragState.draggedTasks`) into one
+  ref per task; a single-item drag returns one ref; an unrecognised drag returns
+  `[]`.
+- `pointerFromDragEnd(activatorEvent, delta): { clientX, clientY } | null` —
+  dnd-kit reports no drop coordinate, so the pointer position is the
+  pointerdown coordinate plus the drag delta. Returns `null` when the activator
+  event carries no coordinates (keyboard sensor).
+
+### 2. `pages/canvas/canvas-card-overlay.tsx` (extended)
+
+- `useId()` gives a droppable id unique to this mounted overlay, i.e. per open
+  canvas pane; `useDroppable({ id, data: CANVAS_DROP_DATA })`. `setNodeRef` is
+  pointed at `wrapperRef.current` from an effect (the wrapper element is owned
+  by the editor, not created here).
+- `useDndMonitor({ onDragEnd })`: when `over?.id` is this droppable's id,
+  resolve refs with `entitiesFromDrag`, resolve the pointer with
+  `pointerFromDragEnd`, convert to scene coordinates with
+  `viewportCoordsToSceneCoords`, and create the cards.
+- `createCardElement` generalises to `createCardElements(refs, centerX, centerY)`:
+  the first card is centred on the drop point, each subsequent one is placed by
+  `findFreeCardCenter` so a multi-select drop tiles instead of stacking.
+  A single-item drop keeps today's behaviour exactly.
+- Drop affordance: when `isOver` and the active drag resolves to at least one
+  entity, the wrapper shows a dashed ring. Purely visual.
+- The existing capture-phase HTML5 `dragover`/`drop` listeners are untouched.
+
+### 3. Calendar event chips
+
+A wrapper around `CalendarItemChip` (alongside the existing
+`DraggableTaskChip`) registers, for `item.sourceType === 'event'`:
+
+```
+useDraggable({
+  id: `canvas-event:${item.sourceId}`,
+  data: { type: 'canvas-entity', entityType: 'calendar_event', entityId: item.sourceId }
+})
+```
+
+The draggable id is namespaced so it can never collide with a task id in
+`DragProvider`'s selection lookup. Because the drag type is not a task type,
+`DragProvider` renders no `DragOverlay` for it; the chip itself takes a
+`CSS.Translate` transform while dragging so something follows the cursor. The
+8px `PointerSensor` activation distance keeps click-to-open-popover intact.
+
+## Testing
+
+- `canvas-drop-entity.test.ts` — the mapping table (each accepted `type`, each
+  rejected one), unknown/malformed payloads → `null`, multi-select expansion,
+  single-drag fallback, pointer math including the keyboard-sensor `null` case.
+- `canvas-card-overlay.test.tsx` — `useDndMonitor` mocked (precedent:
+  `components/cold-zero-components.test.tsx`): a task drop creates a card at the
+  drop point; a drag that resolves to no entity creates nothing; a drop whose
+  `over` is a different droppable creates nothing; a multi-select drop creates
+  one card per task and does not stack them.
+- Calendar chip test — an event chip is draggable and carries the right payload;
+  a task chip keeps its existing `type: 'calendar-task'` payload.
+- Regression — dropping a task on the canvas must not also reschedule or move
+  it: `use-drag-handlers`' `switch (overType)` must fall through with no side
+  effect for the canvas droppable.
+
+## Risks
+
+1. A dnd-kit pointer drag passing over Excalidraw could start a selection
+   marquee. The drag holds pointer capture on the source element, so Excalidraw
+   should not see the moves — to be confirmed by hand in the running app.
+2. Adding a drag to calendar event chips could disturb click-to-open-popover.
+   Mitigated by the 8px activation distance and covered by a test.
+3. Picker/drag disagreement on duplicates (accepted above).


### PR DESCRIPTION
## Summary

Putting an item on a canvas required the Add-card picker: search was the only path for tasks and calendar events. Now any placeable item you can see can be dragged straight onto an open canvas and becomes a card where you let go. The picker stays, but stops being mandatory.

- **Task rows drop onto a canvas with no source change.** They are already dnd-kit draggable and `DragProvider`'s `DndContext` is mounted at the app root, so the canvas registers a dnd-kit droppable alongside its existing HTML5 drop target and resolves its own drops with `useDndMonitor`. Every task surface — list, kanban, Today, project — comes along for free. `App.tsx` is untouched.
- **Calendar event chips gain a `useDraggable`** whose drag type (`canvas-entity`) `drag-context` deliberately ignores, so task drag state, multi-select and the drag overlay are unaffected. One wrapper covers the day, week and month views. The draggable id is namespaced (`canvas-event:<id>`) because `drag-context` resolves multi-select by matching `active.id` against the task list, where a bare event id could collide with a task id.
- **A multi-select drop places one card per selected task**, tiling them out from the drop point instead of stacking.
- Sidebar notes keep their existing native HTML5 path; the canvas accepts both.
- A dashed ring shows only while a drag the canvas can actually place is over it.

Design doc: `docs/superpowers/specs/2026-07-23-canvas-drag-drop-items-design.md`.

### Decisions worth a reviewer's attention

- **Native HTML5 DnD was rejected for task rows.** Their dnd-kit listeners sit on the row root (`task-row.tsx`), so a native `draggable` on the same element would put two drag systems on one pointerdown.
- **Duplicates are allowed on drop.** Dropping an entity that already has a card gives you a second card; both stay live and `extractEntityRefs` already dedupes the persisted refs. This is a deliberate difference from the Add-card picker, which still scrolls to the existing card instead. Relaxing the picker is a separate decision.
- **Inbox items are out of scope.** `CANVAS_ENTITY_TYPES` is `['note', 'task', 'calendar_event']`; adding `inbox_item` would touch the contract enum, `canvas_entity_refs`, the card renderer, the entity resolver and the redirect-tab builder, and would need older app versions to tolerate a card type they cannot render — a back-compat problem for a live beta. Filing an inbox item already produces a note or task, which are placeable.
- **A task dropped on a canvas must not also be rescheduled.** The droppable's `data.type` is `canvas`, outside the set `use-drag-handlers` switches on, and there is a regression test asserting no update/delete/reorder fires.

## Release note

Drag notes, tasks and calendar events straight onto a canvas instead of searching for them in the Add-card picker. Select several tasks and they drop together.

## Test plan

```
pnpm typecheck                 # 16/16
pnpm lint                      # 0 errors
cd apps/desktop && pnpm exec vitest run --config config/vitest.config.ts --project renderer
pnpm docs:impact --base origin/main --strict   # covered
pnpm docs:build
```

New/changed suites: `canvas-drop-entity` 19 ✓ · `canvas-card-overlay` 22 ✓ · `draggable-task-chip` 8 ✓ · `use-drag-handlers` 32 ✓.

Full renderer suite: **5597 passed, 4 failed**. The 4 failures are `canvas-editor.test.tsx` and are **pre-existing on `origin/main`** — `useHandleLibrary` is missing from that file's `@excalidraw/excalidraw` mock factory since the shape-library work (#891). Verified by stashing this branch's changes and reproducing the same 4 failures on a clean tree.

`canvas-card-overlay.test.tsx` mocks `@dnd-kit/core` (the monitor throws outside a `DndContext`, and a real drag cannot be synthesized in jsdom), so the drop guard was mutation-checked: inverting the `over.id` check turns the "ignores a drop that landed on another droppable" test red.

### Not verified

A dnd-kit pointer drag passing over Excalidraw could in principle start a selection marquee. The drag holds pointer capture on the source element, so it should not, but this needs one manual pass in the running app — it cannot be exercised in jsdom.
