### PR TITLE
feat(extension): automate Firefox AMO publishing

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -46,3 +46,45 @@ jobs:
           CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
           CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
           CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+
+  publish-firefox:
+    name: Build, zip, and submit to Firefox Add-ons (AMO)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Exposed at job scope so the submit step can skip cleanly until AMO is set up.
+    env:
+      FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Zip extension (Firefox)
+        run: pnpm --filter @memry/extension zip:firefox
+
+      - name: Build reproducible sources zip
+        run: pnpm --filter @memry/extension sources:firefox
+
+      # Skipped (job stays green) until the AMO secrets are added, so the build +
+      # sources zip are still validated on every release. The add-on's first listing
+      # must be created manually on AMO before the API can accept updates.
+      - name: Submit to Firefox Add-ons
+        if: ${{ env.FIREFOX_JWT_SECRET != '' }}
+        run: pnpm --filter @memry/extension submit:firefox
+        env:
+          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -51,10 +51,17 @@ scripts just produce a separately-named artifact for the Edge Add-ons store.
 `zip:edge` produces `.output/*-edge.zip` for submission to the Microsoft Edge
 Add-ons store.
 
-## Release
+## Publishing
 
-`pnpm --filter @memry/extension release` bumps the version and pushes an
-`extension-v*` tag, which triggers `.github/workflows/publish-extension.yml`.
+Submission is automated by [`.github/workflows/publish-extension.yml`](../../.github/workflows/publish-extension.yml),
+triggered by pushing an `extension-v*` tag (`pnpm --filter @memry/extension release`)
+or a manual **workflow_dispatch**. It runs two independent jobs:
+
+- **Chrome** (`zip` → `submit`) → Chrome Web Store. Secrets: `CHROME_EXTENSION_ID`,
+  `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`.
+- **Firefox** (`zip:firefox` → `sources:firefox` → `submit:firefox`) → AMO. Secrets:
+  `FIREFOX_EXTENSION_ID` (the `gecko.id`, `web-clipper@memrynote.com`),
+  `FIREFOX_JWT_ISSUER`, `FIREFOX_JWT_SECRET`.
 
 > [!IMPORTANT]
 > **Ship the desktop app first.** The extension only ever adds fields to the
@@ -63,6 +70,29 @@ Add-ons store.
 > that desktop doesn't know yet (currently PDF clips, which are also never queued,
 > so each one is lost). Release order is always: desktop version containing the
 > contract change → then the `extension-v*` tag.
+
+Run `pnpm --filter @memry/extension exec wxt submit init` once to obtain the store
+credentials; add them as GitHub **repository secrets**. The Firefox submit step
+skips (job stays green) until `FIREFOX_JWT_SECRET` exists.
+
+### Firefox source-code review
+
+AMO requires a rebuildable source ZIP because the add-on is bundled/minified. WXT's
+own sources ZIP is incomplete in this monorepo (it omits the workspace package
+`@memry/article-extract`), so `sources:firefox` builds a self-contained bundle via
+[`scripts/build-extension-firefox-sources.mjs`](../../scripts/build-extension-firefox-sources.mjs):
+the extension + `@memry/article-extract` + `@memry/typescript-config` + root
+manifests, with a trimmed `pnpm-workspace.yaml` so a reviewer builds only those
+three packages (no Electron). Verify once locally before relying on CI:
+
+```bash
+pnpm --filter @memry/extension zip:firefox
+pnpm --filter @memry/extension sources:firefox   # → .output/firefox-review-sources.zip
+```
+
+**First listing is manual:** the AMO API only pushes _updates_ to an existing add-on.
+Create the initial listing once via AMO's "Submit a New Add-on" wizard (upload the
+`*-firefox.zip` and the sources ZIP); afterwards CI pushes every new version.
 
 ## Manual QA (the Phase-3 acceptance gate — human-required)
 

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -14,6 +14,8 @@
     "zip:firefox": "wxt zip -b firefox --mv3",
     "zip:edge": "wxt zip -b edge",
     "submit": "wxt submit --chrome-zip .output/*-chrome.zip",
+    "sources:firefox": "node ../../scripts/build-extension-firefox-sources.mjs",
+    "submit:firefox": "wxt submit --firefox-zip .output/*-firefox.zip --firefox-sources-zip .output/firefox-review-sources.zip",
     "release": "pnpm version --tag-version-prefix=extension-v --message \"chore(extension): release v%s\" && git push --follow-tags",
     "typecheck": "wxt prepare && tsc --noEmit",
     "lint": "eslint .",

--- a/scripts/build-extension-firefox-sources.mjs
+++ b/scripts/build-extension-firefox-sources.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Builds a reproducible, self-contained source ZIP of the Memrynote Web Clipper
+// for Firefox Add-ons (AMO) source-code review.
+//
+// Why a custom builder: WXT's own `--firefox-sources-zip` only captures files
+// under apps/extension, so it drops the workspace dependency @memry/article-extract
+// (and its @memry/typescript-config) — the sources then cannot be built. This
+// bundles the extension + those two internal packages + the root manifests, with a
+// trimmed pnpm-workspace.yaml so a reviewer runs a 3-package `pnpm install` (no
+// Electron / native modules) and rebuilds `build:firefox` to match the submission.
+//
+// The tree is taken from HEAD (release builds tag HEAD), not the working copy.
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '..')
+const outDir = path.join(repoRoot, 'apps/extension/.output')
+const outZip = path.join(outDir, 'firefox-review-sources.zip')
+
+// Everything needed to build apps/extension in isolation.
+const ROOT_FILES = ['package.json', 'pnpm-lock.yaml', '.npmrc', '.nvmrc']
+const PACKAGE_DIRS = ['apps/extension', 'packages/article-extract', 'packages/typescript-config']
+
+const TRIMMED_WORKSPACE_PACKAGES = `packages:\n${PACKAGE_DIRS.map((p) => `  - ${p}`).join('\n')}\n`
+
+const REVIEW_MD = `# Building the Memrynote Web Clipper (Firefox) from source
+
+Prerequisites: Node.js (version in \`.nvmrc\`) and pnpm 11 (\`corepack enable\`).
+
+~~~sh
+pnpm install --no-frozen-lockfile
+pnpm --filter @memry/extension build:firefox
+~~~
+
+Build output: \`apps/extension/.output/firefox-mv3/\` — this matches the submitted
+add-on.
+
+Notes for reviewers:
+- Only three workspace packages are included: the extension and the two internal
+  libraries it imports (\`@memry/article-extract\`, \`@memry/typescript-config\`).
+- \`--no-frozen-lockfile\` is required: the lockfile is shared with the full product
+  monorepo, so installing this subset re-resolves it. Versions are pinned by the
+  included \`pnpm-lock.yaml\` and \`pnpm-workspace.yaml\` \`overrides\`.
+- No Electron or native modules are built.
+`
+
+function git(args) {
+  return execFileSync('git', args, { cwd: repoRoot, maxBuffer: 256 * 1024 * 1024 })
+}
+
+function run(cmd, args, cwd) {
+  execFileSync(cmd, args, { cwd, stdio: 'inherit' })
+}
+
+const staging = mkdtempSync(path.join(tmpdir(), 'memry-ext-sources-'))
+try {
+  // 1. Extract the committed tree at HEAD into a staging dir.
+  const tarPath = path.join(staging, '__src.tar')
+  writeFileSync(tarPath, git(['archive', '--format=tar', 'HEAD', ...ROOT_FILES, ...PACKAGE_DIRS]))
+  const src = path.join(staging, 'src')
+  mkdirSync(src)
+  run('tar', ['-xf', tarPath, '-C', src])
+  rmSync(tarPath)
+
+  // 2. Trimmed pnpm-workspace.yaml: narrow `packages:` to the three we ship and
+  //    drop `patchedDependencies` (its patch file is intentionally excluded, and
+  //    the patched package is not in the extension's dependency tree).
+  let workspace = git(['show', 'HEAD:pnpm-workspace.yaml']).toString('utf8')
+  const rewritten = workspace.replace(/^packages:\n(?:[ \t]+-.*\n)+/m, TRIMMED_WORKSPACE_PACKAGES)
+  if (rewritten === workspace) {
+    throw new Error(
+      'build-extension-firefox-sources: could not rewrite `packages:` in pnpm-workspace.yaml'
+    )
+  }
+  workspace = rewritten.replace(/\npatchedDependencies:\n(?:[ \t]+.*\n?)+/g, '\n')
+  writeFileSync(path.join(src, 'pnpm-workspace.yaml'), workspace)
+
+  // 3. Reviewer build instructions (AMO requires them for minified/bundled code).
+  writeFileSync(path.join(src, 'SOURCE_CODE_REVIEW.md'), REVIEW_MD)
+
+  // 4. Zip the staged tree.
+  mkdirSync(outDir, { recursive: true })
+  if (existsSync(outZip)) rmSync(outZip)
+  run('zip', ['-r', '-q', '-X', outZip, '.'], src)
+  console.log(`Firefox sources zip: ${path.relative(repoRoot, outZip)}`)
+} finally {
+  rmSync(staging, { recursive: true, force: true })
+}


### PR DESCRIPTION
## What

Wires Firefox Add-ons (AMO) submission into the existing **Publish Extension** workflow. Previously `publish-extension.yml` only submitted to the Chrome Web Store and Firefox was a manual AMO upload. Now a single `extension-v*` tag (`pnpm --filter @memry/extension release`) publishes to **both** stores.

## Changes

- **`apps/extension/package.json`** — add `sources:firefox` and `submit:firefox` scripts.
- **`scripts/build-extension-firefox-sources.mjs`** (new) — builds a reproducible AMO source bundle. WXT's own `--firefox-sources-zip` only captures files under `apps/extension`, so it drops the workspace dependency `@memry/article-extract` (and its `@memry/typescript-config`), leaving the sources un-buildable. This bundles the extension + those two internal packages + the root manifests, rewriting a **trimmed `pnpm-workspace.yaml`** so a reviewer builds only those three packages (no Electron / native modules). The `patchedDependencies` block is stripped — its patch file is intentionally excluded and the package isn't in the extension's dependency tree.
- **`.github/workflows/publish-extension.yml`** — add an independent `publish-firefox` job (`zip:firefox` → `sources:firefox` → `submit:firefox`). The submit step is gated on `FIREFOX_JWT_SECRET`, so the build + sources zip are validated on every release while submission stays skipped (job green) until the AMO secrets are added.
- **`apps/extension/README.md`** — document the publishing flow, required secrets, and the manual first-listing step.

## Why

Firefox releases were manual and easy to forget. This makes shipping an extension change a one-liner and keeps the Firefox source-review bundle correct and rebuildable.

## Verification

Extracted the generated sources zip into a clean directory and ran the exact reviewer command:

```
pnpm install --no-frozen-lockfile   # 16s, no Electron
pnpm --filter @memry/extension build:firefox   # ✔ firefox-mv3, MV3 manifest, gecko id web-clipper@memrynote.com
```

Also: sources zip has no leakage of other packages/patches/.git; `package-scripts.test.mjs` 3/3; `git diff --check` clean; workflow YAML parses (jobs: `publish`, `publish-firefox`).

## Follow-up (not in this PR — requires credentials)

1. Run `pnpm --filter @memry/extension exec wxt submit init` to obtain store credentials.
2. Add GitHub repository secrets: `FIREFOX_EXTENSION_ID` (= `web-clipper@memrynote.com`), `FIREFOX_JWT_ISSUER`, `FIREFOX_JWT_SECRET`.
3. Create the initial AMO listing manually once (the API only pushes updates to an existing add-on).