### PR TITLE
fix(notes): restore page navigation on inline PDF embeds

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.test.tsx
@@ -11,7 +11,8 @@ const mocks = vi.hoisted(() => ({
   syncState: {
     uploadProgress: {} as Record<string, { progress: number; status: string }>,
     downloadProgress: {} as Record<string, { progress: number; status: string }>
-  }
+  },
+  pdfPageCount: 2
 }))
 
 vi.mock('@memry/i18n/renderer', () => ({
@@ -44,7 +45,7 @@ vi.mock('react-pdf', () => ({
     onLoadError?: (error: Error) => void
   }) => (
     <div data-testid="pdf-document">
-      <button type="button" onClick={() => onLoadSuccess?.({ numPages: 2 })}>
+      <button type="button" onClick={() => onLoadSuccess?.({ numPages: mocks.pdfPageCount })}>
         load pdf
       </button>
       <button type="button" onClick={() => onLoadError?.(new Error('broken pdf'))}>
@@ -60,6 +61,7 @@ vi.mock('react-pdf', () => ({
 describe('file block helpers', () => {
   beforeEach(() => {
     mocks.syncState = { uploadProgress: {}, downloadProgress: {} }
+    mocks.pdfPageCount = 2
   })
 
   it('serializes, parses, and creates file block content', () => {
@@ -222,6 +224,67 @@ describe('file block helpers', () => {
     expect(updateBlock).toHaveBeenCalledWith(block, {
       props: expect.objectContaining({ width: expect.any(Number) })
     })
+  })
+
+  it('pages through a multi-page PDF from the hover controls', () => {
+    const Render = (createFileBlock as any).render
+
+    render(
+      <Render
+        contentRef={vi.fn()}
+        block={{
+          props: {
+            url: '/vault/manual.pdf',
+            name: 'manual.pdf',
+            size: 2048,
+            mimeType: 'application/pdf'
+          }
+        }}
+      />
+    )
+    fireEvent.click(screen.getAllByText('load pdf')[0])
+
+    const prev = screen.getByLabelText('phaseF.componentsNoteContentAreaFileBlock.previousPage')
+    const next = screen.getByLabelText('phaseF.componentsNoteContentAreaFileBlock.nextPage')
+
+    // Opens on page 1; there is no page before it.
+    expect(screen.getByText('page 1')).toBeInTheDocument()
+    expect(screen.getByText('1 / 2')).toBeInTheDocument()
+    expect(prev).toBeDisabled()
+    expect(next).toBeEnabled()
+
+    fireEvent.click(next)
+    expect(screen.getByText('page 2')).toBeInTheDocument()
+    expect(screen.getByText('2 / 2')).toBeInTheDocument()
+    expect(next).toBeDisabled()
+
+    fireEvent.click(prev)
+    expect(screen.getByText('page 1')).toBeInTheDocument()
+    expect(prev).toBeDisabled()
+  })
+
+  it('keeps single-page PDFs chromeless (no page controls)', () => {
+    const Render = (createFileBlock as any).render
+    mocks.pdfPageCount = 1
+
+    render(
+      <Render
+        contentRef={vi.fn()}
+        block={{
+          props: {
+            url: '/vault/manual.pdf',
+            name: 'manual.pdf',
+            size: 2048,
+            mimeType: 'application/pdf'
+          }
+        }}
+      />
+    )
+    fireEvent.click(screen.getAllByText('load pdf')[0])
+
+    expect(screen.queryByLabelText('phaseF.componentsNoteContentAreaFileBlock.nextPage')).toBeNull()
+    // The rest of the chrome-free embed still works.
+    expect(screen.getByRole('slider')).toBeInTheDocument()
   })
 
   it('commits an alignment to the block prop via the editor', () => {

--- a/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/file-block.tsx
@@ -19,6 +19,8 @@ import {
   Download,
   Upload,
   Loader2,
+  ChevronLeft,
+  ChevronRight,
   LeftToRightBlockQuote,
   TextAlignCenter,
   RightToLeftBlockQuote
@@ -124,6 +126,12 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
   const { t: tPhaseF } = useT('notes')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  // --- Paging ---------------------------------------------------------------
+  // The embed stays chromeless at rest; the page controls are a hover overlay
+  // and only exist at all when the document actually has more than one page.
+  const [numPages, setNumPages] = useState(0)
+  const [currentPage, setCurrentPage] = useState(1)
 
   // --- Resize state ---------------------------------------------------------
   // The column bounds the max width so the page never overflows horizontally;
@@ -273,9 +281,18 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
     [cardWidth, cardHeight, width, height, widthLimit, heightLimit, pageNaturalHeight, onResize]
   )
 
-  const handleLoadSuccess = () => {
+  const handleLoadSuccess = ({ numPages: total }: { numPages: number }) => {
+    setNumPages(total)
+    setCurrentPage(1)
     setLoading(false)
   }
+
+  const goToPage = useCallback(
+    (page: number) => {
+      setCurrentPage((current) => (page >= 1 && page <= numPages ? page : current))
+    },
+    [numPages]
+  )
 
   const handleLoadError = (err: Error) => {
     setError(
@@ -329,13 +346,47 @@ function PdfPreview({ url, name, width, height, align, onResize, onAlign }: PdfP
               loading={PDF_LOADING_INDICATOR}
             >
               <Page
-                pageNumber={1}
+                pageNumber={currentPage}
                 width={pageWidth}
                 renderTextLayer={true}
                 renderAnnotationLayer={true}
               />
             </Document>
           </div>
+
+          {/* Page controls — hover reveal, bottom-centered. `inset-x-0` + a
+              centering flex row keeps this RTL-safe without a translate, and
+              only the pill itself takes pointer events so the page stays
+              selectable underneath. Sits above react-pdf's text layer (z-2). */}
+          {!loading && !error && numPages > 1 && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+              <div className="pointer-events-auto flex items-center gap-px rounded-md border border-border bg-background/90 p-0.5 shadow-sm">
+                <button
+                  type="button"
+                  aria-label={tPhaseF('phaseF.componentsNoteContentAreaFileBlock.previousPage')}
+                  disabled={currentPage <= 1}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={() => goToPage(currentPage - 1)}
+                  className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent/50 disabled:opacity-40 disabled:hover:bg-transparent"
+                >
+                  <ChevronLeft className="h-4 w-4 rtl:rotate-180" />
+                </button>
+                <span className="px-1 text-xs tabular-nums text-muted-foreground">
+                  {currentPage} / {numPages}
+                </span>
+                <button
+                  type="button"
+                  aria-label={tPhaseF('phaseF.componentsNoteContentAreaFileBlock.nextPage')}
+                  disabled={currentPage >= numPages}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={() => goToPage(currentPage + 1)}
+                  className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent/50 disabled:opacity-40 disabled:hover:bg-transparent"
+                >
+                  <ChevronRight className="h-4 w-4 rtl:rotate-180" />
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Alignment controls — hover reveal, top-inline-end */}
           {!loading && !error && (

--- a/packages/i18n/src/locales/en/notes.json
+++ b/packages/i18n/src/locales/en/notes.json
@@ -532,7 +532,9 @@
       "resizePdf": "Resize PDF",
       "alignLeft": "Align left",
       "alignCenter": "Align center",
-      "alignRight": "Align right"
+      "alignRight": "Align right",
+      "previousPage": "Previous page",
+      "nextPage": "Next page"
     },
     "componentsNoteContentAreaTaskBlockTaskBlockRenderer": {
       "openInTaskPanel": "Open in task panel",


### PR DESCRIPTION
## Summary

A user on v2026-07-19.2 reported dropping a PDF into a note and getting the first page with no way to reach the others. That is a regression from #763: the chromeless embed rework pinned the inline preview to `pageNumber={1}` and deleted the page controls along with the header, footer and thumbnail sidebar. `git tag --contains 388daf447` confirms it went out in v2026-07-17 through v2026-07-19.2, and `file-block.tsx` has not been touched since, so it is still live on `main`.

This restores paging without giving up the chrome-free look:

- `numPages` / `currentPage` are tracked again and the page renders `currentPage`.
- The controls are a bottom-centered `[‹] 1 / 12 [›]` pill that appears only on hover or keyboard focus, and only renders when `numPages > 1` — single-page embeds stay exactly as they are today.
- **The current page is view state, not a block prop.** The `<!-- file:{...} -->` marker is untouched and serialization is unchanged, so existing notes stay byte-identical on re-save. No migration or compat concern.

Note that the full-file viewer (`components/viewers/pdf-viewer.tsx`, also used by comment attachments since #829) is a separate component and always kept its arrows, counter and sidebar. Only the note embed lost them.

### Reviewer notes

Three constraints shaped the placement, all previously learned the hard way on this card:

- The pill sits at `z-10`. react-pdf's `.react-pdf__Page__textContent` is `z-index: 2` and silently swallows clicks on anything below it.
- It is centered with `pointer-events-none absolute inset-x-0 bottom-2 flex justify-center` plus a `pointer-events-auto` inner pill, rather than `start-1/2` + `rtl:translate-x-1/2`. This keeps it RTL-safe without a translate, and leaves the page selectable underneath. Chevron glyphs flip via `rtl:rotate-180`.
- Bottom-center is the only free spot on the card: the resize brackets own both bottom corners (`-bottom-1 -start/-end-1`) and the alignment toolbar owns `top-2 end-2`.

## Release note

Multi-page PDFs embedded in a note can be paged through again — hover the embed for page controls.

## Test plan

- `file-block` unit tests — 7 passed, 0 failed (2 new: paging through a multi-page PDF, and single-page PDFs staying chromeless). Both were red before the fix on the missing `previousPage` control.
- content-area + viewers renderer suites — 408 passed, 0 failed, 6 skipped.
- `pnpm --filter @memry/desktop typecheck:web` — clean.
- `eslint --no-cache` on the changed component — 0 errors, 0 warnings.
- `pnpm --filter @memry/desktop i18n:check` — passed (new `previousPage` / `nextPage` keys).
- `pnpm docs:impact --base origin/main --strict` — no docs-relevant changes.
- `prettier --check`, `git diff --check` — clean.

Not covered: no E2E. The existing `tests/e2e/pdf-embed-resize.e2e.ts` fixture is a single-page PDF, and a paging test needs a new multi-page fixture with a byte-correct xref or pdfjs refuses to load it. Happy to add one if it is wanted before merge.
