### PR TITLE
fix(sync): stop losing note metadata pushes that made notes sync as "Untitled"

### DIFF
--- a/apps/desktop/src/main/sync/content-sync-base.ts
+++ b/apps/desktop/src/main/sync/content-sync-base.ts
@@ -51,6 +51,16 @@ export abstract class ContentSyncService<
     this.getController().enqueueDelete(itemId, ...extra)
   }
 
+  /**
+   * Re-queue a push that was lost, WITHOUT advancing the clock — the item's
+   * stored clock is the one that never made it to the server, so bumping it
+   * again would only widen the gap. An item that is actually in step is
+   * replay-detected server side and simply stamped as synced.
+   */
+  enqueueRecoveredUpdate(itemId: string): void {
+    this.getController().enqueueRecoveredUpdate(itemId)
+  }
+
   private getController(): RecordSyncController<NoteMetadata, TArgs, TArgs> {
     if (this.controller) return this.controller
 

--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   yDocToMarkdown: vi.fn(),
   getNoteCacheById: vi.fn(),
   getNoteCacheByPath: vi.fn(),
+  getNoteMetadataById: vi.fn(),
   atomicWrite: vi.fn(),
   safeRead: vi.fn(),
   fileExists: vi.fn(),
@@ -112,6 +113,10 @@ vi.mock('@main/database/queries/notes', () => ({
   getNoteCacheByPath: (...args: unknown[]) => mocks.getNoteCacheByPath(...args)
 }))
 
+vi.mock('@memry/storage-data', () => ({
+  getNoteMetadataById: (...args: unknown[]) => mocks.getNoteMetadataById(...args)
+}))
+
 vi.mock('@memry/app-core/reminders', () => ({
   createRemindersService: (...args: unknown[]) => mocks.createRemindersService(...args)
 }))
@@ -155,6 +160,7 @@ describe('crdt writeback', () => {
       title: 'Existing'
     })
     mocks.getNoteCacheByPath.mockReturnValue(undefined)
+    mocks.getNoteMetadataById.mockReturnValue(undefined)
     mocks.safeRead.mockResolvedValue('---\ntitle: Existing\n---\nold markdown')
     mocks.parseNote.mockReturnValue({
       frontmatter: { id: 'note-1', title: 'Existing', tags: ['old'] },
@@ -274,6 +280,40 @@ describe('crdt writeback', () => {
     expect(mocks.syncNoteToCache).toHaveBeenCalledWith(
       { kind: 'index-db' },
       expect.objectContaining({ parsedContent: 'updated markdown {++added++} {--deleted--}' }),
+      { isNew: false }
+    )
+  })
+
+  it('treats a note the item handler already applied as existing while its index row is still projecting', async () => {
+    // The note handler writes note_metadata synchronously but only queues the
+    // note_cache row (`void flushProjectionEvents()`), so a write-back landing
+    // in that gap used to look "new" and clobber the freshly-applied title and
+    // path with the Y.Doc meta title — the "Untitled" a note is born with.
+    mocks.getNoteCacheById.mockReturnValue(undefined)
+    mocks.getNoteMetadataById.mockReturnValue({
+      id: 'note-applied',
+      path: 'notes/Real Title.md',
+      title: 'Real Title',
+      createdAt: '2025-12-01T00:00:00.000Z',
+      localOnly: false,
+      emoji: null
+    })
+
+    scheduleWriteback('note-applied', makeDoc('Untitled'))
+    await vi.advanceTimersByTimeAsync(500)
+
+    // #then no second file, no CREATED event, and the applied title survives
+    expect(mocks.generateNotePath).not.toHaveBeenCalled()
+    expect(mocks.sent).not.toContainEqual(
+      expect.objectContaining({ channel: NotesChannels.events.CREATED })
+    )
+    expect(mocks.syncNoteToCache).toHaveBeenCalledWith(
+      { kind: 'index-db' },
+      expect.objectContaining({
+        id: 'note-applied',
+        path: 'notes/Real Title.md',
+        title: 'Real Title'
+      }),
       { isNew: false }
     )
   })

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -29,6 +29,7 @@ import { syncNoteToCache, deleteNoteFromCache } from '../vault/note-sync'
 import { flushProjectionEvents } from '../projections'
 import { getIndexDatabase, getDatabase } from '../database/client'
 import { getNoteCacheById, getNoteCacheByPath } from '@main/database/queries/notes'
+import { getNoteMetadataById } from '@memry/storage-data'
 import { createRemindersService } from '@memry/app-core/reminders'
 import { syncNoteDateReminders, clearNoteDateReminders } from '../notes/note-date-reminders'
 import { deleteFile } from '../vault/file-ops'
@@ -167,6 +168,35 @@ export async function flushPendingWritebacks(): Promise<void> {
   )
 }
 
+/**
+ * Second opinion on "does this note already exist here?".
+ *
+ * `note_metadata` (data DB) is written synchronously by the sync item handler,
+ * while its `note_cache` row (index DB) only lands once the projection lane
+ * drains — which `applyUpsert` does not await. A write-back firing inside that
+ * gap used to see no cache row, take the `writebackNewNote` branch, and
+ * overwrite the just-applied title and path with the Y.Doc meta title (the
+ * literal 'Untitled' a note is born with), producing an "Untitled" note whose
+ * content is correct on every receiving device.
+ */
+function resolveFromCanonicalMetadata(
+  noteId: string
+): ReturnType<typeof getNoteCacheById> | undefined {
+  try {
+    const canonical = getNoteMetadataById(getDatabase(), noteId)
+    if (!canonical) return undefined
+
+    log.debug('Write-back: index row not projected yet, using canonical metadata', { noteId })
+    return {
+      ...canonical,
+      date: canonical.journalDate ?? null
+    } as unknown as ReturnType<typeof getNoteCacheById>
+  } catch (err) {
+    log.warn('Write-back: canonical metadata lookup failed', { noteId, error: err })
+    return undefined
+  }
+}
+
 async function performWriteback(noteId: string, doc: Y.Doc): Promise<void> {
   const plainMarkdown = await yDocToMarkdown(doc)
   const markdown =
@@ -185,7 +215,7 @@ async function performWriteback(noteId: string, doc: Y.Doc): Promise<void> {
   }
 
   const indexDb = getIndexDatabase()
-  const cached = getNoteCacheById(indexDb, noteId)
+  const cached = getNoteCacheById(indexDb, noteId) ?? resolveFromCanonicalMetadata(noteId)
 
   if (isJournalId(noteId)) {
     await writebackJournal(noteId, doc, markdown, cached, indexDb)

--- a/apps/desktop/src/main/sync/dirty-recovery.test.ts
+++ b/apps/desktop/src/main/sync/dirty-recovery.test.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm'
 import { createTestDataDb, asClientDb, type TestDatabaseResult } from '@tests/utils/test-db'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
+import { noteMetadata } from '@memry/db-schema/data-schema'
 import type { DataDb } from '../database/client'
 import { SyncQueueManager } from './queue'
 import { initTaskSyncService, resetTaskSyncService } from './task-sync'
@@ -261,5 +262,97 @@ describe('dirty-recovery', () => {
     // #then
     expect(result.tasks).toBe(0)
     expect(result.projects).toBe(0)
+  })
+
+  describe('notes', () => {
+    const recovered: string[] = []
+    const noteAdapters = {
+      getLocal: (type: string) =>
+        type === 'note' ? { enqueueRecoveredUpdate: (id: string) => recovered.push(id) } : undefined
+    } as unknown as Parameters<typeof recoverDirtyItems>[1]
+
+    const insertNote = (values: Record<string, unknown>): void => {
+      db.insert(noteMetadata)
+        .values({
+          path: `notes/${values.id as string}.md`,
+          title: 'A note',
+          createdAt: '2026-01-01T00:00:00Z',
+          ...values
+        } as never)
+        .run()
+    }
+
+    beforeEach(() => {
+      recovered.length = 0
+    })
+
+    it('recovers a synced note whose local change never reached the server', () => {
+      // #given — the push that carried the rename was dropped, so the note is
+      // modified after its last confirmed sync but nothing is queued
+      insertNote({
+        id: 'note-diverged',
+        clock: { 'device-A': 2 },
+        syncedAt: '2026-01-01T00:00:00Z',
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+
+      // #when
+      const result = recoverDirtyItems(db, noteAdapters)
+
+      // #then
+      expect(result.notes).toBe(1)
+      expect(recovered).toEqual(['note-diverged'])
+    })
+
+    it('recovers a synced note that has never been stamped as pushed', () => {
+      // #given — legacy rows carry no syncedAt at all
+      insertNote({
+        id: 'note-legacy',
+        clock: { 'device-A': 1 },
+        syncedAt: null,
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+
+      // #when
+      const result = recoverDirtyItems(db, noteAdapters)
+
+      // #then
+      expect(result.notes).toBe(1)
+      expect(recovered).toEqual(['note-legacy'])
+    })
+
+    it('leaves clean, local-only, journal and never-synced notes alone', () => {
+      // clean: already stamped after its last edit
+      insertNote({
+        id: 'note-clean',
+        clock: { 'device-A': 1 },
+        syncedAt: '2026-01-03T00:00:00Z',
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+      // local-only: must never be pushed
+      insertNote({
+        id: 'note-local',
+        clock: { 'device-A': 1 },
+        localOnly: true,
+        syncPolicy: 'local-only',
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+      // journal: owned by the journal sync service
+      insertNote({
+        id: 'note-journal',
+        clock: { 'device-A': 1 },
+        journalDate: '2026-01-02',
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+      // never synced: seedUnclockedNotes owns clock-less notes
+      insertNote({ id: 'note-unclocked', modifiedAt: '2026-01-02T00:00:00Z' })
+
+      // #when
+      const result = recoverDirtyItems(db, noteAdapters)
+
+      // #then
+      expect(result.notes).toBe(0)
+      expect(recovered).toEqual([])
+    })
   })
 })

--- a/apps/desktop/src/main/sync/dirty-recovery.ts
+++ b/apps/desktop/src/main/sync/dirty-recovery.ts
@@ -1,9 +1,11 @@
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
-import { and, gt, isNull, isNotNull, or } from 'drizzle-orm'
+import { and, gt, isNull, isNotNull, or, sql } from 'drizzle-orm'
 import type * as schema from '@memry/db-schema/data-schema'
+import { noteMetadata } from '@memry/db-schema/data-schema'
 import type { SyncAdapterRegistry } from '@memry/sync-core'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
+import { getNoteSyncService } from './note-sync'
 import { getProjectSyncService } from './project-sync'
 import { getTaskSyncService } from './task-sync'
 import { createLogger } from '../lib/logger'
@@ -15,6 +17,7 @@ const log = createLogger('DirtyRecovery')
 export interface RecoveryResult {
   tasks: number
   projects: number
+  notes: number
 }
 
 /**
@@ -89,9 +92,62 @@ export function recoverDirtyItems(
     }
   }
 
-  if (taskCount > 0 || projectCount > 0) {
-    log.info('Recovered dirty items for sync', { tasks: taskCount, projects: projectCount })
+  const noteCount = recoverDirtyNotes(db, adapters)
+
+  if (taskCount > 0 || projectCount > 0 || noteCount > 0) {
+    log.info('Recovered dirty items for sync', {
+      tasks: taskCount,
+      projects: projectCount,
+      notes: noteCount
+    })
   }
 
-  return { tasks: taskCount, projects: projectCount }
+  return { tasks: taskCount, projects: projectCount, notes: noteCount }
+}
+
+/**
+ * Re-push notes whose last local change never reached the server.
+ *
+ * Note metadata (title, folder, tags, properties) rides the item queue, and a
+ * push that is acknowledged while a fresh mutation sits in the same queue row
+ * used to take that mutation to the grave with it — the local clock had already
+ * advanced, so no later pull could repair the note and other devices kept the
+ * stale title forever (notes created as 'Untitled' and renamed inside the push
+ * window). Re-enqueueing here is what heals installs that already diverged.
+ *
+ * Scope is deliberately narrow: only notes the server already knows (`clock`
+ * set) and that are not local-only. Clock-less notes belong to
+ * `seedUnclockedNotes`, journals to the journal sync service. The recovered
+ * enqueue reuses the stored clock instead of bumping it, so a note that is
+ * actually in step is simply replay-detected by the server and stamped clean.
+ */
+function recoverDirtyNotes(
+  db: DrizzleDb,
+  adapters?: SyncAdapterRegistry<DrizzleDb, (channel: string, data: unknown) => void>
+): number {
+  const noteSync = adapters?.getLocal('note') ?? getNoteSyncService()
+  if (!noteSync?.enqueueRecoveredUpdate) return 0
+
+  const dirtyNotes = db
+    .select({ id: noteMetadata.id })
+    .from(noteMetadata)
+    .where(
+      and(
+        isNotNull(noteMetadata.clock),
+        isNull(noteMetadata.journalDate),
+        sql`${noteMetadata.localOnly} IS NOT 1`,
+        or(
+          isNull(noteMetadata.syncedAt),
+          and(isNotNull(noteMetadata.syncedAt), gt(noteMetadata.modifiedAt, noteMetadata.syncedAt))
+        )
+      )
+    )
+    .all()
+
+  for (const note of dirtyNotes) {
+    log.debug('Recovering dirty note', { noteId: note.id })
+    noteSync.enqueueRecoveredUpdate(note.id)
+  }
+
+  return dirtyNotes.length
 }

--- a/apps/desktop/src/main/sync/engine/push-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.ts
@@ -116,6 +116,10 @@ export class PushCoordinator {
           }
 
           const dedupedItems = this.deduplicateByItemId(items)
+          // Payload as it stood at dequeue. A local mutation made while this
+          // batch is in flight coalesces into the same row (queue.ts enqueue),
+          // so the ack below must only delete rows that still look like this.
+          const payloadAtDequeue = new Map(dedupedItems.map((item) => [item.id, item.payload]))
 
           if (this.ctx.deps.crdtProvider) {
             const snapshotTasks = dedupedItems
@@ -200,7 +204,7 @@ export class PushCoordinator {
             if (pi > 0 && pi % YIELD_EVERY_N_ITEMS === 0) await yieldToEventLoop()
             const { queueId, pushItem } = pushItems[pi]
             if (acceptedSet.has(pushItem.id)) {
-              this.ctx.deps.queue.markSuccess(queueId)
+              this.ctx.deps.queue.markSuccess(queueId, payloadAtDequeue.get(queueId))
               this.markItemSynced(pushItem.id, pushItem.type)
               pushedCount++
               this.stateManager.emitItemSynced(pushItem.id, pushItem.type, 'push')
@@ -212,7 +216,7 @@ export class PushCoordinator {
                   queueId: queueId.slice(0, 8),
                   itemId: pushItem.id.slice(0, 8)
                 })
-                this.ctx.deps.queue.markSuccess(queueId)
+                this.ctx.deps.queue.markSuccess(queueId, payloadAtDequeue.get(queueId))
                 this.markItemSynced(pushItem.id, pushItem.type)
               } else if (reason === 'STORAGE_QUOTA_EXCEEDED') {
                 log.warn('Push: storage quota exceeded', { itemId: pushItem.id.slice(0, 8) })
@@ -353,21 +357,21 @@ export class PushCoordinator {
     items: Array<typeof import('@memry/db-schema/schema/sync-queue').syncQueue.$inferSelect>
   ): typeof items {
     const seen = new Map<string, (typeof items)[0]>()
-    const dupeIds: string[] = []
+    const dupes: Array<{ id: string; payload: string }> = []
 
     for (const item of items) {
       const key = `${item.type}:${item.itemId}`
       if (!seen.has(key)) {
         seen.set(key, item)
       } else {
-        dupeIds.push(item.id)
+        dupes.push({ id: item.id, payload: item.payload })
       }
     }
 
-    if (dupeIds.length > 0) {
-      log.info('Push: deduplicated queue items', { removed: dupeIds.length })
-      for (const id of dupeIds) {
-        this.ctx.deps.queue.markSuccess(id)
+    if (dupes.length > 0) {
+      log.info('Push: deduplicated queue items', { removed: dupes.length })
+      for (const dupe of dupes) {
+        this.ctx.deps.queue.markSuccess(dupe.id, dupe.payload)
       }
     }
 

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.ts
@@ -594,6 +594,15 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
     return fetchLocalNote(itemId)
   }
 
+  /**
+   * Stamp the note as "the server has this state". Without it `syncedAt` only
+   * ever recorded incoming pulls, so dirty-recovery could not tell a note whose
+   * push was lost from one that is perfectly in step.
+   */
+  markPushSynced(db: DrizzleDb, itemId: string): void {
+    updateNoteMetadata(db, itemId, { syncedAt: utcNow() })
+  }
+
   buildPushPayload(
     _db: DrizzleDb,
     itemId: string,

--- a/apps/desktop/src/main/sync/local-mutations.ts
+++ b/apps/desktop/src/main/sync/local-mutations.ts
@@ -178,6 +178,9 @@ const localSyncRegistry = createSyncAdapterRegistry([
       enqueueUpdate(itemId: string): void {
         getNoteSyncService()?.enqueueUpdate(itemId)
       },
+      enqueueRecoveredUpdate(itemId: string): void {
+        getNoteSyncService()?.enqueueRecoveredUpdate(itemId)
+      },
       enqueueDelete(itemId: string): void {
         getNoteSyncService()?.enqueueDelete(itemId)
       }

--- a/apps/desktop/src/main/sync/note-fidelity-roundtrip.test.ts
+++ b/apps/desktop/src/main/sync/note-fidelity-roundtrip.test.ts
@@ -1,0 +1,176 @@
+/**
+ * A note must reach every other device whole: its title, its body, and the
+ * images and PDFs it embeds. Each field below has its own way of going missing,
+ * so this suite walks a real note through the real sender pipeline — real
+ * SQLite, real frontmatter parsing, real files on disk — and asserts the wire
+ * payload still carries everything after an ordinary local edit.
+ */
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createTestDataDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { NoteSyncPayloadSchema } from '@memry/contracts/sync-payloads'
+import { saveCanonicalNote } from '@memry/domain-notes'
+import { getNoteMetadataById, upsertNoteMetadata } from '@memry/storage-data'
+
+const mocks = vi.hoisted(() => ({
+  dataDb: null as unknown,
+  vaultRoot: '',
+  properties: [] as Array<{ name: string; value: unknown }>,
+  pinnedTags: [] as string[]
+}))
+
+vi.mock('../database/client', () => ({
+  getDatabase: () => mocks.dataDb,
+  getIndexDatabase: () => ({ kind: 'index-db' })
+}))
+
+vi.mock('../vault/notes', () => ({
+  toAbsolutePath: (relative: string) => path.join(mocks.vaultRoot, relative)
+}))
+
+vi.mock('../vault/index', () => ({
+  getConfig: () => ({ defaultNoteFolder: 'notes' })
+}))
+
+vi.mock('@main/database/queries/notes', () => ({
+  getNoteProperties: () => mocks.properties
+}))
+
+vi.mock('./item-handlers/note-pin-helpers', () => ({
+  getPinnedTagsForNote: () => mocks.pinnedTags
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { buildNotePushPayload } from './item-handlers/note-handler-sync-helpers'
+
+const NOTE_ID = 'note-fidelity-1'
+const REL_PATH = 'notes/research/Deep Work.md'
+
+const NOTE_BODY = [
+  'Reading notes.',
+  '',
+  '![Cover](../../attachments/note-fidelity-1/cover.png)',
+  '',
+  '[Paper](../../attachments/note-fidelity-1/paper.pdf)'
+].join('\n')
+
+const NOTE_FILE = [
+  '---',
+  'tags:',
+  '  - reading',
+  '  - focus',
+  'properties:',
+  '  status: reading',
+  '  rating: 5',
+  '---',
+  NOTE_BODY
+].join('\n')
+
+describe('note fidelity across devices', () => {
+  let testDb: TestDatabaseResult
+  let vaultRoot: string
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    mocks.dataDb = testDb.db
+    vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-fidelity-'))
+    mocks.vaultRoot = vaultRoot
+    mocks.properties = [
+      { name: 'status', value: 'reading' },
+      { name: 'rating', value: 5 }
+    ]
+    mocks.pinnedTags = ['focus']
+
+    fs.mkdirSync(path.dirname(path.join(vaultRoot, REL_PATH)), { recursive: true })
+    fs.writeFileSync(path.join(vaultRoot, REL_PATH), NOTE_FILE, 'utf-8')
+
+    upsertNoteMetadata(testDb.db as never, {
+      id: NOTE_ID,
+      path: REL_PATH,
+      title: 'Deep Work',
+      emoji: '📚',
+      fileType: 'markdown',
+      attachmentReferences: ['att-cover-png', 'att-paper-pdf'],
+      clock: { 'device-A': 3 },
+      syncedAt: '2026-01-01T00:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      modifiedAt: '2026-01-02T00:00:00.000Z'
+    })
+  })
+
+  afterEach(() => {
+    testDb.close()
+    fs.rmSync(vaultRoot, { recursive: true, force: true })
+  })
+
+  const buildPayload = (operation: 'create' | 'update') => {
+    const raw = buildNotePushPayload(NOTE_ID, operation)
+    expect(raw).not.toBeNull()
+    // Parsing through the contract proves nothing is stripped at the boundary
+    return NoteSyncPayloadSchema.parse(JSON.parse(raw!))
+  }
+
+  it('puts every field a receiving device needs on the wire', () => {
+    const payload = buildPayload('create')
+
+    expect(payload.title).toBe('Deep Work')
+    expect(payload.content).toBe(NOTE_BODY)
+    expect(payload.folderPath).toBe('research')
+    expect(payload.emoji).toBe('📚')
+    expect(payload.fileType).toBe('markdown')
+    expect(payload.tags).toEqual(['reading', 'focus'])
+    expect(payload.properties).toEqual({ status: 'reading', rating: 5 })
+    expect(payload.pinnedTags).toEqual(['focus'])
+    expect(payload.clock).toEqual({ 'device-A': 3 })
+    // The embedded image and PDF only materialize on the other device if their
+    // blob ids ride along — the markdown links alone point at files that exist
+    // nowhere but the authoring machine.
+    expect(payload.attachmentReferences).toEqual(['att-cover-png', 'att-paper-pdf'])
+  })
+
+  it('keeps the embedded image and PDF on the wire after an ordinary local edit', () => {
+    // A rename, a move, a content save and a re-index all funnel through
+    // saveCanonicalNote with file state only — no sync bookkeeping.
+    saveCanonicalNote(testDb.db as never, {
+      id: NOTE_ID,
+      path: REL_PATH,
+      title: 'Deep Work — revised',
+      emoji: '📚',
+      localOnly: false,
+      journalDate: null,
+      properties: { status: 'reading', rating: 5 },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      modifiedAt: '2026-01-03T00:00:00.000Z'
+    })
+
+    const stored = getNoteMetadataById(testDb.db as never, NOTE_ID)
+    expect(stored?.title).toBe('Deep Work — revised')
+    expect(stored?.attachmentReferences).toEqual(['att-cover-png', 'att-paper-pdf'])
+    expect(stored?.clock).toEqual({ 'device-A': 3 })
+    expect(stored?.syncedAt).toBe('2026-01-01T00:00:00.000Z')
+
+    const payload = buildPayload('update')
+    expect(payload.title).toBe('Deep Work — revised')
+    expect(payload.attachmentReferences).toEqual(['att-cover-png', 'att-paper-pdf'])
+    // Body updates ride the CRDT channel, so an update payload carries no content
+    expect(payload.content).toBeNull()
+  })
+
+  it('never pushes a note the user marked local-only', () => {
+    saveCanonicalNote(testDb.db as never, {
+      id: NOTE_ID,
+      path: REL_PATH,
+      title: 'Deep Work',
+      localOnly: true,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      modifiedAt: '2026-01-03T00:00:00.000Z'
+    })
+
+    expect(buildNotePushPayload(NOTE_ID, 'update')).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/sync/queue.test.ts
+++ b/apps/desktop/src/main/sync/queue.test.ts
@@ -256,6 +256,44 @@ describe('SyncQueueManager', () => {
       // #then
       expect(queue.getSize()).toBe(0)
     })
+
+    it('keeps a row that was coalesced into while the push was in flight', () => {
+      // #given a create pushed with the placeholder title the note is born with
+      const frozen = JSON.stringify({ title: 'Untitled', clock: { mac: 1 } })
+      const id = queue.enqueue(makeInput({ payload: frozen }))
+      const [inFlight] = queue.dequeue(10)
+      expect(inFlight.payload).toBe(frozen)
+
+      // #when the user renames the note before the server answers — enqueue
+      // coalesces into the same attempts=0 row
+      queue.enqueue(
+        makeInput({
+          operation: 'update',
+          payload: JSON.stringify({ title: 'Real Title', clock: { mac: 2 } })
+        })
+      )
+
+      // #when the ack for the payload we actually pushed arrives
+      const removed = queue.markSuccess(id, inFlight.payload)
+
+      // #then the rename survives for the next push instead of being deleted
+      expect(removed).toBe(false)
+      expect(queue.getPendingCount()).toBe(1)
+      expect(queue.peek(1)[0].payload).toContain('Real Title')
+    })
+
+    it('removes the row when it is unchanged since dequeue', () => {
+      // #given item dequeued and not touched since
+      const id = queue.enqueue(makeInput())
+      const [inFlight] = queue.dequeue(10)
+
+      // #when markSuccess with the payload that was pushed
+      const removed = queue.markSuccess(id, inFlight.payload)
+
+      // #then
+      expect(removed).toBe(true)
+      expect(queue.getSize()).toBe(0)
+    })
   })
 
   describe('markFailed', () => {

--- a/apps/desktop/src/main/sync/queue.ts
+++ b/apps/desktop/src/main/sync/queue.ts
@@ -108,9 +108,38 @@ export class SyncQueueManager {
       .all()
   }
 
-  markSuccess(id: string): void {
+  /**
+   * Drop an item the server accepted.
+   *
+   * `pushedPayload` makes the delete conditional, and callers that push over
+   * the network MUST pass it. `enqueue` coalesces a new mutation into any
+   * existing `attempts = 0` row, and nothing marks a row as in flight — so a
+   * rename made while a push is awaiting its response lands in the very row
+   * the push is about to delete. Deleting unconditionally loses that mutation
+   * forever: its clock bump is already persisted, so the local item stays
+   * permanently ahead of the server and no later pull can repair it (the note
+   * that produced this guard synced across devices as "Untitled").
+   *
+   * @returns true when the row was removed, false when it changed under us and
+   * was kept for the next push iteration.
+   */
+  markSuccess(id: string, pushedPayload?: string): boolean {
+    const where =
+      pushedPayload === undefined
+        ? eq(syncQueue.id, id)
+        : and(eq(syncQueue.id, id), eq(syncQueue.payload, pushedPayload))
+
+    const changes = this.db.delete(syncQueue).where(where).run().changes
+
+    if (changes === 0 && pushedPayload !== undefined) {
+      log.info('markSuccess: item changed while in flight, keeping it queued', {
+        id: id.slice(0, 8)
+      })
+      return false
+    }
+
     log.debug('markSuccess: deleting item', { id: id.slice(0, 8) })
-    this.db.delete(syncQueue).where(eq(syncQueue.id, id)).run()
+    return true
   }
 
   markFailed(id: string, error: string): void {

--- a/apps/docs/src/architecture/sync-handlers.md
+++ b/apps/docs/src/architecture/sync-handlers.md
@@ -62,6 +62,19 @@ ctx.db.transaction(() => {
 
 A partial write is impossible — either every change in a handler invocation applies, or none.
 
+Atomicity stops at the data DB, though. Index rows are derived state, published as projection events
+and drained on their own lane, so a handler returns before the index reflects what it just applied.
+Anything asking "does this item exist here?" must therefore ask the data DB, or accept that a freshly
+applied item can look absent. The debounced CRDT write-back is the case that matters for notes: from
+the index alone, a note the handler had already applied looked new, so the write-back re-derived its
+title from the Yjs `meta` map — the placeholder a note is created with — and the canonical upsert
+overwrote the correct title and path. It now falls back to the canonical row before treating a note
+as new.
+
+The Yjs `meta` title is not a source of truth in the other direction either. It is set once at note
+creation and updated only while the note's doc is open in memory, so a note renamed from the sidebar
+never records the new title there. Read it only when nothing else knows the note.
+
 ## Adding a New Sync Type
 
 1. Define a Zod schema in `packages/contracts/<domain>-api.ts`.

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -108,6 +108,31 @@ broken the item re-quarantines within a few pulls, and if it was repaired server
 again without an emergency wipe. The manifest-check throttle (30 minutes) persists in sync state, so
 engine restarts and vault switches cannot re-arm an immediate check.
 
+### Push acknowledgements and in-flight mutations
+
+The push queue coalesces: a new mutation for an item that already has an unattempted row overwrites
+that row's payload instead of inserting a second one, and dequeue is a plain read that leaves no
+in-flight marker. A row handed to a push therefore stays a valid coalesce target for the whole
+flight — worker encryption, the round trip, and every retry — and the user can rename or re-tag the
+item at any point in that window.
+
+An acknowledgement is consequently conditional: the push remembers the payload each row held when it
+was dequeued and only deletes rows that still match. A row that changed under the push is left
+queued and goes out on the next iteration. Deleting unconditionally would drop the newer mutation
+permanently, because the local clock advances at mutation time: the item would sit ahead of the
+server with nothing queued, and every later pull would resolve `skip` rather than repair it.
+
+### Recovering pushes that never landed
+
+Items expose a "the server has this state" stamp (`syncedAt`) that advances on a confirmed push as
+well as on an applied pull. Anything modified after its stamp — or never stamped at all — is
+re-queued on the next full sync for tasks, projects and notes alike.
+
+Recovery re-sends the item's **stored** clock rather than bumping it. An item that is genuinely in
+step is then replay-detected by the server, costs one round trip, and is stamped clean; only an item
+that really is ahead of the server changes anything. Scope is limited to items the server already
+knows: clock-less rows belong to the initial seed, and journals to their own handler.
+
 ### Foreign-key parents and orphan repair
 
 Some rows carry foreign keys — a task references its project and its status — and the data DB
@@ -233,6 +258,13 @@ across devices:
   cleared only after the server accepts the file. Failed or quit-interrupted
   uploads are retried on every sync runtime start instead of being lost with
   the in-memory queue.
+
+`attachmentReferences` is the only signal that tells another device a note
+embeds a file — the markdown link alone points at a path that exists nowhere
+but the authoring machine. It is sync bookkeeping, not file state, so the
+canonical note upsert leaves it (and the sync stamp) untouched when a caller
+has nothing to say about it. Ordinary vault writes — a content save, a rename,
+a move, a re-index — carry file state only, and must not erase it.
 
 ## Tombstones
 

--- a/packages/domain-notes/src/commands.test.ts
+++ b/packages/domain-notes/src/commands.test.ts
@@ -23,4 +23,54 @@ describe('domain-notes commands', () => {
     expect(resolveNoteSyncPolicy(true)).toBe('local-only')
     expect(resolveNoteSyncPolicy(false)).toBe('sync')
   })
+
+  it('leaves sync bookkeeping untouched when the caller does not supply it', () => {
+    // Vault saves (content edit, rename, move, re-index) call this with file
+    // state only. Materialising `null` here reaches upsertNoteMetadata's
+    // onConflictDoUpdate and ERASES the row's attachment references, so the
+    // note's embedded images/PDFs stop being announced to other devices after
+    // the first edit. Absent must stay absent so the stored value survives.
+    const result = buildCanonicalNoteMetadata({
+      id: 'note-1',
+      path: 'notes/test.md',
+      title: 'Test',
+      createdAt: '2026-04-08T10:00:00.000Z',
+      modifiedAt: '2026-04-08T10:05:00.000Z'
+    })
+
+    expect(result.attachmentReferences).toBeUndefined()
+    expect(result.attachmentId).toBeUndefined()
+    expect(result.syncedAt).toBeUndefined()
+    expect(result.clock).toBeUndefined()
+  })
+
+  it('still writes the values the caller does supply, including explicit clears', () => {
+    const set = buildCanonicalNoteMetadata({
+      id: 'note-1',
+      path: 'notes/test.md',
+      title: 'Test',
+      createdAt: '2026-04-08T10:00:00.000Z',
+      modifiedAt: '2026-04-08T10:05:00.000Z',
+      attachmentId: 'att-1',
+      syncedAt: '2026-04-08T10:06:00.000Z'
+    })
+    expect(set.attachmentId).toBe('att-1')
+    // attachmentId still seeds the reference list when none was passed
+    expect(set.attachmentReferences).toEqual(['att-1'])
+    expect(set.syncedAt).toBe('2026-04-08T10:06:00.000Z')
+
+    const cleared = buildCanonicalNoteMetadata({
+      id: 'note-1',
+      path: 'notes/test.md',
+      title: 'Test',
+      createdAt: '2026-04-08T10:00:00.000Z',
+      modifiedAt: '2026-04-08T10:05:00.000Z',
+      attachmentReferences: null,
+      attachmentId: null,
+      syncedAt: null
+    })
+    expect(cleared.attachmentReferences).toBeNull()
+    expect(cleared.attachmentId).toBeNull()
+    expect(cleared.syncedAt).toBeNull()
+  })
 })

--- a/packages/domain-notes/src/commands.ts
+++ b/packages/domain-notes/src/commands.ts
@@ -57,8 +57,18 @@ export function buildCanonicalNoteMetadata(input: UpsertCanonicalNoteInput): New
   const propertyDefinitionNames =
     input.propertyDefinitionNames ??
     (input.properties ? Object.keys(input.properties).sort((a, b) => a.localeCompare(b)) : null)
+  // `undefined` means "caller had nothing to say", and it must survive as
+  // undefined: upsertNoteMetadata's onConflictDoUpdate writes every key it is
+  // given, and drizzle drops only undefined. Materialising `null` here turned
+  // every vault save (edit, rename, move, re-index) into an erase of the
+  // note's sync bookkeeping — most visibly attachmentReferences, which is how
+  // other devices learn that a note embeds an image or PDF.
   const attachmentReferences =
-    input.attachmentReferences ?? (input.attachmentId ? [input.attachmentId] : null)
+    input.attachmentReferences !== undefined
+      ? input.attachmentReferences
+      : input.attachmentId
+        ? [input.attachmentId]
+        : undefined
   const localOnly = input.localOnly ?? false
 
   return {
@@ -69,20 +79,23 @@ export function buildCanonicalNoteMetadata(input: UpsertCanonicalNoteInput): New
     fileType: input.fileType ?? 'markdown',
     mimeType: input.mimeType ?? null,
     fileSize: input.fileSize ?? null,
-    attachmentId: input.attachmentId ?? null,
+    attachmentId: input.attachmentId,
     attachmentReferences,
     localOnly,
     syncPolicy: resolveNoteSyncPolicy(localOnly, input.syncPolicy),
     journalDate: input.journalDate ?? null,
     propertyDefinitionNames,
     clock: input.clock,
-    syncedAt: input.syncedAt ?? null,
+    syncedAt: input.syncedAt,
     createdAt: input.createdAt,
     modifiedAt: input.modifiedAt
   }
 }
 
-export function saveCanonicalNote(db: NoteMetadataDb, input: UpsertCanonicalNoteInput): NoteMetadata {
+export function saveCanonicalNote(
+  db: NoteMetadataDb,
+  input: UpsertCanonicalNoteInput
+): NoteMetadata {
   return upsertNoteMetadata(db, buildCanonicalNoteMetadata(input))
 }
 

--- a/packages/storage-data/src/note-metadata-repository.test.ts
+++ b/packages/storage-data/src/note-metadata-repository.test.ts
@@ -87,6 +87,49 @@ describe('note-metadata-repository', () => {
       expect(created.localOnly).toBe(true)
       expect(created.journalDate).toBe('2026-04-16')
     })
+
+    it('keeps sync bookkeeping the caller did not supply', () => {
+      // #given a note the sync layer has already stamped
+      upsertNoteMetadata(
+        db,
+        makeNote({
+          clock: { 'device-a': 4 },
+          syncedAt: '2026-01-01T00:00:00.000Z',
+          attachmentId: 'att-1',
+          attachmentReferences: ['att-1', 'att-2']
+        })
+      )
+
+      // #when a plain content save re-upserts it (vault saves carry no sync fields)
+      const updated = upsertNoteMetadata(
+        db,
+        makeNote({ title: 'Edited', modifiedAt: '2026-02-01T00:00:00.000Z' })
+      )
+
+      // #then the embedded-attachment refs and sync stamps survive the edit —
+      // wiping them stops other devices from ever materializing the images and
+      // PDFs the note embeds
+      expect(updated.title).toBe('Edited')
+      expect(updated.attachmentReferences).toEqual(['att-1', 'att-2'])
+      expect(updated.attachmentId).toBe('att-1')
+      expect(updated.clock).toEqual({ 'device-a': 4 })
+      expect(updated.syncedAt).toBe('2026-01-01T00:00:00.000Z')
+    })
+
+    it('still clears attachment references when the caller passes null explicitly', () => {
+      // #given
+      upsertNoteMetadata(db, makeNote({ attachmentReferences: ['att-1'] }))
+
+      // #when
+      const updated = upsertNoteMetadata(
+        db,
+        makeNote({ attachmentReferences: null, attachmentId: null })
+      )
+
+      // #then
+      expect(updated.attachmentReferences).toBeNull()
+      expect(updated.attachmentId).toBeNull()
+    })
   })
 
   describe('updateNoteMetadata', () => {


### PR DESCRIPTION
## Summary

A user on `v2026-07-19.2` reported notes made on their Mac arriving on their Linux machine titled **"Untitled"**, with the content intact. A note's title, folder, tags and properties travel on the sync item queue; its body travels on the Yjs CRDT. That split is exactly why the content survived and only the title died.

Four independent defects in the metadata half. Nothing merged since the `v2026-07-19.2` tag touched this path — `queue.ts`, `push-coordinator.ts`, `content-sync-base.ts` and `note-sync.ts` are byte-identical between the tag and `main` — so this was never release-fixed.

**1. Lost update in the push queue (root cause).** `enqueue` coalesces into any row with `attempts = 0` and overwrites its payload; `dequeue` is a plain read that leaves no in-flight marker; `markSuccess` deleted by id unconditionally. A rename made between the payload snapshot and the server ack landed in the very row the ack then deleted. The clock bump was already persisted, so the device stayed permanently ahead of the server and every later pull resolved `skip` — self-locking, with no path back. The window spans worker encryption plus a full round trip with up to five retries, and the default flow aims straight at it: notes are created with the literal title `Untitled` and the push debounce is 2s, so a user who finishes typing a title a few seconds later lands inside it.

`markSuccess` now takes the payload that was pushed and deletes only a row that still matches it. A row that changed under the push stays queued and goes out on the next iteration.

**2. CRDT write-back clobbered an already-correct title.** `performWriteback` decided new-vs-existing from the index DB, but the item handler writes the data DB synchronously and only *queues* the index row. Inside the write-back debounce an applied note looked new, so it was re-titled from the Yjs `meta` map and the canonical upsert overwrote title and path. It now falls back to the canonical row.

**3. Every vault save erased the note's attachment references.** `buildCanonicalNoteMetadata` materialised `null` for `attachmentReferences`, `attachmentId` and `syncedAt` when the caller omitted them. Drizzle drops `undefined` but honours `null`, so each save, rename, move and re-index wiped the only signal that tells another device a note embeds an image or PDF — silently undoing #896. Absent fields now stay absent; explicit clears still clear.

**4. No anti-entropy for notes.** Dirty recovery covered only tasks and projects, and the note handler had no `markPushSynced`, so `syncedAt` only ever recorded pulls. Notes now stamp `syncedAt` on a confirmed push, and dirty recovery re-enqueues the rest through `enqueueRecoveredUpdate`, which reuses the stored clock instead of bumping it.

## Reviewer notes

- **(4) is the part that heals installs already broken.** A forward-only fix would leave this user's existing notes titled "Untitled" forever, because their local clock dominates the server's and no pull can repair that.
- **Expect one metadata re-push per device on first sync after upgrade.** Legacy rows have no `syncedAt`, so every clocked note is re-queued once. Payloads are metadata-only (bodies live in the CRDT), the clock is not bumped, unchanged notes are replay-detected server-side, and `markPushSynced` then stamps them quiet. That cost is the repair.
- **Backward compatible: no schema change, no migration, no DB reset.** `markSuccess`'s new parameter is optional, so existing callers keep their old behaviour. Older clients parse payloads in strip mode and are unaffected.
- The Yjs `meta` title is deliberately *not* used to heal anything — it is set once at creation and `updateMeta` silently no-ops when the note's doc is not open, so it goes stale for any note renamed from the sidebar.

## Release note

Fixed notes syncing to other devices as "Untitled", and embedded images and PDFs not appearing on other devices after a note was edited.

## Test plan

- `pnpm typecheck` — 16/16 ✓
- `pnpm lint` — clean ✓
- `pnpm test` — 12074 passed, 1039 files ✓
- `pnpm check:architecture`, `pnpm check:contracts`, `git diff --check` — ✓
- `pnpm docs:impact --base 84849cc64 --strict`, `pnpm docs:build` — ✓

Each fix was **mutation-checked**: the fix was reverted and its test confirmed to go red, then restored.

New coverage:
- `sync/queue.test.ts` — a row coalesced into while the push is in flight survives the ack
- `sync/crdt-writeback.test.ts` — a note whose index row is still projecting is treated as existing
- `sync/dirty-recovery.test.ts` — diverged / never-stamped notes recover; clean, local-only, journal and clock-less notes are left alone
- `sync/note-fidelity-roundtrip.test.ts` (new) — walks a real note through the real sender pipeline on real SQLite with a real vault file, asserting title, body, tags, properties, emoji, folder and embedded image/PDF references all survive an ordinary edit
- `domain-notes/commands.test.ts`, `storage-data/note-metadata-repository.test.ts`

Not covered: no two-device Playwright E2E was added. The harness exists (`tests/e2e/fixtures/sync-auth-fixtures.ts` launches two Electron apps against a shared simulated server), but local darwin fixture launches hang on this machine, and I did not want to add a test I could not show green. Worth adding on CI as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
