### PR TITLE
fix(editor): render note-relative image paths against the vault

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -53,6 +53,8 @@ import { editorSchema } from './editor-schema'
 import { analyzeTaskIntents } from './scan-task-intents'
 import { useSidebarDrillDown } from '@/contexts/sidebar-drill-down'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
+import { useVault } from '@/hooks/use-vault'
+import { resolveNoteRelativeUrl } from '@/lib/resolve-note-relative-url'
 import {
   ReviewFormattingToolbar,
   ReviewFormattingToolbarController
@@ -130,6 +132,7 @@ interface ContentAreaEditorProps extends ContentAreaProps {
 
 const ContentAreaEditor = memo(function ContentAreaEditor({
   noteId,
+  notePath,
   initialContent,
   contentType = 'html',
   placeholder,
@@ -205,11 +208,30 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
     return result.path
   }, [])
 
+  // Vaults written by other apps reference media with a plain relative path
+  // (`../Images/Media/photo.png`). Without this, BlockNote hands that string to
+  // `<img src>`, where it resolves against the renderer document's base URL
+  // instead of the vault and 404s. Render-time only — the markdown on disk keeps
+  // its relative path, so the vault stays readable by the app that wrote it.
+  const { vaultPath } = useVault()
+  const notePathRef = useRef(notePath)
+  const vaultPathRef = useRef(vaultPath)
+  useEffect(() => {
+    notePathRef.current = notePath
+    vaultPathRef.current = vaultPath
+  }, [notePath, vaultPath])
+
+  const resolveFileUrl = useCallback(
+    async (url: string) => resolveNoteRelativeUrl(url, notePathRef.current, vaultPathRef.current),
+    []
+  )
+
   // Create the BlockNote editor instance
   const editor = useCreateBlockNote({
     schema: editorSchema,
     setIdAttribute: true,
     uploadFile,
+    resolveFileUrl,
     placeholders: {
       default: resolvedPlaceholder,
       heading: t('editor.content.headingPlaceholder'),

--- a/apps/desktop/src/renderer/src/components/note/content-area/types.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/types.ts
@@ -81,6 +81,12 @@ export interface ContentAreaProps {
   /** Note ID for attachment uploads (T069) */
   noteId?: string
   /**
+   * The note's path relative to the vault root (`Folder/Note.md`). Used to
+   * resolve relative image/file URLs written by other apps (Obsidian,
+   * Capacities) against the note's own folder at render time.
+   */
+  notePath?: string
+  /**
    * When false, this editor does NOT run note-level task auto-conversion side
    * effects (a sibling editor on the same note in this window owns them, R17).
    * Defaults to true; standalone callers own their effects.

--- a/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.test.ts
+++ b/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { resolveNoteRelativeUrl } from './resolve-note-relative-url'
+
+const VAULT = '/Users/me/vault'
+const NOTE = 'People (1)/Person.md'
+
+describe('resolveNoteRelativeUrl', () => {
+  it('resolves a sibling-folder ref against the note directory', () => {
+    expect(resolveNoteRelativeUrl('../Images/Media/a.png', NOTE, VAULT)).toBe(
+      'memry-file://local/Users/me/vault/Images/Media/a.png'
+    )
+  })
+
+  it('resolves a same-folder ref', () => {
+    expect(resolveNoteRelativeUrl('a.png', NOTE, VAULT)).toBe(
+      'memry-file://local/Users/me/vault/People%20(1)/a.png'
+    )
+  })
+
+  it('resolves a ref from a note at the vault root', () => {
+    expect(resolveNoteRelativeUrl('Images/a.png', 'Root.md', VAULT)).toBe(
+      'memry-file://local/Users/me/vault/Images/a.png'
+    )
+  })
+
+  it('decodes percent-encoded refs before resolving', () => {
+    expect(resolveNoteRelativeUrl('../Images/my%20photo.png', NOTE, VAULT)).toBe(
+      'memry-file://local/Users/me/vault/Images/my%20photo.png'
+    )
+  })
+
+  it('collapses . and redundant separators', () => {
+    expect(resolveNoteRelativeUrl('./sub//a.png', NOTE, VAULT)).toBe(
+      'memry-file://local/Users/me/vault/People%20(1)/sub/a.png'
+    )
+  })
+
+  it.each([
+    ['https://example.com/a.png'],
+    ['http://example.com/a.png'],
+    ['data:image/png;base64,iVBOR'],
+    ['blob:abc-123'],
+    ['memry-file://local/Users/me/vault/attachments/n1/ab-a.png'],
+    ['C:/Users/me/a.png']
+  ])('leaves %s untouched', (url) => {
+    expect(resolveNoteRelativeUrl(url, NOTE, VAULT)).toBe(url)
+  })
+
+  it('leaves vault-absolute paths untouched', () => {
+    expect(resolveNoteRelativeUrl('/Images/a.png', NOTE, VAULT)).toBe('/Images/a.png')
+  })
+
+  it('leaves the url untouched when it would escape the vault', () => {
+    expect(resolveNoteRelativeUrl('../../../etc/passwd', NOTE, VAULT)).toBe('../../../etc/passwd')
+  })
+
+  it('leaves the url untouched without a note path or vault path', () => {
+    expect(resolveNoteRelativeUrl('a.png', undefined, VAULT)).toBe('a.png')
+    expect(resolveNoteRelativeUrl('a.png', NOTE, null)).toBe('a.png')
+  })
+
+  it('returns empty input as-is', () => {
+    expect(resolveNoteRelativeUrl('', NOTE, VAULT)).toBe('')
+  })
+
+  // A Capacities export copied straight into a vault: emoji + spaces + parens in
+  // the note path, media in a sibling folder.
+  it('handles a Capacities export laid out in the vault', () => {
+    expect(
+      resolveNoteRelativeUrl(
+        '../Images/Media/01KX65VSYZ9NBBNP9PG7ARJKD2.png',
+        'People (1)/🙋♂️ How to Use This People Object.md',
+        '/Users/me/vault/cap'
+      )
+    ).toBe('memry-file://local/Users/me/vault/cap/Images/Media/01KX65VSYZ9NBBNP9PG7ARJKD2.png')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.ts
+++ b/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.ts
@@ -1,0 +1,70 @@
+/**
+ * Resolve a note-relative asset URL to a `memry-file://` URL the renderer can load.
+ *
+ * Vaults written by other apps (Obsidian, Capacities, …) reference media with a
+ * plain relative path — `![x](../Images/Media/photo.png)`. BlockNote hands that
+ * string straight to `<img src>`, where it resolves against the *renderer
+ * document's* base URL (`http://localhost:5173/` in dev, `file://…/out/` when
+ * packaged) rather than the vault, and 404s.
+ *
+ * This runs at render time only: the markdown on disk keeps its relative path,
+ * so the vault stays readable by the app that wrote it.
+ */
+
+import { toMemryFileUrl } from './memry-file-url'
+
+/** `https:`, `data:`, `memry-file:` — and `C:` on Windows, which we also skip. */
+const HAS_SCHEME = /^[a-zA-Z][a-zA-Z\d+\-.]*:/
+
+/**
+ * Join a vault-relative directory with a relative ref, collapsing `.` and `..`.
+ * Returns null if the ref climbs above the vault root.
+ */
+function joinWithinVault(dir: string, ref: string): string | null {
+  const out: string[] = []
+  for (const segment of [...dir.split('/'), ...ref.split('/')]) {
+    if (!segment || segment === '.') continue
+    if (segment === '..') {
+      if (out.length === 0) return null
+      out.pop()
+      continue
+    }
+    out.push(segment)
+  }
+  return out.length > 0 ? out.join('/') : null
+}
+
+/**
+ * @param url        Raw `props.url` from a BlockNote file/image block.
+ * @param notePath   The note's path relative to the vault root (`Folder/Note.md`).
+ * @param vaultPath  Absolute path of the open vault.
+ * @returns A `memry-file://` URL, or `url` unchanged when it is not a resolvable
+ *          vault-relative path.
+ */
+export function resolveNoteRelativeUrl(
+  url: string,
+  notePath: string | undefined,
+  vaultPath: string | null
+): string {
+  if (!url || !notePath || !vaultPath) return url
+  if (HAS_SCHEME.test(url)) return url
+  // A leading slash is ambiguous (vault root? filesystem root?) — don't guess.
+  if (url.startsWith('/')) return url
+
+  // Refs are commonly percent-encoded (`my%20photo.png`); decode for the disk
+  // path, then let toMemryFileUrl re-encode each segment.
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(url)
+  } catch {
+    decoded = url
+  }
+
+  const lastSlash = notePath.lastIndexOf('/')
+  const noteDir = lastSlash === -1 ? '' : notePath.slice(0, lastSlash)
+
+  const resolved = joinWithinVault(noteDir, decoded)
+  if (!resolved) return url
+
+  return toMemryFileUrl(`${vaultPath.replace(/[/\\]+$/, '')}/${resolved}`)
+}

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -1417,6 +1417,7 @@ export function NotePage({ noteId }: NotePageProps) {
             <ContentArea
               key={`${noteId}-${externalUpdateCount}`}
               noteId={noteId}
+              notePath={note.path}
               initialContent={review.editorInitialContent}
               contentType="markdown"
               placeholder={t('editor.content.placeholder')}

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -43,6 +43,23 @@ transcript with the audio file, so opening the file page shows the player and tr
 
 Images render as image blocks (not file blocks). Drag them to resize; double-click for the lightbox.
 
+### Images From Another App's Vault
+
+Vaults written by Obsidian, Capacities and similar apps keep media in a shared
+folder and reference it from notes with a relative path:
+
+```markdown
+![photo](../Images/Media/photo.png)
+```
+
+MemryNote resolves those paths against the note's own folder, so the images show
+up as normal image blocks. Nothing is copied or rewritten — the markdown on disk
+keeps its relative path, so the vault stays readable by the app that wrote it.
+
+A path that points outside the vault is left alone rather than resolved, and so
+are absolute paths and `http(s)` URLs. If an image shows up broken, check that
+the referenced file actually sits where the path points, relative to the note.
+
 ## Removing or Replacing
 
 Click the file block menu to:


### PR DESCRIPTION
## Summary

A vault written by another app — Obsidian, Capacities — references media with a plain relative path:

```markdown
![photo](../Images/Media/photo.png)
```

Copy such a folder into a MemryNote vault and every image renders broken, even though the file sits exactly where the path points.

Parsing was never the problem. That line already becomes a real BlockNote `image` block; I checked all three shapes (image glued to the next line, image with a blank line after, and the post-import `memry-file://` form) and each produced `{type: 'image'}` plus a paragraph. What was missing is URL resolution: nothing ever mapped `props.url` to something loadable, so the raw relative string reached `<img src>` and the browser resolved it against the **renderer document's** base URL — `http://localhost:5173/` in dev, `file://…/out/renderer/` when packaged — instead of the vault. Always a 404.

This passes a `resolveFileUrl` to the editor that resolves a vault-relative ref against the note's own folder and returns a `memry-file://` URL.

**Nothing on disk changes.** The markdown keeps its relative path, so the vault stays readable by the app that wrote it and byte preservation is unaffected.

### Relationship to #906

#906 solved the same underlying problem for Obsidian `![[photo.png]]` embeds — `resolve-embed.ts` says it outright: *"a bare `photo.png` would resolve against the renderer origin and render broken."* But it only covers the wiki-embed syntax. Capacities (and plain Obsidian markdown links) use standard CommonMark image syntax, which was still unresolved.

The two compose without overlapping: #906 rewrites `![[…]]` to an absolute `memry-file://` URL at parse time, and this resolver passes any ref that already carries a scheme through untouched.

### Reviewer notes

- Refs with a scheme (`https:`, `data:`, `blob:`, `memry-file:`, and Windows `C:`) pass through, as do `/`-absolute paths — a leading slash is ambiguous (vault root? filesystem root?) and guessing would be worse than leaving it.
- A ref that climbs above the vault root is left unresolved rather than rewritten, so this cannot widen what the `memry-file://` handler will serve. That handler's existing allowlist already covers vault roots, so there is no main-process change here.
- Resolution reads `notePath` / `vaultPath` through refs so the editor instance is not recreated when either changes.

### Separate concern spotted in #906 (not addressed here)

`rewriteWikiImageEmbeds` runs on parse but has no serialize-side inverse — `blocksToMarkdownLossy` + `normalizeSerializedMarkdown` in `markdown-utils.ts` never turn a `memry-file://` URL back into `![[photo.png]]`. Editing and saving an Obsidian note therefore looks like it would replace the embed in the vault file with an absolute, machine-specific path. Worth confirming and tracking separately; this PR does not touch that path.

## Release note

Images in notes that came from Obsidian, Capacities or a similar app now render instead of showing up broken, including when the media lives in a shared folder alongside your notes.

## Test plan

- New `resolve-note-relative-url.test.ts` — 16 cases: sibling-folder and same-folder refs, notes at the vault root, percent-encoded names, `.`/`//` collapsing, every pass-through scheme, vault escape, missing note/vault path, and the reported Capacities layout verbatim (emoji + spaces + parens in the note path)
- `pnpm --filter @memry/desktop test:renderer` — 517 files, 5663 passed, 0 failed (adding `useVault()` to `ContentArea` touches every test that mounts the editor)
- `pnpm typecheck` — 16/16 packages
- `eslint --no-cache --max-warnings=0` over the changed files
- `pnpm docs:impact --strict` and `pnpm docs:build`
- Verified against the reported vault: the resolver returns `memry-file://local/…/cap/Images/Media/01KX65VSYZ9NBBNP9PG7ARJKD2.png`, and that file is present on disk at exactly that path

Rebased onto `main` after #906 merged; the full renderer suite was re-run on the rebased branch.
