### PR TITLE
fix(editor): treat backslashes as separators when resolving image paths

### DIFF
--- a/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.test.ts
+++ b/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.test.ts
@@ -54,6 +54,30 @@ describe('resolveNoteRelativeUrl', () => {
     expect(resolveNoteRelativeUrl('../../../etc/passwd', NOTE, VAULT)).toBe('../../../etc/passwd')
   })
 
+  // `toMemryFileUrl` rewrites `\` to `/`, so a backslash ref that slipped past
+  // the guard as one opaque segment would only become a traversal afterwards.
+  it('treats backslashes as separators when resolving', () => {
+    expect(resolveNoteRelativeUrl('..\\Images\\Media\\a.png', NOTE, VAULT)).toBe(
+      'memry-file://local/Users/me/vault/Images/Media/a.png'
+    )
+    expect(resolveNoteRelativeUrl('sub\\a.png', NOTE, VAULT)).toBe(
+      'memry-file://local/Users/me/vault/People%20(1)/sub/a.png'
+    )
+  })
+
+  it('leaves a backslash ref untouched when it would escape the vault', () => {
+    expect(resolveNoteRelativeUrl('..\\..\\..\\etc\\passwd', NOTE, VAULT)).toBe(
+      '..\\..\\..\\etc\\passwd'
+    )
+  })
+
+  it.each([['\\Images\\a.png'], ['\\\\server\\share\\a.png']])(
+    'leaves the leading-backslash ref %s untouched',
+    (url) => {
+      expect(resolveNoteRelativeUrl(url, NOTE, VAULT)).toBe(url)
+    }
+  )
+
   it('leaves the url untouched without a note path or vault path', () => {
     expect(resolveNoteRelativeUrl('a.png', undefined, VAULT)).toBe('a.png')
     expect(resolveNoteRelativeUrl('a.png', NOTE, null)).toBe('a.png')

--- a/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.ts
+++ b/apps/desktop/src/renderer/src/lib/resolve-note-relative-url.ts
@@ -17,12 +17,20 @@ import { toMemryFileUrl } from './memry-file-url'
 const HAS_SCHEME = /^[a-zA-Z][a-zA-Z\d+\-.]*:/
 
 /**
+ * Both separators count: `toMemryFileUrl` rewrites `\` to `/` when it builds the
+ * URL, so a ref like `..\..\x.png` would otherwise pass through here as one
+ * opaque segment — skipping the `..` checks — and only become a traversal after
+ * the guard had already approved it.
+ */
+const SEPARATOR = /[/\\]/
+
+/**
  * Join a vault-relative directory with a relative ref, collapsing `.` and `..`.
  * Returns null if the ref climbs above the vault root.
  */
 function joinWithinVault(dir: string, ref: string): string | null {
   const out: string[] = []
-  for (const segment of [...dir.split('/'), ...ref.split('/')]) {
+  for (const segment of [...dir.split(SEPARATOR), ...ref.split(SEPARATOR)]) {
     if (!segment || segment === '.') continue
     if (segment === '..') {
       if (out.length === 0) return null
@@ -48,8 +56,9 @@ export function resolveNoteRelativeUrl(
 ): string {
   if (!url || !notePath || !vaultPath) return url
   if (HAS_SCHEME.test(url)) return url
-  // A leading slash is ambiguous (vault root? filesystem root?) — don't guess.
-  if (url.startsWith('/')) return url
+  // A leading separator is ambiguous (vault root? filesystem root? a Windows UNC
+  // share, for `\\server\share`?) — don't guess.
+  if (url.startsWith('/') || url.startsWith('\\')) return url
 
   // Refs are commonly percent-encoded (`my%20photo.png`); decode for the disk
   // path, then let toMemryFileUrl re-encode each segment.

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -57,8 +57,9 @@ up as normal image blocks. Nothing is copied or rewritten — the markdown on di
 keeps its relative path, so the vault stays readable by the app that wrote it.
 
 A path that points outside the vault is left alone rather than resolved, and so
-are absolute paths and `http(s)` URLs. If an image shows up broken, check that
-the referenced file actually sits where the path points, relative to the note.
+are absolute paths (including Windows `\\server\share` style ones) and `http(s)`
+URLs. If an image shows up broken, check that the referenced file actually sits
+where the path points, relative to the note.
 
 ## Removing or Replacing
 


### PR DESCRIPTION
## Summary

Follow-up to #907, which merged before its review feedback was applied. Copilot flagged two real holes in `resolveNoteRelativeUrl`, both about the backslash separator; I verified each before fixing.

**1. The vault-escape guard could be bypassed.** `joinWithinVault` split only on `/`, but `toMemryFileUrl` rewrites `\` to `/` when it builds the URL. So `..\..\secret.png` arrived as one opaque segment, sailed past the `..` checks, and only became a traversal *after* the guard had approved it — producing a `memry-file://` URL with `../../` in its path. The protocol handler's allowlist would still have refused to serve that, so this was not exploitable on its own, but the function's own documented guarantee ("a ref that climbs above the vault root is left unresolved") was broken, and the test asserting it only passed because it used forward slashes.

**2. Leading backslashes were treated as vault-relative.** Only `/`-absolute refs were exempt, so a Windows UNC path like `\\server\share\img.png` — or a drive-relative `\Images\photo.png` — got rewritten into a vault URL. That is the opposite of the deliberate "a leading separator is ambiguous, don't guess" behaviour #907 documented. Fixing (1) alone would not have covered this: the empty leading segments are skipped, so the ref would have resolved to `<vault>/<note dir>/server/share/img.png`.

Both fixed by splitting on either separator and bailing on either leading separator.

### Reviewer notes

- Normalizing `\` here matches what `toMemryFileUrl` already does, so this does not change how any path that previously *worked* resolves — it only closes the gap between the guard and the URL builder.
- Copilot's third comment asked for backslash test coverage; that is the four new cases.

## Release note

none

## Test plan

- `resolve-note-relative-url.test.ts` — 20 cases (16 existing + 4 new: backslash refs that resolve, a backslash ref that escapes the vault, and both leading-backslash forms)
- **Mutation-verified**: reverting each half of the fix makes all four new cases fail, so they genuinely pin the behaviour rather than passing incidentally
- `pnpm --filter @memry/desktop test:renderer` — 517 files, 5667 passed, 0 failed
- `pnpm typecheck` — 16/16 packages
- `eslint --no-cache --max-warnings=0` on the changed file
