### PR TITLE
fix(editor): await the vault path instead of racing the hook that loads it

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -53,7 +53,7 @@ import { editorSchema } from './editor-schema'
 import { analyzeTaskIntents } from './scan-task-intents'
 import { useSidebarDrillDown } from '@/contexts/sidebar-drill-down'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
-import { useVault } from '@/hooks/use-vault'
+import { vaultService } from '@/services/vault-service'
 import { resolveNoteRelativeUrl } from '@/lib/resolve-note-relative-url'
 import {
   ReviewFormattingToolbar,
@@ -213,18 +213,30 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   // `<img src>`, where it resolves against the renderer document's base URL
   // instead of the vault and 404s. Render-time only — the markdown on disk keeps
   // its relative path, so the vault stays readable by the app that wrote it.
-  const { vaultPath } = useVault()
+  //
+  // BlockNote calls `resolveFileUrl` once, as it builds the image block's DOM,
+  // and keeps whatever it returns. So the vault path has to be *awaited* here
+  // rather than read off a hook: `useVault` starts at null and fills in after an
+  // IPC round-trip, which the editor mount routinely wins — leaving the image
+  // permanently broken even though the path arrives moments later. Fetched once
+  // per editor, on the first ref that actually needs resolving.
   const notePathRef = useRef(notePath)
-  const vaultPathRef = useRef(vaultPath)
   useEffect(() => {
     notePathRef.current = notePath
-    vaultPathRef.current = vaultPath
-  }, [notePath, vaultPath])
+  }, [notePath])
 
-  const resolveFileUrl = useCallback(
-    async (url: string) => resolveNoteRelativeUrl(url, notePathRef.current, vaultPathRef.current),
-    []
-  )
+  const vaultPathRef = useRef<Promise<string | null> | null>(null)
+  const resolveFileUrl = useCallback(async (url: string) => {
+    const notePath = notePathRef.current
+    if (!notePath) return url
+    if (!vaultPathRef.current) {
+      vaultPathRef.current = vaultService
+        .getStatus()
+        .then((status) => status.path ?? null)
+        .catch(() => null)
+    }
+    return resolveNoteRelativeUrl(url, notePath, await vaultPathRef.current)
+  }, [])
 
   // Create the BlockNote editor instance
   const editor = useCreateBlockNote({


### PR DESCRIPTION
## Summary

Follow-up to #907. The relative-path resolver was correct, but it never got the vault path in time.

BlockNote calls `resolveFileUrl` exactly **once**, while it builds the image block's DOM, and keeps whatever comes back (`Image/block.ts`: `resolveFileUrl(url).then(u => { image.src = u })`). #907 read the vault path from `useVault()` — which is not a cached query. It is `useState(null)` plus an async `useEffect` that fetches over IPC (`use-vault.ts:40-47`), so on the first render `vaultPath` is always `null`.

The editor mount routinely wins that race. `resolveNoteRelativeUrl` then sees a null vault path, correctly returns the ref untouched, and the image stays broken for the life of the block — even though the vault path lands milliseconds later. Nothing re-triggers resolution.

This awaits the vault path inside the callback instead, fetched once per editor on the first ref that actually needs resolving. It also drops the `useVault()` subscription the editor did not otherwise need.

### Reviewer notes

- Reported symptom: a Capacities vault copied into MemryNote showed the wiki link but not the image, which is exactly this failure — the `![](…)` block parses fine and renders, its `src` just never becomes loadable.
- The promise is cached in a ref, so a note with many images makes one `getStatus()` call, not one per image. A rejected status resolves to `null`, which degrades to today's leave-it-alone behaviour rather than throwing inside the editor.
- Vault switching tears down the editor, so the per-editor cache cannot go stale against a different vault.

## Release note

none

## Test plan

- `pnpm --filter @memry/desktop test:renderer` — 517 files, 5667 passed, 0 failed
- `pnpm --filter @memry/desktop typecheck:web`
- `eslint --no-cache --max-warnings=0` on `ContentArea.tsx`

Not covered by an automated test: driving BlockNote's image-block DOM construction in jsdom to observe the one-shot `resolveFileUrl` call is disproportionate for this change. The race is read directly off the two sources — `useVault`'s `useState(null)` + async effect, and BlockNote's single call site — rather than reproduced.
