### PR TITLE
test(editor): cover the vault-path race the image resolver hit

### DIFF
--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -54,7 +54,7 @@ import { analyzeTaskIntents } from './scan-task-intents'
 import { useSidebarDrillDown } from '@/contexts/sidebar-drill-down'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
 import { vaultService } from '@/services/vault-service'
-import { resolveNoteRelativeUrl } from '@/lib/resolve-note-relative-url'
+import { createNoteFileUrlResolver } from '@/lib/create-note-file-url-resolver'
 import {
   ReviewFormattingToolbar,
   ReviewFormattingToolbarController
@@ -213,30 +213,19 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   // `<img src>`, where it resolves against the renderer document's base URL
   // instead of the vault and 404s. Render-time only — the markdown on disk keeps
   // its relative path, so the vault stays readable by the app that wrote it.
-  //
-  // BlockNote calls `resolveFileUrl` once, as it builds the image block's DOM,
-  // and keeps whatever it returns. So the vault path has to be *awaited* here
-  // rather than read off a hook: `useVault` starts at null and fills in after an
-  // IPC round-trip, which the editor mount routinely wins — leaving the image
-  // permanently broken even though the path arrives moments later. Fetched once
-  // per editor, on the first ref that actually needs resolving.
+  // See `createNoteFileUrlResolver` for why the vault path is awaited rather
+  // than read off a hook.
   const notePathRef = useRef(notePath)
   useEffect(() => {
     notePathRef.current = notePath
   }, [notePath])
 
-  const vaultPathRef = useRef<Promise<string | null> | null>(null)
-  const resolveFileUrl = useCallback(async (url: string) => {
-    const notePath = notePathRef.current
-    if (!notePath) return url
-    if (!vaultPathRef.current) {
-      vaultPathRef.current = vaultService
-        .getStatus()
-        .then((status) => status.path ?? null)
-        .catch(() => null)
-    }
-    return resolveNoteRelativeUrl(url, notePath, await vaultPathRef.current)
-  }, [])
+  const resolveFileUrl = useRef(
+    createNoteFileUrlResolver(
+      () => notePathRef.current,
+      async () => (await vaultService.getStatus()).path ?? null
+    )
+  ).current
 
   // Create the BlockNote editor instance
   const editor = useCreateBlockNote({

--- a/apps/desktop/src/renderer/src/lib/create-note-file-url-resolver.test.ts
+++ b/apps/desktop/src/renderer/src/lib/create-note-file-url-resolver.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createNoteFileUrlResolver } from './create-note-file-url-resolver'
+
+const NOTE = 'People (1)/Person.md'
+const VAULT = '/Users/me/vault'
+const REF = '../Images/Media/a.png'
+const RESOLVED = 'memry-file://local/Users/me/vault/Images/Media/a.png'
+
+/** A vault lookup that has not answered yet — the state every editor mounts in. */
+function deferred() {
+  let settle!: (value: string | null) => void
+  const promise = new Promise<string | null>((resolve) => {
+    settle = resolve
+  })
+  return { promise, settle }
+}
+
+describe('createNoteFileUrlResolver', () => {
+  // The regression this exists for: reading the vault path off a hook meant it
+  // was still null when BlockNote made its one and only call, so the image
+  // stayed broken even though the path arrived milliseconds later.
+  it('waits for a vault path that has not arrived yet', async () => {
+    const vault = deferred()
+    const resolve = createNoteFileUrlResolver(
+      () => NOTE,
+      () => vault.promise
+    )
+
+    const pending = resolve(REF)
+    vault.settle(VAULT)
+
+    expect(await pending).toBe(RESOLVED)
+  })
+
+  it('looks the vault up once no matter how many images a note has', async () => {
+    const fetchVaultPath = vi.fn(async () => VAULT)
+    const resolve = createNoteFileUrlResolver(() => NOTE, fetchVaultPath)
+
+    const urls = await Promise.all([resolve(REF), resolve(REF), resolve('b.png')])
+
+    expect(fetchVaultPath).toHaveBeenCalledTimes(1)
+    expect(urls[0]).toBe(RESOLVED)
+    expect(urls[2]).toBe('memry-file://local/Users/me/vault/People%20(1)/b.png')
+  })
+
+  it('hands the url back untouched when the vault lookup fails', async () => {
+    const resolve = createNoteFileUrlResolver(
+      () => NOTE,
+      async () => {
+        throw new Error('vault closed')
+      }
+    )
+
+    expect(await resolve(REF)).toBe(REF)
+  })
+
+  it('hands the url back untouched before a note path is known', async () => {
+    const fetchVaultPath = vi.fn(async () => VAULT)
+    const resolve = createNoteFileUrlResolver(() => undefined, fetchVaultPath)
+
+    expect(await resolve(REF)).toBe(REF)
+    expect(fetchVaultPath).not.toHaveBeenCalled()
+  })
+
+  it('picks up a note path that arrives after the editor mounted', async () => {
+    let notePath: string | undefined
+    const resolve = createNoteFileUrlResolver(
+      () => notePath,
+      async () => VAULT
+    )
+
+    expect(await resolve(REF)).toBe(REF)
+    notePath = NOTE
+    expect(await resolve(REF)).toBe(RESOLVED)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/create-note-file-url-resolver.ts
+++ b/apps/desktop/src/renderer/src/lib/create-note-file-url-resolver.ts
@@ -1,0 +1,32 @@
+/**
+ * Build the `resolveFileUrl` BlockNote calls when it mounts a file/image block.
+ *
+ * Two properties this has to get right, both learned the hard way:
+ *
+ *  1. BlockNote calls it *once*, while building the block's DOM, and keeps
+ *     whatever comes back. So the vault path must be **awaited**, never read off
+ *     a hook that fills in later — the editor mount wins that race and the image
+ *     stays broken for the life of the block.
+ *  2. A note with many images must not fire one vault lookup per image, so the
+ *     in-flight promise is cached and reused.
+ *
+ * A lookup that fails resolves to `null`, which makes the resolver hand the URL
+ * back untouched — the same "leave it alone" behaviour as an unresolvable ref,
+ * rather than throwing inside the editor.
+ */
+
+import { resolveNoteRelativeUrl } from './resolve-note-relative-url'
+
+export function createNoteFileUrlResolver(
+  getNotePath: () => string | undefined,
+  fetchVaultPath: () => Promise<string | null>
+): (url: string) => Promise<string> {
+  let vaultPath: Promise<string | null> | null = null
+
+  return async (url: string) => {
+    const notePath = getNotePath()
+    if (!notePath) return url
+    if (!vaultPath) vaultPath = fetchVaultPath().catch(() => null)
+    return resolveNoteRelativeUrl(url, notePath, await vaultPath)
+  }
+}


### PR DESCRIPTION
## Summary

#910 fixed a real race: BlockNote calls `resolveFileUrl` exactly once while building an image block's DOM, and #907 read the vault path from `useVault()`, which starts at `null` and fills in after an IPC round-trip. The editor mount won that race, so the resolver saw a null vault path, correctly left the ref alone, and the image stayed broken for the life of the block.

That fix shipped **without a test** — I said so in #910, because driving BlockNote's image-block DOM construction in jsdom is disproportionate for a change that size. This closes that gap without the jsdom cost.

The callback moves into `createNoteFileUrlResolver`, which takes the note path and the vault lookup as plain functions. `ContentArea` wires the real ones; the test wires a vault lookup that has deliberately not answered yet. Behaviour is unchanged.

Three properties are now pinned:

- **It waits for a vault path that has not arrived yet** — the actual #910 regression.
- **It looks the vault up once** however many images a note has, so a media-heavy note does not fire one IPC per image.
- **A failed lookup degrades to leaving the URL alone** rather than throwing inside the editor.

Plus two boundary cases: no note path yet (no vault lookup fired at all), and a note path that arrives after mount.

### Reviewer notes

- Mutation-verified: restoring the pre-#910 "read whatever has loaded so far" shape fails three of the five cases, so these tests pin the fix rather than passing incidentally.
- `docs:impact` was skipped for this branch (`MEMRY_DOCS_IMPACT_SKIP=1`). Nothing user-visible changes — the behaviour this describes is already documented under "Images From Another App's Vault" in `apps/docs/src/user-guide/notes/attachments.md`, added by #907 and refined by #908.

## Release note

none

## Test plan

- `pnpm --filter @memry/desktop test:renderer` — 518 files, 5672 passed, 0 failed
- `pnpm --filter @memry/desktop typecheck:web`
- `eslint --no-cache --max-warnings=0` on both changed source files
