### PR TITLE
fix(notes): keep obsidian image embeds portable when a note is saved

### DIFF
--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -411,7 +411,7 @@ export interface MainIpcInvokeHandlers {
   "vault:list-account": (...args: []) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").AccountVaultInfo[]>>
   "vault:reindex": (...args: []) => Awaited<Promise<void>>
   "vault:remove": (...args: [string]) => Awaited<Promise<void>>
-  "vault:resolve-embeds": (...args: [string[]]) => Awaited<Promise<Record<string, string>>>
+  "vault:resolve-embeds": (...args: [{ refs: string[]; notePath?: string | undefined; }]) => Awaited<Promise<Record<string, string>>>
   "vault:reveal": (...args: []) => Awaited<Promise<void>>
   "vault:select": (...args: [{ path?: string | undefined; }]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").SelectVaultResponse>>
   "vault:switch": (...args: [string]) => Awaited<Promise<import("../../../../../packages/contracts/src/vault-api").SelectVaultResponse>>

--- a/apps/desktop/src/main/ipc/vault-handlers.ts
+++ b/apps/desktop/src/main/ipc/vault-handlers.ts
@@ -120,10 +120,13 @@ export function registerVaultHandlers(): void {
   // vault:resolve-embeds - Map `![[photo.png]]` targets to memry-file:// URLs
   ipcMain.handle(
     VaultChannels.invoke.RESOLVE_EMBEDS,
-    createValidatedHandler(z.array(z.string()).max(500), async (refs) => {
-      const { resolveVaultEmbeds } = await import('../vault/resolve-embed')
-      return resolveVaultEmbeds(refs)
-    })
+    createValidatedHandler(
+      z.object({ refs: z.array(z.string()).max(500), notePath: z.string().optional() }),
+      async ({ refs, notePath }) => {
+        const { resolveVaultEmbeds } = await import('../vault/resolve-embed')
+        return resolveVaultEmbeds(refs, notePath)
+      }
+    )
   )
 
   // vault:reindex - Trigger manual reindex

--- a/apps/desktop/src/main/sync/blocknote-converter.ts
+++ b/apps/desktop/src/main/sync/blocknote-converter.ts
@@ -112,10 +112,13 @@ export async function yDocToMarkdown(
   }
 }
 
-export async function markdownToBlocks(markdown: string): Promise<Block[] | null> {
+export async function markdownToBlocks(
+  markdown: string,
+  notePath?: string
+): Promise<Block[] | null> {
   try {
     const editor = getEditor()
-    return await markdownToBlocksPreserving(editor, markdown)
+    return await markdownToBlocksPreserving(editor, markdown, notePath)
   } catch (err) {
     log.error('Markdown-to-blocks conversion failed', err)
     return null
@@ -171,10 +174,11 @@ export function repairEmptyBlockIds(fragment: Y.XmlFragment): number {
 
 export async function markdownToYFragment(
   markdown: string,
-  fragment: Y.XmlFragment
+  fragment: Y.XmlFragment,
+  notePath?: string
 ): Promise<boolean> {
   const parsed = parseCriticMarkup(markdown)
-  const blocks = await markdownToBlocks(parsed.plainText)
+  const blocks = await markdownToBlocks(parsed.plainText, notePath)
   if (!blocks) return false
   // Upgrade `- [ ] … {task:id}` checkboxes into taskBlock nodes so the renderer
   // binds the custom block on first paint instead of a raw checkbox.
@@ -312,12 +316,12 @@ async function serializeBlocksWithNestingMarkers(
  * vault lookup is a direct call instead of an IPC round trip. A closed vault or
  * an unreadable index resolves nothing, which leaves every embed as written.
  */
-function resolveWikiImageEmbedsInMarkdown(markdown: string): string {
+function resolveWikiImageEmbedsInMarkdown(markdown: string, notePath?: string): string {
   const refs = extractWikiImageEmbedRefs(markdown)
   if (refs.length === 0) return markdown
 
   try {
-    const resolved = resolveVaultEmbeds(refs)
+    const resolved = resolveVaultEmbeds(refs, notePath)
     return rewriteWikiImageEmbeds(markdown, (ref) => resolved[ref])
   } catch {
     return markdown
@@ -326,11 +330,12 @@ function resolveWikiImageEmbedsInMarkdown(markdown: string): string {
 
 async function markdownToBlocksPreserving(
   editor: ServerBlockNoteEditor,
-  markdown: string
+  markdown: string,
+  notePath?: string
 ): Promise<Block[]> {
   // Obsidian image embeds become `![alt](memry-file://…)` first, so the same
   // note renders identically here and in the editor (see normalize-note-blocks).
-  const withEmbeds = resolveWikiImageEmbedsInMarkdown(markdown)
+  const withEmbeds = resolveWikiImageEmbedsInMarkdown(markdown, notePath)
   // Inline color spans are masked into markdown-inert tokens before parsing
   // (BlockNote strips raw spans), then re-applied as styles on the parsed runs.
   const { text, spans } = maskInlineColorSpans(separateBlockImages(withEmbeds))

--- a/apps/desktop/src/main/sync/crdt-feed.ts
+++ b/apps/desktop/src/main/sync/crdt-feed.ts
@@ -7,6 +7,21 @@
 
 import { getCrdtProvider, ORIGIN_LOCAL } from './crdt-provider'
 import { markdownToBlocks, blocksToYFragment } from './blocknote-converter'
+import { getIndexDatabase } from '../database'
+import { getNoteCacheById } from '@main/database/queries/notes'
+
+/**
+ * The note's vault-relative path, so embed targets are rewritten relative to it
+ * rather than as this machine's absolute paths. Unknown notes resolve to
+ * undefined, which keeps the previous absolute-URL behaviour.
+ */
+function noteCachePath(noteId: string): string | undefined {
+  try {
+    return getNoteCacheById(getIndexDatabase(), noteId)?.path
+  } catch {
+    return undefined
+  }
+}
 
 /**
  * Full XML-fragment replace of a note's body inside its live Y.Doc.
@@ -18,7 +33,7 @@ export async function replaceNoteBodyInCrdt(noteId: string, markdown: string): P
   const doc = provider.getDoc(noteId)
   if (!doc) return false
 
-  const blocks = await markdownToBlocks(markdown)
+  const blocks = await markdownToBlocks(markdown, noteCachePath(noteId))
   if (!blocks) return false
 
   const fragment = doc.getXmlFragment('prosemirror')

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -565,7 +565,9 @@ export class CrdtProvider {
     const parsed = parseNote(raw, cached.path)
     if (!parsed.content?.trim()) return
 
-    const ok = await markdownToYFragment(parsed.content, fragment)
+    // Pass the note's path so embed targets are written relative to it — this
+    // fragment is what gets serialized back to the vault file.
+    const ok = await markdownToYFragment(parsed.content, fragment, cached.path)
     if (ok && this.persistence) {
       await this.persistence.storeUpdate(noteId, Y.encodeStateAsUpdate(doc)).catch((err) => {
         log.error('Failed to persist markdown-seeded CRDT doc', { noteId, error: err })

--- a/apps/desktop/src/main/sync/embed-roundtrip.test.ts
+++ b/apps/desktop/src/main/sync/embed-roundtrip.test.ts
@@ -1,0 +1,73 @@
+/**
+ * What an Obsidian image embed looks like after a note has been opened and saved.
+ *
+ * The embed rewrite happens on the markdown string before it is parsed, so
+ * whatever it produces is what `blocksToMarkdownLossy` writes back to the vault
+ * file. Before this was fixed the round trip replaced `![[photo.png]]` with an
+ * absolute `memry-file://` URL carrying this machine's home directory — into a
+ * file that syncs to other devices and is supposed to stay readable in Obsidian.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import * as Y from 'yjs'
+
+const NOTE = 'People/Person.md'
+
+vi.mock('../vault/resolve-embed', () => ({
+  resolveVaultEmbeds: (refs: string[], notePath?: string) =>
+    Object.fromEntries(
+      refs.map((ref) => [
+        ref,
+        // Mirrors the real resolver's two shapes: relative to the note when the
+        // caller knows where the note lives, absolute otherwise.
+        notePath ? `../Images/${ref}` : `memry-file://local/Users/me/vault/Images/${ref}`
+      ])
+    )
+}))
+
+async function roundTrip(markdown: string, notePath?: string): Promise<string | null> {
+  const { markdownToYFragment, yDocToMarkdown } = await import('./blocknote-converter')
+  const doc = new Y.Doc()
+  const ok = await markdownToYFragment(markdown, doc.getXmlFragment('blocknote'), notePath)
+  expect(ok).toBe(true)
+  return yDocToMarkdown(doc, 'blocknote')
+}
+
+describe('obsidian image embed round trip', () => {
+  it('writes the embed back as a portable relative link', async () => {
+    const back = await roundTrip('Before\n\n![[photo.png]]\n\nAfter\n', NOTE)
+
+    expect(back).toContain('![photo.png](../Images/photo.png)')
+    expect(back).toContain('Before')
+    expect(back).toContain('After')
+  })
+
+  it('never bakes an absolute machine path into the note', async () => {
+    const back = await roundTrip('![[photo.png]]\n', NOTE)
+
+    expect(back).not.toContain('memry-file://')
+    expect(back).not.toContain('/Users/')
+  })
+
+  it('carries the sized form through as the same link', async () => {
+    const back = await roundTrip('![[photo.png|300x200]]\n', NOTE)
+
+    expect(back).toContain('![photo.png](../Images/photo.png)')
+    expect(back).not.toContain('memry-file://')
+  })
+
+  it('leaves note transclusions and plain wikilinks alone', async () => {
+    const back = await roundTrip('![[Some Note]]\n\n[[wikilink]]\n', NOTE)
+
+    expect(back).toContain('![[Some Note]]')
+    expect(back).toContain('[[wikilink]]')
+  })
+
+  // Read-only surfaces (canvas previews) have no note path and never persist
+  // what they render, so an absolute URL there is harmless.
+  it('still resolves to an absolute url when no note path is given', async () => {
+    const back = await roundTrip('![[photo.png]]\n')
+
+    expect(back).toContain('memry-file://')
+  })
+})

--- a/apps/desktop/src/main/vault/resolve-embed.test.ts
+++ b/apps/desktop/src/main/vault/resolve-embed.test.ts
@@ -68,6 +68,54 @@ describe('resolveVaultEmbed', () => {
     expect(url).toContain('photo.png')
   })
 
+  // Whatever this returns is spliced into the note's markdown, so it is also
+  // what gets written back to the vault file on the next save. Given the note's
+  // own path it must stay portable — no absolute, machine-specific prefix in a
+  // file that syncs to other devices and is meant to stay readable in Obsidian.
+  describe('given the note path', () => {
+    it('returns a target relative to the note, not an absolute URL', () => {
+      writeVaultFile('Images/photo.png')
+      const target = resolver.resolveVaultEmbed('Images/photo.png', 'People/Person.md')
+      expect(target).toBe('../Images/photo.png')
+    })
+
+    it('resolves a sibling file without any ../ prefix', () => {
+      writeVaultFile('People/photo.png')
+      expect(resolver.resolveVaultEmbed('People/photo.png', 'People/Person.md')).toBe('photo.png')
+    })
+
+    it('keeps a note at the vault root simple', () => {
+      writeVaultFile('Images/photo.png')
+      expect(resolver.resolveVaultEmbed('Images/photo.png', 'Root.md')).toBe('Images/photo.png')
+    })
+
+    it('encodes characters that would break the markdown link', () => {
+      writeVaultFile('Images/my photo (1).png')
+      expect(resolver.resolveVaultEmbed('Images/my photo (1).png', 'Root.md')).toBe(
+        'Images/my%20photo%20%281%29.png'
+      )
+    })
+
+    it('still resolves a bare filename found by index lookup', () => {
+      writeVaultFile('Images/nested.png')
+      indexDb.sqlite
+        .prepare(
+          `INSERT INTO note_cache (id, path, title, file_type, created_at, modified_at)
+           VALUES (?, ?, ?, 'image', 0, 0)`
+        )
+        .run('img1', 'Images/nested.png', 'nested')
+
+      expect(resolver.resolveVaultEmbed('nested.png', 'People/Person.md')).toBe(
+        '../Images/nested.png'
+      )
+    })
+  })
+
+  it('falls back to an absolute URL when the note path is unknown', () => {
+    writeVaultFile('Images/photo.png')
+    expect(resolver.resolveVaultEmbed('Images/photo.png')).toMatch(/^memry-file:\/\/local\//)
+  })
+
   it('resolves a target relative to the notes folder', () => {
     writeVaultFile('notes/Media/shot.png')
     expect(resolver.resolveVaultEmbed('Media/shot.png')).toContain('shot.png')

--- a/apps/desktop/src/main/vault/resolve-embed.ts
+++ b/apps/desktop/src/main/vault/resolve-embed.ts
@@ -1,11 +1,19 @@
 /**
- * Resolve Obsidian image embeds (`![[photo.png]]`) to loadable URLs.
+ * Resolve Obsidian image embeds (`![[photo.png]]`) to something the editor can
+ * load. Obsidian writes embeds either as a vault-relative path
+ * (`Images/photo.png`) or as a bare filename it looks up across the whole vault,
+ * so both forms have to map back to a real file here.
  *
- * The editor renders images through the `memry-file://` protocol and only ever
- * resolves absolute URLs — a bare `photo.png` would resolve against the renderer
- * origin and render broken. Obsidian writes embeds either as a vault-relative
- * path (`Images/photo.png`) or as a bare filename it looks up across the whole
- * vault, so both forms have to map back to an absolute path here.
+ * **Two output shapes, and the difference matters.** The rewrite is spliced into
+ * the note's markdown before parsing, so whatever this returns is what
+ * `blocksToMarkdownLossy` writes back to the vault file on the next save:
+ *
+ *  - Given the note's own path, it returns a path **relative to that note** —
+ *    which survives the round trip, stays valid in Obsidian, and carries no
+ *    machine-specific prefix into a file that syncs to other devices.
+ *  - Without a note path it falls back to an absolute `memry-file://` URL. Only
+ *    read-only surfaces (canvas note previews) are in that position; they render
+ *    the markdown and throw it away, so nothing is ever persisted.
  *
  * Targets that cannot be found resolve to nothing on purpose: the caller leaves
  * the embed as written rather than rewriting it into a broken image.
@@ -72,10 +80,28 @@ function lookupByFilename(vaultPath: string, filename: string): string | null {
 }
 
 /**
- * Resolve one embed target to a `memry-file://` URL, or null when the vault is
- * closed or nothing matches.
+ * Render the resolved file the way the note should carry it: relative to the
+ * note when we know where the note lives, absolute otherwise. Forward slashes
+ * always — this goes into markdown, not onto a Windows command line.
  */
-export function resolveVaultEmbed(ref: string): string | null {
+function embedTarget(vaultPath: string, absPath: string, notePath?: string): string {
+  if (!notePath) return encodeAttachmentUrl(toMemryFileUrl(absPath))
+
+  const noteDir = path.dirname(path.resolve(vaultPath, notePath))
+  const relative = path.relative(noteDir, absPath).split(path.sep).join('/')
+  // `path.relative` returns '' for the directory itself and an absolute path
+  // across Windows drives; neither is a usable ref.
+  if (!relative || path.isAbsolute(relative)) {
+    return encodeAttachmentUrl(toMemryFileUrl(absPath))
+  }
+  return encodeAttachmentUrl(relative)
+}
+
+/**
+ * Resolve one embed target, or null when the vault is closed or nothing matches.
+ * See the module comment for why `notePath` changes the shape of the result.
+ */
+export function resolveVaultEmbed(ref: string, notePath?: string): string | null {
   const status = getStatus()
   if (!status.isOpen || !status.path) return null
   const vaultPath = status.path
@@ -88,12 +114,12 @@ export function resolveVaultEmbed(ref: string): string | null {
   for (const candidate of candidatePaths(vaultPath, notesFolder, ref)) {
     if (!isInsideVault(vaultPath, candidate)) continue
     if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-      return encodeAttachmentUrl(toMemryFileUrl(candidate))
+      return embedTarget(vaultPath, candidate, notePath)
     }
   }
 
   const byName = lookupByFilename(vaultPath, path.basename(ref))
-  return byName ? encodeAttachmentUrl(toMemryFileUrl(byName)) : null
+  return byName ? embedTarget(vaultPath, byName, notePath) : null
 }
 
 /**
@@ -101,11 +127,11 @@ export function resolveVaultEmbed(ref: string): string | null {
  * note, so opening a note costs a single round trip instead of one per image.
  * Unresolvable targets are omitted rather than mapped to null.
  */
-export function resolveVaultEmbeds(refs: string[]): Record<string, string> {
+export function resolveVaultEmbeds(refs: string[], notePath?: string): Record<string, string> {
   const resolved: Record<string, string> = {}
   for (const ref of refs) {
-    const url = resolveVaultEmbed(ref)
-    if (url) resolved[ref] = url
+    const target = resolveVaultEmbed(ref, notePath)
+    if (target) resolved[ref] = target
   }
   return resolved
 }

--- a/apps/desktop/src/preload/api/vault.ts
+++ b/apps/desktop/src/preload/api/vault.ts
@@ -19,7 +19,8 @@ export const vaultApi = {
     invoke(VaultChannels.invoke.DOWNLOAD_REMOTE, { vaultUuid, parentPath }),
   deleteFromAccount: (vaultUuid: string) =>
     invoke(VaultChannels.invoke.DELETE_FROM_ACCOUNT, vaultUuid),
-  resolveEmbeds: (refs: string[]) => invoke(VaultChannels.invoke.RESOLVE_EMBEDS, refs)
+  resolveEmbeds: (input: { refs: string[]; notePath?: string }) =>
+    invoke(VaultChannels.invoke.RESOLVE_EMBEDS, input)
 }
 
 export const vaultEvents = {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -482,7 +482,7 @@ export interface VaultClientAPI {
   listAccount(): Promise<AccountVaultInfo[]>
   downloadRemote(vaultUuid: string, parentPath?: string): Promise<SelectVaultResponse>
   deleteFromAccount(vaultUuid: string): Promise<void>
-  resolveEmbeds(refs: string[]): Promise<Record<string, string>>
+  resolveEmbeds(input: { refs: string[]; notePath?: string }): Promise<Record<string, string>>
 }
 
 // Notes client API interface

--- a/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
+++ b/apps/desktop/src/renderer/src/components/note/content-area/ContentArea.tsx
@@ -279,6 +279,7 @@ const ContentAreaEditor = memo(function ContentAreaEditor({
   const { handleChange } = useEditorSync({
     editor,
     noteId,
+    notePath,
     initialContent,
     contentType,
     yjsFragment,

--- a/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/hooks/use-editor-sync.ts
@@ -104,6 +104,8 @@ function hydrateLinkMentionFavicons(editor: any): void {
 interface EditorSyncParams {
   editor: any
   noteId?: string
+  /** Vault-relative path of the note, so embed targets resolve relative to it. */
+  notePath?: string
   initialContent?: Block[] | string
   contentType?: 'html' | 'markdown' | 'blocks'
   yjsFragment?: Y.XmlFragment
@@ -127,6 +129,7 @@ interface EditorSyncResult {
 export function useEditorSync({
   editor,
   noteId,
+  notePath,
   initialContent,
   contentType = 'html',
   yjsFragment,
@@ -202,7 +205,7 @@ export function useEditorSync({
 
             let blocks
             if (contentType === 'markdown') {
-              blocks = await parseMarkdownPreservingBlanks(editor, content)
+              blocks = await parseMarkdownPreservingBlanks(editor, content, notePath)
             } else {
               blocks = await editor.tryParseHTMLToBlocks(content)
             }

--- a/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
+++ b/apps/desktop/src/renderer/src/components/note/content-area/markdown-utils.ts
@@ -157,19 +157,23 @@ export function sanitizeBlockIds(blocks: Block[]): Block[] {
 }
 
 /**
- * Turn Obsidian image embeds into the `![alt](url)` form BlockNote parses into
- * an image block. The target has to become an absolute `memry-file://` URL for
- * the image to load at all, so the main process resolves it against the vault;
+ * Turn Obsidian image embeds into the `![alt](target)` form BlockNote parses
+ * into an image block. The main process resolves the target against the vault;
  * anything it cannot find is left as the author wrote it. Failures degrade to
  * "no embeds resolved" rather than blocking the note from opening.
+ *
+ * `notePath` matters beyond correctness: with it the target comes back relative
+ * to the note, so saving the note writes a portable link rather than this
+ * machine's absolute path into a file that syncs. Callers that never persist
+ * what they render may omit it.
  */
-async function resolveWikiImageEmbeds(markdown: string): Promise<string> {
+async function resolveWikiImageEmbeds(markdown: string, notePath?: string): Promise<string> {
   const refs = extractWikiImageEmbedRefs(markdown)
   if (refs.length === 0) return markdown
 
   let resolved: Record<string, string> = {}
   try {
-    resolved = (await window.api?.vault?.resolveEmbeds?.(refs)) ?? {}
+    resolved = (await window.api?.vault?.resolveEmbeds?.({ refs, notePath })) ?? {}
   } catch {
     return markdown
   }
@@ -179,9 +183,10 @@ async function resolveWikiImageEmbeds(markdown: string): Promise<string> {
 
 export async function parseMarkdownPreservingBlanks(
   editor: any,
-  markdown: string
+  markdown: string,
+  notePath?: string
 ): Promise<Block[]> {
-  const withEmbeds = await resolveWikiImageEmbeds(markdown)
+  const withEmbeds = await resolveWikiImageEmbeds(markdown, notePath)
   // Inline color spans are masked into markdown-inert tokens before parsing
   // (BlockNote strips raw spans), then re-applied as styles on the parsed runs.
   const { text: maskedMarkdown, spans } = maskInlineColorSpans(withEmbeds)

--- a/apps/desktop/src/renderer/src/services/vault-service.ts
+++ b/apps/desktop/src/renderer/src/services/vault-service.ts
@@ -113,8 +113,11 @@ export const vaultService: VaultClientAPI = {
    * Map Obsidian image embed targets (`![[photo.png]]`) to loadable
    * `memry-file://` URLs. Targets not found in the vault are omitted.
    */
-  resolveEmbeds: (refs: string[]): Promise<Record<string, string>> => {
-    return window.api.vault.resolveEmbeds(refs)
+  resolveEmbeds: (input: {
+    refs: string[]
+    notePath?: string
+  }): Promise<Record<string, string>> => {
+    return window.api.vault.resolveEmbeds(input)
   }
 }
 

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -34,8 +34,11 @@ rendered as a broken image — so a typo stays visible and fixable.
 
 ::: tip
 Editing a note that contains `![[photo.png]]` rewrites the embed to memrynote's standard
-image syntax the next time the note is saved. The picture and its position are unchanged;
-only the markup differs.
+image syntax the next time the note is saved — `![photo.png](../Images/photo.png)`. The
+picture and its position are unchanged; only the markup differs.
+
+The rewritten link is **relative to the note**, so it keeps working after the note syncs to
+your other devices, and the vault stays readable by Obsidian.
 :::
 
 ## Backlinks Panel

--- a/packages/contracts/src/vault-api.ts
+++ b/packages/contracts/src/vault-api.ts
@@ -108,6 +108,17 @@ export interface GetVaultsResponse {
  */
 export type ResolvedEmbeds = Record<string, string>
 
+/**
+ * `notePath` (vault-relative) makes the resolver return targets relative to that
+ * note, which is what keeps the rewritten markdown portable when the note is
+ * saved back. Omit it only on read-only surfaces that never persist what they
+ * render; those get absolute `memry-file://` URLs instead.
+ */
+export interface ResolveEmbedsInput {
+  refs: string[]
+  notePath?: string
+}
+
 export interface VaultHandlers {
   [VaultChannels.invoke.SELECT]: (
     input: z.infer<typeof SelectVaultSchema>
@@ -145,7 +156,7 @@ export interface VaultHandlers {
 
   [VaultChannels.invoke.DELETE_FROM_ACCOUNT]: (vaultUuid: string) => Promise<void>
 
-  [VaultChannels.invoke.RESOLVE_EMBEDS]: (refs: string[]) => Promise<ResolvedEmbeds>
+  [VaultChannels.invoke.RESOLVE_EMBEDS]: (input: ResolveEmbedsInput) => Promise<ResolvedEmbeds>
 }
 
 // ============================================================================
@@ -186,5 +197,5 @@ export interface VaultClientAPI {
   listAccount(): Promise<AccountVaultInfo[]>
   downloadRemote(vaultUuid: string, parentPath?: string): Promise<SelectVaultResponse>
   deleteFromAccount(vaultUuid: string): Promise<void>
-  resolveEmbeds(refs: string[]): Promise<ResolvedEmbeds>
+  resolveEmbeds(input: ResolveEmbedsInput): Promise<ResolvedEmbeds>
 }


### PR DESCRIPTION
## Summary

Opening and editing an Obsidian note replaced its image embed with this machine's absolute path, inside a file that syncs to other devices and is meant to stay readable in Obsidian.

The embed rewrite added in #906 runs on the markdown string *before* it is parsed, so whatever it produces is what `blocksToMarkdownLossy` writes back to the vault file. It produced an absolute `memry-file://` URL. Round-tripping a note through the converter confirmed it:

```
source      : Before\n\n![[photo.png]]\n\nAfter
round trip  : Before\n\n![photo.png](memry-file://local/Users/me/vault/Images/photo.png)\n\nAfter
```

`resolveVaultEmbed` now takes the note's vault-relative path and returns a target relative to that note — `../Images/photo.png` — so the saved file stays portable and valid in Obsidian. Rendering is unchanged: the renderer's existing `resolveFileUrl` (#907/#910) already loads relative refs against the note's folder.

### Why not restore `![[photo.png]]` on save

A serialize-side inverse would have to turn `memry-file://` URLs back into embeds, and nothing distinguishes an embed-derived URL from a genuine attachment or a file dragged in from the sidebar. It would rewrite content the user actually authored. Emitting a relative link at parse time needs no provenance tracking and is stable across any number of save cycles.

### Threading

The note path is passed on the three parse paths that write back to disk:

| Path | Where the note path comes from |
| --- | --- |
| Editor | `ContentArea` → `useEditorSync` → `parseMarkdownPreservingBlanks` (the `notePath` prop added in #907) |
| CRDT seeding | `seedFromMarkdown` already had `cached.path` |
| External file edits | `replaceNoteBodyInCrdt` looks it up by note id |

Surfaces that render markdown and throw it away — canvas note previews — pass no path and keep the absolute URL. That is deliberate: nothing there is ever persisted, so this cannot regress an existing render, and it keeps the change off paths I could not verify.

### Reviewer notes

- `resolveEmbeds` IPC input becomes `{ refs, notePath? }`. Intra-app boundary within one build, so no compat window; contracts, preload types, and the generated invoke map are regenerated.
- `path.relative` returning `''` or an absolute path (different Windows drives) falls back to the absolute URL rather than emitting a broken ref.
- Targets are still percent-encoded, so spaces and parens cannot truncate the markdown link.

## Release note

Notes that use Obsidian-style image embeds now keep a portable link when you edit them, instead of being rewritten with a path specific to one computer.

## Test plan

- New `embed-roundtrip.test.ts` — 5 cases pinning what the vault file looks like after a save: the portable relative link, no `memry-file://` and no `/Users/` anywhere in the output, the sized `|300x200` form, note transclusions and plain wikilinks untouched, and the deliberate absolute-URL fallback when no note path is given
- `resolve-embed.test.ts` — 6 new cases: relative-to-note output, sibling file with no `../`, note at the vault root, percent-encoding, bare-filename index lookup, and the no-note-path fallback
- `pnpm test:desktop` — 1041 files, 12146 passed, 0 failed
- `pnpm typecheck` — 16/16 packages
- `pnpm ipc:generate` + `pnpm ipc:check`, `pnpm check:architecture`, `pnpm check:contracts`
- `eslint --no-cache --max-warnings=0` over all nine changed source files
- `pnpm docs:impact --strict` and `pnpm docs:build`
