### PR TITLE
test(e2e): match the quick-add task field now that it is a textarea

### DIFF
--- a/apps/desktop/tests/e2e/utils/electron-helpers.ts
+++ b/apps/desktop/tests/e2e/utils/electron-helpers.ts
@@ -38,7 +38,12 @@ export const SELECTORS = {
   taskItem: '[role="button"][aria-label*="Task:"], [data-testid="task-item"]',
   taskCheckbox: '[role="checkbox"], [data-testid="task-checkbox"]',
   addTaskButton: 'button:has-text("Add Task")', // Header button opens modal
-  taskInput: 'input[aria-label="Quick add task"], input[placeholder*="Add task"]', // Quick add input
+  // Quick add input. The Tasks page renders this through the shared CaptureBar,
+  // which is a `textarea` — an `input`-only selector silently stops matching and
+  // sends createTask() down the fallback path that creates nothing (see the note
+  // in createTask; that is how the smoke job reaches its job timeout).
+  taskInput:
+    '[aria-label="Quick add task"], input[placeholder*="Add task"], textarea[placeholder*="Add task"]',
   taskModalTitleInput: '#task-title', // Title input in Add Task modal
   taskModal: '[role="dialog"]:has-text("Add Task")', // Add Task modal
   kanbanBoard: '[data-testid="kanban-board"], [class*="kanban"]',


### PR DESCRIPTION
## What broke

`#905` moved the Tasks page quick-add into the shared `CaptureBar`, which renders a `textarea`. The E2E selector was `input`-only:

```ts
taskInput: 'input[aria-label="Quick add task"], input[placeholder*="Add task"]'
```

So it stopped matching. `createTask()` then waits 10s for it, falls through to the "Add Task" button — which focuses that same field rather than opening a modal — and returns having created nothing. Every caller's row assertion is left to burn its own timeout.

This is the exact trap the comment inside `createTask` already warns about (it is how the macOS smoke job used to reach its 45-minute ceiling). It came back on all three platforms.

## Evidence from the main run for #905 ([30759648967](https://github.com/memrynote/memry/actions/runs/30759648967))

- `Electron E2E smoke`, `smoke (macOS)`, `smoke (Windows)` — all cancelled at their job ceilings. Baseline on the previous main run was 16m50s / 21m09s / 20m20s, all green.
- `Electron E2E full (15/16)` — failed. Every failing test is a `Task Drag and Drop` case, and the failure snapshot shows an empty board:

```
- heading "No tasks yet"
- /placeholder: "Add a task…    !today  !!high  #project"
```

Zero task rows, and right above them the textarea the old selector could not see.

## Fix

Element-agnostic selector, so it matches the field wherever it is rendered and whatever tag it uses.

## Verification

Local run against the built app, on this branch:

```
28 passed (6.0m)
```

zero `no task input found` logs. Before the fix, the same seeded tests each took 27.3s and logged it every time; with it they run 13–14s. The drag tests that failed in CI all pass here.