### PR TITLE
fix(agent-mcp): expose note file type to MCP search and read

### DIFF
--- a/apps/desktop/src/main/agent/mcp/tools/__tests__/read-tools.test.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/__tests__/read-tools.test.ts
@@ -3,24 +3,51 @@ import { buildReadTools } from '../read-tools'
 import type { VaultServiceHandles } from '../handles'
 import { AgentToolError } from '../../errors'
 
+let lastSearchInput: Parameters<VaultServiceHandles['notes']['search']>[0] | null = null
+
 function fake(): VaultServiceHandles {
   return {
     notes: {
-      search: async ({ query }) =>
-        query === 'hit'
-          ? [{ id: 'n1', title: 'Hit', snippet: 'hit me', folder_path: '/Inbox' }]
-          : [],
-      read: async (id) =>
-        id === 'n1'
-          ? {
-              id: 'n1',
-              title: 'Hit',
-              content_markdown: '# Hit',
-              tags: ['t'],
-              folder_path: '/Inbox',
-              frontmatter: { foo: 1 }
-            }
-          : null,
+      search: async (input) => {
+        lastSearchInput = input
+        return input.query === 'hit'
+          ? [
+              {
+                id: 'n1',
+                title: 'Hit',
+                snippet: 'hit me',
+                folder_path: '/Inbox',
+                file_type: 'markdown'
+              },
+              { id: 'f1', title: 'Scan', snippet: '', folder_path: '/Inbox', file_type: 'pdf' }
+            ]
+          : []
+      },
+      read: async (id) => {
+        if (id === 'n1') {
+          return {
+            id: 'n1',
+            title: 'Hit',
+            content_markdown: '# Hit',
+            tags: ['t'],
+            folder_path: '/Inbox',
+            frontmatter: { foo: 1 },
+            file_type: 'markdown'
+          }
+        }
+        if (id === 'f1') {
+          return {
+            id: 'f1',
+            title: 'Scan',
+            content_markdown: '',
+            tags: [],
+            folder_path: '/Inbox',
+            frontmatter: {},
+            file_type: 'pdf'
+          }
+        }
+        return null
+      },
       create: async () => ({ id: 'unused' }),
       rename: async ({ id }) => ({ id }),
       delete: async (id) => ({ id }),
@@ -118,13 +145,39 @@ describe('Read tools', () => {
   beforeEach(() => {
     handles = fake()
     tools = buildReadTools(handles)
+    lastSearchInput = null
   })
 
-  it('vault_search_notes returns hits', async () => {
+  it('vault_search_notes returns hits tagged with their file type', async () => {
     const out = await tools
       .find((t) => t.name === 'vault_search_notes')!
       .handler({ query: 'hit' }, { conversationId: null, windowId: null })
-    expect(out).toEqual([{ id: 'n1', title: 'Hit', snippet: 'hit me', folder_path: '/Inbox' }])
+    expect(out).toEqual([
+      { id: 'n1', title: 'Hit', snippet: 'hit me', folder_path: '/Inbox', file_type: 'markdown' },
+      { id: 'f1', title: 'Scan', snippet: '', folder_path: '/Inbox', file_type: 'pdf' }
+    ])
+  })
+
+  it('vault_search_notes forwards file_types to the search handle', async () => {
+    await tools
+      .find((t) => t.name === 'vault_search_notes')!
+      .handler({ query: 'hit', file_types: ['markdown'] }, { conversationId: null, windowId: null })
+    expect(lastSearchInput).toMatchObject({ query: 'hit', fileTypes: ['markdown'] })
+  })
+
+  it('vault_search_notes leaves fileTypes unset when no filter is given', async () => {
+    await tools
+      .find((t) => t.name === 'vault_search_notes')!
+      .handler({ query: 'hit' }, { conversationId: null, windowId: null })
+    expect(lastSearchInput?.fileTypes).toBeUndefined()
+  })
+
+  it('vault_read_note rejects a filed binary instead of returning it as markdown', async () => {
+    await expect(
+      tools
+        .find((t) => t.name === 'vault_read_note')!
+        .handler({ id: 'f1' }, { conversationId: null, windowId: null })
+    ).rejects.toMatchObject({ code: 'VALIDATION', details: { id: 'f1', file_type: 'pdf' } })
   })
 
   it('vault_read_note throws NOT_FOUND for missing note', async () => {

--- a/apps/desktop/src/main/agent/mcp/tools/__tests__/schemas.test.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/__tests__/schemas.test.ts
@@ -83,6 +83,27 @@ describe('Vault MCP tool schemas', () => {
     expect(r.success).toBe(false)
   })
 
+  it('accepts a file_types filter for search', () => {
+    const parsed = TOOL_SCHEMAS.vault_search_notes.input.parse({
+      query: 'invoice',
+      file_types: ['markdown', 'pdf']
+    })
+    expect(parsed).toEqual({ query: 'invoice', file_types: ['markdown', 'pdf'] })
+  })
+
+  it('rejects an unknown file_type for search', () => {
+    const r = TOOL_SCHEMAS.vault_search_notes.input.safeParse({
+      query: 'invoice',
+      file_types: ['spreadsheet']
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects an empty file_types array for search', () => {
+    const r = TOOL_SCHEMAS.vault_search_notes.input.safeParse({ query: 'invoice', file_types: [] })
+    expect(r.success).toBe(false)
+  })
+
   it('rejects unknown update_note modes', () => {
     const r = TOOL_SCHEMAS.vault_update_note.input.safeParse({
       id: 'x',

--- a/apps/desktop/src/main/agent/mcp/tools/handles-adapter.test.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles-adapter.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   searchAll: vi.fn(),
   listJournalEntriesInRange: vi.fn(),
+  getNoteCacheById: vi.fn(),
   getInboxProject: vi.fn(),
   createDesktopInboxDomain: vi.fn(),
   createDesktopInboxCrudHandlers: vi.fn(),
@@ -36,7 +37,8 @@ vi.mock('../../../database/queries/search', () => ({
 }))
 
 vi.mock('../../../database/queries/notes', () => ({
-  listJournalEntriesInRange: mocks.listJournalEntriesInRange
+  listJournalEntriesInRange: mocks.listJournalEntriesInRange,
+  getNoteCacheById: mocks.getNoteCacheById
 }))
 
 vi.mock('../../../database/queries/projects', () => ({
@@ -212,6 +214,12 @@ describe('createVaultServiceHandles', () => {
               metadata: { type: 'note', path: 'notes/work/alpha.md', emoji: '🎬' }
             },
             {
+              id: 'file-1',
+              title: 'Scan',
+              snippet: 'scan snippet',
+              metadata: { type: 'note', path: 'notes/work/scan.pdf', fileType: 'pdf' }
+            },
+            {
               id: 'note-2',
               title: 'Loose',
               snippet: 'loose snippet',
@@ -225,15 +233,41 @@ describe('createVaultServiceHandles', () => {
     await expect(
       handles.notes.search({ query: 'alpha', folderId: '/work', limit: 5 })
     ).resolves.toEqual([
-      { id: 'note-1', title: 'Alpha', snippet: '', folder_path: '/work', icon: '🎬' },
-      { id: 'note-2', title: 'Loose', snippet: 'loose snippet', folder_path: null }
+      {
+        id: 'note-1',
+        title: 'Alpha',
+        snippet: '',
+        folder_path: '/work',
+        file_type: 'markdown',
+        icon: '🎬'
+      },
+      {
+        id: 'file-1',
+        title: 'Scan',
+        snippet: 'scan snippet',
+        folder_path: '/work',
+        file_type: 'pdf'
+      },
+      {
+        id: 'note-2',
+        title: 'Loose',
+        snippet: 'loose snippet',
+        folder_path: null,
+        file_type: 'markdown'
+      }
     ])
     expect(mocks.searchAll).toHaveBeenCalledWith(
       deps.indexDb,
       deps.dataDb,
-      expect.objectContaining({ folderPath: 'notes/work', limit: 5 })
+      expect.objectContaining({ folderPath: 'notes/work', limit: 5, noteFileTypes: undefined })
     )
 
+    mocks.getNoteCacheById.mockReturnValue({
+      id: 'note-1',
+      title: 'Alpha',
+      path: 'notes/work/alpha.md',
+      fileType: 'markdown'
+    })
     mocks.getNoteById.mockResolvedValue({
       id: 'note-1',
       title: 'Alpha',
@@ -250,6 +284,7 @@ describe('createVaultServiceHandles', () => {
       tags: ['Team'],
       folder_path: '/work',
       frontmatter: { owner: 'Kaan' },
+      file_type: 'markdown',
       icon: '📚'
     })
 
@@ -339,6 +374,72 @@ describe('createVaultServiceHandles', () => {
 
     await handles.notes.moveToFolder({ id: 'note-1', folder_path: '/' })
     expect(mocks.moveNoteCommand).toHaveBeenLastCalledWith('note-1', '')
+  })
+
+  it('pushes the note file type filter into the FTS query', async () => {
+    const handles = createVaultServiceHandles(deps)
+
+    await handles.notes.search({ query: 'invoice', fileTypes: ['markdown'] })
+
+    expect(mocks.searchAll).toHaveBeenCalledWith(
+      deps.indexDb,
+      deps.dataDb,
+      expect.objectContaining({ noteFileTypes: ['markdown'] })
+    )
+  })
+
+  it('reads a filed binary as its file type without parsing the bytes as markdown', async () => {
+    const handles = createVaultServiceHandles(deps)
+
+    mocks.getNoteCacheById.mockReturnValue({
+      id: 'file-1',
+      title: 'Scan',
+      path: 'notes/work/scan.pdf',
+      fileType: 'pdf'
+    })
+
+    await expect(handles.notes.read('file-1')).resolves.toMatchObject({
+      id: 'file-1',
+      title: 'Scan',
+      folder_path: '/work',
+      file_type: 'pdf'
+    })
+    expect(mocks.getNoteById).not.toHaveBeenCalled()
+  })
+
+  it('treats a note cache row with no file type as markdown', async () => {
+    const handles = createVaultServiceHandles(deps)
+
+    mocks.getNoteCacheById.mockReturnValue({
+      id: 'legacy-1',
+      title: 'Legacy',
+      path: 'notes/legacy.md',
+      fileType: null
+    })
+    mocks.getNoteById.mockResolvedValue({
+      id: 'legacy-1',
+      title: 'Legacy',
+      content: 'Body',
+      tags: [],
+      path: 'notes/legacy.md',
+      frontmatter: {},
+      emoji: null
+    })
+
+    await expect(handles.notes.read('legacy-1')).resolves.toMatchObject({
+      id: 'legacy-1',
+      content_markdown: 'Body',
+      file_type: 'markdown'
+    })
+  })
+
+  it('returns null when the note cache has no row for the id', async () => {
+    const handles = createVaultServiceHandles(deps)
+
+    mocks.getNoteCacheById.mockReturnValue(undefined)
+
+    await expect(handles.notes.read('missing')).resolves.toBeNull()
+    expect(mocks.getNoteById).not.toHaveBeenCalled()
   })
 
   it('lists direct and recursive folder entries using tool paths', async () => {

--- a/apps/desktop/src/main/agent/mcp/tools/handles-adapter.test.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles-adapter.test.ts
@@ -433,6 +433,22 @@ describe('createVaultServiceHandles', () => {
     })
   })
 
+  it('refuses to overwrite a filed binary with markdown', async () => {
+    const handles = createVaultServiceHandles(deps)
+
+    mocks.getNoteCacheById.mockReturnValue({
+      id: 'file-1',
+      title: 'Scan',
+      path: 'notes/work/scan.pdf',
+      fileType: 'pdf'
+    })
+
+    await expect(
+      handles.notes.update({ id: 'file-1', mode: 'replace', content_markdown: 'Body' })
+    ).rejects.toMatchObject({ code: 'VALIDATION', details: { id: 'file-1', file_type: 'pdf' } })
+    expect(mocks.updateNoteCommand).not.toHaveBeenCalled()
+  })
+
   it('returns null when the note cache has no row for the id', async () => {
     const handles = createVaultServiceHandles(deps)
 

--- a/apps/desktop/src/main/agent/mcp/tools/handles-adapter.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles-adapter.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import { searchAll } from '../../../database/queries/search'
-import { listJournalEntriesInRange } from '../../../database/queries/notes'
+import { getNoteCacheById, listJournalEntriesInRange } from '../../../database/queries/notes'
 import { getInboxProject } from '../../../database/queries/projects'
 import { createDesktopInboxDomain } from '../../../inbox/domain'
 import { createDesktopInboxCrudHandlers } from '../../../inbox/domain'
@@ -175,7 +175,7 @@ function inboxVisualType(item: {
 export function createVaultServiceHandles({ dataDb, indexDb }: AdapterDeps): VaultServiceHandles {
   return {
     notes: {
-      async search({ query, limit = 10, folderId }) {
+      async search({ query, limit = 10, folderId, fileTypes }) {
         const result = searchAll(indexDb, dataDb, {
           text: query,
           types: ['note'],
@@ -184,7 +184,10 @@ export function createVaultServiceHandles({ dataDb, indexDb }: AdapterDeps): Vau
           projectId: null,
           folderPath: folderId ? cacheFolderFromToolPath(folderId) : null,
           limit,
-          offset: 0
+          offset: 0,
+          // Filtering inside the FTS query keeps `limit` counting eligible rows
+          // only, so filed binaries can't starve markdown notes out (#874).
+          noteFileTypes: fileTypes
         })
         const notes = result.groups.find((group) => group.type === 'note')?.results ?? []
         return notes.map<NoteSummary>((note) => {
@@ -194,11 +197,32 @@ export function createVaultServiceHandles({ dataDb, indexDb }: AdapterDeps): Vau
             title: note.title,
             snippet: note.snippet ?? '',
             folder_path: metadata?.path ? folderPathFromNotePath(metadata.path) : null,
+            file_type: metadata?.fileType ?? 'markdown',
             ...(metadata?.emoji ? { icon: metadata.emoji } : {})
           }
         })
       },
       async read(id) {
+        const cached = getNoteCacheById(indexDb, id)
+        if (!cached) return null
+
+        const fileType = cached.fileType ?? 'markdown'
+        if (fileType !== 'markdown') {
+          // Filed binary (#800): reading it off disk would only hand `parseNote`
+          // bytes to mangle. Return identity + file type so the tool layer can
+          // refuse it — the empty body never reaches an agent (#919).
+          return {
+            id: cached.id,
+            title: cached.title,
+            content_markdown: '',
+            tags: [],
+            folder_path: folderPathFromNotePath(cached.path),
+            frontmatter: {},
+            file_type: fileType,
+            ...(cached.emoji ? { icon: cached.emoji } : {})
+          }
+        }
+
         const note = await getNoteById(id)
         if (!note) return null
         const icon =
@@ -214,6 +238,7 @@ export function createVaultServiceHandles({ dataDb, indexDb }: AdapterDeps): Vau
           tags: note.tags,
           folder_path: folderPathFromNotePath(note.path),
           frontmatter: note.frontmatter,
+          file_type: 'markdown',
           ...(icon ? { icon } : {})
         }
       },

--- a/apps/desktop/src/main/agent/mcp/tools/handles-adapter.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles-adapter.ts
@@ -32,6 +32,7 @@ import {
 } from '../../../notes/folder-config-effects'
 import type { RepeatConfig } from '@memry/domain-tasks'
 import type { DataDb, IndexDb } from '../../../database'
+import { AgentToolError } from '../errors'
 import { snapshotCurrentNoteFromWindow } from './current-note'
 import { invokeDesktopApiFromWindow } from './desktop-api'
 import type {
@@ -260,6 +261,19 @@ export function createVaultServiceHandles({ dataDb, indexDb }: AdapterDeps): Vau
         return { id }
       },
       async update(input) {
+        // A filed pdf/image/audio/video indexes as a "note" row (#800), so an
+        // agent can reach one from search. Writing markdown over it would
+        // destroy the user's file — refuse before touching disk (#919).
+        const fileType = getNoteCacheById(indexDb, input.id)?.fileType ?? 'markdown'
+        if (fileType !== 'markdown') {
+          throw new AgentToolError(
+            'VALIDATION',
+            `Note ${input.id} is a filed ${fileType} file, not a markdown note. ` +
+              'Writing markdown to it would destroy the file.',
+            { id: input.id, file_type: fileType }
+          )
+        }
+
         const note = await getNoteById(input.id)
         if (!note) {
           throw new Error(`Note not found: ${input.id}`)

--- a/apps/desktop/src/main/agent/mcp/tools/handles.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles.ts
@@ -5,12 +5,20 @@ import type {
   AgentMcpDesktopReadOperation,
   AgentMcpDesktopWriteOperation
 } from '@memry/contracts/agent-mcp-channels'
+import type { NoteFileType } from '@memry/contracts/search-api'
 
+/**
+ * `file_type` is always populated: index rows written before filed binaries
+ * existed carry no file type, and those are always markdown (#800, #919). A
+ * binary value means the row is a filed file, not a note — `vault_read_note`
+ * rejects it rather than handing an agent bytes to read as markdown.
+ */
 export interface NoteSummary {
   id: string
   title: string
   snippet: string
   folder_path: string | null
+  file_type: NoteFileType
   icon?: string | null
 }
 
@@ -21,6 +29,7 @@ export interface NoteFull {
   tags: string[]
   folder_path: string | null
   frontmatter: Record<string, unknown>
+  file_type: NoteFileType
   icon?: string | null
 }
 
@@ -84,7 +93,12 @@ export interface CurrentNoteSnapshot {
 
 export interface VaultServiceHandles {
   notes: {
-    search(input: { query: string; limit?: number; folderId?: string }): Promise<NoteSummary[]>
+    search(input: {
+      query: string
+      limit?: number
+      folderId?: string
+      fileTypes?: NoteFileType[]
+    }): Promise<NoteSummary[]>
     read(id: string): Promise<NoteFull | null>
     create(input: {
       title: string

--- a/apps/desktop/src/main/agent/mcp/tools/read-tools.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/read-tools.ts
@@ -5,6 +5,7 @@ import type { ToolRegistration } from '../server'
 import type { VaultServiceHandles } from './handles'
 import { TOOL_SCHEMAS, READ_TOOL_NAMES } from './schemas'
 import type { AgentMcpDesktopReadOperation } from '@memry/contracts/agent-mcp-channels'
+import type { NoteFileType } from '@memry/contracts/search-api'
 
 function parse<T>(schema: ZodTypeAny, input: unknown): T {
   const r = schema.safeParse(input)
@@ -21,11 +22,18 @@ export function buildReadTools(handles: VaultServiceHandles): ToolRegistration[]
       description: TOOL_SCHEMAS.vault_search_notes.description,
       inputSchema: TOOL_SCHEMAS.vault_search_notes.input,
       handler: async (input) => {
-        const a = parse<{ query: string; limit?: number; folder_id?: string }>(
-          TOOL_SCHEMAS.vault_search_notes.input,
-          input
-        )
-        return handles.notes.search({ query: a.query, limit: a.limit, folderId: a.folder_id })
+        const a = parse<{
+          query: string
+          limit?: number
+          folder_id?: string
+          file_types?: NoteFileType[]
+        }>(TOOL_SCHEMAS.vault_search_notes.input, input)
+        return handles.notes.search({
+          query: a.query,
+          limit: a.limit,
+          folderId: a.folder_id,
+          fileTypes: a.file_types
+        })
       }
     },
     vault_read_note: {
@@ -36,6 +44,17 @@ export function buildReadTools(handles: VaultServiceHandles): ToolRegistration[]
         const a = parse<{ id: string }>(TOOL_SCHEMAS.vault_read_note.input, input)
         const note = await handles.notes.read(a.id)
         if (!note) throw new AgentToolError('NOT_FOUND', `Note ${a.id} not found`, { id: a.id })
+        // A filed pdf/image/audio/video indexes as a "note" row (#800). Handing
+        // its body to an agent would be binary garbage dressed as markdown, so
+        // refuse loudly instead of letting it read or edit one. See #919.
+        if (note.file_type !== 'markdown') {
+          throw new AgentToolError(
+            'VALIDATION',
+            `Note ${a.id} is a filed ${note.file_type} file, not a markdown note. ` +
+              'vault_read_note returns markdown only.',
+            { id: a.id, file_type: note.file_type }
+          )
+        }
         return note
       }
     },

--- a/apps/desktop/src/main/agent/mcp/tools/schemas.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/schemas.ts
@@ -3,6 +3,7 @@ import {
   AgentMcpDesktopReadOperations,
   AgentMcpDesktopWriteOperations
 } from '@memry/contracts/agent-mcp-channels'
+import { NoteFileTypeEnum } from '@memry/contracts/search-api'
 
 const idSchema = z.string().min(1)
 const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
@@ -79,13 +80,20 @@ export const TOOL_SCHEMAS = {
     input: z.object({
       query: z.string().min(1),
       limit: z.number().int().positive().max(50).optional(),
-      folder_id: idSchema.optional()
+      folder_id: idSchema.optional(),
+      file_types: z.array(NoteFileTypeEnum).min(1).optional()
     }),
-    description: 'Full-text search across notes; returns id, title, snippet, folder_path.'
+    description:
+      'Full-text search across notes and filed files; returns id, title, snippet, folder_path, ' +
+      'file_type. A file_type other than "markdown" (pdf/image/audio/video) is a filed file, not ' +
+      'a note — vault_read_note rejects those. Pass file_types to restrict the search, e.g. ' +
+      '["markdown"] for notes only; omitted returns every file type.'
   },
   vault_read_note: {
     input: z.object({ id: idSchema }),
-    description: 'Read a note by id; returns full markdown content + metadata.'
+    description:
+      'Read a markdown note by id; returns full markdown content + metadata. Errors with ' +
+      'VALIDATION when the id belongs to a filed pdf/image/audio/video file.'
   },
   vault_list_folder: {
     input: z.object({

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -184,7 +184,8 @@ so it can turn up in `vault_search_notes`. Every search hit therefore carries a 
 - `markdown` — a real note. `vault_read_note` returns its content.
 - `pdf`, `image`, `audio`, `video` — a filed file. There is no markdown to read, so
   `vault_read_note` refuses it with a `VALIDATION` error naming the file type instead of returning
-  bytes for the client to treat as text.
+  bytes for the client to treat as text. `vault_update_note` refuses it the same way, so an agent
+  cannot overwrite a filed document with markdown.
 
 Pass `file_types` to narrow the search up front — `["markdown"]` for notes only, or
 `["pdf", "image"]` to look for filed documents. The filter runs inside the search query, so `limit`

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -176,6 +176,23 @@ Read tools are available to Agent Chat and external MCP clients:
 - `vault_get_tags`
 - `vault_desktop_read`
 
+### Notes and filed files
+
+Filing a PDF, image, audio file, or video into the vault indexes it alongside your markdown notes,
+so it can turn up in `vault_search_notes`. Every search hit therefore carries a `file_type`:
+
+- `markdown` — a real note. `vault_read_note` returns its content.
+- `pdf`, `image`, `audio`, `video` — a filed file. There is no markdown to read, so
+  `vault_read_note` refuses it with a `VALIDATION` error naming the file type instead of returning
+  bytes for the client to treat as text.
+
+Pass `file_types` to narrow the search up front — `["markdown"]` for notes only, or
+`["pdf", "image"]` to look for filed documents. The filter runs inside the search query, so `limit`
+counts only matching rows. Omit `file_types` to search every file type.
+
+Notes indexed by older memrynote versions have no recorded file type; those are always treated as
+markdown, so upgrading never hides existing notes.
+
 Create, update, delete, archive, move, and reorder tools require Agent Chat context. They can be
 auto-accepted or shown for inline approval depending on the Agent Permissions setting:
 


### PR DESCRIPTION
## What

- `vault_search_notes` gains a `file_types` filter, pushed into the FTS query so `limit` counts eligible rows only
- `NoteSummary`/`NoteFull` carry `file_type`; index rows written before filed binaries existed have none, and those stay markdown
- `vault_read_note` rejects a filed pdf/image/audio/video with a typed `VALIDATION` error instead of parsing its bytes as markdown
- `vault_update_note` gets the same guard — it previously wrote markdown straight over the filed file

## Why

The search API gained a `fileType` discriminator in #800 so filed binaries stop being treated as notes. The MCP layer never picked it up, so agents got a filed PDF back as an ordinary note row and read (or edited) it as markdown.

Closes #919