### PR TITLE
feat(agent-mcp): expose the project hub link layer

### DIFF
--- a/apps/desktop/src/main/agent/mcp/tools/__tests__/read-tools.test.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/__tests__/read-tools.test.ts
@@ -89,7 +89,17 @@ function fake(): VaultServiceHandles {
       removeTag: async () => {}
     },
     projects: {
-      list: async () => [{ id: 'p1', name: 'memrynote', status: 'active', task_count: 5 }],
+      list: async () => [
+        {
+          id: 'p1',
+          name: 'memrynote',
+          status: 'active',
+          task_count: 5,
+          icon: null,
+          home_note_id: null,
+          linked_counts: { notes: 0, files: 0, events: 0 }
+        }
+      ],
       get: async (id) => (id === 'p1' ? { id, name: 'memrynote' } : null),
       create: async () => ({ id: 'unused' }),
       update: async ({ id }) => ({ id }),

--- a/apps/desktop/src/main/agent/mcp/tools/handles-adapter.test.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles-adapter.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   listJournalEntriesInRange: vi.fn(),
   getNoteCacheById: vi.fn(),
   getInboxProject: vi.fn(),
+  getProjectLinkCounts: vi.fn(),
   createDesktopInboxDomain: vi.fn(),
   createDesktopInboxCrudHandlers: vi.fn(),
   deleteJournalEntryFile: vi.fn(),
@@ -42,7 +43,8 @@ vi.mock('../../../database/queries/notes', () => ({
 }))
 
 vi.mock('../../../database/queries/projects', () => ({
-  getInboxProject: mocks.getInboxProject
+  getInboxProject: mocks.getInboxProject,
+  getProjectLinkCounts: mocks.getProjectLinkCounts
 }))
 
 vi.mock('../../../inbox/domain', () => ({
@@ -669,13 +671,40 @@ describe('createVaultServiceHandles', () => {
 
     taskDomain.listProjects.mockReturnValue({
       projects: [
-        { id: 'project-1', name: 'Active', archivedAt: null, taskCount: 2 },
+        {
+          id: 'project-1',
+          name: 'Active',
+          archivedAt: null,
+          taskCount: 2,
+          icon: '🚀',
+          homeNoteId: 'note-home'
+        },
         { id: 'project-2', name: 'Archived', archivedAt: '2026-05-11', taskCount: 0 }
       ]
     })
+    mocks.getProjectLinkCounts.mockReturnValue(
+      new Map([['project-1', { notes: 3, files: 1, events: 2 }]])
+    )
     await expect(handles.projects.list()).resolves.toEqual([
-      { id: 'project-1', name: 'Active', status: 'active', task_count: 2 },
-      { id: 'project-2', name: 'Archived', status: 'archived', task_count: 0 }
+      {
+        id: 'project-1',
+        name: 'Active',
+        status: 'active',
+        task_count: 2,
+        icon: '🚀',
+        home_note_id: 'note-home',
+        linked_counts: { notes: 3, files: 1, events: 2 }
+      },
+      {
+        id: 'project-2',
+        name: 'Archived',
+        status: 'archived',
+        task_count: 0,
+        icon: null,
+        home_note_id: null,
+        // A project with no links is absent from the counts map.
+        linked_counts: { notes: 0, files: 0, events: 0 }
+      }
     ])
 
     taskDomain.getTask.mockReturnValueOnce({ id: 'task-1' })

--- a/apps/desktop/src/main/agent/mcp/tools/handles-adapter.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles-adapter.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import { searchAll } from '../../../database/queries/search'
 import { getNoteCacheById, listJournalEntriesInRange } from '../../../database/queries/notes'
-import { getInboxProject } from '../../../database/queries/projects'
+import { getInboxProject, getProjectLinkCounts } from '../../../database/queries/projects'
 import { createDesktopInboxDomain } from '../../../inbox/domain'
 import { createDesktopInboxCrudHandlers } from '../../../inbox/domain'
 import { deleteJournalEntryFile, readJournalEntry, writeJournalEntry } from '../../../vault/journal'
@@ -542,11 +542,17 @@ export function createVaultServiceHandles({ dataDb, indexDb }: AdapterDeps): Vau
     projects: {
       async list() {
         const result = createTaskDomain(dataDb).listProjects()
+        // One aggregate for the whole list: a per-project contents call would
+        // be an N+1 on a tool the model calls before most project writes.
+        const linkCounts = getProjectLinkCounts(dataDb)
         return result.projects.map<ProjectSummary>((project) => ({
           id: project.id,
           name: project.name,
           status: project.archivedAt ? 'archived' : 'active',
-          task_count: project.taskCount
+          task_count: project.taskCount,
+          icon: project.icon ?? null,
+          home_note_id: project.homeNoteId ?? null,
+          linked_counts: linkCounts.get(project.id) ?? { notes: 0, files: 0, events: 0 }
         }))
       },
       async get(id) {

--- a/apps/desktop/src/main/agent/mcp/tools/handles.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/handles.ts
@@ -55,6 +55,15 @@ export interface ProjectSummary {
   name: string
   status: string | null
   task_count: number
+  icon: string | null
+  /** The project's overview note, if one is set. */
+  home_note_id: string | null
+  /**
+   * Notes, files and events linked to the project. Nonzero counts are the
+   * signal to follow up with `tasks.listProjectContents` — task_count alone
+   * says nothing about the hub's link layer.
+   */
+  linked_counts: { notes: number; files: number; events: number }
 }
 
 export interface JournalEntry {

--- a/apps/desktop/src/main/agent/mcp/tools/schemas.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/schemas.ts
@@ -123,7 +123,7 @@ export const TOOL_SCHEMAS = {
   },
   vault_list_projects: {
     input: z.object({}).default({}),
-    description: 'List all projects with task counts.'
+    description: 'List all projects with task counts and linked note/file/event counts.'
   },
   vault_get_project: {
     input: z.object({ id: idSchema }),

--- a/apps/desktop/src/main/database/queries/projects.test.ts
+++ b/apps/desktop/src/main/database/queries/projects.test.ts
@@ -30,9 +30,11 @@ import {
   getProjectWithStatuses,
   getProjectsWithStatuses,
   getProjectContents,
+  getProjectLinkCounts,
   insertProjectLink,
   getProjectLink,
-  setProjectLinkPinned
+  setProjectLinkPinned,
+  updateProjectHomeNote
 } from './projects'
 import { insertTask } from './tasks'
 import { noteMetadata } from '@memry/db-schema/schema/note-metadata'
@@ -522,6 +524,51 @@ describe('projects queries', () => {
         files: [],
         events: [],
         counts: { notes: 0, files: 0, events: 0 }
+      })
+    })
+
+    it('counts linked items for every project in one pass, skipping orphans', () => {
+      seedProjectWithLinks()
+      insertProject(db, {
+        id: 'p-other',
+        name: 'Other',
+        color: '#6366f1',
+        position: 1,
+        isInbox: false
+      })
+      insertProject(db, {
+        id: 'p-none',
+        name: 'None',
+        color: '#6366f1',
+        position: 2,
+        isInbox: false
+      })
+      seedNote('n2', 'Brief', 'markdown')
+      insertProjectLink(db, { id: 'l5', projectId: 'p-other', itemType: 'note', itemId: 'n2' })
+
+      const counts = getProjectLinkCounts(db)
+
+      expect(counts.get('p-hub')).toEqual({ notes: 1, files: 1, events: 1 })
+      expect(counts.get('p-other')).toEqual({ notes: 1, files: 0, events: 0 })
+      // A project with no links has no row at all — callers default to zero.
+      expect(counts.get('p-none')).toBeUndefined()
+    })
+
+    it('keeps the hub fields on the record read by id', () => {
+      insertProject(db, {
+        id: 'p-shape',
+        name: 'Shape',
+        color: '#6366f1',
+        position: 0,
+        isInbox: false,
+        icon: '🚀'
+      })
+      seedNote('n-home', 'Overview', 'markdown')
+      updateProjectHomeNote(db, 'p-shape', 'n-home')
+
+      expect(getProjectWithStatuses(db, 'p-shape')).toMatchObject({
+        icon: '🚀',
+        homeNoteId: 'n-home'
       })
     })
 

--- a/apps/desktop/src/main/database/queries/projects.ts
+++ b/apps/desktop/src/main/database/queries/projects.ts
@@ -737,6 +737,63 @@ export function getProjectContents(db: DataDb, projectId: string): ProjectConten
   }
 }
 
+export interface ProjectLinkCounts {
+  notes: number
+  files: number
+  events: number
+}
+
+/**
+ * Linked-item counts for every project in one pass, for callers that list
+ * projects and would otherwise run `getProjectContents` per row.
+ *
+ * Same inner joins and same `file_type` split as `getProjectContents`, for the
+ * same reason: a count that includes orphaned links would promise items the
+ * hub does not show. Projects with no links are absent from the map.
+ */
+export function getProjectLinkCounts(db: DataDb): Map<string, ProjectLinkCounts> {
+  const noteRows = db
+    .select({
+      projectId: projectLinks.projectId,
+      fileType: noteMetadata.fileType,
+      total: count()
+    })
+    .from(projectLinks)
+    .innerJoin(noteMetadata, eq(noteMetadata.id, projectLinks.itemId))
+    .where(inArray(projectLinks.itemType, ['note', 'file']))
+    .groupBy(projectLinks.projectId, noteMetadata.fileType)
+    .all()
+
+  const eventRows = db
+    .select({ projectId: projectLinks.projectId, total: count() })
+    .from(projectLinks)
+    .innerJoin(calendarEvents, eq(calendarEvents.id, projectLinks.itemId))
+    .where(eq(projectLinks.itemType, 'calendar_event'))
+    .groupBy(projectLinks.projectId)
+    .all()
+
+  const counts = new Map<string, ProjectLinkCounts>()
+  const entryFor = (projectId: string): ProjectLinkCounts => {
+    const existing = counts.get(projectId)
+    if (existing) return existing
+    const created = { notes: 0, files: 0, events: 0 }
+    counts.set(projectId, created)
+    return created
+  }
+
+  for (const row of noteRows) {
+    const entry = entryFor(row.projectId)
+    if (row.fileType === 'markdown') entry.notes += row.total
+    else entry.files += row.total
+  }
+
+  for (const row of eventRows) {
+    entryFor(row.projectId).events += row.total
+  }
+
+  return counts
+}
+
 /**
  * Set (or clear) a project's home note.
  */

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -261,42 +261,6 @@ calendar, graph, and spatial canvas — so an agent can tell whether an action i
 before suggesting it, and `settings.setFeaturesSettings` toggles them. `settings.getInboxSettings`
 and `settings.setInboxSettings` cover the daily inbox review reminder.
 
-## Project Links
-
-`vault_list_projects` returns each project's `icon`, `home_note_id`, and `linked_counts` (notes,
-files, events) alongside `task_count`. Nonzero `linked_counts` are the signal that a project has a
-hub link layer worth reading; `task_count` alone says nothing about it.
-
-The hub's link layer is reachable through the desktop bridge. Reads, via `vault_desktop_read`:
-
-| Operation                   | Args                 | Answers                                          |
-| --------------------------- | -------------------- | ------------------------------------------------ |
-| `tasks.listProjectContents` | `[projectId]`        | Which notes, files, and events a project holds   |
-| `tasks.listProjectLinks`    | `[projectId]`        | The raw link rows, including pin state           |
-| `tasks.listForItem`         | `[itemType, itemId]` | Which projects a note, file, or event belongs to |
-
-`itemType` is one of `note`, `file`, or `calendar_event`.
-
-Writes, via `vault_desktop_write`, behind the same approval flow as other writes:
-
-| Operation                    | Args                                |
-| ---------------------------- | ----------------------------------- |
-| `tasks.linkProjectItem`      | `[{ projectId, itemType, itemId }]` |
-| `tasks.unlinkProjectItem`    | `[{ projectId, itemType, itemId }]` |
-| `tasks.setProjectLinkPinned` | `[{ projectId, itemId, pinned }]`   |
-| `tasks.setProjectHomeNote`   | `[{ projectId, noteId }]`           |
-| `tasks.captureUrlToProject`  | `[{ projectId, url }]`              |
-| `tasks.importFilesToProject` | `[{ projectId, sourcePaths }]`      |
-
-`captureUrlToProject` fetches the page title over the network, and `importFilesToProject` copies
-files from paths you supply into the vault — both on caller-supplied input, like the already
-available `inbox.captureLink` and `notes.importFiles`. Operations that open native UI or hand an
-item to the OS stay out of the allowlist.
-
-`importFilesToProject` waits for the indexer to assign an id to each imported file, so importing
-several large files at once can exceed the bridge's ten-second window. The import still completes;
-the tool call reports a timeout. Import in smaller batches to see the result.
-
 Calendar desktop reads accept the same single-object shape as the renderer bridge. For example:
 `calendar.listEvents` accepts `args: [{}]`, and `calendar.getRange` accepts either
 `args: ["2026-05-14", "2026-06-14"]` or
@@ -324,6 +288,45 @@ approval controls inside the tool row. You can allow the request once, allow cre
 that conversation, deny it, or edit the arguments before allowing. Note updates load a before/after
 diff before the write is applied. Unauthenticated or context-free write requests continue to be
 denied.
+
+## Project Links
+
+`vault_list_projects` returns each project's `icon`, `home_note_id`, and `linked_counts` (notes,
+files, events) alongside `task_count`. Nonzero `linked_counts` are the signal that a project has a
+hub link layer worth reading; `task_count` alone says nothing about it.
+
+The hub's link layer is reachable through the desktop bridge. Reads, via `vault_desktop_read`:
+
+| Operation                   | Args                 | Answers                                          |
+| --------------------------- | -------------------- | ------------------------------------------------ |
+| `tasks.listProjectContents` | `[projectId]`        | Which notes, files, and events a project holds    |
+| `tasks.listProjectLinks`    | `[projectId]`        | The raw link rows, including pin state            |
+| `tasks.listForItem`         | `[itemType, itemId]` | Which projects a note, file, or event belongs to  |
+
+`itemType` is one of `note`, `file`, or `calendar_event`.
+
+Writes, via `vault_desktop_write`, behind the same approval flow as other writes:
+
+| Operation                    | Args                                |
+| ---------------------------- | ----------------------------------- |
+| `tasks.linkProjectItem`      | `[{ projectId, itemType, itemId }]` |
+| `tasks.unlinkProjectItem`    | `[{ projectId, itemType, itemId }]` |
+| `tasks.setProjectLinkPinned` | `[{ projectId, itemId, pinned }]`   |
+| `tasks.setProjectHomeNote`   | `[{ projectId, noteId }]`           |
+| `tasks.captureUrlToProject`  | `[{ projectId, url }]`              |
+| `tasks.importFilesToProject` | `[{ projectId, sourcePaths }]`      |
+
+`setProjectHomeNote` takes `noteId: null` to clear the project's home note, the same way the hub's
+own overview rail does.
+
+`captureUrlToProject` fetches the page title over the network, and `importFilesToProject` copies
+files from paths you supply into the vault — both on caller-supplied input, like the already
+available `inbox.captureLink` and `notes.importFiles`. Operations that open native UI or hand an
+item to the OS stay out of the allowlist.
+
+`importFilesToProject` waits for the indexer to assign an id to each imported file, so importing
+several large files at once can exceed the bridge's ten-second window. The import still completes;
+the tool call reports a timeout. Import in smaller batches to see the result.
 
 ## Current Note
 

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -244,12 +244,12 @@ auto-accepted or shown for inline approval depending on the Agent Permissions se
 `vault_desktop_read` and `vault_desktop_write` cover the remaining desktop CRUD surface through an
 allowlisted desktop API operation name plus an `args` array. They are used for desktop domains such
 as templates, saved filters, bookmarks, reminders, calendar events, folder views, properties, tags,
-search reasons, inbox conversions, and settings. The write bridge uses the same in-app approval flow
-as named write tools. Security-sensitive and system operations stay outside the allowlist, including
-account/auth flows, provider connect/disconnect/refresh actions, app updater actions, external
-open/reveal actions, import dialogs, OS settings panes, telemetry, feedback and diagnostics
-reporting, and raw secret writes. Unsupported or unavailable desktop API operations return a
-structured MCP error instead of falling back to an arbitrary desktop call.
+search reasons, inbox conversions, project links, and settings. The write bridge uses the same in-app
+approval flow as named write tools. Security-sensitive and system operations stay outside the
+allowlist, including account/auth flows, provider connect/disconnect/refresh actions, app updater
+actions, external open/reveal actions, import dialogs, OS settings panes, telemetry, feedback and
+diagnostics reporting, and raw secret writes. Unsupported or unavailable desktop API operations
+return a structured MCP error instead of falling back to an arbitrary desktop call.
 
 Inbox items convert through the bridge into any of the four targets the app itself offers:
 `inbox.convertToNote`, `inbox.convertToTask`, `inbox.convertToEvent`, and
@@ -260,6 +260,42 @@ through `templates.get` to an existing note.
 calendar, graph, and spatial canvas — so an agent can tell whether an action is even available
 before suggesting it, and `settings.setFeaturesSettings` toggles them. `settings.getInboxSettings`
 and `settings.setInboxSettings` cover the daily inbox review reminder.
+
+## Project Links
+
+`vault_list_projects` returns each project's `icon`, `home_note_id`, and `linked_counts` (notes,
+files, events) alongside `task_count`. Nonzero `linked_counts` are the signal that a project has a
+hub link layer worth reading; `task_count` alone says nothing about it.
+
+The hub's link layer is reachable through the desktop bridge. Reads, via `vault_desktop_read`:
+
+| Operation                   | Args                 | Answers                                          |
+| --------------------------- | -------------------- | ------------------------------------------------ |
+| `tasks.listProjectContents` | `[projectId]`        | Which notes, files, and events a project holds   |
+| `tasks.listProjectLinks`    | `[projectId]`        | The raw link rows, including pin state           |
+| `tasks.listForItem`         | `[itemType, itemId]` | Which projects a note, file, or event belongs to |
+
+`itemType` is one of `note`, `file`, or `calendar_event`.
+
+Writes, via `vault_desktop_write`, behind the same approval flow as other writes:
+
+| Operation                    | Args                                |
+| ---------------------------- | ----------------------------------- |
+| `tasks.linkProjectItem`      | `[{ projectId, itemType, itemId }]` |
+| `tasks.unlinkProjectItem`    | `[{ projectId, itemType, itemId }]` |
+| `tasks.setProjectLinkPinned` | `[{ projectId, itemId, pinned }]`   |
+| `tasks.setProjectHomeNote`   | `[{ projectId, noteId }]`           |
+| `tasks.captureUrlToProject`  | `[{ projectId, url }]`              |
+| `tasks.importFilesToProject` | `[{ projectId, sourcePaths }]`      |
+
+`captureUrlToProject` fetches the page title over the network, and `importFilesToProject` copies
+files from paths you supply into the vault — both on caller-supplied input, like the already
+available `inbox.captureLink` and `notes.importFiles`. Operations that open native UI or hand an
+item to the OS stay out of the allowlist.
+
+`importFilesToProject` waits for the indexer to assign an id to each imported file, so importing
+several large files at once can exceed the bridge's ten-second window. The import still completes;
+the tool call reports a timeout. Import in smaller batches to see the result.
 
 Calendar desktop reads accept the same single-object shape as the renderer bridge. For example:
 `calendar.listEvents` accepts `args: [{}]`, and `calendar.getRange` accepts either

--- a/packages/contracts/src/agent-mcp-channels.test.ts
+++ b/packages/contracts/src/agent-mcp-channels.test.ts
@@ -16,9 +16,29 @@ const googleIntegrationOperations = [
   'settings.setCalendarGoogleSettings'
 ] as const
 
+// The Projects hub added a project↔item link layer. Agents get the same reads
+// and writes the hub itself uses, so "what is linked to project X" and "what
+// projects is note Y in" are answerable without a desktop-only detour.
+const projectHubReadOperations = [
+  'tasks.listProjectLinks',
+  'tasks.listProjectContents',
+  'tasks.listForItem'
+] as const
+
+const projectHubWriteOperations = [
+  'tasks.linkProjectItem',
+  'tasks.unlinkProjectItem',
+  'tasks.setProjectLinkPinned',
+  'tasks.setProjectHomeNote',
+  'tasks.captureUrlToProject',
+  'tasks.importFilesToProject'
+] as const
+
 // Deliberately excluded from both allowlists: reporting pipelines the agent has
 // no business driving, and shell/UI operations whose effect happens outside the
-// vault where the agent cannot observe or undo it.
+// vault where the agent cannot observe or undo it. Reaching the network or the
+// filesystem is not itself the line — `inbox.captureLink`,
+// `notes.importFiles`, and `tasks.captureUrlToProject` are all allowlisted.
 const deliberatelyExcludedOperations = [
   'telemetry.track',
   'telemetry.flush',
@@ -72,6 +92,20 @@ describe('agent MCP desktop operation allowlists', () => {
   it('gives inbox settings the same get/set pair as every other settings group', () => {
     expect(AgentMcpDesktopReadOperations).toContain('settings.getInboxSettings')
     expect(AgentMcpDesktopWriteOperations).toContain('settings.setInboxSettings')
+  })
+
+  it('exposes the project hub link layer as reads', () => {
+    for (const operation of projectHubReadOperations) {
+      expect(AgentMcpDesktopReadOperations).toContain(operation)
+      expect(AgentMcpDesktopWriteOperations).not.toContain(operation)
+    }
+  })
+
+  it('exposes the project hub mutations as writes', () => {
+    for (const operation of projectHubWriteOperations) {
+      expect(AgentMcpDesktopWriteOperations).toContain(operation)
+      expect(AgentMcpDesktopReadOperations).not.toContain(operation)
+    }
   })
 
   it('excludes telemetry, feedback, diagnostics, and shell operations', () => {

--- a/packages/contracts/src/agent-mcp-channels.ts
+++ b/packages/contracts/src/agent-mcp-channels.ts
@@ -42,6 +42,9 @@ export const AgentMcpDesktopReadOperations = [
   'tasks.getUpcoming',
   'tasks.getOverdue',
   'tasks.getLinkedTasks',
+  'tasks.listProjectLinks',
+  'tasks.listProjectContents',
+  'tasks.listForItem',
   'inbox.get',
   'inbox.list',
   'inbox.previewLink',
@@ -172,6 +175,16 @@ export const AgentMcpDesktopWriteOperations = [
   'tasks.deleteProject',
   'tasks.archiveProject',
   'tasks.reorderProjects',
+  'tasks.linkProjectItem',
+  'tasks.unlinkProjectItem',
+  'tasks.setProjectLinkPinned',
+  'tasks.setProjectHomeNote',
+  // These two reach the network and the filesystem, but on caller-supplied
+  // input only — the same footing as the allowlisted `inbox.captureLink` and
+  // `notes.importFiles`. What stays out is opening native UI or handing an
+  // item to the OS (`notes.showImportDialog`, `openExternal`, `revealInFinder`).
+  'tasks.captureUrlToProject',
+  'tasks.importFilesToProject',
   'tasks.createStatus',
   'tasks.updateStatus',
   'tasks.deleteStatus',

--- a/packages/contracts/src/agent-mcp-channels.ts
+++ b/packages/contracts/src/agent-mcp-channels.ts
@@ -182,7 +182,8 @@ export const AgentMcpDesktopWriteOperations = [
   // These two reach the network and the filesystem, but on caller-supplied
   // input only — the same footing as the allowlisted `inbox.captureLink` and
   // `notes.importFiles`. What stays out is opening native UI or handing an
-  // item to the OS (`notes.showImportDialog`, `openExternal`, `revealInFinder`).
+  // item to the OS (`notes.showImportDialog`, `notes.openExternal`,
+  // `notes.revealInFinder`).
   'tasks.captureUrlToProject',
   'tasks.importFilesToProject',
   'tasks.createStatus',


### PR DESCRIPTION
## What

- Allowlists the project↔item link layer: 3 reads (`listProjectLinks`, `listProjectContents`, `listForItem`) and 6 writes (`link`/`unlinkProjectItem`, `setProjectLinkPinned`, `setProjectHomeNote`, `captureUrlToProject`, `importFilesToProject`).
- Extends `ProjectSummary` with `icon`, `home_note_id`, and `linked_counts`, sourced from one new aggregate rather than a `getProjectContents` call per row.
- Documents the bridge operations and their arg shapes in `agent-mcp.md`.

## Why

The Projects hub (#812, #905) shipped a whole link layer that never reached MCP, so an agent could not answer "what is linked to project X" or "what projects is note Y in", and `vault_list_projects` gave no signal that a project held anything but tasks.

Closes #917

## Notes

The two open questions in the issue resolved against existing precedent rather than preference:

- `captureUrlToProject` / `importFilesToProject` are in. The allowlist's exclusion line is not "reaches the network or disk" — `inbox.captureLink` and `notes.importFiles` are already allowlisted. It is "opens native UI or hands an item to the OS", which is why `showImportDialog` / `openExternal` / `revealInFinder` stay out. A test now pins that line.
- `vault_get_project` needed no change: it returns `ProjectWithStatuses extends Project`, which already carried `icon` and `homeNoteId`. Verified with a real-DB test rather than assumed.

Known and documented, not fixed here: `importFilesToProject` waits on the indexer up to 5s per file against the bridge's 10s window, so a multi-file import can report a timeout while still completing.