### PR TITLE
feat(calendar): gate agent access to Google Calendar events on user consent

### DIFF
--- a/apps/desktop/src/main/calendar/google/onboarding.test.ts
+++ b/apps/desktop/src/main/calendar/google/onboarding.test.ts
@@ -128,7 +128,8 @@ describe('setDefaultGoogleCalendar (M2)', () => {
       defaultTargetCalendarId: 'primary@group.calendar.google.com',
       onboardingCompleted: true,
       promoteConfirmDismissed: false,
-      pushEventsToGoogle: true
+      pushEventsToGoogle: true,
+      agentReadEventsConsent: null
     })
   })
 

--- a/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
+++ b/apps/desktop/src/main/ipc/generated-ipc-invoke-map.ts
@@ -256,7 +256,7 @@ export interface MainIpcInvokeHandlers {
   "settings:getAIModelStatus": (...args: []) => Awaited<Promise<import("./settings-handlers").AIModelStatus>>
   "settings:getAISettings": (...args: []) => Awaited<import("./settings-handlers").AISettings>
   "settings:getBackupSettings": (...args: []) => Awaited<{ autoBackup: boolean; frequencyHours: 1 | 6 | 12 | 24; maxBackups: number; lastBackupAt: string | null; }>
-  "settings:getCalendarGoogleSettings": (...args: []) => Awaited<{ defaultTargetCalendarId: string | null; onboardingCompleted: boolean; promoteConfirmDismissed: boolean; pushEventsToGoogle: boolean; }>
+  "settings:getCalendarGoogleSettings": (...args: []) => Awaited<{ defaultTargetCalendarId: string | null; onboardingCompleted: boolean; promoteConfirmDismissed: boolean; pushEventsToGoogle: boolean; agentReadEventsConsent: boolean | null; }>
   "settings:getCalendarSettings": (...args: []) => Awaited<{ dayCellClickBehavior: "calendar" | "journal"; calendarPageClickOverride: "calendar" | "inherit" | "journal"; weekStartDay: "sunday" | "monday"; showNotesOnCalendar: boolean; }>
   "settings:getEditorSettings": (...args: []) => Awaited<{ width: string; toolbarMode: "floating" | "sticky"; spellCheck: boolean; }>
   "settings:getFeaturesSettings": (...args: []) => Awaited<{ home: boolean; inbox: boolean; journal: boolean; tasks: boolean; calendar: boolean; graph: boolean; spatialCanvas: boolean; }>
@@ -284,7 +284,7 @@ export interface MainIpcInvokeHandlers {
   "settings:set": (...args: [{ key: string; value: string; }]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
   "settings:setAISettings": (...args: [Partial<import("./settings-handlers").AISettings>]) => Awaited<{ success: boolean; error: string; } | { success: boolean; error?: undefined; }>
   "settings:setBackupSettings": (...args: [Partial<{ autoBackup: boolean; frequencyHours: 1 | 6 | 12 | 24; maxBackups: number; lastBackupAt: string | null; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
-  "settings:setCalendarGoogleSettings": (...args: [Partial<{ defaultTargetCalendarId: string | null; onboardingCompleted: boolean; promoteConfirmDismissed: boolean; pushEventsToGoogle: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
+  "settings:setCalendarGoogleSettings": (...args: [Partial<{ defaultTargetCalendarId: string | null; onboardingCompleted: boolean; promoteConfirmDismissed: boolean; pushEventsToGoogle: boolean; agentReadEventsConsent: boolean | null; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
   "settings:setCalendarSettings": (...args: [Partial<{ dayCellClickBehavior: "calendar" | "journal"; calendarPageClickOverride: "calendar" | "inherit" | "journal"; weekStartDay: "sunday" | "monday"; showNotesOnCalendar: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
   "settings:setEditorSettings": (...args: [Partial<{ width: "normal" | "full"; toolbarMode: "floating" | "sticky"; spellCheck: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>
   "settings:setFeaturesSettings": (...args: [Partial<{ home: boolean; inbox: boolean; journal: boolean; tasks: boolean; calendar: boolean; graph: boolean; spatialCanvas: boolean; }>]) => Awaited<{ success: boolean; error?: string | undefined; }>

--- a/apps/desktop/src/main/ipc/settings-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/settings-handlers.test.ts
@@ -999,7 +999,8 @@ describe('settings-handlers', () => {
         defaultTargetCalendarId: null,
         onboardingCompleted: false,
         promoteConfirmDismissed: false,
-        pushEventsToGoogle: true
+        pushEventsToGoogle: true,
+        agentReadEventsConsent: null
       })
     })
 
@@ -1023,7 +1024,8 @@ describe('settings-handlers', () => {
         defaultTargetCalendarId: 'primary@group.calendar.google.com',
         onboardingCompleted: true,
         promoteConfirmDismissed: false,
-        pushEventsToGoogle: true
+        pushEventsToGoogle: true,
+        agentReadEventsConsent: null
       })
     })
 
@@ -1044,7 +1046,8 @@ describe('settings-handlers', () => {
           defaultTargetCalendarId: 'work@group.calendar.google.com',
           onboardingCompleted: true,
           promoteConfirmDismissed: false,
-          pushEventsToGoogle: true
+          pushEventsToGoogle: true,
+          agentReadEventsConsent: null
         })
       )
     })

--- a/apps/desktop/src/renderer/src/agent-mcp/desktop-api-handler.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-mcp/desktop-api-handler.test.tsx
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AgentMcpDesktopApiChannel } from '@memry/contracts/agent-mcp-channels'
 
 const mocks = vi.hoisted(() => ({
-  logError: vi.fn()
+  logError: vi.fn(),
+  logWarn: vi.fn()
 }))
 
 vi.mock('@/lib/logger', () => ({
   createLogger: () => ({
-    error: mocks.logError
+    error: mocks.logError,
+    warn: mocks.logWarn
   })
 }))
 
@@ -24,6 +26,7 @@ describe('useAgentMcpDesktopApiResponder', () => {
   let calendarGetProviderStatus: ReturnType<typeof vi.fn>
   let calendarGetRange: ReturnType<typeof vi.fn>
   let calendarListEvents: ReturnType<typeof vi.fn>
+  let getCalendarGoogleSettings: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     onMainInvokeCallback = undefined
@@ -36,6 +39,9 @@ describe('useAgentMcpDesktopApiResponder', () => {
     calendarGetProviderStatus = vi.fn().mockResolvedValue({ connected: true })
     calendarGetRange = vi.fn().mockResolvedValue({ items: [] })
     calendarListEvents = vi.fn().mockResolvedValue({ events: [] })
+    // null = the user has not answered the agent-access prompt yet. Until they
+    // grant it, Google-synced events stay out of every agent read.
+    getCalendarGoogleSettings = vi.fn().mockResolvedValue({ agentReadEventsConsent: null })
     mocks.logError.mockReset()
     ;(window as Window & { api: unknown }).api = {
       onMainInvoke: vi.fn(
@@ -59,6 +65,9 @@ describe('useAgentMcpDesktopApiResponder', () => {
         getProviderStatus: calendarGetProviderStatus,
         getRange: calendarGetRange,
         listEvents: calendarListEvents
+      },
+      settings: {
+        getCalendarGoogleSettings
       }
     }
   })
@@ -171,12 +180,9 @@ describe('useAgentMcpDesktopApiResponder', () => {
     })
   })
 
-  it('forces native-only calendar range reads regardless of caller flags', async () => {
-    renderHook(() => useAgentMcpDesktopApiResponder())
-    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
-
+  async function invokeCalendarRange(requestId: string): Promise<void> {
     await onMainInvokeCallback?.({
-      requestId: 'request-calendar-range-datetime',
+      requestId,
       channel: AgentMcpDesktopApiChannel,
       payload: {
         operation: 'calendar.getRange',
@@ -190,6 +196,55 @@ describe('useAgentMcpDesktopApiResponder', () => {
         ]
       }
     })
+  }
+
+  it('keeps Google events out of range reads while consent is unanswered', async () => {
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await invokeCalendarRange('request-calendar-range-unanswered')
+
+    expect(calendarGetRange).toHaveBeenCalledWith({
+      startAt: '2026-05-14T09:00:00.000Z',
+      endAt: '2026-05-14T10:00:00.000Z',
+      includeExternal: false
+    })
+  })
+
+  it('keeps Google events out of range reads when consent is denied, ignoring caller flags', async () => {
+    getCalendarGoogleSettings.mockResolvedValue({ agentReadEventsConsent: false })
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await invokeCalendarRange('request-calendar-range-denied')
+
+    expect(calendarGetRange).toHaveBeenCalledWith({
+      startAt: '2026-05-14T09:00:00.000Z',
+      endAt: '2026-05-14T10:00:00.000Z',
+      includeExternal: false
+    })
+  })
+
+  it('includes Google events in range reads once the user grants consent', async () => {
+    getCalendarGoogleSettings.mockResolvedValue({ agentReadEventsConsent: true })
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await invokeCalendarRange('request-calendar-range-granted')
+
+    expect(calendarGetRange).toHaveBeenCalledWith({
+      startAt: '2026-05-14T09:00:00.000Z',
+      endAt: '2026-05-14T10:00:00.000Z',
+      includeExternal: true
+    })
+  })
+
+  it('falls back to excluding Google events when the consent lookup fails', async () => {
+    getCalendarGoogleSettings.mockRejectedValue(new Error('settings unavailable'))
+    renderHook(() => useAgentMcpDesktopApiResponder())
+    await waitFor(() => expect(window.api.onMainInvoke).toHaveBeenCalled())
+
+    await invokeCalendarRange('request-calendar-range-settings-error')
 
     expect(calendarGetRange).toHaveBeenCalledWith({
       startAt: '2026-05-14T09:00:00.000Z',

--- a/apps/desktop/src/renderer/src/agent-mcp/desktop-api-handler.ts
+++ b/apps/desktop/src/renderer/src/agent-mcp/desktop-api-handler.ts
@@ -30,14 +30,27 @@ function resolveDesktopApiOperation(operation: string): (...args: unknown[]) => 
   return target as (...args: unknown[]) => unknown
 }
 
-function normalizeDesktopApiArgs(operation: string, args: unknown[]): unknown[] {
+async function normalizeDesktopApiArgs(operation: string, args: unknown[]): Promise<unknown[]> {
   switch (operation) {
     case 'calendar.listEvents':
       return [normalizeCalendarListEventsInput(args)]
     case 'calendar.getRange':
-      return [normalizeCalendarRangeInput(args)]
+      return [await normalizeCalendarRangeInput(args)]
     default:
       return args
+  }
+}
+
+// Google Workspace Limited Use: Google-synced events are invisible to the agent
+// until the user explicitly opts in. Anything other than a stored `true` — not
+// asked yet, opted out, or a settings read that failed — stays native-only.
+async function hasAgentGoogleEventConsent(): Promise<boolean> {
+  try {
+    const settings = await window.api.settings.getCalendarGoogleSettings()
+    return settings.agentReadEventsConsent === true
+  } catch (error) {
+    log.warn('Calendar consent lookup failed; keeping agent reads native-only', error)
+    return false
   }
 }
 
@@ -45,7 +58,7 @@ function normalizeCalendarListEventsInput(args: unknown[]): JsonRecord {
   return objectArg(args[0]) ?? {}
 }
 
-function normalizeCalendarRangeInput(args: unknown[]): JsonRecord {
+async function normalizeCalendarRangeInput(args: unknown[]): Promise<JsonRecord> {
   const input =
     typeof args[0] === 'string' && typeof args[1] === 'string'
       ? { start: args[0], end: args[1] }
@@ -55,9 +68,9 @@ function normalizeCalendarRangeInput(args: unknown[]): JsonRecord {
   return {
     startAt: start ? normalizeCalendarRangeBound(start, 'start') : start,
     endAt: end ? normalizeCalendarRangeBound(end, 'end') : end,
-    // Google Workspace Limited Use: agent range reads must never include
-    // Google-synced external events, regardless of caller-supplied flags.
-    includeExternal: false
+    // Resolved from stored consent, never from the caller: an agent that asks
+    // for external events cannot talk its way past the user's answer.
+    includeExternal: await hasAgentGoogleEventConsent()
   }
 }
 
@@ -122,7 +135,8 @@ export function useAgentMcpDesktopApiResponder({
 
       try {
         const fn = resolveDesktopApiOperation(parsed.data.operation)
-        const data = await fn(...normalizeDesktopApiArgs(parsed.data.operation, parsed.data.args))
+        const args = await normalizeDesktopApiArgs(parsed.data.operation, parsed.data.args)
+        const data = await fn(...args)
         const response: AgentMcpDesktopApiResponse = { ok: true, data }
         window.api.respondToMainInvoke(requestId, response)
       } catch (error) {

--- a/apps/desktop/src/renderer/src/components/calendar/agent-access-consent-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/agent-access-consent-dialog.tsx
@@ -1,0 +1,78 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { useT } from '@memry/i18n/renderer'
+import { Button } from '@/components/ui/button'
+import { useAgentAccessConsent } from '@/hooks/use-agent-access-consent'
+import { cn } from '@/lib/utils'
+
+export interface AgentAccessConsentDialogProps {
+  /** Whether this vault has Google calendars imported. No connection, no question. */
+  hasImportedSources: boolean
+}
+
+/**
+ * Google Workspace Limited Use: asked once, the first time a user with a live
+ * Google Calendar connection opens the calendar. Both buttons are an answer —
+ * there is no dismiss, and Escape/outside clicks are suppressed, because an
+ * unanswered prompt is exactly what makes us ask again on the next visit.
+ *
+ * Owns its consent state instead of taking it as props: nothing else drives
+ * this dialog, and the calendar page is already at its line budget.
+ */
+export function AgentAccessConsentDialog({
+  hasImportedSources
+}: AgentAccessConsentDialogProps): React.JSX.Element | null {
+  const { t } = useT('calendar')
+  const { isPromptOpen, isSaving, error, decide } = useAgentAccessConsent(hasImportedSources)
+
+  if (!isPromptOpen) return null
+
+  return (
+    <DialogPrimitive.Root open>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm" />
+        <DialogPrimitive.Content
+          data-testid="agent-access-consent-dialog"
+          aria-label={t('agent-access-dialog.aria')}
+          onEscapeKeyDown={(event) => event.preventDefault()}
+          onPointerDownOutside={(event) => event.preventDefault()}
+          onInteractOutside={(event) => event.preventDefault()}
+          className={cn(
+            // start-1/2 flips to right:50% in RTL, so the centering translate has
+            // to flip with it — hence the rtl: override on translate-x.
+            'fixed start-1/2 top-1/2 z-50 w-[440px] -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2',
+            'rounded-md border bg-popover p-6 text-popover-foreground shadow-lg outline-none'
+          )}
+        >
+          <DialogPrimitive.Title className="mb-1 text-lg font-semibold">
+            {t('agent-access-dialog.title')}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="mb-2 text-sm text-muted-foreground">
+            {t('agent-access-dialog.body')}
+          </DialogPrimitive.Description>
+          <p className="text-xs/4 text-muted-foreground">{t('agent-access-dialog.footnote')}</p>
+
+          {error && (
+            <p role="alert" className="mt-3 text-xs text-destructive">
+              {error}
+            </p>
+          )}
+
+          <div className="mt-6 flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => void decide(false)}
+              disabled={isSaving}
+            >
+              {t('agent-access-dialog.deny')}
+            </Button>
+            <Button type="button" size="sm" onClick={() => void decide(true)} disabled={isSaving}>
+              {t('agent-access-dialog.allow')}
+            </Button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
@@ -355,6 +355,25 @@ describe('CalendarPage', () => {
       )
     })
 
+    it('#given the save fails with no reason #then the prompt stays open with the translated fallback', async () => {
+      const user = userEvent.setup()
+      mockConsent(null)
+      vi.mocked(window.api.settings.setCalendarGoogleSettings).mockResolvedValue({ success: false })
+
+      renderWithProviders(<CalendarPage />)
+
+      await waitFor(() =>
+        expect(screen.getByRole('heading', { name: PROMPT_TITLE })).toBeInTheDocument()
+      )
+      await user.click(screen.getByRole('button', { name: 'Allow' }))
+
+      // Never an empty string or a raw "undefined" leaking to the user.
+      await waitFor(() =>
+        expect(screen.getByRole('alert')).toHaveTextContent('Failed to save your choice')
+      )
+      expect(screen.getByRole('heading', { name: PROMPT_TITLE })).toBeInTheDocument()
+    })
+
     it('#when the user declines #then consent is stored as denied so we stop asking', async () => {
       const user = userEvent.setup()
       mockConsent(null)

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
@@ -294,6 +294,87 @@ describe('CalendarPage', () => {
     mockUseActiveTab.mockReturnValue(null)
   })
 
+  describe('AI access consent prompt', () => {
+    const PROMPT_TITLE = /Let AI read your Google Calendar events\?/i
+
+    function mockConsent(agentReadEventsConsent: boolean | null): void {
+      vi.mocked(window.api.settings.getCalendarGoogleSettings).mockResolvedValue({
+        defaultTargetCalendarId: null,
+        onboardingCompleted: true,
+        promoteConfirmDismissed: false,
+        pushEventsToGoogle: true,
+        agentReadEventsConsent
+      })
+    }
+
+    it('#given a Google connection and no answer yet #then the prompt opens on first calendar visit', async () => {
+      mockConsent(null)
+
+      renderWithProviders(<CalendarPage />)
+
+      await waitFor(() =>
+        expect(screen.getByRole('heading', { name: PROMPT_TITLE })).toBeInTheDocument()
+      )
+    })
+
+    it('#given no Google calendars imported #then the prompt stays closed', async () => {
+      mockConsent(null)
+      mockListSources.mockResolvedValue({ sources: [] })
+
+      renderWithProviders(<CalendarPage />)
+
+      await waitFor(() => expect(mockListSources).toHaveBeenCalled())
+      expect(screen.queryByRole('heading', { name: PROMPT_TITLE })).not.toBeInTheDocument()
+    })
+
+    it('#given the user already answered #then the prompt stays closed', async () => {
+      mockConsent(false)
+
+      renderWithProviders(<CalendarPage />)
+
+      await waitFor(() => expect(window.api.settings.getCalendarGoogleSettings).toHaveBeenCalled())
+      expect(screen.queryByRole('heading', { name: PROMPT_TITLE })).not.toBeInTheDocument()
+    })
+
+    it('#when the user allows #then consent is stored as granted and the prompt closes', async () => {
+      const user = userEvent.setup()
+      mockConsent(null)
+
+      renderWithProviders(<CalendarPage />)
+
+      await waitFor(() =>
+        expect(screen.getByRole('heading', { name: PROMPT_TITLE })).toBeInTheDocument()
+      )
+      await user.click(screen.getByRole('button', { name: 'Allow' }))
+
+      expect(window.api.settings.setCalendarGoogleSettings).toHaveBeenCalledWith({
+        agentReadEventsConsent: true
+      })
+      await waitFor(() =>
+        expect(screen.queryByRole('heading', { name: PROMPT_TITLE })).not.toBeInTheDocument()
+      )
+    })
+
+    it('#when the user declines #then consent is stored as denied so we stop asking', async () => {
+      const user = userEvent.setup()
+      mockConsent(null)
+
+      renderWithProviders(<CalendarPage />)
+
+      await waitFor(() =>
+        expect(screen.getByRole('heading', { name: PROMPT_TITLE })).toBeInTheDocument()
+      )
+      await user.click(screen.getByRole('button', { name: "Don't allow" }))
+
+      expect(window.api.settings.setCalendarGoogleSettings).toHaveBeenCalledWith({
+        agentReadEventsConsent: false
+      })
+      await waitFor(() =>
+        expect(screen.queryByRole('heading', { name: PROMPT_TITLE })).not.toBeInTheDocument()
+      )
+    })
+  })
+
   it('switches between day, week, month, and year views', async () => {
     const user = userEvent.setup()
     renderWithProviders(<CalendarPage />)

--- a/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.test.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.test.tsx
@@ -275,6 +275,102 @@ describe('Google Calendar integration row', () => {
     expect(mockDisconnectGoogleCalendarProvider).toHaveBeenCalledTimes(1)
   })
 
+  const AGENT_ACCESS_LABEL = 'Let AI read Google Calendar events'
+
+  it('#given no Google connection #then the AI access switch is not offered', async () => {
+    mockGetGoogleCalendarStatus.mockResolvedValue(DISCONNECTED_STATUS)
+    mockListSources.mockResolvedValue({ sources: [] })
+
+    renderIntegrationList()
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument())
+    expect(screen.queryByRole('switch', { name: AGENT_ACCESS_LABEL })).not.toBeInTheDocument()
+  })
+
+  it('#given consent was granted #then the AI access switch reads as on', async () => {
+    mockGetGoogleCalendarStatus.mockResolvedValue(CONNECTED_STATUS)
+    mockListSources.mockResolvedValue({ sources: CONNECTED_SOURCES })
+    vi.mocked(window.api.settings.getCalendarGoogleSettings).mockResolvedValue({
+      defaultTargetCalendarId: null,
+      onboardingCompleted: true,
+      promoteConfirmDismissed: false,
+      pushEventsToGoogle: true,
+      agentReadEventsConsent: true
+    })
+
+    renderIntegrationList()
+
+    await waitFor(() =>
+      expect(screen.getByRole('switch', { name: AGENT_ACCESS_LABEL })).toBeChecked()
+    )
+  })
+
+  it('#given consent is unanswered #then the AI access switch reads as off', async () => {
+    mockGetGoogleCalendarStatus.mockResolvedValue(CONNECTED_STATUS)
+    mockListSources.mockResolvedValue({ sources: CONNECTED_SOURCES })
+    vi.mocked(window.api.settings.getCalendarGoogleSettings).mockResolvedValue({
+      defaultTargetCalendarId: null,
+      onboardingCompleted: true,
+      promoteConfirmDismissed: false,
+      pushEventsToGoogle: true,
+      agentReadEventsConsent: null
+    })
+
+    renderIntegrationList()
+
+    await waitFor(() =>
+      expect(screen.getByRole('switch', { name: AGENT_ACCESS_LABEL })).not.toBeChecked()
+    )
+  })
+
+  it('#when the user grants AI access from Settings #then the answer is persisted', async () => {
+    const user = userEvent.setup()
+    mockGetGoogleCalendarStatus.mockResolvedValue(CONNECTED_STATUS)
+    mockListSources.mockResolvedValue({ sources: CONNECTED_SOURCES })
+    vi.mocked(window.api.settings.getCalendarGoogleSettings).mockResolvedValue({
+      defaultTargetCalendarId: null,
+      onboardingCompleted: true,
+      promoteConfirmDismissed: false,
+      pushEventsToGoogle: true,
+      agentReadEventsConsent: null
+    })
+
+    renderIntegrationList()
+
+    await waitFor(() =>
+      expect(screen.getByRole('switch', { name: AGENT_ACCESS_LABEL })).toBeInTheDocument()
+    )
+    await user.click(screen.getByRole('switch', { name: AGENT_ACCESS_LABEL }))
+
+    expect(window.api.settings.setCalendarGoogleSettings).toHaveBeenCalledWith({
+      agentReadEventsConsent: true
+    })
+  })
+
+  it('#when the user revokes AI access from Settings #then the answer is persisted', async () => {
+    const user = userEvent.setup()
+    mockGetGoogleCalendarStatus.mockResolvedValue(CONNECTED_STATUS)
+    mockListSources.mockResolvedValue({ sources: CONNECTED_SOURCES })
+    vi.mocked(window.api.settings.getCalendarGoogleSettings).mockResolvedValue({
+      defaultTargetCalendarId: null,
+      onboardingCompleted: true,
+      promoteConfirmDismissed: false,
+      pushEventsToGoogle: true,
+      agentReadEventsConsent: true
+    })
+
+    renderIntegrationList()
+
+    await waitFor(() =>
+      expect(screen.getByRole('switch', { name: AGENT_ACCESS_LABEL })).toBeChecked()
+    )
+    await user.click(screen.getByRole('switch', { name: AGENT_ACCESS_LABEL }))
+
+    expect(window.api.settings.setCalendarGoogleSettings).toHaveBeenCalledWith({
+      agentReadEventsConsent: false
+    })
+  })
+
   it('#given an existing Google connection + onboardingCompleted=false #when the row mounts #then the onboarding dialog opens automatically (M2 review fix)', async () => {
     mockGetGoogleCalendarStatus.mockResolvedValue(CONNECTED_STATUS)
     mockListSources.mockResolvedValue({ sources: CONNECTED_SOURCES })

--- a/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/google-calendar-integration-row.tsx
@@ -134,6 +134,21 @@ export function GoogleCalendarIntegrationRow(): React.JSX.Element {
     }
   })
 
+  const agentAccessMutation = useMutation({
+    mutationFn: async (agentReadEventsConsent: boolean) => {
+      const result = await window.api.settings.setCalendarGoogleSettings({
+        agentReadEventsConsent
+      })
+      if (!result.success) {
+        throw new Error(result.error ?? t('integrations.googleCalendar.agentAccess.error'))
+      }
+      return result
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: GOOGLE_SETTINGS_QUERY_KEY })
+    }
+  })
+
   // Re-open onboarding for users who connected before M2 shipped OR who
   // closed the dialog last time without picking a default. Single auto-open
   // per mount via the ref above; settings.onboardingCompleted flips to true
@@ -160,6 +175,8 @@ export function GoogleCalendarIntegrationRow(): React.JSX.Element {
   )
   const status = statusData
   const pushEventsToGoogle = googleSettingsData?.pushEventsToGoogle ?? true
+  // Only an explicit grant counts. Unanswered (null) and revoked both read as off.
+  const agentReadEventsConsent = googleSettingsData?.agentReadEventsConsent === true
   const reconnectRequired = Boolean(
     status?.accounts?.some((account) => account.status === 'reconnect_required')
   )
@@ -336,6 +353,23 @@ export function GoogleCalendarIntegrationRow(): React.JSX.Element {
               disabled={pushSettingMutation.isPending || googleSettingsIsLoading}
               onCheckedChange={(checked) => pushSettingMutation.mutate(checked)}
               aria-label={t('integrations.googleCalendar.pushToGoogle.label')}
+            />
+          </div>
+
+          <div className="mt-1 flex items-start justify-between gap-3 border-t border-border/60 pt-3">
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <span className="text-[13px]/4 font-medium text-foreground">
+                {t('integrations.googleCalendar.agentAccess.label')}
+              </span>
+              <p className="text-xs/4 text-muted-foreground">
+                {t('integrations.googleCalendar.agentAccess.description')}
+              </p>
+            </div>
+            <Switch
+              checked={agentReadEventsConsent}
+              disabled={agentAccessMutation.isPending || googleSettingsIsLoading}
+              onCheckedChange={(checked) => agentAccessMutation.mutate(checked)}
+              aria-label={t('integrations.googleCalendar.agentAccess.label')}
             />
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/hooks/use-agent-access-consent.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-agent-access-consent.ts
@@ -55,7 +55,9 @@ export function useAgentAccessConsent(hasImportedSources: boolean): AgentAccessC
       const result = await window.api.settings.setCalendarGoogleSettings({
         agentReadEventsConsent: granted
       })
-      if (!result.success) throw new Error(result.error ?? undefined)
+      // No message when the IPC gave no reason: extractErrorMessage falls back to
+      // the translated string rather than surfacing an empty or raw error.
+      if (!result.success) throw new Error(result.error)
       setIsPromptOpen(false)
     } catch (cause) {
       const t = getI18n().getFixedT(null, 'calendar')

--- a/apps/desktop/src/renderer/src/hooks/use-agent-access-consent.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-agent-access-consent.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react'
+import { getI18n } from 'react-i18next'
+
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('AgentAccessConsent')
+
+export interface AgentAccessConsentState {
+  isPromptOpen: boolean
+  isSaving: boolean
+  error: string | null
+  decide: (granted: boolean) => Promise<void>
+}
+
+/**
+ * Google Workspace Limited Use: asks once, the first time someone with imported
+ * Google calendars opens the calendar, whether the agent may read those events.
+ *
+ * Only a stored answer closes the question — `null` means "not asked yet", which
+ * the agent read path treats as a no. That is why declining stores `false`
+ * rather than just dismissing: a dismissal would ask again on the next visit.
+ */
+export function useAgentAccessConsent(hasImportedSources: boolean): AgentAccessConsentState {
+  const [isPromptOpen, setIsPromptOpen] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const checkedRef = useRef(false)
+
+  useEffect(() => {
+    if (checkedRef.current) return
+    if (!hasImportedSources) return
+    checkedRef.current = true
+
+    let cancelled = false
+    void window.api.settings
+      .getCalendarGoogleSettings()
+      .then((settings) => {
+        if (cancelled) return
+        if (settings.agentReadEventsConsent === null) setIsPromptOpen(true)
+      })
+      .catch((cause) => {
+        log.error('Failed to read Google Calendar agent access setting', cause)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [hasImportedSources])
+
+  const decide = async (granted: boolean): Promise<void> => {
+    setIsSaving(true)
+    setError(null)
+    try {
+      const result = await window.api.settings.setCalendarGoogleSettings({
+        agentReadEventsConsent: granted
+      })
+      if (!result.success) throw new Error(result.error ?? undefined)
+      setIsPromptOpen(false)
+    } catch (cause) {
+      const t = getI18n().getFixedT(null, 'calendar')
+      setError(extractErrorMessage(cause, t('agent-access-dialog.save-error')))
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return { isPromptOpen, isSaving, error, decide }
+}

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -7,6 +7,7 @@ import {
   type CalendarWorkspaceView
 } from '@/components/calendar'
 import { VISUAL_TYPE_ORDER } from '@/components/calendar/visual-type-meta'
+import { AgentAccessConsentDialog } from '@/components/calendar/agent-access-consent-dialog'
 import { PromoteExternalDialog } from '@/components/calendar/promote-external-dialog'
 import { CalendarTaskPopover } from '@/components/calendar/calendar-task-popover'
 import {
@@ -761,6 +762,8 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
 
   return (
     <>
+      <AgentAccessConsentDialog hasImportedSources={importedSources.length > 0} />
+
       <PromoteExternalDialog
         open={pendingPromote !== null}
         isWorking={isPromoting}

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -266,12 +266,17 @@ Calendar desktop reads accept the same single-object shape as the renderer bridg
 `args: ["2026-05-14", "2026-06-14"]` or
 `args: [{"startAt": "2026-05-14T00:00:00.000Z", "endAt": "2026-06-15T00:00:00.000Z"}]`.
 
-Agent calendar access covers native memrynote events only. Google-integration operations —
-calendar sources, provider status, Google calendar lists, promoting external events, and Google
-calendar settings — are excluded from the agent allowlists, and `calendar.getRange` always runs
-with Google-synced external events filtered out. Data obtained from Google APIs is never included
-in agent tool results or forwarded to any AI backend, in line with the Google API Services User
-Data Policy (Limited Use).
+Google-integration operations — calendar sources, provider status, Google calendar lists, promoting
+external events, and Google calendar settings — are excluded from the agent allowlists outright.
+
+Google-synced events themselves are gated on explicit user consent. `calendar.getRange` resolves
+`includeExternal` from the stored answer to the **Let AI read Google Calendar events** setting, never
+from the caller: an agent that passes `includeExternal: true` still gets native-only results unless
+the user granted access. Not asked yet, declined, or a settings read that failed all resolve to
+native-only. See [Calendar → Google Data and AI Features](/user-guide/calendar#google-data-and-ai-features).
+
+Google user data is never used to train or improve AI models, in line with the Google API Services
+User Data Policy (Limited Use).
 
 By default, Agent Chat accepts these tool calls automatically. The chat still shows each requested
 tool as compact, subdued text with a readable label such as `Reading note` or `Creating task`.

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -131,10 +131,24 @@ Right-click an external event → **Promote to vault** to copy it into your encr
 
 ### Google Data and AI Features
 
-Events synced from Google Calendar are never shared with AI features. The Agent Chat assistant can
-only read events you created in memrynote — Google-synced events, calendar lists, and connection
-details are excluded from what it can access, and Google user data is never used to train or
+AI access to your Google Calendar events is off until you turn it on. The first time you open the
+calendar with Google calendars imported, memrynote asks once: **Let AI read your Google Calendar
+events?** Both answers are recorded, so you are asked only that one time.
+
+- **Don't allow** (also the default until you answer) — the Agent Chat assistant reads only events
+  you created in memrynote. Ask it about a Google event and it gets nothing back.
+- **Allow** — the assistant can read events from your imported Google calendars.
+
+Change your answer any time at [Settings → Integrations](/user-guide/settings#integrations) →
+Google Calendar → **Let AI read Google Calendar events**. Turning it off takes effect on the next
+question you ask; turning it on likewise applies from that point forward.
+
+Either way you keep seeing your Google events in the calendar, calendar lists and connection
+details stay out of what the assistant can access, and Google user data is never used to train or
 improve AI models.
+
+Note that promoting an external event (above) copies it into your vault as a memrynote event. From
+then on it is your own event, and the assistant can read it regardless of this setting.
 
 ## Day Cell Click Behavior
 

--- a/packages/contracts/src/settings-schemas.test.ts
+++ b/packages/contracts/src/settings-schemas.test.ts
@@ -711,6 +711,44 @@ describe('CalendarGoogleSettingsSchema (M2)', () => {
     expect(promoteConfirmDismissed).toBe(false)
   })
 
+  it('leaves agent access unanswered on a fresh install', () => {
+    // #given — the default payload
+    // #then — null means "we have not asked yet", which reads as denied everywhere
+    expect(CALENDAR_GOOGLE_SETTINGS_DEFAULTS.agentReadEventsConsent).toBeNull()
+  })
+
+  it('reads settings written before agent access shipped as unanswered', () => {
+    // #given — a payload from an older install, with no agentReadEventsConsent key
+    const result = CalendarGoogleSettingsSchema.safeParse({
+      defaultTargetCalendarId: null,
+      onboardingCompleted: true,
+      promoteConfirmDismissed: true,
+      pushEventsToGoogle: true
+    })
+
+    // #then — it parses, and the user counts as not yet asked (so: no agent access)
+    expect(result.success).toBe(true)
+    expect(result.success && result.data.agentReadEventsConsent).toBeNull()
+  })
+
+  it('accepts an explicit agent access answer in both directions', () => {
+    for (const agentReadEventsConsent of [true, false, null]) {
+      const result = CalendarGoogleSettingsSchema.safeParse({
+        ...CALENDAR_GOOGLE_SETTINGS_DEFAULTS,
+        agentReadEventsConsent
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects a non-boolean agent access answer', () => {
+    const result = CalendarGoogleSettingsSchema.safeParse({
+      ...CALENDAR_GOOGLE_SETTINGS_DEFAULTS,
+      agentReadEventsConsent: 'yes'
+    })
+    expect(result.success).toBe(false)
+  })
+
   it('accepts a user who picked a default calendar during onboarding', () => {
     const result = CalendarGoogleSettingsSchema.safeParse({
       defaultTargetCalendarId: 'primary@group.calendar.google.com',

--- a/packages/contracts/src/settings-schemas.ts
+++ b/packages/contracts/src/settings-schemas.ts
@@ -199,7 +199,13 @@ export const CalendarGoogleSettingsSchema = z.object({
   promoteConfirmDismissed: z.boolean(),
   // false = one-way (inbound-only): pull Google events into memrynote but never
   // push memrynote events out to Google.
-  pushEventsToGoogle: z.boolean()
+  pushEventsToGoogle: z.boolean(),
+  // Google Workspace Limited Use: whether the AI agent may read Google-synced
+  // calendar events. null = the user has not been asked yet; anything other
+  // than an explicit true keeps Google events out of every agent read.
+  // Defaulted, not required: settings written before this shipped have no such
+  // key, and those installs must land on "not asked" rather than fail to parse.
+  agentReadEventsConsent: z.boolean().nullable().default(null)
 })
 
 export type CalendarGoogleSettings = z.infer<typeof CalendarGoogleSettingsSchema>
@@ -208,7 +214,8 @@ export const CALENDAR_GOOGLE_SETTINGS_DEFAULTS: CalendarGoogleSettings = {
   defaultTargetCalendarId: null,
   onboardingCompleted: false,
   promoteConfirmDismissed: false,
-  pushEventsToGoogle: true
+  pushEventsToGoogle: true,
+  agentReadEventsConsent: null
 }
 
 // ============================================================================

--- a/packages/i18n/src/locales/en/calendar.json
+++ b/packages/i18n/src/locales/en/calendar.json
@@ -80,6 +80,15 @@
     "context-menu-delete-label": "Delete event",
     "context-menu-add-to-project": "Add to project"
   },
+  "agent-access-dialog": {
+    "aria": "Choose whether AI can read your Google Calendar events",
+    "title": "Let AI read your Google Calendar events?",
+    "body": "You'll keep seeing your Google events in memrynote either way. This only decides whether the AI agent can read them when you ask it about your schedule.",
+    "footnote": "You can change this any time in Settings → Integrations → Google Calendar.",
+    "allow": "Allow",
+    "deny": "Don't allow",
+    "save-error": "Failed to save your choice"
+  },
   "promote-dialog": {
     "aria": "Edit external calendar event",
     "title": "Edit this event in memrynote?",

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -992,6 +992,11 @@
         "label": "Show memrynote events in Google Calendar",
         "description": "Turn off for one-way sync — you'll still see your Google events in memrynote, but memrynote events won't appear in Google.",
         "error": "Failed to update sync direction"
+      },
+      "agentAccess": {
+        "label": "Let AI read Google Calendar events",
+        "description": "Off by default. Turn on and the AI agent can read your Google events; turn off and it gets nothing back when asked about them. You keep seeing them in memrynote either way.",
+        "error": "Failed to update AI access"
       }
     },
     "sourcePicker": {

--- a/packages/i18n/src/locales/tr/calendar.json
+++ b/packages/i18n/src/locales/tr/calendar.json
@@ -69,6 +69,15 @@
     "google-bound-description": "\"{title}\" memrynote ve Google Calendar'dan kaldırılacak. Bu eylem geri alınamaz.",
     "context-menu-delete-label": "Etkinliği sil"
   },
+  "agent-access-dialog": {
+    "aria": "Yapay zekanın Google Calendar etkinliklerinizi okuyup okuyamayacağını seçin",
+    "title": "Yapay zeka Google Calendar etkinliklerinizi okusun mu?",
+    "body": "Google etkinliklerinizi her durumda memrynote'ta görmeye devam edersiniz. Bu seçim yalnızca, takviminizi sorduğunuzda yapay zeka asistanının bu etkinlikleri okuyup okuyamayacağını belirler.",
+    "footnote": "Bunu istediğiniz zaman Ayarlar → Entegrasyonlar → Google Calendar bölümünden değiştirebilirsiniz.",
+    "allow": "İzin ver",
+    "deny": "İzin verme",
+    "save-error": "Seçiminiz kaydedilemedi"
+  },
   "promote-dialog": {
     "aria": "Harici takvim etkinliğini düzenle",
     "title": "Bu etkinlik memrynote'te düzenlensin mi?",

--- a/packages/i18n/src/locales/tr/settings.json
+++ b/packages/i18n/src/locales/tr/settings.json
@@ -855,6 +855,11 @@
         "description": "Tek yönlü eşitleme için kapatın — Google etkinliklerinizi yine memrynote'ta görürsünüz, ancak memrynote etkinlikleri Google'da görünmez.",
         "error": "Eşitleme yönü güncellenemedi",
         "label": "memrynote etkinliklerini Google Calendar'da göster"
+      },
+      "agentAccess": {
+        "description": "Varsayılan olarak kapalı. Açarsanız yapay zeka asistanı Google etkinliklerinizi okuyabilir; kapatırsanız onlara dair hiçbir yanıt alamaz. Her iki durumda da etkinlikleri memrynote'ta görmeye devam edersiniz.",
+        "error": "Yapay zeka erişimi güncellenemedi",
+        "label": "Yapay zeka Google Calendar etkinliklerini okuyabilsin"
       }
     },
     "sourcePicker": {


### PR DESCRIPTION
## Why

Agent Chat could report the contents of a Google Calendar event, which #895 was supposed to make impossible. It turned out isolation was holding — the event had been *promoted* into a native memrynote event by a calendar click, so the agent read it legitimately. But the investigation showed the underlying model was wrong: #895 made Google events permanently invisible to AI, with no way for a user who *wants* that capability to turn it on, and no moment where anyone was asked.

This replaces the hard block with an explicit, revocable consent gate.

## What

**New setting** — `CalendarGoogleSettings.agentReadEventsConsent: boolean | null`, defaulting to `null` ("not asked yet"). Additive and `.default(null)`, so settings written by older versions parse and land on "not asked" rather than failing.

**Read gate** — `calendar.getRange` on the agent MCP surface resolves `includeExternal` from stored consent instead of hard-forcing `false`. Resolved server-side of the caller: an agent passing `includeExternal: true` still gets native-only results unless the user granted access. Not asked, declined, and a failed settings read all resolve to native-only.

**First-open prompt** — the first time a user with imported Google calendars opens the calendar, they're asked once: *Let AI read your Google Calendar events?* Escape and outside-click are suppressed and there is no dismiss, because an unanswered prompt is what causes us to ask again. Declining stores `false`, so it is asked exactly once.

**Settings toggle** — Settings → Integrations → Google Calendar gains **Let AI read Google Calendar events**, shown only while connected. Flipping it takes effect on the next agent read in both directions.

Out of scope by design: promoting an external event copies it into the vault as a memrynote event, and stays agent-readable regardless of this setting. Documented in the calendar user guide.

## Tests

Written first, each watched fail for the right reason before implementing.

- `settings-schemas.test.ts` — default is `null`; explicit answers accepted; non-boolean rejected; **payload written before this shipped parses as unanswered** (backward compat)
- `desktop-api-handler.test.tsx` — unanswered → excluded; declined → excluded *even when the caller passes `includeExternal: true`*; granted → included; settings lookup throws → excluded
- `calendar-page.test.tsx` — prompt opens on first visit with Google sources; stays closed with no sources; stays closed once answered; Allow persists `true` and closes; Don't allow persists `false` and closes
- `google-calendar-integration-row.test.tsx` — switch absent while disconnected; reflects granted/unanswered; persists both directions

## Verification

| Gate | Result |
|---|---|
| renderer suite | 535 files, 5888 passed |
| main suite | 407 files, 4422 passed |
| contracts suite | 48 files, 1571 passed |
| typecheck | clean (node + web + all packages) |
| lint | clean |
| i18n:check | passed |
| ipc:check | invoke map up to date |
| check:architecture / check:contracts | passed |
| docs:impact --strict | covered |
| docs:build | complete |

Four pre-existing main tests asserted the full `calendar.google` settings object and were updated to include the new key — the shape genuinely gained a field.

## Follow-up needed before replying to Google

`apps/landing/src/pages/Privacy.tsx` §3, shipped in #895, currently states that Google Calendar data is isolated from AI features unconditionally. That is no longer accurate — it is now user-controlled and off by default. **The privacy policy and the verification demo video both need updating before the reply email goes to Google.** Left out of this PR deliberately: it is legal copy on a separate surface and shouldn't be rewritten without review.

Docs updated here: `user-guide/calendar.md` (Google Data and AI Features) and `user-guide/ai/agent-mcp.md`.

