### PR TITLE
test(mcp): cover canvas handles and the features flag reader

### DIFF
--- a/apps/desktop/src/main/agent/mcp/tools/__tests__/canvas-handles.test.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/__tests__/canvas-handles.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getCanvasContext: vi.fn(),
+  getCanvas: vi.fn(),
+  listCanvasesWithCounts: vi.fn(),
+  getNoteById: vi.fn(),
+  getTaskById: vi.fn(),
+  getCalendarEventById: vi.fn(),
+  assertSpatialCanvasEnabled: vi.fn(),
+  invokeCanvasWrite: vi.fn()
+}))
+
+vi.mock('../../../../canvas/vault-key', () => ({ getCanvasContext: mocks.getCanvasContext }))
+vi.mock('../../../../canvas/store', () => ({
+  getCanvas: mocks.getCanvas,
+  listCanvasesWithCounts: mocks.listCanvasesWithCounts
+}))
+vi.mock('../../../../vault/notes', () => ({ getNoteById: mocks.getNoteById }))
+vi.mock('../../../../database/queries/tasks', () => ({ getTaskById: mocks.getTaskById }))
+vi.mock('../../../../calendar/repositories/calendar-events-repository', () => ({
+  getCalendarEventById: mocks.getCalendarEventById
+}))
+vi.mock('../canvas-flag', () => ({
+  assertSpatialCanvasEnabled: mocks.assertSpatialCanvasEnabled,
+  isCanvasOperation: (op: string) => op.startsWith('canvas.')
+}))
+vi.mock('../canvas-write', () => ({ invokeCanvasWrite: mocks.invokeCanvasWrite }))
+
+// summarizeScene is pure — exercised for real so the wiring is proven end to end.
+import { createCanvasHandles } from '../canvas-handles'
+
+const dataDb = {} as never
+
+function sceneWith(
+  cards: { entityType: string; entityId: string }[],
+  texts: string[] = []
+): string {
+  return JSON.stringify({
+    type: 'excalidraw',
+    elements: [
+      ...cards.map((c, i) => ({
+        id: `rect-${i}`,
+        type: 'rectangle',
+        customData: c
+      })),
+      ...texts.map((t, i) => ({ id: `text-${i}`, type: 'text', text: t }))
+    ]
+  })
+}
+
+describe('canvas handles', () => {
+  let handles: ReturnType<typeof createCanvasHandles>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getCanvasContext.mockResolvedValue({
+      db: {},
+      vaultId: 'vault-1',
+      vaultKey: new Uint8Array()
+    })
+    mocks.assertSpatialCanvasEnabled.mockImplementation(() => {})
+    handles = createCanvasHandles(dataDb)
+  })
+
+  describe('list', () => {
+    it('maps store rows to the agent shape', async () => {
+      mocks.listCanvasesWithCounts.mockReturnValue([
+        { id: 'c1', title: 'Roadmap', createdAt: 1, updatedAt: 5, itemCount: 2 }
+      ])
+
+      await expect(handles.list()).resolves.toEqual([
+        { id: 'c1', title: 'Roadmap', updated_at: 5, item_count: 2 }
+      ])
+    })
+
+    it('refuses when the spatialCanvas flag is off', async () => {
+      mocks.assertSpatialCanvasEnabled.mockImplementation(() => {
+        throw new Error('Spatial Canvas is disabled')
+      })
+
+      await expect(handles.list()).rejects.toThrow(/disabled/i)
+      expect(mocks.listCanvasesWithCounts).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('read', () => {
+    it('returns null for a missing canvas', async () => {
+      mocks.getCanvas.mockReturnValue(null)
+
+      await expect(handles.read('nope')).resolves.toBeNull()
+    })
+
+    it('resolves entity titles per type and never returns the scene', async () => {
+      mocks.getCanvas.mockReturnValue({
+        id: 'c1',
+        title: 'Roadmap',
+        createdAt: 1,
+        updatedAt: 5,
+        scene: sceneWith(
+          [
+            { entityType: 'note', entityId: 'n1' },
+            { entityType: 'task', entityId: 't1' },
+            { entityType: 'calendar_event', entityId: 'e1' }
+          ],
+          ['Q3 planning']
+        )
+      })
+      mocks.getNoteById.mockResolvedValue({ id: 'n1', title: 'Spec' })
+      mocks.getTaskById.mockReturnValue({ id: 't1', title: 'Ship it' })
+      mocks.getCalendarEventById.mockReturnValue({ id: 'e1', title: 'Standup' })
+
+      const detail = await handles.read('c1')
+
+      expect(detail).toMatchObject({
+        id: 'c1',
+        title: 'Roadmap',
+        created_at: 1,
+        updated_at: 5,
+        texts: ['Q3 planning'],
+        element_count: 4,
+        texts_truncated: false
+      })
+      expect(detail?.items).toEqual([
+        { entity_type: 'note', entity_id: 'n1', title: 'Spec', missing: false },
+        { entity_type: 'task', entity_id: 't1', title: 'Ship it', missing: false },
+        { entity_type: 'calendar_event', entity_id: 'e1', title: 'Standup', missing: false }
+      ])
+      expect(JSON.stringify(detail)).not.toContain('"scene"')
+    })
+
+    it('reports a dangling card as missing rather than dropping it', async () => {
+      mocks.getCanvas.mockReturnValue({
+        id: 'c1',
+        title: null,
+        createdAt: 1,
+        updatedAt: 5,
+        scene: sceneWith([{ entityType: 'note', entityId: 'gone' }])
+      })
+      mocks.getNoteById.mockResolvedValue(null)
+
+      const detail = await handles.read('c1')
+
+      expect(detail?.items).toEqual([
+        { entity_type: 'note', entity_id: 'gone', title: null, missing: true }
+      ])
+    })
+
+    it('survives an unparseable scene with an empty summary', async () => {
+      mocks.getCanvas.mockReturnValue({
+        id: 'c1',
+        title: null,
+        createdAt: 1,
+        updatedAt: 5,
+        scene: '{not json'
+      })
+
+      const detail = await handles.read('c1')
+
+      expect(detail).toMatchObject({ items: [], texts: [], element_count: 0 })
+    })
+  })
+
+  describe('addItems', () => {
+    const okWrite = {
+      applied: [{ entityType: 'note', entityId: 'n1' }],
+      skipped: [{ ref: { entityType: 'task', entityId: 't1' }, reason: 'already-on-canvas' }],
+      updatedAt: 7,
+      tooLarge: true
+    }
+
+    it('validates every entity exists before minting anything', async () => {
+      mocks.getNoteById.mockResolvedValue(null)
+
+      await expect(
+        handles.addItems(
+          { canvasId: 'c1', items: [{ entityType: 'note', entityId: 'ghost' }] },
+          '1'
+        )
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+      expect(mocks.invokeCanvasWrite).not.toHaveBeenCalled()
+    })
+
+    it('routes the write and maps the outcome to snake_case', async () => {
+      mocks.getNoteById.mockResolvedValue({ id: 'n1', title: 'Spec' })
+      mocks.invokeCanvasWrite.mockResolvedValue(okWrite)
+
+      const outcome = await handles.addItems(
+        { canvasId: 'c1', items: [{ entityType: 'note', entityId: 'n1' }] },
+        '1'
+      )
+
+      expect(mocks.invokeCanvasWrite).toHaveBeenCalledWith('1', {
+        canvasId: 'c1',
+        op: 'add',
+        items: [{ entityType: 'note', entityId: 'n1' }]
+      })
+      expect(outcome).toEqual({
+        canvas_id: 'c1',
+        applied: [{ entity_type: 'note', entity_id: 'n1' }],
+        skipped: [{ entity_type: 'task', entity_id: 't1', reason: 'already-on-canvas' }],
+        updated_at: 7,
+        too_large: true
+      })
+    })
+  })
+
+  describe('removeItem', () => {
+    it('sends a single-item remove and does not require the entity to exist', async () => {
+      mocks.getNoteById.mockResolvedValue(null)
+      mocks.invokeCanvasWrite.mockResolvedValue({
+        applied: [{ entityType: 'note', entityId: 'gone' }],
+        skipped: [],
+        updatedAt: 9,
+        tooLarge: false
+      })
+
+      const outcome = await handles.removeItem(
+        { canvasId: 'c1', item: { entityType: 'note', entityId: 'gone' } },
+        null
+      )
+
+      expect(mocks.invokeCanvasWrite).toHaveBeenCalledWith(null, {
+        canvasId: 'c1',
+        op: 'remove',
+        items: [{ entityType: 'note', entityId: 'gone' }]
+      })
+      expect(outcome).toMatchObject({ canvas_id: 'c1', updated_at: 9, too_large: false })
+    })
+
+    it('refuses when the spatialCanvas flag is off', async () => {
+      mocks.assertSpatialCanvasEnabled.mockImplementation(() => {
+        throw new Error('Spatial Canvas is disabled')
+      })
+
+      await expect(
+        handles.removeItem({ canvasId: 'c1', item: { entityType: 'note', entityId: 'n1' } }, null)
+      ).rejects.toThrow(/disabled/i)
+      expect(mocks.invokeCanvasWrite).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/desktop/src/main/settings/features.test.ts
+++ b/apps/desktop/src/main/settings/features.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { FEATURES_SETTINGS_DEFAULTS } from '@memry/contracts/settings-schemas'
+
+const mocks = vi.hoisted(() => ({
+  getDatabase: vi.fn(),
+  getSetting: vi.fn(),
+  deleteSetting: vi.fn()
+}))
+
+vi.mock('../database', () => ({ getDatabase: mocks.getDatabase }))
+vi.mock('../database/queries/settings', () => ({
+  getSetting: mocks.getSetting,
+  deleteSetting: mocks.deleteSetting
+}))
+
+import { getFeaturesSettings } from './features'
+
+describe('getFeaturesSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getDatabase.mockReturnValue({} as never)
+  })
+
+  it('returns defaults when no vault is open', () => {
+    mocks.getDatabase.mockImplementation(() => {
+      throw new Error('No vault is open')
+    })
+
+    expect(getFeaturesSettings()).toEqual(FEATURES_SETTINGS_DEFAULTS)
+    expect(mocks.getSetting).not.toHaveBeenCalled()
+  })
+
+  it('returns defaults when the group has never been written', () => {
+    mocks.getSetting.mockReturnValue(undefined)
+
+    expect(getFeaturesSettings()).toEqual(FEATURES_SETTINGS_DEFAULTS)
+  })
+
+  it('merges a stored partial over the defaults', () => {
+    mocks.getSetting.mockReturnValue(JSON.stringify({ spatialCanvas: true }))
+
+    const settings = getFeaturesSettings()
+
+    expect(settings.spatialCanvas).toBe(true)
+    // Every other flag keeps its default rather than becoming undefined.
+    expect(settings.inbox).toBe(FEATURES_SETTINGS_DEFAULTS.inbox)
+  })
+
+  it('defaults spatialCanvas off, matching the opt-in rollout', () => {
+    mocks.getSetting.mockReturnValue(undefined)
+
+    expect(getFeaturesSettings().spatialCanvas).toBe(false)
+  })
+
+  it('falls back to defaults on a corrupt blob WITHOUT deleting it', () => {
+    mocks.getSetting.mockReturnValue('{not json')
+
+    expect(getFeaturesSettings()).toEqual(FEATURES_SETTINGS_DEFAULTS)
+    // Deliberate difference from ipc/settings-handlers readGroupSettings: a flag
+    // lookup on a tool call must never mutate the user's settings as a side
+    // effect, so the corrupt key is left for the IPC path to repair.
+    expect(mocks.deleteSetting).not.toHaveBeenCalled()
+  })
+
+  it('reads the "features" group key', () => {
+    mocks.getSetting.mockReturnValue(undefined)
+
+    getFeaturesSettings()
+
+    expect(mocks.getSetting).toHaveBeenCalledWith(expect.anything(), 'features')
+  })
+})


### PR DESCRIPTION
Follow-up to #927, which merged before these tests landed.

codecov flagged that PR's patch at **81.79% against an 87.44% target**. Looking at what the diff
actually missed, both gaps were modules that shipped with **no test file at all** — not thin coverage,
zero. This adds them.

## `main/agent/mcp/tools/canvas-handles.ts`

The module every canvas MCP tool calls into. Now covered:

- `list` maps store rows to the agent shape, and refuses when `spatialCanvas` is off
- `read` resolves titles per entity type (note / task / calendar_event), returns `null` for a missing
  canvas, and **never** emits a `scene` key
- a card whose entity no longer exists reports `missing: true` rather than being dropped — the
  behaviour that keeps an agent from silently under-reporting a canvas
- an unparseable scene degrades to an empty summary instead of throwing
- `addItems` validates every entity exists **before** anything is minted, and `NOT_FOUND` short-circuits
  the write rather than routing it
- outcome mapping to the snake_case tool shape, including `too_large`

`summarizeScene` is deliberately left unmocked so the read path is exercised for real end to end.

## `main/settings/features.ts`

The flag reader the canvas tools gate on. Now covered: no vault open, group never written, partial
blob merged over defaults, `spatialCanvas` defaulting off, and the group key it reads.

One behaviour is worth locking in explicitly: on a corrupt blob this returns defaults **without
deleting the key**, unlike `readGroupSettings` in `ipc/settings-handlers.ts`. That difference is
intentional — a flag lookup on a tool call must never mutate the user's settings as a side effect —
and it was previously only asserted by a comment.

## Verification

```
2 files / 16 tests   passed
typecheck:node       passed
```

No production code changes.
