### PR TITLE
fix(calendar): confirm promotion while agent access to Google events is off

### DIFF
--- a/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-page.test.tsx
@@ -589,6 +589,8 @@ describe('CalendarPage', () => {
     await waitFor(() => expect(mockUnsnooze).toHaveBeenCalledWith('snooze-1'))
   })
 
+  // Skipping the confirmation also requires agent access to Google events to be on;
+  // otherwise promotion would silently widen what the agent can read.
   it('promotes external events directly when the confirmation is dismissed', async () => {
     const user = userEvent.setup()
     const api = window.api as typeof window.api & {
@@ -597,7 +599,10 @@ describe('CalendarPage', () => {
         setCalendarGoogleSettings: ReturnType<typeof vi.fn>
       }
     }
-    api.settings.getCalendarGoogleSettings.mockResolvedValue({ promoteConfirmDismissed: true })
+    api.settings.getCalendarGoogleSettings.mockResolvedValue({
+      promoteConfirmDismissed: true,
+      agentReadEventsConsent: true
+    })
     mockPromoteExternal.mockResolvedValue({ success: true, eventId: 'event-promoted' })
     mockGetEvent.mockResolvedValue({
       id: 'event-promoted',

--- a/apps/desktop/src/renderer/src/components/calendar/promote-external-dialog.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/promote-external-dialog.test.tsx
@@ -44,6 +44,16 @@ describe('PromoteExternalDialog (M2)', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
   })
 
+  it('#given agentAccessOff #when rendered #then warns that the copy becomes agent-readable', () => {
+    render(<PromoteExternalDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} agentAccessOff />)
+    expect(screen.getByText(/AI agent can read this copy/)).toBeInTheDocument()
+  })
+
+  it('#given agent access is already on #when rendered #then omits the warning', () => {
+    render(<PromoteExternalDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />)
+    expect(screen.queryByText(/AI agent can read this copy/)).not.toBeInTheDocument()
+  })
+
   it('#given errorMessage #when rendered #then surfaces it via role=alert', () => {
     render(
       <PromoteExternalDialog

--- a/apps/desktop/src/renderer/src/components/calendar/promote-external-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/promote-external-dialog.tsx
@@ -11,6 +11,12 @@ export interface PromoteExternalDialogProps {
   onConfirm: (dontAskAgain: boolean) => void | Promise<void>
   isWorking?: boolean
   errorMessage?: string | null
+  /**
+   * The promoted copy lives in native storage, which the agent may read even when
+   * Google-event access is off. Surface that so the user is not opted back in by a
+   * gesture that reads as "let me look at this event".
+   */
+  agentAccessOff?: boolean
 }
 
 export function PromoteExternalDialog({
@@ -18,7 +24,8 @@ export function PromoteExternalDialog({
   onOpenChange,
   onConfirm,
   isWorking = false,
-  errorMessage = null
+  errorMessage = null,
+  agentAccessOff = false
 }: PromoteExternalDialogProps): React.JSX.Element | null {
   const [dontAskAgain, setDontAskAgain] = useState(false)
   const { t } = useT('calendar')
@@ -34,7 +41,7 @@ export function PromoteExternalDialog({
           data-testid="promote-external-dialog"
           aria-label={t('promote-dialog.aria')}
           className={cn(
-            'fixed left-1/2 top-1/2 z-50 w-[420px] -translate-x-1/2 -translate-y-1/2',
+            'fixed start-1/2 top-1/2 z-50 w-[420px] -translate-x-1/2 -translate-y-1/2 rtl:translate-x-1/2',
             'rounded-md border bg-popover p-6 text-popover-foreground shadow-lg outline-none'
           )}
         >
@@ -44,6 +51,12 @@ export function PromoteExternalDialog({
           <DialogPrimitive.Description className="mb-4 text-sm text-muted-foreground">
             {t('promote-dialog.body')}
           </DialogPrimitive.Description>
+
+          {agentAccessOff && (
+            <p className="mb-4 rounded-md border border-border bg-muted/50 p-3 text-xs text-foreground">
+              {t('promote-dialog.agent-notice')}
+            </p>
+          )}
 
           <label className="flex items-center gap-2 text-sm">
             <Checkbox

--- a/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
@@ -280,17 +280,20 @@ vi.mock('@/components/calendar/promote-external-dialog', () => ({
   PromoteExternalDialog: ({
     open,
     errorMessage,
+    agentAccessOff,
     onConfirm,
     onOpenChange
   }: {
     open: boolean
     errorMessage: string | null
+    agentAccessOff?: boolean
     onConfirm: (dontAskAgain: boolean) => void
     onOpenChange: (open: boolean) => void
   }) =>
     open ? (
       <div>
         {errorMessage && <div role="alert">{errorMessage}</div>}
+        {agentAccessOff && <div>promote agent warning</div>}
         <button type="button" onClick={() => onConfirm(false)}>
           promote once
         </button>
@@ -557,6 +560,48 @@ describe('CalendarPage callback coverage', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('Promote denied')
     fireEvent.click(screen.getByText('close promote'))
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  // Promotion copies a Google event into native storage, which makes it agent-readable
+  // regardless of the Google-events consent gate. "Don't ask again" must not be allowed
+  // to make that happen silently while the user has AI access switched off.
+  it.each([
+    ['explicitly denied', false],
+    ['never answered', null]
+  ])(
+    'given "don\'t ask again" and agent access %s, still confirms before promoting',
+    async (_label, agentReadEventsConsent) => {
+      mocks.getSettings.mockResolvedValue({
+        promoteConfirmDismissed: true,
+        agentReadEventsConsent
+      })
+      renderPage()
+
+      fireEvent.click(screen.getByText('select external'))
+
+      expect(await screen.findByText('promote agent warning')).toBeInTheDocument()
+      expect(mocks.promoteExternal).not.toHaveBeenCalled()
+
+      fireEvent.click(screen.getByText('promote once'))
+      await waitFor(() =>
+        expect(mocks.promoteExternal).toHaveBeenCalledWith({ externalEventId: 'external-1' })
+      )
+    }
+  )
+
+  it('given "don\'t ask again" and agent access granted, promotes without the dialog', async () => {
+    mocks.getSettings.mockResolvedValue({
+      promoteConfirmDismissed: true,
+      agentReadEventsConsent: true
+    })
+    renderPage()
+
+    fireEvent.click(screen.getByText('select external'))
+
+    await waitFor(() =>
+      expect(mocks.promoteExternal).toHaveBeenCalledWith({ externalEventId: 'external-1' })
+    )
+    expect(screen.queryByText('promote agent warning')).not.toBeInTheDocument()
   })
 
   it('routes a dragged task chip through tasksService.update, not calendarService.updateEvent', async () => {

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -240,6 +240,7 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
   const [pendingPromote, setPendingPromote] = useState<{
     item: CalendarProjectionItem
     anchorRect: AnchorRect
+    agentAccessOff: boolean
   } | null>(null)
   const [isPromoting, setIsPromoting] = useState(false)
   const [promoteError, setPromoteError] = useState<string | null>(null)
@@ -443,14 +444,13 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
   }
 
   async function runPromote(
-    item: CalendarProjectionItem,
-    rect: AnchorRect,
+    target: { item: CalendarProjectionItem; anchorRect: AnchorRect },
     options: { dontAskAgain: boolean }
   ): Promise<void> {
     setIsPromoting(true)
     setPromoteError(null)
     try {
-      const result = await promoteExternalCalendarEvent({ externalEventId: item.sourceId })
+      const result = await promoteExternalCalendarEvent({ externalEventId: target.item.sourceId })
       if (!result.success || !result.eventId) {
         throw new Error(result.error ?? 'Could not edit this event.')
       }
@@ -458,7 +458,7 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
         await window.api.settings.setCalendarGoogleSettings({ promoteConfirmDismissed: true })
       }
       await queryClient.invalidateQueries({ queryKey: ['calendar', 'range'] })
-      await openEditPopoverAfterPromote(result.eventId, item, rect)
+      await openEditPopoverAfterPromote(result.eventId, target.item, target.anchorRect)
       setPendingPromote(null)
     } catch (err) {
       setPromoteError(
@@ -523,12 +523,17 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
 
     setNotePopoverState(null)
     const settings = await window.api.settings.getCalendarGoogleSettings()
-    if (settings.promoteConfirmDismissed) {
-      await runPromote(item, rect, { dontAskAgain: false })
+    // Promotion copies the event into native storage, where the agent can read it
+    // regardless of the Google-events consent gate. While that consent is anything but
+    // a stored `true`, confirm every time — "don't ask again" must not silently widen
+    // what the agent can see.
+    const agentAccessOff = settings.agentReadEventsConsent !== true
+    if (settings.promoteConfirmDismissed && !agentAccessOff) {
+      await runPromote({ item, anchorRect: rect }, { dontAskAgain: false })
       return
     }
 
-    setPendingPromote({ item, anchorRect: rect })
+    setPendingPromote({ item, anchorRect: rect, agentAccessOff })
   }
 
   // Search jump: focus the item's day, then open its popover. The item is already
@@ -768,16 +773,15 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
         open={pendingPromote !== null}
         isWorking={isPromoting}
         errorMessage={promoteError}
+        agentAccessOff={pendingPromote?.agentAccessOff ?? false}
         onOpenChange={(open) => {
-          if (!open) {
-            setPendingPromote(null)
-            setPromoteError(null)
-          }
+          if (open) return
+          setPendingPromote(null)
+          setPromoteError(null)
         }}
         onConfirm={(dontAskAgain) => {
-          if (pendingPromote) {
-            void runPromote(pendingPromote.item, pendingPromote.anchorRect, { dontAskAgain })
-          }
+          if (!pendingPromote) return
+          void runPromote(pendingPromote, { dontAskAgain })
         }}
       />
       <CalendarShell

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -143,6 +143,12 @@ Change your answer any time at [Settings → Integrations](/user-guide/settings#
 Google Calendar → **Let AI read Google Calendar events**. Turning it off takes effect on the next
 question you ask; turning it on likewise applies from that point forward.
 
+This setting covers events that live on your Google calendars. A [promoted](#promote-external-events)
+event is different: the copy sits in your vault as a memrynote event, so the assistant can read it
+like any other event you created. While AI access is off, memrynote confirms every promotion and
+says so in the dialog, and **Don't ask again** does not skip that confirmation. Your original Google
+event stays hidden from the assistant either way.
+
 Either way you keep seeing your Google events in the calendar, calendar lists and connection
 details stay out of what the assistant can access, and Google user data is never used to train or
 improve AI models.

--- a/packages/i18n/src/locales/en/calendar.json
+++ b/packages/i18n/src/locales/en/calendar.json
@@ -94,7 +94,8 @@
     "title": "Edit this event in memrynote?",
     "body": "Editing this event will create a linked copy in memrynote so changes sync both ways. Continue?",
     "do-not-ask-again": "Don't ask again",
-    "confirm-label": "Edit in memrynote"
+    "confirm-label": "Edit in memrynote",
+    "agent-notice": "The AI agent can read this copy, even though AI access to Google Calendar is off. Your original Google event stays hidden from it."
   },
   "onboarding-dialog": {
     "aria": "Pick your default Google calendar",

--- a/packages/i18n/src/locales/tr/calendar.json
+++ b/packages/i18n/src/locales/tr/calendar.json
@@ -83,7 +83,8 @@
     "title": "Bu etkinlik memrynote'te düzenlensin mi?",
     "body": "Bu etkinliği düzenlemek memrynote'de bağlantılı bir kopya oluşturur; değişiklikler iki yönde de senkronize edilir. Devam edilsin mi?",
     "do-not-ask-again": "Bir daha sorma",
-    "confirm-label": "memrynote'de düzenle"
+    "confirm-label": "memrynote'de düzenle",
+    "agent-notice": "Yapay zeka ajanı bu kopyayı okuyabilir; Google Takvim için yapay zeka erişimi kapalı olsa bile. Google’daki asıl etkinliğiniz ona kapalı kalır."
   },
   "onboarding-dialog": {
     "aria": "Varsayılan Google takviminizi seçin",


### PR DESCRIPTION
## Problem

Reported as "the AI reads my Google events even though I never gave it permission."

The consent gate itself is fine. Verified against a real vault where `agentReadEventsConsent` was `false`: the event the agent answered with was sitting in **native** `calendar_events`, alongside a `calendar_bindings` row created in the same millisecond. It had been promoted.

Promotion copies an external Google event into native storage, and promoted events are Memry data by design (#926), so the agent reads them legitimately. The gap is that nothing tells the user promotion has that consequence:

- `promote-dialog.body` only says a linked copy is created and changes sync both ways. AI is never mentioned.
- With **Don't ask again** ticked, a plain click on a Google event promoted it with no dialog at all.

So a user who explicitly declined AI access could re-open it, one event at a time, with a gesture that reads as "let me look at this event."

## Change

- Skip the promote confirmation only when agent access is explicitly granted. While it is off, confirm every time, `promoteConfirmDismissed` notwithstanding.
- Show the consequence in the dialog when access is off: *"The AI agent can read this copy, even though AI access to Google Calendar is off. Your original Google event stays hidden from it."*

Consent is three-state, so the gate keys on `!== true`. Never-answered (`null`) also means the agent cannot read Google events today, so promoting still widens what it sees.

Scope is deliberately narrow: promoted events stay outside the consent gate, per the D1 decision in #926. This makes the decision visible, it does not reverse it.

## Verification

| Check | Result |
|---|---|
| Full renderer suite | 5934 passed, 6 skipped (541 files) |
| Calendar renderer tests | 262 passed (39 files) |
| `typecheck:web` | clean |
| `i18n:check` | ok |
| eslint (changed files) | 0 errors |
| `docs:impact --strict` | covered |
| `docs:build` | clean |

Regression tests cover denied, never-answered, and granted consent, plus the dialog notice in both states. One existing test in `calendar-page.test.tsx` encoded the old contract ("dismissed means promote directly"); its fixture now grants agent access, preserving the test's intent.

## Notes

- `calendar.tsx` sits exactly at the 800-line `max-lines` cap. The fix went 3 lines over, so the promote block was compacted to fit (`runPromote` now takes a grouped `target` object). It is back at the cap.
- The dialog's pre-existing `left-1/2` became `start-1/2` + `rtl:translate-x-1/2`. The renderer guardrail scans the whole staged file, not just changed lines.
- **Out of scope, still open:** `agent/cli/spawn.ts` spawns `computer_access` turns with `--add-dir /`, `--permission-mode dontAsk`, and no `--allowed-tools`, so an agent in that mode can read `calendar_external_events` straight out of SQLite regardless of consent. Default is `vault_only`, so it is opt-in, but it is a real bypass and wants its own PR.
- **Follow-up:** `apps/landing/src/pages/Privacy.tsx` §3 still describes the isolation as unconditional, which stopped being true in #926. Worth fixing before the Google Limited Use reply and demo video.