### PR TITLE
fix(sync): recover from hung sync requests instead of staying stale until restart

### DIFF
--- a/apps/desktop/src/main/sync/engine.test.ts
+++ b/apps/desktop/src/main/sync/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { SyncEngine } from './engine'
+import { SyncEngine, SYNC_LOCK_STALE_MS } from './engine'
 import type { WebSocketMessage } from './websocket'
 import { createMockDeps, createMockNetwork, setupTestDb } from '@tests/utils/engine-mocks'
 
@@ -31,6 +31,65 @@ describe('SyncEngine', () => {
 
       expect(deps.ws.connect).toHaveBeenCalled()
       vi.restoreAllMocks()
+    })
+  })
+
+  describe('#given initial full sync fails #when start called', () => {
+    it('#then start resolves and the periodic pull is armed', async () => {
+      vi.useFakeTimers()
+      const getSpy = vi.spyOn(await import('./http-client'), 'getFromServer').mockResolvedValue({
+        items: [],
+        deleted: [],
+        hasMore: false,
+        nextCursor: 0
+      })
+      const deps = createMockDeps(getDb())
+      const engine = new SyncEngine(deps)
+      vi.spyOn(engine, 'fullSync').mockRejectedValueOnce(new Error('transient first-sync failure'))
+
+      // #when — must not throw: a throwing start() tears down the sync runtime
+      await engine.start()
+
+      // #then — the 60s tick still pulls, so sync self-heals this session
+      const callsAfterStart = getSpy.mock.calls.length
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(getSpy.mock.calls.length).toBeGreaterThan(callsAfterStart)
+
+      await engine.stop()
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+  })
+
+  describe('#given the sync lock is stuck past the stale threshold #when the watchdog runs', () => {
+    it('#then force-releases the lock and aborts the in-flight sync', () => {
+      const deps = createMockDeps(getDb())
+      const engine = new SyncEngine(deps)
+      const abortController = new AbortController()
+      engine['ctx'].syncing = true
+      engine['ctx'].fullSyncActive = true
+      engine['ctx'].abortController = abortController
+      engine['syncLockAcquiredAt'] = Date.now() - SYNC_LOCK_STALE_MS - 1
+
+      engine['recoverStaleSyncLock']()
+
+      expect(engine['ctx'].syncing).toBe(false)
+      expect(engine['ctx'].fullSyncActive).toBe(false)
+      expect(abortController.signal.aborted).toBe(true)
+    })
+
+    it('#then leaves a freshly acquired lock alone', () => {
+      const deps = createMockDeps(getDb())
+      const engine = new SyncEngine(deps)
+      engine['ctx'].syncing = true
+      engine['syncLockAcquiredAt'] = Date.now()
+
+      engine['recoverStaleSyncLock']()
+
+      expect(engine['ctx'].syncing).toBe(true)
+      // The engine is a static singleton: a leaked syncing=true makes every
+      // later `new SyncEngine` in this file throw "instance already active".
+      engine['ctx'].syncing = false
     })
   })
 

--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -37,6 +37,12 @@ export type { SyncEngineDeps, SyncEngineOptions }
 const log = createLogger('SyncEngine')
 const MAX_SYNC_ENGINE_LISTENERS = 50
 
+// A sync run legitimately spans many paged requests plus retry backoff, so
+// this sits far above SYNC_REQUEST_TIMEOUT_MS × the retry budget. A lock held
+// longer than this is leaked (a never-settling non-HTTP await): left alone it
+// makes periodicPull skip forever, and only an app restart recovers.
+export const SYNC_LOCK_STALE_MS = 15 * 60 * 1000
+
 const classifySyncErrorCode = (error: unknown): string => {
   try {
     const info = classifyError(error)
@@ -59,6 +65,8 @@ export class SyncEngine extends EventEmitter {
   private fullSyncRunner: FullSyncRunner
   private pullInterval: ReturnType<typeof setInterval> | null = null
   private networkReconnectAbortController: AbortController | null = null
+  private syncLockAcquiredAt: number | null = null
+  private activeLockRelease: (() => void) | null = null
 
   constructor(deps: SyncEngineDeps, options?: Partial<SyncEngineOptions>) {
     super()
@@ -170,10 +178,20 @@ export class SyncEngine extends EventEmitter {
       }
 
       await this.ctx.deps.ws.connect()
+      // Armed before the first full sync: if that sync fails, the 60s tick is
+      // what heals sync for the rest of the session.
+      this.armPeriodicPull()
       if (!this.stateManager.isPaused()) {
-        await this.fullSync()
+        try {
+          await this.fullSync()
+        } catch (error) {
+          // A throw here used to propagate out of start() and tear down the
+          // whole sync runtime, so one transient 429 or offline blip during
+          // the first sync left sync dead until restart. Revocation and auth
+          // failures still surface via WS events and the next pull cycle.
+          log.error('Initial full sync failed — periodic pull will retry', error)
+        }
       }
-      this.pullInterval = setInterval(() => this.pullCoordinator.periodicPull(), 60_000)
     } else {
       this.stateManager.setState('offline')
     }
@@ -483,6 +501,7 @@ export class SyncEngine extends EventEmitter {
   private async acquireSyncLock(): Promise<(() => void) | null> {
     if (this.ctx.syncing || this.stateManager.isPaused()) return null
     this.ctx.syncing = true
+    this.syncLockAcquiredAt = Date.now()
 
     let release!: () => void
     const prev = this.syncLock
@@ -490,12 +509,40 @@ export class SyncEngine extends EventEmitter {
       release = r
     })
     await prev
+    this.activeLockRelease = release
     return release
+  }
+
+  private armPeriodicPull(): void {
+    if (this.pullInterval) return
+    this.pullInterval = setInterval(() => {
+      this.recoverStaleSyncLock()
+      this.pullCoordinator.periodicPull()
+    }, 60_000)
+  }
+
+  // Last-resort watchdog. Request timeouts make a hung HTTP call settle on its
+  // own; this covers a lock leaked by any other never-settling await. Forcing
+  // the release risks a brief overlap if the zombie sync later resumes —
+  // accepted over sync staying dead until restart.
+  private recoverStaleSyncLock(): void {
+    if (!this.ctx.syncing || this.syncLockAcquiredAt === null) return
+    const heldForMs = Date.now() - this.syncLockAcquiredAt
+    if (heldForMs < SYNC_LOCK_STALE_MS) return
+
+    log.error('Sync lock held past stale threshold — force releasing', { heldForMs })
+    this.ctx.abortController?.abort()
+    this.ctx.fullSyncActive = false
+    this.ctx.inFlightSync = null
+    this.activeLockRelease?.()
+    this.releaseLock()
   }
 
   private releaseLock(): void {
     this.ctx.syncing = false
     this.ctx.abortController = null
+    this.syncLockAcquiredAt = null
+    this.activeLockRelease = null
     if (this.ctx.state === 'syncing') {
       this.stateManager.setState(this.ctx.deps.network.online ? 'idle' : 'offline')
     }
@@ -552,9 +599,7 @@ export class SyncEngine extends EventEmitter {
         this.stateManager.setState('idle')
         void this.ctx.deps.ws.connect()
 
-        if (!this.pullInterval) {
-          this.pullInterval = setInterval(() => this.pullCoordinator.periodicPull(), 60_000)
-        }
+        this.armPeriodicPull()
 
         if (!this.stateManager.isPaused()) {
           this.scheduleSync(() => this.reconnectSync(offlineDurationMs))

--- a/apps/desktop/src/main/sync/http-client.test.ts
+++ b/apps/desktop/src/main/sync/http-client.test.ts
@@ -214,6 +214,38 @@ describe('http-client', () => {
         serverError: 'AUTH_DEVICE_REVOKED: Device has been revoked'
       })
     })
+
+    it('passes an abort signal to fetch', async () => {
+      // #given
+      mockFetch.mockResolvedValue(createJsonResponse({ ok: true }))
+
+      // #when
+      await syncFetch('GET', '/sync/changes')
+
+      // #then
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/sync/changes'),
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      )
+    })
+
+    it('aborts a hung request after the timeout and throws a timed-out NetworkError', async () => {
+      // #given a request that never resolves on its own
+      mockFetch.mockImplementation(
+        (_url: string, init: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            init.signal.addEventListener('abort', () => reject(init.signal.reason), { once: true })
+          })
+      )
+
+      // #when / #then
+      await expect(
+        syncFetch('GET', '/sync/changes', undefined, undefined, undefined, 25)
+      ).rejects.toMatchObject({
+        name: 'NetworkError',
+        message: expect.stringContaining('timed out')
+      })
+    })
   })
 
   describe('convenience functions', () => {

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -93,12 +93,19 @@ interface ServerErrorResponse {
   message?: string
 }
 
+// A socket that black-holes (suspend/resume, NAT teardown) would otherwise
+// keep this request pending forever — and with it the sync lock, which
+// silences every future periodic pull until the app restarts. The timeout is
+// per attempt; withRetry owns the retry budget on top of it.
+export const SYNC_REQUEST_TIMEOUT_MS = 60_000
+
 export const syncFetch = async <T>(
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
   path: string,
   body?: unknown,
   token?: string,
-  fetchFn?: FetchFn
+  fetchFn?: FetchFn,
+  timeoutMs: number = SYNC_REQUEST_TIMEOUT_MS
 ): Promise<T> => {
   const url = `${getSyncServerUrl()}${path}`
   const fetchImpl = fetchFn ?? ((...args: Parameters<typeof net.fetch>) => net.fetch(...args))
@@ -119,9 +126,13 @@ export const syncFetch = async <T>(
     response = await fetchImpl(url, {
       method,
       headers,
-      body: body != null ? JSON.stringify(body) : undefined
+      body: body != null ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(timeoutMs)
     })
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError')) {
+      throw new NetworkError('Sync request timed out. Please check your internet connection.')
+    }
     throw new NetworkError(
       `Unable to connect to sync server. Please check your internet connection.`
     )

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -229,6 +229,20 @@ terminal status.
 
 `server_cursor_sequence` tracks per-device pull progress. Pull is incremental: fetch everything strictly after the cursor, advance, repeat.
 
+## Pull Scheduling and Hang Recovery
+
+A periodic pull fires every 60 seconds; WebSocket `changes_available` and `connected` messages
+schedule additional pulls in between. The interval is armed before the first full sync, and a
+failure in that first sync is logged rather than propagated, so one transient error at startup
+cannot leave a session without a pull cycle.
+
+Three guards keep a wedged sync from lasting until restart. Every sync HTTP request carries a
+60-second abort timeout, so a black-holed socket (suspend/resume, NAT teardown) surfaces as a
+retryable network error instead of pinning the sync lock forever. If the lock is still held after
+15 minutes anyway, a watchdog on the periodic tick force-releases it, aborts the in-flight run,
+and lets the next pull proceed. Skipped periodic pulls log `Periodic pull skipped` with the
+blocking flags, which is the first thing to look for when a device shows stale data.
+
 ## Manifest Integrity
 
 Desktop periodically compares `/sync/manifest` with local syncable records. Notes and journals are


### PR DESCRIPTION
## Problem

Field report (Linux, v2026-07-19.2): Device 2 edits tasks/notes; Device 1 never shows them until the app is restarted, even though the vault files on disk keep updating.

Root cause: `syncFetch` had no request timeout and `withRetry` never hands its abort signal to the in-flight request. A black-holed socket (suspend/resume, NAT teardown) leaves `net.fetch` pending forever, which pins `ctx.syncing` for the life of the process. The 60s periodic pull then skips silently on every tick (`Periodic pull skipped`), and only a restart clears the in-memory flag. The vault still updating is consistent: note bodies land via the CRDT/WS path while the record pull is frozen.

Two adjacent fragilities fixed in the same pass:
- `pullInterval` was armed only after the first `fullSync()` resolved, and `start()` rethrew — one transient 429/offline blip during startup tore down the whole sync runtime for the session.
- Nothing recovered a leaked sync lock from any other never-settling await.

## Changes

- **`http-client.ts`** — every sync request now carries `AbortSignal.timeout(60s)` (per attempt; `withRetry` still owns the retry budget). Timeouts surface as a retryable `NetworkError`.
- **`engine.ts`** — `armPeriodicPull()` runs before the first full sync; a first-sync failure is logged instead of propagating out of `start()`. A stale-lock watchdog on the 60s tick force-releases a sync lock held past 15 minutes and aborts the zombie run.
- **docs** — pull scheduling + hang recovery section in `sync-protocol.md`.

## Tests

- `http-client.test.ts`: signal is passed to fetch; a hung request aborts after the timeout and throws a timed-out `NetworkError`.
- `engine.test.ts`: `start()` resolves when the initial full sync rejects and the periodic pull still fires; watchdog force-releases a stale lock and leaves a fresh one alone.
- `vitest --project main` on the sync engine suites: 123/123 green. `typecheck:node` clean for the touched files (pre-existing unrelated error in `agent/mcp/tools/schemas.ts` on main).