### PR TITLE
fix(sync): skip destroyed windows in renderer emit fan-out

### DIFF
--- a/apps/desktop/src/main/calendar/change-events.ts
+++ b/apps/desktop/src/main/calendar/change-events.ts
@@ -1,11 +1,10 @@
-import { BrowserWindow } from 'electron'
 import type { CalendarChangedEvent } from '@memry/contracts/calendar-api'
 import { CalendarChannels } from '@memry/contracts/ipc-channels'
 
+import { broadcastToAllWindows } from '../lib/window-broadcast'
+
 export function emitCalendarChanged(event: CalendarChangedEvent): void {
-  for (const win of BrowserWindow.getAllWindows()) {
-    win.webContents.send(CalendarChannels.events.CHANGED, event)
-  }
+  broadcastToAllWindows(CalendarChannels.events.CHANGED, event)
 }
 
 export function emitCalendarProjectionChanged(id: string): void {

--- a/apps/desktop/src/main/calendar/google/sync-service.test.ts
+++ b/apps/desktop/src/main/calendar/google/sync-service.test.ts
@@ -25,7 +25,9 @@ vi.mock('electron', () => ({
   BrowserWindow: {
     getAllWindows: vi.fn(() => [
       {
+        isDestroyed: () => false,
         webContents: {
+          isDestroyed: () => false,
           send: mockCalendarSend
         }
       }

--- a/apps/desktop/src/main/ipc/tasks-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/tasks-handlers.test.ts
@@ -25,7 +25,9 @@ vi.mock('electron', () => ({
     })
   },
   BrowserWindow: {
-    getAllWindows: vi.fn(() => [{ webContents: { send: vi.fn() } }])
+    getAllWindows: vi.fn(() => [
+      { isDestroyed: () => false, webContents: { isDestroyed: () => false, send: vi.fn() } }
+    ])
   }
 }))
 

--- a/apps/desktop/src/main/lib/window-broadcast.test.ts
+++ b/apps/desktop/src/main/lib/window-broadcast.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Window broadcast tests
+ *
+ * Regression: emit fan-outs iterated BrowserWindow.getAllWindows() and called
+ * webContents.send() with no isDestroyed() guard. A destroyed short-lived
+ * window (splash, quick-capture, print/export) made the emit throw — inside
+ * sync item handlers that throw propagates out of ctx.emit within
+ * ctx.db.transaction and rolls back an applied sync item.
+ *
+ * @module lib/window-broadcast.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const windows: unknown[] = []
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => windows)
+  }
+}))
+
+import { broadcastToAllWindows } from './window-broadcast'
+
+function makeLiveWindow() {
+  const send = vi.fn()
+  return {
+    win: {
+      isDestroyed: () => false,
+      webContents: { isDestroyed: () => false, send }
+    },
+    send
+  }
+}
+
+// Real Electron throws 'Object has been destroyed' on any access to a
+// destroyed window's webContents.
+function makeDestroyedWindow() {
+  return {
+    isDestroyed: () => true,
+    get webContents(): never {
+      throw new Error('Object has been destroyed')
+    }
+  }
+}
+
+function makeDeadContentsWindow() {
+  const send = vi.fn(() => {
+    throw new Error('Object has been destroyed')
+  })
+  return {
+    win: {
+      isDestroyed: () => false,
+      webContents: { isDestroyed: () => true, send }
+    },
+    send
+  }
+}
+
+describe('broadcastToAllWindows', () => {
+  beforeEach(() => {
+    windows.length = 0
+  })
+
+  it('sends the payload to every live window', () => {
+    const a = makeLiveWindow()
+    const b = makeLiveWindow()
+    windows.push(a.win, b.win)
+
+    broadcastToAllWindows('sync:event', { id: 1 })
+
+    expect(a.send).toHaveBeenCalledWith('sync:event', { id: 1 })
+    expect(b.send).toHaveBeenCalledWith('sync:event', { id: 1 })
+  })
+
+  it('skips a destroyed window and still delivers to the remaining windows', () => {
+    const before = makeLiveWindow()
+    const after = makeLiveWindow()
+    windows.push(before.win, makeDestroyedWindow(), after.win)
+
+    expect(() => broadcastToAllWindows('sync:event', { id: 1 })).not.toThrow()
+
+    expect(before.send).toHaveBeenCalledWith('sync:event', { id: 1 })
+    expect(after.send).toHaveBeenCalledWith('sync:event', { id: 1 })
+  })
+
+  it('skips a window whose webContents is destroyed', () => {
+    const live = makeLiveWindow()
+    const dead = makeDeadContentsWindow()
+    windows.push(dead.win, live.win)
+
+    expect(() => broadcastToAllWindows('sync:event', { id: 1 })).not.toThrow()
+
+    expect(dead.send).not.toHaveBeenCalled()
+    expect(live.send).toHaveBeenCalledWith('sync:event', { id: 1 })
+  })
+})

--- a/apps/desktop/src/main/lib/window-broadcast.ts
+++ b/apps/desktop/src/main/lib/window-broadcast.ts
@@ -1,0 +1,18 @@
+import { BrowserWindow } from 'electron'
+
+/**
+ * Send an IPC payload to every live window.
+ *
+ * getAllWindows() can contain destroyed short-lived windows (splash,
+ * quick-capture, print/export); touching their webContents throws
+ * "Object has been destroyed". Callers run inside db transactions (sync item
+ * handlers), where an unguarded throw rolls back an applied item — so skip
+ * destroyed windows, mirroring window-rpc.ts and crdt-provider.ts.
+ */
+export function broadcastToAllWindows(channel: string, data: unknown): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue
+    if (typeof win.webContents.isDestroyed === 'function' && win.webContents.isDestroyed()) continue
+    win.webContents.send(channel, data)
+  }
+}

--- a/apps/desktop/src/main/sync/runtime.test.ts
+++ b/apps/desktop/src/main/sync/runtime.test.ts
@@ -161,7 +161,12 @@ const runtimeMocks = vi.hoisted(() => {
 vi.mock('electron', () => ({
   app: { getVersion: vi.fn(() => '1.2.3') },
   BrowserWindow: {
-    getAllWindows: vi.fn(() => [{ webContents: { send: runtimeMocks.browserSend } }])
+    getAllWindows: vi.fn(() => [
+      {
+        isDestroyed: () => false,
+        webContents: { isDestroyed: () => false, send: runtimeMocks.browserSend }
+      }
+    ])
   }
 }))
 

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron'
+import { app } from 'electron'
 import sodium from 'libsodium-wrappers-sumo'
 import { eq } from 'drizzle-orm'
 import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
@@ -7,6 +7,7 @@ import { syncDevices } from '@memry/db-schema/schema/sync-devices'
 import { getDatabase, type DataDb } from '../database'
 import { isAppShuttingDown } from '../app-shutdown'
 import { createLogger } from '../lib/logger'
+import { broadcastToAllWindows } from '../lib/window-broadcast'
 import {
   getDevicePublicKey as deriveDevicePublicKey,
   getOrInitializeLocalVaultKey,
@@ -99,15 +100,11 @@ function getVerifiedVaultKey(db: DataDb): Promise<Uint8Array> {
 }
 
 function emitVaultRecoveryNeeded(event: VaultRecoveryNeededEvent): void {
-  for (const win of BrowserWindow.getAllWindows()) {
-    win.webContents.send(EVENT_CHANNELS.VAULT_RECOVERY_NEEDED, event)
-  }
+  broadcastToAllWindows(EVENT_CHANNELS.VAULT_RECOVERY_NEEDED, event)
 }
 
 function emitSyncStatus(event: SyncStatusChangedEvent): void {
-  for (const win of BrowserWindow.getAllWindows()) {
-    win.webContents.send(EVENT_CHANNELS.STATUS_CHANGED, event)
-  }
+  broadcastToAllWindows(EVENT_CHANNELS.STATUS_CHANGED, event)
 }
 
 function emitQuotaExceeded(): void {
@@ -590,9 +587,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       await crdtProvider.init(crdtQueue, snapshotPushFn)
 
       const emitFn = (channel: string, data: unknown): void => {
-        for (const win of BrowserWindow.getAllWindows()) {
-          win.webContents.send(channel, data)
-        }
+        broadcastToAllWindows(channel, data)
       }
 
       const workerBridge = new SyncWorkerBridge()

--- a/apps/desktop/src/main/tasks/publisher.test.ts
+++ b/apps/desktop/src/main/tasks/publisher.test.ts
@@ -14,7 +14,9 @@ const mockSend = vi.fn()
 
 vi.mock('electron', () => ({
   BrowserWindow: {
-    getAllWindows: vi.fn(() => [{ webContents: { send: mockSend } }])
+    getAllWindows: vi.fn(() => [
+      { isDestroyed: () => false, webContents: { isDestroyed: () => false, send: mockSend } }
+    ])
   }
 }))
 

--- a/apps/desktop/src/main/tasks/publisher.ts
+++ b/apps/desktop/src/main/tasks/publisher.ts
@@ -1,4 +1,3 @@
-import { BrowserWindow } from 'electron'
 import type { TasksDomainPublisher } from '@memry/domain-tasks'
 import { TasksChannels } from '@memry/contracts/ipc-channels'
 
@@ -11,11 +10,10 @@ import {
   syncTaskUpdate
 } from './runtime-effects'
 import { trackMainEvent } from '../telemetry/track'
+import { broadcastToAllWindows } from '../lib/window-broadcast'
 
 function emitTaskEvent(channel: string, data: unknown): void {
-  BrowserWindow.getAllWindows().forEach((win) => {
-    win.webContents.send(channel, data)
-  })
+  broadcastToAllWindows(channel, data)
 }
 
 // Task tags share the global tag list (see getTagsWithCounts). The tag hooks

--- a/apps/docs/src/architecture/ipc.md
+++ b/apps/docs/src/architecture/ipc.md
@@ -80,3 +80,7 @@ log.info('created note', { id })
 - The main process owns SQLite, Yjs `Y.Doc`s, and the file system.
 - The renderer owns UI state, tabs, and the BlockNote editor.
 - CRDT updates flow renderer → main via the Yjs IPC provider; updates are tagged with `sourceWindowId` and Y.Doc origin parameters to prevent loops.
+
+## Main → Renderer Broadcasts
+
+Main-process code that fans an event out to every open window (sync status, task and calendar change events) goes through `broadcastToAllWindows(channel, data)` in `src/main/lib/window-broadcast.ts`. The helper skips destroyed windows: short-lived windows (splash, quick capture, print/export) can still appear in `BrowserWindow.getAllWindows()` after destruction, and an unguarded `webContents.send()` throws — inside a sync item handler that throw escapes `ctx.emit` within the item's DB transaction and rolls it back. Use the helper instead of hand-rolling a `getAllWindows()` loop.


### PR DESCRIPTION
## What
Extract a guarded `broadcastToAllWindows()` helper (mirroring the `isDestroyed()` checks in `window-rpc.ts`/`crdt-provider.ts`) and route the sync runtime emits (`emitFn`, `emitSyncStatus`, `emitVaultRecoveryNeeded`), the tasks publisher, and calendar change-events through it; unit test covers fan-out surviving a destroyed window.

## Why
A destroyed short-lived window (splash, quick-capture, print/export) makes `webContents.send()` throw; inside sync item handlers that throw escapes `ctx.emit` within `ctx.db.transaction` and rolls back an applied sync item.