### PR TITLE
fix(agent-mcp): drop duplicated canvas tool schemas

### DIFF
--- a/apps/desktop/src/main/agent/mcp/tools/schemas.ts
+++ b/apps/desktop/src/main/agent/mcp/tools/schemas.ts
@@ -170,18 +170,6 @@ export const TOOL_SCHEMAS = {
       'Read one canvas: title, the entities on it (with titles), and any text written on it. ' +
       'Returns no scene geometry — use vault_add_canvas_item to change what is on it.'
   },
-  vault_list_canvases: {
-    input: z.object({}).default({}),
-    description:
-      'List spatial canvases with how many notes/tasks/events sit on each. ' +
-      'Never returns scene geometry.'
-  },
-  vault_read_canvas: {
-    input: z.object({ id: idSchema }),
-    description:
-      'Read one canvas: title, the entities on it (with titles), and any text written on it. ' +
-      'Returns no scene geometry — use vault_add_canvas_item to change what is on it.'
-  },
   vault_desktop_read: {
     input: desktopReadSchema,
     description:


### PR DESCRIPTION
## What
Remove the byte-identical second copies of `vault_list_canvases` / `vault_read_canvas` in `TOOL_SCHEMAS` — TS1117 has been breaking `typecheck:node` on main.

## Why
#927 and #929 both added the same canvas schema blocks; the merge kept both copies. No behavior change (duplicate keys resolve last-wins to identical values).

## Why CI didn't stop it
CI caught it — the gap is process, not tsconfig. Desktop CI runs the identical command (`tsc --noEmit -p tsconfig.node.json --composite false`, "Typecheck desktop main process" in desktop-ci.yml). #929's own **Static checks** run finished FAILURE at 12:12:27Z, 76s *after* the PR merged at 12:11:11Z — it was merged while checks were still pending, so they were never gating. The push-to-main Desktop CI runs for 2545aee08 and 7eb5813d0 also failed; main has been red since. Suggested fix: branch-protect "Static checks" as a required check (or wait for checks before merging).