### PR TITLE
feat(canvas): default the spatialCanvas flag on

### DIFF
--- a/apps/desktop/src/main/ipc/canvas-handlers.ts
+++ b/apps/desktop/src/main/ipc/canvas-handlers.ts
@@ -1,6 +1,6 @@
 /**
  * Canvas IPC handlers (spatial canvas).
- * CRUD for encrypted canvas scene snapshots; hidden behind the spatialCanvas
+ * CRUD for encrypted canvas scene snapshots; gated by the spatialCanvas
  * feature flag in the renderer.
  *
  * @module ipc/canvas-handlers

--- a/apps/desktop/src/main/settings/features.test.ts
+++ b/apps/desktop/src/main/settings/features.test.ts
@@ -37,19 +37,20 @@ describe('getFeaturesSettings', () => {
   })
 
   it('merges a stored partial over the defaults', () => {
-    mocks.getSetting.mockReturnValue(JSON.stringify({ spatialCanvas: true }))
+    mocks.getSetting.mockReturnValue(JSON.stringify({ spatialCanvas: false }))
 
     const settings = getFeaturesSettings()
 
-    expect(settings.spatialCanvas).toBe(true)
+    // The stored opt-out wins over the default-on flag.
+    expect(settings.spatialCanvas).toBe(false)
     // Every other flag keeps its default rather than becoming undefined.
     expect(settings.inbox).toBe(FEATURES_SETTINGS_DEFAULTS.inbox)
   })
 
-  it('defaults spatialCanvas off, matching the opt-in rollout', () => {
+  it('defaults spatialCanvas on for an install that never wrote the key', () => {
     mocks.getSetting.mockReturnValue(undefined)
 
-    expect(getFeaturesSettings().spatialCanvas).toBe(false)
+    expect(getFeaturesSettings().spatialCanvas).toBe(true)
   })
 
   it('falls back to defaults on a corrupt blob WITHOUT deleting it', () => {

--- a/apps/desktop/src/main/settings/promote-spatial-canvas.test.ts
+++ b/apps/desktop/src/main/settings/promote-spatial-canvas.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getSetting: vi.fn(),
+  setSetting: vi.fn()
+}))
+
+vi.mock('../database/queries/settings', () => ({
+  getSetting: mocks.getSetting,
+  setSetting: mocks.setSetting
+}))
+
+import { promoteSpatialCanvas, SPATIAL_CANVAS_PROMOTED_KEY } from './promote-spatial-canvas'
+
+const db = {} as never
+
+/** Stored settings rows, keyed the way getSetting reads them. */
+function withStore(rows: Record<string, string>): void {
+  mocks.getSetting.mockImplementation((_db: unknown, key: string) => rows[key] ?? null)
+}
+
+/** The `features` blob written by this run, or null when nothing was written. */
+function writtenFeatures(): Record<string, unknown> | null {
+  const call = mocks.setSetting.mock.calls.find(([, key]) => key === 'features')
+  return call ? (JSON.parse(call[2] as string) as Record<string, unknown>) : null
+}
+
+describe('promoteSpatialCanvas', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rewrites the collateral false left by a pre-M7 feature toggle', () => {
+    withStore({ features: JSON.stringify({ journal: false, spatialCanvas: false }) })
+
+    promoteSpatialCanvas(db)
+
+    expect(writtenFeatures()).toEqual({ journal: false, spatialCanvas: true })
+  })
+
+  it('preserves the rest of the group, including keys it does not know', () => {
+    withStore({
+      features: JSON.stringify({ graph: false, spatialCanvas: false, futureFlag: true })
+    })
+
+    promoteSpatialCanvas(db)
+
+    expect(writtenFeatures()).toEqual({ graph: false, spatialCanvas: true, futureFlag: true })
+  })
+
+  it('never runs twice — an opt-out made after the promotion survives', () => {
+    withStore({
+      features: JSON.stringify({ spatialCanvas: false }),
+      [SPATIAL_CANVAS_PROMOTED_KEY]: '1'
+    })
+
+    promoteSpatialCanvas(db)
+
+    expect(mocks.setSetting).not.toHaveBeenCalled()
+  })
+
+  it('marks the vault promoted so the next open is a no-op', () => {
+    withStore({ features: JSON.stringify({ spatialCanvas: false }) })
+
+    promoteSpatialCanvas(db)
+
+    expect(mocks.setSetting).toHaveBeenCalledWith(db, SPATIAL_CANVAS_PROMOTED_KEY, '1')
+  })
+
+  it('writes no features blob for a fresh vault that never stored the group', () => {
+    withStore({})
+
+    promoteSpatialCanvas(db)
+
+    expect(writtenFeatures()).toBeNull()
+    expect(mocks.setSetting).toHaveBeenCalledWith(db, SPATIAL_CANVAS_PROMOTED_KEY, '1')
+  })
+
+  it('leaves a group that never stored the key to the defaults merge', () => {
+    withStore({ features: JSON.stringify({ journal: false }) })
+
+    promoteSpatialCanvas(db)
+
+    expect(writtenFeatures()).toBeNull()
+  })
+
+  it('leaves an already-on install untouched', () => {
+    withStore({ features: JSON.stringify({ spatialCanvas: true }) })
+
+    promoteSpatialCanvas(db)
+
+    expect(writtenFeatures()).toBeNull()
+  })
+
+  it('marks a corrupt blob promoted without rewriting it', () => {
+    withStore({ features: '{not json' })
+
+    promoteSpatialCanvas(db)
+
+    // The read path already reports defaults — on — for a corrupt blob, and
+    // rewriting it here would destroy whatever the IPC repair path could keep.
+    expect(writtenFeatures()).toBeNull()
+    expect(mocks.setSetting).toHaveBeenCalledWith(db, SPATIAL_CANVAS_PROMOTED_KEY, '1')
+  })
+})

--- a/apps/desktop/src/main/settings/promote-spatial-canvas.ts
+++ b/apps/desktop/src/main/settings/promote-spatial-canvas.ts
@@ -1,0 +1,60 @@
+/**
+ * One-time promotion of the spatialCanvas flag to on.
+ *
+ * `spatialCanvas` defaulted to `false` until the M7 rollout. Flipping the
+ * default alone does not reach every install: `writeGroupSettings` persists the
+ * whole `features` group, so a user who toggled *any* feature — Journal, Graph,
+ * anything — also wrote `spatialCanvas: false` to disk without ever making a
+ * decision about canvas. The stored value wins over the default, so those
+ * installs would silently miss the surface the release is announcing.
+ *
+ * This pass runs once per vault and rewrites only that collateral `false`. It
+ * is not a re-enable loop: the marker key is set on the first run whatever the
+ * outcome, so a user who turns canvas off *after* the promotion keeps it off
+ * forever. Deleting this module (and its call in `vault/index.ts`) is the
+ * clean-up once the flip is well past.
+ *
+ * Read-only sibling: `settings/features.ts` deliberately never writes. The
+ * write lives here so that stays true.
+ *
+ * @module settings/promote-spatial-canvas
+ */
+
+import type { FeaturesSettings } from '@memry/contracts/settings-schemas'
+import type { DataDb } from '../database/types'
+import { getSetting, setSetting } from '../database/queries/settings'
+import { createLogger } from '../lib/logger'
+
+const logger = createLogger('Settings:CanvasPromotion')
+
+const FEATURES_KEY = 'features'
+
+/** Set once the vault has been through the promotion, whatever the outcome. */
+export const SPATIAL_CANVAS_PROMOTED_KEY = 'features.spatialCanvasPromoted'
+
+export function promoteSpatialCanvas(db: DataDb): void {
+  if (getSetting(db, SPATIAL_CANVAS_PROMOTED_KEY)) return
+
+  const raw = getSetting(db, FEATURES_KEY)
+
+  // No stored group at all (a fresh vault) — the read path already merges the
+  // default, which is now on. Nothing to rewrite.
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as Partial<FeaturesSettings>
+
+      // Only an explicit `false` needs rewriting. A missing key already reads
+      // as on via the defaults merge, and `true` is where we want to be.
+      if (parsed.spatialCanvas === false) {
+        setSetting(db, FEATURES_KEY, JSON.stringify({ ...parsed, spatialCanvas: true }))
+        logger.info('Promoted spatialCanvas to on for this vault')
+      }
+    } catch {
+      // A corrupt blob reads as defaults — already on — so there is nothing to
+      // promote. Fall through and mark it so this does not retry every open.
+      logger.warn('Features settings unreadable; skipping canvas promotion')
+    }
+  }
+
+  setSetting(db, SPATIAL_CANVAS_PROMOTED_KEY, '1')
+}

--- a/apps/desktop/src/main/vault/index.test.ts
+++ b/apps/desktop/src/main/vault/index.test.ts
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => ({
   initializeFtsInbox: vi.fn(),
   closeAllDatabases: vi.fn(),
   ensureDefaultTaskProject: vi.fn(),
+  promoteSpatialCanvas: vi.fn(),
   reloadPropertyDefinitions: vi.fn(),
   destroyPropertyDefinitions: vi.fn(),
   migrateSettingsToConfig: vi.fn(),
@@ -117,6 +118,10 @@ vi.mock('../database', () => ({
   getDatabase: () => ({ kind: 'data-db' }),
   getIndexDatabase: () => ({ kind: 'index-db' }),
   checkIndexHealth: (...args: unknown[]) => mocks.checkIndexHealth(...args)
+}))
+
+vi.mock('../settings/promote-spatial-canvas', () => ({
+  promoteSpatialCanvas: (...args: unknown[]) => mocks.promoteSpatialCanvas(...args)
 }))
 
 vi.mock('../database/defaults', () => ({
@@ -294,6 +299,8 @@ describe('vault lifecycle', () => {
     expect(mocks.initVault).toHaveBeenCalledWith('/vault/work')
     expect(mocks.runMigrations).toHaveBeenCalledWith('/vault/work/data.db')
     expect(mocks.runIndexMigrations).toHaveBeenCalledWith('/vault/work/index.db')
+    // Existing installs only get canvas turned on if this runs on open.
+    expect(mocks.promoteSpatialCanvas).toHaveBeenCalledWith({ kind: 'data-db' })
     expect(mocks.reloadPropertyDefinitions).toHaveBeenCalled()
     expect(mocks.indexVault).toHaveBeenCalledWith('/vault/work')
     expect(mocks.startWatcher).toHaveBeenCalledWith('/vault/work')

--- a/apps/desktop/src/main/vault/index.ts
+++ b/apps/desktop/src/main/vault/index.ts
@@ -58,6 +58,7 @@ import { createEmbeddingProjector } from '../projections/projectors/embedding-pr
 import { createInboxStatsProjector } from '../projections/projectors/inbox-stats-projector'
 import { PropertyDefinitionsService } from './property-definitions'
 import { migrateSettingsToConfig } from './settings-cache'
+import { promoteSpatialCanvas } from '../settings/promote-spatial-canvas'
 import { configureLazyAgentServices } from '../agent/lazy-services'
 import { registerLazyAgentHandlers, unregisterLazyAgentHandlers } from '../ipc/agent-lazy-handlers'
 import type { AgentHandle } from '../agent/bootstrap'
@@ -260,6 +261,9 @@ async function openVault(vaultPath: string): Promise<void> {
 
   // Migrate settings: config.json ↔ SQLite cache
   migrateSettingsToConfig(dataDb, vaultPath)
+
+  // One-time: clear a collateral `spatialCanvas: false` left by pre-M7 writes.
+  promoteSpatialCanvas(dataDb)
 
   // Check index database health before proceeding
   const indexHealth: IndexHealth = checkIndexHealth(indexDbPath)

--- a/apps/desktop/src/renderer/src/components/app-sidebar.projects.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.projects.test.tsx
@@ -88,6 +88,13 @@ vi.mock('@/components/sidebar/sidebar-tag-list', () => ({
   SidebarTagList: () => <div>Tag list</div>
 }))
 
+// Heavy child, and the only one that subscribes to canvas IPC events. The
+// spatialCanvas flag defaults on, so this list now mounts in every sidebar
+// test; its own behavior is covered by sidebar-canvas-list.test.tsx.
+vi.mock('@/components/sidebar/sidebar-canvas-list', () => ({
+  SidebarCanvasList: () => <div>Canvas list</div>
+}))
+
 vi.mock('@/components/sidebar/sidebar-bookmark-list', () => ({
   SidebarBookmarkList: () => <div>Bookmark list</div>
 }))

--- a/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.test.tsx
@@ -124,6 +124,13 @@ vi.mock('@/components/notes-tree', () => ({
   )
 }))
 
+// Heavy child, and the only one that subscribes to canvas IPC events. The
+// spatialCanvas flag defaults on, so this list now mounts in every sidebar
+// test; its own behavior is covered by sidebar-canvas-list.test.tsx.
+vi.mock('@/components/sidebar/sidebar-canvas-list', () => ({
+  SidebarCanvasList: () => <div>Canvas list</div>
+}))
+
 vi.mock('@/components/sidebar/sidebar-tag-list', () => ({
   SidebarTagList: ({ onActionsReady }: { onActionsReady: (node: ReactNode) => void }) => {
     useEffect(() => {

--- a/apps/desktop/src/renderer/src/components/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-sidebar.tsx
@@ -561,7 +561,7 @@ function AppSidebarInner({ currentPage: _currentPage, viewCounts, ...props }: Ap
           <SidebarBookmarkList maxVisible={6} onBookmarkClick={handleBookmarkClick} />
         </SidebarSection>
 
-        {/* CANVASES Section (hidden-phase spatialCanvas flag) */}
+        {/* CANVASES Section (gated by the spatialCanvas flag, default on) */}
         {isEnabled('spatialCanvas') && (
           <SidebarSection
             id="canvases"

--- a/apps/docs/src/user-guide/canvas/overview.md
+++ b/apps/docs/src/user-guide/canvas/overview.md
@@ -12,6 +12,9 @@ notes it explains.
 
 Canvas is on by default: a **Canvases** section is already in your sidebar.
 
+Canvas was off by default in earlier versions, so upgrading turns it on once
+even if it was off before. Turning it off after that keeps it off for good.
+
 To hide it, open **Settings → Features** and turn **Canvas** off. The setting is
 per device and persists across restarts, so turning it off on your laptop leaves
 it on elsewhere. Turning it off hides the surface — it does not delete any

--- a/apps/docs/src/user-guide/canvas/overview.md
+++ b/apps/docs/src/user-guide/canvas/overview.md
@@ -8,12 +8,14 @@ Canvases are useful when an outline is the wrong shape for your thinking —
 planning a project, mapping how ideas connect, sketching a diagram next to the
 notes it explains.
 
-## Turning it on
+## Turning it on and off
 
-Canvas is opt-in. Open **Settings → Features** and turn on **Canvas**. The
-setting is per device and persists across restarts.
+Canvas is on by default: a **Canvases** section is already in your sidebar.
 
-Once enabled, a **Canvases** section appears in the sidebar.
+To hide it, open **Settings → Features** and turn **Canvas** off. The setting is
+per device and persists across restarts, so turning it off on your laptop leaves
+it on elsewhere. Turning it off hides the surface — it does not delete any
+canvas you have already made.
 
 ## Creating and opening a canvas
 

--- a/apps/docs/src/user-guide/canvas/sync-and-limits.md
+++ b/apps/docs/src/user-guide/canvas/sync-and-limits.md
@@ -52,8 +52,8 @@ canvases is the usual fix.
 - Palm rejection and pen pressure depend on your hardware and OS.
 - The drawing toolbar's language comes from the underlying canvas engine and may
   differ from memrynote's interface language.
-- Canvas is opt-in per device — enabling it on one device does not enable it on
-  another.
+- The Canvas toggle is per device — turning it off on one device does not turn
+  it off on another.
 - The shape library is stored per vault but does not sync between devices yet.
 - Publishing a shape kit to the public Excalidraw library from inside memrynote
   is not supported; the panel's **Publish** action does not work here.

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -196,7 +196,7 @@ Show or hide journal sidebar panes:
 
 Simple on/off toggles for optional or in-progress surfaces, per device.
 
-- **Canvas** — enables the spatial canvas surface and its sidebar section. Off by default. See [Canvas Overview](./canvas/overview.md).
+- **Canvas** — enables the spatial canvas surface and its sidebar section. On by default. See [Canvas Overview](./canvas/overview.md).
 
 ---
 

--- a/packages/contracts/src/feature-flags.test.ts
+++ b/packages/contracts/src/feature-flags.test.ts
@@ -3,7 +3,7 @@ import { FEATURES_SETTINGS_DEFAULTS, FeaturesSettingsSchema } from './settings-s
 import { featureForTabType, FEATURE_KEYS } from './feature-flags'
 
 describe('feature flags', () => {
-  it('defaults core features on and the opt-in spatialCanvas off', () => {
+  it('defaults every feature on, including spatialCanvas', () => {
     expect(FeaturesSettingsSchema.parse(FEATURES_SETTINGS_DEFAULTS)).toEqual({
       home: true,
       inbox: true,
@@ -11,7 +11,7 @@ describe('feature flags', () => {
       tasks: true,
       calendar: true,
       graph: true,
-      spatialCanvas: false
+      spatialCanvas: true
     })
   })
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -673,7 +673,7 @@ export type CalendarEventChannel =
   (typeof CalendarChannels.events)[keyof typeof CalendarChannels.events]
 
 // ============================================================================
-// Canvas Channels (spatial canvas — hidden behind the spatialCanvas flag)
+// Canvas Channels (spatial canvas — gated by the spatialCanvas flag)
 // ============================================================================
 
 export const CanvasChannels = {

--- a/packages/contracts/src/settings-schemas.ts
+++ b/packages/contracts/src/settings-schemas.ts
@@ -229,8 +229,9 @@ export const FeaturesSettingsSchema = z.object({
   tasks: z.boolean(),
   calendar: z.boolean(),
   graph: z.boolean(),
-  // Opt-in Settings toggle (in FEATURE_KEYS), default OFF: spatial canvas
-  // surface. Local-only for now — cross-device sync (M4) is not wired yet.
+  // Settings toggle (in FEATURE_KEYS), default ON since the M7 rollout: spatial
+  // canvas surface. An install that stored `false` keeps it off — the stored
+  // value wins over the default.
   spatialCanvas: z.boolean()
 })
 
@@ -243,7 +244,7 @@ export const FEATURES_SETTINGS_DEFAULTS: FeaturesSettings = {
   tasks: true,
   calendar: true,
   graph: true,
-  spatialCanvas: false
+  spatialCanvas: true
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

- Flips `FEATURES_SETTINGS_DEFAULTS.spatialCanvas` to `true`, so a fresh install gets the **Canvases** sidebar section and a **Settings → Features → Canvas** toggle that already reads On.
- Adds `promoteSpatialCanvas`, a one-time per-vault pass at vault open that clears a collateral `spatialCanvas: false` left by pre-M7 writes.
- Docs and the default-off test expectations follow; the two sidebar suites now mock `SidebarCanvasList`, which mounts for the first time under the on-by-default flag.

## Why

M7 PR B — the default-on flip, per `docs/superpowers/specs/2026-07-22-spatial-canvas-m7-rollout-design.md` §7. Its prerequisites are on `main`: the split-view note lock, `canvas_created` / `canvas_opened` telemetry, `X-Memry-Sync-Types` negotiation, and the canvas user guide.

The default alone does not reach every install. `writeGroupSettings` persists the whole `features` group, so a user who toggled *any* other feature also wrote `spatialCanvas: false` to disk without ever deciding about canvas, and the stored value wins over the default. §8 of the design reads that as a deliberate opt-out; the mechanism cannot tell it apart from "turned Journal off once". The promotion pass rewrites only that case, marks the vault, and never runs again — so an opt-out made *after* this release survives.

Rollback: the one-line default plus its two test expectations; the promotion module and its `vault/index.ts` call are one file and one line to delete.