### PR TITLE
feat(calendar): assign a project to an event from the event form

### DIFF
--- a/apps/desktop/src/main/database/queries/projects.ts
+++ b/apps/desktop/src/main/database/queries/projects.ts
@@ -806,6 +806,11 @@ export function updateProjectHomeNote(db: DataDb, projectId: string, noteId: str
 
 /**
  * List the projects a given item (note, calendar event, or file) belongs to.
+ *
+ * Ordered oldest link first, same as `getProjectLinks`. Consumers that render a
+ * single-select control over this many-to-many table treat the first row as the
+ * item's project, so an unordered result would let an unrelated write reshuffle
+ * what the UI calls "the" project.
  */
 export function getProjectsForItem(db: DataDb, itemType: string, itemId: string) {
   return db
@@ -818,6 +823,7 @@ export function getProjectsForItem(db: DataDb, itemType: string, itemId: string)
     .from(projectLinks)
     .innerJoin(projects, eq(projectLinks.projectId, projects.id))
     .where(and(eq(projectLinks.itemType, itemType), eq(projectLinks.itemId, itemId)))
+    .orderBy(asc(projectLinks.createdAt), asc(projectLinks.id))
     .all()
 }
 

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-event-form.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-event-form.tsx
@@ -17,7 +17,7 @@ import { cn } from '@/lib/utils'
 import { toLocalDateString } from './date-utils'
 import { CalendarPicker } from './calendar-picker'
 import { CalendarEventMetadata } from './calendar-event-metadata'
-import { ItemProjectChips } from '@/components/tasks/projects/item-project-chips'
+import { EventProjectField } from './event-project-field'
 import { useGoogleCalendars } from '@/hooks/use-google-calendars'
 import type { CalendarEventDraft } from './types'
 import type { CalendarEventReadOnlyMetadata } from './calendar-event-popover'
@@ -219,9 +219,13 @@ export function CalendarEventForm({
         disabled={isSaving}
       />
 
-      {mode === 'edit' && eventId && (
-        <ItemProjectChips itemType="calendar_event" itemId={eventId} />
-      )}
+      <EventProjectField
+        mode={mode}
+        eventId={eventId}
+        value={draft.projectId}
+        onChange={(projectId) => onDraftChange({ ...draft, projectId })}
+        disabled={isSaving}
+      />
 
       <label className="flex items-center justify-between gap-3 rounded-md border border-border bg-background px-3 py-2 text-sm">
         <span className="flex items-center gap-2 text-muted-foreground">

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-event-popover.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-event-popover.test.tsx
@@ -99,7 +99,8 @@ const baseDraft: CalendarEventDraft = {
   startAt: '2026-05-10T09:00',
   endAt: '2026-05-10T10:00',
   isAllDay: false,
-  targetCalendarId: null
+  targetCalendarId: null,
+  projectId: null
 }
 
 describe('CalendarEventPopover', () => {

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-quick-create-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-quick-create-dialog.tsx
@@ -83,7 +83,8 @@ export function CalendarQuickCreateDialog({
       isAllDay,
       startAt,
       endAt,
-      targetCalendarId: null
+      targetCalendarId: null,
+      projectId: null
     }
   }
 

--- a/apps/desktop/src/renderer/src/components/calendar/calendar-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/calendar-shell.test.tsx
@@ -106,7 +106,8 @@ vi.mock('./calendar-week-view', () => ({
             startAt: '2026-05-14T09:00',
             endAt: '2026-05-14T10:00',
             isAllDay: false,
-            targetCalendarId: null
+            targetCalendarId: null,
+            projectId: null
           })
         }
       >
@@ -159,7 +160,8 @@ vi.mock('./calendar-event-popover', () => ({
             startAt: '2026-05-14T09:00',
             endAt: '2026-05-14T10:00',
             isAllDay: false,
-            targetCalendarId: null
+            targetCalendarId: null,
+            projectId: null
           })
         }
       >
@@ -263,7 +265,8 @@ describe('CalendarShell', () => {
           startAt: '2026-05-14T09:00',
           endAt: '2026-05-14T10:00',
           isAllDay: false,
-          targetCalendarId: null
+          targetCalendarId: null,
+          projectId: null
         },
         anchorRect: { x: 0, y: 0, width: 10, height: 10 }
       },

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
@@ -1,14 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { EventProjectField } from './event-project-field'
 
-const { mockListForItem, mockLinkProjectItem, mockUnlinkProjectItem, mockOnProjectUpdated } =
-  vi.hoisted(() => ({
-    mockListForItem: vi.fn(),
-    mockLinkProjectItem: vi.fn(),
-    mockUnlinkProjectItem: vi.fn(),
-    mockOnProjectUpdated: vi.fn(() => () => {})
-  }))
+const {
+  mockListForItem,
+  mockLinkProjectItem,
+  mockUnlinkProjectItem,
+  mockOnProjectUpdated,
+  mockToastError
+} = vi.hoisted(() => ({
+  mockListForItem: vi.fn(),
+  mockLinkProjectItem: vi.fn(),
+  mockUnlinkProjectItem: vi.fn(),
+  mockOnProjectUpdated: vi.fn(() => () => {}),
+  mockToastError: vi.fn()
+}))
 
 vi.mock('@/services/tasks-service', () => ({
   tasksService: {
@@ -17,6 +23,10 @@ vi.mock('@/services/tasks-service', () => ({
     unlinkProjectItem: mockUnlinkProjectItem
   },
   onProjectUpdated: mockOnProjectUpdated
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: mockToastError, success: vi.fn() }
 }))
 
 // Projects come from the app-wide TasksProvider, same as calendar-task-popover.
@@ -89,5 +99,147 @@ describe('EventProjectField · create mode', () => {
     fireEvent.click(screen.getByText('No project'))
 
     expect(onChange).toHaveBeenCalledWith(null)
+  })
+})
+
+describe('EventProjectField · edit mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockOnProjectUpdated.mockReturnValue(() => {})
+    mockListForItem.mockResolvedValue([])
+    mockLinkProjectItem.mockResolvedValue({ success: true })
+    mockUnlinkProjectItem.mockResolvedValue({ success: true })
+  })
+
+  it('loads the current links for the event on mount', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledWith('calendar_event', 'evt-1'))
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+  })
+
+  it('renders nothing when edit mode has no event id yet', () => {
+    const { container } = render(
+      <EventProjectField mode="edit" eventId={null} value={null} onChange={vi.fn()} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+    expect(mockListForItem).not.toHaveBeenCalled()
+  })
+
+  it('unlinks the previous project and links the new one when the selection changes', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    fireEvent.click(screen.getByText('pick-Finance'))
+
+    await waitFor(() =>
+      expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'calendar_event',
+        itemId: 'evt-1'
+      })
+    )
+    expect(mockLinkProjectItem).toHaveBeenCalledWith({
+      projectId: 'p2',
+      itemType: 'calendar_event',
+      itemId: 'evt-1'
+    })
+  })
+
+  it('only links when the event had no project', async () => {
+    mockListForItem.mockResolvedValue([])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    await waitFor(() => expect(mockLinkProjectItem).toHaveBeenCalledTimes(1))
+    expect(mockUnlinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('only unlinks when the user picks "No project"', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    fireEvent.click(screen.getByText('No project'))
+
+    await waitFor(() =>
+      expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'calendar_event',
+        itemId: 'evt-1'
+      })
+    )
+    expect(mockLinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('never calls onChange in edit mode (the draft does not own the link)', async () => {
+    const onChange = vi.fn()
+    mockListForItem.mockResolvedValue([])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={onChange} />)
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    await waitFor(() => expect(mockLinkProjectItem).toHaveBeenCalled())
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('treats an IPC error envelope from listForItem as no links', async () => {
+    mockListForItem.mockResolvedValue({ success: false, error: 'db error' })
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', '')
+    )
+  })
+
+  it('shows a toast and reloads when a link write fails', async () => {
+    mockListForItem.mockResolvedValue([])
+    mockLinkProjectItem.mockResolvedValue({ success: false, error: 'link failed' })
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(2))
+  })
+
+  it('reloads when a project update event fires', async () => {
+    mockListForItem
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'p2', name: 'Finance', color: '#00ff00', icon: null }])
+    let updateHandler: (() => void) | undefined
+    mockOnProjectUpdated.mockImplementation((cb: () => void) => {
+      updateHandler = cb
+      return () => {}
+    })
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(1))
+
+    updateHandler?.()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p2')
+    )
   })
 })

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
@@ -344,4 +344,70 @@ describe('EventProjectField · edit mode', () => {
       expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p2')
     )
   })
+
+  it('renders extra links as removable chips beside the picker', async () => {
+    mockListForItem.mockResolvedValue([
+      { id: 'p1', name: 'Launch', color: '#ff0000', icon: null },
+      { id: 'p2', name: 'Finance', color: '#00ff00', icon: null }
+    ])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+    expect(await screen.findByText('Finance')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove from Finance' })).toBeInTheDocument()
+  })
+
+  it('unlinks only the chip that was removed', async () => {
+    mockListForItem.mockResolvedValue([
+      { id: 'p1', name: 'Launch', color: '#ff0000', icon: null },
+      { id: 'p2', name: 'Finance', color: '#00ff00', icon: null }
+    ])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    const remove = await screen.findByRole('button', { name: 'Remove from Finance' })
+
+    fireEvent.click(remove)
+
+    await waitFor(() => expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1))
+    expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+      projectId: 'p2',
+      itemType: 'calendar_event',
+      itemId: 'evt-1'
+    })
+  })
+
+  it('switching the primary project leaves the extra link untouched', async () => {
+    mockListForItem.mockResolvedValue([
+      { id: 'p1', name: 'Launch', color: '#ff0000', icon: null },
+      { id: 'p2', name: 'Finance', color: '#00ff00', icon: null }
+    ])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    fireEvent.click(screen.getByText('pick-Finance'))
+
+    await waitFor(() => expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1))
+    expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+      projectId: 'p1',
+      itemType: 'calendar_event',
+      itemId: 'evt-1'
+    })
+  })
+
+  it('shows no chips when the event has a single project', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+    expect(screen.queryByRole('button', { name: /^Remove from/ })).not.toBeInTheDocument()
+  })
 })

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
@@ -77,10 +77,23 @@ vi.mock('@/components/tasks/project-picker', () => ({
   )
 }))
 
+// `mockReset`, not `vi.clearAllMocks`: the latter clears recorded calls but
+// leaves a `mockResolvedValueOnce` queue intact, and a `mockResolvedValue`
+// fallback never takes precedence over a queued `once`. A test whose queue is
+// sized to the current reload count would then leak its leftover into the next
+// test's mount load and fail it for the wrong reason.
+const resetTaskMocks = (): void => {
+  mockListForItem.mockReset()
+  mockLinkProjectItem.mockReset()
+  mockUnlinkProjectItem.mockReset()
+  mockOnProjectUpdated.mockReset()
+  mockToastError.mockReset()
+  mockOnProjectUpdated.mockImplementation(() => () => {})
+}
+
 describe('EventProjectField · create mode', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockOnProjectUpdated.mockReturnValue(() => {})
+    resetTaskMocks()
   })
 
   it('renders the picker with the draft value and no IPC call', () => {
@@ -110,12 +123,23 @@ describe('EventProjectField · create mode', () => {
 
     expect(onChange).toHaveBeenCalledWith(null)
   })
+
+  it('drops picks while the form is saving', () => {
+    // `handlePopoverSave` has already captured the draft by then, so a pick
+    // accepted here would be written into a `popoverState` the in-flight save
+    // can no longer see — silently lost.
+    const onChange = vi.fn()
+    render(<EventProjectField mode="create" value={null} onChange={onChange} disabled />)
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
 })
 
 describe('EventProjectField · edit mode', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockOnProjectUpdated.mockReturnValue(() => {})
+    resetTaskMocks()
     mockListForItem.mockResolvedValue([])
     mockLinkProjectItem.mockResolvedValue({ success: true })
     mockUnlinkProjectItem.mockResolvedValue({ success: true })
@@ -288,6 +312,37 @@ describe('EventProjectField · edit mode', () => {
     )
     // The click during the load window was dropped, not queued.
     expect(mockLinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('stops blocking picks when a load never answers', async () => {
+    // `listForItem` is a bare `ipcRenderer.invoke` with no timeout, so a wedged
+    // main process would otherwise leave the field inert forever — no spinner,
+    // no toast, and no way back short of closing and reopening the popover.
+    vi.useFakeTimers()
+    try {
+      mockListForItem.mockReturnValue(new Promise(() => {}))
+
+      render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1)
+      })
+
+      // Still inside the guard window: the pick is dropped, as designed.
+      fireEvent.click(screen.getByText('pick-Launch'))
+      expect(mockLinkProjectItem).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000)
+      })
+
+      fireEvent.click(screen.getByText('pick-Launch'))
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1)
+      })
+      expect(mockLinkProjectItem).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('ignores a second selection while the first write is still in flight', async () => {
@@ -474,26 +529,25 @@ describe('EventProjectField · edit mode', () => {
     expect(mockUnlinkProjectItem).not.toHaveBeenCalled()
   })
 
-  it('keeps the write guard closed when a project update reloads mid-swap', async () => {
-    // `unlinkItemFromProject` publishes `projectUpdated` BEFORE it resolves,
-    // so a reload lands between the unlink and the link of one swap and sees
-    // the intermediate (empty) DB state. Sharing one flag between load and
-    // write let that reload's `finally` reopen the guard with stale-empty
-    // `links`, and the next click would link a third project without
-    // unlinking anything.
+  it('ignores the projectUpdated broadcast its own swap publishes', async () => {
+    // `linkItemToProject` / `unlinkItemFromProject` publish `projectUpdated`
+    // BEFORE they resolve, so a broadcast lands mid-swap while the DB is only
+    // half written. Reloading on it would fetch that intermediate state — a
+    // visible "No project" flash — and could reopen the write guard with
+    // stale-empty `links`, letting the next click link a third project without
+    // unlinking anything. The trailing reload after the whole write covers it.
     mockListForItem
       .mockResolvedValueOnce([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
-      .mockResolvedValueOnce([])
       .mockResolvedValue([{ id: 'p2', name: 'Finance', color: '#00ff00', icon: null }])
     let updateHandler: (() => void) | undefined
     mockOnProjectUpdated.mockImplementation((cb: () => void) => {
       updateHandler = cb
       return () => {}
     })
-    let resolveUnlink: ((value: { success: boolean }) => void) | undefined
-    mockUnlinkProjectItem.mockReturnValue(
+    let resolveLink: ((value: { success: boolean }) => void) | undefined
+    mockLinkProjectItem.mockReturnValue(
       new Promise((resolve) => {
-        resolveUnlink = resolve
+        resolveLink = resolve
       })
     )
 
@@ -501,35 +555,132 @@ describe('EventProjectField · edit mode', () => {
     await waitFor(() =>
       expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
     )
+    expect(mockListForItem).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByText('pick-Finance'))
-    await waitFor(() => expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mockLinkProjectItem).toHaveBeenCalledTimes(1))
 
-    // The broadcast the in-flight unlink itself publishes.
+    // The broadcast the in-flight link itself publishes.
     updateHandler?.()
-    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(2))
-    // That reload has resolved and committed the intermediate empty state.
-    await waitFor(() =>
-      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', '')
-    )
+    await act(async () => {})
+    // No mid-swap reload, so no intermediate state on screen either.
+    expect(mockListForItem).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
 
     // A click landing in exactly that window, on a THIRD project so it cannot
     // be absorbed by the "same id, no-op" short-circuit.
     fireEvent.click(screen.getByText('pick-Marketing'))
 
-    resolveUnlink?.({ success: true })
-    await waitFor(() =>
-      expect(mockLinkProjectItem).toHaveBeenCalledWith({
-        projectId: 'p2',
-        itemType: 'calendar_event',
-        itemId: 'evt-1'
-      })
-    )
+    resolveLink?.({ success: true })
+    await waitFor(() => expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1))
     expect(mockLinkProjectItem).toHaveBeenCalledTimes(1)
     expect(mockLinkProjectItem).not.toHaveBeenCalledWith(
       expect.objectContaining({ projectId: 'p3' })
     )
+    // Exactly one reload for the whole swap, not one per IPC call.
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(2))
+  })
+
+  it('keeps a pickable link in the picker when an unpickable link is stored first', async () => {
+    // `getProjectsForItem` has no ORDER BY, so the archived link can come back
+    // first. Reading `links[0]` here would render "No project" while the live
+    // p1 link exists, and the pick below would then link p2 as a THIRD link
+    // instead of replacing p1.
+    mockListForItem.mockResolvedValue([
+      { id: 'p4', name: 'Retired', color: '#999999', icon: null },
+      { id: 'p1', name: 'Launch', color: '#ff0000', icon: null }
+    ])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+    expect(screen.getByRole('button', { name: 'Remove from Retired' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('pick-Finance'))
+
+    await waitFor(() =>
+      expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'calendar_event',
+        itemId: 'evt-1'
+      })
+    )
     expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1)
+  })
+
+  it('links the new project before unlinking the old one', async () => {
+    // Two non-transactional IPC calls: whichever runs second can fail after the
+    // first landed. Linking first makes that failure leave one link too many —
+    // visible and removable as a chip — instead of destroying the assignment
+    // the user asked to *change*.
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+    mockUnlinkProjectItem.mockResolvedValue({ success: false, error: 'unlink failed' })
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    fireEvent.click(screen.getByText('pick-Finance'))
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    expect(mockLinkProjectItem).toHaveBeenCalledWith({
+      projectId: 'p2',
+      itemType: 'calendar_event',
+      itemId: 'evt-1'
+    })
+    expect(mockLinkProjectItem.mock.invocationCallOrder[0]).toBeLessThan(
+      mockUnlinkProjectItem.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('does not carry one event’s links over to another', async () => {
+    // The popover is re-rendered, not remounted, when the form moves to another
+    // event, so unkeyed `links` would let evt-1's project become evt-2's
+    // implicit unlink target.
+    mockListForItem.mockImplementation(async (_type: string, id: string) =>
+      id === 'evt-1' ? [{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }] : []
+    )
+
+    const { rerender } = render(
+      <EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    rerender(<EventProjectField mode="edit" eventId="evt-2" value={null} onChange={vi.fn()} />)
+
+    expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', '')
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledWith('calendar_event', 'evt-2'))
+    await act(async () => {})
+
+    fireEvent.click(screen.getByText('pick-Finance'))
+
+    await waitFor(() => expect(mockLinkProjectItem).toHaveBeenCalledTimes(1))
+    expect(mockUnlinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('writes nothing while the form is saving', async () => {
+    mockListForItem.mockResolvedValue([
+      { id: 'p1', name: 'Launch', color: '#ff0000', icon: null },
+      { id: 'p2', name: 'Finance', color: '#00ff00', icon: null }
+    ])
+
+    render(
+      <EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} disabled />
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    fireEvent.click(screen.getByText('pick-Marketing'))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove from Finance' }))
+    await act(async () => {})
+
+    expect(mockLinkProjectItem).not.toHaveBeenCalled()
+    expect(mockUnlinkProjectItem).not.toHaveBeenCalled()
   })
 
   it('shows no chips when the event has a single project', async () => {

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EventProjectField } from './event-project-field'
+
+const { mockListForItem, mockLinkProjectItem, mockUnlinkProjectItem, mockOnProjectUpdated } =
+  vi.hoisted(() => ({
+    mockListForItem: vi.fn(),
+    mockLinkProjectItem: vi.fn(),
+    mockUnlinkProjectItem: vi.fn(),
+    mockOnProjectUpdated: vi.fn(() => () => {})
+  }))
+
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: {
+    listForItem: mockListForItem,
+    linkProjectItem: mockLinkProjectItem,
+    unlinkProjectItem: mockUnlinkProjectItem
+  },
+  onProjectUpdated: mockOnProjectUpdated
+}))
+
+// Projects come from the app-wide TasksProvider, same as calendar-task-popover.
+vi.mock('@/contexts/tasks', () => ({
+  useTasksOptional: () => ({
+    projects: [
+      { id: 'p1', name: 'Launch', color: '#ff0000', icon: null, isArchived: false },
+      { id: 'p2', name: 'Finance', color: '#00ff00', icon: null, isArchived: false }
+    ]
+  })
+}))
+
+// The real Picker is Radix Popover-based and does not open on click in jsdom
+// (codebase convention: mock it). This passthrough exposes one button per
+// option so the field's own orchestration is what gets tested.
+vi.mock('@/components/tasks/project-picker', () => ({
+  ProjectPicker: ({
+    value,
+    onChange,
+    projects,
+    allOptionLabel
+  }: {
+    value: string | null
+    onChange: (id: string | null) => void
+    projects: Array<{ id: string; name: string }>
+    allOptionLabel?: string
+  }) => (
+    <div data-testid="project-picker" data-value={value ?? ''}>
+      <button type="button" onClick={() => onChange(null)}>
+        {allOptionLabel}
+      </button>
+      {projects.map((project) => (
+        <button key={project.id} type="button" onClick={() => onChange(project.id)}>
+          {`pick-${project.name}`}
+        </button>
+      ))}
+    </div>
+  )
+}))
+
+describe('EventProjectField · create mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockOnProjectUpdated.mockReturnValue(() => {})
+  })
+
+  it('renders the picker with the draft value and no IPC call', () => {
+    render(<EventProjectField mode="create" value="p1" onChange={vi.fn()} />)
+
+    expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    expect(screen.getByText('Project')).toBeInTheDocument()
+    expect(mockListForItem).not.toHaveBeenCalled()
+  })
+
+  it('reports the selected project through onChange without writing links', () => {
+    const onChange = vi.fn()
+    render(<EventProjectField mode="create" value={null} onChange={onChange} />)
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    expect(onChange).toHaveBeenCalledWith('p1')
+    expect(mockLinkProjectItem).not.toHaveBeenCalled()
+    expect(mockUnlinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('reports null when the user picks "No project"', () => {
+    const onChange = vi.fn()
+    render(<EventProjectField mode="create" value="p1" onChange={onChange} />)
+
+    fireEvent.click(screen.getByText('No project'))
+
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
@@ -30,11 +30,14 @@ vi.mock('sonner', () => ({
 }))
 
 // Projects come from the app-wide TasksProvider, same as calendar-task-popover.
+// A third project (p3) exists so a stale-state race test can pick a project
+// that is neither the current link nor the first race click's target.
 vi.mock('@/contexts/tasks', () => ({
   useTasksOptional: () => ({
     projects: [
       { id: 'p1', name: 'Launch', color: '#ff0000', icon: null, isArchived: false },
-      { id: 'p2', name: 'Finance', color: '#00ff00', icon: null, isArchived: false }
+      { id: 'p2', name: 'Finance', color: '#00ff00', icon: null, isArchived: false },
+      { id: 'p3', name: 'Marketing', color: '#0000ff', icon: null, isArchived: false }
     ]
   })
 }))
@@ -297,9 +300,13 @@ describe('EventProjectField · edit mode', () => {
     fireEvent.click(screen.getByText('pick-Finance'))
     await waitFor(() => expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1))
 
-    // Fired before the first selection's unlink settles — `links` still
-    // says `p1` is current, so this would issue a second, stale unlink.
-    fireEvent.click(screen.getByText('pick-Launch'))
+    // Fired before the first selection's unlink settles — `links` still says
+    // `p1` is current. Picking a THIRD project (neither the stale `p1` nor
+    // the first click's `p2`) means a stale read of `previousId` ('p1')
+    // would differ from `nextId` ('p3') and NOT hit the pre-existing
+    // "same id, no-op" short-circuit — only the in-flight guard can produce
+    // the no-op this test expects.
+    fireEvent.click(screen.getByText('pick-Marketing'))
 
     resolveUnlink?.({ success: true })
     await waitFor(() =>
@@ -309,8 +316,13 @@ describe('EventProjectField · edit mode', () => {
         itemId: 'evt-1'
       })
     )
+    // The second click's selection (p3) was dropped entirely: only the first
+    // click's unlink(p1)+link(p2) pair ever went out.
     expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1)
     expect(mockLinkProjectItem).toHaveBeenCalledTimes(1)
+    expect(mockLinkProjectItem).not.toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'p3' })
+    )
   })
 
   it('reloads when a project update event fires', async () => {

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { EventProjectField } from './event-project-field'
 
 const {
@@ -31,20 +31,25 @@ vi.mock('sonner', () => ({
 
 // Projects come from the app-wide TasksProvider, same as calendar-task-popover.
 // A third project (p3) exists so a stale-state race test can pick a project
-// that is neither the current link nor the first race click's target.
+// that is neither the current link nor the first race click's target. `p4` is
+// archived: the real picker filters archived projects out of its list, so a
+// link to one can never be represented by the picker.
 vi.mock('@/contexts/tasks', () => ({
   useTasksOptional: () => ({
     projects: [
       { id: 'p1', name: 'Launch', color: '#ff0000', icon: null, isArchived: false },
       { id: 'p2', name: 'Finance', color: '#00ff00', icon: null, isArchived: false },
-      { id: 'p3', name: 'Marketing', color: '#0000ff', icon: null, isArchived: false }
+      { id: 'p3', name: 'Marketing', color: '#0000ff', icon: null, isArchived: false },
+      { id: 'p4', name: 'Retired', color: '#999999', icon: null, isArchived: true }
     ]
   })
 }))
 
 // The real Picker is Radix Popover-based and does not open on click in jsdom
 // (codebase convention: mock it). This passthrough exposes one button per
-// option so the field's own orchestration is what gets tested.
+// option so the field's own orchestration is what gets tested. It drops
+// archived projects exactly like the real one (project-picker.tsx), which is
+// what makes an archived link unrepresentable here.
 vi.mock('@/components/tasks/project-picker', () => ({
   ProjectPicker: ({
     value,
@@ -54,18 +59,20 @@ vi.mock('@/components/tasks/project-picker', () => ({
   }: {
     value: string | null
     onChange: (id: string | null) => void
-    projects: Array<{ id: string; name: string }>
+    projects: Array<{ id: string; name: string; isArchived: boolean }>
     allOptionLabel?: string
   }) => (
     <div data-testid="project-picker" data-value={value ?? ''}>
       <button type="button" onClick={() => onChange(null)}>
         {allOptionLabel}
       </button>
-      {projects.map((project) => (
-        <button key={project.id} type="button" onClick={() => onChange(project.id)}>
-          {`pick-${project.name}`}
-        </button>
-      ))}
+      {projects
+        .filter((project) => !project.isArchived)
+        .map((project) => (
+          <button key={project.id} type="button" onClick={() => onChange(project.id)}>
+            {`pick-${project.name}`}
+          </button>
+        ))}
     </div>
   )
 }))
@@ -398,6 +405,131 @@ describe('EventProjectField · edit mode', () => {
       itemType: 'calendar_event',
       itemId: 'evt-1'
     })
+  })
+
+  it('keeps the picked project primary when the reload returns the links reordered', async () => {
+    // `getProjectsForItem` has no ORDER BY, so row order is insertion order:
+    // after unlink(p1) + link(p3) the surviving legacy link (p2) comes back
+    // FIRST and the just-picked p3 second. Reading `links[0]` here would show
+    // Finance in the picker and demote Marketing — the project the user just
+    // chose — to a chip.
+    mockListForItem
+      .mockResolvedValueOnce([
+        { id: 'p1', name: 'Launch', color: '#ff0000', icon: null },
+        { id: 'p2', name: 'Finance', color: '#00ff00', icon: null }
+      ])
+      .mockResolvedValue([
+        { id: 'p2', name: 'Finance', color: '#00ff00', icon: null },
+        { id: 'p3', name: 'Marketing', color: '#0000ff', icon: null }
+      ])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    fireEvent.click(screen.getByText('pick-Marketing'))
+
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p3')
+    )
+    // Finance was never picked here, so it stays the chip it already was.
+    expect(screen.getByRole('button', { name: 'Remove from Finance' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Remove from Marketing' })).not.toBeInTheDocument()
+  })
+
+  it('shows a link to an archived project as a chip rather than as "No project"', async () => {
+    // The picker cannot render an archived project (it filters them out), so
+    // the link has to stay visible somewhere — otherwise the row reads "No
+    // project" while a link exists, a regression against the read-only chips.
+    mockListForItem.mockResolvedValue([{ id: 'p4', name: 'Retired', color: '#999999', icon: null }])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+
+    expect(await screen.findByRole('button', { name: 'Remove from Retired' })).toBeInTheDocument()
+    expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', '')
+  })
+
+  it('does not unlink an archived link the picker never showed', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p4', name: 'Retired', color: '#999999', icon: null }])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    // Wait on the load itself, not on how the link ends up rendered, so the
+    // click below happens with `links` committed either way.
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(1))
+    await act(async () => {})
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    await waitFor(() =>
+      expect(mockLinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'calendar_event',
+        itemId: 'evt-1'
+      })
+    )
+    // The archived link was never on screen as a picker value, so the user
+    // never chose to replace it. Only an explicit chip × may remove it.
+    expect(mockUnlinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('keeps the write guard closed when a project update reloads mid-swap', async () => {
+    // `unlinkItemFromProject` publishes `projectUpdated` BEFORE it resolves,
+    // so a reload lands between the unlink and the link of one swap and sees
+    // the intermediate (empty) DB state. Sharing one flag between load and
+    // write let that reload's `finally` reopen the guard with stale-empty
+    // `links`, and the next click would link a third project without
+    // unlinking anything.
+    mockListForItem
+      .mockResolvedValueOnce([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{ id: 'p2', name: 'Finance', color: '#00ff00', icon: null }])
+    let updateHandler: (() => void) | undefined
+    mockOnProjectUpdated.mockImplementation((cb: () => void) => {
+      updateHandler = cb
+      return () => {}
+    })
+    let resolveUnlink: ((value: { success: boolean }) => void) | undefined
+    mockUnlinkProjectItem.mockReturnValue(
+      new Promise((resolve) => {
+        resolveUnlink = resolve
+      })
+    )
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    fireEvent.click(screen.getByText('pick-Finance'))
+    await waitFor(() => expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1))
+
+    // The broadcast the in-flight unlink itself publishes.
+    updateHandler?.()
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(2))
+    // That reload has resolved and committed the intermediate empty state.
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', '')
+    )
+
+    // A click landing in exactly that window, on a THIRD project so it cannot
+    // be absorbed by the "same id, no-op" short-circuit.
+    fireEvent.click(screen.getByText('pick-Marketing'))
+
+    resolveUnlink?.({ success: true })
+    await waitFor(() =>
+      expect(mockLinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p2',
+        itemType: 'calendar_event',
+        itemId: 'evt-1'
+      })
+    )
+    expect(mockLinkProjectItem).toHaveBeenCalledTimes(1)
+    expect(mockLinkProjectItem).not.toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'p3' })
+    )
+    expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1)
   })
 
   it('shows no chips when the event has a single project', async () => {

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
@@ -201,10 +201,31 @@ describe('EventProjectField · edit mode', () => {
   })
 
   it('treats an IPC error envelope from listForItem as no links', async () => {
-    mockListForItem.mockResolvedValue({ success: false, error: 'db error' })
+    // Shaped so `links[0]` would resolve to a *real-looking* project if the
+    // `Array.isArray` guard were removed and this raw envelope were stored as
+    // `links` directly — discriminates the guard instead of merely relying
+    // on `links[0]` being safely `undefined` for any non-array object (which
+    // it would be regardless of the guard, giving no regression coverage).
+    mockListForItem.mockResolvedValue({
+      success: false,
+      error: 'db error',
+      0: { id: 'ghost', name: 'Ghost', color: '#000000', icon: null }
+    })
 
     render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
 
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', '')
+    )
+  })
+
+  it('falls back to no links when listForItem rejects', async () => {
+    mockListForItem.mockRejectedValue(new Error('network error'))
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalled())
     await waitFor(() =>
       expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', '')
     )
@@ -221,6 +242,75 @@ describe('EventProjectField · edit mode', () => {
 
     await waitFor(() => expect(mockToastError).toHaveBeenCalled())
     await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(2))
+  })
+
+  it('shows a toast when a link write rejects outright', async () => {
+    mockListForItem.mockResolvedValue([])
+    mockLinkProjectItem.mockRejectedValue(new Error('link failed'))
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled())
+  })
+
+  it('ignores a selection made before the initial load resolves', async () => {
+    let resolveList: ((value: unknown) => void) | undefined
+    mockListForItem.mockReturnValue(
+      new Promise((resolve) => {
+        resolveList = resolve
+      })
+    )
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalled())
+
+    // Clicked while the initial load is still in flight — `links` is still
+    // `[]`, so a naive read of `previousId` here would be wrong.
+    fireEvent.click(screen.getByText('pick-Launch'))
+    expect(mockLinkProjectItem).not.toHaveBeenCalled()
+
+    resolveList?.([])
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', '')
+    )
+    // The click during the load window was dropped, not queued.
+    expect(mockLinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('ignores a second selection while the first write is still in flight', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+    let resolveUnlink: ((value: { success: boolean }) => void) | undefined
+    mockUnlinkProjectItem.mockReturnValue(
+      new Promise((resolve) => {
+        resolveUnlink = resolve
+      })
+    )
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    fireEvent.click(screen.getByText('pick-Finance'))
+    await waitFor(() => expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1))
+
+    // Fired before the first selection's unlink settles — `links` still
+    // says `p1` is current, so this would issue a second, stale unlink.
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    resolveUnlink?.({ success: true })
+    await waitFor(() =>
+      expect(mockLinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p2',
+        itemType: 'calendar_event',
+        itemId: 'evt-1'
+      })
+    )
+    expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1)
+    expect(mockLinkProjectItem).toHaveBeenCalledTimes(1)
   })
 
   it('reloads when a project update event fires', async () => {

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
@@ -1,0 +1,52 @@
+import { useT } from '@memry/i18n/renderer'
+
+import { ProjectPicker } from '@/components/tasks/project-picker'
+import { useTasksOptional } from '@/contexts/tasks'
+
+export interface EventProjectFieldProps {
+  mode: 'create' | 'edit'
+  /** Saved event id. Required in edit mode; null while drafting a new event. */
+  eventId?: string | null
+  /** Create mode only: the draft's selected project id. */
+  value: string | null
+  /** Create mode only: writes the selection back into the draft. */
+  onChange: (projectId: string | null) => void
+  disabled?: boolean
+}
+
+/**
+ * Project assignment for a calendar event, backed by `project_links`.
+ *
+ * Create mode is fully controlled — the selection rides in the draft until the
+ * event has an id. Edit mode owns its own state and writes link/unlink
+ * immediately, matching the calendar chip's "Add to project" context menu.
+ */
+export function EventProjectField({
+  mode,
+  value,
+  onChange,
+  disabled
+}: EventProjectFieldProps): React.JSX.Element | null {
+  const { t } = useT('calendar')
+  const projects = useTasksOptional()?.projects ?? []
+
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-xs font-medium text-muted-foreground">{t('form.project')}</span>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <ProjectPicker
+          value={value}
+          onChange={onChange}
+          projects={projects}
+          includeAllOption
+          allOptionLabel={t('form.no-project')}
+          searchable
+          allowCreate={false}
+          className="min-w-[160px]"
+        />
+      </div>
+    </label>
+  )
+}
+
+export default EventProjectField

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
@@ -5,6 +5,7 @@ import { useT } from '@memry/i18n/renderer'
 import { ProjectPicker } from '@/components/tasks/project-picker'
 import { useTasksOptional } from '@/contexts/tasks'
 import { extractErrorMessage } from '@/lib/ipc-error'
+import { X } from '@/lib/icons'
 import { createLogger } from '@/lib/logger'
 import { onProjectUpdated, tasksService, type ProjectRef } from '@/services/tasks-service'
 
@@ -74,6 +75,21 @@ export function EventProjectField({
 
   useEffect(() => onProjectUpdated(() => void load()), [load])
 
+  // Shared by `handleSelect` and `handleRemoveExtra`: both are writes on the
+  // same `project_links` rows and must hold `pendingRef` for their duration,
+  // then unconditionally reload (which clears `pendingRef` in its own
+  // `finally`) so the UI reflects the actual DB state whether the write
+  // succeeded or failed.
+  const runLinkWrite = async (write: () => Promise<void>): Promise<void> => {
+    pendingRef.current = true
+    try {
+      await write()
+    } catch (error) {
+      toast.error(extractErrorMessage(error, t('form.project-update-failed')))
+    }
+    await load()
+  }
+
   const handleSelect = async (nextId: string | null): Promise<void> => {
     if (!isEdit || !eventId) {
       onChange(nextId)
@@ -86,8 +102,7 @@ export function EventProjectField({
     const previousId = links[0]?.id ?? null
     if (previousId === nextId) return
 
-    pendingRef.current = true
-    try {
+    await runLinkWrite(async () => {
       if (previousId) {
         const removed = await tasksService.unlinkProjectItem({
           projectId: previousId,
@@ -104,12 +119,24 @@ export function EventProjectField({
         })
         if (!added.success) throw new Error(added.error)
       }
-    } catch (error) {
-      toast.error(extractErrorMessage(error, t('form.project-update-failed')))
-    }
-    // Runs regardless of outcome above; also clears `pendingRef` (in its own
-    // `finally`), reflecting the actual DB state either way.
-    await load()
+    })
+  }
+
+  const handleRemoveExtra = async (projectId: string): Promise<void> => {
+    if (!eventId) return
+    // Same guard as `handleSelect`: a remove is a write on the same
+    // `project_links` rows and must not run while another write or load is
+    // in flight.
+    if (disabled || pendingRef.current) return
+
+    await runLinkWrite(async () => {
+      const removed = await tasksService.unlinkProjectItem({
+        projectId,
+        itemType: 'calendar_event',
+        itemId: eventId
+      })
+      if (!removed.success) throw new Error(removed.error)
+    })
   }
 
   // Edit mode before the event is saved (canvas cards mount the form without an
@@ -117,6 +144,10 @@ export function EventProjectField({
   if (isEdit && !eventId) return null
 
   const selectedId = isEdit ? (links[0]?.id ?? null) : value
+  // Single-select UI over a many-to-many table: an event linked to several
+  // projects (possible via the chip context menu) keeps every link visible and
+  // individually removable. Nothing is dropped that the user did not remove.
+  const extraLinks = isEdit ? links.slice(1) : []
 
   return (
     <label className="flex flex-col gap-1 text-sm">
@@ -132,6 +163,27 @@ export function EventProjectField({
           allowCreate={false}
           className="min-w-[160px]"
         />
+        {extraLinks.map((project) => (
+          <span
+            key={project.id}
+            className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs"
+          >
+            <span
+              className="size-2 shrink-0 rounded-full"
+              style={{ backgroundColor: project.color }}
+              aria-hidden="true"
+            />
+            <span className="max-w-32 truncate">{project.name}</span>
+            <button
+              type="button"
+              aria-label={t('form.remove-from-project', { project: project.name })}
+              onClick={() => void handleRemoveExtra(project.id)}
+              className="text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <X className="size-3" />
+            </button>
+          </span>
+        ))}
       </div>
     </label>
   )

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
@@ -22,10 +22,8 @@ export interface EventProjectFieldProps {
  * immediately, matching the calendar chip's "Add to project" context menu.
  */
 export function EventProjectField({
-  mode,
   value,
-  onChange,
-  disabled
+  onChange
 }: EventProjectFieldProps): React.JSX.Element | null {
   const { t } = useT('calendar')
   const projects = useTasksOptional()?.projects ?? []

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
@@ -39,23 +39,35 @@ export function EventProjectField({
   const { t } = useT('calendar')
   const projects = useTasksOptional()?.projects ?? []
   const [links, setLinks] = useState<ProjectRef[]>([])
+  // The project this field last picked, keyed by the event it was picked for.
+  // `getProjectsForItem` has no ORDER BY, so a reload after a swap can hand
+  // back the new link in any position; without this, an event that also
+  // carries a legacy second link would show that older link in the picker and
+  // demote the just-picked one to a chip. Keying by event id (rather than
+  // resetting from an effect) drops the pick as soon as the form switches
+  // events, since a different event has a different link set.
+  const [chosen, setChosen] = useState<{ eventId: string | null; projectId: string | null }>({
+    eventId: eventId ?? null,
+    projectId: null
+  })
+  const chosenId = chosen.eventId === (eventId ?? null) ? chosen.projectId : null
   const isEdit = mode === 'edit'
 
-  // Guards two races around the single "current link" truth held in `links`:
-  // a selection fired before the initial `load()` resolves would read
-  // `previousId` from the still-empty state and skip the unlink it owes; a
-  // second selection fired before the first write's trailing `load()`
-  // resolves would read that same stale state and skip its unlink too. Both
-  // would leave the event linked to two projects behind a UI that shows only
-  // one. A ref (not state) is required so the guard is visible synchronously
-  // to a call in the same tick, before React re-renders. `load()` holds this
-  // flag for its own duration too, so the initial mount load and any
-  // `onProjectUpdated`-triggered reload gate selections the same way.
-  const pendingRef = useRef(false)
+  // Two separate flags, both gating writes. A single shared flag was
+  // reopenable mid-swap: `linkItemToProject`/`unlinkItemFromProject` publish
+  // `projectUpdated` before they resolve, so a reload lands between the
+  // unlink and the link, and its `finally` would clear the one flag while
+  // `links` momentarily reads empty — a click in that window would compute
+  // `previousId` as null and link a second project without unlinking. Refs
+  // (not state) so the guard is visible synchronously to a call in the same
+  // tick, before React re-renders.
+  const isLoadingRef = useRef(false)
+  const isWritingRef = useRef(false)
+  const isBusy = (): boolean => isLoadingRef.current || isWritingRef.current
 
   const load = useCallback(async (): Promise<void> => {
     if (!isEdit || !eventId) return
-    pendingRef.current = true
+    isLoadingRef.current = true
     try {
       const result = await tasksService.listForItem('calendar_event', eventId)
       // `listForItem` runs through the main-side `withDb` wrapper: on a DB
@@ -65,7 +77,7 @@ export function EventProjectField({
       log.error('Failed to load event projects', extractErrorMessage(error))
       setLinks([])
     } finally {
-      pendingRef.current = false
+      isLoadingRef.current = false
     }
   }, [isEdit, eventId])
 
@@ -76,19 +88,41 @@ export function EventProjectField({
   useEffect(() => onProjectUpdated(() => void load()), [load])
 
   // Shared by `handleSelect` and `handleRemoveExtra`: both are writes on the
-  // same `project_links` rows and must hold `pendingRef` for their duration,
-  // then unconditionally reload (which clears `pendingRef` in its own
-  // `finally`) so the UI reflects the actual DB state whether the write
-  // succeeded or failed.
+  // same `project_links` rows. `isWritingRef` is held across the write *and*
+  // its trailing reload, so no interleaved `load()` can open the guard
+  // mid-swap. The reload is unconditional so the UI reflects the actual DB
+  // state whether the write succeeded or failed.
   const runLinkWrite = async (write: () => Promise<void>): Promise<void> => {
-    pendingRef.current = true
+    isWritingRef.current = true
     try {
       await write()
     } catch (error) {
+      log.error('Failed to write event project link', {
+        eventId,
+        error: extractErrorMessage(error)
+      })
       toast.error(extractErrorMessage(error, t('form.project-update-failed')))
+    } finally {
+      await load()
+      isWritingRef.current = false
     }
-    await load()
   }
+
+  // `ProjectPicker` filters archived projects out of its list and resolves its
+  // trigger only against that filtered list, so a link to an archived project
+  // cannot be represented there. Anything it cannot show falls through to the
+  // chips below, where it stays visible and removable — and is never the
+  // implicit unlink target of the next pick.
+  const isPickable = (projectId: string): boolean =>
+    projects.some((project) => project.id === projectId && !project.isArchived)
+
+  const primaryLink = links.find((link) => link.id === chosenId) ?? links[0]
+  const primaryId = primaryLink && isPickable(primaryLink.id) ? primaryLink.id : null
+  const selectedId = isEdit ? primaryId : value
+  // Single-select UI over a many-to-many table: every link the picker is not
+  // showing keeps its own removable chip. Nothing is dropped that the user did
+  // not remove.
+  const extraLinks = isEdit ? links.filter((link) => link.id !== primaryId) : []
 
   const handleSelect = async (nextId: string | null): Promise<void> => {
     if (!isEdit || !eventId) {
@@ -97,11 +131,13 @@ export function EventProjectField({
     }
     // External `disabled` (Task 4) and the internal in-flight guard compose
     // here rather than one replacing the other.
-    if (disabled || pendingRef.current) return
+    if (disabled || isBusy()) return
 
-    const previousId = links[0]?.id ?? null
+    // Only the link the picker is actually showing can be replaced by a pick.
+    const previousId = primaryId
     if (previousId === nextId) return
 
+    setChosen({ eventId, projectId: nextId })
     await runLinkWrite(async () => {
       if (previousId) {
         const removed = await tasksService.unlinkProjectItem({
@@ -127,7 +163,7 @@ export function EventProjectField({
     // Same guard as `handleSelect`: a remove is a write on the same
     // `project_links` rows and must not run while another write or load is
     // in flight.
-    if (disabled || pendingRef.current) return
+    if (disabled || isBusy()) return
 
     await runLinkWrite(async () => {
       const removed = await tasksService.unlinkProjectItem({
@@ -142,12 +178,6 @@ export function EventProjectField({
   // Edit mode before the event is saved (canvas cards mount the form without an
   // id): nothing to link to, so render nothing rather than a dead control.
   if (isEdit && !eventId) return null
-
-  const selectedId = isEdit ? (links[0]?.id ?? null) : value
-  // Single-select UI over a many-to-many table: an event linked to several
-  // projects (possible via the chip context menu) keeps every link visible and
-  // individually removable. Nothing is dropped that the user did not remove.
-  const extraLinks = isEdit ? links.slice(1) : []
 
   return (
     <label className="flex flex-col gap-1 text-sm">

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
@@ -7,9 +7,22 @@ import { useTasksOptional } from '@/contexts/tasks'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { X } from '@/lib/icons'
 import { createLogger } from '@/lib/logger'
+import type { Project } from '@/data/tasks-data'
 import { onProjectUpdated, tasksService, type ProjectRef } from '@/services/tasks-service'
 
 const log = createLogger('EventProjectField')
+
+// `listForItem` is a plain `ipcRenderer.invoke` with no timeout of its own, so a
+// wedged main process leaves it pending forever. A load that has not answered by
+// then stops blocking picks: an inert picker with no spinner and no way back
+// short of reopening the popover is worse than a pick computed from links this
+// old. Never reached on a healthy round trip, which takes milliseconds.
+const LOAD_GUARD_TIMEOUT_MS = 10_000
+
+// Stable identities: `ProjectPicker` memoizes its list on the `projects`
+// reference, and the popover form re-renders on every keystroke.
+const NO_PROJECTS: Project[] = []
+const NO_LINKS: ProjectRef[] = []
 
 export interface EventProjectFieldProps {
   mode: 'create' | 'edit'
@@ -37,47 +50,65 @@ export function EventProjectField({
   disabled
 }: EventProjectFieldProps): React.JSX.Element | null {
   const { t } = useT('calendar')
-  const projects = useTasksOptional()?.projects ?? []
-  const [links, setLinks] = useState<ProjectRef[]>([])
-  // The project this field last picked, keyed by the event it was picked for.
-  // `getProjectsForItem` has no ORDER BY, so a reload after a swap can hand
-  // back the new link in any position; without this, an event that also
-  // carries a legacy second link would show that older link in the picker and
-  // demote the just-picked one to a chip. Keying by event id (rather than
-  // resetting from an effect) drops the pick as soon as the form switches
-  // events, since a different event has a different link set.
+  const projects = useTasksOptional()?.projects ?? NO_PROJECTS
+  const isEdit = mode === 'edit'
+  const currentEventId = eventId ?? null
+
+  // Both the loaded links and the last pick are keyed by the event they belong
+  // to. The popover is re-rendered rather than remounted when the form moves to
+  // another event, so unkeyed state would let one event's links choose the
+  // unlink target for another. Keying also drops a stale pick for free.
+  //
+  // The pick has to be remembered at all because `getProjectsForItem` has no
+  // ORDER BY: a reload after a swap can hand back the new link in any position,
+  // and without this an event that also carries a legacy second link would show
+  // that older link in the picker and demote the just-picked one to a chip.
+  const [linkState, setLinkState] = useState<{ eventId: string | null; links: ProjectRef[] }>({
+    eventId: currentEventId,
+    links: NO_LINKS
+  })
   const [chosen, setChosen] = useState<{ eventId: string | null; projectId: string | null }>({
-    eventId: eventId ?? null,
+    eventId: currentEventId,
     projectId: null
   })
-  const chosenId = chosen.eventId === (eventId ?? null) ? chosen.projectId : null
-  const isEdit = mode === 'edit'
+  const links = linkState.eventId === currentEventId ? linkState.links : NO_LINKS
+  const chosenId = chosen.eventId === currentEventId ? chosen.projectId : null
 
-  // Two separate flags, both gating writes. A single shared flag was
-  // reopenable mid-swap: `linkItemToProject`/`unlinkItemFromProject` publish
-  // `projectUpdated` before they resolve, so a reload lands between the
-  // unlink and the link, and its `finally` would clear the one flag while
-  // `links` momentarily reads empty — a click in that window would compute
-  // `previousId` as null and link a second project without unlinking. Refs
-  // (not state) so the guard is visible synchronously to a call in the same
+  // Both gate writes. `pendingLoads` is a counter, not a flag: the mount load,
+  // the `projectUpdated` reload and the trailing reload can overlap, and a
+  // boolean would report idle as soon as the *first* of them settled — long
+  // enough for a click to compute its unlink target from links a later response
+  // is about to replace. `loadToken` drops a response a newer load superseded.
+  // Refs (not state) so the guard is visible synchronously to a call in the same
   // tick, before React re-renders.
-  const isLoadingRef = useRef(false)
+  const pendingLoadsRef = useRef(0)
+  const loadTokenRef = useRef(0)
   const isWritingRef = useRef(false)
-  const isBusy = (): boolean => isLoadingRef.current || isWritingRef.current
+  const isBusy = (): boolean => pendingLoadsRef.current > 0 || isWritingRef.current
 
   const load = useCallback(async (): Promise<void> => {
     if (!isEdit || !eventId) return
-    isLoadingRef.current = true
+    const token = ++loadTokenRef.current
+    pendingLoadsRef.current += 1
+    let released = false
+    const release = (): void => {
+      if (released) return
+      released = true
+      pendingLoadsRef.current -= 1
+    }
+    const guardTimer = setTimeout(release, LOAD_GUARD_TIMEOUT_MS)
     try {
       const result = await tasksService.listForItem('calendar_event', eventId)
       // `listForItem` runs through the main-side `withDb` wrapper: on a DB
       // error it resolves `{ success: false, error }` instead of rejecting.
-      setLinks(Array.isArray(result) ? result : [])
+      if (loadTokenRef.current !== token) return
+      setLinkState({ eventId, links: Array.isArray(result) ? result : NO_LINKS })
     } catch (error) {
       log.error('Failed to load event projects', extractErrorMessage(error))
-      setLinks([])
+      if (loadTokenRef.current === token) setLinkState({ eventId, links: NO_LINKS })
     } finally {
-      isLoadingRef.current = false
+      clearTimeout(guardTimer)
+      release()
     }
   }, [isEdit, eventId])
 
@@ -85,13 +116,27 @@ export function EventProjectField({
     void load()
   }, [load])
 
-  useEffect(() => onProjectUpdated(() => void load()), [load])
+  useEffect(() => {
+    // Nothing to reload for an unsaved event, and the canvas mounts one form
+    // per event card — subscribing there would buy a listener per idle card
+    // whose callback can only ever no-op.
+    if (!isEdit || !eventId) return
+    return onProjectUpdated(() => {
+      // `linkItemToProject` / `unlinkItemFromProject` publish `projectUpdated`
+      // *before* they resolve, so reloading on our own writes would fetch the
+      // half-written state between the two calls of a swap — a visible "No
+      // project" flash — and cost two extra round-trips. `runLinkWrite`
+      // reloads once the whole write is done.
+      if (isWritingRef.current) return
+      void load()
+    })
+  }, [isEdit, eventId, load])
 
   // Shared by `handleSelect` and `handleRemoveExtra`: both are writes on the
-  // same `project_links` rows. `isWritingRef` is held across the write *and*
-  // its trailing reload, so no interleaved `load()` can open the guard
-  // mid-swap. The reload is unconditional so the UI reflects the actual DB
-  // state whether the write succeeded or failed.
+  // same `project_links` rows. The reload is unconditional so the UI reflects
+  // the actual DB state whether the write succeeded or failed, and it starts in
+  // the same tick the write flag drops — `load` bumps `pendingLoads` before its
+  // first await — so the guard never opens in between.
   const runLinkWrite = async (write: () => Promise<void>): Promise<void> => {
     isWritingRef.current = true
     try {
@@ -103,9 +148,9 @@ export function EventProjectField({
       })
       toast.error(extractErrorMessage(error, t('form.project-update-failed')))
     } finally {
-      await load()
       isWritingRef.current = false
     }
+    await load()
   }
 
   // `ProjectPicker` filters archived projects out of its list and resolves its
@@ -116,7 +161,13 @@ export function EventProjectField({
   const isPickable = (projectId: string): boolean =>
     projects.some((project) => project.id === projectId && !project.isArchived)
 
-  const primaryLink = links.find((link) => link.id === chosenId) ?? links[0]
+  // The last pick when it survived the reload, else the first link the picker
+  // can actually render. Falling through to `links[0]` instead would let a
+  // single unpickable link hide a perfectly pickable sibling: the row would
+  // read "No project" while a live link exists, and the next pick would add a
+  // third link rather than replace the second.
+  const primaryLink =
+    links.find((link) => link.id === chosenId) ?? links.find((link) => isPickable(link.id))
   const primaryId = primaryLink && isPickable(primaryLink.id) ? primaryLink.id : null
   const selectedId = isEdit ? primaryId : value
   // Single-select UI over a many-to-many table: every link the picker is not
@@ -125,13 +176,14 @@ export function EventProjectField({
   const extraLinks = isEdit ? links.filter((link) => link.id !== primaryId) : []
 
   const handleSelect = async (nextId: string | null): Promise<void> => {
+    // External `disabled` gates both modes; the in-flight guard only applies
+    // where there is a write to guard.
+    if (disabled) return
     if (!isEdit || !eventId) {
       onChange(nextId)
       return
     }
-    // External `disabled` (Task 4) and the internal in-flight guard compose
-    // here rather than one replacing the other.
-    if (disabled || isBusy()) return
+    if (isBusy()) return
 
     // Only the link the picker is actually showing can be replaced by a pick.
     const previousId = primaryId
@@ -139,14 +191,12 @@ export function EventProjectField({
 
     setChosen({ eventId, projectId: nextId })
     await runLinkWrite(async () => {
-      if (previousId) {
-        const removed = await tasksService.unlinkProjectItem({
-          projectId: previousId,
-          itemType: 'calendar_event',
-          itemId: eventId
-        })
-        if (!removed.success) throw new Error(removed.error)
-      }
+      // Link before unlink. These are two independent IPC calls with no
+      // transaction, so one of them can fail after the other landed; ending up
+      // with one link too many leaves a removable chip on screen, while ending
+      // up with none silently destroys an assignment the user asked to
+      // *change*. `project_links` is unique per (project, item type, item), so
+      // holding both links for the width of the swap is legal.
       if (nextId) {
         const added = await tasksService.linkProjectItem({
           projectId: nextId,
@@ -154,6 +204,14 @@ export function EventProjectField({
           itemId: eventId
         })
         if (!added.success) throw new Error(added.error)
+      }
+      if (previousId) {
+        const removed = await tasksService.unlinkProjectItem({
+          projectId: previousId,
+          itemType: 'calendar_event',
+          itemId: eventId
+        })
+        if (!removed.success) throw new Error(removed.error)
       }
     })
   }
@@ -180,7 +238,11 @@ export function EventProjectField({
   if (isEdit && !eventId) return null
 
   return (
-    <label className="flex flex-col gap-1 text-sm">
+    // A plain <div>, not a <label>: a label forwards clicks on its
+    // non-interactive descendants to its first labelable control, so wrapping
+    // the chips alongside the picker would pop the dropdown open whenever the
+    // user clicked a chip's name.
+    <div className="flex flex-col gap-1 text-sm">
       <span className="text-xs font-medium text-muted-foreground">{t('form.project')}</span>
       <div className="flex flex-wrap items-center gap-1.5">
         <ProjectPicker
@@ -191,6 +253,7 @@ export function EventProjectField({
           allOptionLabel={t('form.no-project')}
           searchable
           allowCreate={false}
+          disabled={disabled}
           className="min-w-[160px]"
         />
         {extraLinks.map((project) => (
@@ -208,14 +271,15 @@ export function EventProjectField({
               type="button"
               aria-label={t('form.remove-from-project', { project: project.name })}
               onClick={() => void handleRemoveExtra(project.id)}
-              className="text-muted-foreground transition-colors hover:text-foreground"
+              disabled={disabled}
+              className="text-muted-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
             >
               <X className="size-3" />
             </button>
           </span>
         ))}
       </div>
-    </label>
+    </div>
   )
 }
 

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
@@ -1,7 +1,14 @@
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
 import { useT } from '@memry/i18n/renderer'
 
 import { ProjectPicker } from '@/components/tasks/project-picker'
 import { useTasksOptional } from '@/contexts/tasks'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { createLogger } from '@/lib/logger'
+import { onProjectUpdated, tasksService, type ProjectRef } from '@/services/tasks-service'
+
+const log = createLogger('EventProjectField')
 
 export interface EventProjectFieldProps {
   mode: 'create' | 'edit'
@@ -22,19 +29,79 @@ export interface EventProjectFieldProps {
  * immediately, matching the calendar chip's "Add to project" context menu.
  */
 export function EventProjectField({
+  mode,
+  eventId,
   value,
   onChange
 }: EventProjectFieldProps): React.JSX.Element | null {
   const { t } = useT('calendar')
   const projects = useTasksOptional()?.projects ?? []
+  const [links, setLinks] = useState<ProjectRef[]>([])
+  const isEdit = mode === 'edit'
+
+  const load = useCallback(async (): Promise<void> => {
+    if (!isEdit || !eventId) return
+    try {
+      const result = await tasksService.listForItem('calendar_event', eventId)
+      // `listForItem` runs through the main-side `withDb` wrapper: on a DB
+      // error it resolves `{ success: false, error }` instead of rejecting.
+      setLinks(Array.isArray(result) ? result : [])
+    } catch (error) {
+      log.error('Failed to load event projects', extractErrorMessage(error))
+      setLinks([])
+    }
+  }, [isEdit, eventId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  useEffect(() => onProjectUpdated(() => void load()), [load])
+
+  const handleSelect = async (nextId: string | null): Promise<void> => {
+    if (!isEdit || !eventId) {
+      onChange(nextId)
+      return
+    }
+    const previousId = links[0]?.id ?? null
+    if (previousId === nextId) return
+
+    try {
+      if (previousId) {
+        const removed = await tasksService.unlinkProjectItem({
+          projectId: previousId,
+          itemType: 'calendar_event',
+          itemId: eventId
+        })
+        if (!removed.success) throw new Error(removed.error)
+      }
+      if (nextId) {
+        const added = await tasksService.linkProjectItem({
+          projectId: nextId,
+          itemType: 'calendar_event',
+          itemId: eventId
+        })
+        if (!added.success) throw new Error(added.error)
+      }
+    } catch (error) {
+      toast.error(extractErrorMessage(error, t('form.project-update-failed')))
+    }
+    await load()
+  }
+
+  // Edit mode before the event is saved (canvas cards mount the form without an
+  // id): nothing to link to, so render nothing rather than a dead control.
+  if (isEdit && !eventId) return null
+
+  const selectedId = isEdit ? (links[0]?.id ?? null) : value
 
   return (
     <label className="flex flex-col gap-1 text-sm">
       <span className="text-xs font-medium text-muted-foreground">{t('form.project')}</span>
       <div className="flex flex-wrap items-center gap-1.5">
         <ProjectPicker
-          value={value}
-          onChange={onChange}
+          value={selectedId}
+          onChange={(next) => void handleSelect(next)}
           projects={projects}
           includeAllOption
           allOptionLabel={t('form.no-project')}

--- a/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
+++ b/apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useT } from '@memry/i18n/renderer'
 
@@ -32,15 +32,29 @@ export function EventProjectField({
   mode,
   eventId,
   value,
-  onChange
+  onChange,
+  disabled
 }: EventProjectFieldProps): React.JSX.Element | null {
   const { t } = useT('calendar')
   const projects = useTasksOptional()?.projects ?? []
   const [links, setLinks] = useState<ProjectRef[]>([])
   const isEdit = mode === 'edit'
 
+  // Guards two races around the single "current link" truth held in `links`:
+  // a selection fired before the initial `load()` resolves would read
+  // `previousId` from the still-empty state and skip the unlink it owes; a
+  // second selection fired before the first write's trailing `load()`
+  // resolves would read that same stale state and skip its unlink too. Both
+  // would leave the event linked to two projects behind a UI that shows only
+  // one. A ref (not state) is required so the guard is visible synchronously
+  // to a call in the same tick, before React re-renders. `load()` holds this
+  // flag for its own duration too, so the initial mount load and any
+  // `onProjectUpdated`-triggered reload gate selections the same way.
+  const pendingRef = useRef(false)
+
   const load = useCallback(async (): Promise<void> => {
     if (!isEdit || !eventId) return
+    pendingRef.current = true
     try {
       const result = await tasksService.listForItem('calendar_event', eventId)
       // `listForItem` runs through the main-side `withDb` wrapper: on a DB
@@ -49,6 +63,8 @@ export function EventProjectField({
     } catch (error) {
       log.error('Failed to load event projects', extractErrorMessage(error))
       setLinks([])
+    } finally {
+      pendingRef.current = false
     }
   }, [isEdit, eventId])
 
@@ -63,9 +79,14 @@ export function EventProjectField({
       onChange(nextId)
       return
     }
+    // External `disabled` (Task 4) and the internal in-flight guard compose
+    // here rather than one replacing the other.
+    if (disabled || pendingRef.current) return
+
     const previousId = links[0]?.id ?? null
     if (previousId === nextId) return
 
+    pendingRef.current = true
     try {
       if (previousId) {
         const removed = await tasksService.unlinkProjectItem({
@@ -86,6 +107,8 @@ export function EventProjectField({
     } catch (error) {
       toast.error(extractErrorMessage(error, t('form.project-update-failed')))
     }
+    // Runs regardless of outcome above; also clears `pendingRef` (in its own
+    // `finally`), reflecting the actual DB state either way.
     await load()
   }
 

--- a/apps/desktop/src/renderer/src/components/calendar/types.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/types.ts
@@ -6,6 +6,8 @@ export interface CalendarEventDraft {
   endAt: string
   /** M2: Google calendar this event should be pushed to. Null = fall through to default. */
   targetCalendarId: string | null
+  /** Create mode only: project to link the event to once it has an id. */
+  projectId: string | null
 }
 
 export interface AnchorRect {

--- a/apps/desktop/src/renderer/src/components/tasks/project-picker.tsx
+++ b/apps/desktop/src/renderer/src/components/tasks/project-picker.tsx
@@ -36,6 +36,8 @@ export interface ProjectPickerProps {
   contentWidth?: 'auto' | 'trigger' | number
   /** Trigger text when nothing selected (button variant). */
   placeholder?: string
+  /** Greys out the trigger and stops it opening, e.g. while a form is saving. */
+  disabled?: boolean
   className?: string
 }
 
@@ -147,6 +149,7 @@ export const ProjectPicker = ({
   triggerVariant = 'button',
   contentWidth,
   placeholder,
+  disabled,
   className
 }: ProjectPickerProps): React.JSX.Element => {
   const { t: tTasks } = useT('tasks')
@@ -188,6 +191,7 @@ export const ProjectPicker = ({
               )}
               style={{ backgroundColor: `${badgeColor}14` }}
               onClick={(e) => e.stopPropagation()}
+              disabled={disabled}
               aria-label={`Project: ${badgeName}. Click to change.`}
             >
               <div className="rounded-xs shrink-0 size-2" style={{ backgroundColor: badgeColor }} />
@@ -201,6 +205,7 @@ export const ProjectPicker = ({
             variant="button"
             chevron
             className={className}
+            disabled={disabled}
             aria-label={tTasks('phaseF.componentsTasksProjectsProjectSelector.selectProject')}
           >
             {currentProject ? (

--- a/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-callbacks.test.tsx
@@ -105,7 +105,8 @@ vi.mock('@/components/calendar', () => ({
       isAllDay: false,
       startAt: '2026-05-10T09:00',
       endAt: '2026-05-10T10:00',
-      targetCalendarId: 'google-work'
+      targetCalendarId: 'google-work',
+      projectId: null
     }
     return (
       <div>

--- a/apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders, userEvent } from '@tests/utils/render'
+import { CalendarPage } from '@/pages/calendar'
+import type { CalendarSourceRecord } from '@/services/calendar-service'
+
+const {
+  mockUseCalendarRange,
+  mockListSources,
+  mockCreateEvent,
+  mockUpdateEvent,
+  mockLinkProjectItem,
+  mockOpenTab
+} = vi.hoisted(() => ({
+  mockUseCalendarRange: vi.fn(),
+  mockListSources: vi.fn(),
+  mockCreateEvent: vi.fn(),
+  mockUpdateEvent: vi.fn(),
+  mockLinkProjectItem: vi.fn(),
+  mockOpenTab: vi.fn()
+}))
+
+vi.mock('@/hooks/use-calendar-range', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks/use-calendar-range')>()),
+  useCalendarRange: mockUseCalendarRange
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useActiveTab: () => null,
+  useTabActions: () => ({ openTab: mockOpenTab })
+}))
+
+vi.mock('@/services/calendar-service', () => ({
+  calendarService: {
+    listSources: mockListSources,
+    createEvent: mockCreateEvent,
+    updateEvent: mockUpdateEvent
+  },
+  onCalendarChanged: vi.fn(() => () => {}),
+  listGoogleCalendars: vi.fn(async () => ({
+    calendars: [],
+    primary: null,
+    currentDefaultId: null
+  })),
+  promoteExternalCalendarEvent: vi.fn(),
+  setDefaultGoogleCalendar: vi.fn(async () => ({ success: true }))
+}))
+
+// The project field is exercised in its own test; here it only needs to put a
+// project id into the draft so the page's post-create link is observable.
+vi.mock('@/components/calendar/event-project-field', () => ({
+  EventProjectField: ({
+    value,
+    onChange
+  }: {
+    value: string | null
+    onChange: (id: string | null) => void
+  }) => (
+    <button type="button" data-value={value ?? ''} onClick={() => onChange('p1')}>
+      stub-pick-project
+    </button>
+  )
+}))
+
+vi.mock('@/services/tasks-service', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/tasks-service')>()),
+  tasksService: {
+    linkProjectItem: mockLinkProjectItem
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() }
+}))
+
+const NO_SOURCES: CalendarSourceRecord[] = []
+
+describe('CalendarPage · create with a project selected', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    mockListSources.mockResolvedValue({ sources: NO_SOURCES })
+    mockUseCalendarRange.mockReturnValue({
+      data: { items: [] },
+      items: [],
+      isLoading: false,
+      isFetching: false,
+      error: null
+    })
+    mockCreateEvent.mockResolvedValue({ success: true, event: { id: 'event-new' } })
+    mockLinkProjectItem.mockResolvedValue({ success: true })
+    localStorage.setItem('calendar-view', 'day')
+  })
+
+  async function openCreatePopover(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+    await user.click(await screen.findByRole('button', { name: 'Create event' }))
+    await screen.findByTestId('event-edit-popover')
+  }
+
+  it('links the created event to the drafted project', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<CalendarPage />)
+    await openCreatePopover(user)
+
+    await user.type(screen.getByPlaceholderText('New Event'), 'Kickoff')
+    await user.click(screen.getByText('stub-pick-project'))
+    await user.click(screen.getByTestId('event-edit-save'))
+
+    await waitFor(() => expect(mockCreateEvent).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(mockLinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'calendar_event',
+        itemId: 'event-new'
+      })
+    )
+  })
+
+  it('does not link when no project was selected', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<CalendarPage />)
+    await openCreatePopover(user)
+
+    await user.type(screen.getByPlaceholderText('New Event'), 'Kickoff')
+    await user.click(screen.getByTestId('event-edit-save'))
+
+    await waitFor(() => expect(mockCreateEvent).toHaveBeenCalledTimes(1))
+    expect(mockLinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('keeps the created event when linking fails', async () => {
+    mockLinkProjectItem.mockResolvedValue({ success: false, error: 'link failed' })
+    const user = userEvent.setup()
+    renderWithProviders(<CalendarPage />)
+    await openCreatePopover(user)
+
+    await user.type(screen.getByPlaceholderText('New Event'), 'Kickoff')
+    await user.click(screen.getByText('stub-pick-project'))
+    await user.click(screen.getByTestId('event-edit-save'))
+
+    await waitFor(() => expect(mockLinkProjectItem).toHaveBeenCalled())
+    // The popover closes on a successful create even though the link failed.
+    await waitFor(() => expect(screen.queryByTestId('event-edit-popover')).not.toBeInTheDocument())
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx
@@ -104,7 +104,16 @@ describe('CalendarPage · create with a project selected', () => {
     await openCreatePopover(user)
 
     await user.type(screen.getByPlaceholderText('New Event'), 'Kickoff')
+    expect(screen.getByText('stub-pick-project')).toHaveAttribute('data-value', '')
+
     await user.click(screen.getByText('stub-pick-project'))
+
+    // The draft owns the create-mode selection, so it has to come back down as
+    // `value` — otherwise the picker keeps reading "No project" after a pick.
+    await waitFor(() =>
+      expect(screen.getByText('stub-pick-project')).toHaveAttribute('data-value', 'p1')
+    )
+
     await user.click(screen.getByTestId('event-edit-save'))
 
     await waitFor(() => expect(mockCreateEvent).toHaveBeenCalledTimes(1))

--- a/apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
+import { toast } from 'sonner'
 import { renderWithProviders, userEvent } from '@tests/utils/render'
 import { CalendarPage } from '@/pages/calendar'
 import type { CalendarSourceRecord } from '@/services/calendar-service'
@@ -141,5 +142,7 @@ describe('CalendarPage · create with a project selected', () => {
     await waitFor(() => expect(mockLinkProjectItem).toHaveBeenCalled())
     // The popover closes on a successful create even though the link failed.
     await waitFor(() => expect(screen.queryByTestId('event-edit-popover')).not.toBeInTheDocument())
+    // The failure must not be swallowed silently — it has to surface to the user.
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('link failed'))
   })
 })

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -115,7 +115,8 @@ function createDraftFromAnchor(anchorDate: string): CalendarEventDraft {
     isAllDay: false,
     startAt: `${anchorDate}T09:00`,
     endAt: `${anchorDate}T10:00`,
-    targetCalendarId: null
+    targetCalendarId: null,
+    projectId: null
   }
 }
 
@@ -132,7 +133,8 @@ function createDraftFromItem(item: CalendarProjectionItem): CalendarEventDraft {
         ? toLocalDateInputValue(item.endAt)
         : toLocalDateTimeInputValue(item.endAt)
       : '',
-    targetCalendarId: item.binding?.remoteCalendarId ?? null
+    targetCalendarId: item.binding?.remoteCalendarId ?? null,
+    projectId: null
   }
 }
 
@@ -423,7 +425,8 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
               ? toLocalDateInputValue(record.endAt)
               : toLocalDateTimeInputValue(record.endAt)
             : '',
-          targetCalendarId: record.targetCalendarId
+          targetCalendarId: record.targetCalendarId,
+          projectId: null
         } satisfies CalendarEventDraft)
       : createDraftFromItem(source)
 

--- a/apps/desktop/src/renderer/src/pages/calendar.tsx
+++ b/apps/desktop/src/renderer/src/pages/calendar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import {
   CalendarShell,
   type AnchorRect,
@@ -639,6 +640,28 @@ export function CalendarPage({ className: _className }: CalendarPageProps): Reac
         const result = await calendarService.createEvent(toCreatePayload(popoverState.draft))
         if (!result.success) {
           throw new Error(result.error ?? 'Could not create event.')
+        }
+        const createdId = result.event?.id
+        const projectId = popoverState.draft.projectId
+        // The link needs an event id, which only exists after the create. A
+        // failed link must not discard a successfully created event.
+        if (createdId && projectId) {
+          try {
+            const linked = await tasksService.linkProjectItem({
+              projectId,
+              itemType: 'calendar_event',
+              itemId: createdId
+            })
+            if (!linked.success) throw new Error(linked.error)
+          } catch (error) {
+            const tCalendar = getI18n().getFixedT(null, 'calendar')
+            log.error('Failed to link created event to project', {
+              eventId: createdId,
+              projectId,
+              error: extractErrorMessage(error)
+            })
+            toast.error(extractErrorMessage(error, tCalendar('form.project-update-failed')))
+          }
         }
       } else if (popoverState.eventId) {
         const result = await calendarService.updateEvent({

--- a/apps/desktop/src/renderer/src/pages/canvas/canvas-event-editor.tsx
+++ b/apps/desktop/src/renderer/src/pages/canvas/canvas-event-editor.tsx
@@ -47,7 +47,8 @@ export function toDraft(event: CalendarEventRecord): CalendarEventDraft {
         ? toLocalDateInputValue(event.endAt)
         : toLocalDateTimeInputValue(event.endAt)
       : '',
-    targetCalendarId: event.targetCalendarId
+    targetCalendarId: event.targetCalendarId,
+    projectId: null
   }
 }
 

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -62,11 +62,19 @@ clear the link. When creating a new event, the choice is saved once you save the
 editing an existing one, picking a project links or unlinks it immediately — the same write the
 event chip's **Add to project** context-menu action makes.
 
+On an existing event the change is written straight away, so **Cancel** does not undo it — reopen
+the form and pick **No project** (or the previous project) to change it back. Only new events wait
+for **Save**.
+
 An event can end up linked to more than one project — for example if it was also added to a
 second project from the chip's context menu. The form still shows one project in the picker, and
 lists any additional links as small chips beside it, each with an **×** to remove just that link.
+A link to an archived project also shows as a chip, since the picker only lists active projects;
+it stays until you remove it with its **×**.
+
 Quick Create (dragging on the grid) stays title-only and has no Project row; add a project after
-saving, from the full event form.
+saving, from the full event form. Event cards on a [canvas](/user-guide/canvas/overview) have no
+Project row either — open the event from the calendar to change its project.
 
 ## Scheduling Tasks by Drag
 

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -54,6 +54,20 @@ Click an empty time slot (day / week views) or a date cell (month) to create an 
 
 Click an event to open the popover. Edit title, time, and description in place. The popover has a "Open in tab" action for full editing.
 
+### Assigning a Project
+
+The event form (opened from **+** in the toolbar, or from an existing event) has a **Project**
+row, defaulting to **No project**. Pick a project to link the event to it; pick **No project** to
+clear the link. When creating a new event, the choice is saved once you save the event; when
+editing an existing one, picking a project links or unlinks it immediately — the same write the
+event chip's **Add to project** context-menu action makes.
+
+An event can end up linked to more than one project — for example if it was also added to a
+second project from the chip's context menu. The form still shows one project in the picker, and
+lists any additional links as small chips beside it, each with an **×** to remove just that link.
+Quick Create (dragging on the grid) stays title-only and has no Project row; add a project after
+saving, from the full event form.
+
 ## Scheduling Tasks by Drag
 
 Tasks can be scheduled and rescheduled by dragging, from two places:

--- a/apps/docs/src/user-guide/calendar.md
+++ b/apps/docs/src/user-guide/calendar.md
@@ -67,7 +67,8 @@ the form and pick **No project** (or the previous project) to change it back. On
 for **Save**.
 
 An event can end up linked to more than one project — for example if it was also added to a
-second project from the chip's context menu. The form still shows one project in the picker, and
+second project from the chip's context menu, or if a swap only half-succeeded and reported an
+error. The form still shows one project in the picker, and
 lists any additional links as small chips beside it, each with an **×** to remove just that link.
 A link to an archived project also shows as a chip, since the picker only lists active projects;
 it stays until you remove it with its **×**.

--- a/docs/superpowers/plans/2026-08-03-calendar-event-project-assignment.md
+++ b/docs/superpowers/plans/2026-08-03-calendar-event-project-assignment.md
@@ -1,0 +1,1187 @@
+# Calendar Event → Project Assignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the calendar event form a project field, so a user can assign a project while creating an event and change or clear it while editing one.
+
+**Architecture:** No data-model work — `project_links` already stores `(project_id, 'calendar_event', event_id)` and the `linkProjectItem` / `unlinkProjectItem` / `listForItem` IPC already accepts `calendar_event`. A new `EventProjectField` component wraps the existing `ProjectPicker`. In **create** mode it is fully controlled and its selection rides in the draft until the event has an id; in **edit** mode it owns its own state, loading from `listForItem` and writing link/unlink immediately (same behavior as today's right-click "Add to project" flow). `calendar.tsx` changes in exactly one place: link the draft's project after `createEvent` returns the new id.
+
+**Tech Stack:** React 19, TypeScript, Vitest + @testing-library/react (jsdom), Tailwind, i18next, sonner (toasts), Electron IPC via `@/services/tasks-service`.
+
+## Global Constraints
+
+- **Backward compatibility is mandatory** — this app runs on real user data. This change adds **no** DB migration, **no** schema change, **no** IPC contract change. If you find yourself editing `packages/db-schema` or `packages/contracts`, stop: the plan has gone off the rails.
+- **Single-select in the UI, many-to-many in the DB.** Never delete a link the user did not explicitly remove. If an event has more than one link (possible via the existing right-click flow), extras render as removable chips.
+- **Tailwind logical properties (RTL).** New code uses `ms-*`/`me-*`, `ps-*`/`pe-*`, `start-*`/`end-*`, `text-start`/`text-end`. Never `ml-*`/`mr-*`/`left-*`/`right-*`/`text-left`/`text-right`.
+- **Logging:** `createLogger('Scope')` from `@/lib/logger`, never `console.*`.
+- **User-facing errors:** `extractErrorMessage(err, fallback)` from `@/lib/ipc-error`.
+- **No hardcoded UI strings.** All copy goes through `useT('calendar')`. Add English keys to `packages/i18n/src/locales/en/calendar.json`; English is what `i18n:check` gates, other locales fall back to English.
+- **Do not modify `ItemProjectChips`** — `note.tsx` and `file.tsx` use it and must stay read-only.
+- **Commit after every task.** No `Co-Authored-By` trailer.
+
+## File Structure
+
+| File                                                                                 | Responsibility                                                                                                                       |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx`          | **New.** The whole feature's UI + edit-mode link orchestration. Create mode = controlled; edit mode = self-loading and self-writing. |
+| `apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx`     | **New.** Unit tests for both modes, including legacy multi-link chips and error handling.                                            |
+| `apps/desktop/src/renderer/src/components/calendar/types.ts`                         | Add `projectId: string \| null` to `CalendarEventDraft`.                                                                             |
+| `apps/desktop/src/renderer/src/components/calendar/calendar-event-form.tsx`          | Swap `ItemProjectChips` for `EventProjectField`; drop the edit-only guard.                                                           |
+| `apps/desktop/src/renderer/src/components/calendar/calendar-quick-create-dialog.tsx` | Draft literal gains `projectId: null` (field itself is **not** added here).                                                          |
+| `apps/desktop/src/renderer/src/pages/calendar.tsx`                                   | Two draft constructors + one inline draft gain `projectId`; `handlePopoverSave` links after create.                                  |
+| `apps/desktop/src/renderer/src/pages/canvas/canvas-event-editor.tsx`                 | `toDraft` gains `projectId: null`. No field rendered (no `eventId` is passed to the form there — see Task 4).                        |
+| `packages/i18n/src/locales/en/calendar.json`                                         | Three new keys under `form`.                                                                                                         |
+
+---
+
+### Task 1: `EventProjectField` — create mode
+
+The component in create mode: a labeled `ProjectPicker` whose value lives in the parent's draft. No IPC at all — there is no event row to link to yet.
+
+**Files:**
+
+- Create: `apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx`
+- Create: `apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx`
+- Modify: `packages/i18n/src/locales/en/calendar.json` (the `"form"` object, currently starting at line 60)
+
+**Interfaces:**
+
+- Consumes: `ProjectPicker` from `@/components/tasks/project-picker` (props `value: string | null`, `onChange: (id: string | null) => void`, `projects: Project[]`, `includeAllOption`, `allOptionLabel`, `searchable`, `allowCreate`, `className`); `useTasksOptional` from `@/contexts/tasks` (returns `{ projects: Project[] } | null`).
+- Produces: `EventProjectField` (named + default export) with
+
+```ts
+export interface EventProjectFieldProps {
+  mode: 'create' | 'edit'
+  /** Saved event id. Required in edit mode; null while drafting a new event. */
+  eventId?: string | null
+  /** Create mode only: the draft's selected project id. */
+  value: string | null
+  /** Create mode only: writes the selection back into the draft. */
+  onChange: (projectId: string | null) => void
+  disabled?: boolean
+}
+```
+
+- [ ] **Step 1: Add the English copy**
+
+In `packages/i18n/src/locales/en/calendar.json`, inside the existing `"form"` object, add these three keys after `"primary-suffix": "primary"` (add a comma to that line):
+
+```json
+    "project": "Project",
+    "no-project": "No project",
+    "remove-from-project": "Remove from {project}"
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EventProjectField } from './event-project-field'
+
+const { mockListForItem, mockLinkProjectItem, mockUnlinkProjectItem, mockOnProjectUpdated } =
+  vi.hoisted(() => ({
+    mockListForItem: vi.fn(),
+    mockLinkProjectItem: vi.fn(),
+    mockUnlinkProjectItem: vi.fn(),
+    mockOnProjectUpdated: vi.fn(() => () => {})
+  }))
+
+vi.mock('@/services/tasks-service', () => ({
+  tasksService: {
+    listForItem: mockListForItem,
+    linkProjectItem: mockLinkProjectItem,
+    unlinkProjectItem: mockUnlinkProjectItem
+  },
+  onProjectUpdated: mockOnProjectUpdated
+}))
+
+// Projects come from the app-wide TasksProvider, same as calendar-task-popover.
+vi.mock('@/contexts/tasks', () => ({
+  useTasksOptional: () => ({
+    projects: [
+      { id: 'p1', name: 'Launch', color: '#ff0000', icon: null, isArchived: false },
+      { id: 'p2', name: 'Finance', color: '#00ff00', icon: null, isArchived: false }
+    ]
+  })
+}))
+
+// The real Picker is Radix Popover-based and does not open on click in jsdom
+// (codebase convention: mock it). This passthrough exposes one button per
+// option so the field's own orchestration is what gets tested.
+vi.mock('@/components/tasks/project-picker', () => ({
+  ProjectPicker: ({
+    value,
+    onChange,
+    projects,
+    allOptionLabel
+  }: {
+    value: string | null
+    onChange: (id: string | null) => void
+    projects: Array<{ id: string; name: string }>
+    allOptionLabel?: string
+  }) => (
+    <div data-testid="project-picker" data-value={value ?? ''}>
+      <button type="button" onClick={() => onChange(null)}>
+        {allOptionLabel}
+      </button>
+      {projects.map((project) => (
+        <button key={project.id} type="button" onClick={() => onChange(project.id)}>
+          {`pick-${project.name}`}
+        </button>
+      ))}
+    </div>
+  )
+}))
+
+describe('EventProjectField · create mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockOnProjectUpdated.mockReturnValue(() => {})
+  })
+
+  it('renders the picker with the draft value and no IPC call', () => {
+    render(<EventProjectField mode="create" value="p1" onChange={vi.fn()} />)
+
+    expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    expect(screen.getByText('Project')).toBeInTheDocument()
+    expect(mockListForItem).not.toHaveBeenCalled()
+  })
+
+  it('reports the selected project through onChange without writing links', () => {
+    const onChange = vi.fn()
+    render(<EventProjectField mode="create" value={null} onChange={onChange} />)
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    expect(onChange).toHaveBeenCalledWith('p1')
+    expect(mockLinkProjectItem).not.toHaveBeenCalled()
+    expect(mockUnlinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('reports null when the user picks "No project"', () => {
+    const onChange = vi.fn()
+    render(<EventProjectField mode="create" value="p1" onChange={onChange} />)
+
+    fireEvent.click(screen.getByText('No project'))
+
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+})
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+pnpm --filter @memry/desktop test:renderer src/renderer/src/components/calendar/event-project-field.test.tsx
+```
+
+Expected: FAIL — `Failed to resolve import "./event-project-field"`.
+
+- [ ] **Step 4: Write the minimal implementation**
+
+Create `apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx`:
+
+```tsx
+import { useT } from '@memry/i18n/renderer'
+
+import { ProjectPicker } from '@/components/tasks/project-picker'
+import { useTasksOptional } from '@/contexts/tasks'
+
+export interface EventProjectFieldProps {
+  mode: 'create' | 'edit'
+  /** Saved event id. Required in edit mode; null while drafting a new event. */
+  eventId?: string | null
+  /** Create mode only: the draft's selected project id. */
+  value: string | null
+  /** Create mode only: writes the selection back into the draft. */
+  onChange: (projectId: string | null) => void
+  disabled?: boolean
+}
+
+/**
+ * Project assignment for a calendar event, backed by `project_links`.
+ *
+ * Create mode is fully controlled — the selection rides in the draft until the
+ * event has an id. Edit mode owns its own state and writes link/unlink
+ * immediately, matching the calendar chip's "Add to project" context menu.
+ */
+export function EventProjectField({
+  mode,
+  value,
+  onChange,
+  disabled
+}: EventProjectFieldProps): React.JSX.Element | null {
+  const { t } = useT('calendar')
+  const projects = useTasksOptional()?.projects ?? []
+
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-xs font-medium text-muted-foreground">{t('form.project')}</span>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <ProjectPicker
+          value={value}
+          onChange={onChange}
+          projects={projects}
+          includeAllOption
+          allOptionLabel={t('form.no-project')}
+          searchable
+          allowCreate={false}
+          className="min-w-[160px]"
+        />
+      </div>
+    </label>
+  )
+}
+
+export default EventProjectField
+```
+
+Note: `mode` and `disabled` are unused in this task — Task 2 uses them. Keep them in the props type; if lint objects to the unused `mode` binding, leave it out of the destructure for now and add it back in Task 2.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+pnpm --filter @memry/desktop test:renderer src/renderer/src/components/calendar/event-project-field.test.tsx
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx packages/i18n/src/locales/en/calendar.json
+git commit -m "feat(calendar): event project field, create mode"
+```
+
+---
+
+### Task 2: `EventProjectField` — edit mode reads and writes links
+
+In edit mode the truth is `project_links`, not the draft. The field loads its own state and each selection writes immediately.
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx`
+- Modify: `apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `tasksService.listForItem(itemType: 'calendar_event', itemId: string) => Promise<ProjectRef[]>`; `tasksService.linkProjectItem(input: { projectId: string; itemType: 'calendar_event'; itemId: string }) => Promise<{ success: boolean; error?: string }>`; `tasksService.unlinkProjectItem(input)` with the same shape; `onProjectUpdated(cb) => () => void`. `ProjectRef` is `{ id: string; name: string; color: string; icon: string | null }`.
+- Produces: no new exports — the same `EventProjectField`, now handling `mode="edit"`.
+
+**Important:** `listForItem` goes through the main-side `withDb` wrapper, which resolves an error envelope `{ success: false, error }` instead of rejecting. Guard with `Array.isArray(result)` — `ItemProjectChips` does exactly this and has a test for it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append this describe block to `event-project-field.test.tsx` (keep the existing mocks and the create-mode block; add `waitFor` to the `@testing-library/react` import):
+
+```tsx
+describe('EventProjectField · edit mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockOnProjectUpdated.mockReturnValue(() => {})
+    mockListForItem.mockResolvedValue([])
+    mockLinkProjectItem.mockResolvedValue({ success: true })
+    mockUnlinkProjectItem.mockResolvedValue({ success: true })
+  })
+
+  it('loads the current links for the event on mount', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledWith('calendar_event', 'evt-1'))
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+  })
+
+  it('renders nothing when edit mode has no event id yet', () => {
+    const { container } = render(
+      <EventProjectField mode="edit" eventId={null} value={null} onChange={vi.fn()} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+    expect(mockListForItem).not.toHaveBeenCalled()
+  })
+
+  it('unlinks the previous project and links the new one when the selection changes', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    fireEvent.click(screen.getByText('pick-Finance'))
+
+    await waitFor(() =>
+      expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'calendar_event',
+        itemId: 'evt-1'
+      })
+    )
+    expect(mockLinkProjectItem).toHaveBeenCalledWith({
+      projectId: 'p2',
+      itemType: 'calendar_event',
+      itemId: 'evt-1'
+    })
+  })
+
+  it('only links when the event had no project', async () => {
+    mockListForItem.mockResolvedValue([])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    await waitFor(() => expect(mockLinkProjectItem).toHaveBeenCalledTimes(1))
+    expect(mockUnlinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('only unlinks when the user picks "No project"', async () => {
+    mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+    )
+
+    fireEvent.click(screen.getByText('No project'))
+
+    await waitFor(() =>
+      expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'calendar_event',
+        itemId: 'evt-1'
+      })
+    )
+    expect(mockLinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('never calls onChange in edit mode (the draft does not own the link)', async () => {
+    const onChange = vi.fn()
+    mockListForItem.mockResolvedValue([])
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={onChange} />)
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    await waitFor(() => expect(mockLinkProjectItem).toHaveBeenCalled())
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('treats an IPC error envelope from listForItem as no links', async () => {
+    mockListForItem.mockResolvedValue({ success: false, error: 'db error' })
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', '')
+    )
+  })
+
+  it('shows a toast and reloads when a link write fails', async () => {
+    mockListForItem.mockResolvedValue([])
+    mockLinkProjectItem.mockResolvedValue({ success: false, error: 'link failed' })
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByText('pick-Launch'))
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(2))
+  })
+
+  it('reloads when a project update event fires', async () => {
+    mockListForItem
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'p2', name: 'Finance', color: '#00ff00', icon: null }])
+    let updateHandler: (() => void) | undefined
+    mockOnProjectUpdated.mockImplementation((cb: () => void) => {
+      updateHandler = cb
+      return () => {}
+    })
+
+    render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+    await waitFor(() => expect(mockListForItem).toHaveBeenCalledTimes(1))
+
+    updateHandler?.()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p2')
+    )
+  })
+})
+```
+
+Also add the `sonner` mock next to the other `vi.mock` calls at the top of the file, and add `mockToastError` to the `vi.hoisted` block:
+
+```tsx
+// in the existing vi.hoisted({...}) object, add:
+//   mockToastError: vi.fn()
+vi.mock('sonner', () => ({
+  toast: { error: mockToastError, success: vi.fn() }
+}))
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pnpm --filter @memry/desktop test:renderer src/renderer/src/components/calendar/event-project-field.test.tsx
+```
+
+Expected: FAIL — the edit-mode tests fail because nothing calls `listForItem`; the create-mode tests still pass.
+
+- [ ] **Step 3: Implement edit mode**
+
+Replace the contents of `event-project-field.tsx` with:
+
+```tsx
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { useT } from '@memry/i18n/renderer'
+
+import { ProjectPicker } from '@/components/tasks/project-picker'
+import { useTasksOptional } from '@/contexts/tasks'
+import { extractErrorMessage } from '@/lib/ipc-error'
+import { createLogger } from '@/lib/logger'
+import { onProjectUpdated, tasksService, type ProjectRef } from '@/services/tasks-service'
+
+const log = createLogger('EventProjectField')
+
+export interface EventProjectFieldProps {
+  mode: 'create' | 'edit'
+  /** Saved event id. Required in edit mode; null while drafting a new event. */
+  eventId?: string | null
+  /** Create mode only: the draft's selected project id. */
+  value: string | null
+  /** Create mode only: writes the selection back into the draft. */
+  onChange: (projectId: string | null) => void
+  disabled?: boolean
+}
+
+/**
+ * Project assignment for a calendar event, backed by `project_links`.
+ *
+ * Create mode is fully controlled — the selection rides in the draft until the
+ * event has an id. Edit mode owns its own state and writes link/unlink
+ * immediately, matching the calendar chip's "Add to project" context menu.
+ */
+export function EventProjectField({
+  mode,
+  eventId,
+  value,
+  onChange,
+  disabled
+}: EventProjectFieldProps): React.JSX.Element | null {
+  const { t } = useT('calendar')
+  const projects = useTasksOptional()?.projects ?? []
+  const [links, setLinks] = useState<ProjectRef[]>([])
+  const isEdit = mode === 'edit'
+
+  const load = useCallback(async (): Promise<void> => {
+    if (!isEdit || !eventId) return
+    try {
+      const result = await tasksService.listForItem('calendar_event', eventId)
+      // `listForItem` runs through the main-side `withDb` wrapper: on a DB
+      // error it resolves `{ success: false, error }` instead of rejecting.
+      setLinks(Array.isArray(result) ? result : [])
+    } catch (error) {
+      log.error('Failed to load event projects', extractErrorMessage(error))
+      setLinks([])
+    }
+  }, [isEdit, eventId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  useEffect(() => onProjectUpdated(() => void load()), [load])
+
+  const handleSelect = async (nextId: string | null): Promise<void> => {
+    if (!isEdit || !eventId) {
+      onChange(nextId)
+      return
+    }
+    const previousId = links[0]?.id ?? null
+    if (previousId === nextId) return
+
+    try {
+      if (previousId) {
+        const removed = await tasksService.unlinkProjectItem({
+          projectId: previousId,
+          itemType: 'calendar_event',
+          itemId: eventId
+        })
+        if (!removed.success) throw new Error(removed.error)
+      }
+      if (nextId) {
+        const added = await tasksService.linkProjectItem({
+          projectId: nextId,
+          itemType: 'calendar_event',
+          itemId: eventId
+        })
+        if (!added.success) throw new Error(added.error)
+      }
+    } catch (error) {
+      toast.error(extractErrorMessage(error, t('form.project-update-failed')))
+    }
+    await load()
+  }
+
+  // Edit mode before the event is saved (canvas cards mount the form without an
+  // id): nothing to link to, so render nothing rather than a dead control.
+  if (isEdit && !eventId) return null
+
+  const selectedId = isEdit ? (links[0]?.id ?? null) : value
+
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-xs font-medium text-muted-foreground">{t('form.project')}</span>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <ProjectPicker
+          value={selectedId}
+          onChange={(next) => void handleSelect(next)}
+          projects={projects}
+          includeAllOption
+          allOptionLabel={t('form.no-project')}
+          searchable
+          allowCreate={false}
+          className="min-w-[160px]"
+        />
+      </div>
+    </label>
+  )
+}
+
+export default EventProjectField
+```
+
+`disabled` stays unused until the form passes it — if lint flags it, wire it straight through to `ProjectPicker` only if `ProjectPickerProps` accepts it; it does not today, so instead drop `disabled` from the destructure and keep it in the props type for API symmetry with the other form fields.
+
+- [ ] **Step 4: Add the failure-copy key**
+
+`t('form.project-update-failed')` is referenced above. In `packages/i18n/src/locales/en/calendar.json`, inside `"form"`, add:
+
+```json
+    "project-update-failed": "Could not update the event's project"
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+pnpm --filter @memry/desktop test:renderer src/renderer/src/components/calendar/event-project-field.test.tsx
+```
+
+Expected: PASS — 12 tests (3 create + 9 edit).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx packages/i18n/src/locales/en/calendar.json
+git commit -m "feat(calendar): event project field writes links in edit mode"
+```
+
+---
+
+### Task 3: Legacy multi-link chips
+
+An event can already be linked to several projects — the right-click "Add to project" dialog has always allowed it. The single-select picker shows the first link; the rest must stay visible and removable, never silently dropped.
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx`
+- Modify: `apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `X` icon from `@/lib/icons` (`export const X = createIcon(Cancel01Icon)`).
+- Produces: no new exports.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the edit-mode describe block in `event-project-field.test.tsx`:
+
+```tsx
+it('renders extra links as removable chips beside the picker', async () => {
+  mockListForItem.mockResolvedValue([
+    { id: 'p1', name: 'Launch', color: '#ff0000', icon: null },
+    { id: 'p2', name: 'Finance', color: '#00ff00', icon: null }
+  ])
+
+  render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+
+  await waitFor(() =>
+    expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+  )
+  expect(await screen.findByText('Finance')).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Remove from Finance' })).toBeInTheDocument()
+})
+
+it('unlinks only the chip that was removed', async () => {
+  mockListForItem.mockResolvedValue([
+    { id: 'p1', name: 'Launch', color: '#ff0000', icon: null },
+    { id: 'p2', name: 'Finance', color: '#00ff00', icon: null }
+  ])
+
+  render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+  const remove = await screen.findByRole('button', { name: 'Remove from Finance' })
+
+  fireEvent.click(remove)
+
+  await waitFor(() => expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1))
+  expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+    projectId: 'p2',
+    itemType: 'calendar_event',
+    itemId: 'evt-1'
+  })
+})
+
+it('switching the primary project leaves the extra link untouched', async () => {
+  mockListForItem.mockResolvedValue([
+    { id: 'p1', name: 'Launch', color: '#ff0000', icon: null },
+    { id: 'p2', name: 'Finance', color: '#00ff00', icon: null }
+  ])
+
+  render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+  await waitFor(() =>
+    expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+  )
+
+  fireEvent.click(screen.getByText('pick-Finance'))
+
+  await waitFor(() => expect(mockUnlinkProjectItem).toHaveBeenCalledTimes(1))
+  expect(mockUnlinkProjectItem).toHaveBeenCalledWith({
+    projectId: 'p1',
+    itemType: 'calendar_event',
+    itemId: 'evt-1'
+  })
+})
+
+it('shows no chips when the event has a single project', async () => {
+  mockListForItem.mockResolvedValue([{ id: 'p1', name: 'Launch', color: '#ff0000', icon: null }])
+
+  render(<EventProjectField mode="edit" eventId="evt-1" value={null} onChange={vi.fn()} />)
+
+  await waitFor(() =>
+    expect(screen.getByTestId('project-picker')).toHaveAttribute('data-value', 'p1')
+  )
+  expect(screen.queryByRole('button', { name: /^Remove from/ })).not.toBeInTheDocument()
+})
+```
+
+Note on the third test: the picker's `pick-Finance` selects `p2`, which is already the _extra_ link. `handleSelect` unlinks the previous primary (`p1`) and links `p2`; `linkProjectItem` is a no-op upsert on the existing unique index, so the assertion is about `unlinkProjectItem` being called exactly once, for `p1` only.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pnpm --filter @memry/desktop test:renderer src/renderer/src/components/calendar/event-project-field.test.tsx
+```
+
+Expected: FAIL — `Unable to find an accessible element with the role "button" and name "Remove from Finance"`.
+
+- [ ] **Step 3: Implement the chips**
+
+In `event-project-field.tsx`, add the icon import:
+
+```tsx
+import { X } from '@/lib/icons'
+```
+
+Add the removal handler next to `handleSelect`:
+
+```tsx
+const handleRemoveExtra = async (projectId: string): Promise<void> => {
+  if (!eventId) return
+  try {
+    const removed = await tasksService.unlinkProjectItem({
+      projectId,
+      itemType: 'calendar_event',
+      itemId: eventId
+    })
+    if (!removed.success) throw new Error(removed.error)
+  } catch (error) {
+    toast.error(extractErrorMessage(error, t('form.project-update-failed')))
+  }
+  await load()
+}
+```
+
+Derive the extras next to `selectedId`:
+
+```tsx
+// Single-select UI over a many-to-many table: an event linked to several
+// projects (possible via the chip context menu) keeps every link visible and
+// individually removable. Nothing is dropped that the user did not remove.
+const extraLinks = isEdit ? links.slice(1) : []
+```
+
+And render them inside the existing flex row, after `<ProjectPicker … />`:
+
+```tsx
+{
+  extraLinks.map((project) => (
+    <span
+      key={project.id}
+      className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs"
+    >
+      <span
+        className="size-2 shrink-0 rounded-full"
+        style={{ backgroundColor: project.color }}
+        aria-hidden="true"
+      />
+      <span className="max-w-32 truncate">{project.name}</span>
+      <button
+        type="button"
+        aria-label={t('form.remove-from-project', { project: project.name })}
+        onClick={() => void handleRemoveExtra(project.id)}
+        className="text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <X className="size-3" />
+      </button>
+    </span>
+  ))
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pnpm --filter @memry/desktop test:renderer src/renderer/src/components/calendar/event-project-field.test.tsx
+```
+
+Expected: PASS — 16 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx apps/desktop/src/renderer/src/components/calendar/event-project-field.test.tsx
+git commit -m "feat(calendar): keep extra project links removable on events"
+```
+
+---
+
+### Task 4: Wire the field into the event form
+
+Replace the read-only `ItemProjectChips` row with the new field, add `projectId` to the draft type, and update every draft constructor so the codebase typechecks.
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/components/calendar/types.ts`
+- Modify: `apps/desktop/src/renderer/src/components/calendar/calendar-event-form.tsx:20` (import) and `:222-224` (the chips block)
+- Modify: `apps/desktop/src/renderer/src/components/calendar/calendar-quick-create-dialog.tsx:79-88` (`buildDraft`)
+- Modify: `apps/desktop/src/renderer/src/pages/calendar.tsx:111-137` (`createDraftFromAnchor`, `createDraftFromItem`) and `:420-427` (the record-based edit draft)
+- Modify: `apps/desktop/src/renderer/src/pages/canvas/canvas-event-editor.tsx:37-51` (`toDraft`)
+- Modify: `apps/desktop/src/renderer/src/components/calendar/calendar-event-form.test.tsx` (if the existing tests assert on the chips block)
+
+**Interfaces:**
+
+- Consumes: `EventProjectField` from `./event-project-field` (props exactly as defined in Task 1).
+- Produces: `CalendarEventDraft` gains `projectId: string | null` — Task 5 reads `draft.projectId`.
+
+**Do not** add the field to `CalendarQuickCreateDialog`'s UI. That popover stays title-only by design; it only needs the new draft key so its `buildDraft` still satisfies the type.
+
+**Do not** pass `eventId` from `canvas-event-editor.tsx`. Idle canvas cards mount this form purely to paint, and several mount at once — each would fire a `listForItem` IPC. The field's `isEdit && !eventId` guard (Task 2) makes it render nothing there.
+
+- [ ] **Step 1: Add `projectId` to the draft type**
+
+In `apps/desktop/src/renderer/src/components/calendar/types.ts`:
+
+```ts
+export interface CalendarEventDraft {
+  title: string
+  description: string
+  isAllDay: boolean
+  startAt: string
+  endAt: string
+  /** M2: Google calendar this event should be pushed to. Null = fall through to default. */
+  targetCalendarId: string | null
+  /** Create mode only: project to link the event to once it has an id. */
+  projectId: string | null
+}
+```
+
+- [ ] **Step 2: Run typecheck to see every construction site**
+
+```bash
+pnpm --filter @memry/desktop typecheck:web
+```
+
+Expected: FAIL with "Property 'projectId' is missing" at four places — `calendar-quick-create-dialog.tsx`, two constructors in `calendar.tsx`, the inline record draft in `calendar.tsx`, and `canvas-event-editor.tsx`.
+
+- [ ] **Step 3: Add `projectId: null` at every construction site**
+
+In each of these object literals, add `projectId: null` after `targetCalendarId`:
+
+- `calendar-quick-create-dialog.tsx` → `buildDraft()`
+- `calendar.tsx` → `createDraftFromAnchor()` (currently ends `targetCalendarId: null`)
+- `calendar.tsx` → `createDraftFromItem()` (currently ends `targetCalendarId: item.binding?.remoteCalendarId ?? null`)
+- `calendar.tsx` → the inline `satisfies CalendarEventDraft` literal built from `record` (currently ends `targetCalendarId: record.targetCalendarId`)
+- `canvas-event-editor.tsx` → `toDraft()` (currently ends `targetCalendarId: event.targetCalendarId`)
+
+- [ ] **Step 4: Swap the form's chips row for the field**
+
+In `apps/desktop/src/renderer/src/components/calendar/calendar-event-form.tsx`, replace the import on line 20:
+
+```tsx
+import { EventProjectField } from './event-project-field'
+```
+
+and replace the block at lines 222-224:
+
+```tsx
+<EventProjectField
+  mode={mode}
+  eventId={eventId}
+  value={draft.projectId}
+  onChange={(projectId) => onDraftChange({ ...draft, projectId })}
+/>
+```
+
+- [ ] **Step 5: Run typecheck and the calendar renderer tests**
+
+```bash
+pnpm --filter @memry/desktop typecheck:web
+pnpm --filter @memry/desktop test:renderer src/renderer/src/components/calendar
+```
+
+Expected: typecheck PASS. Tests PASS — if `calendar-event-form.test.tsx` or `calendar-event-popover.test.tsx` mocked or asserted `ItemProjectChips`, update those assertions to the new field (mock `./event-project-field` with a stub that renders `null` if the test is not about projects).
+
+- [ ] **Step 6: Run the canvas editor tests**
+
+```bash
+pnpm --filter @memry/desktop test:renderer src/renderer/src/pages/canvas
+```
+
+Expected: PASS — the canvas editor passes no `eventId`, so the field renders nothing and the card layout is unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/calendar apps/desktop/src/renderer/src/pages/calendar.tsx apps/desktop/src/renderer/src/pages/canvas/canvas-event-editor.tsx
+git commit -m "feat(calendar): show the project field in the event form"
+```
+
+---
+
+### Task 5: Link the project after the event is created
+
+Create mode holds the selection in the draft because there is no event id yet. `createEvent` returns the saved record, so the link is one call away.
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/pages/calendar.tsx` (`handlePopoverSave`, the create branch around line 636)
+- Create: `apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `calendarService.createEvent(input) => Promise<{ success: boolean; event: CalendarEventRecord | null; error?: string }>`; `tasksService.linkProjectItem(input) => Promise<{ success: boolean; error?: string }>`; `draft.projectId` from Task 4.
+- Produces: nothing new.
+
+A failed link must not fail the event creation — the event exists, so keep it, log, and toast.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx`:
+
+```tsx
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders, userEvent } from '@tests/utils/render'
+import { CalendarPage } from '@/pages/calendar'
+import type { CalendarSourceRecord } from '@/services/calendar-service'
+
+const {
+  mockUseCalendarRange,
+  mockListSources,
+  mockCreateEvent,
+  mockUpdateEvent,
+  mockLinkProjectItem,
+  mockOpenTab
+} = vi.hoisted(() => ({
+  mockUseCalendarRange: vi.fn(),
+  mockListSources: vi.fn(),
+  mockCreateEvent: vi.fn(),
+  mockUpdateEvent: vi.fn(),
+  mockLinkProjectItem: vi.fn(),
+  mockOpenTab: vi.fn()
+}))
+
+vi.mock('@/hooks/use-calendar-range', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks/use-calendar-range')>()),
+  useCalendarRange: mockUseCalendarRange
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useActiveTab: () => null,
+  useTabActions: () => ({ openTab: mockOpenTab })
+}))
+
+vi.mock('@/services/calendar-service', () => ({
+  calendarService: {
+    listSources: mockListSources,
+    createEvent: mockCreateEvent,
+    updateEvent: mockUpdateEvent
+  },
+  onCalendarChanged: vi.fn(() => () => {})
+}))
+
+// The project field is exercised in its own test; here it only needs to put a
+// project id into the draft so the page's post-create link is observable.
+vi.mock('@/components/calendar/event-project-field', () => ({
+  EventProjectField: ({
+    value,
+    onChange
+  }: {
+    value: string | null
+    onChange: (id: string | null) => void
+  }) => (
+    <button type="button" data-value={value ?? ''} onClick={() => onChange('p1')}>
+      stub-pick-project
+    </button>
+  )
+}))
+
+vi.mock('@/services/tasks-service', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/tasks-service')>()),
+  tasksService: {
+    linkProjectItem: mockLinkProjectItem
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() }
+}))
+
+const NO_SOURCES: CalendarSourceRecord[] = []
+
+describe('CalendarPage · create with a project selected', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    mockListSources.mockResolvedValue({ sources: NO_SOURCES })
+    mockUseCalendarRange.mockReturnValue({
+      data: { items: [] },
+      items: [],
+      isLoading: false,
+      isFetching: false,
+      error: null
+    })
+    mockCreateEvent.mockResolvedValue({ success: true, event: { id: 'event-new' } })
+    mockLinkProjectItem.mockResolvedValue({ success: true })
+    localStorage.setItem('calendar-view', 'day')
+  })
+
+  async function openCreatePopover(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+    await user.click(await screen.findByRole('button', { name: 'Create event' }))
+    await screen.findByTestId('event-edit-popover')
+  }
+
+  it('links the created event to the drafted project', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<CalendarPage />)
+    await openCreatePopover(user)
+
+    await user.type(screen.getByPlaceholderText('New Event'), 'Kickoff')
+    await user.click(screen.getByText('stub-pick-project'))
+    await user.click(screen.getByTestId('event-edit-save'))
+
+    await waitFor(() => expect(mockCreateEvent).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(mockLinkProjectItem).toHaveBeenCalledWith({
+        projectId: 'p1',
+        itemType: 'calendar_event',
+        itemId: 'event-new'
+      })
+    )
+  })
+
+  it('does not link when no project was selected', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<CalendarPage />)
+    await openCreatePopover(user)
+
+    await user.type(screen.getByPlaceholderText('New Event'), 'Kickoff')
+    await user.click(screen.getByTestId('event-edit-save'))
+
+    await waitFor(() => expect(mockCreateEvent).toHaveBeenCalledTimes(1))
+    expect(mockLinkProjectItem).not.toHaveBeenCalled()
+  })
+
+  it('keeps the created event when linking fails', async () => {
+    mockLinkProjectItem.mockResolvedValue({ success: false, error: 'link failed' })
+    const user = userEvent.setup()
+    renderWithProviders(<CalendarPage />)
+    await openCreatePopover(user)
+
+    await user.type(screen.getByPlaceholderText('New Event'), 'Kickoff')
+    await user.click(screen.getByText('stub-pick-project'))
+    await user.click(screen.getByTestId('event-edit-save'))
+
+    await waitFor(() => expect(mockLinkProjectItem).toHaveBeenCalled())
+    // The popover closes on a successful create even though the link failed.
+    await waitFor(() => expect(screen.queryByTestId('event-edit-popover')).not.toBeInTheDocument())
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @memry/desktop test:renderer src/renderer/src/pages/calendar-event-project.test.tsx
+```
+
+Expected: FAIL — `mockLinkProjectItem` is never called.
+
+- [ ] **Step 3: Implement the post-create link**
+
+In `apps/desktop/src/renderer/src/pages/calendar.tsx`, in `handlePopoverSave`, replace the create branch:
+
+```tsx
+      if (popoverState.mode === 'create') {
+        const result = await calendarService.createEvent(toCreatePayload(popoverState.draft))
+        if (!result.success) {
+          throw new Error(result.error ?? 'Could not create event.')
+        }
+        const createdId = result.event?.id
+        const projectId = popoverState.draft.projectId
+        // The link needs an event id, which only exists after the create. A
+        // failed link must not discard a successfully created event.
+        if (createdId && projectId) {
+          try {
+            const linked = await tasksService.linkProjectItem({
+              projectId,
+              itemType: 'calendar_event',
+              itemId: createdId
+            })
+            if (!linked.success) throw new Error(linked.error)
+          } catch (error) {
+            const tCalendar = getI18n().getFixedT(null, 'calendar')
+            log.error('Failed to link created event to project', {
+              eventId: createdId,
+              projectId,
+              error: extractErrorMessage(error)
+            })
+            toast.error(extractErrorMessage(error, tCalendar('form.project-update-failed')))
+          }
+        }
+      } else if (popoverState.eventId) {
+```
+
+Already in scope in this file: `tasksService` (line 39), `extractErrorMessage` (line 36), `log` (line 49), `getI18n` (line 47). The file builds its translator locally with `getI18n().getFixedT(null, 'calendar')` — lines 554 and 597 do the same, so follow that pattern rather than adding a hook.
+
+One import is missing. Add it at the top of the file:
+
+```tsx
+import { toast } from 'sonner'
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @memry/desktop test:renderer src/renderer/src/pages/calendar-event-project.test.tsx
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Run the rest of the calendar page tests**
+
+```bash
+pnpm --filter @memry/desktop test:renderer src/renderer/src/pages/calendar
+```
+
+Expected: PASS — the existing quick-create and callbacks suites are unaffected (the quick-create dialog never sets `projectId`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/pages/calendar.tsx apps/desktop/src/renderer/src/pages/calendar-event-project.test.tsx
+git commit -m "feat(calendar): link a new event to the project chosen at create time"
+```
+
+---
+
+### Task 6: Full verification and docs gate
+
+**Files:**
+
+- Modify: `apps/docs/src/**` only if `docs:impact` reports `missing-docs`
+
+- [ ] **Step 1: Run the full desktop renderer suite**
+
+```bash
+pnpm --filter @memry/desktop test:renderer
+```
+
+Expected: PASS. Fix any suite that mocked `ItemProjectChips` inside a calendar test.
+
+- [ ] **Step 2: Typecheck the whole monorepo**
+
+```bash
+pnpm typecheck
+```
+
+Expected: PASS. Pre-existing errors in `websocket.test.ts` and `folders.test.ts` are known and may be ignored.
+
+- [ ] **Step 3: Lint**
+
+```bash
+pnpm lint
+```
+
+Expected: PASS with zero warnings. Watch for the RTL rule — the new component must use logical Tailwind classes only.
+
+- [ ] **Step 4: i18n check**
+
+```bash
+pnpm --filter @memry/desktop i18n:check
+```
+
+Expected: PASS. English is the gated locale; the four new keys must exist under `form` in `packages/i18n/src/locales/en/calendar.json`: `project`, `no-project`, `remove-from-project`, `project-update-failed`.
+
+- [ ] **Step 5: Whitespace check**
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Docs impact gate**
+
+```bash
+base_commit=$(git merge-base origin/main HEAD)
+pnpm docs:impact --base "$base_commit" --strict
+```
+
+If it reports `missing-docs`, update the calendar page under `apps/docs/src/**` describing the new project field (create + edit, clearing with "No project", extra chips for events linked to several projects), then re-run the command and `pnpm docs:build`.
+
+- [ ] **Step 7: Commit any docs changes**
+
+```bash
+git add apps/docs/src
+git commit -m "docs(calendar): document event project assignment"
+```
+
+---
+
+## Manual smoke test (after Task 6)
+
+```bash
+pnpm dev
+```
+
+1. Calendar → toolbar **+** → the form shows a **Project** row reading "No project".
+2. Pick a project, add a title, Save → open the event again; the picker shows that project.
+3. Change the project in the open event → close and reopen; the new project sticks.
+4. Pick "No project" → reopen; it reads "No project" and the project hub no longer lists the event.
+5. Right-click the event chip → "Add to project" → choose a _second_ project → open the event: the picker shows one project and the second appears as a chip with an ×. Click the × → only that link disappears.
+6. Drag on the grid to open the quick-create box → it stays title-only, no project row.

--- a/docs/superpowers/specs/2026-08-03-calendar-event-project-assignment-design.md
+++ b/docs/superpowers/specs/2026-08-03-calendar-event-project-assignment-design.md
@@ -1,0 +1,193 @@
+# Calendar event → project assignment
+
+Date: 2026-08-03
+Status: Design approved, not implemented
+
+## Problem
+
+A user creating or editing a calendar event has no discoverable way to assign it to a
+project. Some events display a project label, which reads as a feature that is missing
+its controls: the label cannot be changed and cannot be removed.
+
+## Current state
+
+The label is real, and so is the missing control surface.
+
+- `calendar_events` has no `project_id` column. The association lives in the generic link
+  layer: `project_links (project_id, item_type, item_id)` —
+  [packages/db-schema/src/schema/project-links.ts](../../../packages/db-schema/src/schema/project-links.ts).
+  The relation is many-to-many.
+- The IPC surface already exists and already accepts `calendar_event`:
+  `linkProjectItem`, `unlinkProjectItem`, `listForItem` —
+  `ProjectLinkItemSchema` / `ProjectListForItemSchema` in
+  [packages/contracts/src/tasks-api.ts](../../../packages/contracts/src/tasks-api.ts),
+  handlers at
+  [apps/desktop/src/main/ipc/tasks-handlers.ts](../../../apps/desktop/src/main/ipc/tasks-handlers.ts).
+- The only way to create a link is a right-click on a calendar chip → "Add to project",
+  which opens `AddEventToProjectDialog`
+  ([add-event-to-project-dialog.tsx](../../../apps/desktop/src/renderer/src/components/tasks/projects/add-event-to-project-dialog.tsx)).
+  It is undiscoverable, and it only adds.
+- The event form renders `ItemProjectChips` — read-only pills, edit mode only —
+  at [calendar-event-form.tsx:222](../../../apps/desktop/src/renderer/src/components/calendar/calendar-event-form.tsx).
+  This is the label the user sees.
+- `unlinkProjectItem` is exposed in `generated-rpc.ts` but is called from **nowhere** in
+  the renderer. There is no removal UI anywhere in the app.
+- Neither create path (the quick-create popover from a grid drag, nor the full create
+  popover) offers a project field. A link needs an `eventId`, which does not exist until
+  the event is saved.
+
+So the work is a missing UI, not a missing data model.
+
+## Decisions
+
+1. **Single project per event in the UI.** A single-select dropdown, matching the
+   `project_id` mental model users already have from tasks. The DB stays many-to-many.
+2. **Field appears in both create and edit** of the full event form. The quick-create
+   popover (grid drag → title-only box) stays minimal and is not touched.
+3. **Legacy multi-links are preserved, never silently deleted.** If an event is already
+   linked to more than one project (possible today via the right-click flow), the extra
+   links render as removable chips beside the picker. Nothing disappears without the user
+   removing it.
+4. **Edit-mode changes are written immediately** (not deferred to Save). This matches the
+   existing right-click flow, and keeps `calendar.tsx` almost untouched. The field is
+   styled as a chip/picker row rather than a form input, so it reads as
+   applies-immediately. Accepted trade-off: Cancel does not revert a project change.
+
+## Design
+
+### New component: `event-project-field.tsx`
+
+Location: `apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx`
+
+Props:
+
+```ts
+interface EventProjectFieldProps {
+  mode: 'create' | 'edit'
+  /** Saved event id. Required in edit mode; null while drafting. */
+  eventId?: string | null
+  /** Create mode only: the draft's selected project. */
+  value: string | null
+  /** Create mode only: writes the selection back into the draft. */
+  onChange: (projectId: string | null) => void
+  disabled?: boolean
+}
+```
+
+Project list source: `useTasksOptional()?.projects ?? []`, filtered to `!isArchived`.
+`TasksProvider` wraps the whole app
+([App.tsx:484](../../../apps/desktop/src/renderer/src/App.tsx)), and
+`calendar-task-popover.tsx` already reads projects this way — same pattern, no new fetch
+layer.
+
+Picker: the existing `ProjectPicker`
+([project-picker.tsx](../../../apps/desktop/src/renderer/src/components/tasks/project-picker.tsx))
+with `searchable`, `triggerVariant="button"`, and `includeAllOption` whose label is
+"No project" — selecting it emits `null`, which is the clear action.
+
+Behavior by mode:
+
+- **create** — fully controlled. The selection lives in the draft; no IPC is issued. There
+  is no event row to link to yet.
+- **edit** — self-contained. On mount (and on `eventId` change) it calls
+  `tasksService.listForItem('calendar_event', eventId)`. The first link is the picker's
+  value; any further links render as chips with an `×`.
+  - Picking a project: `unlinkProjectItem(previousPrimary)` if one existed, then
+    `linkProjectItem(next)`. Picking "No project" only unlinks.
+  - Removing an extra chip: `unlinkProjectItem` for that project.
+  - After any write, reload via `listForItem`. Subscribe to `onProjectUpdated` to stay
+    fresh when the project changes elsewhere (same as `ItemProjectChips` does today).
+  - Failures surface through `extractErrorMessage` + a `sonner` toast, matching
+    `AddEventToProjectDialog`.
+
+### Changed: `calendar-event-form.tsx`
+
+Replace the `ItemProjectChips` line at
+[calendar-event-form.tsx:222](../../../apps/desktop/src/renderer/src/components/calendar/calendar-event-form.tsx)
+with `EventProjectField`, and drop the `mode === 'edit' && eventId` guard so the field
+shows in both modes. Position is unchanged: directly under the title input.
+
+`ItemProjectChips` itself is **not** modified — `note.tsx` and `file.tsx` also use it, and
+making it editable is out of scope.
+
+### Changed: `types.ts` (draft)
+
+`CalendarEventDraft` gains `projectId: string | null`. Every draft constructor
+(`createDraftFromItem`, `createDraftFromAnchor`, the record-based edit draft, and
+`CalendarQuickCreateDialog.buildDraft`) initializes it to `null`. In edit mode the field
+ignores the draft value and reads from `project_links`; the draft field only carries the
+create-mode selection.
+
+### Changed: `calendar.tsx`
+
+In `handlePopoverSave`, create branch only
+([calendar.tsx:636](../../../apps/desktop/src/renderer/src/pages/calendar.tsx)):
+after a successful `createEvent`, if `draft.projectId` is set, call
+`tasksService.linkProjectItem({ projectId, itemType: 'calendar_event', itemId: result.event.id })`.
+`createEvent` already returns `{ success, event }` with the new id
+(`CalendarEventMutationResponse` in
+[packages/contracts/src/calendar-api.ts](../../../packages/contracts/src/calendar-api.ts)),
+so no contract change is needed.
+
+A link failure after a successful create must not fail the event creation: log it and show
+a toast, keep the event.
+
+### i18n
+
+New keys under `calendar.form` in
+[packages/i18n/src/locales/en/calendar.json](../../../packages/i18n/src/locales/en/calendar.json):
+
+- `project` — "Project"
+- `no-project` — "No project"
+- `remove-from-project` — "Remove from {project}" (chip `×` aria-label)
+
+English gates `i18n:check`; other locales get the same keys.
+
+## Out of scope
+
+- The quick-create popover (grid drag) stays title-only.
+- Google external events. They have no `calendar_events` row, so there is no stable
+  `item_id` to link. `canAddEventToProject` already restricts to `sourceType === 'event'`.
+- The right-click "Add to project" dialog. It keeps working and does not conflict — the
+  field reloads through `onProjectUpdated`.
+- Making `ItemProjectChips` editable for notes and files.
+
+## Backward compatibility
+
+No schema change, no migration, no contract change. `project_links` already syncs as part
+of the project payload
+([project-handler.ts](../../../apps/desktop/src/main/sync/item-handlers/project-handler.ts)),
+so assignments propagate across devices with no protocol work. Older app versions ignore
+the new links gracefully — they are ordinary `project_links` rows, the same shape the
+right-click flow has been writing all along.
+
+## Testing
+
+Test-first, per task.
+
+`event-project-field.test.tsx`:
+
+- create mode: selecting a project calls `onChange` and issues **no** IPC
+- create mode: "No project" emits `null`
+- edit mode: mounts → calls `listForItem` with `('calendar_event', eventId)`
+- edit mode: switching project → `unlinkProjectItem(old)` then `linkProjectItem(new)`
+- edit mode: "No project" → `unlinkProjectItem` only
+- edit mode: event linked to two projects → picker shows the first, second renders as a
+  removable chip; `×` calls `unlinkProjectItem` for that project only
+- edit mode: a failing link surfaces a toast and leaves prior state intact
+
+`calendar-event-form.test.tsx`: the field renders in both create and edit mode.
+
+`calendar-page.test.tsx` (or a focused test on `handlePopoverSave`): creating with a
+project selected calls `linkProjectItem` with the id returned by `createEvent`; creating
+with no project selected calls nothing; a link failure keeps the created event.
+
+Verification commands:
+
+```
+pnpm --filter @memry/desktop test:renderer
+pnpm typecheck
+pnpm lint
+pnpm --filter @memry/desktop i18n:check
+pnpm docs:impact --base <base_commit> --strict
+```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -234,11 +234,11 @@ export default defineConfig(
     files: ['apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx'],
     rules: {
       // The mount-time load and the `onProjectUpdated` reload both call a
-      // `load()` callback that toggles a `pendingRef` guard closing a
-      // stale-state race on `project_links` writes (see the file's inline
-      // comment). The plugin's ref-tracing through that callback misreads
-      // the ref/prop combination as forwarding a ref to a parent; no ref is
-      // exposed outside this component.
+      // `load()` callback that moves the `pendingLoads` / `isWriting` guards
+      // closing a stale-state race on `project_links` writes (see the file's
+      // inline comment). The plugin's ref-tracing through that callback
+      // misreads the ref/prop combination as forwarding a ref to a parent; no
+      // ref is exposed outside this component.
       'react-you-might-not-need-an-effect/no-pass-ref-to-parent': 'off'
     }
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -255,6 +255,7 @@ export default defineConfig(
       'apps/desktop/src/renderer/src/pages/note.tsx',
       'apps/desktop/src/renderer/src/pages/journal.tsx',
       'apps/desktop/src/renderer/src/pages/folder-view.tsx',
+      'apps/desktop/src/renderer/src/pages/calendar.tsx',
       'apps/desktop/src/renderer/src/pages/inbox/inbox-list-view.tsx',
       'apps/desktop/src/renderer/src/components/folder-view/grouped-table.tsx',
       'apps/desktop/src/renderer/src/components/folder-view/folder-table-view.tsx',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -231,6 +231,18 @@ export default defineConfig(
     }
   },
   {
+    files: ['apps/desktop/src/renderer/src/components/calendar/event-project-field.tsx'],
+    rules: {
+      // The mount-time load and the `onProjectUpdated` reload both call a
+      // `load()` callback that toggles a `pendingRef` guard closing a
+      // stale-state race on `project_links` writes (see the file's inline
+      // comment). The plugin's ref-tracing through that callback misreads
+      // the ref/prop combination as forwarding a ref to a parent; no ref is
+      // exposed outside this component.
+      'react-you-might-not-need-an-effect/no-pass-ref-to-parent': 'off'
+    }
+  },
+  {
     files: ['packages/contracts/src/ipc-channels.ts', 'packages/contracts/src/inbox-api.ts'],
     rules: {
       // TODO(phase-4): drop these overrides once contract modules are split by domain

--- a/packages/i18n/src/locales/en/calendar.json
+++ b/packages/i18n/src/locales/en/calendar.json
@@ -71,7 +71,10 @@
     "use-default-calendar": "Use default calendar",
     "use-default-calendar-with-name": "Use default ({calendar})",
     "use-memry-calendar-default": "Use memrynote calendar (default)",
-    "primary-suffix": "primary"
+    "primary-suffix": "primary",
+    "project": "Project",
+    "no-project": "No project",
+    "remove-from-project": "Remove from {project}"
   },
   "delete-dialog": {
     "title": "Delete event?",

--- a/packages/i18n/src/locales/en/calendar.json
+++ b/packages/i18n/src/locales/en/calendar.json
@@ -74,7 +74,8 @@
     "primary-suffix": "primary",
     "project": "Project",
     "no-project": "No project",
-    "remove-from-project": "Remove from {project}"
+    "remove-from-project": "Remove from {project}",
+    "project-update-failed": "Could not update the event's project"
   },
   "delete-dialog": {
     "title": "Delete event?",

--- a/packages/i18n/src/locales/tr/calendar.json
+++ b/packages/i18n/src/locales/tr/calendar.json
@@ -61,7 +61,11 @@
     "use-default-calendar": "Varsayılan takvimi kullan",
     "use-default-calendar-with-name": "Varsayılanı kullan ({calendar})",
     "use-memry-calendar-default": "memrynote takvimini kullan (varsayılan)",
-    "primary-suffix": "birincil"
+    "primary-suffix": "birincil",
+    "project": "Proje",
+    "no-project": "Proje yok",
+    "remove-from-project": "{project} projesinden çıkar",
+    "project-update-failed": "Etkinliğin projesi güncellenemedi"
   },
   "delete-dialog": {
     "title": "Etkinlik silinsin mi?",


### PR DESCRIPTION
## Problem

Events could only be attached to a project from the project hub's "Add event to project" flow. The event UI then showed the resulting link as a read-only chip — the user could neither change it nor remove it. There was no way to pick a project while creating or editing an event.

## What this does

Adds a Project field to the calendar event form.

- **Create** — the picker is controlled by the form draft and does no IPC. Once the event is saved and the create call returns an id, the chosen project is linked to it. If that link fails the created event still stands and the failure surfaces as a toast.
- **Edit** — the field owns its state, loads the event's existing link itself, and writes the change through immediately on selection (unlink the previous, link the new). Changes are not reverted by Cancel.
- **Legacy multi-link** — `project_links` is many-to-many, so events can carry more than one link from the older flow. Every link the picker cannot represent as the single selection renders as a removable chip, so the UI never hides a link it cannot manage. Removing one chip unlinks exactly that project.

Quick Create stays title-only. Canvas event cards deliberately have no Project row — the canvas editor mounts the form without an `eventId`, so idle cards do not each fire a `listForItem`.

## Not changed

No DB migration, no schema change, no IPC contract change — `project_links` and the `linkProjectItem` / `unlinkProjectItem` / `listForItem` IPC already accepted the `calendar_event` item type. `ItemProjectChips` is untouched, so the note and file pages keep their read-only chips.

## Defects found and fixed during review

- `getProjectsForItem` has no `ORDER BY`, so after a swap on a multi-link event the picker showed a project the user had not picked (their own choice was demoted to a chip). The chosen id is now tracked in the renderer and preferred as the primary while it survives in the link set.
- An event linked to an **archived** project rendered "No project" — `ProjectPicker` filters archived projects internally — and the next selection then silently unlinked it. A link the user never saw and never chose to remove. Unpickable links now render as removable chips, and only the shown primary is ever replaced.
- The in-flight write guard was a single ref shared by the load and write paths. `linkItemToProject` publishes `projectUpdated` before returning, so the resulting reload cleared the guard mid-swap and a click in that window could produce a double link. Load and write flags are now separate, and the write flag is held across its trailing reload.

## Testing

- 24 tests on `EventProjectField`, plus post-create link coverage on the calendar page.
- Every regression test for the three defects above was verified by mutation: break the fix, confirm the test fails, restore, confirm green. Three earlier tests on this branch were caught passing against both correct and broken code and were reworked until they discriminated.
- Full suites green on the merged tree: renderer 5961 passed / 6 skipped (543 files), main 4489 passed / 1 skipped (415 files). `typecheck:web`, `lint`, `i18n:check`, `git diff --check`, `docs:impact --strict`, `docs:build` all clean.

Pre-existing and unrelated (verified at the merge base, files untouched here): the `lookup-utils.test.ts` flake and the `schemas.ts` TS1117 duplicate-key error that fails `typecheck:node`.

## Known limitations

- If `unlink` succeeds and the following `link` fails, a swap degrades to a removal. Inherent to two non-transactional IPC calls under the no-migration constraint; the failure is toasted and the field reloads to true DB state.
- No loading indicator during the initial `listForItem` — the field reads "No project" for a beat.
- `disabled` is not honored in create mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
