### PR TITLE
fix(linking): unblock the vault download step on a new device

### DIFF
--- a/apps/desktop/src/main/sync/linking-service.test.ts
+++ b/apps/desktop/src/main/sync/linking-service.test.ts
@@ -1,3 +1,7 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
 import sodium from 'libsodium-wrappers-sumo'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -778,11 +782,71 @@ describe('linking-service multi-vault choice', () => {
     expect(result).toEqual({ success: true })
     // Non-primary vaults are no longer provisioned eagerly — they appear in the
     // switcher's "In your account" section via the vault directory instead.
-    expect(mockCreateDormantVault).not.toHaveBeenCalled()
+    expect(mockCreateDormantVault).toHaveBeenCalledTimes(1)
+    expect(mockCreateDormantVault).toHaveBeenCalledWith(expect.stringContaining('v-a'), 'v-a')
     expect(mockSelectVault).toHaveBeenCalledWith({ path: expect.stringContaining('v-a') })
     expect(mockSelectVault.mock.invocationCallOrder[0]).toBeLessThan(
       mockPersistKeysAndRegisterDevice.mock.invocationCallOrder[0]
     )
+  })
+
+  it('provisions the primary vault folder on disk before opening it', async () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-vault-choice-'))
+    // Mirror the real selectVault: it validates the directory BEFORE openVault
+    // would initialize it, so an unprovisioned folder fails the whole finalize.
+    mockSelectVault.mockImplementation(async ({ path: vaultPath }: { path: string }) =>
+      fs.existsSync(vaultPath)
+        ? { success: true }
+        : { success: false, error: 'Selected path is not a valid directory' }
+    )
+    // Mirror createDormantVault: initVault() creates the folder on disk.
+    mockCreateDormantVault.mockImplementation((folder: string) =>
+      fs.mkdirSync(folder, { recursive: true })
+    )
+
+    try {
+      await linkViaQr(qrData, 'setup-token')
+      await completeLinkingQr('session-1')
+
+      const result = await finalizeVaultChoice({
+        sessionId: 'session-1',
+        parentFolderPath: parent,
+        selectedVaultUuids: ['v-a', 'v-b'],
+        primaryVaultUuid: 'v-a'
+      })
+
+      expect(result).toEqual({ success: true })
+      expect(fs.existsSync(path.join(parent, 'memry-vault-v-a'))).toBe(true)
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the choice retryable when opening the primary vault fails', async () => {
+    await linkViaQr(qrData, 'setup-token')
+    await completeLinkingQr('session-1')
+
+    mockSelectVault.mockResolvedValueOnce({
+      success: false,
+      error: 'Selected path is not a valid directory'
+    })
+
+    const input = {
+      sessionId: 'session-1',
+      parentFolderPath: '/tmp/parent',
+      selectedVaultUuids: ['v-a', 'v-b'],
+      primaryVaultUuid: 'v-a'
+    }
+
+    expect(await finalizeVaultChoice(input)).toEqual({
+      success: false,
+      error: 'Selected path is not a valid directory'
+    })
+
+    // The master key must survive a failed attempt: the user retries from the
+    // same picker (e.g. after choosing a writable folder) without re-linking.
+    expect(await finalizeVaultChoice(input)).toEqual({ success: true })
+    expect(mockPersistKeysAndRegisterDevice).toHaveBeenCalledTimes(1)
   })
 
   it('rejects a finalize for a session without a pending vault choice', async () => {

--- a/apps/desktop/src/main/sync/linking-service.ts
+++ b/apps/desktop/src/main/sync/linking-service.ts
@@ -568,13 +568,14 @@ export async function finalizeVaultChoice(input: {
     return { success: false, error: 'Primary vault must be among the selected vaults' }
   }
 
-  const { masterKey, setupToken, importedProviderAuth, initialWarning } = pendingVaultChoice
-  // Ownership of masterKey moves to finalizeLinking on the happy path; only the
-  // pre-finalizeLinking catch below cleans it up.
+  const choice = pendingVaultChoice
+  const { masterKey, setupToken, importedProviderAuth, initialWarning } = choice
+  // Consume synchronously so a second click cannot start a concurrent finalize
+  // (which would register the device twice). Provisioning failures put it back.
   pendingVaultChoice = null
 
   try {
-    const { dormantVaultFolderName } = await import('./vault-provisioning')
+    const { createDormantVault, dormantVaultFolderName } = await import('./vault-provisioning')
     const path = await import('path')
     const { selectVault } = await import('../vault')
 
@@ -586,27 +587,40 @@ export async function finalizeVaultChoice(input: {
     // Only the primary vault is provisioned here. The remaining account vaults
     // surface in the switcher's "In your account" section (vault directory)
     // and download on demand.
+    //
+    // The primary folder does not exist yet on a fresh device, and selectVault
+    // validates the directory BEFORE openVault would initialize it — so it must
+    // be created first. Provisioning (rather than a bare mkdir) also adopts the
+    // server vault uuid into data.db before selectVault stamps the vault
+    // registry, which keeps this folder matched to its account vault instead of
+    // a freshly minted local uuid.
+    createDormantVault(primaryFolder, input.primaryVaultUuid)
 
     const selected = await selectVault({ path: primaryFolder })
     if (!selected.success) {
       throw new Error(selected.error ?? 'Failed to open the primary vault')
     }
-
-    await finalizeLinking(
-      masterKey,
-      setupToken,
-      input.primaryVaultUuid,
-      importedProviderAuth,
-      initialWarning
-    )
-    return { success: true }
   } catch (err) {
+    // Recoverable: nothing was registered yet. Restore the choice (master key
+    // included — it is wiped by clearPendingVaultChoice on expiry) so the user
+    // can retry from the picker, e.g. with a different parent folder, instead
+    // of being stranded on a dead button until the whole link is redone.
+    pendingVaultChoice = choice
     log.error('finalizeVaultChoice failed', err)
-    secureCleanup(masterKey)
     const message = err instanceof Error ? err.message : 'Vault selection failed'
-    emitLinkingFinalized({ error: message })
     return { success: false, error: message }
   }
+
+  // Ownership of masterKey moves to finalizeLinking, which reports its own
+  // outcome through the linking-finalized event and never throws.
+  await finalizeLinking(
+    masterKey,
+    setupToken,
+    input.primaryVaultUuid,
+    importedProviderAuth,
+    initialWarning
+  )
+  return { success: true }
 }
 
 // ============================================================================

--- a/apps/desktop/src/renderer/src/components/sync/vault-picker-step.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/vault-picker-step.test.tsx
@@ -62,4 +62,19 @@ describe('VaultPickerStep', () => {
 
     await waitFor(() => expect(onError).toHaveBeenCalledWith('boom'))
   })
+
+  it('shows the finalize failure in the step itself', async () => {
+    window.api.syncLinking.finalizeVaultChoice = vi
+      .fn()
+      .mockResolvedValue({ success: false, error: 'boom' })
+    render(<VaultPickerStep sessionId="sess-1" vaults={vaults} onError={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'setup.linking.vaultPickerChooseFolder' }))
+    await screen.findByRole('button', { name: '/tmp/parent' })
+    fireEvent.click(screen.getByRole('button', { name: 'setup.linking.vaultPickerConfirm' }))
+
+    // The wizard renders `wizardError` only on the sign-in/OTP/recovery steps,
+    // so without this the failure is invisible and the button looks dead.
+    expect(await screen.findByRole('alert')).toHaveTextContent('boom')
+  })
 })

--- a/apps/desktop/src/renderer/src/components/sync/vault-picker-step.tsx
+++ b/apps/desktop/src/renderer/src/components/sync/vault-picker-step.tsx
@@ -33,6 +33,10 @@ export function VaultPickerStep({
     vaults.length > 0 ? [vaults[0].vaultUuid] : []
   )
   const [submitting, setSubmitting] = useState(false)
+  // The wizard only renders `wizardError` on the sign-in/OTP/recovery steps, so
+  // this step keeps its own copy — otherwise a failed pull looks like a dead
+  // button (the error reached onError and was never shown).
+  const [error, setError] = useState<string | null>(null)
 
   const orderedSelection = vaults
     .map((vault) => vault.vaultUuid)
@@ -59,6 +63,7 @@ export function VaultPickerStep({
       .filter((vaultUuid) => selected.includes(vaultUuid))
     if (!folderPath || ordered.length === 0 || submitting) return
     setSubmitting(true)
+    setError(null)
     try {
       const result = await window.api.syncLinking.finalizeVaultChoice({
         sessionId,
@@ -67,12 +72,16 @@ export function VaultPickerStep({
         primaryVaultUuid: ordered[0]
       })
       if (!result.success) {
+        const message = result.error ?? t('setup.linking.deviceFailed')
         setSubmitting(false)
-        onError(result.error ?? t('setup.linking.deviceFailed'))
+        setError(message)
+        onError(message)
       }
     } catch (err) {
+      const message = extractErrorMessage(err, t('setup.linking.deviceFailed'))
       setSubmitting(false)
-      onError(extractErrorMessage(err, t('setup.linking.deviceFailed')))
+      setError(message)
+      onError(message)
     }
   }, [folderPath, selected, vaults, submitting, sessionId, onError, t])
 
@@ -144,6 +153,12 @@ export function VaultPickerStep({
           )
         })}
       </ul>
+
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
 
       <Button
         className="w-full"

--- a/apps/docs/src/user-guide/sync/linking-devices.md
+++ b/apps/docs/src/user-guide/sync/linking-devices.md
@@ -43,6 +43,24 @@ Compare the fingerprint with what the new device shows. If they match, approve. 
 
 If something looks wrong, **deny** and start over.
 
+## Choosing What to Pull
+
+If the account holds **two or more vaults**, the new device asks which ones to pull before it
+finishes linking:
+
+1. Pick a **parent folder** — each vault is created as its own folder inside it
+2. Check the vaults you want on this device
+3. Choose **Pull selected**
+
+The first checked vault is the **primary**: memrynote creates its folder, opens it, and starts
+syncing right away. The rest stay cloud-only and show up under **In your account** in the vault
+switcher, where you can download them on demand.
+
+If the pull fails — an unwritable folder, for example — the reason appears under the list and the
+choice stays available, so you can pick a different folder and try again without redoing the link.
+
+Accounts with a single vault skip this step entirely.
+
 ## Initial Sync Progress
 
 After approval, the new device shows a sync progress screen:


### PR DESCRIPTION
A user signing in on a new machine could never get past the vault download step. Every **Pull selected** click did nothing; the logs showed one `finalizeVaultChoice failed Error: Selected path is not a valid directory` and then silence.

Three defects stacked on top of each other. All three only affect accounts with 2+ vaults, since that is the only path that runs `finalizeVaultChoice`.

## 1. The primary vault folder was never created

`finalizeVaultChoice` built `<parent>/memry-vault-<uuid8>` and handed it straight to `selectVault`. Nothing ever created that folder, and `selectVault` → `validateVaultPath` → `isValidDirectory` runs *before* `openVault` would `initVault` it. On a fresh device the folder never exists, so this failed 100% of the time. Broken since `6e43ad72e` — the old dormant-vault loop skipped the primary too.

Fixed by mirroring the ordering `downloadRemoteVault` already uses in production: `createDormantVault(folder, uuid)` then `selectVault`. A bare `mkdir` is not enough — `selectVault` stamps the vault registry from `getOrCreateVaultUuid`, which would mint a random uuid and leave the folder unmatched to its account vault, so a later Download would create a second empty folder.

## 2. The first failure destroyed the session

`pendingVaultChoice = null` and `secureCleanup(masterKey)` ran *before* the risky work. After the first failure every later click hit the guard above the try/catch, returned `No pending vault choice for this session`, and logged nothing — which is exactly what the reporter saw. The only escape was redoing the whole link, and nothing said so.

The choice is now restored when provisioning fails, and the catch wraps only the pre-`finalizeLinking` region. Consumption stays synchronous, so a second click still cannot start a concurrent finalize and register the device twice.

## 3. The failure was invisible

`VaultPickerStep` reported through `onError` → `setWizardError`, but the wizard renders `wizardError` only on the sign-in, OTP and recovery steps. On the picker the message went nowhere and the button looked dead. It now renders inline, same pattern as `linking-code-entry`.

## Testing

- `linking-service.test.ts`: two new tests, both watched failing first. The existing suite mocked `selectVault` to always succeed, which is why defect 1 was invisible — the new test mimics the real directory validation against a temp dir.
- `vault-picker-step.test.tsx`: new test for the rendered error.
- Desktop `main` + `renderer` + `shared`: 12981 pass, 0 fail.
- `pnpm typecheck` 16/16, eslint clean on both source files, `docs:impact --strict` covered, `docs:build` green.

Not covered by automated tests: the real first-launch link on a second machine. Worth a manual pass before this lands.