### PR TITLE
fix(folder-view): project property is a read-only pill that opens the project

### DIFF
--- a/apps/desktop/src/renderer/src/components/folder-view/property-cell.test.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/property-cell.test.tsx
@@ -15,7 +15,14 @@ import {
 
 const mocks = vi.hoisted(() => ({
   resolveRefs: vi.fn(),
-  openTab: vi.fn()
+  openTab: vi.fn(),
+  projects: [] as Array<{
+    id: string
+    name: string
+    icon: string
+    color: string
+    isArchived: boolean
+  }>
 }))
 
 vi.mock('@/services/properties-service', () => ({
@@ -24,10 +31,16 @@ vi.mock('@/services/properties-service', () => ({
   }
 }))
 
-// RelationCell chips navigate through useRelationNavigation, which reads the
+// RelationCell and ProjectCell chips navigate by opening a tab, which reads the
 // tabs context. There is no TabsProvider in these tests.
 vi.mock('@/contexts/tabs', () => ({
   useTabs: () => ({ openTab: mocks.openTab })
+}))
+
+// ProjectCell resolves names against the live project list from the tasks
+// context. There is no TasksProvider in these tests.
+vi.mock('@/contexts/tasks', () => ({
+  useTasksOptional: () => ({ projects: mocks.projects })
 }))
 
 // Real i18n: tests/setup-dom.ts initializes the global i18next singleton with
@@ -218,19 +231,51 @@ describe('folder-view property cells', () => {
     expect(screen.queryByText('[]')).not.toBeInTheDocument()
   })
 
-  it('commits project edits as an array, not a joined string', () => {
-    // Regression test for the second (edit-mode) switch: without a 'project'
-    // case it fell to the plain TextEditor default, which would commit a
-    // single comma-joined string and silently change the property's stored
-    // type from string[] to string.
+  it('treats a bare project string as one name, not a comma list', () => {
+    // The main process's readProjectNames widens a non-array value to a single
+    // entry. Splitting on commas the way multiselect does would turn a project
+    // genuinely called "Alpha, Beta" into two chips that resolve to nothing.
+    render(<PropertyCell value="Alpha, Beta" type="project" />)
+    expect(screen.getByText('Alpha, Beta')).toBeInTheDocument()
+  })
+
+  it('never opens an editor for project values', () => {
+    // Regression test: project entries are project NAMES. Click-to-edit let a
+    // user type over one, pointing the note at a project that does not exist
+    // and silently dropping the membership. The cell is read-only now, even
+    // when the table passes onSave.
     const onSave = vi.fn()
     render(<EditablePropertyCell value={['Reading']} type="project" onSave={onSave} />)
 
+    fireEvent.click(screen.getByText('Reading'))
+
+    expect(screen.queryByLabelText('text-editor')).not.toBeInTheDocument()
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('opens the project page when a resolved project chip is clicked', () => {
+    mocks.openTab.mockClear()
+    mocks.projects = [
+      { id: 'prj_1', name: 'Reading', icon: 'Folder', color: '#6366f1', isArchived: false }
+    ]
+
+    render(<EditablePropertyCell value={['Reading', 'Ghost']} type="project" onSave={vi.fn()} />)
+
     fireEvent.click(screen.getByRole('button', { name: /Reading/ }))
-    fireEvent.change(screen.getByLabelText('text-editor'), {
-      target: { value: 'Reading, Fitness 2026' }
-    })
-    expect(onSave).toHaveBeenCalledWith(['Reading', 'Fitness 2026'])
+    expect(mocks.openTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'project',
+        entityId: 'prj_1',
+        path: '/project/prj_1',
+        title: 'Reading'
+      })
+    )
+
+    // A name matching no project still renders, but has nothing to open.
+    expect(screen.getByText('Ghost')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Ghost/ })).not.toBeInTheDocument()
+
+    mocks.projects = []
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/folder-view/property-cell.tsx
+++ b/apps/desktop/src/renderer/src/components/folder-view/property-cell.tsx
@@ -43,6 +43,10 @@ import { propertiesService } from '@/services/properties-service'
 import type { RelationKind, ResolvedRelationRef } from '@memry/contracts/properties-api'
 import { useT } from '@memry/i18n/renderer'
 import { useRelationNavigation } from '@/hooks/use-relation-navigation'
+import { useTabs } from '@/contexts/tabs'
+import { useTasksOptional } from '@/contexts/tasks'
+import { ProjectIcon } from '@/components/tasks/project-icon'
+import type { Project } from '@/data/tasks-data'
 import { TagChip } from '@/components/note/tags-row/TagChip'
 import { toTagChip, type TagMeta, type TagMetaMap } from './note-card-pieces'
 
@@ -261,15 +265,13 @@ function PropertyValueDisplay({
     case 'select':
       return <SelectCell value={stringifyUnknown(value)} className={className} />
 
-    case 'multiselect':
-    case 'project': {
-      // `project` values are an array of project names (frontmatter), the same
-      // shape as multiselect. Per-chip project color/icon would need the live
-      // project list threaded down into every row's cell — plain chips here
-      // instead (see property-cell.tsx PropertyType doc / fix report).
+    case 'multiselect': {
       const items = Array.isArray(value) ? value : stringifyUnknown(value).split(',')
       return <MultiSelectCell values={items.map(stringifyUnknown)} className={className} />
     }
+
+    case 'project':
+      return <ProjectCell value={value} className={className} />
 
     case 'url':
       return urlAsLink ? (
@@ -363,13 +365,16 @@ export const EditablePropertyCell = memo(function EditablePropertyCell({
     [onSave, value]
   )
 
-  // Relation values are read-only everywhere in the folder view: this cell
-  // has no picker or remove control, so an edit affordance here would let a
-  // click fall through to the generic text editor below and let a user
-  // overwrite the URI array with a plain comma-joined string. Bypass the
-  // onSave-driven click-to-edit wrapper unconditionally, regardless of
+  // Relation and project values are read-only everywhere in the folder view:
+  // this cell has no picker or remove control, so an edit affordance here
+  // would let a click fall through to the generic text editor below and let a
+  // user overwrite the value with free text. For `project` that is worse than
+  // cosmetic — its entries are project NAMES, so typing over one points the
+  // note at a project that does not exist and silently drops the membership
+  // (renaming a project is the Project page's job, not a table cell's). Bypass
+  // the onSave-driven click-to-edit wrapper unconditionally, regardless of
   // whether the caller passed onSave.
-  if (type === 'relation') {
+  if (type === 'relation' || type === 'project') {
     return (
       <PropertyValueDisplay
         value={value}
@@ -459,7 +464,6 @@ export const EditablePropertyCell = memo(function EditablePropertyCell({
                 <UrlEditor value={textValue} onChange={handleCommit} onBlur={handleStopEditing} />
               )
             case 'multiselect':
-            case 'project':
               return (
                 <TextEditor
                   value={textValue}
@@ -863,6 +867,131 @@ export const RelationCell = memo(function RelationCell({
           >
             {glyph}
             <span className="truncate">{label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+})
+
+// ============================================================================
+// Project cell
+// ============================================================================
+
+const EMPTY_PROJECTS: Project[] = []
+
+/**
+ * The `project` frontmatter value as a clean name list.
+ *
+ * Mirrors the main process's `readProjectNames` widening rather than the
+ * multiselect one: a bare string is ONE name, never a comma-separated list, so
+ * a project actually called "Alpha, Beta" doesn't split into two chips that
+ * resolve to nothing.
+ */
+function toProjectNames(value: unknown): string[] {
+  const list = Array.isArray(value) ? value : value === null || value === undefined ? [] : [value]
+
+  const seen = new Set<string>()
+  const names: string[] = []
+  for (const entry of list) {
+    const name = stringifyUnknown(entry).trim()
+    if (!name) continue
+    const key = name.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    names.push(name)
+  }
+  return names
+}
+
+/**
+ * Read-only project chips for the folder table — one pill per project name in
+ * the note's frontmatter, clicking one opens that project's page the same way
+ * a tag chip opens its tag page.
+ *
+ * Resolution is by name and includes archived projects, matching the note-side
+ * {@link ProjectEditor}: a note already in an archived project keeps its real
+ * color/icon. A name matching no project (a typo, or a project since deleted)
+ * still renders — muted and inert — instead of being silently dropped.
+ */
+export const ProjectCell = memo(function ProjectCell({
+  value,
+  className
+}: {
+  value: unknown
+  className?: string
+}): React.JSX.Element {
+  const { openTab } = useTabs()
+  const projects = useTasksOptional()?.projects ?? EMPTY_PROJECTS
+
+  const names = useMemo(() => toProjectNames(value), [value])
+  const byName = useMemo(
+    () => new Map(projects.map((project) => [project.name.toLowerCase(), project])),
+    [projects]
+  )
+
+  if (names.length === 0) {
+    return <span className={cn('text-muted-foreground/50', className)}>—</span>
+  }
+
+  return (
+    <div className={cn('flex flex-wrap items-center gap-1', className)}>
+      {names.map((name) => {
+        const project = byName.get(name.toLowerCase())
+
+        const chipClass = cn(
+          'inline-flex max-w-full items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs',
+          project ? 'border-border bg-muted/40' : 'border-dashed border-border text-text-tertiary'
+        )
+
+        if (!project) {
+          return (
+            <span key={name} className={chipClass} title={name}>
+              <span className="truncate">{name}</span>
+            </span>
+          )
+        }
+
+        return (
+          <button
+            key={name}
+            type="button"
+            title={name}
+            // The row around this cell has its own click behaviour; opening a
+            // chip must not also select the row.
+            onClick={(event) => {
+              event.stopPropagation()
+              openTab({
+                type: 'project',
+                title: project.name,
+                icon: 'folder',
+                path: `/project/${project.id}`,
+                entityId: project.id,
+                isPinned: false,
+                isModified: false,
+                isPreview: false,
+                isDeleted: false
+              })
+            }}
+            className={cn(
+              chipClass,
+              'transition-opacity duration-150 hover:opacity-80',
+              'focus:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+            )}
+          >
+            <ProjectIcon
+              icon={project.icon}
+              color={project.color}
+              className="size-3 shrink-0"
+              fallback={
+                <span
+                  className="size-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: project.color }}
+                  aria-hidden="true"
+                />
+              }
+            />
+            <span className="truncate">{name}</span>
           </button>
         )
       })}

--- a/apps/docs/src/user-guide/notes/properties-tags.md
+++ b/apps/docs/src/user-guide/notes/properties-tags.md
@@ -134,6 +134,7 @@ A note or journal entry joins a project through its **`project` property**, not 
 
 - **Renaming or deleting a project** rewrites the `project` value in every linked note's frontmatter — a rename updates the name in place, a delete removes it from the list.
 - Dragging a note or journal entry onto a project in the sidebar sets this same property.
+- **In a [folder view](/user-guide/folder-view) column**, each project shows as a pill with the project's color and icon; clicking one opens that project's page, the way clicking a tag opens its tag page. The cell is read-only there — a `project` value is a list of project _names_, so editing it as free text in a table would point the note at a project that doesn't exist. Add, remove, and rename projects from the note's property row or the project itself.
 
 ::: tip First open after upgrading
 Notes that were already linked to a project before this property existed get that link written into their frontmatter once, the first time you open the vault. Those notes are saved in the same pass, so their frontmatter is normalised the way any memrynote save normalises it: tags written inline in the note body are lifted into the `tags:` list, and tag capitalisation follows what memrynote has indexed. Nothing is removed, and the note body is untouched.


### PR DESCRIPTION
## Summary

In a folder view, a note's `project` column shared the `multiselect` path in both directions: plain gray chips on display, and a comma-splitting text editor on click. Its entries are project **names**, so typing over one pointed the note at a project that doesn't exist — the membership was silently dropped and the link broke.

- The cell is now **read-only**, like `relation`: no editor, even when the table passes `onSave`. Renaming a project stays the Project page's job.
- Each name renders as a **pill** carrying the project's real icon and color — the same chip the note-side `ProjectEditor` shows. **Clicking one opens that project's page**, the way a tag chip opens its tag page.
- Names resolve against the live project list from the tasks context, so there's no extra IPC per virtualized row.
- A name matching no project (a typo, or a project deleted on another device before this note synced) still renders — muted and inert — rather than disappearing. Archived projects resolve too, keeping their real appearance.
- Widening now mirrors the main process's `readProjectNames` instead of the multiselect one: a bare string is one name, so a project genuinely called `Alpha, Beta` no longer splits into two dangling chips.

`grouped-table` renders through the same cell, so the grouped table is fixed as well. The note-side property row was already safe (`ProjectEditor` + a rename lock on the reserved `project` key); gallery and list views don't render properties.

Reviewer notes:
- `ProjectCell` calls `useTabs()` unconditionally, matching the existing `RelationCell` (via `useRelationNavigation`) in the same file — both assume the folder view lives inside a `TabProvider`, which it always does in the app.
- The old test *"commits project edits as an array, not a joined string"* is removed: its premise (editing project values as text) is the bug being fixed. Three tests replace it.

## Release note

Projects shown in a folder view column are now pills with the project's color and icon — click one to open its project page. They're no longer editable as free text in the table, which could point a note at a project that didn't exist and silently drop the link.

## Test plan

- `pnpm --filter @memry/desktop test:renderer` — 555 files / 6220 tests passing
- `pnpm --filter @memry/desktop typecheck:web` — clean
- `eslint` on changed files (`--no-cache`) — clean
- `pnpm check:architecture` — passed
- `pnpm docs:impact --base origin/main --strict` — covered
- `pnpm docs:build` — passed
- New tests: bare string reads as one name; no editor opens on click even with `onSave`; clicking a resolved chip opens the project tab while an unresolved name renders inert.

Not yet done: manual walkthrough in the running app.
