### PR TITLE
fix(sync): stop notes:updated from throwing once per pulled note

### DIFF
--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -237,9 +237,11 @@ describe('crdt writeback', () => {
       expect.objectContaining({ id: 'note-1', path: 'notes/Existing.md' }),
       { isNew: false }
     )
+    // The body changed here, so `content` rides along — that is what lets an
+    // open editor pick up a remote edit instead of showing stale text.
     expect(mocks.sent).toContainEqual({
       channel: NotesChannels.events.UPDATED,
-      payload: { id: 'note-1', source: 'sync' }
+      payload: { id: 'note-1', changes: { content: 'updated markdown' }, source: 'sync' }
     })
     expect(getWritebackDebugState('note-1')).toMatchObject({
       pending: false,

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -2,6 +2,7 @@ import * as Y from 'yjs'
 import { createLogger } from '../lib/logger'
 import { getCrdtProvider } from './crdt-provider'
 import { yDocToMarkdown } from './blocknote-converter'
+import { emitNoteUpdated } from './note-events'
 import { readCriticMarkupMarksFromYDoc, serializeCriticMarkup } from '@memry/shared'
 import { utcNow } from '@memry/shared/utc'
 import {
@@ -317,7 +318,14 @@ async function writebackExisting(
   )
   void flushProjectionEvents()
 
-  emitToRenderer(NotesChannels.events.UPDATED, { id: noteId, source: 'sync' })
+  // The body genuinely changed here, so `content` has to ride along: it is what
+  // makes an open editor pick up a remote edit instead of showing stale text
+  // until the tab is reopened.
+  emitNoteUpdated(emitToRenderer, {
+    id: noteId,
+    changes: { content: markdown },
+    source: 'sync'
+  })
   log.debug('Write-back complete', { noteId })
 }
 

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.test.ts
@@ -299,8 +299,12 @@ describe('noteHandler.applyUpsert — path collision', () => {
         propertyDefinitionNames: ['Rating']
       })
     )
+    // `changes` is not decoration: renderer subscribers dereference it without
+    // guarding, so an emit that omits it throws once per pulled note. `content`
+    // must stay out — this branch never rewrites the note body.
     expect(ctx.emit).toHaveBeenCalledWith(NotesChannels.events.UPDATED, {
       id: 'note-1',
+      changes: { title: 'a1', emoji: 'sparkles', tags: ['remote'] },
       source: 'sync'
     })
     expect(ctx.emit).toHaveBeenCalledWith('notes:tags-changed', {})
@@ -442,6 +446,7 @@ describe('noteHandler.applyUpsert — path collision', () => {
     )
     expect(ctx.emit).toHaveBeenCalledWith(NotesChannels.events.UPDATED, {
       id: 'note-1',
+      changes: { title: 'a1', emoji: 'sparkles', tags: ['remote'] },
       source: 'sync'
     })
   })

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.ts
@@ -14,6 +14,7 @@ import type { VectorClock } from '@memry/contracts/sync-api'
 import type { SyncQueueManager } from '../queue'
 import { extractFolderFromPath } from '../note-sync'
 import { markWritebackIgnored } from '../crdt-writeback'
+import { emitNoteUpdated } from '../note-events'
 import { attachmentEvents } from '../attachment-events'
 import { getIndexDatabase } from '../../database/client'
 import {
@@ -237,7 +238,12 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
           syncedAt: now,
           modifiedAt: data.modifiedAt ?? now
         })
-        ctx.emit(NotesChannels.events.UPDATED, { id: itemId, source: 'sync' })
+        // Binary/file branch: only sidecar metadata moved, never file bytes.
+        emitNoteUpdated(ctx.emit, {
+          id: itemId,
+          changes: { title: newTitle, emoji: resolvedEmoji },
+          source: 'sync'
+        })
         return resolution.action === 'merge' ? 'conflict' : 'applied'
       }
 
@@ -452,7 +458,19 @@ class NoteHandler extends BaseItemHandler<NoteSyncPayload> {
         }
       }
 
-      ctx.emit(NotesChannels.events.UPDATED, { id: itemId, source: 'sync' })
+      // This branch rewrites frontmatter, title and path — never the note body.
+      // Body edits arrive separately through the CRDT write-back. Leaving
+      // `content` out is what keeps an open editor from remounting on a pull
+      // that did not touch its text.
+      emitNoteUpdated(ctx.emit, {
+        id: itemId,
+        changes: {
+          title: newTitle,
+          emoji: resolvedEmoji,
+          ...(tagsChanged && remoteTags ? { tags: remoteTags } : {})
+        },
+        source: 'sync'
+      })
       if (tagsChanged) {
         ctx.emit('notes:tags-changed', {})
       }

--- a/apps/desktop/src/main/sync/note-events.ts
+++ b/apps/desktop/src/main/sync/note-events.ts
@@ -1,0 +1,20 @@
+import { NotesChannels } from '@memry/contracts/ipc-channels'
+import type { NoteUpdatedEvent } from '@memry/contracts/notes-api'
+
+/**
+ * Both emit paths in this package are `(channel: string, data: unknown)`, so
+ * the renderer-side contract is invisible to typecheck here. Every
+ * `notes:updated` emit from the sync path goes through this helper instead, so
+ * the payload is checked against `NoteUpdatedEvent` at the call site.
+ *
+ * Why it matters: renderer subscribers dereference `event.changes` without
+ * guarding (`use-notes-query.ts` reads `changes.content` for every note that
+ * is not the open one), so an emit that omits `changes` throws once per pulled
+ * note and the subscriber silently misses the event.
+ */
+export function emitNoteUpdated(
+  emit: (channel: string, data: unknown) => void,
+  event: NoteUpdatedEvent
+): void {
+  emit(NotesChannels.events.UPDATED, event)
+}

--- a/apps/desktop/src/renderer/src/pages/note.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.test.tsx
@@ -937,6 +937,25 @@ describe('NotePage', () => {
     expect(screen.getByTestId('editor-content')).toHaveTextContent('Agent edited body')
   })
 
+  // The CRDT write-back fires 500ms after any Y.Doc change — including local
+  // typing, ahead of the 1000ms save — and it now carries `content`. Remounting
+  // on it would destroy the editor mid-keystroke, and the IPC CRDT provider has
+  // already applied those bytes anyway.
+  it('does not remount the editor for CRDT write-back updates', async () => {
+    renderWithProviders(<NotePage noteId="note-1" />)
+    expect(await screen.findByTestId('editor-content')).toHaveTextContent('Original body')
+
+    act(() => {
+      mocks.updatedHandler?.({
+        id: 'note-1',
+        source: 'sync',
+        changes: { content: 'Write-back body' }
+      })
+    })
+
+    expect(screen.getByTestId('editor-content')).toHaveTextContent('Original body')
+  })
+
   it('blocks mutations after the note is deleted', async () => {
     renderWithProviders(<NotePage noteId="note-1" />)
 

--- a/apps/desktop/src/renderer/src/pages/note.tsx
+++ b/apps/desktop/src/renderer/src/pages/note.tsx
@@ -507,6 +507,13 @@ export function NotePage({ noteId }: NotePageProps) {
 
       if (isSavingRef.current) return
 
+      // `sync` means the CRDT write-back rewrote the file from the Y.Doc. The
+      // IPC CRDT provider has already applied those bytes to this editor, so a
+      // remount here would add nothing — and write-back also fires for local
+      // typing (500ms debounce, ahead of the 1000ms save), where it would blow
+      // away the editor mid-keystroke.
+      if (event.source === 'sync') return
+
       // TanStack Query will handle the cache invalidation and refetch.
       // We just need to update lastSavedContent and force editor remount.
       if (typeof event.changes.content !== 'string') return

--- a/apps/desktop/src/renderer/src/services/notes-service.test.ts
+++ b/apps/desktop/src/renderer/src/services/notes-service.test.ts
@@ -111,7 +111,8 @@ describe('notes-service', () => {
     expect(api.onNoteCreated).toHaveBeenCalledWith(createdHandler)
 
     expect(onNoteUpdated(updatedHandler)).toBe(unsubscribe)
-    expect(api.onNoteUpdated).toHaveBeenCalledWith(updatedHandler)
+    // onNoteUpdated wraps the handler to normalize `changes` — see below.
+    expect(api.onNoteUpdated).toHaveBeenCalledWith(expect.any(Function))
 
     expect(onNoteDeleted(deletedHandler)).toBe(unsubscribe)
     expect(api.onNoteDeleted).toHaveBeenCalledWith(deletedHandler)
@@ -130,6 +131,42 @@ describe('notes-service', () => {
 
     expect(onFolderConfigUpdated(updatedHandler)).toBe(unsubscribe)
     expect(api.onFolderConfigUpdated).toHaveBeenCalledWith(updatedHandler)
+  })
+
+  describe('onNoteUpdated payload normalization', () => {
+    // Regression: the sync path shipped `{ id, source: 'sync' }` with no
+    // `changes` for months. Subscribers read `changes.content` unguarded, so
+    // every pulled note threw inside the preload listener loop and the
+    // subscriber silently missed the event.
+    it('substitutes an empty changes object when the emitter omits it', () => {
+      let emit: ((event: unknown) => void) | undefined
+      api.onNoteUpdated = vi.fn((cb: (event: unknown) => void) => {
+        emit = cb
+        return vi.fn()
+      })
+
+      const handler = vi.fn()
+      onNoteUpdated(handler)
+      emit?.({ id: 'note-1', source: 'sync' })
+
+      expect(handler).toHaveBeenCalledWith({ id: 'note-1', source: 'sync', changes: {} })
+      expect(() => handler.mock.calls[0][0].changes.content).not.toThrow()
+    })
+
+    it('passes a well-formed payload through untouched', () => {
+      let emit: ((event: unknown) => void) | undefined
+      api.onNoteUpdated = vi.fn((cb: (event: unknown) => void) => {
+        emit = cb
+        return vi.fn()
+      })
+
+      const payload = { id: 'note-1', changes: { content: 'hello' }, source: 'sync' }
+      const handler = vi.fn()
+      onNoteUpdated(handler)
+      emit?.(payload)
+
+      expect(handler).toHaveBeenCalledWith(payload)
+    })
   })
 
   describe('position operations', () => {

--- a/apps/desktop/src/renderer/src/services/notes-service.ts
+++ b/apps/desktop/src/renderer/src/services/notes-service.ts
@@ -84,7 +84,13 @@ export function onNoteCreated(callback: (event: NoteCreatedEvent) => void): () =
 }
 
 export function onNoteUpdated(callback: (event: NoteUpdatedEvent) => void): () => void {
-  return window.api.onNoteUpdated(callback)
+  // `changes` is required by the contract but the wire is untyped, and a main
+  // process from an older install can still send a payload without it. Every
+  // subscriber dereferences `changes`, so normalize once here rather than
+  // guarding at each call site — a throwing listener silently drops the event.
+  return window.api.onNoteUpdated((event) => {
+    callback(event.changes ? event : { ...event, changes: {} })
+  })
 }
 
 export function onNoteDeleted(callback: (event: NoteDeletedEvent) => void): () => void {

--- a/apps/docs/src/architecture/sync-handlers.md
+++ b/apps/docs/src/architecture/sync-handlers.md
@@ -75,6 +75,43 @@ The Yjs `meta` title is not a source of truth in the other direction either. It 
 creation and updated only while the note's doc is open in memory, so a note renamed from the sidebar
 never records the new title there. Read it only when nothing else knows the note.
 
+## Renderer Events From the Sync Path
+
+Handlers notify the renderer through `ctx.emit`, typed `(channel: string, data: unknown)`. That
+signature is deliberate — a handler emits on many channels — but it means the renderer-side payload
+contract is invisible to `tsc` here, and the write-back path in `crdt-writeback.ts` has the same
+hole.
+
+Subscribers do not defend themselves. `useNoteLinks` reads `changes.content` for every note that is
+not the open one, so a `notes:updated` emitted without `changes` threw once per note in a pull —
+inside the preload listener loop, where each callback is caught individually. Nothing crashed; the
+subscriber simply never saw the event, and link caches stopped refreshing after a pull.
+
+Emit through a typed helper rather than `ctx.emit` directly when a channel has a declared payload
+type. `note-events.ts` is the pattern:
+
+```ts
+export function emitNoteUpdated(
+  emit: (channel: string, data: unknown) => void,
+  event: NoteUpdatedEvent
+): void {
+  emit(NotesChannels.events.UPDATED, event)
+}
+```
+
+Two rules for the `changes` field itself:
+
+- **Only name fields the branch actually wrote.** The handler's markdown-update path rewrites
+  frontmatter, title and path but never the note body, so it must leave `content` out. Including it
+  would remount an open editor over text that did not change.
+- **`content` implies the body moved.** The CRDT write-back is the one emitter that sets it. Because
+  `scheduleWriteback` also fires for local typing — a 500ms debounce, ahead of the editor's 1000ms
+  save — the note page skips `source: 'sync'` entirely rather than remounting mid-keystroke over
+  bytes the IPC CRDT provider has already applied.
+
+The renderer normalizes a missing `changes` to `{}` in `onNoteUpdated`, so a newer renderer stays
+tolerant of an older main process. That is a compatibility floor, not a licence to omit the field.
+
 ## Adding a New Sync Type
 
 1. Define a Zod schema in `packages/contracts/<domain>-api.ts`.

--- a/packages/contracts/src/notes-api.ts
+++ b/packages/contracts/src/notes-api.ts
@@ -217,21 +217,32 @@ export interface NotesHandlers {
 // Event Payloads
 // ============================================================================
 
+/**
+ * Who produced a note event. `sync` is a remote pull or CRDT write-back
+ * landing on this device — it has always been emitted at runtime, the union
+ * just never admitted it.
+ */
+export type NoteEventSource = 'internal' | 'external' | 'sync'
+
 export interface NoteCreatedEvent {
   note: NoteListItem
-  source: 'internal' | 'external'
+  source: NoteEventSource
 }
 
 export interface NoteUpdatedEvent {
   id: string
+  /**
+   * The fields this event actually changed. Always present — subscribers read
+   * it without guarding, so an emitter that omits it throws in the renderer.
+   */
   changes: Partial<Note>
-  source: 'internal' | 'external'
+  source: NoteEventSource
 }
 
 export interface NoteDeletedEvent {
   id: string
   path: string
-  source: 'internal' | 'external'
+  source: NoteEventSource
 }
 
 export interface NoteRenamedEvent {


### PR DESCRIPTION
## What

- Route the three sync-path `notes:updated` emits through a typed `emitNoteUpdated` helper, so the required `changes` field is checked at the call site — both emit paths are `(channel: string, data: unknown)`, which is why `tsc` never saw the violation.
- Emit real `changes`: title/emoji/tags from the note handler (never `content` — that branch only rewrites frontmatter), `content` from the CRDT write-back.
- Normalize a missing `changes` to `{}` once in `onNoteUpdated`, so a newer renderer tolerates an older main process.
- Skip `source: 'sync'` in the note page: `scheduleWriteback` also fires for local typing, on a 500ms debounce that beats the editor's 1000ms save.

## Why

The emitters shipped `{ id, source: 'sync' }` with no `changes`. Subscribers read `changes.content` unguarded, so every note applied by a pull threw inside the preload listener loop — 226 errors in a single vault open. Nothing crashed (preload catches each callback individually), but the throwing subscriber dropped the event, so link caches stopped refreshing after a pull.

Latent since Feb 2026. It only started firing once this device began pulling note upserts.