### PR TITLE
feat(tabs): Chrome-style tab bar — compress to icon-only, then scroll

### DIFF
--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -3,6 +3,11 @@
 :root {
   --chrome-width: 180px;
   --direction: 1;
+
+  /* Tab strip sizing — tabs share the strip evenly, growing to --tab-w-max and
+     compressing to --tab-w-min (icon-only) before the strip starts scrolling. */
+  --tab-w-min: 52px;
+  --tab-w-max: 240px;
 }
 
 [dir='rtl'] {

--- a/apps/desktop/src/renderer/src/components/cold-major-components.test.tsx
+++ b/apps/desktop/src/renderer/src/components/cold-major-components.test.tsx
@@ -529,7 +529,7 @@ vi.mock('@/lib/render-note-icon', () => ({
 }))
 
 vi.mock('./tabs/sortable-tab', () => ({
-  SortableTab: ({ tab }: any) => <div>tab {tab.title}</div>
+  SortableTab: ({ tab }: any) => <div data-tab-id={tab.id}>tab {tab.title}</div>
 }))
 
 vi.mock('./tabs/pinned-tab', () => ({
@@ -1145,5 +1145,33 @@ describe('cold major renderer components', () => {
     mocks.tabGroup = null
     rerender(<TabBarWithDrag groupId="missing" />)
     expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+  })
+
+  it('scrolls the active tab into view so it never stays past the strip edge', () => {
+    const scrolled: Element[] = []
+    const spy = vi
+      .spyOn(HTMLElement.prototype, 'scrollIntoView')
+      .mockImplementation(function scrollIntoViewStub(this: HTMLElement) {
+        scrolled.push(this)
+      })
+
+    try {
+      mocks.tabGroup = {
+        id: 'group-1',
+        activeTabId: 'tab-1',
+        tabs: [
+          { id: 'tab-1', title: 'First', isPinned: false, type: 'note' },
+          { id: 'tab-2', title: 'Last', isPinned: false, type: 'note' }
+        ]
+      }
+      const { rerender } = render(<TabBarWithDrag groupId="group-1" />)
+      expect(scrolled.at(-1)).toHaveAttribute('data-tab-id', 'tab-1')
+
+      mocks.tabGroup = { ...mocks.tabGroup, activeTabId: 'tab-2' }
+      rerender(<TabBarWithDrag groupId="group-1" />)
+      expect(scrolled.at(-1)).toHaveAttribute('data-tab-id', 'tab-2')
+    } finally {
+      spy.mockRestore()
+    }
   })
 })

--- a/apps/desktop/src/renderer/src/components/tabs/regular-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/regular-tab.tsx
@@ -22,6 +22,26 @@ interface RegularTabProps {
   className?: string
 }
 
+/** Unsaved-changes dot, shown in place of the close button when it is hidden */
+const ModifiedDot = ({
+  label,
+  className
+}: {
+  label: string
+  className?: string
+}): React.JSX.Element => (
+  <div
+    className={cn(
+      'w-1.5 h-1.5 rounded-full',
+      'bg-tint',
+      'transition-transform duration-150',
+      'animate-pulse',
+      className
+    )}
+    aria-label={label}
+  />
+)
+
 /**
  * Regular tab component with full title and controls
  * Memoized to prevent unnecessary re-renders when other tabs change
@@ -74,7 +94,10 @@ const RegularTabComponent = ({
     <div
       className={cn(
         'group relative flex items-center gap-2 h-9 pt-0.5 px-4 cursor-pointer',
-        'min-w-[100px] max-w-[180px]',
+        'w-full min-w-0',
+        // Compression tiers — tighten spacing, then drop the close button, then the title
+        '@max-[124px]:px-2.5 @max-[124px]:gap-1.5',
+        '@max-[76px]:px-0 @max-[76px]:gap-0 @max-[76px]:justify-center',
         'select-none',
         'border-e border-e-border/40',
         'border-b-2',
@@ -92,6 +115,8 @@ const RegularTabComponent = ({
       onMouseLeave={handleMouseLeave}
       role="tab"
       aria-selected={isActive}
+      // Keeps the accessible name when the title is hidden at narrow widths
+      aria-label={tab.title}
       tabIndex={isActive ? 0 : -1}
       data-testid={tab.type === 'home' ? 'nav-home' : undefined}
       data-tab-id={tab.id}
@@ -113,6 +138,7 @@ const RegularTabComponent = ({
       <span
         className={cn(
           'flex-1 truncate text-[13px] tracking-[-0.01em]',
+          '@max-[76px]:hidden',
           'transition-colors duration-150',
           isActive
             ? 'text-foreground font-medium'
@@ -124,35 +150,35 @@ const RegularTabComponent = ({
       </span>
 
       {/* Close / Modified indicator with smooth animations */}
-      <div className="w-4 h-4 flex-shrink-0 flex items-center justify-center">
-        {tab.isModified && !showCloseButton ? (
-          // Modified dot with pulse animation
-          <div
-            className={cn(
-              'w-1.5 h-1.5 rounded-full',
-              'bg-tint',
-              'transition-transform duration-150',
-              'animate-pulse'
+      <div className="w-4 h-4 flex-shrink-0 flex items-center justify-center @max-[76px]:hidden">
+        {showCloseButton ? (
+          <>
+            {/* Close button with refined hover state — makes way for the dot when compressed */}
+            <button
+              type="button"
+              onClick={handleClose}
+              className={cn(
+                'w-5 h-5 -me-0.5 rounded-md flex items-center justify-center',
+                '@max-[124px]:hidden',
+                'hover:bg-surface-active/70',
+                'active:bg-surface-active',
+                'transition-all duration-100',
+                // Smooth fade in/out
+                !isActive && 'opacity-0 group-hover:opacity-100'
+              )}
+              aria-label={`Close ${tab.title}`}
+            >
+              <X className="w-3 h-3 text-text-tertiary hover:text-foreground transition-colors" />
+            </button>
+            {tab.isModified && (
+              <ModifiedDot
+                className="hidden @max-[124px]:block"
+                label={tPhaseF('phaseF.componentsTabsRegularTab.unsavedChanges')}
+              />
             )}
-            aria-label={tPhaseF('phaseF.componentsTabsRegularTab.unsavedChanges')}
-          />
-        ) : showCloseButton ? (
-          // Close button with refined hover state
-          <button
-            type="button"
-            onClick={handleClose}
-            className={cn(
-              'w-5 h-5 -me-0.5 rounded-md flex items-center justify-center',
-              'hover:bg-surface-active/70',
-              'active:bg-surface-active',
-              'transition-all duration-100',
-              // Smooth fade in/out
-              !isActive && 'opacity-0 group-hover:opacity-100'
-            )}
-            aria-label={`Close ${tab.title}`}
-          >
-            <X className="w-3 h-3 text-text-tertiary hover:text-foreground transition-colors" />
-          </button>
+          </>
+        ) : tab.isModified ? (
+          <ModifiedDot label={tPhaseF('phaseF.componentsTabsRegularTab.unsavedChanges')} />
         ) : null}
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/tabs/sortable-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/sortable-tab.tsx
@@ -42,17 +42,26 @@ export const SortableTab = ({ tab, groupId, isActive }: SortableTabProps): React
   }
 
   return (
-    <TabContextMenu tab={tab} groupId={groupId}>
+    <TabContextMenu
+      tab={tab}
+      groupId={groupId}
+      // This wrapper is the tab strip's flex item: it shares the strip evenly with
+      // its siblings, and is the container the tab's compression tiers query against.
+      className={cn(
+        'no-drag @container',
+        'flex-[1_1_var(--tab-w-max)] min-w-[var(--tab-w-min)] max-w-[var(--tab-w-max)]'
+      )}
+    >
       <div
         ref={setNodeRef}
         style={style}
         className={cn(
-          'relative',
+          'relative w-full min-w-0',
           // Smooth opacity transition when dragging
           'transition-opacity duration-150 ease-out',
           // Enhanced drop indicator with glow effect
           isOver && [
-            'before:absolute before:-left-0.5 before:top-2 before:bottom-2',
+            'before:absolute before:-start-0.5 before:top-2 before:bottom-2',
             'before:w-0.5 before:bg-sidebar-terracotta before:rounded-full'
           ]
         )}

--- a/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
@@ -33,6 +33,12 @@ interface TabBarWithDragProps {
   className?: string
 }
 
+/** Vertical wheel scrolls the strip horizontally, like Chrome */
+const handleWheel = (e: React.WheelEvent<HTMLDivElement>): void => {
+  if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return
+  e.currentTarget.scrollLeft += e.deltaY
+}
+
 /**
  * Tab bar with drag-to-reorder support and context menu
  * DndContext is provided by SplitViewContainer for cross-panel support
@@ -126,12 +132,6 @@ export const TabBarWithDrag = ({
 
   const scrollToStart = (): void => scrollByLogical(-200)
   const scrollToEnd = (): void => scrollByLogical(200)
-
-  // Vertical wheel scrolls the strip horizontally, like Chrome
-  const handleWheel = (e: React.WheelEvent<HTMLDivElement>): void => {
-    if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return
-    e.currentTarget.scrollLeft += e.deltaY
-  }
 
   return (
     <TabBarContextMenu groupId={groupId}>

--- a/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-bar-with-drag.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useRef, useState, useLayoutEffect, useCallback } from 'react'
+import { useDndContext } from '@dnd-kit/core'
 import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortable'
 import { ChevronLeft, ChevronRight, LayoutAlignRightIcon } from '@/lib/icons'
 import { useDayPanel } from '@/contexts/day-panel-context'
@@ -57,21 +58,28 @@ export const TabBarWithDrag = ({
   // Only the top-right tab bar shows the day-panel toggle (and reserves room for it)
   const showDayPanelToggleButton = !isDayPanelOpen && showDayPanelToggle
 
-  // Scroll state
+  // Scroll state — "start"/"end" are logical, so the math holds in RTL where
+  // scrollLeft counts down from 0
   const scrollRef = useRef<HTMLDivElement>(null)
-  const [canScrollLeft, setCanScrollLeft] = useState(false)
-  const [canScrollRight, setCanScrollRight] = useState(false)
+  const [canScrollToStart, setCanScrollToStart] = useState(false)
+  const [canScrollToEnd, setCanScrollToEnd] = useState(false)
+  const isOverflowing = canScrollToStart || canScrollToEnd
+
+  // A tab being dragged owns the scroll position — dnd-kit runs its own autoscroll
+  const { active: activeDragItem } = useDndContext()
 
   // Check scroll state - must be before early return (rules of hooks)
   const checkScroll = useCallback(() => {
     if (!scrollRef.current) return
     const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current
-    setCanScrollLeft(scrollLeft > 0)
-    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1)
+    const offset = Math.abs(scrollLeft)
+    setCanScrollToStart(offset > 1)
+    setCanScrollToEnd(offset + clientWidth < scrollWidth - 1)
   }, [])
 
   // Compute tabs length safely before early return for useEffect dependency
   const regularTabsLength = group?.tabs.filter((t) => !t.isPinned).length ?? 0
+  const activeTabId = group?.activeTabId ?? null
 
   // Set up scroll listener - must be before early return (rules of hooks)
   useLayoutEffect(() => {
@@ -90,6 +98,17 @@ export const TabBarWithDrag = ({
     }
   }, [checkScroll, regularTabsLength])
 
+  // Keep the active tab visible — without this the strip stays pinned at the start
+  // and a newly opened (or newly activated) tab sits past the end edge.
+  // Re-runs on the chevron gutters too: they widen the scroll content one render
+  // after the scroll fires, which would push the tab back out of view.
+  useLayoutEffect(() => {
+    if (!activeTabId || activeDragItem) return
+    const tabEl = scrollRef.current?.querySelector(`[data-tab-id="${CSS.escape(activeTabId)}"]`)
+    // scrollIntoView is not implemented in jsdom
+    tabEl?.scrollIntoView?.({ inline: 'nearest', block: 'nearest', behavior: 'smooth' })
+  }, [activeTabId, regularTabsLength, activeDragItem, canScrollToStart, canScrollToEnd])
+
   // If group doesn't exist, don't render (after all hooks)
   if (!group) return null
 
@@ -97,13 +116,21 @@ export const TabBarWithDrag = ({
   const pinnedTabs = group.tabs.filter((t) => t.isPinned)
   const regularTabs = group.tabs.filter((t) => !t.isPinned)
 
-  // Scroll handlers
-  const scrollLeft = (): void => {
-    scrollRef.current?.scrollBy({ left: -200, behavior: 'smooth' })
+  // Scroll handlers — scrollLeft runs negative in RTL, so flip the delta with the direction
+  const scrollByLogical = (distance: number): void => {
+    const el = scrollRef.current
+    if (!el) return
+    const sign = getComputedStyle(el).direction === 'rtl' ? -1 : 1
+    el.scrollBy({ left: distance * sign, behavior: 'smooth' })
   }
 
-  const scrollRight = (): void => {
-    scrollRef.current?.scrollBy({ left: 200, behavior: 'smooth' })
+  const scrollToStart = (): void => scrollByLogical(-200)
+  const scrollToEnd = (): void => scrollByLogical(200)
+
+  // Vertical wheel scrolls the strip horizontally, like Chrome
+  const handleWheel = (e: React.WheelEvent<HTMLDivElement>): void => {
+    if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return
+    e.currentTarget.scrollLeft += e.deltaY
   }
 
   return (
@@ -142,11 +169,11 @@ export const TabBarWithDrag = ({
           </>
         )}
 
-        {/* Scroll left button */}
-        {canScrollLeft && (
+        {/* Scroll to start button */}
+        {canScrollToStart && (
           <button
             type="button"
-            onClick={scrollLeft}
+            onClick={scrollToStart}
             className={cn(
               'no-drag',
               'flex items-center justify-center w-7 h-[calc(100%-4px)]',
@@ -157,63 +184,75 @@ export const TabBarWithDrag = ({
             )}
             aria-label={tPhaseF('phaseF.componentsTabsTabBarWithDrag.scrollTabsLeft')}
           >
-            <ChevronLeft className="w-3.5 h-3.5 text-text-tertiary hover:text-foreground transition-colors" />
+            <ChevronLeft className="w-3.5 h-3.5 text-text-tertiary hover:text-foreground transition-colors rtl:rotate-180" />
           </button>
         )}
 
-        {/* Regular tabs section (sortable) */}
+        {/* Regular tabs section (sortable) — tabs are direct flex children so they
+            share the strip evenly and overflow it once they hit their min width */}
         <div
           ref={scrollRef}
+          onWheel={handleWheel}
+          data-testid="tab-strip"
           className={cn(
-            'flex-1 flex items-end overflow-x-auto',
+            'flex-1 flex items-end gap-0.5 px-1 pb-0 overflow-x-auto',
             'scroll-smooth',
             'scrollbar-none [&::-webkit-scrollbar]:hidden',
             '[-ms-overflow-style:none] [scrollbar-width:none]',
-            canScrollLeft && 'ps-7',
-            canScrollRight && 'pe-7'
+            canScrollToStart && 'ps-7',
+            canScrollToEnd && 'pe-7'
           )}
         >
           <SortableContext
             items={regularTabs.map((t) => t.id)}
             strategy={horizontalListSortingStrategy}
           >
-            <div className="no-drag flex items-end gap-0.5 px-1 pb-0">
-              {regularTabs.map((tab) => (
-                <SortableTab
-                  key={tab.id}
-                  tab={tab}
-                  groupId={groupId}
-                  isActive={tab.id === group.activeTabId}
-                />
-              ))}
-            </div>
+            {regularTabs.map((tab) => (
+              <SortableTab
+                key={tab.id}
+                tab={tab}
+                groupId={groupId}
+                isActive={tab.id === group.activeTabId}
+              />
+            ))}
           </SortableContext>
 
-          {/* New tab — inline after last tab, Chrome-style */}
-          <div className="no-drag flex items-center shrink-0 px-1 self-center">
-            <NewTabMenu groupId={groupId} />
-          </div>
+          {/* New tab — inline after last tab, Chrome-style. Once the strip overflows
+              it is pinned outside the scroller instead, so it stays reachable. */}
+          {!isOverflowing && (
+            <div className="no-drag flex items-center shrink-0 px-1 self-center">
+              <NewTabMenu groupId={groupId} />
+            </div>
+          )}
         </div>
 
-        {/* Scroll right button */}
-        {canScrollRight && (
+        {/* Scroll to end button */}
+        {canScrollToEnd && (
           <button
             type="button"
-            onClick={scrollRight}
+            onClick={scrollToEnd}
             className={cn(
               'no-drag',
               'flex items-center justify-center w-7 h-[calc(100%-4px)]',
               'bg-gradient-to-l from-muted/95 via-muted/70 to-transparent',
               'hover:from-surface-active/95',
               'transition-all duration-150 ease-out z-20',
+              // Clears the pinned new-tab button (36px), plus the day-panel toggle (48px)
               showDayPanelToggleButton
-                ? 'absolute end-[48px] bottom-px'
-                : 'absolute end-0 bottom-px'
+                ? 'absolute end-[84px] bottom-px'
+                : 'absolute end-[36px] bottom-px'
             )}
             aria-label={tPhaseF('phaseF.componentsTabsTabBarWithDrag.scrollTabsRight')}
           >
-            <ChevronRight className="w-3.5 h-3.5 text-text-tertiary hover:text-foreground transition-colors" />
+            <ChevronRight className="w-3.5 h-3.5 text-text-tertiary hover:text-foreground transition-colors rtl:rotate-180" />
           </button>
+        )}
+
+        {/* New tab — pinned past the scroller while the strip overflows */}
+        {isOverflowing && (
+          <div className="no-drag flex items-center shrink-0 px-1 self-center">
+            <NewTabMenu groupId={groupId} />
+          </div>
         )}
 
         {/* Tab actions */}

--- a/apps/desktop/src/renderer/src/components/tabs/tab-context-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-context-menu.tsx
@@ -15,15 +15,18 @@ interface TabContextMenuProps {
   groupId: string
   /** Children to wrap */
   children: React.ReactNode
+  /** Additional CSS classes for the wrapper element */
+  className?: string
 }
 
 /**
- * Context menu wrapper that shows a native OS context menu on right-click
+ * Context menu wrapper that shows a native OS context menu on secondary click
  */
 export const TabContextMenu = ({
   tab,
   groupId,
-  children
+  children,
+  className
 }: TabContextMenuProps): React.JSX.Element => {
   const { closeTab, closeOtherTabs, closeTabsToRight, closeAllTabs, dispatch, state } = useTabs()
   const { t } = useT('common')
@@ -121,7 +124,11 @@ export const TabContextMenu = ({
     ]
   )
 
-  return <div onContextMenu={(...args) => void handleContextMenu(...args)}>{children}</div>
+  return (
+    <div className={className} onContextMenu={(...args) => void handleContextMenu(...args)}>
+      {children}
+    </div>
+  )
 }
 
 export default TabContextMenu

--- a/apps/desktop/src/renderer/src/components/tabs/tab-drag-overlay.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-drag-overlay.tsx
@@ -21,7 +21,7 @@ export const TabDragOverlay = ({ tab }: TabDragOverlayProps): React.JSX.Element 
     <div
       className={cn(
         'flex items-center gap-2 h-9 px-4',
-        'min-w-[100px] max-w-[180px]',
+        'min-w-[var(--tab-w-min)] max-w-[var(--tab-w-max)]',
         'select-none pointer-events-none',
         'rounded',
         'bg-sidebar-terracotta/[0.07]',

--- a/apps/desktop/src/renderer/src/components/tabs/tab-hover-preview.tsx
+++ b/apps/desktop/src/renderer/src/components/tabs/tab-hover-preview.tsx
@@ -23,7 +23,9 @@ export function TabHoverPreview({ tab, children }: TabHoverPreviewProps) {
   return (
     <HoverCard openDelay={OPEN_DELAY} closeDelay={CLOSE_DELAY}>
       <HoverCardTrigger asChild>
-        <div data-tab-hover-trigger="">{children}</div>
+        <div className="w-full min-w-0" data-tab-hover-trigger="">
+          {children}
+        </div>
       </HoverCardTrigger>
       <HoverCardContent
         side="bottom"

--- a/apps/desktop/tests/e2e/tabs.e2e.ts
+++ b/apps/desktop/tests/e2e/tabs.e2e.ts
@@ -99,6 +99,39 @@ test.describe('Tab System', () => {
       await expect(activeTab).toBeVisible()
     })
 
+    test('should keep the active tab visible once the strip overflows', async ({ page }) => {
+      const tabBar = page.locator(SELECTORS.tabBar).first()
+      await expect(tabBar).toBeVisible()
+
+      const strip = page.locator('[data-testid="tab-strip"]').first()
+      const isOverflowing = () =>
+        strip.evaluate((el) => el.scrollWidth > el.clientWidth + 1).catch(() => false)
+
+      // Open tabs until they are compressed to their minimum width and the strip overflows
+      for (let i = 0; i < 40 && !(await isOverflowing()); i++) {
+        await page.keyboard.press(SHORTCUTS.newNote)
+        await page.waitForTimeout(200)
+      }
+      await page.waitForTimeout(600)
+
+      if (!(await isOverflowing())) {
+        test.skip(true, `Strip never overflowed (${await getTabCount(page)} tabs)`)
+      }
+
+      const scrollLeft = await strip.evaluate((el) => Math.abs(el.scrollLeft))
+      expect(scrollLeft).toBeGreaterThan(0)
+
+      // The newly activated tab must sit inside the visible strip, not past its end
+      const barBox = await tabBar.boundingBox()
+      const activeBox = await tabBar
+        .locator('[role="tab"][aria-selected="true"]')
+        .first()
+        .boundingBox()
+      expect(activeBox).not.toBeNull()
+      expect(activeBox.x).toBeGreaterThanOrEqual(barBox.x - 1)
+      expect(activeBox.x + activeBox.width).toBeLessThanOrEqual(barBox.x + barBox.width + 1)
+    })
+
     test('should render sidebar trigger inside tab bar', async ({ page }) => {
       const tabBar = page.locator(SELECTORS.tabBar).first()
       await expect(tabBar).toBeVisible()

--- a/apps/docs/src/user-guide/tabs-split-view.md
+++ b/apps/docs/src/user-guide/tabs-split-view.md
@@ -12,6 +12,8 @@ Every note, view, search, project, journal entry, or settings panel opens in a t
 
 Across the top of the app. Drag to reorder. Drag onto a pane edge to split.
 
+Tabs share the width of the bar evenly. Widen the window and they grow, up to a comfortable maximum; open more tabs, or narrow the window, and they compress — first the close button tucks away, then the title, leaving just the icon. Once tabs reach that icon-only minimum the bar scrolls sideways instead of shrinking further: scroll over it with a trackpad or mouse wheel, or use the chevrons that appear at either end. The active tab is always scrolled into view, so opening a new tab never leaves it hidden off the end. The **+** button stays pinned at the end of the bar while it scrolls.
+
 ### Tab Context Menu
 
 Right-click any tab:
@@ -100,7 +102,7 @@ If **Restore Session** is on, the entire tab and split layout restores on app la
 
 ## Modified Indicator
 
-A small dot appears on a tab title when there are unsaved changes (rare — memrynote auto-saves). Closing a modified tab triggers a flush before close.
+A small dot appears on a tab title when there are unsaved changes (rare — memrynote auto-saves). On a compressed tab the dot takes the close button's place, so unsaved work stays visible. Closing a modified tab triggers a flush before close.
 
 ## Canvases in Tabs
 


### PR DESCRIPTION
## What

- Tabs share the strip evenly: they grow to 240px and compress to a 52px icon-only floor (close button hides first, then the title), after which the strip scrolls horizontally.
- The active tab is now scrolled into view — previously a newly opened or activated tab sat past the end edge while the strip stayed pinned at the start.
- The `+` button pins outside the scroller once the strip overflows; vertical wheel scrolls the strip; RTL scroll math and chevron direction fixed.

## Why

With many tabs open the rightmost tab was invisible and unreachable without manual scrolling.