### PR TITLE
feat(landing): submit to IndexNow on every production deploy

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -50,3 +50,58 @@ jobs:
           echo "Deployed: $(cat deployment-url.txt)" >> "$GITHUB_STEP_SUMMARY"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      # Push-notifies Bing, Yandex, Seznam, Naver and Yep that the site changed.
+      # Google does not participate in IndexNow and is not reachable this way.
+      #
+      # Must run after the deploy: IndexNow verifies a batch by fetching the key
+      # file from the live host, so pinging a not-yet-published key returns 403.
+      #
+      # continue-on-error because indexing is a nice-to-have — a flaky endpoint
+      # must never turn a successful production deploy red.
+      - name: Ping IndexNow
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+
+          key=$(sed -n "s/^export const INDEXNOW_KEY = '\([a-zA-Z0-9-]\{8,128\}\)'$/\1/p" \
+            apps/landing/src/lib/indexnow.ts)
+          if [ -z "$key" ]; then
+            echo "Could not read INDEXNOW_KEY from apps/landing/src/lib/indexnow.ts"
+            exit 1
+          fi
+
+          # Confirm the deploy that just went out is actually serving the key file,
+          # otherwise the submission is guaranteed to bounce.
+          if [ "$(curl -fsS "https://memrynote.com/$key.txt" || true)" != "$key" ]; then
+            echo "Key file is not live at /$key.txt yet — skipping submission."
+            exit 1
+          fi
+
+          # The live sitemap is the source of truth for what is indexable, so the
+          # batch cannot drift from it the way a second hardcoded list would.
+          urls=$(curl -fsS https://memrynote.com/sitemap.xml \
+            | grep -oE '<loc>[^<]+</loc>' \
+            | sed -E 's#</?loc>##g' \
+            | jq -R . | jq -sc .)
+          count=$(printf '%s' "$urls" | jq 'length')
+          if [ "$count" -eq 0 ]; then
+            echo "Sitemap returned no URLs — skipping submission."
+            exit 1
+          fi
+
+          status=$(jq -nc --arg key "$key" --argjson urlList "$urls" \
+            '{host: "memrynote.com", key: $key,
+              keyLocation: "https://memrynote.com/\($key).txt", urlList: $urlList}' \
+            | curl -sS -o /dev/stderr -w '%{http_code}' \
+                -X POST https://api.indexnow.org/indexnow \
+                -H 'Content-Type: application/json; charset=utf-8' \
+                --data-binary @-)
+
+          echo "IndexNow: $count URL(s) submitted, HTTP $status" >> "$GITHUB_STEP_SUMMARY"
+
+          # 200 accepted, 202 accepted pending key validation.
+          case "$status" in
+            200|202) ;;
+            *) echo "IndexNow rejected the batch (HTTP $status)"; exit 1 ;;
+          esac

--- a/apps/landing/src/lib/crawl-files.test.ts
+++ b/apps/landing/src/lib/crawl-files.test.ts
@@ -25,6 +25,10 @@ describe('landing crawl files', () => {
     assert.doesNotMatch(sitemap, /memrynote\.ai/)
   })
 
+  it('omits lastmod rather than stamping every URL with the build date', () => {
+    assert.doesNotMatch(buildSitemapXml(), /<lastmod>/)
+  })
+
   it('builds robots.txt pointing crawlers at the sitemap', () => {
     assert.equal(buildRobotsTxt(), `User-agent: *\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml\n`)
   })

--- a/apps/landing/src/lib/crawl-files.ts
+++ b/apps/landing/src/lib/crawl-files.ts
@@ -18,15 +18,14 @@ export function getIndexablePaths(): string[] {
   return Object.values(PAGE_META).map((meta) => meta.path)
 }
 
-export function buildSitemapXml(
-  paths: readonly string[] = getIndexablePaths(),
-  lastmod: string = new Date().toISOString().slice(0, 10)
-): string {
+// No <lastmod>. It used to be the build date, stamped identically onto every URL,
+// which told Google that all 36 pages changed on every deploy. Search engines drop
+// lastmod once they catch it being unreliable, so an omitted date and a distrusted
+// one are worth the same — minus the false signal. Reinstate it only with real
+// per-page change dates.
+export function buildSitemapXml(paths: readonly string[] = getIndexablePaths()): string {
   const urls = paths
-    .map(
-      (path) =>
-        `  <url>\n    <loc>${escapeXml(toAbsoluteUrl(path))}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>`
-    )
+    .map((path) => `  <url>\n    <loc>${escapeXml(toAbsoluteUrl(path))}</loc>\n  </url>`)
     .join('\n')
 
   return [


### PR DESCRIPTION
## Summary

Stacked on #950 — review that one first. Base retargets to `main` once it merges.

#950 added the key file and a manual ping command. This makes it automatic: every production deploy announces the site to Bing, Yandex, Seznam, Naver and Yep without anyone remembering a command.

- `deploy-landing.yml` — new `Ping IndexNow` step after the Vercel deploy.
- `crawl-files.ts` — `<lastmod>` removed from the sitemap.

### Why the step is shaped this way

- **Runs after the deploy, not before.** IndexNow verifies a batch by fetching the key file from the live host; pinging a key that is not published yet returns `403`. The step additionally re-fetches `/<key>.txt` and skips if the deploy has not propagated, so a half-live deploy fails loudly instead of silently submitting garbage.
- **URL list comes from the live `sitemap.xml`, not a second list in the workflow.** The sitemap is already the source of truth for what is indexable, so the batch cannot drift from it.
- **`continue-on-error: true`.** Indexing is a nice-to-have; a flaky endpoint must never turn a green production deploy red.
- The key is read out of `indexnow.ts` with an anchored `sed`, so there is no second copy of it to fall out of sync. Empty match fails the step rather than posting a malformed payload.
- No `pnpm install` in this workflow, so the step uses `curl` + `jq` (both preinstalled on `ubuntu-latest`) instead of the TS script.

### Why `<lastmod>` is gone rather than fixed

It was the build date written onto **every** URL, so changing one page announced that all 36 had changed. Search engines drop lastmod once they catch it being unreliable — which makes a distrusted date worth the same as an omitted one, minus the false signal. Removing it costs nothing in ranking or crawl speed and removes a lie.

Real per-page dates would need a route-to-source map plus git history at build time, and Vercel builds without `.git` (the CLI does not upload it), so it would also need a manifest generated in CI. That machinery is not worth a hint Google may or may not honour. Happy to do it as a follow-up if we later want it.

### Scope note for reviewers

**This does nothing for Google**, which has never adopted IndexNow. Google's Indexing API is limited to `JobPosting` / `BroadcastEvent` pages, and Search Console's "Request indexing" is manual and quota-limited. Google stays sitemap + crawl; the realistic outcome is Bing-family within hours, Google within days.

## Release note

none

## Test plan

- `pnpm --filter @memry/landing test` → 60/60 pass, 0 fail (new test asserts the sitemap emits no `<lastmod>`)
- `pnpm --filter @memry/landing build` → typecheck clean; `grep -c lastmod dist/sitemap.xml` → `0`; `<loc>` entries unchanged at 36
- Workflow YAML parsed and asserted: steps are `Checkout | Setup Node.js | Deploy to production | Ping IndexNow`, with `continue-on-error: true`
- Ran the step's shell pipeline locally against a built `sitemap.xml`: key extraction returned the 32-char key, parsing yielded 36 URLs, and `jq` produced the expected payload (`host`, `key`, `keyLocation`, 36-entry `urlList`, first `https://memrynote.com/`, last `https://memrynote.com/heptabase-alternative`). The parser ignores `<lastmod>` lines, verified against the pre-change sitemap.
- `pnpm --filter @memry/landing lint` → 0 errors; the single warning is pre-existing in `auth-context.tsx`
- Not exercised: the live POST and the step running in Actions, both of which need this merged and deployed.