### PR TITLE
Sync: backfill coverage and close the data-loss and privacy defects it exposed

### DIFF
--- a/apps/desktop/src/main/database/drizzle-data/0046_tag_definition_color_authored.sql
+++ b/apps/desktop/src/main/database/drizzle-data/0046_tag_definition_color_authored.sql
@@ -1,0 +1,17 @@
+-- Did a human pick this tag's colour, or did the palette hand one out?
+--
+-- `getOrCreateTag` colours every tag it mints with `palette[localTagCount % 24]`,
+-- so the same tag name is green on the device where it happened to be the 12th
+-- tag and red where it was the 23rd. That colour then rode the normal sync path
+-- as if the user had chosen it and repainted colours users actually did choose
+-- (report 2026-07-21: "one of my primary tags is green and after updating some
+-- notes I noticed it's now red").
+--
+-- Additive, and existing rows default to 0. Rows written before this column
+-- existed carry auto-minted and hand-picked colours that are indistinguishable,
+-- so we cannot claim a human chose them. 0 is the safe reading: an unauthored
+-- colour is still stored, still displayed, and still travels to devices that do
+-- not have the tag yet — it just may not repaint a colour already sitting on
+-- another device. Choosing the colour once marks it authored and makes it
+-- authoritative everywhere again.
+ALTER TABLE `tag_definitions` ADD `color_authored` integer DEFAULT 0 NOT NULL;

--- a/apps/desktop/src/main/database/drizzle-data/meta/_journal.json
+++ b/apps/desktop/src/main/database/drizzle-data/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1785585341000,
       "tag": "0045_canvas_files",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "6",
+      "when": 1785585342000,
+      "tag": "0046_tag_definition_color_authored",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/src/main/database/queries/tag-definitions.ts
+++ b/apps/desktop/src/main/database/queries/tag-definitions.ts
@@ -61,10 +61,15 @@ export function getOrCreateTag(
     }
   }
 
+  // Indexing by local tag count means the same tag name gets a different colour
+  // on every device (green as the 12th tag, red as the 23rd). That is fine as a
+  // local starting point but it is nobody's choice, so it is minted unauthored:
+  // it may never repaint the same tag on another device. See
+  // tag-definition-handler.ts.
   const tagCount = db.select({ count: count() }).from(tagDefinitions).get()?.count ?? 0
   const color = TAG_COLOR_PALETTE[tagCount % TAG_COLOR_PALETTE.length]
 
-  db.insert(tagDefinitions).values({ name: normalizedName, color }).run()
+  db.insert(tagDefinitions).values({ name: normalizedName, color, colorAuthored: false }).run()
 
   return { name: normalizedName, color, icon: null, categoryId: null, sortOrder: 0 }
 }
@@ -95,9 +100,17 @@ export function setTagCategory(db: DataDb, name: string, categoryId: string | nu
     .run()
 }
 
+/**
+ * The only path by which a human picks a tag colour (tags:update-color, which the
+ * colour picker and the create-tag dialog both use), so this is where the colour
+ * becomes authored and starts outranking auto-minted colours on other devices.
+ */
 export function updateTagColor(db: DataDb, name: string, color: string): void {
   const normalizedName = name.toLowerCase().trim()
-  db.update(tagDefinitions).set({ color }).where(eq(tagDefinitions.name, normalizedName)).run()
+  db.update(tagDefinitions)
+    .set({ color, colorAuthored: true })
+    .where(eq(tagDefinitions.name, normalizedName))
+    .run()
 }
 
 export function updateTagIcon(db: DataDb, name: string, icon: string | null): void {

--- a/apps/desktop/src/main/ipc/agent-handlers.ts
+++ b/apps/desktop/src/main/ipc/agent-handlers.ts
@@ -32,6 +32,7 @@ import type { ConversationStore } from '../agent/storage/conversation-store'
 import type { MessageStore } from '../agent/storage/message-store'
 import type { Conversation, Message } from '../agent/storage/types'
 import { broadcastAgentEvent } from '../agent/runtime/event-bus'
+import { broadcastToAllWindows } from '../lib/window-broadcast'
 import { createLogger } from '../lib/logger'
 import { getMainI18n } from '../lib/main-i18n'
 
@@ -110,12 +111,18 @@ export function registerAgentHandlers(deps: AgentHandlerDeps): void {
       backend?: string
       backendModel?: string | null
     }
-    return deps.conversations.create({
+    const conversation = deps.conversations.create({
       vaultId,
       title: 'New conversation',
       backend: AgentBackendIdSchema.parse(backend),
       backendModel
     })
+    // The creating window learns about the row from this invoke's return value;
+    // every OTHER window learned nothing at all, because `agent:event` only
+    // carries the turn lifecycle. Their conversation list stayed stale until the
+    // app restarted.
+    broadcastConversationsChanged(conversation.id)
+    return conversation
   })
 
   ipcMain.handle(AgentChannels.invoke.LOAD_CONVERSATION, async (_event, payload: unknown) => {
@@ -259,6 +266,10 @@ export function registerAgentHandlers(deps: AgentHandlerDeps): void {
     for (const toolName of remove ?? []) {
       deps.conversations.removeFromTrustList(conversationId, toolName)
     }
+    // Same stale-list problem as create: this rewrites the conversation row
+    // (trust list, clocks, updatedAt — which is the list's sort key) and told
+    // nobody but the calling window.
+    broadcastConversationsChanged(conversationId)
     return deps.conversations.getById(conversationId)
   })
 
@@ -400,6 +411,28 @@ function broadcastMessage(message: Message): void {
 
 function broadcastConversation(conversation: Conversation): void {
   broadcastAgentEvent({ kind: 'conversation_updated', conversation })
+}
+
+/**
+ * Tell every window the conversation list changed. Same channel the sync item
+ * handlers use for a pulled conversation, so the renderer already has one
+ * listener that re-reads the list — a locally created conversation is
+ * indistinguishable from a pulled one as far as a second window is concerned.
+ *
+ * Goes through `broadcastToAllWindows` rather than a hand-rolled
+ * `BrowserWindow.getAllWindows()` loop: that helper skips destroyed windows,
+ * which short-lived windows (quick capture, splash) leave behind and which throw
+ * "Object has been destroyed" on `webContents.send`.
+ *
+ * Backward compatibility: purely additive. A renderer from an older build never
+ * subscribes to this channel, and an unhandled `webContents.send` is a no-op
+ * there — the sender's own invoke result is unchanged, so nothing regresses for
+ * a window that ignores it. `agent:conversations-changed` deliberately carries
+ * only an id, not a row, so it stays readable by any build and leaks no
+ * plaintext title over IPC.
+ */
+function broadcastConversationsChanged(conversationId: string): void {
+  broadcastToAllWindows(AgentChannels.events.CONVERSATIONS_CHANGED, { conversationId })
 }
 
 function resolveSenderWindowId(sender: WebContents): string | null {

--- a/apps/desktop/src/main/sync/apply-item.test.ts
+++ b/apps/desktop/src/main/sync/apply-item.test.ts
@@ -11,7 +11,7 @@ import { projects } from '@memry/db-schema/schema/projects'
 import { inboxItems } from '@memry/db-schema/schema/inbox'
 import { savedFilters } from '@memry/db-schema/schema/settings'
 import type { VectorClock } from '@memry/contracts/sync-api'
-import { ItemApplier, type EmitToWindows } from './apply-item'
+import { ItemApplier, type ApplyItemInput, type EmitToWindows } from './apply-item'
 import { SyncQueueManager } from './queue'
 
 const TEST_PROJECT = {
@@ -753,6 +753,191 @@ describe('ItemApplier', () => {
       expect(result).toBe('skipped')
       const task = testDb.db.select().from(tasks).where(eq(tasks.id, 'task-1')).get()
       expect(task).toBeDefined()
+    })
+  })
+
+  // ─── Mixed-Version Safety ────────────────────────────────────────
+  //
+  // Two devices on different builds is the normal state during a staged
+  // rollout, and the older one is guaranteed to be handed things it cannot
+  // read: a type that did not exist when it shipped, a payload with a field
+  // shape it does not accept, a blob that failed to decrypt cleanly. Its only
+  // correct move is to skip that one item. Anything that escapes `apply()`
+  // aborts the whole page in the pull coordinator and takes the user's other,
+  // perfectly readable items down with it.
+
+  const UNKNOWN_TYPE = 'future_widget' as ApplyItemInput['type']
+
+  describe('#given an item type this build has no handler for', () => {
+    it('#then skips it instead of throwing, and emits nothing', () => {
+      const result = applier.apply({
+        itemId: 'widget-1',
+        type: UNKNOWN_TYPE,
+        operation: 'create',
+        content: new TextEncoder().encode(JSON.stringify({ anything: true })),
+        clock: { 'device-B': 1 }
+      })
+
+      expect(result).toBe('skipped')
+      expect(emitToWindows).not.toHaveBeenCalled()
+    })
+
+    it('#then leaves the neighbouring items in the same batch untouched', () => {
+      // A page mixing one unreadable item with ordinary ones.
+      const batch: ApplyItemInput[] = [
+        {
+          itemId: 'task-1',
+          type: 'task',
+          operation: 'create',
+          content: makeTaskPayload(),
+          clock: { 'device-B': 1 }
+        },
+        {
+          itemId: 'widget-1',
+          type: UNKNOWN_TYPE,
+          operation: 'create',
+          content: new TextEncoder().encode(JSON.stringify({ anything: true })),
+          clock: { 'device-B': 1 }
+        },
+        {
+          itemId: 'inbox-1',
+          type: 'inbox',
+          operation: 'create',
+          content: makeInboxPayload(),
+          clock: { 'device-B': 1 }
+        }
+      ]
+
+      const results = batch.map((item) => applier.apply(item))
+
+      expect(results).toEqual(['applied', 'skipped', 'applied'])
+      expect(testDb.db.select().from(tasks).where(eq(tasks.id, 'task-1')).get()).toBeDefined()
+      expect(
+        testDb.db.select().from(inboxItems).where(eq(inboxItems.id, 'inbox-1')).get()
+      ).toBeDefined()
+    })
+
+    it('#then skips an unknown-type delete without removing anything', () => {
+      testDb.db
+        .insert(tasks)
+        .values({ id: 'task-1', projectId: 'proj-1', title: 'Keep Me', priority: 0, position: 0 })
+        .run()
+
+      const result = applier.apply({
+        itemId: 'task-1',
+        type: UNKNOWN_TYPE,
+        operation: 'delete',
+        content: new Uint8Array(),
+        deletedAt: Date.now()
+      })
+
+      expect(result).toBe('skipped')
+      expect(testDb.db.select().from(tasks).where(eq(tasks.id, 'task-1')).get()).toBeDefined()
+    })
+  })
+
+  describe('#given a payload that fails schema validation', () => {
+    it('#then returns skipped and leaves the local row exactly as it was', () => {
+      testDb.db
+        .insert(tasks)
+        .values({
+          id: 'task-1',
+          projectId: 'proj-1',
+          title: 'Local Title',
+          priority: 0,
+          position: 0,
+          clock: { 'device-A': 1 } satisfies VectorClock
+        })
+        .run()
+
+      // Valid JSON, wrong shape — a newer build widened `title`.
+      const result = applier.apply({
+        itemId: 'task-1',
+        type: 'task',
+        operation: 'update',
+        content: new TextEncoder().encode(JSON.stringify({ title: 42, projectId: 'proj-1' })),
+        clock: { 'device-B': 9 }
+      })
+
+      expect(result).toBe('skipped')
+      const task = testDb.db.select().from(tasks).where(eq(tasks.id, 'task-1')).get()
+      expect(task!.title).toBe('Local Title')
+      expect(task!.clock).toEqual({ 'device-A': 1 })
+    })
+
+    it('#then does not stop the rest of the batch', () => {
+      const results = [
+        applier.apply({
+          itemId: 'task-bad',
+          type: 'task',
+          operation: 'create',
+          content: new TextEncoder().encode(JSON.stringify({ title: 42 })),
+          clock: { 'device-B': 1 }
+        }),
+        applier.apply({
+          itemId: 'task-1',
+          type: 'task',
+          operation: 'create',
+          content: makeTaskPayload(),
+          clock: { 'device-B': 1 }
+        })
+      ]
+
+      expect(results).toEqual(['skipped', 'applied'])
+      expect(testDb.db.select().from(tasks).where(eq(tasks.id, 'task-bad')).get()).toBeUndefined()
+      expect(testDb.db.select().from(tasks).where(eq(tasks.id, 'task-1')).get()).toBeDefined()
+    })
+  })
+
+  describe('#given malformed JSON', () => {
+    it('#then returns parse_error and leaves the local row exactly as it was', () => {
+      testDb.db
+        .insert(tasks)
+        .values({
+          id: 'task-1',
+          projectId: 'proj-1',
+          title: 'Local Title',
+          priority: 0,
+          position: 0,
+          clock: { 'device-A': 1 } satisfies VectorClock
+        })
+        .run()
+
+      // parse_error, not skipped: the pull coordinator refetches these, because
+      // a truncated blob is a transport problem, not an unreadable item.
+      const result = applier.apply({
+        itemId: 'task-1',
+        type: 'task',
+        operation: 'update',
+        content: new TextEncoder().encode('{"title":"Half a pay'),
+        clock: { 'device-B': 9 }
+      })
+
+      expect(result).toBe('parse_error')
+      const task = testDb.db.select().from(tasks).where(eq(tasks.id, 'task-1')).get()
+      expect(task!.title).toBe('Local Title')
+    })
+
+    it('#then does not stop the rest of the batch', () => {
+      const results = [
+        applier.apply({
+          itemId: 'task-broken',
+          type: 'task',
+          operation: 'create',
+          content: new TextEncoder().encode('not json at all'),
+          clock: { 'device-B': 1 }
+        }),
+        applier.apply({
+          itemId: 'task-1',
+          type: 'task',
+          operation: 'create',
+          content: makeTaskPayload(),
+          clock: { 'device-B': 1 }
+        })
+      ]
+
+      expect(results).toEqual(['parse_error', 'applied'])
+      expect(testDb.db.select().from(tasks).where(eq(tasks.id, 'task-1')).get()).toBeDefined()
     })
   })
 })

--- a/apps/desktop/src/main/sync/attachment-events.test.ts
+++ b/apps/desktop/src/main/sync/attachment-events.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const debugSpy = vi.hoisted(() => vi.fn())
+const warnSpy = vi.hoisted(() => vi.fn())
+const errorSpy = vi.hoisted(() => vi.fn())
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: warnSpy,
+    error: errorSpy,
+    debug: debugSpy
+  })
+}))
+
+import { attachmentEvents } from './attachment-events'
+
+interface SavedEvent {
+  noteId: string
+  diskPath: string
+}
+
+interface DownloadNeededEvent {
+  noteId: string
+  attachmentId: string
+  diskPath: string
+  intoDir?: boolean
+}
+
+/**
+ * `attachmentEvents` is a process-wide singleton, so every test has to leave the
+ * bus empty or the next one inherits its listeners.
+ */
+beforeEach(() => {
+  attachmentEvents.removeAllListeners()
+  debugSpy.mockClear()
+  warnSpy.mockClear()
+  errorSpy.mockClear()
+})
+
+afterEach(() => {
+  attachmentEvents.removeAllListeners()
+})
+
+describe('attachmentEvents — saved', () => {
+  it('delivers the saved payload to a registered handler', () => {
+    const handler = vi.fn()
+    attachmentEvents.onSaved(handler)
+
+    attachmentEvents.emitSaved({ noteId: 'note-1', diskPath: '/vault/attachments/a.png' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({
+      noteId: 'note-1',
+      diskPath: '/vault/attachments/a.png'
+    })
+  })
+
+  it('delivers synchronously, before emitSaved returns', () => {
+    const seen: string[] = []
+    attachmentEvents.onSaved(() => seen.push('handler'))
+
+    attachmentEvents.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })
+    seen.push('after-emit')
+
+    expect(seen).toEqual(['handler', 'after-emit'])
+  })
+
+  it('hands the same object to every listener (no defensive copy)', () => {
+    const event: SavedEvent = { noteId: 'note-1', diskPath: '/vault/a.png' }
+    const first = vi.fn()
+    const second = vi.fn()
+    attachmentEvents.onSaved(first)
+    attachmentEvents.onSaved(second)
+
+    attachmentEvents.emitSaved(event)
+
+    expect(first.mock.calls[0][0]).toBe(event)
+    expect(second.mock.calls[0][0]).toBe(event)
+  })
+
+  it('calls listeners in registration order', () => {
+    const order: string[] = []
+    attachmentEvents.onSaved(() => order.push('first'))
+    attachmentEvents.onSaved(() => order.push('second'))
+
+    attachmentEvents.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })
+
+    expect(order).toEqual(['first', 'second'])
+  })
+
+  it('offSaved removes exactly the handler it was given', () => {
+    const kept = vi.fn()
+    const dropped = vi.fn()
+    attachmentEvents.onSaved(kept)
+    attachmentEvents.onSaved(dropped)
+
+    attachmentEvents.offSaved(dropped)
+    attachmentEvents.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })
+
+    expect(kept).toHaveBeenCalledTimes(1)
+    expect(dropped).not.toHaveBeenCalled()
+    expect(attachmentEvents.listenerCount('saved')).toBe(1)
+  })
+
+  it('offSaved with an unregistered handler is a no-op', () => {
+    const handler = vi.fn()
+    attachmentEvents.onSaved(handler)
+
+    attachmentEvents.offSaved(vi.fn())
+    attachmentEvents.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs the noteId only — the absolute host path never reaches the log', () => {
+    attachmentEvents.emitSaved({
+      noteId: 'note-1',
+      diskPath: '/Users/someone/Vault/attachments/note-1/private.png'
+    })
+
+    expect(debugSpy).toHaveBeenCalledWith('attachment saved', { noteId: 'note-1' })
+    const logged = JSON.stringify(debugSpy.mock.calls)
+    expect(logged).not.toContain('/Users/someone')
+    expect(logged).not.toContain('private.png')
+  })
+})
+
+describe('attachmentEvents — download needed', () => {
+  it('delivers the download-needed payload to a registered handler', () => {
+    const handler = vi.fn()
+    attachmentEvents.onDownloadNeeded(handler)
+
+    attachmentEvents.emitDownloadNeeded({
+      noteId: 'note-1',
+      attachmentId: 'att-1',
+      diskPath: '/vault/attachments/note-1',
+      intoDir: true
+    })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({
+      noteId: 'note-1',
+      attachmentId: 'att-1',
+      diskPath: '/vault/attachments/note-1',
+      intoDir: true
+    })
+  })
+
+  it('preserves the intoDir flag exactly — it decides file-vs-directory on the far side', () => {
+    const handler = vi.fn<(event: DownloadNeededEvent) => void>()
+    attachmentEvents.onDownloadNeeded(handler)
+
+    // Embedded-attachment flow: diskPath is the note's attachments DIRECTORY,
+    // the filename only exists inside the encrypted manifest.
+    attachmentEvents.emitDownloadNeeded({
+      noteId: 'note-1',
+      attachmentId: 'att-1',
+      diskPath: '/vault/attachments/note-1',
+      intoDir: true
+    })
+    // Binary-note flow: diskPath is the exact target FILE.
+    attachmentEvents.emitDownloadNeeded({
+      noteId: 'note-2',
+      attachmentId: 'att-2',
+      diskPath: '/vault/Scans/report.pdf'
+    })
+
+    expect(handler.mock.calls[0][0].intoDir).toBe(true)
+    // Not normalised to `false`: the consumer branches on truthiness, and an
+    // accidental `intoDir: true` default would write the blob as a directory.
+    expect(handler.mock.calls[1][0].intoDir).toBeUndefined()
+    expect('intoDir' in handler.mock.calls[1][0]).toBe(false)
+  })
+
+  it('offDownloadNeeded removes exactly the handler it was given', () => {
+    const kept = vi.fn()
+    const dropped = vi.fn()
+    attachmentEvents.onDownloadNeeded(kept)
+    attachmentEvents.onDownloadNeeded(dropped)
+
+    attachmentEvents.offDownloadNeeded(dropped)
+    attachmentEvents.emitDownloadNeeded({
+      noteId: 'note-1',
+      attachmentId: 'att-1',
+      diskPath: '/vault/attachments/note-1',
+      intoDir: true
+    })
+
+    expect(kept).toHaveBeenCalledTimes(1)
+    expect(dropped).not.toHaveBeenCalled()
+  })
+
+  it('logs noteId and attachmentId only — the disk path never reaches the log', () => {
+    attachmentEvents.emitDownloadNeeded({
+      noteId: 'note-1',
+      attachmentId: 'att-1',
+      diskPath: '/Users/someone/Vault/attachments/note-1',
+      intoDir: true
+    })
+
+    expect(debugSpy).toHaveBeenCalledWith('attachment download needed', {
+      noteId: 'note-1',
+      attachmentId: 'att-1'
+    })
+    expect(JSON.stringify(debugSpy.mock.calls)).not.toContain('/Users/someone')
+  })
+})
+
+describe('attachmentEvents — channel isolation', () => {
+  it('keeps saved and download-needed on separate channels', () => {
+    const saved = vi.fn()
+    const download = vi.fn()
+    attachmentEvents.onSaved(saved)
+    attachmentEvents.onDownloadNeeded(download)
+
+    attachmentEvents.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(download).not.toHaveBeenCalled()
+
+    attachmentEvents.emitDownloadNeeded({
+      noteId: 'note-1',
+      attachmentId: 'att-1',
+      diskPath: '/vault/attachments/note-1',
+      intoDir: true
+    })
+
+    expect(download).toHaveBeenCalledTimes(1)
+    expect(saved).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('attachmentEvents — failure surfacing', () => {
+  it('lets a throwing listener escape to the emitter instead of swallowing it', () => {
+    attachmentEvents.onDownloadNeeded(() => {
+      throw new Error('could not resolve attachment')
+    })
+
+    expect(() =>
+      attachmentEvents.emitDownloadNeeded({
+        noteId: 'note-1',
+        attachmentId: 'att-missing',
+        diskPath: '/vault/attachments/note-1',
+        intoDir: true
+      })
+    ).toThrow('could not resolve attachment')
+  })
+
+  it('stops delivering to later listeners once an earlier one throws', () => {
+    const later = vi.fn()
+    attachmentEvents.onDownloadNeeded(() => {
+      throw new Error('boom')
+    })
+    attachmentEvents.onDownloadNeeded(later)
+
+    expect(() =>
+      attachmentEvents.emitDownloadNeeded({
+        noteId: 'note-1',
+        attachmentId: 'att-1',
+        diskPath: '/vault/attachments/note-1',
+        intoDir: true
+      })
+    ).toThrow('boom')
+    // EventEmitter has no per-listener isolation: one bad consumer silences
+    // every consumer registered after it for that emit.
+    expect(later).not.toHaveBeenCalled()
+  })
+
+  it('drops a download-needed event on the floor when nothing is listening', () => {
+    expect(attachmentEvents.listenerCount('download-needed')).toBe(0)
+
+    // No throw, no warn, no error — and the debug line reads exactly the same as
+    // a delivered event. `unregisterAttachmentHandlers()` calls
+    // `removeAllListeners('download-needed')`, so this is the real state during
+    // a sync-runtime restart or sign-out/in.
+    expect(() =>
+      attachmentEvents.emitDownloadNeeded({
+        noteId: 'note-1',
+        attachmentId: 'att-1',
+        diskPath: '/vault/attachments/note-1',
+        intoDir: true
+      })
+    ).not.toThrow()
+
+    expect(debugSpy).toHaveBeenCalledWith('attachment download needed', {
+      noteId: 'note-1',
+      attachmentId: 'att-1'
+    })
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('drops a saved event on the floor when nothing is listening', () => {
+    expect(attachmentEvents.listenerCount('saved')).toBe(0)
+
+    expect(() =>
+      attachmentEvents.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })
+    ).not.toThrow()
+
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it.fails('BUG: emitDownloadNeeded should tell the caller whether the event was delivered', () => {
+    // `EventEmitter.emit` already returns `false` when there is no listener,
+    // but the wrapper declares `: void` and discards it. The caller
+    // (`requestEmbeddedAttachmentDownloads` in item-handlers/note-handler.ts)
+    // adds `"<noteId>:<attachmentId>"` to its `requestedAttachmentDownloads`
+    // dedupe set BEFORE emitting and never removes it, so an event dropped
+    // here is never re-requested for the lifetime of the process — the image
+    // simply never arrives, with nothing above debug level in the log.
+    // Returning the boolean is the minimal fix that lets the caller retry.
+    const bus = attachmentEvents as unknown as {
+      emitDownloadNeeded: (event: DownloadNeededEvent) => boolean | void
+    }
+
+    const delivered = bus.emitDownloadNeeded({
+      noteId: 'note-1',
+      attachmentId: 'att-1',
+      diskPath: '/vault/attachments/note-1',
+      intoDir: true
+    })
+
+    expect(delivered).toBe(false)
+  })
+
+  it.fails('BUG: emitSaved should tell the caller whether the event was delivered', () => {
+    // Same discarded signal on the upload side: the vault watcher emits `saved`
+    // for every new attachment file. With no listener the upload intent is never
+    // even written to the outbox, so the blob is never pushed.
+    const bus = attachmentEvents as unknown as {
+      emitSaved: (event: SavedEvent) => boolean | void
+    }
+
+    const delivered = bus.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })
+
+    expect(delivered).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/sync/attachment-events.test.ts
+++ b/apps/desktop/src/main/sync/attachment-events.test.ts
@@ -204,6 +204,9 @@ describe('attachmentEvents — download needed', () => {
       attachmentId: 'att-1'
     })
     expect(JSON.stringify(debugSpy.mock.calls)).not.toContain('/Users/someone')
+    // No listener is registered here, so the drop warning fires too — it is held
+    // to the same hygiene rule as the debug line.
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('/Users/someone')
   })
 })
 
@@ -267,11 +270,11 @@ describe('attachmentEvents — failure surfacing', () => {
     expect(later).not.toHaveBeenCalled()
   })
 
-  it('drops a download-needed event on the floor when nothing is listening', () => {
+  it('warns when a download-needed event is dropped because nothing is listening', () => {
     expect(attachmentEvents.listenerCount('download-needed')).toBe(0)
 
-    // No throw, no warn, no error — and the debug line reads exactly the same as
-    // a delivered event. `unregisterAttachmentHandlers()` calls
+    // A drop must stay non-fatal, but it must not read like a success either.
+    // `unregisterAttachmentHandlers()` calls
     // `removeAllListeners('download-needed')`, so this is the real state during
     // a sync-runtime restart or sign-out/in.
     expect(() =>
@@ -283,26 +286,45 @@ describe('attachmentEvents — failure surfacing', () => {
       })
     ).not.toThrow()
 
-    expect(debugSpy).toHaveBeenCalledWith('attachment download needed', {
-      noteId: 'note-1',
-      attachmentId: 'att-1'
-    })
-    expect(warnSpy).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(
+      'attachment download-needed event dropped: no listener registered',
+      { noteId: 'note-1', attachmentId: 'att-1' }
+    )
+    // Still not an error: the caller retries on the next pull of the note.
     expect(errorSpy).not.toHaveBeenCalled()
   })
 
-  it('drops a saved event on the floor when nothing is listening', () => {
+  it('warns when a saved event is dropped because nothing is listening', () => {
     expect(attachmentEvents.listenerCount('saved')).toBe(0)
 
     expect(() =>
       attachmentEvents.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })
     ).not.toThrow()
 
-    expect(warnSpy).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith('attachment saved event dropped: no listener registered', {
+      noteId: 'note-1'
+    })
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('/vault/a.png')
     expect(errorSpy).not.toHaveBeenCalled()
   })
 
-  it.fails('BUG: emitDownloadNeeded should tell the caller whether the event was delivered', () => {
+  it('reports delivery when a listener is registered', () => {
+    attachmentEvents.onDownloadNeeded(vi.fn())
+    attachmentEvents.onSaved(vi.fn())
+
+    expect(
+      attachmentEvents.emitDownloadNeeded({
+        noteId: 'note-1',
+        attachmentId: 'att-1',
+        diskPath: '/vault/attachments/note-1',
+        intoDir: true
+      })
+    ).toBe(true)
+    expect(attachmentEvents.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })).toBe(true)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('emitDownloadNeeded tells the caller whether the event was delivered', () => {
     // `EventEmitter.emit` already returns `false` when there is no listener,
     // but the wrapper declares `: void` and discards it. The caller
     // (`requestEmbeddedAttachmentDownloads` in item-handlers/note-handler.ts)
@@ -311,11 +333,7 @@ describe('attachmentEvents — failure surfacing', () => {
     // here is never re-requested for the lifetime of the process — the image
     // simply never arrives, with nothing above debug level in the log.
     // Returning the boolean is the minimal fix that lets the caller retry.
-    const bus = attachmentEvents as unknown as {
-      emitDownloadNeeded: (event: DownloadNeededEvent) => boolean | void
-    }
-
-    const delivered = bus.emitDownloadNeeded({
+    const delivered = attachmentEvents.emitDownloadNeeded({
       noteId: 'note-1',
       attachmentId: 'att-1',
       diskPath: '/vault/attachments/note-1',
@@ -325,15 +343,11 @@ describe('attachmentEvents — failure surfacing', () => {
     expect(delivered).toBe(false)
   })
 
-  it.fails('BUG: emitSaved should tell the caller whether the event was delivered', () => {
+  it('emitSaved tells the caller whether the event was delivered', () => {
     // Same discarded signal on the upload side: the vault watcher emits `saved`
     // for every new attachment file. With no listener the upload intent is never
     // even written to the outbox, so the blob is never pushed.
-    const bus = attachmentEvents as unknown as {
-      emitSaved: (event: SavedEvent) => boolean | void
-    }
-
-    const delivered = bus.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })
+    const delivered = attachmentEvents.emitSaved({ noteId: 'note-1', diskPath: '/vault/a.png' })
 
     expect(delivered).toBe(false)
   })

--- a/apps/desktop/src/main/sync/attachment-events.ts
+++ b/apps/desktop/src/main/sync/attachment-events.ts
@@ -26,9 +26,31 @@ type DownloadNeededHandler = (event: AttachmentDownloadNeededEvent) => void
 type SavedHandler = (event: AttachmentSavedEvent) => void
 
 class AttachmentEventBus extends EventEmitter {
-  emitSaved(event: AttachmentSavedEvent): void {
+  /**
+   * Returns whether the event reached at least one listener.
+   *
+   * `unregisterAttachmentHandlers()` calls `removeAllListeners(...)`, so a
+   * zero-listener window is real during sync-runtime restart, sign-out/in and
+   * token churn. Discarding `EventEmitter.emit`'s boolean made a drop
+   * indistinguishable from a delivery, and callers that dedupe (see
+   * `requestEmbeddedAttachmentDownloads` in item-handlers/note-handler.ts)
+   * recorded the request anyway — so the attachment was never asked for again
+   * for the life of the process.
+   *
+   * Backward compatibility: widening the return type from `void` to `boolean`
+   * is purely local to this process. Nothing here is persisted, sent over IPC,
+   * or put on the wire, so no older build and no on-disk/served payload can
+   * observe the change; existing callers that ignore the value keep compiling
+   * and behaving exactly as before.
+   */
+  emitSaved(event: AttachmentSavedEvent): boolean {
     log.debug('attachment saved', { noteId: event.noteId })
-    this.emit('saved', event)
+    const delivered = this.emit('saved', event)
+    if (!delivered) {
+      // noteId only — the absolute host path must never reach the log.
+      log.warn('attachment saved event dropped: no listener registered', { noteId: event.noteId })
+    }
+    return delivered
   }
 
   onSaved(handler: SavedHandler): void {
@@ -39,12 +61,21 @@ class AttachmentEventBus extends EventEmitter {
     this.off('saved', handler)
   }
 
-  emitDownloadNeeded(event: AttachmentDownloadNeededEvent): void {
+  /** See {@link emitSaved} — same delivery signal, same compat reasoning. */
+  emitDownloadNeeded(event: AttachmentDownloadNeededEvent): boolean {
     log.debug('attachment download needed', {
       noteId: event.noteId,
       attachmentId: event.attachmentId
     })
-    this.emit('download-needed', event)
+    const delivered = this.emit('download-needed', event)
+    if (!delivered) {
+      // Ids only — `diskPath` must never reach the log.
+      log.warn('attachment download-needed event dropped: no listener registered', {
+        noteId: event.noteId,
+        attachmentId: event.attachmentId
+      })
+    }
+    return delivered
   }
 
   onDownloadNeeded(handler: DownloadNeededHandler): void {

--- a/apps/desktop/src/main/sync/auth-state.test.ts
+++ b/apps/desktop/src/main/sync/auth-state.test.ts
@@ -1,0 +1,112 @@
+import { KEYCHAIN_ENTRIES } from '@memry/contracts/crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockRetrieveKey = vi.hoisted(() => vi.fn<(entry: unknown) => Promise<Uint8Array | null>>())
+
+vi.mock('../crypto', () => ({
+  retrieveKey: (entry: unknown) => mockRetrieveKey(entry)
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+import { isMemryUserSignedIn } from './auth-state'
+import { isMemryUserSignedIn as directExport } from '../auth-state'
+
+const encode = (value: string): Uint8Array => new TextEncoder().encode(value)
+
+describe('isMemryUserSignedIn', () => {
+  beforeEach(() => {
+    mockRetrieveKey.mockReset()
+  })
+
+  it('is the same function as the main-process module it re-exports', () => {
+    // sync/auth-state.ts is a pure barrel. Callers import it from both paths
+    // (calendar-handlers from '../auth-state', google sync from
+    // '../../sync/auth-state'), and tests mock one path or the other — that
+    // only stays honest while both resolve to one implementation.
+    expect(isMemryUserSignedIn).toBe(directExport)
+  })
+
+  it('reads the sync refresh token, not any other keychain entry', async () => {
+    mockRetrieveKey.mockResolvedValue(encode('refresh-token-value'))
+
+    await expect(isMemryUserSignedIn()).resolves.toBe(true)
+    expect(mockRetrieveKey).toHaveBeenCalledTimes(1)
+    expect(mockRetrieveKey).toHaveBeenCalledWith(KEYCHAIN_ENTRIES.REFRESH_TOKEN)
+  })
+
+  describe('signed out', () => {
+    it('reports signed out when the keychain has no refresh token', async () => {
+      mockRetrieveKey.mockResolvedValue(null)
+
+      await expect(isMemryUserSignedIn()).resolves.toBe(false)
+    })
+
+    it('reports signed out for a zero-length token', async () => {
+      mockRetrieveKey.mockResolvedValue(new Uint8Array(0))
+
+      await expect(isMemryUserSignedIn()).resolves.toBe(false)
+    })
+
+    it('reports signed out for a whitespace-only token', async () => {
+      mockRetrieveKey.mockResolvedValue(encode('   \n\t  '))
+
+      await expect(isMemryUserSignedIn()).resolves.toBe(false)
+    })
+  })
+
+  describe('signed in', () => {
+    it('tolerates trailing newlines around a real token', async () => {
+      // Keychain backends differ per platform in what they hand back for a
+      // value that was stored with a trailing newline (Windows Credential
+      // Manager and libsecret have both been seen round-tripping "\r\n").
+      // A real token must not read as signed out because of framing.
+      mockRetrieveKey.mockResolvedValue(encode('eyJhbGciOi.token\r\n'))
+
+      await expect(isMemryUserSignedIn()).resolves.toBe(true)
+    })
+
+    it('decodes the stored bytes as UTF-8', async () => {
+      mockRetrieveKey.mockResolvedValue(encode('tökén-ünicode'))
+
+      await expect(isMemryUserSignedIn()).resolves.toBe(true)
+    })
+  })
+
+  describe('transient keychain failure', () => {
+    // retrieveKey throws (it wraps every keychain error) when the OS keychain
+    // is locked, the entry is momentarily unreadable, or the dev build's
+    // signature is broken. That must NOT surface as "signed out": callers gate
+    // Google-calendar sync on this boolean, so a false here would look exactly
+    // like a real sign-out and silently stop syncing until restart.
+    it('propagates the error instead of reporting the user signed out', async () => {
+      mockRetrieveKey.mockRejectedValue(
+        new Error('Failed to retrieve key from keychain (refresh-token): unknown error')
+      )
+
+      await expect(isMemryUserSignedIn()).rejects.toThrow(/Failed to retrieve key from keychain/)
+    })
+
+    it('re-reads the keychain on every call, so a recovered read flips back to signed in', async () => {
+      // No caching, no latch: a transient failure or a re-sign-in is picked up
+      // on the next call rather than pinning the user to signed out.
+      mockRetrieveKey.mockRejectedValueOnce(new Error('keychain unavailable'))
+      await expect(isMemryUserSignedIn()).rejects.toThrow('keychain unavailable')
+
+      mockRetrieveKey.mockResolvedValueOnce(null)
+      await expect(isMemryUserSignedIn()).resolves.toBe(false)
+
+      mockRetrieveKey.mockResolvedValueOnce(encode('fresh-refresh-token'))
+      await expect(isMemryUserSignedIn()).resolves.toBe(true)
+
+      expect(mockRetrieveKey).toHaveBeenCalledTimes(3)
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/calendar-binding-sync.test.ts
+++ b/apps/desktop/src/main/sync/calendar-binding-sync.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import {
+  createTestDataDb,
+  asClientDb,
+  asSyncDb,
+  type TestDatabaseResult
+} from '@tests/utils/test-db'
+import { calendarBindings } from '@memry/db-schema/schema/calendar-bindings'
+import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
+import { CalendarBindingSyncPayloadSchema } from '@memry/contracts/sync-payloads'
+import type { VectorClock } from '@memry/contracts/sync-api'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { SyncQueueManager } from './queue'
+import { calendarBindingHandler } from './item-handlers/calendar-binding-handler'
+import {
+  CalendarBindingSyncService,
+  initCalendarBindingSyncService,
+  getCalendarBindingSyncService,
+  resetCalendarBindingSyncService
+} from './calendar-binding-sync'
+
+const TEST_BINDING = {
+  id: 'bind-1',
+  sourceType: 'event' as const,
+  sourceId: 'evt-1',
+  provider: 'google',
+  remoteCalendarId: 'primary@example.com',
+  remoteEventId: 'google-evt-1',
+  ownershipMode: 'memry_managed' as const,
+  writebackMode: 'broad' as const
+}
+
+describe('CalendarBindingSyncService', () => {
+  let testDb: TestDatabaseResult
+  let queue: SyncQueueManager
+  let service: CalendarBindingSyncService
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    queue = new SyncQueueManager(asClientDb(testDb.db))
+    service = new CalendarBindingSyncService({
+      queue,
+      db: asSyncDb(testDb.db),
+      getDeviceId: () => 'device-A'
+    })
+  })
+
+  afterEach(() => {
+    resetCalendarBindingSyncService()
+    testDb.close()
+  })
+
+  describe('#given a local binding exists #when enqueueCreate called', () => {
+    it('#then enqueues a calendar_binding create carrying the row and a bumped clock', () => {
+      testDb.db.insert(calendarBindings).values(TEST_BINDING).run()
+
+      service.enqueueCreate('bind-1')
+
+      const [item] = queue.dequeue(1)
+      expect(item.type).toBe('calendar_binding')
+      expect(item.itemId).toBe('bind-1')
+      expect(item.operation).toBe('create')
+
+      const payload = JSON.parse(item.payload)
+      expect(payload.sourceType).toBe('event')
+      expect(payload.sourceId).toBe('evt-1')
+      expect(payload.remoteEventId).toBe('google-evt-1')
+      expect(payload.clock).toEqual({ 'device-A': 1 })
+    })
+
+    it('#then the enqueued payload still parses as a CalendarBindingSyncPayload', () => {
+      testDb.db.insert(calendarBindings).values(TEST_BINDING).run()
+
+      service.enqueueCreate('bind-1')
+
+      const [item] = queue.dequeue(1)
+      const parsed = CalendarBindingSyncPayloadSchema.parse(JSON.parse(item.payload))
+      expect(parsed.ownershipMode).toBe('memry_managed')
+      expect(parsed.writebackMode).toBe('broad')
+    })
+  })
+
+  describe('#given a binding with an existing clock #when enqueueUpdate called', () => {
+    it('#then persists the incremented clock on the row and ships the same clock', () => {
+      const existingClock: VectorClock = { 'device-A': 1, 'device-B': 5 }
+      testDb.db
+        .insert(calendarBindings)
+        .values({ ...TEST_BINDING, clock: existingClock })
+        .run()
+
+      service.enqueueUpdate('bind-1')
+
+      const row = testDb.db
+        .select()
+        .from(calendarBindings)
+        .where(eq(calendarBindings.id, 'bind-1'))
+        .get()
+      expect(row?.clock).toEqual({ 'device-A': 2, 'device-B': 5 })
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('update')
+      expect(JSON.parse(item.payload).clock).toEqual({ 'device-A': 2, 'device-B': 5 })
+    })
+  })
+
+  describe('#given a change arrived from sync #when the handler applies it', () => {
+    it('#then nothing is enqueued for push (no echo back to the server)', () => {
+      const result = calendarBindingHandler.applyUpsert(
+        { db: asSyncDb(testDb.db), emit: vi.fn() },
+        'bind-1',
+        {
+          sourceType: 'event',
+          sourceId: 'evt-1',
+          provider: 'google',
+          remoteCalendarId: 'primary@example.com',
+          remoteEventId: 'google-evt-1',
+          ownershipMode: 'memry_managed',
+          writebackMode: 'broad'
+        },
+        { 'device-B': 1 }
+      )
+
+      expect(result).toBe('applied')
+      expect(queue.getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('#given the calendar_source it points at is not present locally', () => {
+    it('#then the binding is still written and still pushes — it holds no FK to calendar_sources', () => {
+      // calendar_bindings addresses the remote calendar by provider +
+      // remote_calendar_id strings, with no `references()` to calendar_sources.
+      // So the missing-parent convention in item-handlers/types.ts
+      // (MissingSyncParentError -> engine/orphan-repair) never applies here:
+      // a binding can neither be blocked by nor repaired against a missing
+      // source. It survives, but it also stays permanently unresolvable if the
+      // source never arrives.
+      expect(
+        testDb.db.select().from(calendarSources).where(eq(calendarSources.id, 'src-1')).get()
+      ).toBeUndefined()
+
+      testDb.db
+        .insert(calendarBindings)
+        .values({ ...TEST_BINDING, remoteCalendarId: 'never-synced@example.com' })
+        .run()
+
+      service.enqueueCreate('bind-1')
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('create')
+      expect(JSON.parse(item.payload).remoteCalendarId).toBe('never-synced@example.com')
+    })
+  })
+
+  describe('#given the row is not present locally #when enqueueCreate called', () => {
+    it('#then the outbound push is dropped with no error and no queue entry', () => {
+      service.enqueueCreate('bind-missing')
+
+      expect(queue.getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('#given no device id #when enqueueCreate called', () => {
+    it('#then skips silently', () => {
+      const noDevice = new CalendarBindingSyncService({
+        queue,
+        db: asSyncDb(testDb.db),
+        getDeviceId: () => null
+      })
+      testDb.db.insert(calendarBindings).values(TEST_BINDING).run()
+
+      noDevice.enqueueCreate('bind-1')
+
+      expect(queue.getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('#when enqueueDelete called', () => {
+    it('#then a snapshot payload is shipped with an incremented clock', () => {
+      const snapshot = JSON.stringify({ ...TEST_BINDING, clock: { 'device-A': 4 } })
+
+      service.enqueueDelete('bind-1', snapshot)
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('delete')
+      expect(item.type).toBe('calendar_binding')
+      expect(JSON.parse(item.payload).clock).toEqual({ 'device-A': 5 })
+    })
+
+    it('#then a delete with neither snapshot nor row still enqueues an id-only tombstone', () => {
+      service.enqueueDelete('bind-gone')
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('delete')
+      expect(JSON.parse(item.payload)).toEqual({ id: 'bind-gone', clock: { 'device-A': 1 } })
+    })
+  })
+
+  describe('#given a peer holds the same binding #when the built delete payload is applied there', () => {
+    it('#then the delete propagates rather than being skipped as concurrent', () => {
+      const originClock: VectorClock = { 'device-A': 3 }
+      testDb.db
+        .insert(calendarBindings)
+        .values({ ...TEST_BINDING, clock: originClock })
+        .run()
+
+      service.enqueueDelete('bind-1')
+      const [item] = queue.dequeue(1)
+      const { clock } = JSON.parse(item.payload) as { clock: VectorClock }
+
+      const peerDb = createTestDataDb()
+      try {
+        peerDb.db
+          .insert(calendarBindings)
+          .values({ ...TEST_BINDING, clock: originClock })
+          .run()
+
+        const result = calendarBindingHandler.applyDelete(
+          { db: asSyncDb(peerDb.db), emit: vi.fn() },
+          'bind-1',
+          clock
+        )
+
+        expect(result).toBe('applied')
+        expect(
+          peerDb.db.select().from(calendarBindings).where(eq(calendarBindings.id, 'bind-1')).get()
+        ).toBeUndefined()
+      } finally {
+        peerDb.close()
+      }
+    })
+  })
+
+  describe('module-level accessor', () => {
+    it('#then returns null before init', () => {
+      expect(getCalendarBindingSyncService()).toBeNull()
+    })
+
+    it('#then returns the instance after init and null after reset', () => {
+      const svc = initCalendarBindingSyncService({
+        queue,
+        db: asSyncDb(testDb.db),
+        getDeviceId: () => 'device-A'
+      })
+      expect(getCalendarBindingSyncService()).toBe(svc)
+
+      resetCalendarBindingSyncService()
+      expect(getCalendarBindingSyncService()).toBeNull()
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/calendar-event-sync.test.ts
+++ b/apps/desktop/src/main/sync/calendar-event-sync.test.ts
@@ -294,14 +294,14 @@ describe('CalendarEventSyncService', () => {
   })
 
   describe('#given an event pinned to a specific Google calendar', () => {
-    // PRODUCT BUG. `targetCalendarId` is what routes a push to the right Google
-    // calendar (see calendar/google/account-routing.ts and sync-service.ts), and
-    // promote-external-event.ts sets it. serialize() ships the whole row so the
-    // column does leave this device — but CalendarEventSyncPayloadSchema has no
-    // `targetCalendarId` key, so zod strips it on the receiving side and the
-    // peer falls back to the memry-managed calendar. The pin is silently lost
-    // cross-device.
-    it.fails('#then the target calendar survives the sync payload contract', () => {
+    // REGRESSION GUARD. `targetCalendarId` is what routes a push to the right
+    // Google calendar (see calendar/google/account-routing.ts and
+    // sync-service.ts), and promote-external-event.ts sets it. serialize() ships
+    // the whole row so the column does leave this device — but
+    // CalendarEventSyncPayloadSchema used to have no `targetCalendarId` key, so
+    // zod stripped it on the receiving side and the peer fell back to the
+    // memry-managed calendar. The pin was silently lost cross-device.
+    it('#then the target calendar survives the sync payload contract', () => {
       testDb.db
         .insert(calendarEvents)
         .values({ ...TEST_EVENT, targetCalendarId: 'work@group.calendar.google.com' })
@@ -315,6 +315,49 @@ describe('CalendarEventSyncService', () => {
 
       const parsed = CalendarEventSyncPayloadSchema.parse(raw) as Record<string, unknown>
       expect(parsed.targetCalendarId).toBe('work@group.calendar.google.com')
+    })
+  })
+
+  describe('#given a recurrence exception written back from Google', () => {
+    // `parentEventId` / `originalStartTime` are written onto the local
+    // calendar_events row by applyGoogleCalendarWriteback and read back out by
+    // mapCalendarEventToGoogleInput (recurringEventId + originalStartTime).
+    // Stripping them on arrival turned a peer's exception into a standalone
+    // event on its next push to Google.
+    it('#then the exception identity survives the sync payload contract', () => {
+      testDb.db
+        .insert(calendarEvents)
+        .values({
+          ...TEST_EVENT,
+          parentEventId: 'series-1',
+          originalStartTime: '2026-08-05T08:00:00.000Z'
+        })
+        .run()
+
+      service.enqueueCreate('evt-1')
+
+      const [item] = queue.dequeue(1)
+      const parsed = CalendarEventSyncPayloadSchema.parse(JSON.parse(item.payload)) as Record<
+        string,
+        unknown
+      >
+      expect(parsed.parentEventId).toBe('series-1')
+      expect(parsed.originalStartTime).toBe('2026-08-05T08:00:00.000Z')
+    })
+
+    it('#then a payload from an older build that omits the new keys still parses', () => {
+      // Backward compat: the three new keys are optional, so an older sender
+      // that never wrote them parses cleanly and leaves them undefined — which
+      // receivers must read as "keep local", not "clear".
+      const parsed = CalendarEventSyncPayloadSchema.parse({
+        title: 'Standup',
+        startAt: '2026-08-05T09:00:00.000Z',
+        timezone: 'UTC'
+      }) as Record<string, unknown>
+
+      expect(parsed.targetCalendarId).toBeUndefined()
+      expect(parsed.parentEventId).toBeUndefined()
+      expect(parsed.originalStartTime).toBeUndefined()
     })
   })
 

--- a/apps/desktop/src/main/sync/calendar-event-sync.test.ts
+++ b/apps/desktop/src/main/sync/calendar-event-sync.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import {
+  createTestDataDb,
+  asClientDb,
+  asSyncDb,
+  type TestDatabaseResult
+} from '@tests/utils/test-db'
+import { calendarEvents } from '@memry/db-schema/schema/calendar-events'
+import { calendarExternalEvents } from '@memry/db-schema/schema/calendar-external-events'
+import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
+import { CalendarEventSyncPayloadSchema } from '@memry/contracts/sync-payloads'
+import type { FieldClocks, VectorClock } from '@memry/contracts/sync-api'
+import { CALENDAR_EVENT_SYNCABLE_FIELDS } from '../calendar/field-merge-calendar'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { SyncQueueManager } from './queue'
+import { calendarEventHandler } from './item-handlers/calendar-event-handler'
+import {
+  CalendarEventSyncService,
+  initCalendarEventSyncService,
+  getCalendarEventSyncService,
+  resetCalendarEventSyncService
+} from './calendar-event-sync'
+
+const TEST_EVENT = {
+  id: 'evt-1',
+  title: 'Standup',
+  startAt: '2026-08-05T09:00:00.000Z',
+  endAt: '2026-08-05T09:15:00.000Z',
+  timezone: 'UTC'
+}
+
+describe('CalendarEventSyncService', () => {
+  let testDb: TestDatabaseResult
+  let queue: SyncQueueManager
+  let service: CalendarEventSyncService
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    queue = new SyncQueueManager(asClientDb(testDb.db))
+    service = new CalendarEventSyncService({
+      queue,
+      db: asSyncDb(testDb.db),
+      getDeviceId: () => 'device-A'
+    })
+  })
+
+  afterEach(() => {
+    resetCalendarEventSyncService()
+    testDb.close()
+  })
+
+  describe('#given a local event exists #when enqueueCreate called', () => {
+    it('#then enqueues a calendar_event create with a bumped doc clock', () => {
+      testDb.db.insert(calendarEvents).values(TEST_EVENT).run()
+
+      service.enqueueCreate('evt-1')
+
+      const [item] = queue.dequeue(1)
+      expect(item.type).toBe('calendar_event')
+      expect(item.itemId).toBe('evt-1')
+      expect(item.operation).toBe('create')
+
+      const payload = JSON.parse(item.payload)
+      expect(payload.title).toBe('Standup')
+      expect(payload.startAt).toBe('2026-08-05T09:00:00.000Z')
+      expect(payload.clock).toEqual({ 'device-A': 1 })
+    })
+
+    it('#then seeds a field clock for every syncable field', () => {
+      testDb.db.insert(calendarEvents).values(TEST_EVENT).run()
+
+      service.enqueueCreate('evt-1')
+
+      const row = testDb.db
+        .select()
+        .from(calendarEvents)
+        .where(eq(calendarEvents.id, 'evt-1'))
+        .get()
+      const fieldClocks = row?.fieldClocks as FieldClocks
+      for (const field of CALENDAR_EVENT_SYNCABLE_FIELDS) {
+        expect(fieldClocks[field]).toEqual({ 'device-A': 1 })
+      }
+    })
+
+    it('#then the enqueued payload still parses as a CalendarEventSyncPayload', () => {
+      testDb.db.insert(calendarEvents).values(TEST_EVENT).run()
+
+      service.enqueueCreate('evt-1')
+
+      const [item] = queue.dequeue(1)
+      const parsed = CalendarEventSyncPayloadSchema.parse(JSON.parse(item.payload))
+      expect(parsed.title).toBe('Standup')
+      expect(parsed.fieldClocks?.title).toEqual({ 'device-A': 1 })
+    })
+  })
+
+  describe('#given changedFields are supplied #when enqueueUpdate called', () => {
+    it('#then only those field clocks advance', () => {
+      testDb.db.insert(calendarEvents).values(TEST_EVENT).run()
+      service.enqueueCreate('evt-1')
+
+      testDb.db
+        .update(calendarEvents)
+        .set({ title: 'Standup (moved)' })
+        .where(eq(calendarEvents.id, 'evt-1'))
+        .run()
+      service.enqueueUpdate('evt-1', ['title'])
+
+      const row = testDb.db
+        .select()
+        .from(calendarEvents)
+        .where(eq(calendarEvents.id, 'evt-1'))
+        .get()
+      const fieldClocks = row?.fieldClocks as FieldClocks
+      expect(fieldClocks.title).toEqual({ 'device-A': 2 })
+      expect(fieldClocks.startAt).toEqual({ 'device-A': 1 })
+      expect(row?.clock).toEqual({ 'device-A': 2 })
+    })
+
+    it('#then omitting changedFields advances every syncable field', () => {
+      testDb.db.insert(calendarEvents).values(TEST_EVENT).run()
+      service.enqueueCreate('evt-1')
+
+      service.enqueueUpdate('evt-1')
+
+      const row = testDb.db
+        .select()
+        .from(calendarEvents)
+        .where(eq(calendarEvents.id, 'evt-1'))
+        .get()
+      const fieldClocks = row?.fieldClocks as FieldClocks
+      for (const field of CALENDAR_EVENT_SYNCABLE_FIELDS) {
+        expect(fieldClocks[field]).toEqual({ 'device-A': 2 })
+      }
+    })
+  })
+
+  describe('#given a change arrived from sync #when the handler applies it', () => {
+    it('#then nothing is enqueued for push (no echo back to the server)', () => {
+      // The inbound path writes through the item handler, never through this
+      // service. If it ever routed through enqueueUpdate, every pulled event
+      // would bounce straight back out and ping-pong between devices.
+      const result = calendarEventHandler.applyUpsert(
+        { db: asSyncDb(testDb.db), emit: vi.fn() },
+        'evt-1',
+        { title: 'Standup', startAt: '2026-08-05T09:00:00.000Z', timezone: 'UTC' },
+        { 'device-B': 1 }
+      )
+
+      expect(result).toBe('applied')
+      expect(queue.getPendingCount()).toBe(0)
+
+      const row = testDb.db
+        .select()
+        .from(calendarEvents)
+        .where(eq(calendarEvents.id, 'evt-1'))
+        .get()
+      expect(row?.title).toBe('Standup')
+    })
+  })
+
+  describe('#given an external event shares an id with a local event', () => {
+    it('#then enqueueUpdate pushes the local calendar_event, never the imported row', () => {
+      testDb.db
+        .insert(calendarSources)
+        .values({
+          id: 'src-1',
+          provider: 'google',
+          kind: 'calendar',
+          remoteId: 'primary@example.com',
+          title: 'Work'
+        })
+        .run()
+      testDb.db
+        .insert(calendarEvents)
+        .values({ ...TEST_EVENT, id: 'shared-id' })
+        .run()
+      testDb.db
+        .insert(calendarExternalEvents)
+        .values({
+          id: 'shared-id',
+          sourceId: 'src-1',
+          remoteEventId: 'google-evt-1',
+          title: 'Google copy',
+          startAt: '2026-08-05T09:00:00.000Z'
+        })
+        .run()
+
+      service.enqueueUpdate('shared-id')
+
+      const [item] = queue.dequeue(1)
+      expect(item.type).toBe('calendar_event')
+      expect(JSON.parse(item.payload).title).toBe('Standup')
+
+      // The imported row keeps its own identity and is untouched by the local
+      // event's clock bump — the two tables are never conflated.
+      const external = testDb.db
+        .select()
+        .from(calendarExternalEvents)
+        .where(eq(calendarExternalEvents.id, 'shared-id'))
+        .get()
+      expect(external?.title).toBe('Google copy')
+      expect(external?.clock).toBeNull()
+    })
+  })
+
+  describe('#given the row is not present locally #when enqueueCreate called', () => {
+    it('#then the outbound push is dropped with no error and no queue entry', () => {
+      service.enqueueCreate('evt-missing')
+
+      expect(queue.getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('#given no device id #when enqueueCreate called', () => {
+    it('#then skips silently', () => {
+      const noDevice = new CalendarEventSyncService({
+        queue,
+        db: asSyncDb(testDb.db),
+        getDeviceId: () => null
+      })
+      testDb.db.insert(calendarEvents).values(TEST_EVENT).run()
+
+      noDevice.enqueueCreate('evt-1')
+
+      expect(queue.getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('#when enqueueDelete called', () => {
+    it('#then a snapshot payload is shipped with an incremented clock', () => {
+      const snapshot = JSON.stringify({ ...TEST_EVENT, clock: { 'device-A': 6 } })
+
+      service.enqueueDelete('evt-1', snapshot)
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('delete')
+      expect(item.type).toBe('calendar_event')
+      expect(JSON.parse(item.payload).clock).toEqual({ 'device-A': 7 })
+    })
+
+    it('#then a delete with neither snapshot nor row still enqueues an id-only tombstone', () => {
+      service.enqueueDelete('evt-gone')
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('delete')
+      expect(JSON.parse(item.payload)).toEqual({ id: 'evt-gone', clock: { 'device-A': 1 } })
+    })
+  })
+
+  describe('#given a peer holds the same event #when the built delete payload is applied there', () => {
+    it('#then the delete propagates rather than being skipped as concurrent', () => {
+      const originClock: VectorClock = { 'device-A': 2 }
+      testDb.db
+        .insert(calendarEvents)
+        .values({ ...TEST_EVENT, clock: originClock })
+        .run()
+
+      service.enqueueDelete('evt-1')
+      const [item] = queue.dequeue(1)
+      const { clock } = JSON.parse(item.payload) as { clock: VectorClock }
+
+      const peerDb = createTestDataDb()
+      try {
+        peerDb.db
+          .insert(calendarEvents)
+          .values({ ...TEST_EVENT, clock: originClock })
+          .run()
+
+        const result = calendarEventHandler.applyDelete(
+          { db: asSyncDb(peerDb.db), emit: vi.fn() },
+          'evt-1',
+          clock
+        )
+
+        expect(result).toBe('applied')
+        expect(
+          peerDb.db.select().from(calendarEvents).where(eq(calendarEvents.id, 'evt-1')).get()
+        ).toBeUndefined()
+      } finally {
+        peerDb.close()
+      }
+    })
+  })
+
+  describe('#given an event pinned to a specific Google calendar', () => {
+    // PRODUCT BUG. `targetCalendarId` is what routes a push to the right Google
+    // calendar (see calendar/google/account-routing.ts and sync-service.ts), and
+    // promote-external-event.ts sets it. serialize() ships the whole row so the
+    // column does leave this device — but CalendarEventSyncPayloadSchema has no
+    // `targetCalendarId` key, so zod strips it on the receiving side and the
+    // peer falls back to the memry-managed calendar. The pin is silently lost
+    // cross-device.
+    it.fails('#then the target calendar survives the sync payload contract', () => {
+      testDb.db
+        .insert(calendarEvents)
+        .values({ ...TEST_EVENT, targetCalendarId: 'work@group.calendar.google.com' })
+        .run()
+
+      service.enqueueCreate('evt-1')
+
+      const [item] = queue.dequeue(1)
+      const raw = JSON.parse(item.payload)
+      expect(raw.targetCalendarId).toBe('work@group.calendar.google.com')
+
+      const parsed = CalendarEventSyncPayloadSchema.parse(raw) as Record<string, unknown>
+      expect(parsed.targetCalendarId).toBe('work@group.calendar.google.com')
+    })
+  })
+
+  describe('module-level accessor', () => {
+    it('#then returns null before init', () => {
+      expect(getCalendarEventSyncService()).toBeNull()
+    })
+
+    it('#then returns the instance after init and null after reset', () => {
+      const svc = initCalendarEventSyncService({
+        queue,
+        db: asSyncDb(testDb.db),
+        getDeviceId: () => 'device-A'
+      })
+      expect(getCalendarEventSyncService()).toBe(svc)
+
+      resetCalendarEventSyncService()
+      expect(getCalendarEventSyncService()).toBeNull()
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/calendar-external-event-sync.test.ts
+++ b/apps/desktop/src/main/sync/calendar-external-event-sync.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import {
+  createTestDataDb,
+  asClientDb,
+  asSyncDb,
+  type TestDatabaseResult
+} from '@tests/utils/test-db'
+import { calendarExternalEvents } from '@memry/db-schema/schema/calendar-external-events'
+import { calendarEvents } from '@memry/db-schema/schema/calendar-events'
+import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
+import { CalendarExternalEventSyncPayloadSchema } from '@memry/contracts/sync-payloads'
+import type { VectorClock } from '@memry/contracts/sync-api'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { SyncQueueManager } from './queue'
+import { MissingSyncParentError } from './item-handlers/types'
+import { calendarExternalEventHandler } from './item-handlers/calendar-external-event-handler'
+import {
+  CalendarExternalEventSyncService,
+  initCalendarExternalEventSyncService,
+  getCalendarExternalEventSyncService,
+  resetCalendarExternalEventSyncService
+} from './calendar-external-event-sync'
+
+const TEST_SOURCE = {
+  id: 'src-1',
+  provider: 'google',
+  kind: 'calendar' as const,
+  remoteId: 'primary@example.com',
+  title: 'Work'
+}
+
+const TEST_EXTERNAL = {
+  id: 'ext-1',
+  sourceId: 'src-1',
+  remoteEventId: 'google-evt-1',
+  title: 'Imported standup',
+  startAt: '2026-08-05T09:00:00.000Z',
+  endAt: '2026-08-05T09:15:00.000Z'
+}
+
+describe('CalendarExternalEventSyncService', () => {
+  let testDb: TestDatabaseResult
+  let queue: SyncQueueManager
+  let service: CalendarExternalEventSyncService
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    queue = new SyncQueueManager(asClientDb(testDb.db))
+    service = new CalendarExternalEventSyncService({
+      queue,
+      db: asSyncDb(testDb.db),
+      getDeviceId: () => 'device-A'
+    })
+    testDb.db.insert(calendarSources).values(TEST_SOURCE).run()
+  })
+
+  afterEach(() => {
+    resetCalendarExternalEventSyncService()
+    testDb.close()
+  })
+
+  describe('#given a local external event exists #when enqueueCreate called', () => {
+    it('#then enqueues a calendar_external_event create with a bumped clock', () => {
+      testDb.db.insert(calendarExternalEvents).values(TEST_EXTERNAL).run()
+
+      service.enqueueCreate('ext-1')
+
+      const [item] = queue.dequeue(1)
+      expect(item.type).toBe('calendar_external_event')
+      expect(item.itemId).toBe('ext-1')
+      expect(item.operation).toBe('create')
+
+      const payload = JSON.parse(item.payload)
+      expect(payload.sourceId).toBe('src-1')
+      expect(payload.remoteEventId).toBe('google-evt-1')
+      expect(payload.title).toBe('Imported standup')
+      expect(payload.clock).toEqual({ 'device-A': 1 })
+    })
+
+    it('#then the enqueued payload still parses as a CalendarExternalEventSyncPayload', () => {
+      testDb.db.insert(calendarExternalEvents).values(TEST_EXTERNAL).run()
+
+      service.enqueueCreate('ext-1')
+
+      const [item] = queue.dequeue(1)
+      const parsed = CalendarExternalEventSyncPayloadSchema.parse(JSON.parse(item.payload))
+      // sourceId is the FK the receiving device needs to reattach the event to
+      // its calendar — losing it here would strand the event on every peer.
+      expect(parsed.sourceId).toBe('src-1')
+      expect(parsed.status).toBe('confirmed')
+    })
+  })
+
+  describe('#given an external event with an existing clock #when enqueueUpdate called', () => {
+    it('#then persists the incremented clock on the row and ships the same clock', () => {
+      const existingClock: VectorClock = { 'device-A': 3, 'device-B': 1 }
+      testDb.db
+        .insert(calendarExternalEvents)
+        .values({ ...TEST_EXTERNAL, clock: existingClock })
+        .run()
+
+      service.enqueueUpdate('ext-1')
+
+      const row = testDb.db
+        .select()
+        .from(calendarExternalEvents)
+        .where(eq(calendarExternalEvents.id, 'ext-1'))
+        .get()
+      expect(row?.clock).toEqual({ 'device-A': 4, 'device-B': 1 })
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('update')
+      expect(JSON.parse(item.payload).clock).toEqual({ 'device-A': 4, 'device-B': 1 })
+    })
+  })
+
+  describe('#given a change arrived from sync #when the handler applies it', () => {
+    it('#then nothing is enqueued for push (no echo back to the server)', () => {
+      const result = calendarExternalEventHandler.applyUpsert(
+        { db: asSyncDb(testDb.db), emit: vi.fn() },
+        'ext-1',
+        {
+          sourceId: 'src-1',
+          remoteEventId: 'google-evt-1',
+          title: 'Imported standup',
+          startAt: '2026-08-05T09:00:00.000Z'
+        },
+        { 'device-B': 1 }
+      )
+
+      expect(result).toBe('applied')
+      expect(queue.getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('#given the calendar_source it references is not present locally', () => {
+    it('#then the row cannot even exist locally — the FK is enforced', () => {
+      expect(() =>
+        testDb.db
+          .insert(calendarExternalEvents)
+          .values({ ...TEST_EXTERNAL, id: 'ext-orphan', sourceId: 'src-never-synced' })
+          .run()
+      ).toThrow(/FOREIGN KEY constraint failed/)
+    })
+
+    // PRODUCT BUG (candidate root cause for "Google Calendar says connected but
+    // no events appear" on a second device).
+    //
+    // calendar_external_events.source_id is a real FK to calendar_sources with
+    // ON DELETE cascade. When a pull hands the external event to the handler
+    // before its calendar_source has landed (both are ordinary sync items with
+    // no ordering guarantee, and the source can easily sit outside this run's
+    // cursor window), the insert raises a bare SQLite "FOREIGN KEY constraint
+    // failed".
+    //
+    // The established convention for that case — see
+    // item-handlers/types.ts MissingSyncParentError and engine/orphan-repair.ts
+    // — is for the handler to throw MissingSyncParentError so the pull
+    // coordinator can defer, re-fetch the parent by id, and either repair the
+    // child or tombstone it (#837). Today only task-handler.ts does that.
+    // calendar-external-event-handler.ts inserts blind, so the pull coordinator
+    // sees an unclassified error, retries once, then logs
+    // "item skipped until next remote update" and drops the event. There is no
+    // next remote update for an unchanged Google event, so the events never
+    // appear on that device — while the calendar_source itself syncs fine and
+    // the UI still reports "connected".
+    //
+    // Worse, the insert defaults `sourceId` to the literal 'unknown-source'
+    // when the payload omits it, which can only ever FK-fail.
+    it.fails('#then the handler reports it as a typed missing-parent, not a raw FK error', () => {
+      expect(() =>
+        calendarExternalEventHandler.applyUpsert(
+          { db: asSyncDb(testDb.db), emit: vi.fn() },
+          'ext-orphan',
+          {
+            sourceId: 'src-never-synced',
+            remoteEventId: 'google-evt-orphan',
+            title: 'Imported standup',
+            startAt: '2026-08-05T09:00:00.000Z'
+          },
+          { 'device-B': 1 }
+        )
+      ).toThrow(MissingSyncParentError)
+    })
+  })
+
+  describe('#given an external event and a local event share an id', () => {
+    it('#then enqueueUpdate pushes the imported row, never the local calendar_event', () => {
+      testDb.db
+        .insert(calendarEvents)
+        .values({
+          id: 'shared-id',
+          title: 'Local standup',
+          startAt: '2026-08-05T09:00:00.000Z'
+        })
+        .run()
+      testDb.db
+        .insert(calendarExternalEvents)
+        .values({ ...TEST_EXTERNAL, id: 'shared-id' })
+        .run()
+
+      service.enqueueUpdate('shared-id')
+
+      const [item] = queue.dequeue(1)
+      expect(item.type).toBe('calendar_external_event')
+      const payload = JSON.parse(item.payload)
+      expect(payload.title).toBe('Imported standup')
+      expect(payload.sourceId).toBe('src-1')
+
+      // The local event keeps its own identity and clock — a Google-originated
+      // change never bumps it.
+      const localEvent = testDb.db
+        .select()
+        .from(calendarEvents)
+        .where(eq(calendarEvents.id, 'shared-id'))
+        .get()
+      expect(localEvent?.title).toBe('Local standup')
+      expect(localEvent?.clock).toBeNull()
+    })
+  })
+
+  describe('#given the row is not present locally #when enqueueCreate called', () => {
+    it('#then the outbound push is dropped with no error and no queue entry', () => {
+      service.enqueueCreate('ext-missing')
+
+      expect(queue.getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('#given no device id #when enqueueCreate called', () => {
+    it('#then skips silently', () => {
+      const noDevice = new CalendarExternalEventSyncService({
+        queue,
+        db: asSyncDb(testDb.db),
+        getDeviceId: () => null
+      })
+      testDb.db.insert(calendarExternalEvents).values(TEST_EXTERNAL).run()
+
+      noDevice.enqueueCreate('ext-1')
+
+      expect(queue.getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('#when enqueueDelete called', () => {
+    it('#then a snapshot payload is shipped with an incremented clock', () => {
+      const snapshot = JSON.stringify({ ...TEST_EXTERNAL, clock: { 'device-A': 2 } })
+
+      service.enqueueDelete('ext-1', snapshot)
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('delete')
+      expect(item.type).toBe('calendar_external_event')
+      expect(JSON.parse(item.payload).clock).toEqual({ 'device-A': 3 })
+    })
+
+    it('#then a delete with neither snapshot nor row still enqueues an id-only tombstone', () => {
+      service.enqueueDelete('ext-gone')
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('delete')
+      expect(JSON.parse(item.payload)).toEqual({ id: 'ext-gone', clock: { 'device-A': 1 } })
+    })
+  })
+
+  describe('#given a peer holds the same external event #when the built delete payload is applied there', () => {
+    it('#then the delete propagates rather than being skipped as concurrent', () => {
+      const originClock: VectorClock = { 'device-A': 2 }
+      testDb.db
+        .insert(calendarExternalEvents)
+        .values({ ...TEST_EXTERNAL, clock: originClock })
+        .run()
+
+      service.enqueueDelete('ext-1')
+      const [item] = queue.dequeue(1)
+      const { clock } = JSON.parse(item.payload) as { clock: VectorClock }
+
+      const peerDb = createTestDataDb()
+      try {
+        peerDb.db.insert(calendarSources).values(TEST_SOURCE).run()
+        peerDb.db
+          .insert(calendarExternalEvents)
+          .values({ ...TEST_EXTERNAL, clock: originClock })
+          .run()
+
+        const result = calendarExternalEventHandler.applyDelete(
+          { db: asSyncDb(peerDb.db), emit: vi.fn() },
+          'ext-1',
+          clock
+        )
+
+        expect(result).toBe('applied')
+        expect(
+          peerDb.db
+            .select()
+            .from(calendarExternalEvents)
+            .where(eq(calendarExternalEvents.id, 'ext-1'))
+            .get()
+        ).toBeUndefined()
+      } finally {
+        peerDb.close()
+      }
+    })
+  })
+
+  describe('module-level accessor', () => {
+    it('#then returns null before init', () => {
+      expect(getCalendarExternalEventSyncService()).toBeNull()
+    })
+
+    it('#then returns the instance after init and null after reset', () => {
+      const svc = initCalendarExternalEventSyncService({
+        queue,
+        db: asSyncDb(testDb.db),
+        getDeviceId: () => 'device-A'
+      })
+      expect(getCalendarExternalEventSyncService()).toBe(svc)
+
+      resetCalendarExternalEventSyncService()
+      expect(getCalendarExternalEventSyncService()).toBeNull()
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/calendar-external-event-sync.test.ts
+++ b/apps/desktop/src/main/sync/calendar-external-event-sync.test.ts
@@ -177,7 +177,7 @@ describe('CalendarExternalEventSyncService', () => {
     //
     // Worse, the insert defaults `sourceId` to the literal 'unknown-source'
     // when the payload omits it, which can only ever FK-fail.
-    it.fails('#then the handler reports it as a typed missing-parent, not a raw FK error', () => {
+    it('#then the handler reports it as a typed missing-parent, not a raw FK error', () => {
       expect(() =>
         calendarExternalEventHandler.applyUpsert(
           { db: asSyncDb(testDb.db), emit: vi.fn() },

--- a/apps/desktop/src/main/sync/calendar-source-sync.test.ts
+++ b/apps/desktop/src/main/sync/calendar-source-sync.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import {
+  createTestDataDb,
+  asClientDb,
+  asSyncDb,
+  type TestDatabaseResult
+} from '@tests/utils/test-db'
+import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
+import { CalendarSourceSyncPayloadSchema } from '@memry/contracts/sync-payloads'
+import type { VectorClock } from '@memry/contracts/sync-api'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { SyncQueueManager } from './queue'
+import { calendarSourceHandler } from './item-handlers/calendar-source-handler'
+import {
+  CalendarSourceSyncService,
+  initCalendarSourceSyncService,
+  getCalendarSourceSyncService,
+  resetCalendarSourceSyncService
+} from './calendar-source-sync'
+
+const TEST_SOURCE = {
+  id: 'src-1',
+  provider: 'google',
+  kind: 'calendar' as const,
+  accountId: 'acct-1',
+  remoteId: 'primary@example.com',
+  title: 'Work',
+  isPrimary: true,
+  isSelected: true
+}
+
+describe('CalendarSourceSyncService', () => {
+  let testDb: TestDatabaseResult
+  let queue: SyncQueueManager
+  let service: CalendarSourceSyncService
+
+  beforeEach(() => {
+    testDb = createTestDataDb()
+    queue = new SyncQueueManager(asClientDb(testDb.db))
+    service = new CalendarSourceSyncService({
+      queue,
+      db: asSyncDb(testDb.db),
+      getDeviceId: () => 'device-A'
+    })
+  })
+
+  afterEach(() => {
+    resetCalendarSourceSyncService()
+    testDb.close()
+  })
+
+  describe('#given a local source exists #when enqueueCreate called', () => {
+    it('#then enqueues a calendar_source create carrying the row and a bumped clock', () => {
+      testDb.db.insert(calendarSources).values(TEST_SOURCE).run()
+
+      service.enqueueCreate('src-1')
+
+      const [item] = queue.dequeue(1)
+      expect(item.type).toBe('calendar_source')
+      expect(item.itemId).toBe('src-1')
+      expect(item.operation).toBe('create')
+
+      const payload = JSON.parse(item.payload)
+      expect(payload.title).toBe('Work')
+      expect(payload.remoteId).toBe('primary@example.com')
+      expect(payload.isSelected).toBe(true)
+      expect(payload.clock).toEqual({ 'device-A': 1 })
+    })
+
+    it('#then the enqueued payload still parses as a CalendarSourceSyncPayload', () => {
+      // serialize() ships the raw drizzle row, so a column the contract does not
+      // know about must not break the receiving device's schema.parse().
+      testDb.db.insert(calendarSources).values(TEST_SOURCE).run()
+
+      service.enqueueCreate('src-1')
+
+      const [item] = queue.dequeue(1)
+      const parsed = CalendarSourceSyncPayloadSchema.parse(JSON.parse(item.payload))
+      expect(parsed.title).toBe('Work')
+      expect(parsed.kind).toBe('calendar')
+    })
+  })
+
+  describe('#given a source with an existing clock #when enqueueUpdate called', () => {
+    it('#then persists the incremented clock on the row and ships the same clock', () => {
+      const existingClock: VectorClock = { 'device-A': 2, 'device-B': 4 }
+      testDb.db
+        .insert(calendarSources)
+        .values({ ...TEST_SOURCE, clock: existingClock })
+        .run()
+
+      service.enqueueUpdate('src-1')
+
+      const row = testDb.db
+        .select()
+        .from(calendarSources)
+        .where(eq(calendarSources.id, 'src-1'))
+        .get()
+      expect(row?.clock).toEqual({ 'device-A': 3, 'device-B': 4 })
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('update')
+      expect(JSON.parse(item.payload).clock).toEqual({ 'device-A': 3, 'device-B': 4 })
+    })
+  })
+
+  describe('#given a change arrived from sync #when the handler applies it', () => {
+    it('#then nothing is enqueued for push (no echo back to the server)', () => {
+      // The inbound path writes through the item handler, never through this
+      // service — that separation IS the echo guard. If a handler ever started
+      // routing writes through enqueueUpdate, every pulled source would bounce
+      // straight back out and ping-pong between devices.
+      const result = calendarSourceHandler.applyUpsert(
+        { db: asSyncDb(testDb.db), emit: vi.fn() },
+        'src-1',
+        {
+          provider: 'google',
+          kind: 'calendar',
+          remoteId: 'primary@example.com',
+          title: 'Work'
+        },
+        { 'device-B': 1 }
+      )
+
+      expect(result).toBe('applied')
+      expect(queue.getPendingCount()).toBe(0)
+
+      const row = testDb.db
+        .select()
+        .from(calendarSources)
+        .where(eq(calendarSources.id, 'src-1'))
+        .get()
+      expect(row?.clock).toEqual({ 'device-B': 1 })
+    })
+  })
+
+  describe('#given the row is not present locally #when enqueueCreate called', () => {
+    it('#then the outbound push is dropped with no error and no queue entry', () => {
+      // Documented current behaviour: RecordSyncController.load() returning
+      // undefined is an unconditional silent return. A caller that enqueues
+      // before the insert commits loses the push entirely.
+      service.enqueueCreate('src-missing')
+
+      expect(queue.getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('#given no device id #when enqueueCreate called', () => {
+    it('#then skips silently', () => {
+      const noDevice = new CalendarSourceSyncService({
+        queue,
+        db: asSyncDb(testDb.db),
+        getDeviceId: () => null
+      })
+      testDb.db.insert(calendarSources).values(TEST_SOURCE).run()
+
+      noDevice.enqueueCreate('src-1')
+
+      expect(queue.getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('#when enqueueDelete called', () => {
+    it('#then a snapshot payload is shipped with an incremented clock', () => {
+      const snapshot = JSON.stringify({ ...TEST_SOURCE, clock: { 'device-A': 2 } })
+
+      service.enqueueDelete('src-1', snapshot)
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('delete')
+      expect(item.type).toBe('calendar_source')
+      const payload = JSON.parse(item.payload)
+      expect(payload.title).toBe('Work')
+      expect(payload.clock).toEqual({ 'device-A': 3 })
+    })
+
+    it('#then a delete with no snapshot still ships the row and its bumped clock', () => {
+      testDb.db
+        .insert(calendarSources)
+        .values({ ...TEST_SOURCE, clock: { 'device-A': 2 } })
+        .run()
+
+      service.enqueueDelete('src-1')
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('delete')
+      expect(JSON.parse(item.payload).clock).toEqual({ 'device-A': 3 })
+    })
+
+    it('#then a delete with neither snapshot nor row still enqueues an id-only tombstone', () => {
+      service.enqueueDelete('src-gone')
+
+      const [item] = queue.dequeue(1)
+      expect(item.operation).toBe('delete')
+      expect(JSON.parse(item.payload)).toEqual({ id: 'src-gone', clock: { 'device-A': 1 } })
+    })
+  })
+
+  describe('#given a peer holds the same source #when the built delete payload is applied there', () => {
+    it('#then the delete propagates rather than being skipped as concurrent', () => {
+      const originClock: VectorClock = { 'device-A': 2 }
+      testDb.db
+        .insert(calendarSources)
+        .values({ ...TEST_SOURCE, clock: originClock })
+        .run()
+
+      service.enqueueDelete('src-1')
+      const [item] = queue.dequeue(1)
+      const { clock } = JSON.parse(item.payload) as { clock: VectorClock }
+
+      const peerDb = createTestDataDb()
+      try {
+        peerDb.db
+          .insert(calendarSources)
+          .values({ ...TEST_SOURCE, clock: originClock })
+          .run()
+
+        const result = calendarSourceHandler.applyDelete(
+          { db: asSyncDb(peerDb.db), emit: vi.fn() },
+          'src-1',
+          clock
+        )
+
+        expect(result).toBe('applied')
+        const row = peerDb.db
+          .select()
+          .from(calendarSources)
+          .where(eq(calendarSources.id, 'src-1'))
+          .get()
+        expect(row).toBeUndefined()
+      } finally {
+        peerDb.close()
+      }
+    })
+  })
+
+  describe('module-level accessor', () => {
+    it('#then returns null before init', () => {
+      expect(getCalendarSourceSyncService()).toBeNull()
+    })
+
+    it('#then returns the instance after init and null after reset', () => {
+      const svc = initCalendarSourceSyncService({
+        queue,
+        db: asSyncDb(testDb.db),
+        getDeviceId: () => 'device-A'
+      })
+      expect(getCalendarSourceSyncService()).toBe(svc)
+
+      resetCalendarSourceSyncService()
+      expect(getCalendarSourceSyncService()).toBeNull()
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/canvas-sync.test.ts
+++ b/apps/desktop/src/main/sync/canvas-sync.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { canvases } from '@memry/db-schema/data-schema'
+import { syncQueue } from '@memry/db-schema/schema/sync-queue'
+import { CanvasSyncPayloadSchema } from '@memry/contracts/sync-payloads'
+import { createTestDataDb, type TestDataDb } from '../../test/helpers/test-data-db'
+
+/**
+ * Push side of canvas sync. Real `RecordSyncController`, real
+ * `SyncQueueManager`, real migrated in-memory data DB.
+ *
+ * The queued payload is deliberately metadata-only (no `scene`) — the
+ * scene-bearing payload is rebuilt with the vault key by
+ * `canvas-handler.buildPushPayload` at push time.
+ */
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { SyncQueueManager } from './queue'
+import {
+  CanvasSyncService,
+  getCanvasSyncService,
+  initCanvasSyncService,
+  resetCanvasSyncService
+} from './canvas-sync'
+
+let db: TestDataDb
+let queue: SyncQueueManager
+
+function seedCanvas(overrides: Record<string, unknown> = {}): void {
+  db.insert(canvases)
+    .values({
+      id: 'canvas-1',
+      vaultId: 'vault-1',
+      title: 'Roadmap Sketch',
+      filePath: 'canvases/Roadmap Sketch.excalidraw',
+      snapshotCiphertext: '',
+      vectorClock: {},
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_001_000,
+      clock: {},
+      ...overrides
+    } as never)
+    .run()
+}
+
+function queueRows(): Array<typeof syncQueue.$inferSelect> {
+  return db.select().from(syncQueue).all()
+}
+
+function payloadOf(row: typeof syncQueue.$inferSelect | undefined): Record<string, unknown> {
+  return JSON.parse(row!.payload) as Record<string, unknown>
+}
+
+function storedClock(id = 'canvas-1'): unknown {
+  return db.select().from(canvases).where(eq(canvases.id, id)).get()?.clock
+}
+
+function makeService(deviceId: string | null = 'device-a'): CanvasSyncService {
+  return new CanvasSyncService({ queue, db, getDeviceId: () => deviceId })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  db = createTestDataDb()
+  queue = new SyncQueueManager(db)
+  resetCanvasSyncService()
+})
+
+describe('CanvasSyncService push', () => {
+  it('enqueues exactly one canvas create carrying the title the user gave it', () => {
+    seedCanvas()
+
+    makeService().enqueueCreate('canvas-1')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].type).toBe('canvas')
+    expect(rows[0].itemId).toBe('canvas-1')
+    expect(rows[0].operation).toBe('create')
+
+    const payload = payloadOf(rows[0])
+    expect(payload).toEqual({
+      id: 'canvas-1',
+      vaultId: 'vault-1',
+      title: 'Roadmap Sketch',
+      clock: { 'device-a': 1 },
+      deletedAt: null
+    })
+    expect(CanvasSyncPayloadSchema.safeParse(payload).success).toBe(true)
+    // Metadata only by design: the receiver skips a scene-less payload rather
+    // than clobbering good ink.
+    expect(payload).not.toHaveProperty('scene')
+  })
+
+  it('persists the bumped clock on the canvas row', () => {
+    seedCanvas({ clock: { 'device-b': 3 } })
+
+    makeService().enqueueUpdate('canvas-1')
+
+    expect(storedClock()).toEqual({ 'device-b': 3, 'device-a': 1 })
+    expect(payloadOf(queueRows()[0]).clock).toEqual({ 'device-b': 3, 'device-a': 1 })
+  })
+
+  it('seeds a clock for a legacy row that never had one', () => {
+    seedCanvas({ clock: null })
+
+    makeService().enqueueCreate('canvas-1')
+
+    expect(storedClock()).toEqual({ 'device-a': 1 })
+    expect(payloadOf(queueRows()[0]).clock).toEqual({ 'device-a': 1 })
+  })
+
+  it('coalesces a rename into the pending push and keeps the newest title', () => {
+    seedCanvas()
+    const service = makeService()
+
+    service.enqueueCreate('canvas-1')
+    db.update(canvases).set({ title: 'Q3 Roadmap' }).where(eq(canvases.id, 'canvas-1')).run()
+    service.enqueueUpdate('canvas-1')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('create')
+    expect(payloadOf(rows[0]).title).toBe('Q3 Roadmap')
+  })
+
+  it('skips a canvas that has no row', () => {
+    makeService().enqueueUpdate('ghost-canvas')
+
+    expect(queueRows()).toEqual([])
+  })
+
+  it('skips every mutation while there is no device id', () => {
+    seedCanvas()
+    const service = makeService(null)
+
+    service.enqueueCreate('canvas-1')
+    service.enqueueUpdate('canvas-1')
+    service.enqueueDelete('canvas-1')
+
+    expect(queueRows()).toEqual([])
+    expect(storedClock()).toEqual({})
+  })
+
+  it('exposes the device id it was constructed with', () => {
+    expect(makeService('device-z').getDeviceId()).toBe('device-z')
+    expect(makeService(null).getDeviceId()).toBeNull()
+  })
+})
+
+describe('CanvasSyncService deletes', () => {
+  it('propagates a delete and persists the bumped clock on the tombstone row', () => {
+    seedCanvas({ clock: { 'device-a': 2 }, deletedAt: 1_700_000_009_000 })
+
+    makeService().enqueueDelete('canvas-1')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].type).toBe('canvas')
+    expect(rows[0].operation).toBe('delete')
+    expect(payloadOf(rows[0])).toEqual({
+      id: 'canvas-1',
+      vaultId: 'vault-1',
+      clock: { 'device-a': 3 },
+      deletedAt: 1_700_000_009_000
+    })
+    // The bumped clock has to survive on the row so a later concurrent edit
+    // resolves against the delete rather than silently winning.
+    expect(storedClock()).toEqual({ 'device-a': 3 })
+  })
+
+  it('lets a delete win over a still-pending create instead of being dropped', () => {
+    seedCanvas()
+    const service = makeService()
+
+    service.enqueueCreate('canvas-1')
+    service.enqueueDelete('canvas-1')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('delete')
+  })
+
+  it('drops a delete for a canvas row that no longer exists', () => {
+    // Canvas deletes are soft, so the tombstone row is always still present in
+    // the real flow; a hard-missing row has no clock to advance.
+    makeService().enqueueDelete('never-existed')
+
+    expect(queueRows()).toEqual([])
+  })
+})
+
+describe('CanvasSyncService local-only clock bumps', () => {
+  it('advances the clock without enqueueing any push', () => {
+    seedCanvas({ clock: { 'device-a': 1 } })
+
+    makeService().bumpClockLocalOnly('canvas-1')
+
+    // A save that is kept locally but is too large to sync must still move the
+    // clock, or a later remote edit dominates it and overwrites the local ink.
+    expect(storedClock()).toEqual({ 'device-a': 2 })
+    expect(queueRows()).toEqual([])
+  })
+
+  it('no-ops without a device id or without a row', () => {
+    seedCanvas()
+
+    makeService(null).bumpClockLocalOnly('canvas-1')
+    expect(storedClock()).toEqual({})
+
+    makeService().bumpClockLocalOnly('ghost-canvas')
+    expect(queueRows()).toEqual([])
+  })
+})
+
+describe('CanvasSyncService conflict-copy pushes', () => {
+  it('enqueues the handler-built payload verbatim, bypassing serialize', () => {
+    const payload = JSON.stringify({
+      id: 'canvas-copy',
+      vaultId: 'vault-1',
+      title: 'Roadmap Sketch (conflict copy)',
+      scene: 'encrypted-scene',
+      clock: { 'device-a': 1 }
+    })
+
+    makeService().enqueueConflictCopyPush('canvas-copy', payload)
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].type).toBe('canvas')
+    expect(rows[0].itemId).toBe('canvas-copy')
+    expect(rows[0].operation).toBe('create')
+    expect(rows[0].payload).toBe(payload)
+    // This is the one push the apply path is allowed to raise: the conflict
+    // copy is new local content, not an echo of what was just pulled.
+    expect(payloadOf(rows[0]).scene).toBe('encrypted-scene')
+  })
+})
+
+describe('canvas sync service lifecycle', () => {
+  it('tracks the module-level singleton', () => {
+    expect(getCanvasSyncService()).toBeNull()
+
+    const service = initCanvasSyncService({ queue, db, getDeviceId: () => 'device-a' })
+    expect(getCanvasSyncService()).toBe(service)
+
+    resetCanvasSyncService()
+    expect(getCanvasSyncService()).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/sync/compress.test.ts
+++ b/apps/desktop/src/main/sync/compress.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+import { compressPayload, decompressPayload } from './compress'
+
+// compressPayload/decompressPayload sit INSIDE the crypto envelope: push
+// compresses before encrypting, pull decompresses after decrypting. Any loss
+// here is silent data corruption that no signature check can catch, because
+// the bytes are signed AFTER compression. Round-trip fidelity is the whole
+// contract.
+
+const FLAG_RAW = 0x00
+const FLAG_DEFLATE = 0x01
+
+function bytes(...values: number[]): Uint8Array {
+  return new Uint8Array(values)
+}
+
+function repeat(byte: number, length: number): Uint8Array {
+  return new Uint8Array(length).fill(byte)
+}
+
+/** Deterministic pseudo-random bytes — incompressible, and stable across runs. */
+function pseudoRandomBytes(length: number, seed = 1): Uint8Array {
+  const out = new Uint8Array(length)
+  let state = seed
+  for (let i = 0; i < length; i++) {
+    state = (state * 1664525 + 1013904223) >>> 0
+    out[i] = state >>> 24
+  }
+  return out
+}
+
+describe('compressPayload / decompressPayload', () => {
+  describe('#given payloads of every shape #when round-tripped', () => {
+    it('#then decompress returns byte-identical input', () => {
+      const cases: Array<[string, Uint8Array]> = [
+        ['empty', new Uint8Array(0)],
+        ['single byte', bytes(0)],
+        ['single 0xff byte', bytes(0xff)],
+        ['short utf8', new TextEncoder().encode('hello world')],
+        ['63 bytes (below the compression threshold)', repeat(0x41, 63)],
+        ['64 bytes (at the compression threshold)', repeat(0x41, 64)],
+        ['65 bytes (above the compression threshold)', repeat(0x41, 65)],
+        ['all 256 byte values', new Uint8Array(Array.from({ length: 256 }, (_, i) => i))],
+        ['highly compressible 100KB', repeat(0x7a, 100_000)],
+        ['incompressible 100KB', pseudoRandomBytes(100_000)],
+        [
+          '1MB note-sized JSON',
+          new TextEncoder().encode(JSON.stringify({ b: 'x'.repeat(1_000_000) }))
+        ],
+        ['embedded NUL bytes', bytes(1, 0, 2, 0, 0, 3)],
+        ['lone surrogate bytes (invalid utf8)', bytes(0xed, 0xa0, 0x80, 0xff, 0xfe)]
+      ]
+
+      for (const [label, input] of cases) {
+        const restored = decompressPayload(compressPayload(input))
+        expect(restored, label).toEqual(input)
+        expect(restored.byteLength, label).toBe(input.byteLength)
+      }
+    })
+
+    it('#then the input buffer is never mutated in place', () => {
+      // The caller (encryptItemForPush) still owns `content` after this call.
+      const input = repeat(0x5a, 4096)
+      const snapshot = input.slice()
+
+      compressPayload(input)
+
+      expect(input).toEqual(snapshot)
+    })
+  })
+
+  describe('#given payloads below the 64-byte threshold #when compressed', () => {
+    it('#then they are stored raw with a 1-byte flag prefix', () => {
+      const input = new TextEncoder().encode('short')
+
+      const compressed = compressPayload(input)
+
+      expect(compressed[0]).toBe(FLAG_RAW)
+      expect(compressed.byteLength).toBe(input.byteLength + 1)
+      expect(compressed.subarray(1)).toEqual(input)
+    })
+
+    it('#then empty input still carries the flag byte', () => {
+      const compressed = compressPayload(new Uint8Array(0))
+
+      expect(compressed.byteLength).toBe(1)
+      expect(compressed[0]).toBe(FLAG_RAW)
+      expect(decompressPayload(compressed)).toEqual(new Uint8Array(0))
+    })
+  })
+
+  describe('#given a large compressible payload #when compressed', () => {
+    it('#then it is deflated and marked with the deflate flag', () => {
+      const input = repeat(0x61, 50_000)
+
+      const compressed = compressPayload(input)
+
+      expect(compressed[0]).toBe(FLAG_DEFLATE)
+      expect(compressed.byteLength).toBeLessThan(input.byteLength)
+      expect(decompressPayload(compressed)).toEqual(input)
+    })
+  })
+
+  describe('#given a large incompressible payload #when compressed', () => {
+    it('#then it falls back to raw rather than growing the payload', () => {
+      // Deflate expands random data. Without the fallback every binary
+      // attachment would push MORE bytes than it has, against a 5MB cap.
+      const input = pseudoRandomBytes(20_000, 7)
+
+      const compressed = compressPayload(input)
+
+      expect(compressed[0]).toBe(FLAG_RAW)
+      expect(compressed.byteLength).toBe(input.byteLength + 1)
+      expect(decompressPayload(compressed)).toEqual(input)
+    })
+  })
+
+  describe('#given malformed compressed input #when decompressed', () => {
+    it('#then a deflate-flagged garbage body throws instead of yielding partial bytes', () => {
+      // A truncated/corrupt R2 body must surface as a decrypt-path failure, not
+      // as silently truncated note content.
+      const garbage = new Uint8Array([FLAG_DEFLATE, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x01])
+
+      expect(() => decompressPayload(garbage)).toThrow()
+    })
+
+    // BUG: pako's `inflate()` only assigns `result` when the deflate stream
+    // ENDS. A truncated stream leaves err === 0 and result === undefined, so
+    // `pako.inflate()` returns undefined without throwing — and
+    // decompressPayload hands that back while claiming a `Uint8Array` return
+    // type. Downstream, decrypt.ts wraps it as `{ content: undefined,
+    // verified: true }` and decrypt-item.ts turns it into '' via
+    // `new TextDecoder().decode(undefined)`: a truncated payload is reported
+    // as a SUCCESSFUL decrypt of an empty item, which applies as a content
+    // wipe rather than a failure. The AEAD tag covers the compressed bytes, so
+    // this is only reachable when a writer emits a short stream (not from
+    // transport corruption) — but the failure mode is silent data loss.
+    // Fix: treat an undefined inflate result as an error in decompressPayload.
+    it.fails('#then a truncated deflate body throws instead of returning nothing', () => {
+      const full = compressPayload(repeat(0x62, 50_000))
+      const truncated = full.slice(0, Math.floor(full.byteLength / 2))
+
+      expect(() => decompressPayload(truncated)).toThrow()
+    })
+
+    it('#then a truncated deflate body currently yields no bytes at all', () => {
+      // Pins the observed behaviour behind the bug above so a change is loud.
+      const full = compressPayload(repeat(0x62, 50_000))
+      const truncated = full.slice(0, Math.floor(full.byteLength / 2))
+
+      expect(decompressPayload(truncated)).toBeUndefined()
+    })
+
+    it('#then a deflate body with a flipped byte throws', () => {
+      const full = compressPayload(repeat(0x63, 50_000))
+      const corrupted = full.slice()
+      corrupted[5] = corrupted[5] ^ 0xff
+
+      expect(() => decompressPayload(corrupted)).toThrow()
+    })
+
+    it('#then a zero-length buffer is returned as-is rather than throwing', () => {
+      // Guard clause: a 0-byte body has no flag byte to read.
+      const empty = new Uint8Array(0)
+
+      expect(decompressPayload(empty)).toEqual(empty)
+    })
+  })
+
+  describe('#given an unknown flag byte #when decompressed', () => {
+    it('#then the body is returned raw (unknown flags are treated as uncompressed)', () => {
+      // Documented consequence: if a future writer ever introduces flag 0x02,
+      // an older client returns the still-encoded body as if it were plaintext
+      // instead of failing. Today only 0x00/0x01 are ever written, and the
+      // cryptoVersion gate in decrypt.ts is what guards format changes.
+      const body = new TextEncoder().encode('payload')
+      const unknownFlag = new Uint8Array(1 + body.byteLength)
+      unknownFlag[0] = 0x02
+      unknownFlag.set(body, 1)
+
+      expect(decompressPayload(unknownFlag)).toEqual(body)
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/compress.test.ts
+++ b/apps/desktop/src/main/sync/compress.test.ts
@@ -124,31 +124,19 @@ describe('compressPayload / decompressPayload', () => {
       expect(() => decompressPayload(garbage)).toThrow()
     })
 
-    // BUG: pako's `inflate()` only assigns `result` when the deflate stream
-    // ENDS. A truncated stream leaves err === 0 and result === undefined, so
-    // `pako.inflate()` returns undefined without throwing — and
-    // decompressPayload hands that back while claiming a `Uint8Array` return
-    // type. Downstream, decrypt.ts wraps it as `{ content: undefined,
-    // verified: true }` and decrypt-item.ts turns it into '' via
-    // `new TextDecoder().decode(undefined)`: a truncated payload is reported
-    // as a SUCCESSFUL decrypt of an empty item, which applies as a content
-    // wipe rather than a failure. The AEAD tag covers the compressed bytes, so
-    // this is only reachable when a writer emits a short stream (not from
-    // transport corruption) — but the failure mode is silent data loss.
-    // Fix: treat an undefined inflate result as an error in decompressPayload.
-    it.fails('#then a truncated deflate body throws instead of returning nothing', () => {
+    // pako's `inflate()` only assigns `result` when the deflate stream ENDS. A
+    // truncated stream leaves err === 0 and result === undefined, so
+    // `pako.inflate()` returns undefined WITHOUT throwing. decompressPayload
+    // must convert that into a throw: otherwise decrypt.ts wraps it as
+    // `{ content: undefined, verified: true }` and decrypt-item.ts turns it
+    // into '' via `new TextDecoder().decode(undefined)` — a truncated payload
+    // reported as a SUCCESSFUL decrypt of an empty item, which applies as a
+    // content wipe rather than a failure.
+    it('#then a truncated deflate body throws instead of returning nothing', () => {
       const full = compressPayload(repeat(0x62, 50_000))
       const truncated = full.slice(0, Math.floor(full.byteLength / 2))
 
-      expect(() => decompressPayload(truncated)).toThrow()
-    })
-
-    it('#then a truncated deflate body currently yields no bytes at all', () => {
-      // Pins the observed behaviour behind the bug above so a change is loud.
-      const full = compressPayload(repeat(0x62, 50_000))
-      const truncated = full.slice(0, Math.floor(full.byteLength / 2))
-
-      expect(decompressPayload(truncated)).toBeUndefined()
+      expect(() => decompressPayload(truncated)).toThrow(/incomplete deflate stream/)
     })
 
     it('#then a deflate body with a flipped byte throws', () => {

--- a/apps/desktop/src/main/sync/compress.ts
+++ b/apps/desktop/src/main/sync/compress.ts
@@ -23,7 +23,25 @@ export function decompressPayload(data: Uint8Array): Uint8Array {
   const payload = data.subarray(1)
 
   if (flag === FLAG_DEFLATE) {
-    return pako.inflate(payload)
+    // pako throws for a corrupt stream, but a TRUNCATED one is different: the
+    // inflator never reaches Z_STREAM_END, so `onEnd` never runs, `err` stays 0
+    // and `inflate()` returns `undefined` without throwing. Handing that back
+    // under a `Uint8Array` return type makes decrypt.ts report
+    // `{ content: undefined, verified: true }`, which decrypt-item.ts decodes
+    // to '' — a truncated body becomes a SUCCESSFUL decrypt of an empty item
+    // and the applier writes it as a content wipe. Throw instead, matching how
+    // this function already reports a corrupt stream.
+    //
+    // Backward compatible: a deflate stream that ends normally always leaves a
+    // defined result (pako's onEnd assigns `flattenChunks(chunks)`, which is an
+    // empty Uint8Array when there is no output, never undefined). So every
+    // payload that decompresses today still decompresses; only the streams that
+    // already produced no usable bytes now surface as a failure.
+    const inflated = pako.inflate(payload) as Uint8Array | undefined
+    if (inflated === undefined) {
+      throw new Error('Failed to decompress payload: incomplete deflate stream')
+    }
+    return inflated
   }
 
   return payload

--- a/apps/desktop/src/main/sync/content-sync-base.test.ts
+++ b/apps/desktop/src/main/sync/content-sync-base.test.ts
@@ -1,0 +1,445 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type Logger from 'electron-log'
+import type { SyncItemType, VectorClock } from '@memry/contracts/sync-api'
+import type { NoteMetadata } from '@memry/db-schema/data-schema'
+import { ContentSyncService } from './content-sync-base'
+
+// The base class every note/journal/canvas-style content sync service extends.
+// Its decision surface is small but load-bearing for a paying multi-device
+// user: which local rows are allowed to leave the device, how the vector clock
+// advances (and is persisted) before a push, and which enqueues are dropped.
+// The real RecordSyncController from @memry/sync-core is used deliberately —
+// mocking it (as content-sync-services.test.ts does) hides the wiring this
+// file exists to provide.
+
+const mocks = vi.hoisted(() => ({
+  local: undefined as NoteMetadata | undefined,
+  getNoteMetadataById: vi.fn(),
+  updateNoteMetadata: vi.fn(),
+  log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => mocks.log
+}))
+
+vi.mock('../database/client', () => ({
+  getDatabase: vi.fn(() => ({ __db: 'data' }))
+}))
+
+vi.mock('@memry/storage-data', () => ({
+  getNoteMetadataById: (...args: unknown[]) => mocks.getNoteMetadataById(...args),
+  updateNoteMetadata: (...args: unknown[]) => mocks.updateNoteMetadata(...args)
+}))
+
+interface QueuedItem {
+  type: SyncItemType
+  itemId: string
+  operation: string
+  payload: string
+  priority?: number
+}
+
+function makeQueue(): { items: QueuedItem[]; enqueue: (item: QueuedItem) => string } {
+  const items: QueuedItem[] = []
+  return {
+    items,
+    enqueue(item) {
+      items.push(item)
+      return `queue-${items.length}`
+    }
+  }
+}
+
+function makeNote(overrides: Partial<NoteMetadata> = {}): NoteMetadata {
+  return {
+    id: 'note-1',
+    path: 'notes/Plan.md',
+    title: 'Plan',
+    clock: {},
+    localOnly: false,
+    ...overrides
+  } as NoteMetadata
+}
+
+type SnapshotCall = {
+  cached: NoteMetadata
+  clock: VectorClock
+  operation: 'create' | 'update'
+  extra: string[]
+}
+
+class TestContentSync extends ContentSyncService<Record<string, unknown>, []> {
+  readonly itemType: SyncItemType = 'note'
+  protected readonly log = mocks.log as unknown as Logger.LogFunctions
+  readonly snapshotCalls: SnapshotCall[] = []
+  readonly deleteCalls: Array<{ cached: NoteMetadata | undefined; clock: VectorClock }> = []
+  deletePayload: Record<string, unknown> | null = { tombstone: true }
+
+  protected buildSnapshotPayload(
+    cached: NoteMetadata,
+    clock: VectorClock,
+    operation: 'create' | 'update'
+  ): Record<string, unknown> {
+    this.snapshotCalls.push({ cached, clock, operation, extra: [] })
+    return { id: cached.id, title: cached.title, clock, operation }
+  }
+
+  protected buildDeletePayload(
+    cached: NoteMetadata | undefined,
+    clock: VectorClock
+  ): Record<string, unknown> | null {
+    this.deleteCalls.push({ cached, clock })
+    return this.deletePayload === null ? null : { ...this.deletePayload, clock }
+  }
+}
+
+/** Journal-shaped subclass: extra args (the journal date) must reach both builders. */
+class TestDatedContentSync extends ContentSyncService<Record<string, unknown>, [string]> {
+  readonly itemType: SyncItemType = 'journal'
+  protected readonly log = mocks.log as unknown as Logger.LogFunctions
+  readonly extras: string[][] = []
+
+  protected buildSnapshotPayload(
+    cached: NoteMetadata,
+    clock: VectorClock,
+    operation: 'create' | 'update',
+    date: string
+  ): Record<string, unknown> {
+    this.extras.push(['snapshot', operation, date])
+    return { id: cached.id, date, clock }
+  }
+
+  protected buildDeletePayload(
+    _cached: NoteMetadata | undefined,
+    clock: VectorClock,
+    date: string
+  ): Record<string, unknown> | null {
+    this.extras.push(['delete', date])
+    return { date, clock }
+  }
+}
+
+function makeService(deviceId: string | null = 'dev-a'): {
+  service: TestContentSync
+  queue: ReturnType<typeof makeQueue>
+} {
+  const queue = makeQueue()
+  const service = new TestContentSync({
+    queue: queue as never,
+    getDeviceId: () => deviceId
+  })
+  return { service, queue }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.local = makeNote()
+  mocks.getNoteMetadataById.mockImplementation(() => mocks.local)
+  mocks.updateNoteMetadata.mockImplementation((_db, _id, updates) => ({
+    ...(mocks.local as NoteMetadata),
+    ...updates
+  }))
+})
+
+describe('ContentSyncService', () => {
+  describe('#given a syncable note #when enqueueCreate/enqueueUpdate', () => {
+    it('#then the clock is incremented, persisted, and pushed as one value', () => {
+      // The clock written to the row and the clock inside the payload must be
+      // identical: a divergence means the server records a version the local
+      // row never claims, and the item re-pushes forever.
+      const { service, queue } = makeService()
+      mocks.local = makeNote({ clock: {} })
+
+      service.enqueueCreate('note-1')
+
+      expect(mocks.updateNoteMetadata).toHaveBeenCalledWith({ __db: 'data' }, 'note-1', {
+        clock: { 'dev-a': 1 }
+      })
+      expect(queue.items).toHaveLength(1)
+      expect(queue.items[0]).toMatchObject({
+        type: 'note',
+        itemId: 'note-1',
+        operation: 'create',
+        priority: 0
+      })
+      expect(JSON.parse(queue.items[0].payload)).toEqual({
+        id: 'note-1',
+        title: 'Plan',
+        clock: { 'dev-a': 1 },
+        operation: 'create'
+      })
+    })
+
+    it('#then other devices’ clock entries are preserved, not overwritten', () => {
+      // Dropping a peer entry makes the merge look like a fresh write and
+      // silently wins conflicts it should lose.
+      const { service, queue } = makeService()
+      mocks.local = makeNote({ clock: { 'dev-a': 2, 'dev-b': 7 } as never })
+
+      service.enqueueUpdate('note-1')
+
+      expect(JSON.parse(queue.items[0].payload).clock).toEqual({ 'dev-a': 3, 'dev-b': 7 })
+    })
+
+    it('#then a missing clock column is treated as an empty clock', () => {
+      const { service, queue } = makeService()
+      mocks.local = makeNote({ clock: null as never })
+
+      service.enqueueUpdate('note-1')
+
+      expect(JSON.parse(queue.items[0].payload).clock).toEqual({ 'dev-a': 1 })
+    })
+
+    it('#then the snapshot builder receives the persisted row and the new clock', () => {
+      const { service } = makeService()
+      mocks.local = makeNote({ clock: { 'dev-a': 5 } as never })
+
+      service.enqueueUpdate('note-1')
+
+      expect(service.snapshotCalls).toHaveLength(1)
+      expect(service.snapshotCalls[0].operation).toBe('update')
+      expect(service.snapshotCalls[0].clock).toEqual({ 'dev-a': 6 })
+      expect(service.snapshotCalls[0].cached.clock).toEqual({ 'dev-a': 6 })
+    })
+
+    it('#then the in-memory clock is still used when the row write returns nothing', () => {
+      // updateNoteMetadata returns undefined when the row vanished mid-write
+      // (concurrent delete). The push must still go out with the advanced
+      // clock rather than being dropped.
+      const { service, queue } = makeService()
+      mocks.local = makeNote({ clock: { 'dev-a': 1 } as never })
+      mocks.updateNoteMetadata.mockReturnValue(undefined)
+
+      service.enqueueUpdate('note-1')
+
+      expect(queue.items).toHaveLength(1)
+      expect(JSON.parse(queue.items[0].payload).clock).toEqual({ 'dev-a': 2 })
+    })
+  })
+
+  describe('#given a local-only note #when enqueued', () => {
+    it('#then nothing is queued and no clock is written', () => {
+      // localOnly is the user's "this never leaves my machine" switch. A leak
+      // here uploads private content to the server.
+      const { service, queue } = makeService()
+      mocks.local = makeNote({ localOnly: true })
+
+      service.enqueueCreate('note-1')
+      service.enqueueUpdate('note-1')
+      service.enqueueRecoveredUpdate('note-1')
+
+      expect(queue.items).toEqual([])
+      expect(mocks.updateNoteMetadata).not.toHaveBeenCalled()
+    })
+
+    it('#then a row that becomes local-only during the write is still skipped', () => {
+      const { service, queue } = makeService()
+      mocks.local = makeNote({ localOnly: false })
+      mocks.updateNoteMetadata.mockImplementation((_db, _id, updates) => ({
+        ...makeNote({ localOnly: true }),
+        ...updates
+      }))
+
+      service.enqueueUpdate('note-1')
+
+      expect(queue.items).toEqual([])
+    })
+  })
+
+  describe('#given the note row is missing #when enqueued', () => {
+    it('#then the enqueue is dropped silently and no missing-device warning is logged', () => {
+      const { service, queue } = makeService()
+      mocks.local = undefined
+
+      service.enqueueCreate('gone')
+      service.enqueueUpdate('gone')
+      service.enqueueRecoveredUpdate('gone')
+
+      expect(queue.items).toEqual([])
+      expect(mocks.updateNoteMetadata).not.toHaveBeenCalled()
+      expect(mocks.log.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('#given no device id yet #when enqueued', () => {
+    it('#then the create/update enqueue warns and writes nothing', () => {
+      const { service, queue } = makeService(null)
+
+      service.enqueueCreate('note-1')
+      service.enqueueUpdate('note-1')
+
+      expect(queue.items).toEqual([])
+      expect(mocks.updateNoteMetadata).not.toHaveBeenCalled()
+      expect(mocks.log.warn).toHaveBeenCalledWith('No device ID, skipping note create enqueue', {
+        itemId: 'note-1'
+      })
+      expect(mocks.log.warn).toHaveBeenCalledWith('No device ID, skipping note update enqueue', {
+        itemId: 'note-1'
+      })
+    })
+
+    it('#then the delete enqueue is dropped WITHOUT any warning', () => {
+      // Asymmetry in the shared controller: enqueueDelete returns before
+      // handleMissingDevice, so a delete issued while the device id is
+      // momentarily unavailable disappears with no trace in the log. Recorded
+      // here as current behaviour, not endorsed.
+      const { service, queue } = makeService(null)
+
+      service.enqueueDelete('note-1')
+
+      expect(queue.items).toEqual([])
+      expect(mocks.log.warn).not.toHaveBeenCalled()
+    })
+
+    it('#then the device id is read per enqueue, so sync recovers once it appears', () => {
+      // The controller is built lazily and cached; the device id must NOT be
+      // captured with it, or a service constructed before device registration
+      // stays dead for the whole session.
+      const queue = makeQueue()
+      let deviceId: string | null = null
+      const service = new TestContentSync({
+        queue: queue as never,
+        getDeviceId: () => deviceId
+      })
+
+      service.enqueueUpdate('note-1')
+      expect(queue.items).toEqual([])
+
+      deviceId = 'dev-late'
+      service.enqueueUpdate('note-1')
+
+      expect(queue.items).toHaveLength(1)
+      expect(JSON.parse(queue.items[0].payload).clock).toEqual({ 'dev-late': 1 })
+    })
+  })
+
+  describe('#given a delete #when enqueueDelete', () => {
+    it('#then a tombstone is queued with an advanced clock and serialized once', () => {
+      const { service, queue } = makeService()
+      mocks.local = makeNote({ clock: { 'dev-a': 4 } as never })
+
+      service.enqueueDelete('note-1')
+
+      expect(queue.items).toHaveLength(1)
+      expect(queue.items[0].operation).toBe('delete')
+      expect(typeof queue.items[0].payload).toBe('string')
+      expect(JSON.parse(queue.items[0].payload)).toEqual({
+        tombstone: true,
+        clock: { 'dev-a': 5 }
+      })
+      // The delete path never rewrites the local row's clock.
+      expect(mocks.updateNoteMetadata).not.toHaveBeenCalled()
+    })
+
+    it('#then a builder returning null suppresses the enqueue entirely', () => {
+      const { service, queue } = makeService()
+      service.deletePayload = null
+
+      service.enqueueDelete('note-1')
+
+      expect(queue.items).toEqual([])
+    })
+
+    it('#then a delete for an already-removed row still builds from an empty clock', () => {
+      const { service, queue } = makeService()
+      mocks.local = undefined
+
+      service.enqueueDelete('note-1')
+
+      expect(service.deleteCalls[0].cached).toBeUndefined()
+      expect(service.deleteCalls[0].clock).toEqual({ 'dev-a': 1 })
+      expect(queue.items).toHaveLength(1)
+    })
+
+    // BUG: `shouldSkip` (localOnly) is wired into the snapshot path only — the
+    // controller's delete path never consults it. Deleting a note the user
+    // marked local-only therefore pushes a tombstone, and the real
+    // NoteSyncService.buildDeletePayload puts the note's TITLE in it. A note
+    // that was promised never to leave the device leaks its title to the
+    // server the moment it is deleted. Fix belongs here: apply the same
+    // localOnly guard to buildDeletePayload (return null for local-only rows).
+    it.fails('#then a local-only row is NOT tombstoned to the server', () => {
+      const { service, queue } = makeService()
+      mocks.local = makeNote({ localOnly: true })
+
+      service.enqueueDelete('note-1')
+
+      expect(queue.items).toEqual([])
+    })
+  })
+
+  describe('#given a push that never reached the server #when enqueueRecoveredUpdate', () => {
+    it('#then the stored clock is replayed unchanged and never re-incremented', () => {
+      // Documented contract of enqueueRecoveredUpdate: bumping the clock again
+      // widens the gap with the server instead of closing it. The server
+      // replay-detects an in-step item and just marks it synced.
+      const { service, queue } = makeService()
+      mocks.local = makeNote({ clock: { 'dev-a': 9, 'dev-b': 2 } as never })
+
+      service.enqueueRecoveredUpdate('note-1')
+
+      expect(mocks.updateNoteMetadata).not.toHaveBeenCalled()
+      expect(queue.items).toHaveLength(1)
+      expect(queue.items[0].operation).toBe('update')
+      expect(JSON.parse(queue.items[0].payload).clock).toEqual({ 'dev-a': 9, 'dev-b': 2 })
+    })
+
+    it('#then it is dropped when there is no device id', () => {
+      const { service, queue } = makeService(null)
+
+      service.enqueueRecoveredUpdate('note-1')
+
+      expect(queue.items).toEqual([])
+    })
+  })
+
+  describe('#given a service with extra args #when enqueued', () => {
+    it('#then the extras reach both the snapshot and the delete builder', () => {
+      const queue = makeQueue()
+      const service = new TestDatedContentSync({
+        queue: queue as never,
+        getDeviceId: () => 'dev-a'
+      })
+
+      service.enqueueCreate('journal-1', '2026-08-05')
+      service.enqueueDelete('journal-1', '2026-08-05')
+
+      expect(service.extras).toEqual([
+        ['snapshot', 'create', '2026-08-05'],
+        ['delete', '2026-08-05']
+      ])
+      expect(queue.items.map((i) => i.type)).toEqual(['journal', 'journal'])
+      expect(JSON.parse(queue.items[0].payload).date).toBe('2026-08-05')
+    })
+
+    it('#then a recovered update loses the extras (falls back to empty args)', () => {
+      // enqueueRecoveredUpdate takes no extras by design, so a dated subclass
+      // rebuilds its payload with an empty date. Journal recovery relies on
+      // the date being derivable from the row.
+      const queue = makeQueue()
+      const service = new TestDatedContentSync({
+        queue: queue as never,
+        getDeviceId: () => 'dev-a'
+      })
+
+      service.enqueueRecoveredUpdate('journal-1')
+
+      expect(service.extras).toEqual([['snapshot', 'update', undefined as unknown as string]])
+    })
+  })
+
+  describe('#given repeated enqueues #when the controller is reused', () => {
+    it('#then every enqueue re-reads the row rather than caching the first load', () => {
+      const { service, queue } = makeService()
+      mocks.local = makeNote({ title: 'First', clock: {} })
+
+      service.enqueueUpdate('note-1')
+      mocks.local = makeNote({ title: 'Second', clock: {} })
+      service.enqueueUpdate('note-1')
+
+      expect(queue.items.map((i) => JSON.parse(i.payload).title)).toEqual(['First', 'Second'])
+      expect(mocks.getNoteMetadataById).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/content-sync-base.test.ts
+++ b/apps/desktop/src/main/sync/content-sync-base.test.ts
@@ -352,14 +352,12 @@ describe('ContentSyncService', () => {
       expect(queue.items).toHaveLength(1)
     })
 
-    // BUG: `shouldSkip` (localOnly) is wired into the snapshot path only — the
-    // controller's delete path never consults it. Deleting a note the user
-    // marked local-only therefore pushes a tombstone, and the real
-    // NoteSyncService.buildDeletePayload puts the note's TITLE in it. A note
-    // that was promised never to leave the device leaks its title to the
-    // server the moment it is deleted. Fix belongs here: apply the same
-    // localOnly guard to buildDeletePayload (return null for local-only rows).
-    it.fails('#then a local-only row is NOT tombstoned to the server', () => {
+    // `shouldSkip` (localOnly) is wired into the snapshot path only — the
+    // shared controller's delete path never consults it — so the base class
+    // re-applies the guard inside its buildDeletePayload wrapper. Without it,
+    // deleting a note the user marked local-only pushes a tombstone off the
+    // device, breaking the one promise localOnly makes.
+    it('#then a local-only row is NOT tombstoned to the server', () => {
       const { service, queue } = makeService()
       mocks.local = makeNote({ localOnly: true })
 

--- a/apps/desktop/src/main/sync/content-sync-base.ts
+++ b/apps/desktop/src/main/sync/content-sync-base.ts
@@ -11,6 +11,14 @@ export interface ContentSyncDeps {
   getDeviceId: () => string | null
 }
 
+/**
+ * Single reading of the "never leaves this device" flag, shared by the snapshot
+ * path and the delete path so the two can never drift apart again.
+ */
+function isLocalOnly(local: NoteMetadata | undefined): boolean {
+  return Boolean(local?.localOnly)
+}
+
 export abstract class ContentSyncService<
   TPayload extends Record<string, unknown>,
   TArgs extends string[] = []
@@ -83,8 +91,24 @@ export abstract class ContentSyncService<
       },
       serialize: (local, operation, extra) =>
         this.buildSnapshotPayload(local, (local.clock as VectorClock) ?? {}, operation, ...extra),
-      shouldSkip: (local) => Boolean(local.localOnly),
+      shouldSkip: (local) => isLocalOnly(local),
       buildDeletePayload: ({ local, deviceId, extra }) => {
+        // `localOnly` is the user's "this never leaves my device" switch, and
+        // RecordSyncController wires `shouldSkip` into the create/update path
+        // ONLY — its `enqueueDelete` never consults it. Without re-applying the
+        // guard here, deleting a local-only row queues a tombstone that is
+        // encrypted, uploaded to the server and fanned out to every other
+        // device in the vault. Returning null makes the controller drop the
+        // enqueue before it ever reaches the queue.
+        //
+        // This covers every subclass (notes and journals both load their row
+        // via getNoteMetadataById, so both carry the same `localOnly` column).
+        //
+        // When `local` is undefined the row is already gone and we cannot tell
+        // whether it was local-only, so the pre-existing behaviour stands and
+        // the subclass decides (NoteSyncService returns null in that case).
+        if (isLocalOnly(local)) return null
+
         const nextClock = incrementClock((local?.clock as VectorClock) ?? {}, deviceId)
         const payload = this.buildDeletePayload(local, nextClock, ...extra)
         return payload === null ? null : JSON.stringify(payload)

--- a/apps/desktop/src/main/sync/content-sync-services.test.ts
+++ b/apps/desktop/src/main/sync/content-sync-services.test.ts
@@ -276,10 +276,11 @@ describe('content sync services', () => {
     })
 
     service.enqueueDelete('note-1')
+    // The tombstone carries the clock and nothing the user typed — no title.
     expect(JSON.parse(queue.items[2].payload)).toMatchObject({
-      title: 'Plan',
       clock: { 'dev-a': 1 }
     })
+    expect(JSON.parse(queue.items[2].payload)).not.toHaveProperty('title')
     expect(service.removeQueueItems('note-1')).toBe(1)
   })
 

--- a/apps/desktop/src/main/sync/crdt-preflight-child.test.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-child.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
+import { PREFLIGHT_MARK_BINDING_LOADED, PREFLIGHT_MARK_STARTED } from './crdt-preflight-protocol'
+
+const mockWriteSync = vi.hoisted(() => vi.fn())
+const mockRmSync = vi.hoisted(() => vi.fn())
+const mockRmdirSync = vi.hoisted(() => vi.fn())
+const mockUnlinkSync = vi.hoisted(() => vi.fn())
+const mockRequire = vi.hoisted(() => vi.fn())
+
+// Only the entry points the child actually uses are swapped; everything else
+// stays real so yjs keeps working. The delete-shaped calls are stubbed purely
+// so the test can prove the child never reaches for them.
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    writeSync: mockWriteSync,
+    rmSync: mockRmSync,
+    rmdirSync: mockRmdirSync,
+    unlinkSync: mockUnlinkSync
+  }
+})
+
+// y-leveldb is pulled in through createRequire, not a static import, so the
+// binding is intercepted at the require boundary. Loading the real one here
+// would dlopen classic-level in the test runner.
+vi.mock('module', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('module')>()
+  return { ...actual, createRequire: () => mockRequire }
+})
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+const PROBE_DOC = '__memry_preflight__'
+const STORE_DIR = '/Users/ada/Library/Application Support/memry/crdt-store'
+
+interface FakePersistence {
+  storeUpdate: ReturnType<typeof vi.fn>
+  getYDoc: ReturnType<typeof vi.fn>
+  clearDocument: ReturnType<typeof vi.fn>
+  destroy: ReturnType<typeof vi.fn>
+}
+
+let persistence: FakePersistence
+let constructedWith: string[]
+let loadedDoc: { destroy: ReturnType<typeof vi.fn> }
+let exitSpy: MockInstance<(code?: number) => never>
+let abortSpy: MockInstance<() => never>
+let errorSpy: MockInstance
+
+function makePersistence(): FakePersistence {
+  loadedDoc = { destroy: vi.fn() }
+  return {
+    storeUpdate: vi.fn(async () => undefined),
+    getYDoc: vi.fn(async () => loadedDoc),
+    clearDocument: vi.fn(async () => undefined),
+    destroy: vi.fn(async () => undefined)
+  }
+}
+
+/** Boot the child fresh — it runs `main()` at import time. `null` = no argv[2]. */
+async function runChild(storeDir: string | null = STORE_DIR): Promise<number | undefined> {
+  process.argv = storeDir === null ? ['node', 'child.js'] : ['node', 'child.js', storeDir]
+  vi.resetModules()
+  await import('./crdt-preflight-child')
+  // Every path must terminate: the parent only has a 10s timeout to fall back
+  // on, and a child that neither exits nor crashes stalls CRDT startup.
+  await vi.waitFor(() => expect(exitSpy).toHaveBeenCalled())
+  return exitSpy.mock.calls[0]?.[0]
+}
+
+const marks = (): string[] =>
+  mockWriteSync.mock.calls.filter(([fd]) => fd === 2).map(([, line]) => String(line))
+
+describe('crdt-preflight-child', () => {
+  const originalArgv = process.argv
+  const originalNodeEnv = process.env.NODE_ENV
+  const originalCrashFlag = process.env.MEMRY_TEST_CRDT_PREFLIGHT_CRASH
+
+  beforeEach(() => {
+    persistence = makePersistence()
+    constructedWith = []
+    mockWriteSync.mockReset().mockReturnValue(0)
+    mockRequire.mockReset().mockImplementation((id: string) => {
+      if (id !== 'y-leveldb') throw new Error(`unexpected require: ${id}`)
+      return {
+        LeveldbPersistence: class {
+          constructor(dir: string) {
+            constructedWith.push(dir)
+          }
+          storeUpdate = persistence.storeUpdate
+          getYDoc = persistence.getYDoc
+          clearDocument = persistence.clearDocument
+          destroy = persistence.destroy
+        }
+      }
+    })
+
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    // Guard the runner: a real abort() would take the vitest worker with it.
+    abortSpy = vi.spyOn(process, 'abort').mockImplementation((() => {
+      throw new Error('process.abort() called')
+    }) as never)
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    delete process.env.MEMRY_TEST_CRDT_PREFLIGHT_CRASH
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    process.env.NODE_ENV = originalNodeEnv
+    if (originalCrashFlag === undefined) delete process.env.MEMRY_TEST_CRDT_PREFLIGHT_CRASH
+    else process.env.MEMRY_TEST_CRDT_PREFLIGHT_CRASH = originalCrashFlag
+    vi.restoreAllMocks()
+  })
+
+  describe('success path', () => {
+    it('round-trips a probe doc through the real store and exits 0', async () => {
+      const code = await runChild()
+
+      expect(constructedWith).toEqual([STORE_DIR])
+      expect(persistence.storeUpdate).toHaveBeenCalledTimes(1)
+      const [docName, update] = persistence.storeUpdate.mock.calls[0]
+      expect(docName).toBe(PROBE_DOC)
+      expect(update).toBeInstanceOf(Uint8Array)
+      expect((update as Uint8Array).byteLength).toBeGreaterThan(0)
+
+      expect(persistence.getYDoc).toHaveBeenCalledWith(PROBE_DOC)
+      expect(loadedDoc.destroy).toHaveBeenCalled()
+      expect(code).toBe(0)
+    })
+
+    it('clears the probe doc and closes the store, releasing the LevelDB LOCK', async () => {
+      // Without clearDocument the throwaway doc stays in the user's store
+      // forever; without destroy the LOCK is still held when main opens the
+      // same directory moments later.
+      await runChild()
+
+      expect(persistence.clearDocument).toHaveBeenCalledWith(PROBE_DOC)
+      expect(persistence.destroy).toHaveBeenCalledTimes(1)
+    })
+
+    it('never deletes anything on disk — quarantine is the parent’s decision', async () => {
+      await runChild()
+
+      expect(mockRmSync).not.toHaveBeenCalled()
+      expect(mockRmdirSync).not.toHaveBeenCalled()
+      expect(mockUnlinkSync).not.toHaveBeenCalled()
+    })
+
+    it('probes the exact directory it was handed, including Windows paths', async () => {
+      const windowsDir = 'C:\\Users\\Ada Lovelace\\AppData\\Roaming\\memry\\crdt-store'
+
+      await runChild(windowsDir)
+
+      // No normalization, no re-derivation from app paths: the parent owns the
+      // location, and probing a different directory would prove nothing.
+      expect(constructedWith).toEqual([windowsDir])
+    })
+  })
+
+  describe('stage markers', () => {
+    it('writes "started" to fd 2 before the native binding is touched', async () => {
+      await runChild()
+
+      expect(marks()).toEqual([`${PREFLIGHT_MARK_STARTED}\n`, `${PREFLIGHT_MARK_BINDING_LOADED}\n`])
+      // The ordering is the whole point of the staging protocol: a child that
+      // dies before `started` never ran, which is no verdict on the store.
+      expect(mockWriteSync.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRequire.mock.invocationCallOrder[0]
+      )
+    })
+
+    it('emits markers with writeSync on fd 2, not through the async stream', async () => {
+      // A native abort microseconds later would eat a buffered stream write —
+      // exactly when the parent needs the marker.
+      await runChild()
+
+      expect(mockWriteSync).toHaveBeenCalledTimes(2)
+      for (const [fd] of mockWriteSync.mock.calls) expect(fd).toBe(2)
+    })
+  })
+
+  describe('failure paths', () => {
+    it('exits non-zero without the binding marker when the binding fails to load', async () => {
+      mockRequire.mockImplementation(() => {
+        throw new Error('ERR_DLOPEN_FAILED: classic-level binding')
+      })
+
+      const code = await runChild()
+
+      expect(code).toBe(1)
+      expect(marks()).toEqual([`${PREFLIGHT_MARK_STARTED}\n`])
+      // No binding marker => the parent stages this 'binding' and leaves the
+      // store alone; it was never opened.
+      expect(marks().join('')).not.toContain(PREFLIGHT_MARK_BINDING_LOADED)
+      expect(errorSpy).toHaveBeenCalled()
+    })
+
+    it('exits non-zero with the binding marker already out when the store probe fails', async () => {
+      persistence.storeUpdate.mockRejectedValue(new Error('IO error: MANIFEST corrupt'))
+
+      const code = await runChild()
+
+      expect(code).toBe(1)
+      // Both markers out => the parent stages this 'store', the only stage
+      // worth quarantining for.
+      expect(marks()).toEqual([`${PREFLIGHT_MARK_STARTED}\n`, `${PREFLIGHT_MARK_BINDING_LOADED}\n`])
+      expect(errorSpy).toHaveBeenCalled()
+    })
+
+    it('exits non-zero when a read-back fails after a successful write', async () => {
+      persistence.getYDoc.mockRejectedValue(new Error('IO error: torn LDB'))
+
+      expect(await runChild()).toBe(1)
+      expect(persistence.clearDocument).not.toHaveBeenCalled()
+    })
+
+    it('exits non-zero, without loading the binding, when no probe dir is passed', async () => {
+      const code = await runChild(null)
+
+      expect(code).toBe(1)
+      expect(mockRequire).not.toHaveBeenCalled()
+      expect(errorSpy.mock.calls[0]?.[0]).toBeInstanceOf(Error)
+      expect(String(errorSpy.mock.calls[0]?.[0])).toContain('missing probe directory')
+    })
+  })
+
+  describe('crash injection', () => {
+    it('aborts before the binding loads when the test harness asks for it', async () => {
+      process.env.NODE_ENV = 'test'
+      process.env.MEMRY_TEST_CRDT_PREFLIGHT_CRASH = '1'
+
+      await runChild()
+
+      expect(abortSpy).toHaveBeenCalled()
+      // The real abort never returns; nothing past it may run.
+      expect(mockRequire).not.toHaveBeenCalled()
+      expect(marks()).toEqual([`${PREFLIGHT_MARK_STARTED}\n`])
+    })
+
+    it('is inert in a shipped build even if the flag leaks into the environment', async () => {
+      process.env.NODE_ENV = 'production'
+      process.env.MEMRY_TEST_CRDT_PREFLIGHT_CRASH = '1'
+
+      const code = await runChild()
+
+      expect(abortSpy).not.toHaveBeenCalled()
+      expect(code).toBe(0)
+    })
+
+    it('is inert under the test harness without the flag', async () => {
+      process.env.NODE_ENV = 'test'
+
+      const code = await runChild()
+
+      expect(abortSpy).not.toHaveBeenCalled()
+      expect(code).toBe(0)
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-preflight-protocol.test.ts
+++ b/apps/desktop/src/main/sync/crdt-preflight-protocol.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { PREFLIGHT_MARK_BINDING_LOADED, PREFLIGHT_MARK_STARTED } from './crdt-preflight-protocol'
+
+/**
+ * The child writes these markers to stderr and the parent stages a failure by
+ * substring-matching the accumulated stderr (`crdt-preflight.ts`,
+ * `stageFromMarkers`). The staging decides whether the user's CRDT store gets
+ * quarantined, so the marker strings themselves carry the invariant.
+ *
+ * `CrdtPreflightStage` is a type-only export — nothing to assert at runtime.
+ */
+describe('crdt preflight markers', () => {
+  const markers = [PREFLIGHT_MARK_STARTED, PREFLIGHT_MARK_BINDING_LOADED]
+
+  it('are distinct', () => {
+    expect(PREFLIGHT_MARK_STARTED).not.toBe(PREFLIGHT_MARK_BINDING_LOADED)
+  })
+
+  it('never contain one another, so a started-only child cannot stage as "store"', () => {
+    // The parent tests binding-loaded FIRST. If binding-loaded were a substring
+    // of started, a child that died before touching the native binding would be
+    // staged 'store' and a perfectly healthy store would be quarantined.
+    expect(PREFLIGHT_MARK_STARTED.includes(PREFLIGHT_MARK_BINDING_LOADED)).toBe(false)
+    expect(PREFLIGHT_MARK_BINDING_LOADED.includes(PREFLIGHT_MARK_STARTED)).toBe(false)
+  })
+
+  it('are single-line printable ASCII, survivable through a stderr pipe on any platform', () => {
+    // The child emits them with writeSync(2, ...) — under a Windows console
+    // codepage or a non-UTF-8 locale, anything outside printable ASCII can come
+    // back mangled and stop matching.
+    for (const marker of markers) {
+      expect(marker).toMatch(/^[\x20-\x7e]+$/)
+      expect(marker).not.toMatch(/\s/)
+    }
+  })
+
+  it('are sentinel-shaped so ordinary child stderr never matches by accident', () => {
+    for (const marker of markers) {
+      expect(marker.startsWith('@@memry-preflight:')).toBe(true)
+      expect(marker.endsWith('@@')).toBe(true)
+    }
+
+    const realWorldNoise = [
+      '[1234:0101/000000.123:ERROR:crashpad_client_win.cc(868)] not connected',
+      'IO error: lock /Users/x/Library/Application Support/memry/crdt-store/LOCK: already held',
+      'Error: dlopen failed: NODE_MODULE_VERSION mismatch',
+      '    at Object.<anonymous> (/app.asar/out/main/crdt-preflight-child.js:12:9)',
+      'preflight started; binding loaded'
+    ].join('\n')
+
+    for (const marker of markers) {
+      expect(realWorldNoise.includes(marker)).toBe(false)
+    }
+  })
+})

--- a/apps/desktop/src/main/sync/decrypt-item.test.ts
+++ b/apps/desktop/src/main/sync/decrypt-item.test.ts
@@ -360,12 +360,12 @@ describe('decryptSingleItem', () => {
       }
     }
 
-    // BUG (root cause in compress.ts — see compress.test.ts): pako returns
-    // `undefined` for an incomplete deflate stream instead of throwing, so
-    // this path reports a SUCCESSFUL decrypt of an empty item. Applying that
-    // as an update wipes the note's content on every device. Decrypt failures
-    // must be typed failures; "" is not a decrypt result.
-    it.fails('#then it is reported as a failure, not as an empty success', () => {
+    // Root cause in compress.ts (see compress.test.ts): pako returns
+    // `undefined` for an incomplete deflate stream instead of throwing. If that
+    // leaks through, this path reports a SUCCESSFUL decrypt of an empty item,
+    // and applying it as an update wipes the note's content on every device.
+    // Decrypt failures must be typed failures; "" is not a decrypt result.
+    it('#then it is reported as a failure, not as an empty success', () => {
       const keys = generateTestKeys()
 
       const result = decryptSingleItem(
@@ -375,10 +375,15 @@ describe('decryptSingleItem', () => {
       )
 
       expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.error).toMatch(/decompress/i)
     })
 
-    it('#then it currently decodes to empty content marked as verified', () => {
-      // Pins the observed behaviour behind the bug above.
+    it('#then the failure is not misreported as a signature or key problem', () => {
+      // The signature verifies and the AEAD tag verifies — only the compressed
+      // body is short. Flagging it as a signature error would quarantine the
+      // item; flagging it as a crypto error would push the page toward the
+      // account-key mismatch path. Neither is true here.
       const keys = generateTestKeys()
 
       const result = decryptSingleItem(
@@ -387,9 +392,11 @@ describe('decryptSingleItem', () => {
         keys.signingPublicKey
       )
 
-      expect(result.ok).toBe(true)
-      if (!result.ok) return
-      expect(result.item.content).toBe('')
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.isSignatureError).toBe(false)
+      expect(result.failure.isCryptoError).toBe(false)
+      expect(result.failure.id).toBe('item-1')
     })
   })
 

--- a/apps/desktop/src/main/sync/decrypt-item.test.ts
+++ b/apps/desktop/src/main/sync/decrypt-item.test.ts
@@ -1,0 +1,428 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import sodium from 'libsodium-wrappers-sumo'
+import { CBOR_FIELD_ORDER } from '@memry/contracts/cbor-ordering'
+import { initCrypto } from '../crypto/index'
+import { encrypt, wrapFileKey } from '../crypto/encryption'
+import { generateFileKey } from '../crypto/primitives'
+import { signPayload } from '../crypto/signatures'
+import { compressPayload } from './compress'
+import { encryptItemForPush } from './encrypt'
+import { decryptSingleItem } from './decrypt-item'
+import type { PullItemForDecrypt } from './worker-protocol'
+
+// decryptSingleItem is the trust boundary for everything the server hands us.
+// It must NEVER throw (a throw inside the pull loop aborts the whole page and
+// strands every later item) and must NEVER return partial plaintext. The
+// failure flags it sets are load-bearing downstream:
+//   isSignatureError -> pull-coordinator quarantines the item
+//   isCryptoError    -> counted toward the page-wide crypto failure that
+//                       triggers the account-key mismatch check
+// See engine/pull-coordinator.ts.
+
+beforeAll(async () => {
+  await initCrypto()
+})
+
+interface TestKeys {
+  vaultKey: Uint8Array
+  signingSecretKey: Uint8Array
+  signingPublicKey: Uint8Array
+  deviceId: string
+}
+
+function generateTestKeys(deviceId = 'device-a'): TestKeys {
+  const keyPair = sodium.crypto_sign_keypair()
+  return {
+    vaultKey: sodium.randombytes_buf(32),
+    signingSecretKey: keyPair.privateKey,
+    signingPublicKey: keyPair.publicKey,
+    deviceId
+  }
+}
+
+function makePullItem(
+  keys: TestKeys,
+  content: string,
+  overrides: Partial<PullItemForDecrypt> = {},
+  encryptOverrides: Record<string, unknown> = {}
+): PullItemForDecrypt {
+  const { pushItem } = encryptItemForPush({
+    id: 'item-1',
+    type: 'note',
+    operation: 'update',
+    content: new TextEncoder().encode(content),
+    vaultKey: keys.vaultKey,
+    signingSecretKey: keys.signingSecretKey,
+    signerDeviceId: keys.deviceId,
+    ...encryptOverrides
+  })
+
+  return {
+    id: pushItem.id,
+    type: pushItem.type,
+    operation: pushItem.operation,
+    cryptoVersion: 1,
+    encryptedKey: pushItem.encryptedKey,
+    keyNonce: pushItem.keyNonce,
+    encryptedData: pushItem.encryptedData,
+    dataNonce: pushItem.dataNonce,
+    signature: pushItem.signature,
+    signerDeviceId: pushItem.signerDeviceId,
+    ...(pushItem.clock && { clock: pushItem.clock }),
+    ...(pushItem.stateVector && { stateVector: pushItem.stateVector }),
+    ...(pushItem.deletedAt !== undefined && { deletedAt: pushItem.deletedAt }),
+    ...overrides
+  }
+}
+
+describe('decryptSingleItem', () => {
+  describe('#given a well-formed item #when decrypted with the right keys', () => {
+    it('#then returns the plaintext with the item identity preserved', () => {
+      const keys = generateTestKeys()
+      const body = JSON.stringify({ title: 'Quarterly plan' })
+      const item = makePullItem(keys, body)
+
+      const result = decryptSingleItem(item, keys.vaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.item).toEqual({
+        id: 'item-1',
+        type: 'note',
+        operation: 'update',
+        content: body,
+        clock: undefined,
+        deletedAt: undefined,
+        signerDeviceId: 'device-a'
+      })
+    })
+
+    it('#then a payload larger than the compression threshold round-trips intact', () => {
+      const keys = generateTestKeys()
+      const body = JSON.stringify({ content: 'lorem ipsum '.repeat(5000) })
+      const item = makePullItem(keys, body)
+
+      const result = decryptSingleItem(item, keys.vaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.item.content).toBe(body)
+    })
+
+    it('#then the signed clock metadata is carried through to the applier', () => {
+      const keys = generateTestKeys()
+      const clock = { 'device-a': 4, 'device-b': 2 }
+      const item = makePullItem(keys, '{}', { clock }, { clock })
+
+      const result = decryptSingleItem(item, keys.vaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.item.clock).toEqual(clock)
+    })
+  })
+
+  describe('#given a tombstone #when decrypted', () => {
+    it('#then the operation is forced to delete regardless of the declared operation', () => {
+      const keys = generateTestKeys()
+      const deletedAt = 1_770_000_000_000
+      const item = makePullItem(keys, '{}', { operation: 'update', deletedAt }, { deletedAt })
+
+      const result = decryptSingleItem(item, keys.vaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      // A tombstone mis-applied as an update resurrects a deleted item on the
+      // pulling device.
+      expect(result.item.operation).toBe('delete')
+      expect(result.item.deletedAt).toBe(deletedAt)
+    })
+  })
+
+  describe('#given a payload encrypted with a DIFFERENT vault key #when decrypted', () => {
+    it('#then fails cleanly as a crypto error, not a signature error', () => {
+      // The "wrong key after re-provisioning" incident class: the signature
+      // still verifies (same signing device) but the file key cannot be
+      // unwrapped. It MUST NOT be reported as a signature error, or every item
+      // in the vault gets quarantined instead of raising a key mismatch.
+      const keys = generateTestKeys()
+      const otherVaultKey = sodium.randombytes_buf(32)
+      const item = makePullItem(keys, JSON.stringify({ secret: true }))
+
+      const result = decryptSingleItem(item, otherVaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.isCryptoError).toBe(true)
+      expect(result.failure.isSignatureError).toBe(false)
+      expect(result.failure.id).toBe('item-1')
+      expect(result.failure.type).toBe('note')
+      expect(result.failure.signerDeviceId).toBe('device-a')
+      expect(result.failure.error).toBeTruthy()
+    })
+
+    it('#then no plaintext leaks into the failure result', () => {
+      const keys = generateTestKeys()
+      const otherVaultKey = sodium.randombytes_buf(32)
+      const item = makePullItem(keys, JSON.stringify({ secret: 'topsecret-marker' }))
+
+      const result = decryptSingleItem(item, otherVaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result).not.toHaveProperty('item')
+      expect(JSON.stringify(result)).not.toContain('topsecret-marker')
+    })
+
+    it('#then a wrong-length vault key fails cleanly rather than throwing', () => {
+      const keys = generateTestKeys()
+      const item = makePullItem(keys, '{}')
+
+      const result = decryptSingleItem(item, new Uint8Array(16), keys.signingPublicKey)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.isCryptoError).toBe(true)
+    })
+  })
+
+  describe('#given an item signed by a foreign device #when decrypted', () => {
+    it('#then reports a signature error so the item is quarantined', () => {
+      const keys = generateTestKeys()
+      const foreign = generateTestKeys('device-evil')
+      const item = makePullItem(keys, '{}')
+
+      const result = decryptSingleItem(item, keys.vaultKey, foreign.signingPublicKey)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.isSignatureError).toBe(true)
+      expect(result.failure.isCryptoError).toBe(true)
+    })
+  })
+
+  describe('#given tampered or truncated ciphertext #when decrypted', () => {
+    it('#then a mutated ciphertext is rejected before any decryption is attempted', () => {
+      const keys = generateTestKeys()
+      const item = makePullItem(keys, JSON.stringify({ amount: 1 }))
+      const tampered: PullItemForDecrypt = {
+        ...item,
+        encryptedData: item.encryptedData.slice(0, -4) + 'AAAA'
+      }
+
+      const result = decryptSingleItem(tampered, keys.vaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.isSignatureError).toBe(true)
+    })
+
+    it('#then a truncated ciphertext fails without throwing', () => {
+      const keys = generateTestKeys()
+      const item = makePullItem(keys, JSON.stringify({ body: 'x'.repeat(500) }))
+      const truncated: PullItemForDecrypt = {
+        ...item,
+        encryptedData: item.encryptedData.slice(0, 24)
+      }
+
+      expect(() => decryptSingleItem(truncated, keys.vaultKey, keys.signingPublicKey)).not.toThrow()
+      const result = decryptSingleItem(truncated, keys.vaultKey, keys.signingPublicKey)
+      expect(result.ok).toBe(false)
+    })
+
+    it('#then non-base64 garbage in every crypto field fails without throwing', () => {
+      const keys = generateTestKeys()
+      const item = makePullItem(keys, '{}')
+
+      for (const field of [
+        'encryptedKey',
+        'keyNonce',
+        'encryptedData',
+        'dataNonce',
+        'signature'
+      ] as const) {
+        const corrupted: PullItemForDecrypt = { ...item, [field]: '!!! not base64 !!!' }
+
+        let result: ReturnType<typeof decryptSingleItem> | undefined
+        expect(() => {
+          result = decryptSingleItem(corrupted, keys.vaultKey, keys.signingPublicKey)
+        }, field).not.toThrow()
+        expect(result?.ok, field).toBe(false)
+      }
+    })
+
+    it('#then a swapped nonce fails as a crypto error, not silently', () => {
+      const keys = generateTestKeys()
+      const a = makePullItem(keys, '{"a":1}')
+      const b = makePullItem(keys, '{"b":2}')
+      // dataNonce is covered by the signature, so swapping it trips the
+      // signature check first — the important part is that it never decodes
+      // into the wrong item's plaintext.
+      const swapped: PullItemForDecrypt = { ...a, dataNonce: b.dataNonce }
+
+      const result = decryptSingleItem(swapped, keys.vaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.isCryptoError).toBe(true)
+    })
+  })
+
+  describe('#given signed metadata is altered in transit #when decrypted', () => {
+    it('#then a rewritten clock is rejected as a signature error', () => {
+      // The vector clock is inside the signature payload: a server (or MITM)
+      // that rewrites the clock to win a merge must not be able to.
+      const keys = generateTestKeys()
+      const item = makePullItem(
+        keys,
+        '{}',
+        { clock: { 'device-a': 1 } },
+        { clock: { 'device-a': 1 } }
+      )
+      const rewritten: PullItemForDecrypt = { ...item, clock: { 'device-a': 999 } }
+
+      const result = decryptSingleItem(rewritten, keys.vaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.isSignatureError).toBe(true)
+    })
+
+    it('#then a stripped clock is rejected as a signature error', () => {
+      const keys = generateTestKeys()
+      const item = makePullItem(
+        keys,
+        '{}',
+        { clock: { 'device-a': 3 } },
+        { clock: { 'device-a': 3 } }
+      )
+      const stripped: PullItemForDecrypt = { ...item }
+      delete stripped.clock
+
+      const result = decryptSingleItem(stripped, keys.vaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.isSignatureError).toBe(true)
+    })
+
+    it('#then an injected deletedAt is rejected as a signature error', () => {
+      // Otherwise anyone able to add a field to a pull response could
+      // tombstone another device's data.
+      const keys = generateTestKeys()
+      const item = makePullItem(keys, '{}')
+      const forged: PullItemForDecrypt = { ...item, deletedAt: Date.now() }
+
+      const result = decryptSingleItem(forged, keys.vaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.isSignatureError).toBe(true)
+    })
+  })
+
+  describe('#given a well-signed item whose compressed body is truncated #when decrypted', () => {
+    /**
+     * Builds a pull item the normal way but with a deliberately short deflate
+     * stream inside the (valid, authenticated) ciphertext — the shape a
+     * writer-side truncation bug produces. The AEAD tag and signature both
+     * verify; only the compressed body is short.
+     */
+    function makeTruncatedBodyItem(keys: TestKeys): PullItemForDecrypt {
+      const compressed = compressPayload(
+        new TextEncoder().encode(JSON.stringify({ title: 'Important', body: 'x'.repeat(20_000) }))
+      )
+      const truncated = compressed.slice(0, Math.floor(compressed.byteLength / 2))
+
+      const fileKey = generateFileKey()
+      const { ciphertext, nonce: dataNonce } = encrypt(truncated, fileKey)
+      const { wrappedKey, nonce: keyNonce } = wrapFileKey(fileKey, keys.vaultKey)
+      const toB64 = (bytes: Uint8Array): string =>
+        sodium.to_base64(bytes, sodium.base64_variants.ORIGINAL)
+
+      const signaturePayload = {
+        id: 'item-1',
+        type: 'note',
+        operation: 'update',
+        cryptoVersion: 1,
+        encryptedKey: toB64(wrappedKey),
+        keyNonce: toB64(keyNonce),
+        encryptedData: toB64(ciphertext),
+        dataNonce: toB64(dataNonce)
+      }
+
+      return {
+        ...signaturePayload,
+        signature: toB64(
+          signPayload(signaturePayload, CBOR_FIELD_ORDER.SYNC_ITEM, keys.signingSecretKey)
+        ),
+        signerDeviceId: keys.deviceId
+      }
+    }
+
+    // BUG (root cause in compress.ts — see compress.test.ts): pako returns
+    // `undefined` for an incomplete deflate stream instead of throwing, so
+    // this path reports a SUCCESSFUL decrypt of an empty item. Applying that
+    // as an update wipes the note's content on every device. Decrypt failures
+    // must be typed failures; "" is not a decrypt result.
+    it.fails('#then it is reported as a failure, not as an empty success', () => {
+      const keys = generateTestKeys()
+
+      const result = decryptSingleItem(
+        makeTruncatedBodyItem(keys),
+        keys.vaultKey,
+        keys.signingPublicKey
+      )
+
+      expect(result.ok).toBe(false)
+    })
+
+    it('#then it currently decodes to empty content marked as verified', () => {
+      // Pins the observed behaviour behind the bug above.
+      const keys = generateTestKeys()
+
+      const result = decryptSingleItem(
+        makeTruncatedBodyItem(keys),
+        keys.vaultKey,
+        keys.signingPublicKey
+      )
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.item.content).toBe('')
+    })
+  })
+
+  describe('#given an unsupported crypto version #when decrypted', () => {
+    it('#then fails as a plain (non-crypto) failure so the item is not quarantined', () => {
+      // A newer-format item from an upgraded device should make this device
+      // retry after updating, NOT brand the item corrupt forever.
+      const keys = generateTestKeys()
+      const item = makePullItem(keys, '{}', { cryptoVersion: 2 })
+
+      const result = decryptSingleItem(item, keys.vaultKey, keys.signingPublicKey)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.error).toContain('Crypto version 2 is not supported')
+      expect(result.failure.isSignatureError).toBe(false)
+      expect(result.failure.isCryptoError).toBe(false)
+    })
+
+    it('#then a zero/negative crypto version fails cleanly', () => {
+      const keys = generateTestKeys()
+
+      for (const cryptoVersion of [0, -1]) {
+        const result = decryptSingleItem(
+          makePullItem(keys, '{}', { cryptoVersion }),
+          keys.vaultKey,
+          keys.signingPublicKey
+        )
+
+        expect(result.ok).toBe(false)
+        if (result.ok) continue
+        expect(result.failure.error).toContain('Invalid crypto version')
+      }
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -1,0 +1,536 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EVENT_CHANNELS } from '@memry/contracts/ipc-events'
+import { FullSyncRunner, type FullSyncActions } from './full-sync-runner'
+import { SYNC_STATE_KEYS, type SyncContext } from './sync-context'
+import type { SyncStateManager } from './sync-state-manager'
+import type { PushCoordinator } from './push-coordinator'
+import type { CrdtSyncCoordinator } from './crdt-sync-coordinator'
+
+// FullSyncRunner is the choreography of a complete sync cycle:
+// pull -> seed -> push -> manifest check -> (conditional re-pull) -> follow-up
+// push -> cleanup, with a finally block that must always release the
+// fullSyncActive flag and flush queued CRDT pulls. Ordering matters (a push
+// before the pull uploads a stale snapshot), and so does the throttle
+// bookkeeping for the manifest check, which is what re-pulls a vault whose
+// server rows went missing.
+
+const mocks = vi.hoisted(() => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  checkManifestIntegrity: vi.fn(),
+  runInitialSeed: vi.fn(),
+  getAllCrdtNoteIds: vi.fn(),
+  isIndexDatabaseInitialized: vi.fn(),
+  getIndexDatabase: vi.fn()
+}))
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => mocks.log
+}))
+
+vi.mock('../manifest-check', () => ({
+  checkManifestIntegrity: (...args: unknown[]) => mocks.checkManifestIntegrity(...args)
+}))
+
+vi.mock('../initial-seed', () => ({
+  runInitialSeed: (...args: unknown[]) => mocks.runInitialSeed(...args)
+}))
+
+vi.mock('../../database/queries/notes', () => ({
+  getAllCrdtNoteIds: (...args: unknown[]) => mocks.getAllCrdtNoteIds(...args)
+}))
+
+vi.mock('../../database/client', () => ({
+  getIndexDatabase: (...args: unknown[]) => mocks.getIndexDatabase(...args),
+  isIndexDatabaseInitialized: (...args: unknown[]) => mocks.isIndexDatabaseInitialized(...args)
+}))
+
+class FakeCrdtSync {
+  private pending = new Set<string>()
+  pullCrdtForNote = vi.fn(async () => {})
+
+  addPendingPull(noteId: string): void {
+    this.pending.add(noteId)
+  }
+
+  get pendingPullCount(): number {
+    return this.pending.size
+  }
+
+  drainPendingPulls(): string[] {
+    const ids = [...this.pending]
+    this.pending.clear()
+    return ids
+  }
+}
+
+interface Harness {
+  runner: FullSyncRunner
+  ctx: SyncContext
+  calls: string[]
+  actions: {
+    pull: ReturnType<typeof vi.fn>
+    push: ReturnType<typeof vi.fn>
+    scheduleSync: ReturnType<typeof vi.fn>
+  }
+  emitToRenderer: ReturnType<typeof vi.fn>
+  setStateValue: ReturnType<typeof vi.fn>
+  getStateValue: ReturnType<typeof vi.fn>
+  isPaused: ReturnType<typeof vi.fn>
+  clearPendingAfterFullSync: ReturnType<typeof vi.fn>
+  purgeOldErrors: ReturnType<typeof vi.fn>
+  getPendingCount: ReturnType<typeof vi.fn>
+  crdtSync: FakeCrdtSync
+}
+
+/**
+ * `pendingCounts` feeds successive getPendingCount() calls, which run() makes
+ * in this order: before the seed, again to compute the seeded delta, again for
+ * the progress total, and finally after the manifest check. The last entry is
+ * reused once the list runs out.
+ */
+function createHarness(
+  options: {
+    pendingCounts?: number[]
+    signingKeys?: { deviceId: string } | null
+    crdtProvider?: unknown
+    isQuarantined?: (itemId: string, itemType: string) => boolean
+  } = {}
+): Harness {
+  const calls: string[] = []
+  const pendingCounts = options.pendingCounts ?? [0]
+  let pendingIndex = 0
+  const getPendingCount = vi.fn(() => {
+    const value = pendingCounts[Math.min(pendingIndex, pendingCounts.length - 1)]
+    pendingIndex++
+    return value
+  })
+  const purgeOldErrors = vi.fn(() => {
+    calls.push('purgeOldErrors')
+  })
+  const emitToRenderer = vi.fn((channel: string, data: unknown) => {
+    if (channel === EVENT_CHANNELS.INITIAL_SYNC_PROGRESS) {
+      calls.push(`progress:${(data as { phase: string }).phase}`)
+    }
+  })
+
+  const ctx = {
+    deps: {
+      db: { __db: 'data' },
+      queue: { getPendingCount, purgeOldErrors },
+      network: { online: true },
+      getAccessToken: vi.fn(async () => 'token-1'),
+      getSigningKeys: vi.fn(async () =>
+        options.signingKeys === undefined ? { deviceId: 'dev-a' } : options.signingKeys
+      ),
+      emitToRenderer,
+      ...(options.crdtProvider !== undefined && { crdtProvider: options.crdtProvider })
+    },
+    fullSyncActive: false
+  } as unknown as SyncContext
+
+  const setStateValue = vi.fn((key: string) => {
+    calls.push(`setState:${key}`)
+  })
+  const getStateValue = vi.fn(() => undefined as string | undefined)
+  const isPaused = vi.fn(() => false)
+  const stateManager = { setStateValue, getStateValue, isPaused } as unknown as SyncStateManager
+
+  const clearPendingAfterFullSync = vi.fn(() => {
+    calls.push('clearPendingAfterFullSync')
+  })
+  const pushCoordinator = { clearPendingAfterFullSync } as unknown as PushCoordinator
+
+  const crdtSync = new FakeCrdtSync()
+
+  const actions = {
+    pull: vi.fn(async () => {
+      calls.push('pull')
+    }),
+    push: vi.fn(async () => {
+      calls.push('push')
+    }),
+    scheduleSync: vi.fn((fn: () => Promise<void>) => {
+      calls.push('scheduleSync')
+      void fn
+    })
+  }
+
+  const runner = new FullSyncRunner(
+    ctx,
+    stateManager,
+    pushCoordinator,
+    crdtSync as unknown as CrdtSyncCoordinator,
+    actions as unknown as FullSyncActions,
+    options.isQuarantined
+  )
+
+  return {
+    runner,
+    ctx,
+    calls,
+    actions,
+    emitToRenderer,
+    setStateValue,
+    getStateValue,
+    isPaused,
+    clearPendingAfterFullSync,
+    purgeOldErrors,
+    getPendingCount,
+    crdtSync
+  }
+}
+
+function manifestResult(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    checkedAt: Date.now(),
+    rePullNeeded: false,
+    serverOnlyCount: 0,
+    performed: true,
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.checkManifestIntegrity.mockResolvedValue(manifestResult())
+  mocks.isIndexDatabaseInitialized.mockReturnValue(false)
+  mocks.getAllCrdtNoteIds.mockReturnValue([])
+  mocks.getIndexDatabase.mockReturnValue({ __db: 'index' })
+})
+
+describe('FullSyncRunner', () => {
+  describe('#given a healthy cycle #when run', () => {
+    it('#then the stages execute in pull -> seed -> push -> manifest order', async () => {
+      // A push before the pull uploads a snapshot that has not yet seen the
+      // other device's changes, which is exactly how a remote edit gets
+      // clobbered.
+      const h = createHarness()
+      mocks.runInitialSeed.mockImplementation(() => h.calls.push('seed'))
+      mocks.checkManifestIntegrity.mockImplementation(async () => {
+        h.calls.push('manifest')
+        return manifestResult()
+      })
+
+      await h.runner.run()
+
+      expect(h.calls).toEqual([
+        'pull',
+        'seed',
+        'push',
+        'progress:manifest',
+        'manifest',
+        `setState:${SYNC_STATE_KEYS.LAST_MANIFEST_CHECK_AT}`,
+        'clearPendingAfterFullSync',
+        'purgeOldErrors',
+        'progress:complete'
+      ])
+    })
+
+    it('#then the seed runs with the signing device id and the shared db/queue', async () => {
+      const h = createHarness()
+
+      await h.runner.run()
+
+      expect(mocks.runInitialSeed).toHaveBeenCalledWith({
+        db: h.ctx.deps.db,
+        queue: h.ctx.deps.queue,
+        deviceId: 'dev-a'
+      })
+    })
+
+    it('#then fullSyncActive is set during the run and cleared afterwards', async () => {
+      const h = createHarness()
+      let activeDuringPull: boolean | undefined
+      h.actions.pull.mockImplementation(async () => {
+        activeDuringPull = h.ctx.fullSyncActive
+      })
+
+      await h.runner.run()
+
+      expect(activeDuringPull).toBe(true)
+      expect(h.ctx.fullSyncActive).toBe(false)
+    })
+
+    it('#then old queue errors are purged with a 7-day cutoff', async () => {
+      const h = createHarness()
+      const before = Date.now()
+
+      await h.runner.run()
+
+      const cutoff = h.purgeOldErrors.mock.calls[0][0] as Date
+      const sevenDaysMs = 7 * 24 * 60 * 60 * 1000
+      expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - sevenDaysMs - 5_000)
+      expect(cutoff.getTime()).toBeLessThanOrEqual(Date.now() - sevenDaysMs + 5_000)
+    })
+  })
+
+  describe('#given no signing keys yet #when run', () => {
+    it('#then the seed is skipped but the cycle still completes', async () => {
+      // Sync can be running for a pull before device registration finishes;
+      // skipping the seed must not abort the rest of the cycle.
+      const h = createHarness({ signingKeys: null })
+
+      await h.runner.run()
+
+      expect(mocks.runInitialSeed).not.toHaveBeenCalled()
+      expect(h.calls).toContain('pull')
+      expect(h.calls).toContain('push')
+      expect(h.calls).toContain('progress:complete')
+    })
+  })
+
+  describe('#given the seed queues work #when run', () => {
+    it('#then a tasks-phase progress event reports the queued total', async () => {
+      const h = createHarness({ pendingCounts: [0, 12, 12, 0] })
+
+      await h.runner.run()
+
+      expect(h.emitToRenderer).toHaveBeenCalledWith(EVENT_CHANNELS.INITIAL_SYNC_PROGRESS, {
+        phase: 'tasks',
+        processedItems: 0,
+        totalItems: 12
+      })
+    })
+
+    it('#then an empty queue emits no tasks-phase event', async () => {
+      const h = createHarness({ pendingCounts: [0, 0, 0, 0] })
+
+      await h.runner.run()
+
+      expect(h.calls).not.toContain('progress:tasks')
+    })
+  })
+
+  describe('#given the manifest throttle timestamp #when the check runs', () => {
+    it('#then a future-dated persisted value is clamped to now', async () => {
+      // Clock skew or a machine migration can leave a timestamp in the future.
+      // Without the clamp the manifest check is throttled until the wall clock
+      // catches up — potentially never.
+      const h = createHarness()
+      h.getStateValue.mockReturnValue(String(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000))
+
+      await h.runner.run()
+
+      const arg = mocks.checkManifestIntegrity.mock.calls[0][0] as { lastCheckAt: number }
+      expect(arg.lastCheckAt).toBeLessThanOrEqual(Date.now())
+    })
+
+    it('#then a non-numeric persisted value falls back to zero', async () => {
+      const h = createHarness()
+      h.getStateValue.mockReturnValue('not-a-number')
+
+      await h.runner.run()
+
+      const arg = mocks.checkManifestIntegrity.mock.calls[0][0] as { lastCheckAt: number }
+      expect(arg.lastCheckAt).toBe(0)
+    })
+
+    it('#then the check is handed the quarantine predicate and the live online flag', async () => {
+      const isQuarantined = vi.fn(() => false)
+      const h = createHarness({ isQuarantined })
+
+      await h.runner.run()
+
+      const arg = mocks.checkManifestIntegrity.mock.calls[0][0] as {
+        isQuarantined?: unknown
+        isOnline: () => boolean
+        getAccessToken: unknown
+      }
+      expect(arg.isQuarantined).toBe(isQuarantined)
+      expect(arg.isOnline()).toBe(true)
+      expect(arg.getAccessToken).toBe(h.ctx.deps.getAccessToken)
+    })
+
+    it('#then only a performed check stamps the persisted timestamp', async () => {
+      const h = createHarness()
+      mocks.checkManifestIntegrity.mockResolvedValue(
+        manifestResult({ performed: false, checkedAt: 123 })
+      )
+
+      await h.runner.run()
+
+      // Stamping a no-token / fetch-failure path would defer the next REAL
+      // check by the full throttle window.
+      expect(h.setStateValue).not.toHaveBeenCalledWith(
+        SYNC_STATE_KEYS.LAST_MANIFEST_CHECK_AT,
+        expect.anything()
+      )
+    })
+
+    it('#then a performed check persists its checkedAt', async () => {
+      const h = createHarness()
+      mocks.checkManifestIntegrity.mockResolvedValue(
+        manifestResult({ performed: true, checkedAt: 456 })
+      )
+
+      await h.runner.run()
+
+      expect(h.setStateValue).toHaveBeenCalledWith(SYNC_STATE_KEYS.LAST_MANIFEST_CHECK_AT, '456')
+    })
+
+    it('#then an unperformed check still advances the in-memory throttle', async () => {
+      // Current behaviour: the in-memory field is stamped from checkedAt even
+      // when nothing was fetched, so a token-less cycle also throttles the
+      // next check for this process — the persisted value deliberately does
+      // not. Recorded so the divergence is visible if it is ever revisited.
+      const h = createHarness()
+      mocks.checkManifestIntegrity.mockResolvedValue(
+        manifestResult({ performed: false, checkedAt: 777 })
+      )
+
+      await h.runner.run()
+
+      expect(h.runner.lastManifestCheckAt).toBe(777)
+    })
+  })
+
+  describe('#given the manifest finds server-only items #when run', () => {
+    it('#then the cursor is reset and a second pull runs', async () => {
+      const h = createHarness()
+      mocks.checkManifestIntegrity.mockResolvedValue(
+        manifestResult({ rePullNeeded: true, serverOnlyCount: 3 })
+      )
+
+      await h.runner.run()
+
+      expect(h.setStateValue).toHaveBeenCalledWith(SYNC_STATE_KEYS.LAST_CURSOR, '0')
+      expect(h.actions.pull).toHaveBeenCalledTimes(2)
+      // The cursor reset must precede the re-pull, or the re-pull uses the old
+      // cursor and the missing items stay missing.
+      expect(h.calls.indexOf(`setState:${SYNC_STATE_KEYS.LAST_CURSOR}`)).toBeLessThan(
+        h.calls.lastIndexOf('pull')
+      )
+    })
+
+    it('#then no re-pull happens when the manifest agrees', async () => {
+      const h = createHarness()
+
+      await h.runner.run()
+
+      expect(h.actions.pull).toHaveBeenCalledTimes(1)
+      expect(h.setStateValue).not.toHaveBeenCalledWith(SYNC_STATE_KEYS.LAST_CURSOR, '0')
+    })
+  })
+
+  describe('#given the manifest re-queued items #when the cycle finishes', () => {
+    it('#then a follow-up push drains them', async () => {
+      const h = createHarness({ pendingCounts: [0, 0, 0, 5] })
+
+      await h.runner.run()
+
+      expect(h.actions.push).toHaveBeenCalledTimes(2)
+    })
+
+    it('#then a paused vault skips the follow-up push', async () => {
+      const h = createHarness({ pendingCounts: [0, 0, 0, 5] })
+      h.isPaused.mockReturnValue(true)
+
+      await h.runner.run()
+
+      expect(h.actions.push).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('#given a stage throws #when run', () => {
+    it('#then a failing pull aborts the remaining stages and surfaces the error', async () => {
+      // No per-stage catch by design: the caller (SyncEngine) decides whether
+      // to retry. What must NOT happen is a swallowed failure that reports a
+      // completed sync.
+      const h = createHarness()
+      h.actions.pull.mockRejectedValue(new Error('network down'))
+
+      await expect(h.runner.run()).rejects.toThrow('network down')
+
+      expect(mocks.runInitialSeed).not.toHaveBeenCalled()
+      expect(h.actions.push).not.toHaveBeenCalled()
+      expect(mocks.checkManifestIntegrity).not.toHaveBeenCalled()
+      expect(h.calls).not.toContain('progress:complete')
+    })
+
+    it('#then fullSyncActive is released even when a stage throws', async () => {
+      // A stuck fullSyncActive flag blocks every later sync attempt for the
+      // lifetime of the process.
+      const h = createHarness()
+      h.actions.push.mockRejectedValue(new Error('push exploded'))
+
+      await expect(h.runner.run()).rejects.toThrow('push exploded')
+
+      expect(h.ctx.fullSyncActive).toBe(false)
+    })
+
+    it('#then CRDT pulls queued before the failure are still flushed', async () => {
+      const h = createHarness()
+      h.crdtSync.addPendingPull('note-1')
+      h.crdtSync.addPendingPull('note-2')
+      h.actions.pull.mockRejectedValue(new Error('boom'))
+
+      await expect(h.runner.run()).rejects.toThrow('boom')
+
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+      expect(h.crdtSync.pendingPullCount).toBe(0)
+    })
+
+    it('#then a failing manifest check does not strand the run mid-cycle', async () => {
+      const h = createHarness()
+      mocks.checkManifestIntegrity.mockRejectedValue(new Error('manifest fetch failed'))
+
+      await expect(h.runner.run()).rejects.toThrow('manifest fetch failed')
+
+      expect(h.ctx.fullSyncActive).toBe(false)
+      // Pull and push already happened, so the device is not left with a
+      // silently empty queue.
+      expect(h.actions.pull).toHaveBeenCalled()
+      expect(h.actions.push).toHaveBeenCalled()
+    })
+  })
+
+  describe('#given CRDT-backed notes #when the cycle ends', () => {
+    it('#then every CRDT note is re-queued and scheduled for a pull', async () => {
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+
+      await h.runner.run()
+
+      expect(mocks.getAllCrdtNoteIds).toHaveBeenCalledWith({ __db: 'index' })
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+      expect(h.crdtSync.pendingPullCount).toBe(0)
+    })
+
+    it('#then the scheduled work pulls the specific note', async () => {
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-7'])
+      const scheduled: Array<() => Promise<void>> = []
+      h.actions.scheduleSync.mockImplementation((fn: () => Promise<void>) => {
+        scheduled.push(fn)
+      })
+
+      await h.runner.run()
+      await scheduled[0]()
+
+      expect(h.crdtSync.pullCrdtForNote).toHaveBeenCalledWith('note-7')
+    })
+
+    it('#then the index DB is not touched while it is uninitialized', async () => {
+      // Vault switch / teardown: reading an unopened index DB throws inside a
+      // finally block, which would replace the real sync error.
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(false)
+
+      await h.runner.run()
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
+    })
+
+    it('#then no CRDT provider means no CRDT bookkeeping at all', async () => {
+      const h = createHarness()
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+
+      await h.runner.run()
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
+      expect(h.actions.scheduleSync).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EVENT_CHANNELS } from '@memry/contracts/ipc-events'
+import { SyncQueueManager, DEFAULT_MAX_ATTEMPTS } from '@main/sync/queue'
+import { setupTestDb, type TestDatabaseResult } from '@tests/utils/engine-mocks'
+import type { SyncContext } from './sync-context'
+import type { SyncStateManager } from './sync-state-manager'
+
+const { encryptPushBatchMock, postToServerMock, getHandlerMock, getRemoteSyncAdapterMock } =
+  vi.hoisted(() => ({
+    encryptPushBatchMock: vi.fn(),
+    postToServerMock: vi.fn(),
+    getHandlerMock: vi.fn(),
+    getRemoteSyncAdapterMock: vi.fn()
+  }))
+
+vi.mock('../../lib/logger', () => {
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+  return { createLogger: () => logger }
+})
+
+// Real crypto would drag libsodium + the worker bridge into a test about queue
+// bookkeeping. secureCleanup only zeroes key bytes in the finally block.
+vi.mock('../../crypto/index', () => ({ secureCleanup: vi.fn() }))
+
+vi.mock('../sync-crypto-batch', () => ({ encryptPushBatch: encryptPushBatchMock }))
+
+vi.mock('../item-handlers', () => ({
+  getHandler: getHandlerMock,
+  getRemoteSyncAdapter: getRemoteSyncAdapterMock
+}))
+
+// Keep the real SyncServerError / RateLimitError classes: withRetry, withAuthRetry
+// and classifyError all branch on `instanceof` and on statusCode.
+vi.mock('../http-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../http-client')>()
+  return { ...actual, postToServer: postToServerMock }
+})
+
+import { PushCoordinator } from './push-coordinator'
+import { SyncServerError } from '../http-client'
+
+interface QueueRow {
+  id: string
+  itemId: string
+  type: string
+  operation: string
+  payload: string
+}
+
+/**
+ * Stands in for the real encryptPushBatch: still routes each row through the
+ * coordinator's own resolvePushPayload (so the fresh-vs-frozen payload path is
+ * exercised) and parks the resulting plaintext in `encryptedData`, which lets a
+ * test assert *which* payload actually went over the wire.
+ */
+function fakeEncryptPushBatch(): void {
+  encryptPushBatchMock.mockImplementation(
+    async (
+      items: QueueRow[],
+      vaultKey: Uint8Array,
+      _signingKey: Uint8Array,
+      deviceId: string,
+      deps: {
+        resolvePushPayload: (item: QueueRow, deviceId: string, vaultKey: Uint8Array) => string
+      }
+    ) =>
+      items.map((item) => ({
+        queueId: item.id,
+        pushItem: {
+          id: item.itemId,
+          type: item.type,
+          operation: item.operation,
+          encryptedKey: 'ek',
+          keyNonce: 'kn',
+          encryptedData: deps.resolvePushPayload(item, deviceId, vaultKey),
+          dataNonce: 'dn',
+          signature: 'sig',
+          signerDeviceId: deviceId
+        }
+      }))
+  )
+}
+
+interface PushBody {
+  items: Array<{ id: string; type: string; operation: string; encryptedData: string }>
+}
+
+function createHarness(testDb: TestDatabaseResult): {
+  ctx: SyncContext
+  queue: SyncQueueManager
+  stateManager: SyncStateManager
+  coordinator: PushCoordinator
+  getAccessToken: ReturnType<typeof vi.fn>
+  refreshAccessToken: ReturnType<typeof vi.fn>
+  emitToRenderer: ReturnType<typeof vi.fn>
+} {
+  const queue = new SyncQueueManager(testDb.db)
+  const getAccessToken = vi.fn().mockResolvedValue('test-token')
+  const refreshAccessToken = vi.fn().mockResolvedValue(false)
+  const emitToRenderer = vi.fn()
+
+  const stateValues = new Map<string, string>()
+  const stateManager = {
+    setState: vi.fn(),
+    isPaused: vi.fn(() => false),
+    emitItemSynced: vi.fn(),
+    recordHistory: vi.fn(),
+    updateLastSyncAt: vi.fn(),
+    checkClockSkew: vi.fn(),
+    getStateValue: vi.fn((key: string) => stateValues.get(key)),
+    setStateValue: vi.fn((key: string, value: string) => {
+      stateValues.set(key, value)
+    })
+  } as unknown as SyncStateManager
+
+  const ctx = {
+    deps: {
+      queue,
+      network: { online: true },
+      ws: {},
+      getAccessToken,
+      getVaultKey: vi.fn().mockResolvedValue(new Uint8Array(32)),
+      getSigningKeys: vi.fn().mockResolvedValue({
+        secretKey: new Uint8Array(64),
+        publicKey: new Uint8Array(32),
+        deviceId: 'device-1'
+      }),
+      getDevicePublicKey: vi.fn().mockResolvedValue(null),
+      db: testDb.db,
+      emitToRenderer,
+      refreshAccessToken
+    },
+    options: { pushBatchSize: 100, pullPageLimit: 100 },
+    state: 'idle',
+    syncing: false,
+    fullSyncActive: false,
+    abortController: null,
+    inFlightSync: null,
+    lastError: undefined,
+    lastErrorInfo: undefined,
+    offlineSince: null,
+    rateLimitConsecutive: 0,
+    scheduleSync: vi.fn(),
+    acquireLock: vi.fn().mockResolvedValue(() => {}),
+    releaseLock: vi.fn(),
+    requestPush: vi.fn()
+  } as unknown as SyncContext
+
+  return {
+    ctx,
+    queue,
+    stateManager,
+    coordinator: new PushCoordinator(ctx, stateManager),
+    getAccessToken,
+    refreshAccessToken,
+    emitToRenderer
+  }
+}
+
+function acceptAll(): void {
+  postToServerMock.mockImplementation(async (_path: string, body: PushBody) => ({
+    accepted: body.items.map((i) => i.id),
+    rejected: [],
+    serverTime: Math.floor(Date.now() / 1000),
+    maxCursor: 0
+  }))
+}
+
+describe('PushCoordinator', () => {
+  const { getDb } = setupTestDb()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fakeEncryptPushBatch()
+    getHandlerMock.mockReturnValue(undefined)
+    getRemoteSyncAdapterMock.mockReturnValue(undefined)
+  })
+
+  describe('#given a queued local mutation #when the server accepts it', () => {
+    it('#then it is pushed, dropped from the queue, and marked synced locally', async () => {
+      const { coordinator, queue, stateManager, emitToRenderer } = createHarness(getDb())
+      const markPushSynced = vi.fn()
+      getHandlerMock.mockReturnValue({ markPushSynced })
+      acceptAll()
+
+      queue.enqueue({
+        type: 'note',
+        itemId: 'note-1',
+        operation: 'create',
+        payload: JSON.stringify({ title: 'Hello' })
+      })
+
+      await coordinator.push()
+
+      expect(postToServerMock).toHaveBeenCalledTimes(1)
+      expect(postToServerMock.mock.calls[0][0]).toBe('/sync/push')
+      const body = postToServerMock.mock.calls[0][1] as PushBody
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0]).toMatchObject({ id: 'note-1', type: 'note', operation: 'create' })
+
+      expect(queue.getSize()).toBe(0)
+      expect(markPushSynced).toHaveBeenCalledWith(expect.anything(), 'note-1')
+      expect(stateManager.emitItemSynced).toHaveBeenCalledWith('note-1', 'note', 'push')
+      expect(stateManager.updateLastSyncAt).toHaveBeenCalled()
+      expect(emitToRenderer).toHaveBeenCalledWith(
+        EVENT_CHANNELS.QUEUE_CLEARED,
+        expect.objectContaining({ itemCount: 1 })
+      )
+    })
+
+    it('#then it advances the pull cursor when the server reports a higher maxCursor', async () => {
+      const { coordinator, queue, stateManager } = createHarness(getDb())
+      postToServerMock.mockResolvedValue({
+        accepted: ['note-1'],
+        rejected: [],
+        serverTime: Math.floor(Date.now() / 1000),
+        maxCursor: 42
+      })
+
+      queue.enqueue({
+        type: 'note',
+        itemId: 'note-1',
+        operation: 'create',
+        payload: JSON.stringify({ title: 'Hello' })
+      })
+
+      await coordinator.push()
+
+      expect(stateManager.setStateValue).toHaveBeenCalledWith('lastCursor', '42')
+    })
+  })
+
+  describe('#given the push request fails #when push runs', () => {
+    it('#then the item stays queued and is NOT marked synced, so the next cycle retries it', async () => {
+      const { coordinator, queue, stateManager } = createHarness(getDb())
+      const markPushSynced = vi.fn()
+      getHandlerMock.mockReturnValue({ markPushSynced })
+      // 4xx so withRetry rethrows immediately instead of sleeping through backoff.
+      postToServerMock.mockRejectedValue(new SyncServerError('Bad request', 400))
+
+      const payload = JSON.stringify({ title: 'Unsent edit' })
+      queue.enqueue({ type: 'task', itemId: 'task-1', operation: 'update', payload })
+
+      await coordinator.push()
+
+      expect(queue.getPendingCount()).toBe(1)
+      const [row] = queue.peek()
+      expect(row.payload).toBe(payload)
+      // The whole request blew up, so no per-item attempt was consumed.
+      expect(row.attempts).toBe(0)
+      expect(markPushSynced).not.toHaveBeenCalled()
+      expect(stateManager.setState).toHaveBeenCalledWith('error')
+      expect(stateManager.updateLastSyncAt).not.toHaveBeenCalled()
+    })
+
+    it('#then a server-side rejection of the item keeps the row instead of deleting it', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      const markPushSynced = vi.fn()
+      getHandlerMock.mockReturnValue({ markPushSynced })
+      postToServerMock.mockImplementation(async (_path: string, body: PushBody) => ({
+        accepted: [],
+        rejected: body.items.map((i) => ({ id: i.id, reason: 'SYNC_VALIDATION_FAILED' })),
+        serverTime: Math.floor(Date.now() / 1000),
+        maxCursor: 0
+      }))
+
+      const payload = JSON.stringify({ title: 'Rejected edit' })
+      queue.enqueue({ type: 'task', itemId: 'task-1', operation: 'update', payload })
+
+      await coordinator.push()
+
+      // Never deleted, never marked synced — the user's edit is still on disk.
+      expect(queue.getSize()).toBe(1)
+      expect(queue.peek()[0].payload).toBe(payload)
+      expect(markPushSynced).not.toHaveBeenCalled()
+      // Documents current behaviour: one push() call re-pushes the same rejected
+      // row every iteration, burning the whole attempt budget in a single cycle
+      // (no backoff between in-cycle retries) and dead-lettering it immediately.
+      expect(queue.peek()[0].attempts).toBe(DEFAULT_MAX_ATTEMPTS)
+      expect(queue.getPendingCount()).toBe(0)
+    })
+
+    it('#then a replay rejection is treated as already-synced and drops the row', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      const markPushSynced = vi.fn()
+      getHandlerMock.mockReturnValue({ markPushSynced })
+      postToServerMock.mockImplementation(async (_path: string, body: PushBody) => ({
+        accepted: [],
+        rejected: body.items.map((i) => ({ id: i.id, reason: 'SYNC_REPLAY_DETECTED' })),
+        serverTime: Math.floor(Date.now() / 1000),
+        maxCursor: 0
+      }))
+
+      queue.enqueue({
+        type: 'task',
+        itemId: 'task-1',
+        operation: 'update',
+        payload: JSON.stringify({ title: 'Already on server' })
+      })
+
+      await coordinator.push()
+
+      expect(queue.getSize()).toBe(0)
+      expect(markPushSynced).toHaveBeenCalledWith(expect.anything(), 'task-1')
+    })
+  })
+
+  describe('#given the access token is stale #when the server answers 401', () => {
+    it('#then the session is refreshed, the push retried with the fresh token, and nothing is dropped', async () => {
+      const { coordinator, queue, getAccessToken, refreshAccessToken } = createHarness(getDb())
+      getAccessToken.mockResolvedValueOnce('test-token').mockResolvedValue('fresh-token')
+      refreshAccessToken.mockResolvedValue(true)
+      postToServerMock
+        .mockRejectedValueOnce(new SyncServerError('Unauthorized', 401))
+        .mockImplementation(async (_path: string, body: PushBody) => ({
+          accepted: body.items.map((i) => i.id),
+          rejected: [],
+          serverTime: Math.floor(Date.now() / 1000),
+          maxCursor: 0
+        }))
+
+      queue.enqueue({
+        type: 'note',
+        itemId: 'note-1',
+        operation: 'update',
+        payload: JSON.stringify({ title: 'Retry me' })
+      })
+
+      await coordinator.push()
+
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1)
+      expect(postToServerMock).toHaveBeenCalledTimes(2)
+      expect(postToServerMock.mock.calls[0][2]).toBe('test-token')
+      expect(postToServerMock.mock.calls[1][2]).toBe('fresh-token')
+      expect(queue.getSize()).toBe(0)
+    })
+
+    it('#then an unrefreshable 401 propagates but leaves the queued edit untouched', async () => {
+      const { coordinator, queue, refreshAccessToken } = createHarness(getDb())
+      refreshAccessToken.mockResolvedValue(false)
+      postToServerMock.mockRejectedValue(new SyncServerError('Unauthorized', 401))
+
+      const payload = JSON.stringify({ title: 'Still mine' })
+      queue.enqueue({ type: 'note', itemId: 'note-1', operation: 'update', payload })
+
+      // auth_expired is rethrown so the engine's error recovery can run.
+      await expect(coordinator.push()).rejects.toThrow()
+
+      expect(queue.getPendingCount()).toBe(1)
+      expect(queue.peek()[0].payload).toBe(payload)
+      expect(queue.peek()[0].attempts).toBe(0)
+    })
+  })
+
+  describe('#given the account is out of storage #when push runs', () => {
+    it('#then an HTTP 413 surfaces as storage_quota_exceeded without discarding the item', async () => {
+      const { coordinator, queue, ctx, stateManager } = createHarness(getDb())
+      postToServerMock.mockRejectedValue(new SyncServerError('Payload too large', 413))
+
+      const payload = JSON.stringify({ title: 'Too big' })
+      queue.enqueue({ type: 'note', itemId: 'note-1', operation: 'update', payload })
+
+      await coordinator.push()
+
+      expect(ctx.lastErrorInfo?.category).toBe('storage_quota_exceeded')
+      expect(stateManager.setState).toHaveBeenCalledWith('error')
+      expect(queue.getSize()).toBe(1)
+      expect(queue.peek()[0].payload).toBe(payload)
+    })
+
+    it('#then a per-item STORAGE_QUOTA_EXCEEDED rejection keeps the row and stops the batch', async () => {
+      const { coordinator, queue, ctx, stateManager } = createHarness(getDb())
+      const markPushSynced = vi.fn()
+      getHandlerMock.mockReturnValue({ markPushSynced })
+      postToServerMock.mockImplementation(async (_path: string, body: PushBody) => ({
+        accepted: [],
+        rejected: body.items.map((i) => ({ id: i.id, reason: 'STORAGE_QUOTA_EXCEEDED' })),
+        serverTime: Math.floor(Date.now() / 1000),
+        maxCursor: 0
+      }))
+
+      const payload = JSON.stringify({ title: 'Over quota' })
+      queue.enqueue({ type: 'note', itemId: 'note-1', operation: 'update', payload })
+
+      await coordinator.push()
+
+      expect(queue.getSize()).toBe(1)
+      expect(queue.peek()[0].payload).toBe(payload)
+      expect(markPushSynced).not.toHaveBeenCalled()
+      expect(ctx.lastErrorInfo).toEqual({
+        category: 'storage_quota_exceeded',
+        message: 'errors:sync.storageQuotaExceeded',
+        retryable: false
+      })
+      expect(ctx.lastError).toBe('errors:sync.storageQuotaExceeded')
+      expect(stateManager.setState).toHaveBeenCalledWith('error')
+    })
+  })
+
+  describe('#given a second edit lands while the first is in flight', () => {
+    it('#then the newer payload survives and is the one that reaches the server', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      const markSuccessSpy = vi.spyOn(queue, 'markSuccess')
+
+      const v1 = JSON.stringify({ title: 'first' })
+      const v2 = JSON.stringify({ title: 'second' })
+      queue.enqueue({ type: 'task', itemId: 'task-1', operation: 'update', payload: v1 })
+
+      let coalesced = false
+      postToServerMock.mockImplementation(async (_path: string, body: PushBody) => {
+        if (!coalesced) {
+          coalesced = true
+          // enqueue() coalesces into the same attempts=0 row that is in flight.
+          queue.enqueue({ type: 'task', itemId: 'task-1', operation: 'update', payload: v2 })
+        }
+        return {
+          accepted: body.items.map((i) => i.id),
+          rejected: [],
+          serverTime: Math.floor(Date.now() / 1000),
+          maxCursor: 0
+        }
+      })
+
+      await coordinator.push()
+
+      // The ack for the first push is payload-conditional, so it must NOT delete
+      // the row that now holds v2. (Losing that delete guard is what once synced
+      // renamed notes across devices as "Untitled".)
+      expect(markSuccessSpy.mock.results[0].value).toBe(false)
+
+      expect(postToServerMock).toHaveBeenCalledTimes(2)
+      const first = postToServerMock.mock.calls[0][1] as PushBody
+      const second = postToServerMock.mock.calls[1][1] as PushBody
+      expect(first.items[0].encryptedData).toBe(v1)
+      expect(second.items[0].encryptedData).toBe(v2)
+
+      expect(queue.getSize()).toBe(0)
+    })
+  })
+
+  describe('#given two queue rows for the same item in one batch', () => {
+    it('#then only one is pushed and the pushed payload is rebuilt fresh from local state', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      acceptAll()
+
+      const v1 = JSON.stringify({ title: 'first' })
+      const v2 = JSON.stringify({ title: 'second' })
+      queue.enqueue({ type: 'task', itemId: 'task-1', operation: 'update', payload: v1 })
+      // attempts > 0 stops enqueue() from coalescing, so the next edit opens a
+      // second row for the same (type, itemId).
+      queue.markFailed(queue.peek()[0].id, 'transient')
+      queue.enqueue({ type: 'task', itemId: 'task-1', operation: 'update', payload: v2 })
+      expect(queue.getSize()).toBe(2)
+
+      // Handlers rebuild the payload from the DB at push time; that rebuild — not
+      // the frozen queue payload — is what carries the newest local state.
+      getHandlerMock.mockReturnValue({ buildPushPayload: () => v2, markPushSynced: vi.fn() })
+
+      await coordinator.push()
+
+      expect(postToServerMock).toHaveBeenCalledTimes(1)
+      const body = postToServerMock.mock.calls[0][1] as PushBody
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0].encryptedData).toBe(v2)
+      expect(queue.getSize()).toBe(0)
+    })
+  })
+
+  describe('#given sync is paused #when requestPush is called', () => {
+    it('#then no push is scheduled', () => {
+      const { coordinator, ctx, stateManager } = createHarness(getDb())
+      vi.mocked(stateManager.isPaused).mockReturnValue(true)
+
+      coordinator.requestPush()
+
+      expect(ctx.scheduleSync).not.toHaveBeenCalled()
+      coordinator.clearDebounce()
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/engine/sync-context.test.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest'
+import { SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+import {
+  BASE_RATE_LIMIT_BACKOFF_MS,
+  CORRUPT_ITEM_COOLDOWN_MS,
+  MAX_PUSH_ITERATIONS,
+  MAX_RATE_LIMIT_BACKOFF_MS,
+  PULL_PAGE_LIMIT,
+  PUSH_BATCH_SIZE,
+  QUARANTINE_ENTRY_TTL_MS,
+  QUARANTINE_MAX_ATTEMPTS,
+  SYNC_STATE_KEYS,
+  YIELD_EVERY_N_ITEMS,
+  itemRefKey,
+  yieldToEventLoop
+} from './sync-context'
+
+// sync-context.ts is mostly type declarations, which carry no runtime
+// behaviour worth asserting. What IS runtime, and what the coordinators all
+// depend on, is: the (type, id) key function, the persisted state key strings
+// (a data contract with every already-installed copy of the app), the
+// relationships between the tuning constants, and the event-loop yield.
+
+describe('itemRefKey', () => {
+  describe('#given the same id used by different item types #when keyed', () => {
+    it('#then the keys differ', () => {
+      // 2026-07-18 incident: ids are NOT unique across types (project 'inbox'
+      // vs tag 'inbox', folder_config ids are folder paths). An id-only key
+      // made two unrelated items share one piece of sync bookkeeping.
+      expect(itemRefKey('project', 'inbox')).not.toBe(itemRefKey('tag_definition', 'inbox'))
+      expect(itemRefKey('note', 'inbox')).not.toBe(itemRefKey('journal', 'inbox'))
+    })
+  })
+
+  describe('#given every known sync item type #when keyed with one shared id', () => {
+    it('#then every key is unique', () => {
+      const keys = SYNC_ITEM_TYPES.map((type) => itemRefKey(type, 'shared-id'))
+
+      expect(new Set(keys).size).toBe(SYNC_ITEM_TYPES.length)
+    })
+
+    it('#then no item type contains the separator, so the key stays unambiguous', () => {
+      // ids can legitimately contain ':' (folder_config ids are folder paths).
+      // The key only stays injective while no TYPE contains ':'.
+      for (const type of SYNC_ITEM_TYPES) {
+        expect(type).not.toContain(':')
+      }
+    })
+  })
+
+  describe('#given ids that contain the separator #when keyed', () => {
+    it('#then distinct ids still produce distinct keys', () => {
+      expect(itemRefKey('folder_config', 'Work/Q3: plans')).toBe('folder_config:Work/Q3: plans')
+      expect(itemRefKey('folder_config', 'a:b')).not.toBe(itemRefKey('folder_config', 'a:c'))
+    })
+  })
+
+  describe('#given the same (type, id) #when keyed twice', () => {
+    it('#then the key is stable', () => {
+      expect(itemRefKey('task', 't-1')).toBe(itemRefKey('task', 't-1'))
+    })
+  })
+})
+
+describe('SYNC_STATE_KEYS', () => {
+  describe('#given an existing install #when the app upgrades', () => {
+    it('#then the persisted key strings are unchanged', () => {
+      // These are literal primary keys in the sync_state table of every
+      // shipped install. Renaming one orphans its row: a lost cursor forces a
+      // full re-pull, a lost quarantine list re-processes poisoned items.
+      expect(SYNC_STATE_KEYS).toEqual({
+        LAST_CURSOR: 'lastCursor',
+        LAST_SYNC_AT: 'lastSyncAt',
+        SYNC_PAUSED: 'syncPaused',
+        INITIAL_SEED_DONE: 'initialSeedDone',
+        QUARANTINED_ITEMS: 'quarantinedItems',
+        LAST_MANIFEST_CHECK_AT: 'lastManifestCheckAt'
+      })
+    })
+
+    it('#then no two logical keys collide on the same row', () => {
+      const values = Object.values(SYNC_STATE_KEYS)
+
+      expect(new Set(values).size).toBe(values.length)
+    })
+  })
+})
+
+describe('sync tuning constants', () => {
+  describe('#given the rate limit backoff #when it escalates', () => {
+    it('#then the base is below the ceiling', () => {
+      // base >= max would clamp the very first retry to the ceiling and turn
+      // exponential backoff into a flat 5-minute stall.
+      expect(BASE_RATE_LIMIT_BACKOFF_MS).toBeGreaterThan(0)
+      expect(BASE_RATE_LIMIT_BACKOFF_MS).toBeLessThan(MAX_RATE_LIMIT_BACKOFF_MS)
+    })
+  })
+
+  describe('#given a quarantined item #when its cooldown and TTL interact', () => {
+    it('#then the entry outlives the retry cooldown', () => {
+      // A TTL shorter than the cooldown expires the bookkeeping before the
+      // item is eligible again, so it is retried (and re-quarantined) forever.
+      expect(QUARANTINE_ENTRY_TTL_MS).toBeGreaterThan(CORRUPT_ITEM_COOLDOWN_MS)
+      expect(QUARANTINE_MAX_ATTEMPTS).toBeGreaterThan(0)
+    })
+  })
+
+  describe('#given a large push backlog #when it is drained in batches', () => {
+    it('#then batch size and iteration cap can clear a realistic vault', () => {
+      expect(PUSH_BATCH_SIZE).toBeGreaterThan(0)
+      expect(MAX_PUSH_ITERATIONS).toBeGreaterThan(1)
+      expect(PUSH_BATCH_SIZE * MAX_PUSH_ITERATIONS).toBeGreaterThanOrEqual(1000)
+    })
+  })
+
+  describe('#given a pull page #when it is applied', () => {
+    it('#then the apply loop yields at least once per page', () => {
+      // YIELD_EVERY_N_ITEMS >= PULL_PAGE_LIMIT would let a full page block the
+      // main process without ever yielding, freezing the UI mid-sync.
+      expect(YIELD_EVERY_N_ITEMS).toBeGreaterThan(0)
+      expect(YIELD_EVERY_N_ITEMS).toBeLessThan(PULL_PAGE_LIMIT)
+    })
+  })
+})
+
+describe('yieldToEventLoop', () => {
+  describe('#given work queued on the event loop #when awaited', () => {
+    it('#then it resolves and lets pending callbacks run first', async () => {
+      const ran: string[] = []
+      setImmediate(() => ran.push('queued-callback'))
+
+      await yieldToEventLoop()
+
+      expect(ran).toEqual(['queued-callback'])
+    })
+
+    it('#then it resolves without a value and can be awaited repeatedly', async () => {
+      const spy = vi.fn()
+
+      await yieldToEventLoop()
+      spy()
+      await expect(yieldToEventLoop()).resolves.toBeUndefined()
+
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/folder-config-sync.test.ts
+++ b/apps/desktop/src/main/sync/folder-config-sync.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { folderConfigs } from '@memry/db-schema/schema/folder-configs'
+import { syncQueue } from '@memry/db-schema/schema/sync-queue'
+import { FolderConfigSyncPayloadSchema } from '@memry/contracts/sync-payloads'
+import { createTestDataDb, type TestDataDb } from '../../test/helpers/test-data-db'
+
+/**
+ * Push side of folder-config sync (the per-folder icon + saved-view record).
+ * Real `RecordSyncController`, real `SyncQueueManager`, real migrated
+ * in-memory data DB — nothing about the queue behaviour is simulated.
+ */
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { SyncQueueManager } from './queue'
+import {
+  FolderConfigSyncService,
+  getFolderConfigSyncService,
+  initFolderConfigSyncService,
+  resetFolderConfigSyncService
+} from './folder-config-sync'
+
+let db: TestDataDb
+let queue: SyncQueueManager
+
+function seedFolder(overrides: Record<string, unknown> = {}): void {
+  db.insert(folderConfigs)
+    .values({
+      path: 'Work',
+      icon: 'briefcase',
+      clock: {},
+      ...overrides
+    } as never)
+    .run()
+}
+
+function queueRows(): Array<typeof syncQueue.$inferSelect> {
+  return db.select().from(syncQueue).all()
+}
+
+function payloadOf(row: typeof syncQueue.$inferSelect | undefined): Record<string, unknown> {
+  return JSON.parse(row!.payload) as Record<string, unknown>
+}
+
+function storedClock(folderPath = 'Work'): unknown {
+  return db.select().from(folderConfigs).where(eq(folderConfigs.path, folderPath)).get()?.clock
+}
+
+function makeService(deviceId: string | null = 'device-a'): FolderConfigSyncService {
+  return new FolderConfigSyncService({ queue, db, getDeviceId: () => deviceId })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  db = createTestDataDb()
+  queue = new SyncQueueManager(db)
+  resetFolderConfigSyncService()
+})
+
+describe('FolderConfigSyncService push', () => {
+  it('enqueues exactly one folder_config create carrying the icon the user picked', () => {
+    seedFolder()
+
+    makeService().enqueueCreate('Work')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].type).toBe('folder_config')
+    expect(rows[0].itemId).toBe('Work')
+    expect(rows[0].operation).toBe('create')
+
+    const payload = payloadOf(rows[0])
+    expect(payload).toMatchObject({ path: 'Work', icon: 'briefcase', clock: { 'device-a': 1 } })
+    expect(FolderConfigSyncPayloadSchema.safeParse(payload).success).toBe(true)
+  })
+
+  it('persists the bumped clock on the folder row', () => {
+    seedFolder({ clock: { 'device-b': 5 } })
+
+    makeService().enqueueUpdate('Work')
+
+    expect(storedClock()).toEqual({ 'device-b': 5, 'device-a': 1 })
+    expect(payloadOf(queueRows()[0]).clock).toEqual({ 'device-b': 5, 'device-a': 1 })
+  })
+
+  it('coalesces a later icon change into the pending push and keeps the newest icon', () => {
+    seedFolder()
+    const service = makeService()
+
+    service.enqueueCreate('Work')
+    db.update(folderConfigs).set({ icon: 'rocket' }).where(eq(folderConfigs.path, 'Work')).run()
+    service.enqueueUpdate('Work')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('create')
+    expect(payloadOf(rows[0])).toMatchObject({ icon: 'rocket', clock: { 'device-a': 2 } })
+  })
+
+  it('skips a folder that has no config row', () => {
+    makeService().enqueueUpdate('Ghost')
+
+    expect(queueRows()).toEqual([])
+  })
+
+  it('skips every mutation while there is no device id', () => {
+    seedFolder()
+    const service = makeService(null)
+
+    service.enqueueCreate('Work')
+    service.enqueueUpdate('Work')
+    service.enqueueDelete('Work')
+
+    expect(queueRows()).toEqual([])
+    expect(storedClock()).toEqual({})
+  })
+})
+
+describe('FolderConfigSyncService deletes', () => {
+  it('propagates a delete using the caller snapshot with the clock advanced', () => {
+    seedFolder()
+
+    makeService().enqueueDelete(
+      'Work',
+      JSON.stringify({ path: 'Work', icon: 'briefcase', clock: { 'device-a': 6 } })
+    )
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('delete')
+    expect(payloadOf(rows[0])).toEqual({
+      path: 'Work',
+      icon: 'briefcase',
+      clock: { 'device-a': 7 }
+    })
+  })
+
+  it('falls back to a minimal tombstone when the caller has no snapshot', () => {
+    makeService().enqueueDelete('Inbox')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].itemId).toBe('Inbox')
+    expect(rows[0].operation).toBe('delete')
+    expect(payloadOf(rows[0])).toEqual({ path: 'Inbox', icon: null, clock: { 'device-a': 1 } })
+  })
+
+  it('propagates a delete for a folder whose row is already gone', () => {
+    // The delete path never loads the row, so a folder removed from disk first
+    // still gets its tombstone out.
+    makeService().enqueueDelete('Archived')
+
+    expect(queueRows()).toHaveLength(1)
+  })
+
+  it('lets a delete win over a still-pending create instead of being dropped', () => {
+    seedFolder()
+    const service = makeService()
+
+    service.enqueueCreate('Work')
+    service.enqueueDelete('Work', JSON.stringify({ path: 'Work', icon: 'briefcase' }))
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('delete')
+  })
+})
+
+describe('folder config sync service lifecycle', () => {
+  it('tracks the module-level singleton', () => {
+    expect(getFolderConfigSyncService()).toBeNull()
+
+    const service = initFolderConfigSyncService({ queue, db, getDeviceId: () => 'device-a' })
+    expect(getFolderConfigSyncService()).toBe(service)
+
+    resetFolderConfigSyncService()
+    expect(getFolderConfigSyncService()).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/__tests__/agent-message-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/__tests__/agent-message-handler.test.ts
@@ -22,6 +22,27 @@ function freshDb() {
       updated_at INTEGER NOT NULL,
       deleted_at INTEGER
     );
+    -- applyUpsert requires the parent conversation to exist before it will
+    -- insert a message (MissingSyncParentError), so a message-only schema no
+    -- longer reflects reality. Seeded with the 'c1' parent every case here uses.
+    CREATE TABLE agent_conversations (
+      id TEXT PRIMARY KEY,
+      vault_id TEXT NOT NULL,
+      title_ciphertext TEXT NOT NULL,
+      backend TEXT NOT NULL,
+      backend_model TEXT,
+      trust_list TEXT NOT NULL DEFAULT '[]',
+      pinned INTEGER NOT NULL DEFAULT 0,
+      vector_clock TEXT NOT NULL,
+      field_clocks TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER,
+      last_synced_at INTEGER
+    );
+    INSERT INTO agent_conversations
+      (id, vault_id, title_ciphertext, backend, vector_clock, field_clocks, created_at, updated_at)
+    VALUES ('c1', 'v1', 'x', 'claude', '{}', '{}', 1, 1);
   `)
   return drizzle(sqlite, { schema })
 }

--- a/apps/desktop/src/main/sync/item-handlers/agent-conversation-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/agent-conversation-handler.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
+import sodium from 'libsodium-wrappers-sumo'
+import { eq } from 'drizzle-orm'
+import { agentConversations } from '@memry/db-schema/schema/agent-conversations'
+import { AgentChannels } from '@memry/contracts/ipc-agent'
+import type { AgentConversationSyncPayload } from '@memry/contracts/sync-payloads'
+import type { FieldClocks, VectorClock } from '@memry/contracts/sync-api'
+import { createTestDataDb, type TestDataDb } from '../../../test/helpers/test-data-db'
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { agentConversationHandler } from './agent-conversation-handler'
+import { decryptConversationTitle } from '../../agent/storage/conversation-store'
+
+const CHANGED = AgentChannels.events.CONVERSATIONS_CHANGED
+
+let db: TestDataDb
+let vaultKey: Uint8Array
+const emit = vi.fn()
+
+const ctx = (): { db: TestDataDb; emit: typeof emit; vaultKey: Uint8Array } => ({
+  db,
+  emit,
+  vaultKey
+})
+
+function payload(
+  overrides: Partial<AgentConversationSyncPayload> = {}
+): AgentConversationSyncPayload {
+  return {
+    vaultId: 'vault-1',
+    title: 'Remote conversation',
+    backend: 'claude_cli',
+    backendModel: null,
+    trustList: [],
+    pinned: false,
+    fieldClocks: {},
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides
+  }
+}
+
+function fieldClocksFor(clock: VectorClock): FieldClocks {
+  return {
+    title: { ...clock },
+    backend: { ...clock },
+    backendModel: { ...clock },
+    trustList: { ...clock },
+    pinned: { ...clock }
+  }
+}
+
+function titleOf(id: string): string | undefined {
+  const row = db.select().from(agentConversations).where(eq(agentConversations.id, id)).get()
+  return row ? decryptConversationTitle(row.titleCiphertext, vaultKey) : undefined
+}
+
+beforeAll(async () => {
+  await sodium.ready
+  vaultKey = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
+})
+
+beforeEach(() => {
+  db = createTestDataDb()
+  emit.mockClear()
+})
+
+describe('agentConversationHandler', () => {
+  it('inserts a conversation that does not exist locally and notifies the renderer', () => {
+    const result = agentConversationHandler.applyUpsert(ctx(), 'conv-1', payload(), { deviceA: 1 })
+
+    expect(result).toBe('applied')
+    expect(titleOf('conv-1')).toBe('Remote conversation')
+    expect(emit).toHaveBeenCalledWith(CHANGED, { conversationId: 'conv-1' })
+  })
+
+  it('applies a cleanly dominating remote update and notifies the renderer', () => {
+    agentConversationHandler.applyUpsert(
+      ctx(),
+      'conv-1',
+      payload({ fieldClocks: fieldClocksFor({ deviceA: 1 }) }),
+      { deviceA: 1 }
+    )
+    emit.mockClear()
+
+    const result = agentConversationHandler.applyUpsert(
+      ctx(),
+      'conv-1',
+      payload({
+        title: 'Renamed remotely',
+        fieldClocks: fieldClocksFor({ deviceA: 3 }),
+        updatedAt: 2000
+      }),
+      { deviceA: 3 }
+    )
+
+    expect(result).toBe('applied')
+    expect(titleOf('conv-1')).toBe('Renamed remotely')
+    expect(emit).toHaveBeenCalledWith(CHANGED, { conversationId: 'conv-1' })
+  })
+
+  it('skips a stale remote update and emits nothing', () => {
+    agentConversationHandler.applyUpsert(
+      ctx(),
+      'conv-1',
+      payload({ title: 'Local wins', fieldClocks: fieldClocksFor({ deviceA: 5 }) }),
+      { deviceA: 5 }
+    )
+    emit.mockClear()
+
+    const result = agentConversationHandler.applyUpsert(
+      ctx(),
+      'conv-1',
+      payload({ title: 'Stale remote', fieldClocks: fieldClocksFor({ deviceA: 2 }) }),
+      { deviceA: 2 }
+    )
+
+    expect(result).toBe('skipped')
+    expect(titleOf('conv-1')).toBe('Local wins')
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('merges concurrent edits, keeps the remote value, and notifies the renderer', () => {
+    agentConversationHandler.applyUpsert(
+      ctx(),
+      'conv-1',
+      payload({ title: 'Local title', fieldClocks: fieldClocksFor({ deviceA: 1 }) }),
+      { deviceA: 1 }
+    )
+    emit.mockClear()
+
+    const result = agentConversationHandler.applyUpsert(
+      ctx(),
+      'conv-1',
+      payload({
+        title: 'Remote title',
+        fieldClocks: fieldClocksFor({ deviceB: 1 }),
+        updatedAt: 2000
+      }),
+      { deviceB: 1 }
+    )
+
+    expect(result).toBe('conflict')
+    expect(titleOf('conv-1')).toBe('Remote title')
+    const row = db
+      .select()
+      .from(agentConversations)
+      .where(eq(agentConversations.id, 'conv-1'))
+      .get()
+    expect(row?.vectorClock).toEqual({ deviceA: 1, deviceB: 1 })
+    expect(emit).toHaveBeenCalledWith(CHANGED, { conversationId: 'conv-1' })
+  })
+
+  it('skips a merge that changes no field value and emits nothing', () => {
+    agentConversationHandler.applyUpsert(
+      ctx(),
+      'conv-1',
+      payload({ fieldClocks: fieldClocksFor({ deviceA: 1 }) }),
+      { deviceA: 1 }
+    )
+    emit.mockClear()
+
+    const result = agentConversationHandler.applyUpsert(
+      ctx(),
+      'conv-1',
+      payload({ fieldClocks: fieldClocksFor({ deviceB: 1 }) }),
+      { deviceB: 1 }
+    )
+
+    expect(result).toBe('skipped')
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('soft-deletes on delete and notifies the renderer', () => {
+    agentConversationHandler.applyUpsert(ctx(), 'conv-1', payload(), { deviceA: 1 })
+    emit.mockClear()
+
+    const result = agentConversationHandler.applyDelete(ctx(), 'conv-1', { deviceA: 2 })
+
+    expect(result).toBe('applied')
+    const row = db
+      .select()
+      .from(agentConversations)
+      .where(eq(agentConversations.id, 'conv-1'))
+      .get()
+    expect(row?.deletedAt).toBeTruthy()
+    expect(emit).toHaveBeenCalledWith(CHANGED, { conversationId: 'conv-1' })
+  })
+
+  it('skips a delete for an unknown or already-deleted row and emits nothing', () => {
+    expect(agentConversationHandler.applyDelete(ctx(), 'missing', { deviceA: 1 })).toBe('skipped')
+
+    agentConversationHandler.applyUpsert(ctx(), 'conv-1', payload(), { deviceA: 1 })
+    agentConversationHandler.applyDelete(ctx(), 'conv-1', { deviceA: 2 })
+    emit.mockClear()
+
+    expect(agentConversationHandler.applyDelete(ctx(), 'conv-1', { deviceA: 3 })).toBe('skipped')
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('returns skipped without emitting when no vault key is available', () => {
+    const result = agentConversationHandler.applyUpsert({ db, emit }, 'conv-1', payload(), {
+      deviceA: 1
+    })
+
+    expect(result).toBe('skipped')
+    expect(emit).not.toHaveBeenCalled()
+    expect(
+      db.select().from(agentConversations).where(eq(agentConversations.id, 'conv-1')).get()
+    ).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/agent-conversation-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/agent-conversation-handler.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { AgentConversationSyncPayloadSchema } from '@memry/contracts/sync-payloads'
 import type { AgentConversationSyncPayload } from '@memry/contracts/sync-payloads'
+import { AgentChannels } from '@memry/contracts/ipc-agent'
 import type { FieldClocks, VectorClock } from '@memry/contracts/sync-api'
 import { agentConversations } from '@memry/db-schema/schema/agent-conversations'
 import type { SyncQueueManager } from '../queue'
@@ -127,6 +128,7 @@ export class AgentConversationHandler extends BaseItemHandler<AgentConversationS
             lastSyncedAt: now
           })
           .run()
+        ctx.emit(AgentChannels.events.CONVERSATIONS_CHANGED, { conversationId: itemId })
         return 'applied'
       }
 
@@ -164,6 +166,7 @@ export class AgentConversationHandler extends BaseItemHandler<AgentConversationS
         if (fieldValuesEqual(localPayload, nextPayload)) return 'skipped'
 
         this.writeMerged(tx, itemId, nextPayload, vaultKey, now)
+        ctx.emit(AgentChannels.events.CONVERSATIONS_CHANGED, { conversationId: itemId })
         return merged.hadConflicts ? 'conflict' : 'applied'
       }
 
@@ -174,6 +177,7 @@ export class AgentConversationHandler extends BaseItemHandler<AgentConversationS
         deletedAt: data.deletedAt ?? null
       }
       this.writeMerged(tx, itemId, nextPayload, vaultKey, now)
+      ctx.emit(AgentChannels.events.CONVERSATIONS_CHANGED, { conversationId: itemId })
       return 'applied'
     })
   }
@@ -197,6 +201,7 @@ export class AgentConversationHandler extends BaseItemHandler<AgentConversationS
       .set({ deletedAt: now, updatedAt: now, lastSyncedAt: now })
       .where(eq(agentConversations.id, itemId))
       .run()
+    ctx.emit(AgentChannels.events.CONVERSATIONS_CHANGED, { conversationId: itemId })
     return 'applied'
   }
 

--- a/apps/desktop/src/main/sync/item-handlers/agent-message-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/agent-message-handler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
 import sodium from 'libsodium-wrappers-sumo'
 import { eq } from 'drizzle-orm'
 import { agentMessages } from '@memry/db-schema/schema/agent-messages'
+import { agentConversations } from '@memry/db-schema/schema/agent-conversations'
 import { AgentChannels } from '@memry/contracts/ipc-agent'
 import type { AgentMessageSyncPayload } from '@memry/contracts/sync-payloads'
 import { createTestDataDb, type TestDataDb } from '../../../test/helpers/test-data-db'
@@ -16,6 +17,8 @@ vi.mock('../../lib/logger', () => ({
 }))
 
 import { agentMessageHandler } from './agent-message-handler'
+import { MissingSyncParentError } from './types'
+import { encryptConversationTitle } from '../../agent/storage/conversation-store'
 
 const CHANGED = AgentChannels.events.MESSAGES_CHANGED
 const CONVERSATION_ID = 'conv-1'
@@ -44,6 +47,31 @@ function payload(overrides: Partial<AgentMessageSyncPayload> = {}): AgentMessage
   }
 }
 
+/**
+ * `agent_messages.conversation_id` has no FK, so the parent has to be seeded
+ * deliberately: without it the handler now defers the message for orphan repair
+ * instead of writing a row nothing can ever reach.
+ */
+function seedConversation(id: string): void {
+  db.insert(agentConversations)
+    .values({
+      id,
+      vaultId: 'vault-1',
+      titleCiphertext: encryptConversationTitle('Seeded conversation', vaultKey),
+      backend: 'claude_cli',
+      backendModel: null,
+      trustList: [],
+      pinned: false,
+      vectorClock: {},
+      fieldClocks: {},
+      createdAt: 1000,
+      updatedAt: 1000,
+      deletedAt: null,
+      lastSyncedAt: null
+    })
+    .run()
+}
+
 beforeAll(async () => {
   await sodium.ready
   vaultKey = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
@@ -51,11 +79,12 @@ beforeAll(async () => {
 
 beforeEach(() => {
   db = createTestDataDb()
+  seedConversation(CONVERSATION_ID)
   emit.mockClear()
 })
 
 describe('agentMessageHandler', () => {
-  it('inserts a message that does not exist locally and notifies the renderer', () => {
+  it('inserts a message whose conversation is already local and notifies the renderer', () => {
     const result = agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload(), { deviceA: 1 })
 
     expect(result).toBe('applied')
@@ -67,6 +96,55 @@ describe('agentMessageHandler', () => {
       conversationId: CONVERSATION_ID,
       messageId: 'msg-1'
     })
+  })
+
+  it('defers a message that arrives before its conversation instead of orphaning it', () => {
+    // conversation_id has no FK, so SQLite would happily write this row — and it
+    // would then be unreachable forever, since listByConversation is only called
+    // for conversations the UI knows about and an immutable message never gets a
+    // later remote update. MissingSyncParentError is the only error the pull
+    // coordinator routes into repairOrphans.
+    let thrown: unknown
+    try {
+      agentMessageHandler.applyUpsert(
+        ctx(),
+        'msg-early',
+        payload({ conversationId: 'conv-not-pulled-yet' }),
+        { deviceA: 1 }
+      )
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown).toBeInstanceOf(MissingSyncParentError)
+    expect((thrown as MissingSyncParentError).childType).toBe('agent_message')
+    expect((thrown as MissingSyncParentError).childId).toBe('msg-early')
+    expect((thrown as MissingSyncParentError).parentType).toBe('agent_conversation')
+    expect((thrown as MissingSyncParentError).parentId).toBe('conv-not-pulled-yet')
+    expect(
+      db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-early')).get()
+    ).toBeUndefined()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('accepts a message whose conversation is locally tombstoned', () => {
+    // repairOrphans asks fetchLocal whether the parent exists, and that returns
+    // soft-deleted rows too. Treating a tombstoned conversation as missing here
+    // would park the message in a repair loop it can never leave.
+    seedConversation('conv-deleted')
+    db.update(agentConversations)
+      .set({ deletedAt: 2000 })
+      .where(eq(agentConversations.id, 'conv-deleted'))
+      .run()
+
+    const result = agentMessageHandler.applyUpsert(
+      ctx(),
+      'msg-2',
+      payload({ conversationId: 'conv-deleted' }),
+      { deviceA: 1 }
+    )
+
+    expect(result).toBe('applied')
   })
 
   it('falls back to the payload clock when the envelope clock is empty', () => {
@@ -131,6 +209,43 @@ describe('agentMessageHandler', () => {
     expect(result).toBe('applied')
     const row = db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-1')).get()
     expect(row?.deletedAt).toBeTruthy()
+    expect(emit).toHaveBeenCalledWith(CHANGED, {
+      conversationId: CONVERSATION_ID,
+      messageId: 'msg-1'
+    })
+  })
+
+  it('skips a remote delete whose clock the local row already dominates', () => {
+    agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload({ clock: { deviceA: 5 } }), {
+      deviceA: 5
+    })
+    emit.mockClear()
+
+    const result = agentMessageHandler.applyDelete(ctx(), 'msg-1', { deviceA: 2 })
+
+    expect(result).toBe('skipped')
+    const row = db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-1')).get()
+    expect(row?.deletedAt).toBeNull()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('skips a remote delete that is concurrent with the local row', () => {
+    agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload(), { deviceA: 3 })
+    emit.mockClear()
+
+    const result = agentMessageHandler.applyDelete(ctx(), 'msg-1', { deviceB: 1 })
+
+    expect(result).toBe('skipped')
+    const row = db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-1')).get()
+    expect(row?.deletedAt).toBeNull()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('applies a delete with no clock, so an older peer keeps working', () => {
+    agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload(), { deviceA: 1 })
+    emit.mockClear()
+
+    expect(agentMessageHandler.applyDelete(ctx(), 'msg-1')).toBe('applied')
     expect(emit).toHaveBeenCalledWith(CHANGED, {
       conversationId: CONVERSATION_ID,
       messageId: 'msg-1'

--- a/apps/desktop/src/main/sync/item-handlers/agent-message-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/agent-message-handler.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
+import sodium from 'libsodium-wrappers-sumo'
+import { eq } from 'drizzle-orm'
+import { agentMessages } from '@memry/db-schema/schema/agent-messages'
+import { AgentChannels } from '@memry/contracts/ipc-agent'
+import type { AgentMessageSyncPayload } from '@memry/contracts/sync-payloads'
+import { createTestDataDb, type TestDataDb } from '../../../test/helpers/test-data-db'
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { agentMessageHandler } from './agent-message-handler'
+
+const CHANGED = AgentChannels.events.MESSAGES_CHANGED
+const CONVERSATION_ID = 'conv-1'
+
+let db: TestDataDb
+let vaultKey: Uint8Array
+const emit = vi.fn()
+
+const ctx = (): { db: TestDataDb; emit: typeof emit; vaultKey: Uint8Array } => ({
+  db,
+  emit,
+  vaultKey
+})
+
+function payload(overrides: Partial<AgentMessageSyncPayload> = {}): AgentMessageSyncPayload {
+  return {
+    conversationId: CONVERSATION_ID,
+    role: 'user',
+    content: { role: 'user', data: { text: 'hello from another device' } },
+    attachments: [],
+    toolCallId: null,
+    status: 'completed',
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides
+  }
+}
+
+beforeAll(async () => {
+  await sodium.ready
+  vaultKey = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
+})
+
+beforeEach(() => {
+  db = createTestDataDb()
+  emit.mockClear()
+})
+
+describe('agentMessageHandler', () => {
+  it('inserts a message that does not exist locally and notifies the renderer', () => {
+    const result = agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload(), { deviceA: 1 })
+
+    expect(result).toBe('applied')
+    const row = db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-1')).get()
+    expect(row?.conversationId).toBe(CONVERSATION_ID)
+    expect(row?.status).toBe('completed')
+    expect(row?.vectorClock).toEqual({ deviceA: 1 })
+    expect(emit).toHaveBeenCalledWith(CHANGED, {
+      conversationId: CONVERSATION_ID,
+      messageId: 'msg-1'
+    })
+  })
+
+  it('falls back to the payload clock when the envelope clock is empty', () => {
+    agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload({ clock: { deviceB: 4 } }), {})
+
+    const row = db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-1')).get()
+    expect(row?.vectorClock).toEqual({ deviceB: 4 })
+  })
+
+  it('skips a redelivery of the identical payload and emits nothing', () => {
+    agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload(), { deviceA: 2 })
+    emit.mockClear()
+
+    // Messages are immutable, so the handler dedupes on a payload hash rather
+    // than a vector-clock comparison: an older clock on the same body is still
+    // a no-op redelivery.
+    const result = agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload(), { deviceA: 1 })
+
+    expect(result).toBe('skipped')
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('reports a conflict without rewriting the row or emitting when the body differs', () => {
+    agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload(), { deviceA: 1 })
+    const before = db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-1')).get()
+    emit.mockClear()
+
+    const result = agentMessageHandler.applyUpsert(
+      ctx(),
+      'msg-1',
+      payload({ content: { role: 'user', data: { text: 'different body' } } }),
+      { deviceB: 9 }
+    )
+
+    expect(result).toBe('conflict')
+    const after = db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-1')).get()
+    expect(after?.contentCiphertext).toBe(before?.contentCiphertext)
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-terminal status as a parse error without emitting', () => {
+    const result = agentMessageHandler.applyUpsert(
+      ctx(),
+      'msg-1',
+      { ...payload(), status: 'streaming' } as unknown as AgentMessageSyncPayload,
+      { deviceA: 1 }
+    )
+
+    expect(result).toBe('parse_error')
+    expect(
+      db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-1')).get()
+    ).toBeUndefined()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('soft-deletes on delete and notifies the renderer', () => {
+    agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload(), { deviceA: 1 })
+    emit.mockClear()
+
+    const result = agentMessageHandler.applyDelete(ctx(), 'msg-1', { deviceA: 2 })
+
+    expect(result).toBe('applied')
+    const row = db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-1')).get()
+    expect(row?.deletedAt).toBeTruthy()
+    expect(emit).toHaveBeenCalledWith(CHANGED, {
+      conversationId: CONVERSATION_ID,
+      messageId: 'msg-1'
+    })
+  })
+
+  it('skips a delete for an unknown or already-deleted row and emits nothing', () => {
+    expect(agentMessageHandler.applyDelete(ctx(), 'missing', { deviceA: 1 })).toBe('skipped')
+
+    agentMessageHandler.applyUpsert(ctx(), 'msg-1', payload(), { deviceA: 1 })
+    agentMessageHandler.applyDelete(ctx(), 'msg-1', { deviceA: 2 })
+    emit.mockClear()
+
+    expect(agentMessageHandler.applyDelete(ctx(), 'msg-1', { deviceA: 3 })).toBe('skipped')
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('returns skipped without emitting when no vault key is available', () => {
+    const result = agentMessageHandler.applyUpsert({ db, emit }, 'msg-1', payload(), { deviceA: 1 })
+
+    expect(result).toBe('skipped')
+    expect(emit).not.toHaveBeenCalled()
+    expect(
+      db.select().from(agentMessages).where(eq(agentMessages.id, 'msg-1')).get()
+    ).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/agent-message-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/agent-message-handler.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import { AgentMessageSyncPayloadSchema } from '@memry/contracts/sync-payloads'
 import type { AgentMessageSyncPayload } from '@memry/contracts/sync-payloads'
+import { AgentChannels } from '@memry/contracts/ipc-agent'
 import type { VectorClock } from '@memry/contracts/sync-api'
 import { agentMessages } from '@memry/db-schema/schema/agent-messages'
 import type { SyncQueueManager } from '../queue'
@@ -115,6 +116,10 @@ export class AgentMessageHandler extends BaseItemHandler<AgentMessageSyncPayload
             deletedAt: data.deletedAt ?? null
           })
           .run()
+        ctx.emit(AgentChannels.events.MESSAGES_CHANGED, {
+          conversationId: data.conversationId,
+          messageId: itemId
+        })
         return 'applied'
       }
 
@@ -135,6 +140,10 @@ export class AgentMessageHandler extends BaseItemHandler<AgentMessageSyncPayload
       .set({ deletedAt: Date.now(), updatedAt: Date.now() })
       .where(eq(agentMessages.id, itemId))
       .run()
+    ctx.emit(AgentChannels.events.MESSAGES_CHANGED, {
+      conversationId: existing.conversationId,
+      messageId: itemId
+    })
     return 'applied'
   }
 

--- a/apps/desktop/src/main/sync/item-handlers/agent-message-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/agent-message-handler.ts
@@ -5,6 +5,7 @@ import type { AgentMessageSyncPayload } from '@memry/contracts/sync-payloads'
 import { AgentChannels } from '@memry/contracts/ipc-agent'
 import type { VectorClock } from '@memry/contracts/sync-api'
 import { agentMessages } from '@memry/db-schema/schema/agent-messages'
+import { agentConversations } from '@memry/db-schema/schema/agent-conversations'
 import type { SyncQueueManager } from '../queue'
 import {
   agentMessageRowToModel,
@@ -15,6 +16,7 @@ import { TERMINAL_STATUSES } from '../../agent/storage/types'
 import type { MessageStatus } from '../../agent/storage/types'
 import { createLogger } from '../../lib/logger'
 import { BaseItemHandler } from './base-handler'
+import { MissingSyncParentError } from './types'
 import type { ApplyContext, ApplyResult, DrizzleDb } from './types'
 
 const log = createLogger('AgentMessageHandler')
@@ -69,6 +71,49 @@ function isTerminal(status: string): boolean {
   return TERMINAL_STATUSES.has(status as MessageStatus)
 }
 
+/**
+ * `agent_messages.conversation_id` carries NO foreign key, so — unlike the
+ * task/project and calendar work in #837 — SQLite happily writes a message whose
+ * conversation has not been pulled yet. The row then exists but belongs to
+ * nothing: `listByConversation` is only ever called for a conversation the UI
+ * knows about, so the message is invisible forever, and because messages are
+ * immutable it never receives a later remote update that could reconcile it.
+ *
+ * Checking the parent by hand restores the convention the FK-bound handlers get
+ * for free: throw `MissingSyncParentError`, which is the only error
+ * pull-coordinator routes into `orphanedItems` → `repairOrphans`. That re-fetches
+ * the conversation by id (authoritative in a way the pull cursor window is not)
+ * and either replays the message once its conversation lands or tombstones it if
+ * the conversation is gone everywhere.
+ *
+ * Backward compatibility: nothing new goes on the wire and no payload written by
+ * an older app version is read differently — this only decides whether an
+ * out-of-order message is written now or a moment later. Throwing from inside
+ * the transaction leaves the DB exactly as it was, and the pull coordinator
+ * parks the item in `pendingApplyRetries`, so deferring cannot lose it. A peer
+ * on an older build is unaffected: it pushes the same message payload it always
+ * did, and its own (unguarded) apply keeps its previous behaviour.
+ *
+ * Soft-deleted conversations still count as present — `fetchLocal`, which
+ * `repairOrphans` uses to decide "parent exists locally", returns tombstoned
+ * rows too, so treating them as missing here would spin the repair loop.
+ */
+function requireConversation(tx: DrizzleDb, messageId: string, conversationId: string): void {
+  const parent = tx
+    .select({ id: agentConversations.id })
+    .from(agentConversations)
+    .where(eq(agentConversations.id, conversationId))
+    .get()
+  if (!parent) {
+    throw new MissingSyncParentError(
+      'agent_message',
+      messageId,
+      'agent_conversation',
+      conversationId
+    )
+  }
+}
+
 export class AgentMessageHandler extends BaseItemHandler<AgentMessageSyncPayload> {
   readonly type = 'agent_message' as const
   readonly schema = AgentMessageSyncPayloadSchema
@@ -101,6 +146,7 @@ export class AgentMessageHandler extends BaseItemHandler<AgentMessageSyncPayload
       const remoteClock = Object.keys(clock).length > 0 ? clock : (data.clock ?? {})
 
       if (!existing) {
+        requireConversation(tx as unknown as DrizzleDb, itemId, data.conversationId)
         tx.insert(agentMessages)
           .values({
             id: itemId,
@@ -131,9 +177,28 @@ export class AgentMessageHandler extends BaseItemHandler<AgentMessageSyncPayload
     })
   }
 
-  applyDelete(ctx: ApplyContext, itemId: string, _clock?: VectorClock): 'applied' | 'skipped' {
+  applyDelete(ctx: ApplyContext, itemId: string, clock?: VectorClock): 'applied' | 'skipped' {
     const existing = ctx.db.select().from(agentMessages).where(eq(agentMessages.id, itemId)).get()
     if (!existing || existing.deletedAt !== null) return 'skipped'
+
+    // Every other handler here gates a remote tombstone on the clock (see
+    // bookmark-handler / tag-category-handler); this one accepted it blindly, so
+    // a delete could win over a local row the deleting peer had never seen.
+    //
+    // Backward compatibility: this reads a clock that already travels with every
+    // delete envelope — nothing new is emitted, nothing new is required of a
+    // peer on an older build, and an absent clock keeps the previous
+    // unconditional behaviour. A message is frozen once terminal and only
+    // terminal messages sync, so a synced row's clock equals the tombstone's and
+    // still resolves to 'apply'; the only newly-skipped case is a row still
+    // being written locally, where losing the delete is the correct answer.
+    if (clock && existing.vectorClock) {
+      const resolution = this.resolveClock(existing.vectorClock, clock)
+      if (resolution.action === 'skip' || resolution.action === 'merge') {
+        log.info('Skipping remote agent message delete, local has unseen changes', { itemId })
+        return 'skipped'
+      }
+    }
 
     ctx.db
       .update(agentMessages)

--- a/apps/desktop/src/main/sync/item-handlers/calendar-binding-source-gaps.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/calendar-binding-source-gaps.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { calendarBindings } from '@memry/db-schema/schema/calendar-bindings'
+import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
+import { createTestDataDb, type TestDataDb } from '../../../test/helpers/test-data-db'
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { calendarBindingHandler } from './calendar-binding-handler'
+import { calendarSourceHandler } from './calendar-source-handler'
+
+/**
+ * Gap coverage for `calendar-source-binding-handlers.test.ts`, which already
+ * exercises every branch of both handlers (insert defaults, stale skip,
+ * concurrent conflict, all three delete outcomes, fetchLocal, buildPushPayload,
+ * seedUnclocked) but always sends a *complete* remote payload — so the
+ * `data.<field> ?? existing.<field>` merge contract that protects local values
+ * against a payload written by an older app version is never asserted. It also
+ * never asserts `ctx.emit` for the binding handler, nor on either delete path.
+ */
+
+let db: TestDataDb
+const emit = vi.fn()
+const ctx = () => ({ db, emit })
+
+beforeEach(() => {
+  db = createTestDataDb()
+  emit.mockClear()
+})
+
+describe('calendarSourceHandler — partial payload merge', () => {
+  it('keeps every local field the remote payload omits', () => {
+    calendarSourceHandler.applyUpsert(
+      ctx(),
+      'source-1',
+      {
+        provider: 'google',
+        kind: 'calendar',
+        accountId: 'account-1',
+        remoteId: 'remote-1',
+        title: 'Work',
+        timezone: 'Europe/Istanbul',
+        color: '#ff0000',
+        isPrimary: true,
+        isSelected: true,
+        isMemryManaged: true,
+        syncCursor: 'cursor-1',
+        syncStatus: 'ok',
+        lastSyncedAt: '2026-05-01T00:00:00.000Z',
+        metadata: { pageToken: 'next' }
+      },
+      { 'device-a': 1 }
+    )
+
+    // Older peer: dominating clock, but only the fields that version knows about.
+    expect(
+      calendarSourceHandler.applyUpsert(
+        ctx(),
+        'source-1',
+        { title: 'Work renamed' },
+        {
+          'device-a': 2
+        }
+      )
+    ).toBe('applied')
+
+    expect(
+      db.select().from(calendarSources).where(eq(calendarSources.id, 'source-1')).get()
+    ).toMatchObject({
+      title: 'Work renamed',
+      accountId: 'account-1',
+      remoteId: 'remote-1',
+      timezone: 'Europe/Istanbul',
+      color: '#ff0000',
+      isPrimary: true,
+      isSelected: true,
+      isMemryManaged: true,
+      syncCursor: 'cursor-1',
+      syncStatus: 'ok',
+      lastSyncedAt: '2026-05-01T00:00:00.000Z',
+      metadata: { pageToken: 'next' }
+    })
+  })
+
+  it('emits calendar:changed when a delete is applied', () => {
+    calendarSourceHandler.applyUpsert(ctx(), 'source-1', { title: 'Work' }, { 'device-a': 1 })
+    emit.mockClear()
+
+    expect(calendarSourceHandler.applyDelete(ctx(), 'source-1', { 'device-a': 2 })).toBe('applied')
+    expect(emit).toHaveBeenCalledWith('calendar:changed', {
+      entityType: 'calendar_source',
+      id: 'source-1'
+    })
+  })
+
+  it('emits nothing when a delete is skipped', () => {
+    calendarSourceHandler.applyUpsert(ctx(), 'source-1', { title: 'Work' }, { 'device-a': 5 })
+    emit.mockClear()
+
+    expect(calendarSourceHandler.applyDelete(ctx(), 'source-1', { 'device-a': 2 })).toBe('skipped')
+    expect(emit).not.toHaveBeenCalled()
+  })
+})
+
+describe('calendarBindingHandler — partial payload merge and events', () => {
+  it('keeps every local field the remote payload omits', () => {
+    calendarBindingHandler.applyUpsert(
+      ctx(),
+      'binding-1',
+      {
+        sourceType: 'task',
+        sourceId: 'task-1',
+        provider: 'google',
+        remoteCalendarId: 'calendar-1',
+        remoteEventId: 'event-1',
+        ownershipMode: 'provider_managed',
+        writebackMode: 'schedule_only',
+        remoteVersion: 'etag-1',
+        lastLocalSnapshot: { title: 'Task' }
+      },
+      { 'device-a': 1 }
+    )
+
+    expect(
+      calendarBindingHandler.applyUpsert(
+        ctx(),
+        'binding-1',
+        { remoteVersion: 'etag-2' },
+        {
+          'device-a': 2
+        }
+      )
+    ).toBe('applied')
+
+    expect(
+      db.select().from(calendarBindings).where(eq(calendarBindings.id, 'binding-1')).get()
+    ).toMatchObject({
+      sourceType: 'task',
+      sourceId: 'task-1',
+      remoteCalendarId: 'calendar-1',
+      remoteEventId: 'event-1',
+      ownershipMode: 'provider_managed',
+      writebackMode: 'schedule_only',
+      remoteVersion: 'etag-2',
+      lastLocalSnapshot: { title: 'Task' }
+    })
+  })
+
+  it('emits calendar:changed on insert, on update, and on an applied delete', () => {
+    calendarBindingHandler.applyUpsert(ctx(), 'binding-1', {}, { 'device-a': 1 })
+    expect(emit).toHaveBeenCalledWith('calendar:changed', {
+      entityType: 'calendar_binding',
+      id: 'binding-1'
+    })
+
+    emit.mockClear()
+    calendarBindingHandler.applyUpsert(
+      ctx(),
+      'binding-1',
+      { remoteVersion: 'etag-1' },
+      { 'device-a': 2 }
+    )
+    expect(emit).toHaveBeenCalledWith('calendar:changed', {
+      entityType: 'calendar_binding',
+      id: 'binding-1'
+    })
+
+    emit.mockClear()
+    expect(calendarBindingHandler.applyDelete(ctx(), 'binding-1', { 'device-a': 3 })).toBe(
+      'applied'
+    )
+    expect(emit).toHaveBeenCalledWith('calendar:changed', {
+      entityType: 'calendar_binding',
+      id: 'binding-1'
+    })
+  })
+
+  it('emits nothing when a delete is skipped', () => {
+    calendarBindingHandler.applyUpsert(ctx(), 'binding-1', {}, { 'device-a': 5 })
+    emit.mockClear()
+
+    expect(calendarBindingHandler.applyDelete(ctx(), 'binding-1', { 'device-b': 1 })).toBe(
+      'skipped'
+    )
+    expect(emit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/calendar-event-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/calendar-event-handler.ts
@@ -64,10 +64,26 @@ class CalendarEventHandler extends BaseItemHandler<CalendarEventSyncPayload> {
             remoteFC
           )
 
+          // Routing and recurrence identity are deliberately NOT in
+          // CALENDAR_EVENT_SYNCABLE_FIELDS — adding them would change the
+          // fieldClocks shape mid-flight and put entries on the wire that older
+          // peers never wrote. They are merged by presence instead: an absent
+          // key means the sender predates the field and the local value stands.
+          const hasMergeKey = (k: string): boolean => Object.prototype.hasOwnProperty.call(data, k)
+
           tx.update(calendarEvents)
             .set({
               ...result.merged,
               archivedAt: data.archivedAt ?? existing.archivedAt,
+              targetCalendarId: hasMergeKey('targetCalendarId')
+                ? (data.targetCalendarId ?? null)
+                : (existing.targetCalendarId ?? null),
+              parentEventId: hasMergeKey('parentEventId')
+                ? (data.parentEventId ?? null)
+                : (existing.parentEventId ?? null),
+              originalStartTime: hasMergeKey('originalStartTime')
+                ? (data.originalStartTime ?? null)
+                : (existing.originalStartTime ?? null),
               clock: resolution.mergedClock,
               fieldClocks: result.mergedFieldClocks,
               modifiedAt: data.modifiedAt ?? now
@@ -108,6 +124,15 @@ class CalendarEventHandler extends BaseItemHandler<CalendarEventSyncPayload> {
               ? (data.visibility ?? null)
               : (existing.visibility ?? null),
             colorId: hasKey('colorId') ? (data.colorId ?? null) : (existing.colorId ?? null),
+            targetCalendarId: hasKey('targetCalendarId')
+              ? (data.targetCalendarId ?? null)
+              : (existing.targetCalendarId ?? null),
+            parentEventId: hasKey('parentEventId')
+              ? (data.parentEventId ?? null)
+              : (existing.parentEventId ?? null),
+            originalStartTime: hasKey('originalStartTime')
+              ? (data.originalStartTime ?? null)
+              : (existing.originalStartTime ?? null),
             conferenceData: hasKey('conferenceData')
               ? ((data.conferenceData as CalendarEvent['conferenceData']) ?? null)
               : (existing.conferenceData ?? null),
@@ -145,6 +170,9 @@ class CalendarEventHandler extends BaseItemHandler<CalendarEventSyncPayload> {
           conferenceData:
             (data.conferenceData as CalendarEvent['conferenceData'] | undefined) ?? null,
           archivedAt: data.archivedAt ?? null,
+          targetCalendarId: data.targetCalendarId ?? null,
+          parentEventId: data.parentEventId ?? null,
+          originalStartTime: data.originalStartTime ?? null,
           clock: remoteClock,
           fieldClocks: insertedFC,
           createdAt: data.createdAt ?? now,
@@ -199,6 +227,12 @@ class CalendarEventHandler extends BaseItemHandler<CalendarEventSyncPayload> {
       colorId: row.colorId ?? null,
       conferenceData: (row.conferenceData as Record<string, unknown> | null) ?? null,
       archivedAt: row.archivedAt ?? null,
+      // The push coordinator prefers this rebuild over the frozen queue payload,
+      // so anything omitted here never reaches the peer even though serialize()
+      // carries it.
+      targetCalendarId: row.targetCalendarId ?? null,
+      parentEventId: row.parentEventId ?? null,
+      originalStartTime: row.originalStartTime ?? null,
       clock: (row.clock as VectorClock) ?? undefined,
       fieldClocks: row.fieldClocks ?? undefined,
       createdAt: row.createdAt,

--- a/apps/desktop/src/main/sync/item-handlers/calendar-external-event-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/calendar-external-event-handler.test.ts
@@ -6,6 +6,7 @@ import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
 import { CalendarExternalEventSyncPayloadSchema } from '@memry/contracts/sync-payloads'
 import { SyncQueueManager } from '../queue'
 import { getHandler } from './index'
+import { MissingSyncParentError } from './types'
 import type { ApplyContext, DrizzleDb } from './types'
 
 vi.mock('../../lib/logger', () => ({
@@ -261,6 +262,92 @@ describe('calendar external event handler — rich fields (M5 Codex P2c)', () =>
       colorId: null,
       conferenceData: null
     })
+  })
+
+  it('reports a create whose calendar_source has not landed as a typed missing parent', () => {
+    const handler = getHandler('calendar_external_event')
+
+    let thrown: unknown
+    try {
+      handler?.applyUpsert(
+        ctx,
+        'external-orphan',
+        {
+          sourceId: 'source-not-pulled-yet',
+          title: 'Imported',
+          startAt: '2026-04-20T09:00:00.000Z'
+        },
+        { 'device-b': 1 }
+      )
+    } catch (err) {
+      thrown = err
+    }
+
+    // Naming the parent is what routes the item into orphan repair instead of
+    // "skipped until next remote update" — an unchanged Google event has no
+    // next remote update, so a bare FK error loses it permanently.
+    expect(thrown).toBeInstanceOf(MissingSyncParentError)
+    expect((thrown as MissingSyncParentError).parentType).toBe('calendar_source')
+    expect((thrown as MissingSyncParentError).parentId).toBe('source-not-pulled-yet')
+
+    // The failed apply is fully rolled back — deferring must never half-write.
+    expect(
+      testDb.db
+        .select()
+        .from(calendarExternalEvents)
+        .where(eq(calendarExternalEvents.id, 'external-orphan'))
+        .get()
+    ).toBeUndefined()
+  })
+
+  it('reports a create with no sourceId at all rather than inventing an id that can only FK-fail', () => {
+    const handler = getHandler('calendar_external_event')
+
+    expect(() =>
+      handler?.applyUpsert(ctx, 'external-sourceless', { title: 'Imported' }, {})
+    ).toThrow(MissingSyncParentError)
+    expect(
+      testDb.db
+        .select()
+        .from(calendarExternalEvents)
+        .where(eq(calendarExternalEvents.id, 'external-sourceless'))
+        .get()
+    ).toBeUndefined()
+  })
+
+  it('reports an update that moves the event onto a source that has not landed', () => {
+    const handler = getHandler('calendar_external_event')
+    testDb.db
+      .insert(calendarExternalEvents)
+      .values({
+        id: 'external-moved',
+        sourceId: 'source-rich',
+        remoteEventId: 'google-moved',
+        title: 'Existing',
+        startAt: '2026-04-20T09:00:00.000Z',
+        clock: { 'device-a': 1 }
+      })
+      .run()
+
+    expect(() =>
+      handler?.applyUpsert(
+        ctx,
+        'external-moved',
+        { sourceId: 'source-added-later' },
+        {
+          'device-a': 2
+        }
+      )
+    ).toThrow(MissingSyncParentError)
+
+    // Rolled back: the row keeps the parent it had.
+    expect(
+      testDb.db
+        .select()
+        .from(calendarExternalEvents)
+        .where(eq(calendarExternalEvents.id, 'external-moved'))
+        .get()
+    ).toMatchObject({ sourceId: 'source-rich', title: 'Existing' })
   })
 
   it('handles stale/concurrent clocks, delete guards, fetch, null payload, and seed queueing', () => {

--- a/apps/desktop/src/main/sync/item-handlers/calendar-external-event-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/calendar-external-event-handler.ts
@@ -1,5 +1,6 @@
 import { eq, isNull } from 'drizzle-orm'
 import { calendarExternalEvents } from '@memry/db-schema/schema/calendar-external-events'
+import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
 import type {
   CalendarAttendee,
   CalendarConferenceData,
@@ -16,10 +17,50 @@ import type { SyncQueueManager } from '../queue'
 import { increment } from '../vector-clock'
 import { createLogger } from '../../lib/logger'
 import { BaseItemHandler } from './base-handler'
+import { MissingSyncParentError } from './types'
 import type { ApplyContext, ApplyResult, DrizzleDb } from './types'
 
 const log = createLogger('CalendarExternalEventHandler')
 const CALENDAR_CHANGED = 'calendar:changed'
+
+/**
+ * `calendar_external_events.source_id` is NOT NULL and FK-bound to
+ * `calendar_sources` (ON DELETE cascade), so an event whose source has not
+ * landed locally is unwritable. Surface it as a typed error naming the missing
+ * id instead of SQLite's anonymous `FOREIGN KEY constraint failed` (#837).
+ *
+ * Why the classification matters: pull-coordinator routes only
+ * `MissingSyncParentError` into `orphanedItems` → `repairOrphans`, which
+ * re-fetches the parent by id (authoritative in a way the pull cursor window is
+ * not) and then either replays the child or tombstones it. Any other error is
+ * logged as "deferred retry failed — item skipped until next remote update" and
+ * the item is dropped. An unchanged Google event never gets a next remote
+ * update, so it would stay invisible forever while the calendar_source itself
+ * syncs fine and the UI keeps reporting "connected".
+ *
+ * Backward compatibility: this only changes how an already-failing apply is
+ * classified. The write threw before and throws now, from inside the same
+ * transaction, so no row is written or mutated either way and no payload
+ * written by an older app version is read differently. Throwing is precisely
+ * what parks the item in `pendingApplyRetries`, so deferring cannot lose it:
+ * it replays once its source arrives, and if the source is gone everywhere the
+ * repair path tombstones it rather than re-pulling it forever.
+ */
+function requireCalendarSource(tx: DrizzleDb, eventId: string, sourceId: string): void {
+  const parent = tx
+    .select({ id: calendarSources.id })
+    .from(calendarSources)
+    .where(eq(calendarSources.id, sourceId))
+    .get()
+  if (!parent) {
+    throw new MissingSyncParentError(
+      'calendar_external_event',
+      eventId,
+      'calendar_source',
+      sourceId
+    )
+  }
+}
 
 class CalendarExternalEventHandler extends BaseItemHandler<CalendarExternalEventSyncPayload> {
   readonly type = 'calendar_external_event' as const
@@ -49,6 +90,11 @@ class CalendarExternalEventHandler extends BaseItemHandler<CalendarExternalEvent
 
         // M5 nullable rich fields: distinguish "omitted" from "explicit null".
         const hasKey = (k: string): boolean => Object.prototype.hasOwnProperty.call(data, k)
+
+        // An absent sourceId means "unchanged", and the existing parent is
+        // already valid — only a supplied one can point somewhere that has not
+        // landed yet (an event moved onto a newly added calendar).
+        if (data.sourceId) requireCalendarSource(tx as unknown as DrizzleDb, itemId, data.sourceId)
 
         tx.update(calendarExternalEvents)
           .set({
@@ -90,10 +136,19 @@ class CalendarExternalEventHandler extends BaseItemHandler<CalendarExternalEvent
         return resolution.action === 'merge' ? 'conflict' : 'applied'
       }
 
+      // A create must name its source. `source_id` is NOT NULL and FK-bound, so
+      // there is no id we could invent to stand in for a missing one — the old
+      // `?? 'unknown-source'` literal was exactly such an invention and could
+      // only ever FK-fail. Report the absence as a missing parent with no id so
+      // orphan repair asks the server, finds nothing, and tombstones the
+      // unwritable event instead of the pull silently dropping it on every run.
+      const sourceId = data.sourceId ?? ''
+      requireCalendarSource(tx as unknown as DrizzleDb, itemId, sourceId)
+
       tx.insert(calendarExternalEvents)
         .values({
           id: itemId,
-          sourceId: data.sourceId ?? 'unknown-source',
+          sourceId,
           remoteEventId: data.remoteEventId ?? itemId,
           remoteEtag: data.remoteEtag ?? null,
           remoteUpdatedAt: data.remoteUpdatedAt ?? null,

--- a/apps/desktop/src/main/sync/item-handlers/filter-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/filter-handler.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { savedFilters } from '@memry/db-schema/schema/settings'
+import { createTestDataDb, type TestDataDb } from '../../../test/helpers/test-data-db'
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { filterHandler } from './filter-handler'
+import { SyncQueueManager } from '../queue'
+
+let db: TestDataDb
+const emit = vi.fn()
+const ctx = () => ({ db, emit })
+const rowOf = (id: string) => db.select().from(savedFilters).where(eq(savedFilters.id, id)).get()
+
+beforeEach(() => {
+  db = createTestDataDb()
+  emit.mockClear()
+})
+
+describe('filterHandler', () => {
+  it('inserts a remote filter that does not exist locally and emits saved-filters:created', () => {
+    const result = filterHandler.applyUpsert(
+      ctx(),
+      'filter-1',
+      { name: 'Due today', config: { due: 'today' }, position: 2 },
+      { deviceA: 1 }
+    )
+
+    expect(result).toBe('applied')
+    const row = rowOf('filter-1')
+    expect(row).toMatchObject({
+      id: 'filter-1',
+      name: 'Due today',
+      config: { due: 'today' },
+      position: 2,
+      clock: { deviceA: 1 }
+    })
+    expect(row?.syncedAt).toBeTruthy()
+    expect(emit).toHaveBeenCalledWith('saved-filters:created', { id: 'filter-1' })
+  })
+
+  it('defaults a missing name to Untitled Filter on insert', () => {
+    expect(filterHandler.applyUpsert(ctx(), 'filter-1', {}, { deviceA: 1 })).toBe('applied')
+
+    expect(rowOf('filter-1')).toMatchObject({
+      name: 'Untitled Filter',
+      config: {},
+      position: 0
+    })
+  })
+
+  it('skips a stale remote update, leaves the local row untouched, and emits nothing', () => {
+    filterHandler.applyUpsert(
+      ctx(),
+      'filter-1',
+      { name: 'Local', config: { a: 1 }, position: 1 },
+      { deviceA: 5 }
+    )
+    emit.mockClear()
+    const before = rowOf('filter-1')
+
+    const result = filterHandler.applyUpsert(
+      ctx(),
+      'filter-1',
+      { name: 'Stale remote', config: { a: 9 }, position: 9 },
+      { deviceA: 2 }
+    )
+
+    expect(result).toBe('skipped')
+    expect(rowOf('filter-1')).toEqual(before)
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('reports a conflict on concurrent clocks, keeps the remote value, and merges the clock', () => {
+    filterHandler.applyUpsert(ctx(), 'filter-1', { name: 'Local', position: 1 }, { deviceA: 3 })
+    emit.mockClear()
+
+    const result = filterHandler.applyUpsert(
+      ctx(),
+      'filter-1',
+      { name: 'Remote', position: 4 },
+      { deviceB: 4 }
+    )
+
+    expect(result).toBe('conflict')
+    expect(rowOf('filter-1')).toMatchObject({
+      name: 'Remote',
+      position: 4,
+      clock: { deviceA: 3, deviceB: 4 }
+    })
+    expect(emit).toHaveBeenCalledWith('saved-filters:updated', { id: 'filter-1' })
+  })
+
+  it('applies and emits saved-filters:updated when the remote clock cleanly dominates', () => {
+    filterHandler.applyUpsert(ctx(), 'filter-1', { name: 'Local' }, { deviceA: 3 })
+    emit.mockClear()
+
+    const result = filterHandler.applyUpsert(
+      ctx(),
+      'filter-1',
+      { name: 'Newer', config: { due: 'week' }, position: 7 },
+      { deviceA: 7 }
+    )
+
+    expect(result).toBe('applied')
+    expect(rowOf('filter-1')).toMatchObject({
+      name: 'Newer',
+      config: { due: 'week' },
+      position: 7,
+      clock: { deviceA: 7 }
+    })
+    expect(emit).toHaveBeenCalledWith('saved-filters:updated', { id: 'filter-1' })
+  })
+
+  it('falls back to the payload clock when the transport clock is empty', () => {
+    expect(
+      filterHandler.applyUpsert(
+        ctx(),
+        'filter-1',
+        { name: 'From payload', clock: { deviceA: 2 } },
+        {}
+      )
+    ).toBe('applied')
+
+    expect(rowOf('filter-1')).toMatchObject({ clock: { deviceA: 2 } })
+  })
+
+  it('keeps name, config and position when the remote payload omits them', () => {
+    filterHandler.applyUpsert(
+      ctx(),
+      'filter-1',
+      { name: 'Kept', config: { due: 'today' }, position: 3 },
+      { deviceA: 1 }
+    )
+
+    expect(filterHandler.applyUpsert(ctx(), 'filter-1', {}, { deviceA: 2 })).toBe('applied')
+
+    expect(rowOf('filter-1')).toMatchObject({
+      name: 'Kept',
+      config: { due: 'today' },
+      position: 3,
+      clock: { deviceA: 2 }
+    })
+  })
+
+  it('never overwrites an existing name with the Untitled Filter insert default', () => {
+    filterHandler.applyUpsert(ctx(), 'filter-1', { name: 'Kept' }, { deviceA: 1 })
+
+    // Update with no name at all, then update with a concurrent clock: neither
+    // path may fall back to the insert-only 'Untitled Filter' default.
+    filterHandler.applyUpsert(ctx(), 'filter-1', { position: 5 }, { deviceA: 2 })
+    expect(rowOf('filter-1')?.name).toBe('Kept')
+
+    filterHandler.applyUpsert(ctx(), 'filter-1', { position: 6 }, { deviceB: 1 })
+    expect(rowOf('filter-1')?.name).toBe('Kept')
+  })
+
+  it('deletes the row and emits saved-filters:deleted when the remote delete clock dominates', () => {
+    filterHandler.applyUpsert(ctx(), 'filter-1', { name: 'Local' }, { deviceA: 1 })
+    emit.mockClear()
+
+    const result = filterHandler.applyDelete(ctx(), 'filter-1', { deviceA: 2 })
+
+    expect(result).toBe('applied')
+    expect(rowOf('filter-1')).toBeUndefined()
+    expect(emit).toHaveBeenCalledWith('saved-filters:deleted', { id: 'filter-1' })
+  })
+
+  it('skips a delete for an unknown filter and emits nothing', () => {
+    expect(filterHandler.applyDelete(ctx(), 'missing', { deviceA: 1 })).toBe('skipped')
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('skips a delete when the local clock is newer or concurrent', () => {
+    filterHandler.applyUpsert(ctx(), 'filter-1', { name: 'Local' }, { deviceA: 5 })
+    emit.mockClear()
+
+    expect(filterHandler.applyDelete(ctx(), 'filter-1', { deviceA: 2 })).toBe('skipped')
+    expect(filterHandler.applyDelete(ctx(), 'filter-1', { deviceB: 1 })).toBe('skipped')
+    expect(rowOf('filter-1')).toBeDefined()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('deletes unconditionally when the local row has never been clocked', () => {
+    db.insert(savedFilters).values({ id: 'filter-1', name: 'Unclocked', config: {} }).run()
+
+    expect(filterHandler.applyDelete(ctx(), 'filter-1', { deviceA: 1 })).toBe('applied')
+    expect(rowOf('filter-1')).toBeUndefined()
+  })
+
+  it('fetches the local row and reports undefined for an unknown id', () => {
+    filterHandler.applyUpsert(ctx(), 'filter-1', { name: 'Local' }, { deviceA: 1 })
+
+    expect(filterHandler.fetchLocal(db, 'filter-1')).toMatchObject({ name: 'Local' })
+    expect(filterHandler.fetchLocal(db, 'missing')).toBeUndefined()
+  })
+
+  it('builds a push payload that round-trips and returns null for a missing filter', () => {
+    filterHandler.applyUpsert(
+      ctx(),
+      'filter-1',
+      { name: 'Local', config: { due: 'today' }, position: 2 },
+      { deviceA: 1 }
+    )
+
+    const json = filterHandler.buildPushPayload(db, 'filter-1', 'deviceA', 'update')
+    expect(JSON.parse(json!)).toMatchObject({
+      id: 'filter-1',
+      name: 'Local',
+      config: { due: 'today' },
+      position: 2,
+      clock: { deviceA: 1 }
+    })
+    expect(filterHandler.buildPushPayload(db, 'missing', 'deviceA', 'update')).toBeNull()
+  })
+
+  it('stamps syncedAt on markPushSynced', () => {
+    db.insert(savedFilters).values({ id: 'filter-1', name: 'Local', config: {} }).run()
+    expect(rowOf('filter-1')?.syncedAt).toBeNull()
+
+    filterHandler.markPushSynced(db, 'filter-1')
+
+    expect(rowOf('filter-1')?.syncedAt).toBeTruthy()
+  })
+
+  it('seeds unclocked filters into the queue', () => {
+    db.insert(savedFilters)
+      .values([
+        { id: 'filter-unclocked', name: 'Unclocked', config: {} },
+        { id: 'filter-clocked', name: 'Clocked', config: {}, clock: { deviceA: 1 } }
+      ])
+      .run()
+
+    const queue = new SyncQueueManager(db)
+    expect(filterHandler.seedUnclocked(db, 'deviceA', queue)).toBe(1)
+
+    expect(rowOf('filter-unclocked')).toMatchObject({ clock: { deviceA: 1 } })
+
+    const [queued] = queue.dequeue(5)
+    expect(queued).toMatchObject({
+      type: 'filter',
+      itemId: 'filter-unclocked',
+      operation: 'create'
+    })
+    expect(JSON.parse(queued.payload)).toMatchObject({
+      id: 'filter-unclocked',
+      clock: { deviceA: 1 }
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/folder-config-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/folder-config-handler.test.ts
@@ -19,17 +19,47 @@ vi.mock('../../vault/folders', () => ({
   readFolderConfig: vi.fn()
 }))
 
+// Shared stub (not a fresh object per createLogger call) so the vault-write
+// failure paths can be asserted on.
+const logger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn()
+}))
+
 vi.mock('../../lib/logger', () => ({
-  createLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn()
-  })
+  createLogger: () => logger
 }))
 
 import { folderConfigHandler } from './folder-config-handler'
 import { writeFolderConfig, readFolderConfig } from '../../vault/folders'
+import { VaultError, VaultErrorCode } from '../../lib/errors'
+
+/**
+ * The vault mirror write is fire-and-forget, so give Node a chance to drain the
+ * microtask queue and emit `unhandledRejection` before asserting on it.
+ */
+async function flushPendingRejections(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve))
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
+/** Records anything Node reports as an unhandled rejection while `run` executes. */
+async function captureUnhandledRejections(run: () => void): Promise<unknown[]> {
+  const rejections: unknown[] = []
+  const onUnhandled = (reason: unknown): void => {
+    rejections.push(reason)
+  }
+  process.on('unhandledRejection', onUnhandled)
+  try {
+    run()
+    await flushPendingRejections()
+  } finally {
+    process.off('unhandledRejection', onUnhandled)
+  }
+  return rejections
+}
 
 const mockWriteFolderConfig = vi.mocked(writeFolderConfig)
 const mockReadFolderConfig = vi.mocked(readFolderConfig)
@@ -196,6 +226,122 @@ describe('folderConfigHandler', () => {
       const row = testDb.db.select().from(folderConfigs).where(eq(folderConfigs.path, 'docs')).get()
       expect(row!.icon).toBe('🔥')
       expect(row!.clock).toEqual({ 'device-A': 2, 'device-B': 3 })
+    })
+  })
+
+  // The .folder.md mirror is fire-and-forget, so a rejection there used to
+  // escape as an unhandled rejection in the main process — reachable in
+  // production whenever a folder_config lands while the vault is closed or
+  // mid-close (quit, vault switch, sign-out).
+  describe('vault mirror failures', () => {
+    it('#given no vault is open #when remote upsert arrives #then applies the DB row without an unhandled rejection', async () => {
+      mockReadFolderConfig.mockRejectedValue(
+        new VaultError('No vault is currently open', VaultErrorCode.NOT_INITIALIZED)
+      )
+
+      let result: string | undefined
+      const rejections = await captureUnhandledRejections(() => {
+        result = folderConfigHandler.applyUpsert(ctx, 'docs', { icon: '📁' }, { 'device-B': 1 })
+      })
+
+      expect(result).toBe('applied')
+      expect(rejections).toEqual([])
+
+      const row = testDb.db.select().from(folderConfigs).where(eq(folderConfigs.path, 'docs')).get()
+      expect(row!.icon).toBe('📁')
+      expect(ctx.emit as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+        'notes:folder-config-updated',
+        { path: 'docs' }
+      )
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Skipped folder config file write, no vault is open',
+        { itemId: 'docs' }
+      )
+      expect(logger.error).not.toHaveBeenCalled()
+    })
+
+    it('#given no vault is open #when remote delete arrives #then removes the DB row without an unhandled rejection', async () => {
+      testDb.db
+        .insert(folderConfigs)
+        .values({
+          path: 'old-folder',
+          icon: '📁',
+          clock: { 'device-A': 1 },
+          createdAt: '2026-04-10T00:00:00.000Z',
+          modifiedAt: '2026-04-10T00:00:00.000Z'
+        })
+        .run()
+      mockReadFolderConfig.mockRejectedValue(
+        new VaultError('No vault is currently open', VaultErrorCode.NOT_INITIALIZED)
+      )
+
+      let result: string | undefined
+      const rejections = await captureUnhandledRejections(() => {
+        result = folderConfigHandler.applyDelete(ctx, 'old-folder', {
+          'device-A': 1,
+          'device-B': 2
+        })
+      })
+
+      expect(result).toBe('applied')
+      expect(rejections).toEqual([])
+      expect(
+        testDb.db.select().from(folderConfigs).where(eq(folderConfigs.path, 'old-folder')).get()
+      ).toBeUndefined()
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Skipped folder config file write, no vault is open',
+        { itemId: 'old-folder' }
+      )
+    })
+
+    // Same shape as the registry emit probe: a bare data-db handle, no vault
+    // ever opened, and the REAL vault/folders module behind the mock. Guards
+    // the exemption removal in registry.test.ts.
+    it('#given the real vault module and no vault ever opened #when remote upsert arrives #then applies and emits without an unhandled rejection', async () => {
+      const actual =
+        await vi.importActual<typeof import('../../vault/folders')>('../../vault/folders')
+      mockReadFolderConfig.mockImplementation(actual.readFolderConfig)
+      mockWriteFolderConfig.mockImplementation(actual.writeFolderConfig)
+
+      let result: string | undefined
+      const rejections = await captureUnhandledRejections(() => {
+        result = folderConfigHandler.applyUpsert(
+          ctx,
+          'folder_config-registry-probe',
+          { icon: null },
+          { 'device-remote': 1 }
+        )
+      })
+
+      expect(result).toBe('applied')
+      expect(rejections).toEqual([])
+      expect(ctx.emit as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+        'notes:folder-config-updated',
+        { path: 'folder_config-registry-probe' }
+      )
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Skipped folder config file write, no vault is open',
+        { itemId: 'folder_config-registry-probe' }
+      )
+    })
+
+    it('#given the .folder.md write fails #when remote upsert arrives #then logs at error with the itemId instead of throwing', async () => {
+      const writeError = new Error('EACCES: permission denied')
+      mockWriteFolderConfig.mockRejectedValue(writeError)
+
+      let result: string | undefined
+      const rejections = await captureUnhandledRejections(() => {
+        result = folderConfigHandler.applyUpsert(ctx, 'docs', { icon: '📁' }, { 'device-B': 1 })
+      })
+
+      expect(result).toBe('applied')
+      expect(rejections).toEqual([])
+      expect(logger.error).toHaveBeenCalledWith('Failed to write synced folder config file', {
+        itemId: 'docs',
+        error: writeError
+      })
+      // A genuine write failure must not be downgraded to the benign no-vault path.
+      expect(logger.warn).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/desktop/src/main/sync/item-handlers/folder-config-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/folder-config-handler.ts
@@ -10,6 +10,7 @@ import type { VectorClock } from '@memry/contracts/sync-api'
 import type { SyncQueueManager } from '../queue'
 import { increment } from '../vector-clock'
 import { createLogger } from '../../lib/logger'
+import { VaultError, VaultErrorCode } from '../../lib/errors'
 import { BaseItemHandler } from './base-handler'
 import type { ApplyContext, ApplyResult, DrizzleDb } from './types'
 import { readFolderConfig, writeFolderConfig } from '../../vault/folders'
@@ -25,6 +26,33 @@ const log = createLogger('FolderConfigHandler')
 async function writeMergedFolderConfig(folderPath: string, icon: string | null): Promise<void> {
   const current = (await readFolderConfig(folderPath)) ?? {}
   await writeFolderConfig(folderPath, { ...current, icon })
+}
+
+/**
+ * Mirror the applied icon into .folder.md without letting the file write take
+ * down the apply.
+ *
+ * The DB row is the sync record and is written inside the surrounding
+ * transaction; the .folder.md write is a best-effort vault mirror, so it is
+ * deliberately fire-and-forget. Un-awaited it must still be `.catch()`-ed:
+ * `vault/folders` throws `VAULT_NOT_INITIALIZED` when no vault is open, so
+ * every folder_config applied while the vault is closed or mid-close (quit,
+ * vault switch, sign-out) otherwise surfaces as an unhandled promise rejection
+ * in the main process.
+ *
+ * The no-vault case is expected during those transitions and is logged at warn
+ * — it is a real DB/vault divergence (nothing re-mirrors the row on the next
+ * vault open) but not a fault worth drowning error telemetry in. Everything
+ * else is a genuine write failure and is logged at error with the itemId.
+ */
+function mirrorFolderConfigToVault(itemId: string, icon: string | null): void {
+  void writeMergedFolderConfig(itemId, icon).catch((error: unknown) => {
+    if (error instanceof VaultError && error.code === VaultErrorCode.NOT_INITIALIZED) {
+      log.warn('Skipped folder config file write, no vault is open', { itemId })
+      return
+    }
+    log.error('Failed to write synced folder config file', { itemId, error })
+  })
 }
 
 class FolderConfigHandler extends BaseItemHandler<FolderConfigSyncPayload> {
@@ -61,7 +89,7 @@ class FolderConfigHandler extends BaseItemHandler<FolderConfigSyncPayload> {
           .where(eq(folderConfigs.path, itemId))
           .run()
 
-        void writeMergedFolderConfig(itemId, data.icon ?? existing.icon)
+        mirrorFolderConfigToVault(itemId, data.icon ?? existing.icon)
         ctx.emit(NotesChannels.events.FOLDER_CONFIG_UPDATED, { path: itemId })
         return resolution.action === 'merge' ? 'conflict' : 'applied'
       }
@@ -76,7 +104,7 @@ class FolderConfigHandler extends BaseItemHandler<FolderConfigSyncPayload> {
         })
         .run()
 
-      void writeMergedFolderConfig(itemId, data.icon ?? null)
+      mirrorFolderConfigToVault(itemId, data.icon ?? null)
       ctx.emit(NotesChannels.events.FOLDER_CONFIG_UPDATED, { path: itemId })
       return 'applied'
     })
@@ -95,7 +123,7 @@ class FolderConfigHandler extends BaseItemHandler<FolderConfigSyncPayload> {
     }
 
     ctx.db.delete(folderConfigs).where(eq(folderConfigs.path, itemId)).run()
-    void writeMergedFolderConfig(itemId, null)
+    mirrorFolderConfigToVault(itemId, null)
     ctx.emit(NotesChannels.events.FOLDER_CONFIG_UPDATED, { path: itemId })
     return 'applied'
   }

--- a/apps/desktop/src/main/sync/item-handlers/inbox-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/inbox-handler.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { inboxItems } from '@memry/db-schema/schema/inbox'
+import { createTestDataDb, type TestDataDb } from '../../../test/helpers/test-data-db'
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { inboxHandler } from './inbox-handler'
+import { SyncQueueManager } from '../queue'
+
+let db: TestDataDb
+const emit = vi.fn()
+const ctx = () => ({ db, emit })
+const rowOf = (id: string) => db.select().from(inboxItems).where(eq(inboxItems.id, id)).get()
+
+beforeEach(() => {
+  db = createTestDataDb()
+  emit.mockClear()
+})
+
+describe('inboxHandler', () => {
+  it('inserts a remote item that does not exist locally and emits inbox:captured', () => {
+    const result = inboxHandler.applyUpsert(
+      ctx(),
+      'inbox-1',
+      {
+        title: 'Read later',
+        type: 'link',
+        content: 'excerpt',
+        sourceUrl: 'https://example.com',
+        sourceTitle: 'Example',
+        captureSource: 'clipper'
+      },
+      { deviceA: 1 }
+    )
+
+    expect(result).toBe('applied')
+    const row = rowOf('inbox-1')
+    expect(row).toMatchObject({
+      id: 'inbox-1',
+      title: 'Read later',
+      type: 'link',
+      content: 'excerpt',
+      sourceUrl: 'https://example.com',
+      sourceTitle: 'Example',
+      captureSource: 'clipper',
+      clock: { deviceA: 1 }
+    })
+    expect(row?.syncedAt).toBeTruthy()
+    expect(emit).toHaveBeenCalledWith('inbox:captured', { id: 'inbox-1' })
+  })
+
+  it('falls back to the Untitled/note defaults when the payload omits title and type', () => {
+    expect(inboxHandler.applyUpsert(ctx(), 'inbox-1', {}, { deviceA: 1 })).toBe('applied')
+
+    expect(rowOf('inbox-1')).toMatchObject({ title: 'Untitled', type: 'note' })
+  })
+
+  it('skips a stale remote update, leaves the local row untouched, and emits nothing', () => {
+    inboxHandler.applyUpsert(ctx(), 'inbox-1', { title: 'Local', type: 'note' }, { deviceA: 5 })
+    emit.mockClear()
+    const before = rowOf('inbox-1')
+
+    const result = inboxHandler.applyUpsert(
+      ctx(),
+      'inbox-1',
+      { title: 'Stale remote', type: 'link' },
+      { deviceA: 2 }
+    )
+
+    expect(result).toBe('skipped')
+    expect(rowOf('inbox-1')).toEqual(before)
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('reports a conflict on concurrent clocks, keeps the remote value, and merges the clock', () => {
+    inboxHandler.applyUpsert(ctx(), 'inbox-1', { title: 'Local' }, { deviceA: 3 })
+    emit.mockClear()
+
+    const result = inboxHandler.applyUpsert(ctx(), 'inbox-1', { title: 'Remote' }, { deviceB: 4 })
+
+    expect(result).toBe('conflict')
+    expect(rowOf('inbox-1')).toMatchObject({
+      title: 'Remote',
+      clock: { deviceA: 3, deviceB: 4 }
+    })
+    expect(emit).toHaveBeenCalledWith('inbox:updated', { id: 'inbox-1' })
+  })
+
+  it('applies and emits inbox:updated when the remote clock cleanly dominates', () => {
+    inboxHandler.applyUpsert(ctx(), 'inbox-1', { title: 'Local' }, { deviceA: 3 })
+    emit.mockClear()
+
+    const result = inboxHandler.applyUpsert(
+      ctx(),
+      'inbox-1',
+      { title: 'Newer', content: 'body' },
+      { deviceA: 7 }
+    )
+
+    expect(result).toBe('applied')
+    expect(rowOf('inbox-1')).toMatchObject({
+      title: 'Newer',
+      content: 'body',
+      clock: { deviceA: 7 }
+    })
+    expect(emit).toHaveBeenCalledWith('inbox:updated', { id: 'inbox-1' })
+  })
+
+  it('falls back to the payload clock when the transport clock is empty', () => {
+    expect(
+      inboxHandler.applyUpsert(
+        ctx(),
+        'inbox-1',
+        { title: 'From payload', clock: { deviceA: 2 } },
+        {}
+      )
+    ).toBe('applied')
+
+    expect(rowOf('inbox-1')).toMatchObject({ clock: { deviceA: 2 } })
+  })
+
+  it('keeps title, type and captureSource when the remote payload omits them', () => {
+    inboxHandler.applyUpsert(
+      ctx(),
+      'inbox-1',
+      { title: 'Kept', type: 'link', captureSource: 'clipper' },
+      { deviceA: 1 }
+    )
+
+    expect(inboxHandler.applyUpsert(ctx(), 'inbox-1', {}, { deviceA: 2 })).toBe('applied')
+
+    expect(rowOf('inbox-1')).toMatchObject({
+      title: 'Kept',
+      type: 'link',
+      captureSource: 'clipper'
+    })
+  })
+
+  it('carries filed, snoozed and archived state onto a first-time insert', () => {
+    // buildPushPayload ships the whole row, so an item archived on the origin
+    // device must not land un-archived on a device seeing it for the first time.
+    inboxHandler.applyUpsert(
+      ctx(),
+      'inbox-new',
+      {
+        title: 'Filed and archived',
+        filedAt: '2026-08-01T00:00:00.000Z',
+        filedTo: 'project-1',
+        filedAction: 'move',
+        snoozedUntil: '2026-09-01T00:00:00.000Z',
+        snoozeReason: 'later',
+        archivedAt: '2026-08-02T00:00:00.000Z'
+      },
+      { deviceA: 1 }
+    )
+
+    expect(rowOf('inbox-new')).toMatchObject({
+      filedAt: '2026-08-01T00:00:00.000Z',
+      filedTo: 'project-1',
+      filedAction: 'move',
+      snoozedUntil: '2026-09-01T00:00:00.000Z',
+      snoozeReason: 'later',
+      archivedAt: '2026-08-02T00:00:00.000Z'
+    })
+  })
+
+  // The two halves of the nullable-field contract. They pull in opposite
+  // directions, so both must be asserted: a blanket `?? null` fails the first,
+  // a blanket `?? existing` fails the second.
+  it('keeps local values for nullable keys the payload omits', () => {
+    inboxHandler.applyUpsert(
+      ctx(),
+      'inbox-1',
+      {
+        title: 'Kept',
+        content: 'excerpt',
+        sourceUrl: 'https://example.com',
+        sourceTitle: 'Example',
+        snoozedUntil: '2026-09-01T00:00:00.000Z',
+        archivedAt: '2026-08-01T00:00:00.000Z',
+        filedTo: 'project-1'
+      },
+      { deviceA: 1 }
+    )
+
+    // An app version predating those columns omits the keys entirely. It must
+    // not be read as an instruction to clear them.
+    inboxHandler.applyUpsert(ctx(), 'inbox-1', { title: 'Kept' }, { deviceA: 2 })
+
+    expect(rowOf('inbox-1')).toMatchObject({
+      content: 'excerpt',
+      sourceUrl: 'https://example.com',
+      sourceTitle: 'Example',
+      snoozedUntil: '2026-09-01T00:00:00.000Z',
+      archivedAt: '2026-08-01T00:00:00.000Z',
+      filedTo: 'project-1'
+    })
+  })
+
+  it('applies an explicit null as a remote clear', () => {
+    inboxHandler.applyUpsert(
+      ctx(),
+      'inbox-1',
+      {
+        title: 'Kept',
+        content: 'excerpt',
+        snoozedUntil: '2026-09-01T00:00:00.000Z',
+        snoozeReason: 'later',
+        archivedAt: '2026-08-01T00:00:00.000Z',
+        filedAt: '2026-08-01T00:00:00.000Z',
+        filedTo: 'project-1',
+        filedAction: 'move'
+      },
+      { deviceA: 1 }
+    )
+
+    // What unsnoozeItem / unarchive / unfile push from the other device
+    // (inbox/snooze.ts, inbox/crud.ts). buildPushPayload JSON.stringify's the
+    // whole row, so a cleared column arrives as a present key holding null.
+    inboxHandler.applyUpsert(
+      ctx(),
+      'inbox-1',
+      {
+        title: 'Kept',
+        content: null,
+        snoozedUntil: null,
+        snoozeReason: null,
+        archivedAt: null,
+        filedAt: null,
+        filedTo: null,
+        filedAction: null
+      },
+      { deviceA: 2 }
+    )
+
+    expect(rowOf('inbox-1')).toMatchObject({
+      content: null,
+      snoozedUntil: null,
+      snoozeReason: null,
+      archivedAt: null,
+      filedAt: null,
+      filedTo: null,
+      filedAction: null
+    })
+  })
+
+  it('deletes the row and emits inbox:archived when the remote delete clock dominates', () => {
+    inboxHandler.applyUpsert(ctx(), 'inbox-1', { title: 'Local' }, { deviceA: 1 })
+    emit.mockClear()
+
+    const result = inboxHandler.applyDelete(ctx(), 'inbox-1', { deviceA: 2 })
+
+    expect(result).toBe('applied')
+    expect(rowOf('inbox-1')).toBeUndefined()
+    expect(emit).toHaveBeenCalledWith('inbox:archived', { id: 'inbox-1' })
+  })
+
+  it('skips a delete for an unknown item and emits nothing', () => {
+    expect(inboxHandler.applyDelete(ctx(), 'missing', { deviceA: 1 })).toBe('skipped')
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('skips a delete when the local clock is newer or concurrent', () => {
+    inboxHandler.applyUpsert(ctx(), 'inbox-1', { title: 'Local' }, { deviceA: 5 })
+    emit.mockClear()
+
+    expect(inboxHandler.applyDelete(ctx(), 'inbox-1', { deviceA: 2 })).toBe('skipped')
+    expect(inboxHandler.applyDelete(ctx(), 'inbox-1', { deviceB: 1 })).toBe('skipped')
+    expect(rowOf('inbox-1')).toBeDefined()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('fetches the local row and reports undefined for an unknown id', () => {
+    inboxHandler.applyUpsert(ctx(), 'inbox-1', { title: 'Local' }, { deviceA: 1 })
+
+    expect(inboxHandler.fetchLocal(db, 'inbox-1')).toMatchObject({ title: 'Local' })
+    expect(inboxHandler.fetchLocal(db, 'missing')).toBeUndefined()
+  })
+
+  it('builds a push payload but never pushes local-only items', () => {
+    inboxHandler.applyUpsert(ctx(), 'inbox-1', { title: 'Local' }, { deviceA: 1 })
+
+    expect(
+      JSON.parse(inboxHandler.buildPushPayload(db, 'inbox-1', 'deviceA', 'update')!)
+    ).toMatchObject({ id: 'inbox-1', title: 'Local', clock: { deviceA: 1 } })
+    expect(inboxHandler.buildPushPayload(db, 'missing', 'deviceA', 'update')).toBeNull()
+
+    db.update(inboxItems).set({ localOnly: true }).where(eq(inboxItems.id, 'inbox-1')).run()
+    expect(inboxHandler.buildPushPayload(db, 'inbox-1', 'deviceA', 'update')).toBeNull()
+  })
+
+  it('stamps syncedAt on markPushSynced', () => {
+    db.insert(inboxItems).values({ id: 'inbox-1', title: 'Local', type: 'note' }).run()
+    expect(rowOf('inbox-1')?.syncedAt).toBeNull()
+
+    inboxHandler.markPushSynced(db, 'inbox-1')
+
+    expect(rowOf('inbox-1')?.syncedAt).toBeTruthy()
+  })
+
+  it('seeds unclocked items into the queue and leaves local-only items alone', () => {
+    db.insert(inboxItems)
+      .values([
+        { id: 'inbox-unclocked', title: 'Unclocked', type: 'note' },
+        { id: 'inbox-local', title: 'Local only', type: 'note', localOnly: true }
+      ])
+      .run()
+
+    const queue = new SyncQueueManager(db)
+    expect(inboxHandler.seedUnclocked(db, 'deviceA', queue)).toBe(1)
+
+    expect(rowOf('inbox-unclocked')).toMatchObject({ clock: { deviceA: 1 } })
+    expect(rowOf('inbox-local')?.clock).toBeNull()
+
+    const [queued] = queue.dequeue(5)
+    expect(queued).toMatchObject({
+      type: 'inbox',
+      itemId: 'inbox-unclocked',
+      operation: 'create'
+    })
+    expect(JSON.parse(queued.payload)).toMatchObject({
+      id: 'inbox-unclocked',
+      clock: { deviceA: 1 }
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/inbox-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/inbox-handler.ts
@@ -38,21 +38,36 @@ class InboxHandler extends BaseItemHandler<InboxSyncPayload> {
           log.warn('Concurrent inbox edit, using last-write-wins', { itemId })
         }
 
+        // Nullable fields distinguish "key omitted" from "key present and null".
+        // Omitted means the sender predates the column and must not clobber the
+        // local value; an explicit null IS the remote clear that unsnooze,
+        // unarchive and unfile push (inbox/snooze.ts, inbox/crud.ts). A blanket
+        // `?? null` destroys local data on an older payload; a blanket
+        // `?? existing` strands a remote unsnooze forever. Same approach as
+        // calendar-external-event-handler.ts.
+        const hasKey = (k: string): boolean => Object.prototype.hasOwnProperty.call(data, k)
+
         tx.update(inboxItems)
           .set({
             title: data.title ?? existing.title,
-            content: data.content ?? null,
+            content: hasKey('content') ? (data.content ?? null) : existing.content,
             type: data.type ?? existing.type,
-            metadata: data.metadata ?? null,
-            filedAt: data.filedAt ?? null,
-            filedTo: data.filedTo ?? null,
-            filedAction: data.filedAction ?? null,
-            snoozedUntil: data.snoozedUntil ?? null,
-            snoozeReason: data.snoozeReason ?? null,
-            archivedAt: data.archivedAt ?? null,
-            sourceUrl: data.sourceUrl ?? null,
-            sourceTitle: data.sourceTitle ?? null,
-            captureSource: data.captureSource ?? existing.captureSource ?? null,
+            metadata: hasKey('metadata') ? (data.metadata ?? null) : existing.metadata,
+            filedAt: hasKey('filedAt') ? (data.filedAt ?? null) : existing.filedAt,
+            filedTo: hasKey('filedTo') ? (data.filedTo ?? null) : existing.filedTo,
+            filedAction: hasKey('filedAction') ? (data.filedAction ?? null) : existing.filedAction,
+            snoozedUntil: hasKey('snoozedUntil')
+              ? (data.snoozedUntil ?? null)
+              : existing.snoozedUntil,
+            snoozeReason: hasKey('snoozeReason')
+              ? (data.snoozeReason ?? null)
+              : existing.snoozeReason,
+            archivedAt: hasKey('archivedAt') ? (data.archivedAt ?? null) : existing.archivedAt,
+            sourceUrl: hasKey('sourceUrl') ? (data.sourceUrl ?? null) : existing.sourceUrl,
+            sourceTitle: hasKey('sourceTitle') ? (data.sourceTitle ?? null) : existing.sourceTitle,
+            captureSource: hasKey('captureSource')
+              ? (data.captureSource ?? null)
+              : existing.captureSource,
             clock: resolution.mergedClock,
             syncedAt: now,
             modifiedAt: data.modifiedAt ?? now
@@ -72,6 +87,16 @@ class InboxHandler extends BaseItemHandler<InboxSyncPayload> {
           type: data.type ?? 'note',
           content: data.content ?? null,
           metadata: data.metadata ?? null,
+          // Carried on the insert too: buildPushPayload ships the whole row, so
+          // an item that is snoozed, filed or archived on the origin device must
+          // arrive that way on a device seeing it for the first time. Omitting
+          // these resurrected archived items into the peer's inbox.
+          filedAt: data.filedAt ?? null,
+          filedTo: data.filedTo ?? null,
+          filedAction: data.filedAction ?? null,
+          snoozedUntil: data.snoozedUntil ?? null,
+          snoozeReason: data.snoozeReason ?? null,
+          archivedAt: data.archivedAt ?? null,
           sourceUrl: data.sourceUrl ?? null,
           sourceTitle: data.sourceTitle ?? null,
           captureSource: data.captureSource ?? null,

--- a/apps/desktop/src/main/sync/item-handlers/note-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/note-handler.ts
@@ -119,13 +119,20 @@ function requestEmbeddedAttachmentDownloads(
   for (const attachmentId of refs) {
     const key = `${itemId}:${attachmentId}`
     if (requestedAttachmentDownloads.has(key)) continue
-    requestedAttachmentDownloads.add(key)
-    attachmentEvents.emitDownloadNeeded({
+    const delivered = attachmentEvents.emitDownloadNeeded({
       noteId: itemId,
       attachmentId,
       diskPath: attachmentsDir,
       intoDir: true
     })
+    // Only remember the request once it actually reached the downloader.
+    // `unregisterAttachmentHandlers()` removes every 'download-needed' listener
+    // on sync-runtime restart, sign-out/in and token churn, and this Set is
+    // never cleared — so marking a dropped emit as requested meant the image was
+    // never asked for again for the life of the process. Skipping the record
+    // lets the next pull of the same note re-request it; the downloader still
+    // skips files that already exist on disk, so a re-request is cheap.
+    if (delivered) requestedAttachmentDownloads.add(key)
   }
 }
 

--- a/apps/desktop/src/main/sync/item-handlers/registry.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/registry.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { SYNC_ITEM_TYPES, RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
+import type { SyncItemType } from '@memry/contracts/sync-api'
+import { createTestDataDb, type TestDataDb } from '../../../test/helpers/test-data-db'
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { getAllHandlers, getHandler } from './index'
+
+/**
+ * Types that are deliberately absent from the record-handler registry because
+ * they travel a different transport. Anything NOT listed here must resolve to a
+ * handler — `ItemApplier.apply` logs a warning and returns 'skipped' for an
+ * unregistered type, which is silent data loss on the receiving device.
+ */
+const NON_RECORD_TYPES: SyncItemType[] = [
+  // Blobs pushed/pulled through the attachment outbox + R2, never a record row.
+  'attachment'
+]
+
+/**
+ * Types excluded from the emit-via-`ctx.emit` probe only. They still have to
+ * satisfy every structural assertion above.
+ */
+const EMIT_PROBE_EXEMPT: Partial<Record<SyncItemType, string>> = {
+  // Writes the index DB as well as the data DB, so it cannot run against a bare
+  // data-db handle. Covered by note-handler.test.ts.
+  note: 'requires an initialised index database',
+  journal: 'requires an initialised index database',
+  // applyUpsert kicks off an un-awaited writeMergedFolderConfig() that throws
+  // VAULT_NOT_INITIALIZED without an open vault — an unhandled rejection here,
+  // and in main whenever a folder_config lands while the vault is closed.
+  folder_config: 'writes the vault folder config; needs an open vault',
+  // Notifies the renderer by walking BrowserWindow.getAllWindows() itself
+  // (settings-handler.ts) instead of going through ctx.emit.
+  settings: 'broadcasts directly via BrowserWindow, not ctx.emit'
+}
+
+/**
+ * Types that currently FAIL the invariant. Listed here so the suite stays green
+ * while the gap is tracked: each runs under `it.fails`, so the moment the
+ * handler starts notifying the renderer the test goes red and this entry must
+ * be deleted.
+ *
+ * agent_conversation / agent_message write the local DB on a remote pull and
+ * emit nothing — and nothing else in the main process broadcasts an agent
+ * conversation change either. A conversation synced from another device is
+ * therefore invisible in an already-running window until the app restarts.
+ */
+const KNOWN_MISSING_EMIT: SyncItemType[] = ['agent_conversation', 'agent_message']
+
+const PROJECT_ID = 'registry-probe-project'
+const CALENDAR_SOURCE_ID = 'registry-probe-calendar-source'
+
+/**
+ * Minimal valid payload per type. Most sync payload schemas are fully optional
+ * (handlers merge with `data.x ?? existing.x`), so `{}` parses. Types with a
+ * required field — or an FK parent — get an explicit fixture here.
+ */
+const FIXTURE_OVERRIDES: Partial<Record<SyncItemType, Record<string, unknown>>> = {
+  journal: { date: '2026-08-05' },
+  tag_definition: { name: 'registry-probe', color: '#00ff00' },
+  tag_category: { name: 'Registry Probe', sortOrder: 0 },
+  folder_config: { icon: null },
+  // tasks.project_id is NOT NULL and FK-bound (#837), so the parent is seeded
+  // in beforeEach and referenced here.
+  task: { projectId: PROJECT_ID },
+  calendar_external_event: { sourceId: CALENDAR_SOURCE_ID },
+  agent_conversation: {
+    vaultId: 'registry-probe-vault',
+    title: 'Registry probe',
+    backend: 'claude',
+    backendModel: null,
+    trustList: [],
+    pinned: false,
+    fieldClocks: {},
+    createdAt: 1,
+    updatedAt: 1
+  },
+  agent_message: {
+    conversationId: 'registry-probe-conversation',
+    role: 'user',
+    content: { role: 'user', data: { text: 'registry probe' } },
+    attachments: [],
+    toolCallId: null,
+    status: 'completed',
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+let db: TestDataDb
+
+beforeEach(() => {
+  db = createTestDataDb()
+
+  // Seed FK parents through their own handlers so the fixtures stay honest:
+  // if a parent handler stops applying, this fails loudly rather than silently
+  // weakening the child assertions.
+  const seedEmit = vi.fn()
+  const seedCtx = { db, emit: seedEmit, vaultKey: new Uint8Array(32) }
+
+  const projectHandler = getHandler('project')!
+  expect(projectHandler.applyUpsert(seedCtx, PROJECT_ID, {}, { 'device-seed': 1 })).toBe('applied')
+
+  const sourceHandler = getHandler('calendar_source')!
+  expect(sourceHandler.applyUpsert(seedCtx, CALENDAR_SOURCE_ID, {}, { 'device-seed': 1 })).toBe(
+    'applied'
+  )
+})
+
+describe('sync item handler registry', () => {
+  it('registers a handler for every syncable item type', () => {
+    const missing = SYNC_ITEM_TYPES.filter(
+      (type) => !NON_RECORD_TYPES.includes(type) && !getHandler(type)
+    )
+
+    expect(missing).toEqual([])
+  })
+
+  it('registers a handler for every record sync item type', () => {
+    const missing = RECORD_SYNC_ITEM_TYPES.filter((type) => !getHandler(type))
+
+    expect(missing).toEqual([])
+  })
+
+  it('maps every type key to a handler that declares the same type', () => {
+    const mismatched = SYNC_ITEM_TYPES.filter((type) => {
+      const handler = getHandler(type)
+      return handler !== undefined && handler.type !== type
+    })
+
+    expect(mismatched).toEqual([])
+  })
+
+  it('registers each handler under exactly one type', () => {
+    const handlers = getAllHandlers()
+    const declaredTypes = handlers.map((h) => h.type)
+
+    expect(new Set(declaredTypes).size).toBe(handlers.length)
+  })
+
+  describe('renderer notification', () => {
+    // A handler that mutates the local DB without emitting leaves the running
+    // renderer showing stale data until the app is restarted — the "vault is
+    // updated but the app does not refresh" class of report.
+    for (const type of SYNC_ITEM_TYPES) {
+      if (NON_RECORD_TYPES.includes(type)) continue
+      const exemption = EMIT_PROBE_EXEMPT[type]
+      if (exemption) {
+        it.skip(`${type}: emit probe skipped — ${exemption}`, () => {})
+        continue
+      }
+
+      const probe = KNOWN_MISSING_EMIT.includes(type) ? it.fails : it
+
+      probe(`${type}: emits a renderer event when a remote upsert is applied`, () => {
+        const handler = getHandler(type)
+        expect(handler, `no handler registered for ${type}`).toBeDefined()
+
+        const parsed = handler!.schema.safeParse(FIXTURE_OVERRIDES[type] ?? {})
+        expect(
+          parsed.success,
+          `no minimal fixture for ${type} — add one to FIXTURE_OVERRIDES`
+        ).toBe(true)
+
+        const emit = vi.fn()
+        const result = handler!.applyUpsert(
+          { db, emit, vaultKey: new Uint8Array(32) },
+          `${type}-registry-probe`,
+          parsed.success ? (parsed as { data: unknown }).data : {},
+          { 'device-remote': 1 }
+        )
+
+        if (result !== 'applied') {
+          // Only 'applied' obligates a broadcast; a skip/parse_error changed
+          // nothing locally so there is nothing for the renderer to re-read.
+          return
+        }
+
+        expect(
+          emit,
+          `${type} applied a remote upsert without notifying the renderer`
+        ).toHaveBeenCalled()
+      })
+    }
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/registry.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/registry.test.ts
@@ -34,27 +34,10 @@ const EMIT_PROBE_EXEMPT: Partial<Record<SyncItemType, string>> = {
   // data-db handle. Covered by note-handler.test.ts.
   note: 'requires an initialised index database',
   journal: 'requires an initialised index database',
-  // applyUpsert kicks off an un-awaited writeMergedFolderConfig() that throws
-  // VAULT_NOT_INITIALIZED without an open vault — an unhandled rejection here,
-  // and in main whenever a folder_config lands while the vault is closed.
-  folder_config: 'writes the vault folder config; needs an open vault',
   // Notifies the renderer by walking BrowserWindow.getAllWindows() itself
   // (settings-handler.ts) instead of going through ctx.emit.
   settings: 'broadcasts directly via BrowserWindow, not ctx.emit'
 }
-
-/**
- * Types that currently FAIL the invariant. Listed here so the suite stays green
- * while the gap is tracked: each runs under `it.fails`, so the moment the
- * handler starts notifying the renderer the test goes red and this entry must
- * be deleted.
- *
- * agent_conversation / agent_message write the local DB on a remote pull and
- * emit nothing — and nothing else in the main process broadcasts an agent
- * conversation change either. A conversation synced from another device is
- * therefore invisible in an already-running window until the app restarts.
- */
-const KNOWN_MISSING_EMIT: SyncItemType[] = ['agent_conversation', 'agent_message']
 
 const PROJECT_ID = 'registry-probe-project'
 const CALENDAR_SOURCE_ID = 'registry-probe-calendar-source'
@@ -159,9 +142,7 @@ describe('sync item handler registry', () => {
         continue
       }
 
-      const probe = KNOWN_MISSING_EMIT.includes(type) ? it.fails : it
-
-      probe(`${type}: emits a renderer event when a remote upsert is applied`, () => {
+      it(`${type}: emits a renderer event when a remote upsert is applied`, () => {
         const handler = getHandler(type)
         expect(handler, `no handler registered for ${type}`).toBeDefined()
 

--- a/apps/desktop/src/main/sync/item-handlers/registry.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/registry.test.ts
@@ -41,6 +41,7 @@ const EMIT_PROBE_EXEMPT: Partial<Record<SyncItemType, string>> = {
 
 const PROJECT_ID = 'registry-probe-project'
 const CALENDAR_SOURCE_ID = 'registry-probe-calendar-source'
+const CONVERSATION_ID = 'registry-probe-conversation'
 
 /**
  * Minimal valid payload per type. Most sync payload schemas are fully optional
@@ -68,7 +69,7 @@ const FIXTURE_OVERRIDES: Partial<Record<SyncItemType, Record<string, unknown>>> 
     updatedAt: 1
   },
   agent_message: {
-    conversationId: 'registry-probe-conversation',
+    conversationId: CONVERSATION_ID,
     role: 'user',
     content: { role: 'user', data: { text: 'registry probe' } },
     attachments: [],
@@ -97,6 +98,16 @@ beforeEach(() => {
   expect(sourceHandler.applyUpsert(seedCtx, CALENDAR_SOURCE_ID, {}, { 'device-seed': 1 })).toBe(
     'applied'
   )
+
+  const conversationHandler = getHandler('agent_conversation')!
+  expect(
+    conversationHandler.applyUpsert(
+      seedCtx,
+      CONVERSATION_ID,
+      conversationHandler.schema.parse(FIXTURE_OVERRIDES.agent_conversation),
+      { 'device-seed': 1 }
+    )
+  ).toBe('applied')
 })
 
 describe('sync item handler registry', () => {

--- a/apps/desktop/src/main/sync/item-handlers/tag-definition-color-preservation.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/tag-definition-color-preservation.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tag colour must survive sync.
+ *
+ * Live report (2026-07-21, macOS): "one of my primary tags is green and after
+ * updating some notes I noticed it's now red." A tag colour is a deliberate
+ * user choice; nothing that merely *touches* a tag — a pull from an older
+ * build, a re-index after a file edit — is allowed to repaint it.
+ *
+ * The colour reaches a tag definition down three separate paths, so this suite
+ * pins all three:
+ *   1. the wire   — `TagDefinitionSyncPayloadSchema` + `ItemApplier`
+ *   2. the merge  — `tagDefinitionHandler.applyUpsert`
+ *   3. the mint   — `getOrCreateTag`, which vault indexing calls for every tag
+ *                   it sees in a note and which picks a palette colour by
+ *                   *how many tags happen to exist right now*
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { tagDefinitions } from '@memry/db-schema/schema/tag-definitions'
+import {
+  TagDefinitionSyncPayloadSchema,
+  type TagDefinitionSyncPayload
+} from '@memry/contracts/sync-payloads'
+import { createTestDataDb, type TestDataDb } from '../../../test/helpers/test-data-db'
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { tagDefinitionHandler } from './tag-definition-handler'
+import { ensureTagDefinitions, getOrCreateTag } from '../../database/queries/tag-definitions'
+import { SyncQueueManager } from '../queue'
+import { ItemApplier } from '../apply-item'
+import type { ApplyContext, DrizzleDb } from './types'
+
+/** A payload from a build that does not know about `color` at all. */
+const withoutColor = (fields: Record<string, unknown>): TagDefinitionSyncPayload =>
+  fields as unknown as TagDefinitionSyncPayload
+
+/** The palette index `getOrCreateTag` lands on is `tagCount % palette.length`. */
+const GREEN_AT_TAG_COUNT = 11
+const RED_AT_TAG_COUNT = 22
+
+let db: TestDataDb
+let emit: ReturnType<typeof vi.fn>
+let ctx: ApplyContext
+let applier: ItemApplier
+
+const asSync = (handle: TestDataDb): DrizzleDb => handle as unknown as DrizzleDb
+
+function colorOf(handle: TestDataDb, name: string): string | undefined {
+  return handle.select().from(tagDefinitions).where(eq(tagDefinitions.name, name)).get()?.color
+}
+
+/** Mint `focus` locally as the Nth tag, so its palette colour is deterministic. */
+function mintTagAsNth(handle: TestDataDb, name: string, existingTags: number): string {
+  for (let i = 0; i < existingTags; i++) getOrCreateTag(handle, `filler-${i}`)
+  return getOrCreateTag(handle, name).color
+}
+
+beforeEach(() => {
+  db = createTestDataDb()
+  emit = vi.fn()
+  ctx = { db: asSync(db), emit }
+  applier = new ItemApplier(asSync(db), emit)
+})
+
+describe('tag colour: an incoming payload may only repaint a tag when it says so', () => {
+  beforeEach(() => {
+    tagDefinitionHandler.applyUpsert(ctx, 'focus', { name: 'focus', color: 'green' }, { mac: 1 })
+  })
+
+  it('keeps the local colour when a remote upsert omits color entirely', () => {
+    // An older build that predates a field sends it as `undefined`. Collapsing
+    // that into the insert default would repaint every tag it ever syncs.
+    const result = tagDefinitionHandler.applyUpsert(
+      ctx,
+      'focus',
+      withoutColor({ name: 'focus', categoryId: 'cat-1' }),
+      { mac: 2 }
+    )
+
+    expect(result).toBe('applied')
+    expect(colorOf(db, 'focus')).toBe('green')
+  })
+
+  it('keeps the local colour when an omitting payload arrives over the wire', () => {
+    // Second line of defence: `color` is required by the schema, so a payload
+    // without it never even reaches the merge — it is rejected, not defaulted.
+    expect(TagDefinitionSyncPayloadSchema.safeParse({ name: 'focus' }).success).toBe(false)
+
+    const result = applier.apply({
+      itemId: 'focus',
+      type: 'tag_definition',
+      operation: 'update',
+      content: new TextEncoder().encode(JSON.stringify({ name: 'focus', sortOrder: 4 })),
+      clock: { mac: 2 }
+    })
+
+    expect(result).toBe('skipped')
+    expect(colorOf(db, 'focus')).toBe('green')
+  })
+
+  it('applies an explicit new colour from a dominating clock', () => {
+    const result = applier.apply({
+      itemId: 'focus',
+      type: 'tag_definition',
+      operation: 'update',
+      content: new TextEncoder().encode(JSON.stringify({ name: 'focus', color: 'violet' })),
+      clock: { mac: 2 }
+    })
+
+    expect(result).toBe('applied')
+    expect(colorOf(db, 'focus')).toBe('violet')
+  })
+
+  it('leaves the colour alone when a newer build only moves the tag into a category', () => {
+    // A category assignment re-pushes the whole tag. It carries the colour it
+    // already had, so the round trip must be colour-neutral.
+    const result = tagDefinitionHandler.applyUpsert(
+      ctx,
+      'focus',
+      { name: 'focus', color: 'green', categoryId: 'cat-1', sortOrder: 2 },
+      { mac: 2 }
+    )
+
+    expect(result).toBe('applied')
+    expect(colorOf(db, 'focus')).toBe('green')
+  })
+
+  it('does not repaint on a stale update, even one carrying a different colour', () => {
+    tagDefinitionHandler.applyUpsert(ctx, 'focus', { name: 'focus', color: 'green' }, { mac: 5 })
+
+    const result = tagDefinitionHandler.applyUpsert(
+      ctx,
+      'focus',
+      { name: 'focus', color: 'red' },
+      { mac: 2 }
+    )
+
+    expect(result).toBe('skipped')
+    expect(colorOf(db, 'focus')).toBe('green')
+  })
+})
+
+describe('tag colour: note indexing must not re-colour a tag it did not create', () => {
+  it('returns the stored colour for a tag that already exists', () => {
+    tagDefinitionHandler.applyUpsert(ctx, 'focus', { name: 'focus', color: 'green' }, { mac: 1 })
+
+    // What the vault watcher runs for every tag in a note it just re-read.
+    ensureTagDefinitions(db, ['focus'])
+
+    expect(colorOf(db, 'focus')).toBe('green')
+  })
+
+  it('never falls back to the #808080 insert default when re-indexing a synced tag', () => {
+    // A tag pulled from another device with no colour of its own gets the grey
+    // default once. Re-indexing must keep that row, not mint a palette colour
+    // on top of it.
+    tagDefinitionHandler.applyUpsert(ctx, 'focus', withoutColor({ name: 'focus' }), { mac: 1 })
+    expect(colorOf(db, 'focus')).toBe('#808080')
+
+    ensureTagDefinitions(db, ['focus', 'reading', 'focus'])
+
+    expect(colorOf(db, 'focus')).toBe('#808080')
+    expect(colorOf(db, 'reading')).not.toBe('#808080')
+  })
+
+  it('keeps the colour when indexing sees the tag in different casing', () => {
+    tagDefinitionHandler.applyUpsert(ctx, 'focus', { name: 'focus', color: 'green' }, { mac: 1 })
+
+    ensureTagDefinitions(db, ['Focus', ' FOCUS '])
+
+    expect(db.select().from(tagDefinitions).all()).toHaveLength(1)
+    expect(colorOf(db, 'focus')).toBe('green')
+  })
+})
+
+/**
+ * The reported flip, reproduced end to end through real code only.
+ *
+ * `getOrCreateTag` colours a brand-new tag with `palette[tagCount % 24]`, so
+ * the same tag name mints *green* on the device where it was the 12th tag and
+ * *red* on the device where it was the 23rd. That auto-minted colour is then
+ * pushed like any user choice (`seedUnclocked`), lands as a concurrent clock on
+ * the first device, and last-write-wins repaints a colour the user picked with
+ * one nobody picked at all.
+ *
+ * Trigger matches the report exactly: the mint happens inside
+ * `ensureTagDefinitions`, which the vault watcher calls when notes are edited.
+ */
+describe('tag colour: green → red across devices (report 2026-07-21)', () => {
+  function pushLocallyMintedTag(handle: TestDataDb, deviceId: string): string {
+    const queue = new SyncQueueManager(handle)
+    tagDefinitionHandler.seedUnclocked(asSync(handle), deviceId, queue)
+    const row = queue.peek(200).find((item) => item.itemId === 'focus')
+    if (!row) throw new Error('expected the locally minted tag to be queued for push')
+    return row.payload
+  }
+
+  function replayOnDeviceA(payload: string): ReturnType<ItemApplier['apply']> {
+    // Parsed by the receiver's own schema first, exactly as ItemApplier does.
+    expect(TagDefinitionSyncPayloadSchema.safeParse(JSON.parse(payload)).success).toBe(true)
+    return applier.apply({
+      itemId: 'focus',
+      type: 'tag_definition',
+      operation: 'create',
+      content: new TextEncoder().encode(payload),
+      clock: { 'device-b': 1 }
+    })
+  }
+
+  it('documents the palette drift that makes the two devices disagree', () => {
+    const deviceB = createTestDataDb()
+
+    expect(mintTagAsNth(db, 'focus', GREEN_AT_TAG_COUNT)).toBe('green')
+    expect(mintTagAsNth(deviceB, 'focus', RED_AT_TAG_COUNT)).toBe('red')
+  })
+
+  it('documents CURRENT behaviour: the auto-minted red wins on the green device', () => {
+    mintTagAsNth(db, 'focus', GREEN_AT_TAG_COUNT)
+    pushLocallyMintedTag(db, 'device-a')
+
+    const deviceB = createTestDataDb()
+    mintTagAsNth(deviceB, 'focus', RED_AT_TAG_COUNT)
+
+    expect(replayOnDeviceA(pushLocallyMintedTag(deviceB, 'device-b'))).toBe('conflict')
+    expect(colorOf(db, 'focus')).toBe('red')
+  })
+
+  // BUG. A colour the user never chose — picked by a modulo over the local tag
+  // count — overwrites one they did. Because both sides are only ever "seeded",
+  // the clocks are concurrent and last-write-wins has no way to prefer the real
+  // choice. Fixing it means either not pushing an auto-minted colour as an
+  // authored value, or preferring the older `createdAt` on a concurrent tag
+  // merge. Delete `.fails` once that lands.
+  it.fails('a locally auto-minted colour must not repaint the tag on other devices', () => {
+    mintTagAsNth(db, 'focus', GREEN_AT_TAG_COUNT)
+    pushLocallyMintedTag(db, 'device-a')
+
+    const deviceB = createTestDataDb()
+    mintTagAsNth(deviceB, 'focus', RED_AT_TAG_COUNT)
+    replayOnDeviceA(pushLocallyMintedTag(deviceB, 'device-b'))
+
+    expect(colorOf(db, 'focus')).toBe('green')
+  })
+})

--- a/apps/desktop/src/main/sync/item-handlers/tag-definition-color-preservation.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/tag-definition-color-preservation.test.ts
@@ -33,7 +33,11 @@ vi.mock('../../lib/logger', () => ({
 }))
 
 import { tagDefinitionHandler } from './tag-definition-handler'
-import { ensureTagDefinitions, getOrCreateTag } from '../../database/queries/tag-definitions'
+import {
+  ensureTagDefinitions,
+  getOrCreateTag,
+  updateTagColor
+} from '../../database/queries/tag-definitions'
 import { SyncQueueManager } from '../queue'
 import { ItemApplier } from '../apply-item'
 import type { ApplyContext, DrizzleDb } from './types'
@@ -55,6 +59,12 @@ const asSync = (handle: TestDataDb): DrizzleDb => handle as unknown as DrizzleDb
 
 function colorOf(handle: TestDataDb, name: string): string | undefined {
   return handle.select().from(tagDefinitions).where(eq(tagDefinitions.name, name)).get()?.color
+}
+
+/** Did a human pick that colour, or did the palette hand it out? */
+function authoredFlagOf(handle: TestDataDb, name: string): boolean | undefined {
+  return handle.select().from(tagDefinitions).where(eq(tagDefinitions.name, name)).get()
+    ?.colorAuthored
 }
 
 /** Mint `focus` locally as the Nth tag, so its palette colour is deterministic. */
@@ -187,9 +197,13 @@ describe('tag colour: note indexing must not re-colour a tag it did not create',
  * `getOrCreateTag` colours a brand-new tag with `palette[tagCount % 24]`, so
  * the same tag name mints *green* on the device where it was the 12th tag and
  * *red* on the device where it was the 23rd. That auto-minted colour is then
- * pushed like any user choice (`seedUnclocked`), lands as a concurrent clock on
- * the first device, and last-write-wins repaints a colour the user picked with
- * one nobody picked at all.
+ * pushed like any user choice (`seedUnclocked`) and lands as a concurrent clock
+ * on the first device, where last-write-wins used to repaint a colour the user
+ * picked with one nobody picked at all.
+ *
+ * The fix is `color_authored`: the palette's pick travels marked as nobody's
+ * choice and may create a tag but never repaint one, while a colour set through
+ * the picker still wins the very same merge.
  *
  * Trigger matches the report exactly: the mint happens inside
  * `ensureTagDefinitions`, which the vault watcher calls when notes are edited.
@@ -222,31 +236,38 @@ describe('tag colour: green → red across devices (report 2026-07-21)', () => {
     expect(mintTagAsNth(deviceB, 'focus', RED_AT_TAG_COUNT)).toBe('red')
   })
 
-  it('documents CURRENT behaviour: the auto-minted red wins on the green device', () => {
+  it('a locally auto-minted colour must not repaint the tag on other devices', () => {
     mintTagAsNth(db, 'focus', GREEN_AT_TAG_COUNT)
     pushLocallyMintedTag(db, 'device-a')
 
     const deviceB = createTestDataDb()
     mintTagAsNth(deviceB, 'focus', RED_AT_TAG_COUNT)
+
+    // The clocks still merge — the rest of the row has to converge — but the
+    // colour is the one thing a concurrent seed may not decide.
+    expect(replayOnDeviceA(pushLocallyMintedTag(deviceB, 'device-b'))).toBe('conflict')
+    expect(colorOf(db, 'focus')).toBe('green')
+  })
+
+  it('still lets a colour the user actually picked win the same concurrent merge', () => {
+    // Same shape as above, but on device B the user opened the colour picker.
+    // Authorship, not the clock, is what separates the two cases.
+    mintTagAsNth(db, 'focus', GREEN_AT_TAG_COUNT)
+    pushLocallyMintedTag(db, 'device-a')
+
+    const deviceB = createTestDataDb()
+    mintTagAsNth(deviceB, 'focus', RED_AT_TAG_COUNT)
+    updateTagColor(deviceB, 'focus', 'red')
 
     expect(replayOnDeviceA(pushLocallyMintedTag(deviceB, 'device-b'))).toBe('conflict')
     expect(colorOf(db, 'focus')).toBe('red')
   })
 
-  // BUG. A colour the user never chose — picked by a modulo over the local tag
-  // count — overwrites one they did. Because both sides are only ever "seeded",
-  // the clocks are concurrent and last-write-wins has no way to prefer the real
-  // choice. Fixing it means either not pushing an auto-minted colour as an
-  // authored value, or preferring the older `createdAt` on a concurrent tag
-  // merge. Delete `.fails` once that lands.
-  it.fails('a locally auto-minted colour must not repaint the tag on other devices', () => {
-    mintTagAsNth(db, 'focus', GREEN_AT_TAG_COUNT)
-    pushLocallyMintedTag(db, 'device-a')
+  it('marks a tag authored only once someone picks its colour', () => {
+    getOrCreateTag(db, 'focus')
+    expect(authoredFlagOf(db, 'focus')).toBe(false)
 
-    const deviceB = createTestDataDb()
-    mintTagAsNth(deviceB, 'focus', RED_AT_TAG_COUNT)
-    replayOnDeviceA(pushLocallyMintedTag(deviceB, 'device-b'))
-
-    expect(colorOf(db, 'focus')).toBe('green')
+    updateTagColor(db, 'focus', 'violet')
+    expect(authoredFlagOf(db, 'focus')).toBe(true)
   })
 })

--- a/apps/desktop/src/main/sync/item-handlers/tag-definition-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/tag-definition-handler.ts
@@ -41,9 +41,27 @@ class TagDefinitionHandler extends BaseItemHandler<TagDefinitionSyncPayload> {
           log.warn('Concurrent tag definition edit, using last-write-wins', { itemId })
         }
 
+        // A colour the palette handed out is not a colour anyone chose.
+        // `getOrCreateTag` mints one from `palette[localTagCount % 24]`, so the
+        // same tag name is green on the device where it was the 12th tag and red
+        // where it was the 23rd. Both sides only ever "seed" that row, so the
+        // clocks come out concurrent and last-write-wins used to repaint a
+        // deliberate colour with one nobody picked (report 2026-07-21, a green
+        // tag turning red after some notes were edited).
+        //
+        // So an explicitly unauthored colour may create a tag (below) but may
+        // never repaint one. `undefined` is *not* "unauthored": only a build that
+        // knows this field can send `false`, and refusing every older payload
+        // would silently stop honouring real colour changes made on older builds.
+        // We honour such a colour without recording an authorship we never
+        // observed, so it is never re-asserted onward to a third device.
+        const takeRemoteColor = data.colorAuthored !== false && data.color !== undefined
+        const color = takeRemoteColor ? data.color : existing.color
+
         tx.update(tagDefinitions)
           .set({
-            color: data.color ?? existing.color,
+            color,
+            colorAuthored: takeRemoteColor ? data.colorAuthored === true : existing.colorAuthored,
             icon: data.icon !== undefined ? data.icon : existing.icon,
             categoryId: data.categoryId !== undefined ? data.categoryId : existing.categoryId,
             sortOrder: data.sortOrder ?? existing.sortOrder,
@@ -60,7 +78,9 @@ class TagDefinitionHandler extends BaseItemHandler<TagDefinitionSyncPayload> {
           writeTagViews(tx, itemId, data.views)
         }
 
-        ctx.emit(TagsChannels.events.COLOR_UPDATED, { tag: itemId, color: data.color })
+        // The colour the row actually kept, not the one that was offered — the
+        // renderer must not paint a repaint the merge just refused.
+        ctx.emit(TagsChannels.events.COLOR_UPDATED, { tag: itemId, color })
         ctx.emit('notes:tags-changed', {})
         return resolution.action === 'merge' ? 'conflict' : 'applied'
       }
@@ -69,6 +89,10 @@ class TagDefinitionHandler extends BaseItemHandler<TagDefinitionSyncPayload> {
         .values({
           name: itemId,
           color: data.color ?? '#808080',
+          // Creating a tag we do not have takes the sender's colour whatever its
+          // provenance — there is nothing here to overwrite. We only record
+          // authorship the sender actually asserted.
+          colorAuthored: data.colorAuthored === true,
           icon: data.icon ?? null,
           categoryId: data.categoryId ?? null,
           sortOrder: data.sortOrder ?? 0,
@@ -126,6 +150,7 @@ class TagDefinitionHandler extends BaseItemHandler<TagDefinitionSyncPayload> {
     const payload: TagDefinitionSyncPayload = {
       name: tag.name,
       color: tag.color,
+      colorAuthored: tag.colorAuthored,
       icon: tag.icon ?? null,
       categoryId: tag.categoryId ?? null,
       sortOrder: tag.sortOrder,

--- a/apps/desktop/src/main/sync/journal-sync.test.ts
+++ b/apps/desktop/src/main/sync/journal-sync.test.ts
@@ -1,0 +1,285 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { noteMetadata } from '@memry/db-schema/data-schema'
+import { syncQueue } from '@memry/db-schema/schema/sync-queue'
+import { JournalSyncPayloadSchema } from '@memry/contracts/sync-payloads'
+import { createTestDataDb, type TestDataDb } from '../../test/helpers/test-data-db'
+
+/**
+ * Push side of journal sync. Real `RecordSyncController`, real
+ * `SyncQueueManager`, real migrated in-memory data DB, real files on disk —
+ * only the vault path/parse edge is faked (the real module pulls in the whole
+ * vault runtime).
+ */
+
+const h = vi.hoisted(() => ({
+  db: null as unknown,
+  journalDir: '',
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => h.log
+}))
+
+vi.mock('../database/client', () => ({
+  getDatabase: () => h.db,
+  getIndexDatabase: () => ({})
+}))
+
+vi.mock('../vault/journal', async () => {
+  const matter = (await import('gray-matter')).default
+  return {
+    getJournalPath: (date: string) => path.join(h.journalDir, `${date}.md`),
+    parseJournalEntry: (raw: string, date: string) => {
+      const parsed = matter(raw)
+      return { frontmatter: parsed.data, content: parsed.content.trim(), date }
+    }
+  }
+})
+
+import { SyncQueueManager } from './queue'
+import {
+  JournalSyncService,
+  getJournalSyncService,
+  initJournalSyncService,
+  resetJournalSyncService
+} from './journal-sync'
+
+let db: TestDataDb
+let queue: SyncQueueManager
+
+const DATE = '2026-05-10'
+const JOURNAL_ID = 'journal-2026-05-10'
+const CREATED_AT = '2026-05-10T06:00:00.000Z'
+const MODIFIED_AT = '2026-05-10T21:30:00.000Z'
+
+function seedJournalNote(overrides: Record<string, unknown> = {}): void {
+  db.insert(noteMetadata)
+    .values({
+      id: JOURNAL_ID,
+      path: `journal/${DATE}.md`,
+      title: DATE,
+      fileType: 'markdown',
+      journalDate: DATE,
+      clock: {},
+      createdAt: CREATED_AT,
+      modifiedAt: MODIFIED_AT,
+      ...overrides
+    } as never)
+    .run()
+}
+
+function writeJournalFile(date: string, contents: string): void {
+  fs.writeFileSync(path.join(h.journalDir, `${date}.md`), contents, 'utf-8')
+}
+
+function queueRows(): Array<typeof syncQueue.$inferSelect> {
+  return db.select().from(syncQueue).all()
+}
+
+function payloadOf(row: typeof syncQueue.$inferSelect | undefined): Record<string, unknown> {
+  return JSON.parse(row!.payload) as Record<string, unknown>
+}
+
+function storedClock(): unknown {
+  return db.select().from(noteMetadata).where(eq(noteMetadata.id, JOURNAL_ID)).get()?.clock
+}
+
+function makeService(deviceId: string | null = 'device-a'): JournalSyncService {
+  return new JournalSyncService({ queue, getDeviceId: () => deviceId })
+}
+
+beforeAll(() => {
+  h.journalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-journal-sync-'))
+})
+
+afterAll(() => {
+  fs.rmSync(h.journalDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  db = createTestDataDb()
+  h.db = db
+  queue = new SyncQueueManager(db)
+  resetJournalSyncService()
+  writeJournalFile(
+    DATE,
+    '---\ntags:\n  - daily\nproperties:\n  Mood: good\n---\n\nWoke up early.\n'
+  )
+})
+
+describe('JournalSyncService push', () => {
+  it('enqueues exactly one journal create with the date, body, tags and properties', () => {
+    seedJournalNote()
+
+    makeService().enqueueCreate(JOURNAL_ID, DATE)
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].type).toBe('journal')
+    expect(rows[0].itemId).toBe(JOURNAL_ID)
+    expect(rows[0].operation).toBe('create')
+
+    const payload = payloadOf(rows[0])
+    expect(payload).toMatchObject({
+      date: DATE,
+      content: 'Woke up early.',
+      tags: ['daily'],
+      properties: { Mood: 'good' },
+      clock: { 'device-a': 1 },
+      createdAt: CREATED_AT,
+      modifiedAt: MODIFIED_AT
+    })
+    expect(JournalSyncPayloadSchema.safeParse(payload).success).toBe(true)
+  })
+
+  it('persists the bumped clock on the journal note row', () => {
+    seedJournalNote({ clock: { 'device-b': 2 } })
+
+    makeService().enqueueCreate(JOURNAL_ID, DATE)
+
+    expect(storedClock()).toEqual({ 'device-b': 2, 'device-a': 1 })
+  })
+
+  it('keeps the date and tags on an update even though the body is omitted', () => {
+    seedJournalNote()
+
+    makeService().enqueueUpdate(JOURNAL_ID, DATE)
+
+    const payload = payloadOf(queueRows()[0])
+    expect(queueRows()[0].operation).toBe('update')
+    expect(payload.date).toBe(DATE)
+    expect(payload.content).toBeNull()
+    expect(payload.tags).toEqual(['daily'])
+    expect(payload.properties).toEqual({ Mood: 'good' })
+  })
+
+  it('coalesces a follow-up update into the pending create with the newest frontmatter', () => {
+    seedJournalNote()
+    const service = makeService()
+
+    service.enqueueCreate(JOURNAL_ID, DATE)
+    writeJournalFile(DATE, '---\ntags:\n  - daily\n  - gratitude\n---\n\nWoke up early.\n')
+    service.enqueueUpdate(JOURNAL_ID, DATE)
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('create')
+    expect(payloadOf(rows[0]).tags).toEqual(['daily', 'gratitude'])
+  })
+
+  it('still pushes the date when the journal file cannot be read', () => {
+    seedJournalNote()
+    fs.rmSync(path.join(h.journalDir, `${DATE}.md`))
+
+    makeService().enqueueCreate(JOURNAL_ID, DATE)
+
+    const payload = payloadOf(queueRows()[0])
+    expect(payload).toMatchObject({ date: DATE, content: null, tags: [], properties: null })
+    expect(JournalSyncPayloadSchema.safeParse(payload).success).toBe(true)
+    expect(h.log.warn).toHaveBeenCalledWith(
+      'Could not read journal file for sync snapshot',
+      expect.objectContaining({ noteId: JOURNAL_ID, date: DATE })
+    )
+  })
+
+  it('never pushes a local-only journal and leaves its clock untouched', () => {
+    seedJournalNote({ localOnly: true })
+
+    makeService().enqueueCreate(JOURNAL_ID, DATE)
+
+    expect(queueRows()).toEqual([])
+    expect(storedClock()).toEqual({})
+  })
+
+  it('skips a journal that is not in the metadata cache', () => {
+    makeService().enqueueUpdate('journal-missing', '2026-01-01')
+
+    expect(queueRows()).toEqual([])
+  })
+
+  it('skips and warns when no device id is available yet', () => {
+    seedJournalNote()
+
+    makeService(null).enqueueUpdate(JOURNAL_ID, DATE)
+
+    expect(queueRows()).toEqual([])
+    expect(storedClock()).toEqual({})
+    expect(h.log.warn).toHaveBeenCalledWith(
+      'No device ID, skipping journal update enqueue',
+      expect.objectContaining({ itemId: JOURNAL_ID })
+    )
+  })
+})
+
+describe('JournalSyncService deletes', () => {
+  it('propagates a delete as a dated tombstone with a bumped clock', () => {
+    seedJournalNote({ clock: { 'device-a': 3 } })
+
+    makeService().enqueueDelete(JOURNAL_ID, DATE)
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].type).toBe('journal')
+    expect(rows[0].operation).toBe('delete')
+    expect(payloadOf(rows[0])).toMatchObject({
+      date: DATE,
+      clock: { 'device-a': 4 },
+      createdAt: CREATED_AT,
+      modifiedAt: MODIFIED_AT
+    })
+  })
+
+  it('still propagates the delete when the metadata row is already gone', () => {
+    // Unlike notes, a journal tombstone is buildable from the date alone, so a
+    // missing cache row must not swallow the delete.
+    makeService().enqueueDelete('journal-2026-01-01', '2026-01-01')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('delete')
+    expect(payloadOf(rows[0])).toEqual({ date: '2026-01-01', clock: { 'device-a': 1 } })
+  })
+
+  it('lets a delete win over a still-pending create instead of being dropped', () => {
+    seedJournalNote()
+    const service = makeService()
+
+    service.enqueueCreate(JOURNAL_ID, DATE)
+    service.enqueueDelete(JOURNAL_ID, DATE)
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('delete')
+  })
+
+  it('does not enqueue a delete without a device id', () => {
+    seedJournalNote()
+
+    makeService(null).enqueueDelete(JOURNAL_ID, DATE)
+
+    expect(queueRows()).toEqual([])
+  })
+})
+
+describe('journal sync service lifecycle', () => {
+  it('tracks the module-level singleton', () => {
+    expect(getJournalSyncService()).toBeNull()
+
+    const service = initJournalSyncService({ queue, getDeviceId: () => 'device-a' })
+    expect(getJournalSyncService()).toBe(service)
+
+    resetJournalSyncService()
+    expect(getJournalSyncService()).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/sync/note-attachment-metadata.test.ts
+++ b/apps/desktop/src/main/sync/note-attachment-metadata.test.ts
@@ -24,6 +24,12 @@ vi.mock('../database', () => ({
   getIndexDatabase: () => state.index
 }))
 
+// Stubbed at the module boundary: the real registry drags in every sync service
+// singleton, and what this module owes the caller is only "the established
+// enqueue path was called with ('note', noteId)".
+const enqueueLocalSyncUpdate = vi.hoisted(() => vi.fn())
+vi.mock('./local-mutations', () => ({ enqueueLocalSyncUpdate }))
+
 import { recordUploadedAttachment, recordDownloadedFileSize } from './note-attachment-metadata'
 
 let dataDb: TestDataDb
@@ -65,6 +71,7 @@ beforeEach(() => {
   indexDb = indexResult.db as unknown as IndexDb
   state.data = dataDb
   state.index = indexDb
+  enqueueLocalSyncUpdate.mockClear()
 })
 
 afterEach(() => {
@@ -231,7 +238,68 @@ describe('recordUploadedAttachment', () => {
     // never tells any peer it exists — "images inside notes never arrive",
     // and re-adding the image walks the same path again. The two writes are
     // not atomic and the failed one is neither retried nor logged.
+    //
+    // STILL FAILING BY DESIGN. Closing this would mean minting a
+    // `note_metadata` row out of the index cache, i.e. fabricating a sync
+    // source-of-truth row (path, clock, createdAt) from a rebuildable cache.
+    // What this module can honestly do — and now does — is (a) write the data
+    // DB FIRST so the cache can never get ahead of the sync store, (b) log a
+    // warn instead of swallowing the miss, and (c) not enqueue a push for a
+    // note it could not record. Repairing an orphaned index row belongs to the
+    // index rebuild, not to the attachment upload path.
     expect(getNoteMetadataById(dataDb, 'note-1')?.attachmentReferences).toEqual(['att-1'])
+  })
+
+  it('enqueues a note push so peers learn about the new reference', () => {
+    seedDataRow('note-1')
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+
+    // Nothing else on the upload path enqueues a note push. Without this the
+    // reference sat in the local data DB until an unrelated later edit happened
+    // to push the note, and until then every peer got a payload with no
+    // `attachmentReferences` and never emitted `download-needed` — text arrived,
+    // images did not.
+    expect(enqueueLocalSyncUpdate).toHaveBeenCalledWith('note', 'note-1')
+  })
+
+  it('enqueues one push per upload so a multi-image note converges', () => {
+    seedDataRow('note-1')
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+    recordUploadedAttachment('note-1', 'att-2')
+
+    expect(enqueueLocalSyncUpdate).toHaveBeenCalledTimes(2)
+    expect(enqueueLocalSyncUpdate).toHaveBeenLastCalledWith('note', 'note-1')
+  })
+
+  it('re-enqueues even when the id was already recorded', () => {
+    // Re-adding the same image is exactly what a user does when the picture
+    // never showed up on the other device, so the retry must still push.
+    seedDataRow('note-1', { attachmentReferences: ['att-1'], attachmentId: 'att-1' })
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+
+    expect(enqueueLocalSyncUpdate).toHaveBeenCalledWith('note', 'note-1')
+  })
+
+  it('does not enqueue a push for a note the data DB never recorded', () => {
+    // The push payload is built from the data DB. With no row there is nothing
+    // to push, and enqueuing would only churn the sync queue.
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+
+    expect(enqueueLocalSyncUpdate).not.toHaveBeenCalled()
+  })
+
+  it('does not enqueue a push for a note that exists in neither store', () => {
+    recordUploadedAttachment('ghost', 'att-1')
+
+    expect(enqueueLocalSyncUpdate).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/main/sync/note-attachment-metadata.test.ts
+++ b/apps/desktop/src/main/sync/note-attachment-metadata.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getNoteMetadataById, upsertNoteMetadata } from '@memry/storage-data'
+import { insertNoteCache, getNoteCacheById } from '@main/database/queries/notes'
+import type { IndexDb } from '@main/database/types'
+import { createTestDataDb, type TestDataDb } from '../../test/helpers/test-data-db'
+import { createTestIndexDb, type TestDatabaseResult } from '@tests/utils/test-db'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+const state = vi.hoisted(() => ({
+  data: undefined as unknown,
+  index: undefined as unknown
+}))
+
+vi.mock('../database', () => ({
+  getDatabase: () => state.data,
+  getIndexDatabase: () => state.index
+}))
+
+import { recordUploadedAttachment, recordDownloadedFileSize } from './note-attachment-metadata'
+
+let dataDb: TestDataDb
+let indexResult: TestDatabaseResult
+let indexDb: IndexDb
+
+const NOW = '2026-08-05T10:00:00.000Z'
+
+function seedDataRow(
+  id: string,
+  overrides: Partial<Parameters<typeof upsertNoteMetadata>[1]> = {}
+): void {
+  upsertNoteMetadata(dataDb, {
+    id,
+    // Vault-relative, forward-slashed — this is the cross-platform contract for
+    // the `path` column and nothing in this module may rewrite it.
+    path: `notes/${id}.md`,
+    title: id,
+    fileType: 'markdown',
+    createdAt: NOW,
+    modifiedAt: NOW,
+    ...overrides
+  })
+}
+
+function seedIndexRow(id: string): void {
+  insertNoteCache(indexDb, {
+    id,
+    path: `notes/${id}.md`,
+    title: id,
+    createdAt: NOW,
+    modifiedAt: NOW
+  })
+}
+
+beforeEach(() => {
+  dataDb = createTestDataDb()
+  indexResult = createTestIndexDb()
+  indexDb = indexResult.db as unknown as IndexDb
+  state.data = dataDb
+  state.index = indexDb
+})
+
+afterEach(() => {
+  indexResult.close()
+})
+
+describe('recordUploadedAttachment', () => {
+  it('writes the attachment id into both the data DB and the index cache', () => {
+    seedDataRow('note-1')
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+
+    const meta = getNoteMetadataById(dataDb, 'note-1')
+    expect(meta?.attachmentId).toBe('att-1')
+    expect(meta?.attachmentReferences).toEqual(['att-1'])
+    // The index cache is what the note list renders from; the data DB is what
+    // the sync push payload is built from. Both have to move together.
+    expect(getNoteCacheById(indexDb, 'note-1')?.attachmentId).toBe('att-1')
+  })
+
+  it('merges additional attachments instead of replacing the list', () => {
+    seedDataRow('note-1')
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+    recordUploadedAttachment('note-1', 'att-2')
+    recordUploadedAttachment('note-1', 'att-3')
+
+    // A note can embed several images and each upload lands here separately —
+    // replacing the list dropped every id but the last, which is exactly "some
+    // images never arrive on the other device".
+    expect(getNoteMetadataById(dataDb, 'note-1')?.attachmentReferences).toEqual([
+      'att-1',
+      'att-2',
+      'att-3'
+    ])
+  })
+
+  it('does not duplicate an attachment id that is already recorded', () => {
+    seedDataRow('note-1')
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+    recordUploadedAttachment('note-1', 'att-1')
+
+    expect(getNoteMetadataById(dataDb, 'note-1')?.attachmentReferences).toEqual(['att-1'])
+  })
+
+  it('preserves references that arrived from another device', () => {
+    // Refs pulled from a peer, merged in by the note handler before this
+    // device uploads one of its own.
+    seedDataRow('note-1', { attachmentReferences: ['att-from-mac', 'att-from-linux'] })
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-local')
+
+    expect(getNoteMetadataById(dataDb, 'note-1')?.attachmentReferences).toEqual([
+      'att-from-mac',
+      'att-from-linux',
+      'att-local'
+    ])
+  })
+
+  it('always overwrites attachmentId with the newest upload while the list accumulates', () => {
+    seedDataRow('note-1')
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+    recordUploadedAttachment('note-1', 'att-2')
+
+    const meta = getNoteMetadataById(dataDb, 'note-1')
+    expect(meta?.attachmentId).toBe('att-2')
+    expect(meta?.attachmentReferences).toEqual(['att-1', 'att-2'])
+    expect(getNoteCacheById(indexDb, 'note-1')?.attachmentId).toBe('att-2')
+  })
+
+  it('touches nothing except the attachment columns — path stays vault-relative', () => {
+    seedDataRow('note-1', { emoji: '📝', fileSize: 42, mimeType: 'text/markdown' })
+    seedIndexRow('note-1')
+    const before = getNoteMetadataById(dataDb, 'note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+
+    const after = getNoteMetadataById(dataDb, 'note-1')
+    // The `path` column is the one cross-platform hazard on this row. This
+    // module must never rewrite it — it takes no path argument at all.
+    expect(after?.path).toBe('notes/note-1.md')
+    expect(after?.path).toBe(before?.path)
+    expect(after?.title).toBe(before?.title)
+    expect(after?.emoji).toBe(before?.emoji)
+    expect(after?.fileSize).toBe(before?.fileSize)
+    expect(after?.mimeType).toBe(before?.mimeType)
+    expect(after?.fileType).toBe(before?.fileType)
+    expect(after?.localOnly).toBe(before?.localOnly)
+    expect(after?.clock).toEqual(before?.clock)
+    expect(getNoteCacheById(indexDb, 'note-1')?.path).toBe('notes/note-1.md')
+  })
+
+  it('stores no filesystem path — every value it writes is an opaque blob id', () => {
+    seedDataRow('note-1')
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-9f2c')
+
+    const meta = getNoteMetadataById(dataDb, 'note-1')
+    const written = [meta?.attachmentId ?? '', ...(meta?.attachmentReferences ?? [])]
+    for (const value of written) {
+      // No drive letter, no backslash separator, no POSIX absolute path — none
+      // of which would survive a macOS ↔ Linux ↔ Windows round trip.
+      expect(value).not.toMatch(/^[A-Za-z]:/)
+      expect(value).not.toContain('\\')
+      expect(value.startsWith('/')).toBe(false)
+      expect(value).not.toContain('/Users/')
+      expect(value).not.toContain('/home/')
+    }
+  })
+
+  it('round-trips ids through the JSON column byte-for-byte', () => {
+    seedDataRow('note-1')
+    seedIndexRow('note-1')
+
+    // Deliberately awkward ids: the column is JSON-encoded, so anything the
+    // encoder mangles would silently break the reference on the far device.
+    const ids = ['att-1', 'ATT-UPPER', 'att_with-dash.and.dot', 'att-üñïçø∂é', 'att 1']
+    for (const id of ids) {
+      recordUploadedAttachment('note-1', id)
+    }
+
+    const refs = getNoteMetadataById(dataDb, 'note-1')?.attachmentReferences
+    expect(refs).toEqual(ids)
+    expect(refs?.every((ref, i) => ref === ids[i])).toBe(true)
+  })
+
+  it('is a silent no-op for a note that exists in neither store', () => {
+    expect(() => recordUploadedAttachment('ghost', 'att-1')).not.toThrow()
+
+    // No row is created, and the caller (the upload success path in
+    // ipc/sync-attachment-handlers.ts) gets no signal that the reference was
+    // discarded.
+    expect(getNoteMetadataById(dataDb, 'ghost')).toBeUndefined()
+    expect(getNoteCacheById(indexDb, 'ghost')).toBeUndefined()
+  })
+
+  it('writes the index cache even when the data DB has no row for the note', () => {
+    // Realistic: the index DB is a rebuildable cache and the data DB is the
+    // sidecar sync store. They are separate SQLite files with separate
+    // migrations and there is no transaction spanning them.
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+
+    expect(getNoteCacheById(indexDb, 'note-1')?.attachmentId).toBe('att-1')
+  })
+
+  it.fails('BUG: a data-DB miss silently loses the reference the index cache just accepted', () => {
+    seedIndexRow('note-1')
+
+    recordUploadedAttachment('note-1', 'att-1')
+
+    // `buildNotePushPayload` (item-handlers/note-handler-sync-helpers.ts)
+    // reads `attachmentReferences` from the DATA DB. With the index cache
+    // written and the data DB not, this device shows the image locally and
+    // never tells any peer it exists — "images inside notes never arrive",
+    // and re-adding the image walks the same path again. The two writes are
+    // not atomic and the failed one is neither retried nor logged.
+    expect(getNoteMetadataById(dataDb, 'note-1')?.attachmentReferences).toEqual(['att-1'])
+  })
+})
+
+describe('recordDownloadedFileSize', () => {
+  it('writes the size into both the data DB and the index cache', () => {
+    seedDataRow('note-1', { fileType: 'pdf', fileSize: 0 })
+    seedIndexRow('note-1')
+
+    recordDownloadedFileSize('note-1', 20_481)
+
+    expect(getNoteMetadataById(dataDb, 'note-1')?.fileSize).toBe(20_481)
+    expect(getNoteCacheById(indexDb, 'note-1')?.fileSize).toBe(20_481)
+  })
+
+  it('stores a zero-byte size as 0, not null', () => {
+    seedDataRow('note-1', { fileType: 'pdf', fileSize: 99 })
+    seedIndexRow('note-1')
+
+    recordDownloadedFileSize('note-1', 0)
+
+    expect(getNoteMetadataById(dataDb, 'note-1')?.fileSize).toBe(0)
+    expect(getNoteCacheById(indexDb, 'note-1')?.fileSize).toBe(0)
+  })
+
+  it('leaves the attachment references alone', () => {
+    seedDataRow('note-1', { attachmentReferences: ['att-1'], attachmentId: 'att-1' })
+    seedIndexRow('note-1')
+
+    recordDownloadedFileSize('note-1', 512)
+
+    const meta = getNoteMetadataById(dataDb, 'note-1')
+    expect(meta?.attachmentReferences).toEqual(['att-1'])
+    expect(meta?.attachmentId).toBe('att-1')
+    expect(meta?.path).toBe('notes/note-1.md')
+  })
+
+  it('is a silent no-op for an unknown note', () => {
+    expect(() => recordDownloadedFileSize('ghost', 512)).not.toThrow()
+    expect(getNoteMetadataById(dataDb, 'ghost')).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/sync/note-attachment-metadata.ts
+++ b/apps/desktop/src/main/sync/note-attachment-metadata.ts
@@ -1,6 +1,10 @@
 import { getNoteMetadataById, updateNoteMetadata } from '@memry/storage-data'
 import { updateNoteCache } from '@main/database/queries/notes'
 import { getDatabase, getIndexDatabase } from '../database'
+import { createLogger } from '../lib/logger'
+import { enqueueLocalSyncUpdate } from './local-mutations'
+
+const log = createLogger('NoteAttachmentMetadata')
 
 export function recordUploadedAttachment(noteId: string, attachmentId: string): void {
   const db = getDatabase()
@@ -8,11 +12,44 @@ export function recordUploadedAttachment(noteId: string, attachmentId: string): 
   // lands here separately — replacing the list dropped every id but the last.
   const existing = getNoteMetadataById(db, noteId)?.attachmentReferences ?? []
   const merged = existing.includes(attachmentId) ? existing : [...existing, attachmentId]
-  updateNoteCache(getIndexDatabase(), noteId, { attachmentId })
-  updateNoteMetadata(db, noteId, {
+  // Data DB FIRST. It is the sync source of truth (`buildNotePushPayload` reads
+  // `attachmentReferences` from it) while the index DB is a rebuildable cache.
+  // These are two SQLite files with no shared transaction, so if one write has
+  // to lose it must be the cache: an index-only write would show the image on
+  // this device and never tell any peer it exists.
+  const updated = updateNoteMetadata(db, noteId, {
     attachmentId,
     attachmentReferences: merged
   })
+  updateNoteCache(getIndexDatabase(), noteId, { attachmentId })
+
+  if (!updated) {
+    // No sync row for this note, so the reference is not in — and will never
+    // reach — the push payload. Previously silent; the note kept syncing while
+    // its images stayed on this machine.
+    log.warn('Uploaded attachment has no note metadata row — reference will not sync', {
+      noteId,
+      attachmentId
+    })
+    return
+  }
+
+  // A successful upload only mutates this sidecar row, and nothing else on the
+  // upload path enqueues a note push. Without this the new reference sat in the
+  // local data DB until some unrelated later note edit happened to push the
+  // note; until then every peer received a payload with no
+  // `attachmentReferences` and so never emitted `download-needed` — notes
+  // arrived with text but no images, and re-adding the image walked the same
+  // dead path again.
+  //
+  // Backward compatibility: this enqueues an ordinary note UPDATE through the
+  // existing note sync service. No new sync item type, no new IPC contract, no
+  // change to the note payload shape — `attachmentReferences` is an optional
+  // key `buildNotePushPayload` already emits (and omits when empty), and note
+  // payloads are parsed with zod strip mode, so a peer on an older build that
+  // predates the key ignores it and applies the rest of the update exactly as
+  // it does today.
+  enqueueLocalSyncUpdate('note', noteId)
 }
 
 export function recordDownloadedFileSize(noteId: string, fileSize: number): void {

--- a/apps/desktop/src/main/sync/note-events.test.ts
+++ b/apps/desktop/src/main/sync/note-events.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest'
+import { NotesChannels } from '@memry/contracts/ipc-channels'
+import type { NoteUpdatedEvent } from '@memry/contracts/notes-api'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { emitNoteUpdated } from './note-events'
+
+describe('emitNoteUpdated', () => {
+  it('emits on the notes:updated channel', () => {
+    const emit = vi.fn()
+
+    emitNoteUpdated(emit, { id: 'note-1', changes: { title: 'Hi' }, source: 'sync' })
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(emit.mock.calls[0][0]).toBe(NotesChannels.events.UPDATED)
+    // Channel name is part of the renderer contract, not an implementation
+    // detail: the preload subscribes by literal string.
+    expect(emit.mock.calls[0][0]).toBe('notes:updated')
+  })
+
+  it('forwards the exact event object it was given, by reference', () => {
+    const emit = vi.fn()
+    const event: NoteUpdatedEvent = {
+      id: 'note-1',
+      changes: { title: 'Hi', emoji: '📝' },
+      source: 'internal'
+    }
+
+    emitNoteUpdated(emit, event)
+
+    // No copying, no normalisation, no key filtering — the payload the caller
+    // constructed is exactly what the renderer receives.
+    expect(emit.mock.calls[0][1]).toBe(event)
+  })
+
+  it('carries `changes` for every payload shape the sync path emits', () => {
+    const emit = vi.fn()
+
+    // crdt-writeback.ts: a remote body edit landing on this device.
+    emitNoteUpdated(emit, {
+      id: 'note-1',
+      changes: { content: '# Remote edit' },
+      source: 'sync'
+    })
+    // note-handler.ts binary branch: sidecar metadata only, never file bytes.
+    emitNoteUpdated(emit, {
+      id: 'note-2',
+      changes: { title: 'Scan', emoji: '📎' },
+      source: 'sync'
+    })
+    // note-handler.ts markdown branch: frontmatter/title/path, never the body.
+    emitNoteUpdated(emit, {
+      id: 'note-3',
+      changes: { title: 'Notes', emoji: null, tags: ['a', 'b'] },
+      source: 'sync'
+    })
+
+    for (const [, payload] of emit.mock.calls) {
+      const event = payload as NoteUpdatedEvent
+      // `use-notes-query.ts` reads `event.changes.content` without guarding for
+      // every note that is not the open one, so an emit that omits `changes`
+      // throws once per pulled note and the subscriber misses the event.
+      expect(event.changes).toBeDefined()
+      expect(typeof event.changes).toBe('object')
+    }
+
+    expect(emit.mock.calls[0][1]).toEqual({
+      id: 'note-1',
+      changes: { content: '# Remote edit' },
+      source: 'sync'
+    })
+    expect(emit.mock.calls[1][1]).toEqual({
+      id: 'note-2',
+      changes: { title: 'Scan', emoji: '📎' },
+      source: 'sync'
+    })
+    expect(emit.mock.calls[2][1]).toEqual({
+      id: 'note-3',
+      changes: { title: 'Notes', emoji: null, tags: ['a', 'b'] },
+      source: 'sync'
+    })
+  })
+
+  it('preserves `source: sync` so the subscriber can tell a pull from a local edit', () => {
+    const emit = vi.fn()
+
+    emitNoteUpdated(emit, { id: 'note-1', changes: { content: 'remote' }, source: 'sync' })
+
+    expect((emit.mock.calls[0][1] as NoteUpdatedEvent).source).toBe('sync')
+  })
+
+  it('does NOT suppress sync-sourced events — echo suppression is the subscriber’s job', () => {
+    const emit = vi.fn()
+
+    // Read the source before changing this expectation: `emitNoteUpdated` is an
+    // unconditional passthrough. It holds no loop guard of its own; a change
+    // that arrived FROM sync is still emitted outward, tagged `source: 'sync'`,
+    // and it is the renderer subscriber that must not write it back. The loop
+    // is broken by the tag, not by dropping the emit.
+    emitNoteUpdated(emit, { id: 'note-1', changes: { content: 'remote' }, source: 'sync' })
+    emitNoteUpdated(emit, { id: 'note-1', changes: { content: 'local' }, source: 'internal' })
+    emitNoteUpdated(emit, { id: 'note-1', changes: { content: 'watcher' }, source: 'external' })
+
+    expect(emit).toHaveBeenCalledTimes(3)
+    expect(emit.mock.calls.map(([, payload]) => (payload as NoteUpdatedEvent).source)).toEqual([
+      'sync',
+      'internal',
+      'external'
+    ])
+  })
+
+  it('emits once per call and never fans out to a second channel', () => {
+    const emit = vi.fn()
+
+    emitNoteUpdated(emit, { id: 'note-1', changes: { title: 'A' }, source: 'sync' })
+    emitNoteUpdated(emit, { id: 'note-2', changes: { title: 'B' }, source: 'sync' })
+
+    expect(emit).toHaveBeenCalledTimes(2)
+    expect(new Set(emit.mock.calls.map(([channel]) => channel))).toEqual(
+      new Set([NotesChannels.events.UPDATED])
+    )
+  })
+
+  it('does not swallow an emitter that throws', () => {
+    const emit = vi.fn(() => {
+      throw new Error('destroyed window')
+    })
+
+    expect(() =>
+      emitNoteUpdated(emit, { id: 'note-1', changes: { title: 'A' }, source: 'sync' })
+    ).toThrow('destroyed window')
+  })
+
+  it('performs no runtime validation — `changes` is enforced by the type, not a check', () => {
+    const emit = vi.fn()
+    // Documents the real guarantee: the helper exists so the payload is
+    // typechecked at the call site. A caller that defeats the type (e.g. a
+    // payload built from `unknown` and cast) still reaches the renderer as-is.
+    const malformed = { id: 'note-1', source: 'sync' } as unknown as NoteUpdatedEvent
+
+    emitNoteUpdated(emit, malformed)
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(emit.mock.calls[0][1]).toBe(malformed)
+    expect((emit.mock.calls[0][1] as NoteUpdatedEvent).changes).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/sync/note-sync.test.ts
+++ b/apps/desktop/src/main/sync/note-sync.test.ts
@@ -279,7 +279,7 @@ describe('NoteSyncService push', () => {
 })
 
 describe('NoteSyncService deletes', () => {
-  it('propagates a delete as its own queue row carrying the title and a bumped clock', () => {
+  it('propagates a delete as its own queue row with a bumped clock and NO title', () => {
     seedNote({ clock: { 'device-a': 2 } })
 
     makeService().enqueueDelete('note-1')
@@ -289,11 +289,24 @@ describe('NoteSyncService deletes', () => {
     expect(rows[0].type).toBe('note')
     expect(rows[0].operation).toBe('delete')
     expect(payloadOf(rows[0])).toMatchObject({
-      title: 'Quarterly Plan',
       clock: { 'device-a': 3 },
       createdAt: CREATED_AT,
       modifiedAt: MODIFIED_AT
     })
+    // The tombstone must not carry the note's title. Nothing on the receiving
+    // side reads it, so shipping it only widened what a delete uploads.
+    expect(payloadOf(rows[0])).not.toHaveProperty('title')
+  })
+
+  it('never tombstones a local-only note', () => {
+    // localOnly is the user's "this never leaves my machine" switch. The shared
+    // controller applies it to creates/updates only, so the delete path needs
+    // its own guard or the promise breaks at exactly the wrong moment.
+    seedNote({ localOnly: true })
+
+    makeService().enqueueDelete('note-1')
+
+    expect(queueRows()).toEqual([])
   })
 
   it('lets a delete win over a still-pending create instead of being dropped', () => {

--- a/apps/desktop/src/main/sync/note-sync.test.ts
+++ b/apps/desktop/src/main/sync/note-sync.test.ts
@@ -1,0 +1,390 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { noteMetadata } from '@memry/db-schema/data-schema'
+import { syncQueue } from '@memry/db-schema/schema/sync-queue'
+import { NoteSyncPayloadSchema } from '@memry/contracts/sync-payloads'
+import { createTestDataDb, type TestDataDb } from '../../test/helpers/test-data-db'
+
+/**
+ * Push side of note sync: a local note mutation -> an outbound queue row.
+ *
+ * Everything below runs the REAL `RecordSyncController`, the REAL
+ * `SyncQueueManager` and a REAL migrated in-memory data DB, so a queue row is
+ * only asserted after it has actually been written (and coalesced) by the
+ * production code path. Only the vault/index-DB edges are faked.
+ */
+
+const h = vi.hoisted(() => ({
+  db: null as unknown,
+  vaultDir: '',
+  properties: [] as Array<{ name: string; value: unknown }>,
+  pinnedTags: [] as string[],
+  renameCallback: null as ((id: string) => void) | null,
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => h.log
+}))
+
+vi.mock('../database/client', () => ({
+  getDatabase: () => h.db,
+  getIndexDatabase: () => ({})
+}))
+
+vi.mock('@main/database/queries/notes', () => ({
+  getNoteProperties: () => h.properties
+}))
+
+vi.mock('./item-handlers/note-pin-helpers', () => ({
+  getPinnedTagsForNote: () => h.pinnedTags
+}))
+
+vi.mock('../vault/notes', () => ({
+  toAbsolutePath: (relativePath: string) => path.join(h.vaultDir, relativePath)
+}))
+
+vi.mock('../vault/index', () => ({
+  getConfig: () => ({ defaultNoteFolder: 'notes' })
+}))
+
+vi.mock('../vault/rename-tracker', () => ({
+  registerRenameSyncCallback: (cb: (id: string) => void) => {
+    h.renameCallback = cb
+  },
+  unregisterRenameSyncCallback: () => {
+    h.renameCallback = null
+  }
+}))
+
+import { SyncQueueManager } from './queue'
+import {
+  NoteSyncService,
+  extractFolderFromPath,
+  getNoteSyncService,
+  initNoteSyncService,
+  resetNoteSyncService
+} from './note-sync'
+
+let db: TestDataDb
+let queue: SyncQueueManager
+
+const CREATED_AT = '2026-05-01T10:00:00.000Z'
+const MODIFIED_AT = '2026-05-02T11:00:00.000Z'
+
+function seedNote(overrides: Record<string, unknown> = {}): void {
+  db.insert(noteMetadata)
+    .values({
+      id: 'note-1',
+      path: 'notes/Projects/Plan.md',
+      title: 'Quarterly Plan',
+      fileType: 'markdown',
+      clock: {},
+      createdAt: CREATED_AT,
+      modifiedAt: MODIFIED_AT,
+      ...overrides
+    } as never)
+    .run()
+}
+
+function writeNoteFile(relativePath: string, contents: string): void {
+  const absolute = path.join(h.vaultDir, relativePath)
+  fs.mkdirSync(path.dirname(absolute), { recursive: true })
+  fs.writeFileSync(absolute, contents, 'utf-8')
+}
+
+function queueRows(): Array<typeof syncQueue.$inferSelect> {
+  return db.select().from(syncQueue).all()
+}
+
+function payloadOf(row: typeof syncQueue.$inferSelect | undefined): Record<string, unknown> {
+  return JSON.parse(row!.payload) as Record<string, unknown>
+}
+
+function storedClock(id = 'note-1'): unknown {
+  return db.select().from(noteMetadata).where(eq(noteMetadata.id, id)).get()?.clock
+}
+
+function makeService(deviceId: string | null = 'device-a'): NoteSyncService {
+  return new NoteSyncService({ queue, getDeviceId: () => deviceId })
+}
+
+beforeAll(() => {
+  h.vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-note-sync-'))
+})
+
+afterAll(() => {
+  fs.rmSync(h.vaultDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  db = createTestDataDb()
+  h.db = db
+  queue = new SyncQueueManager(db)
+  h.properties = [{ name: 'Status', value: 'Draft' }]
+  h.pinnedTags = ['roadmap']
+  h.renameCallback = null
+  resetNoteSyncService()
+  writeNoteFile('notes/Projects/Plan.md', '---\ntags:\n  - roadmap\n  - q3\n---\n\nBody text\n')
+})
+
+describe('NoteSyncService push', () => {
+  it('enqueues exactly one note create carrying the title, body and tags the user sees', () => {
+    seedNote()
+
+    makeService().enqueueCreate('note-1')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].type).toBe('note')
+    expect(rows[0].itemId).toBe('note-1')
+    expect(rows[0].operation).toBe('create')
+
+    const payload = payloadOf(rows[0])
+    // `parseNote` preserves the body bytes verbatim, so match on substance.
+    expect(payload.content).toContain('Body text')
+    expect(payload).toMatchObject({
+      title: 'Quarterly Plan',
+      tags: ['roadmap', 'q3'],
+      properties: { Status: 'Draft' },
+      pinnedTags: ['roadmap'],
+      folderPath: 'Projects',
+      fileType: 'markdown',
+      clock: { 'device-a': 1 },
+      createdAt: CREATED_AT,
+      modifiedAt: MODIFIED_AT
+    })
+    expect(NoteSyncPayloadSchema.safeParse(payload).success).toBe(true)
+  })
+
+  it('persists the bumped clock on the note row so the push is not replayed from a stale clock', () => {
+    seedNote({ clock: { 'device-b': 4 } })
+
+    makeService().enqueueCreate('note-1')
+
+    expect(storedClock()).toEqual({ 'device-b': 4, 'device-a': 1 })
+    expect(payloadOf(queueRows()[0]).clock).toEqual({ 'device-b': 4, 'device-a': 1 })
+  })
+
+  it('keeps the title on a metadata-only update even though the body is omitted', () => {
+    seedNote()
+
+    // `update` deliberately ships `content: null` (the body travels via CRDT),
+    // so the title is the only user-visible text in the payload. Losing it here
+    // is exactly how a note lands on the other device as "Untitled".
+    makeService().enqueueUpdate('note-1')
+
+    const payload = payloadOf(queueRows()[0])
+    expect(queueRows()[0].operation).toBe('update')
+    expect(payload.title).toBe('Quarterly Plan')
+    expect(payload.content).toBeNull()
+    expect(payload.tags).toEqual(['roadmap', 'q3'])
+  })
+
+  it('rewrites the pending push with the NEW title when a rename lands before the flush', () => {
+    seedNote()
+    const service = makeService()
+
+    service.enqueueCreate('note-1')
+    db.update(noteMetadata)
+      .set({ title: 'Renamed Plan' })
+      .where(eq(noteMetadata.id, 'note-1'))
+      .run()
+    service.enqueueUpdate('note-1')
+
+    // The queue coalesces onto the pending row; the surviving payload must carry
+    // the renamed title, never the stale one.
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('create')
+    expect(payloadOf(rows[0]).title).toBe('Renamed Plan')
+  })
+
+  it('pushes binary notes as attachment metadata without reading the file', () => {
+    seedNote({
+      path: 'notes/Files/Report.pdf',
+      title: 'Report',
+      fileType: 'pdf',
+      mimeType: 'application/pdf',
+      attachmentId: 'attachment-1'
+    })
+
+    makeService().enqueueUpdate('note-1')
+
+    const payload = payloadOf(queueRows()[0])
+    expect(payload).toMatchObject({
+      title: 'Report',
+      fileType: 'pdf',
+      mimeType: 'application/pdf',
+      attachmentId: 'attachment-1',
+      folderPath: 'Files'
+    })
+    expect(payload).not.toHaveProperty('content')
+    expect(NoteSyncPayloadSchema.safeParse(payload).success).toBe(true)
+  })
+
+  it('still pushes the title when the note file cannot be read', () => {
+    seedNote({ path: 'notes/Projects/Missing.md' })
+
+    makeService().enqueueCreate('note-1')
+
+    const payload = payloadOf(queueRows()[0])
+    expect(payload.title).toBe('Quarterly Plan')
+    expect(payload.content).toBeNull()
+    expect(payload.tags).toEqual([])
+    expect(h.log.warn).toHaveBeenCalledWith(
+      'Could not read note file for sync snapshot',
+      expect.objectContaining({ noteId: 'note-1' })
+    )
+  })
+
+  it('never pushes a local-only note and leaves its clock untouched', () => {
+    seedNote({ localOnly: true })
+
+    const service = makeService()
+    service.enqueueCreate('note-1')
+    service.enqueueUpdate('note-1')
+
+    expect(queueRows()).toEqual([])
+    expect(storedClock()).toEqual({})
+  })
+
+  it('skips notes that are not in the metadata cache', () => {
+    makeService().enqueueUpdate('ghost-note')
+
+    expect(queueRows()).toEqual([])
+  })
+
+  it('skips and warns when no device id is available yet', () => {
+    seedNote()
+
+    makeService(null).enqueueUpdate('note-1')
+
+    expect(queueRows()).toEqual([])
+    expect(storedClock()).toEqual({})
+    expect(h.log.warn).toHaveBeenCalledWith(
+      'No device ID, skipping note update enqueue',
+      expect.objectContaining({ itemId: 'note-1' })
+    )
+  })
+})
+
+describe('NoteSyncService deletes', () => {
+  it('propagates a delete as its own queue row carrying the title and a bumped clock', () => {
+    seedNote({ clock: { 'device-a': 2 } })
+
+    makeService().enqueueDelete('note-1')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].type).toBe('note')
+    expect(rows[0].operation).toBe('delete')
+    expect(payloadOf(rows[0])).toMatchObject({
+      title: 'Quarterly Plan',
+      clock: { 'device-a': 3 },
+      createdAt: CREATED_AT,
+      modifiedAt: MODIFIED_AT
+    })
+  })
+
+  it('lets a delete win over a still-pending create instead of being dropped', () => {
+    seedNote()
+    const service = makeService()
+
+    service.enqueueCreate('note-1')
+    service.enqueueDelete('note-1')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('delete')
+  })
+
+  it('drops a delete for a note the cache never knew about', () => {
+    makeService().enqueueDelete('ghost-note')
+
+    expect(queueRows()).toEqual([])
+    expect(h.log.warn).toHaveBeenCalledWith('Note not found in cache for delete enqueue')
+  })
+
+  it('removes queued pushes for an item on request', () => {
+    seedNote()
+    const service = makeService()
+    service.enqueueCreate('note-1')
+
+    expect(service.removeQueueItems('note-1')).toBe(1)
+    expect(queueRows()).toEqual([])
+  })
+})
+
+describe('NoteSyncService recovery pushes', () => {
+  it('re-queues a lost push without advancing the clock again', () => {
+    seedNote({ clock: { 'device-a': 7 } })
+
+    makeService().enqueueRecoveredUpdate('note-1')
+
+    // The stored clock is the one that never reached the server; bumping it
+    // again would only widen the gap.
+    expect(storedClock()).toEqual({ 'device-a': 7 })
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('update')
+    expect(payloadOf(rows[0])).toMatchObject({
+      title: 'Quarterly Plan',
+      clock: { 'device-a': 7 }
+    })
+  })
+
+  it('does not re-queue a recovered push for a local-only note', () => {
+    seedNote({ localOnly: true })
+
+    makeService().enqueueRecoveredUpdate('note-1')
+
+    expect(queueRows()).toEqual([])
+  })
+})
+
+describe('note sync service lifecycle', () => {
+  it('registers a rename callback that pushes the new title, and unregisters on reset', () => {
+    seedNote()
+    expect(getNoteSyncService()).toBeNull()
+
+    const service = initNoteSyncService({ queue, getDeviceId: () => 'device-a' })
+    expect(getNoteSyncService()).toBe(service)
+    expect(h.renameCallback).toBeTypeOf('function')
+
+    db.update(noteMetadata)
+      .set({ title: 'Renamed By Watcher' })
+      .where(eq(noteMetadata.id, 'note-1'))
+      .run()
+    h.renameCallback!('note-1')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(payloadOf(rows[0]).title).toBe('Renamed By Watcher')
+
+    resetNoteSyncService()
+    expect(h.renameCallback).toBeNull()
+    expect(getNoteSyncService()).toBeNull()
+  })
+})
+
+describe('extractFolderFromPath', () => {
+  it('strips the configured note root and returns the remaining folder', () => {
+    expect(extractFolderFromPath('notes/Projects/Plan.md')).toBe('Projects')
+    expect(extractFolderFromPath('notes/Projects/Q3/Plan.md')).toBe('Projects/Q3')
+  })
+
+  it('returns null for notes that sit directly in the root', () => {
+    expect(extractFolderFromPath('notes/Plan.md')).toBeNull()
+    expect(extractFolderFromPath('Plan.md')).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/sync/note-sync.ts
+++ b/apps/desktop/src/main/sync/note-sync.ts
@@ -50,8 +50,20 @@ export class NoteSyncService extends ContentSyncService<NoteSyncPayload> {
       return null
     }
 
+    // A tombstone deliberately carries NO user-visible text. Nothing consumes
+    // it: ItemApplier short-circuits `operation === 'delete'` and calls
+    // applyDelete(ctx, itemId, clock) without ever decoding the payload bytes,
+    // and SyncItemHandler.applyDelete has no data parameter to receive them
+    // with. The title was therefore dead weight that still got encrypted and
+    // uploaded on every single note delete.
+    //
+    // Backward compatible in both directions: `title` is optional in
+    // NoteSyncPayloadSchema, so an older receiving build that did parse this
+    // body still validates it, and no shipped delete path reads the field. The
+    // `clock` MUST stay — push-coordinator.extractPayloadMetadata lifts it out
+    // of this string to stamp the server-side item version, so dropping it
+    // would break delete ordering across devices.
     return {
-      title: cached.title,
       clock,
       createdAt: cached.createdAt,
       modifiedAt: cached.modifiedAt

--- a/apps/desktop/src/main/sync/note-title-sync-regression.test.ts
+++ b/apps/desktop/src/main/sync/note-title-sync-regression.test.ts
@@ -1,0 +1,194 @@
+/**
+ * A note must never arrive on another device called "Untitled".
+ *
+ * Reported 2026-07-26 (Mac → Linux): notes synced with their body intact but
+ * the placeholder title they are born with. Fixed by 4bfbe2f0f, which shipped
+ * after the last release, so these are the locks that fail if any part of it is
+ * reverted. Two independent seams, both exercised here against real SQLite:
+ *
+ *   queue.ts        — `enqueue` coalesces a fresh mutation into the row a push
+ *                     is already carrying, and nothing marks a row in flight.
+ *                     `markSuccess(id)` deleting unconditionally took the
+ *                     rename to the grave; its clock bump was already
+ *                     persisted, so no later pull could ever repair the note.
+ *                     The ack is now conditional on the payload that was
+ *                     actually pushed.
+ *
+ *   note-handler.ts — `markPushSynced` stamps `syncedAt` on a successful push.
+ *                     Without it `syncedAt` only ever recorded *incoming*
+ *                     pulls, so dirty-recovery could not tell a note whose push
+ *                     was lost from one that is perfectly in step, and installs
+ *                     that had already diverged stayed "Untitled" forever.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { noteMetadata } from '@memry/db-schema/data-schema'
+import {
+  createTestDataDb,
+  asClientDb,
+  asSyncDb,
+  type TestDatabaseResult
+} from '@tests/utils/test-db'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { SyncQueueManager } from './queue'
+import { recoverDirtyItems } from './dirty-recovery'
+import { noteHandler } from './item-handlers/note-handler'
+
+/** The title every note is born with, before the user types a real one. */
+const BORN_TITLE = 'Untitled'
+const REAL_TITLE = 'Quarterly retro'
+
+const payloadWith = (title: string, tick: number): string =>
+  JSON.stringify({ title, content: 'body', clock: { mac: tick } })
+
+let testDb: TestDatabaseResult
+let queue: SyncQueueManager
+
+beforeEach(() => {
+  testDb = createTestDataDb()
+  queue = new SyncQueueManager(asClientDb(testDb.db))
+})
+
+afterEach(() => {
+  testDb.close()
+})
+
+describe('note title: a rename made while the push is in flight is not lost', () => {
+  it('keeps the queue row when the ack does not match what was pushed', () => {
+    // #given the create was pushed carrying the placeholder title
+    const inFlightPayload = payloadWith(BORN_TITLE, 1)
+    const queueId = queue.enqueue({
+      type: 'note',
+      itemId: 'note-1',
+      operation: 'create',
+      payload: inFlightPayload
+    })
+    const [dequeued] = queue.dequeue(10)
+    expect(dequeued.payload).toBe(inFlightPayload)
+
+    // #when the user names the note before the server answers — enqueue
+    // coalesces straight into the row the push is about to acknowledge
+    queue.enqueue({
+      type: 'note',
+      itemId: 'note-1',
+      operation: 'update',
+      payload: payloadWith(REAL_TITLE, 2)
+    })
+
+    // #when the ack for the payload we actually sent arrives
+    const removed = queue.markSuccess(queueId, dequeued.payload)
+
+    // #then the rename survives and is what the next push carries
+    expect(removed).toBe(false)
+    const [next] = queue.dequeue(10)
+    expect(next).toBeDefined()
+    expect(JSON.parse(next.payload).title).toBe(REAL_TITLE)
+  })
+
+  it('is the real title, never the placeholder, that finally reaches the server', () => {
+    const inFlightPayload = payloadWith(BORN_TITLE, 1)
+    const queueId = queue.enqueue({
+      type: 'note',
+      itemId: 'note-1',
+      operation: 'create',
+      payload: inFlightPayload
+    })
+    queue.dequeue(10)
+    queue.enqueue({
+      type: 'note',
+      itemId: 'note-1',
+      operation: 'update',
+      payload: payloadWith(REAL_TITLE, 2)
+    })
+    queue.markSuccess(queueId, inFlightPayload)
+
+    // Second push round: this is the payload the receiving device renders.
+    const [second] = queue.dequeue(10)
+    expect(JSON.parse(second.payload).title).not.toBe(BORN_TITLE)
+    queue.markSuccess(second.id, second.payload)
+    expect(queue.getSize()).toBe(0)
+  })
+
+  it('still clears the row when the ack matches the pushed payload', () => {
+    const payload = payloadWith(REAL_TITLE, 1)
+    const queueId = queue.enqueue({
+      type: 'note',
+      itemId: 'note-1',
+      operation: 'create',
+      payload
+    })
+
+    expect(queue.markSuccess(queueId, payload)).toBe(true)
+    expect(queue.getSize()).toBe(0)
+  })
+})
+
+describe('note title: a push that never landed is re-pushed, not forgotten', () => {
+  const recovered: string[] = []
+  const noteAdapters = {
+    getLocal: (type: string) =>
+      type === 'note' ? { enqueueRecoveredUpdate: (id: string) => recovered.push(id) } : undefined
+  } as unknown as Parameters<typeof recoverDirtyItems>[1]
+
+  const insertNote = (values: Record<string, unknown>): void => {
+    testDb.db
+      .insert(noteMetadata)
+      .values({
+        path: 'notes/retro.md',
+        title: REAL_TITLE,
+        createdAt: '2026-01-01T00:00:00Z',
+        ...values
+      } as never)
+      .run()
+  }
+
+  beforeEach(() => {
+    recovered.length = 0
+  })
+
+  it('stamps syncedAt on a successful push so an in-step note is left alone', () => {
+    insertNote({
+      id: 'note-in-step',
+      clock: { mac: 2 },
+      syncedAt: null,
+      modifiedAt: '2026-01-02T00:00:00Z'
+    })
+
+    // What the push coordinator calls once the server accepts the item.
+    noteHandler.markPushSynced?.(asSyncDb(testDb.db), 'note-in-step')
+
+    const row = testDb.db
+      .select()
+      .from(noteMetadata)
+      .where(eq(noteMetadata.id, 'note-in-step'))
+      .get()
+    expect(row?.syncedAt).toBeTruthy()
+    expect(row!.syncedAt! > row!.modifiedAt!).toBe(true)
+
+    expect(recoverDirtyItems(asSyncDb(testDb.db), noteAdapters).notes).toBe(0)
+    expect(recovered).toEqual([])
+  })
+
+  it('re-enqueues the note whose rename never reached the server', () => {
+    // #given a note the server knows, renamed after its last confirmed push —
+    // exactly the state the dropped-ack bug above leaves behind
+    insertNote({
+      id: 'note-diverged',
+      clock: { mac: 2 },
+      syncedAt: '2026-01-01T00:00:00Z',
+      modifiedAt: '2026-01-02T00:00:00Z'
+    })
+
+    expect(recoverDirtyItems(asSyncDb(testDb.db), noteAdapters).notes).toBe(1)
+    expect(recovered).toEqual(['note-diverged'])
+  })
+})

--- a/apps/desktop/src/main/sync/sync-parent-ordering.test.ts
+++ b/apps/desktop/src/main/sync/sync-parent-ordering.test.ts
@@ -1,0 +1,209 @@
+/**
+ * A child that arrives before its FK parent must be deferred, never lost.
+ *
+ * `tasks.project_id` is NOT NULL and FK-bound, and so is
+ * `calendar_external_events.source_id`. The server hands pages back in
+ * last-update order, not dependency order, so a task genuinely can land before
+ * its project. What the user must never see is the task simply missing.
+ *
+ * Three mechanisms cooperate, and this suite walks the same sequence the pull
+ * coordinator runs, against real SQLite with foreign keys ON:
+ *   1. `sortByApplyOrder` puts parents first inside a page, so the ordinary
+ *      case never defers at all;
+ *   2. an apply that still fails throws instead of returning, which is what
+ *      makes the pull coordinator park the item in `pendingApplyRetries`;
+ *   3. the replay after the parent lands writes it for real.
+ *
+ * `orphan-repair.test.ts` covers step 4 — the parent that is gone *everywhere*
+ * — so this file deliberately stops at the parent that merely arrives late.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { tasks } from '@memry/db-schema/schema/tasks'
+import { projects } from '@memry/db-schema/schema/projects'
+import { calendarSources } from '@memry/db-schema/schema/calendar-sources'
+import { calendarExternalEvents } from '@memry/db-schema/schema/calendar-external-events'
+import { createTestDataDb, asSyncDb, type TestDatabaseResult } from '@tests/utils/test-db'
+import { makeTaskPayload } from '@tests/utils/fixtures/sync-item-handlers'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { ItemApplier, type ApplyItemInput } from './apply-item'
+import { MissingSyncParentError } from './item-handlers/types'
+import { sortByApplyOrder } from './engine/pull-coordinator'
+
+const LATE_PROJECT = 'proj-late'
+const LATE_SOURCE = 'source-late'
+
+let testDb: TestDatabaseResult
+let applier: ItemApplier
+let emit: ReturnType<typeof vi.fn>
+
+const encode = (payload: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(payload))
+
+/** One decrypted pull item, shaped the way the coordinator hands it to apply. */
+function pulled(
+  type: ApplyItemInput['type'],
+  itemId: string,
+  payload: unknown,
+  clock: Record<string, number> = { mac: 1 }
+): ApplyItemInput {
+  return { itemId, type, operation: 'create', content: encode(payload), clock }
+}
+
+const taskItem = (): ApplyItemInput =>
+  pulled(
+    'task',
+    'task-late',
+    makeTaskPayload({ title: 'Ship the release', projectId: LATE_PROJECT, statusId: null })
+  )
+
+const projectItem = (): ApplyItemInput =>
+  pulled('project', LATE_PROJECT, { name: 'Release 2.0', color: '#123456', position: 0 })
+
+const externalEventItem = (): ApplyItemInput =>
+  pulled('calendar_external_event', 'event-late', {
+    sourceId: LATE_SOURCE,
+    remoteEventId: 'remote-1',
+    title: 'Design review',
+    startAt: '2026-08-01T09:00:00.000Z'
+  })
+
+const sourceItem = (): ApplyItemInput =>
+  pulled('calendar_source', LATE_SOURCE, { title: 'Work', provider: 'google' })
+
+/** Applies and returns whatever escaped, mirroring the coordinator's try/catch. */
+function applyCatching(input: ApplyItemInput): unknown {
+  try {
+    applier.apply(input)
+    return undefined
+  } catch (err) {
+    return err
+  }
+}
+
+beforeEach(() => {
+  testDb = createTestDataDb()
+  emit = vi.fn()
+  applier = new ItemApplier(asSyncDb(testDb.db), emit)
+})
+
+afterEach(() => {
+  testDb.close()
+})
+
+describe('out-of-order pull: task before its project', () => {
+  it('defers rather than writing a half-broken row', () => {
+    const err = applyCatching(taskItem())
+
+    expect(err).toBeInstanceOf(MissingSyncParentError)
+    // Naming the parent is what lets the coordinator refetch it instead of
+    // dropping the child until some future remote update (#837).
+    const missing = err as MissingSyncParentError
+    expect(missing.parentType).toBe('project')
+    expect(missing.parentId).toBe(LATE_PROJECT)
+    expect(missing.childId).toBe('task-late')
+
+    expect(testDb.db.select().from(tasks).where(eq(tasks.id, 'task-late')).get()).toBeUndefined()
+  })
+
+  it('lands the task intact once the parent arrives and the deferred item replays', () => {
+    applyCatching(taskItem())
+
+    // A later page of the same run carries the project.
+    expect(applier.apply(projectItem())).toBe('applied')
+
+    // applyDeferredRetries replays everything that threw.
+    expect(applier.apply(taskItem())).toBe('applied')
+
+    const row = testDb.db.select().from(tasks).where(eq(tasks.id, 'task-late')).get()
+    expect(row?.title).toBe('Ship the release')
+    expect(row?.projectId).toBe(LATE_PROJECT)
+  })
+
+  it('never defers in the first place when both items are in the same page', () => {
+    // Cursor order is last-update order, so the child can lead the page.
+    const page = sortByApplyOrder([taskItem(), projectItem()])
+
+    expect(page.map((item) => item.type)).toEqual(['project', 'task'])
+    for (const item of page) expect(applier.apply(item)).toBe('applied')
+    expect(testDb.db.select().from(tasks).where(eq(tasks.id, 'task-late')).get()).toBeDefined()
+  })
+})
+
+describe('out-of-order pull: calendar_external_event before its calendar_source', () => {
+  it('defers rather than writing an event pointing at a source that is not there', () => {
+    const err = applyCatching(externalEventItem())
+
+    expect(err).toBeInstanceOf(Error)
+    expect(
+      testDb.db
+        .select()
+        .from(calendarExternalEvents)
+        .where(eq(calendarExternalEvents.id, 'event-late'))
+        .get()
+    ).toBeUndefined()
+  })
+
+  it('lands the event intact once the source arrives and the deferred item replays', () => {
+    applyCatching(externalEventItem())
+
+    expect(applier.apply(sourceItem())).toBe('applied')
+    expect(
+      testDb.db.select().from(calendarSources).where(eq(calendarSources.id, LATE_SOURCE)).get()
+    ).toBeDefined()
+
+    expect(applier.apply(externalEventItem())).toBe('applied')
+
+    const row = testDb.db
+      .select()
+      .from(calendarExternalEvents)
+      .where(eq(calendarExternalEvents.id, 'event-late'))
+      .get()
+    expect(row?.title).toBe('Design review')
+    expect(row?.sourceId).toBe(LATE_SOURCE)
+  })
+
+  it('never defers in the first place when both items are in the same page', () => {
+    const page = sortByApplyOrder([externalEventItem(), sourceItem()])
+
+    expect(page.map((item) => item.type)).toEqual(['calendar_source', 'calendar_external_event'])
+    for (const item of page) expect(applier.apply(item)).toBe('applied')
+  })
+
+  // GAP. `taskHandler` translates a dangling FK into MissingSyncParentError, so
+  // repairOrphans can refetch the parent and — if it is gone everywhere —
+  // tombstone the child, ending the #837 re-pull loop. The external event
+  // handler still raises SQLite's anonymous "FOREIGN KEY constraint failed",
+  // which names neither the constraint nor the missing id, so the coordinator
+  // can only log and drop it. Deleting a calendar_source cascades its events
+  // away locally while the server keeps them alive, which is exactly the loop
+  // #837 fixed for tasks. Delete `.fails` once the handler names its parent.
+  it.fails('should name the missing calendar_source so orphan repair can act', () => {
+    const err = applyCatching(externalEventItem())
+
+    expect(err).toBeInstanceOf(MissingSyncParentError)
+  })
+})
+
+describe('out-of-order pull: a deferred child does not disturb its neighbours', () => {
+  it('applies every other item in the page even though one child is unwritable', () => {
+    expect(applier.apply(sourceItem())).toBe('applied')
+    expect(applyCatching(taskItem())).toBeInstanceOf(MissingSyncParentError)
+    expect(applier.apply(projectItem())).toBe('applied')
+
+    expect(
+      testDb.db.select().from(calendarSources).where(eq(calendarSources.id, LATE_SOURCE)).get()
+    ).toBeDefined()
+    expect(
+      testDb.db.select().from(projects).where(eq(projects.id, LATE_PROJECT)).get()
+    ).toBeDefined()
+  })
+})

--- a/apps/desktop/src/main/sync/sync-parent-ordering.test.ts
+++ b/apps/desktop/src/main/sync/sync-parent-ordering.test.ts
@@ -178,18 +178,22 @@ describe('out-of-order pull: calendar_external_event before its calendar_source'
     for (const item of page) expect(applier.apply(item)).toBe('applied')
   })
 
-  // GAP. `taskHandler` translates a dangling FK into MissingSyncParentError, so
-  // repairOrphans can refetch the parent and — if it is gone everywhere —
-  // tombstone the child, ending the #837 re-pull loop. The external event
-  // handler still raises SQLite's anonymous "FOREIGN KEY constraint failed",
-  // which names neither the constraint nor the missing id, so the coordinator
-  // can only log and drop it. Deleting a calendar_source cascades its events
-  // away locally while the server keeps them alive, which is exactly the loop
-  // #837 fixed for tasks. Delete `.fails` once the handler names its parent.
-  it.fails('should name the missing calendar_source so orphan repair can act', () => {
+  // Like `taskHandler`, the external event handler translates a dangling FK
+  // into MissingSyncParentError, so repairOrphans can refetch the parent and —
+  // if it is gone everywhere — tombstone the child, ending the #837 re-pull
+  // loop. SQLite's anonymous "FOREIGN KEY constraint failed" names neither the
+  // constraint nor the missing id, so the coordinator could only log and drop
+  // it, and an unchanged Google event has no next remote update to recover on.
+  // Deleting a calendar_source cascades its events away locally while the
+  // server keeps them alive, which is exactly the loop #837 fixed for tasks.
+  it('names the missing calendar_source so orphan repair can act', () => {
     const err = applyCatching(externalEventItem())
 
     expect(err).toBeInstanceOf(MissingSyncParentError)
+    const missing = err as MissingSyncParentError
+    expect(missing.parentType).toBe('calendar_source')
+    expect(missing.parentId).toBe(LATE_SOURCE)
+    expect(missing.childId).toBe('event-late')
   })
 })
 

--- a/apps/desktop/src/main/sync/sync-server-url.test.ts
+++ b/apps/desktop/src/main/sync/sync-server-url.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveSyncServerUrl } from './sync-server-url'
 
 const ORIGINAL_URL = process.env.SYNC_SERVER_URL
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV
 const DEV_FALLBACK = 'http://localhost:8787'
 
 function setEnvUrl(value: string | undefined): void {
@@ -9,13 +10,22 @@ function setEnvUrl(value: string | undefined): void {
   else process.env.SYNC_SERVER_URL = value
 }
 
+function setNodeEnv(value: string | undefined): void {
+  if (value === undefined) delete process.env.NODE_ENV
+  else process.env.NODE_ENV = value
+}
+
 describe('resolveSyncServerUrl', () => {
   beforeEach(() => {
     setEnvUrl(undefined)
+    // Vitest already runs as 'test', but pin it so the fallback branch under
+    // test does not depend on the runner's ambient value.
+    setNodeEnv('development')
   })
 
   afterEach(() => {
     setEnvUrl(ORIGINAL_URL)
+    setNodeEnv(ORIGINAL_NODE_ENV)
   })
 
   describe('lazy resolution', () => {
@@ -65,6 +75,58 @@ describe('resolveSyncServerUrl', () => {
       process.env.SYNC_SERVER_URL = ''
       expect(resolveSyncServerUrl()).toBe(DEV_FALLBACK)
     })
+
+    it('also falls back under the test harness, which runs an unpackaged build', () => {
+      // vitest and tests/e2e/utils/electron-lifecycle.ts both launch with
+      // NODE_ENV=test and frequently without SYNC_SERVER_URL. Throwing there
+      // would break a currently-green harness without making a shipped build
+      // any safer.
+      setNodeEnv('test')
+      expect(resolveSyncServerUrl()).toBe(DEV_FALLBACK)
+    })
+  })
+
+  describe('production policy', () => {
+    // The defect this guard closes: one env var had two policies. http-client.ts
+    // already threw outside development, so a packaged app with a missing or
+    // corrupt Resources/app-config failed sync HTTP loudly — while THIS resolver
+    // handed the OAuth sign-in URL (ipc/auth-oauth-handlers.ts) and the canvas
+    // asset service (canvas/assets/asset-service-context.ts) a silent
+    // http://localhost:8787, pointing a real user at a port nothing is on.
+
+    it('refuses to fall back to localhost when NODE_ENV is production', () => {
+      setNodeEnv('production')
+      expect(() => resolveSyncServerUrl()).toThrow(
+        'SYNC_SERVER_URL environment variable is not configured'
+      )
+    })
+
+    it('refuses to fall back when NODE_ENV is unset, as it is in packaged Electron', () => {
+      // Packaged builds leave NODE_ENV undefined at runtime — see the
+      // applyPackagedLogLevels comment in src/main/index.ts. That is precisely
+      // the case that used to silently resolve to localhost.
+      setNodeEnv(undefined)
+      expect(() => resolveSyncServerUrl()).toThrow(
+        'SYNC_SERVER_URL environment variable is not configured'
+      )
+    })
+
+    it('raises the same message http-client.ts raises, so one policy has one error', () => {
+      setNodeEnv(undefined)
+      expect(() => resolveSyncServerUrl()).toThrow(
+        new Error('SYNC_SERVER_URL environment variable is not configured')
+      )
+    })
+
+    it('never throws for a correctly packaged build, which always ships a configured URL', () => {
+      // scripts/build-packaged-app.js refuses to package without
+      // apps/desktop/.env.production and asserts the value is a non-local HTTPS
+      // URL, then stages it as Resources/app-config. So production reaching the
+      // throw means the config is genuinely gone, not that this guard is strict.
+      setNodeEnv('production')
+      process.env.SYNC_SERVER_URL = 'https://sync.memrynote.com'
+      expect(resolveSyncServerUrl()).toBe('https://sync.memrynote.com')
+    })
   })
 
   describe('configured values', () => {
@@ -82,12 +144,31 @@ describe('resolveSyncServerUrl', () => {
       }
     })
 
-    it('does not normalize a trailing slash', () => {
-      // Callers build paths with `${url}/auth/...`, so a trailing slash in the
-      // env yields a double slash. Recorded as current behaviour: this module
-      // is a raw reader, normalization (if ever wanted) belongs to the caller.
+    it('strips a trailing slash so callers never build a double-slash path', () => {
+      // Callers build paths with `${url}/auth/...`. Left un-normalized, a
+      // trailing slash in the env produced `https://host//auth/...`, which the
+      // Cloudflare Worker routes as a different path — so sign-in 404s against
+      // an otherwise correct configuration.
       process.env.SYNC_SERVER_URL = 'https://sync.memrynote.com/'
-      expect(resolveSyncServerUrl()).toBe('https://sync.memrynote.com/')
+      expect(resolveSyncServerUrl()).toBe('https://sync.memrynote.com')
+      expect(`${resolveSyncServerUrl()}/auth/oauth/google`).toBe(
+        'https://sync.memrynote.com/auth/oauth/google'
+      )
+    })
+
+    it('strips repeated trailing slashes and leaves a base path intact', () => {
+      process.env.SYNC_SERVER_URL = 'https://sync.memrynote.com///'
+      expect(resolveSyncServerUrl()).toBe('https://sync.memrynote.com')
+
+      process.env.SYNC_SERVER_URL = 'https://edge.example.com/memry/'
+      expect(resolveSyncServerUrl()).toBe('https://edge.example.com/memry')
+    })
+
+    it('leaves an all-slashes value alone rather than collapsing it to an empty string', () => {
+      // Degenerate, but returning '' would silently turn every absolute call
+      // into a relative path instead of failing at the call site.
+      process.env.SYNC_SERVER_URL = '/'
+      expect(resolveSyncServerUrl()).toBe('/')
     })
 
     it('never silently substitutes the default for a present-but-malformed value', () => {

--- a/apps/desktop/src/main/sync/sync-server-url.test.ts
+++ b/apps/desktop/src/main/sync/sync-server-url.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveSyncServerUrl } from './sync-server-url'
+
+const ORIGINAL_URL = process.env.SYNC_SERVER_URL
+const DEV_FALLBACK = 'http://localhost:8787'
+
+function setEnvUrl(value: string | undefined): void {
+  if (value === undefined) delete process.env.SYNC_SERVER_URL
+  else process.env.SYNC_SERVER_URL = value
+}
+
+describe('resolveSyncServerUrl', () => {
+  beforeEach(() => {
+    setEnvUrl(undefined)
+  })
+
+  afterEach(() => {
+    setEnvUrl(ORIGINAL_URL)
+  })
+
+  describe('lazy resolution', () => {
+    // The regression this module exists for: a module-level
+    // `const URL = process.env.SYNC_SERVER_URL || 'http://localhost:8787'`
+    // froze to the fallback because main loads `.env.<environment>` via dotenv
+    // AFTER the IPC handler modules are imported. In `dev` the fallback happens
+    // to equal `.env.dev`, so the bug was invisible; in `dev:staging` it pinned
+    // OAuth and sync to localhost.
+    it('reflects an env value that was set after the module was imported', () => {
+      // This module was imported at the top of the file, with the var unset.
+      expect(process.env.SYNC_SERVER_URL).toBeUndefined()
+
+      process.env.SYNC_SERVER_URL = 'https://sync-staging.memrynote.com'
+
+      expect(resolveSyncServerUrl()).toBe('https://sync-staging.memrynote.com')
+    })
+
+    it('picks up a changed env on the very next call', () => {
+      process.env.SYNC_SERVER_URL = 'https://sync.memrynote.com'
+      expect(resolveSyncServerUrl()).toBe('https://sync.memrynote.com')
+
+      process.env.SYNC_SERVER_URL = 'https://sync-staging.memrynote.com'
+      expect(resolveSyncServerUrl()).toBe('https://sync-staging.memrynote.com')
+
+      setEnvUrl(undefined)
+      expect(resolveSyncServerUrl()).toBe(DEV_FALLBACK)
+    })
+
+    it('imports cleanly with no env configured and still resolves later', async () => {
+      // Import-time throws are what made the eager version untestable; a fresh
+      // import with nothing configured must not blow up.
+      vi.resetModules()
+      const fresh = await import('./sync-server-url')
+
+      process.env.SYNC_SERVER_URL = 'https://sync.memrynote.com'
+      expect(fresh.resolveSyncServerUrl()).toBe('https://sync.memrynote.com')
+    })
+  })
+
+  describe('absent or empty configuration', () => {
+    it('falls back to the local dev server when unset', () => {
+      expect(resolveSyncServerUrl()).toBe(DEV_FALLBACK)
+    })
+
+    it('treats an empty value as absent rather than returning an empty host', () => {
+      process.env.SYNC_SERVER_URL = ''
+      expect(resolveSyncServerUrl()).toBe(DEV_FALLBACK)
+    })
+  })
+
+  describe('configured values', () => {
+    it('returns a configured URL verbatim, never rewriting scheme, host or port', () => {
+      for (const configured of [
+        'https://sync.memrynote.com',
+        'https://sync-staging.memrynote.com',
+        'http://127.0.0.1:8787',
+        'http://localhost:9999'
+      ]) {
+        process.env.SYNC_SERVER_URL = configured
+        const resolved = resolveSyncServerUrl()
+        expect(resolved).toBe(configured)
+        expect(new URL(resolved).host).toBe(new URL(configured).host)
+      }
+    })
+
+    it('does not normalize a trailing slash', () => {
+      // Callers build paths with `${url}/auth/...`, so a trailing slash in the
+      // env yields a double slash. Recorded as current behaviour: this module
+      // is a raw reader, normalization (if ever wanted) belongs to the caller.
+      process.env.SYNC_SERVER_URL = 'https://sync.memrynote.com/'
+      expect(resolveSyncServerUrl()).toBe('https://sync.memrynote.com/')
+    })
+
+    it('never silently substitutes the default for a present-but-malformed value', () => {
+      // The dangerous failure mode would be swallowing a typo and quietly
+      // talking to localhost instead. A malformed value comes back verbatim, so
+      // the first request against it fails loudly at the call site.
+      process.env.SYNC_SERVER_URL = 'sync.memrynote.com'
+      const resolved = resolveSyncServerUrl()
+
+      expect(resolved).toBe('sync.memrynote.com')
+      expect(resolved).not.toBe(DEV_FALLBACK)
+      expect(() => new URL(resolved)).toThrow()
+    })
+
+    it('keeps whitespace-only configuration distinguishable from unset', () => {
+      // ' ' is truthy, so it is NOT treated as absent — it produces an
+      // unparseable URL rather than a silent localhost fallback.
+      process.env.SYNC_SERVER_URL = '   '
+      expect(resolveSyncServerUrl()).toBe('   ')
+      expect(() => new URL(resolveSyncServerUrl())).toThrow()
+    })
+  })
+})

--- a/apps/desktop/src/main/sync/sync-server-url.ts
+++ b/apps/desktop/src/main/sync/sync-server-url.ts
@@ -9,6 +9,63 @@
  * `.env.dev`'s value so the bug is invisible; in `dev:staging` it silently
  * pinned OAuth/sync to localhost. Mirrors `http-client.ts`'s lazy resolution.
  */
+
+const DEV_FALLBACK_URL = 'http://localhost:8787'
+
 export function resolveSyncServerUrl(): string {
-  return process.env.SYNC_SERVER_URL || 'http://localhost:8787'
+  const configured = process.env.SYNC_SERVER_URL
+  if (configured) return normalizeSyncServerUrl(configured)
+
+  // Same policy as http-client.ts's getSyncServerUrl(): the localhost fallback
+  // is a *development* convenience, not a runtime default. This module used to
+  // fall back unconditionally, which meant the two call sites that do NOT go
+  // through http-client — the OAuth sign-in URL (ipc/auth-oauth-handlers.ts)
+  // and the canvas asset service (canvas/assets/asset-service-context.ts) —
+  // silently pointed a real user's packaged app at http://localhost:8787 while
+  // sync HTTP was already failing loudly with a config error. One env var must
+  // not have two contradictory policies.
+  //
+  // NODE_ENV is 'development' under `electron-vite dev` and undefined at
+  // runtime in packaged Electron (see the applyPackagedLogLevels comment in
+  // src/main/index.ts), so a packaged build lands on the throw.
+  //
+  // 'test' is accepted alongside 'development' — the same predicate
+  // certificate-pinning.ts uses for its dev bypass — because vitest and the
+  // Playwright Electron harness (tests/e2e/utils/electron-lifecycle.ts sets
+  // NODE_ENV: 'test') run an UNPACKAGED build that often has no
+  // SYNC_SERVER_URL. Excluding it would turn a green harness into a hard
+  // failure without making a shipped build any safer.
+  //
+  // Compat, packaged builds: this throw is unreachable for an app that was
+  // built normally. scripts/build-packaged-app.js refuses to package without
+  // apps/desktop/.env.production, asserts the value is a valid non-local HTTPS
+  // URL (assertProductionSyncServerUrl in build-packaged-app-utils.cjs), and
+  // stages it as `app-config`, which every electron-builder config copies into
+  // Resources. There is no packaging path that legitimately omits it. If
+  // app-config is nevertheless absent or corrupt at runtime, sync HTTP was
+  // ALREADY dead — http-client.ts throws this exact error — so no working
+  // configuration becomes a hard failure here. The only change is that OAuth
+  // and canvas assets now report the same explicit config error instead of
+  // dialing a localhost port nothing is listening on.
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
+    return DEV_FALLBACK_URL
+  }
+
+  throw new Error('SYNC_SERVER_URL environment variable is not configured')
+}
+
+/**
+ * Every caller builds paths as `${url}/auth/...`, so a trailing slash in the
+ * env yields `https://host//auth/...`. Cloudflare Workers routes that as a
+ * different path, so the request 404s instead of reaching the handler.
+ *
+ * Only trailing slashes are stripped: scheme, host, port and any base path are
+ * left verbatim so a typo still fails loudly at the call site rather than being
+ * silently rewritten into something that "works". A value that is nothing but
+ * slashes is returned unchanged rather than collapsed to '', which would turn
+ * an absolute URL into a relative path.
+ */
+function normalizeSyncServerUrl(url: string): string {
+  const trimmed = url.replace(/\/+$/, '')
+  return trimmed || url
 }

--- a/apps/desktop/src/main/sync/tag-definition-sync.test.ts
+++ b/apps/desktop/src/main/sync/tag-definition-sync.test.ts
@@ -147,27 +147,47 @@ describe('TagDefinitionSyncService push', () => {
     expect(storedClock()).toEqual({})
   })
 
-  it.fails(
-    'queues a create payload that satisfies the tag_definition sync schema when views are saved',
-    () => {
-      // PRODUCT BUG: `serialize: (local) => local` ships the raw DB row, and
-      // `tag_definitions.views` is a TEXT column holding JSON, so the queued
-      // payload carries `views` as a *string* while the contract expects an
-      // array. The push coordinator normally rebuilds the payload via
-      // `tagDefinitionHandler.buildPushPayload` (which calls `readTagViews`),
-      // so this only escapes on the frozen-payload fallback — reached when the
-      // row disappears locally before the push flushes (e.g. a remote delete
-      // hard-deletes the row, which `tagDefinitionHandler.applyDelete` does).
-      // The receiver then fails schema validation and drops the whole tag,
-      // colour included.
-      seedTag({ views: JSON.stringify([{ id: 'v1', name: 'All', type: 'list' }]) })
+  it('queues a create payload that satisfies the tag_definition sync schema when views are saved', () => {
+    // REGRESSION GUARD: `serialize` used to ship the raw DB row, and
+    // `tag_definitions.views` is a TEXT column holding JSON, so the queued
+    // payload carried `views` as a *string* while the contract expects an
+    // array. The push coordinator normally rebuilds the payload via
+    // `tagDefinitionHandler.buildPushPayload` (which calls `readTagViews`),
+    // so this only escaped on the frozen-payload fallback — reached when the
+    // row disappears locally before the push flushes (e.g. a remote delete
+    // hard-deletes the row, which `tagDefinitionHandler.applyDelete` does).
+    // The receiver then failed schema validation and dropped the whole tag,
+    // colour included.
+    seedTag({ views: JSON.stringify([{ id: 'v1', name: 'All', type: 'list' }]) })
 
-      makeService().enqueueCreate('work')
+    makeService().enqueueCreate('work')
 
-      const payload = payloadOf(queueRows()[0])
-      expect(TagDefinitionSyncPayloadSchema.safeParse(payload).success).toBe(true)
-    }
-  )
+    const payload = payloadOf(queueRows()[0])
+    expect(payload.views).toEqual([{ id: 'v1', name: 'All', type: 'list' }])
+    expect(TagDefinitionSyncPayloadSchema.safeParse(payload).success).toBe(true)
+  })
+
+  it('sends null views as an explicit clear and never invents the key', () => {
+    seedTag()
+
+    makeService().enqueueCreate('work')
+
+    const payload = payloadOf(queueRows()[0])
+    expect(payload.views).toBeNull()
+    expect(TagDefinitionSyncPayloadSchema.safeParse(payload).success).toBe(true)
+  })
+
+  it('drops an unreadable views blob instead of clearing the peer copy', () => {
+    // A corrupt blob must not become `views: null` on the wire — the receiver
+    // treats an absent key as "sender predates this field, keep local".
+    seedTag({ views: '{not json' })
+
+    makeService().enqueueCreate('work')
+
+    const payload = payloadOf(queueRows()[0])
+    expect(Object.prototype.hasOwnProperty.call(payload, 'views')).toBe(false)
+    expect(TagDefinitionSyncPayloadSchema.safeParse(payload).success).toBe(true)
+  })
 })
 
 describe('TagDefinitionSyncService deletes', () => {

--- a/apps/desktop/src/main/sync/tag-definition-sync.test.ts
+++ b/apps/desktop/src/main/sync/tag-definition-sync.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { tagDefinitions } from '@memry/db-schema/schema/tag-definitions'
+import { syncQueue } from '@memry/db-schema/schema/sync-queue'
+import { TagDefinitionSyncPayloadSchema } from '@memry/contracts/sync-payloads'
+import { createTestDataDb, type TestDataDb } from '../../test/helpers/test-data-db'
+
+/**
+ * Push side of tag-definition sync. Real `RecordSyncController`, real
+ * `SyncQueueManager`, real migrated in-memory data DB.
+ *
+ * The colour is the field users notice: a tag whose colour fails to leave the
+ * machine (or leaves stale) shows up as "my tag colours changed on their own".
+ */
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import { SyncQueueManager } from './queue'
+import {
+  TagDefinitionSyncService,
+  getTagDefinitionSyncService,
+  initTagDefinitionSyncService,
+  resetTagDefinitionSyncService
+} from './tag-definition-sync'
+
+let db: TestDataDb
+let queue: SyncQueueManager
+
+function seedTag(overrides: Record<string, unknown> = {}): void {
+  db.insert(tagDefinitions)
+    .values({
+      name: 'work',
+      color: 'terracotta',
+      icon: null,
+      clock: {},
+      categoryId: null,
+      sortOrder: 0,
+      ...overrides
+    } as never)
+    .run()
+}
+
+function queueRows(): Array<typeof syncQueue.$inferSelect> {
+  return db.select().from(syncQueue).all()
+}
+
+function payloadOf(row: typeof syncQueue.$inferSelect | undefined): Record<string, unknown> {
+  return JSON.parse(row!.payload) as Record<string, unknown>
+}
+
+function storedClock(name = 'work'): unknown {
+  return db.select().from(tagDefinitions).where(eq(tagDefinitions.name, name)).get()?.clock
+}
+
+function makeService(deviceId: string | null = 'device-a'): TagDefinitionSyncService {
+  return new TagDefinitionSyncService({ queue, db, getDeviceId: () => deviceId })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  db = createTestDataDb()
+  queue = new SyncQueueManager(db)
+  resetTagDefinitionSyncService()
+})
+
+describe('TagDefinitionSyncService push', () => {
+  it('enqueues exactly one tag_definition create carrying the colour', () => {
+    seedTag()
+
+    makeService().enqueueCreate('work')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].type).toBe('tag_definition')
+    expect(rows[0].itemId).toBe('work')
+    expect(rows[0].operation).toBe('create')
+
+    const payload = payloadOf(rows[0])
+    expect(payload).toMatchObject({
+      name: 'work',
+      color: 'terracotta',
+      sortOrder: 0,
+      clock: { 'device-a': 1 }
+    })
+    expect(TagDefinitionSyncPayloadSchema.safeParse(payload).success).toBe(true)
+  })
+
+  it('pushes the NEW colour after the user recolours a tag', () => {
+    seedTag()
+    const service = makeService()
+
+    service.enqueueCreate('work')
+    db.update(tagDefinitions).set({ color: 'indigo' }).where(eq(tagDefinitions.name, 'work')).run()
+    service.enqueueUpdate('work')
+
+    // The pending push is rewritten in place, so the surviving payload must
+    // carry the colour the user just chose, not the one it replaced.
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(payloadOf(rows[0]).color).toBe('indigo')
+  })
+
+  it('carries the icon, category and sort order alongside the colour', () => {
+    seedTag({ icon: 'briefcase', categoryId: 'cat-1', sortOrder: 3 })
+
+    makeService().enqueueUpdate('work')
+
+    expect(payloadOf(queueRows()[0])).toMatchObject({
+      color: 'terracotta',
+      icon: 'briefcase',
+      categoryId: 'cat-1',
+      sortOrder: 3
+    })
+  })
+
+  it('persists the bumped clock on the tag row', () => {
+    seedTag({ clock: { 'device-b': 2 } })
+
+    makeService().enqueueUpdate('work')
+
+    expect(storedClock()).toEqual({ 'device-b': 2, 'device-a': 1 })
+    expect(payloadOf(queueRows()[0]).clock).toEqual({ 'device-b': 2, 'device-a': 1 })
+  })
+
+  it('skips a tag that has no definition row', () => {
+    makeService().enqueueUpdate('ghost')
+
+    expect(queueRows()).toEqual([])
+  })
+
+  it('skips every mutation while there is no device id', () => {
+    seedTag()
+    const service = makeService(null)
+
+    service.enqueueCreate('work')
+    service.enqueueUpdate('work')
+    service.enqueueDelete('work')
+
+    expect(queueRows()).toEqual([])
+    expect(storedClock()).toEqual({})
+  })
+
+  it.fails(
+    'queues a create payload that satisfies the tag_definition sync schema when views are saved',
+    () => {
+      // PRODUCT BUG: `serialize: (local) => local` ships the raw DB row, and
+      // `tag_definitions.views` is a TEXT column holding JSON, so the queued
+      // payload carries `views` as a *string* while the contract expects an
+      // array. The push coordinator normally rebuilds the payload via
+      // `tagDefinitionHandler.buildPushPayload` (which calls `readTagViews`),
+      // so this only escapes on the frozen-payload fallback — reached when the
+      // row disappears locally before the push flushes (e.g. a remote delete
+      // hard-deletes the row, which `tagDefinitionHandler.applyDelete` does).
+      // The receiver then fails schema validation and drops the whole tag,
+      // colour included.
+      seedTag({ views: JSON.stringify([{ id: 'v1', name: 'All', type: 'list' }]) })
+
+      makeService().enqueueCreate('work')
+
+      const payload = payloadOf(queueRows()[0])
+      expect(TagDefinitionSyncPayloadSchema.safeParse(payload).success).toBe(true)
+    }
+  )
+})
+
+describe('TagDefinitionSyncService deletes', () => {
+  it('propagates a delete using the caller snapshot with the clock advanced', () => {
+    seedTag()
+
+    makeService().enqueueDelete(
+      'work',
+      JSON.stringify({ name: 'work', color: 'terracotta', clock: { 'device-a': 4 } })
+    )
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('delete')
+    expect(payloadOf(rows[0])).toEqual({
+      name: 'work',
+      color: 'terracotta',
+      clock: { 'device-a': 5 }
+    })
+  })
+
+  it('falls back to a minimal tombstone when the caller has no snapshot', () => {
+    makeService().enqueueDelete('work')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('delete')
+    // The empty colour is a placeholder that only exists to satisfy the
+    // required `color` field; the receiver's delete path ignores it.
+    const payload = payloadOf(rows[0])
+    expect(payload).toEqual({ name: 'work', color: '', clock: { 'device-a': 1 } })
+    expect(TagDefinitionSyncPayloadSchema.safeParse(payload).success).toBe(true)
+  })
+
+  it('propagates a delete for a tag whose row is already gone', () => {
+    makeService().enqueueDelete('already-removed')
+
+    expect(queueRows()).toHaveLength(1)
+  })
+
+  it('lets a delete win over a still-pending create instead of being dropped', () => {
+    seedTag()
+    const service = makeService()
+
+    service.enqueueCreate('work')
+    service.enqueueDelete('work')
+
+    const rows = queueRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].operation).toBe('delete')
+  })
+})
+
+describe('tag definition sync service lifecycle', () => {
+  it('tracks the module-level singleton', () => {
+    expect(getTagDefinitionSyncService()).toBeNull()
+
+    const service = initTagDefinitionSyncService({ queue, db, getDeviceId: () => 'device-a' })
+    expect(getTagDefinitionSyncService()).toBe(service)
+
+    resetTagDefinitionSyncService()
+    expect(getTagDefinitionSyncService()).toBeNull()
+  })
+})

--- a/apps/desktop/src/main/sync/tag-definition-sync.ts
+++ b/apps/desktop/src/main/sync/tag-definition-sync.ts
@@ -16,6 +16,50 @@ interface TagDefinitionSyncDeps {
 
 let instance: TagDefinitionSyncService | null = null
 
+/**
+ * Normalise a raw `tag_definitions` row into something
+ * `TagDefinitionSyncPayloadSchema` accepts.
+ *
+ * `tag_definitions.views` is a TEXT column holding a JSON array, but the
+ * contract expects `array | null | undefined`. Shipping the row verbatim put a
+ * *string* on the wire, so `safeParse` failed on the receiving device and the
+ * whole tag definition — colour included — was dropped.
+ *
+ * The push coordinator normally rebuilds this payload via
+ * `tagDefinitionHandler.buildPushPayload` (which calls `readTagViews`), so the
+ * frozen queue payload only escapes on the fallback path — reached when the row
+ * is gone locally by flush time, e.g. a remote delete hard-deletes it while a
+ * local update is still queued. Normalising here makes both paths agree.
+ *
+ * Backward compatibility:
+ * - Key presence is preserved exactly as the row provides it, so this never
+ *   turns an absent `views` into an explicit clear.
+ * - A corrupt or non-array blob drops the key rather than sending `null`, so the
+ *   receiver's `hasOwnProperty` guard keeps its local views instead of clearing
+ *   them. An absent key is also what an older sender produces, so receivers on
+ *   every build already handle it.
+ */
+function normalizeTagPayload(local: Record<string, unknown>): Record<string, unknown> {
+  if (!Object.prototype.hasOwnProperty.call(local, 'views')) return local
+
+  const raw = local.views
+  // `null` is an explicit clear and an array is already schema-shaped.
+  if (raw === null || Array.isArray(raw)) return local
+
+  if (typeof raw === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      if (Array.isArray(parsed)) return { ...local, views: parsed }
+    } catch {
+      // Corrupt blob: fall through and drop the key. Mirrors `readTagViews`,
+      // which treats unreadable JSON as "no saved views" rather than throwing.
+    }
+  }
+
+  const { views: _unreadable, ...rest } = local
+  return rest
+}
+
 export function initTagDefinitionSyncService(
   deps: TagDefinitionSyncDeps
 ): TagDefinitionSyncService {
@@ -55,7 +99,7 @@ export class TagDefinitionSyncService {
 
         return { ...local, clock: newClock }
       },
-      serialize: (local) => local,
+      serialize: (local) => normalizeTagPayload(local),
       buildDeletePayload: ({ itemId, extra, deviceId }) => {
         const snapshotPayload = extra[0]
         if (snapshotPayload) {

--- a/apps/desktop/src/main/sync/worker-protocol.test.ts
+++ b/apps/desktop/src/main/sync/worker-protocol.test.ts
@@ -1,0 +1,281 @@
+import type { PushItem } from '@memry/contracts/sync-api'
+import { describe, expect, it } from 'vitest'
+import type {
+  DecryptedPullItem,
+  DecryptionFailure,
+  EncryptedPushResult,
+  MainToWorkerMessage,
+  PullItemForDecrypt,
+  RawPushItem,
+  WorkerToMainMessage
+} from './worker-protocol'
+import { isCryptoErrorMessage } from './worker-protocol'
+
+/**
+ * `worker_threads.postMessage` uses the structured clone algorithm, which is
+ * exactly what `structuredClone` implements — so cloning here reproduces what
+ * a message actually looks like on the far side of the thread boundary.
+ */
+const overWire = <T>(msg: T): T => structuredClone(msg)
+
+const pushItem: PushItem = {
+  id: 'item-1',
+  type: 'note',
+  operation: 'update',
+  encryptedKey: 'ek',
+  keyNonce: 'kn',
+  encryptedData: 'ed',
+  dataNonce: 'dn',
+  signature: 'sig',
+  signerDeviceId: 'device-a',
+  clock: { 'device-a': 4 },
+  stateVector: 'sv'
+}
+
+const rawPushItem: RawPushItem = {
+  queueId: 'q-1',
+  itemId: 'item-1',
+  type: 'note',
+  operation: 'update',
+  payload: '{"title":"hello"}',
+  clock: { 'device-a': 4, 'device-b': 1 },
+  stateVector: 'AQID',
+  deletedAt: 1_760_000_000_000
+}
+
+const pullItem: PullItemForDecrypt = {
+  id: 'item-1',
+  type: 'note',
+  operation: 'update',
+  cryptoVersion: 1,
+  encryptedKey: 'ek',
+  keyNonce: 'kn',
+  encryptedData: 'ed',
+  dataNonce: 'dn',
+  signature: 'sig',
+  signerDeviceId: 'device-a',
+  clock: { 'device-a': 4 },
+  stateVector: 'AQID',
+  deletedAt: 1_760_000_000_000
+}
+
+describe('worker message contract', () => {
+  describe('key material across the thread boundary', () => {
+    it('hands the worker a Uint8Array copy, not a view onto the caller’s key', () => {
+      // Load-bearing: worker.ts wipes msg.vaultKey / msg.signingSecretKey with
+      // secureCleanup() in a `finally`. Structured clone copies rather than
+      // transfers, so that zeroing must not reach back into the main process's
+      // vault key — if it ever did, every subsequent push/pull in that session
+      // would encrypt with a zeroed key.
+      const vaultKey = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+      const signingSecretKey = new Uint8Array([9, 8, 7, 6])
+
+      const msg: MainToWorkerMessage = {
+        type: 'encrypt-batch',
+        requestId: 'req-1',
+        items: [rawPushItem],
+        vaultKey,
+        signingSecretKey,
+        signerDeviceId: 'device-a'
+      }
+
+      const received = overWire(msg)
+      if (received.type !== 'encrypt-batch') throw new Error('unreachable')
+
+      expect(received.vaultKey).toBeInstanceOf(Uint8Array)
+      expect(Array.from(received.vaultKey)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+      expect(received.vaultKey).not.toBe(vaultKey)
+      expect(received.vaultKey.buffer).not.toBe(vaultKey.buffer)
+
+      received.vaultKey.fill(0)
+      received.signingSecretKey.fill(0)
+
+      expect(Array.from(vaultKey)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+      expect(Array.from(signingSecretKey)).toEqual([9, 8, 7, 6])
+    })
+  })
+
+  describe('round-trips', () => {
+    it('preserves an encrypt-batch request, clocks and optional fields included', () => {
+      const msg: MainToWorkerMessage = {
+        type: 'encrypt-batch',
+        requestId: 'req-1',
+        items: [rawPushItem, { ...rawPushItem, queueId: 'q-2', clock: undefined }],
+        vaultKey: new Uint8Array(32),
+        signingSecretKey: new Uint8Array(64),
+        signerDeviceId: 'device-a'
+      }
+
+      const received = overWire(msg)
+      if (received.type !== 'encrypt-batch') throw new Error('unreachable')
+
+      expect(received.items[0]).toEqual(rawPushItem)
+      // A VectorClock is a plain Record<string, number>; nothing in it needs a
+      // custom serializer, and an absent clock must not become `{}` (the push
+      // path treats a clock as "this item is clock-tracked").
+      expect(received.items[0].clock).toEqual({ 'device-a': 4, 'device-b': 1 })
+      expect(received.items[1].clock).toBeUndefined()
+      expect(received.items[0].deletedAt).toBe(1_760_000_000_000)
+    })
+
+    it('preserves a decrypt-batch request including the signer key map', () => {
+      const msg: MainToWorkerMessage = {
+        type: 'decrypt-batch',
+        requestId: 'req-2',
+        items: [pullItem, { ...pullItem, id: 'item-2', clock: undefined, deletedAt: undefined }],
+        vaultKey: new Uint8Array([7, 7, 7]),
+        signerKeys: { 'device-a': 'base64-public-key', 'device-b': 'other-key' }
+      }
+
+      const received = overWire(msg)
+      if (received.type !== 'decrypt-batch') throw new Error('unreachable')
+
+      expect(received.items[0]).toEqual(pullItem)
+      expect(received.signerKeys).toEqual({
+        'device-a': 'base64-public-key',
+        'device-b': 'other-key'
+      })
+      expect(received.items[1].clock).toBeUndefined()
+    })
+
+    it('preserves both batch results and the error reply', () => {
+      const encryptResult: EncryptedPushResult = { queueId: 'q-1', pushItem, sizeBytes: 412 }
+      const decrypted: DecryptedPullItem = {
+        id: 'item-1',
+        type: 'note',
+        operation: 'update',
+        content: '{"title":"hello"}',
+        clock: { 'device-a': 4 },
+        deletedAt: undefined,
+        signerDeviceId: 'device-a'
+      }
+      const failure: DecryptionFailure = {
+        id: 'item-2',
+        type: 'note',
+        signerDeviceId: 'device-b',
+        error: 'incorrect signature',
+        isCryptoError: true,
+        isSignatureError: true
+      }
+
+      const replies: WorkerToMainMessage[] = [
+        {
+          type: 'encrypt-batch-result',
+          requestId: 'req-1',
+          results: [encryptResult],
+          errors: [{ queueId: 'q-3', itemId: 'item-3', error: 'boom' }]
+        },
+        {
+          type: 'decrypt-batch-result',
+          requestId: 'req-2',
+          results: [decrypted],
+          failures: [failure]
+        },
+        { type: 'error', requestId: 'req-2', error: 'worker blew up' },
+        { type: 'ready' },
+        { type: 'shutdown-ack' }
+      ]
+
+      for (const reply of replies) {
+        expect(overWire(reply)).toEqual(reply)
+      }
+      expect(overWire<MainToWorkerMessage>({ type: 'shutdown' })).toEqual({ type: 'shutdown' })
+    })
+  })
+
+  describe('mixed-version safety', () => {
+    // A packaged app can end up with a main bundle and a worker bundle from
+    // different builds (partial update, stale asar). Neither side may crash on
+    // a kind it does not know.
+    const KNOWN_MAIN_TO_WORKER = ['encrypt-batch', 'decrypt-batch', 'shutdown']
+    const KNOWN_WORKER_TO_MAIN = [
+      'encrypt-batch-result',
+      'decrypt-batch-result',
+      'error',
+      'ready',
+      'shutdown-ack'
+    ]
+
+    it('carries an unknown kind across intact, requestId included, so it can be answered', () => {
+      const fromNewerBuild = { type: 'compact-batch', requestId: 'req-9', docIds: ['a', 'b'] }
+
+      const received = overWire(fromNewerBuild)
+
+      expect(received.type).toBe('compact-batch')
+      expect(KNOWN_MAIN_TO_WORKER).not.toContain(received.type)
+      // The requestId survives, which is what lets a receiver reply with a
+      // typed `error` instead of leaving the sender's promise dangling.
+      expect(received.requestId).toBe('req-9')
+    })
+
+    it('keeps the two kind namespaces disjoint so a reply is never mistaken for a request', () => {
+      for (const kind of KNOWN_WORKER_TO_MAIN) {
+        expect(KNOWN_MAIN_TO_WORKER).not.toContain(kind)
+      }
+    })
+
+    it('lets a receiver discriminate on `type` without touching unknown payloads', () => {
+      const fromNewerBuild = overWire({
+        type: 'encrypt-batch-result',
+        requestId: 'req-9',
+        results: [],
+        errors: [],
+        // Field a future build added; this build must ignore it, not choke.
+        compressionCodec: 'zstd'
+      }) as WorkerToMainMessage & { compressionCodec?: string }
+
+      expect(KNOWN_WORKER_TO_MAIN).toContain(fromNewerBuild.type)
+      expect(fromNewerBuild.compressionCodec).toBe('zstd')
+    })
+  })
+})
+
+describe('isCryptoErrorMessage', () => {
+  // Drives DecryptionFailure.isCryptoError, which the pull coordinator uses to
+  // decide whether to re-fetch an item from the server and to emit ITEM_CORRUPT
+  // to the user. False positives cause pointless refetch storms; false
+  // negatives leave a genuinely corrupt item unrecovered on this device.
+
+  it('classifies the sodium/decrypt failures it was written for', () => {
+    for (const message of [
+      'incorrect signature for the given public key',
+      'unable to decrypt the ciphertext',
+      'sodium is not ready',
+      'invalid nonce length',
+      'invalid input: not base64'
+    ]) {
+      expect(isCryptoErrorMessage(message)).toBe(true)
+    }
+  })
+
+  it('matches regardless of case', () => {
+    expect(isCryptoErrorMessage('Signature Verification Failed')).toBe(true)
+    expect(isCryptoErrorMessage('DECRYPT FAILED')).toBe(true)
+    expect(isCryptoErrorMessage('Invalid Base64 Encoding')).toBe(true)
+  })
+
+  it('does not classify transport, disk or server failures as crypto failures', () => {
+    // These are retried by other machinery; marking them crypto would refetch
+    // the blob and tell the user their item is corrupt.
+    for (const message of [
+      'fetch failed',
+      'read ECONNRESET',
+      'ENOSPC: no space left on device',
+      'HTTP 500 from sync server',
+      'Worker exited with code 1',
+      ''
+    ]) {
+      expect(isCryptoErrorMessage(message)).toBe(false)
+    }
+  })
+
+  it('does not classify a newer crypto version as a corrupt payload', () => {
+    // decrypt.ts throws this for an item written by a newer app version. It is
+    // not corruption and refetching it would change nothing — the user needs an
+    // update, so this must stay out of the crypto/refetch path.
+    expect(isCryptoErrorMessage('Crypto version 3 is not supported. Please update the app.')).toBe(
+      false
+    )
+    expect(isCryptoErrorMessage('Invalid crypto version: 0. Version must be >= 1.')).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/sync/worker-protocol.test.ts
+++ b/apps/desktop/src/main/sync/worker-protocol.test.ts
@@ -208,6 +208,38 @@ describe('worker message contract', () => {
       expect(received.requestId).toBe('req-9')
     })
 
+    it('lets the worker answer an unknown kind with a reply the bridge can route', () => {
+      // worker.ts's `default:` branch builds exactly this from the unknown
+      // request. worker-bridge.ts routes replies with `'requestId' in msg` and
+      // then rejects on `type === 'error'`, so this shape settles the caller's
+      // promise immediately instead of leaving it to the 60s REQUEST_TIMEOUT_MS.
+      const fromNewerBuild = overWire({ type: 'compact-batch', requestId: 'req-9' })
+
+      const reply: WorkerToMainMessage = {
+        type: 'error',
+        requestId: fromNewerBuild.requestId,
+        error: `Unsupported worker message kind: ${fromNewerBuild.type}`
+      }
+
+      const received = overWire(reply)
+
+      expect(received).toEqual(reply)
+      expect('requestId' in received).toBe(true)
+      if (received.type !== 'error') throw new Error('unreachable')
+      expect(received.requestId).toBe('req-9')
+      expect(received.error).toContain('compact-batch')
+    })
+
+    it('has no reply to route when an unknown kind carries no requestId', () => {
+      // `shutdown` is the only known kind without one. An unknown kind that also
+      // lacks it has no pending promise, and a reply with `requestId:
+      // undefined` would pass worker-bridge's `'requestId' in msg` check and be
+      // looked up under the key `undefined` — so worker.ts stays silent.
+      const fromNewerBuild = overWire({ type: 'flush-cache' }) as { requestId?: unknown }
+
+      expect(typeof fromNewerBuild.requestId).not.toBe('string')
+    })
+
     it('keeps the two kind namespaces disjoint so a reply is never mistaken for a request', () => {
       for (const kind of KNOWN_WORKER_TO_MAIN) {
         expect(KNOWN_MAIN_TO_WORKER).not.toContain(kind)

--- a/apps/desktop/src/main/sync/worker.ts
+++ b/apps/desktop/src/main/sync/worker.ts
@@ -31,14 +31,55 @@ async function init(): Promise<void> {
         handleDecryptBatch(msg)
         break
       case 'shutdown':
+        // The exit is delegated to the `if (shuttingDown)` line below (which
+        // already existed for exactly this) rather than called inline, so this
+        // case can `break` and a `default:` can follow it without falling
+        // through. Same tick, same behaviour as the previous inline exit.
         shuttingDown = true
         port.postMessage({ type: 'shutdown-ack' } satisfies WorkerToMainMessage)
-        process.exit(0)
+        break
+      default:
+        handleUnknownMessage(msg)
+        break
     }
     if (shuttingDown) process.exit(0)
   })
 
   port.postMessage({ type: 'ready' } satisfies WorkerToMainMessage)
+}
+
+/**
+ * Reply to a message kind this worker build does not know about.
+ *
+ * A packaged install can end up with a main bundle and a worker bundle from
+ * different builds (partial update, stale asar). Before this existed the switch
+ * above simply dropped such a message with no reply, so the parent's promise
+ * only settled when worker-bridge's REQUEST_TIMEOUT_MS (60s) fired — every
+ * crypto batch stalled a full minute. A typed `error` reply lets
+ * SyncWorkerBridge.encryptBatch/decryptBatch reject immediately instead.
+ *
+ * Compat: unreachable when main and worker come from the same build, because
+ * every kind in `MainToWorkerMessage` is handled above — which is why `msg`
+ * narrows to `never` here. Same-build installs see no behaviour change at all.
+ */
+function handleUnknownMessage(msg: never): void {
+  const unknown = msg as { type?: unknown; requestId?: unknown }
+  const kind = typeof unknown.type === 'string' ? unknown.type : String(unknown.type)
+
+  log.warn('Unsupported message kind from main process', { kind })
+
+  // `shutdown` is the only known kind with no requestId, and an unknown kind
+  // without one has no pending promise to settle. Replying `requestId:
+  // undefined` would put an off-protocol message on the wire that
+  // worker-bridge's `'requestId' in msg` check would accept and then look up as
+  // the key `undefined`, so stay silent in that case.
+  if (typeof unknown.requestId !== 'string') return
+
+  port.postMessage({
+    type: 'error',
+    requestId: unknown.requestId,
+    error: `Unsupported worker message kind: ${kind}`
+  } satisfies WorkerToMainMessage)
 }
 
 function handleEncryptBatch(msg: Extract<MainToWorkerMessage, { type: 'encrypt-batch' }>): void {

--- a/apps/desktop/src/preload/api/agent.ts
+++ b/apps/desktop/src/preload/api/agent.ts
@@ -74,5 +74,14 @@ export const agentApi = {
   getWindowId: (): Promise<{ windowId: string | null }> =>
     invoke(AgentChannels.invoke.GET_WINDOW_ID),
   onEvent: (callback: (event: AgentEvent) => void): (() => void) =>
-    subscribe<AgentEvent>(AgentChannels.events.AGENT_EVENT, callback)
+    subscribe<AgentEvent>(AgentChannels.events.AGENT_EVENT, callback),
+  onConversationsChanged: (callback: (payload: { conversationId: string }) => void): (() => void) =>
+    subscribe<{ conversationId: string }>(AgentChannels.events.CONVERSATIONS_CHANGED, callback),
+  onMessagesChanged: (
+    callback: (payload: { conversationId: string; messageId: string }) => void
+  ): (() => void) =>
+    subscribe<{ conversationId: string; messageId: string }>(
+      AgentChannels.events.MESSAGES_CHANGED,
+      callback
+    )
 }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1711,6 +1711,10 @@ interface AgentClientAPI {
   getDisclosureState: () => Promise<{ accepted: boolean }>
   getWindowId: () => Promise<{ windowId: string | null }>
   onEvent: (callback: (event: AgentEvent) => void) => () => void
+  onConversationsChanged: (callback: (payload: { conversationId: string }) => void) => () => void
+  onMessagesChanged: (
+    callback: (payload: { conversationId: string; messageId: string }) => void
+  ) => () => void
 }
 
 interface MainInvokePayload {

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useReducer } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef
+} from 'react'
 import type { ReactNode } from 'react'
 
 import type {
@@ -52,6 +60,14 @@ interface AgentClientApi {
   acceptDisclosure: () => Promise<DisclosureState>
   getWindowId: () => Promise<{ windowId: string | null }>
   onEvent: (callback: (event: AgentEvent) => void) => () => void
+  /**
+   * Fired when a sync pull rewrites a conversation row. Optional because older
+   * preload bundles (and the test stubs written against them) do not expose it.
+   */
+  onConversationsChanged?: (callback: (payload: { conversationId: string }) => void) => () => void
+  onMessagesChanged?: (
+    callback: (payload: { conversationId: string; messageId: string }) => void
+  ) => () => void
 }
 
 interface AgentContextValue {
@@ -145,6 +161,12 @@ export function AgentProvider({
 }): React.JSX.Element {
   const { t } = useT('common')
   const [state, dispatch] = useReducer(agentReducer, initialAgentState)
+
+  // Read by the sync-event subscription below without making it a dependency:
+  // resubscribing on every conversation switch would tear down and rebuild the
+  // IPC listener for no gain.
+  const activeConversationIdRef = useRef(state.activeConversationId)
+  activeConversationIdRef.current = state.activeConversationId
 
   const refreshConversations = useCallback(async () => {
     try {
@@ -356,11 +378,25 @@ export function AgentProvider({
       })
 
     const unsubscribe = api.onEvent((event) => dispatch({ type: 'event', event }))
+
+    // `agent:event` only carries this window's own turn lifecycle. A
+    // conversation or message pulled from another device lands straight in the
+    // local DB, so without these the list stays stale until the app restarts.
+    const unsubscribeConversations = api.onConversationsChanged?.(() => {
+      void refreshConversations()
+    })
+    const unsubscribeMessages = api.onMessagesChanged?.(({ conversationId }) => {
+      if (conversationId !== activeConversationIdRef.current) return
+      void loadConversation(conversationId, { activate: false })
+    })
+
     return () => {
       cancelled = true
       unsubscribe()
+      unsubscribeConversations?.()
+      unsubscribeMessages?.()
     }
-  }, [t, active])
+  }, [t, active, refreshConversations, loadConversation])
 
   const value = useMemo<AgentContextValue>(
     () => ({

--- a/apps/docs/src/architecture/sync-handlers.md
+++ b/apps/docs/src/architecture/sync-handlers.md
@@ -122,6 +122,73 @@ Two rules for the `changes` field itself:
 The renderer normalizes a missing `changes` to `{}` in `onNoteUpdated`, so a newer renderer stays
 tolerant of an older main process. That is a compatibility floor, not a licence to omit the field.
 
+**Every applied write must emit.** A handler that mutates the data DB and returns `applied` without
+notifying the renderer leaves an open window showing stale data until the app restarts — the "my
+other device changed it but this one still shows the old version" report. `registry.test.ts` walks
+`SYNC_ITEM_TYPES`, applies a minimal payload through each registered handler, and fails any type that
+returns `applied` without calling `ctx.emit`. The agent conversation and message handlers were
+written without one and are the reason the test exists. Only `applied` obligates a broadcast: a
+`skipped` or `parse_error` changed nothing locally, so there is nothing to re-read.
+
+Two types are exempt from that probe and say so in the test. `settings` notifies by walking
+`BrowserWindow.getAllWindows()` itself rather than going through `ctx.emit`; `note` and `journal`
+write the index DB too, so they cannot run against a bare data-db handle and are covered by their own
+handler tests instead.
+
+## Nullable Fields: Omitted vs Explicit Null
+
+A nullable column has two distinct remote signals and `??` cannot tell them apart:
+
+- **Key absent** — the sender predates the column. Keep the local value.
+- **Key present, value `null`** — an explicit clear. Apply it.
+
+Collapsing them either way loses data. `data.x ?? null` lets an older peer wipe a column it has never
+heard of; `data.x ?? existing.x` strands a real clear forever. The inbox handler shipped the first
+form for ten columns, so a payload from a build predating any one of them silently nulled the local
+value — and an explicit clear is not hypothetical there: `unsnoozeItem`, unarchive and unfile all
+push `null` (`main/inbox/snooze.ts`, `main/inbox/crud.ts`). Reading those as "omitted" would leave an
+item snoozed on the other device forever.
+
+The house pattern is a local `hasKey` helper over the raw payload:
+
+```ts
+const hasKey = (k: string): boolean => Object.prototype.hasOwnProperty.call(data, k)
+
+tx.update(inboxItems).set({
+  snoozedUntil: hasKey('snoozedUntil') ? (data.snoozedUntil ?? null) : existing.snoozedUntil
+})
+```
+
+`calendar-external-event-handler.ts`, `inbox-handler.ts` and `calendar-event-handler.ts` all use it.
+Because `buildPushPayload` serializes the whole row, a same-version peer always sends the key — so
+`hasKey` is false exactly when the sender is older, which is precisely when the local value must win.
+
+Insert branches need the same audit for a different reason: they simply omitted six inbox columns, so
+an item archived on one device arrived un-archived on a device seeing it for the first time. If a
+column round-trips through `buildPushPayload`, it has to be written on **both** branches.
+
+## Missing Parents
+
+An FK-bound child whose parent has not arrived yet must throw `MissingSyncParentError` from inside
+the transaction, naming the parent type and id:
+
+```ts
+if (!parent) throw new MissingSyncParentError('task', taskId, 'project', projectId)
+```
+
+`pull-coordinator` routes only that typed error into `orphanedItems`, where `repairOrphans` re-fetches
+the parent by id and either replays the child or tombstones it. Let SQLite raise its anonymous
+`FOREIGN KEY constraint failed` instead and the coordinator logs "deferred retry failed — item
+skipped until next remote update" and drops the item. For an unchanged upstream record — a Google
+calendar event nobody has edited — there is no next remote update, so it never appears on that device
+at all while the UI keeps reporting the source as connected.
+
+`sortByApplyOrder` ranks parents ahead of children, but only within a page, so cross-page ordering is
+unprotected and the guard is what makes it safe. `task-handler.ts`, `calendar-external-event-handler.ts`
+and `agent-message-handler.ts` implement it. Never substitute a placeholder id to get past the
+constraint: an invented `'unknown-source'` can only ever FK-fail, and it makes the failure
+unclassifiable as well as fatal.
+
 ## Adding a New Sync Type
 
 1. Define a Zod schema in `packages/contracts/<domain>-api.ts`.
@@ -136,6 +203,10 @@ tolerant of an older main process. That is a compatibility floor, not a licence 
    register it in **both** `local-mutations.ts` and the adapter registry in `runtime.ts`.
 7. Add a server-side validator in `apps/sync-server` if the new type has unusual constraints.
 8. Add tests under the handler file (every existing handler has one).
+9. Add a minimal payload for the type to `FIXTURE_OVERRIDES` in `item-handlers/registry.test.ts` if
+   `{}` does not parse against its schema, and seed any FK parent the fixture needs. The registry
+   test fails on an unregistered type and on an applied write that does not emit, so it is the one
+   place a half-wired type shows up as a failure rather than as silence.
 
 Steps 5 and 6 are three separate registrations and each fails silently on its own:
 `enqueueLocalSync*` typechecks and no-ops when no push service is registered, so the entity never

--- a/apps/sync-server/src/routes/blob.ts
+++ b/apps/sync-server/src/routes/blob.ts
@@ -19,7 +19,8 @@ import {
   MAX_CHUNK_CRYPTO_OVERHEAD,
   expectedEncryptedTotal,
   getUploadedByteTotal,
-  parseUploadedChunks
+  readUploadedChunks,
+  type UploadedChunkEntry
 } from '../services/upload-size'
 import { DereferenceRequestSchema, UploadInitRequestSchema } from '@memry/contracts/blob-api'
 import type { AppContext } from '../types'
@@ -302,7 +303,7 @@ blob.put('/attachments/upload/:session_id/chunk/:chunk_index', chunkUploadLimit,
     )
   }
 
-  const uploadedChunks = parseUploadedChunks(session.uploaded_chunks)
+  const uploadedChunks = readSessionChunksOrThrow(session, 'uploadChunk')
   if (uploadedChunks.some((c) => c.i === chunkIndex)) {
     throw new AppError(ErrorCodes.UPLOAD_CHUNK_CONFLICT, 'Chunk already uploaded', 409)
   }
@@ -381,7 +382,7 @@ blob.post('/attachments/upload/:session_id/complete', chunkUploadLimit, async (c
 
   const session = await getUploadSession(c.env.DB, sessionId, userId, vaultId)
 
-  const uploadedEntries = parseUploadedChunks(session.uploaded_chunks)
+  const uploadedEntries = readSessionChunksOrThrow(session, 'uploadComplete')
   const uploadedIndices = new Set(uploadedEntries.map((e) => e.i))
   const expected = Array.from({ length: session.chunk_count }, (_, i) => i)
   const missing = expected.filter((i) => !uploadedIndices.has(i))
@@ -465,7 +466,7 @@ blob.get('/attachments/upload/:session_id', uploadSessionLimit, async (c) => {
 
   const session = await getUploadSession(c.env.DB, sessionId, userId, vaultId)
 
-  const entries: Array<{ i: number }> = JSON.parse(session.uploaded_chunks)
+  const entries = readSessionChunksOrThrow(session, 'uploadStatus')
   return c.json({
     sessionId: session.id,
     attachmentId: session.attachment_id,
@@ -483,8 +484,24 @@ blob.delete('/attachments/upload/:session_id', uploadSessionLimit, async (c) => 
 
   const session = await getUploadSession(c.env.DB, sessionId, userId, vaultId)
 
-  const uploadedEntries: Array<{ i: number; h: string }> = JSON.parse(session.uploaded_chunks)
-  const sessionHashes = new Set(uploadedEntries.map((e) => e.h))
+  // Abort RELEASES storage, so unlike the upload paths it must never be blocked
+  // by a corrupt column: refusing here would strand the reservation refunded
+  // below and leave the user paying for an upload they cancelled, with no way
+  // to clear it. Degrade to "no chunks" and still delete the row and refund.
+  // The skipped ref_count decrements leave those blob_chunks rows charged until
+  // the vault is deleted — a bounded residue, and far better than a session
+  // that can never be aborted.
+  const abortRead = readUploadedChunks(session.uploaded_chunks)
+  if (!abortRead.ok) {
+    logger.error('upload session uploaded_chunks is corrupt; aborting without chunk cleanup', {
+      operation: 'uploadAbort',
+      sessionId: session.id,
+      userId,
+      vaultId,
+      reason: abortRead.reason
+    })
+  }
+  const sessionHashes = new Set(abortRead.entries.map((e) => e.h))
 
   for (const hash of sessionHashes) {
     const chunk = await c.env.DB.prepare(
@@ -679,6 +696,44 @@ interface UploadSessionRow {
   uploaded_chunks: string
   expires_at: number
   created_at: number
+}
+
+/**
+ * Read a session's chunk list for a path that ACQUIRES storage, refusing to
+ * continue when the column is corrupt.
+ *
+ * Degrading a corrupt `uploaded_chunks` to "no chunks" is unsafe here in three
+ * separate ways: it reports zero landed bytes, silently resetting the quota
+ * ceiling compared on every chunk PUT; it re-opens the duplicate-chunk guard;
+ * and at complete it blames the client for chunks it may well have sent. The
+ * chunk PUT could not succeed anyway — the `json_insert` append needs the
+ * column to be valid JSON — so continuing would merely write the chunk to R2
+ * and touch blob_chunks before failing untyped.
+ *
+ * `uploaded_chunks` is written solely by this server, so a corrupt value is a
+ * server fault, not a client one: log it and raise a typed 500 (captured by
+ * errorHandler) instead of mis-billing quietly. Aborting the session still
+ * works and refunds the reservation, which is the way out.
+ */
+function readSessionChunksOrThrow(
+  session: UploadSessionRow,
+  operation: string
+): UploadedChunkEntry[] {
+  const read = readUploadedChunks(session.uploaded_chunks)
+  if (read.ok) return read.entries
+
+  logger.error('upload session uploaded_chunks is corrupt', {
+    operation,
+    sessionId: session.id,
+    userId: session.user_id,
+    vaultId: session.vault_id,
+    reason: read.reason
+  })
+  throw new AppError(
+    ErrorCodes.INTERNAL_ERROR,
+    'Upload session state is corrupt; abort the session and retry the upload',
+    500
+  )
 }
 
 async function getUploadSession(

--- a/apps/sync-server/src/services/checkout-token.test.ts
+++ b/apps/sync-server/src/services/checkout-token.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest'
+
+import { signCheckoutToken } from './checkout-token'
+
+// checkout-token.ts is SIGN-ONLY: it mints the bearer token that POST
+// /auth/checkout-token (routes/auth.ts:673) hands to the client, which then
+// replays it to the landing checkout endpoint. Verification lives in the
+// consumer, apps/landing/api/paddle-checkout-config.ts (`verifyCheckoutToken` +
+// `parsePaddleCheckoutIntent`) — there is no verifier anywhere in the sync
+// server. So the security property this module owns is narrow but total: the
+// emitted token must be an unforgeable HMAC-SHA256 over the encoded payload, in
+// exactly the wire format the landing verifier expects.
+//
+// The reference verifier below decodes independently (atob, and
+// crypto.subtle.verify rather than the source's crypto.subtle.sign) so it pins
+// the format contract instead of restating the implementation. Node's `Buffer`
+// and `node:crypto` are deliberately not used: this package typechecks against
+// @cloudflare/workers-types only.
+//
+// Never use a real secret here.
+const TEST_SECRET = 'test-checkout-token-secret'
+const OTHER_SECRET = 'a-different-test-secret'
+
+interface CheckoutTokenPayload {
+  userId: string
+  exp: number
+}
+
+const encoder = new TextEncoder()
+
+function base64UrlDecode(value: string): Uint8Array | null {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+  try {
+    const binary = atob(padded)
+    const bytes = new Uint8Array(binary.length)
+    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index)
+    return bytes
+  } catch {
+    return null
+  }
+}
+
+/** Only used to build attack inputs, never to verify one. */
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function encodePayload(payload: unknown): string {
+  return base64UrlEncode(encoder.encode(JSON.stringify(payload)))
+}
+
+/**
+ * Independent reference verifier mirroring the checks in
+ * apps/landing/api/paddle-checkout-config.ts:106-129 — exactly two segments,
+ * signature check, then JSON payload decode. Returns null on any failure and
+ * never throws.
+ */
+async function referenceVerify(
+  secret: string,
+  token: string
+): Promise<CheckoutTokenPayload | null> {
+  const [encodedPayload, encodedSignature, extra] = token.split('.')
+  if (!encodedPayload || !encodedSignature || extra !== undefined) return null
+
+  const signature = base64UrlDecode(encodedSignature)
+  if (!signature) return null
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['verify']
+  )
+  const valid = await crypto.subtle.verify('HMAC', key, signature, encoder.encode(encodedPayload))
+  if (!valid) return null
+
+  const payloadBytes = base64UrlDecode(encodedPayload)
+  if (!payloadBytes) return null
+
+  try {
+    return JSON.parse(new TextDecoder().decode(payloadBytes)) as CheckoutTokenPayload
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The consumer's freshness rule, from paddle-checkout-config.ts:153 —
+ * `exp <= nowSeconds` is rejected. Reproduced here only to prove the signer
+ * itself does not enforce it.
+ */
+function isFresh(payload: CheckoutTokenPayload, nowSeconds: number): boolean {
+  return typeof payload.exp === 'number' && Number.isFinite(payload.exp) && payload.exp > nowSeconds
+}
+
+const nowSeconds = () => Math.floor(Date.now() / 1000)
+
+describe('signCheckoutToken', () => {
+  it('mints a token that verifies under the signing secret and round-trips the payload', async () => {
+    // #given
+    const exp = nowSeconds() + 600
+
+    // #when
+    const token = await signCheckoutToken(TEST_SECRET, { userId: 'user-1', exp })
+
+    // #then
+    const payload = await referenceVerify(TEST_SECRET, token)
+    expect(payload).toEqual({ userId: 'user-1', exp })
+    expect(isFresh(payload!, nowSeconds())).toBe(true)
+  })
+
+  it('emits exactly two unpadded base64url segments', async () => {
+    // #given / #when
+    const token = await signCheckoutToken(TEST_SECRET, { userId: 'user-1', exp: 1 })
+
+    // #then — the landing verifier rejects anything that is not
+    // `payload.signature`, and base64url means no '+', '/' or '=' may survive.
+    const segments = token.split('.')
+    expect(segments).toHaveLength(2)
+    expect(token).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/)
+    // HMAC-SHA256 is 32 bytes -> 43 base64url chars unpadded.
+    expect(base64UrlDecode(segments[1])).toHaveLength(32)
+    expect(segments[1]).toHaveLength(43)
+  })
+
+  it('is deterministic for the same secret and payload', async () => {
+    // #given / #when
+    const payload = { userId: 'user-1', exp: 1_700_000_000 }
+    const first = await signCheckoutToken(TEST_SECRET, payload)
+    const second = await signCheckoutToken(TEST_SECRET, payload)
+
+    // #then
+    expect(first).toBe(second)
+  })
+
+  it('rejects a token signed with the wrong secret', async () => {
+    // #given
+    const token = await signCheckoutToken(OTHER_SECRET, {
+      userId: 'attacker',
+      exp: nowSeconds() + 600
+    })
+
+    // #then — a token minted under any other secret must not verify.
+    await expect(referenceVerify(TEST_SECRET, token)).resolves.toBeNull()
+    // Sanity: it is a well-formed token, just bound to a different key.
+    await expect(referenceVerify(OTHER_SECRET, token)).resolves.not.toBeNull()
+  })
+
+  it('rejects a tampered payload segment (user-id substitution)', async () => {
+    // #given — a legitimately signed token for user-1...
+    const exp = nowSeconds() + 600
+    const token = await signCheckoutToken(TEST_SECRET, { userId: 'user-1', exp })
+    const [, signature] = token.split('.')
+
+    // #when — ...whose payload is swapped to a victim while keeping the signature.
+    const forged = `${encodePayload({ userId: 'victim-user', exp })}.${signature}`
+
+    // #then — this is the entitlement-hijack case; it must not verify.
+    expect(forged).not.toBe(token)
+    await expect(referenceVerify(TEST_SECRET, forged)).resolves.toBeNull()
+  })
+
+  it('rejects an extended-expiry payload carrying a valid signature', async () => {
+    // #given
+    const token = await signCheckoutToken(TEST_SECRET, { userId: 'user-1', exp: nowSeconds() + 60 })
+    const [, signature] = token.split('.')
+
+    // #when — self-service TTL extension attempt.
+    const forgedPayload = encodePayload({
+      userId: 'user-1',
+      exp: nowSeconds() + 60 * 60 * 24 * 365
+    })
+
+    // #then
+    await expect(referenceVerify(TEST_SECRET, `${forgedPayload}.${signature}`)).resolves.toBeNull()
+  })
+
+  it('rejects a tampered signature segment', async () => {
+    // #given
+    const token = await signCheckoutToken(TEST_SECRET, {
+      userId: 'user-1',
+      exp: nowSeconds() + 600
+    })
+    const [payload, signature] = token.split('.')
+
+    // #when — flip one byte of the MAC.
+    const bytes = base64UrlDecode(signature)!
+    bytes[0] ^= 0xff
+
+    // #then
+    await expect(
+      referenceVerify(TEST_SECRET, `${payload}.${base64UrlEncode(bytes)}`)
+    ).resolves.toBeNull()
+  })
+
+  it('rejects a fully forged token built without the secret', async () => {
+    // #given / #when — attacker crafts a payload and MACs it under a guess.
+    const payload = encodePayload({ userId: 'user-1', exp: nowSeconds() + 600 })
+    const guessed = await signCheckoutToken('guessed-secret', {
+      userId: 'user-1',
+      exp: nowSeconds() + 600
+    })
+    const forgedSignature = guessed.split('.')[1]
+
+    // #then
+    await expect(referenceVerify(TEST_SECRET, `${payload}.${forgedSignature}`)).resolves.toBeNull()
+  })
+
+  it('rejects a signature truncated to the wrong length', async () => {
+    // #given
+    const token = await signCheckoutToken(TEST_SECRET, {
+      userId: 'user-1',
+      exp: nowSeconds() + 600
+    })
+    const [payload, signature] = token.split('.')
+    const truncated = base64UrlDecode(signature)!.slice(0, 16)
+
+    // #then — must reject cleanly, not throw on the length mismatch (the landing
+    // verifier's timingSafeEqual short-circuits on unequal byte lengths).
+    await expect(
+      referenceVerify(TEST_SECRET, `${payload}.${base64UrlEncode(truncated)}`)
+    ).resolves.toBeNull()
+  })
+
+  it.each([
+    ['empty string', ''],
+    ['no separator', 'notatoken'],
+    ['separator only', '.'],
+    ['empty payload segment', '.c2ln'],
+    ['empty signature segment', 'cGF5.'],
+    ['three segments', 'cGF5.c2ln.extra'],
+    ['jwt-shaped', 'eyJhbGciOiJub25lIn0.eyJ1c2VySWQiOiJ1c2VyLTEifQ.'],
+    ['non-base64 garbage', '!!!.???'],
+    ['whitespace', '   '],
+    ['valid signature over non-JSON payload', 'bm90LWpzb24.c2ln']
+  ])('rejects a malformed token cleanly: %s', async (_label, token) => {
+    // #then — must resolve null rather than throw; a throw becomes a 500 on the
+    // landing route instead of a clean "no checkout intent".
+    await expect(referenceVerify(TEST_SECRET, token)).resolves.toBeNull()
+  })
+
+  it('signs an already-expired payload without complaint — expiry is consumer-side only', async () => {
+    // #given — signCheckoutToken has no clock and no exp validation of its own.
+    const expiredAt = nowSeconds() - 60
+
+    // #when
+    const token = await signCheckoutToken(TEST_SECRET, { userId: 'user-1', exp: expiredAt })
+
+    // #then — the MAC is valid, so the ONLY thing stopping replay of a stale
+    // token is the consumer's `exp <= now` check. Pinned here so a regression on
+    // the consumer side cannot be waved off as "the signer handles it".
+    const payload = await referenceVerify(TEST_SECRET, token)
+    expect(payload).toEqual({ userId: 'user-1', exp: expiredAt })
+    expect(isFresh(payload!, nowSeconds())).toBe(false)
+  })
+
+  it('refuses to mint a token under an empty secret', async () => {
+    // #then — WebCrypto rejects a zero-length HMAC key, so an unset
+    // PADDLE_CHECKOUT_TOKEN_SECRET fails loudly at sign time rather than
+    // emitting a token anyone could forge. Defence in depth behind the
+    // required-secret guard at src/index.ts:141-147.
+    await expect(
+      signCheckoutToken('', { userId: 'user-1', exp: nowSeconds() + 600 })
+    ).rejects.toThrow()
+  })
+
+  it('binds the signature to the whole payload, not just the user id', async () => {
+    // #given / #when
+    const a = await signCheckoutToken(TEST_SECRET, { userId: 'user-1', exp: 1_700_000_000 })
+    const b = await signCheckoutToken(TEST_SECRET, { userId: 'user-1', exp: 1_700_000_001 })
+
+    // #then — cross-pollinating segments between two legitimate tokens must fail.
+    const [payloadA, sigA] = a.split('.')
+    const [payloadB, sigB] = b.split('.')
+    expect(sigA).not.toBe(sigB)
+    await expect(referenceVerify(TEST_SECRET, `${payloadA}.${sigB}`)).resolves.toBeNull()
+    await expect(referenceVerify(TEST_SECRET, `${payloadB}.${sigA}`)).resolves.toBeNull()
+  })
+
+  it('survives payloads with characters that need base64url escaping', async () => {
+    // #given — raw base64 '+' and '/' must be replaced and padding stripped, or
+    // the landing verifier's base64url decode desynchronises.
+    const userId = 'user-üß/+?=&'
+    const exp = nowSeconds() + 600
+
+    // #when
+    const token = await signCheckoutToken(TEST_SECRET, { userId, exp })
+
+    // #then
+    expect(token).not.toMatch(/[+/=]/)
+    await expect(referenceVerify(TEST_SECRET, token)).resolves.toEqual({ userId, exp })
+  })
+})

--- a/apps/sync-server/src/services/upload-size.test.ts
+++ b/apps/sync-server/src/services/upload-size.test.ts
@@ -1,0 +1,241 @@
+import { XCHACHA20_PARAMS } from '@memry/contracts/crypto'
+import { describe, expect, it } from 'vitest'
+
+import {
+  CHUNK_CRYPTO_OVERHEAD,
+  MAX_CHUNK_CRYPTO_OVERHEAD,
+  expectedEncryptedTotal,
+  getUploadedByteTotal,
+  parseUploadedChunks,
+  type UploadedChunkEntry
+} from './upload-size'
+
+// upload-size.ts is pure byte accounting. It does not itself enforce a limit —
+// the comparisons live in routes/blob.ts (chunk PUT: `uploadedBytes === null ||
+// uploadedBytes + chunkData.byteLength > expectedEncrypted` -> 413
+// STORAGE_FILE_TOO_LARGE, blob.ts:318-324) and in services/vault-deletion.ts.
+// What this module owns is producing the exact ceiling those comparisons use,
+// and failing closed (null) when the persisted byte counts cannot be trusted.
+
+describe('crypto overhead constants', () => {
+  it('derives per-chunk overhead from the contracts crypto params', () => {
+    // #then — the module comment promises it cannot silently drift from
+    // packages/contracts/src/crypto.ts.
+    expect(CHUNK_CRYPTO_OVERHEAD).toBe(XCHACHA20_PARAMS.NONCE_LENGTH + XCHACHA20_PARAMS.TAG_LENGTH)
+    expect(CHUNK_CRYPTO_OVERHEAD).toBe(40)
+  })
+
+  it('leaves slack above the current overhead for a future AEAD', () => {
+    // #then — MAX_ is the client-declared sanity bound; if it ever dropped below
+    // the real overhead, honest clients would be rejected at upload init.
+    expect(MAX_CHUNK_CRYPTO_OVERHEAD).toBe(64)
+    expect(MAX_CHUNK_CRYPTO_OVERHEAD).toBeGreaterThan(CHUNK_CRYPTO_OVERHEAD)
+  })
+})
+
+describe('expectedEncryptedTotal', () => {
+  it('derives the ceiling from plaintext size plus per-chunk overhead when no size was declared', () => {
+    // #given / #when — the `encryptedSize === null` path is what keeps
+    // already-installed clients and pre-`encrypted_size` sessions working.
+    // #then
+    expect(expectedEncryptedTotal(1024, 1, null)).toBe(1024 + CHUNK_CRYPTO_OVERHEAD)
+    expect(expectedEncryptedTotal(2048, 2, null)).toBe(2048 + CHUNK_CRYPTO_OVERHEAD * 2)
+    expect(expectedEncryptedTotal(0, 0, null)).toBe(0)
+  })
+
+  it('scales overhead linearly with chunk count, not with size', () => {
+    // #then — one 10 MiB chunk costs one tag; ten 1 MiB chunks cost ten.
+    const tenMib = 10 * 1024 * 1024
+    expect(expectedEncryptedTotal(tenMib, 1, null)).toBe(tenMib + CHUNK_CRYPTO_OVERHEAD)
+    expect(expectedEncryptedTotal(tenMib, 10, null)).toBe(tenMib + CHUNK_CRYPTO_OVERHEAD * 10)
+  })
+
+  it('honours an explicitly declared encrypted size verbatim', () => {
+    // #given — a client that declared its own on-the-wire total.
+    // #then — the declared number wins; blob.ts has already range-checked it
+    // against totalSize + MAX_CHUNK_CRYPTO_OVERHEAD * chunkCount before this
+    // value is persisted (blob.ts:232).
+    expect(expectedEncryptedTotal(1024, 2, 1234)).toBe(1234)
+    // Deliberately smaller than the derived figure: still honoured verbatim.
+    expect(expectedEncryptedTotal(1024, 2, 1)).toBe(1)
+  })
+
+  it('treats a declared size of zero as declared, not as absent', () => {
+    // #then — the source uses `??`, so only null/undefined trigger the derive
+    // path. A `||` regression here would silently hand a zero-byte session the
+    // full derived allowance.
+    expect(expectedEncryptedTotal(1024, 2, 0)).toBe(0)
+    expect(expectedEncryptedTotal(1024, 2, 0)).not.toBe(1024 + CHUNK_CRYPTO_OVERHEAD * 2)
+  })
+
+  it('produces the exact boundary value that blob.ts compares with a strict >', () => {
+    // #given — blob.ts:318 rejects only when running total EXCEEDS this number,
+    // so a session landing exactly on it is allowed. Pin the arithmetic so the
+    // inclusive boundary is not shifted by a rounding change.
+    const ceiling = expectedEncryptedTotal(1024, 1, null)
+
+    // #then
+    expect(ceiling).toBe(1064)
+    expect(ceiling > ceiling).toBe(false) // exactly at the limit: accepted
+    expect(ceiling + 1 > ceiling).toBe(true) // one byte over: rejected
+  })
+})
+
+describe('parseUploadedChunks', () => {
+  it('parses a well-formed chunk array', () => {
+    // #given
+    const raw = JSON.stringify([
+      { i: 0, h: 'hash-0', b: 100 },
+      { i: 1, h: 'hash-1', b: 200 }
+    ])
+
+    // #then
+    expect(parseUploadedChunks(raw)).toEqual([
+      { i: 0, h: 'hash-0', b: 100 },
+      { i: 1, h: 'hash-1', b: 200 }
+    ])
+  })
+
+  it('returns no chunks for an empty array', () => {
+    expect(parseUploadedChunks('[]')).toEqual([])
+  })
+
+  it.each([
+    ['object', '{"i":0}'],
+    ['null literal', 'null'],
+    ['string literal', '"nope"'],
+    ['number literal', '42'],
+    ['boolean literal', 'true']
+  ])('treats a valid-JSON non-array payload as no chunks: %s', (_label, raw) => {
+    // #then — a session whose column decoded to a non-array must count as zero
+    // landed bytes, which makes callers fail closed rather than over-credit.
+    expect(parseUploadedChunks(raw)).toEqual([])
+  })
+
+  // PRODUCT BUG (documented, not fixed here — this file may not touch source).
+  //
+  // The JSDoc on parseUploadedChunks claims it tolerates "a malformed or
+  // non-array payload as 'no chunks'". Only the non-array half is true: the bare
+  // `JSON.parse(value)` throws a SyntaxError on malformed JSON, which propagates
+  // to every caller.
+  //
+  // Blast radius, all with an unguarded call:
+  //   - routes/blob.ts:305 and :384 — a chunk PUT / upload completion becomes an
+  //     unhandled 500 instead of a typed AppError.
+  //   - services/vault-deletion.ts:52 — sumOpenUploadSessionBytes throws, so the
+  //     whole vault deletion aborts and the user's storage is never released.
+  //
+  // Severity: low-to-moderate. `uploaded_chunks` is only ever written by the
+  // server via JSON.stringify, so reaching this needs DB corruption or a
+  // partial write — it is not a client-reachable quota bypass. But the
+  // documented contract and the code disagree, and the failure mode is a stuck,
+  // undeletable vault rather than a clean error.
+  it.fails('tolerates malformed JSON as no chunks, as its JSDoc promises', () => {
+    expect(parseUploadedChunks('not json')).toEqual([])
+  })
+
+  it('actually throws on malformed JSON today', () => {
+    // #then — pinning the real behaviour alongside the it.fails above, so the
+    // discrepancy is unambiguous rather than looking like a flaky expectation.
+    expect(() => parseUploadedChunks('not json')).toThrow(SyntaxError)
+    expect(() => parseUploadedChunks('')).toThrow(SyntaxError)
+    expect(() => parseUploadedChunks('[{"i":0},')).toThrow(SyntaxError)
+  })
+})
+
+describe('getUploadedByteTotal', () => {
+  it('sums the per-chunk byte counts', () => {
+    // #given
+    const entries: UploadedChunkEntry[] = [
+      { i: 0, h: 'hash-0', b: 100 },
+      { i: 1, h: 'hash-1', b: 250 }
+    ]
+
+    // #then
+    expect(getUploadedByteTotal(entries)).toBe(350)
+  })
+
+  it('returns zero for no chunks', () => {
+    expect(getUploadedByteTotal([])).toBe(0)
+  })
+
+  it('accepts a zero-byte chunk as a real count, not a missing one', () => {
+    // #then — 0 is a valid non-negative integer, so it must sum, not poison.
+    expect(getUploadedByteTotal([{ i: 0, h: 'hash-0', b: 0 }])).toBe(0)
+    expect(
+      getUploadedByteTotal([
+        { i: 0, h: 'hash-0', b: 0 },
+        { i: 1, h: 'hash-1', b: 10 }
+      ])
+    ).toBe(10)
+  })
+
+  it('returns null when a chunk has no byte count at all', () => {
+    // #given — `b` is optional on the interface, so pre-`b` sessions hit this.
+    // #then — must NOT default the missing chunk to zero: under-counting landed
+    // bytes is exactly how a client would slip past the blob.ts ceiling.
+    expect(getUploadedByteTotal([{ i: 0, h: 'hash-0' }])).toBeNull()
+    expect(
+      getUploadedByteTotal([
+        { i: 0, h: 'hash-0', b: 100 },
+        { i: 1, h: 'hash-1' }
+      ])
+    ).toBeNull()
+  })
+
+  it.each([
+    ['string', '100'],
+    ['numeric string', '0'],
+    ['null', null],
+    ['undefined', undefined],
+    ['object', {}],
+    ['array', []],
+    ['boolean', true],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY]
+  ])('returns null for a non-integer byte count: %s', (_label, bytes) => {
+    // #then — Number.isInteger rejects NaN and Infinity too, so a poisoned
+    // count can never make the running total unbounded or unorderable.
+    const entries = [{ i: 0, h: 'hash-0', b: bytes }] as unknown as UploadedChunkEntry[]
+    expect(getUploadedByteTotal(entries)).toBeNull()
+  })
+
+  it('returns null for a fractional byte count', () => {
+    expect(getUploadedByteTotal([{ i: 0, h: 'hash-0', b: 1.5 }])).toBeNull()
+  })
+
+  it('returns null for a negative byte count', () => {
+    // #then — a negative count would otherwise subtract from the running total
+    // and buy headroom under the blob.ts ceiling.
+    expect(
+      getUploadedByteTotal([
+        { i: 0, h: 'hash-0', b: 1000 },
+        { i: 1, h: 'hash-1', b: -900 }
+      ])
+    ).toBeNull()
+  })
+
+  it('short-circuits to null regardless of where the bad entry sits', () => {
+    // #then — one untrustworthy entry invalidates the whole sum.
+    const bad = { i: 9, h: 'hash-9' } as UploadedChunkEntry
+    const good = { i: 0, h: 'hash-0', b: 10 }
+    expect(getUploadedByteTotal([bad, good, good])).toBeNull()
+    expect(getUploadedByteTotal([good, bad, good])).toBeNull()
+    expect(getUploadedByteTotal([good, good, bad])).toBeNull()
+  })
+
+  it('composes with parseUploadedChunks to fail closed on an untrusted column', () => {
+    // #given — the exact pipeline used at blob.ts:305-318 and
+    // vault-deletion.ts:52.
+    const trustworthy = JSON.stringify([{ i: 0, h: 'hash-0', b: 1024 + CHUNK_CRYPTO_OVERHEAD }])
+    const untrustworthy = JSON.stringify([{ i: 0, h: 'hash-0' }])
+
+    // #then
+    expect(getUploadedByteTotal(parseUploadedChunks(trustworthy))).toBe(
+      1024 + CHUNK_CRYPTO_OVERHEAD
+    )
+    expect(getUploadedByteTotal(parseUploadedChunks(untrustworthy))).toBeNull()
+    // A non-array column also yields 0 landed bytes rather than a bogus credit.
+    expect(getUploadedByteTotal(parseUploadedChunks('{}'))).toBe(0)
+  })
+})

--- a/apps/sync-server/src/services/upload-size.test.ts
+++ b/apps/sync-server/src/services/upload-size.test.ts
@@ -7,6 +7,7 @@ import {
   expectedEncryptedTotal,
   getUploadedByteTotal,
   parseUploadedChunks,
+  readUploadedChunks,
   type UploadedChunkEntry
 } from './upload-size'
 
@@ -112,34 +113,77 @@ describe('parseUploadedChunks', () => {
     expect(parseUploadedChunks(raw)).toEqual([])
   })
 
-  // PRODUCT BUG (documented, not fixed here — this file may not touch source).
-  //
-  // The JSDoc on parseUploadedChunks claims it tolerates "a malformed or
-  // non-array payload as 'no chunks'". Only the non-array half is true: the bare
-  // `JSON.parse(value)` throws a SyntaxError on malformed JSON, which propagates
-  // to every caller.
-  //
-  // Blast radius, all with an unguarded call:
-  //   - routes/blob.ts:305 and :384 — a chunk PUT / upload completion becomes an
-  //     unhandled 500 instead of a typed AppError.
-  //   - services/vault-deletion.ts:52 — sumOpenUploadSessionBytes throws, so the
-  //     whole vault deletion aborts and the user's storage is never released.
-  //
-  // Severity: low-to-moderate. `uploaded_chunks` is only ever written by the
-  // server via JSON.stringify, so reaching this needs DB corruption or a
-  // partial write — it is not a client-reachable quota bypass. But the
-  // documented contract and the code disagree, and the failure mode is a stuck,
-  // undeletable vault rather than a clean error.
-  it.fails('tolerates malformed JSON as no chunks, as its JSDoc promises', () => {
+  // FIXED: the bare `JSON.parse(value)` used to throw a SyntaxError on a
+  // malformed column, which propagated to every unguarded caller — most
+  // damagingly services/vault-deletion.ts, where it aborted the whole vault
+  // deletion so the user's storage was never released and the vault could not
+  // be deleted. The function is now total, matching its JSDoc.
+  it('tolerates malformed JSON as no chunks, as its JSDoc promises', () => {
     expect(parseUploadedChunks('not json')).toEqual([])
   })
 
-  it('actually throws on malformed JSON today', () => {
-    // #then — pinning the real behaviour alongside the it.fails above, so the
-    // discrepancy is unambiguous rather than looking like a flaky expectation.
-    expect(() => parseUploadedChunks('not json')).toThrow(SyntaxError)
-    expect(() => parseUploadedChunks('')).toThrow(SyntaxError)
-    expect(() => parseUploadedChunks('[{"i":0},')).toThrow(SyntaxError)
+  it('never throws on any malformed payload', () => {
+    // #then — totality is the contract storage-releasing callers depend on:
+    // vault-deletion.ts must not abort on an unreadable column.
+    expect(parseUploadedChunks('')).toEqual([])
+    expect(parseUploadedChunks('[{"i":0},')).toEqual([])
+    expect(parseUploadedChunks('{"i":0')).toEqual([])
+    expect(parseUploadedChunks('undefined')).toEqual([])
+  })
+})
+
+describe('readUploadedChunks', () => {
+  // parseUploadedChunks flattens "corrupt" into "empty", which is right for
+  // storage-releasing callers and wrong for billing ones. readUploadedChunks is
+  // how routes/blob.ts tells the two apart.
+
+  it('reports a well-formed array as readable', () => {
+    // #given
+    const raw = JSON.stringify([{ i: 0, h: 'hash-0', b: 100 }])
+
+    // #then
+    expect(readUploadedChunks(raw)).toEqual({
+      ok: true,
+      entries: [{ i: 0, h: 'hash-0', b: 100 }]
+    })
+  })
+
+  it('reports a genuinely empty upload as readable, not corrupt', () => {
+    // #then — a session with no chunks yet is the normal state right after
+    // initiate. It must NOT be conflated with an unreadable column, or every
+    // fresh session would 500 on its first chunk PUT.
+    expect(readUploadedChunks('[]')).toEqual({ ok: true, entries: [] })
+  })
+
+  it('reports malformed JSON as corrupt', () => {
+    // #then — same [] entries as the tolerant parse, but flagged so billing
+    // callers can refuse rather than credit the user zero landed bytes.
+    expect(readUploadedChunks('not json')).toEqual({
+      ok: false,
+      entries: [],
+      reason: 'malformed-json'
+    })
+    expect(readUploadedChunks('')).toEqual({ ok: false, entries: [], reason: 'malformed-json' })
+  })
+
+  it.each([
+    ['object', '{"i":0}'],
+    ['null literal', 'null'],
+    ['string literal', '"nope"'],
+    ['number literal', '42'],
+    ['boolean literal', 'true']
+  ])('reports a valid-JSON non-array payload as corrupt: %s', (_label, raw) => {
+    // #then — valid JSON that is not a chunk list is just as unreadable as
+    // broken JSON, and is distinguished only for triage in the log line.
+    expect(readUploadedChunks(raw)).toEqual({ ok: false, entries: [], reason: 'not-an-array' })
+  })
+
+  it('agrees with parseUploadedChunks on entries for every input', () => {
+    // #then — parseUploadedChunks is defined as `readUploadedChunks(...).entries`,
+    // so the tolerant path can never drift from the discriminated one.
+    for (const raw of ['[]', '[{"i":0,"h":"a","b":1}]', 'not json', '{}', 'null', '']) {
+      expect(parseUploadedChunks(raw)).toEqual(readUploadedChunks(raw).entries)
+    }
   })
 })
 
@@ -237,5 +281,15 @@ describe('getUploadedByteTotal', () => {
     expect(getUploadedByteTotal(parseUploadedChunks(untrustworthy))).toBeNull()
     // A non-array column also yields 0 landed bytes rather than a bogus credit.
     expect(getUploadedByteTotal(parseUploadedChunks('{}'))).toBe(0)
+  })
+
+  it('lets a malformed column resolve to zero landed bytes instead of throwing', () => {
+    // #given — the exact expression at vault-deletion.ts:52. It computes
+    // `total_size - landed`, so 0 landed releases the FULL reservation, which
+    // is what that function's own JSDoc prescribes for an unparseable column.
+    // Before the fix this threw and aborted the entire vault deletion.
+    // #then
+    expect(getUploadedByteTotal(parseUploadedChunks('not json'))).toBe(0)
+    expect(getUploadedByteTotal(parseUploadedChunks(''))).toBe(0)
   })
 })

--- a/apps/sync-server/src/services/upload-size.ts
+++ b/apps/sync-server/src/services/upload-size.ts
@@ -36,13 +36,51 @@ export interface UploadedChunkEntry {
   b?: number
 }
 
+export type UploadedChunksRead =
+  | { ok: true; entries: UploadedChunkEntry[] }
+  | { ok: false; entries: []; reason: 'malformed-json' | 'not-an-array' }
+
+/**
+ * Read an upload session's persisted `uploaded_chunks` JSON, reporting whether
+ * the column actually decoded to a chunk array.
+ *
+ * `uploaded_chunks` is only ever written server-side (`JSON.stringify` at
+ * initiate, `json_insert` per chunk), so `ok: false` means DB corruption or a
+ * partial write — never a hostile client. That distinction matters because the
+ * two families of caller must react in opposite directions:
+ *
+ *   - Paths that ACQUIRE storage or bill the user (chunk PUT, complete) must
+ *     fail closed. Degrading a corrupt column to "no chunks" reports zero
+ *     landed bytes, which resets the quota ceiling in routes/blob.ts and
+ *     re-opens the duplicate-chunk guard.
+ *   - Paths that RELEASE storage (session abort, vault deletion) must never be
+ *     blocked by a corrupt column, or the user's reservation is stranded and
+ *     their vault cannot be deleted. Those use `parseUploadedChunks` and
+ *     release the full reservation.
+ *
+ * Either way the corruption is logged by the caller rather than swallowed.
+ */
+export function readUploadedChunks(value: string): UploadedChunksRead {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return { ok: false, entries: [], reason: 'malformed-json' }
+  }
+  if (!Array.isArray(parsed)) return { ok: false, entries: [], reason: 'not-an-array' }
+  return { ok: true, entries: parsed as UploadedChunkEntry[] }
+}
+
 /**
  * Parse an upload session's persisted `uploaded_chunks` JSON into typed
  * entries, tolerating a malformed or non-array payload as "no chunks".
+ *
+ * Total by design — it never throws — so a corrupt column cannot abort a
+ * storage-releasing path. Callers that must not silently treat corruption as an
+ * empty upload should use `readUploadedChunks` instead.
  */
 export function parseUploadedChunks(value: string): UploadedChunkEntry[] {
-  const parsed = JSON.parse(value) as UploadedChunkEntry[]
-  return Array.isArray(parsed) ? parsed : []
+  return readUploadedChunks(value).entries
 }
 
 /**

--- a/apps/sync-server/src/services/vault-deletion.ts
+++ b/apps/sync-server/src/services/vault-deletion.ts
@@ -1,5 +1,8 @@
 import { deleteByPrefix } from './blob'
-import { getUploadedByteTotal, parseUploadedChunks } from './upload-size'
+import { getUploadedByteTotal, readUploadedChunks } from './upload-size'
+import { createLogger } from '../lib/logger'
+
+const logger = createLogger('VaultDeletion')
 
 /**
  * True if this user owns this vault. Callers 404 on false — a cross-user
@@ -34,6 +37,11 @@ interface OpenUploadSessionRow {
  * of whether we can read the chunk list — fall back to releasing the full
  * `total_size` (matching abort/expiry-sweep behavior in blob.ts /
  * cleanup.ts), not zero, so we never under-release.
+ *
+ * A corrupt column must never abort the deletion: that would strand the
+ * reservation and leave the user unable to delete their vault at all. It is
+ * logged rather than swallowed, because we are about to delete the row that
+ * carries the evidence.
  */
 async function sumOpenUploadSessionBytes(
   db: D1Database,
@@ -49,7 +57,16 @@ async function sumOpenUploadSessionBytes(
 
   let total = 0
   for (const session of result.results ?? []) {
-    const landed = getUploadedByteTotal(parseUploadedChunks(session.uploaded_chunks))
+    const read = readUploadedChunks(session.uploaded_chunks)
+    if (!read.ok) {
+      logger.error('upload session uploaded_chunks is corrupt; releasing full reservation', {
+        userId,
+        vaultId,
+        reason: read.reason,
+        totalSize: session.total_size
+      })
+    }
+    const landed = getUploadedByteTotal(read.entries)
     total += landed === null ? session.total_size : session.total_size - landed
   }
   return total

--- a/packages/contracts/src/ipc-agent.test.ts
+++ b/packages/contracts/src/ipc-agent.test.ts
@@ -51,7 +51,9 @@ describe('AgentChannels', () => {
         GET_WINDOW_ID: 'agent:getWindowId'
       },
       events: {
-        AGENT_EVENT: 'agent:event'
+        AGENT_EVENT: 'agent:event',
+        CONVERSATIONS_CHANGED: 'agent:conversations-changed',
+        MESSAGES_CHANGED: 'agent:messages-changed'
       }
     })
   })

--- a/packages/contracts/src/ipc-agent.ts
+++ b/packages/contracts/src/ipc-agent.ts
@@ -33,7 +33,15 @@ export const AgentChannels = {
     GET_WINDOW_ID: 'agent:getWindowId'
   },
   events: {
-    AGENT_EVENT: 'agent:event'
+    AGENT_EVENT: 'agent:event',
+    /**
+     * A conversation row changed outside the live turn stream — today only a
+     * sync pull from another device. The renderer must re-read the list; the
+     * `agent:event` stream only carries the local turn lifecycle.
+     */
+    CONVERSATIONS_CHANGED: 'agent:conversations-changed',
+    /** A message row for `conversationId` changed via a sync pull. */
+    MESSAGES_CHANGED: 'agent:messages-changed'
   }
 } as const
 

--- a/packages/contracts/src/sync-payloads.ts
+++ b/packages/contracts/src/sync-payloads.ts
@@ -193,6 +193,10 @@ export const JournalSyncPayloadSchema = z.object({
 export const TagDefinitionSyncPayloadSchema = z.object({
   name: z.string(),
   color: z.string(),
+  // Did a human pick `color`, or did the palette hand it out? Only a sender that
+  // knows this field can say `false`; absent means "cannot tell" and the receiver
+  // honours the colour. See tag-definition-handler.ts.
+  colorAuthored: z.boolean().optional(),
   icon: z.string().nullable().optional(),
   categoryId: z.string().nullable().optional(),
   sortOrder: z.number().int().optional(),
@@ -234,6 +238,23 @@ export const CalendarEventSyncPayloadSchema = z.object({
   visibility: z.enum(['default', 'public', 'private', 'confidential']).nullable().optional(),
   colorId: z.string().nullable().optional(),
   conferenceData: z.record(z.string(), z.unknown()).nullable().optional(),
+  // Recurrence-exception identity. Written locally by the Google writeback
+  // (calendar/google/sync-service.ts applyGoogleCalendarWriteback) and read back
+  // out by mapCalendarEventToGoogleInput to set recurringEventId/originalStartTime
+  // on the next push. Without these keys zod stripped them on arrival, so a peer
+  // re-pushed an exception as a brand new standalone event.
+  parentEventId: z.string().nullable().optional(),
+  originalStartTime: z.string().nullable().optional(),
+  // Which remote calendar this event is pinned to. Consumed by
+  // calendar/google/account-routing.ts and sync-service.ts to route the push, and
+  // set by promote-external-event.ts. Zod used to strip it on arrival, so the
+  // receiving device silently fell back to the memry-managed calendar.
+  //
+  // All three are `.optional()` on purpose: a payload from an older build simply
+  // omits the key, and an absent key must mean "sender predates this field, keep
+  // the local value" — never a clear. Receiving handlers must gate on
+  // `Object.prototype.hasOwnProperty.call(data, key)`, not on `?? existing`.
+  targetCalendarId: z.string().nullable().optional(),
   archivedAt: z.string().nullable().optional(),
   clock: VectorClockSchema.optional(),
   fieldClocks: FieldClocksSchema.nullable().optional(),

--- a/packages/db-schema/src/schema/tag-definitions.ts
+++ b/packages/db-schema/src/schema/tag-definitions.ts
@@ -5,6 +5,11 @@ import { nocaseText } from './nocase.ts'
 export const tagDefinitions = sqliteTable('tag_definitions', {
   name: nocaseText('name').primaryKey(),
   color: text('color').notNull(),
+  // True only when a human picked `color`. False means the palette handed it out
+  // in `getOrCreateTag`, which indexes by local tag count and so disagrees with
+  // every other device — such a colour may not repaint another device's tag.
+  // See drizzle-data/0046_tag_definition_color_authored.sql.
+  colorAuthored: integer('color_authored', { mode: 'boolean' }).notNull().default(false),
   icon: text('icon'),
   clock: text('clock', { mode: 'json' }),
   createdAt: text('created_at')


### PR DESCRIPTION
Sync is the paid multi-device feature and most of its surface shipped untested. This adds that coverage, then fixes what the coverage found.

## Why

Several open user reports pointed at the same untested surface: notes arriving blank or half-complete between a Mac and a Fedora machine, images that never arrive and do not arrive after re-adding either, a tag going green on one device and red on another, Google Calendar reporting connected with no events. Each turned out to have a concrete mechanism.

## Coverage

37 test files across the desktop sync engine, its item handlers, the push-side services and the sync-server services.

The load-bearing one is `item-handlers/registry.test.ts`, a registry-level invariant over `SYNC_ITEM_TYPES`: every type resolves to a handler, every type key matches its handler's declared type, and a successful remote upsert broadcasts to the renderer. A handler that mutates the local DB without emitting leaves an open window on stale data until restart, which is a whole class of report rather than a single bug.

Defects found were pinned as `it.fails` with the mechanism documented, then fixed in a second pass. Each fix was mutation-checked: the fix reverted, the test confirmed red, then restored.

## Fixed

- **Truncated deflate decoded as an empty success.** `pako.inflate` returns `undefined` without throwing when a stream never reaches its end. That reached the applier as `{ verified: true, content: '' }` and was written as a content wipe. A note that arrived blank on a second device is this path.
- **`localOnly` notes leaked their title on delete.** The guard was wired into the snapshot path but not into `enqueueDelete`. Local-only rows now enqueue nothing, and the title is dropped from every note tombstone — `applyDelete` takes no data parameter, so the receiving side structurally never read it and it was being encrypted and uploaded for nothing.
- **Inbox nulled columns an older peer omitted.** Ten nullable columns used `data.x ?? null`, so a payload from a build predating any one of them destroyed the local value. Now distinguishes an omitted key from an explicit null — the latter being the clear that unsnooze, unarchive and unfile push. The insert branch separately dropped six columns, resurrecting archived items on a device seeing them for the first time.
- **`calendar_external_event` raised a bare FK error** instead of `MissingSyncParentError`, which the pull coordinator drops rather than defers and repairs. An unchanged Google event is never re-sent, so the device stayed empty while the UI read connected.
- **Tag colours repainted across devices.** `getOrCreateTag` indexes the palette by local tag count, so the same tag name minted green where it was the 12th tag and red where it was the 23rd, then pushed that as though the user had chosen it. Adds a `color_authored` column so an unauthored colour can create a tag but never repaint one.
- **Attachments never reached peers.** A completed upload did not enqueue the note push, so the peer's payload carried no `attachmentReferences` and it never requested the blob; and a `download-needed` event dropped in the zero-listener window was marked requested anyway, suppressing it for the process lifetime. Those are both halves of "text syncs, images never arrive, re-adding does not help".
- **Agent chat**: applied remote pulls emitted nothing, `applyDelete` ignored the incoming clock, `agent_message` had no missing-parent guard so an early message inserted as a permanent orphan, and conversation mutations did not fan out across windows.
- **`folder_config`** fired an un-awaited vault write that threw an unhandled rejection in main whenever an item landed while the vault was closed.

Also: wires `targetCalendarId`, `parentEventId` and `originalStartTime` through the calendar payload schema and handler (they were stripped on arrival, losing Google calendar routing and recurrence identity); makes `parseUploadedChunks` total so a corrupt chunk column can no longer block a vault deletion; reconciles the two contradictory `SYNC_SERVER_URL` fallback policies so a packaged build cannot silently dial localhost.

## Migration

`0046_tag_definition_color_authored.sql` — additive, hand-written, `DEFAULT 0 NOT NULL`, no row rewritten. Existing rows start unauthored because they were written before intent was recorded, so an auto-minted and a hand-picked colour are indistinguishable. Nothing is lost: an unauthored colour is still stored, still displayed, and still travels to a device that does not have the tag yet. The cost is that a legacy colour no longer propagates onto a device already holding a different one — those freeze instead of flapping, and opening the colour picker once marks it authored and authoritative everywhere again.

## Verification

| | |
|---|---|
| desktop `main` | 468 files, 5262 tests, 0 failures |
| sync-server | 859 |
| contracts | 1603 |
| renderer | 6231 |
| typecheck / lint / `ipc:check` / `check:architecture` | clean |

## Not in this PR

Two defects need a design decision first and have their own issues: #952 (the push retry budget is consumed inside a single `push()` call, permanently parking an edit) and #953 (queue coalescing keeps the older row, so any type without `buildPushPayload` loses the newer edit).

Follow-ups found and deliberately left: `RecordSyncController.enqueueDelete` still ignores `shouldSkip` for every other record service, journal tombstones still carry the journal date, and a worker crypto rejection does not degrade to main-thread crypto despite a comment saying it does.

Two `it.fails` remain in the tree by design, each documenting a defect with its mechanism rather than hiding it.
