### PR TITLE
sync: degrade to main-thread crypto when the worker rejects a batch

### DIFF
--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -604,8 +604,9 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         await workerBridge.start()
       } catch (err) {
         // Worker init failure must not take down sync: sync-crypto-batch
-        // checks workerBridge.isRunning per batch and falls back to
-        // main-thread crypto when the worker is unavailable.
+        // checks workerBridge.isRunning per batch and also catches a rejected
+        // worker request (protocol drift, timeout, worker error/exit), falling
+        // back to main-thread crypto in either case.
         log.error('Sync worker failed to start — continuing with main-thread crypto', err)
       }
 

--- a/apps/desktop/src/main/sync/sync-crypto-batch.test.ts
+++ b/apps/desktop/src/main/sync/sync-crypto-batch.test.ts
@@ -206,6 +206,87 @@ describe('sync crypto batch', () => {
     ])
   })
 
+  it('falls back to main-thread encryption when the worker rejects the batch', async () => {
+    // A version-skewed worker bundle answers an unknown kind with
+    // { type: 'error' }, which the bridge turns into a rejection.
+    const workerBridge = {
+      isRunning: true,
+      encryptBatch: vi
+        .fn()
+        .mockRejectedValue(new Error('Unsupported worker message kind: encrypt-batch'))
+    }
+
+    const result = await encryptPushBatch([queueRow], vaultKey, signingSecretKey, 'device-1', {
+      workerBridge: workerBridge as never,
+      queue: { markFailed: mocks.markFailed } as never,
+      extractPayloadMetadata: () => ({ clock: { a: 1 }, stateVector: 'sv' }),
+      resolvePushPayload: (item) => item.payload
+    })
+
+    expect(result).toEqual([{ queueId: 'queue-1', pushItem: { encrypted: true } }])
+    expect(mocks.encryptItemForPush).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'note-1', clock: { a: 1 }, stateVector: 'sv' })
+    )
+    expect(mocks.markFailed).not.toHaveBeenCalled()
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'Push: worker crypto unavailable, falling back to main thread',
+      { error: 'Unsupported worker message kind: encrypt-batch' }
+    )
+  })
+
+  it('resolves the push payload once so the encrypt fallback reuses the worker payload', async () => {
+    const workerBridge = {
+      isRunning: true,
+      encryptBatch: vi.fn().mockRejectedValue(new Error('Worker exited with code 1'))
+    }
+    const resolvePushPayload = vi.fn((item: { payload: string }) => item.payload)
+
+    await encryptPushBatch([queueRow], vaultKey, signingSecretKey, 'device-1', {
+      workerBridge: workerBridge as never,
+      queue: { markFailed: mocks.markFailed } as never,
+      extractPayloadMetadata: () => ({}),
+      resolvePushPayload: resolvePushPayload as never
+    })
+
+    // Re-resolving would read live DB rows again and could hand the fallback a
+    // different payload than the worker was asked to encrypt.
+    expect(resolvePushPayload).toHaveBeenCalledTimes(1)
+    expect(workerBridge.encryptBatch.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ payload: queueRow.payload })
+    ])
+    expect(mocks.encryptItemForPush).toHaveBeenCalledWith(expect.objectContaining({ id: 'note-1' }))
+  })
+
+  it('falls back to main-thread decryption when the worker rejects the batch', async () => {
+    mocks.decryptSingleItem.mockReturnValue({ ok: true, item: { id: 'note-1', content: 'plain' } })
+    const workerBridge = {
+      isRunning: true,
+      decryptBatch: vi.fn().mockRejectedValue(new Error('Worker exited with code 1'))
+    }
+
+    const result = await decryptPullBatch(
+      [pullItem, { ...pullItem, id: 'note-skip', signerDeviceId: 'skip' }] as never,
+      vaultKey,
+      {
+        workerBridge: workerBridge as never,
+        resolveDeviceKey: vi.fn(async (deviceId) =>
+          deviceId === 'skip' ? null : new Uint8Array([9])
+        )
+      }
+    )
+
+    expect(mocks.decryptSingleItem).toHaveBeenCalledTimes(1)
+    expect(result.decrypted).toEqual([{ id: 'note-1', content: 'plain' }])
+    // The skipped item is re-derived by the fallback loop, not duplicated.
+    expect(result.failures).toEqual([
+      expect.objectContaining({ id: 'note-skip', signerDeviceId: 'skip' })
+    ])
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'Pull: worker crypto unavailable, falling back to main thread',
+      { error: 'Worker exited with code 1' }
+    )
+  })
+
   it('returns only skipped failures when every worker item lacks a signer key', async () => {
     const workerBridge = {
       isRunning: true,

--- a/apps/desktop/src/main/sync/sync-crypto-batch.ts
+++ b/apps/desktop/src/main/sync/sync-crypto-batch.ts
@@ -48,67 +48,70 @@ export async function encryptPushBatch(
   signerDeviceId: string,
   deps: EncryptBatchDeps
 ): Promise<Array<{ queueId: string; pushItem: PushItem }>> {
-  const prepareItem = (
-    item: QueueRow
-  ): {
-    payload: string
-    meta: ReturnType<EncryptBatchDeps['extractPayloadMetadata']>
-    deletedAt?: number
-  } => {
+  // Prepared once, used by whichever path ends up doing the crypto. Building it
+  // up front (rather than per path) keeps the worker request and the
+  // main-thread fallback byte-identical: resolvePushPayload reads live DB rows,
+  // so re-running it after a worker failure could hand the fallback a different
+  // payload than the one the worker was asked to encrypt.
+  const rawItems: RawPushItem[] = items.map((item) => {
     const payload = deps.resolvePushPayload(item, signerDeviceId, vaultKey)
     const meta = deps.extractPayloadMetadata(payload)
     return {
+      queueId: item.id,
+      itemId: item.itemId,
+      type: item.type as SyncItemType,
+      operation: item.operation as SyncOperation,
       payload,
-      meta,
-      ...(item.operation === 'delete' ? { deletedAt: Math.floor(Date.now() / 1000) } : {})
+      clock: meta.clock,
+      stateVector: meta.stateVector,
+      deletedAt: item.operation === 'delete' ? Math.floor(Date.now() / 1000) : undefined
     }
-  }
+  })
 
   if (deps.workerBridge?.isRunning) {
-    const rawItems: RawPushItem[] = items.map((item) => {
-      const { payload, meta, deletedAt } = prepareItem(item)
-      return {
-        queueId: item.id,
-        itemId: item.itemId,
-        type: item.type as SyncItemType,
-        operation: item.operation as SyncOperation,
-        payload,
-        clock: meta.clock,
-        stateVector: meta.stateVector,
-        deletedAt
+    try {
+      const { results, errors } = await deps.workerBridge.encryptBatch(
+        rawItems,
+        vaultKey,
+        signingKeyBytes,
+        signerDeviceId
+      )
+
+      for (const err of errors) {
+        log.error('Push: worker encrypt failed', { itemId: err.itemId, error: err.error })
+        deps.queue.markFailed(err.queueId, `Encrypt failed: ${err.error}`)
       }
-    })
 
-    const { results, errors } = await deps.workerBridge.encryptBatch(
-      rawItems,
-      vaultKey,
-      signingKeyBytes,
-      signerDeviceId
-    )
-
-    for (const err of errors) {
-      log.error('Push: worker encrypt failed', { itemId: err.itemId, error: err.error })
-      deps.queue.markFailed(err.queueId, `Encrypt failed: ${err.error}`)
+      return results.map((r) => ({ queueId: r.queueId, pushItem: r.pushItem }))
+    } catch (err) {
+      // Only worker transport/lifecycle failures reach here — the worker never
+      // rejects the request for a crypto failure. Per-item crypto errors come
+      // back in-band in `errors` above; a reject means "worker not started",
+      // request timeout, worker `error`/non-zero `exit` (rejectAll), an
+      // `{ type: 'error' }` protocol reply, or an unexpected response type.
+      // Falling through therefore cannot swallow a crypto/auth failure: the
+      // fallback re-runs the exact same encryptItemForPush on the same inputs,
+      // so a genuinely bad item still fails, just on this thread.
+      log.error('Push: worker crypto unavailable, falling back to main thread', {
+        error: err instanceof Error ? err.message : String(err)
+      })
     }
-
-    return results.map((r) => ({ queueId: r.queueId, pushItem: r.pushItem }))
   }
 
-  return items.map((item) => {
-    const { payload, meta, deletedAt } = prepareItem(item)
+  return rawItems.map((item) => {
     const result = encryptItemForPush({
       id: item.itemId,
-      type: item.type as Parameters<typeof encryptItemForPush>[0]['type'],
-      operation: item.operation as Parameters<typeof encryptItemForPush>[0]['operation'],
-      content: new TextEncoder().encode(payload),
+      type: item.type,
+      operation: item.operation,
+      content: new TextEncoder().encode(item.payload),
       vaultKey,
       ['signingSecretKey']: signingKeyBytes,
       signerDeviceId,
-      clock: meta.clock,
-      stateVector: meta.stateVector,
-      deletedAt
+      clock: item.clock,
+      stateVector: item.stateVector,
+      deletedAt: item.deletedAt
     })
-    return { queueId: item.id, pushItem: result.pushItem }
+    return { queueId: item.queueId, pushItem: result.pushItem }
   })
 }
 
@@ -167,15 +170,28 @@ export async function decryptPullBatch(
       return { decrypted: [], failures: skipped }
     }
 
-    const { results, failures } = await deps.workerBridge.decryptBatch(
-      workerItems,
-      vaultKey,
-      signerKeys
-    )
+    try {
+      const { results, failures } = await deps.workerBridge.decryptBatch(
+        workerItems,
+        vaultKey,
+        signerKeys
+      )
 
-    return {
-      decrypted: results,
-      failures: [...skipped, ...failures]
+      return {
+        decrypted: results,
+        failures: [...skipped, ...failures]
+      }
+    } catch (err) {
+      // Same reasoning as the push path: a reject is a worker transport or
+      // lifecycle failure, never a crypto verdict — per-item decrypt and
+      // signature failures arrive in-band in `failures`. The loop below re-runs
+      // the identical decryptSingleItem (signature verification included) on
+      // this thread, so nothing unverified is accepted. It also re-derives
+      // `skipped` from the cached device keys, so those failures are neither
+      // lost nor duplicated.
+      log.error('Pull: worker crypto unavailable, falling back to main thread', {
+        error: err instanceof Error ? err.message : String(err)
+      })
     }
   }
 

--- a/apps/desktop/src/main/sync/worker-bridge.test.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.test.ts
@@ -32,13 +32,15 @@ vi.mock('worker_threads', () => {
   }
 })
 
+const logger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn()
+}))
+
 vi.mock('../lib/logger', () => ({
-  createLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn()
-  })
+  createLogger: () => logger
 }))
 
 import { SyncWorkerBridge } from './worker-bridge'
@@ -388,6 +390,60 @@ describe('SyncWorkerBridge', () => {
       await expect(
         bridge.encryptBatch([], new Uint8Array(32), new Uint8Array(64), 'device-1')
       ).rejects.toThrow('Worker not started')
+    })
+  })
+
+  describe('#given running bridge #when a reply matches no pending request', () => {
+    it('#then logs the dropped reply instead of vanishing', async () => {
+      // #given
+      const p = bridge.start()
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await p
+      logger.warn.mockClear()
+
+      // #when — a reply for a request this bridge never issued (or one that
+      // already timed out)
+      mockWorkerInstance.simulateMessage({
+        type: 'error',
+        requestId: 'req_stale_1',
+        error: 'boom'
+      })
+
+      // #then
+      expect(logger.warn).toHaveBeenCalledWith('Dropped worker reply with no pending request', {
+        type: 'error',
+        requestId: 'req_stale_1'
+      })
+    })
+
+    it('#then logs an off-protocol message that carries no requestId', async () => {
+      // #given
+      const p = bridge.start()
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await p
+      logger.warn.mockClear()
+
+      // #when
+      mockWorkerInstance.simulateMessage({ type: 'nonsense' } as never)
+
+      // #then
+      expect(logger.warn).toHaveBeenCalledWith('Dropped off-protocol worker message', {
+        type: 'nonsense'
+      })
+    })
+
+    it('#then stays quiet for shutdown-ack, which legitimately has no requestId', async () => {
+      // #given
+      const p = bridge.start()
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await p
+      logger.warn.mockClear()
+
+      // #when
+      mockWorkerInstance.simulateMessage({ type: 'shutdown-ack' })
+
+      // #then — a clean stop() must not warn on every shutdown
+      expect(logger.warn).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/desktop/src/main/sync/worker-bridge.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.ts
@@ -81,7 +81,9 @@ export class SyncWorkerBridge {
     if (!this.worker) return
 
     this.worker.on('message', (msg: WorkerToMainMessage) => {
-      if (msg.type === 'ready') return
+      // `ready` is consumed by start(); `shutdown-ack` is the expected reply to
+      // stop() and carries no requestId. Neither is a dropped reply.
+      if (msg.type === 'ready' || msg.type === 'shutdown-ack') return
 
       if ('requestId' in msg) {
         const pending = this.pendingRequests.get(msg.requestId)
@@ -89,8 +91,21 @@ export class SyncWorkerBridge {
           clearTimeout(pending.timer)
           this.pendingRequests.delete(msg.requestId)
           pending.resolve(msg)
+          return
         }
+        // Late reply after a timeout, or a requestId this bridge never issued.
+        // Silently dropping it left the caller's 60s timeout unexplained in
+        // user logs. requestId is a counter + timestamp, never key material.
+        log.warn('Dropped worker reply with no pending request', {
+          type: msg.type,
+          requestId: msg.requestId
+        })
+        return
       }
+
+      log.warn('Dropped off-protocol worker message', {
+        type: (msg as { type?: unknown }).type
+      })
     })
 
     this.worker.on('error', (err: Error) => {

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -387,3 +387,22 @@ latch and sync resumes.
 ## Encryption Stays End-to-End
 
 The server never sees plaintext. See [Cryptography](/architecture/cryptography) for the key hierarchy.
+
+### Crypto worker and main-thread fallback
+
+Push encryption and pull decryption run in a worker thread so a large batch does not block the main
+process. The worker is an optimisation, never a dependency: whenever it is unavailable the same
+batch is encrypted or decrypted on the main thread instead, and sync continues at reduced speed
+rather than failing.
+
+"Unavailable" covers both a worker that never started and a running worker that rejects a request —
+a request timeout, the worker crashing or exiting mid-batch, or a message kind the worker build does
+not implement, which is what a partially updated install looks like. The batch that was in flight
+when any of those happen degrades to the main thread with the rest; it is not lost.
+
+Degrading cannot mask a bad payload. The worker reports per-item crypto outcomes in its reply — a
+failed decrypt or a signature mismatch comes back as a per-item failure, not as a rejected batch —
+so a rejection only ever means the worker itself was unreachable. The main-thread path then runs the
+identical encryption and signature verification over the same inputs, so an item that genuinely
+fails crypto still fails; it just fails on the main thread. Push payloads are resolved once and
+shared by both paths, so the fallback encrypts exactly what the worker was handed.


### PR DESCRIPTION
Closes #957

## Problem

`runtime.ts` documented that sync crypto degrades to the main thread when the worker is unavailable. It only did so for a worker that failed to **start**. A worker that was running and **rejected** a request failed the whole batch.

`sync-crypto-batch.ts` gated the fallback purely on `workerBridge?.isRunning`, and the `await`s underneath it were unguarded — so `encryptPushBatch` / `decryptPullBatch` propagated the rejection out and never reached the main-thread path sitting a few lines below.

Ways a running worker rejects:

- a message kind the worker build does not implement (a partially updated install where main and worker bundles disagree) — the worker replies `{ type: 'error' }` and the bridge throws
- the 60s request timeout
- `rejectAll` on worker `error` or non-zero `exit` — later batches recovered because `exit` nulls the worker and `isRunning` goes false, but the batch in flight when the worker died was already lost, and the log line promising a fallback fired for it

## Fix

Both bridge calls are wrapped and fall through to the existing main-thread path.

Push payloads are now resolved once, up front, and shared by both paths. `resolvePushPayload` reads live DB rows, so re-running it after a worker failure could have handed the fallback a different payload than the one the worker was asked to encrypt.

## Why this cannot mask a crypto or auth failure

The distinction that matters here is worker-infrastructure failure vs. crypto verdict, and the protocol already separates them:

- Per-item crypto outcomes come back **in-band**. `encrypt-batch-result` carries `errors[]` (which still go to `queue.markFailed`), `decrypt-batch-result` carries `failures[]` including signature mismatches. Neither rejects the request. Those paths are untouched.
- A **rejection** therefore only ever means the worker was unreachable: not started, timed out, crashed/exited, protocol drift, or an unexpected response type.
- The fallback re-runs the identical `encryptItemForPush` / `decryptSingleItem` — the same signature verification, the same AEAD — on the same inputs. An item that genuinely fails crypto still fails, just on this thread. Nothing unverified is accepted.

Key material is safe across the fallback: the bridge copies (`new Uint8Array(vaultKey)`) before posting, so the worker's `secureCleanup` zeroes only the worker's copy and the main thread's key is intact.

The decrypt fallback re-derives its "no public key for signer" skips from `resolveDeviceKey`, which is cached per pull run — so those failures are neither lost nor duplicated.

## Unmatched replies

`worker-bridge.ts` dropped, with no log, any reply whose `requestId` had no pending entry and any message with no `requestId` at all. The caller then saw only an unexplained 60s timeout. Both cases now `log.warn`. `shutdown-ack` is carved out explicitly — it legitimately has no `requestId`, and warning on it would fire on every clean stop. Only `type` and `requestId` (a counter + timestamp) are logged; no key material or plaintext.

The `runtime.ts` comment was updated to match the implemented behaviour.

## Backward compatibility

No schema, contract, protocol, or persisted-format change. The wire protocol between main and worker is untouched, so a main bundle from this build talks to an older or newer worker bundle exactly as before — the only difference is that a mismatch now degrades instead of failing the batch, which is strictly better for the mixed-build case this targets. Behaviour when the worker answers normally is byte-identical; the new code path is reachable only on a rejection that previously threw.

## Tests

`apps/desktop/src/main/sync/sync-crypto-batch.test.ts` — 3 new: encrypt falls back on an `{ type: 'error' }` rejection, decrypt falls back on a worker-exit rejection (asserting the skipped item is re-derived and not duplicated), and the push payload is resolved exactly once so the fallback reuses what the worker was handed.

`apps/desktop/src/main/sync/worker-bridge.test.ts` — 3 new: unmatched reply logged, off-protocol message logged, `shutdown-ack` stays quiet.

Green:

```
Test Files  4 passed (4)
     Tests  49 passed (49)
```

Whole `src/main/sync` suite:

```
Test Files  136 passed (136)
     Tests  1629 passed | 1 expected fail | 3 skipped (1633)
```

Mutation check — source fix stashed, tests re-run:

```
 × sync-crypto-batch.test.ts > falls back to main-thread encryption when the worker rejects the batch
 × sync-crypto-batch.test.ts > resolves the push payload once so the encrypt fallback reuses the worker payload
 × sync-crypto-batch.test.ts > falls back to main-thread decryption when the worker rejects the batch
 × worker-bridge.test.ts > #then logs the dropped reply instead of vanishing
 × worker-bridge.test.ts > #then logs an off-protocol message that carries no requestId
Test Files  2 failed (2)
     Tests  5 failed | 24 passed (29)
```

Fix restored, green again. `pnpm typecheck` 16/16 successful, `pnpm lint` clean, `pnpm docs:impact --strict` covered, `pnpm docs:build` complete.

## Deliberately out of scope

- **Latching the bridge off after repeated worker failures.** Raised in the issue. A worker that is alive but always rejects now costs a round trip per batch — negligible for an immediate `{ type: 'error' }` reply, but a worker that goes *silent* costs the full 60s timeout per batch before degrading. Worth deciding separately, including whether a transient hiccup should permanently give up the worker for the session.
- **Bounding main-thread fallback latency for large pull batches.** Also raised in the issue; unchanged here.
- **`encryptItemForPush` throwing in the fallback** (e.g. "Item too large for sync") still propagates out of `encryptPushBatch` instead of becoming a per-item `markFailed`. That is the pre-existing main-thread path's behaviour when no worker is configured at all, so it is not a regression introduced here.
