### PR TITLE
sync: unify sync server URL resolution and cover two untested branches

### DIFF
--- a/apps/desktop/src/main/sync/http-client.test.ts
+++ b/apps/desktop/src/main/sync/http-client.test.ts
@@ -81,6 +81,30 @@ describe('http-client', () => {
       expect(result).toEqual(responseData)
     })
 
+    it('strips a trailing slash from SYNC_SERVER_URL before appending the path', async () => {
+      // #given a slash-terminated env value. http-client used to interpolate it
+      // verbatim, producing `http://localhost:8787//api/users` — Cloudflare
+      // Workers routes the doubled slash as a different path, so every sync
+      // request 404'd instead of reaching its handler.
+      const original = process.env.SYNC_SERVER_URL
+      process.env.SYNC_SERVER_URL = 'http://localhost:8787/'
+      mockFetch.mockResolvedValue(createJsonResponse({}))
+
+      try {
+        // #when
+        await syncFetch('GET', '/api/users')
+
+        // #then
+        expect(mockFetch).toHaveBeenCalledWith(
+          'http://localhost:8787/api/users',
+          expect.objectContaining({ method: 'GET' })
+        )
+      } finally {
+        if (original === undefined) delete process.env.SYNC_SERVER_URL
+        else process.env.SYNC_SERVER_URL = original
+      }
+    })
+
     it('makes a POST request with body', async () => {
       // #given
       const requestBody = { email: 'test@example.com' }

--- a/apps/desktop/src/main/sync/http-client.ts
+++ b/apps/desktop/src/main/sync/http-client.ts
@@ -1,19 +1,13 @@
 import { net } from 'electron'
 import { RECORD_SYNC_ITEM_TYPES } from '@memry/contracts/sync-api'
 import { getMainI18n } from '../lib/main-i18n'
+import { resolveSyncServerUrl } from './sync-server-url'
 import { withRetry } from './retry'
 
 // Declared to the server so it never sends this build an item type our
 // RecordPullResponseSchema would reject — one unknown type fails the whole-page
 // safeParse and silently drops the page.
 const SYNC_TYPES_HEADER_VALUE = RECORD_SYNC_ITEM_TYPES.join(',')
-
-function getSyncServerUrl(): string {
-  const url = process.env.SYNC_SERVER_URL
-  if (url) return url
-  if (process.env.NODE_ENV === 'development') return 'http://localhost:8787'
-  throw new Error('SYNC_SERVER_URL environment variable is not configured')
-}
 
 export type FetchFn = typeof globalThis.fetch
 
@@ -108,7 +102,14 @@ export const syncFetch = async <T>(
   fetchFn?: FetchFn,
   timeoutMs: number = SYNC_REQUEST_TIMEOUT_MS
 ): Promise<T> => {
-  const url = `${getSyncServerUrl()}${path}`
+  // Resolved per call, never hoisted to a module-level const: dotenv runs in
+  // index.ts *after* this module is imported, so capturing at import time
+  // freezes the wrong value (see sync-server-url.ts). resolveSyncServerUrl()
+  // preserves that laziness and additionally strips a trailing slash, which
+  // this file used to pass through verbatim — `${url}/sync/...` against a
+  // slash-terminated env yields `//sync/...`, a different route to Cloudflare
+  // Workers, so every sync request 404'd.
+  const url = `${resolveSyncServerUrl()}${path}`
   const fetchImpl = fetchFn ?? ((...args: Parameters<typeof net.fetch>) => net.fetch(...args))
 
   const headers: Record<string, string> = {

--- a/apps/desktop/src/main/sync/sync-server-url.ts
+++ b/apps/desktop/src/main/sync/sync-server-url.ts
@@ -7,7 +7,9 @@
  * `const URL = process.env.SYNC_SERVER_URL || 'http://localhost:8787'` freezes
  * to the fallback before the env file is applied. In `dev` the fallback equals
  * `.env.dev`'s value so the bug is invisible; in `dev:staging` it silently
- * pinned OAuth/sync to localhost. Mirrors `http-client.ts`'s lazy resolution.
+ * pinned OAuth/sync to localhost. `http-client.ts` used to carry its own copy of
+ * this resolution; it now calls in here, so every sync-adjacent consumer —
+ * sync HTTP, OAuth sign-in, canvas assets, attachments — reads one policy.
  */
 
 const DEV_FALLBACK_URL = 'http://localhost:8787'
@@ -16,14 +18,14 @@ export function resolveSyncServerUrl(): string {
   const configured = process.env.SYNC_SERVER_URL
   if (configured) return normalizeSyncServerUrl(configured)
 
-  // Same policy as http-client.ts's getSyncServerUrl(): the localhost fallback
-  // is a *development* convenience, not a runtime default. This module used to
-  // fall back unconditionally, which meant the two call sites that do NOT go
-  // through http-client — the OAuth sign-in URL (ipc/auth-oauth-handlers.ts)
-  // and the canvas asset service (canvas/assets/asset-service-context.ts) —
-  // silently pointed a real user's packaged app at http://localhost:8787 while
-  // sync HTTP was already failing loudly with a config error. One env var must
-  // not have two contradictory policies.
+  // The localhost fallback is a *development* convenience, not a runtime
+  // default. This module used to fall back unconditionally, which meant the two
+  // call sites that do NOT go through http-client — the OAuth sign-in URL
+  // (ipc/auth-oauth-handlers.ts) and the canvas asset service
+  // (canvas/assets/asset-service-context.ts) — silently pointed a real user's
+  // packaged app at http://localhost:8787 while sync HTTP was already failing
+  // loudly with a config error. One env var must not have two contradictory
+  // policies.
   //
   // NODE_ENV is 'development' under `electron-vite dev` and undefined at
   // runtime in packaged Electron (see the applyPackagedLogLevels comment in
@@ -35,6 +37,15 @@ export function resolveSyncServerUrl(): string {
   // NODE_ENV: 'test') run an UNPACKAGED build that often has no
   // SYNC_SERVER_URL. Excluding it would turn a green harness into a hard
   // failure without making a shipped build any safer.
+  //
+  // Compat, http-client: adopting this resolver widened sync HTTP's dev-only
+  // predicate to include 'test', so an unconfigured harness now dials
+  // localhost:8787 instead of throwing a config error. That combination —
+  // NODE_ENV==='test' with no SYNC_SERVER_URL — cannot occur in a packaged
+  // build (NODE_ENV is undefined there), so no shipped install changes
+  // behaviour; and the rest of the sync surface (attachments, canvas assets,
+  // OAuth) already resolved to localhost under 'test', so sync HTTP was the
+  // outlier, not the standard.
   //
   // Compat, packaged builds: this throw is unreachable for an app that was
   // built normally. scripts/build-packaged-app.js refuses to package without

--- a/apps/desktop/src/main/sync/worker.test.ts
+++ b/apps/desktop/src/main/sync/worker.test.ts
@@ -340,4 +340,63 @@ describe('worker', () => {
       expect(mockCleanup).toHaveBeenCalledWith(vaultKey)
     })
   })
+
+  // A packaged install can end up with a main bundle and a worker bundle from
+  // different builds (partial update, stale asar), which is the only way an
+  // unknown kind reaches this switch. Both halves matter and fail in opposite
+  // directions, so both are pinned.
+  describe('#given worker ready #when an unknown message kind is received', () => {
+    const emitUnknown = (msg: unknown): void => {
+      mockPort.emit('message', msg as MainToWorkerMessage)
+    }
+
+    it('#then replies with a typed error for a request-shaped message', async () => {
+      // #given a kind this build does not implement, carrying a requestId — so
+      // the parent has a pending promise waiting on it.
+      const resultPromise = captureNextPostMessage()
+
+      // #when
+      emitUnknown({ type: 'compact-batch', requestId: 'req-9' })
+      const result = await resultPromise
+
+      // #then the bridge can reject immediately instead of stalling until its
+      // 60s REQUEST_TIMEOUT_MS fires, which is what a silent drop used to cost
+      // every crypto batch.
+      expect(result).toEqual({
+        type: 'error',
+        requestId: 'req-9',
+        error: 'Unsupported worker message kind: compact-batch'
+      })
+    })
+
+    it('#then stays silent when the message carries no requestId', async () => {
+      // #given no requestId, so there is no pending promise to settle.
+      // #when
+      emitUnknown({ type: 'flush-cache' })
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      // #then replying `requestId: undefined` would put an off-protocol message
+      // on the wire that worker-bridge's `'requestId' in msg` check accepts and
+      // then looks up under the key `undefined`. Silence is the contract.
+      expect(mockPort.postMessage).not.toHaveBeenCalled()
+    })
+
+    it('#then does not throw when `type` is not a string', async () => {
+      // #given a bundle mismatch can deliver anything, including a message with
+      // no usable discriminant. String(undefined) keeps the log line readable
+      // rather than crashing the worker on a property access.
+      const resultPromise = captureNextPostMessage()
+
+      // #when
+      emitUnknown({ requestId: 'req-10' })
+      const result = await resultPromise
+
+      // #then
+      expect(result).toEqual({
+        type: 'error',
+        requestId: 'req-10',
+        error: 'Unsupported worker message kind: undefined'
+      })
+    })
+  })
 })

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -326,6 +326,32 @@ list.
 | `POST /devices/*`         | mixed     | Linking, listing, revoking                                                     |
 | `POST /keys/*`            | mixed     | Key sealing during link, rotation                                              |
 
+### Server base URL
+
+Every path above is appended to a single resolved base URL. `resolveSyncServerUrl()`
+(`src/main/sync/sync-server-url.ts`) is the only resolver — sync HTTP, OAuth sign-in, canvas assets
+and attachment transfers all call it, so one env var cannot end up with two policies.
+
+Two properties of that resolver are load-bearing:
+
+- **Resolved per call, never at import time.** The main process applies `.env.<environment>` via
+  dotenv in `index.ts` _after_ the IPC handler modules are imported, so a module-level
+  `const URL = process.env.SYNC_SERVER_URL || …` freezes to the fallback before the env file lands.
+  In `dev` the fallback happens to equal the configured value, which hides the bug; in `dev:staging`
+  it silently pinned sync and OAuth to localhost.
+- **Trailing slashes are stripped.** Callers build paths as `` `${base}${path}` ``, so a
+  slash-terminated `SYNC_SERVER_URL` yields `https://host//sync/push`. Cloudflare Workers routes the
+  doubled slash as a different path, so the request 404s instead of reaching its handler. Only
+  trailing slashes are normalized — scheme, host, port and any base path are left verbatim so a typo
+  still fails loudly rather than being rewritten into something that "works".
+
+`SYNC_SERVER_URL` is required. The `http://localhost:8787` fallback applies only when `NODE_ENV` is
+`development` or `test` — the unpackaged dev server and the vitest/Playwright harnesses. A packaged
+build has `NODE_ENV` undefined and gets an explicit configuration error rather than a silent dial to
+a localhost port nothing is listening on. Packaging cannot legitimately omit the value:
+`scripts/build-packaged-app.js` refuses to build without `apps/desktop/.env.production` and asserts
+the value is a non-local HTTPS URL.
+
 ## Realtime Socket Auth
 
 The change-notification WebSocket (`/sync/ws`) authenticates once at handshake with a Bearer access

--- a/apps/sync-server/src/services/vault-deletion.test.ts
+++ b/apps/sync-server/src/services/vault-deletion.test.ts
@@ -171,6 +171,25 @@ describe('deleteVaultData with open upload sessions', () => {
     ])
     expect(decrement).toBe(-(BASE + 300))
   })
+
+  it('releases the full total_size when uploaded_chunks is not JSON at all', async () => {
+    // The sibling case above passes valid JSON with a bad byte count, which
+    // only exercises getUploadedByteTotal's null fallback. This one never
+    // parses, so it takes readUploadedChunks' `ok: false` branch instead.
+    //
+    // The invariant under test is that a corrupt column must not abort the
+    // deletion: the failure mode is a user permanently unable to delete their
+    // vault. Asserting the numeric release keeps the fallback honest at the
+    // same time — the reservation is real whether or not the chunk list can be
+    // read, so the whole total_size comes back rather than zero.
+    const decrement = await decrementFor([{ total_size: 700, uploaded_chunks: 'not json' }])
+    expect(decrement).toBe(-(BASE + 700))
+  })
+
+  it('releases the full total_size when uploaded_chunks parses to a non-array', async () => {
+    const decrement = await decrementFor([{ total_size: 900, uploaded_chunks: '{"i":0}' }])
+    expect(decrement).toBe(-(BASE + 900))
+  })
 })
 
 describe('deleteVaultData ordering', () => {


### PR DESCRIPTION
Closes #959

Three of the four items were valid and are fixed here. The fourth was verified against the source and deliberately left alone — details below.

## 1. `http-client.ts` kept its own copy of the SYNC_SERVER_URL policy — VALID, fixed

`getSyncServerUrl()` is deleted; `syncFetch` now calls `resolveSyncServerUrl()`. The duplication came with a real bug: the old function returned `process.env.SYNC_SERVER_URL` verbatim, so a slash-terminated value produced `https://host//sync/push`. Cloudflare Workers routes the doubled slash as a different path, so every sync request 404'd instead of reaching its handler.

Lazy resolution is preserved: `resolveSyncServerUrl()` reads the env per call, exactly as the deleted function did, so dotenv still gets to run in `index.ts` after these modules are imported and nothing throws at import time.

**The `test` arm decision.** The issue asked for this to be an explicit decision rather than a side effect. It is taken here, on two grounds:

- It cannot reach a shipped build. The widening only applies when `NODE_ENV === 'test'` **and** `SYNC_SERVER_URL` is unset. Packaged Electron has `NODE_ENV` undefined, so a real install lands on the same throw as before. No user-visible behaviour changes.
- Sync HTTP was the outlier, not the standard. Attachments (`ipc/sync-attachment-handlers.ts`), canvas assets (`canvas/assets/asset-service-context.ts`) and OAuth sign-in already resolve to `localhost:8787` under `NODE_ENV=test`. The harness previously got a config error from sync HTTP while the rest of the same subsystem happily dialed localhost.

What actually changes: an E2E run that does not opt into `syncServerUrl` (`tests/e2e/utils/electron-lifecycle.ts` only sets it when a test asks) now gets a connection refusal instead of a configuration error. Sync fails either way; only the error shape moves. No test asserts on that message — `grep` for `SYNC_SERVER_URL environment variable is not configured` outside `sync-server-url.test.ts` finds only the deleted line.

The rationale is recorded in a comment in `sync-server-url.ts` rather than the commit message, and the two comments in that file that referred to `http-client.ts`'s now-deleted copy were corrected.

## 2. No direct test for an unparseable `uploaded_chunks` — VALID, fixed

Confirmed: the existing "malformed" case passes valid JSON with a negative byte count, which only reaches `getUploadedByteTotal`'s `null` fallback. `readUploadedChunks`' `ok: false` branch was untested. Two siblings added through the existing `decrementFor` helper — `'not json'` (the `malformed-json` reason) and `'{"i":0}'` (the `not-an-array` reason) — each asserting the full `total_size` comes back.

The invariant being pinned is that a corrupt column must never abort a vault deletion; the failure mode is a user permanently unable to delete their vault.

## 3. No test for the worker's `default:` branch — VALID, fixed

Three tests on the file's existing `mockPort.emit('message', …)` harness:

- `{ type: 'compact-batch', requestId: 'req-9' }` → asserts the exact `{ type: 'error', requestId: 'req-9', error: 'Unsupported worker message kind: compact-batch' }` reply, which is what lets the bridge reject immediately instead of stalling for the full 60s `REQUEST_TIMEOUT_MS`.
- `{ type: 'flush-cache' }` with no `requestId` → asserts `postMessage` is not called. This is the load-bearing half: a reply with `requestId: undefined` would pass `worker-bridge`'s `'requestId' in msg` check and then be looked up under the key `undefined`.
- `{ requestId: 'req-10' }` with no `type` at all → asserts the `String(undefined)` path in `handleUnknownMessage` produces a readable message rather than crashing, since a bundle mismatch can deliver anything.

## 4. Four modules read `process.env.SYNC_SERVER_URL` raw — NOT FIXED (scope is wrong)

The five call sites are real, but the stated motivation does not hold at any of them, and routing them through `resolveSyncServerUrl` would make one of them worse.

- `diagnostics/incident-report.ts:110`, `telemetry/log-ship.ts:98`, `telemetry/runtime.ts:87` — all three **already** normalize, with `` `${syncServer.replace(/\/$/, '')}/…` ``. There is no trailing-slash divergence to close. The only residual difference against `normalizeSyncServerUrl` is multi-slash (`https://host//` → `https://host/` vs `https://host`), which is not a configuration anyone writes; it is not worth changing three telemetry endpoints and their fallback chains over.
- `sync/certificate-pins.ts:27` and `:41` — these feed the value straight into `new URL(…)` and read only `.hostname`, where a trailing slash is definitionally irrelevant. Worse, switching would be an actual regression: with `SYNC_SERVER_URL` unset the functions currently return `DEFAULT_SYNC_CERT_HOSTNAME` (`sync.memrynote.com`) and its real pins, while `resolveSyncServerUrl()` under dev/test would hand back `http://localhost:8787` → hostname `localhost` → **no pins at all**. The `undefined`-tolerant default parameter is the correct shape here.

The underlying observation — one env var, several readers — is fair, but the concrete fix as described has negative value at every site. Left as-is.

## Backward compatibility

No schema, contract, protocol or file-format change; the diff is one import swap plus tests and docs. The only production-reachable behaviour change is item 1's trailing-slash normalization, which strictly turns a 404'ing configuration into a working one — a value with no trailing slash resolves byte-identically to before. The `NODE_ENV=test` widening is unreachable in a packaged build, as argued above.

## Verification

```
# desktop, full main project (5278 tests)
PASS (5278) FAIL (0) skipped (4)

# sync-server, full package
PASS (861) FAIL (0)

pnpm typecheck   → Tasks: 16 successful, 16 total
pnpm lint        → 10 problems (0 errors, 10 warnings)   # all pre-existing, none in touched files
pnpm docs:impact --base origin/main --strict → covered
```

The six `schema/d1.test.ts` failures seen on the first sync-server run were `better-sqlite3` `ERR_DLOPEN_FAILED` (worktree native-module version mismatch); `pnpm --filter @memry/desktop rebuild:node` cleared them and the package is green.

### Mutation checks

Each behaviour-carrying change was reverted, observed red, and restored:

| Mutation | Result |
| --- | --- |
| `resolveSyncServerUrl()` → `process.env.SYNC_SERVER_URL` in `syncFetch` | RED — `expected "http://localhost:8787/api/users", received "http://localhost:8787//api/users"` |
| `readUploadedChunks` drops its `JSON.parse` try/catch | RED — `SyntaxError: Unexpected token 'o', "not json" is not valid JSON`, and only the new test failed (12 others still passed), confirming the pre-existing "malformed" case does not cover this branch |
| `worker.ts` drops the `default:` case | RED — `Error: No postMessage within 1s` ×2 |
| `worker.ts` drops the `typeof unknown.requestId !== 'string'` guard | RED — `expected "vi.fn()" to not be called at all, but actually been called 1 times` |

All restored and re-verified green (`http-client` 27 passed, `worker` 10 passed, `vault-deletion` 13 passed), with `git diff` against `HEAD` clean for both mutated production files.

## Out of scope

- Item 4, as argued above.
- `packages/contracts` untouched, so no `ipc:generate` / `ipc:check` cycle was needed.
