### PR TITLE
fix(sync): stop shipping the journal date in delete tombstones

### DIFF
--- a/apps/desktop/src/main/sync/content-sync-services.test.ts
+++ b/apps/desktop/src/main/sync/content-sync-services.test.ts
@@ -365,10 +365,11 @@ describe('content sync services', () => {
     })
 
     service.enqueueDelete('journal-2026-05-10', '2026-05-10')
-    expect(JSON.parse(queue.items[2].payload)).toMatchObject({
-      date: '2026-05-10',
-      clock: { 'dev-a': 1 }
-    })
+    // The tombstone keeps the clock (push-coordinator reads it back out) but
+    // drops the journalled day — no receiver ever decodes a delete body.
+    const tombstone = JSON.parse(queue.items[2].payload) as Record<string, unknown>
+    expect(tombstone).toMatchObject({ clock: { 'dev-a': 1 } })
+    expect(Object.prototype.hasOwnProperty.call(tombstone, 'date')).toBe(false)
 
     expect(getJournalSyncService()).toBeNull()
     expect(

--- a/apps/desktop/src/main/sync/item-handlers/journal-handler.test.ts
+++ b/apps/desktop/src/main/sync/item-handlers/journal-handler.test.ts
@@ -163,6 +163,48 @@ describe('journalHandler', () => {
     })
   })
 
+  it('skips an upsert with no date instead of writing an undefined day', async () => {
+    // `date` is optional in the schema only so delete tombstones can omit it.
+    // A create/update without one has no day to write to, so the handler has to
+    // reject it where the required field used to.
+    mockGetNoteMetadataById.mockReturnValue(undefined)
+    const ctx = makeCtx()
+
+    expect(
+      journalHandler.applyUpsert(ctx, 'journal-1', { content: 'orphan' }, { 'device-a': 1 })
+    ).toBe('skipped')
+    await flushPromises()
+
+    expect(mockWriteJournalEntryWithContent).not.toHaveBeenCalled()
+    expect(mockSaveCanonicalNote).not.toHaveBeenCalled()
+    expect(ctx.emit).not.toHaveBeenCalled()
+    expect(loggerMock.warn).toHaveBeenCalledWith('Skipping remote journal upsert with no date', {
+      itemId: 'journal-1'
+    })
+  })
+
+  it('applies a delete without reading the tombstone body at all', async () => {
+    // The receiver-side half of the compat argument for dropping `date`:
+    // applyDelete takes only (ctx, itemId, clock) — there is no parameter that
+    // could carry the payload — and it resolves the day from the local row.
+    // Every shipped build behaves this way, so a tombstone with no date is
+    // indistinguishable from one with a date on any receiver.
+    mockGetNoteMetadataById.mockReturnValue({
+      id: 'journal-1',
+      journalDate: '2026-05-10',
+      clock: { 'device-a': 1 }
+    })
+    const ctx = makeCtx()
+
+    expect(journalHandler.applyDelete(ctx, 'journal-1', { 'device-a': 2 })).toBe('applied')
+
+    expect(mockDeleteJournalEntryFile).toHaveBeenCalledWith('2026-05-10')
+    expect(ctx.emit).toHaveBeenCalledWith(JournalChannels.events.ENTRY_DELETED, {
+      date: '2026-05-10',
+      source: 'sync'
+    })
+  })
+
   it('skips stale updates and applies concurrent updates as conflicts', async () => {
     const ctx = makeCtx()
     mockGetNoteMetadataById.mockReturnValueOnce({

--- a/apps/desktop/src/main/sync/item-handlers/journal-handler.ts
+++ b/apps/desktop/src/main/sync/item-handlers/journal-handler.ts
@@ -35,6 +35,17 @@ class JournalHandler extends BaseItemHandler<JournalSyncPayload> {
     data: JournalSyncPayload,
     clock: VectorClock
   ): ApplyResult {
+    // `date` is optional in JournalSyncPayloadSchema only so a delete tombstone
+    // can leave it out (see sync-payloads.ts and journal-sync.buildDeletePayload).
+    // An upsert without it has no day to write to, so keep rejecting it here —
+    // this is the same outcome the required field used to produce, just with a
+    // clearer log line than a generic schema validation failure.
+    const { date } = data
+    if (!date) {
+      log.warn('Skipping remote journal upsert with no date', { itemId })
+      return 'skipped'
+    }
+
     const remoteClock = Object.keys(clock).length > 0 ? clock : (data.clock ?? {})
     const now = utcNow()
     const existing = getNoteMetadataById(ctx.db, itemId)
@@ -51,7 +62,7 @@ class JournalHandler extends BaseItemHandler<JournalSyncPayload> {
       }
 
       writeJournalEntryWithContent(
-        data.date,
+        date,
         data.content ?? '',
         data.tags,
         null,
@@ -87,15 +98,15 @@ class JournalHandler extends BaseItemHandler<JournalSyncPayload> {
           void flushProjectionEvents()
         })
         .catch((err) => {
-          log.error('Failed to write synced journal entry', { itemId, date: data.date, error: err })
+          log.error('Failed to write synced journal entry', { itemId, date, error: err })
         })
 
-      ctx.emit(JournalChannels.events.ENTRY_UPDATED, { date: data.date, source: 'sync' })
+      ctx.emit(JournalChannels.events.ENTRY_UPDATED, { date, source: 'sync' })
       return resolution.action === 'merge' ? 'conflict' : 'applied'
     }
 
     writeJournalEntryWithContent(
-      data.date,
+      date,
       data.content ?? '',
       data.tags,
       null,
@@ -130,12 +141,12 @@ class JournalHandler extends BaseItemHandler<JournalSyncPayload> {
         )
         void flushProjectionEvents()
 
-        ctx.emit(JournalChannels.events.ENTRY_CREATED, { date: data.date, source: 'sync' })
+        ctx.emit(JournalChannels.events.ENTRY_CREATED, { date, source: 'sync' })
       })
       .catch((err) => {
         log.error('Failed to write new synced journal entry', {
           itemId,
-          date: data.date,
+          date,
           error: err
         })
       })

--- a/apps/desktop/src/main/sync/journal-sync.test.ts
+++ b/apps/desktop/src/main/sync/journal-sync.test.ts
@@ -223,7 +223,7 @@ describe('JournalSyncService push', () => {
 })
 
 describe('JournalSyncService deletes', () => {
-  it('propagates a delete as a dated tombstone with a bumped clock', () => {
+  it('propagates a delete as a bumped clock with NO journal date', () => {
     seedJournalNote({ clock: { 'device-a': 3 } })
 
     makeService().enqueueDelete(JOURNAL_ID, DATE)
@@ -232,8 +232,12 @@ describe('JournalSyncService deletes', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0].type).toBe('journal')
     expect(rows[0].operation).toBe('delete')
-    expect(payloadOf(rows[0])).toMatchObject({
-      date: DATE,
+    // The tombstone must not carry the journalled day. Nothing on the receiving
+    // side reads it — ItemApplier never decodes a delete body — so shipping it
+    // only widened what every delete encrypts, uploads and parks in the local
+    // plaintext sync queue. The clock MUST survive: push-coordinator lifts it
+    // out of this string to stamp the server-side item version.
+    expect(payloadOf(rows[0])).toEqual({
       clock: { 'device-a': 4 },
       createdAt: CREATED_AT,
       modifiedAt: MODIFIED_AT
@@ -241,14 +245,24 @@ describe('JournalSyncService deletes', () => {
   })
 
   it('still propagates the delete when the metadata row is already gone', () => {
-    // Unlike notes, a journal tombstone is buildable from the date alone, so a
-    // missing cache row must not swallow the delete.
+    // Unlike notes, a journal delete is enqueued even without a cache row, so a
+    // missing row must not swallow the delete.
     makeService().enqueueDelete('journal-2026-01-01', '2026-01-01')
 
     const rows = queueRows()
     expect(rows).toHaveLength(1)
     expect(rows[0].operation).toBe('delete')
-    expect(payloadOf(rows[0])).toEqual({ date: '2026-01-01', clock: { 'device-a': 1 } })
+    expect(payloadOf(rows[0])).toEqual({ clock: { 'device-a': 1 } })
+  })
+
+  it('emits a tombstone the current schema accepts, date key entirely absent', () => {
+    seedJournalNote()
+
+    makeService().enqueueDelete(JOURNAL_ID, DATE)
+
+    const payload = payloadOf(queueRows()[0])
+    expect(Object.prototype.hasOwnProperty.call(payload, 'date')).toBe(false)
+    expect(JournalSyncPayloadSchema.safeParse(payload).success).toBe(true)
   })
 
   it('lets a delete win over a still-pending create instead of being dropped', () => {

--- a/apps/desktop/src/main/sync/journal-sync.ts
+++ b/apps/desktop/src/main/sync/journal-sync.ts
@@ -27,13 +27,32 @@ export class JournalSyncService extends ContentSyncService<JournalSyncPayload, [
   protected readonly log = log
   readonly itemType = 'journal' as const
 
+  // `date` is still taken so the controller's extra-args signature is unchanged
+  // and callers keep passing it; it is deliberately not put on the wire.
   protected buildDeletePayload(
     cached: NoteMetadata | undefined,
     clock: VectorClock,
-    date: string
+    _date: string
   ): JournalSyncPayload {
+    // A tombstone deliberately carries NO user-visible data, matching notes.
+    // Nothing consumes it: ItemApplier short-circuits `operation === 'delete'`
+    // and calls applyDelete(ctx, itemId, clock) without ever decoding the
+    // payload bytes, and SyncItemHandler.applyDelete has no data parameter to
+    // receive them with. journal-handler.applyDelete resolves the day from the
+    // local row (`existing.journalDate`), never from the body. The date was
+    // therefore dead weight that still got encrypted and uploaded on every
+    // journal delete — and sat in plaintext in the local sync queue until the
+    // push drained.
+    //
+    // Backward compatible in both directions. New sender → old receiver: no
+    // shipped build has ever parsed a delete body (the short-circuit is in the
+    // first ItemApplier commit, d52dbf875), so the missing field is unreadable
+    // either way. Old sender → new receiver: `date` stays accepted, it is only
+    // optional now. The `clock` MUST stay —
+    // push-coordinator.extractPayloadMetadata lifts it out of this string to
+    // stamp the server-side item version, so dropping it would break delete
+    // ordering across devices.
     return {
-      date,
       clock,
       createdAt: cached?.createdAt,
       modifiedAt: cached?.modifiedAt

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -284,6 +284,25 @@ a move, a re-index — carry file state only, and must not erase it.
 
 Deletions include `deleted_at` inside the **Ed25519-signed** payload — preventing a hostile server from forging deletions.
 
+A tombstone body carries no user content. The receiving side never decodes it: `ItemApplier`
+short-circuits on `operation === 'delete'` and calls `applyDelete(ctx, itemId, clock)`, and
+`SyncItemHandler.applyDelete` has no parameter that could accept the body. Handlers resolve
+whatever they need from the local row instead — the journal handler, for example, reads the
+journalled day from `noteMetadata.journalDate`.
+
+So note and journal tombstones ship `{ clock, createdAt, modifiedAt }` and nothing else: no title,
+no journal date. Anything more is encrypted and uploaded on every delete for no reader, and sits in
+plaintext in the local `sync_queue` row until the push drains.
+
+`clock` is the one field a tombstone must keep. `PushCoordinator.extractPayloadMetadata` parses it
+back out of the payload string to stamp the server-side item version, so dropping it would break
+delete ordering across devices.
+
+Payload schemas therefore mark these fields optional (`NoteSyncPayloadSchema.title`,
+`JournalSyncPayloadSchema.date`) — a tombstone legitimately omits them. Where a field is still
+required for a create or update, the handler enforces it: `journal-handler.applyUpsert` skips an
+upsert that arrives with no `date`.
+
 ## Account Vault Directory
 
 An account can hold several vaults (subject to the plan's vault limit). The directory lets any

--- a/packages/contracts/src/sync-payloads.test.ts
+++ b/packages/contracts/src/sync-payloads.test.ts
@@ -329,8 +329,33 @@ describe('JournalSyncPayloadSchema', () => {
     expect(result.success).toBe(true)
   })
 
-  it('rejects missing date', () => {
-    const result = JournalSyncPayloadSchema.safeParse({ content: 'Today...' })
+  it('accepts a delete tombstone that omits the date', () => {
+    // Deletes carry no user data: the receiver short-circuits on
+    // `operation === 'delete'` and never decodes the body, so the journalled
+    // day was uploaded on every delete for nothing. See
+    // journal-sync.buildDeletePayload. An upsert without a date is still
+    // rejected — by journal-handler.applyUpsert, not by this schema.
+    const result = JournalSyncPayloadSchema.safeParse({
+      clock: { 'device-a': 4 },
+      createdAt: '2026-04-16T00:00:00Z',
+      modifiedAt: '2026-04-16T01:00:00Z'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('still accepts a dated tombstone from a sender that predates the change', () => {
+    // Old sender -> new receiver: the field is optional now, not removed.
+    const result = JournalSyncPayloadSchema.safeParse({
+      date: '2026-04-16',
+      clock: { 'device-a': 4 },
+      createdAt: '2026-04-16T00:00:00Z',
+      modifiedAt: '2026-04-16T01:00:00Z'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a non-string date', () => {
+    const result = JournalSyncPayloadSchema.safeParse({ date: 20260416 })
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0].path).toContain('date')

--- a/packages/contracts/src/sync-payloads.ts
+++ b/packages/contracts/src/sync-payloads.ts
@@ -181,7 +181,14 @@ export const NoteSyncPayloadSchema = z.object({
 })
 
 export const JournalSyncPayloadSchema = z.object({
-  date: z.string(),
+  // Optional ONLY so a delete tombstone can leave it out — a create/update
+  // without a date is still rejected, by an explicit guard in
+  // journal-handler.applyUpsert rather than by this schema. Deletes never reach
+  // any parser: ItemApplier short-circuits `operation === 'delete'` before it
+  // decodes the body, and SyncItemHandler.applyDelete has no data parameter, so
+  // shipping the journalled day inside a tombstone only widened what every
+  // delete encrypts and uploads. See journal-sync.buildDeletePayload.
+  date: z.string().optional(),
   content: z.string().nullable().optional(),
   tags: z.array(z.string()).optional(),
   properties: z.record(z.string(), z.unknown()).nullable().optional(),


### PR DESCRIPTION
Closes #956

## Problem

Every journal delete uploaded the journalled day inside its tombstone, and nothing on the receiving side has ever read it.

- `ItemApplier.apply` short-circuits `operation === 'delete'` (`apps/desktop/src/main/sync/apply-item.ts:50-61`) and calls `applyDelete(ctx, itemId, clock)`. The `TextDecoder().decode(input.content)` sits below that early return.
- `SyncItemHandler.applyDelete` (`item-handlers/types.ts:22`) has no data parameter that could receive a body.
- `journal-handler.applyDelete` resolves the day from the local row (`existing.journalDate`), never from the payload.

The payloads are encrypted before upload, so this was never a plaintext leak to the server. What it did cost: a field that lives as at-rest ciphertext in R2 forever with zero consumer, and — because `sync_queue.payload` is stored unencrypted (`packages/db-schema/src/schema/sync-queue.ts:10`) — a plaintext record of which day was journalled sitting in the local outbox until the push drained. Journal item ids are note ids, not dates, so the day was genuinely extra information rather than something already recoverable from the id.

Same argument that removed `title` from note tombstones in `5e7871f46`.

## Change

- `journal-sync.buildDeletePayload` now returns `{ clock, createdAt, modifiedAt }`, matching note tombstones. `clock` stays: `PushCoordinator.extractPayloadMetadata` lifts it back out of the payload string to stamp the server-side item version, so dropping it would break delete ordering across devices.
- `JournalSyncPayloadSchema.date` becomes optional, with a comment recording why.
- Because that relaxation would otherwise weaken create/update validation — `date` is load-bearing there, `applyUpsert` writes the file at that day — the rejection moves into `journal-handler.applyUpsert` as an explicit guard. Same outcome as before, with a clearer log line than a generic schema failure.

## Backward compatibility

Both directions are safe, and the field is not removed from the wire contract — only made optional.

- **New sender to old receiver.** No shipped build has ever parsed a delete body. The `operation === 'delete'` short-circuit is present in the very first `ItemApplier` commit (`d52dbf875`) and in every version since, including the pre-monorepo file. The two other places that parse a decrypted body are both unreachable for a delete: the CRDT branches in `pull-coordinator` are guarded by `itemOp !== 'delete'`, and `handleConflict` only runs on a `conflict` result, which `journalHandler.applyDelete` never returns. A missing `date` is therefore unreadable on any receiver, old or new.
- **Old sender to new receiver.** `date` is still accepted; older builds keep sending it and it keeps validating.
- No DB schema change, no migration. Tombstones already queued by an older build still push and apply unchanged.

The issue suggested staging this over two releases (relax the schema, wait for deployment, then stop emitting). The evidence above says that is not required — a receiver that never decodes the body cannot notice the field's absence — so both halves land together, which is also what the issue's own acceptance criteria ask for. Splitting is a one-hunk revert if you want the staged rollout anyway.

## Tests

`pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/sync`

```
Test Files  136 passed (136)
     Tests  1626 passed | 1 expected fail | 3 skipped (1630)
```

`packages/contracts` — `pnpm exec vitest run`

```
Test Files  49 passed (49)
     Tests  1605 passed (1605)
```

`pnpm typecheck` — `Tasks: 16 successful, 16 total`. `pnpm lint` — `0 errors, 10 warnings` (all pre-existing, none in the changed files).

### Mutation checks

Re-adding `date` to the tombstone:

```
× JournalSyncService deletes > propagates a delete as a bumped clock with NO journal date
× JournalSyncService deletes > still propagates the delete when the metadata row is already gone
× JournalSyncService deletes > emits a tombstone the current schema accepts, date key entirely absent
Test Files  1 failed (1)
     Tests  3 failed | 11 passed (14)
```

Restored: `Tests 14 passed (14)`.

Removing the `applyUpsert` date guard:

```
× journalHandler > skips an upsert with no date instead of writing an undefined day
Test Files  1 failed (1)
     Tests  1 failed | 5 passed (6)
```

Restored: full sync suite green as above.

New/updated coverage: tombstone shape and absence of the `date` key (`journal-sync.test.ts`, `content-sync-services.test.ts`), schema accepts both the new dateless tombstone and an old dated one (`sync-payloads.test.ts`), upsert without a date is skipped with no file write, and a delete applies with no body at all (`journal-handler.test.ts`).

## Deliberately out of scope

- `journal-handler.buildPushPayload` and `seedUnclocked` still emit `date` — both are create/update paths where it is required.
- `sync_queue.payload` remains plaintext at rest. Narrowing what goes into it is this change; encrypting the outbox is a separate question.
- No audit of the other item types' tombstones beyond note and journal.
