### PR TITLE
fix(sync): keep the attachment note push when the sync runtime is down

### DIFF
--- a/apps/desktop/src/main/sync/dirty-recovery.test.ts
+++ b/apps/desktop/src/main/sync/dirty-recovery.test.ts
@@ -4,7 +4,9 @@ import { createTestDataDb, asClientDb, type TestDatabaseResult } from '@tests/ut
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
 import { noteMetadata } from '@memry/db-schema/data-schema'
+import { syncDevices } from '@memry/db-schema/schema/sync-devices'
 import type { DataDb } from '../database/client'
+import { incrementNoteClockOffline } from './offline-clock'
 import { SyncQueueManager } from './queue'
 import { initTaskSyncService, resetTaskSyncService } from './task-sync'
 import { initProjectSyncService, resetProjectSyncService } from './project-sync'
@@ -353,6 +355,45 @@ describe('dirty-recovery', () => {
       // #then
       expect(result.notes).toBe(0)
       expect(recovered).toEqual([])
+    })
+
+    it('re-pushes a note whose update was enqueued while the sync service was down', () => {
+      // #given — a note the server has already confirmed, and a registered
+      // device (uploads only happen signed in)
+      db.insert(syncDevices)
+        .values({
+          id: 'device-A',
+          name: 'Test device',
+          platform: 'darwin',
+          appVersion: '1.0.0',
+          linkedAt: new Date('2026-01-01T00:00:00Z'),
+          isCurrentDevice: true,
+          signingPublicKey: 'pk'
+        })
+        .run()
+      insertNote({
+        id: 'note-attachment',
+        clock: { 'device-A': 2 },
+        syncedAt: '2026-01-02T00:00:00Z',
+        modifiedAt: '2026-01-01T00:00:00Z'
+      })
+
+      // The attachment reference write itself never touches modifiedAt, so
+      // without the fallback this note stays invisible to recovery forever.
+      expect(recoverDirtyItems(db, noteAdapters).notes).toBe(0)
+
+      // #when — the upload completes after the runtime was torn down, so the
+      // note adapter's offline fallback is all that runs
+      incrementNoteClockOffline(db, 'note-attachment')
+
+      // #then — the next runtime start pushes it, at a clock the server cannot
+      // dismiss as a replay of what it already has
+      const result = recoverDirtyItems(db, noteAdapters)
+      expect(result.notes).toBe(1)
+      expect(recovered).toEqual(['note-attachment'])
+
+      const row = db.select().from(noteMetadata).where(eq(noteMetadata.id, 'note-attachment')).get()
+      expect(row?.clock).toEqual({ 'device-A': 3 })
     })
   })
 })

--- a/apps/desktop/src/main/sync/local-mutations.test.ts
+++ b/apps/desktop/src/main/sync/local-mutations.test.ts
@@ -79,7 +79,8 @@ vi.mock('./offline-clock', () => ({
   incrementFilterClockOffline: vi.fn(),
   incrementBookmarkClockOffline: vi.fn(),
   incrementReminderClockOffline: vi.fn(),
-  incrementTemplateClockOffline: vi.fn()
+  incrementTemplateClockOffline: vi.fn(),
+  incrementNoteClockOffline: vi.fn()
 }))
 
 import { getDatabase } from '../database'
@@ -94,6 +95,7 @@ import {
   incrementBookmarkClockOffline,
   incrementFilterClockOffline,
   incrementInboxClockOffline,
+  incrementNoteClockOffline,
   incrementProjectClocksOffline,
   incrementReminderClockOffline,
   incrementTaskClocksOffline,
@@ -364,6 +366,28 @@ describe('local-mutations', () => {
     expect(filterService.enqueueDelete).not.toHaveBeenCalled()
     expect(removePendingNoteSyncItems('note-1')).toBe(0)
     expect(() => syncSettingsFieldUpdate('general.locale', 'tr')).not.toThrow()
+  })
+
+  it('falls back to the offline clock bump when the note sync service is down', () => {
+    const db = {}
+    ;(getDatabase as Mock).mockReturnValue(db)
+    ;(getNoteSyncService as Mock).mockReturnValue(null)
+
+    enqueueLocalSyncUpdate('note', 'note-1')
+
+    // Without this the enqueue evaporated: a note update raised during runtime
+    // teardown (an attachment upload finishing, say) was never pushed.
+    expect(incrementNoteClockOffline).toHaveBeenCalledWith(db, 'note-1')
+  })
+
+  it('does not bump the offline clock when the note sync service is up', () => {
+    const noteService = { enqueueUpdate: vi.fn() }
+    ;(getNoteSyncService as Mock).mockReturnValue(noteService)
+
+    enqueueLocalSyncUpdate('note', 'note-1')
+
+    expect(noteService.enqueueUpdate).toHaveBeenCalledWith('note-1')
+    expect(incrementNoteClockOffline).not.toHaveBeenCalled()
   })
 
   it('removes pending note sync items through the local sync helper', () => {

--- a/apps/desktop/src/main/sync/local-mutations.ts
+++ b/apps/desktop/src/main/sync/local-mutations.ts
@@ -8,6 +8,7 @@ import {
   incrementCanvasClockOffline,
   incrementFilterClockOffline,
   incrementInboxClockOffline,
+  incrementNoteClockOffline,
   incrementProjectClocksOffline,
   incrementReminderClockOffline,
   incrementTaskClocksOffline
@@ -264,10 +265,28 @@ const localSyncRegistry = createSyncAdapterRegistry([
     kind: 'crdt',
     local: {
       enqueueCreate(itemId: string): void {
+        // No offline fallback on purpose: a note that has never been pushed has
+        // no clock, and `seedUnclockedNotes` already sweeps those into a create
+        // at the next sync runtime start.
         getNoteSyncService()?.enqueueCreate(itemId)
       },
       enqueueUpdate(itemId: string): void {
-        getNoteSyncService()?.enqueueUpdate(itemId)
+        const service = getNoteSyncService()
+        if (service) {
+          service.enqueueUpdate(itemId)
+          return
+        }
+
+        // Notes used to be the one type whose update simply evaporated when the
+        // sync runtime was down (quit, vault switch, re-auth). It bites hardest
+        // on attachment uploads: the blob is durably queued in the attachment
+        // outbox, but `recordUploadedAttachment`'s note push — the thing that
+        // tells peers a blob exists to download — was fire-and-forget, so an
+        // upload completing during teardown left the image on this device until
+        // some unrelated later edit happened to push the note. Marking the note
+        // dirty hands the push to `recoverDirtyItems`, which re-pushes it at the
+        // next runtime start.
+        incrementNoteClockOffline(getDatabase(), itemId)
       },
       enqueueRecoveredUpdate(itemId: string): void {
         getNoteSyncService()?.enqueueRecoveredUpdate(itemId)

--- a/apps/desktop/src/main/sync/offline-clock.test.ts
+++ b/apps/desktop/src/main/sync/offline-clock.test.ts
@@ -4,9 +4,12 @@ import { createTestDataDb, asClientDb, type TestDatabaseResult } from '@tests/ut
 import { bookmarks } from '@memry/db-schema/schema/bookmarks'
 import { reminders } from '@memry/db-schema/schema/reminders'
 import { templates } from '@memry/db-schema/schema/templates'
+import { noteMetadata } from '@memry/db-schema/data-schema'
+import { syncDevices } from '@memry/db-schema/schema/sync-devices'
 import {
   OFFLINE_DEVICE_KEY,
   incrementBookmarkClockOffline,
+  incrementNoteClockOffline,
   incrementReminderClockOffline,
   incrementTemplateClockOffline
 } from './offline-clock'
@@ -140,6 +143,104 @@ describe('offline clock helpers', () => {
 
       const row = testDb.db.select().from(reminders).where(eq(reminders.id, 'rem-1')).get()
       expect(row?.triggeredAt).toBe('2026-08-03T09:00:01.000Z')
+    })
+  })
+
+  // The note fallback is the only one that bumps under the real device id and
+  // clears `syncedAt` — see the doc comment on the helper for why. What it owes
+  // callers is a row `recoverDirtyItems` will re-push, with a clock the server
+  // cannot dismiss as a replay.
+  describe('incrementNoteClockOffline', () => {
+    const SYNCED_AT = '2026-08-04T10:00:00.000Z'
+
+    const insertNote = (values: Record<string, unknown>): void => {
+      testDb.db
+        .insert(noteMetadata)
+        .values({
+          path: `notes/${values.id as string}.md`,
+          title: 'A note',
+          createdAt: '2026-08-01T00:00:00.000Z',
+          modifiedAt: '2026-08-01T00:00:00.000Z',
+          ...values
+        } as never)
+        .run()
+    }
+
+    const registerDevice = (id: string): void => {
+      testDb.db
+        .insert(syncDevices)
+        .values({
+          id,
+          name: 'Test device',
+          platform: 'darwin',
+          appVersion: '1.0.0',
+          linkedAt: new Date('2026-08-01T00:00:00.000Z'),
+          isCurrentDevice: true,
+          signingPublicKey: 'pk'
+        })
+        .run()
+    }
+
+    const readNote = (id: string): { clock: unknown; syncedAt: string | null } | undefined =>
+      testDb.db.select().from(noteMetadata).where(eq(noteMetadata.id, id)).get()
+
+    it('#given a synced note #then bumps the clock under the current device and clears syncedAt', () => {
+      registerDevice('device-A')
+      insertNote({ id: 'note-1', clock: { 'device-A': 3 }, syncedAt: SYNCED_AT })
+
+      incrementNoteClockOffline(asClientDb(testDb.db), 'note-1')
+
+      const row = readNote('note-1')
+      expect(row?.clock).toEqual({ 'device-A': 4 })
+      expect(row?.syncedAt).toBeNull()
+    })
+
+    it('#then never parks a tick under the offline device key', () => {
+      registerDevice('device-A')
+      insertNote({ id: 'note-1', clock: { 'device-B': 2 }, syncedAt: SYNCED_AT })
+
+      incrementNoteClockOffline(asClientDb(testDb.db), 'note-1')
+
+      // Notes have no rebinding step on the way out, so an `_offline` tick would
+      // reach peers verbatim and collide with theirs.
+      expect(readNote('note-1')?.clock).toEqual({ 'device-B': 2, 'device-A': 1 })
+    })
+
+    it('#given a local-only note #then leaves the row untouched', () => {
+      registerDevice('device-A')
+      insertNote({ id: 'note-1', clock: { 'device-A': 3 }, syncedAt: SYNCED_AT, localOnly: true })
+
+      incrementNoteClockOffline(asClientDb(testDb.db), 'note-1')
+
+      const row = readNote('note-1')
+      expect(row?.clock).toEqual({ 'device-A': 3 })
+      expect(row?.syncedAt).toBe(SYNCED_AT)
+    })
+
+    it('#given a note that was never pushed #then leaves it to the unclocked seed', () => {
+      registerDevice('device-A')
+      insertNote({ id: 'note-1' })
+
+      incrementNoteClockOffline(asClientDb(testDb.db), 'note-1')
+
+      expect(readNote('note-1')?.clock).toBeNull()
+    })
+
+    it('#given no registered device #then leaves the row untouched', () => {
+      insertNote({ id: 'note-1', clock: { 'device-A': 3 }, syncedAt: SYNCED_AT })
+
+      incrementNoteClockOffline(asClientDb(testDb.db), 'note-1')
+
+      const row = readNote('note-1')
+      expect(row?.clock).toEqual({ 'device-A': 3 })
+      expect(row?.syncedAt).toBe(SYNCED_AT)
+    })
+
+    it('#given the note does not exist #then no-ops without throwing', () => {
+      registerDevice('device-A')
+
+      expect(() => incrementNoteClockOffline(asClientDb(testDb.db), 'missing')).not.toThrow()
+      expect(testDb.db.select().from(noteMetadata).all()).toHaveLength(0)
     })
   })
 })

--- a/apps/desktop/src/main/sync/offline-clock.ts
+++ b/apps/desktop/src/main/sync/offline-clock.ts
@@ -1,4 +1,6 @@
 import { eq } from 'drizzle-orm'
+import { noteMetadata } from '@memry/db-schema/data-schema'
+import { syncDevices } from '@memry/db-schema/schema/sync-devices'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
 import { inboxItems } from '@memry/db-schema/schema/inbox'
@@ -229,6 +231,75 @@ export function incrementReminderClockOffline(db: DataDb, reminderId: string): v
     log.debug('Incremented offline reminder clock', { reminderId })
   } catch (err) {
     log.warn('Failed to increment offline reminder clock', { reminderId, error: err })
+  }
+}
+
+function getCurrentDeviceId(db: DataDb): string | null {
+  const device = db
+    .select({ id: syncDevices.id })
+    .from(syncDevices)
+    .where(eq(syncDevices.isCurrentDevice, true))
+    .get()
+  return device?.id ?? null
+}
+
+/**
+ * Offline fallback for note metadata updates — the note counterpart of the
+ * `increment*ClockOffline` helpers above, with two deliberate differences.
+ *
+ * 1. It bumps under the REAL device id, not `OFFLINE_DEVICE_KEY`. The record
+ *    types park ticks under `_offline` because they can be edited with no
+ *    device registered at all, and their sync services rebind those ticks on
+ *    the way out (`recoverPendingChange` in task-sync/project-sync). Notes have
+ *    no such rebinding hook — `ContentSyncService` pushes the stored clock
+ *    verbatim — so an `_offline` tick would reach peers as a device entry two
+ *    machines can both claim, and their clocks would then compare equal for
+ *    edits that are actually concurrent. When no device is registered we do
+ *    nothing, which is exactly what the online path already does (the
+ *    controller drops the enqueue via `handleMissingDevice`).
+ * 2. It clears `syncedAt` so `recoverDirtyItems` re-pushes the note at the next
+ *    sync runtime start. A clock bump alone is invisible to that sweep: its
+ *    dirty test is `modifiedAt > syncedAt`, and metadata-only writes such as
+ *    `recordUploadedAttachment` never touch `modifiedAt` (updateNoteMetadata
+ *    only stamps `storedAt`). `syncedAt = null` is also simply true here — the
+ *    local row now holds state the server has not confirmed.
+ *
+ * The bump itself is load-bearing: the recovered push reuses the stored clock
+ * without advancing it, so re-pushing at the acknowledged clock would be
+ * replay-detected and peers would never see the new metadata.
+ *
+ * Backward compatible: no schema change. `clock` and `syncedAt` are existing
+ * columns, `syncedAt` is already nullable and already means "never confirmed
+ * synced" for notes created offline, and older builds treat such a row exactly
+ * the same way (dirty-recovery is the only reader).
+ */
+export function incrementNoteClockOffline(db: DataDb, noteId: string): void {
+  try {
+    const note = db.select().from(noteMetadata).where(eq(noteMetadata.id, noteId)).get()
+    if (!note) return
+    // The user's "never leaves this device" switch — mirrors `shouldSkip` on
+    // the online path.
+    if (note.localOnly) return
+    // No clock means the note has never been pushed; `seedUnclockedNotes` owns
+    // its first push and would overwrite whatever we set here.
+    if (!note.clock) return
+
+    const deviceId = getCurrentDeviceId(db)
+    if (!deviceId) {
+      log.warn('No current device, skipping offline note clock bump', { noteId })
+      return
+    }
+
+    const nextClock = increment(note.clock, deviceId)
+
+    db.update(noteMetadata)
+      .set({ clock: nextClock, syncedAt: null })
+      .where(eq(noteMetadata.id, noteId))
+      .run()
+
+    log.debug('Incremented offline note clock', { noteId })
+  } catch (err) {
+    log.warn('Failed to increment offline note clock', { noteId, error: err })
   }
 }
 

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -133,6 +133,15 @@ step is then replay-detected by the server, costs one round trip, and is stamped
 that really is ahead of the server changes anything. Scope is limited to items the server already
 knows: clock-less rows belong to the initial seed, and journals to their own handler.
 
+Because recovery never advances a clock, a change made while the sync runtime is down has to advance
+its own at write time or the re-push would be dismissed as a replay. Records park that tick under a
+placeholder device that their sync service rebinds on the way out; notes have no rebinding step, so
+their fallback bumps under the current device directly and does nothing when no device is registered
+(the same thing the online path does). It also clears the sync stamp, because metadata-only writes —
+recording an uploaded attachment, say — deliberately leave `modifiedAt` alone and would otherwise be
+invisible to the "modified after its stamp" test above. A note that never leaves the device, and one
+with no clock yet, are both left alone.
+
 ### Foreign-key parents and orphan repair
 
 Some rows carry foreign keys — a task references its project and its status — and the data DB
@@ -271,7 +280,11 @@ across devices:
   (`attachment_upload_queue`, migration 0039) before the transfer starts and
   cleared only after the server accepts the file. Failed or quit-interrupted
   uploads are retried on every sync runtime start instead of being lost with
-  the in-memory queue.
+  the in-memory queue. Recording the reference enqueues a note push so peers
+  learn the blob exists; if that lands while the runtime is down — an upload
+  finishing during quit, a vault switch, re-auth — the note is marked for
+  [recovery](#recovering-pushes-that-never-landed) instead, so the push happens
+  at the next runtime start rather than waiting for an unrelated later edit.
 
 `attachmentReferences` is the only signal that tells another device a note
 embeds a file — the markdown link alone points at a path that exists nowhere


### PR DESCRIPTION
Closes #958

## The hole

The note adapter in `local-mutations.ts` was the only local-mutation adapter with no fallback: when
`getNoteSyncService()` returned null the enqueue evaporated with no log and no durable trace. Every
record type falls back to an offline clock bump instead.

It bites hardest on attachment uploads, where the two halves of the same operation had very
different durability:

- the **blob** is durably queued (`attachment_upload_queue`, survives restarts, drains at runtime start);
- the **note push** that tells peers the blob exists (`recordUploadedAttachment` → `enqueueLocalSyncUpdate('note', …)`)
  was fire-and-forget.

An upload completing while the runtime is torn down (quit, vault switch, re-auth — including the
outbox drain itself, which is fire-and-forget from runtime start) writes `attachmentReferences` to
the data DB and drops the push. The note syncs, the image does not, and it stays that way until an
unrelated later edit happens to push the note.

## Why nothing compensated

`recoverDirtyItems` re-pushes notes where `modifiedAt > syncedAt` (or `syncedAt IS NULL`), but
`updateNoteMetadata` only stamps `storedAt` — a metadata-only write never touches `modifiedAt`, so
the note stays "clean" and the sweep never sees it. Verified in source, not assumed.

## The fix

`incrementNoteClockOffline` (offline-clock.ts), called from the note adapter's `enqueueUpdate` when
the service is down:

- bumps `note_metadata.clock` under the **current device id**, not `_offline`. Records park ticks
  under `_offline` because they rebind them on the way out (`recoverPendingChange` in
  task-sync/project-sync); notes have no rebinding hook — `ContentSyncService` pushes the stored
  clock verbatim — so an `_offline` tick would reach peers as a device entry two machines can both
  claim, and their clocks would compare equal for edits that are actually concurrent. With no device
  registered it does nothing, exactly what the online path already does via `handleMissingDevice`.
- clears `syncedAt`, which is what makes the note visible to the existing recovery sweep.
- skips local-only notes (the "never leaves this device" switch) and clock-less notes
  (`seedUnclockedNotes` owns their first push).

The bump is load-bearing: recovery re-sends the stored clock without advancing it, so re-pushing at
the acknowledged clock would be replay-detected and peers would never see the new reference. The
push payload is rebuilt at push time by `buildNotePushPayload`, which already reads
`attachmentReferences` from the data DB.

## Backward compatibility

No schema change, no migration, no contract or payload change. `clock` and `syncedAt` are existing
columns; `syncedAt` is already nullable and already means "never confirmed synced" for notes created
offline, and dirty-recovery is its only reader. A row written by this build is indistinguishable to
an older build from a note that was edited while signed out — which is exactly what it is. Nothing
new goes on the wire, so peers on older builds are unaffected.

## Tests

`pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/sync`

```
Test Files  136 passed (136)
     Tests  1632 passed | 1 expected fail | 3 skipped (1636)
```

New coverage:

- `offline-clock.test.ts` — real in-memory data DB: bumps under the current device and clears the
  stamp, never parks a tick under the offline key, skips local-only / clock-less / missing rows, and
  no-ops with no registered device.
- `dirty-recovery.test.ts` — end-to-end over the real DB and the real recovery predicate: a clean,
  server-confirmed note is *not* recovered, the fallback runs, and the next recovery pass re-pushes
  it at an advanced clock.
- `local-mutations.test.ts` — the adapter reaches the fallback when the service is null, and does not
  when it is up.

Mutation check (fix reverted in both halves — the adapter fallback and the `syncedAt` clear):

```
Tests  3 failed | 54 passed (57)
 FAIL  dirty-recovery.test.ts > notes > re-pushes a note whose update was enqueued while the sync service was down
 FAIL  local-mutations.test.ts > falls back to the offline clock bump when the note sync service is down
 FAIL  offline-clock.test.ts > incrementNoteClockOffline > #given a synced note #then bumps the clock under the current device and clears syncedAt
```

Restored:

```
Test Files  4 passed (4)
     Tests  76 passed | 1 expected fail (77)
```

`pnpm typecheck` green. `pnpm lint` 0 errors (11 pre-existing warnings, none in the changed files).
`docs:impact --strict` covered, `docs:build` green.

## Deliberately out of scope

- **`enqueueCreate` / `enqueueDelete` on notes** keep the no-op. A note that has never been pushed
  has no clock, and `seedUnclockedNotes` already sweeps those into a create at the next runtime start.
- **Journals.** The journal adapter has the same shape, but journal rows are excluded from
  `recoverDirtyNotes` (`journalDate IS NULL`), so this fix does not reach them and giving them one is
  a separate decision about journal recovery.
- **The `it.fails` pin in `note-attachment-metadata.test.ts:230`** (orphaned index row when the data
  write misses). Untouched — it is a question about index-rebuild reconciliation, not about this
  push being lost.
- **Direction (2) from the issue** (outbox drain re-enqueues a push per cleared row). It does not
  cover the reported scenario: a successful upload clears its own row, so by the time the push is
  dropped there is no row left to drive it. Making it cover that would mean keeping the row past a
  successful upload behind a new "uploaded, push pending" flag — a schema change — and risking a
  re-upload of the blob.
