### PR TITLE
sync: honour shouldSkip on delete so local-only rows are never tombstoned

### DIFF
--- a/apps/desktop/src/main/sync/content-sync-base.ts
+++ b/apps/desktop/src/main/sync/content-sync-base.ts
@@ -12,8 +12,9 @@ export interface ContentSyncDeps {
 }
 
 /**
- * Single reading of the "never leaves this device" flag, shared by the snapshot
- * path and the delete path so the two can never drift apart again.
+ * Single reading of the "never leaves this device" flag. Handed to the
+ * controller as `shouldSkip`, which applies it to the snapshot path and the
+ * delete path alike, so the two can never drift apart again.
  */
 function isLocalOnly(local: NoteMetadata | undefined): boolean {
   return Boolean(local?.localOnly)
@@ -93,22 +94,16 @@ export abstract class ContentSyncService<
         this.buildSnapshotPayload(local, (local.clock as VectorClock) ?? {}, operation, ...extra),
       shouldSkip: (local) => isLocalOnly(local),
       buildDeletePayload: ({ local, deviceId, extra }) => {
-        // `localOnly` is the user's "this never leaves my device" switch, and
-        // RecordSyncController wires `shouldSkip` into the create/update path
-        // ONLY — its `enqueueDelete` never consults it. Without re-applying the
-        // guard here, deleting a local-only row queues a tombstone that is
-        // encrypted, uploaded to the server and fanned out to every other
-        // device in the vault. Returning null makes the controller drop the
-        // enqueue before it ever reaches the queue.
+        // No `localOnly` check here on purpose: RecordSyncController.enqueueDelete
+        // applies `shouldSkip` above, so a local-only row never reaches this
+        // builder. Both subclasses are covered — notes and journals load their
+        // row via getNoteMetadataById, so both read the same `localOnly` column.
         //
-        // This covers every subclass (notes and journals both load their row
-        // via getNoteMetadataById, so both carry the same `localOnly` column).
-        //
-        // When `local` is undefined the row is already gone and we cannot tell
-        // whether it was local-only, so the pre-existing behaviour stands and
-        // the subclass decides (NoteSyncService returns null in that case).
-        if (isLocalOnly(local)) return null
-
+        // The controller's guard works for us because deletes are enqueued
+        // BEFORE the row is removed (see deleteNoteCommand in notes/domain.ts,
+        // which enqueues first precisely so the clock is still readable). If
+        // that order is ever flipped, `load` starts returning undefined and the
+        // guard goes silently dead — re-read the note on enqueueDelete first.
         const nextClock = incrementClock((local?.clock as VectorClock) ?? {}, deviceId)
         const payload = this.buildDeletePayload(local, nextClock, ...extra)
         return payload === null ? null : JSON.stringify(payload)

--- a/apps/desktop/src/main/sync/inbox-sync.test.ts
+++ b/apps/desktop/src/main/sync/inbox-sync.test.ts
@@ -5,6 +5,7 @@ import {
   asSyncDb,
   type TestDatabaseResult
 } from '@tests/utils/test-db'
+import { eq } from 'drizzle-orm'
 import { inboxItems } from '@memry/db-schema/schema/inbox'
 import type { VectorClock } from '@memry/contracts/sync-api'
 import { SyncQueueManager } from './queue'
@@ -133,6 +134,32 @@ describe('InboxSyncService', () => {
       const payload = JSON.parse(item.payload)
       expect(payload).toMatchObject(TEST_INBOX_ITEM)
       expect(payload.clock).toEqual({ 'device-A': 1 })
+    })
+  })
+
+  describe('#given a localOnly inbox item #when enqueueDelete called', () => {
+    it('#then no tombstone leaves the device', () => {
+      // Mirrors handleDeletePermanent (inbox/crud.ts), which snapshots the row,
+      // DELETES it, and only then enqueues. The row is deliberately NOT seeded:
+      // seeding it would test a state production never reaches and would go
+      // green off the controller's row guard instead of the snapshot guard that
+      // is the only thing actually running here.
+      expect(
+        testDb.db.select().from(inboxItems).where(eq(inboxItems.id, 'inbox-1')).get()
+      ).toBeUndefined()
+
+      service.enqueueDelete('inbox-1', JSON.stringify({ ...TEST_INBOX_ITEM, localOnly: true }))
+
+      expect(queue.getPendingCount()).toBe(0)
+    })
+
+    it('#then an unparseable snapshot still tombstones instead of swallowing the delete', () => {
+      // Older builds wrote this payload too. A snapshot we cannot read tells us
+      // nothing about localOnly, and dropping the delete would strand the item
+      // on every other device — the worse of the two failure modes.
+      service.enqueueDelete('inbox-1', 'not json')
+
+      expect(queue.getPendingCount()).toBe(1)
     })
   })
 

--- a/apps/desktop/src/main/sync/inbox-sync.ts
+++ b/apps/desktop/src/main/sync/inbox-sync.ts
@@ -14,6 +14,31 @@ interface InboxSyncDeps {
   getDeviceId: () => string | null
 }
 
+/** Single reading of the "never leaves this device" flag for a loaded row. */
+function isLocalOnly(local: Record<string, unknown>): boolean {
+  return Boolean(local.localOnly)
+}
+
+/**
+ * Same flag, read off a serialized snapshot instead of a live row — the only
+ * option on the delete path, where the row is already gone. Column name is
+ * `local_only` in SQL but the snapshot is a stringified Drizzle row, so the
+ * mapped `localOnly` property is what lands in the JSON.
+ */
+function isLocalOnlySnapshot(snapshot: string): boolean {
+  try {
+    const parsed = JSON.parse(snapshot) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false
+    return Boolean((parsed as { localOnly?: unknown }).localOnly)
+  } catch {
+    // An unparseable snapshot tells us nothing about localOnly. Fall through to
+    // the normal tombstone rather than swallowing a legitimate delete — older
+    // builds wrote this payload too, and dropping their deletes would strand
+    // the item on every other device.
+    return false
+  }
+}
+
 let instance: InboxSyncService | null = null
 
 export function initInboxSyncService(deps: InboxSyncDeps): InboxSyncService {
@@ -50,8 +75,21 @@ export class InboxSyncService {
         return { ...local, clock: newClock }
       },
       serialize: (local) => local,
-      shouldSkip: (local) => Boolean(local.localOnly),
-      buildDeletePayload: ({ extra, deviceId }) => withIncrementedClock(extra[0], deviceId)
+      shouldSkip: isLocalOnly,
+      buildDeletePayload: ({ extra, deviceId }) => {
+        // Second home for the localOnly guard, and inbox genuinely needs it.
+        // RecordSyncController.enqueueDelete applies `shouldSkip` to the row it
+        // loads, but handleDeletePermanent (inbox/crud.ts) snapshots the row,
+        // DELETES it, and only then enqueues — so by the time the controller
+        // runs, `load` returns undefined and its guard cannot fire on this path.
+        //
+        // The snapshot we are handed is the row's last known state, which makes
+        // it the only thing left that still knows whether the user marked this
+        // item as never leaving the device.
+        if (isLocalOnlySnapshot(extra[0])) return null
+
+        return withIncrementedClock(extra[0], deviceId)
+      }
     })
   }
 

--- a/apps/docs/src/architecture/sync-handlers.md
+++ b/apps/docs/src/architecture/sync-handlers.md
@@ -167,6 +167,41 @@ Insert branches need the same audit for a different reason: they simply omitted 
 an item archived on one device arrived un-archived on a device seeing it for the first time. If a
 column round-trips through `buildPushPayload`, it has to be written on **both** branches.
 
+## Local-Only Rows Must Not Be Tombstoned
+
+`shouldSkip` on `RecordSyncController` is the "this row never leaves my device" switch, and it has to
+hold on delete as well as on create/update. A tombstone carries no body, but the item's id and its
+deletion time still get encrypted, uploaded and fanned out to every other device in the vault.
+
+`enqueueDelete` applies it (`packages/sync-core/src/record-sync.ts`), so a service that passes a
+`shouldSkip` gets the guard on every path without a second copy inside `buildDeletePayload`.
+
+The guard has one hard limit: it reads the row `load` returns, so it can only fire while that row
+still exists.
+
+```ts
+const local = this.deps.load(itemId)
+if (local !== undefined && this.deps.shouldSkip?.(local)) return
+```
+
+When `load` returns `undefined` the row is already gone and its local-only-ness is unknowable, so the
+delete is let through deliberately. Refusing there would swallow legitimate tombstones for ordinary
+rows — data loss in the opposite direction, and the item would be stranded on every other device.
+
+That splits the record services in two by delete ordering:
+
+- **Enqueue, then delete** — notes and journals. `deleteNoteCommand` (`main/notes/domain.ts`)
+  enqueues first precisely so the clock is still readable, so `load` still sees the row and the
+  controller guard covers them. Flipping that order would kill the guard silently.
+- **Delete, then enqueue** — inbox. `handleDeletePermanent` (`main/inbox/crud.ts`) snapshots the row,
+  deletes it, and only then enqueues, so `load` returns `undefined` on that path every time. The
+  controller guard can never fire there, so `inbox-sync.ts` guards on the snapshot it is handed —
+  the last thing that still knows the flag.
+
+A service in the second shape has to carry its own guard. An unparseable snapshot falls through to
+the normal tombstone rather than dropping the delete, so payloads written by older builds keep
+working.
+
 ## Missing Parents
 
 An FK-bound child whose parent has not arrived yet must throw `MissingSyncParentError` from inside

--- a/packages/sync-core/src/record-sync.test.ts
+++ b/packages/sync-core/src/record-sync.test.ts
@@ -59,6 +59,50 @@ describe('RecordSyncController', () => {
     expect(handleMissingDevice).toHaveBeenCalledWith('task-1', 'update', [['statusId']])
     expect(queue.enqueue).not.toHaveBeenCalled()
   })
+
+  it('does not tombstone a row shouldSkip rejects', () => {
+    const queue = { enqueue: vi.fn() }
+
+    const controller = new RecordSyncController({
+      type: 'task',
+      queue,
+      getDeviceId: () => 'device-A',
+      load: () => ({ id: 'task-1', title: 'Hello', localOnly: true }),
+      applyLocalChange: ({ local }) => local,
+      serialize: (local) => local,
+      shouldSkip: (local) => Boolean(local.localOnly),
+      buildDeletePayload: () => JSON.stringify({ tombstone: true })
+    })
+
+    controller.enqueueDelete('task-1')
+
+    expect(queue.enqueue).not.toHaveBeenCalled()
+  })
+
+  it('still tombstones an already-removed row, whose local-only-ness is unknowable', () => {
+    // Deliberate asymmetry: with the row gone there is nothing left to read the
+    // flag off, and refusing to enqueue would silently swallow legitimate
+    // deletes for ordinary rows. `shouldSkip` here would reject everything —
+    // it simply never gets a row to reject.
+    const queue = { enqueue: vi.fn() }
+    const buildDeletePayload = vi.fn(() => JSON.stringify({ tombstone: true }))
+
+    const controller = new RecordSyncController<{ id: string; localOnly?: boolean }, [], []>({
+      type: 'task',
+      queue,
+      getDeviceId: () => 'device-A',
+      load: () => undefined,
+      applyLocalChange: ({ local }) => local,
+      serialize: (local) => local,
+      shouldSkip: () => true,
+      buildDeletePayload
+    })
+
+    controller.enqueueDelete('task-1')
+
+    expect(buildDeletePayload).toHaveBeenCalledWith(expect.objectContaining({ local: undefined }))
+    expect(queue.enqueue).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('withIncrementedClock', () => {

--- a/packages/sync-core/src/record-sync.ts
+++ b/packages/sync-core/src/record-sync.ts
@@ -55,9 +55,26 @@ export class RecordSyncController<
     const deviceId = this.deps.getDeviceId()
     if (!deviceId || !this.deps.buildDeletePayload) return
 
+    // `shouldSkip` is the "this row never leaves the device" switch, and it has
+    // to hold on delete too. A tombstone carries no body, but the item's id and
+    // its deletion time still get encrypted, uploaded, and fanned out to every
+    // other device in the vault.
+    //
+    // LIMIT OF THIS GUARD — it can only fire while the row outlives the
+    // enqueue. When `load` returns undefined the row is already gone and its
+    // local-only-ness is unknowable, so the delete is let through on purpose:
+    // dropping it here would silently swallow legitimate tombstones for
+    // ordinary rows, which is a data-loss bug in the opposite direction.
+    //
+    // So a caller that deletes its row BEFORE it enqueues has to carry its own
+    // guard over whatever snapshot it passes in — this one never sees its row.
+    // `inbox-sync.ts` is exactly that shape and guards on its snapshot.
+    const local = this.deps.load(itemId)
+    if (local !== undefined && this.deps.shouldSkip?.(local)) return
+
     const payload = this.deps.buildDeletePayload({
       itemId,
-      local: this.deps.load(itemId),
+      local,
       deviceId,
       extra
     })


### PR DESCRIPTION
Closes #954

## The problem

`RecordSyncController` wired `shouldSkip` into the create/update path only (`enqueueMutation`, `buildSerializedPayload`), never into `enqueueDelete`. `shouldSkip` is how a service expresses "this row never leaves the device", so the guard was enforced on every path except delete.

A tombstone carries no user text, but the item's id and its deletion time still get encrypted, uploaded, and fanned out to every other device in the vault.

## What this changes

**1. The invariant moves into the controller.** `enqueueDelete` now loads the row once and gates on `shouldSkip` before building a payload. `content-sync-base.ts` had been re-applying the guard by hand inside its `buildDeletePayload` wrapper; that copy is gone, so the invariant has one home and every future service that passes a `shouldSkip` gets the delete path for free.

**2. Inbox gets a snapshot guard, because the controller guard cannot reach it.** This is the part the issue's suggested direction would have missed. `handleDeletePermanent` (`main/inbox/crud.ts:238-240`) snapshots the row, **deletes it**, and only then enqueues:

```ts
const snapshot = JSON.stringify(existing)
db.delete(inboxItems).where(eq(inboxItems.id, id)).run()   // row is gone here
syncInboxDelete(id, snapshot)                              // ...then we enqueue
```

So `load(itemId)` returns `undefined` and the controller's guard can never fire on that path. Notes and journals are the opposite ordering and it is deliberate — `deleteNoteCommand` enqueues first precisely so the clock is still readable — which is why the controller guard does cover them. Inbox instead guards on the snapshot it is handed, the last thing that still knows the flag.

Verified by audit that these are the only two services affected: repo-wide, exactly two call sites pass a `shouldSkip` (`content-sync-base.ts`, `inbox-sync.ts`). The other ~14 record services pass none and are untouched.

## The `local === undefined` decision

Let through, deliberately. With the row gone its local-only-ness is unknowable, and refusing to enqueue would silently swallow legitimate tombstones for ordinary rows — data loss in the opposite direction, and worse, since the item would be stranded on every other device. Tested explicitly rather than left implicit.

## Backward compatibility

No schema, contract, or payload-shape change — this only ever suppresses an enqueue that should not have happened.

The one compat risk is the inbox snapshot parse, handled explicitly: an unparseable snapshot returns `false` and falls through to the normal tombstone, so deletes written by older builds are never dropped. The column is read via the Drizzle-mapped `localOnly` property, which is what a stringified row actually contains (`local_only` is the SQL name only).

Worth noting the inbox hole was **latent, not a live leak**: `localOnly` is exposed in contracts on the notes API only, so there is no way to mark an inbox item today. This closes it before inbox gains a toggle. Notes and journals were already covered by the hand-written guard, so no shipped path was leaking.

## Tests

Mutation-checked both guards independently — removed each fix, confirmed red, restored, confirmed green.

Controller guard removed:
```
 × ../../packages/sync-core/src/record-sync.test.ts > RecordSyncController > does not tombstone a row shouldSkip rejects
      Tests  1 failed | 4 passed (5)
 × src/main/sync/content-sync-base.test.ts > #given a delete #when enqueueDelete > #then a local-only row is NOT tombstoned to the server
      Tests  1 failed | 19 passed (20)
```

Inbox snapshot guard removed:
```
 × src/main/sync/inbox-sync.test.ts > #given a localOnly inbox item #when enqueueDelete called > #then no tombstone leaves the device
      Tests  1 failed | 11 passed (12)
```

Restored:
```
 Test Files  136 passed (136)          # --project main src/main/sync
      Tests  1550 passed | 1 expected fail | 3 skipped (1554)
 Test Files  2 passed (2)              # --project shared packages/sync-core
      Tests  6 passed (6)
```

The inbox test deliberately does **not** seed the row — seeding it would test a state production never reaches and would go green off the controller's row guard rather than the snapshot guard that actually runs. `pnpm typecheck` 16/16, `pnpm lint` 0 errors, `pnpm docs:build` clean.

## Deliberately out of scope

**Reordering inbox to enqueue-before-delete.** It would let the controller guard cover inbox too and give the invariant a single home outright, but `handleDeletePermanent` does attachment and tag cleanup before the snapshot is taken, and reordering that on a live delete path is not worth the risk for a latent hole. The asymmetry is documented in code at both ends and in `apps/docs/src/architecture/sync-handlers.md` instead, including the warning that flipping the note ordering would kill the controller guard silently.
