### PR TITLE
sync: keep the newest queue row when coalescing a push batch

### DIFF
--- a/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
@@ -464,6 +464,65 @@ describe('PushCoordinator', () => {
       expect(body.items[0].encryptedData).toBe(v2)
       expect(queue.getSize()).toBe(0)
     })
+
+    // `buildPushPayload` is optional on SyncItemHandler and `settings` omits it,
+    // so nothing rebuilds the payload from local state — the frozen queue
+    // payload is what goes over the wire. The retained row therefore has to be
+    // the newer one, or the newer edit is deleted via the success path having
+    // never been pushed (#953).
+    it('#then the newer payload is pushed even when the handler cannot rebuild it', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      acceptAll()
+      getHandlerMock.mockReturnValue({ markPushSynced: vi.fn() })
+
+      const v1 = JSON.stringify({ general: { theme: 'light' } })
+      const v2 = JSON.stringify({ general: { theme: 'dark' } })
+      queue.enqueue({
+        type: 'settings',
+        itemId: 'synced_settings',
+        operation: 'update',
+        payload: v1
+      })
+      queue.markFailed(queue.peek()[0].id, 'transient')
+      queue.enqueue({
+        type: 'settings',
+        itemId: 'synced_settings',
+        operation: 'update',
+        payload: v2
+      })
+      expect(queue.getSize()).toBe(2)
+
+      await coordinator.push()
+
+      expect(postToServerMock).toHaveBeenCalledTimes(1)
+      const body = postToServerMock.mock.calls[0][1] as PushBody
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0].encryptedData).toBe(v2)
+      expect(queue.getSize()).toBe(0)
+    })
+
+    // Keeping the newest row must not silently downgrade the operation: the
+    // create was never acked, so an `update` for an id the server has never
+    // seen is not an equivalent request. Same precedence enqueue() applies.
+    it('#then an unacked create survives a newer update row', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      acceptAll()
+      getHandlerMock.mockReturnValue({ markPushSynced: vi.fn() })
+
+      const v1 = JSON.stringify({ title: 'first' })
+      const v2 = JSON.stringify({ title: 'second' })
+      queue.enqueue({ type: 'task', itemId: 'task-2', operation: 'create', payload: v1 })
+      queue.markFailed(queue.peek()[0].id, 'transient')
+      queue.enqueue({ type: 'task', itemId: 'task-2', operation: 'update', payload: v2 })
+
+      await coordinator.push()
+
+      const body = postToServerMock.mock.calls[0][1] as PushBody
+      expect(body.items).toHaveLength(1)
+      expect(body.items[0].operation).toBe('create')
+      expect(body.items[0].encryptedData).toBe(v2)
+      expect(queue.getSize()).toBe(0)
+    })
   })
 
   describe('#given sync is paused #when requestPush is called', () => {

--- a/apps/desktop/src/main/sync/engine/push-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.ts
@@ -5,6 +5,7 @@ import type { PushResponse, SyncItemType } from '@memry/contracts/sync-api'
 import { secureCleanup } from '../../crypto/index'
 import { encryptPushBatch } from '../sync-crypto-batch'
 import { getHandler, getRemoteSyncAdapter } from '../item-handlers'
+import { coalesceSyncOperations } from '../queue'
 import { withRetry } from '../retry'
 import { engineAuthRetryDeps, withAuthRetry } from '../auth-retry'
 import { postToServer, RateLimitError } from '../http-client'
@@ -353,25 +354,48 @@ export class PushCoordinator {
     }
   }
 
+  /**
+   * Collapse rows that `enqueue` could not coalesce — it only folds into an
+   * `attempts = 0` row, so a failed push leaves the next edit to open a second
+   * row for the same `(type, itemId)`.
+   *
+   * The retained row must be the NEWEST one. `dequeue` orders
+   * `desc(priority), asc(createdAt)`, so at equal priority the batch arrives
+   * oldest-first; keeping the first row seen would keep the stale payload.
+   * That only looked harmless because `resolvePushPayload` rebuilds from the
+   * DB via the OPTIONAL `handler.buildPushPayload` — for a type without it
+   * (`settings`) the frozen payload is all the push has, so the older row
+   * pushed the older state and the newer edit was deleted unpushed (#953).
+   * Keeping the newest row also keeps the row that live mutations coalesce
+   * into (`attempts = 0`), so the payload-conditional ack still guards it.
+   */
   private deduplicateByItemId(
     items: Array<typeof import('@memry/db-schema/schema/sync-queue').syncQueue.$inferSelect>
   ): typeof items {
     const seen = new Map<string, (typeof items)[0]>()
-    const dupes: Array<{ id: string; payload: string }> = []
+    const superseded: Array<{ id: string; payload: string }> = []
 
     for (const item of items) {
       const key = `${item.type}:${item.itemId}`
-      if (!seen.has(key)) {
+      const older = seen.get(key)
+      if (!older) {
         seen.set(key, item)
-      } else {
-        dupes.push({ id: item.id, payload: item.payload })
+        continue
       }
+      // Fold the operation with the same precedence `enqueue` uses, or a
+      // create that was never acked would be downgraded to the newer row's
+      // update and pushed for an id the server has never seen.
+      seen.set(key, {
+        ...item,
+        operation: coalesceSyncOperations(older.operation, item.operation)
+      })
+      superseded.push({ id: older.id, payload: older.payload })
     }
 
-    if (dupes.length > 0) {
-      log.info('Push: deduplicated queue items', { removed: dupes.length })
-      for (const dupe of dupes) {
-        this.ctx.deps.queue.markSuccess(dupe.id, dupe.payload)
+    if (superseded.length > 0) {
+      log.info('Push: dropped superseded queue rows', { removed: superseded.length })
+      for (const row of superseded) {
+        this.ctx.deps.queue.markSuccess(row.id, row.payload)
       }
     }
 

--- a/apps/desktop/src/main/sync/queue.ts
+++ b/apps/desktop/src/main/sync/queue.ts
@@ -26,6 +26,23 @@ export interface QueueStats {
   total: number
 }
 
+/**
+ * Fold two mutations for the same item into the single operation that has to
+ * reach the server. A later delete wins outright; otherwise an unacked create
+ * survives, because the server has never seen the item and an `update` for an
+ * id it does not know is not the same request.
+ *
+ * Exported because two call sites collapse rows for the same `(type, itemId)`:
+ * `enqueue` (into an `attempts = 0` row) and the push coordinator's batch
+ * dedupe (rows that could not coalesce because the older one had already
+ * failed). They must agree, or the precedence depends on which path ran.
+ */
+export function coalesceSyncOperations(existing: string, incoming: string): string {
+  if (incoming === 'delete') return 'delete'
+  if (existing === 'create' || incoming === 'create') return 'create'
+  return incoming
+}
+
 export class SyncQueueManager {
   constructor(private readonly db: DataDb) {}
 
@@ -50,12 +67,7 @@ export class SyncQueueManager {
         .get()
 
       if (existing) {
-        const coalescedOp =
-          operation === 'delete'
-            ? 'delete'
-            : existing.operation === 'create' || operation === 'create'
-              ? 'create'
-              : operation
+        const coalescedOp = coalesceSyncOperations(existing.operation, operation)
         tx.update(syncQueue)
           .set({ payload, priority, operation: coalescedOp })
           .where(eq(syncQueue.id, existing.id))

--- a/apps/docs/src/architecture/sync-handlers.md
+++ b/apps/docs/src/architecture/sync-handlers.md
@@ -48,6 +48,19 @@ For tasks, projects, and agent conversations, handlers additionally invoke `merg
 Agent message sync is append-only. If a message id already exists locally, the handler treats the
 remote item as idempotent instead of overwriting a terminal message.
 
+## `buildPushPayload` is optional
+
+`buildPushPayload` rebuilds the outgoing payload from local state at push time, so the newest local
+state goes out even when the queued row was frozen earlier. It is optional on the interface, and
+`BaseItemHandler` supplies no default. Every handler backed by a sync table implements it; `settings`
+does not, because settings live in `config.json` and the preferences cache rather than in a table
+there is anything to rebuild from.
+
+A type without it pushes the frozen queue payload verbatim, so queue bookkeeping alone has to be
+correct for it — see
+[Push acknowledgements and in-flight mutations](/architecture/sync-protocol#push-acknowledgements-and-in-flight-mutations).
+When adding a handler, implement it unless the type genuinely has no local row to read back.
+
 ## Canvas: the payload comes from a file
 
 `canvas-handler.ts` is the one handler whose content does not live in the data DB. A canvas scene

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -122,6 +122,25 @@ queued and goes out on the next iteration. Deleting unconditionally would drop t
 permanently, because the local clock advances at mutation time: the item would sit ahead of the
 server with nothing queued, and every later pull would resolve `skip` rather than repair it.
 
+Enqueue-time coalescing only folds into a row that has **not** been attempted yet, so a failed or
+rejected push leaves the next edit to open a second row for the same `(type, itemId)`. Both rows can
+then land in one batch, and the push collapses them again before encrypting. That batch-level
+collapse keeps the **newest** row: the batch arrives oldest-first, and the older row's payload is by
+definition the stale one. Keeping the newest row also keeps the row that is still unattempted, which
+is the row a concurrent local edit would coalesce into — so the conditional acknowledgement above
+continues to guard it.
+
+The superseded row's operation is folded into the retained row with the same precedence enqueue
+uses: a later delete wins outright, and an unacked create survives a newer update, because the server
+has never seen the item and an update for an unknown id is not an equivalent request.
+
+Collapsing to the newest row matters on its own terms rather than as an optimisation. The pushed
+payload is normally rebuilt from local state at push time, but that rebuild hook is optional on the
+handler interface and settings does not implement it — settings live in `config.json` and the
+preferences cache, not in a sync table there is anything to rebuild from. For any such type the
+frozen queue payload is the entire push, so retaining the older row published older state and
+discarded the newer edit through the success path, with no error surfaced.
+
 ### Recovering pushes that never landed
 
 Items expose a "the server has this state" stamp (`syncedAt`) that advances on a confirmed push as


### PR DESCRIPTION
Closes #953

## Problem

`deduplicateByItemId` kept the **first** row it saw for a `(type, itemId)`, and `dequeue` orders `desc(priority), asc(createdAt)` — so at equal priority the batch arrives oldest-first and the retained row was the **oldest**. The newer row was dropped via `queue.markSuccess`, i.e. the success path, having never been pushed.

That only looked harmless because `resolvePushPayload` rebuilds the payload from the DB via `handler.buildPushPayload` — which is **optional** on `SyncItemHandler`, and `BaseItemHandler` supplies no default. Verified against the tree: `settings-handler.ts` and `base-handler.ts` are the only two files under `item-handlers/` with no `buildPushPayload`, and the remote adapter is derived from the handler (`toRemoteSyncAdapter`), so there is no second source for it either.

For `settings` the frozen queue payload is therefore the entire push: the older payload went to the server, the newer settings edit was deleted, and no error surfaced.

The window is reachable. `enqueue` coalesces only into an `attempts = 0` row, so any failed or rejected push (`markFailed`) lets the next edit open a second row; all settings changes share the singleton `itemId` `synced_settings`. Two settings changes around one transient push failure and the second silently reverts, locally and across devices.

## Fix

Direction **(A)** from the issue — `deduplicateByItemId` retains the newest row — rather than **(B)** (give `settings-handler` a `buildPushPayload`).

Rationale:

- (A) fixes the class of defect. (B) closes one instance and leaves the trap armed for the next handler that omits an optional method; nothing would fail.
- (A) is correct on the dedupe's own terms. Its job is to collapse rows for one item into the one that should go out; the older payload is stale by definition. Depending on a *different* subsystem to undo a wrong choice is what hid this.
- The retained row is also the better row to keep for the in-flight guard: the newest row is the `attempts = 0` row, which is exactly the row a concurrent local edit coalesces into. Retaining the older (`attempts > 0`) row meant a mutation landing mid-flight coalesced into a row that had already been deleted — a second loss vector, closed by the same change.
- (B) was not added on top: settings have no sync table to rebuild from (`fetchLocal` returns `undefined`, state lives in `config.json` + the prefs cache), so it would introduce a second source of truth for the settings payload to serve a path that no longer needs it.

`markSuccess(older.id, older.payload)` keeps the payload-conditional delete. The older row has `attempts > 0`, so `enqueue` cannot coalesce into it and its payload cannot change under us; the guard costs nothing and stays consistent with every other delete on this path.

### Operation coalescing

Open question 1 in the issue flagged that a raw newest-wins dedupe would not replicate `enqueue`'s create/delete precedence. It does not, and it matters: `create` → failure → `update` would have pushed `update` for an id the server has never seen, and would also have skipped the CRDT snapshot push (gated on `operation === 'create'`).

So the superseded row's operation is folded into the retained row using the same precedence, extracted from `enqueue` as `coalesceSyncOperations` in `queue.ts` so both collapse paths cannot drift. The extraction is behaviour-preserving — the existing `queue.test.ts` coalescing tests pass untouched.

## Backward compatibility

No schema, contract, protocol or payload-format change. `sync_queue` rows written by older versions are read exactly as before; the change is which in-memory row a batch retains and which row is deleted. Both rows were already going to be collapsed — this picks the correct one. A client on the old code and one on the new code interoperate; nothing about the wire format moves.

## Tests

Two new tests in `push-coordinator.test.ts`, both under `#given two queue rows for the same item in one batch`:

- `#then the newer payload is pushed even when the handler cannot rebuild it` — drives the real loss through a handler with **no** `buildPushPayload`, asserting the payload that reaches the server, not the dedupe order.
- `#then an unacked create survives a newer update row` — pins the operation precedence.

Mutation check (fix reverted to keep the first row):

```
 × #then the newer payload is pushed even when the handler cannot rebuild it
   → expected '{"general":{"theme":"light"}}' to be '{"general":{"theme":"dark"}}'
 × #then an unacked create survives a newer update row
   → expected '{"title":"first"}' to be '{"title":"second"}'
 Tests  2 failed | 12 passed (14)
```

The failures are the older payload arriving at the server — the defect itself, not an ordering assertion. Note the pre-existing test `#then only one is pushed and the pushed payload is rebuilt fresh from local state` stayed **green** with the bug present, exactly as the issue predicted: it mocks a handler that does implement `buildPushPayload`.

Fix restored:

```
 Test Files  136 passed (136)
      Tests  1631 passed | 1 expected fail | 3 skipped (1635)
```

(`pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/sync`)

`pnpm typecheck` 16/16 successful. `pnpm lint` 0 errors (10 pre-existing warnings, all renderer files untouched here). `pnpm docs:impact --strict` covered, `pnpm docs:build` complete.

## Out of scope

- **Making `buildPushPayload` required** (open question 2). It is now a freshness optimisation rather than a correctness dependency, so forcing it onto types where rebuilding is meaningless buys less than it costs. Documented in `sync-handlers.md` instead.
- **A distinct queue method for dropping a superseded row** (open question 4). `markSuccess` is the only payload-guarded delete and the guard is load-bearing; splitting it is a separate change. The log line now reads `Push: dropped superseded queue rows` so the intent is at least legible in logs.
- The retry-budget behaviour that drives `attempts` above zero, tracked separately.
