### PR TITLE
sync: latch the crypto worker bridge off after repeated failures

### DIFF
--- a/apps/desktop/src/main/sync/sync-crypto-batch.test.ts
+++ b/apps/desktop/src/main/sync/sync-crypto-batch.test.ts
@@ -287,6 +287,37 @@ describe('sync crypto batch', () => {
     )
   })
 
+  // A bridge that has latched itself off reports isRunning false. These two pin
+  // the other half of that contract: a false gate must take the main-thread path
+  // outright, never paying a worker round trip to rediscover it is broken.
+  it('encrypts on the main thread without a worker request when the bridge is not running', async () => {
+    const workerBridge = { isRunning: false, encryptBatch: vi.fn() }
+
+    const result = await encryptPushBatch([queueRow], vaultKey, signingSecretKey, 'device-1', {
+      workerBridge: workerBridge as never,
+      queue: { markFailed: mocks.markFailed } as never,
+      extractPayloadMetadata: () => ({}),
+      resolvePushPayload: (item) => item.payload
+    })
+
+    expect(workerBridge.encryptBatch).not.toHaveBeenCalled()
+    expect(mocks.encryptItemForPush).toHaveBeenCalledTimes(1)
+    expect(result).toEqual([{ queueId: 'queue-1', pushItem: { encrypted: true } }])
+  })
+
+  it('decrypts on the main thread without a worker request when the bridge is not running', async () => {
+    const workerBridge = { isRunning: false, decryptBatch: vi.fn() }
+
+    const result = await decryptPullBatch([pullItem] as never, vaultKey, {
+      workerBridge: workerBridge as never,
+      resolveDeviceKey: vi.fn(async () => new Uint8Array([9]))
+    })
+
+    expect(workerBridge.decryptBatch).not.toHaveBeenCalled()
+    expect(mocks.decryptSingleItem).toHaveBeenCalledTimes(1)
+    expect(result.decrypted).toEqual([{ id: 'note-1', content: 'plain' }])
+  })
+
   it('returns only skipped failures when every worker item lacks a signer key', async () => {
     const workerBridge = {
       isRunning: true,

--- a/apps/desktop/src/main/sync/worker-bridge.test.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.test.ts
@@ -43,7 +43,7 @@ vi.mock('../lib/logger', () => ({
   createLogger: () => logger
 }))
 
-import { SyncWorkerBridge } from './worker-bridge'
+import { MAX_CONSECUTIVE_FAILURES, SyncWorkerBridge } from './worker-bridge'
 
 describe('SyncWorkerBridge', () => {
   let bridge: SyncWorkerBridge
@@ -444,6 +444,102 @@ describe('SyncWorkerBridge', () => {
 
       // #then — a clean stop() must not warn on every shutdown
       expect(logger.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('#given running bridge #when requests keep failing', () => {
+    const startReady = async (): Promise<void> => {
+      const p = bridge.start()
+      mockWorkerInstance.simulateMessage({ type: 'ready' })
+      await p
+    }
+
+    const encryptBatchRequests = (): unknown[] =>
+      mockWorkerInstance.postMessage.mock.calls.filter(([m]) => m.type === 'encrypt-batch')
+
+    /** One batch against a worker that is alive but never answers. */
+    const silentBatch = async (): Promise<void> => {
+      const request = bridge.encryptBatch([], new Uint8Array(32), new Uint8Array(64), 'device-1')
+      vi.advanceTimersByTime(60_001)
+      await expect(request).rejects.toThrow('Worker request timed out')
+    }
+
+    const answeredBatch = async (): Promise<void> => {
+      const request = bridge.encryptBatch([], new Uint8Array(32), new Uint8Array(64), 'device-1')
+      const posted = encryptBatchRequests().at(-1)![0]
+      mockWorkerInstance.simulateMessage({
+        type: 'encrypt-batch-result',
+        requestId: posted.requestId,
+        results: [],
+        errors: []
+      })
+      await request
+    }
+
+    it('#then still routes to the worker below the latch threshold', async () => {
+      // #given
+      await startReady()
+
+      // #when — one short of the threshold; a lone hiccup must not cost the
+      // session its worker
+      for (let i = 0; i < MAX_CONSECUTIVE_FAILURES - 1; i++) await silentBatch()
+
+      // #then
+      expect(bridge.isRunning).toBe(true)
+      expect(encryptBatchRequests()).toHaveLength(MAX_CONSECUTIVE_FAILURES - 1)
+    })
+
+    it('#then latches off at the threshold so no further round trip is paid', async () => {
+      // #given
+      await startReady()
+
+      // #when
+      for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i++) await silentBatch()
+
+      // #then — sync-crypto-batch gates on isRunning (its only two call sites),
+      // so a false here is exactly "main-thread crypto, no worker request". The
+      // timeout penalty is now bounded at MAX_CONSECUTIVE_FAILURES for the whole
+      // session instead of one per batch.
+      expect(bridge.isRunning).toBe(false)
+      expect(encryptBatchRequests()).toHaveLength(MAX_CONSECUTIVE_FAILURES)
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Sync worker latched off after repeated failures — using main-thread crypto',
+        expect.objectContaining({ consecutiveFailures: MAX_CONSECUTIVE_FAILURES })
+      )
+    })
+
+    it('#then a successful batch clears the failure count', async () => {
+      // #given — failures stop one short of the threshold
+      await startReady()
+      for (let i = 0; i < MAX_CONSECUTIVE_FAILURES - 1; i++) await silentBatch()
+
+      // #when — the worker recovers, then stumbles again
+      await answeredBatch()
+      for (let i = 0; i < MAX_CONSECUTIVE_FAILURES - 1; i++) await silentBatch()
+
+      // #then — failures must be *consecutive* to latch. Without the reset the
+      // count would already stand at 2 * (MAX - 1) and this would be latched.
+      expect(bridge.isRunning).toBe(true)
+
+      // #and — the threshold is still enforced, just counted from the success
+      await silentBatch()
+      expect(bridge.isRunning).toBe(false)
+    })
+
+    it('#then a restarted bridge is no longer latched', async () => {
+      // #given — a latched bridge
+      await startReady()
+      for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i++) await silentBatch()
+      expect(bridge.isRunning).toBe(false)
+
+      // #when — the only in-session recovery path: drop the thread and respawn
+      const stopPromise = bridge.stop()
+      mockWorkerInstance.simulateExit(0)
+      await stopPromise
+      await startReady()
+
+      // #then — a fresh thread is not the thread that failed
+      expect(bridge.isRunning).toBe(true)
     })
   })
 

--- a/apps/desktop/src/main/sync/worker-bridge.ts
+++ b/apps/desktop/src/main/sync/worker-bridge.ts
@@ -21,14 +21,38 @@ type PendingRequest = {
 
 const REQUEST_TIMEOUT_MS = 60_000
 
+/**
+ * Consecutive failed worker requests before the bridge stops offering itself.
+ *
+ * `isRunning` can only see that the thread has not exited, so a worker that is
+ * alive but never answers keeps being chosen and costs a full
+ * REQUEST_TIMEOUT_MS per batch before sync-crypto-batch degrades to
+ * main-thread crypto. Counting failures gives that case an exit.
+ *
+ * 3 rather than 1: a single failure is noise — one transient timeout under load
+ * should not cost the session its worker. 3 rather than more: the worst case is
+ * paid in whole minutes, and 3 silent batches is a bounded ~3 minutes of
+ * degraded-but-correct sync, after which the worker costs nothing for the rest
+ * of the session.
+ */
+export const MAX_CONSECUTIVE_FAILURES = 3
+
 export class SyncWorkerBridge {
   private worker: Worker | null = null
   private pendingRequests = new Map<string, PendingRequest>()
   private readyPromise: Promise<void> | null = null
   private requestCounter = 0
+  private consecutiveFailures = 0
+  private latchedOff = false
 
   async start(): Promise<void> {
     if (this.worker) return
+
+    // A freshly spawned thread is not the thread that failed, so it gets a
+    // clean slate. Reaching here after a latch (stop() then start()) is the
+    // only in-session way back to worker crypto.
+    this.consecutiveFailures = 0
+    this.latchedOff = false
 
     const workerPath = join(__dirname, 'sync-worker.js')
     this.worker = new Worker(workerPath)
@@ -131,6 +155,32 @@ export class SyncWorkerBridge {
     }
   }
 
+  /**
+   * Only worker-infrastructure failures reach here, never a crypto verdict.
+   * The worker returns per-item outcomes in-band — `encrypt-batch-result.errors`
+   * and `decrypt-batch-result.failures`, including signature mismatches — and
+   * never rejects the request for them. A rejection therefore always means the
+   * worker was unreachable: not started, timed out, crashed/exited, protocol
+   * drift (`{ type: 'error' }`), or an unexpected response type. Latching on
+   * these cannot hide a bad item; the main-thread path re-runs the same crypto.
+   *
+   * The thread is left alive rather than terminated. Terminating buys nothing
+   * once the bridge stops routing to it, and it would remove the stop()/start()
+   * recovery path above.
+   */
+  private recordRequestFailure(err: unknown): void {
+    this.consecutiveFailures += 1
+    if (this.latchedOff || this.consecutiveFailures < MAX_CONSECUTIVE_FAILURES) return
+
+    this.latchedOff = true
+    // Only the failure count and the transport error text; crypto error
+    // messages never travel this path, so no key material or plaintext.
+    log.warn('Sync worker latched off after repeated failures — using main-thread crypto', {
+      consecutiveFailures: this.consecutiveFailures,
+      error: err instanceof Error ? err.message : String(err)
+    })
+  }
+
   private nextRequestId(): string {
     return `req_${++this.requestCounter}_${Date.now()}`
   }
@@ -163,23 +213,29 @@ export class SyncWorkerBridge {
     errors: Array<{ queueId: string; itemId: string; error: string }>
   }> {
     const requestId = this.nextRequestId()
-    const response = await this.sendRequest({
-      type: 'encrypt-batch',
-      requestId,
-      items,
-      vaultKey: new Uint8Array(vaultKey),
-      signingSecretKey: new Uint8Array(signingSecretKey),
-      signerDeviceId
-    })
+    try {
+      const response = await this.sendRequest({
+        type: 'encrypt-batch',
+        requestId,
+        items,
+        vaultKey: new Uint8Array(vaultKey),
+        signingSecretKey: new Uint8Array(signingSecretKey),
+        signerDeviceId
+      })
 
-    if (response.type === 'error') {
-      throw new Error(response.error)
-    }
-    if (response.type !== 'encrypt-batch-result') {
-      throw new Error(`Unexpected response type: ${response.type}`)
-    }
+      if (response.type === 'error') {
+        throw new Error(response.error)
+      }
+      if (response.type !== 'encrypt-batch-result') {
+        throw new Error(`Unexpected response type: ${response.type}`)
+      }
 
-    return { results: response.results, errors: response.errors }
+      this.consecutiveFailures = 0
+      return { results: response.results, errors: response.errors }
+    } catch (err) {
+      this.recordRequestFailure(err)
+      throw err
+    }
   }
 
   async decryptBatch(
@@ -191,26 +247,36 @@ export class SyncWorkerBridge {
     failures: DecryptionFailure[]
   }> {
     const requestId = this.nextRequestId()
-    const response = await this.sendRequest({
-      type: 'decrypt-batch',
-      requestId,
-      items,
-      vaultKey: new Uint8Array(vaultKey),
-      signerKeys
-    })
+    try {
+      const response = await this.sendRequest({
+        type: 'decrypt-batch',
+        requestId,
+        items,
+        vaultKey: new Uint8Array(vaultKey),
+        signerKeys
+      })
 
-    if (response.type === 'error') {
-      throw new Error(response.error)
-    }
-    if (response.type !== 'decrypt-batch-result') {
-      throw new Error(`Unexpected response type: ${response.type}`)
-    }
+      if (response.type === 'error') {
+        throw new Error(response.error)
+      }
+      if (response.type !== 'decrypt-batch-result') {
+        throw new Error(`Unexpected response type: ${response.type}`)
+      }
 
-    return { results: response.results, failures: response.failures }
+      this.consecutiveFailures = 0
+      return { results: response.results, failures: response.failures }
+    } catch (err) {
+      this.recordRequestFailure(err)
+      throw err
+    }
   }
 
+  // sync-crypto-batch gates every batch on this, so a latched bridge sends it
+  // straight to main-thread crypto without a round trip. stop() deliberately
+  // checks `this.worker` instead, so a latched-but-alive thread is still shut
+  // down cleanly.
   get isRunning(): boolean {
-    return this.worker !== null
+    return this.worker !== null && !this.latchedOff
   }
 
   async stop(): Promise<void> {

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -464,3 +464,16 @@ so a rejection only ever means the worker itself was unreachable. The main-threa
 identical encryption and signature verification over the same inputs, so an item that genuinely
 fails crypto still fails; it just fails on the main thread. Push payloads are resolved once and
 shared by both paths, so the fallback encrypts exactly what the worker was handed.
+
+A worker that crashes takes itself out of the rotation, because the exit leaves nothing to send to. A
+worker that is alive but silent does not: it looks healthy, so every batch would ask it again and
+wait out the 60-second request timeout before degrading. The bridge therefore counts consecutive
+failed requests and stops offering itself after three, from which point batches go straight to the
+main thread with no round trip. The penalty for a silent worker is bounded at three timeouts for the
+whole session rather than one per batch.
+
+Three is deliberate on both sides. One failure is noise — a single timeout under load should not cost
+the session its worker — so a successful batch resets the count and only consecutive failures latch.
+Waiting longer is expensive, because the penalty is paid in whole minutes. The thread is left alive
+rather than terminated, and restarting the sync runtime gives the bridge a fresh worker and a clean
+count.


### PR DESCRIPTION
Closes #964

Builds directly on #960.

## Problem

#960 made a rejected worker crypto request degrade to main-thread crypto instead of failing the batch. It deliberately did not stop *asking* the worker, and the two failure shapes are very far apart in cost.

A worker that **crashes** is already fine — the `exit` handler nulls `this.worker`, `isRunning` goes false, and later batches skip it. A worker that **answers with an error** is fine too: the reply is immediate and the fallback costs sub-millisecond IPC.

The gap is the worker that is **alive but silent**. `isRunning` was `this.worker !== null`, which only knows the thread has not exited, so a hung-but-alive worker kept reporting healthy and kept being chosen. Nothing anywhere short-circuits: `sendRequest` arms a fresh 60s timer per request, and `isRunning` has exactly two production consumers, both of them the per-batch gate in `sync-crypto-batch.ts`. Every push batch and every pull batch therefore paid a full minute before degrading. Sync still completed — that is #960 working — but at a rate that reads as broken.

## Fix

`SyncWorkerBridge` counts consecutive failed requests. After three it latches: `isRunning` reports false, and `sync-crypto-batch.ts` takes the main-thread path with no round trip. A successful batch resets the count to zero.

Both `encryptBatch` and `decryptBatch` are wrapped, so the count also covers the post-response throws (`{ type: 'error' }` protocol drift, unexpected response type), not just `sendRequest` rejections.

## Design decisions

**N = 3.** One failure is noise — a single transient timeout under load should not cost the session its worker. Three consecutive failures is not noise. Because the penalty is paid in whole minutes, a larger N is expensive: three silent batches is a bounded ~3 minutes of degraded-but-correct sync, after which the worker costs nothing for the rest of the session. The reasoning lives in a comment on the constant.

**Latch scope: session-lifetime, not a timed retry.** The acceptance criterion asks for a *bounded, one-time* penalty. A cooldown-and-reprobe scheme cannot deliver that — every expiry buys another 60s stall — whereas a session latch gives a hard ceiling of three timeouts total. It is also simpler and deterministic: no timers, no clock. The cost of being wrong is small and bounded in the right direction: main-thread crypto is correct (the whole point of #960), just slower, so losing the worker for one session is a performance regression and never a correctness one. Re-probing a wedged worker, by contrast, costs the user another frozen minute each time.

The reset-on-success still does the work that matters, because it applies *before* the latch trips — that is exactly the transient-hiccup case. In-session recovery after a latch is `stop()` then `start()`, which spawns a fresh thread and clears the count; a fresh thread is not the thread that failed.

**The worker thread is not terminated.** Raised as an open question in the issue. Terminating buys nothing once the bridge has stopped routing to it, and it would add a failure mode (terminating a wedged thread, `exit` racing `rejectAll`) while removing the only in-session way back. `stop()` deliberately still keys off `this.worker` rather than `isRunning`, so a latched-but-alive thread is still shut down cleanly and does not leak.

## Why this cannot mask a crypto or auth failure

Re-verified against current `worker.ts`, not assumed from #960. Per-item crypto outcomes still come back **in-band**: `encrypt-batch-result` carries `errors[]`, `decrypt-batch-result` carries `failures[]` including signature mismatches. Neither rejects the request. The only producer of `{ type: 'error' }` is `handleUnknownMessage`, i.e. protocol drift. So an `encryptBatch`/`decryptBatch` rejection is purely infrastructure, and the latch counts nothing else. Latching cannot suppress a bad item — the main-thread path re-runs the identical encryption and signature verification.

No key material or plaintext is logged: the latch warning carries only the failure count and the transport error text, and crypto error messages never travel that path.

## Backward compatibility

No schema, contract, wire-protocol, or persisted-format change. Purely in-process bridge state. The main↔worker protocol is untouched, so mixed-build installs behave exactly as they do today. Behaviour when the worker answers normally is unchanged — the new path is reachable only after three consecutive infrastructure failures, which previously meant three 60s stalls.

## Tests

`worker-bridge.test.ts` — 4 new: still routes to the worker below the threshold; latches at the threshold and stops issuing round trips; a success clears the count and the threshold is then re-counted from that success; a restarted bridge is no longer latched.

`sync-crypto-batch.test.ts` — 2 new, pinning the other half of the contract: an `isRunning: false` bridge encrypts and decrypts on the main thread without ever calling the worker.

Whole `src/main/sync` suite green:

```
Test Files  136 passed (136)
     Tests  1653 passed | 1 expected fail | 3 skipped (1657)
```

Mutation check — `worker-bridge.ts` stashed, tests re-run:

```
 × worker-bridge.test.ts > #then still routes to the worker below the latch threshold
 × worker-bridge.test.ts > #then latches off at the threshold so no further round trip is paid
 × worker-bridge.test.ts > #then a successful batch clears the failure count
 × worker-bridge.test.ts > #then a restarted bridge is no longer latched
Test Files  1 failed | 1 passed (2)
     Tests  4 failed | 31 passed (35)
```

Fix restored, green again. `pnpm typecheck` 16/16 successful, `pnpm lint` 0 errors (10 pre-existing renderer warnings, none in changed files), `pnpm docs:impact --strict` covered, `pnpm docs:build` complete.

The first draft of the reset test asserted only `isRunning === true`, which passes with no latch at all; it was tightened to also assert the latch still fires on the next failure, so all four are mutation-sensitive.

## Deliberately out of scope

- **Bounding main-thread fallback latency for large pull batches.** Raised in #957 and still open. No measurements exist for how long a realistic large batch takes on the main thread, and inventing a bound without them is guesswork.
- **`encryptItemForPush` throwing in the fallback** (e.g. "Item too large for sync") still propagates out of `encryptPushBatch` instead of becoming a per-item `queue.markFailed`. That is how the main-thread path has always behaved when no worker is configured, so it is a pre-existing rough edge rather than a regression.
