### PR TITLE
fix(sync): spend the push retry budget across cycles, not inside one push()

### DIFF
--- a/apps/desktop/src/main/database/drizzle-data/0047_sync_queue_revive_dead_lettered.sql
+++ b/apps/desktop/src/main/database/drizzle-data/0047_sync_queue_revive_dead_lettered.sql
@@ -1,0 +1,21 @@
+-- Revive sync-queue rows that were dead-lettered inside a single push cycle.
+--
+-- Before this release one push() call spent the whole retry budget on a burst of
+-- back-to-back requests, so a single transient server rejection pushed a row to
+-- attempts = DEFAULT_MAX_ATTEMPTS (5) immediately. Both dequeue() and
+-- getPendingCount() ignore rows at or above that ceiling and nothing ever reset
+-- them, so the mutation was parked forever, invisible in the UI, and eventually
+-- purged. Those edits are still on disk and still unsynced on real installs.
+--
+-- Attempts are now spread across sync cycles, so hand the budget back once.
+-- Data-only and row-preserving: no schema change, no DELETE. error_message and
+-- last_attempt are kept so the earlier failure stays diagnosable. A row whose
+-- rejection is genuinely permanent simply re-parks after five more cycles —
+-- a bounded cost against silently losing a user's edit.
+--
+-- The literal 5 mirrors DEFAULT_MAX_ATTEMPTS in src/main/sync/queue.ts; SQL
+-- cannot import it. Raising that constant does not require editing this file:
+-- the migration only ever runs once, against the ceiling in force when the row
+-- was parked.
+-- Hand-written (project switched off Drizzle generator after 0020).
+UPDATE `sync_queue` SET `attempts` = 0 WHERE `attempts` >= 5;

--- a/apps/desktop/src/main/database/drizzle-data/meta/_journal.json
+++ b/apps/desktop/src/main/database/drizzle-data/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1785585342000,
       "tag": "0046_tag_definition_color_authored",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "6",
+      "when": 1785585343000,
+      "tag": "0047_sync_queue_revive_dead_lettered",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/src/main/database/migrate.test.ts
+++ b/apps/desktop/src/main/database/migrate.test.ts
@@ -534,3 +534,84 @@ describe('0043_bookmark_reminder_sync migration', () => {
     sqlite.close()
   })
 })
+
+describe('0047_sync_queue_revive_dead_lettered migration', () => {
+  let tempDir: string
+  const migrationsDir = path.join(__dirname, 'drizzle-data')
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-sync-queue-revive-migrate-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  /** Copy of drizzle-data/ with 0047 and everything after it stripped. */
+  function makePre0047Folder(): string {
+    const copy = path.join(tempDir, 'drizzle-data-pre-0047')
+    fs.cpSync(migrationsDir, copy, { recursive: true })
+    const journalPath = path.join(copy, 'meta', '_journal.json')
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as {
+      entries: { tag: string }[]
+    }
+    const cutoff = journal.entries.findIndex(
+      (e) => e.tag === '0047_sync_queue_revive_dead_lettered'
+    )
+    expect(cutoff).toBeGreaterThanOrEqual(0)
+    const removed = journal.entries.splice(cutoff)
+    for (const entry of removed) {
+      fs.rmSync(path.join(copy, `${entry.tag}.sql`))
+    }
+    fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2))
+    return copy
+  }
+
+  it('hands the retry budget back to rows an older build parked, and leaves the rest alone', () => {
+    const sqlite = new Database(path.join(tempDir, 'data.db'))
+    const db = drizzle(sqlite)
+    migrate(db, { migrationsFolder: makePre0047Folder() })
+
+    const insert = sqlite.prepare(
+      `INSERT INTO sync_queue (id, type, item_id, operation, payload, priority, attempts, last_attempt, error_message, created_at)
+       VALUES (?, 'note', ?, 'update', ?, 0, ?, ?, ?, ?)`
+    )
+    // Parked by the old in-cycle burn: unreachable and invisible in the UI.
+    insert.run(
+      'q_dead',
+      'note_1',
+      '{"title":"Parked"}',
+      5,
+      1785000000000,
+      'SYNC_VALIDATION_FAILED',
+      1784000000000
+    )
+    // Mid-budget and untouched rows must keep the attempts they earned.
+    insert.run(
+      'q_partial',
+      'note_2',
+      '{"title":"Halfway"}',
+      2,
+      1785000000000,
+      'SYNC_VALIDATION_FAILED',
+      1784000000000
+    )
+    insert.run('q_fresh', 'note_3', '{"title":"Fresh"}', 0, null, null, 1784000000000)
+
+    migrate(db, { migrationsFolder: migrationsDir })
+
+    const rows = sqlite
+      .prepare('SELECT id, attempts, payload, error_message FROM sync_queue ORDER BY id')
+      .all() as { id: string; attempts: number; payload: string; error_message: string | null }[]
+
+    expect(rows.map((r) => [r.id, r.attempts])).toEqual([
+      ['q_dead', 0],
+      ['q_fresh', 0],
+      ['q_partial', 2]
+    ])
+    // Row-preserving: the edit and its failure reason both survive the reset.
+    expect(rows[0].payload).toBe('{"title":"Parked"}')
+    expect(rows[0].error_message).toBe('SYNC_VALIDATION_FAILED')
+    sqlite.close()
+  })
+})

--- a/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.test.ts
@@ -166,6 +166,15 @@ function acceptAll(): void {
   }))
 }
 
+function rejectAllWith(reason: string): void {
+  postToServerMock.mockImplementation(async (_path: string, body: PushBody) => ({
+    accepted: [],
+    rejected: body.items.map((i) => ({ id: i.id, reason })),
+    serverTime: Math.floor(Date.now() / 1000),
+    maxCursor: 0
+  }))
+}
+
 describe('PushCoordinator', () => {
   const { getDb } = setupTestDb()
 
@@ -257,12 +266,7 @@ describe('PushCoordinator', () => {
       const { coordinator, queue } = createHarness(getDb())
       const markPushSynced = vi.fn()
       getHandlerMock.mockReturnValue({ markPushSynced })
-      postToServerMock.mockImplementation(async (_path: string, body: PushBody) => ({
-        accepted: [],
-        rejected: body.items.map((i) => ({ id: i.id, reason: 'SYNC_VALIDATION_FAILED' })),
-        serverTime: Math.floor(Date.now() / 1000),
-        maxCursor: 0
-      }))
+      rejectAllWith('SYNC_VALIDATION_FAILED')
 
       const payload = JSON.stringify({ title: 'Rejected edit' })
       queue.enqueue({ type: 'task', itemId: 'task-1', operation: 'update', payload })
@@ -273,11 +277,75 @@ describe('PushCoordinator', () => {
       expect(queue.getSize()).toBe(1)
       expect(queue.peek()[0].payload).toBe(payload)
       expect(markPushSynced).not.toHaveBeenCalled()
-      // Documents current behaviour: one push() call re-pushes the same rejected
-      // row every iteration, burning the whole attempt budget in a single cycle
-      // (no backoff between in-cycle retries) and dead-lettering it immediately.
-      expect(queue.peek()[0].attempts).toBe(DEFAULT_MAX_ATTEMPTS)
+      // One cycle costs exactly one attempt. The push loop has no backoff, so a
+      // row re-pushed inside the same call would burn the whole budget against a
+      // single burst of requests and dead-letter a transiently rejected edit for
+      // good; the row is deferred to the next cycle instead.
+      expect(postToServerMock).toHaveBeenCalledTimes(1)
+      expect(queue.peek()[0].attempts).toBe(1)
+      expect(queue.getPendingCount()).toBe(1)
+    })
+
+    it('#then the attempt budget still dead-letters the row, but only after one cycle each', async () => {
+      const { coordinator, queue } = createHarness(getDb())
+      rejectAllWith('SYNC_VALIDATION_FAILED')
+
+      queue.enqueue({
+        type: 'task',
+        itemId: 'task-1',
+        operation: 'update',
+        payload: JSON.stringify({ title: 'Doomed edit' })
+      })
+
+      for (let cycle = 1; cycle <= DEFAULT_MAX_ATTEMPTS; cycle++) {
+        await coordinator.push()
+        expect(queue.peek()[0].attempts).toBe(cycle)
+      }
+
+      // The brake is intact: the budget is spent, just spread over cycles.
+      expect(postToServerMock).toHaveBeenCalledTimes(DEFAULT_MAX_ATTEMPTS)
       expect(queue.getPendingCount()).toBe(0)
+
+      // And a spent budget really does stop the pushing.
+      await coordinator.push()
+      expect(postToServerMock).toHaveBeenCalledTimes(DEFAULT_MAX_ATTEMPTS)
+    })
+
+    it('#then a rejected row does not block the rows queued behind it in the same cycle', async () => {
+      const { coordinator, queue, ctx } = createHarness(getDb())
+      // One row per request, so the rejected row is at the head of every dequeue.
+      ctx.options.pushBatchSize = 1
+      postToServerMock.mockImplementation(async (_path: string, body: PushBody) => {
+        const rejected = body.items.filter((i) => i.id === 'task-1')
+        return {
+          accepted: body.items.filter((i) => i.id !== 'task-1').map((i) => i.id),
+          rejected: rejected.map((i) => ({ id: i.id, reason: 'SYNC_VALIDATION_FAILED' })),
+          serverTime: Math.floor(Date.now() / 1000),
+          maxCursor: 0
+        }
+      })
+
+      queue.enqueue({
+        type: 'task',
+        itemId: 'task-1',
+        operation: 'update',
+        payload: JSON.stringify({ title: 'Rejected' })
+      })
+      queue.enqueue({
+        type: 'task',
+        itemId: 'task-2',
+        operation: 'update',
+        payload: JSON.stringify({ title: 'Fine' })
+      })
+
+      await coordinator.push()
+
+      // Two requests: the rejected row is skipped for the rest of the cycle
+      // rather than re-sent, and the healthy row behind it still goes out.
+      expect(postToServerMock).toHaveBeenCalledTimes(2)
+      expect(queue.peek()).toHaveLength(1)
+      expect(queue.peek()[0].itemId).toBe('task-1')
+      expect(queue.peek()[0].attempts).toBe(1)
     })
 
     it('#then a replay rejection is treated as already-synced and drops the row', async () => {

--- a/apps/desktop/src/main/sync/engine/push-coordinator.ts
+++ b/apps/desktop/src/main/sync/engine/push-coordinator.ts
@@ -97,6 +97,15 @@ export class PushCoordinator {
         return
       }
 
+      // Rows the server rejected during THIS call. They keep their remaining
+      // retry budget but must not be dequeued again before the next sync cycle:
+      // this loop has no backoff, so re-pushing a rejected row here would spend
+      // every attempt on one burst of requests and permanently park the edit.
+      // A row that `markSuccess` declined to delete (it changed while in flight)
+      // is intentionally absent — that re-push consumes no attempt and is how
+      // the newer payload reaches the server.
+      const rejectedThisCycle = new Set<string>()
+
       try {
         for (let iteration = 0; iteration < MAX_PUSH_ITERATIONS; iteration++) {
           if (abortSignal.aborted) break
@@ -109,9 +118,16 @@ export class PushCoordinator {
               raw: rawCount
             })
           }
-          const items = this.ctx.deps.queue.dequeue(this.ctx.options.pushBatchSize)
+          const items = this.ctx.deps.queue.dequeue(
+            this.ctx.options.pushBatchSize,
+            rejectedThisCycle
+          )
           if (items.length === 0) {
-            log.debug('Push complete: queue empty', { preDequeueCount, rawCount })
+            log.debug('Push complete: nothing left to push this cycle', {
+              preDequeueCount,
+              rawCount,
+              deferredToNextCycle: rejectedThisCycle.size
+            })
             break
           }
 
@@ -221,6 +237,7 @@ export class PushCoordinator {
               } else if (reason === 'STORAGE_QUOTA_EXCEEDED') {
                 log.warn('Push: storage quota exceeded', { itemId: pushItem.id.slice(0, 8) })
                 this.ctx.deps.queue.markFailed(queueId, reason)
+                rejectedThisCycle.add(queueId)
                 this.ctx.lastErrorInfo = {
                   category: 'storage_quota_exceeded',
                   message: 'errors:sync.storageQuotaExceeded',
@@ -236,6 +253,7 @@ export class PushCoordinator {
                   reason
                 })
                 this.ctx.deps.queue.markFailed(queueId, reason)
+                rejectedThisCycle.add(queueId)
               }
             }
           }

--- a/apps/desktop/src/main/sync/queue.test.ts
+++ b/apps/desktop/src/main/sync/queue.test.ts
@@ -186,6 +186,22 @@ describe('SyncQueueManager', () => {
       expect(queue.getSize()).toBe(1)
     })
 
+    it('skips excluded ids without touching their remaining attempt budget', () => {
+      // #given a row the caller already failed inside the current push cycle
+      const failed = queue.enqueue(makeInput({ itemId: 'failed-this-cycle' }))
+      queue.enqueue(makeInput({ itemId: 'still-fresh' }))
+      simulateFailedAttempt(queue, failed, 'transient')
+
+      // #when dequeue excludes it
+      const items = queue.dequeue(10, [failed])
+
+      // #then only the other row comes back, and the excluded one keeps its
+      // budget for the next cycle rather than being spent again immediately
+      expect(items.map((i) => i.itemId)).toEqual(['still-fresh'])
+      expect(queue.getPendingCount()).toBe(2)
+      expect(queue.peek().find((r) => r.id === failed)?.attempts).toBe(1)
+    })
+
     it('does not increment attempts on dequeue before a failure is recorded', () => {
       // #given item in queue
       queue.enqueue(makeInput())

--- a/apps/desktop/src/main/sync/queue.ts
+++ b/apps/desktop/src/main/sync/queue.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, desc, asc, lt, lte, count } from 'drizzle-orm'
+import { eq, and, sql, desc, asc, lt, lte, count, notInArray } from 'drizzle-orm'
 import { syncQueue } from '@memry/db-schema/schema/sync-queue'
 import type { SyncItemType, SyncOperation } from '@memry/contracts/sync-api'
 import type { DataDb } from '../database'
@@ -89,11 +89,31 @@ export class SyncQueueManager {
     return id
   }
 
-  dequeue(batchSize: number): Array<typeof syncQueue.$inferSelect> {
+  /**
+   * Rows still inside their retry budget, highest priority / oldest first.
+   *
+   * `excludeIds` holds rows the caller has already failed during the current
+   * push cycle. It matters because the push loop dequeues repeatedly in one
+   * `push()` call: without the exclusion it re-dequeues the row it just failed
+   * on the very next iteration, so all `DEFAULT_MAX_ATTEMPTS` are spent against
+   * a single burst of back-to-back requests and one transient server rejection
+   * dead-letters a user's edit for good. The budget is meant to span sync
+   * cycles, and the delay between them is the cycle interval itself — so the
+   * exclusion is per-call state only and is deliberately never persisted.
+   *
+   * Excluding by id rather than by `lastAttempt` keeps this independent of the
+   * system clock: a backwards clock jump must never hide a pending edit.
+   */
+  dequeue(batchSize: number, excludeIds?: Iterable<string>): Array<typeof syncQueue.$inferSelect> {
+    const excluded = excludeIds ? Array.from(excludeIds) : []
+    const withinBudget = lt(syncQueue.attempts, DEFAULT_MAX_ATTEMPTS)
+
     return this.db
       .select()
       .from(syncQueue)
-      .where(lt(syncQueue.attempts, DEFAULT_MAX_ATTEMPTS))
+      .where(
+        excluded.length > 0 ? and(withinBudget, notInArray(syncQueue.id, excluded)) : withinBudget
+      )
       .orderBy(desc(syncQueue.priority), asc(syncQueue.createdAt))
       .limit(batchSize)
       .all()

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -122,6 +122,28 @@ queued and goes out on the next iteration. Deleting unconditionally would drop t
 permanently, because the local clock advances at mutation time: the item would sit ahead of the
 server with nothing queued, and every later pull would resolve `skip` rather than repair it.
 
+### The per-item attempt budget is spent per sync cycle
+
+A push response can accept some items and reject others. A rejected row keeps its payload and is
+charged one attempt; after five it stops being dequeued and no longer counts as pending.
+
+That budget is spent **at most once per push cycle**. One `push()` call loops until the queue drains,
+and the loop has no backoff, so a row re-sent inside the same call would consume all five attempts
+across a handful of back-to-back requests — turning a few seconds of transient server trouble into a
+permanently parked edit that the UI reports as nothing-to-sync. Rows the server rejects are therefore
+excluded from the remaining dequeues of that call and picked up again on the next cycle, which is
+where the delay between attempts comes from. Other queued rows are unaffected: a rejected row is
+skipped, not treated as a barrier, so healthy items behind it still go out in the same cycle.
+
+The exclusion lives only in memory for the duration of the call. It is keyed on row id rather than on
+the persisted `lastAttempt` timestamp, so a backwards system-clock jump can never hide a pending
+edit. A row that changed while in flight is a different case and is _not_ excluded — that re-send
+carries the newer payload and costs no attempt.
+
+Migration 0047 resets `attempts` to 0 for rows that an earlier build had already exhausted, so edits
+stranded by the old in-cycle spend are retried again after upgrading. It preserves the row, its
+payload, and its recorded error.
+
 ### Recovering pushes that never landed
 
 Items expose a "the server has this state" stamp (`syncedAt`) that advances on a confirmed push as


### PR DESCRIPTION
Closes #952

## Verified first

Every claim in the issue still holds at the referenced lines on `main`. The push loop
(`push-coordinator.ts:101`) dequeues (`:112`), and on a per-item rejection calls `markFailed` (`:238`)
before looping straight back to dequeue — no backoff, no exclusion. `markFailed` (`queue.ts:145`)
only bumps a counter; `dequeue`'s `attempts < DEFAULT_MAX_ATTEMPTS` filter (`queue.ts:96`) is the sole
brake, `lastAttempt` is written but never read as a gate, `getRetryableItems` has no production
callers (tests only), and nothing ever resets `attempts`. One `push()` call against a rejecting server
therefore leaves the row at `attempts = 5` and `getPendingCount() === 0`.

One addition the issue does not mention: the `break` on `STORAGE_QUOTA_EXCEEDED` (`:231`) exits only
the inner per-item loop, not the iteration loop, so a quota-rejected row was re-dequeued and
re-pushed the same way. Same defect, second path — closed by the same fix.

## The fix

Rows the server rejects during a push cycle are collected in a `rejectedThisCycle` set and excluded
from the remaining dequeues of that same `push()` call. `dequeue` takes an optional `excludeIds`. The
attempt ceiling is untouched, so the budget still dead-letters — it is just spent one attempt per
cycle, which is the delay it was always meant to have.

Rows `markSuccess` declines to delete (they changed while in flight) are deliberately **not**
excluded: that re-push carries the newer payload and consumes no attempt.

## Design decisions

- **No timer, no sleep.** Excluding a row for the rest of the cycle is enough; the real delay is the
  sync-cycle interval that already exists. Adding backoff inside the push loop would hold the sync
  lock while sleeping.
- **Exclude by row id, not by `lastAttempt`.** Gating on the persisted timestamp would have been
  fewer moving parts, but it makes a pending edit invisible whenever the system clock jumps
  backwards. Losing an edit to clock skew is the exact failure class this issue is about.
- **Exclusion is per-call, in-memory, never persisted.** No schema change for the runtime fix, and no
  new state that can be left stale by a crash mid-push.
- **Rejected rows do not act as a barrier.** They are skipped, not stopped at — healthy rows queued
  behind a rejected one still go out in the same cycle. Covered by a test that forces
  `pushBatchSize = 1`.

## Backward compatibility

Real installs already have rows parked at `attempts >= 5` by the old behaviour: invisible in the UI,
never retried, deleted after 7 days by `purgeOldErrors`. Shipping only the runtime fix would leave
those users' edits stranded.

Migration `0047_sync_queue_revive_dead_lettered` (hand-written, no `db:generate`) hands the budget
back exactly once:

```sql
UPDATE `sync_queue` SET `attempts` = 0 WHERE `attempts` >= 5;
```

Data-only, no schema change, no `DELETE`. `error_message` and `last_attempt` survive so the earlier
failure stays diagnosable. A row whose rejection is genuinely permanent simply re-parks after five
more cycles — a bounded cost against silently losing a user's edit. Runs once per install; rows below
the ceiling are untouched.

## Tests

`push-coordinator.test.ts:256-281` pinned the defect (`attempts === DEFAULT_MAX_ATTEMPTS` after a
single `push()`). Rewritten to assert the correct invariant — one cycle, one attempt, one request —
and joined by tests that keep the brake honest:

- the budget still dead-letters, but only after `DEFAULT_MAX_ATTEMPTS` separate `push()` calls, and a
  spent budget really does stop pushing;
- a rejected row does not block rows queued behind it in the same cycle;
- `queue.test.ts`: `dequeue` skips excluded ids without touching their remaining budget;
- `migrate.test.ts`: migration 0047 revives a parked row, preserves payload + error, and leaves
  mid-budget and fresh rows alone.

**Mutation check** — fix reverted (dropped the `excludeIds` argument, neutered the migration to
`WHERE 1 = 0`):

```
× a server-side rejection of the item keeps the row instead of deleting it
  → expected "vi.fn()" to be called 1 times, but got 5 times
× the attempt budget still dead-letters the row, but only after one cycle each
  → expected 5 to be 1
× a rejected row does not block the rows queued behind it in the same cycle
  → expected "vi.fn()" to be called 2 times, but got 6 times
× 0047 hands the retry budget back to rows an older build parked
  → expected [ [ 'q_dead', 5 ], …(2) ] to deeply equal [ [ 'q_dead', +0 ], …(2) ]
 Test Files  2 failed | 1 passed (3)
      Tests  4 failed | 57 passed (61)
```

Restored:

```
 Test Files  137 passed (137)
      Tests  1639 passed | 1 expected fail | 3 skipped (1643)
```

(full `src/main/sync` suite + `migrate.test.ts`)

Also green: `pnpm typecheck` (16/16), `pnpm lint` (0 errors; 11 pre-existing renderer warnings),
`pnpm docs:impact --strict` → covered, `pnpm docs:build`.

## Out of scope

Deliberately not addressed here, to keep this a data-loss fix rather than a redesign:

- UI affordance to surface or manually retry dead-lettered rows (`getRetryableItems` still has no
  production caller);
- classifying permanent rejections (schema, auth) from transient ones (5xx, network) so a
  never-going-to-succeed row dead-letters on the first attempt with a visible error;
- `purgeOldErrors` semantics — it can still delete an unsynced edit after 7 days without the user
  ever acknowledging the loss.

Each is worth its own issue; none is a prerequisite for stopping the immediate data loss.
