### PR TITLE
fix(sync): recover journal metadata updates raised while the sync runtime is down

### DIFF
--- a/apps/desktop/src/main/sync/content-sync-base.ts
+++ b/apps/desktop/src/main/sync/content-sync-base.ts
@@ -66,8 +66,8 @@ export abstract class ContentSyncService<
    * again would only widen the gap. An item that is actually in step is
    * replay-detected server side and simply stamped as synced.
    */
-  enqueueRecoveredUpdate(itemId: string): void {
-    this.getController().enqueueRecoveredUpdate(itemId)
+  enqueueRecoveredUpdate(itemId: string, ...extra: TArgs): void {
+    this.getController().enqueueRecoveredUpdate(itemId, ...extra)
   }
 
   private getController(): RecordSyncController<NoteMetadata, TArgs, TArgs> {

--- a/apps/desktop/src/main/sync/dirty-recovery.test.ts
+++ b/apps/desktop/src/main/sync/dirty-recovery.test.ts
@@ -396,4 +396,131 @@ describe('dirty-recovery', () => {
       expect(row?.clock).toEqual({ 'device-A': 3 })
     })
   })
+
+  // Journals share `note_metadata` with notes but are pushed by their own sync
+  // service, so the note sweep excludes them by construction (`journalDate IS
+  // NULL`). Without an arm of their own, a journal metadata update raised while
+  // the runtime was down had nothing left to re-push it: no queue row, no dirty
+  // marker, no sweep.
+  describe('journals', () => {
+    const recovered: string[] = []
+    const journalAdapters = {
+      getLocal: (type: string) =>
+        type === 'journal'
+          ? { enqueueRecoveredUpdate: (id: string) => recovered.push(id) }
+          : undefined
+    } as unknown as Parameters<typeof recoverDirtyItems>[1]
+
+    const insertJournal = (values: Record<string, unknown>): void => {
+      db.insert(noteMetadata)
+        .values({
+          path: `journal/${values.id as string}.md`,
+          title: 'A journal',
+          journalDate: '2026-01-02',
+          createdAt: '2026-01-01T00:00:00Z',
+          ...values
+        } as never)
+        .run()
+    }
+
+    beforeEach(() => {
+      recovered.length = 0
+    })
+
+    it('recovers a synced journal whose local change never reached the server', () => {
+      // #given — the push that carried the tag edit was dropped, so the journal
+      // is modified after its last confirmed sync but nothing is queued
+      insertJournal({
+        id: 'journal-diverged',
+        clock: { 'device-A': 2 },
+        syncedAt: '2026-01-01T00:00:00Z',
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+
+      // #when
+      const result = recoverDirtyItems(db, journalAdapters)
+
+      // #then
+      expect(result.journals).toBe(1)
+      expect(recovered).toEqual(['journal-diverged'])
+    })
+
+    it('leaves clean, local-only and clock-less journals — and plain notes — alone', () => {
+      // clean: already stamped after its last edit
+      insertJournal({
+        id: 'journal-clean',
+        clock: { 'device-A': 1 },
+        syncedAt: '2026-01-03T00:00:00Z',
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+      // local-only: must never be pushed
+      insertJournal({
+        id: 'journal-local',
+        clock: { 'device-A': 1 },
+        localOnly: true,
+        syncPolicy: 'local-only',
+        modifiedAt: '2026-01-02T00:00:00Z'
+      })
+      // clock-less: journalHandler.seedUnclocked owns the first push
+      insertJournal({ id: 'journal-unclocked', modifiedAt: '2026-01-02T00:00:00Z' })
+      // a plain note must not be dragged in by the journal arm
+      db.insert(noteMetadata)
+        .values({
+          id: 'plain-note',
+          path: 'notes/plain-note.md',
+          title: 'A note',
+          createdAt: '2026-01-01T00:00:00Z',
+          clock: { 'device-A': 1 },
+          syncedAt: null,
+          modifiedAt: '2026-01-02T00:00:00Z'
+        } as never)
+        .run()
+
+      // #when
+      const result = recoverDirtyItems(db, journalAdapters)
+
+      // #then
+      expect(result.journals).toBe(0)
+      expect(recovered).toEqual([])
+    })
+
+    it('re-pushes a journal whose update was enqueued while the sync service was down', () => {
+      // #given — a journal the server has already confirmed, and a registered
+      // device (metadata edits only sync while signed in)
+      db.insert(syncDevices)
+        .values({
+          id: 'device-A',
+          name: 'Test device',
+          platform: 'darwin',
+          appVersion: '1.0.0',
+          linkedAt: new Date('2026-01-01T00:00:00Z'),
+          isCurrentDevice: true,
+          signingPublicKey: 'pk'
+        })
+        .run()
+      insertJournal({
+        id: 'journal-tagged',
+        clock: { 'device-A': 2 },
+        syncedAt: '2026-01-02T00:00:00Z',
+        modifiedAt: '2026-01-01T00:00:00Z'
+      })
+
+      // A metadata-only write never touches modifiedAt, so without the fallback
+      // this journal stays invisible to recovery forever.
+      expect(recoverDirtyItems(db, journalAdapters).journals).toBe(0)
+
+      // #when — the property edit lands after the runtime was torn down, so the
+      // journal adapter's offline fallback is all that runs
+      incrementNoteClockOffline(db, 'journal-tagged')
+
+      // #then — the next runtime start pushes it, at a clock the server cannot
+      // dismiss as a replay of what it already has
+      const result = recoverDirtyItems(db, journalAdapters)
+      expect(result.journals).toBe(1)
+      expect(recovered).toEqual(['journal-tagged'])
+
+      const row = db.select().from(noteMetadata).where(eq(noteMetadata.id, 'journal-tagged')).get()
+      expect(row?.clock).toEqual({ 'device-A': 3 })
+    })
+  })
 })

--- a/apps/desktop/src/main/sync/dirty-recovery.ts
+++ b/apps/desktop/src/main/sync/dirty-recovery.ts
@@ -5,6 +5,7 @@ import { noteMetadata } from '@memry/db-schema/data-schema'
 import type { SyncAdapterRegistry } from '@memry/sync-core'
 import { tasks } from '@memry/db-schema/schema/tasks'
 import { projects } from '@memry/db-schema/schema/projects'
+import { getJournalSyncService } from './journal-sync'
 import { getNoteSyncService } from './note-sync'
 import { getProjectSyncService } from './project-sync'
 import { getTaskSyncService } from './task-sync'
@@ -18,6 +19,7 @@ export interface RecoveryResult {
   tasks: number
   projects: number
   notes: number
+  journals: number
 }
 
 /**
@@ -93,16 +95,18 @@ export function recoverDirtyItems(
   }
 
   const noteCount = recoverDirtyNotes(db, adapters)
+  const journalCount = recoverDirtyJournals(db, adapters)
 
-  if (taskCount > 0 || projectCount > 0 || noteCount > 0) {
+  if (taskCount > 0 || projectCount > 0 || noteCount > 0 || journalCount > 0) {
     log.info('Recovered dirty items for sync', {
       tasks: taskCount,
       projects: projectCount,
-      notes: noteCount
+      notes: noteCount,
+      journals: journalCount
     })
   }
 
-  return { tasks: taskCount, projects: projectCount, notes: noteCount }
+  return { tasks: taskCount, projects: projectCount, notes: noteCount, journals: journalCount }
 }
 
 /**
@@ -117,9 +121,11 @@ export function recoverDirtyItems(
  *
  * Scope is deliberately narrow: only notes the server already knows (`clock`
  * set) and that are not local-only. Clock-less notes belong to
- * `seedUnclockedNotes`, journals to the journal sync service. The recovered
- * enqueue reuses the stored clock instead of bumping it, so a note that is
- * actually in step is simply replay-detected by the server and stamped clean.
+ * `seedUnclockedNotes`, journals to `recoverDirtyJournals` below — they are a
+ * different sync service with a different payload builder, so they stay a
+ * separate query rather than a branch in this one. The recovered enqueue reuses
+ * the stored clock instead of bumping it, so a note that is actually in step is
+ * simply replay-detected by the server and stamped clean.
  */
 function recoverDirtyNotes(
   db: DrizzleDb,
@@ -150,4 +156,63 @@ function recoverDirtyNotes(
   }
 
   return dirtyNotes.length
+}
+
+/**
+ * The journal half of the sweep above. Journals live in the same
+ * `note_metadata` table but are pushed by their own sync service, so they need
+ * their own query and their own enqueue — the note arm excludes them by
+ * construction (`journalDate IS NULL`).
+ *
+ * Kept as a sibling rather than a branch inside `recoverDirtyNotes` on purpose:
+ * the two route to different services, and the journal payload builder takes an
+ * argument the note one does not. Folding them together would mean carrying the
+ * date and a service switch through a query that currently needs neither.
+ *
+ * The `date` handed to `enqueueRecoveredUpdate` is load-bearing.
+ * `JournalSyncService.buildSnapshotPayload` resolves the journal's file path
+ * from it *before* its own try/catch, and `formatJournalFilename` does
+ * `isoDate.split('-')`, so recovering a journal without one throws out of this
+ * loop and takes the whole sweep — tasks, projects and notes included — with it.
+ *
+ * Same narrow scope as notes: only journals the server already knows (`clock`
+ * set) and that are not local-only. Clock-less journals belong to
+ * `journalHandler.seedUnclocked`. The enqueue reuses the stored clock rather
+ * than bumping it, so a journal that is actually in step is replay-detected
+ * server side and simply stamped as synced.
+ */
+function recoverDirtyJournals(
+  db: DrizzleDb,
+  adapters?: SyncAdapterRegistry<DrizzleDb, (channel: string, data: unknown) => void>
+): number {
+  const journalSync = adapters?.getLocal('journal') ?? getJournalSyncService()
+  if (!journalSync?.enqueueRecoveredUpdate) return 0
+
+  const dirtyJournals = db
+    .select({ id: noteMetadata.id, journalDate: noteMetadata.journalDate })
+    .from(noteMetadata)
+    .where(
+      and(
+        isNotNull(noteMetadata.clock),
+        isNotNull(noteMetadata.journalDate),
+        sql`${noteMetadata.localOnly} IS NOT 1`,
+        or(
+          isNull(noteMetadata.syncedAt),
+          and(isNotNull(noteMetadata.syncedAt), gt(noteMetadata.modifiedAt, noteMetadata.syncedAt))
+        )
+      )
+    )
+    .all()
+
+  let recovered = 0
+  for (const journal of dirtyJournals) {
+    // Unreachable given the `isNotNull` above — but the date is what keeps the
+    // payload builder from throwing, so it is narrowed here rather than asserted.
+    if (!journal.journalDate) continue
+    log.debug('Recovering dirty journal', { noteId: journal.id })
+    journalSync.enqueueRecoveredUpdate(journal.id, journal.journalDate)
+    recovered++
+  }
+
+  return recovered
 }

--- a/apps/desktop/src/main/sync/journal-sync.test.ts
+++ b/apps/desktop/src/main/sync/journal-sync.test.ts
@@ -164,6 +164,23 @@ describe('JournalSyncService push', () => {
     expect(payload.properties).toEqual({ Mood: 'good' })
   })
 
+  it('re-pushes a recovered update at the stored clock, carrying the date it was given', () => {
+    seedJournalNote({ clock: { 'device-a': 4 } })
+
+    // Dirty recovery hands the date over from the row it selected. Without it
+    // the payload builder resolves a file path from `undefined` — outside its
+    // own try/catch — and throws out of the recovery loop.
+    makeService().enqueueRecoveredUpdate(JOURNAL_ID, DATE)
+
+    const payload = payloadOf(queueRows()[0])
+    expect(payload.date).toBe(DATE)
+    expect(payload.tags).toEqual(['daily'])
+    expect(JournalSyncPayloadSchema.safeParse(payload).success).toBe(true)
+    // Recovery re-sends the STORED clock: the one that never reached the server.
+    expect(payload.clock).toEqual({ 'device-a': 4 })
+    expect(storedClock()).toEqual({ 'device-a': 4 })
+  })
+
   it('coalesces a follow-up update into the pending create with the newest frontmatter', () => {
     seedJournalNote()
     const service = makeService()

--- a/apps/desktop/src/main/sync/local-mutations.test.ts
+++ b/apps/desktop/src/main/sync/local-mutations.test.ts
@@ -390,6 +390,29 @@ describe('local-mutations', () => {
     expect(incrementNoteClockOffline).not.toHaveBeenCalled()
   })
 
+  it('falls back to the offline clock bump when the journal sync service is down', () => {
+    const db = {}
+    ;(getDatabase as Mock).mockReturnValue(db)
+    ;(getJournalSyncService as Mock).mockReturnValue(null)
+
+    enqueueLocalSyncUpdate('journal', 'journal-1', '2026-08-04')
+
+    // Journals had the same fallback-less adapter notes used to have, and are
+    // additionally outside the note recovery sweep — so a metadata edit raised
+    // during runtime teardown had nothing at all to re-push it.
+    expect(incrementNoteClockOffline).toHaveBeenCalledWith(db, 'journal-1')
+  })
+
+  it('does not bump the offline clock when the journal sync service is up', () => {
+    const journalService = { enqueueUpdate: vi.fn() }
+    ;(getJournalSyncService as Mock).mockReturnValue(journalService)
+
+    enqueueLocalSyncUpdate('journal', 'journal-1', '2026-08-04')
+
+    expect(journalService.enqueueUpdate).toHaveBeenCalledWith('journal-1', '2026-08-04')
+    expect(incrementNoteClockOffline).not.toHaveBeenCalled()
+  })
+
   it('removes pending note sync items through the local sync helper', () => {
     const removeQueueItems = vi.fn(() => 2)
     ;(getNoteSyncService as Mock).mockReturnValue({ removeQueueItems })

--- a/apps/desktop/src/main/sync/local-mutations.ts
+++ b/apps/desktop/src/main/sync/local-mutations.ts
@@ -306,7 +306,20 @@ const localSyncRegistry = createSyncAdapterRegistry([
       },
       enqueueUpdate(itemId: string, date?: string): void {
         if (!date) return
-        getJournalSyncService()?.enqueueUpdate(itemId, date)
+
+        const service = getJournalSyncService()
+        if (service) {
+          service.enqueueUpdate(itemId, date)
+          return
+        }
+
+        // Same hole notes had, and worse: journals were also outside the note
+        // recovery sweep (`recoverDirtyNotes` filters `journalDate IS NULL`), so
+        // a metadata edit raised while the runtime was down (quit, vault switch,
+        // re-auth) had nothing left to re-push it — no queue row, no dirty
+        // marker, no sweep. Marking the row dirty hands it to
+        // `recoverDirtyJournals` at the next runtime start.
+        incrementNoteClockOffline(getDatabase(), itemId)
       },
       enqueueDelete(itemId: string, date?: string): void {
         if (!date) return

--- a/apps/desktop/src/main/sync/offline-clock.ts
+++ b/apps/desktop/src/main/sync/offline-clock.ts
@@ -247,6 +247,11 @@ function getCurrentDeviceId(db: DataDb): string | null {
  * Offline fallback for note metadata updates — the note counterpart of the
  * `increment*ClockOffline` helpers above, with two deliberate differences.
  *
+ * Journals use it too: they are `note_metadata` rows like notes, share the
+ * `clock`/`syncedAt`/`localOnly` columns this touches, and are re-pushed by
+ * `recoverDirtyJournals` on the same `syncedAt` signal. Only the sweep that
+ * picks the row up and the service that pushes it differ.
+ *
  * 1. It bumps under the REAL device id, not `OFFLINE_DEVICE_KEY`. The record
  *    types park ticks under `_offline` because they can be edited with no
  *    device registered at all, and their sync services rebind those ticks on
@@ -280,8 +285,9 @@ export function incrementNoteClockOffline(db: DataDb, noteId: string): void {
     // The user's "never leaves this device" switch — mirrors `shouldSkip` on
     // the online path.
     if (note.localOnly) return
-    // No clock means the note has never been pushed; `seedUnclockedNotes` owns
-    // its first push and would overwrite whatever we set here.
+    // No clock means the row has never been pushed; the unclocked seeds own its
+    // first push (`seedUnclockedNotes` for notes, `journalHandler.seedUnclocked`
+    // for journals) and would overwrite whatever we set here.
     if (!note.clock) return
 
     const deviceId = getCurrentDeviceId(db)

--- a/apps/docs/src/architecture/sync-protocol.md
+++ b/apps/docs/src/architecture/sync-protocol.md
@@ -126,21 +126,27 @@ server with nothing queued, and every later pull would resolve `skip` rather tha
 
 Items expose a "the server has this state" stamp (`syncedAt`) that advances on a confirmed push as
 well as on an applied pull. Anything modified after its stamp — or never stamped at all — is
-re-queued on the next full sync for tasks, projects and notes alike.
+re-queued on the next full sync for tasks, projects, notes and journals alike.
 
 Recovery re-sends the item's **stored** clock rather than bumping it. An item that is genuinely in
 step is then replay-detected by the server, costs one round trip, and is stamped clean; only an item
 that really is ahead of the server changes anything. Scope is limited to items the server already
-knows: clock-less rows belong to the initial seed, and journals to their own handler.
+knows: clock-less rows belong to the initial seed.
+
+Notes and journals share a table but not a sync service, so they are swept separately and each
+re-push is handed to the service that owns it. The journal sweep also carries the entry's date, which
+its payload builder needs to find the file on disk — recovering a journal without one would fail
+before the builder's own error handling and take the rest of the sweep down with it.
 
 Because recovery never advances a clock, a change made while the sync runtime is down has to advance
 its own at write time or the re-push would be dismissed as a replay. Records park that tick under a
-placeholder device that their sync service rebinds on the way out; notes have no rebinding step, so
-their fallback bumps under the current device directly and does nothing when no device is registered
-(the same thing the online path does). It also clears the sync stamp, because metadata-only writes —
-recording an uploaded attachment, say — deliberately leave `modifiedAt` alone and would otherwise be
-invisible to the "modified after its stamp" test above. A note that never leaves the device, and one
-with no clock yet, are both left alone.
+placeholder device that their sync service rebinds on the way out; notes and journals have no
+rebinding step, so their fallback bumps under the current device directly and does nothing when no
+device is registered (the same thing the online path does). It also clears the sync stamp, because
+metadata-only writes — recording an uploaded attachment or editing a journal's tags, say —
+deliberately leave `modifiedAt` alone and would otherwise be invisible to the "modified after its
+stamp" test above. A row that never leaves the device, and one with no clock yet, are both left
+alone.
 
 ### Foreign-key parents and orphan repair
 

--- a/packages/sync-core/src/adapter.ts
+++ b/packages/sync-core/src/adapter.ts
@@ -20,7 +20,7 @@ export interface RecordLocalSyncAdapter {
   enqueueUpdate(itemId: string, ...extra: unknown[]): void
   enqueueDelete(itemId: string, ...extra: unknown[]): void
   enqueueForPush?(itemId: string, operation: 'create' | 'update', ...extra: unknown[]): void
-  enqueueRecoveredUpdate?(itemId: string): void
+  enqueueRecoveredUpdate?(itemId: string, ...extra: unknown[]): void
 }
 
 export interface RemoteSyncAdapter<TDb = unknown, TEmit = unknown, TPayload = unknown> {

--- a/packages/sync-core/src/record-sync.ts
+++ b/packages/sync-core/src/record-sync.ts
@@ -104,18 +104,27 @@ export class RecordSyncController<
     })
   }
 
-  enqueueRecoveredUpdate(itemId: string): void {
+  /**
+   * `extra` is optional because most types serialize from the row alone. Types
+   * whose payload builder needs an argument (journals need their date) must
+   * pass it: the empty fallback would reach the builder as `undefined`, and
+   * `journal-sync`'s builder resolves a file path from it before its own
+   * try/catch, so it would throw out of the caller's recovery loop.
+   */
+  enqueueRecoveredUpdate(itemId: string, ...extra: TArgs): void {
     const deviceId = this.deps.getDeviceId()
     if (!deviceId) return
 
+    const args = extra.length > 0 ? extra : this.getFallbackArgs()
+
     if (!this.deps.recoverPendingChange) {
-      this.enqueueForPush(itemId, 'update', ...this.getFallbackArgs())
+      this.enqueueForPush(itemId, 'update', ...args)
       return
     }
 
     const recovered = this.deps.recoverPendingChange(itemId, deviceId)
     if (recovered === null) {
-      this.enqueueForPush(itemId, 'update', ...this.getFallbackArgs())
+      this.enqueueForPush(itemId, 'update', ...args)
       return
     }
 


### PR DESCRIPTION
Closes #965

## The hole

Journals had the same fallback-less local adapter notes had before #963 — `getJournalSyncService()?.enqueueUpdate(...)`, optional chaining, no else — and were additionally excluded from the sweep that fixed notes. `recoverDirtyNotes` filters `journalDate IS NULL` by construction.

So a journal metadata update raised while the sync runtime was down (quit, vault switch, re-auth) had nothing left to re-push it: no queue row, no dirty marker, no sweep. Real callers that hit this are `notes/entity-properties.ts` (journal properties) and `ipc/journal-handlers.ts` (tags/frontmatter).

## Nothing compensated — verified in source, not assumed

- `journalHandler.seedUnclocked` only selects `clock IS NULL`, so it owns first pushes and never sees a journal the server already knows.
- `seedUnclockedNotes` excludes journals outright (`journalDate IS NULL`).
- `checkManifestIntegrity` re-enqueues only items **absent** from the server manifest (`if (!serverRef)`). It does no version comparison, so a journal that exists on the server at a stale version is invisible to it.

## The fix

**1. Offline fallback on the journal adapter's `enqueueUpdate`** (`local-mutations.ts`), reusing `incrementNoteClockOffline`. Journals are `note_metadata` rows and share the exact columns that helper touches (`clock`, `syncedAt`, `localOnly`), so no second helper was warranted — its doc comment now states it serves both.

**2. A `recoverDirtyJournals` arm** (`dirty-recovery.ts`) selecting `journalDate IS NOT NULL`, routed through the journal sync service, adding `journals` to `RecoveryResult`.

**3. `enqueueRecoveredUpdate` forwards extra args** (`sync-core`, `content-sync-base.ts`) so the journal recovery can hand over the entry's date.

## Decisions, and why

**Separate `recoverDirtyJournals`, not a branch in `recoverDirtyNotes`.** The two route to different sync services *and* the journal payload builder takes an argument the note one does not. Folding them together would push a service switch and a date through a query that needs neither, and would edit the shipped note query — which I wanted left byte-for-byte alone. The doc comment that declared the ownership split is updated rather than contradicted.

**The recovery arm must pass the date — this is the non-obvious part.** `enqueueRecoveredUpdate(itemId)` calls `enqueueForPush(itemId, 'update', ...getFallbackArgs())`, and `getFallbackArgs()` returns `[]`. For journals `TArgs = [string]`, so the date reaches `JournalSyncService.buildSnapshotPayload` as `undefined`. That builder calls `getJournalPath(date)` **outside** its own try/catch, and `formatJournalFilename` does `isoDate.split('-')` — so a naive copy of the note arm throws a `TypeError` out of the recovery loop and takes the **whole sweep down with it**, tasks and projects included. Hence change (3).

I considered instead defaulting to `cached.journalDate` inside the payload builder (one file, no shared-package change). Rejected: it forces the builder to fabricate a payload for the "journal row with no date" case it cannot skip, and the frozen bad payload would still reach the wire via `resolvePushPayload`'s fallback. Passing the date keeps the builder's `date: string` contract intact and makes the omission a compile error at the `ContentSyncService` boundary.

## The two fixed constraints

**Clock is advanced at write time.** The fallback bumps before returning; recovery deliberately does not bump (`content-sync-base.ts` re-sends the stored clock). Pinned by `journal-sync.test.ts`, which asserts the recovered push carries the *stored* clock and the row is not re-bumped, and by the dirty-recovery test asserting `{ 'device-A': 3 }` after the fallback.

**No `_offline` key.** `incrementNoteClockOffline` bumps under `sync_devices.is_current_device` and no-ops when no device is registered — matching `handleMissingDevice` on the online path. `ContentSyncService` has no rebinding hook, so an `_offline` tick would reach peers as a device id two machines could both claim. Already covered by the note tests; journals inherit it by using the same helper.

## Backward compatibility

No schema change, no migration, no contract or payload change. `clock` and `syncedAt` are existing columns; `syncedAt` is already nullable and already means "never confirmed synced". Nothing new goes on the wire — the recovered push is an ordinary journal update, and `journalHandler.buildPushPayload` rebuilds it from the row at push time exactly as before. Peers on older builds are unaffected.

`enqueueRecoveredUpdate(itemId, ...extra)` is additive: every existing caller passes no extra args and takes the identical `getFallbackArgs()` path.

## Tests

`pnpm --filter @memry/desktop exec vitest run --config config/vitest.config.ts --project main src/main/sync`

```
PASS (1654) FAIL (0) skipped (3)
```

`packages/sync-core`: `PASS (6) FAIL (0)`. `pnpm typecheck` green. ESLint 0 errors on all changed files. `docs:impact --strict` passes, `docs:build` green.

New coverage:

- `dirty-recovery.test.ts` — real in-memory data DB and the real recovery predicate: a diverged journal is recovered; clean, local-only, clock-less journals and plain notes are left alone; and end-to-end, a server-confirmed journal is *not* recovered until the fallback runs, then is re-pushed at an advanced clock.
- `journal-sync.test.ts` — real `RecordSyncController` + real queue: a recovered update carries the date it was given and re-sends the stored clock without bumping it.
- `local-mutations.test.ts` — the journal adapter reaches the fallback when the service is null, and does not when it is up.

### Mutation check

Each half reverted separately, red observed, restored.

1. Adapter fallback (`incrementNoteClockOffline` → no-op):

```
1. local-mutations falls back to the offline clock bump when the journal sync service is down
   AssertionError: expected "vi.fn()" to be called with arguments: [ {}, 'journal-1' ]
   Number of calls: 0
```

2. Recovery arm (`recoverDirtyJournals` call removed):

```
1. dirty-recovery journals recovers a synced journal whose local change never reached the server
   AssertionError: expected +0 to be 1
2. dirty-recovery journals re-pushes a journal whose update was enqueued while the sync service was down
   AssertionError: expected +0 to be 1
```

3. Date pass-through (`extra` ignored in `enqueueRecoveredUpdate`):

```
1. JournalSyncService push re-pushes a recovered update at the stored clock, carrying the date it was given
   AssertionError: expected undefined to be '2026-05-10'
```

Restored: `PASS (1654) FAIL (0)`.

## Deliberately out of scope

- **`enqueueCreate` / `enqueueDelete` on journals** keep the no-op. Confirmed in source rather than carried over from the note conclusion: `journalHandler.seedUnclocked` sweeps `clock IS NULL AND journalDate IS NOT NULL` into a create at the next runtime start, so a journal that has never been pushed is already owned.
- **`checkManifestIntegrity` doing version comparison.** It would also cover this class of drift, but it is a 30-minute periodic network check with a much wider blast radius than the issue calls for.
- **CRDT body content.** This is the metadata push only; journal bodies ride the CRDT path and are unaffected.
