### PR TITLE
fix(calendar): keep the quick-create popover inside the window

### DIFF
--- a/apps/desktop/src/renderer/src/components/calendar/popover-position.test.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/popover-position.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { POPOVER_WIDTH, computePopoverPosition } from './popover-position'
+
+const VIEWPORT = { width: 1550, height: 900 }
+
+function withViewport<T>(run: () => T): T {
+  const originalWidth = window.innerWidth
+  const originalHeight = window.innerHeight
+  Object.defineProperty(window, 'innerWidth', { value: VIEWPORT.width, configurable: true })
+  Object.defineProperty(window, 'innerHeight', { value: VIEWPORT.height, configurable: true })
+  try {
+    return run()
+  } finally {
+    Object.defineProperty(window, 'innerWidth', { value: originalWidth, configurable: true })
+    Object.defineProperty(window, 'innerHeight', { value: originalHeight, configurable: true })
+  }
+}
+
+describe('computePopoverPosition', () => {
+  it('places the popover to the right of the anchor when it fits', () => {
+    const { top, left } = withViewport(() =>
+      computePopoverPosition({ x: 430, y: 132, width: 125, height: 48 })
+    )
+    expect(left).toBe(430 + 125 + 8)
+    expect(top).toBe(132)
+  })
+
+  it('flips to the left of the anchor when the right side would overflow', () => {
+    const { left } = withViewport(() =>
+      computePopoverPosition({ x: 1300, y: 200, width: 125, height: 48 })
+    )
+    expect(left).toBe(1300 - POPOVER_WIDTH - 8)
+  })
+
+  it('keeps the popover inside the window when the anchor is far off-screen left', () => {
+    // Regression: the week grid is an infinitely virtualized strip, so its own
+    // rect sits millions of pixels to the left once scrolled to today. Anchoring
+    // on it parked the popover off-window, where its Save button could never be
+    // clicked — Playwright reported "element is outside of the viewport" forever.
+    const { top, left } = withViewport(() =>
+      computePopoverPosition({ x: -2_591_714, y: 132, width: 125, height: 48 })
+    )
+    expect(left).toBeGreaterThanOrEqual(8)
+    expect(left + POPOVER_WIDTH).toBeLessThanOrEqual(VIEWPORT.width)
+    expect(top).toBe(132)
+  })
+
+  it('keeps the popover inside the window when the anchor is far off-screen right', () => {
+    const { left } = withViewport(() =>
+      computePopoverPosition({ x: 2_591_714, y: 132, width: 125, height: 48 })
+    )
+    expect(left).toBeGreaterThanOrEqual(8)
+    expect(left + POPOVER_WIDTH).toBeLessThanOrEqual(VIEWPORT.width)
+  })
+
+  it('keeps the popover inside the window when the anchor is below the fold', () => {
+    const { top } = withViewport(() =>
+      computePopoverPosition({ x: 430, y: 5000, width: 125, height: 48 })
+    )
+    expect(top).toBeGreaterThanOrEqual(8)
+    expect(top).toBeLessThanOrEqual(VIEWPORT.height - 240)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/calendar/popover-position.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/popover-position.ts
@@ -14,7 +14,12 @@ export function computePopoverPosition(
 
   const rightCandidate = anchor.x + anchor.width + POPOVER_GAP
   const fitsRight = rightCandidate + width + 8 <= viewportWidth
-  const left = fitsRight ? rightCandidate : Math.max(8, anchor.x - width - POPOVER_GAP)
+  const preferredLeft = fitsRight ? rightCandidate : anchor.x - width - POPOVER_GAP
+  // Clamp both edges into the window. An anchor can sit outside the viewport —
+  // the week grid is an infinitely virtualized strip whose own rect is millions
+  // of pixels off-screen — and an unclamped `left` then parked the popover
+  // outside the window, where its Save/action row could never be clicked.
+  const left = Math.min(Math.max(8, preferredLeft), Math.max(8, viewportWidth - width - 8))
   const top = Math.min(Math.max(8, anchor.y), Math.max(8, viewportHeight - estimatedHeight))
   return { top, left }
 }

--- a/apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.test.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.test.ts
@@ -270,6 +270,55 @@ describe('useTimeGridMarquee', () => {
     vi.unstubAllGlobals()
   })
 
+  it('anchors on the column offset when the column element cannot be measured', () => {
+    // Week view renders an infinitely virtualized day strip: the grid element is
+    // ~4.5M px wide and, once scrolled to today, its own left edge sits ~2.5M px
+    // outside the window. Falling back to that edge put the quick-create popover
+    // off-window entirely, so its Save button was unclickable.
+    const COLUMN_WIDTH = 125
+    const COLUMN_COUNT = 36_525
+    const TODAY_INDEX = 20_671
+    const GRID_LEFT = 304 - 20_670 * COLUMN_WIDTH
+
+    const grid = document.createElement('div')
+    Object.defineProperty(grid, 'scrollTop', { value: 0, writable: true })
+    grid.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          top: 100,
+          left: GRID_LEFT,
+          bottom: 1252,
+          right: GRID_LEFT + COLUMN_WIDTH * COLUMN_COUNT,
+          width: COLUMN_WIDTH * COLUMN_COUNT,
+          height: 1152,
+          x: GRID_LEFT,
+          y: 100,
+          toJSON: () => ({})
+        }) as DOMRect
+    )
+    const ref = { current: grid } as React.RefObject<HTMLDivElement | null>
+    const { result } = renderHook(() =>
+      useTimeGridMarquee({
+        gridRef: ref,
+        dateForColumn: () => '2026-08-06',
+        columnCount: COLUMN_COUNT,
+        // The virtualizer had not rendered this column yet.
+        getColumnElement: () => null
+      })
+    )
+
+    act(() => {
+      result.current.handlers.onDoubleClick(
+        { clientY: 196, target: grid, preventDefault: vi.fn() } as unknown as React.MouseEvent,
+        TODAY_INDEX
+      )
+    })
+
+    expect(result.current.selection!.anchorRect).toEqual(
+      expect.objectContaining({ x: 429, width: COLUMN_WIDTH })
+    )
+  })
+
   it('clears click-only drags on mouseup', () => {
     const ref = createMockGridRef()
     const { result } = renderHook(() =>

--- a/apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.ts
+++ b/apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.ts
@@ -113,10 +113,16 @@ function buildSelection(
     ? getColumnElement(columnIndex)
     : ((el?.children?.[columnIndex + 1] as HTMLElement | undefined) ?? null)
   const colRect = columnEl?.getBoundingClientRect()
+  const fallbackColumnWidth = (gridRect?.width ?? 0) / Math.max(columnCount, 1)
   const anchorRect = {
-    x: colRect?.x ?? gridRect?.x ?? 0,
+    // Week view's grid is an infinitely virtualized strip, so `gridRect.x` is the
+    // strip's own left edge — millions of pixels off-screen once scrolled to
+    // today. Collapsing the anchor onto it placed the quick-create popover
+    // outside the window; offset by the column instead. Day view has a single
+    // column at index 0, so its anchor is unchanged.
+    x: colRect?.x ?? (gridRect?.x ?? 0) + columnIndex * fallbackColumnWidth,
     y: (gridRect?.top ?? 0) + top - scrollTop,
-    width: colRect?.width ?? (gridRect?.width ?? 0) / Math.max(columnCount, 1),
+    width: colRect?.width ?? fallbackColumnWidth,
     height
   }
   return {

--- a/apps/docs/src/contribute/gotchas.md
+++ b/apps/docs/src/contribute/gotchas.md
@@ -89,6 +89,17 @@ Fix: fire submit from `onPointerDown`. Keep `onClick` as a keyboard-activation f
 
 See `calendar-quick-create-dialog.tsx` for the canonical version.
 
+## Anchor Rects From Virtualized Scrollers Are Not Viewport Coordinates
+
+The calendar week grid is an **infinitely virtualized day strip**: the grid element is roughly 4.5 million pixels wide, and once it is scrolled to today its own left edge sits about 2.6 million pixels outside the window. Using that element's rect as a popover anchor — for example as a fallback when the day column element cannot be measured — places the popover far off-screen. It still reports as visible and enabled, so a click on it retries until the test or the user gives up.
+
+Two rules when anchoring floating UI on a virtualized grid:
+
+1. Anchor on the **column** element, and derive the column offset (`gridRect.x + columnIndex * columnWidth`) when that element is not measurable. Never collapse onto the strip's own left edge.
+2. Clamp the computed position into the viewport on **both** axes, so a bad anchor can never push an action row out of reach.
+
+`computePopoverPosition` in `popover-position.ts` owns the clamp for every calendar popover (task, note, event, inbox-snooze, quick-create).
+
 ## Editor-Zone Mousedown Handlers Steal Focus from BlockNote Menus
 
 BlockNote's shadcn menus (drag-handle menu, side menu, toolbars and their nested dropdowns) render **inline inside `.bn-container`, not portaled**. Any editor-zone mousedown handler — such as the "click the marquee zone to focus the editor at end" handler in `note.tsx` / `journal.tsx`, or the marquee selection hook — therefore also sees clicks on menu items. If such a handler focuses the editor on mousedown, the menu unmounts between `pointerdown` and `pointerup`, so the item's click never lands and the action silently does nothing (for example, drag-handle Colors/Delete appear to do nothing).


### PR DESCRIPTION
Desktop CI "Electron E2E full (3/16)" has been red on main with one failing test:

`apps/desktop/tests/e2e/calendar-marquee.e2e.ts:100` — *drag + Save-button click creates event (week view) — regression*

```
TimeoutError: locator.click: Timeout 30000ms exceeded.
  - waiting for getByTestId('quick-create-popover').getByTestId('quick-create-save')
    - locator resolved to <button data-testid="quick-create-save" ...>Save</button>
    - element is visible, enabled and stable
    - scrolling into view if needed
    - element is outside of the viewport
    - retrying click action  (60+ times, always the same)
```

Not the old "submit button disables itself mid-click" defect — that fix (`onPointerDown`) is still in place and still works. This one is placement: the popover is rendered outside the window, so `Save` can never be clicked. That is a **product** bug, not a test bug: any user in that state cannot reach Save either.

## Root cause

The week grid is an **infinitely virtualized day strip**. `useWeekInfiniteScroll` renders 36,525 day columns, so `gridRef`'s element is roughly 4.5M px wide, and `scrollLeft` is set to `todayIndex * columnWidth` (~2.6M px). The strip's own `getBoundingClientRect().x` is therefore about **-2,600,000** — far outside the window — while its `.top` is a normal viewport coordinate.

Two places trusted that rect:

1. `apps/desktop/src/renderer/src/components/calendar/use-time-grid-marquee.ts:117` — `buildSelection` fell back to `gridRect.x` whenever the day column element could not be measured, collapsing the marquee anchor onto the strip's off-screen left edge. `anchorRect.y` is derived from `gridRect.top` and stays correct, so only x goes wrong.
2. `apps/desktop/src/renderer/src/components/calendar/popover-position.ts:17` — `computePopoverPosition` clamped only the near edge (`Math.max(8, ...)`) and, in the "fits to the right" branch, nothing at all. It trusted the anchor to be on-screen, so an off-screen anchor produced an off-screen popover.

The CI failure screenshot confirms the split: the marquee overlay ("New Event 8:00 AM - 9:00") renders in the correct column at the correct y, and the popover is nowhere in the 1550x900 viewport. Correct y + wrong x is exactly the signature of the `colRect?.x ?? gridRect?.x` fallback.

## Fix

- `use-time-grid-marquee.ts` — offset the fallback anchor by the column: `gridRect.x + columnIndex * columnWidth`. Day view has a single column at index 0, so its anchor is identical to before.
- `popover-position.ts` — clamp the popover into the viewport on the far edge as well as the near one, so no anchor can push its action row out of reach. This covers every caller: task, note, event, inbox-snooze and quick-create popovers.

Deliberately **not** done: no `test.skip`, no `fixme`, no extra retries, no larger timeout, no `force: true`. All of those would hide a real unreachable-Save bug from users.

## Reproduction and evidence

The E2E does not reproduce on macOS — the failing geometry needs the column element to be momentarily unmeasurable, which only happened on the Linux runner. Verified 10/10 green locally at the exact CI viewport (1550x900, calendar view at x=256 w=974, popover left ~563), so the E2E alone could not prove or disprove anything. The defect is pure geometry, so it is reproduced deterministically at that level instead, using the real CI numbers.

**Mutation check** — fix reverted, tests go red:

```
× computePopoverPosition > keeps the popover inside the window when the anchor is far off-screen left
  → expected -2591581 to be greater than or equal to 8
× computePopoverPosition > keeps the popover inside the window when the anchor is far off-screen right
  → expected 2591706 to be less than or equal to 1550
× useTimeGridMarquee > anchors on the column offset when the column element cannot be measured
  → expected { x: -2583446, ... } to deeply equal ObjectContaining{...}
Tests  3 failed | 23 passed (26)
```

Fix restored:

```
Test Files  2 passed (2)
     Tests  26 passed (26)
```

**Whole calendar unit suite**: `Test Files 38 passed (38)  Tests 282 passed (282)`

**Marquee E2E, 3 consecutive runs of the full file (18/18)**:

```
✓  3 calendar-marquee.e2e.ts:100:7 › drag + Save-button click creates event (week view) — regression (5.3s)
✓  9 calendar-marquee.e2e.ts:100:7 › drag + Save-button click creates event (week view) — regression (5.4s)
✓ 15 calendar-marquee.e2e.ts:100:7 › drag + Save-button click creates event (week view) — regression (5.3s)
18 passed (1.6m)
```

`pnpm typecheck` 16/16 successful · `pnpm lint` 0 errors (10 pre-existing warnings, none in touched files) · `pnpm docs:impact --strict` covered · `pnpm docs:build` complete.

## Notes

- No IPC, schema, sync-protocol or file-format change — renderer geometry only, so nothing to migrate.
- No RTL concern: the change is inline `top`/`left` on a portaled fixed element, no physical Tailwind classes added.
