### PR TITLE
fix(inbox): don't fail task conversion when sync enqueue throws

### DIFF
--- a/apps/desktop/src/main/inbox/filing.test.ts
+++ b/apps/desktop/src/main/inbox/filing.test.ts
@@ -35,6 +35,7 @@ const mockCopyFile = vi.fn()
 const mockUnlink = vi.fn()
 const mockExistsSync = vi.fn()
 const mockSyncTaskCreate = vi.fn()
+const mockTrackMainError = vi.fn()
 const mockInsertTask = vi.fn()
 const mockGetNextTaskPosition = vi.fn()
 const mockSetTaskTags = vi.fn()
@@ -94,6 +95,10 @@ vi.mock('../lib/logger', () => ({
 
 vi.mock('../tasks/runtime-effects', () => ({
   syncTaskCreate: (...args: unknown[]) => mockSyncTaskCreate(...args)
+}))
+
+vi.mock('../telemetry/diagnostics', () => ({
+  trackMainError: (...args: unknown[]) => mockTrackMainError(...args)
 }))
 
 vi.mock('../database/queries/tasks', () => ({
@@ -180,6 +185,7 @@ describe('Inbox Filing Operations', () => {
     mockUnlink.mockReset().mockResolvedValue(undefined)
     mockExistsSync.mockReset().mockReturnValue(false)
     mockSyncTaskCreate.mockReset()
+    mockTrackMainError.mockReset()
     mockInsertTask.mockReset().mockImplementation((_db, input) => ({ ...input }))
     mockGetNextTaskPosition.mockReset().mockReturnValue(42)
     mockSetTaskTags.mockReset()
@@ -1014,6 +1020,31 @@ describe('Inbox Filing Operations', () => {
 
       await expect(convertToTask(failingItemId)).resolves.toEqual(
         expect.objectContaining({ success: false, error: 'insert failed' })
+      )
+    })
+
+    it('still reports success when syncTaskCreate throws (task persisted locally)', async () => {
+      const itemId = seedInboxItem(testDb.db, {
+        id: 'task-sync-throws',
+        type: 'note',
+        title: 'Sync enqueue fails'
+      })
+      const syncError = new Error('sync runtime down')
+      mockSyncTaskCreate.mockImplementationOnce(() => {
+        throw syncError
+      })
+
+      const result = await convertToTask(itemId)
+
+      expect(result.success).toBe(true)
+      expect(result.taskId).toEqual(expect.any(String))
+      const row = testDb.db.select().from(inboxItems).where(eq(inboxItems.id, itemId)).get()
+      expect(row?.filedAction).toBe('task')
+      expect(row?.filedTo).toBe(result.taskId)
+      expect(mockTrackMainError).toHaveBeenCalledWith(
+        'inbox',
+        'task_conversion_sync_enqueue',
+        syncError
       )
     })
 

--- a/apps/desktop/src/main/inbox/filing.ts
+++ b/apps/desktop/src/main/inbox/filing.ts
@@ -32,6 +32,7 @@ import { extractYouTubeVideoId } from '@memry/shared/youtube'
 import { extractDomain } from './metadata-utils'
 import { publishProjectionEvent } from '../projections'
 import { syncTaskCreate } from '../tasks/runtime-effects'
+import { trackMainError } from '../telemetry/diagnostics'
 
 const log = createLogger('Inbox:Filing')
 
@@ -803,7 +804,12 @@ export async function convertToTask(
     const enrichedTask = { ...task, linkedNoteIds: [] as string[] }
     broadcastToAllWindows(TasksChannels.events.CREATED, { task: enrichedTask })
 
-    syncTaskCreate(taskId)
+    try {
+      syncTaskCreate(taskId)
+    } catch (error) {
+      log.warn('syncTaskCreate failed; task persisted locally', error)
+      trackMainError('inbox', 'task_conversion_sync_enqueue', error)
+    }
 
     return { success: true, taskId }
   } catch (error) {


### PR DESCRIPTION
## What
Wrap `syncTaskCreate` in `convertToTask` with the same try/catch + telemetry guard `convertToEvent` already uses, so a sync enqueue failure no longer reports an already-committed conversion as failed.

## Why
The item was already filed and the task row committed before the enqueue call; the throw only corrupted the caller's view (item filed, task local-only, reported as failure). Local task stays valid and dirty-recovery sweeps it later.