### PR TITLE
test(sync-server): sweep every trusted key for PostHog dimension collisions

### DIFF
--- a/apps/sync-server/src/services/posthog-transform.test.ts
+++ b/apps/sync-server/src/services/posthog-transform.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import type { TelemetryBatch } from '@memry/contracts/telemetry-api'
+import type {
+  TelemetryBatch,
+  TelemetryEvent,
+  TelemetryMetrics
+} from '@memry/contracts/telemetry-api'
 
 import {
   exceptionEvent,
@@ -167,6 +171,114 @@ describe('productEvent', () => {
     )
     expect(result.properties.log_action).toBe('gpu_gone')
   })
+})
+
+// productEvent writes client dimensions FIRST and every server-derived key after,
+// so a trusted value always overwrites a colliding client one. Only `environment`
+// and `session_id` had dedicated regression tests above; the rest of the trusted
+// keys rested on that structural ordering plus a code comment, so an edit that
+// inserted a new trusted assignment ABOVE the dimensions loop would have gone
+// unnoticed. The sweep below covers every trusted key at once.
+//
+// SafeDimensionKeySchema now also rejects reserved and `$`-prefixed dimension
+// keys outright, which reduces but does not replace this: the ordering is the
+// second line of defence, and these fixtures are built directly rather than
+// parsed so they deliberately carry keys the schema would refuse.
+const SPOOFED_DIMENSION_VALUE = 'client-spoofed'
+
+// The Required<> annotations are the anti-drift guard. TRUSTED_KEYS is derived
+// from the implementation, but a NEW conditional trusted key would only show up
+// there if these fixtures populate the field that gates it. Typing them as
+// Required<> means a fresh optional field on TelemetryEvent, TelemetryMetrics or
+// TelemetryBatch stops this file typechecking until the fixture covers it, so
+// the gap cannot reopen quietly.
+const maximalMetrics: Required<TelemetryMetrics> = {
+  durationMs: 42,
+  itemCount: 7,
+  byteCount: 2048,
+  queueCount: 3,
+  resultCount: 11,
+  retryCount: 2,
+  activeSeconds: 90,
+  value: 5
+}
+
+const maximalBatch = (): TelemetryBatch => {
+  const batch: Required<TelemetryBatch> = { ...batchFixture(), clientQueueDepth: 4 }
+  return batch
+}
+
+const maximalEvent = (dimensions?: Record<string, string>): TelemetryEvent => {
+  const event: Required<Omit<TelemetryEvent, 'dimensions'>> = {
+    id: '44444444-4444-4444-8444-444444444444',
+    name: 'note_created',
+    occurredAt: '2026-07-22T10:00:00.000Z',
+    surface: 'notes',
+    action: 'create',
+    objectType: 'note',
+    source: 'command_palette',
+    result: 'success',
+    errorCode: 'SYNC_TIMEOUT',
+    metrics: maximalMetrics,
+    error: { message: 'boom', stack: 'at boom (a.js:1:1)', componentStack: 'at Note' }
+  }
+  return dimensions ? { ...event, dimensions } : event
+}
+
+// Read off the implementation rather than hand-listed, so a trusted key added
+// later is swept without anyone remembering to extend this file.
+const TRUSTED_KEYS = Object.keys(productEvent(maximalBatch(), maximalEvent(), ctx).properties)
+
+describe('productEvent trusted-key collisions', () => {
+  it('owns exactly the reviewed set of server-derived keys', () => {
+    // The sweep below adapts on its own; this is the reviewed record of what
+    // productEvent is allowed to own, so adding or dropping a trusted key has to
+    // be a deliberate, visible change rather than a silent one.
+    expect([...TRUSTED_KEYS].sort()).toEqual(
+      [
+        'surface',
+        'action',
+        'environment',
+        'session_id',
+        '$set',
+        'platform',
+        'app_version',
+        'build_channel',
+        'object_type',
+        'source',
+        'result',
+        'error_code',
+        'duration_ms',
+        'item_count',
+        'byte_count',
+        'queue_count',
+        'result_count',
+        'retry_count',
+        'active_seconds',
+        'value'
+      ].sort()
+    )
+  })
+
+  it.each(TRUSTED_KEYS)(
+    'does not let a client dimension named "%s" overwrite the server-derived value',
+    (key) => {
+      const baseline = productEvent(maximalBatch(), maximalEvent(), ctx).properties
+      const spoofed = productEvent(
+        maximalBatch(),
+        maximalEvent({ [key]: SPOOFED_DIMENSION_VALUE }),
+        ctx
+      ).properties
+
+      // Fixture sanity: a trusted value that already equalled the sentinel would
+      // make the assertions below pass for the wrong reason.
+      expect(baseline[key]).not.toBe(SPOOFED_DIMENSION_VALUE)
+      expect(spoofed[key]).toEqual(baseline[key])
+      // Nothing else shifts either: the colliding key is fully absorbed, so the
+      // client cannot smuggle a value in under any trusted name.
+      expect(spoofed).toEqual(baseline)
+    }
+  )
 })
 
 describe('exceptionEvent', () => {


### PR DESCRIPTION
Partial fix for #864 — item 4 only. Items 1, 2 and 3 are untouched.

## Problem

`productEvent` (`apps/sync-server/src/services/posthog-transform.ts`) writes client-supplied dimensions **first** and every server-derived key **after**, so a trusted value always overwrites a colliding client one. That ordering closed a real vulnerability: a dimension named `environment` or `session_id` could clobber the server's value.

Only those two keys had dedicated regression tests. `surface`, `action`, `$set`, `platform`, `app_version`, `build_channel`, `object_type`, `source`, `result`, `error_code` and the eight metric destinations rested on the ordering plus a code comment. An edit that inserted one new trusted assignment *above* the dimensions loop would not have been caught.

The schema-level guard added later (`SafeDimensionKeySchema` rejects reserved and `$`-prefixed dimension keys outright) reduces but does not replace this — the ordering is still the second line of defence, so the new fixtures are constructed directly rather than parsed and deliberately carry keys the schema would refuse.

## Change

Test-only. `productEvent` is unchanged.

- `TRUSTED_KEYS` is **derived from the implementation** at module load: run `productEvent` over a maximally populated event with no dimensions and read the resulting property keys. A trusted key added later is swept without anyone remembering to extend the test.
- `it.each(TRUSTED_KEYS)` re-runs the transform with a client dimension of that exact name and asserts the trusted value survives, plus that the whole properties object is byte-identical to the baseline — so a client cannot smuggle a value in under any trusted name.
- Anti-drift guard for the one case derivation alone cannot see (a *conditional* trusted key whose gating field the fixture does not populate): the fixtures are typed `Required<Omit<TelemetryEvent, 'dimensions'>>`, `Required<TelemetryMetrics>` and `Required<TelemetryBatch>`, so a new optional field on any of those three stops the file typechecking until the fixture covers it.
- An inventory assertion pins the derived set against the reviewed list of 20 keys, so adding or dropping a trusted key is a deliberate, visible change rather than a silent one.

20 keys now covered: `surface`, `action`, `environment`, `session_id`, `$set`, `platform`, `app_version`, `build_channel`, `object_type`, `source`, `result`, `error_code`, `duration_ms`, `item_count`, `byte_count`, `queue_count`, `result_count`, `retry_count`, `active_seconds`, `value`.

No ordering bug was found while reading `productEvent`; the implementation is correct as written.

## Proof the test bites

Moving **one** trusted assignment (`result`) above the dimensions loop — the exact drift the issue describes. Every pre-existing test still passed; only the new sweep caught it:

```
 ❯ src/services/posthog-transform.test.ts (44 tests | 1 failed) 11ms
     × does not let a client dimension named "result" overwrite the server-derived value 3ms

 FAIL  productEvent trusted-key collisions > does not let a client dimension named "result" overwrite the server-derived value
AssertionError: expected 'client-spoofed' to deeply equal 'success'

Expected: "success"
Received: "client-spoofed"

 Test Files  1 failed (1)
      Tests  1 failed | 43 passed (44)
```

Moving the whole dimensions loop to the end fails all 20 sweep cases:

```
     × does not let a client dimension named "surface" overwrite the server-derived value 0ms
     × does not let a client dimension named "action" overwrite the server-derived value 0ms
     ... (all 20)
     × does not let a client dimension named "value" overwrite the server-derived value 0ms
 Test Files  1 failed (1)
      Tests  23 failed | 21 passed (44)
```

Both mutations were reverted; `git diff` touches only the test file.

## Verify

```
pnpm lint              → 0 errors, 10 warnings (all pre-existing, apps/desktop)
pnpm typecheck         → 16 successful, 16 total
pnpm test:sync-server  → 57 files, 882 tests passed
git diff --check       → clean
pnpm docs:impact --base origin/main --strict
                       → no desktop/sync-server docs-relevant changes detected
```
