### PR TITLE
perf(landing): split posthog-js into its own cached chunk

### DIFF
--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -97,6 +97,11 @@ export default defineConfig(({ mode }) => {
             'react-vendor': ['react', 'react-dom', 'react-router'],
             motion: ['framer-motion', 'lenis'],
             paddle: ['@paddle/paddle-js'],
+            // Must stay the module.full.no-external subpath: the bare specifier
+            // resolves to the lean bundle that lazy-loads rrweb as an external
+            // script, which disable_external_dependency_loading blocks, silently
+            // killing session replay. See src/lib/analytics.ts.
+            posthog: ['posthog-js/dist/module.full.no-external'],
             crypto: ['libsodium-wrappers-sumo'],
             icons: ['lucide-react', '@hugeicons/react', '@hugeicons/core-free-icons']
           }


### PR DESCRIPTION
Partial fix for #864 — **item 1 only**. Items 2, 3 and 4 are untouched.

## What

Adds `posthog-js/dist/module.full.no-external` to `manualChunks` in `apps/landing/vite.config.ts`, next to the existing `react-vendor` / `motion` / `paddle` / `crypto` / `icons` entries. One file, five added lines.

Until now the PostHog bundle — rrweb **plus** surveys, exception-autocapture, web-vitals, dead-clicks-autocapture, all statically included — sat inside the main entry chunk. Every marketing-site visitor downloaded it before first paint, and any unrelated app-code deploy invalidated its cache along with the app code. It now lives in its own chunk under the immutable per-lib cache policy in `vercel.json`.

## Before / after

Real numbers from `pnpm --filter @memry/landing build` (`vite build`, production mode), not estimates:

| chunk | before | after |
| --- | --- | --- |
| `index` (entry) | 1,327.24 kB / **376.65 kB gzip** | 802.02 kB / **211.18 kB gzip** |
| `posthog` | — (inside entry) | 523.13 kB / **163.80 kB gzip** |

Entry chunk drops **165.47 kB gzip (−44%)** off the first-paint critical path. Total shipped bytes are unchanged (−2.09 kB raw from chunk-boundary bookkeeping) — this is a caching and first-paint change, not a payload reduction. That part is the next section.

## Do NOT substitute the bare `posthog-js` import

The size below is not a bug to be "fixed" by switching to the bare specifier. `posthog-js` has no `exports`/`browser` field, so `import posthog from 'posthog-js'` resolves to the lean `dist/module.js`, which has no rrweb compiled in and lazy-loads `/static/recorder.js` as an external `<script>`. `disable_external_dependency_loading: true` (set in `src/lib/analytics.ts`) blocks that fetch, so session replay silently never starts — **zero recordings, no error**. This project has already lost working replay to exactly this trap once. The `module.full.no-external` subpath is deliberate; a comment on the new `manualChunks` line now says so at the point where someone would be tempted to change it.

## Payload options — measured, not applied

#864 also asks whether replay, surveys and exception-autocapture are all needed on a marketing site. Not deciding that unilaterally. Here are the real numbers so it can be decided on evidence — each row is an actual production build of the landing app with that entrypoint, measuring the `posthog` chunk:

| option | `posthog` chunk | gzip | saves (gzip) | what is lost |
| --- | --- | --- | --- | --- |
| **`module.full.no-external`** (current, this PR) | 523.13 kB | **163.80 kB** | — | nothing |
| `module.slim.no-external` + `SessionReplayExtensions` + `AnalyticsExtensions` | 413.03 kB | **136.22 kB** | **−27.58 kB** | surveys, exception-autocapture, dead-clicks, logs, tracing-headers. Keeps replay + autocapture/heatmaps/web-vitals |
| `module.no-external` | 250.02 kB | **77.78 kB** | **−86.02 kB** | session replay only (rrweb). Keeps surveys, exception-autocapture, web-vitals, dead-clicks |
| `module.slim.no-external` (core only) | 116.53 kB | **39.39 kB** | **−124.41 kB** | replay, surveys, exception-autocapture, dead-clicks, web-vitals — everything opt-in |

Which decomposes to:

- **session replay (rrweb) ≈ 86 kB gzip** — by far the largest single line item.
- **surveys + exception-autocapture + dead-clicks + web-vitals + logs + tracing-headers ≈ 38 kB gzip combined.**

Reading it: dropping surveys and exception-autocapture while keeping replay buys ~28 kB. Dropping replay and keeping the rest buys ~86 kB — 3× more. If the payload matters, replay is the lever; if replay is the reason PostHog is on the marketing site at all, the rest is cheap by comparison and there is little to gain from trimming it.

Two caveats on the non-current rows:

- The `slim` rows need code changes in `src/lib/analytics.ts` (`__extensionClasses`, explicit recorder import), not just a config edit. Sizes are measured from real builds; **runtime behaviour of those configurations is not verified in this PR.**
- Turning features off via `init()` config does **not** shrink anything — the extensions are statically included in the entrypoint. Only a different entrypoint changes bytes.

Happy to follow up with whichever row you pick.

## Verification

```
$ pnpm lint
✖ 10 problems (0 errors, 10 warnings)
```
0 errors. All 10 warnings pre-existing in `apps/desktop`, untouched here.

```
$ npx turbo run typecheck --force --filter='!@memry/extension'
 Tasks:    19 successful, 19 total
Cached:    0 cached, 19 total
  Time:    51.53s
```
`@memry/extension` is excluded because it fails identically on a clean `origin/main` tree (`wxt.config.ts(36,3): error TS2322` — duplicate `vite@7.3.5` instances differing only by `jiti` version). Verified pre-existing by stashing this diff and re-running: same single error. Unrelated to landing.

```
$ pnpm --filter @memry/landing test
✔ landing analytics event data
✔ landing analytics send path
✔ landing CSP
ℹ tests 60
ℹ pass 60
ℹ fail 0
```

```
$ pnpm --filter @memry/landing build
dist/assets/paddle-CQAbpomY.js            1.61 kB │ gzip:   0.69 kB
dist/assets/icons-Bklke-C3.js            28.71 kB │ gzip:   9.55 kB
dist/assets/react-vendor-Cv0H7eLR.js     47.97 kB │ gzip:  17.10 kB
dist/assets/motion-D0d00oBF.js          148.86 kB │ gzip:  48.24 kB
dist/assets/posthog-DxZnKzdO.js         523.13 kB │ gzip: 163.80 kB
dist/assets/index-N8SeYUZn.js           802.02 kB │ gzip: 211.18 kB
dist/assets/crypto-DtAbFgw-.js        1,230.76 kB │ gzip: 380.31 kB
...
  45 routes prerendered.
```
Prerender (45 routes) still green — worth checking, since `analytics.ts` is imported on the SSR path.

```
$ git diff --check
(no output)
```
