### PR TITLE
feat(telemetry): account identity from a verified bearer, hashed before it reaches PostHog

### DIFF
--- a/apps/desktop/src/main/diagnostics/incident-report.test.ts
+++ b/apps/desktop/src/main/diagnostics/incident-report.test.ts
@@ -23,6 +23,9 @@ vi.mock('../telemetry/diagnostics-salt', () => ({
 }))
 
 const getSyncEngineMock = vi.fn()
+vi.mock('../sync/token-manager', () => ({
+  getValidAccessToken: vi.fn(async () => null)
+}))
 vi.mock('../sync/runtime', () => ({
   getSyncEngine: () => getSyncEngineMock()
 }))
@@ -157,6 +160,59 @@ describe('sendIncidentReport', () => {
     expect(calls).toHaveLength(1)
     expect(calls[0].url).toBe('http://localhost:8787/diagnostics/report')
     expect(calls[0].body).toEqual(report)
+  })
+
+  it('attaches the access token so the report lands on the account person profile', async () => {
+    const headers: Record<string, string>[] = []
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      headers.push(init?.headers as Record<string, string>)
+      return { ok: true, status: 202 }
+    })
+
+    await sendIncidentReport(report, {
+      fetch: fetchMock,
+      endpoint: 'http://localhost:8787/diagnostics/report',
+      getAccessToken: async () => 'jwt-token'
+    })
+
+    expect(headers[0].Authorization).toBe('Bearer jwt-token')
+  })
+
+  it('sends anonymously when there is no token', async () => {
+    const headers: Record<string, string>[] = []
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      headers.push(init?.headers as Record<string, string>)
+      return { ok: true, status: 202 }
+    })
+
+    await sendIncidentReport(report, {
+      fetch: fetchMock,
+      endpoint: 'http://localhost:8787/diagnostics/report',
+      getAccessToken: async () => null
+    })
+
+    expect(headers[0]).not.toHaveProperty('Authorization')
+  })
+
+  it('still sends the report when the token lookup throws', async () => {
+    // Signed out, keychain locked, refresh failed — losing the incident report
+    // would be worse than losing its attribution.
+    const headers: Record<string, string>[] = []
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      headers.push(init?.headers as Record<string, string>)
+      return { ok: true, status: 202 }
+    })
+
+    const result = await sendIncidentReport(report, {
+      fetch: fetchMock,
+      endpoint: 'http://localhost:8787/diagnostics/report',
+      getAccessToken: async () => {
+        throw new Error('keychain locked')
+      }
+    })
+
+    expect(result).toEqual({ incidentId: report.incidentId })
+    expect(headers[0]).not.toHaveProperty('Authorization')
   })
 
   // DoD: "verified with a synthetic secret that does not appear in [what reaches] Loki".

--- a/apps/desktop/src/main/diagnostics/incident-report.ts
+++ b/apps/desktop/src/main/diagnostics/incident-report.ts
@@ -23,6 +23,7 @@ import { getTelemetryAuthState, getTelemetrySyncState } from '../telemetry/state
 import { getOrCreateDiagnosticsSalt, makeSaltedHasher } from '../telemetry/diagnostics-salt'
 import type { TelemetryFetch } from '../telemetry/client'
 import { getSyncEngine } from '../sync/runtime'
+import { getValidAccessToken } from '../sync/token-manager'
 
 // Crockford-ish base32 (no 0/1/8/9 or lowercase) keeps ids unambiguous when read
 // aloud/typed into a support ticket. 8 chars satisfies the schema's 6-12 range.
@@ -116,6 +117,18 @@ export interface SendIncidentReportDeps {
   /** Injectable for tests; defaults to electron's net.fetch. */
   fetch?: TelemetryFetch
   endpoint?: string
+  /**
+   * Resolves the signed-in account's access token so the server can attribute
+   * the report to the same PostHog person as this install's events. Same
+   * contract as the telemetry client's: null/throw → anonymous report. The
+   * report body's `accountId` is NOT used for this — a body field is
+   * client-asserted, the bearer is verified.
+   *
+   * Injectable for tests; defaults to the real token manager. The default lives
+   * here rather than at the IPC call site because `src/main/ipc/**` may not
+   * import `src/main/sync/**` (see scripts/check-architecture-boundaries.js).
+   */
+  getAccessToken?: () => Promise<string | null>
 }
 
 export const sendIncidentReport = async (
@@ -124,9 +137,20 @@ export const sendIncidentReport = async (
 ): Promise<{ incidentId: string }> => {
   const endpoint = resolveEndpoint(deps.endpoint, report.buildChannel)
   const fetchFn = deps.fetch ?? ((input, init) => net.fetch(input.toString(), init))
+  let bearer: string | null = null
+  try {
+    bearer = await (deps.getAccessToken ?? getValidAccessToken)()
+  } catch {
+    // Signed out, keychain locked, refresh failed — send anonymously rather
+    // than losing the report.
+    bearer = null
+  }
   const response = await fetchFn(endpoint, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(bearer ? { Authorization: `Bearer ${bearer}` } : {})
+    },
     body: JSON.stringify(report)
   })
   if (!response.ok) {

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -241,8 +241,36 @@ grouping follows the app's own error taxonomy rather than PostHog's pattern-hash
 
 No raw identifiers are stored: the install ID is HMAC-hashed server-side (`TELEMETRY_HMAC_KEY`,
 `hashTelemetryId`) and used as the PostHog `distinct_id`; server-side `user_id`/`device_id`/
-`vault_id` are hashed the same way before they ride along as event properties. Telemetry batches
-are anonymous — no account identity is attached today.
+`vault_id` are hashed the same way before they ride along as event properties.
+
+### Account identity
+
+The desktop attaches its access token to `/telemetry/batch` and `/diagnostics/report` as an
+**optional** bearer. Neither route runs the auth middleware: `resolveTelemetryAccountHash`
+verifies the JWT if one is present and returns `undefined` for a missing, malformed or expired
+token, so telemetry is never rejected for auth reasons — that batch simply reports anonymously
+against its install hash.
+
+The resolved account id is **HMAC-hashed before it can become a `distinct_id`**, exactly like the
+install ID. `TransformContext` names the field `accountHash`, and `resolveDistinctId` shape-checks
+it against `hashTelemetryId`'s output (64 lowercase hex chars); anything else — most plausibly a
+raw account id — degrades to the install hash rather than reaching PostHog. This is deliberately
+strict: a PostHog `$identify` merge is permanent and cannot be undone or re-keyed, so a raw
+account id that reached a person profile could not be removed afterwards.
+
+When a batch resolves to an account, a `$identify` event aliases the anonymous install person onto
+the account person. It fires **once per app session**, guarded by the `telemetry_identify_sessions`
+D1 table (`claimIdentifySession`, migration `0003`, swept by the cron cleanup after 24h). Without
+the guard, the desktop's ~30s flush cadence would emit one identified event per batch. The guard
+fails open: a D1 error emits `$identify` anyway (idempotent in PostHog) rather than leaving the
+install unlinked.
+
+Diagnostic reports resolve identity through the same `resolveDistinctId` path as events and logs,
+so a report lands on the same person profile as the events around it.
+
+**Known limitation:** telemetry identity is verified but **not revocation-checked**. A revoked
+device's still-unexpired access token (≤15 min) can attribute telemetry until it lapses. Telemetry
+is not an authorization decision, so a per-batch device lookup is not worth the D1 read.
 
 Environments are separated by an `environment` property on every event inside one PostHog
 project, not by separate projects.
@@ -580,9 +608,9 @@ POSTHOG_HOST=https://us.i.posthog.com    # wrangler var (staging and production)
 
 ### Diagnostic Log Endpoints
 
-Two additional endpoints feed the `kind=log` / `kind=report` streams. Both are anonymous (no
-sign-in required), rate-limited per user/IP, Zod-validated, and PostHog-Logs-only — neither
-writes a PostHog product event:
+Two additional endpoints feed the `kind=log` / `kind=report` streams. Both accept unauthenticated
+requests (no sign-in required), are rate-limited per user/IP, Zod-validated, and PostHog-Logs-only
+— neither writes a PostHog product event:
 
 | Endpoint                   | Stream                 | Rate limit    | Payload                                                                                                 |
 | -------------------------- | ---------------------- | ------------- | ------------------------------------------------------------------------------------------------------- |
@@ -592,9 +620,14 @@ writes a PostHog product event:
 A malformed payload is rejected with `400 VALIDATION_ERROR` (only the Zod path + issue code is
 logged, never values, same convention as `/telemetry/batch`). A valid payload always gets `202`,
 including when `POSTHOG_KEY` is unset — the push inside `pushPostHogLogs` is a silent no-op in
-that case, so a dev build never error-spams. The `accountId` field is reserved in the report
-schema for future account attribution but is not currently populated by the client (reports are
-anonymous). `/telemetry/batch` is unchanged by either endpoint.
+that case, so a dev build never error-spams.
+
+`/diagnostics/report` attributes to an account when the desktop attaches a bearer (see
+[Account identity](#account-identity)); `/telemetry/logs` is still anonymous because the log
+shipper does not attach one yet. `DiagnosticReportSchema.accountId` is accepted for backward
+compatibility with older desktop builds but is **deliberately ignored** — a body field is
+client-asserted, and it would feed a `distinct_id` whose `$identify` merge is permanent, so
+identity comes only from the verified bearer. `/telemetry/batch` is unchanged by either endpoint.
 
 ## Performance
 

--- a/apps/sync-server/migrations/0003_telemetry_identify_sessions.sql
+++ b/apps/sync-server/migrations/0003_telemetry_identify_sessions.sql
@@ -1,0 +1,19 @@
+-- Once-per-session guard for PostHog $identify.
+--
+-- $identify is idempotent in PostHog but bills as an identified event, and the
+-- desktop flushes a telemetry batch roughly every 30s. Without a guard an
+-- 8-hour authenticated session emits ~960 $identify events instead of 1.
+--
+-- The Worker has no KV binding (D1 + R2 + two Durable Objects), so this is a D1
+-- table, following the same convention as `rate_limits`: a single TEXT primary
+-- key, an integer unix timestamp, and a scheduled sweep (see
+-- cleanupStaleIdentifySessions).
+--
+-- Additive: new table only, no existing table or column is touched.
+CREATE TABLE IF NOT EXISTS telemetry_identify_sessions (
+  key TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_telemetry_identify_sessions_created_at
+  ON telemetry_identify_sessions(created_at);

--- a/apps/sync-server/src/index.test.ts
+++ b/apps/sync-server/src/index.test.ts
@@ -220,12 +220,12 @@ describe('scheduled cleanup', () => {
       { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as never
     )
 
-    // all 8 cleanup tasks fail against the broken DB — each must reach PostHog
+    // all 9 cleanup tasks fail against the broken DB — each must reach PostHog
     // Logs (redacted detail) and PostHog events (server_error_seen), one of each per failure.
     const logCalls = fetchMock.mock.calls.filter(([url]) => String(url).endsWith('/v1/logs'))
     const eventCalls = fetchMock.mock.calls.filter(([url]) => String(url).endsWith('/batch/'))
-    expect(logCalls).toHaveLength(8)
-    expect(eventCalls).toHaveLength(8)
+    expect(logCalls).toHaveLength(9)
+    expect(eventCalls).toHaveLength(9)
     const body = JSON.parse((logCalls[0][1] as RequestInit).body as string)
     const record = body.resourceLogs[0].scopeLogs[0].logRecords[0]
     expect(record.severityText).toBe('error')

--- a/apps/sync-server/src/index.ts
+++ b/apps/sync-server/src/index.ts
@@ -24,6 +24,7 @@ import {
   cleanupExpiredTombstones,
   cleanupExpiredUploadSessions,
   cleanupOrphanedBlobChunks,
+  cleanupStaleIdentifySessions,
   cleanupStaleRateLimits
 } from './services/cleanup'
 import { createLogger } from './lib/logger'
@@ -178,7 +179,8 @@ const scheduled: ExportedHandlerScheduledHandler<Bindings> = async (_event, env,
     ['consumed_setup_tokens', cleanupConsumedSetupTokens(env.DB)],
     ['expired_tombstones', cleanupExpiredTombstones(env.DB, env.STORAGE)],
     ['orphaned_blob_chunks', cleanupOrphanedBlobChunks(env.DB, env.STORAGE)],
-    ['expired_gcal_channels', cleanupExpiredGoogleCalendarChannels(env.DB)]
+    ['expired_gcal_channels', cleanupExpiredGoogleCalendarChannels(env.DB)],
+    ['stale_identify_sessions', cleanupStaleIdentifySessions(env.DB)]
   ]
   const results = await Promise.allSettled(tasks.map(([, promise]) => promise))
 

--- a/apps/sync-server/src/routes/diagnostics.ts
+++ b/apps/sync-server/src/routes/diagnostics.ts
@@ -7,7 +7,8 @@ import { createLogger } from '../lib/logger'
 import { createRateLimiter } from '../middleware/rate-limit'
 import { safeWaitUntil } from '../services/analytics'
 import { desktopReportRecords, pushPostHogLogs } from '../services/posthog-logs'
-import { hashTelemetryId } from '../services/telemetry'
+import { resolveDistinctId } from '../services/posthog-transform'
+import { hashTelemetryId, resolveTelemetryAccountHash } from '../services/telemetry'
 import type { AppContext } from '../types'
 
 const logger = createLogger('Diagnostics')
@@ -35,8 +36,30 @@ diagnostics.post('/report', async (c) => {
   const report = parsed.data
   safeWaitUntil(
     c,
-    hashTelemetryId(c.env.TELEMETRY_HMAC_KEY, report.installId)
-      .then((installHash) => pushPostHogLogs(c.env, desktopReportRecords(report, installHash)))
+    Promise.all([
+      hashTelemetryId(c.env.TELEMETRY_HMAC_KEY, report.installId),
+      // The VERIFIED bearer, not report.accountId. The body field is
+      // client-asserted, so trusting it would let any caller attribute an
+      // incident report to another person's PostHog profile. Identity here
+      // resolves exactly the way /telemetry/batch resolves it.
+      resolveTelemetryAccountHash(
+        c.req.header('Authorization'),
+        c.env.JWT_PUBLIC_KEY,
+        c.env.TELEMETRY_HMAC_KEY
+      )
+    ])
+      .then(([installHash, accountHash]) => {
+        // resolveDistinctId, not the bare installHash: the event and log paths
+        // already resolve identity this way, and a report landing on a
+        // different distinct_id than the events around it would split one
+        // person's history across two profiles.
+        const distinctId = resolveDistinctId({
+          installHash,
+          accountHash,
+          environment: c.env.ENVIRONMENT ?? 'unknown'
+        })
+        return pushPostHogLogs(c.env, desktopReportRecords(report, distinctId))
+      })
       // safeWaitUntil only guards the synchronous waitUntil() call, not this
       // promise — hashTelemetryId throws when TELEMETRY_HMAC_KEY is missing/
       // empty, which would otherwise surface as an unhandled rejection.

--- a/apps/sync-server/src/routes/telemetry-identity.test.ts
+++ b/apps/sync-server/src/routes/telemetry-identity.test.ts
@@ -1,0 +1,376 @@
+// End-to-end identity tests for the telemetry/diagnostics routes: a REAL
+// Ed25519 keypair and a REAL signed access token, so nothing about the
+// verify → hash → distinct_id path is mocked away.
+//
+// The load-bearing assertion is `expectNoRawAccountId`: the raw account id must
+// not appear anywhere in the bytes sent to PostHog. $identify merges are
+// permanent and cannot be re-keyed, so a leak here is unrecoverable.
+import { exportPKCS8, exportSPKI, generateKeyPair, importPKCS8, SignJWT } from 'jose'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../middleware/rate-limit', () => ({
+  createRateLimiter: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next())
+}))
+
+import { app } from '../index'
+import { hashTelemetryId } from '../services/telemetry'
+
+const ACCOUNT_ID = '99999999-9999-4999-8999-999999999999'
+const INSTALL_ID = '11111111-1111-4111-8111-111111111111'
+const SESSION_ID = '22222222-2222-4222-8222-222222222222'
+const HMAC_KEY = 'test-hmac-key'
+
+let publicKeyPem: string
+let privateKeyPem: string
+
+beforeAll(async () => {
+  const { publicKey, privateKey } = await generateKeyPair('EdDSA', { extractable: true })
+  publicKeyPem = await exportSPKI(publicKey)
+  privateKeyPem = await exportPKCS8(privateKey)
+})
+
+const signAccessToken = async (
+  overrides: { userId?: string; expiresIn?: string; type?: string } = {}
+): Promise<string> =>
+  new SignJWT({ device_id: 'device-1', type: overrides.type ?? 'access' })
+    .setProtectedHeader({ alg: 'EdDSA' })
+    .setSubject(overrides.userId ?? ACCOUNT_ID)
+    .setIssuer('memry-sync')
+    .setAudience('memry-client')
+    .setIssuedAt()
+    .setExpirationTime(overrides.expiresIn ?? '15m')
+    .sign(await importPKCS8(privateKeyPem, 'EdDSA'))
+
+// D1 double for the once-per-session $identify guard. `changes: 1` on the first
+// INSERT for a key, `0` afterwards — the real ON CONFLICT DO NOTHING semantics.
+const createDb = () => {
+  const claimed = new Set<string>()
+  const db = {
+    prepare: (sql: string) => ({
+      bind: (...args: unknown[]) => ({
+        run: async () => {
+          if (!sql.includes('telemetry_identify_sessions')) return { meta: { changes: 0 } }
+          const key = String(args[0])
+          const isNew = !claimed.has(key)
+          claimed.add(key)
+          return { meta: { changes: isNew ? 1 : 0 } }
+        }
+      })
+    })
+  } as unknown as D1Database
+  return { db, claimed }
+}
+
+const createEnv = (db: D1Database, overrides?: Record<string, unknown>) => ({
+  DB: db,
+  STORAGE: {} as R2Bucket,
+  USER_SYNC_STATE: {} as DurableObjectNamespace,
+  LINKING_SESSION: {} as DurableObjectNamespace,
+  TELEMETRY_HMAC_KEY: HMAC_KEY,
+  // 'development' so the app's required-secret guard warns instead of throwing
+  // for the unrelated secrets this path never touches (RESEND_API_KEY etc.).
+  ENVIRONMENT: 'development',
+  ALLOWED_ORIGIN: 'https://app.memry.test',
+  JWT_PUBLIC_KEY: publicKeyPem,
+  // The app's startup secret guard requires this to be present once
+  // JWT_PUBLIC_KEY is; the telemetry path never signs anything.
+  JWT_PRIVATE_KEY: privateKeyPem,
+  RESEND_API_KEY: '',
+  OTP_HMAC_KEY: '',
+  RECOVERY_DUMMY_SECRET: '',
+  WEBHOOK_HMAC_KEY: '',
+  POSTHOG_KEY: 'phc_test',
+  POSTHOG_HOST: 'https://us.i.posthog.com',
+  ...overrides
+})
+
+const batchBody = (sessionId = SESSION_ID) => ({
+  schemaVersion: 1,
+  installId: INSTALL_ID,
+  sessionId,
+  appVersion: '2026.7.1',
+  buildChannel: 'production',
+  platform: 'darwin',
+  arch: 'arm64',
+  locale: 'tr-TR',
+  timezoneOffsetMinutes: 180,
+  authState: 'signed_in',
+  syncState: 'enabled',
+  events: [
+    {
+      id: '33333333-3333-4333-8333-333333333333',
+      name: 'note_created',
+      occurredAt: '2026-07-22T10:00:00.000Z',
+      surface: 'notes',
+      action: 'create'
+    }
+  ]
+})
+
+const postBatch = (env: ReturnType<typeof createEnv>, bearer?: string, sessionId?: string) =>
+  app.request(
+    new Request('http://localhost/telemetry/batch', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(bearer ? { Authorization: `Bearer ${bearer}` } : {})
+      },
+      body: JSON.stringify(batchBody(sessionId))
+    }),
+    {},
+    env
+  )
+
+/** Every byte sent to any PostHog endpoint during the test, concatenated. */
+const sentBytes = (fetchSpy: ReturnType<typeof vi.fn>): string =>
+  fetchSpy.mock.calls.map(([, init]) => String((init as RequestInit | undefined)?.body)).join('\n')
+
+const expectNoRawAccountId = (fetchSpy: ReturnType<typeof vi.fn>): void => {
+  expect(sentBytes(fetchSpy)).not.toContain(ACCOUNT_ID)
+}
+
+const captureEvents = (fetchSpy: ReturnType<typeof vi.fn>) => {
+  const call = fetchSpy.mock.calls.find(([url]) => String(url).endsWith('/batch/'))
+  expect(call).toBeDefined()
+  return JSON.parse((call?.[1] as RequestInit).body as string).batch as Array<{
+    event: string
+    distinct_id: string
+    properties: Record<string, unknown>
+  }>
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('POST /telemetry/batch — account identity', () => {
+  it('resolves a verified bearer to the HASHED account id, never the raw id', async () => {
+    // #given PostHog configured and a valid access token for a known account
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { db } = createDb()
+    const token = await signAccessToken()
+
+    // #when posting an authenticated batch
+    const response = await postBatch(createEnv(db), token)
+
+    // #then every distinct_id is the HMAC of the account id...
+    expect(response.status).toBe(202)
+    const expectedHash = await hashTelemetryId(HMAC_KEY, ACCOUNT_ID)
+    const events = captureEvents(fetchSpy)
+    for (const event of events) expect(event.distinct_id).toBe(expectedHash)
+
+    // #and the raw account id appears nowhere in the payload. This is the
+    // regression guard for the one-way door — a $identify merge onto a raw
+    // account id is permanent and irreversible.
+    expectNoRawAccountId(fetchSpy)
+  })
+
+  it('emits $identify aliasing the install hash onto the account hash', async () => {
+    // #given an authenticated batch
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { db } = createDb()
+
+    // #when posting
+    await postBatch(createEnv(db), await signAccessToken())
+
+    // #then $identify merges the anonymous install person into the account person
+    const identify = captureEvents(fetchSpy).find((e) => e.event === '$identify')
+    expect(identify).toBeDefined()
+    expect(identify?.distinct_id).toBe(await hashTelemetryId(HMAC_KEY, ACCOUNT_ID))
+    expect(identify?.properties.$anon_distinct_id).toBe(
+      await hashTelemetryId(HMAC_KEY, INSTALL_ID)
+    )
+    expectNoRawAccountId(fetchSpy)
+  })
+
+  it('emits $identify only once per session, not on every 30s batch', async () => {
+    // #given three authenticated batches from the same session
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { db } = createDb()
+    const env = createEnv(db)
+    const token = await signAccessToken()
+
+    // #when posting them in turn
+    await postBatch(env, token)
+    await postBatch(env, token)
+    await postBatch(env, token)
+
+    // #then the permanent merge fires exactly once
+    const identifyCount = fetchSpy.mock.calls
+      .filter(([url]) => String(url).endsWith('/batch/'))
+      .flatMap(([, init]) => JSON.parse((init as RequestInit).body as string).batch)
+      .filter((e: { event: string }) => e.event === '$identify').length
+    expect(identifyCount).toBe(1)
+  })
+
+  it('re-identifies for a new session id', async () => {
+    // #given two batches from DIFFERENT sessions on the same account
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { db, claimed } = createDb()
+    const env = createEnv(db)
+    const token = await signAccessToken()
+
+    // #when posting both
+    await postBatch(env, token, SESSION_ID)
+    await postBatch(env, token, '44444444-4444-4444-8444-444444444444')
+
+    // #then the guard is keyed per session, so each claims its own row
+    expect(claimed.size).toBe(2)
+  })
+
+  it('falls back to the install hash when the bearer is invalid', async () => {
+    // #given a garbage bearer
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { db } = createDb()
+
+    // #when posting
+    const response = await postBatch(createEnv(db), 'not-a-jwt')
+
+    // #then telemetry is never rejected for auth reasons; it reports anonymously
+    expect(response.status).toBe(202)
+    const events = captureEvents(fetchSpy)
+    const installHash = await hashTelemetryId(HMAC_KEY, INSTALL_ID)
+    for (const event of events) expect(event.distinct_id).toBe(installHash)
+    expect(events.some((e) => e.event === '$identify')).toBe(false)
+  })
+
+  it('falls back to the install hash when the token is expired', async () => {
+    // #given a token that expired an hour ago
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { db } = createDb()
+    const expired = await signAccessToken({ expiresIn: '-1h' })
+
+    // #when posting
+    const response = await postBatch(createEnv(db), expired)
+
+    // #then it still 202s, anonymously
+    expect(response.status).toBe(202)
+    const installHash = await hashTelemetryId(HMAC_KEY, INSTALL_ID)
+    for (const event of captureEvents(fetchSpy)) expect(event.distinct_id).toBe(installHash)
+  })
+
+  it('rejects a refresh token as an identity source', async () => {
+    // #given a correctly signed token whose type is not "access"
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { db } = createDb()
+    const refresh = await signAccessToken({ type: 'refresh' })
+
+    // #when posting
+    await postBatch(createEnv(db), refresh)
+
+    // #then identity does not resolve
+    const installHash = await hashTelemetryId(HMAC_KEY, INSTALL_ID)
+    for (const event of captureEvents(fetchSpy)) expect(event.distinct_id).toBe(installHash)
+  })
+})
+
+describe('POST /diagnostics/report — account identity', () => {
+  const reportBody = (overrides: Record<string, unknown> = {}) => ({
+    schemaVersion: 1,
+    installId: INSTALL_ID,
+    sessionId: SESSION_ID,
+    appVersion: '2026.7.1',
+    buildChannel: 'production',
+    platform: 'darwin',
+    arch: 'arm64',
+    incidentId: 'MEMRY-ABCD2345',
+    trigger: { source: 'user_report' },
+    snapshot: {
+      appVersion: '2026.7.1',
+      buildChannel: 'production',
+      platform: 'darwin',
+      arch: 'arm64',
+      locale: 'tr-TR',
+      uptimeSeconds: 120,
+      syncEnabled: true,
+      syncState: 'enabled',
+      queueDepth: 0,
+      vaultOpen: true,
+      authState: 'signed_in'
+    },
+    lines: [],
+    ...overrides
+  })
+
+  const postReport = (env: ReturnType<typeof createEnv>, bearer?: string, body = reportBody()) =>
+    app.request(
+      new Request('http://localhost/diagnostics/report', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(bearer ? { Authorization: `Bearer ${bearer}` } : {})
+        },
+        body: JSON.stringify(body)
+      }),
+      {},
+      env
+    )
+
+  const reportDistinctId = async (fetchSpy: ReturnType<typeof vi.fn>): Promise<string> => {
+    await vi.waitFor(() =>
+      expect(fetchSpy.mock.calls.some(([url]) => String(url).endsWith('/v1/logs'))).toBe(true)
+    )
+    const call = fetchSpy.mock.calls.find(([url]) => String(url).endsWith('/v1/logs'))
+    const record = JSON.parse((call?.[1] as RequestInit).body as string).resourceLogs[0]
+      .scopeLogs[0].logRecords[0]
+    const attribute = record.attributes.find(
+      (a: { key: string }) => a.key === 'posthogDistinctId'
+    )
+    return attribute.value.stringValue
+  }
+
+  it('lands the report on the same person profile as the events', async () => {
+    // #given an authenticated incident report
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { db } = createDb()
+
+    // #when posting with a valid bearer
+    const response = await postReport(createEnv(db), await signAccessToken())
+
+    // #then the log records carry the resolved (hashed) account distinct id,
+    // not the bare install hash — otherwise a report would split off onto a
+    // second profile the moment account identity is populated.
+    expect(response.status).toBe(202)
+    expect(await reportDistinctId(fetchSpy)).toBe(await hashTelemetryId(HMAC_KEY, ACCOUNT_ID))
+    expectNoRawAccountId(fetchSpy)
+  })
+
+  it('falls back to the install hash without a bearer', async () => {
+    // #given an anonymous incident report
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { db } = createDb()
+
+    // #when posting with no Authorization header
+    const response = await postReport(createEnv(db))
+
+    // #then it resolves to the install hash
+    expect(response.status).toBe(202)
+    expect(await reportDistinctId(fetchSpy)).toBe(await hashTelemetryId(HMAC_KEY, INSTALL_ID))
+  })
+
+  it('ignores a client-asserted accountId in the body', async () => {
+    // #given a report body claiming to belong to another account, with no bearer
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const { db } = createDb()
+    const spoofed = '77777777-7777-4777-8777-777777777777'
+
+    // #when posting
+    const response = await postReport(createEnv(db), undefined, reportBody({ accountId: spoofed }))
+
+    // #then identity stays anonymous — a body field must never steer a PostHog
+    // person profile, because the merge it would feed is permanent.
+    expect(response.status).toBe(202)
+    expect(await reportDistinctId(fetchSpy)).toBe(await hashTelemetryId(HMAC_KEY, INSTALL_ID))
+    expect(sentBytes(fetchSpy)).not.toContain(spoofed)
+  })
+})

--- a/apps/sync-server/src/routes/telemetry.ts
+++ b/apps/sync-server/src/routes/telemetry.ts
@@ -15,7 +15,8 @@ import {
   productEvent,
   resolveDistinctId
 } from '../services/posthog-transform'
-import { hashTelemetryId } from '../services/telemetry'
+import { hashTelemetryId, resolveTelemetryAccountHash } from '../services/telemetry'
+import { claimIdentifySession } from '../services/telemetry-identify'
 import type { AppContext } from '../types'
 
 const logger = createLogger('Telemetry')
@@ -43,15 +44,21 @@ telemetry.post('/batch', async (c) => {
   }
 
   const batch = parsed.data
-  const installHash = await hashTelemetryId(c.env.TELEMETRY_HMAC_KEY, batch.installId)
-  // accountId stays undefined in this train: /telemetry/* deliberately bypasses
-  // the auth middleware and TelemetryBatchSchema carries no account identifier,
-  // so every install reports anonymously until a later release restores the
-  // bearer. resolveDistinctId already falls back to installHash — nothing here
-  // changes when that lands except this one field becoming populated.
+  const [installHash, accountHash] = await Promise.all([
+    hashTelemetryId(c.env.TELEMETRY_HMAC_KEY, batch.installId),
+    // /telemetry/* still bypasses the auth middleware — a bad or absent bearer
+    // must never reject telemetry. resolveTelemetryAccountHash returns undefined
+    // in that case and the batch reports anonymously against installHash.
+    // It returns the HMAC of the account id, never the raw id.
+    resolveTelemetryAccountHash(
+      c.req.header('Authorization'),
+      c.env.JWT_PUBLIC_KEY,
+      c.env.TELEMETRY_HMAC_KEY
+    )
+  ])
   const ctx = {
     installHash,
-    accountId: undefined as string | undefined,
+    accountHash,
     environment: c.env.ENVIRONMENT ?? 'unknown'
   }
   const distinctId = resolveDistinctId(ctx)
@@ -61,12 +68,16 @@ telemetry.post('/batch', async (c) => {
     .map((event) => exceptionEvent(batch, event, ctx))
     .filter((event): event is NonNullable<typeof event> => event !== null)
 
-  // identifyEvent returns null whenever ctx.accountId is unset, which is always
-  // true today — so this is unreachable until account resolution ships. $identify
-  // merges the anonymous install into the account PERMANENTLY, so once accountId
-  // is populated a once-per-session guard MUST land together with that
-  // resolution, before this can fire on every 30s batch instead of once.
-  const identify = identifyEvent(batch, ctx)
+  // $identify merges the anonymous install person into the account person
+  // PERMANENTLY, and the desktop flushes roughly every 30s. claimIdentifySession
+  // is the once-per-session guard that keeps this to one merge per app session
+  // instead of ~120/hour. identifyEvent still returns null for an anonymous
+  // batch, so the claim is only attempted when there is an account to merge to.
+  const identify = accountHash
+    ? (await claimIdentifySession(c.env.DB, batch.sessionId, accountHash))
+      ? identifyEvent(batch, ctx)
+      : null
+    : null
 
   safeWaitUntil(
     c,
@@ -123,10 +134,13 @@ telemetry.post('/logs', async (c) => {
     hashTelemetryId(c.env.TELEMETRY_HMAC_KEY, batch.installId)
       .then((installHash) => {
         // Resolved distinct id, not the raw install hash, so these logs surface
-        // on the right person profile once account resolution lands.
+        // on the right person profile once account resolution lands here too.
+        // Still anonymous: the desktop log shipper does not attach a bearer to
+        // /telemetry/logs yet, so wiring the header read on this side alone
+        // would be dead code. Tracked as a follow-up.
         const distinctId = resolveDistinctId({
           installHash,
-          accountId: undefined,
+          accountHash: undefined,
           environment: c.env.ENVIRONMENT ?? 'unknown'
         })
         return pushPostHogLogs(

--- a/apps/sync-server/src/services/cleanup.test.ts
+++ b/apps/sync-server/src/services/cleanup.test.ts
@@ -8,8 +8,10 @@ import {
   cleanupExpiredTombstones,
   cleanupExpiredUploadSessions,
   cleanupOrphanedBlobChunks,
+  cleanupStaleIdentifySessions,
   cleanupStaleRateLimits
 } from './cleanup'
+import { IDENTIFY_SESSION_TTL_SECONDS } from './telemetry-identify'
 
 function createDbWithChanges(changes: number) {
   const run = vi.fn(async () => ({ meta: { changes } }))
@@ -234,6 +236,21 @@ describe('cleanup services', () => {
     expect(result).toBe(7)
     expect(prepare).toHaveBeenCalledWith('DELETE FROM rate_limits WHERE window_start < ?')
     expect(bind).toHaveBeenCalledWith(1_700_000_000 - 3600)
+  })
+
+  it('cleans up $identify session claims older than the TTL', async () => {
+    // #given
+    const { db, prepare, bind } = createDbWithChanges(8)
+
+    // #when
+    const result = await cleanupStaleIdentifySessions(db)
+
+    // #then
+    expect(result).toBe(8)
+    expect(prepare).toHaveBeenCalledWith(
+      'DELETE FROM telemetry_identify_sessions WHERE created_at < ?'
+    )
+    expect(bind).toHaveBeenCalledWith(1_700_000_000 - IDENTIFY_SESSION_TTL_SECONDS)
   })
 
   describe('cleanupExpiredTombstones', () => {

--- a/apps/sync-server/src/services/cleanup.ts
+++ b/apps/sync-server/src/services/cleanup.ts
@@ -1,4 +1,5 @@
 import { adjustStorageUsed } from './quota'
+import { IDENTIFY_SESSION_TTL_SECONDS } from './telemetry-identify'
 
 export const cleanupExpiredOtpCodes = async (db: D1Database): Promise<number> => {
   const now = Math.floor(Date.now() / 1000)
@@ -120,6 +121,15 @@ export const cleanupStaleRateLimits = async (db: D1Database): Promise<number> =>
   const result = await db
     .prepare('DELETE FROM rate_limits WHERE window_start < ?')
     .bind(oneHourAgo)
+    .run()
+  return result.meta.changes ?? 0
+}
+
+export const cleanupStaleIdentifySessions = async (db: D1Database): Promise<number> => {
+  const cutoff = Math.floor(Date.now() / 1000) - IDENTIFY_SESSION_TTL_SECONDS
+  const result = await db
+    .prepare('DELETE FROM telemetry_identify_sessions WHERE created_at < ?')
+    .bind(cutoff)
     .run()
   return result.meta.changes ?? 0
 }

--- a/apps/sync-server/src/services/posthog-transform.test.ts
+++ b/apps/sync-server/src/services/posthog-transform.test.ts
@@ -26,15 +26,51 @@ export const batchFixture = (overrides: Partial<TelemetryBatch> = {}): Telemetry
   ...overrides
 })
 
+// hashTelemetryId output shape: 64 lowercase hex chars.
+const ACCOUNT_HASH = 'a'.repeat(64)
+const RAW_ACCOUNT_ID = '550e8400-e29b-41d4-a716-446655440000'
+
 describe('resolveDistinctId', () => {
-  it('uses the account id when present', () => {
+  it('uses the account hash when present', () => {
     expect(
-      resolveDistinctId({ installHash: 'hash', accountId: 'acct_1', environment: 'production' })
-    ).toBe('acct_1')
+      resolveDistinctId({
+        installHash: 'hash',
+        accountHash: ACCOUNT_HASH,
+        environment: 'production'
+      })
+    ).toBe(ACCOUNT_HASH)
   })
 
   it('falls back to the install hash', () => {
     expect(resolveDistinctId({ installHash: 'hash', environment: 'production' })).toBe('hash')
+  })
+
+  // THE ONE-WAY DOOR. A raw account id reaching distinct_id cannot be undone:
+  // $identify merges in PostHog are permanent and cannot be re-keyed. If this
+  // test fails, do not "fix" it by loosening the guard.
+  it('never lets a raw account id become the distinct id', () => {
+    expect(
+      resolveDistinctId({
+        installHash: 'hash',
+        accountHash: RAW_ACCOUNT_ID,
+        environment: 'production'
+      })
+    ).toBe('hash')
+  })
+
+  it('rejects anything that is not a 64-char lowercase hex hash', () => {
+    for (const value of [
+      '',
+      'acct_1',
+      'kaan@example.com',
+      ACCOUNT_HASH.toUpperCase(),
+      ACCOUNT_HASH.slice(0, 63),
+      `${ACCOUNT_HASH}a`
+    ]) {
+      expect(
+        resolveDistinctId({ installHash: 'hash', accountHash: value, environment: 'production' })
+      ).toBe('hash')
+    }
   })
 })
 
@@ -63,14 +99,26 @@ describe('identifyEvent', () => {
   it('aliases the install hash onto the account', () => {
     const event = identifyEvent(batchFixture({ authState: 'signed_in' }), {
       installHash: 'hash',
-      accountId: 'acct_1',
+      accountHash: ACCOUNT_HASH,
       environment: 'production'
     })
     expect(event).not.toBeNull()
     expect(event?.event).toBe('$identify')
-    expect(event?.distinct_id).toBe('acct_1')
+    expect(event?.distinct_id).toBe(ACCOUNT_HASH)
     expect(event?.properties.$anon_distinct_id).toBe('hash')
     expect(event?.properties.environment).toBe('production')
+  })
+
+  // A permanent merge onto a raw account id is the exact irreversible outcome
+  // this whole module guards against — refuse to merge rather than fall back.
+  it('refuses to merge when the account hash is a raw account id', () => {
+    expect(
+      identifyEvent(batchFixture({ authState: 'signed_in' }), {
+        installHash: 'hash',
+        accountHash: RAW_ACCOUNT_ID,
+        environment: 'production'
+      })
+    ).toBeNull()
   })
 })
 

--- a/apps/sync-server/src/services/posthog-transform.ts
+++ b/apps/sync-server/src/services/posthog-transform.ts
@@ -9,12 +9,31 @@ import type { PostHogEvent } from './posthog'
 
 export interface TransformContext {
   installHash: string
-  accountId?: string
+  /**
+   * HMAC of the account id (`hashTelemetryId`), NEVER the raw account id.
+   * Deliberately named `accountHash`, not `accountId`, for the same reason
+   * `installHash` is: PostHog is a third-party sink and only ever sees opaque
+   * hashes. See ACCOUNT_HASH_PATTERN below.
+   */
+  accountHash?: string
   environment: string
 }
 
+// THE ONE-WAY DOOR. `hashTelemetryId` returns exactly 64 lowercase hex chars.
+// Anything else reaching this field is a bug — most plausibly a raw account id
+// — and must never become a `distinct_id`, because a `$identify` merge in
+// PostHog is PERMANENT and IRREVERSIBLE: a leaked raw account id cannot be
+// un-leaked or re-keyed afterwards. Shape-checking here rather than trusting
+// call sites means the failure mode of a future mistake is "telemetry stays
+// anonymous", not "raw account ids are now in a third-party product forever".
+// Do not relax this to a truthiness check.
+const ACCOUNT_HASH_PATTERN = /^[0-9a-f]{64}$/
+
+export const isAccountHash = (value: string | undefined): value is string =>
+  typeof value === 'string' && ACCOUNT_HASH_PATTERN.test(value)
+
 export const resolveDistinctId = (ctx: TransformContext): string =>
-  ctx.accountId && ctx.accountId.length > 0 ? ctx.accountId : ctx.installHash
+  isAccountHash(ctx.accountHash) ? ctx.accountHash : ctx.installHash
 
 export const personProperties = (
   batch: TelemetryBatch,
@@ -30,17 +49,20 @@ export const personProperties = (
   environment
 })
 
-// Emitted once per session by the caller (see the KV guard in the route), not on
-// every batch: $identify is idempotent in PostHog but bills as an identified event.
-// The merge it performs is PERMANENT and cannot be undone.
+// Emitted once per session by the caller (see claimIdentifySession in the
+// route), not on every batch: $identify is idempotent in PostHog but bills as an
+// identified event. The merge it performs is PERMANENT and cannot be undone.
 export const identifyEvent = (
   batch: TelemetryBatch,
   ctx: TransformContext
 ): PostHogEvent | null => {
-  if (!ctx.accountId || ctx.accountId.length === 0) return null
+  // Not `resolveDistinctId`: that falls back to installHash, which would make
+  // $identify alias the anonymous person onto itself. No valid account hash
+  // means no merge at all.
+  if (!isAccountHash(ctx.accountHash)) return null
   return {
     event: '$identify',
-    distinct_id: ctx.accountId,
+    distinct_id: ctx.accountHash,
     properties: {
       $anon_distinct_id: ctx.installHash,
       $set: personProperties(batch, ctx.environment),

--- a/apps/sync-server/src/services/telemetry-identify.test.ts
+++ b/apps/sync-server/src/services/telemetry-identify.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { claimIdentifySession, IDENTIFY_SESSION_TTL_SECONDS } from './telemetry-identify'
+
+const SESSION_ID = '22222222-2222-4222-8222-222222222222'
+const ACCOUNT_HASH = 'a'.repeat(64)
+
+const createDb = (run: () => Promise<unknown>) => {
+  const bind = vi.fn((..._args: unknown[]) => ({ run }))
+  const prepare = vi.fn(() => ({ bind }))
+  return { db: { prepare } as unknown as D1Database, prepare, bind }
+}
+
+describe('claimIdentifySession', () => {
+  it('claims the session when the insert wrote a row', async () => {
+    // #given an INSERT that inserted
+    const { db } = createDb(async () => ({ meta: { changes: 1 } }))
+
+    // #when claiming
+    const claimed = await claimIdentifySession(db, SESSION_ID, ACCOUNT_HASH)
+
+    // #then the caller may emit $identify
+    expect(claimed).toBe(true)
+  })
+
+  it('does not claim again when the row already exists', async () => {
+    // #given ON CONFLICT DO NOTHING hit an existing row
+    const { db } = createDb(async () => ({ meta: { changes: 0 } }))
+
+    // #when claiming
+    const claimed = await claimIdentifySession(db, SESSION_ID, ACCOUNT_HASH)
+
+    // #then the permanent merge is suppressed for this session
+    expect(claimed).toBe(false)
+  })
+
+  it('keys the row by session AND account hash', async () => {
+    // #given a claim
+    const { db, bind } = createDb(async () => ({ meta: { changes: 1 } }))
+
+    // #when claiming
+    await claimIdentifySession(db, SESSION_ID, ACCOUNT_HASH)
+
+    // #then two accounts sharing a session id get separate rows
+    expect(bind.mock.calls[0][0]).toBe(`${SESSION_ID}:${ACCOUNT_HASH}`)
+  })
+
+  it('fails open so a D1 error costs duplicate merges, not a missing one', async () => {
+    // #given D1 throwing
+    const { db } = createDb(async () => {
+      throw new Error('D1_ERROR')
+    })
+
+    // #when claiming
+    const claimed = await claimIdentifySession(db, SESSION_ID, ACCOUNT_HASH)
+
+    // #then $identify still fires (idempotent in PostHog) rather than the
+    // install never linking to its account
+    expect(claimed).toBe(true)
+  })
+
+  it('exposes a TTL long enough to cover a normal app session', () => {
+    expect(IDENTIFY_SESSION_TTL_SECONDS).toBe(86400)
+  })
+})

--- a/apps/sync-server/src/services/telemetry-identify.ts
+++ b/apps/sync-server/src/services/telemetry-identify.ts
@@ -1,0 +1,45 @@
+import { createLogger } from '../lib/logger'
+
+// Once-per-session guard for the PostHog $identify merge. See
+// migrations/0003_telemetry_identify_sessions.sql for why this is a D1 table
+// and not KV.
+
+const logger = createLogger('TelemetryIdentify')
+
+// Sessions are app-launch scoped, so a day is generous. A session still running
+// past the TTL re-identifies once, which is harmless (the merge is idempotent)
+// and keeps the table from growing without bound.
+export const IDENTIFY_SESSION_TTL_SECONDS = 24 * 60 * 60
+
+/**
+ * Atomically claims the right to emit `$identify` for a (session, account)
+ * pair. Returns true exactly once per pair per TTL window.
+ *
+ * Fails OPEN: a D1 error returns true, so a flaky database costs duplicate
+ * (idempotent) $identify events rather than silently never linking the
+ * anonymous install to its account. In practice D1 being down fails the
+ * rate-limit middleware first, so this branch is close to unreachable.
+ */
+export const claimIdentifySession = async (
+  db: D1Database,
+  sessionId: string,
+  accountHash: string
+): Promise<boolean> => {
+  const key = `${sessionId}:${accountHash}`
+  try {
+    const result = await db
+      .prepare(
+        `INSERT INTO telemetry_identify_sessions (key, created_at)
+         VALUES (?, ?)
+         ON CONFLICT (key) DO NOTHING`
+      )
+      .bind(key, Math.floor(Date.now() / 1000))
+      .run()
+    return (result.meta.changes ?? 0) > 0
+  } catch (error) {
+    logger.warn('Identify session claim failed, emitting $identify anyway', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return true
+  }
+}

--- a/apps/sync-server/src/services/telemetry.ts
+++ b/apps/sync-server/src/services/telemetry.ts
@@ -1,4 +1,5 @@
 import { AppError, ErrorCodes } from '../lib/errors'
+import { verifyAccessToken } from '../lib/jwt-verify'
 
 const requireHmacKey = (key: string): string => {
   if (typeof key !== 'string' || key.length === 0) {
@@ -21,4 +22,36 @@ export const hashTelemetryId = async (secret: string, id: string): Promise<strin
   return Array.from(new Uint8Array(signature))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
+}
+
+/**
+ * Resolves the OPTIONAL bearer that `/telemetry/*` and `/diagnostics/*` carry
+ * into an HMAC'd account id.
+ *
+ * These routes deliberately bypass the auth middleware — telemetry must never
+ * be rejected for auth reasons — so identity here is best-effort: a missing,
+ * malformed or expired token simply yields `undefined` and the caller reports
+ * anonymously against its install hash.
+ *
+ * Returns the HASH, never the raw user id. Hashing at the resolution boundary
+ * (rather than at each call site) is what keeps a raw account id from ever
+ * reaching PostHog, where an $identify merge would be permanent.
+ *
+ * Known, accepted limitation: identity is verified but NOT revocation-checked.
+ * A revoked device's still-unexpired access token (≤15 min) can attribute
+ * telemetry until it lapses. Telemetry is not an authorization decision, so a
+ * per-batch device lookup is not worth the D1 read.
+ */
+export const resolveTelemetryAccountHash = async (
+  authHeader: string | undefined,
+  jwtPublicKey: string,
+  hmacKey: string
+): Promise<string | undefined> => {
+  if (!authHeader?.startsWith('Bearer ')) return undefined
+  try {
+    const claims = await verifyAccessToken(authHeader.slice(7), jwtPublicKey)
+    return await hashTelemetryId(hmacKey, claims.userId)
+  } catch {
+    return undefined
+  }
 }

--- a/packages/contracts/src/diagnostics-api.ts
+++ b/packages/contracts/src/diagnostics-api.ts
@@ -71,6 +71,13 @@ export const DiagnosticReportSchema = z.object({
   }),
   snapshot: DiagnosticSnapshotSchema,
   lines: z.array(DiagnosticLogLineSchema).max(200),
+  /**
+   * Accepted for backward compatibility with older desktop builds, but
+   * DELIBERATELY IGNORED by the server. Report identity is resolved from the
+   * verified `Authorization` bearer instead (see routes/diagnostics.ts): a body
+   * field is client-asserted, and it feeds a PostHog `distinct_id`, where an
+   * `$identify` merge is permanent. Do not start trusting this.
+   */
   accountId: z.string().uuid().optional()
 })
 


### PR DESCRIPTION
Implements the **account identity** half of #858 (section 1). Sections 2 (crash capture) and 3 (redacted error message) ship separately.

## What changed

`TelemetryBatchSchema` carries `authState` but no account identifier, and `/telemetry/*` deliberately bypasses the auth middleware — so every install reported anonymously and `resolveDistinctId` always fell back to `installHash`. This restores the PR #512 design on top of the Train 1 PostHog transform.

**Server**

- `resolveTelemetryAccountHash` (`services/telemetry.ts`) verifies the **optional** bearer on `/telemetry/batch` and `/diagnostics/report` and returns the **HMAC of** the account id. Both routes still bypass auth middleware: a missing, malformed, expired, or wrong-type token yields `undefined` and the batch reports anonymously. Telemetry is never rejected for auth reasons.
- `TransformContext.accountId` → `accountHash`, and `resolveDistinctId` / `identifyEvent` shape-check it.
- Once-per-session `$identify` guard: new D1 table `telemetry_identify_sessions` (migration `0003`), `claimIdentifySession`, plus a cron sweep in the scheduled handler.
- `routes/diagnostics.ts` now resolves through `resolveDistinctId` instead of passing a bare `installHash`.

**Desktop**

- `sendIncidentReport` attaches the access token (defaulting to `getValidAccessToken`). The desktop telemetry client already sent its bearer on `/telemetry/batch` — that half of #512 survived; only the server side had been dropped.

## The account id is hashed, and that was non-negotiable

`resolveDistinctId` returned `ctx.accountId` verbatim. Train 1 established that PostHog, as a third-party sink, only ever sees opaque hashes — `installId`, `user_id`, `device_id`, `vault_id` and `paddle_customer_id` all go through `hashTelemetryId`. A raw account id would have broken that rule **irreversibly**: a PostHog `$identify` merge is permanent, so a leaked raw account id cannot be un-leaked or re-keyed afterwards.

Two layers guard it:

1. The field is named `accountHash`, not `accountId`, mirroring `installHash`. Hashing happens once, at the resolution boundary — call sites never see the raw id.
2. `resolveDistinctId` shape-checks against `hashTelemetryId`'s output (`/^[0-9a-f]{64}$/`). Anything else degrades to `installHash`; `identifyEvent` returns `null` rather than merging. The failure mode of a future mistake is "telemetry stays anonymous", not "raw account ids are in a third-party product forever".

Regression coverage in `routes/telemetry-identity.test.ts` uses a **real Ed25519 keypair and a real signed access token** — nothing on the verify → hash → `distinct_id` path is mocked. `expectNoRawAccountId` asserts the raw account id appears nowhere in the bytes sent to PostHog. Unit-level cases in `posthog-transform.test.ts` assert a raw UUID, an uppercase hash, and off-by-one lengths all fall back to `installHash`.

## `$identify` guard: implemented (D1 table)

Implemented rather than deferred. PR #512 fired `$identify` on every authenticated batch (~every 30s) — idempotent in PostHog, but it burns identified-event volume: an 8-hour session emits ~960 merges instead of 1.

Train 1 skipped it because the Worker has no KV binding. The rate limiter already solves the same problem with a D1 table, so this follows that convention: `telemetry_identify_sessions (key TEXT PRIMARY KEY, created_at INTEGER)`, claimed with `INSERT ... ON CONFLICT DO NOTHING` and checked via `meta.changes`, keyed by `sessionId:accountHash`. Migration `0003` is additive — new table and index only, nothing existing is touched, and it applies before deploy per the expand-before-deploy workflow. Stale rows are swept after 24h by the existing cron cleanup.

The guard **fails open**: a D1 error emits `$identify` anyway. Duplicate idempotent merges are strictly better than an install that never links to its account. (In practice D1 being down fails the rate-limit middleware first, so this branch is near-unreachable.)

Cost is one extra D1 write per authenticated batch, on a request that already does one for rate limiting.

## `DiagnosticReportSchema.accountId` is still ignored — on purpose

The issue notes this field exists and is silently ignored. It stays ignored, and the schema now says so. Identity on `/diagnostics/report` comes from the **verified bearer**, resolved by the same helper as `/telemetry/batch`.

Trusting the body field instead would let any caller attribute an incident report to another person's PostHog profile, feeding a permanent `$identify`-adjacent merge. A body field is client-asserted; a bearer is verified. The field is kept (not removed) so older desktop builds that send it still validate. There's a test asserting a spoofed body `accountId` does not steer the `distinct_id`.

## Known limitation, accepted

Telemetry identity is **verified but not revocation-checked**. A revoked device's still-unexpired access token (≤15 min) can attribute telemetry until it lapses. Telemetry is not an authorization decision, so a per-batch device lookup is not worth the D1 read. Carried forward from #512 and documented in `apps/docs/src/architecture/observability.md`.

## Follow-up, not in scope

`/telemetry/logs` still resolves anonymously. The server side is a six-line change, but the desktop log shipper does not attach a bearer, so wiring only the server would be dead code. Noted in a comment at the call site.

## Deploy order

This is a **sync-server** change and deploys with the Train 1 server. The desktop already sends its telemetry bearer, so no desktop release is required for the `/telemetry/batch` half to start working. The `/diagnostics/report` bearer needs the next desktop build; until then reports resolve anonymously, exactly as today.

## Verification

```
$ pnpm lint
✖ 10 problems (0 errors, 10 warnings)      # all pre-existing, none in changed files

$ pnpm typecheck
 Tasks:    16 successful, 16 total
contracts boundary check passed
architecture boundary check passed

$ pnpm test:sync-server
 Test Files  59 passed (59)
      Tests  880 passed (880)

$ pnpm test:desktop
 Test Files  1161 passed | 1 skipped (1162)
      Tests  13927 passed | 1 expected fail | 10 skipped (13938)

$ pnpm ipc:generate && pnpm ipc:check
Generated RPC bindings are up to date
IPC invoke map is up to date

$ git diff --check
(clean)

$ pnpm docs:impact --base origin/main --strict
docs impact: docs changed on this branch

$ pnpm docs:build
build complete in 13.76s.
```

Refs #858 (partial — crash capture and the redacted error message ship separately).
