### PR TITLE
feat(telemetry): durable ship queues, crash reporter, redacted error message

### DIFF
--- a/apps/desktop/src/main/canvas/assets/asset-service.ts
+++ b/apps/desktop/src/main/canvas/assets/asset-service.ts
@@ -27,6 +27,7 @@ import type { CanvasAssetRow } from '@memry/db-schema'
 import { createLogger } from '../../lib/logger'
 import { toMemryFileUrl } from '../../lib/paths'
 import { atomicWriteBinary, fileExists } from '../../vault/file-ops'
+import { getMainRedactOptions } from '../../telemetry/redact-options'
 import type { TrackMainEventOptions } from '../../telemetry/track'
 
 import { assetFilename, hashAssetContent } from './content-hash'
@@ -246,7 +247,7 @@ export async function ensureAssetsPresent(
         source: 'canvas_asset_service',
         result: 'failed',
         errorCode: toErrorCode(err),
-        error: buildErrorDetail(err)
+        error: buildErrorDetail(err, undefined, getMainRedactOptions())
       })
     }
   }

--- a/apps/desktop/src/main/index.phase2.test.ts
+++ b/apps/desktop/src/main/index.phase2.test.ts
@@ -78,6 +78,7 @@ const ipcMainHandleMock = vi.fn()
 const setCertificateVerifyProcMock = vi.fn()
 const setPermissionRequestHandlerMock = vi.fn()
 const setPermissionCheckHandlerMock = vi.fn()
+const crashReporterStartMock = vi.fn()
 const globalShortcutRegisterMock = vi.fn(() => true)
 const globalShortcutUnregisterAllMock = vi.fn()
 const menuSetApplicationMenuMock = vi.fn()
@@ -372,6 +373,9 @@ vi.mock('electron', () => ({
   },
   net: {
     fetch: netFetchMock
+  },
+  crashReporter: {
+    start: crashReporterStartMock
   },
   globalShortcut: {
     register: globalShortcutRegisterMock,
@@ -1766,6 +1770,16 @@ describe('main index phase2 exports', () => {
     await flushUntil(() => vi.mocked(app.exit).mock.calls.length > 0)
 
     expect(app.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('starts the crash reporter without ever uploading minidumps', async () => {
+    // #when the main module loads
+    await importMainModule()
+
+    // #then dumps are kept for the local diagnostic bundle only. uploadToServer
+    // must stay false: a minidump is raw process memory, and PostHog neither
+    // ingests it nor could redact it.
+    expect(crashReporterStartMock).toHaveBeenCalledWith({ uploadToServer: false })
   })
 
   it('handles app close lifecycle events', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,6 +2,7 @@ import {
   app,
   shell,
   BrowserWindow,
+  crashReporter,
   ipcMain,
   protocol,
   net,
@@ -206,6 +207,14 @@ migrateLegacyLogDir()
 // blacklisted Windows GPUs paint nothing, leaving an invisible window), fall
 // back to software rendering this launch instead of stranding the user.
 applyGpuCrashGuard()
+
+// Native crashes (the ones no JS handler ever sees) leave a minidump in
+// app.getPath('crashDumps') for the Path B diagnostic bundle the user submits
+// deliberately. uploadToServer is false and must STAY false: PostHog does not
+// ingest minidumps, and a dump is raw process memory — shipping it would breach
+// the redaction model every other telemetry path is built around. Started before
+// 'ready' so renderer and utility processes inherit the handler.
+crashReporter.start({ uploadToServer: false })
 
 const mainLog = createLogger('Main')
 const configLog = createLogger('Config')
@@ -1355,16 +1364,26 @@ const appReady = app.whenReady().then(async () => {
 
   // Initialize telemetry runtime before handlers so registerTelemetryHandlers
   // can resolve `getTelemetryRuntime()` to the live instance.
+  // Both queues mirror to userData so a hard crash no longer discards the last
+  // flush interval — including the app_crashed event detectUncleanShutdown is
+  // about to record. Resolved here rather than inside the telemetry modules, for
+  // the same reason installLogShip is: nothing under telemetry/ reaches for
+  // process-wide state on its own.
+  const telemetryDir = app.getPath('userData')
   const telemetryRuntime = initializeTelemetryRuntime({
     appVersion: app.getVersion(),
     locale: app.getLocale(),
     buildChannel: resolveMemryEnvironment(),
     authStateProvider: getTelemetryAuthState,
     syncStateProvider: getTelemetrySyncState,
-    accessTokenProvider: () => getValidAccessToken()
+    accessTokenProvider: () => getValidAccessToken(),
+    persistPath: join(telemetryDir, 'telemetry-event-queue.json')
   })
   drainEarlyMainEvents()
-  installLogShip({ buildChannel: resolveMemryEnvironment() })
+  installLogShip({
+    buildChannel: resolveMemryEnvironment(),
+    persistPath: join(telemetryDir, 'telemetry-log-queue.json')
+  })
   registerMainDiagnostics()
   // Order matters: detect the PREVIOUS session's leftover marker before this
   // session writes its own.

--- a/apps/desktop/src/main/ipc/validate.ts
+++ b/apps/desktop/src/main/ipc/validate.ts
@@ -8,7 +8,7 @@ import { isExpectedConditionError } from '../telemetry/expected-conditions'
 
 const ipcLog = createLogger('IPC')
 
-// Every IPC envelope error becomes a telemetry event (→ Loki), throttled so an
+// Every IPC envelope error becomes a telemetry event (→ PostHog), throttled so an
 // error loop can't flood the queue. The key must discriminate: keyed only by
 // error.name and shared across ALL handlers, one benign recurring "Error"
 // masked a genuine different "Error" from another handler for a whole window.

--- a/apps/desktop/src/main/telemetry/client.test.ts
+++ b/apps/desktop/src/main/telemetry/client.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
 import type { TelemetryEvent } from '@memry/contracts/telemetry-api'
 
@@ -341,5 +344,52 @@ describe('createTelemetryClient', () => {
       expect(headers['Authorization']).toBe('Bearer my-access-token')
       expect(headers['Authorization']).toMatch(/^Bearer [^ ]+$/)
     })
+  })
+})
+
+describe('createTelemetryClient — crash durability', () => {
+  let tempDir: string
+  let persistPath: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-telemetry-client-'))
+    persistPath = path.join(tempDir, 'events.json')
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('restores events a killed process never got to flush', async () => {
+    // #given a session that recorded app_crashed and died before its 30s flush
+    const dead = createTelemetryClient(createDeps({ persistPath }).deps)
+    dead.track(buildEvent('11111111-1111-1111-1111-111111111111', 'app_crashed'))
+
+    // #when the next launch opens the same mirror
+    const { deps, calls } = createDeps({ persistPath })
+    const revived = createTelemetryClient(deps)
+    expect(revived.getQueueDepth()).toBe(1)
+
+    // #then the crash event ships instead of being lost with the process
+    await revived.flush('manual')
+    const batch = JSON.parse(String(calls[0].init?.body)) as { events: TelemetryEvent[] }
+    expect(batch.events.map((e) => e.name)).toEqual(['app_crashed'])
+
+    // #and it is not sent again on the launch after that
+    expect(createTelemetryClient(createDeps({ persistPath }).deps).getQueueDepth()).toBe(0)
+  })
+
+  it('never restores events for an install that opted out between launches', () => {
+    // #given events mirrored while telemetry was on
+    createTelemetryClient(createDeps({ persistPath }).deps).track(
+      buildEvent('11111111-1111-1111-1111-111111111111')
+    )
+
+    // #when the next launch starts with telemetry disabled
+    const client = createTelemetryClient(createDeps({ persistPath, initialEnabled: false }).deps)
+
+    // #then nothing is restored and nothing is left on disk
+    expect(client.getQueueDepth()).toBe(0)
+    expect(fs.existsSync(persistPath)).toBe(false)
   })
 })

--- a/apps/desktop/src/main/telemetry/client.ts
+++ b/apps/desktop/src/main/telemetry/client.ts
@@ -8,6 +8,7 @@ import type {
 } from '@memry/contracts/telemetry-api'
 
 import { createLogger } from '../lib/logger'
+import { createQueueStore } from './queue-store'
 
 const logger = createLogger('Telemetry')
 
@@ -39,6 +40,13 @@ export interface TelemetryClientDeps {
   getSyncState: () => TelemetrySyncState
   /** Resolves the signed-in account's access token for identity attribution; null/throw → anonymous batch. */
   getAccessToken?: () => Promise<string | null>
+  /**
+   * Absolute path of the crash-durable mirror. `app_crashed` (and every other
+   * event recorded in the ≤30s before a hard crash) lives in THIS queue, so
+   * without it the crash marker only reports a crash that does not kill the app
+   * again within one flush interval. Omitted → memory only, as before.
+   */
+  persistPath?: string
 }
 
 export type TelemetryFlushReason = 'manual' | 'interval' | 'shutdown' | 'background'
@@ -59,13 +67,31 @@ export interface TelemetryClient {
 }
 
 export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClient => {
-  const queue: TelemetryEvent[] = []
+  const store = deps.persistPath ? createQueueStore<TelemetryEvent>(deps.persistPath) : null
+  // Restore only when telemetry is on: an install that opted out between
+  // launches must not keep the previous session's events on disk, let alone
+  // ship them. Each restored event keeps its own occurredAt; the batch envelope
+  // is stamped with the CURRENT session, so a resurrected event is attributed
+  // to the launch that shipped it rather than the one that died.
+  const queue: TelemetryEvent[] = store && deps.initialEnabled ? store.load() : []
+  if (store && !deps.initialEnabled) store.clear()
   let enabled = deps.initialEnabled
 
   const trimQueue = (): void => {
     if (queue.length > TELEMETRY_QUEUE_LIMIT) {
       queue.splice(0, queue.length - TELEMETRY_QUEUE_LIMIT)
     }
+  }
+
+  const persist = (): void => {
+    store?.save(queue)
+  }
+
+  // A mirror written by a build with a larger limit must not resurrect an
+  // unbounded queue; rewrite so the dropped head does not return next launch.
+  if (queue.length > TELEMETRY_QUEUE_LIMIT) {
+    trimQueue()
+    persist()
   }
 
   const buildBatch = (events: TelemetryEvent[]): TelemetryBatch => ({
@@ -88,6 +114,7 @@ export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClien
     if (!enabled) return
     queue.push(event)
     trimQueue()
+    persist()
   }
 
   const flush = async (reason: TelemetryFlushReason): Promise<TelemetryFlushResult> => {
@@ -130,6 +157,7 @@ export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClien
           response.status >= 400 && response.status < 500 && response.status !== 429
         if (permanentlyRejected) {
           queue.splice(0, batchSize)
+          persist()
         }
         logger.warn('Telemetry batch rejected', {
           status: response.status,
@@ -145,6 +173,7 @@ export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClien
       }
 
       queue.splice(0, batchSize)
+      persist()
       return { success: true, attempted: batchSize, accepted: batchSize }
     } catch (error) {
       logger.warn('Telemetry flush failed', {
@@ -164,6 +193,8 @@ export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClien
     enabled = next
     if (!next) {
       queue.length = 0
+      // Turning telemetry off must leave nothing behind on disk either.
+      store?.clear()
     }
   }
 

--- a/apps/desktop/src/main/telemetry/diagnostics.ts
+++ b/apps/desktop/src/main/telemetry/diagnostics.ts
@@ -7,6 +7,7 @@ import {
 } from '@memry/contracts/telemetry-api'
 
 import { isExpectedConditionError } from './expected-conditions'
+import { getMainRedactOptions } from './redact-options'
 import { shouldEmitThrottled } from './throttle'
 import { trackMainEvent, type TrackMainEventOptions } from './track'
 
@@ -69,7 +70,7 @@ export const trackMainError = (source: string, action: string, error: unknown): 
     source: toSafeToken(source, 'main_process'),
     result: 'failed',
     errorCode: toErrorCode(error),
-    error: buildErrorDetail(error)
+    error: buildErrorDetail(error, undefined, getMainRedactOptions())
   })
 }
 

--- a/apps/desktop/src/main/telemetry/log-ship.test.ts
+++ b/apps/desktop/src/main/telemetry/log-ship.test.ts
@@ -147,7 +147,7 @@ describe('installLogShip', () => {
     expect(lines[0].fields?.filePath).toMatch(/^<vault>\/\[name:[0-9a-f]{8}\]\.md$/)
   })
 
-  it('ignores records from its own re-entrancy scopes (LogShip/Telemetry/Loki)', () => {
+  it('ignores records from its own re-entrancy scopes (LogShip/Telemetry/QueueStore)', () => {
     const { fetchMock } = createFetch()
     const shipped = installLogShip({
       buildChannel: 'production',
@@ -159,7 +159,7 @@ describe('installLogShip', () => {
 
     getTransport()({ level: 'warn', scope: 'LogShip', data: ['flush failed'] })
     getTransport()({ level: 'warn', scope: 'Telemetry', data: ['flush failed'] })
-    getTransport()({ level: 'warn', scope: 'Loki', data: ['flush failed'] })
+    getTransport()({ level: 'warn', scope: 'TelemetryQueueStore', data: ['flush failed'] })
 
     expect(shipped.recentLines()).toHaveLength(0)
   })

--- a/apps/desktop/src/main/telemetry/log-ship.ts
+++ b/apps/desktop/src/main/telemetry/log-ship.ts
@@ -20,9 +20,9 @@ import { createShipQueue, type ShipQueue } from './ship-queue'
 // Scopes that belong to this pipeline itself. Without this guard a flush failure
 // (logged via createLogger('LogShip').warn(...) in ship-queue.ts) would be
 // re-ingested by this same transport, redacted, enqueued, and potentially fail to
-// flush again — an unbounded loop. 'Telemetry'/'Loki' are the sibling telemetry
-// scopes with the same recursion risk.
-const SKIP_SCOPES = new Set(['LogShip', 'Telemetry', 'Loki'])
+// flush again — an unbounded loop. 'Telemetry'/'TelemetryQueueStore' are the
+// sibling telemetry scopes with the same recursion risk.
+const SKIP_SCOPES = new Set(['LogShip', 'Telemetry', 'TelemetryQueueStore'])
 
 const RING_LIMIT = 200
 const RING_MS = 5 * 60 * 1000
@@ -78,6 +78,8 @@ export interface LogShipDeps {
   level?: string
   /** null disables the periodic flush timer (tests drive flush via dispose()). */
   flushIntervalMs?: number | null
+  /** Absolute path of the log queue's crash-durable mirror; omitted → memory only. */
+  persistPath?: string
 }
 
 export interface LogShip {
@@ -150,10 +152,20 @@ export const installLogShip = (deps: LogShipDeps): LogShip => {
   const queue: ShipQueue<DiagnosticLogLine> = createShipQueue<DiagnosticLogLine>({
     fetch: wrapFetch(deps.fetch),
     endpoint,
-    buildBody
+    buildBody,
+    persistPath: deps.persistPath
   })
 
   const enabled = (): boolean => getTelemetryRuntime()?.getSettings().enabled === true
+
+  // Settle the gate once at install, not only on the next log record: lines a
+  // crashed session left in the mirror have to become flushable without waiting
+  // for a fresh warn/error, and an install with telemetry off has to purge the
+  // mirror instead of carrying it forward.
+  const syncQueueEnabled = (): void => {
+    queue.setEnabled(deps.buildChannel === 'development' ? false : enabled())
+  }
+  syncQueueEnabled()
 
   let reentrant = false
 
@@ -207,7 +219,7 @@ export const installLogShip = (deps: LogShipDeps): LogShip => {
       sweepThrottle(now)
       pushRing(line)
 
-      queue.setEnabled(deps.buildChannel === 'development' ? false : enabled())
+      syncQueueEnabled()
       queue.enqueue(line)
     } finally {
       reentrant = false

--- a/apps/desktop/src/main/telemetry/queue-store.ts
+++ b/apps/desktop/src/main/telemetry/queue-store.ts
@@ -1,0 +1,78 @@
+// Crash-durable mirror for the in-memory telemetry queues. A hard crash (main-
+// process abort, OOM kill, force-quit) discards everything queued since the last
+// 30s flush — including the `app_crashed` event the launch just recorded, which
+// is exactly the evidence the crash marker exists to produce. The mirror is
+// rewritten on every enqueue, so the next launch drains what the dead process
+// left behind.
+//
+// On-disk format is `{"version":1,"items":[...]}`. Builds older than this one
+// never read the file at all, so a newer build's mirror is inert for them; a
+// version this build does not recognise is discarded rather than parsed. Neither
+// direction can wedge startup.
+import fs from 'node:fs'
+
+import { createLogger } from '../lib/logger'
+
+const logger = createLogger('TelemetryQueueStore')
+
+const FORMAT_VERSION = 1
+
+export interface QueueStore<T> {
+  /** Items left behind by the previous process. Never throws; `[]` on any fault. */
+  load(): T[]
+  /** Rewrite the mirror. Never throws — a full or read-only disk must not break logging. */
+  save(items: readonly T[]): void
+  /** Remove the mirror (clean drain, or telemetry turned off). */
+  clear(): void
+}
+
+export const createQueueStore = <T>(filePath: string): QueueStore<T> => {
+  // save() runs on every enqueue, so a persistently unwritable disk would log
+  // once per line without this latch.
+  let writeFailureLogged = false
+
+  const clear = (): void => {
+    try {
+      fs.rmSync(filePath, { force: true })
+    } catch {
+      // Best effort: a stale mirror is drained-and-overwritten, never replayed
+      // twice, because load() is only called once per queue.
+    }
+  }
+
+  return {
+    load: () => {
+      let raw: string
+      try {
+        raw = fs.readFileSync(filePath, 'utf-8')
+      } catch {
+        return [] // no mirror: the previous session drained cleanly, or first launch
+      }
+      try {
+        const parsed = JSON.parse(raw) as { version?: unknown; items?: unknown }
+        if (parsed && parsed.version === FORMAT_VERSION && Array.isArray(parsed.items)) {
+          return parsed.items as T[]
+        }
+      } catch {
+        // fall through to the discard path
+      }
+      // Truncated by the very crash it was written to survive, or written by a
+      // format this build does not know. Startup must never depend on it.
+      logger.warn('Discarding unreadable telemetry queue mirror')
+      clear()
+      return []
+    },
+    save: (items) => {
+      try {
+        fs.writeFileSync(filePath, JSON.stringify({ version: FORMAT_VERSION, items }), 'utf-8')
+        writeFailureLogged = false
+      } catch (error) {
+        if (!writeFailureLogged) {
+          writeFailureLogged = true
+          logger.warn('Failed to persist telemetry queue; a crash would lose it', { error })
+        }
+      }
+    },
+    clear
+  }
+}

--- a/apps/desktop/src/main/telemetry/redact-options.ts
+++ b/apps/desktop/src/main/telemetry/redact-options.ts
@@ -1,0 +1,29 @@
+// The main process's redaction config, shared by anything that scrubs free-form
+// text before it leaves the device. It is deliberately the SAME salted-hash
+// setup Path A log shipping installs (see log-ship.ts), so an error message and
+// a shipped log line collapse the same vault path and hash the same note title
+// to the same placeholder — otherwise the two halves of an incident cannot be
+// joined during triage.
+import type { RedactOptions } from '@memry/contracts/redact'
+
+import { getCurrentVaultPath } from '../store'
+import { getOrCreateDiagnosticsSalt, makeSaltedHasher } from './diagnostics-salt'
+
+let hasher: ((value: string) => string) | null = null
+
+/**
+ * Never throws: reading/creating the salt touches the telemetry config file, and
+ * every caller is an error path, so a failure here would destroy the very report
+ * being built. It degrades to mask mode (fixed `<email>`/`<id>` placeholders, no
+ * correlation) instead — still fully redacted, just less useful during triage.
+ * Deliberately silent: the config module logs its own read/write failures, and
+ * logging from here would re-enter the diagnostics path that called it.
+ */
+export const getMainRedactOptions = (): RedactOptions => {
+  try {
+    hasher ??= makeSaltedHasher(getOrCreateDiagnosticsSalt())
+    return { vaultRoot: getCurrentVaultPath() ?? undefined, hash: hasher }
+  } catch {
+    return {}
+  }
+}

--- a/apps/desktop/src/main/telemetry/runtime.ts
+++ b/apps/desktop/src/main/telemetry/runtime.ts
@@ -47,6 +47,8 @@ export interface TelemetryRuntimeDeps {
   accessTokenProvider?: () => Promise<string | null>
   /** Disable internal flush interval (used in tests) */
   flushIntervalMs?: number | null
+  /** Absolute path of the event queue's crash-durable mirror; omitted → memory only. */
+  persistPath?: string
 }
 
 export interface TelemetryRuntime {
@@ -141,7 +143,8 @@ export const initializeTelemetryRuntime = (deps?: TelemetryRuntimeDeps): Telemet
     initialEnabled,
     getAuthState: deps?.authStateProvider ?? (() => 'anonymous'),
     getSyncState: deps?.syncStateProvider ?? (() => 'unknown'),
-    getAccessToken: deps?.accessTokenProvider
+    getAccessToken: deps?.accessTokenProvider,
+    persistPath: deps?.persistPath
   })
 
   if (initialEnabled) {

--- a/apps/desktop/src/main/telemetry/ship-queue.test.ts
+++ b/apps/desktop/src/main/telemetry/ship-queue.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
+import type { TelemetryFetch } from './client'
 import { createShipQueue } from './ship-queue'
 
 const okFetch = vi.fn(async () => ({ ok: true, status: 202 }))
@@ -57,5 +61,155 @@ describe('createShipQueue', () => {
     q.setEnabled(true)
     for (let i = 0; i < 10; i++) q.enqueue(i)
     expect(q.depth()).toBe(3)
+  })
+})
+
+describe('createShipQueue — crash durability', () => {
+  let tempDir: string
+  let persistPath: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-ship-queue-'))
+    persistPath = path.join(tempDir, 'queue.json')
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  // A "process death" is modelled by simply dropping the queue object: nothing
+  // is flushed, no dispose runs, and the only state that can survive is the
+  // on-disk mirror — exactly what a SIGKILL leaves behind.
+  const makeDurable = (fetch: TelemetryFetch = okFetch, queueLimit?: number) =>
+    createShipQueue<number>({
+      fetch,
+      endpoint: 'https://x/logs',
+      buildBody: (items) => ({ items }),
+      persistPath,
+      ...(queueLimit === undefined ? {} : { queueLimit })
+    })
+
+  it('restores what a killed process enqueued but never flushed', async () => {
+    // #given a session that queued two lines and died before its 30s flush
+    const dead = makeDurable()
+    dead.setEnabled(true)
+    dead.enqueue(1)
+    dead.enqueue(2)
+
+    // #when the next launch opens the same mirror
+    const bodies: unknown[] = []
+    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)))
+      return { ok: true, status: 202 }
+    })
+    const revived = makeDurable(fetchMock)
+    expect(revived.depth()).toBe(2)
+
+    // #then the lines ship on this launch instead of being lost
+    revived.setEnabled(true)
+    expect(await revived.flush()).toMatchObject({ success: true, accepted: 2 })
+    expect(bodies).toEqual([{ items: [1, 2] }])
+  })
+
+  it('enforces the queue limit against the persisted set, not just the live one', () => {
+    // #given a mirror holding more than this build's limit
+    fs.writeFileSync(persistPath, JSON.stringify({ version: 1, items: [1, 2, 3, 4, 5, 6, 7] }))
+
+    // #when the queue restores it
+    const q = makeDurable(okFetch, 3)
+
+    // #then the oldest are dropped, and the trim is written back so they do not
+    // return on the launch after this one
+    expect(q.depth()).toBe(3)
+    expect(JSON.parse(fs.readFileSync(persistPath, 'utf-8'))).toEqual({
+      version: 1,
+      items: [5, 6, 7]
+    })
+  })
+
+  it('starts clean when the mirror is corrupt instead of blocking startup', () => {
+    // #given a mirror truncated by the very crash it was meant to survive
+    fs.writeFileSync(persistPath, '{"version":1,"items":[1,2')
+
+    // #when the next launch opens it
+    // #then construction succeeds, the queue is empty, and the junk is gone
+    const q = makeDurable()
+    expect(q.depth()).toBe(0)
+    expect(fs.existsSync(persistPath)).toBe(false)
+  })
+
+  it('starts clean when the mirror was written by an unknown format version', () => {
+    // #given a mirror from a future build
+    fs.writeFileSync(persistPath, JSON.stringify({ version: 99, items: [1, 2] }))
+
+    // #when this build opens it
+    // #then it is discarded rather than mis-parsed
+    expect(makeDurable().depth()).toBe(0)
+  })
+
+  it('drains once — a restored batch is not re-sent on the launch after it', async () => {
+    // #given a crashed session's lines, drained by the next launch
+    const dead = makeDurable()
+    dead.setEnabled(true)
+    dead.enqueue(1)
+    dead.enqueue(2)
+
+    const revived = makeDurable()
+    revived.setEnabled(true)
+    await revived.flush()
+
+    // #when a third launch opens the same mirror
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 202 }))
+    const third = makeDurable(fetchMock)
+    third.setEnabled(true)
+
+    // #then there is nothing left to send
+    expect(third.depth()).toBe(0)
+    expect(await third.flush()).toMatchObject({ attempted: 0 })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('restoring twice without a flush does not duplicate the queue', () => {
+    // #given a mirror left by a crash
+    const dead = makeDurable()
+    dead.setEnabled(true)
+    dead.enqueue(1)
+    dead.enqueue(2)
+
+    // #when two queues restore it (a second instance racing the primary)
+    // #then each sees the same two items, never four
+    expect(makeDurable().depth()).toBe(2)
+    expect(makeDurable().depth()).toBe(2)
+  })
+
+  it('turning telemetry off deletes the mirror, not just the in-memory queue', () => {
+    // #given queued lines mirrored to disk
+    const q = makeDurable()
+    q.setEnabled(true)
+    q.enqueue(1)
+    expect(fs.existsSync(persistPath)).toBe(true)
+
+    // #when the user opts out
+    q.setEnabled(false)
+
+    // #then nothing survives the opt-out on disk either
+    expect(fs.existsSync(persistPath)).toBe(false)
+    expect(makeDurable().depth()).toBe(0)
+  })
+
+  it('keeps working when the mirror cannot be written', () => {
+    // #given a persist path inside a directory that does not exist
+    const q = createShipQueue<number>({
+      fetch: okFetch,
+      endpoint: 'https://x/logs',
+      buildBody: (items) => ({ items }),
+      persistPath: path.join(tempDir, 'missing', 'nested', 'queue.json')
+    })
+
+    // #when enqueuing
+    // #then the in-memory queue still works; durability is the only loss
+    q.setEnabled(true)
+    expect(() => q.enqueue(1)).not.toThrow()
+    expect(q.depth()).toBe(1)
   })
 })

--- a/apps/desktop/src/main/telemetry/ship-queue.ts
+++ b/apps/desktop/src/main/telemetry/ship-queue.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '../lib/logger'
 import type { TelemetryFetch } from './client'
+import { createQueueStore } from './queue-store'
 
 const logger = createLogger('LogShip')
 
@@ -12,6 +13,13 @@ export interface ShipQueueDeps<T> {
   buildBody: (items: T[]) => unknown
   queueLimit?: number
   batchLimit?: number
+  /**
+   * Absolute path of the crash-durable mirror. Set → the queue restores whatever
+   * the previous process left behind and rewrites the file on every enqueue and
+   * flush, so a hard crash no longer discards the last 30s of evidence. Omitted
+   * (tests, callers that do not want on-disk state) → memory only, as before.
+   */
+  persistPath?: string
 }
 
 export interface ShipQueueFlushResult {
@@ -30,7 +38,8 @@ export interface ShipQueue<T> {
 export const createShipQueue = <T>(deps: ShipQueueDeps<T>): ShipQueue<T> => {
   const queueLimit = deps.queueLimit ?? SHIP_QUEUE_LIMIT
   const batchLimit = deps.batchLimit ?? SHIP_BATCH_LIMIT
-  const queue: T[] = []
+  const store = deps.persistPath ? createQueueStore<T>(deps.persistPath) : null
+  const queue: T[] = store ? store.load() : []
   let enabled = false
 
   const trimQueue = (): void => {
@@ -39,10 +48,23 @@ export const createShipQueue = <T>(deps: ShipQueueDeps<T>): ShipQueue<T> => {
     }
   }
 
+  const persist = (): void => {
+    store?.save(queue)
+  }
+
+  // The restored set is bounded by the SAME limit as a live one, so a mirror
+  // written by a build with a larger queueLimit cannot resurrect an unbounded
+  // queue. Rewrite immediately, otherwise the dropped head returns next launch.
+  if (queue.length > queueLimit) {
+    trimQueue()
+    persist()
+  }
+
   const enqueue = (item: T): void => {
     if (!enabled) return
     queue.push(item)
     trimQueue()
+    persist()
   }
 
   const flush = async (): Promise<ShipQueueFlushResult> => {
@@ -69,6 +91,7 @@ export const createShipQueue = <T>(deps: ShipQueueDeps<T>): ShipQueue<T> => {
           response.status >= 400 && response.status < 500 && response.status !== 429
         if (permanentlyRejected) {
           queue.splice(0, batchSize)
+          persist()
         }
         logger.warn('Ship batch rejected', {
           status: response.status,
@@ -78,6 +101,7 @@ export const createShipQueue = <T>(deps: ShipQueueDeps<T>): ShipQueue<T> => {
       }
 
       queue.splice(0, batchSize)
+      persist()
       return { success: true, attempted: batchSize, accepted: batchSize }
     } catch (error) {
       logger.warn('Ship flush failed', {
@@ -91,6 +115,9 @@ export const createShipQueue = <T>(deps: ShipQueueDeps<T>): ShipQueue<T> => {
     enabled = next
     if (!next) {
       queue.length = 0
+      // Turning telemetry off must leave nothing behind on disk either — a
+      // restored mirror would otherwise outlive the opt-out.
+      store?.clear()
     }
   }
 

--- a/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.test.ts
+++ b/apps/desktop/src/renderer/src/lib/telemetry-diagnostics.test.ts
@@ -20,15 +20,17 @@ describe('renderer telemetry diagnostics', () => {
     trackTelemetryMock.mockReset()
   })
 
-  it('emits a stack for renderer errors but never the raw message', () => {
+  it('emits a stack and a redacted message for renderer errors, never the raw one', () => {
     // #given an error whose message embeds a private note path
     const error = new TypeError('failed at /Users/kaan/private-note.md')
 
     // #when tracking it
     trackRendererError('unhandled_rejection', error)
 
-    // #then stable metadata + a stack (code locations) leave the renderer,
-    //   but the message text (which held the note path) never does
+    // #then stable metadata, a stack (code locations) and the message all leave
+    //   the renderer — the message only after redactText ran on it here. The
+    //   renderer knows no diagnostics salt, so redaction is mask mode: fixed
+    //   placeholders instead of correlatable hashes, equally scrubbed.
     expect(trackTelemetryMock).toHaveBeenCalledWith(
       'app_error_seen',
       expect.objectContaining({
@@ -38,11 +40,15 @@ describe('renderer telemetry diagnostics', () => {
         source: 'renderer',
         result: 'failed',
         errorCode: 'TypeError',
-        error: expect.objectContaining({ stack: expect.stringContaining('at ') })
+        error: expect.objectContaining({
+          stack: expect.stringContaining('at '),
+          message: 'failed at ~/[name].md'
+        })
       })
     )
     const serialized = JSON.stringify(trackTelemetryMock.mock.calls[0])
-    // message header is stripped; home paths in stack frames are scrubbed
+    // the note filename is gone from the message; home paths in stack frames
+    // and message alike are scrubbed
     expect(serialized).not.toContain('private-note')
     expect(serialized).not.toContain('/Users/')
   })

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -190,9 +190,12 @@ offline quit never stalls the exit.
 
 ## Crash & Unclean-Shutdown Detection
 
-A hard crash — main-process abort, OOM kill, force quit — discards the in-memory telemetry queue,
-so the crash itself never ships: the classic "it crashed and there are no logs" report. A marker
-file inverts that (`apps/desktop/src/main/telemetry/crash-marker.ts`):
+A hard crash — main-process abort, OOM kill, force quit — used to discard the in-memory telemetry
+queue, so the crash itself never shipped: the classic "it crashed and there are no logs" report.
+Two mechanisms fix that: a marker file that notices the crash, and a durable queue that keeps the
+resulting event alive long enough to send.
+
+A marker file (`apps/desktop/src/main/telemetry/crash-marker.ts`):
 
 - `session-marker.json` is written into `userData` at startup with the session id, `startedAt`,
   `lastAliveAt`, and app version, then refreshed every 60s while the app is alive.
@@ -219,6 +222,49 @@ line for that failure never flushes, but the marker survives to the next launch.
 that wrote a marker may remove one — a second instance that loses the single-instance lock shares
 `userData` and must not erase the primary's marker on its way out. Marker write failures are
 logged and swallowed; a read-only disk must never break startup.
+
+### Durable Queues
+
+The marker only detects the crash — `app_crashed` still has to survive long enough to be sent, and
+both telemetry queues flush on a 30s interval. A second hard crash inside that window would
+otherwise take the crash report with it, which is why both queues mirror to `userData`
+(`telemetry/queue-store.ts`):
+
+| Queue                                      | Mirror                       | Carries                                     |
+| ------------------------------------------ | ---------------------------- | ------------------------------------------- |
+| Event queue (`telemetry/client.ts`)        | `telemetry-event-queue.json` | `app_crashed`, `app_error_seen`, all events |
+| Log-ship queue (`telemetry/ship-queue.ts`) | `telemetry-log-queue.json`   | Path A redacted `warn`/`error` log lines    |
+
+The mirror is rewritten on every enqueue and after every flush, so what is on disk is what has not
+yet been accepted by the server. The next launch restores it and drains it; a drained batch is
+removed from the mirror, so nothing is sent twice.
+
+Rules the mirror follows:
+
+- **Format** is `{"version":1,"items":[…]}`. A file whose version this build does not recognise is
+  discarded rather than parsed, and builds that predate the mirror never read it at all — so
+  neither a downgrade nor a future format bump can wedge startup.
+- **Corruption is expected.** The mirror is most likely to be truncated by exactly the crash it was
+  written to survive, so an unparseable file is logged, deleted, and treated as empty.
+- **Write failures are non-fatal.** A read-only or full disk costs durability, never logging or
+  shutdown; the failure is logged once per streak rather than once per line.
+- **The limit applies to the restored set too** (`TELEMETRY_QUEUE_LIMIT` / `SHIP_QUEUE_LIMIT`), so a
+  mirror written by a build with a larger limit cannot resurrect an unbounded queue.
+- **Opting out deletes the mirror.** Turning telemetry off clears the file, not just the in-memory
+  queue, and a launch that starts with telemetry disabled discards the mirror instead of restoring
+  it.
+
+Restored events keep their own `occurredAt`; the batch envelope is stamped with the session that
+ships them, so an event resurrected from a dead session is attributed to the launch that sent it.
+
+### Native Crash Dumps
+
+`crashReporter.start({ uploadToServer: false })` runs before `app.ready`, so main, renderer, and
+utility processes all write minidumps for native crashes that no JS handler ever observes. The
+dumps stay in `app.getPath('crashDumps')` for the Path B diagnostic bundle the user submits
+deliberately. **`uploadToServer` must stay `false`**: a minidump is raw process memory — PostHog
+does not ingest minidumps, and there is no way to redact one, so uploading would breach the
+redaction model every other telemetry path is built around.
 
 ## PostHog Event Capture
 

--- a/packages/contracts/src/redact.fuzz.test.ts
+++ b/packages/contracts/src/redact.fuzz.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { createHash } from 'node:crypto'
 import { redactLogLine } from './redact'
+import { buildErrorDetail } from './telemetry-api'
 
 // Real salted hasher (this test runs under Node/Vitest, node:crypto available).
 const hash = (v: string): string =>
@@ -52,6 +53,45 @@ describe('fuzz invariant — no raw secret survives', () => {
     )
     const dump = serialize(out)
     for (const s of SECRETS) expect(dump).not.toContain(s)
+  })
+})
+
+// TelemetryErrorDetail.message is the ONE telemetry field carrying free-form
+// error text, so the same invariant has to hold there — and it is redacted by a
+// different call path (buildErrorDetail → redactText) than the log lines above.
+describe('fuzz invariant — no raw secret survives buildErrorDetail.message', () => {
+  for (const secret of SECRETS) {
+    it(`drops "${secret.slice(0, 20)}…" with the salted (main-process) config`, () => {
+      const detail = buildErrorDetail(new Error(`operation failed: ${secret}`), undefined, opts)
+      expect(detail?.message).toBeTruthy()
+      expect(serialize(detail)).not.toContain(secret)
+    })
+    it(`drops "${secret.slice(0, 20)}…" in mask mode (renderer, no salt)`, () => {
+      const detail = buildErrorDetail(new Error(`operation failed: ${secret}`))
+      expect(detail?.message).toBeTruthy()
+      expect(serialize(detail)).not.toContain(secret)
+    })
+  }
+
+  it('combined payload leaks nothing, from message or component stack', () => {
+    const detail = buildErrorDetail(
+      new Error(SECRETS.join(' | ')),
+      `    in Editor (at ${SECRETS[3]})`,
+      opts
+    )
+    const dump = serialize(detail)
+    for (const s of SECRETS) expect(dump).not.toContain(s)
+  })
+
+  it('keeps the message useful — the diagnostic prose survives redaction', () => {
+    const detail = buildErrorDetail(
+      new Error('Failed to open vault: EACCES /home/victim/Vault/Notes/Passport Scan.pdf'),
+      undefined,
+      opts
+    )
+    expect(detail?.message).toContain('Failed to open vault: EACCES')
+    expect(detail?.message).toContain('<vault>/Notes/')
+    expect(detail?.message).not.toContain('Passport Scan')
   })
 })
 

--- a/packages/contracts/src/telemetry-api.ts
+++ b/packages/contracts/src/telemetry-api.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { redactText, type RedactOptions } from './redact'
+
 // DEPLOY ORDER: the sync-server validates /telemetry/batch with THIS schema
 // (apps/sync-server/src/routes/telemetry.ts). A server running older contracts
 // rejects the ENTIRE batch with a 400, not just the unknown event — so any
@@ -465,18 +467,31 @@ export const normalizeWindowError = (report: WindowErrorReport): Error => {
 
 /**
  * Build the redacted, length-capped error detail attached to `app_error_seen`
- * desktop telemetry. buildErrorDetail itself never populates `message` — a raw
- * error message can contain a note title/filename/content — so this only sends
- * the stack frames (code locations) and the React component stack, with home
- * paths and stray identifiers scrubbed. See TelemetryErrorDetailSchema.message
- * above for the contract's own optional, redacted message field.
- * Returns undefined when there is nothing useful to send.
+ * desktop telemetry: the stack frames (code locations), the React component
+ * stack, and the error message — each with home paths and stray identifiers
+ * scrubbed. Returns undefined when there is nothing useful to send.
+ *
+ * The message is the one field that can carry free-form text (a note title, a
+ * filename, note content), so it never ships raw: it goes through `redactText`
+ * — the same module Path A log shipping uses — HERE, on the device, before it
+ * ever leaves the process. `redactOptions` carries the caller's vault root and
+ * salted hasher; main-process callers pass both, so placeholders correlate
+ * across lines. A caller with neither (the renderer, which knows no salt) still
+ * gets full redaction, just with fixed `<email>`/`<id>`/`[name].ext`
+ * placeholders instead of correlatable hashes. The sync-server re-runs the same
+ * redaction in mask mode as a backstop; see TelemetryErrorDetailSchema.message.
  */
 export const buildErrorDetail = (
   error: unknown,
-  componentStack?: string
+  componentStack?: string,
+  redactOptions?: RedactOptions
 ): TelemetryErrorDetail | undefined => {
   const detail: TelemetryErrorDetail = {}
+  const message = readProp(error, 'message')
+  if (typeof message === 'string' && message) {
+    const redacted = truncate(redactText(message, redactOptions), 512)
+    if (redacted) detail.message = redacted
+  }
   const stack = readProp(error, 'stack')
   const rawStack = isError(error) && typeof stack === 'string' ? stack : undefined
   if (rawStack) {
@@ -486,5 +501,5 @@ export const buildErrorDetail = (
   if (componentStack) {
     detail.componentStack = truncate(redactSensitive(componentStack), 2000)
   }
-  return detail.stack || detail.componentStack ? detail : undefined
+  return detail.message || detail.stack || detail.componentStack ? detail : undefined
 }


### PR DESCRIPTION
Partial for #858 (crash capture D7 + redacted error message D8). Also clears item 3 of #864. Account identity (#858 section 1) is out of scope here and untouched.

## Why the durable queue is the point

#974 merged the unclean-shutdown marker and the `app_crashed` event. That work is only as trustworthy as the queue holding the event: both telemetry queues were `const queue: T[] = []`, purely in memory, flushed on a 30s interval. A hard crash discarded everything queued since the last flush — including the `app_crashed` event the launch had just recorded. So the marker reliably detected a crash it could then lose to the *next* crash.

Worth flagging: the issue names `ship-queue.ts`, but `app_crashed` actually rides the telemetry **event** queue in `client.ts`, not the log-ship queue. Persisting only `ship-queue.ts` would have left the crash event exactly as fragile as before, so both queues are now durable through one shared primitive.

## What changed

**Durable queues** — new `telemetry/queue-store.ts` mirrors a queue to `userData`, rewritten on every enqueue and after every flush, restored and drained on the next launch. Both queues opt in via `persistPath`, wired from `main/index.ts`:

| Queue | Mirror | Carries |
| --- | --- | --- |
| `telemetry/client.ts` | `telemetry-event-queue.json` | `app_crashed`, `app_error_seen`, all events |
| `telemetry/ship-queue.ts` | `telemetry-log-queue.json` | Path A redacted `warn`/`error` log lines |

A drained batch is removed from the mirror, so nothing is sent twice. `SHIP_QUEUE_LIMIT` / `TELEMETRY_QUEUE_LIMIT` are enforced against the *restored* set, not only the live one. Turning telemetry off deletes the mirror rather than just clearing memory, and a launch that starts with telemetry disabled discards the mirror instead of restoring it. `installLogShip` now settles the enabled gate once at install so restored lines become flushable without waiting for a fresh `warn`/`error`.

**Crash reporter** — `crashReporter.start({ uploadToServer: false })` before `app.ready`, so main, renderer and utility processes all write minidumps for native crashes no JS handler observes. **Minidumps are never uploaded.** They stay in `app.getPath('crashDumps')` for the Path B diagnostic bundle the user submits deliberately. A minidump is raw process memory: PostHog does not ingest one and there is no way to redact one, so uploading would breach the redaction model every other telemetry path is built around. `index.phase2.test.ts` pins the `{ uploadToServer: false }` argument so a future edit cannot flip it silently.

**Redacted error message** — `buildErrorDetail` now populates `TelemetryErrorDetail.message`, run through `redactText` **on the device** before it leaves the process. Main-process callers pass the same salted-hash config Path A log shipping uses (new `telemetry/redact-options.ts`), so an error message and a shipped log line collapse the same vault path and hash the same note title to the same placeholder. The renderer knows no salt and degrades to mask mode — equally scrubbed, just non-correlatable. Its docblock was corrected in Train 1 but the function still sent nothing; code and comment now agree. The `redact.ts` fuzz invariant is extended to cover the new field in both salted and mask mode, plus a case asserting the message stays *useful* after redaction.

**Stale Loki refs (#864 item 3)** — `ipc/validate.ts` comment and `log-ship.ts` `SKIP_SCOPES`. The skip entry is replaced with `TelemetryQueueStore` rather than dropped: that is a real sibling telemetry scope with the same recursion risk this set exists to prevent, so the entry (and its test) now describe live behaviour. `incident-report.test.ts:162` is left alone — it quotes a historical DoD verbatim.

## Backward compatibility

The mirror format is `{"version":1,"items":[…]}`, and the risk is a user moving between builds:

- **New build → old build.** Builds that predate this change never read either file, so a mirror written by a newer build is inert for them. No parse, no crash, no behaviour change.
- **Old build → new build.** Neither file exists; `load()` returns `[]` on a missing file, which is the normal clean-shutdown path.
- **Future format bump.** A `version` this build does not recognise is discarded rather than parsed, so a rollback after a format change degrades to "queue starts empty" instead of wedging startup.
- **Corruption is expected, not exceptional.** The mirror is most likely to be truncated by exactly the crash it was written to survive, so an unparseable file is logged, deleted and treated as empty. Startup never depends on it.
- **Write failures are non-fatal.** A read-only or full disk costs durability only — never logging, never shutdown — and is logged once per streak rather than once per line.
- **Bounded on disk.** The restored set is trimmed to this build's queue limit and rewritten, so a mirror written by a build with a larger limit cannot resurrect an unbounded queue. Worst case is 500 stale events after a downgrade/re-upgrade.
- **Privacy.** Opting out deletes the file; a disabled launch discards rather than restores.
- **No schema, contract or protocol change.** `persistPath` is an optional dep (omitted → previous in-memory behaviour) and `buildErrorDetail`'s third parameter is optional. `TelemetryErrorDetailSchema.message` already shipped in Train 1, so the deployed sync-server already accepts it — but the deploy order in #858 still stands: Train 1 server first, this desktop release after.

One accepted semantic wrinkle: restored events keep their own `occurredAt`, but the batch envelope is stamped with the session that ships them, so an event resurrected from a dead session is attributed to the launch that sent it. That is the right attribution for `app_crashed` (the new launch emits it anyway) and a minor fidelity loss otherwise — far better than losing the event.

## Verification

`pnpm lint` → 0 errors, 10 pre-existing warnings, none in touched files (confirmed with `--no-cache` on the changed paths).
`pnpm typecheck` → 16/16 tasks successful.
`pnpm test:desktop` → 1161 files passed, 13951 tests passed, 1 expected fail, 10 skipped.
`git diff --check` → clean.
`pnpm docs:impact --base origin/main --strict` → covered.
`pnpm docs:build` → build complete.
`pnpm check:architecture` / `pnpm check:contracts` → passed.

Docs: `apps/docs/src/architecture/observability.md` gains "Durable Queues" and "Native Crash Dumps" under Crash & Unclean-Shutdown Detection; the section's opening claim that a hard crash "discards the in-memory telemetry queue" is no longer true and was corrected.
