### PR TITLE
feat(graph): live force simulation with node dragging

### DIFF
--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.test.tsx
@@ -53,12 +53,18 @@ vi.mock('./graph-events', () => ({
     onHoverNode,
     onTooltipMove,
     onFocusNode,
-    onContextMenu
+    onContextMenu,
+    onNodeGrab,
+    onNodeDrag,
+    onNodeRelease
   }: {
     onHoverNode: (id: string | null) => void
     onTooltipMove: (pos: { x: number; y: number } | null) => void
     onFocusNode: (id: string) => void
     onContextMenu?: (menu: { nodeId: string; x: number; y: number } | null) => void
+    onNodeGrab?: (id: string) => void
+    onNodeDrag?: (id: string, x: number, y: number) => void
+    onNodeRelease?: (id: string) => void
   }) => (
     <div>
       <button
@@ -78,6 +84,15 @@ vi.mock('./graph-events', () => ({
       </button>
       <button type="button" onClick={() => onContextMenu?.({ nodeId: 'ghost', x: 3, y: 4 })}>
         context ghost
+      </button>
+      <button type="button" onClick={() => onNodeGrab?.('note-a')}>
+        grab note
+      </button>
+      <button type="button" onClick={() => onNodeDrag?.('note-a', 777, -321)}>
+        drag note
+      </button>
+      <button type="button" onClick={() => onNodeRelease?.('note-a')}>
+        release note
       </button>
     </div>
   )
@@ -353,8 +368,8 @@ describe('GraphCanvas', () => {
     expect(graphCanvasMocks.sigma.setSetting).toHaveBeenCalledWith('labelRenderedSizeThreshold', 6)
   })
 
-  it('syncs sigma settings and starts/stops forceatlas layout', () => {
-    const { rerender, unmount } = render(
+  it('syncs sigma settings and hides nodes outside the focus set', () => {
+    render(
       <GraphCanvas
         data={data}
         filterState={{ ...filters, focusNodeId: 'note-a', focusDepth: 1 }}
@@ -368,7 +383,6 @@ describe('GraphCanvas', () => {
       />
     )
 
-    expect(graphCanvasMocks.layoutStart).toHaveBeenCalledTimes(1)
     expect(graphCanvasMocks.sigma.setSetting).toHaveBeenCalledWith(
       'labelRenderedSizeThreshold',
       Infinity
@@ -382,17 +396,98 @@ describe('GraphCanvas', () => {
       isOrphan: true
     })
     expect(focusedOut.hidden).toBe(true)
+  })
 
-    rerender(
-      <GraphCanvas
-        data={data}
-        filterState={filters}
-        graphSettings={{ ...settings, layout: 'random', animateLayout: false }}
-        onFocusNode={vi.fn()}
-      />
-    )
+  describe('live simulation', () => {
+    const livePhysics: GraphSettings = {
+      ...settings,
+      layout: 'forceatlas2',
+      animateLayout: true
+    }
 
-    unmount()
-    expect(graphCanvasMocks.layoutStop).toHaveBeenCalled()
+    function renderLive(overrides: Partial<GraphSettings> = {}): {
+      graph: any
+      unmount: () => void
+    } {
+      const { unmount } = render(
+        <GraphCanvas
+          data={data}
+          filterState={filters}
+          graphSettings={{ ...livePhysics, ...overrides }}
+          onFocusNode={vi.fn()}
+        />
+      )
+      return { graph: graphCanvasMocks.sigmaContainerProps?.graph, unmount }
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('moves nodes and repaints on every animation frame', () => {
+      const { graph } = renderLive()
+      const before = graph.getNodeAttribute('note-a', 'x')
+      graphCanvasMocks.sigma.refresh.mockClear()
+
+      vi.advanceTimersToNextFrame()
+
+      expect(graph.getNodeAttribute('note-a', 'x')).not.toBe(before)
+      expect(graphCanvasMocks.sigma.refresh).toHaveBeenCalled()
+    })
+
+    it('pins a node to the pointer while it is being dragged', () => {
+      const { graph } = renderLive()
+
+      fireEvent.click(screen.getByText('grab note'))
+      fireEvent.click(screen.getByText('drag note'))
+      vi.advanceTimersToNextFrame()
+
+      expect(graph.getNodeAttribute('note-a', 'x')).toBe(777)
+      expect(graph.getNodeAttribute('note-a', 'y')).toBe(-321)
+    })
+
+    it('lets a released node settle back into the layout', () => {
+      const { graph } = renderLive()
+
+      fireEvent.click(screen.getByText('grab note'))
+      fireEvent.click(screen.getByText('drag note'))
+      vi.advanceTimersToNextFrame()
+      fireEvent.click(screen.getByText('release note'))
+      for (let i = 0; i < 20; i++) vi.advanceTimersToNextFrame()
+
+      expect(graph.getNodeAttribute('note-a', 'x')).not.toBe(777)
+    })
+
+    it('leaves positions alone for static layouts', () => {
+      const { graph } = renderLive({ layout: 'random' })
+      const before = graph.getNodeAttribute('note-a', 'x')
+
+      vi.advanceTimersToNextFrame()
+
+      expect(graph.getNodeAttribute('note-a', 'x')).toBe(before)
+    })
+
+    it('leaves positions alone when live motion is switched off', () => {
+      const { graph } = renderLive({ animateLayout: false })
+      const before = graph.getNodeAttribute('note-a', 'x')
+
+      vi.advanceTimersToNextFrame()
+
+      expect(graph.getNodeAttribute('note-a', 'x')).toBe(before)
+    })
+
+    it('stops the animation loop on unmount', () => {
+      const { graph, unmount } = renderLive()
+      unmount()
+      const before = graph.getNodeAttribute('note-a', 'x')
+
+      vi.advanceTimersToNextFrame()
+
+      expect(graph.getNodeAttribute('note-a', 'x')).toBe(before)
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-canvas.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { SigmaContainer, useSigma } from '@react-sigma/core'
-import { useWorkerLayoutForceAtlas2 } from '@react-sigma/layout-forceatlas2'
 import { useTheme } from 'next-themes'
 import '@react-sigma/core/lib/style.css'
 import type Graph from 'graphology'
 import type { GraphDataResponse } from '@memry/contracts/graph-api'
 import type { NodeDisplayData, EdgeDisplayData } from 'sigma/types'
 import { buildGraphologyGraph, computeFocusSet, type BuildGraphOptions } from '@/lib/graph-builder'
+import { LivePhysics, SettledPhysics, type PhysicsHandle } from './physics-layout'
 import type { GraphFilterState } from '@/hooks/use-graph-filters'
 import type { GraphSettings } from '@memry/contracts/graph-api'
 import { useTabActions } from '@/contexts/tabs'
@@ -73,6 +73,19 @@ export function GraphCanvas({
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
   const fadeRef = useRef(0)
   const hoverTargetRef = useRef<string | null>(null)
+  const physicsHandleRef = useRef<PhysicsHandle | null>(null)
+
+  const handleNodeGrab = useCallback((nodeId: string) => {
+    physicsHandleRef.current?.grab(nodeId)
+  }, [])
+
+  const handleNodeDrag = useCallback((nodeId: string, x: number, y: number) => {
+    physicsHandleRef.current?.drag(nodeId, x, y)
+  }, [])
+
+  const handleNodeRelease = useCallback((nodeId: string) => {
+    physicsHandleRef.current?.release(nodeId)
+  }, [])
 
   const dimmedColor = useMemo(() => resolveGraphVar('--graph-dimmed-node', '#e4e4de'), [])
 
@@ -254,12 +267,16 @@ export function GraphCanvas({
           layout={graphSettings.layout}
           animate={graphSettings.animateLayout}
           graph={graph}
+          physicsHandleRef={physicsHandleRef}
         />
         <GraphEvents
           onHoverNode={setHoveredNode}
           onTooltipMove={setTooltipPos}
           onFocusNode={onFocusNode}
           onContextMenu={setContextMenu}
+          onNodeGrab={handleNodeGrab}
+          onNodeDrag={handleNodeDrag}
+          onNodeRelease={handleNodeRelease}
         />
       </SigmaContainer>
       {hoveredNode && tooltipPos && !contextMenu && (
@@ -466,11 +483,13 @@ function SigmaSettingsSync({
 function LayoutManager({
   layout,
   animate,
-  graph
+  graph,
+  physicsHandleRef
 }: {
   layout: GraphSettings['layout']
   animate: boolean
   graph: Graph
+  physicsHandleRef: React.MutableRefObject<PhysicsHandle | null>
 }): React.JSX.Element | null {
   useEffect(() => {
     if (layout === 'circular') {
@@ -480,11 +499,13 @@ function LayoutManager({
     }
   }, [layout, graph])
 
-  if (layout === 'forceatlas2') {
-    return <ForceAtlas2Layout animate={animate} />
-  }
+  if (layout !== 'forceatlas2') return null
 
-  return null
+  return animate ? (
+    <LivePhysics graph={graph} handleRef={physicsHandleRef} />
+  ) : (
+    <SettledPhysics graph={graph} />
+  )
 }
 
 function applyCircularLayout(graph: Graph): void {
@@ -504,35 +525,4 @@ function applyRandomLayout(graph: Graph): void {
     graph.setNodeAttribute(node, 'x', (Math.random() - 0.5) * 1000)
     graph.setNodeAttribute(node, 'y', (Math.random() - 0.5) * 1000)
   })
-}
-
-function ForceAtlas2Layout({ animate }: { animate: boolean }): null {
-  const { start, stop } = useWorkerLayoutForceAtlas2({
-    settings: {
-      gravity: 0.75,
-      scalingRatio: 12.5,
-      slowDown: 3,
-      barnesHutOptimize: true,
-      strongGravityMode: true,
-      edgeWeightInfluence: 0
-    }
-  })
-
-  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
-
-  useEffect(() => {
-    if (!animate) {
-      stop()
-      return
-    }
-    start()
-    timerRef.current = setTimeout(stop, 8000)
-
-    return () => {
-      clearTimeout(timerRef.current)
-      stop()
-    }
-  }, [start, stop, animate])
-
-  return null
 }

--- a/apps/desktop/src/renderer/src/components/graph/graph-control-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-control-panel.tsx
@@ -212,6 +212,11 @@ export function GraphControlPanel({
                 checked={settings.showLabels}
                 onCheckedChange={(v) => updateSettings({ showLabels: v })}
               />
+              <FilterSwitch
+                label={t('control.live-motion')}
+                checked={settings.animateLayout}
+                onCheckedChange={(v) => updateSettings({ animateLayout: v })}
+              />
             </div>
           </PanelSection>
         </div>

--- a/apps/desktop/src/renderer/src/components/graph/graph-events.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-events.test.tsx
@@ -5,6 +5,7 @@ import { GraphEvents } from './graph-events'
 const mocks = vi.hoisted(() => ({
   events: {} as Record<string, (payload?: any) => void>,
   openTab: vi.fn(),
+  viewportToGraph: vi.fn(),
   graph: {
     hasNode: vi.fn(),
     getNodeAttributes: vi.fn()
@@ -16,7 +17,8 @@ vi.mock('@react-sigma/core', () => ({
     mocks.events = events
   },
   useSigma: () => ({
-    getGraph: () => mocks.graph
+    getGraph: () => mocks.graph,
+    viewportToGraph: mocks.viewportToGraph
   })
 }))
 
@@ -122,5 +124,122 @@ describe('GraphEvents', () => {
         path: '/task/task-1'
       })
     )
+  })
+
+  describe('node dragging', () => {
+    function renderWithDrag(): {
+      onNodeGrab: ReturnType<typeof vi.fn>
+      onNodeDrag: ReturnType<typeof vi.fn>
+      onNodeRelease: ReturnType<typeof vi.fn>
+    } {
+      const handlers = {
+        onNodeGrab: vi.fn(),
+        onNodeDrag: vi.fn(),
+        onNodeRelease: vi.fn()
+      }
+      render(
+        <GraphEvents
+          onHoverNode={vi.fn()}
+          onTooltipMove={vi.fn()}
+          onFocusNode={vi.fn()}
+          onContextMenu={vi.fn()}
+          {...handlers}
+        />
+      )
+      return handlers
+    }
+
+    it('grabs a node on pointer down', () => {
+      const { onNodeGrab } = renderWithDrag()
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+
+      expect(onNodeGrab).toHaveBeenCalledWith('note-1')
+      expect(document.body.style.cursor).toBe('grabbing')
+    })
+
+    it('drags the grabbed node in graph coordinates and blocks the camera pan', () => {
+      const { onNodeDrag } = renderWithDrag()
+      mocks.viewportToGraph.mockReturnValue({ x: 120, y: -40 })
+      const preventSigmaDefault = vi.fn()
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+      mocks.events.mousemovebody({ x: 60, y: 80, preventSigmaDefault })
+
+      expect(mocks.viewportToGraph).toHaveBeenCalledWith({ x: 60, y: 80 })
+      expect(onNodeDrag).toHaveBeenCalledWith('note-1', 120, -40)
+      expect(preventSigmaDefault).toHaveBeenCalled()
+    })
+
+    it('leaves the camera alone when no node is grabbed', () => {
+      const { onNodeDrag } = renderWithDrag()
+      const preventSigmaDefault = vi.fn()
+
+      mocks.events.mousemovebody({ x: 60, y: 80, preventSigmaDefault })
+
+      expect(onNodeDrag).not.toHaveBeenCalled()
+      expect(preventSigmaDefault).not.toHaveBeenCalled()
+    })
+
+    it('releases the node on mouse up', () => {
+      const { onNodeRelease } = renderWithDrag()
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+      mocks.events.mouseup()
+
+      expect(onNodeRelease).toHaveBeenCalledWith('note-1')
+    })
+
+    it('does not open a tab when the pointer actually dragged the node', () => {
+      renderWithDrag()
+      mocks.viewportToGraph.mockReturnValue({ x: 200, y: 200 })
+      mocks.graph.hasNode.mockReturnValue(true)
+      mocks.graph.getNodeAttributes.mockReturnValue({
+        nodeType: 'note',
+        label: 'Roadmap',
+        isUnresolved: false
+      })
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+      mocks.events.mousemovebody({ x: 90, y: 90, preventSigmaDefault: vi.fn() })
+      mocks.events.mouseup()
+      mocks.events.clickNode({ node: 'note-1' })
+
+      expect(mocks.openTab).not.toHaveBeenCalled()
+    })
+
+    it('still opens a tab when the node was pressed without moving', () => {
+      renderWithDrag()
+      mocks.graph.hasNode.mockReturnValue(true)
+      mocks.graph.getNodeAttributes.mockReturnValue({
+        nodeType: 'note',
+        label: 'Roadmap',
+        isUnresolved: false
+      })
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+      mocks.events.mouseup()
+      mocks.events.clickNode({ node: 'note-1' })
+
+      expect(mocks.openTab).toHaveBeenCalledWith(expect.objectContaining({ entityId: 'note-1' }))
+    })
+
+    it('treats sub-threshold jitter as a click, not a drag', () => {
+      renderWithDrag()
+      mocks.viewportToGraph.mockReturnValue({ x: 1, y: 1 })
+      mocks.graph.hasNode.mockReturnValue(true)
+      mocks.graph.getNodeAttributes.mockReturnValue({
+        nodeType: 'note',
+        label: 'Roadmap',
+        isUnresolved: false
+      })
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+      mocks.events.mousemovebody({ x: 6, y: 6, preventSigmaDefault: vi.fn() })
+      mocks.events.mouseup()
+      mocks.events.clickNode({ node: 'note-1' })
+
+      expect(mocks.openTab).toHaveBeenCalledWith(expect.objectContaining({ entityId: 'note-1' }))
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/components/graph/graph-events.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-events.tsx
@@ -1,40 +1,90 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useRegisterEvents, useSigma } from '@react-sigma/core'
 import { useTabActions } from '@/contexts/tabs'
 import { useT } from '@memry/i18n/renderer'
+
+/** Pointer travel (viewport px) past which a press counts as a drag rather than a click. */
+const DRAG_THRESHOLD_PX = 3
+
+interface DragState {
+  nodeId: string
+  startX: number
+  startY: number
+  moved: boolean
+}
 
 interface GraphEventsProps {
   onHoverNode: (nodeId: string | null) => void
   onTooltipMove: (pos: { x: number; y: number } | null) => void
   onFocusNode: (nodeId: string) => void
   onContextMenu?: (menu: { nodeId: string; x: number; y: number } | null) => void
+  onNodeGrab?: (nodeId: string) => void
+  onNodeDrag?: (nodeId: string, x: number, y: number) => void
+  onNodeRelease?: (nodeId: string) => void
 }
 
 export function GraphEvents({
   onHoverNode,
   onTooltipMove,
   onFocusNode,
-  onContextMenu
+  onContextMenu,
+  onNodeGrab,
+  onNodeDrag,
+  onNodeRelease
 }: GraphEventsProps): null {
   const sigma = useSigma()
   const registerEvents = useRegisterEvents()
   const { openTab } = useTabActions()
   const { t } = useT('graph')
+  const dragRef = useRef<DragState | null>(null)
+  const suppressClickRef = useRef(false)
 
   useEffect(() => {
     registerEvents({
       enterNode: ({ node, event }) => {
         onHoverNode(node)
         onTooltipMove({ x: event.x, y: event.y })
-        document.body.style.cursor = 'pointer'
+        if (!dragRef.current) document.body.style.cursor = 'pointer'
       },
       leaveNode: () => {
         onHoverNode(null)
         onTooltipMove(null)
-        document.body.style.cursor = 'default'
+        if (!dragRef.current) document.body.style.cursor = 'default'
+      },
+      downNode: ({ node, event }) => {
+        dragRef.current = { nodeId: node, startX: event.x, startY: event.y, moved: false }
+        document.body.style.cursor = 'grabbing'
+        onNodeGrab?.(node)
+      },
+      mousemovebody: (event) => {
+        const drag = dragRef.current
+        if (!drag) return
+
+        if (!drag.moved) {
+          const travel = Math.hypot(event.x - drag.startX, event.y - drag.startY)
+          if (travel > DRAG_THRESHOLD_PX) drag.moved = true
+        }
+
+        const { x, y } = sigma.viewportToGraph({ x: event.x, y: event.y })
+        onNodeDrag?.(drag.nodeId, x, y)
+
+        // Without this sigma pans the camera while we are moving a node.
+        event.preventSigmaDefault()
+      },
+      mouseup: () => {
+        const drag = dragRef.current
+        if (!drag) return
+        dragRef.current = null
+        suppressClickRef.current = drag.moved
+        document.body.style.cursor = 'pointer'
+        onNodeRelease?.(drag.nodeId)
       },
       clickNode: ({ node }) => {
         onContextMenu?.(null)
+        if (suppressClickRef.current) {
+          suppressClickRef.current = false
+          return
+        }
         openNodeInTab(sigma, openTab, node, t('context-menu.untitled'))
       },
       rightClickNode: ({ node, event }) => {
@@ -45,7 +95,19 @@ export function GraphEvents({
         onContextMenu?.(null)
       }
     })
-  }, [sigma, registerEvents, openTab, onHoverNode, onTooltipMove, onFocusNode, onContextMenu, t])
+  }, [
+    sigma,
+    registerEvents,
+    openTab,
+    onHoverNode,
+    onTooltipMove,
+    onFocusNode,
+    onContextMenu,
+    onNodeGrab,
+    onNodeDrag,
+    onNodeRelease,
+    t
+  ])
 
   return null
 }

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel.test.tsx
@@ -10,11 +10,12 @@ const mocks = vi.hoisted(() => ({
     isLoading: false
   },
   sigma: {
-    refresh: vi.fn()
+    refresh: vi.fn(),
+    // The live simulation refreshes only the instance that owns the graph it is
+    // stepping, so the mock has to model getGraph like the real Sigma does.
+    getGraph: (): unknown => mocks.sigmaContainerProps?.graph
   },
-  sigmaContainerProps: null as null | Record<string, any>,
-  layoutStart: vi.fn(),
-  layoutStop: vi.fn()
+  sigmaContainerProps: null as null | Record<string, any>
 }))
 
 vi.mock('@memry/i18n/renderer', () => ({
@@ -31,13 +32,6 @@ vi.mock('@react-sigma/core', () => ({
     return <div data-testid="sigma">{props.children}</div>
   },
   useSigma: () => mocks.sigma
-}))
-
-vi.mock('@react-sigma/layout-forceatlas2', () => ({
-  useWorkerLayoutForceAtlas2: () => ({
-    start: mocks.layoutStart,
-    stop: mocks.layoutStop
-  })
 }))
 
 vi.mock('@/hooks/use-graph-data', () => ({
@@ -176,7 +170,6 @@ describe('LocalGraphPanel', () => {
     )
 
     expect(screen.getByTestId('sigma')).toBeInTheDocument()
-    expect(mocks.layoutStart).toHaveBeenCalledTimes(1)
     expect(mocks.sigmaContainerProps?.settings.labelColor).toEqual({ color: '#111111' })
     expect(mocks.sigmaContainerProps?.graph.hasNode('note-a')).toBe(true)
 
@@ -215,6 +208,33 @@ describe('LocalGraphPanel', () => {
       vi.runOnlyPendingTimers()
     })
     unmount()
-    expect(mocks.layoutStop).toHaveBeenCalled()
+  })
+
+  it('runs a live simulation and stops it on unmount', () => {
+    // The suite-wide stub runs frames synchronously, which would settle the whole
+    // simulation during mount. Queue them instead so each step is observable.
+    const frames: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback)
+      return frames.length
+    })
+
+    const { unmount } = render(<LocalGraphPanel noteId="note-a" onClose={vi.fn()} />)
+    const graph = mocks.sigmaContainerProps?.graph
+    const before = graph.getNodeAttribute('note-a', 'x')
+    expect(frames).toHaveLength(1)
+
+    act(() => {
+      frames.shift()?.(16)
+    })
+    expect(graph.getNodeAttribute('note-a', 'x')).not.toBe(before)
+    expect(frames).toHaveLength(1)
+
+    unmount()
+    const afterUnmount = graph.getNodeAttribute('note-a', 'x')
+    act(() => {
+      frames.shift()?.(32)
+    })
+    expect(graph.getNodeAttribute('note-a', 'x')).toBe(afterUnmount)
   })
 })

--- a/apps/desktop/src/renderer/src/components/graph/local-graph-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/local-graph-panel.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import { SigmaContainer, useSigma } from '@react-sigma/core'
-import { useWorkerLayoutForceAtlas2 } from '@react-sigma/layout-forceatlas2'
 import { useTheme } from 'next-themes'
 import '@react-sigma/core/lib/style.css'
 import { X, Maximize2 } from '@/lib/icons'
@@ -8,13 +7,21 @@ import type { NodeDisplayData, EdgeDisplayData } from 'sigma/types'
 import { Button } from '@/components/ui/button'
 import { useLocalGraphData } from '@/hooks/use-graph-data'
 import { buildGraphologyGraph } from '@/lib/graph-builder'
+import type { GraphPhysicsOptions } from '@/lib/graph-physics'
 import { useT } from '@memry/i18n/renderer'
 import { GraphEvents } from './graph-events'
 import { GraphTooltip } from './graph-tooltip'
+import { LivePhysics, type PhysicsHandle } from './physics-layout'
 
 const CENTER_HIGHLIGHT_COLOR = '#f59e0b'
 const HOVER_FADE_IN_MS = 250
 const HOVER_FADE_OUT_MS = 180
+
+/** Tighter than the full graph — this panel is only 250px tall. */
+const LOCAL_PHYSICS: GraphPhysicsOptions = {
+  linkDistance: 32,
+  chargeStrength: -140
+}
 
 function resolveGraphVar(varName: string, fallback: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(varName).trim() || fallback
@@ -43,6 +50,7 @@ export function LocalGraphPanel({
   const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null)
   const fadeRef = useRef(0)
   const hoverTargetRef = useRef<string | null>(null)
+  const physicsHandleRef = useRef<PhysicsHandle | null>(null)
 
   const dimmedColor = useMemo(() => resolveGraphVar('--graph-dimmed-node', '#e4e4de'), [])
 
@@ -129,6 +137,18 @@ export function LocalGraphPanel({
 
   const handleFocusNode = useCallback(() => {}, [])
 
+  const handleNodeGrab = useCallback((nodeId: string) => {
+    physicsHandleRef.current?.grab(nodeId)
+  }, [])
+
+  const handleNodeDrag = useCallback((nodeId: string, x: number, y: number) => {
+    physicsHandleRef.current?.drag(nodeId, x, y)
+  }, [])
+
+  const handleNodeRelease = useCallback((nodeId: string) => {
+    physicsHandleRef.current?.release(nodeId)
+  }, [])
+
   if (isLoading || !graph) {
     return (
       <div className="relative h-[250px] rounded-md border border-border bg-muted/30">
@@ -161,11 +181,14 @@ export function LocalGraphPanel({
           fadeRef={fadeRef}
           hoverTargetRef={hoverTargetRef}
         />
-        <LocalForceLayout />
+        <LivePhysics graph={graph} handleRef={physicsHandleRef} options={LOCAL_PHYSICS} />
         <GraphEvents
           onHoverNode={setHoveredNode}
           onTooltipMove={setTooltipPos}
           onFocusNode={handleFocusNode}
+          onNodeGrab={handleNodeGrab}
+          onNodeDrag={handleNodeDrag}
+          onNodeRelease={handleNodeRelease}
         />
       </SigmaContainer>
 
@@ -186,7 +209,7 @@ function PanelHeader({
   const { t } = useT('graph')
 
   return (
-    <div className="absolute top-1.5 right-1.5 z-10 flex items-center gap-1">
+    <div className="absolute top-1.5 end-1.5 z-10 flex items-center gap-1">
       {onOpenFullGraph && (
         <Button
           variant="ghost"
@@ -265,31 +288,6 @@ function LocalHoverFadeAnimator({
       }
     }
   }, [hoveredNode, sigma, fadeRef, hoverTargetRef])
-
-  return null
-}
-
-function LocalForceLayout(): null {
-  const { start, stop } = useWorkerLayoutForceAtlas2({
-    settings: {
-      gravity: 0.5,
-      scalingRatio: 4,
-      slowDown: 3,
-      barnesHutOptimize: true
-    }
-  })
-
-  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
-
-  useEffect(() => {
-    start()
-    timerRef.current = setTimeout(stop, 4000)
-
-    return () => {
-      clearTimeout(timerRef.current)
-      stop()
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return null
 }

--- a/apps/desktop/src/renderer/src/components/graph/physics-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/physics-layout.tsx
@@ -1,0 +1,98 @@
+import { useEffect } from 'react'
+import { useSigma } from '@react-sigma/core'
+import type Graph from 'graphology'
+import { GraphPhysics, type GraphPhysicsOptions } from '@/lib/graph-physics'
+
+/** Upper bound on the synchronous pre-settle, so a huge vault cannot lock the frame forever. */
+const SETTLE_TICK_LIMIT = 400
+
+export interface PhysicsHandle {
+  grab: (nodeId: string) => void
+  drag: (nodeId: string, x: number, y: number) => void
+  release: (nodeId: string) => void
+}
+
+/**
+ * Live force simulation: one tick per animation frame, parked once the graph
+ * comes to rest and woken again whenever a node is grabbed.
+ */
+export function LivePhysics({
+  graph,
+  handleRef,
+  options
+}: {
+  graph: Graph
+  handleRef: React.MutableRefObject<PhysicsHandle | null>
+  options?: GraphPhysicsOptions
+}): null {
+  const sigma = useSigma()
+
+  useEffect(() => {
+    const physics = new GraphPhysics(graph, options)
+    let frame: number | null = null
+
+    const step = (): void => {
+      physics.tick()
+      // SigmaContainer recreates Sigma when `graph` changes and React may hand us
+      // the old, killed instance; refreshing that one throws. Same guard as
+      // SigmaSettingsSync.
+      if (sigma.getGraph() === graph) sigma.refresh()
+      frame = physics.isSettled ? null : requestAnimationFrame(step)
+    }
+
+    const wake = (): void => {
+      if (frame === null) frame = requestAnimationFrame(step)
+    }
+
+    handleRef.current = {
+      grab: (nodeId) => {
+        physics.grab(nodeId)
+        wake()
+      },
+      drag: (nodeId, x, y) => {
+        physics.dragTo(nodeId, x, y)
+        wake()
+      },
+      release: (nodeId) => {
+        physics.release(nodeId)
+        wake()
+      }
+    }
+
+    frame = requestAnimationFrame(step)
+
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame)
+      handleRef.current = null
+      physics.destroy()
+    }
+    // `options` is a static per-call-site literal; re-running on identity would
+    // restart the simulation every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [graph, sigma, handleRef])
+
+  return null
+}
+
+/** Same forces, run to rest in one pass — the static arrangement when live motion is off. */
+export function SettledPhysics({
+  graph,
+  options
+}: {
+  graph: Graph
+  options?: GraphPhysicsOptions
+}): null {
+  const sigma = useSigma()
+
+  useEffect(() => {
+    const physics = new GraphPhysics(graph, options)
+    for (let i = 0; i < SETTLE_TICK_LIMIT && !physics.isSettled; i++) {
+      physics.tick()
+    }
+    physics.destroy()
+    if (sigma.getGraph() === graph) sigma.refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [graph, sigma])
+
+  return null
+}

--- a/apps/desktop/src/renderer/src/lib/graph-builder.test.ts
+++ b/apps/desktop/src/renderer/src/lib/graph-builder.test.ts
@@ -112,17 +112,25 @@ describe('graph-builder', () => {
     expect(graph.getNodeAttribute('tag:shared', 'connectionCount')).toBe(2)
     expect(graph.getNodeAttribute('tag:shared', 'size')).toBe(5)
     expect(graph.hasEdge('note-a-tag:shared-entity-tag')).toBe(true)
+  })
 
-    expect(mocks.assign).toHaveBeenCalledWith(
-      graph,
-      expect.objectContaining({
-        iterations: expect.any(Number),
-        settings: expect.objectContaining({
-          gravity: 0.5,
-          barnesHutOptimize: false
-        })
-      })
-    )
+  it('does not bake a static layout — positions are left to the live simulation', () => {
+    buildGraphologyGraph(graphData)
+
+    expect(mocks.assign).not.toHaveBeenCalled()
+  })
+
+  it('seeds every node at a finite position inside the simulation scale', () => {
+    const graph = buildGraphologyGraph(graphData)
+    const seedLimit = Math.max(60, Math.sqrt(graph.order) * 30)
+
+    graph.forEachNode((node) => {
+      const x = graph.getNodeAttribute(node, 'x') as number
+      const y = graph.getNodeAttribute(node, 'y') as number
+      expect(Number.isFinite(x)).toBe(true)
+      expect(Number.isFinite(y)).toBe(true)
+      expect(Math.hypot(x, y)).toBeLessThanOrEqual(seedLimit)
+    })
   })
 
   it('can omit tag expansion and falls back when CSS variables are absent', () => {

--- a/apps/desktop/src/renderer/src/lib/graph-builder.ts
+++ b/apps/desktop/src/renderer/src/lib/graph-builder.ts
@@ -1,5 +1,4 @@
 import Graph from 'graphology'
-import forceAtlas2 from 'graphology-layout-forceatlas2'
 import type { GraphDataResponse } from '@memry/contracts/graph-api'
 
 const NODE_COLOR_VARS: Record<string, string> = {
@@ -53,7 +52,9 @@ export function buildGraphologyGraph(
     resolvedEdgeColors[type] = resolveVar(varName)
   }
 
-  const spread = Math.max(800, Math.sqrt(data.nodes.length) * 100)
+  // Seeded near the scale the force simulation settles at, so the opening frames
+  // read as the graph organising itself rather than imploding from a huge cloud.
+  const spread = Math.max(60, Math.sqrt(data.nodes.length) * 30)
 
   for (const node of data.nodes) {
     const angle = Math.random() * 2 * Math.PI
@@ -141,21 +142,6 @@ export function buildGraphologyGraph(
       graph.setNodeAttribute(tagNodeId, 'size', tagSize)
       graph.setNodeAttribute(tagNodeId, 'connectionCount', degree)
     }
-  }
-
-  if (graph.order > 1) {
-    const iterations = Math.min(150, Math.max(50, 600 / Math.sqrt(graph.order)))
-    forceAtlas2.assign(graph, {
-      iterations,
-      settings: {
-        gravity: 0.5,
-        scalingRatio: 12,
-        slowDown: 5,
-        barnesHutOptimize: graph.order > 100,
-        strongGravityMode: true,
-        edgeWeightInfluence: 0
-      }
-    })
   }
 
   return graph

--- a/apps/desktop/src/renderer/src/lib/graph-physics.test.ts
+++ b/apps/desktop/src/renderer/src/lib/graph-physics.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest'
+import Graph from 'graphology'
+
+import { GraphPhysics } from './graph-physics'
+
+function makeGraph(
+  nodes: Array<[string, number, number, number?]>,
+  edges: Array<[string, string]> = []
+): Graph {
+  const graph = new Graph({ multi: true, type: 'undirected' })
+  for (const [id, x, y, size] of nodes) {
+    graph.addNode(id, { x, y, size: size ?? 5 })
+  }
+  edges.forEach(([source, target], i) => {
+    graph.addEdgeWithKey(`e${i}`, source, target, { weight: 1 })
+  })
+  return graph
+}
+
+function distance(graph: Graph, a: string, b: string): number {
+  const dx = (graph.getNodeAttribute(a, 'x') as number) - (graph.getNodeAttribute(b, 'x') as number)
+  const dy = (graph.getNodeAttribute(a, 'y') as number) - (graph.getNodeAttribute(b, 'y') as number)
+  return Math.hypot(dx, dy)
+}
+
+function settle(physics: GraphPhysics, ticks = 600): void {
+  for (let i = 0; i < ticks; i++) physics.tick()
+}
+
+describe('GraphPhysics', () => {
+  it('writes simulated positions back onto the graphology graph', () => {
+    const graph = makeGraph([
+      ['a', 0, 0],
+      ['b', 40, 10]
+    ])
+    const physics = new GraphPhysics(graph)
+
+    physics.tick()
+
+    const moved = graph.getNodeAttribute('a', 'x') !== 0 || graph.getNodeAttribute('a', 'y') !== 0
+    expect(moved).toBe(true)
+  })
+
+  it('pushes unconnected nodes apart', () => {
+    const graph = makeGraph([
+      ['a', 0, 0],
+      ['b', 12, 4]
+    ])
+    const physics = new GraphPhysics(graph)
+    const before = distance(graph, 'a', 'b')
+
+    for (let i = 0; i < 40; i++) physics.tick()
+
+    expect(distance(graph, 'a', 'b')).toBeGreaterThan(before)
+  })
+
+  it('pulls linked nodes toward each other when they start far apart', () => {
+    const graph = makeGraph(
+      [
+        ['a', -900, 0],
+        ['b', 900, 0]
+      ],
+      [['a', 'b']]
+    )
+    const physics = new GraphPhysics(graph)
+    const before = distance(graph, 'a', 'b')
+
+    for (let i = 0; i < 60; i++) physics.tick()
+
+    expect(distance(graph, 'a', 'b')).toBeLessThan(before)
+  })
+
+  it('keeps overlapping nodes from sitting on top of each other', () => {
+    const graph = makeGraph([
+      ['a', 0, 0, 12],
+      ['b', 0.5, 0.5, 12]
+    ])
+    const physics = new GraphPhysics(graph)
+
+    for (let i = 0; i < 80; i++) physics.tick()
+
+    expect(distance(graph, 'a', 'b')).toBeGreaterThan(12)
+  })
+
+  it('cools down as it ticks', () => {
+    const physics = new GraphPhysics(
+      makeGraph([
+        ['a', 0, 0],
+        ['b', 30, 0]
+      ])
+    )
+    const start = physics.alpha
+
+    for (let i = 0; i < 50; i++) physics.tick()
+
+    expect(physics.alpha).toBeLessThan(start)
+  })
+
+  it('starts unsettled and reports settled once it has cooled', () => {
+    const physics = new GraphPhysics(
+      makeGraph([
+        ['a', 0, 0],
+        ['b', 30, 0]
+      ])
+    )
+
+    expect(physics.isSettled).toBe(false)
+
+    settle(physics)
+
+    expect(physics.isSettled).toBe(true)
+  })
+
+  it('reheat wakes a settled simulation back up', () => {
+    const physics = new GraphPhysics(
+      makeGraph([
+        ['a', 0, 0],
+        ['b', 30, 0]
+      ])
+    )
+    settle(physics)
+    expect(physics.isSettled).toBe(true)
+
+    physics.reheat()
+
+    expect(physics.isSettled).toBe(false)
+  })
+
+  it('pins a grabbed node exactly at the drag position', () => {
+    const graph = makeGraph([
+      ['a', 0, 0],
+      ['b', 40, 0]
+    ])
+    const physics = new GraphPhysics(graph)
+
+    physics.grab('a')
+    physics.dragTo('a', 100, 60)
+    physics.tick()
+
+    expect(graph.getNodeAttribute('a', 'x')).toBe(100)
+    expect(graph.getNodeAttribute('a', 'y')).toBe(60)
+  })
+
+  it('keeps a grabbed node pinned while the rest of the graph keeps moving', () => {
+    const graph = makeGraph([
+      ['a', 0, 0],
+      ['b', 40, 0]
+    ])
+    const physics = new GraphPhysics(graph)
+
+    physics.grab('a')
+    physics.dragTo('a', 100, 60)
+    for (let i = 0; i < 30; i++) physics.tick()
+
+    expect(graph.getNodeAttribute('a', 'x')).toBe(100)
+    expect(graph.getNodeAttribute('a', 'y')).toBe(60)
+  })
+
+  it('drags linked neighbours along with the grabbed node', () => {
+    const graph = makeGraph(
+      [
+        ['a', 0, 0],
+        ['b', 40, 0]
+      ],
+      [['a', 'b']]
+    )
+    const physics = new GraphPhysics(graph)
+
+    physics.grab('a')
+    physics.dragTo('a', 600, 0)
+    for (let i = 0; i < 60; i++) physics.tick()
+
+    expect(graph.getNodeAttribute('b', 'x')).toBeGreaterThan(40)
+  })
+
+  it('lets a released node drift again', () => {
+    const graph = makeGraph([
+      ['a', 0, 0],
+      ['b', 40, 0]
+    ])
+    const physics = new GraphPhysics(graph)
+
+    physics.grab('a')
+    physics.dragTo('a', 100, 60)
+    physics.tick()
+    physics.release('a')
+    for (let i = 0; i < 40; i++) physics.tick()
+
+    expect(graph.getNodeAttribute('a', 'x')).not.toBe(100)
+  })
+
+  it('ignores drag calls for nodes that are not in the graph', () => {
+    const graph = makeGraph([['a', 0, 0]])
+    const physics = new GraphPhysics(graph)
+
+    expect(() => {
+      physics.grab('missing')
+      physics.dragTo('missing', 10, 10)
+      physics.release('missing')
+      physics.tick()
+    }).not.toThrow()
+  })
+
+  it('stops ticking after destroy', () => {
+    const graph = makeGraph([
+      ['a', 0, 0],
+      ['b', 40, 10]
+    ])
+    const physics = new GraphPhysics(graph)
+    physics.destroy()
+
+    const x = graph.getNodeAttribute('a', 'x')
+    physics.tick()
+
+    expect(graph.getNodeAttribute('a', 'x')).toBe(x)
+  })
+
+  it('handles an empty graph without throwing', () => {
+    const physics = new GraphPhysics(new Graph())
+
+    expect(() => physics.tick()).not.toThrow()
+    expect(physics.isSettled).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/graph-physics.ts
+++ b/apps/desktop/src/renderer/src/lib/graph-physics.ts
@@ -1,0 +1,340 @@
+import type Graph from 'graphology'
+
+interface PhysicsNode {
+  id: string
+  x: number
+  y: number
+  vx: number
+  vy: number
+  fx: number | null
+  fy: number | null
+  radius: number
+  degree: number
+}
+
+interface PhysicsLink {
+  source: PhysicsNode
+  target: PhysicsNode
+  /** How hard this link pulls, damped by the busier of its two endpoints. */
+  strength: number
+  /** Share of the correction applied to the source, so hubs move less than leaves. */
+  bias: number
+}
+
+export interface GraphPhysicsOptions {
+  linkDistance?: number
+  chargeStrength?: number
+  centeringStrength?: number
+  alphaDecay?: number
+  velocityDecay?: number
+  collidePadding?: number
+}
+
+const DEFAULTS: Required<GraphPhysicsOptions> = {
+  linkDistance: 45,
+  chargeStrength: -220,
+  centeringStrength: 0.045,
+  // ~300 ticks from alpha 1 down to alphaMin, matching d3-force's feel.
+  alphaDecay: 0.0228,
+  velocityDecay: 0.38,
+  collidePadding: 3
+}
+
+const ALPHA_MIN = 0.001
+
+/** Energy injected when the graph is nudged back to life (filters, focus, reset). */
+export const REHEAT_ALPHA = 0.35
+
+/** Alpha the simulation is held at while a node is being dragged, so neighbours keep reacting. */
+const DRAG_ALPHA_TARGET = 0.3
+
+/**
+ * Repulsion falls off as 1/d², so past a few link-lengths it is noise. Ignoring
+ * those pairs is what keeps the tick O(n) instead of O(n²) on a large vault.
+ */
+const REPULSION_CUTOFF_FACTOR = 6
+
+/** Collision passes per tick — more is stabler, but each one costs a full neighbour sweep. */
+const COLLIDE_ITERATIONS = 1
+
+/**
+ * A continuously-running force simulation bound to a graphology graph.
+ *
+ * Unlike a one-shot layout, this never "finishes" on its own terms: it cools
+ * toward rest, can be reheated, and holds a dragged node fixed while the rest of
+ * the graph reacts to it. The caller owns the clock — call `tick()` once per
+ * animation frame and render.
+ *
+ * Deliberately dependency-free: the desktop lockfile is pinned and adding a
+ * force library re-resolves shared transitive deps across the whole workspace.
+ */
+export class GraphPhysics {
+  private readonly graph: Graph
+  private readonly settings: Required<GraphPhysicsOptions>
+  private readonly nodes: PhysicsNode[] = []
+  private readonly nodesById = new Map<string, PhysicsNode>()
+  private readonly links: PhysicsLink[] = []
+  private readonly cutoff: number
+  private alphaValue = 1
+  private alphaTarget = 0
+  private destroyed = false
+
+  constructor(graph: Graph, options: GraphPhysicsOptions = {}) {
+    this.graph = graph
+    this.settings = { ...DEFAULTS, ...options }
+    this.cutoff = this.settings.linkDistance * REPULSION_CUTOFF_FACTOR
+
+    graph.forEachNode((id, attrs) => {
+      const node: PhysicsNode = {
+        id,
+        x: (attrs.x as number) ?? 0,
+        y: (attrs.y as number) ?? 0,
+        vx: 0,
+        vy: 0,
+        fx: null,
+        fy: null,
+        radius: ((attrs.size as number) ?? 4) * 1.2 + this.settings.collidePadding,
+        degree: 0
+      }
+      this.nodes.push(node)
+      this.nodesById.set(id, node)
+    })
+
+    graph.forEachEdge((edge) => {
+      const [sourceId, targetId] = graph.extremities(edge)
+      // Self-loops collapse to a zero-length spring and blow the solver up.
+      if (sourceId === targetId) return
+      const source = this.nodesById.get(sourceId)
+      const target = this.nodesById.get(targetId)
+      if (!source || !target) return
+      source.degree++
+      target.degree++
+      this.links.push({ source, target, strength: 0, bias: 0 })
+    })
+
+    for (const link of this.links) {
+      const total = link.source.degree + link.target.degree
+      link.strength = 1 / Math.min(link.source.degree, link.target.degree)
+      link.bias = total === 0 ? 0.5 : link.source.degree / total
+    }
+  }
+
+  get alpha(): number {
+    return this.alphaValue
+  }
+
+  get isSettled(): boolean {
+    if (this.destroyed || this.nodes.length === 0) return true
+    return this.alphaValue < ALPHA_MIN
+  }
+
+  /** Advance one step and publish the new positions to the graph. */
+  tick(): void {
+    if (this.destroyed || this.nodes.length === 0) return
+
+    this.alphaValue += (this.alphaTarget - this.alphaValue) * this.settings.alphaDecay
+
+    this.applyLinks()
+    this.applyRepulsion()
+    this.applyCentering()
+    this.integrate()
+    for (let i = 0; i < COLLIDE_ITERATIONS; i++) this.applyCollision()
+
+    this.syncPositions()
+  }
+
+  reheat(alpha: number = REHEAT_ALPHA): void {
+    if (this.destroyed) return
+    if (this.alphaValue < alpha) this.alphaValue = alpha
+  }
+
+  /** Fix a node at its current position and keep the simulation warm while it is held. */
+  grab(nodeId: string): void {
+    const node = this.nodesById.get(nodeId)
+    if (!node || this.destroyed) return
+    node.fx = node.x
+    node.fy = node.y
+    this.alphaTarget = DRAG_ALPHA_TARGET
+    this.reheat(DRAG_ALPHA_TARGET)
+  }
+
+  dragTo(nodeId: string, x: number, y: number): void {
+    const node = this.nodesById.get(nodeId)
+    if (!node || this.destroyed) return
+    node.fx = x
+    node.fy = y
+  }
+
+  /** Release a held node and let it relax back into the layout. */
+  release(nodeId: string): void {
+    const node = this.nodesById.get(nodeId)
+    if (!node || this.destroyed) return
+    node.fx = null
+    node.fy = null
+    this.alphaTarget = 0
+  }
+
+  destroy(): void {
+    this.destroyed = true
+    this.nodes.length = 0
+    this.links.length = 0
+    this.nodesById.clear()
+  }
+
+  /** Springs pulling each linked pair toward `linkDistance`. */
+  private applyLinks(): void {
+    const { linkDistance } = this.settings
+    for (const link of this.links) {
+      const { source, target } = link
+      const dx = target.x + target.vx - source.x - source.vx
+      const dy = target.y + target.vy - source.y - source.vy
+      const distance = Math.hypot(dx, dy) || 1e-6
+      const push = ((distance - linkDistance) / distance) * this.alphaValue * link.strength
+      const fx = dx * push
+      const fy = dy * push
+
+      target.vx -= fx * link.bias
+      target.vy -= fy * link.bias
+      source.vx += fx * (1 - link.bias)
+      source.vy += fy * (1 - link.bias)
+    }
+  }
+
+  /**
+   * Inverse-square repulsion between nearby nodes. A uniform grid sized to the
+   * cutoff keeps each node comparing against a handful of neighbours.
+   */
+  private applyRepulsion(): void {
+    const { chargeStrength } = this.settings
+    const cutoff = this.cutoff
+    const cutoffSquared = cutoff * cutoff
+    const grid = new Map<string, PhysicsNode[]>()
+
+    for (const node of this.nodes) {
+      const key = `${Math.floor(node.x / cutoff)},${Math.floor(node.y / cutoff)}`
+      const cell = grid.get(key)
+      if (cell) cell.push(node)
+      else grid.set(key, [node])
+    }
+
+    for (const node of this.nodes) {
+      const cellX = Math.floor(node.x / cutoff)
+      const cellY = Math.floor(node.y / cutoff)
+
+      for (let ox = -1; ox <= 1; ox++) {
+        for (let oy = -1; oy <= 1; oy++) {
+          const cell = grid.get(`${cellX + ox},${cellY + oy}`)
+          if (!cell) continue
+
+          for (const other of cell) {
+            if (other === node) continue
+            let dx = other.x - node.x
+            let dy = other.y - node.y
+            let distanceSquared = dx * dx + dy * dy
+            if (distanceSquared > cutoffSquared) continue
+
+            if (distanceSquared === 0) {
+              // Deterministic nudge so coincident nodes still separate.
+              dx = 1e-3
+              dy = 1e-3
+              distanceSquared = dx * dx + dy * dy
+            }
+
+            const push = (chargeStrength * this.alphaValue) / distanceSquared
+            node.vx += dx * push
+            node.vy += dy * push
+          }
+        }
+      }
+    }
+  }
+
+  /** Weak pull toward the origin so the graph stays a graph and not a diaspora. */
+  private applyCentering(): void {
+    const pull = this.settings.centeringStrength * this.alphaValue
+    for (const node of this.nodes) {
+      node.vx -= node.x * pull
+      node.vy -= node.y * pull
+    }
+  }
+
+  private integrate(): void {
+    const friction = 1 - this.settings.velocityDecay
+    for (const node of this.nodes) {
+      if (node.fx !== null) {
+        node.x = node.fx
+        node.vx = 0
+      } else {
+        node.vx *= friction
+        node.x += node.vx
+      }
+
+      if (node.fy !== null) {
+        node.y = node.fy
+        node.vy = 0
+      } else {
+        node.vy *= friction
+        node.y += node.vy
+      }
+    }
+  }
+
+  /** Position-based separation so node discs never overlap — the "cell" packing. */
+  private applyCollision(): void {
+    const grid = new Map<string, PhysicsNode[]>()
+    let maxRadius = 0
+    for (const node of this.nodes) maxRadius = Math.max(maxRadius, node.radius)
+    const cellSize = Math.max(maxRadius * 2, 1)
+
+    for (const node of this.nodes) {
+      const key = `${Math.floor(node.x / cellSize)},${Math.floor(node.y / cellSize)}`
+      const cell = grid.get(key)
+      if (cell) cell.push(node)
+      else grid.set(key, [node])
+    }
+
+    for (const node of this.nodes) {
+      const cellX = Math.floor(node.x / cellSize)
+      const cellY = Math.floor(node.y / cellSize)
+
+      for (let ox = -1; ox <= 1; ox++) {
+        for (let oy = -1; oy <= 1; oy++) {
+          const cell = grid.get(`${cellX + ox},${cellY + oy}`)
+          if (!cell) continue
+
+          for (const other of cell) {
+            if (other === node || other.id <= node.id) continue
+            const minimum = node.radius + other.radius
+            let dx = other.x - node.x
+            let dy = other.y - node.y
+            let distance = Math.hypot(dx, dy)
+            if (distance >= minimum) continue
+
+            if (distance === 0) {
+              dx = 1e-3
+              dy = 1e-3
+              distance = Math.hypot(dx, dy)
+            }
+
+            const overlap = ((minimum - distance) / distance) * 0.5
+            const shiftX = dx * overlap
+            const shiftY = dy * overlap
+
+            if (other.fx === null) other.x += shiftX
+            if (other.fy === null) other.y += shiftY
+            if (node.fx === null) node.x -= shiftX
+            if (node.fy === null) node.y -= shiftY
+          }
+        }
+      }
+    }
+  }
+
+  private syncPositions(): void {
+    for (const node of this.nodes) {
+      if (!this.graph.hasNode(node.id)) continue
+      this.graph.setNodeAttribute(node.id, 'x', node.x)
+      this.graph.setNodeAttribute(node.id, 'y', node.y)
+    }
+  }
+}

--- a/apps/docs/src/user-guide/notes/wiki-links.md
+++ b/apps/docs/src/user-guide/notes/wiki-links.md
@@ -62,6 +62,15 @@ The sidebar **Graph** entry opens a force-directed map of your notes and the lin
 - Nodes are notes; edges are wiki links and [relation properties](/user-guide/notes/properties-tags#relation-properties) (drawn thinner, to tell them apart from wiki links).
 - Click a node to open the note in a tab.
 - Hover to highlight neighbors.
+- Drag a node to pull it around — linked notes follow it, and the graph settles again when you let go.
+
+The layout is a live simulation: it arranges itself when the view opens, comes to rest on
+its own, and wakes up again whenever you drag something. Node positions are not saved, so
+each time you open the graph it settles into a fresh arrangement.
+
+Turn the motion off with **Live motion** under the gear icon → **Display** if you prefer a
+still graph — the same forces then run once and stop, which is also the lighter option on
+very large vaults.
 
 ## Renaming Targets
 

--- a/packages/app-core/src/memry-app.test.ts
+++ b/packages/app-core/src/memry-app.test.ts
@@ -700,7 +700,7 @@ test('opens a standalone vault and exposes core note, journal, task, inbox, and 
     layout: 'forceatlas2',
     showLabels: false,
     showEdgeLabels: false,
-    animateLayout: false,
+    animateLayout: true,
     showTagEdges: false
   })
 

--- a/packages/app-core/src/settings.ts
+++ b/packages/app-core/src/settings.ts
@@ -97,7 +97,7 @@ const settingsGroupDefaults: Record<SettingsGroupName, Record<string, unknown>> 
     layout: 'forceatlas2',
     showLabels: false,
     showEdgeLabels: false,
-    animateLayout: false,
+    animateLayout: true,
     showTagEdges: false
   },
   calendar: {

--- a/packages/contracts/src/graph-api.ts
+++ b/packages/contracts/src/graph-api.ts
@@ -53,6 +53,6 @@ export const GRAPH_SETTINGS_DEFAULTS: GraphSettings = {
   layout: 'forceatlas2',
   showLabels: false,
   showEdgeLabels: false,
-  animateLayout: false,
+  animateLayout: true,
   showTagEdges: false
 }

--- a/packages/i18n/src/locales/en/graph.json
+++ b/packages/i18n/src/locales/en/graph.json
@@ -40,6 +40,7 @@
     "filters": "Filters",
     "display": "Display",
     "show-labels": "Show labels",
+    "live-motion": "Live motion",
     "focus-depth": "depth {depth}",
     "clear-focus": "Clear focused node"
   },

--- a/packages/i18n/src/locales/tr/graph.json
+++ b/packages/i18n/src/locales/tr/graph.json
@@ -40,6 +40,7 @@
     "filters": "Filtreler",
     "display": "Ekran",
     "show-labels": "Etiketleri göster",
+    "live-motion": "Canlı hareket",
     "focus-depth": "derinlik {depth}",
     "clear-focus": "Odaklanmış düğümü temizle"
   },


### PR DESCRIPTION
## What

- Replace the one-shot ForceAtlas2 pre-layout with a continuously running simulation that settles on its own and wakes on interaction
- Add node dragging: linked neighbours follow the grabbed node, a 3px threshold keeps a drag from opening a tab
- New dependency-free `GraphPhysics` (link springs, grid-cutoff repulsion, centering, collision, alpha decay/reheat, `fx`/`fy` pinning)
- `animateLayout` now means "live motion", defaults on, and is finally exposed in the control panel

## Why

The graph looked dead: `graph-builder` baked a static layout at build time and sigma drew frozen coordinates, the force worker was gated off with no UI to enable it, and no drag handlers existed.

Written in-repo rather than pulling in `d3-force` — adding it re-resolved shared transitives (`@floating-ui/dom` 1.7.6 → 1.8.0) and broke 1151 renderer tests. Lockfile is untouched.