### PR TITLE
fix(desktop): use Tailwind v4 (--var) syntax for Radix CSS variables

### DIFF
--- a/apps/desktop/src/renderer/src/components/nav-user.tsx
+++ b/apps/desktop/src/renderer/src/components/nav-user.tsx
@@ -76,7 +76,7 @@ export function NavUser({
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-md"
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-md"
             side={isMobile ? 'bottom' : 'right'}
             align="end"
             sideOffset={4}

--- a/apps/desktop/src/renderer/src/components/team-switcher.tsx
+++ b/apps/desktop/src/renderer/src/components/team-switcher.tsx
@@ -50,14 +50,14 @@ export function TeamSwitcher({
               <div className="flex aspect-square size-6 items-center justify-center rounded-full bg-sidebar-primary text-sidebar-primary-foreground">
                 <activeTeam.logo className="size-3" />
               </div>
-              <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
+              <div className="grid flex-1 text-start text-sm leading-tight group-data-[collapsible=icon]:hidden">
                 <span className="truncate font-normal">{activeTeam.name}</span>
               </div>
-              <ChevronsUpDown className="ml-auto size-4 group-data-[collapsible=icon]:hidden" />
+              <ChevronsUpDown className="ms-auto size-4 group-data-[collapsible=icon]:hidden" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-[--radix-dropdown-menu-trigger-width] min-w-64 rounded-xl p-2 shadow-lg border border-gray-200/80"
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-64 rounded-xl p-2 shadow-lg border border-gray-200/80"
             align="start"
             side={isMobile ? 'bottom' : 'right'}
             sideOffset={8}

--- a/apps/desktop/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
     <DropdownMenuPrimitive.SubContent
       ref={ref}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-card-hover)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-card-hover)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-dropdown-menu-content-transform-origin)',
         'floating-content-motion',
         className
       )}
@@ -67,7 +67,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         'z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-card-hover)]',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-dropdown-menu-content-transform-origin)',
         'floating-content-motion',
         className
       )}

--- a/apps/desktop/src/renderer/src/components/ui/hover-card.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/hover-card.tsx
@@ -17,7 +17,7 @@ const HoverCardContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]',
+        'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-hover-card-content-transform-origin)',
         'floating-content-motion',
         className
       )}

--- a/apps/desktop/src/renderer/src/components/ui/picker/picker-content.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/picker/picker-content.tsx
@@ -16,7 +16,7 @@ export const PickerContent = React.forwardRef<
     width === 'auto'
       ? 'w-auto'
       : width === 'trigger'
-        ? 'w-[--radix-popover-trigger-width]'
+        ? 'w-(--radix-popover-trigger-width)'
         : typeof width === 'number'
           ? undefined
           : 'w-72'

--- a/apps/desktop/src/renderer/src/components/ui/popover.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
+        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)',
         'floating-content-motion',
         className
       )}

--- a/apps/desktop/src/renderer/src/components/ui/select.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/select.tsx
@@ -66,7 +66,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
+        'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-select-content-transform-origin)',
         'floating-content-motion',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',

--- a/apps/desktop/src/renderer/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]',
+        'z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Tailwind v4 removed v3's implicit `var()` wrapping inside square-bracket arbitrary values. A class like `w-[--radix-dropdown-menu-trigger-width]` now compiles to:

```css
width: --radix-dropdown-menu-trigger-width;  /* bare custom-property name where a length belongs */
```

That is invalid CSS, so the browser drops the declaration entirely and the class silently does nothing. Verified by compiling through the workspace's own Tailwind:

| Source | Compiles to | |
|---|---|---|
| `w-[--x]` | `width: --x` | invalid, dropped |
| `w-(--x)` | `width: var(--x)` | correct |
| `w-[var(--x)]` | `width: var(--x)` | also correct |

This converts all nine remaining instances in `apps/desktop/src/renderer/src` to the v4 `(--var)` shorthand. `components/ui/context-menu.tsx` already used that form and served as the style reference.

**Real layout impact** — the floating element never matched its trigger width:
- `components/nav-user.tsx` — `w-(--radix-dropdown-menu-trigger-width)`
- `components/team-switcher.tsx` — same
- `components/ui/picker/picker-content.tsx` — `w-(--radix-popover-trigger-width)`; the `width="trigger"` prop was a **no-op** until now
- `components/ui/select.tsx` — `max-h-(--radix-select-content-available-height)`; long select menus had no viewport height cap

**Animation origin** silently fell back to `center` instead of the popper-anchored corner:
- `components/ui/dropdown-menu.tsx` (2 instances), `select.tsx`, `popover.tsx`, `hover-card.tsx`, `tooltip.tsx`

### Note for reviewers

Two changes fall outside the strict scope, both flagged deliberately:

1. **`select.tsx` `max-h-`** — the brief listed eight instances and said the `max-h-` ones were already fixed. One was not: `max-h-[--radix-select-content-available-height]` sits on the same line as the origin class in `select.tsx:69`. Same bug class, and the verification grep still flagged it, so it is fixed here.
2. **`team-switcher.tsx` `text-left` → `text-start`, `ml-auto` → `ms-auto`** — pre-existing physical Tailwind classes, unrelated to this fix. The pre-commit renderer guard scans whole staged files rather than changed lines, so touching the file requires clearing them. Both conversions are RTL-correct.

No behavior is gated or changed beyond CSS that previously did not apply. Purely additive to what the browser actually renders — no migration or compat concern.

## Release note

Dropdown and popover menus now correctly match the width of the control that opens them, and open/close animations anchor to the right corner instead of scaling from the center.

## Test plan

- `grep -rnE "[a-z0-9-]+-\[--[a-z0-9-]+\]" apps/desktop/src/renderer` — no matches remain (exit 1)
- `pnpm --filter @memry/desktop typecheck:web` — clean
- `pnpm --filter @memry/desktop test:renderer` — 559 files, 6301 passed, 6 skipped, 0 failed