### PR TITLE
fix(sync): stop retaining full note markdown in writeback debugState

### DIFF
--- a/apps/desktop/src/main/sync/crdt-writeback.test.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.test.ts
@@ -250,6 +250,26 @@ describe('crdt writeback', () => {
     })
   })
 
+  it('keeps no debug state (and no note markdown) outside test mode', async () => {
+    const previousNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      scheduleWriteback('note-prod', makeDoc('Yjs title'))
+      expect(getWritebackDebugState('note-prod')).toBeNull()
+
+      await vi.advanceTimersByTimeAsync(500)
+
+      // The write-back itself still runs; only the debug bookkeeping is skipped.
+      expect(mocks.atomicWrite).toHaveBeenCalledWith(
+        '/vault/notes/Existing.md',
+        expect.stringContaining('updated markdown')
+      )
+      expect(getWritebackDebugState('note-prod')).toBeNull()
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv
+    }
+  })
+
   it('serializes CriticMarkup marks from the Y.Doc during existing note writeback', async () => {
     const markdown = 'updated markdown added deleted'
     const doc = makeDoc('Yjs title')

--- a/apps/desktop/src/main/sync/crdt-writeback.ts
+++ b/apps/desktop/src/main/sync/crdt-writeback.ts
@@ -88,9 +88,17 @@ interface WritebackDebugState {
   lastError: string | null
 }
 
+/**
+ * E2E-only bookkeeping. `lastMarkdown` is the entire serialized note body, and
+ * nothing evicts entries, so populating this in a real session would pin one
+ * full copy of every edited note in the main process for the app's lifetime.
+ * The only reader is the `getWritebackDebugState` test hook, which is itself
+ * registered behind the same gate (see `registerTestHooks`).
+ */
 const debugState = new Map<string, WritebackDebugState>()
 
 function updateDebugState(noteId: string, patch: Partial<WritebackDebugState>): void {
+  if (process.env.NODE_ENV !== 'test') return
   const current = debugState.get(noteId) ?? {
     pending: false,
     scheduledCount: 0,


### PR DESCRIPTION
Fixes #990

## Verification (issue is real on current `main`)

`apps/desktop/src/main/sync/crdt-writeback.ts` (pre-fix line numbers):

- `:91` `const debugState = new Map<string, WritebackDebugState>()` — module-level, no TTL, no cap, never cleared on vault close or vault switch.
- `:87` the entry type carries `lastMarkdown: string | null`.
- `:248` `performWriteback` writes `lastMarkdown: markdown` — the entire serialized note body, on every debounced write-back (every 500 ms while typing).
- `:159-163` `scheduleWriteback` allocates a fresh entry object per schedule.

Grep confirms the only reader is the E2E test hook:

```
apps/desktop/src/main/test-hooks.ts:7,564   getWritebackDebugState
apps/desktop/tests/e2e/utils/note-sync-helpers.ts:296
apps/desktop/tests/e2e/body-crdt-*.e2e.ts    (poll `.lastMarkdown`)
```

No production code path reads it. Net effect on a real install: one full copy of every edited note body stays resident in the main process for the lifetime of the app.

## Change

`apps/desktop/src/main/sync/crdt-writeback.ts` — one early return in `updateDebugState`:

```ts
if (process.env.NODE_ENV !== 'test') return
```

plus a comment explaining why the map must stay test-only.

Why this and not deletion: the E2E suites (`body-crdt-coverage-variants.e2e.ts`, `body-crdt-same-note-merge.e2e.ts`) poll `lastMarkdown` to assert cross-device body convergence, so the hook has to keep working. `registerTestHooks()` (`test-hooks.ts:255`) already uses exactly this `NODE_ENV === 'test'` gate, so the producer and the consumer are now enabled by the same condition — in a packaged app neither exists.

No contract, schema, IPC, sync-protocol or settings surface is touched, so there is no backward-compat exposure.

## Tests

Added `keeps no debug state (and no note markdown) outside test mode` to `apps/desktop/src/main/sync/crdt-writeback.test.ts`. It sets `NODE_ENV=production`, schedules and flushes a write-back, and asserts the write still lands on disk while `getWritebackDebugState` stays `null`.

Red before the fix:

```
FAIL src/main/sync/crdt-writeback.test.ts > keeps no debug state (and no note markdown) outside test mode
AssertionError: expected { pending: true, …(4) } to be null
+ Received:
{ "lastError": null, "lastMarkdown": null, "pending": true, "performedCount": 0, "scheduledCount": 1 }
```

Green after: `PASS (13) FAIL (0)`.

Mutation check (both directions, so the test is not a no-op):

- guard removed → the new test fails (output above).
- guard forced to always return → the pre-existing test `debounces and writes back an existing markdown note with merged frontmatter` fails at `:216` with `expected null to match object { pending: true, scheduledCount: 2 }`, proving the test-mode behaviour the E2E hook depends on is still intact.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts, architecture, rpc, ipc map, node + web tsc all clean).
- `pnpm lint` — `0 errors, 14 warnings`; all 14 are pre-existing warnings in unrelated renderer files (tags-hub, use-folder-view, use-tab-keyboard-shortcuts). Nothing in the touched files.
- `pnpm exec vitest run --project main src/main/sync/crdt-writeback.test.ts src/main/test-hooks.test.ts` — `PASS (21) FAIL (0)`.
- `git diff --check` — clean.
