### PR TITLE
fix(calendar): latch Google sync runner start so concurrent callers cannot orphan an interval

### DIFF
--- a/apps/desktop/src/main/calendar/google/google-sync-runner.test.ts
+++ b/apps/desktop/src/main/calendar/google/google-sync-runner.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockDbHolder, powerMonitorHolder, syncNowMock, signedInMock, hasConnectionMock } =
+  vi.hoisted(() => ({
+    mockDbHolder: { db: {} as object },
+    powerMonitorHolder: {
+      resumeHandlers: [] as Array<() => void>
+    },
+    syncNowMock: vi.fn(async () => {}),
+    signedInMock: vi.fn(async () => true),
+    hasConnectionMock: vi.fn(async () => true)
+  }))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  powerMonitor: {
+    on: (event: string, cb: () => void) => {
+      if (event === 'resume') powerMonitorHolder.resumeHandlers.push(cb)
+    },
+    removeListener: (event: string, cb: () => void) => {
+      if (event === 'resume') {
+        const index = powerMonitorHolder.resumeHandlers.indexOf(cb)
+        if (index >= 0) powerMonitorHolder.resumeHandlers.splice(index, 1)
+      }
+    }
+  }
+}))
+
+vi.mock('./oauth', () => ({
+  hasGoogleCalendarConnection: hasConnectionMock,
+  hasGoogleCalendarLocalAuth: vi.fn(async () => true),
+  listGoogleAccountIds: vi.fn(() => []),
+  resolveDefaultGoogleAccountId: vi.fn(() => null)
+}))
+
+vi.mock('../../sync/auth-state', () => ({
+  isMemryUserSignedIn: signedInMock
+}))
+
+vi.mock('../../database', () => ({
+  requireDatabase: vi.fn(() => mockDbHolder.db),
+  getDatabase: vi.fn(() => mockDbHolder.db),
+  isDatabaseInitialized: vi.fn(() => true)
+}))
+
+vi.mock('./sync-service', async () => {
+  const actual = await vi.importActual<typeof import('./sync-service')>('./sync-service')
+  return {
+    ...actual,
+    syncGoogleCalendarNow: syncNowMock
+  }
+})
+
+import { startGoogleCalendarSyncRunner, stopGoogleCalendarSyncRunner } from './google-sync-runner'
+
+describe('startGoogleCalendarSyncRunner (concurrent start)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    powerMonitorHolder.resumeHandlers.length = 0
+    syncNowMock.mockClear()
+    signedInMock.mockClear()
+    hasConnectionMock.mockClear()
+  })
+
+  afterEach(() => {
+    stopGoogleCalendarSyncRunner()
+    vi.useRealTimers()
+  })
+
+  it('arms exactly one interval and one resume listener when two callers start concurrently', async () => {
+    // #given two overlapping callers (app startup + sign-in / connect-account)
+    // #when both call start before the sign-in / connection awaits resolve
+    await Promise.all([startGoogleCalendarSyncRunner(), startGoogleCalendarSyncRunner()])
+
+    // #then only one poll timer and one powerMonitor resume listener exist
+    expect(vi.getTimerCount()).toBe(1)
+    expect(powerMonitorHolder.resumeHandlers).toHaveLength(1)
+  })
+
+  it('leaves nothing running after stop when the start calls raced', async () => {
+    // #given two callers raced the runner into life
+    await Promise.all([startGoogleCalendarSyncRunner(), startGoogleCalendarSyncRunner()])
+
+    // #when the runner is stopped (sign-out / disconnect / app quit)
+    stopGoogleCalendarSyncRunner()
+
+    // #then no orphaned timer or listener survives
+    expect(vi.getTimerCount()).toBe(0)
+    expect(powerMonitorHolder.resumeHandlers).toHaveLength(0)
+  })
+
+  it('can be restarted after stop (the in-flight latch clears)', async () => {
+    // #given a full start/stop cycle
+    await startGoogleCalendarSyncRunner()
+    stopGoogleCalendarSyncRunner()
+
+    // #when the runner starts again
+    await startGoogleCalendarSyncRunner()
+
+    // #then it is live again with a single timer and listener
+    expect(vi.getTimerCount()).toBe(1)
+    expect(powerMonitorHolder.resumeHandlers).toHaveLength(1)
+  })
+
+  it('does not latch permanently when the start attempt bails out', async () => {
+    // #given the user is not signed in yet
+    signedInMock.mockResolvedValueOnce(false)
+    await startGoogleCalendarSyncRunner()
+    expect(vi.getTimerCount()).toBe(0)
+
+    // #when they sign in and start is called again
+    await startGoogleCalendarSyncRunner()
+
+    // #then the runner actually starts
+    expect(vi.getTimerCount()).toBe(1)
+    expect(powerMonitorHolder.resumeHandlers).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/main/calendar/google/google-sync-runner.test.ts
+++ b/apps/desktop/src/main/calendar/google/google-sync-runner.test.ts
@@ -102,6 +102,32 @@ describe('startGoogleCalendarSyncRunner (concurrent start)', () => {
     expect(powerMonitorHolder.resumeHandlers).toHaveLength(1)
   })
 
+  it('installs nothing when stop() ran while the start was still in flight', async () => {
+    // #given a start that is parked on its connection check (sign-in / device
+    // registration kicked it off just before the user signed out)
+    let releaseConnectionCheck: () => void = () => {}
+    const reachedConnectionCheck = new Promise<void>((entered) => {
+      hasConnectionMock.mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            releaseConnectionCheck = () => resolve(true)
+            entered()
+          })
+      )
+    })
+    const pending = startGoogleCalendarSyncRunner()
+    await reachedConnectionCheck
+
+    // #when the runner is stopped before that start finishes, then it resolves
+    stopGoogleCalendarSyncRunner()
+    releaseConnectionCheck()
+    await pending
+
+    // #then the stopped runner stays stopped — no timer, no resume listener
+    expect(vi.getTimerCount()).toBe(0)
+    expect(powerMonitorHolder.resumeHandlers).toHaveLength(0)
+  })
+
   it('does not latch permanently when the start attempt bails out', async () => {
     // #given the user is not signed in yet
     signedInMock.mockResolvedValueOnce(false)

--- a/apps/desktop/src/main/calendar/google/google-sync-runner.ts
+++ b/apps/desktop/src/main/calendar/google/google-sync-runner.ts
@@ -21,6 +21,7 @@ let syncInterval: NodeJS.Timeout | null = null
 let currentPollIntervalMs = RUN_INTERVAL_MS
 let resumeHandler: (() => void) | null = null
 let lastTriggerAt = 0
+let startInFlight: Promise<void> | null = null
 
 export function getCurrentPollIntervalMs(): number {
   return currentPollIntervalMs
@@ -95,8 +96,27 @@ export function reEvaluatePollCadence(activeChannelCount: number): void {
   syncInterval = setInterval(runPeriodicSync, target)
 }
 
+// Startup, sign-in, connect-account and device registration can all call this
+// within the same session. The `syncInterval` guard alone is not enough: it is
+// checked before the awaits below, so two overlapping callers both pass it and
+// the second setInterval orphans the first — unreachable by stop() and by quit.
+// The in-flight latch is assigned synchronously, so the second caller joins the
+// first instead of arming a duplicate timer and resume listener.
 export async function startGoogleCalendarSyncRunner(): Promise<void> {
   if (syncInterval) return
+  if (startInFlight) {
+    await startInFlight
+    return
+  }
+  startInFlight = runStart()
+  try {
+    await startInFlight
+  } finally {
+    startInFlight = null
+  }
+}
+
+async function runStart(): Promise<void> {
   if (!(await isMemryUserSignedIn())) return
   if (!(await hasGoogleCalendarConnection(requireDatabase()))) return
 

--- a/apps/desktop/src/main/calendar/google/google-sync-runner.ts
+++ b/apps/desktop/src/main/calendar/google/google-sync-runner.ts
@@ -22,6 +22,7 @@ let currentPollIntervalMs = RUN_INTERVAL_MS
 let resumeHandler: (() => void) | null = null
 let lastTriggerAt = 0
 let startInFlight: Promise<void> | null = null
+let startGeneration = 0
 
 export function getCurrentPollIntervalMs(): number {
   return currentPollIntervalMs
@@ -117,8 +118,14 @@ export async function startGoogleCalendarSyncRunner(): Promise<void> {
 }
 
 async function runStart(): Promise<void> {
+  const generation = startGeneration
   if (!(await isMemryUserSignedIn())) return
   if (!(await hasGoogleCalendarConnection(requireDatabase()))) return
+  // Sign-out / disconnect can call stop() while this start is still parked on
+  // the awaits above. Installing now would arm a timer and resume listener that
+  // nothing is going to stop again. Checked after the last await, before any
+  // install.
+  if (generation !== startGeneration) return
 
   void syncGoogleCalendarNow()
     .then(() => trackSyncCompleted('initial'))
@@ -153,6 +160,11 @@ async function runStart(): Promise<void> {
 }
 
 export function stopGoogleCalendarSyncRunner(): void {
+  // Bump first, above the `!syncInterval` early return: when the runner has not
+  // installed its interval yet, an in-flight start is exactly what needs
+  // invalidating.
+  startGeneration += 1
+
   if (resumeHandler) {
     powerMonitor.removeListener('resume', resumeHandler)
     resumeHandler = null


### PR DESCRIPTION
Fixes #989

Two ways the runner ends up with an interval nobody can stop. Both fixed here.

## Verification (issue is real on current `main`)

`apps/desktop/src/main/calendar/google/google-sync-runner.ts:98-113` (pre-fix):

```ts
export async function startGoogleCalendarSyncRunner(): Promise<void> {
  if (syncInterval) return
  if (!(await isMemryUserSignedIn())) return
  if (!(await hasGoogleCalendarConnection(requireDatabase()))) return
  ...
  syncInterval = setInterval(runPeriodicSync, currentPollIntervalMs)
  resumeHandler = () => triggerGoogleCalendarSyncNow('system-resume')
  powerMonitor.on('resume', resumeHandler)
```

**A — concurrent starts (the filed defect).** The `syncInterval` guard is checked
before both `await`s. Every caller reaches the first `await` synchronously, so two
overlapping callers both pass the guard. The second `setInterval` overwrites
`syncInterval` and the second `resumeHandler` overwrites the first — the earlier
timer and listener become unreachable. `stopGoogleCalendarSyncRunner()` (`:135-151`)
clears only the last handle, so app quit and sign-out leave an orphaned 5-minute
network-sync timer plus a leaked `powerMonitor.on('resume')` listener for the
process lifetime.

**B — stop during an in-flight start (same defect class).** Sign-out / disconnect
calls `stop()` while a start kicked off by `device-registration.ts:230` or
`auth-oauth-handlers.ts:278` is still parked on its awaits. That start then resolves
*after* the stop and arms a fresh interval and resume listener on an already-stopped
runner. Nothing is going to call `stop()` again, so a signed-out user keeps polling
Google Calendar forever.

Overlapping callers confirmed in the current tree:
- `apps/desktop/src/main/index.ts:1676` (startup)
- `apps/desktop/src/main/ipc/auth-oauth-handlers.ts:278` (sign-in)
- `apps/desktop/src/main/ipc/calendar-handlers.ts:691` (connect account)
- `apps/desktop/src/main/sync/device-registration.ts:230`

All four call it as fire-and-forget (`void start().catch(...)`), so nothing
serializes them against each other or against `stop()`.

## Change

`apps/desktop/src/main/calendar/google/google-sync-runner.ts` only:
- new `startInFlight: Promise<void> | null` — `startGoogleCalendarSyncRunner()`
  assigns it **synchronously** before any `await` and clears it in a `finally`; a
  second concurrent caller awaits the existing promise instead of starting a second
  runner (fixes A)
- new `startGeneration` counter — `runStart()` captures it up front and returns
  without installing anything if it changed by the time its awaits resolve;
  `stopGoogleCalendarSyncRunner()` bumps it (fixes B). The check sits after the
  **last** await and before the first install. The bump sits **above** the
  `if (!syncInterval) return` early return, because the case that matters is exactly
  the one where no interval is installed yet
- the original body moved verbatim into a private `runStart()` — no behavior change
  inside it

No other file touched. No contract, schema, or settings surface involved.

## Tests

New: `apps/desktop/src/main/calendar/google/google-sync-runner.test.ts` (5 cases)
- two concurrent `start()` calls arm exactly one timer + one resume listener
- `stop()` after a raced start leaves zero timers and zero listeners
- **a start that was still in flight when `stop()` ran installs nothing** — the
  connection check is gated on a deferred so `stop()` lands mid-start deterministically
- start → stop → start still works (latch clears)
- a start that bails out (not signed in) does not wedge the next start

Red before each fix, from these same tests:

```
# A (concurrent starts)
AssertionError: expected 2 to be 1     # arms exactly one interval...
AssertionError: expected 1 to be +0    # leaves nothing running after stop...

# B (stop during in-flight start)
AssertionError: expected 1 to be +0    # installs nothing when stop() ran while
                                       # the start was still in flight
```

Green after: `PASS (5) FAIL (0)`.

Mutation checks (per repo guidance on mocked tests) — each re-reds only the case it
should:
- delete the `if (startInFlight) { await startInFlight; return }` join → `expected 2
  to be 1` + `expected 1 to be +0`
- delete `if (generation !== startGeneration) return` → `expected 1 to be +0` on the
  in-flight case
- move `startGeneration += 1` below `if (!syncInterval) return` in `stop()` →
  `expected 1 to be +0` on the in-flight case

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + RPC + IPC map + node/web tsc all clean)
- `pnpm lint` — 0 errors, 14 warnings, all pre-existing in unrelated renderer files
- `pnpm --filter @memry/desktop test:main` — 476 files passed, 5421 tests passed, 1 skipped
