### PR TITLE
perf(projections): throttle inbox stats rebuilds instead of one per event

### DIFF
--- a/apps/desktop/src/main/projections/projectors/inbox-stats-projector.test.ts
+++ b/apps/desktop/src/main/projections/projectors/inbox-stats-projector.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const rebuildInboxStatsTable = vi.hoisted(() => vi.fn())
 
@@ -6,9 +6,25 @@ vi.mock('../../inbox/stats', () => ({
   rebuildInboxStatsTable
 }))
 
-import { createInboxStatsProjector } from './inbox-stats-projector'
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+import { INBOX_STATS_REBUILD_INTERVAL_MS, createInboxStatsProjector } from './inbox-stats-projector'
+import type { ProjectionEvent } from '../types'
+
+const upserted = (itemId: string): ProjectionEvent => ({ type: 'inbox.upserted', itemId })
 
 describe('inbox stats projector', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('rebuild delegates to inbox stats table rebuild', async () => {
     rebuildInboxStatsTable.mockReturnValue({ rows: 3 })
 
@@ -25,5 +41,87 @@ describe('inbox stats projector', () => {
 
     await expect(projector.reconcile()).resolves.toEqual({ rows: 5 })
     expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuilds immediately for an isolated event so stats stay fresh', async () => {
+    vi.useFakeTimers()
+    rebuildInboxStatsTable.mockReturnValue({ rows: 1 })
+
+    const projector = createInboxStatsProjector()
+    await projector.project(upserted('item-1'))
+
+    expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces a burst of inbox events into a small constant number of rebuilds', async () => {
+    vi.useFakeTimers()
+    rebuildInboxStatsTable.mockReturnValue({ rows: 1 })
+
+    const projector = createInboxStatsProjector()
+
+    for (let i = 0; i < 100; i++) {
+      await projector.project(upserted(`item-${i}`))
+    }
+
+    // Leading edge only: the other 99 events collapse into one trailing rebuild.
+    expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(INBOX_STATS_REBUILD_INTERVAL_MS)
+
+    expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(2)
+
+    // No extra rebuild is left armed once the burst has been flushed.
+    await vi.advanceTimersByTimeAsync(INBOX_STATS_REBUILD_INTERVAL_MS * 10)
+    expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(2)
+  })
+
+  it('rebuilds again for an event that arrives after the coalescing window', async () => {
+    vi.useFakeTimers()
+    rebuildInboxStatsTable.mockReturnValue({ rows: 1 })
+
+    const projector = createInboxStatsProjector()
+
+    await projector.project(upserted('item-1'))
+    expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(INBOX_STATS_REBUILD_INTERVAL_MS)
+
+    await projector.project(upserted('item-2'))
+    expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops a pending coalesced rebuild when a full rebuild runs', async () => {
+    vi.useFakeTimers()
+    rebuildInboxStatsTable.mockReturnValue({ rows: 1 })
+
+    const projector = createInboxStatsProjector()
+
+    await projector.project(upserted('item-1'))
+    await projector.project(upserted('item-2'))
+    expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(1)
+
+    await projector.rebuild()
+    expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(INBOX_STATS_REBUILD_INTERVAL_MS * 10)
+    expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the queue alive when a coalesced rebuild throws', async () => {
+    vi.useFakeTimers()
+    rebuildInboxStatsTable.mockReturnValue({ rows: 1 })
+
+    const projector = createInboxStatsProjector()
+
+    await projector.project(upserted('item-1'))
+    await projector.project(upserted('item-2'))
+
+    rebuildInboxStatsTable.mockImplementationOnce(() => {
+      throw new Error('database closed')
+    })
+
+    await vi.advanceTimersByTimeAsync(INBOX_STATS_REBUILD_INTERVAL_MS)
+
+    expect(rebuildInboxStatsTable).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/desktop/src/main/projections/projectors/inbox-stats-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/inbox-stats-projector.ts
@@ -1,7 +1,46 @@
+import { createLogger } from '../../lib/logger'
 import { rebuildInboxStatsTable } from '../../inbox/stats'
 import type { ProjectionEvent, ProjectionProjector } from '../types'
 
+const logger = createLogger('Projections:InboxStats')
+
+/**
+ * Shortest gap allowed between two full `inbox_stats` rebuilds.
+ *
+ * `rebuildInboxStatsTable()` scans every row of `inbox_items`, rewrites the whole
+ * `inbox_stats` table, and there is no cheaper incremental form: a stats row is a
+ * per-date aggregate and an `inbox.upserted` event carries only an item id, so
+ * adjusting a counter would need the item's previous contribution, which is not
+ * stored anywhere. Since one event is published per item, a bookmark import or a
+ * sync pull of N items used to cost N full scans plus N table rewrites (#991).
+ *
+ * Throttling instead of debouncing keeps the common case exact: an isolated
+ * capture still rebuilds inline, so nothing reading the stats sees a delay. Only
+ * a burst is capped, to one rebuild per window plus a trailing one that folds in
+ * everything the window swallowed.
+ */
+export const INBOX_STATS_REBUILD_INTERVAL_MS = 500
+
 export function createInboxStatsProjector(): ProjectionProjector {
+  let lastRebuildAt = 0
+  let pendingRebuild: ReturnType<typeof setTimeout> | null = null
+
+  const runRebuild = (): { rows: number } => {
+    lastRebuildAt = Date.now()
+    return rebuildInboxStatsTable()
+  }
+
+  const cancelPendingRebuild = (): void => {
+    if (!pendingRebuild) return
+    clearTimeout(pendingRebuild)
+    pendingRebuild = null
+  }
+
+  const runFullRebuild = (): { rows: number } => {
+    cancelPendingRebuild()
+    return runRebuild()
+  }
+
   return {
     name: 'inbox-stats',
 
@@ -10,15 +49,35 @@ export function createInboxStatsProjector(): ProjectionProjector {
     },
 
     async project(): Promise<void> {
-      rebuildInboxStatsTable()
+      const sinceLastRebuild = Date.now() - lastRebuildAt
+      if (sinceLastRebuild >= INBOX_STATS_REBUILD_INTERVAL_MS) {
+        cancelPendingRebuild()
+        runRebuild()
+        return
+      }
+
+      if (pendingRebuild) return
+
+      pendingRebuild = setTimeout(() => {
+        pendingRebuild = null
+        try {
+          runRebuild()
+        } catch (error) {
+          // Outside the runtime's per-event try/catch, so an unguarded throw
+          // (closed database after the vault shut down) would surface as an
+          // unhandled exception. The next inbox event rebuilds anyway.
+          logger.warn('Deferred inbox stats rebuild failed', error)
+        }
+      }, INBOX_STATS_REBUILD_INTERVAL_MS - sinceLastRebuild)
+      pendingRebuild.unref?.()
     },
 
     async rebuild(): Promise<{ rows: number }> {
-      return rebuildInboxStatsTable()
+      return runFullRebuild()
     },
 
     async reconcile(): Promise<{ rows: number }> {
-      return rebuildInboxStatsTable()
+      return runFullRebuild()
     }
   }
 }


### PR DESCRIPTION
Fixes #991

## Verification (issue is real on current `main`)

`apps/desktop/src/main/projections/projectors/inbox-stats-projector.ts:12-14` (pre-change) ran the full rebuild on every event:

```ts
async project(): Promise<void> {
  rebuildInboxStatsTable()
},
```

`rebuildInboxStatsTable()` (`apps/desktop/src/main/inbox/stats.ts:260-306`) does `SELECT … FROM inbox_items` over the whole table, aggregates in JS, `DELETE FROM inbox_stats`, then bulk re-INSERTs. `handles()` matches every `inbox.*` event, and one event is published per item from `inbox/ingest.ts`, `inbox/capture.ts`, `inbox/filing.ts`, `inbox/jobs.ts`, `inbox/transcription.ts` and `sync/item-handlers/inbox-handler.ts` — so an import or sync pull of N items was N full scans + N table rewrites.

Reproduced in a test before touching the implementation: 100 `inbox.upserted` events produced **100** rebuilds.

## Change

`apps/desktop/src/main/projections/projectors/inbox-stats-projector.ts` only.

Throttle (leading + trailing), not debounce:

- an event more than `INBOX_STATS_REBUILD_INTERVAL_MS` (500ms) after the last rebuild still rebuilds **inline**, so an isolated capture is exactly as fresh as before — no added staleness on the common path;
- events inside the window arm a single trailing rebuild that folds in everything the window swallowed;
- `rebuild()` / `reconcile()` cancel a pending trailing rebuild before running (they already do the full work);
- the trailing rebuild is guarded with try/catch + `logger.warn` because it runs outside the projection runtime's per-event try/catch — a vault closing between the arm and the fire would otherwise throw unhandled. The timer is `unref()`d.

No incremental counter maths: an `inbox.upserted` event carries only an item id and a stats row is a per-date aggregate, so a delta would need the item's previous contribution, which isn't stored anywhere. Output stays byte-identical to a full rebuild because it *is* the same full rebuild, just run fewer times.

No schema, IPC, sync or settings change — nothing to migrate.

## Tests

`apps/desktop/src/main/projections/projectors/inbox-stats-projector.test.ts` (5 new cases, existing 2 kept).

Red before the fix:

```
1. coalesces a burst of inbox events into a small constant number of rebuilds
   AssertionError: expected "vi.fn()" to be called 1 times, but got 100 times
2. drops a pending coalesced rebuild when a full rebuild runs
   AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
```

Green after: `PASS (7) FAIL (0)`.

Mutation-checked: deleting the try/catch around the deferred rebuild turns "keeps the queue alive when a coalesced rebuild throws" red (`Error: database closed`), so the tests are not passing vacuously.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + rpc + ipc map + node + web).
- `pnpm lint` — 0 errors, 14 warnings, all pre-existing in unrelated renderer files.
- `vitest --project main src/main/projections src/main/inbox/stats.test.ts` — `PASS (90) FAIL (0)`.
