### PR TITLE
fix(projections): route events by handles() and bound each lane queue

### DIFF
--- a/apps/desktop/src/main/projections/bus.test.ts
+++ b/apps/desktop/src/main/projections/bus.test.ts
@@ -5,6 +5,30 @@ import type { ProjectionEvent } from './types'
 
 const ev = (id: string) => ({ type: 'note.updated', itemId: id }) as unknown as ProjectionEvent
 
+const upsert = (noteId: string, parsedContent: string): ProjectionEvent => ({
+  type: 'note.upserted',
+  note: {
+    kind: 'markdown',
+    noteId,
+    path: `notes/${noteId}.md`,
+    title: noteId,
+    fileType: 'markdown',
+    localOnly: false,
+    contentHash: parsedContent,
+    wordCount: 1,
+    characterCount: parsedContent.length,
+    snippet: parsedContent,
+    date: null,
+    emoji: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    modifiedAt: '2026-01-01T00:00:00.000Z',
+    parsedContent,
+    tags: [],
+    properties: {},
+    wikiLinks: []
+  }
+})
+
 describe('ProjectionBus', () => {
   it('dequeues in FIFO order and tracks size', () => {
     // #given
@@ -39,5 +63,74 @@ describe('ProjectionBus', () => {
     // #then
     expect(bus.size).toBe(0)
     expect(bus.dequeue()).toBeUndefined()
+  })
+
+  /**
+   * #992: a stalled lane used to hold one copy of every note body it had ever
+   * been handed. Re-saving one note must not grow the queue.
+   */
+  it('coalesces newest-wins per entity, in place', () => {
+    // #given
+    const bus = new ProjectionBus()
+    bus.enqueue(upsert('a', 'v1'))
+    bus.enqueue(upsert('b', 'v1'))
+
+    // #when
+    bus.enqueue(upsert('a', 'v2'))
+
+    // #then
+    expect(bus.size).toBe(2)
+    expect(bus.dequeue()).toMatchObject({ note: { noteId: 'a', parsedContent: 'v2' } })
+    expect(bus.dequeue()).toMatchObject({ note: { noteId: 'b', parsedContent: 'v1' } })
+  })
+
+  it('never coalesces across event types for the same entity', () => {
+    // #given
+    const bus = new ProjectionBus()
+    bus.enqueue(upsert('a', 'v1'))
+    bus.enqueue({ type: 'note.deleted', noteId: 'a' })
+
+    // #when
+    bus.enqueue(upsert('a', 'v2'))
+
+    // #then — coalescing must never reorder the delete after the newer upsert
+    expect(bus.size).toBe(3)
+    expect(bus.dequeue()).toMatchObject({ type: 'note.upserted', note: { parsedContent: 'v1' } })
+    expect(bus.dequeue()).toMatchObject({ type: 'note.deleted' })
+    expect(bus.dequeue()).toMatchObject({ type: 'note.upserted', note: { parsedContent: 'v2' } })
+  })
+
+  it('does not coalesce into an already dequeued event', () => {
+    // #given
+    const bus = new ProjectionBus()
+    bus.enqueue(upsert('a', 'v1'))
+    bus.enqueue(upsert('b', 'v1'))
+    expect(bus.dequeue()).toMatchObject({ note: { noteId: 'a', parsedContent: 'v1' } })
+
+    // #when
+    bus.enqueue(upsert('a', 'v2'))
+
+    // #then
+    expect(bus.size).toBe(2)
+    expect(bus.dequeue()).toMatchObject({ note: { noteId: 'b' } })
+    expect(bus.dequeue()).toMatchObject({ note: { noteId: 'a', parsedContent: 'v2' } })
+  })
+
+  it('drops the oldest event once the queue limit is reached', () => {
+    // #given
+    const bus = new ProjectionBus(3)
+
+    // #when
+    for (let i = 0; i < 1000; i++) {
+      bus.enqueue(upsert(`note-${i}`, 'body'))
+    }
+
+    // #then
+    expect(bus.size).toBe(3)
+    expect(bus.takeDroppedCount()).toBe(997)
+    expect(bus.takeDroppedCount()).toBe(0)
+    expect(bus.dequeue()).toMatchObject({ note: { noteId: 'note-997' } })
+    expect(bus.dequeue()).toMatchObject({ note: { noteId: 'note-998' } })
+    expect(bus.dequeue()).toMatchObject({ note: { noteId: 'note-999' } })
   })
 })

--- a/apps/desktop/src/main/projections/bus.ts
+++ b/apps/desktop/src/main/projections/bus.ts
@@ -1,21 +1,123 @@
 import type { ProjectionEvent } from './types'
 
+/**
+ * Per-lane queue cap (#992).
+ *
+ * A lane that backs up past this many *distinct* pending entities is already
+ * pathological — the embedding lane awaits a ~23MB model load plus per-note CPU
+ * inference, and every queued `note.upserted` pins that note's whole body. An
+ * unbounded queue turns that backlog into an OOM, so the oldest event is dropped
+ * instead. Drops are counted so the runtime can log them, and every projector
+ * has a `rebuild()` / `reconcile()` repair path for the lost work.
+ */
+export const DEFAULT_PROJECTION_QUEUE_LIMIT = 2000
+
+/** Rebase the backing array once this many consumed slots have piled up. */
+const COMPACT_AFTER = 512
+
+/**
+ * The entity an event is about. Two events sharing an entity key *and* a type
+ * are redundant: the newer payload fully supersedes the older one.
+ */
+function entityKey(event: ProjectionEvent): string {
+  switch (event.type) {
+    case 'note.upserted':
+      return `note:${event.note.noteId}`
+    case 'note.deleted':
+      return `note:${event.noteId}`
+    case 'task.upserted':
+    case 'task.deleted':
+      return `task:${event.taskId}`
+    default:
+      return `inbox:${event.itemId}`
+  }
+}
+
+interface PendingEntry {
+  /** Index into `queue` of the newest still-queued event for this entity. */
+  index: number
+  type: ProjectionEvent['type']
+}
+
 export class ProjectionBus {
-  private queue: ProjectionEvent[] = []
+  private queue: (ProjectionEvent | undefined)[] = []
+  private head = 0
+  private newestByEntity = new Map<string, PendingEntry>()
+  private dropped = 0
+  private readonly limit: number
+
+  constructor(limit: number = DEFAULT_PROJECTION_QUEUE_LIMIT) {
+    this.limit = Math.max(1, limit)
+  }
 
   enqueue(event: ProjectionEvent): void {
+    const key = entityKey(event)
+    const newest = this.newestByEntity.get(key)
+
+    // Newest-wins, in place: an already-queued event of the same type for the
+    // same entity is fully superseded, so overwrite it instead of queueing a
+    // second copy of the payload. Only the entity's *newest* pending event is a
+    // candidate, so a `note.deleted` can never be reordered behind a later
+    // `note.upserted` — a type change re-anchors the entity to the tail.
+    if (newest && newest.type === event.type) {
+      this.queue[newest.index] = event
+      return
+    }
+
+    if (this.size >= this.limit) {
+      this.dequeue()
+      this.dropped++
+    }
+
     this.queue.push(event)
+    this.newestByEntity.set(key, { index: this.queue.length - 1, type: event.type })
   }
 
   dequeue(): ProjectionEvent | undefined {
-    return this.queue.shift()
+    if (this.head >= this.queue.length) {
+      return undefined
+    }
+
+    const event = this.queue[this.head]
+    this.queue[this.head] = undefined
+    this.head++
+
+    if (event) {
+      const key = entityKey(event)
+      const newest = this.newestByEntity.get(key)
+      if (newest && newest.index < this.head) {
+        this.newestByEntity.delete(key)
+      }
+    }
+
+    if (this.head >= this.queue.length) {
+      this.clear()
+    } else if (this.head >= COMPACT_AFTER) {
+      const consumed = this.head
+      this.queue = this.queue.slice(consumed)
+      this.head = 0
+      for (const entry of this.newestByEntity.values()) {
+        entry.index -= consumed
+      }
+    }
+
+    return event
   }
 
   clear(): void {
     this.queue = []
+    this.head = 0
+    this.newestByEntity.clear()
+  }
+
+  /** Number of events dropped to stay under the cap since the last read. */
+  takeDroppedCount(): number {
+    const dropped = this.dropped
+    this.dropped = 0
+    return dropped
   }
 
   get size(): number {
-    return this.queue.length
+    return this.queue.length - this.head
   }
 }

--- a/apps/desktop/src/main/projections/runtime.test.ts
+++ b/apps/desktop/src/main/projections/runtime.test.ts
@@ -239,6 +239,96 @@ describe('projection runtime', () => {
     )
   })
 
+  /**
+   * #992: the cap drops the oldest pending events, so the lane's output is now
+   * missing whatever they carried — a dropped `note.upserted` in the search lane
+   * means that note is absent from search. Nothing else calls reconcile() on this
+   * path, so overflow must pay for itself with a deferred repair rather than
+   * leaving a quietly wrong projection.
+   */
+  it('reconciles a lane once after an overflowed queue drains', async () => {
+    const slow = createProjector('slow', { reconcile: vi.fn() })
+    const runtime = createProjectionRuntime({
+      projectors: [slow],
+      scheduleDrain: () => {},
+      queueLimit: 2
+    })
+
+    for (let i = 0; i < 10; i++) {
+      runtime.publish(markdownEvent(`note-${i}`, 'body'))
+    }
+    await runtime.flush()
+
+    expect(slow.reconcile).toHaveBeenCalledOnce()
+
+    // A later burst that never overflows must not pay for another repair.
+    runtime.publish(markdownEvent('note-later', 'body'))
+    await runtime.flush()
+
+    expect(slow.reconcile).toHaveBeenCalledOnce()
+  })
+
+  it('does not let an event published by the overflow repair trigger another repair', async () => {
+    // A repair that writes through the bus must not re-arm itself. Publishing is
+    // capped so that a runtime which never clears the flag fails the assertion
+    // below instead of spinning forever.
+    let echoes = 0
+    const slow = createProjector('slow', {
+      reconcile: vi.fn(() => {
+        if (echoes >= 3) {
+          return
+        }
+        echoes++
+        runtime.publish(markdownEvent(`echo-${echoes}`, 'body'))
+      })
+    })
+    const runtime = createProjectionRuntime({
+      projectors: [slow],
+      scheduleDrain: () => {},
+      queueLimit: 2
+    })
+
+    for (let i = 0; i < 10; i++) {
+      runtime.publish(markdownEvent(`note-${i}`, 'body'))
+    }
+    await runtime.flush()
+
+    expect(slow.reconcile).toHaveBeenCalledOnce()
+    expect(echoes).toBe(1)
+  })
+
+  it('logs a failed overflow repair and retries it on the next drain', async () => {
+    const logger = { warn: vi.fn() }
+    const slow = createProjector('slow', {
+      reconcile: vi.fn(async () => {
+        throw new Error('boom')
+      })
+    })
+    const runtime = createProjectionRuntime({
+      projectors: [slow],
+      scheduleDrain: () => {},
+      queueLimit: 2,
+      logger
+    })
+
+    for (let i = 0; i < 10; i++) {
+      runtime.publish(markdownEvent(`note-${i}`, 'body'))
+    }
+    await runtime.flush()
+
+    expect(slow.reconcile).toHaveBeenCalledOnce()
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Projection overflow repair failed',
+      expect.objectContaining({ projector: 'slow' })
+    )
+
+    // The lane is not wedged and the repair is still owed, so the next drain retries.
+    runtime.publish(markdownEvent('note-later', 'body'))
+    await runtime.flush()
+
+    expect(slow.reconcile).toHaveBeenCalledTimes(2)
+  })
+
   it('dispatches rebuild and reconcile to selected projectors', async () => {
     const first = createProjector('first', { rebuild: vi.fn(), reconcile: vi.fn() })
     const second = createProjector('second', { rebuild: vi.fn(), reconcile: vi.fn() })

--- a/apps/desktop/src/main/projections/runtime.test.ts
+++ b/apps/desktop/src/main/projections/runtime.test.ts
@@ -2,29 +2,33 @@ import { describe, expect, it, vi } from 'vitest'
 import { createProjectionRuntime } from './runtime'
 import type { ProjectionEvent, ProjectionProjector } from './types'
 
-const noteEvent: ProjectionEvent = {
-  type: 'note.upserted',
-  note: {
-    kind: 'markdown',
-    noteId: 'note-1',
-    path: 'notes/note-1.md',
-    title: 'Note 1',
-    fileType: 'markdown',
-    localOnly: false,
-    contentHash: 'hash',
-    wordCount: 1,
-    characterCount: 4,
-    snippet: 'test',
-    date: null,
-    emoji: null,
-    createdAt: '2026-01-01T00:00:00.000Z',
-    modifiedAt: '2026-01-01T00:00:00.000Z',
-    parsedContent: 'test',
-    tags: [],
-    properties: {},
-    wikiLinks: []
+function markdownEvent(noteId: string, parsedContent: string): ProjectionEvent {
+  return {
+    type: 'note.upserted',
+    note: {
+      kind: 'markdown',
+      noteId,
+      path: `notes/${noteId}.md`,
+      title: 'Note 1',
+      fileType: 'markdown',
+      localOnly: false,
+      contentHash: 'hash',
+      wordCount: 1,
+      characterCount: parsedContent.length,
+      snippet: parsedContent,
+      date: null,
+      emoji: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      modifiedAt: '2026-01-01T00:00:00.000Z',
+      parsedContent,
+      tags: [],
+      properties: {},
+      wikiLinks: []
+    }
   }
 }
+
+const noteEvent: ProjectionEvent = markdownEvent('note-1', 'test')
 
 function createProjector(
   name: string,
@@ -170,6 +174,69 @@ describe('projection runtime', () => {
 
     expect(done).toEqual(['fast', 'slow'])
     expect(runtime.getPendingCount()).toBe(0)
+  })
+
+  /**
+   * #992: publish() used to push every event into all five lanes and only ask
+   * handles() at drain time, so an inbox event sat in the note lanes (and a
+   * note body sat in the inbox lane) until the slowest lane got to it.
+   */
+  it('queues an event only in the lanes whose projector handles it', () => {
+    const noteLane = createProjector('note-lane', {
+      handles: (event: ProjectionEvent) => event.type === 'note.upserted'
+    })
+    const inboxLane = createProjector('inbox-lane', {
+      handles: (event: ProjectionEvent) => event.type.startsWith('inbox.')
+    })
+    // Freeze the lanes so the queues stay observable.
+    const runtime = createProjectionRuntime({
+      projectors: [noteLane, inboxLane],
+      scheduleDrain: () => {}
+    })
+
+    runtime.publish(noteEvent)
+
+    expect(runtime.getPendingCount()).toBe(1)
+  })
+
+  /**
+   * #992: the embedding lane awaits a ~23MB model load plus per-note CPU
+   * inference, so a stalled lane used to retain one full `parsedContent` per
+   * queued event. Re-saving one note must not grow its backlog.
+   */
+  it('retains only the newest queued event per note while a lane is stalled', () => {
+    const runtime = createProjectionRuntime({
+      projectors: [createProjector('slow')],
+      scheduleDrain: () => {}
+    })
+
+    for (let i = 0; i < 10_000; i++) {
+      runtime.publish(markdownEvent('note-1', `body ${i}`))
+    }
+
+    expect(runtime.getPendingCount()).toBe(1)
+  })
+
+  it('bounds a stalled lane queue and reports the dropped events', async () => {
+    const logger = { warn: vi.fn() }
+    const runtime = createProjectionRuntime({
+      projectors: [createProjector('slow')],
+      scheduleDrain: () => {},
+      queueLimit: 100,
+      logger
+    })
+
+    for (let i = 0; i < 10_000; i++) {
+      runtime.publish(markdownEvent(`note-${i}`, 'body'))
+    }
+
+    expect(runtime.getPendingCount()).toBe(100)
+
+    await runtime.flush()
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Projection queue overflow — dropped pending events',
+      expect.objectContaining({ projector: 'slow', dropped: 9900, limit: 100 })
+    )
   })
 
   it('dispatches rebuild and reconcile to selected projectors', async () => {

--- a/apps/desktop/src/main/projections/runtime.ts
+++ b/apps/desktop/src/main/projections/runtime.ts
@@ -49,6 +49,8 @@ interface ProjectorLane {
   bus: ProjectionBus
   isScheduled: boolean
   activeDrain: Promise<void> | null
+  /** Set when the cap dropped events; owed repair, paid once the lane empties. */
+  needsReconcile: boolean
 }
 
 export function createProjectionRuntime(options: ProjectionRuntimeOptions): ProjectionRuntime {
@@ -62,7 +64,8 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
     projector,
     bus: new ProjectionBus(queueLimit),
     isScheduled: false,
-    activeDrain: null
+    activeDrain: null,
+    needsReconcile: false
   }))
 
   const runEvent = async (lane: ProjectorLane, event: ProjectionEvent): Promise<void> => {
@@ -76,6 +79,32 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
       logger?.error?.('Projection projector failed', {
         projector: lane.projector.name,
         event,
+        error
+      })
+    }
+  }
+
+  /**
+   * Pay off the repair the queue cap owes. Dropping the oldest events keeps the
+   * lane bounded, but it also means this projector's output is now missing
+   * whatever they carried, and nothing else calls reconcile() on this path — so
+   * overflow costs a deferred full repair instead of a silently wrong
+   * projection (#992).
+   *
+   * The flag is cleared before reconcile() runs so any event reconcile itself
+   * publishes cannot re-trigger the repair in a loop; only a *new* overflow
+   * sets it again. On failure the flag is restored, so the next drain pass
+   * retries rather than leaving the loss unrepaired forever.
+   */
+  const repairLane = async (lane: ProjectorLane): Promise<void> => {
+    lane.needsReconcile = false
+
+    try {
+      await lane.projector.reconcile()
+    } catch (error) {
+      lane.needsReconcile = true
+      logger?.warn?.('Projection overflow repair failed', {
+        projector: lane.projector.name,
         error
       })
     }
@@ -106,18 +135,23 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
 
           await runEvent(lane, event)
         }
-      } finally {
-        lane.isScheduled = false
-        lane.activeDrain = null
 
         const dropped = lane.bus.takeDroppedCount()
         if (dropped > 0) {
+          lane.needsReconcile = true
           logger?.warn?.('Projection queue overflow — dropped pending events', {
             projector: lane.projector.name,
             dropped,
             limit: queueLimit
           })
         }
+
+        if (!isStopped && lane.needsReconcile) {
+          await repairLane(lane)
+        }
+      } finally {
+        lane.isScheduled = false
+        lane.activeDrain = null
 
         settle()
 
@@ -160,6 +194,11 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
       // Route at enqueue time. Fanning every event into every lane meant a note
       // body sat in the inbox lane (and an inbox event in the note lanes) until
       // the slowest lane finally dequeued and discarded it (#992).
+      //
+      // This skip assumes handles() is a pure function of event.type — every
+      // projector's is. runEvent() re-checks at drain time, so a stateful
+      // handles() would still never project an event it rejects; it would only
+      // lose the ones it would have accepted later.
       for (const lane of lanes) {
         if (!lane.projector.handles(event)) {
           continue

--- a/apps/desktop/src/main/projections/runtime.ts
+++ b/apps/desktop/src/main/projections/runtime.ts
@@ -1,10 +1,12 @@
-import { ProjectionBus } from './bus'
+import { DEFAULT_PROJECTION_QUEUE_LIMIT, ProjectionBus } from './bus'
 import type { ProjectionEvent, ProjectionLogger, ProjectionProjector } from './types'
 
 interface ProjectionRuntimeOptions {
   projectors: ProjectionProjector[]
   logger?: ProjectionLogger
   scheduleDrain?: (task: () => void) => void
+  /** Per-lane pending-event cap. See DEFAULT_PROJECTION_QUEUE_LIMIT. */
+  queueLimit?: number
 }
 
 export interface ProjectionRuntime {
@@ -52,12 +54,13 @@ interface ProjectorLane {
 export function createProjectionRuntime(options: ProjectionRuntimeOptions): ProjectionRuntime {
   const logger = options.logger
   const scheduleDrain = options.scheduleDrain ?? ((task: () => void) => queueMicrotask(task))
+  const queueLimit = options.queueLimit ?? DEFAULT_PROJECTION_QUEUE_LIMIT
 
   let isStopped = false
 
   const lanes: ProjectorLane[] = options.projectors.map((projector) => ({
     projector,
-    bus: new ProjectionBus(),
+    bus: new ProjectionBus(queueLimit),
     isScheduled: false,
     activeDrain: null
   }))
@@ -106,6 +109,16 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
       } finally {
         lane.isScheduled = false
         lane.activeDrain = null
+
+        const dropped = lane.bus.takeDroppedCount()
+        if (dropped > 0) {
+          logger?.warn?.('Projection queue overflow — dropped pending events', {
+            projector: lane.projector.name,
+            dropped,
+            limit: queueLimit
+          })
+        }
+
         settle()
 
         if (!isStopped && lane.bus.size > 0) {
@@ -144,7 +157,14 @@ export function createProjectionRuntime(options: ProjectionRuntimeOptions): Proj
         return
       }
 
+      // Route at enqueue time. Fanning every event into every lane meant a note
+      // body sat in the inbox lane (and an inbox event in the note lanes) until
+      // the slowest lane finally dequeued and discarded it (#992).
       for (const lane of lanes) {
+        if (!lane.projector.handles(event)) {
+          continue
+        }
+
         lane.bus.enqueue(event)
         schedule(lane)
       }


### PR DESCRIPTION
Fixes #992

## Verification (issue confirmed on current `main`)

- `apps/desktop/src/main/projections/runtime.ts:147-150` (pre-fix) — `publish()` looped over **every** lane and called `lane.bus.enqueue(event)` unconditionally.
- `apps/desktop/src/main/projections/runtime.ts:65-68` — `handles()` was only consulted inside `runEvent`, i.e. at drain time.
- `apps/desktop/src/main/projections/bus.ts` (pre-fix) — `enqueue()` was a bare `this.queue.push(event)`; no cap, no coalescing.
- `apps/desktop/src/main/projections/types.ts:18-21` — `note.upserted` carries `parsedContent`, `properties` and `wikiLinks`, so a queued event pins the whole note body.
- `apps/desktop/src/main/projections/projectors/embedding-projector.ts:180-217` — the embedding lane handles `note.upserted`/`note.deleted` and awaits `initEmbeddingModel()` (~23MB) plus per-note CPU inference inside `project()`, so it is the lane that decides how long every other lane's copy stays alive.

Reproduced by test before the fix: publishing one `note.upserted` with two projectors (only one of which handles it) left `getPendingCount() === 2`, and publishing 10 000 events for the *same* note left `getPendingCount() === 10000`.

## Change

`apps/desktop/src/main/projections/runtime.ts`
- `publish()` skips lanes whose projector does not `handles()` the event. Every `handles()` implementation in the repo is a pure switch on `event.type`; that assumption is now stated in a comment at the routing site, and `runEvent()` still re-checks at drain time.
- New optional `queueLimit` runtime option (defaults to `DEFAULT_PROJECTION_QUEUE_LIMIT`).
- **Overflow is self-healing.** A lane that had to drop events latches `needsReconcile` and, once its queue drains to empty, runs that projector's `reconcile()` exactly once. Overflow therefore costs a deferred full repair, not a permanently wrong projection.
  - The flag is cleared *before* `reconcile()` runs, so an event the repair itself publishes cannot re-arm it; only a new overflow sets it again.
  - The call is wrapped: on failure it logs `Projection overflow repair failed` and restores the flag, so the next drain pass retries and a throwing `reconcile()` never wedges the lane or escapes as an unhandled rejection.
  - Skipped when the runtime is stopped.
- A drain pass that dropped events logs once with the total instead of once per dropped event.

`apps/desktop/src/main/projections/bus.ts`
- Newest-wins coalescing per entity, **in place**: an already-queued event with the same entity *and* the same type is overwritten rather than appended, so an edit burst on one note retains one body instead of N. Coalescing only ever targets the entity's *newest* pending event, so a `note.deleted` can never be reordered behind a later `note.upserted` (a type change re-anchors the entity to the tail).
- Hard per-lane cap (default 2000). On overflow the oldest event is dropped and counted, which the runtime turns into the repair described above.
- Queue now uses a head pointer instead of `Array#shift()` so coalescing can address queued slots by index; consumed prefix is compacted periodically and reset when the lane drains empty (the entity map is cleaned on dequeue, so it cannot leak).

No schema, IPC, sync-protocol, vault-format or settings change. Nothing outside `projections/bus.ts` + `projections/runtime.ts` was touched — `reconcileMissingFiles`, the FTS rebuild path and the embedding projector's internal state are untouched.

## Tests

`apps/desktop/src/main/projections/runtime.test.ts`
- `queues an event only in the lanes whose projector handles it` — red before: `expected 2 to be 1`
- `retains only the newest queued event per note while a lane is stalled` — red before: `expected 10000 to be 1`
- `bounds a stalled lane queue and reports the dropped events` — red before: `expected 10000 to be 100`
- `reconciles a lane once after an overflowed queue drains` — red before: `expected "vi.fn()" to be called once, but got 0 times`
- `does not let an event published by the overflow repair trigger another repair` — red before: same
- `logs a failed overflow repair and retries it on the next drain` — red before: same

`apps/desktop/src/main/projections/bus.test.ts`
- `coalesces newest-wins per entity, in place`
- `never coalesces across event types for the same entity`
- `does not coalesce into an already dequeued event`
- `drops the oldest event once the queue limit is reached`

Mutation-tested — the fix reverted one line at a time, confirming each test goes red again:

| mutation | test that catches it |
| --- | --- |
| drop the `newest.type === event.type` guard | `never coalesces across event types for the same entity` — `expected 1 to be 3` |
| drop the stale-entity cleanup in `dequeue()` | `does not coalesce into an already dequeued event` — `expected 1 to be 2` |
| never latch `needsReconcile` on drop | all 3 repair tests — `called once, but got 0 times` |
| never clear `needsReconcile` | `…trigger another repair` — `called once, but got 4 times` |
| do not restore the flag when `reconcile()` throws | `logs a failed overflow repair and retries it` — `called 2 times, but got 1 times` |

One equivalent mutant found and reported rather than papered over: moving `needsReconcile = false` to *after* a successful `reconcile()` keeps all tests green. It is genuinely equivalent under the current control flow — the flag is only ever set synchronously in `drainLane` immediately before `repairLane` is awaited, so nothing can set it during the call. Clearing first is kept as the defensive placement.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + ipc:check + rpc:check + node/web tsc)
- `pnpm lint` — 0 errors, 14 warnings, all pre-existing in unrelated renderer files
- `vitest --project main src/main/projections` — 7 files, 46 tests passed
- `pnpm --filter @memry/desktop test:main` — 475 files passed | 1 skipped, 5426 tests passed | 1 expected fail | 4 skipped
