### PR TITLE
perf(telemetry): journal queue enqueues instead of rewriting the mirror

### DIFF
--- a/apps/desktop/src/main/telemetry/client.test.ts
+++ b/apps/desktop/src/main/telemetry/client.test.ts
@@ -407,6 +407,32 @@ describe('createTelemetryClient — crash durability', () => {
     expect(revived.getQueueDepth()).toBe(TELEMETRY_QUEUE_LIMIT)
   })
 
+  it('cannot be made to forge mirror entries by a hostile dimension value', () => {
+    // #given an event whose dimension carries remote-controlled text — inbox link
+    // metadata is scraped from arbitrary pages, which is the taint path CodeQL
+    // flags into this file — shaped to break out of a newline-delimited journal
+    const hostile = '\n{"id":"forged","name":"app_crashed","surface":"app"}\n'
+    const client = createTelemetryClient(createDeps({ persistPath }).deps)
+    client.track({
+      ...buildEvent('11111111-1111-1111-1111-111111111111', 'inbox_item_added'),
+      dimensions: { source: hostile }
+    })
+    client.track(buildEvent('22222222-2222-2222-2222-222222222222'))
+
+    // #then the payload was escaped rather than written raw: two events, two lines
+    const raw = fs.readFileSync(persistPath, 'utf-8')
+    expect(raw.split('\n')).toHaveLength(4) // header + 2 events + trailing ''
+
+    // #and the next launch restores the two real events, not a forged crash
+    const revived = createTelemetryClient(createDeps({ persistPath }).deps)
+    expect(revived.getQueueDepth()).toBe(2)
+    const restored = JSON.parse(
+      fs.readFileSync(persistPath, 'utf-8').split('\n')[1]
+    ) as TelemetryEvent
+    expect(restored.name).toBe('inbox_item_added')
+    expect(restored.dimensions?.source).toBe(hostile)
+  })
+
   it('never restores events for an install that opted out between launches', () => {
     // #given events mirrored while telemetry was on
     createTelemetryClient(createDeps({ persistPath }).deps).track(

--- a/apps/desktop/src/main/telemetry/client.test.ts
+++ b/apps/desktop/src/main/telemetry/client.test.ts
@@ -379,6 +379,34 @@ describe('createTelemetryClient — crash durability', () => {
     expect(createTelemetryClient(createDeps({ persistPath }).deps).getQueueDepth()).toBe(0)
   })
 
+  it('does not rewrite the whole mirror once per tracked event', () => {
+    // #given a client whose queue is already at the limit — what an unreachable
+    // endpoint produces, where every further event used to re-serialise all 500
+    const client = createTelemetryClient(createDeps({ persistPath }).deps)
+    for (let i = 0; i < TELEMETRY_QUEUE_LIMIT; i++) {
+      client.track(buildEvent(`11111111-1111-1111-1111-${String(i).padStart(12, '0')}`))
+    }
+    const mirrorSize = fs.statSync(persistPath).size
+    // fs.appendFileSync dispatches through fs.writeFileSync inside Node, so this
+    // spy sees both paths; byte volume is what separates them.
+    const write = vi.spyOn(fs, 'writeFileSync')
+
+    // #when 100 more events are tracked
+    for (let i = 1000; i < 1100; i++) {
+      client.track(buildEvent(`11111111-1111-1111-1111-${String(i).padStart(12, '0')}`))
+    }
+
+    // #then the whole burst wrote less than a single copy of the queue, where
+    // mirroring per event wrote 100 copies of it
+    const written = write.mock.calls.reduce((sum, call) => sum + String(call[1]).length, 0)
+    expect(written).toBeLessThan(mirrorSize)
+    write.mockRestore()
+
+    // #and a crash still loses nothing: the newest 500 events are on disk
+    const revived = createTelemetryClient(createDeps({ persistPath }).deps)
+    expect(revived.getQueueDepth()).toBe(TELEMETRY_QUEUE_LIMIT)
+  })
+
   it('never restores events for an install that opted out between launches', () => {
     // #given events mirrored while telemetry was on
     createTelemetryClient(createDeps({ persistPath }).deps).track(

--- a/apps/desktop/src/main/telemetry/client.ts
+++ b/apps/desktop/src/main/telemetry/client.ts
@@ -87,6 +87,12 @@ export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClien
     store?.save(queue)
   }
 
+  // The enqueue path appends one line rather than rewriting the mirror, so a
+  // tracked event costs the same whether the queue holds 1 event or 500.
+  const persistAppend = (event: TelemetryEvent): void => {
+    store?.append(event, queue)
+  }
+
   // A mirror written by a build with a larger limit must not resurrect an
   // unbounded queue; rewrite so the dropped head does not return next launch.
   if (queue.length > TELEMETRY_QUEUE_LIMIT) {
@@ -114,7 +120,7 @@ export const createTelemetryClient = (deps: TelemetryClientDeps): TelemetryClien
     if (!enabled) return
     queue.push(event)
     trimQueue()
-    persist()
+    persistAppend(event)
   }
 
   const flush = async (reason: TelemetryFlushReason): Promise<TelemetryFlushResult> => {

--- a/apps/desktop/src/main/telemetry/queue-store.test.ts
+++ b/apps/desktop/src/main/telemetry/queue-store.test.ts
@@ -85,6 +85,48 @@ describe('createQueueStore — incremental writes', () => {
     expect(createQueueStore<number>(filePath).load()).toEqual([1])
   })
 
+  // The journal is newline-delimited, so a value carrying a raw newline would
+  // forge extra entries or truncate the parse. Telemetry dimensions can carry
+  // remote-controlled text — page titles and URLs scraped by the inbox fetcher
+  // reach them — so this is the format's load-bearing invariant, and CodeQL
+  // flags the append as a network-data-to-file sink for exactly that reason.
+  const HOSTILE = {
+    lf: 'a\nb',
+    crlf: 'a\r\nb',
+    cr: 'a\rb',
+    forgedLine: '\n{"id":"forged","name":"app_crashed"}\n',
+    forgedHeader: '\n{"version":2}\n',
+    quotes: 'he said "hi" \\ and \\\\ too',
+    // JSON.stringify emits U+2028/U+2029 raw — legal inside a JSON string, and
+    // harmless here only because the journal splits on \n alone.
+    lineSeparators: 'a\u2028b\u2029c',
+    controls: 'a\tb\u0000c\u001fd',
+    // Keys go through the same quoting as values.
+    ['key\nwith\nnewlines']: 'value'
+  }
+
+  it('cannot be made to forge journal lines by an item carrying newlines', () => {
+    // #given three items whose values (and one key) carry every line-breaking
+    // character, plus text shaped like a complete journal entry and header
+    const store = createQueueStore<Record<string, string>>(filePath)
+    const items = [HOSTILE, { plain: 'ordinary' }, HOSTILE]
+    store.save([items[0]])
+    store.append(items[1], items.slice(0, 2))
+    store.append(items[2], items)
+
+    // #then the file is exactly one header line plus one line per item — the
+    // embedded newlines were escaped, not written raw
+    const raw = fs.readFileSync(filePath, 'utf-8')
+    expect(raw.split('\n')).toHaveLength(items.length + 2) // + header, + trailing ''
+    expect(raw.endsWith('\n')).toBe(true)
+
+    // #and every value survives byte-for-byte, forged lines included
+    const restored = createQueueStore<Record<string, string>>(filePath).load()
+    expect(restored).toEqual(items)
+    expect(restored[0].forgedLine).toBe(HOSTILE.forgedLine)
+    expect(restored[0]['key\nwith\nnewlines']).toBe('value')
+  })
+
   it('reads a mirror left by the previous format', () => {
     // #given a file written by the build that shipped before the journal
     fs.writeFileSync(filePath, JSON.stringify({ version: 1, items: [1, 2, 3] }))
@@ -118,5 +160,35 @@ describe('createQueueStore — incremental writes', () => {
     // #then durability is the only loss; nothing throws
     expect(() => store.append(1, [1])).not.toThrow()
     expect(() => store.save([1])).not.toThrow()
+  })
+
+  it('keeps working when the disk fails mid-session, after the journal started', () => {
+    // #given a healthy journal that then hits a full or read-only disk — the
+    // append path has its own failure handling, separate from the rewrite path
+    const store = createQueueStore<number>(filePath)
+    store.save([1])
+    vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {
+      throw new Error('ENOSPC')
+    })
+
+    // #when further items are recorded
+    // #then nothing throws and the already-journalled items are still readable
+    expect(() => store.append(2, [1, 2])).not.toThrow()
+    expect(() => store.append(3, [1, 2, 3])).not.toThrow()
+    vi.restoreAllMocks()
+    expect(createQueueStore<number>(filePath).load()).toEqual([1])
+  })
+
+  it.each([
+    ['a header that is not an object', '5\n'],
+    ['a v1 header whose items are not an array', '{"version":1,"items":"nope"}'],
+    ['a v2 header with no items yet', '{"version":2}']
+  ])('starts clean on %s', (_case, contents) => {
+    // #given a mirror this build cannot make sense of
+    fs.writeFileSync(filePath, contents)
+
+    // #when the next launch opens it
+    // #then it yields nothing rather than throwing or half-parsing
+    expect(createQueueStore<number>(filePath).load()).toEqual([])
   })
 })

--- a/apps/desktop/src/main/telemetry/queue-store.test.ts
+++ b/apps/desktop/src/main/telemetry/queue-store.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { createQueueStore } from './queue-store'
+
+describe('createQueueStore — incremental writes', () => {
+  let tempDir: string
+  let filePath: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-queue-store-'))
+    filePath = path.join(tempDir, 'queue.json')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  // fs.appendFileSync dispatches through fs.writeFileSync inside Node, so a spy
+  // on writeFileSync sees both paths. Byte volume is what separates them: an
+  // append costs one line, a rewrite costs the entire queue.
+  const bytesWrittenBy = (run: () => void): number => {
+    const write = vi.spyOn(fs, 'writeFileSync')
+    run()
+    const total = write.mock.calls.reduce((sum, call) => sum + String(call[1]).length, 0)
+    write.mockRestore()
+    return total
+  }
+
+  it('appends one line per item instead of rewriting the whole queue', () => {
+    // #given a store holding a queue at its limit — what an offline session looks
+    // like, where every extra item used to re-serialise all 500
+    const store = createQueueStore<number>(filePath)
+    const items = Array.from({ length: 500 }, (_, i) => i)
+    store.save(items)
+    const mirrorSize = fs.statSync(filePath).size
+    const appendLine = vi.spyOn(fs, 'appendFileSync')
+
+    // #when 200 more items are recorded
+    const written = bytesWrittenBy(() => {
+      for (let i = 500; i < 700; i++) {
+        items.push(i)
+        store.append(i, items)
+      }
+    })
+
+    // #then each cost a single appended line, and the whole burst wrote less than
+    // one copy of the queue — rewriting per item would have written ~200 copies
+    expect(appendLine).toHaveBeenCalledTimes(200)
+    expect(written).toBeLessThan(mirrorSize)
+
+    // #and the mirror still holds every item, in order
+    expect(createQueueStore<number>(filePath).load()).toEqual(items)
+  })
+
+  it('compacts once the journal outgrows its bound', () => {
+    // #given a session that queues far more than it ever holds: the queue trims
+    // from the head, which an append cannot express, so the journal keeps the
+    // dropped lines until it is worth rewriting
+    const store = createQueueStore<number>(filePath)
+    const queue: number[] = []
+    for (let i = 0; i <= 1000; i++) {
+      queue.push(i)
+      if (queue.length > 500) queue.shift()
+      store.append(i, queue)
+    }
+
+    // #then crossing the bound rewrote the file from the live queue instead of
+    // letting it grow one line per event for the life of the session
+    expect(createQueueStore<number>(filePath).load()).toEqual(queue)
+  })
+
+  it('never creates the file from an append, which would leave it headerless', () => {
+    // #given a store whose mirror does not exist yet
+    const store = createQueueStore<number>(filePath)
+
+    // #when the very first item is recorded
+    store.append(1, [1])
+
+    // #then the file is readable — an appended line with no header would parse as
+    // an unknown format and be thrown away on the next launch
+    expect(createQueueStore<number>(filePath).load()).toEqual([1])
+  })
+
+  it('reads a mirror left by the previous format', () => {
+    // #given a file written by the build that shipped before the journal
+    fs.writeFileSync(filePath, JSON.stringify({ version: 1, items: [1, 2, 3] }))
+
+    // #when this build opens it
+    const store = createQueueStore<number>(filePath)
+
+    // #then the upgrading install keeps what its last session queued, and the
+    // next write upgrades the file in place
+    expect(store.load()).toEqual([1, 2, 3])
+    store.append(4, [1, 2, 3, 4])
+    expect(createQueueStore<number>(filePath).load()).toEqual([1, 2, 3, 4])
+  })
+
+  it('drops a line the crash truncated instead of the whole journal', () => {
+    // #given a journal whose last append died half-written
+    const store = createQueueStore<number>(filePath)
+    store.save([1, 2])
+    fs.appendFileSync(filePath, '{"a":')
+
+    // #when the next launch opens it
+    // #then the complete lines survive and only the partial one is lost
+    expect(createQueueStore<number>(filePath).load()).toEqual([1, 2])
+  })
+
+  it('keeps working when the mirror cannot be written', () => {
+    // #given a path inside a directory that does not exist
+    const store = createQueueStore<number>(path.join(tempDir, 'missing', 'queue.json'))
+
+    // #when items are recorded
+    // #then durability is the only loss; nothing throws
+    expect(() => store.append(1, [1])).not.toThrow()
+    expect(() => store.save([1])).not.toThrow()
+  })
+})

--- a/apps/desktop/src/main/telemetry/queue-store.ts
+++ b/apps/desktop/src/main/telemetry/queue-store.ts
@@ -1,43 +1,119 @@
 // Crash-durable mirror for the in-memory telemetry queues. A hard crash (main-
 // process abort, OOM kill, force-quit) discards everything queued since the last
 // 30s flush — including the `app_crashed` event the launch just recorded, which
-// is exactly the evidence the crash marker exists to produce. The mirror is
-// rewritten on every enqueue, so the next launch drains what the dead process
-// left behind.
+// is exactly the evidence the crash marker exists to produce. Every enqueue
+// reaches disk, so the next launch drains what the dead process left behind.
 //
-// On-disk format is `{"version":1,"items":[...]}`. Builds older than this one
-// never read the file at all, so a newer build's mirror is inert for them; a
-// version this build does not recognise is discarded rather than parsed. Neither
-// direction can wedge startup.
+// On-disk format is a journal: a `{"version":2}` header line followed by one
+// JSON item per line. An enqueue appends its own line instead of re-serialising
+// the whole queue, which used to make each event cost O(queue) — brutal when the
+// endpoint is unreachable and the queue sits pegged at its 500-item limit. The
+// file is compacted (rewritten) on drains, trims, and once the journal has grown
+// well past the queue limit, so it stays bounded.
+//
+// Version handling. `{"version":1,"items":[...]}` is the previous format and is
+// still READ, so an upgrading install keeps whatever its last session queued;
+// the next write upgrades the file in place. Builds older than the mirror never
+// read the file at all, and the v1 reader rejects a v2 journal as unparseable
+// and discards it, so a downgrade loses one session's queue rather than wedging
+// startup. A version this build does not recognise is discarded, never parsed.
 import fs from 'node:fs'
 
 import { createLogger } from '../lib/logger'
 
 const logger = createLogger('TelemetryQueueStore')
 
-const FORMAT_VERSION = 1
+const LEGACY_FORMAT_VERSION = 1
+const FORMAT_VERSION = 2
+
+// Trimming drops from the head, which an append-only journal cannot express, so
+// the file is allowed to hold trimmed-away items until it is worth rewriting.
+// Both queues cap at 500, so this compacts roughly once per 500 enqueues and the
+// restored set is at most this long before the caller trims it back down.
+const COMPACT_AFTER_LINES = 1000
 
 export interface QueueStore<T> {
   /** Items left behind by the previous process. Never throws; `[]` on any fault. */
   load(): T[]
-  /** Rewrite the mirror. Never throws — a full or read-only disk must not break logging. */
+  /**
+   * Record one newly enqueued item as a single appended line. `currentItems` is
+   * only read on the compaction pass, when the journal is rewritten from it.
+   * Never throws — a full or read-only disk must not break logging.
+   */
+  append(item: T, currentItems: readonly T[]): void
+  /** Rewrite the mirror from `items` (drain, trim). Never throws. */
   save(items: readonly T[]): void
   /** Remove the mirror (clean drain, or telemetry turned off). */
   clear(): void
 }
 
 export const createQueueStore = <T>(filePath: string): QueueStore<T> => {
-  // save() runs on every enqueue, so a persistently unwritable disk would log
+  // Writes run on every enqueue, so a persistently unwritable disk would log
   // once per line without this latch.
   let writeFailureLogged = false
+  // False until this process has written a header, so an append can never be the
+  // call that creates the file — a headerless journal reads back as garbage.
+  let journalStarted = false
+  let journalLines = 0
+
+  const encodeItem = (item: T): string => `${JSON.stringify(item)}\n`
+
+  const onWriteFailure = (error: unknown): void => {
+    if (writeFailureLogged) return
+    writeFailureLogged = true
+    logger.warn('Failed to persist telemetry queue; a crash would lose it', { error })
+  }
 
   const clear = (): void => {
+    journalStarted = false
+    journalLines = 0
     try {
       fs.rmSync(filePath, { force: true })
     } catch {
       // Best effort: a stale mirror is drained-and-overwritten, never replayed
       // twice, because load() is only called once per queue.
     }
+  }
+
+  const save = (items: readonly T[]): void => {
+    const header = `${JSON.stringify({ version: FORMAT_VERSION })}\n`
+    try {
+      fs.writeFileSync(filePath, header + items.map(encodeItem).join(''), 'utf-8')
+      journalStarted = true
+      journalLines = items.length
+      writeFailureLogged = false
+    } catch (error) {
+      onWriteFailure(error)
+    }
+  }
+
+  const parse = (raw: string): T[] | null => {
+    const firstBreak = raw.indexOf('\n')
+    const headerLine = firstBreak === -1 ? raw : raw.slice(0, firstBreak)
+    let header: { version?: unknown; items?: unknown }
+    try {
+      header = JSON.parse(headerLine) as { version?: unknown; items?: unknown }
+    } catch {
+      return null
+    }
+    if (!header || typeof header !== 'object') return null
+    if (header.version === LEGACY_FORMAT_VERSION) {
+      return Array.isArray(header.items) ? (header.items as T[]) : null
+    }
+    if (header.version !== FORMAT_VERSION) return null
+
+    const items: T[] = []
+    if (firstBreak === -1) return items
+    for (const line of raw.slice(firstBreak + 1).split('\n')) {
+      if (line.length === 0) continue
+      try {
+        items.push(JSON.parse(line) as T)
+      } catch {
+        // Only the tail can be half-written: the crash this mirror exists for
+        // can land mid-append. Drop the partial line, keep the rest.
+      }
+    }
+    return items
   }
 
   return {
@@ -48,31 +124,30 @@ export const createQueueStore = <T>(filePath: string): QueueStore<T> => {
       } catch {
         return [] // no mirror: the previous session drained cleanly, or first launch
       }
-      try {
-        const parsed = JSON.parse(raw) as { version?: unknown; items?: unknown }
-        if (parsed && parsed.version === FORMAT_VERSION && Array.isArray(parsed.items)) {
-          return parsed.items as T[]
-        }
-      } catch {
-        // fall through to the discard path
-      }
+      const items = parse(raw)
+      if (items) return items
       // Truncated by the very crash it was written to survive, or written by a
       // format this build does not know. Startup must never depend on it.
       logger.warn('Discarding unreadable telemetry queue mirror')
       clear()
       return []
     },
-    save: (items) => {
+    append: (item, currentItems) => {
+      // No header yet (fresh session, or a file this process has not written),
+      // or the journal has outgrown its bound — either way, rewrite it whole.
+      if (!journalStarted || journalLines >= COMPACT_AFTER_LINES) {
+        save(currentItems)
+        return
+      }
       try {
-        fs.writeFileSync(filePath, JSON.stringify({ version: FORMAT_VERSION, items }), 'utf-8')
+        fs.appendFileSync(filePath, encodeItem(item), 'utf-8')
+        journalLines += 1
         writeFailureLogged = false
       } catch (error) {
-        if (!writeFailureLogged) {
-          writeFailureLogged = true
-          logger.warn('Failed to persist telemetry queue; a crash would lose it', { error })
-        }
+        onWriteFailure(error)
       }
     },
+    save,
     clear
   }
 }

--- a/apps/desktop/src/main/telemetry/ship-queue.test.ts
+++ b/apps/desktop/src/main/telemetry/ship-queue.test.ts
@@ -121,10 +121,8 @@ describe('createShipQueue — crash durability', () => {
     // #then the oldest are dropped, and the trim is written back so they do not
     // return on the launch after this one
     expect(q.depth()).toBe(3)
-    expect(JSON.parse(fs.readFileSync(persistPath, 'utf-8'))).toEqual({
-      version: 1,
-      items: [5, 6, 7]
-    })
+    expect(makeDurable(okFetch, 3).depth()).toBe(3)
+    expect(fs.readFileSync(persistPath, 'utf-8')).toBe('{"version":2}\n5\n6\n7\n')
   })
 
   it('starts clean when the mirror is corrupt instead of blocking startup', () => {

--- a/apps/desktop/src/main/telemetry/ship-queue.ts
+++ b/apps/desktop/src/main/telemetry/ship-queue.ts
@@ -15,9 +15,9 @@ export interface ShipQueueDeps<T> {
   batchLimit?: number
   /**
    * Absolute path of the crash-durable mirror. Set → the queue restores whatever
-   * the previous process left behind and rewrites the file on every enqueue and
-   * flush, so a hard crash no longer discards the last 30s of evidence. Omitted
-   * (tests, callers that do not want on-disk state) → memory only, as before.
+   * the previous process left behind and journals every enqueue and flush, so a
+   * hard crash no longer discards the last 30s of evidence. Omitted (tests,
+   * callers that do not want on-disk state) → memory only, as before.
    */
   persistPath?: string
 }
@@ -52,6 +52,12 @@ export const createShipQueue = <T>(deps: ShipQueueDeps<T>): ShipQueue<T> => {
     store?.save(queue)
   }
 
+  // The enqueue path appends one line rather than rewriting the mirror, so a
+  // queued log line costs the same whether the queue holds 1 line or 500.
+  const persistAppend = (item: T): void => {
+    store?.append(item, queue)
+  }
+
   // The restored set is bounded by the SAME limit as a live one, so a mirror
   // written by a build with a larger queueLimit cannot resurrect an unbounded
   // queue. Rewrite immediately, otherwise the dropped head returns next launch.
@@ -64,7 +70,7 @@ export const createShipQueue = <T>(deps: ShipQueueDeps<T>): ShipQueue<T> => {
     if (!enabled) return
     queue.push(item)
     trimQueue()
-    persist()
+    persistAppend(item)
   }
 
   const flush = async (): Promise<ShipQueueFlushResult> => {

--- a/apps/docs/src/architecture/observability.md
+++ b/apps/docs/src/architecture/observability.md
@@ -235,15 +235,22 @@ otherwise take the crash report with it, which is why both queues mirror to `use
 | Event queue (`telemetry/client.ts`)        | `telemetry-event-queue.json` | `app_crashed`, `app_error_seen`, all events |
 | Log-ship queue (`telemetry/ship-queue.ts`) | `telemetry-log-queue.json`   | Path A redacted `warn`/`error` log lines    |
 
-The mirror is rewritten on every enqueue and after every flush, so what is on disk is what has not
-yet been accepted by the server. The next launch restores it and drains it; a drained batch is
-removed from the mirror, so nothing is sent twice.
+Every enqueue reaches disk before it returns, and the mirror is rewritten after every flush, so what
+is on disk is what has not yet been accepted by the server. The next launch restores it and drains
+it; a drained batch is removed from the mirror, so nothing is sent twice.
 
 Rules the mirror follows:
 
-- **Format** is `{"version":1,"items":[…]}`. A file whose version this build does not recognise is
-  discarded rather than parsed, and builds that predate the mirror never read it at all — so
-  neither a downgrade nor a future format bump can wedge startup.
+- **Format** is a journal: a `{"version":2}` header line followed by one JSON item per line. An
+  enqueue appends its own line rather than re-serialising the queue, which otherwise made each
+  event cost a full rewrite of up to 500 objects — worst exactly during the error bursts and
+  offline sessions that keep the queue pegged at its limit. The file is rewritten (compacted) on
+  drains, on trims, and once the journal outgrows its bound, so it stays bounded.
+- **Format changes cannot wedge startup.** The previous `{"version":1,"items":[…]}` format is still
+  read, so an upgrading install keeps whatever its last session queued. A file whose version this
+  build does not recognise is discarded rather than parsed, builds that predate the mirror never
+  read it at all, and a build that predates the journal sees it as unparseable and discards it —
+  so a downgrade costs one session's queue, never the launch.
 - **Corruption is expected.** The mirror is most likely to be truncated by exactly the crash it was
   written to survive, so an unparseable file is logged, deleted, and treated as empty.
 - **Write failures are non-fatal.** A read-only or full disk costs durability, never logging or


### PR DESCRIPTION
Fixes #988

## Verification — the issue was still real

`apps/desktop/src/main/telemetry/queue-store.ts:65-75` on `main` @ `27bc2b96`:

```ts
save: (items) => {
  try {
    fs.writeFileSync(filePath, JSON.stringify({ version: FORMAT_VERSION, items }), 'utf-8')
```

`save(queue)` was called with the **whole** queue from `client.ts:117` (`track` → `persist()`) and
`ship-queue.ts:67` (`enqueue` → `persist()`) — i.e. on every `trackMainEvent` / `trackMainLog` /
`trackMainError` and every `>= warn` log line. With `TELEMETRY_QUEUE_LIMIT = 500` and a 50-item
drain per 30s flush, an unreachable endpoint pegs the queue at 500 and each further event
re-serialises and sync-writes all 500 objects on the main thread.

Measured on the branch by mutating the fix back to the old behaviour: a 100-event burst on a full
queue wrote **8,051,400 bytes** instead of **80,514** — a 100× amplification that grows with queue
depth.

## Change

The mirror is now an append-only journal instead of a full-file rewrite:

- `queue-store.ts` — on-disk format is a `{"version":2}` header line plus one JSON item per line.
  New `append(item, currentItems)` writes a single line via `fs.appendFileSync`; `save(items)` is
  unchanged in role (full rewrite) and is now the compaction path.
- `client.ts` / `ship-queue.ts` — only the enqueue path changes (`persist()` → `persistAppend()`).
  Drains, trims and opt-out still go through `save()` / `clear()`.

Why not debounce (the issue's first suggestion): the mirror exists so a hard crash cannot take
`app_crashed` with it. Deferring the write would reintroduce exactly the loss window the file was
added to close. The journal keeps **every enqueue on disk before it returns** and still makes the
write O(1) in queue depth.

Compaction: trimming drops from the head, which an append cannot express, so the journal is allowed
to carry trimmed-away lines until it passes `COMPACT_AFTER_LINES = 1000` (2× both queue limits), at
which point it is rewritten from the live queue. Callers already trim the restored set, so an
over-long journal is bounded on load as well.

### Backward compatibility

- **Upgrade:** `{"version":1,"items":[…]}` is still read, so an install upgrading from the shipped
  build keeps whatever its last session queued. The next write upgrades the file in place.
- **Downgrade:** the v1 reader `JSON.parse`s the whole file, fails on a multi-line journal, and takes
  its existing "unreadable mirror → warn, delete, treat as empty" path. Costs one session's queued
  telemetry, cannot wedge startup.
- Unknown versions are still discarded rather than parsed. A crash-truncated tail line is dropped
  rather than the whole journal.

## Tests

New `apps/desktop/src/main/telemetry/queue-store.test.ts` (7 tests) plus one test added to
`client.test.ts`. `ship-queue.test.ts` has one assertion updated from the raw v1 shape to the v2
shape (plus a behavioural restore check).

Note: `fs.appendFileSync` dispatches through `fs.writeFileSync` inside Node, so call counts cannot
separate the two paths — the tests assert **byte volume** and observable restore behaviour instead.

Red → green:

- Before the fix, `client.test.ts > does not rewrite the whole mirror once per tracked event`:
  `AssertionError: expected "writeFileSync" to be called +0 times, but got 100 times`
- After: `PASS (140) FAIL (0)` across `src/main/telemetry`.

Mutation-tested (reverted `persistAppend(event)` → `persist()` and dropped the compaction bound):

```
PASS (138) FAIL (2)
1. does not rewrite the whole mirror once per tracked event
   AssertionError: expected 8051400 to be less than 80514
2. compacts once the journal outgrows its bound
   AssertionError: expected [ +0, 1, 2, … ] to deeply equal [ Array(500) ]
```

Both went green again on restore, so neither test is vacuous.

## Checks

| Check | Result |
| --- | --- |
| `pnpm --filter @memry/desktop typecheck` | pass (contracts + architecture + ipc:check + node + web) |
| `pnpm lint` | pass — 0 errors, 14 pre-existing warnings, none in touched files |
| `vitest --project main` (full) | `PASS (5424) FAIL (0) skipped (4)` |
| `pnpm docs:impact --base origin/main --strict` | pass |
| `pnpm docs:build` | pass |

`apps/docs/src/architecture/observability.md` documented the old `{"version":1,"items":[…]}` format
verbatim, so it is updated in the same branch.
