### PR TITLE
perf(projections): stream reconcileMissingFiles off the main thread

### DIFF
--- a/apps/desktop/src/main/database/queries/notes/index.ts
+++ b/apps/desktop/src/main/database/queries/notes/index.ts
@@ -7,13 +7,15 @@ export {
   noteCacheExists,
   getLocalOnlyCount,
   listNotesFromCache,
+  listNoteCacheFilesAfter,
   countNotes,
   bulkInsertNotes,
   clearNoteCache,
   getAllNoteIds,
   getAllCrdtNoteIds,
   getNotesModifiedAfter,
-  type ListNotesOptions
+  type ListNotesOptions,
+  type NoteCacheFileRow
 } from './note-crud'
 
 export {

--- a/apps/desktop/src/main/database/queries/notes/note-crud.ts
+++ b/apps/desktop/src/main/database/queries/notes/note-crud.ts
@@ -1,4 +1,4 @@
-import { eq, desc, asc, and, like, inArray, sql, count, type SQL } from 'drizzle-orm'
+import { eq, desc, asc, and, gt, like, inArray, sql, count, type SQL } from 'drizzle-orm'
 import {
   noteCache,
   noteTags,
@@ -140,6 +140,35 @@ export function listNotesFromCache(db: IndexDb, options: ListNotesOptions = {}):
   }
 
   return query.orderBy(orderFn(sortColumn)).limit(limit).offset(offset).all()
+}
+
+export interface NoteCacheFileRow {
+  id: string
+  path: string
+  indexedAt: string
+}
+
+/**
+ * Cursor-paged `id`/`path` scan over the same rows `listNotesFromCache` walks
+ * (journal entries carry a date and stay out of it).
+ *
+ * Keyset on the primary key instead of LIMIT/OFFSET: the reconcile pass deletes
+ * rows while it walks, and an offset window silently skips a row for every one
+ * removed behind it. `indexedAt` rides along so a caller that leaves the pass to
+ * do async work can tell whether the row it read was rewritten in the meantime.
+ */
+export function listNoteCacheFilesAfter(
+  db: IndexDb,
+  afterId: string,
+  limit: number
+): NoteCacheFileRow[] {
+  return db
+    .select({ id: noteCache.id, path: noteCache.path, indexedAt: noteCache.indexedAt })
+    .from(noteCache)
+    .where(and(sql`${noteCache.date} IS NULL`, gt(noteCache.id, afterId)))
+    .orderBy(asc(noteCache.id))
+    .limit(limit)
+    .all()
 }
 
 export function countNotes(db: IndexDb, folder?: string): number {

--- a/apps/desktop/src/main/projections/projectors/note-derived-state-projector.test.ts
+++ b/apps/desktop/src/main/projections/projectors/note-derived-state-projector.test.ts
@@ -85,6 +85,107 @@ describe('note derived state projector', () => {
     expect(cached).toEqual(expect.objectContaining({ id: 'present-note', path: relativePath }))
   })
 
+  it('reconcile yields to the event loop instead of running the whole pass in one turn', async () => {
+    for (let i = 0; i < 20; i++) {
+      const relativePath = `notes/present-${i}.md`
+      const absolutePath = path.join(vaultDir, relativePath)
+      fs.mkdirSync(path.dirname(absolutePath), { recursive: true })
+      fs.writeFileSync(absolutePath, '# Present\n', 'utf8')
+      seedCachedNote(`present-${i}`, relativePath)
+    }
+
+    const projector = createNoteDerivedStateProjector(() => vaultDir)
+
+    let settled = false
+    const pending = Promise.resolve(projector.reconcile()).then(() => {
+      settled = true
+    })
+
+    // Three microtask ticks. A pass that stats synchronously has already
+    // finished by now; one that awaits real file I/O cannot have.
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(settled).toBe(false)
+
+    await pending
+  })
+
+  it('reconcile keeps a cached note when the file check fails for a reason other than ENOENT', async () => {
+    seedCachedNote('unreadable-note', 'notes/unreadable.md')
+
+    const permissionError = Object.assign(new Error('EACCES: permission denied'), {
+      code: 'EACCES'
+    })
+    const statSpy = vi.spyOn(fs.promises, 'stat').mockRejectedValue(permissionError)
+
+    try {
+      const projector = createNoteDerivedStateProjector(() => vaultDir)
+      await projector.reconcile()
+    } finally {
+      statSpy.mockRestore()
+    }
+
+    const cached = indexDb.db
+      .select()
+      .from(noteCache)
+      .where(eq(noteCache.id, 'unreadable-note'))
+      .get()
+
+    expect(cached).toBeDefined()
+  })
+
+  it('reconcile stops deleting when the index database is swapped mid-pass', async () => {
+    seedCachedNote('missing-note', 'notes/missing.md')
+
+    const otherIndexDb = createTestIndexDb()
+    const statSpy = vi.spyOn(fs.promises, 'stat').mockImplementation(async () => {
+      // A vault switch lands between reading the ids and applying the deletes.
+      getIndexDatabase.mockReturnValue(otherIndexDb.db)
+      throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+    })
+
+    try {
+      const projector = createNoteDerivedStateProjector(() => vaultDir)
+      await projector.reconcile()
+    } finally {
+      statSpy.mockRestore()
+      getIndexDatabase.mockReturnValue(indexDb.db)
+      otherIndexDb.close()
+    }
+
+    const cached = indexDb.db.select().from(noteCache).where(eq(noteCache.id, 'missing-note')).get()
+
+    expect(cached).toBeDefined()
+  })
+
+  it('reconcile leaves a note alone when its cache row moved while the old path was checked', async () => {
+    seedCachedNote('renamed-note', 'notes/old-name.md')
+
+    const statSpy = vi.spyOn(fs.promises, 'stat').mockImplementation(async () => {
+      // The note is renamed on disk (and reindexed) while the old path is checked.
+      const movedPath = path.join(vaultDir, 'notes/new-name.md')
+      fs.mkdirSync(path.dirname(movedPath), { recursive: true })
+      fs.writeFileSync(movedPath, '# Renamed\n', 'utf8')
+      indexDb.db.run(
+        sql`UPDATE note_cache SET path = ${'notes/new-name.md'}, indexed_at = ${'2026-02-02T00:00:00.000Z'} WHERE id = ${'renamed-note'}`
+      )
+      throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+    })
+
+    try {
+      const projector = createNoteDerivedStateProjector(() => vaultDir)
+      await projector.reconcile()
+    } finally {
+      statSpy.mockRestore()
+    }
+
+    const cached = indexDb.db.select().from(noteCache).where(eq(noteCache.id, 'renamed-note')).get()
+
+    expect(cached).toEqual(expect.objectContaining({ path: 'notes/new-name.md' }))
+  })
+
   it('project clears stale outbound links when a note no longer contains wiki links', async () => {
     seedCachedNote('source-note', 'notes/source.md')
     indexDb.db.run(sql`

--- a/apps/desktop/src/main/projections/projectors/note-derived-state-projector.ts
+++ b/apps/desktop/src/main/projections/projectors/note-derived-state-projector.ts
@@ -8,18 +8,26 @@ import {
   getNoteCacheById,
   getPropertyType,
   insertNoteCache,
-  listNotesFromCache,
+  listNoteCacheFilesAfter,
   resolveNotesByTitles,
   setNoteLinks,
   setNoteProperties,
   setNoteTags,
-  updateNoteCache
+  updateNoteCache,
+  type NoteCacheFileRow
 } from '@main/database/queries/notes'
-import { getIndexDatabase } from '../../database'
+import { getIndexDatabase, type IndexDb } from '../../database'
 import { inferPropertyType } from '../../vault/frontmatter'
 import type { NoteProjectionRecord, ProjectionEvent, ProjectionProjector } from '../types'
 
 const logger = createLogger('Projections:NoteState')
+
+// Rows read per keyset page, and how many `stat` calls are in flight at once.
+// The pass used to load every note in one query and walk it with `fs.existsSync`,
+// which parked the Electron main thread for thousands of blocking syscalls on
+// every vault open.
+const RECONCILE_PAGE_SIZE = 500
+const RECONCILE_STAT_CONCURRENCY = 8
 
 function persistMarkdownNote(note: Extract<NoteProjectionRecord, { kind: 'markdown' }>): void {
   const db = getIndexDatabase()
@@ -102,36 +110,109 @@ function persistFileNote(note: Extract<NoteProjectionRecord, { kind: 'file' }>):
   })
 }
 
-function deleteNote(noteId: string): void {
-  const db = getIndexDatabase()
+function deleteNote(db: IndexDb, noteId: string): void {
   deleteLinksToNote(db, noteId)
   deleteNoteCache(db, noteId)
 }
 
-function reconcileMissingFiles(): void {
-  const db = getIndexDatabase()
-  const cachedNotes = listNotesFromCache(db, { limit: 100000 })
-  const vaultPath = currentVaultPathProvider?.()
+/**
+ * Only ENOENT/ENOTDIR mean the file is genuinely gone. Every other failure
+ * (EACCES, EIO, EBUSY, a timeout on a network volume) leaves the note alone:
+ * `fs.existsSync` folded all of those into `false` and dropped the cache row for
+ * a file that is still on disk.
+ */
+async function isFileMissing(absolutePath: string): Promise<boolean> {
+  try {
+    await fs.promises.stat(absolutePath)
+    return false
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return true
+    }
+
+    logger.warn('Keeping cached note: file check failed', { path: absolutePath, code })
+    return false
+  }
+}
+
+/**
+ * The pass yields between pages now, so a vault switch or close can land in the
+ * middle of it. The handle is read once and re-checked against the live one
+ * before any write: ids read out of one vault's index must never be deleted from
+ * another's.
+ */
+function isCurrentIndexDatabase(db: IndexDb): boolean {
+  try {
+    return getIndexDatabase() === db
+  } catch {
+    return false
+  }
+}
+
+async function reconcileMissingFiles(getVaultPath: () => string | null): Promise<void> {
+  const vaultPath = getVaultPath()
 
   if (!vaultPath) {
     return
   }
 
-  for (const cached of cachedNotes) {
-    const absolutePath = path.join(vaultPath, cached.path)
-    if (!fs.existsSync(absolutePath)) {
-      deleteNote(cached.id)
+  const db = getIndexDatabase()
+  let afterId = ''
+
+  for (;;) {
+    if (!isCurrentIndexDatabase(db)) {
+      logger.debug?.('Stopping note reconcile: index database changed')
+      return
+    }
+
+    const page = listNoteCacheFilesAfter(db, afterId, RECONCILE_PAGE_SIZE)
+    if (page.length === 0) {
+      return
+    }
+
+    afterId = page[page.length - 1].id
+
+    const absent: NoteCacheFileRow[] = []
+    for (let i = 0; i < page.length; i += RECONCILE_STAT_CONCURRENCY) {
+      const batch = page.slice(i, i + RECONCILE_STAT_CONCURRENCY)
+      const results = await Promise.all(
+        batch.map((row) => isFileMissing(path.join(vaultPath, row.path)))
+      )
+      results.forEach((missing, index) => {
+        if (missing) {
+          absent.push(batch[index])
+        }
+      })
+    }
+
+    if (absent.length === 0) {
+      continue
+    }
+
+    if (!isCurrentIndexDatabase(db)) {
+      logger.debug?.('Stopping note reconcile: index database changed')
+      return
+    }
+
+    // Re-read and delete in one synchronous turn, so nothing can interleave
+    // between the check and the write. A row whose path or indexedAt moved while
+    // its old path was being stat'd was rewritten by a rename or a re-index —
+    // the file it points at now was never checked, so it is left alone.
+    for (const row of absent) {
+      const current = getNoteCacheById(db, row.id)
+      if (!current || current.path !== row.path || current.indexedAt !== row.indexedAt) {
+        continue
+      }
+
+      deleteNote(db, row.id)
     }
   }
 }
 
-let currentVaultPathProvider: (() => string | null) | null = null
-
 export function createNoteDerivedStateProjector(
   getVaultPath: () => string | null
 ): ProjectionProjector {
-  currentVaultPathProvider = getVaultPath
-
   return {
     name: 'note-derived-state',
     handles(event: ProjectionEvent): boolean {
@@ -140,7 +221,7 @@ export function createNoteDerivedStateProjector(
 
     async project(event: ProjectionEvent): Promise<void> {
       if (event.type === 'note.deleted') {
-        deleteNote(event.noteId)
+        deleteNote(getIndexDatabase(), event.noteId)
         return
       }
 
@@ -159,11 +240,11 @@ export function createNoteDerivedStateProjector(
     },
 
     async rebuild(): Promise<void> {
-      reconcileMissingFiles()
+      await reconcileMissingFiles(getVaultPath)
     },
 
     async reconcile(): Promise<void> {
-      reconcileMissingFiles()
+      await reconcileMissingFiles(getVaultPath)
       logger.debug?.('Reconciled note-derived state')
     }
   }


### PR DESCRIPTION
Fixes #994

## Verification (issue still real on current `main`)

`apps/desktop/src/main/projections/projectors/note-derived-state-projector.ts:111-126` on `main` @ `cd3c82e0a`:

```ts
function reconcileMissingFiles(): void {
  const db = getIndexDatabase()
  const cachedNotes = listNotesFromCache(db, { limit: 100000 })
  ...
  for (const cached of cachedNotes) {
    const absolutePath = path.join(vaultPath, cached.path)
    if (!fs.existsSync(absolutePath)) {
      deleteNote(cached.id)
    }
  }
}
```

`fs` is the sync import at line 1. Both `rebuild()` (161) and `reconcile()` (165) call it, and `reconcile()` runs on every vault open (`apps/desktop/src/main/vault/index.ts:407`). One 100k-row query plus a blocking `stat` per note on the Electron main thread.

## Change

`note-derived-state-projector.ts`
- `reconcileMissingFiles` walks the cache in keyset-paged batches of 500 and stats with `fs.promises.stat` at a concurrency of 8. The `await` between batches hands the loop back to the event loop, so IPC is serviced throughout.
- Reads `id`/`path`/`indexedAt` instead of ~17 full columns per row.
- `deleteNote` takes the index handle instead of re-resolving it.
- Drops the `currentVaultPathProvider` module global (the pass now uses the projector's own `getVaultPath` closure); it had no other reader.

`database/queries/notes/note-crud.ts`
- New `listNoteCacheFilesAfter(db, afterId, limit)`: keyset page on the primary key, same `date IS NULL` row set `listNotesFromCache` walks, so journal entries stay out of the pass exactly as before.

### Correctness — this pass decides deletions, so every new async gap is closed

The pass used to be one uninterruptible synchronous block. Making it yield opens four windows; each is guarded, and each guard has its own test that goes red when only that guard is removed:

1. **Slow / flaky disk.** Only `ENOENT` and `ENOTDIR` count as missing. `fs.existsSync` returned `false` for `EACCES`, `EIO`, `EBUSY` and network-volume timeouts too, and deleted the row for a file that was still on disk. This is strictly safer than the old behavior.
2. **Vault switch or close mid-run.** The index handle is read once and re-checked against the live one before any write. Ids read out of one vault's index can never be deleted from another's, and a superseded pass stops instead of writing.
3. **Row moved while its old path was being stat'd.** Each candidate is re-read and compared on `path` + `indexedAt` immediately before its delete, in the same synchronous turn (no `await` between check and write, so nothing can interleave). A row rewritten by a rename or a re-index is left alone — the file it points at now was never checked.
4. **Rows shifting under pagination.** Keyset on the primary key, not `LIMIT`/`OFFSET`: an offset window silently skips a row for every one the pass deletes behind it.

Aborted run: the pass has no destructive intermediate state — it only deletes, one confirmed row at a time. Stopping anywhere leaves stale rows that the next reconcile removes; it can never leave a live note deleted.

## Tests

`note-derived-state-projector.test.ts`, four added cases. Red before the fix:

```
FAIL > reconcile yields to the event loop instead of running the whole pass in one turn
  AssertionError: expected true to be false
FAIL > reconcile keeps a cached note when the file check fails for a reason other than ENOENT
  AssertionError: expected undefined to be defined
FAIL > reconcile stops deleting when the index database is swapped mid-pass
  AssertionError: expected undefined to be defined
FAIL > reconcile leaves a note alone when its cache row moved while the old path was checked
  AssertionError: expected undefined to deeply equal ObjectContaining{ "path": "notes/new-name.md" }

Test Files  1 failed | 474 passed | 1 skipped (476)
Tests  4 failed | 5416 passed
```

Green after: `PASS (7) FAIL (0)` for the file.

Mutation-tested — each guard removed on its own turns exactly one test red:

| mutation | result |
| --- | --- |
| treat every `stat` error as missing | `PASS (6) FAIL (1)` — ENOENT-only test |
| drop the pre-delete index-handle check | `PASS (6) FAIL (1)` — vault-switch test |
| drop the `path`/`indexedAt` re-read | `PASS (6) FAIL (1)` — renamed-row test |
| the sync `existsSync` pass itself (pre-fix run above) | yield test red |

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts, architecture, rpc, ipc map, node, web).
- `pnpm lint` — 0 errors, 14 warnings, all pre-existing in unrelated renderer files (`tags-hub/*`, `use-folder-view.ts`, `use-tab-keyboard-shortcuts.ts`); none in the files touched here.
- `pnpm --filter @memry/desktop test:main` — `475 passed | 1 skipped (476)` files, `5420 passed` tests.
- `git diff --check` clean, prettier clean.
- Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: internal index-reconcile mechanics only, no user-visible surface, setting, IPC contract, schema or file format change.
