### PR TITLE
perf(secrets): latch the completed keytar migration per secret

### DIFF
--- a/apps/desktop/src/main/secrets/secret-storage-callsites.test.ts
+++ b/apps/desktop/src/main/secrets/secret-storage-callsites.test.ts
@@ -221,6 +221,23 @@ describe('secret-storage call sites — account string preservation and migratio
       expect(harness.keytarStore.has(`${MASTER.service}:${MASTER.account}`)).toBe(false)
     })
 
+    it('stops paying the OS keychain round-trip on repeat vault-key fetches', async () => {
+      const db = freshDb()
+      const masterKey = sodium.randombytes_buf(32)
+      harness.keytarStore.set(`${MASTER.service}:${MASTER.account}`, toB64(masterKey))
+
+      const first = await getOrInitializeLocalVaultKey(db, 'vault-1')
+
+      harness.keytarGet.mockClear()
+      for (let i = 0; i < 10; i += 1) {
+        // Same key every time — the latch only skips work that is provably a
+        // no-op, it never changes what the fetch returns.
+        await expect(getOrInitializeLocalVaultKey(db, 'vault-1')).resolves.toEqual(first)
+      }
+
+      expect(harness.keytarGet).not.toHaveBeenCalled()
+    })
+
     it('keeps the keytar master key when the vault verifier rejects it', async () => {
       const db = freshDb()
       const boundKey = sodium.randombytes_buf(32)

--- a/apps/desktop/src/main/secrets/secret-storage.test.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.test.ts
@@ -370,6 +370,88 @@ describe('secret-storage', () => {
     })
   })
 
+  describe('finalize latch', () => {
+    it('stops re-reading the store and the OS keychain once the copy is gone', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'master-key-material')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'master-key-material')
+
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+      expect(harness.keytarDelete).toHaveBeenCalledTimes(1)
+
+      vi.clearAllMocks()
+      const readSpy = vi.spyOn(fs, 'readFileSync')
+      try {
+        for (let i = 0; i < 5; i += 1) await finalizeKeytarMigration(SERVICE, ACCOUNT)
+        expect(harness.keytarGet).not.toHaveBeenCalled()
+        expect(readSpy).not.toHaveBeenCalled()
+      } finally {
+        readSpy.mockRestore()
+      }
+    })
+
+    it('latches after a run that finds no OS keychain copy at all', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'master-key-material')
+
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+      expect(harness.keytarGet).toHaveBeenCalledTimes(1)
+
+      vi.clearAllMocks()
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+      expect(harness.keytarGet).not.toHaveBeenCalled()
+    })
+
+    it('keeps retrying while a mismatched keytar copy is still there', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'store-value')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'different-value')
+
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+
+      vi.clearAllMocks()
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+      expect(harness.keytarGet).toHaveBeenCalledTimes(1)
+      expect(harness.keytarDelete).not.toHaveBeenCalled()
+    })
+
+    it('never latches a missing store entry, so a later migration still runs', async () => {
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+
+      seedStoreFile(SERVICE, ACCOUNT, 'master-key-material')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'master-key-material')
+
+      vi.clearAllMocks()
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+      expect(harness.keytarDelete).toHaveBeenCalledWith(SERVICE, ACCOUNT)
+    })
+
+    it('re-arms after the secret is rewritten (rotation / re-provision)', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'v1')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'v1')
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+
+      await setSecret(SERVICE, ACCOUNT, 'v2')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'v2')
+
+      vi.clearAllMocks()
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+      expect(harness.keytarDelete).toHaveBeenCalledWith(SERVICE, ACCOUNT)
+    })
+
+    it('re-arms after the secret is deleted (sign-out)', async () => {
+      seedStoreFile(SERVICE, ACCOUNT, 'v1')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'v1')
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+
+      await deleteSecret(SERVICE, ACCOUNT)
+
+      seedStoreFile(SERVICE, ACCOUNT, 'v2')
+      harness.keytarStore.set(`${SERVICE}:${ACCOUNT}`, 'v2')
+
+      vi.clearAllMocks()
+      await finalizeKeytarMigration(SERVICE, ACCOUNT)
+      expect(harness.keytarDelete).toHaveBeenCalledWith(SERVICE, ACCOUNT)
+    })
+  })
+
   // --------------------------------------------------------------------------
   // Writes
   // --------------------------------------------------------------------------

--- a/apps/desktop/src/main/secrets/secret-storage.ts
+++ b/apps/desktop/src/main/secrets/secret-storage.ts
@@ -32,6 +32,16 @@ export interface GetSecretOptions {
 // delete never ran) is attempted at most once per secret per process run.
 const keytarCleanupAttempted = new Set<string>()
 
+// Secrets whose deferred keytar migration this run has already PROVEN complete
+// — the OS keychain holds no copy of them any more. The master key is finalized
+// on every vault-key fetch (getOrInitializeLocalVaultKey), which sync calls per
+// CRDT update batch and per pulled note, so without this latch the steady state
+// repeats a store read + safeStorage decrypt + OS keychain round-trip hundreds
+// of times an hour only to find nothing left to delete. Entries are added only
+// once the keytar copy is known gone, and dropped whenever the secret is
+// written or deleted, so a re-created keytar copy is still migrated.
+const keytarMigrationFinalized = new Set<string>()
+
 let loggedPlaintextBackend = false
 
 const cleanupKey = (service: string, account: string): string => `${service}\u0000${account}`
@@ -39,6 +49,7 @@ const cleanupKey = (service: string, account: string): string => `${service}\u00
 /** Test-only: reset per-run module state between test cases. */
 export function resetSecretStorageForTests(): void {
   keytarCleanupAttempted.clear()
+  keytarMigrationFinalized.clear()
   loggedPlaintextBackend = false
 }
 
@@ -267,6 +278,9 @@ export async function getSecret(
 }
 
 export async function setSecret(service: string, account: string, value: string): Promise<void> {
+  // A rewritten secret can land back in the OS keychain (the fallback below),
+  // so any earlier "migration complete" verdict no longer holds.
+  keytarMigrationFinalized.delete(cleanupKey(service, account))
   const filePath = isSafeStorageAvailable() ? resolveStoreFilePath() : null
 
   if (filePath) {
@@ -310,6 +324,9 @@ export async function setSecret(service: string, account: string, value: string)
 }
 
 export async function deleteSecret(service: string, account: string): Promise<void> {
+  // Sign-out clears the secret; whatever is provisioned next must be migrated
+  // from scratch, so drop any "migration complete" verdict for it.
+  keytarMigrationFinalized.delete(cleanupKey(service, account))
   // Keytar first: it was the pre-migration source of truth and its errors are
   // what call sites historically surfaced.
   await keytar.deletePassword(service, account)
@@ -326,6 +343,7 @@ export async function deleteSecret(service: string, account: string): Promise<vo
  * safeStorage copy.
  */
 export async function finalizeKeytarMigration(service: string, account: string): Promise<void> {
+  if (keytarMigrationFinalized.has(cleanupKey(service, account))) return
   if (!isSafeStorageAvailable()) return
   const filePath = resolveStoreFilePath()
   if (!filePath) return
@@ -335,10 +353,18 @@ export async function finalizeKeytarMigration(service: string, account: string):
     const value = decryptValue(ciphertext)
     if (value === null) return
     const legacy = await keytar.getPassword(service, account)
-    if (legacy !== null && legacy === value) {
+    if (legacy === null) {
+      // Nothing left in the OS keychain — this migration is done for this run.
+      keytarMigrationFinalized.add(cleanupKey(service, account))
+      return
+    }
+    if (legacy === value) {
       await keytar.deletePassword(service, account)
+      keytarMigrationFinalized.add(cleanupKey(service, account))
       logger.info('Removed confirmed migrated secret from OS keychain', { service, account })
     }
+    // A keytar copy that differs from the stored secret is deliberately left
+    // unlatched so the next call re-checks it.
   } catch (err) {
     logger.warn('Deferred OS keychain cleanup failed (will retry next run)', {
       error: err,


### PR DESCRIPTION
Fixes #997

## Verification (the issue is real on current `main`)

`apps/desktop/src/main/crypto/vault-key-state.ts:112` — `getOrInitializeLocalVaultKey()` ends with `await confirmMasterKeyMigrated()` on **every** call.

`apps/desktop/src/main/crypto/keychain.ts:131-137` — `confirmMasterKeyMigrated()` forwards straight to `finalizeKeytarMigration(MASTER_KEY.service, resolveAccount(MASTER_KEY))` with no guard.

`apps/desktop/src/main/secrets/secret-storage.ts:328-349` (pre-change) — `finalizeKeytarMigration` unconditionally did `readCiphertext` (`fs.readFileSync` + `JSON.parse`) → `decryptValue` (`safeStorage.decryptString`) → `await keytar.getPassword(...)`, i.e. a disk read, a safeStorage decrypt and an **OS keychain round-trip**, even in the steady state where the keytar copy was deleted long ago and there is nothing to do.

Hot callers confirmed: `sync/runtime.ts:101` `getVerifiedVaultKey` → used per CRDT update batch (`runtime.ts:477`) and per snapshot push (`runtime.ts:545`), plus `ipc/crypto-handlers.ts:87`, `ipc/sync-attachment-handlers.ts:103`, `agent/bootstrap.ts:61`.

New test `stops paying the OS keychain round-trip on repeat vault-key fetches` measures it directly: 10 vault-key fetches = **10** `keytar.getPassword` calls before the fix, **0** after.

## Change

One file: `apps/desktop/src/main/secrets/secret-storage.ts` (+28/-1).

A module-level `keytarMigrationFinalized: Set<string>` keyed by the existing `cleanupKey(service, account)`. `finalizeKeytarMigration` returns immediately when the secret is latched, and only latches on the two outcomes that **prove** no migration work remains:

- `keytar.getPassword` returned `null` → no OS keychain copy exists;
- the copy matched the stored secret and `keytar.deletePassword` resolved → the copy is gone.

Everything else stays unlatched and re-checks next call: a mismatched keytar copy, a missing store entry, an undecryptable ciphertext, `safeStorage` unavailable, and any thrown error (the `catch` runs before any `add`).

`setSecret` and `deleteSecret` drop the latch for their key, so a rotated / re-provisioned / post-sign-out secret is migrated from scratch. `resetSecretStorageForTests` clears it.

### Why this is safe in this specific code

The latch is not a key cache and not a key-location cache. It caches one fact: *"this process run already proved the OS keychain holds no copy of secret X."*

- **Which key is returned never changes.** `finalizeKeytarMigration` returns `void`; it is cleanup only. `retrieveKey` / `getSecret` are untouched, including the deferred-delete path and the "refusing to report it as absent" guard.
- **No migration that would otherwise run is skipped.** The latch is only set once the migration is provably complete. Every inconclusive or failed outcome stays unlatched.
- **Nothing is written, rewritten or deleted where it previously was not.** The change strictly *removes* work; it adds no new `keytar.setPassword` / `deletePassword` / `persistCiphertext` / `removeCiphertext` call.
- **Account-name derivation is untouched.** `resolveKeychainAccount` / `normalizeDeviceSuffix` and the safeStorage-then-keytar fallback order are unchanged.
- **Latch lifetime.** Per process run and per `(service, account)`. It never persists to disk.

Every place `MASTER_KEY` can change, and how the latch is covered:

| Path | Effect |
| --- | --- |
| `sync/session-teardown.ts:86` sign-out → `deleteKey(MASTER_KEY)` → `deleteSecret` | latch dropped |
| `sync/device-registration.ts:147` link/rotate → `storeKey(MASTER_KEY)` → `setSecret` | latch dropped |
| `crypto/vault-key-state.ts:96` first-run mint → `storeKey` → `setSecret` | latch dropped |
| `setSecret` safeStorage failure → keytar fallback re-creates a keytar copy | latch dropped at the top of `setSecret`, before the fallback |
| Vault switch / vault close | `MASTER_KEY` is device-global (`com.memry.sync` / `master-key[-DEVICE]`), not per-vault — no vault-scoped state is cached, so there is nothing to invalidate |
| Plain-dev shared keychain (`MEMRY_DEVICE=dev`) | `confirmMasterKeyMigrated` already returns before `finalizeKeytarMigration`; unaffected |

Only `crypto/keychain.ts` and `secrets/secret-storage.ts` import `keytar` (verified by grep), so `setSecret` / `deleteSecret` are the only in-process ways a keytar copy can reappear, apart from the shared-dev path above, which never reaches this function.

Scenario walkthrough:

- **Fresh install** — nothing in the store, nothing in keytar. First fetch mints the master key via `storeKey` → `setSecret` (safeStorage), which already deletes any keytar copy. The next `finalizeKeytarMigration` reads the store, finds `legacy === null`, latches. One keychain round-trip for the whole run.
- **First launch on a device with the pre-migration layout** — the keytar copy exists. `retrieveKey` migrates it into safeStorage with `deferKeytarDelete`, the vault verifier accepts the key, then `finalizeKeytarMigration` deletes the keytar copy and latches. Identical behaviour to today, then quiet.
- **Device still pre-migration where the verifier rejects the key** — the throw happens in `bindOrVerifyVaultKey` before `confirmMasterKeyMigrated()` is reached, so nothing is latched and the keytar copy survives, exactly as before (covered by the existing test at `secret-storage-callsites.test.ts`).
- **Vault switch** — no vault-scoped state is involved; the same device-global master key is re-fetched and re-verified against the new vault's verifier on every switch, unchanged.

### Deliberately out of scope

The issue's second suggestion — caching the derived vault key for the vault-open lifetime — is not implemented. Callers `secureCleanup()` the returned key, so a shared cached buffer would change ownership semantics across ~8 call sites, and a stale vault key is a wrong-key-decryption hazard. The issue's own success metric ("keychain round-trips drop from ~120 to ≤ 1") is met by the latch alone. The remaining per-fetch cost is one store read + one safeStorage decrypt in `retrieveKey`, with no keychain IPC.

## Tests

`apps/desktop/src/main/secrets/secret-storage.test.ts` — new `finalize latch` block (6 cases): latches after a successful delete (asserts zero `keytar.getPassword` **and** zero `fs.readFileSync` over 5 repeat calls); latches when the run finds no keytar copy; keeps retrying on a store/keytar mismatch; never latches a missing store entry; re-arms after `setSecret` (rotation); re-arms after `deleteSecret` (sign-out).

`apps/desktop/src/main/secrets/secret-storage-callsites.test.ts` — end-to-end through the real `getOrInitializeLocalVaultKey`: 10 repeat fetches return the identical key and hit `keytar.getPassword` zero times.

**Red → green.**

Before the fix:

```
FAIL secret-storage > finalize latch > stops re-reading the store and the OS keychain once the copy is gone
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 5 times
FAIL secret-storage > finalize latch > latches after a run that finds no OS keychain copy at all
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```

After: `PASS (38) FAIL (0)`.

**Mutation checks** (per repo guidance on mocked-keychain tests):

- Removing the `keytarMigrationFinalized.has(...)` early return → the call-site test goes red with `Number of calls: 10`.
- Removing the two `keytarMigrationFinalized.delete(...)` invalidation lines → `re-arms after the secret is rewritten (rotation / re-provision)` and `re-arms after the secret is deleted (sign-out)` both go red.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture boundaries, RPC bindings, IPC invoke map, node + web tsc all clean).
- `pnpm lint` — **0 errors**, 14 pre-existing warnings, all in renderer files untouched by this PR (`tags-hub/*`, `use-folder-view.ts`, `use-tab-keyboard-shortcuts.ts`).
- `pnpm exec vitest --project main src/main/secrets src/main/crypto src/main/sync/session-teardown.test.ts` — `PASS (319) FAIL (0) skipped (1)`.
- `pnpm docs:impact --strict` reports `missing-docs` for `secret-storage.ts`. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: the change is a per-process in-memory performance latch with no user-visible surface — no setting, no IPC, no file format, no behaviour change to document.
