### PR TITLE
fix(sync): merge buffered CRDT updates and persist them across shutdown

### DIFF
--- a/apps/desktop/src/main/sync/crdt-pending-notes.test.ts
+++ b/apps/desktop/src/main/sync/crdt-pending-notes.test.ts
@@ -1,0 +1,81 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ userDataDir: '' }))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => mocks.userDataDir }
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+const storeFile = (): string => path.join(mocks.userDataDir, 'crdt-pending-notes.json')
+
+describe('crdt pending note store', () => {
+  beforeEach(() => {
+    mocks.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memry-crdt-pending-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(mocks.userDataDir, { recursive: true, force: true })
+    vi.resetModules()
+  })
+
+  it('records note ids across restarts and unions repeated shutdowns', async () => {
+    const { readPendingCrdtNotes, recordPendingCrdtNotes } = await import('./crdt-pending-notes')
+
+    recordPendingCrdtNotes(['note-a', 'note-b'])
+    recordPendingCrdtNotes(['note-b', 'note-c'])
+
+    expect(readPendingCrdtNotes()).toEqual(['note-a', 'note-b', 'note-c'])
+  })
+
+  it('returns an empty list when nothing was ever recorded or the file is corrupt', async () => {
+    const { readPendingCrdtNotes } = await import('./crdt-pending-notes')
+
+    expect(readPendingCrdtNotes()).toEqual([])
+
+    fs.writeFileSync(storeFile(), '{ not json', 'utf8')
+    expect(readPendingCrdtNotes()).toEqual([])
+  })
+
+  it('clears only the notes whose state actually reached the server', async () => {
+    const { drainPendingCrdtNotes, readPendingCrdtNotes, recordPendingCrdtNotes } =
+      await import('./crdt-pending-notes')
+
+    recordPendingCrdtNotes(['note-ok', 'note-offline', 'note-throws'])
+
+    const result = await drainPendingCrdtNotes({
+      isSyncable: () => true,
+      pushSnapshot: async (noteId) => {
+        if (noteId === 'note-throws') throw new Error('offline')
+        return noteId === 'note-ok'
+      }
+    })
+
+    expect(result).toEqual({ cleared: 1, retained: 2 })
+    expect(readPendingCrdtNotes()).toEqual(['note-offline', 'note-throws'])
+  })
+
+  it('drops notes that no longer exist instead of retrying them forever', async () => {
+    const { drainPendingCrdtNotes, readPendingCrdtNotes, recordPendingCrdtNotes } =
+      await import('./crdt-pending-notes')
+    recordPendingCrdtNotes(['note-deleted'])
+
+    const pushSnapshot = vi.fn(async () => true)
+    await drainPendingCrdtNotes({ isSyncable: () => false, pushSnapshot })
+
+    expect(pushSnapshot).not.toHaveBeenCalled()
+    expect(readPendingCrdtNotes()).toEqual([])
+    expect(fs.existsSync(storeFile())).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/sync/crdt-pending-notes.ts
+++ b/apps/desktop/src/main/sync/crdt-pending-notes.ts
@@ -1,0 +1,124 @@
+import fs from 'fs'
+import path from 'path'
+import { app } from 'electron'
+import { createLogger } from '../lib/logger'
+
+const log = createLogger('CrdtPendingNotes')
+
+const FILE_NAME = 'crdt-pending-notes.json'
+
+/**
+ * Durable record of notes whose CRDT updates never reached the server.
+ *
+ * The in-memory update queue no-ops its flush while paused (offline, expired
+ * token, quota), so quitting in that state used to discard everything buffered:
+ * the edits stayed on this device but silently never synced. The buffered
+ * updates themselves are already durable — the CRDT provider persists every one
+ * of them to the local store — so only the note ids need to survive the
+ * shutdown. On the next start their full doc state is pushed as a snapshot,
+ * which strictly supersedes the individual updates that were buffered.
+ */
+
+function storePath(): string {
+  return path.join(app.getPath('userData'), FILE_NAME)
+}
+
+export function readPendingCrdtNotes(): string[] {
+  let raw: string
+  try {
+    raw = fs.readFileSync(storePath(), 'utf8')
+  } catch {
+    // No file is the normal case — nothing was ever left unflushed.
+    return []
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((id): id is string => typeof id === 'string' && id.length > 0)
+  } catch (err) {
+    log.warn('Pending CRDT note store is unreadable, ignoring it', { error: err })
+    return []
+  }
+}
+
+function writePendingCrdtNotes(noteIds: string[]): void {
+  try {
+    if (noteIds.length === 0) {
+      fs.rmSync(storePath(), { force: true })
+      return
+    }
+    fs.writeFileSync(storePath(), JSON.stringify(noteIds), 'utf8')
+  } catch (err) {
+    log.error('Failed to write the pending CRDT note store', { error: err })
+  }
+}
+
+/**
+ * Add note ids to the durable set. Synchronous on purpose: the only caller is
+ * the update queue's `stop()`, which runs while the process is quitting.
+ */
+export function recordPendingCrdtNotes(noteIds: string[]): void {
+  if (noteIds.length === 0) return
+  const merged = new Set(readPendingCrdtNotes())
+  for (const noteId of noteIds) merged.add(noteId)
+  writePendingCrdtNotes(Array.from(merged))
+}
+
+export function clearPendingCrdtNotes(noteIds: string[]): void {
+  if (noteIds.length === 0) return
+  const done = new Set(noteIds)
+  writePendingCrdtNotes(readPendingCrdtNotes().filter((noteId) => !done.has(noteId)))
+}
+
+export interface PendingCrdtDrainDeps {
+  /** Push the note's full CRDT state to the server. `false` means try again. */
+  pushSnapshot: (noteId: string) => Promise<boolean>
+  /** `false` for notes that no longer exist or never sync via CRDT (binaries). */
+  isSyncable: (noteId: string) => boolean
+}
+
+let draining = false
+
+/**
+ * Replay the notes recorded at the last shutdown. An entry is cleared only once
+ * its state has actually reached the server, so a still-offline start leaves it
+ * queued for the next attempt rather than losing it.
+ */
+export async function drainPendingCrdtNotes(
+  deps: PendingCrdtDrainDeps
+): Promise<{ cleared: number; retained: number }> {
+  if (draining) return { cleared: 0, retained: 0 }
+
+  const pending = readPendingCrdtNotes()
+  if (pending.length === 0) return { cleared: 0, retained: 0 }
+
+  draining = true
+  const cleared: string[] = []
+  try {
+    for (const noteId of pending) {
+      if (!deps.isSyncable(noteId)) {
+        cleared.push(noteId)
+        continue
+      }
+      try {
+        if (await deps.pushSnapshot(noteId)) cleared.push(noteId)
+      } catch (err) {
+        log.warn('Failed to replay a CRDT note buffered at shutdown', { noteId, error: err })
+      }
+    }
+  } finally {
+    draining = false
+    clearPendingCrdtNotes(cleared)
+  }
+
+  const retained = pending.length - cleared.length
+  if (retained > 0) {
+    log.warn('Some CRDT notes buffered at shutdown still have not synced', {
+      cleared: cleared.length,
+      retained
+    })
+  } else {
+    log.info('Replayed CRDT notes buffered at shutdown', { cleared: cleared.length })
+  }
+  return { cleared: cleared.length, retained }
+}

--- a/apps/desktop/src/main/sync/crdt-queue.test.ts
+++ b/apps/desktop/src/main/sync/crdt-queue.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
 import { CrdtUpdateQueue } from './crdt-queue'
 import { SyncServerError } from './http-client'
 
@@ -123,5 +124,89 @@ describe('CrdtUpdateQueue', () => {
     queue.stop()
 
     expect(queue.getPendingCount()).toBe(0)
+  })
+
+  it('coalesces a paused buffer instead of growing it per update, losing nothing', async () => {
+    const queue = new CrdtUpdateQueue()
+    const pushed: Uint8Array[] = []
+    const push = vi.fn(async (_noteId: string, updates: Uint8Array[]) => {
+      pushed.push(...updates)
+    })
+
+    // Real Yjs updates, one per transaction, exactly what the provider forwards
+    // while the queue is paused. ~1KB each so the total crosses the merged-run
+    // size bound several times over and the coalesced buffer holds more than a
+    // single merged entry.
+    const source = new Y.Doc()
+    const rawUpdates: Uint8Array[] = []
+    source.on('update', (update: Uint8Array) => rawUpdates.push(update))
+    const text = source.getText('body')
+    for (let i = 0; i < 1000; i++) {
+      text.insert(text.length, `${String(i).padStart(4, '0')}${'x'.repeat(1020)}`)
+    }
+    expect(rawUpdates).toHaveLength(1000)
+
+    queue.start(push)
+    queue.pause()
+    for (const update of rawUpdates) {
+      queue.enqueue('note-a', update)
+    }
+
+    // Bounded: a handful of merged runs, not one buffer entry per edit.
+    expect(queue.getPendingCount()).toBeLessThanOrEqual(50)
+    expect(queue.getPendingCount()).toBeGreaterThan(1)
+    expect(push).not.toHaveBeenCalled()
+
+    queue.resume()
+    for (let i = 0; i < 20; i++) {
+      await flushPromises()
+      vi.advanceTimersByTime(1000)
+    }
+    await flushPromises()
+    expect(queue.getPendingCount()).toBe(0)
+
+    // No flush carries a payload the server would reject (~900KB base64).
+    for (const [, updates] of push.mock.calls) {
+      const bytes = updates.reduce((total, update) => total + update.byteLength, 0)
+      expect(bytes).toBeLessThanOrEqual(768 * 1024)
+    }
+
+    // Every character the user typed while paused still reaches the server.
+    const replica = new Y.Doc()
+    for (const update of pushed) {
+      Y.applyUpdate(replica, update)
+    }
+    expect(replica.getText('body').toString()).toBe(text.toString())
+
+    queue.stop()
+  })
+
+  it('hands still-buffered notes to the durable store when stopped while paused', () => {
+    const persistUnflushed = vi.fn()
+    const queue = new CrdtUpdateQueue({ persistUnflushed })
+
+    queue.start(vi.fn(async () => undefined))
+    queue.pause()
+    queue.enqueue('note-a', new Uint8Array([1]))
+    queue.enqueue('note-b', new Uint8Array([2]))
+
+    queue.stop()
+
+    expect(persistUnflushed).toHaveBeenCalledWith(['note-a', 'note-b'])
+  })
+
+  it('does not persist anything when the shutdown flush drains the buffers', async () => {
+    const persistUnflushed = vi.fn()
+    const queue = new CrdtUpdateQueue({ persistUnflushed })
+
+    queue.start(vi.fn(async () => undefined))
+    queue.enqueue('note-a', new Uint8Array([1]))
+    await flushPromises()
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+
+    queue.stop()
+
+    expect(persistUnflushed).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/main/sync/crdt-queue.ts
+++ b/apps/desktop/src/main/sync/crdt-queue.ts
@@ -1,3 +1,4 @@
+import * as Y from 'yjs'
 import { createLogger } from '../lib/logger'
 import { SyncServerError } from './http-client'
 
@@ -5,11 +6,27 @@ const log = createLogger('CrdtUpdateQueue')
 
 const FLUSH_INTERVAL_MS = 1000
 const MAX_BATCH_SIZE = 50
+// Largest single merged update produced by coalescing. Merged updates are
+// pushed as one payload, so this keeps a long offline session from producing
+// one blob the server rejects (the push fn caps a batch at ~900KB base64).
+const MAX_MERGED_UPDATE_BYTES = 256 * 1024
+// Largest raw payload a single flush may carry, for the same reason: after
+// coalescing a batch of 50 entries could otherwise be tens of megabytes.
+const MAX_FLUSH_PAYLOAD_BYTES = 512 * 1024
 
 interface BufferedUpdate {
   noteId: string
   rawUpdate: Uint8Array
   timestamp: number
+}
+
+export interface CrdtUpdateQueueOptions {
+  /**
+   * Called synchronously from `stop()` with the notes whose updates could not
+   * be flushed before shutdown. Must persist them durably — see
+   * `recordPendingCrdtNotes`.
+   */
+  persistUnflushed?: (noteIds: string[]) => void
 }
 
 export class CrdtUpdateQueue {
@@ -18,6 +35,8 @@ export class CrdtUpdateQueue {
   private flushingNotes = new Set<string>()
   private pushFn: ((noteId: string, updates: Uint8Array[]) => Promise<void>) | null = null
   private paused = false
+
+  constructor(private readonly options: CrdtUpdateQueueOptions = {}) {}
 
   start(pushFn: (noteId: string, updates: Uint8Array[]) => Promise<void>): void {
     this.pushFn = pushFn
@@ -33,6 +52,22 @@ export class CrdtUpdateQueue {
       this.flushTimer = null
     }
     this.flushAll()
+
+    // flushAll() no-ops while paused (offline / 401 / quota) and its pushes are
+    // async, so anything still buffered or in flight here dies with the
+    // process. The local Y.Doc already holds this content, so recording the
+    // note ids durably is enough: the next start re-pushes their full state.
+    const unflushed = new Set(this.flushingNotes)
+    for (const [noteId, buffer] of this.buffers) {
+      if (buffer.length > 0) unflushed.add(noteId)
+    }
+    if (unflushed.size > 0) {
+      log.warn('Recording notes with unflushed CRDT updates for replay on next start', {
+        noteCount: unflushed.size
+      })
+      this.options.persistUnflushed?.(Array.from(unflushed))
+    }
+
     log.info('CrdtUpdateQueue stopped')
   }
 
@@ -57,8 +92,17 @@ export class CrdtUpdateQueue {
     }
     buffer.push({ noteId, rawUpdate, timestamp: Date.now() })
 
-    if (buffer.length >= MAX_BATCH_SIZE) {
-      this.flushNote(noteId)
+    if (buffer.length < MAX_BATCH_SIZE) return
+
+    this.flushNote(noteId)
+
+    // A paused, offline or mid-flight queue keeps the buffer. Merge it in place
+    // so an offline session costs the size of the edit instead of one retained
+    // Uint8Array per keystroke. Yjs update merging is lossless — nothing is
+    // evicted, the same operations are simply carried in fewer arrays.
+    const remaining = this.buffers.get(noteId)
+    if (remaining && remaining.length >= MAX_BATCH_SIZE) {
+      this.coalesce(noteId, remaining)
     }
   }
 
@@ -74,6 +118,67 @@ export class CrdtUpdateQueue {
     return this.getPendingCount() + this.flushingNotes.size
   }
 
+  /**
+   * Replace a note's buffer with the same operations packed into size-bounded
+   * merged updates. Never drops an update: `Y.mergeUpdates` is lossless, and a
+   * merge failure leaves the buffer exactly as it was.
+   */
+  private coalesce(noteId: string, buffer: BufferedUpdate[]): void {
+    const merged: BufferedUpdate[] = []
+    let run: Uint8Array[] = []
+    let runBytes = 0
+    let runTimestamp = 0
+
+    const closeRun = (): void => {
+      if (run.length === 0) return
+      merged.push({
+        noteId,
+        rawUpdate: run.length === 1 ? run[0]! : Y.mergeUpdates(run),
+        timestamp: runTimestamp
+      })
+      run = []
+      runBytes = 0
+    }
+
+    try {
+      for (const entry of buffer) {
+        if (run.length > 0 && runBytes + entry.rawUpdate.byteLength > MAX_MERGED_UPDATE_BYTES) {
+          closeRun()
+        }
+        if (run.length === 0) runTimestamp = entry.timestamp
+        run.push(entry.rawUpdate)
+        runBytes += entry.rawUpdate.byteLength
+      }
+      closeRun()
+    } catch (err) {
+      log.warn('Failed to merge buffered CRDT updates, keeping them unmerged', {
+        noteId,
+        error: err
+      })
+      return
+    }
+
+    if (merged.length >= buffer.length) return
+    buffer.splice(0, buffer.length, ...merged)
+  }
+
+  /**
+   * Take the head of a buffer, bounded by both entry count and raw bytes so a
+   * merged backlog cannot produce a payload the server rejects. Always takes at
+   * least one entry, so an oversized update can never wedge the queue.
+   */
+  private takeBatch(buffer: BufferedUpdate[]): BufferedUpdate[] {
+    let count = 0
+    let bytes = 0
+    for (const entry of buffer) {
+      if (count >= MAX_BATCH_SIZE) break
+      if (count > 0 && bytes + entry.rawUpdate.byteLength > MAX_FLUSH_PAYLOAD_BYTES) break
+      count++
+      bytes += entry.rawUpdate.byteLength
+    }
+    return buffer.splice(0, count)
+  }
+
   private flushAll(): void {
     for (const noteId of this.buffers.keys()) {
       this.flushNote(noteId)
@@ -87,7 +192,7 @@ export class CrdtUpdateQueue {
     const buffer = this.buffers.get(noteId)
     if (!buffer || buffer.length === 0) return
 
-    const updates = buffer.splice(0, MAX_BATCH_SIZE)
+    const updates = this.takeBatch(buffer)
     if (buffer.length === 0) this.buffers.delete(noteId)
 
     if (!this.pushFn) {

--- a/apps/desktop/src/main/sync/runtime.ts
+++ b/apps/desktop/src/main/sync/runtime.ts
@@ -55,6 +55,7 @@ import { noteCache } from '@memry/db-schema/schema/notes-cache'
 import { getDeviceSigningKey } from './device-keys'
 import { getCrdtProvider, resetCrdtProvider } from './crdt-provider'
 import { CrdtUpdateQueue } from './crdt-queue'
+import { drainPendingCrdtNotes, recordPendingCrdtNotes } from './crdt-pending-notes'
 import { recoverDirtyItems } from './dirty-recovery'
 import { encryptCrdtUpdate } from './crdt-encrypt'
 import { postToServer, pushCrdtSnapshot, SyncServerError } from './http-client'
@@ -472,7 +473,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
         }
       ])
 
-      const crdtQueue = new CrdtUpdateQueue()
+      const crdtQueue = new CrdtUpdateQueue({ persistUnflushed: recordPendingCrdtNotes })
       crdtQueue.start(async (noteId, updates) => {
         let token = await getValidAccessToken()
         const vaultKey = await getOptionalRuntimeVaultKey(db, 'crdt update batch')
@@ -596,6 +597,16 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       const crdtProvider = getCrdtProvider()
       await crdtProvider.init(crdtQueue, snapshotPushFn)
 
+      // Notes whose updates were still buffered when the app last quit paused
+      // (offline / expired token / quota). Their content is safe in the local
+      // CRDT store; pushing the full state is what the server missed.
+      const replayPendingCrdtNotes = (): void => {
+        void drainPendingCrdtNotes({
+          pushSnapshot: (noteId) => crdtProvider.pushSnapshotForNote(noteId),
+          isSyncable: (noteId) => crdtProvider.validateNoteForCrdt(noteId).ok
+        }).catch((err) => log.warn('Pending CRDT note replay failed', err))
+      }
+
       const emitFn = (channel: string, data: unknown): void => {
         broadcastToAllWindows(channel, data)
       }
@@ -619,6 +630,7 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       network.on('status-changed', ({ online }: { online: boolean }) => {
         if (online) {
           crdtQueue.resume()
+          replayPendingCrdtNotes()
         } else {
           crdtQueue.pause()
         }
@@ -740,6 +752,8 @@ export async function startSyncRuntime(): Promise<SyncEngine | null> {
       void import('./attachment-outbox')
         .then(({ drainAttachmentOutbox }) => drainAttachmentOutbox())
         .catch(() => {})
+
+      replayPendingCrdtNotes()
 
       trackMainEvent('sync_enabled', {
         surface: 'sync',

--- a/apps/docs/src/user-guide/sync/how-sync-works.md
+++ b/apps/docs/src/user-guide/sync/how-sync-works.md
@@ -61,6 +61,12 @@ Pause sync from the indicator menu when:
 
 Resume sync to push and pull queued changes. Outgoing changes queue locally until paused → resumed.
 
+Quitting while paused or offline does not lose those queued note edits. Everything you typed is
+already on disk, and memrynote records which notes still owe the server an update. The next time
+sync runs — on the next launch, or as soon as the network comes back — it pushes those notes'
+current state. A long offline editing session also stays cheap in memory: queued edits for a note
+are merged together rather than kept one per keystroke.
+
 ## What Gets Synced
 
 | Item                                                           | Sync? |


### PR DESCRIPTION
Fixes #995

## Verification — the issue is still real on `main`

`apps/desktop/src/main/sync/crdt-queue.ts` (worktree from `origin/main` @ `27bc2b961`), all three defects present:

- L16 `private buffers = new Map<string, BufferedUpdate[]>()` — one retained `Uint8Array` per Yjs update, no cap.
- L60-62 `if (buffer.length >= MAX_BATCH_SIZE) this.flushNote(noteId)` — `MAX_BATCH_SIZE` only *triggers* a flush.
- L84 `private flushNote(noteId) { if (this.paused) return; ... }` — the flush no-ops while paused.
- L35 `stop() { ... this.flushAll() ... }` — `flushAll()` calls the same `flushNote`, so **every buffered update is discarded at shutdown while paused**.

The queue is paused whenever the app is offline (`runtime.ts:617,623`), on 401 (`runtime.ts:531`), and on 413/quota (`runtime.ts:534,586`). No later commit touched the file: last change to `crdt-queue.ts` was `f3e46b6ca` (#734).

**Reproduced as a test before fixing** — 1000 real Yjs updates enqueued while paused:

```
FAIL src/main/sync/crdt-queue.test.ts > coalesces a paused buffer instead of growing it per update, losing nothing
AssertionError: expected 1000 to be less than or equal to 50

FAIL src/main/sync/crdt-queue.test.ts > hands still-buffered notes to the durable store when stopped while paused
AssertionError: expected "vi.fn()" to be called with arguments: [ [ 'note-a', 'note-b' ] ]
Number of calls: 0
```

## Change

**Nothing is ever evicted.** A queued CRDT update is the user's typing, so the bound comes from merging, not dropping.

`apps/desktop/src/main/sync/crdt-queue.ts`
- `coalesce()` — when a buffer stays full after a flush attempt (paused / offline / mid-flight), pack it in place into size-bounded merged runs via `Y.mergeUpdates`. Lossless: the same operations, carried in fewer arrays. An offline session now costs the size of the edit instead of one array per keystroke. A merge failure leaves the buffer untouched.
- `takeBatch()` — a flush is now bounded by bytes as well as entry count, always taking at least one entry. Without this, coalescing could hand the push fn a multi-megabyte batch, and `runtime.ts:494-501` **silently drops** any batch over ~900KB base64 — i.e. bounding naively would have created a new data-loss path.
- `stop()` — after the final `flushAll()`, hand every note still buffered *or still in flight* to a durable store. Those pushes cannot complete before the process exits.

`apps/desktop/src/main/sync/crdt-pending-notes.ts` (new)
- Durable set of note ids in `userData/crdt-pending-notes.json`. Only ids are needed: the CRDT provider already persists every one of those updates to the local Y.Doc store, so replaying is a full-state snapshot push, which strictly supersedes the individual buffered updates.
- `drainPendingCrdtNotes()` clears an entry **only after** the server has taken it. A still-offline start leaves it queued for the next attempt. Notes that no longer exist (or are binary) are dropped so the list cannot grow stale forever.

`apps/desktop/src/main/sync/runtime.ts`
- Wire `persistUnflushed: recordPendingCrdtNotes` into the queue; replay on sync-runtime start and again when the network comes back online.

### Data-loss assessment

No loss is introduced, and the shutdown loss is closed. Two residual caveats, both pre-existing and out of scope here:

1. If a *single* Yjs update is itself larger than ~675KB (one paste of a very large document), `runtime.ts:494-501` still drops that batch. That drop predates this PR and is unchanged — merging can only shrink payloads, never grow them, and the new flush byte budget keeps coalescing from pushing anything into that path that was not already there.
2. If the local CRDT store is in its degraded in-memory mode (broken `classic-level` binding), doc state does not survive the quit, so there is nothing to replay. The note's text is still safe — the markdown writeback wrote it to the vault file and `seedFromMarkdown` reseeds — but CRDT edit history for that session is gone. Again pre-existing.

## Tests

`apps/desktop/src/main/sync/crdt-queue.test.ts` (+4)
- **coalesces a paused buffer … losing nothing** — 1000 real Yjs updates (~1KB each, crossing the merged-run bound several times) enqueued while paused; asserts the buffer is bounded (`<= 50` entries, `> 1` so multi-run packing is actually exercised), that no flush payload exceeds the size budget, and — the load-bearing assertion — that replaying every pushed update into a fresh `Y.Doc` reproduces the source text **character for character**.
- **hands still-buffered notes to the durable store when stopped while paused**
- **does not persist anything when the shutdown flush drains the buffers** (no spurious replay on a clean quit)

`apps/desktop/src/main/sync/crdt-pending-notes.test.ts` (new, 4 tests) — union across restarts, corrupt/missing file tolerance, clear-only-on-success, drop-deleted-notes.

**Mutation-tested** (each mutation applied to the fix, then reverted):

| Mutation | Result |
| --- | --- |
| `buffer.splice(0, buffer.length, ...merged.slice(0, 1))` (drop merged runs) | RED — `expected '0000xxx…' to be '0000xxx…'` |
| remove the `MAX_FLUSH_PAYLOAD_BYTES` guard | RED — `expected 1035028 to be less than or equal to 786432` |
| no coalescing | RED — `expected 1000 to be less than or equal to 50` |
| no `persistUnflushed` call | RED — `Number of calls: 0` |

An earlier, weaker version of the first test survived the run-dropping mutation (all updates happened to fit one merged run); the test was rewritten with realistically-sized updates until it caught it.

## Checks

```
pnpm --filter @memry/desktop typecheck   pass (contracts + architecture + ipc:check + node + web)
pnpm lint                                pass — 0 errors, 15 warnings, all pre-existing in untouched renderer files
vitest --project main (full)             476 files passed | 1 skipped; 5423 passed | 1 expected fail | 4 skipped
pnpm docs:impact --base origin/main --strict   covered
pnpm docs:build                          pass
git diff --check                         clean
```

## Backward compatibility

No DB schema change, no IPC contract change, no sync-protocol change. The new JSON file is created only by this version and simply ignored by older ones; a missing or corrupt file reads as an empty list. Replay reuses the existing, already-shipped `pushSnapshotForNote` path.
