### PR TITLE
fix(sync): throttle the vault-wide CRDT sweep at the end of full sync

### DIFF
--- a/apps/desktop/src/main/sync/engine.ts
+++ b/apps/desktop/src/main/sync/engine.ts
@@ -260,6 +260,7 @@ export class SyncEngine extends EventEmitter {
     this.ctx.deps.ws.removeListener('device_revoked', this.handleDeviceRevokedFromWs)
     this.ctx.deps.ws.removeListener('certificate_pin_failed', this.handleCertPinFailed)
     this.ctx.deps.ws.disconnect()
+    this.fullSyncRunner.dispose()
     this.pullCoordinator.clearCaches()
     this.quarantine.clear()
     this.ctx.syncing = false

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -1,7 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { EVENT_CHANNELS } from '@memry/contracts/ipc-events'
 import { FullSyncRunner, type FullSyncActions } from './full-sync-runner'
-import { CRDT_FULL_SWEEP_MIN_INTERVAL_MS, SYNC_STATE_KEYS, type SyncContext } from './sync-context'
+import {
+  CRDT_FULL_SWEEP_MIN_INTERVAL_MS,
+  CRDT_RECONNECT_SWEEP_FLOOR_MS,
+  SYNC_STATE_KEYS,
+  type SyncContext
+} from './sync-context'
 import type { SyncStateManager } from './sync-state-manager'
 import type { PushCoordinator } from './push-coordinator'
 import type { CrdtSyncCoordinator } from './crdt-sync-coordinator'
@@ -621,7 +626,7 @@ describe('FullSyncRunner', () => {
     it('#then the sweep runs immediately rather than waiting out the interval', async () => {
       // This is the one case where broadcasts were provably missed, and the
       // case where the user is most likely staring at a stale note. Deferring
-      // it on a timer would be exactly backwards.
+      // it by the fallback interval would be exactly backwards.
       const h = createHarness({ crdtProvider: {} })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
@@ -629,9 +634,11 @@ describe('FullSyncRunner', () => {
       await h.runner.run()
       mocks.getAllCrdtNoteIds.mockClear()
       h.actions.scheduleSync.mockClear()
-      // Swept one second ago — deep inside the fallback interval.
+      // Past the reconnect floor but far inside the fallback interval.
       h.getStateValue.mockImplementation((key: string) =>
-        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now() - 1000) : undefined
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT
+          ? String(Date.now() - CRDT_RECONNECT_SWEEP_FLOOR_MS - 1)
+          : undefined
       )
       h.ws.connectionGeneration += 1
 
@@ -670,6 +677,116 @@ describe('FullSyncRunner', () => {
       await h.runner.run()
 
       expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('#given a connection flapping faster than the floor #when it reconnects', () => {
+    // A drop/reconnect is a real gap, so the sweep is owed — but one full
+    // O(vault) pass per flap is the exact "single Wi-Fi blip = ~2,000 requests"
+    // storm #998 was filed about. The floor collapses a burst of flaps into one
+    // sweep; the debt must survive it.
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    async function reconnectInsideFloor(): Promise<Harness> {
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+
+      await h.runner.run()
+      mocks.getAllCrdtNoteIds.mockClear()
+      h.actions.scheduleSync.mockClear()
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now() - 1_000) : undefined
+      )
+      h.ws.connectionGeneration += 1
+
+      await h.runner.run()
+      return h
+    }
+
+    it('#then the sweep is held back instead of running per flap', async () => {
+      const h = await reconnectInsideFloor()
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
+      expect(h.actions.scheduleSync).not.toHaveBeenCalled()
+    })
+
+    it('#then the owed sweep still runs once the floor expires', async () => {
+      // The debt cannot be silently swallowed: after a flap the device is
+      // missing whatever changed during the gap, and no further fullSync is
+      // guaranteed once the connection settles.
+      const h = await reconnectInsideFloor()
+
+      await vi.advanceTimersByTimeAsync(CRDT_RECONNECT_SWEEP_FLOOR_MS)
+
+      expect(mocks.getAllCrdtNoteIds).toHaveBeenCalledTimes(1)
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+    })
+
+    it('#then repeated flaps inside the floor still cost exactly one sweep', async () => {
+      const h = await reconnectInsideFloor()
+
+      for (let i = 0; i < 5; i++) {
+        h.ws.connectionGeneration += 1
+        await h.runner.run()
+      }
+      await vi.advanceTimersByTimeAsync(CRDT_RECONNECT_SWEEP_FLOOR_MS)
+
+      expect(mocks.getAllCrdtNoteIds).toHaveBeenCalledTimes(1)
+    })
+
+    it('#then a full sync arriving past the floor pays the debt without double-sweeping', async () => {
+      // The deferred timer is still armed at this point. If it did not check
+      // whether the debt was already settled, the vault would be swept twice
+      // for one gap — the storm this floor exists to prevent, half-restored.
+      const h = await reconnectInsideFloor()
+
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT
+          ? String(Date.now() - CRDT_RECONNECT_SWEEP_FLOOR_MS - 1)
+          : undefined
+      )
+      await h.runner.run()
+      expect(mocks.getAllCrdtNoteIds).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(CRDT_RECONNECT_SWEEP_FLOOR_MS * 2)
+
+      expect(mocks.getAllCrdtNoteIds).toHaveBeenCalledTimes(1)
+    })
+
+    it('#then the debt is cleared once paid, so a live socket never re-arms it', async () => {
+      const h = await reconnectInsideFloor()
+      await vi.advanceTimersByTimeAsync(CRDT_RECONNECT_SWEEP_FLOOR_MS)
+      mocks.getAllCrdtNoteIds.mockClear()
+
+      await h.runner.run()
+      // A leaked debt would have deferred here and armed a fresh timer.
+      await vi.advanceTimersByTimeAsync(CRDT_RECONNECT_SWEEP_FLOOR_MS * 2)
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
+    })
+
+    it('#then disposing the runner cancels every pending owed sweep', async () => {
+      // Engine teardown (vault switch, sign-out): a timer left armed fires
+      // against a dead engine and drains the pending pulls into a no-op. Each
+      // flap must therefore re-use the one armed timer rather than stacking a
+      // new one — dispose() can only clear the handle it still holds.
+      const h = await reconnectInsideFloor()
+      for (let i = 0; i < 3; i++) {
+        h.ws.connectionGeneration += 1
+        await h.runner.run()
+      }
+
+      h.runner.dispose()
+      await vi.advanceTimersByTimeAsync(CRDT_RECONNECT_SWEEP_FLOOR_MS * 2)
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -80,6 +80,17 @@ interface Harness {
   purgeOldErrors: ReturnType<typeof vi.fn>
   getPendingCount: ReturnType<typeof vi.fn>
   crdtSync: FakeCrdtSync
+  ws: FakeWebSocket
+}
+
+/**
+ * `connectionGeneration` advances once per successful socket open, so an
+ * unchanged generation on a still-connected socket proves no `crdt_updated`
+ * broadcast could have been missed since it was last read.
+ */
+interface FakeWebSocket {
+  connected: boolean
+  connectionGeneration: number
 }
 
 /**
@@ -95,6 +106,7 @@ function createHarness(
     crdtProvider?: unknown
     isQuarantined?: (itemId: string, itemType: string) => boolean
     online?: boolean
+    ws?: FakeWebSocket | null
   } = {}
 ): Harness {
   const calls: string[] = []
@@ -114,11 +126,20 @@ function createHarness(
     }
   })
 
+  const ws: FakeWebSocket =
+    options.ws === undefined
+      ? { connected: true, connectionGeneration: 1 }
+      : (options.ws ?? {
+          connected: false,
+          connectionGeneration: 0
+        })
+
   const ctx = {
     deps: {
       db: { __db: 'data' },
       queue: { getPendingCount, purgeOldErrors },
       network: { online: options.online ?? true },
+      ...(options.ws !== null && { ws }),
       getAccessToken: vi.fn(async () => 'token-1'),
       getSigningKeys: vi.fn(async () =>
         options.signingKeys === undefined ? { deviceId: 'dev-a' } : options.signingKeys
@@ -177,7 +198,8 @@ function createHarness(
     clearPendingAfterFullSync,
     purgeOldErrors,
     getPendingCount,
-    crdtSync
+    crdtSync,
+    ws
   }
 }
 
@@ -545,17 +567,27 @@ describe('FullSyncRunner', () => {
     })
   })
 
-  describe('#given a vault-wide CRDT sweep that just ran #when another full sync starts', () => {
-    it('#then the sweep is skipped instead of re-pulling every note in the vault', async () => {
-      // fullSync runs on every reconnect, resume, rate-limit release and auth
-      // refresh. Re-queueing every note in the vault each time costs two HTTP
-      // requests, a Y.Doc load and a keychain read PER NOTE, so a single Wi-Fi
-      // blip on a 1,000-note vault cost ~2,000 requests.
+  describe('#given the socket stayed live since the last sweep #when another full sync starts', () => {
+    it('#then the sweep never runs again, however long has passed', async () => {
+      // fullSync also fires on auth refresh and rate-limit release. While the
+      // socket is up, every remote body edit already arrived as a
+      // `crdt_updated` broadcast and was pulled per note, so a sweep can only
+      // re-discover what this device already has. A clock cannot see that: the
+      // liveness signal must win over the interval, not the other way round.
       const h = createHarness({ crdtProvider: {} })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+
+      await h.runner.run()
+      expect(mocks.getAllCrdtNoteIds).toHaveBeenCalledTimes(1)
+
+      mocks.getAllCrdtNoteIds.mockClear()
+      h.actions.scheduleSync.mockClear()
+      // Well past the fallback interval, and the socket never dropped.
       h.getStateValue.mockImplementation((key: string) =>
-        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now() - 1000) : undefined
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT
+          ? String(Date.now() - CRDT_FULL_SWEEP_MIN_INTERVAL_MS * 10)
+          : undefined
       )
 
       await h.runner.run()
@@ -565,15 +597,16 @@ describe('FullSyncRunner', () => {
     })
 
     it('#then notes the server announced over the websocket are still pulled', async () => {
-      // The throttle only covers the blanket safety-net sweep. A `crdt_updated`
+      // The gate only covers the blanket safety-net sweep. A `crdt_updated`
       // broadcast is a positive signal that THIS note changed remotely and must
       // never be swallowed.
       const h = createHarness({ crdtProvider: {} })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
-      h.getStateValue.mockImplementation((key: string) =>
-        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now() - 1000) : undefined
-      )
+
+      await h.runner.run()
+      mocks.getAllCrdtNoteIds.mockClear()
+      h.actions.scheduleSync.mockClear()
       h.crdtSync.addPendingPull('note-9')
 
       await h.runner.run()
@@ -582,8 +615,83 @@ describe('FullSyncRunner', () => {
       expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
       expect(h.crdtSync.pendingPullCount).toBe(0)
     })
+  })
 
-    it('#then a sweep older than the interval runs again', async () => {
+  describe('#given the socket dropped and came back #when another full sync starts', () => {
+    it('#then the sweep runs immediately rather than waiting out the interval', async () => {
+      // This is the one case where broadcasts were provably missed, and the
+      // case where the user is most likely staring at a stale note. Deferring
+      // it on a timer would be exactly backwards.
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+
+      await h.runner.run()
+      mocks.getAllCrdtNoteIds.mockClear()
+      h.actions.scheduleSync.mockClear()
+      // Swept one second ago — deep inside the fallback interval.
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now() - 1000) : undefined
+      )
+      h.ws.connectionGeneration += 1
+
+      await h.runner.run()
+
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+    })
+
+    it('#then a socket that is still down falls back to the interval', async () => {
+      // Down-and-not-yet-back is not a completed reconnect. Sweeping on every
+      // cycle here would reinstate the storm for anyone whose socket is blocked
+      // outright, so the interval bounds it instead.
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+
+      await h.runner.run()
+      mocks.getAllCrdtNoteIds.mockClear()
+      h.actions.scheduleSync.mockClear()
+      h.ws.connected = false
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now() - 1000) : undefined
+      )
+
+      await h.runner.run()
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
+
+      // ...but it does run once the interval elapses.
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT
+          ? String(Date.now() - CRDT_FULL_SWEEP_MIN_INTERVAL_MS - 1)
+          : undefined
+      )
+
+      await h.runner.run()
+
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('#given no liveness signal yet #when a full sync starts', () => {
+    it('#then a fresh runner does not sweep unconditionally', async () => {
+      // FullSyncRunner is rebuilt with every engine (vault switch, restart,
+      // retry). An instance-only signal that re-armed an immediate sweep would
+      // repeat the lastManifestCheckAt bug: a retry loop would sweep the whole
+      // vault on every single cycle. The persisted stamp is the authority here.
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now() - 1000) : undefined
+      )
+
+      await h.runner.run()
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
+    })
+
+    it('#then a stamp older than the interval sweeps', async () => {
       // A device that was offline for weeks discovers body-only remote edits
       // (which never enter the record change feed) only through this sweep.
       const h = createHarness({ crdtProvider: {} })
@@ -598,6 +706,23 @@ describe('FullSyncRunner', () => {
       await h.runner.run()
 
       expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+    })
+
+    it('#then a missing websocket manager falls back to the interval', async () => {
+      const h = createHarness({ crdtProvider: {}, ws: null })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1'])
+
+      await h.runner.run()
+      mocks.getAllCrdtNoteIds.mockClear()
+      h.actions.scheduleSync.mockClear()
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now() - 1000) : undefined
+      )
+
+      await h.runner.run()
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
     })
 
     it('#then a future-dated stamp does not park the sweep until the clock catches up', async () => {
@@ -630,13 +755,20 @@ describe('FullSyncRunner', () => {
 
       expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
     })
+  })
 
-    it('#then a manifest re-pull forces the sweep regardless of the throttle', async () => {
+  describe('#given the gate would otherwise skip #when the cycle demands a sweep', () => {
+    it('#then a manifest re-pull forces the sweep even on a live socket', async () => {
       // Server rows this device has never seen (fresh install, restored vault,
-      // index rebuild) mean the local CRDT watermarks cannot be trusted.
+      // index rebuild) mean local CRDT state cannot be trusted, whatever the
+      // socket did.
       const h = createHarness({ crdtProvider: {} })
       mocks.isIndexDatabaseInitialized.mockReturnValue(true)
       mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+
+      await h.runner.run()
+      mocks.getAllCrdtNoteIds.mockClear()
+      h.actions.scheduleSync.mockClear()
       h.getStateValue.mockImplementation((key: string) =>
         key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now()) : undefined
       )

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { EVENT_CHANNELS } from '@memry/contracts/ipc-events'
 import { FullSyncRunner, type FullSyncActions } from './full-sync-runner'
-import { SYNC_STATE_KEYS, type SyncContext } from './sync-context'
+import { CRDT_FULL_SWEEP_MIN_INTERVAL_MS, SYNC_STATE_KEYS, type SyncContext } from './sync-context'
 import type { SyncStateManager } from './sync-state-manager'
 import type { PushCoordinator } from './push-coordinator'
 import type { CrdtSyncCoordinator } from './crdt-sync-coordinator'
@@ -94,6 +94,7 @@ function createHarness(
     signingKeys?: { deviceId: string } | null
     crdtProvider?: unknown
     isQuarantined?: (itemId: string, itemType: string) => boolean
+    online?: boolean
   } = {}
 ): Harness {
   const calls: string[] = []
@@ -117,7 +118,7 @@ function createHarness(
     deps: {
       db: { __db: 'data' },
       queue: { getPendingCount, purgeOldErrors },
-      network: { online: true },
+      network: { online: options.online ?? true },
       getAccessToken: vi.fn(async () => 'token-1'),
       getSigningKeys: vi.fn(async () =>
         options.signingKeys === undefined ? { deviceId: 'dev-a' } : options.signingKeys
@@ -131,7 +132,7 @@ function createHarness(
   const setStateValue = vi.fn((key: string) => {
     calls.push(`setState:${key}`)
   })
-  const getStateValue = vi.fn(() => undefined as string | undefined)
+  const getStateValue = vi.fn((_key: string) => undefined as string | undefined)
   const isPaused = vi.fn(() => false)
   const stateManager = { setStateValue, getStateValue, isPaused } as unknown as SyncStateManager
 
@@ -531,6 +532,134 @@ describe('FullSyncRunner', () => {
 
       expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
       expect(h.actions.scheduleSync).not.toHaveBeenCalled()
+    })
+
+    it('#then a completed sweep is stamped so the next cycle can throttle it', async () => {
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1'])
+
+      await h.runner.run()
+
+      expect(h.calls).toContain(`setState:${SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT}`)
+    })
+  })
+
+  describe('#given a vault-wide CRDT sweep that just ran #when another full sync starts', () => {
+    it('#then the sweep is skipped instead of re-pulling every note in the vault', async () => {
+      // fullSync runs on every reconnect, resume, rate-limit release and auth
+      // refresh. Re-queueing every note in the vault each time costs two HTTP
+      // requests, a Y.Doc load and a keychain read PER NOTE, so a single Wi-Fi
+      // blip on a 1,000-note vault cost ~2,000 requests.
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now() - 1000) : undefined
+      )
+
+      await h.runner.run()
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
+      expect(h.actions.scheduleSync).not.toHaveBeenCalled()
+    })
+
+    it('#then notes the server announced over the websocket are still pulled', async () => {
+      // The throttle only covers the blanket safety-net sweep. A `crdt_updated`
+      // broadcast is a positive signal that THIS note changed remotely and must
+      // never be swallowed.
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now() - 1000) : undefined
+      )
+      h.crdtSync.addPendingPull('note-9')
+
+      await h.runner.run()
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
+      expect(h.crdtSync.pendingPullCount).toBe(0)
+    })
+
+    it('#then a sweep older than the interval runs again', async () => {
+      // A device that was offline for weeks discovers body-only remote edits
+      // (which never enter the record change feed) only through this sweep.
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT
+          ? String(Date.now() - CRDT_FULL_SWEEP_MIN_INTERVAL_MS - 1)
+          : undefined
+      )
+
+      await h.runner.run()
+
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+    })
+
+    it('#then a future-dated stamp does not park the sweep until the clock catches up', async () => {
+      // Clock skew or a machine migration can leave a stamp 30 days ahead.
+      // Trusting it would disable the only discovery path for body-only remote
+      // edits for a month.
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1'])
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT
+          ? String(Date.now() + 30 * 24 * 60 * 60 * 1000)
+          : undefined
+      )
+
+      await h.runner.run()
+
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
+    })
+
+    it('#then a non-numeric stamp is treated as never swept', async () => {
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1'])
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? 'not-a-number' : undefined
+      )
+
+      await h.runner.run()
+
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(1)
+    })
+
+    it('#then a manifest re-pull forces the sweep regardless of the throttle', async () => {
+      // Server rows this device has never seen (fresh install, restored vault,
+      // index rebuild) mean the local CRDT watermarks cannot be trusted.
+      const h = createHarness({ crdtProvider: {} })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+      h.getStateValue.mockImplementation((key: string) =>
+        key === SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT ? String(Date.now()) : undefined
+      )
+      mocks.checkManifestIntegrity.mockResolvedValue(
+        manifestResult({ rePullNeeded: true, serverOnlyCount: 3 })
+      )
+
+      await h.runner.run()
+
+      expect(h.actions.scheduleSync).toHaveBeenCalledTimes(2)
+    })
+
+    it('#then an offline cycle neither sweeps nor burns the throttle window', async () => {
+      // Pulls scheduled while offline are guaranteed to fail; stamping the
+      // sweep there would hide real remote edits for a whole interval.
+      const h = createHarness({ crdtProvider: {}, online: false })
+      mocks.isIndexDatabaseInitialized.mockReturnValue(true)
+      mocks.getAllCrdtNoteIds.mockReturnValue(['note-1', 'note-2'])
+
+      await h.runner.run()
+
+      expect(mocks.getAllCrdtNoteIds).not.toHaveBeenCalled()
+      expect(h.calls).not.toContain(`setState:${SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT}`)
     })
   })
 })

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -5,7 +5,11 @@ import { ERROR_RETENTION_DAYS } from '../queue'
 import { checkManifestIntegrity } from '../manifest-check'
 import { runInitialSeed } from '../initial-seed'
 import type { SyncContext } from './sync-context'
-import { CRDT_FULL_SWEEP_MIN_INTERVAL_MS, SYNC_STATE_KEYS } from './sync-context'
+import {
+  CRDT_FULL_SWEEP_MIN_INTERVAL_MS,
+  CRDT_RECONNECT_SWEEP_FLOOR_MS,
+  SYNC_STATE_KEYS
+} from './sync-context'
 import type { SyncStateManager } from './sync-state-manager'
 import type { PushCoordinator } from './push-coordinator'
 import type { CrdtSyncCoordinator } from './crdt-sync-coordinator'
@@ -39,6 +43,14 @@ export class FullSyncRunner {
    * a previous process says nothing about the current socket.
    */
   private lastSweepConnectionGeneration: number | null = null
+  /**
+   * A reconnect gap was seen inside the floor and the deferred timer has not
+   * paid it yet. Cleared by any sweep, so a fullSync that arrives past the
+   * floor first settles the debt and the pending timer becomes a no-op instead
+   * of sweeping the vault a second time.
+   */
+  private crdtSweepOwed = false
+  private owedSweepTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(
     ctx: SyncContext,
@@ -70,8 +82,8 @@ export class FullSyncRunner {
    * auth refresh or rate-limit release on a socket that never dropped, a sweep
    * is provably pointless — every broadcast in that window arrived. Fired by a
    * real reconnect, it is provably necessary, and is exactly when the user is
-   * most likely looking at a stale note, so it must not wait out a timer. Only
-   * when the trigger is unknowable does the interval decide.
+   * most likely looking at a stale note, so it must not wait out the interval.
+   * Only when the trigger is unknowable does the interval decide.
    */
   private shouldSweepAllCrdtNotes(force: boolean): boolean {
     // Nothing is fetchable while offline. Sweeping here would schedule pulls
@@ -82,14 +94,23 @@ export class FullSyncRunner {
 
     const ws = this.ctx.deps.ws
     if (ws && this.lastSweepConnectionGeneration !== null) {
-      // Same socket as the last sweep and still up: no broadcast could have
-      // been missed in between, whatever the clock says.
-      if (ws.connected && ws.connectionGeneration === this.lastSweepConnectionGeneration) {
+      // A generation past the one the last sweep saw means the socket dropped
+      // and came back, so broadcasts were missed. This stays true for every
+      // later cycle until a sweep actually runs and re-reads the generation —
+      // which is what carries an unpaid debt forward, no extra flag needed.
+      if (ws.connectionGeneration !== this.lastSweepConnectionGeneration) {
+        // Due, but not necessarily now: a connection flapping every few seconds
+        // would buy one full O(vault) pass per flap. Hold it to one per floor
+        // and remember the debt — dropping it would strand whatever changed
+        // during the gap.
+        if (this.msSinceLastSweep() >= CRDT_RECONNECT_SWEEP_FLOOR_MS) return true
+        this.deferOwedSweep()
         return false
       }
-      // A new generation means the socket dropped and came back. Broadcasts
-      // were missed in that gap — sweep now, not on the next interval.
-      if (ws.connectionGeneration !== this.lastSweepConnectionGeneration) return true
+
+      // Same socket as the last sweep and still up: no broadcast could have
+      // been missed in between, whatever the clock says.
+      if (ws.connected) return false
     }
 
     // Trigger unknowable: no sweep recorded against this runner yet, no socket
@@ -99,6 +120,10 @@ export class FullSyncRunner {
     // instance-only signal that re-armed here would sweep the whole vault on
     // every cycle of a retry loop, the same trap documented on
     // lastManifestCheckAt above. The persisted stamp is the authority.
+    return this.msSinceLastSweep() >= CRDT_FULL_SWEEP_MIN_INTERVAL_MS
+  }
+
+  private msSinceLastSweep(): number {
     const persistedRaw = Number(
       this.stateManager.getStateValue(SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT) ?? '0'
     )
@@ -108,7 +133,52 @@ export class FullSyncRunner {
     // until the wall clock catches up. Clamping to now would not help: the
     // elapsed time stays pinned at zero for exactly as long.
     const lastSweepAt = Number.isFinite(persistedRaw) && persistedRaw <= now ? persistedRaw : 0
-    return now - lastSweepAt >= CRDT_FULL_SWEEP_MIN_INTERVAL_MS
+    return now - lastSweepAt
+  }
+
+  /** Hold an owed sweep until the floor expires, without losing it. */
+  private deferOwedSweep(): void {
+    this.crdtSweepOwed = true
+    // One timer, re-used: a flapping connection must not stack a timer per flap.
+    if (this.owedSweepTimer) return
+
+    const waitMs = Math.max(0, CRDT_RECONNECT_SWEEP_FLOOR_MS - this.msSinceLastSweep())
+    this.owedSweepTimer = setTimeout(() => {
+      this.owedSweepTimer = null
+      this.payOwedSweep()
+    }, waitMs)
+    this.owedSweepTimer.unref?.()
+  }
+
+  private payOwedSweep(): void {
+    if (!this.crdtSweepOwed) return
+    // Keep the debt rather than sweep into a wall: a fullSync in flight would
+    // have its scheduleSync calls dropped (the engine ignores them while
+    // fullSyncActive) and offline pulls cannot succeed. Both states end in
+    // another fullSync, whose finally pays the debt with the floor long past.
+    if (this.ctx.fullSyncActive || !this.ctx.deps.network.online) return
+    if (!this.ctx.deps.crdtProvider || !isIndexDatabaseInitialized()) return
+
+    log.debug('fullSync: paying owed CRDT sweep after reconnect floor')
+    this.sweepAllCrdtNotes()
+    this.flushPendingCrdtPulls()
+  }
+
+  /** Clears the deferred sweep timer. Call on engine teardown. */
+  dispose(): void {
+    if (this.owedSweepTimer) {
+      clearTimeout(this.owedSweepTimer)
+      this.owedSweepTimer = null
+    }
+  }
+
+  private sweepAllCrdtNotes(): void {
+    for (const noteId of getAllCrdtNoteIds(getIndexDatabase())) {
+      this.crdtSync.addPendingPull(noteId)
+    }
+    this.lastSweepConnectionGeneration = this.ctx.deps.ws?.connectionGeneration ?? null
+    this.crdtSweepOwed = false
+    this.stateManager.setStateValue(SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT, String(Date.now()))
   }
 
   async run(): Promise<void> {
@@ -226,20 +296,24 @@ export class FullSyncRunner {
         isIndexDatabaseInitialized() &&
         this.shouldSweepAllCrdtNotes(forceCrdtSweep)
       ) {
-        for (const noteId of getAllCrdtNoteIds(getIndexDatabase())) {
-          this.crdtSync.addPendingPull(noteId)
-        }
-        this.lastSweepConnectionGeneration = this.ctx.deps.ws?.connectionGeneration ?? null
-        this.stateManager.setStateValue(SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT, String(Date.now()))
+        this.sweepAllCrdtNotes()
       }
-      if (this.crdtSync.pendingPullCount > 0) {
-        log.debug('fullSync: flushing pending CRDT pulls', {
-          count: this.crdtSync.pendingPullCount
-        })
-        for (const noteId of this.crdtSync.drainPendingPulls()) {
-          this.actions.scheduleSync(() => this.crdtSync.pullCrdtForNote(noteId))
-        }
-      }
+      this.flushPendingCrdtPulls()
+    }
+  }
+
+  /**
+   * Always runs, gate or no gate: these are notes the server named in a
+   * `crdt_updated` broadcast, which is a positive signal about that specific
+   * note rather than the blanket safety net.
+   */
+  private flushPendingCrdtPulls(): void {
+    if (this.crdtSync.pendingPullCount === 0) return
+    log.debug('fullSync: flushing pending CRDT pulls', {
+      count: this.crdtSync.pendingPullCount
+    })
+    for (const noteId of this.crdtSync.drainPendingPulls()) {
+      this.actions.scheduleSync(() => this.crdtSync.pullCrdtForNote(noteId))
     }
   }
 }

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -5,7 +5,7 @@ import { ERROR_RETENTION_DAYS } from '../queue'
 import { checkManifestIntegrity } from '../manifest-check'
 import { runInitialSeed } from '../initial-seed'
 import type { SyncContext } from './sync-context'
-import { SYNC_STATE_KEYS } from './sync-context'
+import { CRDT_FULL_SWEEP_MIN_INTERVAL_MS, SYNC_STATE_KEYS } from './sync-context'
 import type { SyncStateManager } from './sync-state-manager'
 import type { PushCoordinator } from './push-coordinator'
 import type { CrdtSyncCoordinator } from './crdt-sync-coordinator'
@@ -50,9 +50,42 @@ export class FullSyncRunner {
     this.isQuarantined = isQuarantined
   }
 
+  /**
+   * Should the end-of-cycle sweep re-queue every CRDT note in the vault?
+   *
+   * The sweep is the only way a body-only remote edit is discovered when this
+   * device was not connected to receive its `crdt_updated` broadcast — note
+   * bodies never travel in the record change feed (NoteSync sends
+   * `content: null` on update), so nothing else covers them. It therefore stays
+   * exhaustive: no note is ever excluded, the sweep just does not re-run on
+   * every reconnect.
+   */
+  private shouldSweepAllCrdtNotes(force: boolean): boolean {
+    // Nothing is fetchable while offline. Sweeping here would schedule pulls
+    // that are guaranteed to fail and then stamp the interval, hiding real
+    // remote edits until the window reopened.
+    if (!this.ctx.deps.network.online) return false
+    if (force) return true
+
+    const persistedRaw = Number(
+      this.stateManager.getStateValue(SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT) ?? '0'
+    )
+    const now = Date.now()
+    // A future-dated stamp (clock skew, machine migration) is not a sweep that
+    // happened — treated as "never swept" so the safety net cannot be parked
+    // until the wall clock catches up. Clamping to now would not help: the
+    // elapsed time stays pinned at zero for exactly as long.
+    const lastSweepAt = Number.isFinite(persistedRaw) && persistedRaw <= now ? persistedRaw : 0
+    return now - lastSweepAt >= CRDT_FULL_SWEEP_MIN_INTERVAL_MS
+  }
+
   async run(): Promise<void> {
     log.debug('fullSync started')
     this.ctx.fullSyncActive = true
+    // A manifest re-pull means the server holds items this device has never
+    // seen (fresh install, restored vault, rebuilt index): local CRDT state
+    // cannot be trusted, so the sweep runs regardless of the throttle.
+    let forceCrdtSweep = false
     try {
       await this.actions.pull()
       log.debug('fullSync: pull complete')
@@ -129,6 +162,7 @@ export class FullSyncRunner {
       })
 
       if (manifestResult.rePullNeeded) {
+        forceCrdtSweep = true
         log.info('fullSync: manifest detected server-only items, resetting cursor for re-pull', {
           serverOnlyCount: manifestResult.serverOnlyCount
         })
@@ -155,10 +189,15 @@ export class FullSyncRunner {
       } satisfies InitialSyncProgressEvent)
     } finally {
       this.ctx.fullSyncActive = false
-      if (this.ctx.deps.crdtProvider && isIndexDatabaseInitialized()) {
+      if (
+        this.ctx.deps.crdtProvider &&
+        isIndexDatabaseInitialized() &&
+        this.shouldSweepAllCrdtNotes(forceCrdtSweep)
+      ) {
         for (const noteId of getAllCrdtNoteIds(getIndexDatabase())) {
           this.crdtSync.addPendingPull(noteId)
         }
+        this.stateManager.setStateValue(SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT, String(Date.now()))
       }
       if (this.crdtSync.pendingPullCount > 0) {
         log.debug('fullSync: flushing pending CRDT pulls', {

--- a/apps/desktop/src/main/sync/engine/full-sync-runner.ts
+++ b/apps/desktop/src/main/sync/engine/full-sync-runner.ts
@@ -33,6 +33,12 @@ export class FullSyncRunner {
   // manifest check each time — with a permanently quarantined item that meant
   // a cursor reset and full re-pull on every single sync cycle.
   lastManifestCheckAt = 0
+  /**
+   * WebSocket connection generation observed the last time this runner swept.
+   * Null until it sweeps once — deliberately in-memory only: a generation from
+   * a previous process says nothing about the current socket.
+   */
+  private lastSweepConnectionGeneration: number | null = null
 
   constructor(
     ctx: SyncContext,
@@ -57,8 +63,15 @@ export class FullSyncRunner {
    * device was not connected to receive its `crdt_updated` broadcast — note
    * bodies never travel in the record change feed (NoteSync sends
    * `content: null` on update), so nothing else covers them. It therefore stays
-   * exhaustive: no note is ever excluded, the sweep just does not re-run on
-   * every reconnect.
+   * exhaustive: no note is ever excluded from a sweep that runs.
+   *
+   * What changes is WHEN it runs, and that is decided by the trigger rather
+   * than by a clock, because fullSync's callers are not equivalent. Fired by
+   * auth refresh or rate-limit release on a socket that never dropped, a sweep
+   * is provably pointless — every broadcast in that window arrived. Fired by a
+   * real reconnect, it is provably necessary, and is exactly when the user is
+   * most likely looking at a stale note, so it must not wait out a timer. Only
+   * when the trigger is unknowable does the interval decide.
    */
   private shouldSweepAllCrdtNotes(force: boolean): boolean {
     // Nothing is fetchable while offline. Sweeping here would schedule pulls
@@ -67,6 +80,25 @@ export class FullSyncRunner {
     if (!this.ctx.deps.network.online) return false
     if (force) return true
 
+    const ws = this.ctx.deps.ws
+    if (ws && this.lastSweepConnectionGeneration !== null) {
+      // Same socket as the last sweep and still up: no broadcast could have
+      // been missed in between, whatever the clock says.
+      if (ws.connected && ws.connectionGeneration === this.lastSweepConnectionGeneration) {
+        return false
+      }
+      // A new generation means the socket dropped and came back. Broadcasts
+      // were missed in that gap — sweep now, not on the next interval.
+      if (ws.connectionGeneration !== this.lastSweepConnectionGeneration) return true
+    }
+
+    // Trigger unknowable: no sweep recorded against this runner yet, no socket
+    // manager, or a socket that went down and has not reconnected. Note that
+    // "no sweep recorded yet" must NOT mean "sweep now" — this runner is
+    // rebuilt with every engine (vault switch, restart, retry), and an
+    // instance-only signal that re-armed here would sweep the whole vault on
+    // every cycle of a retry loop, the same trap documented on
+    // lastManifestCheckAt above. The persisted stamp is the authority.
     const persistedRaw = Number(
       this.stateManager.getStateValue(SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT) ?? '0'
     )
@@ -197,6 +229,7 @@ export class FullSyncRunner {
         for (const noteId of getAllCrdtNoteIds(getIndexDatabase())) {
           this.crdtSync.addPendingPull(noteId)
         }
+        this.lastSweepConnectionGeneration = this.ctx.deps.ws?.connectionGeneration ?? null
         this.stateManager.setStateValue(SYNC_STATE_KEYS.LAST_CRDT_SWEEP_AT, String(Date.now()))
       }
       if (this.crdtSync.pendingPullCount > 0) {

--- a/apps/desktop/src/main/sync/engine/sync-context.test.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.test.ts
@@ -74,7 +74,10 @@ describe('SYNC_STATE_KEYS', () => {
         SYNC_PAUSED: 'syncPaused',
         INITIAL_SEED_DONE: 'initialSeedDone',
         QUARANTINED_ITEMS: 'quarantinedItems',
-        LAST_MANIFEST_CHECK_AT: 'lastManifestCheckAt'
+        LAST_MANIFEST_CHECK_AT: 'lastManifestCheckAt',
+        // Additive: absent on installs written by older builds, which reads
+        // back as 0 and simply runs the vault-wide CRDT sweep once.
+        LAST_CRDT_SWEEP_AT: 'lastCrdtSweepAt'
       })
     })
 

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -84,7 +84,8 @@ export const SYNC_STATE_KEYS = {
   SYNC_PAUSED: 'syncPaused',
   INITIAL_SEED_DONE: 'initialSeedDone',
   QUARANTINED_ITEMS: 'quarantinedItems',
-  LAST_MANIFEST_CHECK_AT: 'lastManifestCheckAt'
+  LAST_MANIFEST_CHECK_AT: 'lastManifestCheckAt',
+  LAST_CRDT_SWEEP_AT: 'lastCrdtSweepAt'
 } as const
 
 // Item ids are NOT unique across item types (default project id 'inbox', tag
@@ -106,6 +107,15 @@ export const MAX_RATE_LIMIT_BACKOFF_MS = 5 * 60 * 1000
 export const BASE_RATE_LIMIT_BACKOFF_MS = 5_000
 export const YIELD_EVERY_N_ITEMS = 20
 export const CRDT_SNAPSHOT_CONCURRENCY = 5
+// The vault-wide CRDT sweep at the end of fullSync is a safety net, not the
+// primary transport: while the socket is up, every remote body edit arrives as
+// a `crdt_updated` broadcast and is pulled per note, and notes whose record
+// metadata changed are CRDT-batched inside pull() itself. fullSync, however,
+// re-runs on every reconnect/resume/rate-limit release/auth refresh, so an
+// unthrottled sweep charged two HTTP requests, a Y.Doc load and a keychain read
+// per note in the vault for every Wi-Fi blip. Throttling bounds that to once
+// per interval without ever excluding a note from the sweep.
+export const CRDT_FULL_SWEEP_MIN_INTERVAL_MS = 15 * 60 * 1000
 export const PUSH_DEBOUNCE_MS = 2000
 
 export const yieldToEventLoop = (): Promise<void> => new Promise((r) => setImmediate(r))

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -121,6 +121,18 @@ export const CRDT_SNAPSHOT_CONCURRENCY = 5
 // hour in the worst case (a socket blocked outright by a proxy) while keeping
 // the blind window short enough to be invisible in normal use.
 export const CRDT_FULL_SWEEP_MIN_INTERVAL_MS = 15 * 60 * 1000
+// Floor between reconnect-triggered sweeps. A drop/reconnect is a real gap, so
+// the sweep is genuinely owed — but a connection flapping every few seconds
+// would otherwise buy one full O(vault) pass per flap, which is precisely the
+// "one Wi-Fi blip = ~2,000 requests" storm this whole gate exists to remove.
+// Inside the floor the sweep is deferred, never dropped.
+//
+// 60 seconds: long enough to collapse a flapping burst (drops re-establish in
+// seconds) and to outlast a sweep of a large vault, so passes cannot overlap;
+// short enough that a user who lost Wi-Fi and got it back sees another device's
+// edits inside a minute. Unlike the fallback interval this one is only ever
+// paid once per burst, so it does not need to be conservative.
+export const CRDT_RECONNECT_SWEEP_FLOOR_MS = 60 * 1000
 export const PUSH_DEBOUNCE_MS = 2000
 
 export const yieldToEventLoop = (): Promise<void> => new Promise((r) => setImmediate(r))

--- a/apps/desktop/src/main/sync/engine/sync-context.ts
+++ b/apps/desktop/src/main/sync/engine/sync-context.ts
@@ -107,14 +107,19 @@ export const MAX_RATE_LIMIT_BACKOFF_MS = 5 * 60 * 1000
 export const BASE_RATE_LIMIT_BACKOFF_MS = 5_000
 export const YIELD_EVERY_N_ITEMS = 20
 export const CRDT_SNAPSHOT_CONCURRENCY = 5
-// The vault-wide CRDT sweep at the end of fullSync is a safety net, not the
-// primary transport: while the socket is up, every remote body edit arrives as
-// a `crdt_updated` broadcast and is pulled per note, and notes whose record
-// metadata changed are CRDT-batched inside pull() itself. fullSync, however,
-// re-runs on every reconnect/resume/rate-limit release/auth refresh, so an
-// unthrottled sweep charged two HTTP requests, a Y.Doc load and a keychain read
-// per note in the vault for every Wi-Fi blip. Throttling bounds that to once
-// per interval without ever excluding a note from the sweep.
+// Fallback cadence for the vault-wide CRDT sweep at the end of fullSync, used
+// ONLY when the socket cannot answer whether broadcasts were missed: no sweep
+// recorded against the current engine yet (process start, vault switch, engine
+// retry), or a socket that is down and has not reconnected. A live socket skips
+// the sweep outright and a completed reconnect runs it immediately, so this
+// number never gates the healthy path.
+//
+// It is deliberately not shorter. Where it does apply the device is receiving
+// no broadcasts at all, which makes the sweep the sole discovery path for
+// remote body edits — and each pass costs an HTTP round trip, a Y.Doc load and
+// a keychain read per note in the vault. 15 minutes caps that at four passes an
+// hour in the worst case (a socket blocked outright by a proxy) while keeping
+// the blind window short enough to be invisible in normal use.
 export const CRDT_FULL_SWEEP_MIN_INTERVAL_MS = 15 * 60 * 1000
 export const PUSH_DEBOUNCE_MS = 2000
 

--- a/apps/desktop/src/main/sync/websocket.test.ts
+++ b/apps/desktop/src/main/sync/websocket.test.ts
@@ -252,6 +252,46 @@ describe('WebSocketManager', () => {
     })
   })
 
+  describe('#given the connection generation #when the socket opens and drops', () => {
+    // Consumers use this to tell "the socket has been live the whole time"
+    // (nothing was missed) from "it dropped and came back" (broadcasts were
+    // missed). A boolean `connected` cannot distinguish the two after the fact.
+    it('#then it starts at zero before the first open', () => {
+      const manager = new WebSocketManager(createMockDeps())
+
+      expect(manager.connectionGeneration).toBe(0)
+    })
+
+    it('#then it advances once per successful open', async () => {
+      const manager = new WebSocketManager(createMockDeps())
+
+      await manager.connect()
+      lastWs().simulateOpen()
+      const afterFirstOpen = manager.connectionGeneration
+
+      lastWs().simulateClose()
+      await vi.advanceTimersByTimeAsync(2_000)
+      lastWs().simulateOpen()
+
+      expect(afterFirstOpen).toBe(1)
+      expect(manager.connectionGeneration).toBe(2)
+    })
+
+    it('#then a close alone does not advance it', async () => {
+      // Only a reconnect means broadcasts resumed on a NEW socket. A close on
+      // its own must leave the marker put, or a still-down socket would read as
+      // a completed reconnect.
+      const manager = new WebSocketManager(createMockDeps())
+
+      await manager.connect()
+      lastWs().simulateOpen()
+      lastWs().simulateClose()
+
+      expect(manager.connectionGeneration).toBe(1)
+      expect(manager.connected).toBe(false)
+    })
+  })
+
   describe('#given connected WebSocket #when connection closes', () => {
     it('#then emits disconnected', async () => {
       const manager = new WebSocketManager(createMockDeps())

--- a/apps/desktop/src/main/sync/websocket.ts
+++ b/apps/desktop/src/main/sync/websocket.ts
@@ -51,6 +51,7 @@ export class WebSocketManager extends EventEmitter {
   private reconnectAttempt = 0
   private shouldBeConnected = false
   private _connected = false
+  private _connectionGeneration = 0
   private authFailed = false
   private versionRejected = false
   private certPinFailed = false
@@ -67,6 +68,17 @@ export class WebSocketManager extends EventEmitter {
 
   get connected(): boolean {
     return this._connected
+  }
+
+  /**
+   * Advances once per successful socket open (including the internal
+   * reconnects nothing else observes). Read together with `connected` it tells
+   * "this is the same socket you saw last time, still up" — so no server
+   * broadcast could have been missed in between — apart from "it dropped and
+   * came back", which `connected` alone cannot distinguish after the fact.
+   */
+  get connectionGeneration(): number {
+    return this._connectionGeneration
   }
 
   async connect(): Promise<void> {
@@ -110,6 +122,7 @@ export class WebSocketManager extends EventEmitter {
 
     ws.on('open', () => {
       this._connected = true
+      this._connectionGeneration++
       this.reconnectAttempt = 0
       this.resetHeartbeat()
       this.startPing()


### PR DESCRIPTION
Fixes #998

## Verification — the issue is still live on `main`

`apps/desktop/src/main/sync/engine/full-sync-runner.ts:156-171` (`main` @ `27bc2b96`) still ends every full sync with an unconditional vault-wide fan-out:

```ts
} finally {
  this.ctx.fullSyncActive = false
  if (this.ctx.deps.crdtProvider && isIndexDatabaseInitialized()) {
    for (const noteId of getAllCrdtNoteIds(getIndexDatabase())) {
      this.crdtSync.addPendingPull(noteId)
    }
  }
  ...
    this.actions.scheduleSync(() => this.crdtSync.pullCrdtForNote(noteId))
```

- `getAllCrdtNoteIds` (`database/queries/notes/note-crud.ts:189`) is an unfiltered `SELECT id FROM note_cache WHERE fileType = 'markdown'` — every note, no predicate.
- `pullCrdtForNote` (`engine/crdt-sync-coordinator.ts:322`) does `getAccessToken()` + `getVaultKey()` per note, then `applyCrdtIncrementals` opens the Y.Doc, GETs `/sync/crdt/snapshot/:noteId` and pages `/sync/crdt/updates`.
- `fullSync()` runs on engine start, on `resume()`, after rate-limit pauses, after auth refresh, and on **every** network reconnect (`engine.ts:605` → `reconnectSync`).

So a 1,000-note vault paid ~2,000 HTTP requests, 1,000 leveldb Y.Doc loads and 1,000 keychain reads for a single Wi-Fi blip.

## Change

`full-sync-runner.ts`, `sync-context.ts`, `websocket.ts`, plus **one line in `engine.ts`**: `this.fullSyncRunner.dispose()` inside `stop()`, so the deferred-sweep timer is cleared on engine teardown. The websocket handlers and the reconnect path (`handleWsConnected` / `handleWsMessage` / `handleNetworkChange`) are untouched — that is #1026's territory.

The set of notes swept is **unchanged** — the sweep is still exhaustive when it runs. What changes is *when*, gated on the trigger rather than on a clock, because `fullSync()`'s callers are not equivalent:

| trigger | sweep? | why |
| --- | --- | --- |
| socket never dropped since the last sweep (auth refresh, rate-limit release, `resume()`) | **never**, however long has passed | every `crdt_updated` broadcast in that window arrived and was pulled per note — a sweep can only re-discover what this device already has |
| socket dropped and came back, last sweep > 60s ago | **immediately** | broadcasts were provably missed, and this is when the user is most likely looking at a stale note |
| socket dropped and came back, last sweep < 60s ago | **deferred to the 60s floor, never dropped** | otherwise a flapping connection buys one full O(vault) pass per flap — #998's own headline case |
| manifest reported `rePullNeeded` | **immediately** | server holds items this device has never seen; local state is not trustworthy |
| offline right now | no | the pulls could not succeed, and stamping the window would hide real edits |
| trigger unknowable | fallback interval (15 min) | see below |

**The liveness signal.** `WebSocketManager` gains a `connectionGeneration` that advances once per successful `open` (including the internal reconnects nothing else observes). Same generation **and** still connected ⇒ same socket, continuously live ⇒ nothing missed. A different generation ⇒ it dropped and came back. A boolean `connected` cannot distinguish those after the fact, which is why the counter exists rather than a `connected` read. The generation comparison also carries an *unpaid* debt forward on its own: it stays true on every later cycle until a sweep actually runs and re-reads the generation.

**The reconnect floor** (`CRDT_RECONNECT_SWEEP_FLOOR_MS`, 60s). Inside the floor the sweep is deferred on a single re-used timer (`dispose()`-able), never dropped. If a full sync arrives past the floor before the timer fires, that one pays the debt and the pending timer no-ops rather than sweeping the vault twice. 60 seconds is long enough to collapse a flapping burst (drops re-establish in seconds) and to outlast a sweep of a large vault so passes cannot overlap, and short enough to stay invisible to a user who lost Wi-Fi and got it back. Unlike the fallback interval it is only ever paid once per burst, so it does not need to be conservative.

**The fallback interval** (`CRDT_FULL_SWEEP_MIN_INTERVAL_MS`, 15 min, persisted as `sync_state.lastCrdtSweepAt`) now survives **only** where the socket cannot answer: no sweep recorded against the current engine yet (process start, vault switch, engine retry), no socket manager, or a socket that is down and has not reconnected. It never gates the healthy path. Not shorter, because where it applies the device is receiving no broadcasts at all — the sweep is the sole discovery path and each pass is O(vault). Shortening it only adds full passes to already-degraded devices.

Note the deliberate non-shortcut: "no sweep recorded yet" does **not** mean "sweep now". `FullSyncRunner` is rebuilt with every engine, and an instance-only signal that re-armed here would sweep the whole vault on every cycle of a retry loop — the exact trap already documented on `lastManifestCheckAt`. The persisted stamp is the authority in that branch.

### Why not narrow *which* notes

Body edits never enter the record change feed: `NoteSyncService.buildSnapshotPayload` sends `content: null` for `operation === 'update'` (`note-sync.ts:100`), and `updateNoteCommand` only enqueues a `note` item when title/tags/frontmatter/emoji changed (`notes/domain.ts:29-37`). Note bodies travel exclusively over `/sync/crdt/updates`, and the server exposes no "notes with CRDT updates since X" endpoint. Any filter keyed on the change cursor, on open notes, or on a locally persisted per-note sequence would drop a body-only edit made while this device was disconnected (the server also prunes updates at or below a note's snapshot watermark via `pruneUpdatesBeforeSnapshot`, so a local watermark is not sufficient either). Narrowing correctly would require a new server endpoint — deliberately out of scope.

### Worst-case staleness, in user terms

**A note edited on another device while this one was disconnected appears within 60 seconds of the connection coming back — usually immediately.**

Stated plainly, because the reconnect path is no longer unconditionally instant:

| situation | when the remote edit shows up |
| --- | --- |
| socket live throughout | **immediately** — `crdt_updated` delivers in real time, and those pulls bypass the gate entirely |
| reconnect, no sweep in the previous 60s (the normal case) | **immediately** on reconnect |
| reconnect during a flapping burst (a sweep already ran < 60s ago) | **within 60 seconds** — deferred to the floor, then run |
| socket cannot connect at all (proxy/firewall; HTTP sync still working) | within 15 minutes |
| app restarted within 15 min of its last sweep | within 15 minutes of launch |

The 60-second figure is new in this round and applies only while a connection is actively flapping. Closing the two 15-minute windows entirely would need a persisted clean-shutdown marker and a server-side "notes changed since X" endpoint respectively; neither belongs here.

### What is left

A flapping connection now costs **one sweep per 60-second floor** instead of one per flap — a connection dropping every 5 seconds goes from ~12 full O(vault) passes a minute to 1. Together with the liveness gate, the sweeps this PR removes are: every engine start on a live socket, every `resume()`, every rate-limit release, every auth refresh, and every flap past the first in each floor period. The sweeps it keeps are exactly those following a real gap.

No sweep is ever silently dropped: a deferred sweep is held on a re-used timer and paid when the floor expires, and a full sync arriving past the floor pays it instead.

Backward compatible: `lastCrdtSweepAt` is a new `sync_state` KV key, no schema change, no protocol change. Older builds ignore it; this build reading a DB written by an older build sees no row and sweeps once. `connectionGeneration` is a read-only accessor on an in-process object.

## Tests

`apps/desktop/src/main/sync/websocket.test.ts` — 3 cases: generation starts at zero, advances once per successful open, and a close alone does not advance it.

`apps/desktop/src/main/sync/engine/full-sync-runner.test.ts` — 17 cases across four groups: live socket never sweeps however long has passed (and WS-queued pulls still flush) · reconnect past the floor sweeps immediately, still-down socket falls back to the interval · flapping burst held to one sweep, owed sweep runs when the floor expires, repeated flaps cost exactly one sweep, a later full sync pays the debt without double-sweeping, debt cleared once paid, `dispose()` cancels every pending sweep · fresh runner does not sweep unconditionally, stamp older than the interval sweeps, missing WS manager falls back, future-dated and non-numeric stamps treated as never-swept, `rePullNeeded` forces the sweep on a live socket, offline neither sweeps nor stamps.

`sync-context.test.ts` — the persisted-key guard now includes the additive key.

**Red → green.** Tests written first, against the unimplemented floor:

```
 × #then the sweep is held back instead of running per flap
   → expected "vi.fn()" to not be called at all, but actually been called 1 times
 × #then repeated flaps inside the floor still cost exactly one sweep
   → expected "vi.fn()" to be called 1 times, but got 6 times
 × #then disposing the runner cancels every pending owed sweep
   → h.runner.dispose is not a function
 Tests  3 failed | 40 passed (43)
```

("got 6 times" is the per-flap storm, measured.) After implementing: `Tests 43 passed (43)`.

**Mutation checked.** Two mutations survived on the first attempt and both were real findings, not test-tuning:

1. Removing the owed-flag read from the gate condition changed nothing — the generation comparison already carries an unpaid debt forward, so the clause was **unreachable dead code**. It was deleted rather than propped up with a test.
2. Allowing the deferred timer to stack changed nothing — because `payOwedSweep` guards on the debt flag, the extra timers were no-ops. The real consequence is that `dispose()` can only clear the handle it still holds, so the dispose test was strengthened to flap several times first. It now catches it.

Final round, all caught:

| mutation | result |
| --- | --- |
| drop the live-socket skip branch | 2 failures |
| drop the new-generation sweep branch | 1 failure |
| drop `ws.connected &&` from the skip branch | 1 failure |
| fresh runner `return true` (the `lastManifestCheckAt` trap) | 2 failures |
| stop advancing `_connectionGeneration` on open | 2 failures |
| remove the reconnect floor (sweep per flap) | 3 failures |
| defer without recording the debt (silently swallowed) | 2 failures |
| `payOwedSweep` loses its debt guard (double sweep) | 1 failure |
| sweep never clears the debt | 1 failure |
| allow the deferred timer to stack | 1 failure |
| `dispose()` made a no-op | 1 failure |

Earlier in this PR the same discipline caught a **toothless assertion of mine**: an original `Math.min(stamp, now)` clamp survived mutation because it is provably a no-op for this comparison. It was replaced with a reset-to-zero and the test rewritten to assert the sweep actually runs.

## Checks

- `pnpm --filter @memry/desktop typecheck` → exit 0 (contracts, architecture, RPC/IPC map, node + web)
- `pnpm lint` → exit 0, `14 problems (0 errors, 14 warnings)`, all warnings pre-existing in renderer files this PR does not touch (zero hits in the changed files)
- `vitest --project main src/main/sync/engine/ websocket.test.ts engine.test.ts engine-crdt.test.ts engine-pull.test.ts engine-push.test.ts engine-retries.test.ts session-teardown.test.ts` → `18 files passed, 272 tests passed`
- `git diff --check` clean
