### PR TITLE
fix(agent): settle pending tool approvals as denied when a turn is cancelled

### DIFF
--- a/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
+++ b/apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts
@@ -13,9 +13,23 @@ vi.mock('../event-bus', () => ({
   broadcastAgentEvent: mocks.broadcastAgentEvent
 }))
 
+import type { VaultServiceHandles } from '../../mcp/tools/handles'
+import { buildWriteTools } from '../../mcp/tools/write-tools'
 import type { ConversationStore } from '../../storage/conversation-store'
 import type { MessageStore } from '../../storage/message-store'
 import { AgentRuntime } from '../runtime'
+
+/** Drains every queued microtask so an already-settled promise wins a race. */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function broadcastToolCallIds(): string[] {
+  return mocks.broadcastAgentEvent.mock.calls
+    .map(([event]) => event as { kind: string; toolCallId: string })
+    .filter((event) => event.kind === 'tool_call_pending_approval')
+    .map((event) => event.toolCallId)
+}
 
 function createRuntime(toolApprovalMode: 'always_accept' | 'ask' = 'always_accept') {
   const conversations = {
@@ -165,6 +179,77 @@ describe('AgentRuntime approval gate', () => {
       approved: false,
       reason: 'User denied request.'
     })
+  })
+
+  it('denies pending approvals for the cancelled conversation only', async () => {
+    const { runtime, conversations } = createRuntime('ask')
+    conversations.getById.mockImplementation((id: string) => ({ id, trustList: [] }))
+    vi.spyOn(Date, 'now').mockReturnValueOnce(100).mockReturnValueOnce(200)
+
+    runtime.install()
+    const gate = installedGate()
+    const cancelled = gate({
+      conversationId: 'conversation-1',
+      toolName: 'vault_create_task',
+      parsedArgs: { title: 'Task' }
+    })
+    const untouched = gate({
+      conversationId: 'conversation-2',
+      toolName: 'vault_create_task',
+      parsedArgs: { title: 'Other task' }
+    })
+    const [cancelledId, untouchedId] = broadcastToolCallIds()
+    expect(cancelledId).not.toBe(untouchedId)
+
+    runtime.cancelTurn('conversation-1')
+    await flushMicrotasks()
+
+    await expect(
+      Promise.race([cancelled, Promise.resolve('still-pending' as const)])
+    ).resolves.toEqual({ approved: false, reason: 'User denied request.' })
+    expect(runtime.getPendingApproval(cancelledId)).toBeNull()
+    expect(mocks.broadcastAgentEvent).toHaveBeenCalledWith({
+      kind: 'tool_call_failed',
+      conversationId: 'conversation-1',
+      toolCallId: cancelledId,
+      error: { code: 'PERMISSION_DENIED', message: 'Turn cancelled before approval.' }
+    })
+
+    await expect(
+      Promise.race([untouched, Promise.resolve('still-pending' as const)])
+    ).resolves.toBe('still-pending')
+    expect(runtime.getPendingApproval(untouchedId)).not.toBeNull()
+  })
+
+  it('fails the awaiting write tool with PERMISSION_DENIED and never executes it on cancel', async () => {
+    const { runtime, conversations } = createRuntime('ask')
+    conversations.getById.mockReturnValue({ id: 'conversation-1', trustList: [] })
+
+    runtime.install()
+    const create = vi.fn(async () => ({ id: 'note-1' }))
+    const createNote = buildWriteTools(
+      { notes: { create } } as unknown as VaultServiceHandles,
+      installedGate()
+    ).find((tool) => tool.name === 'vault_create_note')
+    if (!createNote) throw new Error('vault_create_note is not registered')
+
+    const call = createNote.handler(
+      { title: 'Notes', content_markdown: 'body' },
+      { conversationId: 'conversation-1', windowId: null }
+    )
+    const settled = call.then(
+      () => 'resolved-as-approved' as const,
+      (error: unknown) => error
+    )
+    expect(runtime.getPendingApproval('gate-100-i')).not.toBeNull()
+
+    runtime.cancelTurn('conversation-1')
+    await flushMicrotasks()
+
+    await expect(
+      Promise.race([settled, Promise.resolve('still-pending' as const)])
+    ).resolves.toMatchObject({ code: 'PERMISSION_DENIED' })
+    expect(create).not.toHaveBeenCalled()
   })
 
   it('denies pending approvals and clears the MCP write gate on shutdown', async () => {

--- a/apps/desktop/src/main/agent/runtime/runtime.ts
+++ b/apps/desktop/src/main/agent/runtime/runtime.ts
@@ -140,6 +140,7 @@ export class AgentRuntime {
 
   cancelTurn(conversationId: string): void {
     this.inFlight.get(conversationId)?.abort()
+    this.denyPendingApprovals(conversationId)
     for (const sub of this.subprocesses.values()) {
       if (sub.conversationId !== conversationId) continue
       try {
@@ -233,6 +234,30 @@ export class AgentRuntime {
       await Promise.allSettled(turns)
     }
     this.activeTurns.clear()
+  }
+
+  /**
+   * A cancelled turn must settle every approval it left on screen. An approval
+   * promise nobody resolves strands its MCP tool handler forever, and with it
+   * the HTTP response, the socket and the per-request McpServer behind it —
+   * which also blocks `server.close()` at quit. Cancelling is never consent, so
+   * these always settle as deny; the tool call fails with PERMISSION_DENIED and
+   * never runs.
+   */
+  private denyPendingApprovals(conversationId: string): void {
+    for (const [toolCallId, approval] of this.pending) {
+      if (approval.conversationId !== conversationId) continue
+      this.pending.delete(toolCallId)
+      approval.resolve({ kind: 'deny' })
+      // The approval card is only ever cleared by a decision event; without
+      // this the cancelled turn leaves a dead card the user can still click.
+      broadcastAgentEvent({
+        kind: 'tool_call_failed',
+        conversationId,
+        toolCallId,
+        error: { code: 'PERMISSION_DENIED', message: 'Turn cancelled before approval.' }
+      })
+    }
   }
 
   private waitForApproval(input: PendingApprovalSnapshot): Promise<ApproveToolDecision> {

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -410,6 +410,9 @@ that conversation, deny it, or edit the arguments before allowing. Note updates 
 diff before the write is applied. Unauthenticated or context-free write requests continue to be
 denied.
 
+Stopping the turn while an approval is waiting counts as a denial: the pending request is refused,
+the tool never runs, and the approval controls disappear. Nothing is written to your vault.
+
 ## Project Links
 
 `vault_list_projects` returns each project's `icon`, `home_note_id`, and `linked_counts` (notes,


### PR DESCRIPTION
Fixes #1002

## Verification — the issue was still real on `main`

`apps/desktop/src/main/agent/runtime/runtime.ts:141-151` (pre-fix) aborted the turn and killed
subprocesses but never touched `this.pending`:

```ts
cancelTurn(conversationId: string): void {
  this.inFlight.get(conversationId)?.abort()
  for (const sub of this.subprocesses.values()) { ... }
}
```

`killAll()` (`:207-236`) already denied every pending approval on shutdown; `cancelTurn` had no
equivalent. The awaiting consumer is `gateOrDeny` (`agent/mcp/tools/write-tools.ts:31-49`) inside an
MCP tool handler (`agent/mcp/server.ts:53-79`), so the unresolved promise strands
`transport.handleRequest` (`server.ts:109`), the HTTP response, the socket, and the per-request
`McpServer` — `finally { await mcp.close() }` (`server.ts:117-119`) never runs. One leaked
server + socket per cancelled approval, and leaked sockets block `server.close()` at quit.

There is no conversation-delete/close IPC channel today (`packages/contracts/src/ipc-agent.ts:13-34`),
so `cancelTurn` is the only additional settle point that exists.

## Change

`apps/desktop/src/main/agent/runtime/runtime.ts`
- `cancelTurn()` calls a new private `denyPendingApprovals(conversationId)`.
- `denyPendingApprovals()` removes each pending entry for that conversation and settles it as
  `{ kind: 'deny' }`, then broadcasts an existing `tool_call_failed` event with
  `PERMISSION_DENIED` for the same `toolCallId`.

**Cancelling is never consent.** The denial is explicit: the gate returns
`{ approved: false, reason: 'User denied request.' }`, `gateOrDeny` throws `PERMISSION_DENIED`, and
the tool body never executes. There is no default/fallback path that could let the write through.
Approvals for other conversations are untouched.

The `tool_call_failed` broadcast is needed because a pending approval card is only ever cleared by a
decision event; without it a cancelled turn leaves a dead but still-clickable approval card on
screen. No contract change — `tool_call_failed` is already in `AgentEventSchema` and the renderer
reducer already treats a `PERMISSION_DENIED` failure as "denied".

No new dependencies, no schema/contract/IPC changes, no migration needed.

## Tests

`apps/desktop/src/main/agent/runtime/__tests__/runtime-approval.test.ts` — two new cases:

1. `denies pending approvals for the cancelled conversation only` — two approvals pending across two
   conversations; after `cancelTurn('conversation-1')` the first settles as denied, is gone from
   `pending`, and emits the `tool_call_failed` event; the second is still pending.
2. `fails the awaiting write tool with PERMISSION_DENIED and never executes it on cancel` — drives a
   real `vault_create_note` registration built by `buildWriteTools` against the runtime's installed
   gate, then cancels. Asserts the handler rejects with `PERMISSION_DENIED` **and that the vault
   handle `notes.create` was never called**.

Red before the fix (promise never settles):

```
FAIL  ... > denies pending approvals for the cancelled conversation only
AssertionError: expected 'still-pending' to deeply equal { approved: false, …(1) }

FAIL  ... > fails the awaiting write tool with PERMISSION_DENIED and never executes it on cancel
AssertionError: expected 'still-pending' to match object { code: 'PERMISSION_DENIED' }
```

Green after:

```
✓ runtime-approval.test.ts > denies pending approvals for the cancelled conversation only 2ms
✓ runtime-approval.test.ts > fails the awaiting write tool with PERMISSION_DENIED and never executes it on cancel 2ms
Test Files  2 passed (2)   Tests  11 passed (11)
```

Mutation check (the tests are not mocked-IPC theatre): flipping the settle value from
`{ kind: 'deny' }` to `{ kind: 'allow' }` turns both tests red again —

```
- { "approved": false, "reason": "User denied request." }
+ { "approved": true, "args": { "title": "Task" } }

AssertionError: expected 'resolved-as-approved' to match object { code: 'PERMISSION_DENIED' }
```

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + ipc:check all clean)
- `pnpm lint` — 0 errors, 14 pre-existing warnings, none in touched files
- targeted `vitest --project main` over `runtime-approval`, `runtime-cancel`, `agent-handlers`,
  `write-tools` — 33 passed
- `pnpm docs:impact --base origin/main --strict` — covered
- `pnpm docs:build` — pass

## Out of scope (noted, not fixed here)

- #1003 — the MCP HTTP server still stops without destroying live connections. This fix removes the
  deterministic source of stranded sockets but does not add connection teardown.
- #451 — an approval timeout would cover the abandon-without-cancel path; complementary, not
  included.
- Telemetry still labels a cancelled approval as `deny` rather than a distinct token; adding a new
  label was outside this issue.
