### PR TITLE
fix(crdt): release a window's Y.Docs when the window is destroyed

### DIFF
--- a/apps/desktop/src/main/ipc/crdt-handlers.ts
+++ b/apps/desktop/src/main/ipc/crdt-handlers.ts
@@ -10,14 +10,45 @@ import {
   type CrdtSyncStep1Result
 } from '@memry/contracts/ipc-crdt'
 import { getCrdtProvider } from '../sync/crdt-provider'
+import { createLogger } from '../lib/logger'
 import { trackNoteBodyEditThrottled } from '../telemetry/diagnostics'
 import { createValidatedHandler } from './validate'
 
+const log = createLogger('CrdtIpc')
+
 let handlersRegistered = false
+const windowsHookedForClose = new Set<number>()
 
 /** Test-only: resets the idempotency guard so handlers can be re-registered. */
 export function _resetCrdtIpcHandlersForTests(): void {
   handlersRegistered = false
+  windowsHookedForClose.clear()
+}
+
+/**
+ * Release the window's Y.Docs when it goes away.
+ *
+ * The renderer's crdt:close-doc invoke only fires on React unmount, so ⌘W, a
+ * reload, or a renderer crash leaves the window id in the doc's windowIds set
+ * forever — pinning the doc and disabling eviction and compaction with it.
+ *
+ * One listener per WINDOW, not per doc: a window that opens dozens of notes
+ * would otherwise stack a listener each time and trip Electron's max-listeners
+ * warning. The id is captured now because `win.id` is not safe to read once the
+ * window is destroyed.
+ */
+function hookWindowClose(win: BrowserWindow): void {
+  const windowId = win.id
+  if (windowsHookedForClose.has(windowId)) return
+  windowsHookedForClose.add(windowId)
+  win.once('closed', () => {
+    windowsHookedForClose.delete(windowId)
+    void getCrdtProvider()
+      .forgetWindow(windowId)
+      .catch((err) => {
+        log.error('Failed to release CRDT docs for a closed window', { windowId, error: err })
+      })
+  })
 }
 
 /**
@@ -32,7 +63,11 @@ export function registerCrdtIpcHandlers(): void {
 
   ipcMain.handle(CRDT_CHANNELS.OPEN_DOC, async (event, rawInput: unknown) => {
     const { noteId } = CrdtOpenDocSchema.parse(rawInput)
-    const windowId = BrowserWindow.fromWebContents(event.sender)?.id
+    const win = BrowserWindow.fromWebContents(event.sender)
+    const windowId = win?.id
+    // Hook before the first await: a window destroyed while open() is in
+    // flight would already have emitted 'closed' by the time we got back.
+    if (win) hookWindowClose(win)
 
     const provider = getCrdtProvider()
     if (!provider.isInitialized()) {

--- a/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
+++ b/apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts
@@ -9,10 +9,14 @@ import { CRDT_CHANNELS } from '@memry/contracts/ipc-crdt'
 // electron.app) to keep the test focused on handler lifecycle behaviour.
 // ============================================================================
 
+const senderWindow = vi.hoisted(() => ({
+  current: { id: 1, once: vi.fn() } as { id: number; once: ReturnType<typeof vi.fn> }
+}))
+
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/crdt-test-userdata' },
   BrowserWindow: {
-    fromWebContents: () => ({ id: 1 }),
+    fromWebContents: () => senderWindow.current,
     fromId: () => null
   },
   ipcMain: mockIpcMain
@@ -34,8 +38,12 @@ vi.mock('../vault/frontmatter', () => ({
   serializeNote: vi.fn(),
   serializeParsedNote: vi.fn()
 }))
-vi.mock('./blocknote-converter', () => ({ markdownToYFragment: vi.fn() }))
+vi.mock('./blocknote-converter', () => ({
+  markdownToYFragment: vi.fn(),
+  repairEmptyBlockIds: vi.fn(() => 0)
+}))
 vi.mock('./crdt-compact-utils', () => ({ compactYDoc: vi.fn() }))
+vi.mock('./crdt-preflight', () => ({ runCrdtPreflight: vi.fn(async () => ({ ok: true })) }))
 vi.mock('./crdt-writeback', () => ({
   scheduleWriteback: vi.fn(),
   cancelPendingWritebacks: vi.fn(),
@@ -44,6 +52,8 @@ vi.mock('./crdt-writeback', () => ({
 }))
 vi.mock('./microtask-batch-broadcaster', () => ({
   MicrotaskBatchBroadcaster: class {
+    enqueue() {}
+    flush() {}
     flushAll() {}
     schedule() {}
   }
@@ -58,6 +68,7 @@ vi.mock('y-leveldb', () => ({
     }
     async storeUpdate() {}
     async clearDocument() {}
+    async flushDocument() {}
   }
 }))
 
@@ -191,6 +202,36 @@ describe('CRDT IPC handlers — lifecycle resilience', () => {
       // #then
       expect(result.success).toBe(false)
       expect(result.error).toMatch(/not initialized/i)
+    })
+  })
+
+  describe('window teardown releases the docs it pinned', () => {
+    beforeEach(() => {
+      senderWindow.current = { id: 42, once: vi.fn() }
+      mockGetNoteCacheById.mockReturnValue({ id: 'n1', path: 'n1.md', fileType: 'markdown' })
+    })
+
+    it('releases every doc the window held once it is closed', async () => {
+      // ⌘W / reload / renderer crash never runs the React cleanup that sends
+      // crdt:close-doc, and BrowserWindow ids are never recycled — so without
+      // this hook the id pins both docs for the rest of the session.
+      const provider = getCrdtProvider()
+      await provider.init()
+
+      await invokeHandler(CRDT_CHANNELS.OPEN_DOC, { noteId: 'n1' })
+      await invokeHandler(CRDT_CHANNELS.OPEN_DOC, { noteId: 'n2' })
+      expect(provider.getOpenNoteIds().sort()).toEqual(['n1', 'n2'])
+
+      // One 'closed' listener per window, not one per doc it opens.
+      expect(senderWindow.current.once).toHaveBeenCalledTimes(1)
+      expect(senderWindow.current.once).toHaveBeenCalledWith('closed', expect.any(Function))
+
+      const onClosed = senderWindow.current.once.mock.calls[0][1] as () => void
+      onClosed()
+
+      await vi.waitFor(() => {
+        expect(provider.getOpenNoteIds()).toEqual([])
+      })
     })
   })
 

--- a/apps/desktop/src/main/sync/crdt-provider.test.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.test.ts
@@ -454,6 +454,46 @@ describe('CrdtProvider', () => {
     expect(provider.getDoc('active-note')).toBe(activeDoc)
   })
 
+  it('releases the docs of a destroyed window and closes the ones it was last to hold', async () => {
+    // A window torn down by ⌘W / reload / renderer crash never runs the React
+    // cleanup that sends crdt:close-doc, and BrowserWindow ids are never
+    // recycled — so without an explicit release the stale id pins the doc for
+    // the rest of the session and disables eviction and compaction with it.
+    createWindow(11)
+    createWindow(12)
+
+    const shared = await provider.open('shared-note', 11, { skipSeed: true })
+    await provider.open('shared-note', 12, { skipSeed: true })
+    await provider.open('solo-note', 11, { skipSeed: true })
+
+    await provider.forgetWindow(11)
+
+    // Window 12 is still live and editing shared-note — never evict under it.
+    expect(provider.getDoc('shared-note')).toBe(shared)
+    expect(
+      provider.getOpenDocMetrics().docs.find((doc) => doc.noteId === 'shared-note')?.windowCount
+    ).toBe(1)
+
+    // solo-note lost its only window: flushed to persistence, then released.
+    expect(mocks.persistenceInstances[0].flushDocument).toHaveBeenCalledWith('solo-note')
+    expect(provider.getDoc('solo-note')).toBeUndefined()
+  })
+
+  it('drops broadcast targets whose window is gone so the doc stops being pinned', async () => {
+    createWindow(21)
+    await provider.open('note-1', 21, { skipSeed: true })
+    expect(provider.getOpenDocMetrics().docs[0].windowCount).toBe(1)
+
+    // The window is destroyed without any close-doc IPC and without the
+    // 'closed' hook having run (e.g. it was opened before registration).
+    mocks.windows.delete(21)
+
+    provider.updateMeta('note-1', { title: 'still typing' })
+
+    expect(provider.getOpenDocMetrics().docs[0].windowCount).toBe(0)
+    await expect(provider.closeIfInactive('note-1')).resolves.toBe(true)
+  })
+
   it('evicts least-recently-used inactive docs without evicting active editor docs', async () => {
     let now = 1_000
     const cappedProvider = new CrdtProvider({

--- a/apps/desktop/src/main/sync/crdt-provider.ts
+++ b/apps/desktop/src/main/sync/crdt-provider.ts
@@ -345,6 +345,38 @@ export class CrdtProvider {
     return !this.docs.has(noteId)
   }
 
+  /**
+   * Release every doc reference held by a window that no longer exists.
+   *
+   * The CLOSE_DOC invoke, sent from the renderer's React cleanup, is the only
+   * other path that clears a windowId — and ⌘W, a reload, or a renderer crash
+   * tears the process down without running it. BrowserWindow ids are monotonic
+   * and never recycled, so the stale id pins the doc for the rest of the
+   * session: close() early-returns, eviction skips it (windowIds.size === 0)
+   * and compaction bails, leaving the update log to grow unbounded.
+   *
+   * Call this ONLY for a window that has actually been destroyed. A hidden,
+   * minimised or background window is still live and must keep its docs
+   * pinned. Docs another live window still holds are left untouched, and the
+   * release goes through the same closeIfInactive path the sync engine uses,
+   * so the doc is flushed to persistence before it is destroyed.
+   */
+  async forgetWindow(windowId: number): Promise<void> {
+    const orphaned: string[] = []
+    for (const [noteId, entry] of this.docs) {
+      if (!entry.windowIds.delete(windowId)) continue
+      if (entry.windowIds.size === 0) orphaned.push(noteId)
+    }
+
+    for (const noteId of orphaned) {
+      await this.closeIfInactive(noteId)
+    }
+
+    if (orphaned.length > 0) {
+      log.debug('Released docs held by a closed window', { windowId, count: orphaned.length })
+    }
+  }
+
   async purge(noteId: string): Promise<void> {
     await this.close(noteId)
     await this.persistence?.clearDocument(noteId).catch((err) => {
@@ -724,7 +756,15 @@ export class CrdtProvider {
           origin
         })
       } else {
-        log.debug('Skipping CRDT broadcast for unavailable window', { noteId, windowId })
+        // Backstop for a window whose 'closed' hook never ran (opened the note
+        // before the hook was registered, or the provider was replaced by a
+        // vault switch): drop the id so it stops pinning the doc. A hidden or
+        // minimised window still resolves here, so this only ever sheds ids
+        // whose window is genuinely gone. Deliberately does not close the doc —
+        // this runs inside the doc's own 'update' handler — it just makes the
+        // doc eligible for the normal inactive-doc eviction pass.
+        entry.windowIds.delete(windowId)
+        log.debug('Dropped CRDT broadcast target for a window that is gone', { noteId, windowId })
       }
     }
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -173,6 +173,7 @@ export default defineConfig(
       'apps/desktop/src/main/inbox/filing.ts',
       'apps/desktop/src/main/inbox/suggestions.ts',
       'apps/desktop/src/main/sync/attachments.ts',
+      'apps/desktop/src/main/sync/crdt-provider.ts',
       'apps/desktop/src/main/vault/watcher.ts'
     ],
     rules: {


### PR DESCRIPTION
Fixes #999

## Verification — the issue is still real on current `main`

Confirmed on `main` @ `27bc2b961`:

- `apps/desktop/src/main/sync/crdt-provider.ts:305-312` — `close(noteId, windowId)` is the only code that removes an id from `entry.windowIds`.
- `apps/desktop/src/main/ipc/crdt-handlers.ts:51-56` — its only windowId-carrying caller is the `crdt:close-doc` invoke.
- `apps/desktop/src/renderer/src/sync/yjs-ipc-provider.ts:58` — that invoke is sent from `disconnect()`, i.e. React unmount only.
- No `'closed'` listener anywhere touched the CRDT provider (`grep "on('closed'\|once('closed'" apps/desktop/src/main` → only `canvas-handlers.ts:272`, `index.ts:717/742/1810`).

So ⌘W / reload / renderer crash left the id behind, and `BrowserWindow.id` is monotonic and never recycled. Downstream, exactly as filed:
`close()` early-returns forever (`:311`), `evictInactiveDocsIfNeeded` filters the entry out (`:804`, `windowIds.size === 0`), `compactDoc` bails (`:820-823`), and `broadcastToWindows` (`:716-728`) re-resolved the dead id to `null` on every single update without ever pruning it.

## Change

**`apps/desktop/src/main/sync/crdt-provider.ts`** — new `forgetWindow(windowId)`: strips the id from every entry, then runs `closeIfInactive()` for the notes that window was the last to hold. Plus one line in `broadcastToWindows` that drops ids whose `BrowserWindow` no longer resolves.

**`apps/desktop/src/main/ipc/crdt-handlers.ts`** — `crdt:open-doc` hooks `win.once('closed')` once per window (same pattern and rationale as `canvas-handlers.ts:266-277`), which calls `forgetWindow`. Registered before the first `await` so a window destroyed while `open()` is in flight is not missed.

**`eslint.config.mjs`** — `crdt-provider.ts` sat at *exactly* the 800-line `max-lines` cap on `main`, so any addition trips it. It joins the existing large-main-process-module override group rather than being split in a bugfix PR.

No IPC contract change (no new channel), no schema change, no renderer change.

### Why this is safe — the eviction correctness bar

**A live window's doc is never evicted.** `forgetWindow` is only ever invoked from `'closed'`, which Electron emits after the window is destroyed. Hidden, minimised and background windows never emit it, so they keep their docs pinned. The `broadcastToWindows` backstop resolves `BrowserWindow.fromId(windowId)` and additionally checks `isDestroyed()` — a hidden/minimised window still resolves there, so it can only shed ids whose window is genuinely gone. A doc another live window still holds is left untouched (covered by the `shared-note` assertion in the test).

**No unpersisted updates are dropped, including one that arrives microseconds before eviction.** `forgetWindow` does not introduce an eviction path — it routes into `closeIfInactive` → `close()`, byte-for-byte the same flush-then-destroy the `crdt:close-doc` unmount path and the sync engine (`crdt-sync-coordinator.ts:185,317`) already use. Every update is handed to `persistence.storeUpdate` synchronously inside the doc's own `'update'` handler (`persistUpdate`, `:686`), and y-leveldb funnels all operations through a single FIFO transaction chain — so an update stored at T is already queued ahead of the `flushDocument` that `close()` awaits at T+ε. `close()` also flushes the pending network broadcast and pushes a snapshot when `pendingSnapshotBytes > 0` before `doc.destroy()`.

The 500 ms debounced markdown writeback holds its own `Y.Doc` reference and can fire after `destroy()`. Verified this is not lossy — `Doc.destroy()` clears observers and subdocs but leaves `store`/`share` intact:

```
isDestroyed: true
fragment readable after destroy: "typed right before eviction"
encoded state identical after destroy: true
reopen reconstructs: "typed right before eviction"
```

**Re-opening reconstructs identical content.** `doOpen` rebuilds from `persistence.getYDoc(noteId)`, which merges every stored update; since all updates were `storeUpdate`d before the flush, the reopened doc is byte-identical (last line of the check above).

**Eviction racing a concurrent open / SYNC_STEP_1.** If a reopen lands during an async close, `open()` sees `entry.closing` and takes `doOpen`, reading from persistence — and y-leveldb's FIFO ordering guarantees it observes every update stored before, whether or not the in-flight `flushDocument` has settled yet. The pre-existing `applyRemoteUpdate` drop-while-closing behaviour is unchanged and self-heals: `applyCrdtIncrementals` re-applies the server snapshot baseline at the top of every cycle, and `lastAppliedSequence` is in-memory only.

### Interaction with #1084 (deliberately not fixed here)

Enabling eviction does **not** make #1084 live, and this was checked rather than assumed:

- `syncStep1` has exactly one caller — `YjsIpcProvider.performSyncHandshake()` — reached only after `await this.openDoc()` resolves. A failed `openDoc` throws out of `connect()` before the handshake. So a window that is actively editing a note always has its id in `windowIds`; there is no live editor whose doc `forgetWindow` could orphan.
- `forgetWindow` never removes an id belonging to a window that still exists, so it cannot empty the set under a live editor.
- The eviction *pressure* in #1084 goes **down**, not up: today window-pinned docs never enter the inactive pool at all, and after this change they are closed outright when their last window dies. The LRU pool `evictInactiveDocsIfNeeded` scans is the same size or smaller, so a handshake-opened doc is no more likely to be evicted than before.

Also deliberately **not** done: releasing ids on renderer *reload*. There is no Electron signal that distinguishes a reload from in-app navigation, and `did-start-navigation` fires on hash routing too — releasing a live window's ids there would let `applyIpcUpdate` silently drop the editor's keystrokes into an unopened doc. That is exactly the hazard this PR must not ship. Residual: a note open at reload time and not restored afterwards stays pinned for that window's lifetime.

## Tests

`apps/desktop/src/main/sync/crdt-provider.test.ts` (real provider, real Y.Docs, no IPC mocking):
- `releases the docs of a destroyed window and closes the ones it was last to hold` — `shared-note` (windows 11+12) survives `forgetWindow(11)` with `windowCount: 1`; `solo-note` is flushed then released.
- `drops broadcast targets whose window is gone so the doc stops being pinned` — window vanishes with no cleanup at all; the next update sheds the id and `closeIfInactive` then succeeds.

`apps/desktop/src/main/sync/crdt-ipc-handlers.test.ts`:
- `releases every doc the window held once it is closed` — end-to-end through the real handler and a real initialised provider: two docs opened via `crdt:open-doc` from window 42, one `'closed'` listener (not one per doc), firing it empties `getOpenNoteIds()`.

**Red → green.** Before the fix:

```
FAIL  crdt-ipc-handlers.test.ts > releases every doc the window held once it is closed
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times   (no 'closed' hook exists)

FAIL  crdt-provider.test.ts > releases the docs of a destroyed window ...
TypeError: provider.forgetWindow is not a function

FAIL  crdt-provider.test.ts > drops broadcast targets whose window is gone ...
AssertionError: expected 1 to be +0                                        (stale id still pins the doc)
```

After: `Test Files 2 passed (2) · Tests 50 passed (50)`.

**Mutation-tested** (the fix reverted one piece at a time, each confirmed red again):

| reverted | result |
|---|---|
| `if (win) hookWindowClose(win)` | `1 failed \| 9 passed` — "expected to be called 1 times, but got 0" |
| `forgetWindow`'s `closeIfInactive` loop | `2 failed \| 48 passed` — "expected [ 'n1', 'n2' ] to deeply equal []" |
| `entry.windowIds.delete(windowId)` in `broadcastToWindows` | `1 failed \| 39 passed` — "expected 1 to be +0" |

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (incl. `check:contracts`, `check:architecture`, `ipc:check`, `rpc:check`; all "up to date").
- `pnpm lint` — `14 problems (0 errors, 14 warnings)`. The 14 warnings are pre-existing on `main` in untouched files (`tags-hub/*`, `use-folder-view.ts`, `use-tab-keyboard-shortcuts.ts`).
- Full main-process suite: `Test Files 475 passed | 1 skipped (476) · Tests 5419 passed | 1 expected fail | 4 skipped`.
- Renderer untouched, so the renderer suite was not run.
