### PR TITLE
fix(agent): destroy in-flight MCP connections when the server stops

### DIFF
--- a/apps/desktop/src/main/agent/mcp/__tests__/server.test.ts
+++ b/apps/desktop/src/main/agent/mcp/__tests__/server.test.ts
@@ -216,6 +216,52 @@ describe('Agent MCP server tool round-trip', () => {
   })
 })
 
+describe('Agent MCP server shutdown', () => {
+  it('stops while a tool call is still in flight', async () => {
+    let releaseHandler!: () => void
+    let markHandlerStarted!: () => void
+    const handlerStarted = new Promise<void>((resolve) => {
+      markHandlerStarted = resolve
+    })
+    const handlerCanFinish = new Promise<void>((resolve) => {
+      releaseHandler = resolve
+    })
+    const handle = await startAgentMcpServer({
+      toolRegistrations: [
+        {
+          name: 'stuck_tool',
+          description: 'blocks until released',
+          inputSchema: z.object({}),
+          handler: async () => {
+            markHandlerStarted()
+            await handlerCanFinish
+            return {}
+          }
+        }
+      ]
+    })
+    const inFlight = callTool(handle, 'stuck_tool', {}).catch(() => undefined)
+    await handlerStarted
+
+    try {
+      await expect(withDeadline(handle.stop(), 3000)).resolves.toBe('stopped')
+    } finally {
+      releaseHandler()
+      await inFlight
+    }
+  })
+})
+
+function withDeadline(promise: Promise<unknown>, ms: number): Promise<'stopped'> {
+  let timer: NodeJS.Timeout
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`stop() did not resolve within ${ms}ms`)), ms)
+  })
+  return Promise.race([promise.then(() => 'stopped' as const), deadline]).finally(() =>
+    clearTimeout(timer)
+  )
+}
+
 function callTool(
   handle: AgentMcpServerHandle,
   name: string,

--- a/apps/desktop/src/main/agent/mcp/server.ts
+++ b/apps/desktop/src/main/agent/mcp/server.ts
@@ -12,6 +12,10 @@ import { createMcpSession } from './session'
 
 const logger = createLogger('AgentMcpServer')
 
+// How long stop() lets an in-flight tool call finish before its socket is
+// destroyed. Kept well under the 5s app shutdown budget in main/index.ts.
+const STOP_GRACE_MS = 500
+
 export interface ToolRegistration {
   name: string
   description: string
@@ -148,7 +152,22 @@ export async function startAgentMcpServer(opts: StartOptions): Promise<AgentMcpS
     rotateToken: () => session.rotateToken(),
     registerTool: bindTool,
     async stop() {
-      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await new Promise<void>((resolve) => {
+        // close() only refuses new connections and drops idle ones: a socket
+        // still serving a request (including one whose tool call never
+        // settles) keeps it pending forever. At quit that stalls closeVault()
+        // before it can drain projections, stop sync and close the databases,
+        // so the 5s shutdown timeout fires app.exit(1) with work unfinished.
+        // Give in-flight calls a short grace period, then destroy the sockets.
+        const graceTimer = setTimeout(() => {
+          logger.warn('Agent MCP connections still open at stop; destroying them')
+          server.closeAllConnections?.()
+        }, STOP_GRACE_MS)
+        server.close(() => {
+          clearTimeout(graceTimer)
+          resolve()
+        })
+      })
       logger.info('Agent MCP server stopped')
     }
   }


### PR DESCRIPTION
Fixes #1003

## Verification (issue still real)

`apps/desktop/src/main/agent/mcp/server.ts:150-153` on current `main`:

```ts
async stop() {
  await new Promise<void>((resolve) => server.close(() => resolve()))
  logger.info('Agent MCP server stopped')
}
```

No connection destruction, unlike `apps/desktop/src/main/capture/server.ts:242` which calls `closing.closeAllConnections?.()` before `close()`.

Why a hang here is expensive: `stopAgentMcpLifecycle()` is awaited from `stopVaultAgentServices()`, which is the **first** step of `closeVault()` (`apps/desktop/src/main/vault/index.ts:570-597`) — before `stopWatcher()`, `stopProjectionRuntime({ drain: true })`, `stopSyncRuntime()` and `closeAllDatabases()`. So a stalled MCP stop blocks the projection drain and the database close, and the 5s `shutdownTimeout` (`apps/desktop/src/main/index.ts:1971-1985`) then fires `app.exit(1)`.

One nuance found while verifying: Node's `http.Server.close()` already calls `closeIdleConnections()` internally, so a purely *idle* keep-alive socket does not block. Tests for a parked keep-alive socket and for a connected-but-silent socket both passed unmodified, so they were dropped as worthless. The real, reproducible stall is an **active** connection — a socket whose request handler has not returned, which is exactly the leaked-socket shape described in #1002. That case blocks `close()` indefinitely.

## Change

`apps/desktop/src/main/agent/mcp/server.ts` — `stop()` now arms a `STOP_GRACE_MS` (500 ms) timer that calls `server.closeAllConnections?.()`, cleared when `close()` completes first. Nothing else changed; `close()` still handles the normal and idle cases, the grace period still lets a legitimate in-flight tool call finish, and the shutdown work that must complete (renderer flush, close snapshots, telemetry flush, final sync push, projection drain, DB close) all runs either before this point or after it in `closeVault()` — destroying a socket only drops the HTTP response, it does not interrupt a service call already executing.

500 ms is deliberately well under the 5 s shutdown budget.

## Tests

`apps/desktop/src/main/agent/mcp/__tests__/server.test.ts` — new `Agent MCP server shutdown > stops while a tool call is still in flight`: registers a tool whose handler blocks, issues a real `tools/call` over HTTP, waits for the handler to start, then asserts `handle.stop()` resolves within 3 s.

Red before the fix:

```
FAIL src/main/agent/mcp/__tests__/server.test.ts > Agent MCP server shutdown > stops while a tool call is still in flight
AssertionError: promise rejected "Error: stop() did not resolve within 3000…" instead of resolving
Caused by: Error: stop() did not resolve within 3000ms
```

Green after: `PASS (25) FAIL (0)` for `src/main/agent/mcp/__tests__/`.

Mutation check: replacing the `server.closeAllConnections?.()` line with a no-op turns the test red again (`PASS (9) FAIL (1)`, same assertion), then green when restored.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + rpc + ipc map all up to date)
- `pnpm lint` — 0 errors, 14 warnings, all pre-existing in unrelated renderer files
- `pnpm exec vitest run --project main src/main/agent/mcp/__tests__/ src/main/vault/index.test.ts` — `PASS (35) FAIL (0)`
- `git diff --check` — clean
