### PR TITLE
fix(agent-chat): evict agent conversation transcripts beyond an LRU cap

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context-eviction.test.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context-eviction.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AgentEvent, Conversation, Message } from '@memry/contracts/ipc-agent'
+
+import {
+  agentReducer,
+  HYDRATED_CONVERSATION_LIMIT,
+  initialAgentState,
+  type AgentState
+} from '../agent-context.reducer'
+
+function conversation(id: string): Conversation {
+  return {
+    id,
+    vaultId: 'vault-1',
+    title: id,
+    backend: 'claude_cli',
+    backendModel: null,
+    trustList: [],
+    pinned: false,
+    vectorClock: {},
+    fieldClocks: {},
+    createdAt: 100,
+    updatedAt: 100,
+    deletedAt: null,
+    lastSyncedAt: null
+  }
+}
+
+function assistantMessage(input: {
+  id: string
+  conversationId: string
+  text: string
+  status?: Message['status']
+}): Message {
+  return {
+    id: input.id,
+    conversationId: input.conversationId,
+    role: 'assistant',
+    content: { role: 'assistant', data: { text: input.text } },
+    toolCallId: null,
+    attachments: [],
+    status: input.status ?? 'completed',
+    vectorClock: {},
+    createdAt: 100,
+    updatedAt: 100,
+    deletedAt: null
+  }
+}
+
+/** Hydrates `count` conversations in order, activating each one in turn. */
+function hydrateSequence(count: number, from = 0): AgentState {
+  let state = initialAgentState
+  for (let index = from; index < from + count; index++) {
+    const id = `conversation-${index}`
+    state = agentReducer(state, {
+      type: 'set_active_conversation',
+      conversation: conversation(id),
+      messages: [assistantMessage({ id: `message-${index}`, conversationId: id, text: id })]
+    })
+  }
+  return state
+}
+
+describe('agentReducer transcript retention', () => {
+  it('keeps every hydrated transcript up to the cap', () => {
+    const state = hydrateSequence(HYDRATED_CONVERSATION_LIMIT)
+
+    expect(Object.keys(state.messagesByConversation)).toHaveLength(HYDRATED_CONVERSATION_LIMIT)
+  })
+
+  it('evicts the least-recently hydrated transcript once the cap is exceeded', () => {
+    const state = hydrateSequence(HYDRATED_CONVERSATION_LIMIT + 2)
+
+    expect(Object.keys(state.messagesByConversation)).toHaveLength(HYDRATED_CONVERSATION_LIMIT)
+    expect(state.messagesByConversation['conversation-0']).toBeUndefined()
+    expect(state.messagesByConversation['conversation-1']).toBeUndefined()
+    expect(
+      state.messagesByConversation[`conversation-${HYDRATED_CONVERSATION_LIMIT + 1}`]
+    ).toBeDefined()
+  })
+
+  it('re-hydrating an old conversation makes it most recent again', () => {
+    let state = hydrateSequence(HYDRATED_CONVERSATION_LIMIT)
+    // Touch the oldest so it is no longer the eviction candidate.
+    state = agentReducer(state, {
+      type: 'set_active_conversation',
+      conversation: conversation('conversation-0'),
+      messages: [
+        assistantMessage({ id: 'message-0', conversationId: 'conversation-0', text: 'again' })
+      ]
+    })
+    state = agentReducer(state, {
+      type: 'set_active_conversation',
+      conversation: conversation('conversation-new'),
+      messages: []
+    })
+
+    expect(state.messagesByConversation['conversation-0']).toBeDefined()
+    expect(state.messagesByConversation['conversation-1']).toBeUndefined()
+  })
+
+  it('never evicts the active conversation', () => {
+    let state = hydrateSequence(1)
+    // `conversation-0` stays active while background loads hydrate everything else.
+    for (let index = 1; index < HYDRATED_CONVERSATION_LIMIT + 3; index++) {
+      const id = `conversation-${index}`
+      state = agentReducer(state, {
+        type: 'set_conversation_messages',
+        conversation: conversation(id),
+        messages: [assistantMessage({ id: `message-${index}`, conversationId: id, text: id })]
+      })
+    }
+
+    expect(state.activeConversationId).toBe('conversation-0')
+    expect(state.messagesByConversation['conversation-0']).toBeDefined()
+  })
+
+  it('never evicts a conversation with an in-flight turn', () => {
+    let state = hydrateSequence(1)
+    state = agentReducer(state, {
+      type: 'set_in_flight',
+      conversationId: 'conversation-0',
+      inFlight: true
+    })
+    state = { ...state, activeConversationId: null }
+
+    for (let index = 1; index < HYDRATED_CONVERSATION_LIMIT + 3; index++) {
+      const id = `conversation-${index}`
+      state = agentReducer(state, {
+        type: 'set_conversation_messages',
+        conversation: conversation(id),
+        messages: [assistantMessage({ id: `message-${index}`, conversationId: id, text: id })]
+      })
+    }
+
+    expect(state.messagesByConversation['conversation-0']).toBeDefined()
+  })
+
+  it('never evicts a conversation with a pending tool approval', () => {
+    let state = hydrateSequence(1)
+    const approval: AgentEvent = {
+      kind: 'tool_call_pending_approval',
+      conversationId: 'conversation-0',
+      toolCallId: 'tool-1',
+      name: 'vault_create_task',
+      args: { title: 'Buy milk' },
+      requiresDiff: false
+    }
+    state = agentReducer(state, { type: 'event', event: approval })
+    state = { ...state, activeConversationId: null }
+
+    for (let index = 1; index < HYDRATED_CONVERSATION_LIMIT + 3; index++) {
+      const id = `conversation-${index}`
+      state = agentReducer(state, {
+        type: 'set_conversation_messages',
+        conversation: conversation(id),
+        messages: [assistantMessage({ id: `message-${index}`, conversationId: id, text: id })]
+      })
+    }
+
+    expect(state.pendingApprovals).toHaveLength(1)
+    expect(state.messagesByConversation['conversation-0']).toBeDefined()
+  })
+
+  it('never evicts a transcript holding an unpersisted streaming message', () => {
+    let state = agentReducer(initialAgentState, {
+      type: 'set_active_conversation',
+      conversation: conversation('conversation-0'),
+      messages: [
+        assistantMessage({
+          id: 'assistant-0',
+          conversationId: 'conversation-0',
+          text: '',
+          status: 'streaming'
+        })
+      ]
+    })
+    // Main only persists the assistant text when the turn ends, so the deltas
+    // accumulated here exist nowhere else.
+    state = agentReducer(state, {
+      type: 'event',
+      event: {
+        kind: 'assistant_text_delta',
+        conversationId: 'conversation-0',
+        messageId: 'assistant-0',
+        text: 'partial answer'
+      }
+    })
+    state = { ...state, activeConversationId: null }
+
+    for (let index = 1; index < HYDRATED_CONVERSATION_LIMIT + 3; index++) {
+      const id = `conversation-${index}`
+      state = agentReducer(state, {
+        type: 'set_conversation_messages',
+        conversation: conversation(id),
+        messages: [assistantMessage({ id: `message-${index}`, conversationId: id, text: id })]
+      })
+    }
+
+    expect(state.messagesByConversation['conversation-0']?.[0]?.content).toEqual({
+      role: 'assistant',
+      data: { text: 'partial answer' }
+    })
+  })
+
+  it('rebuilds an evicted transcript from main on reopen', () => {
+    const persisted = [
+      assistantMessage({ id: 'message-0', conversationId: 'conversation-0', text: 'conversation-0' })
+    ]
+    let state = hydrateSequence(HYDRATED_CONVERSATION_LIMIT + 2)
+    expect(state.messagesByConversation['conversation-0']).toBeUndefined()
+
+    state = agentReducer(state, {
+      type: 'set_active_conversation',
+      conversation: conversation('conversation-0'),
+      messages: persisted
+    })
+
+    expect(state.messagesByConversation['conversation-0']).toEqual(persisted)
+  })
+
+  it('does not duplicate messages when a late event races the reload of an evicted transcript', () => {
+    const late = assistantMessage({
+      id: 'message-late',
+      conversationId: 'conversation-0',
+      text: 'late'
+    })
+    let state = hydrateSequence(HYDRATED_CONVERSATION_LIMIT + 2)
+    expect(state.messagesByConversation['conversation-0']).toBeUndefined()
+
+    // Event lands before the reload resolves…
+    state = agentReducer(state, {
+      type: 'event',
+      event: { kind: 'message_upserted', message: late }
+    })
+    state = agentReducer(state, {
+      type: 'set_active_conversation',
+      conversation: conversation('conversation-0'),
+      messages: [late]
+    })
+    // …and again after it.
+    state = agentReducer(state, {
+      type: 'event',
+      event: { kind: 'message_upserted', message: late }
+    })
+
+    expect(state.messagesByConversation['conversation-0']).toEqual([late])
+  })
+})

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
@@ -15,6 +15,12 @@ export interface AgentState {
   activeConversationId: string | null
   conversations: Record<string, Conversation>
   messagesByConversation: Record<string, Message[]>
+  /**
+   * Conversation ids whose transcript was hydrated from main, least recently
+   * hydrated first. Drives transcript eviction; see
+   * {@link HYDRATED_CONVERSATION_LIMIT}.
+   */
+  hydratedConversationIds: string[]
   pendingApprovals: PendingToolApproval[]
   inFlight: Record<string, boolean>
   error: string | null
@@ -41,6 +47,19 @@ export type AgentAction =
   | { type: 'event'; event: AgentEvent }
   | { type: 'clear_pending'; toolCallId: string; status?: 'approved' | 'denied' }
 
+/**
+ * How many conversation transcripts stay hydrated in renderer memory. Without a
+ * cap, a day of Agent Chat use retains every opened conversation's full message
+ * array — including every tool call's args and every tool result's output — for
+ * the lifetime of the window.
+ *
+ * The cap sits above the number of agent surfaces that can be mounted at once
+ * (four split-view panes plus the right sidebar) so a transcript is never
+ * evicted out from under a view that is rendering it, which would make that
+ * view re-fetch it immediately.
+ */
+export const HYDRATED_CONVERSATION_LIMIT = 6
+
 export const initialAgentState: AgentState = {
   backendStatuses: null,
   disclosureAccepted: null,
@@ -48,6 +67,7 @@ export const initialAgentState: AgentState = {
   activeConversationId: null,
   conversations: {},
   messagesByConversation: {},
+  hydratedConversationIds: [],
   pendingApprovals: [],
   inFlight: {},
   error: null
@@ -157,6 +177,71 @@ function updateToolCallStatusEverywhere(
   )
 }
 
+/**
+ * A transcript may only be dropped when main can rebuild it byte for byte.
+ * Anything still live in this window — the conversation on screen, a turn we
+ * started, an approval the user has not answered, or an assistant message whose
+ * streamed text main only persists once the turn ends — is retained regardless
+ * of the cap.
+ */
+function isPinnedTranscript(
+  state: AgentState,
+  input: {
+    activeConversationId: string | null
+    messagesByConversation: AgentState['messagesByConversation']
+    conversationId: string
+  }
+): boolean {
+  if (input.conversationId === input.activeConversationId) return true
+  if (state.inFlight[input.conversationId] === true) return true
+  if (state.pendingApprovals.some((pending) => pending.conversationId === input.conversationId)) {
+    return true
+  }
+  return (input.messagesByConversation[input.conversationId] ?? []).some(
+    (message) => message.status === 'streaming'
+  )
+}
+
+/**
+ * Records `hydratedConversationId` as the most recently hydrated transcript and
+ * drops the transcripts that fall outside the cap. Everything dropped here is
+ * re-fetched from main the next time the conversation is opened.
+ */
+function retainHydratedTranscripts(
+  state: AgentState,
+  input: {
+    hydratedConversationId: string
+    activeConversationId: string | null
+    messagesByConversation: AgentState['messagesByConversation']
+  }
+): Pick<AgentState, 'messagesByConversation' | 'hydratedConversationIds'> {
+  const hydratedConversationIds = [
+    ...state.hydratedConversationIds.filter((id) => id !== input.hydratedConversationId),
+    input.hydratedConversationId
+  ]
+  const recent = new Set(hydratedConversationIds.slice(-HYDRATED_CONVERSATION_LIMIT))
+  const evicted = new Set(
+    Object.keys(input.messagesByConversation).filter(
+      (conversationId) =>
+        !recent.has(conversationId) &&
+        !isPinnedTranscript(state, {
+          activeConversationId: input.activeConversationId,
+          messagesByConversation: input.messagesByConversation,
+          conversationId
+        })
+    )
+  )
+  if (evicted.size === 0) {
+    return { messagesByConversation: input.messagesByConversation, hydratedConversationIds }
+  }
+  return {
+    messagesByConversation: Object.fromEntries(
+      Object.entries(input.messagesByConversation).filter(([id]) => !evicted.has(id))
+    ),
+    hydratedConversationIds: hydratedConversationIds.filter((id) => !evicted.has(id))
+  }
+}
+
 function withoutInFlight(state: AgentState, conversationId: string): Record<string, boolean> {
   const { [conversationId]: _removed, ...rest } = state.inFlight
   return rest
@@ -180,35 +265,47 @@ export function agentReducer(state: AgentState, action: AgentAction): AgentState
           action.conversations.map((conversation) => [conversation.id, conversation])
         )
       }
-    case 'set_active_conversation':
+    case 'set_active_conversation': {
       if (!action.conversation) {
         return { ...state, activeConversationId: null }
       }
+      const conversationId = action.conversation.id
       return {
         ...state,
-        activeConversationId: action.conversation.id,
+        activeConversationId: conversationId,
         conversations: {
           ...state.conversations,
-          [action.conversation.id]: action.conversation
+          [conversationId]: action.conversation
         },
-        messagesByConversation: {
-          ...state.messagesByConversation,
-          [action.conversation.id]: action.messages
-        }
+        ...retainHydratedTranscripts(state, {
+          hydratedConversationId: conversationId,
+          activeConversationId: conversationId,
+          messagesByConversation: {
+            ...state.messagesByConversation,
+            [conversationId]: action.messages
+          }
+        })
       }
-    case 'set_conversation_messages':
+    }
+    case 'set_conversation_messages': {
       if (!action.conversation) return state
+      const conversationId = action.conversation.id
       return {
         ...state,
         conversations: {
           ...state.conversations,
-          [action.conversation.id]: action.conversation
+          [conversationId]: action.conversation
         },
-        messagesByConversation: {
-          ...state.messagesByConversation,
-          [action.conversation.id]: action.messages
-        }
+        ...retainHydratedTranscripts(state, {
+          hydratedConversationId: conversationId,
+          activeConversationId: state.activeConversationId,
+          messagesByConversation: {
+            ...state.messagesByConversation,
+            [conversationId]: action.messages
+          }
+        })
       }
+    }
     case 'clear_active_conversation':
       return {
         ...state,


### PR DESCRIPTION
Fixes #1004

## Verification — the issue is still real on `main`

`apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts` on current `main`:

- `AgentState.messagesByConversation: Record<string, Message[]>` (`:17`)
- written by `set_active_conversation` (`:194`), `set_conversation_messages` (`:207`) and by the `event` case for `message_upserted` (`:245`), `assistant_text_delta` (`:266`), `tool_call_pending_approval` (`:279`) and `tool_call_started` (`:297`)
- `clear_active_conversation` (`:212-216`) only nulls `activeConversationId` — it deliberately keeps the cached transcripts, and there is an existing test asserting that ("clears the active conversation without dropping cached conversations or messages")
- no action anywhere deletes a key from `messagesByConversation`

So every conversation opened during a session keeps its full message array — including every tool call's `args` and every tool result's `output` — until the window is destroyed. `broadcastAgentEvent` fans out to *all* windows (`main/agent/runtime/event-bus.ts`), so background windows accumulate entries too.

## Change

One file: `agent-context.reducer.ts`.

- New `AgentState.hydratedConversationIds: string[]` — conversation ids whose transcript came from main, least-recently hydrated first.
- New exported `HYDRATED_CONVERSATION_LIMIT = 6`. The cap is above the maximum number of agent surfaces that can be mounted simultaneously (four split-view panes — `layout-presets.ts` tops out at `grid-2x2` — plus the right sidebar), so a transcript is never evicted out from under a view rendering it, which would make that view re-fetch it in a loop.
- `set_active_conversation` and `set_conversation_messages` — the only two actions that hydrate a transcript from main — now record recency and drop transcripts outside the cap.
- Evicted transcripts are re-fetched on reopen through the paths that already exist: `AgentConversationTab` reloads when `messagesByConversation[id]` is `undefined`, and selecting a conversation always calls `loadConversation`.

### What is never evicted

`isPinnedTranscript` keeps anything main cannot rebuild, regardless of the cap:

- the active conversation
- a conversation with an in-flight turn (`state.inFlight[id]`)
- a conversation with a pending tool approval
- a transcript holding a message with `status === 'streaming'` — `runTurn` only persists the assistant text at `markTerminal` (`main/agent/runtime/turn.ts:240`), so mid-stream delta text exists nowhere but renderer memory

### Why it is minimal

No change to how tokens or tool results are applied, no reducer restructuring, no touch to `sidebar-tabs.tsx`, no IPC/contract/schema/settings change. `clear_active_conversation` keeps its documented cache-preserving behaviour. Renderer-local state only — nothing persisted, so nothing to migrate.

### Known limitation (pre-existing, unchanged in kind)

`tool_call` messages are synthesised in the reducer and are **never** persisted by main — `MessageStore.append` is only called with `user` and `assistant` roles. They already do not survive an app restart, and the existing sync-driven reload path (`onMessagesChanged` → `loadConversation({activate:false})` → `set_conversation_messages`) already replaces them wholesale. After eviction, reopening a conversation older than the 6 most recent likewise shows it without its tool rows. Persisting tool calls would be a main-process write-path + sync change and is out of scope for this issue.

## Tests

New `apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context-eviction.test.ts` (9 cases).

**Red** (constant + state field present, eviction not implemented):

```
PASS (5) FAIL (4)
1. evicts the least-recently hydrated transcript once the cap is exceeded
   AssertionError: expected [ 'conversation-0', …(7) ] to have a length of 6 but got 8
2. re-hydrating an old conversation makes it most recent again
   AssertionError: expected [ { id: 'message-1', …(10) } ] to be undefined
3. rebuilds an evicted transcript from main on reopen
   AssertionError: expected [ { id: 'message-0', …(10) } ] to be undefined
4. does not duplicate messages when a late event races the reload of an evicted transcript
   AssertionError: expected [ { id: 'message-0', …(10) } ] to be undefined
```

**Green** after the fix, together with the whole existing agent-chat suite:

```
vitest run --project renderer \
  agent-context-eviction.test.ts agent-context.test.tsx agent-provider.test.tsx \
  agent-conversation-tab.test.tsx conversation-view.test.tsx sidebar-tabs.test.tsx agent-pane.test.tsx
PASS (55) FAIL (0)
```

**Mutation check** — the four safety guards are load-bearing. Forcing `isPinnedTranscript` to `return false`:

```
PASS (5) FAIL (4)
1. never evicts the active conversation
2. never evicts a conversation with an in-flight turn
3. never evicts a conversation with a pending tool approval
4. never evicts a transcript holding an unpersisted streaming message
```

Reverted, re-verified byte-identical, green again.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture boundaries, RPC bindings, IPC invoke map, node + web tsc all clean)
- `pnpm lint` — `✖ 14 problems (0 errors, 14 warnings)`; all pre-existing warnings in unrelated files (`tags-hub/*`, `use-folder-view.ts`, `use-tab-keyboard-shortcuts.ts`), none in the changed file
- targeted renderer tests — pass, as above

`pnpm docs:impact --strict` reports `missing-docs` for the reducer. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: this is renderer-internal memory management with no user-visible surface, no setting, no shortcut and no behaviour a user can observe beyond a transcript being re-read from the local DB on reopen.
