### PR TITLE
perf(agent-chat): coalesce streamed deltas and scope message re-renders

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-provider.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
   AgentBackendStatus,
@@ -360,5 +360,176 @@ describe('AgentProvider', () => {
 
   it('requires an AgentProvider', () => {
     expect(() => renderHook(() => useAgent())).toThrow('useAgent must be used within AgentProvider')
+  })
+
+  describe('assistant text streaming', () => {
+    let frames: Array<() => void>
+
+    beforeEach(() => {
+      frames = []
+      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        frames.push(() => callback(0))
+        return frames.length
+      })
+      vi.stubGlobal('cancelAnimationFrame', (handle: number) => {
+        frames[handle - 1] = () => {}
+      })
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    function runFrame(): void {
+      act(() => {
+        for (const frame of frames.splice(0, frames.length)) frame()
+      })
+    }
+
+    function delta(text: string) {
+      return {
+        kind: 'assistant_text_delta',
+        conversationId: conversation.id,
+        messageId: message.id,
+        text
+      }
+    }
+
+    function streamedText(state: { messagesByConversation: Record<string, Message[]> }): string {
+      const target = (state.messagesByConversation[conversation.id] ?? []).find(
+        (candidate) => candidate.id === message.id
+      )
+      if (!target || target.content.role !== 'assistant') return ''
+      return target.content.data.text
+    }
+
+    async function mountStreamingConversation() {
+      const renders = { count: 0 }
+      const { result } = renderHook(
+        () => {
+          renders.count += 1
+          return useAgent()
+        },
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.state.sourceWindowId).toBe('window-1'))
+      await act(async () => {
+        await result.current.loadConversation(conversation.id)
+      })
+      await waitFor(() =>
+        expect(result.current.state.messagesByConversation[conversation.id]).toHaveLength(1)
+      )
+
+      return { renders, result }
+    }
+
+    it('coalesces a burst of deltas into a single commit without dropping a token', async () => {
+      const { renders, result } = await mountStreamingConversation()
+      const tokens = Array.from({ length: 200 }, (_, index) => `tok${index} `)
+      const rendersBeforeStream = renders.count
+
+      for (const token of tokens) {
+        act(() => {
+          eventHandler?.(delta(token))
+        })
+      }
+
+      // Every token used to dispatch on its own, re-rendering every consumer of
+      // the agent context once per token.
+      expect(renders.count).toBe(rendersBeforeStream)
+
+      runFrame()
+
+      expect(renders.count).toBe(rendersBeforeStream + 1)
+      expect(streamedText(result.current.state)).toBe(`Ready${tokens.join('')}`)
+    })
+
+    it('keeps committing partial text while the turn is still streaming', async () => {
+      const { result } = await mountStreamingConversation()
+
+      for (const token of ['alpha ', 'beta ']) {
+        act(() => {
+          eventHandler?.(delta(token))
+        })
+      }
+      runFrame()
+      expect(streamedText(result.current.state)).toBe('Readyalpha beta ')
+
+      for (const token of ['gamma ', 'delta']) {
+        act(() => {
+          eventHandler?.(delta(token))
+        })
+      }
+      runFrame()
+      expect(streamedText(result.current.state)).toBe('Readyalpha beta gamma delta')
+    })
+
+    it('drains buffered deltas before the next non-delta event is applied', async () => {
+      const { result } = await mountStreamingConversation()
+
+      act(() => {
+        eventHandler?.(delta('one '))
+        eventHandler?.(delta('two '))
+      })
+
+      act(() => {
+        eventHandler?.({
+          kind: 'turn_completed',
+          conversationId: conversation.id,
+          turnId: 'turn-1'
+        })
+      })
+
+      // No frame ran, yet the buffered text must already be in state: a later
+      // event must never be applied ahead of text that arrived before it.
+      expect(streamedText(result.current.state)).toBe('Readyone two ')
+      expect(result.current.state.inFlight[conversation.id]).toBeUndefined()
+
+      runFrame()
+      expect(streamedText(result.current.state)).toBe('Readyone two ')
+    })
+
+    it('keeps interleaved messages in arrival order', async () => {
+      const { result } = await mountStreamingConversation()
+
+      act(() => {
+        eventHandler?.({
+          kind: 'message_upserted',
+          message: {
+            ...message,
+            id: 'message-2',
+            content: { role: 'assistant', data: { text: '' } },
+            status: 'streaming',
+            createdAt: 200,
+            updatedAt: 200
+          }
+        })
+      })
+
+      act(() => {
+        eventHandler?.(delta('a'))
+        eventHandler?.({
+          kind: 'assistant_text_delta',
+          conversationId: conversation.id,
+          messageId: 'message-2',
+          text: 'x'
+        })
+        eventHandler?.(delta('b'))
+        eventHandler?.({
+          kind: 'assistant_text_delta',
+          conversationId: conversation.id,
+          messageId: 'message-2',
+          text: 'y'
+        })
+      })
+
+      runFrame()
+
+      const messages = result.current.state.messagesByConversation[conversation.id]
+      const second = messages.find((candidate) => candidate.id === 'message-2')
+      expect(streamedText(result.current.state)).toBe('Readyab')
+      expect(second?.content.role === 'assistant' ? second.content.data.text : null).toBe('xy')
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream-render-scoping.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/message-stream-render-scoping.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Message } from '@memry/contracts/ipc-agent'
+
+const mockUseAgentOptional = vi.hoisted(() => vi.fn())
+const mockOpenTab = vi.hoisted(() => vi.fn())
+const renderCounts = vi.hoisted(() => ({ user: 0, assistant: 0 }))
+
+vi.mock('../agent-context', () => ({
+  useAgentOptional: mockUseAgentOptional
+}))
+
+vi.mock('@/contexts/tabs', () => ({
+  useTabActions: () => ({ openTab: mockOpenTab })
+}))
+
+vi.mock('../messages/user-message', () => ({
+  UserMessage: ({ message }: { message: Message }) => {
+    renderCounts.user += 1
+    return <div data-testid={`user-${message.id}`} />
+  }
+}))
+
+vi.mock('../messages/assistant-message', () => ({
+  AssistantMessage: ({ message }: { message: Message }) => {
+    renderCounts.assistant += 1
+    return (
+      <div data-testid={`assistant-${message.id}`}>
+        {message.content.role === 'assistant' ? message.content.data.text : ''}
+      </div>
+    )
+  }
+}))
+
+import { MessageStream } from '../message-stream'
+
+function baseMessage(input: {
+  id: string
+  role: Message['role']
+  content: Message['content']
+  createdAt: number
+}): Message {
+  return {
+    id: input.id,
+    conversationId: 'conversation-1',
+    role: input.role,
+    content: input.content,
+    toolCallId: null,
+    attachments: [],
+    status: 'completed',
+    vectorClock: {},
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
+    deletedAt: null
+  }
+}
+
+describe('MessageStream render scoping', () => {
+  beforeEach(() => {
+    renderCounts.user = 0
+    renderCounts.assistant = 0
+    mockUseAgentOptional.mockReturnValue(null)
+  })
+
+  it('re-renders only the streamed message when a delta lands', () => {
+    const users = Array.from({ length: 5 }, (_, index) =>
+      baseMessage({
+        id: `user-${index}`,
+        role: 'user',
+        content: { role: 'user', data: { text: `ask ${index}` } },
+        createdAt: index
+      })
+    )
+    const assistant = baseMessage({
+      id: 'assistant-1',
+      role: 'assistant',
+      content: { role: 'assistant', data: { text: 'Rea' } },
+      createdAt: 100
+    })
+
+    const { rerender } = render(<MessageStream messages={[...users, assistant]} />)
+    expect(renderCounts.user).toBe(users.length)
+    expect(renderCounts.assistant).toBe(1)
+
+    // Exactly what the reducer produces for a delta: a new array where every
+    // message except the streamed one keeps its object identity.
+    const streamed: Message = {
+      ...assistant,
+      content: { role: 'assistant', data: { text: 'Ready' } }
+    }
+    rerender(<MessageStream messages={[...users, streamed]} />)
+
+    expect(renderCounts.user).toBe(users.length)
+    expect(renderCounts.assistant).toBe(2)
+    expect(screen.getByTestId('assistant-assistant-1')).toHaveTextContent('Ready')
+  })
+
+  it('does not re-render any row when the message array identity is unchanged', () => {
+    const messages = [
+      baseMessage({
+        id: 'user-1',
+        role: 'user',
+        content: { role: 'user', data: { text: 'ask' } },
+        createdAt: 1
+      }),
+      baseMessage({
+        id: 'assistant-1',
+        role: 'assistant',
+        content: { role: 'assistant', data: { text: 'Ready' } },
+        createdAt: 2
+      })
+    ]
+
+    const { rerender } = render(<MessageStream messages={messages} inFlight={false} />)
+    expect(renderCounts.user).toBe(1)
+    expect(renderCounts.assistant).toBe(1)
+
+    rerender(<MessageStream messages={messages} inFlight />)
+
+    expect(renderCounts.user).toBe(1)
+    expect(renderCounts.assistant).toBe(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
@@ -56,18 +56,28 @@ export const initialAgentState: AgentState = {
 function appendAssistantDelta(messages: Message[], event: AgentEvent): Message[] {
   if (event.kind !== 'assistant_text_delta') return messages
 
-  return messages.map((message) => {
-    if (message.id !== event.messageId || message.content.role !== 'assistant') return message
-    return {
-      ...message,
-      content: {
-        role: 'assistant',
-        data: {
-          text: `${message.content.data.text}${event.text}`
-        }
+  const index = messages.findIndex(
+    (message) => message.id === event.messageId && message.content.role === 'assistant'
+  )
+  // The delta can arrive before the message it belongs to (or for a transcript
+  // this window never loaded). Returning the same reference keeps the array
+  // identity stable so the stream does not re-render for nothing.
+  if (index === -1) return messages
+
+  const target = messages[index]
+  if (target.content.role !== 'assistant') return messages
+
+  const next = messages.slice()
+  next[index] = {
+    ...target,
+    content: {
+      role: 'assistant',
+      data: {
+        text: `${target.content.data.text}${event.text}`
       }
     }
-  })
+  }
+  return next
 }
 
 function upsertMessage(messages: Message[], nextMessage: Message): Message[] {
@@ -261,14 +271,14 @@ export function agentReducer(state: AgentState, action: AgentAction): AgentState
         }
       }
       if (event.kind === 'assistant_text_delta') {
+        const current = state.messagesByConversation[event.conversationId] ?? []
+        const next = appendAssistantDelta(current, event)
+        if (next === current) return state
         return {
           ...state,
           messagesByConversation: {
             ...state.messagesByConversation,
-            [event.conversationId]: appendAssistantDelta(
-              state.messagesByConversation[event.conversationId] ?? [],
-              event
-            )
+            [event.conversationId]: next
           }
         }
       }

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
@@ -103,6 +103,25 @@ const AgentContext = createContext<AgentContextValue | null>(null)
 const AGENT_BOOTSTRAP_ATTEMPTS = 40
 const AGENT_BOOTSTRAP_RETRY_MS = 250
 
+type AssistantTextDelta = Extract<AgentEvent, { kind: 'assistant_text_delta' }>
+
+/**
+ * Folds a delta into the tail of the pending buffer when it continues the same
+ * message. Backends emit dozens of tiny deltas per second and each one used to
+ * dispatch on its own, re-rendering every agent-context consumer per token.
+ * Merging only into the *adjacent* entry keeps interleaved messages in their
+ * exact arrival order, and the buffer stays at one entry per streamed message
+ * even when a hidden window goes a long time without a frame.
+ */
+function bufferAssistantDelta(pending: AssistantTextDelta[], event: AssistantTextDelta): void {
+  const last = pending[pending.length - 1]
+  if (last && last.conversationId === event.conversationId && last.messageId === event.messageId) {
+    pending[pending.length - 1] = { ...last, text: `${last.text}${event.text}` }
+    return
+  }
+  pending.push(event)
+}
+
 /**
  * Mirrors `AGENT_RUNTIME_STARTING_CODE` in main/ipc/agent-lazy-handlers.ts —
  * the two processes cannot share a module, so keep the literals in sync. The
@@ -168,6 +187,23 @@ export function AgentProvider({
   // IPC listener for no gain.
   const activeConversationIdRef = useRef(state.activeConversationId)
   activeConversationIdRef.current = state.activeConversationId
+
+  // Streamed text is buffered here and committed once per animation frame. A
+  // hidden window gets no frames, so a background window stops re-rendering
+  // altogether until the next event that has to be applied immediately.
+  const pendingDeltasRef = useRef<AssistantTextDelta[]>([])
+  const deltaFrameRef = useRef<number | null>(null)
+
+  const flushAssistantDeltas = useCallback(() => {
+    if (deltaFrameRef.current !== null) {
+      cancelAnimationFrame(deltaFrameRef.current)
+      deltaFrameRef.current = null
+    }
+    const pending = pendingDeltasRef.current
+    if (pending.length === 0) return
+    pendingDeltasRef.current = []
+    for (const event of pending) dispatch({ type: 'event', event })
+  }, [])
 
   const refreshConversations = useCallback(async () => {
     try {
@@ -390,7 +426,22 @@ export function AgentProvider({
         })
       })
 
-    const unsubscribe = api.onEvent((event) => dispatch({ type: 'event', event }))
+    const unsubscribe = api.onEvent((event) => {
+      if (event.kind === 'assistant_text_delta') {
+        bufferAssistantDelta(pendingDeltasRef.current, event)
+        if (deltaFrameRef.current === null) {
+          deltaFrameRef.current = requestAnimationFrame(() => {
+            deltaFrameRef.current = null
+            flushAssistantDeltas()
+          })
+        }
+        return
+      }
+      // Every other event has to observe the text that arrived before it, so
+      // drain the buffer first and keep the transcript in exact arrival order.
+      flushAssistantDeltas()
+      dispatch({ type: 'event', event })
+    })
 
     // `agent:event` only carries this window's own turn lifecycle. A
     // conversation or message pulled from another device lands straight in the
@@ -405,11 +456,14 @@ export function AgentProvider({
 
     return () => {
       cancelled = true
+      // Locale changes re-run this effect mid-stream; commit what is buffered
+      // rather than dropping it.
+      flushAssistantDeltas()
       unsubscribe()
       unsubscribeConversations?.()
       unsubscribeMessages?.()
     }
-  }, [t, active, refreshConversations, loadConversation])
+  }, [t, active, refreshConversations, loadConversation, flushAssistantDeltas])
 
   const value = useMemo<AgentContextValue>(
     () => ({

--- a/apps/desktop/src/renderer/src/agent-chat/message-stream.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/message-stream.tsx
@@ -1,3 +1,5 @@
+import { memo, useMemo } from 'react'
+
 import type { Message } from '@memry/contracts/ipc-agent'
 
 import { Conversation, ConversationContent } from '@/components/ai-elements/conversation'
@@ -22,19 +24,32 @@ function isToolMessage(message: Message): boolean {
   return message.role === 'tool_call' || message.role === 'tool_result'
 }
 
+/**
+ * A streamed delta rebuilds the message array but every message object except
+ * the one being streamed keeps its identity, so memoised rows turn a token into
+ * a single row commit instead of re-rendering the whole transcript. Wrapped
+ * here rather than at each definition: this is the only caller that re-renders
+ * per token, and the rows stay plain components everywhere else.
+ */
+const AssistantMessageRow = memo(AssistantMessage)
+const SystemMessageRow = memo(SystemMessage)
+const ToolCallMessageRow = memo(ToolCallMessage)
+const ToolResultMessageRow = memo(ToolResultMessage)
+const UserMessageRow = memo(UserMessage)
+
 function renderMessage(message: Message): React.JSX.Element | null {
-  if (message.role === 'user') return <UserMessage key={message.id} message={message} />
+  if (message.role === 'user') return <UserMessageRow key={message.id} message={message} />
   if (message.role === 'assistant') {
-    return <AssistantMessage key={message.id} message={message} />
+    return <AssistantMessageRow key={message.id} message={message} />
   }
   if (message.role === 'tool_call') {
-    return <ToolCallMessage key={message.id} message={message} />
+    return <ToolCallMessageRow key={message.id} message={message} />
   }
   if (message.role === 'tool_result') {
-    return <ToolResultMessage key={message.id} message={message} />
+    return <ToolResultMessageRow key={message.id} message={message} />
   }
   if (message.role === 'system') {
-    return <SystemMessage key={message.id} message={message} />
+    return <SystemMessageRow key={message.id} message={message} />
   }
   return null
 }
@@ -61,7 +76,7 @@ export function MessageStream({
   contentClassName,
   messageListClassName
 }: MessageStreamProps): React.JSX.Element {
-  const groups = groupMessages(messages)
+  const groups = useMemo(() => groupMessages(messages), [messages])
   const renderedMessages = groups.map((group, index) => {
     const first = group[0]
     if (group.length < 2) return renderMessage(first)


### PR DESCRIPTION
Fixes #1005

## Verification — the issue is still real on current `main`

Confirmed against `origin/main` (`27bc2b961`), line numbers had drifted slightly:

- `agent-chat/agent-context.reducer.ts:56-71` — `appendAssistantDelta` ran `messages.map()` over the whole transcript for every token, allocating a new array (and a new message object) per delta.
- `agent-chat/agent-context.tsx:393` — `api.onEvent((event) => dispatch({ type: 'event', event }))` dispatched **once per token**, so React committed once per token.
- `agent-chat/agent-context.tsx:414-440` — the context `useMemo` depends on `state`, so the context identity changed on every one of those commits, re-rendering `ConversationView`, `MessageStream`, `Composer`, `SidebarTabs` and every row.
- `agent-chat/message-stream.tsx:64` — `groupMessages(messages)` ran unmemoised on every render, and none of the row components were memoised.

Measured on `main` by the new tests: **200 deltas produced 203 renders** of an agent-context consumer, and a single delta re-rendered **all 5** unrelated user rows.

## Change

Three files, all on the streamed-token path:

- **`agent-context.tsx`** — `assistant_text_delta` events are buffered in a ref and committed once per animation frame. `bufferAssistantDelta` merges a delta into the *adjacent* buffer entry when it continues the same message, so the buffer stays at one entry per streamed message even in a hidden window that never gets a frame. Every non-delta event drains the buffer **before** it dispatches, so the transcript keeps exact arrival order; the effect cleanup also drains, so a locale change mid-stream cannot drop text.
- **`agent-context.reducer.ts`** — `appendAssistantDelta` finds the streamed message by index and patches only that slot; when nothing matches it returns the original array, and the `assistant_text_delta` case then returns the original `state`. Rows that are not streaming keep their object identity (they already did) and the transcript array identity is now stable when a delta is a no-op.
- **`message-stream.tsx`** — `groupMessages` is memoised on `messages`, and the five row components are wrapped in `React.memo` at the single call site that re-renders per token. Row components themselves are untouched.

No new dependency, no IPC/contract/schema change, no behavioural change to what is rendered.

### Deliberately out of scope

The suggested "split state/actions contexts" is **not** in this PR: making `Composer` stop re-rendering on state changes needs a selector store, and `SidebarTabs` is owned by #1007. The delta coalescing already cuts every consumer's per-turn render count by the token-per-frame factor (and to zero in a background window, since `requestAnimationFrame` does not fire there — which is exactly the "multiplies per window" case in the issue).

## Tests

**`__tests__/agent-provider.test.tsx`** — new `assistant text streaming` block with a deterministic `requestAnimationFrame` stub:

1. *coalesces a burst of deltas into a single commit without dropping a token* — streams 200 deltas, asserts **zero** renders before the frame, exactly **one** after it, and that the final text equals `'Ready' + tokens.join('')` character for character.
2. *keeps committing partial text while the turn is still streaming* — two frames, asserts the intermediate text is visible after the first. Guards against "optimised until it stops updating".
3. *drains buffered deltas before the next non-delta event is applied* — asserts buffered text is already in state when `turn_completed` arrives with no frame in between.
4. *keeps interleaved messages in arrival order* — two messages streaming at once end up `'ab'` and `'xy'`, never cross-merged.

**`__tests__/message-stream-render-scoping.test.tsx`** (new) — counts row renders through module mocks:

1. a delta that changes one assistant message re-renders **only** that row (5 user rows stay at 1 render each) and the new text is in the DOM.
2. re-rendering with an unchanged `messages` reference re-renders no row at all.

### Red → green

Before the fix:

```
1. AgentProvider assistant text streaming coalesces a burst of deltas into a single commit without dropping a token
   AssertionError: expected 203 to be 3
2. MessageStream render scoping re-renders only the streamed message when a delta lands
   AssertionError: expected 10 to be 5
3. MessageStream render scoping does not re-render any row when the message array identity is unchanged
   AssertionError: expected 2 to be 1
```

After the fix: `PASS (58) FAIL (0)` across `agent-provider`, `agent-context` (reducer), `message-stream` and `message-stream-render-scoping`.

Mutation check — removed the `flushAssistantDeltas()` call that precedes a non-delta dispatch:

```
1. AgentProvider assistant text streaming drains buffered deltas before the next non-delta event is applied
   AssertionError: expected 'Ready' to be 'Readyone two '
```

The ordering guarantee is genuinely covered, not incidental.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + ipc:check + node + web).
- `pnpm lint` — exit 0, `0 errors, 14 warnings`; all 14 warnings are pre-existing files unrelated to agent-chat (graph, tags-hub, settings, hooks). Zero findings on the three changed source files with `--no-cache`.
- `pnpm --filter @memry/desktop test:renderer src/renderer/src/agent-chat` — `PASS (138) FAIL (0)`.
- `npx react-doctor@latest .` — the only `agent-chat/agent-context.tsx` finding is the pre-existing `activeConversationIdRef.current = …` ref-during-render assignment that this PR does not touch.
- Docs gate reports `missing-docs`; pushed with `MEMRY_DOCS_IMPACT_SKIP=1` because this is an internal renderer render-scheduling change with no user-visible surface — no new setting, command, format or workflow to document.
