### PR TITLE
fix(agent-chat): scope tool result updates to the owning conversation

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx
@@ -301,7 +301,11 @@ describe('agentReducer', () => {
     }
 
     const queued = agentReducer(initialAgentState, { type: 'event', event })
-    const cleared = agentReducer(queued, { type: 'clear_pending', toolCallId: 'tool-1' })
+    const cleared = agentReducer(queued, {
+      type: 'clear_pending',
+      conversationId: conversation.id,
+      toolCallId: 'tool-1'
+    })
 
     expect(queued.pendingApprovals).toEqual([event])
     expect(cleared.pendingApprovals).toEqual([])
@@ -376,6 +380,7 @@ describe('agentReducer', () => {
 
     const approved = agentReducer(queued, {
       type: 'clear_pending',
+      conversationId: conversation.id,
       toolCallId: 'tool-1',
       status: 'approved'
     })
@@ -505,6 +510,251 @@ describe('agentReducer', () => {
         error: { code: 'INTERNAL', message: 'Connection timeout' }
       }
     })
+  })
+
+  it('applies a tool result only to the conversation that owns the tool call', () => {
+    const otherConversation: Conversation = { ...conversation, id: 'conversation-2' }
+    const otherMessages = [
+      message({
+        id: 'assistant-2',
+        conversationId: otherConversation.id,
+        role: 'assistant',
+        text: 'Other transcript',
+        status: 'completed'
+      })
+    ]
+
+    const started = agentReducer(
+      {
+        ...initialAgentState,
+        activeConversationId: conversation.id,
+        conversations: {
+          [conversation.id]: conversation,
+          [otherConversation.id]: otherConversation
+        },
+        messagesByConversation: {
+          [conversation.id]: [],
+          [otherConversation.id]: otherMessages
+        }
+      },
+      {
+        type: 'event',
+        event: {
+          kind: 'tool_call_started',
+          conversationId: conversation.id,
+          toolCallId: 'tool-1',
+          name: 'vault_read_note',
+          args: { id: 'note-1' }
+        }
+      }
+    )
+
+    const completed = agentReducer(started, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_completed',
+        conversationId: conversation.id,
+        toolCallId: 'tool-1',
+        result: { title: 'Planning' }
+      }
+    })
+
+    expect(completed.messagesByConversation[conversation.id][0]?.content).toEqual({
+      role: 'tool_call',
+      data: {
+        tool: 'vault_read_note',
+        args: { id: 'note-1' },
+        status: 'output-available',
+        output: { title: 'Planning' }
+      }
+    })
+    expect(completed.messagesByConversation[otherConversation.id]).toBe(
+      started.messagesByConversation[otherConversation.id]
+    )
+  })
+
+  it('keeps each in-flight tool call on its own conversation when results interleave', () => {
+    const otherConversation: Conversation = { ...conversation, id: 'conversation-2' }
+    const base: AgentState = {
+      ...initialAgentState,
+      activeConversationId: conversation.id,
+      conversations: {
+        [conversation.id]: conversation,
+        [otherConversation.id]: otherConversation
+      },
+      messagesByConversation: {
+        [conversation.id]: [],
+        [otherConversation.id]: []
+      }
+    }
+
+    const bothStarted = [
+      { conversationId: conversation.id, toolCallId: 'tool-1' },
+      { conversationId: otherConversation.id, toolCallId: 'tool-2' }
+    ].reduce(
+      (acc, input) =>
+        agentReducer(acc, {
+          type: 'event',
+          event: {
+            kind: 'tool_call_started',
+            conversationId: input.conversationId,
+            toolCallId: input.toolCallId,
+            name: 'vault_read_note',
+            args: { id: 'note-1' }
+          }
+        }),
+      base
+    )
+
+    const secondDone = agentReducer(bothStarted, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_completed',
+        conversationId: otherConversation.id,
+        toolCallId: 'tool-2',
+        result: { title: 'Second' }
+      }
+    })
+
+    expect(secondDone.messagesByConversation[otherConversation.id][0]?.content).toEqual({
+      role: 'tool_call',
+      data: {
+        tool: 'vault_read_note',
+        args: { id: 'note-1' },
+        status: 'output-available',
+        output: { title: 'Second' }
+      }
+    })
+    expect(secondDone.messagesByConversation[conversation.id]).toBe(
+      bothStarted.messagesByConversation[conversation.id]
+    )
+
+    const firstDone = agentReducer(secondDone, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_completed',
+        conversationId: conversation.id,
+        toolCallId: 'tool-1',
+        result: { title: 'First' }
+      }
+    })
+
+    expect(firstDone.messagesByConversation[conversation.id][0]?.content).toEqual({
+      role: 'tool_call',
+      data: {
+        tool: 'vault_read_note',
+        args: { id: 'note-1' },
+        status: 'output-available',
+        output: { title: 'First' }
+      }
+    })
+    expect(firstDone.messagesByConversation[otherConversation.id]).toBe(
+      secondDone.messagesByConversation[otherConversation.id]
+    )
+  })
+
+  it('leaves the transcript map untouched when the tool result targets an unloaded conversation', () => {
+    const state: AgentState = {
+      ...initialAgentState,
+      activeConversationId: conversation.id,
+      conversations: { [conversation.id]: conversation },
+      messagesByConversation: { [conversation.id]: [] }
+    }
+
+    const next = agentReducer(state, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_completed',
+        conversationId: 'conversation-not-loaded',
+        toolCallId: 'tool-9',
+        result: { title: 'Planning' }
+      }
+    })
+
+    expect(next.messagesByConversation).toBe(state.messagesByConversation)
+    expect(Object.keys(next.messagesByConversation)).toEqual([conversation.id])
+  })
+
+  it('keeps the transcript reference when no message matches the tool call', () => {
+    const state: AgentState = {
+      ...initialAgentState,
+      activeConversationId: conversation.id,
+      conversations: { [conversation.id]: conversation },
+      messagesByConversation: {
+        [conversation.id]: [
+          message({
+            id: 'assistant-1',
+            conversationId: conversation.id,
+            role: 'assistant',
+            text: 'Hello',
+            status: 'completed'
+          })
+        ]
+      }
+    }
+
+    const next = agentReducer(state, {
+      type: 'event',
+      event: {
+        kind: 'tool_call_completed',
+        conversationId: conversation.id,
+        toolCallId: 'tool-not-in-transcript',
+        result: { title: 'Planning' }
+      }
+    })
+
+    expect(next.messagesByConversation).toBe(state.messagesByConversation)
+    expect(next.messagesByConversation[conversation.id]).toBe(
+      state.messagesByConversation[conversation.id]
+    )
+  })
+
+  it('applies an approval response only to the conversation that owns the tool call', () => {
+    const otherConversation: Conversation = { ...conversation, id: 'conversation-2' }
+    const queued = agentReducer(
+      {
+        ...initialAgentState,
+        activeConversationId: conversation.id,
+        conversations: {
+          [conversation.id]: conversation,
+          [otherConversation.id]: otherConversation
+        },
+        messagesByConversation: {
+          [conversation.id]: [],
+          [otherConversation.id]: []
+        }
+      },
+      {
+        type: 'event',
+        event: {
+          kind: 'tool_call_pending_approval',
+          conversationId: conversation.id,
+          toolCallId: 'tool-1',
+          name: 'vault_create_task',
+          args: { title: 'Buy milk' },
+          requiresDiff: false
+        }
+      }
+    )
+
+    const approved = agentReducer(queued, {
+      type: 'clear_pending',
+      conversationId: conversation.id,
+      toolCallId: 'tool-1',
+      status: 'approved'
+    })
+
+    expect(approved.messagesByConversation[conversation.id][0]?.content).toEqual({
+      role: 'tool_call',
+      data: {
+        tool: 'vault_create_task',
+        args: { title: 'Buy milk' },
+        status: 'approval-responded'
+      }
+    })
+    expect(approved.messagesByConversation[otherConversation.id]).toBe(
+      queued.messagesByConversation[otherConversation.id]
+    )
   })
 
   it('clears in-flight state when a turn ends', () => {

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
@@ -39,7 +39,12 @@ export type AgentAction =
   | { type: 'set_in_flight'; conversationId: string; inFlight: boolean }
   | { type: 'set_error'; error: string | null }
   | { type: 'event'; event: AgentEvent }
-  | { type: 'clear_pending'; toolCallId: string; status?: 'approved' | 'denied' }
+  | {
+      type: 'clear_pending'
+      conversationId: string
+      toolCallId: string
+      status?: 'approved' | 'denied'
+    }
 
 export const initialAgentState: AgentState = {
   backendStatuses: null,
@@ -121,8 +126,10 @@ function updateToolCallStatus(
   status: ToolCallStatus,
   patch?: { output?: unknown; error?: { code: string; message: string } }
 ): Message[] {
-  return messages.map((message) => {
+  let matched = false
+  const next: Message[] = messages.map((message) => {
     if (message.toolCallId !== toolCallId || message.content.role !== 'tool_call') return message
+    matched = true
     return {
       ...message,
       status:
@@ -141,20 +148,23 @@ function updateToolCallStatus(
       }
     }
   })
+  return matched ? next : messages
 }
 
-function updateToolCallStatusEverywhere(
+function updateToolCallStatusIn(
   messagesByConversation: AgentState['messagesByConversation'],
+  conversationId: string,
   toolCallId: string,
   status: ToolCallStatus,
   patch?: { output?: unknown; error?: { code: string; message: string } }
 ): AgentState['messagesByConversation'] {
-  return Object.fromEntries(
-    Object.entries(messagesByConversation).map(([conversationId, messages]) => [
-      conversationId,
-      updateToolCallStatus(messages, toolCallId, status, patch)
-    ])
-  )
+  const messages = messagesByConversation[conversationId]
+  // Transcript not loaded (or already evicted): nothing to patch here. The persisted
+  // transcript is reloaded from the main process on open, so no result is lost.
+  if (!messages) return messagesByConversation
+  const nextMessages = updateToolCallStatus(messages, toolCallId, status, patch)
+  if (nextMessages === messages) return messagesByConversation
+  return { ...messagesByConversation, [conversationId]: nextMessages }
 }
 
 function withoutInFlight(state: AgentState, conversationId: string): Record<string, boolean> {
@@ -230,8 +240,9 @@ export function agentReducer(state: AgentState, action: AgentAction): AgentState
           (pending) => pending.toolCallId !== action.toolCallId
         ),
         messagesByConversation: action.status
-          ? updateToolCallStatusEverywhere(
+          ? updateToolCallStatusIn(
               state.messagesByConversation,
+              action.conversationId,
               action.toolCallId,
               action.status === 'denied' ? 'output-denied' : 'approval-responded'
             )
@@ -317,8 +328,9 @@ export function agentReducer(state: AgentState, action: AgentAction): AgentState
           pendingApprovals: state.pendingApprovals.filter(
             (pending) => pending.toolCallId !== event.toolCallId
           ),
-          messagesByConversation: updateToolCallStatusEverywhere(
+          messagesByConversation: updateToolCallStatusIn(
             state.messagesByConversation,
+            event.conversationId,
             event.toolCallId,
             event.kind === 'tool_call_completed'
               ? 'output-available'

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.tsx
@@ -281,6 +281,7 @@ export function AgentProvider({
         await getAgentApi().approveTool(input)
         dispatch({
           type: 'clear_pending',
+          conversationId: input.conversationId,
           toolCallId: input.toolCallId,
           status: input.decision.kind === 'deny' ? 'denied' : 'approved'
         })


### PR DESCRIPTION
Fixes #1006

## Verification (issue is real on current `main`)

`apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts` on `origin/main`:

- `updateToolCallStatusEverywhere` (`:146-158`) rebuilt **every** entry of `messagesByConversation` via `Object.fromEntries(Object.entries(...).map(...))`.
- `updateToolCallStatus` (`:118-144`) ended in `return messages.map(...)`, so it allocated a fresh array **even when no message matched**.

Both were reached from `tool_call_completed` / `tool_call_failed` (`:320`) and `clear_pending` (`:233`) — i.e. on every tool completion, failure, and approval response. Net effect: one tool result changed the array identity of every transcript loaded this session, invalidating all downstream memoization.

## Change

The fan-out was never needed. `tool_call_completed` and `tool_call_failed` already carry `conversationId` (`packages/contracts/src/ipc-agent.ts:504-515`), and `apps/desktop/src/main/agent/runtime/turn.ts:484-511` emits `tool_call_started`, `tool_call_completed` and `tool_call_failed` from the same `ctx.conversationId`, so the result always belongs to the conversation the tool message was created under. No toolCallId→conversationId side map is required.

- `updateToolCallStatusEverywhere` → `updateToolCallStatusIn(messagesByConversation, conversationId, ...)`: touches one conversation, returns the **same** `messagesByConversation` reference when nothing changed.
- `updateToolCallStatus` returns the original array reference when no message matched.
- `clear_pending` now carries `conversationId`; `approveTool` already has it on `ApproveToolRequest`, so the dispatch in `agent-context.tsx` just passes it through.

Correctness notes:

- **Conversation switch mid-call**: scoping is by the event's own `conversationId`, not by the active conversation, so a result that lands after the user switched away still patches the right transcript.
- **Two calls in flight**: each event carries its own `conversationId` + `toolCallId`, so results are independent (covered by a test).
- **Transcript not loaded / already evicted**: `updateToolCallStatusIn` returns the map unchanged and does **not** create a phantom empty entry. This is byte-for-byte the pre-existing behavior — `Object.entries` only ever iterated keys that existed, so an unloaded conversation was skipped before too. Nothing is newly dropped: `tool_call` messages are synthesized in the renderer and the transcript is re-fetched from the main process on open.

No new dependency, no eviction logic, no streaming-token path, no SidebarTabs.

## Tests

`apps/desktop/src/renderer/src/agent-chat/__tests__/agent-context.test.tsx` — 5 new cases:

1. a tool result updates only the owning conversation; the other transcript keeps `===` identity
2. two interleaved in-flight tool calls each land on their own conversation
3. a result for an unloaded conversation leaves the map reference untouched and adds no key
4. a result whose toolCallId matches nothing keeps both the map and the array reference
5. an approval response (`clear_pending`) is scoped to the owning conversation

RED (before the fix, 4 of them failed on identity):

```
 FAIL  ... > applies a tool result only to the conversation that owns the tool call
 FAIL  ... > keeps each in-flight tool call on its own conversation when results interleave
 FAIL  ... > leaves the transcript map untouched when the tool result targets an unloaded conversation
 FAIL  ... > applies an approval response only to the conversation that owns the tool call
AssertionError: expected [ { id: 'tool-call-tool-1', …(10) } ] to be [ { id: 'tool-call-tool-1', …(10) } ] // Object.is equality
 Test Files  1 failed (1)
      Tests  4 failed | 15 passed (19)
```

GREEN after the fix: `Tests  20 passed (20)`.

Mutation check: reverting `return matched ? next : messages` to `return next` turns case 4 red again (`1 failed | 19 passed`), so the assertions are load-bearing.

## Checks

- `tsc --noEmit -p tsconfig.node.json` + `tsconfig.web.json` (the two halves of `@memry/desktop typecheck`): clean, no output.
- `pnpm lint`: `0 errors, 14 warnings` — all 14 pre-existing and in unrelated files (tags-hub, use-folder-view, use-tab-keyboard-shortcuts).
- `vitest --project renderer src/renderer/src/agent-chat`: `16 files / 137 tests passed`.
