### PR TITLE
perf(agent): detect CLI binaries asynchronously with a shared probe cache

### DIFF
--- a/apps/desktop/src/main/agent/cli/__tests__/binary-detection.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/binary-detection.test.ts
@@ -1,0 +1,168 @@
+import { spawnSync } from 'node:child_process'
+
+import type { BinaryStatus } from '@memry/contracts/ipc-agent'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Keep the real implementations but watch spawnSync: a synchronous probe is the
+// regression this module exists to prevent.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return { ...actual, spawnSync: vi.fn(actual.spawnSync) }
+})
+
+import {
+  BINARY_DETECTION_TTL_MS,
+  cacheBinaryDetection,
+  locateBinary,
+  runBinaryCommand
+} from '../binary-detection'
+
+const usable: BinaryStatus = {
+  detected: true,
+  version: '2.1.138',
+  meetsMinimum: true,
+  minimumRequired: '2.1.0',
+  installHint: null
+}
+const missing: BinaryStatus = {
+  detected: false,
+  version: null,
+  meetsMinimum: false,
+  minimumRequired: '2.1.0',
+  installHint: 'install it'
+}
+
+describe('runBinaryCommand', () => {
+  beforeEach(() => {
+    vi.mocked(spawnSync).mockClear()
+  })
+
+  it('returns stdout for a successful command', async () => {
+    const result = await runBinaryCommand(process.execPath, ['-e', 'process.stdout.write("ok")'])
+
+    expect(result?.stdout).toBe('ok')
+    expect(spawnSync).not.toHaveBeenCalled()
+  })
+
+  it('returns null for a non-zero exit', async () => {
+    await expect(runBinaryCommand(process.execPath, ['-e', 'process.exit(1)'])).resolves.toBeNull()
+  })
+
+  it('returns null when the command cannot be spawned', async () => {
+    await expect(runBinaryCommand('memry-no-such-binary-xyz', [])).resolves.toBeNull()
+  })
+
+  it('keeps the event loop turning while the command runs', async () => {
+    let ticks = 0
+    const timer = setInterval(() => {
+      ticks += 1
+    }, 10)
+
+    const result = await runBinaryCommand(process.execPath, [
+      '-e',
+      'setTimeout(() => process.stdout.write("slow"), 200)'
+    ])
+    clearInterval(timer)
+
+    expect(result?.stdout).toBe('slow')
+    // spawnSync would have blocked the loop for the full 200ms and left ticks at 0.
+    expect(ticks).toBeGreaterThan(0)
+  })
+})
+
+describe('locateBinary', () => {
+  beforeEach(() => {
+    vi.mocked(spawnSync).mockClear()
+  })
+
+  it('resolves an executable that is on PATH without spawnSync', async () => {
+    const resolved = await locateBinary(process.platform === 'win32' ? 'node.exe' : 'node')
+
+    expect(resolved).toBeTruthy()
+    expect(spawnSync).not.toHaveBeenCalled()
+  })
+
+  it('returns null for an executable that is not installed', async () => {
+    await expect(locateBinary('memry-no-such-binary-xyz')).resolves.toBeNull()
+  })
+})
+
+describe('cacheBinaryDetection', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reuses a usable detection instead of re-probing', async () => {
+    const probe = vi.fn(async () => usable)
+    const detect = cacheBinaryDetection(probe)
+
+    await detect()
+    await detect()
+
+    expect(probe).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares one probe between concurrent callers', async () => {
+    let release = (): void => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const probe = vi.fn(async () => {
+      await gate
+      return usable
+    })
+    const detect = cacheBinaryDetection(probe)
+
+    const both = Promise.all([detect(), detect()])
+    release()
+    const [first, second] = await both
+
+    expect(probe).toHaveBeenCalledTimes(1)
+    expect(first).toEqual(usable)
+    expect(second).toEqual(usable)
+  })
+
+  it('never caches a miss, so installing the CLI mid-session is picked up', async () => {
+    const probe = vi.fn(async () => missing)
+    const detect = cacheBinaryDetection(probe)
+
+    await detect()
+    await detect()
+
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
+
+  it('never caches a binary that is below the minimum version', async () => {
+    const probe = vi.fn(async () => ({ ...usable, version: '1.5.0', meetsMinimum: false }))
+    const detect = cacheBinaryDetection(probe)
+
+    await detect()
+    await detect()
+
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-probes once the cached detection expires', async () => {
+    vi.useFakeTimers()
+    const probe = vi.fn(async () => usable)
+    const detect = cacheBinaryDetection(probe)
+
+    await detect()
+    vi.setSystemTime(Date.now() + BINARY_DETECTION_TTL_MS + 1)
+    await detect()
+
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not latch a rejected probe', async () => {
+    const probe = vi.fn(async () => {
+      throw new Error('probe blew up')
+    })
+    const detect = cacheBinaryDetection(probe)
+
+    await expect(detect()).rejects.toThrow('probe blew up')
+    await expect(detect()).rejects.toThrow('probe blew up')
+
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/main/agent/cli/__tests__/claude-binary.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/claude-binary.test.ts
@@ -1,28 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }))
-vi.mock('node:fs', async () => {
-  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
-  return { ...actual, existsSync: vi.fn() }
+const mocks = vi.hoisted(() => ({
+  locateBinary: vi.fn<(name: string) => Promise<string | null>>(),
+  runBinaryCommand:
+    vi.fn<(command: string, args: string[]) => Promise<{ stdout: string; stderr: string } | null>>()
+}))
+
+// Real `cacheBinaryDetection` — the caching contract is part of what is tested.
+vi.mock('../binary-detection', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../binary-detection')>()
+  return { ...actual, locateBinary: mocks.locateBinary, runBinaryCommand: mocks.runBinaryCommand }
 })
 
-import { spawnSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { MIN_CLAUDE_VERSION } from '../claude-binary'
 
-import { detectClaudeBinary, MIN_CLAUDE_VERSION } from '../claude-binary'
+/** Fresh module instance so each test starts with an empty detection cache. */
+async function loadDetector() {
+  vi.resetModules()
+  const mod = await import('../claude-binary')
+  return mod.detectClaudeBinary
+}
+
+function installed(version: string): void {
+  mocks.locateBinary.mockResolvedValue('/usr/local/bin/claude')
+  mocks.runBinaryCommand.mockResolvedValue({ stdout: `${version} (Claude Code)\n`, stderr: '' })
+}
 
 describe('detectClaudeBinary', () => {
   beforeEach(() => {
-    vi.mocked(spawnSync).mockReset()
-    vi.mocked(existsSync).mockReset()
+    mocks.locateBinary.mockReset()
+    mocks.runBinaryCommand.mockReset()
   })
 
   it('reports detected: false when which/where finds nothing', async () => {
-    vi.mocked(spawnSync).mockReturnValueOnce({
-      status: 1,
-      stdout: '',
-      stderr: ''
-    } as ReturnType<typeof spawnSync>)
+    mocks.locateBinary.mockResolvedValue(null)
+    const detectClaudeBinary = await loadDetector()
 
     const status = await detectClaudeBinary()
 
@@ -32,10 +44,8 @@ describe('detectClaudeBinary', () => {
   })
 
   it('parses --version output and confirms minimum', async () => {
-    vi.mocked(spawnSync)
-      .mockReturnValueOnce({ status: 0, stdout: '/usr/local/bin/claude\n', stderr: '' } as any)
-      .mockReturnValueOnce({ status: 0, stdout: '2.1.138 (Claude Code)\n', stderr: '' } as any)
-    vi.mocked(existsSync).mockReturnValue(true)
+    installed('2.1.138')
+    const detectClaudeBinary = await loadDetector()
 
     const status = await detectClaudeBinary()
 
@@ -45,11 +55,21 @@ describe('detectClaudeBinary', () => {
     expect(status.minimumRequired).toBe(MIN_CLAUDE_VERSION)
   })
 
+  it('reports detected without a version when --version fails', async () => {
+    mocks.locateBinary.mockResolvedValue('/usr/local/bin/claude')
+    mocks.runBinaryCommand.mockResolvedValue(null)
+    const detectClaudeBinary = await loadDetector()
+
+    const status = await detectClaudeBinary()
+
+    expect(status.detected).toBe(true)
+    expect(status.version).toBeNull()
+    expect(status.meetsMinimum).toBe(false)
+  })
+
   it('flags too-old versions', async () => {
-    vi.mocked(spawnSync)
-      .mockReturnValueOnce({ status: 0, stdout: '/usr/local/bin/claude\n', stderr: '' } as any)
-      .mockReturnValueOnce({ status: 0, stdout: '1.5.0\n', stderr: '' } as any)
-    vi.mocked(existsSync).mockReturnValue(true)
+    installed('1.5.0')
+    const detectClaudeBinary = await loadDetector()
 
     const status = await detectClaudeBinary()
 
@@ -59,10 +79,45 @@ describe('detectClaudeBinary', () => {
   })
 
   it('emits an install hint when undetected', async () => {
-    vi.mocked(spawnSync).mockReturnValueOnce({ status: 1, stdout: '', stderr: '' } as any)
+    mocks.locateBinary.mockResolvedValue(null)
+    const detectClaudeBinary = await loadDetector()
 
     const status = await detectClaudeBinary()
 
     expect(status.installHint).toContain('claude.ai/code')
+  })
+
+  it('probes once when a usable binary is asked for repeatedly', async () => {
+    installed('2.1.138')
+    const detectClaudeBinary = await loadDetector()
+
+    const first = await detectClaudeBinary()
+    const second = await detectClaudeBinary()
+
+    expect(second).toEqual(first)
+    expect(mocks.locateBinary).toHaveBeenCalledTimes(1)
+    expect(mocks.runBinaryCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-probes after a miss so installing the CLI mid-session is picked up', async () => {
+    mocks.locateBinary.mockResolvedValueOnce(null)
+    const detectClaudeBinary = await loadDetector()
+
+    expect((await detectClaudeBinary()).detected).toBe(false)
+
+    installed('2.1.138')
+
+    expect((await detectClaudeBinary()).detected).toBe(true)
+  })
+
+  it('re-probes after an outdated binary so upgrading mid-session is picked up', async () => {
+    installed('1.5.0')
+    const detectClaudeBinary = await loadDetector()
+
+    expect((await detectClaudeBinary()).meetsMinimum).toBe(false)
+
+    installed('2.1.138')
+
+    expect((await detectClaudeBinary()).meetsMinimum).toBe(true)
   })
 })

--- a/apps/desktop/src/main/agent/cli/__tests__/codex-binary.test.ts
+++ b/apps/desktop/src/main/agent/cli/__tests__/codex-binary.test.ts
@@ -1,17 +1,36 @@
-import { spawnSync } from 'node:child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { describe, expect, it, vi } from 'vitest'
+const mocks = vi.hoisted(() => ({
+  locateBinary: vi.fn<(name: string) => Promise<string | null>>(),
+  runBinaryCommand:
+    vi.fn<(command: string, args: string[]) => Promise<{ stdout: string; stderr: string } | null>>()
+}))
 
-vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }))
-vi.mock('node:fs', () => ({ existsSync: vi.fn(() => true) }))
+// Real `cacheBinaryDetection` — the caching contract is part of what is tested.
+vi.mock('../binary-detection', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../binary-detection')>()
+  return { ...actual, locateBinary: mocks.locateBinary, runBinaryCommand: mocks.runBinaryCommand }
+})
 
-import { detectCodexBinary, MIN_CODEX_VERSION } from '../codex-binary'
+import { MIN_CODEX_VERSION } from '../codex-binary'
+
+/** Fresh module instance so each test starts with an empty detection cache. */
+async function loadDetector() {
+  vi.resetModules()
+  const mod = await import('../codex-binary')
+  return mod.detectCodexBinary
+}
 
 describe('detectCodexBinary', () => {
+  beforeEach(() => {
+    mocks.locateBinary.mockReset()
+    mocks.runBinaryCommand.mockReset()
+  })
+
   it('reports the installed codex version when it meets the minimum', async () => {
-    vi.mocked(spawnSync)
-      .mockReturnValueOnce({ status: 0, stdout: '/opt/homebrew/bin/codex\n', stderr: '' } as any)
-      .mockReturnValueOnce({ status: 0, stdout: 'codex-cli 0.130.0\n', stderr: '' } as any)
+    mocks.locateBinary.mockResolvedValue('/opt/homebrew/bin/codex')
+    mocks.runBinaryCommand.mockResolvedValue({ stdout: 'codex-cli 0.130.0\n', stderr: '' })
+    const detectCodexBinary = await loadDetector()
 
     await expect(detectCodexBinary()).resolves.toEqual({
       detected: true,
@@ -22,13 +41,46 @@ describe('detectCodexBinary', () => {
     })
   })
 
+  it('reads the version from stderr when codex prints it there', async () => {
+    mocks.locateBinary.mockResolvedValue('/opt/homebrew/bin/codex')
+    mocks.runBinaryCommand.mockResolvedValue({ stdout: '', stderr: 'codex-cli 0.130.0\n' })
+    const detectCodexBinary = await loadDetector()
+
+    await expect(detectCodexBinary()).resolves.toMatchObject({ version: '0.130.0' })
+  })
+
   it('surfaces install guidance when codex is missing', async () => {
-    vi.mocked(spawnSync).mockReturnValueOnce({ status: 1, stdout: '', stderr: '' } as any)
+    mocks.locateBinary.mockResolvedValue(null)
+    const detectCodexBinary = await loadDetector()
 
     const status = await detectCodexBinary()
 
     expect(status.detected).toBe(false)
     expect(status.minimumRequired).toBe(MIN_CODEX_VERSION)
     expect(status.installHint).toContain('codex')
+  })
+
+  it('probes once when a usable binary is asked for repeatedly', async () => {
+    mocks.locateBinary.mockResolvedValue('/opt/homebrew/bin/codex')
+    mocks.runBinaryCommand.mockResolvedValue({ stdout: 'codex-cli 0.130.0\n', stderr: '' })
+    const detectCodexBinary = await loadDetector()
+
+    await detectCodexBinary()
+    await detectCodexBinary()
+
+    expect(mocks.locateBinary).toHaveBeenCalledTimes(1)
+    expect(mocks.runBinaryCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-probes after a miss so installing the CLI mid-session is picked up', async () => {
+    mocks.locateBinary.mockResolvedValueOnce(null)
+    const detectCodexBinary = await loadDetector()
+
+    expect((await detectCodexBinary()).detected).toBe(false)
+
+    mocks.locateBinary.mockResolvedValue('/opt/homebrew/bin/codex')
+    mocks.runBinaryCommand.mockResolvedValue({ stdout: 'codex-cli 0.130.0\n', stderr: '' })
+
+    expect((await detectCodexBinary()).detected).toBe(true)
   })
 })

--- a/apps/desktop/src/main/agent/cli/binary-detection.ts
+++ b/apps/desktop/src/main/agent/cli/binary-detection.ts
@@ -1,0 +1,97 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { platform } from 'node:os'
+import { promisify } from 'node:util'
+
+import type { BinaryStatus } from '@memry/contracts/ipc-agent'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * How long a *usable* detection is trusted before it is probed again.
+ *
+ * Deliberately bounded rather than cached for the whole session: the CLI can be
+ * uninstalled or moved while the app runs, and a stale "available" answer turns
+ * a friendly install hint into a raw spawn failure. A few minutes is long
+ * enough that a burst of turns, titles and summaries share one probe.
+ */
+export const BINARY_DETECTION_TTL_MS = 5 * 60 * 1000
+
+/**
+ * Run a command without blocking the main-process event loop.
+ *
+ * Returns `null` on a non-zero exit or a spawn failure, mirroring the
+ * `status !== 0` checks the synchronous probes used to do.
+ */
+export async function runBinaryCommand(
+  command: string,
+  args: string[]
+): Promise<{ stdout: string; stderr: string } | null> {
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, { encoding: 'utf8' })
+    return { stdout, stderr }
+  } catch {
+    return null
+  }
+}
+
+/** Resolve an executable on PATH, or `null` when it is not installed. */
+export async function locateBinary(name: string): Promise<string | null> {
+  const which = platform() === 'win32' ? 'where' : 'which'
+  const result = await runBinaryCommand(which, [name])
+  if (!result) {
+    return null
+  }
+
+  const binaryPath = result.stdout.split(/\r?\n/).filter(Boolean)[0]
+  if (!binaryPath || !existsSync(binaryPath)) {
+    return null
+  }
+
+  return binaryPath
+}
+
+/**
+ * Wrap a binary probe so repeated callers share one spawn.
+ *
+ * Two guarantees matter more than the caching itself:
+ * - Concurrent callers await the *same* in-flight probe, so a turn and a status
+ *   query never race into two spawns (or into a premature "no binary").
+ * - A miss is never remembered. The CLI has twice been reported as greyed out
+ *   for reasons the user can fix mid-session (a packaged-app PATH gap, a
+ *   keychain mismatch); memoising "not found" would make those permanent for
+ *   the rest of the session instead of clearing on the next call.
+ */
+export function cacheBinaryDetection(
+  probe: () => Promise<BinaryStatus>
+): () => Promise<BinaryStatus> {
+  let cached: { status: BinaryStatus; expiresAt: number } | null = null
+  let inFlight: Promise<BinaryStatus> | null = null
+
+  return async () => {
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.status
+    }
+    cached = null
+    if (inFlight) {
+      return inFlight
+    }
+
+    const pending = probe().then(
+      (status) => {
+        inFlight = null
+        cached =
+          status.detected && status.meetsMinimum
+            ? { status, expiresAt: Date.now() + BINARY_DETECTION_TTL_MS }
+            : null
+        return status
+      },
+      (error: unknown) => {
+        inFlight = null
+        throw error
+      }
+    )
+    inFlight = pending
+    return pending
+  }
+}

--- a/apps/desktop/src/main/agent/cli/claude-binary.ts
+++ b/apps/desktop/src/main/agent/cli/claude-binary.ts
@@ -1,32 +1,15 @@
-import { spawnSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { platform } from 'node:os'
-
 import type { BinaryStatus } from '@memry/contracts/ipc-agent'
+
+import { cacheBinaryDetection, locateBinary, runBinaryCommand } from './binary-detection'
 
 export const MIN_CLAUDE_VERSION = '2.1.0'
 
 const INSTALL_HINT =
   'Install Claude Code CLI from https://claude.ai/code, then run `claude login` to sign in to your subscription.'
 
-function locate(): string | null {
-  const which = platform() === 'win32' ? 'where' : 'which'
-  const result = spawnSync(which, ['claude'])
-  if (result.status !== 0) {
-    return null
-  }
-
-  const binaryPath = result.stdout.toString().split(/\r?\n/).filter(Boolean)[0]
-  if (!binaryPath || !existsSync(binaryPath)) {
-    return null
-  }
-
-  return binaryPath
-}
-
-function readVersion(binaryPath: string): string | null {
-  const result = spawnSync(binaryPath, ['--version'], { encoding: 'utf8' })
-  if (result.status !== 0) {
+async function readVersion(binaryPath: string): Promise<string | null> {
+  const result = await runBinaryCommand(binaryPath, ['--version'])
+  if (!result) {
     return null
   }
 
@@ -49,8 +32,8 @@ function compareSemver(a: string, b: string): number {
   return patchA - patchB
 }
 
-export async function detectClaudeBinary(): Promise<BinaryStatus> {
-  const binaryPath = locate()
+async function probeClaudeBinary(): Promise<BinaryStatus> {
+  const binaryPath = await locateBinary('claude')
   if (!binaryPath) {
     return {
       detected: false,
@@ -61,7 +44,7 @@ export async function detectClaudeBinary(): Promise<BinaryStatus> {
     }
   }
 
-  const version = readVersion(binaryPath)
+  const version = await readVersion(binaryPath)
   if (!version) {
     return {
       detected: true,
@@ -81,3 +64,6 @@ export async function detectClaudeBinary(): Promise<BinaryStatus> {
     installHint: meetsMinimum ? null : INSTALL_HINT
   }
 }
+
+export const detectClaudeBinary: () => Promise<BinaryStatus> =
+  cacheBinaryDetection(probeClaudeBinary)

--- a/apps/desktop/src/main/agent/cli/codex-binary.ts
+++ b/apps/desktop/src/main/agent/cli/codex-binary.ts
@@ -1,31 +1,14 @@
-import { spawnSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { platform } from 'node:os'
-
 import type { BinaryStatus } from '@memry/contracts/ipc-agent'
+
+import { cacheBinaryDetection, locateBinary, runBinaryCommand } from './binary-detection'
 
 export const MIN_CODEX_VERSION = '0.130.0'
 
 const INSTALL_HINT = 'Install Codex CLI, then run `codex login` to sign in to your OpenAI account.'
 
-function locate(): string | null {
-  const which = platform() === 'win32' ? 'where' : 'which'
-  const result = spawnSync(which, ['codex'])
-  if (result.status !== 0) {
-    return null
-  }
-
-  const binaryPath = result.stdout.toString().split(/\r?\n/).filter(Boolean)[0]
-  if (!binaryPath || !existsSync(binaryPath)) {
-    return null
-  }
-
-  return binaryPath
-}
-
-function readVersion(binaryPath: string): string | null {
-  const result = spawnSync(binaryPath, ['--version'], { encoding: 'utf8' })
-  if (result.status !== 0) {
+async function readVersion(binaryPath: string): Promise<string | null> {
+  const result = await runBinaryCommand(binaryPath, ['--version'])
+  if (!result) {
     return null
   }
 
@@ -49,8 +32,8 @@ function compareSemver(a: string, b: string): number {
   return patchA - patchB
 }
 
-export async function detectCodexBinary(): Promise<BinaryStatus> {
-  const binaryPath = locate()
+async function probeCodexBinary(): Promise<BinaryStatus> {
+  const binaryPath = await locateBinary('codex')
   if (!binaryPath) {
     return {
       detected: false,
@@ -61,7 +44,7 @@ export async function detectCodexBinary(): Promise<BinaryStatus> {
     }
   }
 
-  const version = readVersion(binaryPath)
+  const version = await readVersion(binaryPath)
   if (!version) {
     return {
       detected: true,
@@ -81,3 +64,5 @@ export async function detectCodexBinary(): Promise<BinaryStatus> {
     installHint: meetsMinimum ? null : INSTALL_HINT
   }
 }
+
+export const detectCodexBinary: () => Promise<BinaryStatus> = cacheBinaryDetection(probeCodexBinary)

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -39,7 +39,10 @@ that `claude` is available on `PATH`, that it reports version `2.1.0` or newer, 
 disclosure has been accepted; the Codex CLI is detected the same way. On macOS and Linux, memrynote
 resolves your login shell's `PATH` at startup, so CLIs installed in shell-managed locations
 (`~/.local/bin`, Homebrew, nvm, volta) are still found when the app is launched from the Dock or
-Finder rather than from a terminal. For local models, configure a compatible server in
+Finder rather than from a terminal. These checks run in the background rather than pausing the app,
+and a successful check is reused for a few minutes so a burst of turns does not re-run it. A failed
+check is never remembered: if you install or upgrade a CLI while memrynote is running, the next
+message or provider check picks it up without a restart. For local models, configure a compatible server in
 [Settings -> AI Assistant -> Agent Permissions](/user-guide/settings#agent-permissions) first.
 If the global AI switch is off in [Settings -> AI](/user-guide/settings#ai), the Agent tab and Agent
 MCP current-note bridge are hidden and inactive.


### PR DESCRIPTION
Fixes #1008

## Verification

Still valid on `main` @ `27bc2b961` — the audit's line numbers had not drifted:

- `apps/desktop/src/main/agent/cli/claude-binary.ts:14` `spawnSync(which, ['claude'])`, `:28` `spawnSync(binaryPath, ['--version'])`
- `apps/desktop/src/main/agent/cli/codex-binary.ts:13`, `:27` — same pair
- `apps/desktop/src/main/agent/bootstrap.ts:91` `await detectClaudeBinary()` and `:148` `await detectCodexBinary()`, inside the spawn adapters that run for every turn, title generation and summarization
- `backends/claude-cli-backend.ts:38` / `codex-cli-backend.ts:36` call it again for `agent:getBackendStatuses`

No caching anywhere, so each of those paid two full process boots on the main thread.

## Change

New `apps/desktop/src/main/agent/cli/binary-detection.ts`:

- `runBinaryCommand` — `promisify(execFile)`, returns `null` on non-zero exit or spawn failure, mirroring the old `status !== 0` checks exactly.
- `locateBinary` — the `which`/`where` + `existsSync` logic that was duplicated in both files, now async.
- `cacheBinaryDetection` — wraps a probe so repeated callers share one spawn.

`claude-binary.ts` / `codex-binary.ts` keep their own version parsing and semver comparison (Codex still reads stderr as well as stdout) and now export `detectClaudeBinary` / `detectCodexBinary` as the cached wrapper around an async probe. No call sites changed — both are still `() => Promise<BinaryStatus>`.

### Cache semantics, deliberately conservative

This code path has produced a "CLI greyed out" report twice (#755 packaged-app `PATH`, #758 dev-worktree keychain), so the cache is built not to make either permanent:

- **A miss is never cached.** Undetected, unreadable version, and below-minimum all leave the cache empty, so a user who installs or upgrades the CLI mid-session sees it on the very next call — no restart, no invalidation hook to remember to fire. The cost of that is one async `which` per attempted turn for users without the CLI, which no longer blocks anything.
- **A hit is cached for 5 minutes, not for the session.** A session-lifetime positive would survive the binary being uninstalled or moved and turn a friendly install hint into a raw spawn error. The TTL bounds that window while still collapsing a burst of turn + title + summary probes into one.
- **Concurrent callers share the in-flight promise.** A turn starting while `agent:getBackendStatuses` is resolving awaits the same probe rather than starting a second one, and nothing proceeds before detection resolves — the gate in `bootstrap.ts` still `await`s a real result, so there is no window where a call reports "no binary" spuriously.

## Tests

`apps/desktop/src/main/agent/cli/__tests__/binary-detection.test.ts` (new, 12 tests) — real subprocesses, no child_process mocking:

- `runBinaryCommand` success / non-zero exit / unspawnable, and **keeps the event loop turning**: a `setInterval` tick counter must advance while a 200 ms child runs. `spawnSync` leaves it at 0.
- `locateBinary` resolves `node` and rejects a nonexistent name, both asserting `spawnSync` was never called (the module partially mocks `node:child_process` to watch it).
- `cacheBinaryDetection`: reuse, single shared in-flight probe, no negative cache, no below-minimum cache, TTL expiry, and no latching of a rejected probe.

`claude-binary.test.ts` / `codex-binary.test.ts` — kept every existing assertion, re-pointed at `locateBinary`/`runBinaryCommand` while running the real cache, plus new cases for "probes once when asked repeatedly", "re-probes after a miss so installing the CLI mid-session is picked up", and (Claude) "re-probes after an outdated binary so upgrading mid-session is picked up".

### Red -> green

Red, before the fix, with two probes added to the then-current test file:

```
FAIL src/main/agent/cli/__tests__/claude-binary.test.ts > never blocks the main-process event loop with spawnSync
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 2 times
  1st call: [ "which", [ "claude" ] ]
  2nd call: [ "/usr/local/bin/claude", [ "--version" ], { "encoding": "utf8" } ]

FAIL src/main/agent/cli/__tests__/claude-binary.test.ts > probes once when a detected binary is asked for repeatedly
AssertionError: expected { Object (detected, version, ...) } to deeply equal { detected: true, ... }

Tests  2 failed | 4 passed (6)
```

Green after: `Tests 78 passed` across `src/main/agent/cli/`.

### Mutation check

The fix was mutated three ways to prove the tests bite, not just pass:

| Mutation | Result |
| --- | --- |
| cache negatives too + drop in-flight dedup | `Tests 6 failed \| 19 passed` — the three "re-probes after a miss/outdated" cases, "never caches a miss", "never caches below minimum", "shares one probe" |
| `execFile` -> `spawnSync` | `Tests 3 failed \| 9 passed` — "keeps the event loop turning", "returns stdout", "resolves an executable without spawnSync" |

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts, architecture, `ipc:check`, node + web `tsc`)
- `pnpm lint` — pass, `0 errors, 14 warnings`; all 14 are pre-existing renderer warnings in files this branch does not touch (`tags-hub/*`, `hooks/use-folder-view.ts`, `use-tab-keyboard-shortcuts.ts`)
- `pnpm --filter @memry/desktop test:main` — `Test Files 476 passed | 1 skipped`, `Tests 5435 passed | 1 expected fail | 4 skipped`
- `pnpm docs:impact --base origin/main --strict` — `covered`; `pnpm docs:build` — `build complete`
