### PR TITLE
fix(agent): cache the local provider capability probe instead of re-running it every turn

### DIFF
--- a/apps/desktop/src/main/agent/backends/__tests__/local-openai-compatible-backend.test.ts
+++ b/apps/desktop/src/main/agent/backends/__tests__/local-openai-compatible-backend.test.ts
@@ -433,6 +433,180 @@ describe('LocalOpenAICompatibleBackend', () => {
     expect(streamArgs.providerOptions).toEqual({ ollama: { options: { num_ctx: 8192 } } })
   })
 
+  describe('capability probe caching', () => {
+    const baseSettings = {
+      preset: 'ollama' as const,
+      baseUrl: 'http://localhost:11434/v1',
+      model: 'llama3.2',
+      apiKeyConfigured: false,
+      allowNonLoopback: false
+    }
+
+    function alwaysStream(): void {
+      mocks.streamText.mockImplementation(() => ({
+        fullStream: (async function* () {
+          yield { type: 'finish' }
+        })()
+      }))
+    }
+
+    function probeCallCount(fetchImpl: typeof fetch): number {
+      return (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length
+    }
+
+    async function turn(backend: LocalOpenAICompatibleBackend): Promise<void> {
+      await backend.runTurn({
+        conversationId: 'conversation-1',
+        windowId: 'window-1',
+        prompt: 'User: hello',
+        options: { backend: 'local_openai_compatible', model: 'llama3.2', toolsEnabled: true }
+      })
+    }
+
+    it('probes once and reuses the result across turns', async () => {
+      alwaysStream()
+      const fetchImpl = createProbeFetch()
+      const backend = new LocalOpenAICompatibleBackend({
+        getSettings: async () => baseSettings,
+        getApiKey: async () => null,
+        toolBridge: { execute: vi.fn() } as never,
+        fetch: fetchImpl
+      })
+
+      await turn(backend)
+      // /v1/models + streaming completion + two tool round-trip completions
+      expect(probeCallCount(fetchImpl)).toBe(4)
+
+      await turn(backend)
+      expect(probeCallCount(fetchImpl)).toBe(4)
+      expect(mocks.streamText).toHaveBeenLastCalledWith(
+        expect.objectContaining({ tools: expect.anything() })
+      )
+    })
+
+    it('re-probes when the model, base URL, or API key changes', async () => {
+      alwaysStream()
+      const fetchImpl = createProbeFetch({ models: ['llama3.2', 'qwen3'] })
+      let settings = { ...baseSettings }
+      let apiKey: string | null = null
+      const backend = new LocalOpenAICompatibleBackend({
+        getSettings: async () => settings,
+        getApiKey: async () => apiKey,
+        toolBridge: { execute: vi.fn() } as never,
+        fetch: fetchImpl
+      })
+
+      await turn(backend)
+      expect(probeCallCount(fetchImpl)).toBe(4)
+
+      settings = { ...settings, model: 'qwen3' }
+      await turn(backend)
+      expect(probeCallCount(fetchImpl)).toBe(8)
+
+      settings = { ...settings, baseUrl: 'http://localhost:1234/v1' }
+      await turn(backend)
+      expect(probeCallCount(fetchImpl)).toBe(12)
+
+      apiKey = 'rotated'
+      await turn(backend)
+      expect(probeCallCount(fetchImpl)).toBe(16)
+    })
+
+    it('never caches an unreachable provider so starting the server takes effect next turn', async () => {
+      alwaysStream()
+      const live = createProbeFetch()
+      let serverUp = false
+      const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) =>
+        serverUp ? live(url, init) : new Response('down', { status: 503 })
+      ) as unknown as typeof fetch
+
+      const backend = new LocalOpenAICompatibleBackend({
+        getSettings: async () => baseSettings,
+        getApiKey: async () => null,
+        toolBridge: { execute: vi.fn() } as never,
+        fetch: fetchImpl
+      })
+
+      await turn(backend)
+      await turn(backend)
+      // Both turns hit /v1/models — the failure must never be cached.
+      expect(probeCallCount(fetchImpl)).toBe(2)
+      expect(mocks.streamText).toHaveBeenLastCalledWith(
+        expect.not.objectContaining({ tools: expect.anything() })
+      )
+
+      serverUp = true
+      await turn(backend)
+      expect(probeCallCount(fetchImpl)).toBe(6)
+      expect(mocks.streamText).toHaveBeenLastCalledWith(
+        expect.objectContaining({ tools: expect.anything() })
+      )
+    })
+
+    it('collapses concurrent turns onto a single in-flight probe', async () => {
+      alwaysStream()
+      const fetchImpl = createProbeFetch()
+      const backend = new LocalOpenAICompatibleBackend({
+        getSettings: async () => baseSettings,
+        getApiKey: async () => null,
+        toolBridge: { execute: vi.fn() } as never,
+        fetch: fetchImpl
+      })
+
+      await Promise.all([turn(backend), turn(backend), turn(backend)])
+
+      expect(probeCallCount(fetchImpl)).toBe(4)
+    })
+
+    it('forces a live probe for the settings screen and refreshes the cache', async () => {
+      alwaysStream()
+      const fetchImpl = createProbeFetch()
+      const backend = new LocalOpenAICompatibleBackend({
+        getSettings: async () => baseSettings,
+        getApiKey: async () => null,
+        toolBridge: { execute: vi.fn() } as never,
+        fetch: fetchImpl
+      })
+
+      await turn(backend)
+      expect(probeCallCount(fetchImpl)).toBe(4)
+
+      await expect(backend.probeCapabilities()).resolves.toMatchObject({ toolsEnabled: true })
+      expect(probeCallCount(fetchImpl)).toBe(8)
+
+      await turn(backend)
+      expect(probeCallCount(fetchImpl)).toBe(8)
+    })
+
+    it('expires a cached probe after the TTL', async () => {
+      alwaysStream()
+      vi.useFakeTimers({ toFake: ['Date'] })
+      try {
+        vi.setSystemTime(new Date('2026-08-07T00:00:00.000Z'))
+        const fetchImpl = createProbeFetch()
+        const backend = new LocalOpenAICompatibleBackend({
+          getSettings: async () => baseSettings,
+          getApiKey: async () => null,
+          toolBridge: { execute: vi.fn() } as never,
+          fetch: fetchImpl
+        })
+
+        await turn(backend)
+        expect(probeCallCount(fetchImpl)).toBe(4)
+
+        vi.setSystemTime(new Date('2026-08-07T00:09:00.000Z'))
+        await turn(backend)
+        expect(probeCallCount(fetchImpl)).toBe(4)
+
+        vi.setSystemTime(new Date('2026-08-07T00:10:01.000Z'))
+        await turn(backend)
+        expect(probeCallCount(fetchImpl)).toBe(8)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
   it('non-ollama preset stays on the /v1 openai-compat path without num_ctx', async () => {
     mocks.streamText.mockReturnValueOnce({
       fullStream: (async function* () {
@@ -467,12 +641,17 @@ describe('LocalOpenAICompatibleBackend', () => {
 })
 
 function createProbeFetch(
-  input: { toolCall?: boolean; toolProbeStatus?: number; streamBody?: boolean } = {}
+  input: {
+    toolCall?: boolean
+    toolProbeStatus?: number
+    streamBody?: boolean
+    models?: string[]
+  } = {}
 ): typeof fetch {
   return vi.fn(async (url: string | URL, init?: RequestInit) => {
     const href = String(url)
     if (href.endsWith('/models')) {
-      return jsonResponse({ data: [{ id: 'llama3.2' }] })
+      return jsonResponse({ data: (input.models ?? ['llama3.2']).map((id) => ({ id })) })
     }
 
     const body = JSON.parse(String(init?.body ?? '{}')) as {

--- a/apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts
+++ b/apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 import { createOpenAI } from '@ai-sdk/openai'
 import { createOllama } from 'ollama-ai-provider-v2'
 import {
@@ -19,6 +21,15 @@ let nextLocalRunPid = -1
 // if someone needs to tune it.
 const OLLAMA_NUM_CTX = 8192
 
+// ponytail: a capability probe costs /v1/models, a streaming completion and two full
+// tool round-trip generations (#1009), so it cannot run per message. Results are cached
+// per (preset, baseUrl, model, api key); anything the user can change from outside the
+// app is bounded by these TTLs instead.
+const PROBE_TTL_MS = 10 * 60_000
+// A "no tools" verdict is usually a model property, but a transient provider error at
+// the tool step looks identical, so it expires fast.
+const PROBE_DEGRADED_TTL_MS = 60_000
+
 // Ollama's native API (the only endpoint that accepts num_ctx) lives at /api, while
 // the stored ollama preset baseUrl points at the /v1 OpenAI-compat path.
 function toOllamaApiBaseUrl(baseUrl: string): string {
@@ -27,6 +38,16 @@ function toOllamaApiBaseUrl(baseUrl: string): string {
 
 export class LocalOpenAICompatibleBackend implements AgentBackend {
   readonly id = 'local_openai_compatible' as const
+
+  // Single slot: only one provider configuration is live at a time, so an entry for an
+  // older one is worthless and this can never grow.
+  private probeCache: {
+    key: string
+    result: AgentLocalProviderProbeResult
+    expiresAt: number
+  } | null = null
+  private probeInFlight: { key: string; promise: Promise<AgentLocalProviderProbeResult> } | null =
+    null
 
   constructor(
     private readonly deps: {
@@ -68,7 +89,43 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
   async probeCapabilities(): Promise<AgentLocalProviderProbeResult> {
     const settings = await this.deps.getSettings()
     const apiKey = await this.deps.getApiKey()
-    return probeLocalProvider(settings, this.deps.fetch ?? fetch, apiKey)
+    // The settings screen asks for this on demand, so it must be live and it doubles as
+    // the manual way to clear a stale verdict.
+    return this.resolveProbe(settings, apiKey, { force: true })
+  }
+
+  private async resolveProbe(
+    settings: AgentLocalProviderSettings,
+    apiKey: string | null,
+    options: { force?: boolean } = {}
+  ): Promise<AgentLocalProviderProbeResult> {
+    const key = probeCacheKey(settings, apiKey)
+    if (!options.force) {
+      const cached = this.probeCache
+      if (cached?.key === key && cached.expiresAt > Date.now()) return cached.result
+      // Two turns starting at once must share one probe rather than racing.
+      const pending = this.probeInFlight
+      if (pending?.key === key) return pending.promise
+    }
+
+    const promise = this.runProbe(key, settings, apiKey)
+    if (!options.force) this.probeInFlight = { key, promise }
+    try {
+      return await promise
+    } finally {
+      if (this.probeInFlight?.promise === promise) this.probeInFlight = null
+    }
+  }
+
+  private async runProbe(
+    key: string,
+    settings: AgentLocalProviderSettings,
+    apiKey: string | null
+  ): Promise<AgentLocalProviderProbeResult> {
+    const result = await probeLocalProvider(settings, this.deps.fetch ?? fetch, apiKey)
+    const ttl = probeCacheTtlMs(result)
+    this.probeCache = ttl > 0 ? { key, result, expiresAt: Date.now() + ttl } : null
+    return result
   }
 
   private async run(input: AgentBackendRunInput, allowTools: boolean): Promise<BackendRunHandle> {
@@ -90,7 +147,7 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
     const toolsEnabled =
       allowTools &&
       (options?.toolsEnabled ?? true) &&
-      (await probeLocalProvider(settings, this.deps.fetch ?? fetch, apiKey)).toolsEnabled
+      (await this.resolveProbe(settings, apiKey)).toolsEnabled
     const result = streamText({
       model,
       prompt: input.prompt,
@@ -243,6 +300,21 @@ async function probeLocalProvider(
       toolProbe.toolCallingSupported &&
       toolProbe.toolContinuationSupported
   }
+}
+
+function probeCacheKey(settings: AgentLocalProviderSettings, apiKey: string | null): string {
+  // Hashed so a long-lived cache entry never keeps a second copy of the API key around.
+  return createHash('sha256')
+    .update(JSON.stringify([settings.preset, settings.baseUrl, settings.model, apiKey]))
+    .digest('hex')
+}
+
+function probeCacheTtlMs(result: AgentLocalProviderProbeResult): number {
+  // Unreachable provider, model not pulled yet, or no streaming: the user fixes all of
+  // these outside the app, and none of them paid for the expensive tool probe, so never
+  // cache them — starting the local server must take effect on the very next turn.
+  if (!result.connected || !result.modelAvailable || !result.streamingSupported) return 0
+  return result.toolsEnabled ? PROBE_TTL_MS : PROBE_DEGRADED_TTL_MS
 }
 
 export async function listOpenAiCompatibleModels(

--- a/apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts
+++ b/apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'node:crypto'
-
 import { createOpenAI } from '@ai-sdk/openai'
 import { createOllama } from 'ollama-ai-provider-v2'
 import {
@@ -40,14 +38,20 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
   readonly id = 'local_openai_compatible' as const
 
   // Single slot: only one provider configuration is live at a time, so an entry for an
-  // older one is worthless and this can never grow.
+  // older one is worthless and this can never grow. `apiKey` is compared by value and
+  // never hashed or otherwise derived — the cache only needs to know whether the key
+  // changed since the last probe.
   private probeCache: {
-    key: string
+    settingsKey: string
+    apiKey: string | null
     result: AgentLocalProviderProbeResult
     expiresAt: number
   } | null = null
-  private probeInFlight: { key: string; promise: Promise<AgentLocalProviderProbeResult> } | null =
-    null
+  private probeInFlight: {
+    settingsKey: string
+    apiKey: string | null
+    promise: Promise<AgentLocalProviderProbeResult>
+  } | null = null
 
   constructor(
     private readonly deps: {
@@ -99,17 +103,23 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
     apiKey: string | null,
     options: { force?: boolean } = {}
   ): Promise<AgentLocalProviderProbeResult> {
-    const key = probeCacheKey(settings, apiKey)
+    const settingsKey = probeSettingsKey(settings)
     if (!options.force) {
       const cached = this.probeCache
-      if (cached?.key === key && cached.expiresAt > Date.now()) return cached.result
+      if (
+        cached?.settingsKey === settingsKey &&
+        cached.apiKey === apiKey &&
+        cached.expiresAt > Date.now()
+      ) {
+        return cached.result
+      }
       // Two turns starting at once must share one probe rather than racing.
       const pending = this.probeInFlight
-      if (pending?.key === key) return pending.promise
+      if (pending?.settingsKey === settingsKey && pending.apiKey === apiKey) return pending.promise
     }
 
-    const promise = this.runProbe(key, settings, apiKey)
-    if (!options.force) this.probeInFlight = { key, promise }
+    const promise = this.runProbe(settingsKey, settings, apiKey)
+    if (!options.force) this.probeInFlight = { settingsKey, apiKey, promise }
     try {
       return await promise
     } finally {
@@ -118,13 +128,13 @@ export class LocalOpenAICompatibleBackend implements AgentBackend {
   }
 
   private async runProbe(
-    key: string,
+    settingsKey: string,
     settings: AgentLocalProviderSettings,
     apiKey: string | null
   ): Promise<AgentLocalProviderProbeResult> {
     const result = await probeLocalProvider(settings, this.deps.fetch ?? fetch, apiKey)
     const ttl = probeCacheTtlMs(result)
-    this.probeCache = ttl > 0 ? { key, result, expiresAt: Date.now() + ttl } : null
+    this.probeCache = ttl > 0 ? { settingsKey, apiKey, result, expiresAt: Date.now() + ttl } : null
     return result
   }
 
@@ -302,11 +312,11 @@ async function probeLocalProvider(
   }
 }
 
-function probeCacheKey(settings: AgentLocalProviderSettings, apiKey: string | null): string {
-  // Hashed so a long-lived cache entry never keeps a second copy of the API key around.
-  return createHash('sha256')
-    .update(JSON.stringify([settings.preset, settings.baseUrl, settings.model, apiKey]))
-    .digest('hex')
+// Non-secret half of the probe identity. The API key is deliberately not part of this
+// string: it is compared by value on the cache slot instead, so no derived form of the
+// user's credential is ever produced.
+function probeSettingsKey(settings: AgentLocalProviderSettings): string {
+  return JSON.stringify([settings.preset, settings.baseUrl, settings.model])
 }
 
 function probeCacheTtlMs(result: AgentLocalProviderProbeResult): number {

--- a/apps/docs/src/user-guide/ai/agent-mcp.md
+++ b/apps/docs/src/user-guide/ai/agent-mcp.md
@@ -141,6 +141,12 @@ model can emit tool calls and continue after a tool result, memrynote enables th
 the probe fails, local chat can still answer from attached context, but vault tool calls stay
 disabled.
 
+The probe costs a couple of model generations, so memrynote runs it once and reuses the verdict for
+up to ten minutes instead of repeating it on every message. Changing the preset, base URL, model, or
+API key re-checks immediately, and an unreachable provider is never remembered — start your local
+server and the next message picks it up. If you swap the model behind an unchanged configuration,
+press **Probe Tools** in Settings to force a fresh check.
+
 If the configured local provider is not running, the model picker returns no discovered models
 instead of treating the settings page as an Agent runtime error. Start the provider, then load models
 or test the connection again.

--- a/apps/docs/src/user-guide/settings.md
+++ b/apps/docs/src/user-guide/settings.md
@@ -296,7 +296,7 @@ machine-local and are not synced between devices.
 - **Model** — choose from `/v1/models` when available or type a model manually
 - **API Key** — optional, stored in the OS keychain
 - **Test Connection** — checks the endpoint and selected model
-- **Probe Tools** — verifies tool-call emission and tool-result continuation before vault tools are enabled
+- **Probe Tools** — verifies tool-call emission and tool-result continuation before vault tools are enabled, and forces a fresh check when the cached verdict is stale
 
 The Agent Chat prompt bar can override access for one turn and can enable web search when the active
 backend supports it. Vault-only turns keep the CLI backend constrained to memrynote tools; computer


### PR DESCRIPTION
Fixes #1009

## Verification (the issue is real on current `main`)

`apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts:90-93` on `main` @ `27bc2b961`:

```ts
const toolsEnabled =
  allowTools &&
  (options?.toolsEnabled ?? true) &&
  (await probeLocalProvider(settings, this.deps.fetch ?? fetch, apiKey)).toolsEnabled
```

`probeLocalProvider` (`:219-246`) chains `GET /v1/models` → a streaming `chat/completions` → `probeToolCalling` (`:297-362`), which posts **two** non-streaming `chat/completions` for the synthetic `memry_probe_echo` round-trip. No cache, no TTL, no in-flight dedupe.

Measured with the existing `createProbeFetch` harness: **two consecutive turns issued 8 probe HTTP calls** (4 per turn), including 3 full model generations per turn. The new test failed on unpatched code with `expected 8 to be 4`.

## Change

One file: `apps/desktop/src/main/agent/backends/local-openai-compatible-backend.ts`.

- Single-slot probe cache on the backend instance. Its identity has two halves:
  - `settingsKey` — a plain composite string over the non-secret fields `(preset, baseUrl, model)`;
  - `apiKey` — held as its own field and compared by plain inequality. The key's *value* is never needed, only whether it changed since the last probe, so no hash or other derived form of the user's credential is ever produced. (An earlier revision keyed on a SHA-256 over all four fields; CodeQL correctly flagged that as a credential hashed with insufficient computational effort, and the digest is gone.)
  - Single slot, not a map, so it is strictly bounded — only one provider configuration is live at a time.
- `probeCacheTtlMs()` decides retention:
  - **not cached at all** when `!connected || !modelAvailable || !streamingSupported` — the user fixes all three from outside the app, and none of them paid for the expensive tool probe;
  - **60 s** when the tool probe ran but came back negative (a genuine "model has no tools" and a transient provider 500 are indistinguishable at that point);
  - **10 min** when `toolsEnabled` is true.
- `probeInFlight` slot so two turns starting at once share one probe instead of racing, and no turn proceeds before the probe resolves (the `await` is unchanged, only its source).
- `probeCapabilities()` — the Settings **Probe Tools** button — now forces a live probe and refreshes the cache, giving the user a manual invalidation lever.

Nothing else moved: `probeLocalProvider`, `testOpenAiCompatibleConnection`, `getStatus`, and the streaming path are untouched. No new dependency, no contract/IPC/schema change, no persisted state — the cache is per-process and dies with the vault's backend instance, so there is no backward-compatibility surface.

### Invalidation coverage

| Provider state change | Covered by |
| --- | --- |
| Preset / base URL / model edited in Settings | `settingsKey` (settings are re-read from the store every turn, so it changes on the next turn) |
| API key rotated | `apiKey` field compared by value on the cache slot |
| Per-conversation model | unchanged behaviour — the probe already keys off `settings.model`, not `options.model`; the cache identity matches exactly what the probe consumes, so it can never return a verdict computed for different inputs |
| Local server not running | negative never cached — every turn re-probes, and a dead loopback port fails fast on `/v1/models` |
| Model not pulled yet / no streaming | negative never cached — same |
| Transient error during the tool probe | 60 s TTL, plus **Probe Tools** to clear immediately |
| Server goes down mid-session with a cached positive | bounded to 10 min. The turn then fails inside `streamText`, `mapAiSdkEvents` catches it, `exitCode` becomes 1 and the message lands on stderr; `runtime/turn.ts:214-232` turns that into a `turn_error` with the fetch error text. A clear error, not a hang. |
| Concurrent turns | single in-flight slot compared the same way |

## Tests

`apps/desktop/src/main/agent/backends/__tests__/local-openai-compatible-backend.test.ts` — new `capability probe caching` describe block (6 cases):

1. probes once and reuses the result across turns
2. re-probes when the model, base URL, or API key changes
3. never caches an unreachable provider so starting the server takes effect next turn
4. collapses concurrent turns onto a single in-flight probe
5. forces a live probe for the settings screen and refreshes the cache
6. expires a cached probe after the TTL

**Red (before the fix)** — `PASS (12) FAIL (4)`:

```
1. probes once and reuses the result across turns
   AssertionError: expected 8 to be 4
2. collapses concurrent turns onto a single in-flight probe
   AssertionError: expected 12 to be 4
3. forces a live probe for the settings screen and refreshes the cache
   AssertionError: expected 12 to be 8
4. expires a cached probe after the TTL
   AssertionError: expected 8 to be 4
```

**Green (after the fix)** — `PASS (16) FAIL (0)`.

Cases 2 and 3 pass trivially without a cache, so they were mutation-tested rather than trusted:

- drop the `cached.apiKey === apiKey` comparison (and its in-flight twin) → *re-probes when the model, base URL, or API key changes* goes red (`expected 12 to be 16` — the rotated key reused the cached verdict)
- collapse `settingsKey` to `[settings.preset]` → same test goes red (`expected 4 to be 8`)
- make `probeCacheTtlMs` cache everything (`if (false) return 0`) → *never caches an unreachable provider* goes red (`expected 1 to be 2`)
- drop `{ force: true }` from `probeCapabilities` → *forces a live probe* goes red (`expected 4 to be 8`)

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + rpc + IPC invoke map all up to date, node and web `tsc` clean)
- `pnpm lint` — `14 problems (0 errors, 14 warnings)`, all pre-existing and in files this branch does not touch (`tags-hub/*`, `use-folder-view.ts`, `use-tab-keyboard-shortcuts.ts`)
- `pnpm --filter @memry/desktop test:main src/main/agent` — `PASS (333) FAIL (0)`
- `pnpm docs:impact --base origin/main --strict` — `covered`; `pnpm docs:build` — pass
- CI on this PR: 13 passed, 0 failed — including `CodeQL`, `Analyze (javascript-typescript)`, `Static checks`, `Unit & integration tests`, `Packaged runtime smoke`
