### PR TITLE
fix(voice): stop delivering a cancelled recording

### DIFF
--- a/apps/desktop/src/renderer/src/components/voice-recorder.test.tsx
+++ b/apps/desktop/src/renderer/src/components/voice-recorder.test.tsx
@@ -6,7 +6,6 @@ import { VoiceRecorder, type VoiceRecorderHandle } from './voice-recorder'
 
 class MockMediaRecorder {
   static isTypeSupported = vi.fn(() => true)
-  static emitDataOnStop = true
 
   state: 'inactive' | 'recording' = 'inactive'
   ondataavailable: ((event: { data: Blob }) => void) | null = null
@@ -25,9 +24,7 @@ class MockMediaRecorder {
   stop(): void {
     this.state = 'inactive'
     queueMicrotask(() => {
-      if (MockMediaRecorder.emitDataOnStop) {
-        this.ondataavailable?.({ data: new Blob(['voice'], { type: 'audio/webm' }) })
-      }
+      this.ondataavailable?.({ data: new Blob(['voice'], { type: 'audio/webm' }) })
       this.onstop?.()
     })
   }
@@ -79,7 +76,6 @@ describe('VoiceRecorder', () => {
     getUserMedia.mockResolvedValue({
       getTracks: () => [{ stop: trackStop }]
     })
-    MockMediaRecorder.emitDataOnStop = true
   })
 
   it('starts recording, stops, and returns the captured blob', async () => {
@@ -125,8 +121,9 @@ describe('VoiceRecorder', () => {
     expect(recordingShell).not.toHaveClass('py-2.5')
   })
 
+  // The recorder runs without a timeslice, so a real browser always emits the
+  // whole recording *after* stop() — cancel has to survive that late blob.
   it('cancels an active recording and clears chunks', async () => {
-    MockMediaRecorder.emitDataOnStop = false
     render(<VoiceRecorder onRecordingComplete={onRecordingComplete} onCancel={onCancel} />)
 
     await userEvent.click(screen.getByLabelText('Start voice recording'))

--- a/apps/desktop/src/renderer/src/hooks/use-voice-capture.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-voice-capture.test.tsx
@@ -1,0 +1,181 @@
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useVoiceCapture, type VoiceCapture } from './use-voice-capture'
+
+/**
+ * Mirrors real browser ordering: `MediaRecorder` is started without a timeslice,
+ * so the whole recording arrives as a single `dataavailable` fired *after*
+ * `stop()` returns, immediately followed by `onstop`.
+ */
+class MockMediaRecorder {
+  static isTypeSupported = vi.fn(() => true)
+  static instances: MockMediaRecorder[] = []
+
+  state: 'inactive' | 'recording' = 'inactive'
+  ondataavailable: ((event: { data: Blob }) => void) | null = null
+  onstop: (() => void) | null = null
+  onerror: ((event: unknown) => void) | null = null
+
+  constructor(
+    public stream: MediaStream,
+    public options: MediaRecorderOptions
+  ) {
+    MockMediaRecorder.instances.push(this)
+  }
+
+  start(): void {
+    this.state = 'recording'
+  }
+
+  stop(): void {
+    this.state = 'inactive'
+    queueMicrotask(() => {
+      this.ondataavailable?.({ data: new Blob(['voice-audio'], { type: 'audio/webm' }) })
+      this.onstop?.()
+    })
+  }
+}
+
+describe('useVoiceCapture cancel', () => {
+  const prepareVoiceMemoAudio = vi.fn()
+  const captureVoice = vi.fn()
+  const transcribeAudio = vi.fn()
+  const onError = vi.fn()
+  const trackStop = vi.fn()
+  const getUserMedia = vi.fn()
+
+  // Stands in for what every voice surface does with a delivered blob: decode +
+  // WAV encode, then the vault write and the transcription request.
+  const onComplete = vi.fn((audioBlob: Blob, duration: number) => {
+    void (async () => {
+      const prepared = await prepareVoiceMemoAudio(audioBlob)
+      await captureVoice({ ...prepared, duration, transcribe: true })
+      await transcribeAudio(prepared)
+    })()
+  })
+
+  const capture: { current: VoiceCapture | null } = { current: null }
+
+  function Harness(): null {
+    capture.current = useVoiceCapture({ onComplete, onError })
+    return null
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    MockMediaRecorder.instances = []
+    capture.current = null
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia }
+    })
+    Object.defineProperty(globalThis, 'MediaRecorder', {
+      configurable: true,
+      value: MockMediaRecorder
+    })
+
+    getUserMedia.mockResolvedValue({ getTracks: () => [{ stop: trackStop }] })
+    prepareVoiceMemoAudio.mockResolvedValue({
+      data: new ArrayBuffer(8),
+      duration: 3,
+      format: 'wav'
+    })
+    captureVoice.mockResolvedValue({ success: true })
+    transcribeAudio.mockResolvedValue({ success: true, text: 'hello' })
+  })
+
+  async function startRecording(): Promise<{ unmount: () => void }> {
+    const view = render(<Harness />)
+    await act(async () => {
+      await capture.current?.start()
+    })
+    return view
+  }
+
+  /** Lets the queued `dataavailable`/`onstop` callbacks run. */
+  async function flushRecorder(): Promise<void> {
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+  }
+
+  it('never delivers, writes, or transcribes a cancelled recording', async () => {
+    await startRecording()
+
+    act(() => capture.current?.cancel())
+    await flushRecorder()
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(prepareVoiceMemoAudio).not.toHaveBeenCalled()
+    expect(captureVoice).not.toHaveBeenCalled()
+    expect(transcribeAudio).not.toHaveBeenCalled()
+    expect(capture.current?.state).toBe('idle')
+  })
+
+  it('releases the microphone when a recording is cancelled', async () => {
+    await startRecording()
+
+    act(() => capture.current?.cancel())
+    await flushRecorder()
+
+    expect(trackStop).toHaveBeenCalled()
+    expect(capture.current?.stream).toBeNull()
+  })
+
+  it('discards the recording when cancel lands while a stop is already in flight', async () => {
+    await startRecording()
+
+    act(() => {
+      capture.current?.stop()
+      capture.current?.cancel()
+    })
+    await flushRecorder()
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(captureVoice).not.toHaveBeenCalled()
+    expect(transcribeAudio).not.toHaveBeenCalled()
+  })
+
+  it('drops audio that arrives after unmounting mid-recording', async () => {
+    const { unmount } = await startRecording()
+
+    act(() => unmount())
+    await flushRecorder()
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(captureVoice).not.toHaveBeenCalled()
+    expect(transcribeAudio).not.toHaveBeenCalled()
+  })
+
+  it('still delivers a recording that was stopped normally', async () => {
+    await startRecording()
+
+    act(() => capture.current?.stop())
+    await flushRecorder()
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(onComplete.mock.calls[0][0]).toBeInstanceOf(Blob)
+    expect(prepareVoiceMemoAudio).toHaveBeenCalled()
+    expect(captureVoice).toHaveBeenCalled()
+    expect(transcribeAudio).toHaveBeenCalled()
+  })
+
+  it('delivers a fresh recording started after a cancelled one', async () => {
+    await startRecording()
+
+    act(() => capture.current?.cancel())
+    await flushRecorder()
+    expect(onComplete).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await capture.current?.start()
+    })
+    act(() => capture.current?.stop())
+    await flushRecorder()
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-voice-capture.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-voice-capture.ts
@@ -73,6 +73,7 @@ export function useVoiceCapture(options: UseVoiceCaptureOptions): VoiceCapture {
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const streamRef = useRef<MediaStream | null>(null)
   const chunksRef = useRef<Blob[]>([])
+  const cancelledRef = useRef(false)
   const timerRef = useRef<number | null>(null)
   const startTimeRef = useRef<number>(0)
 
@@ -80,6 +81,14 @@ export function useVoiceCapture(options: UseVoiceCaptureOptions): VoiceCapture {
     if (timerRef.current) {
       clearInterval(timerRef.current)
       timerRef.current = null
+    }
+
+    // The recorder runs without a timeslice, so the whole recording arrives as a
+    // single `dataavailable` fired *after* `stop()` returns. Latch the discard
+    // before stopping so those late callbacks never resurrect the audio — a
+    // cancelled memo must never reach the vault or the transcriber.
+    if (cancelled) {
+      cancelledRef.current = true
     }
 
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
@@ -113,6 +122,7 @@ export function useVoiceCapture(options: UseVoiceCaptureOptions): VoiceCapture {
 
       streamRef.current = mediaStream
       chunksRef.current = []
+      cancelledRef.current = false
 
       const mediaRecorder = new MediaRecorder(mediaStream, {
         mimeType: MediaRecorder.isTypeSupported(MIME_TYPE) ? MIME_TYPE : 'audio/webm'
@@ -121,12 +131,18 @@ export function useVoiceCapture(options: UseVoiceCaptureOptions): VoiceCapture {
       mediaRecorderRef.current = mediaRecorder
 
       mediaRecorder.ondataavailable = (event) => {
+        if (cancelledRef.current) return
         if (event.data.size > 0) {
           chunksRef.current.push(event.data)
         }
       }
 
       mediaRecorder.onstop = () => {
+        if (cancelledRef.current) {
+          chunksRef.current = []
+          return
+        }
+
         if (chunksRef.current.length > 0) {
           setState('processing')
 


### PR DESCRIPTION
Fixes #1011

## Verification (issue is real on current `main`)

`apps/desktop/src/renderer/src/hooks/use-voice-capture.ts` @ `27bc2b961`:

- `:150` — `mediaRecorder.start()` is called with **no timeslice**, so the recorder emits exactly one `dataavailable`, fired asynchronously *after* `stop()` returns.
- `:85-87` — `stopRecording(cancelled)` calls `mediaRecorderRef.current.stop()`.
- `:95-99` — on cancel it clears `chunksRef.current` **synchronously**, i.e. before that late `dataavailable` lands.
- `:123-127` — `ondataavailable` then pushes the full blob back into the freshly cleared array.
- `:129-138` — `onstop` sees `chunksRef.current.length > 0` and calls `optionsRef.current.onComplete(blob, ...)` anyway.

So a cancelled recording is delivered to every surface:

- `components/capture-input.tsx:173-182` → `prepareVoiceMemoAudio` (AudioBuffer decode + OfflineAudioContext render + WAV encode) → `captureVoice` with `transcribe: true` → **vault write + transcription**.
- `components/quick-capture.tsx:455-463` → same.
- `agent-chat/voice-dictation-button.tsx:69-74` → `prepareVoiceMemoAudio` → `window.api.inbox.transcribeAudio`.

**Transcription routing** — `main/inbox/transcription.ts` routes per `getVoiceTranscriptionSettings()`: either the local Whisper Small utility process (`main/inbox/voice-model.ts`) **or** the remote OpenAI Whisper API (`new OpenAI(...)` + `toFile`). So on the cloud configuration a cancelled recording was uploaded off-device. That makes this a privacy bug, not just wasted CPU.

The existing test masked it: `voice-recorder.test.tsx:129` set `emitDataOnStop = false` for the cancel case, so real browser ordering was never exercised.

## Change

`apps/desktop/src/renderer/src/hooks/use-voice-capture.ts` (+16 lines, no API change):

- New `cancelledRef`, latched to `true` inside `stopRecording` **before** `.stop()` is called — so callbacks already in flight see the discard.
- `ondataavailable` drops the event when cancelled (the audio is never retained at all).
- `onstop` returns early when cancelled, clearing chunks and never calling `onComplete`.
- `start()` resets the flag so a fresh recording still delivers normally.

Mic release was already correct and is unchanged: `stopRecording` stops every track and `setStream(null)`, which drives `voice-recorder.tsx`'s effect cleanup → `cleanupAudio()` → `AudioContext.close()`. Both are now asserted by tests. The `MediaRecorder`-constructor-throw path (#1012) and the waveform-setup-throw path (#1067) are untouched.

## Tests

New `apps/desktop/src/renderer/src/hooks/use-voice-capture.test.tsx` — mock `MediaRecorder` reproduces real browser ordering (single `dataavailable` fired after `stop()`), and `onComplete` is wired to a stand-in pipeline (`prepareVoiceMemoAudio` → `captureVoice` → `transcribeAudio`) so the assertions are about the actual consequences:

1. cancel → no `onComplete`, **no decode, no vault write, no transcription**
2. cancel → microphone tracks stopped and `stream` nulled
3. `stop()` then `cancel()` while the stop is already in flight → still discarded
4. unmount mid-recording → late audio dropped
5. control: a normal `stop()` still delivers (decode + write + transcribe all run)
6. control: a recording started after a cancelled one still delivers

`apps/desktop/src/renderer/src/components/voice-recorder.test.tsx` — the mock now always emits `dataavailable` on `stop()`; the `emitDataOnStop` escape hatch that hid this is gone.

Red → green:

```
# before the fix
 × use-voice-capture.test.tsx > never delivers, writes, or transcribes a cancelled recording
 × use-voice-capture.test.tsx > discards the recording when cancel lands while a stop is already in flight
 × use-voice-capture.test.tsx > drops audio that arrives after unmounting mid-recording
 × use-voice-capture.test.tsx > delivers a fresh recording started after a cancelled one
 × voice-recorder.test.tsx    > cancels an active recording and clears chunks
   AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
   1st vi.fn() call: [ Blob {}, 0.001 ]
 Tests  5 failed | 6 passed (11)

# after the fix
 Test Files  2 passed (2)
      Tests  11 passed (11)
```

Mutation-checked (mocked tests can lie):

- removing the `cancelledRef.current = true` latch → `5 failed | 6 passed`
- removing the `cancelledRef.current = false` reset in `start()` → control test 6 fails

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts, architecture, rpc, ipc map, node, web all clean)
- `pnpm lint` — pass, `0 errors, 14 warnings`; all 14 are pre-existing and in unrelated files (tags-hub, use-folder-view, use-tab-keyboard-shortcuts, graph-events, onenote-import-panel)
- Renderer tests for every voice surface — `5 files, 59 tests passed`: `use-voice-capture`, `voice-recorder`, `capture-input`, `quick-capture`, `agent-chat/composer`
