### PR TITLE
fix(voice): release the microphone when the recorder fails to start

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-voice-capture-start-failure.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-voice-capture-start-failure.test.tsx
@@ -1,0 +1,172 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useVoiceCapture } from './use-voice-capture'
+
+/**
+ * A failed recorder start is a privacy bug, not just a leak: `getUserMedia`
+ * already turned the microphone on, so every track has to be stopped before the
+ * hook goes back to idle or the OS keeps recording with no UI saying so.
+ */
+
+interface FakeTrack {
+  readyState: 'live' | 'ended'
+  stop: ReturnType<typeof vi.fn>
+}
+
+interface FakeStream {
+  tracks: FakeTrack[]
+  stream: MediaStream
+}
+
+function createFakeStream(): FakeStream {
+  const tracks: FakeTrack[] = [
+    { readyState: 'live', stop: vi.fn() },
+    { readyState: 'live', stop: vi.fn() }
+  ]
+
+  for (const track of tracks) {
+    track.stop.mockImplementation(() => {
+      track.readyState = 'ended'
+    })
+  }
+
+  return { tracks, stream: { getTracks: () => tracks } as unknown as MediaStream }
+}
+
+type RecorderFailure = 'none' | 'constructor' | 'start'
+
+let recorderFailure: RecorderFailure = 'none'
+
+class MockMediaRecorder {
+  static isTypeSupported = vi.fn(() => true)
+
+  state: 'inactive' | 'recording' = 'inactive'
+  ondataavailable: ((event: { data: Blob }) => void) | null = null
+  onstop: (() => void) | null = null
+  onerror: ((event: unknown) => void) | null = null
+
+  constructor(
+    public stream: MediaStream,
+    public options: MediaRecorderOptions
+  ) {
+    if (recorderFailure === 'constructor') {
+      throw new TypeError(
+        "Failed to construct 'MediaRecorder': Failed to initialize native MediaRecorder, the type provided is not supported."
+      )
+    }
+  }
+
+  start(): void {
+    if (recorderFailure === 'start') {
+      throw new DOMException('The MediaRecorder is not in a valid state', 'InvalidStateError')
+    }
+    this.state = 'recording'
+  }
+
+  stop(): void {
+    this.state = 'inactive'
+    queueMicrotask(() => {
+      this.onstop?.()
+    })
+  }
+}
+
+describe('useVoiceCapture — failed recorder start releases the microphone', () => {
+  const onComplete = vi.fn()
+  const onError = vi.fn()
+  const getUserMedia = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    recorderFailure = 'none'
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia }
+    })
+
+    Object.defineProperty(globalThis, 'MediaRecorder', {
+      configurable: true,
+      value: MockMediaRecorder
+    })
+  })
+
+  it.each([
+    ['the MediaRecorder constructor throws', 'constructor' as const, 'start-failed'],
+    ['MediaRecorder.start() throws', 'start' as const, 'access-failed']
+  ])('stops every acquired track when %s', async (_label, failure, expectedKind) => {
+    const first = createFakeStream()
+    getUserMedia.mockResolvedValue(first.stream)
+    recorderFailure = failure
+
+    const { result } = renderHook(() => useVoiceCapture({ onComplete, onError }))
+
+    await act(async () => {
+      await result.current.start()
+    })
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ kind: expectedKind }))
+
+    // The mic must be off: every track of the stream we acquired is stopped.
+    for (const track of first.tracks) {
+      expect(track.stop).toHaveBeenCalledTimes(1)
+      expect(track.readyState).toBe('ended')
+    }
+
+    // And the hook must be back to a retryable idle state, not mid-recording.
+    expect(result.current.state).toBe('idle')
+    expect(result.current.stream).toBeNull()
+
+    // A second attempt still works and drives a fresh stream end to end.
+    const second = createFakeStream()
+    getUserMedia.mockResolvedValue(second.stream)
+    recorderFailure = 'none'
+
+    await act(async () => {
+      await result.current.start()
+    })
+
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+    expect(result.current.state).toBe('recording')
+    expect(result.current.stream).toBe(second.stream)
+    expect(second.tracks.every((track) => track.readyState === 'live')).toBe(true)
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    expect(second.tracks.every((track) => track.readyState === 'ended')).toBe(true)
+  })
+
+  it('never overwrites the stream ref while its tracks are still live', async () => {
+    const first = createFakeStream()
+    getUserMedia.mockResolvedValue(first.stream)
+
+    const { result } = renderHook(() => useVoiceCapture({ onComplete, onError }))
+
+    await act(async () => {
+      await result.current.start()
+    })
+
+    expect(first.tracks.every((track) => track.readyState === 'live')).toBe(true)
+
+    // Starting again replaces `streamRef`; the previous stream would otherwise
+    // become unreachable and stay hot for the life of the window.
+    const second = createFakeStream()
+    getUserMedia.mockResolvedValue(second.stream)
+
+    await act(async () => {
+      await result.current.start()
+    })
+
+    expect(first.tracks.every((track) => track.readyState === 'ended')).toBe(true)
+    expect(result.current.stream).toBe(second.stream)
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    expect(second.tracks.every((track) => track.readyState === 'ended')).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/hooks/use-voice-capture.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-voice-capture.ts
@@ -76,6 +76,19 @@ export function useVoiceCapture(options: UseVoiceCaptureOptions): VoiceCapture {
   const timerRef = useRef<number | null>(null)
   const startTimeRef = useRef<number>(0)
 
+  /**
+   * Hand the microphone back to the OS. `getUserMedia` turns the mic on before
+   * the recorder is built, so any path that abandons a stream has to stop every
+   * track — otherwise the mic stays hot with no UI saying it is recording.
+   */
+  const releaseStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop())
+      streamRef.current = null
+    }
+    setStream(null)
+  }, [])
+
   const stopRecording = useCallback((cancelled: boolean) => {
     if (timerRef.current) {
       clearInterval(timerRef.current)
@@ -110,6 +123,10 @@ export function useVoiceCapture(options: UseVoiceCaptureOptions): VoiceCapture {
           sampleRate: 44100
         }
       })
+
+      // Overwriting the ref while an earlier stream is still live would strand
+      // it: nothing else holds a reference, so it could never be stopped.
+      releaseStream()
 
       streamRef.current = mediaStream
       chunksRef.current = []
@@ -164,10 +181,14 @@ export function useVoiceCapture(options: UseVoiceCaptureOptions): VoiceCapture {
       }, 100)
     } catch (err) {
       log.error('Failed to start recording', err)
+      // `getUserMedia` may have already succeeded before the MediaRecorder
+      // constructor or `start()` threw, so release the mic before going idle.
+      releaseStream()
+      mediaRecorderRef.current = null
       optionsRef.current.onError(toCaptureError(err))
       setState('idle')
     }
-  }, [stopRecording])
+  }, [releaseStream, stopRecording])
 
   const stop = useCallback(() => stopRecording(false), [stopRecording])
   const cancel = useCallback(() => stopRecording(true), [stopRecording])


### PR DESCRIPTION
Fixes #1012

## Verification (issue is real on current `main`)

`apps/desktop/src/renderer/src/hooks/use-voice-capture.ts` @ `origin/main`:

- `:114` — `streamRef.current = mediaStream` overwrites the ref unconditionally. Any stream already held there becomes unreachable while its tracks are still live.
- `:165-169` — the catch that wraps `getUserMedia` **and** `new MediaRecorder(...)` **and** `recorder.start()`:

```ts
} catch (err) {
  log.error('Failed to start recording', err)
  optionsRef.current.onError(toCaptureError(err))
  setState('idle')
}
```

No `track.stop()` anywhere on that path. `getUserMedia` has already turned the microphone on by the time the recorder is constructed, so a constructor throw (unsupported mimeType) or a `start()` throw (`InvalidStateError`, device yanked) leaves the OS recording with the app back at idle and no UI indicating capture. `voice-dictation-button.tsx` and `voice-recorder.tsx` stay mounted, so every retry strands another live stream.

This is a privacy failure, not only a leak.

## Change

`apps/desktop/src/renderer/src/hooks/use-voice-capture.ts` (+22/-1):

- New `releaseStream()` helper: stops **every** track of `streamRef.current`, nulls the ref, clears the exposed `stream` state.
- Called immediately before `streamRef.current = mediaStream`, so the ref is never overwritten while the previous stream is live.
- Called in the catch, before `setState('idle')`, so a failed constructor/`start()` hands the mic back to the OS.
- `mediaRecorderRef.current = null` on the failure path so a dead recorder wired to a released stream is not retained until the next attempt.

`stopRecording` is deliberately untouched — it already released the stream correctly, and #1011 is being fixed in that same function.

## Tests

New `apps/desktop/src/renderer/src/hooks/use-voice-capture-start-failure.test.tsx` (separate filename from `use-voice-capture.test.tsx` to avoid colliding with the #1011 branch).

Streams are mocked with **two** tracks so the assertion is "every track stopped", not "cleanup ran". The two throw sites are covered separately because they fail at different points:

1. `new MediaRecorder(...)` throws (`TypeError`, unsupported type) → every track `stop()`ed once and `readyState === 'ended'`, `state === 'idle'`, `stream === null`, then a second `start()` acquires a fresh stream and reaches `recording`, and `cancel()` releases that one too.
2. `recorder.start()` throws (`InvalidStateError`) → same assertions.
3. Ref-overwrite guard: start, then start again — the first stream's tracks are ended before the second is installed.

Red → green:

```
# before the fix
PASS (0) FAIL (3)
1. ... constructor throws        AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
2. ... MediaRecorder.start() throws  AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
3. ... never overwrites the stream ref while its tracks are still live  AssertionError: expected false to be true

# after the fix
PASS (8) FAIL (0)   # new file + existing voice-recorder.test.tsx
```

Mutation-tested (mocked tests can be worthless otherwise):

- Delete `releaseStream()` from the catch → `PASS (1) FAIL (2)` (tests 1 and 2 go red).
- Delete `releaseStream()` before the ref overwrite → `PASS (2) FAIL (1)` (test 3 goes red).

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + rpc + ipc map + node + web, no output).
- `pnpm lint` — `0 errors, 14 warnings`. All 14 are pre-existing, in files this PR does not touch (`tags-hub/*`, `use-folder-view.ts`, `use-tab-keyboard-shortcuts.ts`). `eslint --no-cache` on the changed hook is clean.
- Renderer tests: `use-voice-capture-start-failure.test.tsx` + `voice-recorder.test.tsx` + `agent-chat/__tests__/composer.test.tsx` → `PASS (41) FAIL (0)`.
- `pnpm docs:impact --strict` reported `missing-docs` for the hook. Pushed with `MEMRY_DOCS_IMPACT_SKIP=1`: no user-visible surface changes — no new setting, contract, UI, or documented behavior. The only behavior delta is that a failed recorder start now stops the mic it already opened.

## Scope

Out of scope and untouched: #1011 (cancelled recording still delivered — same file, `stopRecording`/`onstop`), #1067 (AudioContext leak on waveform setup failure — lives in `voice-recorder.tsx`, a separate surface from this hook), #1069, #1070.
