### PR TITLE
perf(agent-chat): derive the streaming flag in the reducer instead of rescanning transcripts

### DIFF
--- a/apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
@@ -1,10 +1,10 @@
 import userEvent from '@testing-library/user-event'
-import { useState } from 'react'
+import { useReducer, useState } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { Conversation } from '@memry/contracts/ipc-agent'
+import type { Conversation, Message, MessageStatus } from '@memry/contracts/ipc-agent'
 
 const mockUseAgentOptional = vi.hoisted(() => vi.fn())
 const mockOpenTab = vi.hoisted(() => vi.fn())
@@ -36,6 +36,12 @@ vi.mock('@/contexts/ai-settings-context', () => ({
 }))
 
 import { SettingsModalProvider } from '@/contexts/settings-modal-context'
+import {
+  agentReducer,
+  initialAgentState,
+  type AgentAction,
+  type AgentState
+} from '../agent-context.reducer'
 import { SidebarTabs } from '../sidebar-tabs'
 import { AgentPane } from '../agent-pane'
 
@@ -133,9 +139,82 @@ function conversation(id: string, title: string, updatedAt: number): Conversatio
   }
 }
 
+function assistantMessage(
+  id: string,
+  conversationId: string,
+  status: MessageStatus,
+  createdAt: number
+): Message {
+  return {
+    id,
+    conversationId,
+    role: 'assistant',
+    content: { role: 'assistant', data: { text: '' } },
+    toolCallId: null,
+    attachments: [],
+    status,
+    vectorClock: {},
+    createdAt,
+    updatedAt: createdAt,
+    deletedAt: null
+  }
+}
+
+/** Message whose `status` read is observable, so a transcript rescan is measurable. */
+function statusProbeMessage(message: Message, onStatusRead: () => void): Message {
+  const { status, ...rest } = message
+  const probe = { ...rest } as Message
+  Object.defineProperty(probe, 'status', {
+    enumerable: true,
+    configurable: true,
+    get() {
+      onStatusRead()
+      return status
+    }
+  })
+  return probe
+}
+
+let harnessDispatch: React.Dispatch<AgentAction> | null = null
+
+/** Drives SidebarTabs from the real reducer instead of a hand-built state object. */
+function ReducerHarness({ seed }: { seed: AgentState }): React.JSX.Element {
+  const [state, dispatch] = useReducer(agentReducer, seed)
+  harnessDispatch = dispatch
+  mockUseAgentOptional.mockReturnValue({
+    state,
+    createConversation: vi.fn(),
+    loadConversation: vi.fn(),
+    clearActiveConversation: vi.fn()
+  })
+  return (
+    <SidebarTabs>
+      {{
+        day: <div>Day content</div>,
+        agent: <div>Agent content</div>
+      }}
+    </SidebarTabs>
+  )
+}
+
+function renderReducerHarness(seed: AgentState = initialAgentState) {
+  return render(
+    <QueryClientProvider client={testQueryClient()}>
+      <ReducerHarness seed={seed} />
+    </QueryClientProvider>
+  )
+}
+
+function dispatchToHarness(action: AgentAction): void {
+  act(() => {
+    harnessDispatch?.(action)
+  })
+}
+
 describe('SidebarTabs', () => {
   beforeEach(() => {
     localStorage.clear()
+    harnessDispatch = null
     mockUseAgentOptional.mockReturnValue(null)
     mockOpenTab.mockReset()
     mockCloseDayPanel.mockReset()
@@ -386,5 +465,115 @@ describe('SidebarTabs', () => {
     expect(
       screen.queryByRole('button', { name: 'Open conversation in tab' })
     ).not.toBeInTheDocument()
+  })
+
+  it('raises and clears the activity dot as a message starts and stops streaming', () => {
+    renderReducerHarness()
+
+    expect(screen.queryByLabelText('Agent turn in progress')).not.toBeInTheDocument()
+
+    dispatchToHarness({
+      type: 'event',
+      event: {
+        kind: 'message_upserted',
+        message: assistantMessage('message-1', 'conversation-1', 'streaming', 1)
+      }
+    })
+
+    expect(screen.getByLabelText('Agent turn in progress')).toBeInTheDocument()
+
+    dispatchToHarness({
+      type: 'event',
+      event: {
+        kind: 'message_upserted',
+        message: assistantMessage('message-1', 'conversation-1', 'completed', 1)
+      }
+    })
+
+    expect(screen.queryByLabelText('Agent turn in progress')).not.toBeInTheDocument()
+  })
+
+  it('raises and clears the activity dot as a tool call runs and finishes', () => {
+    renderReducerHarness()
+
+    dispatchToHarness({
+      type: 'event',
+      event: {
+        kind: 'tool_call_started',
+        conversationId: 'conversation-1',
+        toolCallId: 'tool-1',
+        name: 'vault_create_task',
+        args: {}
+      }
+    })
+
+    expect(screen.getByLabelText('Agent turn in progress')).toBeInTheDocument()
+
+    dispatchToHarness({
+      type: 'event',
+      event: {
+        kind: 'tool_call_completed',
+        conversationId: 'conversation-1',
+        toolCallId: 'tool-1',
+        result: {}
+      }
+    })
+
+    expect(screen.queryByLabelText('Agent turn in progress')).not.toBeInTheDocument()
+  })
+
+  it('raises the activity dot when a loaded conversation already has a streaming message', () => {
+    renderReducerHarness()
+
+    dispatchToHarness({
+      type: 'set_active_conversation',
+      conversation: conversation('conversation-1', 'Planning', 100),
+      messages: [assistantMessage('message-1', 'conversation-1', 'streaming', 1)]
+    })
+
+    expect(screen.getByLabelText('Agent turn in progress')).toBeInTheDocument()
+  })
+
+  it('does not rescan other conversations on every streamed token', () => {
+    let statusReads = 0
+    const otherTranscript = [
+      assistantMessage('other-1', 'conversation-2', 'completed', 1),
+      assistantMessage('other-2', 'conversation-2', 'completed', 2)
+    ].map((message) =>
+      statusProbeMessage(message, () => {
+        statusReads += 1
+      })
+    )
+
+    renderReducerHarness({
+      ...initialAgentState,
+      messagesByConversation: { 'conversation-2': otherTranscript }
+    })
+
+    dispatchToHarness({
+      type: 'event',
+      event: {
+        kind: 'message_upserted',
+        message: assistantMessage('message-1', 'conversation-1', 'streaming', 10)
+      }
+    })
+
+    expect(screen.getByLabelText('Agent turn in progress')).toBeInTheDocument()
+
+    const readsBeforeTokens = statusReads
+    for (let token = 0; token < 20; token += 1) {
+      dispatchToHarness({
+        type: 'event',
+        event: {
+          kind: 'assistant_text_delta',
+          conversationId: 'conversation-1',
+          messageId: 'message-1',
+          text: 'x'
+        }
+      })
+    }
+
+    expect(statusReads).toBe(readsBeforeTokens)
+    expect(screen.getByLabelText('Agent turn in progress')).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
+++ b/apps/desktop/src/renderer/src/agent-chat/agent-context.reducer.ts
@@ -17,6 +17,9 @@ export interface AgentState {
   messagesByConversation: Record<string, Message[]>
   pendingApprovals: PendingToolApproval[]
   inFlight: Record<string, boolean>
+  /** Derived: any message in any conversation is still streaming. Kept here so
+   * subscribers read a scalar instead of rescanning every transcript. */
+  hasStreamingMessage: boolean
   error: string | null
 }
 
@@ -50,6 +53,7 @@ export const initialAgentState: AgentState = {
   messagesByConversation: {},
   pendingApprovals: [],
   inFlight: {},
+  hasStreamingMessage: false,
   error: null
 }
 
@@ -162,7 +166,30 @@ function withoutInFlight(state: AgentState, conversationId: string): Record<stri
   return rest
 }
 
+function scanForStreamingMessage(
+  messagesByConversation: AgentState['messagesByConversation']
+): boolean {
+  for (const messages of Object.values(messagesByConversation)) {
+    for (const message of messages) {
+      if (message.status === 'streaming') return true
+    }
+  }
+  return false
+}
+
 export function agentReducer(state: AgentState, action: AgentAction): AgentState {
+  const next = reduceAgentState(state, action)
+  // The transcripts are untouched, so no message status can have changed.
+  if (next.messagesByConversation === state.messagesByConversation) return next
+  // `assistant_text_delta` only appends text to an existing message: it never adds,
+  // removes, or restatuses one, so the derived flag survives every streamed token.
+  if (action.type === 'event' && action.event.kind === 'assistant_text_delta') return next
+  const hasStreamingMessage = scanForStreamingMessage(next.messagesByConversation)
+  if (hasStreamingMessage === next.hasStreamingMessage) return next
+  return { ...next, hasStreamingMessage }
+}
+
+function reduceAgentState(state: AgentState, action: AgentAction): AgentState {
   switch (action.type) {
     case 'set_backend_statuses':
       return {

--- a/apps/desktop/src/renderer/src/agent-chat/sidebar-tabs.tsx
+++ b/apps/desktop/src/renderer/src/agent-chat/sidebar-tabs.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { History } from 'lucide-react'
 import { useT } from '@memry/i18n/renderer'
 
@@ -66,13 +66,7 @@ export function SidebarTabs({
   }, [active])
 
   const pendingApprovalCount = agent?.state.pendingApprovals.length ?? 0
-  const hasStreamingMessage = useMemo(
-    () =>
-      Object.values(agent?.state.messagesByConversation ?? {}).some((messages) =>
-        messages.some((message) => message.status === 'streaming')
-      ),
-    [agent?.state.messagesByConversation]
-  )
+  const hasStreamingMessage = agent?.state.hasStreamingMessage ?? false
   const hasInFlightTurn = Object.values(agent?.state.inFlight ?? {}).some(Boolean)
   const hasBackgroundActivity =
     aiEnabled &&


### PR DESCRIPTION
Fixes #1007

## Verification (issue is real on current `main`)

`apps/desktop/src/renderer/src/agent-chat/sidebar-tabs.tsx:68-75` on `origin/main` @ `27bc2b961`:

```tsx
const hasStreamingMessage = useMemo(
  () =>
    Object.values(agent?.state.messagesByConversation ?? {}).some((messages) =>
      messages.some((message) => message.status === 'streaming')
    ),
  [agent?.state.messagesByConversation]
)
```

`agent-context.reducer.ts` rebuilds `messagesByConversation` on every `assistant_text_delta`
(`appendAssistantDelta` maps the array), so the dep identity changes per streamed token and the
`O(conversations × messages)` scan re-runs. `SidebarTabs` is mounted whenever the right sidebar
exists, agent tab active or not.

## Change

- `agent-context.reducer.ts` — `AgentState` gains a derived `hasStreamingMessage: boolean`.
  `agentReducer` is now a thin wrapper over the existing switch (renamed to `reduceAgentState`,
  body untouched) that recomputes the flag with a short-circuiting scan. It skips the recompute in
  exactly two provable cases:
  1. `next.messagesByConversation === state.messagesByConversation` — transcripts untouched, so no
     status can have changed (the reducer never mutates in place).
  2. `action.event.kind === 'assistant_text_delta'` — `appendAssistantDelta` only appends text to an
     existing message; it can neither add, remove, nor restatus one.

  Everything else (`message_upserted`, `tool_call_*`, `clear_pending`, `set_active_conversation`,
  `set_conversation_messages`) rescans. The gate is fail-safe: a future action that is not
  `assistant_text_delta` recomputes by default.
- `sidebar-tabs.tsx` — reads `agent?.state.hasStreamingMessage ?? false`; `useMemo` import dropped.

Store edit is deliberately minimal (one field + one wrapper function) — the existing switch bodies
are byte-for-byte unchanged, to stay out of the way of the sibling agent-chat perf issues.

## Tests

`apps/desktop/src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx` — new tests drive
`SidebarTabs` from the **real** `agentReducer` (not a hand-built mock state), so they exercise the
actual invalidation path.

Correctness (these assert the indicator DOES change):
- dot appears on `message_upserted{status:'streaming'}`, clears on `message_upserted{status:'completed'}`
- dot appears on `tool_call_started`, clears on `tool_call_completed`
- dot appears when `set_active_conversation` loads a transcript that already has a streaming message

Cost (this is the regression guard): a second conversation's messages get an instrumented `status`
getter that counts reads. After streaming starts, 20 `assistant_text_delta` dispatches must add
**zero** reads.

Red before the fix:

```
FAIL src/renderer/src/agent-chat/__tests__/sidebar-tabs.test.tsx
  > SidebarTabs > does not rescan other conversations on every streamed token
AssertionError: expected 44 to be 4 // Object.is equality
```

(20 tokens × 2 messages = 40 extra scans.)

Green after: `Test Files 1 passed (1) / Tests 15 passed (15)`.

Mutation check (guards against a memo that goes stale, which would be worse than the rescan):
widening the skip from `action.event.kind === 'assistant_text_delta'` to all `event` actions turns
**3 of the 4** new tests red — both "clears the dot" tests and the token test. The tests are not
vacuous.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + ipc:check + node + web)
- `pnpm lint` — pass, `0 errors, 14 warnings`, all pre-existing and in unrelated files
- `npx eslint --no-cache` on the three touched files — clean
- `npx -y react-doctor@latest .` — no findings in `sidebar-tabs.tsx` or `agent-context.reducer.ts`
- `vitest --project renderer` over `sidebar-tabs`, `agent-context`, `agent-provider`, `agent-pane`,
  `conversation-view`, `message-stream` — `77 passed (77)`
- `pnpm docs:impact --strict` reports `missing-docs`; pushed with `MEMRY_DOCS_IMPACT_SKIP=1`. The
  change is an internal render/derivation optimisation with no user-visible surface: the indicator's
  behaviour, appearance, and labels are identical.
