### PR TITLE
fix(hooks): keep the useAllTags tag-event subscription stable across renders

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-all-tags.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-all-tags.test.tsx
@@ -8,7 +8,8 @@ import { useAllTags } from './use-all-tags'
 const mocks = vi.hoisted(() => ({
   notesGetTags: vi.fn(),
   inboxGetTags: vi.fn(),
-  tagListeners: [] as Array<() => void>
+  tagListeners: [] as Array<() => void>,
+  tagUnsubscribes: [] as Array<ReturnType<typeof vi.fn>>
 }))
 
 vi.mock('@/services/notes-service', () => ({
@@ -17,7 +18,9 @@ vi.mock('@/services/notes-service', () => ({
   },
   onTagsChanged: (callback: () => void) => {
     mocks.tagListeners.push(callback)
-    return vi.fn()
+    const unsubscribe = vi.fn()
+    mocks.tagUnsubscribes.push(unsubscribe)
+    return unsubscribe
   }
 }))
 
@@ -46,6 +49,7 @@ describe('useAllTags', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.tagListeners = []
+    mocks.tagUnsubscribes = []
     mocks.notesGetTags.mockResolvedValue([
       { tag: 'Work', count: 4, color: '#111111' },
       { tag: 'work/design', count: 2, color: '#222222' },
@@ -106,6 +110,34 @@ describe('useAllTags', () => {
     })
     expect(mocks.notesGetTags).toHaveBeenCalledTimes(3)
     expect(mocks.inboxGetTags).toHaveBeenCalledTimes(2)
+  })
+
+  it('subscribes to tag events once across re-renders and unsubscribes on unmount', async () => {
+    const { result, rerender, unmount } = renderHook(() => useAllTags(), {
+      wrapper: createWrapper()
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // The sole consumer (tag-autocomplete) re-renders on every keystroke.
+    for (let i = 0; i < 10; i += 1) {
+      rerender()
+    }
+
+    expect(mocks.tagListeners).toHaveLength(1)
+    expect(mocks.tagUnsubscribes.filter((fn) => fn.mock.calls.length > 0)).toHaveLength(0)
+
+    // A tags-changed event arriving after those re-renders must still reach the
+    // consumer (guards against a listener left holding stale render state).
+    // mockResolvedValue (not ...Once) so an unconsumed queue entry can never leak
+    // into the next test in this file.
+    mocks.notesGetTags.mockResolvedValue([{ tag: 'after-rerenders', count: 12 }])
+    await act(async () => {
+      mocks.tagListeners[mocks.tagListeners.length - 1]()
+    })
+    await waitFor(() => expect(result.current.tags[0].name).toBe('after-rerenders'))
+
+    unmount()
+    expect(mocks.tagUnsubscribes.filter((fn) => fn.mock.calls.length > 0)).toHaveLength(1)
   })
 
   it('surfaces query errors while still exposing empty helper results', async () => {

--- a/apps/desktop/src/renderer/src/hooks/use-all-tags.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-all-tags.ts
@@ -78,13 +78,18 @@ export function useAllTags(): UseAllTagsResult {
     staleTime: 60 * 1000 // 1 minute
   })
 
+  // `notesQuery` is a new object on every render, so depending on it re-subscribed
+  // the IPC listener per keystroke in tag-autocomplete. `refetch` is stable and
+  // always refetches the current query, so it cannot go stale.
+  const refetchNotes = notesQuery.refetch
+
   useEffect(() => {
     const unsubscribe = onTagsChanged(() => {
-      void notesQuery.refetch()
+      void refetchNotes()
     })
 
     return unsubscribe
-  }, [notesQuery, notesQuery.refetch])
+  }, [refetchNotes])
 
   // Combine and deduplicate tags from both sources
   const combinedTags = useMemo((): TagWithMeta[] => {


### PR DESCRIPTION
Fixes #1013

## Verification (issue is real on current `main`)

`apps/desktop/src/renderer/src/hooks/use-all-tags.ts:81-87` @ `27bc2b961`:

```ts
useEffect(() => {
  const unsubscribe = onTagsChanged(() => {
    void notesQuery.refetch()
  })
  return unsubscribe
}, [notesQuery, notesQuery.refetch])
```

`notesQuery` is the TanStack v5 `useQuery` result — `useBaseQuery` returns `observer.trackResult(result)`, a fresh proxy object on every render — so the dep array changes every render and the `notes:tags-changed` IPC listener is unsubscribed + re-registered each time.

Sole consumer `components/filing/tag-autocomplete.tsx:82,91` holds `const [inputValue, setInputValue] = useState('')` and calls `useAllTags()`, so it re-renders per keystroke.

Measured with the new test before the fix: 10 re-renders produced **12** subscriptions instead of 1.

## Change

`apps/desktop/src/renderer/src/hooks/use-all-tags.ts` — hoist `notesQuery.refetch` into `refetchNotes` and depend only on it. Two lines plus a comment; nothing else in the hook is touched.

No stale closure: `refetch` is a bound `QueryObserver` method that always refetches the *current* query state, and it is the only value the listener closes over — if its identity ever did change, the dep array re-runs the effect and re-subscribes. Nothing render-scoped (props, state, `notesQuery.data`) is captured.

Tag identity semantics (case-preserving + NOCASE, #689) are untouched.

## Tests

`apps/desktop/src/renderer/src/hooks/use-all-tags.test.tsx` — the mock now tracks the returned unsubscribe fns, and a new case asserts:

1. after 10 re-renders there is exactly **1** listener and **0** unsubscribes fired;
2. a `tags-changed` event arriving **after** those re-renders still refreshes the consumer's tags (no missed/stale delivery);
3. `unmount()` fires exactly one unsubscribe (no leaked listener).

Red → green:

```
# before the fix
FAIL  useAllTags subscribes to tag events once across re-renders and unsubscribes on unmount
  AssertionError: expected [ [Function], [Function], …(10) ] to have a length of 1 but got 12

# after the fix
PASS (4) FAIL (0)
```

Mutation-tested (mocked-IPC tests can lie):
- `return unsubscribe` → `return undefined` ⇒ red (`expected [] to have a length of 1`)
- `void refetchNotes()` → `void 0` ⇒ red (event no longer delivered)

The new case uses `mockResolvedValue`, not `mockResolvedValueOnce`, so an unconsumed queue entry can't leak into later tests in the file.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + ipc:check + node + web)
- `pnpm lint` — **0 errors**, 14 warnings, all pre-existing and none in the touched files
- `pnpm exec vitest run --config config/vitest.config.ts --project renderer src/renderer/src/hooks/use-all-tags.test.tsx src/renderer/src/components/filing/tag-autocomplete.test.tsx` — PASS (9) FAIL (0)
- `npx -y react-doctor@latest .` — no findings in `use-all-tags.ts`; remaining findings are pre-existing repo-wide
