### PR TITLE
fix(capture-bar): stop rebinding the q listener per keystroke and pick one owner in split view

### DIFF
--- a/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.test.tsx
@@ -248,6 +248,103 @@ describe('CaptureBar — focus', () => {
 })
 
 // ============================================================================
+// The global `q` binding — one stable listener, one owner
+// ============================================================================
+
+describe('CaptureBar — global q binding', () => {
+  const countKeydown = (calls: readonly unknown[][]): number =>
+    calls.filter((call) => String(call[0]) === 'keydown').length
+
+  it('binds the window listener once instead of rebinding on every keystroke', async () => {
+    const user = userEvent.setup()
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+
+    try {
+      renderBar(<CaptureBar {...baseProps} onSubmit={vi.fn()} />)
+      expect(countKeydown(addSpy.mock.calls)).toBe(1)
+
+      await user.type(field(), 'Buy milk')
+
+      expect(countKeydown(addSpy.mock.calls)).toBe(1)
+      expect(countKeydown(removeSpy.mock.calls)).toBe(0)
+    } finally {
+      addSpy.mockRestore()
+      removeSpy.mockRestore()
+    }
+  })
+
+  it('removes the window listener on unmount', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+
+    try {
+      const { unmount } = renderBar(<CaptureBar {...baseProps} onSubmit={vi.fn()} />)
+      unmount()
+
+      expect(countKeydown(addSpy.mock.calls)).toBe(1)
+      expect(countKeydown(removeSpy.mock.calls)).toBe(1)
+    } finally {
+      addSpy.mockRestore()
+      removeSpy.mockRestore()
+    }
+  })
+
+  it('lets only the active pane act on q when split view mounts two bars', async () => {
+    const user = userEvent.setup()
+    renderBar(
+      <>
+        <div data-pane-active="true">
+          <CaptureBar {...baseProps} ariaLabel="Active pane capture" onSubmit={vi.fn()} />
+        </div>
+        <div data-pane-active="false">
+          <CaptureBar {...baseProps} ariaLabel="Idle pane capture" onSubmit={vi.fn()} />
+        </div>
+      </>
+    )
+
+    const activeField = screen.getByRole('textbox', { name: 'Active pane capture' })
+    const idleField = screen.getByRole('textbox', { name: 'Idle pane capture' })
+    const activeFocus = vi.spyOn(activeField, 'focus')
+    const idleFocus = vi.spyOn(idleField, 'focus')
+
+    await user.keyboard('q')
+
+    // One keypress, one action — and it lands in the pane the user is in.
+    expect(activeFocus).toHaveBeenCalledTimes(1)
+    expect(idleFocus).not.toHaveBeenCalled()
+    expect(activeField).toHaveFocus()
+  })
+
+  it('hands the shortcut to the survivor when a pane unmounts', async () => {
+    const user = userEvent.setup()
+    const Panes = ({ withActivePane }: { withActivePane: boolean }): ReactElement => (
+      <>
+        {withActivePane && (
+          <div data-pane-active="true">
+            <CaptureBar {...baseProps} ariaLabel="Active pane capture" onSubmit={vi.fn()} />
+          </div>
+        )}
+        <div data-pane-active="false">
+          <CaptureBar {...baseProps} ariaLabel="Idle pane capture" onSubmit={vi.fn()} />
+        </div>
+      </>
+    )
+
+    const { rerender } = renderBar(<Panes withActivePane />)
+    rerender(<Panes withActivePane={false} />)
+
+    const survivor = screen.getByRole('textbox', { name: 'Idle pane capture' })
+    const survivorFocus = vi.spyOn(survivor, 'focus')
+
+    await user.keyboard('q')
+
+    expect(survivorFocus).toHaveBeenCalledTimes(1)
+    expect(survivor).toHaveFocus()
+  })
+})
+
+// ============================================================================
 // Capability matrix — an affordance renders only when its prop is passed
 // ============================================================================
 

--- a/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/capture-bar/capture-bar.tsx
@@ -27,6 +27,7 @@ import {
   lastToken,
   replaceLastToken
 } from './capture-bar-tokens'
+import { ownsFocusShortcut, registerCaptureField } from './focus-shortcut-owner'
 import type { Priority } from '@/data/task-model'
 import type { Project } from '@/data/tasks-data'
 
@@ -146,13 +147,27 @@ export const CaptureBar = ({
   const disabled = isBusy
   const trimmed = value.trim()
 
-  useKeyboardShortcuts([
-    {
-      key: 'q',
-      action: () => fieldRef.current?.focus(),
-      description: t('capture.focusShortcut')
-    }
-  ])
+  // Registered for the lifetime of the bar, so `ownsFocusShortcut` can pick a
+  // single winner when split view has more than one bar mounted.
+  useEffect(() => registerCaptureField(() => fieldRef.current), [])
+
+  // Memoized: an inline array would hand `useKeyboardShortcuts` a new value on
+  // every render, tearing the window listener down and re-adding it on every
+  // keystroke. Both callbacks read `fieldRef` at keypress time rather than
+  // closing over state, so a stable array cannot go stale.
+  const focusShortcuts = useMemo(
+    () => [
+      {
+        key: 'q',
+        when: () => ownsFocusShortcut(fieldRef.current),
+        action: () => fieldRef.current?.focus(),
+        description: t('capture.focusShortcut')
+      }
+    ],
+    [t]
+  )
+
+  useKeyboardShortcuts(focusShortcuts)
 
   // Focus on demand (sidebar clicks, empty-state buttons). The signal changes
   // each time, so this re-fires even when the surface is already open.

--- a/apps/desktop/src/renderer/src/components/capture-bar/focus-shortcut-owner.test.ts
+++ b/apps/desktop/src/renderer/src/components/capture-bar/focus-shortcut-owner.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Ownership of the global `q` focus shortcut.
+ *
+ * Split view mounts one CaptureBar per pane, so the rule that picks a single
+ * winner — and the unregistration that keeps unmounted bars out of the running
+ * — are what stop one keypress from firing two handlers.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { ownsFocusShortcut, registerCaptureField } from './focus-shortcut-owner'
+
+const cleanups: Array<() => void> = []
+
+const mount = (field: HTMLElement): void => {
+  cleanups.push(registerCaptureField(() => (field.isConnected ? field : null)))
+}
+
+const paneWithField = (isActive: boolean): HTMLElement => {
+  const pane = document.createElement('div')
+  pane.setAttribute('data-pane-active', String(isActive))
+  const field = document.createElement('textarea')
+  pane.appendChild(field)
+  document.body.appendChild(pane)
+  return field
+}
+
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()?.()
+  document.body.innerHTML = ''
+})
+
+describe('ownsFocusShortcut', () => {
+  it('gives the shortcut to the most recent bar when no pane is marked active', () => {
+    const first = document.createElement('textarea')
+    const second = document.createElement('textarea')
+    document.body.append(first, second)
+    mount(first)
+    mount(second)
+
+    expect(ownsFocusShortcut(second)).toBe(true)
+    expect(ownsFocusShortcut(first)).toBe(false)
+  })
+
+  it('gives the shortcut to the active pane regardless of mount order', () => {
+    const active = paneWithField(true)
+    const idle = paneWithField(false)
+    mount(active)
+    mount(idle)
+
+    expect(ownsFocusShortcut(active)).toBe(true)
+    expect(ownsFocusShortcut(idle)).toBe(false)
+  })
+
+  it('drops a bar from the running once it unregisters', () => {
+    const first = document.createElement('textarea')
+    const second = document.createElement('textarea')
+    document.body.append(first, second)
+    mount(first)
+    const unregisterSecond = registerCaptureField(() => second)
+
+    expect(ownsFocusShortcut(first)).toBe(false)
+
+    unregisterSecond()
+
+    expect(ownsFocusShortcut(first)).toBe(true)
+  })
+
+  it('never hands the shortcut to a bar with no field', () => {
+    expect(ownsFocusShortcut(null)).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/capture-bar/focus-shortcut-owner.ts
+++ b/apps/desktop/src/renderer/src/components/capture-bar/focus-shortcut-owner.ts
@@ -1,0 +1,48 @@
+/**
+ * Decides which mounted CaptureBar owns the global `q` focus shortcut.
+ *
+ * Split view can show two capture surfaces at once (Inbox beside Tasks), and
+ * every mounted bar binds `q` on `window`. Without an owner a single keypress
+ * ran every handler and whichever focused last won, so the caret landed in a
+ * non-deterministic pane. Each bar registers its field here instead; on a
+ * keypress exactly one is the owner — the bar inside the pane the split view
+ * marks active, or, when nothing marks a pane active (single-surface renders),
+ * the most recently mounted bar.
+ *
+ * Fields are read through a getter at keypress time, never captured at render
+ * time, so the decision always reflects the live DOM.
+ */
+
+/** Set by `tab-pane-with-drop-zones` on the pane the split view considers focused. */
+const ACTIVE_PANE_SELECTOR = '[data-pane-active="true"]'
+
+type FieldGetter = () => HTMLElement | null
+
+/** Mount order; the last entry is the most recently mounted bar. */
+const mountedFields: FieldGetter[] = []
+
+/**
+ * Register a capture field for the lifetime of a bar. Returns the unregister
+ * function, so the caller can use it directly as an effect cleanup.
+ */
+export const registerCaptureField = (getField: FieldGetter): (() => void) => {
+  mountedFields.push(getField)
+  return () => {
+    const index = mountedFields.indexOf(getField)
+    if (index !== -1) mountedFields.splice(index, 1)
+  }
+}
+
+/** Whether `field` is the single bar allowed to act on the `q` shortcut right now. */
+export const ownsFocusShortcut = (field: HTMLElement | null): boolean => {
+  if (!field) return false
+
+  const fields = mountedFields
+    .map((getField) => getField())
+    .filter((element): element is HTMLElement => element !== null)
+
+  const owner =
+    fields.find((element) => element.closest(ACTIVE_PANE_SELECTOR)) ?? fields[fields.length - 1]
+
+  return owner === field
+}


### PR DESCRIPTION
Fixes #1014

## Verification — the issue is still real on `main`

Both defects reproduce on `origin/main` @ `27bc2b961`.

**(a) Listener churn.** `apps/desktop/src/renderer/src/components/capture-bar/capture-bar.tsx:149-155` passed an inline array literal to `useKeyboardShortcuts`, and `apps/desktop/src/renderer/src/hooks/use-keyboard-shortcuts-base.ts:85` "memoizes" it with `useMemo(() => shortcuts, [shortcuts])` — a no-op, because the dep *is* the fresh array. So `handleKeyDown` (`:87`) is a new function every render and the `window` keydown effect (`:148-151`) re-runs each time. Every keystroke changes `value`, so every keystroke re-renders and rebinds.

Measured: typing `Buy milk` (8 chars) produced **10** `window.addEventListener('keydown', …)` calls for a single mounted bar (1 mount + focus + 8 keystrokes).

**(b) Duplicate `q` in split view.** `CaptureBar` mounts from Inbox, Tasks and the Project hub; `split-view/tab-content.tsx` can have two of those panes live at once, so two `window` listeners both matched `q`, both called `preventDefault`, and both called `focus()`. The last one to run won, which is registration order — not the pane the user is in.

Measured: with two bars mounted and the *first* one inside the active pane, one `q` keypress focused **both** fields; the idle pane won.

## Change

- `capture-bar.tsx` — the shortcut array is now `useMemo`'d (deps `[t]`), so `useKeyboardShortcuts` gets a stable value and binds once per mount. The bar also registers its field on mount and gates the shortcut with `when`.
- `focus-shortcut-owner.ts` (new, 45 lines) — a module-level registry of mounted capture fields plus `ownsFocusShortcut(field)`. On a keypress, exactly one bar is the owner: the one whose field is inside `[data-pane-active="true"]` (set by `split-view/tab-pane-with-drop-zones.tsx:164`), else the most recently mounted bar. `registerCaptureField` returns its own unregister function, used directly as the effect cleanup.

### No stale closure

The memoized array does not close over any state. `when` and `action` both read `fieldRef.current` — a ref — at *keypress* time, and `ownsFocusShortcut` re-reads the live DOM on every call. Nothing from the first render's state is captured, so a stable array cannot act on stale data. The only dep is `t`, which react-i18next keeps stable across renders (proven by the zero-rebind assertion below).

### How "which pane wins" is decided

The split view already stamps `data-pane-active={isActive}` on each pane, driven by `state.activeGroupId`. The owner is the bar whose field `.closest('[data-pane-active="true"]')` resolves — i.e. the pane the user last focused. Exactly one pane carries that attribute, so the choice is deterministic. When no pane is marked active (a bar rendered outside the split view, or in a unit test), the most recently mounted bar wins — also deterministic, and it keeps the existing single-surface behaviour.

No new dependency. `useKeyboardShortcuts` and every other call site are untouched (#1074 owns the shared hook).

## Tests

`capture-bar.test.tsx` (4 new) and `focus-shortcut-owner.test.ts` (new, 4).

Red on `main`:

```
1. CaptureBar — global q binding binds the window listener once instead of rebinding on every keystroke
   AssertionError: expected 10 to be 1

2. CaptureBar — global q binding lets only the active pane act on q when split view mounts two bars
   AssertionError: expected "patchedFocus" to not be called at all, but actually been called 1 times
```

Green after the fix: `PASS (44) FAIL (0)` for the capture-bar directory.

Coverage of the correctness bar:
- one keypress → exactly one action (`expect(activeFocus).toHaveBeenCalledTimes(1)` + `expect(idleFocus).not.toHaveBeenCalled()`);
- the *right* bar acts — the active pane is deliberately the **first** mounted, so the old "last registration wins" answer is the wrong one;
- the shortcut still works after a pane unmounts, and the survivor takes over;
- `addEventListener('keydown')` and `removeEventListener('keydown')` counts match after unmount — no listener survives;
- unregistration is asserted directly, so the registry cannot grow across mount/unmount cycles.

Mutation-tested (each reverted after):

| mutation | result |
| --- | --- |
| memo deps `[t]` → `[t, value]` | red — `expected 9 to be 1` |
| drop the `when` ownership guard | red — idle pane focused too |
| make `registerCaptureField`'s cleanup a no-op | red — `expected false to be true` |

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + IPC map + node/web tsc).
- `pnpm lint` — 0 errors, 14 warnings, all pre-existing and none in `capture-bar/`. `npx eslint --no-cache --max-warnings=0 apps/desktop/src/renderer/src/components/capture-bar/` is clean.
- Renderer tests — `capture-bar/`, `capture-input.test.tsx`, `pages/tasks.test.tsx`, `project-capture-input.test.tsx`, `pages/inbox*`: `PASS (95) FAIL (0)`; `pages/inbox.test.tsx` + `components/split-view/`: `PASS (41) FAIL (0)`.
- `npx react-doctor@latest .` — no findings in `capture-bar/` (run twice).
