### PR TITLE
fix(graph): end node drags that never deliver a mouseup

### DIFF
--- a/apps/desktop/src/renderer/src/components/graph/graph-events.test.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-events.test.tsx
@@ -1,15 +1,22 @@
+import { useRef, type ReactElement } from 'react'
 import { render } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Graph from 'graphology'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { GraphEvents } from './graph-events'
+import { LivePhysics, type PhysicsHandle } from './physics-layout'
 
 const mocks = vi.hoisted(() => ({
   events: {} as Record<string, (payload?: any) => void>,
   openTab: vi.fn(),
   viewportToGraph: vi.fn(),
+  refresh: vi.fn(),
   graph: {
     hasNode: vi.fn(),
     getNodeAttributes: vi.fn()
-  }
+  },
+  // Set by the physics tests so `useSigma().getGraph()` hands back the real
+  // graphology instance LivePhysics compares against.
+  liveGraph: null as Graph | null
 }))
 
 vi.mock('@react-sigma/core', () => ({
@@ -17,8 +24,9 @@ vi.mock('@react-sigma/core', () => ({
     mocks.events = events
   },
   useSigma: () => ({
-    getGraph: () => mocks.graph,
-    viewportToGraph: mocks.viewportToGraph
+    getGraph: () => mocks.liveGraph ?? mocks.graph,
+    viewportToGraph: mocks.viewportToGraph,
+    refresh: mocks.refresh
   })
 }))
 
@@ -30,10 +38,30 @@ vi.mock('@memry/i18n/renderer', () => ({
   useT: () => ({ t: (key: string) => (key === 'context-menu.untitled' ? 'Untitled' : key) })
 }))
 
+/** GraphEvents wired to a real simulation, the way graph-canvas wires them. */
+function DragHarness({ graph }: { graph: Graph }): ReactElement {
+  const handleRef = useRef<PhysicsHandle | null>(null)
+  return (
+    <>
+      <LivePhysics graph={graph} handleRef={handleRef} />
+      <GraphEvents
+        onHoverNode={vi.fn()}
+        onTooltipMove={vi.fn()}
+        onFocusNode={vi.fn()}
+        onContextMenu={vi.fn()}
+        onNodeGrab={(nodeId) => handleRef.current?.grab(nodeId)}
+        onNodeDrag={(nodeId, x, y) => handleRef.current?.drag(nodeId, x, y)}
+        onNodeRelease={(nodeId) => handleRef.current?.release(nodeId)}
+      />
+    </>
+  )
+}
+
 describe('GraphEvents', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.events = {}
+    mocks.liveGraph = null
     document.body.style.cursor = ''
   })
 
@@ -190,6 +218,113 @@ describe('GraphEvents', () => {
       expect(onNodeRelease).toHaveBeenCalledWith('note-1')
     })
 
+    it('releases the node when the pointer comes up outside the window', () => {
+      const { onNodeDrag, onNodeRelease } = renderWithDrag()
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+      // Sigma binds mouseup on `document`; a release the window never sees only
+      // reaches us as a window-level pointerup.
+      window.dispatchEvent(new Event('pointerup'))
+
+      expect(onNodeRelease).toHaveBeenCalledWith('note-1')
+      expect(document.body.style.cursor).toBe('pointer')
+
+      // The drag is over: a later pointer move must not keep hauling the node.
+      mocks.events.mousemovebody({ x: 200, y: 200, preventSigmaDefault: vi.fn() })
+      expect(onNodeDrag).not.toHaveBeenCalled()
+    })
+
+    it('releases the node when the window loses focus mid-drag', () => {
+      const { onNodeRelease } = renderWithDrag()
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+      window.dispatchEvent(new Event('blur'))
+
+      expect(onNodeRelease).toHaveBeenCalledWith('note-1')
+    })
+
+    it('releases the node when another element swallows the pointerup', () => {
+      const { onNodeRelease } = renderWithDrag()
+      const overlay = document.createElement('div')
+      document.body.appendChild(overlay)
+      overlay.addEventListener('pointerup', (event) => event.stopPropagation())
+
+      try {
+        mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+        overlay.dispatchEvent(new Event('pointerup', { bubbles: true }))
+
+        expect(onNodeRelease).toHaveBeenCalledWith('note-1')
+      } finally {
+        overlay.remove()
+      }
+    })
+
+    it('releases the node when the browser cancels the pointer', () => {
+      const { onNodeRelease } = renderWithDrag()
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+      window.dispatchEvent(new Event('pointercancel'))
+
+      expect(onNodeRelease).toHaveBeenCalledWith('note-1')
+    })
+
+    it('releases only once when both pointerup and mouseup arrive', () => {
+      const { onNodeRelease } = renderWithDrag()
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+      window.dispatchEvent(new Event('pointerup'))
+      mocks.events.mouseup()
+
+      expect(onNodeRelease).toHaveBeenCalledTimes(1)
+    })
+
+    it('still suppresses the click that follows an interrupted drag', () => {
+      renderWithDrag()
+      mocks.viewportToGraph.mockReturnValue({ x: 200, y: 200 })
+      mocks.graph.hasNode.mockReturnValue(true)
+      mocks.graph.getNodeAttributes.mockReturnValue({
+        nodeType: 'note',
+        label: 'Roadmap',
+        isUnresolved: false
+      })
+
+      mocks.events.downNode({ node: 'note-1', event: { x: 5, y: 5 } })
+      mocks.events.mousemovebody({ x: 90, y: 90, preventSigmaDefault: vi.fn() })
+      window.dispatchEvent(new Event('pointerup'))
+      mocks.events.mouseup()
+      mocks.events.clickNode({ node: 'note-1' })
+
+      expect(mocks.openTab).not.toHaveBeenCalled()
+    })
+
+    it('removes its window listeners on unmount', () => {
+      const addSpy = vi.spyOn(window, 'addEventListener')
+      const removeSpy = vi.spyOn(window, 'removeEventListener')
+
+      const { unmount } = render(
+        <GraphEvents
+          onHoverNode={vi.fn()}
+          onTooltipMove={vi.fn()}
+          onFocusNode={vi.fn()}
+          onContextMenu={vi.fn()}
+          onNodeGrab={vi.fn()}
+          onNodeDrag={vi.fn()}
+          onNodeRelease={vi.fn()}
+        />
+      )
+
+      const added = addSpy.mock.calls.filter(([type]) =>
+        ['pointerup', 'pointercancel', 'blur'].includes(type)
+      )
+      expect(added.length).toBeGreaterThan(0)
+
+      unmount()
+
+      for (const [type, handler, options] of added) {
+        expect(removeSpy).toHaveBeenCalledWith(type, handler, options)
+      }
+    })
+
     it('does not open a tab when the pointer actually dragged the node', () => {
       renderWithDrag()
       mocks.viewportToGraph.mockReturnValue({ x: 200, y: 200 })
@@ -240,6 +375,112 @@ describe('GraphEvents', () => {
       mocks.events.clickNode({ node: 'note-1' })
 
       expect(mocks.openTab).toHaveBeenCalledWith(expect.objectContaining({ entityId: 'note-1' }))
+    })
+  })
+
+  describe('live physics frame loop', () => {
+    let pending: Map<number, FrameRequestCallback>
+    let raf: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      pending = new Map()
+      let nextFrameId = 1
+      raf = vi.fn((callback: FrameRequestCallback) => {
+        const id = nextFrameId++
+        pending.set(id, callback)
+        return id
+      })
+      vi.stubGlobal('requestAnimationFrame', raf)
+      vi.stubGlobal('cancelAnimationFrame', (id: number) => pending.delete(id))
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    /** Run queued frames until the loop parks. `true` means it stopped on its own. */
+    function drainFrames(limit: number): boolean {
+      for (let i = 0; i < limit; i++) {
+        if (pending.size === 0) return true
+        const due = [...pending.values()]
+        pending.clear()
+        for (const callback of due) callback(i)
+      }
+      return pending.size === 0
+    }
+
+    function stepFrames(count: number): void {
+      for (let i = 0; i < count; i++) {
+        const due = [...pending.values()]
+        pending.clear()
+        for (const callback of due) callback(i)
+      }
+    }
+
+    function renderLiveGraph(): Graph {
+      const graph = new Graph({ type: 'undirected' })
+      graph.addNode('a', { x: 0, y: 0, size: 5 })
+      graph.addNode('b', { x: 40, y: 0, size: 5 })
+      graph.addNode('c', { x: 0, y: 40, size: 5 })
+      graph.addEdgeWithKey('e0', 'a', 'b', { weight: 1 })
+      mocks.liveGraph = graph
+      render(<DragHarness graph={graph} />)
+      return graph
+    }
+
+    function startDrag(nodeId: string, x: number, y: number): void {
+      mocks.viewportToGraph.mockReturnValue({ x, y })
+      mocks.events.downNode({ node: nodeId, event: { x: 5, y: 5 } })
+      mocks.events.mousemovebody({ x: 90, y: 90, preventSigmaDefault: vi.fn() })
+    }
+
+    it('parks the frame loop when the pointer is released outside the window', () => {
+      renderLiveGraph()
+      expect(drainFrames(2000)).toBe(true)
+
+      startDrag('a', 300, 300)
+      // Held: the simulation is deliberately kept warm while a node is dragged.
+      expect(drainFrames(600)).toBe(false)
+
+      window.dispatchEvent(new Event('pointerup'))
+
+      expect(drainFrames(2000)).toBe(true)
+      const scheduled = raf.mock.calls.length
+      stepFrames(10)
+      expect(raf.mock.calls.length).toBe(scheduled)
+      expect(pending.size).toBe(0)
+    })
+
+    it('parks the frame loop when the window loses focus mid-drag', () => {
+      renderLiveGraph()
+      expect(drainFrames(2000)).toBe(true)
+
+      startDrag('a', 300, 300)
+      expect(drainFrames(600)).toBe(false)
+
+      window.dispatchEvent(new Event('blur'))
+
+      expect(drainFrames(2000)).toBe(true)
+    })
+
+    it('keeps dragging normally after a drag that ended outside the window', () => {
+      const graph = renderLiveGraph()
+      expect(drainFrames(2000)).toBe(true)
+
+      startDrag('a', 300, 300)
+      window.dispatchEvent(new Event('pointerup'))
+      expect(drainFrames(2000)).toBe(true)
+
+      startDrag('b', -150, 220)
+      stepFrames(3)
+      expect(graph.getNodeAttribute('b', 'x')).toBe(-150)
+      expect(graph.getNodeAttribute('b', 'y')).toBe(220)
+      expect(drainFrames(600)).toBe(false)
+
+      mocks.events.mouseup()
+
+      expect(drainFrames(2000)).toBe(true)
+      expect(graph.getNodeAttribute('b', 'x')).not.toBe(-150)
     })
   })
 })

--- a/apps/desktop/src/renderer/src/components/graph/graph-events.tsx
+++ b/apps/desktop/src/renderer/src/components/graph/graph-events.tsx
@@ -40,6 +40,15 @@ export function GraphEvents({
   const suppressClickRef = useRef(false)
 
   useEffect(() => {
+    const endDrag = (): void => {
+      const drag = dragRef.current
+      if (!drag) return
+      dragRef.current = null
+      suppressClickRef.current = drag.moved
+      document.body.style.cursor = 'pointer'
+      onNodeRelease?.(drag.nodeId)
+    }
+
     registerEvents({
       enterNode: ({ node, event }) => {
         onHoverNode(node)
@@ -71,14 +80,7 @@ export function GraphEvents({
         // Without this sigma pans the camera while we are moving a node.
         event.preventSigmaDefault()
       },
-      mouseup: () => {
-        const drag = dragRef.current
-        if (!drag) return
-        dragRef.current = null
-        suppressClickRef.current = drag.moved
-        document.body.style.cursor = 'pointer'
-        onNodeRelease?.(drag.nodeId)
-      },
+      mouseup: endDrag,
       clickNode: ({ node }) => {
         onContextMenu?.(null)
         if (suppressClickRef.current) {
@@ -95,6 +97,23 @@ export function GraphEvents({
         onContextMenu?.(null)
       }
     })
+
+    // Sigma only learns a drag is over from its own mouseup. A pointer released
+    // past the window edge, focus lost mid-drag, or a pointer the browser hands
+    // elsewhere never delivers one — the node would stay pinned and the physics
+    // simulation held at its drag alpha, so the frame loop would never park.
+    // Capture phase, so nothing in between can swallow the release.
+    window.addEventListener('pointerup', endDrag, true)
+    window.addEventListener('pointercancel', endDrag, true)
+    // Bubble phase: `blur` does not bubble, but capturing it here would end the
+    // drag every time any field in the app loses focus.
+    window.addEventListener('blur', endDrag, false)
+
+    return () => {
+      window.removeEventListener('pointerup', endDrag, true)
+      window.removeEventListener('pointercancel', endDrag, true)
+      window.removeEventListener('blur', endDrag, false)
+    }
   }, [
     sigma,
     registerEvents,


### PR DESCRIPTION
Fixes #1016

## Verification — the issue was still real on `origin/main`

- `apps/desktop/src/renderer/src/lib/graph-physics.ts:157` — `grab()` sets `this.alphaTarget = DRAG_ALPHA_TARGET` (0.3).
- `graph-physics.ts:169-175` — `release()` is the only thing that puts `alphaTarget` back to 0.
- `graph-physics.ts:135` — `tick()` decays `alphaValue` *toward* `alphaTarget`, so with a held node alpha converges to 0.3.
- `graph-physics.ts:126-129` — `isSettled` is `alphaValue < 0.001`, so it can never become true at alpha 0.3.
- `physics-layout.tsx:40` — `frame = physics.isSettled ? null : requestAnimationFrame(step)` → the rAF loop (full physics + `sigma.refresh()`) runs forever.
- `graph-events.tsx:74-81` (pre-fix) — Sigma's `mouseup` was the only caller of `release()`. Sigma binds that on `document` (`sigma@3.0.3` `MouseCaptor`), so any release the page never sees leaves the drag open permanently.

## Change

`apps/desktop/src/renderer/src/components/graph/graph-events.tsx` only:

- Lifted the existing `mouseup` body into a single idempotent `endDrag()` (`mouseup: endDrag` — same code, no behavior change on the happy path).
- Registered window-level fallbacks that run the same path:
  - `pointerup` **capture phase** — the release that arrives when the pointer was let go outside the window, and the one an intermediate element would otherwise swallow with `stopPropagation()`.
  - `pointercancel` **capture phase** — the browser taking the pointer away mid-drag.
  - `blur` **bubble phase** — window loses focus mid-drag. Deliberately *not* capture, because `blur` does not bubble and capturing at `window` would fire for every field blur in the app.
- All three are removed in the effect cleanup, so nothing survives unmount.

`endDrag()` also sets `suppressClickRef`, so when both `pointerup` and Sigma's `mouseup` arrive (the normal in-window case) the second is a no-op and post-drag click suppression is unchanged.

No new dependency; the physics simulation stays dependency-free. Nothing in the graph mount/teardown path was touched.

## Coverage of the ways a drag can end without a mouseup

| Scenario | Covered by | Test |
| --- | --- | --- |
| Pointer released outside the window | window `pointerup` (capture) | yes |
| Window loses focus mid-drag | window `blur` | yes |
| Another element captures/swallows the release | window `pointerup` in **capture** phase | yes — dispatched on a child that calls `stopPropagation()` |
| Browser cancels the pointer | window `pointercancel` (capture) | yes |

Not reproducible in jsdom: a genuine OS-level release outside the Electron window (jsdom has no window manager), so it is modelled as "the release only ever reaches `window`, never Sigma's `document` mouseup" — which is exactly the delivery gap.

## Tests — `apps/desktop/src/renderer/src/components/graph/graph-events.test.tsx`

Nine new tests. The important ones mount `LivePhysics` + `GraphEvents` together against a **real** `GraphPhysics` and a **real** graphology graph, with `requestAnimationFrame` / `cancelAnimationFrame` stubbed by a controllable queue, and assert the loop actually **stops** — the frame queue drains to empty and no further frames are requested — not merely that a handler ran:

- `parks the frame loop when the pointer is released outside the window` — drains the initial layout, starts a drag, asserts the loop provably cannot park while held (`drainFrames(600) === false`), dispatches `pointerup` on `window`, then asserts the queue drains and `requestAnimationFrame` is not called again.
- `parks the frame loop when the window loses focus mid-drag`.
- `keeps dragging normally after a drag that ended outside the window` — a second drag still pins the node exactly at the drag position, still holds the simulation warm, and still releases and parks on a normal `mouseup`.
- Plus handler-level tests for pointer-outside / blur / swallowed pointerup / pointercancel, "a later mousemove no longer hauls the node", click suppression after an interrupted drag, single release when both events arrive, and listener removal on unmount.

**Red → green**

Before the fix (7 of 19 failing):

```
× releases the node when the pointer comes up outside the window
    AssertionError: expected "vi.fn()" to be called with arguments: [ 'note-1' ]  Number of calls: 0
× releases the node when the window loses focus mid-drag
× releases the node when another element swallows the pointerup
× removes its window listeners on unmount
    AssertionError: expected 0 to be greater than 0
× parks the frame loop when the pointer is released outside the window
    AssertionError: expected false to be true   (graph-events.test.tsx:438 — frame queue never drained in 2000 frames)
× parks the frame loop when the window loses focus mid-drag
× keeps dragging normally after a drag that ended outside the window
```

After the fix: `PASS (19) FAIL (0)`.

**Mutation-tested** (each mutation applied alone, then reverted):

| Mutation | Result |
| --- | --- |
| `pointerup` capture `true` → `false` | 2 failed |
| drop the `blur` listener | 2 failed |
| drop the `pointerup` listener | 4 failed |
| drop the `pointercancel` listener | 1 failed |
| drop the `removeEventListener` cleanup | 1 failed |

Every line of the fix is load-bearing.

## Checks

- `pnpm --filter @memry/desktop typecheck` — pass (contracts + architecture + IPC map + node + web all clean).
- `pnpm lint` — 0 errors, 12 warnings, all pre-existing in files this PR does not touch (`tags-hub/*`, `use-folder-view.ts`, `use-tab-keyboard-shortcuts.ts`). `eslint --no-cache` on `graph-events.tsx` is clean.
- `npx react-doctor@latest .` — no findings for `graph-events.tsx`.
- Graph suites: `graph-events.test.tsx`, `graph-canvas.test.tsx`, `local-graph-panel.test.tsx`, `graph-physics.test.ts` → `PASS (46) FAIL (0)`.
- Docs gate: pushed with `MEMRY_DOCS_IMPACT_SKIP=1`. This restores the already-documented behavior of node dragging; no user-facing surface, setting, or flow changes, and there is no docs page describing the graph physics loop.
