### PR TITLE
fix(tabs): scope useTabActions to a stable actions context

### DIFF
--- a/apps/desktop/src/renderer/src/contexts/tabs/context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.test.tsx
@@ -317,3 +317,105 @@ describe('tab selector hooks', () => {
     )
   })
 })
+
+describe('tab context render scoping', () => {
+  const STATE_UPDATES = 200
+
+  function renderScopingHarness() {
+    const alpha = makeTab({ id: 'alpha', title: 'Alpha', entityId: 'alpha' })
+    const beta = makeTab({ id: 'beta', title: 'Beta', entityId: 'beta' })
+    const initialState = makeState([makeGroup('main', [alpha, beta], 'alpha')])
+
+    const renders = { actions: 0, tabState: 0 }
+    let capturedActions: ReturnType<typeof useTabActions> | null = null
+    let capturedContext: ReturnType<typeof useTabs> | null = null
+    let seenTitle = ''
+
+    // Only ever reads actions: must not re-render when tab state changes.
+    const ActionsProbe = (): null => {
+      renders.actions += 1
+      capturedActions = useTabActions()
+      return null
+    }
+
+    // Reads tab state: must keep re-rendering when tab state changes.
+    const StateProbe = (): null => {
+      renders.tabState += 1
+      seenTitle = useTabs().state.tabGroups.main.tabs.find((t) => t.id === 'alpha')?.title ?? ''
+      return null
+    }
+
+    // Drives the state changes from outside the two probes above.
+    const Driver = (): null => {
+      capturedContext = useTabs()
+      return null
+    }
+
+    const view = render(
+      <TabProvider initialState={initialState}>
+        <ActionsProbe />
+        <StateProbe />
+        <Driver />
+      </TabProvider>
+    )
+
+    return {
+      ...view,
+      renders,
+      get actions() {
+        if (!capturedActions) throw new Error('missing tab actions')
+        return capturedActions
+      },
+      get ctx() {
+        if (!capturedContext) throw new Error('missing tab context')
+        return capturedContext
+      },
+      get seenTitle() {
+        return seenTitle
+      },
+      tab(id: string) {
+        if (!capturedContext) throw new Error('missing tab context')
+        return capturedContext.state.tabGroups.main.tabs.find((t) => t.id === id)
+      }
+    }
+  }
+
+  it('keeps useTabActions consumers out of tab state re-renders', () => {
+    const harness = renderScopingHarness()
+
+    expect(harness.renders.actions).toBe(1)
+    expect(harness.renders.tabState).toBe(1)
+
+    for (let i = 0; i < STATE_UPDATES; i++) {
+      act(() => {
+        harness.ctx.updateTabTitle('alpha', `Alpha ${i}`)
+      })
+    }
+
+    // State consumers must still see every change.
+    expect(harness.seenTitle).toBe(`Alpha ${STATE_UPDATES - 1}`)
+    expect(harness.renders.tabState).toBe(1 + STATE_UPDATES)
+
+    // Action-only consumers must render exactly once.
+    expect(harness.renders.actions).toBe(1)
+  })
+
+  it('runs actions against current tab state from a consumer that never re-rendered', () => {
+    const harness = renderScopingHarness()
+    const actions = harness.actions
+
+    act(() => {
+      harness.ctx.pinTab('alpha')
+    })
+    expect(harness.tab('alpha')?.isPinned).toBe(true)
+
+    // togglePinTab must read the committed state, not the render that captured it.
+    act(() => {
+      actions.togglePinTab('alpha')
+    })
+    expect(harness.tab('alpha')?.isPinned).toBe(false)
+
+    // ...and it did all of that without the action consumer re-rendering once.
+    expect(harness.renders.actions).toBe(1)
+  })
+})

--- a/apps/desktop/src/renderer/src/contexts/tabs/context.test.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.test.tsx
@@ -1,6 +1,7 @@
-import { act, render, renderHook, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TabCloseGuard } from './close-guard'
 import {
   TabProvider,
   useActiveGroup,
@@ -110,6 +111,21 @@ describe('TabProvider context', () => {
 
     expect(result.current).toBeInstanceOf(Error)
     expect((result.current as Error).message).toBe('useTabs must be used within a TabProvider')
+  })
+
+  it('throws when useTabActions is used outside a provider', () => {
+    const { result } = renderHook(() => {
+      try {
+        return useTabActions()
+      } catch (error) {
+        return error
+      }
+    })
+
+    expect(result.current).toBeInstanceOf(Error)
+    expect((result.current as Error).message).toBe(
+      'useTabActions must be used within a TabProvider'
+    )
   })
 
   it('merges initial settings, handles settings events, and unsubscribes', async () => {
@@ -315,6 +331,80 @@ describe('tab selector hooks', () => {
     expect(renderHook(() => useTabActions(), { wrapper }).result.current.dispatch).toBeTypeOf(
       'function'
     )
+  })
+})
+
+describe('TabProvider unsaved-changes prompt', () => {
+  // The registry itself is covered in close-guard.test.tsx; these cover the
+  // provider's wiring of it into the dialog — the prompt's title, and each
+  // button actually resolving the close it was raised for.
+  function promptForDirtyTab(guard: TabCloseGuard) {
+    const alpha = makeTab({ id: 'alpha', title: 'Alpha', entityId: 'alpha' })
+    const beta = makeTab({ id: 'beta', title: 'Beta', entityId: 'beta' })
+    const rendered = captureContext(makeState([makeGroup('main', [alpha, beta], 'alpha')]))
+
+    act(() => {
+      rendered.ctx.registerCloseGuard('alpha', guard)
+    })
+    act(() => {
+      rendered.ctx.closeTab('alpha')
+    })
+
+    return {
+      ...rendered,
+      get openTabIds() {
+        return rendered.ctx.state.tabGroups.main.tabs.map((tab) => tab.id)
+      }
+    }
+  }
+
+  it('names the pending tab and keeps it open when the prompt is cancelled', async () => {
+    const save = vi.fn().mockResolvedValue(true)
+    const rendered = promptForDirtyTab({ isDirty: () => true, save })
+
+    expect(screen.getByRole('alertdialog')).toBeTruthy()
+    expect(screen.getByText('"Alpha" has unsaved changes. What would you like to do?')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alertdialog')).toBeNull()
+    })
+    expect(save).not.toHaveBeenCalled()
+    expect(rendered.openTabIds).toEqual(['alpha', 'beta'])
+  })
+
+  it('closes the tab without saving on Don’t Save', async () => {
+    const save = vi.fn().mockResolvedValue(true)
+    const rendered = promptForDirtyTab({ isDirty: () => true, save })
+
+    fireEvent.click(screen.getByRole('button', { name: "Don't Save" }))
+
+    await waitFor(() => {
+      expect(rendered.openTabIds).toEqual(['beta'])
+    })
+    expect(save).not.toHaveBeenCalled()
+    expect(screen.queryByRole('alertdialog')).toBeNull()
+  })
+
+  it('saves before closing the tab on Save', async () => {
+    const save = vi.fn().mockResolvedValue(true)
+    const rendered = promptForDirtyTab({ isDirty: () => true, save })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(rendered.openTabIds).toEqual(['beta'])
+    })
+    expect(save).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops the Save button while the pending tab cannot be saved yet', () => {
+    const save = vi.fn().mockResolvedValue(true)
+    promptForDirtyTab({ isDirty: () => true, canSave: () => false, save })
+
+    expect(screen.getByRole('button', { name: "Don't Save" })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull()
   })
 })
 

--- a/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
+++ b/apps/desktop/src/renderer/src/contexts/tabs/context.tsx
@@ -34,11 +34,11 @@ import { UnsavedChangesDialog } from '@/components/tabs/unsaved-changes-dialog'
 // =============================================================================
 
 /**
- * Tab context interface providing state and methods
+ * Tab actions interface. Every member keeps its identity for the provider's
+ * lifetime, so this half of the context is published separately and consumers
+ * that only act on tabs never re-render when tab state changes.
  */
-interface TabContextType {
-  /** Current tab system state */
-  state: TabSystemState
+interface TabActionsContextType {
   /** Dispatch function for actions */
   dispatch: React.Dispatch<TabAction>
 
@@ -118,24 +118,9 @@ interface TabContextType {
   navForward: (groupId?: string) => void
 
   /**
-   * True when navBack would activate a tab.
-   */
-  canNavBack: boolean
-
-  /**
-   * True when navForward would activate a tab.
-   */
-  canNavForward: boolean
-
-  /**
    * Reopen the most recently closed tab (browser-style Cmd+Shift+T).
    */
   reopenClosedTab: () => void
-
-  /**
-   * True when there is a closed tab available to reopen.
-   */
-  canReopenClosedTab: boolean
 
   /**
    * Pin a tab
@@ -229,6 +214,29 @@ interface TabContextType {
    * Reset to default state
    */
   resetToDefault: () => void
+}
+
+/**
+ * Tab context interface providing state and methods
+ */
+interface TabContextType extends TabActionsContextType {
+  /** Current tab system state */
+  state: TabSystemState
+
+  /**
+   * True when navBack would activate a tab.
+   */
+  canNavBack: boolean
+
+  /**
+   * True when navForward would activate a tab.
+   */
+  canNavForward: boolean
+
+  /**
+   * True when there is a closed tab available to reopen.
+   */
+  canReopenClosedTab: boolean
 
   // =========================================================================
   // SELECTORS
@@ -265,6 +273,13 @@ interface TabContextType {
 // =============================================================================
 
 const TabContext = createContext<TabContextType | null>(null)
+
+/**
+ * Published alongside `TabContext` so `useTabActions` can subscribe to the
+ * stable half alone. Its value is memoized over callbacks that never change
+ * identity, so it never notifies its consumers after the first render.
+ */
+const TabActionsContext = createContext<TabActionsContextType | null>(null)
 
 // =============================================================================
 // PROVIDER COMPONENT
@@ -700,11 +715,12 @@ export const TabProvider = ({
   // CONTEXT VALUE
   // =========================================================================
 
-  const value = useMemo<TabContextType>(
+  // Every member below is a `useCallback` that never changes identity (they read
+  // live state through refs, not through closures), so this object is created
+  // once and `useTabActions` consumers never re-render because of tab state.
+  const actions = useMemo<TabActionsContextType>(
     () => ({
-      state,
       dispatch,
-      // Methods
       openTab,
       openFromSidebar,
       closeTab,
@@ -719,10 +735,7 @@ export const TabProvider = ({
       goToTabIndex,
       navBack,
       navForward,
-      canNavBack,
-      canNavForward,
       reopenClosedTab,
-      canReopenClosedTab,
       pinTab,
       unpinTab,
       togglePinTab,
@@ -739,7 +752,51 @@ export const TabProvider = ({
       moveTabToNewSplit,
       updateSettings,
       restoreSession,
-      resetToDefault,
+      resetToDefault
+    }),
+    [
+      openTab,
+      openFromSidebar,
+      closeTab,
+      registerCloseGuard,
+      closeOtherTabs,
+      closeTabsToRight,
+      closeAllTabs,
+      setActiveTab,
+      setActiveGroup,
+      goToNextTab,
+      goToPreviousTab,
+      goToTabIndex,
+      navBack,
+      navForward,
+      reopenClosedTab,
+      pinTab,
+      unpinTab,
+      togglePinTab,
+      setTabModified,
+      setTabDeleted,
+      updateTabTitle,
+      updateTabTitleByEntityId,
+      setTabEntity,
+      reorderTabs,
+      moveTabToGroup,
+      saveTabState,
+      splitView,
+      closeSplit,
+      moveTabToNewSplit,
+      updateSettings,
+      restoreSession,
+      resetToDefault
+    ]
+  )
+
+  const value = useMemo<TabContextType>(
+    () => ({
+      ...actions,
+      state,
+      canNavBack,
+      canNavForward,
+      canReopenClosedTab,
       // Selectors
       getActiveTab,
       getActiveGroup,
@@ -748,42 +805,11 @@ export const TabProvider = ({
       hasTabForEntity
     }),
     [
+      actions,
       state,
-      openTab,
-      openFromSidebar,
-      closeTab,
-      registerCloseGuard,
-      closeOtherTabs,
-      closeTabsToRight,
-      closeAllTabs,
-      setActiveTab,
-      setActiveGroup,
-      goToNextTab,
-      goToPreviousTab,
-      goToTabIndex,
-      navBack,
-      navForward,
       canNavBack,
       canNavForward,
-      reopenClosedTab,
       canReopenClosedTab,
-      pinTab,
-      unpinTab,
-      togglePinTab,
-      setTabModified,
-      setTabDeleted,
-      updateTabTitle,
-      updateTabTitleByEntityId,
-      setTabEntity,
-      reorderTabs,
-      moveTabToGroup,
-      saveTabState,
-      splitView,
-      closeSplit,
-      moveTabToNewSplit,
-      updateSettings,
-      restoreSession,
-      resetToDefault,
       getActiveTab,
       getActiveGroup,
       getAllTabs,
@@ -798,19 +824,23 @@ export const TabProvider = ({
         .find((t) => t.id === closeGuards.pending?.tabId)?.title ?? '')
     : ''
 
+  // Both providers render unconditionally: swapping either for a Fragment would
+  // remount the whole app subtree.
   return (
-    <TabContext.Provider value={value}>
-      {children}
-      <UnsavedChangesDialog
-        isOpen={closeGuards.pending !== null}
-        tabTitle={pendingTabTitle}
-        onSave={
-          closeGuards.pendingCanSave ? () => void closeGuards.resolvePending('save') : undefined
-        }
-        onDiscard={() => void closeGuards.resolvePending('discard')}
-        onCancel={() => void closeGuards.resolvePending('cancel')}
-      />
-    </TabContext.Provider>
+    <TabActionsContext.Provider value={actions}>
+      <TabContext.Provider value={value}>
+        {children}
+        <UnsavedChangesDialog
+          isOpen={closeGuards.pending !== null}
+          tabTitle={pendingTabTitle}
+          onSave={
+            closeGuards.pendingCanSave ? () => void closeGuards.resolvePending('save') : undefined
+          }
+          onDiscard={() => void closeGuards.resolvePending('discard')}
+          onCancel={() => void closeGuards.resolvePending('cancel')}
+        />
+      </TabContext.Provider>
+    </TabActionsContext.Provider>
   )
 }
 
@@ -912,103 +942,17 @@ export const useTabCounts = () => {
 }
 
 /**
- * Hook to get only tab actions (stable references that don't change)
+ * Hook to get only tab actions (stable references that don't change).
  * Use this when you only need to perform actions like openTab, closeTab, etc.
- * This prevents re-renders when tab state changes.
+ *
+ * Subscribes to `TabActionsContext` alone, so tab state changes never re-render
+ * the caller. The actions still operate on the current state: they read it
+ * through refs the provider keeps in sync, not through a captured closure.
  */
-export const useTabActions = () => {
-  const {
-    openTab,
-    openFromSidebar,
-    closeTab,
-    closeOtherTabs,
-    closeTabsToRight,
-    closeAllTabs,
-    setActiveTab,
-    setActiveGroup,
-    goToNextTab,
-    goToPreviousTab,
-    goToTabIndex,
-    pinTab,
-    unpinTab,
-    togglePinTab,
-    setTabModified,
-    setTabDeleted,
-    updateTabTitle,
-    updateTabTitleByEntityId,
-    reorderTabs,
-    moveTabToGroup,
-    saveTabState,
-    splitView,
-    closeSplit,
-    moveTabToNewSplit,
-    updateSettings,
-    restoreSession,
-    resetToDefault,
-    dispatch
-  } = useTabs()
-
-  // Return only actions - these are stable references due to useCallback with empty deps
-  return useMemo(
-    () => ({
-      openTab,
-      openFromSidebar,
-      closeTab,
-      closeOtherTabs,
-      closeTabsToRight,
-      closeAllTabs,
-      setActiveTab,
-      setActiveGroup,
-      goToNextTab,
-      goToPreviousTab,
-      goToTabIndex,
-      pinTab,
-      unpinTab,
-      togglePinTab,
-      setTabModified,
-      setTabDeleted,
-      updateTabTitle,
-      updateTabTitleByEntityId,
-      reorderTabs,
-      moveTabToGroup,
-      saveTabState,
-      splitView,
-      closeSplit,
-      moveTabToNewSplit,
-      updateSettings,
-      restoreSession,
-      resetToDefault,
-      dispatch
-    }),
-    [
-      openTab,
-      openFromSidebar,
-      closeTab,
-      closeOtherTabs,
-      closeTabsToRight,
-      closeAllTabs,
-      setActiveTab,
-      setActiveGroup,
-      goToNextTab,
-      goToPreviousTab,
-      goToTabIndex,
-      pinTab,
-      unpinTab,
-      togglePinTab,
-      setTabModified,
-      setTabDeleted,
-      updateTabTitle,
-      updateTabTitleByEntityId,
-      reorderTabs,
-      moveTabToGroup,
-      saveTabState,
-      splitView,
-      closeSplit,
-      moveTabToNewSplit,
-      updateSettings,
-      restoreSession,
-      resetToDefault,
-      dispatch
-    ]
-  )
+export const useTabActions = (): TabActionsContextType => {
+  const context = useContext(TabActionsContext)
+  if (!context) {
+    throw new Error('useTabActions must be used within a TabProvider')
+  }
+  return context
 }


### PR DESCRIPTION
Fixes #1019

## Verification (issue is real on current `main` @ 27bc2b961)

`apps/desktop/src/renderer/src/contexts/tabs/context.tsx`:

- `useTabActions` (`:919-1014`) opened with `const { ... } = useTabs()`, i.e. it subscribed to the whole `TabContext`.
- The provider value (`:703-793`) was `useMemo(..., [state, ...])` — its identity changed on every tab state change.
- `useContext` re-renders every consumer when the provider value changes, no matter what the consumer destructures. So the doc comment's claim ("This prevents re-renders when tab state changes") was false.

Measured on `main`: an action-only consumer rendered **201** times across 200 `updateTabTitle` dispatches. It should render once.

## Change

`apps/desktop/src/renderer/src/contexts/tabs/context.tsx` only.

- Split `TabContextType` into `TabActionsContextType` (the callbacks) + `TabContextType extends TabActionsContextType` (adds `state`, `canNavBack`, `canNavForward`, `canReopenClosedTab`, selectors). The public shape of `useTabs()` is unchanged.
- Added `TabActionsContext`, whose value is memoized over the action callbacks only.
- `TabContext`'s value now spreads `actions` and re-memoizes on `[actions, state, canNav*, canReopenClosedTab, selectors]` — same behaviour, shorter dep list.
- `useTabActions()` is now `useContext(TabActionsContext)`. Its return type gained `registerCloseGuard`, `navBack`, `navForward`, `reopenClosedTab`, `setTabEntity` (a superset — no consumer breaks).
- Both providers render unconditionally, nested. No Fragment↔Provider swap, so no subtree remount.

### Why there is no stale-closure risk

Every action was already a `useCallback` that never changes identity, and none of them close over `state`. The ones that need current state read it through `activeGroupIdRef` / `tabGroupsRef` / `stateRef`, which the provider re-syncs in a `useEffect` on every render. `dispatch` is stable by `useReducer`. `requestClose` / `registerCloseGuard` come from `useCloseGuardRegistry` and are `useCallback`s over stable refs. So freezing the actions object does not freeze the state it acts on — and the new test proves it.

## Tests

`apps/desktop/src/renderer/src/contexts/tabs/context.test.tsx` — new `tab context render scoping` describe with three probes under one `TabProvider`: an actions-only probe, a state probe, and a driver.

1. `keeps useTabActions consumers out of tab state re-renders` — 200 `updateTabTitle` dispatches, each in its own `act()`.
   - state probe: **201** renders and sees the final title (state consumers still update — asserted, not assumed)
   - actions probe: **1** render
2. `runs actions against current tab state from a consumer that never re-rendered` — pin `alpha` through the driver, then call `togglePinTab('alpha')` from the actions object captured on render 1. It must **unpin** (reads committed state, not the captured render), and the actions probe must still be at 1 render.

Red → green:

```
# before the fix
FAIL  tab context render scoping keeps useTabActions consumers out of tab state re-renders
      AssertionError: expected 201 to be 1
FAIL  tab context render scoping runs actions against current tab state from a consumer that never re-rendered
      AssertionError: expected 3 to be 1
PASS (5) FAIL (2)

# after the fix
PASS (7) FAIL (0)
```

Mutation check (the fix is load-bearing): re-adding `state` to the `actions` memo dep array puts both tests back to `expected 201 to be 1` / `expected 3 to be 1`.

## Checks

| check | result |
|---|---|
| `pnpm --filter @memry/desktop typecheck` | pass (contracts + architecture + rpc + ipc map + node + web) |
| `pnpm lint` | 0 errors, 14 warnings — byte-identical to the same run with the change stashed, so all pre-existing |
| full renderer suite (`vitest --project renderer`) | `PASS (6310) FAIL (0) skipped (6)` |
| targeted consumer suites (tabs, split-view, home widgets, graph, calendar, canvas, sidebar, journal, hooks, agent-chat) | `PASS (653) FAIL (0)` |
| `npx react-doctor@latest .` | no findings in `contexts/tabs/**`; remaining output matches the pre-existing baseline |

Renderer-internal only — no user-visible surface, no IPC/schema/sync/settings shape touched, so no docs update.
