### PR TITLE
fix(viewers): load the PDF once and window the thumbnail rail

### DIFF
--- a/apps/desktop/src/renderer/src/components/viewers/pdf-viewer.test.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/pdf-viewer.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Regression tests for the PDF viewer's document/thumbnail memory footprint.
+ *
+ * Covers two defects reported in issue #1018:
+ *  1. the viewer mounted one `<Document>` per surface, so a single file was
+ *     loaded twice into two independent pdf.js document proxies;
+ *  2. the thumbnail rail mounted one `<Page>` canvas per page with no
+ *     windowing, so a long PDF allocated hundreds of canvases on open.
+ *
+ * The `react-pdf` mock mirrors the real teardown contract: `Document` creates
+ * one loading task per mount and destroys it in its effect cleanup (see
+ * `react-pdf/dist/Document.js` -> `loadDocument`), and `Page` holds a canvas
+ * for as long as it stays mounted.
+ */
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PdfViewer } from './pdf-viewer'
+
+const NUM_PAGES = 400
+const RAIL_VIEWPORT_HEIGHT = 600
+
+const pdfMocks = vi.hoisted(() => ({
+  loadedDocuments: [] as { file: string; destroyed: boolean }[],
+  liveCanvases: new Set<{ page: number; kind: 'main' | 'thumbnail' }>()
+}))
+
+vi.mock('@memry/i18n/renderer', () => ({
+  useT: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('react-i18next', () => ({
+  getI18n: () => ({ getFixedT: () => (key: string) => key })
+}))
+
+vi.mock('react-pdf', async () => {
+  const { useEffect, useState } = await import('react')
+
+  return {
+    pdfjs: { GlobalWorkerOptions: {} },
+    Document: ({
+      file,
+      children,
+      className,
+      loading,
+      onLoadSuccess
+    }: {
+      file: string
+      children?: React.ReactNode
+      className?: string
+      loading?: React.ReactNode
+      onLoadSuccess?: (result: { numPages: number }) => void
+    }) => {
+      const [ready, setReady] = useState(false)
+
+      useEffect(() => {
+        const proxy = { file, destroyed: false }
+        pdfMocks.loadedDocuments.push(proxy)
+        setReady(true)
+        onLoadSuccess?.({ numPages: NUM_PAGES })
+        return () => {
+          proxy.destroyed = true
+        }
+      }, [file, onLoadSuccess])
+
+      return (
+        <div data-testid="pdf-document" data-file={file} className={className}>
+          {ready ? children : loading}
+        </div>
+      )
+    },
+    Page: ({ pageNumber, width }: { pageNumber: number; width?: number }) => {
+      useEffect(() => {
+        const canvas = {
+          page: pageNumber,
+          kind: (width ? 'thumbnail' : 'main') as 'main' | 'thumbnail'
+        }
+        pdfMocks.liveCanvases.add(canvas)
+        return () => {
+          pdfMocks.liveCanvases.delete(canvas)
+        }
+      }, [pageNumber, width])
+
+      return (
+        <div
+          data-testid={width ? 'pdf-thumbnail-canvas' : 'pdf-main-canvas'}
+          data-page={pageNumber}
+        >
+          page {pageNumber}
+        </div>
+      )
+    }
+  }
+})
+
+const renderedPages = (): number[] =>
+  screen
+    .queryAllByTestId('pdf-thumbnail')
+    .map((node) => Number(node.getAttribute('data-page')))
+    .sort((a, b) => a - b)
+
+const thumbnailFor = (page: number): HTMLElement => {
+  const match = screen
+    .queryAllByTestId('pdf-thumbnail')
+    .find((node) => node.getAttribute('data-page') === String(page))
+  if (!match) throw new Error(`thumbnail for page ${page} is not rendered`)
+  return match
+}
+
+const scrollRailTo = (offset: number): void => {
+  const rail = screen.getByTestId('pdf-thumbnail-rail')
+  Object.defineProperty(rail, 'scrollTop', { value: offset, configurable: true })
+  fireEvent.scroll(rail)
+}
+
+/** Row pitch the rail lays out with, derived from the sizer it renders. */
+const rowHeight = (): number =>
+  Number.parseFloat(screen.getByTestId('pdf-thumbnail-sizer').style.height) / NUM_PAGES
+
+describe('PdfViewer document loading and thumbnail windowing', () => {
+  let scrollToSpy: ReturnType<typeof vi.fn>
+  let originalScrollTo: unknown
+  let originalOffsetHeight: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    pdfMocks.loadedDocuments.length = 0
+    pdfMocks.liveCanvases.clear()
+
+    originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')
+    // @tanstack/react-virtual sizes its viewport from `offsetHeight`, which
+    // jsdom always reports as 0. Give the rail a real viewport.
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.dataset.testid === 'pdf-thumbnail-rail' ? RAIL_VIEWPORT_HEIGHT : 0
+      }
+    })
+
+    scrollToSpy = vi.fn()
+    originalScrollTo = (Element.prototype as unknown as { scrollTo?: unknown }).scrollTo
+    ;(Element.prototype as unknown as { scrollTo?: unknown }).scrollTo = scrollToSpy
+  })
+
+  afterEach(() => {
+    if (originalOffsetHeight) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight)
+    } else {
+      delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetHeight
+    }
+    ;(Element.prototype as unknown as { scrollTo?: unknown }).scrollTo = originalScrollTo
+  })
+
+  it('loads the file into a single pdf.js document for both surfaces', async () => {
+    render(<PdfViewer src="memry-file://spec.pdf" />)
+
+    await screen.findAllByTestId('pdf-thumbnail-canvas')
+    expect(screen.getAllByTestId('pdf-document')).toHaveLength(1)
+    expect(pdfMocks.loadedDocuments).toHaveLength(1)
+    expect(pdfMocks.loadedDocuments[0]?.file).toBe('memry-file://spec.pdf')
+  })
+
+  it('windows the thumbnail rail instead of mounting one canvas per page', async () => {
+    render(<PdfViewer src="memry-file://spec.pdf" />)
+
+    const canvases = await screen.findAllByTestId('pdf-thumbnail-canvas')
+    expect(screen.getByText('1 / 400')).toBeInTheDocument()
+    expect(canvases.length).toBeGreaterThan(0)
+    expect(canvases.length).toBeLessThan(20)
+    expect([...pdfMocks.liveCanvases].filter((c) => c.kind === 'thumbnail')).toHaveLength(
+      canvases.length
+    )
+
+    const pages = renderedPages()
+    expect(pages).toHaveLength(canvases.length)
+    expect(pages[0]).toBe(1)
+  })
+
+  it('renders the thumbnails for the scrolled region and navigates deep into the document', async () => {
+    const user = userEvent.setup()
+    render(<PdfViewer src="memry-file://spec.pdf" />)
+
+    await screen.findByTestId('pdf-thumbnail-rail')
+    scrollRailTo(rowHeight() * 299)
+
+    const pages = renderedPages()
+    expect(pages.length).toBeLessThan(20)
+    expect(pages).toContain(300)
+    expect(pages).not.toContain(1)
+
+    await user.click(thumbnailFor(300))
+
+    expect(screen.getByText('300 / 400')).toBeInTheDocument()
+    expect(screen.getByTestId('pdf-main-canvas')).toHaveAttribute('data-page', '300')
+    expect(thumbnailFor(300)).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('pulls the active thumbnail back into view when the page changes from the toolbar', async () => {
+    const user = userEvent.setup()
+    render(<PdfViewer src="memry-file://spec.pdf" />)
+
+    await screen.findByTestId('pdf-thumbnail-rail')
+    const pitch = rowHeight()
+    scrollRailTo(pitch * 350)
+    expect(renderedPages()).not.toContain(2)
+
+    scrollToSpy.mockClear()
+    await user.click(screen.getByTitle('phaseF.componentsViewersPdfViewer.nextPage'))
+    expect(screen.getByText('2 / 400')).toBeInTheDocument()
+
+    expect(scrollToSpy).toHaveBeenCalled()
+    const requestedTop = Number(scrollToSpy.mock.calls.at(-1)?.[0]?.top)
+    expect(requestedTop).toBeLessThanOrEqual(pitch * 2)
+
+    // Applying the rail scroll the viewer asked for brings page 2 back.
+    scrollRailTo(requestedTop)
+    expect(renderedPages()).toContain(2)
+  })
+
+  it('releases the document proxy and every page canvas on unmount', async () => {
+    const { unmount } = render(<PdfViewer src="memry-file://spec.pdf" />)
+
+    await screen.findAllByTestId('pdf-thumbnail-canvas')
+    expect(pdfMocks.loadedDocuments).toHaveLength(1)
+    expect(pdfMocks.liveCanvases.size).toBeGreaterThan(0)
+
+    unmount()
+
+    expect(pdfMocks.loadedDocuments.every((doc) => doc.destroyed)).toBe(true)
+    expect(pdfMocks.liveCanvases.size).toBe(0)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/viewers/pdf-viewer.tsx
+++ b/apps/desktop/src/renderer/src/components/viewers/pdf-viewer.tsx
@@ -6,7 +6,8 @@ import { getI18n } from 'react-i18next'
  * @module components/viewers/pdf-viewer
  */
 
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { extractErrorMessage } from '@/lib/ipc-error'
 import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/Page/AnnotationLayer.css'
@@ -23,7 +24,6 @@ import {
   Maximize2
 } from '@/lib/icons'
 import { Button } from '@/components/ui/button'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
 
 // Configure PDF.js worker - import from node_modules for Electron compatibility
@@ -49,6 +49,111 @@ const PDF_LOADING = (
 )
 
 // ============================================================================
+// Thumbnail Rail
+// ============================================================================
+
+/** Rendered width of a thumbnail canvas, in CSS pixels. */
+const THUMBNAIL_WIDTH = 120
+/** Fixed preview box height: a Letter/A4 portrait page at {@link THUMBNAIL_WIDTH}. */
+const THUMBNAIL_MEDIA_HEIGHT = 156
+/** Height of one rail row: preview box + page label + gap. */
+const THUMBNAIL_ROW_HEIGHT = THUMBNAIL_MEDIA_HEIGHT + 26
+
+interface PdfThumbnailRailProps {
+  numPages: number
+  currentPage: number
+  onSelectPage: (page: number) => void
+}
+
+/**
+ * Windowed thumbnail rail. Only the rows inside the rail viewport are mounted,
+ * so a 500-page document keeps a handful of canvases alive instead of 500.
+ * Rows have a fixed height so the window stays stable while pdf.js renders.
+ *
+ * Uses a native scroller rather than `ScrollArea` because the virtualizer needs
+ * a ref to the element that actually scrolls.
+ */
+function PdfThumbnailRail({
+  numPages,
+  currentPage,
+  onSelectPage
+}: PdfThumbnailRailProps): React.JSX.Element {
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const virtualizer = useVirtualizer({
+    count: numPages,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => THUMBNAIL_ROW_HEIGHT,
+    overscan: 2
+  })
+
+  // The active page's thumbnail is not necessarily inside the window when the
+  // page changes from the toolbar, so pull it back into view.
+  useEffect(() => {
+    if (numPages > 0) {
+      virtualizer.scrollToIndex(currentPage - 1, { align: 'auto' })
+    }
+  }, [currentPage, numPages, virtualizer])
+
+  return (
+    <div
+      ref={scrollRef}
+      data-testid="pdf-thumbnail-rail"
+      className="hidden w-[140px] flex-shrink-0 overflow-y-auto border-e border-border bg-muted/30 px-2 sm:block"
+    >
+      <div
+        data-testid="pdf-thumbnail-sizer"
+        className="relative w-full"
+        style={{ height: `${virtualizer.getTotalSize()}px` }}
+      >
+        {virtualizer.getVirtualItems().map((row) => {
+          const page = row.index + 1
+          const isActive = page === currentPage
+
+          return (
+            <button
+              key={row.key}
+              type="button"
+              data-testid="pdf-thumbnail"
+              data-page={page}
+              aria-current={isActive ? 'page' : undefined}
+              onClick={() => onSelectPage(page)}
+              style={{
+                position: 'absolute',
+                top: 0,
+                insetInlineStart: 0,
+                width: '100%',
+                height: `${row.size}px`,
+                transform: `translateY(${row.start}px)`
+              }}
+              className={cn(
+                'overflow-hidden rounded border-2 transition-all hover:border-primary/50',
+                isActive ? 'border-primary ring-2 ring-primary/20' : 'border-transparent'
+              )}
+            >
+              <div
+                className="flex items-center justify-center overflow-hidden"
+                style={{ height: `${THUMBNAIL_MEDIA_HEIGHT}px` }}
+              >
+                <Page
+                  pageNumber={page}
+                  width={THUMBNAIL_WIDTH}
+                  renderTextLayer={false}
+                  renderAnnotationLayer={false}
+                />
+              </div>
+              <div className="bg-background/80 py-1 text-center text-[10px] text-muted-foreground">
+                {page}
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
 // PDF Viewer Component
 // ============================================================================
 
@@ -60,12 +165,10 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
   const [scale, setScale] = useState(1.0)
   const [rotation, setRotation] = useState(0)
   const [sidebarOpen, setSidebarOpen] = useState(true)
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   const handleLoadSuccess = useCallback(({ numPages }: { numPages: number }) => {
     setNumPages(numPages)
-    setLoading(false)
   }, [])
 
   const handleLoadError = useCallback((err: Error) => {
@@ -75,7 +178,6 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
         getI18n().getFixedT(null, 'notes')('phaseF.componentsViewersPdfViewer.failedToLoadPdf')
       )
     )
-    setLoading(false)
   }, [])
 
   const goToPage = useCallback(
@@ -223,54 +325,28 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
         </div>
       </div>
 
-      {/* Main content */}
-      <div className="flex flex-1 min-h-0 overflow-hidden">
-        {/* Thumbnail sidebar */}
-        {sidebarOpen && (
-          <div className="w-[140px] border-e border-border bg-muted/30 flex-shrink-0 hidden sm:block">
-            <ScrollArea className="h-full">
-              <div className="p-2 space-y-2">
-                {!loading && (
-                  <Document file={src}>
-                    {Array.from({ length: numPages }, (_, i) => (
-                      <button
-                        key={i + 1}
-                        type="button"
-                        onClick={() => goToPage(i + 1)}
-                        className={cn(
-                          'w-full rounded border-2 overflow-hidden transition-all hover:border-primary/50',
-                          currentPage === i + 1
-                            ? 'border-primary ring-2 ring-primary/20'
-                            : 'border-transparent'
-                        )}
-                      >
-                        <Page
-                          pageNumber={i + 1}
-                          width={120}
-                          renderTextLayer={false}
-                          renderAnnotationLayer={false}
-                        />
-                        <div className="text-[10px] text-center py-1 bg-background/80 text-muted-foreground">
-                          {i + 1}
-                        </div>
-                      </button>
-                    ))}
-                  </Document>
-                )}
-              </div>
-            </ScrollArea>
-          </div>
-        )}
+      {/* Main content - one Document shared by the rail and the page view, so
+          the file is loaded into a single pdf.js document proxy */}
+      <Document
+        file={src}
+        onLoadSuccess={handleLoadSuccess}
+        onLoadError={handleLoadError}
+        loading={PDF_LOADING}
+        className="flex flex-1 min-h-0 flex-col overflow-hidden"
+      >
+        <div className="flex flex-1 min-h-0 overflow-hidden">
+          {/* Thumbnail sidebar */}
+          {sidebarOpen && (
+            <PdfThumbnailRail
+              numPages={numPages}
+              currentPage={currentPage}
+              onSelectPage={goToPage}
+            />
+          )}
 
-        {/* PDF content - with both horizontal and vertical scrolling */}
-        <div className="flex-1 overflow-auto min-h-0">
-          <div className="inline-flex justify-center min-w-full p-4">
-            <Document
-              file={src}
-              onLoadSuccess={handleLoadSuccess}
-              onLoadError={handleLoadError}
-              loading={PDF_LOADING}
-            >
+          {/* PDF content - with both horizontal and vertical scrolling */}
+          <div className="flex-1 overflow-auto min-h-0">
+            <div className="inline-flex justify-center min-w-full p-4">
               <Page
                 pageNumber={currentPage}
                 scale={scale}
@@ -279,10 +355,10 @@ export function PdfViewer({ src, className }: PdfViewerProps) {
                 renderAnnotationLayer={true}
                 className="shadow-lg"
               />
-            </Document>
+            </div>
           </div>
         </div>
-      </div>
+      </Document>
     </div>
   )
 }

--- a/apps/docs/src/user-guide/notes/attachments.md
+++ b/apps/docs/src/user-guide/notes/attachments.md
@@ -27,6 +27,8 @@ Each attachment renders as a block with:
 
 PDFs render inline as a clean first-page preview — no viewer chrome — so a note reads as a document with its source embedded. Open the file page (double-click the sidebar item) for the full multi-page viewer with zoom and find-in-page.
 
+The file page viewer has a thumbnail sidebar for jumping between pages. It draws only the thumbnails currently scrolled into view, so a several-hundred-page PDF opens without rendering every page up front.
+
 Hover the preview, or click to select it, to reveal its controls:
 
 - **Resize** — drag either bottom corner. Width scales the whole embed like an image; dragging upward shortens it, cropping the first page from the top so only the opening shows (no inner scroll).


### PR DESCRIPTION
Fixes #1018

## Verification — the issue was still real

`apps/desktop/src/renderer/src/components/viewers/pdf-viewer.tsx` on `origin/main` (27bc2b961):

- **Two documents.** `<Document file={src}>` at line 234 (sidebar) and line 268 (main pane). Two mounts of react-pdf's `Document` means two `pdfjs.getDocument()` loading tasks and two independent `PDFDocumentProxy` objects for the same file (`react-pdf/dist/Document.js` → `loadDocument`).
- **No windowing.** Line 235: `Array.from({ length: numPages }, ...)` mounted one `<Page width={120}>` per page inside the sidebar `Document`, so a 400-page PDF mounted 400 canvases and queued 400 render tasks on open.

The characterisation test reproduced both against unmodified `main`:

```
× loads the file into a single pdf.js document for both surfaces
  → expected [ <div …(2)>…(400)</div>, …(1) ] to have a length of 1 but got 2
× windows the thumbnail rail instead of mounting one canvas per page
  → expected 400 to be less than 20
× releases the document proxy and every page canvas on unmount
  → expected [ { …(2) }, { …(2) } ] to have a length of 1 but got 2
```

## Change

Single file changed: `apps/desktop/src/renderer/src/components/viewers/pdf-viewer.tsx`.

1. **One document.** The single `<Document>` now wraps the whole content row, so the rail and the page view share one proxy via react-pdf's `DocumentContext`. The local `loading` state existed only to gate the second `<Document>` and is gone — react-pdf's own `loading` prop already covers the pane.
2. **Windowed rail.** New `PdfThumbnailRail` renders only the rows in view using `@tanstack/react-virtual`, **already a `@memry/desktop` dependency** (`apps/desktop/package.json:193`, used by the task lists, notes tree and folder table). No new dependency, no lockfile change.
   - Rows are a fixed height (`156px` preview + label), so the window does not shift while pdf.js renders asynchronously.
   - The rail scrolls natively instead of through `ScrollArea`: the virtualizer needs a ref to the element that actually scrolls, and Radix keeps that inside its own viewport.
   - A `scrollToIndex(currentPage - 1, { align: 'auto' })` effect pulls the active thumbnail back into view when the page changes from the toolbar, since it may be outside the window.
   - The active row carries `aria-current="page"` in addition to the existing highlight.

**Large documents:** no page cap and no lazy `numPages`. A 500-page PDF still opens fully — the toolbar reports `1 / 500`, the rail's scroll range covers all 500 rows, and any page is reachable by scrolling or by the page controls. Only the ~4 rows in the viewport (plus 2 overscan each side) hold a canvas at a time, versus 500 before.

Behaviour deliberately unchanged: toolbar, zoom, rotate, fit-to-width, error state, `hidden sm:block` rail visibility, 140px rail width, 120px thumbnails.

## Tests

New `apps/desktop/src/renderer/src/components/viewers/pdf-viewer.test.tsx` (5 tests, 400-page document). The `react-pdf` mock mirrors the real teardown contract — `Document` registers one loading task per mount and destroys it in its effect cleanup; `Page` holds a canvas while mounted. `@tanstack/react-virtual` is **not** mocked; the test gives the rail a real `offsetHeight` and drives real scroll events.

- single `<Document>` / single loaded proxy for both surfaces
- fewer than 20 thumbnail canvases mounted for 400 pages, and live-canvas count matches the DOM
- scrolling the rail to page 300 renders that region (and drops page 1), clicking it navigates to `300 / 400` and marks it `aria-current`
- after scrolling the rail to page ~350, the toolbar's next-page control makes the rail scroll back so page 2 is rendered again
- unmount destroys the document proxy and leaves zero live canvases

Red → green: all 5 failed on unmodified `main` (output above), all 5 pass after the change. The existing `viewers.test.tsx` (5 tests) still passes untouched.

Mutation-tested (the fix reverted one line at a time, test must go red):

- drop `virtualizer.scrollToIndex(...)` → `pulls the active thumbnail back into view` fails (`expected "vi.fn()" to be called at least once`)
- `overscan: 2` → `overscan: 500` → `expected 400 to be less than 20`, plus 2 more

## Checks

| check | result |
| --- | --- |
| `pnpm --filter @memry/desktop typecheck` | pass (contracts + architecture + ipc:check + node + web) |
| `pnpm lint` | pass — 0 errors, 17 warnings (14 pre-existing) |
| `pnpm exec vitest run --project renderer .../viewers/` | 10 passed (2 files) |
| `npx react-doctor@latest .` | no findings in `pdf-viewer.tsx`; score unchanged at 64 (repo-wide pre-existing) |
| `pnpm docs:impact --base origin/main --strict` | `covered` |
| `pnpm docs:build` | pass |

The 3 new lint warnings are all on the `useVirtualizer` call and its follow-scroll effect: one `react-hooks/incompatible-library` ("TanStack Virtual's `useVirtualizer()` API returns functions that cannot be memoized safely" — inherent to the library) and two `react-you-might-not-need-an-effect/no-pass-ref-to-parent` false positives on the `scrollToIndex` effect. All warnings, not errors; the lint gate does not set `--max-warnings`.

## Docs

`apps/docs/src/user-guide/notes/attachments.md` — one sentence under **PDF Inline Preview** noting the file-page thumbnail sidebar draws thumbnails on demand. Needed to clear the `missing-docs` gate, and it is accurate user-visible behaviour.
